### PR TITLE
feat: add M2 install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ bun install --frozen-lockfile
 bun run dev
 ```
 
+## Install From Release
+
+Linux/macOS:
+
+```bash
+scripts/install.sh
+```
+
+Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install.ps1
+```
+
+See `docs/INSTALL.md` for version, repository, and install path overrides.
+
 ## Checks
 
 ```bash

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,6 +28,12 @@ Install to a custom directory:
 ZERO_INSTALL_DIR="$HOME/bin" scripts/install.sh
 ```
 
+Install from a fork or internal repository:
+
+```bash
+scripts/install.sh --repo owner/repo
+```
+
 Defaults:
 
 - Repository: `Gitlawb/zero`
@@ -54,6 +60,12 @@ Install to a custom directory:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts/install.ps1 -InstallDir "$env:USERPROFILE\bin"
+```
+
+Install from a fork or internal repository:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install.ps1 -Repository owner/repo
 ```
 
 Defaults:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,73 @@
+# Zero Install Scripts
+
+Zero release archives are published as:
+
+- `zero-v<version>-linux-<arch>.tar.gz`
+- `zero-v<version>-macos-<arch>.tar.gz`
+- `zero-v<version>-windows-<arch>.zip`
+
+Each archive must have a matching `.sha256` file. The install scripts download both files and verify the checksum before copying the binary.
+
+## Linux And macOS
+
+From a checkout:
+
+```bash
+scripts/install.sh
+```
+
+Install a specific version:
+
+```bash
+ZERO_VERSION=0.1.0 scripts/install.sh
+```
+
+Install to a custom directory:
+
+```bash
+ZERO_INSTALL_DIR="$HOME/bin" scripts/install.sh
+```
+
+Defaults:
+
+- Repository: `Gitlawb/zero`
+- Version: latest GitHub release
+- Install path: `~/.local/bin/zero`
+
+Requirements: `curl` or `wget`, `tar`, and `shasum` or `sha256sum`.
+
+## Windows
+
+From a checkout:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install.ps1
+```
+
+Install a specific version:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install.ps1 -Version 0.1.0
+```
+
+Install to a custom directory:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install.ps1 -InstallDir "$env:USERPROFILE\bin"
+```
+
+Defaults:
+
+- Repository: `Gitlawb/zero`
+- Version: latest GitHub release
+- Install path: `%LOCALAPPDATA%\zero\bin\zero.exe`
+
+## Updating
+
+Check whether a newer release exists:
+
+```bash
+zero update --check
+```
+
+For M2, updates are check-only. Re-run the installer to replace the local binary after reviewing the release.

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -18,4 +18,4 @@ The release endpoint resolves in this order:
 
 `options.endpoint` and `ZERO_UPDATE_RELEASE_URL` may be a full URL or an `owner/repo` slug.
 
-Installer scripts should use this command before downloading the matching release asset for the local platform.
+Installer scripts download the matching release asset for the local platform and verify its `.sha256` file. If Zero is already installed, use this command before re-running the installer.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,101 @@
+[CmdletBinding()]
+param(
+  [string]$Version = $env:ZERO_VERSION,
+  [string]$Repository = $(if ($env:ZERO_REPO) { $env:ZERO_REPO } else { "Gitlawb/zero" }),
+  [string]$InstallDir = $env:ZERO_INSTALL_DIR,
+  [string]$GitHubApi = $(if ($env:ZERO_GITHUB_API) { $env:ZERO_GITHUB_API } else { "https://api.github.com" }),
+  [string]$GitHubBaseUrl = $(if ($env:ZERO_GITHUB_BASE_URL) { $env:ZERO_GITHUB_BASE_URL } else { "https://github.com" })
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = "latest"
+}
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+  $InstallDir = Join-Path $env:LOCALAPPDATA "zero\bin"
+}
+
+function Get-ZeroLatestTag {
+  param([string]$Repository, [string]$GitHubApi)
+
+  $apiBase = $GitHubApi.TrimEnd([char[]]"/")
+  $release = Invoke-RestMethod `
+    -Uri "$apiBase/repos/$Repository/releases/latest" `
+    -Headers @{ Accept = "application/vnd.github+json" } `
+    -TimeoutSec 15
+
+  if ([string]::IsNullOrWhiteSpace($release.tag_name)) {
+    throw "GitHub release response did not include tag_name"
+  }
+
+  return [string]$release.tag_name
+}
+
+function Get-ZeroArch {
+  $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+
+  switch ($arch) {
+    "X64" { return "x64" }
+    "Arm64" { return "arm64" }
+    default { throw "Unsupported architecture: $arch" }
+  }
+}
+
+if ($Version -eq "latest") {
+  $tag = Get-ZeroLatestTag -Repository $Repository -GitHubApi $GitHubApi
+} elseif ($Version.StartsWith("v")) {
+  $tag = $Version
+} else {
+  $tag = "v$Version"
+}
+
+$releaseVersion = $tag -replace "^v", ""
+$arch = Get-ZeroArch
+$archiveName = "zero-v$releaseVersion-windows-$arch.zip"
+$checksumName = "$archiveName.sha256"
+$releaseBase = $GitHubBaseUrl.TrimEnd([char[]]"/")
+$releaseUrl = "$releaseBase/$Repository/releases/download/$tag"
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("zero-install-" + [System.Guid]::NewGuid().ToString("N"))
+$extractDir = Join-Path $tempDir "extract"
+$archivePath = Join-Path $tempDir $archiveName
+$checksumPath = Join-Path $tempDir $checksumName
+
+try {
+  New-Item -ItemType Directory -Path $tempDir, $extractDir -Force | Out-Null
+
+  Write-Host "Installing Zero $tag for windows-$arch"
+  Invoke-WebRequest -Uri "$releaseUrl/$archiveName" -OutFile $archivePath -UseBasicParsing -TimeoutSec 300
+  Invoke-WebRequest -Uri "$releaseUrl/$checksumName" -OutFile $checksumPath -UseBasicParsing -TimeoutSec 300
+
+  $checksumLine = Get-Content -Path $checksumPath -TotalCount 1
+  $expectedChecksum = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+  $actualChecksum = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+  if ($expectedChecksum -ne $actualChecksum) {
+    throw "Checksum mismatch for $archiveName"
+  }
+
+  Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+  $binaryPath = Join-Path $extractDir "zero.exe"
+
+  if (-not (Test-Path $binaryPath)) {
+    throw "Release archive did not contain zero.exe"
+  }
+
+  New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  $targetPath = Join-Path $InstallDir "zero.exe"
+  Copy-Item -Path $binaryPath -Destination $targetPath -Force
+
+  Write-Host "Installed $targetPath"
+
+  $pathEntries = $env:PATH -split [System.IO.Path]::PathSeparator
+  if ($pathEntries -notcontains $InstallDir) {
+    Write-Host "Add $InstallDir to PATH to run zero from any directory."
+  }
+} finally {
+  if (Test-Path $tempDir) {
+    Remove-Item -Path $tempDir -Recurse -Force
+  }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -81,7 +81,15 @@ try {
   $binaryPath = Join-Path $extractDir "zero.exe"
 
   if (-not (Test-Path $binaryPath)) {
-    throw "Release archive did not contain zero.exe"
+    $binaryMatches = @(Get-ChildItem -Path $extractDir -Filter "zero.exe" -File -Recurse)
+
+    if ($binaryMatches.Count -eq 1) {
+      $binaryPath = $binaryMatches[0].FullName
+    }
+  }
+
+  if (-not (Test-Path $binaryPath)) {
+    throw "Release archive did not contain exactly one zero.exe"
   }
 
   New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ZERO_REPO="${ZERO_REPO:-Gitlawb/zero}"
+ZERO_VERSION="${ZERO_VERSION:-latest}"
+ZERO_INSTALL_DIR="${ZERO_INSTALL_DIR:-$HOME/.local/bin}"
+ZERO_GITHUB_API="${ZERO_GITHUB_API:-https://api.github.com}"
+ZERO_GITHUB_BASE_URL="${ZERO_GITHUB_BASE_URL:-https://github.com}"
+
+usage() {
+  cat <<'EOF'
+Install Zero from GitHub Releases.
+
+Usage:
+  scripts/install.sh [--version <version>] [--repo <owner/repo>] [--install-dir <path>]
+
+Environment:
+  ZERO_VERSION          Release version or tag. Defaults to latest.
+  ZERO_REPO             GitHub repository. Defaults to Gitlawb/zero.
+  ZERO_INSTALL_DIR      Directory for the zero binary. Defaults to ~/.local/bin.
+  ZERO_GITHUB_API       GitHub API base URL. Defaults to https://api.github.com.
+  ZERO_GITHUB_BASE_URL  GitHub web base URL. Defaults to https://github.com.
+EOF
+}
+
+fail() {
+  echo "zero install: $*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || fail "--version requires a value"
+      ZERO_VERSION="$2"
+      shift 2
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || fail "--repo requires a value"
+      ZERO_REPO="$2"
+      shift 2
+      ;;
+    --install-dir)
+      [ "$#" -ge 2 ] || fail "--install-dir requires a value"
+      ZERO_INSTALL_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+need_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+download() {
+  local url="$1"
+  local output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --location --show-error --silent "$url" --output "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget --quiet "$url" --output-document "$output"
+  else
+    fail "curl or wget is required"
+  fi
+}
+
+detect_platform() {
+  case "$(uname -s)" in
+    Linux) echo "linux" ;;
+    Darwin) echo "macos" ;;
+    *) fail "unsupported platform: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo "x64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *) fail "unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+latest_tag() {
+  local metadata_file="$1"
+  local api_url="${ZERO_GITHUB_API%/}/repos/${ZERO_REPO}/releases/latest"
+  local tag
+
+  download "$api_url" "$metadata_file"
+  tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$metadata_file" | head -n 1)"
+  [ -n "$tag" ] || fail "could not read tag_name from $api_url"
+  echo "$tag"
+}
+
+verify_checksum() {
+  local checksum_file="$1"
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$checksum_file"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$checksum_file"
+  else
+    fail "shasum or sha256sum is required"
+  fi
+}
+
+need_command uname
+need_command sed
+need_command tar
+need_command mktemp
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/zero-install.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+if [ "$ZERO_VERSION" = "latest" ]; then
+  tag="$(latest_tag "$tmp_dir/latest.json")"
+else
+  case "$ZERO_VERSION" in
+    v*) tag="$ZERO_VERSION" ;;
+    *) tag="v$ZERO_VERSION" ;;
+  esac
+fi
+
+version="${tag#v}"
+platform="$(detect_platform)"
+arch="$(detect_arch)"
+archive_name="zero-v${version}-${platform}-${arch}.tar.gz"
+checksum_name="${archive_name}.sha256"
+release_url="${ZERO_GITHUB_BASE_URL%/}/${ZERO_REPO}/releases/download/${tag}"
+archive_path="$tmp_dir/$archive_name"
+checksum_path="$tmp_dir/$checksum_name"
+extract_dir="$tmp_dir/extract"
+
+echo "Installing Zero ${tag} for ${platform}-${arch}"
+download "${release_url}/${archive_name}" "$archive_path"
+download "${release_url}/${checksum_name}" "$checksum_path"
+
+(
+  cd "$tmp_dir"
+  verify_checksum "$checksum_name"
+)
+
+mkdir -p "$extract_dir"
+tar -xzf "$archive_path" -C "$extract_dir"
+
+binary_path="$extract_dir/zero"
+[ -f "$binary_path" ] || fail "release archive did not contain zero"
+
+mkdir -p "$ZERO_INSTALL_DIR"
+cp "$binary_path" "$ZERO_INSTALL_DIR/zero"
+chmod 755 "$ZERO_INSTALL_DIR/zero"
+
+echo "Installed $ZERO_INSTALL_DIR/zero"
+
+case ":$PATH:" in
+  *":$ZERO_INSTALL_DIR:"*) ;;
+  *) echo "Add $ZERO_INSTALL_DIR to PATH to run zero from any directory." ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,6 +72,19 @@ download() {
   fi
 }
 
