### PR TITLE
feat: add Go worktree and verification backend

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
+	"github.com/Gitlawb/zero/internal/verify"
+	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -32,6 +34,9 @@ type appDeps struct {
 	loadHooks        func(hooks.LoadOptions) (hooks.LoadResult, error)
 	newMCPStore      func() (*mcp.PermissionStore, error)
 	registerMCPTools func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error)
+	prepareWorktree  func(context.Context, worktrees.Options) (worktrees.Result, error)
+	detectVerifyPlan func(string) (verify.Plan, error)
+	runVerify        func(context.Context, verify.Plan, verify.RunOptions) verify.Report
 	runTUI           func(context.Context, tui.Options) int
 	now              func() time.Time
 }
@@ -85,8 +90,11 @@ func defaultAppDeps() appDeps {
 		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
 			return mcp.RegisterTools(ctx, registry, cfg, options)
 		},
-		runTUI: tui.Run,
-		now:    time.Now,
+		prepareWorktree:  worktrees.Prepare,
+		detectVerifyPlan: verify.DetectPlan,
+		runVerify:        verify.Run,
+		runTUI:           tui.Run,
+		now:              time.Now,
 	}
 }
 
@@ -138,6 +146,10 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runHooks(args[1:], stdout, stderr, deps)
 	case "mcp":
 		return runMCP(args[1:], stdout, stderr, deps)
+	case "worktrees", "worktree":
+		return runWorktrees(args[1:], stdout, stderr, deps)
+	case "verify":
+		return runVerifyCommand(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
 	default:
@@ -182,6 +194,15 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.registerMCPTools == nil {
 		deps.registerMCPTools = defaults.registerMCPTools
+	}
+	if deps.prepareWorktree == nil {
+		deps.prepareWorktree = defaults.prepareWorktree
+	}
+	if deps.detectVerifyPlan == nil {
+		deps.detectVerifyPlan = defaults.detectVerifyPlan
+	}
+	if deps.runVerify == nil {
+		deps.runVerify = defaults.runVerify
 	}
 	if deps.runTUI == nil {
 		deps.runTUI = defaults.runTUI
@@ -282,6 +303,8 @@ Commands:
   plugins    Inspect local Zero plugin manifests
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings
+  worktrees  Prepare isolated git worktrees
+  verify     Detect and run local verification checks
   serve      Run Zero protocol servers
   help       Show this help
   version    Print version
@@ -316,6 +339,8 @@ Flags:
       --disabled-tools <tools>       Hide these comma or space separated tools
       --list-tools                   List model-visible tools and exit
   -C, --cwd <path>                   Set the workspace directory
+  -w, --worktree [name]              Run from an isolated git worktree
+      --worktree-dir <path>          Base directory for created worktrees
   -i, --input-format text|stream-json
                                     Select prompt input format
   -o, --output-format text|json|stream-json

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -216,6 +216,9 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"plugin"},
 		{"hooks"},
 		{"mcp"},
+		{"worktrees"},
+		{"worktree"},
+		{"verify"},
 		{"serve"},
 	} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
@@ -263,6 +266,8 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"plugins",
 		"hooks",
 		"mcp",
+		"worktrees",
+		"verify",
 		"serve",
 		"--version",
 	} {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/worktrees"
 )
 
 const (
@@ -49,6 +50,9 @@ type execOptions struct {
 	resume                string
 	resumeLatest          bool
 	fork                  string
+	worktree              bool
+	worktreeName          string
+	worktreeDir           string
 	skipPermissionsUnsafe bool
 }
 
@@ -75,6 +79,18 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
 	if err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
+	}
+	if options.worktree {
+		preparedWorktree, err := deps.prepareWorktree(context.Background(), worktrees.Options{
+			Cwd:     workspaceRoot,
+			Name:    options.worktreeName,
+			BaseDir: options.worktreeDir,
+			Now:     deps.now,
+		})
+		if err != nil {
+			return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
+		}
+		workspaceRoot = preparedWorktree.Path
 	}
 
 	registry := newCoreRegistry(workspaceRoot)

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -158,6 +158,24 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--fork="):
 			options.fork = strings.TrimSpace(strings.TrimPrefix(arg, "--fork="))
+		case arg == "-w" || arg == "--worktree":
+			options.worktree = true
+			if index+1 < len(args) && !flagValueLooksLikeOption(strings.TrimSpace(args[index+1])) && strings.TrimSpace(args[index+1]) != "" {
+				options.worktreeName = strings.TrimSpace(args[index+1])
+				index++
+			}
+		case strings.HasPrefix(arg, "--worktree="):
+			options.worktree = true
+			options.worktreeName = strings.TrimSpace(strings.TrimPrefix(arg, "--worktree="))
+		case arg == "--worktree-dir":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.worktreeDir = value
+			index = next
+		case strings.HasPrefix(arg, "--worktree-dir="):
+			options.worktreeDir = strings.TrimSpace(strings.TrimPrefix(arg, "--worktree-dir="))
 		case arg == "--":
 			options.promptParts = append(options.promptParts, args[index+1:]...)
 			index = len(args)
@@ -170,6 +188,12 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 
 	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
 		return options, false, execUsageError{"Use either --resume or --fork, not both."}
