### PR TITLE
feat: add Zero exec resume and fork sessions

### DIFF
--- a/docs/STREAM_JSON_PROTOCOL.md
+++ b/docs/STREAM_JSON_PROTOCOL.md
@@ -36,7 +36,7 @@ Unknown fields are rejected so protocol clients catch drift early.
 `zero exec --output-format stream-json` emits schema-versioned JSONL events.
 
 ```json
-{ "schemaVersion": 1, "type": "run_start", "runId": "run_20260603_abc123", "cwd": "/repo", "provider": "openai", "model": "gpt-4.1", "apiModel": "gpt-4.1" }
+{ "schemaVersion": 1, "type": "run_start", "runId": "run_20260603_abc123", "sessionId": "zero_20260603100000_abc123", "cwd": "/repo", "provider": "openai", "model": "gpt-4.1", "apiModel": "gpt-4.1" }
 { "schemaVersion": 1, "type": "text", "runId": "run_20260603_abc123", "delta": "..." }
 { "schemaVersion": 1, "type": "tool_call", "runId": "run_20260603_abc123", "id": "call_1", "name": "read_file", "args": { "path": "README.md" }, "sideEffect": "read" }
 { "schemaVersion": 1, "type": "tool_result", "runId": "run_20260603_abc123", "id": "call_1", "status": "ok", "output": "...", "truncated": false }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,13 @@ import {
   type ZeroRunContext,
 } from '../zero-runtime';
 import {
+  ZeroExecSessionError,
+  formatZeroExecSessionPrompt,
+  prepareZeroExecSession,
+  type PreparedZeroExecSession,
+  type AppendZeroSessionEventInput,
+} from '../zero-sessions';
+import {
   ZERO_STREAM_JSON_SCHEMA_VERSION,
   createZeroStreamJsonRunId,
   formatZeroStreamJsonEvent,
@@ -50,6 +57,8 @@ export interface RunExecOptions {
   listTools?: boolean;
   maxTurns?: number;
   stdin?: string;
+  resume?: string | boolean;
+  fork?: string;
 }
 
 class ExecUsageError extends Error {}
@@ -133,6 +142,24 @@ export async function runExec(options: RunExecOptions): Promise<number> {
 
   const previousCwd = process.cwd();
   const runId = createZeroStreamJsonRunId();
+  let preparedSession: PreparedZeroExecSession | undefined;
+  let sessionEventQueue: Promise<void> = Promise.resolve();
+  const appendSessionEvent = (input: AppendZeroSessionEventInput): void => {
+    if (!preparedSession) return;
+    const session = preparedSession.session;
+    sessionEventQueue = sessionEventQueue.then(async () => {
+      await preparedSession?.store.appendEvent(session.sessionId, input);
+    });
+  };
+
+  if (options.resume && options.fork) {
+    writeExecError(outputFormat, 'usage_error', 'Use either --resume or --fork, not both.', {
+      exitCode: ZERO_EXEC_EXIT_CODES.usage,
+      recoverable: true,
+      runId,
+    });
+    return ZERO_EXEC_EXIT_CODES.usage;
+  }
 
   try {
     await changeWorkingDirectory(options.cwd);
@@ -179,6 +206,31 @@ export async function runExec(options: RunExecOptions): Promise<number> {
       return ZERO_EXEC_EXIT_CODES.success;
     }
 
+    if (prompt === undefined) {
+      throw new ExecUsageError('Prompt required. Use `zero exec "prompt"` or `zero exec --file prompt.txt`.');
+    }
+
+    try {
+      preparedSession = await prepareZeroExecSession({
+        resume: options.resume,
+        fork: options.fork,
+        cwd: process.cwd(),
+        modelId: context.modelId,
+        provider: context.runtime.provider,
+        title: createSessionTitle(prompt),
+      });
+    } catch (err: unknown) {
+      if (err instanceof ZeroExecSessionError) {
+        writeExecError(outputFormat, 'usage_error', err.message, {
+          exitCode: ZERO_EXEC_EXIT_CODES.usage,
+          recoverable: true,
+          runId,
+        });
+        return ZERO_EXEC_EXIT_CODES.usage;
+      }
+      throw err;
+    }
+
     if (context.permissionMode === 'unsafe') {
       writeWarning(outputFormat, 'Unsafe permissions are active for this run.', runId);
     }
@@ -197,11 +249,13 @@ export async function runExec(options: RunExecOptions): Promise<number> {
       enabled_tools: context.enabledTools,
       disabled_tools: context.disabledTools,
       output_format: outputFormat,
+      session_id: preparedSession.session.sessionId,
     });
     emitStreamJson(outputFormat, {
       schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
       type: 'run_start',
       runId,
+      sessionId: preparedSession.session.sessionId,
       cwd: process.cwd(),
       provider: context.runtime.provider,
       model: context.modelId,
@@ -209,8 +263,13 @@ export async function runExec(options: RunExecOptions): Promise<number> {
     });
 
     let streamedText = '';
+    appendSessionEvent({
+      type: 'message',
+      payload: { role: 'user', content: prompt, source: 'exec' },
+    });
+    const agentPrompt = formatZeroExecSessionPrompt(prompt, preparedSession);
 
-    const finalAnswer = await runAgent(prompt!, context.provider, {
+    const finalAnswer = await runAgent(agentPrompt, context.provider, {
       ...context.agentOptions,
       onText: (text) => {
         streamedText += text;
@@ -228,6 +287,8 @@ export async function runExec(options: RunExecOptions): Promise<number> {
         }
       },
       onToolCall: (toolCall) => {
+        const args = parseToolArguments(toolCall.arguments);
+        const sideEffect = classifyToolSideEffect(toolCall.name);
         if (outputFormat === 'json') {
           emitLegacyJson(outputFormat, {
             type: 'tool_call',
@@ -242,14 +303,24 @@ export async function runExec(options: RunExecOptions): Promise<number> {
             runId,
             id: toolCall.id,
             name: toolCall.name,
-            args: parseToolArguments(toolCall.arguments),
-            sideEffect: classifyToolSideEffect(toolCall.name),
+            args,
+            sideEffect,
           });
         } else {
           process.stderr.write(`[tool] ${toolCall.name}\n`);
         }
+        appendSessionEvent({
+          type: 'tool_call',
+          payload: {
+            id: toolCall.id,
+            name: toolCall.name,
+            args,
+            sideEffect,
+          },
+        });
       },
       onToolResult: (result) => {
+        const status = result.result.startsWith('Error') ? 'error' : 'ok';
         if (outputFormat === 'json') {
           emitLegacyJson(outputFormat, {
             type: 'tool_result',
@@ -262,13 +333,22 @@ export async function runExec(options: RunExecOptions): Promise<number> {
             type: 'tool_result',
             runId,
             id: result.toolCallId,
-            status: result.result.startsWith('Error') ? 'error' : 'ok',
+            status,
             output: result.result,
             truncated: false,
           });
         } else {
           process.stderr.write(`[result] ${truncateForStatus(result.result)}\n`);
         }
+        appendSessionEvent({
+          type: 'tool_result',
+          payload: {
+            id: result.toolCallId,
+            status,
+            output: result.result,
+            truncated: false,
+          },
+        });
       },
       onUsage: (usage) => {
         const totalTokens = (usage.promptTokens ?? 0) + (usage.completionTokens ?? 0);
@@ -286,8 +366,21 @@ export async function runExec(options: RunExecOptions): Promise<number> {
           completionTokens: usage.completionTokens,
           totalTokens,
         });
+        appendSessionEvent({
+          type: 'provider_usage',
+          payload: {
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+            totalTokens,
+          },
+        });
       },
     });
+    appendSessionEvent({
+      type: 'message',
+      payload: { role: 'assistant', content: finalAnswer, source: 'exec' },
+    });
+    await sessionEventQueue;
 
     if (outputFormat === 'json') {
       emitLegacyJson(outputFormat, { type: 'final', text: finalAnswer });
@@ -327,6 +420,14 @@ export async function runExec(options: RunExecOptions): Promise<number> {
       return ZERO_EXEC_EXIT_CODES.usage;
     }
 
+    appendSessionEvent({
+      type: 'error',
+      payload: {
+        code: 'crash',
+        message: err?.message ?? String(err),
+      },
+    });
+    await sessionEventQueue;
     writeExecError(outputFormat, 'crash', err?.message ?? String(err), {
       exitCode: ZERO_EXEC_EXIT_CODES.crash,
       recoverable: false,
@@ -565,6 +666,11 @@ function classifyToolSideEffect(name: string): ZeroStreamJsonToolSideEffect {
   if (['apply_patch', 'edit_file', 'write_file'].includes(name)) return 'write';
   if (name === 'bash') return 'shell';
   return 'unknown';
+}
+
+function createSessionTitle(prompt: string): string {
+  const normalized = prompt.replace(/\s+/g, ' ').trim();
+  return normalized ? normalized.slice(0, 80) : 'Zero exec session';
 }
 
 function formatProviderError(err: any): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ program
   .option('-C, --cwd <path>', 'Run from a different working directory')
   .option('-i, --input-format <format>', 'Input format: text or stream-json', 'text')
   .option('-o, --output-format <format>', 'Output format: text, json, or stream-json', 'text')
+  .option('--resume [id]', 'Resume a persisted Zero session; omit id to use the latest session')
+  .option('--fork <id>', 'Fork an existing Zero session into a new session branch')
   .option('--skip-permissions-unsafe', 'Allow prompt-gated tools for this run')
   .action(async (promptParts: string[] | undefined, options) => {
     let maxTurns: number | undefined;
@@ -87,6 +89,8 @@ program
       maxTurns,
       cwd: options.cwd,
       outputFormat: options.outputFormat,
+      resume: options.resume,
+      fork: options.fork,
       skipPermissionsUnsafe: Boolean(options.skipPermissionsUnsafe),
     });
   });

--- a/src/zero-sessions/exec-session.ts
+++ b/src/zero-sessions/exec-session.ts
@@ -1,0 +1,144 @@
+import { redactZeroString } from '../zero-redaction';
+import { ZeroSessionEventStore } from './store';
+import type {
+  CreateZeroSessionInput,
+  ZeroSessionEvent,
+  ZeroSessionMetadata,
+} from './types';
+
+export type ZeroExecSessionMode = 'new' | 'resume' | 'fork';
+
+export class ZeroExecSessionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ZeroExecSessionError';
+  }
+}
+
+export interface PrepareZeroExecSessionOptions extends CreateZeroSessionInput {
+  store?: ZeroSessionEventStore;
+  resume?: string | boolean;
+  fork?: string;
+}
+
+export interface PreparedZeroExecSession {
+  mode: ZeroExecSessionMode;
+  session: ZeroSessionMetadata;
+  contextEvents: ZeroSessionEvent[];
+  store: ZeroSessionEventStore;
+}
+
+export async function prepareZeroExecSession(
+  options: PrepareZeroExecSessionOptions = {}
+): Promise<PreparedZeroExecSession> {
+  if (options.resume && options.fork) {
+    throw new ZeroExecSessionError('Use either --resume or --fork, not both.');
+  }
+
+  const store = options.store ?? new ZeroSessionEventStore();
+  const sessionInput = toCreateSessionInput(options);
+
+  if (options.fork) {
+    const parent = await store.getSession(options.fork);
+    if (!parent) throw new ZeroExecSessionError(`Zero session not found: ${options.fork}`);
+
+    const contextEvents = await store.readEvents(parent.sessionId);
+    const session = await store.forkSession(parent.sessionId, {
+      ...sessionInput,
+      title: sessionInput.title ?? (parent.title ? `${parent.title} (fork)` : undefined),
+    });
+
+    return {
+      mode: 'fork',
+      session,
+      contextEvents,
+      store,
+    };
+  }
+
+  if (options.resume) {
+    const sessionId = await resolveResumeSessionId(store, options.resume);
+    const session = await store.getSession(sessionId);
+    if (!session) throw new ZeroExecSessionError(`Zero session not found: ${sessionId}`);
+
+    return {
+      mode: 'resume',
+      session,
+      contextEvents: await store.readEvents(session.sessionId),
+      store,
+    };
+  }
+
+  return {
+    mode: 'new',
+    session: await store.createSession(sessionInput),
+    contextEvents: [],
+    store,
+  };
+}
+
+export function formatZeroExecSessionPrompt(
+  prompt: string,
+  prepared: PreparedZeroExecSession,
+  maxEvents = 20
+): string {
+  if (prepared.mode === 'new' || prepared.contextEvents.length === 0) {
+    return prompt;
+  }
+
+  const recentEvents = prepared.contextEvents.slice(-Math.max(1, maxEvents));
+  const context = recentEvents
+    .map((event) => `- #${event.sequence} ${event.type}: ${summarizeEventPayload(event.payload)}`)
+    .join('\n');
+
+  const label = prepared.mode === 'fork' ? 'Forked from' : 'Continuing';
+  return [
+    `${label} Zero session ${prepared.session.parentSessionId ?? prepared.session.sessionId}.`,
+    'Previous session context:',
+    context,
+    '',
+    'Current user request:',
+    prompt,
+  ].join('\n');
+}
+
+async function resolveResumeSessionId(
+  store: ZeroSessionEventStore,
+  resume: string | boolean
+): Promise<string> {
+  if (typeof resume === 'string' && resume.trim()) {
+    return resume.trim();
+  }
+
+  const latest = await store.getLatestSession();
+  if (!latest) throw new ZeroExecSessionError('No Zero sessions available to resume.');
+  return latest.sessionId;
+}
+
+function toCreateSessionInput(
+  options: PrepareZeroExecSessionOptions
+): CreateZeroSessionInput {
+  return {
+    sessionId: options.sessionId,
+    title: options.title,
+    cwd: options.cwd,
+    modelId: options.modelId,
+    provider: options.provider,
+  };
+}
+
+function summarizeEventPayload(payload: unknown): string {
+  const text = extractText(payload).replace(/\s+/g, ' ').trim();
+  const summary = text || JSON.stringify(payload ?? {});
+  return redactZeroString(summary.slice(0, 500));
+}
+
+function extractText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) return value.map(extractText).filter(Boolean).join(' ');
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value).map(extractText).filter(Boolean).join(' ');
+  }
+  return '';
+}

