### PR TITLE
[codex] add Go MCP network transports

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 type RemoteTool struct {
@@ -44,6 +46,8 @@ type Client struct {
 	mu     sync.Mutex
 	nextID int
 }
+
+const stdioCloseWaitTimeout = 500 * time.Millisecond
 
 func Connect(ctx context.Context, server Server) (ToolClient, error) {
 	switch server.Type {
@@ -139,10 +143,28 @@ func (client *Client) Close() error {
 		client.stdin = nil
 	}
 	if client.cmd != nil && client.cmd.Process != nil {
-		_ = client.cmd.Process.Kill()
-		waitErr := client.cmd.Wait()
-		if err == nil && waitErr != nil && !strings.Contains(waitErr.Error(), "signal: killed") {
-			err = waitErr
+		waitDone := make(chan error, 1)
+		go func() {
+			waitDone <- client.cmd.Wait()
+		}()
+
+		select {
+		case waitErr := <-waitDone:
+			if err == nil && waitErr != nil {
+				err = waitErr
+			}
+		case <-time.After(stdioCloseWaitTimeout):
+			killed := false
+			killErr := client.cmd.Process.Kill()
+			if killErr == nil {
+				killed = true
+			} else if err == nil && !errors.Is(killErr, os.ErrProcessDone) {
+				err = killErr
+			}
+			waitErr := <-waitDone
+			if err == nil && waitErr != nil && !killed {
+				err = waitErr
+			}
 		}
 		client.cmd = nil
 	}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -38,13 +38,14 @@ type ToolClient interface {
 }
 
 type Client struct {
-	server Server
-	cmd    *exec.Cmd
-	stdin  io.WriteCloser
-	reader *messageReader
-	writer *messageWriter
-	mu     sync.Mutex
-	nextID int
+	server  Server
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	reader  *messageReader
+	writer  *messageWriter
+	mu      sync.Mutex
+	closeMu sync.Mutex
+	nextID  int
 }
 
 const stdioCloseWaitTimeout = 500 * time.Millisecond
@@ -137,15 +138,22 @@ func (client *Client) CallTool(ctx context.Context, name string, args map[string
 }
 
 func (client *Client) Close() error {
+	client.closeMu.Lock()
+	defer client.closeMu.Unlock()
+
 	var err error
-	if client.stdin != nil {
-		err = client.stdin.Close()
-		client.stdin = nil
+	stdin := client.stdin
+	cmd := client.cmd
+	client.stdin = nil
+	client.cmd = nil
+
+	if stdin != nil {
+		err = stdin.Close()
 	}
-	if client.cmd != nil && client.cmd.Process != nil {
+	if cmd != nil && cmd.Process != nil {
 		waitDone := make(chan error, 1)
 		go func() {
-			waitDone <- client.cmd.Wait()
+			waitDone <- cmd.Wait()
 		}()
 
 		select {
@@ -155,7 +163,7 @@ func (client *Client) Close() error {
 			}
 		case <-time.After(stdioCloseWaitTimeout):
 			killed := false
-			killErr := client.cmd.Process.Kill()
+			killErr := cmd.Process.Kill()
 			if killErr == nil {
 				killed = true
 			} else if err == nil && !errors.Is(killErr, os.ErrProcessDone) {
@@ -166,7 +174,6 @@ func (client *Client) Close() error {
 				err = waitErr
 			}
 		}
-		client.cmd = nil
 	}
 	return err
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -45,12 +45,14 @@ type Client struct {
 	nextID int
 }
 
-func Connect(ctx context.Context, server Server) (*Client, error) {
+func Connect(ctx context.Context, server Server) (ToolClient, error) {
 	switch server.Type {
 	case ServerTypeStdio:
 		return connectStdio(ctx, server)
-	case ServerTypeHTTP, ServerTypeSSE:
-		return nil, fmt.Errorf("MCP %s transport is not implemented yet for server %s", server.Type, server.Name)
+	case ServerTypeHTTP:
+		return connectNetwork(ctx, server)
+	case ServerTypeSSE:
+		return connectRemoteSSE(ctx, server)
 	default:
 		return nil, fmt.Errorf("unsupported MCP transport %q for server %s", server.Type, server.Name)
 	}

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,6 +60,46 @@ func TestStdioClientListsAndCallsTools(t *testing.T) {
 	}
 	if got := TextContent(result.Content); got != "lookup: zero" {
 		t.Fatalf("CallTool() text = %q, want lookup result", got)
+	}
+}
+
+func TestStdioClientCloseAllowsConcurrentCallers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := Connect(ctx, Server{
+		Name:    "docs",
+		Type:    ServerTypeStdio,
+		Command: executable,
+		Args:    []string{"-test.run=TestMCPStdioHelperProcess", "--"},
+		Env:     map[string]string{"ZERO_MCP_STDIO_HELPER": "1"},
+	})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wait sync.WaitGroup
+	for range 2 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			errs <- client.Close()
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
 	}
 }
 

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -361,6 +362,26 @@ func TestHTTPClientReportsNonOKStatus(t *testing.T) {
 	}
 }
 
+func TestCloseResponseBodyMergesCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	var err error
+
+	closeResponseBody(&err, Server{Name: "web", Type: ServerTypeHTTP}, errorCloser{err: closeErr})
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("closeResponseBody() error = %v, want wrapped close error", err)
+	}
+	if !strings.Contains(err.Error(), "close MCP http response from web") {
+		t.Fatalf("closeResponseBody() error = %q, want close context", err.Error())
+	}
+
+	baseErr := errors.New("decode failed")
+	err = baseErr
+	closeResponseBody(&err, Server{Name: "web", Type: ServerTypeHTTP}, errorCloser{err: closeErr})
+	if !errors.Is(err, baseErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("closeResponseBody() merged error = %v, want base and close errors", err)
+	}
+}
+
 func TestConnectRejectsUnsupportedTransport(t *testing.T) {
 	_, err := Connect(context.Background(), Server{Name: "web", Type: ServerType("websocket")})
 	if err == nil {
@@ -405,6 +426,14 @@ func TestClientRequestWaitsForMatchingResponseID(t *testing.T) {
 	if result.Value != "matched" {
 		t.Fatalf("result.Value = %q, want matched response", result.Value)
 	}
+}
+
+type errorCloser struct {
+	err error
+}
+
+func (closer errorCloser) Close() error {
+	return closer.err
 }
 
 func TestMCPStdioHelperProcess(t *testing.T) {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -33,7 +33,11 @@ func TestStdioClientListsAndCallsTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
-	defer client.Close()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
 
 	listed, err := client.ListTools(ctx)
 	if err != nil {
@@ -142,7 +146,11 @@ func TestHTTPClientListsAndCallsTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
-	defer client.Close()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
 
 	listed, err := client.ListTools(ctx)
 	if err != nil {
@@ -181,15 +189,23 @@ func TestSSEClientListsAndCallsToolsFromRemoteStream(t *testing.T) {
 			}
 			flusher, ok := response.(http.Flusher)
 			if !ok {
-				t.Fatal("test response writer does not support flushing")
+				t.Errorf("test response writer does not support flushing")
+				http.Error(response, "streaming unsupported", http.StatusInternalServerError)
+				return
 			}
 			response.Header().Set("Content-Type", "text/event-stream")
-			fmt.Fprint(response, "event: endpoint\ndata: /messages\n\n")
+			if _, err := fmt.Fprint(response, "event: endpoint\ndata: /messages\n\n"); err != nil {
+				t.Errorf("write endpoint event: %v", err)
+				return
+			}
 			flusher.Flush()
 			for {
 				select {
 				case event := <-events:
-					fmt.Fprint(response, event)
+					if _, err := fmt.Fprint(response, event); err != nil {
+						t.Errorf("write SSE event: %v", err)
+						return
+					}
 					flusher.Flush()
 				case <-request.Context().Done():
 					return
@@ -259,7 +275,11 @@ func TestSSEClientListsAndCallsToolsFromRemoteStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect() error = %v", err)
 	}
-	defer client.Close()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	}()
 
 	listed, err := client.ListTools(ctx)
 	if err != nil {
@@ -433,7 +453,11 @@ func mustRaw(value any) json.RawMessage {
 func readHTTPRPCMessage(t *testing.T, request *http.Request) rpcMessage {
 	t.Helper()
 
-	defer request.Body.Close()
+	defer func() {
+		if err := request.Body.Close(); err != nil {
+			t.Fatalf("close HTTP JSON-RPC request body: %v", err)
+		}
+	}()
 	var message rpcMessage
 	if err := json.NewDecoder(request.Body).Decode(&message); err != nil {
 		t.Fatalf("decode HTTP JSON-RPC request: %v", err)
@@ -467,15 +491,6 @@ func writeHTTPRPCError(t *testing.T, response http.ResponseWriter, id any, messa
 	}
 }
 
-func writeSSERPCResponse(t *testing.T, response http.ResponseWriter, id any, result any) {
-	t.Helper()
-
-	response.Header().Set("Content-Type", "text/event-stream")
-	if _, err := fmt.Fprint(response, formatSSERPCResponse(t, id, result)); err != nil {
-		t.Fatalf("write SSE JSON-RPC response: %v", err)
-	}
-}
-
 func formatSSERPCResponse(t *testing.T, id any, result any) string {
 	t.Helper()
 
@@ -489,15 +504,6 @@ func formatSSERPCResponse(t *testing.T, id any, result any) string {
 		t.Fatalf("marshal SSE JSON-RPC response: %v", err)
 	}
 	return fmt.Sprintf("event: message\ndata: %s\n\n", body)
-}
-
-func writeSSERPCError(t *testing.T, response http.ResponseWriter, id any, message string) {
-	t.Helper()
-
-	response.Header().Set("Content-Type", "text/event-stream")
-	if _, err := fmt.Fprint(response, formatSSERPCError(t, id, message)); err != nil {
-		t.Fatalf("write SSE JSON-RPC error: %v", err)
-	}
 }
 
 func formatSSERPCError(t *testing.T, id any, message string) string {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -56,17 +58,255 @@ func TestStdioClientListsAndCallsTools(t *testing.T) {
 	}
 }
 
-func TestConnectRejectsUnsupportedRunnableTransports(t *testing.T) {
-	_, err := Connect(context.Background(), Server{
+func TestHTTPClientListsAndCallsTools(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", request.Method)
+			http.Error(response, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		if request.URL.Path != "/mcp" {
+			t.Errorf("path = %s, want /mcp", request.URL.Path)
+			http.Error(response, "bad path", http.StatusNotFound)
+			return
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer test" {
+			t.Errorf("Authorization = %q, want bearer header", got)
+			http.Error(response, "missing auth", http.StatusUnauthorized)
+			return
+		}
+
+		message := readHTTPRPCMessage(t, request)
+		switch message.Method {
+		case "initialize":
+			response.Header().Set("Mcp-Session-Id", "session-123")
+			writeHTTPRPCResponse(t, response, message.ID, map[string]any{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "http-docs", "version": "1.0.0"},
+			})
+		case "notifications/initialized":
+			if got := request.Header.Get("Mcp-Session-Id"); got != "session-123" {
+				t.Errorf("initialized session header = %q, want session-123", got)
+				http.Error(response, "missing session", http.StatusBadRequest)
+				return
+			}
+			response.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if got := request.Header.Get("Mcp-Session-Id"); got != "session-123" {
+				t.Errorf("tools/list session header = %q, want session-123", got)
+				http.Error(response, "missing session", http.StatusBadRequest)
+				return
+			}
+			writeHTTPRPCResponse(t, response, message.ID, map[string]any{
+				"tools": []map[string]any{{
+					"name":        "lookup",
+					"description": "Lookup documentation",
+					"inputSchema": map[string]any{"type": "object"},
+				}},
+			})
+		case "tools/call":
+			var params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			}
+			if err := json.Unmarshal(message.Params, &params); err != nil {
+				t.Errorf("decode tools/call params: %v", err)
+				http.Error(response, "bad params", http.StatusBadRequest)
+				return
+			}
+			if params.Name != "lookup" || params.Arguments["query"] != "zero" {
+				t.Errorf("tools/call params = %#v", params)
+				http.Error(response, "bad tool call", http.StatusBadRequest)
+				return
+			}
+			writeHTTPRPCResponse(t, response, message.ID, map[string]any{
+				"content": []map[string]any{{"type": "text", "text": "lookup: zero"}},
+			})
+		default:
+			t.Errorf("unexpected method %q", message.Method)
+			writeHTTPRPCError(t, response, message.ID, "method not found")
+		}
+	}))
+	defer testServer.Close()
+
+	client, err := Connect(ctx, Server{
+		Name:    "docs",
+		Type:    ServerTypeHTTP,
+		URL:     testServer.URL + "/mcp",
+		Headers: map[string]string{"Authorization": "Bearer test"},
+	})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	defer client.Close()
+
+	listed, err := client.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "lookup" {
+		t.Fatalf("listed tools = %#v, want lookup", listed)
+	}
+
+	result, err := client.CallTool(ctx, "lookup", map[string]any{"query": "zero"})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if got := TextContent(result.Content); got != "lookup: zero" {
+		t.Fatalf("CallTool() text = %q, want lookup result", got)
+	}
+}
+
+func TestSSEClientListsAndCallsToolsFromRemoteStream(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events := make(chan string, 4)
+	testServer := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if got := request.Header.Get("Authorization"); got != "Bearer test" {
+			t.Errorf("Authorization = %q, want bearer header", got)
+			http.Error(response, "missing auth", http.StatusUnauthorized)
+			return
+		}
+
+		if request.Method == http.MethodGet && request.URL.Path == "/sse" {
+			if got := request.Header.Get("Accept"); !strings.Contains(got, "text/event-stream") {
+				t.Errorf("Accept = %q, want text/event-stream", got)
+				http.Error(response, "bad accept", http.StatusBadRequest)
+				return
+			}
+			flusher, ok := response.(http.Flusher)
+			if !ok {
+				t.Fatal("test response writer does not support flushing")
+			}
+			response.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(response, "event: endpoint\ndata: /messages\n\n")
+			flusher.Flush()
+			for {
+				select {
+				case event := <-events:
+					fmt.Fprint(response, event)
+					flusher.Flush()
+				case <-request.Context().Done():
+					return
+				}
+			}
+		}
+
+		if request.Method != http.MethodPost || request.URL.Path != "/messages" {
+			t.Errorf("request = %s %s, want POST /messages", request.Method, request.URL.Path)
+			http.Error(response, "bad request", http.StatusNotFound)
+			return
+		}
+
+		message := readHTTPRPCMessage(t, request)
+		switch message.Method {
+		case "initialize":
+			events <- formatSSERPCResponse(t, message.ID, map[string]any{
+				"protocolVersion": "2024-11-05",
+				"capabilities":    map[string]any{"tools": map[string]any{}},
+				"serverInfo":      map[string]any{"name": "sse-docs", "version": "1.0.0"},
+			})
+			response.WriteHeader(http.StatusAccepted)
+		case "notifications/initialized":
+			response.WriteHeader(http.StatusNoContent)
+		case "tools/list":
+			events <- formatSSERPCResponse(t, message.ID, map[string]any{
+				"tools": []map[string]any{{
+					"name":        "lookup",
+					"description": "Lookup documentation",
+					"inputSchema": map[string]any{"type": "object"},
+				}},
+			})
+			response.WriteHeader(http.StatusAccepted)
+		case "tools/call":
+			var params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			}
+			if err := json.Unmarshal(message.Params, &params); err != nil {
+				t.Errorf("decode tools/call params: %v", err)
+				http.Error(response, "bad params", http.StatusBadRequest)
+				return
+			}
+			if params.Name != "lookup" || params.Arguments["query"] != "zero" {
+				t.Errorf("tools/call params = %#v", params)
+				http.Error(response, "bad tool call", http.StatusBadRequest)
+				return
+			}
+			events <- formatSSERPCResponse(t, message.ID, map[string]any{
+				"content": []map[string]any{{"type": "text", "text": "lookup: zero"}},
+			})
+			response.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected method %q", message.Method)
+			events <- formatSSERPCError(t, message.ID, "method not found")
+			response.WriteHeader(http.StatusAccepted)
+		}
+	}))
+	defer testServer.Close()
+
+	client, err := Connect(ctx, Server{
+		Name:    "docs",
+		Type:    ServerTypeSSE,
+		URL:     testServer.URL + "/sse",
+		Headers: map[string]string{"Authorization": "Bearer test"},
+	})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	defer client.Close()
+
+	listed, err := client.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].Name != "lookup" {
+		t.Fatalf("listed tools = %#v, want lookup", listed)
+	}
+
+	result, err := client.CallTool(ctx, "lookup", map[string]any{"query": "zero"})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if got := TextContent(result.Content); got != "lookup: zero" {
+		t.Fatalf("CallTool() text = %q, want lookup result", got)
+	}
+}
+
+func TestHTTPClientReportsNonOKStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Error(response, "server failed", http.StatusBadGateway)
+	}))
+	defer testServer.Close()
+
+	_, err := Connect(ctx, Server{
 		Name: "web",
 		Type: ServerTypeHTTP,
-		URL:  "https://example.com/mcp",
+		URL:  testServer.URL + "/mcp",
 	})
+	if err == nil {
+		t.Fatal("Connect() error = nil, want status error")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Fatalf("error = %q, want HTTP status", err.Error())
+	}
+}
+
+func TestConnectRejectsUnsupportedTransport(t *testing.T) {
+	_, err := Connect(context.Background(), Server{Name: "web", Type: ServerType("websocket")})
 	if err == nil {
 		t.Fatal("Connect() error = nil, want unsupported transport error")
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Fatalf("error = %q, want not implemented", err.Error())
+	if !strings.Contains(err.Error(), "unsupported MCP transport") {
+		t.Fatalf("error = %q, want unsupported transport", err.Error())
 	}
 }
 
@@ -188,6 +428,91 @@ func mustRaw(value any) json.RawMessage {
 		panic(err)
 	}
 	return data
+}
+
+func readHTTPRPCMessage(t *testing.T, request *http.Request) rpcMessage {
+	t.Helper()
+
+	defer request.Body.Close()
+	var message rpcMessage
+	if err := json.NewDecoder(request.Body).Decode(&message); err != nil {
+		t.Fatalf("decode HTTP JSON-RPC request: %v", err)
+	}
+	return message
+}
+
+func writeHTTPRPCResponse(t *testing.T, response http.ResponseWriter, id any, result any) {
+	t.Helper()
+
+	response.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(response).Encode(rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  mustRaw(result),
+	}); err != nil {
+		t.Fatalf("write HTTP JSON-RPC response: %v", err)
+	}
+}
+
+func writeHTTPRPCError(t *testing.T, response http.ResponseWriter, id any, message string) {
+	t.Helper()
+
+	response.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(response).Encode(rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: -32601, Message: message},
+	}); err != nil {
+		t.Fatalf("write HTTP JSON-RPC error: %v", err)
+	}
+}
+
+func writeSSERPCResponse(t *testing.T, response http.ResponseWriter, id any, result any) {
+	t.Helper()
+
+	response.Header().Set("Content-Type", "text/event-stream")
+	if _, err := fmt.Fprint(response, formatSSERPCResponse(t, id, result)); err != nil {
+		t.Fatalf("write SSE JSON-RPC response: %v", err)
+	}
+}
+
+func formatSSERPCResponse(t *testing.T, id any, result any) string {
+	t.Helper()
+
+	message := rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  mustRaw(result),
+	}
+	body, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("marshal SSE JSON-RPC response: %v", err)
+	}
+	return fmt.Sprintf("event: message\ndata: %s\n\n", body)
+}
+
+func writeSSERPCError(t *testing.T, response http.ResponseWriter, id any, message string) {
+	t.Helper()
+
+	response.Header().Set("Content-Type", "text/event-stream")
+	if _, err := fmt.Fprint(response, formatSSERPCError(t, id, message)); err != nil {
+		t.Fatalf("write SSE JSON-RPC error: %v", err)
+	}
+}
+
+func formatSSERPCError(t *testing.T, id any, message string) string {
+	t.Helper()
+
+	payload := rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: -32601, Message: message},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal SSE JSON-RPC error: %v", err)
+	}
+	return fmt.Sprintf("event: message\ndata: %s\n\n", body)
 }
 
 func TestSchemaFromMCPInputSchema(t *testing.T) {

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -314,7 +315,7 @@ func (client *remoteSSEClient) notify(ctx context.Context, method string, params
 	})
 }
 
