### PR TITLE
feat: add Go headless protocol sessions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,8 +5,8 @@ tone_instructions: "Be direct and prioritize actionable correctness, safety, CLI
 
 reviews:
   profile: "chill"
-  # Keep CodeRabbit as a review signal without letting stale bot reviews block merges.
-  request_changes_workflow: false
+  # Allow explicit @coderabbitai approve / resolve commands to submit review verdicts.
+  request_changes_workflow: true
   high_level_summary: true
   poem: false
   # Avoid noisy "review skipped" status comments when CodeRabbit decides not to run.

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -40,7 +40,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		result.Turns = turn + 1
 		request := zeroruntime.CompletionRequest{
 			Messages: copyMessages(messages),
-			Tools:    toolDefinitions(registry, permissionMode),
+			Tools:    toolDefinitions(registry, permissionMode, options),
 		}
 
 		stream, err := provider.StreamCompletion(ctx, request)
@@ -78,7 +78,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			if options.OnToolCall != nil {
 				options.OnToolCall(call)
 			}
-			toolResult := executeToolCall(ctx, registry, call, permissionMode)
+			toolResult := executeToolCall(ctx, registry, call, permissionMode, options)
 			if options.OnToolResult != nil {
 				options.OnToolResult(toolResult)
 			}
@@ -95,7 +95,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	return result, nil
 }
 
-func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCall, permissionMode PermissionMode) ToolResult {
+func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCall, permissionMode PermissionMode, options Options) ToolResult {
 	args := map[string]any{}
 	if call.Arguments != "" {
 		if err := json.Unmarshal([]byte(call.Arguments), &args); err != nil {
@@ -105,6 +105,14 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 				Status:     tools.StatusError,
 				Output:     "Error: Failed to parse arguments for " + call.Name + ": " + err.Error(),
 			}
+		}
+	}
+	if !toolAllowedByFilters(call.Name, options) {
+		return ToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Status:     tools.StatusError,
+			Output:     `Error: Tool "` + call.Name + `" is not enabled for this run.`,
 		}
 	}
 
@@ -124,10 +132,13 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	}
 }
 
-func toolDefinitions(registry *tools.Registry, permissionMode PermissionMode) []zeroruntime.ToolDefinition {
+func toolDefinitions(registry *tools.Registry, permissionMode PermissionMode, options Options) []zeroruntime.ToolDefinition {
 	registeredTools := registry.All()
 	definitions := make([]zeroruntime.ToolDefinition, 0, len(registeredTools))
 	for _, tool := range registeredTools {
+		if !toolAllowedByFilters(tool.Name(), options) {
+			continue
+		}
 		if !isAdvertised(tool, permissionMode) {
 			continue
 		}
@@ -142,6 +153,27 @@ func toolDefinitions(registry *tools.Registry, permissionMode PermissionMode) []
 		return definitions[left].Name < definitions[right].Name
 	})
 	return definitions
+}
+
+func toolAllowedByFilters(name string, options Options) bool {
+	if len(options.EnabledTools) > 0 {
+		if !containsToolName(options.EnabledTools, name) {
+			return false
+		}
+	}
+	if containsToolName(options.DisabledTools, name) {
+		return false
+	}
+	return true
+}
+
+func containsToolName(names []string, name string) bool {
+	for _, candidate := range names {
+		if candidate == name {
+			return true
+		}
+	}
+	return false
 }
 
 func schemaToRuntimeMap(schema tools.Schema) map[string]any {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -160,6 +160,73 @@ func TestRunAdvertisesRuntimeToolDefinitions(t *testing.T) {
 	}
 }
 
