### PR TITLE
feat: add Zero config inspection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ import { configManager } from './config/manager';
 import { startTUI } from './tui';
 import { DEFAULT_UPDATE_CHECK_TIMEOUT_MS, checkForUpdate, formatUpdateCheck } from './update/check';
 import { ZERO_VERSION } from './version';
+import {
+  formatZeroConfigInspection,
+  inspectZeroConfig,
+  type ZeroConfigInspectionReport,
+} from './zero-config-inspection';
 import { formatZeroDoctorReport, runZeroDoctor, type ZeroDoctorReport } from './zero-doctor';
 import { redactZeroErrorMessage, redactZeroSecrets } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
@@ -194,6 +199,30 @@ program
       }
     } catch (err: unknown) {
       console.error(`[zero] Doctor failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('config')
+  .description('Inspect Zero configuration')
+  .option('--json', 'Print config inspection as JSON')
+  .action((options: { json?: boolean }) => {
+    try {
+      const report = inspectZeroConfig();
+      const safeReport = redactZeroSecrets(report) as ZeroConfigInspectionReport;
+
+      if (options.json) {
+        console.log(JSON.stringify(safeReport, null, 2));
+      } else {
+        console.log(formatZeroConfigInspection(safeReport));
+      }
+
+      if (!report.ok) {
+        process.exitCode = 1;
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] Config inspection failed: ${redactZeroErrorMessage(err)}`);
       process.exitCode = 1;
     }
   });

--- a/src/zero-config-inspection/index.ts
+++ b/src/zero-config-inspection/index.ts
@@ -1,0 +1,15 @@
+export {
+  formatZeroConfigInspection,
+  inspectZeroConfig,
+} from './inspection';
+
+export type {
+  ZeroConfigInspectionOptions,
+  ZeroConfigInspectionReport,
+  ZeroConfigIssue,
+  ZeroConfigLayerInspection,
+  ZeroConfigLayerSource,
+  ZeroConfigLayerStatus,
+  ZeroConfigProviderInspection,
+  ZeroConfigProviderSource,
+} from './types';

