### PR TITLE
feat: add M2 release checksum verification

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Package release artifact
         run: bun run package:release
 
+      - name: Verify release checksums
+        run: bun run verify:release
+
       - name: Upload package
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ bun run build
 bun run smoke:build
 bun run perf:bench
 bun run package:release
+bun run verify:release
 ```
 
 Check for released CLI updates:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -8,6 +8,19 @@ Zero release archives are published as:
 
 Each archive must have a matching `.sha256` file. The install scripts download both files and verify the checksum before copying the binary.
 
+Maintainers can verify the release directory before upload:
+
+```bash
+bun run package:release
+bun run verify:release
+```
+
+`verify:release` requires every archive in `dist/release` to have a same-directory `.sha256` file whose contents are:
+
+```text
+<sha256>  <archive-name>
+```
+
 ## Linux And macOS
 
 From a checkout:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "bun run scripts/build.ts",
     "smoke:build": "bun run scripts/smoke-build.ts",
     "package:release": "bun run scripts/package-release.ts",
+    "verify:release": "bun run scripts/release-checksums.ts",
     "perf:bench": "bun run scripts/perf-bench.ts",
     "perf:smoke": "bun run scripts/perf-bench.ts --output dist/perf/perf-bench.json"
   },

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -1,13 +1,13 @@
 import { $ } from 'bun';
-import { createHash } from 'node:crypto';
 import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import {
   getReleaseArchiveName,
   getReleasePackageName,
   zeroArtifactName,
   zeroArtifactPath,
 } from './artifact';
+import { writeSha256Checksum } from './release-checksums';
 
 function parsePackageVersion(packageText: string): string {
   const parsed = JSON.parse(packageText) as { version?: unknown };
@@ -41,11 +41,6 @@ async function run(command: string[]): Promise<void> {
     const message = stderr.trim() || `${command[0]} exited with ${exitCode}`;
     throw new Error(message);
   }
-}
-
-async function sha256(path: string): Promise<string> {
-  const bytes = await Bun.file(path).arrayBuffer();
-  return createHash('sha256').update(Buffer.from(bytes)).digest('hex');
 }
 
 const packageText = await Bun.file('package.json').text();
@@ -87,8 +82,7 @@ if (process.platform === 'win32') {
   await $`tar -C ${stagingDir} -czf ${archivePath} .`;
 }
 
-const checksum = await sha256(archivePath);
-await writeFile(`${archivePath}.sha256`, `${checksum}  ${basename(archivePath)}\n`);
+const checksum = await writeSha256Checksum(archivePath);
 
 console.log(`Packaged ${archiveName}`);
-console.log(`Wrote ${archiveName}.sha256`);
+console.log(`Wrote ${checksum.archiveName}.sha256`);

--- a/scripts/release-checksums.ts
+++ b/scripts/release-checksums.ts
@@ -1,0 +1,258 @@
+import { createHash } from 'node:crypto';
+import { readdir, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+
+export interface ParsedSha256Checksum {
+  checksum: string;
+  fileName: string;
+}
+
+export interface WrittenReleaseChecksum {
+  archivePath: string;
+  checksumPath: string;
+  archiveName: string;
+  checksum: string;
+}
+
+export interface VerifiedReleaseChecksum extends WrittenReleaseChecksum {
+  expectedChecksum: string;
+  actualChecksum: string;
+}
+
+export interface VerifyReleaseChecksumsOptions {
+  releaseDir?: string;
+}
+
+export async function sha256File(path: string): Promise<string> {
+  const bytes = await Bun.file(path).arrayBuffer();
+  return createHash('sha256').update(Buffer.from(bytes)).digest('hex');
+}
+
+export function parseSha256Checksum(text: string): ParsedSha256Checksum {
+  const lines = text.split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
+
+  if (lines.length === 0) {
+    throw new Error('Checksum file is empty');
+  }
+
+  if (lines.length > 1) {
+    throw new Error('Checksum file must contain exactly one checksum line');
+  }
+
+  const line = lines[0]!;
+  const match = /^([a-fA-F0-9]{64})\s+(.+)$/.exec(line);
+  if (!match) {
+    throw new Error('Checksum file must contain "<sha256>  <archive-name>"');
+  }
+
+  const checksum = match[1]!.toLowerCase();
+  const fileName = match[2]!.trim();
+  assertSafeChecksumFileName(fileName);
+
+  return { checksum, fileName };
+}
+
+export function formatSha256Checksum(checksum: string, fileName: string): string {
+  if (!/^[a-fA-F0-9]{64}$/.test(checksum)) {
+    throw new Error('SHA-256 checksum must be 64 hexadecimal characters');
+  }
+
+  assertSafeChecksumFileName(fileName);
+  return `${checksum.toLowerCase()}  ${fileName}\n`;
+}
+
+export async function writeSha256Checksum(archivePath: string): Promise<WrittenReleaseChecksum> {
+  const archiveName = basename(archivePath);
+  const checksum = await sha256File(archivePath);
+  const checksumPath = `${archivePath}.sha256`;
+
+  await writeFile(checksumPath, formatSha256Checksum(checksum, archiveName), 'utf-8');
+
+  return {
+    archivePath,
+    checksumPath,
+    archiveName,
+    checksum,
+  };
+}
+
+export async function verifySha256Checksum(
+  checksumPath: string
+): Promise<VerifiedReleaseChecksum> {
+  const checksumText = await Bun.file(checksumPath).text();
+  const parsed = parseSha256Checksum(checksumText);
+  const archivePath = join(dirname(checksumPath), parsed.fileName);
+
+  if (!(await Bun.file(archivePath).exists())) {
+    throw new Error(`Archive referenced by checksum does not exist: ${parsed.fileName}`);
+  }
+
+  const actualChecksum = await sha256File(archivePath);
+  if (actualChecksum !== parsed.checksum) {
+    throw new Error(
+      `Checksum mismatch for ${parsed.fileName}: expected ${parsed.checksum}, got ${actualChecksum}`
+    );
+  }
+
+  return {
+    archivePath,
+    checksumPath,
+    archiveName: parsed.fileName,
+    checksum: parsed.checksum,
+    expectedChecksum: parsed.checksum,
+    actualChecksum,
+  };
+}
+
+export async function verifyReleaseChecksums(
+  options: VerifyReleaseChecksumsOptions = {}
+): Promise<VerifiedReleaseChecksum[]> {
+  const releaseDir = options.releaseDir ?? join(process.cwd(), 'dist', 'release');
+  const entries = await readdir(releaseDir, { withFileTypes: true });
+  const files = entries.filter((entry) => entry.isFile()).map((entry) => entry.name).sort();
+  const archiveNames = files.filter((name) => !name.endsWith('.sha256'));
+  const checksumNames = files.filter((name) => name.endsWith('.sha256'));
+
+  if (archiveNames.length === 0) {
+    throw new Error(`No release archives found in ${releaseDir}`);
+  }
+
+  const expectedChecksumNames = new Set(archiveNames.map((name) => `${name}.sha256`));
+  for (const checksumName of checksumNames) {
+    if (!expectedChecksumNames.has(checksumName)) {
+      throw new Error(`Unexpected checksum file without matching archive: ${checksumName}`);
+    }
+  }
+
+  const verified: VerifiedReleaseChecksum[] = [];
+  for (const archiveName of archiveNames) {
+    const checksumName = `${archiveName}.sha256`;
+    if (!checksumNames.includes(checksumName)) {
+      throw new Error(`Missing checksum file: ${checksumName}`);
+    }
+
+    const result = await verifySha256Checksum(join(releaseDir, checksumName));
+    if (result.archiveName !== archiveName) {
+      throw new Error(
+        `Checksum file ${checksumName} references ${result.archiveName}, expected ${archiveName}`
+      );
+    }
+
+    verified.push(result);
+  }
+
+  return verified;
+}
+
+export function parseReleaseChecksumArgs(args: string[]): VerifyReleaseChecksumsOptions & {
+  help: boolean;
+} {
+  const options: VerifyReleaseChecksumsOptions & { help: boolean } = { help: false };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!;
+    const [flag, inlineValue] = splitFlagValue(arg);
+
+    switch (flag) {
+      case '--dir':
+        options.releaseDir = readOptionValue(args, inlineValue, ++index, flag);
+        if (inlineValue !== undefined) index--;
+        break;
+      case '--help':
+      case '-h':
+        rejectInlineValue(flag, inlineValue);
+        options.help = true;
+        break;
+      default:
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        if (options.releaseDir) {
+          throw new Error(`Unexpected argument: ${arg}`);
+        }
+        options.releaseDir = arg;
+    }
+  }
+
+  return options;
+}
+
+export function releaseChecksumHelp(): string {
+  return [
+    'Usage: bun run scripts/release-checksums.ts [--dir <path>]',
+    '',
+    'Verifies that every release archive has a matching .sha256 file and digest.',
+    '',
+    'Options:',
+    '  --dir <path>  Release directory to verify (default: dist/release)',
+    '  -h, --help    Show this help',
+  ].join('\n');
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseReleaseChecksumArgs(process.argv.slice(2));
+
+    if (options.help) {
+      console.log(releaseChecksumHelp());
+      return;
+    }
+
+    const results = await verifyReleaseChecksums(options);
+    for (const result of results) {
+      console.log(`Verified ${result.archiveName}.sha256 (${result.actualChecksum})`);
+    }
+    console.log(`Verified ${results.length} release checksum(s)`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[zero] Release checksum verification failed: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+function assertSafeChecksumFileName(fileName: string): void {
+  if (
+    !fileName ||
+    fileName !== basename(fileName) ||
+    fileName.includes('/') ||
+    fileName.includes('\\')
+  ) {
+    throw new Error(`Checksum archive name must be a same-directory file name: ${fileName}`);
+  }
+}
+
+function splitFlagValue(arg: string): [string, string | undefined] {
+  const separatorIndex = arg.indexOf('=');
+  if (separatorIndex === -1) return [arg, undefined];
+  return [arg.slice(0, separatorIndex), arg.slice(separatorIndex + 1)];
+}
+
+function readOptionValue(
+  args: string[],
+  inlineValue: string | undefined,
+  index: number,
+  flag: string
+): string {
+  if (inlineValue !== undefined) {
+    if (inlineValue === '') {
+      throw new Error(`${flag} requires a value`);
+    }
+    return inlineValue;
+  }
+
+  const value = args[index];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function rejectInlineValue(flag: string, inlineValue: string | undefined): void {
+  if (inlineValue !== undefined) {
+    throw new Error(`${flag} does not accept a value`);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/release-checksums.test.ts
+++ b/tests/release-checksums.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  formatSha256Checksum,
+  parseReleaseChecksumArgs,
+  parseSha256Checksum,
+  verifyReleaseChecksums,
+  verifySha256Checksum,
+  writeSha256Checksum,
+} from '../scripts/release-checksums';
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'zero-release-checksums-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('release checksum helpers', () => {
+  it('writes installer-compatible SHA-256 files and verifies release directories', async () => {
+    await withTempDir(async (dir) => {
+      const archiveName = 'zero-v0.1.0-linux-x64.tar.gz';
+      const archivePath = join(dir, archiveName);
+      await writeFile(archivePath, 'zero archive bytes', 'utf-8');
+
+      const written = await writeSha256Checksum(archivePath);
+      const checksumText = await readFile(written.checksumPath, 'utf-8');
+
+      expect(checksumText).toMatch(new RegExp(`^[a-f0-9]{64}  ${archiveName}\\n$`));
+
+      const verifiedFile = await verifySha256Checksum(written.checksumPath);
+      expect(verifiedFile.archiveName).toBe(archiveName);
+      expect(verifiedFile.expectedChecksum).toBe(verifiedFile.actualChecksum);
+
+      const verifiedRelease = await verifyReleaseChecksums({ releaseDir: dir });
+      expect(verifiedRelease).toHaveLength(1);
+      expect(verifiedRelease[0]?.archiveName).toBe(archiveName);
+    });
+  });
+
+  it('rejects malformed checksum files and unsafe archive names', () => {
+    expect(() => parseSha256Checksum('not a checksum')).toThrow(
+      'Checksum file must contain'
+    );
+    expect(() => formatSha256Checksum('abc', 'zero.tar.gz')).toThrow(
+      '64 hexadecimal characters'
+    );
+    expect(() => parseSha256Checksum(`${'a'.repeat(64)}  ../zero.tar.gz\n`)).toThrow(
+      'same-directory file name'
+    );
+    expect(() =>
+      parseSha256Checksum(`${'a'.repeat(64)}  zero.tar.gz\n${'b'.repeat(64)}  other.tar.gz\n`)
+    ).toThrow('exactly one checksum line');
+  });
+
+  it('detects archive changes after checksum generation', async () => {
+    await withTempDir(async (dir) => {
+      const archivePath = join(dir, 'zero-v0.1.0-linux-x64.tar.gz');
+      await writeFile(archivePath, 'original bytes', 'utf-8');
+      const written = await writeSha256Checksum(archivePath);
+
+      await writeFile(archivePath, 'changed bytes', 'utf-8');
+
+      await expect(verifySha256Checksum(written.checksumPath)).rejects.toThrow(
+        'Checksum mismatch'
+      );
+    });
+  });
+
+  it('requires each release archive to have exactly one matching checksum file', async () => {
+    await withTempDir(async (dir) => {
+      const archivePath = join(dir, 'zero-v0.1.0-linux-x64.tar.gz');
+      await writeFile(archivePath, 'archive bytes', 'utf-8');
+
+      await expect(verifyReleaseChecksums({ releaseDir: dir })).rejects.toThrow(
+        'Missing checksum file'
+      );
+
+      await writeSha256Checksum(archivePath);
+      await writeFile(
+        join(dir, 'zero-v0.1.0-macos-arm64.tar.gz.sha256'),
+        `${'a'.repeat(64)}  zero-v0.1.0-macos-arm64.tar.gz\n`,
+        'utf-8'
+      );
+
+      await expect(verifyReleaseChecksums({ releaseDir: dir })).rejects.toThrow(
+        'Unexpected checksum file'
+      );
+    });
+  });
+
+  it('parses verifier CLI arguments', () => {
+    expect(parseReleaseChecksumArgs(['--dir=dist/release'])).toEqual({
+      releaseDir: 'dist/release',
+      help: false,
+    });
+    expect(parseReleaseChecksumArgs(['dist/release'])).toEqual({
+      releaseDir: 'dist/release',
+      help: false,
+    });
+    expect(parseReleaseChecksumArgs(['--help'])).toEqual({ help: true });
+  });
+});

--- a/tests/release-checksums.test.ts
+++ b/tests/release-checksums.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,6 +7,7 @@ import {
   formatSha256Checksum,
   parseReleaseChecksumArgs,
   parseSha256Checksum,
+  sha256File,
   verifyReleaseChecksums,
   verifySha256Checksum,
   writeSha256Checksum,
@@ -21,6 +23,18 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
 }
 
 describe('release checksum helpers', () => {
+  it('hashes archive bytes as SHA-256 hex', async () => {
+    await withTempDir(async (dir) => {
+      const archivePath = join(dir, 'zero-v0.1.0-linux-x64.tar.gz');
+      const archiveBytes = 'zero archive bytes';
+      await writeFile(archivePath, archiveBytes, 'utf-8');
+
+      const expected = createHash('sha256').update(archiveBytes).digest('hex');
+
+      expect(await sha256File(archivePath)).toBe(expected);
+    });
+  });
+
   it('writes installer-compatible SHA-256 files and verifies release directories', async () => {
     await withTempDir(async (dir) => {
       const archiveName = 'zero-v0.1.0-linux-x64.tar.gz';
@@ -89,6 +103,14 @@ describe('release checksum helpers', () => {
 
       await expect(verifyReleaseChecksums({ releaseDir: dir })).rejects.toThrow(
         'Unexpected checksum file'
+      );
+    });
+  });
+
+  it('rejects empty release directories', async () => {
+    await withTempDir(async (dir) => {
+      await expect(verifyReleaseChecksums({ releaseDir: dir })).rejects.toThrow(
+        'No release archives found'
       );
     });
   });


### PR DESCRIPTION
Summary
- Add reusable release checksum helpers for SHA-256 generation, parsing, and verification.
- Move package:release checksum writing to the shared helper.
- Add verify:release and run it in the release artifact workflow before upload.
- Document the release checksum contract and maintainer verification command.

Validation
- bun test tests/release-checksums.test.ts tests/build-scripts.test.ts tests/install-scripts.test.ts
- bun run typecheck
- bun run package:release
- bun run verify:release
- bun run test
- git diff --check