### PR TITLE
[codex] p0 foundation tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/react": "^19.2.15",
+        "react-devtools-core": "^7.0.1",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -181,6 +182,8 @@
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
@@ -196,6 +199,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "shiki": ["shiki@4.1.0", "", { "dependencies": { "@shikijs/core": "4.1.0", "@shikijs/engine-javascript": "4.1.0", "@shikijs/engine-oniguruma": "4.1.0", "@shikijs/langs": "4.1.0", "@shikijs/themes": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q=="],
 
@@ -249,7 +254,7 @@
 
     "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
-    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+    "ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
@@ -261,9 +266,13 @@
 
     "ink/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "ink/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "openai/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "bun run src/index.ts",
+    "typecheck": "bunx tsc --noEmit",
     "test": "bun test ./tests --timeout 15000",
     "build": "bun build src/index.ts --compile --outfile zero"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/react": "^19.2.15"
+    "@types/react": "^19.2.15",
+    "react-devtools-core": "^7.0.1"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -114,19 +114,27 @@ export async function runAgent(
       }
 
       if (event.type === 'tool-call-start') {
-        toolCallMap.set(event.id, {
-          id: event.id,
-          name: event.name,
-          arguments: '',
-        });
+        const existing = toolCallMap.get(event.id);
+        if (existing) {
+          existing.name = event.name;
+        } else {
+          toolCallMap.set(event.id, {
+            id: event.id,
+            name: event.name,
+            arguments: '',
+          });
+        }
         // Do NOT emit to UI yet — we want the full arguments for proper formatting
       }
 
       if (event.type === 'tool-call-delta') {
-        const existing = toolCallMap.get(event.id);
-        if (existing) {
-          existing.arguments += event.argumentsFragment;
-        }
+        const existing = toolCallMap.get(event.id) ?? {
+          id: event.id,
+          name: '',
+          arguments: '',
+        };
+        existing.arguments += event.argumentsFragment;
+        toolCallMap.set(event.id, existing);
       }
 
       if (event.type === 'tool-call-end') {
@@ -162,32 +170,21 @@ export async function runAgent(
 
     // === Execute tools (in parallel) ===
     const toolPromises = assistantToolCalls.map(async (tc) => {
-      const tool = tools.find(t => t.name === tc.name);
-
       let result: string;
 
-      if (!tool) {
-        result = `Error: Unknown tool "${tc.name}".`;
-      } else {
-        let parsedArgs: any = {};
-        try {
-          parsedArgs = tc.arguments ? JSON.parse(tc.arguments) : {};
-        } catch (e: any) {
-          result = `Error: Failed to parse arguments for ${tc.name}: ${e.message}`;
-          if (onToolResult) onToolResult({ toolCallId: tc.id, result });
-          return { toolCallId: tc.id, result };
-        }
+      let parsedArgs: any = {};
+      try {
+        parsedArgs = tc.arguments ? JSON.parse(tc.arguments) : {};
+      } catch (e: any) {
+        result = `Error: Failed to parse arguments for ${tc.name}: ${e.message}`;
+        if (onToolResult) onToolResult({ toolCallId: tc.id, result });
+        return { toolCallId: tc.id, result };
+      }
 
-        try {
-          // Prefer the safe `run` path (ToolBase) so schema validation
-          // and thrown-error handling kick in for subclasses. Plain
-          // object-literal tools fall back to `execute` directly.
-          result = await (tool.run
-            ? tool.run(parsedArgs)
-            : tool.execute(parsedArgs));
-        } catch (e: any) {
-          result = `Error executing ${tc.name}: ${e.message}`;
-        }
+      try {
+        result = await toolRegistry.run(tc.name, parsedArgs);
+      } catch (e: any) {
+        result = `Error executing ${tc.name}: ${e.message}`;
       }
 
       if (onToolResult) {

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -47,11 +47,16 @@ export async function runAgent(
   ];
 
   const tools = toolRegistry.getAll();
+  // Until a real permission UX exists, only advertise tools that can run
+  // without an interactive grant. Prompt/deny tools remain registered for
+  // direct guarded execution, but the model should not be invited to call
+  // tools that the agent loop cannot approve yet.
+  const autoExecutableTools = tools.filter(t => t.safety.permission === 'allow');
   let finalAnswer = '';
 
   for (let turn = 0; turn < maxTurns; turn++) {
-    const toolDefinitions = (toolsEnabled && tools.length > 0)
-      ? tools.map(t => {
+    const toolDefinitions = (toolsEnabled && autoExecutableTools.length > 0)
+      ? autoExecutableTools.map(t => {
           // Convert Zod schema to proper JSON Schema (critical for many providers).
           // zod v4 ships this natively — no external package needed.
           const jsonSchema = z.toJSONSchema(t.parameters, {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -71,6 +71,7 @@ export class OpenAIProvider implements Provider {
       id: string; 
       name: string; 
       arguments: string;
+      emittedLength: number;
       started: boolean;
     }>();
 
@@ -96,7 +97,7 @@ export class OpenAIProvider implements Provider {
 
             let acc = toolCallAccumulators.get(tc.index);
             if (!acc) {
-              acc = { id: '', name: '', arguments: '', started: false };
+              acc = { id: '', name: '', arguments: '', emittedLength: 0, started: false };
               toolCallAccumulators.set(tc.index, acc);
             }
 
@@ -106,12 +107,15 @@ export class OpenAIProvider implements Provider {
               if (acc.id) {
                 yield { type: 'tool-call-end', id: acc.id };
               }
-              acc = { id: '', name: '', arguments: '', started: false };
+              acc = { id: '', name: '', arguments: '', emittedLength: 0, started: false };
               toolCallAccumulators.set(tc.index, acc);
             }
 
             if (tc.id) acc.id = tc.id;
             if (tc.function?.name) acc.name = tc.function.name;
+            if (tc.function?.arguments) {
+              acc.arguments += tc.function.arguments;
+            }
 
             // Emit start before the first argument delta when a provider
             // sends id, name, and arguments in the same stream chunk.
@@ -120,12 +124,13 @@ export class OpenAIProvider implements Provider {
               acc.started = true;
             }
 
-            if (tc.function?.arguments) {
-              acc.arguments += tc.function.arguments;
+            if (acc.id && acc.started && acc.arguments.length > acc.emittedLength) {
+              const argumentsFragment = acc.arguments.slice(acc.emittedLength);
+              acc.emittedLength = acc.arguments.length;
               yield {
                 type: 'tool-call-delta',
-                id: acc.id || `pending-${tc.index}`,
-                argumentsFragment: tc.function.arguments,
+                id: acc.id,
+                argumentsFragment,
               };
             }
           }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -112,6 +112,14 @@ export class OpenAIProvider implements Provider {
 
             if (tc.id) acc.id = tc.id;
             if (tc.function?.name) acc.name = tc.function.name;
+
+            // Emit start before the first argument delta when a provider
+            // sends id, name, and arguments in the same stream chunk.
+            if (acc.id && acc.name && !acc.started) {
+              yield { type: 'tool-call-start', id: acc.id, name: acc.name };
+              acc.started = true;
+            }
+
             if (tc.function?.arguments) {
               acc.arguments += tc.function.arguments;
               yield {
@@ -119,12 +127,6 @@ export class OpenAIProvider implements Provider {
                 id: acc.id || `pending-${tc.index}`,
                 argumentsFragment: tc.function.arguments,
               };
-            }
-
-            // Emit start event the first time we have both id and name
-            if (acc.id && acc.name && !acc.started) {
-              yield { type: 'tool-call-start', id: acc.id, name: acc.name };
-              acc.started = true;
             }
           }
         }

--- a/src/tools/apply_patch.ts
+++ b/src/tools/apply_patch.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import { z } from 'zod';
 import { execa } from 'execa';
 import type { Tool } from './types';
@@ -21,15 +21,28 @@ export const applyPatchTool: Tool = {
   },
   async execute(args) {
     const { patch, cwd } = ApplyPatchParams.parse(args);
-    const root = cwd || process.cwd();
+    const workspaceRoot = process.cwd();
+    const root = resolve(cwd || workspaceRoot);
+    const rel = relative(workspaceRoot, root);
+
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      return `Error applying patch: cwd must stay inside the workspace (${workspaceRoot}).`;
+    }
+
     const tempDir = await mkdtemp(join(tmpdir(), 'zero-patch-'));
     const patchPath = join(tempDir, 'change.patch');
 
     try {
       await writeFile(patchPath, patch, 'utf-8');
 
-      const result = await execa('git', ['apply', '--whitespace=nowarn', patchPath], {
-        cwd: root,
+      const gitArgs = ['apply', '--whitespace=nowarn'];
+      if (rel) {
+        gitArgs.push(`--directory=${rel.replaceAll('\\', '/')}`);
+      }
+      gitArgs.push(patchPath);
+
+      const result = await execa('git', gitArgs, {
+        cwd: workspaceRoot,
         reject: false,
       });
 

--- a/src/tools/apply_patch.ts
+++ b/src/tools/apply_patch.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { z } from 'zod';
+import { execa } from 'execa';
+import type { Tool } from './types';
+
+const ApplyPatchParams = z.object({
+  patch: z.string().min(1).describe('Unified diff patch to apply.'),
+  cwd: z.string().optional().describe('Directory where the patch should be applied. Defaults to the current workspace.'),
+});
+
+export const applyPatchTool: Tool = {
+  name: 'apply_patch',
+  description: 'Apply a unified diff patch to files in the workspace.',
+  parameters: ApplyPatchParams,
+  safety: {
+    sideEffect: 'write',
+    permission: 'prompt',
+    reason: 'Applies patch hunks that can create, edit, or delete files.',
+  },
+  async execute(args) {
+    const { patch, cwd } = ApplyPatchParams.parse(args);
+    const root = cwd || process.cwd();
+    const tempDir = await mkdtemp(join(tmpdir(), 'zero-patch-'));
+    const patchPath = join(tempDir, 'change.patch');
+
+    try {
+      await writeFile(patchPath, patch, 'utf-8');
+
+      const result = await execa('git', ['apply', '--whitespace=nowarn', patchPath], {
+        cwd: root,
+        reject: false,
+      });
+
+      if (result.exitCode !== 0) {
+        const output = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+        return `Error applying patch: ${output || `git apply exited with code ${result.exitCode}`}`;
+      }
+
+      return 'Patch applied successfully.';
+    } catch (err: any) {
+      return `Error applying patch: ${err.message}`;
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  },
+};

--- a/src/tools/apply_patch.ts
+++ b/src/tools/apply_patch.ts
@@ -12,7 +12,8 @@ const ApplyPatchParams = z.object({
 
 export const applyPatchTool: Tool = {
   name: 'apply_patch',
-  description: 'Apply a unified diff patch to files in the workspace.',
+  description:
+    'Apply a unified diff patch inside the current workspace. Paths outside the workspace are rejected; be conservative about which paths you patch.',
   parameters: ApplyPatchParams,
   safety: {
     sideEffect: 'write',

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -28,22 +28,6 @@ export abstract class ToolBase<T extends z.ZodObject<any> = z.ZodObject<any>> {
   abstract execute(args: z.infer<T>): Promise<string>;
 
   /**
-   * Parse raw LLM-supplied arguments through the Zod schema, then execute.
-   * Returns either a string result or a `ZodError` formatted as a string.
-   */
-  async run(rawArgs: unknown): Promise<string> {
-    const parsed = this.parameters.safeParse(rawArgs);
-    if (!parsed.success) {
-      return `Error: Invalid arguments for ${this.name}: ${parsed.error.message}`;
-    }
-    try {
-      return await this.execute(parsed.data as z.infer<T>);
-    } catch (err: any) {
-      return `Error executing ${this.name}: ${err?.message ?? String(err)}`;
-    }
-  }
-
-  /**
    * JSON Schema (draft-7) representation of the parameters, suitable for
    * sending to OpenAI-compatible providers. We rely on Zod v4's built-in
    * converter so no extra dependency is required.

--- a/src/tools/base.ts
+++ b/src/tools/base.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import type { ToolSafety } from './types';
 
 /**
  * Abstract base class for all Zero tools.
@@ -17,6 +18,7 @@ export abstract class ToolBase<T extends z.ZodObject<any> = z.ZodObject<any>> {
   abstract readonly name: string;
   abstract readonly description: string;
   abstract readonly parameters: T;
+  abstract readonly safety: ToolSafety;
 
   /**
    * Run the tool with the (already parsed) arguments.

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -11,6 +11,11 @@ export const bashTool: Tool = {
   name: 'bash',
   description: 'Execute a shell command and return the output. Use for running commands, git, tests, etc.',
   parameters: BashParams,
+  safety: {
+    sideEffect: 'shell',
+    permission: 'prompt',
+    reason: 'Shell commands can read, write, or execute programs.',
+  },
   async execute(args) {
     const { command, cwd } = BashParams.parse(args);
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -9,7 +9,9 @@ const BashParams = z.object({
 
 export const bashTool: Tool = {
   name: 'bash',
-  description: 'Execute a shell command and return the output. Use for running commands, git, tests, etc.',
+  description:
+    'Execute a shell command and return the output. Use for running commands, git, tests, etc. ' +
+    'No command allowlist exists yet, so only run conservative workspace-safe commands after permission is granted.',
   parameters: BashParams,
   safety: {
     sideEffect: 'shell',

--- a/src/tools/edit_file.ts
+++ b/src/tools/edit_file.ts
@@ -27,6 +27,11 @@ export const editFileTool: Tool = {
     'Replace an exact string in a file. By default old_string must match exactly one location (a safety check). ' +
     'Pass replace_all: true to replace every occurrence. The new_string may be empty to delete a region.',
   parameters: EditFileParams,
+  safety: {
+    sideEffect: 'write',
+    permission: 'prompt',
+    reason: 'Edits files in place.',
+  },
   async execute(args) {
     const { path, old_string, new_string, replace_all } = EditFileParams.parse(args);
 

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -22,11 +22,15 @@ export const globTool: Tool = {
     const glob = new Bun.Glob(pattern);
     const root = cwd || process.cwd();
     const matches: string[] = [];
+    let truncated = false;
 
     try {
       for (const match of glob.scanSync({ cwd: root, onlyFiles: !include_dirs })) {
+        if (matches.length >= limit) {
+          truncated = true;
+          break;
+        }
         matches.push(match);
-        if (matches.length > limit) break;
       }
     } catch (err: any) {
       return `Error running glob "${pattern}": ${err.message}`;
@@ -36,8 +40,6 @@ export const globTool: Tool = {
       return `No matches found for ${pattern}`;
     }
 
-    const visible = matches.slice(0, limit);
-    const truncated = matches.length > limit ? `\n... truncated after ${limit} matches` : '';
-    return visible.join('\n') + truncated;
+    return matches.join('\n') + (truncated ? `\n... truncated after ${limit} matches` : '');
   },
 };

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import type { Tool } from './types';
+
+const GlobParams = z.object({
+  pattern: z.string().min(1).describe('Glob pattern to match, for example "**/*.ts".'),
+  cwd: z.string().optional().describe('Directory to scan. Defaults to the current working directory.'),
+  limit: z.number().int().min(1).max(1000).optional().default(100).describe('Maximum matches to return.'),
+  include_dirs: z.boolean().optional().default(false).describe('Whether directory matches should be included.'),
+});
+
+export const globTool: Tool = {
+  name: 'glob',
+  description: 'Find files by glob pattern. Use this to quickly discover files by name or extension.',
+  parameters: GlobParams,
+  safety: {
+    sideEffect: 'read',
+    permission: 'allow',
+    reason: 'Finds matching paths without reading contents or modifying files.',
+  },
+  async execute(args) {
+    const { pattern, cwd, limit, include_dirs } = GlobParams.parse(args);
+    const glob = new Bun.Glob(pattern);
+    const root = cwd || process.cwd();
+    const matches: string[] = [];
+
+    try {
+      for (const match of glob.scanSync({ cwd: root, onlyFiles: !include_dirs })) {
+        matches.push(match);
+        if (matches.length > limit) break;
+      }
+    } catch (err: any) {
+      return `Error running glob "${pattern}": ${err.message}`;
+    }
+
+    if (matches.length === 0) {
+      return `No matches found for ${pattern}`;
+    }
+
+    const visible = matches.slice(0, limit);
+    const truncated = matches.length > limit ? `\n... truncated after ${limit} matches` : '';
+    return visible.join('\n') + truncated;
+  },
+};

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -24,6 +24,11 @@ Features:
 - Different output modes (content, files_with_matches, count)
 - Automatically respects .gitignore`,
   parameters: GrepParams,
+  safety: {
+    sideEffect: 'read',
+    permission: 'allow',
+    reason: 'Searches file paths and matching lines without modifying files.',
+  },
   async execute(args) {
     const params = GrepParams.parse(args);
     const { pattern, path = '.', glob, output_mode, '-i': caseInsensitive, '-n': showLineNumbers, head_limit } = params;

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -22,7 +22,8 @@ Features:
 - Full regex support
 - Filter by glob
 - Different output modes (content, files_with_matches, count)
-- Automatically respects .gitignore`,
+- Automatically respects .gitignore
+- Requires ripgrep (rg) on PATH; returns an error if rg is unavailable`,
   parameters: GrepParams,
   safety: {
     sideEffect: 'read',
@@ -92,8 +93,7 @@ Features:
 
       return formatted.join('\n');
     } catch (err) {
-      // Fallback to simple grep if rg not available (not ideal but works)
-      return `ripgrep (rg) not found. Falling back to basic search is not yet implemented. Please install ripgrep for best results.`;
+      return `Error: ripgrep (rg) is required for grep but was not found on PATH.`;
     }
   },
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,8 @@ import { bashTool } from './bash';
 import { planTool } from './plan';
 import { listDirectoryTool } from './list-directory';
 import { grepTool } from './grep';
+import { globTool } from './glob';
+import { applyPatchTool } from './apply_patch';
 
 toolRegistry.register(readFileTool);
 toolRegistry.register(writeFileTool);
@@ -14,6 +16,8 @@ toolRegistry.register(bashTool);
 toolRegistry.register(planTool);
 toolRegistry.register(listDirectoryTool);
 toolRegistry.register(grepTool);
+toolRegistry.register(globTool);
+toolRegistry.register(applyPatchTool);
 
 // Compatibility re-exports (kebab-case filenames still resolve)
 export { readFileTool as readFileToolKebab } from './read_file';

--- a/src/tools/list-directory.ts
+++ b/src/tools/list-directory.ts
@@ -18,6 +18,11 @@ This is the preferred tool for understanding the codebase layout before planning
 - Supports recursive listing with depth control
 - Ignores common junk directories (.git, node_modules, dist, etc.) by default`,
   parameters: ListDirectoryParams,
+  safety: {
+    sideEffect: 'read',
+    permission: 'allow',
+    reason: 'Lists directory entries without modifying files.',
+  },
   async execute(args) {
     const { path = '.', recursive, max_depth } = ListDirectoryParams.parse(args);
 

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -52,6 +52,11 @@ When to use:
 
 The plan should be clear, actionable, and ordered. Keep it up to date as you work.`,
   parameters: UpdatePlanParams,
+  safety: {
+    sideEffect: 'read',
+    permission: 'allow',
+    reason: 'Updates in-memory planning state only.',
+  },
   async execute(args) {
     const { plan } = UpdatePlanParams.parse(args);
 

--- a/src/tools/read_file.ts
+++ b/src/tools/read_file.ts
@@ -38,6 +38,11 @@ export const readFileTool: Tool = {
     'Read the contents of a file. Supports an optional inclusive line range (start_line, end_line) and a max_lines cap. ' +
     'Output is line-numbered so lines can be referenced precisely.',
   parameters: ReadFileParams,
+  safety: {
+    sideEffect: 'read',
+    permission: 'allow',
+    reason: 'Reads file contents without modifying files.',
+  },
   async execute(args) {
     const { path, start_line, end_line, max_lines } = ReadFileParams.parse(args);
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -15,10 +15,15 @@ export class ToolRegistry {
     return Array.from(this.tools.values());
   }
 
-  async run(name: string, args: unknown): Promise<string> {
+  async run(name: string, args: unknown, options: { permissionGranted?: boolean } = {}): Promise<string> {
     const tool = this.get(name);
     if (!tool) {
       return `Error: Unknown tool "${name}".`;
+    }
+
+    if (tool.safety.permission !== 'allow' && !options.permissionGranted) {
+      return `Error: Permission required for ${name}: ${tool.safety.reason} ` +
+        `The tool is marked "${tool.safety.permission}" and was not executed.`;
     }
 
     if (tool.run) {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -15,6 +15,28 @@ export class ToolRegistry {
     return Array.from(this.tools.values());
   }
 
+  async run(name: string, args: unknown): Promise<string> {
+    const tool = this.get(name);
+    if (!tool) {
+      return `Error: Unknown tool "${name}".`;
+    }
+
+    if (tool.run) {
+      return tool.run(args);
+    }
+
+    const parsed = tool.parameters.safeParse(args);
+    if (!parsed.success) {
+      return `Error: Invalid arguments for ${name}: ${parsed.error.message}`;
+    }
+
+    try {
+      return await tool.execute(parsed.data);
+    } catch (err: any) {
+      return `Error executing ${name}: ${err?.message ?? String(err)}`;
+    }
+  }
+
   getDefinitionsForProvider() {
     return this.getAll().map(tool => ({
       name: tool.name,

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -26,10 +26,6 @@ export class ToolRegistry {
         `The tool is marked "${tool.safety.permission}" and was not executed.`;
     }
 
-    if (tool.run) {
-      return tool.run(args);
-    }
-
     const parsed = tool.parameters.safeParse(args);
     if (!parsed.success) {
       return `Error: Invalid arguments for ${name}: ${parsed.error.message}`;
@@ -40,14 +36,6 @@ export class ToolRegistry {
     } catch (err: any) {
       return `Error executing ${name}: ${err?.message ?? String(err)}`;
     }
-  }
-
-  getDefinitionsForProvider() {
-    return this.getAll().map(tool => ({
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters.shape, // We'll convert properly later
-    }));
   }
 }
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,5 +1,14 @@
 import type { z } from 'zod';
 
+export type ToolSideEffect = 'read' | 'write' | 'shell' | 'network' | 'out_of_workspace';
+export type ToolPermission = 'allow' | 'prompt' | 'deny';
+
+export interface ToolSafety {
+  sideEffect: ToolSideEffect;
+  permission: ToolPermission;
+  reason: string;
+}
+
 /**
  * Structural type describing any tool usable by the agent loop.
  *
@@ -11,6 +20,7 @@ export interface Tool<T extends z.ZodObject<any> = z.ZodObject<any>> {
   name: string;
   description: string;
   parameters: T;
+  safety: ToolSafety;
   execute: (args: z.infer<T>) => Promise<string>;
   /**
    * Optional safe-execute path used by the agent loop. When present the

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,5 +1,11 @@
 import type { z } from 'zod';
 
+/**
+ * Durable side-effect class for permission policy.
+ *
+ * In-memory-only updates, such as update_plan, should use the closest
+ * non-durable class and explain the distinction in their safety reason.
+ */
 export type ToolSideEffect = 'read' | 'write' | 'shell' | 'network' | 'out_of_workspace';
 export type ToolPermission = 'allow' | 'prompt' | 'deny';
 
@@ -12,9 +18,8 @@ export interface ToolSafety {
 /**
  * Structural type describing any tool usable by the agent loop.
  *
- * This is a duck-typed interface (matches both plain object literals and
- * subclasses of `ToolBase`). The registry accepts anything that satisfies
- * this shape, which keeps the tool authoring style flexible.
+ * Current tools use object literals. The registry owns raw argument
+ * validation/error handling before calling `execute`.
  */
 export interface Tool<T extends z.ZodObject<any> = z.ZodObject<any>> {
   name: string;
@@ -22,13 +27,6 @@ export interface Tool<T extends z.ZodObject<any> = z.ZodObject<any>> {
   parameters: T;
   safety: ToolSafety;
   execute: (args: z.infer<T>) => Promise<string>;
-  /**
-   * Optional safe-execute path used by the agent loop. When present the
-   * loop should prefer it over calling `execute` directly so schema
-   * validation and thrown-error handling from `ToolBase.run` are honored.
-   * Falls back to `execute` for plain object-literal tools.
-   */
-  run?: (rawArgs: unknown) => Promise<string>;
 }
 
 export interface ToolCall {

--- a/src/tools/write_file.ts
+++ b/src/tools/write_file.ts
@@ -19,6 +19,11 @@ export const writeFileTool: Tool = {
     'Create a new file with the given contents. Refuses to overwrite existing files unless `overwrite: true` is passed. ' +
     'Parent directories are created automatically. Use this for new files; for existing files prefer `edit_file`.',
   parameters: WriteFileParams,
+  safety: {
+    sideEffect: 'write',
+    permission: 'prompt',
+    reason: 'Creates or overwrites files.',
+  },
   async execute(args) {
     const { path, content, overwrite } = WriteFileParams.parse(args);
 

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -7,6 +7,7 @@ import type { Provider, Message, StreamEvent } from '../src/providers/types';
 // scripted sequence of stream events per turn.
 class MockProvider implements Provider {
   public received: Message[][] = [];
+  public receivedTools: any[][] = [];
   private turns: StreamEvent[][];
   private turn = 0;
 
@@ -14,9 +15,10 @@ class MockProvider implements Provider {
     this.turns = turns;
   }
 
-  async *streamCompletion(messages: Message[]): AsyncIterable<StreamEvent> {
-    // Snapshot the messages for this turn so tests can inspect the prompt.
+  async *streamCompletion(messages: Message[], tools: any[] = []): AsyncIterable<StreamEvent> {
+    // Snapshot the messages and tool definitions for this turn so tests can inspect the prompt.
     this.received.push(messages.map((m) => ({ ...m })));
+    this.receivedTools.push(tools.map((t) => ({ ...t })));
     const events = this.turns[this.turn] ?? [{ type: 'done' as const }];
     this.turn++;
     for (const ev of events) yield ev;
@@ -77,6 +79,22 @@ describe('runAgent tool-call flow', () => {
     const toolMsg = secondTurn.find((m) => m.role === 'tool');
     expect(toolMsg).toBeDefined();
     expect(toolMsg?.content).toContain('do it');
+  });
+
+  it('does not advertise prompt-gated tools until permission UX exists', async () => {
+    const provider = new MockProvider([[{ type: 'text', content: 'done' }]]);
+
+    await runAgent('which tools can you use?', provider);
+
+    const names = (provider.receivedTools[0] ?? []).map((tool) => tool.name).sort();
+    expect(names).toContain('read_file');
+    expect(names).toContain('grep');
+    expect(names).toContain('glob');
+    expect(names).toContain('update_plan');
+    expect(names).not.toContain('bash');
+    expect(names).not.toContain('apply_patch');
+    expect(names).not.toContain('write_file');
+    expect(names).not.toContain('edit_file');
   });
 
   it('keeps tool arguments when a delta arrives before the start event', async () => {

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -79,6 +79,30 @@ describe('runAgent tool-call flow', () => {
     expect(toolMsg?.content).toContain('do it');
   });
 
+  it('keeps tool arguments when a delta arrives before the start event', async () => {
+    const provider = new MockProvider([
+      [
+        {
+          type: 'tool-call-delta',
+          id: 'call_1',
+          argumentsFragment: JSON.stringify({
+            plan: [{ id: '1', content: 'ordered safely', status: 'pending' }],
+          }),
+        },
+        { type: 'tool-call-start', id: 'call_1', name: 'update_plan' },
+        { type: 'tool-call-end', id: 'call_1' },
+      ],
+      [{ type: 'text', content: 'all done' }],
+    ]);
+
+    const toolResults: string[] = [];
+    await runAgent('make a plan', provider, {
+      onToolResult: (r) => toolResults.push(r.result),
+    });
+
+    expect(toolResults[0]).toContain('ordered safely');
+  });
+
   it('stops and returns text when the model makes no tool calls', async () => {
     const provider = new MockProvider([[{ type: 'text', content: 'just an answer' }]]);
     const answer = await runAgent('hi', provider, {});

--- a/tests/foundation-tools.test.ts
+++ b/tests/foundation-tools.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { applyPatchTool } from '../src/tools/apply_patch';
+import { globTool } from '../src/tools/glob';
+import { toolRegistry } from '../src/tools';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'zero-foundation-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('package scripts', () => {
+  it('exposes the v0.1 foundation validation commands', async () => {
+    const pkg = await Bun.file(join(process.cwd(), 'package.json')).json();
+
+    expect(pkg.scripts.typecheck).toBe('bunx tsc --noEmit');
+    expect(pkg.scripts.test).toBe('bun test ./tests --timeout 15000');
+    expect(pkg.scripts.build).toBe('bun build src/index.ts --compile --outfile zero');
+  });
+});
+
+describe('tool safety metadata', () => {
+  it('marks core tools with side effects and default permission decisions', () => {
+    expect(toolRegistry.get('bash')?.safety).toEqual({
+      sideEffect: 'shell',
+      permission: 'prompt',
+      reason: expect.any(String),
+    });
+    expect(toolRegistry.get('grep')?.safety.sideEffect).toBe('read');
+    expect(toolRegistry.get('glob')?.safety.permission).toBe('allow');
+    expect(toolRegistry.get('apply_patch')?.safety.sideEffect).toBe('write');
+    expect(toolRegistry.get('apply_patch')?.safety.permission).toBe('prompt');
+  });
+});
+
+describe('globTool', () => {
+  it('returns matching paths from the requested cwd', async () => {
+    await writeFile(join(dir, 'one.ts'), 'export const one = 1;', 'utf-8');
+    await writeFile(join(dir, 'two.txt'), 'two', 'utf-8');
+
+    const result = await globTool.execute({ pattern: '*.ts', cwd: dir });
+    expect(result).toContain('one.ts');
+    expect(result).not.toContain('two.txt');
+  });
+});
+
+describe('applyPatchTool', () => {
+  it('applies a unified diff patch', async () => {
+    const file = join(dir, 'hello.txt');
+    await writeFile(file, 'hello\nold\n', 'utf-8');
+
+    const patch = [
+      'diff --git a/hello.txt b/hello.txt',
+      '--- a/hello.txt',
+      '+++ b/hello.txt',
+      '@@ -1,2 +1,2 @@',
+      ' hello',
+      '-old',
+      '+new',
+      '',
+    ].join('\n');
+
+    const result = await applyPatchTool.execute({ patch, cwd: dir });
+    expect(result).toBe('Patch applied successfully.');
+    const content = await readFile(file, 'utf-8');
+    expect(content.replace(/\r\n/g, '\n')).toBe('hello\nnew\n');
+  });
+});

--- a/tests/foundation-tools.test.ts
+++ b/tests/foundation-tools.test.ts
@@ -9,7 +9,7 @@ import { toolRegistry } from '../src/tools';
 let dir: string;
 
 beforeEach(async () => {
-  dir = await mkdtemp(join(tmpdir(), 'zero-foundation-'));
+  dir = await mkdtemp(join(process.cwd(), '.zero-foundation-'));
 });
 
 afterEach(async () => {
@@ -71,5 +71,19 @@ describe('applyPatchTool', () => {
     expect(result).toBe('Patch applied successfully.');
     const content = await readFile(file, 'utf-8');
     expect(content.replace(/\r\n/g, '\n')).toBe('hello\nnew\n');
+  });
+
+  it('refuses to apply patches outside the workspace', async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), 'zero-outside-'));
+    try {
+      const result = await applyPatchTool.execute({
+        cwd: outsideDir,
+        patch: 'diff --git a/nope.txt b/nope.txt\n',
+      });
+
+      expect(result).toContain('cwd must stay inside the workspace');
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/foundation-tools.test.ts
+++ b/tests/foundation-tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { applyPatchTool } from '../src/tools/apply_patch';
@@ -27,16 +27,15 @@ describe('package scripts', () => {
 });
 
 describe('tool safety metadata', () => {
-  it('marks core tools with side effects and default permission decisions', () => {
-    expect(toolRegistry.get('bash')?.safety).toEqual({
-      sideEffect: 'shell',
-      permission: 'prompt',
-      reason: expect.any(String),
-    });
-    expect(toolRegistry.get('grep')?.safety.sideEffect).toBe('read');
-    expect(toolRegistry.get('glob')?.safety.permission).toBe('allow');
-    expect(toolRegistry.get('apply_patch')?.safety.sideEffect).toBe('write');
-    expect(toolRegistry.get('apply_patch')?.safety.permission).toBe('prompt');
+  it('marks every registered tool with valid safety metadata', () => {
+    const sideEffects = ['read', 'write', 'shell', 'network', 'out_of_workspace'];
+    const permissions = ['allow', 'prompt', 'deny'];
+
+    for (const tool of toolRegistry.getAll()) {
+      expect(sideEffects).toContain(tool.safety.sideEffect);
+      expect(permissions).toContain(tool.safety.permission);
+      expect(tool.safety.reason.length).toBeGreaterThan(0);
+    }
   });
 });
 
@@ -48,6 +47,25 @@ describe('globTool', () => {
     const result = await globTool.execute({ pattern: '*.ts', cwd: dir });
     expect(result).toContain('one.ts');
     expect(result).not.toContain('two.txt');
+  });
+
+  it('respects limit without collecting an extra match', async () => {
+    await writeFile(join(dir, 'a.ts'), '', 'utf-8');
+    await writeFile(join(dir, 'b.ts'), '', 'utf-8');
+    await writeFile(join(dir, 'c.ts'), '', 'utf-8');
+
+    const result = await globTool.execute({ pattern: '*.ts', cwd: dir, limit: 2 });
+    const lines = result.split('\n');
+    expect(lines.filter(line => line.endsWith('.ts'))).toHaveLength(2);
+    expect(result).toContain('truncated after 2 matches');
+  });
+
+  it('can include directory matches', async () => {
+    await mkdir(join(dir, 'src'), { recursive: true });
+    await writeFile(join(dir, 'src', 'index.ts'), 'export {};', 'utf-8');
+
+    const result = await globTool.execute({ pattern: 'src', cwd: dir, include_dirs: true });
+    expect(result).toContain('src');
   });
 });
 

--- a/tests/openai-provider.test.ts
+++ b/tests/openai-provider.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+import { OpenAIProvider } from '../src/providers/openai';
+import type { StreamEvent } from '../src/providers/types';
+
+function makeProviderWithChunks(chunks: any[]): OpenAIProvider {
+  const provider = new OpenAIProvider({ apiKey: 'test', model: 'test' });
+  (provider as any).client = {
+    chat: {
+      completions: {
+        create: async function* () {
+          for (const chunk of chunks) {
+            yield chunk;
+          }
+        },
+      },
+    },
+  };
+  return provider;
+}
+
+describe('OpenAIProvider tool-call streaming', () => {
+  it('buffers argument deltas until the real tool call id arrives', async () => {
+    const provider = makeProviderWithChunks([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { arguments: '{"path"' } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'call_1', function: { name: 'read_file' } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { arguments: ':"src/index.ts"}' } },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ]);
+
+    const events: StreamEvent[] = [];
+    for await (const event of provider.streamCompletion([], [])) {
+      events.push(event);
+    }
+
+    const starts = events.filter(event => event.type === 'tool-call-start');
+    const deltas = events.filter(event => event.type === 'tool-call-delta');
+
+    expect(starts).toEqual([{ type: 'tool-call-start', id: 'call_1', name: 'read_file' }]);
+    expect(deltas.every(event => event.id === 'call_1')).toBe(true);
+    expect(deltas.map(event => event.argumentsFragment).join('')).toBe('{"path":"src/index.ts"}');
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -19,6 +19,17 @@ function makeTool(name: string): Tool {
   };
 }
 
+function makePromptTool(name: string): Tool {
+  return {
+    ...makeTool(name),
+    safety: {
+      sideEffect: 'write',
+      permission: 'prompt',
+      reason: 'test prompt gate',
+    },
+  };
+}
+
 describe('ToolRegistry', () => {
   it('registers and retrieves a tool by name', () => {
     const registry = new ToolRegistry();
@@ -58,5 +69,14 @@ describe('ToolRegistry', () => {
 
     expect(await registry.run('safe', { x: 'ok' })).toBe('ran safe:ok');
     expect(await registry.run('safe', { x: 1 })).toContain('Invalid arguments');
+  });
+
+  it('does not auto-run prompt-gated tools without a grant', async () => {
+    const registry = new ToolRegistry();
+    registry.register(makePromptTool('mutate'));
+
+    const result = await registry.run('mutate', { x: 'ok' });
+    expect(result).toContain('Permission required');
+    expect(result).toContain('was not executed');
   });
 });

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -71,6 +71,11 @@ describe('ToolRegistry', () => {
     expect(await registry.run('safe', { x: 1 })).toContain('Invalid arguments');
   });
 
+  it('reports unknown tools from the registry run path', async () => {
+    const registry = new ToolRegistry();
+    expect(await registry.run('missing', {})).toBe('Error: Unknown tool "missing".');
+  });
+
   it('does not auto-run prompt-gated tools without a grant', async () => {
     const registry = new ToolRegistry();
     registry.register(makePromptTool('mutate'));

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -8,8 +8,13 @@ function makeTool(name: string): Tool {
     name,
     description: `tool ${name}`,
     parameters: z.object({ x: z.string() }),
-    async execute() {
-      return `ran ${name}`;
+    safety: {
+      sideEffect: 'read',
+      permission: 'allow',
+      reason: 'test tool',
+    },
+    async execute(args) {
+      return `ran ${name}:${args.x}`;
     },
   };
 }
@@ -45,5 +50,13 @@ describe('ToolRegistry', () => {
 
     expect(registry.getAll()).toHaveLength(1);
     expect(registry.get('dup')).toBe(second);
+  });
+
+  it('runs tools through the validating registry path', async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('safe'));
+
+    expect(await registry.run('safe', { x: 'ok' })).toBe('ran safe:ok');
+    expect(await registry.run('safe', { x: 1 })).toContain('Invalid arguments');
   });
 });

--- a/tests/tool-base.test.ts
+++ b/tests/tool-base.test.ts
@@ -42,22 +42,8 @@ describe('ToolBase', () => {
 
   it('runs parsed arguments through execute()', async () => {
     const tool = new EchoTool();
-    const result = await tool.run({ message: 'hi' });
+    const result = await tool.execute({ message: 'hi' });
     expect(result).toBe('echo: hi');
-  });
-
-  it('returns a friendly string for invalid arguments', async () => {
-    const tool = new EchoTool();
-    const result = await tool.run({ message: 123 }); // wrong type
-    expect(result).toContain('Invalid arguments');
-    expect(result).toContain('echo');
-  });
-
-  it('catches thrown errors and surfaces them as a string', async () => {
-    const tool = new FailingTool();
-    const result = await tool.run({});
-    expect(result).toContain('Error executing boom');
-    expect(result).toContain('kaboom');
   });
 
   it('produces a valid object JSON Schema', () => {

--- a/tests/tool-base.test.ts
+++ b/tests/tool-base.test.ts
@@ -6,6 +6,11 @@ class EchoTool extends ToolBase {
   readonly name = 'echo';
   readonly description = 'Returns its input back.';
   readonly parameters = z.object({ message: z.string() });
+  readonly safety = {
+    sideEffect: 'read' as const,
+    permission: 'allow' as const,
+    reason: 'test tool',
+  };
 
   async execute(args: z.infer<typeof this.parameters>) {
     return `echo: ${args.message}`;
@@ -16,6 +21,11 @@ class FailingTool extends ToolBase {
   readonly name = 'boom';
   readonly description = 'Always throws.';
   readonly parameters = z.object({});
+  readonly safety = {
+    sideEffect: 'read' as const,
+    permission: 'allow' as const,
+    reason: 'test tool',
+  };
 
   async execute(_args: Record<string, unknown>): Promise<string> {
     throw new Error('kaboom');


### PR DESCRIPTION
﻿## What changed

- Added the `typecheck` package script for the v0.1 foundation validation flow.
- Added tool safety metadata for the core local tools, including `bash` as a prompt-gated shell tool.
- Added `glob` and `apply_patch` tools and registered them in the core tool registry.
- Added a registry-level `run` path so agent tool execution goes through validation/error handling instead of raw `execute` dispatch.
- Blocks prompt/deny tools from auto-executing through the registry until a permission grant path exists.
- Keeps `apply_patch` execution inside the workspace and rejects out-of-workspace `cwd` values.
- Buffers OpenAI-compatible tool-call argument chunks until the real tool-call id is known, avoiding stranded `pending-*` ids.
- Removed the optional `Tool.run` contract and the unused provider-definition helper so registry validation is the single object-literal execution path.
- Fixed glob truncation off-by-one and expanded safety/tool tests.
- Includes the M0 CI/build baseline from `main`, including build and smoke scripts.

## Why

This finishes the next small P0 foundation slice after M0 without pulling in later features like MCP, plugins, subagents, or sandboxing.

## Validation

- `bun run typecheck` passed
- `bun test ./tests --timeout 15000` passed: 76 tests, 0 failures
- `bun run build` passed and compiled `zero.exe`
- `bun run smoke:build` passed

## Notes

This PR is intentionally small and keeps full permission prompting UI, persistent grants, structured tool results, and session persistence for later v0.1 slices.
