### PR TITLE
Add automated PR review workflow

### DIFF
--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -58,16 +58,125 @@ jobs:
         continue-on-error: true
         run: bun run smoke:build
 
+      - name: Collect changed files
+        id: changed-files
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo 'files<<EOF'
+            git diff --name-only "origin/${{ github.base_ref }}...HEAD" | sort
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Post review summary
         if: always()
+        uses: actions/github-script@v7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZERO_REVIEW_DIFF_CHECK: ${{ steps.diffcheck.outcome }}
           ZERO_REVIEW_TYPECHECK: ${{ steps.typecheck.outcome }}
           ZERO_REVIEW_TEST: ${{ steps.test.outcome }}
           ZERO_REVIEW_BUILD: ${{ steps.build.outcome }}
           ZERO_REVIEW_SMOKE: ${{ steps.smoke.outcome }}
-        run: bun run review:pr
+          ZERO_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = '<!-- zero-auto-review -->';
+            const checks = [
+              { label: 'Diff hygiene', command: 'git diff --check', outcome: process.env.ZERO_REVIEW_DIFF_CHECK },
+              { label: 'Typecheck', command: 'bun run typecheck', outcome: process.env.ZERO_REVIEW_TYPECHECK },
+              { label: 'Tests', command: 'bun run test', outcome: process.env.ZERO_REVIEW_TEST },
+              { label: 'Build', command: 'bun run build', outcome: process.env.ZERO_REVIEW_BUILD },
+              { label: 'Smoke build', command: 'bun run smoke:build', outcome: process.env.ZERO_REVIEW_SMOKE },
+            ].map((check) => ({
+              ...check,
+              outcome: normalizeOutcome(check.outcome),
+            }));
+            const blocking = new Set(['failure', 'cancelled', 'timed_out', 'action_required', 'unknown']);
+            const blockers = checks.filter((check) => blocking.has(check.outcome));
+            const files = (process.env.ZERO_CHANGED_FILES || '')
+              .split(/\r?\n/)
+              .map((file) => file.trim())
+              .filter(Boolean)
+              .sort();
+            const visibleFiles = files.slice(0, 12);
+            const fileSuffix = files.length > visibleFiles.length
+              ? `, and ${files.length - visibleFiles.length} more`
+              : '';
+            const fileLine = files.length > 0
+              ? `Changed files (${files.length}): ${visibleFiles.map((file) => `\`${file}\``).join(', ')}${fileSuffix}`
+              : 'Changed files: unavailable in this run.';
+            const body = [
+              marker,
+              '## Zero automated PR review',
+              '',
+              `Verdict: **${blockers.length > 0 ? 'Changes requested' : 'No blockers found'}**`,
+              '',
+              '### Blockers',
+              '',
+              blockers.length > 0
+                ? blockers.map((check) => `- \`${check.command}\` ended with \`${check.outcome}\`.`).join('\n')
+                : '- None found.',
+              '',
+              '### Validation',
+              '',
+              ...checks.map((check) => `- ${formatOutcome(check.outcome)} ${check.label}: \`${check.command}\``),
+              '',
+              '### Scope',
+              '',
+              `Head: \`${context.payload.pull_request.head.sha.slice(0, 12)}\``,
+              fileLine,
+              '',
+              'This deterministic review checks validation status and basic diff hygiene. A human reviewer still owns product judgment and design quality.',
+            ].join('\n');
+
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body?.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to post automated review comment: ${error.message}`);
+              await core.summary.addRaw(body, true).write();
+            }
+
+            function normalizeOutcome(value) {
+              const normalized = String(value || '').trim().toLowerCase().replace(/-/g, '_');
+              return [
+                'success',
+                'failure',
+                'cancelled',
+                'skipped',
+                'timed_out',
+                'action_required',
+                'neutral',
+              ].includes(normalized) ? normalized : 'unknown';
+            }
+
+            function formatOutcome(outcome) {
+              if (outcome === 'success') return '[pass]';
+              if (outcome === 'skipped' || outcome === 'neutral') return '[info]';
+              return '[fail]';
+            }
 
       - name: Fail on review blockers
         if: ${{ steps.diffcheck.outcome != 'success' || steps.typecheck.outcome != 'success' || steps.test.outcome != 'success' || steps.build.outcome != 'success' || steps.smoke.outcome != 'success' }}

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -1,0 +1,74 @@
+name: PR Auto Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    name: Zero Review
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Diff hygiene
+        id: diffcheck
+        continue-on-error: true
+        run: git diff --check origin/${{ github.base_ref }}...HEAD
+
+      - name: Typecheck
+        id: typecheck
+        continue-on-error: true
+        run: bun run typecheck
+
+      - name: Test
+        id: test
+        continue-on-error: true
+        run: bun run test
+
+      - name: Build
+        id: build
+        continue-on-error: true
+        run: bun run build
+
+      - name: Smoke build
+        id: smoke
+        continue-on-error: true
+        run: bun run smoke:build
+
+      - name: Post review summary
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZERO_REVIEW_DIFF_CHECK: ${{ steps.diffcheck.outcome }}
+          ZERO_REVIEW_TYPECHECK: ${{ steps.typecheck.outcome }}
+          ZERO_REVIEW_TEST: ${{ steps.test.outcome }}
+          ZERO_REVIEW_BUILD: ${{ steps.build.outcome }}
+          ZERO_REVIEW_SMOKE: ${{ steps.smoke.outcome }}
+        run: bun run review:pr
+
+      - name: Fail on review blockers
+        if: ${{ steps.diffcheck.outcome != 'success' || steps.typecheck.outcome != 'success' || steps.test.outcome != 'success' || steps.build.outcome != 'success' || steps.smoke.outcome != 'success' }}
+        run: exit 1

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "bunx tsc --noEmit",
     "build": "bun run scripts/build.ts",
     "smoke:build": "bun run scripts/smoke-build.ts",
+    "review:pr": "bun run scripts/pr-review.ts",
     "package:release": "bun run scripts/package-release.ts",
     "verify:release": "bun run scripts/release-checksums.ts",
     "perf:bench": "bun run scripts/perf-bench.ts",

--- a/scripts/pr-review.ts
+++ b/scripts/pr-review.ts
@@ -116,101 +116,12 @@ export function formatOutcome(outcome: ReviewOutcome): string {
   return '[fail]';
 }
 
-export async function resolvePullRequestContext(
-  env: Record<string, string | undefined>
-): Promise<PullRequestContext> {
-  const eventPath = env.GITHUB_EVENT_PATH;
-  const repository = env.GITHUB_REPOSITORY;
-  if (!eventPath) {
-    throw new Error('GITHUB_EVENT_PATH is required.');
-  }
-  if (!repository || !repository.includes('/')) {
-    throw new Error('GITHUB_REPOSITORY must be in owner/repo form.');
-  }
-
-  const [owner, repo] = repository.split('/') as [string, string];
-  const event = await Bun.file(eventPath).json() as {
-    pull_request?: {
-      number?: number;
-      title?: string;
-      head?: { sha?: string };
-      base?: { ref?: string };
-    };
-  };
-  const pullRequest = event.pull_request;
-  if (!pullRequest?.number) {
-    throw new Error('This review script must run from a pull_request event.');
-  }
-
-  return {
-    owner,
-    repo,
-    number: pullRequest.number,
-    title: pullRequest.title,
-    headSha: pullRequest.head?.sha ?? env.GITHUB_SHA,
-    baseRef: pullRequest.base?.ref,
-  };
-}
-
-export async function collectChangedFiles(baseRef: string | undefined): Promise<string[]> {
-  if (!baseRef) return [];
-
-  const fetchResult = await runGit(['fetch', '--no-tags', '--depth=1', 'origin', baseRef]);
-  if (fetchResult.exitCode !== 0) return [];
-
-  const diffResult = await runGit(['diff', '--name-only', `origin/${baseRef}...HEAD`]);
-  if (diffResult.exitCode !== 0) return [];
-
-  return diffResult.stdout
+export function parseChangedFiles(value: string | undefined): string[] {
+  return (value ?? '')
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
     .sort();
-}
-
-export async function upsertReviewComment(options: {
-  context: PullRequestContext;
-  body: string;
-  token: string;
-}): Promise<void> {
-  const apiBase = `https://api.github.com/repos/${options.context.owner}/${options.context.repo}`;
-  const headers = {
-    Authorization: `Bearer ${options.token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-  };
-  const commentsUrl = `${apiBase}/issues/${options.context.number}/comments?per_page=100`;
-  const commentsResponse = await fetch(commentsUrl, { headers });
-  if (!commentsResponse.ok) {
-    throw new Error(`Failed to list PR comments: ${commentsResponse.status} ${commentsResponse.statusText}`);
-  }
-
-  const comments = await commentsResponse.json() as Array<{ id: number; body?: string; url: string }>;
-  const existing = comments.find((comment) => comment.body?.includes(ZERO_AUTO_REVIEW_MARKER));
-  const response = await fetch(existing?.url ?? commentsUrl, {
-    method: existing ? 'PATCH' : 'POST',
-    headers: {
-      ...headers,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ body: options.body }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to ${existing ? 'update' : 'create'} PR review comment: ${response.status} ${response.statusText}`);
-  }
-}
-
-async function runGit(args: string[]): Promise<{ exitCode: number; stdout: string }> {
-  const child = Bun.spawn(['git', ...args], {
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
-  const [exitCode, stdout] = await Promise.all([
-    child.exited,
-    new Response(child.stdout).text(),
-  ]);
-  return { exitCode, stdout };
 }
 
 function formatChangedFiles(files: string[]): string {
@@ -219,37 +130,31 @@ function formatChangedFiles(files: string[]): string {
   return `${visible.map((file) => `\`${file}\``).join(', ')}${suffix}`;
 }
 
-async function main(): Promise<void> {
-  const context = await resolvePullRequestContext(Bun.env);
+function resolveLocalContext(env: Record<string, string | undefined>): PullRequestContext {
+  const repository = env.GITHUB_REPOSITORY ?? 'Gitlawb/zero';
+  const [owner = 'Gitlawb', repo = 'zero'] = repository.split('/');
+  return {
+    owner,
+    repo,
+    number: Number(env.ZERO_PR_NUMBER ?? env.GITHUB_REF_NAME?.split('/')[0] ?? 0),
+    headSha: env.GITHUB_SHA,
+    baseRef: env.GITHUB_BASE_REF,
+  };
+}
+
+function main(): void {
+  const context = resolveLocalContext(Bun.env);
   const checks = buildChecksFromEnv(Bun.env);
-  const changedFiles = await collectChangedFiles(context.baseRef);
+  const changedFiles = parseChangedFiles(Bun.env.ZERO_CHANGED_FILES);
   const body = buildReviewMarkdown({
     ...context,
     checks,
     changedFiles,
   });
 
-  if (Bun.env.ZERO_PR_REVIEW_DRY_RUN === '1') {
-    console.log(body);
-    return;
-  }
-
-  const token = Bun.env.GITHUB_TOKEN;
-  if (!token) {
-    console.log(body);
-    console.warn('GITHUB_TOKEN is missing; printed review summary instead of posting.');
-    return;
-  }
-
-  try {
-    await upsertReviewComment({ context, body, token });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Unable to post automated review comment: ${message}`);
-    console.log(body);
-  }
+  console.log(body);
 }
 
 if (import.meta.main) {
-  await main();
+  main();
 }

