### PR TITLE
feat: add Zero MCP client backend

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -87,9 +87,11 @@ export async function runAgent(
       ? executableTools.map(t => {
           // Convert Zod schema to proper JSON Schema (critical for many providers).
           // zod v4 ships this natively — no external package needed.
-          const jsonSchema = z.toJSONSchema(t.parameters, {
-            target: 'draft-7',
-          }) as any;
+          const jsonSchema = typeof t.toJSONSchema === 'function'
+            ? t.toJSONSchema() as any
+            : z.toJSONSchema(t.parameters, {
+                target: 'draft-7',
+              }) as any;
 
           // Remove $schema if present (some providers dislike it)
           delete jsonSchema.$schema;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { z } from 'zod';
 import { PROVIDER_PROFILE_KINDS } from './types';
+import { ZeroMcpConfigSchema, normalizeZeroMcpConfig } from '../zero-mcp/config';
 
 /**
  * Layered configuration loader for Zero.
@@ -30,6 +31,7 @@ export const ProviderProfileSchema = z.object({
 export const ZeroConfigSchema = z.object({
   activeProvider: z.string().optional(),
   providers: z.array(ProviderProfileSchema).optional(),
+  mcp: ZeroMcpConfigSchema.optional(),
   maxTurns: z.number().int().min(1).max(100).optional(),
   planMode: z.boolean().optional(),
   debug: z.boolean().optional(),
@@ -204,6 +206,16 @@ export function mergeLayers(...layers: ZeroConfig[]): ZeroConfig {
       }
     }
     if (layer.activeProvider !== undefined) result.activeProvider = layer.activeProvider;
+    if (layer.mcp !== undefined) {
+      const normalized = normalizeZeroMcpConfig(layer.mcp);
+      result.mcp = {
+        ...result.mcp,
+        servers: {
+          ...(result.mcp?.servers ?? {}),
+          ...(normalized.servers ?? {}),
+        },
+      };
+    }
     if (layer.maxTurns !== undefined) result.maxTurns = layer.maxTurns;
     if (layer.planMode !== undefined) result.planMode = layer.planMode;
     if (layer.debug !== undefined) result.debug = layer.debug;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { runExec } from './cli';
+import { loadConfig } from './config/loader';
 import { configManager } from './config/manager';
 import { DEFAULT_UPDATE_CHECK_TIMEOUT_MS, checkForUpdate, formatUpdateCheck } from './update/check';
 import { ZERO_VERSION } from './version';
@@ -12,6 +13,12 @@ import {
 import { formatZeroDoctorReport, runZeroDoctor, type ZeroDoctorReport } from './zero-doctor';
 import { redactZeroErrorMessage, redactZeroSecrets } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
+import {
+  ZeroMcpClientManager,
+  createZeroMcpToolName,
+  type ZeroMcpServerStatus,
+  type ZeroMcpToolDescriptor,
+} from './zero-mcp';
 
 const program = new Command();
 
@@ -28,6 +35,44 @@ function parseNonNegativeIntegerOption(name: string, value: string | undefined):
   }
 
   return Number(normalized);
+}
+
+function formatZeroMcpServerList(servers: ZeroMcpServerStatus[]): string {
+  if (servers.length === 0) {
+    return 'No MCP servers configured.';
+  }
+
+  return [
+    'MCP Servers:',
+    ...servers.map((server) =>
+      `  ${server.name} [${server.type}] ${server.enabled ? 'enabled' : 'disabled'} ${server.identity}`
+    ),
+  ].join('\n');
+}
+
+function formatZeroMcpToolList(tools: ZeroMcpToolDescriptor[]): string {
+  if (tools.length === 0) {
+    return 'No MCP tools discovered.';
+  }
+
+  return [
+    'MCP Tools:',
+    ...tools.map((tool) =>
+      `  ${createZeroMcpToolName(tool.serverName, tool.name)} (${tool.serverName}/${tool.name})` +
+      (tool.description ? ` - ${tool.description}` : '')
+    ),
+  ].join('\n');
+}
+
+function toZeroMcpToolJson(tool: ZeroMcpToolDescriptor): Record<string, unknown> {
+  return {
+    serverName: tool.serverName,
+    serverIdentity: tool.serverIdentity,
+    name: tool.name,
+    zeroToolName: createZeroMcpToolName(tool.serverName, tool.name),
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  };
 }
 
 program
@@ -179,6 +224,43 @@ program
     } catch (err: unknown) {
       console.error(`[zero] ${getErrorMessage(err)}`);
       process.exitCode = 2;
+    }
+  });
+
+const mcpCmd = program
+  .command('mcp')
+  .description('Inspect configured MCP servers and tools');
+
+mcpCmd
+  .command('list')
+  .description('List configured MCP servers')
+  .option('--json', 'Print MCP server or tool data as JSON')
+  .option('--tools', 'Connect to enabled servers and list MCP tools')
+  .action(async (options: { json?: boolean; tools?: boolean }) => {
+    const manager = new ZeroMcpClientManager(loadConfig().mcp?.servers ?? {});
+
+    try {
+      if (options.tools) {
+        const tools = await manager.listTools();
+        if (options.json) {
+          console.log(JSON.stringify({ tools: tools.map(toZeroMcpToolJson) }, null, 2));
+        } else {
+          console.log(formatZeroMcpToolList(tools));
+        }
+        return;
+      }
+
+      const servers = manager.listServers();
+      if (options.json) {
+        console.log(JSON.stringify({ servers }, null, 2));
+      } else {
+        console.log(formatZeroMcpServerList(servers));
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] MCP list failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
+    } finally {
+      await manager.closeAll();
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ function formatZeroMcpToolList(tools: ZeroMcpToolDescriptor[]): string {
   return [
     'MCP Tools:',
     ...tools.map((tool) =>
-      `  ${createZeroMcpToolName(tool.serverName, tool.name)} (${tool.serverName}/${tool.name})` +
+      `  ${createZeroMcpToolName(tool.serverName, tool.serverIdentity, tool.name)} (${tool.serverName}/${tool.name})` +
       (tool.description ? ` - ${tool.description}` : '')
     ),
   ].join('\n');
@@ -69,7 +69,7 @@ function toZeroMcpToolJson(tool: ZeroMcpToolDescriptor): Record<string, unknown>
     serverName: tool.serverName,
     serverIdentity: tool.serverIdentity,
     name: tool.name,
-    zeroToolName: createZeroMcpToolName(tool.serverName, tool.name),
+    zeroToolName: createZeroMcpToolName(tool.serverName, tool.serverIdentity, tool.name),
     description: tool.description,
     inputSchema: tool.inputSchema,
   };

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -26,6 +26,7 @@ export interface Tool<T extends z.ZodObject<any> = z.ZodObject<any>> {
   description: string;
   parameters: T;
   safety: ToolSafety;
+  toJSONSchema?: () => Record<string, unknown>;
   execute: (args: z.infer<T>) => Promise<string>;
 }
 

--- a/src/zero-mcp/config.ts
+++ b/src/zero-mcp/config.ts
@@ -1,0 +1,92 @@
+import { createHash } from 'crypto';
+import { z } from 'zod';
+import type {
+  ZeroMcpConfig,
+  ZeroMcpServerConfig,
+  ZeroMcpStdioServerConfig,
+} from './types';
+
+const StringRecordSchema = z.record(z.string(), z.string());
+
+export const ZeroMcpStdioServerConfigSchema = z.object({
+  type: z.literal('stdio'),
+  command: z.string().trim().min(1),
+  args: z.array(z.string()).optional(),
+  cwd: z.string().trim().min(1).optional(),
+  env: StringRecordSchema.optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const ZeroMcpHttpServerConfigSchema = z.object({
+  type: z.union([z.literal('http'), z.literal('sse')]),
+  url: z.string().url(),
+  headers: StringRecordSchema.optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const ZeroMcpServerConfigSchema = z.discriminatedUnion('type', [
+  ZeroMcpStdioServerConfigSchema,
+  ZeroMcpHttpServerConfigSchema,
+]);
+
+export const ZeroMcpConfigSchema = z.object({
+  servers: z.record(z.string(), ZeroMcpServerConfigSchema).optional(),
+});
+
+export function normalizeZeroMcpServerConfig(config: ZeroMcpServerConfig): ZeroMcpServerConfig {
+  if (config.type === 'stdio') {
+    return {
+      ...config,
+      args: config.args ?? [],
+      env: config.env ?? {},
+      enabled: config.enabled ?? true,
+    };
+  }
+
+  return {
+    ...config,
+    headers: config.headers ?? {},
+    enabled: config.enabled ?? true,
+  };
+}
+
+export function normalizeZeroMcpConfig(config: ZeroMcpConfig | undefined): ZeroMcpConfig {
+  const servers = config?.servers;
+  if (!servers) return {};
+
+  return {
+    servers: Object.fromEntries(
+      Object.entries(servers).map(([name, server]) => [
+        name,
+        normalizeZeroMcpServerConfig(server),
+      ])
+    ),
+  };
+}
+
+export function computeZeroMcpServerIdentity(config: ZeroMcpServerConfig): string {
+  const normalized = normalizeZeroMcpServerConfig(config);
+  const identityPayload = normalized.type === 'stdio'
+    ? {
+        type: normalized.type,
+        command: normalized.command,
+        args: (normalized as ZeroMcpStdioServerConfig).args ?? [],
+      }
+    : {
+        type: normalized.type,
+        url: normalized.url,
+      };
+
+  return createHash('sha256')
+    .update(JSON.stringify(identityPayload))
+    .digest('hex')
+    .slice(0, 32);
+}
+
+export function validateZeroMcpServerName(name: string): void {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+    throw new Error(
+      `Invalid MCP server name "${name}". Use letters, numbers, dots, dashes, or underscores.`
+    );
+  }
+}

--- a/src/zero-mcp/index.ts
+++ b/src/zero-mcp/index.ts
@@ -1,0 +1,5 @@
+export * from './config';
+export * from './manager';
+export * from './tools';
+export * from './transport';
+export * from './types';

--- a/src/zero-mcp/manager.ts
+++ b/src/zero-mcp/manager.ts
@@ -1,0 +1,127 @@
+import {
+  computeZeroMcpServerIdentity,
+  normalizeZeroMcpServerConfig,
+  validateZeroMcpServerName,
+} from './config';
+import {
+  type ZeroMcpCallResult,
+  type ZeroMcpRemoteTool,
+  type ZeroMcpServerConfig,
+  type ZeroMcpServerStatus,
+  type ZeroMcpToolDescriptor,
+  type ZeroMcpTransportClient,
+} from './types';
+import {
+  createZeroMcpTransport,
+  type ZeroMcpTransportOptions,
+} from './transport';
+
+export interface ZeroMcpClientManagerOptions extends ZeroMcpTransportOptions {
+  transportFactory?: (serverName: string, config: ZeroMcpServerConfig) => ZeroMcpTransportClient;
+}
+
+export class ZeroMcpClientManager {
+  private readonly servers = new Map<string, ZeroMcpServerConfig>();
+  private readonly transports = new Map<string, ZeroMcpTransportClient>();
+
+  constructor(
+    servers: Record<string, ZeroMcpServerConfig> = {},
+    private readonly options: ZeroMcpClientManagerOptions = {}
+  ) {
+    for (const [name, config] of Object.entries(servers)) {
+      this.setServer(name, config);
+    }
+  }
+
+  setServer(name: string, config: ZeroMcpServerConfig): void {
+    validateZeroMcpServerName(name);
+    this.servers.set(name, normalizeZeroMcpServerConfig(config));
+    const existing = this.transports.get(name);
+    if (existing?.close) {
+      void existing.close();
+    }
+    this.transports.delete(name);
+  }
+
+  listServers(): ZeroMcpServerStatus[] {
+    return Array.from(this.servers.entries()).map(([name, config]) => ({
+      name,
+      type: config.type,
+      identity: computeZeroMcpServerIdentity(config),
+      enabled: config.enabled ?? true,
+    }));
+  }
+
+  async listTools(serverName?: string): Promise<ZeroMcpToolDescriptor[]> {
+    const names = serverName ? [serverName] : Array.from(this.servers.keys());
+    const descriptors: ZeroMcpToolDescriptor[] = [];
+
+    for (const name of names) {
+      const config = this.requireServer(name);
+      if (config.enabled === false) continue;
+
+      const identity = computeZeroMcpServerIdentity(config);
+      const transport = this.getTransport(name, config);
+      const tools = await transport.listTools();
+      descriptors.push(...tools.map((tool) => toDescriptor(name, identity, tool)));
+    }
+
+    return descriptors;
+  }
+
+  async callTool(
+    serverName: string,
+    toolName: string,
+    args: Record<string, unknown>
+  ): Promise<ZeroMcpCallResult> {
+    const config = this.requireServer(serverName);
+    if (config.enabled === false) {
+      throw new Error(`MCP server "${serverName}" is disabled.`);
+    }
+
+    return this.getTransport(serverName, config).callTool(toolName, args);
+  }
+
+  async closeAll(): Promise<void> {
+    await Promise.all(
+      Array.from(this.transports.values()).map((transport) => transport.close?.() ?? Promise.resolve())
+    );
+    this.transports.clear();
+  }
+
+  private requireServer(name: string): ZeroMcpServerConfig {
+    const config = this.servers.get(name);
+    if (!config) {
+      throw new Error(`Unknown MCP server "${name}".`);
+    }
+    return config;
+  }
+
+  private getTransport(name: string, config: ZeroMcpServerConfig): ZeroMcpTransportClient {
+    const existing = this.transports.get(name);
+    if (existing) return existing;
+
+    const created = this.options.transportFactory
+      ? this.options.transportFactory(name, config)
+      : createZeroMcpTransport(name, config, { timeoutMs: this.options.timeoutMs });
+    this.transports.set(name, created);
+    return created;
+  }
+}
+
+function toDescriptor(
+  serverName: string,
+  serverIdentity: string,
+  tool: ZeroMcpRemoteTool
+): ZeroMcpToolDescriptor {
+  return {
+    ...tool,
+    serverName,
+    serverIdentity,
+    inputSchema: tool.inputSchema ?? {
+      type: 'object',
+      properties: {},
+      additionalProperties: true,
+    },
+  };
+}

--- a/src/zero-mcp/tools.ts
+++ b/src/zero-mcp/tools.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { z } from 'zod';
 import type { Tool } from '../tools/types';
 import type { ToolRegistry } from '../tools/registry';
@@ -8,8 +9,18 @@ import type {
 } from './types';
 import type { ZeroMcpClientManager } from './manager';
 
-export function createZeroMcpToolName(serverName: string, toolName: string): string {
-  return `mcp__${sanitizeToolSegment(serverName)}__${sanitizeToolSegment(toolName)}`;
+export function createZeroMcpToolName(
+  serverName: string,
+  serverIdentity: string,
+  toolName: string
+): string {
+  return [
+    'mcp',
+    sanitizeToolSegment(serverName),
+    sanitizeIdentitySegment(serverIdentity),
+    sanitizeToolSegment(toolName),
+    shortToolDigest(toolName),
+  ].join('__');
 }
 
 export function createZeroMcpTool(
@@ -17,7 +28,7 @@ export function createZeroMcpTool(
   manager: ZeroMcpClientManager
 ): Tool & { toJSONSchema: () => Record<string, unknown> } {
   return {
-    name: createZeroMcpToolName(descriptor.serverName, descriptor.name),
+    name: createZeroMcpToolName(descriptor.serverName, descriptor.serverIdentity, descriptor.name),
     description: descriptor.description
       ? `[MCP:${descriptor.serverName}] ${descriptor.description}`
       : `[MCP:${descriptor.serverName}] ${descriptor.name}`,
@@ -42,7 +53,12 @@ export async function registerZeroMcpTools(
 ): Promise<Tool[]> {
   const descriptors = await manager.listTools(options.serverName);
   const tools = descriptors.map((descriptor) => createZeroMcpTool(descriptor, manager));
+  const names = new Set<string>();
   for (const tool of tools) {
+    if (names.has(tool.name) || registry.get(tool.name)) {
+      throw new Error(`Duplicate MCP tool registry name "${tool.name}" was refused.`);
+    }
+    names.add(tool.name);
     registry.register(tool);
   }
   return tools;
@@ -107,6 +123,19 @@ function sanitizeToolSegment(value: string): string {
     .replace(/[^a-z0-9_]+/g, '_')
     .replace(/^_+|_+$/g, '');
   return sanitized || 'unnamed';
+}
+
+function sanitizeIdentitySegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-f0-9]+/g, '')
+    .slice(0, 12);
+  return sanitized || 'unknown';
+}
+
+function shortToolDigest(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 8);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/zero-mcp/tools.ts
+++ b/src/zero-mcp/tools.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import type { Tool } from '../tools/types';
+import type { ToolRegistry } from '../tools/registry';
+import type {
+  ZeroMcpCallResult,
+  ZeroMcpToolContent,
+  ZeroMcpToolDescriptor,
+} from './types';
+import type { ZeroMcpClientManager } from './manager';
+
+export function createZeroMcpToolName(serverName: string, toolName: string): string {
+  return `mcp__${sanitizeToolSegment(serverName)}__${sanitizeToolSegment(toolName)}`;
+}
+
+export function createZeroMcpTool(
+  descriptor: ZeroMcpToolDescriptor,
+  manager: ZeroMcpClientManager
+): Tool & { toJSONSchema: () => Record<string, unknown> } {
+  return {
+    name: createZeroMcpToolName(descriptor.serverName, descriptor.name),
+    description: descriptor.description
+      ? `[MCP:${descriptor.serverName}] ${descriptor.description}`
+      : `[MCP:${descriptor.serverName}] ${descriptor.name}`,
+    parameters: z.object({}).catchall(z.unknown()),
+    safety: {
+      sideEffect: 'network',
+      permission: 'prompt',
+      reason: `Calls MCP tool "${descriptor.name}" on server "${descriptor.serverName}".`,
+    },
+    toJSONSchema: () => normalizeMcpInputSchema(descriptor.inputSchema),
+    async execute(args) {
+      const result = await manager.callTool(descriptor.serverName, descriptor.name, args);
+      return formatZeroMcpCallResult(result);
+    },
+  };
+}
+
+export async function registerZeroMcpTools(
+  registry: ToolRegistry,
+  manager: ZeroMcpClientManager,
+  options: { serverName?: string } = {}
+): Promise<Tool[]> {
+  const descriptors = await manager.listTools(options.serverName);
+  const tools = descriptors.map((descriptor) => createZeroMcpTool(descriptor, manager));
+  for (const tool of tools) {
+    registry.register(tool);
+  }
+  return tools;
+}
+
+export function formatZeroMcpCallResult(result: ZeroMcpCallResult): string {
+  const parts: string[] = [];
+
+  for (const item of result.content ?? []) {
+    const formatted = formatContentItem(item);
+    if (formatted) parts.push(formatted);
+  }
+
+  if (result.structuredContent !== undefined) {
+    parts.push(JSON.stringify(result.structuredContent, null, 2));
+  }
+
+  if (parts.length === 0) {
+    return result.isError ? 'MCP tool returned an error without content.' : 'MCP tool completed.';
+  }
+
+  return parts.join('\n');
+}
+
+export function normalizeMcpInputSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  if (schema.type !== 'object') {
+    return {
+      type: 'object',
+      properties: {},
+      additionalProperties: true,
+    };
+  }
+
+  return {
+    ...schema,
+    properties: isRecord(schema.properties) ? schema.properties : {},
+    additionalProperties: schema.additionalProperties ?? true,
+  };
+}
+
+function formatContentItem(item: ZeroMcpToolContent): string | undefined {
+  if (isRecord(item) && item.type === 'text' && typeof item.text === 'string') {
+    return item.text;
+  }
+
+  if (isRecord(item) && item.type === 'resource') {
+    return JSON.stringify(item.resource, null, 2);
+  }
+
+  if (isRecord(item) && item.type === 'image') {
+    const mime = typeof item.mimeType === 'string' ? item.mimeType : 'image/*';
+    return `[MCP image content: ${mime}]`;
+  }
+
+  return JSON.stringify(item, null, 2);
+}
+
+function sanitizeToolSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return sanitized || 'unnamed';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/zero-mcp/transport.ts
+++ b/src/zero-mcp/transport.ts
@@ -1,0 +1,428 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import {
+  ZERO_MCP_PROTOCOL_VERSION,
+  type ZeroMcpCallResult,
+  type ZeroMcpHttpServerConfig,
+  type ZeroMcpJsonRpcResponse,
+  type ZeroMcpRemoteTool,
+  type ZeroMcpServerConfig,
+  type ZeroMcpStdioServerConfig,
+  type ZeroMcpTransportClient,
+} from './types';
+import { normalizeZeroMcpServerConfig } from './config';
+import { ZERO_VERSION } from '../version';
+
+export class ZeroMcpError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ZeroMcpError';
+  }
+}
+
+export class ZeroMcpJsonRpcError extends ZeroMcpError {
+  constructor(
+    public readonly code: number,
+    message: string,
+    public readonly data?: unknown
+  ) {
+    super(message);
+    this.name = 'ZeroMcpJsonRpcError';
+  }
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export interface ZeroMcpTransportOptions {
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export function createZeroMcpTransport(
+  serverName: string,
+  config: ZeroMcpServerConfig,
+  options: ZeroMcpTransportOptions = {}
+): ZeroMcpTransportClient {
+  const normalized = normalizeZeroMcpServerConfig(config);
+  if (normalized.type === 'stdio') {
+    return new ZeroMcpStdioTransport(serverName, normalized, options);
+  }
+
+  return new ZeroMcpHttpTransport(serverName, normalized, options);
+}
+
+export class ZeroMcpStdioTransport implements ZeroMcpTransportClient {
+  private child: ChildProcessWithoutNullStreams | undefined;
+  private initialized: Promise<void> | undefined;
+  private stdoutBuffer = '';
+  private stderrBuffer = '';
+  private nextId = 1;
+  private readonly pending = new Map<string | number, PendingRequest>();
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly serverName: string,
+    private readonly config: ZeroMcpStdioServerConfig,
+    options: ZeroMcpTransportOptions = {}
+  ) {
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async listTools(): Promise<ZeroMcpRemoteTool[]> {
+    await this.ensureInitialized();
+    const result = await this.request('tools/list', {});
+    return normalizeToolsListResult(result, this.serverName);
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<ZeroMcpCallResult> {
+    await this.ensureInitialized();
+    const result = await this.request('tools/call', {
+      name,
+      arguments: args,
+    });
+    return normalizeToolCallResult(result, this.serverName, name);
+  }
+
+  async close(): Promise<void> {
+    const child = this.child;
+    this.child = undefined;
+    this.initialized = undefined;
+    if (!child) return;
+
+    child.stdin.end();
+    if (!child.killed) {
+      child.kill();
+    }
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) {
+      this.initialized = (async () => {
+        await this.request('initialize', {
+          protocolVersion: ZERO_MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: {
+            name: 'zero',
+            version: ZERO_VERSION,
+          },
+        });
+        this.notify('notifications/initialized', {});
+      })();
+    }
+
+    await this.initialized;
+  }
+
+  private ensureStarted(): ChildProcessWithoutNullStreams {
+    if (this.child) return this.child;
+
+    const child = spawn(this.config.command, this.config.args ?? [], {
+      cwd: this.config.cwd,
+      env: {
+        ...process.env,
+        ...(this.config.env ?? {}),
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+
+    child.stdout.on('data', (chunk: string) => this.handleStdout(chunk));
+    child.stderr.on('data', (chunk: string) => {
+      this.stderrBuffer = (this.stderrBuffer + chunk).slice(-4000);
+    });
+    child.on('error', (err) => this.rejectAll(err));
+    child.on('exit', (code, signal) => {
+      this.child = undefined;
+      this.initialized = undefined;
+      if (this.pending.size > 0) {
+        this.rejectAll(new ZeroMcpError(
+          `MCP server "${this.serverName}" exited before responding` +
+            ` (code ${code ?? 'null'}, signal ${signal ?? 'null'}).` +
+            (this.stderrBuffer ? ` stderr: ${this.stderrBuffer.trim()}` : '')
+        ));
+      }
+    });
+
+    this.child = child;
+    return child;
+  }
+
+  private async request(method: string, params: unknown): Promise<unknown> {
+    const child = this.ensureStarted();
+    const id = this.nextId++;
+
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new ZeroMcpError(
+          `MCP request "${method}" to "${this.serverName}" timed out after ${this.timeoutMs}ms.`
+        ));
+      }, this.timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+    });
+
+    child.stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method,
+      params,
+    }) + '\n');
+
+    return promise;
+  }
+
+  private notify(method: string, params: unknown): void {
+    const child = this.ensureStarted();
+    child.stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      method,
+      params,
+    }) + '\n');
+  }
+
+  private handleStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    let newlineIndex = this.stdoutBuffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const rawLine = this.stdoutBuffer.slice(0, newlineIndex).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (rawLine) this.handleMessage(rawLine);
+      newlineIndex = this.stdoutBuffer.indexOf('\n');
+    }
+  }
+
+  private handleMessage(rawLine: string): void {
+    let message: ZeroMcpJsonRpcResponse;
+    try {
+      message = JSON.parse(rawLine) as ZeroMcpJsonRpcResponse;
+    } catch (err: unknown) {
+      this.rejectAll(new ZeroMcpError(
+        `MCP server "${this.serverName}" wrote invalid JSON to stdout.`,
+        { cause: err }
+      ));
+      return;
+    }
+
+    if (!('id' in message)) return;
+    const pending = this.pending.get(message.id ?? '');
+    if (!pending) return;
+
+    clearTimeout(pending.timer);
+    this.pending.delete(message.id ?? '');
+
+    if ('error' in message) {
+      pending.reject(new ZeroMcpJsonRpcError(
+        message.error.code,
+        message.error.message,
+        message.error.data
+      ));
+      return;
+    }
+
+    pending.resolve(message.result);
+  }
+
+  private rejectAll(err: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(err);
+    }
+    this.pending.clear();
+  }
+}
+
+export class ZeroMcpHttpTransport implements ZeroMcpTransportClient {
+  private initialized = false;
+  private sessionId: string | undefined;
+  private nextId = 1;
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly serverName: string,
+    private readonly config: ZeroMcpHttpServerConfig,
+    options: ZeroMcpTransportOptions = {}
+  ) {
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async listTools(): Promise<ZeroMcpRemoteTool[]> {
+    await this.ensureInitialized();
+    const result = await this.request('tools/list', {});
+    return normalizeToolsListResult(result, this.serverName);
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<ZeroMcpCallResult> {
+    await this.ensureInitialized();
+    const result = await this.request('tools/call', {
+      name,
+      arguments: args,
+    });
+    return normalizeToolCallResult(result, this.serverName, name);
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return;
+
+    await this.request('initialize', {
+      protocolVersion: ZERO_MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: {
+        name: 'zero',
+        version: ZERO_VERSION,
+      },
+    }, { skipInitialize: true });
+    await this.notify('notifications/initialized', {});
+    this.initialized = true;
+  }
+
+  private async request(
+    method: string,
+    params: unknown,
+    options: { skipInitialize?: boolean } = {}
+  ): Promise<unknown> {
+    if (!options.skipInitialize) {
+      await this.ensureInitialized();
+    }
+
+    const id = this.nextId++;
+    const response = await this.postJsonRpc({
+      jsonrpc: '2.0',
+      id,
+      method,
+      params,
+    });
+    return response;
+  }
+
+  private async notify(method: string, params: unknown): Promise<void> {
+    await this.postJsonRpc({
+      jsonrpc: '2.0',
+      method,
+      params,
+    });
+  }
+
+  private async postJsonRpc(payload: Record<string, unknown>): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(this.config.url, {
+        method: 'POST',
+        headers: {
+          ...this.config.headers,
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+          'mcp-protocol-version': ZERO_MCP_PROTOCOL_VERSION,
+          ...(this.sessionId ? { 'mcp-session-id': this.sessionId } : {}),
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      const nextSessionId = response.headers.get('mcp-session-id');
+      if (nextSessionId) this.sessionId = nextSessionId;
+
+      if (response.status === 202) return undefined;
+      if (!response.ok) {
+        throw new ZeroMcpError(
+          `MCP HTTP server "${this.serverName}" returned ${response.status} ${response.statusText}.`
+        );
+      }
+
+      const contentType = response.headers.get('content-type') ?? '';
+      if (contentType.includes('text/event-stream')) {
+        return extractJsonRpcResultFromSse(await response.text());
+      }
+
+      return extractJsonRpcResult(await response.json());
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new ZeroMcpError(
+          `MCP HTTP request to "${this.serverName}" timed out after ${this.timeoutMs}ms.`
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function normalizeToolsListResult(result: unknown, serverName: string): ZeroMcpRemoteTool[] {
+  if (!isRecord(result) || !Array.isArray(result.tools)) {
+    throw new ZeroMcpError(`MCP server "${serverName}" returned an invalid tools/list result.`);
+  }
+
+  return result.tools.map((tool) => {
+    if (!isRecord(tool) || typeof tool.name !== 'string' || tool.name.trim() === '') {
+      throw new ZeroMcpError(`MCP server "${serverName}" returned a tool without a valid name.`);
+    }
+
+    return {
+      name: tool.name,
+      description: typeof tool.description === 'string' ? tool.description : undefined,
+      inputSchema: isRecord(tool.inputSchema) ? tool.inputSchema : undefined,
+    };
+  });
+}
+
+function normalizeToolCallResult(
+  result: unknown,
+  serverName: string,
+  toolName: string
+): ZeroMcpCallResult {
+  if (!isRecord(result)) {
+    throw new ZeroMcpError(
+      `MCP tool "${serverName}/${toolName}" returned an invalid tools/call result.`
+    );
+  }
+
+  return {
+    content: Array.isArray(result.content) ? result.content as ZeroMcpCallResult['content'] : undefined,
+    structuredContent: result.structuredContent,
+    isError: typeof result.isError === 'boolean' ? result.isError : undefined,
+  };
+}
+
+function extractJsonRpcResultFromSse(text: string): unknown {
+  const dataLines = text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice('data:'.length).trim())
+    .filter((line) => line.length > 0 && line !== '[DONE]');
+
+  for (const data of dataLines) {
+    const parsed = JSON.parse(data);
+    if (isRecord(parsed) && 'id' in parsed) {
+      return extractJsonRpcResult(parsed);
+    }
+  }
+
+  throw new ZeroMcpError('MCP SSE response did not include a JSON-RPC response.');
+}
+
+function extractJsonRpcResult(response: unknown): unknown {
+  if (!isRecord(response)) {
+    throw new ZeroMcpError('MCP response was not a JSON-RPC object.');
+  }
+
+  if ('error' in response && isRecord(response.error)) {
+    const code = typeof response.error.code === 'number' ? response.error.code : -32000;
+    const message = typeof response.error.message === 'string'
+      ? response.error.message
+      : 'Unknown MCP JSON-RPC error';
+    throw new ZeroMcpJsonRpcError(code, message, response.error.data);
+  }
+
+  return response.result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/zero-mcp/types.ts
+++ b/src/zero-mcp/types.ts
@@ -1,0 +1,99 @@
+export const ZERO_MCP_PROTOCOL_VERSION = '2025-06-18';
+
+export type ZeroMcpTransportType = 'stdio' | 'http' | 'sse';
+
+export interface ZeroMcpBaseServerConfig {
+  type: ZeroMcpTransportType;
+  enabled?: boolean;
+}
+
+export interface ZeroMcpStdioServerConfig extends ZeroMcpBaseServerConfig {
+  type: 'stdio';
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface ZeroMcpHttpServerConfig extends ZeroMcpBaseServerConfig {
+  type: 'http' | 'sse';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type ZeroMcpServerConfig = ZeroMcpStdioServerConfig | ZeroMcpHttpServerConfig;
+
+export interface ZeroMcpConfig {
+  servers?: Record<string, ZeroMcpServerConfig>;
+}
+
+export interface ZeroMcpServerStatus {
+  name: string;
+  type: ZeroMcpTransportType;
+  identity: string;
+  enabled: boolean;
+}
+
+export interface ZeroMcpRemoteTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+export interface ZeroMcpToolDescriptor extends ZeroMcpRemoteTool {
+  serverName: string;
+  serverIdentity: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface ZeroMcpTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ZeroMcpResourceContent {
+  type: 'resource';
+  resource: unknown;
+}
+
+export interface ZeroMcpImageContent {
+  type: 'image';
+  data?: string;
+  mimeType?: string;
+}
+
+export type ZeroMcpToolContent =
+  | ZeroMcpTextContent
+  | ZeroMcpResourceContent
+  | ZeroMcpImageContent
+  | Record<string, unknown>;
+
+export interface ZeroMcpCallResult {
+  content?: ZeroMcpToolContent[];
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+export interface ZeroMcpTransportClient {
+  listTools(): Promise<ZeroMcpRemoteTool[]>;
+  callTool(name: string, args: Record<string, unknown>): Promise<ZeroMcpCallResult>;
+  close?(): Promise<void>;
+}
+
+export interface ZeroMcpJsonRpcSuccess {
+  jsonrpc: '2.0';
+  id: string | number;
+  result: unknown;
+}
+
+export interface ZeroMcpJsonRpcFailure {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export type ZeroMcpJsonRpcResponse = ZeroMcpJsonRpcSuccess | ZeroMcpJsonRpcFailure;

--- a/tests/zero-mcp-client.test.ts
+++ b/tests/zero-mcp-client.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ToolRegistry } from '../src/tools/registry';
+import { loadConfig } from '../src/config/loader';
+import {
+  ZeroMcpClientManager,
+  computeZeroMcpServerIdentity,
+  createZeroMcpToolName,
+  registerZeroMcpTools,
+} from '../src/zero-mcp';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'zero-mcp-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeFakeMcpServer(dir: string): Promise<string> {
+  const serverPath = join(dir, 'fake-mcp-server.mjs');
+  await writeFile(serverPath, `
+import { createInterface } from 'node:readline';
+
+const rl = createInterface({ input: process.stdin });
+
+function send(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\\n');
+}
+
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    send(message.id, {
+      protocolVersion: '2025-06-18',
+      capabilities: { tools: {} },
+      serverInfo: { name: 'fake-zero-mcp', version: '1.0.0' },
+    });
+    return;
+  }
+  if (message.method === 'notifications/initialized') return;
+  if (message.method === 'tools/list') {
+    send(message.id, {
+      tools: [
+        {
+          name: 'lookup',
+          description: 'Look up Zero docs',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+        },
+      ],
+    });
+    return;
+  }
+  if (message.method === 'tools/call') {
+    send(message.id, {
+      content: [{ type: 'text', text: 'answer:' + message.params.arguments.query }],
+      isError: false,
+    });
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    jsonrpc: '2.0',
+    id: message.id,
+    error: { code: -32601, message: 'unknown method' },
+  }) + '\\n');
+});
+`, 'utf-8');
+  return serverPath;
+}
+
+async function runZeroMcp(
+  cwd: string,
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {}
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, join(process.cwd(), 'src/index.ts'), 'mcp', ...args], {
+    cwd,
+    env: { ...process.env, ...envOverrides },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('Zero MCP client backend', () => {
+  it('loads and merges MCP server config from project config', async () => {
+    const dir = await makeTempDir();
+    const projectConfigPath = join(dir, 'config.json');
+    await writeFile(projectConfigPath, JSON.stringify({
+      mcp: {
+        servers: {
+          docs: {
+            type: 'stdio',
+            command: 'node',
+            args: ['server.js'],
+            env: { ZERO_TEST: '1' },
+          },
+          remote: {
+            type: 'http',
+            url: 'https://example.com/mcp',
+            headers: { Authorization: 'Bearer test' },
+          },
+        },
+      },
+    }), 'utf-8');
+
+    const config = loadConfig({
+      userConfigPath: join(dir, 'missing-user.json'),
+      projectConfigPath,
+      env: {},
+    });
+
+    expect(config.mcp?.servers?.docs).toMatchObject({
+      type: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      env: { ZERO_TEST: '1' },
+    });
+    expect(config.mcp?.servers?.remote).toMatchObject({
+      type: 'http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer test' },
+    });
+  });
+
+  it('computes stable server identities from transport-defining fields', () => {
+    const first = computeZeroMcpServerIdentity({
+      type: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      env: { IGNORED_SECRET: 'x' },
+    });
+    const sameTransport = computeZeroMcpServerIdentity({
+      type: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      env: { IGNORED_SECRET: 'y' },
+    });
+    const changedTransport = computeZeroMcpServerIdentity({
+      type: 'stdio',
+      command: 'node',
+      args: ['other.js'],
+    });
+
+    expect(first).toHaveLength(32);
+    expect(first).toBe(sameTransport);
+    expect(first).not.toBe(changedTransport);
+  });
+
+  it('discovers and calls tools from a stdio MCP server', async () => {
+    const dir = await makeTempDir();
+    const serverPath = await writeFakeMcpServer(dir);
+    const manager = new ZeroMcpClientManager({
+      docs: {
+        type: 'stdio',
+        command: process.execPath,
+        args: [serverPath],
+      },
+    });
+
+    try {
+      const tools = await manager.listTools();
+      expect(tools).toHaveLength(1);
+      const [tool] = tools;
+      if (!tool) throw new Error('Expected one discovered MCP tool.');
+      expect(tool).toMatchObject({
+        serverName: 'docs',
+        name: 'lookup',
+        description: 'Look up Zero docs',
+      });
+      expect(tool.serverIdentity).toHaveLength(32);
+
+      const result = await manager.callTool('docs', 'lookup', { query: 'sessions' });
+      expect(result.content).toEqual([{ type: 'text', text: 'answer:sessions' }]);
+    } finally {
+      await manager.closeAll();
+    }
+  });
+
+  it('registers MCP tools into the Zero tool registry with prompt-gated execution', async () => {
+    const dir = await makeTempDir();
+    const serverPath = await writeFakeMcpServer(dir);
+    const registry = new ToolRegistry();
+    const manager = new ZeroMcpClientManager({
+      docs: {
+        type: 'stdio',
+        command: process.execPath,
+        args: [serverPath],
+      },
+    });
+
+    try {
+      const registered = await registerZeroMcpTools(registry, manager);
+      const toolName = createZeroMcpToolName('docs', 'lookup');
+      const tool = registry.get(toolName);
+
+      expect(registered.map((tool) => tool.name)).toEqual([toolName]);
+      expect(tool).toBeDefined();
+      expect(tool?.safety).toMatchObject({
+        sideEffect: 'network',
+        permission: 'prompt',
+      });
+      expect(tool?.toJSONSchema?.()).toMatchObject({
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+        additionalProperties: false,
+      });
+
+      const blocked = await registry.run(toolName, { query: 'blocked' });
+      expect(blocked).toContain('Permission required');
+
+      const allowed = await registry.run(toolName, { query: 'allowed' }, { permissionGranted: true });
+      expect(allowed).toBe('answer:allowed');
+    } finally {
+      await manager.closeAll();
+    }
+  });
+
+  it('lists configured MCP servers and discovered tools from the CLI', async () => {
+    const dir = await makeTempDir();
+    const serverPath = await writeFakeMcpServer(dir);
+    await mkdir(join(dir, '.zero'), { recursive: true });
+    await writeFile(join(dir, '.zero', 'config.json'), JSON.stringify({
+      mcp: {
+        servers: {
+          docs: {
+            type: 'stdio',
+            command: process.execPath,
+            args: [serverPath],
+          },
+        },
+      },
+    }), 'utf-8');
+
+    const listResult = await runZeroMcp(dir, ['list', '--json'], {
+      HOME: join(dir, 'home'),
+      USERPROFILE: join(dir, 'home'),
+    });
+
+    expect(listResult.exitCode).toBe(0);
+    expect(listResult.stderr.trim()).toBe('');
+    expect(JSON.parse(listResult.stdout).servers).toEqual([
+      expect.objectContaining({
+        name: 'docs',
+        type: 'stdio',
+        enabled: true,
+      }),
+    ]);
+
+    const toolsResult = await runZeroMcp(dir, ['list', '--tools', '--json'], {
+      HOME: join(dir, 'home'),
+      USERPROFILE: join(dir, 'home'),
+    });
+
+    expect(toolsResult.exitCode).toBe(0);
+    expect(toolsResult.stderr.trim()).toBe('');
+    expect(JSON.parse(toolsResult.stdout).tools).toEqual([
+      expect.objectContaining({
+        name: 'lookup',
+        zeroToolName: 'mcp__docs__lookup',
+        serverName: 'docs',
+      }),
+    ]);
+  });
+});

--- a/tests/zero-mcp-client.test.ts
+++ b/tests/zero-mcp-client.test.ts
@@ -209,7 +209,9 @@ describe('Zero MCP client backend', () => {
 
     try {
       const registered = await registerZeroMcpTools(registry, manager);
-      const toolName = createZeroMcpToolName('docs', 'lookup');
+      const [registeredTool] = registered;
+      if (!registeredTool) throw new Error('Expected one registered MCP tool.');
+      const toolName = registeredTool.name;
       const tool = registry.get(toolName);
 
       expect(registered.map((tool) => tool.name)).toEqual([toolName]);
@@ -233,6 +235,63 @@ describe('Zero MCP client backend', () => {
     } finally {
       await manager.closeAll();
     }
+  });
+
+  it('generates collision-safe registry names for sanitized server and tool names', () => {
+    const serverCollisionA = createZeroMcpToolName(
+      'docs-prod',
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'lookup-all'
+    );
+    const serverCollisionB = createZeroMcpToolName(
+      'docs_prod',
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      'lookup_all'
+    );
+    const toolCollisionA = createZeroMcpToolName(
+      'docs',
+      'cccccccccccccccccccccccccccccccc',
+      'lookup-all'
+    );
+    const toolCollisionB = createZeroMcpToolName(
+      'docs',
+      'cccccccccccccccccccccccccccccccc',
+      'lookup_all'
+    );
+
+    expect(serverCollisionA).not.toBe(serverCollisionB);
+    expect(toolCollisionA).not.toBe(toolCollisionB);
+    expect(serverCollisionA).toContain('__aaaaaaaaaaaa__');
+    expect(serverCollisionB).toContain('__bbbbbbbbbbbb__');
+  });
+
+  it('refuses duplicate generated MCP registry names before overwriting tools', async () => {
+    const registry = new ToolRegistry();
+    const manager = {
+      async listTools() {
+        return [
+          {
+            serverName: 'docs',
+            serverIdentity: 'dddddddddddddddddddddddddddddddd',
+            name: 'lookup',
+            inputSchema: { type: 'object', properties: {} },
+          },
+          {
+            serverName: 'docs',
+            serverIdentity: 'dddddddddddddddddddddddddddddddd',
+            name: 'lookup',
+            inputSchema: { type: 'object', properties: {} },
+          },
+        ];
+      },
+      async callTool() {
+        return { content: [] };
+      },
+    } as unknown as ZeroMcpClientManager;
+
+    await expect(registerZeroMcpTools(registry, manager)).rejects.toThrow(
+      'Duplicate MCP tool registry name'
+    );
   });
 
   it('lists configured MCP servers and discovered tools from the CLI', async () => {
@@ -276,7 +335,7 @@ describe('Zero MCP client backend', () => {
     expect(JSON.parse(toolsResult.stdout).tools).toEqual([
       expect.objectContaining({
         name: 'lookup',
-        zeroToolName: 'mcp__docs__lookup',
+        zeroToolName: expect.stringMatching(/^mcp__docs__[a-f0-9]{12}__lookup__[a-f0-9]{8}$/),
         serverName: 'docs',
       }),
     ]);


### PR DESCRIPTION
## Summary

Adds the first M4 MCP backend slice for Zero. This PR introduces a typed MCP client layer that can read MCP server configuration, connect to servers, discover tools, and adapt those tools into Zero's existing tool registry shape.

## What Changed

- Added `src/zero-mcp` with typed config, server identity hashing, transport clients, manager APIs, and tool registration helpers.
- Added stdio MCP JSON-RPC support with initialization, newline-delimited message handling, request timeouts, stderr capture, tool discovery, tool calls, and cleanup.
- Added HTTP/SSE transport seams for MCP servers using the current streamable HTTP request shape, including session header preservation and SSE response parsing.
- Added stable MCP tool names using `mcp__<server>__<serverIdentity>__<tool>__<toolDigest>` so external tools remain unique after sanitization.
- Added duplicate generated-name detection before registration so MCP tools fail closed instead of overwriting another tool.
- Preserved MCP-provided input schemas through an optional `Tool.toJSONSchema()` hook so remote schemas are sent to providers without losing their shape.
- Extended layered config with `mcp.servers` support for stdio, HTTP, and SSE definitions.
- Added `zero mcp list` with `--json` and `--tools` for backend inspection and local smoke usage.
- Added coverage for config loading, server identity stability, stdio tool discovery/call, registry permission gating, collision-safe names, duplicate-name refusal, and CLI list output.

## Behavior Notes

- MCP tools are registered as prompt-gated `network` tools by default.
- Server identities are derived from transport-defining fields, not secrets or environment values.
- Disabled MCP servers are skipped during tool discovery.
- The CLI inspection path is backend-focused; permission lifecycle commands, plugin loading, and MCP server mode remain separate M4 slices.

## Validation

- `git diff --check`
- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test tests/zero-mcp-client.test.ts --timeout 15000` — 7 pass
- `npx --yes bun test ./tests --timeout 15000` — 245 pass, 0 fail
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero mcp --help`
- `./zero mcp list --help`
- `./zero mcp list --json`

Reviewers: @vasanthdev2004 @anandh8x
