### PR TITLE
Add M1 release packaging workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,59 @@
+name: Release Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to package. Defaults to the workflow branch.
+        required: false
+        type: string
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  package:
+    name: Package (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.ref == '' }}
+        uses: actions/checkout@v4
+
+      - name: Checkout requested ref
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != '' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun run test
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Package release artifact
+        run: bun run package:release
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: zero-${{ runner.os }}-${{ runner.arch }}
+          path: dist/release/*
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ bun test
 bun run typecheck
 bun run build
 bun run smoke:build
+bun run package:release
 ```
 
 Bun version is pinned in `package.json`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "bun test ./tests --timeout 15000",
     "typecheck": "bunx tsc --noEmit",
     "build": "bun run scripts/build.ts",
-    "smoke:build": "bun run scripts/smoke-build.ts"
+    "smoke:build": "bun run scripts/smoke-build.ts",
+    "package:release": "bun run scripts/package-release.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/artifact.ts
+++ b/scripts/artifact.ts
@@ -4,5 +4,31 @@ export function getZeroArtifactName(platform = process.platform): string {
   return platform === 'win32' ? 'zero.exe' : 'zero';
 }
 
+export function getReleasePlatform(platform = process.platform): string {
+  if (platform === 'darwin') return 'macos';
+  if (platform === 'win32') return 'windows';
+  return platform;
+}
+
+export function getReleaseArchiveExtension(platform = process.platform): string {
+  return platform === 'win32' ? 'zip' : 'tar.gz';
+}
+
+export function getReleasePackageName(
+  version: string,
+  platform = process.platform,
+  arch = process.arch,
+): string {
+  return `zero-v${version}-${getReleasePlatform(platform)}-${arch}`;
+}
+
+export function getReleaseArchiveName(
+  version: string,
+  platform = process.platform,
+  arch = process.arch,
+): string {
+  return `${getReleasePackageName(version, platform, arch)}.${getReleaseArchiveExtension(platform)}`;
+}
+
 export const zeroArtifactName = getZeroArtifactName();
 export const zeroArtifactPath = join(process.cwd(), zeroArtifactName);

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -1,0 +1,94 @@
+import { $ } from 'bun';
+import { createHash } from 'node:crypto';
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import {
+  getReleaseArchiveName,
+  getReleasePackageName,
+  zeroArtifactName,
+  zeroArtifactPath,
+} from './artifact';
+
+function parsePackageVersion(packageText: string): string {
+  const parsed = JSON.parse(packageText) as { version?: unknown };
+
+  if (typeof parsed.version !== 'string' || parsed.version.trim() === '') {
+    throw new Error('package.json must contain a non-empty string version');
+  }
+
+  return parsed.version;
+}
+
+function quotePowerShellPath(path: string): string {
+  return `'${path.replaceAll("'", "''")}'`;
+}
+
+async function run(command: string[]): Promise<void> {
+  const child = Bun.spawn(command, {
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  if (stdout.trim()) console.log(stdout.trim());
+
+  if (exitCode !== 0) {
+    const message = stderr.trim() || `${command[0]} exited with ${exitCode}`;
+    throw new Error(message);
+  }
+}
+
+async function sha256(path: string): Promise<string> {
+  const bytes = await Bun.file(path).arrayBuffer();
+  return createHash('sha256').update(Buffer.from(bytes)).digest('hex');
+}
+
+const packageText = await Bun.file('package.json').text();
+const version = parsePackageVersion(packageText);
+const packageName = getReleasePackageName(version);
+const archiveName = getReleaseArchiveName(version);
+const releaseDir = join(process.cwd(), 'dist', 'release');
+const stagingRoot = join(process.cwd(), 'dist', 'package');
+const stagingDir = join(stagingRoot, packageName);
+const archivePath = join(releaseDir, archiveName);
+const stagedBinaryPath = join(stagingDir, zeroArtifactName);
+
+await rm(releaseDir, { recursive: true, force: true });
+await rm(stagingRoot, { recursive: true, force: true });
+await mkdir(stagingDir, { recursive: true });
+await mkdir(releaseDir, { recursive: true });
+
+await $`bun run build`;
+await $`bun run smoke:build`;
+await cp(zeroArtifactPath, stagedBinaryPath);
+await cp('README.md', join(stagingDir, 'README.md'));
+await cp('package.json', join(stagingDir, 'package.json'));
+await writeFile(join(stagingDir, 'VERSION'), `${version}\n`);
+
+if (process.platform === 'win32') {
+  const sourceGlob = join(stagingDir, '*');
+  const command = [
+    'powershell',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-Command',
+    `Compress-Archive -Path ${quotePowerShellPath(sourceGlob)} -DestinationPath ${quotePowerShellPath(archivePath)} -Force`,
+  ];
+  await run(command);
+} else {
+  await $`chmod 755 ${stagedBinaryPath}`;
+  await $`tar -C ${stagingDir} -czf ${archivePath} .`;
+}
+
+const checksum = await sha256(archivePath);
+await writeFile(`${archivePath}.sha256`, `${checksum}  ${basename(archivePath)}\n`);
+
+console.log(`Packaged ${archiveName}`);
+console.log(`Wrote ${archiveName}.sha256`);

--- a/tests/build-scripts.test.ts
+++ b/tests/build-scripts.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test';
-import { getZeroArtifactName } from '../scripts/artifact';
+import {
+  getReleaseArchiveExtension,
+  getReleaseArchiveName,
+  getReleasePackageName,
+  getReleasePlatform,
+  getZeroArtifactName,
+} from '../scripts/artifact';
 
 describe('build artifact naming', () => {
   it('uses a Windows executable suffix on win32', () => {
@@ -9,5 +15,25 @@ describe('build artifact naming', () => {
   it('uses the plain binary name on Unix platforms', () => {
     expect(getZeroArtifactName('linux')).toBe('zero');
     expect(getZeroArtifactName('darwin')).toBe('zero');
+  });
+});
+
+describe('release artifact naming', () => {
+  it('normalizes package platform names', () => {
+    expect(getReleasePlatform('darwin')).toBe('macos');
+    expect(getReleasePlatform('win32')).toBe('windows');
+    expect(getReleasePlatform('linux')).toBe('linux');
+  });
+
+  it('uses zip for Windows and tar.gz elsewhere', () => {
+    expect(getReleaseArchiveExtension('win32')).toBe('zip');
+    expect(getReleaseArchiveExtension('linux')).toBe('tar.gz');
+    expect(getReleaseArchiveExtension('darwin')).toBe('tar.gz');
+  });
+
+  it('includes version, platform, and architecture in release names', () => {
+    expect(getReleasePackageName('0.1.0', 'darwin', 'arm64')).toBe('zero-v0.1.0-macos-arm64');
+    expect(getReleaseArchiveName('0.1.0', 'win32', 'x64')).toBe('zero-v0.1.0-windows-x64.zip');
+    expect(getReleaseArchiveName('0.1.0', 'linux', 'x64')).toBe('zero-v0.1.0-linux-x64.tar.gz');
   });
 });


### PR DESCRIPTION
## Summary
- Add release artifact naming helpers for platform/architecture-specific packages
- Add `bun run package:release` to build, smoke-check, package, and checksum release artifacts
- Add manual/tag-triggered Release Artifacts workflow for Linux/macOS/Windows uploads

## Artifact behavior
- Linux/macOS produce `zero-v<version>-<platform>-<arch>.tar.gz`
- Windows produces `zero-v<version>-windows-<arch>.zip`
- Each package also emits a matching `.sha256` file

## Verification
- bun install --frozen-lockfile
- bun test
- bun run typecheck
- bun run build
- bun run smoke:build
- bun run package:release
- git diff --check