### PR TITLE
[codex] add TUI model selector

### DIFF
--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Box, Text, useApp, useInput } from 'ink';
 import { ProviderPicker } from './ProviderPicker';
+import { ModelPicker } from './ModelPicker';
 import { AddProvider } from './AddProvider';
 import { Logo } from './Logo';
 import { ThinkingSpinner } from './Spinner';
@@ -8,10 +9,16 @@ import { MessageRenderer } from './MessageRenderer';
 import { ToolCallRenderer } from './ToolCallRenderer';
 import { configManager } from '../config/manager';
 import { loadProviderConfig } from '../config/provider';
-import { OpenAIProvider } from '../providers/openai';
+import { createZeroProvider, resolveZeroProviderRuntime } from '../zero-provider-runtime';
 import { runAgent } from '../agent/loop';
+import { ZERO_DEFAULT_MODEL_ID } from '../zero-model-registry';
+import {
+  buildTuiModelStatus,
+  formatModelListLines,
+  resolveTuiModelSelection,
+} from './model-selection';
 
-type Screen = 'chat' | 'provider-picker' | 'add-provider';
+type Screen = 'chat' | 'provider-picker' | 'add-provider' | 'model-picker';
 
 // Map low-level errors back to actionable guidance for the user. The full
 // error object is still surfaced separately when debug mode is on.
