### PR TITLE
[codex] add Go observability backend commands

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -17,10 +19,12 @@ import (
 var version = "dev"
 
 type appDeps struct {
-	getwd         func() (string, error)
-	resolveConfig func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
-	newProvider   func(config.ProviderProfile) (zeroruntime.Provider, error)
-	runTUI        func(context.Context, tui.Options) int
+	getwd           func() (string, error)
+	resolveConfig   func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
+	newProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
+	newSessionStore func() *sessions.Store
+	runTUI          func(context.Context, tui.Options) int
+	now             func() time.Time
 }
 
 // Run executes the minimal Go CLI surface. It returns an exit code so tests can
@@ -43,7 +47,11 @@ func defaultAppDeps() appDeps {
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
 			return providers.New(profile, providers.Options{UserAgent: userAgent()})
 		},
+		newSessionStore: func() *sessions.Store {
+			return sessions.NewStore(sessions.StoreOptions{})
+		},
 		runTUI: tui.Run,
+		now:    time.Now,
 	}
 }
 
@@ -77,6 +85,10 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runExec(execArgs, stdout, stderr, deps)
 	case "exec":
 		return runExec(args[1:], stdout, stderr, deps)
+	case "doctor":
+		return runDoctor(args[1:], stdout, stderr, deps)
+	case "search", "find":
+		return runSearch(args[1:], stdout, stderr, deps)
 	default:
 		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
 			return 1
@@ -99,8 +111,14 @@ func fillAppDeps(deps appDeps) appDeps {
 	if deps.newProvider == nil {
 		deps.newProvider = defaults.newProvider
 	}
+	if deps.newSessionStore == nil {
+		deps.newSessionStore = defaults.newSessionStore
+	}
 	if deps.runTUI == nil {
 		deps.runTUI = defaults.runTUI
+	}
+	if deps.now == nil {
+		deps.now = defaults.now
 	}
 	return deps
 }
@@ -168,6 +186,8 @@ Usage:
 
 Commands:
   exec       Run a one-shot prompt through the Go agent runtime
+  doctor     Run backend health checks for config and provider setup
+  search     Search persisted local Zero session events
   help       Show this help
   version    Print version
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -188,6 +188,7 @@ Commands:
   exec       Run a one-shot prompt through the Go agent runtime
   doctor     Run backend health checks for config and provider setup
   search     Search persisted local Zero session events
+  find       Alias for search
   help       Show this help
   version    Print version
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -206,6 +206,7 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"exec"},
 		{"doctor"},
 		{"search"},
+		{"find"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -204,6 +204,8 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"version"},
 		{"wat"},
 		{"exec"},
