### PR TITLE
feat: add Zero doctor backend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import { configManager } from './config/manager';
 import { startTUI } from './tui';
 import { DEFAULT_UPDATE_CHECK_TIMEOUT_MS, checkForUpdate, formatUpdateCheck } from './update/check';
 import { ZERO_VERSION } from './version';
-import { redactZeroSecrets } from './zero-redaction';
+import { formatZeroDoctorReport, runZeroDoctor, type ZeroDoctorReport } from './zero-doctor';
+import { redactZeroErrorMessage, redactZeroSecrets } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
 
 const program = new Command();
@@ -166,6 +167,33 @@ program
       }
     } catch (err: unknown) {
       console.error(`[zero] Could not check for updates: ${getErrorMessage(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('doctor')
+  .description('Run Zero health checks')
+  .option('--json', 'Print health checks as JSON')
+  .option('--connectivity', 'Probe the configured provider endpoint')
+  .action(async (options: { json?: boolean; connectivity?: boolean }) => {
+    try {
+      const report = await runZeroDoctor({
+        connectivity: Boolean(options.connectivity),
+      });
+      const safeReport = redactZeroSecrets(report) as ZeroDoctorReport;
+
+      if (options.json) {
+        console.log(JSON.stringify(safeReport, null, 2));
+      } else {
+        console.log(formatZeroDoctorReport(safeReport));
+      }
+
+      if (!report.ok) {
+        process.exitCode = 1;
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] Doctor failed: ${redactZeroErrorMessage(err)}`);
       process.exitCode = 1;
     }
   });

--- a/src/zero-doctor/index.ts
+++ b/src/zero-doctor/index.ts
@@ -1,0 +1,11 @@
+export {
+  formatZeroDoctorReport,
+  runZeroDoctor,
+} from './report';
+
+export type {
+  ZeroDoctorCheck,
+  ZeroDoctorOptions,
+  ZeroDoctorReport,
+  ZeroDoctorStatus,
+} from './types';

