### PR TITLE
feat: add config validation diagnostics

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -45,9 +45,24 @@ const DEFAULT_CONFIG: ZeroConfig = {
   debug: false,
 };
 
+export type ConfigLayerSource = 'defaults' | 'user' | 'project' | 'env' | 'cli';
+export type ConfigLayerStatus = 'loaded' | 'invalid';
+export type ConfigDiagnosticKind = 'io' | 'json' | 'schema' | 'env';
+
+export interface ConfigDiagnostic {
+  source: ConfigLayerSource;
+  kind: ConfigDiagnosticKind;
+  message: string;
+  path?: string;
+  fieldPath?: string;
+}
+
 export interface ConfigLayer {
-  source: 'defaults' | 'user' | 'project' | 'env' | 'cli';
+  source: ConfigLayerSource;
+  status: ConfigLayerStatus;
+  path?: string;
   config: Partial<ZeroConfig>;
+  errors?: ConfigDiagnostic[];
 }
 
 export interface LoadConfigOptions {
@@ -65,29 +80,108 @@ const userConfigPath = (): string => join(homedir(), '.config', 'zero', 'config.
 const projectConfigPath = (): string => join(process.cwd(), '.zero', 'config.json');
 
 /**
- * Read and parse a single config file. Returns `{}` for any I/O or
- * parse error so a single bad file never blocks startup.
+ * Read and parse a single config file. Invalid files are returned as
+ * diagnostics so a single bad file never blocks startup.
  */
-function readConfigFile(path: string): ZeroConfig {
-  if (!existsSync(path)) return {};
+export function readConfigLayer(
+  source: Extract<ConfigLayerSource, 'user' | 'project'>,
+  path: string
+): ConfigLayer | undefined {
+  if (!existsSync(path)) return undefined;
+
+  let text: string;
   try {
-    const text = readFileSync(path, 'utf-8');
-    const parsed = JSON.parse(text);
-    return ZeroConfigSchema.partial().parse(parsed);
-  } catch {
-    return {};
+    text = readFileSync(path, 'utf-8');
+  } catch (err: unknown) {
+    return invalidConfigLayer(source, path, [{
+      source,
+      kind: 'io',
+      path,
+      message: errorMessage(err),
+    }]);
   }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err: unknown) {
+    return invalidConfigLayer(source, path, [{
+      source,
+      kind: 'json',
+      path,
+      message: errorMessage(err),
+    }]);
+  }
+
+  const result = ZeroConfigSchema.partial().safeParse(parsed);
+  if (!result.success) {
+    return invalidConfigLayer(
+      source,
+      path,
+      result.error.issues.map((issue) => ({
+        source,
+        kind: 'schema',
+        path,
+        fieldPath: formatConfigFieldPath(issue.path),
+        message: issue.message,
+      }))
+    );
+  }
+
+  return {
+    source,
+    status: 'loaded',
+    path,
+    config: result.data,
+  };
 }
 
-function envLayer(env: NodeJS.ProcessEnv = process.env): ZeroConfig {
+function invalidConfigLayer(
+  source: Extract<ConfigLayerSource, 'user' | 'project'>,
+  path: string,
+  errors: ConfigDiagnostic[]
+): ConfigLayer {
+  return {
+    source,
+    status: 'invalid',
+    path,
+    config: {},
+    errors,
+  };
+}
+
+function formatConfigFieldPath(path: PropertyKey[]): string | undefined {
+  if (path.length === 0) return undefined;
+  return path.map((part) => String(part)).join('.');
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function envLayer(env: NodeJS.ProcessEnv = process.env): {
+  config: ZeroConfig;
+  diagnostics: ConfigDiagnostic[];
+} {
   const layer: ZeroConfig = {};
+  const diagnostics: ConfigDiagnostic[] = [];
+
   if (env.ZERO_MAX_TURNS) {
     const n = parseInt(env.ZERO_MAX_TURNS, 10);
-    if (!Number.isNaN(n)) layer.maxTurns = n;
+    if (!Number.isNaN(n)) {
+      layer.maxTurns = n;
+    } else {
+      diagnostics.push({
+        source: 'env',
+        kind: 'env',
+        fieldPath: 'ZERO_MAX_TURNS',
+        message: `ZERO_MAX_TURNS must be an integer, received "${env.ZERO_MAX_TURNS}".`,
+      });
+    }
   }
   if (env.ZERO_PLAN_MODE === '1' || env.ZERO_PLAN_MODE === 'true') layer.planMode = true;
   if (env.ZERO_DEBUG === '1' || env.ZERO_DEBUG === 'true') layer.debug = true;
-  return layer;
+  return { config: layer, diagnostics };
 }
 
 /**
@@ -124,27 +218,40 @@ export function mergeLayers(...layers: ZeroConfig[]): ZeroConfig {
 export function loadConfigWithLayers(options: LoadConfigOptions = {}): {
   effective: ZeroConfig;
   layers: ConfigLayer[];
+  diagnostics: ConfigDiagnostic[];
 } {
   const userPath = options.userConfigPath ?? userConfigPath();
   const projectPath = options.projectConfigPath ?? projectConfigPath();
 
   const defaults: ZeroConfig = { ...DEFAULT_CONFIG };
 
-  const user: ZeroConfig = readConfigFile(userPath);
-  const project: ZeroConfig = readConfigFile(projectPath);
-  const env: ZeroConfig = envLayer(options.env);
+  const user = readConfigLayer('user', userPath);
+  const project = readConfigLayer('project', projectPath);
+  const { config: env, diagnostics: envDiagnostics } = envLayer(options.env);
   const cli: ZeroConfig = options.cliOverrides ?? {};
 
   const layers: ConfigLayer[] = [
-    { source: 'defaults', config: defaults },
-    ...(Object.keys(user).length ? [{ source: 'user' as const, config: user }] : []),
-    ...(Object.keys(project).length ? [{ source: 'project' as const, config: project }] : []),
-    ...(Object.keys(env).length ? [{ source: 'env' as const, config: env }] : []),
-    ...(Object.keys(cli).length ? [{ source: 'cli' as const, config: cli }] : []),
+    { source: 'defaults', status: 'loaded', config: defaults },
+    ...(user ? [user] : []),
+    ...(project ? [project] : []),
+    ...(Object.keys(env).length || envDiagnostics.length
+      ? [{
+          source: 'env' as const,
+          status: Object.keys(env).length ? 'loaded' as const : 'invalid' as const,
+          config: env,
+          ...(envDiagnostics.length ? { errors: envDiagnostics } : {}),
+        }]
+      : []),
+    ...(Object.keys(cli).length ? [{ source: 'cli' as const, status: 'loaded' as const, config: cli }] : []),
   ];
 
-  const effective = mergeLayers(defaults, user, project, env, cli);
-  return { effective, layers };
+  const diagnostics = layers.flatMap((layer) => layer.errors ?? []);
+  const effective = mergeLayers(
+    ...(layers
+      .filter((layer) => layer.status === 'loaded')
+      .map((layer) => layer.config) as ZeroConfig[])
+  );
+  return { effective, layers, diagnostics };
 }
 
 /**

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -1,11 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { ZERO_DEFAULT_MODEL_ID } from '../zero-model-registry';
 import {
   type ProviderProfile,
   type ZeroConfig,
-  ZeroConfigSchema,
+  readConfigLayer,
 } from './loader';
 import {
   parseProviderProfileKind,
@@ -36,16 +36,12 @@ function readConfig(): ConfigState {
     return { providers: [] };
   }
 
-  try {
-    const content = readFileSync(CONFIG_PATH, 'utf-8');
-    const parsed = JSON.parse(content);
-    return normalizeConfig(ZeroConfigSchema.partial().parse(parsed));
-  } catch (err: any) {
-    console.warn(
-      `[zero] Ignoring invalid config at ${CONFIG_PATH}: ${err?.message ?? String(err)}`
-    );
-    return { providers: [] };
+  const layer = readConfigLayer('user', CONFIG_PATH);
+  if (layer?.status === 'loaded') {
+    return normalizeConfig(layer.config);
   }
+
+  return { providers: [] };
 }
 
 function writeConfig(config: ConfigState) {

--- a/src/zero-config-inspection/inspection.ts
+++ b/src/zero-config-inspection/inspection.ts
@@ -1,9 +1,8 @@
-import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import {
   mergeLayers,
-  ZeroConfigSchema,
+  readConfigLayer as readZeroConfigLayer,
   type ZeroConfig,
 } from '../config/loader';
 import {
@@ -21,7 +20,7 @@ import type {
   ZeroConfigInspectionReport,
   ZeroConfigIssue,
   ZeroConfigLayerInspection,
-  ZeroConfigLayerSource,
+  ZeroConfigValidationError,
   ZeroConfigProviderInspection,
 } from './types';
 
@@ -50,13 +49,13 @@ export function inspectZeroConfig(
   ];
   const issues: ZeroConfigIssue[] = [];
 
-  const userLayer = readConfigLayer('user', userConfigPath);
+  const userLayer = toInspectionLayer(readZeroConfigLayer('user', userConfigPath));
   if (userLayer) {
     layers.push(userLayer);
     collectLayerIssues(userLayer, issues);
   }
 
-  const projectLayer = readConfigLayer('project', projectConfigPath);
+  const projectLayer = toInspectionLayer(readZeroConfigLayer('project', projectConfigPath));
   if (projectLayer) {
     layers.push(projectLayer);
     collectLayerIssues(projectLayer, issues);
@@ -124,7 +123,7 @@ export function formatZeroConfigInspection(report: ZeroConfigInspectionReport): 
     const layerSummary = formatLayerConfig(layer.config);
     if (layerSummary) lines.push(`    ${layerSummary}`);
     for (const error of layer.errors ?? []) {
-      lines.push(`    error: ${redactZeroString(error)}`);
+      lines.push(`    error: ${formatLayerError(error)}`);
     }
   }
 
@@ -139,8 +138,9 @@ export function formatZeroConfigInspection(report: ZeroConfigInspectionReport): 
   if (report.issues.length > 0) {
     lines.push('Issues:');
     for (const issue of report.issues) {
+      const location = formatIssueLocation(issue);
       lines.push(
-        `  [${issue.severity}] ${redactZeroString(issue.id)} - ${redactZeroString(issue.message)}`
+        `  [${issue.severity}] ${redactZeroString(issue.id)}${location} - ${redactZeroString(issue.message)}`
       );
     }
   }
@@ -148,43 +148,25 @@ export function formatZeroConfigInspection(report: ZeroConfigInspectionReport): 
   return lines.join('\n');
 }
 
-function readConfigLayer(
-  source: Extract<ZeroConfigLayerSource, 'user' | 'project'>,
-  path: string
+function toInspectionLayer(
+  layer: ReturnType<typeof readZeroConfigLayer>
 ): ZeroConfigLayerInspection | undefined {
-  if (!existsSync(path)) return undefined;
+  if (!layer) return undefined;
+  return {
+    ...layer,
+    present: true,
+  };
+}
 
-  try {
-    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
-    const result = ZeroConfigSchema.partial().safeParse(parsed);
-    if (!result.success) {
-      return {
-        source,
-        status: 'invalid',
-        present: true,
-        path,
-        config: {},
-        errors: result.error.issues.map((issue) => issue.message),
-      };
-    }
+function formatLayerError(error: ZeroConfigValidationError): string {
+  const field = error.fieldPath ? `${redactZeroString(error.fieldPath)}: ` : '';
+  return `${field}${redactZeroString(error.message)}`;
+}
 
-    return {
-      source,
-      status: 'loaded',
-      present: true,
-      path,
-      config: result.data,
-    };
-  } catch (err: unknown) {
-    return {
-      source,
-      status: 'invalid',
-      present: true,
-      path,
-      config: {},
-      errors: [redactZeroErrorMessage(err)],
-    };
-  }
+function formatIssueLocation(issue: ZeroConfigIssue): string {
+  const parts = [issue.path, issue.fieldPath].filter((part): part is string => Boolean(part));
+  if (parts.length === 0) return '';
+  return ` (${redactZeroString(parts.join(' '))})`;
 }
 
 function collectLayerIssues(
@@ -193,13 +175,29 @@ function collectLayerIssues(
 ): void {
   if (layer.status !== 'invalid') return;
 
-  issues.push({
-    id: `config.${layer.source}.invalid`,
-    severity: 'error',
-    source: layer.source,
-    path: layer.path,
-    message: `${layer.source} config is invalid: ${(layer.errors ?? []).join('; ')}`,
-  });
+  const errors = layer.errors ?? [];
+  if (errors.length === 0) {
+    issues.push({
+      id: `config.${layer.source}.invalid`,
+      severity: 'error',
+      source: layer.source,
+      path: layer.path,
+      message: `${layer.source} config is invalid.`,
+    });
+    return;
+  }
+
+  for (const error of errors) {
+    const field = error.fieldPath ? `${error.fieldPath}: ` : '';
+    issues.push({
+      id: `config.${layer.source}.invalid`,
+      severity: 'error',
+      source: layer.source,
+      path: error.path ?? layer.path,
+      fieldPath: error.fieldPath,
+      message: `${layer.source} config is invalid: ${field}${error.message}`,
+    });
+  }
 }
 
 function inspectEnvConfig(
@@ -217,6 +215,7 @@ function inspectEnvConfig(
         id: 'config.env.ZERO_MAX_TURNS.invalid',
         severity: 'error',
         source: 'env',
+        fieldPath: 'ZERO_MAX_TURNS',
         message: `ZERO_MAX_TURNS must be an integer, received "${env.ZERO_MAX_TURNS}".`,
       });
     }
@@ -237,6 +236,7 @@ function inspectEnvConfig(
         id: 'config.env.ZERO_PROVIDER.invalid',
         severity: 'error',
         source: 'env',
+        fieldPath: 'ZERO_PROVIDER',
         message: redactZeroErrorMessage(err),
       });
     }

--- a/src/zero-config-inspection/types.ts
+++ b/src/zero-config-inspection/types.ts
@@ -1,8 +1,15 @@
-import type { ProviderProfile, ZeroConfig } from '../config/loader';
+import type {
+  ConfigDiagnostic,
+  ConfigLayerSource,
+  ConfigLayerStatus,
+  ProviderProfile,
+  ZeroConfig,
+} from '../config/loader';
 import type { ProviderProfileKind } from '../config/types';
 
-export type ZeroConfigLayerSource = 'defaults' | 'user' | 'project' | 'env' | 'cli';
-export type ZeroConfigLayerStatus = 'loaded' | 'invalid';
+export type ZeroConfigLayerSource = ConfigLayerSource;
+export type ZeroConfigLayerStatus = ConfigLayerStatus;
+export type ZeroConfigValidationError = ConfigDiagnostic;
 export type ZeroConfigIssueSeverity = 'warning' | 'error';
 export type ZeroConfigProviderSource = 'profile' | 'environment' | 'provider-command' | 'none';
 
@@ -20,7 +27,7 @@ export interface ZeroConfigLayerInspection {
   present: boolean;
   path?: string;
   config: Partial<ZeroConfig>;
-  errors?: string[];
+  errors?: ZeroConfigValidationError[];
 }
 
 export interface ZeroConfigIssue {
@@ -29,6 +36,7 @@ export interface ZeroConfigIssue {
   source: ZeroConfigLayerSource | 'provider';
   message: string;
   path?: string;
+  fieldPath?: string;
 }
 
 export interface ZeroConfigProviderInspection {

--- a/tests/config-loader.test.ts
+++ b/tests/config-loader.test.ts
@@ -104,6 +104,30 @@ describe('loadConfigWithLayers', () => {
     }
   });
 
+  it('keeps valid env overrides while reporting invalid env diagnostics', () => {
+    const tmp = freshTmp();
+    try {
+      const { effective, diagnostics } = loadConfigWithLayers({
+        userConfigPath: join(tmp, 'no-user.json'),
+        projectConfigPath: join(tmp, 'no-project.json'),
+        env: {
+          ZERO_MAX_TURNS: 'many',
+          ZERO_DEBUG: 'true',
+        },
+      });
+
+      expect(effective.debug).toBe(true);
+      expect(effective.maxTurns).toBe(12);
+      expect(diagnostics).toContainEqual(expect.objectContaining({
+        source: 'env',
+        fieldPath: 'ZERO_MAX_TURNS',
+        kind: 'env',
+      }));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('lets CLI overrides win over everything else', () => {
     const tmp = freshTmp();
     try {
@@ -137,6 +161,41 @@ describe('loadConfigWithLayers', () => {
       });
 
       expect(effective.maxTurns).toBe(12);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('reports invalid config diagnostics with source paths and field paths', () => {
+    const tmp = freshTmp();
+    try {
+      const user = join(tmp, 'user.json');
+      writeFileSync(
+        user,
+        JSON.stringify({
+          providers: [{ name: 'broken', baseURL: 'not a url', model: 'm' }],
+        }),
+        'utf-8',
+      );
+
+      const { effective, layers, diagnostics } = loadConfigWithLayers({
+        userConfigPath: user,
+        projectConfigPath: join(tmp, 'no-project.json'),
+        env: {},
+      });
+
+      expect(effective.maxTurns).toBe(12);
+      expect(layers.find((layer) => layer.source === 'user')).toMatchObject({
+        source: 'user',
+        status: 'invalid',
+        path: user,
+      });
+      expect(diagnostics).toContainEqual(expect.objectContaining({
+        source: 'user',
+        path: user,
+        fieldPath: 'providers.0.baseURL',
+        kind: 'schema',
+      }));
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/tests/zero-config-cli.test.ts
+++ b/tests/zero-config-cli.test.ts
@@ -29,6 +29,7 @@ describe('zero config CLI', () => {
     try {
       const result = await runZeroConfig(['--json'], {
         HOME: home,
+        USERPROFILE: home,
         OPENAI_API_KEY: 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
         OPENAI_MODEL: 'gpt-4.1',
       });
@@ -68,7 +69,10 @@ describe('zero config CLI', () => {
         'utf-8'
       );
 
-      const result = await runZeroConfig(['--json'], { HOME: home });
+      const result = await runZeroConfig(['--json'], {
+        HOME: home,
+        USERPROFILE: home,
+      });
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr.trim()).toBe('');

--- a/tests/zero-config-cli.test.ts
+++ b/tests/zero-config-cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
@@ -50,6 +50,39 @@ describe('zero config CLI', () => {
         'defaults',
         'env',
       ]);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('prints config validation diagnostics with source and field paths', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'zero-config-cli-'));
+    try {
+      const configPath = join(home, '.config', 'zero', 'config.json');
+      mkdirSync(join(home, '.config', 'zero'), { recursive: true });
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          providers: [{ name: 'broken', baseURL: 'not a url', model: 'm' }],
+        }),
+        'utf-8'
+      );
+
+      const result = await runZeroConfig(['--json'], { HOME: home });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.trim()).toBe('');
+
+      const payload = JSON.parse(result.stdout);
+      expect(payload.ok).toBe(false);
+      expect(payload.layers.find((layer: { source: string }) => layer.source === 'user')).toMatchObject({
+        status: 'invalid',
+        path: configPath,
+      });
+      expect(payload.issues.find((issue: { id: string }) => issue.id === 'config.user.invalid')).toMatchObject({
+        path: configPath,
+        fieldPath: 'providers.0.baseURL',
+      });
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/tests/zero-config-inspection.test.ts
+++ b/tests/zero-config-inspection.test.ts
@@ -103,9 +103,19 @@ describe('Zero config inspection backend', () => {
       expect(report.layers.find((layer) => layer.source === 'user')).toMatchObject({
         present: true,
         status: 'invalid',
+        path: userConfigPath,
+      });
+      expect(report.layers.find((layer) => layer.source === 'user')?.errors?.[0]).toMatchObject({
+        fieldPath: 'providers.0.baseURL',
+        path: userConfigPath,
+      });
+      expect(report.issues.find((issue) => issue.id === 'config.user.invalid')).toMatchObject({
+        path: userConfigPath,
+        fieldPath: 'providers.0.baseURL',
       });
       expect(report.issues.some((issue) => issue.id === 'config.user.invalid')).toBe(true);
       expect(output).toContain('[invalid] user');
+      expect(output).toContain('providers.0.baseURL');
       expect(output).toContain('config.user.invalid');
       expect(output).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
     } finally {


### PR DESCRIPTION
## Summary
- Adds structured config validation diagnostics for user, project, and environment layers, including source, file path, field path, and diagnostic kind.
- Keeps invalid config files non-fatal while preserving valid loaded layers in the effective config.
- Updates `zero config` inspection output and JSON output so automation can identify exact invalid config fields without noisy import-time warnings.

## Validation
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `HOME=$(mktemp -d) ./zero config --json`
- Built CLI invalid-config JSON diagnostic probe
- `git diff --check origin/main..HEAD`

Reviewers: @vasanthdev2004 @anandh8x
