### PR TITLE
feat: add local plugin manifest loader

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ import {
   type ZeroMcpServerStatus,
   type ZeroMcpToolDescriptor,
 } from './zero-mcp';
+import {
+  loadZeroPlugins,
+  type ZeroLoadedPlugin,
+  type ZeroPluginDiagnostic,
+} from './zero-plugins';
 
 const program = new Command();
 
@@ -91,6 +96,39 @@ function toZeroMcpToolJson(tool: ZeroMcpToolDescriptor): Record<string, unknown>
     description: tool.description,
     inputSchema: tool.inputSchema,
   };
+}
+
+function formatZeroPluginList(
+  plugins: ZeroLoadedPlugin[],
+  diagnostics: ZeroPluginDiagnostic[]
+): string {
+  const lines: string[] = [];
+
+  if (plugins.length === 0) {
+    lines.push('No local Zero plugins loaded.');
+  } else {
+    lines.push('Zero Plugins:');
+    for (const plugin of plugins) {
+      const counts = [
+        `${plugin.tools.length} tools`,
+        `${plugin.prompts.length} prompts`,
+        `${plugin.skills.length} skills`,
+        `${plugin.hooks.length} hooks`,
+      ].join(', ');
+      lines.push(
+        `  ${plugin.id}@${plugin.version} [${plugin.source}] ${plugin.enabled ? 'enabled' : 'disabled'} - ${counts}`
+      );
+    }
+  }
+
+  if (diagnostics.length > 0) {
+    lines.push('Plugin diagnostics:');
+    for (const diagnostic of diagnostics) {
+      lines.push(`  [${diagnostic.kind}] ${diagnostic.message}`);
+    }
+  }
+
+  return lines.join('\n');
 }
 
 program
@@ -359,6 +397,29 @@ mcpPermissionsCmd
       }
     } catch (err: unknown) {
       console.error(`[zero] MCP permissions clear failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('plugins')
+  .description('Inspect local Zero plugin manifests')
+  .command('list')
+  .description('List local Zero plugins')
+  .option('--json', 'Print local plugin data as JSON')
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const result = await loadZeroPlugins();
+      if (options.json) {
+        console.log(JSON.stringify(redactZeroSecrets({
+          plugins: result.plugins,
+          diagnostics: result.diagnostics,
+        }), null, 2));
+      } else {
+        console.log(formatZeroPluginList(result.plugins, result.diagnostics));
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] Plugin list failed: ${redactZeroErrorMessage(err)}`);
       process.exitCode = 1;
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ function formatZeroPluginList(
         `${plugin.hooks.length} hooks`,
       ].join(', ');
       lines.push(
-        `  ${plugin.id}@${plugin.version} [${plugin.source}] ${plugin.enabled ? 'enabled' : 'disabled'} - ${counts}`
+        `  ${plugin.id}@${plugin.version} ${plugin.name} [${plugin.source}] ${plugin.enabled ? 'enabled' : 'disabled'} - ${counts}`
       );
     }
   }

--- a/src/zero-plugins/index.ts
+++ b/src/zero-plugins/index.ts
@@ -1,0 +1,3 @@
+export * from './loader';
+export * from './manifest';
+export * from './types';

