### PR TITLE
Add Go M0 validation scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,13 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Go test
-        run: go test ./...
+        run: bun run test:go
 
       - name: Go build
-        run: go build ./cmd/zero
+        run: bun run build:go
+
+      - name: Go smoke
+        run: bun run smoke:go
 
       - name: Test
         run: bun run test

--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@
 
 **A clean, terminal-first AI coding agent you fully own — multi-provider, scriptable, and safe by default.**
 
-![runtime](https://img.shields.io/badge/runtime-Bun-14151a?logo=bun&logoColor=fbf0df)
-![typescript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript&logoColor=white)
-![tui](https://img.shields.io/badge/TUI-Ink-22d3ee)
+![core](https://img.shields.io/badge/core-Go--native-00ADD8?logo=go&logoColor=white)
+![distribution](https://img.shields.io/badge/distribution-npm%20wrapper-cb3837?logo=npm&logoColor=white)
+![transition](https://img.shields.io/badge/TS%2FBun-transitional-14151a?logo=bun&logoColor=fbf0df)
 ![status](https://img.shields.io/badge/status-active%20development-67e8f9)
 
 Zero is a coding agent that lives in your terminal. It runs an agentic tool loop —
 reading, editing, searching, and running commands in your repo — against **whatever
-model you choose**. One TypeScript codebase powers an interactive TUI and a fully
-scriptable headless mode, so the same agent works at your prompt or inside CI.
+model you choose**. Zero is migrating to a **Go-native core** with an npm
+distribution wrapper; the current TypeScript/Bun implementation remains a
+transitional reference while the Go M0 foundation lands.
 
 > Zero treats the **model as a swappable, per-task choice** — no single-vendor lock-in —
 > and never mutates your system without a permission decision.
@@ -31,7 +32,7 @@ scriptable headless mode, so the same agent works at your prompt or inside CI.
 ## Highlights
 
 - 🔌 **Multi-provider** — OpenAI-compatible, Anthropic, and Gemini behind one interface, with a model registry (capabilities, context limits, cost). Bring your own key and endpoint.
-- 🖥️ **Premium TUI** — append-style, scrollback-native Ink interface: streaming responses, compact tool-call rows with inline diffs, a slash-command palette, and a live status footer (model · tokens · cost · context).
+- 🖥️ **Premium TUI** — Bubble Tea/Lip Gloss is the target TUI stack; the current Ink surface remains transitional during the Go migration.
 - 🤖 **Headless & scriptable** — `zero exec` with clean `text` / `json` / `stream-json` I/O and meaningful exit codes for CI and automation.
 - 🧰 **Real tools** — read / write / edit files, `apply_patch`, `grep`, `glob`, `bash`, directory listing, and a live plan/todo.
 - 🛡️ **Safe by default** — mutating tools are permission-gated; `--skip-permissions-unsafe` is an explicit, clearly-labeled opt-out.
@@ -40,7 +41,8 @@ scriptable headless mode, so the same agent works at your prompt or inside CI.
 
 ## Quick start
 
-> Requires [Bun](https://bun.com) (version pinned in `package.json`).
+> Requires [Bun](https://bun.com) for the current transitional npm wrapper and
+> [Go](https://go.dev/) for Go-native validation commands.
 
 ```bash
 bun install --frozen-lockfile
@@ -127,14 +129,15 @@ Write/shell tools route through the permission policy before any side effect.
 ## Architecture
 
 ```
-        TUI (Ink)          headless `exec`           (future) editor ext
+ Terminal (Bubble Tea target)   headless `exec`      (future) editor ext
             └───────────────────┬───────────────────────┘
-                          Agent Core (loop, events, tools)
+                    Go-native core target (loop, events, tools)
    ┌──────────┬───────────┬──────────┬──────────┬───────────┬──────────┐
  providers   tools     sessions    usage     redaction    doctor /   stream-json
  + registry  registry  + search   + cost                  config
 ```
 
+- **Go-native target**: the new `cmd/zero` entrypoint is the foundation for the production core; TS/Bun code remains in place during migration.
 - **Surface-agnostic core**: the agent loop streams text + tool calls, executes tools, and emits a typed event stream consumed identically by every surface.
 - **Edges are interfaces**: `Provider`, `Tool`, `SessionStore`, and the permission policy are swappable.
 - **Model is data**: capabilities, cost, and routing live in the registry — never hard-coded.
@@ -145,11 +148,11 @@ Write/shell tools route through the permission policy before any side effect.
 cmd/zero                # Go-native entrypoint
 internal/cli            # minimal Go CLI surface during migration
 src/
-  agent/                 # agent loop + system prompts
-  cli/                   # headless exec + command surface
+  agent/                 # transitional TS agent loop + system prompts
+  cli/                   # transitional TS headless exec + command surface
   providers/             # openai · anthropic · gemini · base
   tools/                 # read/write/edit/bash/grep/glob/apply_patch/plan
-  tui/                   # Ink interface (splash + working view) + startup/
+  tui/                   # transitional Ink interface + startup/
   config/                # layered configuration
   zero-model-registry/   # models, capabilities, cost
   zero-provider-runtime/ # provider resolution/routing
@@ -209,4 +212,4 @@ License is being finalized; a `LICENSE` file will be added before a public relea
 
 ---
 
-<sub>Built with Bun · TypeScript · Ink. Zero is the from-scratch successor to <em>openclaude</em>.</sub>
+<sub>Targeting a Go-native core with an npm distribution wrapper. The current Bun · TypeScript · Ink implementation is transitional during migration.</sub>

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Write/shell tools route through the permission policy before any side effect.
 ## Project layout
 
 ```
+cmd/zero                # Go-native entrypoint
+internal/cli            # minimal Go CLI surface during migration
 src/
   agent/                 # agent loop + system prompts
   cli/                   # headless exec + command surface
@@ -166,9 +168,12 @@ tests/                   # bun test suite
 
 ```bash
 bun test            # run the test suite
+bun run test:go     # run Go tests
 bun run typecheck   # tsc --noEmit
 bun run build       # compile a standalone binary
+bun run build:go    # compile the Go entrypoint
 bun run smoke:build # verify the built binary
+bun run smoke:go    # verify the Go entrypoint binary
 bun run perf:bench  # performance benchmarks (see docs/PERFORMANCE.md)
 ```
 
@@ -190,6 +195,7 @@ and [`docs/UPDATE.md`](docs/UPDATE.md) for the update flow.
 - [Product Requirements (PRD)](docs/PRD.md) — vision, goals, full feature spec, roadmap
 - [Stream-JSON protocol](docs/STREAM_JSON_PROTOCOL.md) — headless I/O contract
 - [Headless exec PRD](docs/M1_HEADLESS_EXEC_PRD.md)
+- [npm wrapper smoke checklist](docs/NPM_WRAPPER_SMOKE.md)
 - [Performance](docs/PERFORMANCE.md) · [Install](docs/INSTALL.md) · [Update](docs/UPDATE.md)
 
 ## Contributing

--- a/docs/NPM_WRAPPER_SMOKE.md
+++ b/docs/NPM_WRAPPER_SMOKE.md
@@ -1,0 +1,33 @@
+# npm Wrapper Smoke Checklist
+
+Run this checklist when a PR changes npm distribution files such as
+`package.json`, `bun.lock`, `index.ts`, build scripts, package release scripts,
+or the npm `bin` wrapper.
+
+## Required Checks
+
+```bash
+bun install --frozen-lockfile
+bun run build
+bun run smoke:build
+```
+
+Also run the Go checks when the PR changes Go entrypoint, CLI, or release
+artifact behavior:
+
+```bash
+bun run test:go
+bun run build:go
+bun run smoke:go
+```
+
+## Checklist
+
+- `package.json` has the expected package name, version, and `bin.zero` entry.
+- `bun install --frozen-lockfile` succeeds without lockfile changes.
+- The wrapper binary resolves through the package `bin` entry and
+  `node_modules/.bin` in a package-install smoke test.
+- The built wrapper exits 0 for `zero --version` or `zero --help`.
+- The reported version matches `package.json`.
+- Release packaging still emits the expected archive and checksum names when
+  package release files change.

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "test": "bun test ./tests --timeout 15000",
+    "test:go": "go test ./...",
     "typecheck": "bunx tsc --noEmit",
     "build": "bun run scripts/build.ts",
+    "build:go": "go build ./cmd/zero",
     "smoke:build": "bun run scripts/smoke-build.ts",
+    "smoke:go": "bun run scripts/smoke-go.ts",
     "review:pr": "bun run scripts/pr-review.ts",
     "package:release": "bun run scripts/package-release.ts",
     "verify:release": "bun run scripts/release-checksums.ts",

--- a/scripts/smoke-go.ts
+++ b/scripts/smoke-go.ts
@@ -28,7 +28,12 @@ if (exitCode !== 0) {
 let expectedVersion: string;
 
 try {
-  expectedVersion = JSON.parse(packageText).version;
+  const parsedPackage = JSON.parse(packageText);
+  if (typeof parsedPackage?.version !== 'string') {
+    console.error(`Invalid package.json: version is not a string (${JSON.stringify(parsedPackage?.version)})`);
+    process.exit(1);
+  }
+  expectedVersion = parsedPackage.version;
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`Failed to parse package.json: ${message}`);

--- a/scripts/smoke-go.ts
+++ b/scripts/smoke-go.ts
@@ -1,0 +1,46 @@
+import { zeroArtifactName, zeroArtifactPath } from './artifact';
+
+const artifact = Bun.file(zeroArtifactPath);
+
+if (!(await artifact.exists())) {
+  console.error(`Go build artifact not found: ${zeroArtifactName}`);
+  console.error('Run `bun run build:go` before `bun run smoke:go`.');
+  process.exit(1);
+}
+
+const child = Bun.spawn([zeroArtifactPath, '--version'], {
+  stderr: 'pipe',
+  stdout: 'pipe',
+});
+
+const [exitCode, stdout, stderr, packageText] = await Promise.all([
+  child.exited,
+  new Response(child.stdout).text(),
+  new Response(child.stderr).text(),
+  Bun.file('package.json').text(),
+]);
+
+if (exitCode !== 0) {
+  console.error(stderr.trim() || `${zeroArtifactName} --version exited with ${exitCode}`);
+  process.exit(exitCode);
+}
+
+let expectedVersion: string;
+
+try {
+  expectedVersion = JSON.parse(packageText).version;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to parse package.json: ${message}`);
+  process.exit(1);
+}
+
+const expectedOutput = `zero ${expectedVersion}`;
+const actualOutput = stdout.trim();
+
+if (actualOutput !== expectedOutput) {
+  console.error(`Expected ${zeroArtifactName} --version to print ${expectedOutput}, got ${actualOutput}`);
+  process.exit(1);
+}
+
+console.log(`${zeroArtifactName} Go smoke check passed (${expectedVersion})`);

--- a/tests/foundation-tools.test.ts
+++ b/tests/foundation-tools.test.ts
@@ -22,8 +22,31 @@ describe('package scripts', () => {
 
     expect(pkg.scripts.typecheck).toBe('bunx tsc --noEmit');
     expect(pkg.scripts.test).toBe('bun test ./tests --timeout 15000');
+    expect(pkg.scripts['test:go']).toBe('go test ./...');
     expect(pkg.scripts.build).toBe('bun run scripts/build.ts');
+    expect(pkg.scripts['build:go']).toBe('go build ./cmd/zero');
     expect(pkg.scripts['smoke:build']).toBe('bun run scripts/smoke-build.ts');
+    expect(pkg.scripts['smoke:go']).toBe('bun run scripts/smoke-go.ts');
+  });
+
+  it('keeps CI wired to the stable project commands', async () => {
+    const workflow = await readFile(join(process.cwd(), '.github/workflows/ci.yml'), 'utf-8');
+
+    expect(workflow).toContain('run: bun run test:go');
+    expect(workflow).toContain('run: bun run build:go');
+    expect(workflow).toContain('run: bun run smoke:go');
+    expect(workflow).toContain('run: bun run test');
+    expect(workflow).toContain('run: bun run typecheck');
+    expect(workflow).toContain('run: bun run smoke:build');
+  });
+
+  it('documents the npm wrapper smoke checklist', async () => {
+    const checklist = await readFile(join(process.cwd(), 'docs/NPM_WRAPPER_SMOKE.md'), 'utf-8');
+
+    expect(checklist).toContain('bun install --frozen-lockfile');
+    expect(checklist).toContain('bun run smoke:build');
+    expect(checklist).toContain('node_modules/.bin');
+    expect(checklist).toContain('bun run smoke:go');
   });
 });
 


### PR DESCRIPTION
## Summary
- add stable package scripts for Go test, build, and artifact smoke validation
- wire CI Go steps through those package scripts and add a Go smoke step
- document the npm wrapper smoke checklist and pin the contracts with focused tests

## Testing
- bun test tests/foundation-tools.test.ts --timeout 15000
- bun run test:go
- bun run build:go
- bun run smoke:go
- bun run typecheck

## Notes
- Local latest-main full `bun run test` had 5 pre-existing failures in headless-exec/MCP before this branch; this PR does not touch those areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified project direction to a Go-native core with an npm wrapper, updated quickstart/prereqs and architecture diagrams, and added an npm-wrapper smoke checklist.

* **Chores**
  * CI now invokes Go test/build/smoke via repository scripts; added scripts to run Go tests, build the Go entrypoint, and perform Go smoke checks; added a Go build smoke-test utility.

* **Tests**
  * Extended test suite to validate repo scripts, CI steps, and smoke-check documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->