### PR TITLE
feat: advance Go-first TUI and npm wrapper

### DIFF
--- a/bin/zero.ts
+++ b/bin/zero.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bun
+
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runNpmWrapper } from '../src/npm-wrapper';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+process.exitCode = await runNpmWrapper({ root: packageRoot });

--- a/docs/NPM_WRAPPER_SMOKE.md
+++ b/docs/NPM_WRAPPER_SMOKE.md
@@ -1,8 +1,8 @@
 # npm Wrapper Smoke Checklist
 
 Run this checklist when a PR changes npm distribution files such as
-`package.json`, `bun.lock`, `index.ts`, build scripts, package release scripts,
-or the npm `bin` wrapper.
+`package.json`, `bun.lock`, `bin/zero.ts`, `src/npm-wrapper.ts`, build scripts,
+package release scripts, or the npm `bin` wrapper.
 
 ## Required Checks
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -195,6 +195,7 @@ Runs a one-shot prompt through the Go agent runtime.
 Flags:
   -f, --file <path>                  Read prompt text from a file
   -m, --model <model>                Select the model for provider setup
+      --max-turns <number>           Override the maximum agent loop turns
   -C, --cwd <path>                   Set the workspace directory
   -o, --output-format text|json      Select text or newline-delimited JSON output
       --prompt <prompt>              Provide prompt text as a flag

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -239,8 +239,8 @@ func parseExecMaxTurns(value string) (int, error) {
 		return 0, execUsageError{"--max-turns requires a value"}
 	}
 	maxTurns, err := strconv.Atoi(trimmed)
