### PR TITLE
Add M0 CI scripts baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test
-        run: bun test
+        run: bun run test
 
       - name: Typecheck
         run: bun run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke:
+    name: Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun test
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Build binary
+        run: bun run build
+
+      - name: Smoke binary
+        run: bun run smoke:build

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Setup
 
 ```bash
-bun install
+bun install --frozen-lockfile
 ```
 
 ## Run
@@ -21,4 +21,4 @@ bun run build
 bun run smoke:build
 ```
 
-This project uses Bun 1.3.14.
+Bun version is pinned in `package.json`.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # zero
 
-To install dependencies:
+## Setup
 
 ```bash
 bun install
 ```
 
-To run:
+## Run
 
 ```bash
-bun run index.ts
+bun run dev
 ```
 
-This project was created using `bun init` in bun v1.3.11. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+## Checks
+
+```bash
+bun test
+bun run typecheck
+bun run build
+bun run smoke:build
+```
+
+This project uses Bun 1.3.14.

--- a/bun.lock
+++ b/bun.lock
@@ -18,9 +18,8 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/react": "^19.2.15",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
+        "react-devtools-core": "^7.0.1",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -181,6 +180,8 @@
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -196,6 +197,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "shiki": ["shiki@4.1.0", "", { "dependencies": { "@shikijs/core": "4.1.0", "@shikijs/engine-javascript": "4.1.0", "@shikijs/engine-oniguruma": "4.1.0", "@shikijs/langs": "4.1.0", "@shikijs/themes": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q=="],
 
@@ -249,7 +252,7 @@
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
@@ -261,9 +264,13 @@
 
     "ink/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "ink/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "openai/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "test": "bun test ./tests --timeout 15000",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "bunx tsc --noEmit",
     "build": "bun run scripts/build.ts",
     "smoke:build": "bun run scripts/smoke-build.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "zero",
   "version": "0.1.0",
+  "packageManager": "bun@1.3.14",
   "module": "src/index.ts",
   "type": "module",
   "bin": {
@@ -9,14 +10,15 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "test": "bun test ./tests --timeout 15000",
-    "build": "bun build src/index.ts --compile --outfile zero"
+    "typecheck": "tsc --noEmit",
+    "build": "bun run scripts/build.ts",
+    "smoke:build": "bun run scripts/smoke-build.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/react": "^19.2.15"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
+    "@types/react": "^19.2.15",
+    "react-devtools-core": "^7.0.1",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "commander": "^15.0.0",

--- a/scripts/artifact.ts
+++ b/scripts/artifact.ts
@@ -1,0 +1,4 @@
+import { join } from 'node:path';
+
+export const zeroArtifactName = process.platform === 'win32' ? 'zero.exe' : 'zero';
+export const zeroArtifactPath = join(process.cwd(), zeroArtifactName);

--- a/scripts/artifact.ts
+++ b/scripts/artifact.ts
@@ -1,4 +1,8 @@
 import { join } from 'node:path';
 
-export const zeroArtifactName = process.platform === 'win32' ? 'zero.exe' : 'zero';
+export function getZeroArtifactName(platform = process.platform): string {
+  return platform === 'win32' ? 'zero.exe' : 'zero';
+}
+
+export const zeroArtifactName = getZeroArtifactName();
 export const zeroArtifactPath = join(process.cwd(), zeroArtifactName);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,5 @@
+import { $ } from 'bun';
+import { zeroArtifactName, zeroArtifactPath } from './artifact';
+
+await $`bun build src/index.ts --compile --outfile ${zeroArtifactPath}`;
+console.log(`Built ${zeroArtifactName}`);

--- a/scripts/smoke-build.ts
+++ b/scripts/smoke-build.ts
@@ -24,7 +24,16 @@ if (exitCode !== 0) {
   process.exit(exitCode);
 }
 
-const expectedVersion = JSON.parse(packageText).version;
+let expectedVersion: string;
+
+try {
+  expectedVersion = JSON.parse(packageText).version;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to parse package.json: ${message}`);
+  process.exit(1);
+}
+
 const actualVersion = stdout.trim();
 
 if (actualVersion !== expectedVersion) {

--- a/scripts/smoke-build.ts
+++ b/scripts/smoke-build.ts
@@ -1,0 +1,35 @@
+import { zeroArtifactName, zeroArtifactPath } from './artifact';
+
+const artifact = Bun.file(zeroArtifactPath);
+
+if (!(await artifact.exists())) {
+  console.error(`Build artifact not found: ${zeroArtifactName}`);
+  process.exit(1);
+}
+
+const child = Bun.spawn([zeroArtifactPath, '--version'], {
+  stderr: 'pipe',
+  stdout: 'pipe',
+});
+
+const [exitCode, stdout, stderr, packageText] = await Promise.all([
+  child.exited,
+  new Response(child.stdout).text(),
+  new Response(child.stderr).text(),
+  Bun.file('package.json').text(),
+]);
+
+if (exitCode !== 0) {
+  console.error(stderr.trim() || `${zeroArtifactName} --version exited with ${exitCode}`);
+  process.exit(exitCode);
+}
+
+const expectedVersion = JSON.parse(packageText).version;
+const actualVersion = stdout.trim();
+
+if (actualVersion !== expectedVersion) {
+  console.error(`Expected ${zeroArtifactName} --version to print ${expectedVersion}, got ${actualVersion}`);
+  process.exit(1);
+}
+
+console.log(`${zeroArtifactName} smoke check passed (${actualVersion})`);

--- a/tests/build-scripts.test.ts
+++ b/tests/build-scripts.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'bun:test';
+import { getZeroArtifactName } from '../scripts/artifact';
+
+describe('build artifact naming', () => {
+  it('uses a Windows executable suffix on win32', () => {
+    expect(getZeroArtifactName('win32')).toBe('zero.exe');
+  });
+
+  it('uses the plain binary name on Unix platforms', () => {
+    expect(getZeroArtifactName('linux')).toBe('zero');
+    expect(getZeroArtifactName('darwin')).toBe('zero');
+  });
+});

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+
+describe('zero --version', () => {
+  it('prints the package version', async () => {
+    const packageJson = await Bun.file('package.json').json() as { version: string };
+    const child = Bun.spawn([process.execPath, 'src/index.ts', '--version'], {
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr.trim()).toBe('');
+    expect(stdout.trim()).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- Add stable M0 scripts for test, typecheck, binary build, and binary smoke checks
- Add Linux/macOS/Windows GitHub Actions smoke matrix
- Pin Bun version metadata and document setup/check commands

## Verification
- bun install --frozen-lockfile
- bun test
- bun run typecheck
- bun run build
- bun run smoke:build
- git diff --check