### PR TITLE
feat: add MCP permission grants

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1,9 +1,13 @@
 import type { Provider } from '../providers/types';
 import type { ZeroReasoningEffort, ZeroTokenUsage } from '../zero-model-registry';
-import type { ToolCall, ToolResult, ToolSafety } from '../tools/types';
+import type { Tool, ToolCall, ToolResult, ToolSafety } from '../tools/types';
 import { toolRegistry } from '../tools';
 import { DEFAULT_SYSTEM_PROMPT, PLAN_MODE_SYSTEM_PROMPT } from './prompts';
 import { clearPlan } from '../tools/plan';
+import {
+  ZeroMcpPermissionStore,
+  type ZeroMcpPermissionAutonomy,
+} from '../zero-mcp';
 import { z } from 'zod';
 
 export type AgentPermissionMode = 'auto' | 'ask' | 'unsafe';
@@ -31,6 +35,8 @@ export interface AgentOptions {
   enabledTools?: readonly string[];
   disabledTools?: readonly string[];
   reasoningEffort?: ZeroReasoningEffort;
+  autonomy?: ZeroMcpPermissionAutonomy;
+  mcpPermissionStore?: ZeroMcpPermissionStore;
 }
 
 interface PendingToolCall {
@@ -58,6 +64,8 @@ export async function runAgent(
     enabledTools,
     disabledTools,
     reasoningEffort,
+    autonomy = 'low',
+    mcpPermissionStore = new ZeroMcpPermissionStore(),
   } = options;
 
   // Clear any previous plan when starting a new task
@@ -87,14 +95,15 @@ export async function runAgent(
       ? executableTools.map(t => {
           // Convert Zod schema to proper JSON Schema (critical for many providers).
           // zod v4 ships this natively — no external package needed.
-          const jsonSchema = typeof t.toJSONSchema === 'function'
+          const rawJsonSchema = typeof t.toJSONSchema === 'function'
             ? t.toJSONSchema() as any
             : z.toJSONSchema(t.parameters, {
                 target: 'draft-7',
               }) as any;
 
-          // Remove $schema if present (some providers dislike it)
-          delete jsonSchema.$schema;
+          // Remove $schema if present (some providers dislike it), without
+          // mutating custom schemas returned by tool implementations.
+          const { $schema: _schema, ...jsonSchema } = rawJsonSchema;
 
           // Make it strict by default (good practice)
           if (jsonSchema.type === 'object' && !('additionalProperties' in jsonSchema)) {
@@ -224,6 +233,8 @@ export async function runAgent(
         onToolApproval,
         onToolResult,
         permissionMode,
+        autonomy,
+        mcpPermissionStore,
       }));
     }
 
@@ -247,6 +258,8 @@ async function executeToolCall(
     onToolApproval?: AgentOptions['onToolApproval'];
     onToolResult?: AgentOptions['onToolResult'];
     permissionMode: AgentPermissionMode;
+    autonomy: ZeroMcpPermissionAutonomy;
+    mcpPermissionStore: ZeroMcpPermissionStore;
   }
 ): Promise<ToolResult> {
   const emitResult = (result: string): ToolResult => {
@@ -264,11 +277,13 @@ async function executeToolCall(
 
   try {
     const tool = toolRegistry.get(tc.name);
-    const grantKey = tool ? `${tool.safety.permission}:${tool.safety.sideEffect}` : `unknown:${tc.name}`;
+    const grantKey = createToolGrantKey(tool, tc.name);
     let permissionGranted = options.permissionMode === 'unsafe' || tool?.safety.permission === 'allow';
 
     if (options.permissionMode === 'ask' && tool?.safety.permission === 'prompt') {
-      if (options.approvalGrants.has(grantKey)) {
+      if (await isPersistentlyApprovedMcpTool(tool, options.mcpPermissionStore, options.autonomy)) {
+        permissionGranted = true;
+      } else if (options.approvalGrants.has(grantKey)) {
         permissionGranted = true;
       } else if (options.onToolApproval) {
         const decision = await options.onToolApproval({
@@ -317,4 +332,30 @@ function filterExecutableTools(
       ? tool.safety.permission !== 'deny'
       : tool.safety.permission === 'allow';
   });
+}
+
+function createToolGrantKey(tool: Tool | undefined, toolName: string): string {
+  if (tool?.zeroMcp) {
+    return `mcp:${tool.zeroMcp.serverName}:${tool.zeroMcp.serverIdentity}:${tool.zeroMcp.toolName}`;
+  }
+  return tool ? `${tool.safety.permission}:${tool.safety.sideEffect}` : `unknown:${toolName}`;
+}
+
+async function isPersistentlyApprovedMcpTool(
+  tool: Tool,
+  store: ZeroMcpPermissionStore,
+  requestedAutonomy: ZeroMcpPermissionAutonomy
+): Promise<boolean> {
+  if (!tool.zeroMcp) return false;
+
+  try {
+    return await store.isToolPersistentlyApproved({
+      serverName: tool.zeroMcp.serverName,
+      serverIdentity: tool.zeroMcp.serverIdentity,
+      toolName: tool.zeroMcp.toolName,
+      requestedAutonomy,
+    });
+  } catch {
+    return false;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,9 @@ import { redactZeroErrorMessage, redactZeroSecrets } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
 import {
   ZeroMcpClientManager,
+  ZeroMcpPermissionStore,
   createZeroMcpToolName,
+  type ZeroMcpPermissionGrant,
   type ZeroMcpServerStatus,
   type ZeroMcpToolDescriptor,
 } from './zero-mcp';
@@ -61,6 +63,22 @@ function formatZeroMcpToolList(tools: ZeroMcpToolDescriptor[]): string {
       `  ${createZeroMcpToolName(tool.serverName, tool.serverIdentity, tool.name)} (${tool.serverName}/${tool.name})` +
       (tool.description ? ` - ${tool.description}` : '')
     ),
+  ].join('\n');
+}
+
+function formatZeroMcpPermissionList(permissions: ZeroMcpPermissionGrant[]): string {
+  if (permissions.length === 0) {
+    return 'No persistent MCP permissions granted.';
+  }
+
+  return [
+    'MCP Permissions:',
+    ...permissions.map((permission) => {
+      const target = permission.scope === 'tool'
+        ? `${permission.serverName}/${permission.toolName}`
+        : `${permission.serverName}/*`;
+      return `  ${target} [${permission.maxAutonomy}] ${permission.serverIdentity} approved ${permission.approvedAt}`;
+    }),
   ].join('\n');
 }
 
@@ -261,6 +279,87 @@ mcpCmd
       process.exitCode = 1;
     } finally {
       await manager.closeAll();
+    }
+  });
+
+const mcpPermissionsCmd = mcpCmd
+  .command('permissions')
+  .description('List and revoke persistent MCP tool permissions');
+
+mcpPermissionsCmd
+  .command('list')
+  .description('List persistent MCP permissions')
+  .option('--json', 'Print MCP permissions as JSON')
+  .action(async (options: { json?: boolean }) => {
+    const store = new ZeroMcpPermissionStore();
+
+    try {
+      const permissions = await store.list();
+      if (options.json) {
+        console.log(JSON.stringify({ permissions }, null, 2));
+      } else {
+        console.log(formatZeroMcpPermissionList(permissions));
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] MCP permissions list failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+mcpPermissionsCmd
+  .command('revoke')
+  .description('Revoke a server grant or one tool grant')
+  .argument('<server>', 'MCP server name')
+  .argument('[tool]', 'MCP tool name; omit to revoke the server and all of its tool grants')
+  .option('--json', 'Print revoke result as JSON')
+  .action(async (serverName: string, toolName: string | undefined, options: { json?: boolean }) => {
+    const store = new ZeroMcpPermissionStore();
+
+    try {
+      const revoked = toolName
+        ? await store.revokeTool(serverName, toolName)
+        : await store.revokeServer(serverName);
+      if (options.json) {
+        console.log(JSON.stringify({
+          revoked,
+          scope: toolName ? 'tool' : 'server',
+          serverName,
+          ...(toolName ? { toolName } : {}),
+        }, null, 2));
+      } else {
+        const target = toolName ? `${serverName}/${toolName}` : `${serverName}/*`;
+        console.log(`Revoked ${revoked} MCP permission grant${revoked === 1 ? '' : 's'} for ${target}.`);
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] MCP permissions revoke failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+mcpPermissionsCmd
+  .command('clear')
+  .description('Clear all persistent MCP permissions')
+  .option('--confirm', 'Confirm clearing all persistent MCP permissions')
+  .option('--json', 'Print clear result as JSON')
+  .action(async (options: { confirm?: boolean; json?: boolean }) => {
+    if (!options.confirm) {
+      console.error('[zero] Refusing to clear MCP permissions without --confirm.');
+      process.exitCode = 1;
+      return;
+    }
+
+    const store = new ZeroMcpPermissionStore();
+
+    try {
+      const cleared = await store.clear();
+      if (options.json) {
+        console.log(JSON.stringify({ cleared }, null, 2));
+      } else {
+        console.log(`Cleared ${cleared} MCP permission grant${cleared === 1 ? '' : 's'}.`);
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] MCP permissions clear failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
     }
   });
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -11,6 +11,10 @@ export class ToolRegistry {
     return this.tools.get(name);
   }
 
+  unregister(name: string): boolean {
+    return this.tools.delete(name);
+  }
+
   getAll(): Tool[] {
     return Array.from(this.tools.values());
   }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -26,6 +26,11 @@ export interface Tool<T extends z.ZodObject<any> = z.ZodObject<any>> {
   description: string;
   parameters: T;
   safety: ToolSafety;
+  zeroMcp?: {
+    serverName: string;
+    serverIdentity: string;
+    toolName: string;
+  };
   toJSONSchema?: () => Record<string, unknown>;
   execute: (args: z.infer<T>) => Promise<string>;
 }

--- a/src/zero-mcp/index.ts
+++ b/src/zero-mcp/index.ts
@@ -1,5 +1,6 @@
 export * from './config';
 export * from './manager';
+export * from './permissions';
 export * from './tools';
 export * from './transport';
 export * from './types';

--- a/src/zero-mcp/permissions.ts
+++ b/src/zero-mcp/permissions.ts
@@ -1,0 +1,371 @@
+import { mkdir, readFile, rename, rm, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, isAbsolute, join, resolve } from 'path';
+import { validateZeroMcpServerName } from './config';
+
+export type ZeroMcpPermissionScope = 'server' | 'tool';
+export type ZeroMcpPermissionAutonomy = 'low' | 'medium' | 'high';
+
+export interface ZeroMcpPermissionGrant {
+  scope: ZeroMcpPermissionScope;
+  serverName: string;
+  serverIdentity: string;
+  toolName?: string;
+  maxAutonomy: ZeroMcpPermissionAutonomy;
+  approvedAt: string;
+}
+
+export interface ZeroMcpPermissionStoreOptions {
+  filePath?: string;
+  now?: () => Date;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface GrantZeroMcpServerPermissionInput {
+  serverName: string;
+  serverIdentity: string;
+  maxAutonomy?: ZeroMcpPermissionAutonomy;
+}
+
+export interface GrantZeroMcpToolPermissionInput extends GrantZeroMcpServerPermissionInput {
+  toolName: string;
+}
+
+export interface CheckZeroMcpToolPermissionInput {
+  serverName: string;
+  serverIdentity: string;
+  toolName: string;
+  requestedAutonomy?: ZeroMcpPermissionAutonomy;
+}
+
+interface StoredZeroMcpGrant {
+  serverIdentity: string;
+  maxAutonomy: ZeroMcpPermissionAutonomy;
+  approvedAt: string;
+}
+
+interface ZeroMcpPermissionFile {
+  schemaVersion: 1;
+  servers: Record<string, StoredZeroMcpGrant>;
+  tools: Record<string, Record<string, StoredZeroMcpGrant>>;
+}
+
+const ZERO_MCP_PERMISSION_SCHEMA_VERSION = 1;
+const ZERO_MCP_PERMISSION_AUTONOMY_ORDER: Record<ZeroMcpPermissionAutonomy, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+export function resolveZeroMcpPermissionPath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.ZERO_MCP_PERMISSIONS_PATH?.trim();
+  if (override) {
+    return isAbsolute(override) ? override : resolve(override);
+  }
+
+  const configHome = env.XDG_CONFIG_HOME?.trim();
+  const baseDir = configHome
+    ? (isAbsolute(configHome) ? configHome : resolve(configHome))
+    : join(homedir(), '.config');
+  return join(baseDir, 'zero', 'mcp-permissions.json');
+}
+
+export class ZeroMcpPermissionStore {
+  readonly filePath: string;
+  private readonly now: () => Date;
+  private writeQueue: Promise<unknown> = Promise.resolve();
+
+  constructor(options: ZeroMcpPermissionStoreOptions = {}) {
+    this.filePath = options.filePath ?? resolveZeroMcpPermissionPath(options.env);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async grantServer(input: GrantZeroMcpServerPermissionInput): Promise<ZeroMcpPermissionGrant> {
+    const grant = createStoredGrant(input.serverIdentity, input.maxAutonomy, this.now);
+    validateZeroMcpServerName(input.serverName);
+
+    return this.withWriteLock(async () => {
+      const state = await this.readState();
+      state.servers[input.serverName] = grant;
+      await this.writeState(state);
+      return toServerGrant(input.serverName, grant);
+    });
+  }
+
+  async grantTool(input: GrantZeroMcpToolPermissionInput): Promise<ZeroMcpPermissionGrant> {
+    const grant = createStoredGrant(input.serverIdentity, input.maxAutonomy, this.now);
+    validateZeroMcpServerName(input.serverName);
+    validateToolName(input.toolName);
+
+    return this.withWriteLock(async () => {
+      const state = await this.readState();
+      state.tools[input.serverName] = state.tools[input.serverName] ?? {};
+      state.tools[input.serverName]![input.toolName] = grant;
+      await this.writeState(state);
+      return toToolGrant(input.serverName, input.toolName, grant);
+    });
+  }
+
+  async isToolPersistentlyApproved(input: CheckZeroMcpToolPermissionInput): Promise<boolean> {
+    validateZeroMcpServerName(input.serverName);
+    validateToolName(input.toolName);
+    const requestedAutonomy = normalizeAutonomy(input.requestedAutonomy ?? 'low');
+    const state = await this.readState();
+    const toolGrant = state.tools[input.serverName]?.[input.toolName];
+    if (isGrantAllowed(toolGrant, input.serverIdentity, requestedAutonomy)) {
+      return true;
+    }
+
+    const serverGrant = state.servers[input.serverName];
+    return isGrantAllowed(serverGrant, input.serverIdentity, requestedAutonomy);
+  }
+
+  async list(): Promise<ZeroMcpPermissionGrant[]> {
+    const state = await this.readState();
+    const servers = Object.entries(state.servers)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([serverName, grant]) => toServerGrant(serverName, grant));
+    const tools = Object.entries(state.tools)
+      .flatMap(([serverName, serverTools]) =>
+        Object.entries(serverTools).map(([toolName, grant]) => toToolGrant(serverName, toolName, grant))
+      )
+      .sort((left, right) =>
+        left.serverName.localeCompare(right.serverName) ||
+        (left.toolName ?? '').localeCompare(right.toolName ?? '')
+      );
+    return [...servers, ...tools];
+  }
+
+  async revokeTool(serverName: string, toolName: string): Promise<number> {
+    validateZeroMcpServerName(serverName);
+    validateToolName(toolName);
+
+    return this.withWriteLock(async () => {
+      const state = await this.readState();
+      const serverTools = state.tools[serverName];
+      if (!serverTools?.[toolName]) return 0;
+
+      delete serverTools[toolName];
+      if (Object.keys(serverTools).length === 0) {
+        delete state.tools[serverName];
+      }
+      await this.writeState(state);
+      return 1;
+    });
+  }
+
+  async revokeServer(serverName: string): Promise<number> {
+    validateZeroMcpServerName(serverName);
+
+    return this.withWriteLock(async () => {
+      const state = await this.readState();
+      let revoked = state.servers[serverName] ? 1 : 0;
+      delete state.servers[serverName];
+
+      const serverTools = state.tools[serverName];
+      if (serverTools) {
+        revoked += Object.keys(serverTools).length;
+        delete state.tools[serverName];
+      }
+
+      if (revoked > 0) {
+        await this.writeState(state);
+      }
+      return revoked;
+    });
+  }
+
+  async clear(): Promise<number> {
+    return this.withWriteLock(async () => {
+      const state = await this.readState();
+      const count = countGrants(state);
+      if (count > 0) {
+        await this.writeState(createEmptyState());
+      }
+      return count;
+    });
+  }
+
+  private async readState(): Promise<ZeroMcpPermissionFile> {
+    let text: string;
+    try {
+      text = await readFile(this.filePath, 'utf-8');
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') return createEmptyState();
+      throw err;
+    }
+
+    try {
+      return parsePermissionFile(JSON.parse(text), this.filePath);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid MCP permissions file at ${this.filePath}: ${message}`);
+    }
+  }
+
+  private async writeState(state: ZeroMcpPermissionFile): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const tempPath = `${this.filePath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+    try {
+      await writeFile(tempPath, `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+      await rename(tempPath, this.filePath);
+    } catch (err: unknown) {
+      await rm(tempPath, { force: true });
+      throw err;
+    }
+  }
+
+  private async withWriteLock<T>(operation: () => Promise<T>): Promise<T> {
+    const next = this.writeQueue.then(operation, operation);
+    this.writeQueue = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  }
+}
+
+function createEmptyState(): ZeroMcpPermissionFile {
+  return {
+    schemaVersion: ZERO_MCP_PERMISSION_SCHEMA_VERSION,
+    servers: {},
+    tools: {},
+  };
+}
+
+function createStoredGrant(
+  serverIdentity: string,
+  maxAutonomy: ZeroMcpPermissionAutonomy | undefined,
+  now: () => Date
+): StoredZeroMcpGrant {
+  const identity = serverIdentity.trim();
+  if (!identity) {
+    throw new Error('MCP server identity is required.');
+  }
+
+  return {
+    serverIdentity: identity,
+    maxAutonomy: normalizeAutonomy(maxAutonomy ?? 'low'),
+    approvedAt: now().toISOString(),
+  };
+}
+
+function parsePermissionFile(parsed: unknown, filePath: string): ZeroMcpPermissionFile {
+  if (!isRecord(parsed)) {
+    throw new Error('Expected a JSON object.');
+  }
+  if (parsed.schemaVersion !== ZERO_MCP_PERMISSION_SCHEMA_VERSION) {
+    throw new Error(`Unsupported schemaVersion in ${filePath}.`);
+  }
+
+  return {
+    schemaVersion: ZERO_MCP_PERMISSION_SCHEMA_VERSION,
+    servers: parseGrantRecord(parsed.servers, 'servers'),
+    tools: parseToolGrantRecord(parsed.tools),
+  };
+}
+
+function parseGrantRecord(value: unknown, label: string): Record<string, StoredZeroMcpGrant> {
+  if (value === undefined) return {};
+  if (!isRecord(value)) {
+    throw new Error(`Expected "${label}" to be an object.`);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([name, grant]) => [name, parseStoredGrant(grant, `${label}.${name}`)])
+  );
+}
+
+function parseToolGrantRecord(value: unknown): Record<string, Record<string, StoredZeroMcpGrant>> {
+  if (value === undefined) return {};
+  if (!isRecord(value)) {
+    throw new Error('Expected "tools" to be an object.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([serverName, serverTools]) => [
+      serverName,
+      parseGrantRecord(serverTools, `tools.${serverName}`),
+    ])
+  );
+}
+
+function parseStoredGrant(value: unknown, label: string): StoredZeroMcpGrant {
+  if (!isRecord(value)) {
+    throw new Error(`Expected "${label}" to be an object.`);
+  }
+  const serverIdentity = readString(value.serverIdentity, `${label}.serverIdentity`);
+  const approvedAt = readString(value.approvedAt, `${label}.approvedAt`);
+  return {
+    serverIdentity,
+    approvedAt,
+    maxAutonomy: normalizeAutonomy(readString(value.maxAutonomy, `${label}.maxAutonomy`)),
+  };
+}
+
+function readString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Expected "${label}" to be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function normalizeAutonomy(value: string): ZeroMcpPermissionAutonomy {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'low' || normalized === 'medium' || normalized === 'high') {
+    return normalized;
+  }
+  throw new Error(`Invalid MCP permission autonomy "${value}". Expected low, medium, or high.`);
+}
+
+function validateToolName(toolName: string): void {
+  if (!toolName.trim()) {
+    throw new Error('MCP tool name is required.');
+  }
+}
+
+function isGrantAllowed(
+  grant: StoredZeroMcpGrant | undefined,
+  serverIdentity: string,
+  requestedAutonomy: ZeroMcpPermissionAutonomy
+): boolean {
+  if (!grant) return false;
+  if (grant.serverIdentity !== serverIdentity) return false;
+  return ZERO_MCP_PERMISSION_AUTONOMY_ORDER[requestedAutonomy] <=
+    ZERO_MCP_PERMISSION_AUTONOMY_ORDER[grant.maxAutonomy];
+}
+
+function toServerGrant(serverName: string, grant: StoredZeroMcpGrant): ZeroMcpPermissionGrant {
+  return {
+    scope: 'server',
+    serverName,
+    serverIdentity: grant.serverIdentity,
+    maxAutonomy: grant.maxAutonomy,
+    approvedAt: grant.approvedAt,
+  };
+}
+
+function toToolGrant(
+  serverName: string,
+  toolName: string,
+  grant: StoredZeroMcpGrant
+): ZeroMcpPermissionGrant {
+  return {
+    scope: 'tool',
+    serverName,
+    serverIdentity: grant.serverIdentity,
+    toolName,
+    maxAutonomy: grant.maxAutonomy,
+    approvedAt: grant.approvedAt,
+  };
+}
+
+function countGrants(state: ZeroMcpPermissionFile): number {
+  return Object.keys(state.servers).length +
+    Object.values(state.tools).reduce((count, serverTools) => count + Object.keys(serverTools).length, 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/zero-mcp/tools.ts
+++ b/src/zero-mcp/tools.ts
@@ -38,6 +38,11 @@ export function createZeroMcpTool(
       permission: 'prompt',
       reason: `Calls MCP tool "${descriptor.name}" on server "${descriptor.serverName}".`,
     },
+    zeroMcp: {
+      serverName: descriptor.serverName,
+      serverIdentity: descriptor.serverIdentity,
+      toolName: descriptor.name,
+    },
     toJSONSchema: () => normalizeMcpInputSchema(descriptor.inputSchema),
     async execute(args) {
       const result = await manager.callTool(descriptor.serverName, descriptor.name, args);
@@ -59,6 +64,8 @@ export async function registerZeroMcpTools(
       throw new Error(`Duplicate MCP tool registry name "${tool.name}" was refused.`);
     }
     names.add(tool.name);
+  }
+  for (const tool of tools) {
     registry.register(tool);
   }
   return tools;

--- a/src/zero-runtime/context.ts
+++ b/src/zero-runtime/context.ts
@@ -88,6 +88,7 @@ export async function createZeroRunContext(options: ZeroRuntimeOptions): Promise
         enabledTools,
         disabledTools,
         reasoningEffort,
+        autonomy,
       },
     };
   } catch (err: unknown) {

--- a/src/zero-runtime/types.ts
+++ b/src/zero-runtime/types.ts
@@ -44,7 +44,7 @@ export interface ZeroRunContext {
   disabledTools?: readonly string[];
   agentOptions: Pick<
     AgentOptions,
-    'maxTurns' | 'permissionMode' | 'enabledTools' | 'disabledTools' | 'reasoningEffort'
+    'maxTurns' | 'permissionMode' | 'enabledTools' | 'disabledTools' | 'reasoningEffort' | 'autonomy'
   >;
 }
 

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { mkdtemp, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { z } from 'zod';
 import {
   runAgent,
   type ToolApprovalDecision,
@@ -9,6 +10,8 @@ import {
 } from '../src/agent/loop';
 import { DEFAULT_SYSTEM_PROMPT, PLAN_MODE_SYSTEM_PROMPT } from '../src/agent/prompts';
 import type { Provider, Message, StreamEvent } from '../src/providers/types';
+import { toolRegistry } from '../src/tools';
+import { ZeroMcpPermissionStore } from '../src/zero-mcp';
 
 // A mock provider that records the messages it receives and replays a
 // scripted sequence of stream events per turn.
@@ -165,6 +168,42 @@ describe('runAgent tool-call flow', () => {
     expect(names).toEqual(['read_file', 'write_file']);
   });
 
+  it('does not mutate custom tool JSON schemas while preparing provider tools', async () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {},
+      additionalProperties: true,
+    };
+    toolRegistry.register({
+      name: 'custom_schema_probe',
+      description: 'custom schema probe',
+      parameters: z.object({}),
+      safety: {
+        sideEffect: 'read',
+        permission: 'allow',
+        reason: 'Test-only schema probe.',
+      },
+      toJSONSchema: () => schema,
+      async execute() {
+        return 'ok';
+      },
+    });
+    const provider = new MockProvider([[{ type: 'text', content: 'schema done' }]]);
+
+    try {
+      await runAgent('check schema', provider, {
+        enabledTools: ['custom_schema_probe'],
+      });
+
+      const toolDefinition = provider.receivedTools[0]?.find((tool) => tool.name === 'custom_schema_probe');
+      expect(toolDefinition?.parameters.$schema).toBeUndefined();
+      expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    } finally {
+      toolRegistry.unregister('custom_schema_probe');
+    }
+  });
+
   it('runs prompt-gated tools through the registry only when unsafe mode grants permission', async () => {
     const command = 'echo zero-agent-unsafe';
     const safeProvider = new MockProvider([
@@ -296,6 +335,68 @@ describe('runAgent tool-call flow', () => {
     expect(approvalCount).toBe(1);
     expect(await readFile(firstPath, 'utf-8')).toBe('first');
     expect(await readFile(secondPath, 'utf-8')).toBe('second');
+  });
+
+  it('runs a matching persistently approved MCP tool without prompting again', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'zero-mcp-agent-grant-'));
+    const permissionStore = new ZeroMcpPermissionStore({
+      filePath: join(dir, 'mcp-permissions.json'),
+      now: () => new Date('2026-06-03T09:30:00.000Z'),
+    });
+    const toolName = 'mcp__persisted_docs__aaaaaaaaaaaa__lookup__00000000';
+    await permissionStore.grantTool({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'lookup',
+      maxAutonomy: 'medium',
+    });
+    toolRegistry.register({
+      name: toolName,
+      description: 'persisted MCP tool',
+      parameters: z.object({}),
+      safety: {
+        sideEffect: 'network',
+        permission: 'prompt',
+        reason: 'Calls a persisted MCP tool.',
+      },
+      zeroMcp: {
+        serverName: 'docs',
+        serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        toolName: 'lookup',
+      },
+      async execute() {
+        return 'persisted mcp ok';
+      },
+    });
+    const provider = new MockProvider([
+      [
+        { type: 'tool-call-start', id: 'call_1', name: toolName },
+        { type: 'tool-call-delta', id: 'call_1', argumentsFragment: '{}' },
+        { type: 'tool-call-end', id: 'call_1' },
+      ],
+      [{ type: 'text', content: 'grant done' }],
+    ]);
+    let approvalCount = 0;
+    const toolResults: string[] = [];
+
+    try {
+      const answer = await runAgent('use persisted mcp', provider, {
+        permissionMode: 'ask',
+        autonomy: 'medium',
+        mcpPermissionStore: permissionStore,
+        onToolApproval: () => {
+          approvalCount++;
+          return 'deny';
+        },
+        onToolResult: (result) => toolResults.push(result.result),
+      });
+
+      expect(answer).toBe('grant done');
+      expect(approvalCount).toBe(0);
+      expect(toolResults[0]).toBe('persisted mcp ok');
+    } finally {
+      toolRegistry.unregister(toolName);
+    }
   });
 
   it('serializes multiple prompt-gated approvals from the same assistant turn', async () => {

--- a/tests/zero-mcp-client.test.ts
+++ b/tests/zero-mcp-client.test.ts
@@ -292,6 +292,11 @@ describe('Zero MCP client backend', () => {
     await expect(registerZeroMcpTools(registry, manager)).rejects.toThrow(
       'Duplicate MCP tool registry name'
     );
+    expect(registry.get(createZeroMcpToolName(
+      'docs',
+      'dddddddddddddddddddddddddddddddd',
+      'lookup'
+    ))).toBeUndefined();
   });
 
   it('lists configured MCP servers and discovered tools from the CLI', async () => {

--- a/tests/zero-mcp-permissions.test.ts
+++ b/tests/zero-mcp-permissions.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  ZeroMcpPermissionStore,
+  type ZeroMcpPermissionAutonomy,
+} from '../src/zero-mcp';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'zero-mcp-permissions-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function makeStore(): Promise<{
+  dir: string;
+  permissionPath: string;
+  store: ZeroMcpPermissionStore;
+}> {
+  const dir = await makeTempDir();
+  const permissionPath = join(dir, 'mcp-permissions.json');
+  const store = new ZeroMcpPermissionStore({
+    filePath: permissionPath,
+    now: () => new Date('2026-06-03T09:30:00.000Z'),
+  });
+  return { dir, permissionPath, store };
+}
+
+async function runZeroMcpPermissions(
+  cwd: string,
+  args: string[],
+  permissionPath: string
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn(
+    [process.execPath, join(process.cwd(), 'src/index.ts'), 'mcp', 'permissions', ...args],
+    {
+      cwd,
+      env: {
+        ...process.env,
+        HOME: join(cwd, 'home'),
+        USERPROFILE: join(cwd, 'home'),
+        ZERO_MCP_PERMISSIONS_PATH: permissionPath,
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    }
+  );
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('Zero MCP permission store', () => {
+  it('persists identity-aware tool grants and enforces the autonomy ceiling', async () => {
+    const { permissionPath, store } = await makeStore();
+
+    await store.grantTool({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'lookup',
+      maxAutonomy: 'medium',
+    });
+
+    expect(await Bun.file(permissionPath).exists()).toBe(true);
+    expect(await store.isToolPersistentlyApproved({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'lookup',
+      requestedAutonomy: 'medium',
+    })).toBe(true);
+    expect(await store.isToolPersistentlyApproved({
+      serverName: 'docs',
+      serverIdentity: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      toolName: 'lookup',
+      requestedAutonomy: 'medium',
+    })).toBe(false);
+    expect(await store.isToolPersistentlyApproved({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'lookup',
+      requestedAutonomy: 'high',
+    })).toBe(false);
+  });
+
+  it('allows server grants to cover tools and server revocation to cascade', async () => {
+    const { store } = await makeStore();
+
+    await store.grantServer({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      maxAutonomy: 'high',
+    });
+    await store.grantTool({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'lookup',
+      maxAutonomy: 'low',
+    });
+    await store.grantTool({
+      serverName: 'other',
+      serverIdentity: 'cccccccccccccccccccccccccccccccc',
+      toolName: 'search',
+      maxAutonomy: 'low',
+    });
+
+    expect(await store.isToolPersistentlyApproved({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'write',
+      requestedAutonomy: 'high',
+    })).toBe(true);
+
+    const revoked = await store.revokeServer('docs');
+
+    expect(revoked).toBe(2);
+    expect(await store.list()).toEqual([
+      expect.objectContaining({
+        scope: 'tool',
+        serverName: 'other',
+        toolName: 'search',
+      }),
+    ]);
+  });
+
+  it('lists grants in stable server/tool order and clears them', async () => {
+    const { store } = await makeStore();
+
+    await store.grantTool({
+      serverName: 'zeta',
+      serverIdentity: 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
+      toolName: 'lookup',
+      maxAutonomy: 'low',
+    });
+    await store.grantServer({
+      serverName: 'alpha',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      maxAutonomy: 'medium',
+    });
+
+    expect(await store.list()).toEqual([
+      expect.objectContaining({ scope: 'server', serverName: 'alpha' }),
+      expect.objectContaining({ scope: 'tool', serverName: 'zeta', toolName: 'lookup' }),
+    ]);
+
+    expect(await store.clear()).toBe(2);
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('rejects invalid autonomy values before writing a grant', async () => {
+    const { store } = await makeStore();
+
+    await expect(store.grantServer({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      maxAutonomy: 'urgent' as ZeroMcpPermissionAutonomy,
+    })).rejects.toThrow('Invalid MCP permission autonomy');
+
+    expect(await store.list()).toEqual([]);
+  });
+});
+
+describe('zero mcp permissions CLI', () => {
+  it('lists and revokes MCP grants as JSON', async () => {
+    const { dir, permissionPath, store } = await makeStore();
+    await mkdir(join(dir, '.zero'), { recursive: true });
+    await store.grantServer({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      maxAutonomy: 'medium',
+    });
+    await store.grantTool({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      toolName: 'lookup',
+      maxAutonomy: 'low',
+    });
+
+    const listResult = await runZeroMcpPermissions(dir, ['list', '--json'], permissionPath);
+
+    expect(listResult.exitCode).toBe(0);
+    expect(listResult.stderr.trim()).toBe('');
+    expect(JSON.parse(listResult.stdout).permissions).toEqual([
+      expect.objectContaining({
+        scope: 'server',
+        serverName: 'docs',
+        maxAutonomy: 'medium',
+      }),
+      expect.objectContaining({
+        scope: 'tool',
+        serverName: 'docs',
+        toolName: 'lookup',
+        maxAutonomy: 'low',
+      }),
+    ]);
+
+    const revokeToolResult = await runZeroMcpPermissions(
+      dir,
+      ['revoke', 'docs', 'lookup', '--json'],
+      permissionPath
+    );
+
+    expect(revokeToolResult.exitCode).toBe(0);
+    expect(revokeToolResult.stderr.trim()).toBe('');
+    expect(JSON.parse(revokeToolResult.stdout)).toEqual({
+      revoked: 1,
+      scope: 'tool',
+      serverName: 'docs',
+      toolName: 'lookup',
+    });
+
+    const revokeServerResult = await runZeroMcpPermissions(
+      dir,
+      ['revoke', 'docs', '--json'],
+      permissionPath
+    );
+
+    expect(revokeServerResult.exitCode).toBe(0);
+    expect(revokeServerResult.stderr.trim()).toBe('');
+    expect(JSON.parse(revokeServerResult.stdout)).toEqual({
+      revoked: 1,
+      scope: 'server',
+      serverName: 'docs',
+    });
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('requires confirmation before clearing all MCP grants', async () => {
+    const { dir, permissionPath, store } = await makeStore();
+    await store.grantServer({
+      serverName: 'docs',
+      serverIdentity: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      maxAutonomy: 'medium',
+    });
+
+    const denied = await runZeroMcpPermissions(dir, ['clear', '--json'], permissionPath);
+
+    expect(denied.exitCode).toBe(1);
+    expect(denied.stderr).toContain('--confirm');
+    expect(await store.list()).toHaveLength(1);
+
+    const cleared = await runZeroMcpPermissions(dir, ['clear', '--confirm', '--json'], permissionPath);
+
+    expect(cleared.exitCode).toBe(0);
+    expect(cleared.stderr.trim()).toBe('');
+    expect(JSON.parse(cleared.stdout)).toEqual({ cleared: 1 });
+    expect(await store.list()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the M4 MCP permissions backend so Zero can persist trusted MCP server/tool grants and manage them from the CLI.

## What changed

- Added `ZeroMcpPermissionStore` for durable per-server and per-tool MCP grants.
- Enforced server identity matching so stale grants do not apply after a server transport changes.
- Added autonomy ceilings (`low`, `medium`, `high`) for persistent approvals.
- Added `zero mcp permissions list`, `revoke`, and `clear` CLI commands with JSON output support.
- Wired MCP tool metadata into the agent loop so matching persistent grants can skip repeated ask-mode prompts.
- Kept one-time session approval grants separate from persistent MCP grants.
- Made MCP registry registration atomic when duplicate generated tool names are detected.
- Preserved custom tool JSON schemas while preparing provider tool definitions.

## Validation

- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000` (`253 pass`, `0 fail`)
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero mcp --help`
- `./zero mcp permissions --help`
- `ZERO_MCP_PERMISSIONS_PATH=/tmp/zero-mcp-permissions-pr-smoke.json ./zero mcp permissions list --json`
- `git diff --check HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manage persistent MCP permission grants via new `zero mcp permissions` CLI commands: list permissions, revoke server or tool grants, and clear all approvals.
  * Control MCP tool execution through autonomy level settings (low, medium, high).

* **Bug Fixes**
  * Fixed JSON schema object mutations during tool definition preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->