### PR TITLE
feat: add TUI session controls

### DIFF
--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -112,12 +112,18 @@ func (m model) handleModelCommand(args string) (model, string) {
 	m.provider = nextProvider
 	m.providerName = displayValue(nextProfile.Name, string(metadata.ProviderKind))
 	m.modelName = entry.ID
+	effortLine := "effort: " + m.effortDisplay()
+	if m.reasoningEffort != "" && !reasoningEffortAllowed(registry.ReasoningEfforts(entry.ID), m.reasoningEffort) {
+		m.reasoningEffort = ""
+		effortLine = "effort: auto (unsupported preference reset)"
+	}
 	return m, strings.Join([]string{
 		"Model",
 		"Switched model for this TUI session.",
 		"model: " + entry.ID,
 		"provider: " + string(metadata.ProviderKind),
 		"api model: " + metadata.APIModel,
+		effortLine,
 	}, "\n")
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -21,6 +21,9 @@ const (
 	commandPlan
 	commandSearch
 	commandResume
+	commandCompact
+	commandEffort
+	commandStyle
 	commandTheme
 	commandInputStyle
 	commandUnknown
@@ -116,6 +119,27 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "List recent sessions or show resume guidance.",
 		kind:        commandResume,
+	},
+	{
+		name:        "/compact",
+		usage:       "/compact [status]",
+		group:       commandGroupSession,
+		description: "Show or request transcript compaction shell status.",
+		kind:        commandCompact,
+	},
+	{
+		name:        "/effort",
+		usage:       "/effort [list|low|medium|high|auto]",
+		group:       commandGroupModel,
+		description: "Show or set reasoning effort for supported models.",
+		kind:        commandEffort,
+	},
+	{
+		name:        "/style",
+		usage:       "/style [list|balanced|concise|explanatory|review]",
+		group:       commandGroupSession,
+		description: "Show or set the response style preference.",
+		kind:        commandStyle,
 	},
 	{
 		name:        "/doctor",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/usage"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -25,33 +27,42 @@ var (
 )
 
 const tuiToolOutputLimit = 240
+const defaultResponseStyle = "balanced"
 
 type model struct {
-	ctx             context.Context
-	cwd             string
-	providerName    string
-	modelName       string
-	providerProfile config.ProviderProfile
-	provider        zeroruntime.Provider
-	newProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
-	registry        *tools.Registry
-	sessionStore    *sessions.Store
-	agentOptions    agent.Options
-	permissionMode  agent.PermissionMode
-	transcript      []transcriptRow
-	input           textinput.Model
-	pending         bool
-	exiting         bool
-	runCancel       context.CancelFunc
-	runID           int
-	activeRunID     int
-	now             func() time.Time
+	ctx              context.Context
+	cwd              string
+	providerName     string
+	modelName        string
+	providerProfile  config.ProviderProfile
+	provider         zeroruntime.Provider
+	newProvider      func(config.ProviderProfile) (zeroruntime.Provider, error)
+	registry         *tools.Registry
+	sessionStore     *sessions.Store
+	usageTracker     *usage.Tracker
+	agentOptions     agent.Options
+	permissionMode   agent.PermissionMode
+	reasoningEffort  modelregistry.ReasoningEffort
+	responseStyle    string
+	compactRequests  int
+	unpricedRequests int
+	unpricedTokens   int
+	transcript       []transcriptRow
+	input            textinput.Model
+	pending          bool
+	exiting          bool
+	runCancel        context.CancelFunc
+	runID            int
+	activeRunID      int
+	now              func() time.Time
 }
 
 type agentResponseMsg struct {
-	runID int
-	rows  []transcriptRow
-	err   error
+	runID        int
+	rows         []transcriptRow
+	usageEvents  []zeroruntime.Usage
+	usageModelID string
+	err          error
 }
 
 func newModel(ctx context.Context, options Options) model {
@@ -76,6 +87,10 @@ func newModel(ctx context.Context, options Options) model {
 	sessionStore := options.SessionStore
 	if sessionStore == nil {
 		sessionStore = sessions.NewStore(sessions.StoreOptions{})
+	}
+	usageTracker := options.UsageTracker
+	if usageTracker == nil {
+		usageTracker = usage.NewTracker(usage.TrackerOptions{})
 	}
 
 	permissionMode := options.PermissionMode
@@ -103,6 +118,9 @@ func newModel(ctx context.Context, options Options) model {
 		sessionStore:    sessionStore,
 		agentOptions:    options.AgentOptions,
 		permissionMode:  permissionMode,
+		reasoningEffort: options.ReasoningEffort,
+		responseStyle:   defaultedResponseStyle(options.ResponseStyle),
+		usageTracker:    usageTracker,
 		transcript:      initialTranscript(),
 		input:           input,
 		now:             time.Now,
@@ -137,6 +155,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pending = false
 		m.runCancel = nil
 		m.activeRunID = 0
+		for _, event := range msg.usageEvents {
+			var usageRows []transcriptRow
+			m, usageRows = m.recordUsageEvent(msg.usageModelID, event)
+			for _, row := range usageRows {
+				m.transcript = appendRow(m.transcript, row.kind, row.text)
+			}
+		}
 		for _, row := range msg.rows {
 			m.transcript = appendRow(m.transcript, row.kind, row.text)
 		}
@@ -231,6 +256,21 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	case commandResume:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.resumeText(command.text)})
 		return m, nil
+	case commandCompact:
+		text := ""
+		m, text = m.handleCompactCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		return m, nil
+	case commandEffort:
+		text := ""
+		m, text = m.handleEffortCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		return m, nil
+	case commandStyle:
+		text := ""
+		m, text = m.handleStyleCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		return m, nil
 	case commandTheme, commandInputStyle:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
 			kind: actionAppendSystem,
@@ -275,6 +315,8 @@ func (m *model) cancelRun() {
 func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cmd {
 	return func() tea.Msg {
 		rows := []transcriptRow{}
+		usageEvents := []zeroruntime.Usage{}
+		usageModelID := m.modelName
 		options := m.agentOptions
 		options.Registry = m.registry
 		options.PermissionMode = m.permissionMode
@@ -298,12 +340,20 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 			}
 		}
 
+		onUsage := options.OnUsage
+		options.OnUsage = func(event zeroruntime.Usage) {
+			usageEvents = append(usageEvents, event)
+			if onUsage != nil {
+				onUsage(event)
+			}
+		}
+
 		result, err := agent.Run(runCtx, prompt, m.provider, options)
 		if err != nil {
-			return agentResponseMsg{runID: runID, rows: rows, err: err}
+			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, err: err}
 		}
 		rows = append(rows, transcriptRow{kind: rowAssistant, text: result.FinalAnswer})
-		return agentResponseMsg{runID: runID, rows: rows}
+		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID}
 	}
 }
 
