### PR TITLE
feat: persist TUI sessions

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -39,6 +39,8 @@ type model struct {
 	newProvider      func(config.ProviderProfile) (zeroruntime.Provider, error)
 	registry         *tools.Registry
 	sessionStore     *sessions.Store
+	activeSession    sessions.Metadata
+	sessionEvents    []sessions.Event
 	usageTracker     *usage.Tracker
 	agentOptions     agent.Options
 	permissionMode   agent.PermissionMode
@@ -58,11 +60,12 @@ type model struct {
 }
 
 type agentResponseMsg struct {
-	runID        int
-	rows         []transcriptRow
-	usageEvents  []zeroruntime.Usage
-	usageModelID string
-	err          error
+	runID         int
+	rows          []transcriptRow
+	usageEvents   []zeroruntime.Usage
+	usageModelID  string
+	sessionEvents []pendingSessionEvent
+	err           error
 }
 
 func newModel(ctx context.Context, options Options) model {
@@ -162,6 +165,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.transcript = appendRow(m.transcript, row.kind, row.text)
 			}
 		}
+		var sessionRows []transcriptRow
+		m, sessionRows = m.appendSessionEvents(msg.sessionEvents)
+		for _, row := range sessionRows {
+			m.transcript = appendRow(m.transcript, row.kind, row.text)
+		}
 		for _, row := range msg.rows {
 			m.transcript = appendRow(m.transcript, row.kind, row.text)
 		}
@@ -254,7 +262,18 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.searchText(command.text)})
 		return m, nil
 	case commandResume:
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.resumeText(command.text)})
+		if m.pending {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{
+				kind: actionAppendError,
+				text: "Cannot resume sessions while a run is active.",
+			})
+			return m, nil
+		}
+		text := ""
+		m, text = m.handleResumeCommand(command.text)
+		if text != "" {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		}
 		return m, nil
 	case commandCompact:
 		text := ""
@@ -292,6 +311,27 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			})
 			return m, nil
 		}
+		var err error
+		m, err = m.ensureActiveSession(command.text)
+		if err != nil {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{
+				kind: actionAppendError,
+				text: "session create error: " + err.Error(),
+			})
+		} else {
+			agentPrompt := m.sessionPrompt(command.text)
+			m, err = m.appendSessionEvent(sessions.EventMessage, map[string]any{
+				"role":    "user",
+				"content": command.text,
+			})
+			if err != nil {
+				m.transcript = reduceTranscript(m.transcript, transcriptAction{
+					kind: actionAppendError,
+					text: "session record error: " + err.Error(),
+				})
+			}
+			command.text = agentPrompt
+		}
 		runCtx, cancel := context.WithCancel(m.ctx)
 		m.runID++
 		m.activeRunID = m.runID
@@ -307,6 +347,13 @@ func (m *model) cancelRun() {
 	if m.runCancel != nil {
 		m.runCancel()
 	}
+	if m.pending && m.activeSession.SessionID != "" {
+		if next, err := (*m).appendSessionEvent(sessions.EventError, map[string]any{
+			"message": "Run cancelled.",
+		}); err == nil {
+			*m = next
+		}
+	}
 	m.pending = false
 	m.runCancel = nil
 	m.activeRunID = 0
@@ -316,6 +363,7 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 	return func() tea.Msg {
 		rows := []transcriptRow{}
 		usageEvents := []zeroruntime.Usage{}
+		sessionEvents := []pendingSessionEvent{}
 		usageModelID := m.modelName
 		options := m.agentOptions
 		options.Registry = m.registry
@@ -324,6 +372,14 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		onToolCall := options.OnToolCall
 		options.OnToolCall = func(call agent.ToolCall) {
 			rows = append(rows, transcriptRow{kind: rowToolCall, text: "tool call: " + call.Name})
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type: sessions.EventToolCall,
+				Payload: map[string]any{
+					"id":        call.ID,
+					"name":      call.Name,
+					"arguments": call.Arguments,
+				},
+			})
 			if onToolCall != nil {
 				onToolCall(call)
 			}
@@ -335,6 +391,15 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 				kind: rowToolResult,
 				text: toolResultRowText(result),
 			})
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type: sessions.EventToolResult,
+				Payload: map[string]any{
+					"toolCallId": result.ToolCallID,
+					"name":       result.Name,
+					"status":     string(result.Status),
+					"output":     result.Output,
+				},
+			})
 			if onToolResult != nil {
 				onToolResult(result)
 			}
