### PR TITLE
Build release binary with Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/README.md
+++ b/README.md
@@ -173,11 +173,18 @@ tests/                   # bun test suite
 bun test            # run the test suite
 bun run test:go     # run Go tests
 bun run typecheck   # tsc --noEmit
-bun run build       # compile a standalone binary
-bun run build:go    # compile the Go entrypoint
-bun run smoke:build # verify the built binary
-bun run smoke:go    # verify the Go entrypoint binary
+bun run build       # compile the release-facing Go binary
+bun run build:go    # same Go binary builder, kept as a stable validation command
+bun run smoke:build # verify the release-facing Go binary
+bun run smoke:go    # verify the Go binary through the Go smoke path
 bun run perf:bench  # performance benchmarks (see docs/PERFORMANCE.md)
+```
+
+Cross-compile by passing Go targets to the builder:
+
+```bash
+bun run scripts/build.ts --goos linux --goarch amd64
+bun run scripts/build.ts --goos windows --goarch amd64 --output dist/zero.exe
 ```
 
 ### Install from a release

--- a/docs/NPM_WRAPPER_SMOKE.md
+++ b/docs/NPM_WRAPPER_SMOKE.md
@@ -12,6 +12,10 @@ bun run build
 bun run smoke:build
 ```
 
+`build` and `build:go` both compile the Go-native release binary and inject the
+version from `package.json`. Keep the Bun install/test checks because the npm
+wrapper and transitional TypeScript surface still ship from this package.
+
 Also run the Go checks when the PR changes Go entrypoint, CLI, or release
 artifact behavior:
 
@@ -27,7 +31,7 @@ bun run smoke:go
 - `bun install --frozen-lockfile` succeeds without lockfile changes.
 - The wrapper binary resolves through the package `bin` entry and
   `node_modules/.bin` in a package-install smoke test.
-- The built wrapper exits 0 for `zero --version` or `zero --help`.
-- The reported version matches `package.json`.
+- The built binary exits 0 for `zero --version` or `zero --help`.
+- `zero --version` reports `zero <package.json version>`.
 - Release packaging still emits the expected archive and checksum names when
   package release files change.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,7 +6,7 @@ The M2 performance harness tracks three release-facing signals:
 - TTFT: time from starting the local agent loop to the first streamed text event from a deterministic provider.
 - Memory: peak RSS for the benchmarked in-process agent path.
 
-When a built binary exists at `./zero` or `./zero.exe`, cold start uses that artifact. Otherwise it falls back to `bun src/index.ts --version` so the benchmark can run before a local build.
+When a built Go binary exists at `./zero` or `./zero.exe`, cold start uses that artifact. Otherwise it falls back to `bun src/index.ts --version` so the benchmark can run before a local build.
 
 ## Run Locally
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
-const version = "0.1.0"
+var version = "dev"
 
 // Run executes the minimal Go CLI surface. It returns an exit code so tests can
 // exercise command behavior without terminating the test process.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -25,7 +25,7 @@ func TestRunPrintsVersion(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
