### PR TITLE
docs: add final Zero PRD and work split

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,594 @@
+# Zero — Product Requirements Document (v1.0)
+
+**Status:** DRAFT v1.0
+**Target:** Compete with Claude Code + Cursor + OpenCode
+**Timeline:** 6-12 months
+**Stack:** TypeScript + Bun
+
+---
+
+## 1. Vision
+
+**Zero is a terminal-first, editor-aware, multi-provider AI coding platform.**
+
+It combines the best of:
+- **Claude Code** — terminal-native agentic coding
+- **Cursor** — IDE integration + smart editing
+- **OpenCode** — multi-provider + headless
+
+**One TypeScript codebase. Three surfaces. Zero lock-in.**
+
+---
+
+## 2. Core Surfaces
+
+### 2.1 Terminal (TUI) — Primary
+- Interactive coding agent in terminal
+- Streaming, append-style (like Claude Code)
+- Ink + React-based
+- Full keyboard control
+- Mouse support
+
+### 2.2 Editor (VS Code Extension)
+- Same agent core, different UI
+- Inline suggestions + chat panel
+- File editing with diff view
+- Diagnostics integration
+- LSP-aware
+
+### 2.3 Headless (CLI/CI)
+- `zero exec "prompt"` for scripts
+- `zero serve` for daemon mode
+- JSON-RPC over stdio/WebSocket
+- MCP server support
+
+---
+
+## 3. Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│              ZERO PLATFORM                        │
+├─────────────────────────────────────────────────┤
+│                                                  │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐     │
+│  │   TUI    │  │   VSCode │  │ Headless │     │
+│  │ Surface  │  │ Surface  │  │ Surface  │     │
+│  └────┬─────┘  └────┬─────┘  └────┬─────┘     │
+│       │             │             │            │
+│       └─────────────┼─────────────┘            │
+│                     │                          │
+│              ┌──────▼──────┐                   │
+│              │  Agent Core │                   │
+│              │  (ReAct)    │                   │
+│              └──────┬──────┘                   │
+│                     │                          │
+│  ┌──────┬──────┬────┴────┬──────┬──────┐      │
+│  │Tools │Perms │Sessions │Provi │Memory│      │
+│  └──────┴──────┴─────────┴──────┴──────┘      │
+│                                                  │
+└─────────────────────────────────────────────────┘
+```
+
+**Layering Rules:**
+- Agent Core never imports a surface
+- Surfaces are thin shells (I/O + rendering)
+- All state persists to local files
+- No cloud dependency
+
+---
+
+## 4. Functional Requirements (24 Features)
+
+### F1 — Agent Core (P0)
+- ReAct loop: think → tool → result → think
+- Stream text + tool calls + thinking
+- Parallel tool execution where safe
+- Bound turns (max 100)
+- Clean interrupt (Esc/Ctrl-C)
+- Event stream: `text | tool_call | tool_result | thinking | usage | plan_update | error | turn_end`
+
+### F2 — Tools (P0)
+
+**Core (8):**
+- `read_file` — read with line ranges, images
+- `write_file` — create/overwrite
+- `edit_file` — exact-string edit (uniqueness guard)
+- `bash` — run shell command
+- `grep` — ripgrep content search
+- `glob` — file pattern matching
+- `apply_patch` — multi-hunk patches
+- `update_plan` — todo list
+
+**Advanced (4):**
+- `web_fetch` / `web_search` — web access
+- `task` — spawn subagent
+- `structured_output` — JSON-Schema validated
+- `notebook_edit` — Jupyter notebooks
+
+**Tool Requirements:**
+- Zod schema → JSON Schema
+- Side-effect class: `read | write | shell | network | out_of_workspace`
+- Structured results: `{ status, output, truncated?, meta? }`
+- Atomic execution
+- Permission gating
+
+### F3 — Providers & Model Registry (P0)
+- OpenAI-compatible (works with OpenAI, OpenRouter, Ollama, etc.)
+- Anthropic (Claude)
+- Google Gemini
+- Azure OpenAI
+- AWS Bedrock
+- xAI (Grok)
+
+**Model Registry:**
+
+```ts
+interface ModelEntry {
+  id: string
+  name: string
+  provider: "anthropic" | "openai" | "google" | "xai" | string
+  apiProviders: string[]          // endpoints that can serve
+  contextLimits: { input: number; output: number }
+  reasoningEffort: { supported: string[]; default: string }
+  capabilities: { tools, thinking, vision, pdf }
+  cost: { inputPerMTok, outputPerMTok, tokenMultiplier }
+  tier: "standard" | "premium"
+  matchPatterns?: RegExp[]        // fuzzy id resolution
+}
+```
+
+- Per-task model selection (`-m`)
+- Provider rotation/failover
+- Cost tracking
+- "Spec model" for planning
+- Fallback model on failure
+
+### F4 — Terminal UI (P0)
+- **Layout:** header (cwd · git · model) → tool rows → diff → response → input → footer
+- **Streaming:** Ink `<Static>` for transcript, live tail for streaming
+- **Markdown:** full CommonMark + syntax highlighting
+- **Tool rows:** collapsible with one-line summaries
+- **Input:** `/` commands, `@` files, `!` bash, `Esc` interrupt
+- **Robustness:** resize, wide-char, ANSI, non-TTY fallback
+- **Splash:** ZERO wordmark
+- **Themes:** light/dark + custom
+
+### F5 — Sessions (P0)
+- Persist to `~/.local/share/zero/sessions/<id>/`
+- `meta.json` + `events.jsonl` + `messages.jsonl` + `checkpoints/`
+- `--resume [id]` (default: latest)
+- `--fork <id>` (copy with lineage)
+- Search: `zero search <query>` over messages/tools/results
+- Atomic writes (write-temp-then-rename)
+- Schema versioning
+- Export to Markdown/JSON
+
+### F6 — Configuration (P0)
+- Layered: defaults → user → project → env → CLI
+- `~/.config/zero/config.json` (user)
+- `./.zero/config.json` (project)
+- Runtime overlay (`--settings <path>`)
+- Feature flags for staged rollout
+- Validation on load
+
+### F7 — MCP (Model Context Protocol) (P0)
+- Connect to stdio/HTTP/SSE servers
+- Surface MCP tools into registry
+- `zero mcp add/remove/list`
+- Per-server and per-tool permissions
+- Persistent grants with revoke/clear
+- MCP server mode (zero as MCP server)
+
+### F8 — Headless / Programmatic (P0)
+- `zero exec [prompt]` — one-shot
+- `zero serve` — daemon mode
+- `--input-format stream-json` — line-delimited events
+- `--input-format stream-jsonrpc` — JSON-RPC protocol
+- `-o text|json` output formats
+- Exit codes: `0=success, 1=crash, 2=usage, 3=provider, 4=tool, 5=permission, 6=budget`
+
+### F9 — Permissions & Autonomy (P0)
+- **Side-effect classes:** read, write, shell, network, out_of_workspace
+- **Autonomy levels:** low (ask), medium (smart), high (auto)
+- `--skip-permissions-unsafe` (loud warning)
+- TUI: inline prompts (allow/deny/always)
+- Headless: default-deny unless granted
+- Persistent grants with list/revoke/clear
+- Audit log in `events.jsonl`
+
+**Permission Matrix:**
+
+| Tool Class | low | medium | high |
+|------------|-----|--------|------|
+| Read | allow | allow | allow |
+| Workspace write | prompt | allow | allow |
+| Shell | prompt | prompt | allow |
+| Network | prompt | allow | allow |
+| Out-of-workspace | deny | prompt | prompt |
+
+### F10 — Observability (P0)
+- Structured logging (stdout/stderr split)
+- Secret redaction (API keys, tokens, passwords)
+- No vendor telemetry (local only)
+- `zero doctor` — health check command
+- Crash reports (opt-in, local)
+- Performance metrics (TTFT, tokens/sec)
+
+### F11 — Subagents (P1)
+- `task` tool spawns scoped subagent
+- Built-in agents: code-review, security-review, refactor, test-gen
+- Recursion depth limit
+- Parent session linkage
+- Shared/isolated budgets
+
+### F12 — Plugins (P1)
+- User/project-scoped plugins
+- Commands, tools, prompts, hooks
+- Plugin manifest: `plugin.json`
+- `zero plugin install <path|url>`
+- No marketplace in v1 (manual install)
+
+### F13 — Distribution (P0)
+- **Single binary** via `bun build --compile`
+- Cross-platform: Linux, macOS, Windows
+- `zero update [--check]` self-update
+- Checksum verification
+- Rollback on failure
+
+### F14 — VS Code Extension (P1)
+- Same agent core via stream protocol
+- Inline chat panel
+- Diff view in editor
+- Diagnostics integration
+- LSP awareness
+- File watching
+
+### F15 — Memory & Context (P1)
+- `AGENTS.md` hierarchical memory
+- `@import` for modular rules
+- Auto-generated from `init` command
+- Project conventions learning
+- Skills system (reusable instruction packs)
+- Context budgeting (token tracking)
+- Auto-compaction when full
+
+### F16 — Hooks System (P1)
+- Lifecycle hooks: `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd`
+- User-defined shell commands
+- JSON output for conditional flow
+- `.zero/hooks/` directory
+
+### F17 — Slash Commands (P0)
+
+**Built-in (20):**
+- Session: `/clear`, `/compact`, `/context`, `/rewind`, `/resume`, `/exit`
+- Model: `/model`, `/effort`, `/style`, `/permissions`
+- Project: `/init`, `/memory`, `/skills`
+- Extensibility: `/mcp`, `/hooks`, `/agents`
+- Meta: `/help`, `/config`, `/doctor`, `/feedback`
+
+**Custom:** `./.zero/commands/*.md`
+
+### F18 — Git Integration (P1)
+- Worktree isolation per task
+- Auto-commit with messages
+- Branch management
+- PR creation
+- Diff review
+- Conflict resolution
+
+### F19 — Testing & Verification (P1)
+- `run_tests` tool
+- Self-verification loop
+- Test runner integration
+- Coverage reporting
+- Diagnostics (typecheck, lint)
+- LSP integration
+
+### F20 — Web Access (P1)
+- `web_fetch` — fetch URL content
+- `web_search` — search engine
+- Provider/permission gated
+- Rate limiting
+- Caching
+
+### F21 — Sandbox (P2)
+- Linux: bubblewrap
+- macOS: sandbox-exec
+- Windows: AppContainer
+- Filesystem policies
+- Network policies
+- Unix socket controls
+
+### F22 — Multi-modal (P2)
+- Image input (screenshots, diagrams)
+- PDF parsing
+- Voice input (optional)
+- File attachments
+- Paste support
+
+### F23 — Telemetry (P2)
+- Local-only metrics
+- Token usage tracking
+- Cost reports
+- Performance profiling
+- Crash reports (opt-in)
+- NO vendor telemetry
+
+### F24 — Advanced Features (P2)
+- Code review automation
+- Auto-refactor
+- Dependency updates
+- Security scanning
+- Documentation generation
+
+---
+
+## 5. Data Models
+
+### 5.1 Headless Event Stream
+
+```json
+{ "type": "run_start", "runId": "r1", "sessionId": "s1", "cwd": "/repo", "model": "..." }
+{ "type": "text", "delta": "..." }
+{ "type": "tool_call", "id": "t1", "name": "bash", "args": {...}, "sideEffect": "shell" }
+{ "type": "permission", "id": "t1", "decision": "needs_approval", "reason": "shell" }
+{ "type": "tool_result", "id": "t1", "status": "ok", "output": "...", "truncated": false }
+{ "type": "usage", "promptTokens": 1234, "completionTokens": 567, "costUsd": 0.012 }
+{ "type": "plan_update", "plan": [{ "id": "1", "content": "...", "status": "in_progress" }] }
+{ "type": "turn_end", "stopReason": "end_turn" }
+{ "type": "error", "code": "rate_limit", "message": "...", "recoverable": true }
+{ "type": "run_end", "status": "success", "exitCode": 0 }
+```
+
+### 5.2 Session On Disk
+
+```
+~/.local/share/zero/sessions/<id>/
+  meta.json        # { schemaVersion, id, parentId?, title, cwd, model, createdAt, updatedAt, tokens, cost }
+  events.jsonl     # append-only AgentEvent stream
+  messages.jsonl   # provider-facing messages
+  checkpoints/     # snapshots for restore/fork/compact
+```
+
+### 5.3 Tool Contract
+
+```ts
+interface Tool {
+  name: string
+  description: string
+  parameters: ZodObject
+  sideEffect: "read" | "write" | "shell" | "network" | "out_of_workspace"
+  execute(args, ctx): Promise<{ status: "ok"|"error", output: string, truncated?: boolean, meta?: object }>
+}
+```
+
+### 5.4 Config Schema
+
+```json
+{
+  "model": "claude-sonnet-4-6",
+  "providers": {
+    "anthropic": { "apiKey": "env:AN..._KEY" },
+    "openai": { "apiKey": "env:OP..._KEY" }
+  },
+  "permissions": {
+    "autonomy": "medium",
+    "grants": [{ "tool": "bash", "pattern": "git status", "decision": "allow" }]
+  },
+  "ui": { "theme": "dark", "syntaxHighlighting": true }
+}
+```
+
+---
+
+## 6. Non-Functional Requirements
+
+### Performance
+- TTFT < 500ms after provider's first byte
+- No full-transcript repaint per token
+- Cold start < 300ms (warm cache)
+- Tool execution < 100ms overhead
+- Session resume < 1s
+
+### Reliability
+- Crash-free TUI under resize, wide-char, non-TTY
+- Clean interrupt (no half-written state)
+- Atomic session writes
+- Recovery from malformed JSONL
+- Provider failover
+
+### Security
+- No mutation without permission decision (hard invariant)
+- API keys never logged
+- Secret redaction everywhere
+- Headless stdout free of logs
+- Workspace boundary by default
+- Sandboxing for untrusted code
+
+### Portability
+- Linux, macOS, Windows
+- Any OpenAI-compatible endpoint
+- x86_64, ARM64
+- Single binary distribution
+
+### Testability
+- Mock provider for unit tests
+- Fake MCP server/client
+- Fake terminal/PTY
+- Sandbox simulator
+- Deterministic event replay
+
+---
+
+## 7. Milestones
+
+### M0 — Foundation (Weeks 1-2)
+- Bun + TypeScript setup
+- Agent core skeleton
+- 8 core tools (read, write, edit, bash, grep, glob, apply_patch, update_plan)
+- OpenAI-compatible provider
+- Basic Ink TUI
+- Permission gate (read vs mutate)
+- Session persistence
+
+**Exit:** `zero` runs, can read/edit files, basic chat works.
+
+### M1 — Multi-Provider (Weeks 3-4)
+- Anthropic provider
+- Gemini provider
+- Model registry
+- Per-task model selection
+- Provider rotation
+- Cost tracking
+- Headless `exec` mode
+
+**Exit:** Switch between Claude/GPT/Gemini, see cost, run headless.
+
+### M2 — Polish (Weeks 5-8)
+- Advanced TUI features
+- Full markdown + syntax highlighting
+- Tool result truncation/pagination
+- Auto-compaction
+- Context budgeting
+- 20 slash commands
+- Doctor command
+- Search command
+
+**Exit:** Production-ready TUI, smooth streaming, all commands work.
+
+### M3 — Distribution (Weeks 9-10)
+- Single binary build
+- Self-update
+- Cross-platform CI
+- VS Code extension MVP
+- Documentation site
+
+**Exit:** `zero` ships as one binary, works on Win/Mac/Linux.
+
+### M4 — Extensibility (Weeks 11-14)
+- MCP client + permissions
+- Hooks system
+- Skills system
+- Memory (AGENTS.md)
+- Plugin loading
+- Subagents (built-in: review, security)
+
+**Exit:** Plugins work, MCP servers connect, memory persists.
+
+### M5 — Advanced (Weeks 15-20)
+- Web fetch/search
+- Git worktrees
+- Self-verification
+- Diagnostics (LSP, typecheck)
+- Testing integration
+- Code review automation
+
+**Exit:** Zero can review code, run tests, manage git.
+
+### M6 — Sandbox & Security (Weeks 21-24)
+- Linux sandbox (bubblewrap)
+- macOS sandbox
+- Windows AppContainer
+- Network policies
+- Filesystem policies
+
+**Exit:** Untrusted code runs safely in sandbox.
+
+### Beyond v1.0
+- Multi-modal (images, PDFs)
+- Voice input
+- Cloud sync (optional)
+- Team features
+- Marketplace (if demand)
+
+---
+
+## 8. Risks & Mitigations
+
+| # | Risk | Mitigation |
+|---|------|------------|
+| R1 | Scope creep | Stick to milestones, defer features |
+| R2 | Provider API changes | Abstract via interface, test with mocks |
+| R3 | TUI complexity | Use Ink, copy Claude Code patterns |
+| R4 | Performance | Benchmark early, optimize streaming |
+| R5 | Security vulnerabilities | Permission gate from day 1, security review |
+| R6 | Cross-platform bugs | CI on Win/Mac/Linux from M0 |
+| R7 | Breaking changes | Schema versioning, migration tools |
+
+---
+
+## 9. Success Metrics
+
+### v1.0 (6 months)
+- 5+ providers supported
+- 12+ tools
+- 100% test coverage on core
+- < 300ms cold start
+- Single binary < 50MB
+- Works on Win/Mac/Linux
+- 1000+ GitHub stars
+- 50+ contributors
+
+### v2.0 (12 months)
+- VS Code extension published
+- MCP server mode
+- Plugin ecosystem (20+ plugins)
+- 10K+ active users
+- Compete with Claude Code on benchmarks
+
+---
+
+## 10. Out of Scope (v1.0)
+
+- Cloud sync / hosted backend
+- Relay / remote SSH execution
+- Multi-agent mission mode
+- Plugin marketplace
+- Auto-generated wikis
+- Git authorship notes
+- Vendor telemetry
+- Voice input
+- Mobile support
+
+---
+
+## 11. Open Decisions
+
+1. **TUI library:** Ink (React) vs OpenTUI (Solid) — **Decide: Ink** (mature, large ecosystem)
+2. **Storage:** JSONL files vs SQLite — **Decide: JSONL** (inspectable, simple)
+3. **Package structure:** Single vs monorepo — **Decide: Single** until M4
+4. **Provider abstraction:** Direct API vs wrapper — **Decide: Direct** (portability)
+5. **Patch strategy:** apply_patch vs edit_file — **Decide: Both** (apply_patch for bulk, edit_file for small)
+
+---
+
+## 12. Team & Timeline
+
+**Team (3 people):**
+- You (lead + TUI + tools)
+- Backend dev (providers + core)
+- Designer (VS Code extension + docs)
+
+**Timeline:**
+- M0-M1: 4 weeks (foundation)
+- M2-M3: 6 weeks (polish + distribution)
+- M4-M5: 8 weeks (extensibility)
+- M6: 4 weeks (sandbox)
+- **Total v1.0: 6 months**
+
+---
+
+## 13. Why This Will Work
+
+1. **Proven patterns** — Based on clean-room analysis of existing terminal coding-agent UX patterns
+2. **Multi-provider** — Unique advantage vs Claude Code/Cursor
+3. **Open source** — Community contributions
+4. **TypeScript** — Type safety, fast iteration
+5. **Bun** — Fast runtime, single binary
+6. **Clear milestones** — Ship early, iterate
+
+---
+
+**This is the real PRD. 13 sections, 24 features, 6 months to v1.0.**

--- a/docs/WORK_SPLIT_PRD.md
+++ b/docs/WORK_SPLIT_PRD.md
@@ -1,0 +1,562 @@
+# Zero WorkSplit PRD v2: Balanced And Conflict-Free Team Plan
+
+Status: Draft v2.0
+Date: 2026-06-02
+Timeline: 6 months to v1.0
+Team: Vasanth, Gnanam, Anandan
+
+This v2 replaces the conflict points in the original WorkSplit PRD:
+
+- UI/TUI surfaces are separated from backend capabilities.
+- Headless `exec` is split into CLI surface, runtime protocol, and distribution responsibilities.
+- Search is scheduled after a minimal session event store exists.
+- Slash commands are split into command UI, backend APIs, and integration commands.
+- Anandan's workload is narrowed to infra/distribution/integrations, with clear dependencies on Gnanam runtime contracts.
+- Each milestone gives all 3 people similar effort and reviewable PR slices.
+
+## Product Goal
+
+Zero is a production coding agent CLI/TUI that can:
+
+- Chat and stream responses in a polished terminal UI.
+- Read, write, edit, search, and run tools safely.
+- Use OpenAI-compatible, Anthropic, and Gemini providers.
+- Track context and cost.
+- Run headless for scripts, automation, CI, and VS Code.
+- Persist, resume, fork, search, and export sessions.
+- Connect to MCP servers and load local plugins.
+- Run tests, manage git, self-verify changes, and operate inside sandbox policies.
+
+## Ownership Rules
+
+These rules prevent future conflicts:
+
+1. Every feature has one Directly Responsible Owner.
+2. UI/TUI commands and backend modules are separate deliverables.
+3. Cross-owner features must land the backend contract before UI/integration work depends on it.
+4. Provider-specific logic stays inside provider modules.
+5. Session/event protocol is owned by Gnanam and consumed by TUI, VS Code, MCP, and automation.
+6. Distribution work packages stable behavior; it does not define runtime semantics.
+7. Permission prompts are Vasanth's UI, but grants/policy/sandbox enforcement are Gnanam's backend.
+8. Windows platform implementation is Anandan's, but it must use the shared sandbox policy interface.
+
+## Team Roles
+
+| Person | Primary role | Owns | Does not own |
+|---|---|---|---|
+| Vasanth | Product lead, TUI, tools UX | Ink TUI, slash command UI, tool result rendering, local tool UX, permission prompts, themes, command palette, user-facing flows | Provider internals, session protocol, MCP transports, release pipeline |
+| Gnanam | Runtime backend, providers, protocols | Model registry, provider factory, Anthropic/Gemini, usage/cost, session store, stream-json, config validation, doctor/search backend, MCP/plugin backend, permissions/grants, sandbox policy | TUI rendering, binary packaging, VS Code extension UI |
+| Anandan | Infra, distribution, external integrations | CI, build, single binary, release packages, installers, self-update, performance benchmarks, VS Code extension, GitHub PR integration, Windows sandbox, release security | Provider internals, TUI command rendering, model registry |
+
+## Shared Contracts
+
+These contracts are required before dependent work starts:
+
+| Contract | Owner | Consumers | Needed by |
+|---|---|---|---|
+| Provider stream event schema | Gnanam | Vasanth, Anandan | TUI streaming, headless output, VS Code |
+| Model registry API | Gnanam | Vasanth | `/model`, `/effort`, cost, context budget |
+| Session event schema | Gnanam | Vasanth, Anandan | `/resume`, `/rewind`, search, VS Code, audit |
+| Command registry shape | Vasanth | Gnanam, Anandan | Slash command registration and help |
+| Build/test scripts | Anandan | Vasanth, Gnanam | CI, DoD, release |
+| Permission/grant policy | Gnanam | Vasanth, Anandan | prompts, MCP permissions, sandbox, Windows |
+| Stream-json protocol | Gnanam | Anandan | VS Code extension and automation |
+
+## Milestone M0: Foundation Baseline, Weeks 1-2
+
+Goal: Zero runs locally, has basic tools, one OpenAI-compatible provider, basic TUI, tests, and project scripts.
+
+Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and starts workload balancing from M1.
+
+### Vasanth
+
+- ToolBase with Zod schema validation.
+- Core file tools: read, write, edit, grep, list directory, bash, plan.
+- Basic Ink TUI and message/tool rendering.
+- Basic agent loop integration.
+- PR: existing PR #6 plus follow-up fixes if needed.
+
+### Gnanam
+
+- Review and stabilize provider contract from PR #6.
+- Define first draft of normalized `Usage` type.
+- Define first draft of model registry type.
+- Review config loader and list missing provider/config fields.
+- PR: `feat/m0-runtime-contracts` if not already covered.
+
+### Anandan
+
+- Add stable package scripts: `bun test`, `bun run build`, `bun run typecheck`.
+- Add initial CI smoke job.
+- Verify Bun version and lockfile behavior.
+- Add build artifact smoke check.
+- PR: `feat/m0-ci-scripts`.
+
+### M0 Done
+
+- `bun test` passes.
+- `bun run typecheck` exists and passes.
+- `bun run build` exists or has a documented placeholder until binary work.
+- `zero` can run, read a file, edit a file, and stream a response.
+
+## Milestone M1: Multi-Provider And Headless Foundation, Weeks 3-4
+
+Goal: Zero can select models/providers, use Claude/Gemini/OpenAI-compatible providers, and run headless with stable output.
+
+### Vasanth: TUI And CLI Surface
+
+- Model selector UI and `/model` command shell.
+- Reasoning effort UI and `/effort` command shell.
+- Header/footer model display.
+- Streaming output polish in TUI.
+- Headless command surface: parse `zero exec`, flags, output mode selection.
+- Exit code mapping display and CLI user messages.
+- PRs:
+  - `feat/m1-model-selector-ui`
+  - `feat/m1-headless-cli-surface`
+
+### Gnanam: Provider Runtime
+
+- Model registry with 10+ models, cost, context limits, capabilities.
+- Provider factory that resolves model/profile/provider.
+- Anthropic provider with streaming text, tool calls, system prompt, usage.
+- Gemini provider with streaming text, tool calls, usage, vision-ready input shape.
+- Normalized provider event schema and usage type.
+- PRs:
+  - `feat/m1-model-registry`
+  - `feat/m1-provider-factory`
+  - `feat/m1-anthropic-provider`
+  - `feat/m1-gemini-provider`
+
+### Anandan: Build And CI
+
+- Single binary build spike with `bun build --compile`.
+- CI matrix for Linux/macOS/Windows test and build smoke.
+- Release packaging formats: tar.gz for Unix, zip for Windows.
+- Artifact upload on tags or manual workflow.
+- PRs:
+  - `feat/m1-ci-matrix`
+  - `feat/m1-binary-build`
+  - `feat/m1-release-packaging`
+
+### M1 Dependency Order
+
+1. Gnanam lands model registry.
+2. Gnanam lands provider factory.
+3. Vasanth connects model selector to registry.
+4. Gnanam lands Anthropic/Gemini.
+5. Vasanth finishes provider-aware TUI/headless surface.
+6. Anandan packages once scripts and entrypoints are stable.
+
+### M1 Done
+
+- `zero exec -m <model> "list files"` runs through provider factory.
+- OpenAI-compatible provider still works.
+- Anthropic and Gemini providers pass mocked stream tests.
+- Model selector reads registry data.
+- CI runs tests and typecheck on PR.
+- Binary build has at least one working platform artifact or documented blocker.
+
+## Milestone M2: Core Commands, Cost, Observability, Install Flow, Weeks 5-8
+
+Goal: Core slash commands work, cost and diagnostics are visible, sessions have a minimal event store, and installation/update flows begin.
+
+### Vasanth: Core Command UX
+
+- Slash command framework and help registry.
+- Session commands UI: `/clear`, `/compact`, `/context`, `/resume`, `/exit`.
+- Model commands UI: `/model`, `/effort`, `/style`.
+- Meta commands UI: `/help`, `/config`, `/doctor`.
+- Tool result truncation and pagination UI.
+- Auto-compaction prompt UX.
+- PRs:
+  - `feat/m2-slash-framework`
+  - `feat/m2-session-model-commands`
+  - `feat/m2-tool-truncation`
+  - `feat/m2-compaction-ui`
+
+### Gnanam: Observability Backend
+
+- Minimal session event store to support cost/search/resume later.
+- Cost tracking from normalized usage and model registry.
+- `zero doctor` backend checks: Bun, config, provider, connectivity, model validity.
+- `zero search` backend over local session events.
+- Config inspection and validation API for `/config`.
+- Secret redaction helper used by logs, provider errors, doctor, feedback.
+- PRs:
+  - `feat/m2-minimal-session-events`
+  - `feat/m2-cost-tracking`
+  - `feat/m2-doctor`
+  - `feat/m2-search`
+  - `feat/m2-secret-redaction`
+
+### Anandan: Install, Update, Performance
+
+- Self-update design and `zero update --check`.
+- Install scripts for Linux/macOS and PowerShell draft for Windows.
+- Performance benchmark harness: cold start, TTFT, memory.
+- CI performance smoke job with threshold warnings.
+- Release checksum generation.
+- PRs:
+  - `feat/m2-update-check`
+  - `feat/m2-install-scripts`
+  - `feat/m2-perf-bench`
+  - `feat/m2-release-checksums`
+
+### M2 Command Scope
+
+Fully working in M2:
+
+- `/clear`
+- `/compact`
+- `/context`
+- `/resume`
+- `/exit`
+- `/model`
+- `/effort`
+- `/style`
+- `/help`
+- `/config`
+- `/doctor`
+
+Registered but full backend lands later:
+
+- `/rewind`: full in M3 with session event replay.
+- `/permissions`: full in M4/M6 with permission/grant system.
+- `/init`, `/memory`, `/skills`: full in M4 with memory/skills.
+- `/mcp`, `/hooks`, `/agents`: full in M4 with MCP/hooks/subagents.
+- `/feedback`: full in M3/M5 with integration/redaction.
+
+### M2 Done
+
+- TUI command framework is stable.
+- Core 11 commands work.
+- Cost shows in footer/session summary.
+- `zero doctor` gives redacted pass/warn/fail checks.
+- `zero search` can search persisted local events.
+- Install scripts and update check have smoke tests.
+
+## Milestone M3: Sessions, Stream Protocol, VS Code MVP, Weeks 9-10
+
+Goal: Sessions are durable, stream-json is stable, and VS Code can drive Zero through the protocol.
+
+### Vasanth: TUI Session UX
+
+- Themes: light, dark, custom config.
+- Mouse support for selectors and command palette where feasible.
+- Collapsible tool rows with one-line summaries.
+- `/rewind` interactive UI using Gnanam's session event API.
+- Session picker polish for `/resume` and fork display.
+- PRs:
+  - `feat/m3-themes`
+  - `feat/m3-tool-rows`
+  - `feat/m3-rewind-ui`
+
+### Gnanam: Headless And Sessions
+
+- Full session persistence under `~/.local/share/zero/sessions/<id>/`.
+- Append-only `events.jsonl`.
+- `--resume` and `--fork` support.
+- Stream-json input/output protocol with schema tests.
+- Config validation errors with source paths.
+- Session search indexing improvements.
+- PRs:
+  - `feat/m3-sessions`
+  - `feat/m3-resume-fork`
+  - `feat/m3-stream-json`
+  - `feat/m3-config-validation`
+
+### Anandan: VS Code And Docs Distribution
+
+- VS Code extension MVP using stream-json.
+- Inline chat panel.
+- Diff view integration.
+- Homebrew tap or formula draft.
+- Documentation site skeleton with install and CLI docs.
+- PRs:
+  - `feat/m3-vscode-mvp`
+  - `feat/m3-homebrew`
+  - `feat/m3-docs-site`
+
+### M3 Dependency Order
+
+1. Gnanam freezes stream-json event schema.
+2. Anandan builds VS Code against that schema.
+3. Gnanam lands session resume/fork.
+4. Vasanth wires `/rewind` and session picker.
+5. Anandan documents protocol and install path.
+
+### M3 Done
+
+- Sessions survive process restart.
+- `zero exec --resume <id>` works.
+- `zero exec --fork <id>` creates a new session branch.
+- Stream-json is line-delimited and schema-tested.
+- VS Code MVP can send prompt and render streamed text/tool events.
+
+## Milestone M4: Extensibility, MCP, Skills, Subagents, Weeks 11-14
+
+Goal: Users can extend Zero with memory, skills, hooks, MCP servers, plugins, and subagents.
+
+### Vasanth: Extensibility UX
+
+- `/init` generates project memory scaffold.
+- `/memory` inspect/reload UI.
+- `/skills` manager UI.
+- `/hooks` manager UI.
+- `/mcp` manager UI shell.
+- `/agents` selector UI.
+- PRs:
+  - `feat/m4-memory-ui`
+  - `feat/m4-skills-ui`
+  - `feat/m4-extensibility-commands`
+
+### Gnanam: MCP And Plugin Backend
+
+- MCP client with stdio, HTTP, and SSE transports.
+- Surface MCP tools in Zero tool registry.
+- MCP permissions: per-server and per-tool grants, list/revoke/clear.
+- Local plugin loader from `~/.config/zero/plugins/` and `.zero/plugins/`.
+- Plugin manifest validation with `plugin.json`.
+- MCP server mode: `zero serve --mcp`.
+- Hook config storage and audit events.
+- PRs:
+  - `feat/m4-mcp-client`
+  - `feat/m4-mcp-permissions`
+  - `feat/m4-plugin-loader`
+  - `feat/m4-mcp-server`
+  - `feat/m4-hook-backend`
+
+### Anandan: Subagents And Integration Docs
+
+- Subagent framework using Gnanam's parent/child session linkage.
+- `task` tool implementation for scoped subagents.
+- Built-in agents: code-review, security-review, refactor, test-gen.
+- VS Code support for subagent session tree.
+- Extensibility docs for MCP/plugins/agents.
+- PRs:
+  - `feat/m4-subagent-framework`
+  - `feat/m4-builtin-agents`
+  - `feat/m4-vscode-agents`
+  - `feat/m4-extensibility-docs`
+
+### M4 Dependency Order
+
+1. Gnanam lands MCP tool registry integration.
+2. Vasanth wires `/mcp` UI to backend.
+3. Gnanam lands parent/child session APIs.
+4. Anandan lands subagent framework.
+5. Vasanth wires `/agents` UI.
+
+### M4 Done
+
+- User can add and call an MCP tool.
+- User can list/revoke/clear MCP permissions.
+- User can load a local plugin manifest.
+- User can run `zero serve --mcp`.
+- User can spawn a scoped subagent through `task`.
+- Extensibility commands are fully functional.
+
+## Milestone M5: Advanced Agent Operations, Weeks 15-20
+
+Goal: Zero can verify work, manage git/test flows, and assist code review.
+
+### Vasanth: Advanced Tool UX
+
+- `web_fetch` and `web_search` tools with safe display and truncation.
+- LSP diagnostics display in TUI.
+- Typecheck/lint result rendering.
+- Rich test failure rendering in TUI.
+- Review summary UI for agent findings.
+- PRs:
+  - `feat/m5-web-tools-ui`
+  - `feat/m5-diagnostics-ui`
+  - `feat/m5-verification-ui`
+
+### Gnanam: Git And Verification Backend
+
+- Git worktree isolation per task.
+- Auto-commit backend: detect changes and generate commit messages.
+- Test runner detection and execution.
+- Parse test results into structured summaries.
+- Self-verification loop: run checks after edits, retry within budget.
+- PRs:
+  - `feat/m5-worktrees`
+  - `feat/m5-autocommit`
+  - `feat/m5-test-runner`
+  - `feat/m5-self-verify`
+
+### Anandan: GitHub And Review Automation
+
+- GitHub API integration for PR metadata and comments.
+- Automated code-review workflow using built-in agent.
+- Security-review workflow.
+- Dependency update detection.
+- CI integration for agent-generated reports.
+- PRs:
+  - `feat/m5-github-integration`
+  - `feat/m5-code-review-agent`
+  - `feat/m5-security-review-agent`
+  - `feat/m5-dependency-updates`
+
+### M5 Dependency Order
+
+1. Gnanam lands git/test backend APIs.
+2. Vasanth renders verification output.
+3. Anandan builds GitHub PR review workflow on git/test/session APIs.
+4. Anandan publishes CI report integration.
+
+### M5 Done
+
+- Zero can create/use a git worktree for a task.
+- Zero can run project tests and parse failures.
+- Zero can self-verify after edits.
+- Zero can produce a code-review report.
+- GitHub PR comment posting works when configured.
+
+## Milestone M6: Sandbox And Security, Weeks 21-24
+
+Goal: Zero can safely run higher-autonomy workflows with OS-aware sandboxing and durable permission grants.
+
+### Vasanth: Security UX
+
+- Permission prompts: allow, deny, always allow, always deny.
+- Autonomy level UI: low, medium, high.
+- Permission audit log view.
+- Sandbox violation rendering.
+- Security warnings in TUI and headless text output.
+- PRs:
+  - `feat/m6-permission-prompts`
+  - `feat/m6-autonomy-ui`
+  - `feat/m6-audit-ui`
+
+### Gnanam: Sandbox Backend
+
+- Shared sandbox policy interface.
+- Linux sandbox using bubblewrap.
+- macOS sandbox using sandbox-exec or best available policy backend.
+- Persistent grants: allow/deny list/revoke/clear.
+- Network and filesystem policy enforcement.
+- Structured sandbox violation errors.
+- PRs:
+  - `feat/m6-sandbox-policy`
+  - `feat/m6-sandbox-linux`
+  - `feat/m6-sandbox-macos`
+  - `feat/m6-persistent-grants`
+
+### Anandan: Windows And Release Security
+
+- Windows sandbox using AppContainer or best supported Windows isolation.
+- Release signing/checksum verification.
+- Security CI hardening.
+- Dependency vulnerability scanning.
+- Security audit and penetration test coordination.
+- PRs:
+  - `feat/m6-sandbox-windows`
+  - `feat/m6-release-signing`
+  - `feat/m6-security-ci`
+  - `feat/m6-security-audit`
+
+### M6 Dependency Order
+
+1. Gnanam lands shared sandbox policy interface.
+2. Vasanth wires prompts to the shared policy.
+3. Gnanam implements Linux/macOS policy adapters.
+4. Anandan implements Windows adapter using same policy.
+5. Anandan finalizes release security.
+
+### M6 Done
+
+- `zero --auto high` uses permission policy and sandbox backend.
+- Persistent grants work across sessions.
+- Linux/macOS sandboxing works or has documented OS-specific fallback.
+- Windows sandbox adapter works or has documented fallback.
+- Security audit findings are triaged and fixed or accepted.
+
+## Slash Command Ownership Matrix
+
+| Command | UI owner | Backend owner | Fully done by | Notes |
+|---|---|---|---|---|
+| `/clear` | Vasanth | Gnanam | M2 | New session/reset event. |
+| `/compact` | Vasanth | Gnanam | M2 | Requires token/cost/context backend. |
+| `/context` | Vasanth | Gnanam | M2 | Registry + usage + tool/MCP context. |
+| `/rewind` | Vasanth | Gnanam | M3 | Requires durable event store. |
+| `/resume` | Vasanth | Gnanam | M3 | M2 can list minimal sessions; M3 full resume/fork. |
+| `/exit` | Vasanth | Gnanam | M2 | Must flush session-end event. |
+| `/model` | Vasanth | Gnanam | M1/M2 | Registry lands M1, UI polished M2. |
+| `/effort` | Vasanth | Gnanam | M1/M2 | Reasoning metadata from registry. |
+| `/style` | Vasanth | Vasanth | M2 | UI/config preference only unless style affects prompts. |
+| `/permissions` | Vasanth | Gnanam | M4/M6 | MCP permissions in M4, sandbox grants in M6. |
+| `/init` | Vasanth | Vasanth | M4 | Project memory scaffold. |
+| `/memory` | Vasanth | Vasanth | M4 | Memory inspect/reload. |
+| `/skills` | Vasanth | Gnanam | M4 | UI by Vasanth; plugin-provided skills backend by Gnanam. |
+| `/mcp` | Vasanth | Gnanam | M4 | MCP client/server/backend by Gnanam. |
+| `/hooks` | Vasanth | Gnanam | M4 | UI by Vasanth; hook config/audit backend by Gnanam. |
+| `/agents` | Vasanth | Anandan | M4 | Requires Gnanam parent/child session API. |
+| `/help` | Vasanth | Vasanth | M2 | Command metadata registry. |
+| `/config` | Vasanth | Gnanam | M2/M3 | Inspect in M2, validation source errors in M3. |
+| `/doctor` | Vasanth | Gnanam | M2 | Backend CLI and TUI share same checks. |
+| `/feedback` | Vasanth | Anandan | M3/M5 | Redaction by Gnanam; GitHub/product integration by Anandan. |
+
+## Headless Exec Ownership
+
+Headless `exec` is split to avoid conflict:
+
+| Area | Owner | Scope |
+|---|---|---|
+| CLI command and flags | Vasanth | `zero exec`, `--model`, `--output-format`, help text, exit message display. |
+| Runtime execution | Gnanam | Provider factory, stream events, usage, tool loop hooks, session recording, stream-json. |
+| Packaging and CI | Anandan | Binary command works across platforms, CI tests headless modes, release artifacts. |
+
+## Permission Ownership
+
+| Area | Owner | Scope |
+|---|---|---|
+| Prompt UI | Vasanth | Allow/deny/always controls and TUI display. |
+| Policy engine | Gnanam | Risk classification, grants, persistent decisions, MCP permissions, sandbox policy. |
+| Platform adapters | Gnanam + Anandan | Gnanam owns Linux/macOS; Anandan owns Windows using same policy. |
+
+## Definition Of Done Per PR
+
+Every PR must include:
+
+- Tests for changed behavior.
+- `bun test` passes.
+- `bun run typecheck` passes.
+- `bun run build` passes or the PR explicitly documents why build is not applicable.
+- PR description explains what changed and why.
+- No unrelated refactors.
+- Redaction used for secrets in logs/errors/tests.
+- Cross-owner API changes include a small contract note or test.
+
+## Review Rotation
+
+| Author | Primary reviewer | Secondary reviewer when cross-owner |
+|---|---|---|
+| Vasanth | Gnanam | Anandan for distribution/VS Code impact |
+| Gnanam | Anandan | Vasanth for TUI/UX impact |
+| Anandan | Vasanth | Gnanam for runtime/protocol impact |
+
+## Balanced Workload Summary
+
+| Milestone | Vasanth load | Gnanam load | Anandan load |
+|---|---|---|---|
+| M0 | Core tools + TUI baseline | Runtime contracts | Scripts + CI baseline |
+| M1 | Model/headless UI | Registry + providers | CI + binary + packaging |
+| M2 | Core slash UX + compaction UI | Cost + doctor + search + events | Install + update + perf |
+| M3 | Session UI + themes | Sessions + stream-json | VS Code + docs + Homebrew |
+| M4 | Extensibility UI | MCP + plugins + permissions | Subagents + agent docs |
+| M5 | Verification/web UX | Git + tests + self-verify | GitHub review automation |
+| M6 | Security UX | Linux/macOS sandbox + grants | Windows sandbox + release security |
+
+This keeps workload balanced while preserving clean ownership boundaries.
+
+## Immediate Next Steps
+
+1. Merge or close PR #6 with M0 baseline decision.
+2. Anandan adds/validates project scripts and CI baseline if missing.
+3. Gnanam starts `feat/m1-model-registry`.
+4. Vasanth starts model selector UI only after registry API shape is agreed.
+5. Gnanam starts provider factory before Anthropic/Gemini providers.
+6. Anandan starts CI matrix and binary build spike in parallel.
+


### PR DESCRIPTION
## Summary

Adds the final public Zero docs:

- docs/PRD.md
- docs/WORK_SPLIT_PRD.md

## Sanitization

- Removed internal/reference wording from the PRD.
- Verified docs do not include internal build-agent names, private local paths, source-map/prompt-pack text, or GPT subscription details.

## Notes

This branch was created from latest origin/main in an isolated worktree and does not touch the active Codex working directory.