### PR TITLE
[codex] add Go provider runtime adapters

### DIFF
--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -160,7 +160,7 @@ func applyProviderEnv(cfg *FileConfig, providerKind ProviderKind, env envProfile
 	}
 
 	profile := ProviderProfile{
-		Name:         env.Name,
+		Name:         providerEnvTargetName(cfg, providerKind, env.Name),
 		ProviderKind: providerKind,
 		APIKey:       apiKey,
 		BaseURL:      baseURL,
@@ -173,6 +173,39 @@ func applyProviderEnv(cfg *FileConfig, providerKind ProviderKind, env envProfile
 		profile.ProviderKind = ProviderKindOpenAICompatible
 	}
 	mergeProvider(cfg, profile)
+}
+
+func providerEnvTargetName(cfg *FileConfig, providerKind ProviderKind, fallback string) string {
+	if activeName := strings.TrimSpace(cfg.ActiveProvider); activeName != "" {
+		for _, provider := range cfg.Providers {
+			if strings.TrimSpace(provider.Name) != activeName {
+				continue
+			}
+			if normalizedProfileKind(provider) == providerKind {
+				return activeName
+			}
+			break
+		}
+	}
+
+	for _, provider := range cfg.Providers {
+		if normalizedProfileKind(provider) != providerKind {
+			continue
+		}
+		if name := strings.TrimSpace(provider.Name); name != "" {
+			return name
+		}
+	}
+
+	return strings.TrimSpace(fallback)
+}
+
+func normalizedProfileKind(profile ProviderProfile) ProviderKind {
+	kind := strings.TrimSpace(string(profile.ProviderKind))
+	if kind == "" {
+		kind = strings.TrimSpace(profile.Provider)
+	}
+	return ProviderKind(strings.ToLower(kind))
 }
 
 func envValue(env map[string]string, key string) string {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -124,24 +124,52 @@ func applyEnv(cfg *FileConfig, env map[string]string) {
 		cfg.ActiveProvider = activeProvider
 	}
 
-	apiKey := envValue(env, "OPENAI_API_KEY")
-	baseURL := strings.TrimSpace(envValue(env, "OPENAI_BASE_URL"))
-	model := strings.TrimSpace(envValue(env, "OPENAI_MODEL"))
+	applyProviderEnv(cfg, ProviderKindOpenAI, envProfile{
+		Name:    string(ProviderKindOpenAI),
+		APIKey:  envValue(env, "OPENAI_API_KEY"),
+		BaseURL: envValue(env, "OPENAI_BASE_URL"),
+		Model:   envValue(env, "OPENAI_MODEL"),
+	})
+	applyProviderEnv(cfg, ProviderKindAnthropic, envProfile{
+		Name:    string(ProviderKindAnthropic),
+		APIKey:  envValue(env, "ANTHROPIC_API_KEY"),
+		BaseURL: envValue(env, "ANTHROPIC_BASE_URL"),
+		Model:   envValue(env, "ANTHROPIC_MODEL"),
+	})
+	applyProviderEnv(cfg, ProviderKindGoogle, envProfile{
+		Name:    string(ProviderKindGoogle),
+		APIKey:  firstNonEmpty(envValue(env, "GEMINI_API_KEY"), envValue(env, "GOOGLE_API_KEY")),
+		BaseURL: firstNonEmpty(envValue(env, "GEMINI_BASE_URL"), envValue(env, "GOOGLE_BASE_URL")),
+		Model:   firstNonEmpty(envValue(env, "GEMINI_MODEL"), envValue(env, "GOOGLE_MODEL")),
+	})
+}
+
+type envProfile struct {
+	Name    string
+	APIKey  string
+	BaseURL string
+	Model   string
+}
+
+func applyProviderEnv(cfg *FileConfig, providerKind ProviderKind, env envProfile) {
+	apiKey := strings.TrimSpace(env.APIKey)
+	baseURL := strings.TrimSpace(env.BaseURL)
+	model := strings.TrimSpace(env.Model)
 	if apiKey == "" && baseURL == "" && model == "" {
 		return
 	}
 
 	profile := ProviderProfile{
-		Name:         cfg.ActiveProvider,
-		ProviderKind: ProviderKindOpenAI,
+		Name:         env.Name,
+		ProviderKind: providerKind,
 		APIKey:       apiKey,
 		BaseURL:      baseURL,
 		Model:        model,
 	}
 	if profile.Name == "" {
-		profile.Name = string(ProviderKindOpenAI)
+		profile.Name = string(providerKind)
 	}
-	if baseURL != "" && !isOfficialOpenAIBaseURL(baseURL) {
+	if providerKind == ProviderKindOpenAI && baseURL != "" && !isOfficialOpenAIBaseURL(baseURL) {
 		profile.ProviderKind = ProviderKindOpenAICompatible
 	}
 	mergeProvider(cfg, profile)
@@ -247,6 +275,16 @@ func normalizeProvider(profile ProviderProfile) (ProviderProfile, error) {
 		}
 		if isOfficialOpenAIBaseURL(profile.BaseURL) {
 			return ProviderProfile{}, providerError(profile, "openai-compatible provider %s requires custom baseURL", profile.Name)
+		}
+		return profile, nil
+	case ProviderKindAnthropic:
+		if profile.BaseURL == "" {
+			profile.BaseURL = AnthropicBaseURL
+		}
+		return profile, nil
+	case ProviderKindGoogle:
+		if profile.BaseURL == "" {
+			profile.BaseURL = GoogleBaseURL
 		}
 		return profile, nil
 	default:

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -174,6 +174,49 @@ func TestResolveUsesAnthropicEnvFallback(t *testing.T) {
 	}
 }
 
+func TestResolveUsesAnthropicEnvFallbackWithCustomProfile(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "claude-prod",
+		"providers": [{
+			"name": "claude-prod",
+			"provider_kind": "anthropic",
+			"description": "production Claude"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"ZERO_PROVIDER":      "claude-prod",
+			"ANTHROPIC_API_KEY":  "sk-ant-env",
+			"ANTHROPIC_BASE_URL": "https://anthropic.example",
+			"ANTHROPIC_MODEL":    "claude-sonnet-4.5",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.ActiveProvider != "claude-prod" {
+		t.Fatalf("ActiveProvider = %q, want claude-prod", resolved.ActiveProvider)
+	}
+	if resolved.Provider.ProviderKind != ProviderKindAnthropic {
+		t.Fatalf("ProviderKind = %q, want anthropic", resolved.Provider.ProviderKind)
+	}
+	if resolved.Provider.APIKey != "sk-ant-env" || resolved.Provider.Model != "claude-sonnet-4.5" {
+		t.Fatalf("Provider = %#v, want Anthropic env credentials/model on custom profile", resolved.Provider)
+	}
+	if resolved.Provider.BaseURL != "https://anthropic.example" {
+		t.Fatalf("BaseURL = %q, want Anthropic env URL", resolved.Provider.BaseURL)
+	}
+	if resolved.Provider.Description != "production Claude" {
+		t.Fatalf("Description = %q, want existing custom profile metadata preserved", resolved.Provider.Description)
+	}
+	if len(resolved.Providers) != 1 {
+		t.Fatalf("Providers = %#v, want only custom Anthropic profile", resolved.Providers)
+	}
+}
+
 func TestResolveUsesGoogleEnvFallbackAliases(t *testing.T) {
 	resolved, err := Resolve(ResolveOptions{
 		Env: map[string]string{

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -139,6 +139,68 @@ func TestResolveUsesOpenAIEnvFallback(t *testing.T) {
 	}
 }
 
+func TestResolveUsesAnthropicEnvFallback(t *testing.T) {
+	resolved, err := Resolve(ResolveOptions{
+		Env: map[string]string{
+			"ZERO_PROVIDER":      "anthropic",
+			"ANTHROPIC_API_KEY":  "sk-ant-env",
+			"ANTHROPIC_BASE_URL": "https://anthropic.example",
+			"ANTHROPIC_MODEL":    "claude-sonnet-4.5",
+			"OPENAI_API_KEY":     "sk-openai-env",
+			"OPENAI_MODEL":       "gpt-4.1",
+			"GEMINI_API_KEY":     "sk-google-env",
+			"GEMINI_MODEL":       "gemini-2.5-flash",
+			"GEMINI_BASE_URL":    "https://google.example",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.ActiveProvider != "anthropic" {
+		t.Fatalf("ActiveProvider = %q, want anthropic", resolved.ActiveProvider)
+	}
+	if resolved.Provider.ProviderKind != ProviderKindAnthropic {
+		t.Fatalf("ProviderKind = %q, want anthropic", resolved.Provider.ProviderKind)
+	}
+	if resolved.Provider.APIKey != "sk-ant-env" || resolved.Provider.Model != "claude-sonnet-4.5" {
+		t.Fatalf("Provider = %#v, want Anthropic env credentials/model", resolved.Provider)
+	}
+	if resolved.Provider.BaseURL != "https://anthropic.example" {
+		t.Fatalf("BaseURL = %q, want Anthropic env URL", resolved.Provider.BaseURL)
+	}
+	if len(resolved.Providers) != 3 {
+		t.Fatalf("Providers = %#v, want openai, anthropic, and google env profiles", resolved.Providers)
+	}
+}
+
+func TestResolveUsesGoogleEnvFallbackAliases(t *testing.T) {
+	resolved, err := Resolve(ResolveOptions{
+		Env: map[string]string{
+			"ZERO_PROVIDER":   "google",
+			"GOOGLE_API_KEY":  "sk-google-env",
+			"GOOGLE_BASE_URL": "https://google.example",
+			"GOOGLE_MODEL":    "gemini-2.5-pro",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.ActiveProvider != "google" {
+		t.Fatalf("ActiveProvider = %q, want google", resolved.ActiveProvider)
+	}
+	if resolved.Provider.ProviderKind != ProviderKindGoogle {
+		t.Fatalf("ProviderKind = %q, want google", resolved.Provider.ProviderKind)
+	}
+	if resolved.Provider.APIKey != "sk-google-env" || resolved.Provider.Model != "gemini-2.5-pro" {
+		t.Fatalf("Provider = %#v, want Google env credentials/model", resolved.Provider)
+	}
+	if resolved.Provider.BaseURL != "https://google.example" {
+		t.Fatalf("BaseURL = %q, want Google env URL", resolved.Provider.BaseURL)
+	}
+}
+
 func TestResolveProviderCommandOverridesEnvProviderFields(t *testing.T) {
 	command := writeCommand(t, commandScript{
 		Stdout: `{"name":"cmd","provider":"openai","apiKey":"sk-command","model":"gpt-command"}`,
@@ -265,6 +327,34 @@ func TestResolveNormalizesOfficialOpenAIBaseURL(t *testing.T) {
 	}
 }
 
+func TestResolveAcceptsOfficialAnthropicAndGoogleProfiles(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "claude",
+		"providers": [
+			{"name": "claude", "provider": "anthropic", "apiKey": "sk-ant", "model": "claude-sonnet-4.5"},
+			{"name": "gemini", "provider": "google", "apiKey": "sk-google", "model": "gemini-2.5-flash"}
+		]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.ProviderKind != ProviderKindAnthropic {
+		t.Fatalf("ProviderKind = %q, want anthropic", resolved.Provider.ProviderKind)
+	}
+	if resolved.Provider.BaseURL != AnthropicBaseURL {
+		t.Fatalf("BaseURL = %q, want default Anthropic URL", resolved.Provider.BaseURL)
+	}
+	if resolved.Providers[1].ProviderKind != ProviderKindGoogle {
+		t.Fatalf("Google ProviderKind = %q, want google", resolved.Providers[1].ProviderKind)
+	}
+	if resolved.Providers[1].BaseURL != GoogleBaseURL {
+		t.Fatalf("Google BaseURL = %q, want default Google URL", resolved.Providers[1].BaseURL)
+	}
+}
+
 func TestResolveRejectsOpenAICompatibleWithoutBaseURL(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "custom",
@@ -290,9 +380,9 @@ func TestResolveRejectsUnknownProviderKind(t *testing.T) {
 		"activeProvider": "bad",
 		"providers": [{
 			"name": "bad",
-			"provider": "anthropic",
+			"provider": "bedrock",
 			"apiKey": "sk-bad",
-			"model": "claude"
+			"model": "model"
 		}]
 	}`)
 
@@ -300,7 +390,7 @@ func TestResolveRejectsUnknownProviderKind(t *testing.T) {
 	if err == nil {
 		t.Fatal("Resolve() error = nil, want validation error")
 	}
-	if !strings.Contains(err.Error(), `unknown provider kind "anthropic"`) {
+	if !strings.Contains(err.Error(), `unknown provider kind "bedrock"`) {
 		t.Fatalf("error = %q, want unknown provider kind", err.Error())
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,11 +6,15 @@ import (
 )
 
 const OpenAIBaseURL = "https://api.openai.com/v1"
+const AnthropicBaseURL = "https://api.anthropic.com"
+const GoogleBaseURL = "https://generativelanguage.googleapis.com"
 
 type ProviderKind string
 
 const (
 	ProviderKindOpenAI           ProviderKind = "openai"
+	ProviderKindAnthropic        ProviderKind = "anthropic"
+	ProviderKindGoogle           ProviderKind = "google"
 	ProviderKindOpenAICompatible ProviderKind = "openai-compatible"
 )
 

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -1,0 +1,457 @@
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+const defaultBaseURL = "https://api.anthropic.com"
+const defaultVersion = "2023-06-01"
+const defaultMaxTokens = 4096
+
+// Options configures an Anthropic Messages API provider.
+type Options struct {
+	APIKey     string
+	BaseURL    string
+	Model      string
+	MaxTokens  int
+	Version    string
+	Beta       string
+	HTTPClient *http.Client
+	UserAgent  string
+}
+
+// Provider streams completions from Anthropic's Messages API.
+type Provider struct {
+	apiKey     string
+	baseURL    string
+	model      string
+	maxTokens  int
+	version    string
+	beta       string
+	httpClient *http.Client
+	userAgent  string
+}
+
+// New creates an Anthropic provider.
+func New(options Options) (*Provider, error) {
+	model := strings.TrimSpace(options.Model)
+	if model == "" {
+		return nil, errors.New("anthropic provider requires a model")
+	}
+	maxTokens, err := providerio.PositiveOrDefault(options.MaxTokens, defaultMaxTokens, "Zero Anthropic provider maxTokens")
+	if err != nil {
+		return nil, err
+	}
+	baseURL, err := providerio.NormalizeBaseURL(options.BaseURL, defaultBaseURL, "Anthropic")
+	if err != nil {
+		return nil, err
+	}
+	version := strings.TrimSpace(options.Version)
+	if version == "" {
+		version = defaultVersion
+	}
+	return &Provider{
+		apiKey:     options.APIKey,
+		baseURL:    baseURL,
+		model:      model,
+		maxTokens:  maxTokens,
+		version:    version,
+		beta:       strings.TrimSpace(options.Beta),
+		httpClient: providerio.HTTPClient(options.HTTPClient),
+		userAgent:  options.UserAgent,
+	}, nil
+}
+
+// StreamCompletion sends one streaming Anthropic Messages request.
+func (provider *Provider) StreamCompletion(
+	ctx context.Context,
+	request zeroruntime.CompletionRequest,
+) (<-chan zeroruntime.StreamEvent, error) {
+	mapped, err := provider.anthropicRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(mapped)
+	if err != nil {
+		return nil, fmt.Errorf("encode Anthropic request: %w", err)
+	}
+
+	events := make(chan zeroruntime.StreamEvent, 16)
+	go func() {
+		defer close(events)
+		provider.stream(ctx, body, events)
+	}()
+	return events, nil
+}
+
+func (provider *Provider) stream(ctx context.Context, body []byte, events chan<- zeroruntime.StreamEvent) {
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
+		return
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("anthropic-version", provider.version)
+	if provider.apiKey != "" {
+		httpRequest.Header.Set("x-api-key", provider.apiKey)
+	}
+	if provider.beta != "" {
+		httpRequest.Header.Set("anthropic-beta", provider.beta)
+	}
+	if provider.userAgent != "" {
+		httpRequest.Header.Set("User-Agent", provider.userAgent)
+	}
+
+	response, err := provider.httpClient.Do(httpRequest)
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		provider.emitHTTPError(ctx, response, events)
+		return
+	}
+
+	state := newStreamState()
+	err = providerio.ScanSSEData(response.Body, func(data string) bool {
+		return provider.emitPayload(ctx, data, state, events)
+	})
+	if err != nil {
+		state.closeOpen(ctx, events)
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
+	}
+	if err := ctx.Err(); err != nil {
+		state.closeOpen(ctx, events)
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
+	}
+	if !state.done {
+		provider.emitDone(ctx, state, events)
+	}
+}
+
+func (provider *Provider) emitPayload(ctx context.Context, data string, state *streamState, events chan<- zeroruntime.StreamEvent) bool {
+	var payload streamPayload
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		state.closeOpen(ctx, events)
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact("provider stream error: malformed JSON: " + err.Error()),
+		})
+		state.done = true
+		return false
+	}
+
+	switch payload.Type {
+	case "message_start":
+		if payload.Message != nil {
+			state.recordUsage(payload.Message.Usage)
+		}
+	case "content_block_start":
+		if payload.ContentBlock != nil && payload.ContentBlock.Type == "tool_use" && payload.ContentBlock.ID != "" && payload.ContentBlock.Name != "" {
+			state.startTool(ctx, payload.Index, payload.ContentBlock.ID, payload.ContentBlock.Name, events)
+			if len(payload.ContentBlock.Input) > 0 {
+				encoded, err := json.Marshal(payload.ContentBlock.Input)
+				if err == nil {
+					state.deltaTool(ctx, payload.Index, string(encoded), events)
+				}
+			}
+		}
+	case "content_block_delta":
+		if payload.Delta == nil {
+			return true
+		}
+		switch payload.Delta.Type {
+		case "text_delta":
+			if payload.Delta.Text != "" {
+				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: payload.Delta.Text})
+			}
+		case "input_json_delta":
+			if payload.Delta.PartialJSON != "" {
+				state.deltaTool(ctx, payload.Index, payload.Delta.PartialJSON, events)
+			}
+		}
+	case "content_block_stop":
+		state.stopTool(ctx, payload.Index, events)
+	case "message_delta":
+		if payload.Usage != nil {
+			state.recordUsage(*payload.Usage)
+		}
+	case "message_stop":
+		provider.emitDone(ctx, state, events)
+	case "error":
+		message := "Anthropic stream error"
+		if payload.Error != nil {
+			message = firstNonEmpty(payload.Error.Message, payload.Error.Type, message)
+		}
+		state.closeOpen(ctx, events)
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.classifiedError(http.StatusInternalServerError, message),
+		})
+		state.done = true
+		return false
+	}
+	return true
+}
+
+func (provider *Provider) emitDone(ctx context.Context, state *streamState, events chan<- zeroruntime.StreamEvent) {
+	state.closeOpen(ctx, events)
+	if state.hasInputUsage || state.hasOutputUsage {
+		usage, err := zeroruntime.NormalizeUsage(zeroruntime.TokenUsage{
+			InputTokens:  state.inputTokens,
+			OutputTokens: state.outputTokens,
+		})
+		if err == nil {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: usage})
+		}
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	state.done = true
+}
+
+func (provider *Provider) emitHTTPError(ctx context.Context, response *http.Response, events chan<- zeroruntime.StreamEvent) {
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	message := response.Status
+	if parsed := parseErrorMessage(body); parsed != "" {
+		message = parsed
+	} else if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+		message = trimmed
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:  zeroruntime.StreamEventError,
+		Error: provider.classifiedError(response.StatusCode, message),
+	})
+}
+
+func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest) (messagesRequest, error) {
+	system, messages, err := mapMessages(request.Messages)
+	if err != nil {
+		return messagesRequest{}, err
+	}
+	if len(messages) == 0 {
+		return messagesRequest{}, errors.New("Zero Anthropic provider requires at least one non-system message")
+	}
+
+	mapped := messagesRequest{
+		Model:     provider.model,
+		MaxTokens: provider.maxTokens,
+		Messages:  messages,
+		System:    system,
+		Stream:    true,
+	}
+	if len(request.Tools) > 0 {
+		mapped.Tools = make([]anthropicTool, 0, len(request.Tools))
+		for _, tool := range request.Tools {
+			mapped.Tools = append(mapped.Tools, anthropicTool{
+				Name:        tool.Name,
+				Description: tool.Description,
+				InputSchema: tool.Parameters,
+			})
+		}
+	}
+	return mapped, nil
+}
+
+func mapMessages(messages []zeroruntime.Message) (string, []anthropicMessage, error) {
+	systemParts := []string{}
+	mapped := []anthropicMessage{}
+	for _, message := range messages {
+		content := message.Content
+		hasContent := strings.TrimSpace(content) != ""
+		switch message.Role {
+		case zeroruntime.MessageRoleSystem:
+			if hasContent {
+				systemParts = append(systemParts, content)
+			}
+		case zeroruntime.MessageRoleTool:
+			if message.ToolCallID == "" {
+				return "", nil, errors.New("Zero Anthropic provider requires toolCallId on tool result messages")
+			}
+			appendUserBlocks(&mapped, []map[string]any{{
+				"type":        "tool_result",
+				"tool_use_id": message.ToolCallID,
+				"content":     content,
+			}})
+		case zeroruntime.MessageRoleAssistant:
+			blocks := []map[string]any{}
+			if hasContent {
+				blocks = append(blocks, map[string]any{"type": "text", "text": content})
+			}
+			for _, toolCall := range message.ToolCalls {
+				input, err := parseToolArguments(toolCall.Arguments, toolCall.Name)
+				if err != nil {
+					return "", nil, err
+				}
+				blocks = append(blocks, map[string]any{
+					"type":  "tool_use",
+					"id":    toolCall.ID,
+					"name":  toolCall.Name,
+					"input": input,
+				})
+			}
+			if len(blocks) == 0 {
+				continue
+			}
+			var messageContent any = blocks
+			if len(blocks) == 1 && blocks[0]["type"] == "text" {
+				messageContent = blocks[0]["text"]
+			}
+			mapped = append(mapped, anthropicMessage{Role: "assistant", Content: messageContent})
+		default:
+			if hasContent {
+				appendUserBlocks(&mapped, []map[string]any{{"type": "text", "text": content}})
+			}
+		}
+	}
+	return strings.Join(systemParts, "\n\n"), mapped, nil
+}
+
+func appendUserBlocks(messages *[]anthropicMessage, blocks []map[string]any) {
+	if len(*messages) > 0 && (*messages)[len(*messages)-1].Role == "user" {
+		last := &(*messages)[len(*messages)-1]
+		last.Content = append(contentBlocks(last.Content), blocks...)
+		return
+	}
+	*messages = append(*messages, anthropicMessage{Role: "user", Content: blocks})
+}
+
+func contentBlocks(content any) []map[string]any {
+	if content == nil {
+		return nil
+	}
+	if text, ok := content.(string); ok {
+		return []map[string]any{{"type": "text", "text": text}}
+	}
+	if blocks, ok := content.([]map[string]any); ok {
+		return blocks
+	}
+	return nil
+}
+
+func parseToolArguments(argumentsJSON string, toolName string) (map[string]any, error) {
+	if strings.TrimSpace(argumentsJSON) == "" {
+		return map[string]any{}, nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(argumentsJSON), &parsed); err != nil {
+		return nil, fmt.Errorf("Zero Anthropic provider could not parse tool arguments for %s as JSON", toolName)
+	}
+	object, ok := parsed.(map[string]any)
+	if !ok || object == nil {
+		return nil, fmt.Errorf("Zero Anthropic provider requires tool arguments for %s to be a JSON object", toolName)
+	}
+	return object, nil
+}
+
+func parseErrorMessage(body []byte) string {
+	var parsed struct {
+		Error   apiError `json:"error"`
+		Message string   `json:"message"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return firstNonEmpty(parsed.Error.Message, parsed.Message)
+}
+
+func (provider *Provider) classifiedError(statusCode int, message string) string {
+	return providerio.ClassifiedError(statusCode, message, provider.apiKey)
+}
+
+func (provider *Provider) redact(message string) string {
+	return providerio.Redact(message, provider.apiKey)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+type toolBlock struct {
+	id   string
+	name string
+}
+
+type streamState struct {
+	tools          map[int]toolBlock
+	inputTokens    int
+	outputTokens   int
+	hasInputUsage  bool
+	hasOutputUsage bool
+	done           bool
+}
+
+func newStreamState() *streamState {
+	return &streamState{tools: make(map[int]toolBlock)}
+}
+
+func (state *streamState) recordUsage(usage usage) {
+	if usage.InputTokens != 0 {
+		state.inputTokens = usage.InputTokens
+		state.hasInputUsage = true
+	}
+	if usage.OutputTokens != 0 {
+		state.outputTokens = usage.OutputTokens
+		state.hasOutputUsage = true
+	}
+}
+
+func (state *streamState) startTool(ctx context.Context, index int, id string, name string, events chan<- zeroruntime.StreamEvent) {
+	state.tools[index] = toolBlock{id: id, name: name}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:       zeroruntime.StreamEventToolCallStart,
+		ToolCallID: id,
+		ToolName:   name,
+	})
+}
+
+func (state *streamState) deltaTool(ctx context.Context, index int, fragment string, events chan<- zeroruntime.StreamEvent) {
+	tool, ok := state.tools[index]
+	if !ok || fragment == "" {
+		return
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:              zeroruntime.StreamEventToolCallDelta,
+		ToolCallID:        tool.id,
+		ArgumentsFragment: fragment,
+	})
+}
+
+func (state *streamState) stopTool(ctx context.Context, index int, events chan<- zeroruntime.StreamEvent) {
+	tool, ok := state.tools[index]
+	if !ok {
+		return
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:       zeroruntime.StreamEventToolCallEnd,
+		ToolCallID: tool.id,
+	})
+	delete(state.tools, index)
+}
+
+func (state *streamState) closeOpen(ctx context.Context, events chan<- zeroruntime.StreamEvent) {
+	for index := range state.tools {
+		state.stopTool(ctx, index, events)
+	}
+}

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -48,7 +48,7 @@ func New(options Options) (*Provider, error) {
 	if model == "" {
 		return nil, errors.New("anthropic provider requires a model")
 	}
-	maxTokens, err := providerio.PositiveOrDefault(options.MaxTokens, defaultMaxTokens, "Zero Anthropic provider maxTokens")
+	maxTokens, err := providerio.PositiveOrDefault(options.MaxTokens, defaultMaxTokens, "zero Anthropic provider maxTokens")
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest
 		return messagesRequest{}, err
 	}
 	if len(messages) == 0 {
-		return messagesRequest{}, errors.New("Zero Anthropic provider requires at least one non-system message")
+		return messagesRequest{}, errors.New("zero Anthropic provider requires at least one non-system message")
 	}
 
 	mapped := messagesRequest{
@@ -281,7 +281,7 @@ func mapMessages(messages []zeroruntime.Message) (string, []anthropicMessage, er
 			}
 		case zeroruntime.MessageRoleTool:
 			if message.ToolCallID == "" {
-				return "", nil, errors.New("Zero Anthropic provider requires toolCallId on tool result messages")
+				return "", nil, errors.New("zero Anthropic provider requires toolCallId on tool result messages")
 			}
 			appendUserBlocks(&mapped, []map[string]any{{
 				"type":        "tool_result",
@@ -350,11 +350,11 @@ func parseToolArguments(argumentsJSON string, toolName string) (map[string]any, 
 	}
 	var parsed any
 	if err := json.Unmarshal([]byte(argumentsJSON), &parsed); err != nil {
-		return nil, fmt.Errorf("Zero Anthropic provider could not parse tool arguments for %s as JSON", toolName)
+		return nil, fmt.Errorf("zero Anthropic provider could not parse tool arguments for %s as JSON", toolName)
 	}
 	object, ok := parsed.(map[string]any)
 	if !ok || object == nil {
-		return nil, fmt.Errorf("Zero Anthropic provider requires tool arguments for %s to be a JSON object", toolName)
+		return nil, fmt.Errorf("zero Anthropic provider requires tool arguments for %s to be a JSON object", toolName)
 	}
 	return object, nil
 }

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -1,0 +1,326 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestStreamCompletionPostsMessagesRequest(t *testing.T) {
+	var gotPath string
+	var gotAPIKey string
+	var gotVersion string
+	var gotUserAgent string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		gotUserAgent = r.Header.Get("User-Agent")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSEEvent(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":3}}}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:    "sk-ant",
+		BaseURL:   server.URL + "/",
+		Model:     "claude-test",
+		MaxTokens: 64_000,
+		UserAgent: "zero-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "You are Zero."},
+			{Role: zeroruntime.MessageRoleUser, Content: "Read the file."},
+			{
+				Role:    zeroruntime.MessageRoleAssistant,
+				Content: "I will inspect it.",
+				ToolCalls: []zeroruntime.ToolCall{{
+					ID:        "toolu_1",
+					Name:      "read_file",
+					Arguments: `{"path":"src/index.ts"}`,
+				}},
+			},
+			{Role: zeroruntime.MessageRoleTool, Content: "file contents", ToolCallID: "toolu_1"},
+		},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name:        "read_file",
+			Description: "Read a file",
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if gotPath != "/v1/messages" {
+		t.Fatalf("path = %q, want /v1/messages", gotPath)
+	}
+	if gotAPIKey != "sk-ant" {
+		t.Fatalf("x-api-key = %q, want key", gotAPIKey)
+	}
+	if gotVersion != defaultVersion {
+		t.Fatalf("anthropic-version = %q, want %q", gotVersion, defaultVersion)
+	}
+	if gotUserAgent != "zero-test" {
+		t.Fatalf("User-Agent = %q, want zero-test", gotUserAgent)
+	}
+	if gotBody["model"] != "claude-test" || gotBody["stream"] != true || gotBody["max_tokens"] != float64(64_000) {
+		t.Fatalf("unexpected model/stream/max_tokens: %#v", gotBody)
+	}
+	if gotBody["system"] != "You are Zero." {
+		t.Fatalf("system = %#v, want system prompt", gotBody["system"])
+	}
+	messages := gotBody["messages"].([]any)
+	if len(messages) != 3 {
+		t.Fatalf("messages = %#v, want user, assistant, tool-result user", messages)
+	}
+	assistant := messages[1].(map[string]any)
+	assistantBlocks := assistant["content"].([]any)
+	toolUse := assistantBlocks[1].(map[string]any)
+	if toolUse["type"] != "tool_use" || toolUse["id"] != "toolu_1" || toolUse["name"] != "read_file" {
+		t.Fatalf("unexpected tool_use block: %#v", toolUse)
+	}
+	input := toolUse["input"].(map[string]any)
+	if input["path"] != "src/index.ts" {
+		t.Fatalf("tool input = %#v, want path", input)
+	}
+	toolResult := messages[2].(map[string]any)
+	toolResultBlocks := toolResult["content"].([]any)
+	if toolResultBlocks[0].(map[string]any)["tool_use_id"] != "toolu_1" {
+		t.Fatalf("unexpected tool result: %#v", toolResultBlocks[0])
+	}
+	tools := gotBody["tools"].([]any)
+	if tools[0].(map[string]any)["input_schema"].(map[string]any)["type"] != "object" {
+		t.Fatalf("unexpected tool schema: %#v", tools)
+	}
+}
+
+func TestStreamCompletionEmitsTextUsageAndDone(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":25}}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Zero"}}`)
+		writeSSEEvent(w, "message_delta", `{"type":"message_delta","usage":{"output_tokens":15}}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	want := []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "Hello"},
+		{Type: zeroruntime.StreamEventText, Content: " Zero"},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 25, OutputTokens: 15, PromptTokens: 25, CompletionTokens: 15}},
+		{Type: zeroruntime.StreamEventDone},
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestStreamCompletionEmitsToolUseBlocks(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file","input":{}}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"path\":"}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"src/index.ts\"}"}}`)
+		writeSSEEvent(w, "content_block_stop", `{"type":"content_block_stop","index":1}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	want := []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "toolu_1", ToolName: "read_file"},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "toolu_1", ArgumentsFragment: `{"path":`},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "toolu_1", ArgumentsFragment: `"src/index.ts"}`},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "toolu_1"},
+		{Type: zeroruntime.StreamEventDone},
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestStreamCompletionClosesOpenToolCallOnEOF(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"grep","input":{}}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"pattern\":\"Zero\"}"}}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	if len(eventsOfType(events, zeroruntime.StreamEventToolCallEnd)) != 1 {
+		t.Fatalf("events = %#v, want one tool-call-end on EOF", events)
+	}
+	if len(eventsOfType(events, zeroruntime.StreamEventDone)) != 1 {
+		t.Fatalf("events = %#v, want done on EOF", events)
+	}
+}
+
+func TestStreamCompletionClassifiesHTTPErrorsAndRedactsToken(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantPrefix string
+	}{
+		{"auth", http.StatusUnauthorized, `{"error":{"message":"bad key sk-ant"}}`, "auth error:"},
+		{"rate limit", http.StatusTooManyRequests, `{"error":{"message":"slow down"}}`, "rate limit error:"},
+		{"overloaded", http.StatusServiceUnavailable, `{"error":{"message":"overloaded"}}`, "rate limit error:"},
+		{"bad request", http.StatusBadRequest, `{"error":{"message":"bad request"}}`, "provider request error:"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := newTestProviderWithKey(t, "sk-ant", func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, tc.body, tc.status)
+			})
+			stream, err := provider.StreamCompletion(context.Background(), validRequest())
+			if err != nil {
+				t.Fatalf("StreamCompletion returned setup error: %v", err)
+			}
+			events := readAll(stream)
+			if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
+				t.Fatalf("events = %#v, want one error", events)
+			}
+			if !strings.HasPrefix(events[0].Error, tc.wantPrefix) {
+				t.Fatalf("error = %q, want prefix %q", events[0].Error, tc.wantPrefix)
+			}
+			if strings.Contains(events[0].Error, "sk-ant") {
+				t.Fatalf("error leaked token: %q", events[0].Error)
+			}
+		})
+	}
+}
+
+func TestStreamCompletionEmitsStreamErrorObject(t *testing.T) {
+	provider := newTestProviderWithKey(t, "sk-ant", func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "error", `{"type":"error","error":{"message":"stream failed sk-ant","type":"overloaded_error"}}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
+		t.Fatalf("events = %#v, want one error", events)
+	}
+	if !strings.HasPrefix(events[0].Error, "provider error:") {
+		t.Fatalf("error = %q, want provider error prefix", events[0].Error)
+	}
+	if strings.Contains(events[0].Error, "sk-ant") {
+		t.Fatalf("error leaked token: %q", events[0].Error)
+	}
+}
+
+func TestStreamCompletionRejectsMalformedHistoryBeforeDispatch(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("provider should not dispatch malformed history")
+	})
+
+	_, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleTool, Content: "missing id"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires toolCallId") {
+		t.Fatalf("error = %v, want missing toolCallId", err)
+	}
+
+	_, err = provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "call tool"},
+			{
+				Role:      zeroruntime.MessageRoleAssistant,
+				ToolCalls: []zeroruntime.ToolCall{{ID: "toolu_1", Name: "read_file", Arguments: `"src/index.ts"`}},
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires tool arguments for read_file to be a JSON object") {
+		t.Fatalf("error = %v, want non-object tool argument error", err)
+	}
+}
+
+func TestNewRequiresModelAndPositiveMaxTokens(t *testing.T) {
+	if _, err := New(Options{}); err == nil {
+		t.Fatal("New without model returned nil error")
+	}
+	if _, err := New(Options{Model: "claude-test", MaxTokens: -1}); err == nil {
+		t.Fatal("New with negative max tokens returned nil error")
+	}
+}
+
+func newTestProvider(t *testing.T, handler http.HandlerFunc) *Provider {
+	t.Helper()
+	return newTestProviderWithKey(t, "", handler)
+}
+
+func newTestProviderWithKey(t *testing.T, apiKey string, handler http.HandlerFunc) *Provider {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	provider, err := New(Options{
+		APIKey:  apiKey,
+		BaseURL: server.URL,
+		Model:   "claude-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	return provider
+}
+
+func collectProviderEvents(t *testing.T, provider *Provider) []zeroruntime.StreamEvent {
+	t.Helper()
+	stream, err := provider.StreamCompletion(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("StreamCompletion returned setup error: %v", err)
+	}
+	return readAll(stream)
+}
+
+func validRequest() zeroruntime.CompletionRequest {
+	return zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+	}
+}
+
+func readAll(stream <-chan zeroruntime.StreamEvent) []zeroruntime.StreamEvent {
+	events := []zeroruntime.StreamEvent{}
+	for event := range stream {
+		events = append(events, event)
+	}
+	return events
+}
+
+func drain(stream <-chan zeroruntime.StreamEvent) {
+	for range stream {
+	}
+}
+
+func writeSSEEvent(w http.ResponseWriter, eventName string, payload string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	if eventName != "" {
+		_, _ = w.Write([]byte("event: " + eventName + "\n"))
+	}
+	_, _ = w.Write([]byte("data: " + payload + "\n\n"))
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func eventsOfType(events []zeroruntime.StreamEvent, eventType zeroruntime.StreamEventType) []zeroruntime.StreamEvent {
+	matching := []zeroruntime.StreamEvent{}
+	for _, event := range events {
+		if event.Type == eventType {
+			matching = append(matching, event)
+		}
+	}
+	return matching
+}

--- a/internal/providers/anthropic/types.go
+++ b/internal/providers/anthropic/types.go
@@ -1,0 +1,59 @@
+package anthropic
+
+type messagesRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+	System    string             `json:"system,omitempty"`
+	Tools     []anthropicTool    `json:"tools,omitempty"`
+	Stream    bool               `json:"stream"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+type anthropicTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema,omitempty"`
+}
+
+type streamPayload struct {
+	Type         string         `json:"type"`
+	Index        int            `json:"index"`
+	Message      *streamMessage `json:"message"`
+	ContentBlock *contentBlock  `json:"content_block"`
+	Delta        *streamDelta   `json:"delta"`
+	Usage        *usage         `json:"usage"`
+	Error        *apiError      `json:"error"`
+}
+
+type streamMessage struct {
+	Usage usage `json:"usage"`
+}
+
+type contentBlock struct {
+	Type  string         `json:"type"`
+	ID    string         `json:"id"`
+	Name  string         `json:"name"`
+	Input map[string]any `json:"input"`
+}
+
+type streamDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	PartialJSON string `json:"partial_json"`
+	StopReason  string `json:"stop_reason"`
+}
+
+type usage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type apiError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -3,30 +3,136 @@ package providers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providers/anthropic"
+	"github.com/Gitlawb/zero/internal/providers/gemini"
 	"github.com/Gitlawb/zero/internal/providers/openai"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 // Options configures provider construction.
 type Options struct {
-	UserAgent  string
-	HTTPClient *http.Client
+	UserAgent     string
+	HTTPClient    *http.Client
+	ModelRegistry *modelregistry.Registry
 }
 
 // New creates a runtime provider for a resolved provider profile.
 func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider, error) {
-	switch profile.ProviderKind {
+	resolved, err := resolveProfile(profile, options)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resolved.providerKind {
 	case config.ProviderKindOpenAI, config.ProviderKindOpenAICompatible:
 		return openai.New(openai.Options{
 			APIKey:     profile.APIKey,
-			BaseURL:    profile.BaseURL,
-			Model:      profile.Model,
+			BaseURL:    resolved.baseURL,
+			Model:      resolved.apiModel,
+			HTTPClient: options.HTTPClient,
+			UserAgent:  options.UserAgent,
+		})
+	case config.ProviderKindAnthropic:
+		return anthropic.New(anthropic.Options{
+			APIKey:     profile.APIKey,
+			BaseURL:    resolved.baseURL,
+			Model:      resolved.apiModel,
+			MaxTokens:  resolved.maxOutputTokens,
+			HTTPClient: options.HTTPClient,
+			UserAgent:  options.UserAgent,
+		})
+	case config.ProviderKindGoogle:
+		return gemini.New(gemini.Options{
+			APIKey:     profile.APIKey,
+			BaseURL:    resolved.baseURL,
+			Model:      resolved.apiModel,
+			MaxTokens:  resolved.maxOutputTokens,
 			HTTPClient: options.HTTPClient,
 			UserAgent:  options.UserAgent,
 		})
 	default:
-		return nil, fmt.Errorf("unsupported provider kind %q", profile.ProviderKind)
+		return nil, fmt.Errorf("unsupported provider kind %q", resolved.providerKind)
 	}
+}
+
+type resolvedProfile struct {
+	providerKind    config.ProviderKind
+	apiModel        string
+	baseURL         string
+	maxOutputTokens int
+}
+
+func resolveProfile(profile config.ProviderProfile, options Options) (resolvedProfile, error) {
+	model := strings.TrimSpace(profile.Model)
+	if model == "" {
+		return resolvedProfile{}, fmt.Errorf("provider %s requires model", profile.Name)
+	}
+	providerKind, explicitProvider := explicitProviderKind(profile)
+	registry, err := defaultRegistry(options.ModelRegistry)
+	if err != nil {
+		return resolvedProfile{}, err
+	}
+
+	if entry, ok := registry.Get(model); ok {
+		modelProvider := configKind(entry.Provider)
+		if !explicitProvider || isImplicitOpenAI(profile, providerKind) {
+			providerKind = modelProvider
+		}
+		if providerKind == config.ProviderKindOpenAICompatible {
+			if !entry.AllowsProvider(modelregistry.ProviderOpenAICompatible) {
+				return resolvedProfile{}, fmt.Errorf("zero model %s belongs to %s, not %s", entry.ID, entry.Provider, modelregistry.ProviderOpenAICompatible)
+			}
+		} else if providerKind != modelProvider {
+			return resolvedProfile{}, fmt.Errorf("zero model %s belongs to %s, not %s", entry.ID, entry.Provider, providerKind)
+		}
+		return resolvedProfile{
+			providerKind:    providerKind,
+			apiModel:        entry.APIModel,
+			baseURL:         strings.TrimSpace(profile.BaseURL),
+			maxOutputTokens: entry.ContextLimits.MaxOutputTokens,
+		}, nil
+	}
+
+	if providerKind == "" {
+		providerKind = config.ProviderKindOpenAI
+	}
+	return resolvedProfile{
+		providerKind: providerKind,
+		apiModel:     model,
+		baseURL:      strings.TrimSpace(profile.BaseURL),
+	}, nil
+}
+
+func explicitProviderKind(profile config.ProviderProfile) (config.ProviderKind, bool) {
+	providerKind := config.ProviderKind(strings.TrimSpace(strings.ToLower(string(profile.ProviderKind))))
+	if providerKind != "" {
+		return providerKind, true
+	}
+	provider := strings.TrimSpace(strings.ToLower(profile.Provider))
+	if provider != "" {
+		return config.ProviderKind(provider), true
+	}
+	return "", false
+}
+
+func isImplicitOpenAI(profile config.ProviderProfile, providerKind config.ProviderKind) bool {
+	return providerKind == config.ProviderKindOpenAI &&
+		strings.TrimSpace(string(profile.ProviderKind)) == "" &&
+		strings.TrimSpace(profile.Provider) == "" &&
+		strings.TrimSpace(profile.BaseURL) == ""
+}
+
+func configKind(provider modelregistry.ProviderKind) config.ProviderKind {
+	return config.ProviderKind(provider)
+}
+
+func defaultRegistry(registry *modelregistry.Registry) (modelregistry.Registry, error) {
+	if registry != nil {
+		return *registry, nil
+	}
+	return modelregistry.DefaultRegistry()
 }

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -68,27 +69,145 @@ func TestNewSupportsOpenAIProviderKind(t *testing.T) {
 	}
 }
 
