### PR TITLE
[codex] add Go MCP stdio tool bridge

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -203,7 +203,7 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 	if err != nil {
 		return writeAppError(stderr, err.Error(), 1)
 	}
-	defer mcpRuntime.Close()
+	defer closeMCPRuntime(stderr, mcpRuntime)
 	permissionMode := agent.PermissionModeAuto
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:          workspaceRoot,
@@ -233,6 +233,15 @@ func newCoreRegistry(workspaceRoot string) *tools.Registry {
 		registry.Register(tool)
 	}
 	return registry
+}
+
+func closeMCPRuntime(stderr io.Writer, runtime mcpToolRuntime) {
+	if runtime == nil {
+		return
+	}
+	if err := runtime.Close(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "[zero] mcp_close_error: %s\n", err)
+	}
 }
 
 func writeAppError(stderr io.Writer, message string, exitCode int) int {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -22,16 +22,28 @@ import (
 var version = "dev"
 
 type appDeps struct {
-	getwd           func() (string, error)
-	stdin           io.Reader
-	resolveConfig   func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
-	newProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
-	newSessionStore func() *sessions.Store
-	loadPlugins     func(plugins.LoadOptions) (plugins.LoadResult, error)
-	loadHooks       func(hooks.LoadOptions) (hooks.LoadResult, error)
-	newMCPStore     func() (*mcp.PermissionStore, error)
-	runTUI          func(context.Context, tui.Options) int
-	now             func() time.Time
+	getwd            func() (string, error)
+	stdin            io.Reader
+	resolveConfig    func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
+	resolveMCPConfig func(workspaceRoot string) (config.MCPConfig, error)
+	newProvider      func(config.ProviderProfile) (zeroruntime.Provider, error)
+	newSessionStore  func() *sessions.Store
+	loadPlugins      func(plugins.LoadOptions) (plugins.LoadResult, error)
+	loadHooks        func(hooks.LoadOptions) (hooks.LoadResult, error)
+	newMCPStore      func() (*mcp.PermissionStore, error)
+	registerMCPTools func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error)
+	runTUI           func(context.Context, tui.Options) int
+	now              func() time.Time
+}
+
+type mcpToolRuntime interface {
+	Close() error
+}
+
+type noopMCPRuntime struct{}
+
+func (noopMCPRuntime) Close() error {
+	return nil
 }
 
 // Run executes the minimal Go CLI surface. It returns an exit code so tests can
@@ -52,6 +64,13 @@ func defaultAppDeps() appDeps {
 			options.Overrides = overrides
 			return config.Resolve(options)
 		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			options, err := config.DefaultResolveOptions(workspaceRoot)
+			if err != nil {
+				return config.MCPConfig{}, err
+			}
+			return config.ResolveMCP(options)
+		},
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
 			return providers.New(profile, providers.Options{UserAgent: userAgent()})
 		},
@@ -62,6 +81,9 @@ func defaultAppDeps() appDeps {
 		loadHooks:   hooks.LoadConfig,
 		newMCPStore: func() (*mcp.PermissionStore, error) {
 			return mcp.NewPermissionStore(mcp.StoreOptions{})
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return mcp.RegisterTools(ctx, registry, cfg, options)
 		},
 		runTUI: tui.Run,
 		now:    time.Now,
@@ -130,6 +152,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	if deps.resolveConfig == nil {
 		deps.resolveConfig = defaults.resolveConfig
 	}
+	if deps.resolveMCPConfig == nil {
+		deps.resolveMCPConfig = defaults.resolveMCPConfig
+	}
 	if deps.newProvider == nil {
 		deps.newProvider = defaults.newProvider
 	}
@@ -144,6 +169,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.newMCPStore == nil {
 		deps.newMCPStore = defaults.newMCPStore
+	}
+	if deps.registerMCPTools == nil {
+		deps.registerMCPTools = defaults.registerMCPTools
 	}
 	if deps.runTUI == nil {
 		deps.runTUI = defaults.runTUI
@@ -171,6 +199,11 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
+	mcpRuntime, err := registerMCPToolsForWorkspace(context.Background(), workspaceRoot, registry, deps, mcp.AutonomyLow)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), 1)
+	}
+	defer mcpRuntime.Close()
 	permissionMode := agent.PermissionModeAuto
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:          workspaceRoot,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -78,11 +78,16 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
-	if err := validateExecToolFilters(options, registry); err != nil {
-		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
-	}
 	permissionMode, err := resolveExecPermissionMode(options)
 	if err != nil {
+		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
+	}
+	mcpRuntime, err := registerMCPToolsForWorkspace(context.Background(), workspaceRoot, registry, deps, execMCPAutonomy(options))
+	if err != nil {
+		return writeExecProviderError(stdout, stderr, options.outputFormat, "mcp_error", err.Error())
+	}
+	defer mcpRuntime.Close()
+	if err := validateExecToolFilters(options, registry); err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
 	if options.listTools {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -86,7 +86,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "mcp_error", err.Error())
 	}
-	defer mcpRuntime.Close()
+	defer closeMCPRuntime(stderr, mcpRuntime)
 	if err := validateExecToolFilters(options, registry); err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"path/filepath"
 	"slices"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -108,6 +110,55 @@ func TestRunExecListsToolsAsStreamJSONWhenRequested(t *testing.T) {
 		if strings.Contains(text, name) {
 			t.Fatalf("unexpected non-enabled tool %q leaked into stream-json output: %#v", name, events[1])
 		}
+	}
+}
+
+func TestRunExecListsMCPToolsWithoutProviderResolution(t *testing.T) {
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	providerResolved := false
+	closed := false
+
+	exitCode := runWithDeps([]string{"exec", "--list-tools", "--enabled-tools", "mcp_docs_lookup"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			providerResolved = true
+			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"docs": {Type: "stdio", Command: "docs-mcp"},
+			}}, nil
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			registry.Register(cliFakeMCPRegistryTool{})
+			return closeFunc(func() error {
+				closed = true
+				return nil
+			}), nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if providerResolved {
+		t.Fatal("provider config should not be resolved for --list-tools")
+	}
+	if !closed {
+		t.Fatal("MCP runtime was not closed after --list-tools")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "mcp_docs_lookup") || !strings.Contains(stdout.String(), "Lookup documentation") {
+		t.Fatalf("expected MCP tool in list output, got %q", stdout.String())
 	}
 }
 
@@ -384,4 +435,42 @@ func TestRunExecReadsStreamJSONPromptFromStdin(t *testing.T) {
 	if final["type"] != "final" || final["text"] != "from stdin" {
 		t.Fatalf("expected final event from stdin, got %#v", final)
 	}
+}
+
+type cliFakeMCPRegistryTool struct{}
+
+func (cliFakeMCPRegistryTool) Name() string {
+	return "mcp_docs_lookup"
+}
+
+func (cliFakeMCPRegistryTool) Description() string {
+	return "Lookup documentation"
+}
+
+func (cliFakeMCPRegistryTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Properties: map[string]tools.PropertySchema{
+			"query": {Type: "string"},
+		},
+	}
+}
+
+func (cliFakeMCPRegistryTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect: tools.SideEffectNetwork,
+		Permission: tools.PermissionAllow,
+		Reason:     "MCP test tool",
+	}
+}
+
+func (cliFakeMCPRegistryTool) Run(context.Context, map[string]any) tools.Result {
+	return tools.Result{Status: tools.StatusOK, Output: "ok"}
+}
+
+type closeFunc func() error
+
+func (fn closeFunc) Close() error {
+	return fn()
 }

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -162,6 +162,42 @@ func TestRunExecListsMCPToolsWithoutProviderResolution(t *testing.T) {
 	}
 }
 
+func TestRunExecLogsMCPRuntimeCloseError(t *testing.T) {
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--list-tools", "--enabled-tools", "mcp_docs_lookup"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"docs": {Type: "stdio", Command: "docs-mcp"},
+			}}, nil
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return nil, nil
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			registry.Register(cliFakeMCPRegistryTool{})
+			return closeFunc(func() error {
+				return errors.New("close failed")
+			}), nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "mcp_close_error: close failed") {
+		t.Fatalf("stderr = %q, want MCP close error", stderr.String())
+	}
+}
+
 func TestRunExecRejectsInvalidProtocolOptionsBeforeRuntime(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 type pluginListOptions struct {
@@ -134,8 +136,62 @@ func runMCP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 		return exitSuccess
 	case "permissions":
 		return runMCPPermissions(args[1:], stdout, stderr, deps)
+	case "tools":
+		return runMCPTools(args[1:], stdout, stderr, deps)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown mcp subcommand %q", args[0]))
+	}
+}
+
+func runMCPTools(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "mcp tools subcommand required. Use `zero mcp tools list`.")
+	}
+	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		if err := writeMCPToolsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	switch args[0] {
+	case "list":
+		options, help, err := parseMCPCommandOptions(args[1:])
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		if help {
+			if err := writeMCPToolsHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		cwd, err := deps.getwd()
+		if err != nil {
+			return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), exitCrash)
+		}
+		registry := tools.NewRegistry()
+		runtime, err := registerMCPToolsForWorkspace(context.Background(), cwd, registry, deps, mcp.AutonomyLow)
+		if err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+		defer runtime.Close()
+		items := mcpToolList(registry)
+		if options.json {
+			payload := struct {
+				Tools []mcpToolListItem `json:"tools"`
+			}{Tools: items}
+			if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatMCPToolList(items), redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown mcp tools subcommand %q", args[0]))
 	}
 }
 
