### PR TITLE
feat: add M2 update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bun run package:release
 Check for released CLI updates:
 
 ```bash
-bun run src/index.ts update --check
+./zero update --check
 ```
 
 Bun version is pinned in `package.json`.

--- a/README.md
+++ b/README.md
@@ -22,4 +22,10 @@ bun run smoke:build
 bun run package:release
 ```
 
+Check for released CLI updates:
+
+```bash
+bun run src/index.ts update --check
+```
+
 Bun version is pinned in `package.json`.

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -1,0 +1,12 @@
+# Zero Update Flow
+
+`zero update --check` checks the latest GitHub release for `Gitlawb/zero` and compares it with the local CLI version.
+
+For M2 this command is intentionally check-only:
+
+- It does not replace the running binary.
+- It exits with code `0` when the check succeeds, even when an update is available.
+- It exits with code `1` when the release check cannot be completed.
+- `--json` prints the same result in a machine-readable format for scripts and CI.
+
+Installer scripts should use this command before downloading the matching release asset for the local platform.

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -8,5 +8,14 @@ For M2 this command is intentionally check-only:
 - It exits with code `0` when the check succeeds, even when an update is available.
 - It exits with code `1` when the release check cannot be completed.
 - `--json` prints the same result in a machine-readable format for scripts and CI.
+- Release checks time out after 5 seconds by default.
+
+The release endpoint resolves in this order:
+
+- `options.endpoint` when calling `checkForUpdate` from code.
+- `ZERO_UPDATE_RELEASE_URL` from the environment.
+- `https://api.github.com/repos/Gitlawb/zero/releases/latest`.
+
+`options.endpoint` and `ZERO_UPDATE_RELEASE_URL` may be a full URL or an `owner/repo` slug.
 
 Installer scripts should use this command before downloading the matching release asset for the local platform.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,14 @@ import { Command } from 'commander';
 import { runHeadless } from './cli';
 import { configManager } from './config/manager';
 import { startTUI } from './tui';
-import { checkForUpdate, formatUpdateCheck } from './update/check';
+import { DEFAULT_UPDATE_CHECK_TIMEOUT_MS, checkForUpdate, formatUpdateCheck } from './update/check';
 import { ZERO_VERSION } from './version';
 
 const program = new Command();
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 program
   .name('zero')
@@ -91,15 +95,15 @@ program
     }
 
     try {
-      const result = await checkForUpdate();
+      const result = await checkForUpdate({ timeoutMs: DEFAULT_UPDATE_CHECK_TIMEOUT_MS });
 
       if (options.json) {
         console.log(JSON.stringify(result, null, 2));
       } else {
         console.log(formatUpdateCheck(result));
       }
-    } catch (err: any) {
-      console.error(`[zero] Could not check for updates: ${err?.message ?? String(err)}`);
+    } catch (err: unknown) {
+      console.error(`[zero] Could not check for updates: ${getErrorMessage(err)}`);
       process.exitCode = 1;
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,15 @@ import { Command } from 'commander';
 import { runHeadless } from './cli';
 import { configManager } from './config/manager';
 import { startTUI } from './tui';
+import { checkForUpdate, formatUpdateCheck } from './update/check';
+import { ZERO_VERSION } from './version';
 
 const program = new Command();
 
 program
   .name('zero')
   .description('A clean terminal AI coding agent')
-  .version('0.1.0');
+  .version(ZERO_VERSION);
 
 program
   .option('-p, --prompt <prompt>', 'Run in headless mode with the given prompt')
@@ -76,4 +78,30 @@ providersCmd
     }
   });
 