--- a/src/zero-sessions/index.ts
+++ b/src/zero-sessions/index.ts
@@ -1,8 +1,14 @@
 export { ZeroSessionEventStore, defaultZeroSessionRoot } from './store';
+export {
+  ZeroExecSessionError,
+  formatZeroExecSessionPrompt,
+  prepareZeroExecSession,
+} from './exec-session';
 export type {
   AppendZeroSessionEventInput,
   CreateZeroSessionInput,
   DefaultZeroSessionRootOptions,
+  ForkZeroSessionInput,
   ZeroSessionEvent,
   ZeroSessionEventStoreOptions,
   ZeroSessionEventType,
@@ -10,3 +16,8 @@ export type {
   ZeroSessionSearchHit,
   ZeroSessionSearchOptions,
 } from './types';
+export type {
+  PreparedZeroExecSession,
+  PrepareZeroExecSessionOptions,
+  ZeroExecSessionMode,
+} from './exec-session';

--- a/src/zero-sessions/store.ts
+++ b/src/zero-sessions/store.ts
@@ -5,6 +5,7 @@ import type {
   AppendZeroSessionEventInput,
   CreateZeroSessionInput,
   DefaultZeroSessionRootOptions,
+  ForkZeroSessionInput,
   ZeroSessionEvent,
   ZeroSessionEventStoreOptions,
   ZeroSessionMetadata,
@@ -46,6 +47,9 @@ export class ZeroSessionEventStore {
       cwd: input.cwd,
       modelId: input.modelId,
       provider: input.provider,
+      parentSessionId: input.parentSessionId,
+      forkedFromEventId: input.forkedFromEventId,
+      forkedFromSequence: input.forkedFromSequence,
       createdAt,
       updatedAt: createdAt,
       eventCount: 0,
@@ -94,6 +98,55 @@ export class ZeroSessionEventStore {
       const updated = right.updatedAt.localeCompare(left.updatedAt);
       return updated || left.sessionId.localeCompare(right.sessionId);
     });
+  }
+
+  async getLatestSession(): Promise<ZeroSessionMetadata | undefined> {
+    const sessions = await this.listSessions();
+    return sessions[0];
+  }
+
+  async forkSession(
+    parentSessionId: string,
+    input: ForkZeroSessionInput = {}
+  ): Promise<ZeroSessionMetadata> {
+    assertValidSessionId(parentSessionId);
+    const parent = await this.getSession(parentSessionId);
+    if (!parent) {
+      throw new Error(`Zero session not found: ${parentSessionId}`);
+    }
+
+    const parentEvents = await this.readEvents(parentSessionId);
+    const lastParentEvent = parentEvents[parentEvents.length - 1];
+    const fork = await this.createSession({
+      sessionId: input.sessionId,
+      title: input.title ?? (parent.title ? `${parent.title} (fork)` : undefined),
+      cwd: input.cwd ?? parent.cwd,
+      modelId: input.modelId ?? parent.modelId,
+      provider: input.provider ?? parent.provider,
+      parentSessionId,
+      forkedFromEventId: lastParentEvent?.id,
+      forkedFromSequence: lastParentEvent?.sequence,
+    });
+
+    for (const event of parentEvents) {
+      await this.appendEvent(fork.sessionId, {
+        type: event.type,
+        payload: cloneJsonValue(event.payload),
+      });
+    }
+
+    await this.appendEvent(fork.sessionId, {
+      type: 'session_fork',
+      payload: {
+        parentSessionId,
+        parentEventCount: parent.eventCount,
+        copiedEventCount: parentEvents.length,
+        forkedFromEventId: lastParentEvent?.id,
+        forkedFromSequence: lastParentEvent?.sequence,
+      },
+    });
+
+    return await this.readMetadata(fork.sessionId);
   }
 
   async appendEvent(
@@ -241,6 +294,11 @@ function extractSearchText(value: unknown): string {
     return Object.values(value).map(extractSearchText).filter(Boolean).join(' ');
   }
   return '';
+}
+
+function cloneJsonValue<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
 }
 
 function isFileExistsError(err: unknown): boolean {

--- a/src/zero-sessions/types.ts
+++ b/src/zero-sessions/types.ts
@@ -4,6 +4,7 @@ export type ZeroSessionEventType =
   | 'tool_result'
   | 'provider_usage'
   | 'error'
+  | 'session_fork'
   | (string & {});
 
 export interface ZeroSessionMetadata {
@@ -12,6 +13,9 @@ export interface ZeroSessionMetadata {
   cwd?: string;
   modelId?: string;
   provider?: string;
+  parentSessionId?: string;
+  forkedFromEventId?: string;
+  forkedFromSequence?: number;
   createdAt: string;
   updatedAt: string;
   eventCount: number;
@@ -24,7 +28,12 @@ export interface CreateZeroSessionInput {
   cwd?: string;
   modelId?: string;
   provider?: string;
+  parentSessionId?: string;
+  forkedFromEventId?: string;
+  forkedFromSequence?: number;
 }
+
+export interface ForkZeroSessionInput extends Omit<CreateZeroSessionInput, 'parentSessionId'> {}
 
 export interface AppendZeroSessionEventInput {
   type: ZeroSessionEventType;

--- a/tests/headless-exec.test.ts
+++ b/tests/headless-exec.test.ts
@@ -7,6 +7,7 @@ import {
   resolveExecPrompt,
   ZERO_EXEC_EXIT_CODES,
 } from '../src/cli';
+import { ZeroSessionEventStore } from '../src/zero-sessions';
 import { ZERO_STREAM_JSON_SCHEMA_VERSION } from '../src/zero-stream-json';
 
 async function runZero(
@@ -53,6 +54,8 @@ describe('zero exec CLI surface', () => {
     expect(result.stdout).toContain('--cwd');
     expect(result.stdout).toContain('--input-format');
     expect(result.stdout).toContain('--output-format');
+    expect(result.stdout).toContain('--resume');
+    expect(result.stdout).toContain('--fork');
     expect(result.stdout).toContain('stream-json');
     expect(result.stdout).toContain('--skip-permissions-unsafe');
   });
@@ -117,6 +120,42 @@ describe('zero exec CLI surface', () => {
       expect(result.stdout).not.toContain('bash');
     } finally {
       await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns usage exit code for invalid resume and fork options', async () => {
+    const dataHome = await mkdtemp(join(process.cwd(), '.zero-session-cli-'));
+    try {
+      const conflictWithoutProvider = await runZero(
+        ['exec', '--resume', 'abc', '--fork', 'def', 'hello'],
+        { XDG_DATA_HOME: dataHome, OPENAI_API_KEY: '' }
+      );
+      expect(conflictWithoutProvider.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+      expect(conflictWithoutProvider.stderr).toContain('Use either --resume or --fork, not both');
+      expect(conflictWithoutProvider.stderr).not.toContain('No LLM provider configured');
+
+      const conflict = await runZero(
+        ['exec', '--resume', 'abc', '--fork', 'def', 'hello'],
+        { XDG_DATA_HOME: dataHome, OPENAI_API_KEY: 'test-key' }
+      );
+      expect(conflict.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+      expect(conflict.stderr).toContain('Use either --resume or --fork, not both');
+
+      const missingLatest = await runZero(
+        ['exec', 'hello', '--resume'],
+        { XDG_DATA_HOME: dataHome, OPENAI_API_KEY: 'test-key' }
+      );
+      expect(missingLatest.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+      expect(missingLatest.stderr).toContain('No Zero sessions available to resume');
+
+      const missingFork = await runZero(
+        ['exec', '--fork', 'missing', 'hello'],
+        { XDG_DATA_HOME: dataHome, OPENAI_API_KEY: 'test-key' }
+      );
+      expect(missingFork.exitCode).toBe(ZERO_EXEC_EXIT_CODES.usage);
+      expect(missingFork.stderr).toContain('Zero session not found: missing');
+    } finally {
+      await rm(dataHome, { recursive: true, force: true });
     }
   });
 
@@ -253,6 +292,74 @@ describe('zero exec CLI surface', () => {
       expect(events[0].message).not.toContain(leakedModel);
     } finally {
       await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits session id and records successful exec events', async () => {
+    const dataHome = await mkdtemp(join(process.cwd(), '.zero-session-cli-'));
+    const providerDir = await mkdtemp(join(process.cwd(), '.zero-provider-test-'));
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response([
+          'data: {"id":"chatcmpl_zero","object":"chat.completion.chunk","created":0,"model":"local-coder","choices":[{"index":0,"delta":{"content":"session recorded"},"finish_reason":null}]}\n\n',
+          'data: {"id":"chatcmpl_zero","object":"chat.completion.chunk","created":0,"model":"local-coder","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+          'data: [DONE]\n\n',
+        ].join(''), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      },
+    });
+
+    try {
+      const providerScript = join(providerDir, 'provider-command.js');
+      await writeFile(
+        providerScript,
+        `console.log(JSON.stringify({ provider: "openai-compatible", model: "local-coder", base_url: "http://127.0.0.1:${server.port}/v1" }));\n`,
+        'utf-8'
+      );
+
+      const result = await runZero(
+        ['exec', '--model', 'local-coder', '--output-format', 'stream-json', 'persist this'],
+        {
+          XDG_DATA_HOME: dataHome,
+          ZERO_PROVIDER_COMMAND: `${JSON.stringify(process.execPath)} ${JSON.stringify(providerScript)}`,
+        }
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.trim()).toBe('');
+      const events = result.stdout.trim().split('\n').map((line) => JSON.parse(line));
+      const runStart = events.find((event) => event.type === 'run_start');
+      const sessionId = runStart?.sessionId;
+      expect(runStart).toMatchObject({
+        schemaVersion: ZERO_STREAM_JSON_SCHEMA_VERSION,
+      });
+      expect(typeof sessionId).toBe('string');
+      expect(events.find((event) => event.type === 'final')).toMatchObject({
+        text: 'session recorded',
+      });
+
+      const store = new ZeroSessionEventStore({
+        rootDir: join(dataHome, 'zero', 'sessions'),
+      });
+      const sessions = await store.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]).toMatchObject({
+        sessionId,
+        eventCount: 2,
+        lastEventType: 'message',
+      });
+      const recorded = await store.readEvents(sessionId);
+      expect(recorded.map((event) => [event.type, (event.payload as any).role])).toEqual([
+        ['message', 'user'],
+        ['message', 'assistant'],
+      ]);
+      expect((recorded[1]?.payload as any).content).toBe('session recorded');
+    } finally {
+      server.stop(true);
+      await rm(dataHome, { recursive: true, force: true });
+      await rm(providerDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/zero-exec-session.test.ts
+++ b/tests/zero-exec-session.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  ZeroSessionEventStore,
+  formatZeroExecSessionPrompt,
+  prepareZeroExecSession,
+} from '../src/zero-sessions';
+
+function tempRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'zero-exec-session-'));
+}
+
+describe('Zero exec session resolution', () => {
+  it('creates a new session for a normal exec run', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock(['2026-06-03T10:00:00.000Z']),
+      });
+
+      const prepared = await prepareZeroExecSession({
+        store,
+        cwd: '/repo/zero',
+        modelId: 'gpt-4.1',
+        provider: 'openai',
+        title: 'Implement sessions',
+      });
+
+      expect(prepared.mode).toBe('new');
+      expect(prepared.session).toMatchObject({
+        title: 'Implement sessions',
+        cwd: '/repo/zero',
+        modelId: 'gpt-4.1',
+        provider: 'openai',
+        eventCount: 0,
+      });
+      expect(prepared.contextEvents).toEqual([]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resumes the latest session when --resume has no id', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T10:00:00.000Z',
+          '2026-06-03T10:00:01.000Z',
+          '2026-06-03T10:00:02.000Z',
+        ]),
+      });
+      await store.createSession({ sessionId: 'older', title: 'Older' });
+      await store.createSession({ sessionId: 'latest', title: 'Latest' });
+      await store.appendEvent('latest', {
+        type: 'message',
+        payload: { role: 'assistant', content: 'previous answer' },
+      });
+
+      const prepared = await prepareZeroExecSession({
+        store,
+        resume: true,
+        cwd: '/repo/zero',
+        modelId: 'gpt-4.1',
+        provider: 'openai',
+      });
+
+      expect(prepared.mode).toBe('resume');
+      expect(prepared.session.sessionId).toBe('latest');
+      expect(prepared.contextEvents.map((event) => event.id)).toEqual(['latest:1']);
+      expect(formatZeroExecSessionPrompt('continue', prepared)).toContain('previous answer');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('forks an existing session into a new lineage-preserving session', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T10:00:00.000Z',
+          '2026-06-03T10:00:01.000Z',
+          '2026-06-03T10:00:02.000Z',
+          '2026-06-03T10:00:03.000Z',
+          '2026-06-03T10:00:04.000Z',
+          '2026-06-03T10:00:05.000Z',
+        ]),
+      });
+      await store.createSession({
+        sessionId: 'parent',
+        title: 'Parent work',
+        cwd: '/repo/old',
+        modelId: 'gpt-4.1',
+        provider: 'openai',
+      });
+      await store.appendEvent('parent', {
+        type: 'message',
+        payload: { role: 'user', content: 'original request' },
+      });
+      await store.appendEvent('parent', {
+        type: 'tool_result',
+        payload: { result: 'original tool output' },
+      });
+
+      const prepared = await prepareZeroExecSession({
+        store,
+        fork: 'parent',
+        sessionId: 'forked',
+        cwd: '/repo/new',
+        modelId: 'claude-sonnet-4.5',
+        provider: 'anthropic',
+      });
+
+      expect(prepared.mode).toBe('fork');
+      expect(prepared.session).toMatchObject({
+        sessionId: 'forked',
+        parentSessionId: 'parent',
+        title: 'Parent work (fork)',
+        cwd: '/repo/new',
+        modelId: 'claude-sonnet-4.5',
+        provider: 'anthropic',
+        eventCount: 3,
+        lastEventType: 'session_fork',
+      });
+      expect(prepared.contextEvents.map((event) => event.id)).toEqual([
+        'parent:1',
+        'parent:2',
+      ]);
+
+      const forkedEvents = await store.readEvents('forked');
+      expect(forkedEvents.map((event) => [event.id, event.type])).toEqual([
+        ['forked:1', 'message'],
+        ['forked:2', 'tool_result'],
+        ['forked:3', 'session_fork'],
+      ]);
+      expect(forkedEvents[2]?.payload).toMatchObject({
+        parentSessionId: 'parent',
+        copiedEventCount: 2,
+      });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ambiguous or missing resume and fork targets', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({ rootDir });
+
+      await expect(
+        prepareZeroExecSession({ store, resume: 'abc', fork: 'def' })
+      ).rejects.toThrow('Use either --resume or --fork, not both');
+      await expect(
+        prepareZeroExecSession({ store, resume: true })
+      ).rejects.toThrow('No Zero sessions available to resume');
+      await expect(
+        prepareZeroExecSession({ store, resume: 'missing' })
+      ).rejects.toThrow('Zero session not found: missing');
+      await expect(
+        prepareZeroExecSession({ store, fork: 'missing' })
+      ).rejects.toThrow('Zero session not found: missing');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function sequenceClock(values: string[]): () => Date {
+  let index = 0;
+  return () => new Date(values[Math.min(index++, values.length - 1)]!);
+}

