### PR TITLE
feat: add M5 test runner backend

### DIFF
--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/testrunner"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zerogit"
@@ -167,6 +168,13 @@ func TestRunVerifyTextAndJSON(t *testing.T) {
 			Status:   verify.StatusPass,
 			ExitCode: 0,
 			Stdout:   "ok",
+			TestSummary: &testrunner.Summary{
+				Framework: testrunner.FrameworkGo,
+				Total:     2,
+				Passed:    1,
+				Failed:    1,
+				Failures:  []testrunner.Failure{{Name: "TestBroken"}},
+			},
 		}},
 	}
 
@@ -214,7 +222,7 @@ func TestRunVerifyTextAndJSON(t *testing.T) {
 				if decoded.Root != cwd {
 					t.Fatalf("decoded verify root = %q, want %q", decoded.Root, cwd)
 				}
-			} else if !strings.Contains(stdout.String(), "Zero verification") || !strings.Contains(stdout.String(), "go.test") || !strings.Contains(stdout.String(), cwd) {
+			} else if !strings.Contains(stdout.String(), "Zero verification") || !strings.Contains(stdout.String(), "go.test") || !strings.Contains(stdout.String(), cwd) || !strings.Contains(stdout.String(), "tests: 2 total, 1 passed, 1 failed") {
 				t.Fatalf("unexpected verify text output: %q", stdout.String())
 			}
 		})
