### PR TITLE
feat: add M5 git workflow backend

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Gitlawb/zero/internal/tui"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
+	"github.com/Gitlawb/zero/internal/zerogit"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -37,6 +38,9 @@ type appDeps struct {
 	prepareWorktree  func(context.Context, worktrees.Options) (worktrees.Result, error)
 	detectVerifyPlan func(string) (verify.Plan, error)
 	runVerify        func(context.Context, verify.Plan, verify.RunOptions) verify.Report
+	runVerifyLoop    func(context.Context, verify.Plan, verify.LoopOptions) verify.LoopReport
+	inspectChanges   func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error)
+	commitChanges    func(context.Context, zerogit.CommitOptions) (zerogit.CommitResult, error)
 	runTUI           func(context.Context, tui.Options) int
 	now              func() time.Time
 }
@@ -93,6 +97,9 @@ func defaultAppDeps() appDeps {
 		prepareWorktree:  worktrees.Prepare,
 		detectVerifyPlan: verify.DetectPlan,
 		runVerify:        verify.Run,
+		runVerifyLoop:    verify.RunLoop,
+		inspectChanges:   zerogit.Inspect,
+		commitChanges:    zerogit.Commit,
 		runTUI:           tui.Run,
 		now:              time.Now,
 	}
@@ -150,6 +157,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runWorktrees(args[1:], stdout, stderr, deps)
 	case "verify":
 		return runVerifyCommand(args[1:], stdout, stderr, deps)