-	if err != nil || maxTurns < 0 {
-		return 0, execUsageError{fmt.Sprintf("invalid --max-turns %q. Expected a non-negative integer.", value)}
+	if err != nil || maxTurns <= 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid --max-turns %q. Expected a positive integer.", value)}
 	}
 	return maxTurns, nil
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/agent"
@@ -31,6 +32,7 @@ type execOptions struct {
 	promptParts           []string
 	file                  string
 	model                 string
+	maxTurns              int
 	cwd                   string
 	outputFormat          execOutputFormat
 	skipPermissionsUnsafe bool
@@ -69,6 +71,9 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	overrides := config.Overrides{}
 	if options.model != "" {
 		overrides.Provider.Model = options.model
+	}
+	if options.maxTurns > 0 {
+		overrides.MaxTurns = options.maxTurns
 	}
 	resolved, err := deps.resolveConfig(workspaceRoot, overrides)
 	if err != nil {
@@ -160,6 +165,23 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--model="):
 			options.model = strings.TrimSpace(strings.TrimPrefix(arg, "--model="))
+		case arg == "--max-turns":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			maxTurns, err := parseExecMaxTurns(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.maxTurns = maxTurns
+			index = next
+		case strings.HasPrefix(arg, "--max-turns="):
+			maxTurns, err := parseExecMaxTurns(strings.TrimSpace(strings.TrimPrefix(arg, "--max-turns=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.maxTurns = maxTurns
 		case arg == "-C" || arg == "--cwd":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -209,6 +231,18 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 		return options, false, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
 	}
 	return options, false, nil
+}
+
+func parseExecMaxTurns(value string) (int, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, execUsageError{"--max-turns requires a value"}
+	}
+	maxTurns, err := strconv.Atoi(trimmed)
+	if err != nil || maxTurns < 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid --max-turns %q. Expected a non-negative integer.", value)}
+	}
+	return maxTurns, nil
 }
 
 func nextFlagValue(args []string, index int, flag string) (string, int, error) {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -35,6 +35,7 @@ func TestRunExecHelpDocumentsM1Flags(t *testing.T) {
 			for _, want := range []string{
 				"-f, --file",
 				"-m, --model",
+				"--max-turns",
 				"-C, --cwd",
 				"-o, --output-format text|json",
 				"--prompt",
@@ -48,6 +49,57 @@ func TestRunExecHelpDocumentsM1Flags(t *testing.T) {
 				t.Fatalf("expected empty stderr, got %q", stderr.String())
 			}
 		})
+	}
+}
+
+func TestRunExecRejectsInvalidMaxTurnsBeforeRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  string
+	}{
+		{value: "nope", want: "invalid --max-turns"},
+		{value: "-1", want: "invalid --max-turns"},
+	} {
+		t.Run(tc.value, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			exitCode := Run([]string{"exec", "--max-turns", tc.value, "hello"}, &stdout, &stderr)
+
+			if exitCode != exitUsage {
+				t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout before runtime, got %q", stdout.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, tc.want) {
+				t.Fatalf("expected max-turns validation error containing %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRunExecMaxTurnsReachesConfigOverrides(t *testing.T) {
+	cwd := t.TempDir()
+	var gotMaxTurns int
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--max-turns", "7", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			gotMaxTurns = overrides.MaxTurns
+			return config.ResolvedConfig{}, errors.New("stop before provider")
+		},
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d", exitProvider, exitCode)
+	}
+	if gotMaxTurns != 7 {
+		t.Fatalf("overrides.MaxTurns = %d, want 7", gotMaxTurns)
 	}
 }
 

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -59,6 +59,7 @@ func TestRunExecRejectsInvalidMaxTurnsBeforeRuntime(t *testing.T) {
 	}{
 		{value: "nope", want: "invalid --max-turns"},
 		{value: "-1", want: "invalid --max-turns"},
+		{value: "0", want: "invalid --max-turns"},
 	} {
 		t.Run(tc.value, func(t *testing.T) {
 			var stdout bytes.Buffer
@@ -77,6 +78,23 @@ func TestRunExecRejectsInvalidMaxTurnsBeforeRuntime(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("equals-empty", func(t *testing.T) {
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+
+		exitCode := Run([]string{"exec", "--max-turns=", "hello"}, &stdout, &stderr)
+
+		if exitCode != exitUsage {
+			t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+		}
+		if stdout.Len() != 0 {
+			t.Fatalf("expected empty stdout before runtime, got %q", stdout.String())
+		}
+		if got := stderr.String(); !strings.Contains(got, "--max-turns requires a value") {
+			t.Fatalf("expected empty max-turns validation error, got %q", got)
+		}
+	})
 }
 
 func TestRunExecMaxTurnsReachesConfigOverrides(t *testing.T) {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -12,12 +12,152 @@ const (
 	commandExit
 	commandTools
 	commandPermissions
+	commandProvider
+	commandModel
+	commandContext
+	commandConfig
+	commandDebug
+	commandDoctor
+	commandPlan
+	commandSearch
+	commandTheme
+	commandInputStyle
 	commandUnknown
 )
+
+type commandGroup string
+
+const (
+	commandGroupSession commandGroup = "session"
+	commandGroupModel   commandGroup = "model"
+	commandGroupRuntime commandGroup = "runtime"
+	commandGroupTools   commandGroup = "tools"
+	commandGroupMeta    commandGroup = "meta"
+)
+
+type commandDefinition struct {
+	name        string
+	aliases     []string
+	usage       string
+	group       commandGroup
+	description string
+	kind        commandKind
+}
 
 type parsedCommand struct {
 	kind commandKind
 	text string
+	name string
+}
+
+var commandDefinitions = []commandDefinition{
+	{
+		name:        "/provider",
+		usage:       "/provider",
+		group:       commandGroupModel,
+		description: "Show the active provider.",
+		kind:        commandProvider,
+	},
+	{
+		name:        "/model",
+		usage:       "/model [list|id]",
+		group:       commandGroupModel,
+		description: "Show the active model and model-shell status.",
+		kind:        commandModel,
+	},
+	{
+		name:        "/plan",
+		usage:       "/plan",
+		group:       commandGroupSession,
+		description: "Show planning mode status.",
+		kind:        commandPlan,
+	},
+	{
+		name:        "/permissions",
+		usage:       "/permissions",
+		group:       commandGroupRuntime,
+		description: "Show the active permission mode.",
+		kind:        commandPermissions,
+	},
+	{
+		name:        "/tools",
+		usage:       "/tools",
+		group:       commandGroupTools,
+		description: "List registered tools.",
+		kind:        commandTools,
+	},
+	{
+		name:        "/context",
+		usage:       "/context",
+		group:       commandGroupSession,
+		description: "Show current workspace and runtime context.",
+		kind:        commandContext,
+	},
+	{
+		name:        "/clear",
+		usage:       "/clear",
+		group:       commandGroupMeta,
+		description: "Clear the visible transcript.",
+		kind:        commandClear,
+	},
+	{
+		name:        "/search",
+		usage:       "/search",
+		group:       commandGroupSession,
+		description: "Show code search shell status.",
+		kind:        commandSearch,
+	},
+	{
+		name:        "/doctor",
+		usage:       "/doctor",
+		group:       commandGroupRuntime,
+		description: "Show local diagnostics shell status.",
+		kind:        commandDoctor,
+	},
+	{
+		name:        "/config",
+		usage:       "/config",
+		group:       commandGroupRuntime,
+		description: "Show active configuration summary.",
+		kind:        commandConfig,
+	},
+	{
+		name:        "/debug",
+		aliases:     []string{"/debug-mode"},
+		usage:       "/debug",
+		group:       commandGroupRuntime,
+		description: "Show debug mode status.",
+		kind:        commandDebug,
+	},
+	{
+		name:        "/theme",
+		usage:       "/theme",
+		group:       commandGroupSession,
+		description: "Show theme shell status.",
+		kind:        commandTheme,
+	},
+	{
+		name:        "/input-style",
+		usage:       "/input-style",
+		group:       commandGroupSession,
+		description: "Show input style shell status.",
+		kind:        commandInputStyle,
+	},
+	{
+		name:        "/help",
+		usage:       "/help",
+		group:       commandGroupMeta,
+		description: "Show available commands.",
+		kind:        commandHelp,
+	},
+	{
+		name:        "/exit",
+		aliases:     []string{"/quit"},
+		usage:       "/exit",
+		group:       commandGroupMeta,
+		description: "Exit Zero.",
+		kind:        commandExit,
+	},
 }
 
 func parseCommand(input string) parsedCommand {
@@ -26,22 +166,61 @@ func parseCommand(input string) parsedCommand {
 		return parsedCommand{kind: commandEmpty}
 	}
 
-	switch trimmed {
-	case "/help":
-		return parsedCommand{kind: commandHelp}
-	case "/clear":
-		return parsedCommand{kind: commandClear}
-	case "/exit":
-		return parsedCommand{kind: commandExit}
-	case "/tools":
-		return parsedCommand{kind: commandTools}
-	case "/permissions":
-		return parsedCommand{kind: commandPermissions}
-	}
-
 	if strings.HasPrefix(trimmed, "/") {
+		name, args := splitCommand(trimmed)
+		command, ok := resolveCommand(name)
+		if ok {
+			return parsedCommand{kind: command.kind, name: command.name, text: args}
+		}
 		return parsedCommand{kind: commandUnknown, text: trimmed}
 	}
 
 	return parsedCommand{kind: commandPrompt, text: trimmed}
+}
+
+func splitCommand(input string) (string, string) {
+	parts := strings.Fields(input)
+	if len(parts) == 0 {
+		return "", ""
+	}
+
+	name := parts[0]
+	args := strings.TrimSpace(input[len(name):])
+	return strings.ToLower(name), args
+}
+
+func resolveCommand(name string) (commandDefinition, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	for _, command := range commandDefinitions {
+		if normalized == command.name {
+			return command, true
+		}
+		for _, alias := range command.aliases {
+			if normalized == alias {
+				return command, true
+			}
+		}
+	}
+	return commandDefinition{}, false
+}
+
+func listCommandNames() []string {
+	names := make([]string, 0, len(commandDefinitions))
+	for _, command := range commandDefinitions {
+		names = append(names, command.name)
+		names = append(names, command.aliases...)
+	}
+	return names
+}
+
+func formatCommandHelpLines() []string {
+	lines := make([]string, 0, len(commandDefinitions))
+	for _, command := range commandDefinitions {
+		label := command.usage
+		if len(command.aliases) > 0 {
+			label += " (" + strings.Join(command.aliases, ", ") + ")"
+		}
+		lines = append(lines, label+" - "+command.description)
+	}
+	return lines
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -384,8 +384,45 @@ func helpText() string {
 	return "Commands:\n" + strings.Join(formatCommandHelpLines(), "\n") + "\nSubmit text to ask the assistant."
 }
 
+const defaultCommandFooterText = "/help  /model  /provider  /context  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
+
 func commandFooterText() string {
-	return "/help  /model  /provider  /context  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
+	return formatCommandFooterText(commandDefinitions)
+}
+
+func formatCommandFooterText(commands []commandDefinition) string {
+	if len(commands) == 0 {
+		return defaultCommandFooterText
+	}
+
+	namesByKind := make(map[commandKind]string, len(commands))
+	for _, command := range commands {
+		namesByKind[command.kind] = command.name
+	}
+
+	featured := []commandKind{
+		commandHelp,
+		commandModel,
+		commandProvider,
+		commandContext,
+		commandTools,
+		commandPermissions,
+		commandClear,
+		commandExit,
+	}
+	parts := make([]string, 0, len(featured)+2)
+	for _, kind := range featured {
+		name := namesByKind[kind]
+		if name != "" {
+			parts = append(parts, name)
+		}
+	}
+	if len(parts) == 0 {
+		return defaultCommandFooterText
+	}
+
+	parts = append(parts, "Esc clear", "Ctrl+C quit")
+	return strings.Join(parts, "  ")
 }
 
 func renderRow(row transcriptRow) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -200,7 +200,10 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	case commandDebug:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.debugText()})
 		return m, nil
-	case commandDoctor, commandPlan, commandSearch, commandTheme, commandInputStyle:
+	case commandPlan:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.planText()})
+		return m, nil
+	case commandDoctor, commandSearch, commandTheme, commandInputStyle:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
 			kind: actionAppendSystem,
 			text: shellOnlyCommandText(command.name),
@@ -323,6 +326,11 @@ func (m model) providerText() string {
 }
 
 func (m model) modelText(args string) string {
+	switch strings.ToLower(strings.TrimSpace(args)) {
+	case "list", "ls":
+		return m.modelListText()
+	}
+
 	lines := []string{
 		"Model",
 		"Active model: " + displayValue(m.modelName, "none"),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -155,7 +155,7 @@ func (m model) View() string {
 	builder.WriteString("\n")
 	builder.WriteString(m.input.View())
 	builder.WriteString("\n\n")
-	builder.WriteString(footerStyle.Render("/help  /clear  /exit  /tools  /permissions  Esc clear  Ctrl+C quit"))
+	builder.WriteString(footerStyle.Render(commandFooterText()))
 
 	return builder.String()
 }
@@ -184,6 +184,27 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		return m, nil
 	case commandPermissions:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.permissionsText()})
+		return m, nil
+	case commandProvider:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.providerText()})
+		return m, nil
+	case commandModel:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.modelText(command.text)})
+		return m, nil
+	case commandContext:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.contextText()})
+		return m, nil
+	case commandConfig:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.configText()})
+		return m, nil
+	case commandDebug:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.debugText()})
+		return m, nil
+	case commandDoctor, commandPlan, commandSearch, commandTheme, commandInputStyle:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendSystem,
+			text: shellOnlyCommandText(command.name),
+		})
 		return m, nil
 	case commandUnknown:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