@@ -343,6 +408,14 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		onUsage := options.OnUsage
 		options.OnUsage = func(event zeroruntime.Usage) {
 			usageEvents = append(usageEvents, event)
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type: sessions.EventUsage,
+				Payload: map[string]any{
+					"promptTokens":     event.EffectiveInputTokens(),
+					"completionTokens": event.EffectiveOutputTokens(),
+					"totalTokens":      event.TotalTokens(),
+				},
+			})
 			if onUsage != nil {
 				onUsage(event)
 			}
@@ -350,10 +423,21 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 
 		result, err := agent.Run(runCtx, prompt, m.provider, options)
 		if err != nil {
-			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, err: err}
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type:    sessions.EventError,
+				Payload: map[string]any{"message": err.Error()},
+			})
+			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, err: err}
 		}
 		rows = append(rows, transcriptRow{kind: rowAssistant, text: result.FinalAnswer})
-		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID}
+		sessionEvents = append(sessionEvents, pendingSessionEvent{
+			Type: sessions.EventMessage,
+			Payload: map[string]any{
+				"role":    "assistant",
+				"content": result.FinalAnswer,
+			},
+		})
+		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents}
 	}
 }
 
@@ -425,6 +509,7 @@ func (m model) contextText() string {
 		"usage: " + m.usageSummaryText(),
 		"compaction: " + m.compactionStatus(),
 		fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
+		"active session: " + displayValue(m.activeSession.SessionID, "none"),
 		"session root: " + displayValue(m.sessionStore.RootDir, "unknown"),
 		fmt.Sprintf("tools: %d", len(m.registry.All())),
 	}, "\n")

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -535,7 +535,7 @@ func TestResumeCommandWithUnknownIDReportsMissingSession(t *testing.T) {
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
-	if !transcriptContains(next.transcript, "Zero session not found: zero_123") {
+	if !transcriptContains(next.transcript, "zero session not found: zero_123") {
 		t.Fatalf("expected missing session message, got %#v", next.transcript)
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -528,15 +528,15 @@ func TestResumeCommandListsRecentSessions(t *testing.T) {
 	}
 }
 
-func TestResumeCommandWithIDShowsHeadlessGuidance(t *testing.T) {
-	m := newModel(context.Background(), Options{})
+func TestResumeCommandWithUnknownIDReportsMissingSession(t *testing.T) {
+	m := newModel(context.Background(), Options{SessionStore: testSessionStore(t)})
 	m.input.SetValue("/resume zero_123")
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
-	if !transcriptContains(next.transcript, "zero exec --resume zero_123") {
-		t.Fatalf("expected resume guidance, got %#v", next.transcript)
+	if !transcriptContains(next.transcript, "Zero session not found: zero_123") {
+		t.Fatalf("expected missing session message, got %#v", next.transcript)
 	}
 }
 
@@ -547,8 +547,9 @@ func TestPromptSubmitAppendsUserAndAssistantRows(t *testing.T) {
 		{Type: zeroruntime.StreamEventDone},
 	}}
 	m := newModel(context.Background(), Options{
-		Provider: provider,
-		Registry: tools.NewRegistry(),
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
 	})
 	m.input.SetValue("say hi")
 

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -1,0 +1,235 @@
+package tui
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const tuiSessionTitleLimit = 80
+
+type pendingSessionEvent struct {
+	Type    sessions.EventType
+	Payload any
+}
+
+func (m model) ensureActiveSession(prompt string) (model, error) {
+	if m.activeSession.SessionID != "" {
+		return m, nil
+	}
+
+	session, err := m.sessionStore.Create(sessions.CreateInput{
+		Title:    tuiSessionTitle(prompt),
+		Cwd:      m.cwd,
+		ModelID:  m.modelName,
+		Provider: m.providerName,
+	})
+	if err != nil {
+		return m, err
+	}
+	m.activeSession = session
+	m.sessionEvents = []sessions.Event{}
+	return m, nil
+}
+
+func (m model) appendSessionEvent(eventType sessions.EventType, payload any) (model, error) {
+	if m.activeSession.SessionID == "" {
+		return m, nil
+	}
+
+	event, err := m.sessionStore.AppendEvent(m.activeSession.SessionID, sessions.AppendEventInput{
+		Type:    eventType,
+		Payload: payload,
+	})
+	if err != nil {
+		return m, err
+	}
+	m.activeSession.UpdatedAt = event.CreatedAt
+	m.activeSession.EventCount = event.Sequence
+	m.activeSession.LastEventType = event.Type
+	m.sessionEvents = append(m.sessionEvents, event)
+	return m, nil
+}
+
+func (m model) appendSessionEvents(events []pendingSessionEvent) (model, []transcriptRow) {
+	rows := []transcriptRow{}
+	for _, event := range events {
+		next, err := m.appendSessionEvent(event.Type, event.Payload)
+		if err != nil {
+			rows = append(rows, transcriptRow{kind: rowError, text: "session record error: " + err.Error()})
+			continue
+		}
+		m = next
+	}
+	return m, rows
+}
+
+func tuiSessionTitle(prompt string) string {
+	title := strings.Join(strings.Fields(prompt), " ")
+	if len(title) > tuiSessionTitleLimit {
+		title = title[:tuiSessionTitleLimit]
+	}
+	if title == "" {
+		return "Zero TUI session"
+	}
+	return title
+}
+
+func (m model) handleResumeCommand(args string) (model, string) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return m, m.resumeText("")
+	}
+
+	session, err := m.resolveResumeSession(args)
+	if err != nil {
+		return m, "Sessions\n" + err.Error()
+	}
+	events, err := m.sessionStore.ReadEvents(session.SessionID)
+	if err != nil {
+		return m, "Sessions\nerror: " + err.Error()
+	}
+
+	m.activeSession = *session
+	m.sessionEvents = append([]sessions.Event{}, events...)
+	if m.providerName == "" {
+		m.providerName = session.Provider
+	}
+	if m.modelName == "" {
+		m.modelName = session.ModelID
+	}
+
+	rows := initialTranscript()
+	rows = appendRow(rows, rowSystem, formatResumeSummary(*session, len(events)))
+	for _, row := range transcriptRowsFromSessionEvents(events) {
+		rows = appendRow(rows, row.kind, row.text)
+	}
+	m.transcript = rows
+	return m, ""
+}
+
+func (m model) sessionPrompt(prompt string) string {
+	if m.activeSession.SessionID == "" || len(m.sessionEvents) == 0 {
+		return prompt
+	}
+	return sessions.FormatExecPrompt(prompt, sessions.PreparedExec{
+		Mode:          sessions.ModeResume,
+		Session:       m.activeSession,
+		ContextEvents: append([]sessions.Event{}, m.sessionEvents...),
+	})
+}
+
+func (m model) resolveResumeSession(args string) (*sessions.Metadata, error) {
+	if strings.EqualFold(args, "latest") {
+		latest, err := m.sessionStore.Latest()
+		if err != nil {
+			return nil, err
+		}
+		if latest == nil {
+			return nil, errors.New("No Zero sessions available to resume.")
+		}
+		return latest, nil
+	}
+
+	session, err := m.sessionStore.Get(args)
+	if err != nil {
+		return nil, err
+	}
+	if session == nil {
+		return nil, fmt.Errorf("Zero session not found: %s", args)
+	}
+	return session, nil
+}
+
+func formatResumeSummary(session sessions.Metadata, eventCount int) string {
+	return strings.Join([]string{
+		"Resumed Zero session",
+		"id: " + session.SessionID,
+		"title: " + displayValue(session.Title, "untitled"),
+		"model: " + displayValue(session.ModelID, "none"),
+		"provider: " + displayValue(session.Provider, "none"),
+		fmt.Sprintf("events: %d", eventCount),
+	}, "\n")
+}
+
+func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
+	rows := []transcriptRow{}
+	for _, event := range events {
+		payload := sessionPayload(event)
+		switch event.Type {
+		case sessions.EventMessage:
+			content := payloadString(payload, "content")
+			if content == "" {
+				continue
+			}
+			switch strings.ToLower(payloadString(payload, "role")) {
+			case "user":
+				rows = append(rows, transcriptRow{kind: rowUser, text: content})
+			case "assistant":
+				rows = append(rows, transcriptRow{kind: rowAssistant, text: content})
+			default:
+				rows = append(rows, transcriptRow{kind: rowSystem, text: content})
+			}
+		case sessions.EventToolCall:
+			name := payloadString(payload, "name")
+			if name == "" {
+				name = "unknown"
+			}
+			rows = append(rows, transcriptRow{kind: rowToolCall, text: "tool call: " + name})
+		case sessions.EventToolResult:
+			name := payloadString(payload, "name")
+			if name == "" {
+				name = "unknown"
+			}
+			status := tools.Status(payloadString(payload, "status"))
+			if status == "" {
+				status = tools.StatusOK
+			}
+			rows = append(rows, transcriptRow{
+				kind: rowToolResult,
+				text: fmt.Sprintf("tool result: %s %s %s", name, status, truncateTUIOutput(payloadString(payload, "output"), tuiToolOutputLimit)),
+			})
+		case sessions.EventError:
+			if message := payloadString(payload, "message"); message != "" {
+				rows = append(rows, transcriptRow{kind: rowError, text: message})
+			}
+		case sessions.EventSessionFork:
+			parentID := payloadString(payload, "parentSessionId")
+			if parentID != "" {
+				rows = append(rows, transcriptRow{kind: rowSystem, text: "forked from session: " + parentID})
+			}
+		}
+	}
+	return rows
+}
+
+func sessionPayload(event sessions.Event) map[string]any {
+	payload := map[string]any{}
+	if len(event.Payload) == 0 {
+		return payload
+	}
+	_ = json.Unmarshal(event.Payload, &payload)
+	return payload
+}
+
+func payloadString(payload map[string]any, key string) string {
+	value := payload[key]
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case float64, bool:
+		return fmt.Sprint(typed)
+	case nil:
+		return ""
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return ""
+		}
+		return string(data)
+	}
+}

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -130,7 +130,7 @@ func (m model) resolveResumeSession(args string) (*sessions.Metadata, error) {
 			return nil, err
 		}
 		if latest == nil {
-			return nil, errors.New("No Zero sessions available to resume.")
+			return nil, errors.New("no zero sessions available to resume")
 		}
 		return latest, nil
 	}
