### PR TITLE
feat: add Zero hook backend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ import { formatZeroDoctorReport, runZeroDoctor, type ZeroDoctorReport } from './
 import { redactZeroErrorMessage, redactZeroSecrets } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
 import {
+  formatZeroHookList,
+  loadZeroHooksConfig,
+} from './zero-hooks';
+import {
   ZeroMcpClientManager,
   ZeroMcpPermissionStore,
   createZeroMcpToolName,
@@ -420,6 +424,29 @@ program
       }
     } catch (err: unknown) {
       console.error(`[zero] Plugin list failed: ${redactZeroErrorMessage(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('hooks')
+  .description('Inspect Zero hook configuration and audit data')
+  .command('list')
+  .description('List configured Zero hooks')
+  .option('--json', 'Print hook config as JSON')
+  .action(async (options: { json?: boolean }) => {
+    try {
+      const result = await loadZeroHooksConfig();
+      if (options.json) {
+        console.log(JSON.stringify(redactZeroSecrets({
+          hooks: result.config,
+          diagnostics: result.diagnostics,
+        }), null, 2));
+      } else {
+        console.log(formatZeroHookList(result.config, result.diagnostics));
+      }
+    } catch (err: unknown) {
+      console.error(`[zero] Hook list failed: ${redactZeroErrorMessage(err)}`);
       process.exitCode = 1;
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   type ZeroConfigInspectionReport,
 } from './zero-config-inspection';
 import { formatZeroDoctorReport, runZeroDoctor, type ZeroDoctorReport } from './zero-doctor';
-import { redactZeroErrorMessage, redactZeroSecrets } from './zero-redaction';
+import { redactZeroErrorMessage, redactZeroSecrets, redactZeroString } from './zero-redaction';
 import { formatZeroSearchResult, searchZeroSessions } from './zero-search';
 import {
   formatZeroHookList,
@@ -443,7 +443,7 @@ program
           diagnostics: result.diagnostics,
         }), null, 2));
       } else {
-        console.log(formatZeroHookList(result.config, result.diagnostics));
+        console.log(redactZeroString(formatZeroHookList(result.config, result.diagnostics)));
       }
     } catch (err: unknown) {
       console.error(`[zero] Hook list failed: ${redactZeroErrorMessage(err)}`);

--- a/src/zero-hooks/audit.ts
+++ b/src/zero-hooks/audit.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir, readFile } from 'fs/promises';
 import { dirname, resolve } from 'path';
+import { redactZeroString } from '../zero-redaction';
 import { resolveZeroHookPaths } from './config';
 import type {
   AppendZeroHookCompletedInput,
@@ -17,6 +18,7 @@ export interface ZeroHookAuditStoreOptions {
 export class ZeroHookAuditStore {
   private readonly auditPath: string;
   private readonly now: () => Date;
+  private appendQueue: Promise<unknown> = Promise.resolve();
 
   constructor(options: ZeroHookAuditStoreOptions = {}) {
     this.auditPath = resolve(options.auditPath ?? resolveZeroHookPaths().auditPath);
@@ -55,7 +57,7 @@ export class ZeroHookAuditStore {
       try {
         events.push(JSON.parse(line) as ZeroHookAuditEvent);
       } catch {
-        throw new Error(`Invalid JSON in Zero hook audit at line ${index + 1}`);
+        console.warn(`[zero] Ignoring malformed hook audit line ${index + 1}: ${redactZeroString(line)}`);
       }
     }
     return events;
@@ -64,15 +66,22 @@ export class ZeroHookAuditStore {
   private async append<T extends Omit<ZeroHookAuditEvent, 'sequence' | 'createdAt'>>(
     input: T
   ): Promise<T & { sequence: number; createdAt: string }> {
-    const sequence = (await this.readEvents()).length + 1;
-    const event = {
-      sequence,
-      createdAt: this.now().toISOString(),
-      ...input,
+    const run = async (): Promise<T & { sequence: number; createdAt: string }> => {
+      const events = await this.readEvents();
+      const sequence = events.reduce((highest, event) => Math.max(highest, event.sequence), 0) + 1;
+      const event = {
+        sequence,
+        createdAt: this.now().toISOString(),
+        ...input,
+      };
+
+      await mkdir(dirname(this.auditPath), { recursive: true });
+      await appendFile(this.auditPath, `${JSON.stringify(event)}\n`, 'utf-8');
+      return event;
     };
 
-    await mkdir(dirname(this.auditPath), { recursive: true });
-    await appendFile(this.auditPath, `${JSON.stringify(event)}\n`, 'utf-8');
-    return event;
+    const next = this.appendQueue.then(run, run);
+    this.appendQueue = next.then(() => undefined, () => undefined);
+    return await next;
   }
 }

--- a/src/zero-hooks/audit.ts
+++ b/src/zero-hooks/audit.ts
@@ -1,0 +1,78 @@
+import { appendFile, mkdir, readFile } from 'fs/promises';
+import { dirname, resolve } from 'path';
+import { resolveZeroHookPaths } from './config';
+import type {
+  AppendZeroHookCompletedInput,
+  AppendZeroHookStartedInput,
+  ZeroHookAuditEvent,
+  ZeroHookExecutionCompletedAudit,
+  ZeroHookExecutionStartedAudit,
+} from './types';
+
+export interface ZeroHookAuditStoreOptions {
+  auditPath?: string;
+  now?: () => Date;
+}
+
+export class ZeroHookAuditStore {
+  private readonly auditPath: string;
+  private readonly now: () => Date;
+
+  constructor(options: ZeroHookAuditStoreOptions = {}) {
+    this.auditPath = resolve(options.auditPath ?? resolveZeroHookPaths().auditPath);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async appendStarted(input: AppendZeroHookStartedInput): Promise<ZeroHookExecutionStartedAudit> {
+    return await this.append({
+      type: 'hook_execution_started',
+      ...input,
+    });
+  }
+
+  async appendCompleted(input: AppendZeroHookCompletedInput): Promise<ZeroHookExecutionCompletedAudit> {
+    return await this.append({
+      type: 'hook_execution_completed',
+      ...input,
+    });
+  }
+
+  async readEvents(): Promise<ZeroHookAuditEvent[]> {
+    let content: string;
+    try {
+      content = await readFile(this.auditPath, 'utf-8');
+    } catch (err: any) {
+      if (err?.code === 'ENOENT') return [];
+      throw err;
+    }
+
+    const events: ZeroHookAuditEvent[] = [];
+    const lines = content.split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index]?.trim();
+      if (!line) continue;
+
+      try {
+        events.push(JSON.parse(line) as ZeroHookAuditEvent);
+      } catch {
+        throw new Error(`Invalid JSON in Zero hook audit at line ${index + 1}`);
+      }
+    }
+    return events;
+  }
+
+  private async append<T extends Omit<ZeroHookAuditEvent, 'sequence' | 'createdAt'>>(
+    input: T
+  ): Promise<T & { sequence: number; createdAt: string }> {
+    const sequence = (await this.readEvents()).length + 1;
+    const event = {
+      sequence,
+      createdAt: this.now().toISOString(),
+      ...input,
+    };
+
+    await mkdir(dirname(this.auditPath), { recursive: true });
+    await appendFile(this.auditPath, `${JSON.stringify(event)}\n`, 'utf-8');
+    return event;
+  }
+}

--- a/src/zero-hooks/config.ts
+++ b/src/zero-hooks/config.ts
@@ -19,6 +19,8 @@ const HookIdSchema = z.string().trim().min(1).regex(
 );
 const HookEventSchema = z.enum(['beforeTool', 'afterTool', 'sessionStart', 'sessionEnd']);
 
+const SESSION_HOOK_EVENTS = new Set(['sessionStart', 'sessionEnd']);
+
 const HookDefinitionSchema = z.object({
   id: HookIdSchema,
   name: z.string().trim().min(1).optional(),
@@ -28,6 +30,14 @@ const HookDefinitionSchema = z.object({
   matcher: z.string().trim().min(1).optional(),
   command: z.string().trim().min(1),
   args: z.array(z.string()).optional(),
+}).superRefine((hook, ctx) => {
+  if (hook.matcher && SESSION_HOOK_EVENTS.has(hook.event)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['matcher'],
+      message: 'matcher is only supported for beforeTool and afterTool hooks.',
+    });
+  }
 });
 
 const HooksConfigSchema = z.object({
@@ -107,6 +117,7 @@ export async function writeZeroHooksConfig(path: string, config: Partial<ZeroHoo
 }
 
 export class ZeroHookConfigStore {
+  private static readonly mutationQueues = new Map<string, Promise<void>>();
   private readonly configPath: string;
 
   constructor(options: ZeroHookConfigStoreOptions = {}) {
@@ -122,42 +133,68 @@ export class ZeroHookConfigStore {
   }
 
   async upsert(hook: Omit<ZeroHookDefinition, 'enabled'> & { enabled?: boolean }): Promise<ZeroHookDefinition> {
-    const config = await this.list();
-    const normalized = normalizeHookDefinition(hook);
-    const nextHooks = config.hooks.filter((existing) => existing.id !== normalized.id);
-    nextHooks.push(normalized);
-    await writeZeroHooksConfig(this.configPath, {
-      enabled: config.enabled,
-      hooks: nextHooks,
+    return await this.withMutationLock(async () => {
+      const config = await this.list();
+      const normalized = normalizeHookDefinition(hook);
+      const nextHooks = config.hooks.filter((existing) => existing.id !== normalized.id);
+      nextHooks.push(normalized);
+      await writeZeroHooksConfig(this.configPath, {
+        enabled: config.enabled,
+        hooks: nextHooks,
+      });
+      return normalized;
     });
-    return normalized;
   }
 
   async remove(hookId: string): Promise<boolean> {
-    const config = await this.list();
-    const nextHooks = config.hooks.filter((hook) => hook.id !== hookId);
-    if (nextHooks.length === config.hooks.length) return false;
-    await writeZeroHooksConfig(this.configPath, {
-      enabled: config.enabled,
-      hooks: nextHooks,
+    return await this.withMutationLock(async () => {
+      const config = await this.list();
+      const nextHooks = config.hooks.filter((hook) => hook.id !== hookId);
+      if (nextHooks.length === config.hooks.length) return false;
+      await writeZeroHooksConfig(this.configPath, {
+        enabled: config.enabled,
+        hooks: nextHooks,
+      });
+      return true;
     });
-    return true;
   }
 
   async setEnabled(hookId: string, enabled: boolean): Promise<boolean> {
-    const config = await this.list();
-    let changed = false;
-    const nextHooks = config.hooks.map((hook) => {
-      if (hook.id !== hookId) return hook;
-      changed = true;
-      return { ...hook, enabled };
+    return await this.withMutationLock(async () => {
+      const config = await this.list();
+      let changed = false;
+      const nextHooks = config.hooks.map((hook) => {
+        if (hook.id !== hookId) return hook;
+        changed = true;
+        return { ...hook, enabled };
+      });
+      if (!changed) return false;
+      await writeZeroHooksConfig(this.configPath, {
+        enabled: config.enabled,
+        hooks: nextHooks,
+      });
+      return true;
     });
-    if (!changed) return false;
-    await writeZeroHooksConfig(this.configPath, {
-      enabled: config.enabled,
-      hooks: nextHooks,
+  }
+
+  private async withMutationLock<T>(fn: () => Promise<T>): Promise<T> {
+    const previous = ZeroHookConfigStore.mutationQueues.get(this.configPath) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolveCurrent) => {
+      release = resolveCurrent;
     });
-    return true;
+    const next = previous.then(() => current, () => current);
+    ZeroHookConfigStore.mutationQueues.set(this.configPath, next);
+
+    await previous.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (ZeroHookConfigStore.mutationQueues.get(this.configPath) === next) {
+        ZeroHookConfigStore.mutationQueues.delete(this.configPath);
+      }
+    }
   }
 }
 
@@ -278,9 +315,7 @@ function normalizeHooksConfig(value: unknown): ZeroHooksConfig {
   };
 }
 
-function normalizeHookDefinition(
-  value: z.infer<typeof HookDefinitionSchema>
-): ZeroHookDefinition {
+function normalizeHookDefinition(value: z.input<typeof HookDefinitionSchema>): ZeroHookDefinition {
   const parsed = HookDefinitionSchema.parse(value);
   return {
     id: parsed.id,
@@ -298,11 +333,30 @@ function matchesHookMatcher(matcher: string, toolName: string): boolean {
   if (matcher === '*') return true;
   if (!matcher.includes('*')) return matcher === toolName;
 
-  const escaped = matcher
-    .split('*')
-    .map((segment) => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-    .join('.*');
-  return new RegExp(`^${escaped}$`).test(toolName);
+  const segments = matcher.split('*');
+  let cursor = 0;
+  let searchEnd = toolName.length;
+
+  if (!matcher.startsWith('*')) {
+    const first = segments.shift() ?? '';
+    if (!toolName.startsWith(first)) return false;
+    cursor = first.length;
+  }
+
+  if (!matcher.endsWith('*')) {
+    const last = segments.pop() ?? '';
+    if (!toolName.endsWith(last)) return false;
+    searchEnd = toolName.length - last.length;
+  }
+
+  for (const segment of segments) {
+    if (!segment) continue;
+    const index = toolName.indexOf(segment, cursor);
+    if (index === -1 || index + segment.length > searchEnd) return false;
+    cursor = index + segment.length;
+  }
+
+  return cursor <= searchEnd;
 }
 
 function toHookDiagnostic(

--- a/src/zero-hooks/config.ts
+++ b/src/zero-hooks/config.ts
@@ -1,0 +1,334 @@
+import { existsSync } from 'fs';
+import { mkdir, readFile, rename, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join, resolve } from 'path';
+import { z, ZodError } from 'zod';
+import type {
+  SelectZeroHooksInput,
+  ZeroHookConfigSource,
+  ZeroHookDefinition,
+  ZeroHookDiagnostic,
+  ZeroHookLoadResult,
+  ZeroHookPaths,
+  ZeroHooksConfig,
+} from './types';
+
+const HookIdSchema = z.string().trim().min(1).regex(
+  /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
+  'Use letters, numbers, dots, dashes, or underscores.'
+);
+const HookEventSchema = z.enum(['beforeTool', 'afterTool', 'sessionStart', 'sessionEnd']);
+
+const HookDefinitionSchema = z.object({
+  id: HookIdSchema,
+  name: z.string().trim().min(1).optional(),
+  description: z.string().trim().min(1).optional(),
+  enabled: z.boolean().optional(),
+  event: HookEventSchema,
+  matcher: z.string().trim().min(1).optional(),
+  command: z.string().trim().min(1),
+  args: z.array(z.string()).optional(),
+});
+
+const HooksConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+  hooks: z.array(HookDefinitionSchema).optional(),
+});
+
+interface HookLayer {
+  source: ZeroHookConfigSource;
+  path: string;
+  config: ZeroHooksConfig;
+}
+
+export interface ResolveZeroHookPathOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface LoadZeroHooksConfigOptions extends ResolveZeroHookPathOptions {
+  userConfigPath?: string;
+  projectConfigPath?: string;
+}
+
+export interface ZeroHookConfigStoreOptions {
+  configPath?: string;
+}
+
+export function resolveZeroHookPaths(options: ResolveZeroHookPathOptions = {}): ZeroHookPaths {
+  const env = options.env ?? process.env;
+  const cwd = resolve(options.cwd ?? process.cwd());
+  const home = env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
+  const configHome = env.XDG_CONFIG_HOME?.trim() || join(home, '.config');
+  const dataHome = env.XDG_DATA_HOME?.trim() || join(home, '.local', 'share');
+
+  return {
+    userConfigPath: join(configHome, 'zero', 'hooks.json'),
+    projectConfigPath: join(cwd, '.zero', 'hooks.json'),
+    auditPath: join(dataHome, 'zero', 'hooks', 'audit.jsonl'),
+  };
+}
+
+export async function loadZeroHooksConfig(
+  options: LoadZeroHooksConfigOptions = {}
+): Promise<ZeroHookLoadResult> {
+  const paths = resolveZeroHookPaths(options);
+  const userConfigPath = resolve(options.userConfigPath ?? paths.userConfigPath);
+  const projectConfigPath = resolve(options.projectConfigPath ?? paths.projectConfigPath);
+  const diagnostics: ZeroHookDiagnostic[] = [];
+  const layers: HookLayer[] = [];
+
+  for (const [source, path] of [
+    ['user', userConfigPath],
+    ['project', projectConfigPath],
+  ] as const) {
+    const layer = await readHookLayer(source, path, diagnostics);
+    if (layer) layers.push(layer);
+  }
+
+  return {
+    config: mergeHookLayers(layers, diagnostics),
+    diagnostics,
+    paths: {
+      ...paths,
+      userConfigPath,
+      projectConfigPath,
+    },
+  };
+}
+
+export async function writeZeroHooksConfig(path: string, config: Partial<ZeroHooksConfig>): Promise<void> {
+  const normalized = normalizeHooksConfig(config);
+  const resolved = resolve(path);
+  await mkdir(dirname(resolved), { recursive: true });
+  const tempPath = `${resolved}.tmp`;
+  await writeFile(tempPath, JSON.stringify(normalized, null, 2), 'utf-8');
+  await rename(tempPath, resolved);
+}
+
+export class ZeroHookConfigStore {
+  private readonly configPath: string;
+
+  constructor(options: ZeroHookConfigStoreOptions = {}) {
+    this.configPath = resolve(options.configPath ?? resolveZeroHookPaths().projectConfigPath);
+  }
+
+  async list(): Promise<ZeroHooksConfig> {
+    const result = await loadZeroHooksConfig({
+      userConfigPath: `${this.configPath}.user-missing`,
+      projectConfigPath: this.configPath,
+    });
+    return result.config;
+  }
+
+  async upsert(hook: Omit<ZeroHookDefinition, 'enabled'> & { enabled?: boolean }): Promise<ZeroHookDefinition> {
+    const config = await this.list();
+    const normalized = normalizeHookDefinition(hook);
+    const nextHooks = config.hooks.filter((existing) => existing.id !== normalized.id);
+    nextHooks.push(normalized);
+    await writeZeroHooksConfig(this.configPath, {
+      enabled: config.enabled,
+      hooks: nextHooks,
+    });
+    return normalized;
+  }
+
+  async remove(hookId: string): Promise<boolean> {
+    const config = await this.list();
+    const nextHooks = config.hooks.filter((hook) => hook.id !== hookId);
+    if (nextHooks.length === config.hooks.length) return false;
+    await writeZeroHooksConfig(this.configPath, {
+      enabled: config.enabled,
+      hooks: nextHooks,
+    });
+    return true;
+  }
+
+  async setEnabled(hookId: string, enabled: boolean): Promise<boolean> {
+    const config = await this.list();
+    let changed = false;
+    const nextHooks = config.hooks.map((hook) => {
+      if (hook.id !== hookId) return hook;
+      changed = true;
+      return { ...hook, enabled };
+    });
+    if (!changed) return false;
+    await writeZeroHooksConfig(this.configPath, {
+      enabled: config.enabled,
+      hooks: nextHooks,
+    });
+    return true;
+  }
+}
+
+export function selectZeroHooks(
+  config: ZeroHooksConfig,
+  input: SelectZeroHooksInput
+): ZeroHookDefinition[] {
+  if (!config.enabled) return [];
+
+  return config.hooks.filter((hook) => {
+    if (!hook.enabled || hook.event !== input.event) return false;
+    if (!hook.matcher) return true;
+    if (!input.toolName) return false;
+    return matchesHookMatcher(hook.matcher, input.toolName);
+  });
+}
+
+export function formatZeroHookList(
+  config: ZeroHooksConfig,
+  diagnostics: ZeroHookDiagnostic[]
+): string {
+  const lines: string[] = [];
+  lines.push(`Zero Hooks: ${config.enabled ? 'enabled' : 'disabled'}`);
+
+  if (config.hooks.length === 0) {
+    lines.push('  No hooks configured.');
+  } else {
+    for (const hook of config.hooks) {
+      const matcher = hook.matcher ? ` ${hook.matcher}` : '';
+      const command = [hook.command, ...hook.args].join(' ');
+      lines.push(
+        `  ${hook.id} [${hook.event}${matcher}] ${hook.enabled ? 'enabled' : 'disabled'} - ${command}`
+      );
+    }
+  }
+
+  if (diagnostics.length > 0) {
+    lines.push('Hook diagnostics:');
+    for (const diagnostic of diagnostics) {
+      lines.push(`  [${diagnostic.kind}] ${diagnostic.message}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+async function readHookLayer(
+  source: ZeroHookConfigSource,
+  path: string,
+  diagnostics: ZeroHookDiagnostic[]
+): Promise<HookLayer | undefined> {
+  if (!existsSync(path)) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf-8'));
+  } catch (err: unknown) {
+    diagnostics.push({
+      kind: err instanceof SyntaxError ? 'json' : 'io',
+      source,
+      path,
+      message: getErrorMessage(err),
+    });
+    return undefined;
+  }
+
+  try {
+    return {
+      source,
+      path,
+      config: normalizeHooksConfig(parsed),
+    };
+  } catch (err: unknown) {
+    diagnostics.push(toHookDiagnostic(err, source, path));
+    return undefined;
+  }
+}
+
+function mergeHookLayers(
+  layers: HookLayer[],
+  diagnostics: ZeroHookDiagnostic[]
+): ZeroHooksConfig {
+  let enabled = true;
+  const byId = new Map<string, ZeroHookDefinition>();
+  const sourceById = new Map<string, HookLayer>();
+
+  for (const layer of layers) {
+    enabled = layer.config.enabled;
+    for (const hook of layer.config.hooks) {
+      const previous = sourceById.get(hook.id);
+      if (previous) {
+        diagnostics.push({
+          kind: 'duplicate',
+          source: layer.source,
+          path: layer.path,
+          hookId: hook.id,
+          message: `Hook "${hook.id}" from ${layer.source} overrides ${previous.source} hook at ${previous.path}.`,
+        });
+      }
+      byId.set(hook.id, hook);
+      sourceById.set(hook.id, layer);
+    }
+  }
+
+  return {
+    enabled,
+    hooks: Array.from(byId.values()).sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}
+
+function normalizeHooksConfig(value: unknown): ZeroHooksConfig {
+  const parsed = HooksConfigSchema.parse(value ?? {});
+  return {
+    enabled: parsed.enabled ?? true,
+    hooks: (parsed.hooks ?? [])
+      .map(normalizeHookDefinition)
+      .sort((left, right) => left.id.localeCompare(right.id)),
+  };
+}
+
+function normalizeHookDefinition(
+  value: z.infer<typeof HookDefinitionSchema>
+): ZeroHookDefinition {
+  const parsed = HookDefinitionSchema.parse(value);
+  return {
+    id: parsed.id,
+    name: parsed.name,
+    description: parsed.description,
+    event: parsed.event,
+    matcher: parsed.matcher,
+    command: parsed.command,
+    args: parsed.args ?? [],
+    enabled: parsed.enabled ?? true,
+  };
+}
+
+function matchesHookMatcher(matcher: string, toolName: string): boolean {
+  if (matcher === '*') return true;
+  if (!matcher.includes('*')) return matcher === toolName;
+
+  const escaped = matcher
+    .split('*')
+    .map((segment) => segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${escaped}$`).test(toolName);
+}
+
+function toHookDiagnostic(
+  err: unknown,
+  source: ZeroHookConfigSource,
+  path: string
+): ZeroHookDiagnostic {
+  if (err instanceof ZodError) {
+    const issue = err.issues[0];
+    return {
+      kind: 'schema',
+      source,
+      path,
+      fieldPath: issue?.path.map(String).join('.'),
+      message: issue?.message ?? err.message,
+    };
+  }
+
+  return {
+    kind: 'schema',
+    source,
+    path,
+    message: getErrorMessage(err),
+  };
+}
+
+function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/zero-hooks/index.ts
+++ b/src/zero-hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './audit';
+export * from './config';
+export * from './types';

--- a/src/zero-hooks/types.ts
+++ b/src/zero-hooks/types.ts
@@ -1,0 +1,91 @@
+export type ZeroHookEvent = 'beforeTool' | 'afterTool' | 'sessionStart' | 'sessionEnd';
+export type ZeroHookDiagnosticKind = 'io' | 'json' | 'schema' | 'duplicate';
+export type ZeroHookConfigSource = 'user' | 'project';
+
+export interface ZeroHookCommand {
+  command: string;
+  args: string[];
+}
+
+export interface ZeroHookDefinition extends ZeroHookCommand {
+  id: string;
+  name?: string;
+  description?: string;
+  event: ZeroHookEvent;
+  matcher?: string;
+  enabled: boolean;
+}
+
+export interface ZeroHooksConfig {
+  enabled: boolean;
+  hooks: ZeroHookDefinition[];
+}
+
+export interface ZeroHookDiagnostic {
+  kind: ZeroHookDiagnosticKind;
+  message: string;
+  source?: ZeroHookConfigSource;
+  path?: string;
+  hookId?: string;
+  fieldPath?: string;
+}
+
+export interface ZeroHookLoadResult {
+  config: ZeroHooksConfig;
+  diagnostics: ZeroHookDiagnostic[];
+  paths: ZeroHookPaths;
+}
+
+export interface ZeroHookPaths {
+  userConfigPath: string;
+  projectConfigPath: string;
+  auditPath: string;
+}
+
+export interface SelectZeroHooksInput {
+  event: ZeroHookEvent;
+  toolName?: string;
+}
+
+export interface ZeroHookAuditCommand extends ZeroHookCommand {}
+
+export interface ZeroHookAuditResult {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface ZeroHookAuditBase {
+  sequence: number;
+  createdAt: string;
+  hookId: string;
+  event: ZeroHookEvent;
+  matcher?: string;
+  toolCallId?: string;
+}
+
+export interface ZeroHookExecutionStartedAudit extends ZeroHookAuditBase {
+  type: 'hook_execution_started';
+  commands: ZeroHookAuditCommand[];
+}
+
+export interface ZeroHookExecutionCompletedAudit extends ZeroHookAuditBase {
+  type: 'hook_execution_completed';
+  status: 'completed' | 'error' | 'blocked';
+  results?: ZeroHookAuditResult[];
+  durationMs?: number;
+}
+
+export type ZeroHookAuditEvent =
+  | ZeroHookExecutionStartedAudit
+  | ZeroHookExecutionCompletedAudit;
+
+export type AppendZeroHookStartedInput = Omit<
+  ZeroHookExecutionStartedAudit,
+  'type' | 'sequence' | 'createdAt'
+>;
+
+export type AppendZeroHookCompletedInput = Omit<
+  ZeroHookExecutionCompletedAudit,
+  'type' | 'sequence' | 'createdAt'
+>;

--- a/tests/zero-hooks.test.ts
+++ b/tests/zero-hooks.test.ts
@@ -32,7 +32,8 @@ async function runZeroHooks(
   cwd: string,
   args: string[] = []
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const child = Bun.spawn([process.execPath, join(process.cwd(), 'src/index.ts'), 'hooks', ...args], {
+  const cliEntrypoint = join(import.meta.dir, '..', 'src', 'index.ts');
+  const child = Bun.spawn([process.execPath, cliEntrypoint, 'hooks', ...args], {
     cwd,
     env: {
       ...process.env,
@@ -132,6 +133,32 @@ describe('Zero hook config backend', () => {
     ]);
   });
 
+  it('rejects matchers on session hooks with a schema diagnostic', async () => {
+    const dir = await makeTempDir();
+    const projectConfigPath = join(dir, 'hooks.json');
+    await writeJson(projectConfigPath, {
+      hooks: [{
+        id: 'zero.session',
+        event: 'sessionStart',
+        matcher: 'bash',
+        command: 'node',
+      }],
+    });
+
+    const result = await loadZeroHooksConfig({
+      userConfigPath: join(dir, 'missing-user-hooks.json'),
+      projectConfigPath,
+    });
+
+    expect(result.config.hooks).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        kind: 'schema',
+        fieldPath: 'hooks.0.matcher',
+      }),
+    ]);
+  });
+
   it('persists hook updates through the config store', async () => {
     const dir = await makeTempDir();
     const configPath = join(dir, 'hooks.json');
@@ -160,8 +187,34 @@ describe('Zero hook config backend', () => {
     expect((await store.list()).hooks).toEqual([]);
   });
 
+  it('serializes concurrent config store mutations for the same path', async () => {
+    const dir = await makeTempDir();
+    const configPath = join(dir, 'hooks.json');
+    const first = new ZeroHookConfigStore({ configPath });
+    const second = new ZeroHookConfigStore({ configPath });
+
+    await Promise.all([
+      first.upsert({
+        id: 'zero.first',
+        event: 'beforeTool',
+        matcher: 'read_*',
+        command: 'node',
+        args: [],
+      }),
+      second.upsert({
+        id: 'zero.second',
+        event: 'afterTool',
+        matcher: 'write_*',
+        command: 'node',
+        args: [],
+      }),
+    ]);
+
+    expect((await first.list()).hooks.map((hook) => hook.id)).toEqual(['zero.first', 'zero.second']);
+  });
+
   it('selects enabled hooks by event and matcher', () => {
-    const selected = selectZeroHooks({
+    const config = {
       enabled: true,
       hooks: [
         {
@@ -187,13 +240,31 @@ describe('Zero hook config backend', () => {
           args: [],
           enabled: true,
         },
+        {
+          id: 'zero.shell-edit',
+          event: 'beforeTool',
+          matcher: 'shell_*_edit',
+          command: 'node',
+          args: [],
+          enabled: true,
+        },
       ],
-    }, {
+    } satisfies Parameters<typeof selectZeroHooks>[0];
+
+    expect(selectZeroHooks(config, {
       event: 'beforeTool',
       toolName: 'read_file',
-    });
+    }).map((hook) => hook.id)).toEqual(['zero.reads']);
 
-    expect(selected.map((hook) => hook.id)).toEqual(['zero.reads']);
+    expect(selectZeroHooks(config, {
+      event: 'beforeTool',
+      toolName: 'shell_safe_edit',
+    }).map((hook) => hook.id)).toEqual(['zero.shell-edit']);
+
+    expect(selectZeroHooks(config, {
+      event: 'beforeTool',
+      toolName: 'shell_safe_view',
+    })).toEqual([]);
   });
 
   it('formats hook config for CLI and UI consumers', () => {
@@ -253,18 +324,66 @@ describe('Zero hook audit backend', () => {
       }),
     ]);
   });
+
+  it('serializes concurrent appends and skips malformed audit lines', async () => {
+    const dir = await makeTempDir();
+    const auditPath = join(dir, 'audit.jsonl');
+    await writeFile(auditPath, [
+      JSON.stringify({
+        sequence: 1,
+        createdAt: '2026-06-04T00:00:00.000Z',
+        type: 'hook_execution_started',
+        hookId: 'zero.seed',
+        event: 'sessionStart',
+        commands: [{ command: 'node', args: [] }],
+      }),
+      '{not-json',
+      JSON.stringify({
+        sequence: 2,
+        createdAt: '2026-06-04T00:00:01.000Z',
+        type: 'hook_execution_completed',
+        hookId: 'zero.seed',
+        event: 'sessionStart',
+        status: 'completed',
+      }),
+      '',
+    ].join('\n'), 'utf-8');
+    const audit = new ZeroHookAuditStore({
+      auditPath,
+      now: () => new Date('2026-06-04T00:00:02.000Z'),
+    });
+
+    expect((await audit.readEvents()).map((event) => event.sequence)).toEqual([1, 2]);
+
+    const appended = await Promise.all([
+      audit.appendStarted({
+        hookId: 'zero.one',
+        event: 'sessionStart',
+        commands: [{ command: 'node', args: [] }],
+      }),
+      audit.appendStarted({
+        hookId: 'zero.two',
+        event: 'sessionStart',
+        commands: [{ command: 'node', args: [] }],
+      }),
+    ]);
+
+    expect(appended.map((event) => event.sequence)).toEqual([3, 4]);
+    expect((await audit.readEvents()).map((event) => event.sequence)).toEqual([1, 2, 3, 4]);
+  });
 });
 
 describe('zero hooks CLI', () => {
   it('lists project hook config as JSON and formatted text', async () => {
     const dir = await makeTempDir();
+    const syntheticSecret = `sk-proj-${'a'.repeat(24)}`;
     await writeJson(join(dir, '.zero', 'hooks.json'), {
       hooks: [{
         id: 'zero.preflight',
         event: 'beforeTool',
         matcher: 'bash',
         command: 'node',
-        args: ['hooks/preflight.mjs'],
+        args: ['hooks/preflight.mjs', syntheticSecret],
       }],
     });
 
@@ -278,6 +397,8 @@ describe('zero hooks CLI', () => {
       }),
       diagnostics: [],
     });
+    expect(jsonResult.stdout).toContain('[REDACTED]');
+    expect(jsonResult.stdout).not.toContain(syntheticSecret);
 
     const textResult = await runZeroHooks(dir, ['list']);
     expect(textResult.exitCode).toBe(0);
@@ -285,5 +406,7 @@ describe('zero hooks CLI', () => {
     expect(textResult.stdout).toContain('Zero Hooks');
     expect(textResult.stdout).toContain('zero.preflight');
     expect(textResult.stdout).toContain('beforeTool');
+    expect(textResult.stdout).toContain('[REDACTED]');
+    expect(textResult.stdout).not.toContain(syntheticSecret);
   });
 });

--- a/tests/zero-hooks.test.ts
+++ b/tests/zero-hooks.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import {
+  ZeroHookAuditStore,
+  ZeroHookConfigStore,
+  formatZeroHookList,
+  loadZeroHooksConfig,
+  resolveZeroHookPaths,
+  selectZeroHooks,
+} from '../src/zero-hooks';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'zero-hooks-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+async function runZeroHooks(
+  cwd: string,
+  args: string[] = []
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const child = Bun.spawn([process.execPath, join(process.cwd(), 'src/index.ts'), 'hooks', ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      HOME: join(cwd, 'home'),
+      USERPROFILE: join(cwd, 'home'),
+      XDG_CONFIG_HOME: join(cwd, 'xdg-config'),
+      XDG_DATA_HOME: join(cwd, 'xdg-data'),
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('Zero hook config backend', () => {
+  it('resolves default hook config and audit paths', async () => {
+    const dir = await makeTempDir();
+
+    expect(resolveZeroHookPaths({
+      cwd: dir,
+      env: {
+        XDG_CONFIG_HOME: join(dir, 'config'),
+        XDG_DATA_HOME: join(dir, 'data'),
+      },
+    })).toEqual({
+      userConfigPath: join(dir, 'config', 'zero', 'hooks.json'),
+      projectConfigPath: join(dir, '.zero', 'hooks.json'),
+      auditPath: join(dir, 'data', 'zero', 'hooks', 'audit.jsonl'),
+    });
+  });
+
+  it('loads layered hook config with project overrides and diagnostics', async () => {
+    const dir = await makeTempDir();
+    const userConfigPath = join(dir, 'user-hooks.json');
+    const projectConfigPath = join(dir, 'project-hooks.json');
+    await writeJson(userConfigPath, {
+      enabled: true,
+      hooks: [
+        {
+          id: 'zero.format',
+          name: 'Format after edits',
+          event: 'afterTool',
+          matcher: 'edit_file',
+          command: 'bun',
+          args: ['run', 'format'],
+        },
+        {
+          id: 'zero.audit',
+          event: 'sessionEnd',
+          command: 'node',
+          args: ['audit.mjs'],
+        },
+      ],
+    });
+    await writeJson(projectConfigPath, {
+      hooks: [
+        {
+          id: 'zero.format',
+          event: 'afterTool',
+          matcher: 'write_file',
+          command: 'bun',
+          args: ['run', 'lint'],
+          enabled: false,
+        },
+      ],
+    });
+
+    const result = await loadZeroHooksConfig({ userConfigPath, projectConfigPath });
+
+    expect(result.config.enabled).toBe(true);
+    expect(result.config.hooks).toEqual([
+      expect.objectContaining({
+        id: 'zero.audit',
+        enabled: true,
+        event: 'sessionEnd',
+      }),
+      expect.objectContaining({
+        id: 'zero.format',
+        enabled: false,
+        event: 'afterTool',
+        matcher: 'write_file',
+        args: ['run', 'lint'],
+      }),
+    ]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        kind: 'duplicate',
+        hookId: 'zero.format',
+      }),
+    ]);
+  });
+
+  it('persists hook updates through the config store', async () => {
+    const dir = await makeTempDir();
+    const configPath = join(dir, 'hooks.json');
+    const store = new ZeroHookConfigStore({ configPath });
+
+    await store.upsert({
+      id: 'zero.preflight',
+      name: 'Preflight',
+      event: 'beforeTool',
+      matcher: 'bash',
+      command: 'node',
+      args: ['hooks/preflight.mjs'],
+    });
+    await store.setEnabled('zero.preflight', false);
+
+    const result = await loadZeroHooksConfig({ projectConfigPath: configPath });
+    expect(result.config.hooks).toEqual([
+      expect.objectContaining({
+        id: 'zero.preflight',
+        enabled: false,
+        matcher: 'bash',
+      }),
+    ]);
+
+    expect(await store.remove('zero.preflight')).toBe(true);
+    expect((await store.list()).hooks).toEqual([]);
+  });
+
+  it('selects enabled hooks by event and matcher', () => {
+    const selected = selectZeroHooks({
+      enabled: true,
+      hooks: [
+        {
+          id: 'zero.reads',
+          event: 'beforeTool',
+          matcher: 'read_*',
+          command: 'node',
+          args: [],
+          enabled: true,
+        },
+        {
+          id: 'zero.shell',
+          event: 'beforeTool',
+          matcher: 'bash',
+          command: 'node',
+          args: [],
+          enabled: false,
+        },
+        {
+          id: 'zero.done',
+          event: 'sessionEnd',
+          command: 'node',
+          args: [],
+          enabled: true,
+        },
+      ],
+    }, {
+      event: 'beforeTool',
+      toolName: 'read_file',
+    });
+
+    expect(selected.map((hook) => hook.id)).toEqual(['zero.reads']);
+  });
+
+  it('formats hook config for CLI and UI consumers', () => {
+    expect(formatZeroHookList({
+      enabled: true,
+      hooks: [{
+        id: 'zero.preflight',
+        name: 'Preflight',
+        event: 'beforeTool',
+        matcher: 'bash',
+        command: 'node',
+        args: ['hooks/preflight.mjs'],
+        enabled: true,
+      }],
+    }, [])).toContain('zero.preflight');
+  });
+});
+
+describe('Zero hook audit backend', () => {
+  it('appends and reads hook audit events as JSONL', async () => {
+    const dir = await makeTempDir();
+    const auditPath = join(dir, 'audit.jsonl');
+    const audit = new ZeroHookAuditStore({
+      auditPath,
+      now: () => new Date('2026-06-04T00:00:00.000Z'),
+    });
+
+    await audit.appendStarted({
+      hookId: 'zero.preflight',
+      event: 'beforeTool',
+      matcher: 'bash',
+      commands: [{ command: 'node', args: ['hooks/preflight.mjs'] }],
+      toolCallId: 'call_1',
+    });
+    await audit.appendCompleted({
+      hookId: 'zero.preflight',
+      event: 'beforeTool',
+      matcher: 'bash',
+      status: 'completed',
+      results: [{ exitCode: 0, stdout: 'ok', stderr: '' }],
+      toolCallId: 'call_1',
+      durationMs: 12,
+    });
+
+    expect(await audit.readEvents()).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        type: 'hook_execution_started',
+        hookId: 'zero.preflight',
+        createdAt: '2026-06-04T00:00:00.000Z',
+      }),
+      expect.objectContaining({
+        sequence: 2,
+        type: 'hook_execution_completed',
+        status: 'completed',
+        durationMs: 12,
+      }),
+    ]);
+  });
+});
+
+describe('zero hooks CLI', () => {
+  it('lists project hook config as JSON and formatted text', async () => {
+    const dir = await makeTempDir();
+    await writeJson(join(dir, '.zero', 'hooks.json'), {
+      hooks: [{
+        id: 'zero.preflight',
+        event: 'beforeTool',
+        matcher: 'bash',
+        command: 'node',
+        args: ['hooks/preflight.mjs'],
+      }],
+    });
+
+    const jsonResult = await runZeroHooks(dir, ['list', '--json']);
+    expect(jsonResult.exitCode).toBe(0);
+    expect(jsonResult.stderr.trim()).toBe('');
+    expect(JSON.parse(jsonResult.stdout)).toEqual({
+      hooks: expect.objectContaining({
+        enabled: true,
+        hooks: [expect.objectContaining({ id: 'zero.preflight', enabled: true })],
+      }),
+      diagnostics: [],
+    });
+
+    const textResult = await runZeroHooks(dir, ['list']);
+    expect(textResult.exitCode).toBe(0);
+    expect(textResult.stderr.trim()).toBe('');
+    expect(textResult.stdout).toContain('Zero Hooks');
+    expect(textResult.stdout).toContain('zero.preflight');
+    expect(textResult.stdout).toContain('beforeTool');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Zero hook backend for layered user/project hook configuration, enablement, matching, and diagnostics.
- Add hook audit JSONL persistence for started/completed hook execution events with stable sequence ordering.
- Expose `zero hooks list` in text and JSON formats so CLI users can inspect configured hooks and load diagnostics.

## Details
- Supports default hook paths from XDG config/data homes with project-level overrides from `.zero/hooks.json`.
- Keeps valid hook entries available while reporting malformed or duplicate configuration as diagnostics.
- Adds config-store helpers for list/upsert/remove/enable flows and selector helpers for event/tool matching.
- Adds focused coverage for config layering, persistence, selection, audit storage, and CLI output.

## Validation
- `bunx tsc --noEmit`
- `bun test ./tests --timeout 15000` (274 pass)
- `bun run build`
- `bun run smoke:build`
- `./zero --help`
- `./zero hooks list`
- `./zero hooks list --json`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `zero hooks list` CLI subcommand with JSON and formatted text output
  * Hook configuration management: add, remove, enable/disable, and layered user/project settings
  * Audit logging for hook execution events with timestamps and sequence numbers
  * Configuration diagnostics to report errors and conflicts

* **Tests**
  * End-to-end tests covering config, audit, CLI output, concurrency, and secret redaction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->