--- a/src/zero-config-inspection/inspection.ts
+++ b/src/zero-config-inspection/inspection.ts
@@ -1,0 +1,355 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import {
+  mergeLayers,
+  ZeroConfigSchema,
+  type ZeroConfig,
+} from '../config/loader';
+import {
+  parseProviderProfileKind,
+  type ProviderProfileKind,
+} from '../config/types';
+import { ZERO_DEFAULT_MODEL_ID } from '../zero-model-registry';
+import {
+  redactZeroErrorMessage,
+  redactZeroSecrets,
+  redactZeroString,
+} from '../zero-redaction';
+import type {
+  ZeroConfigInspectionOptions,
+  ZeroConfigInspectionReport,
+  ZeroConfigIssue,
+  ZeroConfigLayerInspection,
+  ZeroConfigLayerSource,
+  ZeroConfigProviderInspection,
+} from './types';
+
+const DEFAULT_CONFIG: ZeroConfig = {
+  providers: [],
+  maxTurns: 12,
+  planMode: false,
+  debug: false,
+};
+
+export function inspectZeroConfig(
+  options: ZeroConfigInspectionOptions = {}
+): ZeroConfigInspectionReport {
+  const now = options.now ?? (() => new Date());
+  const env = options.env ?? process.env;
+  const userConfigPath = options.userConfigPath ?? defaultUserConfigPath();
+  const projectConfigPath = options.projectConfigPath ?? defaultProjectConfigPath();
+
+  const layers: ZeroConfigLayerInspection[] = [
+    {
+      source: 'defaults',
+      status: 'loaded',
+      present: true,
+      config: DEFAULT_CONFIG,
+    },
+  ];
+  const issues: ZeroConfigIssue[] = [];
+
+  const userLayer = readConfigLayer('user', userConfigPath);
+  if (userLayer) {
+    layers.push(userLayer);
+    collectLayerIssues(userLayer, issues);
+  }
+
+  const projectLayer = readConfigLayer('project', projectConfigPath);
+  if (projectLayer) {
+    layers.push(projectLayer);
+    collectLayerIssues(projectLayer, issues);
+  }
+
+  const envConfig = inspectEnvConfig(env, issues);
+  if (Object.keys(envConfig).length > 0 || hasProviderEnv(env)) {
+    layers.push({
+      source: 'env',
+      status: 'loaded',
+      present: true,
+      config: envConfig,
+    });
+  }
+
+  if (options.cliOverrides && Object.keys(options.cliOverrides).length > 0) {
+    layers.push({
+      source: 'cli',
+      status: 'loaded',
+      present: true,
+      config: options.cliOverrides,
+    });
+  }
+
+  const effective = mergeLayers(
+    DEFAULT_CONFIG,
+    ...(layers
+      .filter((layer) => layer.status === 'loaded' && layer.source !== 'defaults')
+      .map((layer) => layer.config) as ZeroConfig[])
+  );
+  const provider = inspectProviderConfig(effective, env, issues);
+
+  if (
+    effective.activeProvider &&
+    !effective.providers?.some((providerProfile) => providerProfile.name === effective.activeProvider)
+  ) {
+    issues.push({
+      id: 'config.activeProvider.missing',
+      severity: 'error',
+      source: 'provider',
+      message: `Active provider "${effective.activeProvider}" is not defined in providers.`,
+    });
+  }
+
+  return redactZeroSecrets({
+    generatedAt: now().toISOString(),
+    ok: !issues.some((issue) => issue.severity === 'error'),
+    effective,
+    layers,
+    provider,
+    issues,
+  }) as ZeroConfigInspectionReport;
+}
+
+export function formatZeroConfigInspection(report: ZeroConfigInspectionReport): string {
+  const lines = [
+    `Zero config inspection (${redactZeroString(report.generatedAt)})`,
+    `Overall: ${report.ok ? 'pass' : 'fail'}`,
+    'Layers:',
+  ];
+
+  for (const layer of report.layers) {
+    const location = layer.path ? ` ${redactZeroString(layer.path)}` : '';
+    lines.push(`  [${layer.status}] ${redactZeroString(layer.source)}${location}`);
+    const layerSummary = formatLayerConfig(layer.config);
+    if (layerSummary) lines.push(`    ${layerSummary}`);
+    for (const error of layer.errors ?? []) {
+      lines.push(`    error: ${redactZeroString(error)}`);
+    }
+  }
+
+  lines.push('Effective:');
+  lines.push(`  maxTurns: ${String(report.effective.maxTurns ?? 'unset')}`);
+  lines.push(`  planMode: ${String(report.effective.planMode ?? false)}`);
+  lines.push(`  debug: ${String(report.effective.debug ?? false)}`);
+  lines.push(`  activeProvider: ${redactZeroString(report.effective.activeProvider ?? 'none')}`);
+  lines.push(`  providers: ${report.effective.providers?.length ?? 0}`);
+  lines.push(`provider: ${formatProvider(report.provider)}`);
+
+  if (report.issues.length > 0) {
+    lines.push('Issues:');
+    for (const issue of report.issues) {
+      lines.push(
+        `  [${issue.severity}] ${redactZeroString(issue.id)} - ${redactZeroString(issue.message)}`
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function readConfigLayer(
+  source: Extract<ZeroConfigLayerSource, 'user' | 'project'>,
+  path: string
+): ZeroConfigLayerInspection | undefined {
+  if (!existsSync(path)) return undefined;
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    const result = ZeroConfigSchema.partial().safeParse(parsed);
+    if (!result.success) {
+      return {
+        source,
+        status: 'invalid',
+        present: true,
+        path,
+        config: {},
+        errors: result.error.issues.map((issue) => issue.message),
+      };
+    }
+
+    return {
+      source,
+      status: 'loaded',
+      present: true,
+      path,
+      config: result.data,
+    };
+  } catch (err: unknown) {
+    return {
+      source,
+      status: 'invalid',
+      present: true,
+      path,
+      config: {},
+      errors: [redactZeroErrorMessage(err)],
+    };
+  }
+}
+
+function collectLayerIssues(
+  layer: ZeroConfigLayerInspection,
+  issues: ZeroConfigIssue[]
+): void {
+  if (layer.status !== 'invalid') return;
+
+  issues.push({
+    id: `config.${layer.source}.invalid`,
+    severity: 'error',
+    source: layer.source,
+    path: layer.path,
+    message: `${layer.source} config is invalid: ${(layer.errors ?? []).join('; ')}`,
+  });
+}
+
+function inspectEnvConfig(
+  env: NodeJS.ProcessEnv,
+  issues: ZeroConfigIssue[]
+): ZeroConfig {
+  const config: ZeroConfig = {};
+
+  if (env.ZERO_MAX_TURNS) {
+    const maxTurns = Number.parseInt(env.ZERO_MAX_TURNS, 10);
+    if (Number.isFinite(maxTurns)) {
+      config.maxTurns = maxTurns;
+    } else {
+      issues.push({
+        id: 'config.env.ZERO_MAX_TURNS.invalid',
+        severity: 'error',
+        source: 'env',
+        message: `ZERO_MAX_TURNS must be an integer, received "${env.ZERO_MAX_TURNS}".`,
+      });
+    }
+  }
+
+  if (env.ZERO_PLAN_MODE === '1' || env.ZERO_PLAN_MODE === 'true') {
+    config.planMode = true;
+  }
+  if (env.ZERO_DEBUG === '1' || env.ZERO_DEBUG === 'true') {
+    config.debug = true;
+  }
+
+  if (env.ZERO_PROVIDER) {
+    try {
+      parseProviderProfileKind(env.ZERO_PROVIDER);
+    } catch (err: unknown) {
+      issues.push({
+        id: 'config.env.ZERO_PROVIDER.invalid',
+        severity: 'error',
+        source: 'env',
+        message: redactZeroErrorMessage(err),
+      });
+    }
+  }
+
+  return config;
+}
+
+function inspectProviderConfig(
+  effective: ZeroConfig,
+  env: NodeJS.ProcessEnv,
+  issues: ZeroConfigIssue[]
+): ZeroConfigProviderInspection {
+  if (env.ZERO_PROVIDER_COMMAND) {
+    return {
+      configured: true,
+      source: 'provider-command',
+      commandConfigured: true,
+    };
+  }
+
+  if (effective.activeProvider) {
+    const activeProfile = effective.providers?.find(
+      (provider) => provider.name === effective.activeProvider
+    );
+    if (activeProfile) {
+      return {
+        configured: true,
+        source: 'profile',
+        profileName: activeProfile.name,
+        provider: activeProfile.provider ?? 'auto',
+        baseURL: activeProfile.baseURL,
+        model: activeProfile.model,
+        apiKey: activeProfile.apiKey,
+        activeProfile,
+      };
+    }
+  }
+
+  if (hasProviderEnv(env)) {
+    let provider: ProviderProfileKind | 'auto' = 'auto';
+    if (env.ZERO_PROVIDER) {
+      try {
+        provider = parseProviderProfileKind(env.ZERO_PROVIDER) ?? 'auto';
+      } catch {
+        provider = 'auto';
+      }
+    }
+
+    return {
+      configured: true,
+      source: 'environment',
+      provider,
+      baseURL: env.OPENAI_BASE_URL || 'https://api.openai.com/v1',
+      model: env.OPENAI_MODEL || ZERO_DEFAULT_MODEL_ID,
+      apiKey: env.OPENAI_API_KEY,
+    };
+  }
+
+  if ((effective.providers?.length ?? 0) > 0) {
+    issues.push({
+      id: 'config.provider.noActiveProvider',
+      severity: 'warning',
+      source: 'provider',
+      message: 'Provider profiles exist, but activeProvider is not set.',
+    });
+  }
+
+  return {
+    configured: false,
+    source: 'none',
+  };
+}
+
+function hasProviderEnv(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.OPENAI_API_KEY ||
+    env.OPENAI_BASE_URL ||
+    env.OPENAI_MODEL ||
+    env.ZERO_PROVIDER ||
+    env.ZERO_PROVIDER_COMMAND
+  );
+}
+
+function formatLayerConfig(config: Partial<ZeroConfig>): string {
+  const parts = [
+    config.maxTurns !== undefined ? `maxTurns=${config.maxTurns}` : undefined,
+    config.planMode !== undefined ? `planMode=${config.planMode}` : undefined,
+    config.debug !== undefined ? `debug=${config.debug}` : undefined,
+    config.activeProvider ? `activeProvider=${redactZeroString(config.activeProvider)}` : undefined,
+    config.providers ? `providers=${config.providers.length}` : undefined,
+  ].filter(Boolean);
+
+  return parts.join(' | ');
+}
+
+function formatProvider(provider: ZeroConfigProviderInspection): string {
+  if (!provider.configured) return 'none';
+
+  const parts = [
+    provider.source,
+    provider.profileName,
+    provider.provider && provider.provider !== 'auto' ? provider.provider : undefined,
+    provider.model,
+  ].filter(Boolean);
+
+  return redactZeroString(parts.join(' '));
+}
+
+function defaultUserConfigPath(): string {
+  return join(homedir(), '.config', 'zero', 'config.json');
+}
+
+function defaultProjectConfigPath(): string {
+  return join(process.cwd(), '.zero', 'config.json');
+}

--- a/src/zero-config-inspection/types.ts
+++ b/src/zero-config-inspection/types.ts
@@ -1,0 +1,53 @@
+import type { ProviderProfile, ZeroConfig } from '../config/loader';
+import type { ProviderProfileKind } from '../config/types';
+
+export type ZeroConfigLayerSource = 'defaults' | 'user' | 'project' | 'env' | 'cli';
+export type ZeroConfigLayerStatus = 'loaded' | 'invalid';
+export type ZeroConfigIssueSeverity = 'warning' | 'error';
+export type ZeroConfigProviderSource = 'profile' | 'environment' | 'provider-command' | 'none';
+
+export interface ZeroConfigInspectionOptions {
+  now?: () => Date;
+  userConfigPath?: string;
+  projectConfigPath?: string;
+  env?: NodeJS.ProcessEnv;
+  cliOverrides?: Partial<ZeroConfig>;
+}
+
+export interface ZeroConfigLayerInspection {
+  source: ZeroConfigLayerSource;
+  status: ZeroConfigLayerStatus;
+  present: boolean;
+  path?: string;
+  config: Partial<ZeroConfig>;
+  errors?: string[];
+}
+
+export interface ZeroConfigIssue {
+  id: string;
+  severity: ZeroConfigIssueSeverity;
+  source: ZeroConfigLayerSource | 'provider';
+  message: string;
+  path?: string;
+}
+
+export interface ZeroConfigProviderInspection {
+  configured: boolean;
+  source: ZeroConfigProviderSource;
+  provider?: ProviderProfileKind | 'auto';
+  profileName?: string;
+  baseURL?: string;
+  model?: string;
+  apiKey?: string;
+  commandConfigured?: boolean;
+  activeProfile?: ProviderProfile;
+}
+
+export interface ZeroConfigInspectionReport {
+  generatedAt: string;
+  ok: boolean;
+  effective: ZeroConfig;
+  layers: ZeroConfigLayerInspection[];
+  provider: ZeroConfigProviderInspection;
+  issues: ZeroConfigIssue[];
+}

--- a/tests/zero-config-cli.test.ts
+++ b/tests/zero-config-cli.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
+
+async function runZeroConfig(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {}
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, 'src/index.ts', 'config', ...args], {
+    env: { ...process.env, ...envOverrides },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('zero config CLI', () => {
+  it('prints redacted structured config inspection', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'zero-config-cli-'));
+    try {
+      const result = await runZeroConfig(['--json'], {
+        HOME: home,
+        OPENAI_API_KEY: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+        OPENAI_MODEL: 'gpt-4.1',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.trim()).toBe('');
+      expect(result.stdout).toContain(ZERO_REDACTED_SECRET);
+      expect(result.stdout).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.ok).toBe(true);
+      expect(payload.provider).toMatchObject({
+        configured: true,
+        source: 'environment',
+        model: 'gpt-4.1',
+        apiKey: ZERO_REDACTED_SECRET,
+      });
+      expect(payload.layers.map((layer: { source: string }) => layer.source)).toEqual([
+        'defaults',
+        'env',
+      ]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/zero-config-inspection.test.ts
+++ b/tests/zero-config-inspection.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
+import {
+  formatZeroConfigInspection,
+  inspectZeroConfig,
+} from '../src/zero-config-inspection';
+
+function freshTmp(): string {
+  return mkdtempSync(join(tmpdir(), 'zero-config-inspection-'));
+}
+
+describe('Zero config inspection backend', () => {
+  it('reports layered effective config and redacted provider details', () => {
+    const tmp = freshTmp();
+    try {
+      const userConfigPath = join(tmp, 'user.json');
+      const projectConfigPath = join(tmp, 'project.json');
+      writeFileSync(
+        userConfigPath,
+        JSON.stringify({
+          activeProvider: 'work',
+          maxTurns: 20,
+          providers: [{
+            name: 'work',
+            provider: 'openai',
+            baseURL: 'https://api.openai.com/v1',
+            model: 'gpt-4.1',
+            apiKey: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+          }],
+        }),
+        'utf-8'
+      );
+      writeFileSync(projectConfigPath, JSON.stringify({ maxTurns: 6 }), 'utf-8');
+
+      const report = inspectZeroConfig({
+        now: () => new Date('2026-06-03T00:00:00.000Z'),
+        userConfigPath,
+        projectConfigPath,
+        env: { ZERO_DEBUG: 'true' },
+      });
+
+      expect(report.generatedAt).toBe('2026-06-03T00:00:00.000Z');
+      expect(report.ok).toBe(true);
+      expect(report.effective.maxTurns).toBe(6);
+      expect(report.effective.debug).toBe(true);
+      expect(report.layers.map((layer) => layer.source)).toEqual([
+        'defaults',
+        'user',
+        'project',
+        'env',
+      ]);
+      expect(report.layers.find((layer) => layer.source === 'user')).toMatchObject({
+        present: true,
+        status: 'loaded',
+      });
+      expect(report.provider).toMatchObject({
+        configured: true,
+        source: 'profile',
+        profileName: 'work',
+        model: 'gpt-4.1',
+        apiKey: ZERO_REDACTED_SECRET,
+      });
+
+      const output = formatZeroConfigInspection(report);
+      expect(output).toContain('[loaded] user');
+      expect(output).toContain('provider: profile work');
+      expect(output).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces invalid config files without leaking secrets', () => {
+    const tmp = freshTmp();
+    try {
+      const userConfigPath = join(tmp, 'bad-user.json');
+      writeFileSync(
+        userConfigPath,
+        JSON.stringify({
+          providers: [{
+            name: 'broken',
+            provider: 'openai',
+            baseURL: 'not a url',
+            model: 'gpt-4.1',
+            apiKey: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+          }],
+        }),
+        'utf-8'
+      );
+
+      const report = inspectZeroConfig({
+        now: () => new Date('2026-06-03T00:00:00.000Z'),
+        userConfigPath,
+        projectConfigPath: join(tmp, 'missing-project.json'),
+        env: {},
+      });
+      const output = formatZeroConfigInspection(report);
+
+      expect(report.ok).toBe(false);
+      expect(report.layers.find((layer) => layer.source === 'user')).toMatchObject({
+        present: true,
+        status: 'invalid',
+      });
+      expect(report.issues.some((issue) => issue.id === 'config.user.invalid')).toBe(true);
+      expect(output).toContain('[invalid] user');
+      expect(output).toContain('config.user.invalid');
+      expect(output).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the M2 Zero config inspection backend and CLI surface for the `/config` workflow.

### What changed

- Added `src/zero-config-inspection` with a typed `inspectZeroConfig()` report API for CLI/TUI consumers.
- Added `zero config` CLI command with text output and `--json` structured output.
- Reports effective config, loaded config layers, provider source details, and validation issues.
- Validates user/project config files without changing the runtime loader behavior that tolerates bad config at startup.
- Redacts provider secrets and sensitive config details before returning/printing inspection output.
- Added backend and CLI regression coverage for layered config, invalid config diagnostics, and JSON redaction.

### Why

M2 needs a config inspection and validation API that the `/config` UI can consume. This gives users a safe way to understand which config layers are active, whether files are invalid, and where provider settings come from without leaking API keys.

### Validation

- `npx --yes bun run typecheck`
- `npx --yes bun test tests/zero-config-inspection.test.ts tests/zero-config-cli.test.ts`
- `npx --yes bun test ./tests --timeout 15000` (193 pass)
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero config --help`
- `HOME=$(mktemp -d) OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890 OPENAI_MODEL=gpt-4.1 ./zero config --json` (confirmed redaction)
- `./zero providers current`
- `git diff --check origin/main..HEAD` and `git diff --check`

@Vasanthdev2004 @anandh8x please review when you get a chance.