### PR TITLE
Add Go M0 write tools

### DIFF
--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -57,12 +57,18 @@ func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result 
 		return errorResult("Error applying patch: " + err.Error())
 	}
 	patchPath := tempFile.Name()
-	defer os.Remove(patchPath)
+	defer func() {
+		_ = os.Remove(patchPath)
+	}()
 	if _, err := tempFile.WriteString(patch); err != nil {
-		tempFile.Close()
+		_ = tempFile.Close()
 		return errorResult("Error applying patch: " + err.Error())
 	}
 	if err := tempFile.Close(); err != nil {
+		return errorResult("Error applying patch: " + err.Error())
+	}
+
+	if err := recheckPatchWriteTargets(applyRoot, patch); err != nil {
 		return errorResult("Error applying patch: " + err.Error())
 	}
 
@@ -93,6 +99,20 @@ func validatePatchPaths(root string, patch string) error {
 				return fmt.Errorf("patch path %q must stay inside the workspace", path)
 			}
 			if _, _, err := resolveWorkspaceTargetPath(root, path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func recheckPatchWriteTargets(root string, patch string) error {
+	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
+		for _, path := range patchPathsFromLine(line) {
+			if path == "" || path == "/dev/null" {
+				continue
+			}
+			if err := recheckWorkspaceWriteTarget(root, path); err != nil {
 				return err
 			}
 		}

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -1,0 +1,124 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type applyPatchTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+func NewApplyPatchTool(workspaceRoot string) Tool {
+	return applyPatchTool{
+		baseTool: baseTool{
+			name:        "apply_patch",
+			description: "Apply a unified diff patch inside the workspace.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"patch": {Type: "string", Description: "Unified diff patch to apply."},
+					"cwd":   {Type: "string", Description: "Directory where the patch should be applied. Defaults to workspace root.", Default: "."},
+				},
+				Required:             []string{"patch"},
+				AdditionalProperties: false,
+			},
+			safety: promptSafety(SideEffectWrite, "Applies patch hunks that can create, edit, or delete files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result {
+	patch, err := stringArg(args, "patch", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for apply_patch: " + err.Error())
+	}
+	cwd, err := stringArg(args, "cwd", ".", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for apply_patch: " + err.Error())
+	}
+
+	applyRoot, relativeRoot, err := resolveWorkspacePath(tool.workspaceRoot, cwd)
+	if err != nil {
+		return errorResult("Error applying patch: " + err.Error())
+	}
+	if err := validatePatchPaths(applyRoot, patch); err != nil {
+		return errorResult("Error applying patch: " + err.Error())
+	}
+
+	tempFile, err := os.CreateTemp("", "zero-patch-*.patch")
+	if err != nil {
+		return errorResult("Error applying patch: " + err.Error())
+	}
+	patchPath := tempFile.Name()
+	defer os.Remove(patchPath)
+	if _, err := tempFile.WriteString(patch); err != nil {
+		tempFile.Close()
+		return errorResult("Error applying patch: " + err.Error())
+	}
+	if err := tempFile.Close(); err != nil {
+		return errorResult("Error applying patch: " + err.Error())
+	}
+
+	command := exec.CommandContext(ctx, "git", "apply", "--whitespace=nowarn", patchPath)
+	command.Dir = applyRoot
+	output, err := command.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return errorResult("Error applying patch: " + message)
+	}
+
+	if relativeRoot == "." {
+		return okResult("Patch applied successfully.")
+	}
+	return okResult("Patch applied successfully in " + relativeRoot + ".")
+}
+
+func validatePatchPaths(root string, patch string) error {
+	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
+		for _, path := range patchPathsFromLine(line) {
+			if path == "" || path == "/dev/null" {
+				continue
+			}
+			if filepath.IsAbs(path) || path == ".." || strings.HasPrefix(path, "../") {
+				return fmt.Errorf("patch path %q must stay inside the workspace", path)
+			}
+			if _, _, err := resolveWorkspaceTargetPath(root, path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func patchPathsFromLine(line string) []string {
+	if strings.HasPrefix(line, "diff --git ") {
+		fields := strings.Fields(line)
+		if len(fields) >= 4 {
+			return []string{stripPatchPrefix(fields[2]), stripPatchPrefix(fields[3])}
+		}
+	}
+	if strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			return []string{stripPatchPrefix(fields[1])}
+		}
+	}
+	return nil
+}
+
+func stripPatchPrefix(path string) string {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "a/")
+	path = strings.TrimPrefix(path, "b/")
+	return filepath.ToSlash(path)
+}

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -19,7 +19,10 @@ func stringArgWithEmpty(args map[string]any, key string, fallback string, requir
 	}
 
 	text, ok := value.(string)
-	if !ok || (!allowEmpty && text == "") {
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", key)
+	}
+	if !allowEmpty && text == "" {
 		return "", fmt.Errorf("%s must be a non-empty string", key)
 	}
 	return text, nil

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -6,6 +6,10 @@ import (
 )
 
 func stringArg(args map[string]any, key string, fallback string, required bool) (string, error) {
+	return stringArgWithEmpty(args, key, fallback, required, false)
+}
+
+func stringArgWithEmpty(args map[string]any, key string, fallback string, required bool, allowEmpty bool) (string, error) {
 	value, ok := args[key]
 	if !ok || value == nil {
 		if required {
@@ -15,7 +19,7 @@ func stringArg(args map[string]any, key string, fallback string, required bool) 
 	}
 
 	text, ok := value.(string)
-	if !ok || text == "" {
+	if !ok || (!allowEmpty && text == "") {
 		return "", fmt.Errorf("%s must be a non-empty string", key)
 	}
 	return text, nil

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -79,6 +79,9 @@ func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
 	if updated == content {
 		return okResult("No changes: new_string is identical to old_string.")
 	}
+	if err := recheckWorkspaceWriteTarget(tool.workspaceRoot, requestedPath); err != nil {
+		return errorResult("Error writing " + relativePath + ": " + err.Error())
+	}
 	if err := os.WriteFile(absolutePath, []byte(updated), 0o644); err != nil {
 		return errorResult("Error writing " + relativePath + ": " + err.Error())
 	}

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -1,0 +1,91 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type editFileTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+func NewEditFileTool(workspaceRoot string) Tool {
+	return editFileTool{
+		baseTool: baseTool{
+			name:        "edit_file",
+			description: "Replace an exact string in an existing file with uniqueness protection by default.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"path":        {Type: "string", Description: "Path of the file to edit."},
+					"old_string":  {Type: "string", Description: "Exact string to replace. Must match byte-for-byte."},
+					"new_string":  {Type: "string", Description: "Replacement string. May be empty."},
+					"replace_all": {Type: "boolean", Description: "Replace every occurrence instead of requiring uniqueness.", Default: false},
+				},
+				Required:             []string{"path", "old_string", "new_string"},
+				AdditionalProperties: false,
+			},
+			safety: promptSafety(SideEffectWrite, "Edits files in place."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
+	requestedPath, err := stringArg(args, "path", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
+	}
+	oldString, err := stringArg(args, "old_string", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
+	}
+	newString, err := stringArgWithEmpty(args, "new_string", "", true, true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
+	}
+	replaceAll, err := boolArg(args, "replace_all", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
+	}
+
+	absolutePath, relativePath, err := resolveWorkspacePath(tool.workspaceRoot, requestedPath)
+	if err != nil {
+		return errorResult("Error reading " + requestedPath + ": " + err.Error())
+	}
+	contentBytes, err := os.ReadFile(absolutePath)
+	if err != nil {
+		return errorResult("Error reading " + relativePath + ": " + err.Error())
+	}
+	content := string(contentBytes)
+	occurrences := strings.Count(content, oldString)
+
+	if occurrences == 0 {
+		return errorResult("Error: Could not find the exact string to replace in " + relativePath + ". The old_string must match the file byte-for-byte.")
+	}
+	if !replaceAll && occurrences > 1 {
+		return errorResult(fmt.Sprintf("Error: old_string matches %d locations in %s. Either make old_string more specific, or pass replace_all: true to replace every occurrence.", occurrences, relativePath))
+	}
+
+	updated := strings.Replace(content, oldString, newString, 1)
+	replacedCount := 1
+	if replaceAll {
+		updated = strings.ReplaceAll(content, oldString, newString)
+		replacedCount = occurrences
+	}
+	if updated == content {
+		return okResult("No changes: new_string is identical to old_string.")
+	}
+	if err := os.WriteFile(absolutePath, []byte(updated), 0o644); err != nil {
+		return errorResult("Error writing " + relativePath + ": " + err.Error())
+	}
+
+	suffix := ""
+	if replacedCount != 1 {
+		suffix = "s"
+	}
+	return okResult(fmt.Sprintf("Successfully edited %s (replaced %d occurrence%s).", relativePath, replacedCount, suffix))
+}

--- a/internal/tools/plan_tool_test.go
+++ b/internal/tools/plan_tool_test.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestUpdatePlanToolStoresAndFormatsPlan(t *testing.T) {
+	tool := NewUpdatePlanTool()
+
+	result := tool.Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{"id": "1", "content": "First step", "status": "completed"},
+			map[string]any{"id": "2", "content": "Second step", "status": "in_progress", "notes": "halfway"},
+			map[string]any{"id": "3", "content": "Third step", "status": "pending"},
+		},
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	for _, want := range []string{
+		"Current Plan:",
+		"1. [completed] First step",
+		"2. [in_progress] Second step",
+		"Notes: halfway",
+		"3. [pending] Third step",
+	} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, result.Output)
+		}
+	}
+
+	plan := tool.CurrentPlan()
+	if len(plan) != 3 {
+		t.Fatalf("expected 3 plan items, got %d", len(plan))
+	}
+	plan[0].Content = "mutated"
+	if tool.CurrentPlan()[0].Content != "First step" {
+		t.Fatalf("CurrentPlan returned mutable internal state")
+	}
+}
+
+func TestUpdatePlanToolRejectsInvalidStatus(t *testing.T) {
+	result := NewUpdatePlanTool().Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{"id": "1", "content": "Bad step", "status": "nope"},
+		},
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "status must be pending, in_progress, completed, or failed") {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}

--- a/internal/tools/plan_tool_test.go
+++ b/internal/tools/plan_tool_test.go
@@ -56,3 +56,29 @@ func TestUpdatePlanToolRejectsInvalidStatus(t *testing.T) {
 		t.Fatalf("unexpected output: %q", result.Output)
 	}
 }
