### PR TITLE
[codex] add Go read-only core tools

### DIFF
--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -1,0 +1,71 @@
+package tools
+
+import (
+	"fmt"
+	"math"
+)
+
+func stringArg(args map[string]any, key string, fallback string, required bool) (string, error) {
+	value, ok := args[key]
+	if !ok || value == nil {
+		if required {
+			return "", fmt.Errorf("%s is required", key)
+		}
+		return fallback, nil
+	}
+
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return "", fmt.Errorf("%s must be a non-empty string", key)
+	}
+	return text, nil
+}
+
+func boolArg(args map[string]any, key string, fallback bool) (bool, error) {
+	value, ok := args[key]
+	if !ok || value == nil {
+		return fallback, nil
+	}
+
+	boolean, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("%s must be a boolean", key)
+	}
+	return boolean, nil
+}
+
+func intArg(args map[string]any, key string, fallback int, min int, max int) (int, error) {
+	value, ok := args[key]
+	if !ok || value == nil {
+		return fallback, nil
+	}
+
+	var number int
+	switch typed := value.(type) {
+	case int:
+		number = typed
+	case int32:
+		number = int(typed)
+	case int64:
+		number = int(typed)
+	case float64:
+		if math.Trunc(typed) != typed {
+			return 0, fmt.Errorf("%s must be an integer", key)
+		}
+		number = int(typed)
+	default:
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+
+	if number < min {
+		return 0, fmt.Errorf("%s must be at least %d", key, min)
+	}
+	if max > 0 && number > max {
+		return 0, fmt.Errorf("%s must be at most %d", key, max)
+	}
+	return number, nil
+}
+
+func intPtr(value int) *int {
+	return &value
+}

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -1,0 +1,179 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadFileToolReadsLineRanges(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta\ngamma\ndelta")
+
+	result := NewReadFileTool(root).Run(context.Background(), map[string]any{
+		"path":       "notes.txt",
+		"start_line": 2,
+		"max_lines":  2,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	for _, want := range []string{
+		"File: notes.txt (lines 2-3 of 4)",
+		"2 | beta",
+		"3 | gamma",
+	} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, result.Output)
+		}
+	}
+	if strings.Contains(result.Output, "alpha") || strings.Contains(result.Output, "delta") {
+		t.Fatalf("line range leaked outside requested slice: %q", result.Output)
+	}
+}
+
+func TestReadFileToolRejectsOutsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	writeTestFile(t, outside, "secret")
+
+	result := NewReadFileTool(root).Run(context.Background(), map[string]any{
+		"path": outside,
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "must stay inside the workspace") {
+		t.Fatalf("expected workspace error, got %q", result.Output)
+	}
+}
+
+func TestListDirectoryToolListsRecursivelyAndIgnoresJunk(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "src", "main.go"), "package main")
+	writeTestFile(t, filepath.Join(root, "node_modules", "leftpad", "index.js"), "module.exports = 1")
+	writeTestFile(t, filepath.Join(root, "README.md"), "# Zero")
+
+	result := NewListDirectoryTool(root).Run(context.Background(), map[string]any{
+		"path":      ".",
+		"recursive": true,
+		"max_depth": 2,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "src/") || !strings.Contains(result.Output, "main.go") {
+		t.Fatalf("expected recursive source listing, got %q", result.Output)
+	}
+	if !strings.Contains(result.Output, "README.md") {
+		t.Fatalf("expected README.md, got %q", result.Output)
+	}
+	if strings.Contains(result.Output, "node_modules") || strings.Contains(result.Output, "leftpad") {
+		t.Fatalf("expected ignored junk directory, got %q", result.Output)
+	}
+}
+
+func TestGlobToolFindsMatchesWithLimit(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "a.go"), "package zero")
+	writeTestFile(t, filepath.Join(root, "nested", "b.go"), "package nested")
+	writeTestFile(t, filepath.Join(root, "nested", "c.txt"), "text")
+
+	result := NewGlobTool(root).Run(context.Background(), map[string]any{
+		"pattern": "**/*.go",
+		"limit":   1,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if result.Truncated != true {
+		t.Fatalf("expected truncated result")
+	}
+	if got := strings.Count(result.Output, ".go"); got != 1 {
+		t.Fatalf("expected exactly one go match, got %d in %q", got, result.Output)
+	}
+}
+
+func TestGlobToolCanIncludeDirectoryMatches(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := NewGlobTool(root).Run(context.Background(), map[string]any{
+		"pattern":      "src",
+		"include_dirs": true,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if strings.TrimSpace(result.Output) != "src" {
+		t.Fatalf("expected src directory match, got %q", result.Output)
+	}
+}
+
+func TestGrepToolSearchesContent(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "cmd", "main.go"), "package main\nfunc main() {}\n")
+	writeTestFile(t, filepath.Join(root, "README.md"), "main docs\n")
+
+	result := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":    "func main",
+		"path":       ".",
+		"glob":       "**/*.go",
+		"head_limit": 5,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "cmd/main.go:2: func main() {}") {
+		t.Fatalf("expected formatted grep result, got %q", result.Output)
+	}
+	if strings.Contains(result.Output, "README.md") {
+		t.Fatalf("glob filter leaked README match: %q", result.Output)
+	}
+}
+
+func TestGrepToolSupportsFilesAndCountModes(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "a.txt"), "needle\nneedle\n")
+	writeTestFile(t, filepath.Join(root, "b.txt"), "needle\n")
+
+	files := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":     "needle",
+		"output_mode": "files_with_matches",
+	})
+	if files.Status != StatusOK {
+		t.Fatalf("expected files result, got %s: %s", files.Status, files.Output)
+	}
+	if !strings.Contains(files.Output, "a.txt") || !strings.Contains(files.Output, "b.txt") {
+		t.Fatalf("expected both files, got %q", files.Output)
+	}
+
+	count := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":     "needle",
+		"output_mode": "count",
+	})
+	if count.Output != "3 matches found" {
+		t.Fatalf("expected count output, got %q", count.Output)
+	}
+}
+
+func writeTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -95,7 +96,8 @@ func TestGlobToolFindsMatchesWithLimit(t *testing.T) {
 	if result.Truncated != true {
 		t.Fatalf("expected truncated result")
 	}
-	if got := strings.Count(result.Output, ".go"); got != 1 {
+	matchedPaths := regexp.MustCompile(`(?m)^[^\n]*\.go\b`).FindAllString(result.Output, -1)
+	if got := len(matchedPaths); got != 1 {
 		t.Fatalf("expected exactly one go match, got %d in %q", got, result.Output)
 	}
 }
@@ -162,6 +164,9 @@ func TestGrepToolSupportsFilesAndCountModes(t *testing.T) {
 		"pattern":     "needle",
 		"output_mode": "count",
 	})
