### PR TITLE
feat: add M5 self verification backend

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/selfverify"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
@@ -39,7 +40,7 @@ type appDeps struct {
 	prepareWorktree  func(context.Context, worktrees.Options) (worktrees.Result, error)
 	detectVerifyPlan func(string) (verify.Plan, error)
 	runVerify        func(context.Context, verify.Plan, verify.RunOptions) verify.Report
-	runVerifyLoop    func(context.Context, verify.Plan, verify.LoopOptions) verify.LoopReport
+	runSelfVerify    func(context.Context, verify.Plan, selfverify.Options) selfverify.Report
 	inspectChanges   func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error)
 	commitChanges    func(context.Context, zerogit.CommitOptions) (zerogit.CommitResult, error)
 	runTUI           func(context.Context, tui.Options) int
@@ -99,7 +100,7 @@ func defaultAppDeps() appDeps {
 		prepareWorktree:  worktrees.Prepare,
 		detectVerifyPlan: verify.DetectPlan,
 		runVerify:        verify.Run,
-		runVerifyLoop:    verify.RunLoop,
+		runSelfVerify:    selfverify.Run,
 		inspectChanges:   zerogit.Inspect,
 		commitChanges:    zerogit.Commit,
 		runTUI:           tui.Run,
@@ -218,8 +219,8 @@ func fillAppDeps(deps appDeps) appDeps {
 	if deps.runVerify == nil {
 		deps.runVerify = defaults.runVerify
 	}
-	if deps.runVerifyLoop == nil {
-		deps.runVerifyLoop = defaults.runVerifyLoop
+	if deps.runSelfVerify == nil {
+		deps.runSelfVerify = defaults.runSelfVerify
 	}
 	if deps.inspectChanges == nil {
 		deps.inspectChanges = defaults.inspectChanges

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/selfverify"
 	"github.com/Gitlawb/zero/internal/testrunner"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
@@ -330,9 +331,11 @@ func TestRunVerifyReturnsProviderExitWhenChecksFail(t *testing.T) {
 func TestRunVerifyAttemptsUsesSelfVerifyLoop(t *testing.T) {
 	cwd := t.TempDir()
 	plan := verify.Plan{Root: cwd, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
-	loopReport := verify.LoopReport{
-		OK: true,
-		Attempts: []verify.Attempt{
+	loopReport := selfverify.Report{
+		Root:       cwd,
+		OK:         true,
+		StopReason: selfverify.StopReasonPassed,
+		Attempts: []selfverify.Attempt{
 			{Number: 1, Report: verify.Report{Root: cwd, OK: false, Summary: verify.Summary{Total: 1, Failed: 1}}},
 			{Number: 2, Report: verify.Report{Root: cwd, OK: true, Summary: verify.Summary{Total: 1, Passed: 1}}},
 		},
@@ -348,7 +351,7 @@ func TestRunVerifyAttemptsUsesSelfVerifyLoop(t *testing.T) {
 			}
 			return plan, nil
 		},
-		runVerifyLoop: func(ctx context.Context, gotPlan verify.Plan, options verify.LoopOptions) verify.LoopReport {
+		runSelfVerify: func(ctx context.Context, gotPlan verify.Plan, options selfverify.Options) selfverify.Report {
 			if options.MaxAttempts != 2 {
 				t.Fatalf("MaxAttempts = %d, want 2", options.MaxAttempts)
 			}
@@ -359,12 +362,53 @@ func TestRunVerifyAttemptsUsesSelfVerifyLoop(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	var decoded verify.LoopReport
+	var decoded selfverify.Report
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("decode verify loop JSON: %v\n%s", err, stdout.String())
 	}
-	if len(decoded.Attempts) != 2 || !decoded.OK {
+	if len(decoded.Attempts) != 2 || !decoded.OK || decoded.StopReason != selfverify.StopReasonPassed {
 		t.Fatalf("unexpected loop JSON: %#v", decoded)
+	}
+}
+
+func TestRunVerifyAttemptsFormatsSelfVerifyText(t *testing.T) {
+	cwd := t.TempDir()
+	plan := verify.Plan{Root: cwd, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	loopReport := selfverify.Report{
+		Root:       cwd,
+		OK:         true,
+		StopReason: selfverify.StopReasonPassed,
+		Summary:    verify.Summary{Total: 1, Passed: 1},
+		Attempts: []selfverify.Attempt{
+			{
+				Number:      1,
+				Report:      verify.Report{Root: cwd, OK: false, Summary: verify.Summary{Total: 1, Failed: 1}},
+				Remediation: &selfverify.Remediation{Applied: true, Message: "prepared retry"},
+			},
+			{Number: 2, Report: verify.Report{Root: cwd, OK: true, Summary: verify.Summary{Total: 1, Passed: 1}}},
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"verify", "--attempts=2"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		detectVerifyPlan: func(string) (verify.Plan, error) {
+			return plan, nil
+		},
+		runSelfVerify: func(context.Context, verify.Plan, selfverify.Options) selfverify.Report {
+			return loopReport
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"Zero self-verification", "root: " + cwd, "stop: passed", "attempt 1: failed", "remediation: applied - prepared retry", "attempt 2: passed"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected %q in output: %q", want, output)
+		}
 	}
 }
 

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/selfverify"
 	"github.com/Gitlawb/zero/internal/testrunner"
 	"github.com/Gitlawb/zero/internal/verify"
 	"github.com/Gitlawb/zero/internal/worktrees"
@@ -108,7 +109,7 @@ func runVerifyCommand(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		return writeExecUsageError(stderr, err.Error())
 	}
 	if options.attempts > 1 {
-		loopReport := deps.runVerifyLoop(context.Background(), plan, verify.LoopOptions{
+		loopReport := deps.runSelfVerify(context.Background(), plan, selfverify.Options{
 			RunOptions: verify.RunOptions{
 				Only:      options.only,
 				TimeoutMS: options.timeoutMS,
@@ -461,10 +462,19 @@ func redactVerifyReport(report verify.Report) verify.Report {
 	return report
 }
 
-func redactVerifyLoopReport(report verify.LoopReport) verify.LoopReport {
+func redactVerifyLoopReport(report selfverify.Report) selfverify.Report {
+	report.Root = redactCLIString(report.Root)
 	report.Error = redactCLIString(report.Error)
 	for index := range report.Attempts {
 		report.Attempts[index].Report = redactVerifyReport(report.Attempts[index].Report)
+		if report.Attempts[index].Remediation != nil {
+			remediation := *report.Attempts[index].Remediation
+			remediation.StartedAt = redactCLIString(remediation.StartedAt)
+			remediation.EndedAt = redactCLIString(remediation.EndedAt)
+			remediation.Message = redactCLIString(remediation.Message)
+			remediation.Error = redactCLIString(remediation.Error)
+			report.Attempts[index].Remediation = &remediation
+		}
 	}
 	return report
 }
@@ -555,23 +565,47 @@ func formatVerifyTestSummary(summary *testrunner.Summary) string {
 	return line
 }
 
-func formatVerifyLoopReport(report verify.LoopReport) string {
+func formatVerifyLoopReport(report selfverify.Report) string {
 	lines := []string{
 		"Zero self-verification",
-		fmt.Sprintf("attempts: %d", len(report.Attempts)),
-		fmt.Sprintf("summary: %d total, %d passed, %d failed, %d errors", report.Summary.Total, report.Summary.Passed, report.Summary.Failed, report.Summary.Errors),
 	}
+	if report.Root != "" {
+		lines = append(lines, "root: "+report.Root)
+	}
+	lines = append(lines,
+		fmt.Sprintf("attempts: %d", len(report.Attempts)),
+		"stop: "+string(report.StopReason),
+		fmt.Sprintf("summary: %d total, %d passed, %d failed, %d errors", report.Summary.Total, report.Summary.Passed, report.Summary.Failed, report.Summary.Errors),
+	)
 	for _, attempt := range report.Attempts {
 		status := "failed"
 		if attempt.Report.OK {
 			status = "passed"
 		}
 		lines = append(lines, fmt.Sprintf("  attempt %d: %s", attempt.Number, status))
+		if attempt.Remediation != nil {
+			lines = append(lines, "    remediation: "+formatRemediation(*attempt.Remediation))
+		}
 	}
 	if report.Error != "" {
 		lines = append(lines, "error: "+report.Error)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func formatRemediation(remediation selfverify.Remediation) string {
+	status := "not applied"
+	if remediation.Applied {
+		status = "applied"
+	}
+	details := []string{status}
+	if remediation.Message != "" {
+		details = append(details, remediation.Message)
+	}
+	if remediation.Error != "" {
+		details = append(details, "error: "+remediation.Error)
+	}
+	return strings.Join(details, " - ")
 }
 
 func formatChangeSummary(summary zerogit.ChangeSummary) string {

--- a/internal/selfverify/selfverify.go
+++ b/internal/selfverify/selfverify.go
@@ -1,0 +1,146 @@
+package selfverify
+
+import (
+	"context"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/verify"
+)
+
+type StopReason string
+
+const (
+	StopReasonPassed          StopReason = "passed"
+	StopReasonMaxAttempts     StopReason = "max_attempts"
+	StopReasonRemediatorError StopReason = "remediator_error"
+	StopReasonContextCanceled StopReason = "context_canceled"
+)
+
+type Remediation struct {
+	StartedAt string `json:"startedAt,omitempty"`
+	EndedAt   string `json:"endedAt,omitempty"`
+	Applied   bool   `json:"applied"`
+	Message   string `json:"message,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+type Attempt struct {
+	Number      int           `json:"number"`
+	Report      verify.Report `json:"report"`
+	Remediation *Remediation  `json:"remediation,omitempty"`
+}
+
+type Report struct {
+	Root       string         `json:"root,omitempty"`
+	StartedAt  string         `json:"startedAt"`
+	EndedAt    string         `json:"endedAt"`
+	OK         bool           `json:"ok"`
+	StopReason StopReason     `json:"stopReason"`
+	Summary    verify.Summary `json:"summary"`
+	Attempts   []Attempt      `json:"attempts"`
+	Error      string         `json:"error,omitempty"`
+}
+
+type Remediator func(context.Context, Attempt) (Remediation, error)
+
+type Options struct {
+	RunOptions  verify.RunOptions
+	MaxAttempts int
+	Remediator  Remediator
+}
+
+func Run(ctx context.Context, plan verify.Plan, options Options) Report {
+	runOptions := options.RunOptions
+	now := runOptions.Now
+	if now == nil {
+		now = time.Now
+		runOptions.Now = now
+	}
+	start := now()
+	report := Report{
+		Root:       plan.Root,
+		StartedAt:  formatTime(start),
+		StopReason: StopReasonMaxAttempts,
+	}
+	if err := ctx.Err(); err != nil {
+		report.StopReason = StopReasonContextCanceled
+		report.Error = redact(err.Error())
+		report.EndedAt = formatTime(now())
+		return report
+	}
+
+	maxAttempts := firstPositive(options.MaxAttempts, 1)
+	for attemptNumber := 1; attemptNumber <= maxAttempts; attemptNumber++ {
+		attemptReport := verify.Run(ctx, plan, runOptions)
+		attempt := Attempt{Number: attemptNumber, Report: attemptReport}
+		report.Attempts = append(report.Attempts, attempt)
+		report.Summary = attemptReport.Summary
+		if attemptReport.OK {
+			report.OK = true
+			report.StopReason = StopReasonPassed
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			report.StopReason = StopReasonContextCanceled
+			report.Error = redact(err.Error())
+			break
+		}
+		if attemptNumber >= maxAttempts {
+			report.StopReason = StopReasonMaxAttempts
+			break
+		}
+		if options.Remediator == nil {
+			continue
+		}
+		remediationStart := now()
+		remediation, err := options.Remediator(ctx, attempt)
+		remediation = redactRemediation(remediation)
+		if remediation.StartedAt == "" {
+			remediation.StartedAt = formatTime(remediationStart)
+		}
+		if remediation.EndedAt == "" {
+			remediation.EndedAt = formatTime(now())
+		}
+		if err != nil {
+			remediation.Error = redact(err.Error())
+			attempt.Remediation = &remediation
+			report.Attempts[len(report.Attempts)-1] = attempt
+			report.StopReason = StopReasonRemediatorError
+			report.Error = remediation.Error
+			break
+		}
+		attempt.Remediation = &remediation
+		report.Attempts[len(report.Attempts)-1] = attempt
+	}
+	report.EndedAt = formatTime(now())
+	return report
+}
+
+func redactRemediation(remediation Remediation) Remediation {
+	remediation.StartedAt = redact(remediation.StartedAt)
+	remediation.EndedAt = redact(remediation.EndedAt)
+	remediation.Message = redact(remediation.Message)
+	remediation.Error = redact(remediation.Error)
+	return remediation
+}
+
+func redact(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/selfverify/selfverify_test.go
+++ b/internal/selfverify/selfverify_test.go
@@ -1,0 +1,166 @@
+package selfverify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/verify"
+)
+
+func TestRunStopsAfterPassingAttempt(t *testing.T) {
+	root := t.TempDir()
+	plan := verify.Plan{Root: root, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	runner := &fakeVerifyRunner{results: []verify.CommandResult{
+		{ExitCode: 1, Stdout: "FAIL\n"},
+		{ExitCode: 0, Stdout: "ok\n"},
+	}}
+	remediations := 0
+
+	report := Run(context.Background(), plan, Options{
+		RunOptions: verify.RunOptions{
+			Runner: runner.Run,
+			Now:    fixedSelfVerifyTime("2026-06-05T12:00:00Z"),
+		},
+		MaxAttempts: 3,
+		Remediator: func(ctx context.Context, attempt Attempt) (Remediation, error) {
+			remediations++
+			if attempt.Number != 1 || attempt.Report.OK {
+				t.Fatalf("unexpected remediation attempt: %#v", attempt)
+			}
+			return Remediation{Applied: true, Message: "prepared a second verification pass"}, nil
+		},
+	})
+
+	if !report.OK || report.StopReason != StopReasonPassed {
+		t.Fatalf("expected passed report, got %#v", report)
+	}
+	if len(report.Attempts) != 2 || !report.Attempts[1].Report.OK {
+		t.Fatalf("unexpected attempts: %#v", report.Attempts)
+	}
+	if remediations != 1 {
+		t.Fatalf("remediator called %d times, want 1", remediations)
+	}
+	if report.Attempts[0].Remediation == nil || !report.Attempts[0].Remediation.Applied {
+		t.Fatalf("expected remediation metadata on first attempt, got %#v", report.Attempts[0].Remediation)
+	}
+}
+
+func TestRunStopsAtMaxAttempts(t *testing.T) {
+	root := t.TempDir()
+	plan := verify.Plan{Root: root, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	runner := &fakeVerifyRunner{results: []verify.CommandResult{
+		{ExitCode: 1, Stdout: "FAIL one\n"},
+		{ExitCode: 1, Stdout: "FAIL two\n"},
+	}}
+	remediations := 0
+
+	report := Run(context.Background(), plan, Options{
+		RunOptions: verify.RunOptions{
+			Runner: runner.Run,
+			Now:    fixedSelfVerifyTime("2026-06-05T12:05:00Z"),
+		},
+		MaxAttempts: 2,
+		Remediator: func(context.Context, Attempt) (Remediation, error) {
+			remediations++
+			return Remediation{Applied: true, Message: "retry budget continues"}, nil
+		},
+	})
+
+	if report.OK || report.StopReason != StopReasonMaxAttempts {
+		t.Fatalf("expected max-attempt failure, got %#v", report)
+	}
+	if len(report.Attempts) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(report.Attempts))
+	}
+	if remediations != 1 {
+		t.Fatalf("remediator called %d times, want 1", remediations)
+	}
+	if report.Summary.Failed != 1 {
+		t.Fatalf("expected latest failed summary, got %#v", report.Summary)
+	}
+}
+
+func TestRunDefaultsToOneAttempt(t *testing.T) {
+	root := t.TempDir()
+	plan := verify.Plan{Root: root, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	runner := &fakeVerifyRunner{results: []verify.CommandResult{{ExitCode: 1, Stdout: "FAIL\n"}}}
+
+	report := Run(context.Background(), plan, Options{
+		RunOptions: verify.RunOptions{
+			Runner: runner.Run,
+			Now:    fixedSelfVerifyTime("2026-06-05T12:10:00Z"),
+		},
+		Remediator: func(context.Context, Attempt) (Remediation, error) {
+			t.Fatal("remediator should not run when the default single attempt is exhausted")
+			return Remediation{}, nil
+		},
+	})
+
+	if report.OK || report.StopReason != StopReasonMaxAttempts {
+		t.Fatalf("expected one failed attempt, got %#v", report)
+	}
+	if len(report.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(report.Attempts))
+	}
+}
+
+func TestRunStopsOnRemediatorErrorAndRedacts(t *testing.T) {
+	root := t.TempDir()
+	secret := "sk-proj-abcdefghijklmnopqrstuvwxyz"
+	plan := verify.Plan{Root: root, Checks: []verify.Check{{ID: "go.test", Name: "Go tests", Command: []string{"go", "test", "./..."}}}}
+	runner := &fakeVerifyRunner{results: []verify.CommandResult{{ExitCode: 1, Stdout: "FAIL\n"}}}
+
+	report := Run(context.Background(), plan, Options{
+		RunOptions: verify.RunOptions{
+			Runner: runner.Run,
+			Now:    fixedSelfVerifyTime("2026-06-05T12:15:00Z"),
+		},
+		MaxAttempts: 2,
+		Remediator: func(context.Context, Attempt) (Remediation, error) {
+			return Remediation{Message: "repair used token " + secret}, errors.New("repair failed with " + secret)
+		},
+	})
+
+	if report.OK || report.StopReason != StopReasonRemediatorError {
+		t.Fatalf("expected remediator error stop, got %#v", report)
+	}
+	if len(report.Attempts) != 1 {
+		t.Fatalf("attempts = %d, want 1", len(report.Attempts))
+	}
+	remediation := report.Attempts[0].Remediation
+	if remediation == nil {
+		t.Fatalf("expected remediation metadata")
+	}
+	combined := report.Error + remediation.Message + remediation.Error
+	if strings.Contains(combined, secret) {
+		t.Fatalf("self-verify report leaked secret: %#v", report)
+	}
+	if !strings.Contains(combined, redaction.RedactedSecret) {
+		t.Fatalf("expected redaction marker in report, got %#v", report)
+	}
+}
+
+type fakeVerifyRunner struct {
+	results []verify.CommandResult
+}
+
+func (runner *fakeVerifyRunner) Run(context.Context, string, []string, time.Duration) (verify.CommandResult, error) {
+	if len(runner.results) == 0 {
+		return verify.CommandResult{}, nil
+	}
+	result := runner.results[0]
+	runner.results = runner.results[1:]
+	return result, nil
+}
+
+func fixedSelfVerifyTime(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time { return parsed }
+}


### PR DESCRIPTION
## Summary
- Add the M5 self-verification backend contract with bounded attempts, stop reasons, remediation metadata, and redacted remediation errors.
- Wire `zero verify --attempts` through the self-verification backend while preserving the existing single-run verifier path.
- Extend CLI JSON/text output tests plus backend tests for pass-after-retry, max-attempt stops, default attempt behavior, and remediation error redaction.

## Validation
- `git diff --check origin/main...HEAD`
- `go test -count=1 -p 1 ./...`
- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`
- `bun run smoke:build`
- `bun run smoke:go`
- `./zero verify --attempts 2 --json --only go.test --timeout-ms 120000`

## PRD Slice
- M5 Gnanam: self-verification loop, with reusable backend data structures for future repair/retry orchestration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced self-verification with automatic remediation support for `verify --attempts`
  * Verification now tracks stop reasons and per-attempt remediation results
  * Enhanced output formatting with detailed attempt status and remediation information

* **Tests**
  * Added comprehensive test coverage for self-verification and remediation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->