--- a/tests/zero-session-events.test.ts
+++ b/tests/zero-session-events.test.ts
@@ -139,6 +139,57 @@ describe('ZeroSessionEventStore', () => {
     }
   });
 
+  it('finds the latest session and forks sessions with copied events', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+          '2026-06-03T00:00:02.000Z',
+          '2026-06-03T00:00:03.000Z',
+          '2026-06-03T00:00:04.000Z',
+          '2026-06-03T00:00:05.000Z',
+        ]),
+      });
+
+      await store.createSession({ sessionId: 'base', title: 'Base' });
+      await store.appendEvent('base', {
+        type: 'message',
+        payload: { role: 'user', content: 'base prompt' },
+      });
+      expect((await store.getLatestSession())?.sessionId).toBe('base');
+
+      const forked = await store.forkSession('base', {
+        sessionId: 'forked',
+        title: 'Forked',
+      });
+
+      expect(forked).toMatchObject({
+        sessionId: 'forked',
+        parentSessionId: 'base',
+        title: 'Forked',
+        eventCount: 2,
+        lastEventType: 'session_fork',
+      });
+      expect((await store.getLatestSession())?.sessionId).toBe('forked');
+
+      const forkedEvents = await store.readEvents('forked');
+      expect(forkedEvents.map((event) => [event.id, event.type])).toEqual([
+        ['forked:1', 'message'],
+        ['forked:2', 'session_fork'],
+      ]);
+      expect(forkedEvents[0]?.payload).toEqual({ role: 'user', content: 'base prompt' });
+      expect(forkedEvents[1]?.payload).toMatchObject({
+        parentSessionId: 'base',
+        copiedEventCount: 1,
+      });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it('searches persisted event payload text with bounded context', async () => {
     const rootDir = tempRoot();
     try {


### PR DESCRIPTION
## Summary
- add a Zero exec session resolver for new, resumed, and forked runs
- extend the session event store with latest-session lookup, fork lineage metadata, and append-only event copying
- wire `zero exec --resume [id]` and `zero exec --fork <id>` into headless runs with persisted user, assistant, tool, usage, and crash events
- include `sessionId` in stream-json `run_start` events and update the protocol example

## Why
This gives headless Zero runs a durable session lifecycle so later CLI and TUI flows can continue prior context or branch from an existing run without losing lineage.

## Validation
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run typecheck`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero exec --help`
- `OPENAI_API_KEY= ./zero exec hi --resume abc --fork def --output-format stream-json`
- `git diff --check origin/main..HEAD`

## Reviewers
Please review: @vasanthdev2004 @anandh8x