@@ -140,7 +140,7 @@ func (m model) resolveResumeSession(args string) (*sessions.Metadata, error) {
 		return nil, err
 	}
 	if session == nil {
-		return nil, fmt.Errorf("Zero session not found: %s", args)
+		return nil, fmt.Errorf("zero session not found: %s", args)
 	}
 	return session, nil
 }

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -127,9 +127,10 @@ func TestUsageEventsUpdateFooterAndContext(t *testing.T) {
 		{Type: zeroruntime.StreamEventDone},
 	}}
 	m := newModel(context.Background(), Options{
-		ModelName: "gpt-4.1",
-		Provider:  provider,
-		Registry:  tools.NewRegistry(),
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
 	})
 	m.input.SetValue("track usage")
 
@@ -170,9 +171,10 @@ func TestUsageEventsForwardExistingAgentCallback(t *testing.T) {
 	}}
 	seen := []zeroruntime.Usage{}
 	m := newModel(context.Background(), Options{
-		ModelName: "gpt-4.1",
-		Provider:  provider,
-		Registry:  tools.NewRegistry(),
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
 		AgentOptions: agent.Options{
 			OnUsage: func(event agent.Usage) {
 				seen = append(seen, event)
@@ -205,9 +207,10 @@ func TestUsageEventsForCustomModelUseTokenOnlyFallback(t *testing.T) {
 		{Type: zeroruntime.StreamEventDone},
 	}}
 	m := newModel(context.Background(), Options{
-		ModelName: "custom-coder",
-		Provider:  provider,
-		Registry:  tools.NewRegistry(),
+		ModelName:    "custom-coder",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
 	})
 	m.input.SetValue("track usage")
 
@@ -237,9 +240,10 @@ func TestInvalidUsageEventsAppendTranscriptError(t *testing.T) {
 		{Type: zeroruntime.StreamEventDone},
 	}}
 	m := newModel(context.Background(), Options{
-		ModelName: "gpt-4.1",
-		Provider:  provider,
-		Registry:  tools.NewRegistry(),
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
 	})
 	m.input.SetValue("track usage")
 

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -1,0 +1,443 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+type scriptedProvider struct {
+	scripts  [][]zeroruntime.StreamEvent
+	requests []zeroruntime.CompletionRequest
+	calls    int
+}
+
+func (provider *scriptedProvider) StreamCompletion(
+	ctx context.Context,
+	request zeroruntime.CompletionRequest,
+) (<-chan zeroruntime.StreamEvent, error) {
+	provider.requests = append(provider.requests, request)
+	if len(provider.scripts) == 0 {
+		ch := make(chan zeroruntime.StreamEvent)
+		close(ch)
+		return ch, nil
+	}
+	index := provider.calls
+	provider.calls++
+	if index >= len(provider.scripts) {
+		index = len(provider.scripts) - 1
+	}
+	ch := make(chan zeroruntime.StreamEvent, len(provider.scripts[index]))
+	for _, event := range provider.scripts[index] {
+		ch <- event
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestPromptSubmitPersistsTUISessionEvents(t *testing.T) {
+	store := testSessionStore(t)
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "saved"},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 10, OutputTokens: 4}},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		Cwd:          "repo",
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: store,
+	})
+	m.input.SetValue("inspect repo")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one persisted TUI session, got %d", len(list))
+	}
+	session := list[0]
+	if session.Title != "inspect repo" || session.Cwd != "repo" || session.ModelID != "gpt-4.1" || session.Provider != "openai" {
+		t.Fatalf("unexpected session metadata: %#v", session)
+	}
+
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
+		sessions.EventMessage,
+		sessions.EventUsage,
+		sessions.EventMessage,
+	}) {
+		t.Fatalf("unexpected event sequence: %#v", got)
+	}
+	assertPayloadField(t, events[0], "role", "user")
+	assertPayloadField(t, events[0], "content", "inspect repo")
+	assertPayloadField(t, events[1], "promptTokens", float64(10))
+	assertPayloadField(t, events[1], "completionTokens", float64(4))
+	assertPayloadField(t, events[1], "totalTokens", float64(14))
+	assertPayloadField(t, events[2], "role", "assistant")
+	assertPayloadField(t, events[2], "content", "saved")
+	if !transcriptContains(next.transcript, "saved") {
+		t.Fatalf("expected persisted run to still render assistant text, got %#v", next.transcript)
+	}
+}
+
+func TestPromptWithoutProviderDoesNotCreateSession(t *testing.T) {
+	store := testSessionStore(t)
+	m := newModel(context.Background(), Options{SessionStore: store})
+	m.input.SetValue("hello")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected missing provider prompt to stay synchronous")
+	}
+	if !transcriptContains(next.transcript, "No provider configured.") {
+		t.Fatalf("expected missing provider message, got %#v", next.transcript)
+	}
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected missing provider prompt not to create sessions, got %#v", list)
+	}
+}
+
+func TestPromptSubmitPersistsToolSessionEvents(t *testing.T) {
+	store := testSessionStore(t)
+	root := t.TempDir()
+	writeTestFile(t, root, "notes.txt", "file contents")
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_1", ToolName: "read_file"},
+			{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_1", ArgumentsFragment: `{"path":"notes.txt"}`},
+			{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_1"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+		{
+			{Type: zeroruntime.StreamEventText, Content: "read complete"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool(root))
+	m := newModel(context.Background(), Options{
+		Cwd:          root,
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     registry,
+		SessionStore: store,
+	})
+	m.input.SetValue("read notes")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+	updated, _ = next.Update(cmd())
+
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one session, got %d", len(list))
+	}
+	events, err := store.ReadEvents(list[0].SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
+		sessions.EventMessage,
+		sessions.EventToolCall,
+		sessions.EventToolResult,
+		sessions.EventMessage,
+	}) {
+		t.Fatalf("unexpected event sequence: %#v", got)
+	}
+	assertPayloadField(t, events[1], "id", "call_1")
+	assertPayloadField(t, events[1], "name", "read_file")
+	assertPayloadField(t, events[1], "arguments", `{"path":"notes.txt"}`)
+	assertPayloadField(t, events[2], "toolCallId", "call_1")
+	assertPayloadField(t, events[2], "name", "read_file")
+	assertPayloadField(t, events[2], "status", "ok")
+	assertPayloadFieldContains(t, events[2], "output", "file contents")
+	assertPayloadField(t, events[3], "content", "read complete")
+}
+
+func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "Hydrate me", Cwd: "repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "user", "content": "previous request"})
+	appendTestEvent(t, store, session.SessionID, sessions.EventToolCall, map[string]any{"id": "call_1", "name": "grep", "arguments": `{"pattern":"Zero"}`})
+	appendTestEvent(t, store, session.SessionID, sessions.EventToolResult, map[string]any{"toolCallId": "call_1", "name": "grep", "status": "ok", "output": "matches"})
+	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "previous answer"})
+	appendTestEvent(t, store, session.SessionID, sessions.EventError, map[string]any{"message": "old error"})
+
+	m := newModel(context.Background(), Options{SessionStore: store})
+	m.input.SetValue("/resume " + session.SessionID)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /resume to hydrate synchronously")
+	}
+	for _, want := range []string{"Resumed Zero session", session.SessionID, "previous request", "tool call: grep", "tool result: grep ok matches", "previous answer", "old error"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected resumed transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	if transcriptContains(next.transcript, "zero exec --resume") {
+		t.Fatalf("resume should not show headless-only guidance after hydration, got %#v", next.transcript)
+	}
+}
+
+func TestResumeCommandIsBlockedWhileRunPending(t *testing.T) {
+	store := testSessionStore(t)
+	active, err := store.Create(sessions.CreateInput{Title: "Active"})
+	if err != nil {
+		t.Fatalf("Create active returned error: %v", err)
+	}
+	other, err := store.Create(sessions.CreateInput{Title: "Other"})
+	if err != nil {
+		t.Fatalf("Create other returned error: %v", err)
+	}
+	m := newModel(context.Background(), Options{SessionStore: store})
+	m.activeSession = active
+	m.pending = true
+	m.input.SetValue("/resume " + other.SessionID)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected pending /resume to be handled without a command")
+	}
+	if next.activeSession.SessionID != active.SessionID {
+		t.Fatalf("expected pending /resume not to replace active session, got %#v", next.activeSession)
+	}
+	if !transcriptContains(next.transcript, "Cannot resume sessions while a run is active") {
+		t.Fatalf("expected pending resume error, got %#v", next.transcript)
+	}
+}
+
+func TestResumeLatestHydratesNewestSession(t *testing.T) {
+	store := testSessionStore(t)
+	older, err := store.Create(sessions.CreateInput{Title: "Older"})
+	if err != nil {
+		t.Fatalf("Create older returned error: %v", err)
+	}
+	appendTestEvent(t, store, older.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "old answer"})
+	newer, err := store.Create(sessions.CreateInput{Title: "Newer"})
+	if err != nil {
+		t.Fatalf("Create newer returned error: %v", err)
+	}
+	appendTestEvent(t, store, newer.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "new answer"})
+
+	m := newModel(context.Background(), Options{SessionStore: store})
+	m.input.SetValue("/resume latest")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if !transcriptContains(next.transcript, "Newer") || !transcriptContains(next.transcript, "new answer") {
+		t.Fatalf("expected latest session to hydrate, got %#v", next.transcript)
+	}
+	if transcriptContains(next.transcript, "old answer") {
+		t.Fatalf("expected /resume latest to skip older session transcript, got %#v", next.transcript)
+	}
+}
+
+func TestEscCancelRecordsSessionError(t *testing.T) {
+	store := testSessionStore(t)
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "ignored"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: store,
+	})
+	m.input.SetValue("cancel me")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	next = updated.(model)
+
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one session, got %d", len(list))
+	}
+	events, err := store.ReadEvents(list[0].SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
+		sessions.EventMessage,
+		sessions.EventError,
+	}) {
+		t.Fatalf("unexpected event sequence after cancel: %#v", got)
+	}
+	assertPayloadField(t, events[1], "message", "Run cancelled.")
+	if next.pending {
+		t.Fatal("expected Esc to clear pending state")
+	}
+}
+
+func TestResumedPromptIncludesSessionContext(t *testing.T) {
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "Existing", Cwd: "repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "user", "content": "previous request"})
+	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "previous answer"})
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "continued"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	m := newModel(context.Background(), Options{
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: store,
+	})
+	m.input.SetValue("/resume " + session.SessionID)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	next.input.SetValue("continue")
+
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd == nil {
+		t.Fatal("expected resumed prompt to start an agent run")
+	}
+	updated, _ = next.Update(cmd())
+
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one provider request, got %d", len(provider.requests))
+	}
+	messages := provider.requests[0].Messages
+	if len(messages) == 0 {
+		t.Fatal("expected provider request to include messages")
+	}
+	prompt := messages[len(messages)-1].Content
+	for _, want := range []string{"Continuing Zero session", session.SessionID, "previous request", "previous answer", "Current user request:", "continue"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("expected resumed prompt to contain %q, got %q", want, prompt)
+		}
+	}
+}
+
+func TestResumeCommandReportsMissingSession(t *testing.T) {
+	m := newModel(context.Background(), Options{SessionStore: testSessionStore(t)})
+	m.input.SetValue("/resume missing_session")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if !transcriptContains(next.transcript, "Zero session not found: missing_session") {
+		t.Fatalf("expected missing session error, got %#v", next.transcript)
+	}
+}
+
+func appendTestEvent(t *testing.T, store *sessions.Store, sessionID string, eventType sessions.EventType, payload any) {
+	t.Helper()
+
+	if _, err := store.AppendEvent(sessionID, sessions.AppendEventInput{Type: eventType, Payload: payload}); err != nil {
+		t.Fatalf("AppendEvent(%s) returned error: %v", eventType, err)
+	}
+}
+
+func writeTestFile(t *testing.T, root string, name string, content string) {
+	t.Helper()
+
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func eventTypes(events []sessions.Event) []sessions.EventType {
+	types := make([]sessions.EventType, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}
+
+func equalEventTypes(left []sessions.EventType, right []sessions.EventType) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func assertPayloadField(t *testing.T, event sessions.Event, key string, want any) {
+	t.Helper()
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("failed to decode payload for %s: %v", event.Type, err)
+	}
+	if payload[key] != want {
+		t.Fatalf("expected payload %s=%#v, got %#v in %#v", key, want, payload[key], payload)
+	}
+}
+
+func assertPayloadFieldContains(t *testing.T, event sessions.Event, key string, want string) {
+	t.Helper()
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("failed to decode payload for %s: %v", event.Type, err)
+	}
+	text, ok := payload[key].(string)
+	if !ok || !strings.Contains(text, want) {
+		t.Fatalf("expected payload %s to contain %q, got %#v in %#v", key, want, payload[key], payload)
+	}
+}

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -161,7 +161,7 @@ func TestPromptSubmitPersistsToolSessionEvents(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected prompt submit to start an agent run")
 	}
