### PR TITLE
Add Go M0 runtime provider contracts

### DIFF
--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -1,0 +1,75 @@
+package zeroruntime
+
+import "context"
+
+type CollectedStream struct {
+	Text      string
+	ToolCalls []ToolCall
+	Usage     Usage
+}
+
+func SeedMessages(systemPrompt string, userPrompt string) []Message {
+	return []Message{
+		{Role: MessageRoleSystem, Content: systemPrompt},
+		{Role: MessageRoleUser, Content: userPrompt},
+	}
+}
+
+func CollectStream(ctx context.Context, events <-chan StreamEvent) CollectedStream {
+	collected := CollectedStream{}
+	pendingToolCalls := make(map[string]*ToolCall)
+	toolCallOrder := []string{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return collected
+		case event, ok := <-events:
+			if !ok {
+				return collected
+			}
+
+			switch event.Type {
+			case StreamEventText:
+				collected.Text += event.Content
+			case StreamEventToolCallStart:
+				pendingToolCalls[event.ToolCallID] = &ToolCall{
+					ID:   event.ToolCallID,
+					Name: event.ToolName,
+				}
+				toolCallOrder = append(toolCallOrder, event.ToolCallID)
+			case StreamEventToolCallDelta:
+				if toolCall, ok := pendingToolCalls[event.ToolCallID]; ok {
+					toolCall.Arguments += event.ArgumentsFragment
+				}
+			case StreamEventToolCallEnd:
+				if toolCall, ok := pendingToolCalls[event.ToolCallID]; ok {
+					collected.ToolCalls = append(collected.ToolCalls, *toolCall)
+					delete(pendingToolCalls, event.ToolCallID)
+				}
+			case StreamEventUsage:
+				collected.Usage.PromptTokens += event.Usage.PromptTokens
+				collected.Usage.CompletionTokens += event.Usage.CompletionTokens
+				collected.Usage.CachedInputTokens += event.Usage.CachedInputTokens
+			case StreamEventDone:
+				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
+				return collected
+			}
+		}
+	}
+}
+
+func appendOpenToolCalls(
+	collected *CollectedStream,
+	toolCallOrder []string,
+	pendingToolCalls map[string]*ToolCall,
+) {
+	for _, id := range toolCallOrder {
+		toolCall, ok := pendingToolCalls[id]
+		if !ok {
+			continue
+		}
+		collected.ToolCalls = append(collected.ToolCalls, *toolCall)
+		delete(pendingToolCalls, id)
+	}
+}

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -2,12 +2,15 @@ package zeroruntime
 
 import "context"
 
+// CollectedStream is the non-streaming summary of provider events.
 type CollectedStream struct {
 	Text      string
 	ToolCalls []ToolCall
 	Usage     Usage
+	Error     string
 }
 