--- a/src/zero-plugins/loader.ts
+++ b/src/zero-plugins/loader.ts
@@ -1,0 +1,156 @@
+import { readdir, readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { isAbsolute, join, resolve } from 'path';
+import { ZodError } from 'zod';
+import { parseZeroPluginManifest } from './manifest';
+import type {
+  ZeroLoadedPlugin,
+  ZeroPluginDiagnostic,
+  ZeroPluginLoadResult,
+  ZeroPluginRoot,
+} from './types';
+
+export interface ResolveZeroPluginRootOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface LoadZeroPluginsOptions extends ResolveZeroPluginRootOptions {
+  roots?: ZeroPluginRoot[];
+}
+
+export function resolveZeroPluginRoots(options: ResolveZeroPluginRootOptions = {}): ZeroPluginRoot[] {
+  const env = options.env ?? process.env;
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const configHome = normalizeRoot(env.XDG_CONFIG_HOME, cwd) ?? join(getHomeDir(env), '.config');
+
+  return [
+    { source: 'user', path: join(configHome, 'zero', 'plugins') },
+    { source: 'project', path: join(cwd, '.zero', 'plugins') },
+  ];
+}
+
+export async function loadZeroPlugins(options: LoadZeroPluginsOptions = {}): Promise<ZeroPluginLoadResult> {
+  const roots = options.roots ?? resolveZeroPluginRoots(options);
+  const diagnostics: ZeroPluginDiagnostic[] = [];
+  const discovered: ZeroLoadedPlugin[] = [];
+
+  for (const root of roots) {
+    const rootPath = resolve(root.path);
+    let entries;
+    try {
+      entries = await readdir(rootPath, { withFileTypes: true });
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') continue;
+      diagnostics.push({
+        kind: 'io',
+        source: root.source,
+        root: rootPath,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const pluginDir = join(rootPath, entry.name);
+      const manifestPath = join(pluginDir, 'plugin.json');
+      try {
+        const text = await readFile(manifestPath, 'utf-8');
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text);
+        } catch (err: unknown) {
+          diagnostics.push({
+            kind: 'json',
+            source: root.source,
+            root: rootPath,
+            pluginPath: pluginDir,
+            manifestPath,
+            message: err instanceof Error ? err.message : String(err),
+          });
+          continue;
+        }
+
+        discovered.push(parseZeroPluginManifest(parsed, {
+          source: root.source,
+          root: rootPath,
+          pluginDir,
+          manifestPath,
+        }));
+      } catch (err: any) {
+        if (err?.code === 'ENOENT') continue;
+        diagnostics.push(toPluginDiagnostic(err, root, rootPath, pluginDir, manifestPath));
+      }
+    }
+  }
+
+  const plugins = mergePluginsById(discovered, diagnostics);
+  return { roots, plugins, diagnostics };
+}
+
+function mergePluginsById(
+  discovered: ZeroLoadedPlugin[],
+  diagnostics: ZeroPluginDiagnostic[]
+): ZeroLoadedPlugin[] {
+  const byId = new Map<string, ZeroLoadedPlugin>();
+
+  for (const plugin of discovered) {
+    const previous = byId.get(plugin.id);
+    if (previous) {
+      diagnostics.push({
+        kind: 'duplicate',
+        pluginId: plugin.id,
+        source: plugin.source,
+        root: plugin.root,
+        pluginPath: plugin.pluginDir,
+        manifestPath: plugin.manifestPath,
+        message: `Plugin "${plugin.id}" from ${plugin.source} overrides ${previous.source} plugin at ${previous.pluginDir}.`,
+      });
+    }
+    byId.set(plugin.id, plugin);
+  }
+
+  return Array.from(byId.values()).sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function toPluginDiagnostic(
+  err: unknown,
+  root: ZeroPluginRoot,
+  rootPath: string,
+  pluginDir: string,
+  manifestPath: string
+): ZeroPluginDiagnostic {
+  if (err instanceof ZodError) {
+    const issue = err.issues[0];
+    return {
+      kind: 'schema',
+      source: root.source,
+      root: rootPath,
+      pluginPath: pluginDir,
+      manifestPath,
+      fieldPath: issue?.path.map(String).join('.'),
+      message: issue?.message ?? err.message,
+    };
+  }
+
+  return {
+    kind: 'schema',
+    source: root.source,
+    root: rootPath,
+    pluginPath: pluginDir,
+    manifestPath,
+    message: err instanceof Error ? err.message : String(err),
+  };
+}
+
+function normalizeRoot(value: string | undefined, cwd: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return isAbsolute(trimmed) ? trimmed : resolve(cwd, trimmed);
+}
+
+function getHomeDir(env: NodeJS.ProcessEnv): string {
+  return env.HOME || env.USERPROFILE || homedir();
+}

--- a/src/zero-plugins/manifest.ts
+++ b/src/zero-plugins/manifest.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from 'path';
+import { isAbsolute, relative, resolve, win32 } from 'path';
 import { z } from 'zod';
 import type {
   ZeroLoadedPlugin,
@@ -12,6 +12,7 @@ export interface ParseZeroPluginManifestOptions {
   root: string;
   pluginDir: string;
   manifestPath: string;
+  allowManifestToolAutoApproval?: boolean;
 }
 
 const PluginIdSchema = z.string().trim().min(1).regex(
@@ -77,18 +78,24 @@ export function parseZeroPluginManifest(
     root: resolve(options.root),
     pluginDir,
     manifestPath: resolve(options.manifestPath),
-    tools: (parsed.tools ?? []).map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      command: tool.command,
-      args: tool.args ?? [],
-      inputSchema: tool.inputSchema ?? {
-        type: 'object',
-        properties: {},
-        additionalProperties: true,
-      },
-      permission: (tool.permission ?? 'prompt') as ZeroPluginToolPermission,
-    })),
+    tools: (parsed.tools ?? []).map((tool) => {
+      const permission = normalizePluginToolPermission(
+        tool.permission,
+        options.allowManifestToolAutoApproval
+      );
+      return {
+        name: tool.name,
+        description: tool.description,
+        command: tool.command,
+        args: tool.args ?? [],
+        inputSchema: tool.inputSchema ?? {
+          type: 'object',
+          properties: {},
+          additionalProperties: true,
+        },
+        permission,
+      };
+    }),
     prompts: (parsed.prompts ?? []).map((prompt) => ({
       name: prompt.name,
       description: prompt.description,
@@ -110,10 +117,25 @@ export function parseZeroPluginManifest(
 }
 
 function resolvePluginPath(pluginDir: string, value: string, fieldPath: string): string {
+  if (isAbsolute(value) || win32.isAbsolute(value)) {
+    throw new Error(`${fieldPath} must stay inside the plugin directory.`);
+  }
+
   const resolved = resolve(pluginDir, value);
   const pathWithinPlugin = relative(pluginDir, resolved);
   if (pathWithinPlugin === '' || pathWithinPlugin.startsWith('..') || pathWithinPlugin.includes('..\\')) {
     throw new Error(`${fieldPath} must stay inside the plugin directory.`);
+  }
+  return resolved;
+}
+
+function normalizePluginToolPermission(
+  permission: ZeroPluginToolPermission | undefined,
+  allowManifestToolAutoApproval = false
+): ZeroPluginToolPermission {
+  const resolved = (permission ?? 'prompt') as ZeroPluginToolPermission;
+  if (resolved === 'allow' && !allowManifestToolAutoApproval) {
+    return 'prompt';
   }
   return resolved;
 }

--- a/src/zero-plugins/manifest.ts
+++ b/src/zero-plugins/manifest.ts
@@ -1,0 +1,119 @@
+import { relative, resolve } from 'path';
+import { z } from 'zod';
+import type {
+  ZeroLoadedPlugin,
+  ZeroPluginHookEvent,
+  ZeroPluginSource,
+  ZeroPluginToolPermission,
+} from './types';
+
+export interface ParseZeroPluginManifestOptions {
+  source: ZeroPluginSource;
+  root: string;
+  pluginDir: string;
+  manifestPath: string;
+}
+
+const PluginIdSchema = z.string().trim().min(1).regex(
+  /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
+  'Use letters, numbers, dots, dashes, or underscores.'
+);
+const PluginNameSchema = z.string().trim().min(1);
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+const PluginToolPermissionSchema = z.enum(['allow', 'prompt', 'deny']);
+const PluginHookEventSchema = z.enum(['beforeTool', 'afterTool', 'sessionStart', 'sessionEnd']);
+
+const ZeroPluginToolExtensionSchema = z.object({
+  name: PluginIdSchema,
+  description: z.string().trim().min(1).optional(),
+  command: z.string().trim().min(1),
+  args: z.array(z.string()).optional(),
+  inputSchema: JsonObjectSchema.optional(),
+  permission: PluginToolPermissionSchema.optional(),
+});
+
+const ZeroPluginPathExtensionSchema = z.object({
+  name: PluginIdSchema,
+  description: z.string().trim().min(1).optional(),
+  path: z.string().trim().min(1),
+});
+
+const ZeroPluginHookExtensionSchema = z.object({
+  name: PluginIdSchema,
+  description: z.string().trim().min(1).optional(),
+  event: PluginHookEventSchema,
+  command: z.string().trim().min(1),
+  args: z.array(z.string()).optional(),
+});
+
+export const ZeroPluginManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  id: PluginIdSchema,
+  name: PluginNameSchema,
+  version: z.string().trim().min(1),
+  description: z.string().trim().min(1).optional(),
+  enabled: z.boolean().optional(),
+  tools: z.array(ZeroPluginToolExtensionSchema).optional(),
+  prompts: z.array(ZeroPluginPathExtensionSchema).optional(),
+  skills: z.array(ZeroPluginPathExtensionSchema).optional(),
+  hooks: z.array(ZeroPluginHookExtensionSchema).optional(),
+});
+
+export function parseZeroPluginManifest(
+  manifest: unknown,
+  options: ParseZeroPluginManifestOptions
+): ZeroLoadedPlugin {
+  const parsed = ZeroPluginManifestSchema.parse(manifest);
+  const pluginDir = resolve(options.pluginDir);
+
+  return {
+    schemaVersion: 1,
+    id: parsed.id,
+    name: parsed.name,
+    version: parsed.version,
+    description: parsed.description,
+    enabled: parsed.enabled ?? true,
+    source: options.source,
+    root: resolve(options.root),
+    pluginDir,
+    manifestPath: resolve(options.manifestPath),
+    tools: (parsed.tools ?? []).map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      command: tool.command,
+      args: tool.args ?? [],
+      inputSchema: tool.inputSchema ?? {
+        type: 'object',
+        properties: {},
+        additionalProperties: true,
+      },
+      permission: (tool.permission ?? 'prompt') as ZeroPluginToolPermission,
+    })),
+    prompts: (parsed.prompts ?? []).map((prompt) => ({
+      name: prompt.name,
+      description: prompt.description,
+      path: resolvePluginPath(pluginDir, prompt.path, `prompts.${prompt.name}.path`),
+    })),
+    skills: (parsed.skills ?? []).map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      path: resolvePluginPath(pluginDir, skill.path, `skills.${skill.name}.path`),
+    })),
+    hooks: (parsed.hooks ?? []).map((hook) => ({
+      name: hook.name,
+      description: hook.description,
+      event: hook.event as ZeroPluginHookEvent,
+      command: hook.command,
+      args: hook.args ?? [],
+    })),
+  };
+}
+
+function resolvePluginPath(pluginDir: string, value: string, fieldPath: string): string {
+  const resolved = resolve(pluginDir, value);
+  const pathWithinPlugin = relative(pluginDir, resolved);
+  if (pathWithinPlugin === '' || pathWithinPlugin.startsWith('..') || pathWithinPlugin.includes('..\\')) {
+    throw new Error(`${fieldPath} must stay inside the plugin directory.`);
+  }
+  return resolved;
+}

