### PR TITLE
feat: add M2 performance benchmark harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,33 @@ jobs:
 
       - name: Smoke binary
         run: bun run smoke:build
+
+  performance:
+    name: Performance Smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build binary
+        run: bun run build
+
+      - name: Performance smoke
+        run: bun run scripts/perf-bench.ts --ci --output dist/perf/perf-bench.json
+
+      - name: Upload performance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zero-performance-smoke
+          path: dist/perf/perf-bench.json
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ bun test
 bun run typecheck
 bun run build
 bun run smoke:build
+bun run perf:bench
 bun run package:release
 ```
 
@@ -43,5 +44,7 @@ Check for released CLI updates:
 ```bash
 ./zero update --check
 ```
+
+See `docs/PERFORMANCE.md` for benchmark thresholds and CI smoke behavior.
 
 Bun version is pinned in `package.json`.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,60 @@
+# Zero Performance Benchmarks
+
+The M2 performance harness tracks three release-facing signals:
+
+- Cold start: process startup time for `zero --version`.
+- TTFT: time from starting the local agent loop to the first streamed text event from a deterministic provider.
+- Memory: peak RSS for the benchmarked in-process agent path.
+
+When a built binary exists at `./zero` or `./zero.exe`, cold start uses that artifact. Otherwise it falls back to `bun src/index.ts --version` so the benchmark can run before a local build.
+
+## Run Locally
+
+```bash
+bun run perf:bench
+```
+
+Run against a freshly built binary:
+
+```bash
+bun run build
+bun run perf:bench
+```
+
+Write the JSON report used by CI:
+
+```bash
+bun run perf:smoke
+```
+
+Default warning thresholds:
+
+- Cold start p95: 300 ms
+- TTFT p95: 500 ms
+- Agent RSS peak: 256 MB
+
+Override thresholds with CLI flags:
+
+```bash
+bun run scripts/perf-bench.ts --cold-start-warn-ms 350 --ttft-warn-ms 600 --rss-warn-mb 384
+```
+
+Or with environment variables:
+
+```bash
+ZERO_PERF_COLD_START_WARN_MS=350 bun run perf:bench
+```
+
+Supported environment variables:
+
+- `ZERO_PERF_ITERATIONS`
+- `ZERO_PERF_WARMUP_ITERATIONS`
+- `ZERO_PERF_COLD_START_WARN_MS`
+- `ZERO_PERF_TTFT_WARN_MS`
+- `ZERO_PERF_RSS_WARN_MB`
+
+## CI Behavior
+
+The `Performance Smoke` job builds the binary, runs `bun run perf:smoke`, and uploads `dist/perf/perf-bench.json`.
+
+Threshold drift is emitted as GitHub Actions warnings. The job fails only if the benchmark cannot run, the build fails, or `--fail-on-warning` is passed explicitly.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -33,10 +33,12 @@ Default warning thresholds:
 - TTFT p95: 500 ms
 - Agent RSS peak: 256 MB
 
+The default sample count is intentionally small for CI smoke coverage. `p95` uses nearest-rank percentile selection, so with the default 5 measured samples it is the slowest sample. Increase `--iterations` for local baseline investigations.
+
 Override thresholds with CLI flags:
 
 ```bash
