### PR TITLE
[codex] add Go extension backend commands

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,8 +5,8 @@ tone_instructions: "Be direct and prioritize actionable correctness, safety, CLI
 
 reviews:
   profile: "chill"
-  # Keep CodeRabbit as a review signal without letting stale bot reviews block merges.
-  request_changes_workflow: false
+  # Allow explicit @coderabbitai approve / resolve commands to submit review verdicts.
+  request_changes_workflow: true
   high_level_summary: true
   poem: false
   # Avoid noisy "review skipped" status comments when CodeRabbit decides not to run.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -23,6 +26,9 @@ type appDeps struct {
 	resolveConfig   func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
 	newProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
 	newSessionStore func() *sessions.Store
+	loadPlugins     func(plugins.LoadOptions) (plugins.LoadResult, error)
+	loadHooks       func(hooks.LoadOptions) (hooks.LoadResult, error)
+	newMCPStore     func() (*mcp.PermissionStore, error)
 	runTUI          func(context.Context, tui.Options) int
 	now             func() time.Time
 }
@@ -49,6 +55,11 @@ func defaultAppDeps() appDeps {
 		},
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
+		},
+		loadPlugins: plugins.Load,
+		loadHooks:   hooks.LoadConfig,
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return mcp.NewPermissionStore(mcp.StoreOptions{})
 		},
 		runTUI: tui.Run,
 		now:    time.Now,
@@ -89,6 +100,12 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runDoctor(args[1:], stdout, stderr, deps)
 	case "search", "find":
 		return runSearch(args[1:], stdout, stderr, deps)
+	case "plugins", "plugin":
+		return runPlugins(args[1:], stdout, stderr, deps)
+	case "hooks":
+		return runHooks(args[1:], stdout, stderr, deps)
+	case "mcp":
+		return runMCP(args[1:], stdout, stderr, deps)
 	default:
 		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
 			return 1
@@ -113,6 +130,15 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore
+	}
+	if deps.loadPlugins == nil {
+		deps.loadPlugins = defaults.loadPlugins
+	}
+	if deps.loadHooks == nil {
+		deps.loadHooks = defaults.loadHooks
+	}
+	if deps.newMCPStore == nil {
+		deps.newMCPStore = defaults.newMCPStore
 	}
 	if deps.runTUI == nil {
 		deps.runTUI = defaults.runTUI
@@ -189,6 +215,9 @@ Commands:
   doctor     Run backend health checks for config and provider setup
   search     Search persisted local Zero session events
   find       Alias for search
+  plugins    Inspect local Zero plugin manifests
+  hooks      Inspect Zero hook configuration
+  mcp        Manage MCP backend settings
   help       Show this help
   version    Print version
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -207,6 +207,9 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"doctor"},
 		{"search"},
 		{"find"},
+		{"plugins"},
+		{"hooks"},
+		{"mcp"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
@@ -247,6 +250,9 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"exec",
 		"doctor",
 		"search",
+		"plugins",
+		"hooks",
+		"mcp",
 		"--version",
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -208,6 +208,7 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"search"},
 		{"find"},
 		{"plugins"},
+		{"plugin"},
 		{"hooks"},
 		{"mcp"},
 	} {

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -264,7 +264,7 @@ func runMCPPermissionsClear(args []string, stdout io.Writer, stderr io.Writer, d
 		return exitSuccess
 	}
 	if !options.confirm {
-		return writeAppError(stderr, "Pass --confirm to clear all MCP permission grants.", exitCrash)
+		return writeExecUsageError(stderr, "Pass --confirm to clear all MCP permission grants.")
 	}
 	store, err := deps.newMCPStore()
 	if err != nil {

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -150,11 +150,6 @@ func runMCPPermissions(args []string, stdout io.Writer, stderr io.Writer, deps a
 		return exitSuccess
 	}
 
-	store, err := deps.newMCPStore()
-	if err != nil {
-		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
-	}
-
 	switch args[0] {
 	case "list":
 		options, help, err := parseMCPCommandOptions(args[1:])
@@ -166,6 +161,10 @@ func runMCPPermissions(args []string, stdout io.Writer, stderr io.Writer, deps a
 				return exitCrash
 			}
 			return exitSuccess
+		}
+		store, err := deps.newMCPStore()
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 		}
 		permissions, err := store.List()
 		if err != nil {
@@ -185,15 +184,15 @@ func runMCPPermissions(args []string, stdout io.Writer, stderr io.Writer, deps a
 		}
 		return exitSuccess
 	case "revoke":
-		return runMCPPermissionsRevoke(args[1:], stdout, stderr, store)
+		return runMCPPermissionsRevoke(args[1:], stdout, stderr, deps)
 	case "clear":
-		return runMCPPermissionsClear(args[1:], stdout, stderr, store)
+		return runMCPPermissionsClear(args[1:], stdout, stderr, deps)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown mcp permissions subcommand %q", args[0]))
 	}
 }
 