-program.parse();
+program
+  .command('update')
+  .description('Check for Zero CLI updates')
+  .option('--check', 'Check the latest GitHub release without installing')
+  .option('--json', 'Print the update check result as JSON')
+  .action(async (options: { check?: boolean; json?: boolean }) => {
+    if (!options.check) {
+      console.error('Only `zero update --check` is available right now.');
+      process.exitCode = 1;
+      return;
+    }
+
+    try {
+      const result = await checkForUpdate();
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatUpdateCheck(result));
+      }
+    } catch (err: any) {
+      console.error(`[zero] Could not check for updates: ${err?.message ?? String(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+await program.parseAsync();

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -1,0 +1,123 @@
+import { ZERO_RELEASE_REPOSITORY, ZERO_VERSION } from '../version';
+
+type FetchResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+};
+
+export type UpdateFetch = (
+  url: string,
+  init?: {
+    headers?: Record<string, string>;
+  }
+) => Promise<FetchResponse>;
+
+export type UpdateCheckResult = {
+  currentVersion: string;
+  latestVersion: string;
+  releaseUrl: string;
+  tagName: string;
+  updateAvailable: boolean;
+};
+
+export type UpdateCheckOptions = {
+  currentVersion?: string;
+  endpoint?: string;
+  fetch?: UpdateFetch;
+  repository?: string;
+};
+
+type Semver = [major: number, minor: number, patch: number];
+
+function getDefaultEndpoint(repository: string): string {
+  return `https://api.github.com/repos/${repository}/releases/latest`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function normalizeVersionTag(version: string): string {
+  const trimmed = version.trim();
+  const match = trimmed.match(/^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${version}`);
+  }
+
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+}
+
+function parseSemver(version: string): Semver {
+  const normalized = normalizeVersionTag(version);
+  const parts = normalized.split('.').map(part => Number(part));
+
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+export function compareSemver(left: string, right: string): number {
+  const leftParts = parseSemver(left);
+  const rightParts = parseSemver(right);
+
+  return (
+    leftParts[0] - rightParts[0] ||
+    leftParts[1] - rightParts[1] ||
+    leftParts[2] - rightParts[2]
+  );
+}
+
+export async function checkForUpdate(options: UpdateCheckOptions = {}): Promise<UpdateCheckResult> {
+  const currentVersion = normalizeVersionTag(options.currentVersion ?? ZERO_VERSION);
+  const repository = options.repository ?? ZERO_RELEASE_REPOSITORY;
+  const endpoint = options.endpoint ?? process.env.ZERO_UPDATE_RELEASE_URL ?? getDefaultEndpoint(repository);
+  const fetchRelease = options.fetch ?? (globalThis.fetch as unknown as UpdateFetch);
+
+  const response = await fetchRelease(endpoint, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': `zero/${currentVersion}`,
+    },
+  });
+
+  if (!response.ok) {
+    const status = response.statusText ? `${response.status} ${response.statusText}` : `${response.status}`;
+    throw new Error(`GitHub release check failed (${status})`);
+  }
+
+  const body = await response.json();
+
+  if (!isRecord(body) || typeof body.tag_name !== 'string') {
+    throw new Error('GitHub release response did not include a tag_name');
+  }
+
+  const tagName = body.tag_name;
+  const latestVersion = normalizeVersionTag(tagName);
+  const releaseUrl = typeof body.html_url === 'string'
+    ? body.html_url
+    : `https://github.com/${repository}/releases/tag/${tagName}`;
+
+  return {
+    currentVersion,
+    latestVersion,
+    releaseUrl,
+    tagName,
+    updateAvailable: compareSemver(latestVersion, currentVersion) > 0,
+  };
+}
+
+export function formatUpdateCheck(result: UpdateCheckResult): string {
+  if (result.updateAvailable) {
+    return [
+      `[zero] Update available: ${result.currentVersion} -> ${result.latestVersion}`,
+      `Release: ${result.releaseUrl}`,
+      'Download the matching release asset for your platform, then replace the current zero binary.',
+    ].join('\n');
+  }
+
+  return [
+    `[zero] zero is up to date (${result.currentVersion})`,
+    `Latest release: ${result.releaseUrl}`,
+  ].join('\n');
+}

--- a/src/update/check.ts
+++ b/src/update/check.ts
@@ -1,5 +1,7 @@
 import { ZERO_RELEASE_REPOSITORY, ZERO_VERSION } from '../version';
 
+export const DEFAULT_UPDATE_CHECK_TIMEOUT_MS = 5000;
+
 type FetchResponse = {
   ok: boolean;
   status: number;
@@ -11,6 +13,7 @@ export type UpdateFetch = (
   url: string,
   init?: {
     headers?: Record<string, string>;
+    signal?: AbortSignal;
   }
 ) => Promise<FetchResponse>;
 
@@ -27,16 +30,51 @@ export type UpdateCheckOptions = {
   endpoint?: string;
   fetch?: UpdateFetch;
   repository?: string;
+  timeoutMs?: number;
 };
 
 type Semver = [major: number, minor: number, patch: number];
 
-function getDefaultEndpoint(repository: string): string {
+export function getReleaseEndpoint(repository: string): string {
   return `https://api.github.com/repos/${repository}/releases/latest`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isRepositorySlug(value: string): boolean {
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value);
+}
+
+export function resolveReleaseEndpoint(endpointOrRepository: string | undefined, repository: string): string {
+  const value = endpointOrRepository?.trim();
+
+  if (!value) {
+    return getReleaseEndpoint(repository);
+  }
+
+  if (isRepositorySlug(value)) {
+    return getReleaseEndpoint(value);
+  }
+
+  try {
+    new URL(value);
+  } catch {
+    throw new Error(
+      `Invalid update endpoint "${value}". Use a full URL or an owner/repo slug like ${repository}.`
+    );
+  }
+
+  return value;
+}
+
+function createTimeoutSignal(timeoutMs: number | undefined): AbortSignal | undefined {
+  if (timeoutMs === undefined || timeoutMs <= 0) {
+    return undefined;
+  }
+
+  return AbortSignal.timeout(timeoutMs);
 }
 
 export function normalizeVersionTag(version: string): string {
@@ -71,14 +109,16 @@ export function compareSemver(left: string, right: string): number {
 export async function checkForUpdate(options: UpdateCheckOptions = {}): Promise<UpdateCheckResult> {
   const currentVersion = normalizeVersionTag(options.currentVersion ?? ZERO_VERSION);
   const repository = options.repository ?? ZERO_RELEASE_REPOSITORY;
-  const endpoint = options.endpoint ?? process.env.ZERO_UPDATE_RELEASE_URL ?? getDefaultEndpoint(repository);
+  const endpoint = resolveReleaseEndpoint(options.endpoint ?? process.env.ZERO_UPDATE_RELEASE_URL, repository);
   const fetchRelease = options.fetch ?? (globalThis.fetch as unknown as UpdateFetch);
+  const signal = createTimeoutSignal(options.timeoutMs ?? DEFAULT_UPDATE_CHECK_TIMEOUT_MS);
 
   const response = await fetchRelease(endpoint, {
     headers: {
       Accept: 'application/vnd.github+json',
       'User-Agent': `zero/${currentVersion}`,
     },
+    signal,
   });
 
   if (!response.ok) {
@@ -117,7 +157,7 @@ export function formatUpdateCheck(result: UpdateCheckResult): string {
   }
 
   return [
-    `[zero] zero is up to date (${result.currentVersion})`,
+    `[zero] up to date (${result.currentVersion})`,
     `Latest release: ${result.releaseUrl}`,
   ].join('\n');
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,5 @@
-export const ZERO_VERSION = '0.1.0';
+import pkg from '../package.json' with { type: 'json' };
+
+export const ZERO_VERSION = pkg.version;
 
 export const ZERO_RELEASE_REPOSITORY = 'Gitlawb/zero';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+export const ZERO_VERSION = '0.1.0';
+
+export const ZERO_RELEASE_REPOSITORY = 'Gitlawb/zero';

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it } from 'bun:test';
 
+type ReleasePayload = {
+  tag_name: string;
+  html_url: string;
+};
+
+async function packageVersion(): Promise<string> {
+  const packageJson = await Bun.file('package.json').json() as { version: string };
+  return packageJson.version;
+}
+
+function nextPatchVersion(version: string): string {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+
+  if (!match) {
+    throw new Error(`Invalid package version: ${version}`);
+  }
+
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3]) + 1}`;
+}
+
+function releaseEndpoint(payload: ReleasePayload): string {
+  return `data:application/json,${encodeURIComponent(JSON.stringify(payload))}`;
+}
+
 describe('zero --version', () => {
   it('prints the package version', async () => {
-    const packageJson = await Bun.file('package.json').json() as { version: string };
+    const version = await packageVersion();
     const child = Bun.spawn([process.execPath, 'src/index.ts', '--version'], {
       stderr: 'pipe',
       stdout: 'pipe',
@@ -16,20 +40,21 @@ describe('zero --version', () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe('');
-    expect(stdout.trim()).toBe(packageJson.version);
+    expect(stdout.trim()).toBe(version);
   });
 });
 
 describe('zero update --check', () => {
   it('prints the latest release status from the configured endpoint', async () => {
-    const release = encodeURIComponent(JSON.stringify({
-      tag_name: 'v0.2.0',
-      html_url: 'https://github.com/Gitlawb/zero/releases/tag/v0.2.0',
-    }));
+    const currentVersion = await packageVersion();
+    const latestVersion = nextPatchVersion(currentVersion);
     const child = Bun.spawn([process.execPath, 'src/index.ts', 'update', '--check'], {
       env: {
         ...process.env,
-        ZERO_UPDATE_RELEASE_URL: `data:application/json,${release}`,
+        ZERO_UPDATE_RELEASE_URL: releaseEndpoint({
+          tag_name: `v${latestVersion}`,
+          html_url: `https://github.com/Gitlawb/zero/releases/tag/v${latestVersion}`,
+        }),
       },
       stderr: 'pipe',
       stdout: 'pipe',
@@ -43,6 +68,34 @@ describe('zero update --check', () => {
 
     expect(exitCode).toBe(0);
     expect(stderr.trim()).toBe('');
-    expect(stdout).toContain('Update available: 0.1.0 -> 0.2.0');
+    expect(stdout).toContain(`Update available: ${currentVersion} -> ${latestVersion}`);
+  });
+
+  it('prints JSON output for automation', async () => {
+    const currentVersion = await packageVersion();
+    const child = Bun.spawn([process.execPath, 'src/index.ts', 'update', '--check', '--json'], {
+      env: {
+        ...process.env,
+        ZERO_UPDATE_RELEASE_URL: releaseEndpoint({
+          tag_name: `v${currentVersion}`,
+          html_url: `https://github.com/Gitlawb/zero/releases/tag/v${currentVersion}`,
+        }),
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    const parsed = JSON.parse(stdout) as { currentVersion: string; updateAvailable: boolean };
+
+    expect(exitCode).toBe(0);
+    expect(stderr.trim()).toBe('');
+    expect(parsed.currentVersion).toBe(currentVersion);
+    expect(parsed.updateAvailable).toBe(false);
   });
 });

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -19,3 +19,30 @@ describe('zero --version', () => {
     expect(stdout.trim()).toBe(packageJson.version);
   });
 });
+
+describe('zero update --check', () => {
+  it('prints the latest release status from the configured endpoint', async () => {
+    const release = encodeURIComponent(JSON.stringify({
+      tag_name: 'v0.2.0',
+      html_url: 'https://github.com/Gitlawb/zero/releases/tag/v0.2.0',
+    }));
+    const child = Bun.spawn([process.execPath, 'src/index.ts', 'update', '--check'], {
+      env: {
+        ...process.env,
+        ZERO_UPDATE_RELEASE_URL: `data:application/json,${release}`,
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr.trim()).toBe('');
+    expect(stdout).toContain('Update available: 0.1.0 -> 0.2.0');
+  });
+});

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  checkForUpdate,
+  compareSemver,
+  formatUpdateCheck,
+  normalizeVersionTag,
+  type UpdateFetch,
+} from '../src/update/check';
+
+function releaseFetch(body: unknown): UpdateFetch {
+  return async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  });
+}
+
+describe('update version helpers', () => {
+  it('normalizes GitHub release tags into semantic versions', () => {
+    expect(normalizeVersionTag('v0.2.0')).toBe('0.2.0');
+    expect(normalizeVersionTag('0.2.0')).toBe('0.2.0');
+    expect(normalizeVersionTag('v1.2.3+build.4')).toBe('1.2.3');
+  });
+
+  it('compares semantic versions by major, minor, and patch', () => {
+    expect(compareSemver('0.2.0', '0.1.9')).toBeGreaterThan(0);
+    expect(compareSemver('1.0.0', '0.99.99')).toBeGreaterThan(0);
+    expect(compareSemver('0.1.1', '0.1.2')).toBeLessThan(0);
+    expect(compareSemver('v0.1.0', '0.1.0')).toBe(0);
+  });
+});
+
+describe('checkForUpdate', () => {
+  it('reports an available update from the latest release', async () => {
+    const result = await checkForUpdate({
+      currentVersion: '0.1.0',
+      fetch: releaseFetch({
+        tag_name: 'v0.2.0',
+        html_url: 'https://github.com/Gitlawb/zero/releases/tag/v0.2.0',
+      }),
+    });
+
+    expect(result).toEqual({
+      currentVersion: '0.1.0',
+      latestVersion: '0.2.0',
+      releaseUrl: 'https://github.com/Gitlawb/zero/releases/tag/v0.2.0',
+      tagName: 'v0.2.0',
+      updateAvailable: true,
+    });
+  });
+
+  it('reports up to date when the latest release matches the current version', async () => {
+    const result = await checkForUpdate({
+      currentVersion: '0.2.0',
+      fetch: releaseFetch({
+        tag_name: 'v0.2.0',
+        html_url: 'https://github.com/Gitlawb/zero/releases/tag/v0.2.0',
+      }),
+    });
+
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  it('throws on malformed release payloads', async () => {
+    await expect(checkForUpdate({
+      fetch: releaseFetch({ name: 'Zero 0.2.0' }),
+    })).rejects.toThrow('tag_name');
+  });
+
+  it('formats human-readable update output', () => {
+    expect(formatUpdateCheck({
+      currentVersion: '0.1.0',
+      latestVersion: '0.2.0',
+      releaseUrl: 'https://github.com/Gitlawb/zero/releases/tag/v0.2.0',
+      tagName: 'v0.2.0',
+      updateAvailable: true,
+    })).toContain('Update available: 0.1.0 -> 0.2.0');
+  });
+});

--- a/tests/update-check.test.ts
+++ b/tests/update-check.test.ts
@@ -1,22 +1,36 @@
 import { describe, expect, it } from 'bun:test';
+import pkg from '../package.json' with { type: 'json' };
 import {
   checkForUpdate,
   compareSemver,
   formatUpdateCheck,
+  getReleaseEndpoint,
   normalizeVersionTag,
+  resolveReleaseEndpoint,
   type UpdateFetch,
 } from '../src/update/check';
+import { ZERO_VERSION } from '../src/version';
 
-function releaseFetch(body: unknown): UpdateFetch {
-  return async () => ({
-    ok: true,
-    status: 200,
-    statusText: 'OK',
-    json: async () => body,
-  });
+function releaseFetch(
+  body: unknown,
+  onRequest?: (url: string, init?: Parameters<UpdateFetch>[1]) => void
+): UpdateFetch {
+  return async (url, init) => {
+    onRequest?.(url, init);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => body,
+    };
+  };
 }
 
 describe('update version helpers', () => {
+  it('uses package.json as the CLI version source of truth', () => {
+    expect(ZERO_VERSION).toBe(pkg.version);
+  });
+
   it('normalizes GitHub release tags into semantic versions', () => {
     expect(normalizeVersionTag('v0.2.0')).toBe('0.2.0');
     expect(normalizeVersionTag('0.2.0')).toBe('0.2.0');
@@ -76,5 +90,60 @@ describe('checkForUpdate', () => {
       tagName: 'v0.2.0',
       updateAvailable: true,
     })).toContain('Update available: 0.1.0 -> 0.2.0');
+  });
+
+  it('passes an abort signal to fetch when timeoutMs is enabled', async () => {
+    let signal: AbortSignal | undefined;
+
+    await checkForUpdate({
+      currentVersion: '0.1.0',
+      timeoutMs: 5000,
+      fetch: releaseFetch({
+        tag_name: 'v0.1.0',
+        html_url: 'https://github.com/Gitlawb/zero/releases/tag/v0.1.0',
+      }, (_url, init) => {
+        signal = init?.signal;
+      }),
+    });
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+  });
+
+  it('resolves update endpoint precedence and owner/repo slugs', async () => {
+    const previous = process.env.ZERO_UPDATE_RELEASE_URL;
+    const urls: string[] = [];
+    const fetch = releaseFetch({
+      tag_name: 'v0.1.0',
+      html_url: 'https://github.com/Gitlawb/zero/releases/tag/v0.1.0',
+    }, (url) => {
+      urls.push(url);
+    });
+
+    try {
+      process.env.ZERO_UPDATE_RELEASE_URL = 'Gitlawb/env-zero';
+
+      await checkForUpdate({ endpoint: 'Gitlawb/option-zero', fetch, timeoutMs: 0 });
+      expect(urls.pop()).toBe(getReleaseEndpoint('Gitlawb/option-zero'));
+
+      await checkForUpdate({ repository: 'Gitlawb/repo-zero', fetch, timeoutMs: 0 });
+      expect(urls.pop()).toBe(getReleaseEndpoint('Gitlawb/env-zero'));
+
+      delete process.env.ZERO_UPDATE_RELEASE_URL;
+      await checkForUpdate({ repository: 'Gitlawb/repo-zero', fetch, timeoutMs: 0 });
+      expect(urls.pop()).toBe(getReleaseEndpoint('Gitlawb/repo-zero'));
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ZERO_UPDATE_RELEASE_URL;
+      } else {
+        process.env.ZERO_UPDATE_RELEASE_URL = previous;
+      }
+    }
+  });
+
+  it('accepts full endpoint URLs and rejects invalid endpoint values', () => {
+    expect(resolveReleaseEndpoint('https://example.test/latest', 'Gitlawb/zero')).toBe('https://example.test/latest');
+    expect(resolveReleaseEndpoint('Gitlawb/zero', 'Fallback/repo')).toBe(getReleaseEndpoint('Gitlawb/zero'));
+    expect(() => resolveReleaseEndpoint('not-a-url', 'Gitlawb/zero')).toThrow('Invalid update endpoint');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
 


### PR DESCRIPTION
## Summary
- add zero update --check for latest GitHub release comparison
- add JSON output for automation and docs for the M2 check-only update flow
- centralize the CLI version constant used by commander and update checks

## Validation
- bun test
- bun run typecheck
- bun run build
- bun run smoke:build
- bun run package:release
- compiled ./zero update --check --json with a stubbed release endpoint