### PR TITLE
[codex] add Go runtime contract foundations

### DIFF
--- a/internal/config/contracts.go
+++ b/internal/config/contracts.go
@@ -1,0 +1,73 @@
+package config
+
+const ContractOwnerRuntime = "runtime"
+
+type ContractGap struct {
+	Field     string
+	Owner     string
+	Milestone string
+	Reason    string
+}
+
+func DefaultContractGaps() []ContractGap {
+	return []ContractGap{
+		{
+			Field:     "env.OPENAI_API_KEY",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M0",
+			Reason:    "OpenAI-compatible provider startup needs a stable environment key contract.",
+		},
+		{
+			Field:     "env.ZERO_PROVIDER",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M0",
+			Reason:    "Provider selection needs an explicit environment override before provider resolution is wired.",
+		},
+		{
+			Field:     "providers[].timeout",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M1",
+			Reason:    "Provider adapters need bounded request and stream waits.",
+		},
+		{
+			Field:     "providers[].retryPolicy",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M1",
+			Reason:    "Provider runtime needs consistent retry behavior across adapters.",
+		},
+		{
+			Field:     "providers[].maxOutputTokens",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M0",
+			Reason:    "The provider contract must bound generated output for chat and tool loops.",
+		},
+		{
+			Field:     "providers[].reasoningEffort",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M1",
+			Reason:    "Reasoning-capable models need a normalized config surface.",
+		},
+		{
+			Field:     "permissions.mode",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M0",
+			Reason:    "Runtime permission behavior must be explicit before tools execute mutating actions.",
+		},
+		{
+			Field:     "sandbox.policy",
+			Owner:     ContractOwnerRuntime,
+			Milestone: "M0",
+			Reason:    "Sandbox policy needs a shared backend contract before platform adapters land.",
+		},
+	}
+}
+
+func FindContractGapsByMilestone(gaps []ContractGap, milestone string) []ContractGap {
+	var matches []ContractGap
+	for _, gap := range gaps {
+		if gap.Milestone == milestone {
+			matches = append(matches, gap)
+		}
+	}
+	return matches
+}