+	case "changes", "change":
+		return runChanges(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
 	default:
@@ -203,6 +212,15 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.runVerify == nil {
 		deps.runVerify = defaults.runVerify
+	}
+	if deps.runVerifyLoop == nil {
+		deps.runVerifyLoop = defaults.runVerifyLoop
+	}
+	if deps.inspectChanges == nil {
+		deps.inspectChanges = defaults.inspectChanges
+	}
+	if deps.commitChanges == nil {
+		deps.commitChanges = defaults.commitChanges
 	}
 	if deps.runTUI == nil {
 		deps.runTUI = defaults.runTUI
@@ -305,6 +323,7 @@ Commands:
   mcp        Manage MCP backend settings
   worktrees  Prepare isolated git worktrees
   verify     Detect and run local verification checks
+  changes    Inspect and commit local git changes
   serve      Run Zero protocol servers
   help       Show this help
   version    Print version

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
+	"github.com/Gitlawb/zero/internal/zerogit"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -299,6 +300,111 @@ func TestRunVerifyReturnsProviderExitWhenChecksFail(t *testing.T) {
 	if !strings.Contains(stdout.String(), "failed") {
 		t.Fatalf("expected failure summary in stdout, got %q", stdout.String())
 	}
+}
+
+func TestRunVerifyAttemptsUsesSelfVerifyLoop(t *testing.T) {
+	cwd := t.TempDir()
+	plan := verify.Plan{Root: cwd, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	loopReport := verify.LoopReport{
+		OK: true,
+		Attempts: []verify.Attempt{
+			{Number: 1, Report: verify.Report{Root: cwd, OK: false, Summary: verify.Summary{Total: 1, Failed: 1}}},
+			{Number: 2, Report: verify.Report{Root: cwd, OK: true, Summary: verify.Summary{Total: 1, Passed: 1}}},
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"verify", "--attempts", "2", "--json"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		detectVerifyPlan: func(root string) (verify.Plan, error) {
+			if root != cwd {
+				t.Fatalf("verify root = %q, want %q", root, cwd)
+			}
+			return plan, nil
+		},
+		runVerifyLoop: func(ctx context.Context, gotPlan verify.Plan, options verify.LoopOptions) verify.LoopReport {
+			if options.MaxAttempts != 2 {
+				t.Fatalf("MaxAttempts = %d, want 2", options.MaxAttempts)
+			}
+			return loopReport
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var decoded verify.LoopReport
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode verify loop JSON: %v\n%s", err, stdout.String())
+	}
+	if len(decoded.Attempts) != 2 || !decoded.OK {
+		t.Fatalf("unexpected loop JSON: %#v", decoded)
+	}
+}
+
+func TestRunChangesInspectAndCommit(t *testing.T) {
+	cwd := t.TempDir()
+	summary := zerogit.ChangeSummary{
+		Root:   cwd,
+		Branch: "main",
+		Commit: "abc1234",
+		Files:  []zerogit.FileChange{{Path: "README.md", Status: "modified", Unstaged: true}},
+	}
+	commit := zerogit.CommitResult{
+		Root:       cwd,
+		Message:    "Update README",
+		DryRun:     true,
+		Committed:  false,
+		Before:     summary,
+		CommitHash: "",
+	}
+
+	t.Run("inspect json", func(t *testing.T) {
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		exitCode := runWithDeps([]string{"changes", "inspect", "--json"}, &stdout, &stderr, appDeps{
+			getwd: func() (string, error) { return cwd, nil },
+			inspectChanges: func(ctx context.Context, options zerogit.InspectOptions) (zerogit.ChangeSummary, error) {
+				if options.Cwd != cwd {
+					t.Fatalf("inspect cwd = %q, want %q", options.Cwd, cwd)
+				}
+				return summary, nil
+			},
+		})
+
+		if exitCode != exitSuccess {
+			t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+		}
+		var decoded zerogit.ChangeSummary
+		if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+			t.Fatalf("decode changes JSON: %v\n%s", err, stdout.String())
+		}
+		if len(decoded.Files) != 1 || decoded.Files[0].Path != "README.md" {
+			t.Fatalf("unexpected changes JSON: %#v", decoded)
+		}
+	})
+
+	t.Run("commit dry-run", func(t *testing.T) {
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		exitCode := runWithDeps([]string{"changes", "commit", "--message", "Update README", "--dry-run"}, &stdout, &stderr, appDeps{
+			getwd: func() (string, error) { return cwd, nil },
+			commitChanges: func(ctx context.Context, options zerogit.CommitOptions) (zerogit.CommitResult, error) {
+				if options.Cwd != cwd || options.Message != "Update README" || !options.DryRun {
+					t.Fatalf("unexpected commit options: %#v", options)
+				}
+				return commit, nil
+			},
+		})
+
+		if exitCode != exitSuccess {
+			t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "Zero changes commit") || !strings.Contains(stdout.String(), "dry-run: true") {
+			t.Fatalf("unexpected changes commit output: %q", stdout.String())
+		}
+	})
 }
 
 func TestRunExecWorktreeUsesPreparedWorkspace(t *testing.T) {

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
+	"github.com/Gitlawb/zero/internal/zerogit"
 )
 
 type worktreeCommandOptions struct {
@@ -24,6 +25,15 @@ type verifyCommandOptions struct {
 	cwd       string
 	only      []string
 	timeoutMS int
+	attempts  int
+}
+
+type changesCommandOptions struct {
+	json         bool
+	cwd          string
+	message      string
+	dryRun       bool
+	maxDiffBytes int
 }
 
 func runWorktrees(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -96,6 +106,28 @@ func runVerifyCommand(args []string, stdout io.Writer, stderr io.Writer, deps ap
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
+	if options.attempts > 1 {
+		loopReport := deps.runVerifyLoop(context.Background(), plan, verify.LoopOptions{
+			RunOptions: verify.RunOptions{
+				Only:      options.only,
+				TimeoutMS: options.timeoutMS,
+				Now:       deps.now,
+			},
+			MaxAttempts: options.attempts,
+		})
+		safeLoopReport := redactVerifyLoopReport(loopReport)
+		if options.json {
+			if err := writePrettyJSON(stdout, safeLoopReport); err != nil {
+				return exitCrash
+			}
+		} else if _, err := fmt.Fprintln(stdout, formatVerifyLoopReport(safeLoopReport)); err != nil {
+			return exitCrash
+		}
+		if !loopReport.OK {
+			return exitProvider
+		}
+		return exitSuccess
+	}
 	report := deps.runVerify(context.Background(), plan, verify.RunOptions{
 		Only:      options.only,
 		TimeoutMS: options.timeoutMS,
@@ -113,6 +145,78 @@ func runVerifyCommand(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		return exitProvider
 	}
 	return exitSuccess
+}
+
+func runChanges(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	command := "inspect"
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		command = strings.ToLower(strings.TrimSpace(args[0]))
+		args = args[1:]
+	}
+	if command == "help" {
+		if err := writeChangesHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	options, help, err := parseChangesArgs(args, command)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeChangesHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	switch command {
+	case "inspect", "status":
+		summary, err := deps.inspectChanges(context.Background(), zerogit.InspectOptions{
+			Cwd:          workspaceRoot,
+			MaxDiffBytes: options.maxDiffBytes,
+		})
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		safeSummary := redactChangeSummary(summary)
+		if options.json {
+			if err := writePrettyJSON(stdout, safeSummary); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, formatChangeSummary(safeSummary)); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	case "commit":
+		result, err := deps.commitChanges(context.Background(), zerogit.CommitOptions{
+			Cwd:          workspaceRoot,
+			Message:      options.message,
+			DryRun:       options.dryRun,
+			MaxDiffBytes: options.maxDiffBytes,
+		})
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		safeResult := redactCommitResult(result)
+		if options.json {
+			if err := writePrettyJSON(stdout, safeResult); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, formatCommitResult(safeResult)); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown changes command %q", command))
+	}
 }
 
 func parseWorktreeCommandArgs(args []string) (worktreeCommandOptions, bool, error) {
@@ -222,11 +326,86 @@ func parseVerifyCommandArgs(args []string) (verifyCommandOptions, bool, error) {
 				return options, false, err
 			}
 			options.timeoutMS = timeoutMS
+		case arg == "--attempts":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			attempts, err := parsePositiveIntFlag("--attempts", value)
+			if err != nil {
+				return options, false, err
+			}
+			options.attempts = attempts
+			index = next
+		case strings.HasPrefix(arg, "--attempts="):
+			attempts, err := parsePositiveIntFlag("--attempts", strings.TrimSpace(strings.TrimPrefix(arg, "--attempts=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.attempts = attempts
 		case strings.HasPrefix(arg, "-"):
 			return options, false, execUsageError{fmt.Sprintf("unknown verify flag %q", arg)}
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unexpected verify argument %q", arg)}
 		}
+	}
+	return options, false, nil
+}
+
+func parseChangesArgs(args []string, command string) (changesCommandOptions, bool, error) {
+	options := changesCommandOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--dry-run":
+			options.dryRun = true
+		case arg == "-C" || arg == "--cwd":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.cwd = value
+			index = next
+		case strings.HasPrefix(arg, "--cwd="):
+			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
+		case arg == "-m" || arg == "--message":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.message = value
+			index = next
+		case strings.HasPrefix(arg, "--message="):
+			options.message = strings.TrimSpace(strings.TrimPrefix(arg, "--message="))
+		case arg == "--diff-bytes":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			maxDiffBytes, err := parsePositiveIntFlag("--diff-bytes", value)
+			if err != nil {
+				return options, false, err
+			}
+			options.maxDiffBytes = maxDiffBytes
+			index = next
+		case strings.HasPrefix(arg, "--diff-bytes="):
+			maxDiffBytes, err := parsePositiveIntFlag("--diff-bytes", strings.TrimSpace(strings.TrimPrefix(arg, "--diff-bytes=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.maxDiffBytes = maxDiffBytes
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown changes flag %q", arg)}
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unexpected changes argument %q", arg)}
+		}
+	}
+	if command != "commit" && (options.message != "" || options.dryRun) {
+		return options, false, execUsageError{"--message and --dry-run are only valid with `zero changes commit`"}
 	}
 	return options, false, nil
 }
@@ -260,6 +439,35 @@ func redactVerifyReport(report verify.Report) verify.Report {
 		report.Results[index].Error = redactCLIString(report.Results[index].Error)
 	}
 	return report
+}
+
+func redactVerifyLoopReport(report verify.LoopReport) verify.LoopReport {
+	report.Error = redactCLIString(report.Error)
+	for index := range report.Attempts {
+		report.Attempts[index].Report = redactVerifyReport(report.Attempts[index].Report)
+	}
+	return report
+}
+
+func redactChangeSummary(summary zerogit.ChangeSummary) zerogit.ChangeSummary {
+	summary.Root = redactCLIString(summary.Root)
+	summary.Branch = redactCLIString(summary.Branch)
+	summary.Commit = redactCLIString(summary.Commit)
+	summary.DiffStat = redactCLIString(summary.DiffStat)
+	summary.Diff = redactCLIString(summary.Diff)
+	for index := range summary.Files {
+		summary.Files[index].Path = redactCLIString(summary.Files[index].Path)
+		summary.Files[index].Status = redactCLIString(summary.Files[index].Status)
+	}
+	return summary
+}
+
+func redactCommitResult(result zerogit.CommitResult) zerogit.CommitResult {
+	result.Root = redactCLIString(result.Root)
+	result.Message = redactCLIString(result.Message)
+	result.CommitHash = redactCLIString(result.CommitHash)
+	result.Before = redactChangeSummary(result.Before)
+	return result
 }
 
 func redactCLIString(value string) string {
@@ -306,6 +514,62 @@ func formatVerifyReport(report verify.Report) string {
 	return strings.Join(lines, "\n")
 }
 
+func formatVerifyLoopReport(report verify.LoopReport) string {
+	lines := []string{
+		"Zero self-verification",
+		fmt.Sprintf("attempts: %d", len(report.Attempts)),
+		fmt.Sprintf("summary: %d total, %d passed, %d failed, %d errors", report.Summary.Total, report.Summary.Passed, report.Summary.Failed, report.Summary.Errors),
+	}
+	for _, attempt := range report.Attempts {
+		status := "failed"
+		if attempt.Report.OK {
+			status = "passed"
+		}
+		lines = append(lines, fmt.Sprintf("  attempt %d: %s", attempt.Number, status))
+	}
+	if report.Error != "" {
+		lines = append(lines, "error: "+report.Error)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatChangeSummary(summary zerogit.ChangeSummary) string {
+	lines := []string{
+		"Zero changes",
+		"root: " + summary.Root,
+		fmt.Sprintf("files: %d changed", len(summary.Files)),
+	}
+	if summary.Branch != "" {
+		lines = append(lines, "branch: "+summary.Branch)
+	}
+	if summary.Commit != "" {
+		lines = append(lines, "commit: "+summary.Commit)
+	}
+	if summary.Clean {
+		lines = append(lines, "clean: true")
+		return strings.Join(lines, "\n")
+	}
+	for _, file := range summary.Files {
+		lines = append(lines, fmt.Sprintf("  [%s] %s", file.Status, file.Path))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatCommitResult(result zerogit.CommitResult) string {
+	lines := []string{
+		"Zero changes commit",
+		"root: " + result.Root,
+		"message: " + result.Message,
+		fmt.Sprintf("dry-run: %t", result.DryRun),
+		fmt.Sprintf("committed: %t", result.Committed),
+		fmt.Sprintf("files: %d changed", len(result.Before.Files)),
+	}
+	if result.CommitHash != "" {
+		lines = append(lines, "commit: "+result.CommitHash)
+	}
+	return strings.Join(lines, "\n")
+}
+
 func writeWorktreesHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero worktrees prepare [flags] [name]
@@ -332,6 +596,25 @@ Flags:
   -C, --cwd <path>        Workspace directory
       --only <ids>        Run only matching check ids
       --timeout-ms <n>    Per-check timeout in milliseconds
+      --attempts <n>      Run a bounded self-verification loop
+      --json              Print JSON output
+  -h, --help              Show this help
+`)
+	return err
+}
+
+func writeChangesHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero changes inspect [flags]
+  zero changes commit [flags]
+
+Inspects local git changes and optionally creates a commit.
+
+Flags:
+  -C, --cwd <path>        Workspace directory
+      --diff-bytes <n>    Maximum diff bytes to include
+  -m, --message <text>    Commit message for `+"`zero changes commit`"+`
+      --dry-run           Preview commit metadata without mutating git state
       --json              Print JSON output
   -h, --help              Show this help
 `)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -106,6 +106,7 @@ type LoopOptions struct {
 }
 
 const defaultTimeoutMS = 120000
+const maxOutputSummaryLines = 8
 
 func DetectPlan(root string) (Plan, error) {
 	resolvedRoot, err := resolveRoot(root)
@@ -254,6 +255,7 @@ func detectPackageChecks(root string) []Check {
 
 func summarizeOutput(values ...string) *OutputSummary {
 	lines := []string{}
+	fallback := ""
 	contextLines := 0
 	truncated := false
 	for _, value := range values {
@@ -262,25 +264,34 @@ func summarizeOutput(values ...string) *OutputSummary {
 			if trimmed == "" {
 				continue
 			}
+			if fallback == "" {
+				fallback = trimmed
+			}
+			include := false
 			if isFailureLine(trimmed) {
-				lines = append(lines, trimmed)
+				include = true
 				contextLines = 2
 			} else if contextLines > 0 {
-				lines = append(lines, trimmed)
+				include = true
 				contextLines--
-			} else {
+			}
+			if !include {
 				continue
 			}
-			if len(lines) >= 8 {
+			if len(lines) >= maxOutputSummaryLines {
 				truncated = true
 				break
 			}
+			lines = append(lines, trimmed)
 		}
 		if truncated {
 			break
 		}
 	}
 	if len(lines) == 0 {
+		if fallback != "" {
+			return &OutputSummary{Lines: []string{fallback}}
+		}
 		return nil
 	}
 	return &OutputSummary{Lines: lines, Truncated: truncated}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -42,17 +42,18 @@ type Summary struct {
 }
 
 type Result struct {
-	ID         string   `json:"id"`
-	Name       string   `json:"name"`
-	Command    []string `json:"command"`
-	Status     Status   `json:"status"`
-	ExitCode   int      `json:"exitCode"`
-	Stdout     string   `json:"stdout,omitempty"`
-	Stderr     string   `json:"stderr,omitempty"`
-	StartedAt  string   `json:"startedAt"`
-	EndedAt    string   `json:"endedAt"`
-	DurationMs int      `json:"durationMs"`
-	Error      string   `json:"error,omitempty"`
+	ID            string         `json:"id"`
+	Name          string         `json:"name"`
+	Command       []string       `json:"command"`
+	Status        Status         `json:"status"`
+	ExitCode      int            `json:"exitCode"`
+	Stdout        string         `json:"stdout,omitempty"`
+	Stderr        string         `json:"stderr,omitempty"`
+	StartedAt     string         `json:"startedAt"`
+	EndedAt       string         `json:"endedAt"`
+	DurationMs    int            `json:"durationMs"`
+	Error         string         `json:"error,omitempty"`
+	OutputSummary *OutputSummary `json:"outputSummary,omitempty"`
 }
 
 type Report struct {
@@ -62,6 +63,25 @@ type Report struct {
 	OK        bool     `json:"ok"`
 	Summary   Summary  `json:"summary"`
 	Results   []Result `json:"results"`
+}
+
+type OutputSummary struct {
+	Lines     []string `json:"lines,omitempty"`
+	Truncated bool     `json:"truncated,omitempty"`
+}
+
+type Attempt struct {
+	Number int    `json:"number"`
+	Report Report `json:"report"`
+}
+
+type LoopReport struct {
+	StartedAt string    `json:"startedAt"`
+	EndedAt   string    `json:"endedAt"`
+	OK        bool      `json:"ok"`
+	Summary   Summary   `json:"summary"`
+	Attempts  []Attempt `json:"attempts"`
+	Error     string    `json:"error,omitempty"`
 }
 
 type CommandResult struct {
@@ -77,6 +97,12 @@ type RunOptions struct {
 	TimeoutMS int
 	Runner    Runner
 	Now       func() time.Time
+}
+
+type LoopOptions struct {
+	RunOptions
+	MaxAttempts int
+	OnFailure   func(context.Context, Attempt) error
 }
 
 const defaultTimeoutMS = 120000
@@ -129,12 +155,14 @@ func Run(ctx context.Context, plan Plan, options RunOptions) Report {
 		if err != nil {
 			result.Status = StatusError
 			result.Error = redaction.RedactString(err.Error(), redaction.Options{})
+			result.OutputSummary = summarizeOutput(result.Stdout, result.Stderr, result.Error)
 			report.Summary.Errors++
 		} else if commandResult.ExitCode == 0 {
 			result.Status = StatusPass
 			report.Summary.Passed++
 		} else {
 			result.Status = StatusFail
+			result.OutputSummary = summarizeOutput(result.Stdout, result.Stderr)
 			report.Summary.Failed++
 		}
 		report.Results = append(report.Results, result)
@@ -154,6 +182,37 @@ func Run(ctx context.Context, plan Plan, options RunOptions) Report {
 	}
 	report.Summary.Total = len(report.Results)
 	report.OK = report.Summary.Failed == 0 && report.Summary.Errors == 0
+	report.EndedAt = formatTime(now())
+	return report
+}
+
+func RunLoop(ctx context.Context, plan Plan, options LoopOptions) LoopReport {
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	start := now()
+	report := LoopReport{
+		StartedAt: formatTime(start),
+		OK:        false,
+	}
+	maxAttempts := firstPositive(options.MaxAttempts, 1)
+	for attemptNumber := 1; attemptNumber <= maxAttempts; attemptNumber++ {
+		attemptReport := Run(ctx, plan, options.RunOptions)
+		attempt := Attempt{Number: attemptNumber, Report: attemptReport}
+		report.Attempts = append(report.Attempts, attempt)
+		report.Summary = attemptReport.Summary
+		if attemptReport.OK {
+			report.OK = true
+			break
+		}
+		if attemptNumber < maxAttempts && options.OnFailure != nil {
+			if err := options.OnFailure(ctx, attempt); err != nil {
+				report.Error = redaction.RedactString(err.Error(), redaction.Options{})
+				break
+			}
+		}
+	}
 	report.EndedAt = formatTime(now())
 	return report
 }
@@ -191,6 +250,51 @@ func detectPackageChecks(root string) []Check {
 		})
 	}
 	return checks
+}
+
+func summarizeOutput(values ...string) *OutputSummary {
+	lines := []string{}
+	contextLines := 0
+	truncated := false
+	for _, value := range values {
+		for _, line := range strings.Split(value, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if isFailureLine(trimmed) {
+				lines = append(lines, trimmed)
+				contextLines = 2
+			} else if contextLines > 0 {
+				lines = append(lines, trimmed)
+				contextLines--
+			} else {
+				continue
+			}
+			if len(lines) >= 8 {
+				truncated = true
+				break
+			}
+		}
+		if truncated {
+			break
+		}
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	return &OutputSummary{Lines: lines, Truncated: truncated}
+}
+
+func isFailureLine(line string) bool {
+	lower := strings.ToLower(line)
+	return strings.HasPrefix(line, "--- FAIL:") ||
+		strings.HasPrefix(line, "FAIL") ||
+		strings.HasPrefix(lower, "panic:") ||
+		strings.HasPrefix(lower, "error:") ||
+		strings.HasPrefix(lower, "not ok") ||
+		strings.Contains(lower, " assertion") ||
+		strings.Contains(lower, " failed")
 }
 
 func defaultRunner(ctx context.Context, dir string, command []string, timeout time.Duration) (CommandResult, error) {

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -71,6 +71,74 @@ func TestRunExecutesPlanAndRedactsOutput(t *testing.T) {
 	}
 }
 
+func TestRunParsesStructuredFailureSummary(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}},
+	}}
+	runner := &fakeCommandRunner{results: []CommandResult{{
+		ExitCode: 1,
+		Stdout: strings.Join([]string{
+			"--- FAIL: TestSecret (0.00s)",
+			"    secret_test.go:12: token sk-proj-abcdefghijklmnopqrstuvwxyz",
+			"FAIL",
+		}, "\n"),
+	}}}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Runner: runner.Run,
+		Now:    fixedVerifyTime("2026-06-05T11:15:00Z"),
+	})
+
+	if report.Results[0].OutputSummary == nil {
+		t.Fatalf("expected output summary, got %#v", report.Results[0])
+	}
+	lines := strings.Join(report.Results[0].OutputSummary.Lines, "\n")
+	if !strings.Contains(lines, "TestSecret") || !strings.Contains(lines, "[REDACTED]") {
+		t.Fatalf("expected redacted failure summary lines, got %q", lines)
+	}
+	if strings.Contains(lines, "sk-proj-abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("failure summary leaked secret: %q", lines)
+	}
+}
+
+func TestRunLoopRetriesUntilVerificationPasses(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}},
+	}}
+	runner := &fakeCommandRunner{results: []CommandResult{
+		{ExitCode: 1, Stdout: "--- FAIL: TestOne\nFAIL\n"},
+		{ExitCode: 0, Stdout: "ok\n"},
+	}}
+	retryCount := 0
+
+	report := RunLoop(context.Background(), plan, LoopOptions{
+		RunOptions: RunOptions{
+			Runner: runner.Run,
+			Now:    fixedVerifyTime("2026-06-05T11:20:00Z"),
+		},
+		MaxAttempts: 2,
+		OnFailure: func(ctx context.Context, attempt Attempt) error {
+			retryCount++
+			if attempt.Number != 1 || attempt.Report.OK {
+				t.Fatalf("unexpected failed attempt passed to hook: %#v", attempt)
+			}
+			return nil
+		},
+	})
+
+	if !report.OK {
+		t.Fatalf("expected loop to pass, got %#v", report)
+	}
+	if len(report.Attempts) != 2 || !report.Attempts[1].Report.OK {
+		t.Fatalf("unexpected attempts: %#v", report.Attempts)
+	}
+	if retryCount != 1 {
+		t.Fatalf("retry hook called %d times, want 1", retryCount)
+	}
+}
+
 func TestRunFiltersChecksByID(t *testing.T) {
 	root := t.TempDir()
 	plan := Plan{Root: root, Checks: []Check{

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,6 +100,54 @@ func TestRunParsesStructuredFailureSummary(t *testing.T) {
 	}
 	if strings.Contains(lines, "sk-proj-abcdefghijklmnopqrstuvwxyz") {
 		t.Fatalf("failure summary leaked secret: %q", lines)
+	}
+}
+
+func TestRunSummarizesPlainCommandErrors(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "bun.test", Name: "Bun tests", Command: []string{"bun", "test"}},
+	}}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Runner: func(context.Context, string, []string, time.Duration) (CommandResult, error) {
+			return CommandResult{}, errors.New(`exec: "bun": executable file not found in $PATH`)
+		},
+		Now: fixedVerifyTime("2026-06-05T11:16:00Z"),
+	})
+
+	summary := report.Results[0].OutputSummary
+	if summary == nil {
+		t.Fatalf("expected plain command error summary, got %#v", report.Results[0])
+	}
+	if len(summary.Lines) != 1 || !strings.Contains(summary.Lines[0], "executable file not found") {
+		t.Fatalf("unexpected plain command error summary: %#v", summary)
+	}
+	if summary.Truncated {
+		t.Fatalf("plain command error summary should not be truncated: %#v", summary)
+	}
+}
+
+func TestRunFailureSummaryTruncatesOnlyOnOverflow(t *testing.T) {
+	lines := []string{}
+	for index := 0; index < maxOutputSummaryLines; index++ {
+		lines = append(lines, "--- FAIL: TestExact (0.00s)")
+	}
+	exact := summarizeOutput(strings.Join(lines, "\n"))
+	if exact == nil || len(exact.Lines) != maxOutputSummaryLines {
+		t.Fatalf("expected exact-limit summary, got %#v", exact)
+	}
+	if exact.Truncated {
+		t.Fatalf("exact-limit summary should not be truncated: %#v", exact)
+	}
+
+	overflowLines := append(append([]string{}, lines...), "--- FAIL: TestOverflow (0.00s)")
+	overflow := summarizeOutput(strings.Join(overflowLines, "\n"))
+	if overflow == nil || len(overflow.Lines) != maxOutputSummaryLines {
+		t.Fatalf("expected capped overflow summary, got %#v", overflow)
+	}
+	if !overflow.Truncated {
+		t.Fatalf("overflow summary should be truncated: %#v", overflow)
 	}
 }
 

--- a/internal/zerogit/zerogit.go
+++ b/internal/zerogit/zerogit.go
@@ -1,0 +1,340 @@
+package zerogit
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+type Runner func(context.Context, string, ...string) (CommandResult, error)
+
+type CommandResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+type InspectOptions struct {
+	Cwd          string
+	MaxDiffBytes int
+	RunGit       Runner
+}
+
+type CommitOptions struct {
+	Cwd          string
+	Message      string
+	DryRun       bool
+	MaxDiffBytes int
+	RunGit       Runner
+}
+
+type FileChange struct {
+	Path      string `json:"path"`
+	Status    string `json:"status"`
+	Staged    bool   `json:"staged,omitempty"`
+	Unstaged  bool   `json:"unstaged,omitempty"`
+	Untracked bool   `json:"untracked,omitempty"`
+}
+
+type ChangeSummary struct {
+	Root      string       `json:"root"`
+	Branch    string       `json:"branch,omitempty"`
+	Commit    string       `json:"commit,omitempty"`
+	Clean     bool         `json:"clean"`
+	Files     []FileChange `json:"files"`
+	DiffStat  string       `json:"diffStat,omitempty"`
+	Diff      string       `json:"diff,omitempty"`
+	Truncated bool         `json:"truncated,omitempty"`
+}
+
+type CommitResult struct {
+	Root       string        `json:"root"`
+	Message    string        `json:"message"`
+	DryRun     bool          `json:"dryRun"`
+	Committed  bool          `json:"committed"`
+	CommitHash string        `json:"commitHash,omitempty"`
+	Before     ChangeSummary `json:"before"`
+}
+
+const defaultMaxDiffBytes = 120000
+
+func Inspect(ctx context.Context, options InspectOptions) (ChangeSummary, error) {
+	cwd, err := resolveCwd(options.Cwd)
+	if err != nil {
+		return ChangeSummary{}, err
+	}
+	runGit := options.RunGit
+	if runGit == nil {
+		runGit = defaultRunGit
+	}
+
+	root, err := gitOutput(ctx, runGit, cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return ChangeSummary{}, fmt.Errorf("not a git repository: %w", err)
+	}
+	root = filepath.Clean(root)
+	branch, _ := gitOutput(ctx, runGit, root, "rev-parse", "--abbrev-ref", "HEAD")
+	commit, _ := gitOutput(ctx, runGit, root, "rev-parse", "--short", "HEAD")
+	status, err := gitRawOutput(ctx, runGit, root, "status", "--short", "--untracked-files=all")
+	if err != nil {
+		return ChangeSummary{}, fmt.Errorf("inspect git status: %w", err)
+	}
+	diffStat, err := gitRawOutput(ctx, runGit, root, "diff", "--stat", "HEAD", "--")
+	if err != nil {
+		return ChangeSummary{}, fmt.Errorf("inspect git diff stat: %w", err)
+	}
+	diff, err := gitRawOutput(ctx, runGit, root, "diff", "HEAD", "--")
+	if err != nil {
+		return ChangeSummary{}, fmt.Errorf("inspect git diff: %w", err)
+	}
+
+	maxDiffBytes := firstPositive(options.MaxDiffBytes, defaultMaxDiffBytes)
+	redactedDiff, truncated := truncateString(redactText(diff), maxDiffBytes)
+	files := parseStatus(status)
+	return ChangeSummary{
+		Root:      root,
+		Branch:    redactText(branch),
+		Commit:    redactText(commit),
+		Clean:     len(files) == 0,
+		Files:     files,
+		DiffStat:  redactText(diffStat),
+		Diff:      redactedDiff,
+		Truncated: truncated,
+	}, nil
+}
+
+func Commit(ctx context.Context, options CommitOptions) (CommitResult, error) {
+	summary, err := Inspect(ctx, InspectOptions{
+		Cwd:          options.Cwd,
+		MaxDiffBytes: options.MaxDiffBytes,
+		RunGit:       options.RunGit,
+	})
+	if err != nil {
+		return CommitResult{}, err
+	}
+	if summary.Clean {
+		return CommitResult{}, fmt.Errorf("no changes to commit")
+	}
+	message := strings.TrimSpace(options.Message)
+	if message == "" {
+		message = GenerateMessage(summary)
+	}
+	if err := ValidateMessage(message); err != nil {
+		return CommitResult{}, err
+	}
+	result := CommitResult{
+		Root:      summary.Root,
+		Message:   message,
+		DryRun:    options.DryRun,
+		Committed: false,
+		Before:    summary,
+	}
+	if options.DryRun {
+		return result, nil
+	}
+
+	runGit := options.RunGit
+	if runGit == nil {
+		runGit = defaultRunGit
+	}
+	if _, err := gitOutput(ctx, runGit, summary.Root, "add", "-A"); err != nil {
+		return CommitResult{}, fmt.Errorf("stage changes: %w", err)
+	}
+	if _, err := gitOutput(ctx, runGit, summary.Root, "commit", "-m", message); err != nil {
+		return CommitResult{}, fmt.Errorf("commit changes: %w", err)
+	}
+	hash, err := gitOutput(ctx, runGit, summary.Root, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return CommitResult{}, fmt.Errorf("resolve created commit: %w", err)
+	}
+	result.Committed = true
+	result.CommitHash = redactText(hash)
+	return result, nil
+}
+
+func GenerateMessage(summary ChangeSummary) string {
+	count := len(summary.Files)
+	switch count {
+	case 0:
+		return "Update workspace"
+	case 1:
+		return truncateSubject("Update " + summary.Files[0].Path)
+	default:
+		return fmt.Sprintf("Update %d files", count)
+	}
+}
+
+func ValidateMessage(message string) error {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return fmt.Errorf("commit message is required")
+	}
+	firstLine := strings.Split(trimmed, "\n")[0]
+	if len(firstLine) > 72 {
+		return fmt.Errorf("commit message subject must be 72 characters or fewer")
+	}
+	return nil
+}
+
+func parseStatus(status string) []FileChange {
+	files := []FileChange{}
+	for _, line := range strings.Split(status, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if len(line) < 3 {
+			continue
+		}
+		code := line[:2]
+		path := strings.TrimSpace(line[3:])
+		if path == "" {
+			continue
+		}
+		files = append(files, FileChange{
+			Path:      redactText(path),
+			Status:    statusName(code),
+			Staged:    code[0] != ' ' && code[0] != '?',
+			Unstaged:  code[1] != ' ' && code[1] != '?',
+			Untracked: code == "??",
+		})
+	}
+	return files
+}
+
+func statusName(code string) string {
+	if code == "??" {
+		return "untracked"
+	}
+	if strings.Contains(code, "U") {
+		return "conflicted"
+	}
+	if code[0] == 'A' || code[1] == 'A' {
+		return "added"
+	}
+	if code[0] == 'D' || code[1] == 'D' {
+		return "deleted"
+	}
+	if code[0] == 'R' || code[1] == 'R' {
+		return "renamed"
+	}
+	if code[0] == 'C' || code[1] == 'C' {
+		return "copied"
+	}
+	return "modified"
+}
+
+func resolveCwd(cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve git cwd: %w", err)
+		}
+	}
+	absolute, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve git cwd: %w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("git cwd must be an existing directory: %s", absolute)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func gitOutput(ctx context.Context, runGit Runner, dir string, args ...string) (string, error) {
+	output, err := gitRawOutput(ctx, runGit, dir, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func gitRawOutput(ctx context.Context, runGit Runner, dir string, args ...string) (string, error) {
+	result, err := runGit(ctx, dir, args...)
+	if err != nil {
+		return "", err
+	}
+	if result.ExitCode != 0 {
+		message := strings.TrimSpace(firstNonEmpty(result.Stderr, result.Stdout))
+		if message == "" {
+			message = fmt.Sprintf("git exited with code %d", result.ExitCode)
+		}
+		return "", fmt.Errorf("%s", redactText(message))
+	}
+	return result.Stdout, nil
+}
+
+func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResult, error) {
+	command := exec.CommandContext(ctx, "git", args...)
+	command.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	exitCode := 0
+	if err != nil {
+		exitCode = -1
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+			err = nil
+		}
+	}
+	return CommandResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: exitCode}, err
+}
+
+func truncateString(value string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value, false
+	}
+	suffix := "\n[truncated]"
+	if maxBytes <= len(suffix) {
+		return suffix, true
+	}
+	head := value[:maxBytes-len(suffix)]
+	if strings.Contains(value, redaction.RedactedSecret) && !strings.Contains(head, redaction.RedactedSecret) {
+		marker := "\n" + redaction.RedactedSecret
+		budget := maxBytes - len(suffix) - len(marker)
+		if budget <= 0 {
+			return redaction.RedactedSecret + suffix, true
+		}
+		return value[:budget] + marker + suffix, true
+	}
+	return head + suffix, true
+}
+
+func truncateSubject(value string) string {
+	if len(value) <= 72 {
+		return value
+	}
+	return strings.TrimSpace(value[:69]) + "..."
+}
+
+func redactText(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/zerogit/zerogit.go
+++ b/internal/zerogit/zerogit.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Runner func(context.Context, string, ...string) (CommandResult, error)
+type EnvRunner func(context.Context, string, []string, ...string) (CommandResult, error)
 
 type CommandResult struct {
 	Stdout   string
@@ -24,6 +25,7 @@ type InspectOptions struct {
 	Cwd          string
 	MaxDiffBytes int
 	RunGit       Runner
+	RunGitEnv    EnvRunner
 }
 
 type CommitOptions struct {
@@ -32,6 +34,7 @@ type CommitOptions struct {
 	DryRun       bool
 	MaxDiffBytes int
 	RunGit       Runner
+	RunGitEnv    EnvRunner
 }
 
 type FileChange struct {
@@ -69,10 +72,7 @@ func Inspect(ctx context.Context, options InspectOptions) (ChangeSummary, error)
 	if err != nil {
 		return ChangeSummary{}, err
 	}
-	runGit := options.RunGit
-	if runGit == nil {
-		runGit = defaultRunGit
-	}
+	runGit, runGitEnv := resolveRunners(options.RunGit, options.RunGitEnv)
 
 	root, err := gitOutput(ctx, runGit, cwd, "rev-parse", "--show-toplevel")
 	if err != nil {
@@ -85,13 +85,9 @@ func Inspect(ctx context.Context, options InspectOptions) (ChangeSummary, error)
 	if err != nil {
 		return ChangeSummary{}, fmt.Errorf("inspect git status: %w", err)
 	}
-	diffStat, err := gitRawOutput(ctx, runGit, root, "diff", "--stat", "HEAD", "--")
+	diffStat, diff, err := stagedSnapshotDiff(ctx, runGitEnv, root)
 	if err != nil {
-		return ChangeSummary{}, fmt.Errorf("inspect git diff stat: %w", err)
-	}
-	diff, err := gitRawOutput(ctx, runGit, root, "diff", "HEAD", "--")
-	if err != nil {
-		return ChangeSummary{}, fmt.Errorf("inspect git diff: %w", err)
+		return ChangeSummary{}, err
 	}
 
 	maxDiffBytes := firstPositive(options.MaxDiffBytes, defaultMaxDiffBytes)
@@ -114,6 +110,7 @@ func Commit(ctx context.Context, options CommitOptions) (CommitResult, error) {
 		Cwd:          options.Cwd,
 		MaxDiffBytes: options.MaxDiffBytes,
 		RunGit:       options.RunGit,
+		RunGitEnv:    options.RunGitEnv,
 	})
 	if err != nil {
 		return CommitResult{}, err
@@ -139,10 +136,7 @@ func Commit(ctx context.Context, options CommitOptions) (CommitResult, error) {
 		return result, nil
 	}
 
-	runGit := options.RunGit
-	if runGit == nil {
-		runGit = defaultRunGit
-	}
+	runGit, _ := resolveRunners(options.RunGit, options.RunGitEnv)
 	if _, err := gitOutput(ctx, runGit, summary.Root, "add", "-A"); err != nil {
 		return CommitResult{}, fmt.Errorf("stage changes: %w", err)
 	}
@@ -258,6 +252,15 @@ func gitOutput(ctx context.Context, runGit Runner, dir string, args ...string) (
 
 func gitRawOutput(ctx context.Context, runGit Runner, dir string, args ...string) (string, error) {
 	result, err := runGit(ctx, dir, args...)
+	return gitResultOutput(result, err)
+}
+
+func gitRawOutputEnv(ctx context.Context, runGit EnvRunner, dir string, env []string, args ...string) (string, error) {
+	result, err := runGit(ctx, dir, env, args...)
+	return gitResultOutput(result, err)
+}
+
+func gitResultOutput(result CommandResult, err error) (string, error) {
 	if err != nil {
 		return "", err
 	}
@@ -271,9 +274,45 @@ func gitRawOutput(ctx context.Context, runGit Runner, dir string, args ...string
 	return result.Stdout, nil
 }
 
+func stagedSnapshotDiff(ctx context.Context, runGit EnvRunner, root string) (string, string, error) {
+	tempDir, err := os.MkdirTemp("", "zero-git-index-")
+	if err != nil {
+		return "", "", fmt.Errorf("prepare preview index: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	env := []string{"GIT_INDEX_FILE=" + filepath.Join(tempDir, "index")}
+	if _, err := gitRawOutputEnv(ctx, runGit, root, env, "rev-parse", "--verify", "HEAD"); err != nil {
+		if _, emptyErr := gitRawOutputEnv(ctx, runGit, root, env, "read-tree", "--empty"); emptyErr != nil {
+			return "", "", fmt.Errorf("prepare empty preview index: %w", emptyErr)
+		}
+	} else if _, err := gitRawOutputEnv(ctx, runGit, root, env, "read-tree", "HEAD"); err != nil {
+		return "", "", fmt.Errorf("prepare preview index from HEAD: %w", err)
+	}
+	if _, err := gitRawOutputEnv(ctx, runGit, root, env, "add", "-A"); err != nil {
+		return "", "", fmt.Errorf("stage preview index: %w", err)
+	}
+	diffStat, err := gitRawOutputEnv(ctx, runGit, root, env, "diff", "--cached", "--stat", "--")
+	if err != nil {
+		return "", "", fmt.Errorf("inspect git diff stat: %w", err)
+	}
+	diff, err := gitRawOutputEnv(ctx, runGit, root, env, "diff", "--cached", "--")
+	if err != nil {
+		return "", "", fmt.Errorf("inspect git diff: %w", err)
+	}
+	return diffStat, diff, nil
+}
+
 func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResult, error) {
+	return defaultRunGitEnv(ctx, dir, nil, args...)
+}
+
+func defaultRunGitEnv(ctx context.Context, dir string, env []string, args ...string) (CommandResult, error) {
 	command := exec.CommandContext(ctx, "git", args...)
 	command.Dir = dir
+	if len(env) > 0 {
+		command.Env = append(os.Environ(), env...)
+	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	command.Stdout = &stdout
@@ -290,20 +329,38 @@ func defaultRunGit(ctx context.Context, dir string, args ...string) (CommandResu
 	return CommandResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: exitCode}, err
 }
 
+func resolveRunners(runGit Runner, runGitEnv EnvRunner) (Runner, EnvRunner) {
+	if runGit == nil {
+		runGit = defaultRunGit
+		if runGitEnv == nil {
+			runGitEnv = defaultRunGitEnv
+		}
+	} else if runGitEnv == nil {
+		runGitEnv = func(ctx context.Context, dir string, _ []string, args ...string) (CommandResult, error) {
+			return runGit(ctx, dir, args...)
+		}
+	}
+	return runGit, runGitEnv
+}
+
 func truncateString(value string, maxBytes int) (string, bool) {
 	if maxBytes <= 0 || len(value) <= maxBytes {
 		return value, false
 	}
 	suffix := "\n[truncated]"
 	if maxBytes <= len(suffix) {
-		return suffix, true
+		return suffix[:maxBytes], true
 	}
 	head := value[:maxBytes-len(suffix)]
 	if strings.Contains(value, redaction.RedactedSecret) && !strings.Contains(head, redaction.RedactedSecret) {
 		marker := "\n" + redaction.RedactedSecret
 		budget := maxBytes - len(suffix) - len(marker)
 		if budget <= 0 {
-			return redaction.RedactedSecret + suffix, true
+			allowed := maxBytes - len(suffix)
+			if allowed > len(redaction.RedactedSecret) {
+				allowed = len(redaction.RedactedSecret)
+			}
+			return redaction.RedactedSecret[:allowed] + suffix, true
 		}
 		return value[:budget] + marker + suffix, true
 	}

--- a/internal/zerogit/zerogit.go
+++ b/internal/zerogit/zerogit.go
@@ -279,7 +279,7 @@ func stagedSnapshotDiff(ctx context.Context, runGit EnvRunner, root string) (str
 	if err != nil {
 		return "", "", fmt.Errorf("prepare preview index: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	env := []string{"GIT_INDEX_FILE=" + filepath.Join(tempDir, "index")}
 	if _, err := gitRawOutputEnv(ctx, runGit, root, env, "rev-parse", "--verify", "HEAD"); err != nil {

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -1,0 +1,163 @@
+package zerogit
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestInspectSummarizesChangesAndRedactsDiff(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},
+		{Stdout: "feature/m5\n"},
+		{Stdout: "abc1234\n"},
+		{Stdout: " M internal/verify/verify.go\n?? internal/zerogit/zerogit.go\n"},
+		{Stdout: " internal/verify/verify.go | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n"},
+		{Stdout: "diff --git a/internal/verify/verify.go b/internal/verify/verify.go\n+token sk-proj-abcdefghijklmnopqrstuvwxyz\n"},
+	}}
+
+	summary, err := Inspect(context.Background(), InspectOptions{
+		Cwd:          root,
+		MaxDiffBytes: 80,
+		RunGit:       runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+
+	if summary.Root != root || summary.Branch != "feature/m5" || summary.Commit != "abc1234" {
+		t.Fatalf("unexpected git metadata: %#v", summary)
+	}
+	if summary.Clean {
+		t.Fatalf("Clean = true, want false")
+	}
+	if len(summary.Files) != 2 {
+		t.Fatalf("expected two changed files, got %#v", summary.Files)
+	}
+	if summary.Files[0].Path != "internal/verify/verify.go" || summary.Files[0].Status != "modified" || !summary.Files[0].Unstaged {
+		t.Fatalf("unexpected modified file summary: %#v", summary.Files[0])
+	}
+	if summary.Files[1].Path != "internal/zerogit/zerogit.go" || summary.Files[1].Status != "untracked" || !summary.Files[1].Untracked {
+		t.Fatalf("unexpected untracked file summary: %#v", summary.Files[1])
+	}
+	if strings.Contains(summary.Diff, "sk-proj-abcdefghijklmnopqrstuvwxyz") || !strings.Contains(summary.Diff, "[REDACTED]") {
+		t.Fatalf("expected redacted diff, got %q", summary.Diff)
+	}
+	if !summary.Truncated {
+		t.Fatalf("expected diff to be marked truncated")
+	}
+	if got := runner.commandLine(3); got != "git status --short --untracked-files=all" {
+		t.Fatalf("status command = %q", got)
+	}
+}
+
+func TestCommitStagesAllChangesAndUsesGeneratedMessage(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},
+		{Stdout: "main\n"},
+		{Stdout: "abc1234\n"},
+		{Stdout: " M internal/verify/verify.go\n?? internal/zerogit/zerogit.go\n"},
+		{Stdout: " 2 files changed, 10 insertions(+)\n"},
+		{Stdout: "diff --git a/internal/verify/verify.go b/internal/verify/verify.go\n"},
+		{},
+		{Stdout: "[main def5678] Update 2 files\n"},
+		{Stdout: "def5678\n"},
+	}}
+
+	result, err := Commit(context.Background(), CommitOptions{
+		Cwd:    root,
+		RunGit: runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Commit returned error: %v", err)
+	}
+
+	if !result.Committed || result.CommitHash != "def5678" {
+		t.Fatalf("unexpected commit result: %#v", result)
+	}
+	if result.Message == "" || len(result.Message) > 72 || !strings.Contains(result.Message, "2 files") {
+		t.Fatalf("unexpected generated commit message: %q", result.Message)
+	}
+	if got := runner.commandLine(6); got != "git add -A" {
+		t.Fatalf("stage command = %q", got)
+	}
+	if got := runner.commandLine(7); !strings.HasPrefix(got, "git commit -m ") {
+		t.Fatalf("commit command = %q", got)
+	}
+}
+
+func TestCommitDryRunDoesNotMutateRepository(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},
+		{Stdout: "main\n"},
+		{Stdout: "abc1234\n"},
+		{Stdout: " M README.md\n"},
+		{Stdout: " README.md | 1 +\n"},
+		{Stdout: "diff --git a/README.md b/README.md\n"},
+	}}
+
+	result, err := Commit(context.Background(), CommitOptions{
+		Cwd:     root,
+		Message: "Update README",
+		DryRun:  true,
+		RunGit:  runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Commit dry-run returned error: %v", err)
+	}
+
+	if result.Committed || !result.DryRun || result.Message != "Update README" {
+		t.Fatalf("unexpected dry-run result: %#v", result)
+	}
+	if len(runner.calls) != 6 {
+		t.Fatalf("dry-run should only inspect changes, got calls %#v", runner.calls)
+	}
+}
+
+func TestCommitRejectsCleanTreeAndInvalidMessage(t *testing.T) {
+	root := t.TempDir()
+	cleanRunner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},
+		{Stdout: "main\n"},
+		{Stdout: "abc1234\n"},
+		{Stdout: ""},
+		{Stdout: ""},
+		{Stdout: ""},
+	}}
+	if _, err := Commit(context.Background(), CommitOptions{Cwd: root, Message: "Update", RunGit: cleanRunner.Run}); err == nil || !strings.Contains(err.Error(), "no changes") {
+		t.Fatalf("expected clean tree error, got %v", err)
+	}
+	if err := ValidateMessage("   "); err == nil || !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected message validation error, got %v", err)
+	}
+}
+
+type fakeRunner struct {
+	calls   []gitCall
+	results []CommandResult
+}
+
+func (runner *fakeRunner) Run(ctx context.Context, dir string, args ...string) (CommandResult, error) {
+	runner.calls = append(runner.calls, gitCall{dir: dir, args: append([]string{}, args...)})
+	if len(runner.results) == 0 {
+		return CommandResult{}, nil
+	}
+	result := runner.results[0]
+	runner.results = runner.results[1:]
+	return result, nil
+}
+
+func (runner *fakeRunner) commandLine(index int) string {
+	if index >= len(runner.calls) {
+		return ""
+	}
+	return "git " + strings.Join(runner.calls[index].args, " ")
+}
+
+type gitCall struct {
+	dir  string
+	args []string
+}

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -2,8 +2,13 @@ package zerogit
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/redaction"
 )
 
 func TestInspectSummarizesChangesAndRedactsDiff(t *testing.T) {
@@ -13,6 +18,9 @@ func TestInspectSummarizesChangesAndRedactsDiff(t *testing.T) {
 		{Stdout: "feature/m5\n"},
 		{Stdout: "abc1234\n"},
 		{Stdout: " M internal/verify/verify.go\n?? internal/zerogit/zerogit.go\n"},
+		{Stdout: "abc1234\n"},
+		{},
+		{},
 		{Stdout: " internal/verify/verify.go | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n"},
 		{Stdout: "diff --git a/internal/verify/verify.go b/internal/verify/verify.go\n+token sk-proj-abcdefghijklmnopqrstuvwxyz\n"},
 	}}
@@ -50,6 +58,12 @@ func TestInspectSummarizesChangesAndRedactsDiff(t *testing.T) {
 	if got := runner.commandLine(3); got != "git status --short --untracked-files=all" {
 		t.Fatalf("status command = %q", got)
 	}
+	if got := runner.commandLine(6); got != "git add -A" {
+		t.Fatalf("preview stage command = %q", got)
+	}
+	if got := runner.commandLine(7); got != "git diff --cached --stat --" {
+		t.Fatalf("preview diff stat command = %q", got)
+	}
 }
 
 func TestCommitStagesAllChangesAndUsesGeneratedMessage(t *testing.T) {
@@ -59,6 +73,9 @@ func TestCommitStagesAllChangesAndUsesGeneratedMessage(t *testing.T) {
 		{Stdout: "main\n"},
 		{Stdout: "abc1234\n"},
 		{Stdout: " M internal/verify/verify.go\n?? internal/zerogit/zerogit.go\n"},
+		{Stdout: "abc1234\n"},
+		{},
+		{},
 		{Stdout: " 2 files changed, 10 insertions(+)\n"},
 		{Stdout: "diff --git a/internal/verify/verify.go b/internal/verify/verify.go\n"},
 		{},
@@ -80,10 +97,10 @@ func TestCommitStagesAllChangesAndUsesGeneratedMessage(t *testing.T) {
 	if result.Message == "" || len(result.Message) > 72 || !strings.Contains(result.Message, "2 files") {
 		t.Fatalf("unexpected generated commit message: %q", result.Message)
 	}
-	if got := runner.commandLine(6); got != "git add -A" {
+	if got := runner.commandLine(9); got != "git add -A" {
 		t.Fatalf("stage command = %q", got)
 	}
-	if got := runner.commandLine(7); !strings.HasPrefix(got, "git commit -m ") {
+	if got := runner.commandLine(10); !strings.HasPrefix(got, "git commit -m ") {
 		t.Fatalf("commit command = %q", got)
 	}
 }
@@ -95,6 +112,9 @@ func TestCommitDryRunDoesNotMutateRepository(t *testing.T) {
 		{Stdout: "main\n"},
 		{Stdout: "abc1234\n"},
 		{Stdout: " M README.md\n"},
+		{Stdout: "abc1234\n"},
+		{},
+		{},
 		{Stdout: " README.md | 1 +\n"},
 		{Stdout: "diff --git a/README.md b/README.md\n"},
 	}}
@@ -112,7 +132,7 @@ func TestCommitDryRunDoesNotMutateRepository(t *testing.T) {
 	if result.Committed || !result.DryRun || result.Message != "Update README" {
 		t.Fatalf("unexpected dry-run result: %#v", result)
 	}
-	if len(runner.calls) != 6 {
+	if len(runner.calls) != 9 {
 		t.Fatalf("dry-run should only inspect changes, got calls %#v", runner.calls)
 	}
 }
@@ -124,6 +144,9 @@ func TestCommitRejectsCleanTreeAndInvalidMessage(t *testing.T) {
 		{Stdout: "main\n"},
 		{Stdout: "abc1234\n"},
 		{Stdout: ""},
+		{Stdout: "abc1234\n"},
+		{},
+		{},
 		{Stdout: ""},
 		{Stdout: ""},
 	}}
@@ -132,6 +155,68 @@ func TestCommitRejectsCleanTreeAndInvalidMessage(t *testing.T) {
 	}
 	if err := ValidateMessage("   "); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Fatalf("expected message validation error, got %v", err)
+	}
+}
+
+func TestInspectPreviewIncludesUntrackedOnlyChanges(t *testing.T) {
+	root := initGitRepo(t, true)
+	writeTestFile(t, filepath.Join(root, "notes.md"), "hello zero\n")
+
+	summary, err := Inspect(context.Background(), InspectOptions{Cwd: root})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+
+	if summary.Clean {
+		t.Fatalf("Clean = true, want false")
+	}
+	if len(summary.Files) != 1 || summary.Files[0].Path != "notes.md" || !summary.Files[0].Untracked {
+		t.Fatalf("unexpected untracked summary: %#v", summary.Files)
+	}
+	if !strings.Contains(summary.DiffStat, "notes.md") {
+		t.Fatalf("diff stat does not include untracked file: %q", summary.DiffStat)
+	}
+	if !strings.Contains(summary.Diff, "diff --git a/notes.md b/notes.md") || !strings.Contains(summary.Diff, "+hello zero") {
+		t.Fatalf("diff does not include untracked file content: %q", summary.Diff)
+	}
+	if staged := runGitCommand(t, root, "diff", "--cached", "--name-only"); strings.TrimSpace(staged) != "" {
+		t.Fatalf("Inspect mutated the real index, staged files: %q", staged)
+	}
+}
+
+func TestInspectPreviewWorksWithUnbornHead(t *testing.T) {
+	root := initGitRepo(t, false)
+	writeTestFile(t, filepath.Join(root, "README.md"), "new repository\n")
+
+	summary, err := Inspect(context.Background(), InspectOptions{Cwd: root})
+	if err != nil {
+		t.Fatalf("Inspect returned error for unborn HEAD: %v", err)
+	}
+
+	if summary.Clean {
+		t.Fatalf("Clean = true, want false")
+	}
+	if len(summary.Files) != 1 || summary.Files[0].Path != "README.md" || !summary.Files[0].Untracked {
+		t.Fatalf("unexpected unborn HEAD summary: %#v", summary.Files)
+	}
+	if !strings.Contains(summary.DiffStat, "README.md") || !strings.Contains(summary.Diff, "+new repository") {
+		t.Fatalf("unborn HEAD preview did not include README: stat=%q diff=%q", summary.DiffStat, summary.Diff)
+	}
+	if staged := runGitCommand(t, root, "diff", "--cached", "--name-only"); strings.TrimSpace(staged) != "" {
+		t.Fatalf("Inspect mutated the real unborn index, staged files: %q", staged)
+	}
+}
+
+func TestTruncateStringHonorsMaxBytesWithRedactionMarker(t *testing.T) {
+	value := strings.Repeat("a", 32) + redaction.RedactedSecret + strings.Repeat("b", 32)
+	for maxBytes := 1; maxBytes < len(redaction.RedactedSecret)+len("\n[truncated]"); maxBytes++ {
+		truncated, ok := truncateString(value, maxBytes)
+		if !ok {
+			t.Fatalf("truncateString truncated = false for maxBytes=%d", maxBytes)
+		}
+		if len(truncated) > maxBytes {
+			t.Fatalf("truncateString returned %d bytes for maxBytes=%d: %q", len(truncated), maxBytes, truncated)
+		}
 	}
 }
 
@@ -160,4 +245,37 @@ func (runner *fakeRunner) commandLine(index int) string {
 type gitCall struct {
 	dir  string
 	args []string
+}
+
+func initGitRepo(t *testing.T, withCommit bool) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	root := t.TempDir()
+	runGitCommand(t, root, "init")
+	if withCommit {
+		writeTestFile(t, filepath.Join(root, "README.md"), "initial\n")
+		runGitCommand(t, root, "add", "README.md")
+		runGitCommand(t, root, "-c", "user.name=Zero", "-c", "user.email=zero@example.invalid", "commit", "-m", "Initial commit")
+	}
+	return root
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+	return string(output)
+}
+
+func writeTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -264,7 +264,13 @@ func initGitRepo(t *testing.T, withCommit bool) string {
 
 func runGitCommand(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	command := exec.Command("git", args...)
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		defer cancel()
+	}
+	command := exec.CommandContext(ctx, "git", args...)
 	command.Dir = dir
 	output, err := command.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add a Go-native `internal/zerogit` backend for local git change inspection, redacted diff summaries, generated commit messages, dry-run commit previews, and real `git add -A` / commit execution.
- Extend verification reports with structured failure summaries and a bounded self-verification loop contract for retry-aware automation.
- Expose the backend through `zero changes inspect`, `zero changes commit`, and `zero verify --attempts` with JSON/text output and CLI regression coverage.

## Validation
- `go test ./internal/zerogit ./internal/verify ./internal/cli`
- `go test ./...`
- `go test -count=1 ./internal/zerogit ./internal/verify ./internal/cli`
- `go test -count=1 -p 1 ./...`
- `go build ./cmd/zero`
- `bun run typecheck`
- `bun test ./tests --timeout 15000` - 291 pass / 0 fail
- `bun run build`
- `bun run smoke:build`
- `bun run smoke:go`
- `/tmp/zero-m5 changes inspect --json --diff-bytes 600`
- `/tmp/zero-m5 changes commit --dry-run --message "Update M5 git backend"`
- `/tmp/zero-m5 verify --attempts 2 --only go.test --timeout-ms 600000 --json`
- `git diff --check origin/main..HEAD`

Reviewers: @Vasanthdev2004 @anandh8x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added change commands to inspect repo status/preview diffs and to commit changes (supports --message, --dry-run, --diff-bytes, --cwd); commit message generation/validation and commit-result reporting included
  * Verify command supports bounded retries via --attempts and emits loop reports (JSON or formatted)
  * Output summarization, redaction and diff truncation applied to verify and change outputs

* **Tests**
  * Expanded tests covering verify retries, output summarization/truncation/redaction, change inspect/commit, dry-run semantics, and repo-preview behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->