+func TestNewResolvesKnownModelToAPIModelAndProvider(t *testing.T) {
+	transport := &captureTransport{
+		responseBody: "data: {\"type\":\"message_stop\"}\n\n",
+	}
+	client := &http.Client{Transport: transport}
+
+	provider, err := New(config.ProviderProfile{
+		Name:   "claude",
+		APIKey: "sk-ant",
+		Model:  "claude-sonnet-4.5",
+	}, Options{
+		HTTPClient: client,
+		UserAgent:  "zero-factory-test",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+
+	if transport.request == nil {
+		t.Fatal("HTTP client was not used")
+	}
+	if transport.request.URL.String() != "https://api.anthropic.com/v1/messages" {
+		t.Fatalf("request URL = %q, want Anthropic Messages API", transport.request.URL.String())
+	}
+	if transport.request.Header.Get("x-api-key") != "sk-ant" {
+		t.Fatalf("x-api-key = %q, want Anthropic key", transport.request.Header.Get("x-api-key"))
+	}
+	if transport.request.Header.Get("User-Agent") != "zero-factory-test" {
+		t.Fatalf("User-Agent = %q, want factory user agent", transport.request.Header.Get("User-Agent"))
+	}
+	var body map[string]any
+	if err := json.NewDecoder(transport.body()).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if body["model"] != "claude-sonnet-4-5-20250929" {
+		t.Fatalf("model = %q, want registry API model", body["model"])
+	}
+	if body["max_tokens"] != float64(64000) {
+		t.Fatalf("max_tokens = %#v, want registry output ceiling", body["max_tokens"])
+	}
+}
+
+func TestNewCreatesGeminiProviderFromFactoryOptions(t *testing.T) {
+	transport := &captureTransport{
+		responseBody: "data: {}\n\n",
+	}
+	client := &http.Client{Transport: transport}
+
+	provider, err := New(config.ProviderProfile{
+		Name:         "google",
+		ProviderKind: config.ProviderKindGoogle,
+		APIKey:       "sk-google",
+		Model:        "gemini-2.5-flash",
+	}, Options{
+		HTTPClient: client,
+		UserAgent:  "zero-factory-test",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+
+	if transport.request == nil {
+		t.Fatal("HTTP client was not used")
+	}
+	wantURL := "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+	if transport.request.URL.String() != wantURL {
+		t.Fatalf("request URL = %q, want %s", transport.request.URL.String(), wantURL)
+	}
+	if transport.request.Header.Get("x-goog-api-key") != "sk-google" {
+		t.Fatalf("x-goog-api-key = %q, want Google key", transport.request.Header.Get("x-goog-api-key"))
+	}
+	var body map[string]any
+	if err := json.NewDecoder(transport.body()).Decode(&body); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	generationConfig := body["generationConfig"].(map[string]any)
+	if generationConfig["maxOutputTokens"] != float64(65536) {
+		t.Fatalf("maxOutputTokens = %#v, want registry output ceiling", generationConfig["maxOutputTokens"])
+	}
+}
+
+func TestNewRejectsMismatchedOfficialProviderAndKnownModel(t *testing.T) {
+	_, err := New(config.ProviderProfile{
+		Name:         "openai",
+		ProviderKind: config.ProviderKindOpenAI,
+		Model:        "claude-sonnet-4.5",
+	}, Options{})
+	if err == nil {
+		t.Fatal("New() error = nil, want provider/model mismatch")
+	}
+	if !strings.Contains(err.Error(), "belongs to anthropic, not openai") {
+		t.Fatalf("error = %q, want model/provider mismatch", err.Error())
+	}
+}
+
 func TestNewRejectsUnsupportedProviderKind(t *testing.T) {
 	_, err := New(config.ProviderProfile{
 		Name:         "bad",
-		ProviderKind: "anthropic",
-		Model:        "claude",
+		ProviderKind: "bedrock",
+		Model:        "model",
 	}, Options{})
 	if err == nil {
 		t.Fatal("New() error = nil, want unsupported kind error")
 	}
-	if !strings.Contains(err.Error(), `unsupported provider kind "anthropic"`) {
+	if !strings.Contains(err.Error(), `unsupported provider kind "bedrock"`) {
 		t.Fatalf("error = %q, want unsupported provider kind", err.Error())
 	}
 }
 
 type captureTransport struct {
 	request      *http.Request
+	requestBody  string
 	responseBody string
 }
 
 func (transport *captureTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	transport.request = request
+	if request.Body != nil {
+		body, _ := io.ReadAll(request.Body)
+		transport.requestBody = string(body)
+	}
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Status:     "200 OK",
@@ -96,4 +215,8 @@ func (transport *captureTransport) RoundTrip(request *http.Request) (*http.Respo
 		Body:       io.NopCloser(strings.NewReader(transport.responseBody)),
 		Request:    request,
 	}, nil
+}
+
+func (transport *captureTransport) body() io.Reader {
+	return strings.NewReader(transport.requestBody)
 }

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -44,7 +44,7 @@ func New(options Options) (*Provider, error) {
 	if model == "" {
 		return nil, errors.New("gemini provider requires a model")
 	}
-	maxTokens, err := providerio.PositiveOrDefault(options.MaxTokens, defaultMaxTokens, "Zero Gemini provider maxTokens")
+	maxTokens, err := providerio.PositiveOrDefault(options.MaxTokens, defaultMaxTokens, "zero Gemini provider maxTokens")
 	if err != nil {
 		return nil, err
 	}
@@ -141,9 +141,13 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 	}
 	if payload.Error != nil {
 		message := firstNonEmpty(payload.Error.Message, payload.Error.Status, "Gemini stream error")
+		status := payload.Error.Code
+		if status == 0 {
+			status = http.StatusInternalServerError
+		}
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
 			Type:  zeroruntime.StreamEventError,
-			Error: provider.classifiedError(http.StatusInternalServerError, message),
+			Error: provider.classifiedError(status, message),
 		})
 		state.done = true
 		return false
@@ -249,7 +253,7 @@ func (provider *Provider) geminiRequest(request zeroruntime.CompletionRequest) (
 		return generateContentRequest{}, err
 	}
 	if len(contents) == 0 {
-		return generateContentRequest{}, errors.New("Zero Gemini provider requires at least one non-system message")
+		return generateContentRequest{}, errors.New("zero Gemini provider requires at least one non-system message")
 	}
 
 	mapped := generateContentRequest{
@@ -286,7 +290,7 @@ func mapMessages(messages []zeroruntime.Message) (*geminiContent, []geminiConten
 			}
 		case zeroruntime.MessageRoleTool:
 			if message.ToolCallID == "" {
-				return nil, nil, errors.New("Zero Gemini provider requires toolCallId on tool result messages")
+				return nil, nil, errors.New("zero Gemini provider requires toolCallId on tool result messages")
 			}
 			name := toolNamesByID[message.ToolCallID]
 			if name == "" {
@@ -327,7 +331,7 @@ func mapMessages(messages []zeroruntime.Message) (*geminiContent, []geminiConten
 	}
 	var systemInstruction *geminiContent
 	if len(systemParts) > 0 {
-		systemInstruction = &geminiContent{Role: "system", Parts: systemParts}
+		systemInstruction = &geminiContent{Parts: systemParts}
 	}
 	return systemInstruction, contents, nil
 }
@@ -346,11 +350,11 @@ func parseToolArguments(argumentsJSON string, toolName string) (map[string]any, 
 	}
 	var parsed any
 	if err := json.Unmarshal([]byte(argumentsJSON), &parsed); err != nil {
-		return nil, fmt.Errorf("Zero Gemini provider could not parse tool arguments for %s as JSON", toolName)
+		return nil, fmt.Errorf("zero Gemini provider could not parse tool arguments for %s as JSON", toolName)
 	}
 	object, ok := parsed.(map[string]any)
 	if !ok || object == nil {
-		return nil, fmt.Errorf("Zero Gemini provider requires tool arguments for %s to be a JSON object", toolName)
+		return nil, fmt.Errorf("zero Gemini provider requires tool arguments for %s to be a JSON object", toolName)
 	}
 	return object, nil
 }
@@ -361,7 +365,7 @@ func normalizeFunctionCallArgs(value any, toolName string) (map[string]any, erro
 	}
 	object, ok := value.(map[string]any)
 	if !ok || object == nil {
-		return nil, fmt.Errorf("Zero Gemini provider requires streamed tool arguments for %s to be a JSON object", toolName)
+		return nil, fmt.Errorf("zero Gemini provider requires streamed tool arguments for %s to be a JSON object", toolName)
 	}
 	return object, nil
 }

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -1,0 +1,424 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+const defaultBaseURL = "https://generativelanguage.googleapis.com"
+const defaultMaxTokens = 8192
+
+// Options configures a Gemini streamGenerateContent provider.
+type Options struct {
+	APIKey     string
+	BaseURL    string
+	Model      string
+	MaxTokens  int
+	HTTPClient *http.Client
+	UserAgent  string
+}
+
+// Provider streams completions from the Gemini API.
+type Provider struct {
+	apiKey     string
+	baseURL    string
+	model      string
+	maxTokens  int
+	httpClient *http.Client
+	userAgent  string
+}
+
+// New creates a Gemini provider.
+func New(options Options) (*Provider, error) {
+	model := normalizeModel(options.Model)
+	if model == "" {
+		return nil, errors.New("gemini provider requires a model")
+	}
+	maxTokens, err := providerio.PositiveOrDefault(options.MaxTokens, defaultMaxTokens, "Zero Gemini provider maxTokens")
+	if err != nil {
+		return nil, err
+	}
+	baseURL, err := providerio.NormalizeBaseURL(options.BaseURL, defaultBaseURL, "Gemini")
+	if err != nil {
+		return nil, err
+	}
+	return &Provider{
+		apiKey:     options.APIKey,
+		baseURL:    baseURL,
+		model:      model,
+		maxTokens:  maxTokens,
+		httpClient: providerio.HTTPClient(options.HTTPClient),
+		userAgent:  options.UserAgent,
+	}, nil
+}
+
+// StreamCompletion sends one streaming Gemini GenerateContent request.
+func (provider *Provider) StreamCompletion(
+	ctx context.Context,
+	request zeroruntime.CompletionRequest,
+) (<-chan zeroruntime.StreamEvent, error) {
+	mapped, err := provider.geminiRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(mapped)
+	if err != nil {
+		return nil, fmt.Errorf("encode Gemini request: %w", err)
+	}
+
+	events := make(chan zeroruntime.StreamEvent, 16)
+	go func() {
+		defer close(events)
+		provider.stream(ctx, body, events)
+	}()
+	return events, nil
+}
+
+func (provider *Provider) stream(ctx context.Context, body []byte, events chan<- zeroruntime.StreamEvent) {
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.streamURL(), bytes.NewReader(body))
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
+		return
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	if provider.apiKey != "" {
+		httpRequest.Header.Set("x-goog-api-key", provider.apiKey)
+	}
+	if provider.userAgent != "" {
+		httpRequest.Header.Set("User-Agent", provider.userAgent)
+	}
+
+	response, err := provider.httpClient.Do(httpRequest)
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		provider.emitHTTPError(ctx, response, events)
+		return
+	}
+
+	state := streamState{}
+	err = providerio.ScanSSEData(response.Body, func(data string) bool {
+		return provider.emitPayload(ctx, data, &state, events)
+	})
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
+	}
+	if err := ctx.Err(); err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
+	}
+	if !state.done {
+		provider.emitDone(ctx, state, events)
+	}
+}
+
+func (provider *Provider) emitPayload(ctx context.Context, data string, state *streamState, events chan<- zeroruntime.StreamEvent) bool {
+	var payload streamPayload
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact("provider stream error: malformed JSON: " + err.Error()),
+		})
+		state.done = true
+		return false
+	}
+	if payload.Error != nil {
+		message := firstNonEmpty(payload.Error.Message, payload.Error.Status, "Gemini stream error")
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.classifiedError(http.StatusInternalServerError, message),
+		})
+		state.done = true
+		return false
+	}
+	if payload.PromptFeedback != nil && payload.PromptFeedback.BlockReason != "" {
+		message := firstNonEmpty(payload.PromptFeedback.BlockReasonMessage, payload.PromptFeedback.BlockReason)
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact("provider error: Content blocked: " + message),
+		})
+		state.done = true
+		return false
+	}
+	if payload.UsageMetadata != nil {
+		state.inputTokens = payload.UsageMetadata.PromptTokenCount
+		state.outputTokens = payload.UsageMetadata.CandidatesTokenCount
+		state.reasoningTokens = payload.UsageMetadata.ThoughtsTokenCount
+		state.hasUsage = true
+	}
+	for _, candidate := range payload.Candidates {
+		if candidate.Content == nil {
+			continue
+		}
+		for _, part := range candidate.Content.Parts {
+			if part.Text != "" {
+				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: part.Text})
+			}
+			if part.FunctionCall != nil && part.FunctionCall.Name != "" {
+				state.syntheticToolIndex++
+				if !provider.emitToolCall(ctx, *part.FunctionCall, state.syntheticToolIndex, events) {
+					state.done = true
+					return false
+				}
+			}
+		}
+	}
+	for _, functionCall := range payload.FunctionCalls {
+		if functionCall.Name == "" {
+			continue
+		}
+		state.syntheticToolIndex++
+		if !provider.emitToolCall(ctx, functionCall, state.syntheticToolIndex, events) {
+			state.done = true
+			return false
+		}
+	}
+	return true
+}
+
+func (provider *Provider) emitDone(ctx context.Context, state streamState, events chan<- zeroruntime.StreamEvent) {
+	if state.hasUsage {
+		usage, err := zeroruntime.NormalizeUsage(zeroruntime.TokenUsage{
+			InputTokens:     state.inputTokens,
+			OutputTokens:    state.outputTokens,
+			ReasoningTokens: state.reasoningTokens,
+		})
+		if err == nil {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: usage})
+		}
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	state.done = true
+}
+
+func (provider *Provider) emitToolCall(ctx context.Context, functionCall functionCall, syntheticIndex int, events chan<- zeroruntime.StreamEvent) bool {
+	id := functionCall.ID
+	if id == "" {
+		id = fmt.Sprintf("gemini_tool_%d", syntheticIndex)
+	}
+	args, err := normalizeFunctionCallArgs(firstNonNil(functionCall.Args, functionCall.Arguments), functionCall.Name)
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider error: " + err.Error())})
+		return false
+	}
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider error: " + err.Error())})
+		return false
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: id, ToolName: functionCall.Name})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: id, ArgumentsFragment: string(encoded)})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: id})
+	return true
+}
+
+func (provider *Provider) emitHTTPError(ctx context.Context, response *http.Response, events chan<- zeroruntime.StreamEvent) {
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	message := response.Status
+	if parsed := parseErrorMessage(body); parsed != "" {
+		message = parsed
+	} else if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+		message = trimmed
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:  zeroruntime.StreamEventError,
+		Error: provider.classifiedError(response.StatusCode, message),
+	})
+}
+
+func (provider *Provider) geminiRequest(request zeroruntime.CompletionRequest) (generateContentRequest, error) {
+	systemInstruction, contents, err := mapMessages(request.Messages)
+	if err != nil {
+		return generateContentRequest{}, err
+	}
+	if len(contents) == 0 {
+		return generateContentRequest{}, errors.New("Zero Gemini provider requires at least one non-system message")
+	}
+
+	mapped := generateContentRequest{
+		SystemInstruction: systemInstruction,
+		Contents:          contents,
+		GenerationConfig:  generationConfig{MaxOutputTokens: provider.maxTokens},
+	}
+	if len(request.Tools) > 0 {
+		declarations := make([]geminiFunctionDeclaration, 0, len(request.Tools))
+		for _, tool := range request.Tools {
+			declarations = append(declarations, geminiFunctionDeclaration{
+				Name:        tool.Name,
+				Description: tool.Description,
+				Parameters:  tool.Parameters,
+			})
+		}
+		mapped.Tools = []geminiToolGroup{{FunctionDeclarations: declarations}}
+	}
+	return mapped, nil
+}
+
+func mapMessages(messages []zeroruntime.Message) (*geminiContent, []geminiContent, error) {
+	systemParts := []geminiPart{}
+	contents := []geminiContent{}
+	toolNamesByID := make(map[string]string)
+
+	for _, message := range messages {
+		content := message.Content
+		hasContent := strings.TrimSpace(content) != ""
+		switch message.Role {
+		case zeroruntime.MessageRoleSystem:
+			if hasContent {
+				systemParts = append(systemParts, geminiPart{Text: content})
+			}
+		case zeroruntime.MessageRoleTool:
+			if message.ToolCallID == "" {
+				return nil, nil, errors.New("Zero Gemini provider requires toolCallId on tool result messages")
+			}
+			name := toolNamesByID[message.ToolCallID]
+			if name == "" {
+				name = message.ToolCallID
+			}
+			appendUserParts(&contents, []geminiPart{{
+				FunctionResponse: &geminiFunctionResponse{
+					ID:       message.ToolCallID,
+					Name:     name,
+					Response: map[string]interface{}{"result": content},
+				},
+			}})
+		case zeroruntime.MessageRoleAssistant:
+			parts := []geminiPart{}
+			if hasContent {
+				parts = append(parts, geminiPart{Text: content})
+			}
+			for _, toolCall := range message.ToolCalls {
+				args, err := parseToolArguments(toolCall.Arguments, toolCall.Name)
+				if err != nil {
+					return nil, nil, err
+				}
+				toolNamesByID[toolCall.ID] = toolCall.Name
+				parts = append(parts, geminiPart{FunctionCall: &geminiFunctionCall{
+					ID:   toolCall.ID,
+					Name: toolCall.Name,
+					Args: args,
+				}})
+			}
+			if len(parts) > 0 {
+				contents = append(contents, geminiContent{Role: "model", Parts: parts})
+			}
+		default:
+			if hasContent {
+				appendUserParts(&contents, []geminiPart{{Text: content}})
+			}
+		}
+	}
+	var systemInstruction *geminiContent
+	if len(systemParts) > 0 {
+		systemInstruction = &geminiContent{Role: "system", Parts: systemParts}
+	}
+	return systemInstruction, contents, nil
+}
+
+func appendUserParts(contents *[]geminiContent, parts []geminiPart) {
+	if len(*contents) > 0 && (*contents)[len(*contents)-1].Role == "user" {
+		(*contents)[len(*contents)-1].Parts = append((*contents)[len(*contents)-1].Parts, parts...)
+		return
+	}
+	*contents = append(*contents, geminiContent{Role: "user", Parts: parts})
+}
+
+func parseToolArguments(argumentsJSON string, toolName string) (map[string]any, error) {
+	if strings.TrimSpace(argumentsJSON) == "" {
+		return map[string]any{}, nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(argumentsJSON), &parsed); err != nil {
+		return nil, fmt.Errorf("Zero Gemini provider could not parse tool arguments for %s as JSON", toolName)
+	}
+	object, ok := parsed.(map[string]any)
+	if !ok || object == nil {
+		return nil, fmt.Errorf("Zero Gemini provider requires tool arguments for %s to be a JSON object", toolName)
+	}
+	return object, nil
+}
+
+func normalizeFunctionCallArgs(value any, toolName string) (map[string]any, error) {
+	if value == nil {
+		return map[string]any{}, nil
+	}
+	object, ok := value.(map[string]any)
+	if !ok || object == nil {
+		return nil, fmt.Errorf("Zero Gemini provider requires streamed tool arguments for %s to be a JSON object", toolName)
+	}
+	return object, nil
+}
+
+func parseErrorMessage(body []byte) string {
+	var parsed struct {
+		Error   apiError `json:"error"`
+		Message string   `json:"message"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return firstNonEmpty(parsed.Error.Message, parsed.Message)
+}
+
+func (provider *Provider) streamURL() string {
+	return provider.baseURL + "/v1beta/models/" + url.PathEscape(provider.model) + ":streamGenerateContent?alt=sse"
+}
+
+func (provider *Provider) classifiedError(statusCode int, message string) string {
+	return providerio.ClassifiedError(statusCode, message, provider.apiKey)
+}
+
+func (provider *Provider) redact(message string) string {
+	return providerio.Redact(message, provider.apiKey)
+}
+
+func normalizeModel(model string) string {
+	model = strings.TrimSpace(model)
+	model = strings.TrimPrefix(model, "models/")
+	return strings.TrimSpace(model)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstNonNil(values ...any) any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+type streamState struct {
+	inputTokens        int
+	outputTokens       int
+	reasoningTokens    int
+	hasUsage           bool
+	syntheticToolIndex int
+	done               bool
+}

--- a/internal/providers/gemini/provider_test.go
+++ b/internal/providers/gemini/provider_test.go
@@ -81,8 +81,8 @@ func TestStreamCompletionPostsGenerateContentRequest(t *testing.T) {
 		t.Fatalf("User-Agent = %q, want zero-test", gotUserAgent)
 	}
 	systemInstruction := gotBody["systemInstruction"].(map[string]any)
-	if systemInstruction["role"] != "system" {
-		t.Fatalf("systemInstruction = %#v, want system role", systemInstruction)
+	if _, ok := systemInstruction["role"]; ok {
+		t.Fatalf("systemInstruction = %#v, want omitted role", systemInstruction)
 	}
 	generationConfig := gotBody["generationConfig"].(map[string]any)
 	if generationConfig["maxOutputTokens"] != float64(65_536) {
@@ -209,15 +209,15 @@ func TestStreamCompletionClassifiesHTTPAndPromptBlockErrors(t *testing.T) {
 
 func TestStreamCompletionEmitsStreamErrorObject(t *testing.T) {
 	provider := newTestProviderWithKey(t, "sk-google", func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"error":{"message":"stream failed sk-google","status":"UNAVAILABLE"}}`)
+		writeSSE(w, `{"error":{"code":429,"message":"stream failed sk-google","status":"RESOURCE_EXHAUSTED"}}`)
 	})
 
 	events := collectProviderEvents(t, provider)
 	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
 		t.Fatalf("events = %#v, want one error", events)
 	}