--- a/internal/config/contracts_test.go
+++ b/internal/config/contracts_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+func TestDefaultContractGapsCoverProviderAndPolicyFields(t *testing.T) {
+	gaps := DefaultContractGaps()
+	fields := make(map[string]ContractGap)
+	for _, gap := range gaps {
+		fields[gap.Field] = gap
+	}
+
+	for _, field := range []string{
+		"env.OPENAI_API_KEY",
+		"env.ZERO_PROVIDER",
+		"providers[].timeout",
+		"providers[].retryPolicy",
+		"providers[].maxOutputTokens",
+		"providers[].reasoningEffort",
+		"permissions.mode",
+		"sandbox.policy",
+	} {
+		gap, ok := fields[field]
+		if !ok {
+			t.Fatalf("missing config contract gap for %s", field)
+		}
+		if gap.Owner != ContractOwnerRuntime {
+			t.Fatalf("gap %s owner = %q, want %q", field, gap.Owner, ContractOwnerRuntime)
+		}
+		if gap.Milestone == "" {
+			t.Fatalf("gap %s should include milestone", field)
+		}
+		if gap.Reason == "" {
+			t.Fatalf("gap %s should include reason", field)
+		}
+	}
+}
+
+func TestFindContractGapsByMilestone(t *testing.T) {
+	gaps := FindContractGapsByMilestone(DefaultContractGaps(), "M0")
+	if len(gaps) == 0 {
+		t.Fatal("expected M0 gaps")
+	}
+	for _, gap := range gaps {
+		if gap.Milestone != "M0" {
+			t.Fatalf("got milestone %q, want M0", gap.Milestone)
+		}
+	}
+}

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -192,6 +192,9 @@ func NewRegistry(entries []ModelEntry) (Registry, error) {
 	registry := Registry{entries: make(map[string]ModelEntry)}
 	seenModelIDs := make(map[string]struct{})
 	for _, entry := range entries {
+		if err := entry.Validate(); err != nil {
+			return Registry{}, fmt.Errorf("invalid model %q: %w", entry.ID, err)
+		}
 		modelID := normalizePattern(entry.ID)
 		if modelID == "" {
 			return Registry{}, fmt.Errorf("model id is required")

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -1,0 +1,250 @@
+package modelregistry
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ProviderKind string
+
+const (
+	ProviderOpenAI           ProviderKind = "openai"
+	ProviderAnthropic        ProviderKind = "anthropic"
+	ProviderGoogle           ProviderKind = "google"
+	ProviderOpenAICompatible ProviderKind = "openai-compatible"
+)
+
+type ReasoningEffort string
+
+const (
+	ReasoningEffortNone    ReasoningEffort = "none"
+	ReasoningEffortMinimal ReasoningEffort = "minimal"
+	ReasoningEffortLow     ReasoningEffort = "low"
+	ReasoningEffortMedium  ReasoningEffort = "medium"
+	ReasoningEffortHigh    ReasoningEffort = "high"
+	ReasoningEffortXHigh   ReasoningEffort = "xhigh"
+)
+
+type ModelCapability string
+
+const (
+	ModelCapabilityChat         ModelCapability = "chat"
+	ModelCapabilityStreaming    ModelCapability = "streaming"
+	ModelCapabilityToolCalling  ModelCapability = "tool-calling"
+	ModelCapabilityVision       ModelCapability = "vision"
+	ModelCapabilityJSONMode     ModelCapability = "json-mode"
+	ModelCapabilityReasoning    ModelCapability = "reasoning"
+	ModelCapabilitySystemPrompt ModelCapability = "system-prompt"
+	ModelCapabilityPromptCache  ModelCapability = "prompt-cache"
+	ModelCapabilityLongContext  ModelCapability = "long-context"
+)
+
+type ModelCapabilities []ModelCapability
+
+type ModelStatus string
+
+const (
+	ModelStatusActive     ModelStatus = "active"
+	ModelStatusPreview    ModelStatus = "preview"
+	ModelStatusDeprecated ModelStatus = "deprecated"
+)
+
+type ContextLimits struct {
+	ContextWindow   int
+	MaxOutputTokens int
+}
+
+type ModelCost struct {
+	Currency              string
+	Unit                  string
+	InputPerMillion       float64
+	OutputPerMillion      float64
+	CachedInputPerMillion float64
+	Source                string
+	SourceLastVerified    string
+}
+
+type ModelEntry struct {
+	ID               string
+	DisplayName      string
+	APIModel         string
+	Provider         ProviderKind
+	APIProviders     []ProviderKind
+	ContextLimits    ContextLimits
+	ReasoningEfforts []ReasoningEffort
+	Capabilities     ModelCapabilities
+	Cost             ModelCost
+	Status           ModelStatus
+	Aliases          []string
+	Description      string
+}
+
+func (model ModelEntry) Validate() error {
+	if strings.TrimSpace(model.ID) == "" {
+		return fmt.Errorf("model id is required")
+	}
+	if strings.TrimSpace(model.DisplayName) == "" {
+		return fmt.Errorf("model display name is required")
+	}
+	if strings.TrimSpace(model.APIModel) == "" {
+		return fmt.Errorf("api model is required")
+	}
+	if !ValidPrimaryProviderKind(model.Provider) {
+		return fmt.Errorf("unknown primary provider %q", model.Provider)
+	}
+	if model.ContextLimits.ContextWindow <= 0 {
+		return fmt.Errorf("context window must be positive")
+	}
+	if model.ContextLimits.MaxOutputTokens <= 0 {
+		return fmt.Errorf("max output tokens must be positive")
+	}
+	if model.ContextLimits.MaxOutputTokens > model.ContextLimits.ContextWindow {
+		return fmt.Errorf("max output tokens cannot exceed context window")
+	}
+	if len(model.Capabilities) == 0 {
+		return fmt.Errorf("at least one model capability is required")
+	}
+	for _, capability := range model.Capabilities {
+		if !ValidModelCapability(capability) {
+			return fmt.Errorf("unknown model capability %q", capability)
+		}
+	}
+	for _, effort := range model.ReasoningEfforts {
+		if !ValidReasoningEffort(effort) {
+			return fmt.Errorf("unknown reasoning effort %q", effort)
+		}
+	}
+	if err := model.Cost.Validate(); err != nil {
+		return err
+	}
+	if !ValidModelStatus(model.Status) {
+		return fmt.Errorf("unknown model status %q", model.Status)
+	}
+	if len(model.Aliases) == 0 {
+		return fmt.Errorf("at least one model alias is required")
+	}
+	for _, alias := range model.Aliases {
+		if strings.TrimSpace(alias) == "" {
+			return fmt.Errorf("model aliases cannot be blank")
+		}
+	}
+	for _, provider := range model.APIProviders {
+		if !ValidRuntimeProviderKind(provider) {
+			return fmt.Errorf("unknown api provider %q", provider)
+		}
+	}
+	return nil
+}
+
+func (cost ModelCost) Validate() error {
+	if cost.Currency != "USD" {
+		return fmt.Errorf("model cost currency must be USD")
+	}
+	if cost.Unit != "per_1m_tokens" {
+		return fmt.Errorf("model cost unit must be per_1m_tokens")
+	}
+	if cost.InputPerMillion < 0 || cost.OutputPerMillion < 0 || cost.CachedInputPerMillion < 0 {
+		return fmt.Errorf("model cost values must be non-negative")
+	}
+	if strings.TrimSpace(cost.Source) == "" {
+		return fmt.Errorf("model cost source is required")
+	}
+	if strings.TrimSpace(cost.SourceLastVerified) == "" {
+		return fmt.Errorf("model cost source last verified date is required")
+	}
+	return nil
+}
+
+func (model ModelEntry) Supports(capability ModelCapability) bool {
+	for _, candidate := range model.Capabilities {
+		if candidate == capability {
+			return true
+		}
+	}
+	return false
+}
+
+func (model ModelEntry) AllowsProvider(provider ProviderKind) bool {
+	if len(model.APIProviders) == 0 {
+		return model.Provider == provider
+	}
+	for _, candidate := range model.APIProviders {
+		if candidate == provider {
+			return true
+		}
+	}
+	return false
+}
+
+type Registry struct {
+	entries map[string]ModelEntry
+}
+
+func NewRegistry(entries []ModelEntry) Registry {
+	registry := Registry{entries: make(map[string]ModelEntry)}
+	for _, entry := range entries {
+		registry.register(entry.ID, entry)
+		registry.register(entry.APIModel, entry)
+		for _, alias := range entry.Aliases {
+			registry.register(alias, entry)
+		}
+	}
+	return registry
+}
+
+func (registry Registry) Get(pattern string) (ModelEntry, bool) {
+	entry, ok := registry.entries[normalizePattern(pattern)]
+	return entry, ok
+}
+
+func (registry Registry) register(pattern string, entry ModelEntry) {
+	normalized := normalizePattern(pattern)
+	if normalized == "" {
+		return
+	}
+	registry.entries[normalized] = entry
+}
+
+func normalizePattern(pattern string) string {
+	return strings.ToLower(strings.TrimSpace(pattern))
+}
+
+func ValidPrimaryProviderKind(provider ProviderKind) bool {
+	switch provider {
+	case ProviderOpenAI, ProviderAnthropic, ProviderGoogle:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidRuntimeProviderKind(provider ProviderKind) bool {
+	return ValidPrimaryProviderKind(provider) || provider == ProviderOpenAICompatible
+}
+
+func ValidReasoningEffort(effort ReasoningEffort) bool {
+	switch effort {
+	case ReasoningEffortNone, ReasoningEffortMinimal, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidModelCapability(capability ModelCapability) bool {
+	switch capability {
+	case ModelCapabilityChat, ModelCapabilityStreaming, ModelCapabilityToolCalling, ModelCapabilityVision, ModelCapabilityJSONMode, ModelCapabilityReasoning, ModelCapabilitySystemPrompt, ModelCapabilityPromptCache, ModelCapabilityLongContext:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidModelStatus(status ModelStatus) bool {
+	switch status {
+	case ModelStatusActive, ModelStatusPreview, ModelStatusDeprecated:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -3,6 +3,7 @@ package modelregistry
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type ProviderKind string
@@ -133,6 +134,9 @@ func (model ModelEntry) Validate() error {
 			return fmt.Errorf("unknown api provider %q", provider)
 		}
 	}
+	if len(model.APIProviders) > 0 && !model.AllowsProvider(model.Provider) {
+		return fmt.Errorf("primary provider %q not allowed by api providers", model.Provider)
+	}
 	return nil
 }
 
@@ -149,8 +153,12 @@ func (cost ModelCost) Validate() error {
 	if strings.TrimSpace(cost.Source) == "" {
 		return fmt.Errorf("model cost source is required")
 	}
-	if strings.TrimSpace(cost.SourceLastVerified) == "" {
+	sourceLastVerified := strings.TrimSpace(cost.SourceLastVerified)
+	if sourceLastVerified == "" {
 		return fmt.Errorf("model cost source last verified date is required")
+	}
+	if _, err := time.Parse("2006-01-02", sourceLastVerified); err != nil {
+		return fmt.Errorf("model cost source last verified date must use YYYY-MM-DD format")
 	}
 	return nil
 }
@@ -180,16 +188,31 @@ type Registry struct {
 	entries map[string]ModelEntry
 }
 
-func NewRegistry(entries []ModelEntry) Registry {
+func NewRegistry(entries []ModelEntry) (Registry, error) {
 	registry := Registry{entries: make(map[string]ModelEntry)}
+	seenModelIDs := make(map[string]struct{})
 	for _, entry := range entries {
-		registry.register(entry.ID, entry)
-		registry.register(entry.APIModel, entry)
+		modelID := normalizePattern(entry.ID)
+		if modelID == "" {
+			return Registry{}, fmt.Errorf("model id is required")
+		}
+		if _, ok := seenModelIDs[modelID]; ok {
+			return Registry{}, fmt.Errorf("duplicate model id %q", modelID)
+		}
+		seenModelIDs[modelID] = struct{}{}
+		if err := registry.register(entry.ID, entry); err != nil {
+			return Registry{}, err
+		}
+		if err := registry.register(entry.APIModel, entry); err != nil {
+			return Registry{}, err
+		}
 		for _, alias := range entry.Aliases {
-			registry.register(alias, entry)
+			if err := registry.register(alias, entry); err != nil {
+				return Registry{}, err
+			}
 		}
 	}
-	return registry
+	return registry, nil
 }
 
 func (registry Registry) Get(pattern string) (ModelEntry, bool) {
@@ -197,12 +220,16 @@ func (registry Registry) Get(pattern string) (ModelEntry, bool) {
 	return entry, ok
 }
 
-func (registry Registry) register(pattern string, entry ModelEntry) {
+func (registry Registry) register(pattern string, entry ModelEntry) error {
 	normalized := normalizePattern(pattern)
 	if normalized == "" {
-		return
+		return nil
+	}
+	if existing, ok := registry.entries[normalized]; ok && existing.ID != entry.ID {
+		return fmt.Errorf("duplicate model lookup key %q for %q and %q", normalized, existing.ID, entry.ID)
 	}
 	registry.entries[normalized] = entry
+	return nil
 }
 
 func normalizePattern(pattern string) string {

--- a/internal/modelregistry/models_test.go
+++ b/internal/modelregistry/models_test.go
@@ -1,0 +1,150 @@
+package modelregistry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestModelEntryValidatesPRDShape(t *testing.T) {
+	model := ModelEntry{
+		ID:          "gpt-4.1-mini",
+		DisplayName: "GPT-4.1 mini",
+		APIModel:    "gpt-4.1-mini",
+		Provider:    ProviderOpenAI,
+		APIProviders: []ProviderKind{
+			ProviderOpenAI,
+			ProviderOpenAICompatible,
+		},
+		ContextLimits: ContextLimits{
+			ContextWindow:   1_047_576,
+			MaxOutputTokens: 32_768,
+		},
+		Capabilities: ModelCapabilities{
+			ModelCapabilityChat,
+			ModelCapabilityStreaming,
+			ModelCapabilityToolCalling,
+			ModelCapabilitySystemPrompt,
+			ModelCapabilityLongContext,
+		},
+		Cost: ModelCost{
+			Currency:              "USD",
+			Unit:                  "per_1m_tokens",
+			InputPerMillion:       0.4,
+			OutputPerMillion:      1.6,
+			CachedInputPerMillion: 0.1,
+			Source:                "https://platform.openai.com/docs/pricing/",
+			SourceLastVerified:    "2026-06-02",
+		},
+		Status:      ModelStatusActive,
+		Aliases:     []string{"openai:gpt-4.1-mini"},
+		Description: "OpenAI lower-cost long-context model for frequent edit loops.",
+	}
+
+	if err := model.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+	if !model.Supports(ModelCapabilityToolCalling) {
+		t.Fatal("model should support tool calling")
+	}
+	if !model.AllowsProvider(ProviderOpenAICompatible) {
+		t.Fatal("model should allow OpenAI-compatible runtime adapter")
+	}
+}
+
+func TestModelEntryRejectsInvalidContextLimits(t *testing.T) {
+	model := validModelEntry()
+	model.ContextLimits.ContextWindow = 1_000
+	model.ContextLimits.MaxOutputTokens = 2_000
+
+	err := model.Validate()
+	if err == nil {
+		t.Fatal("expected context limit validation error")
+	}
+	if !strings.Contains(err.Error(), "max output tokens") {
+		t.Fatalf("error = %q, want max output tokens", err.Error())
+	}
+}
+
+func TestModelEntryRejectsOpenAICompatibleAsPrimaryProvider(t *testing.T) {
+	model := validModelEntry()
+	model.Provider = ProviderOpenAICompatible
+
+	err := model.Validate()
+	if err == nil {
+		t.Fatal("expected primary provider validation error")
+	}
+	if !strings.Contains(err.Error(), "primary provider") {
+		t.Fatalf("error = %q, want primary provider", err.Error())
+	}
+}
+
+func TestModelEntryRejectsUnknownContractEnums(t *testing.T) {
+	model := validModelEntry()
+	model.Capabilities = ModelCapabilities{"telepathy"}
+
+	err := model.Validate()
+	if err == nil {
+		t.Fatal("expected capability validation error")
+	}
+	if !strings.Contains(err.Error(), "model capability") {
+		t.Fatalf("error = %q, want model capability", err.Error())
+	}
+
+	model = validModelEntry()
+	model.ReasoningEfforts = []ReasoningEffort{"warp"}
+
+	err = model.Validate()
+	if err == nil {
+		t.Fatal("expected reasoning effort validation error")
+	}
+	if !strings.Contains(err.Error(), "reasoning effort") {
+		t.Fatalf("error = %q, want reasoning effort", err.Error())
+	}
+
+	model = validModelEntry()
+	model.Status = "retired"
+
+	err = model.Validate()
+	if err == nil {
+		t.Fatal("expected model status validation error")
+	}
+	if !strings.Contains(err.Error(), "model status") {
+		t.Fatalf("error = %q, want model status", err.Error())
+	}
+}
+
+func TestModelRegistryResolvesStablePatterns(t *testing.T) {
+	registry := NewRegistry([]ModelEntry{validModelEntry()})
+
+	model, ok := registry.Get("OPENAI:GPT-4.1-MINI")
+	if !ok {
+		t.Fatal("expected model to resolve from case-insensitive match pattern")
+	}
+	if model.ID != "gpt-4.1-mini" {
+		t.Fatalf("model ID = %q, want gpt-4.1-mini", model.ID)
+	}
+}
+
+func validModelEntry() ModelEntry {
+	return ModelEntry{
+		ID:          "gpt-4.1-mini",
+		DisplayName: "GPT-4.1 mini",
+		APIModel:    "gpt-4.1-mini",
+		Provider:    ProviderOpenAI,
+		ContextLimits: ContextLimits{
+			ContextWindow:   1_047_576,
+			MaxOutputTokens: 32_768,
+		},
+		Capabilities: ModelCapabilities{ModelCapabilityChat},
+		Cost: ModelCost{
+			Currency:           "USD",
+			Unit:               "per_1m_tokens",
+			InputPerMillion:    0.4,
+			OutputPerMillion:   1.6,
+			Source:             "https://platform.openai.com/docs/pricing/",
+			SourceLastVerified: "2026-06-02",
+		},
+		Status:  ModelStatusActive,
+		Aliases: []string{"openai:gpt-4.1-mini"},
+	}
+}

--- a/internal/modelregistry/models_test.go
+++ b/internal/modelregistry/models_test.go
@@ -154,6 +154,19 @@ func TestModelRegistryResolvesStablePatterns(t *testing.T) {
 	}
 }
 
+func TestRegistryRejectsInvalidModelEntries(t *testing.T) {
+	model := validModelEntry()
+	model.ContextLimits.MaxOutputTokens = model.ContextLimits.ContextWindow + 1
+
+	_, err := NewRegistry([]ModelEntry{model})
+	if err == nil {
+		t.Fatal("expected invalid model validation error")
+	}
+	if !strings.Contains(err.Error(), "max output tokens") {
+		t.Fatalf("error = %q, want max output tokens", err.Error())
+	}
+}
+
 func TestRegistryDetectsDuplicateNormalizedLookupKeys(t *testing.T) {
 	first := validModelEntry()
 	second := validModelEntry()

--- a/internal/modelregistry/models_test.go
+++ b/internal/modelregistry/models_test.go
@@ -78,6 +78,19 @@ func TestModelEntryRejectsOpenAICompatibleAsPrimaryProvider(t *testing.T) {
 	}
 }
 
+func TestModelEntryRejectsProviderNotInAPIProviders(t *testing.T) {
+	model := validModelEntry()
+	model.APIProviders = []ProviderKind{ProviderAnthropic}
+
+	err := model.Validate()
+	if err == nil {
+		t.Fatal("expected provider/api providers validation error")
+	}
+	if !strings.Contains(err.Error(), "api providers") {
+		t.Fatalf("error = %q, want api providers", err.Error())
+	}
+}
+
 func TestModelEntryRejectsUnknownContractEnums(t *testing.T) {
 	model := validModelEntry()
 	model.Capabilities = ModelCapabilities{"telepathy"}
@@ -113,8 +126,24 @@ func TestModelEntryRejectsUnknownContractEnums(t *testing.T) {
 	}
 }
 
+func TestModelEntryRejectsInvalidSourceLastVerifiedDate(t *testing.T) {
+	model := validModelEntry()
+	model.Cost.SourceLastVerified = "2026/06/02"
+
+	err := model.Validate()
+	if err == nil {
+		t.Fatal("expected source last verified date validation error")
+	}
+	if !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Fatalf("error = %q, want YYYY-MM-DD", err.Error())
+	}
+}
+
 func TestModelRegistryResolvesStablePatterns(t *testing.T) {
-	registry := NewRegistry([]ModelEntry{validModelEntry()})
+	registry, err := NewRegistry([]ModelEntry{validModelEntry()})
+	if err != nil {
+		t.Fatalf("NewRegistry returned error: %v", err)
+	}
 
 	model, ok := registry.Get("OPENAI:GPT-4.1-MINI")
 	if !ok {
@@ -122,6 +151,38 @@ func TestModelRegistryResolvesStablePatterns(t *testing.T) {
 	}
 	if model.ID != "gpt-4.1-mini" {
 		t.Fatalf("model ID = %q, want gpt-4.1-mini", model.ID)
+	}
+}
+
+func TestRegistryDetectsDuplicateNormalizedLookupKeys(t *testing.T) {
+	first := validModelEntry()
+	second := validModelEntry()
+	second.ID = "other-model"
+	second.DisplayName = "Other model"
+	second.APIModel = "other-model"
+	second.Aliases = []string{"GPT-4.1-MINI"}
+
+	_, err := NewRegistry([]ModelEntry{first, second})
+	if err == nil {
+		t.Fatal("expected duplicate lookup key validation error")
+	}
+	if !strings.Contains(err.Error(), "duplicate model lookup key") {
+		t.Fatalf("error = %q, want duplicate model lookup key", err.Error())
+	}
+}
+
+func TestRegistryDetectsDuplicateModelIDs(t *testing.T) {
+	first := validModelEntry()
+	second := validModelEntry()
+	second.APIModel = "other-api-model"
+	second.Aliases = []string{"other:model"}
+
+	_, err := NewRegistry([]ModelEntry{first, second})
+	if err == nil {
+		t.Fatal("expected duplicate model id validation error")
+	}
+	if !strings.Contains(err.Error(), "duplicate model id") {
+		t.Fatalf("error = %q, want duplicate model id", err.Error())
 	}
 }
 

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -65,10 +65,12 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 					delete(pendingToolCalls, event.ToolCallID)
 				}
 			case StreamEventUsage:
-				collected.Usage.InputTokens += event.Usage.InputTokens
-				collected.Usage.OutputTokens += event.Usage.OutputTokens
-				collected.Usage.PromptTokens += event.Usage.PromptTokens
-				collected.Usage.CompletionTokens += event.Usage.CompletionTokens
+				inputTokens := event.Usage.EffectiveInputTokens()
+				outputTokens := event.Usage.EffectiveOutputTokens()
+				collected.Usage.InputTokens += inputTokens
+				collected.Usage.OutputTokens += outputTokens
+				collected.Usage.PromptTokens += inputTokens
+				collected.Usage.CompletionTokens += outputTokens
 				collected.Usage.CachedInputTokens += event.Usage.CachedInputTokens
 				collected.Usage.ReasoningTokens += event.Usage.ReasoningTokens
 				if options.OnUsage != nil {

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -65,9 +65,12 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 					delete(pendingToolCalls, event.ToolCallID)
 				}
 			case StreamEventUsage:
+				collected.Usage.InputTokens += event.Usage.InputTokens
+				collected.Usage.OutputTokens += event.Usage.OutputTokens
 				collected.Usage.PromptTokens += event.Usage.PromptTokens
 				collected.Usage.CompletionTokens += event.Usage.CompletionTokens
 				collected.Usage.CachedInputTokens += event.Usage.CachedInputTokens
+				collected.Usage.ReasoningTokens += event.Usage.ReasoningTokens
 				if options.OnUsage != nil {
 					options.OnUsage(event.Usage)
 				}

--- a/internal/zeroruntime/provider_test.go
+++ b/internal/zeroruntime/provider_test.go
@@ -205,6 +205,39 @@ func TestCollectStreamAccumulatesNormalizedUsageAliases(t *testing.T) {
 	}
 }
 
+func TestCollectStreamAccumulatesMixedUsageShapes(t *testing.T) {
+	normalizedUsage, err := NormalizeUsage(TokenUsage{InputTokens: 6, OutputTokens: 3, ReasoningTokens: 2})
+	if err != nil {
+		t.Fatalf("NormalizeUsage returned error: %v", err)
+	}
+
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		events <- StreamEvent{Type: StreamEventUsage, Usage: Usage{PromptTokens: 10, CompletionTokens: 4, CachedInputTokens: 3}}
+		events <- StreamEvent{Type: StreamEventUsage, Usage: normalizedUsage}
+		events <- StreamEvent{Type: StreamEventDone}
+	}()
+
+	collected := CollectStream(context.Background(), events)
+
+	if collected.Usage.EffectiveInputTokens() != 16 {
+		t.Fatalf("input tokens = %d, want 16", collected.Usage.EffectiveInputTokens())
+	}
+	if collected.Usage.EffectiveOutputTokens() != 7 {
+		t.Fatalf("output tokens = %d, want 7", collected.Usage.EffectiveOutputTokens())
+	}
+	if collected.Usage.CachedInputTokens != 3 {
+		t.Fatalf("cached input tokens = %d, want 3", collected.Usage.CachedInputTokens)
+	}
+	if collected.Usage.ReasoningTokens != 2 {
+		t.Fatalf("reasoning tokens = %d, want 2", collected.Usage.ReasoningTokens)
+	}
+	if collected.Usage.TotalTokens() != 25 {
+		t.Fatalf("total tokens = %d, want 25", collected.Usage.TotalTokens())
+	}
+}
+
 func TestCollectStreamWithOptionsEmitsTextAndUsageCallbacks(t *testing.T) {
 	events := make(chan StreamEvent)
 	go func() {

--- a/internal/zeroruntime/provider_test.go
+++ b/internal/zeroruntime/provider_test.go
@@ -2,6 +2,7 @@ package zeroruntime
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -59,6 +60,88 @@ func TestStreamEventNamesMatchProviderContract(t *testing.T) {
 	}
 }
 
+func TestAgentEventNamesMatchPRDContract(t *testing.T) {
+	cases := map[AgentEventType]string{
+		AgentEventText:       "text",
+		AgentEventToolCall:   "tool_call",
+		AgentEventToolResult: "tool_result",
+		AgentEventThinking:   "thinking",
+		AgentEventUsage:      "usage",
+		AgentEventPlanUpdate: "plan_update",
+		AgentEventError:      "error",
+		AgentEventTurnEnd:    "turn_end",
+	}
+
+	for eventType, want := range cases {
+		if string(eventType) != want {
+			t.Fatalf("event type %s = %q, want %q", eventType, string(eventType), want)
+		}
+	}
+}
+
+func TestNormalizeUsageMapsProviderAliasesAndReasoningTokens(t *testing.T) {
+	usage, err := NormalizeUsage(TokenUsage{
+		PromptTokens:      100,
+		CachedInputTokens: 25,
+		CompletionTokens:  40,
+		ReasoningTokens:   10,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeUsage returned error: %v", err)
+	}
+
+	if usage.EffectiveInputTokens() != 100 {
+		t.Fatalf("input tokens = %d, want 100", usage.EffectiveInputTokens())
+	}
+	if usage.EffectiveOutputTokens() != 40 {
+		t.Fatalf("output tokens = %d, want 40", usage.EffectiveOutputTokens())
+	}
+	if usage.CachedInputTokens != 25 {
+		t.Fatalf("cached input tokens = %d, want 25", usage.CachedInputTokens)
+	}
+	if usage.ReasoningTokens != 10 {
+		t.Fatalf("reasoning tokens = %d, want 10", usage.ReasoningTokens)
+	}
+	if usage.TotalTokens() != 150 {
+		t.Fatalf("total tokens = %d, want 150", usage.TotalTokens())
+	}
+	if usage.BillableOutputTokens() != 50 {
+		t.Fatalf("billable output tokens = %d, want 50", usage.BillableOutputTokens())
+	}
+}
+
+func TestNormalizeUsageClampsCachedInputTokens(t *testing.T) {
+	usage, err := NormalizeUsage(TokenUsage{
+		InputTokens:       5,
+		CachedInputTokens: 12,
+		OutputTokens:      3,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeUsage returned error: %v", err)
+	}
+	if usage.CachedInputTokens != 5 {
+		t.Fatalf("cached input tokens = %d, want 5", usage.CachedInputTokens)
+	}
+}
+
+func TestNormalizeUsageRejectsNegativeTokenCounts(t *testing.T) {
+	_, err := NormalizeUsage(TokenUsage{OutputTokens: -1})
+	if err == nil {
+		t.Fatal("expected negative output token validation error")
+	}
+	if !strings.Contains(err.Error(), "output tokens") {
+		t.Fatalf("error = %q, want output tokens", err.Error())
+	}
+
+	_, err = NormalizeUsage(TokenUsage{InputTokens: 1, PromptTokens: -1})
+	if err == nil {
+		t.Fatal("expected negative prompt token alias validation error")
+	}
+	if !strings.Contains(err.Error(), "input tokens alias") {
+		t.Fatalf("error = %q, want input tokens alias", err.Error())
+	}
+}
+
 func TestCollectStreamAccumulatesTextToolCallsAndUsage(t *testing.T) {
 	events := make(chan StreamEvent)
 	go func() {
@@ -87,6 +170,35 @@ func TestCollectStreamAccumulatesTextToolCallsAndUsage(t *testing.T) {
 	}
 	if collected.Usage.PromptTokens != 12 || collected.Usage.CompletionTokens != 8 || collected.Usage.CachedInputTokens != 3 {
 		t.Fatalf("unexpected usage: %#v", collected.Usage)
+	}
+	if collected.Usage.TotalTokens() != 20 {
+		t.Fatalf("total tokens = %d, want 20", collected.Usage.TotalTokens())
+	}
+}
+
+func TestCollectStreamAccumulatesNormalizedUsageAliases(t *testing.T) {
+	usage, err := NormalizeUsage(TokenUsage{InputTokens: 12, OutputTokens: 5, ReasoningTokens: 3})
+	if err != nil {
+		t.Fatalf("NormalizeUsage returned error: %v", err)
+	}
+
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		events <- StreamEvent{Type: StreamEventUsage, Usage: usage}
+		events <- StreamEvent{Type: StreamEventDone}
+	}()
+
+	collected := CollectStream(context.Background(), events)
+
+	if collected.Usage.EffectiveInputTokens() != 12 {
+		t.Fatalf("input tokens = %d, want 12", collected.Usage.EffectiveInputTokens())
+	}
+	if collected.Usage.EffectiveOutputTokens() != 5 {
+		t.Fatalf("output tokens = %d, want 5", collected.Usage.EffectiveOutputTokens())
+	}
+	if collected.Usage.ReasoningTokens != 3 {
+		t.Fatalf("reasoning tokens = %d, want 3", collected.Usage.ReasoningTokens)
 	}
 	if collected.Usage.TotalTokens() != 20 {
 		t.Fatalf("total tokens = %d, want 20", collected.Usage.TotalTokens())

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -8,11 +8,26 @@ type MessageRole string
 // StreamEventType identifies one event in a provider completion stream.
 type StreamEventType string
 
+// AgentEventType is the stable PRD-level event stream shared by TUI,
+// headless output, sessions, and future editor integrations.
+type AgentEventType string
+
 const (
 	MessageRoleSystem    MessageRole = "system"
 	MessageRoleUser      MessageRole = "user"
 	MessageRoleAssistant MessageRole = "assistant"
 	MessageRoleTool      MessageRole = "tool"
+)
+
+const (
+	AgentEventText       AgentEventType = "text"
+	AgentEventToolCall   AgentEventType = "tool_call"
+	AgentEventToolResult AgentEventType = "tool_result"
+	AgentEventThinking   AgentEventType = "thinking"
+	AgentEventUsage      AgentEventType = "usage"
+	AgentEventPlanUpdate AgentEventType = "plan_update"
+	AgentEventError      AgentEventType = "error"
+	AgentEventTurnEnd    AgentEventType = "turn_end"
 )
 
 const (
@@ -47,16 +62,47 @@ type ToolDefinition struct {
 	Parameters  map[string]any
 }
 
+// TokenUsage accepts provider-specific token aliases before normalization.
+type TokenUsage struct {
+	InputTokens       int
+	PromptTokens      int
+	CachedInputTokens int
+	OutputTokens      int
+	CompletionTokens  int
+	ReasoningTokens   int
+}
+
 // Usage records normalized token accounting reported by a provider.
 type Usage struct {
+	InputTokens       int
+	OutputTokens      int
 	PromptTokens      int
 	CompletionTokens  int
 	CachedInputTokens int
+	ReasoningTokens   int
 }
 
 // TotalTokens returns prompt plus completion tokens.
 func (usage Usage) TotalTokens() int {
-	return usage.PromptTokens + usage.CompletionTokens
+	return usage.EffectiveInputTokens() + usage.EffectiveOutputTokens() + usage.ReasoningTokens
+}
+
+func (usage Usage) EffectiveInputTokens() int {
+	if usage.InputTokens != 0 {
+		return usage.InputTokens
+	}
+	return usage.PromptTokens
+}
+
+func (usage Usage) EffectiveOutputTokens() int {
+	if usage.OutputTokens != 0 {
+		return usage.OutputTokens
+	}
+	return usage.CompletionTokens
+}
+
+func (usage Usage) BillableOutputTokens() int {
+	return usage.EffectiveOutputTokens() + usage.ReasoningTokens
 }
 
 // StreamEvent is one normalized event emitted by a streaming provider.

--- a/internal/zeroruntime/usage.go
+++ b/internal/zeroruntime/usage.go
@@ -1,0 +1,58 @@
+package zeroruntime
+
+import "fmt"
+
+// NormalizeUsage converts provider token aliases into the shared runtime shape.
+func NormalizeUsage(input TokenUsage) (Usage, error) {
+	inputTokens, err := providerAlias(input.InputTokens, input.PromptTokens, "input tokens")
+	if err != nil {
+		return Usage{}, err
+	}
+
+	outputTokens, err := providerAlias(input.OutputTokens, input.CompletionTokens, "output tokens")
+	if err != nil {
+		return Usage{}, err
+	}
+
+	cachedInputTokens, err := nonNegative(input.CachedInputTokens, "cached input tokens")
+	if err != nil {
+		return Usage{}, err
+	}
+	if cachedInputTokens > inputTokens {
+		cachedInputTokens = inputTokens
+	}
+
+	reasoningTokens, err := nonNegative(input.ReasoningTokens, "reasoning tokens")
+	if err != nil {
+		return Usage{}, err
+	}
+
+	return Usage{
+		InputTokens:       inputTokens,
+		OutputTokens:      outputTokens,
+		PromptTokens:      inputTokens,
+		CompletionTokens:  outputTokens,
+		CachedInputTokens: cachedInputTokens,
+		ReasoningTokens:   reasoningTokens,
+	}, nil
+}
+
+func providerAlias(primary int, alias int, label string) (int, error) {
+	if _, err := nonNegative(primary, label); err != nil {
+		return 0, err
+	}
+	if _, err := nonNegative(alias, label+" alias"); err != nil {
+		return 0, err
+	}
+	if primary != 0 {
+		return primary, nil
+	}
+	return alias, nil
+}
+
+func nonNegative(value int, label string) (int, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", label)
+	}
+	return value, nil
+}


### PR DESCRIPTION
## Summary
- add Go runtime event and usage contracts, including provider token alias normalization and reasoning-token accounting
- add the first Go model registry contract with provider/status/capability/reasoning validation and case-insensitive alias lookup
- add config contract gap reporting for provider startup, runtime policy, and sandbox fields

## Commits
- feat: add Go runtime usage contracts
- feat: add Go model registry contracts
- feat: add Go config contract gaps

## Validation
- go test ./...
- bun run test
- bun run typecheck
- bun run build
- bun run smoke:build
- bun run build:go
- bun run smoke:go
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model registry to manage models across providers with capability, status, validation, and lookup support.
  * Introduced runtime configuration contract-gap tracking for required settings by milestone.
  * Expanded agent event types and enhanced token accounting: provider-specific aliases, reasoning tokens, cached-token handling, and effective/billable input/output calculations.

* **Tests**
  * Added comprehensive tests for model validation and registry behavior, usage normalization, event names, and token-aggregation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->