+	if count.Status != StatusOK {
+		t.Fatalf("expected count result, got %s: %s", count.Status, count.Output)
+	}
 	if count.Output != "3 matches found" {
 		t.Fatalf("expected count output, got %q", count.Output)
 	}

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -1,0 +1,155 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type globTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+func NewGlobTool(workspaceRoot string) Tool {
+	return globTool{
+		baseTool: baseTool{
+			name:        "glob",
+			description: "Find files by glob pattern inside the workspace.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"pattern":      {Type: "string", Description: `Glob pattern to match, for example "**/*.go".`},
+					"cwd":          {Type: "string", Description: "Directory to scan. Defaults to workspace root.", Default: "."},
+					"limit":        {Type: "integer", Description: "Maximum matches to return.", Default: 100, Minimum: intPtr(1), Maximum: intPtr(1000)},
+					"include_dirs": {Type: "boolean", Description: "Whether directory matches should be included.", Default: false},
+				},
+				Required:             []string{"pattern"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Finds matching paths without reading contents or modifying files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool globTool) Run(_ context.Context, args map[string]any) Result {
+	pattern, err := stringArg(args, "pattern", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for glob: " + err.Error())
+	}
+	cwd, err := stringArg(args, "cwd", ".", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for glob: " + err.Error())
+	}
+	limit, err := intArg(args, "limit", 100, 1, 1000)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for glob: " + err.Error())
+	}
+	includeDirs, err := boolArg(args, "include_dirs", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for glob: " + err.Error())
+	}
+
+	root, _, err := resolveWorkspacePath(tool.workspaceRoot, cwd)
+	if err != nil {
+		return errorResult("Error running glob " + fmt.Sprintf("%q", pattern) + ": " + err.Error())
+	}
+	matcher, err := compileGlob(pattern)
+	if err != nil {
+		return errorResult("Error running glob " + fmt.Sprintf("%q", pattern) + ": " + err.Error())
+	}
+
+	matches, err := scanGlob(root, matcher, includeDirs)
+	if err != nil {
+		return errorResult("Error running glob " + fmt.Sprintf("%q", pattern) + ": " + err.Error())
+	}
+	if len(matches) == 0 {
+		return okResult("No matches found for " + pattern)
+	}
+
+	sort.Strings(matches)
+	truncated := len(matches) > limit
+	if truncated {
+		matches = matches[:limit]
+	}
+
+	return Result{
+		Status:    StatusOK,
+		Output:    strings.Join(matches, "\n"),
+		Truncated: truncated,
+		Meta: map[string]string{
+			"pattern": pattern,
+		},
+	}
+}
+
+func scanGlob(root string, matcher *regexp.Regexp, includeDirs bool) ([]string, error) {
+	matches := []string{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+		if entry.IsDir() && shouldSkipDirectory(entry.Name()) {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() && !includeDirs {
+			return nil
+		}
+
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		normalized := filepath.ToSlash(relative)
+		if matcher.MatchString(normalized) {
+			matches = append(matches, normalized)
+		}
+		return nil
+	})
+	if errors.Is(err, filepath.SkipDir) {
+		return matches, nil
+	}
+	return matches, err
+}
+
+func compileGlob(pattern string) (*regexp.Regexp, error) {
+	if pattern == "" {
+		return nil, fmt.Errorf("pattern is required")
+	}
+	return regexp.Compile("^" + globToRegexp(filepath.ToSlash(pattern)) + "$")
+}
+
+func globToRegexp(pattern string) string {
+	var builder strings.Builder
+	for index := 0; index < len(pattern); index++ {
+		char := pattern[index]
+		switch char {
+		case '*':
+			if index+1 < len(pattern) && pattern[index+1] == '*' {
+				index++
+				if index+1 < len(pattern) && pattern[index+1] == '/' {
+					index++
+					builder.WriteString("(?:.*/)?")
+				} else {
+					builder.WriteString(".*")
+				}
+			} else {
+				builder.WriteString("[^/]*")
+			}
+		case '?':
+			builder.WriteString("[^/]")
+		default:
+			builder.WriteString(regexp.QuoteMeta(string(char)))
+		}
+	}
+	return builder.String()
+}

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
@@ -93,7 +92,7 @@ func scanGlob(root string, matcher *regexp.Regexp, includeDirs bool) ([]string, 
 	matches := []string{}
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			return nil
+			return walkErr
 		}
 		if path == root {
 			return nil
@@ -115,9 +114,6 @@ func scanGlob(root string, matcher *regexp.Regexp, includeDirs bool) ([]string, 
 		}
 		return nil
 	})