-	if !strings.HasPrefix(events[0].Error, "provider error:") {
-		t.Fatalf("error = %q, want provider error prefix", events[0].Error)
+	if !strings.HasPrefix(events[0].Error, "rate limit error:") {
+		t.Fatalf("error = %q, want rate limit error prefix", events[0].Error)
 	}
 	if strings.Contains(events[0].Error, "sk-google") {
 		t.Fatalf("error leaked token: %q", events[0].Error)

--- a/internal/providers/gemini/provider_test.go
+++ b/internal/providers/gemini/provider_test.go
@@ -1,0 +1,344 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestStreamCompletionPostsGenerateContentRequest(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+	var gotAPIKey string
+	var gotUserAgent string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAPIKey = r.Header.Get("x-goog-api-key")
+		gotUserAgent = r.Header.Get("User-Agent")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":1}}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:    "sk-google",
+		BaseURL:   server.URL + "/",
+		Model:     "models/gemini-2.5-flash",
+		MaxTokens: 65_536,
+		UserAgent: "zero-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "You are Zero."},
+			{Role: zeroruntime.MessageRoleUser, Content: "Read the file."},
+			{
+				Role:    zeroruntime.MessageRoleAssistant,
+				Content: "I will inspect it.",
+				ToolCalls: []zeroruntime.ToolCall{{
+					ID:        "call_1",
+					Name:      "read_file",
+					Arguments: `{"path":"src/index.ts"}`,
+				}},
+			},
+			{Role: zeroruntime.MessageRoleTool, Content: "file contents", ToolCallID: "call_1"},
+			{Role: zeroruntime.MessageRoleUser, Content: "Now grep for Zero."},
+		},
+		Tools: []zeroruntime.ToolDefinition{{
+			Name:        "read_file",
+			Description: "Read a file",
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if gotPath != "/v1beta/models/gemini-2.5-flash:streamGenerateContent" {
+		t.Fatalf("path = %q, want Gemini stream path", gotPath)
+	}
+	if gotQuery != "alt=sse" {
+		t.Fatalf("query = %q, want alt=sse", gotQuery)
+	}
+	if gotAPIKey != "sk-google" {
+		t.Fatalf("x-goog-api-key = %q, want key", gotAPIKey)
+	}
+	if gotUserAgent != "zero-test" {
+		t.Fatalf("User-Agent = %q, want zero-test", gotUserAgent)
+	}
+	systemInstruction := gotBody["systemInstruction"].(map[string]any)
+	if systemInstruction["role"] != "system" {
+		t.Fatalf("systemInstruction = %#v, want system role", systemInstruction)
+	}
+	generationConfig := gotBody["generationConfig"].(map[string]any)
+	if generationConfig["maxOutputTokens"] != float64(65_536) {
+		t.Fatalf("maxOutputTokens = %#v, want 65536", generationConfig["maxOutputTokens"])
+	}
+	contents := gotBody["contents"].([]any)
+	if len(contents) != 3 {
+		t.Fatalf("contents = %#v, want user, model, merged user", contents)
+	}
+	modelTurn := contents[1].(map[string]any)
+	modelParts := modelTurn["parts"].([]any)
+	functionCall := modelParts[1].(map[string]any)["functionCall"].(map[string]any)
+	if functionCall["id"] != "call_1" || functionCall["name"] != "read_file" {
+		t.Fatalf("unexpected functionCall: %#v", functionCall)
+	}
+	args := functionCall["args"].(map[string]any)
+	if args["path"] != "src/index.ts" {
+		t.Fatalf("functionCall args = %#v, want path", args)
+	}
+	mergedUserParts := contents[2].(map[string]any)["parts"].([]any)
+	if mergedUserParts[0].(map[string]any)["functionResponse"].(map[string]any)["name"] != "read_file" {
+		t.Fatalf("unexpected functionResponse: %#v", mergedUserParts[0])
+	}
+	if mergedUserParts[1].(map[string]any)["text"] != "Now grep for Zero." {
+		t.Fatalf("user text after tool result was not merged: %#v", mergedUserParts)
+	}
+	tools := gotBody["tools"].([]any)
+	declarations := tools[0].(map[string]any)["functionDeclarations"].([]any)
+	if declarations[0].(map[string]any)["name"] != "read_file" {
+		t.Fatalf("unexpected tool declarations: %#v", declarations)
+	}
+}
+
+func TestStreamCompletionEmitsTextUsageAndReasoningTokens(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}`)
+		writeSSE(w, `{"candidates":[{"content":{"parts":[{"text":" Zero"}]}}],"usageMetadata":{"promptTokenCount":25,"candidatesTokenCount":15,"thoughtsTokenCount":3}}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	want := []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "Hello"},
+		{Type: zeroruntime.StreamEventText, Content: " Zero"},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 25, OutputTokens: 15, PromptTokens: 25, CompletionTokens: 15, ReasoningTokens: 3}},
+		{Type: zeroruntime.StreamEventDone},
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestStreamCompletionEmitsCandidateFunctionCalls(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"parts":[{"functionCall":{"id":"call_1","name":"read_file","args":{"path":"src/index.ts"}}},{"functionCall":{"id":"call_2","name":"grep","args":{"pattern":"Zero"}}}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	want := []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_1", ToolName: "read_file"},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_1", ArgumentsFragment: `{"path":"src/index.ts"}`},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_1"},
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_2", ToolName: "grep"},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_2", ArgumentsFragment: `{"pattern":"Zero"}`},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_2"},
+		{Type: zeroruntime.StreamEventDone},
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestStreamCompletionEmitsTopLevelFunctionCalls(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"functionCalls":[{"id":"call_1","name":"read_file","args":{"path":"README.md"}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	want := []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_1", ToolName: "read_file"},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_1", ArgumentsFragment: `{"path":"README.md"}`},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_1"},
+		{Type: zeroruntime.StreamEventDone},
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestStreamCompletionUsesSyntheticToolIDsWhenMissing(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"functionCalls":[{"name":"grep","args":{"pattern":"Zero"}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	if events[0].ToolCallID != "gemini_tool_1" || events[0].ToolName != "grep" {
+		t.Fatalf("events = %#v, want synthetic tool id", events)
+	}
+}
+
+func TestStreamCompletionClassifiesHTTPAndPromptBlockErrors(t *testing.T) {
+	authProvider := newTestProviderWithKey(t, "sk-google", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"API key not valid"}}`, http.StatusUnauthorized)
+	})
+	stream, err := authProvider.StreamCompletion(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("StreamCompletion returned setup error: %v", err)
+	}
+	events := readAll(stream)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError || !strings.HasPrefix(events[0].Error, "auth error:") {
+		t.Fatalf("events = %#v, want auth error", events)
+	}
+	if strings.Contains(events[0].Error, "sk-google") {
+		t.Fatalf("error leaked token: %q", events[0].Error)
+	}
+
+	blockProvider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"promptFeedback":{"blockReason":"SAFETY","blockReasonMessage":"blocked by policy"}}`)
+	})
+	events = collectProviderEvents(t, blockProvider)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError || !strings.Contains(events[0].Error, "Content blocked: blocked by policy") {
+		t.Fatalf("events = %#v, want content block error", events)
+	}
+}
+
+func TestStreamCompletionEmitsStreamErrorObject(t *testing.T) {
+	provider := newTestProviderWithKey(t, "sk-google", func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"error":{"message":"stream failed sk-google","status":"UNAVAILABLE"}}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
+		t.Fatalf("events = %#v, want one error", events)
+	}
+	if !strings.HasPrefix(events[0].Error, "provider error:") {
+		t.Fatalf("error = %q, want provider error prefix", events[0].Error)
+	}
+	if strings.Contains(events[0].Error, "sk-google") {
+		t.Fatalf("error leaked token: %q", events[0].Error)
+	}
+}
+
+func TestStreamCompletionStopsOnMalformedStreamToolArgs(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"functionCalls":[{"id":"call_1","name":"grep","args":"raw"}]}`)
+		writeSSE(w, `{"candidates":[{"content":{"parts":[{"text":"should not emit"}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
+		t.Fatalf("events = %#v, want one error", events)
+	}
+	if !strings.Contains(events[0].Error, "streamed tool arguments for grep") {
+		t.Fatalf("error = %q, want streamed tool arguments error", events[0].Error)
+	}
+	if len(eventsOfType(events, zeroruntime.StreamEventDone)) != 0 {
+		t.Fatalf("events = %#v, want no done after stream tool arg error", events)
+	}
+}
+
+func TestStreamCompletionRejectsMalformedHistoryBeforeDispatch(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("provider should not dispatch malformed history")
+	})
+
+	_, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleTool, Content: "missing id"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires toolCallId") {
+		t.Fatalf("error = %v, want missing toolCallId", err)
+	}
+
+	_, err = provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "call tool"},
+			{
+				Role:      zeroruntime.MessageRoleAssistant,
+				ToolCalls: []zeroruntime.ToolCall{{ID: "call_1", Name: "read_file", Arguments: `"src/index.ts"`}},
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires tool arguments for read_file to be a JSON object") {
+		t.Fatalf("error = %v, want non-object tool argument error", err)
+	}
+}
+
+func TestNewRequiresModelAndPositiveMaxTokens(t *testing.T) {
+	if _, err := New(Options{}); err == nil {
+		t.Fatal("New without model returned nil error")
+	}
+	if _, err := New(Options{Model: "gemini-test", MaxTokens: -1}); err == nil {
+		t.Fatal("New with negative max tokens returned nil error")
+	}
+}
+
+func newTestProvider(t *testing.T, handler http.HandlerFunc) *Provider {
+	t.Helper()
+	return newTestProviderWithKey(t, "", handler)
+}
+
+func newTestProviderWithKey(t *testing.T, apiKey string, handler http.HandlerFunc) *Provider {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	provider, err := New(Options{
+		APIKey:  apiKey,
+		BaseURL: server.URL,
+		Model:   "gemini-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	return provider
+}
+
+func collectProviderEvents(t *testing.T, provider *Provider) []zeroruntime.StreamEvent {
+	t.Helper()
+	stream, err := provider.StreamCompletion(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("StreamCompletion returned setup error: %v", err)
+	}
+	return readAll(stream)
+}
+
+func validRequest() zeroruntime.CompletionRequest {
+	return zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+	}
+}
+
+func readAll(stream <-chan zeroruntime.StreamEvent) []zeroruntime.StreamEvent {
+	events := []zeroruntime.StreamEvent{}
+	for event := range stream {
+		events = append(events, event)
+	}
+	return events
+}
+
+func drain(stream <-chan zeroruntime.StreamEvent) {
+	for range stream {
+	}
+}
+
+func writeSSE(w http.ResponseWriter, payload string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	_, _ = w.Write([]byte("data: " + payload + "\n\n"))
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func eventsOfType(events []zeroruntime.StreamEvent, eventType zeroruntime.StreamEventType) []zeroruntime.StreamEvent {
+	matching := []zeroruntime.StreamEvent{}
+	for _, event := range events {
+		if event.Type == eventType {
+			matching = append(matching, event)
+		}
+	}
+	return matching
+}

--- a/internal/providers/gemini/types.go
+++ b/internal/providers/gemini/types.go
@@ -1,0 +1,93 @@
+package gemini
+
+type generateContentRequest struct {
+	SystemInstruction *geminiContent    `json:"systemInstruction,omitempty"`
+	Contents          []geminiContent   `json:"contents"`
+	GenerationConfig  generationConfig  `json:"generationConfig"`
+	Tools             []geminiToolGroup `json:"tools,omitempty"`
+}
+
+type generationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text             string                  `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	ID   string         `json:"id,omitempty"`
+	Name string         `json:"name"`
+	Args map[string]any `json:"args,omitempty"`
+}
+
+type geminiFunctionResponse struct {
+	ID       string                 `json:"id,omitempty"`
+	Name     string                 `json:"name"`
+	Response map[string]interface{} `json:"response"`
+}
+
+type geminiToolGroup struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations"`
+}
+
+type geminiFunctionDeclaration struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+type streamPayload struct {
+	Candidates     []candidate     `json:"candidates"`
+	FunctionCalls  []functionCall  `json:"functionCalls"`
+	PromptFeedback *promptFeedback `json:"promptFeedback"`
+	UsageMetadata  *usageMetadata  `json:"usageMetadata"`
+	Error          *apiError       `json:"error"`
+}
+
+type candidate struct {
+	Content      *candidateContent `json:"content"`
+	FinishReason string            `json:"finishReason"`
+}
+
+type candidateContent struct {
+	Role  string       `json:"role"`
+	Parts []streamPart `json:"parts"`
+}
+
+type streamPart struct {
+	Text         string        `json:"text"`
+	FunctionCall *functionCall `json:"functionCall"`
+}
+
+type functionCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Args      any    `json:"args"`
+	Arguments any    `json:"arguments"`
+}
+
+type promptFeedback struct {
+	BlockReason        string `json:"blockReason"`
+	BlockReasonMessage string `json:"blockReasonMessage"`
+}
+
+type usageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+}
+
+type apiError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status"`
+}