-func (client *networkClient) post(ctx context.Context, message rpcMessage, expectResponse bool) (rpcMessage, error) {
+func (client *networkClient) post(ctx context.Context, message rpcMessage, expectResponse bool) (result rpcMessage, err error) {
 	body, err := json.Marshal(message)
 	if err != nil {
 		return rpcMessage{}, err
@@ -329,7 +330,7 @@ func (client *networkClient) post(ctx context.Context, message rpcMessage, expec
 	if err != nil {
 		return rpcMessage{}, fmt.Errorf("call MCP %s server %s: %w", client.server.Type, client.server.Name, err)
 	}
-	defer response.Body.Close()
+	defer closeResponseBody(&err, client.server, response.Body)
 
 	if sessionID := strings.TrimSpace(response.Header.Get("Mcp-Session-Id")); sessionID != "" {
 		client.sessionID = sessionID
@@ -362,8 +363,9 @@ func (client *remoteSSEClient) openStream(ctx context.Context) error {
 		return fmt.Errorf("open MCP SSE stream for %s: %w", client.server.Name, err)
 	}
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		defer response.Body.Close()
-		return httpStatusError(client.server, response)
+		err = httpStatusError(client.server, response)
+		closeResponseBody(&err, client.server, response.Body)
+		return err
 	}
 	client.streamBody = response.Body
 
@@ -377,7 +379,7 @@ func (client *remoteSSEClient) openStream(ctx context.Context) error {
 	}
 }
 
-func (client *remoteSSEClient) post(ctx context.Context, message rpcMessage) error {
+func (client *remoteSSEClient) post(ctx context.Context, message rpcMessage) (err error) {
 	endpointURL, err := client.currentEndpoint()
 	if err != nil {
 		return err
@@ -396,7 +398,7 @@ func (client *remoteSSEClient) post(ctx context.Context, message rpcMessage) err
 	if err != nil {
 		return fmt.Errorf("post MCP SSE message to %s: %w", client.server.Name, err)
 	}
-	defer response.Body.Close()
+	defer closeResponseBody(&err, client.server, response.Body)
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return httpStatusError(client.server, response)
 	}
@@ -428,6 +430,12 @@ func (client *remoteSSEClient) applyPostHeaders(request *http.Request) {
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
+}
+
+func closeResponseBody(errp *error, server Server, body io.Closer) {
+	if closeErr := body.Close(); closeErr != nil {
+		*errp = errors.Join(*errp, fmt.Errorf("close MCP %s response from %s: %w", server.Type, server.Name, closeErr))
+	}
 }
 
 func (client *networkClient) decodeResponse(response *http.Response) (rpcMessage, error) {

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -1,0 +1,697 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+type networkClient struct {
+	server    Server
+	client    *http.Client
+	mu        sync.Mutex
+	nextID    int
+	sessionID string
+}
+
+type remoteSSEClient struct {
+	server       Server
+	client       *http.Client
+	mu           sync.Mutex
+	nextID       int
+	endpointURL  string
+	streamBody   io.Closer
+	streamCancel context.CancelFunc
+	pending      map[string]chan ssePendingResponse
+	streamErr    error
+	closed       bool
+}
+
+type ssePendingResponse struct {
+	message rpcMessage
+	err     error
+}
+
+type sseEvent struct {
+	Name string
+	Data string
+}
+
+func connectNetwork(ctx context.Context, server Server) (ToolClient, error) {
+	client := &networkClient{
+		server: server,
+		client: http.DefaultClient,
+		nextID: 1,
+	}
+	if err := client.initialize(ctx); err != nil {
+		return nil, fmt.Errorf("initialize MCP server %s: %w", server.Name, err)
+	}
+	return client, nil
+}
+
+func connectRemoteSSE(ctx context.Context, server Server) (ToolClient, error) {
+	client := &remoteSSEClient{
+		server:  server,
+		client:  http.DefaultClient,
+		nextID:  1,
+		pending: map[string]chan ssePendingResponse{},
+	}
+	if err := client.openStream(ctx); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("connect MCP SSE server %s: %w", server.Name, err)
+	}
+	if err := client.initialize(ctx); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("initialize MCP server %s: %w", server.Name, err)
+	}
+	return client, nil
+}
+
+func (client *networkClient) initialize(ctx context.Context) error {
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := client.request(ctx, "initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "zero",
+			"version": "dev",
+		},
+	}, &result); err != nil {
+		return err
+	}
+	return client.notify(ctx, "notifications/initialized", map[string]any{})
+}
+
+func (client *remoteSSEClient) initialize(ctx context.Context) error {
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := client.request(ctx, "initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "zero",
+			"version": "dev",
+		},
+	}, &result); err != nil {
+		return err
+	}
+	return client.notify(ctx, "notifications/initialized", map[string]any{})
+}
+
+func (client *networkClient) ListTools(ctx context.Context) ([]RemoteTool, error) {
+	var result struct {
+		Tools []RemoteTool `json:"tools"`
+	}
+	if err := client.request(ctx, "tools/list", map[string]any{}, &result); err != nil {
+		return nil, err
+	}
+	return result.Tools, nil
+}
+
+func (client *remoteSSEClient) ListTools(ctx context.Context) ([]RemoteTool, error) {
+	var result struct {
+		Tools []RemoteTool `json:"tools"`
+	}
+	if err := client.request(ctx, "tools/list", map[string]any{}, &result); err != nil {
+		return nil, err
+	}
+	return result.Tools, nil
+}
+
+func (client *networkClient) CallTool(ctx context.Context, name string, args map[string]any) (CallToolResult, error) {
+	var result CallToolResult
+	if err := client.request(ctx, "tools/call", map[string]any{
+		"name":      name,
+		"arguments": args,
+	}, &result); err != nil {
+		return CallToolResult{}, err
+	}
+	return result, nil
+}
+
+func (client *remoteSSEClient) CallTool(ctx context.Context, name string, args map[string]any) (CallToolResult, error) {
+	var result CallToolResult
+	if err := client.request(ctx, "tools/call", map[string]any{
+		"name":      name,
+		"arguments": args,
+	}, &result); err != nil {
+		return CallToolResult{}, err
+	}
+	return result, nil
+}
+
+func (client *networkClient) Close() error {
+	return nil
+}
+
+func (client *remoteSSEClient) Close() error {
+	client.mu.Lock()
+	if client.closed {
+		client.mu.Unlock()
+		return nil
+	}
+	client.closed = true
+	pending := client.pending
+	client.pending = map[string]chan ssePendingResponse{}
+	streamBody := client.streamBody
+	cancel := client.streamCancel
+	client.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	var err error
+	if streamBody != nil {
+		err = streamBody.Close()
+	}
+	closeErr := fmt.Errorf("MCP SSE client for %s is closed", client.server.Name)
+	for _, channel := range pending {
+		channel <- ssePendingResponse{err: closeErr}
+		close(channel)
+	}
+	return err
+}
+
+func (client *networkClient) request(ctx context.Context, method string, params any, target any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+
+	id := client.nextID
+	client.nextID++
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	message, err := client.post(ctx, rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  rawParams,
+	}, true)
+	if err != nil {
+		return err
+	}
+	if !rpcIDMatches(message.ID, id) {
+		return fmt.Errorf("MCP %s response id mismatch for server %s", method, client.server.Name)
+	}
+	if message.Error != nil {
+		return fmt.Errorf("MCP %s failed: %s", method, message.Error.Message)
+	}
+	if target != nil && len(message.Result) > 0 {
+		if err := json.Unmarshal(message.Result, target); err != nil {
+			return fmt.Errorf("decode MCP %s result: %w", method, err)
+		}
+	}
+	return nil
+}
+
+func (client *remoteSSEClient) request(ctx context.Context, method string, params any, target any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+
+	client.mu.Lock()
+	if client.streamErr != nil {
+		err := client.streamErr
+		client.mu.Unlock()
+		return err
+	}
+	if client.closed {
+		client.mu.Unlock()
+		return fmt.Errorf("MCP SSE client for %s is closed", client.server.Name)
+	}
+	id := client.nextID
+	client.nextID++
+	key := rpcResponseKey(id)
+	responseChannel := make(chan ssePendingResponse, 1)
+	client.pending[key] = responseChannel
+	client.mu.Unlock()
+
+	if err := client.post(ctx, rpcMessage{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  rawParams,
+	}); err != nil {
+		client.removePending(key)
+		return err
+	}
+
+	select {
+	case response := <-responseChannel:
+		if response.err != nil {
+			return response.err
+		}
+		if !rpcIDMatches(response.message.ID, id) {
+			return fmt.Errorf("MCP %s response id mismatch for server %s", method, client.server.Name)
+		}
+		if response.message.Error != nil {
+			return fmt.Errorf("MCP %s failed: %s", method, response.message.Error.Message)
+		}
+		if target != nil && len(response.message.Result) > 0 {
+			if err := json.Unmarshal(response.message.Result, target); err != nil {
+				return fmt.Errorf("decode MCP %s result: %w", method, err)
+			}
+		}
+		return nil
+	case <-ctx.Done():
+		client.removePending(key)
+		return ctx.Err()
+	}
+}
+
+func (client *networkClient) notify(ctx context.Context, method string, params any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	_, err = client.post(ctx, rpcMessage{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  rawParams,
+	}, false)
+	return err
+}
+
+func (client *remoteSSEClient) notify(ctx context.Context, method string, params any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	rawParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	return client.post(ctx, rpcMessage{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  rawParams,
+	})
+}
+
+func (client *networkClient) post(ctx context.Context, message rpcMessage, expectResponse bool) (rpcMessage, error) {
+	body, err := json.Marshal(message)
+	if err != nil {
+		return rpcMessage{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, client.server.URL, bytes.NewReader(body))
+	if err != nil {
+		return rpcMessage{}, fmt.Errorf("create MCP %s request for %s: %w", client.server.Type, client.server.Name, err)
+	}
+	client.applyHeaders(request)
+
+	response, err := client.client.Do(request)
+	if err != nil {
+		return rpcMessage{}, fmt.Errorf("call MCP %s server %s: %w", client.server.Type, client.server.Name, err)
+	}
+	defer response.Body.Close()
+
+	if sessionID := strings.TrimSpace(response.Header.Get("Mcp-Session-Id")); sessionID != "" {
+		client.sessionID = sessionID
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return rpcMessage{}, client.statusError(response)
+	}
+	if !expectResponse {
+		_, _ = io.Copy(io.Discard, response.Body)
+		return rpcMessage{}, nil
+	}
+	if response.StatusCode == http.StatusNoContent {
+		return rpcMessage{}, fmt.Errorf("MCP %s server %s returned no response body", client.server.Type, client.server.Name)
+	}
+	return client.decodeResponse(response)
+}
+
+func (client *remoteSSEClient) openStream(ctx context.Context) error {
+	streamCtx, cancel := context.WithCancel(ctx)
+	client.streamCancel = cancel
+
+	request, err := http.NewRequestWithContext(streamCtx, http.MethodGet, client.server.URL, nil)
+	if err != nil {
+		return fmt.Errorf("create MCP SSE stream request for %s: %w", client.server.Name, err)
+	}
+	client.applyStreamHeaders(request)
+
+	response, err := client.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("open MCP SSE stream for %s: %w", client.server.Name, err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		defer response.Body.Close()
+		return httpStatusError(client.server, response)
+	}
+	client.streamBody = response.Body
+
+	ready := make(chan error, 1)
+	go client.readStream(response.Body, ready)
+	select {
+	case err := <-ready:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (client *remoteSSEClient) post(ctx context.Context, message rpcMessage) error {
+	endpointURL, err := client.currentEndpoint()
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create MCP SSE post for %s: %w", client.server.Name, err)
+	}
+	client.applyPostHeaders(request)
+
+	response, err := client.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("post MCP SSE message to %s: %w", client.server.Name, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return httpStatusError(client.server, response)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	return nil
+}
+
+func (client *networkClient) applyHeaders(request *http.Request) {
+	for key, value := range client.server.Headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	if client.sessionID != "" {
+		request.Header.Set("Mcp-Session-Id", client.sessionID)
+	}
+}
+
+func (client *remoteSSEClient) applyStreamHeaders(request *http.Request) {
+	for key, value := range client.server.Headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Accept", "text/event-stream")
+}
+
+func (client *remoteSSEClient) applyPostHeaders(request *http.Request) {
+	for key, value := range client.server.Headers {
+		request.Header.Set(key, value)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+}
+
+func (client *networkClient) decodeResponse(response *http.Response) (rpcMessage, error) {
+	contentType, _, _ := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if contentType == "text/event-stream" {
+		return decodeSSERPCMessage(response.Body)
+	}
+
+	var message rpcMessage
+	decoder := json.NewDecoder(response.Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&message); err != nil {
+		return rpcMessage{}, fmt.Errorf("decode MCP %s response from %s: %w", client.server.Type, client.server.Name, err)
+	}
+	return message, nil
+}
+
+func (client *networkClient) statusError(response *http.Response) error {
+	return httpStatusError(client.server, response)
+}
+
+func (client *remoteSSEClient) readStream(reader io.Reader, ready chan<- error) {
+	endpointReady := false
+	signalReady := func(err error) {
+		if endpointReady {
+			return
+		}
+		endpointReady = true
+		ready <- err
+	}
+
+	var eventErr error
+	err := scanSSEEvents(reader, func(event sseEvent) bool {
+		switch event.Name {
+		case "endpoint":
+			if err := client.setEndpoint(event.Data); err != nil {
+				eventErr = err
+				signalReady(err)
+				return false
+			}
+			signalReady(nil)
+		case "message":
+			if err := client.deliverEventMessage(event.Data); err != nil {
+				eventErr = err
+				return false
+			}
+		}
+		return true
+	})
+	if eventErr != nil {
+		if !endpointReady {
+			signalReady(eventErr)
+		}
+		client.failPending(eventErr)
+		return
+	}
+	if err != nil {
+		if !endpointReady {
+			signalReady(err)
+		}
+		client.failPending(err)
+		return
+	}
+	if !endpointReady {
+		err = fmt.Errorf("missing MCP SSE endpoint event for server %s", client.server.Name)
+		signalReady(err)
+		client.failPending(err)
+		return
+	}
+	client.failPending(fmt.Errorf("MCP SSE stream closed for server %s", client.server.Name))
+}
+
+func (client *remoteSSEClient) setEndpoint(value string) error {
+	endpointURL, err := resolveSSEEndpointURL(client.server.URL, strings.TrimSpace(value))
+	if err != nil {
+		return err
+	}
+	client.mu.Lock()
+	client.endpointURL = endpointURL
+	client.mu.Unlock()
+	return nil
+}
+
+func (client *remoteSSEClient) deliverEventMessage(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	var message rpcMessage
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+	if err := decoder.Decode(&message); err != nil {
+		return fmt.Errorf("decode MCP SSE stream message: %w", err)
+	}
+	key := rpcResponseKey(message.ID)
+	if key == "" {
+		return nil
+	}
+
+	client.mu.Lock()
+	channel := client.pending[key]
+	if channel != nil {
+		delete(client.pending, key)
+	}
+	client.mu.Unlock()
+	if channel != nil {
+		channel <- ssePendingResponse{message: message}
+		close(channel)
+	}
+	return nil
+}
+
+func (client *remoteSSEClient) currentEndpoint() (string, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.streamErr != nil {
+		return "", client.streamErr
+	}
+	if client.closed {
+		return "", fmt.Errorf("MCP SSE client for %s is closed", client.server.Name)
+	}
+	if client.endpointURL == "" {
+		return "", fmt.Errorf("MCP SSE endpoint is not ready for server %s", client.server.Name)
+	}
+	return client.endpointURL, nil
+}
+
+func (client *remoteSSEClient) removePending(key string) {
+	client.mu.Lock()
+	channel := client.pending[key]
+	if channel != nil {
+		delete(client.pending, key)
+	}
+	client.mu.Unlock()
+	if channel != nil {
+		close(channel)
+	}
+}
+
+func (client *remoteSSEClient) failPending(err error) {
+	client.mu.Lock()
+	if client.closed {
+		client.mu.Unlock()
+		return
+	}
+	client.streamErr = err
+	pending := client.pending
+	client.pending = map[string]chan ssePendingResponse{}
+	client.mu.Unlock()
+	for _, channel := range pending {
+		channel <- ssePendingResponse{err: err}
+		close(channel)
+	}
+}
+
+func httpStatusError(server Server, response *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 1024))
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return fmt.Errorf("MCP %s server %s returned HTTP %d", server.Type, server.Name, response.StatusCode)
+	}
+	return fmt.Errorf("MCP %s server %s returned HTTP %d: %s", server.Type, server.Name, response.StatusCode, detail)
+}
+
+func decodeSSERPCMessage(reader io.Reader) (rpcMessage, error) {
+	var decoded rpcMessage
+	var decodeErr error
+	found := false
+	if err := scanSSEEvents(reader, func(event sseEvent) bool {
+		if event.Name != "message" {
+			return true
+		}
+		value := strings.TrimSpace(event.Data)
+		if value == "" {
+			return true
+		}
+		decoder := json.NewDecoder(strings.NewReader(value))
+		decoder.UseNumber()
+		if err := decoder.Decode(&decoded); err != nil {
+			decodeErr = fmt.Errorf("decode MCP SSE response: %w", err)
+			return false
+		}
+		found = true
+		return false
+	}); err != nil {
+		return rpcMessage{}, err
+	}
+	if decodeErr != nil {
+		return rpcMessage{}, decodeErr
+	}
+	if found {
+		return decoded, nil
+	}
+	return rpcMessage{}, fmt.Errorf("missing MCP SSE response data")
+}
+
+func scanSSEEvents(reader io.Reader, handle func(sseEvent) bool) error {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	event := sseEvent{Name: "message"}
+	dataLines := []string{}
+	flush := func() bool {
+		if len(dataLines) == 0 {
+			event = sseEvent{Name: "message"}
+			return true
+		}
+		event.Data = strings.Join(dataLines, "\n")
+		dataLines = dataLines[:0]
+		keepReading := handle(event)
+		event = sseEvent{Name: "message"}
+		return keepReading
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if line == "" {
+			if !flush() {
+				return nil
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, ok := strings.Cut(line, ":")
+		if !ok {
+			field = line
+			value = ""
+		} else {
+			value = strings.TrimPrefix(value, " ")
+		}
+		switch field {
+		case "event":
+			event.Name = value
+		case "data":
+			dataLines = append(dataLines, value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	flush()
+	return nil
+}
+
+func resolveSSEEndpointURL(baseValue string, endpointValue string) (string, error) {
+	if endpointValue == "" {
+		return "", fmt.Errorf("MCP SSE endpoint event is empty")
+	}
+	baseURL, err := url.Parse(baseValue)
+	if err != nil {
+		return "", fmt.Errorf("parse MCP SSE base URL: %w", err)
+	}
+	endpointURL, err := url.Parse(endpointValue)
+	if err != nil {
+		return "", fmt.Errorf("parse MCP SSE endpoint URL: %w", err)
+	}
+	return baseURL.ResolveReference(endpointURL).String(), nil
+}
+
+func rpcResponseKey(id any) string {
+	if id == nil {
+		return ""
+	}
+	return fmt.Sprint(id)
+}


### PR DESCRIPTION
## Summary
- Adds Go MCP streamable HTTP client support behind the existing MCP registry interface.
- Adds Go MCP remote SSE client support with stream handshake, endpoint resolution, pending response routing, and close/cancel cleanup.
- Keeps stdio support unchanged while allowing Connect to return the existing ToolClient interface for all transports.
- Adds regression coverage for HTTP headers/session propagation, remote SSE list/call flow, unsupported transports, and HTTP status errors.

## Validation
- go test -count=1 ./internal/mcp
- go test -count=1 ./...
- npx --yes bun install --frozen-lockfile
- npx --yes bun run typecheck
- npx --yes bun test ./tests --timeout 15000
- npx --yes bun run build
- npx --yes bun run smoke:build
- npx --yes bun run smoke:go
- ./zero --help
- ./zero mcp --help
- ./zero mcp tools --help
- git diff --cached --check

Review requested from @vasanthdev2004 and @anandh8x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP client now supports HTTP and Server-Sent Events (SSE) transports for tool discovery and invocation.

* **Bug Fixes**
  * More robust stdio client shutdown with timeout and improved kill/wait handling.
  * Improved reporting of non-OK HTTP responses.
  * Unsupported transports return an explicit error.

* **Tests**
  * Expanded tests for stdio, HTTP, and SSE flows, concurrent Close handling, headers/sessions, SSE framing, and negative paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->