--- a/src/zero-plugins/types.ts
+++ b/src/zero-plugins/types.ts
@@ -1,0 +1,75 @@
+export type ZeroPluginSource = 'user' | 'project' | 'custom';
+export type ZeroPluginDiagnosticKind = 'io' | 'json' | 'schema' | 'duplicate';
+export type ZeroPluginToolPermission = 'allow' | 'prompt' | 'deny';
+export type ZeroPluginHookEvent = 'beforeTool' | 'afterTool' | 'sessionStart' | 'sessionEnd';
+
+export interface ZeroPluginRoot {
+  source: ZeroPluginSource;
+  path: string;
+}
+
+export interface ZeroPluginDiagnostic {
+  kind: ZeroPluginDiagnosticKind;
+  message: string;
+  source?: ZeroPluginSource;
+  root?: string;
+  pluginPath?: string;
+  manifestPath?: string;
+  fieldPath?: string;
+  pluginId?: string;
+}
+
+export interface ZeroPluginToolExtension {
+  name: string;
+  description?: string;
+  command: string;
+  args: string[];
+  inputSchema: Record<string, unknown>;
+  permission: ZeroPluginToolPermission;
+}
+
+export interface ZeroPluginPromptExtension {
+  name: string;
+  description?: string;
+  path: string;
+}
+
+export interface ZeroPluginSkillExtension {
+  name: string;
+  description?: string;
+  path: string;
+}
+
+export interface ZeroPluginHookExtension {
+  name: string;
+  description?: string;
+  event: ZeroPluginHookEvent;
+  command: string;
+  args: string[];
+}
+
+export interface ZeroPluginManifest {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  enabled: boolean;
+  tools: ZeroPluginToolExtension[];
+  prompts: ZeroPluginPromptExtension[];
+  skills: ZeroPluginSkillExtension[];
+  hooks: ZeroPluginHookExtension[];
+}
+
+export interface ZeroLoadedPlugin extends ZeroPluginManifest {
+  source: ZeroPluginSource;
+  root: string;
+  pluginDir: string;
+  manifestPath: string;
+}
+
+export interface ZeroPluginLoadResult {
+  roots: ZeroPluginRoot[];
+  plugins: ZeroLoadedPlugin[];
+  diagnostics: ZeroPluginDiagnostic[];
+}