--- a/internal/providers/gemini/types.go
+++ b/internal/providers/gemini/types.go
@@ -12,7 +12,7 @@ type generationConfig struct {
 }
 
 type geminiContent struct {
-	Role  string       `json:"role"`
+	Role  string       `json:"role,omitempty"`
 	Parts []geminiPart `json:"parts"`
 }
 

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -1,0 +1,132 @@
+package providerio
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+const maxSSELineBytes = 16 * 1024 * 1024
+
+// NormalizeBaseURL trims trailing slashes and validates an HTTP API base URL.
+func NormalizeBaseURL(baseURL string, defaultBaseURL string, label string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	if _, err := url.ParseRequestURI(baseURL); err != nil {
+		return "", fmt.Errorf("invalid %s base URL: %w", label, err)
+	}
+	return baseURL, nil
+}
+
+// HTTPClient returns the configured client or the process default.
+func HTTPClient(client *http.Client) *http.Client {
+	if client != nil {
+		return client
+	}
+	return http.DefaultClient
+}
+
+// SendEvent writes a provider event without blocking cancellation cleanup.
+func SendEvent(ctx context.Context, events chan<- zeroruntime.StreamEvent, event zeroruntime.StreamEvent) {
+	select {
+	case <-ctx.Done():
+		if event.Type == zeroruntime.StreamEventError {
+			select {
+			case events <- event:
+			default:
+			}
+		}
+	case events <- event:
+	}
+}
+
+// ScanSSEData parses Server-Sent Event data fields from a streaming response.
+func ScanSSEData(reader io.Reader, handle func(data string) bool) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 4096), maxSSELineBytes)
+
+	dataLines := []string{}
+	flush := func() bool {
+		if len(dataLines) == 0 {
+			return true
+		}
+		data := strings.TrimSpace(strings.Join(dataLines, "\n"))
+		dataLines = dataLines[:0]
+		if data == "" || data == "[DONE]" {
+			return true
+		}
+		return handle(data)
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r")
+		if line == "" {
+			if !flush() {
+				return nil
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimLeft(strings.TrimPrefix(line, "data:"), " \t"))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	flush()
+	return nil
+}
+
+// ClassifiedError normalizes provider HTTP/stream errors and redacts secrets.
+func ClassifiedError(statusCode int, message string, apiKey string) string {
+	prefix := "provider error: "
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		prefix = "auth error: "
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable, 529:
+		prefix = "rate limit error: "
+	default:
+		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+			prefix = "provider request error: "
+		}
+	}
+	return Redact(prefix+message, apiKey)
+}
+
+// Redact removes known API-key and bearer-token forms from provider messages.
+func Redact(message string, apiKey string) string {
+	if apiKey != "" {
+		message = strings.ReplaceAll(message, apiKey, "[REDACTED]")
+	}
+	words := strings.Fields(message)
+	for index := 0; index < len(words)-1; index++ {
+		if strings.EqualFold(strings.TrimRight(words[index], ":"), "Bearer") {
+			words[index] = "authorization"
+			words[index+1] = "[REDACTED]"
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// PositiveOrDefault validates optional max token settings.
+func PositiveOrDefault(value int, fallback int, label string) (int, error) {
+	if value == 0 {
+		return fallback, nil
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("%s must be a positive integer", label)
+	}
+	return value, nil
+}


### PR DESCRIPTION
## Summary

Adds the M1 Go provider-runtime slice as one cohesive backend PR:

- Extends Go provider config to accept Anthropic and Google provider kinds, official default base URLs, and environment fallback profiles for Anthropic/Gemini/Google credentials and models.
- Adds shared provider I/O helpers for SSE parsing, event delivery, base URL normalization, max-token validation, and secret-redacted error classification.
- Adds a Go Anthropic Messages API streaming provider with system prompt mapping, tool-use/tool-result history mapping, partial JSON tool input streaming, normalized usage events, EOF cleanup, and mocked HTTP/SSE tests.
- Adds a Go Gemini streamGenerateContent provider with system instruction mapping, user/model/tool history mapping, function call/response support, thinking token usage normalization, synthetic tool IDs, prompt-block handling, and mocked HTTP/SSE tests.
- Wires the Go provider factory to the model registry so Zero model IDs/aliases resolve to provider API model names, output ceilings, and provider compatibility checks before constructing adapters.

## Validation

- `go test ./...`
- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`
- `bun run smoke:build`
- `bun run build:go`
- `bun run smoke:go`
- `./zero --help`
- `git diff --check`
- `git diff --check origin/main..HEAD`

## Notes

- Diff size: 12 files, 2,215 insertions, 19 deletions.
- Commit layout is split by layer: config, shared provider I/O, Anthropic, Gemini, factory wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic and Google Gemini providers and streaming completions
  * Unified provider configuration and base-URL/model handling across providers
  * Shared provider I/O utilities for streaming, error classification, and redaction

* **Tests**
  * Expanded test coverage for provider resolution, request payloads, streaming behavior, error handling, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->