### PR TITLE
feat: add model registry

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "ink-text-input": "^6.0.0",
         "openai": "^6.39.1",
         "react": "^19.2.6",
+        "react-devtools-core": "^7.0.1",
         "shiki": "^4.1.0",
         "zod": "^4.4.3",
       },
@@ -181,6 +182,8 @@
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -196,6 +199,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "shiki": ["shiki@4.1.0", "", { "dependencies": { "@shikijs/core": "4.1.0", "@shikijs/engine-javascript": "4.1.0", "@shikijs/engine-oniguruma": "4.1.0", "@shikijs/langs": "4.1.0", "@shikijs/themes": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q=="],
 
@@ -264,6 +269,8 @@
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ink-text-input": "^6.0.0",
     "openai": "^6.39.1",
     "react": "^19.2.6",
+    "react-devtools-core": "^7.0.1",
     "shiki": "^4.1.0",
     "zod": "^4.4.3"
   }

--- a/src/models/cost.ts
+++ b/src/models/cost.ts
@@ -1,0 +1,79 @@
+import { requireModel } from './registry';
+import type {
+  ModelCostBreakdown,
+  ModelPricing,
+  ModelPricingTier,
+  TokenUsage,
+} from './types';
+
+const TOKENS_PER_MILLION = 1_000_000;
+
+export function calculateModelCost(
+  modelIdOrAlias: string,
+  usage: TokenUsage
+): ModelCostBreakdown {
+  const model = requireModel(modelIdOrAlias);
+  const inputTokens = usage.inputTokens ?? 0;
+  const outputTokens = usage.outputTokens ?? 0;
+  const cacheReadTokens = usage.cacheReadTokens ?? 0;
+  const cacheCreationTokens = usage.cacheCreationTokens ?? 0;
+  const reasoningTokens = usage.reasoningTokens ?? 0;
+  const totalPromptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
+  const pricing = selectPricing(model.pricing, totalPromptTokens);
+
+  const inputCostUsd = priceTokens(inputTokens, pricing.inputPerMillionUsd);
+  const outputCostUsd = priceTokens(
+    outputTokens + reasoningTokens,
+    pricing.outputPerMillionUsd
+  );
+  const cacheReadCostUsd = priceTokens(
+    cacheReadTokens,
+    pricing.cacheReadInputPerMillionUsd ?? pricing.inputPerMillionUsd
+  );
+  const cacheCreationCostUsd = priceTokens(
+    cacheCreationTokens,
+    pricing.cacheWriteInputPerMillionUsd ?? pricing.inputPerMillionUsd
+  );
+
+  return {
+    modelId: model.id,
+    provider: model.provider,
+    inputCostUsd,
+    outputCostUsd,
+    cacheReadCostUsd,
+    cacheCreationCostUsd,
+    totalCostUsd: inputCostUsd + outputCostUsd + cacheReadCostUsd + cacheCreationCostUsd,
+    pricingSource: model.pricing.source,
+  };
+}
+
+export function formatUsd(amount: number): string {
+  if (amount === 0) return '$0.00';
+  if (amount < 0.01) return `$${amount.toFixed(6)}`;
+  return `$${amount.toFixed(2)}`;
+}
+
+function selectPricing(pricing: ModelPricing, promptTokens: number): ModelPricingTier {
+  if (!pricing.tiers || pricing.tiers.length === 0) {
+    return {
+      inputPerMillionUsd: pricing.inputPerMillionUsd,
+      outputPerMillionUsd: pricing.outputPerMillionUsd,
+      cacheReadInputPerMillionUsd: pricing.cacheReadInputPerMillionUsd,
+      cacheWriteInputPerMillionUsd: pricing.cacheWriteInputPerMillionUsd,
+    };
+  }
+
+  const matched = pricing.tiers.find((tier) =>
+    tier.upToInputTokens === undefined || promptTokens <= tier.upToInputTokens
+  );
+
+  if (!matched) {
+    return pricing.tiers[pricing.tiers.length - 1]!;
+  }
+
+  return matched;
+}
+
+function priceTokens(tokens: number, pricePerMillion: number): number {
+  return (tokens / TOKENS_PER_MILLION) * pricePerMillion;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './registry';
+export * from './cost';

--- a/src/models/registry.ts
+++ b/src/models/registry.ts
@@ -1,0 +1,406 @@
+import type {
+  ModelCapability,
+  ModelDefinition,
+  ModelProvider,
+  ReasoningEffort,
+} from './types';
+
+const VERIFIED_AT = '2026-06-02';
+
+const OPENAI_PRICING = 'https://openai.com/api/pricing/';
+const ANTHROPIC_PRICING = 'https://platform.claude.com/docs/en/about-claude/pricing';
+const GEMINI_PRICING = 'https://ai.google.dev/gemini-api/docs/pricing';
+
+export const DEFAULT_MODEL_ID = 'claude-sonnet-4-6';
+
+export const MODELS: readonly ModelDefinition[] = [
+  {
+    id: 'claude-opus-4-8',
+    displayName: 'Claude Opus 4.8',
+    provider: 'anthropic',
+    apiModel: 'claude-opus-4-8',
+    aliases: ['opus-4.8', 'claude-opus-latest'],
+    context: { contextWindowTokens: 200_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 5,
+      outputPerMillionUsd: 25,
+      cacheReadInputPerMillionUsd: 0.5,
+      cacheWriteInputPerMillionUsd: 6.25,
+      source: ANTHROPIC_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'claude-opus-4-7',
+    displayName: 'Claude Opus 4.7',
+    provider: 'anthropic',
+    apiModel: 'claude-opus-4-7',
+    aliases: ['opus-4.7', 'claude-opus-4.7'],
+    context: { contextWindowTokens: 200_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 5,
+      outputPerMillionUsd: 25,
+      cacheReadInputPerMillionUsd: 0.5,
+      cacheWriteInputPerMillionUsd: 6.25,
+      source: ANTHROPIC_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'claude-opus-4-6',
+    displayName: 'Claude Opus 4.6',
+    provider: 'anthropic',
+    apiModel: 'claude-opus-4-6',
+    aliases: ['opus-4.6', 'claude-opus-4.6'],
+    context: { contextWindowTokens: 200_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 5,
+      outputPerMillionUsd: 25,
+      cacheReadInputPerMillionUsd: 0.5,
+      cacheWriteInputPerMillionUsd: 6.25,
+      source: ANTHROPIC_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'claude-sonnet-4-6',
+    displayName: 'Claude Sonnet 4.6',
+    provider: 'anthropic',
+    apiModel: 'claude-sonnet-4-6',
+    aliases: ['sonnet-4.6', 'claude-sonnet-4.6', 'claude-sonnet'],
+    context: { contextWindowTokens: 200_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 3,
+      outputPerMillionUsd: 15,
+      cacheReadInputPerMillionUsd: 0.3,
+      cacheWriteInputPerMillionUsd: 3.75,
+      source: ANTHROPIC_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'claude-sonnet-4-5',
+    displayName: 'Claude Sonnet 4.5',
+    provider: 'anthropic',
+    apiModel: 'claude-sonnet-4-5',
+    aliases: ['sonnet-4.5', 'claude-sonnet-4.5'],
+    context: { contextWindowTokens: 200_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 3,
+      outputPerMillionUsd: 15,
+      cacheReadInputPerMillionUsd: 0.3,
+      cacheWriteInputPerMillionUsd: 3.75,
+      source: ANTHROPIC_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'claude-haiku-4-5',
+    displayName: 'Claude Haiku 4.5',
+    provider: 'anthropic',
+    apiModel: 'claude-haiku-4-5',
+    aliases: ['haiku-4.5', 'claude-haiku'],
+    context: { contextWindowTokens: 200_000, maxOutputTokens: 32_000 },
+    capabilities: ['text', 'tools', 'vision', 'promptCaching'],
+    pricing: {
+      inputPerMillionUsd: 1,
+      outputPerMillionUsd: 5,
+      cacheReadInputPerMillionUsd: 0.1,
+      cacheWriteInputPerMillionUsd: 1.25,
+      source: ANTHROPIC_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gpt-5.5',
+    displayName: 'GPT-5.5',
+    provider: 'openai',
+    apiModel: 'gpt-5.5',
+    aliases: ['gpt-5.5-latest'],
+    context: { contextWindowTokens: 270_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 5,
+      outputPerMillionUsd: 30,
+      cacheReadInputPerMillionUsd: 0.5,
+      source: OPENAI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gpt-5.4',
+    displayName: 'GPT-5.4',
+    provider: 'openai',
+    apiModel: 'gpt-5.4',
+    aliases: ['gpt-5.4-latest'],
+    context: { contextWindowTokens: 270_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 2.5,
+      outputPerMillionUsd: 15,
+      cacheReadInputPerMillionUsd: 0.25,
+      source: OPENAI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gpt-5.4-mini',
+    displayName: 'GPT-5.4 Mini',
+    provider: 'openai',
+    apiModel: 'gpt-5.4-mini',
+    aliases: ['gpt-5-mini'],
+    context: { contextWindowTokens: 270_000, maxOutputTokens: 64_000 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 0.75,
+      outputPerMillionUsd: 4.5,
+      cacheReadInputPerMillionUsd: 0.075,
+      source: OPENAI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    apiModel: 'gpt-4o',
+    aliases: ['gpt-4o-latest'],
+    context: { contextWindowTokens: 128_000, maxOutputTokens: 16_384 },
+    capabilities: ['text', 'tools', 'vision'],
+    pricing: {
+      inputPerMillionUsd: 2.5,
+      outputPerMillionUsd: 10,
+      cacheReadInputPerMillionUsd: 1.25,
+      source: OPENAI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gpt-4-turbo',
+    displayName: 'GPT-4 Turbo',
+    provider: 'openai',
+    apiModel: 'gpt-4-turbo',
+    aliases: ['gpt-4-turbo-preview'],
+    context: { contextWindowTokens: 128_000, maxOutputTokens: 4_096 },
+    capabilities: ['text', 'tools', 'vision'],
+    deprecated: true,
+    pricing: {
+      inputPerMillionUsd: 10,
+      outputPerMillionUsd: 30,
+      source: OPENAI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gemini-3.5-flash',
+    displayName: 'Gemini 3.5 Flash',
+    provider: 'google',
+    apiModel: 'gemini-3.5-flash',
+    aliases: ['gemini-flash-latest'],
+    context: { contextWindowTokens: 1_000_000, maxOutputTokens: 65_536 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 1.5,
+      outputPerMillionUsd: 9,
+      cacheReadInputPerMillionUsd: 0.15,
+      source: GEMINI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gemini-3.1-flash-lite',
+    displayName: 'Gemini 3.1 Flash-Lite',
+    provider: 'google',
+    apiModel: 'gemini-3.1-flash-lite',
+    aliases: ['gemini-flash-lite-latest'],
+    context: { contextWindowTokens: 1_000_000, maxOutputTokens: 65_536 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'low',
+    pricing: {
+      inputPerMillionUsd: 0.25,
+      outputPerMillionUsd: 1.5,
+      cacheReadInputPerMillionUsd: 0.025,
+      source: GEMINI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gemini-2.5-pro',
+    displayName: 'Gemini 2.5 Pro',
+    provider: 'google',
+    apiModel: 'gemini-2.5-pro',
+    aliases: ['gemini-pro', 'gemini-pro-2.5'],
+    context: { contextWindowTokens: 1_048_576, maxOutputTokens: 65_536 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 1.25,
+      outputPerMillionUsd: 10,
+      cacheReadInputPerMillionUsd: 0.125,
+      tiers: [
+        {
+          upToInputTokens: 200_000,
+          inputPerMillionUsd: 1.25,
+          outputPerMillionUsd: 10,
+          cacheReadInputPerMillionUsd: 0.125,
+        },
+        {
+          inputPerMillionUsd: 2.5,
+          outputPerMillionUsd: 15,
+          cacheReadInputPerMillionUsd: 0.25,
+        },
+      ],
+      source: GEMINI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gemini-2.5-flash',
+    displayName: 'Gemini 2.5 Flash',
+    provider: 'google',
+    apiModel: 'gemini-2.5-flash',
+    aliases: ['gemini-flash', 'gemini-flash-2.5'],
+    context: { contextWindowTokens: 1_048_576, maxOutputTokens: 65_536 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'medium',
+    pricing: {
+      inputPerMillionUsd: 0.3,
+      outputPerMillionUsd: 2.5,
+      cacheReadInputPerMillionUsd: 0.03,
+      source: GEMINI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+  {
+    id: 'gemini-2.5-flash-lite',
+    displayName: 'Gemini 2.5 Flash-Lite',
+    provider: 'google',
+    apiModel: 'gemini-2.5-flash-lite',
+    aliases: ['gemini-flash-lite', 'gemini-flash-lite-2.5'],
+    context: { contextWindowTokens: 1_048_576, maxOutputTokens: 65_536 },
+    capabilities: ['text', 'tools', 'vision', 'reasoning', 'promptCaching'],
+    supportedReasoningEfforts: ['low', 'medium', 'high'],
+    defaultReasoningEffort: 'low',
+    pricing: {
+      inputPerMillionUsd: 0.1,
+      outputPerMillionUsd: 0.4,
+      cacheReadInputPerMillionUsd: 0.01,
+      source: GEMINI_PRICING,
+      lastVerified: VERIFIED_AT,
+    },
+  },
+];
+
+const modelById = new Map(MODELS.map((model) => [model.id, model]));
+const aliasToModelId = new Map<string, string>();
+
+for (const model of MODELS) {
+  aliasToModelId.set(model.id.toLowerCase(), model.id);
+  for (const alias of model.aliases) {
+    aliasToModelId.set(alias.toLowerCase(), model.id);
+  }
+}
+
+export interface ListModelsOptions {
+  provider?: ModelProvider;
+  capability?: ModelCapability;
+  includeDeprecated?: boolean;
+}
+
+export function listModels(options: ListModelsOptions = {}): ModelDefinition[] {
+  return MODELS.filter((model) => {
+    if (!options.includeDeprecated && model.deprecated) return false;
+    if (options.provider && model.provider !== options.provider) return false;
+    if (options.capability && !model.capabilities.includes(options.capability)) return false;
+    return true;
+  }).map(cloneModel);
+}
+
+export function resolveModelId(modelIdOrAlias: string): string | undefined {
+  const normalized = modelIdOrAlias.trim().toLowerCase();
+  return aliasToModelId.get(normalized);
+}
+
+export function getModel(modelIdOrAlias: string): ModelDefinition | undefined {
+  const resolved = resolveModelId(modelIdOrAlias);
+  if (!resolved) return undefined;
+  const model = modelById.get(resolved);
+  return model ? cloneModel(model) : undefined;
+}
+
+export function requireModel(modelIdOrAlias: string): ModelDefinition {
+  const model = getModel(modelIdOrAlias);
+  if (!model) {
+    throw new Error(`Unknown model: ${modelIdOrAlias}`);
+  }
+  return model;
+}
+
+export function isKnownModel(modelIdOrAlias: string): boolean {
+  return resolveModelId(modelIdOrAlias) !== undefined;
+}
+
+export function listModelsByProvider(provider: ModelProvider, includeDeprecated = false): ModelDefinition[] {
+  return listModels({ provider, includeDeprecated });
+}
+
+export function listModelsByCapability(capability: ModelCapability): ModelDefinition[] {
+  return listModels({ capability });
+}
+
+export function modelSupportsCapability(modelIdOrAlias: string, capability: ModelCapability): boolean {
+  return requireModel(modelIdOrAlias).capabilities.includes(capability);
+}
+
+export function getReasoningEfforts(modelIdOrAlias: string): ReasoningEffort[] {
+  return [...(requireModel(modelIdOrAlias).supportedReasoningEfforts ?? [])];
+}
+
+export function assertModelProvider(modelIdOrAlias: string, provider: ModelProvider): ModelDefinition {
+  const model = requireModel(modelIdOrAlias);
+  if (model.provider !== provider) {
+    throw new Error(`Model ${model.id} is provided by ${model.provider}, not ${provider}`);
+  }
+  return model;
+}
+
+function cloneModel(model: ModelDefinition): ModelDefinition {
+  return {
+    ...model,
+    aliases: [...model.aliases],
+    capabilities: [...model.capabilities],
+    supportedReasoningEfforts: model.supportedReasoningEfforts
+      ? [...model.supportedReasoningEfforts]
+      : undefined,
+    pricing: {
+      ...model.pricing,
+      tiers: model.pricing.tiers?.map((tier) => ({ ...tier })),
+    },
+  };
+}

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,0 +1,71 @@
+export type ModelProvider = 'openai' | 'anthropic' | 'google';
+
+export type ReasoningEffort = 'low' | 'medium' | 'high';
+
+export type ModelCapability =
+  | 'text'
+  | 'tools'
+  | 'vision'
+  | 'reasoning'
+  | 'promptCaching';
+
+export interface ModelContextLimits {
+  contextWindowTokens: number;
+  maxOutputTokens: number;
+}
+
+export interface ModelPricingTier {
+  /**
+   * Upper bound for tier selection based on total prompt/input tokens.
+   * Omit this for the final catch-all tier.
+   */
+  upToInputTokens?: number;
+  inputPerMillionUsd: number;
+  outputPerMillionUsd: number;
+  cacheReadInputPerMillionUsd?: number;
+  cacheWriteInputPerMillionUsd?: number;
+}
+
+export interface ModelPricing {
+  inputPerMillionUsd: number;
+  outputPerMillionUsd: number;
+  cacheReadInputPerMillionUsd?: number;
+  cacheWriteInputPerMillionUsd?: number;
+  tiers?: ModelPricingTier[];
+  source: string;
+  lastVerified: string;
+}
+
+export interface ModelDefinition {
+  id: string;
+  displayName: string;
+  provider: ModelProvider;
+  apiModel: string;
+  aliases: string[];
+  context: ModelContextLimits;
+  capabilities: ModelCapability[];
+  pricing: ModelPricing;
+  defaultReasoningEffort?: ReasoningEffort;
+  supportedReasoningEfforts?: ReasoningEffort[];
+  deprecated?: boolean;
+  notes?: string;
+}
+
+export interface TokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  reasoningTokens?: number;
+}
+
+export interface ModelCostBreakdown {
+  modelId: string;
+  provider: ModelProvider;
+  inputCostUsd: number;
+  outputCostUsd: number;
+  cacheReadCostUsd: number;
+  cacheCreationCostUsd: number;
+  totalCostUsd: number;
+  pricingSource: string;
+}

--- a/tests/model-registry.test.ts
+++ b/tests/model-registry.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_MODEL_ID,
+  assertModelProvider,
+  calculateModelCost,
+  formatUsd,
+  getModel,
+  getReasoningEfforts,
+  isKnownModel,
+  listModels,
+  listModelsByCapability,
+  listModelsByProvider,
+  modelSupportsCapability,
+  requireModel,
+  resolveModelId,
+} from '../src/models';
+
+describe('model registry', () => {
+  it('contains the M1 provider families and at least 10 active models', () => {
+    const activeModels = listModels();
+    const providers = new Set(activeModels.map((model) => model.provider));
+
+    expect(activeModels.length).toBeGreaterThanOrEqual(10);
+    expect(providers).toContain('openai');
+    expect(providers).toContain('anthropic');
+    expect(providers).toContain('google');
+  });
+
+  it('resolves canonical IDs and aliases case-insensitively', () => {
+    expect(resolveModelId(DEFAULT_MODEL_ID)).toBe(DEFAULT_MODEL_ID);
+    expect(resolveModelId('SONNET-4.6')).toBe('claude-sonnet-4-6');
+    expect(getModel('gemini-flash')?.id).toBe('gemini-2.5-flash');
+    expect(isKnownModel('gpt-5-mini')).toBe(true);
+  });
+
+  it('throws a clear error for unknown models', () => {
+    expect(() => requireModel('not-a-real-model')).toThrow('Unknown model: not-a-real-model');
+  });
+
+  it('filters by provider and capability', () => {
+    const anthropicModels = listModelsByProvider('anthropic');
+    const visionModels = listModelsByCapability('vision');
+
+    expect(anthropicModels.every((model) => model.provider === 'anthropic')).toBe(true);
+    expect(visionModels.every((model) => model.capabilities.includes('vision'))).toBe(true);
+    expect(modelSupportsCapability('claude-sonnet', 'tools')).toBe(true);
+  });
+
+  it('excludes deprecated models unless requested', () => {
+    expect(listModels().some((model) => model.id === 'gpt-4-turbo')).toBe(false);
+    expect(listModels({ includeDeprecated: true }).some((model) => model.id === 'gpt-4-turbo')).toBe(true);
+  });
+
+  it('validates provider compatibility', () => {
+    expect(assertModelProvider('claude-sonnet', 'anthropic').id).toBe('claude-sonnet-4-6');
+    expect(() => assertModelProvider('claude-sonnet', 'openai')).toThrow(
+      'Model claude-sonnet-4-6 is provided by anthropic, not openai'
+    );
+  });
+
+  it('exposes reasoning efforts only for reasoning-capable models', () => {
+    expect(getReasoningEfforts('claude-sonnet')).toEqual(['low', 'medium', 'high']);
+    expect(getReasoningEfforts('gpt-4o')).toEqual([]);
+  });
+
+  it('protects registry data from caller mutation', () => {
+    const listed = listModels();
+    const first = listed[0]!;
+    const tiered = getModel('gemini-2.5-pro')!;
+
+    first.aliases.push('mutated-alias');
+    tiered.pricing.tiers?.push({
+      inputPerMillionUsd: 999,
+      outputPerMillionUsd: 999,
+    });
+
+    expect(getModel(first.id)?.aliases).not.toContain('mutated-alias');
+    expect(getModel('gemini-2.5-pro')?.pricing.tiers?.some((tier) => tier.inputPerMillionUsd === 999)).not.toBe(true);
+  });
+});
+
+describe('model cost calculation', () => {
+  it('calculates input, output, cache, and reasoning costs', () => {
+    const cost = calculateModelCost('claude-sonnet', {
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      cacheReadTokens: 100_000,
+      cacheCreationTokens: 100_000,
+      reasoningTokens: 10_000,
+    });
+
+    expect(cost.modelId).toBe('claude-sonnet-4-6');
+    expect(cost.provider).toBe('anthropic');
+    expect(cost.inputCostUsd).toBe(3);
+    expect(cost.outputCostUsd).toBe(7.65);
+    expect(cost.cacheReadCostUsd).toBe(0.03);
+    expect(cost.cacheCreationCostUsd).toBe(0.375);
+    expect(cost.totalCostUsd).toBeCloseTo(11.055);
+  });
+
+  it('uses tiered pricing when a model has prompt-size tiers', () => {
+    const belowTier = calculateModelCost('gemini-2.5-pro', {
+      inputTokens: 200_000,
+      outputTokens: 100_000,
+    });
+    const aboveTier = calculateModelCost('gemini-2.5-pro', {
+      inputTokens: 200_001,
+      outputTokens: 100_000,
+    });
+
+    expect(belowTier.inputCostUsd).toBe(0.25);
+    expect(belowTier.outputCostUsd).toBe(1);
+    expect(aboveTier.inputCostUsd).toBeCloseTo(0.5000025);
+    expect(aboveTier.outputCostUsd).toBe(1.5);
+  });
+
+  it('formats tiny and normal USD amounts for UI consumers', () => {
+    expect(formatUsd(0)).toBe('$0.00');
+    expect(formatUsd(0.0042)).toBe('$0.004200');
+    expect(formatUsd(1.234)).toBe('$1.23');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a Zero model registry for OpenAI, Anthropic, and Google models with provider metadata, aliases, context/output limits, capabilities, reasoning effort metadata, and pricing source information.
- Add model lookup, provider/capability filters, provider compatibility checks, reasoning effort helpers, and token cost calculation utilities.
- Add focused model registry tests and include `react-devtools-core` so the existing Ink build compiles with Bun.

## Tests

- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check origin/main...HEAD`

## Notes

This is the first Gnanam M1 runtime module. The next slice should be `feat/m1-provider-factory`, which can consume this registry for provider/model resolution.