@@ -78,6 +85,7 @@ export const App: React.FC = () => {
 
   // Plan Mode (inspired by OpenClaude / Claude Code)
   const [isPlanMode, setIsPlanMode] = useState(false);
+  const [selectedModelOverride, setSelectedModelOverride] = useState<string | undefined>();
 
   // Debug mode - when enabled, prints full error objects to console
   const [debugMode, setDebugMode] = useState(false);
@@ -89,7 +97,7 @@ export const App: React.FC = () => {
   // Command suggestions
   const [suggestions, setSuggestions] = useState<string[]>([]);
 
-  const knownCommands = ['/provider', '/plan', '/debug-mode', '/debug', '/tools', '/help', '/exit', '/quit'];
+  const knownCommands = ['/provider', '/model', '/plan', '/debug-mode', '/debug', '/tools', '/help', '/exit', '/quit'];
 
   // Update suggestions when input changes
   React.useEffect(() => {
@@ -108,8 +116,22 @@ export const App: React.FC = () => {
 
   // Current provider info for the input bar (Grok Build style)
   const activeProfile = configManager.getActiveProvider();
-  const currentProviderName = activeProfile?.name || (process.env.ZERO_PROVIDER_COMMAND ? 'command' : 'env');
-  const currentModel = activeProfile?.model || process.env.OPENAI_MODEL || 'default';
+  const modelStatus = buildTuiModelStatus(
+    activeProfile
+      ? {
+          model: activeProfile.model,
+          provider: activeProfile.provider,
+          profileName: activeProfile.name,
+          source: 'profile',
+        }
+      : {
+          model: process.env.OPENAI_MODEL || ZERO_DEFAULT_MODEL_ID,
+          source: process.env.ZERO_PROVIDER_COMMAND ? 'provider-command' : 'environment',
+        },
+    selectedModelOverride
+  );
+  const currentProviderName = activeProfile?.name || modelStatus.providerLabel;
+  const currentModel = `${modelStatus.label}${modelStatus.sourceLabel === 'session' ? ' *' : ''}`;
 
   // Track terminal size for proper scrolling
   React.useEffect(() => {
@@ -215,11 +237,15 @@ export const App: React.FC = () => {
 
       try {
         const providerConfig = await loadProviderConfig();
-        const provider = new OpenAIProvider({
-          apiKey: providerConfig.apiKey || '',
+        const runtime = resolveZeroProviderRuntime({
+          provider: providerConfig.provider,
+          apiKey: providerConfig.apiKey,
           baseURL: providerConfig.baseURL,
-          model: providerConfig.model,
+          model: selectedModelOverride || providerConfig.model,
+          profileName: providerConfig.profileName,
+          source: providerConfig.source,
         });
+        const provider = createZeroProvider(runtime);
 
         // Add empty assistant message that we'll stream into
         setMessages((prev) => {
@@ -327,6 +353,40 @@ export const App: React.FC = () => {
       return;
     }
 
+    if (cmd === '/model') {
+      const modelArg = parts.slice(1).join(' ').trim();
+
+      if (!modelArg) {
+        setScreen('model-picker');
+        return;
+      }
+
+      if (modelArg.toLowerCase() === 'list') {
+        setMessages((prev) => [
+          ...prev,
+          { type: 'system', content: 'Available models:' },
+          ...formatModelListLines().map((line) => ({ type: 'system' as const, content: `  ${line}` })),
+        ]);
+        return;
+      }
+
+      const selectedModel = resolveTuiModelSelection(modelArg);
+      if (!selectedModel) {
+        setMessages((prev) => [
+          ...prev,
+          { type: 'system', content: `Unknown model: ${modelArg}. Type /model list or /model to browse.` },
+        ]);
+        return;
+      }
+
+      setSelectedModelOverride(selectedModel.id);
+      setMessages((prev) => [
+        ...prev,
+        { type: 'system', content: `Model set for this session: ${selectedModel.displayName} (${selectedModel.provider})` },
+      ]);
+      return;
+    }
+
     if (cmd === '/plan') {
       setIsPlanMode(prev => {
         const next = !prev;
@@ -382,6 +442,7 @@ export const App: React.FC = () => {
         ...prev,
         { type: 'system', content: 'Available commands:' },
         { type: 'system', content: '  /provider     - Manage LLM providers (fix provider errors here)' },
+        { type: 'system', content: '  /model        - Select or list registry models for this session' },
         { type: 'system', content: '  /plan         - Toggle Plan Mode (agent plans first, makes no edits)' },
         { type: 'system', content: '  /debug-mode   - Toggle debug mode (prints full errors to console)' },
         { type: 'system', content: '  /tools        - Toggle tool calling (useful for debugging provider errors)' },
@@ -403,11 +464,31 @@ export const App: React.FC = () => {
     const success = configManager.setActiveProvider(name);
     if (success) {
       setMessages((prev) => [...prev, { type: 'system', content: `Switched to provider: ${name}` }]);
+      setSelectedModelOverride(undefined);
     }
     setScreen('chat');
   };
 
   const handleProviderPickerCancel = () => {
+    setScreen('chat');
+  };
+
+  const handleModelSelected = (modelId: string) => {
+    const selectedModel = resolveTuiModelSelection(modelId);
+    setSelectedModelOverride(modelId);
+    setMessages((prev) => [
+      ...prev,
+      {
+        type: 'system',
+        content: selectedModel
+          ? `Model set for this session: ${selectedModel.displayName} (${selectedModel.provider})`
+          : `Model set for this session: ${modelId}`,
+      },
+    ]);
+    setScreen('chat');
+  };
+
+  const handleModelPickerCancel = () => {
     setScreen('chat');
   };
 
@@ -457,6 +538,16 @@ export const App: React.FC = () => {
         onSelect={handleProviderSelected}
         onCancel={handleProviderPickerCancel}
         onAddNew={handleOpenAddProvider}
+      />
+    );
+  }
+
+  if (screen === 'model-picker') {
+    return (
+      <ModelPicker
+        activeModelId={modelStatus.knownModel?.id || modelStatus.modelId}
+        onSelect={handleModelSelected}
+        onCancel={handleModelPickerCancel}
       />
     );
   }

--- a/src/tui/ModelPicker.tsx
+++ b/src/tui/ModelPicker.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import type { ZeroModelDefinition } from '../zero-model-registry';
+import { getSelectableZeroModels } from './model-selection';
+
+interface ModelPickerProps {
+  activeModelId?: string;
+  onSelect: (modelId: string) => void;
+  onCancel: () => void;
+}
+
+export const ModelPicker: React.FC<ModelPickerProps> = ({
+  activeModelId,
+  onSelect,
+  onCancel,
+}) => {
+  const models = useMemo(() => getSelectableZeroModels(), []);
+  const [selectedIndex, setSelectedIndex] = useState(() => {
+    const index = models.findIndex((model) => model.id === activeModelId);
+    return Math.max(index, 0);
+  });
+
+  const selectedModel = models[selectedIndex];
+
+  useInput((input, key) => {
+    if (key.escape || (key.ctrl && input === 'c')) {
+      onCancel();
+      return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex((prev) => Math.max(0, prev - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setSelectedIndex((prev) => Math.min(models.length - 1, prev + 1));
+      return;
+    }
+
+    if (key.return && selectedModel) {
+      onSelect(selectedModel.id);
+      return;
+    }
+
+    const num = parseInt(input, 10);
+    if (!Number.isNaN(num) && num >= 1 && num <= models.length) {
+      onSelect(models[num - 1]!.id);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Select Model
+      </Text>
+      <Text color="gray" dimColor>
+        Up/Down to navigate - Enter to select - Esc to cancel
+      </Text>
+
+      <Box marginY={1} flexDirection="column">
+        {models.map((model, index) => (
+          <ModelRow
+            key={model.id}
+            model={model}
+            index={index}
+            isSelected={index === selectedIndex}
+            isActive={model.id === activeModelId}
+          />
+        ))}
+      </Box>
+
+      {selectedModel && (
+        <Box flexDirection="column" marginLeft={2} borderStyle="round" paddingX={1}>
+          <Text>
+            <Text bold>ID:</Text> {selectedModel.id}
+          </Text>
+          <Text>
+            <Text bold>Provider:</Text> {selectedModel.provider}
+          </Text>
+          <Text>
+            <Text bold>Context:</Text> {formatTokens(selectedModel.context.contextWindow)} input / {formatTokens(selectedModel.context.maxOutputTokens)} output
+          </Text>
+          <Text>
+            <Text bold>Capabilities:</Text> {selectedModel.capabilities.join(', ')}
+          </Text>
+          {selectedModel.reasoningEfforts && (
+            <Text>
+              <Text bold>Effort:</Text> {selectedModel.reasoningEfforts.join(', ')}
+            </Text>
+          )}
+          {selectedModel.description && (
+            <Text color="gray" dimColor>
+              {selectedModel.description}
+            </Text>
+          )}
+        </Box>
+      )}
+
+      <Box marginTop={1}>
+        <Text color="gray" dimColor>
+          Press 1-{models.length} for quick selection. This changes the current TUI session only.
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+function ModelRow({
+  model,
+  index,
+  isSelected,
+  isActive,
+}: {
+  model: ZeroModelDefinition;
+  index: number;
+  isSelected: boolean;
+  isActive: boolean;
+}) {
+  return (
+    <Box paddingLeft={1}>
+      <Text color={isSelected ? 'green' : 'white'}>
+        {isSelected ? '> ' : '  '}
+        {index + 1}. {model.displayName}
+        <Text color="gray"> ({model.provider})</Text>
+        {isActive && <Text color="blue"> current</Text>}
+      </Text>
+    </Box>
+  );
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${Math.round(value / 1_000_000)}M`;
+  if (value >= 1_000) return `${Math.round(value / 1_000)}K`;
+  return String(value);
+}

--- a/src/tui/model-selection.ts
+++ b/src/tui/model-selection.ts
@@ -1,0 +1,71 @@
+import {
+  getZeroModel,
+  listZeroModels,
+  resolveZeroModelId,
+  type ZeroModelDefinition,
+  type ZeroModelProvider,
+} from '../zero-model-registry';
+import type { ProviderConfig } from '../config/provider';
+
+export interface TuiModelStatus {
+  modelId: string;
+  label: string;
+  providerLabel: string;
+  sourceLabel: string;
+  knownModel?: ZeroModelDefinition;
+}
+
+const PROVIDER_ORDER: ZeroModelProvider[] = ['openai', 'anthropic', 'google'];
+
+export function getSelectableZeroModels(): ZeroModelDefinition[] {
+  return listZeroModels().sort((a, b) => {
+    const providerDelta = PROVIDER_ORDER.indexOf(a.provider) - PROVIDER_ORDER.indexOf(b.provider);
+    if (providerDelta !== 0) return providerDelta;
+    return a.displayName.localeCompare(b.displayName);
+  });
+}
+
+export function resolveTuiModelSelection(input: string): ZeroModelDefinition | undefined {
+  const normalized = input.trim();
+  if (!normalized) return undefined;
+  const modelId = resolveZeroModelId(normalized);
+  return modelId ? getZeroModel(modelId) : undefined;
+}
+
+export function buildTuiModelStatus(
+  providerConfig: Pick<ProviderConfig, 'model' | 'provider' | 'source' | 'profileName'> | undefined,
+  sessionModelOverride?: string
+): TuiModelStatus {
+  const modelId = sessionModelOverride || providerConfig?.model || 'default';
+  const knownModel = getZeroModel(modelId);
+
+  return {
+    modelId,
+    label: knownModel?.displayName || modelId,
+    providerLabel: knownModel?.provider || providerConfig?.provider || providerConfig?.profileName || providerConfig?.source || 'env',
+    sourceLabel: sessionModelOverride ? 'session' : providerConfig?.profileName || providerConfig?.source || 'env',
+    knownModel,
+  };
+}
+
+export function formatModelSummary(model: ZeroModelDefinition): string {
+  const caps = [
+    model.capabilities.includes('reasoning') ? 'reasoning' : undefined,
+    model.capabilities.includes('vision') ? 'vision' : undefined,
+    model.capabilities.includes('long-context') ? 'long context' : undefined,
+  ].filter(Boolean);
+
+  return `${model.id} - ${model.displayName} (${model.provider}${caps.length ? `, ${caps.join(', ')}` : ''})`;
+}
+
+export function formatModelListLines(limit = 12): string[] {
+  const models = getSelectableZeroModels();
+  const visible = models.slice(0, limit);
+  const lines = visible.map(formatModelSummary);
+
+  if (models.length > visible.length) {
+    lines.push(`... ${models.length - visible.length} more. Type /model to open the selector.`);
+  }
+
+  return lines;
+}

--- a/tests/tui-model-selection.test.ts
+++ b/tests/tui-model-selection.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildTuiModelStatus,
+  formatModelListLines,
+  getSelectableZeroModels,
+  resolveTuiModelSelection,
+} from '../src/tui/model-selection';
+
+describe('TUI model selection helpers', () => {
+  it('lists active registry models in a stable provider order', () => {
+    const models = getSelectableZeroModels();
+
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((model) => model.status === 'deprecated')).toBe(false);
+    expect(models[0]?.provider).toBe('openai');
+    expect(models.map((model) => model.id)).toContain('claude-sonnet-4.5');
+    expect(models.map((model) => model.id)).toContain('gemini-2.5-flash');
+  });
+
+  it('resolves model ids and aliases for slash command selection', () => {
+    expect(resolveTuiModelSelection('sonnet-4.5')?.id).toBe('claude-sonnet-4.5');
+    expect(resolveTuiModelSelection('google:gemini-2.5-flash')?.id).toBe('gemini-2.5-flash');
+    expect(resolveTuiModelSelection('unknown-model')).toBeUndefined();
+  });
+
+  it('builds session override status without mutating provider config', () => {
+    const status = buildTuiModelStatus(
+      {
+        model: 'gpt-4.1',
+        provider: 'openai',
+        source: 'profile',
+        profileName: 'work',
+      },
+      'claude-sonnet-4.5'
+    );
+
+    expect(status.modelId).toBe('claude-sonnet-4.5');
+    expect(status.label).toBe('Claude Sonnet 4.5');
+    expect(status.providerLabel).toBe('anthropic');
+    expect(status.sourceLabel).toBe('session');
+  });
+
+  it('formats compact model list lines for help output', () => {
+    const lines = formatModelListLines(3);
+
+    expect(lines).toHaveLength(4);
+    expect(lines[0]).toContain('gpt');
+    expect(lines[3]).toContain('more');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first M1 model selector UI slice for Zero:

- adds a registry-backed `ModelPicker` for the TUI
- adds `/model`, `/model list`, and `/model <id-or-alias>` command handling
- shows session-selected model state in the bottom status area
- routes TUI chat through the shared provider runtime resolver instead of hardcoding OpenAI
- resets the session model override when switching provider profiles
- adds pure model-selection helpers and tests

## Tests

- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`

## Notes

This keeps model switching session-local. Persisted model/profile config, `/effort`, and deeper command registry work can land in follow-up M1/M2 slices.