### PR TITLE
feat: add Zero usage tracking backend

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,4 +1,5 @@
 import type { Provider } from '../providers/types';
+import type { ZeroTokenUsage } from '../zero-model-registry';
 import type { ToolCall, ToolResult } from '../tools/types';
 import { toolRegistry } from '../tools';
 import { DEFAULT_SYSTEM_PROMPT, PLAN_MODE_SYSTEM_PROMPT } from './prompts';
@@ -10,6 +11,7 @@ export interface AgentOptions {
   onText?: (text: string) => void;
   onToolCall?: (toolCall: ToolCall) => void;
   onToolResult?: (result: ToolResult) => void;
+  onUsage?: (usage: ZeroTokenUsage) => void;
   toolsEnabled?: boolean;   // allows temporarily disabling tool calling for debugging
   debug?: boolean;          // when true, logs the exact payload sent to the provider
   planMode?: boolean;       // when true, the agent plans without modifying the codebase
@@ -32,6 +34,7 @@ export async function runAgent(
     onText, 
     onToolCall, 
     onToolResult,
+    onUsage,
     toolsEnabled = true,
     debug = false,
     planMode = false,
@@ -121,6 +124,15 @@ export async function runAgent(
       if (event.type === 'text') {
         currentText += event.content;
         if (onText) onText(event.content);
+      }
+
+      if (event.type === 'usage') {
+        if (onUsage) {
+          onUsage({
+            promptTokens: event.promptTokens,
+            completionTokens: event.completionTokens,
+          });
+        }
       }
 
       if (event.type === 'tool-call-start') {

--- a/src/zero-usage/index.ts
+++ b/src/zero-usage/index.ts
@@ -1,0 +1,14 @@
+export {
+  ZeroUsageTracker,
+  formatZeroUsageSummary,
+  normalizeZeroUsage,
+} from './tracker';
+
+export type {
+  RecordZeroUsageInput,
+  ZeroNormalizedUsage,
+  ZeroUsageModelSummary,
+  ZeroUsageRecord,
+  ZeroUsageSummary,
+  ZeroUsageTrackerOptions,
+} from './types';

--- a/src/zero-usage/tracker.ts
+++ b/src/zero-usage/tracker.ts
@@ -1,0 +1,185 @@
+import {
+  calculateZeroModelCost,
+  formatZeroModelCost,
+  requireZeroModel,
+} from '../zero-model-registry';
+import type { ZeroModelCostBreakdown, ZeroTokenUsage } from '../zero-model-registry';
+import type {
+  RecordZeroUsageInput,
+  ZeroNormalizedUsage,
+  ZeroUsageModelSummary,
+  ZeroUsageRecord,
+  ZeroUsageSummary,
+  ZeroUsageTrackerOptions,
+} from './types';
+
+export function normalizeZeroUsage(usage: ZeroTokenUsage): ZeroNormalizedUsage {
+  const inputTokens = nonNegativeInteger(
+    usage.inputTokens ?? usage.promptTokens ?? 0,
+    'inputTokens'
+  );
+  const outputTokens = nonNegativeInteger(
+    usage.outputTokens ?? usage.completionTokens ?? 0,
+    'outputTokens'
+  );
+  const cachedInputTokens = Math.min(
+    nonNegativeInteger(usage.cachedInputTokens ?? 0, 'cachedInputTokens'),
+    inputTokens
+  );
+
+  return {
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+  };
+}
+
+export class ZeroUsageTracker {
+  private readonly now: () => Date;
+  private readonly records: ZeroUsageRecord[] = [];
+  private nextSequence = 1;
+
+  constructor(options: ZeroUsageTrackerOptions = {}) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  recordUsage(input: RecordZeroUsageInput): ZeroUsageRecord {
+    const model = requireZeroModel(input.modelId);
+    const usage = normalizeZeroUsage(input.usage);
+    const cost = calculateZeroModelCost(model, usage);
+    const sequence = this.nextSequence;
+    this.nextSequence += 1;
+
+    const record: ZeroUsageRecord = {
+      id: `zero_usage_${sequence}`,
+      sequence,
+      modelId: model.id,
+      provider: model.provider,
+      source: input.source,
+      createdAt: this.now().toISOString(),
+      usage,
+      cost,
+    };
+
+    this.records.push(record);
+    return record;
+  }
+
+  getRecords(): ZeroUsageRecord[] {
+    return [...this.records];
+  }
+
+  getSummary(): ZeroUsageSummary {
+    const summary = createEmptySummary();
+    const byModel = new Map<string, ZeroUsageModelSummary>();
+
+    for (const record of this.records) {
+      summary.recordCount += 1;
+      addUsage(summary, record.usage);
+      addCost(summary, record.cost);
+
+      let modelSummary = byModel.get(record.modelId);
+      if (!modelSummary) {
+        modelSummary = createEmptyModelSummary(record);
+        byModel.set(record.modelId, modelSummary);
+      }
+
+      modelSummary.recordCount += 1;
+      addUsage(modelSummary, record.usage);
+      addCost(modelSummary, record.cost);
+    }
+
+    summary.formattedTotalCost = formatZeroModelCost(summary.totalCost);
+    summary.byModel = Array.from(byModel.values()).map((modelSummary) => ({
+      ...modelSummary,
+      formattedTotalCost: formatZeroModelCost(modelSummary.totalCost),
+    }));
+
+    const lastRecord = this.records.at(-1);
+    if (lastRecord) {
+      summary.lastRecord = lastRecord;
+    }
+
+    return summary;
+  }
+
+  reset(): void {
+    this.records.length = 0;
+    this.nextSequence = 1;
+  }
+}
+
+export function formatZeroUsageSummary(summary: ZeroUsageSummary): string {
+  const requestLabel = summary.recordCount === 1 ? 'request' : 'requests';
+  const tokens = new Intl.NumberFormat('en-US').format(summary.totalTokens);
+  const requests = new Intl.NumberFormat('en-US').format(summary.recordCount);
+  return `${requests} ${requestLabel}, ${tokens} tokens, ${summary.formattedTotalCost}`;
+}
+
+function createEmptySummary(): ZeroUsageSummary {
+  return {
+    recordCount: 0,
+    currency: 'USD',
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    inputCost: 0,
+    cachedInputCost: 0,
+    outputCost: 0,
+    totalCost: 0,
+    formattedTotalCost: formatZeroModelCost(0),
+    byModel: [],
+  };
+}
+
+function createEmptyModelSummary(record: ZeroUsageRecord): ZeroUsageModelSummary {
+  return {
+    modelId: record.modelId,
+    provider: record.provider,
+    recordCount: 0,
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    inputCost: 0,
+    cachedInputCost: 0,
+    outputCost: 0,
+    totalCost: 0,
+    formattedTotalCost: formatZeroModelCost(0),
+  };
+}
+
+function addUsage(
+  target: Pick<
+    ZeroUsageSummary | ZeroUsageModelSummary,
+    'inputTokens' | 'cachedInputTokens' | 'outputTokens' | 'totalTokens'
+  >,
+  usage: ZeroNormalizedUsage
+): void {
+  target.inputTokens += usage.inputTokens;
+  target.cachedInputTokens += usage.cachedInputTokens;
+  target.outputTokens += usage.outputTokens;
+  target.totalTokens += usage.totalTokens;
+}
+
+function addCost(
+  target: Pick<
+    ZeroUsageSummary | ZeroUsageModelSummary,
+    'inputCost' | 'cachedInputCost' | 'outputCost' | 'totalCost'
+  >,
+  cost: ZeroModelCostBreakdown
+): void {
+  target.inputCost += cost.inputCost;
+  target.cachedInputCost += cost.cachedInputCost;
+  target.outputCost += cost.outputCost;
+  target.totalCost += cost.totalCost;
+}
+
+function nonNegativeInteger(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Expected ${label} to be a non-negative number`);
+  }
+  return Math.floor(value);
+}

--- a/src/zero-usage/types.ts
+++ b/src/zero-usage/types.ts
@@ -1,0 +1,64 @@
+import type {
+  ZeroModelCostBreakdown,
+  ZeroModelProvider,
+  ZeroTokenUsage,
+} from '../zero-model-registry';
+
+export interface ZeroNormalizedUsage {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface RecordZeroUsageInput {
+  modelId: string;
+  usage: ZeroTokenUsage;
+  source?: string;
+}
+
+export interface ZeroUsageRecord {
+  id: string;
+  sequence: number;
+  modelId: string;
+  provider: ZeroModelProvider;
+  source?: string;
+  createdAt: string;
+  usage: ZeroNormalizedUsage;
+  cost: ZeroModelCostBreakdown;
+}
+
+export interface ZeroUsageModelSummary {
+  modelId: string;
+  provider: ZeroModelProvider;
+  recordCount: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  inputCost: number;
+  cachedInputCost: number;
+  outputCost: number;
+  totalCost: number;
+  formattedTotalCost: string;
+}
+
+export interface ZeroUsageSummary {
+  recordCount: number;
+  currency: 'USD';
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  inputCost: number;
+  cachedInputCost: number;
+  outputCost: number;
+  totalCost: number;
+  formattedTotalCost: string;
+  byModel: ZeroUsageModelSummary[];
+  lastRecord?: ZeroUsageRecord;
+}
+
+export interface ZeroUsageTrackerOptions {
+  now?: () => Date;
+}

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -187,3 +187,22 @@ describe('runAgent tool-call flow', () => {
     expect(provider.received).toHaveLength(1);
   });
 });
+
+describe('runAgent usage events', () => {
+  it('forwards provider usage events to backend callers', async () => {
+    const provider = new MockProvider([[
+      { type: 'usage', promptTokens: 12, completionTokens: 8 },
+      { type: 'text', content: 'usage captured' },
+    ]]);
+    const usageEvents: Array<{ promptTokens?: number; completionTokens?: number }> = [];
+
+    const answer = await runAgent('track usage', provider, {
+      onUsage: (usage) => usageEvents.push(usage),
+    });
+
+    expect(answer).toBe('usage captured');
+    expect(usageEvents).toEqual([
+      { promptTokens: 12, completionTokens: 8 },
+    ]);
+  });
+});

--- a/tests/zero-usage.test.ts
+++ b/tests/zero-usage.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  ZeroUsageTracker,
+  formatZeroUsageSummary,
+  normalizeZeroUsage,
+} from '../src/zero-usage';
+
+describe('normalizeZeroUsage', () => {
+  it('normalizes provider token aliases and floors fractional counts', () => {
+    expect(normalizeZeroUsage({
+      promptTokens: 1_000.9,
+      cachedInputTokens: 200.7,
+      completionTokens: 500.4,
+    })).toEqual({
+      inputTokens: 1_000,
+      cachedInputTokens: 200,
+      outputTokens: 500,
+      totalTokens: 1_500,
+    });
+  });
+
+  it('clamps cached input to input tokens', () => {
+    expect(normalizeZeroUsage({
+      inputTokens: 25,
+      cachedInputTokens: 100,
+      outputTokens: 10,
+    })).toEqual({
+      inputTokens: 25,
+      cachedInputTokens: 25,
+      outputTokens: 10,
+      totalTokens: 35,
+    });
+  });
+
+  it('rejects invalid token counts before they reach cost tracking', () => {
+    expect(() => normalizeZeroUsage({ inputTokens: -1 })).toThrow(
+      'Expected inputTokens to be a non-negative number'
+    );
+    expect(() => normalizeZeroUsage({ completionTokens: Number.NaN })).toThrow(
+      'Expected outputTokens to be a non-negative number'
+    );
+  });
+});
+
+describe('ZeroUsageTracker', () => {
+  it('records model usage with cost breakdowns from the model registry', () => {
+    const tracker = new ZeroUsageTracker({
+      now: () => new Date('2026-06-03T05:30:00.000Z'),
+    });
+
+    const record = tracker.recordUsage({
+      modelId: 'gpt-4.1',
+      source: 'agent-loop',
+      usage: {
+        promptTokens: 1_000,
+        cachedInputTokens: 200,
+        completionTokens: 500,
+      },
+    });
+
+    expect(record).toMatchObject({
+      id: 'zero_usage_1',
+      sequence: 1,
+      modelId: 'gpt-4.1',
+      provider: 'openai',
+      source: 'agent-loop',
+      createdAt: '2026-06-03T05:30:00.000Z',
+      usage: {
+        inputTokens: 1_000,
+        cachedInputTokens: 200,
+        outputTokens: 500,
+        totalTokens: 1_500,
+      },
+    });
+    expect(record.cost.totalCost).toBeCloseTo(0.0057);
+
+    const summary = tracker.getSummary();
+    expect(summary.recordCount).toBe(1);
+    expect(summary.totalTokens).toBe(1_500);
+    expect(summary.totalCost).toBeCloseTo(0.0057);
+    expect(summary.formattedTotalCost).toBe('$0.005700');
+    expect(summary.byModel).toHaveLength(1);
+    expect(summary.byModel[0]).toMatchObject({
+      modelId: 'gpt-4.1',
+      provider: 'openai',
+      recordCount: 1,
+      totalTokens: 1_500,
+      formattedTotalCost: '$0.005700',
+    });
+  });
+
+  it('aggregates records by model and formats a compact summary', () => {
+    const tracker = new ZeroUsageTracker();
+    tracker.recordUsage({
+      modelId: 'gpt-4.1',
+      usage: { inputTokens: 1_000, outputTokens: 1_000 },
+    });
+    tracker.recordUsage({
+      modelId: 'gpt-4.1-mini',
+      usage: { inputTokens: 500, outputTokens: 500 },
+    });
+
+    const summary = tracker.getSummary();
+    expect(summary.recordCount).toBe(2);
+    expect(summary.totalTokens).toBe(3_000);
+    expect(summary.totalCost).toBeCloseTo(0.011);
+    expect(summary.byModel.map((model) => model.modelId)).toEqual([
+      'gpt-4.1',
+      'gpt-4.1-mini',
+    ]);
+    expect(formatZeroUsageSummary(summary)).toBe(
+      '2 requests, 3,000 tokens, $0.0110'
+    );
+  });
+
+  it('rejects unknown models instead of producing unpriced records', () => {
+    const tracker = new ZeroUsageTracker();
+
+    expect(() => tracker.recordUsage({
+      modelId: 'unknown-zero-model',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    })).toThrow('Unknown Zero model');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the backend usage tracking foundation for Zero so provider token events can be normalized, costed, summarized, and consumed by later CLI/TUI/session surfaces.

## What Changed

- Added a new `zero-usage` module with normalized token usage records.
- Aggregates usage totals by model, including input, cached input, output, total tokens, and USD cost breakdowns.
- Formats compact usage summaries for future command/status surfaces.
- Exposes `runAgent` `onUsage` callback so backend callers can capture provider usage events without changing provider implementations.
- Added regression coverage for normalization, invalid usage, model pricing, aggregation, unknown model rejection, and agent usage forwarding.

## Impact

This keeps cost tracking backend-owned and reusable. UI, session summary, search, and diagnostics work can now consume a stable usage/cost contract instead of reimplementing token math in each surface.

## Reviewers

Please review: @Vasanthdev2004 @anandh8x

## Validation

- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000` - 158 pass, 0 fail
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero providers current`
- `git diff --check`
- `git diff --check origin/main..HEAD`
