### PR TITLE
feat: add Zero provider runtime resolver

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,23 +1,36 @@
 import { loadProviderConfig } from '../config/provider';
-import { configManager } from '../config/manager';
-import { OpenAIProvider } from '../providers/openai';
+import { createZeroProvider, resolveZeroProviderRuntime } from '../zero-provider-runtime';
+import type { Provider } from '../providers/types';
+import type { ZeroResolvedProviderRuntime } from '../zero-provider-runtime';
 import { runAgent } from '../agent/loop';
 
 export async function runHeadless(prompt: string) {
   const providerConfig = await loadProviderConfig();
-  const activeProfile = configManager.getActiveProvider();
+  let runtime: ZeroResolvedProviderRuntime | undefined;
+  let provider: Provider | undefined;
 
-  const provider = new OpenAIProvider({
-    apiKey: providerConfig.apiKey || '',
-    baseURL: providerConfig.baseURL,
-    model: providerConfig.model,
-  });
+  try {
+    runtime = resolveZeroProviderRuntime({
+      provider: providerConfig.provider,
+      apiKey: providerConfig.apiKey,
+      baseURL: providerConfig.baseURL,
+      model: providerConfig.model,
+      profileName: providerConfig.profileName,
+      source: providerConfig.source,
+    });
+    provider = createZeroProvider(runtime);
+  } catch (err: any) {
+    console.error(`[zero] ${err?.message ?? String(err)}`);
+    if (runtime?.provider === 'anthropic' || runtime?.provider === 'google') {
+      console.error(
+        `[zero] ${runtime.provider} adapter is not yet implemented. ` +
+        'Set provider: "openai-compatible" with a custom gateway or use an OpenAI model.'
+      );
+    }
+    process.exit(1);
+  }
 
-  const source = activeProfile 
-    ? `profile: ${activeProfile.name}`
-    : process.env.ZERO_PROVIDER_COMMAND 
-      ? 'provider-command'
-      : 'environment';
+  if (!runtime || !provider) return;
 
   console.log(`
    ███████╗ ███████╗ ██████╗   ██████╗ 
@@ -28,9 +41,11 @@ export async function runHeadless(prompt: string) {
    ╚══════╝ ╚══════╝ ╚═╝  ╚═╝  ╚═════╝ 
 `);
 
-  console.log(`[zero] Provider: ${source}`);
-  console.log(`[zero] Model: ${providerConfig.model}`);
-  console.log(`[zero] Base URL: ${providerConfig.baseURL}`);
+  console.log(`[zero] Provider: ${runtime.profileName ? `profile: ${runtime.profileName}` : runtime.source}`);
+  console.log(`[zero] Runtime: ${runtime.provider}`);
+  console.log(`[zero] Model: ${runtime.modelId ?? runtime.requestedModel}`);
+  console.log(`[zero] API model: ${runtime.apiModel}`);
+  console.log(`[zero] Base URL: ${runtime.baseURL}`);
   console.log(`\n> ${prompt}\n`);
 
   const finalAnswer = await runAgent(prompt, provider, {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { z } from 'zod';
+import { PROVIDER_PROFILE_KINDS } from './types';
 
 /**
  * Layered configuration loader for Zero.
@@ -19,6 +20,7 @@ import { z } from 'zod';
 
 export const ProviderProfileSchema = z.object({
   name: z.string().min(1),
+  provider: z.enum(PROVIDER_PROFILE_KINDS).optional(),
   baseURL: z.string().url(),
   apiKey: z.string().optional(),
   model: z.string().min(1),

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -1,10 +1,20 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import type { ZeroConfig, ProviderProfile } from './types';
+import { ZERO_DEFAULT_MODEL_ID } from '../zero-model-registry';
+import {
+  type ProviderProfile,
+  type ZeroConfig,
+  ZeroConfigSchema,
+} from './loader';
+import {
+  parseProviderProfileKind,
+  type EffectiveProviderConfig,
+} from './types';
 
 const CONFIG_DIR = join(homedir(), '.config', 'zero');
 const CONFIG_PATH = join(CONFIG_DIR, 'config.json');
+type ConfigState = ZeroConfig & { providers: ProviderProfile[] };
 
 function ensureConfigDir() {
   if (!existsSync(CONFIG_DIR)) {
@@ -12,7 +22,14 @@ function ensureConfigDir() {
   }
 }
 
-function readConfig(): ZeroConfig {
+function normalizeConfig(config: ZeroConfig): ConfigState {
+  return {
+    ...config,
+    providers: config.providers ?? [],
+  };
+}
+
+function readConfig(): ConfigState {
   ensureConfigDir();
 
   if (!existsSync(CONFIG_PATH)) {
@@ -22,25 +39,27 @@ function readConfig(): ZeroConfig {
   try {
     const content = readFileSync(CONFIG_PATH, 'utf-8');
     const parsed = JSON.parse(content);
-    return {
-      activeProvider: parsed.activeProvider,
-      providers: parsed.providers ?? [],
-    };
-  } catch {
+    return normalizeConfig(ZeroConfigSchema.partial().parse(parsed));
+  } catch (err: any) {
+    console.warn(
+      `[zero] Ignoring invalid config at ${CONFIG_PATH}: ${err?.message ?? String(err)}`
+    );
     return { providers: [] };
   }
 }
 
-function writeConfig(config: ZeroConfig) {
+function writeConfig(config: ConfigState) {
   ensureConfigDir();
-  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf-8');
+  const tempPath = `${CONFIG_PATH}.tmp`;
+  writeFileSync(tempPath, JSON.stringify(config, null, 2), 'utf-8');
+  renameSync(tempPath, CONFIG_PATH);
 }
 
 export class ConfigManager {
-  private config: ZeroConfig;
+  private config: ConfigState;
 
-  constructor() {
-    this.config = readConfig();
+  constructor(initialConfig?: ZeroConfig) {
+    this.config = initialConfig ? normalizeConfig(initialConfig) : readConfig();
   }
 
   getActiveProvider(): ProviderProfile | undefined {
@@ -91,28 +110,36 @@ export class ConfigManager {
   }
 
   // Used by the agent loop
-  getEffectiveProviderConfig(): {
+  getEffectiveProviderConfig(env: NodeJS.ProcessEnv = process.env): {
+    provider?: EffectiveProviderConfig['provider'];
     baseURL: string;
     apiKey?: string;
     model: string;
+    source: EffectiveProviderConfig['source'];
+    profileName?: string;
   } | null {
     // Highest priority: provider command (handled elsewhere)
     // Then: active profile from config
     const active = this.getActiveProvider();
     if (active) {
       return {
+        provider: active.provider,
         baseURL: active.baseURL,
         apiKey: active.apiKey,
         model: active.model,
+        source: 'profile',
+        profileName: active.name,
       };
     }
 
     // Fallback to env vars
-    if (process.env.OPENAI_BASE_URL || process.env.OPENAI_MODEL) {
+    if (env.OPENAI_API_KEY || env.OPENAI_BASE_URL || env.OPENAI_MODEL) {
       return {
-        baseURL: process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
-        apiKey: process.env.OPENAI_API_KEY,
-        model: process.env.OPENAI_MODEL || 'gpt-4o',
+        provider: parseProviderProfileKind(env.ZERO_PROVIDER),
+        baseURL: env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
+        apiKey: env.OPENAI_API_KEY,
+        model: env.OPENAI_MODEL || ZERO_DEFAULT_MODEL_ID,
+        source: 'environment',
       };
     }
 

--- a/src/config/provider.ts
+++ b/src/config/provider.ts
@@ -1,10 +1,22 @@
 import { configManager } from './manager';
+import { execa } from 'execa';
+import { z } from 'zod';
+import { ZERO_DEFAULT_MODEL_ID } from '../zero-model-registry';
+import {
+  parseProviderProfileKind,
+  type EffectiveProviderConfig,
+} from './types';
 
-export interface ProviderConfig {
-  apiKey?: string;
-  baseURL: string;
-  model: string;
-}
+export type ProviderConfig = EffectiveProviderConfig;
+
+const ProviderCommandOutputSchema = z.object({
+  provider: z.string().optional(),
+  provider_kind: z.string().optional(),
+  api_key: z.string().optional(),
+  base_url: z.string().optional(),
+  model: z.string().optional(),
+  model_id: z.string().optional(),
+}).passthrough();
 
 /**
  * Loads the effective provider configuration.
@@ -12,18 +24,50 @@ export interface ProviderConfig {
  *   1. ZERO_PROVIDER_COMMAND (external command) - highest
  *   2. Active profile from config (set via /provider)
  *   3. OPENAI_* environment variables
+ *
+ * ZERO_PROVIDER_COMMAND must print JSON with:
+ *   { model | model_id, api_key?, base_url?, provider | provider_kind? }
  */
 export async function loadProviderConfig(): Promise<ProviderConfig> {
   // 1. Highest priority: external provider command
   const providerCommand = process.env.ZERO_PROVIDER_COMMAND;
   if (providerCommand) {
-    const { stdout } = await Bun.$`${providerCommand}`.quiet();
-    const parsed = JSON.parse(stdout.toString());
+    let stdout = '';
+    try {
+      const result = await execa(providerCommand, {
+        shell: true,
+        timeout: 5000,
+      });
+      stdout = result.stdout;
+    } catch (err: any) {
+      if (err.timedOut) {
+        throw new Error('ZERO_PROVIDER_COMMAND timed out after 5 seconds');
+      }
+      throw new Error(
+        `ZERO_PROVIDER_COMMAND failed: ${err?.shortMessage ?? err?.message ?? String(err)}`
+      );
+    }
+
+    let parsed: z.infer<typeof ProviderCommandOutputSchema>;
+    try {
+      parsed = ProviderCommandOutputSchema.parse(JSON.parse(stdout));
+    } catch (err: any) {
+      throw new Error(
+        `ZERO_PROVIDER_COMMAND returned invalid JSON: ${err?.message ?? String(err)}`
+      );
+    }
+
+    const model = parsed.model ?? parsed.model_id;
+    if (!model) {
+      throw new Error('ZERO_PROVIDER_COMMAND output must include a model or model_id field');
+    }
 
     return {
+      provider: parseProviderProfileKind(parsed.provider || parsed.provider_kind),
       apiKey: parsed.api_key,
       baseURL: parsed.base_url || 'https://api.openai.com/v1',
-      model: parsed.model,
+      model,
+      source: 'provider-command',
     };
   }
 
@@ -36,7 +80,7 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
   // 3. Fallback to raw environment variables
   const envApiKey = process.env.OPENAI_API_KEY;
   const envBaseURL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
-  const envModel = process.env.OPENAI_MODEL || 'gpt-4o';
+  const envModel = process.env.OPENAI_MODEL || ZERO_DEFAULT_MODEL_ID;
 
   // If we have no API key and no provider command, give a helpful error
   if (!envApiKey && !process.env.ZERO_PROVIDER_COMMAND) {
@@ -47,8 +91,10 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
   }
 
   return {
+    provider: parseProviderProfileKind(process.env.ZERO_PROVIDER),
     apiKey: envApiKey,
     baseURL: envBaseURL,
     model: envModel,
+    source: 'environment',
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,12 +1,35 @@
-export interface ProviderProfile {
-  name: string;
-  baseURL: string;
-  apiKey?: string;
-  model: string;
-  description?: string;
+export const PROVIDER_PROFILE_KINDS = [
+  'openai',
+  'anthropic',
+  'google',
+  'openai-compatible',
+] as const;
+
+export type ProviderProfileKind = (typeof PROVIDER_PROFILE_KINDS)[number];
+
+export function parseProviderProfileKind(
+  value: unknown
+): ProviderProfileKind | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : value;
+  if (
+    typeof normalized === 'string' &&
+    (PROVIDER_PROFILE_KINDS as readonly string[]).includes(normalized)
+  ) {
+    return normalized as ProviderProfileKind;
+  }
+  throw new Error(`Unknown Zero provider kind: ${String(value)}`);
 }
 
-export interface ZeroConfig {
-  activeProvider?: string;
-  providers: ProviderProfile[];
+export type ProviderConfigSource = 'profile' | 'provider-command' | 'environment';
+
+export interface EffectiveProviderConfig {
+  provider?: ProviderProfileKind;
+  apiKey?: string;
+  baseURL: string;
+  model: string;
+  source: ProviderConfigSource;
+  profileName?: string;
 }
+
+export type { ProviderProfile, ZeroConfig } from './loader';

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ providersCmd
       const isActive = p.name === active ? ' (active)' : '';
       console.log(`  ${p.name}${isActive}`);
       console.log(`    Model:   ${p.model}`);
+      if (p.provider) console.log(`    Provider: ${p.provider}`);
       console.log(`    BaseURL: ${p.baseURL}`);
       if (p.description) console.log(`    Desc:    ${p.description}`);
       console.log('');
@@ -67,6 +68,7 @@ providersCmd
     const active = configManager.getActiveProvider();
     if (active) {
       console.log(`Active provider: ${active.name}`);
+      if (active.provider) console.log(`Provider: ${active.provider}`);
       console.log(`Model: ${active.model}`);
       console.log(`Base URL: ${active.baseURL}`);
     } else {

--- a/src/zero-provider-runtime/index.ts
+++ b/src/zero-provider-runtime/index.ts
@@ -1,0 +1,12 @@
+export {
+  createZeroProvider,
+  createZeroProviderFromInput,
+  resolveZeroProviderRuntime,
+} from './resolver';
+
+export type {
+  ZeroProviderRuntimeInput,
+  ZeroProviderRuntimeKind,
+  ZeroProviderRuntimeSource,
+  ZeroResolvedProviderRuntime,
+} from './types';

--- a/src/zero-provider-runtime/resolver.ts
+++ b/src/zero-provider-runtime/resolver.ts
@@ -1,0 +1,186 @@
+import { OpenAIProvider } from '../providers/openai';
+import type { Provider } from '../providers/types';
+import {
+  getZeroModel,
+  assertZeroModelProvider,
+} from '../zero-model-registry';
+import type { ZeroModelProvider } from '../zero-model-registry';
+import type {
+  ZeroProviderRuntimeInput,
+  ZeroProviderRuntimeKind,
+  ZeroProviderRuntimeSource,
+  ZeroResolvedProviderRuntime,
+} from './types';
+
+const DEFAULT_BASE_URL = {
+  openai: 'https://api.openai.com/v1',
+  anthropic: 'https://api.anthropic.com',
+  google: 'https://generativelanguage.googleapis.com',
+} as const satisfies Record<ZeroModelProvider, string>;
+
+const OFFICIAL_OPENAI_BASE_URLS = new Set([
+  DEFAULT_BASE_URL.openai,
+  'https://api.openai.com',
+]);
+
+export function resolveZeroProviderRuntime(
+  input: ZeroProviderRuntimeInput
+): ZeroResolvedProviderRuntime {
+  const requestedModel = normalizeRequired(input.model, 'model');
+  const explicitProvider = input.provider;
+  const source = input.source ?? 'explicit';
+  const baseURL = normalizeOptionalUrl(input.baseURL);
+  const registryModel = getZeroModel(requestedModel);
+
+  if (registryModel) {
+    if (
+      explicitProvider &&
+      explicitProvider !== 'openai-compatible' &&
+      explicitProvider !== registryModel.provider
+    ) {
+      assertZeroModelProvider(registryModel.id, explicitProvider);
+    }
+
+    const provider = resolveKnownModelProvider(
+      registryModel.provider,
+      explicitProvider,
+      baseURL
+    );
+
+    return {
+      provider,
+      source,
+      profileName: input.profileName,
+      requestedModel,
+      apiModel: registryModel.apiModel,
+      baseURL: resolveRuntimeBaseURL(provider, baseURL),
+      apiKey: input.apiKey,
+      model: registryModel,
+      modelId: registryModel.id,
+      capabilities: registryModel.capabilities,
+    };
+  }
+
+  const provider = resolveUnknownModelProvider(explicitProvider, baseURL, source);
+  return {
+    provider,
+    source,
+    profileName: input.profileName,
+    requestedModel,
+    apiModel: requestedModel,
+    baseURL: resolveRuntimeBaseURL(provider, baseURL),
+    apiKey: input.apiKey,
+    capabilities: ['chat', 'streaming', 'system-prompt'],
+  };
+}
+
+export function createZeroProvider(
+  runtime: ZeroResolvedProviderRuntime
+): Provider {
+  if (runtime.provider === 'openai' || runtime.provider === 'openai-compatible') {
+    if (runtime.provider === 'openai' && !runtime.apiKey) {
+      throw new Error('Zero openai provider requires an API key');
+    }
+
+    return new OpenAIProvider({
+      apiKey: runtime.apiKey || 'zero-openai-compatible',
+      baseURL: runtime.baseURL,
+      model: runtime.apiModel,
+    });
+  }
+
+  throw new Error(
+    `Zero ${runtime.provider} provider adapter is not implemented yet. ` +
+    `The provider resolver can identify the model, but the streaming adapter lands in a later M1 slice.`
+  );
+}
+
+export function createZeroProviderFromInput(
+  input: ZeroProviderRuntimeInput
+): {
+  runtime: ZeroResolvedProviderRuntime;
+  provider: Provider;
+} {
+  const runtime = resolveZeroProviderRuntime(input);
+  return {
+    runtime,
+    provider: createZeroProvider(runtime),
+  };
+}
+
+function resolveKnownModelProvider(
+  modelProvider: ZeroModelProvider,
+  explicitProvider: ZeroProviderRuntimeKind | undefined,
+  baseURL: string | undefined
+): ZeroProviderRuntimeKind {
+  if (explicitProvider === 'openai-compatible') return 'openai-compatible';
+  if (modelProvider === 'openai' && baseURL && !OFFICIAL_OPENAI_BASE_URLS.has(baseURL)) {
+    return 'openai-compatible';
+  }
+  return modelProvider;
+}
+
+function resolveUnknownModelProvider(
+  explicitProvider: ZeroProviderRuntimeKind | undefined,
+  baseURL: string | undefined,
+  source: ZeroProviderRuntimeSource
+): ZeroProviderRuntimeKind {
+  if (explicitProvider === 'openai-compatible') {
+    ensureOpenAICompatibleGatewayBaseURL(baseURL);
+    return 'openai-compatible';
+  }
+  if (explicitProvider) {
+    throw new Error(
+      `Unknown Zero model for official ${explicitProvider} provider runtime. ` +
+      `Official providers require a model from the Zero model registry. ` +
+      `Use provider: "openai-compatible" with a non-official baseURL for custom gateways.`
+    );
+  }
+  if (baseURL && !OFFICIAL_OPENAI_BASE_URLS.has(baseURL)) return 'openai-compatible';
+
+  throw new Error(
+    `Unknown Zero model for ${source} provider runtime. ` +
+    `Use a model from the Zero model registry or set provider: "openai-compatible" for custom OpenAI-compatible gateways. ` +
+    `Valid providers: openai, anthropic, google, openai-compatible.`
+  );
+}
+
+function resolveRuntimeBaseURL(
+  provider: ZeroProviderRuntimeKind,
+  baseURL: string | undefined
+): string {
+  if (provider === 'openai-compatible') {
+    ensureOpenAICompatibleGatewayBaseURL(baseURL);
+    return baseURL;
+  }
+  if (provider === 'openai' && (!baseURL || OFFICIAL_OPENAI_BASE_URLS.has(baseURL))) {
+    return DEFAULT_BASE_URL.openai;
+  }
+  return baseURL ?? DEFAULT_BASE_URL[provider];
+}
+
+function ensureOpenAICompatibleGatewayBaseURL(baseURL: string | undefined): asserts baseURL is string {
+  if (!baseURL || OFFICIAL_OPENAI_BASE_URLS.has(baseURL)) {
+    throw new Error(
+      'Zero openai-compatible provider requires an explicit non-official baseURL. ' +
+      'Use provider: "openai" for the official OpenAI API.'
+    );
+  }
+}
+
+function normalizeRequired(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`Missing Zero provider ${label}`);
+  return normalized;
+}
+
+function normalizeOptionalUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().replace(/\/+$/, '');
+  try {
+    new URL(normalized);
+  } catch {
+    throw new Error(`Invalid Zero provider baseURL: ${value}`);
+  }
+  return normalized;
+}

--- a/src/zero-provider-runtime/types.ts
+++ b/src/zero-provider-runtime/types.ts
@@ -1,0 +1,36 @@
+import type {
+  ZeroModelCapability,
+  ZeroModelDefinition,
+  ZeroModelProvider,
+} from '../zero-model-registry';
+
+export type ZeroProviderRuntimeKind = ZeroModelProvider | 'openai-compatible';
+
+export type ZeroProviderRuntimeSource =
+  | 'profile'
+  | 'provider-command'
+  | 'environment'
+  | 'explicit';
+
+export interface ZeroProviderRuntimeInput {
+  provider?: ZeroProviderRuntimeKind;
+  apiKey?: string;
+  baseURL?: string;
+  /** User-supplied model string. `modelId` on the resolved runtime is registry-canonical when known. */
+  model: string;
+  profileName?: string;
+  source?: ZeroProviderRuntimeSource;
+}
+
+export interface ZeroResolvedProviderRuntime {
+  provider: ZeroProviderRuntimeKind;
+  source: ZeroProviderRuntimeSource;
+  profileName?: string;
+  requestedModel: string;
+  apiModel: string;
+  baseURL: string;
+  apiKey?: string;
+  model?: ZeroModelDefinition;
+  modelId?: string;
+  capabilities: readonly ZeroModelCapability[];
+}

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -3,6 +3,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { loadConfig, loadConfigWithLayers, mergeLayers, ZeroConfigSchema } from '../src/config/loader';
+import { parseProviderProfileKind } from '../src/config/types';
+import { ConfigManager } from '../src/config/manager';
+import { ZERO_DEFAULT_MODEL_ID } from '../src/zero-model-registry';
 
 function freshTmp(): string {
   return mkdtempSync(join(tmpdir(), 'zero-cfg-'));
@@ -24,6 +27,19 @@ describe('mergeLayers', () => {
       { providers: [] },
     );
     expect(merged.providers).toHaveLength(1);
+  });
+
+  it('merges partial provider overrides by provider name', () => {
+    const merged = mergeLayers(
+      { providers: [{ name: 'p1', baseURL: 'https://x.test', model: 'old' }] },
+      { providers: [{ name: 'p1', model: 'new' } as any] },
+    );
+
+    expect(merged.providers?.[0]).toEqual({
+      name: 'p1',
+      baseURL: 'https://x.test',
+      model: 'new',
+    });
   });
 });
 
@@ -137,9 +153,68 @@ describe('ZeroConfigSchema', () => {
 
   it('accepts a minimal valid config', () => {
     const result = ZeroConfigSchema.safeParse({
-      providers: [{ name: 'p', baseURL: 'https://api.example.com', model: 'm' }],
+      providers: [{
+        name: 'p',
+        provider: 'openai-compatible',
+        baseURL: 'https://api.example.com',
+        model: 'm',
+      }],
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown provider kinds', () => {
+    const result = ZeroConfigSchema.safeParse({
+      providers: [{
+        name: 'p',
+        provider: 'made-up',
+        baseURL: 'https://api.example.com',
+        model: 'm',
+      }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses provider kinds defensively for env and provider commands', () => {
+    expect(parseProviderProfileKind('google')).toBe('google');
+    expect(parseProviderProfileKind('OpenAI')).toBe('openai');
+    expect(parseProviderProfileKind('GOOGLE')).toBe('google');
+    expect(parseProviderProfileKind(undefined)).toBeUndefined();
+    expect(() => parseProviderProfileKind('made-up')).toThrow(
+      'Unknown Zero provider kind'
+    );
+  });
+});
+
+describe('ConfigManager', () => {
+  it('uses OPENAI_API_KEY-only env config with the registry default model', () => {
+    const manager = new ConfigManager({ providers: [] });
+    const provider = manager.getEffectiveProviderConfig({
+      OPENAI_API_KEY: 'sk-test',
+    });
+
+    expect(provider).toEqual({
+      provider: undefined,
+      baseURL: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      model: ZERO_DEFAULT_MODEL_ID,
+      source: 'environment',
+    });
+  });
+
+  it('returns active profile config with source metadata', () => {
+    const manager = new ConfigManager({
+      activeProvider: 'local',
+      providers: [{
+        name: 'local',
+        provider: 'openai-compatible',
+        baseURL: 'http://localhost:11434/v1',
+        model: 'local-coder',
+      }],
+    });
+
+    expect(manager.getEffectiveProviderConfig({})?.source).toBe('profile');
+    expect(manager.getEffectiveProviderConfig({})?.profileName).toBe('local');
   });
 });
 

--- a/tests/zero-provider-runtime.test.ts
+++ b/tests/zero-provider-runtime.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  createZeroProvider,
+  resolveZeroProviderRuntime,
+} from '../src/zero-provider-runtime';
+
+describe('resolveZeroProviderRuntime', () => {
+  it('resolves a registry model to its provider and API model', () => {
+    const runtime = resolveZeroProviderRuntime({
+      model: 'openai:gpt-4.1',
+      apiKey: 'test-key',
+      source: 'environment',
+    });
+
+    expect(runtime.provider).toBe('openai');
+    expect(runtime.modelId).toBe('gpt-4.1');
+    expect(runtime.apiModel).toBe('gpt-4.1');
+    expect(runtime.baseURL).toBe('https://api.openai.com/v1');
+    expect(runtime.capabilities).toContain('tool-calling');
+  });
+
+  it('resolves profile provider metadata and keeps profile source', () => {
+    const runtime = resolveZeroProviderRuntime({
+      provider: 'anthropic',
+      model: 'sonnet-4.5',
+      profileName: 'work-claude',
+      source: 'profile',
+      baseURL: 'https://api.anthropic.com/',
+    });
+
+    expect(runtime.provider).toBe('anthropic');
+    expect(runtime.profileName).toBe('work-claude');
+    expect(runtime.modelId).toBe('claude-sonnet-4.5');
+    expect(runtime.apiModel).toBe('claude-sonnet-4-5-20250929');
+    expect(runtime.baseURL).toBe('https://api.anthropic.com');
+  });
+
+  it('rejects explicit provider mismatches for known models', () => {
+    expect(() =>
+      resolveZeroProviderRuntime({
+        provider: 'google',
+        model: 'gpt-4.1',
+      })
+    ).toThrow('belongs to openai');
+  });
+
+  it('allows custom OpenAI-compatible gateways to use registry models', () => {
+    const runtime = resolveZeroProviderRuntime({
+      provider: 'openai-compatible',
+      model: 'gpt-4o',
+      baseURL: 'http://localhost:11434/v1',
+    });
+
+    expect(runtime.provider).toBe('openai-compatible');
+    expect(runtime.apiModel).toBe('gpt-4o');
+    expect(runtime.baseURL).toBe('http://localhost:11434/v1');
+  });
+
+  it('normalizes official OpenAI shorthand URLs to the /v1 endpoint', () => {
+    const runtime = resolveZeroProviderRuntime({
+      model: 'gpt-4.1',
+      baseURL: 'https://api.openai.com',
+    });
+
+    expect(runtime.provider).toBe('openai');
+    expect(runtime.baseURL).toBe('https://api.openai.com/v1');
+  });
+
+  it('rejects OpenAI-compatible configs without a custom gateway base URL', () => {
+    expect(() =>
+      resolveZeroProviderRuntime({
+        provider: 'openai-compatible',
+        model: 'local-coder',
+      })
+    ).toThrow('requires an explicit non-official baseURL');
+
+    expect(() =>
+      resolveZeroProviderRuntime({
+        provider: 'openai-compatible',
+        model: 'local-coder',
+        baseURL: 'https://api.openai.com/v1',
+      })
+    ).toThrow('requires an explicit non-official baseURL');
+  });
+
+  it('allows unknown models only for OpenAI-compatible gateways', () => {
+    const runtime = resolveZeroProviderRuntime({
+      provider: 'openai-compatible',
+      model: 'local-coder:latest',
+      baseURL: 'http://localhost:11434/v1',
+    });
+
+    expect(runtime.provider).toBe('openai-compatible');
+    expect(runtime.modelId).toBeUndefined();
+    expect(runtime.apiModel).toBe('local-coder:latest');
+  });
+
+  it('rejects unknown models for official provider runtimes', () => {
+    expect(() =>
+      resolveZeroProviderRuntime({
+        provider: 'google',
+        model: 'not-in-registry',
+      })
+    ).toThrow('Official providers require a model from the Zero model registry');
+  });
+
+  it('rejects unknown models without an OpenAI-compatible provider hint', () => {
+    expect(() =>
+      resolveZeroProviderRuntime({
+        model: 'not-in-registry',
+        baseURL: 'https://api.openai.com/v1',
+      })
+    ).toThrow('Unknown Zero model');
+  });
+
+  it('creates implemented OpenAI-compatible providers and rejects pending adapters', () => {
+    const openAI = resolveZeroProviderRuntime({
+      provider: 'openai-compatible',
+      model: 'local-coder',
+      baseURL: 'http://localhost:11434/v1',
+    });
+    expect(createZeroProvider(openAI)).toBeDefined();
+
+    const anthropic = resolveZeroProviderRuntime({
+      model: 'sonnet-4.5',
+    });
+    expect(() => createZeroProvider(anthropic)).toThrow(
+      'anthropic provider adapter is not implemented yet'
+    );
+  });
+
+  it('creates OpenAI-compatible providers without an API key for custom gateways', () => {
+    const runtime = resolveZeroProviderRuntime({
+      provider: 'openai-compatible',
+      model: 'local-coder',
+      baseURL: 'http://localhost:11434/v1',
+    });
+
+    expect(createZeroProvider(runtime)).toBeDefined();
+  });
+
+  it('requires an API key for the official OpenAI runtime', () => {
+    const officialOpenAI = resolveZeroProviderRuntime({
+      model: 'gpt-4.1',
+    });
+
+    expect(() => createZeroProvider(officialOpenAI)).toThrow(
+      'openai provider requires an API key'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds the next Gnanam-owned M1 runtime slice after the merged model registry: a Zero provider runtime resolver.

This PR gives Zero a backend contract that resolves `model + profile + provider + baseURL` into a normalized provider runtime plan. It wires headless execution through that resolver while preserving the currently implemented OpenAI-compatible streaming path.

The slice intentionally does not implement Anthropic or Gemini streaming adapters yet. Those are the next Gnanam PRD slices. This resolver identifies those providers and returns clear adapter-not-implemented errors until their concrete provider modules land.

## What Changed

- Added `src/zero-provider-runtime/`.
- Added `resolveZeroProviderRuntime` to:
  - resolve model IDs and aliases through `zero-model-registry`
  - map registry models to provider/runtime metadata
  - preserve the requested model and expose the provider API model
  - normalize official OpenAI base URLs to `/v1`
  - distinguish official `openai` from dispatch-safe `openai-compatible` gateways
  - require explicit non-official base URLs for OpenAI-compatible custom gateways
  - allow custom OpenAI-compatible model strings only for OpenAI-compatible gateways
  - reject unknown models for official OpenAI/Anthropic/Gemini providers
  - reject unknown models when no OpenAI-compatible provider hint exists
  - reject mismatched provider/model pairs, such as Google provider with an OpenAI model
- Added `createZeroProvider` / `createZeroProviderFromInput`.
- Wired headless execution through the Zero provider runtime resolver with friendly pending-adapter errors.
- Added `provider` metadata to saved provider profiles:
  - `openai`
  - `anthropic`
  - `google`
  - `openai-compatible`
- Unified `ZeroConfig` typing on the loader schema while keeping provider-kind parsing in `config/types.ts`.
- Added source metadata to provider config resolution so the CLI does not re-derive profile/env/provider-command source.
- Hardened provider command parsing with timeout, JSON validation, model/model_id validation, and documented output shape.
- Updated provider list/current output to show provider kind when configured.
- Added tests for runtime resolution, custom gateways, provider mismatches, pending adapters, OpenAI API key requirements, env fallback, source metadata, and provider-kind config validation.

## PRD Alignment

This implements the second Gnanam M1 dependency from `Zero-WorkSplit-PRD-v2-balanced`:

- `Provider factory that resolves model/profile/provider`

It depends on the merged Zero model registry (#9) and prepares the contract for later M1 slices:

- Anthropic provider with streaming text, tool calls, system prompt, usage.
- Gemini provider with streaming text, tool calls, usage, vision-ready input shape.
- Normalized provider event schema and usage type.

## Validation

Local checks run successfully after rebasing on latest `origin/main` (`1d1eac2`, PR #10 merged):

- `npx --yes bun run typecheck`
  - pass
- `npx --yes bun test ./tests --timeout 15000`
  - `83 pass`
  - `0 fail`
- `npx --yes bun run build`
  - pass
- `npx --yes bun run smoke:build`
  - pass
- `./zero --help`
  - pass
- `./zero providers current`
  - pass
- `git diff --check origin/main..HEAD`
  - pass

## Review Notes

- PR #10 is now merged into `main`; this branch is rebased on that baseline and uses its build/typecheck/smoke scripts.
- Open PR #11 is Vasanth foundation tooling and remains separate; this PR does not touch tools/TUI ownership areas beyond routing headless provider construction.
- Existing untracked `.hermes/` monitor files were left untouched and are not included.
- This PR deliberately avoids naming the module `factory`; the Zero-aligned module name is `zero-provider-runtime`.
