### PR TITLE
[codex] add Go module entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,20 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Go test
+        run: go test ./...
+
+      - name: Go build
+        run: go build ./cmd/zero
 
       - name: Test
         run: bun run test

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 .cursor
 
-zero
-zero.exe
+/zero
+/zero.exe

--- a/cmd/zero/main.go
+++ b/cmd/zero/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/Gitlawb/zero/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Gitlawb/zero
+
+go 1.24

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+)
+
+const version = "0.1.0"
+
+// Run executes the minimal Go CLI surface. It returns an exit code so tests can
+// exercise command behavior without terminating the test process.
+func Run(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		printHelp(stdout)
+		return 0
+	}
+
+	switch args[0] {
+	case "-h", "--help", "help":
+		printHelp(stdout)
+		return 0
+	case "-v", "--version", "version":
+		fmt.Fprintf(stdout, "zero %s\n", version)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "unknown command %q\n", args[0])
+		fmt.Fprintln(stderr, "Run zero --help for usage.")
+		return 2
+	}
+}
+
+func printHelp(w io.Writer) {
+	fmt.Fprint(w, `ZERO terminal coding agent
+
+Usage:
+  zero [command]
+
+Commands:
+  help       Show this help
+  version    Print version
+
+Flags:
+  -h, --help       Show this help
+  -v, --version    Print version
+`)
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -11,26 +11,36 @@ const version = "0.1.0"
 // exercise command behavior without terminating the test process.
 func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
-		printHelp(stdout)
+		if err := writeHelp(stdout); err != nil {
+			return 1
+		}
 		return 0
 	}
 
 	switch args[0] {
 	case "-h", "--help", "help":
-		printHelp(stdout)
+		if err := writeHelp(stdout); err != nil {
+			return 1
+		}
 		return 0
 	case "-v", "--version", "version":
-		fmt.Fprintf(stdout, "zero %s\n", version)
+		if _, err := fmt.Fprintf(stdout, "zero %s\n", version); err != nil {
+			return 1
+		}
 		return 0
 	default:
-		fmt.Fprintf(stderr, "unknown command %q\n", args[0])
-		fmt.Fprintln(stderr, "Run zero --help for usage.")
+		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
+			return 1
+		}
+		if _, err := fmt.Fprintln(stderr, "Run zero --help for usage."); err != nil {
+			return 1
+		}
 		return 2
 	}
 }
 
-func printHelp(w io.Writer) {
-	fmt.Fprint(w, `ZERO terminal coding agent
+func writeHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `ZERO terminal coding agent
 
 Usage:
   zero [command]
@@ -43,4 +53,5 @@ Flags:
   -h, --help       Show this help
   -v, --version    Print version
 `)
+	return err
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunPrintsVersion(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"--version"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "zero 0.1.0\n" {
+		t.Fatalf("expected version output, got %q", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunPrintsHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"--help"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"ZERO terminal coding agent",
+		"Usage:",
+		"zero [command]",
+		"--version",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected help output to contain %q, got %q", want, output)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunRejectsUnknownCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"wat"}, &stdout, &stderr)
+
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, `unknown command "wat"`) {
+		t.Fatalf("expected unknown command error, got %q", got)
+	}
+}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2,9 +2,19 @@ package cli
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
+
+var errWriteFailed = errors.New("write failed")
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errWriteFailed
+}
 
 func TestRunPrintsVersion(t *testing.T) {
 	var stdout bytes.Buffer
@@ -24,10 +34,25 @@ func TestRunPrintsVersion(t *testing.T) {
 }
 
 func TestRunPrintsHelp(t *testing.T) {
+	for _, args := range [][]string{
+		{"--help"},
+		{"-h"},
+		{"help"},
+		{},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			assertHelpOutput(t, args)
+		})
+	}
+}
+
+func assertHelpOutput(t *testing.T, args []string) {
+	t.Helper()
+
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	exitCode := Run([]string{"--help"}, &stdout, &stderr)
+	exitCode := Run(args, &stdout, &stderr)
 
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
@@ -46,6 +71,22 @@ func TestRunPrintsHelp(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunReturnsFailureWhenStdoutWriteFails(t *testing.T) {
+	exitCode := Run([]string{"--version"}, failingWriter{}, io.Discard)
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+}
+
+func TestRunReturnsFailureWhenStderrWriteFails(t *testing.T) {
+	exitCode := Run([]string{"wat"}, io.Discard, failingWriter{})
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add the first Go module for Zero with `cmd/zero` as the entrypoint.
- Add a minimal internal CLI surface for `--help`, `--version`, and unknown-command handling.
- Add Go tests for that CLI behavior.
- Add CI smoke coverage for `go test ./...` and `go build ./cmd/zero` across the existing OS matrix.
- Narrow `.gitignore` so only root build artifacts `/zero` and `/zero.exe` are ignored, allowing `cmd/zero` to be tracked.

## Why

This starts the Go M0 foundation from the merged PRD direction without rewriting the current TypeScript/Bun app. The slice gives Anandan/Gnanam/Vasanth a concrete Go baseline to build on.

## Validation

Local:
- `git diff --cached --check` passed before commit.
- `bun run typecheck` passed.
- `bun test ./tests --timeout 15000` passed: 277 tests.
- `bun run build` passed.
- `bun run smoke:build` passed.

Blocked locally:
- `go test ./...` and `go build ./cmd/zero` could not run because `go` is not installed on this Windows machine.

CI:
- This PR adds `actions/setup-go` and runs the Go validation commands on Ubuntu, macOS, and Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A new `zero` command-line tool with help (`--help`, `-h`) and version (`--version`, `-v`) output and proper unknown-command exit codes
* **Tests**
  * Expanded CLI test coverage, including help, version, unknown-command, and failure cases for output errors
* **Chores**
  * CI now runs Go tests and a Go build (with Go toolchain setup and caching)
* **Style**
  * Repository ignore rules updated to only exclude built artifacts at repository root
<!-- end of auto-generated comment: release notes by coderabbit.ai -->