### PR TITLE
feat: add Zero secret redaction

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,11 @@ import {
   ZeroPendingProviderError,
 } from '../zero-provider-runtime';
 import type { ZeroResolvedProviderRuntime } from '../zero-provider-runtime';
+import {
+  redactZeroErrorMessage,
+  redactZeroSecrets,
+  redactZeroString,
+} from '../zero-redaction';
 
 export type ExecOutputFormat = 'text' | 'json';
 
@@ -140,7 +145,7 @@ export async function runExec(options: RunExecOptions): Promise<number> {
             type: 'tool_call',
             id: toolCall.id,
             name: toolCall.name,
-            arguments: toolCall.arguments,
+            arguments: redactZeroString(toolCall.arguments),
           });
         } else {
           process.stderr.write(`[tool] ${toolCall.name}\n`);
@@ -151,7 +156,7 @@ export async function runExec(options: RunExecOptions): Promise<number> {
           emitJson(outputFormat, {
             type: 'tool_result',
             tool_call_id: result.toolCallId,
-            result: result.result,
+            result: redactZeroString(result.result),
           });
         } else {
           process.stderr.write(`[result] ${truncateForStatus(result.result)}\n`);
@@ -211,30 +216,32 @@ function writeUsageError(message: string): void {
 }
 
 function writeExecError(format: ExecOutputFormat, code: string, message: string): void {
+  const safeMessage = redactZeroString(message);
   if (format === 'json') {
-    emitJson(format, { type: 'error', code, message });
+    emitJson(format, { type: 'error', code, message: safeMessage });
     return;
   }
 
-  process.stderr.write(`[zero] ${message}\n`);
+  process.stderr.write(`[zero] ${safeMessage}\n`);
 }
 
 function writeWarning(format: ExecOutputFormat, message: string): void {
+  const safeMessage = redactZeroString(message);
   if (format === 'json') {
-    emitJson(format, { type: 'warning', message });
+    emitJson(format, { type: 'warning', message: safeMessage });
     return;
   }
 
-  process.stderr.write(`[zero] WARNING: ${message}\n`);
+  process.stderr.write(`[zero] WARNING: ${safeMessage}\n`);
 }
 
 function emitJson(format: ExecOutputFormat, payload: Record<string, unknown>): void {
   if (format !== 'json') return;
-  process.stdout.write(`${JSON.stringify(payload)}\n`);
+  process.stdout.write(`${JSON.stringify(redactZeroSecrets(payload))}\n`);
 }
 
 function formatProviderError(err: any): string {
-  const message = err?.message ?? String(err);
+  const message = redactZeroErrorMessage(err);
   if (err instanceof ZeroPendingProviderError) {
     return `${message}\nUse an implemented provider, or set provider: "openai-compatible" with a custom gateway.`;
   }
@@ -243,6 +250,6 @@ function formatProviderError(err: any): string {
 }
 
 function truncateForStatus(value: string): string {
-  const compact = value.replace(/\s+/g, ' ').trim();
+  const compact = redactZeroString(value).replace(/\s+/g, ' ').trim();
   return compact.length > 200 ? `${compact.slice(0, 200)}...` : compact;
 }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -12,6 +12,7 @@ import { loadProviderConfig } from '../config/provider';
 import { createZeroProvider, resolveZeroProviderRuntime } from '../zero-provider-runtime';
 import { runAgent } from '../agent/loop';
 import { ZERO_DEFAULT_MODEL_ID } from '../zero-model-registry';
+import { redactZeroError, redactZeroString } from '../zero-redaction';
 import {
   buildTuiModelStatus,
   formatModelListLines,
@@ -23,7 +24,7 @@ type Screen = 'chat' | 'provider-picker' | 'add-provider' | 'model-picker';
 // Map low-level errors back to actionable guidance for the user. The full
 // error object is still surfaced separately when debug mode is on.
 function toFriendlyError(err: any): string {
-  const raw = err?.message || String(err);
+  const raw = redactZeroError(err).message;
   const lower = raw.toLowerCase();
 
   if (lower.includes('no llm provider configured') || lower.includes('no provider')) {
@@ -43,6 +44,12 @@ function toFriendlyError(err: any): string {
   }
 
   return `Error: ${raw}`;
+}
+
+function formatDebugErrorRow(label: string, value: unknown): string {
+  const text = String(value).slice(0, 40);
+  const padding = ' '.repeat(Math.max(0, 41 - text.length));
+  return `│ ${label.padEnd(8)} ${text}${padding}│`;
 }
 
 type ChatMessage =
@@ -278,7 +285,7 @@ export const App: React.FC = () => {
             setIsThinking(false);
             setMessages((prev) => [
               ...prev,
-              { type: 'tool-call', name: tc.name, args: tc.arguments },
+              { type: 'tool-call', name: tc.name, args: redactZeroString(tc.arguments) },
             ]);
             // Reset streaming index since we inserted a message
             setStreamingMessageIndex(null);
@@ -292,7 +299,7 @@ export const App: React.FC = () => {
                 if (msg && msg.type === 'tool-call' && (msg as any).result === undefined) {
                   (newMessages as any)[i] = {
                     ...msg,
-                    result: result.result,
+                    result: redactZeroString(result.result),
                   };
                   break;
                 }
@@ -305,7 +312,8 @@ export const App: React.FC = () => {
         setIsThinking(false);
 
         if (debugMode) {
-          setLastError(err);
+          const safeError = redactZeroError(err);
+          setLastError(safeError);
           try {
             const red = '\x1b[31m';
             const reset = '\x1b[0m';
@@ -314,16 +322,17 @@ export const App: React.FC = () => {
             console.error(`\n${red}┌${border}┐`);
             console.error(`│  FULL PROVIDER ERROR${' '.repeat(29)}│`);
             console.error(`├${border}┤`);
-            console.error(`│ Message: ${(err?.message || String(err)).slice(0, 40)}${' '.repeat(9)}│`);
-            console.error(`│ Name:    ${err?.name || 'Error'}${' '.repeat(42 - (err?.name || 'Error').length)}│`);
+            console.error(formatDebugErrorRow('Message:', safeError.message));
+            console.error(formatDebugErrorRow('Name:', safeError.name));
 
-            if (err?.response?.status) {
-              console.error(`│ Status:  ${err.response.status}${' '.repeat(42 - String(err.response.status).length)}│`);
+            const response = safeError.response as { status?: unknown } | undefined;
+            if (response?.status) {
+              console.error(formatDebugErrorRow('Status:', response.status));
             }
 
             console.error(`└${border}┘${reset}`);
             console.error('Full object:');
-            console.dir(err, { depth: 6 });
+            console.dir(safeError, { depth: 6 });
             console.error(`${red}${'='.repeat(52)}${reset}\n`);
           } catch (logErr) {
             console.error('Failed to log full error:', logErr);
@@ -729,4 +738,3 @@ export const App: React.FC = () => {
     </Box>
   );
 };
-

--- a/src/zero-redaction/index.ts
+++ b/src/zero-redaction/index.ts
@@ -1,0 +1,2 @@
+export * from './redactor';
+export * from './types';

--- a/src/zero-redaction/redactor.ts
+++ b/src/zero-redaction/redactor.ts
@@ -1,0 +1,307 @@
+import type { ZeroRedactedError, ZeroRedactionOptions, ZeroSecretRedactor } from './types';
+
+export const ZERO_REDACTED_SECRET = '[REDACTED]';
+export const ZERO_CIRCULAR_REFERENCE = '[Circular]';
+
+const DEFAULT_MAX_DEPTH = 16;
+
+const DEFAULT_SENSITIVE_KEYS = new Set([
+  'access_token',
+  'anthropic_api_key',
+  'api_key',
+  'auth_token',
+  'authorization',
+  'aws_secret_access_key',
+  'aws_session_token',
+  'bearer',
+  'bearer_token',
+  'client_secret',
+  'cookie',
+  'credential',
+  'credentials',
+  'environment_secret',
+  'gemini_api_key',
+  'github_token',
+  'gitlab_token',
+  'google_api_key',
+  'id_token',
+  'jwt',
+  'npm_token',
+  'oauth_token',
+  'openai_api_key',
+  'passphrase',
+  'password',
+  'private_key',
+  'proxy_authorization',
+  'refresh_token',
+  'secret',
+  'session_ingress_token',
+  'session_token',
+  'set_cookie',
+  'token',
+  'x_api_key',
+  'zero_api_key',
+]);
+
+const SECRET_TEXT_PATTERNS = [
+  /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-ant-api\d{2}-[A-Za-z0-9_-]{20,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\bglpat-[A-Za-z0-9_-]{20,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{20,}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/g,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g,
+];
+
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
+
+interface RedactionContext {
+  options: ZeroRedactionOptions;
+  replacement: string;
+  maxDepth: number;
+  seen: WeakSet<object>;
+}
+
+export function createZeroSecretRedactor(options: ZeroRedactionOptions = {}): ZeroSecretRedactor {
+  return {
+    redact: (value) => redactZeroSecrets(value, options),
+    redactString: (value) => redactZeroString(value, options),
+    redactError: (error) => redactZeroError(error, options),
+    isSensitiveKey: (key) => isZeroSensitiveKey(key, options),
+  };
+}
+
+export function isZeroSensitiveKey(key: string, options: ZeroRedactionOptions = {}): boolean {
+  const normalized = normalizeZeroSecretKey(key);
+  if (!normalized) return false;
+  if (DEFAULT_SENSITIVE_KEYS.has(normalized)) return true;
+
+  return (options.extraSensitiveKeys ?? []).some((extraKey) => {
+    return normalizeZeroSecretKey(extraKey) === normalized;
+  });
+}
+
+export function redactZeroString(value: string, options: ZeroRedactionOptions = {}): string {
+  const replacement = options.replacement ?? ZERO_REDACTED_SECRET;
+  let redacted = value;
+
+  redacted = redactExactSecretValues(redacted, replacement, options.extraSecretValues);
+  redacted = redacted.replace(PRIVATE_KEY_PATTERN, replacement);
+
+  redacted = redacted.replace(
+    /("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)"([^"\\]*(?:\\.[^"\\]*)*)"/g,
+    (match: string, prefix: string, key: string) => {
+      return isZeroSensitiveKey(key, options) ? `${prefix}"${replacement}"` : match;
+    }
+  );
+
+  redacted = redacted.replace(
+    /\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*=\s*)(["']?)([^"'\s&]+)\3/g,
+    (match: string, key: string, assignment: string, quote: string) => {
+      return isZeroSensitiveKey(key, options)
+        ? `${key}${assignment}${quote}${replacement}${quote}`
+        : match;
+    }
+  );
+
+  redacted = redacted.replace(
+    /\b(authorization|proxy-authorization)\s*:\s*(bearer|basic)\s+([^\s,;]+)/gi,
+    (_match: string, header: string, scheme: string) => {
+      return `${header}: ${scheme} ${replacement}`;
+    }
+  );
+
+  redacted = redacted.replace(
+    /\b(x-api-key|api-key|cookie|set-cookie)\s*:\s*([^\r\n]+)/gi,
+    (_match: string, header: string) => {
+      return `${header}: ${replacement}`;
+    }
+  );
+
+  redacted = redacted.replace(
+    /\b((?:https?|wss?|ftp):\/\/[^:\s/@]+:)([^@\s/]+)(@)/gi,
+    (_match: string, prefix: string, _password: string, suffix: string) => {
+      return `${prefix}${replacement}${suffix}`;
+    }
+  );
+
+  redacted = redacted.replace(
+    /([?&])([^=&#\s]+)=([^&#\s]+)/g,
+    (match: string, separator: string, key: string) => {
+      return isZeroSensitiveKey(key, options) ? `${separator}${key}=${replacement}` : match;
+    }
+  );
+
+  for (const pattern of SECRET_TEXT_PATTERNS) {
+    redacted = redacted.replace(pattern, replacement);
+  }
+
+  return redacted;
+}
+
+export function redactZeroSecrets(value: unknown, options: ZeroRedactionOptions = {}): unknown {
+  return redactValue(value, createRedactionContext(options), 0);
+}
+
+export function redactZeroError(error: unknown, options: ZeroRedactionOptions = {}): ZeroRedactedError {
+  const context = createRedactionContext(options);
+
+  if (!(error instanceof Error)) {
+    return {
+      name: 'Error',
+      message: redactZeroString(String(error), options),
+    };
+  }
+
+  const redacted: ZeroRedactedError = {
+    name: error.name || 'Error',
+    message: redactZeroString(error.message, options),
+  };
+
+  if (error.stack) {
+    redacted.stack = redactZeroString(error.stack, options);
+  }
+
+  if ('cause' in error && error.cause !== undefined) {
+    redacted.cause = redactValue(error.cause, context, 1);
+  }
+
+  for (const [key, entryValue] of Object.entries(error)) {
+    if (key === 'name' || key === 'message' || key === 'stack' || key === 'cause') {
+      continue;
+    }
+    redacted[key] = isZeroSensitiveKey(key, options)
+      ? context.replacement
+      : redactValue(entryValue, context, 1);
+  }
+
+  return redacted;
+}
+
+export function redactZeroErrorMessage(error: unknown, options: ZeroRedactionOptions = {}): string {
+  return redactZeroError(error, options).message;
+}
+
+function redactValue(value: unknown, context: RedactionContext, depth: number): unknown {
+  if (typeof value === 'string') {
+    return redactZeroString(value, context.options);
+  }
+
+  if (
+    value === null ||
+    typeof value === 'undefined' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint' ||
+    typeof value === 'symbol' ||
+    typeof value === 'function'
+  ) {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return redactZeroError(value, context.options);
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (depth >= context.maxDepth) {
+    return '[MaxDepth]';
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  if (context.seen.has(value)) {
+    return ZERO_CIRCULAR_REFERENCE;
+  }
+  context.seen.add(value);
+
+  if (isHeaders(value)) {
+    const headers: Record<string, string> = {};
+    for (const [key, headerValue] of value.entries()) {
+      headers[key] = isZeroSensitiveKey(key, context.options)
+        ? context.replacement
+        : redactZeroString(headerValue, context.options);
+    }
+    return headers;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, context, depth + 1));
+  }
+
+  if (value instanceof Map) {
+    const redactedMap = new Map<unknown, unknown>();
+    for (const [mapKey, mapValue] of value.entries()) {
+      const keyText = typeof mapKey === 'string' ? mapKey : String(mapKey);
+      redactedMap.set(
+        mapKey,
+        isZeroSensitiveKey(keyText, context.options)
+          ? context.replacement
+          : redactValue(mapValue, context, depth + 1)
+      );
+    }
+    return redactedMap;
+  }
+
+  if (value instanceof Set) {
+    return new Set([...value].map((item) => redactValue(item, context, depth + 1)));
+  }
+
+  const redactedObject: Record<string, unknown> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    redactedObject[key] = isZeroSensitiveKey(key, context.options)
+      ? context.replacement
+      : redactValue(entryValue, context, depth + 1);
+  }
+
+  return redactedObject;
+}
+
+function createRedactionContext(options: ZeroRedactionOptions): RedactionContext {
+  return {
+    options,
+    replacement: options.replacement ?? ZERO_REDACTED_SECRET,
+    maxDepth: options.maxDepth ?? DEFAULT_MAX_DEPTH,
+    seen: new WeakSet<object>(),
+  };
+}
+
+function normalizeZeroSecretKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function redactExactSecretValues(
+  value: string,
+  replacement: string,
+  exactSecrets: readonly string[] | undefined
+): string {
+  const secrets = [...(exactSecrets ?? [])]
+    .filter((secret) => secret.length > 0)
+    .sort((a, b) => b.length - a.length);
+
+  let redacted = value;
+  for (const secret of secrets) {
+    redacted = redacted.replace(new RegExp(escapeRegExp(secret), 'g'), replacement);
+  }
+  return redacted;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isHeaders(value: object): value is Headers {
+  return typeof Headers !== 'undefined' && value instanceof Headers;
+}

--- a/src/zero-redaction/types.ts
+++ b/src/zero-redaction/types.ts
@@ -1,0 +1,21 @@
+export interface ZeroRedactionOptions {
+  replacement?: string;
+  extraSensitiveKeys?: readonly string[];
+  extraSecretValues?: readonly string[];
+  maxDepth?: number;
+}
+
+export interface ZeroRedactedError {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ZeroSecretRedactor {
+  redact(value: unknown): unknown;
+  redactString(value: string): string;
+  redactError(error: unknown): ZeroRedactedError;
+  isSensitiveKey(key: string): boolean;
+}

--- a/tests/headless-exec.test.ts
+++ b/tests/headless-exec.test.ts
@@ -82,6 +82,37 @@ describe('zero exec CLI surface', () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it('redacts secrets from structured provider errors', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.zero-provider-test-'));
+    const leakedModel = ['sk-proj', 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH'].join('-');
+    try {
+      const providerScript = join(dir, `${leakedModel}.js`);
+      await writeFile(
+        providerScript,
+        `console.error(${JSON.stringify(`provider leaked ${leakedModel}`)}); process.exit(1);\n`,
+        'utf-8'
+      );
+
+      const result = await runZero(
+        ['exec', '--output-format', 'json', 'hello'],
+        {
+          ZERO_PROVIDER_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(providerScript)}`,
+        }
+      );
+
+      const events = result.stdout.trim().split('\n').map((line) => JSON.parse(line));
+      expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.provider);
+      expect(events[0]).toMatchObject({
+        type: 'error',
+        code: 'provider_error',
+      });
+      expect(events[0].message).toContain('[REDACTED]');
+      expect(events[0].message).not.toContain(leakedModel);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('headless exec prompt helpers', () => {

--- a/tests/zero-redaction.test.ts
+++ b/tests/zero-redaction.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  ZERO_REDACTED_SECRET,
+  isZeroSensitiveKey,
+  redactZeroError,
+  redactZeroSecrets,
+  redactZeroString,
+} from '../src/zero-redaction';
+
+const OPENAI_KEY = ['sk-proj', 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH'].join('-');
+const ANTHROPIC_KEY = ['sk-ant-api03', 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGH'].join('-');
+const GITHUB_TOKEN = ['github', 'pat', '11AAAAAAA0abcdefghijklmnopqrstuvwxyz'].join('_');
+const JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ6ZXJvIn0.signature123';
+
+describe('zero secret redaction', () => {
+  it('redacts sensitive object keys without mutating safe fields', () => {
+    const input = {
+      model: 'gpt-4.1',
+      tokenBudget: 8192,
+      authorization: `Bearer ${OPENAI_KEY}`,
+      headers: {
+        'x-api-key': ANTHROPIC_KEY,
+        cookie: 'zero_session=secret-cookie',
+        accept: 'application/json',
+      },
+      nested: {
+        environment_secret: 'env-secret-value',
+        session_ingress_token: 'session-token-value',
+        access_token: GITHUB_TOKEN,
+        prompt: 'token budget should remain readable',
+      },
+    };
+
+    const redacted = redactZeroSecrets(input) as typeof input;
+
+    expect(redacted).not.toBe(input);
+    expect(redacted.model).toBe('gpt-4.1');
+    expect(redacted.tokenBudget).toBe(8192);
+    expect(redacted.headers.accept).toBe('application/json');
+    expect(redacted.authorization).toBe(ZERO_REDACTED_SECRET);
+    expect(redacted.headers['x-api-key']).toBe(ZERO_REDACTED_SECRET);
+    expect(redacted.headers.cookie).toBe(ZERO_REDACTED_SECRET);
+    expect(redacted.nested.environment_secret).toBe(ZERO_REDACTED_SECRET);
+    expect(redacted.nested.session_ingress_token).toBe(ZERO_REDACTED_SECRET);
+    expect(redacted.nested.access_token).toBe(ZERO_REDACTED_SECRET);
+    expect(redacted.nested.prompt).toBe('token budget should remain readable');
+    expect(input.nested.access_token).toBe(GITHUB_TOKEN);
+  });
+
+  it('redacts provider keys, auth headers, URL credentials, query secrets, JWTs, and private keys from text', () => {
+    const privateKey = [
+      '-----BEGIN PRIVATE KEY-----',
+      'abc123',
+      '-----END PRIVATE KEY-----',
+    ].join('\n');
+    const text = [
+      `OPENAI_API_KEY=${OPENAI_KEY}`,
+      `Authorization: Bearer ${JWT}`,
+      `https://zero:${ANTHROPIC_KEY}@example.com/v1?api_key=${OPENAI_KEY}&q=safe`,
+      privateKey,
+    ].join('\n');
+
+    const redacted = redactZeroString(text);
+
+    expect(redacted).toContain(`OPENAI_API_KEY=${ZERO_REDACTED_SECRET}`);
+    expect(redacted).toContain(`Authorization: Bearer ${ZERO_REDACTED_SECRET}`);
+    expect(redacted).toContain(
+      `https://zero:${ZERO_REDACTED_SECRET}@example.com/v1?api_key=${ZERO_REDACTED_SECRET}&q=safe`
+    );
+    expect(redacted).not.toContain(OPENAI_KEY);
+    expect(redacted).not.toContain(ANTHROPIC_KEY);
+    expect(redacted).not.toContain(JWT);
+    expect(redacted).not.toContain('abc123');
+  });
+
+  it('redacts Error messages and stacks while keeping error metadata', () => {
+    const error = new Error(`Provider rejected ${OPENAI_KEY}`);
+    error.stack = `Error: Provider rejected ${OPENAI_KEY}\n    at zero (${GITHUB_TOKEN})`;
+
+    const redacted = redactZeroError(error);
+
+    expect(redacted.name).toBe('Error');
+    expect(redacted.message).toBe(`Provider rejected ${ZERO_REDACTED_SECRET}`);
+    expect(redacted.stack).toContain(ZERO_REDACTED_SECRET);
+    expect(redacted.stack).not.toContain(OPENAI_KEY);
+    expect(redacted.stack).not.toContain(GITHUB_TOKEN);
+  });
+
+  it('handles circular objects and caller-provided exact secret values', () => {
+    const input: Record<string, unknown> = {
+      name: 'zero',
+      safe: 'keep-me',
+      provider_response: `custom secret is custom-secret-value`,
+    };
+    input.self = input;
+
+    const redacted = redactZeroSecrets(input, {
+      extraSecretValues: ['custom-secret-value'],
+    }) as Record<string, unknown>;
+
+    expect(redacted.name).toBe('zero');
+    expect(redacted.safe).toBe('keep-me');
+    expect(redacted.provider_response).toBe(`custom secret is ${ZERO_REDACTED_SECRET}`);
+    expect(redacted.self).toBe('[Circular]');
+  });
+
+  it('classifies sensitive keys without hiding normal token usage fields', () => {
+    expect(isZeroSensitiveKey('apiKey')).toBe(true);
+    expect(isZeroSensitiveKey('x-api-key')).toBe(true);
+    expect(isZeroSensitiveKey('refresh_token')).toBe(true);
+    expect(isZeroSensitiveKey('private_key')).toBe(true);
+    expect(isZeroSensitiveKey('session_ingress_token')).toBe(true);
+    expect(isZeroSensitiveKey('tokenBudget')).toBe(false);
+    expect(isZeroSensitiveKey('input_tokens')).toBe(false);
+    expect(isZeroSensitiveKey('model')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a Zero-native secret redaction module for strings, objects, Errors, Headers, Maps, Sets, and circular payloads.
- Cover sensitive key names, provider/API key formats, bearer/basic auth headers, cookies, URL credentials, secret query params, JWT-like tokens, private key blocks, and caller-provided exact secret values.
- Wire redaction into headless CLI JSON/text errors, warnings, tool arguments, tool results, and status truncation.
- Wire redaction into TUI friendly errors, debug error output, and rendered tool argument/result payloads.
- Add focused unit coverage plus a headless provider-error integration test to prove structured CLI errors do not leak secret-shaped values.

## Why

M2 observability needs one shared sanitizer before diagnostics, provider errors, doctor output, feedback, and later session/search surfaces print user or provider data. This keeps the redaction rules centralized instead of duplicating ad hoc checks across command and UI paths.

## Implementation Notes

- `redactZeroString` sanitizes common secret-bearing text without hiding normal model, token-count, or prompt text.
- `redactZeroSecrets` preserves object shape while replacing sensitive values and safely handling circular references.
- `redactZeroError` returns a sanitized error-shaped object so debug paths can keep useful metadata without exposing credentials.
- Test fake secrets are assembled at runtime to avoid committing scanner-looking static token literals.

## Validation

- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero providers current`
- `git diff --check origin/main..HEAD`

Reviewers: @Vasanthdev2004 @anandh8x