### PR TITLE
Update PRD for Go-native Zero direction

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3,7 +3,7 @@
 **Status:** DRAFT v1.0
 **Target:** Compete with Claude Code + Cursor + OpenCode
 **Timeline:** 6-12 months
-**Stack:** TypeScript + Bun
+**Stack:** Go native core + npm distribution wrapper
 
 ---
 
@@ -16,7 +16,7 @@ It combines the best of:
 - **Cursor** — IDE integration + smart editing
 - **OpenCode** — multi-provider + headless
 
-**One TypeScript codebase. Three surfaces. Zero lock-in.**
+**One Go-native agent core. Three surfaces. Zero lock-in.**
 
 ---
 
@@ -25,7 +25,7 @@ It combines the best of:
 ### 2.1 Terminal (TUI) — Primary
 - Interactive coding agent in terminal
 - Streaming, append-style (like Claude Code)
-- Ink + React-based
+- Bubble Tea + Lip Gloss-based
 - Full keyboard control
 - Mouse support
 
@@ -107,7 +107,7 @@ It combines the best of:
 - `notebook_edit` — Jupyter notebooks
 
 **Tool Requirements:**
-- Zod schema → JSON Schema
+- Go typed parameter schemas -> JSON Schema
 - Side-effect class: `read | write | shell | network | out_of_workspace`
 - Structured results: `{ status, output, truncated?, meta? }`
 - Atomic execution
@@ -123,18 +123,18 @@ It combines the best of:
 
 **Model Registry:**
 