@@ -328,7 +384,7 @@ func parseMCPCommandOptions(args []string) (mcpCommandOptions, bool, error) {
 		case "--confirm":
 			options.confirm = true
 		default:
-			return options, false, execUsageError{fmt.Sprintf("unknown mcp permissions flag %q", arg)}
+			return options, false, execUsageError{fmt.Sprintf("unknown mcp flag %q", arg)}
 		}
 	}
 	return options, false, nil
@@ -403,6 +459,21 @@ func writeMCPHelp(w io.Writer) error {
 
 Commands:
   permissions    Manage persistent MCP tool permissions
+  tools          Inspect configured MCP tools
+`)
+	return err
+}
+
+func writeMCPToolsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp tools <command>
+
+Commands:
+  list    List configured MCP tools
+
+Flags:
+      --json    Print MCP tools as JSON
+  -h, --help    Show this help
 `)
 	return err
 }

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -175,7 +175,7 @@ func runMCPTools(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		if err != nil {
 			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 		}
-		defer runtime.Close()
+		defer closeMCPRuntime(stderr, runtime)
 		items := mcpToolList(registry)
 		if options.json {
 			payload := struct {

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"path/filepath"
@@ -9,9 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 func TestRunPluginsListsJSONAndText(t *testing.T) {
@@ -193,6 +196,56 @@ func TestRunMCPPermissionsListRevokeAndClear(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"cleared": 1`) {
 		t.Fatalf("unexpected clear output: %s", stdout.String())
+	}
+}
+
+func TestRunMCPToolsListJSONAndText(t *testing.T) {
+	cwd := t.TempDir()
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"docs": {Type: "stdio", Command: "docs-mcp"},
+			}}, nil
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			registry.Register(cliFakeMCPRegistryTool{})
+			return closeFunc(func() error { return nil }), nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"mcp", "tools", "list", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var payload struct {
+		Tools []struct {
+			Name       string `json:"name"`
+			Permission string `json:"permission"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("MCP tools JSON failed to decode: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Tools) != 1 || payload.Tools[0].Name != "mcp_docs_lookup" || payload.Tools[0].Permission != string(tools.PermissionAllow) {
+		t.Fatalf("unexpected MCP tools JSON: %#v", payload)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"mcp", "tools", "list"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"MCP Tools:", "mcp_docs_lookup", "Lookup documentation", "allow"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("MCP tools text missing %q: %s", want, stdout.String())
+		}
 	}
 }
 

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -201,6 +201,7 @@ func TestRunMCPPermissionsListRevokeAndClear(t *testing.T) {
 
 func TestRunMCPToolsListJSONAndText(t *testing.T) {
 	cwd := t.TempDir()
+	closeCalls := 0
 	deps := appDeps{
 		getwd: func() (string, error) { return cwd, nil },
 		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
@@ -213,7 +214,10 @@ func TestRunMCPToolsListJSONAndText(t *testing.T) {
 		},
 		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
 			registry.Register(cliFakeMCPRegistryTool{})
-			return closeFunc(func() error { return nil }), nil
+			return closeFunc(func() error {
+				closeCalls++
+				return nil
+			}), nil
 		},
 	}
 
@@ -235,6 +239,9 @@ func TestRunMCPToolsListJSONAndText(t *testing.T) {
 	if len(payload.Tools) != 1 || payload.Tools[0].Name != "mcp_docs_lookup" || payload.Tools[0].Permission != string(tools.PermissionAllow) {
 		t.Fatalf("unexpected MCP tools JSON: %#v", payload)
 	}
+	if closeCalls != 1 {
+		t.Fatalf("MCP runtime close calls after JSON list = %d, want 1", closeCalls)
+	}
 
 	stdout.Reset()
 	stderr.Reset()
@@ -246,6 +253,9 @@ func TestRunMCPToolsListJSONAndText(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("MCP tools text missing %q: %s", want, stdout.String())
 		}
+	}
+	if closeCalls != 2 {
+		t.Fatalf("MCP runtime close calls after text list = %d, want 2", closeCalls)
 	}
 }
 

--- a/internal/cli/mcp_tools.go
+++ b/internal/cli/mcp_tools.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type mcpToolListItem struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	SideEffect  string `json:"sideEffect"`
+	Permission  string `json:"permission"`
+}
+
+func registerMCPToolsForWorkspace(ctx context.Context, workspaceRoot string, registry *tools.Registry, deps appDeps, autonomy mcp.PermissionAutonomy) (mcpToolRuntime, error) {
+	cfg, err := deps.resolveMCPConfig(workspaceRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.Servers) == 0 {
+		return noopMCPRuntime{}, nil
+	}
+	store, err := deps.newMCPStore()
+	if err != nil {
+		return nil, err
+	}
+	return deps.registerMCPTools(ctx, registry, cfg, mcp.RegisterOptions{
+		PermissionStore: store,
+		Autonomy:        autonomy,
+	})
+}
+
+func execMCPAutonomy(options execOptions) mcp.PermissionAutonomy {
+	if options.skipPermissionsUnsafe || strings.EqualFold(strings.TrimSpace(options.autonomy), "high") {
+		return mcp.AutonomyHigh
+	}
+	if strings.EqualFold(strings.TrimSpace(options.autonomy), "medium") {
+		return mcp.AutonomyMedium
+	}
+	return mcp.AutonomyLow
+}
+
+func mcpToolList(registry *tools.Registry) []mcpToolListItem {
+	registered := registry.All()
+	items := make([]mcpToolListItem, 0, len(registered))
+	for _, tool := range registered {
+		if !strings.HasPrefix(tool.Name(), "mcp_") {
+			continue
+		}
+		safety := tool.Safety()
+		items = append(items, mcpToolListItem{
+			Name:        tool.Name(),
+			Description: tool.Description(),
+			SideEffect:  string(safety.SideEffect),
+			Permission:  string(safety.Permission),
+		})
+	}
+	sort.Slice(items, func(left int, right int) bool {
+		return items[left].Name < items[right].Name
+	})
+	return items
+}
+
+func formatMCPToolList(items []mcpToolListItem) string {
+	if len(items) == 0 {
+		return "No MCP tools configured."
+	}
+	lines := []string{"MCP Tools:"}
+	for _, item := range items {
+		lines = append(lines, fmt.Sprintf("  %s [%s/%s] - %s", item.Name, item.SideEffect, item.Permission, item.Description))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -273,28 +273,29 @@ func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig 
 		base.Args = append([]string{}, next.Args...)
 	}
 	if next.Env != nil {
-		if base.Env == nil {
-			base.Env = map[string]string{}
-		}
-		for key, value := range next.Env {
-			base.Env[key] = value
-		}
+		base.Env = copyMCPStringMap(next.Env)
 	}
 	if strings.TrimSpace(next.URL) != "" {
 		base.URL = next.URL
 	}
 	if next.Headers != nil {
-		if base.Headers == nil {
-			base.Headers = map[string]string{}
-		}
-		for key, value := range next.Headers {
-			base.Headers[key] = value
-		}
+		base.Headers = copyMCPStringMap(next.Headers)
 	}
-	if next.Disabled {
-		base.Disabled = true
+	if next.disabledSet || next.Disabled {
+		base.Disabled = next.Disabled
 	}
 	return base
+}
+
+func copyMCPStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
 }
 
 func hasProviderFields(profile ProviderProfile) bool {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -47,7 +47,25 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Providers:      providers,
 		Provider:       active,
 		MaxTurns:       cfg.MaxTurns,
+		MCP:            cfg.MCP,
 	}, nil
+}
+
+func ResolveMCP(options ResolveOptions) (MCPConfig, error) {
+	cfg := FileConfig{}
+
+	for _, path := range []string{options.UserConfigPath, options.ProjectConfigPath} {
+		if path == "" {
+			continue
+		}
+		fileConfig, err := loadConfigFile(path)
+		if err != nil {
+			return MCPConfig{}, err
+		}
+		mergeMCPConfig(&cfg.MCP, fileConfig.MCP)
+	}
+	mergeMCPConfig(&cfg.MCP, options.Overrides.MCP)
+	return cfg.MCP, nil
 }
 
 func loadConfigFile(path string) (FileConfig, error) {
@@ -73,6 +91,7 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	for _, provider := range src.Providers {
 		mergeProvider(dst, provider)
 	}
+	mergeMCPConfig(&dst.MCP, src.MCP)
 }
 
 func mergeProvider(cfg *FileConfig, provider ProviderProfile) {
@@ -228,6 +247,54 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 	if hasProviderFields(overrides.Provider) {
 		mergeProvider(cfg, overrides.Provider)
 	}
+	mergeMCPConfig(&cfg.MCP, overrides.MCP)
+}
+
+func mergeMCPConfig(dst *MCPConfig, src MCPConfig) {
+	if len(src.Servers) == 0 {
+		return
+	}
+	if dst.Servers == nil {
+		dst.Servers = map[string]MCPServerConfig{}
+	}
+	for name, server := range src.Servers {
+		dst.Servers[name] = mergeMCPServer(dst.Servers[name], server)
+	}
+}
+
+func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig {
+	if strings.TrimSpace(next.Type) != "" {
+		base.Type = next.Type
+	}
+	if strings.TrimSpace(next.Command) != "" {
+		base.Command = next.Command
+	}
+	if next.Args != nil {
+		base.Args = append([]string{}, next.Args...)
+	}
+	if next.Env != nil {
+		if base.Env == nil {
+			base.Env = map[string]string{}
+		}
+		for key, value := range next.Env {
+			base.Env[key] = value
+		}
+	}
+	if strings.TrimSpace(next.URL) != "" {
+		base.URL = next.URL
+	}
+	if next.Headers != nil {
+		if base.Headers == nil {
+			base.Headers = map[string]string{}
+		}
+		for key, value := range next.Headers {
+			base.Headers[key] = value
+		}
+	}
+	if next.Disabled {
+		base.Disabled = true
+	}
+	return base
 }
 
 func hasProviderFields(profile ProviderProfile) bool {

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -132,8 +132,8 @@ func TestResolveReplacesMCPServerOverlayCollections(t *testing.T) {
 	if got := strings.Join(docs.Args, " "); got != "--project" {
 		t.Fatalf("docs.Args = %q, want project args override", got)
 	}
-	if docs.Env["ZERO_DOCS_TOKEN"] != "" || docs.Env["ZERO_DOCS_PROJECT"] != "1" {
-		t.Fatalf("docs.Env = %#v, want project env replacement", docs.Env)
+	if _, ok := docs.Env["ZERO_DOCS_TOKEN"]; ok || docs.Env["ZERO_DOCS_PROJECT"] != "1" {
+		t.Fatalf("docs.Env = %#v, want ZERO_DOCS_TOKEN absent and ZERO_DOCS_PROJECT=1", docs.Env)
 	}
 	web := resolved.MCP.Servers["web"]
 	if web.Type != "http" || web.URL != "https://example.com/mcp" {

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -132,12 +132,76 @@ func TestResolveMergesMCPServerConfig(t *testing.T) {
 	if got := strings.Join(docs.Args, " "); got != "--project" {
 		t.Fatalf("docs.Args = %q, want project args override", got)
 	}
-	if docs.Env["ZERO_DOCS_TOKEN"] != "user-token" || docs.Env["ZERO_DOCS_PROJECT"] != "1" {
-		t.Fatalf("docs.Env = %#v, want merged env", docs.Env)
+	if docs.Env["ZERO_DOCS_TOKEN"] != "" || docs.Env["ZERO_DOCS_PROJECT"] != "1" {
+		t.Fatalf("docs.Env = %#v, want project env replacement", docs.Env)
 	}
 	web := resolved.MCP.Servers["web"]
 	if web.Type != "http" || web.URL != "https://example.com/mcp" {
 		t.Fatalf("web server = %#v, want root mcpServers alias loaded", web)
+	}
+}
+
+func TestResolveMCPServerLayersCanClearAndReenable(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "stdio",
+					"command": "docs-mcp",
+					"args": ["--user"],
+					"env": {"ZERO_DOCS_TOKEN": "user-token"},
+					"disabled": true
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcpServers": {
+			"docs": {
+				"args": [],
+				"env": {},
+				"disabled": false
+			}
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	docs := resolved.MCP.Servers["docs"]
+	if docs.Disabled {
+		t.Fatalf("docs.Disabled = true, want project layer to re-enable")
+	}
+	if len(docs.Args) != 0 {
+		t.Fatalf("docs.Args = %#v, want project layer to clear inherited args", docs.Args)
+	}
+	if len(docs.Env) != 0 {
+		t.Fatalf("docs.Env = %#v, want project layer to clear inherited env", docs.Env)
+	}
+}
+
+func TestResolveRejectsDuplicateMCPRootAliases(t *testing.T) {
+	path := writeConfig(t, `{
+		"mcpServers": {
+			"docs": {"type": "stdio", "command": "docs-mcp"}
+		},
+		"mcp_servers": {
+			"docs": {"type": "stdio", "command": "other-docs-mcp"}
+		}
+	}`)
+
+	_, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want duplicate MCP alias error")
+	}
+	if !strings.Contains(err.Error(), `defined in both mcpServers and mcp_servers`) {
+		t.Fatalf("error = %q, want duplicate MCP alias message", err.Error())
 	}
 }
 

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -89,6 +89,80 @@ func TestResolveSelectsActiveProviderProfile(t *testing.T) {
 	}
 }
 
+func TestResolveMergesMCPServerConfig(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {
+					"type": "stdio",
+					"command": "docs-mcp",
+					"args": ["--user"],
+					"env": {"ZERO_DOCS_TOKEN": "user-token"}
+				}
+			}
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"mcpServers": {
+			"docs": {
+				"args": ["--project"],
+				"env": {"ZERO_DOCS_PROJECT": "1"}
+			},
+			"web": {
+				"type": "http",
+				"url": "https://example.com/mcp",
+				"headers": {"Authorization": "Bearer test-token"}
+			}
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	docs := resolved.MCP.Servers["docs"]
+	if docs.Command != "docs-mcp" {
+		t.Fatalf("docs.Command = %q, want inherited user command", docs.Command)
+	}
+	if got := strings.Join(docs.Args, " "); got != "--project" {
+		t.Fatalf("docs.Args = %q, want project args override", got)
+	}
+	if docs.Env["ZERO_DOCS_TOKEN"] != "user-token" || docs.Env["ZERO_DOCS_PROJECT"] != "1" {
+		t.Fatalf("docs.Env = %#v, want merged env", docs.Env)
+	}
+	web := resolved.MCP.Servers["web"]
+	if web.Type != "http" || web.URL != "https://example.com/mcp" {
+		t.Fatalf("web server = %#v, want root mcpServers alias loaded", web)
+	}
+}
+
+func TestResolveMCPDoesNotRunProviderCommand(t *testing.T) {
+	path := writeConfig(t, `{
+		"mcp": {
+			"servers": {
+				"docs": {"type": "stdio", "command": "docs-mcp"}
+			}
+		}
+	}`)
+
+	resolved, err := ResolveMCP(ResolveOptions{
+		ProjectConfigPath: path,
+		ProviderCommand:   "provider-command-that-should-not-run",
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("ResolveMCP() error = %v", err)
+	}
+	if resolved.Servers["docs"].Command != "docs-mcp" {
+		t.Fatalf("MCP docs server = %#v", resolved.Servers["docs"])
+	}
+}
+
 func TestResolveIgnoresWhitespaceOnlyActiveProviderLayers(t *testing.T) {
 	userPath := writeConfig(t, `{
 		"activeProvider": "alpha",

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -89,7 +89,7 @@ func TestResolveSelectsActiveProviderProfile(t *testing.T) {
 	}
 }
 
-func TestResolveMergesMCPServerConfig(t *testing.T) {
+func TestResolveReplacesMCPServerOverlayCollections(t *testing.T) {
 	userPath := writeConfig(t, `{
 		"mcp": {
 			"servers": {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -32,6 +32,7 @@ type FileConfig struct {
 	ActiveProvider string            `json:"activeProvider,omitempty"`
 	Providers      []ProviderProfile `json:"providers,omitempty"`
 	MaxTurns       int               `json:"maxTurns,omitempty"`
+	MCP            MCPConfig         `json:"mcp,omitempty"`
 }
 
 type ResolveOptions struct {
@@ -47,6 +48,7 @@ type Overrides struct {
 	Providers      []ProviderProfile
 	Provider       ProviderProfile
 	MaxTurns       int
+	MCP            MCPConfig
 }
 
 type ResolvedConfig struct {
@@ -54,6 +56,51 @@ type ResolvedConfig struct {
 	Providers      []ProviderProfile
 	Provider       ProviderProfile
 	MaxTurns       int
+	MCP            MCPConfig
+}
+
+type MCPConfig struct {
+	Servers map[string]MCPServerConfig `json:"servers,omitempty"`
+}
+
+type MCPServerConfig struct {
+	Type     string            `json:"type,omitempty"`
+	Command  string            `json:"command,omitempty"`
+	Args     []string          `json:"args,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	URL      string            `json:"url,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+	Disabled bool              `json:"disabled,omitempty"`
+}
+
+func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
+	type rawConfig struct {
+		ActiveProvider  string                     `json:"activeProvider"`
+		Providers       []ProviderProfile          `json:"providers"`
+		MaxTurns        int                        `json:"maxTurns"`
+		MCP             MCPConfig                  `json:"mcp"`
+		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
+		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
+	}
+
+	var raw rawConfig
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	cfg.ActiveProvider = raw.ActiveProvider
+	cfg.Providers = raw.Providers
+	cfg.MaxTurns = raw.MaxTurns
+	cfg.MCP = raw.MCP
+	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
+		cfg.MCP.Servers = map[string]MCPServerConfig{}
+	}
+	for name, server := range raw.MCPServers {
+		cfg.MCP.Servers[name] = server
+	}
+	for name, server := range raw.MCPServersSnake {
+		cfg.MCP.Servers[name] = server
+	}
+	return nil
 }
 
 func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -64,13 +65,14 @@ type MCPConfig struct {
 }
 
 type MCPServerConfig struct {
-	Type     string            `json:"type,omitempty"`
-	Command  string            `json:"command,omitempty"`
-	Args     []string          `json:"args,omitempty"`
-	Env      map[string]string `json:"env,omitempty"`
-	URL      string            `json:"url,omitempty"`
-	Headers  map[string]string `json:"headers,omitempty"`
-	Disabled bool              `json:"disabled,omitempty"`
+	Type        string            `json:"type,omitempty"`
+	Command     string            `json:"command,omitempty"`
+	Args        []string          `json:"args,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
+	URL         string            `json:"url,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Disabled    bool              `json:"disabled,omitempty"`
+	disabledSet bool
 }
 
 func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
@@ -98,7 +100,40 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		cfg.MCP.Servers[name] = server
 	}
 	for name, server := range raw.MCPServersSnake {
+		if _, exists := cfg.MCP.Servers[name]; exists {
+			return fmt.Errorf("MCP server %q is defined in both mcpServers and mcp_servers; mcp_servers would override mcpServers", name)
+		}
 		cfg.MCP.Servers[name] = server
+	}
+	return nil
+}
+
+func (server *MCPServerConfig) UnmarshalJSON(data []byte) error {
+	type rawServer struct {
+		Type     string            `json:"type"`
+		Command  string            `json:"command"`
+		Args     []string          `json:"args"`
+		Env      map[string]string `json:"env"`
+		URL      string            `json:"url"`
+		Headers  map[string]string `json:"headers"`
+		Disabled *bool             `json:"disabled"`
+	}
+
+	var raw rawServer
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	server.Type = raw.Type
+	server.Command = raw.Command
+	server.Args = raw.Args
+	server.Env = raw.Env
+	server.URL = raw.URL
+	server.Headers = raw.Headers
+	server.Disabled = false
+	server.disabledSet = false
+	if raw.Disabled != nil {
+		server.Disabled = *raw.Disabled
+		server.disabledSet = true
 	}
 	return nil
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1,0 +1,218 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+type RemoteTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema,omitempty"`
+}
+
+type Content struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type CallToolResult struct {
+	Content []Content `json:"content"`
+	IsError bool      `json:"isError,omitempty"`
+}
+
+type ToolClient interface {
+	ListTools(context.Context) ([]RemoteTool, error)
+	CallTool(context.Context, string, map[string]any) (CallToolResult, error)
+	Close() error
+}
+
+type Client struct {
+	server Server
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	reader *messageReader
+	writer *messageWriter
+	mu     sync.Mutex
+	nextID int
+}
+
+func Connect(ctx context.Context, server Server) (*Client, error) {
+	switch server.Type {
+	case ServerTypeStdio:
+		return connectStdio(ctx, server)
+	case ServerTypeHTTP, ServerTypeSSE:
+		return nil, fmt.Errorf("MCP %s transport is not implemented yet for server %s", server.Type, server.Name)
+	default:
+		return nil, fmt.Errorf("unsupported MCP transport %q for server %s", server.Type, server.Name)
+	}
+}
+
+func connectStdio(ctx context.Context, server Server) (*Client, error) {
+	cmd := exec.CommandContext(ctx, server.Command, server.Args...)
+	cmd.Env = mergeProcessEnv(server.Env)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open MCP stdin for %s: %w", server.Name, err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open MCP stdout for %s: %w", server.Name, err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start MCP server %s: %w", server.Name, err)
+	}
+
+	client := &Client{
+		server: server,
+		cmd:    cmd,
+		stdin:  stdin,
+		reader: newMessageReader(stdout),
+		writer: newMessageWriter(stdin),
+		nextID: 1,
+	}
+	if err := client.initialize(ctx); err != nil {
+		_ = client.Close()
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return nil, fmt.Errorf("initialize MCP server %s: %w: %s", server.Name, err, message)
+		}
+		return nil, fmt.Errorf("initialize MCP server %s: %w", server.Name, err)
+	}
+	return client, nil
+}
+
+func (client *Client) initialize(ctx context.Context) error {
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := client.request(ctx, "initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "zero",
+			"version": "dev",
+		},
+	}, &result); err != nil {
+		return err
+	}
+	return client.notify("notifications/initialized", map[string]any{})
+}
+
+func (client *Client) ListTools(ctx context.Context) ([]RemoteTool, error) {
+	var result struct {
+		Tools []RemoteTool `json:"tools"`
+	}
+	if err := client.request(ctx, "tools/list", map[string]any{}, &result); err != nil {
+		return nil, err
+	}
+	return result.Tools, nil
+}
+
+func (client *Client) CallTool(ctx context.Context, name string, args map[string]any) (CallToolResult, error) {
+	var result CallToolResult
+	if err := client.request(ctx, "tools/call", map[string]any{
+		"name":      name,
+		"arguments": args,
+	}, &result); err != nil {
+		return CallToolResult{}, err
+	}
+	return result, nil
+}
+
+func (client *Client) Close() error {
+	var err error
+	if client.stdin != nil {
+		err = client.stdin.Close()
+		client.stdin = nil
+	}
+	if client.cmd != nil && client.cmd.Process != nil {
+		_ = client.cmd.Process.Kill()
+		waitErr := client.cmd.Wait()
+		if err == nil && waitErr != nil && !strings.Contains(waitErr.Error(), "signal: killed") {
+			err = waitErr
+		}
+		client.cmd = nil
+	}
+	return err
+}
+
+func (client *Client) request(ctx context.Context, method string, params any, target any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+
+	id := client.nextID
+	client.nextID++
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	if err := client.writer.write(rpcMessage{
+		ID:     id,
+		Method: method,
+		Params: rawParams,
+	}); err != nil {
+		return err
+	}
+
+	for {
+		message, err := client.reader.read()
+		if err != nil {
+			return err
+		}
+		if message.ID == nil {
+			continue
+		}
+		if message.Error != nil {
+			return fmt.Errorf("MCP %s failed: %s", method, message.Error.Message)
+		}
+		if target != nil && len(message.Result) > 0 {
+			if err := json.Unmarshal(message.Result, target); err != nil {
+				return fmt.Errorf("decode MCP %s result: %w", method, err)
+			}
+		}
+		return nil
+	}
+}
+
+func (client *Client) notify(method string, params any) error {
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return client.writer.write(rpcMessage{
+		Method: method,
+		Params: rawParams,
+	})
+}
+
+func mergeProcessEnv(env map[string]string) []string {
+	merged := append([]string{}, os.Environ()...)
+	for key, value := range env {
+		merged = append(merged, key+"="+value)
+	}
+	return merged
+}
+
+func TextContent(content []Content) string {
+	parts := make([]string, 0, len(content))
+	for _, item := range content {
+		if item.Type == "text" {
+			parts = append(parts, item.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -176,6 +177,9 @@ func (client *Client) request(ctx context.Context, method string, params any, ta
 		if message.ID == nil {
 			continue
 		}
+		if !rpcIDMatches(message.ID, id) {
+			continue
+		}
 		if message.Error != nil {
 			return fmt.Errorf("MCP %s failed: %s", method, message.Error.Message)
 		}
@@ -185,6 +189,24 @@ func (client *Client) request(ctx context.Context, method string, params any, ta
 			}
 		}
 		return nil
+	}
+}
+
+func rpcIDMatches(value any, id int) bool {
+	switch typed := value.(type) {
+	case int:
+		return typed == id
+	case int64:
+		return typed == int64(id)
+	case float64:
+		return typed == float64(id)
+	case json.Number:
+		parsed, err := typed.Int64()
+		return err == nil && parsed == int64(id)
+	case string:
+		return typed == strconv.Itoa(id)
+	default:
+		return false
 	}
 }
 

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,0 +1,202 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestStdioClientListsAndCallsTools(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := Connect(ctx, Server{
+		Name:    "docs",
+		Type:    ServerTypeStdio,
+		Command: executable,
+		Args:    []string{"-test.run=TestMCPStdioHelperProcess", "--"},
+		Env:     map[string]string{"ZERO_MCP_STDIO_HELPER": "1"},
+	})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	defer client.Close()
+
+	listed, err := client.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "lookup" {
+		t.Fatalf("listed tools = %#v, want lookup", listed)
+	}
+	if listed[0].InputSchema["type"] != "object" {
+		t.Fatalf("lookup schema = %#v, want object schema", listed[0].InputSchema)
+	}
+
+	result, err := client.CallTool(ctx, "lookup", map[string]any{"query": "zero"})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("CallTool() result IsError = true: %#v", result)
+	}
+	if got := TextContent(result.Content); got != "lookup: zero" {
+		t.Fatalf("CallTool() text = %q, want lookup result", got)
+	}
+}
+
+func TestConnectRejectsUnsupportedRunnableTransports(t *testing.T) {
+	_, err := Connect(context.Background(), Server{
+		Name: "web",
+		Type: ServerTypeHTTP,
+		URL:  "https://example.com/mcp",
+	})
+	if err == nil {
+		t.Fatal("Connect() error = nil, want unsupported transport error")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("error = %q, want not implemented", err.Error())
+	}
+}
+
+func TestMCPStdioHelperProcess(t *testing.T) {
+	if os.Getenv("ZERO_MCP_STDIO_HELPER") != "1" {
+		return
+	}
+
+	reader := newMessageReader(os.Stdin)
+	writer := newMessageWriter(os.Stdout)
+	for {
+		message, err := reader.read()
+		if err != nil {
+			if strings.Contains(err.Error(), "EOF") {
+				os.Exit(0)
+			}
+			fmt.Fprintf(os.Stderr, "read helper message: %v\n", err)
+			os.Exit(1)
+		}
+		if message.Method == "notifications/initialized" {
+			continue
+		}
+
+		switch message.Method {
+		case "initialize":
+			_ = writer.write(rpcMessage{
+				JSONRPC: "2.0",
+				ID:      message.ID,
+				Result: mustRaw(map[string]any{
+					"protocolVersion": "2024-11-05",
+					"capabilities":    map[string]any{"tools": map[string]any{}},
+					"serverInfo":      map[string]any{"name": "test-docs", "version": "1.0.0"},
+				}),
+			})
+		case "tools/list":
+			_ = writer.write(rpcMessage{
+				JSONRPC: "2.0",
+				ID:      message.ID,
+				Result: mustRaw(map[string]any{
+					"tools": []map[string]any{{
+						"name":        "lookup",
+						"description": "Lookup documentation",
+						"inputSchema": map[string]any{
+							"type":                 "object",
+							"additionalProperties": false,
+							"required":             []string{"query"},
+							"properties": map[string]any{
+								"query": map[string]any{"type": "string", "description": "Search query"},
+							},
+						},
+					}},
+				}),
+			})
+		case "tools/call":
+			var params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			}
+			_ = json.Unmarshal(message.Params, &params)
+			_ = writer.write(rpcMessage{
+				JSONRPC: "2.0",
+				ID:      message.ID,
+				Result: mustRaw(map[string]any{
+					"content": []map[string]any{{
+						"type": "text",
+						"text": "lookup: " + strings.TrimSpace(fmt.Sprint(params.Arguments["query"])),
+					}},
+				}),
+			})
+		default:
+			_ = writer.write(rpcMessage{
+				JSONRPC: "2.0",
+				ID:      message.ID,
+				Error:   &rpcError{Code: -32601, Message: "method not found"},
+			})
+		}
+	}
+}
+
+func mustRaw(value any) json.RawMessage {
+	data, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func TestSchemaFromMCPInputSchema(t *testing.T) {
+	schema := SchemaFromMCP(map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"query"},
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "Search query",
+				"enum":        []any{"zero", "docs"},
+			},
+			"limit": map[string]any{
+				"type":    "integer",
+				"default": float64(5),
+				"minimum": float64(1),
+				"maximum": float64(10),
+			},
+		},
+	})
+
+	if schema.Type != "object" || schema.AdditionalProperties {
+		t.Fatalf("schema root = %#v", schema)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "query" {
+		t.Fatalf("required = %#v, want query", schema.Required)
+	}
+	query := schema.Properties["query"]
+	if query.Type != "string" || len(query.Enum) != 2 {
+		t.Fatalf("query schema = %#v", query)
+	}
+	limit := schema.Properties["limit"]
+	if limit.Type != "integer" || limit.Minimum == nil || *limit.Minimum != 1 || limit.Maximum == nil || *limit.Maximum != 10 {
+		t.Fatalf("limit schema = %#v", limit)
+	}
+}
+
+func TestStdioClientServerFromConfig(t *testing.T) {
+	servers, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp", Args: []string{"--root", "."}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if servers[0].Type != ServerTypeStdio || servers[0].Command != "docs-mcp" {
+		t.Fatalf("server = %#v", servers[0])
+	}
+}

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -66,6 +67,42 @@ func TestConnectRejectsUnsupportedRunnableTransports(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not implemented") {
 		t.Fatalf("error = %q, want not implemented", err.Error())
+	}
+}
+
+func TestClientRequestWaitsForMatchingResponseID(t *testing.T) {
+	var incoming bytes.Buffer
+	incomingWriter := newMessageWriter(&incoming)
+	if err := incomingWriter.write(rpcMessage{Method: "notifications/progress"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := incomingWriter.write(rpcMessage{
+		ID:    99,
+		Error: &rpcError{Code: -32000, Message: "wrong response"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := incomingWriter.write(rpcMessage{
+		ID:     1,
+		Result: mustRaw(map[string]any{"value": "matched"}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var outgoing bytes.Buffer
+	client := &Client{
+		reader: newMessageReader(&incoming),
+		writer: newMessageWriter(&outgoing),
+		nextID: 1,
+	}
+	var result struct {
+		Value string `json:"value"`
+	}
+	if err := client.request(context.Background(), "tools/list", map[string]any{}, &result); err != nil {
+		t.Fatalf("request() error = %v", err)
+	}
+	if result.Value != "matched" {
+		t.Fatalf("result.Value = %q, want matched response", result.Value)
 	}
 }
 

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -1,0 +1,176 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+type ServerType string
+
+const (
+	ServerTypeStdio ServerType = "stdio"
+	ServerTypeHTTP  ServerType = "http"
+	ServerTypeSSE   ServerType = "sse"
+)
+
+type Server struct {
+	Name     string
+	Type     ServerType
+	Command  string
+	Args     []string
+	Env      map[string]string
+	URL      string
+	Headers  map[string]string
+	Identity string
+}
+
+func NormalizeConfig(cfg config.MCPConfig) ([]Server, error) {
+	names := make([]string, 0, len(cfg.Servers))
+	for name := range cfg.Servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	servers := make([]Server, 0, len(names))
+	for _, name := range names {
+		raw := cfg.Servers[name]
+		if raw.Disabled {
+			continue
+		}
+		server, err := normalizeServer(name, raw)
+		if err != nil {
+			return nil, err
+		}
+		servers = append(servers, server)
+	}
+	return servers, nil
+}
+
+func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
+	name = strings.TrimSpace(name)
+	if err := ValidateServerName(name); err != nil {
+		return Server{}, err
+	}
+
+	serverType := ServerType(strings.ToLower(strings.TrimSpace(raw.Type)))
+	if serverType == "" {
+		if strings.TrimSpace(raw.URL) != "" {
+			serverType = ServerTypeHTTP
+		} else {
+			serverType = ServerTypeStdio
+		}
+	}
+
+	server := Server{
+		Name:    name,
+		Type:    serverType,
+		Command: strings.TrimSpace(raw.Command),
+		Args:    trimStringSlice(raw.Args),
+		Env:     copyStringMap(raw.Env),
+		URL:     strings.TrimSpace(raw.URL),
+		Headers: copyStringMap(raw.Headers),
+	}
+
+	switch server.Type {
+	case ServerTypeStdio:
+		if server.Command == "" {
+			return Server{}, fmt.Errorf("MCP server %s requires command for stdio transport", server.Name)
+		}
+		if server.URL != "" {
+			return Server{}, fmt.Errorf("MCP server %s url is only supported for http or sse transports", server.Name)
+		}
+		if len(server.Headers) > 0 {
+			return Server{}, fmt.Errorf("MCP server %s headers are only supported for http or sse transports", server.Name)
+		}
+	case ServerTypeHTTP, ServerTypeSSE:
+		if server.URL == "" {
+			return Server{}, fmt.Errorf("MCP server %s requires url for %s transport", server.Name, server.Type)
+		}
+		if server.Command != "" || len(server.Args) > 0 {
+			return Server{}, fmt.Errorf("MCP server %s command and args are only supported for stdio transport", server.Name)
+		}
+		if len(server.Env) > 0 {
+			return Server{}, fmt.Errorf("MCP server %s env is only supported for stdio transport", server.Name)
+		}
+		if err := validateHTTPURL(server.Name, server.URL); err != nil {
+			return Server{}, err
+		}
+	default:
+		return Server{}, fmt.Errorf("MCP server %s has unsupported type %q", server.Name, raw.Type)
+	}
+
+	server.Identity = computeServerIdentity(server)
+	return server, nil
+}
+
+func validateHTTPURL(serverName string, value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" {
+		return fmt.Errorf("MCP server %s url must be a valid http or https URL", serverName)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("MCP server %s url must use http or https", serverName)
+	}
+	return nil
+}
+
+func computeServerIdentity(server Server) string {
+	canonical := struct {
+		Type    ServerType        `json:"type"`
+		Command string            `json:"command,omitempty"`
+		Args    []string          `json:"args,omitempty"`
+		Env     map[string]string `json:"env,omitempty"`
+		URL     string            `json:"url,omitempty"`
+		Headers map[string]string `json:"headers,omitempty"`
+	}{
+		Type:    server.Type,
+		Command: server.Command,
+		Args:    append([]string{}, server.Args...),
+		Env:     copyStringMap(server.Env),
+		URL:     server.URL,
+		Headers: copyStringMap(server.Headers),
+	}
+	data, _ := json.Marshal(canonical)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])[:32]
+}
+
+func trimStringSlice(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		trimmed = append(trimmed, value)
+	}
+	return trimmed
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		copied[key] = value
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	return copied
+}

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -61,6 +61,8 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 
 	serverType := ServerType(strings.ToLower(strings.TrimSpace(raw.Type)))
 	if serverType == "" {
+		// When type is omitted, a URL makes the server use HTTP validation; otherwise
+		// command-based stdio remains the default.
 		if strings.TrimSpace(raw.URL) != "" {
 			serverType = ServerTypeHTTP
 		} else {
@@ -137,8 +139,12 @@ func computeServerIdentity(server Server) string {
 		URL:     server.URL,
 		Headers: copyStringMap(server.Headers),
 	}
+	// Marshal cannot fail for this canonical shape because it only contains
+	// JSON-serializable primitive, slice, and map fields.
 	data, _ := json.Marshal(canonical)
 	sum := sha256.Sum256(data)
+	// The first 32 hex characters give a stable 128-bit identity while keeping
+	// permission records compact.
 	return hex.EncodeToString(sum[:])[:32]
 }
 
@@ -157,6 +163,9 @@ func trimStringSlice(values []string) []string {
 	return trimmed
 }
 
+// copyStringMap trims and filters keys while preserving values verbatim. Env
+// and header values may intentionally contain surrounding whitespace, unlike
+// scalar fields such as Command and URL.
 func copyStringMap(values map[string]string) map[string]string {
 	if len(values) == 0 {
 		return nil

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestNormalizeConfigValidatesTransportBoundaries(t *testing.T) {
+	valid := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {
+			Type:    "stdio",
+			Command: "docs-mcp",
+			Args:    []string{"--workspace", "."},
+			Env:     map[string]string{"ZERO_DOCS_TOKEN": "test"},
+		},
+		"web": {
+			Type:    "http",
+			URL:     "https://example.com/mcp",
+			Headers: map[string]string{"Authorization": "Bearer test"},
+		},
+		"events": {
+			Type: "sse",
+			URL:  "https://example.com/sse",
+		},
+		"disabled": {
+			Type:     "stdio",
+			Command:  "disabled-mcp",
+			Disabled: true,
+		},
+	}}
+
+	servers, err := NormalizeConfig(valid)
+	if err != nil {
+		t.Fatalf("NormalizeConfig() error = %v", err)
+	}
+	if len(servers) != 3 {
+		t.Fatalf("servers = %#v, want disabled server skipped", servers)
+	}
+	if servers[0].Name != "docs" || servers[0].Identity == "" {
+		t.Fatalf("docs server = %#v, want stable identity", servers[0])
+	}
+	if servers[1].Name != "events" || servers[2].Name != "web" {
+		t.Fatalf("servers sorted by name = %#v", servers)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  config.MCPConfig
+		want string
+	}{
+		{
+			name: "stdio-without-command",
+			cfg:  config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": {Type: "stdio"}}},
+			want: "requires command",
+		},
+		{
+			name: "stdio-with-headers",
+			cfg:  config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": {Type: "stdio", Command: "docs-mcp", Headers: map[string]string{"Authorization": "Bearer test"}}}},
+			want: "headers are only supported",
+		},
+		{
+			name: "http-without-url",
+			cfg:  config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": {Type: "http"}}},
+			want: "requires url",
+		},
+		{
+			name: "http-with-env",
+			cfg:  config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": {Type: "http", URL: "https://example.com/mcp", Env: map[string]string{"TOKEN": "test"}}}},
+			want: "env is only supported",
+		},
+		{
+			name: "bad-url",
+			cfg:  config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": {Type: "sse", URL: "file:///tmp/mcp"}}},
+			want: "http or https",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NormalizeConfig(tc.cfg)
+			if err == nil {
+				t.Fatal("NormalizeConfig() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestServerIdentityChangesWithTransportFields(t *testing.T) {
+	first, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp", Args: []string{"--one"}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp", Args: []string{"--two"}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first[0].Identity == second[0].Identity {
+		t.Fatalf("identity did not change when args changed: %s", first[0].Identity)
+	}
+}

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -89,19 +89,62 @@ func TestNormalizeConfigValidatesTransportBoundaries(t *testing.T) {
 }
 
 func TestServerIdentityChangesWithTransportFields(t *testing.T) {
-	first, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-		"docs": {Type: "stdio", Command: "docs-mcp", Args: []string{"--one"}},
-	}})
-	if err != nil {
-		t.Fatal(err)
+	for _, tc := range []struct {
+		name   string
+		first  config.MCPServerConfig
+		second config.MCPServerConfig
+	}{
+		{
+			name:   "command",
+			first:  config.MCPServerConfig{Type: "stdio", Command: "docs-mcp"},
+			second: config.MCPServerConfig{Type: "stdio", Command: "other-docs-mcp"},
+		},
+		{
+			name:   "args",
+			first:  config.MCPServerConfig{Type: "stdio", Command: "docs-mcp", Args: []string{"--one"}},
+			second: config.MCPServerConfig{Type: "stdio", Command: "docs-mcp", Args: []string{"--two"}},
+		},
+		{
+			name:   "env",
+			first:  config.MCPServerConfig{Type: "stdio", Command: "docs-mcp", Env: map[string]string{"TOKEN": "one"}},
+			second: config.MCPServerConfig{Type: "stdio", Command: "docs-mcp", Env: map[string]string{"TOKEN": "two"}},
+		},
+		{
+			name:   "url",
+			first:  config.MCPServerConfig{Type: "http", URL: "https://one.example/mcp"},
+			second: config.MCPServerConfig{Type: "http", URL: "https://two.example/mcp"},
+		},
+		{
+			name:   "headers",
+			first:  config.MCPServerConfig{Type: "http", URL: "https://example.com/mcp", Headers: map[string]string{"Authorization": "Bearer one"}},
+			second: config.MCPServerConfig{Type: "http", URL: "https://example.com/mcp", Headers: map[string]string{"Authorization": "Bearer two"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			first, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": tc.first}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{"docs": tc.second}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first[0].Identity == second[0].Identity {
+				t.Fatalf("identity did not change when %s changed: %s", tc.name, first[0].Identity)
+			}
+		})
 	}
-	second, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
-		"docs": {Type: "stdio", Command: "docs-mcp", Args: []string{"--two"}},
-	}})
-	if err != nil {
-		t.Fatal(err)
+}
+
+func TestCopyStringMapTrimsKeysAndPreservesValues(t *testing.T) {
+	copied := copyStringMap(map[string]string{
+		" TOKEN ": "  keep surrounding spaces  ",
+		"   ":     "ignored",
+	})
+	if len(copied) != 1 {
+		t.Fatalf("copied = %#v, want one trimmed key", copied)
 	}
-	if first[0].Identity == second[0].Identity {
-		t.Fatalf("identity did not change when args changed: %s", first[0].Identity)
+	if copied["TOKEN"] != "  keep surrounding spaces  " {
+		t.Fatalf("copied[TOKEN] = %q, want value preserved verbatim", copied["TOKEN"])
 	}
 }

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type rpcMessage struct {
+	JSONRPC string          `json:"jsonrpc,omitempty"`
+	ID      any             `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type messageReader struct {
+	reader *bufio.Reader
+}
+
+type messageWriter struct {
+	writer *bufio.Writer
+}
+
+func newMessageReader(reader io.Reader) *messageReader {
+	return &messageReader{reader: bufio.NewReader(reader)}
+}
+
+func newMessageWriter(writer io.Writer) *messageWriter {
+	return &messageWriter{writer: bufio.NewWriter(writer)}
+}
+
+func (reader *messageReader) read() (rpcMessage, error) {
+	contentLength := 0
+	for {
+		line, err := reader.reader.ReadString('\n')
+		if err != nil {
+			return rpcMessage{}, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(name), "content-length") {
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil || parsed <= 0 {
+				return rpcMessage{}, fmt.Errorf("invalid MCP content length %q", value)
+			}
+			contentLength = parsed
+		}
+	}
+	if contentLength <= 0 {
+		return rpcMessage{}, fmt.Errorf("missing MCP content length")
+	}
+
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(reader.reader, body); err != nil {
+		return rpcMessage{}, err
+	}
+	var message rpcMessage
+	if err := json.Unmarshal(body, &message); err != nil {
+		return rpcMessage{}, fmt.Errorf("invalid MCP JSON-RPC message: %w", err)
+	}
+	return message, nil
+}
+
+func (writer *messageWriter) write(message rpcMessage) error {
+	if message.JSONRPC == "" {
+		message.JSONRPC = "2.0"
+	}
+	body, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(writer.writer, "Content-Length: %d\r\n\r\n", len(body)); err != nil {
+		return err
+	}
+	if _, err := writer.writer.Write(body); err != nil {
+		return err
+	}
+	return writer.writer.Flush()
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -1,0 +1,203 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type RegisterOptions struct {
+	PermissionStore *PermissionStore
+	Autonomy        PermissionAutonomy
+	ClientFactory   func(context.Context, Server) (ToolClient, error)
+}
+
+type Runtime struct {
+	clients []ToolClient
+	once    sync.Once
+	err     error
+}
+
+var unsafeToolNameChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+
+func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options RegisterOptions) (*Runtime, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("MCP tool registry is required")
+	}
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	runtime := &Runtime{}
+	if len(servers) == 0 {
+		return runtime, nil
+	}
+
+	factory := options.ClientFactory
+	if factory == nil {
+		factory = func(ctx context.Context, server Server) (ToolClient, error) {
+			return Connect(ctx, server)
+		}
+	}
+
+	for _, server := range servers {
+		client, err := factory(ctx, server)
+		if err != nil {
+			_ = runtime.Close()
+			return nil, err
+		}
+		runtime.clients = append(runtime.clients, client)
+
+		remoteTools, err := client.ListTools(ctx)
+		if err != nil {
+			_ = runtime.Close()
+			return nil, fmt.Errorf("list MCP tools for %s: %w", server.Name, err)
+		}
+		for _, remote := range remoteTools {
+			if strings.TrimSpace(remote.Name) == "" {
+				_ = runtime.Close()
+				return nil, fmt.Errorf("MCP server %s returned a tool without a name", server.Name)
+			}
+			tool := newRegistryTool(server, remote, client, options)
+			if existing, ok := registry.Get(tool.Name()); ok {
+				_ = runtime.Close()
+				return nil, fmt.Errorf("MCP tool %s from %s conflicts with existing tool %s", remote.Name, server.Name, existing.Name())
+			}
+			registry.Register(tool)
+		}
+	}
+	return runtime, nil
+}
+
+func (runtime *Runtime) Close() error {
+	if runtime == nil {
+		return nil
+	}
+	runtime.once.Do(func() {
+		for _, client := range runtime.clients {
+			if err := client.Close(); err != nil && runtime.err == nil {
+				runtime.err = err
+			}
+		}
+	})
+	return runtime.err
+}
+
+type registryTool struct {
+	name       string
+	server     Server
+	remote     RemoteTool
+	client     ToolClient
+	parameters tools.Schema
+	safety     tools.Safety
+}
+
+func newRegistryTool(server Server, remote RemoteTool, client ToolClient, options RegisterOptions) registryTool {
+	remote.Name = strings.TrimSpace(remote.Name)
+	name := registryToolName(server.Name, remote.Name)
+	permission := tools.PermissionPrompt
+	if isPersistentlyApproved(options.PermissionStore, server, remote.Name, defaultAutonomy(options.Autonomy)) {
+		permission = tools.PermissionAllow
+	}
+	return registryTool{
+		name:       name,
+		server:     server,
+		remote:     remote,
+		client:     client,
+		parameters: SchemaFromMCP(remote.InputSchema),
+		safety: tools.Safety{
+			SideEffect: tools.SideEffectNetwork,
+			Permission: permission,
+			Reason:     fmt.Sprintf("MCP tool %s/%s runs through the configured %s server.", server.Name, remote.Name, server.Type),
+		},
+	}
+}
+
+func (tool registryTool) Name() string {
+	return tool.name
+}
+
+func (tool registryTool) Description() string {
+	if strings.TrimSpace(tool.remote.Description) != "" {
+		return tool.remote.Description
+	}
+	return fmt.Sprintf("Call MCP tool %s/%s", tool.server.Name, tool.remote.Name)
+}
+
+func (tool registryTool) Parameters() tools.Schema {
+	return tool.parameters
+}
+
+func (tool registryTool) Safety() tools.Safety {
+	return tool.safety
+}
+
+func (tool registryTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	result, err := tool.client.CallTool(ctx, tool.remote.Name, args)
+	if err != nil {
+		return tools.Result{
+			Status: tools.StatusError,
+			Output: "Error: MCP tool " + tool.server.Name + "/" + tool.remote.Name + " failed: " + err.Error(),
+			Meta:   tool.meta(),
+		}
+	}
+	status := tools.StatusOK
+	if result.IsError {
+		status = tools.StatusError
+	}
+	output := TextContent(result.Content)
+	if output == "" {
+		output = "(empty MCP tool result)"
+	}
+	return tools.Result{
+		Status: status,
+		Output: output,
+		Meta:   tool.meta(),
+	}
+}
+
+func (tool registryTool) meta() map[string]string {
+	return map[string]string{
+		"mcp.server":   tool.server.Name,
+		"mcp.tool":     tool.remote.Name,
+		"mcp.identity": tool.server.Identity,
+	}
+}
+
+func registryToolName(serverName string, toolName string) string {
+	serverPart := sanitizeToolNamePart(serverName)
+	toolPart := sanitizeToolNamePart(toolName)
+	if toolPart == "" {
+		toolPart = "tool"
+	}
+	return "mcp_" + serverPart + "_" + toolPart
+}
+
+func sanitizeToolNamePart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	value = unsafeToolNameChars.ReplaceAllString(value, "_")
+	value = strings.Trim(value, "_")
+	if value == "" {
+		return "server"
+	}
+	return value
+}
+
+func isPersistentlyApproved(store *PermissionStore, server Server, toolName string, autonomy PermissionAutonomy) bool {
+	if store == nil {
+		return false
+	}
+	approved, err := store.IsToolPersistentlyApproved(CheckToolInput{
+		ServerName:        server.Name,
+		ServerIdentity:    server.Identity,
+		ToolName:          toolName,
+		RequestedAutonomy: autonomy,
+	})
+	return err == nil && approved
+}

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestRegisterToolsAddsPromptGatedMCPTools(t *testing.T) {
+	registry := tools.NewRegistry()
+	client := &fakeToolClient{listed: []RemoteTool{{
+		Name:        "lookup",
+		Description: "Lookup documentation",
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+		},
+	}}}
+
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}}, RegisterOptions{
+		ClientFactory: func(context.Context, Server) (ToolClient, error) {
+			return client, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTools() error = %v", err)
+	}
+	defer runtime.Close()
+
+	tool, ok := registry.Get("mcp_docs_lookup")
+	if !ok {
+		t.Fatal("expected mcp_docs_lookup to be registered")
+	}
+	if tool.Safety().Permission != tools.PermissionPrompt {
+		t.Fatalf("Safety.Permission = %q, want prompt", tool.Safety().Permission)
+	}
+	if tool.Safety().SideEffect != tools.SideEffectNetwork {
+		t.Fatalf("Safety.SideEffect = %q, want network", tool.Safety().SideEffect)
+	}
+
+	denied := registry.Run(context.Background(), "mcp_docs_lookup", map[string]any{"query": "zero"})
+	if denied.Status != tools.StatusError {
+		t.Fatalf("Run without approval = %#v, want permission error", denied)
+	}
+	approved := registry.RunWithOptions(context.Background(), "mcp_docs_lookup", map[string]any{"query": "zero"}, tools.RunOptions{PermissionGranted: true})
+	if approved.Status != tools.StatusOK || approved.Output != "lookup: zero" {
+		t.Fatalf("approved run = %#v, want lookup output", approved)
+	}
+	if approved.Meta["mcp.server"] != "docs" || approved.Meta["mcp.tool"] != "lookup" {
+		t.Fatalf("approved meta = %#v, want mcp server/tool", approved.Meta)
+	}
+	if client.closed != 0 {
+		t.Fatalf("client.closed before runtime close = %d, want 0", client.closed)
+	}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("Runtime.Close() error = %v", err)
+	}
+	if client.closed != 1 {
+		t.Fatalf("client.closed after runtime close = %d, want 1", client.closed)
+	}
+}
+
+func TestRegisterToolsMarksPersistentlyApprovedToolsAllow(t *testing.T) {
+	store, err := NewPermissionStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "permissions.json"),
+		Now:      func() time.Time { return time.Date(2026, 6, 5, 10, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	servers, err := NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantTool(GrantToolInput{
+		ServerName:     "docs",
+		ServerIdentity: servers[0].Identity,
+		ToolName:       "lookup",
+		MaxAutonomy:    AutonomyLow,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := tools.NewRegistry()
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}}, RegisterOptions{
+		PermissionStore: store,
+		Autonomy:        AutonomyLow,
+		ClientFactory: func(context.Context, Server) (ToolClient, error) {
+			return &fakeToolClient{listed: []RemoteTool{{Name: "lookup", Description: "Lookup documentation"}}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTools() error = %v", err)
+	}
+	defer runtime.Close()
+
+	tool, ok := registry.Get("mcp_docs_lookup")
+	if !ok {
+		t.Fatal("expected mcp_docs_lookup to be registered")
+	}
+	if tool.Safety().Permission != tools.PermissionAllow {
+		t.Fatalf("Safety.Permission = %q, want allow from persistent MCP grant", tool.Safety().Permission)
+	}
+}
+
+type fakeToolClient struct {
+	listed []RemoteTool
+	closed int
+}
+
+func (client *fakeToolClient) ListTools(context.Context) ([]RemoteTool, error) {
+	return client.listed, nil
+}
+
+func (client *fakeToolClient) CallTool(_ context.Context, _ string, args map[string]any) (CallToolResult, error) {
+	return CallToolResult{
+		Content: []Content{{Type: "text", Text: "lookup: " + args["query"].(string)}},
+	}, nil
+}
+
+func (client *fakeToolClient) Close() error {
+	client.closed++
+	return nil
+}

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"math"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func SchemaFromMCP(input map[string]any) tools.Schema {
+	schema := tools.Schema{
+		Type:                 firstString(input["type"], "object"),
+		Properties:           map[string]tools.PropertySchema{},
+		AdditionalProperties: boolValue(input["additionalProperties"], false),
+	}
+
+	for _, required := range stringSlice(input["required"]) {
+		schema.Required = append(schema.Required, required)
+	}
+
+	if properties, ok := input["properties"].(map[string]any); ok {
+		for name, raw := range properties {
+			propertyMap, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			schema.Properties[name] = propertyFromMCP(propertyMap)
+		}
+	}
+	if len(schema.Properties) == 0 {
+		schema.Properties = nil
+	}
+	return schema
+}
+
+func propertyFromMCP(input map[string]any) tools.PropertySchema {
+	property := tools.PropertySchema{
+		Type:        firstString(input["type"], "string"),
+		Description: stringValue(input["description"]),
+		Enum:        stringSlice(input["enum"]),
+		Default:     input["default"],
+	}
+	if property.Type == "number" {
+		property.Type = "number"
+	}
+	if min, ok := intValue(input["minimum"]); ok {
+		property.Minimum = &min
+	}
+	if max, ok := intValue(input["maximum"]); ok {
+		property.Maximum = &max
+	}
+	return property
+}
+
+func firstString(value any, fallback string) string {
+	if text := stringValue(value); text != "" {
+		return text
+	}
+	if values, ok := value.([]any); ok {
+		for _, item := range values {
+			if text := stringValue(item); text != "" {
+				return text
+			}
+		}
+	}
+	return fallback
+}
+
+func stringValue(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return ""
+	}
+}
+
+func stringSlice(value any) []string {
+	switch typed := value.(type) {
+	case []string:
+		return append([]string{}, typed...)
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text := stringValue(item); text != "" {
+				values = append(values, text)
+			}
+		}
+		return values
+	default:
+		return nil
+	}
+}
+
+func boolValue(value any, fallback bool) bool {
+	if typed, ok := value.(bool); ok {
+		return typed
+	}
+	return fallback
+}
+
+func intValue(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		if math.Trunc(typed) == typed {
+			return int(typed), true
+		}
+	}
+	return 0, false
+}

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -14,9 +14,7 @@ func SchemaFromMCP(input map[string]any) tools.Schema {
 		AdditionalProperties: boolValue(input["additionalProperties"], false),
 	}
 
-	for _, required := range stringSlice(input["required"]) {
-		schema.Required = append(schema.Required, required)
-	}
+	schema.Required = append(schema.Required, stringSlice(input["required"])...)
 
 	if properties, ok := input["properties"].(map[string]any); ok {
 		for name, raw := range properties {
@@ -39,9 +37,6 @@ func propertyFromMCP(input map[string]any) tools.PropertySchema {
 		Description: stringValue(input["description"]),
 		Enum:        stringSlice(input["enum"]),
 		Default:     input["default"],
-	}
-	if property.Type == "number" {
-		property.Type = "number"
 	}
 	if min, ok := intValue(input["minimum"]); ok {
 		property.Minimum = &min


### PR DESCRIPTION
## Summary
- Adds Go config support for `mcp.servers` and root-level `mcpServers`, including user/project merge precedence and a provider-free `ResolveMCP` path for tooling discovery.
- Adds the Go MCP stdio JSON-RPC client, server normalization/identity handling, schema conversion, and registry bridge that exposes remote MCP tools as `mcp_<server>_<tool>` Zero tools.
- Wires MCP tools into the Go TUI/exec registries and adds `zero mcp tools list` with JSON/text output while preserving `zero exec --list-tools` without provider resolution.

## PRD Alignment
- Covers the M4 Go MCP client/tool-registry slice from the latest Zero work-split PRD: stdio MCP discovery, stable server identity, permission-store aware tool safety, and CLI visibility for configured MCP tools.
- HTTP and SSE server definitions are normalized and validated in config, but runnable HTTP/SSE transports are intentionally left for a follow-up slice.

## Validation
- `go test ./internal/config ./internal/mcp ./internal/cli`
- `go test -count=1 ./...`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `npx --yes bun run smoke:go`
- Direct local smoke with a disposable stdio MCP server: `zero mcp tools list --json` and `zero exec --list-tools --skip-permissions-unsafe --enabled-tools mcp_docs_lookup`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP tool integration for the CLI with registration, runtime lifecycle, permission gating, and a unified tool listing.
  * New "mcp tools" command with text and --json listing modes.

* **Bug Fixes**
  * Improved CLI error/output handling and logging for MCP tool listing and runtime close failures.

* **Tests**
  * Extensive tests covering MCP config resolution, client protocol, registration, listing, schema conversion, and runtime shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->