### PR TITLE
Add Go M0 agent runtime

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1,0 +1,234 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const defaultSystemPrompt = "You are Zero, a terminal coding agent. Help with the current workspace and use tools when needed."
+const maxTurnsAnswer = "Agent reached maximum number of turns without a final answer."
+
+type pendingToolCall struct {
+	id        string
+	name      string
+	arguments string
+}
+
+func Run(ctx context.Context, prompt string, provider Provider, options Options) (Result, error) {
+	if provider == nil {
+		return Result{}, errors.New("agent provider is required")
+	}
+
+	maxTurns := options.MaxTurns
+	if maxTurns <= 0 {
+		maxTurns = 12
+	}
+
+	registry := options.Registry
+	if registry == nil {
+		registry = tools.NewRegistry()
+	}
+
+	permissionMode := options.PermissionMode
+	if permissionMode == "" {
+		permissionMode = PermissionModeAuto
+	}
+
+	messages := []Message{
+		{Role: RoleSystem, Content: defaultSystemPrompt},
+		{Role: RoleUser, Content: prompt},
+	}
+
+	result := Result{Messages: copyMessages(messages)}
+	for turn := 0; turn < maxTurns; turn++ {
+		result.Turns = turn + 1
+		request := CompletionRequest{
+			Messages: copyMessages(messages),
+			Tools:    toolDefinitions(registry, permissionMode),
+		}
+
+		stream, err := provider.StreamCompletion(ctx, request)
+		if err != nil {
+			result.Messages = copyMessages(messages)
+			return result, err
+		}
+
+		currentText, toolCalls, err := collectTurn(ctx, stream, options.OnText, options.OnUsage)
+		if err != nil {
+			result.Messages = copyMessages(messages)
+			return result, err
+		}
+
+		messages = append(messages, Message{
+			Role:      RoleAssistant,
+			Content:   currentText,
+			ToolCalls: toolCalls,
+		})
+
+		if len(toolCalls) == 0 {
+			result.FinalAnswer = currentText
+			result.Messages = copyMessages(messages)
+			return result, nil
+		}
+
+		for _, call := range toolCalls {
+			if options.OnToolCall != nil {
+				options.OnToolCall(call)
+			}
+			toolResult := executeToolCall(ctx, registry, call, permissionMode)
+			if options.OnToolResult != nil {
+				options.OnToolResult(toolResult)
+			}
+			messages = append(messages, Message{
+				Role:       RoleTool,
+				Content:    toolResult.Output,
+				ToolCallID: toolResult.ToolCallID,
+			})
+		}
+	}
+
+	result.FinalAnswer = maxTurnsAnswer
+	result.Messages = copyMessages(messages)
+	return result, nil
+}
+
+func collectTurn(ctx context.Context, stream <-chan StreamEvent, onText func(string), onUsage func(Usage)) (string, []ToolCall, error) {
+	currentText := ""
+	pending := make(map[string]*pendingToolCall)
+	order := make([]string, 0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", nil, ctx.Err()
+		case event, ok := <-stream:
+			if !ok {
+				return currentText, buildToolCalls(order, pending), nil
+			}
+
+			switch event.Type {
+			case EventText:
+				currentText += event.Content
+				if onText != nil {
+					onText(event.Content)
+				}
+			case EventToolCallStart:
+				call := pending[event.ToolCallID]
+				if call == nil {
+					call = &pendingToolCall{id: event.ToolCallID}
+					pending[event.ToolCallID] = call
+					order = append(order, event.ToolCallID)
+				}
+				call.name = event.ToolName
+			case EventToolCallDelta:
+				call := pending[event.ToolCallID]
+				if call == nil {
+					call = &pendingToolCall{id: event.ToolCallID}
+					pending[event.ToolCallID] = call
+					order = append(order, event.ToolCallID)
+				}
+				call.arguments += event.ArgumentsFragment
+			case EventToolCallEnd:
+			case EventUsage:
+				if onUsage != nil {
+					onUsage(Usage{
+						PromptTokens:     event.PromptTokens,
+						CompletionTokens: event.CompletionTokens,
+					})
+				}
+			case EventDone:
+				return currentText, buildToolCalls(order, pending), nil
+			}
+		}
+	}
+}
+
+func buildToolCalls(order []string, pending map[string]*pendingToolCall) []ToolCall {
+	calls := make([]ToolCall, 0, len(order))
+	for _, id := range order {
+		call := pending[id]
+		if call == nil {
+			continue
+		}
+		calls = append(calls, ToolCall{
+			ID:        call.id,
+			Name:      call.name,
+			Arguments: call.arguments,
+		})
+	}
+	return calls
+}
+
+func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCall, permissionMode PermissionMode) ToolResult {
+	args := map[string]any{}
+	if call.Arguments != "" {
+		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
+			return ToolResult{
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Status:     tools.StatusError,
+				Output:     "Error: Failed to parse arguments for " + call.Name + ": " + err.Error(),
+			}
+		}
+	}
+
+	permissionGranted := permissionMode == PermissionModeUnsafe
+	if tool, ok := registry.Get(call.Name); ok && tool.Safety().Permission == tools.PermissionAllow {
+		permissionGranted = true
+	}
+
+	result := registry.RunWithOptions(ctx, call.Name, args, tools.RunOptions{
+		PermissionGranted: permissionGranted,
+	})
+	return ToolResult{
+		ToolCallID: call.ID,
+		Name:       call.Name,
+		Status:     result.Status,
+		Output:     result.Output,
+	}
+}
+
+func toolDefinitions(registry *tools.Registry, permissionMode PermissionMode) []ToolDefinition {
+	registeredTools := registry.All()
+	definitions := make([]ToolDefinition, 0, len(registeredTools))
+	for _, tool := range registeredTools {
+		if !isAdvertised(tool, permissionMode) {
+			continue
+		}
+		definitions = append(definitions, ToolDefinition{
+			Name:        tool.Name(),
+			Description: tool.Description(),
+			Parameters:  tool.Parameters(),
+		})
+	}
+
+	sort.Slice(definitions, func(left int, right int) bool {
+		return definitions[left].Name < definitions[right].Name
+	})
+	return definitions
+}
+
+func isAdvertised(tool tools.Tool, permissionMode PermissionMode) bool {
+	if tool.Safety().Permission == tools.PermissionDeny {
+		return false
+	}
+	if permissionMode == PermissionModeAuto {
+		return tool.Safety().Permission == tools.PermissionAllow
+	}
+	return true
+}
+
+func copyMessages(messages []Message) []Message {
+	copied := make([]Message, len(messages))
+	for index, message := range messages {
+		copied[index] = message
+		if message.ToolCalls != nil {
+			copied[index].ToolCalls = append([]ToolCall{}, message.ToolCalls...)
+		}
+	}
+	return copied
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1,0 +1,273 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type mockProvider struct {
+	turns    [][]StreamEvent
+	requests []CompletionRequest
+}
+
+func (provider *mockProvider) StreamCompletion(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error) {
+	provider.requests = append(provider.requests, request)
+
+	events := []StreamEvent{{Type: EventDone}}
+	if len(provider.turns) >= len(provider.requests) {
+		events = provider.turns[len(provider.requests)-1]
+	}
+
+	ch := make(chan StreamEvent, len(events))
+	for _, event := range events {
+		ch <- event
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunReturnsProviderText(t *testing.T) {
+	provider := &mockProvider{
+		turns: [][]StreamEvent{{
+			{Type: EventText, Content: "hello"},
+			{Type: EventText, Content: " zero"},
+			{Type: EventDone},
+		}},
+	}
+
+	result, err := Run(context.Background(), "say hi", provider, Options{
+		Registry: tools.NewRegistry(),
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "hello zero" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one provider turn, got %d", len(provider.requests))
+	}
+	assertMessage(t, provider.requests[0].Messages[0], RoleSystem, "")
+	assertMessage(t, provider.requests[0].Messages[1], RoleUser, "say hi")
+}
+
+func TestRunEmitsTextDeltas(t *testing.T) {
+	provider := &mockProvider{
+		turns: [][]StreamEvent{{
+			{Type: EventText, Content: "hello"},
+			{Type: EventText, Content: " zero"},
+			{Type: EventDone},
+		}},
+	}
+
+	var deltas []string
+	_, err := Run(context.Background(), "say hi", provider, Options{
+		Registry: tools.NewRegistry(),
+		OnText:   func(delta string) { deltas = append(deltas, delta) },
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(deltas, "|") != "hello| zero" {
+		t.Fatalf("expected text deltas, got %#v", deltas)
+	}
+}
+
+func TestRunEmitsUsageEvents(t *testing.T) {
+	provider := &mockProvider{
+		turns: [][]StreamEvent{{
+			{Type: EventUsage, PromptTokens: 12, CompletionTokens: 5},
+			{Type: EventText, Content: "done"},
+			{Type: EventDone},
+		}},
+	}
+
+	var usages []Usage
+	_, err := Run(context.Background(), "track usage", provider, Options{
+		Registry: tools.NewRegistry(),
+		OnUsage:  func(usage Usage) { usages = append(usages, usage) },
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(usages) != 1 {
+		t.Fatalf("expected one usage event, got %#v", usages)
+	}
+	if usages[0].PromptTokens != 12 || usages[0].CompletionTokens != 5 {
+		t.Fatalf("unexpected usage event: %#v", usages[0])
+	}
+}
+
+func TestRunExecutesToolCallThroughRegistry(t *testing.T) {
+	root := t.TempDir()
+	writeAgentTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta\n")
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool(root))
+	provider := &mockProvider{
+		turns: [][]StreamEvent{
+			{
+				{Type: EventToolCallStart, ToolCallID: "call-1", ToolName: "read_file"},
+				{Type: EventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"path":"notes.txt"}`},
+				{Type: EventToolCallEnd, ToolCallID: "call-1"},
+				{Type: EventDone},
+			},
+			{
+				{Type: EventText, Content: "read done"},
+				{Type: EventDone},
+			},
+		},
+	}
+
+	var toolResults []ToolResult
+	result, err := Run(context.Background(), "read notes", provider, Options{
+		Registry:     registry,
+		OnToolResult: func(result ToolResult) { toolResults = append(toolResults, result) },
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "read done" {
+		t.Fatalf("expected final answer from second turn, got %q", result.FinalAnswer)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected provider to be called twice, got %d", len(provider.requests))
+	}
+	lastMessage := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	assertMessage(t, lastMessage, RoleTool, "alpha")
+	if lastMessage.ToolCallID != "call-1" {
+		t.Fatalf("expected tool_call_id call-1, got %q", lastMessage.ToolCallID)
+	}
+	if len(toolResults) != 1 || toolResults[0].Status != tools.StatusOK {
+		t.Fatalf("expected one ok tool result, got %#v", toolResults)
+	}
+}
+
+func TestRunDeniesPromptToolWithoutUnsafePermission(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write denied")
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "write denied" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	if _, err := os.Stat(filepath.Join(root, "notes.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected denied write to leave file missing, stat error: %v", err)
+	}
+	lastMessage := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if !strings.Contains(lastMessage.Content, "Permission required for write_file") {
+		t.Fatalf("expected permission denial tool result, got %q", lastMessage.Content)
+	}
+}
+
+func TestRunGrantsPromptToolInUnsafeMode(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write done")
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeUnsafe,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "write done" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("expected written content, got %q", content)
+	}
+}
+
+func TestRunStopsAfterMaxTurns(t *testing.T) {
+	root := t.TempDir()
+	writeAgentTestFile(t, filepath.Join(root, "notes.txt"), "alpha")
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool(root))
+	provider := &mockProvider{
+		turns: [][]StreamEvent{{
+			{Type: EventToolCallStart, ToolCallID: "call-1", ToolName: "read_file"},
+			{Type: EventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"path":"notes.txt"}`},
+			{Type: EventToolCallEnd, ToolCallID: "call-1"},
+			{Type: EventDone},
+		}},
+	}
+
+	result, err := Run(context.Background(), "loop", provider, Options{
+		Registry: registry,
+		MaxTurns: 1,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "Agent reached maximum number of turns without a final answer." {
+		t.Fatalf("expected max-turns answer, got %q", result.FinalAnswer)
+	}
+	if result.Turns != 1 {
+		t.Fatalf("expected one turn, got %d", result.Turns)
+	}
+}
+
+func providerCallingWriteFileThenAnswer(answer string) *mockProvider {
+	return &mockProvider{
+		turns: [][]StreamEvent{
+			{
+				{Type: EventToolCallStart, ToolCallID: "call-1", ToolName: "write_file"},
+				{Type: EventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"path":"notes.txt","content":"hello"}`},
+				{Type: EventToolCallEnd, ToolCallID: "call-1"},
+				{Type: EventDone},
+			},
+			{
+				{Type: EventText, Content: answer},
+				{Type: EventDone},
+			},
+		},
+	}
+}
+
+func assertMessage(t *testing.T, message Message, role Role, contentContains string) {
+	t.Helper()
+
+	if message.Role != role {
+		t.Fatalf("expected role %s, got %s", role, message.Role)
+	}
+	if contentContains != "" && !strings.Contains(message.Content, contentContains) {
+		t.Fatalf("expected message content to contain %q, got %q", contentContains, message.Content)
+	}
+}
+
+func writeAgentTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+type Message struct {
+	Role       Role
+	Content    string
+	ToolCalls  []ToolCall
+	ToolCallID string
+}
+
+type ToolCall struct {
+	ID        string
+	Name      string
+	Arguments string
+}
+
+type ToolDefinition struct {
+	Name        string
+	Description string
+	Parameters  tools.Schema
+}
+
+type CompletionRequest struct {
+	Messages []Message
+	Tools    []ToolDefinition
+}
+
+type EventType string
+
+const (
+	EventText          EventType = "text"
+	EventToolCallStart EventType = "tool-call-start"
+	EventToolCallDelta EventType = "tool-call-delta"
+	EventToolCallEnd   EventType = "tool-call-end"
+	EventUsage         EventType = "usage"
+	EventDone          EventType = "done"
+)
+
+type StreamEvent struct {
+	Type              EventType
+	Content           string
+	ToolCallID        string
+	ToolName          string
+	ArgumentsFragment string
+	PromptTokens      int
+	CompletionTokens  int
+}
+
+type Provider interface {
+	StreamCompletion(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error)
+}
+
+type PermissionMode string
+
+const (
+	PermissionModeAuto   PermissionMode = "auto"
+	PermissionModeAsk    PermissionMode = "ask"
+	PermissionModeUnsafe PermissionMode = "unsafe"
+)
+
+type ToolResult struct {
+	ToolCallID string
+	Name       string
+	Status     tools.Status
+	Output     string
+}
+
+type Usage struct {
+	PromptTokens     int
+	CompletionTokens int
+}
+
+type Options struct {
+	MaxTurns       int
+	Registry       *tools.Registry
+	PermissionMode PermissionMode
+	OnText         func(string)
+	OnToolCall     func(ToolCall)
+	OnToolResult   func(ToolResult)
+	OnUsage        func(Usage)
+}
+
+type Result struct {
+	FinalAnswer string
+	Turns       int
+	Messages    []Message
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -67,10 +67,7 @@ Flags:
 
 func runExec(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
-		if _, err := fmt.Fprintln(stderr, "Prompt required. Use `zero exec \"prompt\"`."); err != nil {
-			return 1
-		}
-		return 2
+		return writePromptRequired(stderr)
 	}
 
 	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
@@ -78,6 +75,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		return 0
+	}
+
+	prompt := strings.TrimSpace(strings.Join(args, " "))
+	if prompt == "" {
+		return writePromptRequired(stderr)
 	}
 
 	workspaceRoot, err := os.Getwd()
@@ -93,7 +95,6 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer) int {
 		registry.Register(tool)
 	}
 
-	prompt := strings.Join(args, " ")
 	result, err := agent.Run(context.Background(), prompt, offlineProvider{}, agent.Options{
 		Registry: registry,
 	})
@@ -108,6 +109,13 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func writePromptRequired(stderr io.Writer) int {
+	if _, err := fmt.Fprintln(stderr, "Prompt required. Use `zero exec \"prompt\"`."); err != nil {
+		return 1
+	}
+	return 2
 }
 
 func writeExecHelp(w io.Writer) error {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"os"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 const version = "0.1.0"
@@ -28,6 +34,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 			return 1
 		}
 		return 0
+	case "exec":
+		return runExec(args[1:], stdout, stderr)
 	default:
 		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
 			return 1
@@ -46,6 +54,7 @@ Usage:
   zero [command]
 
 Commands:
+  exec       Run a one-shot prompt through the Go agent runtime
   help       Show this help
   version    Print version
 
@@ -54,4 +63,81 @@ Flags:
   -v, --version    Print version
 `)
 	return err
+}
+
+func runExec(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		if _, err := fmt.Fprintln(stderr, "Prompt required. Use `zero exec \"prompt\"`."); err != nil {
+			return 1
+		}
+		return 2
+	}
+
+	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help" || args[0] == "help") {
+		if err := writeExecHelp(stdout); err != nil {
+			return 1
+		}
+		return 0
+	}
+
+	workspaceRoot, err := os.Getwd()
+	if err != nil {
+		if _, writeErr := fmt.Fprintf(stderr, "failed to resolve workspace: %v\n", err); writeErr != nil {
+			return 1
+		}
+		return 1
+	}
+
+	registry := tools.NewRegistry()
+	for _, tool := range tools.CoreTools(workspaceRoot) {
+		registry.Register(tool)
+	}
+
+	prompt := strings.Join(args, " ")
+	result, err := agent.Run(context.Background(), prompt, offlineProvider{}, agent.Options{
+		Registry: registry,
+	})
+	if err != nil {
+		if _, writeErr := fmt.Fprintf(stderr, "agent runtime failed: %v\n", err); writeErr != nil {
+			return 1
+		}
+		return 1
+	}
+
+	if _, err := fmt.Fprintln(stdout, result.FinalAnswer); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func writeExecHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero exec <prompt>
+
+Runs a one-shot prompt through the Go agent runtime.
+`)
+	return err
+}
+
+type offlineProvider struct{}
+
+func (offlineProvider) StreamCompletion(ctx context.Context, request agent.CompletionRequest) (<-chan agent.StreamEvent, error) {
+	prompt := ""
+	for index := len(request.Messages) - 1; index >= 0; index-- {
+		if request.Messages[index].Role == agent.RoleUser {
+			prompt = request.Messages[index].Content
+			break
+		}
+	}
+
+	ch := make(chan agent.StreamEvent, 2)
+	select {
+	case <-ctx.Done():
+		close(ch)
+		return ch, ctx.Err()
+	case ch <- agent.StreamEvent{Type: agent.EventText, Content: "Go agent runtime ready: " + prompt}:
+	}
+	ch <- agent.StreamEvent{Type: agent.EventDone}
+	close(ch)
+	return ch, nil
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -93,19 +93,27 @@ func TestRunExecPrintsOfflineRuntimeResponse(t *testing.T) {
 }
 
 func TestRunExecRequiresPrompt(t *testing.T) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+	for _, args := range [][]string{
+		{"exec"},
+		{"exec", ""},
+		{"exec", "   "},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
 
-	exitCode := Run([]string{"exec"}, &stdout, &stderr)
+			exitCode := Run(args, &stdout, &stderr)
 
-	if exitCode != 2 {
-		t.Fatalf("expected exit code 2, got %d", exitCode)
-	}
-	if stdout.Len() != 0 {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if !strings.Contains(stderr.String(), "Prompt required") {
-		t.Fatalf("expected prompt error, got %q", stderr.String())
+			if exitCode != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), "Prompt required") {
+				t.Fatalf("expected prompt error, got %q", stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -63,6 +63,7 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"ZERO terminal coding agent",
 		"Usage:",
 		"zero [command]",
+		"exec",
 		"--version",
 	} {
 		if !strings.Contains(output, want) {
@@ -71,6 +72,40 @@ func assertHelpOutput(t *testing.T, args []string) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunExecPrintsOfflineRuntimeResponse(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec", "hello", "zero"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "hello zero") {
+		t.Fatalf("expected exec response to include prompt, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunExecRequiresPrompt(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec"}, &stdout, &stderr)
+
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Prompt required") {
+		t.Fatalf("expected prompt error, got %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the first Go agent runtime spine for M0:

- Defines Go provider messages, stream events, tool calls, tool definitions, usage, and runtime options.
- Adds a bounded ReAct-style loop that streams text, collects tool calls, executes tools through `tools.Registry.RunWithOptions`, feeds tool results back into provider messages, and stops at `MaxTurns`.
- Supports permission modes for safe reads, prompt-gated denial by default, and unsafe grants.
- Wires a minimal `zero exec <prompt>` Go CLI command through the new runtime with a deterministic offline provider until the real Go provider lands in the next PR.

## Tests

- `git diff --check`
- `go test ./...`
- `bun run build:go`
- `bun run smoke:go`
- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`
- `bun run smoke:build`

## Notes

The Go `zero exec` provider is intentionally offline in this PR. It proves the CLI -> agent runtime path without adding the OpenAI-compatible provider in the same review. The next PR should replace that provider stub with real provider/config wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive agent with streaming responses that supports multi-turn tool calls, emits incremental text and usage updates, and enforces configurable permission modes for tool execution.
  * Tool discovery/advertising with ordered tool-call handling.
  * New CLI command "zero exec" to run a prompt and print the agent's final answer.

* **Chores / Tests**
  * Added comprehensive unit tests covering streaming behavior, tool execution, permission handling, CLI execution, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->