-```ts
-interface ModelEntry {
-  id: string
-  name: string
-  provider: "anthropic" | "openai" | "google" | "xai" | string
-  apiProviders: string[]          // endpoints that can serve
-  contextLimits: { input: number; output: number }
-  reasoningEffort: { supported: string[]; default: string }
-  capabilities: { tools, thinking, vision, pdf }
-  cost: { inputPerMTok, outputPerMTok, tokenMultiplier }
-  tier: "standard" | "premium"
-  matchPatterns?: RegExp[]        // fuzzy id resolution
+```go
+type ModelEntry struct {
+  ID              string
+  Name            string
+  Provider        string
+  APIProviders    []string
+  ContextLimits   ContextLimits
+  ReasoningEffort ReasoningEffort
+  Capabilities    ModelCapabilities
+  Cost            ModelCost
+  Tier            string
+  MatchPatterns   []string
 }
 ```
 
@@ -146,7 +146,7 @@ interface ModelEntry {
 
 ### F4 — Terminal UI (P0)
 - **Layout:** header (cwd · git · model) → tool rows → diff → response → input → footer
-- **Streaming:** Ink `<Static>` for transcript, live tail for streaming
+- **Streaming:** append-only transcript model with live tail updates
 - **Markdown:** full CommonMark + syntax highlighting
 - **Tool rows:** collapsible with one-line summaries
 - **Input:** `/` commands, `@` files, `!` bash, `Esc` interrupt
@@ -230,7 +230,8 @@ interface ModelEntry {
 - No marketplace in v1 (manual install)
 
 ### F13 — Distribution (P0)
-- **Single binary** via `bun build --compile`
+- **Single binary** via Go cross-compilation
+- npm package as a thin installer/launcher for the platform binary
 - Cross-platform: Linux, macOS, Windows
 - `zero update [--check]` self-update
 - Checksum verification
@@ -354,13 +355,20 @@ interface ModelEntry {
 
 ### 5.3 Tool Contract
 
-```ts
-interface Tool {
-  name: string
-  description: string
-  parameters: ZodObject
-  sideEffect: "read" | "write" | "shell" | "network" | "out_of_workspace"
-  execute(args, ctx): Promise<{ status: "ok"|"error", output: string, truncated?: boolean, meta?: object }>
+```go
+type Tool interface {
+  Name() string
+  Description() string
+  Parameters() JSONSchema
+  SideEffect() SideEffect
+  Execute(ctx ToolContext, args map[string]any) ToolResult
+}
+
+type ToolResult struct {
+  Status    string
+  Output    string
+  Truncated bool
+  Meta      map[string]any
 }
 ```
 
@@ -425,11 +433,11 @@ interface Tool {
 ## 7. Milestones
 
 ### M0 — Foundation (Weeks 1-2)
-- Bun + TypeScript setup
+- Go module setup
 - Agent core skeleton
 - 8 core tools (read, write, edit, bash, grep, glob, apply_patch, update_plan)
 - OpenAI-compatible provider
-- Basic Ink TUI
+- Basic Bubble Tea TUI
 - Permission gate (read vs mutate)
 - Session persistence
 
@@ -511,7 +519,7 @@ interface Tool {
 |---|------|------------|
 | R1 | Scope creep | Stick to milestones, defer features |
 | R2 | Provider API changes | Abstract via interface, test with mocks |
-| R3 | TUI complexity | Use Ink, copy Claude Code patterns |
+| R3 | TUI complexity | Use Bubble Tea/Lip Gloss, follow mature terminal agent UX patterns |
 | R4 | Performance | Benchmark early, optimize streaming |
 | R5 | Security vulnerabilities | Permission gate from day 1, security review |
 | R6 | Cross-platform bugs | CI on Win/Mac/Linux from M0 |
@@ -556,7 +564,7 @@ interface Tool {
 
 ## 11. Open Decisions
 
-1. **TUI library:** Ink (React) vs OpenTUI (Solid) — **Decide: Ink** (mature, large ecosystem)
+1. **TUI library:** Bubble Tea + Lip Gloss — **Decide: Go-native TUI** (single-binary friendly, mature terminal ecosystem)
 2. **Storage:** JSONL files vs SQLite — **Decide: JSONL** (inspectable, simple)
 3. **Package structure:** Single vs monorepo — **Decide: Single** until M4
 4. **Provider abstraction:** Direct API vs wrapper — **Decide: Direct** (portability)
@@ -585,8 +593,8 @@ interface Tool {
 1. **Proven patterns** — Based on clean-room analysis of existing terminal coding-agent UX patterns
 2. **Multi-provider** — Unique advantage vs Claude Code/Cursor
 3. **Open source** — Community contributions
-4. **TypeScript** — Type safety, fast iteration
-5. **Bun** — Fast runtime, single binary
+4. **Go** — Native binary, fast startup, strong concurrency, cross-platform CLI ergonomics
+5. **npm distribution wrapper** — Keeps JavaScript ecosystem installation while the runtime stays native
 6. **Clear milestones** — Ship early, iterate
 
 ---

--- a/docs/WORK_SPLIT_PRD.md
+++ b/docs/WORK_SPLIT_PRD.md
@@ -86,7 +86,7 @@ Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and s
 
 ### Anandan
 
-- Add stable project commands: `go test ./...`, `go build ./cmd/zero`, and npm wrapper smoke checks.
+- Add stable project commands: `go test ./...`, `go build ./cmd/zero`, and the npm wrapper smoke checklist.
 - Add initial CI smoke job.
 - Verify Go toolchain version, module cache behavior, and npm wrapper lockfile behavior.
 - Add build artifact smoke check.
@@ -95,9 +95,19 @@ Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and s
 ### M0 Done
 
 - `go test ./...` passes.
-- `go build ./cmd/zero` exists and passes or has a documented placeholder until the Go entrypoint lands.
-- npm wrapper smoke check exists when npm packaging files are touched.
+- `go build ./cmd/zero` passes.
+- npm wrapper smoke checklist exists when npm packaging files are touched.
 - `zero` can run, read a file, edit a file, and stream a response.
+
+### npm Wrapper Smoke Checklist
+
+When npm distribution files are changed, the smoke check must verify:
+
+- `package.json` exists with the expected package name and version.
+- `npm ci` succeeds from the wrapper package directory.
+- The wrapper binary resolves through the package `bin` entry and `node_modules/.bin`.
+- `zero --version` or `zero --help` exits 0 and reports the expected version or command surface.
+- The designated npm smoke/build script exits 0.
 
 ## Milestone M1: Multi-Provider And Headless Foundation, Weeks 3-4
 
@@ -521,9 +531,9 @@ Headless `exec` is split to avoid conflict:
 Every PR must include:
 
 - Tests for changed behavior.
-- `go test ./...` passes when Go code exists or the PR documents why it is not applicable.
-- `go build ./cmd/zero` passes when the Go entrypoint exists or the PR documents why it is not applicable.
-- npm wrapper checks pass when npm distribution files are changed.
+- `go test ./...` must pass when the PR modifies any Go code; docs-only PRs are exempt and must say so in the PR description.
+- `go build ./cmd/zero` must pass when the PR modifies `cmd/zero` or runtime packages used by the entrypoint; docs-only and npm-wrapper-only PRs are exempt and must say so in the PR description.
+- The npm wrapper smoke checklist must pass when the PR modifies npm distribution files.
 - PR description explains what changed and why.
 - No unrelated refactors.
 - Redaction used for secrets in logs/errors/tests.

--- a/docs/WORK_SPLIT_PRD.md
+++ b/docs/WORK_SPLIT_PRD.md
@@ -66,7 +66,7 @@ These contracts are required before dependent work starts:
 
 Goal: Zero runs locally, has basic tools, one OpenAI-compatible provider, basic TUI, tests, and project scripts.
 
-Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and starts workload balancing from M1.
+Current status: the earlier TS/Bun M0 baseline is historical context only. The Go migration resets M0 around a new Go module, `cmd/zero` entrypoint, Bubble Tea TUI shell, core tools, tests, and validation commands. M1 work should start only after these Go foundation PRs are merged.
 
 ### Vasanth
 
@@ -74,15 +74,15 @@ Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and s
 - Core file tools: read, write, edit, grep, list directory, bash, plan.
 - Basic Bubble Tea TUI and message/tool rendering.
 - Basic agent loop integration.
-- PR: existing PR #6 plus follow-up fixes if needed.
+- PR: `feat/go-m0-tools-tui`.
 
 ### Gnanam
 
-- Review and stabilize provider contract from PR #6.
+- Define the first Go provider contract for the M0 OpenAI-compatible provider.
 - Define first draft of normalized `Usage` type.
 - Define first draft of model registry type.
 - Review config loader and list missing provider/config fields.
-- PR: `feat/m0-runtime-contracts` if not already covered.
+- PR: `feat/go-m0-runtime-contracts`.
 
 ### Anandan
 
@@ -563,10 +563,10 @@ This keeps workload balanced while preserving clean ownership boundaries.
 
 ## Immediate Next Steps
 
-1. Merge or close PR #6 with M0 baseline decision.
-2. Anandan adds/validates project scripts and CI baseline if missing.
-3. Gnanam starts `feat/m1-model-registry`.
-4. Vasanth starts model selector UI only after registry API shape is agreed.
-5. Gnanam starts provider factory before Anthropic/Gemini providers.
-6. Anandan starts CI matrix and binary build spike in parallel.
+1. Reset M0 for the Go migration and treat old TS/Bun PR #6 as historical only.
+2. Anandan starts `feat/go-m0-module-entrypoint` with `go.mod`, `cmd/zero`, `go test ./...`, and `go build ./cmd/zero`.
+3. Gnanam starts `feat/go-m0-runtime-contracts` for the Go provider/tool/runtime contracts.
+4. Vasanth starts `feat/go-m0-tools-tui` for core tools, Bubble Tea startup shell, and basic agent loop integration.
+5. Anandan adds CI smoke coverage for the Go commands and the npm wrapper smoke checklist when wrapper files land.
+6. Start M1 model registry, provider factory, and model selector work only after the Go M0 foundation PRs are merged.
 

--- a/docs/WORK_SPLIT_PRD.md
+++ b/docs/WORK_SPLIT_PRD.md
@@ -44,7 +44,7 @@ These rules prevent future conflicts:
 
 | Person | Primary role | Owns | Does not own |
 |---|---|---|---|
-| Vasanth | Product lead, TUI, tools UX | Ink TUI, slash command UI, tool result rendering, local tool UX, permission prompts, themes, command palette, user-facing flows | Provider internals, session protocol, MCP transports, release pipeline |
+| Vasanth | Product lead, TUI, tools UX | Bubble Tea TUI, slash command UI, tool result rendering, local tool UX, permission prompts, themes, command palette, user-facing flows | Provider internals, session protocol, MCP transports, release pipeline |
 | Gnanam | Runtime backend, providers, protocols | Model registry, provider factory, Anthropic/Gemini, usage/cost, session store, stream-json, config validation, doctor/search backend, MCP/plugin backend, permissions/grants, sandbox policy | TUI rendering, binary packaging, VS Code extension UI |
 | Anandan | Infra, distribution, external integrations | CI, build, single binary, release packages, installers, self-update, performance benchmarks, VS Code extension, GitHub PR integration, Windows sandbox, release security | Provider internals, TUI command rendering, model registry |
 
@@ -70,9 +70,9 @@ Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and s
 
 ### Vasanth
 
-- ToolBase with Zod schema validation.
+- Tool interface with JSON Schema-compatible parameter validation.
 - Core file tools: read, write, edit, grep, list directory, bash, plan.
-- Basic Ink TUI and message/tool rendering.
+- Basic Bubble Tea TUI and message/tool rendering.
 - Basic agent loop integration.
 - PR: existing PR #6 plus follow-up fixes if needed.
 
@@ -86,17 +86,17 @@ Current status: PR #6 covers much of M0. This v2 treats M0 as the baseline and s
 
 ### Anandan
 
-- Add stable package scripts: `bun test`, `bun run build`, `bun run typecheck`.
+- Add stable project commands: `go test ./...`, `go build ./cmd/zero`, and npm wrapper smoke checks.
 - Add initial CI smoke job.
-- Verify Bun version and lockfile behavior.
+- Verify Go toolchain version, module cache behavior, and npm wrapper lockfile behavior.
 - Add build artifact smoke check.
 - PR: `feat/m0-ci-scripts`.
 
 ### M0 Done
 
-- `bun test` passes.
-- `bun run typecheck` exists and passes.
-- `bun run build` exists or has a documented placeholder until binary work.
+- `go test ./...` passes.
+- `go build ./cmd/zero` exists and passes or has a documented placeholder until the Go entrypoint lands.
+- npm wrapper smoke check exists when npm packaging files are touched.
 - `zero` can run, read a file, edit a file, and stream a response.
 
 ## Milestone M1: Multi-Provider And Headless Foundation, Weeks 3-4
@@ -130,7 +130,7 @@ Goal: Zero can select models/providers, use Claude/Gemini/OpenAI-compatible prov
 
 ### Anandan: Build And CI
 
-- Single binary build spike with `bun build --compile`.
+- Single binary build spike with Go cross-compilation.
 - CI matrix for Linux/macOS/Windows test and build smoke.
 - Release packaging formats: tar.gz for Unix, zip for Windows.
 - Artifact upload on tags or manual workflow.
@@ -154,7 +154,7 @@ Goal: Zero can select models/providers, use Claude/Gemini/OpenAI-compatible prov
 - OpenAI-compatible provider still works.
 - Anthropic and Gemini providers pass mocked stream tests.
 - Model selector reads registry data.
-- CI runs tests and typecheck on PR.
+- CI runs tests and build checks on PR.
 - Binary build has at least one working platform artifact or documented blocker.
 
 ## Milestone M2: Core Commands, Cost, Observability, Install Flow, Weeks 5-8
@@ -179,7 +179,7 @@ Goal: Core slash commands work, cost and diagnostics are visible, sessions have 
 
 - Minimal session event store to support cost/search/resume later.
 - Cost tracking from normalized usage and model registry.
-- `zero doctor` backend checks: Bun, config, provider, connectivity, model validity.
+- `zero doctor` backend checks: binary, config, provider, connectivity, model validity.
 - `zero search` backend over local session events.
 - Config inspection and validation API for `/config`.
 - Secret redaction helper used by logs, provider errors, doctor, feedback.
@@ -521,9 +521,9 @@ Headless `exec` is split to avoid conflict:
 Every PR must include:
 
 - Tests for changed behavior.
-- `bun test` passes.
-- `bun run typecheck` passes.
-- `bun run build` passes or the PR explicitly documents why build is not applicable.
+- `go test ./...` passes when Go code exists or the PR documents why it is not applicable.
+- `go build ./cmd/zero` passes when the Go entrypoint exists or the PR documents why it is not applicable.
+- npm wrapper checks pass when npm distribution files are changed.
 - PR description explains what changed and why.
 - No unrelated refactors.
 - Redaction used for secrets in logs/errors/tests.


### PR DESCRIPTION
## Summary
- update the main PRD from TypeScript/Bun assumptions to a Go-native agent core
- switch the planned TUI direction from Ink/React to Bubble Tea/Lip Gloss
- keep npm as a distribution wrapper for native platform binaries
- align the work-split PRD commands and DoD with Go build/test expectations

## Validation
- git diff --check

No code was changed, so Go/Bun build and test commands were not run for this docs-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap and technical architecture to a Go-native core with an npm wrapper/launcher and single-binary distribution.
  * TUI surface standardized to Bubble Tea; milestones and ownerships rebalanced to reflect Go-first baseline.
  * Tool parameter schemas aligned to Go-typed → JSON Schema mappings; model/tool examples converted to Go-style definitions.
  * CI/build and definition-of-done updated to Go-first build/test criteria with npm-wrapper smoke checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->