-	updated, _ = next.Update(cmd())
+	_, _ = next.Update(cmd())
 
 	list, err := store.List()
 	if err != nil {
@@ -351,7 +351,7 @@ func TestResumedPromptIncludesSessionContext(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected resumed prompt to start an agent run")
 	}
-	updated, _ = next.Update(cmd())
+	_, _ = next.Update(cmd())
 
 	if len(provider.requests) != 1 {
 		t.Fatalf("expected one provider request, got %d", len(provider.requests))
@@ -375,7 +375,7 @@ func TestResumeCommandReportsMissingSession(t *testing.T) {
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
-	if !transcriptContains(next.transcript, "Zero session not found: missing_session") {
+	if !transcriptContains(next.transcript, "zero session not found: missing_session") {
 		t.Fatalf("expected missing session error, got %#v", next.transcript)
 	}
 }


### PR DESCRIPTION
﻿## Summary
- persist Go TUI sessions with the same event payload contract used by `zero exec`
- hydrate `/resume <id>` and `/resume latest` into the visible TUI transcript
- feed resumed session context into the next provider prompt
- block `/resume` during active runs and record cancellation markers to avoid corrupt or orphaned session history

## Tests
- `go test ./...`
- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`

## Notes
- Multi-agent review was used for session API mapping, TUI test patterns, and final review.
- No MCP/provider transport code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Session management to track and persist conversation history and display active session ID
  - `/resume` command to restore and continue previous sessions (session ID or `latest`), rebuilding transcripts with past events
  - Capture session events including tool calls, tool results, assistant messages, usage, and errors

* **Bug Fixes / Behavior**
  - `/resume` is blocked while a run is active; cancelling a run records a session error
  - Prompt submission now ensures/creates an active session and records user session events

* **Tests**
  - Added comprehensive session/resume test coverage and related test setup changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->