@@ -293,8 +314,78 @@ func (m model) permissionsText() string {
 	return "Permission mode: " + string(m.permissionMode)
 }
 
+func (m model) providerText() string {
+	return strings.Join([]string{
+		"Provider",
+		"provider: " + displayValue(m.providerName, "none"),
+		"model: " + displayValue(m.modelName, "none"),
+	}, "\n")
+}
+
+func (m model) modelText(args string) string {
+	lines := []string{
+		"Model",
+		"Active model: " + displayValue(m.modelName, "none"),
+		"provider: " + displayValue(m.providerName, "none"),
+	}
+	if args != "" {
+		lines = append(lines, "Model switching is not wired in Go TUI yet.")
+	} else {
+		lines = append(lines, "Use /model list to inspect the current model shell.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m model) contextText() string {
+	return strings.Join([]string{
+		"Context",
+		"cwd: " + displayValue(m.cwd, "unknown"),
+		"provider: " + displayValue(m.providerName, "none"),
+		"model: " + displayValue(m.modelName, "none"),
+		"permission mode: " + string(m.permissionMode),
+		fmt.Sprintf("tools: %d", len(m.registry.All())),
+	}, "\n")
+}
+
+func (m model) configText() string {
+	return strings.Join([]string{
+		"Config",
+		"provider: " + displayValue(m.providerName, "none"),
+		"model: " + displayValue(m.modelName, "none"),
+		"permission mode: " + string(m.permissionMode),
+	}, "\n")
+}
+
+func (m model) debugText() string {
+	state := "idle"
+	if m.pending {
+		state = "running"
+	}
+	return strings.Join([]string{
+		"Debug",
+		"run state: " + state,
+		"active run: " + fmt.Sprint(m.activeRunID),
+		"Debug mode is not wired in Go TUI yet.",
+	}, "\n")
+}
+
+func displayValue(value string, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func shellOnlyCommandText(name string) string {
+	return fmt.Sprintf("%s is registered in the Go TUI shell but is not wired yet.", name)
+}
+
 func helpText() string {
-	return "Commands: /help, /clear, /exit, /tools, /permissions. Submit text to ask the assistant."
+	return "Commands:\n" + strings.Join(formatCommandHelpLines(), "\n") + "\nSubmit text to ask the assistant."
+}
+
+func commandFooterText() string {
+	return "/help  /model  /provider  /context  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
 }
 
 func renderRow(row transcriptRow) string {

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -1,0 +1,42 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+)
+
+func (m model) modelListText() string {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return "Models\nFailed to load model catalog: " + err.Error()
+	}
+
+	activeID := activeModelID(registry, m.modelName)
+	lines := []string{
+		"Models",
+		"Active model: " + displayValue(m.modelName, "none"),
+		"provider: " + displayValue(m.providerName, "none"),
+		"Available models:",
+	}
+	for _, model := range registry.List(modelregistry.ListOptions{}) {
+		marker := " "
+		if activeID != "" && model.ID == activeID {
+			marker = "*"
+		}
+		lines = append(lines, fmt.Sprintf("%s %s (%s) - %s", marker, model.ID, model.Provider, model.DisplayName))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func activeModelID(registry modelregistry.Registry, modelName string) string {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		return ""
+	}
+	if model, ok := registry.Get(modelName); ok {
+		return model.ID
+	}
+	return strings.ToLower(modelName)
+}

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
@@ -20,7 +21,14 @@ func (m model) modelListText() string {
 		"provider: " + displayValue(m.providerName, "none"),
 		"Available models:",
 	}
-	for _, model := range registry.List(modelregistry.ListOptions{}) {
+	models := registry.List(modelregistry.ListOptions{})
+	sort.SliceStable(models, func(i, j int) bool {
+		if models[i].Provider == models[j].Provider {
+			return models[i].ID < models[j].ID
+		}
+		return models[i].Provider < models[j].Provider
+	})
+	for _, model := range models {
 		marker := " "
 		if activeID != "" && model.ID == activeID {
 			marker = "*"

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -276,10 +276,13 @@ func TestModelCommandShowsActiveModelWithoutRunningAgent(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /model to be handled without starting an agent run")
 	}
-	for _, want := range []string{"Active model: gpt-4.1", "provider: openai", "Available models", "* gpt-4.1", "claude-sonnet-4.5", "gemini-2.5-pro"} {
+	for _, want := range []string{"Active model: gpt-4.1", "provider: openai", "Available models", "* gpt-4.1"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected model transcript to contain %q, got %#v", want, next.transcript)
 		}
+	}
+	if !transcriptHasMarkedModelEntry(next.transcript) {
+		t.Fatalf("expected model transcript to contain a marked model entry, got %#v", next.transcript)
 	}
 	if transcriptContains(next.transcript, "Model switching") {
 		t.Fatalf("expected /model list to show catalog, got switching placeholder: %#v", next.transcript)
@@ -430,6 +433,17 @@ func transcriptContains(rows []transcriptRow, want string) bool {
 	for _, row := range rows {
 		if strings.Contains(row.text, want) {
 			return true
+		}
+	}
+	return false
+}
+
+func transcriptHasMarkedModelEntry(rows []transcriptRow) bool {
+	for _, row := range rows {
+		for _, line := range strings.Split(row.text, "\n") {
+			if strings.HasPrefix(line, "* ") && strings.Contains(line, " (") {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -39,8 +39,13 @@ func TestParseCommand(t *testing.T) {
 		{input: "/help", kind: commandHelp},
 		{input: "/clear", kind: commandClear},
 		{input: "/exit", kind: commandExit},
+		{input: "/quit", kind: commandExit},
 		{input: "/tools", kind: commandTools},
 		{input: "/permissions", kind: commandPermissions},
+		{input: "/context", kind: commandContext},
+		{input: "/model", kind: commandModel},
+		{input: "/model list", kind: commandModel, text: "list"},
+		{input: "/debug-mode", kind: commandDebug},
 		{input: "hello zero", kind: commandPrompt, text: "hello zero"},
 	}
 
@@ -51,6 +56,25 @@ func TestParseCommand(t *testing.T) {
 				t.Fatalf("expected kind=%v text=%q, got kind=%v text=%q", tc.kind, tc.text, command.kind, command.text)
 			}
 		})
+	}
+}
+
+func TestCommandRegistryResolvesAliasesAndFormatsHelp(t *testing.T) {
+	names := listCommandNames()
+	for _, name := range []string{"/help", "/model", "/provider", "/context", "/debug-mode", "/quit"} {
+		if !stringSliceContains(names, name) {
+			t.Fatalf("expected command names to contain %s, got %#v", name, names)
+		}
+	}
+
+	resolved, ok := resolveCommand("/quit")
+	if !ok || resolved.kind != commandExit {
+		t.Fatalf("expected /quit to resolve to exit, got ok=%v command=%#v", ok, resolved)
+	}
+
+	help := strings.Join(formatCommandHelpLines(), "\n")
+	for _, want := range []string{"/model", "/context", "/debug", "/permissions", "model"} {
+		assertContains(t, help, want)
 	}
 }
 
@@ -105,6 +129,9 @@ func TestHelpCommandAppendsHelpRow(t *testing.T) {
 	if !transcriptContains(next.transcript, "/tools") {
 		t.Fatalf("expected help transcript to mention /tools, got %#v", next.transcript)
 	}
+	if !transcriptContains(next.transcript, "/model") || !transcriptContains(next.transcript, "/context") {
+		t.Fatalf("expected help transcript to mention model and context commands, got %#v", next.transcript)
+	}
 }
 
 func TestClearCommandResetsTranscript(t *testing.T) {
@@ -131,6 +158,58 @@ func TestToolsCommandListsRegisteredTools(t *testing.T) {
 
 	if !transcriptContains(next.transcript, "read_file") {
 		t.Fatalf("expected tools transcript to list read_file, got %#v", next.transcript)
+	}
+}
+
+func TestContextCommandShowsSessionState(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool("."))
+	m := newModel(context.Background(), Options{
+		Cwd:            `D:\codings\Opensource\Zero`,
+		ProviderName:   "openai",
+		ModelName:      "gpt-4.1",
+		Registry:       registry,
+		PermissionMode: agent.PermissionModeAsk,
+	})
+	m.input.SetValue("/context")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /context to be handled without starting an agent run")
+	}
+	for _, want := range []string{
+		`D:\codings\Opensource\Zero`,
+		"provider: openai",
+		"model: gpt-4.1",
+		"permission mode: ask",
+		"tools: 1",
+	} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected context transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
+func TestModelCommandShowsActiveModelWithoutRunningAgent(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     &fakeProvider{},
+	})
+	m.input.SetValue("/model list")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /model to be handled without starting an agent run")
+	}
+	for _, want := range []string{"Active model: gpt-4.1", "provider: openai", "Model switching"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected model transcript to contain %q, got %#v", want, next.transcript)
+		}
 	}
 }
 
@@ -256,6 +335,15 @@ func assertContains(t *testing.T, text string, want string) {
 func transcriptContains(rows []transcriptRow, want string) bool {
 	for _, row := range rows {
 		if strings.Contains(row.text, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
 			return true
 		}
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -119,6 +119,26 @@ func TestInitialRenderContainsHeaderInputAndFooter(t *testing.T) {
 	assertContains(t, view, "Ctrl+C")
 }
 
+func TestCommandFooterTextUsesRegistryEntries(t *testing.T) {
+	footer := commandFooterText()
+
+	for _, command := range []string{"/help", "/model", "/provider", "/context", "/tools", "/permissions", "/clear", "/exit"} {
+		assertContains(t, footer, command)
+	}
+	assertContains(t, footer, "Esc clear")
+	assertContains(t, footer, "Ctrl+C quit")
+}
+
+func TestCommandFooterTextFallsBackWhenRegistryIsEmpty(t *testing.T) {
+	footer := formatCommandFooterText(nil)
+
+	for _, command := range []string{"/help", "/model", "/provider", "/context", "/tools", "/permissions", "/clear", "/exit"} {
+		assertContains(t, footer, command)
+	}
+	assertContains(t, footer, "Esc clear")
+	assertContains(t, footer, "Ctrl+C quit")
+}
+
 func TestHelpCommandAppendsHelpRow(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.input.SetValue("/help")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -181,6 +181,56 @@ func TestToolsCommandListsRegisteredTools(t *testing.T) {
 	}
 }
 
+func TestPlanCommandShowsCurrentPlan(t *testing.T) {
+	registry := tools.NewRegistry()
+	planTool := tools.NewUpdatePlanTool()
+	result := planTool.Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{
+				"id":      "one",
+				"content": "Wire model catalog",
+				"status":  "completed",
+			},
+			map[string]any{
+				"id":      "two",
+				"content": "Add max turns",
+				"status":  "in_progress",
+				"notes":   "Go exec parity",
+			},
+		},
+	})
+	if result.Status != tools.StatusOK {
+		t.Fatalf("update_plan setup failed: %#v", result)
+	}
+	registry.Register(planTool)
+	m := newModel(context.Background(), Options{Registry: registry})
+	m.input.SetValue("/plan")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /plan to be handled without starting an agent run")
+	}
+	for _, want := range []string{"Current Plan", "Wire model catalog", "Add max turns", "in_progress", "Go exec parity"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected plan transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
+func TestPlanCommandHandlesMissingPlanTool(t *testing.T) {
+	m := newModel(context.Background(), Options{Registry: tools.NewRegistry()})
+	m.input.SetValue("/plan")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if !transcriptContains(next.transcript, "No plan is active") {
+		t.Fatalf("expected missing plan message, got %#v", next.transcript)
+	}
+}
+
 func TestContextCommandShowsSessionState(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewReadFileTool("."))
@@ -226,7 +276,31 @@ func TestModelCommandShowsActiveModelWithoutRunningAgent(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /model to be handled without starting an agent run")
 	}
-	for _, want := range []string{"Active model: gpt-4.1", "provider: openai", "Model switching"} {
+	for _, want := range []string{"Active model: gpt-4.1", "provider: openai", "Available models", "* gpt-4.1", "claude-sonnet-4.5", "gemini-2.5-pro"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected model transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	if transcriptContains(next.transcript, "Model switching") {
+		t.Fatalf("expected /model list to show catalog, got switching placeholder: %#v", next.transcript)
+	}
+}
+
+func TestModelCommandKeepsSwitchingStatusExplicit(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     &fakeProvider{},
+	})
+	m.input.SetValue("/model gpt-4.1-mini")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /model to be handled without starting an agent run")
+	}
+	for _, want := range []string{"Active model: gpt-4.1", "provider: openai", "Model switching is not wired"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected model transcript to contain %q, got %#v", want, next.transcript)
 		}

--- a/internal/tui/plan_command.go
+++ b/internal/tui/plan_command.go
@@ -1,0 +1,40 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type currentPlanReader interface {
+	CurrentPlan() []tools.PlanItem
+}
+
+func (m model) planText() string {
+	tool, ok := m.registry.Get("update_plan")
+	if !ok {
+		return "No plan is active."
+	}
+
+	reader, ok := tool.(currentPlanReader)
+	if !ok {
+		return "No plan is active."
+	}
+
+	plan := reader.CurrentPlan()
+	if len(plan) == 0 {
+		return "No plan is active."
+	}
+
+	lines := make([]string, 0, len(plan)+1)
+	lines = append(lines, "Current Plan")
+	for index, item := range plan {
+		line := fmt.Sprintf("%d. [%s] %s", index+1, item.Status, item.Content)
+		if item.Notes != "" {
+			line += "\n   Notes: " + item.Notes
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "zero",
   "version": "0.1.0",
   "packageManager": "bun@1.3.14",
-  "module": "src/index.ts",
+  "module": "bin/zero.ts",
   "type": "module",
   "bin": {
-    "zero": "src/index.ts"
+    "zero": "bin/zero.ts"
   },
   "scripts": {
     "dev": "bun run src/index.ts",

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -54,6 +54,10 @@ await $`bun run smoke:build`;
 await cp(zeroArtifactPath, stagedBinaryPath);
 await cp('README.md', join(stagingDir, 'README.md'));
 await cp('package.json', join(stagingDir, 'package.json'));
+await mkdir(join(stagingDir, 'bin'), { recursive: true });
+await mkdir(join(stagingDir, 'src'), { recursive: true });
+await cp(join('bin', 'zero.ts'), join(stagingDir, 'bin', 'zero.ts'));
+await cp(join('src', 'npm-wrapper.ts'), join(stagingDir, 'src', 'npm-wrapper.ts'));
 await writeFile(join(stagingDir, 'VERSION'), `${version}\n`);
 
 if (process.platform === 'win32') {

--- a/src/npm-wrapper.ts
+++ b/src/npm-wrapper.ts
@@ -1,0 +1,73 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+type Exists = (path: string) => boolean;
+
+export interface NpmWrapperTarget {
+  kind: 'native' | 'typescript';
+  path: string;
+  command: string[];
+}
+
+export interface ResolveNpmWrapperTargetOptions {
+  root?: string;
+  platform?: NodeJS.Platform;
+  bunPath?: string;
+  args?: string[];
+  exists?: Exists;
+}
+
+export interface RunNpmWrapperOptions extends ResolveNpmWrapperTargetOptions {
+  stderr?: Pick<typeof process.stderr, 'write'>;
+}
+
+export function zeroBinaryName(platform: NodeJS.Platform = process.platform): string {
+  return platform === 'win32' ? 'zero.exe' : 'zero';
+}
+
+export function resolveNpmWrapperTarget(
+  options: ResolveNpmWrapperTargetOptions = {}
+): NpmWrapperTarget | null {
+  const root = options.root ?? process.cwd();
+  const args = options.args ?? process.argv.slice(2);
+  const exists = options.exists ?? existsSync;
+  const platform = options.platform ?? process.platform;
+  const bunPath = options.bunPath ?? process.execPath;
+  const nativePath = join(root, zeroBinaryName(platform));
+
+  if (exists(nativePath)) {
+    return {
+      kind: 'native',
+      path: nativePath,
+      command: [nativePath, ...args],
+    };
+  }
+
+  const tsPath = join(root, 'src', 'index.ts');
+  if (exists(tsPath)) {
+    return {
+      kind: 'typescript',
+      path: tsPath,
+      command: [bunPath, tsPath, ...args],
+    };
+  }
+
+  return null;
+}
+
+export async function runNpmWrapper(options: RunNpmWrapperOptions = {}): Promise<number> {
+  const target = resolveNpmWrapperTarget(options);
+  if (target == null) {
+    const stderr = options.stderr ?? process.stderr;
+    stderr.write('[zero] No native zero binary found. Run `bun run build` before using the npm wrapper.\n');
+    return 1;
+  }
+
+  const child = Bun.spawn(target.command, {
+    stdin: 'inherit',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+
+  return await child.exited;
+}

--- a/src/npm-wrapper.ts
+++ b/src/npm-wrapper.ts
@@ -18,7 +18,8 @@ export interface ResolveNpmWrapperTargetOptions {
 }
 
 export interface RunNpmWrapperOptions extends ResolveNpmWrapperTargetOptions {
-  stderr?: Pick<typeof process.stderr, 'write'>;
+  spawn?: typeof Bun.spawn;
+  stderr?: { write(chunk: string): unknown };
 }
 
 export function zeroBinaryName(platform: NodeJS.Platform = process.platform): string {
@@ -57,17 +58,24 @@ export function resolveNpmWrapperTarget(
 
 export async function runNpmWrapper(options: RunNpmWrapperOptions = {}): Promise<number> {
   const target = resolveNpmWrapperTarget(options);
+  const stderr = options.stderr ?? process.stderr;
   if (target == null) {
-    const stderr = options.stderr ?? process.stderr;
-    stderr.write('[zero] No native zero binary found. Run `bun run build` before using the npm wrapper.\n');
+    stderr.write('[zero] No runnable wrapper target found (native binary or src/index.ts). Run `bun run build` before using the npm wrapper.\n');
     return 1;
   }
 
-  const child = Bun.spawn(target.command, {
-    stdin: 'inherit',
-    stdout: 'inherit',
-    stderr: 'inherit',
-  });
+  try {
+    const spawn = options.spawn ?? Bun.spawn;
+    const child = spawn(target.command, {
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    });
 
-  return await child.exited;
+    return await child.exited;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(`[zero] Failed to launch wrapper target: ${message}\n`);
+    return 1;
+  }
 }

--- a/tests/build-scripts.test.ts
+++ b/tests/build-scripts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
-import { resolveNpmWrapperTarget } from '../src/npm-wrapper';
+import { resolveNpmWrapperTarget, runNpmWrapper } from '../src/npm-wrapper';
 import {
   getGoArch,
   getGoOS,
@@ -145,5 +145,46 @@ describe('npm wrapper entrypoint', () => {
       path: join(root, 'src', 'index.ts'),
       command: ['bun', join(root, 'src', 'index.ts'), '--version'],
     });
+  });
+
+  it('returns null when neither native nor TS fallback target exists', () => {
+    const target = resolveNpmWrapperTarget({
+      root: join('repo'),
+      platform: 'win32',
+      bunPath: 'bun',
+      args: ['--version'],
+      exists: () => false,
+    });
+
+    expect(target).toBeNull();
+  });
+
+  it('reports the full no-target state without crashing', async () => {
+    let stderr = '';
+    const code = await runNpmWrapper({
+      root: join('repo'),
+      platform: 'linux',
+      exists: () => false,
+      stderr: { write: (chunk: string) => { stderr += chunk; return true; } },
+    });
+
+    expect(code).toBe(1);
+    expect(stderr).toContain('No runnable wrapper target found');
+    expect(stderr).toContain('native binary or src/index.ts');
+  });
+
+  it('returns a clean exit code when launching the wrapper target throws', async () => {
+    let stderr = '';
+    const code = await runNpmWrapper({
+      root: join('repo'),
+      platform: 'linux',
+      exists: (path) => path === join('repo', 'zero'),
+      spawn: () => { throw new Error('spawn failed'); },
+      stderr: { write: (chunk: string) => { stderr += chunk; return true; } },
+    });
+
+    expect(code).toBe(1);
+    expect(stderr).toContain('Failed to launch wrapper target');
+    expect(stderr).toContain('spawn failed');
   });
 });

--- a/tests/build-scripts.test.ts
+++ b/tests/build-scripts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
+import { resolveNpmWrapperTarget } from '../src/npm-wrapper';
 import {
   getGoArch,
   getGoOS,
@@ -98,5 +99,51 @@ describe('Go binary build script', () => {
     expect(goBuildLdflags('0.1.0')).toContain(
       '-X github.com/Gitlawb/zero/internal/cli.version=0.1.0'
     );
+  });
+});
+
+describe('npm wrapper entrypoint', () => {
+  it('points installed zero commands at the wrapper instead of the TS app', async () => {
+    const pkg = await Bun.file('package.json').json() as { bin?: { zero?: string }; module?: string };
+
+    expect(pkg.bin?.zero).toBe('bin/zero.ts');
+    expect(pkg.module).toBe('bin/zero.ts');
+  });
+
+  it('prefers the Go binary and keeps the TS CLI as a local fallback', () => {
+    const root = join('repo');
+    const existing = new Set([
+      join(root, 'zero.exe'),
+      join(root, 'src', 'index.ts'),
+    ]);
+
+    const native = resolveNpmWrapperTarget({
+      root,
+      platform: 'win32',
+      bunPath: 'bun',
+      args: ['--version'],
+      exists: (path) => existing.has(path),
+    });
+
+    expect(native).toEqual({
+      kind: 'native',
+      path: join(root, 'zero.exe'),
+      command: [join(root, 'zero.exe'), '--version'],
+    });
+
+    existing.delete(join(root, 'zero.exe'));
+    const fallback = resolveNpmWrapperTarget({
+      root,
+      platform: 'win32',
+      bunPath: 'bun',
+      args: ['--version'],
+      exists: (path) => existing.has(path),
+    });
+
+    expect(fallback).toEqual({
+      kind: 'typescript',
+      path: join(root, 'src', 'index.ts'),
+      command: ['bun', join(root, 'src', 'index.ts'), '--version'],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- ported the Go TUI slash-command shell to a registry with aliases and help formatting
- added Go handlers for /provider, /model status, /context, /config, /debug, and shell-only registered commands
- moved the npm bin/module entrypoint to a thin wrapper that prefers the built Go binary and falls back to the transitional TS CLI for local dev
- packaged the wrapper files in release archives and updated wrapper smoke docs

## Tests
- git diff --check
- bun run typecheck
- bun test ./tests --timeout 15000
- bun run test:go
- bun run build
- bun run smoke:build
- bun run build:go
- bun run smoke:go
- bun bin/zero.ts --version
- bun run package:release
- bun run verify:release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive TUI: many new slash commands, dynamic footer/help, model catalog and plan views.
  * CLI/packaging: updated CLI entrypoint and npm-wrapper that prefers a native binary and falls back to the TypeScript CLI.
  * Added --max-turns option to the exec command.

* **Refactor**
  * Centralized command parsing and registry with alias support and formatted help.

* **Tests**
  * Expanded coverage for commands, footer/help, plan/model views, and wrapper/entrypoint behavior.

* **Documentation**
  * Expanded npm-wrapper smoke checklist.

* **Chores**
  * Packaging updated to include executable and wrapper artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->