+
+func TestUpdatePlanToolClearPlanResetsState(t *testing.T) {
+	tool := NewUpdatePlanTool()
+
+	result := tool.Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{"id": "1", "content": "First", "status": "pending"},
+			map[string]any{"id": "2", "content": "Second", "status": "in_progress"},
+		},
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if got := tool.CurrentPlan(); len(got) == 0 {
+		t.Fatalf("expected stored plan before ClearPlan")
+	}
+
+	tool.ClearPlan()
+	if got := tool.CurrentPlan(); len(got) != 0 {
+		t.Fatalf("expected empty plan after ClearPlan, got %d items", len(got))
+	}
+	if got := formatPlan(tool.CurrentPlan()); got != "Plan is currently empty." {
+		t.Fatalf("expected empty plan formatting after ClearPlan, got %q", got)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -6,6 +6,10 @@ type Registry struct {
 	tools map[string]Tool
 }
 
+type RunOptions struct {
+	PermissionGranted bool
+}
+
 func NewRegistry() *Registry {
 	return &Registry{tools: make(map[string]Tool)}
 }
@@ -28,13 +32,23 @@ func (registry *Registry) All() []Tool {
 }
 
 func (registry *Registry) Run(ctx context.Context, name string, args map[string]any) Result {
+	return registry.RunWithOptions(ctx, name, args, RunOptions{})
+}
+
+func (registry *Registry) RunWithOptions(ctx context.Context, name string, args map[string]any, options RunOptions) Result {
 	tool, ok := registry.Get(name)
 	if !ok {
 		return errorResult(`Error: Unknown tool "` + name + `".`)
 	}
 
-	if tool.Safety().Permission != PermissionAllow {
-		return errorResult("Error: Permission required for " + name + ": " + tool.Safety().Reason)
+	switch tool.Safety().Permission {
+	case PermissionAllow:
+	case PermissionPrompt:
+		if !options.PermissionGranted {
+			return errorResult("Error: Permission required for " + name + ": " + tool.Safety().Reason + ` The tool is marked "prompt" and was not executed.`)
+		}
+	default:
+		return errorResult("Error: Permission denied for " + name + ": " + tool.Safety().Reason)
 	}
 
 	return tool.Run(ctx, args)
@@ -47,4 +61,19 @@ func CoreReadOnlyTools(workspaceRoot string) []Tool {
 		NewGlobTool(workspaceRoot),
 		NewGrepTool(workspaceRoot),
 	}
+}
+
+func CoreWriteTools(workspaceRoot string) []Tool {
+	return []Tool{
+		NewWriteFileTool(workspaceRoot),
+		NewEditFileTool(workspaceRoot),
+		NewApplyPatchTool(workspaceRoot),
+		NewUpdatePlanTool(),
+	}
+}
+
+func CoreTools(workspaceRoot string) []Tool {
+	tools := append([]Tool{}, CoreReadOnlyTools(workspaceRoot)...)
+	tools = append(tools, CoreWriteTools(workspaceRoot)...)
+	return tools
 }

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -100,3 +100,11 @@ func readOnlySafety(reason string) Safety {
 		Reason:     reason,
 	}
 }
+
+func promptSafety(sideEffect SideEffect, reason string) Safety {
+	return Safety{
+		SideEffect: sideEffect,
+		Permission: PermissionPrompt,
+		Reason:     reason,
+	}
+}

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -1,0 +1,117 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type PlanItem struct {
+	ID      string
+	Content string
+	Status  string
+	Notes   string
+}
+
+type updatePlanTool struct {
+	baseTool
+	currentPlan []PlanItem
+}
+
+func NewUpdatePlanTool() *updatePlanTool {
+	return &updatePlanTool{
+		baseTool: baseTool{
+			name:        "update_plan",
+			description: "Create or update the in-memory plan for the current task.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"plan": {Type: "array", Description: "Ordered list of plan items."},
+				},
+				Required:             []string{"plan"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Updates in-memory planning state only."),
+		},
+	}
+}
+
+func (tool *updatePlanTool) Run(_ context.Context, args map[string]any) Result {
+	plan, err := parsePlanItems(args["plan"])
+	if err != nil {
+		return errorResult("Error: Invalid arguments for update_plan: " + err.Error())
+	}
+	tool.currentPlan = plan
+	return okResult(formatPlan(plan))
+}
+
+func (tool *updatePlanTool) CurrentPlan() []PlanItem {
+	return append([]PlanItem{}, tool.currentPlan...)
+}
+
+func (tool *updatePlanTool) ClearPlan() {
+	tool.currentPlan = nil
+}
+
+func parsePlanItems(value any) ([]PlanItem, error) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("plan must be an array")
+	}
+
+	plan := make([]PlanItem, 0, len(items))
+	for index, item := range items {
+		object, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("plan item %d must be an object", index+1)
+		}
+
+		id, err := stringArg(object, "id", "", true)
+		if err != nil {
+			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
+		}
+		content, err := stringArg(object, "content", "", true)
+		if err != nil {
+			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
+		}
+		status, err := stringArg(object, "status", "", true)
+		if err != nil {
+			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
+		}
+		if !isPlanStatus(status) {
+			return nil, fmt.Errorf("plan item %d status must be pending, in_progress, completed, or failed", index+1)
+		}
+		notes, err := stringArgWithEmpty(object, "notes", "", false, true)
+		if err != nil {
+			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
+		}
+
+		plan = append(plan, PlanItem{
+			ID:      id,
+			Content: content,
+			Status:  status,
+			Notes:   notes,
+		})
+	}
+	return plan, nil
+}
+
+func isPlanStatus(status string) bool {
+	return status == "pending" || status == "in_progress" || status == "completed" || status == "failed"
+}
+
+func formatPlan(plan []PlanItem) string {
+	if len(plan) == 0 {
+		return "Plan is currently empty."
+	}
+
+	lines := make([]string, 0, len(plan))
+	for index, item := range plan {
+		line := fmt.Sprintf("%d. [%s] %s", index+1, item.Status, item.Content)
+		if item.Notes != "" {
+			line += "\n   Notes: " + item.Notes
+		}
+		lines = append(lines, line)
+	}
+	return "Current Plan:\n" + strings.Join(lines, "\n")
+}

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -91,6 +91,9 @@ func resolveWorkspaceTargetPath(workspaceRoot string, requestedPath string) (str
 	if err != nil {
 		return "", "", err
 	}
+	if err := recheckWorkspaceWriteTarget(root, target); err != nil {
+		return "", "", err
+	}
 
 	existing := target
 	missingSegments := []string{}

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -131,6 +131,66 @@ func resolveWorkspaceTargetPath(workspaceRoot string, requestedPath string) (str
 	return resolved, filepath.ToSlash(relative), nil
 }
 
+func recheckWorkspaceWriteTarget(workspaceRoot string, requestedPath string) error {
+	if requestedPath == "" {
+		requestedPath = "."
+	}
+
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return err
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+
+	target := requestedPath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return fmt.Errorf("%s must stay inside the workspace", requestedPath)
+	}
+	if relative == "." {
+		return nil
+	}
+
+	current := root
+	for _, segment := range strings.Split(filepath.Clean(relative), string(filepath.Separator)) {
+		if segment == "." || segment == "" {
+			continue
+		}
+
+		current = filepath.Join(current, segment)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			symlinkRelative, err := filepath.Rel(root, current)
+			if err != nil {
+				symlinkRelative = current
+			}
+			return fmt.Errorf("%s must not traverse symlink %s", requestedPath, filepath.ToSlash(symlinkRelative))
+		}
+	}
+
+	return nil
+}
+
 func shouldSkipDirectory(name string) bool {
 	return ignoredDirectories[name]
 }

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -66,6 +67,68 @@ func resolveWorkspacePath(workspaceRoot string, requestedPath string) (string, s
 		return target, ".", nil
 	}
 	return target, filepath.ToSlash(relative), nil