+download_json() {
+  local url="$1"
+  local output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --location --show-error --silent --header 'Accept: application/vnd.github+json' "$url" --output "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget --quiet --header='Accept: application/vnd.github+json' "$url" --output-document "$output"
+  else
+    fail "curl or wget is required"
+  fi
+}
+
 detect_platform() {
   case "$(uname -s)" in
     Linux) echo "linux" ;;
@@ -93,7 +106,7 @@ latest_tag() {
   local api_url="${ZERO_GITHUB_API%/}/repos/${ZERO_REPO}/releases/latest"
   local tag
 
-  download "$api_url" "$metadata_file"
+  download_json "$api_url" "$metadata_file"
   tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$metadata_file" | head -n 1)"
   [ -n "$tag" ] || fail "could not read tag_name from $api_url"
   echo "$tag"
@@ -109,6 +122,25 @@ verify_checksum() {
   else
     fail "shasum or sha256sum is required"
   fi
+}
+
+find_extracted_binary() {
+  local root="$1"
+  local candidate
+
+  if [ -f "$root/zero" ]; then
+    echo "$root/zero"
+    return 0
+  fi
+
+  for candidate in "$root"/*/zero; do
+    if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 need_command uname
@@ -153,8 +185,7 @@ download "${release_url}/${checksum_name}" "$checksum_path"
 mkdir -p "$extract_dir"
 tar -xzf "$archive_path" -C "$extract_dir"
 
-binary_path="$extract_dir/zero"
-[ -f "$binary_path" ] || fail "release archive did not contain zero"
+binary_path="$(find_extracted_binary "$extract_dir")" || fail "release archive did not contain zero"
 
 mkdir -p "$ZERO_INSTALL_DIR"
 cp "$binary_path" "$ZERO_INSTALL_DIR/zero"

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+
+async function read(path: string): Promise<string> {
+  return Bun.file(path).text();
+}
+
+describe('install scripts', () => {
+  it('keeps the Unix installer aligned with release artifact naming and checksums', async () => {
+    const script = await read('scripts/install.sh');
+
+    expect(script.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(script).toContain('set -euo pipefail');
+    expect(script).toContain('ZERO_REPO="${ZERO_REPO:-Gitlawb/zero}"');
+    expect(script).toContain('ZERO_INSTALL_DIR="${ZERO_INSTALL_DIR:-$HOME/.local/bin}"');
+    expect(script).toContain('archive_name="zero-v${version}-${platform}-${arch}.tar.gz"');
+    expect(script).toContain('checksum_name="${archive_name}.sha256"');
+    expect(script).toContain('verify_checksum "$checksum_name"');
+    expect(script).toContain('tar -xzf "$archive_path" -C "$extract_dir"');
+    expect(script).toContain('cp "$binary_path" "$ZERO_INSTALL_DIR/zero"');
+  });
+
+  it('keeps the PowerShell installer aligned with Windows release artifacts and checksums', async () => {
+    const script = await read('scripts/install.ps1');
+
+    expect(script).toContain('[string]$Repository = $(if ($env:ZERO_REPO)');
+    expect(script).toContain('Join-Path $env:LOCALAPPDATA "zero\\bin"');
+    expect(script).toContain('$archiveName = "zero-v$releaseVersion-windows-$arch.zip"');
+    expect(script).toContain('$checksumName = "$archiveName.sha256"');
+    expect(script).toContain('Get-FileHash -Path $archivePath -Algorithm SHA256');
+    expect(script).toContain('Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force');
+    expect(script).toContain('Copy-Item -Path $binaryPath -Destination $targetPath -Force');
+  });
+});

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 async function read(path: string): Promise<string> {
   return Bun.file(path).text();
@@ -14,8 +18,10 @@ describe('install scripts', () => {
     expect(script).toContain('ZERO_INSTALL_DIR="${ZERO_INSTALL_DIR:-$HOME/.local/bin}"');
     expect(script).toContain('archive_name="zero-v${version}-${platform}-${arch}.tar.gz"');
     expect(script).toContain('checksum_name="${archive_name}.sha256"');
+    expect(script).toContain("curl --fail --location --show-error --silent --header 'Accept: application/vnd.github+json'");
     expect(script).toContain('verify_checksum "$checksum_name"');
     expect(script).toContain('tar -xzf "$archive_path" -C "$extract_dir"');
+    expect(script).toContain('find_extracted_binary "$extract_dir"');
     expect(script).toContain('cp "$binary_path" "$ZERO_INSTALL_DIR/zero"');
   });
 
@@ -28,6 +34,103 @@ describe('install scripts', () => {
     expect(script).toContain('$checksumName = "$archiveName.sha256"');
     expect(script).toContain('Get-FileHash -Path $archivePath -Algorithm SHA256');
     expect(script).toContain('Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force');
+    expect(script).toContain('Get-ChildItem -Path $extractDir -Filter "zero.exe" -File -Recurse');
     expect(script).toContain('Copy-Item -Path $binaryPath -Destination $targetPath -Force');
+  });
+
+  it('installs from a prefixed Unix release archive without network access', async () => {
+    if (process.platform === 'win32') return;
+
+    const root = await mkdtemp(join(tmpdir(), 'zero-install-test-'));
+    const mockBin = join(root, 'bin');
+    const packageDir = join(root, 'package', 'zero-v0.1.0-linux-x64');
+    const releaseDir = join(root, 'release');
+    const installDir = join(root, 'install');
+    const archiveName = 'zero-v0.1.0-linux-x64.tar.gz';
+    const archivePath = join(releaseDir, archiveName);
+    const checksumPath = `${archivePath}.sha256`;
+
+    await mkdir(mockBin, { recursive: true });
+    await mkdir(packageDir, { recursive: true });
+    await mkdir(releaseDir, { recursive: true });
+    await mkdir(installDir, { recursive: true });
+    await writeFile(join(packageDir, 'zero'), '#!/usr/bin/env sh\necho mock-zero\n');
+    await chmod(join(packageDir, 'zero'), 0o755);
+
+    const tar = Bun.spawn(['tar', '-C', join(root, 'package'), '-czf', archivePath, 'zero-v0.1.0-linux-x64'], {
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+    const [tarExit, tarStderr] = await Promise.all([
+      tar.exited,
+      new Response(tar.stderr).text(),
+    ]);
+    expect(tarExit).toBe(0);
+    expect(tarStderr.trim()).toBe('');
+
+    const checksum = createHash('sha256')
+      .update(Buffer.from(await Bun.file(archivePath).arrayBuffer()))
+      .digest('hex');
+    await writeFile(checksumPath, `${checksum}  ${archiveName}\n`);
+
+    const mockCurl = join(mockBin, 'curl');
+    await writeFile(mockCurl, `#!/usr/bin/env sh
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    --header)
+      shift 2
+      ;;
+    --fail|--location|--show-error|--silent)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  */${archiveName})
+    cp "${archivePath}" "$output"
+    ;;
+  */${archiveName}.sha256)
+    cp "${checksumPath}" "$output"
+    ;;
+  *)
+    echo "unexpected url: $url" >&2
+    exit 2
+    ;;
+esac
+`);
+    await chmod(mockCurl, 0o755);
+
+    const child = Bun.spawn(['bash', 'scripts/install.sh', '--version', '0.1.0', '--install-dir', installDir], {
+      env: {
+        ...process.env,
+        PATH: `${mockBin}:${process.env.PATH ?? ''}`,
+        ZERO_GITHUB_BASE_URL: 'https://example.test',
+        ZERO_REPO: 'Gitlawb/zero',
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr.trim()).toBe('');
+    expect(stdout).toContain(`Installed ${join(installDir, 'zero')}`);
+    expect(await Bun.file(join(installDir, 'zero')).text()).toContain('mock-zero');
   });
 });

--- a/tests/install-scripts.test.ts
+++ b/tests/install-scripts.test.ts
@@ -41,12 +41,15 @@ describe('install scripts', () => {
   it('installs from a prefixed Unix release archive without network access', async () => {
     if (process.platform === 'win32') return;
 
+    const releasePlatform = process.platform === 'darwin' ? 'macos' : 'linux';
+    const releaseArch = process.arch === 'arm64' ? 'arm64' : 'x64';
+    const packageName = `zero-v0.1.0-${releasePlatform}-${releaseArch}`;
+    const archiveName = `${packageName}.tar.gz`;
     const root = await mkdtemp(join(tmpdir(), 'zero-install-test-'));
     const mockBin = join(root, 'bin');
-    const packageDir = join(root, 'package', 'zero-v0.1.0-linux-x64');
+    const packageDir = join(root, 'package', packageName);
     const releaseDir = join(root, 'release');
     const installDir = join(root, 'install');
-    const archiveName = 'zero-v0.1.0-linux-x64.tar.gz';
     const archivePath = join(releaseDir, archiveName);
     const checksumPath = `${archivePath}.sha256`;
 
@@ -57,7 +60,7 @@ describe('install scripts', () => {
     await writeFile(join(packageDir, 'zero'), '#!/usr/bin/env sh\necho mock-zero\n');
     await chmod(join(packageDir, 'zero'), 0o755);
 
-    const tar = Bun.spawn(['tar', '-C', join(root, 'package'), '-czf', archivePath, 'zero-v0.1.0-linux-x64'], {
+    const tar = Bun.spawn(['tar', '-C', join(root, 'package'), '-czf', archivePath, packageName], {
       stderr: 'pipe',
       stdout: 'pipe',
     });


### PR DESCRIPTION
## Summary
- add Linux/macOS install script for GitHub release tarballs with checksum verification
- add Windows PowerShell install script draft for release zip assets with checksum verification
- document install paths, version overrides, and update-check relationship
- add static installer contract tests for asset naming, extraction, and checksum behavior

## Validation
- bun test tests/install-scripts.test.ts
- bun test
- bun run typecheck
- bun run build
- bun run smoke:build
- bun run package:release
- bash -n scripts/install.sh
- scripts/install.sh --help

Note: PowerShell is not installed in this local environment, so the Windows script is covered here by static tests and will be reviewed/validated on Windows.