--- a/src/zero-doctor/report.ts
+++ b/src/zero-doctor/report.ts
@@ -1,0 +1,396 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { loadConfigWithLayers, ZeroConfigSchema } from '../config/loader';
+import { loadProviderConfig, type ProviderConfig } from '../config/provider';
+import {
+  createZeroProvider,
+  resolveZeroProviderRuntime,
+} from '../zero-provider-runtime';
+import type { ZeroResolvedProviderRuntime } from '../zero-provider-runtime';
+import {
+  redactZeroErrorMessage,
+  redactZeroSecrets,
+  redactZeroString,
+} from '../zero-redaction';
+import type {
+  ZeroDoctorCheck,
+  ZeroDoctorOptions,
+  ZeroDoctorReport,
+  ZeroDoctorStatus,
+} from './types';
+
+const DEFAULT_CONNECTIVITY_TIMEOUT_MS = 3000;
+
+export async function runZeroDoctor(
+  options: ZeroDoctorOptions = {}
+): Promise<ZeroDoctorReport> {
+  const checks: ZeroDoctorCheck[] = [];
+  const now = options.now ?? (() => new Date());
+
+  checks.push(checkBunRuntime(options.bunVersion));
+  checks.push(checkConfigFiles(options));
+
+  const providerConfig = await resolveDoctorProviderConfig(options);
+  checks.push(providerConfig.check);
+
+  const runtimeResult = checkProviderRuntime(providerConfig.value);
+  checks.push(runtimeResult.check);
+  checks.push(checkProviderAdapter(runtimeResult.runtime));
+  checks.push(await checkProviderConnectivity(runtimeResult.runtime, options));
+
+  return {
+    generatedAt: now().toISOString(),
+    ok: checks.every((check) => check.status !== 'fail'),
+    checks,
+  };
+}
+
+export function formatZeroDoctorReport(report: ZeroDoctorReport): string {
+  const status = report.ok ? 'pass' : 'fail';
+  const lines = [
+    `Zero doctor report (${redactZeroString(report.generatedAt)})`,
+    `Overall: ${status}`,
+  ];
+
+  for (const check of report.checks) {
+    lines.push(
+      `[${check.status}] ${redactZeroString(check.id)} - ${redactZeroString(check.message)}`
+    );
+    const detailLine = formatDetails(check.details);
+    if (detailLine) lines.push(`  ${detailLine}`);
+  }
+
+  return lines.join('\n');
+}
+
+function checkBunRuntime(bunVersion: string | undefined): ZeroDoctorCheck {
+  const version = bunVersion ?? getBunVersion();
+  if (!version) {
+    return check(
+      'runtime.bun',
+      'Bun runtime',
+      'fail',
+      'Bun runtime was not detected. Zero must be run with Bun for local CLI support.'
+    );
+  }
+
+  return check(
+    'runtime.bun',
+    'Bun runtime',
+    'pass',
+    `Bun ${version} is available.`,
+    { version }
+  );
+}
+
+function checkConfigFiles(options: ZeroDoctorOptions): ZeroDoctorCheck {
+  const userConfigPath = options.userConfigPath ?? defaultUserConfigPath();
+  const projectConfigPath = options.projectConfigPath ?? defaultProjectConfigPath();
+  const fileErrors = [
+    validateConfigFile('user', userConfigPath),
+    validateConfigFile('project', projectConfigPath),
+  ].filter(Boolean) as string[];
+
+  if (fileErrors.length > 0) {
+    return check(
+      'config.files',
+      'Config files',
+      'fail',
+      'One or more Zero config files are invalid.',
+      {
+        errors: fileErrors,
+        userConfigPath,
+        projectConfigPath,
+      }
+    );
+  }
+
+  const { layers } = loadConfigWithLayers({
+    userConfigPath,
+    projectConfigPath,
+    env: options.env,
+  });
+
+  return check(
+    'config.files',
+    'Config files',
+    'pass',
+    `Config loaded from ${layers.length} layer${layers.length === 1 ? '' : 's'}.`,
+    {
+      layers: layers.map((layer) => layer.source),
+      userConfigPath,
+      projectConfigPath,
+    }
+  );
+}
+
+async function resolveDoctorProviderConfig(
+  options: ZeroDoctorOptions
+): Promise<{ check: ZeroDoctorCheck; value?: ProviderConfig }> {
+  try {
+    const providerConfig =
+      'providerConfig' in options
+        ? options.providerConfig ?? undefined
+        : await (options.loadProviderConfig ?? loadProviderConfig)();
+
+    if (!providerConfig) {
+      return {
+        check: check(
+          'provider.config',
+          'Provider config',
+          'fail',
+          'No LLM provider is configured.',
+          {
+            help: 'Run /provider or set OPENAI_API_KEY.',
+          }
+        ),
+      };
+    }
+
+    return {
+      value: providerConfig,
+      check: check(
+        'provider.config',
+        'Provider config',
+        'pass',
+        `Provider config loaded from ${providerConfig.source}.`,
+        {
+          source: providerConfig.source,
+          profileName: providerConfig.profileName,
+          provider: providerConfig.provider ?? 'auto',
+          baseURL: providerConfig.baseURL,
+          model: providerConfig.model,
+          apiKey: providerConfig.apiKey,
+        }
+      ),
+    };
+  } catch (err: unknown) {
+    return {
+      check: check(
+        'provider.config',
+        'Provider config',
+        'fail',
+        `Provider config could not be loaded: ${redactZeroErrorMessage(err)}`
+      ),
+    };
+  }
+}
+
+function checkProviderRuntime(
+  providerConfig: ProviderConfig | undefined
+): { check: ZeroDoctorCheck; runtime?: ZeroResolvedProviderRuntime } {
+  if (!providerConfig) {
+    return {
+      check: check(
+        'provider.model',
+        'Provider model',
+        'warn',
+        'Model validity was skipped because provider config is unavailable.'
+      ),
+    };
+  }
+
+  try {
+    const runtime = resolveZeroProviderRuntime({
+      provider: providerConfig.provider,
+      apiKey: providerConfig.apiKey,
+      baseURL: providerConfig.baseURL,
+      model: providerConfig.model,
+      profileName: providerConfig.profileName,
+      source: providerConfig.source,
+    });
+
+    return {
+      runtime,
+      check: check(
+        'provider.model',
+        'Provider model',
+        'pass',
+        `Model ${runtime.modelId ?? runtime.requestedModel} resolves to ${runtime.provider}.`,
+        {
+          requestedModel: runtime.requestedModel,
+          modelId: runtime.modelId,
+          apiModel: runtime.apiModel,
+          provider: runtime.provider,
+          capabilities: runtime.capabilities,
+        }
+      ),
+    };
+  } catch (err: unknown) {
+    return {
+      check: check(
+        'provider.model',
+        'Provider model',
+        'fail',
+        `Provider model is invalid: ${redactZeroErrorMessage(err)}`
+      ),
+    };
+  }
+}
+
+function checkProviderAdapter(
+  runtime: ZeroResolvedProviderRuntime | undefined
+): ZeroDoctorCheck {
+  if (!runtime) {
+    return check(
+      'provider.adapter',
+      'Provider adapter',
+      'warn',
+      'Provider adapter check was skipped because provider runtime did not resolve.'
+    );
+  }
+
+  try {
+    createZeroProvider(runtime);
+    return check(
+      'provider.adapter',
+      'Provider adapter',
+      'pass',
+      `Provider adapter for ${runtime.provider} is available.`,
+      {
+        provider: runtime.provider,
+        baseURL: runtime.baseURL,
+        apiModel: runtime.apiModel,
+        apiKey: runtime.apiKey,
+      }
+    );
+  } catch (err: unknown) {
+    return check(
+      'provider.adapter',
+      'Provider adapter',
+      'fail',
+      `Provider adapter is not usable: ${redactZeroErrorMessage(err)}`,
+      {
+        provider: runtime.provider,
+        baseURL: runtime.baseURL,
+        apiModel: runtime.apiModel,
+      }
+    );
+  }
+}
+
+async function checkProviderConnectivity(
+  runtime: ZeroResolvedProviderRuntime | undefined,
+  options: ZeroDoctorOptions
+): Promise<ZeroDoctorCheck> {
+  if (!runtime) {
+    return check(
+      'provider.connectivity',
+      'Provider connectivity',
+      'warn',
+      'Connectivity check was skipped because provider runtime did not resolve.'
+    );
+  }
+
+  if (!options.connectivity) {
+    return check(
+      'provider.connectivity',
+      'Provider connectivity',
+      'warn',
+      'Connectivity probe skipped. Run `zero doctor --connectivity` to probe the provider endpoint.',
+      {
+        baseURL: runtime.baseURL,
+      }
+    );
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.connectivityTimeoutMs ?? DEFAULT_CONNECTIVITY_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(runtime.baseURL, {
+      method: 'HEAD',
+      signal: controller.signal,
+    });
+    return check(
+      'provider.connectivity',
+      'Provider connectivity',
+      'pass',
+      `Provider endpoint responded with HTTP ${response.status}.`,
+      {
+        baseURL: runtime.baseURL,
+        status: response.status,
+      }
+    );
+  } catch (err: unknown) {
+    return check(
+      'provider.connectivity',
+      'Provider connectivity',
+      'fail',
+      `Provider endpoint probe failed: ${redactZeroErrorMessage(err)}`,
+      {
+        baseURL: runtime.baseURL,
+      }
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function check(
+  id: string,
+  label: string,
+  status: ZeroDoctorStatus,
+  message: string,
+  details?: Record<string, unknown>
+): ZeroDoctorCheck {
+  return redactZeroSecrets({
+    id,
+    label,
+    status,
+    message,
+    ...(details ? { details } : {}),
+  }) as ZeroDoctorCheck;
+}
+
+function validateConfigFile(label: 'user' | 'project', path: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    const result = ZeroConfigSchema.partial().safeParse(parsed);
+    if (result.success) return undefined;
+    return `${label} config ${path}: ${result.error.issues
+      .map((issue) => issue.message)
+      .join('; ')}`;
+  } catch (err: unknown) {
+    return `${label} config ${path}: ${redactZeroErrorMessage(err)}`;
+  }
+}
+
+function formatDetails(details: Record<string, unknown> | undefined): string {
+  if (!details) return '';
+
+  const entries = Object.entries(details)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${redactZeroString(key)}: ${formatDetailValue(value)}`);
+
+  return entries.join(' | ');
+}
+
+function formatDetailValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(formatDetailValue).join(', ');
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return redactZeroString(JSON.stringify(redactZeroSecrets(value)));
+  }
+
+  return redactZeroString(String(value));
+}
+
+function getBunVersion(): string | undefined {
+  return typeof Bun !== 'undefined' ? Bun.version : undefined;
+}
+
+function defaultUserConfigPath(): string {
+  return join(homedir(), '.config', 'zero', 'config.json');
+}
+
+function defaultProjectConfigPath(): string {
+  return join(process.cwd(), '.zero', 'config.json');
+}

--- a/src/zero-doctor/types.ts
+++ b/src/zero-doctor/types.ts
@@ -1,0 +1,30 @@
+import type { ProviderConfig } from '../config/provider';
+
+export type ZeroDoctorStatus = 'pass' | 'warn' | 'fail';
+
+export interface ZeroDoctorCheck {
+  id: string;
+  label: string;
+  status: ZeroDoctorStatus;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface ZeroDoctorReport {
+  generatedAt: string;
+  ok: boolean;
+  checks: ZeroDoctorCheck[];
+}
+
+export interface ZeroDoctorOptions {
+  now?: () => Date;
+  bunVersion?: string;
+  env?: NodeJS.ProcessEnv;
+  userConfigPath?: string;
+  projectConfigPath?: string;
+  providerConfig?: ProviderConfig | null;
+  loadProviderConfig?: () => Promise<ProviderConfig>;
+  connectivity?: boolean;
+  connectivityTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}

--- a/tests/zero-doctor-cli.test.ts
+++ b/tests/zero-doctor-cli.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
+
+async function runZeroDoctor(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {}
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, 'src/index.ts', 'doctor', ...args], {
+    env: { ...process.env, ...envOverrides },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('zero doctor CLI', () => {
+  it('prints redacted structured health checks', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'zero-doctor-cli-'));
+    try {
+      const result = await runZeroDoctor(['--json'], {
+        HOME: home,
+        OPENAI_API_KEY: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+        OPENAI_MODEL: 'gpt-4.1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.trim()).toBe('');
+      expect(result.stdout).toContain(ZERO_REDACTED_SECRET);
+      expect(result.stdout).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.ok).toBe(true);
+      expect(payload.checks.map((check: { id: string }) => check.id)).toEqual([
+        'runtime.bun',
+        'config.files',
+        'provider.config',
+        'provider.model',
+        'provider.adapter',
+        'provider.connectivity',
+      ]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/zero-doctor.test.ts
+++ b/tests/zero-doctor.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
+import {
+  formatZeroDoctorReport,
+  runZeroDoctor,
+} from '../src/zero-doctor';
+
+function freshTmp(): string {
+  return mkdtempSync(join(tmpdir(), 'zero-doctor-'));
+}
+
+describe('Zero doctor backend', () => {
+  it('reports pass and warn checks for a valid offline provider setup', async () => {
+    const tmp = freshTmp();
+    try {
+      const report = await runZeroDoctor({
+        now: () => new Date('2026-06-03T00:00:00.000Z'),
+        bunVersion: '1.3.14',
+        userConfigPath: join(tmp, 'no-user.json'),
+        projectConfigPath: join(tmp, 'no-project.json'),
+        env: {},
+        providerConfig: {
+          provider: 'openai',
+          apiKey: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+          baseURL: 'https://api.openai.com/v1',
+          model: 'gpt-4.1',
+          source: 'environment',
+        },
+      });
+
+      expect(report.generatedAt).toBe('2026-06-03T00:00:00.000Z');
+      expect(report.ok).toBe(true);
+      expect(report.checks.map((check) => check.id)).toEqual([
+        'runtime.bun',
+        'config.files',
+        'provider.config',
+        'provider.model',
+        'provider.adapter',
+        'provider.connectivity',
+      ]);
+      expect(report.checks.find((check) => check.id === 'provider.model')).toMatchObject({
+        status: 'pass',
+        message: 'Model gpt-4.1 resolves to openai.',
+      });
+      expect(report.checks.find((check) => check.id === 'provider.connectivity')).toMatchObject({
+        status: 'warn',
+      });
+
+      const output = formatZeroDoctorReport(report);
+      expect(output).toContain('[pass] runtime.bun');
+      expect(output).toContain('[warn] provider.connectivity');
+      expect(output).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('fails invalid config files and redacts provider diagnostics', async () => {
+    const tmp = freshTmp();
+    try {
+      const userConfigPath = join(tmp, 'config.json');
+      writeFileSync(
+        userConfigPath,
+        JSON.stringify({
+          providers: [
+            {
+              name: 'broken',
+              provider: 'openai',
+              baseURL: 'not a url',
+              model: 'gpt-4.1',
+              apiKey: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+            },
+          ],
+        }),
+        'utf-8'
+      );
+
+      const report = await runZeroDoctor({
+        now: () => new Date('2026-06-03T00:00:00.000Z'),
+        bunVersion: '1.3.14',
+        userConfigPath,
+        projectConfigPath: join(tmp, 'no-project.json'),
+        env: {},
+        providerConfig: {
+          provider: 'openai',
+          apiKey: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+          baseURL: 'https://api.openai.com/v1?token=local-provider-secret',
+          model: 'not-in-registry',
+          source: 'environment',
+        },
+      });
+      const output = formatZeroDoctorReport(report);
+
+      expect(report.ok).toBe(false);
+      expect(report.checks.find((check) => check.id === 'config.files')?.status).toBe('fail');
+      expect(report.checks.find((check) => check.id === 'provider.model')?.status).toBe('fail');
+      expect(output).toContain(ZERO_REDACTED_SECRET);
+      expect(output).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+      expect(output).not.toContain('local-provider-secret');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the M2 Zero doctor backend and CLI surface for shared health checks across CLI/TUI consumers.

### What changed

- Added `src/zero-doctor` with a typed report model and reusable `runZeroDoctor()` backend.
- Added `zero doctor` CLI command with text output, `--json`, and optional `--connectivity` endpoint probing.
- Added pass/warn/fail checks for Bun runtime, config files, provider config, model validity, provider adapter availability, and provider connectivity.
- Routed doctor diagnostics through centralized redaction so provider keys, auth details, and sensitive URLs are not printed.
- Added backend and CLI regression coverage for successful reports, invalid config/model failures, and redacted structured output.

### Why

M2 requires `zero doctor` to expose redacted pass/warn/fail checks that can be reused by the CLI and TUI. This gives users a local health check before running agent workflows and gives future `/doctor` UI work a backend contract to consume.

### Validation

- `npx --yes bun run typecheck`
- `npx --yes bun test tests/zero-doctor.test.ts tests/zero-doctor-cli.test.ts`
- `npx --yes bun test ./tests --timeout 15000` (190 pass)
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero doctor --help`
- `HOME=$(mktemp -d) OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 OPENAI_MODEL=gpt-4.1 ./zero doctor --json` (confirmed redaction)
- `./zero providers current`
- `git diff --check origin/main..HEAD` and `git diff --check`

@Vasanthdev2004 @anandh8x please review when you get a chance.