+}
+
+func resolveWorkspaceTargetPath(workspaceRoot string, requestedPath string) (string, string, error) {
+	if requestedPath == "" {
+		requestedPath = "."
+	}
+
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", "", err
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", "", err
+	}
+
+	target := requestedPath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(root, target)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", "", err
+	}
+
+	existing := target
+	missingSegments := []string{}
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		} else if os.IsNotExist(err) {
+			parent := filepath.Dir(existing)
+			if parent == existing {
+				return "", "", err
+			}
+			missingSegments = append([]string{filepath.Base(existing)}, missingSegments...)
+			existing = parent
+			continue
+		} else {
+			return "", "", err
+		}
+	}
+
+	resolved, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", "", err
+	}
+	for _, segment := range missingSegments {
+		resolved = filepath.Join(resolved, segment)
+	}
+
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return "", "", err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", "", fmt.Errorf("%s must stay inside the workspace", requestedPath)
+	}
+	if relative == "." {
+		return resolved, ".", nil
+	}
+	return resolved, filepath.ToSlash(relative), nil
 }
 
 func shouldSkipDirectory(name string) bool {

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -65,6 +65,9 @@ func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
 	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
+	if err := recheckWorkspaceWriteTarget(tool.workspaceRoot, requestedPath); err != nil {
+		return errorResult("Error writing file " + relativePath + ": " + err.Error())
+	}
 	if err := os.WriteFile(absolutePath, []byte(content), 0o644); err != nil {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type writeFileTool struct {
+	baseTool
+	workspaceRoot string
+}
+
+func NewWriteFileTool(workspaceRoot string) Tool {
+	return writeFileTool{
+		baseTool: baseTool{
+			name:        "write_file",
+			description: "Create a new file, refusing to overwrite existing files unless overwrite is true.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"path":      {Type: "string", Description: "Absolute or relative path of the file to write."},
+					"content":   {Type: "string", Description: "Full file contents to write."},
+					"overwrite": {Type: "boolean", Description: "Whether to allow overwriting an existing file.", Default: false},
+				},
+				Required:             []string{"path", "content"},
+				AdditionalProperties: false,
+			},
+			safety: promptSafety(SideEffectWrite, "Creates or overwrites files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+	}
+}
+
+func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
+	requestedPath, err := stringArg(args, "path", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for write_file: " + err.Error())
+	}
+	content, err := stringArgWithEmpty(args, "content", "", true, true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for write_file: " + err.Error())
+	}
+	overwrite, err := boolArg(args, "overwrite", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for write_file: " + err.Error())
+	}
+
+	absolutePath, relativePath, err := resolveWorkspaceTargetPath(tool.workspaceRoot, requestedPath)
+	if err != nil {
+		return errorResult("Error writing file " + requestedPath + ": " + err.Error())
+	}
+
+	existed := false
+	if _, err := os.Stat(absolutePath); err == nil {
+		existed = true
+		if !overwrite {
+			return errorResult("Error: " + relativePath + " already exists. Pass overwrite: true to replace it.")
+		}
+	} else if !os.IsNotExist(err) {
+		return errorResult("Error writing file " + relativePath + ": " + err.Error())
+	}
+
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
+		return errorResult("Error writing file " + relativePath + ": " + err.Error())
+	}
+	if err := os.WriteFile(absolutePath, []byte(content), 0o644); err != nil {
+		return errorResult("Error writing file " + relativePath + ": " + err.Error())
+	}
+
+	if existed {
+		return okResult(fmt.Sprintf("Overwrote %s (%d bytes).", relativePath, len([]byte(content))))
+	}
+	return okResult(fmt.Sprintf("Created %s (%d bytes).", relativePath, len([]byte(content))))
+}

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -1,0 +1,311 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCoreToolsExposeWriteAndPlanTools(t *testing.T) {
+	toolset := CoreTools(t.TempDir())
+	byName := make(map[string]Tool, len(toolset))
+	for _, tool := range toolset {
+		byName[tool.Name()] = tool
+	}
+
+	for _, name := range []string{"write_file", "edit_file", "apply_patch"} {
+		tool, ok := byName[name]
+		if !ok {
+			t.Fatalf("expected core tools to include %s", name)
+		}
+		if tool.Safety().SideEffect != SideEffectWrite {
+			t.Fatalf("%s side effect = %s, want write", name, tool.Safety().SideEffect)
+		}
+		if tool.Safety().Permission != PermissionPrompt {
+			t.Fatalf("%s permission = %s, want prompt", name, tool.Safety().Permission)
+		}
+	}
+
+	planTool, ok := byName["update_plan"]
+	if !ok {
+		t.Fatalf("expected core tools to include update_plan")
+	}
+	if planTool.Safety().Permission != PermissionAllow {
+		t.Fatalf("update_plan permission = %s, want allow", planTool.Safety().Permission)
+	}
+}
+
+func TestRegistryBlocksPromptToolsWithoutGrant(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "blocked.txt")
+	registry := NewRegistry()
+	registry.Register(NewWriteFileTool(root))
+
+	result := registry.Run(context.Background(), "write_file", map[string]any{
+		"path":    "blocked.txt",
+		"content": "nope",
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "Permission required for write_file") {
+		t.Fatalf("expected permission error, got %q", result.Output)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("expected file to remain absent, stat err=%v", err)
+	}
+}
+
+func TestRegistryRunsPromptToolsWithGrant(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry()
+	registry.Register(NewWriteFileTool(root))
+
+	result := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
+		"path":    "allowed.txt",
+		"content": "hello",
+	}, RunOptions{PermissionGranted: true})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "allowed.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("expected written content, got %q", string(content))
+	}
+}
+
+func TestWriteFileToolCreatesAndProtectsExistingFiles(t *testing.T) {
+	root := t.TempDir()
+	tool := NewWriteFileTool(root)
+
+	created := tool.Run(context.Background(), map[string]any{
+		"path":    "nested/file.txt",
+		"content": "first",
+	})
+	if created.Status != StatusOK {
+		t.Fatalf("expected create ok, got %s: %s", created.Status, created.Output)
+	}
+	if !strings.Contains(created.Output, "Created nested/file.txt") {
+		t.Fatalf("unexpected create output: %q", created.Output)
+	}
+
+	refused := tool.Run(context.Background(), map[string]any{
+		"path":    "nested/file.txt",
+		"content": "second",
+	})
+	if refused.Status != StatusError {
+		t.Fatalf("expected overwrite refusal, got %s", refused.Status)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "nested", "file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "first" {
+		t.Fatalf("expected original content, got %q", string(content))
+	}
+
+	overwrote := tool.Run(context.Background(), map[string]any{
+		"path":      "nested/file.txt",
+		"content":   "second",
+		"overwrite": true,
+	})
+	if overwrote.Status != StatusOK {
+		t.Fatalf("expected overwrite ok, got %s: %s", overwrote.Status, overwrote.Output)
+	}
+	content, err = os.ReadFile(filepath.Join(root, "nested", "file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "second" {
+		t.Fatalf("expected overwritten content, got %q", string(content))
+	}
+}
+
+func TestWriteFileToolAllowsEmptyContent(t *testing.T) {
+	root := t.TempDir()
+
+	result := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path":    "empty.txt",
+		"content": "",
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "empty.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "" {
+		t.Fatalf("expected empty file, got %q", string(content))
+	}
+}
+
+func TestWriteFileToolRejectsOutsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+
+	result := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path":    outside,
+		"content": "secret",
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "must stay inside the workspace") {
+		t.Fatalf("expected workspace error, got %q", result.Output)
+	}
+	if _, err := os.Stat(outside); !os.IsNotExist(err) {
+		t.Fatalf("expected outside file to remain absent, stat err=%v", err)
+	}
+}
+
+func TestEditFileToolReplacesExactStrings(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "code.go")
+	writeTestFile(t, path, "const a = 1\nconst b = 2\n")
+
+	result := NewEditFileTool(root).Run(context.Background(), map[string]any{
+		"path":       "code.go",
+		"old_string": "const a = 1",
+		"new_string": "const a = 42",
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected edit ok, got %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "const a = 42\nconst b = 2\n" {
+		t.Fatalf("unexpected edited content: %q", string(content))
+	}
+}
+
+func TestEditFileToolAllowsDeletingRegions(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "notes.txt")
+	writeTestFile(t, path, "keep\nremove\nkeep\n")
+
+	result := NewEditFileTool(root).Run(context.Background(), map[string]any{
+		"path":       "notes.txt",
+		"old_string": "remove\n",
+		"new_string": "",
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected edit ok, got %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "keep\nkeep\n" {
+		t.Fatalf("unexpected edited content: %q", string(content))
+	}
+}
+
+func TestEditFileToolRejectsMissingAndAmbiguousMatches(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "dup.txt")
+	writeTestFile(t, path, "x\nx\n")
+	tool := NewEditFileTool(root)
+
+	missing := tool.Run(context.Background(), map[string]any{
+		"path":       "dup.txt",
+		"old_string": "missing",
+		"new_string": "y",
+	})
+	if missing.Status != StatusError || !strings.Contains(missing.Output, "Could not find") {
+		t.Fatalf("expected missing error, got %s: %s", missing.Status, missing.Output)
+	}
+
+	ambiguous := tool.Run(context.Background(), map[string]any{
+		"path":       "dup.txt",
+		"old_string": "x",
+		"new_string": "y",
+	})
+	if ambiguous.Status != StatusError || !strings.Contains(ambiguous.Output, "matches 2 locations") {
+		t.Fatalf("expected ambiguity error, got %s: %s", ambiguous.Status, ambiguous.Output)
+	}
+
+	all := tool.Run(context.Background(), map[string]any{
+		"path":        "dup.txt",
+		"old_string":  "x",
+		"new_string":  "y",
+		"replace_all": true,
+	})
+	if all.Status != StatusOK {
+		t.Fatalf("expected replace_all ok, got %s: %s", all.Status, all.Output)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "y\ny\n" {
+		t.Fatalf("expected all replacements, got %q", string(content))
+	}
+}
+
+func TestApplyPatchToolAppliesUnifiedDiff(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "hello.txt"), "hello\nold\n")
+	patch := strings.Join([]string{
+		"diff --git a/hello.txt b/hello.txt",
+		"--- a/hello.txt",
+		"+++ b/hello.txt",
+		"@@ -1,2 +1,2 @@",
+		" hello",
+		"-old",
+		"+new",
+		"",
+	}, "\n")
+
+	result := NewApplyPatchTool(root).Run(context.Background(), map[string]any{
+		"patch": patch,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected patch ok, got %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "hello.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ReplaceAll(string(content), "\r\n", "\n") != "hello\nnew\n" {
+		t.Fatalf("unexpected patched content: %q", string(content))
+	}
+}
+
+func TestApplyPatchToolRejectsOutsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	result := NewApplyPatchTool(root).Run(context.Background(), map[string]any{
+		"cwd": outside,
+		"patch": strings.Join([]string{
+			"diff --git a/nope.txt b/nope.txt",
+			"--- a/nope.txt",
+			"+++ b/nope.txt",
+			"@@ -0,0 +1 @@",
+			"+nope",
+			"",
+		}, "\n"),
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "must stay inside the workspace") {
+		t.Fatalf("expected workspace error, got %q", result.Output)
+	}
+}

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -148,6 +148,20 @@ func TestWriteFileToolAllowsEmptyContent(t *testing.T) {
 	}
 }
 