+// SeedMessages creates the initial system and user turns for a request.
 func SeedMessages(systemPrompt string, userPrompt string) []Message {
 	return []Message{
 		{Role: MessageRoleSystem, Content: systemPrompt},
@@ -15,6 +18,7 @@ func SeedMessages(systemPrompt string, userPrompt string) []Message {
 	}
 }
 
+// CollectStream drains provider events into text, tool calls, usage, and error state.
 func CollectStream(ctx context.Context, events <-chan StreamEvent) CollectedStream {
 	collected := CollectedStream{}
 	pendingToolCalls := make(map[string]*ToolCall)
@@ -23,9 +27,11 @@ func CollectStream(ctx context.Context, events <-chan StreamEvent) CollectedStre
 	for {
 		select {
 		case <-ctx.Done():
+			appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
 			return collected
 		case event, ok := <-events:
 			if !ok {
+				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
 				return collected
 			}
 
@@ -51,6 +57,10 @@ func CollectStream(ctx context.Context, events <-chan StreamEvent) CollectedStre
 				collected.Usage.PromptTokens += event.Usage.PromptTokens
 				collected.Usage.CompletionTokens += event.Usage.CompletionTokens
 				collected.Usage.CachedInputTokens += event.Usage.CachedInputTokens
+			case StreamEventError:
+				collected.Error = event.Error
+				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
+				return collected
 			case StreamEventDone:
 				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
 				return collected

--- a/internal/zeroruntime/provider_test.go
+++ b/internal/zeroruntime/provider_test.go
@@ -1,0 +1,104 @@
+package zeroruntime
+
+import (
+	"context"
+	"testing"
+)
+
+type mockProvider struct {
+	events []StreamEvent
+}
+
+func (provider mockProvider) StreamCompletion(
+	ctx context.Context,
+	request CompletionRequest,
+) (<-chan StreamEvent, error) {
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		for _, event := range provider.events {
+			select {
+			case <-ctx.Done():
+				return
+			case events <- event:
+			}
+		}
+	}()
+	return events, nil
+}
+
+func TestSeedMessagesProducesSystemAndUserTurns(t *testing.T) {
+	messages := SeedMessages("you are a helper", "inspect this repo")
+
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if messages[0].Role != MessageRoleSystem || messages[0].Content != "you are a helper" {
+		t.Fatalf("unexpected system message: %#v", messages[0])
+	}
+	if messages[1].Role != MessageRoleUser || messages[1].Content != "inspect this repo" {
+		t.Fatalf("unexpected user message: %#v", messages[1])
+	}
+}
+
+func TestCollectStreamAccumulatesTextToolCallsAndUsage(t *testing.T) {
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		events <- StreamEvent{Type: StreamEventText, Content: "Hello "}
+		events <- StreamEvent{Type: StreamEventText, Content: "world"}
+		events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "call_1", ToolName: "read_file"}
+		events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "call_1", ArgumentsFragment: `{"pa`}
+		events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "call_1", ArgumentsFragment: `th":"README.md"}`}
+		events <- StreamEvent{Type: StreamEventToolCallEnd, ToolCallID: "call_1"}
+		events <- StreamEvent{Type: StreamEventUsage, Usage: Usage{PromptTokens: 12, CompletionTokens: 8, CachedInputTokens: 3}}
+		events <- StreamEvent{Type: StreamEventDone}
+	}()
+
+	collected := CollectStream(context.Background(), events)
+
+	if collected.Text != "Hello world" {
+		t.Fatalf("text = %q, want %q", collected.Text, "Hello world")
+	}
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call, got %d", len(collected.ToolCalls))
+	}
+	toolCall := collected.ToolCalls[0]
+	if toolCall.ID != "call_1" || toolCall.Name != "read_file" || toolCall.Arguments != `{"path":"README.md"}` {
+		t.Fatalf("unexpected tool call: %#v", toolCall)
+	}
+	if collected.Usage.PromptTokens != 12 || collected.Usage.CompletionTokens != 8 || collected.Usage.CachedInputTokens != 3 {
+		t.Fatalf("unexpected usage: %#v", collected.Usage)
+	}
+	if collected.Usage.TotalTokens() != 20 {
+		t.Fatalf("total tokens = %d, want 20", collected.Usage.TotalTokens())
+	}
+}
+
+func TestProviderContractCanBeImplementedByMock(t *testing.T) {
+	var provider Provider = mockProvider{
+		events: []StreamEvent{
+			{Type: StreamEventText, Content: "ok"},
+			{Type: StreamEventDone},
+		},
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), CompletionRequest{
+		Messages: SeedMessages("system", "user"),
+		Tools: []ToolDefinition{
+			{
+				Name:        "read_file",
+				Description: "Read a file",
+				Parameters:  map[string]any{"type": "object"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+
+	collected := CollectStream(context.Background(), stream)
+	if collected.Text != "ok" {
+		t.Fatalf("text = %q, want ok", collected.Text)
+	}
+}

--- a/internal/zeroruntime/provider_test.go
+++ b/internal/zeroruntime/provider_test.go
@@ -75,6 +75,70 @@ func TestCollectStreamAccumulatesTextToolCallsAndUsage(t *testing.T) {
 	}
 }
 
+func TestCollectStreamFlushesOpenToolCallsWhenChannelCloses(t *testing.T) {
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "call_closed", ToolName: "grep"}
+		events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "call_closed", ArgumentsFragment: `{"query":"`}
+		events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "call_closed", ArgumentsFragment: `zero"}`}
+	}()
+
+	collected := CollectStream(context.Background(), events)
+
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("expected one flushed tool call, got %d", len(collected.ToolCalls))
+	}
+	toolCall := collected.ToolCalls[0]
+	if toolCall.ID != "call_closed" || toolCall.Name != "grep" || toolCall.Arguments != `{"query":"zero"}` {
+		t.Fatalf("unexpected flushed tool call: %#v", toolCall)
+	}
+}
+
+func TestCollectStreamFlushesOpenToolCallsWhenContextCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	events := make(chan StreamEvent)
+
+	go func() {
+		events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "call_cancelled", ToolName: "read_file"}
+		events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "call_cancelled", ArgumentsFragment: `{"path":"README`}
+		cancel()
+	}()
+
+	collected := CollectStream(ctx, events)
+
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("expected one flushed tool call, got %d", len(collected.ToolCalls))
+	}
+	toolCall := collected.ToolCalls[0]
+	if toolCall.ID != "call_cancelled" || toolCall.Name != "read_file" || toolCall.Arguments != `{"path":"README` {
+		t.Fatalf("unexpected flushed tool call after cancel: %#v", toolCall)
+	}
+}
+
+func TestCollectStreamSurfacesStreamErrors(t *testing.T) {
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "call_error", ToolName: "bash"}
+		events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "call_error", ArgumentsFragment: `{"command":"go test`}
+		events <- StreamEvent{Type: StreamEventError, Error: "provider stream failed"}
+	}()
+
+	collected := CollectStream(context.Background(), events)
+
+	if collected.Error != "provider stream failed" {
+		t.Fatalf("error = %q, want provider stream failed", collected.Error)
+	}
+	if len(collected.ToolCalls) != 1 {
+		t.Fatalf("expected one flushed tool call, got %d", len(collected.ToolCalls))
+	}
+	toolCall := collected.ToolCalls[0]
+	if toolCall.ID != "call_error" || toolCall.Name != "bash" || toolCall.Arguments != `{"command":"go test` {
+		t.Fatalf("unexpected flushed tool call after error: %#v", toolCall)
+	}
+}
+
 func TestProviderContractCanBeImplementedByMock(t *testing.T) {
 	var provider Provider = mockProvider{
 		events: []StreamEvent{

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -1,0 +1,71 @@
+package zeroruntime
+
+import "context"
+
+type MessageRole string
+type StreamEventType string
+
+const (
+	MessageRoleSystem    MessageRole = "system"
+	MessageRoleUser      MessageRole = "user"
+	MessageRoleAssistant MessageRole = "assistant"
+	MessageRoleTool      MessageRole = "tool"
+)
+
+const (
+	StreamEventText          StreamEventType = "text"
+	StreamEventToolCallStart StreamEventType = "tool_call_start"
+	StreamEventToolCallDelta StreamEventType = "tool_call_delta"
+	StreamEventToolCallEnd   StreamEventType = "tool_call_end"
+	StreamEventUsage         StreamEventType = "usage"
+	StreamEventDone          StreamEventType = "done"
+	StreamEventError         StreamEventType = "error"
+)
+
+type ToolCall struct {
+	ID        string
+	Name      string
+	Arguments string
+}
+
+type Message struct {
+	Role       MessageRole
+	Content    string
+	ToolCalls  []ToolCall
+	ToolCallID string
+}
+
+type ToolDefinition struct {
+	Name        string
+	Description string
+	Parameters  map[string]any
+}
+
+type Usage struct {
+	PromptTokens      int
+	CompletionTokens  int
+	CachedInputTokens int
+}
+
+func (usage Usage) TotalTokens() int {
+	return usage.PromptTokens + usage.CompletionTokens
+}
+
+type StreamEvent struct {
+	Type              StreamEventType
+	Content           string
+	ToolCallID        string
+	ToolName          string
+	ArgumentsFragment string
+	Usage             Usage
+	Error             string
+}
+
+type CompletionRequest struct {
+	Messages []Message
+	Tools    []ToolDefinition
+}
+
+type Provider interface {
+	StreamCompletion(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error)
+}

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -2,7 +2,10 @@ package zeroruntime
 
 import "context"
 
+// MessageRole identifies the origin of a conversation message.
 type MessageRole string
+
+// StreamEventType identifies one event in a provider completion stream.
 type StreamEventType string
 
 const (
@@ -22,12 +25,14 @@ const (
 	StreamEventError         StreamEventType = "error"
 )
 
+// ToolCall is a normalized assistant request to run a tool.
 type ToolCall struct {
 	ID        string
 	Name      string
 	Arguments string
 }
 
+// Message is a normalized conversation turn passed to providers.
 type Message struct {
 	Role       MessageRole
 	Content    string
@@ -35,22 +40,26 @@ type Message struct {
 	ToolCallID string
 }
 
+// ToolDefinition describes a model-visible tool and its JSON-schema parameters.
 type ToolDefinition struct {
 	Name        string
 	Description string
 	Parameters  map[string]any
 }
 
+// Usage records normalized token accounting reported by a provider.
 type Usage struct {
 	PromptTokens      int
 	CompletionTokens  int
 	CachedInputTokens int
 }
 
+// TotalTokens returns prompt plus completion tokens.
 func (usage Usage) TotalTokens() int {
 	return usage.PromptTokens + usage.CompletionTokens
 }
 
+// StreamEvent is one normalized event emitted by a streaming provider.
 type StreamEvent struct {
 	Type              StreamEventType
 	Content           string
@@ -61,11 +70,13 @@ type StreamEvent struct {
 	Error             string
 }
 
+// CompletionRequest groups provider input messages and available tools.
 type CompletionRequest struct {
 	Messages []Message
 	Tools    []ToolDefinition
 }
 
+// Provider streams normalized completion events for one request.
 type Provider interface {
 	StreamCompletion(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error)
 }


### PR DESCRIPTION
## Summary
- add a small Go runtime contract package for provider messages, tool calls, stream events, usage, and completion requests
- define the first Provider interface for streaming completion events with context cancellation
- add SeedMessages and CollectStream helpers plus mock-provider contract tests

## Scope
This intentionally does not implement an OpenAI/Anthropic/Gemini provider, model registry, CLI behavior, or stream-json protocol. It is a narrow M0 contract skeleton for Gnanam to extend.

## Testing
- bun run test:go
- bun run build:go
- bun run smoke:go
- bun run typecheck
- bun test tests/foundation-tools.test.ts --timeout 15000
- git diff --check

## Local note
- Full local `bun run test` still has 5 unrelated pre-existing local failures in headless-exec/MCP tests; Go contract tests pass and CI should verify the full matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming completions with structured tool-call support and ordered tool-call reconstruction.
  * Message role system (system/user/assistant/tool) for clearer conversation context.
  * Token usage tracking with total token summaries.
  * Convenience helpers to seed requests with system+user turns and to collect streamed events.

* **Tests**
  * Expanded tests covering message seeding, streaming accumulation, tool-call flushing, error and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->