-func runMCPPermissionsRevoke(args []string, stdout io.Writer, stderr io.Writer, store *mcp.PermissionStore) int {
+func runMCPPermissionsRevoke(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
 	options, positional, help, err := parseMCPPositionalCommand(args)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
@@ -205,9 +204,13 @@ func runMCPPermissionsRevoke(args []string, stdout io.Writer, stderr io.Writer, 
 		return exitSuccess
 	}
 	if len(positional) == 0 || len(positional) > 2 {
-		return writeExecUsageError(stderr, "usage: zero mcp permissions revoke <server> [tool] [--json]")
+		return writeExecUsageError(stderr, "usage: zero mcp permissions revoke <server> [<tool>] [--json]")
 	}
 
+	store, err := deps.newMCPStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
 	serverName := positional[0]
 	if len(positional) == 2 {
 		revoked, err := store.RevokeTool(serverName, positional[1])
@@ -249,7 +252,7 @@ func runMCPPermissionsRevoke(args []string, stdout io.Writer, stderr io.Writer, 
 	return exitSuccess
 }
 
-func runMCPPermissionsClear(args []string, stdout io.Writer, stderr io.Writer, store *mcp.PermissionStore) int {
+func runMCPPermissionsClear(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
 	options, help, err := parseMCPCommandOptions(args)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
@@ -262,6 +265,10 @@ func runMCPPermissionsClear(args []string, stdout io.Writer, stderr io.Writer, s
 	}
 	if !options.confirm {
 		return writeAppError(stderr, "Pass --confirm to clear all MCP permission grants.", exitCrash)
+	}
+	store, err := deps.newMCPStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 	cleared, err := store.Clear()
 	if err != nil {
@@ -406,7 +413,7 @@ func writeMCPPermissionsHelp(w io.Writer) error {
 
 Commands:
   list                  List all persistent MCP permissions
-  revoke <server> [tool] Revoke an MCP server or tool permission
+  revoke <server> [<tool>] Revoke an MCP server or tool permission
   clear --confirm       Clear all persistent MCP permissions
 
 Flags:

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+type pluginListOptions struct {
+	json bool
+}
+
+type hookListOptions struct {
+	json bool
+}
+
+type mcpCommandOptions struct {
+	json    bool
+	confirm bool
+}
+
+func runPlugins(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "plugins subcommand required. Use `zero plugins list`.")
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		if err := writePluginsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	case "list":
+		options, help, err := parsePluginListArgs(args[1:])
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		if help {
+			if err := writePluginsListHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		cwd, err := deps.getwd()
+		if err != nil {
+			return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), exitCrash)
+		}
+		result, err := deps.loadPlugins(plugins.LoadOptions{Cwd: cwd})
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+		if options.json {
+			payload := struct {
+				Plugins     []plugins.LoadedPlugin `json:"plugins"`
+				Diagnostics []plugins.Diagnostic   `json:"diagnostics"`
+			}{Plugins: result.Plugins, Diagnostics: result.Diagnostics}
+			if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		output := redaction.RedactString(plugins.FormatList(result.Plugins, result.Diagnostics), redaction.Options{})
+		if _, err := fmt.Fprintln(stdout, output); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown plugins subcommand %q", args[0]))
+	}
+}
+
+func runHooks(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "hooks subcommand required. Use `zero hooks list`.")
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		if err := writeHooksHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	case "list":
+		options, help, err := parseHookListArgs(args[1:])
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		if help {
+			if err := writeHooksListHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		cwd, err := deps.getwd()
+		if err != nil {
+			return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), exitCrash)
+		}
+		result, err := deps.loadHooks(hooks.LoadOptions{Cwd: cwd})
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+		if options.json {
+			payload := struct {
+				Hooks       hooks.Config       `json:"hooks"`
+				Diagnostics []hooks.Diagnostic `json:"diagnostics"`
+			}{Hooks: result.Config, Diagnostics: result.Diagnostics}
+			if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		output := redaction.RedactString(hooks.FormatList(result.Config, result.Diagnostics), redaction.Options{})
+		if _, err := fmt.Fprintln(stdout, output); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown hooks subcommand %q", args[0]))
+	}
+}
+
+func runMCP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "mcp subcommand required. Use `zero mcp permissions list`.")
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		if err := writeMCPHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	case "permissions":
+		return runMCPPermissions(args[1:], stdout, stderr, deps)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown mcp subcommand %q", args[0]))
+	}
+}
+
+func runMCPPermissions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "mcp permissions subcommand required. Use `zero mcp permissions list`.")
+	}
+	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		if err := writeMCPPermissionsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	store, err := deps.newMCPStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	switch args[0] {
+	case "list":
+		options, help, err := parseMCPCommandOptions(args[1:])
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		if help {
+			if err := writeMCPPermissionsHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		permissions, err := store.List()
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+		if options.json {
+			payload := struct {
+				Permissions []mcp.PermissionGrant `json:"permissions"`
+			}{Permissions: permissions}
+			if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, mcp.FormatPermissionList(permissions)); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	case "revoke":
+		return runMCPPermissionsRevoke(args[1:], stdout, stderr, store)
+	case "clear":
+		return runMCPPermissionsClear(args[1:], stdout, stderr, store)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown mcp permissions subcommand %q", args[0]))
+	}
+}
+
+func runMCPPermissionsRevoke(args []string, stdout io.Writer, stderr io.Writer, store *mcp.PermissionStore) int {
+	options, positional, help, err := parseMCPPositionalCommand(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPPermissionsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) == 0 || len(positional) > 2 {
+		return writeExecUsageError(stderr, "usage: zero mcp permissions revoke <server> [tool] [--json]")
+	}
+
+	serverName := positional[0]
+	if len(positional) == 2 {
+		revoked, err := store.RevokeTool(serverName, positional[1])
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+		if options.json {
+			payload := struct {
+				Revoked    int    `json:"revoked"`
+				Scope      string `json:"scope"`
+				ServerName string `json:"serverName"`
+				ToolName   string `json:"toolName"`
+			}{Revoked: revoked, Scope: string(mcp.ScopeTool), ServerName: serverName, ToolName: positional[1]}
+			if err := writePrettyJSON(stdout, payload); err != nil {
+				return exitCrash
+			}
+		} else if _, err := fmt.Fprintf(stdout, "Revoked %d MCP tool permission grant(s) for %s/%s.\n", revoked, serverName, positional[1]); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	revoked, err := store.RevokeServer(serverName)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		payload := struct {
+			Revoked    int    `json:"revoked"`
+			Scope      string `json:"scope"`
+			ServerName string `json:"serverName"`
+		}{Revoked: revoked, Scope: string(mcp.ScopeServer), ServerName: serverName}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+	} else if _, err := fmt.Fprintf(stdout, "Revoked %d MCP server permission grant(s) for %s.\n", revoked, serverName); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runMCPPermissionsClear(args []string, stdout io.Writer, stderr io.Writer, store *mcp.PermissionStore) int {
+	options, help, err := parseMCPCommandOptions(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPPermissionsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if !options.confirm {
+		return writeAppError(stderr, "Pass --confirm to clear all MCP permission grants.", exitCrash)
+	}
+	cleared, err := store.Clear()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		payload := struct {
+			Cleared int `json:"cleared"`
+		}{Cleared: cleared}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+	} else if _, err := fmt.Fprintf(stdout, "Cleared %d MCP permission grant(s).\n", cleared); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parsePluginListArgs(args []string) (pluginListOptions, bool, error) {
+	options := pluginListOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown plugins list flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parseHookListArgs(args []string) (hookListOptions, bool, error) {
+	options := hookListOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown hooks list flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parseMCPCommandOptions(args []string) (mcpCommandOptions, bool, error) {
+	options := mcpCommandOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		case "--confirm":
+			options.confirm = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown mcp permissions flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parseMCPPositionalCommand(args []string) (mcpCommandOptions, []string, bool, error) {
+	options := mcpCommandOptions{}
+	positional := []string{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, positional, true, nil
+		case "--json":
+			options.json = true
+		case "--confirm":
+			options.confirm = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return options, positional, false, execUsageError{fmt.Sprintf("unknown mcp permissions flag %q", arg)}
+			}
+			positional = append(positional, arg)
+		}
+	}
+	return options, positional, false, nil
+}
+
+func writePluginsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero plugins <command>
+
+Commands:
+  list    List local Zero plugins
+`)
+	return err
+}
+
+func writePluginsListHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero plugins list [flags]
+
+Flags:
+      --json    Print local plugin data as JSON
+  -h, --help    Show this help
+`)
+	return err
+}
+
+func writeHooksHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero hooks <command>
+
+Commands:
+  list    List configured Zero hooks
+`)
+	return err
+}
+
+func writeHooksListHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero hooks list [flags]
+
+Flags:
+      --json    Print hook config as JSON
+  -h, --help    Show this help
+`)
+	return err
+}
+
+func writeMCPHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp <command>
+
+Commands:
+  permissions    Manage persistent MCP tool permissions
+`)
+	return err
+}
+
+func writeMCPPermissionsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp permissions <command>
+
+Commands:
+  list                  List all persistent MCP permissions
+  revoke <server> [tool] Revoke an MCP server or tool permission
+  clear --confirm       Clear all persistent MCP permissions
+
+Flags:
+      --json       Print command result as JSON
+      --confirm    Confirm destructive clear operation
+  -h, --help       Show this help
+`)
+	return err
+}

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -178,7 +178,7 @@ func TestRunMCPPermissionsListRevokeAndClear(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	exitCode = runWithDeps([]string{"mcp", "permissions", "clear", "--json"}, &stdout, &stderr, deps)
-	if exitCode != exitCrash {
+	if exitCode != exitUsage {
 		t.Fatalf("clear without confirm exitCode = %d", exitCode)
 	}
 	if !strings.Contains(stderr.String(), "--confirm") {

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -192,5 +193,34 @@ func TestRunMCPPermissionsListRevokeAndClear(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"cleared": 1`) {
 		t.Fatalf("unexpected clear output: %s", stdout.String())
+	}
+}
+
+func TestRunMCPPermissionsHelpDoesNotOpenStore(t *testing.T) {
+	deps := appDeps{
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return nil, errors.New("store should not be opened for help")
+		},
+	}
+
+	for _, args := range [][]string{
+		{"mcp", "permissions", "list", "--help"},
+		{"mcp", "permissions", "revoke", "--help"},
+		{"mcp", "permissions", "clear", "--help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(args, &stdout, &stderr, deps)
+			if exitCode != exitSuccess {
+				t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected empty stderr, got %q", stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "zero mcp permissions") {
+				t.Fatalf("expected help output, got %q", stdout.String())
+			}
+		})
 	}
 }

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+)
+
+func TestRunPluginsListsJSONAndText(t *testing.T) {
+	cwd := t.TempDir()
+	result := plugins.LoadResult{
+		Plugins: []plugins.LoadedPlugin{{
+			SchemaVersion: 1,
+			ID:            "zero.docs",
+			Name:          "Docs",
+			Version:       "1.0.0",
+			Enabled:       true,
+			Source:        plugins.SourceProject,
+			Prompts:       []plugins.PathExtension{{Name: "review", Path: filepath.Join(cwd, "review.md")}},
+			Tools:         []plugins.ToolExtension{},
+			Skills:        []plugins.PathExtension{},
+			Hooks:         []plugins.HookExtension{},
+		}},
+	}
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		loadPlugins: func(options plugins.LoadOptions) (plugins.LoadResult, error) {
+			if options.Cwd != cwd {
+				t.Fatalf("plugin Cwd = %q, want %q", options.Cwd, cwd)
+			}
+			return result, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"plugins", "list", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var payload struct {
+		Plugins []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Version string `json:"version"`
+			Source  string `json:"source"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("plugin JSON failed to decode: %v\n%s", err, stdout.String())
+	}
+	if payload.Plugins[0].ID != "zero.docs" || payload.Plugins[0].Name != "Docs" || payload.Plugins[0].Version != "1.0.0" {
+		t.Fatalf("unexpected plugin JSON: %#v", payload)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"plugins", "list"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"Zero Plugins:", "zero.docs", "Docs", "1.0.0", "1 prompts"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("plugin text missing %q: %s", want, stdout.String())
+		}
+	}
+}
+
+func TestRunHooksListsRedactedJSONAndText(t *testing.T) {
+	secret := "sk-proj-" + strings.Repeat("a", 24)
+	result := hooks.LoadResult{
+		Config: hooks.Config{
+			Enabled: true,
+			Hooks: []hooks.Definition{{
+				ID:      "zero.preflight",
+				Event:   hooks.EventBeforeTool,
+				Matcher: "bash",
+				Command: "node",
+				Args:    []string{"hooks/preflight.mjs", secret},
+				Enabled: true,
+			}},
+		},
+	}
+	deps := appDeps{
+		getwd: func() (string, error) { return t.TempDir(), nil },
+		loadHooks: func(options hooks.LoadOptions) (hooks.LoadResult, error) {
+			return result, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"hooks", "list", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), secret) || !strings.Contains(stdout.String(), "[REDACTED]") {
+		t.Fatalf("hook JSON redaction failed: %s", stdout.String())
+	}
+	var payload struct {
+		Hooks struct {
+			Hooks []struct {
+				ID string `json:"id"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("hook JSON failed to decode: %v\n%s", err, stdout.String())
+	}
+	if payload.Hooks.Hooks[0].ID != "zero.preflight" {
+		t.Fatalf("unexpected hook JSON: %#v", payload)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"hooks", "list"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Zero Hooks") || !strings.Contains(stdout.String(), "zero.preflight") {
+		t.Fatalf("unexpected hook text: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), secret) || !strings.Contains(stdout.String(), "[REDACTED]") {
+		t.Fatalf("hook text redaction failed: %s", stdout.String())
+	}
+}
+
+func TestRunMCPPermissionsListRevokeAndClear(t *testing.T) {
+	store, err := mcp.NewPermissionStore(mcp.StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json"),
+		Now:      func() time.Time { return time.Date(2026, 6, 3, 9, 30, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewPermissionStore returned error: %v", err)
+	}
+	if _, err := store.GrantServer(mcp.GrantServerInput{ServerName: "docs", ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", MaxAutonomy: mcp.AutonomyMedium}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantTool(mcp.GrantToolInput{ServerName: "docs", ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ToolName: "lookup", MaxAutonomy: mcp.AutonomyLow}); err != nil {
+		t.Fatal(err)
+	}
+	deps := appDeps{newMCPStore: func() (*mcp.PermissionStore, error) { return store, nil }}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"mcp", "permissions", "list", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var listPayload struct {
+		Permissions []mcp.PermissionGrant `json:"permissions"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &listPayload); err != nil {
+		t.Fatalf("permission JSON failed to decode: %v\n%s", err, stdout.String())
+	}
+	if len(listPayload.Permissions) != 2 {
+		t.Fatalf("expected 2 permissions, got %#v", listPayload.Permissions)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"mcp", "permissions", "revoke", "docs", "lookup", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"scope": "tool"`) || !strings.Contains(stdout.String(), `"revoked": 1`) {
+		t.Fatalf("unexpected revoke tool output: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"mcp", "permissions", "clear", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitCrash {
+		t.Fatalf("clear without confirm exitCode = %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "--confirm") {
+		t.Fatalf("expected confirm warning, got %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"mcp", "permissions", "clear", "--confirm", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"cleared": 1`) {
+		t.Fatalf("unexpected clear output: %s", stdout.String())
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,874 @@
+package hooks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Event string
+type DiagnosticKind string
+type ConfigSource string
+type AuditStatus string
+
+const (
+	EventBeforeTool   Event = "beforeTool"
+	EventAfterTool    Event = "afterTool"
+	EventSessionStart Event = "sessionStart"
+	EventSessionEnd   Event = "sessionEnd"
+)
+
+const (
+	DiagnosticIO        DiagnosticKind = "io"
+	DiagnosticJSON      DiagnosticKind = "json"
+	DiagnosticSchema    DiagnosticKind = "schema"
+	DiagnosticDuplicate DiagnosticKind = "duplicate"
+)
+
+const (
+	SourceUser    ConfigSource = "user"
+	SourceProject ConfigSource = "project"
+)
+
+const (
+	AuditCompleted AuditStatus = "completed"
+	AuditError     AuditStatus = "error"
+	AuditBlocked   AuditStatus = "blocked"
+)
+
+type Command struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+type Definition struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Event       Event    `json:"event"`
+	Matcher     string   `json:"matcher,omitempty"`
+	Command     string   `json:"command"`
+	Args        []string `json:"args"`
+	Enabled     bool     `json:"enabled"`
+}
+
+type Config struct {
+	Enabled bool         `json:"enabled"`
+	Hooks   []Definition `json:"hooks"`
+}
+
+type Diagnostic struct {
+	Kind      DiagnosticKind `json:"kind"`
+	Message   string         `json:"message"`
+	Source    ConfigSource   `json:"source,omitempty"`
+	Path      string         `json:"path,omitempty"`
+	HookID    string         `json:"hookId,omitempty"`
+	FieldPath string         `json:"fieldPath,omitempty"`
+}
+
+type Paths struct {
+	UserConfigPath    string `json:"userConfigPath"`
+	ProjectConfigPath string `json:"projectConfigPath"`
+	AuditPath         string `json:"auditPath"`
+}
+
+type LoadResult struct {
+	Config      Config       `json:"config"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+	Paths       Paths        `json:"paths"`
+}
+
+type ResolvePathOptions struct {
+	Cwd string
+	Env map[string]string
+}
+
+type LoadOptions struct {
+	Cwd               string
+	Env               map[string]string
+	UserConfigPath    string
+	ProjectConfigPath string
+}
+
+type StoreOptions struct {
+	ConfigPath string
+}
+
+type SelectInput struct {
+	Event    Event
+	ToolName string
+}
+
+type AuditCommand = Command
+
+type AuditResult struct {
+	ExitCode int    `json:"exitCode"`
+	Stdout   string `json:"stdout,omitempty"`
+	Stderr   string `json:"stderr,omitempty"`
+}
+
+type AuditEvent struct {
+	Sequence   int            `json:"sequence"`
+	CreatedAt  string         `json:"createdAt"`
+	Type       string         `json:"type"`
+	HookID     string         `json:"hookId"`
+	Event      Event          `json:"event"`
+	Matcher    string         `json:"matcher,omitempty"`
+	ToolCallID string         `json:"toolCallId,omitempty"`
+	Commands   []AuditCommand `json:"commands,omitempty"`
+	Status     AuditStatus    `json:"status,omitempty"`
+	Results    []AuditResult  `json:"results,omitempty"`
+	DurationMs int            `json:"durationMs,omitempty"`
+}
+
+type AppendStartedInput struct {
+	HookID     string
+	Event      Event
+	Matcher    string
+	ToolCallID string
+	Commands   []AuditCommand
+}
+
+type AppendCompletedInput struct {
+	HookID     string
+	Event      Event
+	Matcher    string
+	ToolCallID string
+	Status     AuditStatus
+	Results    []AuditResult
+	DurationMs int
+}
+
+type AuditStoreOptions struct {
+	AuditPath string
+	Now       func() time.Time
+}
+
+type manifestError struct {
+	fieldPath string
+	message   string
+}
+
+func (err manifestError) Error() string {
+	if err.fieldPath == "" {
+		return err.message
+	}
+	return err.fieldPath + ": " + err.message
+}
+
+type hookLayer struct {
+	source ConfigSource
+	path   string
+	config Config
+}
+
+var (
+	hookIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	storeLocksMu  sync.Mutex
+	storeLocks    = map[string]*sync.Mutex{}
+)
+
+func ResolvePaths(options ResolvePathOptions) (Paths, error) {
+	cwd, err := resolveCwd(options.Cwd)
+	if err != nil {
+		return Paths{}, err
+	}
+
+	home := strings.TrimSpace(firstNonEmpty(envValue(options.Env, "HOME"), envValue(options.Env, "USERPROFILE")))
+	if home == "" {
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return Paths{}, fmt.Errorf("resolve user home: %w", err)
+		}
+	}
+
+	configHome := resolveEnvDir(options.Env, "XDG_CONFIG_HOME", filepath.Join(home, ".config"), cwd)
+	dataHome := resolveEnvDir(options.Env, "XDG_DATA_HOME", filepath.Join(home, ".local", "share"), cwd)
+	return Paths{
+		UserConfigPath:    filepath.Join(configHome, "zero", "hooks.json"),
+		ProjectConfigPath: filepath.Join(cwd, ".zero", "hooks.json"),
+		AuditPath:         filepath.Join(dataHome, "zero", "hooks", "audit.jsonl"),
+	}, nil
+}
+
+func LoadConfig(options LoadOptions) (LoadResult, error) {
+	paths, err := ResolvePaths(ResolvePathOptions{Cwd: options.Cwd, Env: options.Env})
+	if err != nil {
+		return LoadResult{}, err
+	}
+	userConfigPath := firstNonEmpty(options.UserConfigPath, paths.UserConfigPath)
+	projectConfigPath := firstNonEmpty(options.ProjectConfigPath, paths.ProjectConfigPath)
+	diagnostics := []Diagnostic{}
+	layers := []hookLayer{}
+
+	for _, candidate := range []struct {
+		source ConfigSource
+		path   string
+	}{
+		{source: SourceUser, path: userConfigPath},
+		{source: SourceProject, path: projectConfigPath},
+	} {
+		layer, ok := readLayer(candidate.source, candidate.path, &diagnostics)
+		if ok {
+			layers = append(layers, layer)
+		}
+	}
+
+	paths.UserConfigPath = userConfigPath
+	paths.ProjectConfigPath = projectConfigPath
+	return LoadResult{
+		Config:      mergeLayers(layers, &diagnostics),
+		Diagnostics: diagnostics,
+		Paths:       paths,
+	}, nil
+}
+
+func WriteConfig(path string, config Config) error {
+	normalized, err := normalizeConfig(map[string]any{
+		"enabled": config.Enabled,
+		"hooks":   definitionsToRaw(config.Hooks),
+	})
+	if err != nil {
+		return err
+	}
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(resolved), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(normalized, "", "  ")
+	if err != nil {
+		return err
+	}
+	tempPath := fmt.Sprintf("%s.tmp-%d", resolved, os.Getpid())
+	if err := os.WriteFile(tempPath, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, resolved)
+}
+
+type ConfigStore struct {
+	configPath string
+}
+
+func NewConfigStore(options StoreOptions) *ConfigStore {
+	path := options.ConfigPath
+	if strings.TrimSpace(path) == "" {
+		paths, _ := ResolvePaths(ResolvePathOptions{})
+		path = paths.ProjectConfigPath
+	}
+	resolved, err := filepath.Abs(path)
+	if err == nil {
+		path = resolved
+	}
+	return &ConfigStore{configPath: path}
+}
+
+func (store *ConfigStore) List() (Config, error) {
+	result, err := LoadConfig(LoadOptions{
+		UserConfigPath:    store.configPath + ".user-missing",
+		ProjectConfigPath: store.configPath,
+	})
+	if err != nil {
+		return Config{}, err
+	}
+	return result.Config, nil
+}
+
+func (store *ConfigStore) Upsert(hook Definition) (Definition, error) {
+	lock := lockForPath(store.configPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	config, err := store.List()
+	if err != nil {
+		return Definition{}, err
+	}
+	raw := definitionToRaw(hook)
+	if !hook.Enabled {
+		delete(raw, "enabled")
+	}
+	normalized, err := normalizeDefinition(raw, "hooks.0")
+	if err != nil {
+		return Definition{}, err
+	}
+	next := make([]Definition, 0, len(config.Hooks)+1)
+	for _, existing := range config.Hooks {
+		if existing.ID != normalized.ID {
+			next = append(next, existing)
+		}
+	}
+	next = append(next, normalized)
+	sortDefinitions(next)
+	config.Hooks = next
+	if err := WriteConfig(store.configPath, config); err != nil {
+		return Definition{}, err
+	}
+	return normalized, nil
+}
+
+func (store *ConfigStore) Remove(hookID string) (bool, error) {
+	lock := lockForPath(store.configPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	config, err := store.List()
+	if err != nil {
+		return false, err
+	}
+	next := make([]Definition, 0, len(config.Hooks))
+	removed := false
+	for _, hook := range config.Hooks {
+		if hook.ID == hookID {
+			removed = true
+			continue
+		}
+		next = append(next, hook)
+	}
+	if !removed {
+		return false, nil
+	}
+	config.Hooks = next
+	return true, WriteConfig(store.configPath, config)
+}
+
+func (store *ConfigStore) SetEnabled(hookID string, enabled bool) (bool, error) {
+	lock := lockForPath(store.configPath)
+	lock.Lock()
+	defer lock.Unlock()
+
+	config, err := store.List()
+	if err != nil {
+		return false, err
+	}
+	changed := false
+	for index := range config.Hooks {
+		if config.Hooks[index].ID == hookID {
+			config.Hooks[index].Enabled = enabled
+			changed = true
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, WriteConfig(store.configPath, config)
+}
+
+func Select(config Config, input SelectInput) []Definition {
+	if !config.Enabled {
+		return []Definition{}
+	}
+	selected := []Definition{}
+	for _, hook := range config.Hooks {
+		if !hook.Enabled || hook.Event != input.Event {
+			continue
+		}
+		if hook.Matcher == "" {
+			selected = append(selected, hook)
+			continue
+		}
+		if input.ToolName != "" && matchesHookMatcher(hook.Matcher, input.ToolName) {
+			selected = append(selected, hook)
+		}
+	}
+	return selected
+}
+
+func FormatList(config Config, diagnostics []Diagnostic) string {
+	state := "disabled"
+	if config.Enabled {
+		state = "enabled"
+	}
+	lines := []string{"Zero Hooks: " + state}
+	if len(config.Hooks) == 0 {
+		lines = append(lines, "  No hooks configured.")
+	} else {
+		for _, hook := range config.Hooks {
+			matcher := ""
+			if hook.Matcher != "" {
+				matcher = " " + hook.Matcher
+			}
+			command := strings.Join(append([]string{hook.Command}, hook.Args...), " ")
+			hookState := "disabled"
+			if hook.Enabled {
+				hookState = "enabled"
+			}
+			lines = append(lines, fmt.Sprintf("  %s [%s%s] %s - %s", hook.ID, hook.Event, matcher, hookState, command))
+		}
+	}
+	if len(diagnostics) > 0 {
+		lines = append(lines, "Hook diagnostics:")
+		for _, diagnostic := range diagnostics {
+			lines = append(lines, fmt.Sprintf("  [%s] %s", diagnostic.Kind, diagnostic.Message))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+type AuditStore struct {
+	auditPath string
+	now       func() time.Time
+	mu        sync.Mutex
+}
+
+func NewAuditStore(options AuditStoreOptions) *AuditStore {
+	path := options.AuditPath
+	if strings.TrimSpace(path) == "" {
+		paths, _ := ResolvePaths(ResolvePathOptions{})
+		path = paths.AuditPath
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &AuditStore{auditPath: path, now: now}
+}
+
+func (store *AuditStore) AppendStarted(input AppendStartedInput) (AuditEvent, error) {
+	return store.append(AuditEvent{
+		Type:       "hook_execution_started",
+		HookID:     input.HookID,
+		Event:      input.Event,
+		Matcher:    input.Matcher,
+		ToolCallID: input.ToolCallID,
+		Commands:   input.Commands,
+	})
+}
+
+func (store *AuditStore) AppendCompleted(input AppendCompletedInput) (AuditEvent, error) {
+	return store.append(AuditEvent{
+		Type:       "hook_execution_completed",
+		HookID:     input.HookID,
+		Event:      input.Event,
+		Matcher:    input.Matcher,
+		ToolCallID: input.ToolCallID,
+		Status:     input.Status,
+		Results:    input.Results,
+		DurationMs: input.DurationMs,
+	})
+}
+
+func (store *AuditStore) ReadEvents() ([]AuditEvent, error) {
+	data, err := os.ReadFile(store.auditPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []AuditEvent{}, nil
+		}
+		return nil, err
+	}
+	events := []AuditEvent{}
+	for index, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var event AuditEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			_ = index
+			continue
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func (store *AuditStore) append(event AuditEvent) (AuditEvent, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	events, err := store.ReadEvents()
+	if err != nil {
+		return AuditEvent{}, err
+	}
+	highest := 0
+	for _, existing := range events {
+		if existing.Sequence > highest {
+			highest = existing.Sequence
+		}
+	}
+	event.Sequence = highest + 1
+	event.CreatedAt = store.now().UTC().Format(time.RFC3339Nano)
+
+	if err := os.MkdirAll(filepath.Dir(store.auditPath), 0o700); err != nil {
+		return AuditEvent{}, err
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return AuditEvent{}, err
+	}
+	file, err := os.OpenFile(store.auditPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return AuditEvent{}, err
+	}
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		_ = file.Close()
+		return AuditEvent{}, err
+	}
+	if err := file.Close(); err != nil {
+		return AuditEvent{}, err
+	}
+	return event, nil
+}
+
+func readLayer(source ConfigSource, path string, diagnostics *[]Diagnostic) (hookLayer, bool) {
+	resolved, err := filepath.Abs(path)
+	if err == nil {
+		path = resolved
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return hookLayer{}, false
+		}
+		*diagnostics = append(*diagnostics, Diagnostic{Kind: DiagnosticIO, Source: source, Path: path, Message: err.Error()})
+		return hookLayer{}, false
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		*diagnostics = append(*diagnostics, Diagnostic{Kind: DiagnosticJSON, Source: source, Path: path, Message: err.Error()})
+		return hookLayer{}, false
+	}
+	config, err := normalizeConfig(raw)
+	if err != nil {
+		*diagnostics = append(*diagnostics, toDiagnostic(err, source, path))
+		return hookLayer{}, false
+	}
+	return hookLayer{source: source, path: path, config: config}, true
+}
+
+func mergeLayers(layers []hookLayer, diagnostics *[]Diagnostic) Config {
+	enabled := true
+	byID := map[string]Definition{}
+	sourceByID := map[string]hookLayer{}
+	for _, layer := range layers {
+		enabled = layer.config.Enabled
+		for _, hook := range layer.config.Hooks {
+			if previous, ok := sourceByID[hook.ID]; ok {
+				*diagnostics = append(*diagnostics, Diagnostic{
+					Kind:    DiagnosticDuplicate,
+					Source:  layer.source,
+					Path:    layer.path,
+					HookID:  hook.ID,
+					Message: fmt.Sprintf("Hook %q from %s overrides %s hook at %s.", hook.ID, layer.source, previous.source, previous.path),
+				})
+			}
+			byID[hook.ID] = hook
+			sourceByID[hook.ID] = layer
+		}
+	}
+	hooks := make([]Definition, 0, len(byID))
+	for _, hook := range byID {
+		hooks = append(hooks, hook)
+	}
+	sortDefinitions(hooks)
+	return Config{Enabled: enabled, Hooks: hooks}
+}
+
+func normalizeConfig(raw any) (Config, error) {
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return Config{}, manifestError{message: "Expected hooks config to be a JSON object."}
+	}
+	enabled := true
+	if rawEnabled, ok := obj["enabled"]; ok {
+		parsed, ok := rawEnabled.(bool)
+		if !ok {
+			return Config{}, manifestError{fieldPath: "enabled", message: "Expected a boolean."}
+		}
+		enabled = parsed
+	}
+	items, err := optionalArray(obj["hooks"], "hooks")
+	if err != nil {
+		return Config{}, err
+	}
+	definitions := make([]Definition, 0, len(items))
+	for index, item := range items {
+		definition, err := normalizeDefinition(item, fmt.Sprintf("hooks.%d", index))
+		if err != nil {
+			return Config{}, err
+		}
+		definitions = append(definitions, definition)
+	}
+	sortDefinitions(definitions)
+	return Config{Enabled: enabled, Hooks: definitions}, nil
+}
+
+func normalizeDefinition(raw any, field string) (Definition, error) {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return Definition{}, manifestError{fieldPath: field, message: "Expected hook definition to be an object."}
+	}
+	id, err := requiredID(obj, field+".id")
+	if err != nil {
+		return Definition{}, err
+	}
+	name, err := optionalString(obj, field+".name")
+	if err != nil {
+		return Definition{}, err
+	}
+	description, err := optionalString(obj, field+".description")
+	if err != nil {
+		return Definition{}, err
+	}
+	event, err := parseEvent(obj["event"], field+".event")
+	if err != nil {
+		return Definition{}, err
+	}
+	matcher, err := optionalString(obj, field+".matcher")
+	if err != nil {
+		return Definition{}, err
+	}
+	if matcher != "" && (event == EventSessionStart || event == EventSessionEnd) {
+		return Definition{}, manifestError{fieldPath: field + ".matcher", message: "matcher is only supported for beforeTool and afterTool hooks."}
+	}
+	command, err := requiredString(obj, field+".command")
+	if err != nil {
+		return Definition{}, err
+	}
+	args, err := optionalStringArray(obj["args"], field+".args")
+	if err != nil {
+		return Definition{}, err
+	}
+	enabled := true
+	if rawEnabled, ok := obj["enabled"]; ok {
+		parsed, ok := rawEnabled.(bool)
+		if !ok {
+			return Definition{}, manifestError{fieldPath: field + ".enabled", message: "Expected a boolean."}
+		}
+		enabled = parsed
+	}
+	return Definition{ID: id, Name: name, Description: description, Event: event, Matcher: matcher, Command: command, Args: args, Enabled: enabled}, nil
+}
+
+func matchesHookMatcher(matcher string, toolName string) bool {
+	if matcher == "*" {
+		return true
+	}
+	if !strings.Contains(matcher, "*") {
+		return matcher == toolName
+	}
+	segments := strings.Split(matcher, "*")
+	cursor := 0
+	searchEnd := len(toolName)
+	if !strings.HasPrefix(matcher, "*") {
+		first := segments[0]
+		segments = segments[1:]
+		if !strings.HasPrefix(toolName, first) {
+			return false
+		}
+		cursor = len(first)
+	}
+	if !strings.HasSuffix(matcher, "*") {
+		last := segments[len(segments)-1]
+		segments = segments[:len(segments)-1]
+		if !strings.HasSuffix(toolName, last) {
+			return false
+		}
+		searchEnd = len(toolName) - len(last)
+	}
+	for _, segment := range segments {
+		if segment == "" {
+			continue
+		}
+		index := strings.Index(toolName[cursor:], segment)
+		if index < 0 {
+			return false
+		}
+		cursor += index + len(segment)
+		if cursor > searchEnd {
+			return false
+		}
+	}
+	return cursor <= searchEnd
+}
+
+func toDiagnostic(err error, source ConfigSource, path string) Diagnostic {
+	var manifestErr manifestError
+	if errors.As(err, &manifestErr) {
+		return Diagnostic{Kind: DiagnosticSchema, Source: source, Path: path, FieldPath: manifestErr.fieldPath, Message: manifestErr.message}
+	}
+	return Diagnostic{Kind: DiagnosticSchema, Source: source, Path: path, Message: err.Error()}
+}
+
+func requiredString(obj map[string]any, field string) (string, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok {
+		return "", manifestError{fieldPath: field, message: "Expected a non-empty string."}
+	}
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", manifestError{fieldPath: field, message: "Expected a non-empty string."}
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func optionalString(obj map[string]any, field string) (string, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", manifestError{fieldPath: field, message: "Expected a non-empty string."}
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func requiredID(obj map[string]any, field string) (string, error) {
+	value, err := requiredString(obj, field)
+	if err != nil {
+		return "", err
+	}
+	if !hookIDPattern.MatchString(value) {
+		return "", manifestError{fieldPath: field, message: "Use letters, numbers, dots, dashes, or underscores."}
+	}
+	return value, nil
+}
+
+func parseEvent(raw any, field string) (Event, error) {
+	text, ok := raw.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", manifestError{fieldPath: field, message: "Expected a hook event."}
+	}
+	event := Event(strings.TrimSpace(text))
+	switch event {
+	case EventBeforeTool, EventAfterTool, EventSessionStart, EventSessionEnd:
+		return event, nil
+	default:
+		return "", manifestError{fieldPath: field, message: "Expected beforeTool, afterTool, sessionStart, or sessionEnd."}
+	}
+}
+
+func optionalArray(raw any, field string) ([]any, error) {
+	if raw == nil {
+		return []any{}, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, manifestError{fieldPath: field, message: "Expected an array."}
+	}
+	return items, nil
+}
+
+func optionalStringArray(raw any, field string) ([]string, error) {
+	if raw == nil {
+		return []string{}, nil
+	}
+	if values, ok := raw.([]string); ok {
+		return append([]string{}, values...), nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, manifestError{fieldPath: field, message: "Expected an array."}
+	}
+	values := make([]string, 0, len(items))
+	for index, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			return nil, manifestError{fieldPath: fmt.Sprintf("%s.%d", field, index), message: "Expected a string."}
+		}
+		values = append(values, text)
+	}
+	return values, nil
+}
+
+func definitionsToRaw(definitions []Definition) []any {
+	values := make([]any, 0, len(definitions))
+	for _, definition := range definitions {
+		values = append(values, definitionToRaw(definition))
+	}
+	return values
+}
+
+func definitionToRaw(definition Definition) map[string]any {
+	value := map[string]any{
+		"id":      definition.ID,
+		"event":   string(definition.Event),
+		"command": definition.Command,
+		"args":    definition.Args,
+		"enabled": definition.Enabled,
+	}
+	if definition.Name != "" {
+		value["name"] = definition.Name
+	}
+	if definition.Description != "" {
+		value["description"] = definition.Description
+	}
+	if definition.Matcher != "" {
+		value["matcher"] = definition.Matcher
+	}
+	return value
+}
+
+func sortDefinitions(definitions []Definition) {
+	sort.Slice(definitions, func(left int, right int) bool {
+		return definitions[left].ID < definitions[right].ID
+	})
+}
+
+func lockForPath(path string) *sync.Mutex {
+	storeLocksMu.Lock()
+	defer storeLocksMu.Unlock()
+	lock := storeLocks[path]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		storeLocks[path] = lock
+	}
+	return lock
+}
+
+func resolveEnvDir(env map[string]string, key string, fallback string, cwd string) string {
+	value := strings.TrimSpace(envValue(env, key))
+	if value == "" {
+		return fallback
+	}
+	if filepath.IsAbs(value) {
+		return filepath.Clean(value)
+	}
+	return filepath.Join(cwd, value)
+}
+
+func resolveCwd(cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return os.Getwd()
+	}
+	if filepath.IsAbs(cwd) {
+		return filepath.Clean(cwd), nil
+	}
+	return filepath.Abs(cwd)
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func lastPathSegment(field string) string {
+	if index := strings.LastIndex(field, "."); index >= 0 {
+		return field[index+1:]
+	}
+	return field
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -249,11 +249,15 @@ func WriteConfig(path string, config Config) error {
 	if err != nil {
 		return err
 	}
-	tempPath := fmt.Sprintf("%s.tmp-%d", resolved, os.Getpid())
+	tempPath := fmt.Sprintf("%s.tmp-%d-%d", resolved, os.Getpid(), time.Now().UnixNano())
 	if err := os.WriteFile(tempPath, append(data, '\n'), 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tempPath, resolved)
+	if err := os.Rename(tempPath, resolved); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
 }
 
 type ConfigStore struct {
@@ -277,14 +281,7 @@ func NewConfigStore(options StoreOptions) (*ConfigStore, error) {
 }
 
 func (store *ConfigStore) List() (Config, error) {
-	result, err := LoadConfig(LoadOptions{
-		UserConfigPath:    store.configPath + ".user-missing",
-		ProjectConfigPath: store.configPath,
-	})
-	if err != nil {
-		return Config{}, err
-	}
-	return result.Config, nil
+	return readSingleConfig(store.configPath)
 }
 
 func (store *ConfigStore) Upsert(hook Definition) (Definition, error) {
@@ -557,6 +554,19 @@ func readLayer(source ConfigSource, path string, diagnostics *[]Diagnostic) (hoo
 		return hookLayer{}, false
 	}
 	return hookLayer{source: source, path: path, config: config}, true
+}
+
+func readSingleConfig(path string) (Config, error) {
+	diagnostics := []Diagnostic{}
+	layer, ok := readLayer(SourceProject, path, &diagnostics)
+	if len(diagnostics) > 0 {
+		diagnostic := diagnostics[0]
+		return Config{}, fmt.Errorf("invalid Zero hook config at %s: %s", diagnostic.Path, diagnostic.Message)
+	}
+	if !ok {
+		return Config{Enabled: true, Hooks: []Definition{}}, nil
+	}
+	return layer.config, nil
 }
 
 func mergeLayers(layers []hookLayer, diagnostics *[]Diagnostic) Config {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -260,17 +260,20 @@ type ConfigStore struct {
 	configPath string
 }
 
-func NewConfigStore(options StoreOptions) *ConfigStore {
+func NewConfigStore(options StoreOptions) (*ConfigStore, error) {
 	path := options.ConfigPath
 	if strings.TrimSpace(path) == "" {
-		paths, _ := ResolvePaths(ResolvePathOptions{})
+		paths, err := ResolvePaths(ResolvePathOptions{})
+		if err != nil {
+			return nil, err
+		}
 		path = paths.ProjectConfigPath
 	}
 	resolved, err := filepath.Abs(path)
-	if err == nil {
-		path = resolved
+	if err != nil {
+		return nil, err
 	}
-	return &ConfigStore{configPath: path}
+	return &ConfigStore{configPath: resolved}, nil
 }
 
 func (store *ConfigStore) List() (Config, error) {
@@ -294,6 +297,8 @@ func (store *ConfigStore) Upsert(hook Definition) (Definition, error) {
 		return Definition{}, err
 	}
 	raw := definitionToRaw(hook)
+	// Upsert treats the zero-value Enabled field as omitted so new hooks default
+	// to enabled. Disable persisted hooks explicitly with SetEnabled.
 	if !hook.Enabled {
 		delete(raw, "enabled")
 	}
@@ -420,17 +425,24 @@ type AuditStore struct {
 	mu        sync.Mutex
 }
 
-func NewAuditStore(options AuditStoreOptions) *AuditStore {
+func NewAuditStore(options AuditStoreOptions) (*AuditStore, error) {
 	path := options.AuditPath
 	if strings.TrimSpace(path) == "" {
-		paths, _ := ResolvePaths(ResolvePathOptions{})
+		paths, err := ResolvePaths(ResolvePathOptions{})
+		if err != nil {
+			return nil, err
+		}
 		path = paths.AuditPath
+	}
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
 	}
 	now := options.Now
 	if now == nil {
 		now = time.Now
 	}
-	return &AuditStore{auditPath: path, now: now}
+	return &AuditStore{auditPath: resolved, now: now}, nil
 }
 
 func (store *AuditStore) AppendStarted(input AppendStartedInput) (AuditEvent, error) {
@@ -457,6 +469,9 @@ func (store *AuditStore) AppendCompleted(input AppendCompletedInput) (AuditEvent
 	})
 }
 
+// ReadEvents deliberately does not acquire store.mu. append holds store.mu while
+// writing a single O_APPEND JSONL record, and lock-free readers may miss or skip
+// an in-progress append while still avoiding deadlocks with append's read step.
 func (store *AuditStore) ReadEvents() ([]AuditEvent, error) {
 	data, err := os.ReadFile(store.auditPath)
 	if err != nil {
@@ -466,14 +481,13 @@ func (store *AuditStore) ReadEvents() ([]AuditEvent, error) {
 		return nil, err
 	}
 	events := []AuditEvent{}
-	for index, line := range strings.Split(string(data), "\n") {
+	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
 		var event AuditEvent
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			_ = index
 			continue
 		}
 		events = append(events, event)

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -164,9 +164,11 @@ func (err manifestError) Error() string {
 }
 
 type hookLayer struct {
-	source ConfigSource
-	path   string
-	config Config
+	source         ConfigSource
+	path           string
+	config         Config
+	enabledSet     bool
+	hookEnabledSet map[string]bool
 }
 
 var (
@@ -548,12 +550,13 @@ func readLayer(source ConfigSource, path string, diagnostics *[]Diagnostic) (hoo
 		*diagnostics = append(*diagnostics, Diagnostic{Kind: DiagnosticJSON, Source: source, Path: path, Message: err.Error()})
 		return hookLayer{}, false
 	}
+	enabledSet, hookEnabledSet := extractLayerEnabledMarkers(raw)
 	config, err := normalizeConfig(raw)
 	if err != nil {
 		*diagnostics = append(*diagnostics, toDiagnostic(err, source, path))
 		return hookLayer{}, false
 	}
-	return hookLayer{source: source, path: path, config: config}, true
+	return hookLayer{source: source, path: path, config: config, enabledSet: enabledSet, hookEnabledSet: hookEnabledSet}, true
 }
 
 func readSingleConfig(path string) (Config, error) {
@@ -574,7 +577,9 @@ func mergeLayers(layers []hookLayer, diagnostics *[]Diagnostic) Config {
 	byID := map[string]Definition{}
 	sourceByID := map[string]hookLayer{}
 	for _, layer := range layers {
-		enabled = layer.config.Enabled
+		if layer.enabledSet {
+			enabled = layer.config.Enabled
+		}
 		for _, hook := range layer.config.Hooks {
 			if previous, ok := sourceByID[hook.ID]; ok {
 				*diagnostics = append(*diagnostics, Diagnostic{
@@ -584,6 +589,9 @@ func mergeLayers(layers []hookLayer, diagnostics *[]Diagnostic) Config {
 					HookID:  hook.ID,
 					Message: fmt.Sprintf("Hook %q from %s overrides %s hook at %s.", hook.ID, layer.source, previous.source, previous.path),
 				})
+				if !layer.hookEnabledSet[hook.ID] {
+					hook.Enabled = byID[hook.ID].Enabled
+				}
 			}
 			byID[hook.ID] = hook
 			sourceByID[hook.ID] = layer
@@ -595,6 +603,33 @@ func mergeLayers(layers []hookLayer, diagnostics *[]Diagnostic) Config {
 	}
 	sortDefinitions(hooks)
 	return Config{Enabled: enabled, Hooks: hooks}
+}
+
+func extractLayerEnabledMarkers(raw any) (bool, map[string]bool) {
+	hookEnabledSet := map[string]bool{}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return false, hookEnabledSet
+	}
+	_, enabledSet := obj["enabled"]
+	items, ok := obj["hooks"].([]any)
+	if !ok {
+		return enabledSet, hookEnabledSet
+	}
+	for _, item := range items {
+		hook, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, ok := hook["id"].(string)
+		if !ok {
+			continue
+		}
+		if _, ok := hook["enabled"]; ok {
+			hookEnabledSet[strings.TrimSpace(id)] = true
+		}
+	}
+	return enabledSet, hookEnabledSet
 }
 
 func normalizeConfig(raw any) (Config, error) {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,0 +1,255 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResolvePathsUsesXDGLocations(t *testing.T) {
+	dir := t.TempDir()
+	paths, err := ResolvePaths(ResolvePathOptions{
+		Cwd: dir,
+		Env: map[string]string{
+			"XDG_CONFIG_HOME": filepath.Join(dir, "config"),
+			"XDG_DATA_HOME":   filepath.Join(dir, "data"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolvePaths returned error: %v", err)
+	}
+	if paths.UserConfigPath != filepath.Join(dir, "config", "zero", "hooks.json") {
+		t.Fatalf("user path = %q", paths.UserConfigPath)
+	}
+	if paths.ProjectConfigPath != filepath.Join(dir, ".zero", "hooks.json") {
+		t.Fatalf("project path = %q", paths.ProjectConfigPath)
+	}
+	if paths.AuditPath != filepath.Join(dir, "data", "zero", "hooks", "audit.jsonl") {
+		t.Fatalf("audit path = %q", paths.AuditPath)
+	}
+}
+
+func TestLoadConfigLayersProjectOverridesAndDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	userConfigPath := filepath.Join(dir, "user-hooks.json")
+	projectConfigPath := filepath.Join(dir, "project-hooks.json")
+	writeHookJSON(t, userConfigPath, map[string]any{
+		"enabled": true,
+		"hooks": []any{
+			map[string]any{
+				"id":      "zero.format",
+				"name":    "Format after edits",
+				"event":   "afterTool",
+				"matcher": "edit_file",
+				"command": "bun",
+				"args":    []string{"run", "format"},
+			},
+			map[string]any{
+				"id":      "zero.audit",
+				"event":   "sessionEnd",
+				"command": "node",
+				"args":    []string{"audit.mjs"},
+			},
+		},
+	})
+	writeHookJSON(t, projectConfigPath, map[string]any{
+		"hooks": []any{map[string]any{
+			"id":      "zero.format",
+			"event":   "afterTool",
+			"matcher": "write_file",
+			"command": "bun",
+			"args":    []string{"run", "lint"},
+			"enabled": false,
+		}},
+	})
+
+	result, err := LoadConfig(LoadOptions{UserConfigPath: userConfigPath, ProjectConfigPath: projectConfigPath})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if !result.Config.Enabled {
+		t.Fatalf("config should be enabled")
+	}
+	if got := []string{result.Config.Hooks[0].ID, result.Config.Hooks[1].ID}; !reflect.DeepEqual(got, []string{"zero.audit", "zero.format"}) {
+		t.Fatalf("hook order = %#v", got)
+	}
+	format := result.Config.Hooks[1]
+	if format.Enabled || format.Matcher != "write_file" || !reflect.DeepEqual(format.Args, []string{"run", "lint"}) {
+		t.Fatalf("project override not applied: %#v", format)
+	}
+	if !hasHookDiagnostic(result.Diagnostics, DiagnosticDuplicate, "zero.format", "") {
+		t.Fatalf("missing duplicate diagnostic: %#v", result.Diagnostics)
+	}
+}
+
+func TestLoadConfigRejectsMatchersOnSessionHooks(t *testing.T) {
+	dir := t.TempDir()
+	projectConfigPath := filepath.Join(dir, "hooks.json")
+	writeHookJSON(t, projectConfigPath, map[string]any{
+		"hooks": []any{map[string]any{
+			"id":      "zero.session",
+			"event":   "sessionStart",
+			"matcher": "bash",
+			"command": "node",
+		}},
+	})
+
+	result, err := LoadConfig(LoadOptions{
+		UserConfigPath:    filepath.Join(dir, "missing-user-hooks.json"),
+		ProjectConfigPath: projectConfigPath,
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if len(result.Config.Hooks) != 0 {
+		t.Fatalf("expected invalid hooks to be skipped: %#v", result.Config.Hooks)
+	}
+	if !hasHookDiagnostic(result.Diagnostics, DiagnosticSchema, "", "hooks.0.matcher") {
+		t.Fatalf("missing matcher diagnostic: %#v", result.Diagnostics)
+	}
+}
+
+func TestConfigStorePersistsUpdates(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "hooks.json")
+	store := NewConfigStore(StoreOptions{ConfigPath: configPath})
+
+	_, err := store.Upsert(Definition{
+		ID:      "zero.preflight",
+		Name:    "Preflight",
+		Event:   EventBeforeTool,
+		Matcher: "bash",
+		Command: "node",
+		Args:    []string{"hooks/preflight.mjs"},
+	})
+	if err != nil {
+		t.Fatalf("Upsert returned error: %v", err)
+	}
+	config, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if !config.Hooks[0].Enabled {
+		t.Fatalf("new hooks should default to enabled: %#v", config.Hooks[0])
+	}
+	changed, err := store.SetEnabled("zero.preflight", false)
+	if err != nil || !changed {
+		t.Fatalf("SetEnabled changed=%v err=%v", changed, err)
+	}
+
+	config, err = store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if config.Hooks[0].Enabled || config.Hooks[0].Matcher != "bash" {
+		t.Fatalf("unexpected stored hook: %#v", config.Hooks[0])
+	}
+	removed, err := store.Remove("zero.preflight")
+	if err != nil || !removed {
+		t.Fatalf("Remove removed=%v err=%v", removed, err)
+	}
+	config, err = store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(config.Hooks) != 0 {
+		t.Fatalf("expected no hooks after remove, got %#v", config.Hooks)
+	}
+}
+
+func TestSelectMatchesEnabledHooksByEventAndWildcard(t *testing.T) {
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "zero.reads", Event: EventBeforeTool, Matcher: "read_*", Command: "node", Enabled: true},
+		{ID: "zero.shell", Event: EventBeforeTool, Matcher: "bash", Command: "node", Enabled: false},
+		{ID: "zero.done", Event: EventSessionEnd, Command: "node", Enabled: true},
+		{ID: "zero.shell-edit", Event: EventBeforeTool, Matcher: "shell_*_edit", Command: "node", Enabled: true},
+	}}
+
+	if got := hookIDs(Select(config, SelectInput{Event: EventBeforeTool, ToolName: "read_file"})); !reflect.DeepEqual(got, []string{"zero.reads"}) {
+		t.Fatalf("read selection = %#v", got)
+	}
+	if got := hookIDs(Select(config, SelectInput{Event: EventBeforeTool, ToolName: "shell_safe_edit"})); !reflect.DeepEqual(got, []string{"zero.shell-edit"}) {
+		t.Fatalf("shell edit selection = %#v", got)
+	}
+	if got := Select(config, SelectInput{Event: EventBeforeTool, ToolName: "shell_safe_view"}); len(got) != 0 {
+		t.Fatalf("unexpected selection: %#v", got)
+	}
+}
+
+func TestAuditStoreAppendsAndSkipsMalformedLines(t *testing.T) {
+	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	if err := os.WriteFile(auditPath, []byte(strings.Join([]string{
+		`{"sequence":1,"createdAt":"2026-06-04T00:00:00Z","type":"hook_execution_started","hookId":"zero.seed","event":"sessionStart"}`,
+		"{not-json",
+		`{"sequence":2,"createdAt":"2026-06-04T00:00:01Z","type":"hook_execution_completed","hookId":"zero.seed","event":"sessionStart","status":"completed"}`,
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewAuditStore(AuditStoreOptions{
+		AuditPath: auditPath,
+		Now:       func() time.Time { return time.Date(2026, 6, 4, 0, 0, 2, 0, time.UTC) },
+	})
+
+	events, err := store.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got := []int{events[0].Sequence, events[1].Sequence}; !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("initial sequences = %#v", got)
+	}
+
+	appended, err := store.AppendStarted(AppendStartedInput{
+		HookID:   "zero.preflight",
+		Event:    EventBeforeTool,
+		Matcher:  "bash",
+		Commands: []AuditCommand{{Command: "node", Args: []string{"hooks/preflight.mjs"}}},
+	})
+	if err != nil {
+		t.Fatalf("AppendStarted returned error: %v", err)
+	}
+	if appended.Sequence != 3 || appended.CreatedAt != "2026-06-04T00:00:02Z" {
+		t.Fatalf("unexpected appended event: %#v", appended)
+	}
+}
+
+func writeHookJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hookIDs(definitions []Definition) []string {
+	ids := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		ids = append(ids, definition.ID)
+	}
+	return ids
+}
+
+func hasHookDiagnostic(diagnostics []Diagnostic, kind DiagnosticKind, hookID string, fieldPath string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Kind != kind {
+			continue
+		}
+		if hookID != "" && diagnostic.HookID != hookID {
+			continue
+		}
+		if fieldPath != "" && diagnostic.FieldPath != fieldPath {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -115,9 +115,12 @@ func TestLoadConfigRejectsMatchersOnSessionHooks(t *testing.T) {
 
 func TestConfigStorePersistsUpdates(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "hooks.json")
-	store := NewConfigStore(StoreOptions{ConfigPath: configPath})
+	store, err := NewConfigStore(StoreOptions{ConfigPath: configPath})
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
 
-	_, err := store.Upsert(Definition{
+	_, err = store.Upsert(Definition{
 		ID:      "zero.preflight",
 		Name:    "Preflight",
 		Event:   EventBeforeTool,
@@ -135,6 +138,18 @@ func TestConfigStorePersistsUpdates(t *testing.T) {
 	if !config.Hooks[0].Enabled {
 		t.Fatalf("new hooks should default to enabled: %#v", config.Hooks[0])
 	}
+	upserted, err := store.Upsert(Definition{
+		ID:      "zero.explicit",
+		Event:   EventAfterTool,
+		Command: "node",
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("Upsert with zero-value Enabled returned error: %v", err)
+	}
+	if !upserted.Enabled {
+		t.Fatalf("Upsert should default zero-value Enabled to true; use SetEnabled to disable: %#v", upserted)
+	}
 	changed, err := store.SetEnabled("zero.preflight", false)
 	if err != nil || !changed {
 		t.Fatalf("SetEnabled changed=%v err=%v", changed, err)
@@ -144,8 +159,9 @@ func TestConfigStorePersistsUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
-	if config.Hooks[0].Enabled || config.Hooks[0].Matcher != "bash" {
-		t.Fatalf("unexpected stored hook: %#v", config.Hooks[0])
+	preflight := findHook(config.Hooks, "zero.preflight")
+	if preflight == nil || preflight.Enabled || preflight.Matcher != "bash" {
+		t.Fatalf("unexpected stored hook: %#v", preflight)
 	}
 	removed, err := store.Remove("zero.preflight")
 	if err != nil || !removed {
@@ -155,8 +171,8 @@ func TestConfigStorePersistsUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List returned error: %v", err)
 	}
-	if len(config.Hooks) != 0 {
-		t.Fatalf("expected no hooks after remove, got %#v", config.Hooks)
+	if findHook(config.Hooks, "zero.preflight") != nil {
+		t.Fatalf("expected zero.preflight to be removed, got %#v", config.Hooks)
 	}
 }
 
@@ -189,10 +205,13 @@ func TestAuditStoreAppendsAndSkipsMalformedLines(t *testing.T) {
 	}, "\n")), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	store := NewAuditStore(AuditStoreOptions{
+	store, err := NewAuditStore(AuditStoreOptions{
 		AuditPath: auditPath,
 		Now:       func() time.Time { return time.Date(2026, 6, 4, 0, 0, 2, 0, time.UTC) },
 	})
+	if err != nil {
+		t.Fatalf("NewAuditStore returned error: %v", err)
+	}
 
 	events, err := store.ReadEvents()
 	if err != nil {
@@ -236,6 +255,15 @@ func hookIDs(definitions []Definition) []string {
 		ids = append(ids, definition.ID)
 	}
 	return ids
+}
+
+func findHook(definitions []Definition, id string) *Definition {
+	for index := range definitions {
+		if definitions[index].ID == id {
+			return &definitions[index]
+		}
+	}
+	return nil
 }
 
 func hasHookDiagnostic(diagnostics []Diagnostic, kind DiagnosticKind, hookID string, fieldPath string) bool {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -176,6 +176,37 @@ func TestConfigStorePersistsUpdates(t *testing.T) {
 	}
 }
 
+func TestConfigStoreListReadsOnlyStorePath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "hooks.json")
+	writeHookJSON(t, configPath, map[string]any{
+		"hooks": []any{map[string]any{
+			"id":      "zero.real",
+			"event":   "beforeTool",
+			"command": "node",
+		}},
+	})
+	writeHookJSON(t, configPath+".user-missing", map[string]any{
+		"hooks": []any{map[string]any{
+			"id":      "zero.fake",
+			"event":   "afterTool",
+			"command": "node",
+		}},
+	})
+	store, err := NewConfigStore(StoreOptions{ConfigPath: configPath})
+	if err != nil {
+		t.Fatalf("NewConfigStore returned error: %v", err)
+	}
+
+	config, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got := hookIDs(config.Hooks); !reflect.DeepEqual(got, []string{"zero.real"}) {
+		t.Fatalf("hook ids = %#v", got)
+	}
+}
+
 func TestSelectMatchesEnabledHooksByEventAndWildcard(t *testing.T) {
 	config := Config{Enabled: true, Hooks: []Definition{
 		{ID: "zero.reads", Event: EventBeforeTool, Matcher: "read_*", Command: "node", Enabled: true},

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -86,6 +86,47 @@ func TestLoadConfigLayersProjectOverridesAndDiagnostics(t *testing.T) {
 	}
 }
 
+func TestLoadConfigPreservesUserDisabledStateWhenProjectOmitsEnabled(t *testing.T) {
+	dir := t.TempDir()
+	userConfigPath := filepath.Join(dir, "user-hooks.json")
+	projectConfigPath := filepath.Join(dir, "project-hooks.json")
+	writeHookJSON(t, userConfigPath, map[string]any{
+		"enabled": false,
+		"hooks": []any{map[string]any{
+			"id":      "zero.format",
+			"event":   "afterTool",
+			"matcher": "edit_file",
+			"command": "bun",
+			"args":    []string{"run", "format"},
+			"enabled": false,
+		}},
+	})
+	writeHookJSON(t, projectConfigPath, map[string]any{
+		"hooks": []any{map[string]any{
+			"id":      "zero.format",
+			"event":   "afterTool",
+			"matcher": "write_file",
+			"command": "bun",
+			"args":    []string{"run", "lint"},
+		}},
+	})
+
+	result, err := LoadConfig(LoadOptions{UserConfigPath: userConfigPath, ProjectConfigPath: projectConfigPath})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if result.Config.Enabled {
+		t.Fatalf("project layer without enabled should preserve user disabled config: %#v", result.Config)
+	}
+	if len(result.Config.Hooks) != 1 {
+		t.Fatalf("expected one hook, got %#v", result.Config.Hooks)
+	}
+	format := result.Config.Hooks[0]
+	if format.Enabled || format.Matcher != "write_file" || !reflect.DeepEqual(format.Args, []string{"run", "lint"}) {
+		t.Fatalf("project override should preserve user-disabled hook state: %#v", format)
+	}
+}
+
 func TestLoadConfigRejectsMatchersOnSessionHooks(t *testing.T) {
 	dir := t.TempDir()
 	projectConfigPath := filepath.Join(dir, "hooks.json")

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -27,7 +27,11 @@ const (
 	AutonomyHigh   PermissionAutonomy = "high"
 )
 
-const permissionSchemaVersion = 1
+const (
+	permissionSchemaVersion = 1
+	permissionLockTimeout   = 5 * time.Second
+	permissionLockRetry     = 10 * time.Millisecond
+)
 
 type PermissionGrant struct {
 	Scope          PermissionScope    `json:"scope"`
@@ -158,6 +162,11 @@ func (store *PermissionStore) GrantServer(input GrantServerInput) (PermissionGra
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return PermissionGrant{}, err
+	}
+	defer unlock()
 
 	state, err := store.readState()
 	if err != nil {
@@ -184,6 +193,11 @@ func (store *PermissionStore) GrantTool(input GrantToolInput) (PermissionGrant, 
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return PermissionGrant{}, err
+	}
+	defer unlock()
 
 	state, err := store.readState()
 	if err != nil {
@@ -264,6 +278,11 @@ func (store *PermissionStore) RevokeTool(serverName string, toolName string) (in
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
 
 	state, err := store.readState()
 	if err != nil {
@@ -293,6 +312,11 @@ func (store *PermissionStore) RevokeServer(serverName string) (int, error) {
 
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
 
 	state, err := store.readState()
 	if err != nil {
@@ -318,6 +342,11 @@ func (store *PermissionStore) RevokeServer(serverName string) (int, error) {
 func (store *PermissionStore) Clear() (int, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
 
 	state, err := store.readState()
 	if err != nil {
@@ -415,6 +444,27 @@ func (store *PermissionStore) writeState(state permissionFile) error {
 		return err
 	}
 	return nil
+}
+
+func (store *PermissionStore) lockStateFile() (func(), error) {
+	lockPath := store.filePath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(store.filePath), 0o700); err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(permissionLockTimeout)
+	for {
+		err := os.Mkdir(lockPath, 0o700)
+		if err == nil {
+			return func() { _ = os.Remove(lockPath) }, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for MCP permissions lock at %s", lockPath)
+		}
+		time.Sleep(permissionLockRetry)
+	}
 }
 
 func emptyState() permissionFile {

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -435,7 +435,7 @@ func (store *PermissionStore) writeState(state permissionFile) error {
 	if err != nil {
 		return err
 	}
-	tempPath := fmt.Sprintf("%s.tmp-%d-%d", store.filePath, os.Getpid(), time.Now().UnixNano())
+	tempPath := fmt.Sprintf("%s.tmp-%d-%d", store.filePath, os.Getpid(), store.now().UnixNano())
 	if err := os.WriteFile(tempPath, append(data, '\n'), 0o600); err != nil {
 		return err
 	}

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -1,0 +1,538 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type PermissionScope string
+type PermissionAutonomy string
+
+const (
+	ScopeServer PermissionScope = "server"
+	ScopeTool   PermissionScope = "tool"
+)
+
+const (
+	AutonomyLow    PermissionAutonomy = "low"
+	AutonomyMedium PermissionAutonomy = "medium"
+	AutonomyHigh   PermissionAutonomy = "high"
+)
+
+const permissionSchemaVersion = 1
+
+type PermissionGrant struct {
+	Scope          PermissionScope    `json:"scope"`
+	ServerName     string             `json:"serverName"`
+	ServerIdentity string             `json:"serverIdentity"`
+	ToolName       string             `json:"toolName,omitempty"`
+	MaxAutonomy    PermissionAutonomy `json:"maxAutonomy"`
+	ApprovedAt     string             `json:"approvedAt"`
+}
+
+type StoreOptions struct {
+	FilePath string
+	Now      func() time.Time
+	Env      map[string]string
+}
+
+type GrantServerInput struct {
+	ServerName     string
+	ServerIdentity string
+	MaxAutonomy    PermissionAutonomy
+}
+
+type GrantToolInput struct {
+	ServerName     string
+	ServerIdentity string
+	ToolName       string
+	MaxAutonomy    PermissionAutonomy
+}
+
+type CheckToolInput struct {
+	ServerName        string
+	ServerIdentity    string
+	ToolName          string
+	RequestedAutonomy PermissionAutonomy
+}
+
+type storedGrant struct {
+	ServerIdentity string             `json:"serverIdentity"`
+	MaxAutonomy    PermissionAutonomy `json:"maxAutonomy"`
+	ApprovedAt     string             `json:"approvedAt"`
+}
+
+type permissionFile struct {
+	SchemaVersion int                               `json:"schemaVersion"`
+	Servers       map[string]storedGrant            `json:"servers"`
+	Tools         map[string]map[string]storedGrant `json:"tools"`
+}
+
+type PermissionStore struct {
+	filePath string
+	now      func() time.Time
+	mu       sync.Mutex
+}
+
+var (
+	serverNamePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	autonomyRank      = map[PermissionAutonomy]int{
+		AutonomyLow:    0,
+		AutonomyMedium: 1,
+		AutonomyHigh:   2,
+	}
+)
+
+func ResolvePermissionPath(env map[string]string) (string, error) {
+	override := strings.TrimSpace(envValue(env, "ZERO_MCP_PERMISSIONS_PATH"))
+	if override != "" {
+		if filepath.IsAbs(override) {
+			return filepath.Clean(override), nil
+		}
+		return filepath.Abs(override)
+	}
+
+	configHome := strings.TrimSpace(envValue(env, "XDG_CONFIG_HOME"))
+	if configHome == "" {
+		home := strings.TrimSpace(firstNonEmpty(envValue(env, "HOME"), envValue(env, "USERPROFILE")))
+		var err error
+		if home == "" {
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolve user home: %w", err)
+			}
+		}
+		configHome = filepath.Join(home, ".config")
+	} else if !filepath.IsAbs(configHome) {
+		resolved, err := filepath.Abs(configHome)
+		if err != nil {
+			return "", err
+		}
+		configHome = resolved
+	}
+	return filepath.Join(configHome, "zero", "mcp-permissions.json"), nil
+}
+
+func NewPermissionStore(options StoreOptions) (*PermissionStore, error) {
+	filePath := options.FilePath
+	var err error
+	if strings.TrimSpace(filePath) == "" {
+		filePath, err = ResolvePermissionPath(options.Env)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !filepath.IsAbs(filePath) {
+		filePath, err = filepath.Abs(filePath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &PermissionStore{filePath: filepath.Clean(filePath), now: now}, nil
+}
+
+func (store *PermissionStore) FilePath() string {
+	return store.filePath
+}
+
+func (store *PermissionStore) GrantServer(input GrantServerInput) (PermissionGrant, error) {
+	grant, err := createStoredGrant(input.ServerIdentity, input.MaxAutonomy, store.now)
+	if err != nil {
+		return PermissionGrant{}, err
+	}
+	if err := ValidateServerName(input.ServerName); err != nil {
+		return PermissionGrant{}, err
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return PermissionGrant{}, err
+	}
+	state.Servers[input.ServerName] = grant
+	if err := store.writeState(state); err != nil {
+		return PermissionGrant{}, err
+	}
+	return toServerGrant(input.ServerName, grant), nil
+}
+
+func (store *PermissionStore) GrantTool(input GrantToolInput) (PermissionGrant, error) {
+	grant, err := createStoredGrant(input.ServerIdentity, input.MaxAutonomy, store.now)
+	if err != nil {
+		return PermissionGrant{}, err
+	}
+	if err := ValidateServerName(input.ServerName); err != nil {
+		return PermissionGrant{}, err
+	}
+	if err := validateToolName(input.ToolName); err != nil {
+		return PermissionGrant{}, err
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return PermissionGrant{}, err
+	}
+	if state.Tools[input.ServerName] == nil {
+		state.Tools[input.ServerName] = map[string]storedGrant{}
+	}
+	state.Tools[input.ServerName][input.ToolName] = grant
+	if err := store.writeState(state); err != nil {
+		return PermissionGrant{}, err
+	}
+	return toToolGrant(input.ServerName, input.ToolName, grant), nil
+}
+
+func (store *PermissionStore) IsToolPersistentlyApproved(input CheckToolInput) (bool, error) {
+	if err := ValidateServerName(input.ServerName); err != nil {
+		return false, err
+	}
+	if err := validateToolName(input.ToolName); err != nil {
+		return false, err
+	}
+	requested, err := normalizeAutonomy(defaultAutonomy(input.RequestedAutonomy))
+	if err != nil {
+		return false, err
+	}
+
+	state, err := store.readState()
+	if err != nil {
+		return false, err
+	}
+	if isGrantAllowed(state.Tools[input.ServerName][input.ToolName], input.ServerIdentity, requested) {
+		return true, nil
+	}
+	return isGrantAllowed(state.Servers[input.ServerName], input.ServerIdentity, requested), nil
+}
+
+func (store *PermissionStore) List() ([]PermissionGrant, error) {
+	state, err := store.readState()
+	if err != nil {
+		return nil, err
+	}
+	grants := make([]PermissionGrant, 0, countGrants(state))
+	serverNames := make([]string, 0, len(state.Servers))
+	for serverName := range state.Servers {
+		serverNames = append(serverNames, serverName)
+	}
+	sort.Strings(serverNames)
+	for _, serverName := range serverNames {
+		grants = append(grants, toServerGrant(serverName, state.Servers[serverName]))
+	}
+
+	toolServers := make([]string, 0, len(state.Tools))
+	for serverName := range state.Tools {
+		toolServers = append(toolServers, serverName)
+	}
+	sort.Strings(toolServers)
+	for _, serverName := range toolServers {
+		toolNames := make([]string, 0, len(state.Tools[serverName]))
+		for toolName := range state.Tools[serverName] {
+			toolNames = append(toolNames, toolName)
+		}
+		sort.Strings(toolNames)
+		for _, toolName := range toolNames {
+			grants = append(grants, toToolGrant(serverName, toolName, state.Tools[serverName][toolName]))
+		}
+	}
+	return grants, nil
+}
+
+func (store *PermissionStore) RevokeTool(serverName string, toolName string) (int, error) {
+	if err := ValidateServerName(serverName); err != nil {
+		return 0, err
+	}
+	if err := validateToolName(toolName); err != nil {
+		return 0, err
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return 0, err
+	}
+	serverTools := state.Tools[serverName]
+	if serverTools == nil {
+		return 0, nil
+	}
+	if _, ok := serverTools[toolName]; !ok {
+		return 0, nil
+	}
+	delete(serverTools, toolName)
+	if len(serverTools) == 0 {
+		delete(state.Tools, serverName)
+	}
+	if err := store.writeState(state); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
+func (store *PermissionStore) RevokeServer(serverName string) (int, error) {
+	if err := ValidateServerName(serverName); err != nil {
+		return 0, err
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return 0, err
+	}
+	revoked := 0
+	if _, ok := state.Servers[serverName]; ok {
+		revoked++
+		delete(state.Servers, serverName)
+	}
+	if serverTools := state.Tools[serverName]; serverTools != nil {
+		revoked += len(serverTools)
+		delete(state.Tools, serverName)
+	}
+	if revoked > 0 {
+		if err := store.writeState(state); err != nil {
+			return 0, err
+		}
+	}
+	return revoked, nil
+}
+
+func (store *PermissionStore) Clear() (int, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return 0, err
+	}
+	count := countGrants(state)
+	if count > 0 {
+		if err := store.writeState(emptyState()); err != nil {
+			return 0, err
+		}
+	}
+	return count, nil
+}
+
+func FormatPermissionList(permissions []PermissionGrant) string {
+	if len(permissions) == 0 {
+		return "No persistent MCP permissions granted."
+	}
+	lines := []string{"MCP Permissions:"}
+	for _, permission := range permissions {
+		target := permission.ServerName + "/*"
+		if permission.Scope == ScopeTool {
+			target = permission.ServerName + "/" + permission.ToolName
+		}
+		lines = append(lines, fmt.Sprintf("  %s [%s] %s approved %s", target, permission.MaxAutonomy, permission.ServerIdentity, permission.ApprovedAt))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func ValidateServerName(name string) error {
+	if !serverNamePattern.MatchString(strings.TrimSpace(name)) {
+		return fmt.Errorf("invalid MCP server name %q. Use letters, numbers, dots, dashes, or underscores", name)
+	}
+	return nil
+}
+
+func (store *PermissionStore) readState() (permissionFile, error) {
+	data, err := os.ReadFile(store.filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return emptyState(), nil
+		}
+		return permissionFile{}, err
+	}
+	var state permissionFile
+	if err := json.Unmarshal(data, &state); err != nil {
+		return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
+	}
+	if state.SchemaVersion != permissionSchemaVersion {
+		return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: unsupported schemaVersion", store.filePath)
+	}
+	if state.Servers == nil {
+		state.Servers = map[string]storedGrant{}
+	}
+	if state.Tools == nil {
+		state.Tools = map[string]map[string]storedGrant{}
+	}
+	for serverName, grant := range state.Servers {
+		normalized, err := normalizeStoredGrant(grant, "servers."+serverName)
+		if err != nil {
+			return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
+		}
+		state.Servers[serverName] = normalized
+	}
+	for serverName, serverTools := range state.Tools {
+		if serverTools == nil {
+			state.Tools[serverName] = map[string]storedGrant{}
+			continue
+		}
+		for toolName, grant := range serverTools {
+			normalized, err := normalizeStoredGrant(grant, "tools."+serverName+"."+toolName)
+			if err != nil {
+				return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
+			}
+			serverTools[toolName] = normalized
+		}
+	}
+	return state, nil
+}
+
+func (store *PermissionStore) writeState(state permissionFile) error {
+	if err := os.MkdirAll(filepath.Dir(store.filePath), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tempPath := fmt.Sprintf("%s.tmp-%d-%d", store.filePath, os.Getpid(), time.Now().UnixNano())
+	if err := os.WriteFile(tempPath, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, store.filePath); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func emptyState() permissionFile {
+	return permissionFile{
+		SchemaVersion: permissionSchemaVersion,
+		Servers:       map[string]storedGrant{},
+		Tools:         map[string]map[string]storedGrant{},
+	}
+}
+
+func createStoredGrant(serverIdentity string, maxAutonomy PermissionAutonomy, now func() time.Time) (storedGrant, error) {
+	identity := strings.TrimSpace(serverIdentity)
+	if identity == "" {
+		return storedGrant{}, errors.New("MCP server identity is required")
+	}
+	autonomy, err := normalizeAutonomy(defaultAutonomy(maxAutonomy))
+	if err != nil {
+		return storedGrant{}, err
+	}
+	return storedGrant{
+		ServerIdentity: identity,
+		MaxAutonomy:    autonomy,
+		ApprovedAt:     now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func normalizeStoredGrant(grant storedGrant, label string) (storedGrant, error) {
+	if strings.TrimSpace(grant.ServerIdentity) == "" {
+		return storedGrant{}, fmt.Errorf("expected %s.serverIdentity to be a non-empty string", label)
+	}
+	if strings.TrimSpace(grant.ApprovedAt) == "" {
+		return storedGrant{}, fmt.Errorf("expected %s.approvedAt to be a non-empty string", label)
+	}
+	autonomy, err := normalizeAutonomy(grant.MaxAutonomy)
+	if err != nil {
+		return storedGrant{}, err
+	}
+	grant.ServerIdentity = strings.TrimSpace(grant.ServerIdentity)
+	grant.ApprovedAt = strings.TrimSpace(grant.ApprovedAt)
+	grant.MaxAutonomy = autonomy
+	return grant, nil
+}
+
+func normalizeAutonomy(value PermissionAutonomy) (PermissionAutonomy, error) {
+	normalized := PermissionAutonomy(strings.ToLower(strings.TrimSpace(string(value))))
+	switch normalized {
+	case AutonomyLow, AutonomyMedium, AutonomyHigh:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid MCP permission autonomy %q. Expected low, medium, or high", value)
+	}
+}
+
+func defaultAutonomy(value PermissionAutonomy) PermissionAutonomy {
+	if strings.TrimSpace(string(value)) == "" {
+		return AutonomyLow
+	}
+	return value
+}
+
+func validateToolName(toolName string) error {
+	if strings.TrimSpace(toolName) == "" {
+		return errors.New("MCP tool name is required")
+	}
+	return nil
+}
+
+func isGrantAllowed(grant storedGrant, serverIdentity string, requestedAutonomy PermissionAutonomy) bool {
+	if grant.ServerIdentity == "" {
+		return false
+	}
+	if grant.ServerIdentity != serverIdentity {
+		return false
+	}
+	return autonomyRank[requestedAutonomy] <= autonomyRank[grant.MaxAutonomy]
+}
+
+func toServerGrant(serverName string, grant storedGrant) PermissionGrant {
+	return PermissionGrant{
+		Scope:          ScopeServer,
+		ServerName:     serverName,
+		ServerIdentity: grant.ServerIdentity,
+		MaxAutonomy:    grant.MaxAutonomy,
+		ApprovedAt:     grant.ApprovedAt,
+	}
+}
+
+func toToolGrant(serverName string, toolName string, grant storedGrant) PermissionGrant {
+	return PermissionGrant{
+		Scope:          ScopeTool,
+		ServerName:     serverName,
+		ServerIdentity: grant.ServerIdentity,
+		ToolName:       toolName,
+		MaxAutonomy:    grant.MaxAutonomy,
+		ApprovedAt:     grant.ApprovedAt,
+	}
+}
+
+func countGrants(state permissionFile) int {
+	count := len(state.Servers)
+	for _, serverTools := range state.Tools {
+		count += len(serverTools)
+	}
+	return count
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -405,6 +405,9 @@ func (store *PermissionStore) readState() (permissionFile, error) {
 		state.Tools = map[string]map[string]storedGrant{}
 	}
 	for serverName, grant := range state.Servers {
+		if err := ValidateServerName(serverName); err != nil {
+			return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
+		}
 		normalized, err := normalizeStoredGrant(grant, "servers."+serverName)
 		if err != nil {
 			return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
@@ -412,11 +415,17 @@ func (store *PermissionStore) readState() (permissionFile, error) {
 		state.Servers[serverName] = normalized
 	}
 	for serverName, serverTools := range state.Tools {
+		if err := ValidateServerName(serverName); err != nil {
+			return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
+		}
 		if serverTools == nil {
 			state.Tools[serverName] = map[string]storedGrant{}
 			continue
 		}
 		for toolName, grant := range serverTools {
+			if err := validateToolName(toolName); err != nil {
+				return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
+			}
 			normalized, err := normalizeStoredGrant(grant, "tools."+serverName+"."+toolName)
 			if err != nil {
 				return permissionFile{}, fmt.Errorf("invalid MCP permissions file at %s: %w", store.filePath, err)
@@ -447,20 +456,29 @@ func (store *PermissionStore) writeState(state permissionFile) error {
 }
 
 func (store *PermissionStore) lockStateFile() (func(), error) {
-	lockPath := store.filePath + ".lock"
+	lockPath := store.filePath + ".lockfile"
 	if err := os.MkdirAll(filepath.Dir(store.filePath), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
 		return nil, err
 	}
 	deadline := time.Now().Add(permissionLockTimeout)
 	for {
-		err := os.Mkdir(lockPath, 0o700)
-		if err == nil {
-			return func() { _ = os.Remove(lockPath) }, nil
-		}
-		if !errors.Is(err, os.ErrExist) {
+		locked, err := tryLockPermissionFile(file)
+		if err != nil {
+			_ = file.Close()
 			return nil, err
 		}
+		if locked {
+			return func() {
+				_ = unlockPermissionFile(file)
+				_ = file.Close()
+			}, nil
+		}
 		if time.Now().After(deadline) {
+			_ = file.Close()
 			return nil, fmt.Errorf("timed out waiting for MCP permissions lock at %s", lockPath)
 		}
 		time.Sleep(permissionLockRetry)

--- a/internal/mcp/permissions_lock_unix.go
+++ b/internal/mcp/permissions_lock_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func tryLockPermissionFile(file *os.File) (bool, error) {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockPermissionFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/mcp/permissions_lock_windows.go
+++ b/internal/mcp/permissions_lock_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package mcp
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	lockfileFailImmediately = 0x00000001
+	lockfileExclusiveLock   = 0x00000002
+	errorLockViolation      = syscall.Errno(33)
+	errorSharingViolation   = syscall.Errno(32)
+)
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = kernel32.NewProc("LockFileEx")
+	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
+)
+
+func tryLockPermissionFile(file *os.File) (bool, error) {
+	var overlapped syscall.Overlapped
+	result, _, err := procLockFileEx.Call(
+		file.Fd(),
+		uintptr(lockfileExclusiveLock|lockfileFailImmediately),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if result != 0 {
+		return true, nil
+	}
+	if errors.Is(err, errorLockViolation) || errors.Is(err, errorSharingViolation) {
+		return false, nil
+	}
+	if err == syscall.Errno(0) {
+		return false, nil
+	}
+	return false, err
+}
+
+func unlockPermissionFile(file *os.File) error {
+	var overlapped syscall.Overlapped
+	result, _, err := procUnlockFileEx.Call(
+		file.Fd(),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if result != 0 || err == syscall.Errno(0) {
+		return nil
+	}
+	return err
+}

--- a/internal/mcp/permissions_test.go
+++ b/internal/mcp/permissions_test.go
@@ -198,6 +198,56 @@ func TestPermissionStoreSerializesConcurrentStoreInstances(t *testing.T) {
 	}
 }
 
+func TestPermissionStoreDoesNotBlockOnStaleDirectoryLock(t *testing.T) {
+	store := newTestPermissionStore(t)
+	if err := os.Mkdir(store.FilePath()+".lock", 0o700); err != nil {
+		t.Fatalf("failed to create stale directory lock: %v", err)
+	}
+
+	if _, err := store.GrantServer(GrantServerInput{
+		ServerName:     "docs",
+		ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		MaxAutonomy:    AutonomyLow,
+	}); err != nil {
+		t.Fatalf("GrantServer should ignore stale directory locks, got %v", err)
+	}
+}
+
+func TestPermissionStoreRejectsInvalidPersistedKeys(t *testing.T) {
+	validGrant := `{"serverIdentity":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","maxAutonomy":"low","approvedAt":"2026-06-03T09:30:00Z"}`
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "server key",
+			body: `{"schemaVersion":1,"servers":{"../escape":` + validGrant + `},"tools":{}}`,
+			want: "invalid MCP server name",
+		},
+		{
+			name: "tool key",
+			body: `{"schemaVersion":1,"servers":{},"tools":{"docs":{"":` + validGrant + `}}}`,
+			want: "MCP tool name is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filePath := filepath.Join(t.TempDir(), "mcp-permissions.json")
+			if err := os.WriteFile(filePath, []byte(tc.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			store, err := NewPermissionStore(StoreOptions{FilePath: filePath})
+			if err != nil {
+				t.Fatalf("NewPermissionStore returned error: %v", err)
+			}
+			_, err = store.List()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
 func TestResolvePermissionPathHonorsOverrideAndConfigHome(t *testing.T) {
 	dir := t.TempDir()
 	override, err := ResolvePermissionPath(map[string]string{"ZERO_MCP_PERMISSIONS_PATH": filepath.Join(dir, "custom.json")})

--- a/internal/mcp/permissions_test.go
+++ b/internal/mcp/permissions_test.go
@@ -1,10 +1,12 @@
 package mcp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -143,6 +145,56 @@ func TestPermissionStoreRejectsInvalidAutonomyBeforeWriting(t *testing.T) {
 	}
 	if len(grants) != 0 {
 		t.Fatalf("expected no grants after invalid write, got %#v", grants)
+	}
+}
+
+func TestPermissionStoreSerializesConcurrentStoreInstances(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "mcp-permissions.json")
+	const grantCount = 16
+	var wait sync.WaitGroup
+	errs := make(chan error, grantCount)
+
+	for index := 0; index < grantCount; index++ {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			store, err := NewPermissionStore(StoreOptions{
+				FilePath: filePath,
+				Now:      func() time.Time { return time.Date(2026, 6, 3, 9, 30, index, 0, time.UTC) },
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			_, err = store.GrantTool(GrantToolInput{
+				ServerName:     fmt.Sprintf("docs_%02d", index),
+				ServerIdentity: fmt.Sprintf("%032d", index),
+				ToolName:       "lookup",
+				MaxAutonomy:    AutonomyLow,
+			})
+			if err != nil {
+				errs <- err
+			}
+		}(index)
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent grant failed: %v", err)
+		}
+	}
+
+	store, err := NewPermissionStore(StoreOptions{FilePath: filePath})
+	if err != nil {
+		t.Fatalf("NewPermissionStore returned error: %v", err)
+	}
+	grants, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(grants) != grantCount {
+		t.Fatalf("grant count = %d, want %d: %#v", len(grants), grantCount, grants)
 	}
 }
 

--- a/internal/mcp/permissions_test.go
+++ b/internal/mcp/permissions_test.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPermissionStorePersistsIdentityAwareToolGrants(t *testing.T) {
+	store := newTestPermissionStore(t)
+
+	_, err := store.GrantTool(GrantToolInput{
+		ServerName:     "docs",
+		ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ToolName:       "lookup",
+		MaxAutonomy:    AutonomyMedium,
+	})
+	if err != nil {
+		t.Fatalf("GrantTool returned error: %v", err)
+	}
+	if _, err := os.Stat(store.FilePath()); err != nil {
+		t.Fatalf("permission file was not written: %v", err)
+	}
+
+	approved, err := store.IsToolPersistentlyApproved(CheckToolInput{
+		ServerName:        "docs",
+		ServerIdentity:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ToolName:          "lookup",
+		RequestedAutonomy: AutonomyMedium,
+	})
+	if err != nil || !approved {
+		t.Fatalf("approved=%v err=%v", approved, err)
+	}
+	approved, err = store.IsToolPersistentlyApproved(CheckToolInput{
+		ServerName:        "docs",
+		ServerIdentity:    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		ToolName:          "lookup",
+		RequestedAutonomy: AutonomyMedium,
+	})
+	if err != nil || approved {
+		t.Fatalf("wrong identity approved=%v err=%v", approved, err)
+	}
+	approved, err = store.IsToolPersistentlyApproved(CheckToolInput{
+		ServerName:        "docs",
+		ServerIdentity:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ToolName:          "lookup",
+		RequestedAutonomy: AutonomyHigh,
+	})
+	if err != nil || approved {
+		t.Fatalf("high autonomy approved=%v err=%v", approved, err)
+	}
+}
+
+func TestPermissionStoreServerGrantCoversToolsAndRevokesCascade(t *testing.T) {
+	store := newTestPermissionStore(t)
+	if _, err := store.GrantServer(GrantServerInput{ServerName: "docs", ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", MaxAutonomy: AutonomyHigh}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantTool(GrantToolInput{ServerName: "docs", ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ToolName: "lookup", MaxAutonomy: AutonomyLow}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantTool(GrantToolInput{ServerName: "other", ServerIdentity: "cccccccccccccccccccccccccccccccc", ToolName: "search", MaxAutonomy: AutonomyLow}); err != nil {
+		t.Fatal(err)
+	}
+
+	approved, err := store.IsToolPersistentlyApproved(CheckToolInput{
+		ServerName:        "docs",
+		ServerIdentity:    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ToolName:          "write",
+		RequestedAutonomy: AutonomyHigh,
+	})
+	if err != nil || !approved {
+		t.Fatalf("server grant approved=%v err=%v", approved, err)
+	}
+
+	revoked, err := store.RevokeServer("docs")
+	if err != nil {
+		t.Fatalf("RevokeServer returned error: %v", err)
+	}
+	if revoked != 2 {
+		t.Fatalf("revoked = %d, want 2", revoked)
+	}
+	grants, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(grants) != 1 || grants[0].ServerName != "other" || grants[0].ToolName != "search" {
+		t.Fatalf("unexpected grants after revoke: %#v", grants)
+	}
+}
+
+func TestPermissionStoreListsStableOrderAndClears(t *testing.T) {
+	store := newTestPermissionStore(t)
+	if _, err := store.GrantTool(GrantToolInput{ServerName: "zeta", ServerIdentity: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", ToolName: "lookup", MaxAutonomy: AutonomyLow}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantServer(GrantServerInput{ServerName: "alpha", ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", MaxAutonomy: AutonomyMedium}); err != nil {
+		t.Fatal(err)
+	}
+
+	grants, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if got := []PermissionScope{grants[0].Scope, grants[1].Scope}; !reflect.DeepEqual(got, []PermissionScope{ScopeServer, ScopeTool}) {
+		t.Fatalf("grant scopes = %#v", got)
+	}
+	if grants[0].ServerName != "alpha" || grants[1].ServerName != "zeta" {
+		t.Fatalf("grant order = %#v", grants)
+	}
+	cleared, err := store.Clear()
+	if err != nil {
+		t.Fatalf("Clear returned error: %v", err)
+	}
+	if cleared != 2 {
+		t.Fatalf("cleared = %d, want 2", cleared)
+	}
+	grants, err = store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("expected no grants after clear, got %#v", grants)
+	}
+}
+
+func TestPermissionStoreRejectsInvalidAutonomyBeforeWriting(t *testing.T) {
+	store := newTestPermissionStore(t)
+	_, err := store.GrantServer(GrantServerInput{
+		ServerName:     "docs",
+		ServerIdentity: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		MaxAutonomy:    PermissionAutonomy("urgent"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid MCP permission autonomy") {
+		t.Fatalf("expected invalid autonomy error, got %v", err)
+	}
+	grants, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("expected no grants after invalid write, got %#v", grants)
+	}
+}
+
+func TestResolvePermissionPathHonorsOverrideAndConfigHome(t *testing.T) {
+	dir := t.TempDir()
+	override, err := ResolvePermissionPath(map[string]string{"ZERO_MCP_PERMISSIONS_PATH": filepath.Join(dir, "custom.json")})
+	if err != nil {
+		t.Fatalf("ResolvePermissionPath override returned error: %v", err)
+	}
+	if override != filepath.Join(dir, "custom.json") {
+		t.Fatalf("override path = %q", override)
+	}
+	resolved, err := ResolvePermissionPath(map[string]string{"XDG_CONFIG_HOME": filepath.Join(dir, "xdg")})
+	if err != nil {
+		t.Fatalf("ResolvePermissionPath xdg returned error: %v", err)
+	}
+	if resolved != filepath.Join(dir, "xdg", "zero", "mcp-permissions.json") {
+		t.Fatalf("xdg path = %q", resolved)
+	}
+}
+
+func newTestPermissionStore(t *testing.T) *PermissionStore {
+	t.Helper()
+	store, err := NewPermissionStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json"),
+		Now:      func() time.Time { return time.Date(2026, 6, 3, 9, 30, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewPermissionStore returned error: %v", err)
+	}
+	return store
+}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -486,7 +486,7 @@ func parseHooks(raw any) ([]HookExtension, error) {
 }
 
 func ResolvePluginPath(pluginDir string, value string, fieldPath string) (string, error) {
-	if filepath.IsAbs(value) || isWindowsAbs(value) {
+	if filepath.IsAbs(value) || isRootedPath(value) || isWindowsAbs(value) {
 		return "", ManifestError{FieldPath: fieldPath, Message: "must stay inside the plugin directory."}
 	}
 
@@ -696,6 +696,10 @@ func parseHookEvent(raw any, field string) (HookEvent, error) {
 
 func isWindowsAbs(value string) bool {
 	return regexp.MustCompile(`^[A-Za-z]:[\\/]|^\\\\`).MatchString(value)
+}
+
+func isRootedPath(value string) bool {
+	return strings.HasPrefix(value, "/") || strings.HasPrefix(value, `\`)
 }
 
 func resolveCwd(cwd string) (string, error) {

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -494,11 +494,19 @@ func ResolvePluginPath(pluginDir string, value string, fieldPath string) (string
 	if err != nil {
 		return "", err
 	}
+	rootCheck := root
+	if realRoot, evalErr := filepath.EvalSymlinks(root); evalErr == nil {
+		rootCheck = realRoot
+	}
 	resolved, err := filepath.Abs(filepath.Join(root, value))
 	if err != nil {
 		return "", err
 	}
-	relative, err := filepath.Rel(root, resolved)
+	resolvedCheck := resolved
+	if realResolved, evalErr := filepath.EvalSymlinks(resolved); evalErr == nil {
+		resolvedCheck = realResolved
+	}
+	relative, err := filepath.Rel(rootCheck, resolvedCheck)
 	if err != nil {
 		return "", err
 	}
@@ -549,7 +557,7 @@ func toDiagnostic(err error, root Root, rootPath string, pluginDir string, manif
 		}
 	}
 	return Diagnostic{
-		Kind:         DiagnosticSchema,
+		Kind:         DiagnosticIO,
 		Source:       root.Source,
 		Root:         rootPath,
 		PluginPath:   pluginDir,

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -354,10 +354,28 @@ func FormatList(plugins []LoadedPlugin, diagnostics []Diagnostic) string {
 	if len(diagnostics) > 0 {
 		lines = append(lines, "Plugin diagnostics:")
 		for _, diagnostic := range diagnostics {
-			lines = append(lines, fmt.Sprintf("  [%s] %s", diagnostic.Kind, diagnostic.Message))
+			line := fmt.Sprintf("  [%s] %s", diagnostic.Kind, diagnostic.Message)
+			if location := formatDiagnosticLocation(diagnostic); location != "" {
+				line += " [" + location + "]"
+			}
+			lines = append(lines, line)
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func formatDiagnosticLocation(diagnostic Diagnostic) string {
+	parts := []string{}
+	if diagnostic.ManifestPath != "" {
+		parts = append(parts, "manifestPath="+diagnostic.ManifestPath)
+	}
+	if diagnostic.FieldPath != "" {
+		parts = append(parts, "fieldPath="+diagnostic.FieldPath)
+	}
+	if diagnostic.PluginPath != "" {
+		parts = append(parts, "pluginPath="+diagnostic.PluginPath)
+	}
+	return strings.Join(parts, " ")
 }
 
 func parseTools(raw any, allowAutoApproval bool) ([]ToolExtension, error) {
@@ -497,6 +515,11 @@ func ResolvePluginPath(pluginDir string, value string, fieldPath string) (string
 	rootCheck := root
 	if realRoot, evalErr := filepath.EvalSymlinks(root); evalErr == nil {
 		rootCheck = realRoot
+	} else if errors.Is(evalErr, os.ErrNotExist) {
+		rootCheck, err = resolveMissingPathSymlinks(root)
+		if err != nil {
+			return "", err
+		}
 	}
 	resolved, err := filepath.Abs(filepath.Join(root, value))
 	if err != nil {
@@ -505,6 +528,11 @@ func ResolvePluginPath(pluginDir string, value string, fieldPath string) (string
 	resolvedCheck := resolved
 	if realResolved, evalErr := filepath.EvalSymlinks(resolved); evalErr == nil {
 		resolvedCheck = realResolved
+	} else if errors.Is(evalErr, os.ErrNotExist) {
+		resolvedCheck, err = resolveMissingPathSymlinks(resolved)
+		if err != nil {
+			return "", err
+		}
 	}
 	relative, err := filepath.Rel(rootCheck, resolvedCheck)
 	if err != nil {
@@ -514,6 +542,31 @@ func ResolvePluginPath(pluginDir string, value string, fieldPath string) (string
 		return "", ManifestError{FieldPath: fieldPath, Message: "must stay inside the plugin directory."}
 	}
 	return resolved, nil
+}
+
+func resolveMissingPathSymlinks(path string) (string, error) {
+	existing := path
+	missing := []string{}
+	for {
+		if _, err := os.Stat(existing); err == nil {
+			realExisting, err := filepath.EvalSymlinks(existing)
+			if err != nil {
+				return "", err
+			}
+			for index := len(missing) - 1; index >= 0; index-- {
+				realExisting = filepath.Join(realExisting, missing[index])
+			}
+			return realExisting, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			return path, nil
+		}
+		missing = append(missing, filepath.Base(existing))
+		existing = parent
+	}
 }
 
 func mergePlugins(discovered []LoadedPlugin, diagnostics *[]Diagnostic) []LoadedPlugin {

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -1,0 +1,736 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type Source string
+type DiagnosticKind string
+type ToolPermission string
+type HookEvent string
+
+const (
+	SourceUser    Source = "user"
+	SourceProject Source = "project"
+	SourceCustom  Source = "custom"
+)
+
+const (
+	DiagnosticIO        DiagnosticKind = "io"
+	DiagnosticJSON      DiagnosticKind = "json"
+	DiagnosticSchema    DiagnosticKind = "schema"
+	DiagnosticDuplicate DiagnosticKind = "duplicate"
+)
+
+const (
+	PermissionAllow  ToolPermission = "allow"
+	PermissionPrompt ToolPermission = "prompt"
+	PermissionDeny   ToolPermission = "deny"
+)
+
+const (
+	HookBeforeTool   HookEvent = "beforeTool"
+	HookAfterTool    HookEvent = "afterTool"
+	HookSessionStart HookEvent = "sessionStart"
+	HookSessionEnd   HookEvent = "sessionEnd"
+)
+
+type Root struct {
+	Source Source `json:"source"`
+	Path   string `json:"path"`
+}
+
+type Diagnostic struct {
+	Kind         DiagnosticKind `json:"kind"`
+	Message      string         `json:"message"`
+	Source       Source         `json:"source,omitempty"`
+	Root         string         `json:"root,omitempty"`
+	PluginPath   string         `json:"pluginPath,omitempty"`
+	ManifestPath string         `json:"manifestPath,omitempty"`
+	FieldPath    string         `json:"fieldPath,omitempty"`
+	PluginID     string         `json:"pluginId,omitempty"`
+}
+
+type ToolExtension struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Command     string         `json:"command"`
+	Args        []string       `json:"args"`
+	InputSchema map[string]any `json:"inputSchema"`
+	Permission  ToolPermission `json:"permission"`
+}
+
+type PathExtension struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Path        string `json:"path"`
+}
+
+type HookExtension struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Event       HookEvent `json:"event"`
+	Command     string    `json:"command"`
+	Args        []string  `json:"args"`
+}
+
+type LoadedPlugin struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	Version       string          `json:"version"`
+	Description   string          `json:"description,omitempty"`
+	Enabled       bool            `json:"enabled"`
+	Source        Source          `json:"source"`
+	Root          string          `json:"root"`
+	PluginDir     string          `json:"pluginDir"`
+	ManifestPath  string          `json:"manifestPath"`
+	Tools         []ToolExtension `json:"tools"`
+	Prompts       []PathExtension `json:"prompts"`
+	Skills        []PathExtension `json:"skills"`
+	Hooks         []HookExtension `json:"hooks"`
+}
+
+type LoadResult struct {
+	Roots       []Root         `json:"roots"`
+	Plugins     []LoadedPlugin `json:"plugins"`
+	Diagnostics []Diagnostic   `json:"diagnostics"`
+}
+
+type ResolveRootOptions struct {
+	Cwd string
+	Env map[string]string
+}
+
+type LoadOptions struct {
+	Roots                         []Root
+	Cwd                           string
+	Env                           map[string]string
+	AllowManifestToolAutoApproval bool
+}
+
+type ParseManifestOptions struct {
+	Source                        Source
+	Root                          string
+	PluginDir                     string
+	ManifestPath                  string
+	AllowManifestToolAutoApproval bool
+}
+
+type ManifestError struct {
+	FieldPath string
+	Message   string
+}
+
+func (err ManifestError) Error() string {
+	if err.FieldPath == "" {
+		return err.Message
+	}
+	return err.FieldPath + ": " + err.Message
+}
+
+var pluginIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+func ResolveRoots(options ResolveRootOptions) ([]Root, error) {
+	cwd, err := resolveCwd(options.Cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	configHome := strings.TrimSpace(envValue(options.Env, "XDG_CONFIG_HOME"))
+	if configHome == "" {
+		home := strings.TrimSpace(firstNonEmpty(envValue(options.Env, "HOME"), envValue(options.Env, "USERPROFILE")))
+		if home == "" {
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return nil, fmt.Errorf("resolve user home: %w", err)
+			}
+		}
+		configHome = filepath.Join(home, ".config")
+	} else if !filepath.IsAbs(configHome) {
+		configHome = filepath.Join(cwd, configHome)
+	}
+
+	return []Root{
+		{Source: SourceUser, Path: filepath.Join(configHome, "zero", "plugins")},
+		{Source: SourceProject, Path: filepath.Join(cwd, ".zero", "plugins")},
+	}, nil
+}
+
+func Load(options LoadOptions) (LoadResult, error) {
+	roots := options.Roots
+	if len(roots) == 0 {
+		resolvedRoots, err := ResolveRoots(ResolveRootOptions{Cwd: options.Cwd, Env: options.Env})
+		if err != nil {
+			return LoadResult{}, err
+		}
+		roots = resolvedRoots
+	}
+
+	diagnostics := []Diagnostic{}
+	discovered := []LoadedPlugin{}
+	for _, root := range roots {
+		rootPath, err := filepath.Abs(root.Path)
+		if err != nil {
+			diagnostics = append(diagnostics, Diagnostic{
+				Kind:    DiagnosticIO,
+				Source:  root.Source,
+				Root:    root.Path,
+				Message: err.Error(),
+			})
+			continue
+		}
+
+		entries, err := os.ReadDir(rootPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			diagnostics = append(diagnostics, Diagnostic{
+				Kind:    DiagnosticIO,
+				Source:  root.Source,
+				Root:    rootPath,
+				Message: err.Error(),
+			})
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			pluginDir := filepath.Join(rootPath, entry.Name())
+			manifestPath := filepath.Join(pluginDir, "plugin.json")
+			data, err := os.ReadFile(manifestPath)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				diagnostics = append(diagnostics, toDiagnostic(err, root, rootPath, pluginDir, manifestPath))
+				continue
+			}
+
+			var manifest any
+			if err := json.Unmarshal(data, &manifest); err != nil {
+				diagnostics = append(diagnostics, Diagnostic{
+					Kind:         DiagnosticJSON,
+					Source:       root.Source,
+					Root:         rootPath,
+					PluginPath:   pluginDir,
+					ManifestPath: manifestPath,
+					Message:      err.Error(),
+				})
+				continue
+			}
+
+			plugin, err := ParseManifest(manifest, ParseManifestOptions{
+				Source:                        root.Source,
+				Root:                          rootPath,
+				PluginDir:                     pluginDir,
+				ManifestPath:                  manifestPath,
+				AllowManifestToolAutoApproval: options.AllowManifestToolAutoApproval,
+			})
+			if err != nil {
+				diagnostics = append(diagnostics, toDiagnostic(err, root, rootPath, pluginDir, manifestPath))
+				continue
+			}
+			discovered = append(discovered, plugin)
+		}
+	}
+
+	return LoadResult{
+		Roots:       roots,
+		Plugins:     mergePlugins(discovered, &diagnostics),
+		Diagnostics: diagnostics,
+	}, nil
+}
+
+func ParseManifest(raw any, options ParseManifestOptions) (LoadedPlugin, error) {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return LoadedPlugin{}, ManifestError{Message: "Expected plugin manifest to be a JSON object."}
+	}
+
+	schemaVersion, err := requiredInt(obj, "schemaVersion")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	if schemaVersion != 1 {
+		return LoadedPlugin{}, ManifestError{FieldPath: "schemaVersion", Message: "Expected schemaVersion 1."}
+	}
+
+	id, err := requiredID(obj, "id")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	name, err := requiredString(obj, "name")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	version, err := requiredString(obj, "version")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	description, err := optionalString(obj, "description")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	enabled, err := optionalBool(obj, "enabled", true)
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+
+	pluginDir, err := filepath.Abs(options.PluginDir)
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	root, err := filepath.Abs(options.Root)
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	manifestPath, err := filepath.Abs(options.ManifestPath)
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+
+	tools, err := parseTools(obj["tools"], options.AllowManifestToolAutoApproval)
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	prompts, err := parsePathExtensions(obj["prompts"], pluginDir, "prompts")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	skills, err := parsePathExtensions(obj["skills"], pluginDir, "skills")
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+	hooks, err := parseHooks(obj["hooks"])
+	if err != nil {
+		return LoadedPlugin{}, err
+	}
+
+	return LoadedPlugin{
+		SchemaVersion: 1,
+		ID:            id,
+		Name:          name,
+		Version:       version,
+		Description:   description,
+		Enabled:       enabled,
+		Source:        options.Source,
+		Root:          root,
+		PluginDir:     pluginDir,
+		ManifestPath:  manifestPath,
+		Tools:         tools,
+		Prompts:       prompts,
+		Skills:        skills,
+		Hooks:         hooks,
+	}, nil
+}
+
+func FormatList(plugins []LoadedPlugin, diagnostics []Diagnostic) string {
+	lines := []string{}
+	if len(plugins) == 0 {
+		lines = append(lines, "No local Zero plugins loaded.")
+	} else {
+		lines = append(lines, "Zero Plugins:")
+		for _, plugin := range plugins {
+			counts := fmt.Sprintf("%d tools, %d prompts, %d skills, %d hooks", len(plugin.Tools), len(plugin.Prompts), len(plugin.Skills), len(plugin.Hooks))
+			state := "enabled"
+			if !plugin.Enabled {
+				state = "disabled"
+			}
+			lines = append(lines, fmt.Sprintf("  %s@%s %s [%s] %s - %s", plugin.ID, plugin.Version, plugin.Name, plugin.Source, state, counts))
+		}
+	}
+
+	if len(diagnostics) > 0 {
+		lines = append(lines, "Plugin diagnostics:")
+		for _, diagnostic := range diagnostics {
+			lines = append(lines, fmt.Sprintf("  [%s] %s", diagnostic.Kind, diagnostic.Message))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func parseTools(raw any, allowAutoApproval bool) ([]ToolExtension, error) {
+	items, err := optionalArray(raw, "tools")
+	if err != nil {
+		return nil, err
+	}
+	tools := make([]ToolExtension, 0, len(items))
+	for index, item := range items {
+		field := fmt.Sprintf("tools.%d", index)
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, ManifestError{FieldPath: field, Message: "Expected tool extension to be an object."}
+		}
+		name, err := requiredID(obj, field+".name")
+		if err != nil {
+			return nil, err
+		}
+		description, err := optionalString(obj, field+".description")
+		if err != nil {
+			return nil, err
+		}
+		command, err := requiredString(obj, field+".command")
+		if err != nil {
+			return nil, err
+		}
+		args, err := optionalStringArray(obj["args"], field+".args")
+		if err != nil {
+			return nil, err
+		}
+		inputSchema, err := optionalObject(obj["inputSchema"], field+".inputSchema")
+		if err != nil {
+			return nil, err
+		}
+		if inputSchema == nil {
+			inputSchema = map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"additionalProperties": true,
+			}
+		}
+		permission, err := parsePermission(obj["permission"], allowAutoApproval, field+".permission")
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, ToolExtension{
+			Name:        name,
+			Description: description,
+			Command:     command,
+			Args:        args,
+			InputSchema: inputSchema,
+			Permission:  permission,
+		})
+	}
+	return tools, nil
+}
+
+func parsePathExtensions(raw any, pluginDir string, label string) ([]PathExtension, error) {
+	items, err := optionalArray(raw, label)
+	if err != nil {
+		return nil, err
+	}
+	extensions := make([]PathExtension, 0, len(items))
+	for index, item := range items {
+		field := fmt.Sprintf("%s.%d", label, index)
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, ManifestError{FieldPath: field, Message: "Expected path extension to be an object."}
+		}
+		name, err := requiredID(obj, field+".name")
+		if err != nil {
+			return nil, err
+		}
+		description, err := optionalString(obj, field+".description")
+		if err != nil {
+			return nil, err
+		}
+		path, err := requiredString(obj, field+".path")
+		if err != nil {
+			return nil, err
+		}
+		resolved, err := ResolvePluginPath(pluginDir, path, fmt.Sprintf("%s.%s.path", label, name))
+		if err != nil {
+			return nil, err
+		}
+		extensions = append(extensions, PathExtension{Name: name, Description: description, Path: resolved})
+	}
+	return extensions, nil
+}
+
+func parseHooks(raw any) ([]HookExtension, error) {
+	items, err := optionalArray(raw, "hooks")
+	if err != nil {
+		return nil, err
+	}
+	hooks := make([]HookExtension, 0, len(items))
+	for index, item := range items {
+		field := fmt.Sprintf("hooks.%d", index)
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return nil, ManifestError{FieldPath: field, Message: "Expected hook extension to be an object."}
+		}
+		name, err := requiredID(obj, field+".name")
+		if err != nil {
+			return nil, err
+		}
+		description, err := optionalString(obj, field+".description")
+		if err != nil {
+			return nil, err
+		}
+		event, err := parseHookEvent(obj["event"], field+".event")
+		if err != nil {
+			return nil, err
+		}
+		command, err := requiredString(obj, field+".command")
+		if err != nil {
+			return nil, err
+		}
+		args, err := optionalStringArray(obj["args"], field+".args")
+		if err != nil {
+			return nil, err
+		}
+		hooks = append(hooks, HookExtension{Name: name, Description: description, Event: event, Command: command, Args: args})
+	}
+	return hooks, nil
+}
+
+func ResolvePluginPath(pluginDir string, value string, fieldPath string) (string, error) {
+	if filepath.IsAbs(value) || isWindowsAbs(value) {
+		return "", ManifestError{FieldPath: fieldPath, Message: "must stay inside the plugin directory."}
+	}
+
+	root, err := filepath.Abs(pluginDir)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.Abs(filepath.Join(root, value))
+	if err != nil {
+		return "", err
+	}
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return "", err
+	}
+	if relative == "." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || relative == ".." || strings.Contains(relative, `..\`) {
+		return "", ManifestError{FieldPath: fieldPath, Message: "must stay inside the plugin directory."}
+	}
+	return resolved, nil
+}
+
+func mergePlugins(discovered []LoadedPlugin, diagnostics *[]Diagnostic) []LoadedPlugin {
+	byID := map[string]LoadedPlugin{}
+	for _, plugin := range discovered {
+		if previous, ok := byID[plugin.ID]; ok {
+			*diagnostics = append(*diagnostics, Diagnostic{
+				Kind:         DiagnosticDuplicate,
+				PluginID:     plugin.ID,
+				Source:       plugin.Source,
+				Root:         plugin.Root,
+				PluginPath:   plugin.PluginDir,
+				ManifestPath: plugin.ManifestPath,
+				Message:      fmt.Sprintf("Plugin %q from %s overrides %s plugin at %s.", plugin.ID, plugin.Source, previous.Source, previous.PluginDir),
+			})
+		}
+		byID[plugin.ID] = plugin
+	}
+
+	plugins := make([]LoadedPlugin, 0, len(byID))
+	for _, plugin := range byID {
+		plugins = append(plugins, plugin)
+	}
+	sort.Slice(plugins, func(left int, right int) bool {
+		return plugins[left].ID < plugins[right].ID
+	})
+	return plugins
+}
+
+func toDiagnostic(err error, root Root, rootPath string, pluginDir string, manifestPath string) Diagnostic {
+	var manifestErr ManifestError
+	if errors.As(err, &manifestErr) {
+		return Diagnostic{
+			Kind:         DiagnosticSchema,
+			Source:       root.Source,
+			Root:         rootPath,
+			PluginPath:   pluginDir,
+			ManifestPath: manifestPath,
+			FieldPath:    manifestErr.FieldPath,
+			Message:      manifestErr.Message,
+		}
+	}
+	return Diagnostic{
+		Kind:         DiagnosticSchema,
+		Source:       root.Source,
+		Root:         rootPath,
+		PluginPath:   pluginDir,
+		ManifestPath: manifestPath,
+		Message:      err.Error(),
+	}
+}
+
+func requiredString(obj map[string]any, field string) (string, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok {
+		return "", ManifestError{FieldPath: field, Message: "Expected a non-empty string."}
+	}
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", ManifestError{FieldPath: field, Message: "Expected a non-empty string."}
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func optionalString(obj map[string]any, field string) (string, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", ManifestError{FieldPath: field, Message: "Expected a non-empty string."}
+	}
+	return strings.TrimSpace(text), nil
+}
+
+func requiredID(obj map[string]any, field string) (string, error) {
+	value, err := requiredString(obj, field)
+	if err != nil {
+		return "", err
+	}
+	if !pluginIDPattern.MatchString(value) {
+		return "", ManifestError{FieldPath: field, Message: "Use letters, numbers, dots, dashes, or underscores."}
+	}
+	return value, nil
+}
+
+func requiredInt(obj map[string]any, field string) (int, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok {
+		return 0, ManifestError{FieldPath: field, Message: "Expected a number."}
+	}
+	number, ok := value.(float64)
+	if !ok || number != float64(int(number)) {
+		return 0, ManifestError{FieldPath: field, Message: "Expected a number."}
+	}
+	return int(number), nil
+}
+
+func optionalBool(obj map[string]any, field string, fallback bool) (bool, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok || value == nil {
+		return fallback, nil
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return false, ManifestError{FieldPath: field, Message: "Expected a boolean."}
+	}
+	return boolValue, nil
+}
+
+func optionalArray(raw any, field string) ([]any, error) {
+	if raw == nil {
+		return []any{}, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, ManifestError{FieldPath: field, Message: "Expected an array."}
+	}
+	return items, nil
+}
+
+func optionalObject(raw any, field string) (map[string]any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, ManifestError{FieldPath: field, Message: "Expected an object."}
+	}
+	return obj, nil
+}
+
+func optionalStringArray(raw any, field string) ([]string, error) {
+	if raw == nil {
+		return []string{}, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, ManifestError{FieldPath: field, Message: "Expected an array."}
+	}
+	values := make([]string, 0, len(items))
+	for index, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			return nil, ManifestError{FieldPath: fmt.Sprintf("%s.%d", field, index), Message: "Expected a string."}
+		}
+		values = append(values, text)
+	}
+	return values, nil
+}
+
+func parsePermission(raw any, allowAutoApproval bool, field string) (ToolPermission, error) {
+	if raw == nil {
+		return PermissionPrompt, nil
+	}
+	text, ok := raw.(string)
+	if !ok {
+		return "", ManifestError{FieldPath: field, Message: "Expected allow, prompt, or deny."}
+	}
+	permission := ToolPermission(strings.TrimSpace(text))
+	switch permission {
+	case PermissionAllow:
+		if !allowAutoApproval {
+			return PermissionPrompt, nil
+		}
+		return PermissionAllow, nil
+	case PermissionPrompt, PermissionDeny:
+		return permission, nil
+	default:
+		return "", ManifestError{FieldPath: field, Message: "Expected allow, prompt, or deny."}
+	}
+}
+
+func parseHookEvent(raw any, field string) (HookEvent, error) {
+	text, ok := raw.(string)
+	if !ok || strings.TrimSpace(text) == "" {
+		return "", ManifestError{FieldPath: field, Message: "Expected a hook event."}
+	}
+	event := HookEvent(strings.TrimSpace(text))
+	switch event {
+	case HookBeforeTool, HookAfterTool, HookSessionStart, HookSessionEnd:
+		return event, nil
+	default:
+		return "", ManifestError{FieldPath: field, Message: "Expected beforeTool, afterTool, sessionStart, or sessionEnd."}
+	}
+}
+
+func isWindowsAbs(value string) bool {
+	return regexp.MustCompile(`^[A-Za-z]:[\\/]|^\\\\`).MatchString(value)
+}
+
+func resolveCwd(cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		return os.Getwd()
+	}
+	if filepath.IsAbs(cwd) {
+		return filepath.Clean(cwd), nil
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func lastPathSegment(field string) string {
+	if index := strings.LastIndex(field, "."); index >= 0 {
+		return field[index+1:]
+	}
+	return field
+}

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -1,0 +1,224 @@
+package plugins
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseManifestNormalizesExtensionsAndPaths(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "plugins")
+	pluginDir := filepath.Join(root, "zero-demo")
+	manifestPath := filepath.Join(pluginDir, "plugin.json")
+
+	plugin, err := ParseManifest(map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.demo",
+		"name":          "Zero Demo",
+		"version":       "0.1.0",
+		"description":   "Demo plugin",
+		"tools": []any{map[string]any{
+			"name":        "lookup",
+			"description": "Lookup docs",
+			"command":     "node",
+			"args":        []any{"tools/lookup.mjs"},
+			"inputSchema": map[string]any{"type": "object"},
+			"permission":  "prompt",
+		}},
+		"prompts": []any{map[string]any{"name": "review", "path": "prompts/review.md"}},
+		"skills":  []any{map[string]any{"name": "ts-review", "path": "skills/ts-review/SKILL.md"}},
+		"hooks": []any{map[string]any{
+			"name":    "pre-tool",
+			"event":   "beforeTool",
+			"command": "node",
+			"args":    []any{"hooks/pre-tool.mjs"},
+		}},
+	}, ParseManifestOptions{
+		Source:       SourceProject,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: manifestPath,
+	})
+	if err != nil {
+		t.Fatalf("ParseManifest returned error: %v", err)
+	}
+
+	if plugin.ID != "zero.demo" || plugin.Name != "Zero Demo" || !plugin.Enabled {
+		t.Fatalf("unexpected plugin metadata: %#v", plugin)
+	}
+	if plugin.Tools[0].Permission != PermissionPrompt || plugin.Tools[0].Args[0] != "tools/lookup.mjs" {
+		t.Fatalf("unexpected tool normalization: %#v", plugin.Tools[0])
+	}
+	if plugin.Prompts[0].Path != filepath.Join(pluginDir, "prompts", "review.md") {
+		t.Fatalf("prompt path = %q", plugin.Prompts[0].Path)
+	}
+	if plugin.Skills[0].Path != filepath.Join(pluginDir, "skills", "ts-review", "SKILL.md") {
+		t.Fatalf("skill path = %q", plugin.Skills[0].Path)
+	}
+	if plugin.Hooks[0].Event != HookBeforeTool || plugin.Hooks[0].Args[0] != "hooks/pre-tool.mjs" {
+		t.Fatalf("unexpected hook normalization: %#v", plugin.Hooks[0])
+	}
+}
+
+func TestParseManifestClampsAutoApprovalByDefault(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "zero-demo")
+	manifest := map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.demo",
+		"name":          "Zero Demo",
+		"version":       "0.1.0",
+		"tools": []any{map[string]any{
+			"name":       "lookup",
+			"command":    "node",
+			"permission": "allow",
+		}},
+	}
+	options := ParseManifestOptions{
+		Source:       SourceProject,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: filepath.Join(pluginDir, "plugin.json"),
+	}
+
+	plugin, err := ParseManifest(manifest, options)
+	if err != nil {
+		t.Fatalf("ParseManifest returned error: %v", err)
+	}
+	if got := plugin.Tools[0].Permission; got != PermissionPrompt {
+		t.Fatalf("permission = %s, want prompt", got)
+	}
+
+	options.AllowManifestToolAutoApproval = true
+	plugin, err = ParseManifest(manifest, options)
+	if err != nil {
+		t.Fatalf("ParseManifest returned error: %v", err)
+	}
+	if got := plugin.Tools[0].Permission; got != PermissionAllow {
+		t.Fatalf("permission = %s, want allow", got)
+	}
+}
+
+func TestParseManifestRejectsUnsafePluginLocalPaths(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "bad")
+	options := ParseManifestOptions{
+		Source:       SourceProject,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: filepath.Join(pluginDir, "plugin.json"),
+	}
+
+	for _, path := range []string{"../outside.md", "/tmp/escape.md", `C:\Windows\escape.md`} {
+		t.Run(path, func(t *testing.T) {
+			_, err := ParseManifest(map[string]any{
+				"schemaVersion": float64(1),
+				"id":            "zero.bad",
+				"name":          "Bad",
+				"version":       "0.1.0",
+				"prompts":       []any{map[string]any{"name": "escape", "path": path}},
+			}, options)
+			if err == nil || !strings.Contains(err.Error(), "must stay inside the plugin directory") {
+				t.Fatalf("expected unsafe path error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadPluginsDiscoversDiagnosticsAndProjectPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	userRoot := filepath.Join(dir, "user-plugins")
+	projectRoot := filepath.Join(dir, "project-plugins")
+	writePluginManifest(t, filepath.Join(userRoot, "demo"), map[string]any{
+		"schemaVersion": 1,
+		"id":            "zero.demo",
+		"name":          "User Demo",
+		"version":       "0.1.0",
+	})
+	writePluginManifest(t, filepath.Join(projectRoot, "demo"), map[string]any{
+		"schemaVersion": 1,
+		"id":            "zero.demo",
+		"name":          "Project Demo",
+		"version":       "0.2.0",
+		"enabled":       false,
+	})
+	writePluginManifest(t, filepath.Join(projectRoot, "docs"), map[string]any{
+		"schemaVersion": 1,
+		"id":            "zero.docs",
+		"name":          "Docs",
+		"version":       "1.0.0",
+	})
+	if err := os.MkdirAll(filepath.Join(projectRoot, "bad"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectRoot, "bad", "plugin.json"), []byte("{ invalid json }"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Load(LoadOptions{
+		Roots: []Root{
+			{Source: SourceUser, Path: userRoot},
+			{Source: SourceProject, Path: projectRoot},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if got := []string{result.Plugins[0].ID + ":" + result.Plugins[0].Name, result.Plugins[1].ID + ":" + result.Plugins[1].Name}; got[0] != "zero.demo:Project Demo" || got[1] != "zero.docs:Docs" {
+		t.Fatalf("unexpected plugins: %#v", result.Plugins)
+	}
+	if result.Plugins[0].Enabled {
+		t.Fatalf("project plugin should remain disabled")
+	}
+	if !hasPluginDiagnostic(result.Diagnostics, DiagnosticDuplicate, "zero.demo") {
+		t.Fatalf("missing duplicate diagnostic: %#v", result.Diagnostics)
+	}
+	if !hasPluginDiagnostic(result.Diagnostics, DiagnosticJSON, "") {
+		t.Fatalf("missing json diagnostic: %#v", result.Diagnostics)
+	}
+}
+
+func TestResolveRootsUsesConfigHomeAndProjectRoot(t *testing.T) {
+	dir := t.TempDir()
+	roots, err := ResolveRoots(ResolveRootOptions{
+		Cwd: dir,
+		Env: map[string]string{"XDG_CONFIG_HOME": filepath.Join(dir, "xdg")},
+	})
+	if err != nil {
+		t.Fatalf("ResolveRoots returned error: %v", err)
+	}
+	if roots[0].Path != filepath.Join(dir, "xdg", "zero", "plugins") {
+		t.Fatalf("user root = %q", roots[0].Path)
+	}
+	if roots[1].Path != filepath.Join(dir, ".zero", "plugins") {
+		t.Fatalf("project root = %q", roots[1].Path)
+	}
+}
+
+func writePluginManifest(t *testing.T, pluginDir string, manifest map[string]any) {
+	t.Helper()
+	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasPluginDiagnostic(diagnostics []Diagnostic, kind DiagnosticKind, pluginID string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Kind != kind {
+			continue
+		}
+		if pluginID == "" || diagnostic.PluginID == pluginID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -124,6 +125,54 @@ func TestParseManifestRejectsUnsafePluginLocalPaths(t *testing.T) {
 				t.Fatalf("expected unsafe path error, got %v", err)
 			}
 		})
+	}
+}
+
+func TestParseManifestRejectsSymlinkEscapes(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "bad")
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "escape.md"), []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(pluginDir, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable on this platform: %v", err)
+	}
+
+	_, err := ParseManifest(map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.bad",
+		"name":          "Bad",
+		"version":       "0.1.0",
+		"prompts":       []any{map[string]any{"name": "escape", "path": filepath.Join("link", "escape.md")}},
+	}, ParseManifestOptions{
+		Source:       SourceProject,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: filepath.Join(pluginDir, "plugin.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "must stay inside the plugin directory") {
+		t.Fatalf("expected symlink escape error, got %v", err)
+	}
+}
+
+func TestToDiagnosticClassifiesManifestAndIOErrors(t *testing.T) {
+	root := Root{Source: SourceProject}
+	schemaDiagnostic := toDiagnostic(ManifestError{FieldPath: "prompts.0.path", Message: "bad path"}, root, "/plugins", "/plugins/bad", "/plugins/bad/plugin.json")
+	if schemaDiagnostic.Kind != DiagnosticSchema || schemaDiagnostic.FieldPath != "prompts.0.path" {
+		t.Fatalf("manifest error diagnostic = %#v", schemaDiagnostic)
+	}
+
+	ioDiagnostic := toDiagnostic(errors.New("read failed"), root, "/plugins", "/plugins/bad", "/plugins/bad/plugin.json")
+	if ioDiagnostic.Kind != DiagnosticIO || ioDiagnostic.Message != "read failed" {
+		t.Fatalf("io error diagnostic = %#v", ioDiagnostic)
 	}
 }
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -163,6 +163,52 @@ func TestParseManifestRejectsSymlinkEscapes(t *testing.T) {
 	}
 }
 
+func TestParseManifestRejectsSymlinkEscapesWithMissingLeaf(t *testing.T) {
+	root := t.TempDir()
+	pluginDir := filepath.Join(root, "bad")
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(pluginDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(pluginDir, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable on this platform: %v", err)
+	}
+
+	_, err := ParseManifest(map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.bad",
+		"name":          "Bad",
+		"version":       "0.1.0",
+		"prompts":       []any{map[string]any{"name": "escape", "path": filepath.Join("link", "missing.md")}},
+	}, ParseManifestOptions{
+		Source:       SourceProject,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: filepath.Join(pluginDir, "plugin.json"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "must stay inside the plugin directory") {
+		t.Fatalf("expected missing-leaf symlink escape error, got %v", err)
+	}
+}
+
+func TestFormatListIncludesDiagnosticLocations(t *testing.T) {
+	output := FormatList(nil, []Diagnostic{{
+		Kind:         DiagnosticSchema,
+		Message:      "bad prompt path",
+		ManifestPath: "/plugins/bad/plugin.json",
+		FieldPath:    "prompts.escape.path",
+	}})
+	for _, want := range []string{"[schema] bad prompt path", "manifestPath=/plugins/bad/plugin.json", "fieldPath=prompts.escape.path"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("diagnostic output missing %q: %s", want, output)
+		}
+	}
+}
+
 func TestToDiagnosticClassifiesManifestAndIOErrors(t *testing.T) {
 	root := Root{Source: SourceProject}
 	schemaDiagnostic := toDiagnostic(ManifestError{FieldPath: "prompts.0.path", Message: "bad path"}, root, "/plugins", "/plugins/bad", "/plugins/bad/plugin.json")

--- a/src/zero-plugins/manifest.ts
+++ b/src/zero-plugins/manifest.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, relative, resolve, win32 } from 'path';
+import { existsSync, realpathSync } from 'fs';
+import { basename, dirname, isAbsolute, relative, resolve, win32 } from 'path';
 import { z } from 'zod';
 import type {
   ZeroLoadedPlugin,
@@ -121,12 +122,46 @@ function resolvePluginPath(pluginDir: string, value: string, fieldPath: string):
     throw new Error(`${fieldPath} must stay inside the plugin directory.`);
   }
 
+  const pluginRoot = resolve(pluginDir);
+  const pluginRootCheck = resolveSymlinkAwarePath(pluginRoot);
   const resolved = resolve(pluginDir, value);
-  const pathWithinPlugin = relative(pluginDir, resolved);
+  const resolvedCheck = resolveSymlinkAwarePath(resolved);
+  const pathWithinPlugin = relative(pluginRootCheck, resolvedCheck);
   if (pathWithinPlugin === '' || pathWithinPlugin.startsWith('..') || pathWithinPlugin.includes('..\\')) {
     throw new Error(`${fieldPath} must stay inside the plugin directory.`);
   }
   return resolved;
+}
+
+function resolveSymlinkAwarePath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch (error) {
+    if (!isENOENT(error)) {
+      return path;
+    }
+  }
+
+  const missing: string[] = [];
+  let existing = path;
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) {
+      return path;
+    }
+    missing.unshift(basename(existing));
+    existing = parent;
+  }
+
+  try {
+    return resolve(realpathSync(existing), ...missing);
+  } catch {
+    return path;
+  }
+}
+
+function isENOENT(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
 function normalizePluginToolPermission(

--- a/src/zero-plugins/manifest.ts
+++ b/src/zero-plugins/manifest.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync } from 'fs';
-import { basename, dirname, isAbsolute, relative, resolve, win32 } from 'path';
+import { basename, dirname, isAbsolute, relative, resolve, sep, win32 } from 'path';
 import { z } from 'zod';
 import type {
   ZeroLoadedPlugin,
@@ -127,7 +127,15 @@ function resolvePluginPath(pluginDir: string, value: string, fieldPath: string):
   const resolved = resolve(pluginDir, value);
   const resolvedCheck = resolveSymlinkAwarePath(resolved);
   const pathWithinPlugin = relative(pluginRootCheck, resolvedCheck);
-  if (pathWithinPlugin === '' || pathWithinPlugin.startsWith('..') || pathWithinPlugin.includes('..\\')) {
+  const rootBoundary = pluginRootCheck.endsWith(sep) ? pluginRootCheck : `${pluginRootCheck}${sep}`;
+  if (
+    pathWithinPlugin === '' ||
+    isAbsolute(pathWithinPlugin) ||
+    win32.isAbsolute(pathWithinPlugin) ||
+    pathWithinPlugin.startsWith('..') ||
+    pathWithinPlugin.includes('..\\') ||
+    (resolvedCheck !== pluginRootCheck && !resolvedCheck.startsWith(rootBoundary))
+  ) {
     throw new Error(`${fieldPath} must stay inside the plugin directory.`);
   }
   return resolved;
@@ -138,7 +146,7 @@ function resolveSymlinkAwarePath(path: string): string {
     return realpathSync(path);
   } catch (error) {
     if (!isENOENT(error)) {
-      return path;
+      throw error;
     }
   }
 
@@ -155,7 +163,10 @@ function resolveSymlinkAwarePath(path: string): string {
 
   try {
     return resolve(realpathSync(existing), ...missing);
-  } catch {
+  } catch (error) {
+    if (!isENOENT(error)) {
+      throw error;
+    }
     return path;
   }
 }

--- a/tests/zero-plugins.test.ts
+++ b/tests/zero-plugins.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -153,6 +153,32 @@ describe('Zero plugin manifest validation', () => {
         prompts: [{ name: 'escape', path }],
       }, options)).toThrow('must stay inside the plugin directory');
     }
+  });
+
+  it('rejects symlink-parent escapes with a missing leaf', async () => {
+    const dir = await makeTempDir();
+    const pluginDir = join(dir, 'plugins', 'bad');
+    const outside = join(dir, 'outside');
+    await mkdir(pluginDir, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    try {
+      await symlink(outside, join(pluginDir, 'link'), 'dir');
+    } catch {
+      return;
+    }
+
+    expect(() => parseZeroPluginManifest({
+      schemaVersion: 1,
+      id: 'zero.bad',
+      name: 'Bad',
+      version: '0.1.0',
+      prompts: [{ name: 'escape', path: join('link', 'missing.md') }],
+    }, {
+      manifestPath: join(pluginDir, 'plugin.json'),
+      pluginDir,
+      root: join(dir, 'plugins'),
+      source: 'project',
+    })).toThrow('must stay inside the plugin directory');
   });
 });
 

--- a/tests/zero-plugins.test.ts
+++ b/tests/zero-plugins.test.ts
@@ -177,25 +177,6 @@ describe('Zero plugin manifest validation', () => {
     })).toThrow('must stay inside the plugin directory');
   });
 
-  it('fails closed when plugin-local realpath resolution fails unexpectedly', async () => {
-    const dir = await makeTempDir();
-    const pluginDir = join(dir, 'plugins', 'bad');
-    await mkdir(pluginDir, { recursive: true });
-    await writeFile(join(pluginDir, 'file.md'), 'not a directory', 'utf-8');
-
-    expect(() => parseZeroPluginManifest({
-      schemaVersion: 1,
-      id: 'zero.bad',
-      name: 'Bad',
-      version: '0.1.0',
-      prompts: [{ name: 'escape', path: join('file.md', 'missing.md') }],
-    }, {
-      manifestPath: join(pluginDir, 'plugin.json'),
-      pluginDir,
-      root: join(dir, 'plugins'),
-      source: 'project',
-    })).toThrow();
-  });
 });
 
 describe('Zero local plugin loader', () => {

--- a/tests/zero-plugins.test.ts
+++ b/tests/zero-plugins.test.ts
@@ -161,11 +161,7 @@ describe('Zero plugin manifest validation', () => {
     const outside = join(dir, 'outside');
     await mkdir(pluginDir, { recursive: true });
     await mkdir(outside, { recursive: true });
-    try {
-      await symlink(outside, join(pluginDir, 'link'), 'dir');
-    } catch {
-      return;
-    }
+    await symlink(outside, join(pluginDir, 'link'), process.platform === 'win32' ? 'junction' : 'dir');
 
     expect(() => parseZeroPluginManifest({
       schemaVersion: 1,
@@ -179,6 +175,26 @@ describe('Zero plugin manifest validation', () => {
       root: join(dir, 'plugins'),
       source: 'project',
     })).toThrow('must stay inside the plugin directory');
+  });
+
+  it('fails closed when plugin-local realpath resolution fails unexpectedly', async () => {
+    const dir = await makeTempDir();
+    const pluginDir = join(dir, 'plugins', 'bad');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, 'file.md'), 'not a directory', 'utf-8');
+
+    expect(() => parseZeroPluginManifest({
+      schemaVersion: 1,
+      id: 'zero.bad',
+      name: 'Bad',
+      version: '0.1.0',
+      prompts: [{ name: 'escape', path: join('file.md', 'missing.md') }],
+    }, {
+      manifestPath: join(pluginDir, 'plugin.json'),
+      pluginDir,
+      root: join(dir, 'plugins'),
+      source: 'project',
+    })).toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

This PR adds the next Go-native M4 extension backend slice for Zero:

- adds a local plugin manifest backend with plugin root resolution, manifest parsing, path escape protection, diagnostics, duplicate precedence, and manifest permission clamping so plugin-declared `allow` stays prompt-gated unless explicit auto-approval is enabled
- adds hook backend support for layered user/project hook config, matcher selection, config-store updates, redacted list formatting, and append-only JSONL hook audit events
- adds MCP permission grant storage for server/tool scopes, identity-aware approval checks, autonomy ceilings, revoke/clear operations, stable list ordering, and first-run path resolution
- wires the Go CLI commands for `zero plugins list`, `zero hooks list`, and `zero mcp permissions list|revoke|clear`
- adds focused Go regression coverage for plugin manifests, hooks, MCP permissions, and CLI behavior

## Validation

- `go test -count=1 ./...`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `npx --yes bun run build:go`
- `npx --yes bun run smoke:go`
- direct CLI smoke: `./zero --help`, `./zero plugins list --json`, `./zero hooks list`, `zero mcp permissions list --json` with an isolated permissions path
- `git diff --check origin/main..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin discovery/loading: symlink-aware safe-path checks, deduplication, diagnostics, human/JSON output
  * Hooks: layered user/project configs, persistent config store, enable/disable semantics, selection/filtering, formatted listings, JSONL audit logging, secret redaction
  * MCP permissions: persistent, concurrency-safe grants with list/revoke/clear (clear requires --confirm; supports JSON); platform-safe file locking

* **CLI**
  * New top-level commands for plugins, hooks, and mcp with help text and non‑TUI behavior

* **Tests**
  * Expanded coverage across plugins, hooks, MCP permissions, CLI, JSON output, redaction, and concurrency

* **Chores**
  * CI/tooling config tweak (review workflow flag)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->