-	if errors.Is(err, filepath.SkipDir) {
-		return matches, nil
-	}
 	return matches, err
 }
 

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -168,7 +168,7 @@ func grepFiles(workspaceRoot string, target string, globMatcher *regexp.Regexp) 
 	files := []string{}
 	err = filepath.WalkDir(target, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			return nil
+			return walkErr
 		}
 		if path == target {
 			return nil

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -1,0 +1,223 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type grepTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+type grepMatch struct {
+	file string
+	line int
+	text string
+	hits int
+}
+
+func NewGrepTool(workspaceRoot string) Tool {
+	return grepTool{
+		baseTool: baseTool{
+			name:        "grep",
+			description: "Search file contents with a regular expression inside the workspace.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"pattern":          {Type: "string", Description: "Regular expression pattern to search for."},
+					"path":             {Type: "string", Description: "Directory or file to search. Defaults to workspace root.", Default: "."},
+					"glob":             {Type: "string", Description: `Optional glob filter, for example "**/*.go".`},
+					"output_mode":      {Type: "string", Description: "Output mode.", Enum: []string{"content", "files_with_matches", "count"}, Default: "content"},
+					"-i":               {Type: "boolean", Description: "Case insensitive search.", Default: false},
+					"case_insensitive": {Type: "boolean", Description: "Case insensitive search.", Default: false},
+					"head_limit":       {Type: "integer", Description: "Maximum content results to return.", Default: 50, Minimum: intPtr(1)},
+				},
+				Required:             []string{"pattern"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Searches file paths and matching lines without modifying files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
+	pattern, err := stringArg(args, "pattern", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	targetPath, err := stringArg(args, "path", ".", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	globPattern, err := stringArg(args, "glob", "", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	outputMode, err := stringArg(args, "output_mode", "content", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	if outputMode != "content" && outputMode != "files_with_matches" && outputMode != "count" {
+		return errorResult("Error: Invalid arguments for grep: output_mode must be content, files_with_matches, or count")
+	}
+	caseInsensitive, err := boolArg(args, "case_insensitive", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	shortInsensitive, err := boolArg(args, "-i", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	headLimit, err := intArg(args, "head_limit", 50, 1, 0)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+
+	if caseInsensitive || shortInsensitive {
+		pattern = "(?i)" + pattern
+	}
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		return errorResult("Error running grep: " + err.Error())
+	}
+
+	target, _, err := resolveWorkspacePath(tool.workspaceRoot, targetPath)
+	if err != nil {
+		return errorResult("Error running grep: " + err.Error())
+	}
+
+	var globMatcher *regexp.Regexp
+	if globPattern != "" {
+		globMatcher, err = compileGlob(globPattern)
+		if err != nil {
+			return errorResult("Error running grep: " + err.Error())
+		}
+	}
+
+	files, err := grepFiles(tool.workspaceRoot, target, globMatcher)
+	if err != nil {
+		return errorResult("Error running grep: " + err.Error())
+	}
+
+	matches := collectGrepMatches(tool.workspaceRoot, files, compiled)
+	if len(matches) == 0 {
+		if outputMode == "count" {
+			return okResult("0 matches found")
+		}
+		return okResult("No matches found.")
+	}
+
+	switch outputMode {
+	case "count":
+		total := 0
+		for _, match := range matches {
+			total += match.hits
+		}
+		return okResult(fmt.Sprintf("%d matches found", total))
+	case "files_with_matches":
+		seen := map[string]bool{}
+		files := []string{}
+		for _, match := range matches {
+			if !seen[match.file] {
+				seen[match.file] = true
+				files = append(files, match.file)
+			}
+		}
+		sort.Strings(files)
+		return okResult(strings.Join(files, "\n"))
+	default:
+		lines := make([]string, 0, len(matches))
+		for _, match := range matches {
+			if len(lines) >= headLimit {
+				break
+			}
+			lines = append(lines, fmt.Sprintf("%s:%d: %s", match.file, match.line, match.text))
+		}
+		return Result{
+			Status:    StatusOK,
+			Output:    strings.Join(lines, "\n"),
+			Truncated: len(matches) > headLimit,
+		}
+	}
+}
+
+func grepFiles(workspaceRoot string, target string, globMatcher *regexp.Regexp) ([]string, error) {
+	info, err := os.Stat(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		relative, err := filepath.Rel(workspaceRoot, target)
+		if err != nil {
+			return nil, err
+		}
+		if globMatcher == nil || globMatcher.MatchString(filepath.ToSlash(relative)) {
+			return []string{target}, nil
+		}
+		return []string{}, nil
+	}
+
+	files := []string{}
+	err = filepath.WalkDir(target, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if path == target {
+			return nil
+		}
+		if entry.IsDir() && shouldSkipDirectory(entry.Name()) {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(workspaceRoot, path)
+		if err != nil {
+			return err
+		}
+		if globMatcher == nil || globMatcher.MatchString(filepath.ToSlash(relative)) {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func collectGrepMatches(workspaceRoot string, files []string, compiled *regexp.Regexp) []grepMatch {
+	matches := []grepMatch{}
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			continue
+		}
+		relative, err := filepath.Rel(workspaceRoot, file)
+		if err != nil {
+			continue
+		}
+		for index, line := range strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n") {
+			lineMatches := compiled.FindAllStringIndex(line, -1)
+			if len(lineMatches) == 0 {
+				continue
+			}
+			matches = append(matches, grepMatch{
+				file: filepath.ToSlash(relative),
+				line: index + 1,
+				text: strings.TrimRight(line, "\r"),
+				hits: len(lineMatches),
+			})
+		}
+	}
+	return matches
+}

--- a/internal/tools/list_directory.go
+++ b/internal/tools/list_directory.go
@@ -1,0 +1,103 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type listDirectoryTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+func NewListDirectoryTool(workspaceRoot string) Tool {
+	return listDirectoryTool{
+		baseTool: baseTool{
+			name:        "list_directory",
+			description: "List files and directories in a workspace path with optional recursion.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"path":      {Type: "string", Description: "Directory to list. Defaults to workspace root.", Default: "."},
+					"recursive": {Type: "boolean", Description: "Whether to list recursively.", Default: false},
+					"max_depth": {Type: "integer", Description: "Maximum recursion depth when recursive is true.", Default: 2, Minimum: intPtr(1), Maximum: intPtr(5)},
+				},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Lists directory entries without modifying files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool listDirectoryTool) Run(_ context.Context, args map[string]any) Result {
+	requestedPath, err := stringArg(args, "path", ".", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for list_directory: " + err.Error())
+	}
+	recursive, err := boolArg(args, "recursive", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for list_directory: " + err.Error())
+	}
+	maxDepth, err := intArg(args, "max_depth", 2, 1, 5)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for list_directory: " + err.Error())
+	}
+	if !recursive {
+		maxDepth = 0
+	}
+
+	absolutePath, relativePath, err := resolveWorkspacePath(tool.workspaceRoot, requestedPath)
+	if err != nil {
+		return errorResult("Error listing directory " + requestedPath + ": " + err.Error())
+	}
+
+	entries, err := listDirectoryEntries(absolutePath, 0, maxDepth)
+	if err != nil {
+		return errorResult("Error listing directory " + relativePath + ": " + err.Error())
+	}
+	if len(entries) == 0 {
+		return okResult("Directory is empty: " + relativePath)
+	}
+	return okResult("Contents of " + relativePath + ":\n\n" + strings.Join(entries, "\n"))
+}
+
+func listDirectoryEntries(path string, depth int, maxDepth int) ([]string, error) {
+	dirEntries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(dirEntries, func(left int, right int) bool {
+		if dirEntries[left].IsDir() != dirEntries[right].IsDir() {
+			return dirEntries[left].IsDir()
+		}
+		return dirEntries[left].Name() < dirEntries[right].Name()
+	})
+
+	results := make([]string, 0, len(dirEntries))
+	for _, entry := range dirEntries {
+		if entry.IsDir() && shouldSkipDirectory(entry.Name()) {
+			continue
+		}
+
+		indent := strings.Repeat("  ", depth)
+		if entry.IsDir() {
+			results = append(results, indent+entry.Name()+"/")
+			if depth < maxDepth {
+				children, err := listDirectoryEntries(filepath.Join(path, entry.Name()), depth+1, maxDepth)
+				if err == nil {
+					results = append(results, children...)
+				}
+			}
+			continue
+		}
+
+		results = append(results, fmt.Sprintf("%s%s", indent, entry.Name()))
+	}
+
+	return results, nil
+}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -1,0 +1,104 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type readFileTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+func NewReadFileTool(workspaceRoot string) Tool {
+	return readFileTool{
+		baseTool: baseTool{
+			name:        "read_file",
+			description: "Read a file with optional 1-based inclusive line range and max line cap.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"path":       {Type: "string", Description: "Path of the file to read."},
+					"start_line": {Type: "integer", Description: "1-based inclusive line number to start reading from.", Minimum: intPtr(1)},
+					"end_line":   {Type: "integer", Description: "1-based inclusive line number to stop reading at.", Minimum: intPtr(1)},
+					"max_lines":  {Type: "integer", Description: "Maximum number of lines to return.", Minimum: intPtr(1)},
+				},
+				Required:             []string{"path"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Reads file contents without modifying files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool readFileTool) Run(_ context.Context, args map[string]any) Result {
+	requestedPath, err := stringArg(args, "path", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
+	}
+	startLine, err := intArg(args, "start_line", 1, 1, 0)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
+	}
+	endLine, err := intArg(args, "end_line", 0, 1, 0)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
+	}
+	maxLines, err := intArg(args, "max_lines", 0, 1, 0)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
+	}
+
+	absolutePath, relativePath, err := resolveWorkspacePath(tool.workspaceRoot, requestedPath)
+	if err != nil {
+		return errorResult("Error reading file " + requestedPath + ": " + err.Error())
+	}
+
+	content, err := os.ReadFile(absolutePath)
+	if err != nil {
+		return errorResult("Error reading file " + relativePath + ": " + err.Error())
+	}
+
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	total := len(lines)
+	if startLine > total {
+		return okResult(fmt.Sprintf("File: %s\n(start_line %d is past the end of the file, which has %d lines)", relativePath, startLine, total))
+	}
+
+	if endLine == 0 || endLine > total {
+		endLine = total
+	}
+	if endLine < startLine {
+		return errorResult("Error: Invalid arguments for read_file: end_line must be greater than or equal to start_line")
+	}
+
+	selected := lines[startLine-1 : endLine]
+	truncated := false
+	if maxLines > 0 && len(selected) > maxLines {
+		selected = selected[:maxLines]
+		truncated = true
+	}
+
+	lastLine := startLine + len(selected) - 1
+	width := len(strconv.Itoa(lastLine))
+	numbered := make([]string, 0, len(selected))
+	for index, line := range selected {
+		lineNumber := strconv.Itoa(startLine + index)
+		numbered = append(numbered, strings.Repeat(" ", width-len(lineNumber))+lineNumber+" | "+line)
+	}
+
+	header := fmt.Sprintf("File: %s (%d lines)", relativePath, total)
+	if startLine != 1 || endLine != total || maxLines > 0 {
+		header = fmt.Sprintf("File: %s (lines %d-%d of %d)", relativePath, startLine, lastLine, total)
+	}
+
+	return Result{
+		Status:    StatusOK,
+		Output:    header + "\n\n" + strings.Join(numbered, "\n"),
+		Truncated: truncated,
+	}
+}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -63,7 +63,9 @@ func (tool readFileTool) Run(_ context.Context, args map[string]any) Result {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}
 
-	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+	normalizedContent := strings.ReplaceAll(string(content), "\r\n", "\n")
+	normalizedContent = strings.TrimSuffix(normalizedContent, "\n")
+	lines := strings.Split(normalizedContent, "\n")
 	total := len(lines)
 	if startLine > total {
 		return okResult(fmt.Sprintf("File: %s\n(start_line %d is past the end of the file, which has %d lines)", relativePath, startLine, total))

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -1,0 +1,50 @@
+package tools
+
+import "context"
+
+type Registry struct {
+	tools map[string]Tool
+}
+
+func NewRegistry() *Registry {
+	return &Registry{tools: make(map[string]Tool)}
+}
+
+func (registry *Registry) Register(tool Tool) {
+	registry.tools[tool.Name()] = tool
+}
+
+func (registry *Registry) Get(name string) (Tool, bool) {
+	tool, ok := registry.tools[name]
+	return tool, ok
+}
+
+func (registry *Registry) All() []Tool {
+	tools := make([]Tool, 0, len(registry.tools))
+	for _, tool := range registry.tools {
+		tools = append(tools, tool)
+	}
+	return tools
+}
+
+func (registry *Registry) Run(ctx context.Context, name string, args map[string]any) Result {
+	tool, ok := registry.Get(name)
+	if !ok {
+		return errorResult(`Error: Unknown tool "` + name + `".`)
+	}
+
+	if tool.Safety().Permission != PermissionAllow {
+		return errorResult("Error: Permission required for " + name + ": " + tool.Safety().Reason)
+	}
+
+	return tool.Run(ctx, args)
+}
+
+func CoreReadOnlyTools(workspaceRoot string) []Tool {
+	return []Tool{
+		NewReadFileTool(workspaceRoot),
+		NewListDirectoryTool(workspaceRoot),
+		NewGlobTool(workspaceRoot),
+		NewGrepTool(workspaceRoot),
+	}
+}

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -1,0 +1,69 @@
+package tools
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
+	toolset := CoreReadOnlyTools(t.TempDir())
+	if len(toolset) != 4 {
+		t.Fatalf("expected 4 core read-only tools, got %d", len(toolset))
+	}
+
+	for _, tool := range toolset {
+		if tool.Name() == "" {
+			t.Fatalf("tool has empty name")
+		}
+		if tool.Description() == "" {
+			t.Fatalf("%s has empty description", tool.Name())
+		}
+		if tool.Safety().SideEffect != SideEffectRead {
+			t.Fatalf("%s side effect = %s, want read", tool.Name(), tool.Safety().SideEffect)
+		}
+		if tool.Safety().Permission != PermissionAllow {
+			t.Fatalf("%s permission = %s, want allow", tool.Name(), tool.Safety().Permission)
+		}
+		if tool.Safety().Reason == "" {
+			t.Fatalf("%s has empty safety reason", tool.Name())
+		}
+
+		schema := tool.Parameters()
+		if schema.Type != "object" {
+			t.Fatalf("%s schema type = %s, want object", tool.Name(), schema.Type)
+		}
+		if schema.Properties == nil {
+			t.Fatalf("%s schema properties are nil", tool.Name())
+		}
+		if schema.AdditionalProperties {
+			t.Fatalf("%s schema should disallow additional properties", tool.Name())
+		}
+	}
+}
+
+func TestRegistryRunsToolsThroughSafePath(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(NewReadFileTool(t.TempDir()))
+
+	result := registry.Run(context.Background(), "read_file", map[string]any{
+		"path": "missing.txt",
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected read error status, got %s", result.Status)
+	}
+	if result.Output == "" {
+		t.Fatalf("expected an error output")
+	}
+}
+
+func TestRegistryReportsUnknownTools(t *testing.T) {
+	result := NewRegistry().Run(context.Background(), "missing", map[string]any{})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if result.Output != `Error: Unknown tool "missing".` {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -1,0 +1,102 @@
+package tools
+
+import "context"
+
+type SideEffect string
+type Permission string
+type Status string
+
+const (
+	SideEffectRead           SideEffect = "read"
+	SideEffectWrite          SideEffect = "write"
+	SideEffectShell          SideEffect = "shell"
+	SideEffectNetwork        SideEffect = "network"
+	SideEffectOutOfWorkspace SideEffect = "out_of_workspace"
+)
+
+const (
+	PermissionAllow  Permission = "allow"
+	PermissionPrompt Permission = "prompt"
+	PermissionDeny   Permission = "deny"
+)
+
+const (
+	StatusOK    Status = "ok"
+	StatusError Status = "error"
+)
+
+type Safety struct {
+	SideEffect SideEffect
+	Permission Permission
+	Reason     string
+}
+
+type Schema struct {
+	Type                 string                    `json:"type"`
+	Properties           map[string]PropertySchema `json:"properties,omitempty"`
+	Required             []string                  `json:"required,omitempty"`
+	AdditionalProperties bool                      `json:"additionalProperties"`
+}
+
+type PropertySchema struct {
+	Type        string   `json:"type"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Default     any      `json:"default,omitempty"`
+	Minimum     *int     `json:"minimum,omitempty"`
+	Maximum     *int     `json:"maximum,omitempty"`
+}
+
+type Result struct {
+	Status    Status
+	Output    string
+	Truncated bool
+	Meta      map[string]string
+}
+
+type Tool interface {
+	Name() string
+	Description() string
+	Parameters() Schema
+	Safety() Safety
+	Run(ctx context.Context, args map[string]any) Result
+}
+
+type baseTool struct {
+	name        string
+	description string
+	parameters  Schema
+	safety      Safety
+}
+
+func (tool baseTool) Name() string {
+	return tool.name
+}
+
+func (tool baseTool) Description() string {
+	return tool.description
+}
+
+func (tool baseTool) Parameters() Schema {
+	return tool.parameters
+}
+
+func (tool baseTool) Safety() Safety {
+	return tool.safety
+}
+
+func okResult(output string) Result {
+	return Result{Status: StatusOK, Output: output}
+}
+
+func errorResult(output string) Result {
+	return Result{Status: StatusError, Output: output}
+}
+
+func readOnlySafety(reason string) Safety {
+	return Safety{
+		SideEffect: SideEffectRead,
+		Permission: PermissionAllow,
+		Reason:     reason,
+	}
+}

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var ignoredDirectories = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"dist":         true,
+	"build":        true,
+	".next":        true,
+	".turbo":       true,
+	"coverage":     true,
+	".cache":       true,
+	"tmp":          true,
+	"temp":         true,
+}
+
+func normalizeWorkspaceRoot(workspaceRoot string) string {
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return workspaceRoot
+	}
+	return root
+}
+
+func resolveWorkspacePath(workspaceRoot string, requestedPath string) (string, string, error) {
+	if requestedPath == "" {
+		requestedPath = "."
+	}
+
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", "", err
+	}
+
+	target := requestedPath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", "", err
+	}
+
+	if resolved, err := os.Readlink(target); err == nil {
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(filepath.Dir(target), resolved)
+		}
+		target, err = filepath.Abs(resolved)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", "", err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", "", fmt.Errorf("%s must stay inside the workspace", requestedPath)
+	}
+	if relative == "." {
+		return target, ".", nil
+	}
+	return target, filepath.ToSlash(relative), nil
+}
+
+func shouldSkipDirectory(name string) bool {
+	return ignoredDirectories[name]
+}

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -37,6 +36,10 @@ func resolveWorkspacePath(workspaceRoot string, requestedPath string) (string, s
 	if err != nil {
 		return "", "", err
 	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", "", err
+	}
 
 	target := requestedPath
 	if !filepath.IsAbs(target) {
@@ -47,15 +50,9 @@ func resolveWorkspacePath(workspaceRoot string, requestedPath string) (string, s
 	if err != nil {
 		return "", "", err
 	}
-
-	if resolved, err := os.Readlink(target); err == nil {
-		if !filepath.IsAbs(resolved) {
-			resolved = filepath.Join(filepath.Dir(target), resolved)
-		}
-		target, err = filepath.Abs(resolved)
-		if err != nil {
-			return "", "", err
-		}
+	target, err = filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", "", err
 	}
 
 	relative, err := filepath.Rel(root, target)


### PR DESCRIPTION
## Summary

- Add the first Go `internal/tools` package for Zero.
- Define tool metadata, JSON-schema-compatible parameter shapes, safety metadata, results, and registry safe-run behavior.
- Add read-only core tools: `read_file`, `list_directory`, `glob`, and `grep`.
- Keep tools workspace-scoped and read-only for this first Vasanth M0 slice.
- Add Go tests for metadata/schema, registry behavior, workspace rejection, line ranges, directory listing, glob matching, and grep output modes.

## Why

This starts Vasanth's Go M0 tools/TUI path without jumping into Bubble Tea or mutation tools too early. The TUI and agent loop can now consume a clean Go tool contract and safe read/search tools.

## Validation

Local:
- `git diff --cached --check` passed before commit.
- `git diff --check` passed.
- `bun run typecheck` passed.
- `bun test ./tests --timeout 15000` passed: 277 tests.
- `bun run build` passed.
- `bun run smoke:build` passed.

Blocked locally:
- `go test ./...` and `go build ./cmd/zero` could not run because `go` is not installed on this Windows machine.

CI:
- Existing CI runs `go test ./...` and `go build ./cmd/zero` on Ubuntu, macOS, and Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file tools: read file, list directory, glob matching, and grep-style search, plus a registry exposing read-only tools and safety metadata.

* **Tests**
  * Added comprehensive unit tests covering file operations, glob/grep behaviors, directory listing, and registry safety paths.

* **Chores**
  * Introduced core tooling types, workspace path handling, and argument validation utilities to support the new tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->