### PR TITLE
[codex] add m1 headless exec surface

### DIFF
--- a/docs/M1_HEADLESS_EXEC_PRD.md
+++ b/docs/M1_HEADLESS_EXEC_PRD.md
@@ -1,0 +1,87 @@
+# M1 Headless Exec PRD
+
+Status: Draft
+Owner: Vasanth
+Milestone: M1
+Scope: `zero exec` CLI surface
+
+## Goal
+
+Ship the first production-shaped headless command for Zero:
+
+```sh
+zero exec "inspect this repo and summarize the next fix"
+```
+
+This command should be useful for local scripts, CI smoke runs, and later VS Code integration without pulling in the full future protocol, session, MCP, sandbox, or plugin roadmap.
+
+## Non-Goals
+
+- No daemon mode.
+- No JSON-RPC input protocol.
+- No MCP, plugin, marketplace, or subagent support.
+- No session resume/fork/search.
+- No new provider adapters in this slice.
+- No architecture rewrite of the agent loop.
+
+## User Stories
+
+1. As a CLI user, I can run one prompt headlessly and receive the assistant answer on stdout.
+2. As a script author, I can choose `text` or JSONL output.
+3. As a reviewer, I can see tool activity without corrupting text stdout.
+4. As a model tester, I can override the configured model for one run.
+5. As a cautious user, prompt-gated tools stay disabled unless I pass an explicit unsafe flag.
+
+## CLI Contract
+
+```sh
+zero exec [prompt...] [options]
+```
+
+Options for M1:
+
+- `-f, --file <path>`: read the prompt from a file.
+- `-m, --model <model>`: override the configured model for this run.
+- `-C, --cwd <path>`: run from another working directory.
+- `-o, --output-format <text|json>`: choose stdout format.
+- `--skip-permissions-unsafe`: grant prompt-gated tools for this run.
+
+The existing `zero -p "prompt"` shortcut remains as a compatibility path and should call the same runner.
+
+## Output Contract
+
+Text mode:
+
+- stdout contains assistant text only.
+- stderr contains tool rows, warnings, and errors.
+
+JSON mode:
+
+- stdout is newline-delimited JSON events.
+- Required event types for this slice: `run_start`, `text`, `tool_call`, `tool_result`, `final`, `warning`, `error`, `done`.
+
+## Exit Codes
+
+- `0`: success
+- `1`: unexpected crash
+- `2`: usage error
+- `3`: provider/config/runtime error
+- `4`: reserved for future tool failure policy
+- `5`: reserved for future permission-denied policy
+
+## Permission Behavior
+
+Default headless mode advertises only tools marked `permission: "allow"`.
+
+`--skip-permissions-unsafe` advertises tools that are not marked `deny` and grants prompt-gated tools through `ToolRegistry.run`. It must not bypass schema validation or direct tool execution safeguards.
+
+## Acceptance Criteria
+
+- `bun run typecheck` passes.
+- `bun test ./tests --timeout 15000` passes.
+- `bun run build` passes.
+- `zero exec --help` documents the M1 flags.
+- Usage errors do not initialize providers.
+- Provider failures return exit code `3`.
+- Normal mode does not advertise `bash`, `write_file`, `edit_file`, or `apply_patch`.
+- Unsafe mode still uses the registry execution path.

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -13,6 +13,7 @@ export interface AgentOptions {
   toolsEnabled?: boolean;   // allows temporarily disabling tool calling for debugging
   debug?: boolean;          // when true, logs the exact payload sent to the provider
   planMode?: boolean;       // when true, the agent plans without modifying the codebase
+  permissionMode?: 'auto' | 'unsafe'; // unsafe grants prompt-gated tools for this run
 }
 
 interface PendingToolCall {
@@ -33,7 +34,8 @@ export async function runAgent(
     onToolResult,
     toolsEnabled = true,
     debug = false,
-    planMode = false
+    planMode = false,
+    permissionMode = 'auto'
   } = options;
 
   // Clear any previous plan when starting a new task
@@ -47,16 +49,19 @@ export async function runAgent(
   ];
 
   const tools = toolRegistry.getAll();
-  // Until a real permission UX exists, only advertise tools that can run
-  // without an interactive grant. Prompt/deny tools remain registered for
-  // direct guarded execution, but the model should not be invited to call
-  // tools that the agent loop cannot approve yet.
-  const autoExecutableTools = tools.filter(t => t.safety.permission === 'allow');
+  // Until a real permission UX exists, normal mode only advertises tools that
+  // can run without an interactive grant. Unsafe headless mode is explicit and
+  // still never advertises tools marked deny.
+  const executableTools = tools.filter(t =>
+    permissionMode === 'unsafe'
+      ? t.safety.permission !== 'deny'
+      : t.safety.permission === 'allow'
+  );
   let finalAnswer = '';
 
   for (let turn = 0; turn < maxTurns; turn++) {
-    const toolDefinitions = (toolsEnabled && autoExecutableTools.length > 0)
-      ? autoExecutableTools.map(t => {
+    const toolDefinitions = (toolsEnabled && executableTools.length > 0)
+      ? executableTools.map(t => {
           // Convert Zod schema to proper JSON Schema (critical for many providers).
           // zod v4 ships this natively — no external package needed.
           const jsonSchema = z.toJSONSchema(t.parameters, {
@@ -187,7 +192,9 @@ export async function runAgent(
       }
 
       try {
-        result = await toolRegistry.run(tc.name, parsedArgs);
+        result = await toolRegistry.run(tc.name, parsedArgs, {
+          permissionGranted: permissionMode === 'unsafe',
+        });
       } catch (e: any) {
         result = `Error executing ${tc.name}: ${e.message}`;
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,64 +1,244 @@
-import { loadProviderConfig } from '../config/provider';
-import { createZeroProvider, resolveZeroProviderRuntime } from '../zero-provider-runtime';
-import type { Provider } from '../providers/types';
-import type { ZeroResolvedProviderRuntime } from '../zero-provider-runtime';
+import { stat } from 'fs/promises';
+import { resolve } from 'path';
 import { runAgent } from '../agent/loop';
+import { loadProviderConfig } from '../config/provider';
+import type { Provider } from '../providers/types';
+import { createZeroProvider, resolveZeroProviderRuntime } from '../zero-provider-runtime';
+import type { ZeroResolvedProviderRuntime } from '../zero-provider-runtime';
 
-export async function runHeadless(prompt: string) {
-  const providerConfig = await loadProviderConfig();
-  let runtime: ZeroResolvedProviderRuntime | undefined;
-  let provider: Provider | undefined;
+export type ExecOutputFormat = 'text' | 'json';
+
+export const ZERO_EXEC_EXIT_CODES = {
+  success: 0,
+  crash: 1,
+  usage: 2,
+  provider: 3,
+  tool: 4,
+  permission: 5,
+} as const;
+
+export interface RunExecOptions {
+  prompt?: string;
+  file?: string;
+  model?: string;
+  cwd?: string;
+  outputFormat?: string;
+  skipPermissionsUnsafe?: boolean;
+  maxTurns?: number;
+}
+
+class ExecUsageError extends Error {}
+
+export function parseExecOutputFormat(value: string | undefined): ExecOutputFormat | undefined {
+  const normalized = (value || 'text').trim().toLowerCase();
+  return normalized === 'text' || normalized === 'json' ? normalized : undefined;
+}
+
+export async function resolveExecPrompt(options: Pick<RunExecOptions, 'prompt' | 'file'>): Promise<string> {
+  const parts: string[] = [];
+  const inlinePrompt = options.prompt?.trim();
+
+  if (inlinePrompt) {
+    parts.push(inlinePrompt);
+  }
+
+  if (options.file) {
+    const promptPath = resolve(options.file);
+    const promptFile = Bun.file(promptPath);
+
+    if (!(await promptFile.exists())) {
+      throw new ExecUsageError(`Prompt file not found: ${promptPath}`);
+    }
+
+    const filePrompt = (await promptFile.text()).trim();
+    if (!filePrompt) {
+      throw new ExecUsageError(`Prompt file is empty: ${promptPath}`);
+    }
+    parts.push(filePrompt);
+  }
+
+  const prompt = parts.join('\n\n').trim();
+  if (!prompt) {
+    throw new ExecUsageError('Prompt required. Use `zero exec "prompt"` or `zero exec --file prompt.txt`.');
+  }
+
+  return prompt;
+}
+
+export async function runHeadless(prompt: string): Promise<void> {
+  const exitCode = await runExec({ prompt, outputFormat: 'text' });
+  if (exitCode !== ZERO_EXEC_EXIT_CODES.success) {
+    process.exitCode = exitCode;
+  }
+}
+
+export async function runExec(options: RunExecOptions): Promise<number> {
+  const outputFormat = parseExecOutputFormat(options.outputFormat);
+  if (!outputFormat) {
+    writeUsageError(`Invalid output format "${options.outputFormat}". Expected "text" or "json".`);
+    return ZERO_EXEC_EXIT_CODES.usage;
+  }
+
+  const previousCwd = process.cwd();
 
   try {
-    runtime = resolveZeroProviderRuntime({
-      provider: providerConfig.provider,
-      apiKey: providerConfig.apiKey,
-      baseURL: providerConfig.baseURL,
-      model: providerConfig.model,
-      profileName: providerConfig.profileName,
-      source: providerConfig.source,
-    });
-    provider = createZeroProvider(runtime);
-  } catch (err: any) {
-    console.error(`[zero] ${err?.message ?? String(err)}`);
-    if (runtime?.provider === 'anthropic' || runtime?.provider === 'google') {
-      console.error(
-        `[zero] ${runtime.provider} adapter is not yet implemented. ` +
-        'Set provider: "openai-compatible" with a custom gateway or use an OpenAI model.'
-      );
+    await changeWorkingDirectory(options.cwd);
+    const prompt = await resolveExecPrompt(options);
+
+    let runtime: ZeroResolvedProviderRuntime | undefined;
+    let provider: Provider;
+
+    try {
+      const providerConfig = await loadProviderConfig();
+      runtime = resolveZeroProviderRuntime({
+        provider: providerConfig.provider,
+        apiKey: providerConfig.apiKey,
+        baseURL: providerConfig.baseURL,
+        model: options.model?.trim() || providerConfig.model,
+        profileName: providerConfig.profileName,
+        source: providerConfig.source,
+      });
+      provider = createZeroProvider(runtime);
+    } catch (err: any) {
+      writeExecError(outputFormat, 'provider_error', formatProviderError(err, runtime));
+      return ZERO_EXEC_EXIT_CODES.provider;
     }
-    process.exit(1);
+
+    if (options.skipPermissionsUnsafe) {
+      writeWarning(outputFormat, '--skip-permissions-unsafe grants prompt-gated tools for this run.');
+    }
+
+    emitJson(outputFormat, {
+      type: 'run_start',
+      cwd: process.cwd(),
+      provider: runtime.provider,
+      model: runtime.modelId ?? runtime.requestedModel,
+      api_model: runtime.apiModel,
+      output_format: outputFormat,
+    });
+
+    let streamedText = '';
+
+    const finalAnswer = await runAgent(prompt, provider, {
+      maxTurns: options.maxTurns,
+      permissionMode: options.skipPermissionsUnsafe ? 'unsafe' : 'auto',
+      onText: (text) => {
+        streamedText += text;
+        if (outputFormat === 'json') {
+          emitJson(outputFormat, { type: 'text', delta: text });
+        } else {
+          process.stdout.write(text);
+        }
+      },
+      onToolCall: (toolCall) => {
+        if (outputFormat === 'json') {
+          emitJson(outputFormat, {
+            type: 'tool_call',
+            id: toolCall.id,
+            name: toolCall.name,
+            arguments: toolCall.arguments,
+          });
+        } else {
+          process.stderr.write(`[tool] ${toolCall.name}\n`);
+        }
+      },
+      onToolResult: (result) => {
+        if (outputFormat === 'json') {
+          emitJson(outputFormat, {
+            type: 'tool_result',
+            tool_call_id: result.toolCallId,
+            result: result.result,
+          });
+        } else {
+          process.stderr.write(`[result] ${truncateForStatus(result.result)}\n`);
+        }
+      },
+    });
+
+    if (outputFormat === 'json') {
+      emitJson(outputFormat, { type: 'final', text: finalAnswer });
+      emitJson(outputFormat, { type: 'done', exit_code: ZERO_EXEC_EXIT_CODES.success });
+    } else {
+      if (!streamedText && finalAnswer) {
+        streamedText = finalAnswer;
+        process.stdout.write(finalAnswer);
+      }
+      if (streamedText && !streamedText.endsWith('\n')) {
+        process.stdout.write('\n');
+      }
+    }
+
+    return ZERO_EXEC_EXIT_CODES.success;
+  } catch (err: any) {
+    if (err instanceof ExecUsageError) {
+      writeExecError(outputFormat, 'usage_error', err.message);
+      return ZERO_EXEC_EXIT_CODES.usage;
+    }
+
+    writeExecError(outputFormat, 'crash', err?.message ?? String(err));
+    return ZERO_EXEC_EXIT_CODES.crash;
+  } finally {
+    if (process.cwd() !== previousCwd) {
+      process.chdir(previousCwd);
+    }
+  }
+}
+
+async function changeWorkingDirectory(cwd: string | undefined): Promise<void> {
+  if (!cwd) return;
+
+  const target = resolve(cwd);
+  let info;
+  try {
+    info = await stat(target);
+  } catch {
+    throw new ExecUsageError(`Working directory not found: ${target}`);
   }
 
-  if (!runtime || !provider) return;
-
-  console.log(`
-   ███████╗ ███████╗ ██████╗   ██████╗ 
-   ╚══███╔╝ ██╔════╝ ██╔══██╗ ██╔═══██╗
-     ███╔╝  █████╗   ██████╔╝ ██║   ██║
-    ███╔╝   ██╔══╝   ██╔══██╗ ██║   ██║
-   ███████╗ ███████╗ ██║  ██║ ╚██████╔╝
-   ╚══════╝ ╚══════╝ ╚═╝  ╚═╝  ╚═════╝ 
-`);
-
-  console.log(`[zero] Provider: ${runtime.profileName ? `profile: ${runtime.profileName}` : runtime.source}`);
-  console.log(`[zero] Runtime: ${runtime.provider}`);
-  console.log(`[zero] Model: ${runtime.modelId ?? runtime.requestedModel}`);
-  console.log(`[zero] API model: ${runtime.apiModel}`);
-  console.log(`[zero] Base URL: ${runtime.baseURL}`);
-  console.log(`\n> ${prompt}\n`);
-
-  const finalAnswer = await runAgent(prompt, provider, {
-    onText: (text) => process.stdout.write(text),
-    onToolCall: (tc) => {
-      console.log(`\n[tool] ${tc.name}(${tc.arguments})`);
-    },
-    onToolResult: (result) => {
-      console.log(`[result] ${result.result.slice(0, 200)}${result.result.length > 200 ? '...' : ''}`);
-    },
-  });
-
-  if (finalAnswer) {
-    console.log(`\n\n${finalAnswer}`);
+  if (!info.isDirectory()) {
+    throw new ExecUsageError(`Working directory is not a directory: ${target}`);
   }
+
+  process.chdir(target);
+}
+
+function writeUsageError(message: string): void {
+  process.stderr.write(`[zero] ${message}\n`);
+}
+
+function writeExecError(format: ExecOutputFormat, code: string, message: string): void {
+  if (format === 'json') {
+    emitJson(format, { type: 'error', code, message });
+    return;
+  }
+
+  process.stderr.write(`[zero] ${message}\n`);
+}
+
+function writeWarning(format: ExecOutputFormat, message: string): void {
+  if (format === 'json') {
+    emitJson(format, { type: 'warning', message });
+    return;
+  }
+
+  process.stderr.write(`[zero] WARNING: ${message}\n`);
+}
+
+function emitJson(format: ExecOutputFormat, payload: Record<string, unknown>): void {
+  if (format !== 'json') return;
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+function formatProviderError(err: any, runtime: ZeroResolvedProviderRuntime | undefined): string {
+  const message = err?.message ?? String(err);
+  if (runtime?.provider === 'anthropic' || runtime?.provider === 'google') {
+    return `${message}\nZero ${runtime.provider} adapter is not implemented yet. Use an OpenAI-compatible gateway or an OpenAI model for this slice.`;
+  }
+
+  return message;
+}
+
+function truncateForStatus(value: string): string {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  return compact.length > 200 ? `${compact.slice(0, 200)}...` : compact;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { runHeadless } from './cli';
+import { runExec } from './cli';
 import { configManager } from './config/manager';
 import { startTUI } from './tui';
 
@@ -14,11 +14,30 @@ program
   .option('-p, --prompt <prompt>', 'Run in headless mode with the given prompt')
   .action(async (options) => {
     if (options.prompt) {
-      await runHeadless(options.prompt);
+      process.exitCode = await runExec({ prompt: options.prompt, outputFormat: 'text' });
     } else {
-      // Launch the interactive TUI (Grok Build style)
       startTUI();
     }
+  });
+
+program
+  .command('exec')
+  .description('Run Zero headlessly for scripts, automation, or CI')
+  .argument('[prompt...]', 'Prompt to send to the coding agent')
+  .option('-f, --file <path>', 'Read the prompt from a file')
+  .option('-m, --model <model>', 'Override the configured model for this run')
+  .option('-C, --cwd <path>', 'Run from a different working directory')
+  .option('-o, --output-format <format>', 'Output format: text or json', 'text')
+  .option('--skip-permissions-unsafe', 'Allow prompt-gated tools for this run')
+  .action(async (promptParts: string[] | undefined, options) => {
+    process.exitCode = await runExec({
+      prompt: (promptParts ?? []).join(' '),
+      file: options.file,
+      model: options.model,
+      cwd: options.cwd,
+      outputFormat: options.outputFormat,
+      skipPermissionsUnsafe: Boolean(options.skipPermissionsUnsafe),
+    });
   });
 
 // Providers subcommand (temporary until we have a nice /provider in the TUI)

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -97,6 +97,65 @@ describe('runAgent tool-call flow', () => {
     expect(names).not.toContain('edit_file');
   });
 
+  it('advertises prompt-gated tools only in unsafe permission mode', async () => {
+    const provider = new MockProvider([[{ type: 'text', content: 'done' }]]);
+
+    await runAgent('which tools can you use?', provider, {
+      permissionMode: 'unsafe',
+    });
+
+    const names = (provider.receivedTools[0] ?? []).map((tool) => tool.name).sort();
+    expect(names).toContain('read_file');
+    expect(names).toContain('grep');
+    expect(names).toContain('glob');
+    expect(names).toContain('bash');
+    expect(names).toContain('apply_patch');
+    expect(names).toContain('write_file');
+    expect(names).toContain('edit_file');
+  });
+
+  it('runs prompt-gated tools through the registry only when unsafe mode grants permission', async () => {
+    const command = 'echo zero-agent-unsafe';
+    const safeProvider = new MockProvider([
+      [
+        { type: 'tool-call-start', id: 'call_1', name: 'bash' },
+        {
+          type: 'tool-call-delta',
+          id: 'call_1',
+          argumentsFragment: JSON.stringify({ command }),
+        },
+        { type: 'tool-call-end', id: 'call_1' },
+      ],
+      [{ type: 'text', content: 'safe done' }],
+    ]);
+    const unsafeProvider = new MockProvider([
+      [
+        { type: 'tool-call-start', id: 'call_1', name: 'bash' },
+        {
+          type: 'tool-call-delta',
+          id: 'call_1',
+          argumentsFragment: JSON.stringify({ command }),
+        },
+        { type: 'tool-call-end', id: 'call_1' },
+      ],
+      [{ type: 'text', content: 'unsafe done' }],
+    ]);
+
+    const safeResults: string[] = [];
+    const unsafeResults: string[] = [];
+
+    await runAgent('try shell', safeProvider, {
+      onToolResult: (result) => safeResults.push(result.result),
+    });
+    await runAgent('try shell', unsafeProvider, {
+      permissionMode: 'unsafe',
+      onToolResult: (result) => unsafeResults.push(result.result),
+    });
+
+    expect(safeResults[0]).toContain('Permission required for bash');
+    expect(unsafeResults[0]).toContain('zero-agent-unsafe');
+  });
+
   it('keeps tool arguments when a delta arrives before the start event', async () => {
     const provider = new MockProvider([
       [

--- a/tests/headless-exec.test.ts
+++ b/tests/headless-exec.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import {
+  parseExecOutputFormat,
+  resolveExecPrompt,
+  ZERO_EXEC_EXIT_CODES,
+} from '../src/cli';
+
+async function runZero(args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+  const child = Bun.spawn([process.execPath, 'src/index.ts', ...args], {
+    env: { ...process.env, ...envOverrides },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('zero exec CLI surface', () => {
+  it('documents the M1 headless flags', async () => {
+    const result = await runZero(['exec', '--help']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.trim()).toBe('');
+    expect(result.stdout).toContain('Usage: zero exec');
+    expect(result.stdout).toContain('--file');
+    expect(result.stdout).toContain('--model');
+    expect(result.stdout).toContain('--cwd');
+    expect(result.stdout).toContain('--output-format');
+    expect(result.stdout).toContain('--skip-permissions-unsafe');
+  });
+
+  it('returns usage exit code when no prompt is provided', async () => {
+    const result = await runZero(['exec']);
+
+    expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+    expect(result.stdout.trim()).toBe('');
+    expect(result.stderr).toContain('Prompt required');
+  });
+
+  it('returns usage exit code for an invalid output format', async () => {
+    const result = await runZero(['exec', '--output-format', 'xml', 'hello']);
+
+    expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+    expect(result.stdout.trim()).toBe('');
+    expect(result.stderr).toContain('Invalid output format');
+  });
+
+  it('returns provider exit code for provider runtime failures', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.zero-provider-test-'));
+    try {
+      const providerScript = join(dir, 'provider-command.js');
+      await writeFile(
+        providerScript,
+        'console.log(JSON.stringify({ model: "zero-test-unknown-model" }));\n',
+        'utf-8'
+      );
+
+      const result = await runZero(
+        ['exec', '--output-format', 'json', 'hello'],
+        {
+          ZERO_PROVIDER_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(providerScript)}`,
+        }
+      );
+
+      const events = result.stdout.trim().split('\n').map((line) => JSON.parse(line));
+      expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.provider);
+      expect(result.stderr.trim()).toBe('');
+      expect(events[0]).toMatchObject({
+        type: 'error',
+        code: 'provider_error',
+      });
+      expect(events[0].message).toContain('Unknown Zero model');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('headless exec prompt helpers', () => {
+  it('parses supported output formats', () => {
+    expect(parseExecOutputFormat(undefined)).toBe('text');
+    expect(parseExecOutputFormat('text')).toBe('text');
+    expect(parseExecOutputFormat('json')).toBe('json');
+    expect(parseExecOutputFormat('JSON')).toBe('json');
+    expect(parseExecOutputFormat('xml')).toBeUndefined();
+  });
+
+  it('combines inline and file prompts', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.zero-exec-test-'));
+    try {
+      const promptPath = join(dir, 'prompt.txt');
+      await writeFile(promptPath, 'from file\n', 'utf-8');
+
+      const prompt = await resolveExecPrompt({
+        prompt: 'from cli',
+        file: promptPath,
+      });
+
+      expect(prompt).toBe('from cli\n\nfrom file');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the M1 headless exec slice for Zero:

- adds a focused `docs/M1_HEADLESS_EXEC_PRD.md`
- implements `zero exec [prompt...]` with `--file`, `--model`, `--cwd`, `--output-format text|json`, and `--skip-permissions-unsafe`
- keeps text stdout clean and emits tool/status output on stderr
- emits JSONL events for JSON output mode
- adds explicit exec exit-code handling
- keeps unsafe tool execution on the `ToolRegistry.run` path instead of bypassing validation

## Tests

- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`

## Notes

Provider adapters for Anthropic/Gemini, full stream-json protocol, sessions, resume/fork, and persistent permissions remain later M1/M2 slices by design.