### PR TITLE
feat: add Zero session search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,23 @@ import { configManager } from './config/manager';
 import { startTUI } from './tui';
 import { DEFAULT_UPDATE_CHECK_TIMEOUT_MS, checkForUpdate, formatUpdateCheck } from './update/check';
 import { ZERO_VERSION } from './version';
+import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
 
 const program = new Command();
 
 function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function parseNonNegativeIntegerOption(name: string, value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid ${name} value "${value}". Expected a non-negative integer.`);
+  }
+
+  return Number(normalized);
 }
 
 program
@@ -98,6 +110,36 @@ providersCmd
       console.log(`Base URL: ${active.baseURL}`);
     } else {
       console.log('No active provider set.');
+    }
+  });
+
+program
+  .command('search')
+  .description('Search local Zero session events')
+  .argument('<query...>', 'Search query')
+  .option('--json', 'Print search results as JSON')
+  .option('--limit <number>', 'Maximum number of matches to return', '20')
+  .option('--context <chars>', 'Context characters around each match', '80')
+  .option('--session <id>', 'Search one session id')
+  .option('--type <eventType>', 'Search one event type')
+  .action(async (queryParts: string[] | undefined, options) => {
+    try {
+      const query = (queryParts ?? []).join(' ');
+      const result = await searchZeroSessions(query, {
+        limit: parseNonNegativeIntegerOption('--limit', options.limit),
+        contextChars: parseNonNegativeIntegerOption('--context', options.context),
+        sessionId: options.session,
+        type: options.type,
+      });
+
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatZeroSearchResult(result));
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] ${getErrorMessage(err)}`);
+      process.exitCode = 2;
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { configManager } from './config/manager';
 import { startTUI } from './tui';
 import { DEFAULT_UPDATE_CHECK_TIMEOUT_MS, checkForUpdate, formatUpdateCheck } from './update/check';
 import { ZERO_VERSION } from './version';
+import { redactZeroSecrets } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
 
 const program = new Command();
@@ -133,7 +134,7 @@ program
       });
 
       if (options.json) {
-        console.log(JSON.stringify(result, null, 2));
+        console.log(JSON.stringify(redactZeroSecrets(result), null, 2));
       } else {
         console.log(formatZeroSearchResult(result));
       }

--- a/src/zero-search/index.ts
+++ b/src/zero-search/index.ts
@@ -1,0 +1,11 @@
+export {
+  formatZeroSearchResult,
+  normalizeZeroSearchQuery,
+  searchZeroSessions,
+} from './search';
+export type {
+  ZeroSearchEventSummary,
+  ZeroSearchHit,
+  ZeroSearchOptions,
+  ZeroSearchResult,
+} from './types';