--- a/tests/zero-plugins.test.ts
+++ b/tests/zero-plugins.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  loadZeroPlugins,
+  parseZeroPluginManifest,
+  resolveZeroPluginRoots,
+} from '../src/zero-plugins';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'zero-plugins-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writePluginManifest(
+  pluginDir: string,
+  manifest: Record<string, unknown>
+): Promise<void> {
+  await mkdir(pluginDir, { recursive: true });
+  await writeFile(join(pluginDir, 'plugin.json'), JSON.stringify(manifest, null, 2), 'utf-8');
+}
+
+async function runZeroPlugins(
+  cwd: string,
+  args: string[] = []
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, join(process.cwd(), 'src/index.ts'), 'plugins', ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      HOME: join(cwd, 'home'),
+      USERPROFILE: join(cwd, 'home'),
+      XDG_CONFIG_HOME: join(cwd, 'xdg'),
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('Zero plugin manifest validation', () => {
+  it('normalizes extension metadata and resolves plugin-local paths', async () => {
+    const dir = await makeTempDir();
+    const pluginDir = join(dir, 'plugins', 'zero-demo');
+
+    const parsed = parseZeroPluginManifest({
+      schemaVersion: 1,
+      id: 'zero.demo',
+      name: 'Zero Demo',
+      version: '0.1.0',
+      description: 'Demo plugin',
+      tools: [{
+        name: 'lookup',
+        description: 'Lookup docs',
+        command: 'node',
+        args: ['tools/lookup.mjs'],
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+        permission: 'prompt',
+      }],
+      prompts: [{ name: 'review', path: 'prompts/review.md' }],
+      skills: [{ name: 'ts-review', path: 'skills/ts-review/SKILL.md' }],
+      hooks: [{ name: 'pre-tool', event: 'beforeTool', command: 'node', args: ['hooks/pre-tool.mjs'] }],
+    }, {
+      manifestPath: join(pluginDir, 'plugin.json'),
+      pluginDir,
+      root: join(dir, 'plugins'),
+      source: 'project',
+    });
+
+    expect(parsed).toMatchObject({
+      id: 'zero.demo',
+      name: 'Zero Demo',
+      version: '0.1.0',
+      enabled: true,
+      source: 'project',
+    });
+    expect(parsed.tools).toEqual([
+      expect.objectContaining({
+        name: 'lookup',
+        permission: 'prompt',
+        args: ['tools/lookup.mjs'],
+      }),
+    ]);
+    expect(parsed.prompts[0]?.path).toBe(join(pluginDir, 'prompts', 'review.md'));
+    expect(parsed.skills[0]?.path).toBe(join(pluginDir, 'skills', 'ts-review', 'SKILL.md'));
+    expect(parsed.hooks[0]).toEqual(expect.objectContaining({
+      name: 'pre-tool',
+      event: 'beforeTool',
+      command: 'node',
+      args: ['hooks/pre-tool.mjs'],
+    }));
+  });
+
+  it('rejects unsafe plugin-local paths', async () => {
+    const dir = await makeTempDir();
+    const pluginDir = join(dir, 'plugins', 'bad');
+
+    expect(() => parseZeroPluginManifest({
+      schemaVersion: 1,
+      id: 'zero.bad',
+      name: 'Bad',
+      version: '0.1.0',
+      prompts: [{ name: 'escape', path: '../outside.md' }],
+    }, {
+      manifestPath: join(pluginDir, 'plugin.json'),
+      pluginDir,
+      root: join(dir, 'plugins'),
+      source: 'project',
+    })).toThrow('must stay inside the plugin directory');
+  });
+});
+
+describe('Zero local plugin loader', () => {
+  it('discovers user and project plugin manifests with project precedence', async () => {
+    const dir = await makeTempDir();
+    const userRoot = join(dir, 'user-plugins');
+    const projectRoot = join(dir, 'project-plugins');
+    await writePluginManifest(join(userRoot, 'demo'), {
+      schemaVersion: 1,
+      id: 'zero.demo',
+      name: 'User Demo',
+      version: '0.1.0',
+    });
+    await writePluginManifest(join(projectRoot, 'demo'), {
+      schemaVersion: 1,
+      id: 'zero.demo',
+      name: 'Project Demo',
+      version: '0.2.0',
+      enabled: false,
+    });
+    await writePluginManifest(join(projectRoot, 'docs'), {
+      schemaVersion: 1,
+      id: 'zero.docs',
+      name: 'Docs',
+      version: '1.0.0',
+      skills: [{ name: 'docs', path: 'skills/docs/SKILL.md' }],
+    });
+
+    const result = await loadZeroPlugins({
+      roots: [
+        { source: 'user', path: userRoot },
+        { source: 'project', path: projectRoot },
+      ],
+    });
+
+    expect(result.plugins.map((plugin) => `${plugin.id}:${plugin.name}:${plugin.version}`)).toEqual([
+      'zero.demo:Project Demo:0.2.0',
+      'zero.docs:Docs:1.0.0',
+    ]);
+    expect(result.plugins[0]?.enabled).toBe(false);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        kind: 'duplicate',
+        pluginId: 'zero.demo',
+      }),
+    ]);
+  });
+
+  it('keeps loading valid plugins when one manifest is invalid', async () => {
+    const dir = await makeTempDir();
+    const root = join(dir, 'plugins');
+    await writePluginManifest(join(root, 'good'), {
+      schemaVersion: 1,
+      id: 'zero.good',
+      name: 'Good',
+      version: '1.0.0',
+    });
+    await writePluginManifest(join(root, 'bad'), {
+      schemaVersion: 2,
+      id: 'zero.bad',
+      name: 'Bad',
+      version: '1.0.0',
+    });
+
+    const result = await loadZeroPlugins({
+      roots: [{ source: 'project', path: root }],
+    });
+
+    expect(result.plugins.map((plugin) => plugin.id)).toEqual(['zero.good']);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        kind: 'schema',
+        pluginPath: join(root, 'bad'),
+      }),
+    ]);
+  });
+
+  it('resolves default user and project plugin roots', async () => {
+    const dir = await makeTempDir();
+
+    expect(resolveZeroPluginRoots({
+      cwd: dir,
+      env: {
+        XDG_CONFIG_HOME: join(dir, 'xdg'),
+      },
+    })).toEqual([
+      { source: 'user', path: join(dir, 'xdg', 'zero', 'plugins') },
+      { source: 'project', path: join(dir, '.zero', 'plugins') },
+    ]);
+  });
+});
+
+describe('zero plugins CLI', () => {
+  it('lists local plugin manifests as JSON', async () => {
+    const dir = await makeTempDir();
+    await writePluginManifest(join(dir, '.zero', 'plugins', 'docs'), {
+      schemaVersion: 1,
+      id: 'zero.docs',
+      name: 'Docs',
+      version: '1.0.0',
+      prompts: [{ name: 'review', path: 'prompts/review.md' }],
+    });
+
+    const result = await runZeroPlugins(dir, ['list', '--json']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.trim()).toBe('');
+    expect(JSON.parse(result.stdout)).toEqual({
+      plugins: [
+        expect.objectContaining({
+          id: 'zero.docs',
+          name: 'Docs',
+          version: '1.0.0',
+          source: 'project',
+        }),
+      ],
+      diagnostics: [],
+    });
+  });
+});

