### PR TITLE
feat: add Zero Anthropic provider

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,7 +21,7 @@ export async function runHeadless(prompt: string) {
     provider = createZeroProvider(runtime);
   } catch (err: any) {
     console.error(`[zero] ${err?.message ?? String(err)}`);
-    if (runtime?.provider === 'anthropic' || runtime?.provider === 'google') {
+    if (runtime?.provider === 'google') {
       console.error(
         `[zero] ${runtime.provider} adapter is not yet implemented. ` +
         'Set provider: "openai-compatible" with a custom gateway or use an OpenAI model.'

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,9 @@
 import { loadProviderConfig } from '../config/provider';
-import { createZeroProvider, resolveZeroProviderRuntime } from '../zero-provider-runtime';
+import {
+  createZeroProvider,
+  resolveZeroProviderRuntime,
+  ZeroPendingProviderError,
+} from '../zero-provider-runtime';
 import type { Provider } from '../providers/types';
 import type { ZeroResolvedProviderRuntime } from '../zero-provider-runtime';
 import { runAgent } from '../agent/loop';
@@ -21,10 +25,9 @@ export async function runHeadless(prompt: string) {
     provider = createZeroProvider(runtime);
   } catch (err: any) {
     console.error(`[zero] ${err?.message ?? String(err)}`);
-    if (runtime?.provider === 'google') {
+    if (err instanceof ZeroPendingProviderError) {
       console.error(
-        `[zero] ${runtime.provider} adapter is not yet implemented. ` +
-        'Set provider: "openai-compatible" with a custom gateway or use an OpenAI model.'
+        '[zero] Use an implemented provider, or set provider: "openai-compatible" with a custom gateway.'
       );
     }
     process.exit(1);

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,0 +1,444 @@
+import type { Message, Provider, StreamEvent, ToolDefinition } from './types';
+
+const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
+const DEFAULT_ANTHROPIC_VERSION = '2023-06-01';
+const DEFAULT_MAX_TOKENS = 4096;
+
+type FetchLike = (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>;
+
+interface AnthropicProviderOptions {
+  apiKey: string;
+  baseURL?: string;
+  model: string;
+  maxTokens?: number;
+  version?: string;
+  beta?: string;
+  fetchImpl?: FetchLike;
+}
+
+type AnthropicContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: string };
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContentBlock[];
+}
+
+interface AnthropicStreamPayload {
+  type?: string;
+  index?: number;
+  message?: {
+    usage?: AnthropicUsage;
+  };
+  content_block?: {
+    type?: string;
+    id?: string;
+    name?: string;
+    input?: Record<string, unknown>;
+  };
+  delta?: {
+    type?: string;
+    text?: string;
+    partial_json?: string;
+    stop_reason?: string;
+  };
+  usage?: AnthropicUsage;
+  error?: {
+    type?: string;
+    message?: string;
+  };
+}
+
+interface AnthropicUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+interface AnthropicToolCallBlock {
+  id: string;
+  name: string;
+}
+
+export class AnthropicProvider implements Provider {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly version: string;
+  private readonly beta?: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor({
+    apiKey,
+    baseURL,
+    model,
+    maxTokens = DEFAULT_MAX_TOKENS,
+    version = DEFAULT_ANTHROPIC_VERSION,
+    beta,
+    fetchImpl = fetch,
+  }: AnthropicProviderOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = (baseURL || DEFAULT_ANTHROPIC_BASE_URL).replace(/\/+$/, '');
+    this.model = model;
+    this.maxTokens = maxTokens;
+    this.version = version;
+    this.beta = beta;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async *streamCompletion(
+    messages: Message[],
+    tools: ToolDefinition[]
+  ): AsyncIterable<StreamEvent> {
+    const { system, messages: anthropicMessages } = toAnthropicMessages(messages);
+    if (anthropicMessages.length === 0) {
+      throw new Error('Zero Anthropic provider requires at least one non-system message');
+    }
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      max_tokens: this.maxTokens,
+      messages: anthropicMessages,
+      stream: true,
+    };
+    if (system) body.system = system;
+    if (tools.length > 0) body.tools = toAnthropicTools(tools);
+
+    const response = await this.createStream(body);
+    yield* this.readStream(response);
+  }
+
+  private async createStream(body: Record<string, unknown>): Promise<Response> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      'x-api-key': this.apiKey,
+      'anthropic-version': this.version,
+    };
+    if (this.beta) headers['anthropic-beta'] = this.beta;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseURL}/v1/messages`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    } catch (err: any) {
+      throw new Error(`Provider returned error: ${getDetailedErrorMessage(err)}`);
+    }
+
+    if (!response.ok) {
+      const message = await getResponseErrorMessage(response);
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(`Provider authentication error (check your API key): ${message}`);
+      }
+      if (response.status === 429 || response.status === 529) {
+        throw new Error(`Provider rate limit error: ${message}`);
+      }
+      throw new Error(`Provider returned error: ${message}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Provider returned error: Anthropic stream response did not include a body');
+    }
+
+    return response;
+  }
+
+  private async *readStream(response: Response): AsyncIterable<StreamEvent> {
+    const toolBlocks = new Map<number, AnthropicToolCallBlock>();
+    let promptTokens = 0;
+    let completionTokens = 0;
+    let hasPromptUsage = false;
+    let hasCompletionUsage = false;
+    let emittedDone = false;
+
+    try {
+      for await (const payload of readAnthropicSSE(response.body!)) {
+        switch (payload.type) {
+          case 'message_start': {
+            const inputTokens = payload.message?.usage?.input_tokens;
+            if (typeof inputTokens === 'number') {
+              promptTokens = inputTokens;
+              hasPromptUsage = true;
+            }
+            break;
+          }
+          case 'content_block_start': {
+            if (
+              typeof payload.index === 'number' &&
+              payload.content_block?.type === 'tool_use' &&
+              payload.content_block.id &&
+              payload.content_block.name
+            ) {
+              const toolBlock = {
+                id: payload.content_block.id,
+                name: payload.content_block.name,
+              };
+              toolBlocks.set(payload.index, toolBlock);
+              yield { type: 'tool-call-start', id: toolBlock.id, name: toolBlock.name };
+
+              const initialInput = payload.content_block.input;
+              if (initialInput && Object.keys(initialInput).length > 0) {
+                yield {
+                  type: 'tool-call-delta',
+                  id: toolBlock.id,
+                  argumentsFragment: JSON.stringify(initialInput),
+                };
+              }
+            }
+            break;
+          }
+          case 'content_block_delta': {
+            const delta = payload.delta;
+            if (delta?.type === 'text_delta' && delta.text) {
+              yield { type: 'text', content: delta.text };
+            } else if (
+              delta?.type === 'input_json_delta' &&
+              typeof payload.index === 'number'
+            ) {
+              const toolBlock = toolBlocks.get(payload.index);
+              if (toolBlock && delta.partial_json) {
+                yield {
+                  type: 'tool-call-delta',
+                  id: toolBlock.id,
+                  argumentsFragment: delta.partial_json,
+                };
+              }
+            }
+            break;
+          }
+          case 'content_block_stop': {
+            if (typeof payload.index === 'number') {
+              const toolBlock = toolBlocks.get(payload.index);
+              if (toolBlock) {
+                yield { type: 'tool-call-end', id: toolBlock.id };
+                toolBlocks.delete(payload.index);
+              }
+            }
+            break;
+          }
+          case 'message_delta': {
+            const inputTokens = payload.usage?.input_tokens;
+            const outputTokens = payload.usage?.output_tokens;
+            if (typeof inputTokens === 'number') {
+              promptTokens = inputTokens;
+              hasPromptUsage = true;
+            }
+            if (typeof outputTokens === 'number') {
+              completionTokens = outputTokens;
+              hasCompletionUsage = true;
+            }
+            break;
+          }
+          case 'message_stop': {
+            for (const toolBlock of toolBlocks.values()) {
+              yield { type: 'tool-call-end', id: toolBlock.id };
+            }
+            toolBlocks.clear();
+            if (hasPromptUsage || hasCompletionUsage) {
+              yield { type: 'usage', promptTokens, completionTokens };
+            }
+            yield { type: 'done' };
+            emittedDone = true;
+            break;
+          }
+          case 'error': {
+            throw new Error(payload.error?.message || payload.error?.type || 'Anthropic stream error');
+          }
+          default:
+            break;
+        }
+      }
+
+      if (!emittedDone) {
+        for (const toolBlock of toolBlocks.values()) {
+          yield { type: 'tool-call-end', id: toolBlock.id };
+        }
+        if (hasPromptUsage || hasCompletionUsage) {
+          yield { type: 'usage', promptTokens, completionTokens };
+        }
+        yield { type: 'done' };
+      }
+    } catch (err: any) {
+      throw new Error(`Provider returned error during streaming: ${getDetailedErrorMessage(err)}`);
+    }
+  }
+}
+
+async function* readAnthropicSSE(
+  body: ReadableStream<Uint8Array>
+): AsyncIterable<AnthropicStreamPayload> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+    buffer = buffer.replace(/\r\n/g, '\n');
+
+    let boundary = buffer.indexOf('\n\n');
+    while (boundary !== -1) {
+      const rawEvent = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const payload = parseAnthropicSSEPayload(rawEvent);
+      if (payload) yield payload;
+      boundary = buffer.indexOf('\n\n');
+    }
+
+    if (done) break;
+  }
+
+  const trailingPayload = parseAnthropicSSEPayload(buffer);
+  if (trailingPayload) yield trailingPayload;
+}
+
+function parseAnthropicSSEPayload(rawEvent: string): AnthropicStreamPayload | undefined {
+  const dataLines: string[] = [];
+
+  for (const line of rawEvent.split('\n')) {
+    if (!line || line.startsWith(':')) continue;
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice('data:'.length).trimStart());
+    }
+  }
+
+  if (dataLines.length === 0) return undefined;
+  const data = dataLines.join('\n').trim();
+  if (!data || data === '[DONE]') return undefined;
+
+  try {
+    return JSON.parse(data) as AnthropicStreamPayload;
+  } catch (err: any) {
+    throw new Error(`Invalid Anthropic stream payload: ${getDetailedErrorMessage(err)}`);
+  }
+}
+
+function toAnthropicMessages(messages: Message[]): {
+  system?: string;
+  messages: AnthropicMessage[];
+} {
+  const systemParts: string[] = [];
+  const anthropicMessages: AnthropicMessage[] = [];
+
+  for (const message of messages) {
+    const content = normalizeMessageContent(message.content);
+    if (message.role === 'system') {
+      if (content) systemParts.push(content);
+      continue;
+    }
+
+    if (message.role === 'tool') {
+      if (!message.toolCallId) {
+        throw new Error('Zero Anthropic provider requires toolCallId on tool result messages');
+      }
+      appendUserBlocks(anthropicMessages, [
+        {
+          type: 'tool_result',
+          tool_use_id: message.toolCallId,
+          content,
+        },
+      ]);
+      continue;
+    }
+
+    if (message.role === 'assistant') {
+      const blocks: AnthropicContentBlock[] = [];
+      if (content) blocks.push({ type: 'text', text: content });
+      for (const toolCall of message.toolCalls ?? []) {
+        blocks.push({
+          type: 'tool_use',
+          id: toolCall.id,
+          name: toolCall.name,
+          input: parseToolArguments(toolCall.arguments),
+        });
+      }
+      anthropicMessages.push({
+        role: 'assistant',
+        content: blocks.length === 1 && blocks[0]?.type === 'text'
+          ? blocks[0].text
+          : blocks,
+      });
+      continue;
+    }
+
+    appendUserText(anthropicMessages, content);
+  }
+
+  return {
+    system: systemParts.length > 0 ? systemParts.join('\n\n') : undefined,
+    messages: anthropicMessages,
+  };
+}
+
+function appendUserText(messages: AnthropicMessage[], text: string): void {
+  if (!text) return;
+  appendUserBlocks(messages, [{ type: 'text', text }]);
+}
+
+function appendUserBlocks(
+  messages: AnthropicMessage[],
+  blocks: AnthropicContentBlock[]
+): void {
+  const last = messages.at(-1);
+  if (last?.role === 'user') {
+    last.content = [...toContentBlocks(last.content), ...blocks];
+    return;
+  }
+  messages.push({ role: 'user', content: blocks });
+}
+
+function toContentBlocks(content: string | AnthropicContentBlock[]): AnthropicContentBlock[] {
+  return typeof content === 'string' ? [{ type: 'text', text: content }] : content;
+}
+
+function toAnthropicTools(tools: ToolDefinition[]): Array<Record<string, unknown>> {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters,
+  }));
+}
+
+function parseToolArguments(argumentsJson: string): Record<string, unknown> {
+  if (!argumentsJson) return {};
+  try {
+    const parsed = JSON.parse(argumentsJson);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return { input: parsed };
+  } catch {
+    return { input: argumentsJson };
+  }
+}
+
+function normalizeMessageContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  return String(content);
+}
+
+async function getResponseErrorMessage(response: Response): Promise<string> {
+  const body = await response.text().catch(() => '');
+  if (!body) return `${response.status} ${response.statusText}`.trim();
+
+  try {
+    const parsed = JSON.parse(body);
+    return parsed.error?.message || parsed.message || body;
+  } catch {
+    return body;
+  }
+}
+
+function getDetailedErrorMessage(err: any): string {
+  if (!err) return 'Unknown error';
+  if (err.message && !err.message.includes('Provider returned error')) return err.message;
+  if (err.error?.message) return err.error.message;
+  if (typeof err.error === 'string') return err.error;
+  if (err.cause?.message) return err.cause.message;
+  return err.message || String(err);
+}

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -82,7 +82,7 @@ export class AnthropicProvider implements Provider {
     this.apiKey = apiKey;
     this.baseURL = (baseURL || DEFAULT_ANTHROPIC_BASE_URL).replace(/\/+$/, '');
     this.model = model;
-    this.maxTokens = maxTokens;
+    this.maxTokens = normalizeMaxTokens(maxTokens);
     this.version = version;
     this.beta = beta;
     this.fetchImpl = fetchImpl;
@@ -278,15 +278,14 @@ async function* readAnthropicSSE(
   while (true) {
     const { value, done } = await reader.read();
     buffer += decoder.decode(value, { stream: !done });
-    buffer = buffer.replace(/\r\n/g, '\n');
 
-    let boundary = buffer.indexOf('\n\n');
-    while (boundary !== -1) {
-      const rawEvent = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
+    let boundary = findSSEBoundary(buffer);
+    while (boundary) {
+      const rawEvent = buffer.slice(0, boundary.index);
+      buffer = buffer.slice(boundary.index + boundary.length);
       const payload = parseAnthropicSSEPayload(rawEvent);
       if (payload) yield payload;
-      boundary = buffer.indexOf('\n\n');
+      boundary = findSSEBoundary(buffer);
     }
 
     if (done) break;
@@ -296,10 +295,19 @@ async function* readAnthropicSSE(
   if (trailingPayload) yield trailingPayload;
 }
 
+function findSSEBoundary(buffer: string): { index: number; length: number } | undefined {
+  const lfIndex = buffer.indexOf('\n\n');
+  const crlfIndex = buffer.indexOf('\r\n\r\n');
+  if (lfIndex === -1 && crlfIndex === -1) return undefined;
+  if (lfIndex === -1) return { index: crlfIndex, length: 4 };
+  if (crlfIndex === -1 || lfIndex < crlfIndex) return { index: lfIndex, length: 2 };
+  return { index: crlfIndex, length: 4 };
+}
+
 function parseAnthropicSSEPayload(rawEvent: string): AnthropicStreamPayload | undefined {
   const dataLines: string[] = [];
 
-  for (const line of rawEvent.split('\n')) {
+  for (const line of rawEvent.replace(/\r\n/g, '\n').split('\n')) {
     if (!line || line.startsWith(':')) continue;
     if (line.startsWith('data:')) {
       dataLines.push(line.slice('data:'.length).trimStart());
@@ -353,7 +361,7 @@ function toAnthropicMessages(messages: Message[]): {
           type: 'tool_use',
           id: toolCall.id,
           name: toolCall.name,
-          input: parseToolArguments(toolCall.arguments),
+          input: parseToolArguments(toolCall.arguments, toolCall.name),
         });
       }
       anthropicMessages.push({
@@ -403,17 +411,29 @@ function toAnthropicTools(tools: ToolDefinition[]): Array<Record<string, unknown
   }));
 }
 
-function parseToolArguments(argumentsJson: string): Record<string, unknown> {
+function parseToolArguments(argumentsJson: string, toolName: string): Record<string, unknown> {
   if (!argumentsJson) return {};
   try {
     const parsed = JSON.parse(argumentsJson);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>;
     }
-    return { input: parsed };
-  } catch {
-    return { input: argumentsJson };
+    throw new Error(
+      `Zero Anthropic provider requires tool arguments for ${toolName} to be a JSON object`
+    );
+  } catch (err: any) {
+    if (err?.message?.includes('JSON object')) throw err;
+    throw new Error(
+      `Zero Anthropic provider could not parse tool arguments for ${toolName} as JSON`
+    );
   }
+}
+
+function normalizeMaxTokens(maxTokens: number): number {
+  if (!Number.isFinite(maxTokens) || !Number.isInteger(maxTokens) || maxTokens < 1) {
+    throw new Error('Zero Anthropic provider maxTokens must be a positive integer');
+  }
+  return maxTokens;
 }
 
 function normalizeMessageContent(content: unknown): string {

--- a/src/zero-provider-runtime/index.ts
+++ b/src/zero-provider-runtime/index.ts
@@ -2,6 +2,7 @@ export {
   createZeroProvider,
   createZeroProviderFromInput,
   resolveZeroProviderRuntime,
+  ZeroPendingProviderError,
 } from './resolver';
 
 export type {

--- a/src/zero-provider-runtime/resolver.ts
+++ b/src/zero-provider-runtime/resolver.ts
@@ -24,6 +24,18 @@ const OFFICIAL_OPENAI_BASE_URLS = new Set([
   'https://api.openai.com',
 ]);
 
+const MIN_REGISTRY_ANTHROPIC_MAX_TOKENS = 8192;
+
+export class ZeroPendingProviderError extends Error {
+  constructor(readonly provider: ZeroProviderRuntimeKind) {
+    super(
+      `Zero ${provider} provider adapter is not implemented yet. ` +
+      'The provider resolver can identify the model, but the streaming adapter lands in a later M1 slice.'
+    );
+    this.name = 'ZeroPendingProviderError';
+  }
+}
+
 export function resolveZeroProviderRuntime(
   input: ZeroProviderRuntimeInput
 ): ZeroResolvedProviderRuntime {
@@ -99,13 +111,11 @@ export function createZeroProvider(
       apiKey: runtime.apiKey,
       baseURL: runtime.baseURL,
       model: runtime.apiModel,
+      maxTokens: resolveAnthropicMaxTokens(runtime),
     });
   }
 
-  throw new Error(
-    `Zero ${runtime.provider} provider adapter is not implemented yet. ` +
-    `The provider resolver can identify the model, but the streaming adapter lands in a later M1 slice.`
-  );
+  throw new ZeroPendingProviderError(runtime.provider);
 }
 
 export function createZeroProviderFromInput(
@@ -179,6 +189,14 @@ function ensureOpenAICompatibleGatewayBaseURL(baseURL: string | undefined): asse
       'Use provider: "openai" for the official OpenAI API.'
     );
   }
+}
+
+function resolveAnthropicMaxTokens(runtime: ZeroResolvedProviderRuntime): number | undefined {
+  if (!runtime.model) return undefined;
+  return Math.max(
+    runtime.model.context.maxOutputTokens,
+    MIN_REGISTRY_ANTHROPIC_MAX_TOKENS
+  );
 }
 
 function normalizeRequired(value: string, label: string): string {

--- a/src/zero-provider-runtime/resolver.ts
+++ b/src/zero-provider-runtime/resolver.ts
@@ -1,4 +1,5 @@
 import { OpenAIProvider } from '../providers/openai';
+import { AnthropicProvider } from '../providers/anthropic';
 import type { Provider } from '../providers/types';
 import {
   getZeroModel,
@@ -84,6 +85,18 @@ export function createZeroProvider(
 
     return new OpenAIProvider({
       apiKey: runtime.apiKey || 'zero-openai-compatible',
+      baseURL: runtime.baseURL,
+      model: runtime.apiModel,
+    });
+  }
+
+  if (runtime.provider === 'anthropic') {
+    if (!runtime.apiKey) {
+      throw new Error('Zero anthropic provider requires an API key');
+    }
+
+    return new AnthropicProvider({
+      apiKey: runtime.apiKey,
       baseURL: runtime.baseURL,
       model: runtime.apiModel,
     });

--- a/tests/anthropic-provider.test.ts
+++ b/tests/anthropic-provider.test.ts
@@ -11,6 +11,7 @@ describe('AnthropicProvider', () => {
     const provider = new AnthropicProvider({
       apiKey: 'test-anthropic-key',
       model: 'claude-sonnet-4-5-20250929',
+      maxTokens: 64000,
       fetchImpl: async (url, init) => {
         capturedUrl = String(url);
         capturedBody = JSON.parse(String(init?.body));
@@ -60,7 +61,7 @@ describe('AnthropicProvider', () => {
     expect(capturedHeaders?.get('anthropic-version')).toBe('2023-06-01');
     expect(capturedBody).toEqual({
       model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 4096,
+      max_tokens: 64000,
       stream: true,
       system: 'You are Zero.',
       messages: [
@@ -205,6 +206,53 @@ describe('AnthropicProvider', () => {
     ]);
   });
 
+  it('normalizes multiple Anthropic tool-use blocks in the same response', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([
+        event('content_block_start', {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_1', name: 'read_file', input: {} },
+        }),
+        event('content_block_start', {
+          type: 'content_block_start',
+          index: 1,
+          content_block: { type: 'tool_use', id: 'toolu_2', name: 'grep', input: {} },
+        }),
+        event('content_block_delta', {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'input_json_delta', partial_json: '{"path":"a.ts"}' },
+        }),
+        event('content_block_delta', {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"pattern":"Zero"}' },
+        }),
+        event('content_block_stop', { type: 'content_block_stop', index: 0 }),
+        event('content_block_stop', { type: 'content_block_stop', index: 1 }),
+        event('message_stop', { type: 'message_stop' }),
+      ]),
+    });
+
+    const events = await collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'read and grep' }],
+      []
+    ));
+
+    expect(events).toEqual([
+      { type: 'tool-call-start', id: 'toolu_1', name: 'read_file' },
+      { type: 'tool-call-start', id: 'toolu_2', name: 'grep' },
+      { type: 'tool-call-delta', id: 'toolu_1', argumentsFragment: '{"path":"a.ts"}' },
+      { type: 'tool-call-delta', id: 'toolu_2', argumentsFragment: '{"pattern":"Zero"}' },
+      { type: 'tool-call-end', id: 'toolu_1' },
+      { type: 'tool-call-end', id: 'toolu_2' },
+      { type: 'done' },
+    ]);
+  });
+
   it('surfaces Anthropic HTTP authentication errors with provider context', async () => {
     const provider = new AnthropicProvider({
       apiKey: 'bad-key',
@@ -219,6 +267,94 @@ describe('AnthropicProvider', () => {
       [{ role: 'user', content: 'hello' }],
       []
     ))).rejects.toThrow('Provider authentication error');
+  });
+
+  it('surfaces Anthropic HTTP rate limit errors with provider context', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
+          status: 429,
+        }),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ))).rejects.toThrow('Provider rate limit error');
+  });
+
+  it('surfaces Anthropic stream error events with provider context', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([
+        event('error', {
+          type: 'error',
+          error: { type: 'overloaded_error', message: 'server overloaded' },
+        }),
+      ]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ))).rejects.toThrow('server overloaded');
+  });
+
+  it('rejects Anthropic calls without a non-system message', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'system', content: 'Only system.' }],
+      []
+    ))).rejects.toThrow('requires at least one non-system message');
+  });
+
+  it('rejects tool results without a toolCallId before dispatch', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'tool', content: 'missing id' }],
+      []
+    ))).rejects.toThrow('requires toolCallId');
+  });
+
+  it('rejects assistant tool calls whose arguments are not JSON objects', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [
+        { role: 'user', content: 'call tool' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{ id: 'toolu_1', name: 'read_file', arguments: '"src/index.ts"' }],
+        },
+      ],
+      []
+    ))).rejects.toThrow('requires tool arguments for read_file to be a JSON object');
+  });
+
+  it('validates maxTokens before dispatch', async () => {
+    expect(() => new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      maxTokens: 0,
+    })).toThrow('maxTokens must be a positive integer');
   });
 });
 