+		{"doctor"},
+		{"search"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
@@ -242,6 +244,8 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"Usage:",
 		"zero [command]",
 		"exec",
+		"doctor",
+		"search",
 		"--version",
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/cli/observability.go
+++ b/internal/cli/observability.go
@@ -101,7 +101,7 @@ func runSearch(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
 	if options.json {
-		if err := writePrettyJSON(stdout, result); err != nil {
+		if err := writePrettyJSON(stdout, zsearch.RedactResult(result)); err != nil {
 			return exitCrash
 		}
 		return exitSuccess

--- a/internal/cli/observability.go
+++ b/internal/cli/observability.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/doctor"
+	zsearch "github.com/Gitlawb/zero/internal/search"
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+type doctorOptions struct {
+	json         bool
+	connectivity bool
+}
+
+func runDoctor(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseDoctorArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeDoctorHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
+	}
+
+	report := doctor.Run(doctor.Options{
+		Now:          deps.now,
+		Runtime:      "go",
+		Provider:     resolved.Provider,
+		Connectivity: options.connectivity,
+	})
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+		if !report.OK {
+			return exitProvider
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, doctor.Format(report)); err != nil {
+		return exitCrash
+	}
+	if !report.OK {
+		return exitProvider
+	}
+	return exitSuccess
+}
+
+type searchOptions struct {
+	query        string
+	json         bool
+	limit        int
+	contextChars int
+	sessionID    string
+	eventType    sessions.EventType
+	reindex      bool
+}
+
+func runSearch(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseSearchArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSearchHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if strings.TrimSpace(options.query) == "" {
+		return writeExecUsageError(stderr, "search query required. Use `zero search <query>`.")
+	}
+
+	result, err := zsearch.Sessions(options.query, zsearch.Options{
+		Store:        deps.newSessionStore(),
+		Limit:        options.limit,
+		ContextChars: options.contextChars,
+		SessionID:    options.sessionID,
+		Type:         options.eventType,
+		Reindex:      options.reindex,
+		Now:          deps.now,
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, result); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, zsearch.FormatResult(result)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseDoctorArgs(args []string) (doctorOptions, bool, error) {
+	options := doctorOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		case "--connectivity":
+			options.connectivity = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown doctor flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parseSearchArgs(args []string) (searchOptions, bool, error) {
+	options := searchOptions{}
+	queryParts := []string{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--reindex":
+			options.reindex = true
+		case arg == "--limit":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			limit, err := parsePositiveOrZeroInt(value, "--limit")
+			if err != nil {
+				return options, false, err
+			}
+			options.limit = limit
+			index = next
+		case strings.HasPrefix(arg, "--limit="):
+			limit, err := parsePositiveOrZeroInt(strings.TrimSpace(strings.TrimPrefix(arg, "--limit=")), "--limit")
+			if err != nil {
+				return options, false, err
+			}
+			options.limit = limit
+		case arg == "--context-chars":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			contextChars, err := parsePositiveOrZeroInt(value, "--context-chars")
+			if err != nil {
+				return options, false, err
+			}
+			options.contextChars = contextChars
+			index = next
+		case strings.HasPrefix(arg, "--context-chars="):
+			contextChars, err := parsePositiveOrZeroInt(strings.TrimSpace(strings.TrimPrefix(arg, "--context-chars=")), "--context-chars")
+			if err != nil {
+				return options, false, err
+			}
+			options.contextChars = contextChars
+		case arg == "--session-id":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.sessionID = value
+			index = next
+		case strings.HasPrefix(arg, "--session-id="):
+			options.sessionID = strings.TrimSpace(strings.TrimPrefix(arg, "--session-id="))
+		case arg == "--type":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.eventType = sessions.EventType(value)
+			index = next
+		case strings.HasPrefix(arg, "--type="):
+			options.eventType = sessions.EventType(strings.TrimSpace(strings.TrimPrefix(arg, "--type=")))
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown search flag %q", arg)}
+		default:
+			queryParts = append(queryParts, arg)
+		}
+	}
+	options.query = strings.TrimSpace(strings.Join(queryParts, " "))
+	return options, false, nil
+}
+
+func parsePositiveOrZeroInt(value string, label string) (int, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, execUsageError{fmt.Sprintf("%s requires a value", label)}
+	}
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil || parsed < 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid %s %q. Expected a non-negative integer.", label, value)}
+	}
+	return parsed, nil
+}
+
+func writePrettyJSON(w io.Writer, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeDoctorHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero doctor [flags]
+
+Runs Go backend health checks for config and provider setup.
+
+Flags:
+      --json            Print JSON report
+      --connectivity    Include provider endpoint connectivity probe when available
+  -h, --help            Show this help
+`)
+	return err
+}
+
+func writeSearchHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero search [flags] <query>
+
+Searches persisted local Zero session events.
+
+Flags:
+      --json                 Print JSON results
+      --limit <number>       Maximum hits to return
+      --context-chars <n>    Characters of context around each match
+      --session-id <id>      Search one session
+      --type <event-type>    Filter by session event type
+      --reindex              Rebuild cached search indexes
+  -h, --help                 Show this help
+`)
+	return err
+}

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+func TestRunDoctorFormatsRedactedProviderDiagnostics(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+
+	exitCode := runWithDeps([]string{"doctor"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.ResolvedConfig{
+				Provider: config.ProviderProfile{
+					Name:         "openai",
+					ProviderKind: config.ProviderKindOpenAI,
+					BaseURL:      config.OpenAIBaseURL,
+					APIKey:       "sk-proj-secret1234567890",
+					Model:        "gpt-4.1",
+				},
+			}, nil
+		},
+		now: fixedCLITime("2026-06-04T16:00:00Z"),
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"Zero doctor report", "Overall: pass", "[pass] provider.config", "[warn] provider.connectivity"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected doctor output to contain %q, got %q", want, output)
+		}
+	}
+	if strings.Contains(output, "sk-proj-secret") {
+		t.Fatalf("doctor output leaked secret: %q", output)
+	}
+}
+
+func TestRunDoctorJSONReturnsFailureForMissingProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"doctor", "--json"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
+		now: fixedCLITime("2026-06-04T16:30:00Z"),
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d", exitProvider, exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	var report struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("doctor JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.OK {
+		t.Fatalf("expected report ok=false, got %#v", report)
+	}
+}
+
+func TestRunSearchFindsSessionEventsFromInjectedStore(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T17:00:00Z")})
+	session, err := store.Create(sessions.CreateInput{SessionID: "cli_search", Title: "CLI Search", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventMessage, Payload: map[string]string{"content": "needle with token=sk-secret1234567890"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"search", "needle", "--limit", "3"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Found 1 local session event") || !strings.Contains(output, "cli_search") {
+		t.Fatalf("unexpected search output: %q", output)
+	}
+	if strings.Contains(output, "sk-secret") {
+		t.Fatalf("search output leaked secret: %q", output)
+	}
+}
+
+func TestRunSearchJSONAndValidation(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T17:30:00Z")})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"search", "--json", "missing"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var result struct {
+		Query     string `json:"query"`
+		TotalHits int    `json:"totalHits"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("search JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if result.Query != "missing" || result.TotalHits != 0 {
+		t.Fatalf("unexpected search result: %#v", result)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"search"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "search query required") {
+		t.Fatalf("expected search validation error, got %q", stderr.String())
+	}
+}
+
+func fixedCLITime(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -157,6 +157,60 @@ func TestRunSearchJSONAndValidation(t *testing.T) {
 	}
 }
 
+func TestRunSearchJSONRedactsQueryAndSessionMetadata(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T18:00:00Z")})
+	querySecret := "sk-proj-querysecret1234567890"
+	metadataSecret := "sk-proj-metadatasecret1234567890"
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"search", "--json", querySecret}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), querySecret) {
+		t.Fatalf("search JSON leaked raw query secret: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "[REDACTED]") {
+		t.Fatalf("expected redacted query marker in JSON output: %q", stdout.String())
+	}
+
+	session, err := store.Create(sessions.CreateInput{
+		SessionID: "json_metadata_secret",
+		Title:     "Title " + metadataSecret,
+		Cwd:       "/repo/" + metadataSecret,
+		ModelID:   "model-" + metadataSecret,
+		Provider:  "provider-token=" + metadataSecret,
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventMessage, Payload: map[string]string{"content": "metadata needle"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"search", "--json", "metadata", "needle"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), metadataSecret) {
+		t.Fatalf("search JSON leaked session metadata secret: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "[REDACTED]") {
+		t.Fatalf("expected redacted metadata marker in JSON output: %q", stdout.String())
+	}
+}
+
 func fixedCLITime(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,231 @@
+package doctor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+type Status string
+
+const (
+	StatusPass Status = "pass"
+	StatusWarn Status = "warn"
+	StatusFail Status = "fail"
+)
+
+type Check struct {
+	ID      string         `json:"id"`
+	Label   string         `json:"label"`
+	Status  Status         `json:"status"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+type Report struct {
+	GeneratedAt string  `json:"generatedAt"`
+	OK          bool    `json:"ok"`
+	Checks      []Check `json:"checks"`
+}
+
+type Options struct {
+	Now           func() time.Time
+	Runtime       string
+	UserConfig    string
+	ProjectConfig string
+	Provider      config.ProviderProfile
+	Connectivity  bool
+}
+
+func Run(options Options) Report {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	checks := []Check{
+		runtimeCheck(options.Runtime),
+		configFilesCheck(options.UserConfig, options.ProjectConfig),
+	}
+	providerCheck := providerConfigCheck(options.Provider)
+	checks = append(checks, providerCheck)
+	modelCheck := providerModelCheck(options.Provider)
+	checks = append(checks, modelCheck)
+	checks = append(checks, connectivityCheck(options.Provider, options.Connectivity, modelCheck.Status))
+
+	report := Report{
+		GeneratedAt: now().UTC().Format(time.RFC3339),
+		OK:          true,
+		Checks:      checks,
+	}
+	for _, check := range checks {
+		if check.Status == StatusFail {
+			report.OK = false
+			break
+		}
+	}
+	return report
+}
+
+func (report Report) Check(id string) *Check {
+	for index := range report.Checks {
+		if report.Checks[index].ID == id {
+			return &report.Checks[index]
+		}
+	}
+	return nil
+}
+
+func Format(report Report) string {
+	lines := []string{
+		fmt.Sprintf("Zero doctor report (%s)", redaction.RedactString(report.GeneratedAt, redaction.Options{})),
+		fmt.Sprintf("Overall: %s", passFail(report.OK)),
+	}
+	for _, check := range report.Checks {
+		lines = append(lines, fmt.Sprintf("[%s] %s - %s", check.Status, redaction.RedactString(check.ID, redaction.Options{}), redaction.RedactString(check.Message, redaction.Options{})))
+		if details := formatDetails(check.Details); details != "" {
+			lines = append(lines, "  "+details)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func runtimeCheck(runtime string) Check {
+	runtime = strings.TrimSpace(runtime)
+	if runtime == "" {
+		runtime = "go"
+	}
+	return check("runtime.go", "Go runtime", StatusPass, fmt.Sprintf("Zero Go runtime is available (%s).", runtime), map[string]any{"runtime": runtime})
+}
+
+func configFilesCheck(userPath string, projectPath string) Check {
+	details := map[string]any{}
+	if strings.TrimSpace(userPath) != "" {
+		details["userConfigPath"] = userPath
+	}
+	if strings.TrimSpace(projectPath) != "" {
+		details["projectConfigPath"] = projectPath
+	}
+	if len(details) == 0 {
+		return check("config.files", "Config files", StatusWarn, "No explicit Zero config files were inspected.", nil)
+	}
+	return check("config.files", "Config files", StatusPass, "Zero config file inputs are available for inspection.", details)
+}
+
+func providerConfigCheck(profile config.ProviderProfile) Check {
+	if profile == (config.ProviderProfile{}) {
+		return check("provider.config", "Provider config", StatusFail, "No LLM provider is configured.", map[string]any{"help": "Set a provider in config or environment."})
+	}
+	return check("provider.config", "Provider config", StatusPass, fmt.Sprintf("Provider config loaded for %s.", providerName(profile)), map[string]any{
+		"name":     profile.Name,
+		"provider": profile.ProviderKind,
+		"baseURL":  profile.BaseURL,
+		"model":    profile.Model,
+		"apiKey":   profile.APIKey,
+	})
+}
+
+func providerModelCheck(profile config.ProviderProfile) Check {
+	if profile == (config.ProviderProfile{}) {
+		return check("provider.model", "Provider model", StatusWarn, "Model validity was skipped because provider config is unavailable.", nil)
+	}
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return check("provider.model", "Provider model", StatusFail, "Model registry could not be loaded: "+err.Error(), nil)
+	}
+	model, err := registry.Require(profile.Model)
+	if err != nil {
+		return check("provider.model", "Provider model", StatusFail, "Provider model is invalid: "+err.Error(), map[string]any{"model": profile.Model})
+	}
+	if !model.AllowsProvider(toModelProvider(profile)) {
+		return check("provider.model", "Provider model", StatusFail, fmt.Sprintf("Model %s is not available for provider %s.", model.ID, providerName(profile)), map[string]any{"model": model.ID, "provider": providerName(profile)})
+	}
+	return check("provider.model", "Provider model", StatusPass, fmt.Sprintf("Model %s resolves to %s.", model.ID, model.Provider), map[string]any{
+		"modelId":      model.ID,
+		"apiModel":     model.APIModel,
+		"provider":     model.Provider,
+		"capabilities": model.Capabilities,
+	})
+}
+
+func connectivityCheck(profile config.ProviderProfile, enabled bool, modelStatus Status) Check {
+	if profile == (config.ProviderProfile{}) || modelStatus == StatusFail {
+		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity check was skipped because provider runtime did not resolve.", nil)
+	}
+	if !enabled {
+		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probe skipped. Run `zero doctor --connectivity` to probe the provider endpoint.", map[string]any{"baseURL": profile.BaseURL})
+	}
+	return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probing is not wired in the Go doctor backend yet.", map[string]any{"baseURL": profile.BaseURL})
+}
+
+func check(id string, label string, status Status, message string, details map[string]any) Check {
+	redacted := redaction.RedactValue(map[string]any{
+		"id":      id,
+		"label":   label,
+		"status":  string(status),
+		"message": message,
+		"details": details,
+	}, redaction.Options{}).(map[string]any)
+	out := Check{
+		ID:      redacted["id"].(string),
+		Label:   redacted["label"].(string),
+		Status:  Status(redacted["status"].(string)),
+		Message: redacted["message"].(string),
+	}
+	if detailsValue, ok := redacted["details"].(map[string]any); ok && len(detailsValue) > 0 {
+		out.Details = detailsValue
+	}
+	return out
+}
+
+func providerName(profile config.ProviderProfile) string {
+	if strings.TrimSpace(profile.Name) != "" {
+		return strings.TrimSpace(profile.Name)
+	}
+	if strings.TrimSpace(string(profile.ProviderKind)) != "" {
+		return strings.TrimSpace(string(profile.ProviderKind))
+	}
+	return strings.TrimSpace(profile.Provider)
+}
+
+func toModelProvider(profile config.ProviderProfile) modelregistry.ProviderKind {
+	switch profile.ProviderKind {
+	case config.ProviderKindAnthropic:
+		return modelregistry.ProviderAnthropic
+	case config.ProviderKindGoogle:
+		return modelregistry.ProviderGoogle
+	case config.ProviderKindOpenAICompatible:
+		return modelregistry.ProviderOpenAICompatible
+	default:
+		return modelregistry.ProviderOpenAI
+	}
+}
+
+func formatDetails(details map[string]any) string {
+	if len(details) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(details))
+	for key, value := range details {
+		_ = value
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(details))
+	for _, key := range keys {
+		value := details[key]
+		parts = append(parts, fmt.Sprintf("%s: %v", redaction.RedactString(key, redaction.Options{}), redaction.RedactValue(value, redaction.Options{})))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func passFail(ok bool) string {
+	if ok {
+		return "pass"
+	}
+	return "fail"
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -139,6 +139,9 @@ func providerModelCheck(profile config.ProviderProfile) Check {
 	}
 	model, err := registry.Require(profile.Model)
 	if err != nil {
+		if profile.ProviderKind == config.ProviderKindOpenAICompatible {
+			return check("provider.model", "Provider model", StatusWarn, "Custom OpenAI-compatible model was not found in the Zero registry; runtime will pass it through to the configured provider.", map[string]any{"model": profile.Model, "provider": providerName(profile)})
+		}
 		return check("provider.model", "Provider model", StatusFail, "Provider model is invalid: "+err.Error(), map[string]any{"model": profile.Model})
 	}
 	if !model.AllowsProvider(toModelProvider(profile)) {
@@ -210,8 +213,7 @@ func formatDetails(details map[string]any) string {
 		return ""
 	}
 	keys := make([]string, 0, len(details))
-	for key, value := range details {
-		_ = value
+	for key := range details {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -64,6 +64,26 @@ func TestRunReportFailsInvalidModelAndMissingProvider(t *testing.T) {
 	}
 }
 
+func TestRunReportWarnsForUnknownOpenAICompatibleModel(t *testing.T) {
+	report := Run(Options{
+		Now:     fixedDoctorClock("2026-06-04T15:45:00Z"),
+		Runtime: "go",
+		Provider: config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "http://127.0.0.1:11434/v1",
+			Model:        "local-custom-model",
+		},
+	})
+
+	if !report.OK {
+		t.Fatalf("unknown custom model should warn, not fail: %#v", report)
+	}
+	if check := report.Check("provider.model"); check == nil || check.Status != StatusWarn || !strings.Contains(check.Message, "pass it through") {
+		t.Fatalf("expected custom model warning: %#v", report.Checks)
+	}
+}
+
 func fixedDoctorClock(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,73 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestRunReportRedactsProviderSecretsAndWarnsWithoutConnectivity(t *testing.T) {
+	report := Run(Options{
+		Now:        fixedDoctorClock("2026-06-04T15:00:00Z"),
+		Runtime:    "go",
+		UserConfig: "missing",
+		Provider: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      config.OpenAIBaseURL,
+			APIKey:       "sk-proj-secret1234567890",
+			Model:        "gpt-4.1",
+		},
+	})
+
+	if !report.OK {
+		t.Fatalf("report should be ok when only connectivity is skipped: %#v", report)
+	}
+	if got := report.Check("provider.config"); got == nil || got.Status != StatusPass {
+		t.Fatalf("provider config check missing/pass expected: %#v", report.Checks)
+	}
+	formatted := Format(report)
+	if strings.Contains(formatted, "sk-proj-secret") {
+		t.Fatalf("formatted report leaked provider secret: %q", formatted)
+	}
+	if !strings.Contains(formatted, "[warn] provider.connectivity") {
+		t.Fatalf("expected skipped connectivity warning: %q", formatted)
+	}
+}
+
+func TestRunReportFailsInvalidModelAndMissingProvider(t *testing.T) {
+	missing := Run(Options{Now: fixedDoctorClock("2026-06-04T15:30:00Z"), Runtime: "go"})
+	if missing.OK {
+		t.Fatalf("missing provider should fail: %#v", missing)
+	}
+	if check := missing.Check("provider.config"); check == nil || check.Status != StatusFail {
+		t.Fatalf("expected provider config failure: %#v", missing.Checks)
+	}
+
+	invalid := Run(Options{
+		Now:     fixedDoctorClock("2026-06-04T15:30:00Z"),
+		Runtime: "go",
+		Provider: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      config.OpenAIBaseURL,
+			Model:        "not-a-zero-model",
+		},
+	})
+	if invalid.OK {
+		t.Fatalf("invalid model should fail: %#v", invalid)
+	}
+	if check := invalid.Check("provider.model"); check == nil || check.Status != StatusFail || !strings.Contains(check.Message, "unknown Zero model") {
+		t.Fatalf("expected model failure: %#v", invalid.Checks)
+	}
+}
+
+func fixedDoctorClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -1,0 +1,373 @@
+package redaction
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+const (
+	RedactedSecret    = "[REDACTED]"
+	CircularReference = "[Circular]"
+	maxDepthDefault   = 16
+)
+
+type Options struct {
+	Replacement        string
+	ExtraSensitiveKeys []string
+	ExtraSecretValues  []string
+	MaxDepth           int
+}
+
+type RedactedError struct {
+	Name    string         `json:"name"`
+	Message string         `json:"message"`
+	Stack   string         `json:"stack,omitempty"`
+	Fields  map[string]any `json:"fields,omitempty"`
+}
+
+var sensitiveKeys = map[string]struct{}{
+	"access_token":          {},
+	"anthropic_api_key":     {},
+	"api_key":               {},
+	"apikey":                {},
+	"auth_token":            {},
+	"authorization":         {},
+	"aws_secret_access_key": {},
+	"aws_session_token":     {},
+	"bearer":                {},
+	"bearer_token":          {},
+	"client_secret":         {},
+	"cookie":                {},
+	"credential":            {},
+	"credentials":           {},
+	"gemini_api_key":        {},
+	"github_token":          {},
+	"gitlab_token":          {},
+	"google_api_key":        {},
+	"id_token":              {},
+	"jwt":                   {},
+	"npm_token":             {},
+	"oauth_token":           {},
+	"openai_api_key":        {},
+	"passphrase":            {},
+	"password":              {},
+	"private_key":           {},
+	"proxy_authorization":   {},
+	"refresh_token":         {},
+	"secret":                {},
+	"session_token":         {},
+	"set_cookie":            {},
+	"token":                 {},
+	"x_api_key":             {},
+	"zero_api_key":          {},
+}
+
+var textSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bsk-(?:proj-)?[A-Za-z0-9._-]{12,}\b`),
+	regexp.MustCompile(`\bsk-ant-api\d{2}-[A-Za-z0-9._-]{12,}\b`),
+	regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{12,}\b`),
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9_]{12,}\b`),
+	regexp.MustCompile(`\bglpat-[A-Za-z0-9_-]{12,}\b`),
+	regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{12,}\b`),
+	regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{12,}\b`),
+	regexp.MustCompile(`\b(?:AKIA|ASIA)[A-Z0-9]{16}\b`),
+	regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b`),
+}
+
+var (
+	privateKeyPattern = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+	jsonStringPattern = regexp.MustCompile(`("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)"([^"\\]*(?:\\.[^"\\]*)*)"`)
+	assignPattern     = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s&]+))`)
+	headerPattern     = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(bearer|basic)\s+([^\s,;]+)`)
+	secretHeader      = regexp.MustCompile(`(?i)\b(x-api-key|api-key|cookie|set-cookie)\s*:\s*([^\r\n]+)`)
+	queryPattern      = regexp.MustCompile(`([?&])([^=&#\s]+)=([^&#\s]+)`)
+)
+
+func IsSensitiveKey(key string, options Options) bool {
+	normalized := normalizeKey(key)
+	if normalized == "" {
+		return false
+	}
+	if _, ok := sensitiveKeys[normalized]; ok {
+		return true
+	}
+	for _, extra := range options.ExtraSensitiveKeys {
+		if normalizeKey(extra) == normalized {
+			return true
+		}
+	}
+	return false
+}
+
+func RedactString(value string, options Options) string {
+	replacement := replacement(options)
+	redacted := value
+	for _, secret := range options.ExtraSecretValues {
+		if strings.TrimSpace(secret) != "" {
+			redacted = strings.ReplaceAll(redacted, secret, replacement)
+		}
+	}
+
+	redacted = privateKeyPattern.ReplaceAllString(redacted, replacement)
+	redacted = jsonStringPattern.ReplaceAllStringFunc(redacted, func(match string) string {
+		parts := jsonStringPattern.FindStringSubmatch(match)
+		if len(parts) < 3 || !IsSensitiveKey(parts[2], options) {
+			return match
+		}
+		return parts[1] + `"` + replacement + `"`
+	})
+	redacted = assignPattern.ReplaceAllStringFunc(redacted, func(match string) string {
+		parts := assignPattern.FindStringSubmatch(match)
+		if len(parts) < 6 || !IsSensitiveKey(parts[1], options) {
+			return match
+		}
+		if parts[3] != "" {
+			return parts[1] + parts[2] + `"` + replacement + `"`
+		}
+		if parts[4] != "" {
+			return parts[1] + parts[2] + `'` + replacement + `'`
+		}
+		return parts[1] + parts[2] + replacement
+	})
+	redacted = headerPattern.ReplaceAllString(redacted, "$1: $2 "+replacement)
+	redacted = secretHeader.ReplaceAllString(redacted, "$1: "+replacement)
+	redacted = redactURLPasswords(redacted, replacement)
+	redacted = queryPattern.ReplaceAllStringFunc(redacted, func(match string) string {
+		parts := queryPattern.FindStringSubmatch(match)
+		if len(parts) < 4 || !IsSensitiveKey(parts[2], options) {
+			return match
+		}
+		return parts[1] + parts[2] + "=" + replacement
+	})
+	for _, pattern := range textSecretPatterns {
+		redacted = pattern.ReplaceAllString(redacted, replacement)
+	}
+	return redacted
+}
+
+func RedactValue(value any, options Options) any {
+	return redactReflect(reflect.ValueOf(value), redactionContext{
+		options:     options,
+		replacement: replacement(options),
+		maxDepth:    maxDepth(options),
+		seen:        map[uintptr]struct{}{},
+	}, 0)
+}
+
+func RedactError(err error, options Options) RedactedError {
+	if err == nil {
+		return RedactedError{Name: "Error", Message: ""}
+	}
+	redacted := RedactedError{
+		Name:    errorName(err),
+		Message: RedactString(err.Error(), options),
+	}
+	fields := exportedFields(reflect.ValueOf(err), options)
+	if len(fields) > 0 {
+		redacted.Fields = fields
+	}
+	var stackTracer interface{ StackTrace() fmt.Stringer }
+	if errors.As(err, &stackTracer) {
+		redacted.Stack = RedactString(stackTracer.StackTrace().String(), options)
+	}
+	return redacted
+}
+
+func ErrorMessage(err error, options Options) string {
+	return RedactError(err, options).Message
+}
+
+type redactionContext struct {
+	options     Options
+	replacement string
+	maxDepth    int
+	seen        map[uintptr]struct{}
+}
+
+func redactReflect(value reflect.Value, context redactionContext, depth int) any {
+	if !value.IsValid() {
+		return nil
+	}
+	for value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+	if depth >= context.maxDepth {
+		return "[MaxDepth]"
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		return RedactString(value.String(), context.options)
+	case reflect.Bool:
+		return value.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return value.Uint()
+	case reflect.Float32, reflect.Float64:
+		return value.Float()
+	case reflect.Pointer:
+		if value.IsNil() {
+			return nil
+		}
+		ptr := value.Pointer()
+		if _, ok := context.seen[ptr]; ok {
+			return CircularReference
+		}
+		context.seen[ptr] = struct{}{}
+		return redactReflect(value.Elem(), context, depth+1)
+	case reflect.Map:
+		if value.IsNil() {
+			return nil
+		}
+		ptr := value.Pointer()
+		if _, ok := context.seen[ptr]; ok {
+			return CircularReference
+		}
+		context.seen[ptr] = struct{}{}
+		out := make(map[string]any, value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			key := fmt.Sprint(redactReflect(iter.Key(), context, depth+1))
+			if IsSensitiveKey(key, context.options) {
+				out[key] = context.replacement
+				continue
+			}
+			out[key] = redactReflect(iter.Value(), context, depth+1)
+		}
+		return out
+	case reflect.Slice, reflect.Array:
+		out := make([]any, value.Len())
+		for index := 0; index < value.Len(); index++ {
+			out[index] = redactReflect(value.Index(index), context, depth+1)
+		}
+		return out
+	case reflect.Struct:
+		if value.CanInterface() {
+			if err, ok := value.Interface().(error); ok {
+				return RedactError(err, context.options)
+			}
+		}
+		out := make(map[string]any, value.NumField())
+		valueType := value.Type()
+		for index := 0; index < value.NumField(); index++ {
+			field := valueType.Field(index)
+			if field.PkgPath != "" {
+				continue
+			}
+			name := field.Name
+			if tag := field.Tag.Get("json"); tag != "" {
+				name = strings.Split(tag, ",")[0]
+				if name == "-" {
+					continue
+				}
+			}
+			if IsSensitiveKey(name, context.options) {
+				out[name] = context.replacement
+				continue
+			}
+			out[name] = redactReflect(value.Field(index), context, depth+1)
+		}
+		return out
+	default:
+		if value.CanInterface() {
+			return value.Interface()
+		}
+		return fmt.Sprint(value)
+	}
+}
+
+func exportedFields(value reflect.Value, options Options) map[string]any {
+	for value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return nil
+	}
+	fields := map[string]any{}
+	context := redactionContext{
+		options:     options,
+		replacement: replacement(options),
+		maxDepth:    maxDepth(options),
+		seen:        map[uintptr]struct{}{},
+	}
+	valueType := value.Type()
+	for index := 0; index < value.NumField(); index++ {
+		field := valueType.Field(index)
+		if field.PkgPath != "" {
+			continue
+		}
+		name := field.Name
+		if IsSensitiveKey(name, options) {
+			fields[name] = context.replacement
+		} else {
+			fields[name] = redactReflect(value.Field(index), context, 1)
+		}
+	}
+	return fields
+}
+
+func errorName(err error) string {
+	name := reflect.TypeOf(err).String()
+	if name == "" {
+		return "Error"
+	}
+	return name
+}
+
+func replacement(options Options) string {
+	if options.Replacement != "" {
+		return options.Replacement
+	}
+	return RedactedSecret
+}
+
+func maxDepth(options Options) int {
+	if options.MaxDepth > 0 {
+		return options.MaxDepth
+	}
+	return maxDepthDefault
+}
+
+func normalizeKey(key string) string {
+	key = strings.TrimSpace(key)
+	var builder strings.Builder
+	var lastUnderscore bool
+	for _, r := range key {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(unicode.ToLower(r))
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(builder.String(), "_")
+}
+
+func redactURLPasswords(value string, replacement string) string {
+	return regexp.MustCompile(`\b(?:https?|wss?|ftp)://[^\s]+`).ReplaceAllStringFunc(value, func(candidate string) string {
+		parsed, err := url.Parse(candidate)
+		if err != nil || parsed.User == nil {
+			return candidate
+		}
+		if _, hasPassword := parsed.User.Password(); !hasPassword {
+			return candidate
+		}
+		parsed.User = url.UserPassword(parsed.User.Username(), replacement)
+		return parsed.String()
+	})
+}

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -1,0 +1,85 @@
+package redaction
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRedactStringCoversCommonSecretShapes(t *testing.T) {
+	input := strings.Join([]string{
+		`{"apiKey":"sk-proj-abcdefghijklmnopqrstuvwxyz"}`,
+		"authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz123456",
+		"https://zero:super-secret@example.test/path?token=glpat-abcdefghijklmnopqrstuvwxyz",
+		"-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----",
+	}, "\n")
+
+	got := RedactString(input, Options{ExtraSecretValues: []string{"super-secret"}})
+
+	for _, leaked := range []string{
+		"sk-proj-abcdefghijklmnopqrstuvwxyz",
+		"ghp_abcdefghijklmnopqrstuvwxyz123456",
+		"super-secret",
+		"glpat-abcdefghijklmnopqrstuvwxyz",
+		"abc123",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("redacted string leaked %q in %q", leaked, got)
+		}
+	}
+	if count := strings.Count(got, RedactedSecret); count < 5 {
+		t.Fatalf("expected multiple redaction markers, got %d in %q", count, got)
+	}
+}
+
+func TestRedactValueHandlesSensitiveKeysAndCycles(t *testing.T) {
+	type node struct {
+		Name     string
+		Password string
+		Next     *node
+	}
+	root := &node{Name: "root", Password: "open-sesame"}
+	root.Next = root
+
+	got := RedactValue(root, Options{})
+	asMap, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map output, got %T", got)
+	}
+	if asMap["Password"] != RedactedSecret {
+		t.Fatalf("expected sensitive key redacted, got %#v", asMap["Password"])
+	}
+	if asMap["Next"] != CircularReference {
+		t.Fatalf("expected circular reference marker, got %#v", asMap["Next"])
+	}
+}
+
+func TestRedactErrorRedactsMessageStackAndFields(t *testing.T) {
+	err := withFieldsError{
+		err:    errors.New("request failed with api_key=sk-test-secret1234567890"),
+		Token:  "ghp_abcdefghijklmnopqrstuvwxyz123456",
+		Detail: "safe",
+	}
+
+	got := RedactError(err, Options{})
+
+	if strings.Contains(got.Message, "sk-test-secret") {
+		t.Fatalf("message leaked secret: %#v", got)
+	}
+	if got.Fields["Token"] != RedactedSecret {
+		t.Fatalf("token field was not redacted: %#v", got.Fields)
+	}
+	if got.Fields["Detail"] != "safe" {
+		t.Fatalf("non-sensitive field changed: %#v", got.Fields)
+	}
+}
+
+type withFieldsError struct {
+	err    error
+	Token  string
+	Detail string
+}
+
+func (err withFieldsError) Error() string {
+	return err.err.Error()
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -220,6 +221,45 @@ func FormatResult(result Result) string {
 	return strings.Join(lines, "\n")
 }
 
+func RedactResult(result Result) Result {
+	options := redaction.Options{}
+	redacted := result
+	redacted.Query = redaction.RedactString(redacted.Query, options)
+	redacted.NormalizedQuery = redaction.RedactString(redacted.NormalizedQuery, options)
+	redacted.RootDir = redaction.RedactString(redacted.RootDir, options)
+	redacted.Hits = make([]Hit, len(result.Hits))
+	for index, hit := range result.Hits {
+		redacted.Hits[index] = Hit{
+			Session: redactMetadata(hit.Session, options),
+			Event:   redactEventSummary(hit.Event, options),
+			Context: redaction.RedactString(hit.Context, options),
+			Match:   hit.Match,
+		}
+	}
+	return redacted
+}
+
+func redactMetadata(session sessions.Metadata, options redaction.Options) sessions.Metadata {
+	session.SessionID = redaction.RedactString(session.SessionID, options)
+	session.Title = redaction.RedactString(session.Title, options)
+	session.Cwd = redaction.RedactString(session.Cwd, options)
+	session.ModelID = redaction.RedactString(session.ModelID, options)
+	session.Provider = redaction.RedactString(session.Provider, options)
+	session.ParentSessionID = redaction.RedactString(session.ParentSessionID, options)
+	session.ForkedFromEventID = redaction.RedactString(session.ForkedFromEventID, options)
+	session.CreatedAt = redaction.RedactString(session.CreatedAt, options)
+	session.UpdatedAt = redaction.RedactString(session.UpdatedAt, options)
+	session.LastEventType = sessions.EventType(redaction.RedactString(string(session.LastEventType), options))
+	return session
+}
+
+func redactEventSummary(event EventSummary, options redaction.Options) EventSummary {
+	event.ID = redaction.RedactString(event.ID, options)
+	event.Type = sessions.EventType(redaction.RedactString(string(event.Type), options))
+	event.CreatedAt = redaction.RedactString(event.CreatedAt, options)
+	return event
+}
+
 func NormalizeQuery(query string) string {
 	return strings.ToLower(strings.Join(strings.Fields(query), " "))
 }
@@ -242,7 +282,14 @@ func ExtractText(value any) string {
 		return strings.Join(parts, " ")
 	case map[string]any:
 		parts := []string{}
-		for _, item := range typed {
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			parts = append(parts, key)
+			item := typed[key]
 			if text := ExtractText(item); text != "" {
 				parts = append(parts, text)
 			}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,369 @@
+package search
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+const (
+	IndexFileName  = "search-index.json"
+	indexSchema    = 1
+	defaultLimit   = 20
+	defaultContext = 80
+)
+
+type Options struct {
+	Store        *sessions.Store
+	RootDir      string
+	Limit        int
+	ContextChars int
+	SessionID    string
+	Type         sessions.EventType
+	Reindex      bool
+	Now          func() time.Time
+}
+
+type EventSummary struct {
+	ID        string             `json:"id"`
+	Sequence  int                `json:"sequence"`
+	Type      sessions.EventType `json:"type"`
+	CreatedAt string             `json:"createdAt"`
+}
+
+type Hit struct {
+	Session sessions.Metadata `json:"session"`
+	Event   EventSummary      `json:"event"`
+	Context string            `json:"context"`
+	Match   Match             `json:"match"`
+}
+
+type Match struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type Result struct {
+	Query            string `json:"query"`
+	NormalizedQuery  string `json:"normalizedQuery"`
+	RootDir          string `json:"rootDir"`
+	SearchedSessions int    `json:"searchedSessions"`
+	TotalHits        int    `json:"totalHits"`
+	Hits             []Hit  `json:"hits"`
+}
+
+type Index struct {
+	SchemaVersion     int          `json:"schemaVersion"`
+	SessionID         string       `json:"sessionId"`
+	SessionUpdatedAt  string       `json:"sessionUpdatedAt"`
+	SessionEventCount int          `json:"sessionEventCount"`
+	GeneratedAt       string       `json:"generatedAt"`
+	Entries           []IndexEntry `json:"entries"`
+}
+
+type IndexEntry struct {
+	SessionID string             `json:"sessionId"`
+	EventID   string             `json:"eventId"`
+	Sequence  int                `json:"sequence"`
+	Type      sessions.EventType `json:"type"`
+	CreatedAt string             `json:"createdAt"`
+	Text      string             `json:"text"`
+}
+
+func Sessions(query string, options Options) (Result, error) {
+	normalized := NormalizeQuery(query)
+	store := options.Store
+	if store == nil {
+		store = sessions.NewStore(sessions.StoreOptions{RootDir: options.RootDir})
+	}
+	limit := normalizeLimit(options.Limit)
+	contextChars := normalizeContext(options.ContextChars)
+	if normalized == "" || limit == 0 {
+		return Result{Query: query, NormalizedQuery: normalized, RootDir: store.RootDir, Hits: []Hit{}}, nil
+	}
+	sessionList, err := resolveSessions(store, strings.TrimSpace(options.SessionID))
+	if err != nil {
+		return Result{}, err
+	}
+	terms := splitTerms(normalized)
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	result := Result{
+		Query:            query,
+		NormalizedQuery:  normalized,
+		RootDir:          store.RootDir,
+		SearchedSessions: len(sessionList),
+		Hits:             []Hit{},
+	}
+	for _, session := range sessionList {
+		index, err := LoadIndex(store, session, LoadOptions{Reindex: options.Reindex, Now: now})
+		if err != nil {
+			return Result{}, err
+		}
+		for _, entry := range index.Entries {
+			if options.Type != "" && entry.Type != options.Type {
+				continue
+			}
+			match, ok := findMatch(entry.Text, normalized, terms)
+			if !ok {
+				continue
+			}
+			result.Hits = append(result.Hits, Hit{
+				Session: session,
+				Event: EventSummary{
+					ID:        entry.EventID,
+					Sequence:  entry.Sequence,
+					Type:      entry.Type,
+					CreatedAt: entry.CreatedAt,
+				},
+				Context: buildContext(entry.Text, match.Start, match.End, contextChars),
+				Match:   match,
+			})
+			if len(result.Hits) >= limit {
+				result.TotalHits = len(result.Hits)
+				return result, nil
+			}
+		}
+	}
+	result.TotalHits = len(result.Hits)
+	return result, nil
+}
+
+type LoadOptions struct {
+	Reindex bool
+	Now     func() time.Time
+}
+
+func LoadIndex(store *sessions.Store, session sessions.Metadata, options LoadOptions) (Index, error) {
+	if !options.Reindex {
+		index, ok := readIndex(store, session)
+		if ok && current(index, session) {
+			return index, nil
+		}
+	}
+	return RebuildIndex(store, session, options.Now)
+}
+
+func RebuildIndex(store *sessions.Store, session sessions.Metadata, now func() time.Time) (Index, error) {
+	if now == nil {
+		now = time.Now
+	}
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		return Index{}, err
+	}
+	index := Index{
+		SchemaVersion:     indexSchema,
+		SessionID:         session.SessionID,
+		SessionUpdatedAt:  session.UpdatedAt,
+		SessionEventCount: session.EventCount,
+		GeneratedAt:       now().UTC().Format(time.RFC3339),
+		Entries:           make([]IndexEntry, 0, len(events)),
+	}
+	for _, event := range events {
+		index.Entries = append(index.Entries, IndexEntry{
+			SessionID: session.SessionID,
+			EventID:   event.ID,
+			Sequence:  event.Sequence,
+			Type:      event.Type,
+			CreatedAt: event.CreatedAt,
+			Text:      ExtractText(redactedPayload(event.Payload)),
+		})
+	}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return Index{}, fmt.Errorf("encode Zero search index: %w", err)
+	}
+	if err := os.WriteFile(indexPath(store, session.SessionID), append(data, '\n'), 0o600); err != nil {
+		return Index{}, fmt.Errorf("write Zero search index: %w", err)
+	}
+	return index, nil
+}
+
+func FormatResult(result Result) string {
+	query := redaction.RedactString(strings.TrimSpace(result.Query), redaction.Options{})
+	if len(result.Hits) == 0 {
+		return fmt.Sprintf("No local session events matched %q. Searched %s.", query, count(result.SearchedSessions, "session"))
+	}
+	lines := []string{fmt.Sprintf("Found %s for %q:", count(result.TotalHits, "local session event"), query)}
+	for index, hit := range result.Hits {
+		title := ""
+		if hit.Session.Title != "" {
+			title = " - " + redaction.RedactString(hit.Session.Title, redaction.Options{})
+		}
+		lines = append(lines, fmt.Sprintf("%d. %s #%d %s%s", index+1, redaction.RedactString(hit.Session.SessionID, redaction.Options{}), hit.Event.Sequence, redaction.RedactString(string(hit.Event.Type), redaction.Options{}), title))
+		context := strings.Join(strings.Fields(redaction.RedactString(hit.Context, redaction.Options{})), " ")
+		if context != "" {
+			lines = append(lines, "   "+context)
+		}
+		details := []string{}
+		if hit.Session.Cwd != "" {
+			details = append(details, "cwd: "+redaction.RedactString(hit.Session.Cwd, redaction.Options{}))
+		}
+		if hit.Session.ModelID != "" {
+			details = append(details, "model: "+redaction.RedactString(hit.Session.ModelID, redaction.Options{}))
+		}
+		if hit.Session.Provider != "" {
+			details = append(details, "provider: "+redaction.RedactString(hit.Session.Provider, redaction.Options{}))
+		}
+		details = append(details, "updated: "+redaction.RedactString(hit.Session.UpdatedAt, redaction.Options{}))
+		lines = append(lines, "   "+strings.Join(details, " | "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func NormalizeQuery(query string) string {
+	return strings.ToLower(strings.Join(strings.Fields(query), " "))
+}
+
+func ExtractText(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case float64, float32, int, int64, bool:
+		return fmt.Sprint(typed)
+	case []any:
+		parts := []string{}
+		for _, item := range typed {
+			if text := ExtractText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	case map[string]any:
+		parts := []string{}
+		for _, item := range typed {
+			if text := ExtractText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func resolveSessions(store *sessions.Store, sessionID string) ([]sessions.Metadata, error) {
+	if sessionID == "" {
+		return store.List()
+	}
+	session, err := store.Get(sessionID)
+	if err != nil || session == nil {
+		return []sessions.Metadata{}, err
+	}
+	return []sessions.Metadata{*session}, nil
+}
+
+func readIndex(store *sessions.Store, session sessions.Metadata) (Index, bool) {
+	data, err := os.ReadFile(indexPath(store, session.SessionID))
+	if err != nil {
+		return Index{}, false
+	}
+	var index Index
+	if err := json.Unmarshal(data, &index); err != nil {
+		return Index{}, false
+	}
+	return index, true
+}
+
+func current(index Index, session sessions.Metadata) bool {
+	return index.SchemaVersion == indexSchema &&
+		index.SessionID == session.SessionID &&
+		index.SessionUpdatedAt == session.UpdatedAt &&
+		index.SessionEventCount == session.EventCount &&
+		len(index.Entries) == session.EventCount
+}
+
+func redactedPayload(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return redaction.RedactString(string(raw), redaction.Options{})
+	}
+	return redaction.RedactValue(payload, redaction.Options{})
+}
+
+func findMatch(text string, query string, terms []string) (Match, bool) {
+	normalizedText := strings.ToLower(text)
+	if index := strings.Index(normalizedText, query); index >= 0 {
+		return Match{Start: index, End: index + len(query)}, true
+	}
+	first := -1
+	last := -1
+	for _, term := range terms {
+		index := strings.Index(normalizedText, term)
+		if index < 0 {
+			return Match{}, false
+		}
+		if first < 0 || index < first {
+			first = index
+		}
+		if end := index + len(term); end > last {
+			last = end
+		}
+	}
+	return Match{Start: first, End: last}, first >= 0
+}
+
+func buildContext(text string, start int, end int, contextChars int) string {
+	left := start - contextChars
+	if left < 0 {
+		left = 0
+	}
+	right := end + contextChars
+	if right > len(text) {
+		right = len(text)
+	}
+	return strings.TrimSpace(text[left:right])
+}
+
+func splitTerms(query string) []string {
+	if query == "" {
+		return nil
+	}
+	return strings.Fields(query)
+}
+
+func normalizeLimit(limit int) int {
+	if limit == 0 {
+		return defaultLimit
+	}
+	if limit < 0 {
+		return 0
+	}
+	return limit
+}
+
+func normalizeContext(contextChars int) int {
+	if contextChars == 0 {
+		return defaultContext
+	}
+	if contextChars < 0 {
+		return 0
+	}
+	return contextChars
+}
+
+func indexPath(store *sessions.Store, sessionID string) string {
+	return filepath.Join(store.RootDir, sessionID, IndexFileName)
+}
+
+func count(value int, label string) string {
+	suffix := "s"
+	if value == 1 {
+		suffix = ""
+	}
+	return fmt.Sprintf("%d %s%s", value, label, suffix)
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,90 @@
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+func TestSearchSessionsFindsRedactedEventContextAndCachesIndex(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedSearchClock("2026-06-04T14:00:00Z")})
+	session, err := store.Create(sessions.CreateInput{SessionID: "searchable", Title: "Search", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventMessage, Payload: map[string]any{"content": "please rotate apiKey=sk-secret1234567890 before deploy"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventToolResult, Payload: map[string]any{"output": "deployment finished"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+
+	result, err := Sessions("rotate deploy", Options{Store: store, Limit: 5, ContextChars: 120})
+	if err != nil {
+		t.Fatalf("Sessions returned error: %v", err)
+	}
+	if result.TotalHits != 1 || result.SearchedSessions != 1 {
+		t.Fatalf("unexpected result counts: %#v", result)
+	}
+	if hit := result.Hits[0]; hit.Session.SessionID != "searchable" || hit.Event.Sequence != 1 {
+		t.Fatalf("unexpected hit: %#v", hit)
+	}
+	if strings.Contains(result.Hits[0].Context, "sk-secret") {
+		t.Fatalf("search context leaked secret: %#v", result.Hits[0])
+	}
+
+	indexPath := filepath.Join(store.RootDir, "searchable", IndexFileName)
+	if _, err := os.Stat(indexPath); err != nil {
+		t.Fatalf("expected search index to be written: %v", err)
+	}
+	formatted := FormatResult(result)
+	if !strings.Contains(formatted, "Found 1 local session event") || strings.Contains(formatted, "sk-secret") {
+		t.Fatalf("unexpected formatted result: %q", formatted)
+	}
+}
+
+func TestSearchSessionsSupportsFiltersAndEmptyQuery(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedSearchClock("2026-06-04T14:30:00Z")})
+	one, err := store.Create(sessions.CreateInput{SessionID: "one"})
+	if err != nil {
+		t.Fatalf("Create one returned error: %v", err)
+	}
+	two, err := store.Create(sessions.CreateInput{SessionID: "two"})
+	if err != nil {
+		t.Fatalf("Create two returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(one.SessionID, sessions.AppendEventInput{Type: sessions.EventMessage, Payload: "needle in message"}); err != nil {
+		t.Fatalf("AppendEvent one returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(two.SessionID, sessions.AppendEventInput{Type: sessions.EventToolResult, Payload: "needle in tool result"}); err != nil {
+		t.Fatalf("AppendEvent two returned error: %v", err)
+	}
+
+	result, err := Sessions("needle", Options{Store: store, SessionID: "two", Type: sessions.EventToolResult})
+	if err != nil {
+		t.Fatalf("Sessions returned error: %v", err)
+	}
+	if result.TotalHits != 1 || result.Hits[0].Session.SessionID != "two" {
+		t.Fatalf("unexpected filtered result: %#v", result)
+	}
+
+	empty, err := Sessions("   ", Options{Store: store})
+	if err != nil {
+		t.Fatalf("empty Sessions returned error: %v", err)
+	}
+	if empty.TotalHits != 0 || empty.SearchedSessions != 0 {
+		t.Fatalf("empty query should not search sessions: %#v", empty)
+	}
+}
+
+func fixedSearchClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -81,6 +81,25 @@ func TestSearchSessionsSupportsFiltersAndEmptyQuery(t *testing.T) {
 	}
 }
 
+func TestSearchSessionsMatchesMapKeys(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedSearchClock("2026-06-04T14:45:00Z")})
+	session, err := store.Create(sessions.CreateInput{SessionID: "map_keys"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventError, Payload: map[string]any{"error": "", "status": "success"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+
+	result, err := Sessions("error", Options{Store: store})
+	if err != nil {
+		t.Fatalf("Sessions returned error: %v", err)
+	}
+	if result.TotalHits != 1 || result.Hits[0].Event.Type != sessions.EventError {
+		t.Fatalf("expected map key search hit, got %#v", result)
+	}
+}
+
 func fixedSearchClock(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -84,8 +86,11 @@ type StoreOptions struct {
 }
 
 type Store struct {
-	RootDir string
-	now     func() time.Time
+	RootDir      string
+	now          func() time.Time
+	locksMu      sync.Mutex
+	sessionLocks map[string]*sync.Mutex
+	idCounter    atomic.Uint64
 }
 
 var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
@@ -99,7 +104,7 @@ func NewStore(options StoreOptions) *Store {
 	if now == nil {
 		now = time.Now
 	}
-	return &Store{RootDir: rootDir, now: now}
+	return &Store{RootDir: rootDir, now: now, sessionLocks: map[string]*sync.Mutex{}}
 }
 
 func DefaultRoot(env map[string]string) string {
@@ -150,7 +155,7 @@ func (store *Store) Create(input CreateInput) (Metadata, error) {
 	}
 	if err := os.Mkdir(store.sessionPath(sessionID), 0o700); err != nil {
 		if errors.Is(err, os.ErrExist) {
-			return Metadata{}, fmt.Errorf("Zero session already exists: %s", sessionID)
+			return Metadata{}, fmt.Errorf("zero session already exists: %s", sessionID)
 		}
 		return Metadata{}, fmt.Errorf("create Zero session directory: %w", err)
 	}
@@ -226,7 +231,7 @@ func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, err
 		return Metadata{}, err
 	}
 	if parent == nil {
-		return Metadata{}, fmt.Errorf("Zero session not found: %s", parentSessionID)
+		return Metadata{}, fmt.Errorf("zero session not found: %s", parentSessionID)
 	}
 	events, err := store.ReadEvents(parentSessionID)
 	if err != nil {
@@ -283,8 +288,12 @@ func (store *Store) AppendEvent(sessionID string, input AppendEventInput) (Event
 		return Event{}, fmt.Errorf("invalid Zero session id %q", sessionID)
 	}
 	if strings.TrimSpace(string(input.Type)) == "" {
-		return Event{}, fmt.Errorf("Zero session event type is required")
+		return Event{}, fmt.Errorf("zero session event type is required")
 	}
+	lock := store.sessionLock(sessionID)
+	lock.Lock()
+	defer lock.Unlock()
+
 	session, err := store.readMetadata(sessionID)
 	if err != nil {
 		return Event{}, err
@@ -358,7 +367,22 @@ func (store *Store) timestamp() string {
 }
 
 func (store *Store) createID() string {
-	return fmt.Sprintf("zero_%s_%d", store.now().UTC().Format("20060102150405"), store.now().UTC().UnixNano()%1_000_000)
+	timestamp := store.now().UTC()
+	return fmt.Sprintf("zero_%s_%d_%d", timestamp.Format("20060102150405"), timestamp.UnixNano(), store.idCounter.Add(1))
+}
+
+func (store *Store) sessionLock(sessionID string) *sync.Mutex {
+	store.locksMu.Lock()
+	defer store.locksMu.Unlock()
+	if store.sessionLocks == nil {
+		store.sessionLocks = map[string]*sync.Mutex{}
+	}
+	lock := store.sessionLocks[sessionID]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		store.sessionLocks[sessionID] = lock
+	}
+	return lock
 }
 
 func (store *Store) sessionPath(sessionID string) string {

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -1,0 +1,439 @@
+package sessions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	MetadataFile = "metadata.json"
+	EventsFile   = "events.jsonl"
+)
+
+type EventType string
+
+const (
+	EventMessage       EventType = "message"
+	EventToolCall      EventType = "tool_call"
+	EventToolResult    EventType = "tool_result"
+	EventProviderUsage EventType = "provider_usage"
+	EventError         EventType = "error"
+	EventSessionFork   EventType = "session_fork"
+)
+
+type Metadata struct {
+	SessionID          string    `json:"sessionId"`
+	Title              string    `json:"title,omitempty"`
+	Cwd                string    `json:"cwd,omitempty"`
+	ModelID            string    `json:"modelId,omitempty"`
+	Provider           string    `json:"provider,omitempty"`
+	ParentSessionID    string    `json:"parentSessionId,omitempty"`
+	ForkedFromEventID  string    `json:"forkedFromEventId,omitempty"`
+	ForkedFromSequence int       `json:"forkedFromSequence,omitempty"`
+	CreatedAt          string    `json:"createdAt"`
+	UpdatedAt          string    `json:"updatedAt"`
+	EventCount         int       `json:"eventCount"`
+	LastEventType      EventType `json:"lastEventType,omitempty"`
+}
+
+type CreateInput struct {
+	SessionID          string
+	Title              string
+	Cwd                string
+	ModelID            string
+	Provider           string
+	ParentSessionID    string
+	ForkedFromEventID  string
+	ForkedFromSequence int
+}
+
+type ForkInput struct {
+	SessionID string
+	Title     string
+	Cwd       string
+	ModelID   string
+	Provider  string
+}
+
+type AppendEventInput struct {
+	Type    EventType
+	Payload any
+}
+
+type Event struct {
+	ID        string          `json:"id"`
+	SessionID string          `json:"sessionId"`
+	Sequence  int             `json:"sequence"`
+	Type      EventType       `json:"type"`
+	CreatedAt string          `json:"createdAt"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+}
+
+type StoreOptions struct {
+	RootDir string
+	Now     func() time.Time
+	Env     map[string]string
+}
+
+type Store struct {
+	RootDir string
+	now     func() time.Time
+}
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+
+func NewStore(options StoreOptions) *Store {
+	rootDir := strings.TrimSpace(options.RootDir)
+	if rootDir == "" {
+		rootDir = DefaultRoot(options.Env)
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{RootDir: rootDir, now: now}
+}
+
+func DefaultRoot(env map[string]string) string {
+	dataHome := strings.TrimSpace(envValue(env, "XDG_DATA_HOME"))
+	home := strings.TrimSpace(envValue(env, "HOME"))
+	if home == "" {
+		if userHome, err := os.UserHomeDir(); err == nil {
+			home = userHome
+		}
+	}
+	base := dataHome
+	if base == "" {
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "zero", "sessions")
+}
+
+func ValidSessionID(sessionID string) bool {
+	return sessionIDPattern.MatchString(strings.TrimSpace(sessionID))
+}
+
+func (store *Store) Create(input CreateInput) (Metadata, error) {
+	sessionID := strings.TrimSpace(input.SessionID)
+	if sessionID == "" {
+		sessionID = store.createID()
+	}
+	if !ValidSessionID(sessionID) {
+		return Metadata{}, fmt.Errorf("invalid Zero session id %q", input.SessionID)
+	}
+
+	timestamp := store.timestamp()
+	session := Metadata{
+		SessionID:          sessionID,
+		Title:              strings.TrimSpace(input.Title),
+		Cwd:                strings.TrimSpace(input.Cwd),
+		ModelID:            strings.TrimSpace(input.ModelID),
+		Provider:           strings.TrimSpace(input.Provider),
+		ParentSessionID:    strings.TrimSpace(input.ParentSessionID),
+		ForkedFromEventID:  strings.TrimSpace(input.ForkedFromEventID),
+		ForkedFromSequence: input.ForkedFromSequence,
+		CreatedAt:          timestamp,
+		UpdatedAt:          timestamp,
+		EventCount:         0,
+	}
+
+	if err := os.MkdirAll(store.RootDir, 0o700); err != nil {
+		return Metadata{}, fmt.Errorf("create Zero session root: %w", err)
+	}
+	if err := os.Mkdir(store.sessionPath(sessionID), 0o700); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return Metadata{}, fmt.Errorf("Zero session already exists: %s", sessionID)
+		}
+		return Metadata{}, fmt.Errorf("create Zero session directory: %w", err)
+	}
+	if err := store.writeMetadata(session); err != nil {
+		return Metadata{}, err
+	}
+	file, err := os.OpenFile(store.eventsPath(sessionID), os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("create Zero session events file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return Metadata{}, fmt.Errorf("close Zero session events file: %w", err)
+	}
+	return session, nil
+}
+
+func (store *Store) Get(sessionID string) (*Metadata, error) {
+	if !ValidSessionID(sessionID) {
+		return nil, fmt.Errorf("invalid Zero session id %q", sessionID)
+	}
+	session, err := store.readMetadata(sessionID)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &session, nil
+}
+
+func (store *Store) List() ([]Metadata, error) {
+	if err := os.MkdirAll(store.RootDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create Zero session root: %w", err)
+	}
+	entries, err := os.ReadDir(store.RootDir)
+	if err != nil {
+		return nil, fmt.Errorf("read Zero session root: %w", err)
+	}
+	sessions := []Metadata{}
+	for _, entry := range entries {
+		if !entry.IsDir() || !ValidSessionID(entry.Name()) {
+			continue
+		}
+		session, err := store.Get(entry.Name())
+		if err != nil || session == nil {
+			continue
+		}
+		sessions = append(sessions, *session)
+	}
+	sort.SliceStable(sessions, func(left int, right int) bool {
+		if sessions[left].UpdatedAt == sessions[right].UpdatedAt {
+			return sessions[left].SessionID < sessions[right].SessionID
+		}
+		return sessions[left].UpdatedAt > sessions[right].UpdatedAt
+	})
+	return sessions, nil
+}
+
+func (store *Store) Latest() (*Metadata, error) {
+	sessions, err := store.List()
+	if err != nil || len(sessions) == 0 {
+		return nil, err
+	}
+	return &sessions[0], nil
+}
+
+func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, error) {
+	if !ValidSessionID(parentSessionID) {
+		return Metadata{}, fmt.Errorf("invalid Zero session id %q", parentSessionID)
+	}
+	parent, err := store.Get(parentSessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if parent == nil {
+		return Metadata{}, fmt.Errorf("Zero session not found: %s", parentSessionID)
+	}
+	events, err := store.ReadEvents(parentSessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	var last Event
+	if len(events) > 0 {
+		last = events[len(events)-1]
+	}
+
+	title := strings.TrimSpace(input.Title)
+	if title == "" && parent.Title != "" {
+		title = parent.Title + " (fork)"
+	}
+	fork, err := store.Create(CreateInput{
+		SessionID:          input.SessionID,
+		Title:              title,
+		Cwd:                firstNonEmpty(input.Cwd, parent.Cwd),
+		ModelID:            firstNonEmpty(input.ModelID, parent.ModelID),
+		Provider:           firstNonEmpty(input.Provider, parent.Provider),
+		ParentSessionID:    parent.SessionID,
+		ForkedFromEventID:  last.ID,
+		ForkedFromSequence: last.Sequence,
+	})
+	if err != nil {
+		return Metadata{}, err
+	}
+	for _, event := range events {
+		if _, err := store.AppendEvent(fork.SessionID, AppendEventInput{Type: event.Type, Payload: event.Payload}); err != nil {
+			return Metadata{}, err
+		}
+	}
+	if _, err := store.AppendEvent(fork.SessionID, AppendEventInput{
+		Type: EventSessionFork,
+		Payload: map[string]any{
+			"parentSessionId":    parent.SessionID,
+			"parentEventCount":   parent.EventCount,
+			"copiedEventCount":   len(events),
+			"forkedFromEventId":  last.ID,
+			"forkedFromSequence": last.Sequence,
+		},
+	}); err != nil {
+		return Metadata{}, err
+	}
+	loaded, err := store.readMetadata(fork.SessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return loaded, nil
+}
+
+func (store *Store) AppendEvent(sessionID string, input AppendEventInput) (Event, error) {
+	if !ValidSessionID(sessionID) {
+		return Event{}, fmt.Errorf("invalid Zero session id %q", sessionID)
+	}
+	if strings.TrimSpace(string(input.Type)) == "" {
+		return Event{}, fmt.Errorf("Zero session event type is required")
+	}
+	session, err := store.readMetadata(sessionID)
+	if err != nil {
+		return Event{}, err
+	}
+	payload, err := rawPayload(input.Payload)
+	if err != nil {
+		return Event{}, err
+	}
+	sequence := session.EventCount + 1
+	timestamp := store.timestamp()
+	event := Event{
+		ID:        fmt.Sprintf("%s:%d", sessionID, sequence),
+		SessionID: sessionID,
+		Sequence:  sequence,
+		Type:      input.Type,
+		CreatedAt: timestamp,
+		Payload:   payload,
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return Event{}, fmt.Errorf("encode Zero session event: %w", err)
+	}
+	file, err := os.OpenFile(store.eventsPath(sessionID), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	if err != nil {
+		return Event{}, fmt.Errorf("append Zero session event: %w", err)
+	}
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		_ = file.Close()
+		return Event{}, fmt.Errorf("append Zero session event: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return Event{}, fmt.Errorf("close Zero session event file: %w", err)
+	}
+	session.UpdatedAt = timestamp
+	session.EventCount = sequence
+	session.LastEventType = input.Type
+	if err := store.writeMetadata(session); err != nil {
+		return Event{}, err
+	}
+	return event, nil
+}
+
+func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
+	if !ValidSessionID(sessionID) {
+		return nil, fmt.Errorf("invalid Zero session id %q", sessionID)
+	}
+	data, err := os.ReadFile(store.eventsPath(sessionID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Event{}, nil
+		}
+		return nil, fmt.Errorf("read Zero session events: %w", err)
+	}
+	events := []Event{}
+	for index, line := range bytes.Split(data, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var event Event
+		if err := json.Unmarshal(line, &event); err != nil {
+			return nil, fmt.Errorf("invalid JSON in Zero session %s %s at line %d: %w", sessionID, EventsFile, index+1, err)
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func (store *Store) timestamp() string {
+	return store.now().UTC().Format(time.RFC3339)
+}
+
+func (store *Store) createID() string {
+	return fmt.Sprintf("zero_%s_%d", store.now().UTC().Format("20060102150405"), store.now().UTC().UnixNano()%1_000_000)
+}
+
+func (store *Store) sessionPath(sessionID string) string {
+	return filepath.Join(store.RootDir, sessionID)
+}
+
+func (store *Store) metadataPath(sessionID string) string {
+	return filepath.Join(store.sessionPath(sessionID), MetadataFile)
+}
+
+func (store *Store) eventsPath(sessionID string) string {
+	return filepath.Join(store.sessionPath(sessionID), EventsFile)
+}
+
+func (store *Store) readMetadata(sessionID string) (Metadata, error) {
+	data, err := os.ReadFile(store.metadataPath(sessionID))
+	if err != nil {
+		return Metadata{}, err
+	}
+	var session Metadata
+	if err := json.Unmarshal(data, &session); err != nil {
+		return Metadata{}, fmt.Errorf("invalid Zero session metadata %s: %w", sessionID, err)
+	}
+	return session, nil
+}
+
+func (store *Store) writeMetadata(session Metadata) error {
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode Zero session metadata: %w", err)
+	}
+	path := store.metadataPath(session.SessionID)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write Zero session metadata: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("replace Zero session metadata: %w", err)
+	}
+	return nil
+}
+
+func rawPayload(payload any) (json.RawMessage, error) {
+	if payload == nil {
+		return nil, nil
+	}
+	if raw, ok := payload.(json.RawMessage); ok {
+		copied := append(json.RawMessage{}, bytes.TrimSpace(raw)...)
+		if len(copied) == 0 {
+			return nil, nil
+		}
+		if !json.Valid(copied) {
+			return nil, fmt.Errorf("invalid raw JSON payload")
+		}
+		return copied, nil
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode Zero session payload: %w", err)
+	}
+	return data, nil
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -1,0 +1,146 @@
+package sessions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoreCreatesAppendsListsAndReadsEvents(t *testing.T) {
+	now := fixedClock("2026-06-04T10:00:00Z")
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: now})
+
+	session, err := store.Create(CreateInput{
+		SessionID: "zero_test_1",
+		Title:     "First run",
+		Cwd:       "/repo",
+		ModelID:   "gpt-4.1",
+		Provider:  "openai",
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if session.EventCount != 0 || session.CreatedAt != "2026-06-04T10:00:00Z" {
+		t.Fatalf("unexpected session metadata: %#v", session)
+	}
+
+	event, err := store.AppendEvent(session.SessionID, AppendEventInput{
+		Type: EventMessage,
+		Payload: map[string]any{
+			"role":    "user",
+			"content": "searchable hello",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+	if event.ID != "zero_test_1:1" || event.Sequence != 1 {
+		t.Fatalf("unexpected event identity: %#v", event)
+	}
+
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != 1 || loaded.LastEventType != EventMessage {
+		t.Fatalf("metadata was not updated after append: %#v", loaded)
+	}
+
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected one event, got %#v", events)
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(events[0].Payload, &payload); err != nil {
+		t.Fatalf("payload is not valid JSON: %v", err)
+	}
+	if payload["content"] != "searchable hello" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+
+	sessions, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != session.SessionID {
+		t.Fatalf("unexpected session list: %#v", sessions)
+	}
+}
+
+func TestStoreForkCopiesEventsAndLineage(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T11:00:00Z")})
+	parent, err := store.Create(CreateInput{SessionID: "parent", Title: "Parent", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	for _, content := range []string{"first", "second"} {
+		if _, err := store.AppendEvent(parent.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": content}}); err != nil {
+			t.Fatalf("AppendEvent returned error: %v", err)
+		}
+	}
+
+	fork, err := store.Fork(parent.SessionID, ForkInput{SessionID: "fork"})
+	if err != nil {
+		t.Fatalf("Fork returned error: %v", err)
+	}
+	if fork.ParentSessionID != parent.SessionID || fork.ForkedFromEventID != "parent:2" || fork.ForkedFromSequence != 2 {
+		t.Fatalf("fork lineage not recorded: %#v", fork)
+	}
+	if fork.EventCount != 3 || fork.LastEventType != EventSessionFork {
+		t.Fatalf("fork event count/type wrong: %#v", fork)
+	}
+	events, err := store.ReadEvents(fork.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(events) != 3 || events[0].ID != "fork:1" || events[2].Type != EventSessionFork {
+		t.Fatalf("fork events not copied/remapped: %#v", events)
+	}
+}
+
+func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
+	got := DefaultRoot(map[string]string{
+		"XDG_DATA_HOME": "/tmp/zero-data",
+		"HOME":          "/tmp/home",
+	})
+	want := filepath.Join("/tmp/zero-data", "zero", "sessions")
+	if got != want {
+		t.Fatalf("DefaultRoot = %q, want %q", got, want)
+	}
+}
+
+func TestStoreRejectsUnsafeSessionIDsAndBadJSONL(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T12:00:00Z")})
+	if _, err := store.Create(CreateInput{SessionID: "../escape"}); err == nil {
+		t.Fatal("expected unsafe session id to be rejected")
+	}
+
+	if err := os.MkdirAll(filepath.Join(store.RootDir, "bad"), 0o700); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.RootDir, "bad", "metadata.json"), []byte(`{"sessionId":"bad","createdAt":"x","updatedAt":"x","eventCount":1}`), 0o600); err != nil {
+		t.Fatalf("metadata write failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.RootDir, "bad", "events.jsonl"), []byte("{not-json}\n"), 0o600); err != nil {
+		t.Fatalf("events write failed: %v", err)
+	}
+
+	_, err := store.ReadEvents("bad")
+	if err == nil || !strings.Contains(err.Error(), "events.jsonl at line 1") {
+		t.Fatalf("expected JSONL line error, got %v", err)
+	}
+}
+
+func fixedClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -2,9 +2,11 @@ package sessions
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -134,6 +136,81 @@ func TestStoreRejectsUnsafeSessionIDsAndBadJSONL(t *testing.T) {
 	_, err := store.ReadEvents("bad")
 	if err == nil || !strings.Contains(err.Error(), "events.jsonl at line 1") {
 		t.Fatalf("expected JSONL line error, got %v", err)
+	}
+}
+
+func TestStoreGeneratesUniqueIDsWithFixedClock(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T12:30:00Z")})
+	first, err := store.Create(CreateInput{})
+	if err != nil {
+		t.Fatalf("Create first returned error: %v", err)
+	}
+	second, err := store.Create(CreateInput{})
+	if err != nil {
+		t.Fatalf("Create second returned error: %v", err)
+	}
+	if first.SessionID == second.SessionID {
+		t.Fatalf("generated session ids collided: %q", first.SessionID)
+	}
+}
+
+func TestStoreAppendEventSerializesConcurrentWriters(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T13:00:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "concurrent"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	const total = 24
+	var wg sync.WaitGroup
+	errs := make(chan error, total)
+	for index := 0; index < total; index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			_, err := store.AppendEvent(session.SessionID, AppendEventInput{
+				Type:    EventMessage,
+				Payload: map[string]int{"index": index},
+			})
+			errs <- err
+		}(index)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("AppendEvent returned error: %v", err)
+		}
+	}
+
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(events) != total {
+		t.Fatalf("expected %d events, got %d: %#v", total, len(events), events)
+	}
+	seen := map[int]bool{}
+	for _, event := range events {
+		if seen[event.Sequence] {
+			t.Fatalf("duplicate event sequence %d in %#v", event.Sequence, events)
+		}
+		seen[event.Sequence] = true
+		if event.ID != fmt.Sprintf("%s:%d", session.SessionID, event.Sequence) {
+			t.Fatalf("event id/sequence mismatch: %#v", event)
+		}
+	}
+	for sequence := 1; sequence <= total; sequence++ {
+		if !seen[sequence] {
+			t.Fatalf("missing event sequence %d in %#v", sequence, events)
+		}
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if loaded == nil || loaded.EventCount != total || loaded.LastEventType != EventMessage {
+		t.Fatalf("metadata not updated after concurrent append: %#v", loaded)
 	}
 }
 

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -1,0 +1,284 @@
+package usage
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+type Normalized struct {
+	InputTokens       int
+	CachedInputTokens int
+	OutputTokens      int
+	ReasoningTokens   int
+	TotalTokens       int
+}
+
+type RecordInput struct {
+	ModelID string
+	Usage   zeroruntime.Usage
+	Source  string
+}
+
+type Record struct {
+	ID        string
+	Sequence  int
+	ModelID   string
+	Provider  modelregistry.ProviderKind
+	Source    string
+	CreatedAt string
+	Usage     Normalized
+	Cost      modelregistry.CostBreakdown
+}
+
+type ModelSummary struct {
+	ModelID            string
+	Provider           modelregistry.ProviderKind
+	RecordCount        int
+	InputTokens        int
+	CachedInputTokens  int
+	OutputTokens       int
+	ReasoningTokens    int
+	TotalTokens        int
+	InputCost          float64
+	CachedInputCost    float64
+	OutputCost         float64
+	TotalCost          float64
+	FormattedTotalCost string
+}
+
+type Summary struct {
+	RecordCount        int
+	Currency           string
+	InputTokens        int
+	CachedInputTokens  int
+	OutputTokens       int
+	ReasoningTokens    int
+	TotalTokens        int
+	InputCost          float64
+	CachedInputCost    float64
+	OutputCost         float64
+	TotalCost          float64
+	FormattedTotalCost string
+	ByModel            []ModelSummary
+	LastRecord         *Record
+}
+
+type TrackerOptions struct {
+	Now      func() time.Time
+	Registry *modelregistry.Registry
+}
+
+type Tracker struct {
+	now      func() time.Time
+	registry modelregistry.Registry
+	records  []Record
+	nextSeq  int
+}
+
+func NewTracker(options TrackerOptions) *Tracker {
+	registry := options.Registry
+	if registry == nil {
+		defaultRegistry, err := modelregistry.DefaultRegistry()
+		if err != nil {
+			panic(err)
+		}
+		registry = &defaultRegistry
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Tracker{now: now, registry: *registry, nextSeq: 1}
+}
+
+func (tracker *Tracker) Record(input RecordInput) (Record, error) {
+	model, err := tracker.registry.Require(input.ModelID)
+	if err != nil {
+		return Record{}, err
+	}
+	normalized, runtimeUsage, err := Normalize(input.Usage)
+	if err != nil {
+		return Record{}, err
+	}
+	cost, err := modelregistry.CalculateCost(model, runtimeUsage)
+	if err != nil {
+		return Record{}, err
+	}
+	sequence := tracker.nextSeq
+	tracker.nextSeq++
+	record := Record{
+		ID:        fmt.Sprintf("zero_usage_%d", sequence),
+		Sequence:  sequence,
+		ModelID:   model.ID,
+		Provider:  model.Provider,
+		Source:    input.Source,
+		CreatedAt: tracker.now().UTC().Format(time.RFC3339),
+		Usage:     normalized,
+		Cost:      cost,
+	}
+	tracker.records = append(tracker.records, record)
+	return record, nil
+}
+
+func (tracker *Tracker) Records() []Record {
+	return append([]Record{}, tracker.records...)
+}
+
+func (tracker *Tracker) Summary() Summary {
+	summary := Summary{Currency: "USD"}
+	models := map[string]int{}
+	for _, record := range tracker.records {
+		summary.RecordCount++
+		addUsageToSummary(&summary, record.Usage)
+		addCostToSummary(&summary, record.Cost)
+		index, ok := models[record.ModelID]
+		if !ok {
+			summary.ByModel = append(summary.ByModel, ModelSummary{
+				ModelID:  record.ModelID,
+				Provider: record.Provider,
+			})
+			index = len(summary.ByModel) - 1
+			models[record.ModelID] = index
+		}
+		addUsageToModel(&summary.ByModel[index], record.Usage)
+		addCostToModel(&summary.ByModel[index], record.Cost)
+		recordCopy := record
+		summary.LastRecord = &recordCopy
+	}
+	summary.FormattedTotalCost = formatCost(summary.TotalCost)
+	for index := range summary.ByModel {
+		summary.ByModel[index].FormattedTotalCost = formatCost(summary.ByModel[index].TotalCost)
+	}
+	return summary
+}
+
+func (tracker *Tracker) Reset() {
+	tracker.records = nil
+	tracker.nextSeq = 1
+}
+
+func Normalize(usage zeroruntime.Usage) (Normalized, zeroruntime.Usage, error) {
+	inputTokens, err := nonNegative(firstNonZero(usage.InputTokens, usage.PromptTokens), "inputTokens")
+	if err != nil {
+		return Normalized{}, zeroruntime.Usage{}, err
+	}
+	outputTokens, err := nonNegative(firstNonZero(usage.OutputTokens, usage.CompletionTokens), "outputTokens")
+	if err != nil {
+		return Normalized{}, zeroruntime.Usage{}, err
+	}
+	cachedInputTokens, err := nonNegative(usage.CachedInputTokens, "cachedInputTokens")
+	if err != nil {
+		return Normalized{}, zeroruntime.Usage{}, err
+	}
+	if cachedInputTokens > inputTokens {
+		cachedInputTokens = inputTokens
+	}
+	reasoningTokens, err := nonNegative(usage.ReasoningTokens, "reasoningTokens")
+	if err != nil {
+		return Normalized{}, zeroruntime.Usage{}, err
+	}
+	normalized := Normalized{
+		InputTokens:       inputTokens,
+		CachedInputTokens: cachedInputTokens,
+		OutputTokens:      outputTokens,
+		ReasoningTokens:   reasoningTokens,
+		TotalTokens:       inputTokens + outputTokens + reasoningTokens,
+	}
+	return normalized, zeroruntime.Usage{
+		InputTokens:       inputTokens,
+		PromptTokens:      inputTokens,
+		CachedInputTokens: cachedInputTokens,
+		OutputTokens:      outputTokens,
+		CompletionTokens:  outputTokens,
+		ReasoningTokens:   reasoningTokens,
+	}, nil
+}
+
+func FormatSummary(summary Summary) string {
+	requestLabel := "requests"
+	if summary.RecordCount == 1 {
+		requestLabel = "request"
+	}
+	return fmt.Sprintf("%s %s, %s tokens, %s", comma(summary.RecordCount), requestLabel, comma(summary.TotalTokens), summary.FormattedTotalCost)
+}
+
+func addUsageToSummary(summary *Summary, usage Normalized) {
+	summary.InputTokens += usage.InputTokens
+	summary.CachedInputTokens += usage.CachedInputTokens
+	summary.OutputTokens += usage.OutputTokens
+	summary.ReasoningTokens += usage.ReasoningTokens
+	summary.TotalTokens += usage.TotalTokens
+}
+
+func addUsageToModel(summary *ModelSummary, usage Normalized) {
+	summary.RecordCount++
+	summary.InputTokens += usage.InputTokens
+	summary.CachedInputTokens += usage.CachedInputTokens
+	summary.OutputTokens += usage.OutputTokens
+	summary.ReasoningTokens += usage.ReasoningTokens
+	summary.TotalTokens += usage.TotalTokens
+}
+
+func addCostToSummary(summary *Summary, cost modelregistry.CostBreakdown) {
+	summary.InputCost += cost.InputCost
+	summary.CachedInputCost += cost.CachedInputCost
+	summary.OutputCost += cost.OutputCost
+	summary.TotalCost += cost.TotalCost
+}
+
+func addCostToModel(summary *ModelSummary, cost modelregistry.CostBreakdown) {
+	summary.InputCost += cost.InputCost
+	summary.CachedInputCost += cost.CachedInputCost
+	summary.OutputCost += cost.OutputCost
+	summary.TotalCost += cost.TotalCost
+}
+
+func formatCost(value float64) string {
+	formatted, err := modelregistry.FormatCostUSD(value)
+	if err != nil {
+		return "$0.0000"
+	}
+	return formatted
+}
+
+func nonNegative(value int, label string) (int, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("expected %s to be non-negative", label)
+	}
+	return value, nil
+}
+
+func firstNonZero(values ...int) int {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func comma(value int) string {
+	sign := ""
+	if value < 0 {
+		sign = "-"
+		value = -value
+	}
+	digits := fmt.Sprintf("%d", value)
+	if len(digits) <= 3 {
+		return sign + digits
+	}
+	var out []byte
+	prefix := len(digits) % 3
+	if prefix == 0 {
+		prefix = 3
+	}
+	out = append(out, digits[:prefix]...)
+	for index := prefix; index < len(digits); index += 3 {
+		out = append(out, ',')
+		out = append(out, digits[index:index+3]...)
+	}
+	return sign + string(out)
+}

--- a/internal/usage/tracker_test.go
+++ b/internal/usage/tracker_test.go
@@ -1,0 +1,71 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestTrackerNormalizesUsageAndComputesModelCost(t *testing.T) {
+	tracker := NewTracker(TrackerOptions{Now: fixedUsageClock("2026-06-04T13:00:00Z")})
+
+	record, err := tracker.Record(RecordInput{
+		ModelID: "gpt-4.1",
+		Source:  "exec",
+		Usage: zeroruntime.Usage{
+			PromptTokens:      1_000,
+			CompletionTokens:  250,
+			CachedInputTokens: 200,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Record returned error: %v", err)
+	}
+	if record.Sequence != 1 || record.ID != "zero_usage_1" || record.CreatedAt != "2026-06-04T13:00:00Z" {
+		t.Fatalf("unexpected record identity: %#v", record)
+	}
+	if record.Usage.InputTokens != 1_000 || record.Usage.OutputTokens != 250 || record.Usage.TotalTokens != 1_250 {
+		t.Fatalf("usage not normalized: %#v", record.Usage)
+	}
+	if record.Cost.TotalCost <= 0 || record.Cost.ModelID != "gpt-4.1" {
+		t.Fatalf("cost not computed: %#v", record.Cost)
+	}
+
+	summary := tracker.Summary()
+	if summary.RecordCount != 1 || summary.TotalTokens != 1_250 || summary.ByModel[0].ModelID != "gpt-4.1" {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+	if FormatSummary(summary) != "1 request, 1,250 tokens, "+summary.FormattedTotalCost {
+		t.Fatalf("unexpected formatted summary: %q", FormatSummary(summary))
+	}
+}
+
+func TestTrackerRejectsInvalidUsageAndUnknownModels(t *testing.T) {
+	tracker := NewTracker(TrackerOptions{})
+	if _, err := tracker.Record(RecordInput{ModelID: "missing", Usage: zeroruntime.Usage{InputTokens: 1}}); err == nil {
+		t.Fatal("expected unknown model error")
+	}
+	if _, err := tracker.Record(RecordInput{ModelID: "gpt-4.1", Usage: zeroruntime.Usage{InputTokens: -1}}); err == nil {
+		t.Fatal("expected invalid usage error")
+	}
+}
+
+func TestTrackerResetClearsRecords(t *testing.T) {
+	tracker := NewTracker(TrackerOptions{})
+	if _, err := tracker.Record(RecordInput{ModelID: "gpt-4.1", Usage: zeroruntime.Usage{InputTokens: 1, OutputTokens: 1}}); err != nil {
+		t.Fatalf("Record returned error: %v", err)
+	}
+	tracker.Reset()
+	if summary := tracker.Summary(); summary.RecordCount != 0 || len(summary.ByModel) != 0 {
+		t.Fatalf("Reset did not clear tracker: %#v", summary)
+	}
+}
+
+func fixedUsageClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}


### PR DESCRIPTION
## Summary

Adds the Go-native M2 observability backend slice for the Gnanam-owned runtime track:

- Adds `internal/redaction` for reusable secret redaction across text, values, errors, URL credentials, auth headers, and common provider token shapes.
- Adds `internal/sessions` for a local append-only session event store with metadata, ordered JSONL events, latest-session lookup, safe session IDs, and lineage-preserving forks.
- Adds `internal/usage` for normalized provider usage records, model-registry-backed cost calculation, per-model summaries, and compact formatting.
- Adds `internal/search` for redacted local session-event search with persistent search indexes, session/type filters, bounded context, JSON-ready results, and text formatting.
- Adds `internal/doctor` for Go backend health checks over runtime/config/provider/model state with redacted diagnostics.
- Exposes `zero doctor` and `zero search` / `zero find` in the Go CLI with text and JSON output paths plus injected temp-store coverage in tests.

## Validation

- `go test ./...`
- `bun run typecheck`
- `bun test ./tests --timeout 15000` (290 pass)
- `bun run build`
- `bun run smoke:build`
- `bun run build:go`
- `bun run smoke:go`
- `./zero --help`
- `OPENAI_API_KEY=sk-proj-localdoctor1234567890 OPENAI_MODEL=gpt-4.1 ./zero doctor` (dummy key redacted)
- temp `XDG_DATA_HOME` probe with `./zero search needle` (secret context redacted)
- `git diff --check origin/main..HEAD`

Reviewers: @vasanthdev2004 @anandh8x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `doctor` CLI diagnostic command and `search`/`find` session-search commands
  * Local session search with on-disk indexing and result formatting
  * Filesystem-backed session store with event append, forking, and metadata management
  * Usage tracker with token aggregation and per-model cost summaries
  * Global redaction utility to sanitize secrets in text and structured data

* **Tests**
  * Extensive tests added for doctor, search, sessions, redaction, and usage tracker behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->