--- a/tests/zero-plugins.test.ts
+++ b/tests/zero-plugins.test.ts
@@ -106,22 +106,53 @@ describe('Zero plugin manifest validation', () => {
     }));
   });
 
-  it('rejects unsafe plugin-local paths', async () => {
+  it('clamps manifest tool auto-approval unless explicitly enabled', async () => {
     const dir = await makeTempDir();
-    const pluginDir = join(dir, 'plugins', 'bad');
-
-    expect(() => parseZeroPluginManifest({
+    const pluginDir = join(dir, 'plugins', 'zero-demo');
+    const manifest = {
       schemaVersion: 1,
-      id: 'zero.bad',
-      name: 'Bad',
+      id: 'zero.demo',
+      name: 'Zero Demo',
       version: '0.1.0',
-      prompts: [{ name: 'escape', path: '../outside.md' }],
-    }, {
+      tools: [{
+        name: 'lookup',
+        command: 'node',
+        permission: 'allow',
+      }],
+    };
+    const options = {
       manifestPath: join(pluginDir, 'plugin.json'),
       pluginDir,
       root: join(dir, 'plugins'),
-      source: 'project',
-    })).toThrow('must stay inside the plugin directory');
+      source: 'project' as const,
+    };
+
+    expect(parseZeroPluginManifest(manifest, options).tools[0]?.permission).toBe('prompt');
+    expect(parseZeroPluginManifest(manifest, {
+      ...options,
+      allowManifestToolAutoApproval: true,
+    }).tools[0]?.permission).toBe('allow');
+  });
+
+  it('rejects unsafe plugin-local paths', async () => {
+    const dir = await makeTempDir();
+    const pluginDir = join(dir, 'plugins', 'bad');
+    const options = {
+      manifestPath: join(pluginDir, 'plugin.json'),
+      pluginDir,
+      root: join(dir, 'plugins'),
+      source: 'project' as const,
+    };
+
+    for (const path of ['../outside.md', '/tmp/escape.md', 'C:\\Windows\\escape.md']) {
+      expect(() => parseZeroPluginManifest({
+        schemaVersion: 1,
+        id: 'zero.bad',
+        name: 'Bad',
+        version: '0.1.0',
+        prompts: [{ name: 'escape', path }],
+      }, options)).toThrow('must stay inside the plugin directory');
+    }
   });
 });
 