@@ -370,6 +420,10 @@ func (m model) contextText() string {
 		"provider: " + displayValue(m.providerName, "none"),
 		"model: " + displayValue(m.modelName, "none"),
 		"permission mode: " + string(m.permissionMode),
+		"effort: " + m.effortDisplay(),
+		"style: " + m.responseStyle,
+		"usage: " + m.usageSummaryText(),
+		"compaction: " + m.compactionStatus(),
 		fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
 		"session root: " + displayValue(m.sessionStore.RootDir, "unknown"),
 		fmt.Sprintf("tools: %d", len(m.registry.All())),
@@ -398,95 +452,4 @@ func (m model) debugText() string {
 		"active run: " + fmt.Sprint(m.activeRunID),
 		"Debug mode is not wired in Go TUI yet.",
 	}, "\n")
-}
-
-func displayValue(value string, fallback string) string {
-	if value == "" {
-		return fallback
-	}
-	return value
-}
-
-func (m model) runState() string {
-	if m.pending {
-		return "running"
-	}
-	return "ready"
-}
-
-func shellOnlyCommandText(name string) string {
-	return fmt.Sprintf("%s is registered in the Go TUI shell but is not wired yet.", name)
-}
-
-func helpText() string {
-	return "Commands:\n" + strings.Join(formatCommandHelpLines(), "\n") + "\nSubmit text to ask the assistant."
-}
-
-const defaultCommandFooterText = "/help  /model  /provider  /context  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
-
-func commandFooterText() string {
-	return formatCommandFooterText(commandDefinitions, false)
-}
-
-func (m model) footerText() string {
-	return formatCommandFooterText(commandDefinitions, m.pending)
-}
-
-func formatCommandFooterText(commands []commandDefinition, pending bool) string {
-	if len(commands) == 0 {
-		return defaultCommandFooterText
-	}
-
-	namesByKind := make(map[commandKind]string, len(commands))
-	for _, command := range commands {
-		namesByKind[command.kind] = command.name
-	}
-
-	featured := []commandKind{
-		commandHelp,
-		commandModel,
-		commandProvider,
-		commandContext,
-		commandTools,
-		commandPermissions,
-		commandClear,
-		commandExit,
-	}
-	parts := make([]string, 0, len(featured)+2)
-	for _, kind := range featured {
-		name := namesByKind[kind]
-		if name != "" {
-			parts = append(parts, name)
-		}
-	}
-	if len(parts) == 0 {
-		return defaultCommandFooterText
-	}
-
-	if pending {
-		parts = append(parts, "Esc cancel")
-	} else {
-		parts = append(parts, "Esc clear")
-	}
-	parts = append(parts, "Ctrl+C quit")
-	return strings.Join(parts, "  ")
-}
-
-func renderRow(row transcriptRow) string {
-	switch row.kind {
-	case rowWelcome:
-		return row.text
-	case rowUser:
-		return "user: " + row.text
-	case rowAssistant:
-		return "assistant: " + row.text
-	case rowToolCall:
-		return row.text
-	case rowToolResult:
-		return row.text
-	case rowError:
-		return "error: " + row.text
-	default:
-		return row.text
-	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -53,6 +53,9 @@ func TestParseCommand(t *testing.T) {
 		{input: "/find needle", kind: commandSearch, text: "needle"},
 		{input: "/resume", kind: commandResume},
 		{input: "/sessions", kind: commandResume},
+		{input: "/compact", kind: commandCompact},
+		{input: "/effort high", kind: commandEffort, text: "high"},
+		{input: "/style concise", kind: commandStyle, text: "concise"},
 		{input: "/debug-mode", kind: commandDebug},
 		{input: "hello zero", kind: commandPrompt, text: "hello zero"},
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -133,7 +133,7 @@ func TestInitialRenderContainsHeaderInputAndFooter(t *testing.T) {
 func TestCommandFooterTextUsesRegistryEntries(t *testing.T) {
 	footer := commandFooterText()
 
-	for _, command := range []string{"/help", "/model", "/provider", "/context", "/tools", "/permissions", "/clear", "/exit"} {
+	for _, command := range []string{"/help", "/model", "/provider", "/context", "/compact", "/effort", "/style", "/tools", "/permissions", "/clear", "/exit"} {
 		assertContains(t, footer, command)
 	}
 	assertContains(t, footer, "Esc clear")
@@ -143,7 +143,7 @@ func TestCommandFooterTextUsesRegistryEntries(t *testing.T) {
 func TestCommandFooterTextFallsBackWhenRegistryIsEmpty(t *testing.T) {
 	footer := formatCommandFooterText(nil, false)
 
-	for _, command := range []string{"/help", "/model", "/provider", "/context", "/tools", "/permissions", "/clear", "/exit"} {
+	for _, command := range []string{"/help", "/model", "/provider", "/context", "/compact", "/effort", "/style", "/tools", "/permissions", "/clear", "/exit"} {
 		assertContains(t, footer, command)
 	}
 	assertContains(t, footer, "Esc clear")

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -3,8 +3,10 @@ package tui
 import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/usage"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -18,7 +20,10 @@ type Options struct {
 	NewProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
 	Registry        *tools.Registry
 	SessionStore    *sessions.Store
+	UsageTracker    *usage.Tracker
 
-	AgentOptions   agent.Options
-	PermissionMode agent.PermissionMode
+	AgentOptions    agent.Options
+	PermissionMode  agent.PermissionMode
+	ReasoningEffort modelregistry.ReasoningEffort
+	ResponseStyle   string
 }

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1,0 +1,102 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+func displayValue(value string, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func (m model) runState() string {
+	if m.pending {
+		return "running"
+	}
+	return "ready"
+}
+
+func shellOnlyCommandText(name string) string {
+	return fmt.Sprintf("%s is registered in the Go TUI shell but is not wired yet.", name)
+}
+
+func helpText() string {
+	return "Commands:\n" + strings.Join(formatCommandHelpLines(), "\n") + "\nSubmit text to ask the assistant."
+}
+
+const defaultCommandFooterText = "/help  /model  /provider  /context  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
+
+func commandFooterText() string {
+	return formatCommandFooterText(commandDefinitions, false)
+}
+
+func (m model) footerText() string {
+	return strings.Join([]string{
+		m.runState(),
+		displayValue(m.modelName, "model:none"),
+		m.usageSummaryText(),
+		formatCommandFooterText(commandDefinitions, m.pending),
+	}, "  ")
+}
+
+func formatCommandFooterText(commands []commandDefinition, pending bool) string {
+	if len(commands) == 0 {
+		return defaultCommandFooterText
+	}
+
+	namesByKind := make(map[commandKind]string, len(commands))
+	for _, command := range commands {
+		namesByKind[command.kind] = command.name
+	}
+
+	featured := []commandKind{
+		commandHelp,
+		commandModel,
+		commandProvider,
+		commandContext,
+		commandTools,
+		commandPermissions,
+		commandClear,
+		commandExit,
+	}
+	parts := make([]string, 0, len(featured)+2)
+	for _, kind := range featured {
+		name := namesByKind[kind]
+		if name != "" {
+			parts = append(parts, name)
+		}
+	}
+	if len(parts) == 0 {
+		return defaultCommandFooterText
+	}
+
+	if pending {
+		parts = append(parts, "Esc cancel")
+	} else {
+		parts = append(parts, "Esc clear")
+	}
+	parts = append(parts, "Ctrl+C quit")
+	return strings.Join(parts, "  ")
+}
+
+func renderRow(row transcriptRow) string {
+	switch row.kind {
+	case rowWelcome:
+		return row.text
+	case rowUser:
+		return "user: " + row.text
+	case rowAssistant:
+		return "assistant: " + row.text
+	case rowToolCall:
+		return row.text
+	case rowToolResult:
+		return row.text
+	case rowError:
+		return "error: " + row.text
+	default:
+		return row.text
+	}
+}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -27,7 +27,7 @@ func helpText() string {
 	return "Commands:\n" + strings.Join(formatCommandHelpLines(), "\n") + "\nSubmit text to ask the assistant."
 }
 
-const defaultCommandFooterText = "/help  /model  /provider  /context  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
+const defaultCommandFooterText = "/help  /model  /provider  /context  /compact  /effort  /style  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"
 
 func commandFooterText() string {
 	return formatCommandFooterText(commandDefinitions, false)
@@ -57,6 +57,9 @@ func formatCommandFooterText(commands []commandDefinition, pending bool) string 
 		commandModel,
 		commandProvider,
 		commandContext,
+		commandCompact,
+		commandEffort,
+		commandStyle,
 		commandTools,
 		commandPermissions,
 		commandClear,

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -1,0 +1,218 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/usage"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+var responseStyles = []string{"balanced", "concise", "explanatory", "review"}
+
+func (m model) handleEffortCommand(args string) (model, string) {
+	args = strings.TrimSpace(strings.ToLower(args))
+	if args == "" || args == "list" {
+		return m, m.effortText()
+	}
+	if args == "auto" {
+		m.reasoningEffort = ""
+		return m, strings.Join([]string{
+			"Effort",
+			"active effort: auto",
+			"Reasoning effort selection will follow the active model/provider defaults.",
+		}, "\n")
+	}
+
+	requested := modelregistry.ReasoningEffort(args)
+	if !modelregistry.ValidReasoningEffort(requested) {
+		return m, "Effort\nUnknown reasoning effort: " + args
+	}
+	efforts := m.availableReasoningEfforts()
+	if len(efforts) == 0 {
+		return m, "Effort\nActive model does not expose reasoning effort controls."
+	}
+	if !reasoningEffortAllowed(efforts, requested) {
+		return m, fmt.Sprintf("Effort\nReasoning effort %q is not supported by %s.", requested, displayValue(m.modelName, "the active model"))
+	}
+
+	m.reasoningEffort = requested
+	return m, strings.Join([]string{
+		"Effort",
+		"active effort: " + string(requested),
+		"model: " + displayValue(m.modelName, "none"),
+		"Reasoning effort preference is stored for this TUI session.",
+	}, "\n")
+}
+
+func (m model) effortText() string {
+	lines := []string{
+		"Effort",
+		"active effort: " + m.effortDisplay(),
+		"model: " + displayValue(m.modelName, "none"),
+	}
+	efforts := m.availableReasoningEfforts()
+	if len(efforts) == 0 {
+		lines = append(lines, "available: none for active model")
+		return strings.Join(lines, "\n")
+	}
+	lines = append(lines, "available: "+joinReasoningEfforts(efforts))
+	lines = append(lines, "Use /effort <value> or /effort auto.")
+	return strings.Join(lines, "\n")
+}
+
+func (m model) availableReasoningEfforts() []modelregistry.ReasoningEffort {
+	if strings.TrimSpace(m.modelName) == "" {
+		return nil
+	}
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return nil
+	}
+	return registry.ReasoningEfforts(m.modelName)
+}
+
+func (m model) effortDisplay() string {
+	if m.reasoningEffort == "" {
+		return "auto"
+	}
+	return string(m.reasoningEffort)
+}
+
+func reasoningEffortAllowed(efforts []modelregistry.ReasoningEffort, want modelregistry.ReasoningEffort) bool {
+	for _, effort := range efforts {
+		if effort == want {
+			return true
+		}
+	}
+	return false
+}
+
+func joinReasoningEfforts(efforts []modelregistry.ReasoningEffort) string {
+	values := make([]string, 0, len(efforts))
+	for _, effort := range efforts {
+		values = append(values, string(effort))
+	}
+	return strings.Join(values, ", ")
+}
+
+func (m model) handleStyleCommand(args string) (model, string) {
+	args = strings.TrimSpace(strings.ToLower(args))
+	if args == "" || args == "list" {
+		return m, m.styleText()
+	}
+	if !responseStyleAllowed(args) {
+		return m, "Style\nUnknown response style: " + args
+	}
+	m.responseStyle = args
+	return m, strings.Join([]string{
+		"Style",
+		"active style: " + m.responseStyle,
+		"Style preference is stored for this TUI session.",
+	}, "\n")
+}
+
+func (m model) styleText() string {
+	return strings.Join([]string{
+		"Style",
+		"active style: " + m.responseStyle,
+		"available: " + strings.Join(responseStyles, ", "),
+		"Use /style <value> to update this TUI session.",
+	}, "\n")
+}
+
+func defaultedResponseStyle(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if responseStyleAllowed(value) {
+		return value
+	}
+	return defaultResponseStyle
+}
+
+func responseStyleAllowed(value string) bool {
+	for _, style := range responseStyles {
+		if value == style {
+			return true
+		}
+	}
+	return false
+}
+
+func (m model) handleCompactCommand(args string) (model, string) {
+	args = strings.TrimSpace(strings.ToLower(args))
+	if args == "status" {
+		return m, m.compactText(false)
+	}
+	if args != "" {
+		return m, "Compact\nusage: /compact [status]"
+	}
+	m.compactRequests++
+	return m, m.compactText(true)
+}
+
+func (m model) compactText(requested bool) string {
+	lines := []string{
+		"Compact",
+		"status: " + m.compactionStatus(),
+		fmt.Sprintf("visible transcript rows: %d", len(m.transcript)),
+	}
+	if requested {
+		lines = append(lines, "request recorded for future compaction backend.")
+	} else {
+		lines = append(lines, "backend: not wired yet")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m model) compactionStatus() string {
+	if m.compactRequests > 0 {
+		return "requested, not yet compacted"
+	}
+	return "not compacted"
+}
+
+func (m model) recordUsageEvent(modelID string, event zeroruntime.Usage) (model, []transcriptRow) {
+	if m.usageTracker == nil || strings.TrimSpace(modelID) == "" {
+		return m, nil
+	}
+	normalized, _, err := usage.Normalize(event)
+	if err != nil {
+		return m, []transcriptRow{{kind: rowError, text: "usage: " + err.Error()}}
+	}
+	if _, err := m.usageTracker.Record(usage.RecordInput{
+		ModelID: modelID,
+		Usage:   event,
+		Source:  "tui",
+	}); err != nil {
+		m.unpricedRequests++
+		m.unpricedTokens += normalized.TotalTokens
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) usageSummaryText() string {
+	if m.usageTracker == nil {
+		return "usage unavailable"
+	}
+	summary := m.usageTracker.Summary()
+	if summary.RecordCount == 0 && m.unpricedRequests == 0 {
+		return "no usage yet"
+	}
+	if summary.RecordCount == 0 {
+		return formatUnpricedUsage(m.unpricedRequests, m.unpricedTokens)
+	}
+	if m.unpricedRequests == 0 {
+		return usage.FormatSummary(summary)
+	}
+	return usage.FormatSummary(summary) + "; " + formatUnpricedUsage(m.unpricedRequests, m.unpricedTokens)
+}
+
+func formatUnpricedUsage(requests int, tokens int) string {
+	requestLabel := "requests"
+	if requests == 1 {
+		requestLabel = "request"
+	}
+	return fmt.Sprintf("%d %s, %d tokens, cost unavailable", requests, requestLabel, tokens)
+}

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -176,20 +176,42 @@ func (m model) recordUsageEvent(modelID string, event zeroruntime.Usage) (model,
 	if m.usageTracker == nil || strings.TrimSpace(modelID) == "" {
 		return m, nil
 	}
-	normalized, _, err := usage.Normalize(event)
+	normalized, runtimeUsage, err := usage.Normalize(event)
 	if err != nil {
 		return m, []transcriptRow{{kind: rowError, text: "usage: " + err.Error()}}
 	}
 	if _, err := m.usageTracker.Record(usage.RecordInput{
 		ModelID: modelID,
-		Usage:   event,
+		Usage:   runtimeUsage,
 		Source:  "tui",
 	}); err != nil {
-		m.unpricedRequests++
-		m.unpricedTokens += normalized.TotalTokens
-		return m, nil
+		if isUnpricedUsageError(err) {
+			m.unpricedRequests++
+			m.unpricedTokens += normalized.TotalTokens
+			return m, nil
+		}
+		return m, []transcriptRow{{kind: rowError, text: "usage: " + err.Error()}}
 	}
 	return m, nil
+}
+
+func isUnpricedUsageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"unknown zero model",
+		"missing model input pricing rate",
+		"missing model output pricing rate",
+		"invalid model cached input pricing rate",
+		"no model cost tier covers",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m model) usageSummaryText() string {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -1,0 +1,287 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestEffortCommandListsAndSetsSupportedEffort(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "claude-sonnet-4.5"})
+	m.input.SetValue("/effort list")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /effort list to be handled without starting an agent run")
+	}
+	for _, want := range []string{"Effort", "active effort: auto", "available: low, medium, high"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected effort transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+
+	next.input.SetValue("/effort high")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /effort high to be handled without starting an agent run")
+	}
+	if next.reasoningEffort != modelregistry.ReasoningEffortHigh {
+		t.Fatalf("expected effort high, got %q", next.reasoningEffort)
+	}
+	if !transcriptContains(next.transcript, "active effort: high") {
+		t.Fatalf("expected effort switch transcript, got %#v", next.transcript)
+	}
+}
+
+func TestEffortCommandRejectsUnsupportedActiveModel(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4.1"})
+	m.input.SetValue("/effort high")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if next.reasoningEffort != "" {
+		t.Fatalf("expected effort to remain auto, got %q", next.reasoningEffort)
+	}
+	if !transcriptContains(next.transcript, "does not expose reasoning effort controls") {
+		t.Fatalf("expected unsupported model message, got %#v", next.transcript)
+	}
+}
+
+func TestStyleCommandListsAndSetsSessionPreference(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/style")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /style to be handled without starting an agent run")
+	}
+	if !transcriptContains(next.transcript, "active style: balanced") || !transcriptContains(next.transcript, "concise") {
+		t.Fatalf("expected style list transcript, got %#v", next.transcript)
+	}
+
+	next.input.SetValue("/style concise")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /style concise to be handled without starting an agent run")
+	}
+	if next.responseStyle != "concise" {
+		t.Fatalf("expected concise style, got %q", next.responseStyle)
+	}
+	if !transcriptContains(next.transcript, "active style: concise") {
+		t.Fatalf("expected style switch transcript, got %#v", next.transcript)
+	}
+}
+
+func TestCompactCommandRecordsShellRequest(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/compact")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /compact to be handled without starting an agent run")
+	}
+	if next.compactRequests != 1 {
+		t.Fatalf("expected one compact request, got %d", next.compactRequests)
+	}
+	for _, want := range []string{"Compact", "requested, not yet compacted", "future compaction backend"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected compact transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+
+	next.input.SetValue("/compact status")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /compact status to be handled without starting an agent run")
+	}
+	if next.compactRequests != 1 {
+		t.Fatalf("status should not add compact requests, got %d", next.compactRequests)
+	}
+}
+
+func TestUsageEventsUpdateFooterAndContext(t *testing.T) {
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 100, CachedInputTokens: 25, OutputTokens: 20}},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		Provider:  provider,
+		Registry:  tools.NewRegistry(),
+	})
+	m.input.SetValue("track usage")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt to start agent run")
+	}
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	footer := next.footerText()
+	for _, want := range []string{"ready", "gpt-4.1", "120 tokens", "$"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("expected footer to contain %q, got %q", want, footer)
+		}
+	}
+
+	next.input.SetValue("/context")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /context to be handled without starting an agent run")
+	}
+	for _, want := range []string{"usage: 1 request, 120 tokens", "style: balanced", "effort: auto", "compaction: not compacted"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected context transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
+func TestUsageEventsForwardExistingAgentCallback(t *testing.T) {
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 10, OutputTokens: 5}},
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	seen := []zeroruntime.Usage{}
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		Provider:  provider,
+		Registry:  tools.NewRegistry(),
+		AgentOptions: agent.Options{
+			OnUsage: func(event agent.Usage) {
+				seen = append(seen, event)
+			},
+		},
+	})
+	m.input.SetValue("track usage")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt to start agent run")
+	}
+	msg := cmd()
+	if len(seen) != 1 || seen[0].TotalTokens() != 15 {
+		t.Fatalf("expected original usage callback to receive event, got %#v", seen)
+	}
+	updated, _ = next.Update(msg)
+	next = updated.(model)
+
+	if !strings.Contains(next.footerText(), "15 tokens") {
+		t.Fatalf("expected usage to still update footer, got %q", next.footerText())
+	}
+}
+
+func TestUsageEventsForCustomModelUseTokenOnlyFallback(t *testing.T) {
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 100, OutputTokens: 20}},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		ModelName: "custom-coder",
+		Provider:  provider,
+		Registry:  tools.NewRegistry(),
+	})
+	m.input.SetValue("track usage")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt to start agent run")
+	}
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	footer := next.footerText()
+	for _, want := range []string{"custom-coder", "1 request, 120 tokens", "cost unavailable"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("expected footer to contain %q, got %q", want, footer)
+		}
+	}
+	if transcriptContains(next.transcript, "usage:") {
+		t.Fatalf("custom model usage should not append a transcript error, got %#v", next.transcript)
+	}
+}
+
+func TestStaleAgentUsageResponseIsIgnored(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4.1"})
+
+	updated, _ := m.Update(agentResponseMsg{
+		runID:        42,
+		usageModelID: "gpt-4.1",
+		usageEvents:  []zeroruntime.Usage{{InputTokens: 100, OutputTokens: 20}},
+	})
+	next := updated.(model)
+
+	if strings.Contains(next.footerText(), "120 tokens") {
+		t.Fatalf("stale usage response should be ignored, got footer %q", next.footerText())
+	}
+}
+
+func TestModelSwitchClearsUnsupportedEffortPreference(t *testing.T) {
+	nextProvider := &fakeProvider{}
+	m := newModel(context.Background(), Options{
+		ProviderName:    "openai",
+		ModelName:       "gpt-4.1-mini",
+		ReasoningEffort: modelregistry.ReasoningEffortHigh,
+		Provider:        &fakeProvider{},
+		ProviderProfile: openAITestProfile("gpt-4.1-mini"),
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			if profile.Model != "gpt-4.1" {
+				t.Fatalf("expected provider rebuild for gpt-4.1, got %#v", profile)
+			}
+			return nextProvider, nil
+		},
+	})
+	m.input.SetValue("/model gpt-4.1")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /model to be handled without starting an agent run")
+	}
+	if next.reasoningEffort != "" {
+		t.Fatalf("expected unsupported effort preference to reset, got %q", next.reasoningEffort)
+	}
+	if !transcriptContains(next.transcript, "unsupported preference reset") {
+		t.Fatalf("expected model switch transcript to mention effort reset, got %#v", next.transcript)
+	}
+}
+
+func openAITestProfile(modelID string) config.ProviderProfile {
+	return config.ProviderProfile{
+		Name:         "openai",
+		ProviderKind: config.ProviderKindOpenAI,
+		BaseURL:      config.OpenAIBaseURL,
+		APIKey:       "sk-test",
+		Model:        modelID,
+	}
+}

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -230,6 +230,35 @@ func TestUsageEventsForCustomModelUseTokenOnlyFallback(t *testing.T) {
 	}
 }
 