--- a/src/zero-search/search.ts
+++ b/src/zero-search/search.ts
@@ -1,0 +1,205 @@
+import { ZeroSessionEventStore } from '../zero-sessions';
+import type {
+  ZeroSearchCandidate,
+  ZeroSearchHit,
+  ZeroSearchOptions,
+  ZeroSearchResult,
+} from './types';
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_CONTEXT_CHARS = 80;
+
+export async function searchZeroSessions(
+  query: string,
+  options: ZeroSearchOptions = {}
+): Promise<ZeroSearchResult> {
+  const normalizedQuery = normalizeZeroSearchQuery(query);
+  const store = options.store ?? new ZeroSessionEventStore({ rootDir: options.rootDir });
+  const limit = normalizeLimit(options.limit);
+  const contextChars = normalizeContextChars(options.contextChars);
+
+  if (!normalizedQuery || limit === 0) {
+    return emptySearchResult(query, normalizedQuery, store.rootDir, 0);
+  }
+
+  const sessions = await resolveSearchSessions(store, options.sessionId);
+  const hits: ZeroSearchHit[] = [];
+  const terms = splitSearchTerms(normalizedQuery);
+
+  for (const session of sessions) {
+    const events = await store.readEvents(session.sessionId);
+    for (const event of events) {
+      if (options.type && event.type !== options.type) continue;
+
+      const candidate: ZeroSearchCandidate = {
+        session,
+        event,
+        text: extractSearchText(event.payload),
+      };
+      const match = findSearchMatch(candidate.text, normalizedQuery, terms);
+      if (!match) continue;
+
+      hits.push({
+        session,
+        event: {
+          id: event.id,
+          sequence: event.sequence,
+          type: event.type,
+          createdAt: event.createdAt,
+        },
+        context: buildContext(candidate.text, match.start, match.end, contextChars),
+        match,
+      });
+
+      if (hits.length >= limit) {
+        return {
+          query,
+          normalizedQuery,
+          rootDir: store.rootDir,
+          searchedSessions: sessions.length,
+          totalHits: hits.length,
+          hits,
+        };
+      }
+    }
+  }
+
+  return {
+    query,
+    normalizedQuery,
+    rootDir: store.rootDir,
+    searchedSessions: sessions.length,
+    totalHits: hits.length,
+    hits,
+  };
+}
+
+export function formatZeroSearchResult(result: ZeroSearchResult): string {
+  const query = result.query.trim();
+  if (result.hits.length === 0) {
+    return `No local session events matched "${query}". Searched ${formatCount(
+      result.searchedSessions,
+      'session'
+    )}.`;
+  }
+
+  const lines = [
+    `Found ${formatCount(result.totalHits, 'local session event')} for "${query}":`,
+  ];
+
+  result.hits.forEach((hit, index) => {
+    const title = hit.session.title ? ` - ${hit.session.title}` : '';
+    lines.push(
+      `${index + 1}. ${hit.session.sessionId} #${hit.event.sequence} ${hit.event.type}${title}`
+    );
+    const context = hit.context.replace(/\s+/g, ' ').trim();
+    if (context) lines.push(`   ${context}`);
+
+    const details = [
+      hit.session.cwd ? `cwd: ${hit.session.cwd}` : undefined,
+      hit.session.modelId ? `model: ${hit.session.modelId}` : undefined,
+      hit.session.provider ? `provider: ${hit.session.provider}` : undefined,
+      `updated: ${hit.session.updatedAt}`,
+    ].filter(Boolean);
+    lines.push(`   ${details.join(' | ')}`);
+  });
+
+  return lines.join('\n');
+}
+
+export function normalizeZeroSearchQuery(query: string): string {
+  return query.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+async function resolveSearchSessions(
+  store: ZeroSessionEventStore,
+  sessionId: string | undefined
+) {
+  if (!sessionId) return store.listSessions();
+
+  const session = await store.getSession(sessionId);
+  return session ? [session] : [];
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_LIMIT;
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(0, Math.floor(limit));
+}
+
+function normalizeContextChars(contextChars: number | undefined): number {
+  if (contextChars === undefined) return DEFAULT_CONTEXT_CHARS;
+  if (!Number.isFinite(contextChars)) return DEFAULT_CONTEXT_CHARS;
+  return Math.max(0, Math.floor(contextChars));
+}
+
+function emptySearchResult(
+  query: string,
+  normalizedQuery: string,
+  rootDir: string,
+  searchedSessions: number
+): ZeroSearchResult {
+  return {
+    query,
+    normalizedQuery,
+    rootDir,
+    searchedSessions,
+    totalHits: 0,
+    hits: [],
+  };
+}
+
+function splitSearchTerms(query: string): string[] {
+  return query.split(' ').filter(Boolean);
+}
+
+function findSearchMatch(
+  text: string,
+  normalizedQuery: string,
+  terms: string[]
+): { start: number; end: number } | undefined {
+  const normalizedText = text.toLowerCase();
+  const phraseIndex = normalizedText.indexOf(normalizedQuery);
+  if (phraseIndex >= 0) {
+    return {
+      start: phraseIndex,
+      end: phraseIndex + normalizedQuery.length,
+    };
+  }
+
+  let firstMatch = Number.POSITIVE_INFINITY;
+  let lastMatch = -1;
+  for (const term of terms) {
+    const index = normalizedText.indexOf(term);
+    if (index === -1) return undefined;
+    firstMatch = Math.min(firstMatch, index);
+    lastMatch = Math.max(lastMatch, index + term.length);
+  }
+
+  return {
+    start: firstMatch,
+    end: lastMatch,
+  };
+}
+
+function buildContext(text: string, start: number, end: number, contextChars: number): string {
+  return text
+    .slice(Math.max(0, start - contextChars), Math.min(text.length, end + contextChars))
+    .trim();
+}
+
+function extractSearchText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.map(extractSearchText).filter(Boolean).join(' ');
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value).map(extractSearchText).filter(Boolean).join(' ');
+  }
+  return '';
+}
+
+function formatCount(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? '' : 's'}`;
+}

--- a/src/zero-search/search.ts
+++ b/src/zero-search/search.ts
@@ -1,4 +1,5 @@
 import { ZeroSessionEventStore } from '../zero-sessions';
+import { redactZeroSecrets, redactZeroString } from '../zero-redaction';
 import type {
   ZeroSearchCandidate,
   ZeroSearchHit,
@@ -31,10 +32,11 @@ export async function searchZeroSessions(
     for (const event of events) {
       if (options.type && event.type !== options.type) continue;
 
+      const redactedPayload = redactZeroSecrets(event.payload);
       const candidate: ZeroSearchCandidate = {
         session,
         event,
-        text: extractSearchText(event.payload),
+        text: extractSearchText(redactedPayload),
       };
       const match = findSearchMatch(candidate.text, normalizedQuery, terms);
       if (!match) continue;
@@ -75,7 +77,7 @@ export async function searchZeroSessions(
 }
 
 export function formatZeroSearchResult(result: ZeroSearchResult): string {
-  const query = result.query.trim();
+  const query = redactZeroString(result.query.trim());
   if (result.hits.length === 0) {
     return `No local session events matched "${query}". Searched ${formatCount(
       result.searchedSessions,
@@ -88,18 +90,20 @@ export function formatZeroSearchResult(result: ZeroSearchResult): string {
   ];
 
   result.hits.forEach((hit, index) => {
-    const title = hit.session.title ? ` - ${hit.session.title}` : '';
+    const sessionId = redactZeroString(hit.session.sessionId);
+    const eventType = redactZeroString(hit.event.type);
+    const title = hit.session.title ? ` - ${redactZeroString(hit.session.title)}` : '';
     lines.push(
-      `${index + 1}. ${hit.session.sessionId} #${hit.event.sequence} ${hit.event.type}${title}`
+      `${index + 1}. ${sessionId} #${hit.event.sequence} ${eventType}${title}`
     );
-    const context = hit.context.replace(/\s+/g, ' ').trim();
+    const context = redactZeroString(hit.context).replace(/\s+/g, ' ').trim();
     if (context) lines.push(`   ${context}`);
 
     const details = [
-      hit.session.cwd ? `cwd: ${hit.session.cwd}` : undefined,
-      hit.session.modelId ? `model: ${hit.session.modelId}` : undefined,
-      hit.session.provider ? `provider: ${hit.session.provider}` : undefined,
-      `updated: ${hit.session.updatedAt}`,
+      hit.session.cwd ? `cwd: ${redactZeroString(hit.session.cwd)}` : undefined,
+      hit.session.modelId ? `model: ${redactZeroString(hit.session.modelId)}` : undefined,
+      hit.session.provider ? `provider: ${redactZeroString(hit.session.provider)}` : undefined,
+      `updated: ${redactZeroString(hit.session.updatedAt)}`,
     ].filter(Boolean);
     lines.push(`   ${details.join(' | ')}`);
   });

--- a/src/zero-search/types.ts
+++ b/src/zero-search/types.ts
@@ -1,0 +1,47 @@
+import type {
+  ZeroSessionEvent,
+  ZeroSessionEventStore,
+  ZeroSessionEventType,
+  ZeroSessionMetadata,
+} from '../zero-sessions';
+
+export interface ZeroSearchOptions {
+  store?: ZeroSessionEventStore;
+  rootDir?: string;
+  limit?: number;
+  contextChars?: number;
+  sessionId?: string;
+  type?: ZeroSessionEventType;
+}
+
+export interface ZeroSearchEventSummary {
+  id: string;
+  sequence: number;
+  type: ZeroSessionEventType;
+  createdAt: string;
+}
+
+export interface ZeroSearchHit {
+  session: ZeroSessionMetadata;
+  event: ZeroSearchEventSummary;
+  context: string;
+  match: {
+    start: number;
+    end: number;
+  };
+}
+
+export interface ZeroSearchResult {
+  query: string;
+  normalizedQuery: string;
+  rootDir: string;
+  searchedSessions: number;
+  totalHits: number;
+  hits: ZeroSearchHit[];
+}
+
+export interface ZeroSearchCandidate {
+  session: ZeroSessionMetadata;
+  event: ZeroSessionEvent;
+  text: string;
+}

--- a/tests/zero-search-cli.test.ts
+++ b/tests/zero-search-cli.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZeroSessionEventStore } from '../src/zero-sessions';
+
+async function runZeroSearch(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {}
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, 'src/index.ts', 'search', ...args], {
+    env: { ...process.env, ...envOverrides },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('zero search CLI', () => {
+  it('prints structured JSON search results from the default session root', async () => {
+    const dataHome = mkdtempSync(join(tmpdir(), 'zero-search-cli-'));
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir: join(dataHome, 'zero', 'sessions'),
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+      await store.createSession({
+        sessionId: 'cli_search',
+        title: 'CLI Search',
+        cwd: '/repo/zero',
+      });
+      await store.appendEvent('cli_search', {
+        type: 'tool_result',
+        payload: { result: 'local zero search json output' },
+      });
+
+      const result = await runZeroSearch(
+        ['--json', '--limit', '5', '--context', '12', 'zero', 'search'],
+        { XDG_DATA_HOME: dataHome }
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.trim()).toBe('');
+      const payload = JSON.parse(result.stdout);
+      expect(payload).toMatchObject({
+        query: 'zero search',
+        normalizedQuery: 'zero search',
+        searchedSessions: 1,
+        totalHits: 1,
+      });
+      expect(payload.hits[0]).toMatchObject({
+        session: {
+          sessionId: 'cli_search',
+          title: 'CLI Search',
+        },
+        event: {
+          id: 'cli_search:1',
+          type: 'tool_result',
+        },
+      });
+      expect(payload.hits[0].context).toContain('zero search');
+    } finally {
+      rmSync(dataHome, { recursive: true, force: true });
+    }
+  });
+
+  it('prints readable text output and returns a usage error for invalid options', async () => {
+    const dataHome = mkdtempSync(join(tmpdir(), 'zero-search-cli-'));
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir: join(dataHome, 'zero', 'sessions'),
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+      await store.createSession({ sessionId: 'text_search', title: 'Text Search' });
+      await store.appendEvent('text_search', {
+        type: 'message',
+        payload: { content: 'searchable text output from session events' },
+      });
+
+      const textResult = await runZeroSearch(['searchable', 'output'], {
+        XDG_DATA_HOME: dataHome,
+      });
+      expect(textResult.exitCode).toBe(0);
+      expect(textResult.stderr.trim()).toBe('');
+      expect(textResult.stdout).toContain('Found 1 local session event');
+      expect(textResult.stdout).toContain('text_search #1 message - Text Search');
+
+      const invalidResult = await runZeroSearch(['--limit', 'zero', 'anything'], {
+        XDG_DATA_HOME: dataHome,
+      });
+      expect(invalidResult.exitCode).toBe(2);
+      expect(invalidResult.stdout.trim()).toBe('');
+      expect(invalidResult.stderr).toContain('Invalid --limit value');
+    } finally {
+      rmSync(dataHome, { recursive: true, force: true });
+    }
+  });
+});
+
+function sequenceClock(values: string[]): () => Date {
+  let index = 0;
+  return () => {
+    const value = values[Math.min(index, values.length - 1)];
+    index += 1;
+    return new Date(value ?? '2026-06-03T00:00:00.000Z');
+  };
+}