+	}
+	if options.worktree && options.fork != "" {
+		return options, false, execUsageError{"--fork cannot be used with --worktree. Forked sessions must continue in the source session workspace."}
+	}
+	if options.worktreeDir != "" && !options.worktree {
+		return options, false, execUsageError{"--worktree-dir requires --worktree."}
 	}
 	if options.inputFormat == execInputStreamJSON && strings.TrimSpace(strings.Join(options.promptParts, " ")) != "" {
 		return options, false, execUsageError{"Stream-json input does not accept positional prompt text. Pipe JSONL or use --file."}

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -65,9 +65,11 @@ func TestRunWorktreesPrepareTextAndJSON(t *testing.T) {
 }
 
 func TestRunWorktreesPrepareReportsErrors(t *testing.T) {
+	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := runWithDeps([]string{"worktrees", "prepare", "--name", "bad"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
 		prepareWorktree: func(context.Context, worktrees.Options) (worktrees.Result, error) {
 			return worktrees.Result{}, errors.New("not a git repository")
 		},
@@ -81,6 +83,27 @@ func TestRunWorktreesPrepareReportsErrors(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "not a git repository") {
 		t.Fatalf("expected worktree error, got %q", stderr.String())
+	}
+}
+
+func TestRunWorktreesPrepareRejectsDuplicateNames(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "prepare", "--name", "first", "second"}, &stdout, &stderr, appDeps{
+		prepareWorktree: func(context.Context, worktrees.Options) (worktrees.Result, error) {
+			t.Fatal("prepareWorktree should not be called for invalid flags")
+			return worktrees.Result{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "worktree name was provided more than once") {
+		t.Fatalf("expected duplicate name error, got %q", stderr.String())
 	}
 }
 
@@ -235,6 +258,9 @@ func TestRunExecRejectsForkWithWorktree(t *testing.T) {
 	if !strings.Contains(stderr.String(), "--fork cannot be used with --worktree") {
 		t.Fatalf("expected flag conflict error, got %q", stderr.String())
 	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
 }
 
 func TestRunExecRejectsWorktreeDirWithoutWorktree(t *testing.T) {
@@ -252,5 +278,8 @@ func TestRunExecRejectsWorktreeDirWithoutWorktree(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "--worktree-dir requires --worktree") {
 		t.Fatalf("expected worktree-dir dependency error, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
 	}
 }

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -83,6 +85,47 @@ func TestRunWorktreesPrepareReportsErrors(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "not a git repository") {
 		t.Fatalf("expected worktree error, got %q", stderr.String())
+	}
+}
+
+func TestRunWorktreesPrepareRedactsPathsInOutput(t *testing.T) {
+	secret := "sk-proj-abcdefghijklmnopqrstuvwxyz"
+	cwd := filepath.Join(t.TempDir(), secret, "repo")
+	if err := os.MkdirAll(cwd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	prepared := worktrees.Result{
+		Name:         "agent-task",
+		Path:         filepath.Join(t.TempDir(), secret, "agent-task"),
+		RepoRoot:     cwd,
+		SourceBranch: "feature/" + secret,
+		SourceCommit: "abc1234",
+	}
+
+	for _, args := range [][]string{
+		{"worktrees", "prepare", "--name", "agent-task"},
+		{"worktrees", "prepare", "--name", "agent-task", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+				getwd: func() (string, error) { return cwd, nil },
+				prepareWorktree: func(context.Context, worktrees.Options) (worktrees.Result, error) {
+					return prepared, nil
+				},
+			})
+
+			if exitCode != exitSuccess {
+				t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+			}
+			if strings.Contains(stdout.String(), secret) {
+				t.Fatalf("worktree output leaked secret path segment: %q", stdout.String())
+			}
+			if !strings.Contains(stdout.String(), redaction.RedactedSecret) {
+				t.Fatalf("expected redaction marker in worktree output, got %q", stdout.String())
+			}
+		})
 	}
 }
 
@@ -169,6 +212,54 @@ func TestRunVerifyTextAndJSON(t *testing.T) {
 				}
 			} else if !strings.Contains(stdout.String(), "Zero verification") || !strings.Contains(stdout.String(), "go.test") {
 				t.Fatalf("unexpected verify text output: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunVerifyRedactsWorkspacePathsInOutput(t *testing.T) {
+	secret := "sk-proj-abcdefghijklmnopqrstuvwxyz"
+	cwd := filepath.Join(t.TempDir(), secret, "workspace")
+	if err := os.MkdirAll(cwd, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	plan := verify.Plan{Root: cwd}
+	report := verify.Report{
+		Root:      cwd,
+		StartedAt: "2026-06-05T11:05:00Z",
+		EndedAt:   "2026-06-05T11:05:01Z",
+		OK:        true,
+		Summary:   verify.Summary{},
+	}
+
+	for _, args := range [][]string{
+		{"verify"},
+		{"verify", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+				getwd: func() (string, error) { return cwd, nil },
+				detectVerifyPlan: func(root string) (verify.Plan, error) {
+					if root != cwd {
+						t.Fatalf("verify root = %q, want %q", root, cwd)
+					}
+					return plan, nil
+				},
+				runVerify: func(context.Context, verify.Plan, verify.RunOptions) verify.Report {
+					return report
+				},
+			})
+
+			if exitCode != exitSuccess {
+				t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+			}
+			if strings.Contains(stdout.String(), secret) {
+				t.Fatalf("verify output leaked secret path segment: %q", stdout.String())
+			}
+			if !strings.Contains(stdout.String(), redaction.RedactedSecret) {
+				t.Fatalf("expected redaction marker in verify output, got %q", stdout.String())
 			}
 		})
 	}

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -210,7 +210,10 @@ func TestRunVerifyTextAndJSON(t *testing.T) {
 				if !decoded.OK || decoded.Summary.Passed != 1 {
 					t.Fatalf("unexpected verify JSON: %#v", decoded)
 				}
-			} else if !strings.Contains(stdout.String(), "Zero verification") || !strings.Contains(stdout.String(), "go.test") {
+				if decoded.Root != cwd {
+					t.Fatalf("decoded verify root = %q, want %q", decoded.Root, cwd)
+				}
+			} else if !strings.Contains(stdout.String(), "Zero verification") || !strings.Contains(stdout.String(), "go.test") || !strings.Contains(stdout.String(), cwd) {
 				t.Fatalf("unexpected verify text output: %q", stdout.String())
 			}
 		})

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -1,0 +1,256 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/verify"
+	"github.com/Gitlawb/zero/internal/worktrees"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestRunWorktreesPrepareTextAndJSON(t *testing.T) {
+	cwd := t.TempDir()
+	base := t.TempDir()
+	prepared := worktrees.Result{
+		Name:         "agent-task",
+		Path:         filepath.Join(base, "agent-task"),
+		RepoRoot:     cwd,
+		SourceBranch: "main",
+		SourceCommit: "abc1234",
+	}
+
+	for _, args := range [][]string{
+		{"worktrees", "prepare", "--name", "agent-task", "--dir", base},
+		{"worktrees", "prepare", "--name=agent-task", "--dir=" + base, "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+				getwd: func() (string, error) { return cwd, nil },
+				prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
+					if options.Cwd != cwd || options.Name != "agent-task" || options.BaseDir != base {
+						t.Fatalf("unexpected worktree options: %#v", options)
+					}
+					return prepared, nil
+				},
+			})
+
+			if exitCode != exitSuccess {
+				t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected empty stderr, got %q", stderr.String())
+			}
+			if strings.Contains(strings.Join(args, " "), "--json") {
+				var decoded worktrees.Result
+				if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+					t.Fatalf("decode worktree JSON: %v\n%s", err, stdout.String())
+				}
+				if decoded.Path != prepared.Path || decoded.Name != prepared.Name {
+					t.Fatalf("unexpected JSON result: %#v", decoded)
+				}
+			} else if !strings.Contains(stdout.String(), "Zero worktree ready") || !strings.Contains(stdout.String(), prepared.Path) {
+				t.Fatalf("unexpected worktree text output: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunWorktreesPrepareReportsErrors(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"worktrees", "prepare", "--name", "bad"}, &stdout, &stderr, appDeps{
+		prepareWorktree: func(context.Context, worktrees.Options) (worktrees.Result, error) {
+			return worktrees.Result{}, errors.New("not a git repository")
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "not a git repository") {
+		t.Fatalf("expected worktree error, got %q", stderr.String())
+	}
+}
+
+func TestRunVerifyTextAndJSON(t *testing.T) {
+	cwd := t.TempDir()
+	plan := verify.Plan{Root: cwd, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	report := verify.Report{
+		Root:      cwd,
+		StartedAt: "2026-06-05T11:00:00Z",
+		EndedAt:   "2026-06-05T11:00:01Z",
+		OK:        true,
+		Summary:   verify.Summary{Total: 1, Passed: 1},
+		Results: []verify.Result{{
+			ID:       "go.test",
+			Name:     "Go tests",
+			Command:  []string{"go", "test", "./..."},
+			Status:   verify.StatusPass,
+			ExitCode: 0,
+			Stdout:   "ok",
+		}},
+	}
+
+	for _, args := range [][]string{
+		{"verify"},
+		{"verify", "--json", "--only", "go.test"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+				getwd: func() (string, error) { return cwd, nil },
+				detectVerifyPlan: func(root string) (verify.Plan, error) {
+					if root != cwd {
+						t.Fatalf("verify root = %q, want %q", root, cwd)
+					}
+					return plan, nil
+				},
+				runVerify: func(ctx context.Context, gotPlan verify.Plan, options verify.RunOptions) verify.Report {
+					if gotPlan.Root != cwd {
+						t.Fatalf("plan root = %q, want %q", gotPlan.Root, cwd)
+					}
+					if strings.Contains(strings.Join(args, " "), "--only") && (len(options.Only) != 1 || options.Only[0] != "go.test") {
+						t.Fatalf("Only = %#v, want go.test", options.Only)
+					}
+					return report
+				},
+				now: fixedCLITime("2026-06-05T11:00:00Z"),
+			})
+
+			if exitCode != exitSuccess {
+				t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected empty stderr, got %q", stderr.String())
+			}
+			if strings.Contains(strings.Join(args, " "), "--json") {
+				var decoded verify.Report
+				if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+					t.Fatalf("decode verify JSON: %v\n%s", err, stdout.String())
+				}
+				if !decoded.OK || decoded.Summary.Passed != 1 {
+					t.Fatalf("unexpected verify JSON: %#v", decoded)
+				}
+			} else if !strings.Contains(stdout.String(), "Zero verification") || !strings.Contains(stdout.String(), "go.test") {
+				t.Fatalf("unexpected verify text output: %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunVerifyReturnsProviderExitWhenChecksFail(t *testing.T) {
+	cwd := t.TempDir()
+	report := verify.Report{
+		Root:    cwd,
+		OK:      false,
+		Summary: verify.Summary{Total: 1, Failed: 1},
+		Results: []verify.Result{{
+			ID:       "bun.test",
+			Name:     "Bun tests",
+			Command:  []string{"bun", "test"},
+			Status:   verify.StatusFail,
+			ExitCode: 1,
+		}},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"verify"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		detectVerifyPlan: func(string) (verify.Plan, error) {
+			return verify.Plan{Root: cwd, Checks: []verify.Check{{ID: "bun.test", Name: "Bun tests", Command: []string{"bun", "test"}}}}, nil
+		},
+		runVerify: func(context.Context, verify.Plan, verify.RunOptions) verify.Report { return report },
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider-style failure exit %d, got %d", exitProvider, exitCode)
+	}
+	if !strings.Contains(stdout.String(), "failed") {
+		t.Fatalf("expected failure summary in stdout, got %q", stdout.String())
+	}
+}
+
+func TestRunExecWorktreeUsesPreparedWorkspace(t *testing.T) {
+	root := t.TempDir()
+	worktreeDir := t.TempDir()
+	var resolvedWorkspace string
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree", "task-a", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return root, nil },
+		prepareWorktree: func(ctx context.Context, options worktrees.Options) (worktrees.Result, error) {
+			if options.Cwd != root || options.Name != "task-a" {
+				t.Fatalf("unexpected worktree options: %#v", options)
+			}
+			return worktrees.Result{Name: "task-a", Path: worktreeDir, RepoRoot: root, SourceBranch: "main", SourceCommit: "abc1234"}, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			resolvedWorkspace = workspaceRoot
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if resolvedWorkspace != worktreeDir {
+		t.Fatalf("resolved workspace = %q, want worktree %q", resolvedWorkspace, worktreeDir)
+	}
+	if !strings.Contains(stdout.String(), "hello") {
+		t.Fatalf("expected provider output, got %q", stdout.String())
+	}
+}
+
+func TestRunExecRejectsForkWithWorktree(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree", "--fork", "zero_parent", "hello"}, &stdout, &stderr, appDeps{
+		prepareWorktree: func(context.Context, worktrees.Options) (worktrees.Result, error) {
+			t.Fatal("prepareWorktree should not be called for invalid flags")
+			return worktrees.Result{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "--fork cannot be used with --worktree") {
+		t.Fatalf("expected flag conflict error, got %q", stderr.String())
+	}
+}
+
+func TestRunExecRejectsWorktreeDirWithoutWorktree(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--worktree-dir", "/tmp/zero", "hello"}, &stdout, &stderr, appDeps{
+		prepareWorktree: func(context.Context, worktrees.Options) (worktrees.Result, error) {
+			t.Fatal("prepareWorktree should not be called for invalid flags")
+			return worktrees.Result{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "--worktree-dir requires --worktree") {
+		t.Fatalf("expected worktree-dir dependency error, got %q", stderr.String())
+	}
+}

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
 )
@@ -63,13 +64,14 @@ func runWorktrees(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
+	safeResult := redactWorktreeResult(result)
 	if options.json {
-		if err := writePrettyJSON(stdout, result); err != nil {
+		if err := writePrettyJSON(stdout, safeResult); err != nil {
 			return exitCrash
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, formatWorktreeResult(result)); err != nil {
+	if _, err := fmt.Fprintln(stdout, formatWorktreeResult(safeResult)); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -99,11 +101,12 @@ func runVerifyCommand(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		TimeoutMS: options.timeoutMS,
 		Now:       deps.now,
 	})
+	safeReport := redactVerifyReport(report)
 	if options.json {
-		if err := writePrettyJSON(stdout, report); err != nil {
+		if err := writePrettyJSON(stdout, safeReport); err != nil {
 			return exitCrash
 		}
-	} else if _, err := fmt.Fprintln(stdout, formatVerifyReport(report)); err != nil {
+	} else if _, err := fmt.Fprintln(stdout, formatVerifyReport(safeReport)); err != nil {
 		return exitCrash
 	}
 	if !report.OK {
@@ -238,6 +241,38 @@ func parsePositiveIntFlag(flag string, value string) (int, error) {
 		return 0, execUsageError{fmt.Sprintf("invalid %s %q. Expected a positive integer.", flag, value)}
 	}
 	return number, nil
+}
+
+func redactWorktreeResult(result worktrees.Result) worktrees.Result {
+	result.Name = redactCLIString(result.Name)
+	result.Path = redactCLIString(result.Path)
+	result.RepoRoot = redactCLIString(result.RepoRoot)
+	result.SourceBranch = redactCLIString(result.SourceBranch)
+	result.SourceCommit = redactCLIString(result.SourceCommit)
+	return result
+}
+
+func redactVerifyReport(report verify.Report) verify.Report {
+	report.Root = redactCLIString(report.Root)
+	report.StartedAt = redactCLIString(report.StartedAt)
+	report.EndedAt = redactCLIString(report.EndedAt)
+	for index := range report.Results {
+		report.Results[index].ID = redactCLIString(report.Results[index].ID)
+		report.Results[index].Name = redactCLIString(report.Results[index].Name)
+		report.Results[index].StartedAt = redactCLIString(report.Results[index].StartedAt)
+		report.Results[index].EndedAt = redactCLIString(report.Results[index].EndedAt)
+		report.Results[index].Stdout = redactCLIString(report.Results[index].Stdout)
+		report.Results[index].Stderr = redactCLIString(report.Results[index].Stderr)
+		report.Results[index].Error = redactCLIString(report.Results[index].Error)
+		for commandIndex := range report.Results[index].Command {
+			report.Results[index].Command[commandIndex] = redactCLIString(report.Results[index].Command[commandIndex])
+		}
+	}
+	return report
+}
+
+func redactCLIString(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
 }
 
 func formatWorktreeResult(result worktrees.Result) string {

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -126,10 +126,14 @@ func parseWorktreeCommandArgs(args []string) (worktreeCommandOptions, bool, erro
 			if err != nil {
 				return options, false, err
 			}
-			options.name = value
+			if err := setWorktreeName(&options, value); err != nil {
+				return options, false, err
+			}
 			index = next
 		case strings.HasPrefix(arg, "--name="):
-			options.name = strings.TrimSpace(strings.TrimPrefix(arg, "--name="))
+			if err := setWorktreeName(&options, strings.TrimPrefix(arg, "--name=")); err != nil {
+				return options, false, err
+			}
 		case arg == "--dir":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -151,13 +155,24 @@ func parseWorktreeCommandArgs(args []string) (worktreeCommandOptions, bool, erro
 		case strings.HasPrefix(arg, "-"):
 			return options, false, execUsageError{fmt.Sprintf("unknown worktrees flag %q", arg)}
 		default:
-			if options.name != "" {
-				return options, false, execUsageError{fmt.Sprintf("unexpected worktrees argument %q", arg)}
+			if err := setWorktreeName(&options, arg); err != nil {
+				return options, false, err
 			}
-			options.name = strings.TrimSpace(arg)
 		}
 	}
 	return options, false, nil
+}
+
+func setWorktreeName(options *worktreeCommandOptions, value string) error {
+	name := strings.TrimSpace(value)
+	if name == "" {
+		return nil
+	}
+	if options.name != "" {
+		return execUsageError{"worktree name was provided more than once"}
+	}
+	options.name = name
+	return nil
 }
 
 func parseVerifyCommandArgs(args []string) (verifyCommandOptions, bool, error) {

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -254,24 +254,17 @@ func redactWorktreeResult(result worktrees.Result) worktrees.Result {
 
 func redactVerifyReport(report verify.Report) verify.Report {
 	report.Root = redactCLIString(report.Root)
-	report.StartedAt = redactCLIString(report.StartedAt)
-	report.EndedAt = redactCLIString(report.EndedAt)
 	for index := range report.Results {
-		report.Results[index].ID = redactCLIString(report.Results[index].ID)
-		report.Results[index].Name = redactCLIString(report.Results[index].Name)
-		report.Results[index].StartedAt = redactCLIString(report.Results[index].StartedAt)
-		report.Results[index].EndedAt = redactCLIString(report.Results[index].EndedAt)
 		report.Results[index].Stdout = redactCLIString(report.Results[index].Stdout)
 		report.Results[index].Stderr = redactCLIString(report.Results[index].Stderr)
 		report.Results[index].Error = redactCLIString(report.Results[index].Error)
-		for commandIndex := range report.Results[index].Command {
-			report.Results[index].Command[commandIndex] = redactCLIString(report.Results[index].Command[commandIndex])
-		}
 	}
 	return report
 }
 
 func redactCLIString(value string) string {
+	// Keep ordinary paths visible; these commands report useful locations.
+	// Central redaction still removes secret-looking tokens embedded in paths.
 	return redaction.RedactString(value, redaction.Options{})
 }
 

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -1,0 +1,296 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/verify"
+	"github.com/Gitlawb/zero/internal/worktrees"
+)
+
+type worktreeCommandOptions struct {
+	json    bool
+	name    string
+	baseDir string
+	cwd     string
+}
+
+type verifyCommandOptions struct {
+	json      bool
+	cwd       string
+	only      []string
+	timeoutMS int
+}
+
+func runWorktrees(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	command := "prepare"
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		command = strings.ToLower(strings.TrimSpace(args[0]))
+		args = args[1:]
+	}
+	if command == "help" {
+		if err := writeWorktreesHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if command != "prepare" {
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown worktrees command %q", command))
+	}
+	options, help, err := parseWorktreeCommandArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeWorktreesHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	result, err := deps.prepareWorktree(context.Background(), worktrees.Options{
+		Cwd:     workspaceRoot,
+		Name:    options.name,
+		BaseDir: options.baseDir,
+		Now:     deps.now,
+	})
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, result); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatWorktreeResult(result)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runVerifyCommand(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseVerifyCommandArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeVerifyHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	plan, err := deps.detectVerifyPlan(workspaceRoot)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	report := deps.runVerify(context.Background(), plan, verify.RunOptions{
+		Only:      options.only,
+		TimeoutMS: options.timeoutMS,
+		Now:       deps.now,
+	})
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+	} else if _, err := fmt.Fprintln(stdout, formatVerifyReport(report)); err != nil {
+		return exitCrash
+	}
+	if !report.OK {
+		return exitProvider
+	}
+	return exitSuccess
+}
+
+func parseWorktreeCommandArgs(args []string) (worktreeCommandOptions, bool, error) {
+	options := worktreeCommandOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--name":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.name = value
+			index = next
+		case strings.HasPrefix(arg, "--name="):
+			options.name = strings.TrimSpace(strings.TrimPrefix(arg, "--name="))
+		case arg == "--dir":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.baseDir = value
+			index = next
+		case strings.HasPrefix(arg, "--dir="):
+			options.baseDir = strings.TrimSpace(strings.TrimPrefix(arg, "--dir="))
+		case arg == "-C" || arg == "--cwd":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.cwd = value
+			index = next
+		case strings.HasPrefix(arg, "--cwd="):
+			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown worktrees flag %q", arg)}
+		default:
+			if options.name != "" {
+				return options, false, execUsageError{fmt.Sprintf("unexpected worktrees argument %q", arg)}
+			}
+			options.name = strings.TrimSpace(arg)
+		}
+	}
+	return options, false, nil
+}
+
+func parseVerifyCommandArgs(args []string) (verifyCommandOptions, bool, error) {
+	options := verifyCommandOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "-C" || arg == "--cwd":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.cwd = value
+			index = next
+		case strings.HasPrefix(arg, "--cwd="):
+			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
+		case arg == "--only":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.only = append(options.only, parseToolList(value)...)
+			index = next
+		case strings.HasPrefix(arg, "--only="):
+			options.only = append(options.only, parseToolList(strings.TrimSpace(strings.TrimPrefix(arg, "--only=")))...)
+		case arg == "--timeout-ms":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			timeoutMS, err := parsePositiveIntFlag("--timeout-ms", value)
+			if err != nil {
+				return options, false, err
+			}
+			options.timeoutMS = timeoutMS
+			index = next
+		case strings.HasPrefix(arg, "--timeout-ms="):
+			timeoutMS, err := parsePositiveIntFlag("--timeout-ms", strings.TrimSpace(strings.TrimPrefix(arg, "--timeout-ms=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.timeoutMS = timeoutMS
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown verify flag %q", arg)}
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unexpected verify argument %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parsePositiveIntFlag(flag string, value string) (int, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, execUsageError{flag + " requires a value"}
+	}
+	number, err := strconv.Atoi(trimmed)
+	if err != nil || number <= 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid %s %q. Expected a positive integer.", flag, value)}
+	}
+	return number, nil
+}
+
+func formatWorktreeResult(result worktrees.Result) string {
+	lines := []string{
+		"Zero worktree ready",
+		"name: " + result.Name,
+		"path: " + result.Path,
+		"repo: " + result.RepoRoot,
+	}
+	if result.SourceBranch != "" {
+		lines = append(lines, "branch: "+result.SourceBranch)
+	}
+	if result.SourceCommit != "" {
+		lines = append(lines, "commit: "+result.SourceCommit)
+	}
+	if result.Reused {
+		lines = append(lines, "reused: true")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatVerifyReport(report verify.Report) string {
+	lines := []string{
+		"Zero verification",
+		"root: " + report.Root,
+		fmt.Sprintf("summary: %d total, %d passed, %d failed, %d errors", report.Summary.Total, report.Summary.Passed, report.Summary.Failed, report.Summary.Errors),
+	}
+	if len(report.Results) == 0 {
+		lines = append(lines, "  (no checks detected)")
+		return strings.Join(lines, "\n")
+	}
+	for _, result := range report.Results {
+		lines = append(lines, fmt.Sprintf("  [%s] %s - %s", result.Status, result.ID, strings.Join(result.Command, " ")))
+		if result.Error != "" {
+			lines = append(lines, "    error: "+result.Error)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func writeWorktreesHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero worktrees prepare [flags] [name]
+
+Prepares an isolated git worktree for a Zero task.
+
+Flags:
+      --name <name>       Worktree name; defaults to a timestamped task name
+      --dir <path>        Base directory for Zero worktrees
+  -C, --cwd <path>        Source repository directory
+      --json              Print JSON output
+  -h, --help              Show this help
+`)
+	return err
+}
+
+func writeVerifyHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero verify [flags]
+
+Detects and runs local verification checks for the workspace.
+
+Flags:
+  -C, --cwd <path>        Workspace directory
+      --only <ids>        Run only matching check ids
+      --timeout-ms <n>    Per-check timeout in milliseconds
+      --json              Print JSON output
+  -h, --help              Show this help
+`)
+	return err
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -276,6 +277,7 @@ func filterChecks(checks []Check, only []string) ([]Check, []string) {
 			unknown = append(unknown, id)
 		}
 	}
+	sort.Strings(unknown)
 	return filtered, unknown
 }
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,0 +1,301 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+type Status string
+
+const (
+	StatusPass  Status = "pass"
+	StatusFail  Status = "fail"
+	StatusError Status = "error"
+)
+
+type Check struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Command []string `json:"command"`
+}
+
+type Plan struct {
+	Root   string  `json:"root"`
+	Checks []Check `json:"checks"`
+}
+
+type Summary struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+	Errors int `json:"errors"`
+}
+
+type Result struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Command    []string `json:"command"`
+	Status     Status   `json:"status"`
+	ExitCode   int      `json:"exitCode"`
+	Stdout     string   `json:"stdout,omitempty"`
+	Stderr     string   `json:"stderr,omitempty"`
+	StartedAt  string   `json:"startedAt"`
+	EndedAt    string   `json:"endedAt"`
+	DurationMs int      `json:"durationMs"`
+	Error      string   `json:"error,omitempty"`
+}
+
+type Report struct {
+	Root      string   `json:"root"`
+	StartedAt string   `json:"startedAt"`
+	EndedAt   string   `json:"endedAt"`
+	OK        bool     `json:"ok"`
+	Summary   Summary  `json:"summary"`
+	Results   []Result `json:"results"`
+}
+
+type CommandResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+type Runner func(context.Context, string, []string, time.Duration) (CommandResult, error)
+
+type RunOptions struct {
+	Only      []string
+	TimeoutMS int
+	Runner    Runner
+	Now       func() time.Time
+}
+
+const defaultTimeoutMS = 120000
+
+func DetectPlan(root string) (Plan, error) {
+	resolvedRoot, err := resolveRoot(root)
+	if err != nil {
+		return Plan{}, err
+	}
+	checks := []Check{}
+	if fileExists(filepath.Join(resolvedRoot, "go.mod")) {
+		checks = append(checks, Check{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}})
+	}
+	checks = append(checks, detectPackageChecks(resolvedRoot)...)
+	return Plan{Root: resolvedRoot, Checks: checks}, nil
+}
+
+func Run(ctx context.Context, plan Plan, options RunOptions) Report {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	runner := options.Runner
+	if runner == nil {
+		runner = defaultRunner
+	}
+	timeout := time.Duration(firstPositive(options.TimeoutMS, defaultTimeoutMS)) * time.Millisecond
+	start := now()
+	report := Report{
+		Root:      plan.Root,
+		StartedAt: formatTime(start),
+		OK:        true,
+	}
+	checks, unknownChecks := filterChecks(plan.Checks, options.Only)
+	for _, check := range checks {
+		checkStart := now()
+		result := Result{
+			ID:        check.ID,
+			Name:      check.Name,
+			Command:   append([]string{}, check.Command...),
+			StartedAt: formatTime(checkStart),
+		}
+		commandResult, err := runner(ctx, plan.Root, check.Command, timeout)
+		checkEnd := now()
+		result.EndedAt = formatTime(checkEnd)
+		result.DurationMs = int(checkEnd.Sub(checkStart).Milliseconds())
+		result.Stdout = redaction.RedactString(commandResult.Stdout, redaction.Options{})
+		result.Stderr = redaction.RedactString(commandResult.Stderr, redaction.Options{})
+		result.ExitCode = commandResult.ExitCode
+		if err != nil {
+			result.Status = StatusError
+			result.Error = redaction.RedactString(err.Error(), redaction.Options{})
+			report.Summary.Errors++
+		} else if commandResult.ExitCode == 0 {
+			result.Status = StatusPass
+			report.Summary.Passed++
+		} else {
+			result.Status = StatusFail
+			report.Summary.Failed++
+		}
+		report.Results = append(report.Results, result)
+	}
+	for _, id := range unknownChecks {
+		at := formatTime(now())
+		report.Results = append(report.Results, Result{
+			ID:        id,
+			Name:      "Unknown verification check",
+			Status:    StatusError,
+			ExitCode:  -1,
+			StartedAt: at,
+			EndedAt:   at,
+			Error:     fmt.Sprintf("unknown verification check %q", id),
+		})
+		report.Summary.Errors++
+	}
+	report.Summary.Total = len(report.Results)
+	report.OK = report.Summary.Failed == 0 && report.Summary.Errors == 0
+	report.EndedAt = formatTime(now())
+	return report
+}
+
+func detectPackageChecks(root string) []Check {
+	path := filepath.Join(root, "package.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+	checks := []Check{}
+	for _, candidate := range []struct {
+		script string
+		id     string
+		name   string
+	}{
+		{script: "typecheck", id: "bun.typecheck", name: "Bun typecheck"},
+		{script: "test", id: "bun.test", name: "Bun tests"},
+		{script: "build", id: "bun.build", name: "Bun build"},
+		{script: "lint", id: "bun.lint", name: "Bun lint"},
+	} {
+		if strings.TrimSpace(pkg.Scripts[candidate.script]) == "" {
+			continue
+		}
+		checks = append(checks, Check{
+			ID:      candidate.id,
+			Name:    candidate.name,
+			Command: []string{"bun", "run", candidate.script},
+		})
+	}
+	return checks
+}
+
+func defaultRunner(ctx context.Context, dir string, command []string, timeout time.Duration) (CommandResult, error) {
+	if len(command) == 0 {
+		return CommandResult{ExitCode: -1}, fmt.Errorf("verify command is empty")
+	}
+	commandCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		commandCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, command[0], command[1:]...)
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitCode = -1
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+			err = nil
+		}
+	}
+	if commandCtx.Err() == context.DeadlineExceeded {
+		return CommandResult{
+			ExitCode: -1,
+			Stdout:   stdout.String(),
+			Stderr:   stderr.String(),
+		}, fmt.Errorf("command timed out after %dms", timeout.Milliseconds())
+	}
+	return CommandResult{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}, err
+}
+
+func resolveRoot(root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve verify root: %w", err)
+		}
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve verify root: %w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("verify root must be an existing directory: %s", absolute)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func filterChecks(checks []Check, only []string) ([]Check, []string) {
+	if len(only) == 0 {
+		return append([]Check{}, checks...), nil
+	}
+	allowed := map[string]bool{}
+	for _, id := range only {
+		trimmed := strings.TrimSpace(id)
+		if trimmed != "" {
+			allowed[trimmed] = true
+		}
+	}
+	filtered := []Check{}
+	seen := map[string]bool{}
+	for _, check := range checks {
+		if allowed[check.ID] {
+			filtered = append(filtered, check)
+			seen[check.ID] = true
+		}
+	}
+	unknown := []string{}
+	for id := range allowed {
+		if !seen[id] {
+			unknown = append(unknown, id)
+		}
+	}
+	return filtered, unknown
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -115,6 +115,23 @@ func TestRunReportsUnknownOnlyChecks(t *testing.T) {
 	}
 }
 
+func TestRunReportsUnknownOnlyChecksInStableOrder(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Only: []string{"missing.z", "missing.a"},
+		Now:  fixedVerifyTime("2026-06-05T10:56:00Z"),
+	})
+
+	if len(report.Results) != 2 {
+		t.Fatalf("expected two unknown check results, got %#v", report.Results)
+	}
+	if report.Results[0].ID != "missing.a" || report.Results[1].ID != "missing.z" {
+		t.Fatalf("unknown checks are not stable sorted: %#v", report.Results)
+	}
+}
+
 func TestDetectPlanRejectsMissingRoot(t *testing.T) {
 	_, err := DetectPlan(filepath.Join(t.TempDir(), "missing"))
 	if err == nil || !strings.Contains(err.Error(), "verify root must be an existing directory") {

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -1,0 +1,175 @@
+package verify
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectPlanFindsBunAndGoChecks(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/zero\n")
+	writeFile(t, filepath.Join(root, "package.json"), `{
+		"scripts": {
+			"test": "bun test ./tests",
+			"typecheck": "tsc --noEmit",
+			"build": "bun run scripts/build.ts",
+			"lint": "eslint ."
+		}
+	}`)
+
+	plan, err := DetectPlan(root)
+	if err != nil {
+		t.Fatalf("DetectPlan returned error: %v", err)
+	}
+
+	ids := checkIDs(plan.Checks)
+	for _, want := range []string{"go.test", "bun.typecheck", "bun.test", "bun.build", "bun.lint"} {
+		if !contains(ids, want) {
+			t.Fatalf("expected check %q in %#v", want, ids)
+		}
+	}
+	if plan.Checks[0].Command[0] != "go" || strings.Join(plan.Checks[0].Command, " ") != "go test ./..." {
+		t.Fatalf("first check = %#v, want go test ./...", plan.Checks[0])
+	}
+}
+
+func TestRunExecutesPlanAndRedactsOutput(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}},
+		{ID: "bun.test", Name: "Bun tests", Command: []string{"bun", "test"}},
+	}}
+	runner := &fakeCommandRunner{results: []CommandResult{
+		{ExitCode: 0, Stdout: "ok\n"},
+		{ExitCode: 1, Stdout: "token sk-proj-secret1234567890", Stderr: "fail\n"},
+	}}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Runner:    runner.Run,
+		Now:       fixedVerifyTime("2026-06-05T10:45:00Z"),
+		TimeoutMS: 5000,
+	})
+
+	if report.OK {
+		t.Fatalf("report.OK = true, want false")
+	}
+	if report.Summary.Total != 2 || report.Summary.Passed != 1 || report.Summary.Failed != 1 {
+		t.Fatalf("unexpected summary: %#v", report.Summary)
+	}
+	if report.Results[1].Status != StatusFail || report.Results[1].ExitCode != 1 {
+		t.Fatalf("unexpected failing result: %#v", report.Results[1])
+	}
+	if strings.Contains(report.Results[1].Stdout, "sk-proj-secret") || !strings.Contains(report.Results[1].Stdout, "[REDACTED]") {
+		t.Fatalf("expected redacted stdout, got %q", report.Results[1].Stdout)
+	}
+	if got := runner.calls[0].dir; got != root {
+		t.Fatalf("runner dir = %q, want %q", got, root)
+	}
+}
+
+func TestRunFiltersChecksByID(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}},
+		{ID: "bun.test", Name: "Bun tests", Command: []string{"bun", "test"}},
+	}}
+	runner := &fakeCommandRunner{results: []CommandResult{{ExitCode: 0, Stdout: "ok\n"}}}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Only:   []string{"bun.test"},
+		Runner: runner.Run,
+		Now:    fixedVerifyTime("2026-06-05T10:50:00Z"),
+	})
+
+	if report.Summary.Total != 1 || report.Results[0].ID != "bun.test" {
+		t.Fatalf("unexpected filtered report: %#v", report)
+	}
+	if got := strings.Join(runner.calls[0].args, " "); got != "bun test" {
+		t.Fatalf("runner command = %q, want bun test", got)
+	}
+}
+
+func TestRunReportsUnknownOnlyChecks(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}},
+	}}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Only: []string{"missing.check"},
+		Now:  fixedVerifyTime("2026-06-05T10:55:00Z"),
+	})
+
+	if report.OK {
+		t.Fatalf("report.OK = true, want false")
+	}
+	if report.Summary.Total != 1 || report.Summary.Errors != 1 {
+		t.Fatalf("unexpected summary for unknown check: %#v", report.Summary)
+	}
+	if report.Results[0].Status != StatusError || !strings.Contains(report.Results[0].Error, "unknown verification check") {
+		t.Fatalf("unexpected unknown check result: %#v", report.Results[0])
+	}
+}
+
+func TestDetectPlanRejectsMissingRoot(t *testing.T) {
+	_, err := DetectPlan(filepath.Join(t.TempDir(), "missing"))
+	if err == nil || !strings.Contains(err.Error(), "verify root must be an existing directory") {
+		t.Fatalf("expected missing root error, got %v", err)
+	}
+}
+
+type fakeCommandRunner struct {
+	calls   []commandCall
+	results []CommandResult
+}
+
+func (runner *fakeCommandRunner) Run(ctx context.Context, dir string, command []string, timeout time.Duration) (CommandResult, error) {
+	runner.calls = append(runner.calls, commandCall{dir: dir, args: append([]string{}, command...)})
+	if len(runner.results) == 0 {
+		return CommandResult{}, nil
+	}
+	result := runner.results[0]
+	runner.results = runner.results[1:]
+	return result, nil
+}
+
+type commandCall struct {
+	dir  string
+	args []string
+}
+
+func checkIDs(checks []Check) []string {
+	ids := make([]string, 0, len(checks))
+	for _, check := range checks {
+		ids = append(ids, check.ID)
+	}
+	return ids
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func fixedVerifyTime(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -97,6 +97,13 @@ func Prepare(ctx context.Context, options Options) (Result, error) {
 		return Result{}, err
 	}
 	if reused {
+		sameRepo, err := sameGitCommonDir(ctx, runGit, repoRoot, target)
+		if err != nil {
+			return Result{}, fmt.Errorf("inspect existing worktree repository: %w", err)
+		}
+		if !sameRepo {
+			return Result{}, fmt.Errorf("worktree path already exists for a different git repository: %s", target)
+		}
 		result.Reused = true
 		return result, nil
 	}
@@ -204,6 +211,37 @@ func gitOutput(ctx context.Context, runGit GitRunner, dir string, args ...string
 		return "", fmt.Errorf("%s", message)
 	}
 	return strings.TrimSpace(result.Stdout), nil
+}
+
+func sameGitCommonDir(ctx context.Context, runGit GitRunner, sourceDir string, targetDir string) (bool, error) {
+	sourceCommonDir, err := gitCommonDir(ctx, runGit, sourceDir)
+	if err != nil {
+		return false, err
+	}
+	targetCommonDir, err := gitCommonDir(ctx, runGit, targetDir)
+	if err != nil {
+		return false, err
+	}
+	return sourceCommonDir == targetCommonDir, nil
+}
+
+func gitCommonDir(ctx context.Context, runGit GitRunner, dir string) (string, error) {
+	value, err := gitOutput(ctx, runGit, dir, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(value) {
+		value = filepath.Join(dir, value)
+	}
+	absolute, err := filepath.Abs(value)
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %w", err)
+	}
+	return filepath.Clean(resolved), nil
 }
 
 func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResult, error) {

--- a/internal/worktrees/worktrees.go
+++ b/internal/worktrees/worktrees.go
@@ -1,0 +1,254 @@
+package worktrees
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+)
+
+type GitRunner func(context.Context, string, ...string) (CommandResult, error)
+
+type CommandResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type Options struct {
+	Cwd     string
+	Name    string
+	BaseDir string
+	Env     map[string]string
+	Now     func() time.Time
+	RunGit  GitRunner
+}
+
+type Result struct {
+	Name         string `json:"name"`
+	Path         string `json:"path"`
+	RepoRoot     string `json:"repoRoot"`
+	SourceBranch string `json:"sourceBranch,omitempty"`
+	SourceCommit string `json:"sourceCommit,omitempty"`
+	Reused       bool   `json:"reused"`
+}
+
+var worktreeNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$`)
+
+func Prepare(ctx context.Context, options Options) (Result, error) {
+	cwd, err := resolveCwd(options.Cwd)
+	if err != nil {
+		return Result{}, err
+	}
+	runGit := options.RunGit
+	if runGit == nil {
+		runGit = defaultRunGit
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	name := strings.TrimSpace(options.Name)
+	if name == "" {
+		name = defaultWorktreeName(now())
+	}
+	if err := validateName(name); err != nil {
+		return Result{}, err
+	}
+
+	repoRoot, err := gitOutput(ctx, runGit, cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return Result{}, fmt.Errorf("not a git repository: %w", err)
+	}
+	repoRoot = filepath.Clean(repoRoot)
+	branch, _ := gitOutput(ctx, runGit, repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	commit, _ := gitOutput(ctx, runGit, repoRoot, "rev-parse", "--short", "HEAD")
+
+	baseDir := strings.TrimSpace(options.BaseDir)
+	if baseDir == "" {
+		baseDir, err = DefaultBaseDir(options.Env)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	baseDir, err = filepath.Abs(baseDir)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve worktree dir: %w", err)
+	}
+
+	repoDir := filepath.Join(baseDir, "zero-worktree-"+repoKey(repoRoot))
+	target := filepath.Join(repoDir, name)
+	result := Result{
+		Name:         name,
+		Path:         target,
+		RepoRoot:     repoRoot,
+		SourceBranch: branch,
+		SourceCommit: commit,
+	}
+	reused, err := inspectTarget(target)
+	if err != nil {
+		return Result{}, err
+	}
+	if reused {
+		result.Reused = true
+		return result, nil
+	}
+	if err := os.MkdirAll(repoDir, 0o700); err != nil {
+		return Result{}, fmt.Errorf("create worktree directory: %w", err)
+	}
+	commandResult, err := runGit(ctx, repoRoot, "worktree", "add", "--detach", target, "HEAD")
+	if err != nil {
+		return Result{}, fmt.Errorf("create git worktree: %w", err)
+	}
+	if commandResult.ExitCode != 0 {
+		message := strings.TrimSpace(firstNonEmpty(commandResult.Stderr, commandResult.Stdout))
+		if message == "" {
+			message = fmt.Sprintf("git worktree add exited with code %d", commandResult.ExitCode)
+		}
+		return Result{}, fmt.Errorf("create git worktree: %s", message)
+	}
+	return result, nil
+}
+
+func DefaultBaseDir(env map[string]string) (string, error) {
+	if runtime.GOOS == "windows" {
+		if localAppData := strings.TrimSpace(envValue(env, "LOCALAPPDATA")); localAppData != "" {
+			return filepath.Join(localAppData, "zero", "worktrees"), nil
+		}
+		if profile := strings.TrimSpace(envValue(env, "USERPROFILE")); profile != "" {
+			return filepath.Join(profile, "AppData", "Local", "zero", "worktrees"), nil
+		}
+	}
+
+	if stateHome := strings.TrimSpace(envValue(env, "XDG_STATE_HOME")); stateHome != "" {
+		return filepath.Join(stateHome, "zero", "worktrees"), nil
+	}
+	home := strings.TrimSpace(firstNonEmpty(envValue(env, "HOME"), envValue(env, "USERPROFILE")))
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home: %w", err)
+		}
+	}
+	return filepath.Join(home, ".local", "state", "zero", "worktrees"), nil
+}
+
+func resolveCwd(cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve cwd: %w", err)
+		}
+	}
+	absolute, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve cwd: %w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("cwd must be an existing directory: %s", absolute)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func validateName(name string) error {
+	if !worktreeNamePattern.MatchString(name) || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("invalid worktree name %q: use letters, numbers, dots, dashes, or underscores", name)
+	}
+	return nil
+}
+
+func inspectTarget(target string) (bool, error) {
+	info, err := os.Stat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect worktree path: %w", err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("worktree path already exists and is not a directory: %s", target)
+	}
+	if _, err := os.Stat(filepath.Join(target, ".git")); err == nil {
+		return true, nil
+	}
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		return false, fmt.Errorf("inspect worktree directory: %w", err)
+	}
+	if len(entries) != 0 {
+		return false, fmt.Errorf("worktree path already exists and is not empty: %s", target)
+	}
+	return false, nil
+}
+
+func gitOutput(ctx context.Context, runGit GitRunner, dir string, args ...string) (string, error) {
+	result, err := runGit(ctx, dir, args...)
+	if err != nil {
+		return "", err
+	}
+	if result.ExitCode != 0 {
+		message := strings.TrimSpace(firstNonEmpty(result.Stderr, result.Stdout))
+		if message == "" {
+			message = fmt.Sprintf("git exited with code %d", result.ExitCode)
+		}
+		return "", fmt.Errorf("%s", message)
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
+func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResult, error) {
+	command := exec.CommandContext(ctx, "git", args...)
+	command.Dir = dir
+	output, err := command.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		exitCode = -1
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+			err = nil
+		}
+	}
+	return CommandResult{Stdout: string(output), ExitCode: exitCode}, err
+}
+
+func defaultWorktreeName(now time.Time) string {
+	return "task-" + now.UTC().Format("20060102-150405")
+}
+
+func repoKey(repoRoot string) string {
+	sum := sha1.Sum([]byte(filepath.Clean(repoRoot)))
+	hash := hex.EncodeToString(sum[:])[:10]
+	base := filepath.Base(repoRoot)
+	base = strings.ToLower(base)
+	base = strings.Trim(regexp.MustCompile(`[^a-z0-9._-]+`).ReplaceAllString(base, "-"), "-._")
+	if base == "" {
+		base = "repo"
+	}
+	return base + "-" + hash
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -1,0 +1,175 @@
+package worktrees
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
+	root := t.TempDir()
+	base := t.TempDir()
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: root + "\n"},
+			{Stdout: "main\n"},
+			{Stdout: "abc1234\n"},
+			{},
+		},
+	}
+
+	result, err := Prepare(context.Background(), Options{
+		Cwd:     root,
+		Name:    "review-api",
+		BaseDir: base,
+		Now:     fixedTime("2026-06-05T10:30:00Z"),
+		RunGit:  runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Prepare returned error: %v", err)
+	}
+
+	if result.Name != "review-api" {
+		t.Fatalf("Name = %q, want review-api", result.Name)
+	}
+	if result.RepoRoot != root || result.SourceBranch != "main" || result.SourceCommit != "abc1234" {
+		t.Fatalf("unexpected result metadata: %#v", result)
+	}
+	if !strings.HasPrefix(result.Path, filepath.Join(base, "zero-worktree-")) {
+		t.Fatalf("Path = %q, want under base %q", result.Path, base)
+	}
+	if got := runner.commandLine(3); got != "git worktree add --detach "+result.Path+" HEAD" {
+		t.Fatalf("git worktree command = %q", got)
+	}
+}
+
+func TestPrepareReusesExistingGitWorktree(t *testing.T) {
+	root := t.TempDir()
+	base := t.TempDir()
+	existing := filepath.Join(base, "zero-worktree-"+repoKey(root), "reuse-me")
+	if err := os.MkdirAll(filepath.Join(existing, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: root + "\n"},
+			{Stdout: "main\n"},
+			{Stdout: "abc1234\n"},
+		},
+	}
+
+	result, err := Prepare(context.Background(), Options{
+		Cwd:     root,
+		Name:    "reuse-me",
+		BaseDir: base,
+		RunGit:  runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Prepare returned error: %v", err)
+	}
+
+	if !result.Reused {
+		t.Fatalf("Reused = false, want true")
+	}
+	if result.Path != existing {
+		t.Fatalf("Path = %q, want existing %q", result.Path, existing)
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("expected metadata git calls only, got %#v", runner.calls)
+	}
+}
+
+func TestPrepareValidatesNameAndExistingDirectory(t *testing.T) {
+	root := t.TempDir()
+	base := t.TempDir()
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: root + "\n"},
+			{Stdout: "main\n"},
+			{Stdout: "abc1234\n"},
+		},
+	}
+
+	if _, err := Prepare(context.Background(), Options{Cwd: root, Name: "../escape", BaseDir: base, RunGit: runner.Run}); err == nil || !strings.Contains(err.Error(), "worktree name") {
+		t.Fatalf("expected invalid name error, got %v", err)
+	}
+
+	blocked := filepath.Join(base, "zero-worktree-"+repoKey(root), "blocked")
+	if err := os.MkdirAll(blocked, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blocked, "file.txt"), []byte("busy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Prepare(context.Background(), Options{Cwd: root, Name: "blocked", BaseDir: base, RunGit: runner.Run}); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected non-empty directory error, got %v", err)
+	}
+}
+
+func TestDefaultBaseDirUsesStateHome(t *testing.T) {
+	home := t.TempDir()
+	stateHome := filepath.Join(home, "state")
+	got, err := DefaultBaseDir(map[string]string{
+		"HOME":           home,
+		"XDG_STATE_HOME": stateHome,
+	})
+	if err != nil {
+		t.Fatalf("DefaultBaseDir returned error: %v", err)
+	}
+	if got != filepath.Join(stateHome, "zero", "worktrees") {
+		t.Fatalf("DefaultBaseDir = %q", got)
+	}
+}
+
+func TestDefaultBaseDirFallsBackForWindowsUserProfile(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("USERPROFILE fallback is Windows-specific")
+	}
+	profile := `C:\Users\zero`
+	got, err := DefaultBaseDir(map[string]string{"USERPROFILE": profile})
+	if err != nil {
+		t.Fatalf("DefaultBaseDir returned error: %v", err)
+	}
+	if !strings.Contains(got, filepath.Join(profile, "AppData", "Local", "zero", "worktrees")) {
+		t.Fatalf("DefaultBaseDir = %q, want under USERPROFILE AppData", got)
+	}
+}
+
+type fakeRunner struct {
+	calls   []gitCall
+	results []CommandResult
+}
+
+func (runner *fakeRunner) Run(ctx context.Context, dir string, args ...string) (CommandResult, error) {
+	runner.calls = append(runner.calls, gitCall{dir: dir, args: append([]string{}, args...)})
+	if len(runner.results) == 0 {
+		return CommandResult{}, nil
+	}
+	result := runner.results[0]
+	runner.results = runner.results[1:]
+	return result, nil
+}
+
+func (runner *fakeRunner) commandLine(index int) string {
+	if index >= len(runner.calls) {
+		return ""
+	}
+	return "git " + strings.Join(runner.calls[index].args, " ")
+}
+
+type gitCall struct {
+	dir  string
+	args []string
+}
+
+func fixedTime(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -175,8 +175,9 @@ func TestDefaultBaseDirFallsBackForWindowsUserProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultBaseDir returned error: %v", err)
 	}
-	if !strings.Contains(got, filepath.Join(profile, "AppData", "Local", "zero", "worktrees")) {
-		t.Fatalf("DefaultBaseDir = %q, want under USERPROFILE AppData", got)
+	expected := filepath.Join(profile, "AppData", "Local", "zero", "worktrees")
+	if filepath.Clean(got) != filepath.Clean(expected) {
+		t.Fatalf("DefaultBaseDir = %q, want %q", got, expected)
 	}
 }
 

--- a/internal/worktrees/worktrees_test.go
+++ b/internal/worktrees/worktrees_test.go
@@ -50,6 +50,10 @@ func TestPrepareCreatesDetachedGitWorktree(t *testing.T) {
 func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	root := t.TempDir()
 	base := t.TempDir()
+	sourceGit := filepath.Join(root, ".git")
+	if err := os.MkdirAll(sourceGit, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	existing := filepath.Join(base, "zero-worktree-"+repoKey(root), "reuse-me")
 	if err := os.MkdirAll(filepath.Join(existing, ".git"), 0o700); err != nil {
 		t.Fatal(err)
@@ -59,6 +63,8 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 			{Stdout: root + "\n"},
 			{Stdout: "main\n"},
 			{Stdout: "abc1234\n"},
+			{Stdout: sourceGit + "\n"},
+			{Stdout: sourceGit + "\n"},
 		},
 	}
 
@@ -78,8 +84,43 @@ func TestPrepareReusesExistingGitWorktree(t *testing.T) {
 	if result.Path != existing {
 		t.Fatalf("Path = %q, want existing %q", result.Path, existing)
 	}
-	if len(runner.calls) != 3 {
+	if len(runner.calls) != 5 {
 		t.Fatalf("expected metadata git calls only, got %#v", runner.calls)
+	}
+}
+
+func TestPrepareRejectsExistingWorktreeFromDifferentRepo(t *testing.T) {
+	root := t.TempDir()
+	base := t.TempDir()
+	sourceGit := filepath.Join(root, ".git")
+	otherGit := filepath.Join(t.TempDir(), ".git")
+	for _, dir := range []string{sourceGit, otherGit} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	existing := filepath.Join(base, "zero-worktree-"+repoKey(root), "other-repo")
+	if err := os.MkdirAll(filepath.Join(existing, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{
+		results: []CommandResult{
+			{Stdout: root + "\n"},
+			{Stdout: "main\n"},
+			{Stdout: "abc1234\n"},
+			{Stdout: sourceGit + "\n"},
+			{Stdout: otherGit + "\n"},
+		},
+	}
+
+	_, err := Prepare(context.Background(), Options{
+		Cwd:     root,
+		Name:    "other-repo",
+		BaseDir: base,
+		RunGit:  runner.Run,
+	})
+	if err == nil || !strings.Contains(err.Error(), "different git repository") {
+		t.Fatalf("expected different repository reuse error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a Go worktree isolation backend with deterministic task names, safe worktree path handling, and reusable detached worktree preparation
- add a Go verification backend that detects repository checks, runs filtered verification plans, redacts command output, and reports structured pass/fail/error summaries
- wire the new backend into the CLI through `zero worktrees prepare`, `zero verify`, and `zero exec --worktree` / `--worktree-dir` with conflict validation

## Local validation
- `go test -count=1 ./internal/worktrees ./internal/verify ./internal/cli`
- `go test -count=1 -p 1 ./...`
- `npx --yes bun run typecheck`
- `npx --yes bun test ./tests --timeout 15000`
- `npx --yes bun run build`
- `npx --yes bun run smoke:build`
- `npx --yes bun run smoke:go`
- `./zero verify --only go.test --timeout-ms 600000`
- temp git repo smoke for `./zero worktrees prepare --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added worktrees and verify CLI commands; "zero exec" gains --worktree and --worktree-dir. verify supports --only and timeout; both support --json output.
  * CLI can prepare isolated Git worktrees and run repository verification checks (Go/npm).

* **CLI**
  * Help text updated to list the new commands and options; output redacts sensitive workspace/worktree path segments.

* **Tests**
  * Added extensive tests for CLI, worktrees, and verify (success, failure, redaction, JSON).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->