+func TestWriteFileToolReportsTypeErrorsForEmptyAllowedStrings(t *testing.T) {
+	result := NewWriteFileTool(t.TempDir()).Run(context.Background(), map[string]any{
+		"path":    "bad.txt",
+		"content": 42,
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "content must be a string") {
+		t.Fatalf("expected string type error, got %q", result.Output)
+	}
+}
+
 func TestWriteFileToolRejectsOutsideWorkspace(t *testing.T) {
 	root := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside.txt")
@@ -165,6 +179,32 @@ func TestWriteFileToolRejectsOutsideWorkspace(t *testing.T) {
 	}
 	if _, err := os.Stat(outside); !os.IsNotExist(err) {
 		t.Fatalf("expected outside file to remain absent, stat err=%v", err)
+	}
+}
+
+func TestWriteFileToolRejectsSymlinkParent(t *testing.T) {
+	root := t.TempDir()
+	realDirectory := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDirectory, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	result := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path":    "link/escape.txt",
+		"content": "secret",
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "must not traverse symlink") {
+		t.Fatalf("expected symlink error, got %q", result.Output)
+	}
+	if _, err := os.Stat(filepath.Join(realDirectory, "escape.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink target file to remain absent, stat err=%v", err)
 	}
 }
 
@@ -283,6 +323,41 @@ func TestApplyPatchToolAppliesUnifiedDiff(t *testing.T) {
 	}
 	if strings.ReplaceAll(string(content), "\r\n", "\n") != "hello\nnew\n" {
 		t.Fatalf("unexpected patched content: %q", string(content))
+	}
+}
+
+func TestApplyPatchToolRejectsSymlinkPath(t *testing.T) {
+	root := t.TempDir()
+	realDirectory := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDirectory, filepath.Join(root, "link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	patch := strings.Join([]string{
+		"diff --git a/link/new.txt b/link/new.txt",
+		"new file mode 100644",
+		"index 0000000..e965047",
+		"--- /dev/null",
+		"+++ b/link/new.txt",
+		"@@ -0,0 +1 @@",
+		"+hello",
+		"",
+	}, "\n")
+
+	result := NewApplyPatchTool(root).Run(context.Background(), map[string]any{
+		"patch": patch,
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "must not traverse symlink") {
+		t.Fatalf("expected symlink error, got %q", result.Output)
+	}
+	if _, err := os.Stat(filepath.Join(realDirectory, "new.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink target file to remain absent, stat err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add Go core write tools: write_file, edit_file, apply_patch
- add in-memory update_plan tool and CoreTools/CoreWriteTools registry helpers
- add prompt permission gating through Registry.RunWithOptions
- add workspace target-path resolution for files that may not exist yet

## Tests
- bun run typecheck
- bun test ./tests --timeout 15000
- bun run build
- bun run smoke:build

## Local blockers
- go/go fmt are not installed on this Windows machine, so go test ./..., go build ./cmd/zero, and gofmt could not run locally
- bun run smoke:go fails locally because build:go cannot run; CI is configured with actions/setup-go and will run Go test/build/smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace file tools: create/overwrite files, in-place exact-string edits (first/all), and apply unified-diff patches.
  * Added an in-memory task planning tool to store, format, clear, and inspect plans.

* **Security & Reliability**
  * Stronger workspace path checks and symlink-aware resolution; safer overwrite, permissions gating, and match validations.

* **Tests**
  * Expanded tests covering tools, permission gating, edge cases, and filesystem safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->