--- a/scripts/pr-review.ts
+++ b/scripts/pr-review.ts
@@ -1,0 +1,255 @@
+export const ZERO_AUTO_REVIEW_MARKER = '<!-- zero-auto-review -->';
+
+export type ReviewOutcome =
+  | 'success'
+  | 'failure'
+  | 'cancelled'
+  | 'skipped'
+  | 'timed_out'
+  | 'action_required'
+  | 'neutral'
+  | 'unknown';
+
+export interface ReviewCheck {
+  label: string;
+  command: string;
+  outcome: ReviewOutcome;
+}
+
+export interface PullRequestContext {
+  owner: string;
+  repo: string;
+  number: number;
+  title?: string;
+  headSha?: string;
+  baseRef?: string;
+}
+
+export interface ReviewSummaryInput extends PullRequestContext {
+  checks: ReviewCheck[];
+  changedFiles?: string[];
+}
+
+const REVIEW_CHECKS: Array<{ env: string; label: string; command: string }> = [
+  { env: 'ZERO_REVIEW_DIFF_CHECK', label: 'Diff hygiene', command: 'git diff --check' },
+  { env: 'ZERO_REVIEW_TYPECHECK', label: 'Typecheck', command: 'bun run typecheck' },
+  { env: 'ZERO_REVIEW_TEST', label: 'Tests', command: 'bun run test' },
+  { env: 'ZERO_REVIEW_BUILD', label: 'Build', command: 'bun run build' },
+  { env: 'ZERO_REVIEW_SMOKE', label: 'Smoke build', command: 'bun run smoke:build' },
+];
+
+const BLOCKING_OUTCOMES = new Set<ReviewOutcome>([
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'unknown',
+]);
+
+export function normalizeOutcome(value: string | undefined): ReviewOutcome {
+  const normalized = (value ?? '').trim().toLowerCase().replace(/-/g, '_');
+  if (
+    normalized === 'success' ||
+    normalized === 'failure' ||
+    normalized === 'cancelled' ||
+    normalized === 'skipped' ||
+    normalized === 'timed_out' ||
+    normalized === 'action_required' ||
+    normalized === 'neutral'
+  ) {
+    return normalized;
+  }
+  return 'unknown';
+}
+
+export function buildChecksFromEnv(env: Record<string, string | undefined>): ReviewCheck[] {
+  return REVIEW_CHECKS.map((check) => ({
+    label: check.label,
+    command: check.command,
+    outcome: normalizeOutcome(env[check.env]),
+  }));
+}
+
+export function hasBlockingChecks(checks: readonly ReviewCheck[]): boolean {
+  return checks.some((check) => BLOCKING_OUTCOMES.has(check.outcome));
+}
+
+export function buildReviewMarkdown(input: ReviewSummaryInput): string {
+  const blockers = input.checks.filter((check) => BLOCKING_OUTCOMES.has(check.outcome));
+  const changedFiles = input.changedFiles ?? [];
+  const headLine = input.headSha ? `Head: \`${input.headSha.slice(0, 12)}\`` : undefined;
+
+  return [
+    ZERO_AUTO_REVIEW_MARKER,
+    '## Zero automated PR review',
+    '',
+    `Verdict: **${blockers.length > 0 ? 'Changes requested' : 'No blockers found'}**`,
+    '',
+    '### Blockers',
+    '',
+    blockers.length > 0
+      ? blockers
+          .map((check) => `- \`${check.command}\` ended with \`${check.outcome}\`.`)
+          .join('\n')
+      : '- None found.',
+    '',
+    '### Validation',
+    '',
+    ...input.checks.map(
+      (check) => `- ${formatOutcome(check.outcome)} ${check.label}: \`${check.command}\``
+    ),
+    '',
+    '### Scope',
+    '',
+    headLine ?? `PR: #${input.number}`,
+    changedFiles.length > 0
+      ? `Changed files (${changedFiles.length}): ${formatChangedFiles(changedFiles)}`
+      : 'Changed files: unavailable in this run.',
+    '',
+    'This deterministic review checks validation status and basic diff hygiene. A human reviewer still owns product judgment and design quality.',
+  ].join('\n');
+}
+
+export function formatOutcome(outcome: ReviewOutcome): string {
+  if (outcome === 'success') return '[pass]';
+  if (outcome === 'skipped' || outcome === 'neutral') return '[info]';
+  return '[fail]';
+}
+
+export async function resolvePullRequestContext(
+  env: Record<string, string | undefined>
+): Promise<PullRequestContext> {
+  const eventPath = env.GITHUB_EVENT_PATH;
+  const repository = env.GITHUB_REPOSITORY;
+  if (!eventPath) {
+    throw new Error('GITHUB_EVENT_PATH is required.');
+  }
+  if (!repository || !repository.includes('/')) {
+    throw new Error('GITHUB_REPOSITORY must be in owner/repo form.');
+  }
+
+  const [owner, repo] = repository.split('/') as [string, string];
+  const event = await Bun.file(eventPath).json() as {
+    pull_request?: {
+      number?: number;
+      title?: string;
+      head?: { sha?: string };
+      base?: { ref?: string };
+    };
+  };
+  const pullRequest = event.pull_request;
+  if (!pullRequest?.number) {
+    throw new Error('This review script must run from a pull_request event.');
+  }
+
+  return {
+    owner,
+    repo,
+    number: pullRequest.number,
+    title: pullRequest.title,
+    headSha: pullRequest.head?.sha ?? env.GITHUB_SHA,
+    baseRef: pullRequest.base?.ref,
+  };
+}
+
+export async function collectChangedFiles(baseRef: string | undefined): Promise<string[]> {
+  if (!baseRef) return [];
+
+  const fetchResult = await runGit(['fetch', '--no-tags', '--depth=1', 'origin', baseRef]);
+  if (fetchResult.exitCode !== 0) return [];
+
+  const diffResult = await runGit(['diff', '--name-only', `origin/${baseRef}...HEAD`]);
+  if (diffResult.exitCode !== 0) return [];
+
+  return diffResult.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort();
+}
+
+export async function upsertReviewComment(options: {
+  context: PullRequestContext;
+  body: string;
+  token: string;
+}): Promise<void> {
+  const apiBase = `https://api.github.com/repos/${options.context.owner}/${options.context.repo}`;
+  const headers = {
+    Authorization: `Bearer ${options.token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  const commentsUrl = `${apiBase}/issues/${options.context.number}/comments?per_page=100`;
+  const commentsResponse = await fetch(commentsUrl, { headers });
+  if (!commentsResponse.ok) {
+    throw new Error(`Failed to list PR comments: ${commentsResponse.status} ${commentsResponse.statusText}`);
+  }
+
+  const comments = await commentsResponse.json() as Array<{ id: number; body?: string; url: string }>;
+  const existing = comments.find((comment) => comment.body?.includes(ZERO_AUTO_REVIEW_MARKER));
+  const response = await fetch(existing?.url ?? commentsUrl, {
+    method: existing ? 'PATCH' : 'POST',
+    headers: {
+      ...headers,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body: options.body }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to ${existing ? 'update' : 'create'} PR review comment: ${response.status} ${response.statusText}`);
+  }
+}
+
+async function runGit(args: string[]): Promise<{ exitCode: number; stdout: string }> {
+  const child = Bun.spawn(['git', ...args], {
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const [exitCode, stdout] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+  ]);
+  return { exitCode, stdout };
+}
+
+function formatChangedFiles(files: string[]): string {
+  const visible = files.slice(0, 12);
+  const suffix = files.length > visible.length ? `, and ${files.length - visible.length} more` : '';
+  return `${visible.map((file) => `\`${file}\``).join(', ')}${suffix}`;
+}
+
+async function main(): Promise<void> {
+  const context = await resolvePullRequestContext(Bun.env);
+  const checks = buildChecksFromEnv(Bun.env);
+  const changedFiles = await collectChangedFiles(context.baseRef);
+  const body = buildReviewMarkdown({
+    ...context,
+    checks,
+    changedFiles,
+  });
+
+  if (Bun.env.ZERO_PR_REVIEW_DRY_RUN === '1') {
+    console.log(body);
+    return;
+  }
+
+  const token = Bun.env.GITHUB_TOKEN;
+  if (!token) {
+    console.log(body);
+    console.warn('GITHUB_TOKEN is missing; printed review summary instead of posting.');
+    return;
+  }
+
+  try {
+    await upsertReviewComment({ context, body, token });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Unable to post automated review comment: ${message}`);
+    console.log(body);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/pr-review.test.ts
+++ b/tests/pr-review.test.ts
@@ -6,6 +6,7 @@ import {
   formatOutcome,
   hasBlockingChecks,
   normalizeOutcome,
+  parseChangedFiles,
 } from '../scripts/pr-review';
 
 describe('PR review automation helpers', () => {
@@ -77,5 +78,12 @@ describe('PR review automation helpers', () => {
     expect(markdown).toContain('`bun run typecheck` ended with `failure`');
     expect(formatOutcome('success')).toBe('[pass]');
     expect(formatOutcome('failure')).toBe('[fail]');
+  });
+
+  it('parses changed file output into a stable sorted list', () => {
+    expect(parseChangedFiles('tests/b.test.ts\n\nsrc/a.ts\r\n')).toEqual([
+      'src/a.ts',
+      'tests/b.test.ts',
+    ]);
   });
 });