@@ -234,6 +242,23 @@ func TestRunVerifyRedactsWorkspacePathsInOutput(t *testing.T) {
 		EndedAt:   "2026-06-05T11:05:01Z",
 		OK:        true,
 		Summary:   verify.Summary{},
+		Results: []verify.Result{{
+			ID:            "go.test",
+			Name:          "Go tests",
+			Command:       []string{"go", "test", "./..."},
+			Status:        verify.StatusFail,
+			OutputSummary: &verify.OutputSummary{Lines: []string{"failure at " + secret}},
+			TestSummary: &testrunner.Summary{
+				Framework: testrunner.FrameworkGo,
+				Total:     1,
+				Failed:    1,
+				Failures: []testrunner.Failure{{
+					Name:    secret,
+					File:    filepath.Join(secret, "secret_test.go:12"),
+					Message: "token " + secret,
+				}},
+			},
+		}},
 	}
 
 	for _, args := range [][]string{

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/testrunner"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zerogit"
@@ -433,10 +434,29 @@ func redactWorktreeResult(result worktrees.Result) worktrees.Result {
 
 func redactVerifyReport(report verify.Report) verify.Report {
 	report.Root = redactCLIString(report.Root)
+	report.Results = append([]verify.Result{}, report.Results...)
 	for index := range report.Results {
 		report.Results[index].Stdout = redactCLIString(report.Results[index].Stdout)
 		report.Results[index].Stderr = redactCLIString(report.Results[index].Stderr)
 		report.Results[index].Error = redactCLIString(report.Results[index].Error)
+		if report.Results[index].OutputSummary != nil {
+			summary := *report.Results[index].OutputSummary
+			summary.Lines = append([]string{}, summary.Lines...)
+			for lineIndex := range summary.Lines {
+				summary.Lines[lineIndex] = redactCLIString(summary.Lines[lineIndex])
+			}
+			report.Results[index].OutputSummary = &summary
+		}
+		if report.Results[index].TestSummary != nil {
+			summary := *report.Results[index].TestSummary
+			summary.Failures = append([]testrunner.Failure{}, summary.Failures...)
+			for failureIndex := range summary.Failures {
+				summary.Failures[failureIndex].Name = redactCLIString(summary.Failures[failureIndex].Name)
+				summary.Failures[failureIndex].File = redactCLIString(summary.Failures[failureIndex].File)
+				summary.Failures[failureIndex].Message = redactCLIString(summary.Failures[failureIndex].Message)
+			}
+			report.Results[index].TestSummary = &summary
+		}
 	}
 	return report
 }
@@ -507,11 +527,32 @@ func formatVerifyReport(report verify.Report) string {
 	}
 	for _, result := range report.Results {
 		lines = append(lines, fmt.Sprintf("  [%s] %s - %s", result.Status, result.ID, strings.Join(result.Command, " ")))
+		if result.TestSummary != nil {
+			lines = append(lines, formatVerifyTestSummary(result.TestSummary))
+			for _, failure := range result.TestSummary.Failures {
+				if failure.Name == "" {
+					continue
+				}
+				detail := failure.Name
+				if failure.File != "" {
+					detail += " at " + failure.File
+				}
+				lines = append(lines, "    failure: "+detail)
+			}
+		}
 		if result.Error != "" {
 			lines = append(lines, "    error: "+result.Error)
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+func formatVerifyTestSummary(summary *testrunner.Summary) string {
+	line := fmt.Sprintf("    tests: %d total, %d passed, %d failed", summary.Total, summary.Passed, summary.Failed)
+	if summary.Skipped > 0 {
+		line += fmt.Sprintf(", %d skipped", summary.Skipped)
+	}
+	return line
 }
 
 func formatVerifyLoopReport(report verify.LoopReport) string {

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -202,7 +202,7 @@ func detectPackageManager(root string, declared string) packageManager {
 	case fileExists(filepath.Join(root, "package-lock.json")) || declaredName == "npm":
 		return packageManager{Name: "npm", IDPrefix: "npm", Framework: FrameworkNode}
 	default:
-		return packageManager{Name: "bun", IDPrefix: "bun", Framework: FrameworkBun}
+		return packageManager{Name: "npm", IDPrefix: "npm", Framework: FrameworkNode}
 	}
 }
 
@@ -226,20 +226,19 @@ func parseGoSummary(output string) *Summary {
 	lines := splitLines(output)
 	failureByName := map[string]int{}
 	packagePasses := 0
-	sawDetailedTest := false
+	sawVerbosePerTestOutput := false
 	for index, line := range lines {
 		switch {
 		case goRunPattern.MatchString(line):
-			sawDetailedTest = true
+			sawVerbosePerTestOutput = true
 			summary.Total++
 		case goPassPattern.MatchString(line):
-			sawDetailedTest = true
+			sawVerbosePerTestOutput = true
 			summary.Passed++
 		case goSkipPattern.MatchString(line):
-			sawDetailedTest = true
+			sawVerbosePerTestOutput = true
 			summary.Skipped++
 		case goFailPattern.MatchString(line):
-			sawDetailedTest = true
 			summary.Failed++
 			match := goFailPattern.FindStringSubmatch(line)
 			name := safeSubmatch(match, 1)
@@ -255,7 +254,7 @@ func parseGoSummary(output string) *Summary {
 			packagePasses++
 		}
 	}
-	if !sawDetailedTest {
+	if !sawVerbosePerTestOutput {
 		summary.Passed += packagePasses
 	}
 	for index, line := range lines {

--- a/internal/testrunner/testrunner.go
+++ b/internal/testrunner/testrunner.go
@@ -1,0 +1,471 @@
+package testrunner
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Kind describes the broad purpose of a detected verification check.
+type Kind string
+
+const (
+	KindTest      Kind = "test"
+	KindTypecheck Kind = "typecheck"
+	KindBuild     Kind = "build"
+	KindLint      Kind = "lint"
+)
+
+// Framework identifies the runner family used to execute or parse a check.
+type Framework string
+
+const (
+	FrameworkGo     Framework = "go"
+	FrameworkBun    Framework = "bun"
+	FrameworkNode   Framework = "node"
+	FrameworkPytest Framework = "pytest"
+	FrameworkCargo  Framework = "cargo"
+)
+
+// Check is a runnable workspace verification command discovered from project files.
+type Check struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Command   []string  `json:"command"`
+	Kind      Kind      `json:"kind"`
+	Framework Framework `json:"framework"`
+}
+
+// Summary is the structured test result parsed from runner output.
+type Summary struct {
+	Framework Framework `json:"framework"`
+	Total     int       `json:"total,omitempty"`
+	Passed    int       `json:"passed,omitempty"`
+	Failed    int       `json:"failed,omitempty"`
+	Skipped   int       `json:"skipped,omitempty"`
+	Failures  []Failure `json:"failures,omitempty"`
+}
+
+// Failure captures the most useful location and message for a failing test.
+type Failure struct {
+	Name    string `json:"name"`
+	File    string `json:"file,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type packageJSON struct {
+	PackageManager string            `json:"packageManager"`
+	Scripts        map[string]string `json:"scripts"`
+}
+
+type packageManager struct {
+	Name      string
+	IDPrefix  string
+	Framework Framework
+}
+
+var (
+	goRunPattern       = regexp.MustCompile(`^=== RUN\s+(.+)$`)
+	goPassPattern      = regexp.MustCompile(`^--- PASS:\s+([^\s(]+)`)
+	goFailPattern      = regexp.MustCompile(`^--- FAIL:\s+([^\s(]+)`)
+	goSkipPattern      = regexp.MustCompile(`^--- SKIP:\s+([^\s(]+)`)
+	goFailureLocation  = regexp.MustCompile(`^\s*([^:\s]+\.go:\d+):\s*(.*)$`)
+	goPackageOK        = regexp.MustCompile(`^ok\s+\S+`)
+	bunPassPattern     = regexp.MustCompile(`^\(pass\)\s+(.+?)(?:\s+\[.*)?$`)
+	bunFailPattern     = regexp.MustCompile(`^\(fail\)\s+(.+?)(?:\s+\[.*)?$`)
+	bunSkipPattern     = regexp.MustCompile(`^\(skip\)\s+(.+?)(?:\s+\[.*)?$`)
+	nodePassPattern    = regexp.MustCompile(`^ok\s+\d+(?:\s+-\s+(.+))?$`)
+	nodeFailPattern    = regexp.MustCompile(`^not ok\s+\d+(?:\s+-\s+(.+))?$`)
+	pytestFailureLine  = regexp.MustCompile(`^FAILED\s+(\S+)(?:\s+-\s*(.*))?$`)
+	cargoTestLine      = regexp.MustCompile(`^test\s+(.+)\s+\.\.\.\s+(ok|FAILED|ignored)$`)
+	summaryCountPrefix = regexp.MustCompile(`(?i)(\d+)\s+(pass|passes|passed|fail|fails|failed|skip|skips|skipped|ignored)\b`)
+)
+
+// Detect discovers common test and verification commands in root.
+func Detect(root string) ([]Check, error) {
+	resolvedRoot, err := resolveRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	checks := []Check{}
+	if fileExists(filepath.Join(resolvedRoot, "go.mod")) {
+		checks = append(checks, Check{
+			ID:        "go.test",
+			Name:      "Go tests",
+			Command:   []string{"go", "test", "./..."},
+			Kind:      KindTest,
+			Framework: FrameworkGo,
+		})
+	}
+	checks = append(checks, detectPackageChecks(resolvedRoot)...)
+	if detectsPytest(resolvedRoot) {
+		checks = append(checks, Check{
+			ID:        "python.pytest",
+			Name:      "Python pytest",
+			Command:   []string{"python", "-m", "pytest"},
+			Kind:      KindTest,
+			Framework: FrameworkPytest,
+		})
+	}
+	if fileExists(filepath.Join(resolvedRoot, "Cargo.toml")) {
+		checks = append(checks, Check{
+			ID:        "cargo.test",
+			Name:      "Cargo tests",
+			Command:   []string{"cargo", "test"},
+			Kind:      KindTest,
+			Framework: FrameworkCargo,
+		})
+	}
+	return checks, nil
+}
+
+// ParseSummary extracts structured test counts and failures from runner output.
+func ParseSummary(check Check, stdout string, stderr string) *Summary {
+	framework := check.Framework
+	if framework == "" {
+		framework = inferFramework(check.Command)
+	}
+	combined := strings.TrimSpace(strings.Join([]string{stdout, stderr}, "\n"))
+	if combined == "" {
+		return nil
+	}
+	switch framework {
+	case FrameworkGo:
+		return parseGoSummary(combined)
+	case FrameworkBun:
+		return parseBunSummary(combined)
+	case FrameworkPytest:
+		return parsePytestSummary(combined)
+	case FrameworkCargo:
+		return parseCargoSummary(combined)
+	default:
+		return parseNodeSummary(combined)
+	}
+}
+
+func detectPackageChecks(root string) []Check {
+	pkg, ok := readPackageJSON(filepath.Join(root, "package.json"))
+	if !ok {
+		return nil
+	}
+	manager := detectPackageManager(root, pkg.PackageManager)
+	checks := []Check{}
+	for _, candidate := range []struct {
+		script string
+		kind   Kind
+		label  string
+	}{
+		{script: "typecheck", kind: KindTypecheck, label: "typecheck"},
+		{script: "test", kind: KindTest, label: "tests"},
+		{script: "build", kind: KindBuild, label: "build"},
+		{script: "lint", kind: KindLint, label: "lint"},
+	} {
+		if strings.TrimSpace(pkg.Scripts[candidate.script]) == "" {
+			continue
+		}
+		checks = append(checks, Check{
+			ID:        manager.IDPrefix + "." + candidate.script,
+			Name:      titleWord(manager.Name) + " " + candidate.label,
+			Command:   []string{manager.Name, "run", candidate.script},
+			Kind:      candidate.kind,
+			Framework: manager.Framework,
+		})
+	}
+	return checks
+}
+
+func readPackageJSON(path string) (packageJSON, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return packageJSON{}, false
+	}
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return packageJSON{}, false
+	}
+	return pkg, true
+}
+
+func detectPackageManager(root string, declared string) packageManager {
+	declaredName := strings.ToLower(strings.TrimSpace(strings.Split(declared, "@")[0]))
+	switch {
+	case fileExists(filepath.Join(root, "bun.lock")) || fileExists(filepath.Join(root, "bun.lockb")) || declaredName == "bun":
+		return packageManager{Name: "bun", IDPrefix: "bun", Framework: FrameworkBun}
+	case fileExists(filepath.Join(root, "pnpm-lock.yaml")) || declaredName == "pnpm":
+		return packageManager{Name: "pnpm", IDPrefix: "pnpm", Framework: FrameworkNode}
+	case fileExists(filepath.Join(root, "yarn.lock")) || declaredName == "yarn":
+		return packageManager{Name: "yarn", IDPrefix: "yarn", Framework: FrameworkNode}
+	case fileExists(filepath.Join(root, "package-lock.json")) || declaredName == "npm":
+		return packageManager{Name: "npm", IDPrefix: "npm", Framework: FrameworkNode}
+	default:
+		return packageManager{Name: "bun", IDPrefix: "bun", Framework: FrameworkBun}
+	}
+}
+
+func detectsPytest(root string) bool {
+	for _, name := range []string{"pytest.ini", "tox.ini"} {
+		if fileExists(filepath.Join(root, name)) {
+			return true
+		}
+	}
+	if fileContains(filepath.Join(root, "pyproject.toml"), "pytest") {
+		return true
+	}
+	if fileContains(filepath.Join(root, "setup.cfg"), "pytest") {
+		return true
+	}
+	return false
+}
+
+func parseGoSummary(output string) *Summary {
+	summary := &Summary{Framework: FrameworkGo}
+	lines := splitLines(output)
+	failureByName := map[string]int{}
+	packagePasses := 0
+	sawDetailedTest := false
+	for index, line := range lines {
+		switch {
+		case goRunPattern.MatchString(line):
+			sawDetailedTest = true
+			summary.Total++
+		case goPassPattern.MatchString(line):
+			sawDetailedTest = true
+			summary.Passed++
+		case goSkipPattern.MatchString(line):
+			sawDetailedTest = true
+			summary.Skipped++
+		case goFailPattern.MatchString(line):
+			sawDetailedTest = true
+			summary.Failed++
+			match := goFailPattern.FindStringSubmatch(line)
+			name := safeSubmatch(match, 1)
+			failure := Failure{Name: name}
+			if index+1 < len(lines) {
+				if location := goFailureLocation.FindStringSubmatch(lines[index+1]); location != nil {
+					failure.File = safeSubmatch(location, 1)
+					failure.Message = safeSubmatch(location, 2)
+				}
+			}
+			failureByName[name] = appendFailure(&summary.Failures, failure)
+		case goPackageOK.MatchString(line):
+			packagePasses++
+		}
+	}
+	if !sawDetailedTest {
+		summary.Passed += packagePasses
+	}
+	for index, line := range lines {
+		location := goFailureLocation.FindStringSubmatch(line)
+		if location == nil || index == 0 {
+			continue
+		}
+		previous := goFailPattern.FindStringSubmatch(lines[index-1])
+		if previous == nil {
+			continue
+		}
+		if failureIndex, ok := failureByName[safeSubmatch(previous, 1)]; ok {
+			summary.Failures[failureIndex].File = safeSubmatch(location, 1)
+			summary.Failures[failureIndex].Message = safeSubmatch(location, 2)
+		}
+	}
+	normalizeTotals(summary)
+	return nilIfEmpty(summary)
+}
+
+func parseBunSummary(output string) *Summary {
+	summary := &Summary{Framework: FrameworkBun}
+	for _, line := range splitLines(output) {
+		switch {
+		case bunPassPattern.MatchString(line):
+			summary.Passed++
+		case bunSkipPattern.MatchString(line):
+			summary.Skipped++
+		case bunFailPattern.MatchString(line):
+			summary.Failed++
+			match := bunFailPattern.FindStringSubmatch(line)
+			summary.Failures = append(summary.Failures, Failure{Name: safeSubmatch(match, 1)})
+		default:
+			mergeSummaryCounts(summary, line)
+		}
+	}
+	normalizeTotals(summary)
+	return nilIfEmpty(summary)
+}
+
+func parseNodeSummary(output string) *Summary {
+	summary := &Summary{Framework: FrameworkNode}
+	for _, line := range splitLines(output) {
+		switch {
+		case nodePassPattern.MatchString(line):
+			summary.Passed++
+		case nodeFailPattern.MatchString(line):
+			summary.Failed++
+			match := nodeFailPattern.FindStringSubmatch(line)
+			name := safeSubmatch(match, 1)
+			if name == "" {
+				name = "tap failure"
+			}
+			summary.Failures = append(summary.Failures, Failure{Name: name})
+		default:
+			mergeSummaryCounts(summary, line)
+		}
+	}
+	normalizeTotals(summary)
+	return nilIfEmpty(summary)
+}
+
+func parsePytestSummary(output string) *Summary {
+	summary := &Summary{Framework: FrameworkPytest}
+	for _, line := range splitLines(output) {
+		if match := pytestFailureLine.FindStringSubmatch(line); match != nil {
+			summary.Failures = append(summary.Failures, Failure{Name: safeSubmatch(match, 1), Message: safeSubmatch(match, 2)})
+		}
+		mergeSummaryCounts(summary, line)
+	}
+	if summary.Failed == 0 && len(summary.Failures) > 0 {
+		summary.Failed = len(summary.Failures)
+	}
+	normalizeTotals(summary)
+	return nilIfEmpty(summary)
+}
+
+func parseCargoSummary(output string) *Summary {
+	summary := &Summary{Framework: FrameworkCargo}
+	for _, line := range splitLines(output) {
+		if match := cargoTestLine.FindStringSubmatch(line); match != nil {
+			name := safeSubmatch(match, 1)
+			switch safeSubmatch(match, 2) {
+			case "ok":
+				summary.Passed++
+			case "FAILED":
+				summary.Failed++
+				summary.Failures = append(summary.Failures, Failure{Name: name})
+			case "ignored":
+				summary.Skipped++
+			}
+			continue
+		}
+		mergeSummaryCounts(summary, line)
+	}
+	normalizeTotals(summary)
+	return nilIfEmpty(summary)
+}
+
+func mergeSummaryCounts(summary *Summary, line string) {
+	for _, match := range summaryCountPrefix.FindAllStringSubmatch(line, -1) {
+		count, err := strconv.Atoi(safeSubmatch(match, 1))
+		if err != nil {
+			continue
+		}
+		switch strings.ToLower(safeSubmatch(match, 2)) {
+		case "pass", "passes", "passed":
+			summary.Passed = maxInt(summary.Passed, count)
+		case "fail", "fails", "failed":
+			summary.Failed = maxInt(summary.Failed, count)
+		case "skip", "skips", "skipped", "ignored":
+			summary.Skipped = maxInt(summary.Skipped, count)
+		}
+	}
+}
+
+func normalizeTotals(summary *Summary) {
+	if summary.Total == 0 {
+		summary.Total = summary.Passed + summary.Failed + summary.Skipped
+	}
+}
+
+func nilIfEmpty(summary *Summary) *Summary {
+	if summary.Total == 0 && summary.Passed == 0 && summary.Failed == 0 && summary.Skipped == 0 && len(summary.Failures) == 0 {
+		return nil
+	}
+	return summary
+}
+
+func appendFailure(failures *[]Failure, failure Failure) int {
+	*failures = append(*failures, failure)
+	return len(*failures) - 1
+}
+
+func inferFramework(command []string) Framework {
+	if len(command) == 0 {
+		return FrameworkNode
+	}
+	switch command[0] {
+	case "go":
+		return FrameworkGo
+	case "bun":
+		return FrameworkBun
+	case "python", "python3", "pytest":
+		return FrameworkPytest
+	case "cargo":
+		return FrameworkCargo
+	default:
+		return FrameworkNode
+	}
+}
+
+func splitLines(value string) []string {
+	raw := strings.Split(value, "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
+func safeSubmatch(match []string, index int) string {
+	if index >= len(match) {
+		return ""
+	}
+	return strings.TrimSpace(match[index])
+}
+
+func titleWord(value string) string {
+	if value == "" {
+		return ""
+	}
+	return strings.ToUpper(value[:1]) + value[1:]
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func fileContains(path string, needle string) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && strings.Contains(strings.ToLower(string(data)), strings.ToLower(needle))
+}
+
+func resolveRoot(root string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		var err error
+		root, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve test root: %w", err)
+		}
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve test root: %w", err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("test root must be an existing directory: %s", absolute)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func maxInt(left int, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}

--- a/internal/testrunner/testrunner_test.go
+++ b/internal/testrunner/testrunner_test.go
@@ -1,0 +1,225 @@
+package testrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectFindsWorkspaceChecksInStableOrder(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/app\n")
+	writeFile(t, filepath.Join(root, "bun.lock"), "")
+	writeFile(t, filepath.Join(root, "package.json"), `{
+		"scripts": {
+			"test": "bun test ./tests",
+			"typecheck": "tsc --noEmit",
+			"build": "bun run scripts/build.ts",
+			"lint": "eslint ."
+		}
+	}`)
+	writeFile(t, filepath.Join(root, "pyproject.toml"), "[tool.pytest.ini_options]\n")
+	writeFile(t, filepath.Join(root, "Cargo.toml"), "[package]\nname = \"sample\"\n")
+
+	checks, err := Detect(root)
+	if err != nil {
+		t.Fatalf("Detect returned error: %v", err)
+	}
+
+	if got, want := checkIDs(checks), []string{
+		"go.test",
+		"bun.typecheck",
+		"bun.test",
+		"bun.build",
+		"bun.lint",
+		"python.pytest",
+		"cargo.test",
+	}; !equalStrings(got, want) {
+		t.Fatalf("check ids = %#v, want %#v", got, want)
+	}
+	if got := checks[1].Command; !equalStrings(got, []string{"bun", "run", "typecheck"}) {
+		t.Fatalf("typecheck command = %#v, want bun run typecheck", got)
+	}
+	if checks[5].Framework != FrameworkPytest || checks[6].Framework != FrameworkCargo {
+		t.Fatalf("unexpected framework metadata: %#v", checks)
+	}
+}
+
+func TestDetectUsesPackageManagerLockfiles(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		lockfile    string
+		wantID      string
+		wantCommand []string
+	}{
+		{name: "npm", lockfile: "package-lock.json", wantID: "npm.test", wantCommand: []string{"npm", "run", "test"}},
+		{name: "pnpm", lockfile: "pnpm-lock.yaml", wantID: "pnpm.test", wantCommand: []string{"pnpm", "run", "test"}},
+		{name: "yarn", lockfile: "yarn.lock", wantID: "yarn.test", wantCommand: []string{"yarn", "run", "test"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, filepath.Join(root, test.lockfile), "")
+			writeFile(t, filepath.Join(root, "package.json"), `{"scripts":{"test":"test command"}}`)
+
+			checks, err := Detect(root)
+			if err != nil {
+				t.Fatalf("Detect returned error: %v", err)
+			}
+			if len(checks) != 1 {
+				t.Fatalf("checks = %#v, want one package test check", checks)
+			}
+			if checks[0].ID != test.wantID || !equalStrings(checks[0].Command, test.wantCommand) {
+				t.Fatalf("check = %#v, want id %q command %#v", checks[0], test.wantID, test.wantCommand)
+			}
+		})
+	}
+}
+
+func TestParseSummaryExtractsGoFailures(t *testing.T) {
+	check := Check{ID: "go.test", Framework: FrameworkGo}
+	output := `=== RUN   TestPass
+--- PASS: TestPass (0.00s)
+=== RUN   TestSecret
+--- FAIL: TestSecret (0.00s)
+    secret_test.go:12: expected [REDACTED] to stay hidden
+FAIL`
+
+	summary := ParseSummary(check, output, "")
+
+	if summary == nil {
+		t.Fatal("expected parsed summary")
+	}
+	if summary.Total != 2 || summary.Passed != 1 || summary.Failed != 1 {
+		t.Fatalf("unexpected counts: %#v", summary)
+	}
+	if len(summary.Failures) != 1 || summary.Failures[0].Name != "TestSecret" {
+		t.Fatalf("unexpected failures: %#v", summary.Failures)
+	}
+	if summary.Failures[0].File != "secret_test.go:12" || summary.Failures[0].Message == "" {
+		t.Fatalf("unexpected failure detail: %#v", summary.Failures[0])
+	}
+}
+
+func TestParseSummaryExtractsGoPackageStatus(t *testing.T) {
+	check := Check{ID: "go.test", Framework: FrameworkGo}
+	output := "?   \texample.com/app/cmd\t[no test files]\nok  \texample.com/app/internal/one\t(cached)\nok  \texample.com/app/internal/two\t0.12s\n"
+
+	summary := ParseSummary(check, output, "")
+
+	if summary == nil {
+		t.Fatal("expected parsed summary")
+	}
+	if summary.Total != 2 || summary.Passed != 2 || summary.Failed != 0 {
+		t.Fatalf("unexpected package summary: %#v", summary)
+	}
+}
+
+func TestParseSummaryDoesNotDoubleCountVerboseGoPackageStatus(t *testing.T) {
+	check := Check{ID: "go.test", Framework: FrameworkGo}
+	output := `=== RUN   TestOne
+--- PASS: TestOne (0.00s)
+=== RUN   TestTwo
+--- PASS: TestTwo (0.00s)
+ok  	example.com/app/internal/two	0.12s
+`
+
+	summary := ParseSummary(check, output, "")
+
+	if summary == nil {
+		t.Fatal("expected parsed summary")
+	}
+	if summary.Total != 2 || summary.Passed != 2 || summary.Failed != 0 {
+		t.Fatalf("unexpected verbose package summary: %#v", summary)
+	}
+}
+
+func TestParseSummaryExtractsCommonRunnerCounts(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		check     Check
+		output    string
+		wantTotal int
+		wantPass  int
+		wantFail  int
+		wantSkip  int
+		wantName  string
+	}{
+		{
+			name:      "bun",
+			check:     Check{ID: "bun.test", Framework: FrameworkBun},
+			output:    "(pass) package works\n(fail) cli rejects bad flags\n\n 1 pass\n 1 fail\n",
+			wantTotal: 2,
+			wantPass:  1,
+			wantFail:  1,
+			wantName:  "cli rejects bad flags",
+		},
+		{
+			name:      "node tap",
+			check:     Check{ID: "npm.test", Framework: FrameworkNode},
+			output:    "ok 1 - config loads\nnot ok 2 - session forks\n# pass 1\n# fail 1\n",
+			wantTotal: 2,
+			wantPass:  1,
+			wantFail:  1,
+			wantName:  "session forks",
+		},
+		{
+			name:      "pytest",
+			check:     Check{ID: "python.pytest", Framework: FrameworkPytest},
+			output:    "FAILED tests/test_cli.py::test_stream - AssertionError: boom\n1 failed, 2 passed, 1 skipped in 0.12s\n",
+			wantTotal: 4,
+			wantPass:  2,
+			wantFail:  1,
+			wantSkip:  1,
+			wantName:  "tests/test_cli.py::test_stream",
+		},
+		{
+			name:      "cargo",
+			check:     Check{ID: "cargo.test", Framework: FrameworkCargo},
+			output:    "test tests::runs_zero ... ok\ntest tests::rejects_bad_config ... FAILED\n\ntest result: FAILED. 1 passed; 1 failed; 0 ignored\n",
+			wantTotal: 2,
+			wantPass:  1,
+			wantFail:  1,
+			wantName:  "tests::rejects_bad_config",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			summary := ParseSummary(test.check, test.output, "")
+			if summary == nil {
+				t.Fatal("expected parsed summary")
+			}
+			if summary.Total != test.wantTotal || summary.Passed != test.wantPass || summary.Failed != test.wantFail || summary.Skipped != test.wantSkip {
+				t.Fatalf("summary = %#v, want total/pass/fail/skip %d/%d/%d/%d", summary, test.wantTotal, test.wantPass, test.wantFail, test.wantSkip)
+			}
+			if len(summary.Failures) != 1 || summary.Failures[0].Name != test.wantName {
+				t.Fatalf("failures = %#v, want %q", summary.Failures, test.wantName)
+			}
+		})
+	}
+}
+
+func checkIDs(checks []Check) []string {
+	ids := make([]string, 0, len(checks))
+	for _, check := range checks {
+		ids = append(ids, check.ID)
+	}
+	return ids
+}
+
+func equalStrings(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/testrunner/testrunner_test.go
+++ b/internal/testrunner/testrunner_test.go
@@ -75,6 +75,23 @@ func TestDetectUsesPackageManagerLockfiles(t *testing.T) {
 	}
 }
 
+func TestDetectDefaultsPlainNodeWorkspacesToNPM(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "package.json"), `{"scripts":{"test":"node --test"}}`)
+
+	checks, err := Detect(root)
+	if err != nil {
+		t.Fatalf("Detect returned error: %v", err)
+	}
+
+	if len(checks) != 1 {
+		t.Fatalf("checks = %#v, want one package test check", checks)
+	}
+	if checks[0].ID != "npm.test" || checks[0].Framework != FrameworkNode || !equalStrings(checks[0].Command, []string{"npm", "run", "test"}) {
+		t.Fatalf("plain node check = %#v, want npm.test with npm run test", checks[0])
+	}
+}
+
 func TestParseSummaryExtractsGoFailures(t *testing.T) {
 	check := Check{ID: "go.test", Framework: FrameworkGo}
 	output := `=== RUN   TestPass
@@ -97,6 +114,28 @@ FAIL`
 	}
 	if summary.Failures[0].File != "secret_test.go:12" || summary.Failures[0].Message == "" {
 		t.Fatalf("unexpected failure detail: %#v", summary.Failures[0])
+	}
+}
+
+func TestParseSummaryCountsNonVerboseGoPackagePassesWithFailures(t *testing.T) {
+	check := Check{ID: "go.test", Framework: FrameworkGo}
+	output := `--- FAIL: TestBroken (0.00s)
+    broken_test.go:12: expected value
+FAIL
+FAIL	example.com/app/internal/broken	0.02s
+ok  	example.com/app/internal/healthy	0.12s
+`
+
+	summary := ParseSummary(check, output, "")
+
+	if summary == nil {
+		t.Fatal("expected parsed summary")
+	}
+	if summary.Total != 2 || summary.Passed != 1 || summary.Failed != 1 {
+		t.Fatalf("unexpected mixed non-verbose summary: %#v", summary)
+	}
+	if len(summary.Failures) != 1 || summary.Failures[0].Name != "TestBroken" {
+		t.Fatalf("unexpected failures: %#v", summary.Failures)
 	}
 }
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -3,7 +3,6 @@ package verify
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/testrunner"
 )
 
 type Status string
@@ -24,9 +24,11 @@ const (
 )
 
 type Check struct {
-	ID      string   `json:"id"`
-	Name    string   `json:"name"`
-	Command []string `json:"command"`
+	ID        string               `json:"id"`
+	Name      string               `json:"name"`
+	Command   []string             `json:"command"`
+	Kind      testrunner.Kind      `json:"kind,omitempty"`
+	Framework testrunner.Framework `json:"framework,omitempty"`
 }
 
 type Plan struct {
@@ -42,18 +44,19 @@ type Summary struct {
 }
 
 type Result struct {
-	ID            string         `json:"id"`
-	Name          string         `json:"name"`
-	Command       []string       `json:"command"`
-	Status        Status         `json:"status"`
-	ExitCode      int            `json:"exitCode"`
-	Stdout        string         `json:"stdout,omitempty"`
-	Stderr        string         `json:"stderr,omitempty"`
-	StartedAt     string         `json:"startedAt"`
-	EndedAt       string         `json:"endedAt"`
-	DurationMs    int            `json:"durationMs"`
-	Error         string         `json:"error,omitempty"`
-	OutputSummary *OutputSummary `json:"outputSummary,omitempty"`
+	ID            string              `json:"id"`
+	Name          string              `json:"name"`
+	Command       []string            `json:"command"`
+	Status        Status              `json:"status"`
+	ExitCode      int                 `json:"exitCode"`
+	Stdout        string              `json:"stdout,omitempty"`
+	Stderr        string              `json:"stderr,omitempty"`
+	StartedAt     string              `json:"startedAt"`
+	EndedAt       string              `json:"endedAt"`
+	DurationMs    int                 `json:"durationMs"`
+	Error         string              `json:"error,omitempty"`
+	OutputSummary *OutputSummary      `json:"outputSummary,omitempty"`
+	TestSummary   *testrunner.Summary `json:"testSummary,omitempty"`
 }
 
 type Report struct {
@@ -113,11 +116,20 @@ func DetectPlan(root string) (Plan, error) {
 	if err != nil {
 		return Plan{}, err
 	}
-	checks := []Check{}
-	if fileExists(filepath.Join(resolvedRoot, "go.mod")) {
-		checks = append(checks, Check{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}})
+	detected, err := testrunner.Detect(resolvedRoot)
+	if err != nil {
+		return Plan{}, err
 	}
-	checks = append(checks, detectPackageChecks(resolvedRoot)...)
+	checks := make([]Check, 0, len(detected))
+	for _, check := range detected {
+		checks = append(checks, Check{
+			ID:        check.ID,
+			Name:      check.Name,
+			Command:   append([]string{}, check.Command...),
+			Kind:      check.Kind,
+			Framework: check.Framework,
+		})
+	}
 	return Plan{Root: resolvedRoot, Checks: checks}, nil
 }
 
@@ -153,6 +165,15 @@ func Run(ctx context.Context, plan Plan, options RunOptions) Report {
 		result.Stdout = redaction.RedactString(commandResult.Stdout, redaction.Options{})
 		result.Stderr = redaction.RedactString(commandResult.Stderr, redaction.Options{})
 		result.ExitCode = commandResult.ExitCode
+		if shouldParseTestSummary(check) {
+			result.TestSummary = testrunner.ParseSummary(testrunner.Check{
+				ID:        check.ID,
+				Name:      check.Name,
+				Command:   append([]string{}, check.Command...),
+				Kind:      check.Kind,
+				Framework: check.Framework,
+			}, result.Stdout, result.Stderr)
+		}
 		if err != nil {
 			result.Status = StatusError
 			result.Error = redaction.RedactString(err.Error(), redaction.Options{})
@@ -218,39 +239,24 @@ func RunLoop(ctx context.Context, plan Plan, options LoopOptions) LoopReport {
 	return report
 }
 
-func detectPackageChecks(root string) []Check {
-	path := filepath.Join(root, "package.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil
+func shouldParseTestSummary(check Check) bool {
+	if check.Kind == testrunner.KindTest {
+		return true
 	}
-	var pkg struct {
-		Scripts map[string]string `json:"scripts"`
+	if check.Kind != "" {
+		return false
 	}
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return nil
+	id := strings.ToLower(strings.TrimSpace(check.ID))
+	if strings.Contains(id, ".test") || strings.HasSuffix(id, "test") || strings.Contains(id, "pytest") {
+		return true
 	}
-	checks := []Check{}
-	for _, candidate := range []struct {
-		script string
-		id     string
-		name   string
-	}{
-		{script: "typecheck", id: "bun.typecheck", name: "Bun typecheck"},
-		{script: "test", id: "bun.test", name: "Bun tests"},
-		{script: "build", id: "bun.build", name: "Bun build"},
-		{script: "lint", id: "bun.lint", name: "Bun lint"},
-	} {
-		if strings.TrimSpace(pkg.Scripts[candidate.script]) == "" {
-			continue
+	for _, part := range check.Command {
+		normalized := strings.ToLower(strings.TrimSpace(part))
+		if normalized == "test" || normalized == "pytest" {
+			return true
 		}
-		checks = append(checks, Check{
-			ID:      candidate.id,
-			Name:    candidate.name,
-			Command: []string{"bun", "run", candidate.script},
-		})
 	}
-	return checks
+	return false
 }
 
 func summarizeOutput(values ...string) *OutputSummary {
@@ -394,11 +400,6 @@ func filterChecks(checks []Check, only []string) ([]Check, []string) {
 	}
 	sort.Strings(unknown)
 	return filtered, unknown
-}
-
-func fileExists(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && !info.IsDir()
 }
 
 func formatTime(value time.Time) string {

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Gitlawb/zero/internal/testrunner"
 )
 
 func TestDetectPlanFindsBunAndGoChecks(t *testing.T) {
@@ -35,6 +37,13 @@ func TestDetectPlanFindsBunAndGoChecks(t *testing.T) {
 	}
 	if plan.Checks[0].Command[0] != "go" || strings.Join(plan.Checks[0].Command, " ") != "go test ./..." {
 		t.Fatalf("first check = %#v, want go test ./...", plan.Checks[0])
+	}
+	byID := checksByID(plan.Checks)
+	if byID["go.test"].Kind != testrunner.KindTest || byID["go.test"].Framework != testrunner.FrameworkGo {
+		t.Fatalf("go.test metadata = %#v", byID["go.test"])
+	}
+	if byID["bun.typecheck"].Kind != testrunner.KindTypecheck || byID["bun.test"].Framework != testrunner.FrameworkBun {
+		t.Fatalf("bun metadata = typecheck %#v test %#v", byID["bun.typecheck"], byID["bun.test"])
 	}
 }
 
@@ -75,7 +84,7 @@ func TestRunExecutesPlanAndRedactsOutput(t *testing.T) {
 func TestRunParsesStructuredFailureSummary(t *testing.T) {
 	root := t.TempDir()
 	plan := Plan{Root: root, Checks: []Check{
-		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}},
+		{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}, Kind: testrunner.KindTest, Framework: testrunner.FrameworkGo},
 	}}
 	runner := &fakeCommandRunner{results: []CommandResult{{
 		ExitCode: 1,
@@ -100,6 +109,38 @@ func TestRunParsesStructuredFailureSummary(t *testing.T) {
 	}
 	if strings.Contains(lines, "sk-proj-abcdefghijklmnopqrstuvwxyz") {
 		t.Fatalf("failure summary leaked secret: %q", lines)
+	}
+	if report.Results[0].TestSummary == nil {
+		t.Fatalf("expected parsed test summary, got %#v", report.Results[0])
+	}
+	if report.Results[0].TestSummary.Total != 1 || report.Results[0].TestSummary.Failed != 1 {
+		t.Fatalf("unexpected parsed test summary: %#v", report.Results[0].TestSummary)
+	}
+	if got := report.Results[0].TestSummary.Failures[0]; got.Name != "TestSecret" || got.File != "secret_test.go:12" || !strings.Contains(got.Message, "[REDACTED]") {
+		t.Fatalf("unexpected parsed failure detail: %#v", got)
+	}
+}
+
+func TestRunSkipsStructuredSummaryForNonTestChecks(t *testing.T) {
+	root := t.TempDir()
+	plan := Plan{Root: root, Checks: []Check{
+		{ID: "bun.typecheck", Name: "Bun typecheck", Command: []string{"bun", "run", "typecheck"}, Kind: testrunner.KindTypecheck, Framework: testrunner.FrameworkBun},
+	}}
+	runner := &fakeCommandRunner{results: []CommandResult{{
+		ExitCode: 1,
+		Stdout:   "1 failed, 2 passed while checking types\n",
+	}}}
+
+	report := Run(context.Background(), plan, RunOptions{
+		Runner: runner.Run,
+		Now:    fixedVerifyTime("2026-06-05T11:15:30Z"),
+	})
+
+	if report.Results[0].TestSummary != nil {
+		t.Fatalf("non-test check should not have a parsed test summary: %#v", report.Results[0].TestSummary)
+	}
+	if report.Results[0].OutputSummary == nil {
+		t.Fatalf("expected ordinary failure output summary, got %#v", report.Results[0])
 	}
 }
 
@@ -291,6 +332,14 @@ func contains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func checksByID(checks []Check) map[string]Check {
+	byID := map[string]Check{}
+	for _, check := range checks {
+		byID[check.ID] = check
+	}
+	return byID
 }
 
 func writeFile(t *testing.T, path string, content string) {

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -15,6 +15,7 @@ import (
 func TestDetectPlanFindsBunAndGoChecks(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/zero\n")
+	writeFile(t, filepath.Join(root, "bun.lock"), "")
 	writeFile(t, filepath.Join(root, "package.json"), `{
 		"scripts": {
 			"test": "bun test ./tests",


### PR DESCRIPTION
## Summary
- Adds the M5 Zero test-runner backend for detecting workspace checks across Go, package-manager scripts, pytest, and Cargo projects.
- Parses runner output into structured test summaries with framework, pass/fail/skip counts, and failure details.
- Integrates those summaries into `zero verify` JSON and text output, with nested redaction for output summaries and failure details.

## Validation
- `git diff --check origin/main...HEAD`
- `go test -count=1 -p 1 ./...`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test ./tests --timeout 15000` (217 pass, 0 fail)
- `bun run build`
- `bun run smoke:build`
- `bun run smoke:go`
- `./zero verify --json --only go.test --timeout-ms 120000 | rg '"testSummary"|"framework"|"total"|"passed"|"failed"' -n`

Reviewers: @vasanthdev2004 @anandh8x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verify now detects and parses test summaries across multiple ecosystems (Go, Node, Python, Rust, Bun) and shows structured totals and failure details in output.
* **Bug Fixes**
  * Redaction of sensitive workspace output improved and no longer mutates original results.
* **Tests**
  * Expanded test coverage for detection, parsing across runners, stable ordering, and redaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->