### PR TITLE
[codex] add Go MCP server mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ zero models list [--provider anthropic]     # inspect the model registry
 zero search "<query>" [--json --session <id> --type <event>]   # search local sessions
 zero doctor [--connectivity] [--json]        # health checks
 zero config [--json]                          # inspect resolved configuration
+zero serve --mcp [-C <path>]                  # expose Zero read-only tools over MCP stdio
 zero update --check [--json]                  # check for a newer release
 ```
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -136,6 +136,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runHooks(args[1:], stdout, stderr, deps)
 	case "mcp":
 		return runMCP(args[1:], stdout, stderr, deps)
+	case "serve":
+		return runServe(args[1:], stdout, stderr, deps)
 	default:
 		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
 			return 1
@@ -277,6 +279,7 @@ Commands:
   plugins    Inspect local Zero plugin manifests
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings
+  serve      Run Zero protocol servers
   help       Show this help
   version    Print version
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -214,6 +214,7 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"plugin"},
 		{"hooks"},
 		{"mcp"},
+		{"serve"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			var stdout bytes.Buffer
@@ -260,6 +261,7 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"plugins",
 		"hooks",
 		"mcp",
+		"serve",
 		"--version",
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type serveOptions struct {
+	mcp              bool
+	cwd              string
+	allowUnsafeTools bool
+}
+
+func runServe(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseServeArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeServeHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if !options.mcp {
+		return writeExecUsageError(stderr, "serve requires --mcp. Use `zero serve --mcp`.")
+	}
+
+	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	registry := newServeRegistry(workspaceRoot, options.allowUnsafeTools)
+	if options.allowUnsafeTools {
+		if _, err := fmt.Fprintln(stderr, "[zero] Unsafe MCP server tools enabled because --allow-unsafe-tools was passed."); err != nil {
+			return exitCrash
+		}
+	}
+
+	err = mcp.Serve(context.Background(), deps.stdin, stdout, registry, mcp.ServeOptions{
+		Name:              "zero",
+		Version:           version,
+		PermissionGranted: options.allowUnsafeTools,
+	})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	return exitSuccess
+}
+
+func newServeRegistry(workspaceRoot string, allowUnsafeTools bool) *tools.Registry {
+	registry := tools.NewRegistry()
+	toolset := tools.CoreReadOnlyTools(workspaceRoot)
+	if allowUnsafeTools {
+		toolset = tools.CoreTools(workspaceRoot)
+	}
+	for _, tool := range toolset {
+		registry.Register(tool)
+	}
+	return registry
+}
+
+func parseServeArgs(args []string) (serveOptions, bool, error) {
+	options := serveOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--mcp":
+			options.mcp = true
+		case arg == "--allow-unsafe-tools":
+			options.allowUnsafeTools = true
+		case arg == "-C" || arg == "--cwd":
+			index++
+			if index >= len(args) {
+				return options, false, execUsageError{arg + " requires a path"}
+			}
+			options.cwd = args[index]
+		case strings.HasPrefix(arg, "--cwd="):
+			options.cwd = strings.TrimPrefix(arg, "--cwd=")
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown serve flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func writeServeHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero serve --mcp [flags]
+
+Starts Zero as an MCP stdio server.
+
+Flags:
+      --mcp                   Run the MCP stdio server
+  -C, --cwd <path>            Set the workspace directory
+      --allow-unsafe-tools    Expose write and shell tools to the MCP host
+  -h, --help                  Show this help
+`)
+	return err
+}

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRunServeMCPListsReadOnlyToolsByDefault(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"serve", "--mcp"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		stdin: bytes.NewReader(serveMCPInput(t)),
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code 0, got %d; stderr=%q", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"read_file", "list_directory", "glob", "grep"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected MCP output to contain %q, got %q", want, output)
+		}
+	}
+	for _, unwanted := range []string{"write_file", "apply_patch", "bash"} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("did not expect default MCP output to contain %q: %q", unwanted, output)
+		}
+	}
+}
+
+func TestRunServeMCPAllowsUnsafeToolsWithExplicitFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"serve", "--mcp", "--allow-unsafe-tools"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		stdin: bytes.NewReader(serveMCPInput(t)),
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code 0, got %d; stderr=%q", exitCode, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"read_file", "write_file", "apply_patch", "bash"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected unsafe MCP output to contain %q, got %q", want, output)
+		}
+	}
+	if !strings.Contains(stderr.String(), "Unsafe MCP server tools enabled") {
+		t.Fatalf("expected unsafe warning on stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunServeRequiresMCPMode(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"serve"}, &stdout, &stderr, appDeps{})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "serve requires --mcp") {
+		t.Fatalf("expected usage error, got %q", stderr.String())
+	}
+}
+
+func serveMCPInput(t *testing.T) []byte {
+	t.Helper()
+
+	var input bytes.Buffer
+	writeServeMCPMessage(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params":  map[string]any{},
+	})
+	writeServeMCPMessage(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+		"params":  map[string]any{},
+	})
+	writeServeMCPMessage(t, &input, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	})
+	return input.Bytes()
+}
+
+func writeServeMCPMessage(t *testing.T, buffer *bytes.Buffer, message map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(message)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(buffer, "Content-Length: %d\r\n\r\n%s", len(body), body); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -31,6 +31,52 @@ func SchemaFromMCP(input map[string]any) tools.Schema {
 	return schema
 }
 
+func SchemaToMCP(schema tools.Schema) map[string]any {
+	schemaType := strings.TrimSpace(schema.Type)
+	if schemaType == "" {
+		schemaType = "object"
+	}
+	output := map[string]any{
+		"type":                 schemaType,
+		"additionalProperties": schema.AdditionalProperties,
+	}
+	if len(schema.Required) > 0 {
+		output["required"] = append([]string{}, schema.Required...)
+	}
+	if len(schema.Properties) > 0 {
+		properties := make(map[string]any, len(schema.Properties))
+		for name, property := range schema.Properties {
+			properties[name] = propertyToMCP(property)
+		}
+		output["properties"] = properties
+	}
+	return output
+}
+
+func propertyToMCP(property tools.PropertySchema) map[string]any {
+	propertyType := strings.TrimSpace(property.Type)
+	if propertyType == "" {
+		propertyType = "string"
+	}
+	output := map[string]any{"type": propertyType}
+	if property.Description != "" {
+		output["description"] = property.Description
+	}
+	if len(property.Enum) > 0 {
+		output["enum"] = append([]string{}, property.Enum...)
+	}
+	if property.Default != nil {
+		output["default"] = property.Default
+	}
+	if property.Minimum != nil {
+		output["minimum"] = *property.Minimum
+	}
+	if property.Maximum != nil {
+		output["maximum"] = *property.Maximum
+	}
+	return output
+}
+
 func propertyFromMCP(input map[string]any) tools.PropertySchema {
 	property := tools.PropertySchema{
 		Type:        firstString(input["type"], "string"),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,161 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const defaultProtocolVersion = "2024-11-05"
+
+const (
+	jsonRPCMethodNotFound = -32601
+	jsonRPCInvalidParams  = -32602
+	jsonRPCInternalError  = -32603
+)
+
+type ServeOptions struct {
+	Name              string
+	Version           string
+	PermissionGranted bool
+}
+
+func Serve(ctx context.Context, input io.Reader, output io.Writer, registry *tools.Registry, options ServeOptions) error {
+	if registry == nil {
+		return errors.New("MCP server tool registry is required")
+	}
+	reader := newMessageReader(input)
+	writer := newMessageWriter(output)
+	server := toolServer{
+		registry: registry,
+		options:  options.withDefaults(),
+		writer:   writer,
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		message, err := reader.read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		if err := server.handle(ctx, message); err != nil {
+			return err
+		}
+	}
+}
+
+func (options ServeOptions) withDefaults() ServeOptions {
+	if strings.TrimSpace(options.Name) == "" {
+		options.Name = "zero"
+	}
+	if strings.TrimSpace(options.Version) == "" {
+		options.Version = "dev"
+	}
+	return options
+}
+
+type toolServer struct {
+	registry *tools.Registry
+	options  ServeOptions
+	writer   *messageWriter
+}
+
+func (server toolServer) handle(ctx context.Context, message rpcMessage) error {
+	if message.ID == nil && strings.HasPrefix(message.Method, "notifications/") {
+		return nil
+	}
+	if message.ID == nil {
+		return nil
+	}
+
+	switch message.Method {
+	case "initialize":
+		return server.writeResult(message.ID, map[string]any{
+			"protocolVersion": defaultProtocolVersion,
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo": map[string]any{
+				"name":    server.options.Name,
+				"version": server.options.Version,
+			},
+		})
+	case "tools/list":
+		return server.writeResult(message.ID, map[string]any{
+			"tools": server.remoteTools(),
+		})
+	case "tools/call":
+		result, err := server.callTool(ctx, message.Params)
+		if err != nil {
+			return server.writeError(message.ID, jsonRPCInvalidParams, err.Error())
+		}
+		return server.writeResult(message.ID, result)
+	default:
+		return server.writeError(message.ID, jsonRPCMethodNotFound, "method not found")
+	}
+}
+
+func (server toolServer) remoteTools() []RemoteTool {
+	registered := server.registry.All()
+	sort.Slice(registered, func(left int, right int) bool {
+		return registered[left].Name() < registered[right].Name()
+	})
+
+	remote := make([]RemoteTool, 0, len(registered))
+	for _, tool := range registered {
+		remote = append(remote, RemoteTool{
+			Name:        tool.Name(),
+			Description: tool.Description(),
+			InputSchema: SchemaToMCP(tool.Parameters()),
+		})
+	}
+	return remote
+}
+
+func (server toolServer) callTool(ctx context.Context, rawParams json.RawMessage) (CallToolResult, error) {
+	var params struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments"`
+	}
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return CallToolResult{}, fmt.Errorf("invalid tools/call params: %w", err)
+		}
+	}
+	params.Name = strings.TrimSpace(params.Name)
+	if params.Name == "" {
+		return CallToolResult{}, errors.New("tools/call requires a tool name")
+	}
+	if params.Arguments == nil {
+		params.Arguments = map[string]any{}
+	}
+
+	result := server.registry.RunWithOptions(ctx, params.Name, params.Arguments, tools.RunOptions{
+		PermissionGranted: server.options.PermissionGranted,
+	})
+	return CallToolResult{
+		Content: []Content{{Type: "text", Text: result.Output}},
+		IsError: result.Status != tools.StatusOK,
+	}, nil
+}
+
+func (server toolServer) writeResult(id any, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return server.writeError(id, jsonRPCInternalError, err.Error())
+	}
+	return server.writer.write(rpcMessage{ID: id, Result: raw})
+}
+
+func (server toolServer) writeError(id any, code int, message string) error {
+	return server.writer.write(rpcMessage{ID: id, Error: &rpcError{Code: code, Message: message}})
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,247 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestServeListsAndCallsRegistryTools(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(serverFakeTool{
+		name:        "lookup",
+		description: "Lookup documentation",
+		parameters: tools.Schema{
+			Type: "object",
+			Properties: map[string]tools.PropertySchema{
+				"query": {Type: "string", Description: "Search query"},
+			},
+			Required:             []string{"query"},
+			AdditionalProperties: false,
+		},
+		safety: tools.Safety{SideEffect: tools.SideEffectRead, Permission: tools.PermissionAllow, Reason: "test"},
+		run: func(args map[string]any) tools.Result {
+			return tools.Result{Status: tools.StatusOK, Output: "lookup: " + strings.TrimSpace(args["query"].(string))}
+		},
+	})
+
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{ID: 1, Method: "initialize"})
+	writeServerTestMessage(t, &input, rpcMessage{Method: "notifications/initialized"})
+	writeServerTestMessage(t, &input, rpcMessage{ID: 2, Method: "tools/list"})
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     3,
+		Method: "tools/call",
+		Params: mustRaw(map[string]any{
+			"name":      "lookup",
+			"arguments": map[string]any{"query": "zero"},
+		}),
+	})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, registry, ServeOptions{Name: "zero-test", Version: "1.2.3"}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	reader := newMessageReader(&output)
+	initialize := readServerTestMessage(t, reader)
+	var initResult struct {
+		ProtocolVersion string         `json:"protocolVersion"`
+		Capabilities    map[string]any `json:"capabilities"`
+		ServerInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"serverInfo"`
+	}
+	decodeServerTestResult(t, initialize, &initResult)
+	if initResult.ProtocolVersion != defaultProtocolVersion || initResult.ServerInfo.Name != "zero-test" || initResult.ServerInfo.Version != "1.2.3" {
+		t.Fatalf("initialize result = %#v", initResult)
+	}
+	if _, ok := initResult.Capabilities["tools"]; !ok {
+		t.Fatalf("initialize capabilities = %#v, want tools", initResult.Capabilities)
+	}
+
+	list := readServerTestMessage(t, reader)
+	var listResult struct {
+		Tools []RemoteTool `json:"tools"`
+	}
+	decodeServerTestResult(t, list, &listResult)
+	if len(listResult.Tools) != 1 || listResult.Tools[0].Name != "lookup" || listResult.Tools[0].Description != "Lookup documentation" {
+		t.Fatalf("listed tools = %#v", listResult.Tools)
+	}
+	properties, ok := listResult.Tools[0].InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("input schema = %#v, want properties", listResult.Tools[0].InputSchema)
+	}
+	if _, ok := properties["query"]; !ok {
+		t.Fatalf("properties = %#v, want query", properties)
+	}
+
+	call := readServerTestMessage(t, reader)
+	var callResult CallToolResult
+	decodeServerTestResult(t, call, &callResult)
+	if callResult.IsError {
+		t.Fatalf("call result IsError = true: %#v", callResult)
+	}
+	if got := TextContent(callResult.Content); got != "lookup: zero" {
+		t.Fatalf("call result text = %q, want lookup: zero", got)
+	}
+}
+
+func TestServeUsesToolApprovalGate(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(serverFakeTool{
+		name:        "write_file",
+		description: "Write a file",
+		parameters:  tools.Schema{Type: "object", AdditionalProperties: false},
+		safety:      tools.Safety{SideEffect: tools.SideEffectWrite, Permission: tools.PermissionPrompt, Reason: "writes files"},
+		run: func(map[string]any) tools.Result {
+			return tools.Result{Status: tools.StatusOK, Output: "wrote"}
+		},
+	})
+
+	denied := callServerTool(t, registry, ServeOptions{}, "write_file", map[string]any{})
+	if !denied.IsError || !strings.Contains(TextContent(denied.Content), "Permission required for write_file") {
+		t.Fatalf("denied result = %#v, want permission error", denied)
+	}
+
+	allowed := callServerTool(t, registry, ServeOptions{PermissionGranted: true}, "write_file", map[string]any{})
+	if allowed.IsError || TextContent(allowed.Content) != "wrote" {
+		t.Fatalf("allowed result = %#v, want success", allowed)
+	}
+}
+
+func TestServeReportsUnknownMethods(t *testing.T) {
+	registry := tools.NewRegistry()
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{ID: 42, Method: "missing/method"})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, registry, ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	message := readServerTestMessage(t, newMessageReader(&output))
+	if message.Error == nil || message.Error.Code != jsonRPCMethodNotFound {
+		t.Fatalf("error = %#v, want method not found", message.Error)
+	}
+}
+
+func TestSchemaToMCPInputSchema(t *testing.T) {
+	minimum := 1
+	maximum := 10
+	schema := SchemaToMCP(tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"query": {
+				Type:        "string",
+				Description: "Search query",
+				Enum:        []string{"zero", "docs"},
+			},
+			"limit": {
+				Type:    "integer",
+				Default: 5,
+				Minimum: &minimum,
+				Maximum: &maximum,
+			},
+		},
+		Required:             []string{"query"},
+		AdditionalProperties: false,
+	})
+
+	if schema["type"] != "object" || schema["additionalProperties"] != false {
+		t.Fatalf("schema root = %#v", schema)
+	}
+	required, ok := schema["required"].([]string)
+	if !ok || len(required) != 1 || required[0] != "query" {
+		t.Fatalf("required = %#v, want query", schema["required"])
+	}
+	properties := schema["properties"].(map[string]any)
+	query := properties["query"].(map[string]any)
+	if query["description"] != "Search query" {
+		t.Fatalf("query property = %#v", query)
+	}
+	limit := properties["limit"].(map[string]any)
+	if limit["default"] != 5 || limit["minimum"] != 1 || limit["maximum"] != 10 {
+		t.Fatalf("limit property = %#v", limit)
+	}
+}
+
+type serverFakeTool struct {
+	name        string
+	description string
+	parameters  tools.Schema
+	safety      tools.Safety
+	run         func(map[string]any) tools.Result
+}
+
+func (tool serverFakeTool) Name() string {
+	return tool.name
+}
+
+func (tool serverFakeTool) Description() string {
+	return tool.description
+}
+
+func (tool serverFakeTool) Parameters() tools.Schema {
+	return tool.parameters
+}
+
+func (tool serverFakeTool) Safety() tools.Safety {
+	return tool.safety
+}
+
+func (tool serverFakeTool) Run(_ context.Context, args map[string]any) tools.Result {
+	return tool.run(args)
+}
+
+func callServerTool(t *testing.T, registry *tools.Registry, options ServeOptions, name string, args map[string]any) CallToolResult {
+	t.Helper()
+
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     1,
+		Method: "tools/call",
+		Params: mustRaw(map[string]any{
+			"name":      name,
+			"arguments": args,
+		}),
+	})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, registry, options); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	var result CallToolResult
+	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+	return result
+}
+
+func writeServerTestMessage(t *testing.T, buffer *bytes.Buffer, message rpcMessage) {
+	t.Helper()
+	if err := newMessageWriter(buffer).write(message); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readServerTestMessage(t *testing.T, reader *messageReader) rpcMessage {
+	t.Helper()
+	message, err := reader.read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return message
+}
+
+func decodeServerTestResult(t *testing.T, message rpcMessage, target any) {
+	t.Helper()
+	if message.Error != nil {
+		t.Fatalf("message error = %#v", message.Error)
+	}
+	if err := json.Unmarshal(message.Result, target); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, string(message.Result))
+	}
+}


### PR DESCRIPTION
## Summary
- Add a Go MCP stdio server that handles initialize, tools/list, and tools/call with JSON-RPC framing.
- Export Zero tool schemas to MCP input schemas and run tool calls through the existing registry permission path.
- Wire `zero serve --mcp` into the CLI with read-only tools exposed by default and an explicit `--allow-unsafe-tools` opt-in for write/shell tools.
- Document the new command and cover the protocol, approval gate, CLI defaults, unsafe opt-in, and help routing with tests.

Reviewers: @vasanthdev2004 @anandh8x

## Validation
- `go test -count=1 ./...`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `./zero --help`
- `./zero serve --help`
- MCP protocol smoke against `./zero serve --mcp`, confirming only read-only tools are listed by default
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `zero serve --mcp` command to expose Zero's read-only tools over MCP (Model Context Protocol) stdio, enabling integration with MCP clients.
  * Added `--allow-unsafe-tools` flag to enable write operations through MCP.
  * Added `-C/--cwd` option to specify the workspace directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->