--- a/tests/pr-review.test.ts
+++ b/tests/pr-review.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  ZERO_AUTO_REVIEW_MARKER,
+  buildChecksFromEnv,
+  buildReviewMarkdown,
+  formatOutcome,
+  hasBlockingChecks,
+  normalizeOutcome,
+} from '../scripts/pr-review';
+
+describe('PR review automation helpers', () => {
+  it('normalizes GitHub action step outcomes defensively', () => {
+    expect(normalizeOutcome('success')).toBe('success');
+    expect(normalizeOutcome('timed-out')).toBe('timed_out');
+    expect(normalizeOutcome('ACTION_REQUIRED')).toBe('action_required');
+    expect(normalizeOutcome(undefined)).toBe('unknown');
+  });
+
+  it('builds check rows from workflow environment values', () => {
+    const checks = buildChecksFromEnv({
+      ZERO_REVIEW_DIFF_CHECK: 'success',
+      ZERO_REVIEW_TYPECHECK: 'success',
+      ZERO_REVIEW_TEST: 'failure',
+      ZERO_REVIEW_BUILD: 'success',
+      ZERO_REVIEW_SMOKE: 'skipped',
+    });
+
+    expect(checks.map((check) => check.outcome)).toEqual([
+      'success',
+      'success',
+      'failure',
+      'success',
+      'skipped',
+    ]);
+    expect(hasBlockingChecks(checks)).toBe(true);
+  });
+
+  it('formats an approving deterministic review when checks pass', () => {
+    const checks = buildChecksFromEnv({
+      ZERO_REVIEW_DIFF_CHECK: 'success',
+      ZERO_REVIEW_TYPECHECK: 'success',
+      ZERO_REVIEW_TEST: 'success',
+      ZERO_REVIEW_BUILD: 'success',
+      ZERO_REVIEW_SMOKE: 'success',
+    });
+    const markdown = buildReviewMarkdown({
+      owner: 'Gitlawb',
+      repo: 'zero',
+      number: 30,
+      headSha: 'abcdef1234567890',
+      checks,
+      changedFiles: ['src/index.ts', 'tests/pr-review.test.ts'],
+    });
+
+    expect(markdown).toContain(ZERO_AUTO_REVIEW_MARKER);
+    expect(markdown).toContain('Verdict: **No blockers found**');
+    expect(markdown).toContain('- None found.');
+    expect(markdown).toContain('`src/index.ts`');
+  });
+
+  it('formats check failures as blockers', () => {
+    const checks = buildChecksFromEnv({
+      ZERO_REVIEW_DIFF_CHECK: 'success',
+      ZERO_REVIEW_TYPECHECK: 'failure',
+      ZERO_REVIEW_TEST: 'success',
+      ZERO_REVIEW_BUILD: 'success',
+      ZERO_REVIEW_SMOKE: 'success',
+    });
+    const markdown = buildReviewMarkdown({
+      owner: 'Gitlawb',
+      repo: 'zero',
+      number: 31,
+      checks,
+    });
+
+    expect(markdown).toContain('Verdict: **Changes requested**');
+    expect(markdown).toContain('`bun run typecheck` ended with `failure`');
+    expect(formatOutcome('success')).toBe('[pass]');
+    expect(formatOutcome('failure')).toBe('[fail]');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `PR Auto Review` workflow that runs diff hygiene, typecheck, tests, build, and smoke build on PR updates.
- Add a Bun review script that posts or updates one stable automated review comment with blockers and validation status.
- Add focused tests for outcome normalization and review markdown formatting.

## Validation
- `bun run typecheck`
- `bun test ./tests/pr-review.test.ts --timeout 15000`
- `bun test ./tests --timeout 15000`
- `bun run build`
- `bun run smoke:build`
- dry-run `bun run review:pr`