### PR TITLE
[codex] add Go session lineage backend

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -130,6 +130,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runDoctor(args[1:], stdout, stderr, deps)
 	case "search", "find":
 		return runSearch(args[1:], stdout, stderr, deps)
+	case "sessions", "session":
+		return runSessions(args[1:], stdout, stderr, deps)
 	case "plugins", "plugin":
 		return runPlugins(args[1:], stdout, stderr, deps)
 	case "hooks":
@@ -276,6 +278,7 @@ Commands:
   doctor     Run backend health checks for config and provider setup
   search     Search persisted local Zero session events
   find       Alias for search
+  sessions   Inspect local Zero session lineage
   plugins    Inspect local Zero plugin manifests
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -210,6 +210,8 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"doctor"},
 		{"search"},
 		{"find"},
+		{"sessions"},
+		{"session"},
 		{"plugins"},
 		{"plugin"},
 		{"hooks"},

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+type sessionCommandOptions struct {
+	json bool
+}
+
+func runSessions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	command, remaining, options, help, err := parseSessionsArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSessionsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	store := deps.newSessionStore()
+	switch command {
+	case "list":
+		return runSessionsList(store, options, stdout, stderr)
+	case "children":
+		if len(remaining) != 1 {
+			return writeExecUsageError(stderr, "sessions children requires a session id")
+		}
+		return runSessionsChildren(store, remaining[0], options, stdout, stderr)
+	case "lineage":
+		if len(remaining) != 1 {
+			return writeExecUsageError(stderr, "sessions lineage requires a session id")
+		}
+		return runSessionsLineage(store, remaining[0], options, stdout, stderr)
+	case "tree":
+		if len(remaining) != 1 {
+			return writeExecUsageError(stderr, "sessions tree requires a session id")
+		}
+		return runSessionsTree(store, remaining[0], options, stdout, stderr)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown sessions command %q", command))
+	}
+}
+
+func parseSessionsArgs(args []string) (string, []string, sessionCommandOptions, bool, error) {
+	options := sessionCommandOptions{}
+	command := "list"
+	remaining := []string{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return command, remaining, options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return command, remaining, options, false, execUsageError{fmt.Sprintf("unknown sessions flag %q", arg)}
+			}
+			if command == "list" && len(remaining) == 0 && isSessionsCommand(arg) {
+				command = arg
+				continue
+			}
+			remaining = append(remaining, arg)
+		}
+	}
+	return command, remaining, options, false, nil
+}
+
+func isSessionsCommand(command string) bool {
+	switch command {
+	case "list", "children", "lineage", "tree":
+		return true
+	default:
+		return false
+	}
+}
+
+func runSessionsList(store *sessions.Store, options sessionCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	items, err := store.List()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(items, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatSessionsList(items)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSessionsChildren(store *sessions.Store, sessionID string, options sessionCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	items, err := store.ListChildren(sessionID)
+	if err != nil {
+		return writeSessionCommandError(stderr, err)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(items, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatSessionsList(items)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSessionsLineage(store *sessions.Store, sessionID string, options sessionCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	lineage, err := store.Lineage(sessionID)
+	if err != nil {
+		return writeSessionCommandError(stderr, err)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(lineage, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	ids := make([]string, 0, len(lineage))
+	for _, session := range lineage {
+		ids = append(ids, redact(session.SessionID))
+	}
+	if _, err := fmt.Fprintln(stdout, strings.Join(ids, " -> ")); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSessionsTree(store *sessions.Store, sessionID string, options sessionCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	tree, err := store.Tree(sessionID)
+	if err != nil {
+		return writeSessionCommandError(stderr, err)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(tree, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprint(stdout, formatSessionTree(tree)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func writeSessionCommandError(stderr io.Writer, err error) int {
+	message := strings.TrimPrefix(err.Error(), "zero session")
+	if message != err.Error() {
+		message = "Zero session" + message
+	}
+	if strings.Contains(message, "not found") || strings.Contains(message, "invalid zero session id") {
+		return writeExecUsageError(stderr, message)
+	}
+	return writeAppError(stderr, message, exitCrash)
+}
+
+func formatSessionsList(items []sessions.Metadata) string {
+	if len(items) == 0 {
+		return "No Zero sessions found."
+	}
+	lines := []string{fmt.Sprintf("Zero sessions (%d):", len(items))}
+	for _, session := range items {
+		lines = append(lines, "  "+formatSessionLine(session))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatSessionTree(node sessions.TreeNode) string {
+	lines := []string{"Zero session tree:"}
+	appendSessionTree(&lines, node, "")
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func appendSessionTree(lines *[]string, node sessions.TreeNode, prefix string) {
+	*lines = append(*lines, prefix+formatSessionLine(node.Session))
+	for _, child := range node.Children {
+		appendSessionTree(lines, child, prefix+"  ")
+	}
+}
+
+func formatSessionLine(session sessions.Metadata) string {
+	parts := []string{"- " + redact(session.SessionID)}
+	if session.SessionKind != "" {
+		parts = append(parts, "["+redact(string(session.SessionKind))+"]")
+	}
+	if session.Title != "" {
+		parts = append(parts, redact(session.Title))
+	}
+	details := []string{}
+	if session.AgentName != "" {
+		details = append(details, "agent="+redact(session.AgentName))
+	}
+	if session.TaskID != "" {
+		details = append(details, "task="+redact(session.TaskID))
+	}
+	if session.ParentSessionID != "" {
+		details = append(details, "parent="+redact(session.ParentSessionID))
+	}
+	if session.ModelID != "" {
+		details = append(details, "model="+redact(session.ModelID))
+	}
+	if len(details) > 0 {
+		parts = append(parts, "("+strings.Join(details, ", ")+")")
+	}
+	return strings.Join(parts, " ")
+}
+
+func redact(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
+}
+
+func writeSessionsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero sessions <command> [flags]
+
+Commands:
+  list                  List local Zero sessions
+  children <id>         List direct child sessions for a parent session
+  lineage <id>          Print the root-to-session lineage path
+  tree <id>             Print a child-session tree
+
+Flags:
+      --json            Print JSON output
+  -h, --help            Show this help
+`)
+	return err
+}

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -28,6 +28,9 @@ func runSessions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 	store := deps.newSessionStore()
 	switch command {
 	case "list":
+		if len(remaining) != 0 {
+			return writeExecUsageError(stderr, "sessions list does not accept positional arguments")
+		}
 		return runSessionsList(store, options, stdout, stderr)
 	case "children":
 		if len(remaining) != 1 {
@@ -52,6 +55,7 @@ func runSessions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 func parseSessionsArgs(args []string) (string, []string, sessionCommandOptions, bool, error) {
 	options := sessionCommandOptions{}
 	command := "list"
+	commandExplicit := false
 	remaining := []string{}
 	for _, arg := range args {
 		switch arg {
@@ -63,9 +67,13 @@ func parseSessionsArgs(args []string) (string, []string, sessionCommandOptions, 
 			if strings.HasPrefix(arg, "-") {
 				return command, remaining, options, false, execUsageError{fmt.Sprintf("unknown sessions flag %q", arg)}
 			}
-			if command == "list" && len(remaining) == 0 && isSessionsCommand(arg) {
+			if !commandExplicit && len(remaining) == 0 && isSessionsCommand(arg) {
 				command = arg
+				commandExplicit = true
 				continue
+			}
+			if !commandExplicit && len(remaining) == 0 {
+				return command, remaining, options, false, execUsageError{fmt.Sprintf("unknown sessions command %q", arg)}
 			}
 			remaining = append(remaining, arg)
 		}

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+func TestRunSessionsListsLineageAndTree(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: sequenceClockCLI([]time.Time{
+		time.Date(2026, 6, 4, 19, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 4, 19, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 4, 19, 0, 2, 0, time.UTC),
+		time.Date(2026, 6, 4, 19, 0, 3, 0, time.UTC),
+		time.Date(2026, 6, 4, 19, 0, 4, 0, time.UTC),
+	})})
+	root, err := store.Create(sessions.CreateInput{SessionID: "root", Title: "Root session"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	child, err := store.CreateChild(root.SessionID, sessions.ChildInput{
+		SessionID: "child",
+		Title:     "Review child",
+		AgentName: "code-review",
+		TaskID:    "task-7",
+	})
+	if err != nil {
+		t.Fatalf("CreateChild returned error: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sessions", "list"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("sessions list exit = %d, stderr = %q", exitCode, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Zero sessions") || !strings.Contains(output, root.SessionID) || !strings.Contains(output, child.SessionID) || !strings.Contains(output, "code-review") {
+		t.Fatalf("sessions list output = %q, want root, child, and agent", output)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"sessions", "lineage", child.SessionID}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("sessions lineage exit = %d, stderr = %q", exitCode, stderr.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "root -> child") {
+		t.Fatalf("sessions lineage output = %q, want root-to-child path", got)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"sessions", "tree", root.SessionID, "--json"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("sessions tree exit = %d, stderr = %q", exitCode, stderr.String())
+	}
+	var tree sessions.TreeNode
+	if err := json.Unmarshal(stdout.Bytes(), &tree); err != nil {
+		t.Fatalf("sessions tree JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if tree.Session.SessionID != root.SessionID || len(tree.Children) != 1 || tree.Children[0].Session.SessionID != child.SessionID {
+		t.Fatalf("sessions tree JSON = %#v, want root with one child", tree)
+	}
+}
+
+func TestRunSessionsValidatesArgs(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T19:30:00Z")})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sessions", "children", "missing"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	})
+	if exitCode != exitUsage {
+		t.Fatalf("sessions children exit = %d, want usage", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "Zero session not found: missing") {
+		t.Fatalf("sessions children stderr = %q, want missing-session error", stderr.String())
+	}
+}
+
+func sequenceClockCLI(values []time.Time) func() time.Time {
+	index := 0
+	return func() time.Time {
+		if index >= len(values) {
+			return values[len(values)-1]
+		}
+		value := values[index]
+		index++
+		return value
+	}
+}

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -96,6 +96,31 @@ func TestRunSessionsValidatesArgs(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Zero session not found: missing") {
 		t.Fatalf("sessions children stderr = %q, want missing-session error", stderr.String())
 	}
+
+	for _, test := range []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{name: "unknown command", args: []string{"sessions", "foo"}, wantStderr: `unknown sessions command "foo"`},
+		{name: "list extra arg", args: []string{"sessions", "list", "extra"}, wantStderr: "sessions list does not accept positional arguments"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+			exitCode := runWithDeps(test.args, &stdout, &stderr, appDeps{
+				newSessionStore: func() *sessions.Store {
+					return store
+				},
+			})
+			if exitCode != exitUsage {
+				t.Fatalf("%v exit = %d, want usage", test.args, exitCode)
+			}
+			if !strings.Contains(stderr.String(), test.wantStderr) {
+				t.Fatalf("%v stderr = %q, want %q", test.args, stderr.String(), test.wantStderr)
+			}
+		})
+	}
 }
 
 func sequenceClockCLI(values []time.Time) func() time.Time {

--- a/internal/sessions/lineage.go
+++ b/internal/sessions/lineage.go
@@ -1,0 +1,178 @@
+package sessions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (store *Store) CreateChild(parentSessionID string, input ChildInput) (Metadata, error) {
+	if !ValidSessionID(parentSessionID) {
+		return Metadata{}, fmt.Errorf("invalid zero session id %q", parentSessionID)
+	}
+	parent, err := store.Get(parentSessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if parent == nil {
+		return Metadata{}, fmt.Errorf("zero session not found: %s", parentSessionID)
+	}
+	parentEvents, err := store.ReadEvents(parent.SessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	var lastParentEvent Event
+	if len(parentEvents) > 0 {
+		lastParentEvent = parentEvents[len(parentEvents)-1]
+	}
+
+	child, err := store.Create(CreateInput{
+		SessionID:           input.SessionID,
+		SessionKind:         SessionKindChild,
+		Title:               childTitle(input.Title, input.AgentName, parent.Title),
+		Cwd:                 firstNonEmpty(input.Cwd, parent.Cwd),
+		ModelID:             firstNonEmpty(input.ModelID, parent.ModelID),
+		Provider:            firstNonEmpty(input.Provider, parent.Provider),
+		ParentSessionID:     parent.SessionID,
+		RootSessionID:       firstNonEmpty(parent.RootSessionID, parent.SessionID),
+		AgentName:           strings.TrimSpace(input.AgentName),
+		TaskID:              strings.TrimSpace(input.TaskID),
+		SpawnedFromEventID:  lastParentEvent.ID,
+		SpawnedFromSequence: lastParentEvent.Sequence,
+	})
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	payload := childLinkPayload(parent, child, input, lastParentEvent)
+	if _, err := store.AppendEvent(child.SessionID, AppendEventInput{Type: EventSessionChild, Payload: payload}); err != nil {
+		return Metadata{}, err
+	}
+	if _, err := store.AppendEvent(parent.SessionID, AppendEventInput{Type: EventSessionChild, Payload: payload}); err != nil {
+		return Metadata{}, err
+	}
+	loaded, err := store.readMetadata(child.SessionID)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return loaded, nil
+}
+
+func (store *Store) ListChildren(parentSessionID string) ([]Metadata, error) {
+	if !ValidSessionID(parentSessionID) {
+		return nil, fmt.Errorf("invalid zero session id %q", parentSessionID)
+	}
+	parent, err := store.Get(parentSessionID)
+	if err != nil {
+		return nil, err
+	}
+	if parent == nil {
+		return nil, fmt.Errorf("zero session not found: %s", parentSessionID)
+	}
+	all, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	children := []Metadata{}
+	for _, session := range all {
+		if session.ParentSessionID == parentSessionID && session.SessionKind == SessionKindChild {
+			children = append(children, session)
+		}
+	}
+	sort.SliceStable(children, func(left int, right int) bool {
+		if children[left].SpawnedFromSequence == children[right].SpawnedFromSequence {
+			return children[left].UpdatedAt > children[right].UpdatedAt
+		}
+		return children[left].SpawnedFromSequence > children[right].SpawnedFromSequence
+	})
+	return children, nil
+}
+
+func (store *Store) Lineage(sessionID string) ([]Metadata, error) {
+	if !ValidSessionID(sessionID) {
+		return nil, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	lineage := []Metadata{}
+	seen := map[string]bool{}
+	currentID := sessionID
+	for currentID != "" {
+		if seen[currentID] {
+			return nil, fmt.Errorf("cycle in zero session lineage at %s", currentID)
+		}
+		seen[currentID] = true
+		session, err := store.Get(currentID)
+		if err != nil {
+			return nil, err
+		}
+		if session == nil {
+			return nil, fmt.Errorf("zero session not found: %s", currentID)
+		}
+		lineage = append(lineage, *session)
+		currentID = session.ParentSessionID
+	}
+	for left, right := 0, len(lineage)-1; left < right; left, right = left+1, right-1 {
+		lineage[left], lineage[right] = lineage[right], lineage[left]
+	}
+	return lineage, nil
+}
+
+func (store *Store) Tree(rootSessionID string) (TreeNode, error) {
+	if !ValidSessionID(rootSessionID) {
+		return TreeNode{}, fmt.Errorf("invalid zero session id %q", rootSessionID)
+	}
+	return store.tree(rootSessionID, map[string]bool{})
+}
+
+func (store *Store) tree(sessionID string, seen map[string]bool) (TreeNode, error) {
+	if seen[sessionID] {
+		return TreeNode{}, fmt.Errorf("cycle in zero session tree at %s", sessionID)
+	}
+	seen[sessionID] = true
+	session, err := store.Get(sessionID)
+	if err != nil {
+		return TreeNode{}, err
+	}
+	if session == nil {
+		return TreeNode{}, fmt.Errorf("zero session not found: %s", sessionID)
+	}
+	children, err := store.ListChildren(sessionID)
+	if err != nil {
+		return TreeNode{}, err
+	}
+	node := TreeNode{Session: *session, Children: make([]TreeNode, 0, len(children))}
+	for _, child := range children {
+		childNode, err := store.tree(child.SessionID, seen)
+		if err != nil {
+			return TreeNode{}, err
+		}
+		node.Children = append(node.Children, childNode)
+	}
+	delete(seen, sessionID)
+	return node, nil
+}
+
+func childTitle(title string, agentName string, parentTitle string) string {
+	if trimmed := strings.TrimSpace(title); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(agentName); trimmed != "" {
+		return trimmed + " child session"
+	}
+	if trimmed := strings.TrimSpace(parentTitle); trimmed != "" {
+		return trimmed + " (child)"
+	}
+	return "Zero child session"
+}
+
+func childLinkPayload(parent *Metadata, child Metadata, input ChildInput, lastParentEvent Event) map[string]any {
+	return map[string]any{
+		"parentSessionId":     parent.SessionID,
+		"childSessionId":      child.SessionID,
+		"rootSessionId":       child.RootSessionID,
+		"agentName":           strings.TrimSpace(input.AgentName),
+		"taskId":              strings.TrimSpace(input.TaskID),
+		"prompt":              strings.TrimSpace(input.Prompt),
+		"spawnedFromEventId":  lastParentEvent.ID,
+		"spawnedFromSequence": lastParentEvent.Sequence,
+	}
+}

--- a/internal/sessions/lineage.go
+++ b/internal/sessions/lineage.go
@@ -45,10 +45,10 @@ func (store *Store) CreateChild(parentSessionID string, input ChildInput) (Metad
 	}
 
 	payload := childLinkPayload(parent, child, input, lastParentEvent)
-	if _, err := store.AppendEvent(child.SessionID, AppendEventInput{Type: EventSessionChild, Payload: payload}); err != nil {
+	if _, err := store.AppendEvent(parent.SessionID, AppendEventInput{Type: EventSessionChild, Payload: payload}); err != nil {
 		return Metadata{}, err
 	}
-	if _, err := store.AppendEvent(parent.SessionID, AppendEventInput{Type: EventSessionChild, Payload: payload}); err != nil {
+	if _, err := store.AppendEvent(child.SessionID, AppendEventInput{Type: EventSessionChild, Payload: payload}); err != nil {
 		return Metadata{}, err
 	}
 	loaded, err := store.readMetadata(child.SessionID)

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -30,32 +30,52 @@ const (
 	EventUsage         EventType = EventProviderUsage
 	EventError         EventType = "error"
 	EventSessionFork   EventType = "session_fork"
+	EventSessionChild  EventType = "session_child"
+)
+
+type SessionKind string
+
+const (
+	SessionKindFork  SessionKind = "fork"
+	SessionKindChild SessionKind = "child"
 )
 
 type Metadata struct {
-	SessionID          string    `json:"sessionId"`
-	Title              string    `json:"title,omitempty"`
-	Cwd                string    `json:"cwd,omitempty"`
-	ModelID            string    `json:"modelId,omitempty"`
-	Provider           string    `json:"provider,omitempty"`
-	ParentSessionID    string    `json:"parentSessionId,omitempty"`
-	ForkedFromEventID  string    `json:"forkedFromEventId,omitempty"`
-	ForkedFromSequence int       `json:"forkedFromSequence,omitempty"`
-	CreatedAt          string    `json:"createdAt"`
-	UpdatedAt          string    `json:"updatedAt"`
-	EventCount         int       `json:"eventCount"`
-	LastEventType      EventType `json:"lastEventType,omitempty"`
+	SessionID           string      `json:"sessionId"`
+	SessionKind         SessionKind `json:"sessionKind,omitempty"`
+	Title               string      `json:"title,omitempty"`
+	Cwd                 string      `json:"cwd,omitempty"`
+	ModelID             string      `json:"modelId,omitempty"`
+	Provider            string      `json:"provider,omitempty"`
+	ParentSessionID     string      `json:"parentSessionId,omitempty"`
+	RootSessionID       string      `json:"rootSessionId,omitempty"`
+	AgentName           string      `json:"agentName,omitempty"`
+	TaskID              string      `json:"taskId,omitempty"`
+	ForkedFromEventID   string      `json:"forkedFromEventId,omitempty"`
+	ForkedFromSequence  int         `json:"forkedFromSequence,omitempty"`
+	SpawnedFromEventID  string      `json:"spawnedFromEventId,omitempty"`
+	SpawnedFromSequence int         `json:"spawnedFromSequence,omitempty"`
+	CreatedAt           string      `json:"createdAt"`
+	UpdatedAt           string      `json:"updatedAt"`
+	EventCount          int         `json:"eventCount"`
+	LastEventType       EventType   `json:"lastEventType,omitempty"`
 }
 
 type CreateInput struct {
-	SessionID          string
-	Title              string
-	Cwd                string
-	ModelID            string
-	Provider           string
-	ParentSessionID    string
-	ForkedFromEventID  string
-	ForkedFromSequence int
+	SessionID           string
+	SessionKind         SessionKind
+	Title               string
+	Cwd                 string
+	ModelID             string
+	Provider            string
+	ParentSessionID     string
+	RootSessionID       string
+	AgentName           string
+	TaskID              string
+	ForkedFromEventID   string
+	ForkedFromSequence  int
+	SpawnedFromEventID  string
+	SpawnedFromSequence int
 }
 
 type ForkInput struct {
@@ -64,6 +84,22 @@ type ForkInput struct {
 	Cwd       string
 	ModelID   string
 	Provider  string
+}
+
+type ChildInput struct {
+	SessionID string
+	Title     string
+	Cwd       string
+	ModelID   string
+	Provider  string
+	AgentName string
+	TaskID    string
+	Prompt    string
+}
+
+type TreeNode struct {
+	Session  Metadata   `json:"session"`
+	Children []TreeNode `json:"children"`
 }
 
 type AppendEventInput struct {
@@ -138,17 +174,23 @@ func (store *Store) Create(input CreateInput) (Metadata, error) {
 
 	timestamp := store.timestamp()
 	session := Metadata{
-		SessionID:          sessionID,
-		Title:              strings.TrimSpace(input.Title),
-		Cwd:                strings.TrimSpace(input.Cwd),
-		ModelID:            strings.TrimSpace(input.ModelID),
-		Provider:           strings.TrimSpace(input.Provider),
-		ParentSessionID:    strings.TrimSpace(input.ParentSessionID),
-		ForkedFromEventID:  strings.TrimSpace(input.ForkedFromEventID),
-		ForkedFromSequence: input.ForkedFromSequence,
-		CreatedAt:          timestamp,
-		UpdatedAt:          timestamp,
-		EventCount:         0,
+		SessionID:           sessionID,
+		SessionKind:         input.SessionKind,
+		Title:               strings.TrimSpace(input.Title),
+		Cwd:                 strings.TrimSpace(input.Cwd),
+		ModelID:             strings.TrimSpace(input.ModelID),
+		Provider:            strings.TrimSpace(input.Provider),
+		ParentSessionID:     strings.TrimSpace(input.ParentSessionID),
+		RootSessionID:       strings.TrimSpace(input.RootSessionID),
+		AgentName:           strings.TrimSpace(input.AgentName),
+		TaskID:              strings.TrimSpace(input.TaskID),
+		ForkedFromEventID:   strings.TrimSpace(input.ForkedFromEventID),
+		ForkedFromSequence:  input.ForkedFromSequence,
+		SpawnedFromEventID:  strings.TrimSpace(input.SpawnedFromEventID),
+		SpawnedFromSequence: input.SpawnedFromSequence,
+		CreatedAt:           timestamp,
+		UpdatedAt:           timestamp,
+		EventCount:          0,
 	}
 
 	if err := os.MkdirAll(store.RootDir, 0o700); err != nil {
@@ -249,11 +291,13 @@ func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, err
 	}
 	fork, err := store.Create(CreateInput{
 		SessionID:          input.SessionID,
+		SessionKind:        SessionKindFork,
 		Title:              title,
 		Cwd:                firstNonEmpty(input.Cwd, parent.Cwd),
 		ModelID:            firstNonEmpty(input.ModelID, parent.ModelID),
 		Provider:           firstNonEmpty(input.Provider, parent.Provider),
 		ParentSessionID:    parent.SessionID,
+		RootSessionID:      firstNonEmpty(parent.RootSessionID, parent.SessionID),
 		ForkedFromEventID:  last.ID,
 		ForkedFromSequence: last.Sequence,
 	})

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -112,6 +112,128 @@ func TestStoreForkCopiesEventsAndLineage(t *testing.T) {
 	}
 }
 
+func TestStoreCreatesChildSessionsAndRecordsLineageEvents(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T11:30:00Z")})
+	parent, err := store.Create(CreateInput{
+		SessionID: "parent",
+		Title:     "Parent",
+		Cwd:       "/repo",
+		ModelID:   "gpt-4.1",
+		Provider:  "openai",
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if _, err := store.AppendEvent(parent.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": "plan"}}); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+
+	child, err := store.CreateChild(parent.SessionID, ChildInput{
+		SessionID: "child",
+		Title:     "Review agent",
+		AgentName: "code-review",
+		TaskID:    "task-1",
+		Prompt:    "Review the diff",
+	})
+	if err != nil {
+		t.Fatalf("CreateChild returned error: %v", err)
+	}
+	if child.SessionKind != SessionKindChild || child.ParentSessionID != parent.SessionID || child.RootSessionID != parent.SessionID {
+		t.Fatalf("child lineage metadata = %#v", child)
+	}
+	if child.Cwd != parent.Cwd || child.ModelID != parent.ModelID || child.Provider != parent.Provider {
+		t.Fatalf("child did not inherit parent runtime context: %#v", child)
+	}
+	if child.AgentName != "code-review" || child.TaskID != "task-1" || child.SpawnedFromEventID != "parent:1" || child.SpawnedFromSequence != 1 {
+		t.Fatalf("child agent metadata = %#v", child)
+	}
+
+	childEvents, err := store.ReadEvents(child.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents child returned error: %v", err)
+	}
+	if len(childEvents) != 1 || childEvents[0].Type != EventSessionChild {
+		t.Fatalf("child events = %#v, want one session_child event", childEvents)
+	}
+	var childPayload map[string]any
+	if err := json.Unmarshal(childEvents[0].Payload, &childPayload); err != nil {
+		t.Fatalf("decode child payload: %v", err)
+	}
+	if childPayload["parentSessionId"] != parent.SessionID || childPayload["prompt"] != "Review the diff" {
+		t.Fatalf("child payload = %#v, want parent and prompt", childPayload)
+	}
+
+	parentEvents, err := store.ReadEvents(parent.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents parent returned error: %v", err)
+	}
+	if len(parentEvents) != 2 || parentEvents[1].Type != EventSessionChild {
+		t.Fatalf("parent events = %#v, want child linkage event", parentEvents)
+	}
+	var parentPayload map[string]any
+	if err := json.Unmarshal(parentEvents[1].Payload, &parentPayload); err != nil {
+		t.Fatalf("decode parent payload: %v", err)
+	}
+	if parentPayload["childSessionId"] != child.SessionID || parentPayload["agentName"] != "code-review" {
+		t.Fatalf("parent payload = %#v, want child linkage", parentPayload)
+	}
+}
+
+func TestStoreListsChildrenLineageAndTree(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: sequenceClock([]time.Time{
+		time.Date(2026, 6, 4, 11, 45, 0, 0, time.UTC),
+		time.Date(2026, 6, 4, 11, 45, 1, 0, time.UTC),
+		time.Date(2026, 6, 4, 11, 45, 2, 0, time.UTC),
+		time.Date(2026, 6, 4, 11, 45, 3, 0, time.UTC),
+		time.Date(2026, 6, 4, 11, 45, 4, 0, time.UTC),
+		time.Date(2026, 6, 4, 11, 45, 5, 0, time.UTC),
+		time.Date(2026, 6, 4, 11, 45, 6, 0, time.UTC),
+	})})
+	root, err := store.Create(CreateInput{SessionID: "root", Title: "Root"})
+	if err != nil {
+		t.Fatalf("Create root returned error: %v", err)
+	}
+	first, err := store.CreateChild(root.SessionID, ChildInput{SessionID: "first", AgentName: "review"})
+	if err != nil {
+		t.Fatalf("CreateChild first returned error: %v", err)
+	}
+	second, err := store.CreateChild(root.SessionID, ChildInput{SessionID: "second", AgentName: "test-gen"})
+	if err != nil {
+		t.Fatalf("CreateChild second returned error: %v", err)
+	}
+	grandchild, err := store.CreateChild(first.SessionID, ChildInput{SessionID: "grandchild", AgentName: "security"})
+	if err != nil {
+		t.Fatalf("CreateChild grandchild returned error: %v", err)
+	}
+
+	children, err := store.ListChildren(root.SessionID)
+	if err != nil {
+		t.Fatalf("ListChildren returned error: %v", err)
+	}
+	if got := []string{children[0].SessionID, children[1].SessionID}; !reflect.DeepEqual(got, []string{second.SessionID, first.SessionID}) {
+		t.Fatalf("children order = %#v, want newest direct children first", got)
+	}
+
+	lineage, err := store.Lineage(grandchild.SessionID)
+	if err != nil {
+		t.Fatalf("Lineage returned error: %v", err)
+	}
+	if got := []string{lineage[0].SessionID, lineage[1].SessionID, lineage[2].SessionID}; !reflect.DeepEqual(got, []string{root.SessionID, first.SessionID, grandchild.SessionID}) {
+		t.Fatalf("lineage = %#v, want root to child path", got)
+	}
+
+	tree, err := store.Tree(root.SessionID)
+	if err != nil {
+		t.Fatalf("Tree returned error: %v", err)
+	}
+	if tree.Session.SessionID != root.SessionID || len(tree.Children) != 2 {
+		t.Fatalf("tree root = %#v, want two children", tree)
+	}
+	if tree.Children[1].Session.SessionID != first.SessionID || len(tree.Children[1].Children) != 1 {
+		t.Fatalf("tree nested children = %#v, want grandchild under first", tree.Children)
+	}
+}
+
 func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
 	got := DefaultRoot(map[string]string{
 		"XDG_DATA_HOME": "/tmp/zero-data",


### PR DESCRIPTION
## Summary
- Add Go session lineage metadata for forked and child sessions, including root session, agent/task identifiers, and parent spawn event anchors.
- Add child-session backend APIs to create delegated child sessions, list direct children, walk root-to-child lineage, and build session trees for future agent orchestration surfaces.
- Add a Go `zero sessions` inspector command with text and JSON output for list, children, lineage, and tree views.

## PRD Alignment
- Covers the Gnanam-owned M4 dependency for parent/child session APIs that future subagent framework and `/agents` UI work can consume.
- Keeps task execution/subagent orchestration out of this PR; this slice is only the durable backend contract and inspectable CLI surface.

## Validation
- `go test -run 'TestStoreCreatesChildSessionsAndRecordsLineageEvents|TestStoreListsChildrenLineageAndTree' -count=1 ./internal/sessions`
- `go test -run 'TestRunSessionsListsLineageAndTree|TestRunSessionsValidatesArgs|TestRunCommandsDoNotLaunchTUI|TestRunPrintsHelp' -count=1 ./internal/cli`
- `go test -count=1 ./internal/sessions ./internal/cli`
- `go test -count=1 -p 1 ./...`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000` (291 pass / 0 fail)
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `npx --yes bun run smoke:go`
- `./zero --help`
- `./zero sessions --help`
- `./zero sessions list --json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `sessions` command group (list, children, lineage, tree) with optional `--json` output to inspect local session lineage and relationships.
  * Child sessions inherit runtime context and record parent/child linkage so lineage and tree views reflect full ancestry.

* **Bug Fixes**
  * Improved CLI argument validation and clearer usage/error messages.

* **Tests**
  * Added comprehensive CLI and unit tests covering session creation, lineage, ordering, and tree output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->