--- a/tests/anthropic-provider.test.ts
+++ b/tests/anthropic-provider.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'bun:test';
+import { AnthropicProvider } from '../src/providers/anthropic';
+import type { Message, StreamEvent, ToolDefinition } from '../src/providers/types';
+
+describe('AnthropicProvider', () => {
+  it('maps Zero messages, system prompts, and tools to the Anthropic Messages API', async () => {
+    let capturedUrl = '';
+    let capturedBody: any;
+    let capturedHeaders: Headers | undefined;
+
+    const provider = new AnthropicProvider({
+      apiKey: 'test-anthropic-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: async (url, init) => {
+        capturedUrl = String(url);
+        capturedBody = JSON.parse(String(init?.body));
+        capturedHeaders = new Headers(init?.headers);
+        return streamResponse([
+          event('message_start', {
+            type: 'message_start',
+            message: { usage: { input_tokens: 3, output_tokens: 1 } },
+          }),
+          event('message_stop', { type: 'message_stop' }),
+        ]);
+      },
+    });
+
+    const messages: Message[] = [
+      { role: 'system', content: 'You are Zero.' },
+      { role: 'user', content: 'Read the file.' },
+      {
+        role: 'assistant',
+        content: 'I will inspect it.',
+        toolCalls: [
+          {
+            id: 'toolu_1',
+            name: 'read_file',
+            arguments: '{"path":"src/index.ts"}',
+          },
+        ],
+      },
+      { role: 'tool', toolCallId: 'toolu_1', content: 'file contents' },
+    ];
+    const tools: ToolDefinition[] = [
+      {
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      },
+    ];
+
+    await collectEvents(provider.streamCompletion(messages, tools));
+
+    expect(capturedUrl).toBe('https://api.anthropic.com/v1/messages');
+    expect(capturedHeaders?.get('x-api-key')).toBe('test-anthropic-key');
+    expect(capturedHeaders?.get('anthropic-version')).toBe('2023-06-01');
+    expect(capturedBody).toEqual({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 4096,
+      stream: true,
+      system: 'You are Zero.',
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Read the file.' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'I will inspect it.' },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'read_file',
+              input: { path: 'src/index.ts' },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_1',
+              content: 'file contents',
+            },
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: 'read_file',
+          description: 'Read a file',
+          input_schema: {
+            type: 'object',
+            properties: { path: { type: 'string' } },
+            required: ['path'],
+          },
+        },
+      ],
+    });
+  });
+
+  it('normalizes Anthropic text and usage stream events', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([
+        event('message_start', {
+          type: 'message_start',
+          message: { usage: { input_tokens: 25, output_tokens: 1 } },
+        }),
+        event('content_block_start', {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text', text: '' },
+        }),
+        event('content_block_delta', {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'Hello' },
+        }),
+        event('content_block_delta', {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: ' Zero' },
+        }),
+        event('message_delta', {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn' },
+          usage: { output_tokens: 15 },
+        }),
+        event('message_stop', { type: 'message_stop' }),
+      ]),
+    });
+
+    const events = await collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ));
+
+    expect(events).toEqual([
+      { type: 'text', content: 'Hello' },
+      { type: 'text', content: ' Zero' },
+      { type: 'usage', promptTokens: 25, completionTokens: 15 },
+      { type: 'done' },
+    ]);
+  });
+
+  it('normalizes Anthropic tool-use blocks and partial JSON input deltas', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: createFetch([
+        event('message_start', {
+          type: 'message_start',
+          message: { usage: { input_tokens: 30, output_tokens: 2 } },
+        }),
+        event('content_block_start', {
+          type: 'content_block_start',
+          index: 1,
+          content_block: {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'read_file',
+            input: {},
+          },
+        }),
+        event('content_block_delta', {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '{"path":' },
+        }),
+        event('content_block_delta', {
+          type: 'content_block_delta',
+          index: 1,
+          delta: { type: 'input_json_delta', partial_json: '"src/index.ts"}' },
+        }),
+        event('content_block_stop', { type: 'content_block_stop', index: 1 }),
+        event('message_delta', {
+          type: 'message_delta',
+          delta: { stop_reason: 'tool_use' },
+          usage: { output_tokens: 42 },
+        }),
+        event('message_stop', { type: 'message_stop' }),
+      ]),
+    });
+
+    const events = await collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'read file' }],
+      []
+    ));
+
+    expect(events).toEqual([
+      { type: 'tool-call-start', id: 'toolu_1', name: 'read_file' },
+      { type: 'tool-call-delta', id: 'toolu_1', argumentsFragment: '{"path":' },
+      { type: 'tool-call-delta', id: 'toolu_1', argumentsFragment: '"src/index.ts"}' },
+      { type: 'tool-call-end', id: 'toolu_1' },
+      { type: 'usage', promptTokens: 30, completionTokens: 42 },
+      { type: 'done' },
+    ]);
+  });
+
+  it('surfaces Anthropic HTTP authentication errors with provider context', async () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'bad-key',
+      model: 'claude-sonnet-4-5-20250929',
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: { message: 'invalid x-api-key' } }), {
+          status: 401,
+        }),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ))).rejects.toThrow('Provider authentication error');
+  });
+});
+
+function createFetch(events: string[]) {
+  return async () => streamResponse(events);
+}
+
+function streamResponse(events: string[]): Response {
+  return new Response(events.join(''), {
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function event(name: string, data: Record<string, unknown>): string {
+  return `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function collectEvents(stream: AsyncIterable<StreamEvent>): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}

--- a/tests/zero-provider-runtime.test.ts
+++ b/tests/zero-provider-runtime.test.ts
@@ -113,7 +113,7 @@ describe('resolveZeroProviderRuntime', () => {
     ).toThrow('Unknown Zero model');
   });
 
-  it('creates implemented OpenAI-compatible providers and rejects pending adapters', () => {
+  it('creates implemented OpenAI-compatible and Anthropic providers', () => {
     const openAI = resolveZeroProviderRuntime({
       provider: 'openai-compatible',
       model: 'local-coder',
@@ -123,9 +123,29 @@ describe('resolveZeroProviderRuntime', () => {
 
     const anthropic = resolveZeroProviderRuntime({
       model: 'sonnet-4.5',
+      apiKey: 'test-anthropic-key',
     });
+    expect(createZeroProvider(anthropic)).toBeDefined();
+  });
+
+  it('requires an API key for the official Anthropic runtime', () => {
+    const anthropic = resolveZeroProviderRuntime({
+      model: 'sonnet-4.5',
+    });
+
     expect(() => createZeroProvider(anthropic)).toThrow(
-      'anthropic provider adapter is not implemented yet'
+      'anthropic provider requires an API key'
+    );
+  });
+
+  it('still rejects pending official Google adapters', () => {
+    const google = resolveZeroProviderRuntime({
+      model: 'gemini-flash',
+      apiKey: 'test-google-key',
+    });
+
+    expect(() => createZeroProvider(google)).toThrow(
+      'google provider adapter is not implemented yet'
     );
   });
 

--- a/tests/zero-provider-runtime.test.ts
+++ b/tests/zero-provider-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   createZeroProvider,
   resolveZeroProviderRuntime,
+  ZeroPendingProviderError,
 } from '../src/zero-provider-runtime';
 
 describe('resolveZeroProviderRuntime', () => {
@@ -125,7 +126,9 @@ describe('resolveZeroProviderRuntime', () => {
       model: 'sonnet-4.5',
       apiKey: 'test-anthropic-key',
     });
-    expect(createZeroProvider(anthropic)).toBeDefined();
+    const provider = createZeroProvider(anthropic);
+    expect(provider).toBeDefined();
+    expect((provider as any).maxTokens).toBe(64000);
   });
 
   it('requires an API key for the official Anthropic runtime', () => {
@@ -144,9 +147,7 @@ describe('resolveZeroProviderRuntime', () => {
       apiKey: 'test-google-key',
     });
 
-    expect(() => createZeroProvider(google)).toThrow(
-      'google provider adapter is not implemented yet'
-    );
+    expect(() => createZeroProvider(google)).toThrow(ZeroPendingProviderError);
   });
 
   it('creates OpenAI-compatible providers without an API key for custom gateways', () => {


### PR DESCRIPTION
## Summary

Adds the Zero Anthropic provider module for the M1 provider-runtime slice.

- Adds `src/providers/anthropic.ts`, a Zero-native TypeScript adapter for Anthropic Messages streaming.
- Converts Zero normalized messages into Anthropic request shape:
  - top-level `system`
  - `user` / `assistant` message turns
  - assistant `tool_use` blocks
  - user `tool_result` blocks
  - Zero tool definitions mapped to Anthropic `input_schema`
- Normalizes Anthropic SSE events back into Zero `StreamEvent`s:
  - `text_delta` -> `text`
  - `tool_use` block start -> `tool-call-start`
  - `input_json_delta` -> `tool-call-delta`
  - `content_block_stop` -> `tool-call-end`
  - `message_start` / `message_delta` / `message_stop` -> usage + done handling
- Wires `createZeroProvider` so Anthropic registry models now instantiate the Anthropic adapter with API-key validation.
- Keeps Google as the only pending official provider adapter in this M1 area.

## Drac Reference Map

Used the Drac reverse-engineered source as behavioral reference, then rewrote the module cleanly in TypeScript for Zero:

- `by-function/llm-api/claude-api-50.js`
  - Anthropic event-state handling for `message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, and `message_stop`.
  - Tool-use indexing and streamed partial JSON buffering.
  - Input/output usage tracking.
- `by-function/llm-api/message-handler.js`
  - Anthropic Messages stream invocation shape.
- `app/llm/anthropic/OYA.js`
  - Provider routing reference for Anthropic as a first-class model provider.

## Validation

- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
  - 100 pass
  - 0 fail
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero providers current`
- `git diff --check origin/main..HEAD`

## Reviewers

@vasanthdev2004 @anandh8x please review this provider module.