-	if got := stdout.String(); got != "zero 0.1.0\n" {
+	if got := stdout.String(); got != "zero dev\n" {
 		t.Fatalf("expected version output, got %q", got)
 	}
 	if stderr.Len() != 0 {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:go": "go test ./...",
     "typecheck": "bunx tsc --noEmit",
     "build": "bun run scripts/build.ts",
-    "build:go": "go build ./cmd/zero",
+    "build:go": "bun run scripts/build.ts",
     "smoke:build": "bun run scripts/smoke-build.ts",
     "smoke:go": "bun run scripts/smoke-go.ts",
     "review:pr": "bun run scripts/pr-review.ts",

--- a/scripts/artifact.ts
+++ b/scripts/artifact.ts
@@ -4,6 +4,26 @@ export function getZeroArtifactName(platform = process.platform): string {
   return platform === 'win32' ? 'zero.exe' : 'zero';
 }
 
+export function getZeroArtifactNameForGoOS(goos: string): string {
+  return goos === 'windows' ? 'zero.exe' : 'zero';
+}
+
+export function getZeroArtifactPath(platform = process.platform, cwd = process.cwd()): string {
+  return join(cwd, getZeroArtifactName(platform));
+}
+
+export function getGoOS(platform = process.platform): string {
+  if (platform === 'win32') return 'windows';
+  if (platform === 'darwin') return 'darwin';
+  return platform;
+}
+
+export function getGoArch(arch = process.arch): string {
+  if (arch === 'x64') return 'amd64';
+  if (arch === 'ia32') return '386';
+  return arch;
+}
+
 export function getReleasePlatform(platform = process.platform): string {
   if (platform === 'darwin') return 'macos';
   if (platform === 'win32') return 'windows';
@@ -31,4 +51,4 @@ export function getReleaseArchiveName(
 }
 
 export const zeroArtifactName = getZeroArtifactName();
-export const zeroArtifactPath = join(process.cwd(), zeroArtifactName);
+export const zeroArtifactPath = getZeroArtifactPath();

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,5 +1,201 @@
-import { $ } from 'bun';
-import { zeroArtifactName, zeroArtifactPath } from './artifact';
+import { join } from 'node:path';
+import { getGoArch, getGoOS, getZeroArtifactNameForGoOS } from './artifact';
 
-await $`bun build src/index.ts --compile --outfile ${zeroArtifactPath}`;
-console.log(`Built ${zeroArtifactName}`);
+export interface BuildCliOptions {
+  goos: string;
+  goarch: string;
+  output?: string;
+  help: boolean;
+}
+
+export interface BuildOptions {
+  goos: string;
+  goarch: string;
+  output: string;
+  version: string;
+}
+
+export function parseBuildArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env
+): BuildCliOptions {
+  const options: BuildCliOptions = {
+    goos: env.ZERO_BUILD_GOOS?.trim() || getGoOS(),
+    goarch: env.ZERO_BUILD_GOARCH?.trim() || getGoArch(),
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const rawArg = args[index]!;
+    const { flag, inlineValue } = splitFlagValue(rawArg);
+
+    switch (flag) {
+      case '--goos':
+        options.goos = readOptionValue(args, inlineValue, ++index, flag);
+        if (inlineValue !== undefined) index--;
+        break;
+      case '--goarch':
+        options.goarch = readOptionValue(args, inlineValue, ++index, flag);
+        if (inlineValue !== undefined) index--;
+        break;
+      case '--output':
+      case '-o':
+        options.output = readOptionValue(args, inlineValue, ++index, flag);
+        if (inlineValue !== undefined) index--;
+        break;
+      case '--help':
+      case '-h':
+        rejectInlineValue(flag, inlineValue);
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${rawArg}`);
+    }
+  }
+
+  return options;
+}
+
+export function buildHelp(): string {
+  return [
+    'Usage: bun run scripts/build.ts [options]',
+    '',
+    'Builds the Go-native zero binary.',
+    '',
+    'Options:',
+    '  --goos <goos>       Target GOOS (default: current platform)',
+    '  --goarch <goarch>   Target GOARCH (default: current architecture)',
+    '  -o, --output <path> Write binary to path',
+    '  -h, --help          Show this help',
+    '',
+    'Environment overrides:',
+    '  ZERO_BUILD_GOOS, ZERO_BUILD_GOARCH',
+  ].join('\n');
+}
+
+export function defaultBuildOutput(goos: string, cwd = process.cwd()): string {
+  return join(cwd, getZeroArtifactNameForGoOS(goos));
+}
+
+export function goBuildLdflags(version: string): string {
+  return `-s -w -X github.com/Gitlawb/zero/internal/cli.version=${version}`;
+}
+
+export function parsePackageVersion(packageText: string): string {
+  const parsed = JSON.parse(packageText) as { version?: unknown };
+
+  if (typeof parsed.version !== 'string' || parsed.version.trim() === '') {
+    throw new Error('package.json must contain a non-empty string version');
+  }
+
+  return parsed.version;
+}
+
+export async function buildZeroBinary(options: BuildOptions): Promise<void> {
+  const child = Bun.spawn(
+    [
+      'go',
+      'build',
+      '-trimpath',
+      '-ldflags',
+      goBuildLdflags(options.version),
+      '-o',
+      options.output,
+      './cmd/zero',
+    ],
+    {
+      env: {
+        ...process.env,
+        CGO_ENABLED: process.env.CGO_ENABLED ?? '0',
+        GOOS: options.goos,
+        GOARCH: options.goarch,
+      },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    }
+  );
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+
+  if (stdout.trim()) console.log(stdout.trim());
+
+  if (exitCode !== 0) {
+    throw new Error(stderr.trim() || `go build exited with ${exitCode}`);
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    const cliOptions = parseBuildArgs(process.argv.slice(2));
+
+    if (cliOptions.help) {
+      console.log(buildHelp());
+      return;
+    }
+
+    const packageText = await Bun.file('package.json').text();
+    const version = parsePackageVersion(packageText);
+    const output = cliOptions.output ?? defaultBuildOutput(cliOptions.goos);
+
+    await buildZeroBinary({
+      goos: cliOptions.goos,
+      goarch: cliOptions.goarch,
+      output,
+      version,
+    });
+
+    console.log(`Built ${output} (${cliOptions.goos}/${cliOptions.goarch}, version ${version})`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[zero] Build failed: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+function splitFlagValue(arg: string): { flag: string; inlineValue?: string } {
+  const separatorIndex = arg.indexOf('=');
+  if (separatorIndex === -1) return { flag: arg };
+
+  return {
+    flag: arg.slice(0, separatorIndex),
+    inlineValue: arg.slice(separatorIndex + 1),
+  };
+}
+
+function readOptionValue(
+  args: string[],
+  inlineValue: string | undefined,
+  index: number,
+  flag: string
+): string {
+  if (inlineValue !== undefined) {
+    if (inlineValue === '') {
+      throw new Error(`${flag} requires a value`);
+    }
+    return inlineValue;
+  }
+
+  return requireValue(args, index, flag);
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function rejectInlineValue(flag: string, inlineValue: string | undefined): void {
+  if (inlineValue !== undefined) {
+    throw new Error(`${flag} does not accept a value`);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -7,17 +7,8 @@ import {
   zeroArtifactName,
   zeroArtifactPath,
 } from './artifact';
+import { parsePackageVersion } from './build';
 import { writeSha256Checksum } from './release-checksums';
-
-function parsePackageVersion(packageText: string): string {
-  const parsed = JSON.parse(packageText) as { version?: unknown };
-
-  if (typeof parsed.version !== 'string' || parsed.version.trim() === '') {
-    throw new Error('package.json must contain a non-empty string version');
-  }
-
-  return parsed.version;
-}
 
 function quotePowerShellPath(path: string): string {
   return `'${path.replaceAll("'", "''")}'`;

--- a/scripts/smoke-build.ts
+++ b/scripts/smoke-build.ts
@@ -27,18 +27,24 @@ if (exitCode !== 0) {
 let expectedVersion: string;
 
 try {
-  expectedVersion = JSON.parse(packageText).version;
+  const parsedPackage = JSON.parse(packageText);
+  if (typeof parsedPackage?.version !== 'string') {
+    console.error(`Invalid package.json: version is not a string (${JSON.stringify(parsedPackage?.version)})`);
+    process.exit(1);
+  }
+  expectedVersion = parsedPackage.version;
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   console.error(`Failed to parse package.json: ${message}`);
   process.exit(1);
 }
 
-const actualVersion = stdout.trim();
+const expectedOutput = `zero ${expectedVersion}`;
+const actualOutput = stdout.trim();
 
-if (actualVersion !== expectedVersion) {
-  console.error(`Expected ${zeroArtifactName} --version to print ${expectedVersion}, got ${actualVersion}`);
+if (actualOutput !== expectedOutput) {
+  console.error(`Expected ${zeroArtifactName} --version to print ${expectedOutput}, got ${actualOutput}`);
   process.exit(1);
 }
 
-console.log(`${zeroArtifactName} smoke check passed (${actualVersion})`);
+console.log(`${zeroArtifactName} smoke check passed (${expectedVersion})`);

--- a/tests/build-scripts.test.ts
+++ b/tests/build-scripts.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
 import {
+  getGoArch,
+  getGoOS,
   getReleaseArchiveExtension,
   getReleaseArchiveName,
   getReleasePackageName,
   getReleasePlatform,
   getZeroArtifactName,
+  getZeroArtifactNameForGoOS,
 } from '../scripts/artifact';
+import {
+  defaultBuildOutput,
+  goBuildLdflags,
+  parseBuildArgs,
+  parsePackageVersion,
+} from '../scripts/build';
 
 describe('build artifact naming', () => {
   it('uses a Windows executable suffix on win32', () => {
@@ -15,6 +25,21 @@ describe('build artifact naming', () => {
   it('uses the plain binary name on Unix platforms', () => {
     expect(getZeroArtifactName('linux')).toBe('zero');
     expect(getZeroArtifactName('darwin')).toBe('zero');
+  });
+
+  it('maps Go build targets to executable names', () => {
+    expect(getZeroArtifactNameForGoOS('windows')).toBe('zero.exe');
+    expect(getZeroArtifactNameForGoOS('linux')).toBe('zero');
+    expect(getZeroArtifactNameForGoOS('darwin')).toBe('zero');
+  });
+
+  it('maps Node platform and architecture names to Go targets', () => {
+    expect(getGoOS('win32')).toBe('windows');
+    expect(getGoOS('darwin')).toBe('darwin');
+    expect(getGoOS('linux')).toBe('linux');
+    expect(getGoArch('x64')).toBe('amd64');
+    expect(getGoArch('arm64')).toBe('arm64');
+    expect(getGoArch('ia32')).toBe('386');
   });
 });
 
@@ -35,5 +60,43 @@ describe('release artifact naming', () => {
     expect(getReleasePackageName('0.1.0', 'darwin', 'arm64')).toBe('zero-v0.1.0-macos-arm64');
     expect(getReleaseArchiveName('0.1.0', 'win32', 'x64')).toBe('zero-v0.1.0-windows-x64.zip');
     expect(getReleaseArchiveName('0.1.0', 'linux', 'x64')).toBe('zero-v0.1.0-linux-x64.tar.gz');
+  });
+});
+
+describe('Go binary build script', () => {
+  it('parses target overrides from environment and CLI flags', () => {
+    expect(parseBuildArgs([], {
+      ZERO_BUILD_GOOS: 'linux',
+      ZERO_BUILD_GOARCH: 'arm64',
+    })).toMatchObject({
+      goos: 'linux',
+      goarch: 'arm64',
+      help: false,
+    });
+
+    expect(parseBuildArgs(['--goos=windows', '--goarch', 'amd64', '--output', 'dist/zero.exe'], {}))
+      .toEqual({
+        goos: 'windows',
+        goarch: 'amd64',
+        output: 'dist/zero.exe',
+        help: false,
+      });
+  });
+
+  it('rejects flag-shaped values for options that require values', () => {
+    expect(() => parseBuildArgs(['-o', '-h'])).toThrow('-o requires a value');
+    expect(() => parseBuildArgs(['--goarch', '-h'])).toThrow('--goarch requires a value');
+  });
+
+  it('builds the expected default output path for the target OS', () => {
+    expect(defaultBuildOutput('windows', '/repo')).toBe(join('/repo', 'zero.exe'));
+    expect(defaultBuildOutput('linux', '/repo')).toBe(join('/repo', 'zero'));
+  });
+
+  it('injects the package version into the Go CLI package', () => {
+    expect(parsePackageVersion('{"version":"0.1.0"}')).toBe('0.1.0');
+    expect(goBuildLdflags('0.1.0')).toContain(
+      '-X github.com/Gitlawb/zero/internal/cli.version=0.1.0'
+    );
   });
 });

--- a/tests/foundation-tools.test.ts
+++ b/tests/foundation-tools.test.ts
@@ -24,7 +24,7 @@ describe('package scripts', () => {
     expect(pkg.scripts.test).toBe('bun test ./tests --timeout 15000');
     expect(pkg.scripts['test:go']).toBe('go test ./...');
     expect(pkg.scripts.build).toBe('bun run scripts/build.ts');
-    expect(pkg.scripts['build:go']).toBe('go build ./cmd/zero');
+    expect(pkg.scripts['build:go']).toBe('bun run scripts/build.ts');
     expect(pkg.scripts['smoke:build']).toBe('bun run scripts/smoke-build.ts');
     expect(pkg.scripts['smoke:go']).toBe('bun run scripts/smoke-go.ts');
   });


### PR DESCRIPTION
Summary
- Build the release-facing zero binary with Go instead of Bun compile.
- Inject package.json version into the Go CLI with ldflags and keep dev as the raw Go fallback.
- Add Go target helpers, build flags for cross-target output, workflow Go setup, release/package smoke updates, and docs/tests.

Validation
- bun test tests/build-scripts.test.ts tests/foundation-tools.test.ts --timeout 15000
- bun test tests/install-scripts.test.ts tests/release-checksums.test.ts --timeout 15000
- bun run typecheck
- bun run test:go
- bun run build
- bun run build:go
- bun run smoke:build
- bun run smoke:go
- bun run package:release
- bun run verify:release
- tar -tzf dist/release/zero-v0.1.0-linux-x64.tar.gz
- bun run scripts/build.ts --goos windows --goarch amd64 --output /tmp/zero-build-test.exe
- git diff --check

Full suite note
- bun run test: 279 pass, 5 fail locally in the same known headless/MCP environment-sensitive tests: stream-json stdin provider setup, session server port 0, and MCP stdio initialize/list flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build System**
  * New Go-native build CLI with explicit cross-compile options and deterministic output naming for multiple platforms.

* **Documentation**
  * Updated development guides and checklists with clear build/release examples and clarified smoke/performance benchmark behavior.

* **Chores**
  * CI workflows now set up the Go toolchain with caching enabled.
  * CLI version output changed to "dev"; tests updated to match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->