### PR TITLE
feat: add session search indexing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,7 @@ program
   .option('--context <chars>', 'Context characters around each match', '80')
   .option('--session <id>', 'Search one session id')
   .option('--type <eventType>', 'Search one event type')
+  .option('--reindex', 'Drop and rebuild session search indexes before searching')
   .action(async (queryParts: string[] | undefined, options) => {
     try {
       const query = (queryParts ?? []).join(' ');
@@ -167,6 +168,7 @@ program
         contextChars: parseNonNegativeIntegerOption('--context', options.context),
         sessionId: options.session,
         type: options.type,
+        reindex: Boolean(options.reindex),
       });
 
       if (options.json) {

--- a/src/zero-search/index.ts
+++ b/src/zero-search/index.ts
@@ -3,6 +3,17 @@ export {
   normalizeZeroSearchQuery,
   searchZeroSessions,
 } from './search';
+export {
+  ZERO_SEARCH_INDEX_FILE,
+  ZERO_SEARCH_INDEX_SCHEMA_VERSION,
+  ZeroSessionSearchIndex,
+  extractZeroSearchText,
+} from './session-index';
+export type {
+  LoadZeroSearchIndexOptions,
+  ZeroSearchIndexEntry,
+  ZeroSearchIndexFile,
+} from './session-index';
 export type {
   ZeroSearchEventSummary,
   ZeroSearchHit,

--- a/src/zero-search/search.ts
+++ b/src/zero-search/search.ts
@@ -1,7 +1,7 @@
 import { ZeroSessionEventStore } from '../zero-sessions';
-import { redactZeroSecrets, redactZeroString } from '../zero-redaction';
+import { redactZeroString } from '../zero-redaction';
+import { ZeroSessionSearchIndex } from './session-index';
 import type {
-  ZeroSearchCandidate,
   ZeroSearchHit,
   ZeroSearchOptions,
   ZeroSearchResult,
@@ -16,6 +16,7 @@ export async function searchZeroSessions(
 ): Promise<ZeroSearchResult> {
   const normalizedQuery = normalizeZeroSearchQuery(query);
   const store = options.store ?? new ZeroSessionEventStore({ rootDir: options.rootDir });
+  const searchIndex = options.searchIndex ?? new ZeroSessionSearchIndex(store);
   const limit = normalizeLimit(options.limit);
   const contextChars = normalizeContextChars(options.contextChars);
 
@@ -28,28 +29,24 @@ export async function searchZeroSessions(
   const terms = splitSearchTerms(normalizedQuery);
 
   for (const session of sessions) {
-    const events = await store.readEvents(session.sessionId);
-    for (const event of events) {
-      if (options.type && event.type !== options.type) continue;
+    const indexedSession = await searchIndex.loadSession(session, {
+      reindex: options.reindex,
+    });
+    for (const entry of indexedSession.entries) {
+      if (options.type && entry.type !== options.type) continue;
 
-      const redactedPayload = redactZeroSecrets(event.payload);
-      const candidate: ZeroSearchCandidate = {
-        session,
-        event,
-        text: extractSearchText(redactedPayload),
-      };
-      const match = findSearchMatch(candidate.text, normalizedQuery, terms);
+      const match = findSearchMatch(entry.text, normalizedQuery, terms);
       if (!match) continue;
 
       hits.push({
         session,
         event: {
-          id: event.id,
-          sequence: event.sequence,
-          type: event.type,
-          createdAt: event.createdAt,
+          id: entry.eventId,
+          sequence: entry.sequence,
+          type: entry.type,
+          createdAt: entry.createdAt,
         },
-        context: buildContext(candidate.text, match.start, match.end, contextChars),
+        context: buildContext(entry.text, match.start, match.end, contextChars),
         match,
       });
 
@@ -190,18 +187,6 @@ function buildContext(text: string, start: number, end: number, contextChars: nu
   return text
     .slice(Math.max(0, start - contextChars), Math.min(text.length, end + contextChars))
     .trim();
-}
-
-function extractSearchText(value: unknown): string {
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-  if (Array.isArray(value)) {
-    return value.map(extractSearchText).filter(Boolean).join(' ');
-  }
-  if (typeof value === 'object' && value !== null) {
-    return Object.values(value).map(extractSearchText).filter(Boolean).join(' ');
-  }
-  return '';
 }
 
 function formatCount(count: number, label: string): string {

--- a/src/zero-search/session-index.ts
+++ b/src/zero-search/session-index.ts
@@ -1,0 +1,156 @@
+import { readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { redactZeroSecrets } from '../zero-redaction';
+import type {
+  ZeroSessionEvent,
+  ZeroSessionEventStore,
+  ZeroSessionEventType,
+  ZeroSessionMetadata,
+} from '../zero-sessions';
+
+export const ZERO_SEARCH_INDEX_FILE = 'search-index.json';
+export const ZERO_SEARCH_INDEX_SCHEMA_VERSION = 1;
+
+export interface ZeroSearchIndexEntry {
+  sessionId: string;
+  eventId: string;
+  sequence: number;
+  type: ZeroSessionEventType;
+  createdAt: string;
+  text: string;
+}
+
+export interface ZeroSearchIndexFile {
+  schemaVersion: typeof ZERO_SEARCH_INDEX_SCHEMA_VERSION;
+  sessionId: string;
+  sessionUpdatedAt: string;
+  sessionEventCount: number;
+  generatedAt: string;
+  entries: ZeroSearchIndexEntry[];
+}
+
+export interface LoadZeroSearchIndexOptions {
+  reindex?: boolean;
+}
+
+export class ZeroSessionSearchIndex {
+  constructor(
+    private readonly store: ZeroSessionEventStore,
+    private readonly now: () => Date = () => new Date()
+  ) {}
+
+  async loadSession(
+    session: ZeroSessionMetadata,
+    options: LoadZeroSearchIndexOptions = {}
+  ): Promise<ZeroSearchIndexFile> {
+    if (!options.reindex) {
+      const cached = await this.readSessionIndex(session);
+      if (cached && isCurrentIndex(cached, session)) return cached;
+    }
+
+    return this.rebuildSession(session);
+  }
+
+  async rebuildSession(session: ZeroSessionMetadata): Promise<ZeroSearchIndexFile> {
+    const events = await this.store.readEvents(session.sessionId);
+    const indexFile: ZeroSearchIndexFile = {
+      schemaVersion: ZERO_SEARCH_INDEX_SCHEMA_VERSION,
+      sessionId: session.sessionId,
+      sessionUpdatedAt: session.updatedAt,
+      sessionEventCount: session.eventCount,
+      generatedAt: this.now().toISOString(),
+      entries: events.map((event) => toSearchIndexEntry(session.sessionId, event)),
+    };
+
+    await writeFile(
+      this.indexPath(session.sessionId),
+      `${JSON.stringify(indexFile, null, 2)}\n`,
+      'utf-8'
+    );
+
+    return indexFile;
+  }
+
+  private async readSessionIndex(
+    session: ZeroSessionMetadata
+  ): Promise<ZeroSearchIndexFile | undefined> {
+    try {
+      const content = await readFile(this.indexPath(session.sessionId), 'utf-8');
+      const parsed = JSON.parse(content);
+      return isSearchIndexFile(parsed) ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private indexPath(sessionId: string): string {
+    return join(this.store.rootDir, sessionId, ZERO_SEARCH_INDEX_FILE);
+  }
+}
+
+export function extractZeroSearchText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.map(extractZeroSearchText).filter(Boolean).join(' ');
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value).map(extractZeroSearchText).filter(Boolean).join(' ');
+  }
+  return '';
+}
+
+function toSearchIndexEntry(
+  sessionId: string,
+  event: ZeroSessionEvent
+): ZeroSearchIndexEntry {
+  return {
+    sessionId,
+    eventId: event.id,
+    sequence: event.sequence,
+    type: event.type,
+    createdAt: event.createdAt,
+    text: extractZeroSearchText(redactZeroSecrets(event.payload)),
+  };
+}
+
+function isCurrentIndex(
+  indexFile: ZeroSearchIndexFile,
+  session: ZeroSessionMetadata
+): boolean {
+  return (
+    indexFile.schemaVersion === ZERO_SEARCH_INDEX_SCHEMA_VERSION &&
+    indexFile.sessionId === session.sessionId &&
+    indexFile.sessionUpdatedAt === session.updatedAt &&
+    indexFile.sessionEventCount === session.eventCount &&
+    indexFile.entries.length === session.eventCount &&
+    indexFile.entries.every((entry) => entry.sessionId === session.sessionId)
+  );
+}
+
+function isSearchIndexFile(value: unknown): value is ZeroSearchIndexFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<ZeroSearchIndexFile>;
+  return (
+    candidate.schemaVersion === ZERO_SEARCH_INDEX_SCHEMA_VERSION &&
+    typeof candidate.sessionId === 'string' &&
+    typeof candidate.sessionUpdatedAt === 'string' &&
+    typeof candidate.sessionEventCount === 'number' &&
+    typeof candidate.generatedAt === 'string' &&
+    Array.isArray(candidate.entries) &&
+    candidate.entries.every(isSearchIndexEntry)
+  );
+}
+
+function isSearchIndexEntry(value: unknown): value is ZeroSearchIndexEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<ZeroSearchIndexEntry>;
+  return (
+    typeof candidate.sessionId === 'string' &&
+    typeof candidate.eventId === 'string' &&
+    typeof candidate.sequence === 'number' &&
+    typeof candidate.type === 'string' &&
+    typeof candidate.createdAt === 'string' &&
+    typeof candidate.text === 'string'
+  );
+}

--- a/src/zero-search/types.ts
+++ b/src/zero-search/types.ts
@@ -1,17 +1,19 @@
 import type {
-  ZeroSessionEvent,
   ZeroSessionEventStore,
   ZeroSessionEventType,
   ZeroSessionMetadata,
 } from '../zero-sessions';
+import type { ZeroSessionSearchIndex } from './session-index';
 
 export interface ZeroSearchOptions {
   store?: ZeroSessionEventStore;
+  searchIndex?: ZeroSessionSearchIndex;
   rootDir?: string;
   limit?: number;
   contextChars?: number;
   sessionId?: string;
   type?: ZeroSessionEventType;
+  reindex?: boolean;
 }
 
 export interface ZeroSearchEventSummary {
@@ -38,10 +40,4 @@ export interface ZeroSearchResult {
   searchedSessions: number;
   totalHits: number;
   hits: ZeroSearchHit[];
-}
-
-export interface ZeroSearchCandidate {
-  session: ZeroSessionMetadata;
-  event: ZeroSessionEvent;
-  text: string;
 }

--- a/tests/zero-search-cli.test.ts
+++ b/tests/zero-search-cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
@@ -149,6 +149,63 @@ describe('zero search CLI', () => {
       expect(invalidResult.exitCode).toBe(2);
       expect(invalidResult.stdout.trim()).toBe('');
       expect(invalidResult.stderr).toContain('Invalid --limit value');
+    } finally {
+      rmSync(dataHome, { recursive: true, force: true });
+    }
+  });
+
+  it('forces a search index rebuild with --reindex', async () => {
+    const dataHome = mkdtempSync(join(tmpdir(), 'zero-search-cli-'));
+    try {
+      const rootDir = join(dataHome, 'zero', 'sessions');
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+      await store.createSession({ sessionId: 'cli_reindex', title: 'CLI Reindex' });
+      await store.appendEvent('cli_reindex', {
+        type: 'message',
+        payload: { content: 'force rebuild indexed content' },
+      });
+
+      const session = await store.getSession('cli_reindex');
+      writeFileSync(
+        join(rootDir, 'cli_reindex', 'search-index.json'),
+        `${JSON.stringify({
+          schemaVersion: 1,
+          sessionId: 'cli_reindex',
+          sessionUpdatedAt: session?.updatedAt,
+          sessionEventCount: session?.eventCount,
+          generatedAt: '2026-06-03T00:00:02.000Z',
+          entries: [{
+            sessionId: 'cli_reindex',
+            eventId: 'cli_reindex:1',
+            sequence: 1,
+            type: 'message',
+            createdAt: '2026-06-03T00:00:01.000Z',
+            text: 'cached unrelated text',
+          }],
+        })}\n`,
+        'utf-8'
+      );
+
+      const staleResult = await runZeroSearch(['--json', 'force', 'rebuild'], {
+        XDG_DATA_HOME: dataHome,
+      });
+      expect(JSON.parse(staleResult.stdout).totalHits).toBe(0);
+
+      const rebuiltResult = await runZeroSearch(['--json', '--reindex', 'force', 'rebuild'], {
+        XDG_DATA_HOME: dataHome,
+      });
+
+      expect(rebuiltResult.exitCode).toBe(0);
+      expect(rebuiltResult.stderr.trim()).toBe('');
+      const payload = JSON.parse(rebuiltResult.stdout);
+      expect(payload.totalHits).toBe(1);
+      expect(payload.hits[0].event.id).toBe('cli_reindex:1');
     } finally {
       rmSync(dataHome, { recursive: true, force: true });
     }

--- a/tests/zero-search-index.test.ts
+++ b/tests/zero-search-index.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { ZERO_REDACTED_SECRET } from '../src/zero-redaction';
+import { ZeroSessionEventStore } from '../src/zero-sessions';
+import { searchZeroSessions } from '../src/zero-search';
+
+function tempRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'zero-search-index-'));
+}
+
+describe('Zero session search index', () => {
+  it('builds a persistent redacted search index and reuses it for unchanged sessions', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+        ]),
+      });
+
+      await store.createSession({ sessionId: 'indexed_session', title: 'Indexed' });
+      await store.appendEvent('indexed_session', {
+        type: 'tool_result',
+        payload: {
+          result:
+            'alpha indexed result with OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+        },
+      });
+
+      const first = await searchZeroSessions('alpha indexed', { store });
+      expect(first.totalHits).toBe(1);
+
+      const indexPath = join(rootDir, 'indexed_session', 'search-index.json');
+      expect(existsSync(indexPath)).toBe(true);
+      const indexPayload = JSON.parse(readFileSync(indexPath, 'utf-8'));
+      expect(indexPayload).toMatchObject({
+        schemaVersion: 1,
+        sessionId: 'indexed_session',
+        sessionEventCount: 1,
+      });
+      expect(indexPayload.entries[0]).toMatchObject({
+        sessionId: 'indexed_session',
+        eventId: 'indexed_session:1',
+        sequence: 1,
+        type: 'tool_result',
+      });
+      expect(JSON.stringify(indexPayload)).toContain(ZERO_REDACTED_SECRET);
+      expect(JSON.stringify(indexPayload)).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+
+      writeFileSync(join(rootDir, 'indexed_session', 'events.jsonl'), '', 'utf-8');
+
+      const cached = await searchZeroSessions('alpha indexed', { store });
+      expect(cached.totalHits).toBe(1);
+      expect(cached.hits[0]?.event.id).toBe('indexed_session:1');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rebuilds stale indexes and supports forced reindexing', async () => {
+    const rootDir = tempRoot();
+    try {
+      const store = new ZeroSessionEventStore({
+        rootDir,
+        now: sequenceClock([
+          '2026-06-03T00:00:00.000Z',
+          '2026-06-03T00:00:01.000Z',
+          '2026-06-03T00:00:02.000Z',
+        ]),
+      });
+
+      await store.createSession({ sessionId: 'stale_index' });
+      await store.appendEvent('stale_index', {
+        type: 'message',
+        payload: { content: 'old indexed term' },
+      });
+      await searchZeroSessions('old indexed', { store });
+
+      await store.appendEvent('stale_index', {
+        type: 'message',
+        payload: { content: 'fresh indexed term' },
+      });
+
+      const rebuilt = await searchZeroSessions('fresh indexed', { store });
+      expect(rebuilt.totalHits).toBe(1);
+      expect(rebuilt.hits[0]?.event.id).toBe('stale_index:2');
+
+      const session = await store.getSession('stale_index');
+      const indexPath = join(rootDir, 'stale_index', 'search-index.json');
+      writeFileSync(
+        indexPath,
+        `${JSON.stringify({
+          schemaVersion: 1,
+          sessionId: 'stale_index',
+          sessionUpdatedAt: session?.updatedAt,
+          sessionEventCount: session?.eventCount,
+          generatedAt: '2026-06-03T00:00:03.000Z',
+          entries: [
+            {
+              sessionId: 'stale_index',
+              eventId: 'stale_index:1',
+              sequence: 1,
+              type: 'message',
+              createdAt: '2026-06-03T00:00:01.000Z',
+              text: 'cached unrelated text',
+            },
+            {
+              sessionId: 'stale_index',
+              eventId: 'stale_index:2',
+              sequence: 2,
+              type: 'message',
+              createdAt: '2026-06-03T00:00:02.000Z',
+              text: 'cached unrelated text',
+            },
+          ],
+        })}\n`,
+        'utf-8'
+      );
+
+      const cachedEmpty = await searchZeroSessions('fresh indexed', { store });
+      expect(cachedEmpty.totalHits).toBe(0);
+
+      const forced = await searchZeroSessions('fresh indexed', { store, reindex: true });
+      expect(forced.totalHits).toBe(1);
+      expect(forced.hits[0]?.event.id).toBe('stale_index:2');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function sequenceClock(values: string[]): () => Date {
+  let index = 0;
+  return () => {
+    const value = values[Math.min(index, values.length - 1)];
+    index += 1;
+    return new Date(value ?? '2026-06-03T00:00:00.000Z');
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a persistent per-session search index file for local session events.
- Routes `zero search` through indexed, redacted event text while preserving the existing result shape and filters.
- Adds `zero search --reindex` so users and automation can force cache repair when index files drift.

## Why
Session search currently scans event payloads every time. This change gives the session backend a durable index layer that can be reused for unchanged sessions and rebuilt when metadata shows a session changed.

## Validation
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero search --help`
- Built CLI smoke: `zero search --json --reindex search index`
- `git diff --check origin/main..HEAD`

Reviewers: @vasanthdev2004 @anandh8x
