### PR TITLE
feat: add Zero stream-json protocol

### DIFF
--- a/docs/STREAM_JSON_PROTOCOL.md
+++ b/docs/STREAM_JSON_PROTOCOL.md
@@ -1,0 +1,53 @@
+# Zero Stream-JSON Protocol
+
+Zero stream-json is a line-delimited protocol for headless clients such as
+editor extensions and automation wrappers.
+
+Every line is one JSON object. Empty input lines are ignored. Output events are
+redacted before they are written to stdout.
+
+## Version
+
+Current schema version: `1`
+
+Every input and output event must include:
+
+```json
+{ "schemaVersion": 1, "type": "..." }
+```
+
+Output events also include `runId`.
+
+## Input Events
+
+`zero exec --input-format stream-json` accepts these JSONL events from stdin or
+`--file`.
+
+```json
+{ "schemaVersion": 1, "type": "message", "role": "user", "content": "Inspect this repo." }
+{ "schemaVersion": 1, "type": "prompt", "content": "Return only blockers." }
+```
+
+Zero combines accepted input event content in order, separated by blank lines.
+Unknown fields are rejected so protocol clients catch drift early.
+
+## Output Events
+
+`zero exec --output-format stream-json` emits schema-versioned JSONL events.
+
+```json
+{ "schemaVersion": 1, "type": "run_start", "runId": "run_20260603_abc123", "cwd": "/repo", "provider": "openai", "model": "gpt-4.1", "apiModel": "gpt-4.1" }
+{ "schemaVersion": 1, "type": "text", "runId": "run_20260603_abc123", "delta": "..." }
+{ "schemaVersion": 1, "type": "tool_call", "runId": "run_20260603_abc123", "id": "call_1", "name": "read_file", "args": { "path": "README.md" }, "sideEffect": "read" }
+{ "schemaVersion": 1, "type": "tool_result", "runId": "run_20260603_abc123", "id": "call_1", "status": "ok", "output": "...", "truncated": false }
+{ "schemaVersion": 1, "type": "usage", "runId": "run_20260603_abc123", "promptTokens": 12, "completionTokens": 8, "totalTokens": 20 }
+{ "schemaVersion": 1, "type": "final", "runId": "run_20260603_abc123", "text": "..." }
+{ "schemaVersion": 1, "type": "run_end", "runId": "run_20260603_abc123", "status": "success", "exitCode": 0 }
+```
+
+Errors are part of the protocol and are followed by `run_end`.
+
+```json
+{ "schemaVersion": 1, "type": "error", "runId": "run_20260603_abc123", "code": "provider_error", "message": "...", "recoverable": false }
+{ "schemaVersion": 1, "type": "run_end", "runId": "run_20260603_abc123", "status": "error", "exitCode": 3 }
+```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -363,7 +363,7 @@ async function readStreamJsonStdinIfNeeded(
   if (inputFormat !== 'stream-json' || options.file || options.stdin !== undefined) {
     return undefined;
   }
-  if (process.stdin.isTTY !== false) return undefined;
+  if (process.stdin.isTTY === true) return undefined;
 
   return Bun.stdin.text();
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,8 +14,17 @@ import {
   redactZeroSecrets,
   redactZeroString,
 } from '../zero-redaction';
+import {
+  ZERO_STREAM_JSON_SCHEMA_VERSION,
+  createZeroStreamJsonRunId,
+  formatZeroStreamJsonEvent,
+  parseZeroStreamJsonPrompt,
+  type ZeroStreamJsonOutputEvent,
+  type ZeroStreamJsonToolSideEffect,
+} from '../zero-stream-json';
 
-export type ExecOutputFormat = 'text' | 'json';
+export type ExecInputFormat = 'text' | 'stream-json';
+export type ExecOutputFormat = 'text' | 'json' | 'stream-json';
 
 export const ZERO_EXEC_EXIT_CODES = {
   success: 0,
@@ -29,21 +38,43 @@ export const ZERO_EXEC_EXIT_CODES = {
 export interface RunExecOptions {
   prompt?: string;
   file?: string;
+  inputFormat?: string;
   model?: string;
   cwd?: string;
   outputFormat?: string;
   skipPermissionsUnsafe?: boolean;
   maxTurns?: number;
+  stdin?: string;
 }
 
 class ExecUsageError extends Error {}
 
 export function parseExecOutputFormat(value: string | undefined): ExecOutputFormat | undefined {
   const normalized = (value || 'text').trim().toLowerCase();
-  return normalized === 'text' || normalized === 'json' ? normalized : undefined;
+  return normalized === 'text' || normalized === 'json' || normalized === 'stream-json'
+    ? normalized
+    : undefined;
 }
 
-export async function resolveExecPrompt(options: Pick<RunExecOptions, 'prompt' | 'file'>): Promise<string> {
+export function parseExecInputFormat(value: string | undefined): ExecInputFormat | undefined {
+  const normalized = (value || 'text').trim().toLowerCase();
+  return normalized === 'text' || normalized === 'stream-json' ? normalized : undefined;
+}
+
+export async function resolveExecPrompt(
+  options: Pick<RunExecOptions, 'prompt' | 'file' | 'inputFormat' | 'stdin'>
+): Promise<string> {
+  const inputFormat = parseExecInputFormat(options.inputFormat);
+  if (!inputFormat) {
+    throw new ExecUsageError(
+      `Invalid input format "${options.inputFormat}". Expected "text" or "stream-json".`
+    );
+  }
+
+  if (inputFormat === 'stream-json') {
+    return resolveStreamJsonExecPrompt(options);
+  }
+
   const parts: string[] = [];
   const inlinePrompt = options.prompt?.trim();
 
@@ -84,15 +115,27 @@ export async function runHeadless(prompt: string): Promise<void> {
 export async function runExec(options: RunExecOptions): Promise<number> {
   const outputFormat = parseExecOutputFormat(options.outputFormat);
   if (!outputFormat) {
-    writeUsageError(`Invalid output format "${options.outputFormat}". Expected "text" or "json".`);
+    writeUsageError(
+      `Invalid output format "${options.outputFormat}". Expected "text", "json", or "stream-json".`
+    );
+    return ZERO_EXEC_EXIT_CODES.usage;
+  }
+  const inputFormat = parseExecInputFormat(options.inputFormat);
+  if (!inputFormat) {
+    writeUsageError(`Invalid input format "${options.inputFormat}". Expected "text" or "stream-json".`);
     return ZERO_EXEC_EXIT_CODES.usage;
   }
 
   const previousCwd = process.cwd();
+  const runId = createZeroStreamJsonRunId();
 
   try {
     await changeWorkingDirectory(options.cwd);
-    const prompt = await resolveExecPrompt(options);
+    const prompt = await resolveExecPrompt({
+      ...options,
+      inputFormat,
+      stdin: options.stdin ?? await readStreamJsonStdinIfNeeded(inputFormat, options),
+    });
 
     let runtime: ZeroResolvedProviderRuntime | undefined;
     let provider: Provider;
@@ -109,21 +152,38 @@ export async function runExec(options: RunExecOptions): Promise<number> {
       });
       provider = createZeroProvider(runtime);
     } catch (err: any) {
-      writeExecError(outputFormat, 'provider_error', formatProviderError(err));
+      writeExecError(outputFormat, 'provider_error', formatProviderError(err), {
+        exitCode: ZERO_EXEC_EXIT_CODES.provider,
+        recoverable: false,
+        runId,
+      });
       return ZERO_EXEC_EXIT_CODES.provider;
     }
 
     if (options.skipPermissionsUnsafe) {
-      writeWarning(outputFormat, '--skip-permissions-unsafe grants prompt-gated tools for this run.');
+      writeWarning(
+        outputFormat,
+        '--skip-permissions-unsafe grants prompt-gated tools for this run.',
+        runId
+      );
     }
 
-    emitJson(outputFormat, {
+    emitLegacyJson(outputFormat, {
       type: 'run_start',
       cwd: process.cwd(),
       provider: runtime.provider,
       model: runtime.modelId ?? runtime.requestedModel,
       api_model: runtime.apiModel,
       output_format: outputFormat,
+    });
+    emitStreamJson(outputFormat, {
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'run_start',
+      runId,
+      cwd: process.cwd(),
+      provider: runtime.provider,
+      model: runtime.modelId ?? runtime.requestedModel,
+      apiModel: runtime.apiModel,
     });
 
     let streamedText = '';
@@ -134,18 +194,35 @@ export async function runExec(options: RunExecOptions): Promise<number> {
       onText: (text) => {
         streamedText += text;
         if (outputFormat === 'json') {
-          emitJson(outputFormat, { type: 'text', delta: text });
+          emitLegacyJson(outputFormat, { type: 'text', delta: text });
+        } else if (outputFormat === 'stream-json') {
+          emitStreamJson(outputFormat, {
+            schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+            type: 'text',
+            runId,
+            delta: text,
+          });
         } else {
           process.stdout.write(text);
         }
       },
       onToolCall: (toolCall) => {
         if (outputFormat === 'json') {
-          emitJson(outputFormat, {
+          emitLegacyJson(outputFormat, {
             type: 'tool_call',
             id: toolCall.id,
             name: toolCall.name,
             arguments: redactZeroString(toolCall.arguments),
+          });
+        } else if (outputFormat === 'stream-json') {
+          emitStreamJson(outputFormat, {
+            schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+            type: 'tool_call',
+            runId,
+            id: toolCall.id,
+            name: toolCall.name,
+            args: parseToolArguments(toolCall.arguments),
+            sideEffect: classifyToolSideEffect(toolCall.name),
           });
         } else {
           process.stderr.write(`[tool] ${toolCall.name}\n`);
@@ -153,20 +230,61 @@ export async function runExec(options: RunExecOptions): Promise<number> {
       },
       onToolResult: (result) => {
         if (outputFormat === 'json') {
-          emitJson(outputFormat, {
+          emitLegacyJson(outputFormat, {
             type: 'tool_result',
             tool_call_id: result.toolCallId,
             result: redactZeroString(result.result),
+          });
+        } else if (outputFormat === 'stream-json') {
+          emitStreamJson(outputFormat, {
+            schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+            type: 'tool_result',
+            runId,
+            id: result.toolCallId,
+            status: result.result.startsWith('Error') ? 'error' : 'ok',
+            output: result.result,
+            truncated: false,
           });
         } else {
           process.stderr.write(`[result] ${truncateForStatus(result.result)}\n`);
         }
       },
+      onUsage: (usage) => {
+        const totalTokens = (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
+        emitLegacyJson(outputFormat, {
+          type: 'usage',
+          prompt_tokens: usage.promptTokens,
+          completion_tokens: usage.completionTokens,
+          total_tokens: totalTokens,
+        });
+        emitStreamJson(outputFormat, {
+          schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+          type: 'usage',
+          runId,
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          totalTokens,
+        });
+      },
     });
 
     if (outputFormat === 'json') {
-      emitJson(outputFormat, { type: 'final', text: finalAnswer });
-      emitJson(outputFormat, { type: 'done', exit_code: ZERO_EXEC_EXIT_CODES.success });
+      emitLegacyJson(outputFormat, { type: 'final', text: finalAnswer });
+      emitLegacyJson(outputFormat, { type: 'done', exit_code: ZERO_EXEC_EXIT_CODES.success });
+    } else if (outputFormat === 'stream-json') {
+      emitStreamJson(outputFormat, {
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'final',
+        runId,
+        text: finalAnswer,
+      });
+      emitStreamJson(outputFormat, {
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'run_end',
+        runId,
+        status: 'success',
+        exitCode: ZERO_EXEC_EXIT_CODES.success,
+      });
     } else {
       if (!streamedText && finalAnswer) {
         streamedText = finalAnswer;
@@ -180,17 +298,74 @@ export async function runExec(options: RunExecOptions): Promise<number> {
     return ZERO_EXEC_EXIT_CODES.success;
   } catch (err: any) {
     if (err instanceof ExecUsageError) {
-      writeExecError(outputFormat, 'usage_error', err.message);
+      writeExecError(outputFormat, 'usage_error', err.message, {
+        exitCode: ZERO_EXEC_EXIT_CODES.usage,
+        recoverable: true,
+        runId,
+      });
       return ZERO_EXEC_EXIT_CODES.usage;
     }
 
-    writeExecError(outputFormat, 'crash', err?.message ?? String(err));
+    writeExecError(outputFormat, 'crash', err?.message ?? String(err), {
+      exitCode: ZERO_EXEC_EXIT_CODES.crash,
+      recoverable: false,
+      runId,
+    });
     return ZERO_EXEC_EXIT_CODES.crash;
   } finally {
     if (process.cwd() !== previousCwd) {
       process.chdir(previousCwd);
     }
   }
+}
+
+async function resolveStreamJsonExecPrompt(
+  options: Pick<RunExecOptions, 'prompt' | 'file' | 'stdin'>
+): Promise<string> {
+  if (options.prompt?.trim()) {
+    throw new ExecUsageError(
+      'Stream-json input does not accept positional prompt text. Pipe JSONL or use --file.'
+    );
+  }
+
+  const inputs: string[] = [];
+  if (options.file) {
+    const promptPath = resolve(options.file);
+    const promptFile = Bun.file(promptPath);
+
+    if (!(await promptFile.exists())) {
+      throw new ExecUsageError(`Stream-json input file not found: ${promptPath}`);
+    }
+
+    inputs.push(await promptFile.text());
+  }
+
+  if (options.stdin?.trim()) {
+    inputs.push(options.stdin);
+  }
+
+  const input = inputs.join('\n').trim();
+  if (!input) {
+    throw new ExecUsageError('Stream-json input required. Pipe JSONL or use --file.');
+  }
+
+  try {
+    return parseZeroStreamJsonPrompt(input);
+  } catch (err: unknown) {
+    throw new ExecUsageError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function readStreamJsonStdinIfNeeded(
+  inputFormat: ExecInputFormat,
+  options: RunExecOptions
+): Promise<string | undefined> {
+  if (inputFormat !== 'stream-json' || options.file || options.stdin !== undefined) {
+    return undefined;
+  }
+  if (process.stdin.isTTY !== false) return undefined;
+
+  return Bun.stdin.text();
 }
 
 async function changeWorkingDirectory(cwd: string | undefined): Promise<void> {
@@ -215,29 +390,89 @@ function writeUsageError(message: string): void {
   process.stderr.write(`[zero] ${message}\n`);
 }
 
-function writeExecError(format: ExecOutputFormat, code: string, message: string): void {
+function writeExecError(
+  format: ExecOutputFormat,
+  code: string,
+  message: string,
+  options: {
+    exitCode?: number;
+    recoverable?: boolean;
+    runId?: string;
+  } = {}
+): void {
   const safeMessage = redactZeroString(message);
   if (format === 'json') {
-    emitJson(format, { type: 'error', code, message: safeMessage });
+    emitLegacyJson(format, { type: 'error', code, message: safeMessage });
+    return;
+  }
+  if (format === 'stream-json' && options.runId) {
+    emitStreamJson(format, {
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'error',
+      runId: options.runId,
+      code,
+      message: safeMessage,
+      recoverable: options.recoverable ?? false,
+    });
+
+    if (options.exitCode !== undefined) {
+      emitStreamJson(format, {
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'run_end',
+        runId: options.runId,
+        status: 'error',
+        exitCode: options.exitCode,
+      });
+    }
     return;
   }
 
   process.stderr.write(`[zero] ${safeMessage}\n`);
 }
 
-function writeWarning(format: ExecOutputFormat, message: string): void {
+function writeWarning(format: ExecOutputFormat, message: string, runId: string): void {
   const safeMessage = redactZeroString(message);
   if (format === 'json') {
-    emitJson(format, { type: 'warning', message: safeMessage });
+    emitLegacyJson(format, { type: 'warning', message: safeMessage });
+    return;
+  }
+  if (format === 'stream-json') {
+    emitStreamJson(format, {
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'warning',
+      runId,
+      message: safeMessage,
+    });
     return;
   }
 
   process.stderr.write(`[zero] WARNING: ${safeMessage}\n`);
 }
 
-function emitJson(format: ExecOutputFormat, payload: Record<string, unknown>): void {
+function emitLegacyJson(format: ExecOutputFormat, payload: Record<string, unknown>): void {
   if (format !== 'json') return;
   process.stdout.write(`${JSON.stringify(redactZeroSecrets(payload))}\n`);
+}
+
+function emitStreamJson(format: ExecOutputFormat, event: ZeroStreamJsonOutputEvent): void {
+  if (format !== 'stream-json') return;
+  process.stdout.write(`${formatZeroStreamJsonEvent(event)}\n`);
+}
+
+function parseToolArguments(value: string): unknown {
+  if (!value.trim()) return {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function classifyToolSideEffect(name: string): ZeroStreamJsonToolSideEffect {
+  if (['glob', 'grep', 'list_directory', 'read_file'].includes(name)) return 'read';
+  if (['apply_patch', 'edit_file', 'write_file'].includes(name)) return 'write';
+  if (name === 'bash') return 'shell';
+  return 'unknown';
 }
 
 function formatProviderError(err: any): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,12 +52,14 @@ program
   .option('-f, --file <path>', 'Read the prompt from a file')
   .option('-m, --model <model>', 'Override the configured model for this run')
   .option('-C, --cwd <path>', 'Run from a different working directory')
-  .option('-o, --output-format <format>', 'Output format: text or json', 'text')
+  .option('-i, --input-format <format>', 'Input format: text or stream-json', 'text')
+  .option('-o, --output-format <format>', 'Output format: text, json, or stream-json', 'text')
   .option('--skip-permissions-unsafe', 'Allow prompt-gated tools for this run')
   .action(async (promptParts: string[] | undefined, options) => {
     process.exitCode = await runExec({
       prompt: (promptParts ?? []).join(' '),
       file: options.file,
+      inputFormat: options.inputFormat,
       model: options.model,
       cwd: options.cwd,
       outputFormat: options.outputFormat,

--- a/src/zero-stream-json/index.ts
+++ b/src/zero-stream-json/index.ts
@@ -1,0 +1,2 @@
+export * from './protocol';
+export * from './types';

--- a/src/zero-stream-json/protocol.ts
+++ b/src/zero-stream-json/protocol.ts
@@ -1,0 +1,82 @@
+import { redactZeroSecrets } from '../zero-redaction';
+import {
+  ZeroStreamJsonInputEventSchema,
+  ZeroStreamJsonOutputEventSchema,
+  type ZeroStreamJsonInputEvent,
+  type ZeroStreamJsonOutputEvent,
+} from './types';
+
+export class ZeroStreamJsonProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ZeroStreamJsonProtocolError';
+  }
+}
+
+export function createZeroStreamJsonRunId(now: Date = new Date()): string {
+  const timestamp = now.toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `run_${timestamp}_${random}`;
+}
+
+export function formatZeroStreamJsonEvent(event: ZeroStreamJsonOutputEvent): string {
+  const safeEvent = redactZeroSecrets(event);
+  return JSON.stringify(ZeroStreamJsonOutputEventSchema.parse(safeEvent));
+}
+
+export function parseZeroStreamJsonInput(input: string): ZeroStreamJsonInputEvent[] {
+  const events: ZeroStreamJsonInputEvent[] = [];
+  const lines = input.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]?.trim();
+    if (!line) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new ZeroStreamJsonProtocolError(
+        `Invalid stream-json input at line ${index + 1}: expected a JSON object.`
+      );
+    }
+
+    const result = ZeroStreamJsonInputEventSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new ZeroStreamJsonProtocolError(
+        `Invalid stream-json input at line ${index + 1}: ${formatSchemaIssue(result.error)}`
+      );
+    }
+
+    events.push(result.data);
+  }
+
+  return events;
+}
+
+export function resolveZeroStreamJsonPrompt(events: ZeroStreamJsonInputEvent[]): string {
+  const prompt = events
+    .map((event) => event.content.trim())
+    .filter(Boolean)
+    .join('\n\n');
+
+  if (!prompt) {
+    throw new ZeroStreamJsonProtocolError(
+      'Stream-json input must include at least one prompt or user message event.'
+    );
+  }
+
+  return prompt;
+}
+
+export function parseZeroStreamJsonPrompt(input: string): string {
+  return resolveZeroStreamJsonPrompt(parseZeroStreamJsonInput(input));
+}
+
+function formatSchemaIssue(error: { issues: Array<{ path: PropertyKey[]; message: string }> }): string {
+  const issue = error.issues[0];
+  if (!issue) return 'schema validation failed.';
+
+  const path = issue.path.length > 0 ? `${issue.path.map(String).join('.')}: ` : '';
+  return `${path}${issue.message}`;
+}

--- a/src/zero-stream-json/types.ts
+++ b/src/zero-stream-json/types.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+
+export const ZERO_STREAM_JSON_SCHEMA_VERSION = 1;
+
+const IdSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
+const NonEmptyStringSchema = z.string().min(1);
+const NonNegativeNumberSchema = z.number().finite().nonnegative();
+
+const OutputBaseSchema = z.object({
+  schemaVersion: z.literal(ZERO_STREAM_JSON_SCHEMA_VERSION),
+  runId: IdSchema,
+});
+
+export const ZeroStreamJsonRunStartSchema = OutputBaseSchema.extend({
+  type: z.literal('run_start'),
+  sessionId: IdSchema.optional(),
+  cwd: NonEmptyStringSchema,
+  provider: NonEmptyStringSchema,
+  model: NonEmptyStringSchema,
+  apiModel: NonEmptyStringSchema.optional(),
+}).strict();
+
+export const ZeroStreamJsonTextSchema = OutputBaseSchema.extend({
+  type: z.literal('text'),
+  delta: z.string(),
+}).strict();
+
+export const ZeroStreamJsonToolCallSchema = OutputBaseSchema.extend({
+  type: z.literal('tool_call'),
+  id: IdSchema,
+  name: NonEmptyStringSchema,
+  args: z.unknown().optional(),
+  sideEffect: z.enum(['read', 'write', 'shell', 'network', 'unknown']).optional(),
+}).strict();
+
+export const ZeroStreamJsonToolResultSchema = OutputBaseSchema.extend({
+  type: z.literal('tool_result'),
+  id: IdSchema,
+  status: z.enum(['ok', 'error']),
+  output: z.string(),
+  truncated: z.boolean(),
+}).strict();
+
+export const ZeroStreamJsonUsageSchema = OutputBaseSchema.extend({
+  type: z.literal('usage'),
+  promptTokens: NonNegativeNumberSchema.optional(),
+  completionTokens: NonNegativeNumberSchema.optional(),
+  totalTokens: NonNegativeNumberSchema.optional(),
+  costUsd: NonNegativeNumberSchema.optional(),
+}).strict();
+
+export const ZeroStreamJsonFinalSchema = OutputBaseSchema.extend({
+  type: z.literal('final'),
+  text: z.string(),
+}).strict();
+
+export const ZeroStreamJsonWarningSchema = OutputBaseSchema.extend({
+  type: z.literal('warning'),
+  message: NonEmptyStringSchema,
+}).strict();
+
+export const ZeroStreamJsonErrorSchema = OutputBaseSchema.extend({
+  type: z.literal('error'),
+  code: NonEmptyStringSchema,
+  message: NonEmptyStringSchema,
+  recoverable: z.boolean(),
+}).strict();
+
+export const ZeroStreamJsonRunEndSchema = OutputBaseSchema.extend({
+  type: z.literal('run_end'),
+  status: z.enum(['success', 'error']),
+  exitCode: z.number().int().nonnegative(),
+}).strict();
+
+export const ZeroStreamJsonOutputEventSchema = z.discriminatedUnion('type', [
+  ZeroStreamJsonRunStartSchema,
+  ZeroStreamJsonTextSchema,
+  ZeroStreamJsonToolCallSchema,
+  ZeroStreamJsonToolResultSchema,
+  ZeroStreamJsonUsageSchema,
+  ZeroStreamJsonFinalSchema,
+  ZeroStreamJsonWarningSchema,
+  ZeroStreamJsonErrorSchema,
+  ZeroStreamJsonRunEndSchema,
+]);
+
+export const ZeroStreamJsonPromptInputSchema = z.object({
+  schemaVersion: z.literal(ZERO_STREAM_JSON_SCHEMA_VERSION),
+  type: z.literal('prompt'),
+  content: NonEmptyStringSchema,
+}).strict();
+
+export const ZeroStreamJsonMessageInputSchema = z.object({
+  schemaVersion: z.literal(ZERO_STREAM_JSON_SCHEMA_VERSION),
+  type: z.literal('message'),
+  role: z.literal('user'),
+  content: NonEmptyStringSchema,
+}).strict();
+
+export const ZeroStreamJsonInputEventSchema = z.discriminatedUnion('type', [
+  ZeroStreamJsonPromptInputSchema,
+  ZeroStreamJsonMessageInputSchema,
+]);
+
+export type ZeroStreamJsonOutputEvent = z.infer<typeof ZeroStreamJsonOutputEventSchema>;
+export type ZeroStreamJsonInputEvent = z.infer<typeof ZeroStreamJsonInputEventSchema>;
+export type ZeroStreamJsonToolSideEffect = z.infer<
+  typeof ZeroStreamJsonToolCallSchema
+>['sideEffect'];

--- a/tests/headless-exec.test.ts
+++ b/tests/headless-exec.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'bun:test';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import {
+  parseExecInputFormat,
   parseExecOutputFormat,
   resolveExecPrompt,
   ZERO_EXEC_EXIT_CODES,
 } from '../src/cli';
+import { ZERO_STREAM_JSON_SCHEMA_VERSION } from '../src/zero-stream-json';
 
 async function runZero(args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
   const child = Bun.spawn([process.execPath, 'src/index.ts', ...args], {
@@ -33,7 +35,9 @@ describe('zero exec CLI surface', () => {
     expect(result.stdout).toContain('--file');
     expect(result.stdout).toContain('--model');
     expect(result.stdout).toContain('--cwd');
+    expect(result.stdout).toContain('--input-format');
     expect(result.stdout).toContain('--output-format');
+    expect(result.stdout).toContain('stream-json');
     expect(result.stdout).toContain('--skip-permissions-unsafe');
   });
 
@@ -51,6 +55,15 @@ describe('zero exec CLI surface', () => {
     expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
     expect(result.stdout.trim()).toBe('');
     expect(result.stderr).toContain('Invalid output format');
+    expect(result.stderr).toContain('stream-json');
+  });
+
+  it('returns usage exit code for an invalid input format', async () => {
+    const result = await runZero(['exec', '--input-format', 'yaml', 'hello']);
+
+    expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+    expect(result.stdout.trim()).toBe('');
+    expect(result.stderr).toContain('Invalid input format');
   });
 
   it('returns provider exit code for provider runtime failures', async () => {
@@ -78,6 +91,45 @@ describe('zero exec CLI surface', () => {
         code: 'provider_error',
       });
       expect(events[0].message).toContain('Unknown Zero model');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits schema-versioned stream-json provider errors and run end', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.zero-provider-test-'));
+    try {
+      const providerScript = join(dir, 'provider-command.js');
+      await writeFile(
+        providerScript,
+        'console.log(JSON.stringify({ model: "zero-test-unknown-model" }));\n',
+        'utf-8'
+      );
+
+      const result = await runZero(
+        ['exec', '--output-format', 'stream-json', 'hello'],
+        {
+          ZERO_PROVIDER_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(providerScript)}`,
+        }
+      );
+
+      const events = result.stdout.trim().split('\n').map((line) => JSON.parse(line));
+      expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.provider);
+      expect(result.stderr.trim()).toBe('');
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'error',
+        code: 'provider_error',
+        recoverable: false,
+      });
+      expect(events[0].message).toContain('Unknown Zero model');
+      expect(events[1]).toMatchObject({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'run_end',
+        status: 'error',
+        exitCode: ZERO_EXEC_EXIT_CODES.provider,
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -120,8 +172,17 @@ describe('headless exec prompt helpers', () => {
     expect(parseExecOutputFormat(undefined)).toBe('text');
     expect(parseExecOutputFormat('text')).toBe('text');
     expect(parseExecOutputFormat('json')).toBe('json');
+    expect(parseExecOutputFormat('stream-json')).toBe('stream-json');
     expect(parseExecOutputFormat('JSON')).toBe('json');
     expect(parseExecOutputFormat('xml')).toBeUndefined();
+  });
+
+  it('parses supported input formats', () => {
+    expect(parseExecInputFormat(undefined)).toBe('text');
+    expect(parseExecInputFormat('text')).toBe('text');
+    expect(parseExecInputFormat('stream-json')).toBe('stream-json');
+    expect(parseExecInputFormat('STREAM-JSON')).toBe('stream-json');
+    expect(parseExecInputFormat('yaml')).toBeUndefined();
   });
 
   it('combines inline and file prompts', async () => {
@@ -139,5 +200,26 @@ describe('headless exec prompt helpers', () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it('resolves prompts from stream-json stdin input', async () => {
+    const prompt = await resolveExecPrompt({
+      inputFormat: 'stream-json',
+      stdin: [
+        JSON.stringify({
+          schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+          type: 'message',
+          role: 'user',
+          content: 'Review the changed files.',
+        }),
+        JSON.stringify({
+          schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+          type: 'prompt',
+          content: 'Return only blockers.',
+        }),
+      ].join('\n'),
+    });
+
+    expect(prompt).toBe('Review the changed files.\n\nReturn only blockers.');
   });
 });

--- a/tests/headless-exec.test.ts
+++ b/tests/headless-exec.test.ts
@@ -9,12 +9,22 @@ import {
 } from '../src/cli';
 import { ZERO_STREAM_JSON_SCHEMA_VERSION } from '../src/zero-stream-json';
 
-async function runZero(args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+async function runZero(
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+  stdin?: string
+) {
   const child = Bun.spawn([process.execPath, 'src/index.ts', ...args], {
     env: { ...process.env, ...envOverrides },
     stderr: 'pipe',
+    stdin: stdin === undefined ? undefined : 'pipe',
     stdout: 'pipe',
   });
+
+  if (stdin !== undefined) {
+    child.stdin.write(stdin);
+    child.stdin.end();
+  }
 
   const [exitCode, stdout, stderr] = await Promise.all([
     child.exited,
@@ -130,6 +140,42 @@ describe('zero exec CLI surface', () => {
         status: 'error',
         exitCode: ZERO_EXEC_EXIT_CODES.provider,
       });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reads stream-json prompt events from piped stdin before provider setup', async () => {
+    const dir = await mkdtemp(join(process.cwd(), '.zero-provider-test-'));
+    try {
+      const providerScript = join(dir, 'provider-command.js');
+      await writeFile(
+        providerScript,
+        'console.log(JSON.stringify({ model: "zero-test-unknown-model" }));\n',
+        'utf-8'
+      );
+
+      const result = await runZero(
+        ['exec', '--input-format', 'stream-json', '--output-format', 'stream-json'],
+        {
+          ZERO_PROVIDER_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(providerScript)}`,
+        },
+        `${JSON.stringify({
+          schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+          type: 'prompt',
+          content: 'Read this from piped stdin.',
+        })}\n`
+      );
+
+      const events = result.stdout.trim().split('\n').map((line) => JSON.parse(line));
+      expect(result.exitCode).toBe(ZERO_EXEC_EXIT_CODES.provider);
+      expect(result.stderr.trim()).toBe('');
+      expect(events[0]).toMatchObject({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'error',
+        code: 'provider_error',
+      });
+      expect(events[0].message).not.toContain('Stream-json input required');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/zero-stream-json.test.ts
+++ b/tests/zero-stream-json.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  ZERO_STREAM_JSON_SCHEMA_VERSION,
+  ZeroStreamJsonInputEventSchema,
+  ZeroStreamJsonOutputEventSchema,
+  formatZeroStreamJsonEvent,
+  parseZeroStreamJsonInput,
+  resolveZeroStreamJsonPrompt,
+} from '../src/zero-stream-json';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
+
+describe('Zero stream-json protocol', () => {
+  it('validates representative output events against the frozen schema', () => {
+    const runStart = ZeroStreamJsonOutputEventSchema.parse({
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'run_start',
+      runId: 'run_20260603_abc123',
+      sessionId: 'session_abc123',
+      cwd: '/repo/zero',
+      provider: 'openai',
+      model: 'gpt-4.1',
+      apiModel: 'gpt-4.1',
+    });
+    const text = ZeroStreamJsonOutputEventSchema.parse({
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'text',
+      runId: 'run_20260603_abc123',
+      delta: 'hello',
+    });
+    const toolCall = ZeroStreamJsonOutputEventSchema.parse({
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'tool_call',
+      runId: 'run_20260603_abc123',
+      id: 'call_1',
+      name: 'read_file',
+      args: { path: 'README.md' },
+      sideEffect: 'read',
+    });
+    const runEnd = ZeroStreamJsonOutputEventSchema.parse({
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'run_end',
+      runId: 'run_20260603_abc123',
+      status: 'success',
+      exitCode: 0,
+    });
+
+    expect(runStart).toMatchObject({ type: 'run_start' });
+    expect(text).toMatchObject({ type: 'text', delta: 'hello' });
+    expect(toolCall).toMatchObject({
+      type: 'tool_call',
+      args: { path: 'README.md' },
+    });
+    expect(runEnd).toMatchObject({ type: 'run_end', status: 'success' });
+  });
+
+  it('serializes one redacted JSON object per line', () => {
+    const line = formatZeroStreamJsonEvent({
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'error',
+      runId: 'run_secret',
+      code: 'provider_error',
+      message: 'api key sk-proj-abcdefghijklmnopqrstuvwxyz0123456789 leaked',
+      recoverable: false,
+    });
+
+    expect(line).not.toContain('\n');
+    expect(line).toContain(ZERO_REDACTED_SECRET);
+    expect(line).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz0123456789');
+    expect(JSON.parse(line)).toMatchObject({
+      schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      type: 'error',
+      code: 'provider_error',
+    });
+  });
+
+  it('parses input JSONL and resolves user prompt content', () => {
+    const input = [
+      JSON.stringify({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'message',
+        role: 'user',
+        content: 'Inspect this repo.',
+      }),
+      JSON.stringify({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'prompt',
+        content: 'Focus on failing tests.',
+      }),
+      '',
+    ].join('\n');
+
+    const events = parseZeroStreamJsonInput(input);
+
+    expect(events).toEqual([
+      {
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'message',
+        role: 'user',
+        content: 'Inspect this repo.',
+      },
+      {
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'prompt',
+        content: 'Focus on failing tests.',
+      },
+    ]);
+    expect(resolveZeroStreamJsonPrompt(events)).toBe(
+      'Inspect this repo.\n\nFocus on failing tests.'
+    );
+  });
+
+  it('rejects malformed input with line numbers', () => {
+    expect(() => parseZeroStreamJsonInput('{"type":"prompt"\n')).toThrow(
+      'Invalid stream-json input at line 1'
+    );
+
+    expect(() =>
+      parseZeroStreamJsonInput(
+        JSON.stringify({
+          schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+          type: 'message',
+          role: 'assistant',
+          content: 'not accepted as input',
+        })
+      )
+    ).toThrow('Invalid stream-json input at line 1');
+  });
+
+  it('keeps input schema strict enough for extension authors', () => {
+    expect(() =>
+      ZeroStreamJsonInputEventSchema.parse({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+        type: 'prompt',
+        content: 'hello',
+        unexpected: true,
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a versioned Zero stream-json protocol module with strict input/output schemas, JSONL parsing, prompt resolution, and redacted event serialization.
- Wire `zero exec --input-format stream-json` and `--output-format stream-json` so headless clients receive schema-versioned lifecycle, text, tool, usage, final, and error events.
- Document the stream-json contract for editor integrations and automation clients.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `npx --yes bun test tests/zero-stream-json.test.ts tests/headless-exec.test.ts --timeout 15000`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero exec --help`
- `./zero exec --output-format xml hello`
- `./zero exec --output-format stream-json hello`
- `git diff --check origin/main..HEAD`