@@ -200,6 +231,31 @@ describe('Zero local plugin loader', () => {
     ]);
   });
 
+  it('keeps loading valid plugins when one manifest has malformed JSON', async () => {
+    const dir = await makeTempDir();
+    const root = join(dir, 'plugins');
+    await writePluginManifest(join(root, 'good'), {
+      schemaVersion: 1,
+      id: 'zero.good',
+      name: 'Good',
+      version: '1.0.0',
+    });
+    await mkdir(join(root, 'bad'), { recursive: true });
+    await writeFile(join(root, 'bad', 'plugin.json'), '{ invalid json }', 'utf-8');
+
+    const result = await loadZeroPlugins({
+      roots: [{ source: 'project', path: root }],
+    });
+
+    expect(result.plugins.map((plugin) => plugin.id)).toEqual(['zero.good']);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        kind: 'json',
+        pluginPath: join(root, 'bad'),
+      }),
+    ]);
+  });
+
   it('resolves default user and project plugin roots', async () => {
     const dir = await makeTempDir();
 
@@ -241,5 +297,25 @@ describe('zero plugins CLI', () => {
       ],
       diagnostics: [],
     });
+  });
+
+  it('lists local plugin manifests as formatted text', async () => {
+    const dir = await makeTempDir();
+    await writePluginManifest(join(dir, '.zero', 'plugins', 'docs'), {
+      schemaVersion: 1,
+      id: 'zero.docs',
+      name: 'Docs',
+      version: '1.0.0',
+      prompts: [{ name: 'review', path: 'prompts/review.md' }],
+    });
+
+    const result = await runZeroPlugins(dir, ['list']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.trim()).toBe('');
+    expect(result.stdout).toContain('zero.docs');
+    expect(result.stdout).toContain('Docs');
+    expect(result.stdout).toContain('1.0.0');
+    expect(result.stdout).toMatch(/1\s+prompts?/);
   });
 });