-bun run scripts/perf-bench.ts --cold-start-warn-ms 350 --ttft-warn-ms 600 --rss-warn-mb 384
+bun run scripts/perf-bench.ts --cold-start-warn-ms=350 --ttft-warn-ms=600 --rss-warn-mb=384
 ```
 
 Or with environment variables:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "typecheck": "bunx tsc --noEmit",
     "build": "bun run scripts/build.ts",
     "smoke:build": "bun run scripts/smoke-build.ts",
-    "package:release": "bun run scripts/package-release.ts"
+    "package:release": "bun run scripts/package-release.ts",
+    "perf:bench": "bun run scripts/perf-bench.ts",
+    "perf:smoke": "bun run scripts/perf-bench.ts --output dist/perf/perf-bench.json"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/perf-bench.ts
+++ b/scripts/perf-bench.ts
@@ -1,0 +1,537 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { runAgent } from '../src/agent/loop';
+import type { Message, Provider, StreamEvent, ToolDefinition } from '../src/providers/types';
+import { zeroArtifactName, zeroArtifactPath } from './artifact';
+
+export interface PerfThresholds {
+  coldStartP95Ms: number;
+  ttftP95Ms: number;
+  agentRssMaxMb: number;
+}
+
+export interface NumericStats {
+  samples: number[];
+  min: number;
+  median: number;
+  average: number;
+  p95: number;
+  max: number;
+}
+
+export interface PerfMetrics {
+  coldStartMs: NumericStats;
+  ttftMs: NumericStats;
+  streamOverheadMs: NumericStats;
+  agentRssMb: NumericStats;
+  agentRssDeltaMb: NumericStats;
+}
+
+export interface PerfWarning {
+  metric: keyof PerfMetrics;
+  statistic: keyof NumericStats;
+  observed: number;
+  threshold: number;
+  unit: 'ms' | 'MB';
+  message: string;
+}
+
+export interface PerfBenchResult {
+  schemaVersion: 1;
+  timestamp: string;
+  platform: {
+    os: NodeJS.Platform;
+    arch: string;
+    bunVersion: string;
+  };
+  coldStartCommand: string[];
+  iterations: number;
+  warmupIterations: number;
+  thresholds: PerfThresholds;
+  metrics: PerfMetrics;
+  benchmarkDurationMs: number;
+  warnings: PerfWarning[];
+}
+
+export interface PerfBenchOptions {
+  iterations: number;
+  warmupIterations: number;
+  thresholds: PerfThresholds;
+}
+
+export interface PerfBenchCliOptions extends PerfBenchOptions {
+  ci: boolean;
+  json: boolean;
+  output?: string;
+  failOnWarning: boolean;
+  help: boolean;
+}
+
+interface TtftSample {
+  ttftMs: number;
+  streamOverheadMs: number;
+  agentRssMb: number;
+  agentRssDeltaMb: number;
+}
+
+const DEFAULT_ITERATIONS = 5;
+const DEFAULT_WARMUP_ITERATIONS = 1;
+
+export const DEFAULT_PERF_THRESHOLDS: PerfThresholds = {
+  coldStartP95Ms: 300,
+  ttftP95Ms: 500,
+  agentRssMaxMb: 256,
+};
+
+export function summarizeSamples(samples: number[]): NumericStats {
+  if (samples.length === 0) {
+    throw new Error('Cannot summarize an empty sample set');
+  }
+
+  const sorted = samples.map(roundMetric).sort((a, b) => a - b);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+
+  return {
+    samples: sorted,
+    min: sorted[0]!,
+    median: median(sorted),
+    average: roundMetric(total / sorted.length),
+    p95: percentile(sorted, 95),
+    max: sorted[sorted.length - 1]!,
+  };
+}
+
+export function evaluatePerfWarnings(
+  metrics: PerfMetrics,
+  thresholds: PerfThresholds
+): PerfWarning[] {
+  return [
+    createWarning(
+      'coldStartMs',
+      'p95',
+      metrics.coldStartMs.p95,
+      thresholds.coldStartP95Ms,
+      'ms',
+      'Cold start p95'
+    ),
+    createWarning('ttftMs', 'p95', metrics.ttftMs.p95, thresholds.ttftP95Ms, 'ms', 'TTFT p95'),
+    createWarning(
+      'agentRssMb',
+      'max',
+      metrics.agentRssMb.max,
+      thresholds.agentRssMaxMb,
+      'MB',
+      'Agent RSS peak'
+    ),
+  ].filter((warning): warning is PerfWarning => warning !== undefined);
+}
+
+export function formatPerfSummary(result: PerfBenchResult): string {
+  const lines = [
+    `Zero performance benchmark (${result.platform.os}/${result.platform.arch}, Bun ${result.platform.bunVersion})`,
+    `command: ${formatCommand(result.coldStartCommand)}`,
+    `iterations: ${result.iterations} measured, ${result.warmupIterations} warmup`,
+    `cold start: median ${formatMetric(result.metrics.coldStartMs.median, 'ms')}, p95 ${formatMetric(result.metrics.coldStartMs.p95, 'ms')} (warn > ${formatMetric(result.thresholds.coldStartP95Ms, 'ms')})`,
+    `TTFT: median ${formatMetric(result.metrics.ttftMs.median, 'ms')}, p95 ${formatMetric(result.metrics.ttftMs.p95, 'ms')} (warn > ${formatMetric(result.thresholds.ttftP95Ms, 'ms')})`,
+    `stream overhead: median ${formatMetric(result.metrics.streamOverheadMs.median, 'ms')}, p95 ${formatMetric(result.metrics.streamOverheadMs.p95, 'ms')}`,
+    `agent RSS: peak ${formatMetric(result.metrics.agentRssMb.max, 'MB')}, max delta ${formatMetric(result.metrics.agentRssDeltaMb.max, 'MB')} (warn > ${formatMetric(result.thresholds.agentRssMaxMb, 'MB')})`,
+  ];
+
+  if (result.warnings.length > 0) {
+    lines.push('warnings:');
+    for (const warning of result.warnings) {
+      lines.push(`- ${warning.message}`);
+    }
+  } else {
+    lines.push('warnings: none');
+  }
+
+  return lines.join('\n');
+}
+
+export function parsePerfBenchArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env
+): PerfBenchCliOptions {
+  const options: PerfBenchCliOptions = {
+    iterations: readPositiveIntegerEnv(env, 'ZERO_PERF_ITERATIONS', DEFAULT_ITERATIONS),
+    warmupIterations: readNonNegativeIntegerEnv(
+      env,
+      'ZERO_PERF_WARMUP_ITERATIONS',
+      DEFAULT_WARMUP_ITERATIONS
+    ),
+    thresholds: {
+      coldStartP95Ms: readPositiveNumberEnv(
+        env,
+        'ZERO_PERF_COLD_START_WARN_MS',
+        DEFAULT_PERF_THRESHOLDS.coldStartP95Ms
+      ),
+      ttftP95Ms: readPositiveNumberEnv(
+        env,
+        'ZERO_PERF_TTFT_WARN_MS',
+        DEFAULT_PERF_THRESHOLDS.ttftP95Ms
+      ),
+      agentRssMaxMb: readPositiveNumberEnv(
+        env,
+        'ZERO_PERF_RSS_WARN_MB',
+        DEFAULT_PERF_THRESHOLDS.agentRssMaxMb
+      ),
+    },
+    ci: env.GITHUB_ACTIONS === 'true',
+    json: false,
+    failOnWarning: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!;
+
+    switch (arg) {
+      case '--iterations':
+        options.iterations = parsePositiveInteger(arg, requireValue(args, ++index, arg));
+        break;
+      case '--warmup':
+        options.warmupIterations = parseNonNegativeInteger(arg, requireValue(args, ++index, arg));
+        break;
+      case '--cold-start-warn-ms':
+        options.thresholds.coldStartP95Ms = parsePositiveNumber(arg, requireValue(args, ++index, arg));
+        break;
+      case '--ttft-warn-ms':
+        options.thresholds.ttftP95Ms = parsePositiveNumber(arg, requireValue(args, ++index, arg));
+        break;
+      case '--rss-warn-mb':
+        options.thresholds.agentRssMaxMb = parsePositiveNumber(arg, requireValue(args, ++index, arg));
+        break;
+      case '--output':
+        options.output = requireValue(args, ++index, arg);
+        break;
+      case '--ci':
+        options.ci = true;
+        break;
+      case '--json':
+        options.json = true;
+        break;
+      case '--fail-on-warning':
+        options.failOnWarning = true;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export function perfBenchHelp(): string {
+  return [
+    'Usage: bun run scripts/perf-bench.ts [options]',
+    '',
+    'Options:',
+    '  --iterations <n>             Measured samples to collect (default: 5)',
+    '  --warmup <n>                 Warmup samples to discard (default: 1)',
+    '  --cold-start-warn-ms <n>     Warn when cold-start p95 is above n ms',
+    '  --ttft-warn-ms <n>           Warn when TTFT p95 is above n ms',
+    '  --rss-warn-mb <n>            Warn when agent RSS peak is above n MB',
+    '  --output <path>              Write the JSON report to path',
+    '  --json                       Print only the JSON report',
+    '  --ci                         Emit GitHub Actions warning annotations',
+    '  --fail-on-warning            Exit non-zero when thresholds are exceeded',
+    '  -h, --help                   Show this help',
+    '',
+    'Environment overrides:',
+    '  ZERO_PERF_ITERATIONS, ZERO_PERF_WARMUP_ITERATIONS',
+    '  ZERO_PERF_COLD_START_WARN_MS, ZERO_PERF_TTFT_WARN_MS, ZERO_PERF_RSS_WARN_MB',
+  ].join('\n');
+}
+
+export async function runPerfBench(options: PerfBenchOptions): Promise<PerfBenchResult> {
+  const benchmarkStartedAt = performance.now();
+  const coldStartCommand = await resolveColdStartCommand();
+  const coldStartSamples: number[] = [];
+  const ttftSamples: TtftSample[] = [];
+
+  for (let i = 0; i < options.warmupIterations; i++) {
+    await measureColdStart(coldStartCommand);
+    await measureTtft();
+  }
+
+  for (let i = 0; i < options.iterations; i++) {
+    coldStartSamples.push(await measureColdStart(coldStartCommand));
+    ttftSamples.push(await measureTtft());
+  }
+
+  const metrics: PerfMetrics = {
+    coldStartMs: summarizeSamples(coldStartSamples),
+    ttftMs: summarizeSamples(ttftSamples.map((sample) => sample.ttftMs)),
+    streamOverheadMs: summarizeSamples(ttftSamples.map((sample) => sample.streamOverheadMs)),
+    agentRssMb: summarizeSamples(ttftSamples.map((sample) => sample.agentRssMb)),
+    agentRssDeltaMb: summarizeSamples(ttftSamples.map((sample) => sample.agentRssDeltaMb)),
+  };
+
+  const result: PerfBenchResult = {
+    schemaVersion: 1,
+    timestamp: new Date().toISOString(),
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      bunVersion: Bun.version,
+    },
+    coldStartCommand,
+    iterations: options.iterations,
+    warmupIterations: options.warmupIterations,
+    thresholds: options.thresholds,
+    metrics,
+    benchmarkDurationMs: roundMetric(performance.now() - benchmarkStartedAt),
+    warnings: [],
+  };
+
+  result.warnings = evaluatePerfWarnings(metrics, options.thresholds);
+  return result;
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parsePerfBenchArgs(process.argv.slice(2));
+
+    if (options.help) {
+      console.log(perfBenchHelp());
+      return;
+    }
+
+    const result = await runPerfBench(options);
+
+    if (options.output) {
+      await mkdir(dirname(options.output), { recursive: true });
+      await writeFile(options.output, `${JSON.stringify(result, null, 2)}\n`, 'utf-8');
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatPerfSummary(result));
+    }
+
+    if (options.ci) {
+      emitPerfWarnings(result);
+    }
+
+    if (options.failOnWarning && result.warnings.length > 0) {
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[zero] Performance benchmark failed: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+async function resolveColdStartCommand(): Promise<string[]> {
+  if (await Bun.file(zeroArtifactPath).exists()) {
+    return [zeroArtifactPath, '--version'];
+  }
+
+  return [process.execPath, 'src/index.ts', '--version'];
+}
+
+async function measureColdStart(command: string[]): Promise<number> {
+  const startedAt = performance.now();
+  const child = Bun.spawn(command, {
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+    },
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    readSpawnStream(child.stdout),
+    readSpawnStream(child.stderr),
+  ]);
+  const durationMs = roundMetric(performance.now() - startedAt);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `${formatCommand(command)} exited with ${exitCode}: ${stderr.trim() || stdout.trim() || 'no output'}`
+    );
+  }
+
+  return durationMs;
+}
+
+async function measureTtft(): Promise<TtftSample> {
+  const rssBefore = readRssMb();
+  const startedAt = performance.now();
+  let providerFirstByteAt: number | undefined;
+  let firstTextAt: number | undefined;
+
+  const provider = new ImmediateTextProvider((at) => {
+    providerFirstByteAt = at;
+  });
+
+  await runAgent('Reply with "ok".', provider, {
+    maxTurns: 1,
+    onText: () => {
+      firstTextAt ??= performance.now();
+    },
+  });
+
+  const finishedAt = performance.now();
+  const rssAfter = readRssMb();
+  const observedFirstTextAt = firstTextAt ?? finishedAt;
+  const streamOverheadMs =
+    providerFirstByteAt === undefined ? 0 : observedFirstTextAt - providerFirstByteAt;
+
+  return {
+    ttftMs: roundMetric(observedFirstTextAt - startedAt),
+    streamOverheadMs: roundMetric(Math.max(0, streamOverheadMs)),
+    agentRssMb: roundMetric(rssAfter),
+    agentRssDeltaMb: roundMetric(Math.max(0, rssAfter - rssBefore)),
+  };
+}
+
+class ImmediateTextProvider implements Provider {
+  constructor(private readonly onFirstByte: (at: number) => void) {}
+
+  async *streamCompletion(
+    _messages: Message[],
+    _tools: ToolDefinition[]
+  ): AsyncIterable<StreamEvent> {
+    this.onFirstByte(performance.now());
+    yield { type: 'text', content: 'ok' };
+    yield { type: 'done' };
+  }
+}
+
+function createWarning(
+  metric: keyof PerfMetrics,
+  statistic: keyof NumericStats,
+  observed: number,
+  threshold: number,
+  unit: 'ms' | 'MB',
+  label: string
+): PerfWarning | undefined {
+  if (observed <= threshold) return undefined;
+
+  return {
+    metric,
+    statistic,
+    observed,
+    threshold,
+    unit,
+    message: `${label} ${formatMetric(observed, unit)} exceeded warning threshold ${formatMetric(threshold, unit)}`,
+  };
+}
+
+function emitPerfWarnings(result: PerfBenchResult): void {
+  for (const warning of result.warnings) {
+    console.warn(`::warning title=Zero performance::${escapeActionCommand(warning.message)}`);
+  }
+}
+
+function readRssMb(): number {
+  return process.memoryUsage().rss / 1024 / 1024;
+}
+
+async function readSpawnStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return '';
+  return new Response(stream).text();
+}
+
+function percentile(sortedSamples: number[], percentileValue: number): number {
+  const index = Math.max(
+    0,
+    Math.min(sortedSamples.length - 1, Math.ceil((percentileValue / 100) * sortedSamples.length) - 1)
+  );
+  return sortedSamples[index]!;
+}
+
+function median(sortedSamples: number[]): number {
+  const middle = Math.floor(sortedSamples.length / 2);
+
+  if (sortedSamples.length % 2 === 1) {
+    return sortedSamples[middle]!;
+  }
+
+  return roundMetric((sortedSamples[middle - 1]! + sortedSamples[middle]!) / 2);
+}
+
+function roundMetric(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function formatMetric(value: number, unit: 'ms' | 'MB'): string {
+  return `${roundMetric(value).toFixed(2)} ${unit}`;
+}
+
+function formatCommand(command: string[]): string {
+  return command.map((part) => (/\s/.test(part) ? JSON.stringify(part) : part)).join(' ');
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function readPositiveIntegerEnv(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number
+): number {
+  const value = env[name];
+  return value === undefined ? fallback : parsePositiveInteger(name, value);
+}
+
+function readNonNegativeIntegerEnv(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number
+): number {
+  const value = env[name];
+  return value === undefined ? fallback : parseNonNegativeInteger(name, value);
+}
+
+function readPositiveNumberEnv(env: NodeJS.ProcessEnv, name: string, fallback: number): number {
+  const value = env[name];
+  return value === undefined ? fallback : parsePositiveNumber(name, value);
+}
+
+function parsePositiveInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function parsePositiveNumber(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return parsed;
+}
+
+function escapeActionCommand(value: string): string {
+  return value.replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A');
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/perf-bench.ts
+++ b/scripts/perf-bench.ts
@@ -184,42 +184,65 @@ export function parsePerfBenchArgs(
   };
 
   for (let index = 0; index < args.length; index++) {
-    const arg = args[index]!;
+    const rawArg = args[index]!;
+    const { flag, inlineValue } = splitFlagValue(rawArg);
 
-    switch (arg) {
+    switch (flag) {
       case '--iterations':
-        options.iterations = parsePositiveInteger(arg, requireValue(args, ++index, arg));
+        options.iterations = parsePositiveInteger(flag, readOptionValue(args, inlineValue, ++index, flag));
+        if (inlineValue !== undefined) index--;
         break;
       case '--warmup':
-        options.warmupIterations = parseNonNegativeInteger(arg, requireValue(args, ++index, arg));
+        options.warmupIterations = parseNonNegativeInteger(
+          flag,
+          readOptionValue(args, inlineValue, ++index, flag)
+        );
+        if (inlineValue !== undefined) index--;
         break;
       case '--cold-start-warn-ms':
-        options.thresholds.coldStartP95Ms = parsePositiveNumber(arg, requireValue(args, ++index, arg));
+        options.thresholds.coldStartP95Ms = parsePositiveNumber(
+          flag,
+          readOptionValue(args, inlineValue, ++index, flag)
+        );
+        if (inlineValue !== undefined) index--;
         break;
       case '--ttft-warn-ms':
-        options.thresholds.ttftP95Ms = parsePositiveNumber(arg, requireValue(args, ++index, arg));
+        options.thresholds.ttftP95Ms = parsePositiveNumber(
+          flag,
+          readOptionValue(args, inlineValue, ++index, flag)
+        );
+        if (inlineValue !== undefined) index--;
         break;
       case '--rss-warn-mb':
-        options.thresholds.agentRssMaxMb = parsePositiveNumber(arg, requireValue(args, ++index, arg));
+        options.thresholds.agentRssMaxMb = parsePositiveNumber(
+          flag,
+          readOptionValue(args, inlineValue, ++index, flag)
+        );
+        if (inlineValue !== undefined) index--;
         break;
       case '--output':
-        options.output = requireValue(args, ++index, arg);
+        options.output = readOptionValue(args, inlineValue, ++index, flag);
+        if (inlineValue !== undefined) index--;
         break;
       case '--ci':
+        rejectInlineValue(flag, inlineValue);
         options.ci = true;
         break;
       case '--json':
+        rejectInlineValue(flag, inlineValue);
         options.json = true;
         break;
       case '--fail-on-warning':
+        rejectInlineValue(flag, inlineValue);
         options.failOnWarning = true;
         break;
       case '--help':
       case '-h':
+        rejectInlineValue(flag, inlineValue);
         options.help = true;
         break;
       default:
-        throw new Error(`Unknown option: ${arg}`);
+        throw new Error(`Unknown option: ${rawArg}`);
     }
   }
 
@@ -473,12 +496,44 @@ function formatCommand(command: string[]): string {
   return command.map((part) => (/\s/.test(part) ? JSON.stringify(part) : part)).join(' ');
 }
 
+function splitFlagValue(arg: string): { flag: string; inlineValue?: string } {
+  const separatorIndex = arg.indexOf('=');
+  if (separatorIndex === -1) return { flag: arg };
+
+  return {
+    flag: arg.slice(0, separatorIndex),
+    inlineValue: arg.slice(separatorIndex + 1),
+  };
+}
+
+function readOptionValue(
+  args: string[],
+  inlineValue: string | undefined,
+  index: number,
+  flag: string
+): string {
+  if (inlineValue !== undefined) {
+    if (inlineValue === '') {
+      throw new Error(`${flag} requires a value`);
+    }
+    return inlineValue;
+  }
+
+  return requireValue(args, index, flag);
+}
+
 function requireValue(args: string[], index: number, flag: string): string {
   const value = args[index];
   if (!value || value.startsWith('--')) {
     throw new Error(`${flag} requires a value`);
   }
   return value;
+}
+
+function rejectInlineValue(flag: string, inlineValue: string | undefined): void {
+  if (inlineValue !== undefined) {
+    throw new Error(`${flag} does not accept a value`);
+  }
 }
 
 function readPositiveIntegerEnv(

--- a/tests/perf-bench.test.ts
+++ b/tests/perf-bench.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_PERF_THRESHOLDS,
+  evaluatePerfWarnings,
+  formatPerfSummary,
+  parsePerfBenchArgs,
+  summarizeSamples,
+  type PerfBenchResult,
+  type PerfMetrics,
+} from '../scripts/perf-bench';
+
+describe('performance benchmark helpers', () => {
+  it('summarizes samples with stable sorted output', () => {
+    const stats = summarizeSamples([30.333, 10.111, 20.222, 40.444]);
+
+    expect(stats.samples).toEqual([10.11, 20.22, 30.33, 40.44]);
+    expect(stats.min).toBe(10.11);
+    expect(stats.median).toBe(25.27);
+    expect(stats.p95).toBe(40.44);
+    expect(stats.max).toBe(40.44);
+  });
+
+  it('classifies threshold warnings without failing every metric', () => {
+    const metrics: PerfMetrics = {
+      coldStartMs: summarizeSamples([120, 301]),
+      ttftMs: summarizeSamples([12, 18]),
+      streamOverheadMs: summarizeSamples([0.2, 0.4]),
+      agentRssMb: summarizeSamples([80, 90]),
+      agentRssDeltaMb: summarizeSamples([1, 3]),
+    };
+
+    const warnings = evaluatePerfWarnings(metrics, DEFAULT_PERF_THRESHOLDS);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      metric: 'coldStartMs',
+      statistic: 'p95',
+      observed: 301,
+      threshold: 300,
+      unit: 'ms',
+    });
+  });
+
+  it('parses CLI and environment overrides', () => {
+    const options = parsePerfBenchArgs(
+      [
+        '--iterations',
+        '3',
+        '--warmup',
+        '0',
+        '--ttft-warn-ms',
+        '600',
+        '--output',
+        'dist/perf/report.json',
+        '--ci',
+        '--fail-on-warning',
+      ],
+      {
+        ZERO_PERF_COLD_START_WARN_MS: '250',
+        ZERO_PERF_RSS_WARN_MB: '384',
+      }
+    );
+
+    expect(options.iterations).toBe(3);
+    expect(options.warmupIterations).toBe(0);
+    expect(options.thresholds).toEqual({
+      coldStartP95Ms: 250,
+      ttftP95Ms: 600,
+      agentRssMaxMb: 384,
+    });
+    expect(options.output).toBe('dist/perf/report.json');
+    expect(options.ci).toBe(true);
+    expect(options.failOnWarning).toBe(true);
+  });
+
+  it('formats the benchmark summary with warning details', () => {
+    const metrics: PerfMetrics = {
+      coldStartMs: summarizeSamples([100, 110]),
+      ttftMs: summarizeSamples([20, 30]),
+      streamOverheadMs: summarizeSamples([0.1, 0.2]),
+      agentRssMb: summarizeSamples([300, 310]),
+      agentRssDeltaMb: summarizeSamples([2, 4]),
+    };
+    const warnings = evaluatePerfWarnings(metrics, DEFAULT_PERF_THRESHOLDS);
+    const result: PerfBenchResult = {
+      schemaVersion: 1,
+      timestamp: '2026-06-03T00:00:00.000Z',
+      platform: {
+        os: 'linux',
+        arch: 'x64',
+        bunVersion: '1.3.14',
+      },
+      coldStartCommand: ['/repo/zero', '--version'],
+      iterations: 2,
+      warmupIterations: 1,
+      thresholds: DEFAULT_PERF_THRESHOLDS,
+      metrics,
+      benchmarkDurationMs: 50,
+      warnings,
+    };
+
+    const summary = formatPerfSummary(result);
+
+    expect(summary).toContain('Zero performance benchmark');
+    expect(summary).toContain('cold start: median 105.00 ms');
+    expect(summary).toContain('agent RSS: peak 310.00 MB');
+    expect(summary).toContain('warnings:');
+    expect(summary).toContain('Agent RSS peak 310.00 MB');
+  });
+});

--- a/tests/perf-bench.test.ts
+++ b/tests/perf-bench.test.ts
@@ -4,6 +4,7 @@ import {
   evaluatePerfWarnings,
   formatPerfSummary,
   parsePerfBenchArgs,
+  runPerfBench,
   summarizeSamples,
   type PerfBenchResult,
   type PerfMetrics,
@@ -44,14 +45,11 @@ describe('performance benchmark helpers', () => {
   it('parses CLI and environment overrides', () => {
     const options = parsePerfBenchArgs(
       [
-        '--iterations',
-        '3',
+        '--iterations=3',
         '--warmup',
         '0',
-        '--ttft-warn-ms',
-        '600',
-        '--output',
-        'dist/perf/report.json',
+        '--ttft-warn-ms=600',
+        '--output=dist/perf/report.json',
         '--ci',
         '--fail-on-warning',
       ],
@@ -71,6 +69,25 @@ describe('performance benchmark helpers', () => {
     expect(options.output).toBe('dist/perf/report.json');
     expect(options.ci).toBe(true);
     expect(options.failOnWarning).toBe(true);
+  });
+
+  it('runs a minimal benchmark end to end', async () => {
+    const result = await runPerfBench({
+      iterations: 1,
+      warmupIterations: 0,
+      thresholds: {
+        coldStartP95Ms: 60_000,
+        ttftP95Ms: 60_000,
+        agentRssMaxMb: 4096,
+      },
+    });
+
+    expect(result.schemaVersion).toBe(1);
+    expect(result.iterations).toBe(1);
+    expect(result.metrics.coldStartMs.samples).toHaveLength(1);
+    expect(result.metrics.ttftMs.samples).toHaveLength(1);
+    expect(result.metrics.agentRssMb.max).toBeGreaterThan(0);
+    expect(result.warnings).toEqual([]);
   });
 
   it('formats the benchmark summary with warning details', () => {


### PR DESCRIPTION
Summary
- Add scripts/perf-bench.ts for cold start, deterministic TTFT, stream overhead, and RSS measurements.
- Add perf:bench and perf:smoke package scripts plus performance docs.
- Add a CI Performance Smoke job that builds the binary, emits GitHub warning annotations for threshold drift, and uploads the JSON report.

Validation
- bun run test
- bun run typecheck
- bun run build
- bun run smoke:build
- bun run perf:smoke
- bun run package:release
- git diff --check

Note
- Local perf:smoke passed and intentionally warned that cold-start p95 is above the PRD target of 300 ms. The new job reports that as a warning, not a blocking failure.