### PR TITLE
feat: add Zero Gemini provider

### DIFF
--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,0 +1,441 @@
+import type { Message, Provider, StreamEvent, ToolDefinition } from './types';
+
+const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com';
+const DEFAULT_MAX_TOKENS = 8192;
+
+type FetchLike = (...args: Parameters<typeof fetch>) => ReturnType<typeof fetch>;
+
+interface GeminiProviderOptions {
+  apiKey: string;
+  baseURL?: string;
+  model: string;
+  maxTokens?: number;
+  fetchImpl?: FetchLike;
+}
+
+type GeminiPart =
+  | { text: string }
+  | { functionCall: GeminiFunctionCall }
+  | { functionResponse: GeminiFunctionResponse };
+
+interface GeminiContent {
+  role: 'user' | 'model' | 'system';
+  parts: GeminiPart[];
+}
+
+interface GeminiFunctionCall {
+  id?: string;
+  name: string;
+  args?: Record<string, unknown>;
+}
+
+interface GeminiFunctionResponse {
+  id?: string;
+  name: string;
+  response: { result: string };
+}
+
+interface GeminiStreamPayload {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+        functionCall?: Partial<GeminiFunctionCall> & {
+          args?: unknown;
+          arguments?: unknown;
+        };
+      }>;
+    };
+    finishReason?: string;
+  }>;
+  functionCalls?: Array<Partial<GeminiFunctionCall> & {
+    args?: unknown;
+    arguments?: unknown;
+  }>;
+  promptFeedback?: {
+    blockReason?: string;
+    blockReasonMessage?: string;
+  };
+  usageMetadata?: GeminiUsageMetadata;
+  error?: {
+    code?: number;
+    message?: string;
+    status?: string;
+  };
+}
+
+interface GeminiUsageMetadata {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  thoughtsTokenCount?: number;
+  totalTokenCount?: number;
+}
+
+export class GeminiProvider implements Provider {
+  private readonly apiKey: string;
+  private readonly baseURL: string;
+  private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly fetchImpl: FetchLike;
+
+  constructor({
+    apiKey,
+    baseURL,
+    model,
+    maxTokens = DEFAULT_MAX_TOKENS,
+    fetchImpl = fetch,
+  }: GeminiProviderOptions) {
+    this.apiKey = apiKey;
+    this.baseURL = (baseURL || DEFAULT_GEMINI_BASE_URL).replace(/\/+$/, '');
+    this.model = normalizeModel(model);
+    this.maxTokens = normalizeMaxTokens(maxTokens);
+    this.fetchImpl = fetchImpl;
+  }
+
+  async *streamCompletion(
+    messages: Message[],
+    tools: ToolDefinition[]
+  ): AsyncIterable<StreamEvent> {
+    const { systemInstruction, contents } = toGeminiContents(messages);
+    if (contents.length === 0) {
+      throw new Error('Zero Gemini provider requires at least one non-system message');
+    }
+
+    const body: Record<string, unknown> = {
+      contents,
+      generationConfig: {
+        maxOutputTokens: this.maxTokens,
+      },
+    };
+    if (systemInstruction) body.systemInstruction = systemInstruction;
+    if (tools.length > 0) body.tools = toGeminiTools(tools);
+
+    const response = await this.createStream(body);
+    yield* this.readStream(response);
+  }
+
+  private async createStream(body: Record<string, unknown>): Promise<Response> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(this.streamURL(), {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-goog-api-key': this.apiKey,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (err: any) {
+      throw new Error(`Provider returned error: ${getDetailedErrorMessage(err)}`);
+    }
+
+    if (!response.ok) {
+      const message = await getResponseErrorMessage(response);
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(`Provider authentication error (check your API key): ${message}`);
+      }
+      if (response.status === 429) {
+        throw new Error(`Provider rate limit error: ${message}`);
+      }
+      throw new Error(`Provider returned error: ${message}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Provider returned error: Gemini stream response did not include a body');
+    }
+
+    return response;
+  }
+
+  private async *readStream(response: Response): AsyncIterable<StreamEvent> {
+    let promptTokens = 0;
+    let completionTokens = 0;
+    let hasUsage = false;
+    let syntheticToolCallIndex = 0;
+
+    try {
+      for await (const payload of readGeminiSSE(response.body!)) {
+        if (payload.error) {
+          throw new Error(payload.error.message || payload.error.status || 'Gemini stream error');
+        }
+
+        const blockReason = payload.promptFeedback?.blockReason;
+        if (blockReason) {
+          const message = payload.promptFeedback?.blockReasonMessage || blockReason;
+          throw new Error(`Content blocked: ${message}`);
+        }
+
+        const usage = payload.usageMetadata;
+        if (usage) {
+          if (typeof usage.promptTokenCount === 'number') {
+            promptTokens = usage.promptTokenCount;
+          }
+          const candidateTokens = typeof usage.candidatesTokenCount === 'number'
+            ? usage.candidatesTokenCount
+            : 0;
+          const thoughtTokens = typeof usage.thoughtsTokenCount === 'number'
+            ? usage.thoughtsTokenCount
+            : 0;
+          completionTokens = candidateTokens + thoughtTokens;
+          hasUsage = true;
+        }
+
+        for (const candidate of payload.candidates ?? []) {
+          for (const part of candidate.content?.parts ?? []) {
+            if (part.text) {
+              yield { type: 'text', content: part.text };
+            }
+            if (part.functionCall?.name) {
+              syntheticToolCallIndex += 1;
+              yield* emitGeminiToolCall(part.functionCall, syntheticToolCallIndex);
+            }
+          }
+        }
+
+        for (const functionCall of payload.functionCalls ?? []) {
+          if (!functionCall.name) continue;
+          syntheticToolCallIndex += 1;
+          yield* emitGeminiToolCall(functionCall, syntheticToolCallIndex);
+        }
+      }
+
+      if (hasUsage) {
+        yield { type: 'usage', promptTokens, completionTokens };
+      }
+      yield { type: 'done' };
+    } catch (err: any) {
+      throw new Error(`Provider returned error during streaming: ${getDetailedErrorMessage(err)}`);
+    }
+  }
+
+  private streamURL(): string {
+    return `${this.baseURL}/v1beta/models/${encodeURIComponent(this.model)}:streamGenerateContent?alt=sse`;
+  }
+}
+
+function* emitGeminiToolCall(
+  functionCall: Partial<GeminiFunctionCall> & { args?: unknown; arguments?: unknown },
+  syntheticIndex: number
+): Iterable<StreamEvent> {
+  if (!functionCall.name) return;
+  const id = functionCall.id || `gemini_tool_${syntheticIndex}`;
+  const args = normalizeFunctionCallArgs(
+    functionCall.args ?? functionCall.arguments,
+    functionCall.name
+  );
+
+  yield { type: 'tool-call-start', id, name: functionCall.name };
+  yield {
+    type: 'tool-call-delta',
+    id,
+    argumentsFragment: JSON.stringify(args),
+  };
+  yield { type: 'tool-call-end', id };
+}
+
+async function* readGeminiSSE(
+  body: ReadableStream<Uint8Array>
+): AsyncIterable<GeminiStreamPayload> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+
+    let boundary = findSSEBoundary(buffer);
+    while (boundary) {
+      const rawEvent = buffer.slice(0, boundary.index);
+      buffer = buffer.slice(boundary.index + boundary.length);
+      const payload = parseGeminiSSEPayload(rawEvent);
+      if (payload) yield payload;
+      boundary = findSSEBoundary(buffer);
+    }
+
+    if (done) break;
+  }
+
+  const trailingPayload = parseGeminiSSEPayload(buffer);
+  if (trailingPayload) yield trailingPayload;
+}
+
+function findSSEBoundary(buffer: string): { index: number; length: number } | undefined {
+  const lfIndex = buffer.indexOf('\n\n');
+  const crlfIndex = buffer.indexOf('\r\n\r\n');
+  if (lfIndex === -1 && crlfIndex === -1) return undefined;
+  if (lfIndex === -1) return { index: crlfIndex, length: 4 };
+  if (crlfIndex === -1 || lfIndex < crlfIndex) return { index: lfIndex, length: 2 };
+  return { index: crlfIndex, length: 4 };
+}
+
+function parseGeminiSSEPayload(rawEvent: string): GeminiStreamPayload | undefined {
+  const dataLines: string[] = [];
+
+  for (const line of rawEvent.replace(/\r\n/g, '\n').split('\n')) {
+    if (!line || line.startsWith(':')) continue;
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice('data:'.length).trimStart());
+    }
+  }
+
+  if (dataLines.length === 0) return undefined;
+  const data = dataLines.join('\n').trim();
+  if (!data || data === '[DONE]') return undefined;
+
+  try {
+    return JSON.parse(data) as GeminiStreamPayload;
+  } catch (err: any) {
+    throw new Error(`Invalid Gemini stream payload: ${getDetailedErrorMessage(err)}`);
+  }
+}
+
+function toGeminiContents(messages: Message[]): {
+  systemInstruction?: GeminiContent;
+  contents: GeminiContent[];
+} {
+  const systemParts: GeminiPart[] = [];
+  const contents: GeminiContent[] = [];
+  const toolNamesById = new Map<string, string>();
+
+  for (const message of messages) {
+    const content = normalizeMessageContent(message.content);
+    if (message.role === 'system') {
+      if (content) systemParts.push({ text: content });
+      continue;
+    }
+
+    if (message.role === 'tool') {
+      if (!message.toolCallId) {
+        throw new Error('Zero Gemini provider requires toolCallId on tool result messages');
+      }
+      appendUserParts(contents, [
+        {
+          functionResponse: {
+            id: message.toolCallId,
+            name: toolNamesById.get(message.toolCallId) ?? message.toolCallId,
+            response: { result: content },
+          },
+        },
+      ]);
+      continue;
+    }
+
+    if (message.role === 'assistant') {
+      const parts: GeminiPart[] = [];
+      if (content) parts.push({ text: content });
+      for (const toolCall of message.toolCalls ?? []) {
+        toolNamesById.set(toolCall.id, toolCall.name);
+        parts.push({
+          functionCall: {
+            id: toolCall.id,
+            name: toolCall.name,
+            args: parseToolArguments(toolCall.arguments, toolCall.name),
+          },
+        });
+      }
+      if (parts.length > 0) contents.push({ role: 'model', parts });
+      continue;
+    }
+
+    if (content) {
+      contents.push({ role: 'user', parts: [{ text: content }] });
+    }
+  }
+
+  return {
+    systemInstruction: systemParts.length > 0
+      ? { role: 'system', parts: systemParts }
+      : undefined,
+    contents,
+  };
+}
+
+function appendUserParts(contents: GeminiContent[], parts: GeminiPart[]): void {
+  const last = contents.at(-1);
+  if (last?.role === 'user') {
+    last.parts = [...last.parts, ...parts];
+    return;
+  }
+  contents.push({ role: 'user', parts });
+}
+
+function toGeminiTools(tools: ToolDefinition[]): Array<Record<string, unknown>> {
+  return [
+    {
+      functionDeclarations: tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      })),
+    },
+  ];
+}
+
+function parseToolArguments(argumentsJson: string, toolName: string): Record<string, unknown> {
+  if (!argumentsJson) return {};
+  try {
+    const parsed = JSON.parse(argumentsJson);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    throw new Error(
+      `Zero Gemini provider requires tool arguments for ${toolName} to be a JSON object`
+    );
+  } catch (err: any) {
+    if (err?.message?.includes('JSON object')) throw err;
+    throw new Error(
+      `Zero Gemini provider could not parse tool arguments for ${toolName} as JSON`
+    );
+  }
+}
+
+function normalizeFunctionCallArgs(value: unknown, toolName: string): Record<string, unknown> {
+  if (value === undefined || value === null) return {};
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw new Error(
+    `Zero Gemini provider requires streamed tool arguments for ${toolName} to be a JSON object`
+  );
+}
+
+function normalizeMaxTokens(maxTokens: number): number {
+  if (!Number.isFinite(maxTokens) || !Number.isInteger(maxTokens) || maxTokens < 1) {
+    throw new Error('Zero Gemini provider maxTokens must be a positive integer');
+  }
+  return maxTokens;
+}
+
+function normalizeModel(model: string): string {
+  const normalized = model.trim().replace(/^models\//, '');
+  if (!normalized) throw new Error('Zero Gemini provider requires a model');
+  return normalized;
+}
+
+function normalizeMessageContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  return String(content);
+}
+
+async function getResponseErrorMessage(response: Response): Promise<string> {
+  const body = await response.text().catch(() => '');
+  if (!body) return `${response.status} ${response.statusText}`.trim();
+
+  try {
+    const parsed = JSON.parse(body);
+    return parsed.error?.message || parsed.message || body;
+  } catch {
+    return body;
+  }
+}
+
+function getDetailedErrorMessage(err: any): string {
+  if (!err) return 'Unknown error';
+  if (err.message && !err.message.includes('Provider returned error')) return err.message;
+  if (err.error?.message) return err.error.message;
+  if (typeof err.error === 'string') return err.error;
+  if (err.cause?.message) return err.cause.message;
+  return err.message || String(err);
+}

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -339,7 +339,7 @@ function toGeminiContents(messages: Message[]): {
     }
 
     if (content) {
-      contents.push({ role: 'user', parts: [{ text: content }] });
+      appendUserParts(contents, [{ text: content }]);
     }
   }
 

--- a/src/zero-provider-runtime/resolver.ts
+++ b/src/zero-provider-runtime/resolver.ts
@@ -1,5 +1,6 @@
 import { OpenAIProvider } from '../providers/openai';
 import { AnthropicProvider } from '../providers/anthropic';
+import { GeminiProvider } from '../providers/gemini';
 import type { Provider } from '../providers/types';
 import {
   getZeroModel,
@@ -115,6 +116,19 @@ export function createZeroProvider(
     });
   }
 
+  if (runtime.provider === 'google') {
+    if (!runtime.apiKey) {
+      throw new Error('Zero google provider requires an API key');
+    }
+
+    return new GeminiProvider({
+      apiKey: runtime.apiKey,
+      baseURL: runtime.baseURL,
+      model: runtime.apiModel,
+      maxTokens: resolveGoogleMaxTokens(runtime),
+    });
+  }
+
   throw new ZeroPendingProviderError(runtime.provider);
 }
 
@@ -197,6 +211,10 @@ function resolveAnthropicMaxTokens(runtime: ZeroResolvedProviderRuntime): number
     runtime.model.context.maxOutputTokens,
     MIN_REGISTRY_ANTHROPIC_MAX_TOKENS
   );
+}
+
+function resolveGoogleMaxTokens(runtime: ZeroResolvedProviderRuntime): number | undefined {
+  return runtime.model?.context.maxOutputTokens;
 }
 
 function normalizeRequired(value: string, label: string): string {

--- a/tests/gemini-provider.test.ts
+++ b/tests/gemini-provider.test.ts
@@ -116,6 +116,71 @@ describe('GeminiProvider', () => {
     });
   });
 
+  it('merges user text after a tool result into the same Gemini user turn', async () => {
+    let capturedBody: any;
+
+    const provider = new GeminiProvider({
+      apiKey: 'test-google-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: async (_url, init) => {
+        capturedBody = JSON.parse(String(init?.body));
+        return streamResponse([event({})]);
+      },
+    });
+
+    await collectEvents(provider.streamCompletion(
+      [
+        { role: 'user', content: 'Read the file.' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            {
+              id: 'call_1',
+              name: 'read_file',
+              arguments: '{"path":"src/index.ts"}',
+            },
+          ],
+        },
+        { role: 'tool', toolCallId: 'call_1', content: 'file contents' },
+        { role: 'user', content: 'Now grep for Zero.' },
+      ],
+      []
+    ));
+
+    expect(capturedBody.contents).toEqual([
+      {
+        role: 'user',
+        parts: [{ text: 'Read the file.' }],
+      },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'call_1',
+              name: 'read_file',
+              args: { path: 'src/index.ts' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              id: 'call_1',
+              name: 'read_file',
+              response: { result: 'file contents' },
+            },
+          },
+          { text: 'Now grep for Zero.' },
+        ],
+      },
+    ]);
+  });
+
   it('normalizes Gemini text, usage, and thinking token stream chunks', async () => {
     const provider = new GeminiProvider({
       apiKey: 'test-key',

--- a/tests/gemini-provider.test.ts
+++ b/tests/gemini-provider.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'bun:test';
+import { GeminiProvider } from '../src/providers/gemini';
+import type { Message, StreamEvent, ToolDefinition } from '../src/providers/types';
+
+describe('GeminiProvider', () => {
+  it('maps Zero messages, system prompts, and tools to Gemini streamGenerateContent', async () => {
+    let capturedUrl = '';
+    let capturedBody: any;
+    let capturedHeaders: Headers | undefined;
+
+    const provider = new GeminiProvider({
+      apiKey: 'test-google-key',
+      model: 'gemini-2.5-flash',
+      maxTokens: 65536,
+      fetchImpl: async (url, init) => {
+        capturedUrl = String(url);
+        capturedBody = JSON.parse(String(init?.body));
+        capturedHeaders = new Headers(init?.headers);
+        return streamResponse([
+          event({
+            usageMetadata: {
+              promptTokenCount: 4,
+              candidatesTokenCount: 2,
+            },
+          }),
+        ]);
+      },
+    });
+
+    const messages: Message[] = [
+      { role: 'system', content: 'You are Zero.' },
+      { role: 'user', content: 'Read the file.' },
+      {
+        role: 'assistant',
+        content: 'I will inspect it.',
+        toolCalls: [
+          {
+            id: 'call_1',
+            name: 'read_file',
+            arguments: '{"path":"src/index.ts"}',
+          },
+        ],
+      },
+      { role: 'tool', toolCallId: 'call_1', content: 'file contents' },
+    ];
+    const tools: ToolDefinition[] = [
+      {
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      },
+    ];
+
+    await collectEvents(provider.streamCompletion(messages, tools));
+
+    expect(capturedUrl).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse'
+    );
+    expect(capturedHeaders?.get('x-goog-api-key')).toBe('test-google-key');
+    expect(capturedBody).toEqual({
+      systemInstruction: {
+        role: 'system',
+        parts: [{ text: 'You are Zero.' }],
+      },
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: 'Read the file.' }],
+        },
+        {
+          role: 'model',
+          parts: [
+            { text: 'I will inspect it.' },
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'read_file',
+                args: { path: 'src/index.ts' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'call_1',
+                name: 'read_file',
+                response: { result: 'file contents' },
+              },
+            },
+          ],
+        },
+      ],
+      generationConfig: { maxOutputTokens: 65536 },
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: 'read_file',
+              description: 'Read a file',
+              parameters: {
+                type: 'object',
+                properties: { path: { type: 'string' } },
+                required: ['path'],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('normalizes Gemini text, usage, and thinking token stream chunks', async () => {
+    const provider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: createFetch([
+        event({
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: 'Hello' }],
+              },
+            },
+          ],
+        }),
+        event({
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ text: ' Zero' }],
+              },
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 25,
+            candidatesTokenCount: 15,
+            thoughtsTokenCount: 3,
+          },
+        }),
+      ]),
+    });
+
+    const events = await collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ));
+
+    expect(events).toEqual([
+      { type: 'text', content: 'Hello' },
+      { type: 'text', content: ' Zero' },
+      { type: 'usage', promptTokens: 25, completionTokens: 18 },
+      { type: 'done' },
+    ]);
+  });
+
+  it('normalizes Gemini function calls from candidate parts', async () => {
+    const provider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: createFetch([
+        event({
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'call_1',
+                      name: 'read_file',
+                      args: { path: 'src/index.ts' },
+                    },
+                  },
+                  {
+                    functionCall: {
+                      id: 'call_2',
+                      name: 'grep',
+                      args: { pattern: 'Zero' },
+                    },
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        }),
+      ]),
+    });
+
+    const events = await collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'read and grep' }],
+      []
+    ));
+
+    expect(events).toEqual([
+      { type: 'tool-call-start', id: 'call_1', name: 'read_file' },
+      { type: 'tool-call-delta', id: 'call_1', argumentsFragment: '{"path":"src/index.ts"}' },
+      { type: 'tool-call-end', id: 'call_1' },
+      { type: 'tool-call-start', id: 'call_2', name: 'grep' },
+      { type: 'tool-call-delta', id: 'call_2', argumentsFragment: '{"pattern":"Zero"}' },
+      { type: 'tool-call-end', id: 'call_2' },
+      { type: 'done' },
+    ]);
+  });
+
+  it('normalizes Gemini top-level functionCalls arrays', async () => {
+    const provider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: createFetch([
+        event({
+          functionCalls: [
+            {
+              id: 'call_1',
+              name: 'read_file',
+              args: { path: 'src/index.ts' },
+            },
+          ],
+        }),
+      ]),
+    });
+
+    const events = await collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'read file' }],
+      []
+    ));
+
+    expect(events).toEqual([
+      { type: 'tool-call-start', id: 'call_1', name: 'read_file' },
+      { type: 'tool-call-delta', id: 'call_1', argumentsFragment: '{"path":"src/index.ts"}' },
+      { type: 'tool-call-end', id: 'call_1' },
+      { type: 'done' },
+    ]);
+  });
+
+  it('surfaces Gemini HTTP authentication and rate limit errors with provider context', async () => {
+    const authProvider = new GeminiProvider({
+      apiKey: 'bad-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: { message: 'API key not valid' } }), {
+          status: 401,
+        }),
+    });
+
+    await expect(collectEvents(authProvider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ))).rejects.toThrow('Provider authentication error');
+
+    const rateProvider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ error: { message: 'quota exceeded' } }), {
+          status: 429,
+        }),
+    });
+
+    await expect(collectEvents(rateProvider.streamCompletion(
+      [{ role: 'user', content: 'hello' }],
+      []
+    ))).rejects.toThrow('Provider rate limit error');
+  });
+
+  it('surfaces Gemini prompt block feedback with provider context', async () => {
+    const provider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: createFetch([
+        event({
+          promptFeedback: {
+            blockReason: 'SAFETY',
+            blockReasonMessage: 'blocked by policy',
+          },
+        }),
+      ]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'user', content: 'blocked prompt' }],
+      []
+    ))).rejects.toThrow('Content blocked: blocked by policy');
+  });
+
+  it('rejects Gemini calls without a non-system message', async () => {
+    const provider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: createFetch([]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'system', content: 'Only system.' }],
+      []
+    ))).rejects.toThrow('requires at least one non-system message');
+  });
+
+  it('rejects malformed tool history before dispatch', async () => {
+    const provider = new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      fetchImpl: createFetch([]),
+    });
+
+    await expect(collectEvents(provider.streamCompletion(
+      [{ role: 'tool', content: 'missing id' }],
+      []
+    ))).rejects.toThrow('requires toolCallId');
+
+    await expect(collectEvents(provider.streamCompletion(
+      [
+        { role: 'user', content: 'call tool' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{ id: 'call_1', name: 'read_file', arguments: '"src/index.ts"' }],
+        },
+      ],
+      []
+    ))).rejects.toThrow('requires tool arguments for read_file to be a JSON object');
+  });
+
+  it('validates maxTokens before dispatch', async () => {
+    expect(() => new GeminiProvider({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      maxTokens: 0,
+    })).toThrow('maxTokens must be a positive integer');
+  });
+});
+
+function createFetch(events: string[]) {
+  return async () => streamResponse(events);
+}
+
+function streamResponse(events: string[]): Response {
+  return new Response(events.join(''), {
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function event(data: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+async function collectEvents(stream: AsyncIterable<StreamEvent>): Promise<StreamEvent[]> {
+  const events: StreamEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}

--- a/tests/zero-provider-runtime.test.ts
+++ b/tests/zero-provider-runtime.test.ts
@@ -141,13 +141,25 @@ describe('resolveZeroProviderRuntime', () => {
     );
   });
 
-  it('still rejects pending official Google adapters', () => {
+  it('creates implemented Google Gemini providers', () => {
     const google = resolveZeroProviderRuntime({
       model: 'gemini-flash',
       apiKey: 'test-google-key',
     });
 
-    expect(() => createZeroProvider(google)).toThrow(ZeroPendingProviderError);
+    const provider = createZeroProvider(google);
+    expect(provider).toBeDefined();
+    expect((provider as any).maxTokens).toBe(65536);
+  });
+
+  it('requires an API key for the official Google runtime', () => {
+    const google = resolveZeroProviderRuntime({
+      model: 'gemini-flash',
+    });
+
+    expect(() => createZeroProvider(google)).toThrow(
+      'google provider requires an API key'
+    );
   });
 
   it('creates OpenAI-compatible providers without an API key for custom gateways', () => {


### PR DESCRIPTION
## Summary

Adds the M1 Gnanam Gemini provider slice for Zero. This implements a Zero-native Google Gemini streaming adapter and wires registry-backed `google` models into the existing provider runtime resolver.

## What Changed

- Added `src/providers/gemini.ts` with REST/SSE streaming through Gemini `streamGenerateContent`.
- Maps Zero system/user/assistant/tool history into Gemini `systemInstruction`, `contents`, `functionCall`, and `functionResponse` parts.
- Maps Zero tools into Gemini `functionDeclarations`.
- Normalizes Gemini streamed text, candidate function calls, top-level `functionCalls`, prompt-block feedback, HTTP auth/rate-limit errors, and `usageMetadata` into the shared Zero provider event schema.
- Wires `google` runtime provider creation so registry Gemini models are implemented instead of pending.
- Passes registry `maxOutputTokens` into the Gemini provider.
- Adds provider and runtime tests for mapping, streaming text, usage including thinking tokens, tool calls, prompt blocks, malformed tool history, API key requirement, and max token validation.

## Drac Reference

Used Drac only as behavioral reference, rewritten cleanly in TypeScript for Zero:

- `by-function/llm-api/gemini-api.js` for Gemini usage metadata, prompt block handling, and function call extraction.
- `by-function/llm-api/openai-api-6.js` for Gemini parts and function response mapping.
- `by-function/llm-api/claude-api-50.js` for normalized usage/tool-call behavior.

## Validation

- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test tests/gemini-provider.test.ts tests/zero-provider-runtime.test.ts --timeout 15000` — 24 pass, 0 fail
- `npx --yes bun test ./tests --timeout 15000` — 132 pass, 0 fail
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero providers current`
- `git diff --check origin/main..HEAD`

Review requested from @Vasanthdev2004 and @anandh8x.