+func TestInvalidUsageEventsAppendTranscriptError(t *testing.T) {
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: -1, OutputTokens: 20}},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		Provider:  provider,
+		Registry:  tools.NewRegistry(),
+	})
+	m.input.SetValue("track usage")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt to start agent run")
+	}
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	if !transcriptContains(next.transcript, "usage: expected inputTokens to be non-negative") {
+		t.Fatalf("expected invalid usage transcript error, got %#v", next.transcript)
+	}
+	if next.unpricedRequests != 0 || strings.Contains(next.footerText(), "cost unavailable") {
+		t.Fatalf("invalid usage should not be counted as unpriced, requests=%d footer=%q", next.unpricedRequests, next.footerText())
+	}
+}
+
 func TestStaleAgentUsageResponseIsIgnored(t *testing.T) {
 	m := newModel(context.Background(), Options{ModelName: "gpt-4.1"})
 


### PR DESCRIPTION
## Summary
- add Go TUI shell controls for /compact, /effort, and /style
- show effort, style, compaction, and usage/cost state in /context and the footer
- record provider usage after agent runs while preserving existing OnUsage callbacks
- use token-only cost-unavailable display for custom/unpriced model usage instead of transcript errors
- split render helpers out of model.go to keep the main TUI model smaller

## Tests
- go test ./internal/tui
- go test ./...
- bun run typecheck
- bun test ./tests --timeout 15000
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/effort`, `/style`, and `/compact` session commands for runtime configuration
  * Integrated usage tracking to show token/request metrics and a usage summary in the UI
  * Model switching now clears unsupported reasoning-effort preferences and reflects effort status in responses

* **Tests**
  * Added comprehensive tests covering session commands, usage-event handling, model switches, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->