### PR TITLE
feat: add provider factory

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,17 +1,13 @@
 import { loadProviderConfig } from '../config/provider';
 import { configManager } from '../config/manager';
-import { OpenAIProvider } from '../providers/openai';
+import { createProvider, resolveProviderType } from '../providers/factory';
 import { runAgent } from '../agent/loop';
 
 export async function runHeadless(prompt: string) {
   const providerConfig = await loadProviderConfig();
   const activeProfile = configManager.getActiveProvider();
-
-  const provider = new OpenAIProvider({
-    apiKey: providerConfig.apiKey || '',
-    baseURL: providerConfig.baseURL,
-    model: providerConfig.model,
-  });
+  const providerType = resolveProviderType(providerConfig);
+  const provider = createProvider(providerConfig);
 
   const source = activeProfile 
     ? `profile: ${activeProfile.name}`
@@ -29,6 +25,7 @@ export async function runHeadless(prompt: string) {
 `);
 
   console.log(`[zero] Provider: ${source}`);
+  console.log(`[zero] Provider Type: ${providerType}`);
   console.log(`[zero] Model: ${providerConfig.model}`);
   console.log(`[zero] Base URL: ${providerConfig.baseURL}`);
   console.log(`\n> ${prompt}\n`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -17,8 +17,11 @@ import { z } from 'zod';
  * environment variables. CLI flags win over everything except defaults.
  */
 
+export const ProviderTypeSchema = z.enum(['openai', 'anthropic', 'google', 'openai-compatible']);
+
 export const ProviderProfileSchema = z.object({
   name: z.string().min(1),
+  provider: ProviderTypeSchema.optional(),
   baseURL: z.string().url(),
   apiKey: z.string().optional(),
   model: z.string().min(1),

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -92,6 +92,7 @@ export class ConfigManager {
 
   // Used by the agent loop
   getEffectiveProviderConfig(): {
+    provider?: ProviderProfile['provider'];
     baseURL: string;
     apiKey?: string;
     model: string;
@@ -101,6 +102,7 @@ export class ConfigManager {
     const active = this.getActiveProvider();
     if (active) {
       return {
+        provider: active.provider,
         baseURL: active.baseURL,
         apiKey: active.apiKey,
         model: active.model,
@@ -110,6 +112,7 @@ export class ConfigManager {
     // Fallback to env vars
     if (process.env.OPENAI_BASE_URL || process.env.OPENAI_MODEL) {
       return {
+        provider: 'openai',
         baseURL: process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
         apiKey: process.env.OPENAI_API_KEY,
         model: process.env.OPENAI_MODEL || 'gpt-4o',

--- a/src/config/provider.ts
+++ b/src/config/provider.ts
@@ -1,6 +1,8 @@
 import { configManager } from './manager';
+import type { ProviderType } from './types';
 
 export interface ProviderConfig {
+  provider?: ProviderType;
   apiKey?: string;
   baseURL: string;
   model: string;
@@ -21,6 +23,7 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
     const parsed = JSON.parse(stdout.toString());
 
     return {
+      provider: normalizeProviderType(parsed.provider ?? parsed.provider_type ?? parsed.type),
       apiKey: parsed.api_key,
       baseURL: parsed.base_url || 'https://api.openai.com/v1',
       model: parsed.model,
@@ -47,8 +50,16 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
   }
 
   return {
+    provider: 'openai',
     apiKey: envApiKey,
     baseURL: envBaseURL,
     model: envModel,
   };
+}
+
+function normalizeProviderType(value: unknown): ProviderType | undefined {
+  if (value === 'openai' || value === 'anthropic' || value === 'google' || value === 'openai-compatible') {
+    return value;
+  }
+  return undefined;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,5 +1,10 @@
+import type { ModelProvider } from '../models';
+
+export type ProviderType = ModelProvider | 'openai-compatible';
+
 export interface ProviderProfile {
   name: string;
+  provider?: ProviderType;
   baseURL: string;
   apiKey?: string;
   model: string;

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,0 +1,77 @@
+import type { ProviderConfig } from '../config/provider';
+import type { ProviderType } from '../config/types';
+import { getModel } from '../models';
+import type { ModelProvider } from '../models';
+import { OpenAIProvider } from './openai';
+import type { Provider } from './types';
+
+const OPENAI_BASE_URL = 'https://api.openai.com/v1';
+
+export class ProviderFactoryError extends Error {
+  constructor(message: string, readonly providerType?: ProviderType) {
+    super(message);
+    this.name = 'ProviderFactoryError';
+  }
+}
+
+export function createProvider(config: ProviderConfig): Provider {
+  const providerType = resolveProviderType(config);
+  assertProviderSupportsModel(providerType, config.model);
+  const apiModel = resolveApiModel(config.model);
+
+  if (providerType === 'openai' || providerType === 'openai-compatible') {
+    return new OpenAIProvider({
+      apiKey: config.apiKey || '',
+      baseURL: config.baseURL || OPENAI_BASE_URL,
+      model: apiModel,
+    });
+  }
+
+  throw new ProviderFactoryError(
+    `${displayProvider(providerType)} provider is not implemented yet. ` +
+      'This provider type is reserved for the upcoming M1 provider modules.',
+    providerType
+  );
+}
+
+export function resolveProviderType(config: ProviderConfig): ProviderType {
+  if (config.provider) return config.provider;
+
+  const registryModel = getModel(config.model);
+  if (registryModel) return registryModel.provider;
+
+  return isDefaultOpenAIBaseURL(config.baseURL) ? 'openai' : 'openai-compatible';
+}
+
+export function resolveApiModel(modelIdOrAlias: string): string {
+  return getModel(modelIdOrAlias)?.apiModel ?? modelIdOrAlias;
+}
+
+export function assertProviderSupportsModel(
+  providerType: ProviderType,
+  modelIdOrAlias: string
+): void {
+  const registryModel = getModel(modelIdOrAlias);
+  if (!registryModel) return;
+
+  const expectedProvider = normalizeProvider(providerType);
+  if (registryModel.provider !== expectedProvider) {
+    throw new ProviderFactoryError(
+      `Model ${registryModel.id} is provided by ${registryModel.provider}, not ${providerType}.`,
+      providerType
+    );
+  }
+}
+
+function normalizeProvider(providerType: ProviderType): ModelProvider {
+  return providerType === 'openai-compatible' ? 'openai' : providerType;
+}
+
+function isDefaultOpenAIBaseURL(baseURL: string): boolean {
+  return baseURL.replace(/\/+$/, '') === OPENAI_BASE_URL;
+}
+
+function displayProvider(providerType: ProviderType): string {
+  if (providerType === 'openai-compatible') return 'OpenAI-compatible';
+  return providerType[0]!.toUpperCase() + providerType.slice(1);
+}

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -141,6 +141,30 @@ describe('ZeroConfigSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('accepts supported provider types', () => {
+    const result = ZeroConfigSchema.safeParse({
+      providers: [{
+        name: 'anthropic',
+        provider: 'anthropic',
+        baseURL: 'https://api.anthropic.com',
+        model: 'claude-sonnet',
+      }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown provider types', () => {
+    const result = ZeroConfigSchema.safeParse({
+      providers: [{
+        name: 'bad',
+        provider: 'not-real',
+        baseURL: 'https://api.example.com',
+        model: 'm',
+      }],
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('loadConfig', () => {

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  ProviderFactoryError,
+  assertProviderSupportsModel,
+  createProvider,
+  resolveApiModel,
+  resolveProviderType,
+} from '../src/providers/factory';
+import { OpenAIProvider } from '../src/providers/openai';
+
+describe('provider factory', () => {
+  it('resolves explicit provider type first', () => {
+    expect(resolveProviderType({
+      provider: 'openai-compatible',
+      baseURL: 'https://gateway.example.com/v1',
+      model: 'custom-model',
+    })).toBe('openai-compatible');
+  });
+
+  it('resolves provider type from known registry models', () => {
+    expect(resolveProviderType({
+      baseURL: 'https://api.anthropic.com',
+      model: 'claude-sonnet',
+    })).toBe('anthropic');
+
+    expect(resolveProviderType({
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+      model: 'gemini-flash',
+    })).toBe('google');
+  });
+
+  it('falls back to OpenAI-compatible for unknown custom endpoint models', () => {
+    expect(resolveProviderType({
+      baseURL: 'https://gateway.example.com/v1',
+      model: 'unknown-but-valid-custom-model',
+    })).toBe('openai-compatible');
+  });
+
+  it('falls back to OpenAI for unknown models on the default OpenAI base URL', () => {
+    expect(resolveProviderType({
+      baseURL: 'https://api.openai.com/v1',
+      model: 'unknown-openai-model',
+    })).toBe('openai');
+  });
+
+  it('resolves registry aliases to API model IDs', () => {
+    expect(resolveApiModel('gpt-5-mini')).toBe('gpt-5.4-mini');
+    expect(resolveApiModel('unknown-custom-model')).toBe('unknown-custom-model');
+  });
+
+  it('creates the OpenAI provider for OpenAI-compatible configs', () => {
+    const provider = createProvider({
+      provider: 'openai-compatible',
+      baseURL: 'https://gateway.example.com/v1',
+      apiKey: 'test-key',
+      model: 'custom-model',
+    });
+
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+  });
+
+  it('throws a clear error for reserved providers that do not have modules yet', () => {
+    expect(() => createProvider({
+      provider: 'anthropic',
+      baseURL: 'https://api.anthropic.com',
+      apiKey: 'test-key',
+      model: 'claude-sonnet',
+    })).toThrow('Anthropic provider is not implemented yet');
+  });
+
+  it('rejects known registry models configured under the wrong provider', () => {
+    expect(() => assertProviderSupportsModel('openai', 'claude-sonnet')).toThrow(
+      'Model claude-sonnet-4-6 is provided by anthropic, not openai.'
+    );
+  });
+
+  it('allows unknown models because custom gateways can expose non-registry IDs', () => {
+    expect(() => assertProviderSupportsModel('openai-compatible', 'vendor/custom-model')).not.toThrow();
+  });
+
+  it('uses a typed factory error for unsupported providers', () => {
+    try {
+      createProvider({
+        provider: 'google',
+        baseURL: 'https://generativelanguage.googleapis.com/v1beta',
+        model: 'gemini-flash',
+      });
+      throw new Error('Expected createProvider to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderFactoryError);
+      expect((error as ProviderFactoryError).providerType).toBe('google');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add a provider factory that resolves provider type from explicit config, model registry metadata, or OpenAI-compatible endpoint defaults.
- Route headless execution through the factory instead of constructing `OpenAIProvider` directly.
- Add provider type validation to config and focused tests for provider resolution, API model alias resolution, OpenAI-compatible provider creation, and reserved Anthropic/Gemini errors.

## Tests

- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes tsc --noEmit`
- `npx --yes bun run build`
- `./zero --help`
- `git diff --check`

## Notes

This PR is stacked on `feat/m1-model-registry` while #7 is open because it depends on the model registry APIs. Once #7 merges, this branch can be rebased or retargeted to `main`.

Anthropic and Google provider types are intentionally reserved with clear errors until their concrete provider modules land in the next M1 slices.