+func TestRunFiltersAdvertisedTools(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool(root))
+	registry.Register(tools.NewGrepTool(root))
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{{
+			{Type: zeroruntime.StreamEventText, Content: "done"},
+			{Type: zeroruntime.StreamEventDone},
+		}},
+	}
+
+	_, err := Run(context.Background(), "what tools exist?", provider, Options{
+		Registry:      registry,
+		EnabledTools:  []string{"read_file", "grep"},
+		DisabledTools: []string{"grep"},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(provider.requests))
+	}
+	if len(provider.requests[0].Tools) != 1 || provider.requests[0].Tools[0].Name != "read_file" {
+		t.Fatalf("expected only read_file to be advertised, got %#v", provider.requests[0].Tools)
+	}
+}
+
+func TestRunRejectsFilteredToolCalls(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool(root))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_1", ToolName: "read_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_1", ArgumentsFragment: `{"path":"README.md"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+
+	result, err := Run(context.Background(), "read", provider, Options{
+		Registry:      registry,
+		DisabledTools: []string{"read_file"},
+		MaxTurns:      2,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("expected final answer after filtered tool result, got %q", result.FinalAnswer)
+	}
+	lastMessage := result.Messages[len(result.Messages)-2]
+	if !strings.Contains(lastMessage.Content, "not enabled") {
+		t.Fatalf("expected filtered tool error message, got %#v", result.Messages)
+	}
+}
+
 func TestRunExecutesToolCallThroughRegistry(t *testing.T) {
 	root := t.TempDir()
 	writeAgentTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta\n")

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -29,6 +29,8 @@ type Options struct {
 	MaxTurns       int
 	Registry       *tools.Registry
 	PermissionMode PermissionMode
+	EnabledTools   []string
+	DisabledTools  []string
 	OnText         func(string)
 	OnToolCall     func(ToolCall)
 	OnToolResult   func(ToolResult)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -18,6 +18,7 @@ var version = "dev"
 
 type appDeps struct {
 	getwd         func() (string, error)
+	stdin         io.Reader
 	resolveConfig func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
 	newProvider   func(config.ProviderProfile) (zeroruntime.Provider, error)
 	runTUI        func(context.Context, tui.Options) int
@@ -32,6 +33,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 func defaultAppDeps() appDeps {
 	return appDeps{
 		getwd: os.Getwd,
+		stdin: os.Stdin,
 		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
 			options, err := config.DefaultResolveOptions(workspaceRoot)
 			if err != nil {
@@ -92,6 +94,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	defaults := defaultAppDeps()
 	if deps.getwd == nil {
 		deps.getwd = defaults.getwd
+	}
+	if deps.stdin == nil {
+		deps.stdin = defaults.stdin
 	}
 	if deps.resolveConfig == nil {
 		deps.resolveConfig = defaults.resolveConfig
@@ -196,9 +201,18 @@ Flags:
   -f, --file <path>                  Read prompt text from a file
   -m, --model <model>                Select the model for provider setup
       --max-turns <number>           Override the maximum agent loop turns
+      --auto <low|medium|high>       Set exec autonomy; high enables unsafe tools
+      --enabled-tools <tools>        Only expose these comma or space separated tools
+      --disabled-tools <tools>       Hide these comma or space separated tools
+      --list-tools                   List model-visible tools and exit
   -C, --cwd <path>                   Set the workspace directory
-  -o, --output-format text|json      Select text or newline-delimited JSON output
+  -i, --input-format text|stream-json
+                                    Select prompt input format
+  -o, --output-format text|json|stream-json
+                                    Select text, JSON, or schema-versioned JSONL output
       --prompt <prompt>              Provide prompt text as a flag
+      --resume [id]                  Resume a session; omit id to use the latest
+      --fork <id>                    Fork an existing session into a new session
       --skip-permissions-unsafe      Allow prompt-gated tools without approval
 `)
 	return err

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -2,16 +2,17 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/streamjson"
 )
 
 const (
@@ -22,10 +23,14 @@ const (
 )
 
 type execOutputFormat string
+type execInputFormat string
 
 const (
-	execOutputText execOutputFormat = "text"
-	execOutputJSON execOutputFormat = "json"
+	execOutputText       execOutputFormat = "text"
+	execOutputJSON       execOutputFormat = "json"
+	execOutputStreamJSON execOutputFormat = "stream-json"
+	execInputText        execInputFormat  = "text"
+	execInputStreamJSON  execInputFormat  = "stream-json"
 )
 
 type execOptions struct {
@@ -34,7 +39,15 @@ type execOptions struct {
 	model                 string
 	maxTurns              int
 	cwd                   string
+	inputFormat           execInputFormat
 	outputFormat          execOutputFormat
+	autonomy              string
+	enabledTools          []string
+	disabledTools         []string
+	listTools             bool
+	resume                string
+	resumeLatest          bool
+	fork                  string
 	skipPermissionsUnsafe bool
 }
 
@@ -63,7 +76,25 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return writeExecUsageError(stderr, err.Error())
 	}
 
-	prompt, err := resolveExecPrompt(options, workspaceRoot)
+	registry := newCoreRegistry(workspaceRoot)
+	if err := validateExecToolFilters(options, registry); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	permissionMode, err := resolveExecPermissionMode(options)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if options.listTools {
+		if err := writeExecToolList(stdout, registry, options, permissionMode); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if err := preflightExecSession(options); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+
+	prompt, err := resolveExecPrompt(options, workspaceRoot, deps.stdin)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -88,16 +119,30 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
 	}
 
-	permissionMode := agent.PermissionModeAuto
-	if options.skipPermissionsUnsafe {
-		permissionMode = agent.PermissionModeUnsafe
+	preparedSession := sessions.PreparedExec{}
+	agentPrompt := prompt
+	if shouldUseExecSession(options) {
+		preparedSession, err = sessions.PrepareExec(sessions.PrepareExecOptions{
+			Title:        createSessionTitle(prompt),
+			Cwd:          workspaceRoot,
+			ModelID:      resolved.Provider.Model,
+			Provider:     resolved.Provider.Name,
+			Resume:       options.resume,
+			ResumeLatest: options.resumeLatest,
+			Fork:         options.fork,
+		})
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		agentPrompt = sessions.FormatExecPrompt(prompt, preparedSession)
 	}
-
-	registry := newCoreRegistry(workspaceRoot)
+	runID := streamjson.CreateRunID(time.Now())
 	writer := execEventWriter{
 		stdout:       stdout,
 		stderr:       stderr,
 		format:       options.outputFormat,
+		runID:        runID,
+		sessionID:    preparedSession.Session.SessionID,
 		streamedText: &strings.Builder{},
 	}
 	writer.runStart(workspaceRoot, resolved.Provider, permissionMode)
@@ -111,156 +156,71 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		}
 	}
 
-	result, err := agent.Run(context.Background(), prompt, provider, agent.Options{
+	sessionRecorder := execSessionRecorder{prepared: preparedSession}
+	sessionRecorder.append(sessions.EventMessage, map[string]any{
+		"role":    "user",
+		"content": prompt,
+	})
+
+	result, err := agent.Run(context.Background(), agentPrompt, provider, agent.Options{
 		MaxTurns:       resolved.MaxTurns,
 		Registry:       registry,
 		PermissionMode: permissionMode,
+		EnabledTools:   options.enabledTools,
+		DisabledTools:  options.disabledTools,
 		OnText:         writer.text,
-		OnToolCall:     writer.toolCall,
-		OnToolResult:   writer.toolResult,
-		OnUsage:        writer.usage,
+		OnToolCall: func(call agent.ToolCall) {
+			writer.toolCall(call, registry)
+			sessionRecorder.append(sessions.EventToolCall, map[string]any{
+				"id":        call.ID,
+				"name":      call.Name,
+				"arguments": call.Arguments,
+			})
+		},
+		OnToolResult: func(result agent.ToolResult) {
+			writer.toolResult(result)
+			sessionRecorder.append(sessions.EventToolResult, map[string]any{
+				"toolCallId": result.ToolCallID,
+				"name":       result.Name,
+				"status":     string(result.Status),
+				"output":     result.Output,
+			})
+		},
+		OnUsage: func(usage agent.Usage) {
+			writer.usage(usage)
+			sessionRecorder.append(sessions.EventUsage, map[string]any{
+				"promptTokens":     usage.EffectiveInputTokens(),
+				"completionTokens": usage.EffectiveOutputTokens(),
+				"totalTokens":      usage.TotalTokens(),
+			})
+		},
 	})
 	if writer.err != nil {
 		return exitCrash
 	}
 	if err != nil {
+		sessionRecorder.append(sessions.EventError, map[string]any{"message": err.Error()})
+		if options.outputFormat == execOutputStreamJSON {
+			writer.errorEvent("provider_error", err.Error(), false)
+			writer.runEnd("error", exitProvider)
+			if writer.err != nil {
+				return exitCrash
+			}
+			return exitProvider
+		}
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
 	}
+	sessionRecorder.append(sessions.EventMessage, map[string]any{
+		"role":    "assistant",
+		"content": result.FinalAnswer,
+	})
 
 	writer.final(result.FinalAnswer)
+	writer.runEnd("success", exitSuccess)
 	if writer.err != nil {
 		return exitCrash
 	}
 	return exitSuccess
-}
-
-func parseExecArgs(args []string) (execOptions, bool, error) {
-	options := execOptions{outputFormat: execOutputText}
-	if len(args) == 0 {
-		return options, false, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
-	}
-
-	for index := 0; index < len(args); index++ {
-		arg := args[index]
-		switch {
-		case arg == "-h" || arg == "--help" || arg == "help":
-			return options, true, nil
-		case arg == "--skip-permissions-unsafe":
-			options.skipPermissionsUnsafe = true
-		case arg == "-f" || arg == "--file":
-			value, next, err := nextFlagValue(args, index, arg)
-			if err != nil {
-				return options, false, err
-			}
-			options.file = value
-			index = next
-		case strings.HasPrefix(arg, "--file="):
-			options.file = strings.TrimSpace(strings.TrimPrefix(arg, "--file="))
-		case arg == "-m" || arg == "--model":
-			value, next, err := nextFlagValue(args, index, arg)
-			if err != nil {
-				return options, false, err
-			}
-			options.model = value
-			index = next
-		case strings.HasPrefix(arg, "--model="):
-			options.model = strings.TrimSpace(strings.TrimPrefix(arg, "--model="))
-		case arg == "--max-turns":
-			value, next, err := nextFlagValue(args, index, arg)
-			if err != nil {
-				return options, false, err
-			}
-			maxTurns, err := parseExecMaxTurns(value)
-			if err != nil {
-				return options, false, err
-			}
-			options.maxTurns = maxTurns
-			index = next
-		case strings.HasPrefix(arg, "--max-turns="):
-			maxTurns, err := parseExecMaxTurns(strings.TrimSpace(strings.TrimPrefix(arg, "--max-turns=")))
-			if err != nil {
-				return options, false, err
-			}
-			options.maxTurns = maxTurns
-		case arg == "-C" || arg == "--cwd":
-			value, next, err := nextFlagValue(args, index, arg)
-			if err != nil {
-				return options, false, err
-			}
-			options.cwd = value
-			index = next
-		case strings.HasPrefix(arg, "--cwd="):
-			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
-		case arg == "-o" || arg == "--output-format":
-			value, next, err := nextFlagValue(args, index, arg)
-			if err != nil {
-				return options, false, err
-			}
-			format, err := parseExecOutputFormat(value)
-			if err != nil {
-				return options, false, err
-			}
-			options.outputFormat = format
-			index = next
-		case strings.HasPrefix(arg, "--output-format="):
-			format, err := parseExecOutputFormat(strings.TrimSpace(strings.TrimPrefix(arg, "--output-format=")))
-			if err != nil {
-				return options, false, err
-			}
-			options.outputFormat = format
-		case arg == "--prompt":
-			value, next, err := nextFlagValue(args, index, arg)
-			if err != nil {
-				return options, false, err
-			}
-			options.promptParts = append(options.promptParts, value)
-			index = next
-		case strings.HasPrefix(arg, "--prompt="):
-			options.promptParts = append(options.promptParts, strings.TrimSpace(strings.TrimPrefix(arg, "--prompt=")))
-		case arg == "--":
-			options.promptParts = append(options.promptParts, args[index+1:]...)
-			index = len(args)
-		case strings.HasPrefix(arg, "-"):
-			return options, false, execUsageError{fmt.Sprintf("unknown exec flag %q", arg)}
-		default:
-			options.promptParts = append(options.promptParts, arg)
-		}
-	}
-
-	if options.file == "" && strings.TrimSpace(strings.Join(options.promptParts, " ")) == "" {
-		return options, false, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
-	}
-	return options, false, nil
-}
-
-func parseExecMaxTurns(value string) (int, error) {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return 0, execUsageError{"--max-turns requires a value"}
-	}
-	maxTurns, err := strconv.Atoi(trimmed)
-	if err != nil || maxTurns <= 0 {
-		return 0, execUsageError{fmt.Sprintf("invalid --max-turns %q. Expected a positive integer.", value)}
-	}
-	return maxTurns, nil
-}
-
-func nextFlagValue(args []string, index int, flag string) (string, int, error) {
-	if index+1 >= len(args) || strings.TrimSpace(args[index+1]) == "" {
-		return "", index, execUsageError{fmt.Sprintf("%s requires a value", flag)}
-	}
-	return strings.TrimSpace(args[index+1]), index + 1, nil
-}
-
-func parseExecOutputFormat(value string) (execOutputFormat, error) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", string(execOutputText):
-		return execOutputText, nil
-	case string(execOutputJSON):
-		return execOutputJSON, nil
-	default:
-		return "", execUsageError{fmt.Sprintf("invalid output format %q. Expected text or json.", value)}
-	}
 }
 
 func resolveWorkspaceRoot(cwd string, deps appDeps) (string, error) {
@@ -284,7 +244,33 @@ func resolveWorkspaceRoot(cwd string, deps appDeps) (string, error) {
 	return workspaceRoot, nil
 }
 
-func resolveExecPrompt(options execOptions, workspaceRoot string) (string, error) {
+func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reader) (string, error) {
+	if options.inputFormat == execInputStreamJSON {
+		input := ""
+		if options.file != "" {
+			promptPath := options.file
+			if !filepath.IsAbs(promptPath) {
+				promptPath = filepath.Join(workspaceRoot, promptPath)
+			}
+			data, err := os.ReadFile(promptPath)
+			if err != nil {
+				return "", execUsageError{fmt.Sprintf("prompt file not found: %s", promptPath)}
+			}
+			input = string(data)
+		} else {
+			data, err := io.ReadAll(stdin)
+			if err != nil {
+				return "", execUsageError{fmt.Sprintf("failed to read stream-json input: %v", err)}
+			}
+			input = string(data)
+		}
+		prompt, err := streamjson.ParsePrompt(input)
+		if err != nil {
+			return "", execUsageError{err.Error()}
+		}
+		return prompt, nil
+	}
+
 	parts := []string{}
 	inlinePrompt := strings.TrimSpace(strings.Join(options.promptParts, " "))
 	if inlinePrompt != "" {
@@ -322,6 +308,9 @@ func writeExecUsageError(stderr io.Writer, message string) int {
 }
 
 func writeExecProviderError(stdout io.Writer, stderr io.Writer, format execOutputFormat, code string, message string) int {
+	if format == execOutputStreamJSON {
+		return writeStreamJSONError(stdout, code, message, false, exitProvider)
+	}
 	if format == execOutputJSON {
 		if err := writeJSONLine(stdout, map[string]any{
 			"type":    "error",
@@ -342,137 +331,4 @@ func writeExecProviderError(stdout io.Writer, stderr io.Writer, format execOutpu
 		return exitCrash
 	}
 	return exitProvider
-}
-
-type execEventWriter struct {
-	stdout       io.Writer
-	stderr       io.Writer
-	format       execOutputFormat
-	streamedText *strings.Builder
-	err          error
-}
-
-func (writer *execEventWriter) runStart(cwd string, provider config.ProviderProfile, permissionMode agent.PermissionMode) {
-	if writer.format != execOutputJSON {
-		return
-	}
-	writer.writeJSON(map[string]any{
-		"type":            "run_start",
-		"cwd":             cwd,
-		"provider":        provider.Name,
-		"model":           provider.Model,
-		"permission_mode": string(permissionMode),
-	})
-}
-
-func (writer *execEventWriter) warning(message string) {
-	if writer.format == execOutputJSON {
-		writer.writeJSON(map[string]any{"type": "warning", "message": message})
-		return
-	}
-	writer.writeStderr("[zero] WARNING: " + message + "\n")
-}
-
-func (writer *execEventWriter) text(delta string) {
-	writer.streamedText.WriteString(delta)
-	if writer.format == execOutputJSON {
-		writer.writeJSON(map[string]any{"type": "text", "delta": delta})
-		return
-	}
-	writer.writeStdout(delta)
-}
-
-func (writer *execEventWriter) toolCall(call agent.ToolCall) {
-	if writer.format == execOutputJSON {
-		writer.writeJSON(map[string]any{
-			"type":      "tool_call",
-			"id":        call.ID,
-			"name":      call.Name,
-			"arguments": call.Arguments,
-		})
-		return
-	}
-	writer.writeStderr("[tool] " + call.Name + "\n")
-}
-
-func (writer *execEventWriter) toolResult(result agent.ToolResult) {
-	if writer.format == execOutputJSON {
-		writer.writeJSON(map[string]any{
-			"type":         "tool_result",
-			"tool_call_id": result.ToolCallID,
-			"name":         result.Name,
-			"status":       string(result.Status),
-			"output":       result.Output,
-		})
-		return
-	}
-	writer.writeStderr("[result] " + truncateForStatus(result.Output) + "\n")
-}
-
-func (writer *execEventWriter) usage(usage agent.Usage) {
-	if writer.format != execOutputJSON {
-		return
-	}
-	writer.writeJSON(map[string]any{
-		"type":              "usage",
-		"prompt_tokens":     usage.PromptTokens,
-		"completion_tokens": usage.CompletionTokens,
-		"total_tokens":      usage.TotalTokens(),
-	})
-}
-
-func (writer *execEventWriter) final(answer string) {
-	if writer.format == execOutputJSON {
-		writer.writeJSON(map[string]any{"type": "final", "text": answer})
-		writer.writeJSON(map[string]any{"type": "done", "exit_code": exitSuccess})
-		return
-	}
-
-	if writer.streamedText.Len() == 0 && answer != "" {
-		writer.writeStdout(answer)
-		writer.streamedText.WriteString(answer)
-	}
-	if writer.streamedText.Len() > 0 && !strings.HasSuffix(writer.streamedText.String(), "\n") {
-		writer.writeStdout("\n")
-	}
-}
-
-func (writer *execEventWriter) writeJSON(payload map[string]any) {
-	if writer.err != nil {
-		return
-	}
-	writer.err = writeJSONLine(writer.stdout, payload)
-}
-
-func (writer *execEventWriter) writeStdout(value string) {
-	if writer.err != nil {
-		return
-	}
-	_, writer.err = io.WriteString(writer.stdout, value)
-}
-
-func (writer *execEventWriter) writeStderr(value string) {
-	if writer.err != nil {
-		return
-	}
-	_, writer.err = io.WriteString(writer.stderr, value)
-}
-
-func writeJSONLine(w io.Writer, payload map[string]any) error {
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return err
-	}
-	if _, err := w.Write(append(data, '\n')); err != nil {
-		return err
-	}
-	return nil
-}
-
-func truncateForStatus(value string) string {
-	compact := strings.Join(strings.Fields(value), " ")
-	if len(compact) > 200 {
-		return compact[:200] + "..."
-	}
-	return compact
 }

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func parseExecArgs(args []string) (execOptions, bool, error) {
+	options := execOptions{inputFormat: execInputText, outputFormat: execOutputText, autonomy: "low"}
+	if len(args) == 0 {
+		return options, false, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
+	}
+
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--skip-permissions-unsafe":
+			options.skipPermissionsUnsafe = true
+		case arg == "--list-tools":
+			options.listTools = true
+		case arg == "--auto":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.autonomy = value
+			index = next
+		case strings.HasPrefix(arg, "--auto="):
+			options.autonomy = strings.TrimSpace(strings.TrimPrefix(arg, "--auto="))
+		case arg == "--enabled-tools":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.enabledTools = parseToolList(value)
+			index = next
+		case strings.HasPrefix(arg, "--enabled-tools="):
+			options.enabledTools = parseToolList(strings.TrimSpace(strings.TrimPrefix(arg, "--enabled-tools=")))
+		case arg == "--disabled-tools":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.disabledTools = parseToolList(value)
+			index = next
+		case strings.HasPrefix(arg, "--disabled-tools="):
+			options.disabledTools = parseToolList(strings.TrimSpace(strings.TrimPrefix(arg, "--disabled-tools=")))
+		case arg == "-f" || arg == "--file":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.file = value
+			index = next
+		case strings.HasPrefix(arg, "--file="):
+			options.file = strings.TrimSpace(strings.TrimPrefix(arg, "--file="))
+		case arg == "-m" || arg == "--model":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.model = value
+			index = next
+		case strings.HasPrefix(arg, "--model="):
+			options.model = strings.TrimSpace(strings.TrimPrefix(arg, "--model="))
+		case arg == "--max-turns":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			maxTurns, err := parseExecMaxTurns(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.maxTurns = maxTurns
+			index = next
+		case strings.HasPrefix(arg, "--max-turns="):
+			maxTurns, err := parseExecMaxTurns(strings.TrimSpace(strings.TrimPrefix(arg, "--max-turns=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.maxTurns = maxTurns
+		case arg == "-C" || arg == "--cwd":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.cwd = value
+			index = next
+		case strings.HasPrefix(arg, "--cwd="):
+			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
+		case arg == "-i" || arg == "--input-format":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			format, err := parseExecInputFormat(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.inputFormat = format
+			index = next
+		case strings.HasPrefix(arg, "--input-format="):
+			format, err := parseExecInputFormat(strings.TrimSpace(strings.TrimPrefix(arg, "--input-format=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.inputFormat = format
+		case arg == "-o" || arg == "--output-format":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			format, err := parseExecOutputFormat(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.outputFormat = format
+			index = next
+		case strings.HasPrefix(arg, "--output-format="):
+			format, err := parseExecOutputFormat(strings.TrimSpace(strings.TrimPrefix(arg, "--output-format=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.outputFormat = format
+		case arg == "--prompt":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.promptParts = append(options.promptParts, value)
+			index = next
+		case strings.HasPrefix(arg, "--prompt="):
+			options.promptParts = append(options.promptParts, strings.TrimSpace(strings.TrimPrefix(arg, "--prompt=")))
+		case arg == "--resume":
+			if index+1 < len(args) && !strings.HasPrefix(args[index+1], "-") && strings.TrimSpace(args[index+1]) != "" {
+				options.resume = strings.TrimSpace(args[index+1])
+				index++
+			} else {
+				options.resumeLatest = true
+			}
+		case strings.HasPrefix(arg, "--resume="):
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--resume="))
+			if value == "" {
+				options.resumeLatest = true
+			} else {
+				options.resume = value
+			}
+		case arg == "--fork":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.fork = value
+			index = next
+		case strings.HasPrefix(arg, "--fork="):
+			options.fork = strings.TrimSpace(strings.TrimPrefix(arg, "--fork="))
+		case arg == "--":
+			options.promptParts = append(options.promptParts, args[index+1:]...)
+			index = len(args)
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown exec flag %q", arg)}
+		default:
+			options.promptParts = append(options.promptParts, arg)
+		}
+	}
+
+	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
+		return options, false, execUsageError{"Use either --resume or --fork, not both."}
+	}
+	if options.inputFormat == execInputStreamJSON && strings.TrimSpace(strings.Join(options.promptParts, " ")) != "" {
+		return options, false, execUsageError{"Stream-json input does not accept positional prompt text. Pipe JSONL or use --file."}
+	}
+	if !options.listTools && options.file == "" && options.inputFormat != execInputStreamJSON && strings.TrimSpace(strings.Join(options.promptParts, " ")) == "" {
+		return options, false, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
+	}
+	return options, false, nil
+}
+
+func parseExecMaxTurns(value string) (int, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, execUsageError{"--max-turns requires a value"}
+	}
+	maxTurns, err := strconv.Atoi(trimmed)
+	if err != nil || maxTurns <= 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid --max-turns %q. Expected a positive integer.", value)}
+	}
+	return maxTurns, nil
+}
+
+func nextFlagValue(args []string, index int, flag string) (string, int, error) {
+	if index+1 >= len(args) || strings.TrimSpace(args[index+1]) == "" {
+		return "", index, execUsageError{fmt.Sprintf("%s requires a value", flag)}
+	}
+	return strings.TrimSpace(args[index+1]), index + 1, nil
+}
+
+func parseExecOutputFormat(value string) (execOutputFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", string(execOutputText):
+		return execOutputText, nil
+	case string(execOutputJSON):
+		return execOutputJSON, nil
+	case string(execOutputStreamJSON):
+		return execOutputStreamJSON, nil
+	default:
+		return "", execUsageError{fmt.Sprintf("invalid output format %q. Expected text, json, or stream-json.", value)}
+	}
+}
+
+func parseExecInputFormat(value string) (execInputFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", string(execInputText):
+		return execInputText, nil
+	case string(execInputStreamJSON):
+		return execInputStreamJSON, nil
+	default:
+		return "", execUsageError{fmt.Sprintf("Invalid input format %q. Expected text or stream-json.", value)}
+	}
+}

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestRunExecHelpDocumentsProtocolFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec", "--help"}, &stdout, &stderr)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d", exitSuccess, exitCode)
+	}
+	for _, want := range []string{
+		"--auto",
+		"--enabled-tools",
+		"--disabled-tools",
+		"--list-tools",
+		"--input-format text|stream-json",
+		"--output-format text|json|stream-json",
+		"--resume",
+		"--fork",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected exec help to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunExecListsFilteredToolsWithoutPromptOrProvider(t *testing.T) {
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--list-tools", "--enabled-tools", "read_file,grep"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	for _, want := range []string{"Tools visible to model", "read_file", "grep"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected tool list to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "bash") {
+		t.Fatalf("expected filtered tool list to hide bash, got %q", stdout.String())
+	}
+}
+
+func TestRunExecRejectsInvalidProtocolOptionsBeforeRuntime(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "auto", args: []string{"exec", "--auto", "chaos", "hello"}, want: "Invalid autonomy level"},
+		{name: "enabled", args: []string{"exec", "--enabled-tools", "missing_tool", "hello"}, want: "Unknown tool"},
+		{name: "overlap", args: []string{"exec", "--enabled-tools", "read_file", "--disabled-tools", "read_file", "hello"}, want: "both enabled and disabled"},
+		{name: "input", args: []string{"exec", "--input-format", "yaml", "hello"}, want: "Invalid input format"},
+		{name: "resume-fork", args: []string{"exec", "--resume", "abc", "--fork", "def", "hello"}, want: "Use either --resume or --fork, not both"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			exitCode := Run(tc.args, &stdout, &stderr)
+
+			if exitCode != exitUsage {
+				t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout before runtime, got %q", stdout.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, tc.want) {
+				t.Fatalf("expected stderr to contain %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRunExecStreamJSONOutputsRunEndAndRecordsSession(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--output-format", "stream-json", "persist this"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+
+	events := decodeJSONLines(t, stdout.String())
+	types := jsonEventTypes(events)
+	for _, want := range []string{"run_start", "text", "final", "run_end"} {
+		if !slices.Contains(types, want) {
+			t.Fatalf("expected event %q in %v; output %q", want, types, stdout.String())
+		}
+	}
+	runStart := events[0]
+	sessionID, ok := runStart["sessionId"].(string)
+	if !ok || sessionID == "" {
+		t.Fatalf("expected run_start sessionId, got %#v", runStart)
+	}
+	if got := events[len(events)-1]["type"]; got != "run_end" {
+		t.Fatalf("expected last event run_end, got %#v", events[len(events)-1])
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{
+		RootDir: filepath.Join(dataHome, "zero", "sessions"),
+	})
+	recorded, err := store.ReadEvents(sessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(recorded) != 2 || recorded[0].Type != sessions.EventMessage || recorded[1].Type != sessions.EventMessage {
+		t.Fatalf("recorded events = %#v", recorded)
+	}
+}
+
+func TestRunExecStreamJSONProviderErrorEmitsErrorAndRunEnd(t *testing.T) {
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--output-format", "stream-json", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, errors.New("provider failed")
+		},
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d", exitProvider, exitCode)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	events := decodeJSONLines(t, stdout.String())
+	if len(events) != 2 {
+		t.Fatalf("expected error and run_end events, got %#v", events)
+	}
+	if events[0]["type"] != "error" || events[0]["code"] != "provider_error" {
+		t.Fatalf("expected provider error event, got %#v", events[0])
+	}
+	if events[1]["type"] != "run_end" || events[1]["exitCode"] != float64(exitProvider) {
+		t.Fatalf("expected run_end provider exit, got %#v", events[1])
+	}
+	if events[0]["runId"] != events[1]["runId"] {
+		t.Fatalf("expected matching runId, got %#v", events)
+	}
+}
+
+func TestRunExecReadsStreamJSONPromptFromStdin(t *testing.T) {
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--input-format", "stream-json", "--output-format", "stream-json"}, &stdout, &stderr, appDeps{
+		stdin: strings.NewReader(`{"schemaVersion":1,"type":"prompt","content":"from stdin"}` + "\n"),
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	events := decodeJSONLines(t, stdout.String())
+	final := events[len(events)-2]
+	if final["type"] != "final" || final["text"] != "from stdin" {
+		t.Fatalf("expected final event from stdin, got %#v", final)
+	}
+}

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -100,8 +100,14 @@ func TestRunExecListsToolsAsStreamJSONWhenRequested(t *testing.T) {
 	if events[0]["type"] != "run_start" || events[1]["type"] != "final" || events[2]["type"] != "run_end" {
 		t.Fatalf("unexpected stream-json tool list events: %#v", events)
 	}
-	if text, _ := events[1]["text"].(string); !strings.Contains(text, "Tools visible to model") || !strings.Contains(text, "read_file") {
+	text, _ := events[1]["text"].(string)
+	if !strings.Contains(text, "Tools visible to model") || !strings.Contains(text, "read_file") {
 		t.Fatalf("expected final event to contain tool list, got %#v", events[1])
+	}
+	for _, name := range []string{"bash", "grep", "write_file"} {
+		if strings.Contains(text, name) {
+			t.Fatalf("unexpected non-enabled tool %q leaked into stream-json output: %#v", name, events[1])
+		}
 	}
 }
 

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -314,6 +314,9 @@ func TestExecEventWriterTruncatesStreamJSONToolResults(t *testing.T) {
 	if events[0]["truncated"] != true {
 		t.Fatalf("expected truncated=true, got %#v", events[0])
 	}
+	if events[0]["name"] != "read_file" {
+		t.Fatalf("expected tool_result name to be read_file, got %#v", events[0])
+	}
 	output := events[0]["output"].(string)
 	if len(output) >= streamJSONToolResultOutputLimit+100 || !strings.Contains(output, "[truncated]") {
 		t.Fatalf("expected shortened output with marker, got len=%d", len(output))

--- a/internal/cli/exec_sessions.go
+++ b/internal/cli/exec_sessions.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+type execSessionRecorder struct {
+	prepared sessions.PreparedExec
+	err      error
+}
+
+func shouldUseExecSession(options execOptions) bool {
+	return options.outputFormat == execOutputStreamJSON ||
+		options.resume != "" ||
+		options.resumeLatest ||
+		options.fork != ""
+}
+
+func preflightExecSession(options execOptions) error {
+	if options.resume == "" && !options.resumeLatest && options.fork == "" {
+		return nil
+	}
+	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
+		return execUsageError{"Use either --resume or --fork, not both."}
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{})
+	switch {
+	case options.fork != "":
+		session, err := store.Get(options.fork)
+		if err != nil {
+			return err
+		}
+		if session == nil {
+			return execUsageError{"Zero session not found: " + options.fork}
+		}
+	case options.resume != "":
+		session, err := store.Get(options.resume)
+		if err != nil {
+			return err
+		}
+		if session == nil {
+			return execUsageError{"Zero session not found: " + options.resume}
+		}
+	case options.resumeLatest:
+		latest, err := store.Latest()
+		if err != nil {
+			return err
+		}
+		if latest == nil {
+			return execUsageError{"No Zero sessions available to resume."}
+		}
+	}
+	return nil
+}
+
+func createSessionTitle(prompt string) string {
+	title := strings.Join(strings.Fields(prompt), " ")
+	if len(title) > 80 {
+		title = title[:80]
+	}
+	if title == "" {
+		return "Zero exec session"
+	}
+	return title
+}
+
+func (recorder *execSessionRecorder) append(eventType sessions.EventType, payload any) {
+	if recorder.err != nil || recorder.prepared.Store == nil || recorder.prepared.Session.SessionID == "" {
+		return
+	}
+	_, recorder.err = recorder.prepared.Store.AppendEvent(recorder.prepared.Session.SessionID, sessions.AppendEventInput{
+		Type:    eventType,
+		Payload: payload,
+	})
+}

--- a/internal/cli/exec_tools.go
+++ b/internal/cli/exec_tools.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+var toolNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+func parseToolList(value string) []string {
+	seen := map[string]bool{}
+	tools := []string{}
+	for _, name := range strings.FieldsFunc(value, func(char rune) bool {
+		return char == ',' || char == ' ' || char == '\t' || char == '\n' || char == '\r'
+	}) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		tools = append(tools, name)
+	}
+	return tools
+}
+
+func validateExecToolFilters(options execOptions, registry *tools.Registry) error {
+	for _, name := range append(append([]string{}, options.enabledTools...), options.disabledTools...) {
+		if !toolNamePattern.MatchString(name) {
+			return execUsageError{fmt.Sprintf("Invalid tool name %q.", name)}
+		}
+		if _, ok := registry.Get(name); !ok {
+			return execUsageError{fmt.Sprintf("Unknown tool: %s", name)}
+		}
+	}
+	disabled := map[string]bool{}
+	for _, name := range options.disabledTools {
+		disabled[name] = true
+	}
+	for _, name := range options.enabledTools {
+		if disabled[name] {
+			return execUsageError{fmt.Sprintf("Tool cannot be both enabled and disabled: %s", name)}
+		}
+	}
+	return nil
+}
+
+func resolveExecPermissionMode(options execOptions) (agent.PermissionMode, error) {
+	if options.skipPermissionsUnsafe {
+		return agent.PermissionModeUnsafe, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(options.autonomy)) {
+	case "", "low", "medium":
+		return agent.PermissionModeAuto, nil
+	case "high":
+		return agent.PermissionModeUnsafe, nil
+	default:
+		return "", execUsageError{fmt.Sprintf("Invalid autonomy level %q. Expected low, medium, or high.", options.autonomy)}
+	}
+}
+
+func writeExecToolList(w io.Writer, registry *tools.Registry, options execOptions, permissionMode agent.PermissionMode) error {
+	visible := visibleExecTools(registry, options, permissionMode)
+	lines := []string{"Tools visible to model:"}
+	for _, tool := range visible {
+		safety := tool.Safety()
+		lines = append(lines, fmt.Sprintf("  %s [%s/%s] - %s", tool.Name(), safety.SideEffect, safety.Permission, tool.Description()))
+	}
+	if len(visible) == 0 {
+		lines = append(lines, "  (none)")
+	}
+	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
+	return err
+}
+
+func visibleExecTools(registry *tools.Registry, options execOptions, permissionMode agent.PermissionMode) []tools.Tool {
+	all := registry.All()
+	visible := []tools.Tool{}
+	for _, tool := range all {
+		if !execToolAllowedByFilters(tool.Name(), options) {
+			continue
+		}
+		if !execToolAdvertised(tool, permissionMode) {
+			continue
+		}
+		visible = append(visible, tool)
+	}
+	sort.Slice(visible, func(i, j int) bool {
+		return visible[i].Name() < visible[j].Name()
+	})
+	return visible
+}
+
+func execToolAllowedByFilters(name string, options execOptions) bool {
+	if len(options.enabledTools) > 0 && !toolListContains(options.enabledTools, name) {
+		return false
+	}
+	return !toolListContains(options.disabledTools, name)
+}
+
+func execToolAdvertised(tool tools.Tool, permissionMode agent.PermissionMode) bool {
+	if tool.Safety().Permission == tools.PermissionDeny {
+		return false
+	}
+	if permissionMode == agent.PermissionModeAuto {
+		return tool.Safety().Permission == tools.PermissionAllow
+	}
+	return true
+}
+
+func toolListContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/exec_tools.go
+++ b/internal/cli/exec_tools.go
@@ -96,12 +96,3 @@ func visibleExecTools(registry *tools.Registry, options execOptions, permissionM
 	})
 	return visible
 }
-
-func toolListContains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -1,0 +1,295 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type execEventWriter struct {
+	stdout       io.Writer
+	stderr       io.Writer
+	format       execOutputFormat
+	runID        string
+	sessionID    string
+	streamedText *strings.Builder
+	err          error
+}
+
+func (writer *execEventWriter) runStart(cwd string, provider config.ProviderProfile, permissionMode agent.PermissionMode) {
+	switch writer.format {
+	case execOutputJSON:
+		writer.writeJSON(map[string]any{
+			"type":            "run_start",
+			"cwd":             cwd,
+			"provider":        provider.Name,
+			"model":           provider.Model,
+			"permission_mode": string(permissionMode),
+		})
+	case execOutputStreamJSON:
+		writer.writeStreamJSON(streamjson.Event{
+			Type:      streamjson.EventRunStart,
+			RunID:     writer.runID,
+			SessionID: writer.sessionID,
+			Cwd:       cwd,
+			Provider:  provider.Name,
+			Model:     provider.Model,
+			APIModel:  provider.Model,
+		})
+	}
+}
+
+func (writer *execEventWriter) warning(message string) {
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{"type": "warning", "message": message})
+		return
+	}
+	if writer.format == execOutputStreamJSON {
+		writer.writeStreamJSON(streamjson.Event{Type: streamjson.EventWarning, RunID: writer.runID, Message: message})
+		return
+	}
+	writer.writeStderr("[zero] WARNING: " + message + "\n")
+}
+
+func (writer *execEventWriter) text(delta string) {
+	writer.streamedText.WriteString(delta)
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{"type": "text", "delta": delta})
+		return
+	}
+	if writer.format == execOutputStreamJSON {
+		writer.writeStreamJSON(streamjson.Event{Type: streamjson.EventText, RunID: writer.runID, Delta: delta})
+		return
+	}
+	writer.writeStdout(delta)
+}
+
+func (writer *execEventWriter) toolCall(call agent.ToolCall, registry *tools.Registry) {
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{
+			"type":      "tool_call",
+			"id":        call.ID,
+			"name":      call.Name,
+			"arguments": call.Arguments,
+		})
+		return
+	}
+	if writer.format == execOutputStreamJSON {
+		writer.writeStreamJSON(streamjson.Event{
+			Type:       streamjson.EventToolCall,
+			RunID:      writer.runID,
+			ID:         call.ID,
+			Name:       call.Name,
+			Args:       parseToolCallArgs(call.Arguments),
+			SideEffect: streamJSONSideEffect(call.Name, registry),
+		})
+		return
+	}
+	writer.writeStderr("[tool] " + call.Name + "\n")
+}
+
+func (writer *execEventWriter) toolResult(result agent.ToolResult) {
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{
+			"type":         "tool_result",
+			"tool_call_id": result.ToolCallID,
+			"name":         result.Name,
+			"status":       string(result.Status),
+			"output":       result.Output,
+		})
+		return
+	}
+	if writer.format == execOutputStreamJSON {
+		truncated := false
+		writer.writeStreamJSON(streamjson.Event{
+			Type:      streamjson.EventToolResult,
+			RunID:     writer.runID,
+			ID:        result.ToolCallID,
+			Status:    string(result.Status),
+			Output:    result.Output,
+			Truncated: &truncated,
+		})
+		return
+	}
+	writer.writeStderr("[result] " + truncateForStatus(result.Output) + "\n")
+}
+
+func (writer *execEventWriter) usage(usage agent.Usage) {
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{
+			"type":              "usage",
+			"prompt_tokens":     usage.PromptTokens,
+			"completion_tokens": usage.CompletionTokens,
+			"total_tokens":      usage.TotalTokens(),
+		})
+		return
+	}
+	if writer.format == execOutputStreamJSON {
+		promptTokens := usage.EffectiveInputTokens()
+		completionTokens := usage.EffectiveOutputTokens()
+		totalTokens := usage.TotalTokens()
+		writer.writeStreamJSON(streamjson.Event{
+			Type:             streamjson.EventUsage,
+			RunID:            writer.runID,
+			PromptTokens:     &promptTokens,
+			CompletionTokens: &completionTokens,
+			TotalTokens:      &totalTokens,
+		})
+	}
+}
+
+func (writer *execEventWriter) final(answer string) {
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{"type": "final", "text": answer})
+		writer.writeJSON(map[string]any{"type": "done", "exit_code": exitSuccess})
+		return
+	}
+	if writer.format == execOutputStreamJSON {
+		writer.writeStreamJSON(streamjson.Event{Type: streamjson.EventFinal, RunID: writer.runID, Text: answer})
+		return
+	}
+
+	if writer.streamedText.Len() == 0 && answer != "" {
+		writer.writeStdout(answer)
+		writer.streamedText.WriteString(answer)
+	}
+	if writer.streamedText.Len() > 0 && !strings.HasSuffix(writer.streamedText.String(), "\n") {
+		writer.writeStdout("\n")
+	}
+}
+
+func (writer *execEventWriter) errorEvent(code string, message string, recoverable bool) {
+	if writer.format == execOutputStreamJSON {
+		writer.writeStreamJSON(streamjson.Event{
+			Type:        streamjson.EventError,
+			RunID:       writer.runID,
+			Code:        code,
+			Message:     message,
+			Recoverable: &recoverable,
+		})
+		return
+	}
+	if writer.format == execOutputJSON {
+		writer.writeJSON(map[string]any{"type": "error", "code": code, "message": message})
+		return
+	}
+	writer.writeStderr("[zero] " + message + "\n")
+}
+
+func (writer *execEventWriter) runEnd(status string, exitCode int) {
+	if writer.format != execOutputStreamJSON {
+		return
+	}
+	writer.writeStreamJSON(streamjson.Event{
+		Type:     streamjson.EventRunEnd,
+		RunID:    writer.runID,
+		Status:   status,
+		ExitCode: &exitCode,
+	})
+}
+
+func (writer *execEventWriter) writeStreamJSON(event streamjson.Event) {
+	if writer.err != nil {
+		return
+	}
+	line, err := streamjson.FormatEvent(event)
+	if err != nil {
+		writer.err = err
+		return
+	}
+	writer.writeStdout(line + "\n")
+}
+
+func (writer *execEventWriter) writeJSON(payload map[string]any) {
+	if writer.err != nil {
+		return
+	}
+	writer.err = writeJSONLine(writer.stdout, payload)
+}
+
+func (writer *execEventWriter) writeStdout(value string) {
+	if writer.err != nil {
+		return
+	}
+	_, writer.err = io.WriteString(writer.stdout, value)
+}
+
+func (writer *execEventWriter) writeStderr(value string) {
+	if writer.err != nil {
+		return
+	}
+	_, writer.err = io.WriteString(writer.stderr, value)
+}
+
+func writeJSONLine(w io.Writer, payload map[string]any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseToolCallArgs(arguments string) any {
+	if strings.TrimSpace(arguments) == "" {
+		return nil
+	}
+	var args any
+	if err := json.Unmarshal([]byte(arguments), &args); err != nil {
+		return arguments
+	}
+	return args
+}
+
+func streamJSONSideEffect(name string, registry *tools.Registry) string {
+	tool, ok := registry.Get(name)
+	if !ok {
+		return "unknown"
+	}
+	switch tool.Safety().SideEffect {
+	case tools.SideEffectRead:
+		return "read"
+	case tools.SideEffectWrite:
+		return "write"
+	case tools.SideEffectShell:
+		return "shell"
+	case tools.SideEffectNetwork:
+		return "network"
+	default:
+		return "unknown"
+	}
+}
+
+func truncateForStatus(value string) string {
+	compact := strings.Join(strings.Fields(value), " ")
+	if len(compact) > 200 {
+		return compact[:200] + "..."
+	}
+	return compact
+}
+
+func writeStreamJSONError(stdout io.Writer, code string, message string, recoverable bool, exitCode int) int {
+	writer := execEventWriter{
+		stdout: stdout,
+		format: execOutputStreamJSON,
+		runID:  streamjson.CreateRunID(timeNow()),
+	}
+	writer.errorEvent(code, message, recoverable)
+	writer.runEnd("error", exitCode)
+	if writer.err != nil {
+		return exitCrash
+	}
+	return exitCode
+}
+
+func timeNow() time.Time {
+	return time.Now()
+}

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -119,6 +119,7 @@ func (writer *execEventWriter) toolResult(result agent.ToolResult) {
 			Type:      streamjson.EventToolResult,
 			RunID:     writer.runID,
 			ID:        result.ToolCallID,
+			Name:      result.Name,
 			Status:    string(result.Status),
 			Output:    output,
 			Truncated: &truncated,

--- a/internal/sessions/exec_session.go
+++ b/internal/sessions/exec_session.go
@@ -1,0 +1,197 @@
+package sessions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type ExecMode string
+
+const (
+	ModeNew    ExecMode = "new"
+	ModeResume ExecMode = "resume"
+	ModeFork   ExecMode = "fork"
+)
+
+type ExecError struct {
+	message string
+}
+
+func (err ExecError) Error() string {
+	return err.message
+}
+
+type PrepareExecOptions struct {
+	Store        *Store
+	SessionID    string
+	Title        string
+	Cwd          string
+	ModelID      string
+	Provider     string
+	Resume       string
+	ResumeLatest bool
+	Fork         string
+}
+
+type PreparedExec struct {
+	Mode          ExecMode
+	Session       Metadata
+	ContextEvents []Event
+	Store         *Store
+}
+
+func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
+	if (options.Resume != "" || options.ResumeLatest) && options.Fork != "" {
+		return PreparedExec{}, ExecError{"Use either --resume or --fork, not both."}
+	}
+
+	store := options.Store
+	if store == nil {
+		store = NewStore(StoreOptions{})
+	}
+
+	if options.Fork != "" {
+		parent, err := store.Get(options.Fork)
+		if err != nil {
+			return PreparedExec{}, err
+		}
+		if parent == nil {
+			return PreparedExec{}, ExecError{"Zero session not found: " + options.Fork}
+		}
+		contextEvents, err := store.ReadEvents(parent.SessionID)
+		if err != nil {
+			return PreparedExec{}, err
+		}
+		session, err := store.Fork(parent.SessionID, ForkInput{
+			SessionID: options.SessionID,
+			Title:     firstNonEmpty(options.Title, forkTitle(parent.Title)),
+			Cwd:       options.Cwd,
+			ModelID:   options.ModelID,
+			Provider:  options.Provider,
+		})
+		if err != nil {
+			return PreparedExec{}, err
+		}
+		return PreparedExec{Mode: ModeFork, Session: session, ContextEvents: contextEvents, Store: store}, nil
+	}
+
+	if options.Resume != "" || options.ResumeLatest {
+		sessionID := strings.TrimSpace(options.Resume)
+		if sessionID == "" {
+			latest, err := store.Latest()
+			if err != nil {
+				return PreparedExec{}, err
+			}
+			if latest == nil {
+				return PreparedExec{}, ExecError{"No Zero sessions available to resume."}
+			}
+			sessionID = latest.SessionID
+		}
+		session, err := store.Get(sessionID)
+		if err != nil {
+			return PreparedExec{}, err
+		}
+		if session == nil {
+			return PreparedExec{}, ExecError{"Zero session not found: " + sessionID}
+		}
+		contextEvents, err := store.ReadEvents(session.SessionID)
+		if err != nil {
+			return PreparedExec{}, err
+		}
+		return PreparedExec{Mode: ModeResume, Session: *session, ContextEvents: contextEvents, Store: store}, nil
+	}
+
+	session, err := store.Create(CreateInput{
+		SessionID: options.SessionID,
+		Title:     options.Title,
+		Cwd:       options.Cwd,
+		ModelID:   options.ModelID,
+		Provider:  options.Provider,
+	})
+	if err != nil {
+		return PreparedExec{}, err
+	}
+	return PreparedExec{Mode: ModeNew, Session: session, ContextEvents: []Event{}, Store: store}, nil
+}
+
+func FormatExecPrompt(prompt string, prepared PreparedExec) string {
+	if prepared.Mode == ModeNew || len(prepared.ContextEvents) == 0 {
+		return prompt
+	}
+	events := prepared.ContextEvents
+	if len(events) > 20 {
+		events = events[len(events)-20:]
+	}
+
+	lines := []string{}
+	for _, event := range events {
+		lines = append(lines, fmt.Sprintf("- #%d %s: %s", event.Sequence, event.Type, summarizePayload(event.Payload)))
+	}
+	label := "Continuing"
+	sessionID := prepared.Session.SessionID
+	if prepared.Mode == ModeFork {
+		label = "Forked from"
+		if prepared.Session.ParentSessionID != "" {
+			sessionID = prepared.Session.ParentSessionID
+		}
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("%s Zero session %s.", label, sessionID),
+		"Previous session context:",
+		strings.Join(lines, "\n"),
+		"",
+		"Current user request:",
+		prompt,
+	}, "\n")
+}
+
+func forkTitle(title string) string {
+	if title == "" {
+		return ""
+	}
+	return title + " (fork)"
+}
+
+func summarizePayload(payload any) string {
+	text := extractText(payload)
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return "{}"
+		}
+		text = string(data)
+	}
+	if len(text) > 500 {
+		return text[:500]
+	}
+	return text
+}
+
+func extractText(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case float64, bool, int:
+		return fmt.Sprint(typed)
+	case []any:
+		parts := []string{}
+		for _, item := range typed {
+			if text := extractText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	case map[string]any:
+		parts := []string{}
+		for _, item := range typed {
+			if text := extractText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, " ")
+	default:
+		return ""
+	}
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -1,0 +1,446 @@
+package sessions
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	MetadataFile = "metadata.json"
+	EventsFile   = "events.jsonl"
+)
+
+type EventType string
+
+const (
+	EventMessage     EventType = "message"
+	EventToolCall    EventType = "tool_call"
+	EventToolResult  EventType = "tool_result"
+	EventUsage       EventType = "provider_usage"
+	EventError       EventType = "error"
+	EventSessionFork EventType = "session_fork"
+)
+
+type Metadata struct {
+	SessionID          string    `json:"sessionId"`
+	Title              string    `json:"title,omitempty"`
+	Cwd                string    `json:"cwd,omitempty"`
+	ModelID            string    `json:"modelId,omitempty"`
+	Provider           string    `json:"provider,omitempty"`
+	ParentSessionID    string    `json:"parentSessionId,omitempty"`
+	ForkedFromEventID  string    `json:"forkedFromEventId,omitempty"`
+	ForkedFromSequence int       `json:"forkedFromSequence,omitempty"`
+	CreatedAt          string    `json:"createdAt"`
+	UpdatedAt          string    `json:"updatedAt"`
+	EventCount         int       `json:"eventCount"`
+	LastEventType      EventType `json:"lastEventType,omitempty"`
+}
+
+type Event struct {
+	ID        string    `json:"id"`
+	SessionID string    `json:"sessionId"`
+	Sequence  int       `json:"sequence"`
+	Type      EventType `json:"type"`
+	CreatedAt string    `json:"createdAt"`
+	Payload   any       `json:"payload,omitempty"`
+}
+
+type DefaultRootOptions struct {
+	Env map[string]string
+}
+
+type StoreOptions struct {
+	RootDir string
+	Now     func() time.Time
+}
+
+type Store struct {
+	RootDir string
+	now     func() time.Time
+}
+
+type CreateInput struct {
+	SessionID          string
+	Title              string
+	Cwd                string
+	ModelID            string
+	Provider           string
+	ParentSessionID    string
+	ForkedFromEventID  string
+	ForkedFromSequence int
+}
+
+type ForkInput struct {
+	SessionID string
+	Title     string
+	Cwd       string
+	ModelID   string
+	Provider  string
+}
+
+type AppendEventInput struct {
+	Type    EventType
+	Payload any
+}
+
+func DefaultRoot(options DefaultRootOptions) (string, error) {
+	dataHome := strings.TrimSpace(envValue(options.Env, "XDG_DATA_HOME"))
+	if dataHome == "" {
+		home := strings.TrimSpace(envValue(options.Env, "HOME"))
+		if home == "" {
+			var err error
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+		}
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(dataHome, "zero", "sessions"), nil
+}
+
+func NewStore(options StoreOptions) *Store {
+	root := options.RootDir
+	if root == "" {
+		if resolved, err := DefaultRoot(DefaultRootOptions{}); err == nil {
+			root = resolved
+		}
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{RootDir: root, now: now}
+}
+
+func (store *Store) Create(input CreateInput) (Metadata, error) {
+	sessionID := strings.TrimSpace(input.SessionID)
+	if sessionID == "" {
+		sessionID = createSessionID(store.now())
+	}
+	if !isValidSessionID(sessionID) {
+		return Metadata{}, fmt.Errorf("Invalid Zero session id")
+	}
+
+	createdAt := store.timestamp()
+	session := Metadata{
+		SessionID:          sessionID,
+		Title:              input.Title,
+		Cwd:                input.Cwd,
+		ModelID:            input.ModelID,
+		Provider:           input.Provider,
+		ParentSessionID:    input.ParentSessionID,
+		ForkedFromEventID:  input.ForkedFromEventID,
+		ForkedFromSequence: input.ForkedFromSequence,
+		CreatedAt:          createdAt,
+		UpdatedAt:          createdAt,
+		EventCount:         0,
+	}
+
+	if err := os.MkdirAll(store.RootDir, 0o700); err != nil {
+		return Metadata{}, err
+	}
+	if err := os.Mkdir(store.sessionPath(sessionID), 0o700); err != nil {
+		if os.IsExist(err) {
+			return Metadata{}, fmt.Errorf("Zero session already exists: %s", sessionID)
+		}
+		return Metadata{}, err
+	}
+	if err := store.writeMetadata(session); err != nil {
+		return Metadata{}, err
+	}
+	file, err := os.OpenFile(store.eventsPath(sessionID), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return session, nil
+		}
+		return Metadata{}, err
+	}
+	if err := file.Close(); err != nil {
+		return Metadata{}, err
+	}
+	return session, nil
+}
+
+func (store *Store) Get(sessionID string) (*Metadata, error) {
+	if !isValidSessionID(sessionID) {
+		return nil, fmt.Errorf("Invalid Zero session id")
+	}
+	session, err := store.readMetadata(sessionID)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+func (store *Store) List() ([]Metadata, error) {
+	if err := os.MkdirAll(store.RootDir, 0o700); err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(store.RootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	sessions := []Metadata{}
+	for _, entry := range entries {
+		if !entry.IsDir() || !isValidSessionID(entry.Name()) {
+			continue
+		}
+		session, err := store.Get(entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if session != nil {
+			sessions = append(sessions, *session)
+		}
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		if sessions[i].UpdatedAt == sessions[j].UpdatedAt {
+			return sessions[i].SessionID < sessions[j].SessionID
+		}
+		return sessions[i].UpdatedAt > sessions[j].UpdatedAt
+	})
+	return sessions, nil
+}
+
+func (store *Store) Latest() (*Metadata, error) {
+	sessions, err := store.List()
+	if err != nil || len(sessions) == 0 {
+		return nil, err
+	}
+	return &sessions[0], nil
+}
+
+func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, error) {
+	parent, err := store.Get(parentSessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if parent == nil {
+		return Metadata{}, fmt.Errorf("Zero session not found: %s", parentSessionID)
+	}
+
+	parentEvents, err := store.ReadEvents(parentSessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	lastEventID := ""
+	lastSequence := 0
+	if len(parentEvents) > 0 {
+		last := parentEvents[len(parentEvents)-1]
+		lastEventID = last.ID
+		lastSequence = last.Sequence
+	}
+
+	title := input.Title
+	if title == "" && parent.Title != "" {
+		title = parent.Title + " (fork)"
+	}
+	fork, err := store.Create(CreateInput{
+		SessionID:          input.SessionID,
+		Title:              title,
+		Cwd:                firstNonEmpty(input.Cwd, parent.Cwd),
+		ModelID:            firstNonEmpty(input.ModelID, parent.ModelID),
+		Provider:           firstNonEmpty(input.Provider, parent.Provider),
+		ParentSessionID:    parentSessionID,
+		ForkedFromEventID:  lastEventID,
+		ForkedFromSequence: lastSequence,
+	})
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	for _, event := range parentEvents {
+		if _, err := store.AppendEvent(fork.SessionID, AppendEventInput{Type: event.Type, Payload: cloneJSONValue(event.Payload)}); err != nil {
+			return Metadata{}, err
+		}
+	}
+	if _, err := store.AppendEvent(fork.SessionID, AppendEventInput{
+		Type: EventSessionFork,
+		Payload: map[string]any{
+			"parentSessionId":    parentSessionID,
+			"parentEventCount":   parent.EventCount,
+			"copiedEventCount":   len(parentEvents),
+			"forkedFromEventId":  lastEventID,
+			"forkedFromSequence": lastSequence,
+		},
+	}); err != nil {
+		return Metadata{}, err
+	}
+
+	updated, err := store.readMetadata(fork.SessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return updated, nil
+}
+
+func (store *Store) AppendEvent(sessionID string, input AppendEventInput) (Event, error) {
+	if !isValidSessionID(sessionID) {
+		return Event{}, fmt.Errorf("Invalid Zero session id")
+	}
+	session, err := store.readMetadata(sessionID)
+	if err != nil {
+		return Event{}, err
+	}
+	sequence := session.EventCount + 1
+	createdAt := store.timestamp()
+	event := Event{
+		ID:        fmt.Sprintf("%s:%d", sessionID, sequence),
+		SessionID: sessionID,
+		Sequence:  sequence,
+		Type:      input.Type,
+		CreatedAt: createdAt,
+		Payload:   input.Payload,
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return Event{}, err
+	}
+	file, err := os.OpenFile(store.eventsPath(sessionID), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return Event{}, err
+	}
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		_ = file.Close()
+		return Event{}, err
+	}
+	if err := file.Close(); err != nil {
+		return Event{}, err
+	}
+
+	session.UpdatedAt = createdAt
+	session.EventCount = sequence
+	session.LastEventType = input.Type
+	if err := store.writeMetadata(session); err != nil {
+		return Event{}, err
+	}
+	return event, nil
+}
+
+func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
+	if !isValidSessionID(sessionID) {
+		return nil, fmt.Errorf("Invalid Zero session id")
+	}
+	data, err := os.ReadFile(store.eventsPath(sessionID))
+	if os.IsNotExist(err) {
+		return []Event{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	events := []Event{}
+	for index, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			return nil, fmt.Errorf("Invalid JSON in Zero session %s %s at line %d", sessionID, EventsFile, index+1)
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func (store *Store) timestamp() string {
+	return store.now().UTC().Format(time.RFC3339)
+}
+
+func (store *Store) sessionPath(sessionID string) string {
+	return filepath.Join(store.RootDir, sessionID)
+}
+
+func (store *Store) metadataPath(sessionID string) string {
+	return filepath.Join(store.sessionPath(sessionID), MetadataFile)
+}
+
+func (store *Store) eventsPath(sessionID string) string {
+	return filepath.Join(store.sessionPath(sessionID), EventsFile)
+}
+
+func (store *Store) readMetadata(sessionID string) (Metadata, error) {
+	data, err := os.ReadFile(store.metadataPath(sessionID))
+	if err != nil {
+		return Metadata{}, err
+	}
+	var session Metadata
+	if err := json.Unmarshal(data, &session); err != nil {
+		return Metadata{}, err
+	}
+	return session, nil
+}
+
+func (store *Store) writeMetadata(session Metadata) error {
+	if err := os.MkdirAll(store.sessionPath(session.SessionID), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tempPath := store.metadataPath(session.SessionID) + ".tmp"
+	if err := os.WriteFile(tempPath, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, store.metadataPath(session.SessionID))
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+
+func isValidSessionID(value string) bool {
+	return sessionIDPattern.MatchString(value)
+}
+
+func createSessionID(now time.Time) string {
+	random := make([]byte, 4)
+	if _, err := rand.Read(random); err != nil {
+		copy(random, []byte{byte(now.Nanosecond()), byte(now.Second()), byte(now.Minute()), byte(now.Hour())})
+	}
+	return fmt.Sprintf("zero_%s_%s", now.UTC().Format("20060102150405"), hex.EncodeToString(random))
+}
+
+func cloneJSONValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var cloned any
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return value
+	}
+	return cloned
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -1,0 +1,176 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultRootUsesXDGDataHome(t *testing.T) {
+	root, err := DefaultRoot(DefaultRootOptions{
+		Env: map[string]string{
+			"XDG_DATA_HOME": "/tmp/zero-data",
+			"HOME":          "/tmp/home",
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("DefaultRoot returned error: %v", err)
+	}
+	if root != filepath.Join("/tmp/zero-data", "zero", "sessions") {
+		t.Fatalf("root = %q", root)
+	}
+}
+
+func TestStoreCreatesAppendsListsAndReadsSessions(t *testing.T) {
+	store := NewStore(StoreOptions{
+		RootDir: t.TempDir(),
+		Now: sequenceClock([]time.Time{
+			time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 1, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 2, 0, time.UTC),
+		}),
+	})
+
+	session, err := store.Create(CreateInput{
+		SessionID: "session_one",
+		Title:     "Build headless",
+		Cwd:       "/repo/zero",
+		ModelID:   "gpt-4.1",
+		Provider:  "openai",
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if session.EventCount != 0 || session.CreatedAt != "2026-06-04T10:00:00Z" {
+		t.Fatalf("session metadata = %#v", session)
+	}
+
+	event, err := store.AppendEvent(session.SessionID, AppendEventInput{
+		Type:    EventMessage,
+		Payload: map[string]any{"role": "user", "content": "hello"},
+	})
+	if err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+	if event.ID != "session_one:1" || event.Sequence != 1 {
+		t.Fatalf("event = %#v", event)
+	}
+
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if len(events) != 1 || events[0].Type != EventMessage {
+		t.Fatalf("events = %#v", events)
+	}
+
+	latest, err := store.Latest()
+	if err != nil {
+		t.Fatalf("Latest returned error: %v", err)
+	}
+	if latest == nil || latest.SessionID != session.SessionID || latest.EventCount != 1 {
+		t.Fatalf("latest = %#v", latest)
+	}
+
+	metadataPath := filepath.Join(store.RootDir, session.SessionID, MetadataFile)
+	if _, err := os.Stat(metadataPath); err != nil {
+		t.Fatalf("expected metadata file at %s: %v", metadataPath, err)
+	}
+}
+
+func TestStoreForkCopiesEventsAndRecordsLineage(t *testing.T) {
+	store := NewStore(StoreOptions{
+		RootDir: t.TempDir(),
+		Now: sequenceClock([]time.Time{
+			time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 1, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 2, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 3, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 4, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 5, 0, time.UTC),
+		}),
+	})
+	if _, err := store.Create(CreateInput{SessionID: "parent", Title: "Parent"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendEvent("parent", AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "first"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendEvent("parent", AppendEventInput{Type: EventToolResult, Payload: map[string]any{"output": "done"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fork, err := store.Fork("parent", ForkInput{SessionID: "forked", Cwd: "/repo/new"})
+	if err != nil {
+		t.Fatalf("Fork returned error: %v", err)
+	}
+	if fork.ParentSessionID != "parent" || fork.ForkedFromEventID != "parent:2" || fork.EventCount != 3 {
+		t.Fatalf("fork metadata = %#v", fork)
+	}
+
+	events, err := store.ReadEvents("forked")
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	got := []EventType{events[0].Type, events[1].Type, events[2].Type}
+	want := []EventType{EventMessage, EventToolResult, EventSessionFork}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fork event types = %#v, want %#v", got, want)
+	}
+}
+
+func TestPrepareExecSessionResolvesResumeAndFork(t *testing.T) {
+	store := NewStore(StoreOptions{
+		RootDir: t.TempDir(),
+		Now: sequenceClock([]time.Time{
+			time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 1, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 2, 0, time.UTC),
+			time.Date(2026, 6, 4, 10, 0, 3, 0, time.UTC),
+		}),
+	})
+	if _, err := store.Create(CreateInput{SessionID: "older"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(CreateInput{SessionID: "latest", Title: "Latest"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendEvent("latest", AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "previous answer"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared, err := PrepareExec(PrepareExecOptions{Store: store, ResumeLatest: true})
+	if err != nil {
+		t.Fatalf("PrepareExec returned error: %v", err)
+	}
+	if prepared.Mode != ModeResume || prepared.Session.SessionID != "latest" || len(prepared.ContextEvents) != 1 {
+		t.Fatalf("prepared resume = %#v", prepared)
+	}
+	if got := FormatExecPrompt("continue", prepared); got == "continue" || !strings.Contains(got, "previous answer") {
+		t.Fatalf("expected session context in prompt, got %q", got)
+	}
+
+	forked, err := PrepareExec(PrepareExecOptions{Store: store, Fork: "latest", SessionID: "forked"})
+	if err != nil {
+		t.Fatalf("PrepareExec fork returned error: %v", err)
+	}
+	if forked.Mode != ModeFork || forked.Session.ParentSessionID != "latest" {
+		t.Fatalf("prepared fork = %#v", forked)
+	}
+}
+
+func sequenceClock(values []time.Time) func() time.Time {
+	index := 0
+	return func() time.Time {
+		if index >= len(values) {
+			return values[len(values)-1]
+		}
+		value := values[index]
+		index++
+		return value
+	}
+}

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -1,0 +1,262 @@
+package streamjson
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const SchemaVersion = 1
+
+type EventType string
+
+const (
+	EventRunStart   EventType = "run_start"
+	EventText       EventType = "text"
+	EventToolCall   EventType = "tool_call"
+	EventToolResult EventType = "tool_result"
+	EventUsage      EventType = "usage"
+	EventFinal      EventType = "final"
+	EventWarning    EventType = "warning"
+	EventError      EventType = "error"
+	EventRunEnd     EventType = "run_end"
+)
+
+type InputType string
+
+const (
+	InputPrompt  InputType = "prompt"
+	InputMessage InputType = "message"
+)
+
+type Event struct {
+	SchemaVersion    int       `json:"schemaVersion"`
+	Type             EventType `json:"type"`
+	RunID            string    `json:"runId"`
+	SessionID        string    `json:"sessionId,omitempty"`
+	Cwd              string    `json:"cwd,omitempty"`
+	Provider         string    `json:"provider,omitempty"`
+	Model            string    `json:"model,omitempty"`
+	APIModel         string    `json:"apiModel,omitempty"`
+	Delta            string    `json:"delta,omitempty"`
+	ID               string    `json:"id,omitempty"`
+	Name             string    `json:"name,omitempty"`
+	Args             any       `json:"args,omitempty"`
+	SideEffect       string    `json:"sideEffect,omitempty"`
+	Status           string    `json:"status,omitempty"`
+	Output           string    `json:"output,omitempty"`
+	Truncated        *bool     `json:"truncated,omitempty"`
+	PromptTokens     *int      `json:"promptTokens,omitempty"`
+	CompletionTokens *int      `json:"completionTokens,omitempty"`
+	TotalTokens      *int      `json:"totalTokens,omitempty"`
+	CostUSD          *float64  `json:"costUsd,omitempty"`
+	Text             string    `json:"text,omitempty"`
+	Message          string    `json:"message,omitempty"`
+	Code             string    `json:"code,omitempty"`
+	Recoverable      *bool     `json:"recoverable,omitempty"`
+	ExitCode         *int      `json:"exitCode,omitempty"`
+}
+
+type InputEvent struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	Type          InputType `json:"type"`
+	Role          string    `json:"role,omitempty"`
+	Content       string    `json:"content"`
+}
+
+type ProtocolError struct {
+	message string
+}
+
+func (err ProtocolError) Error() string {
+	return err.message
+}
+
+func CreateRunID(now time.Time) string {
+	random := make([]byte, 3)
+	if _, err := rand.Read(random); err != nil {
+		copy(random, []byte{byte(now.Nanosecond()), byte(now.Second()), byte(now.Minute())})
+	}
+	return fmt.Sprintf("run_%s_%s", now.UTC().Format("20060102150405"), hex.EncodeToString(random))
+}
+
+func FormatEvent(event Event) (string, error) {
+	if event.SchemaVersion == 0 {
+		event.SchemaVersion = SchemaVersion
+	}
+	if err := validateOutputEvent(event); err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return "", err
+	}
+
+	var payload any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", err
+	}
+	redacted := redactValue(payload)
+	output, err := json.Marshal(redacted)
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func ParseInput(input string) ([]InputEvent, error) {
+	lines := strings.Split(input, "\n")
+	events := []InputEvent{}
+	for index, line := range lines {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" {
+			continue
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			return nil, ProtocolError{fmt.Sprintf("Invalid stream-json input at line %d: expected a JSON object.", index+1)}
+		}
+		if err := validateInputFields(raw); err != nil {
+			return nil, ProtocolError{fmt.Sprintf("Invalid stream-json input at line %d: %s", index+1, err.Error())}
+		}
+		var event InputEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			return nil, ProtocolError{fmt.Sprintf("Invalid stream-json input at line %d: expected a JSON object.", index+1)}
+		}
+		if err := validateInputEvent(event); err != nil {
+			return nil, ProtocolError{fmt.Sprintf("Invalid stream-json input at line %d: %s", index+1, err.Error())}
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func ResolvePrompt(events []InputEvent) (string, error) {
+	parts := []string{}
+	for _, event := range events {
+		content := strings.TrimSpace(event.Content)
+		if content != "" {
+			parts = append(parts, content)
+		}
+	}
+	if len(parts) == 0 {
+		return "", ProtocolError{"Stream-json input must include at least one prompt or user message event."}
+	}
+	return strings.Join(parts, "\n\n"), nil
+}
+
+func ParsePrompt(input string) (string, error) {
+	events, err := ParseInput(input)
+	if err != nil {
+		return "", err
+	}
+	return ResolvePrompt(events)
+}
+
+func validateOutputEvent(event Event) error {
+	if event.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schemaVersion must be %d", SchemaVersion)
+	}
+	if !isValidID(event.RunID) {
+		return fmt.Errorf("runId is required")
+	}
+	if event.Type == "" {
+		return fmt.Errorf("type is required")
+	}
+	return nil
+}
+
+func validateInputEvent(event InputEvent) error {
+	if event.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schemaVersion must be %d", SchemaVersion)
+	}
+	if strings.TrimSpace(event.Content) == "" {
+		return fmt.Errorf("content is required")
+	}
+	switch event.Type {
+	case InputPrompt:
+		return nil
+	case InputMessage:
+		if event.Role != "user" {
+			return fmt.Errorf("role must be user")
+		}
+		return nil
+	default:
+		return fmt.Errorf("type must be prompt or message")
+	}
+}
+
+func validateInputFields(raw map[string]json.RawMessage) error {
+	var inputType string
+	if rawType, ok := raw["type"]; ok {
+		_ = json.Unmarshal(rawType, &inputType)
+	}
+	allowed := map[string]bool{
+		"schemaVersion": true,
+		"type":          true,
+		"content":       true,
+	}
+	if inputType == string(InputMessage) {
+		allowed["role"] = true
+	}
+	for key := range raw {
+		if !allowed[key] {
+			return fmt.Errorf("unknown field %s", key)
+		}
+	}
+	return nil
+}
+
+var idPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`)
+
+func isValidID(value string) bool {
+	return idPattern.MatchString(value)
+}
+
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`sk-[A-Za-z0-9._-]+`),
+	regexp.MustCompile(`(?i)(api[_-]?key["'=:\s]+)[^"',\s)]+`),
+	regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._-]+`),
+}
+
+func redactValue(value any) any {
+	switch typed := value.(type) {
+	case string:
+		return redactString(typed)
+	case []any:
+		next := make([]any, len(typed))
+		for index, item := range typed {
+			next[index] = redactValue(item)
+		}
+		return next
+	case map[string]any:
+		next := make(map[string]any, len(typed))
+		for key, item := range typed {
+			next[key] = redactValue(item)
+		}
+		return next
+	default:
+		return value
+	}
+}
+
+func redactString(value string) string {
+	redacted := value
+	for _, pattern := range secretPatterns {
+		redacted = pattern.ReplaceAllStringFunc(redacted, func(match string) string {
+			for _, prefix := range []string{"apiKey=", "api_key=", "api-key=", "Bearer "} {
+				if strings.HasPrefix(strings.ToLower(match), strings.ToLower(prefix)) {
+					return match[:len(prefix)] + "[REDACTED]"
+				}
+			}
+			return "[REDACTED]"
+		})
+	}
+	return redacted
+}

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -238,12 +238,57 @@ func redactValue(value any) any {
 	case map[string]any:
 		next := make(map[string]any, len(typed))
 		for key, item := range typed {
+			if isSensitiveKey(key) {
+				next[key] = "[REDACTED]"
+				continue
+			}
 			next[key] = redactValue(item)
 		}
 		return next
 	default:
 		return value
 	}
+}
+
+var sensitiveKeyNames = map[string]bool{
+	"accesstoken":   true,
+	"apikey":        true,
+	"authorization": true,
+	"bearer":        true,
+	"clientsecret":  true,
+	"credential":    true,
+	"credentials":   true,
+	"idtoken":       true,
+	"password":      true,
+	"passwd":        true,
+	"privatekey":    true,
+	"pwd":           true,
+	"refreshtoken":  true,
+	"secret":        true,
+	"token":         true,
+}
+
+func isSensitiveKey(key string) bool {
+	normalized := normalizeSensitiveKey(key)
+	if sensitiveKeyNames[normalized] {
+		return true
+	}
+	for _, suffix := range []string{"apikey", "clientsecret", "accesstoken", "refreshtoken", "idtoken", "privatekey"} {
+		if strings.HasSuffix(normalized, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSensitiveKey(key string) string {
+	var normalized strings.Builder
+	for _, char := range strings.ToLower(key) {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') {
+			normalized.WriteRune(char)
+		}
+	}
+	return normalized.String()
 }
 
 func redactString(value string) string {

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -41,6 +41,49 @@ func TestFormatEventRedactsSecretsAndSerializesOneLine(t *testing.T) {
 	}
 }
 
+func TestFormatEventRedactsSensitiveObjectKeys(t *testing.T) {
+	apiKey := "plain-api-key-value"
+	accessToken := "plain-access-token-value"
+
+	line, err := FormatEvent(Event{
+		SchemaVersion: SchemaVersion,
+		Type:          EventToolCall,
+		RunID:         "run_test",
+		ID:            "call_1",
+		Name:          "bash",
+		Args: map[string]any{
+			"api_key": apiKey,
+			"nested": map[string]any{
+				"accessToken":  accessToken,
+				"promptTokens": 12,
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("FormatEvent returned error: %v", err)
+	}
+	if strings.Contains(line, apiKey) || strings.Contains(line, accessToken) {
+		t.Fatalf("expected sensitive object values to be redacted, got %q", line)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", line, err)
+	}
+	args := decoded["args"].(map[string]any)
+	if args["api_key"] != "[REDACTED]" {
+		t.Fatalf("expected api_key to be redacted, got %#v", args["api_key"])
+	}
+	nested := args["nested"].(map[string]any)
+	if nested["accessToken"] != "[REDACTED]" {
+		t.Fatalf("expected accessToken to be redacted, got %#v", nested["accessToken"])
+	}
+	if nested["promptTokens"] != float64(12) {
+		t.Fatalf("expected non-sensitive token counter to remain numeric, got %#v", nested["promptTokens"])
+	}
+}
+
 func TestParseInputPromptCombinesPromptAndUserMessages(t *testing.T) {
 	input := strings.Join([]string{
 		`{"schemaVersion":1,"type":"message","role":"user","content":"Inspect this repo."}`,

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -1,0 +1,87 @@
+package streamjson
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatEventRedactsSecretsAndSerializesOneLine(t *testing.T) {
+	secret := "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
+
+	line, err := FormatEvent(Event{
+		SchemaVersion: SchemaVersion,
+		Type:          EventError,
+		RunID:         "run_test",
+		Code:          "provider_error",
+		Message:       "provider leaked " + secret,
+		Recoverable:   boolPtr(false),
+	})
+
+	if err != nil {
+		t.Fatalf("FormatEvent returned error: %v", err)
+	}
+	if strings.Contains(line, "\n") {
+		t.Fatalf("expected one JSON line, got %q", line)
+	}
+	if strings.Contains(line, secret) {
+		t.Fatalf("expected secret to be redacted, got %q", line)
+	}
+	if !strings.Contains(line, "[REDACTED]") {
+		t.Fatalf("expected redaction marker, got %q", line)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", line, err)
+	}
+	if decoded["schemaVersion"] != float64(SchemaVersion) || decoded["type"] != string(EventError) {
+		t.Fatalf("unexpected event payload: %#v", decoded)
+	}
+}
+
+func TestParseInputPromptCombinesPromptAndUserMessages(t *testing.T) {
+	input := strings.Join([]string{
+		`{"schemaVersion":1,"type":"message","role":"user","content":"Inspect this repo."}`,
+		`{"schemaVersion":1,"type":"prompt","content":"Focus on failing tests."}`,
+		"",
+	}, "\n")
+
+	prompt, err := ParsePrompt(input)
+
+	if err != nil {
+		t.Fatalf("ParsePrompt returned error: %v", err)
+	}
+	if prompt != "Inspect this repo.\n\nFocus on failing tests." {
+		t.Fatalf("prompt = %q", prompt)
+	}
+}
+
+func TestParseInputRejectsMalformedLinesWithLineNumbers(t *testing.T) {
+	_, err := ParseInput(`{"type":"prompt"`)
+
+	if err == nil || !strings.Contains(err.Error(), "Invalid stream-json input at line 1") {
+		t.Fatalf("expected line-numbered parse error, got %v", err)
+	}
+}
+
+func TestParseInputRejectsUnknownFields(t *testing.T) {
+	_, err := ParseInput(`{"schemaVersion":1,"type":"prompt","content":"hello","extra":true}`)
+
+	if err == nil || !strings.Contains(err.Error(), "Invalid stream-json input at line 1") {
+		t.Fatalf("expected strict input error, got %v", err)
+	}
+}
+
+func TestCreateRunIDUsesStablePrefix(t *testing.T) {
+	runID := CreateRunID(time.Date(2026, 6, 4, 12, 34, 56, 0, time.UTC))
+
+	if !strings.HasPrefix(runID, "run_20260604123456_") {
+		t.Fatalf("run id = %q", runID)
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}


### PR DESCRIPTION
## Summary
- add Go stream-json protocol helpers with schema-versioned events, strict input parsing, run ids, and redaction
- add Go session event store plus exec resume/fork prompt helpers
- expand Go `zero exec` with stream-json input/output, `--auto`, tool filters, `--list-tools`, `--resume`, and `--fork`
- filter model-visible tools in the Go agent loop and reject disabled tool calls

## Tests
- `git diff --check`
- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run test:go`
- `bun run build`
- `bun run smoke:build`
- `bun run build:go`
- `bun run smoke:go`
- `./zero.exe exec --list-tools --enabled-tools read_file,grep`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tool filtering with `--enabled-tools` and `--disabled-tools` flags to control agent access to specific tools.
  * Added session management: resume, fork, and resume-latest functionality for continuing previous conversations.
  * Added separate input and output format control options.
  * Added stream-json protocol for structured programmatic output.
  * Added `--list-tools` flag to display available tools with descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->