--- a/tests/zero-search-cli.test.ts
+++ b/tests/zero-search-cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
 import { ZeroSessionEventStore } from '../src/zero-sessions';
 
 async function runZeroSearch(
@@ -69,6 +70,50 @@ describe('zero search CLI', () => {
         },
       });
       expect(payload.hits[0].context).toContain('zero search');
+    } finally {
+      rmSync(dataHome, { recursive: true, force: true });
+    }
+  });
+
+  it('redacts secrets from structured JSON search output', async () => {
+    const dataHome = mkdtempSync(join(tmpdir(), 'zero-search-cli-'));
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir: join(dataHome, 'zero', 'sessions'),
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+      await store.createSession({
+        sessionId: 'json_secret_search',
+        title: 'JSON Secret sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+        cwd: '/repo/zero?token=local-cwd-secret',
+      });
+      await store.appendEvent('json_secret_search', {
+        type: 'tool_result',
+        payload: {
+          result:
+            'diagnostic json includes OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+          authorization: 'Bearer local-authorization-secret',
+          headers: {
+            cookie: 'zero_session=local-cookie-secret',
+          },
+        },
+      });
+
+      const result = await runZeroSearch(
+        ['--json', '--context', '240', 'diagnostic', 'json'],
+        { XDG_DATA_HOME: dataHome }
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.trim()).toBe('');
+      expect(result.stdout).toContain(ZERO_REDACTED_SECRET);
+      expect(result.stdout).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+      expect(result.stdout).not.toContain('local-cwd-secret');
+      expect(result.stdout).not.toContain('local-authorization-secret');
+      expect(result.stdout).not.toContain('local-cookie-secret');
     } finally {
       rmSync(dataHome, { recursive: true, force: true });
     }

--- a/tests/zero-search.test.ts
+++ b/tests/zero-search.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZeroSessionEventStore } from '../src/zero-sessions';
+import {
+  formatZeroSearchResult,
+  searchZeroSessions,
+} from '../src/zero-search';
+
+function tempRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'zero-search-'));
+}
+
+describe('Zero session search backend', () => {
+  it('returns metadata-rich local event hits in latest-session order', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+          '2026-06-03T00:00:02.000Z',
+          '2026-06-03T00:00:03.000Z',
+        ]),
+      });
+
+      await store.createSession({
+        sessionId: 'older_search',
+        title: 'Older search work',
+        cwd: '/repo/zero',
+        modelId: 'gpt-4.1',
+        provider: 'openai',
+      });
+      await store.appendEvent('older_search', {
+        type: 'tool_result',
+        payload: {
+          toolCallId: 'call_1',
+          result: 'The Zero search backend reads append-only event JSONL.',
+        },
+      });
+      await store.createSession({
+        sessionId: 'newer_search',
+        title: 'Newer search work',
+        cwd: '/repo/zero/packages/cli',
+        modelId: 'claude-sonnet-4',
+        provider: 'anthropic',
+      });
+      await store.appendEvent('newer_search', {
+        type: 'message',
+        payload: {
+          role: 'user',
+          content: 'Please add zero search command output.',
+        },
+      });
+
+      const result = await searchZeroSessions('ZERO search', {
+        store,
+        contextChars: 18,
+        limit: 10,
+      });
+
+      expect(result.query).toBe('ZERO search');
+      expect(result.normalizedQuery).toBe('zero search');
+      expect(result.rootDir).toBe(rootDir);
+      expect(result.searchedSessions).toBe(2);
+      expect(result.totalHits).toBe(2);
+      expect(result.hits.map((hit) => hit.session.sessionId)).toEqual([
+        'newer_search',
+        'older_search',
+      ]);
+      expect(result.hits[0]).toMatchObject({
+        event: {
+          id: 'newer_search:1',
+          sequence: 1,
+          type: 'message',
+        },
+        session: {
+          title: 'Newer search work',
+          provider: 'anthropic',
+          modelId: 'claude-sonnet-4',
+        },
+      });
+      expect(result.hits[0]?.context).toContain('zero search command');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('filters by session id and event type before applying the result limit', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+          '2026-06-03T00:00:02.000Z',
+          '2026-06-03T00:00:03.000Z',
+        ]),
+      });
+
+      await store.createSession({ sessionId: 'target_session', title: 'Target' });
+      await store.appendEvent('target_session', {
+        type: 'message',
+        payload: { content: 'search term from user message' },
+      });
+      await store.appendEvent('target_session', {
+        type: 'tool_result',
+        payload: { result: 'search term from tool result' },
+      });
+      await store.createSession({ sessionId: 'other_session', title: 'Other' });
+      await store.appendEvent('other_session', {
+        type: 'tool_result',
+        payload: { result: 'search term in another session' },
+      });
+
+      const result = await searchZeroSessions('search term', {
+        store,
+        sessionId: 'target_session',
+        type: 'tool_result',
+        limit: 1,
+      });
+
+      expect(result.searchedSessions).toBe(1);
+      expect(result.totalHits).toBe(1);
+      expect(result.hits[0]?.session.sessionId).toBe('target_session');
+      expect(result.hits[0]?.event.type).toBe('tool_result');
+      expect(result.hits[0]?.context).toContain('tool result');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('formats text output for hits and empty results', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+
+      await store.createSession({
+        sessionId: 'format_session',
+        title: 'Format Session',
+        cwd: '/repo/zero',
+      });
+      await store.appendEvent('format_session', {
+        type: 'message',
+        payload: { content: 'formatting zero search result text' },
+      });
+
+      const hitResult = await searchZeroSessions('search result', { store });
+      expect(formatZeroSearchResult(hitResult)).toContain(
+        '1. format_session #1 message - Format Session'
+      );
+      expect(formatZeroSearchResult(hitResult)).toContain(
+        'formatting zero search result text'
+      );
+
+      const emptyResult = await searchZeroSessions('missing', { store });
+      expect(formatZeroSearchResult(emptyResult)).toBe(
+        'No local session events matched "missing". Searched 1 session.'
+      );
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function sequenceClock(values: string[]): () => Date {
+  let index = 0;
+  return () => {
+    const value = values[Math.min(index, values.length - 1)];
+    index += 1;
+    return new Date(value ?? '2026-06-03T00:00:00.000Z');
+  };
+}

--- a/tests/zero-search.test.ts
+++ b/tests/zero-search.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ZeroSessionEventStore } from '../src/zero-sessions';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
 import {
   formatZeroSearchResult,
   searchZeroSessions,
@@ -166,6 +167,49 @@ describe('Zero session search backend', () => {
       expect(formatZeroSearchResult(emptyResult)).toBe(
         'No local session events matched "missing". Searched 1 session.'
       );
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('redacts secrets from formatted search output', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+      await store.createSession({
+        sessionId: 'secret_search',
+        title: 'Secret Search sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+        cwd: '/repo/zero?token=local-cwd-secret',
+      });
+      await store.appendEvent('secret_search', {
+        type: 'tool_result',
+        payload: {
+          result:
+            'diagnostic output includes OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+          authorization: 'Bearer local-authorization-secret',
+          headers: {
+            'x-api-key': 'local-header-secret',
+          },
+        },
+      });
+
+      const result = await searchZeroSessions('diagnostic output', {
+        store,
+        contextChars: 240,
+      });
+      const output = formatZeroSearchResult(result);
+
+      expect(output).toContain(ZERO_REDACTED_SECRET);
+      expect(output).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+      expect(output).not.toContain('local-cwd-secret');
+      expect(output).not.toContain('local-authorization-secret');
+      expect(output).not.toContain('local-header-secret');
     } finally {
       rmSync(rootDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Add a Zero-native `zero-search` backend that searches persisted local session events and returns metadata-rich hits.
- Support normalized phrase/term matching, bounded context snippets, result limits, session filters, and event-type filters.
- Add `zero search [options] <query...>` with text and JSON output for local session event discovery.
- Cover the backend and CLI with focused tests against real temporary Zero session stores.

## Why

M2 needs a shared backend for local session search so CLI and future TUI slash-command surfaces can reuse the same event-search behavior. This keeps persistence in `zero-sessions` and puts query behavior, filtering, result shaping, and CLI formatting in a separate Zero module.

## Implementation Notes

- `searchZeroSessions` accepts an injected store for tests or an optional root directory for callers that need custom session roots.
- Search results include session metadata, event summaries, match ranges, context snippets, root directory, searched-session count, and total hit count.
- Text formatting gives a compact scan-friendly result list, while `--json` preserves the structured result for automation.
- CLI option validation returns usage-style exit code `2` for invalid numeric options.

## Validation

- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero search --help`
- `./zero providers current`
- `git diff --check origin/main..HEAD`

Reviewers: @Vasanthdev2004 @anandh8x