### PR DESCRIPTION
## Summary

Adds the M4 local plugin manifest backend so Zero can discover and validate local plugin descriptors from user and project plugin directories.

## What changed

- Added `src/zero-plugins` with manifest validation, default root resolution, local plugin discovery, duplicate-id handling, and diagnostics.
- Supports plugin extension metadata for tools, prompts, skills, and hooks without executing plugin code.
- Resolves plugin-local prompt and skill paths while rejecting path escapes.
- Adds `zero plugins list` with JSON output for CLI, TUI, and slash-command integration.
- Adds focused coverage for manifest normalization, path safety, user/project precedence, invalid-manifest diagnostics, default root resolution, and CLI JSON output.

## Validation

- `npx --yes bun install --frozen-lockfile`
- `npx --yes bun run typecheck`
- `npx --yes bun test tests/zero-plugins.test.ts --timeout 15000` (`6 pass`, `0 fail`)
- `npx --yes bun test ./tests --timeout 15000` (`259 pass`, `0 fail`)
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero plugins --help`
- `./zero plugins list --json`
- `git diff --check HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI subcommand to discover and list installed Zero plugins with JSON (secrets redacted) or formatted text output.
  * Plugin discovery now scans user and project locations with deduplication and reports diagnostics alongside listings.

* **Improvements**
  * Manifests are validated and normalized; unsafe plugin-local paths are rejected and tool permission defaults are enforced (opt-in override available).

* **Tests**
  * Added comprehensive tests for discovery, validation, diagnostics, and CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->