### PR TITLE
feat: harden sandbox command execution

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -132,6 +132,7 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		Name:       call.Name,
 		Status:     result.Status,
 		Output:     result.Output,
+		Meta:       result.Meta,
 	}
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -24,6 +24,7 @@ type ToolResult struct {
 	Name       string
 	Status     tools.Status
 	Output     string
+	Meta       map[string]string
 }
 
 type Options struct {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -220,12 +220,16 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		},
 		OnToolResult: func(result agent.ToolResult) {
 			writer.toolResult(result)
-			sessionRecorder.append(sessions.EventToolResult, map[string]any{
+			payload := map[string]any{
 				"toolCallId": result.ToolCallID,
 				"name":       result.Name,
 				"status":     string(result.Status),
 				"output":     result.Output,
-			})
+			}
+			if len(result.Meta) > 0 {
+				payload["meta"] = result.Meta
+			}
+			sessionRecorder.append(sessions.EventToolResult, payload)
 		},
 		OnUsage: func(usage agent.Usage) {
 			writer.usage(usage)

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -389,6 +389,10 @@ func TestExecEventWriterTruncatesStreamJSONToolResults(t *testing.T) {
 		Name:       "read_file",
 		Status:     tools.StatusOK,
 		Output:     strings.Repeat("x", streamJSONToolResultOutputLimit+100),
+		Meta: map[string]string{
+			"sandbox_backend": "bubblewrap",
+			"sandbox_wrapped": "true",
+		},
 	})
 	if writer.err != nil {
 		t.Fatalf("toolResult returned writer error: %v", writer.err)
@@ -403,6 +407,10 @@ func TestExecEventWriterTruncatesStreamJSONToolResults(t *testing.T) {
 	}
 	if events[0]["name"] != "read_file" {
 		t.Fatalf("expected tool_result name to be read_file, got %#v", events[0])
+	}
+	meta := events[0]["meta"].(map[string]any)
+	if meta["sandbox_backend"] != "bubblewrap" || meta["sandbox_wrapped"] != "true" {
+		t.Fatalf("expected sandbox metadata, got %#v", meta)
 	}
 	output := events[0]["output"].(string)
 	if len(output) >= streamJSONToolResultOutputLimit+100 || !strings.Contains(output, "[truncated]") {

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -104,13 +104,17 @@ func (writer *execEventWriter) toolCall(call agent.ToolCall, registry *tools.Reg
 
 func (writer *execEventWriter) toolResult(result agent.ToolResult) {
 	if writer.format == execOutputJSON {
-		writer.writeJSON(map[string]any{
+		payload := map[string]any{
 			"type":         "tool_result",
 			"tool_call_id": result.ToolCallID,
 			"name":         result.Name,
 			"status":       string(result.Status),
 			"output":       result.Output,
-		})
+		}
+		if len(result.Meta) > 0 {
+			payload["meta"] = result.Meta
+		}
+		writer.writeJSON(payload)
 		return
 	}
 	if writer.format == execOutputStreamJSON {
@@ -123,6 +127,7 @@ func (writer *execEventWriter) toolResult(result agent.ToolResult) {
 			Status:    string(result.Status),
 			Output:    output,
 			Truncated: &truncated,
+			Meta:      result.Meta,
 		})
 		return
 	}

--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -66,6 +66,8 @@ func (backend Backend) BuildPlan(workspaceRoot string, policy Policy) BackendPla
 	}
 	if backend.Name == BackendPolicyOnly {
 		restrictions = append(restrictions, "platform sandbox unavailable; policy engine still evaluates tool requests")
+	} else if backend.Available {
+		restrictions = append(restrictions, "shell commands are wrapped through "+string(backend.Name)+" when launched by the sandbox engine")
 	}
 	return BackendPlan{
 		Backend:       backend,

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -1,0 +1,285 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const bubblewrapWorkspace = "/workspace"
+
+var errPolicyOnlyRunnerDisabled = errors.New("policy-only sandbox runner is disabled")
+
+type CommandSpec struct {
+	Name string
+	Args []string
+	Dir  string
+	Env  []string
+}
+
+type CommandPlan struct {
+	Backend       Backend  `json:"backend"`
+	WorkspaceRoot string   `json:"workspaceRoot"`
+	Policy        Policy   `json:"policy"`
+	Wrapped       bool     `json:"wrapped"`
+	Name          string   `json:"name"`
+	Args          []string `json:"args"`
+	Dir           string   `json:"dir,omitempty"`
+	Env           []string `json:"env,omitempty"`
+	SandboxDir    string   `json:"sandboxDir,omitempty"`
+}
+
+func (engine *Engine) CommandContext(ctx context.Context, spec CommandSpec) (*exec.Cmd, CommandPlan, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	plan, err := engine.BuildCommandPlan(spec)
+	if err != nil {
+		return nil, CommandPlan{}, err
+	}
+	command := exec.CommandContext(ctx, plan.Name, plan.Args...)
+	command.Dir = plan.Dir
+	command.Env = plan.Env
+	return command, plan, nil
+}
+
+func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
+	if engine == nil {
+		return directCommandPlan(spec, Backend{Name: BackendPolicyOnly, Message: "sandbox disabled"}, Policy{}, ""), nil
+	}
+	policy := engine.policy
+	if policy.Mode == "" {
+		policy = DefaultPolicy()
+	}
+	workspaceRoot, commandDir, relativeDir, err := engine.resolveCommandDir(spec.Dir, policy)
+	if err != nil {
+		return CommandPlan{}, err
+	}
+	spec.Name = strings.TrimSpace(spec.Name)
+	if spec.Name == "" {
+		return CommandPlan{}, errors.New("sandbox command name is required")
+	}
+	spec.Dir = commandDir
+
+	backend := engine.backend
+	if backend.Name == "" {
+		backend = Backend{Name: BackendPolicyOnly, Message: "policy-only fallback: sandbox backend was not selected"}
+	}
+	if policy.Mode == ModeDisabled {
+		return directCommandPlan(spec, backend, policy, workspaceRoot), nil
+	}
+	switch backend.Name {
+	case BackendBubblewrap:
+		if backend.Available && backend.Executable != "" {
+			return bubblewrapCommandPlan(spec, workspaceRoot, relativeDir, policy, backend), nil
+		}
+	case BackendSandboxExec:
+		if backend.Available && backend.Executable != "" {
+			return sandboxExecCommandPlan(spec, workspaceRoot, policy, backend), nil
+		}
+	}
+	if !policy.AllowPolicyOnlyRunner {
+		return CommandPlan{}, errPolicyOnlyRunnerDisabled
+	}
+	return directCommandPlan(spec, backend, policy, workspaceRoot), nil
+}
+
+func directCommandPlan(spec CommandSpec, backend Backend, policy Policy, workspaceRoot string) CommandPlan {
+	return CommandPlan{
+		Backend:       backend,
+		WorkspaceRoot: workspaceRoot,
+		Policy:        policy,
+		Wrapped:       false,
+		Name:          spec.Name,
+		Args:          cloneStrings(spec.Args),
+		Dir:           spec.Dir,
+		Env:           cloneStrings(spec.Env),
+	}
+}
+
+func (engine *Engine) resolveCommandDir(dir string, policy Policy) (string, string, string, error) {
+	workspaceRoot := strings.TrimSpace(engine.workspaceRoot)
+	if workspaceRoot == "" {
+		return "", "", "", errors.New("sandbox workspace root is required")
+	}
+	workspaceRoot = filepath.Clean(workspaceRoot)
+	if !filepath.IsAbs(workspaceRoot) {
+		absolute, err := filepath.Abs(workspaceRoot)
+		if err != nil {
+			return "", "", "", fmt.Errorf("resolve sandbox workspace: %w", err)
+		}
+		workspaceRoot = absolute
+	}
+	if resolved, err := filepath.EvalSymlinks(workspaceRoot); err == nil {
+		workspaceRoot = resolved
+	}
+
+	commandDir := strings.TrimSpace(dir)
+	if commandDir == "" {
+		commandDir = workspaceRoot
+	} else if !filepath.IsAbs(commandDir) {
+		commandDir = filepath.Join(workspaceRoot, commandDir)
+	}
+	commandDir = filepath.Clean(commandDir)
+	if resolved, err := filepath.EvalSymlinks(commandDir); err == nil {
+		commandDir = resolved
+	}
+	if policy.EnforceWorkspace {
+		if violation := validateWorkspacePath(workspaceRoot, commandDir); violation != nil {
+			return "", "", "", Violation{
+				Code:     violation.Code,
+				ToolName: "sandbox_command",
+				Action:   ActionDeny,
+				Risk: Risk{
+					Level:      RiskCritical,
+					Categories: []string{"path_escape"},
+					Reason:     "critical risk: path_escape",
+				},
+				Path:   violation.Path,
+				Reason: violation.Reason,
+			}
+		}
+	}
+	relativeDir, err := filepath.Rel(workspaceRoot, commandDir)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve sandbox command directory: %w", err)
+	}
+	if relativeDir == "." {
+		relativeDir = ""
+	}
+	return workspaceRoot, commandDir, relativeDir, nil
+}
+
+func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir string, policy Policy, backend Backend) CommandPlan {
+	sandboxDir := bubblewrapWorkspace
+	if relativeDir != "" {
+		sandboxDir = filepath.ToSlash(filepath.Join(bubblewrapWorkspace, relativeDir))
+	}
+	args := []string{
+		"--die-with-parent",
+		"--unshare-pid",
+		"--unshare-ipc",
+		"--unshare-uts",
+		"--proc", "/proc",
+		"--dev", "/dev",
+		"--tmpfs", "/tmp",
+		"--bind", workspaceRoot, bubblewrapWorkspace,
+		"--chdir", sandboxDir,
+	}
+	if policy.Network == NetworkDeny {
+		args = append(args, "--unshare-net")
+	}
+	for _, mount := range existingBubblewrapMounts() {
+		args = append(args, "--ro-bind", mount, mount)
+	}
+	args = append(args, "--clearenv")
+	for _, env := range sandboxEnvironment(policy, BackendBubblewrap, bubblewrapWorkspace) {
+		key, value, ok := strings.Cut(env, "=")
+		if ok {
+			args = append(args, "--setenv", key, value)
+		}
+	}
+	args = append(args, "--", spec.Name)
+	args = append(args, spec.Args...)
+	return CommandPlan{
+		Backend:       backend,
+		WorkspaceRoot: workspaceRoot,
+		Policy:        policy,
+		Wrapped:       true,
+		Name:          backend.Executable,
+		Args:          args,
+		SandboxDir:    sandboxDir,
+	}
+}
+
+func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, policy Policy, backend Backend) CommandPlan {
+	args := []string{"-p", sandboxExecProfile(workspaceRoot, policy), spec.Name}
+	args = append(args, spec.Args...)
+	return CommandPlan{
+		Backend:       backend,
+		WorkspaceRoot: workspaceRoot,
+		Policy:        policy,
+		Wrapped:       true,
+		Name:          backend.Executable,
+		Args:          args,
+		Dir:           spec.Dir,
+		Env:           sandboxEnvironment(policy, BackendSandboxExec, workspaceRoot),
+		SandboxDir:    spec.Dir,
+	}
+}
+
+func existingBubblewrapMounts() []string {
+	candidates := []string{"/bin", "/usr", "/lib", "/lib64", "/sbin", "/etc"}
+	mounts := []string{}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			mounts = append(mounts, candidate)
+		}
+	}
+	return mounts
+}
+
+func sandboxEnvironment(policy Policy, backend BackendName, home string) []string {
+	env := []string{
+		"HOME=" + home,
+		"PATH=" + firstEnv("PATH", defaultPath()),
+		"TERM=" + firstEnv("TERM", "dumb"),
+		"ZERO_SANDBOX_BACKEND=" + string(backend),
+		"ZERO_SANDBOX_NETWORK=" + string(policy.Network),
+	}
+	if runtime.GOOS == "windows" {
+		env = append(env, "COMSPEC="+firstEnv("COMSPEC", "cmd.exe"))
+	}
+	return env
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string{}, values...)
+}
+
+func firstEnv(key string, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func defaultPath() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("PATH")
+	}
+	return "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+}
+
+func sandboxExecProfile(workspaceRoot string, policy Policy) string {
+	networkRule := "(deny network*)"
+	if policy.Network == NetworkAllow {
+		networkRule = "(allow network*)"
+	}
+	writeRule := "(allow file-write*)"
+	if policy.EnforceWorkspace {
+		writeRule = `(allow file-write* (subpath "` + sandboxProfileString(workspaceRoot) + `"))`
+	}
+	return strings.Join([]string{
+		"(version 1)",
+		"(deny default)",
+		"(allow process*)",
+		"(allow sysctl-read)",
+		"(allow file-read*)",
+		writeRule,
+		networkRule,
+	}, "\n")
+}
+
+func sandboxProfileString(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`)
+	return replacer.Replace(value)
+}

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -1,0 +1,173 @@
+package sandbox
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildCommandPlanWrapsBubblewrap(t *testing.T) {
+	root := t.TempDir()
+	resolvedRoot := resolvedTestPath(t, root)
+	nested := filepath.Join(root, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        DefaultPolicy(),
+		Backend: Backend{
+			Name:       BackendBubblewrap,
+			Available:  true,
+			Executable: "/usr/bin/bwrap",
+			Message:    "bubblewrap sandbox available",
+		},
+	})
+
+	plan, err := engine.BuildCommandPlan(CommandSpec{
+		Name: "/bin/sh",
+		Args: []string{"-c", "pwd"},
+		Dir:  nested,
+	})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+
+	if !plan.Wrapped || plan.Name != "/usr/bin/bwrap" || plan.Backend.Name != BackendBubblewrap {
+		t.Fatalf("plan backend = %#v, want wrapped bubblewrap", plan)
+	}
+	assertArgsContainSequence(t, plan.Args, "--bind", resolvedRoot, bubblewrapWorkspace)
+	assertArgsContainSequence(t, plan.Args, "--chdir", bubblewrapWorkspace+"/nested")
+	assertArgsContainSequence(t, plan.Args, "--unshare-net")
+	assertArgsContainSequence(t, plan.Args, "--", "/bin/sh", "-c", "pwd")
+	if plan.SandboxDir != bubblewrapWorkspace+"/nested" {
+		t.Fatalf("SandboxDir = %q, want nested workspace dir", plan.SandboxDir)
+	}
+	if plan.Dir != "" {
+		t.Fatalf("bubblewrap host Dir = %q, want empty because bwrap owns chdir", plan.Dir)
+	}
+}
+
+func TestBuildCommandPlanWrapsSandboxExec(t *testing.T) {
+	root := t.TempDir()
+	resolvedRoot := resolvedTestPath(t, root)
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        DefaultPolicy(),
+		Backend: Backend{
+			Name:       BackendSandboxExec,
+			Available:  true,
+			Executable: "/usr/bin/sandbox-exec",
+			Message:    "sandbox-exec backend available",
+		},
+	})
+
+	plan, err := engine.BuildCommandPlan(CommandSpec{
+		Name: "/bin/sh",
+		Args: []string{"-c", "pwd"},
+		Dir:  root,
+	})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+
+	if !plan.Wrapped || plan.Name != "/usr/bin/sandbox-exec" || plan.Backend.Name != BackendSandboxExec {
+		t.Fatalf("plan backend = %#v, want wrapped sandbox-exec", plan)
+	}
+	if len(plan.Args) < 5 || plan.Args[0] != "-p" {
+		t.Fatalf("sandbox-exec args = %#v, want profile and command", plan.Args)
+	}
+	profile := plan.Args[1]
+	for _, want := range []string{"(deny default)", "(deny network*)", `(allow file-write* (subpath "` + sandboxProfileString(resolvedRoot) + `"))`} {
+		if !strings.Contains(profile, want) {
+			t.Fatalf("profile missing %q:\n%s", want, profile)
+		}
+	}
+	assertArgsContainSequence(t, plan.Args, "/bin/sh", "-c", "pwd")
+	if plan.Dir != resolvedRoot || plan.SandboxDir != resolvedRoot {
+		t.Fatalf("sandbox-exec dirs = host %q sandbox %q, want %q", plan.Dir, plan.SandboxDir, resolvedRoot)
+	}
+}
+
+func TestBuildCommandPlanUsesPolicyOnlyFallback(t *testing.T) {
+	root := t.TempDir()
+	resolvedRoot := resolvedTestPath(t, root)
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        DefaultPolicy(),
+		Backend:       Backend{Name: BackendPolicyOnly, Message: "policy-only fallback"},
+	})
+
+	plan, err := engine.BuildCommandPlan(CommandSpec{
+		Name: "/bin/sh",
+		Args: []string{"-c", "pwd"},
+		Dir:  root,
+	})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+
+	if plan.Wrapped || plan.Name != "/bin/sh" || plan.Dir != resolvedRoot || plan.WorkspaceRoot != resolvedRoot || plan.Backend.Name != BackendPolicyOnly {
+		t.Fatalf("policy-only plan = %#v, want direct command", plan)
+	}
+}
+
+func TestBuildCommandPlanCanRejectPolicyOnlyFallback(t *testing.T) {
+	root := t.TempDir()
+	policy := DefaultPolicy()
+	policy.AllowPolicyOnlyRunner = false
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        policy,
+		Backend:       Backend{Name: BackendPolicyOnly, Message: "policy-only fallback"},
+	})
+
+	_, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Dir: root})
+	if !errors.Is(err, errPolicyOnlyRunnerDisabled) {
+		t.Fatalf("error = %v, want policy-only disabled", err)
+	}
+}
+
+func TestBuildCommandPlanRejectsOutsideDirectory(t *testing.T) {
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: t.TempDir(),
+		Policy:        DefaultPolicy(),
+		Backend:       Backend{Name: BackendPolicyOnly},
+	})
+
+	_, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Dir: t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "outside_workspace") {
+		t.Fatalf("error = %v, want outside workspace violation", err)
+	}
+}
+
+func assertArgsContainSequence(t *testing.T, args []string, sequence ...string) {
+	t.Helper()
+	if len(sequence) == 0 {
+		return
+	}
+	for index := 0; index <= len(args)-len(sequence); index++ {
+		matched := true
+		for offset, want := range sequence {
+			if args[index+offset] != want {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return
+		}
+	}
+	t.Fatalf("args %#v do not contain sequence %#v", args, sequence)
+}
+
+func resolvedTestPath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", path, err)
+	}
+	return resolved
+}

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -34,31 +34,32 @@ const (
 )
 
 type Event struct {
-	SchemaVersion    int       `json:"schemaVersion"`
-	Type             EventType `json:"type"`
-	RunID            string    `json:"runId"`
-	SessionID        string    `json:"sessionId,omitempty"`
-	Cwd              string    `json:"cwd,omitempty"`
-	Provider         string    `json:"provider,omitempty"`
-	Model            string    `json:"model,omitempty"`
-	APIModel         string    `json:"apiModel,omitempty"`
-	Delta            string    `json:"delta,omitempty"`
-	ID               string    `json:"id,omitempty"`
-	Name             string    `json:"name,omitempty"`
-	Args             any       `json:"args,omitempty"`
-	SideEffect       string    `json:"sideEffect,omitempty"`
-	Status           string    `json:"status,omitempty"`
-	Output           string    `json:"output,omitempty"`
-	Truncated        *bool     `json:"truncated,omitempty"`
-	PromptTokens     *int      `json:"promptTokens,omitempty"`
-	CompletionTokens *int      `json:"completionTokens,omitempty"`
-	TotalTokens      *int      `json:"totalTokens,omitempty"`
-	CostUSD          *float64  `json:"costUsd,omitempty"`
-	Text             string    `json:"text,omitempty"`
-	Message          string    `json:"message,omitempty"`
-	Code             string    `json:"code,omitempty"`
-	Recoverable      *bool     `json:"recoverable,omitempty"`
-	ExitCode         *int      `json:"exitCode,omitempty"`
+	SchemaVersion    int               `json:"schemaVersion"`
+	Type             EventType         `json:"type"`
+	RunID            string            `json:"runId"`
+	SessionID        string            `json:"sessionId,omitempty"`
+	Cwd              string            `json:"cwd,omitempty"`
+	Provider         string            `json:"provider,omitempty"`
+	Model            string            `json:"model,omitempty"`
+	APIModel         string            `json:"apiModel,omitempty"`
+	Delta            string            `json:"delta,omitempty"`
+	ID               string            `json:"id,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Args             any               `json:"args,omitempty"`
+	SideEffect       string            `json:"sideEffect,omitempty"`
+	Status           string            `json:"status,omitempty"`
+	Output           string            `json:"output,omitempty"`
+	Truncated        *bool             `json:"truncated,omitempty"`
+	Meta             map[string]string `json:"meta,omitempty"`
+	PromptTokens     *int              `json:"promptTokens,omitempty"`
+	CompletionTokens *int              `json:"completionTokens,omitempty"`
+	TotalTokens      *int              `json:"totalTokens,omitempty"`
+	CostUSD          *float64          `json:"costUsd,omitempty"`
+	Text             string            `json:"text,omitempty"`
+	Message          string            `json:"message,omitempty"`
+	Code             string            `json:"code,omitempty"`
+	Recoverable      *bool             `json:"recoverable,omitempty"`
+	ExitCode         *int              `json:"exitCode,omitempty"`
 }
 
 type InputEvent struct {

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	zeroSandbox "github.com/Gitlawb/zero/internal/sandbox"
 )
 
 const defaultBashTimeoutMS = 120000
@@ -42,6 +44,14 @@ func NewBashTool(workspaceRoot string) Tool {
 }
 
 func (tool bashTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.run(ctx, args, nil)
+}
+
+func (tool bashTool) RunWithSandbox(ctx context.Context, args map[string]any, engine *zeroSandbox.Engine) Result {
+	return tool.run(ctx, args, engine)
+}
+
+func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroSandbox.Engine) Result {
 	commandText, err := stringArg(args, "command", "", true)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for bash: " + err.Error())
@@ -63,8 +73,20 @@ func (tool bashTool) Run(ctx context.Context, args map[string]any) Result {
 	commandCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutMS)*time.Millisecond)
 	defer cancel()
 
-	command := exec.CommandContext(commandCtx, shellExecutable(), shellArguments(commandText)...)
-	command.Dir = absoluteCwd
+	meta := map[string]string{
+		"cwd":        relativeCwd,
+		"timeout_ms": strconv.Itoa(timeoutMS),
+	}
+	command, plan, err := buildBashCommand(commandCtx, commandText, absoluteCwd, engine)
+	if err != nil {
+		meta["exit_code"] = "-1"
+		return Result{
+			Status: StatusError,
+			Output: "Error preparing sandboxed bash command: " + err.Error(),
+			Meta:   meta,
+		}
+	}
+	addSandboxMeta(meta, plan)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -73,11 +95,7 @@ func (tool bashTool) Run(ctx context.Context, args map[string]any) Result {
 
 	err = command.Run()
 	exitCode := commandExitCode(err)
-	meta := map[string]string{
-		"cwd":        relativeCwd,
-		"exit_code":  strconv.Itoa(exitCode),
-		"timeout_ms": strconv.Itoa(timeoutMS),
-	}
+	meta["exit_code"] = strconv.Itoa(exitCode)
 
 	if errors.Is(commandCtx.Err(), context.DeadlineExceeded) {
 		return Result{
@@ -105,6 +123,44 @@ func (tool bashTool) Run(ctx context.Context, args map[string]any) Result {
 		Status: StatusOK,
 		Output: formatBashOutput(stdout.String(), stderr.String(), exitCode),
 		Meta:   meta,
+	}
+}
+
+func buildBashCommand(ctx context.Context, commandText string, absoluteCwd string, engine *zeroSandbox.Engine) (*exec.Cmd, zeroSandbox.CommandPlan, error) {
+	spec := zeroSandbox.CommandSpec{
+		Name: shellExecutable(),
+		Args: shellArguments(commandText),
+		Dir:  absoluteCwd,
+	}
+	if engine != nil {
+		return engine.CommandContext(ctx, spec)
+	}
+	plan := zeroSandbox.CommandPlan{
+		Backend: zeroSandbox.Backend{
+			Name:    zeroSandbox.BackendPolicyOnly,
+			Message: "sandbox engine not provided",
+		},
+		Wrapped: false,
+		Name:    spec.Name,
+		Args:    spec.Args,
+		Dir:     spec.Dir,
+	}
+	command := exec.CommandContext(ctx, spec.Name, spec.Args...)
+	command.Dir = spec.Dir
+	return command, plan, nil
+}
+
+func addSandboxMeta(meta map[string]string, plan zeroSandbox.CommandPlan) {
+	if plan.Backend.Name == "" {
+		return
+	}
+	meta["sandbox_backend"] = string(plan.Backend.Name)
+	meta["sandbox_wrapped"] = strconv.FormatBool(plan.Wrapped)
+	if plan.Backend.Message != "" {
+		meta["sandbox_message"] = plan.Backend.Message
+	}
+	if plan.SandboxDir != "" {
+		meta["sandbox_cwd"] = plan.SandboxDir
 	}
 }
 

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 func TestMain(m *testing.M) {
@@ -174,6 +176,126 @@ func TestBashToolTimesOut(t *testing.T) {
 	}
 	if result.Meta["timeout_ms"] != "20" {
 		t.Fatalf("expected timeout_ms metadata 20, got %q", result.Meta["timeout_ms"])
+	}
+}
+
+func TestRegistryRunsBashThroughSandboxEngine(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry()
+	registry.Register(NewBashTool(root))
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        sandbox.DefaultPolicy(),
+		Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+	})
+
+	result := registry.RunWithOptions(context.Background(), "bash", map[string]any{
+		"command": helperCommand("success"),
+	}, RunOptions{
+		PermissionGranted: true,
+		Sandbox:           engine,
+		PermissionMode:    string(sandbox.PermissionUnsafe),
+		Autonomy:          string(sandbox.AutonomyMedium),
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "hello from bash") {
+		t.Fatalf("expected helper output, got %q", result.Output)
+	}
+	if result.Meta["sandbox_backend"] != string(sandbox.BackendPolicyOnly) || result.Meta["sandbox_wrapped"] != "false" {
+		t.Fatalf("sandbox metadata = %#v, want policy-only fallback", result.Meta)
+	}
+}
+
+func TestBashToolReportsDisabledPolicyOnlyRunner(t *testing.T) {
+	root := t.TempDir()
+	policy := sandbox.DefaultPolicy()
+	policy.AllowPolicyOnlyRunner = false
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        policy,
+		Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+	})
+
+	result := NewBashTool(root).(interface {
+		RunWithSandbox(context.Context, map[string]any, *sandbox.Engine) Result
+	}).RunWithSandbox(context.Background(), map[string]any{
+		"command": helperCommand("success"),
+	}, engine)
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "policy-only sandbox runner is disabled") {
+		t.Fatalf("expected disabled fallback error, got %q", result.Output)
+	}
+	if result.Meta["exit_code"] != "-1" {
+		t.Fatalf("exit_code metadata = %q, want -1", result.Meta["exit_code"])
+	}
+}
+
+func TestBashToolBuildsWrappedSandboxExecCommand(t *testing.T) {
+	root := t.TempDir()
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", root, err)
+	}
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        sandbox.DefaultPolicy(),
+		Backend: sandbox.Backend{
+			Name:       sandbox.BackendSandboxExec,
+			Available:  true,
+			Executable: "/usr/bin/sandbox-exec",
+		},
+	})
+
+	command, plan, err := buildBashCommand(context.Background(), "pwd", root, engine)
+	if err != nil {
+		t.Fatalf("buildBashCommand: %v", err)
+	}
+	if command.Path != "/usr/bin/sandbox-exec" || !plan.Wrapped {
+		t.Fatalf("command path = %q plan = %#v, want wrapped sandbox-exec", command.Path, plan)
+	}
+	if len(command.Args) < 5 || command.Args[1] != "-p" || !strings.Contains(command.Args[2], "(deny network*)") {
+		t.Fatalf("sandbox-exec args = %#v, want inline profile", command.Args)
+	}
+	if command.Dir != resolvedRoot || plan.SandboxDir != resolvedRoot {
+		t.Fatalf("dirs = command %q plan %q, want root", command.Dir, plan.SandboxDir)
+	}
+}
+
+func TestBashToolRunsWithHostSandboxBackendWhenAvailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows sandbox adapter is owned by the Windows integration slice")
+	}
+	backend := sandbox.SelectBackend(sandbox.BackendOptions{})
+	if !backend.Available || backend.Name == sandbox.BackendPolicyOnly {
+		t.Skipf("host sandbox backend unavailable: %s", backend.Message)
+	}
+	root := t.TempDir()
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        sandbox.DefaultPolicy(),
+		Backend:       backend,
+	})
+
+	result := NewBashTool(root).(interface {
+		RunWithSandbox(context.Context, map[string]any, *sandbox.Engine) Result
+	}).RunWithSandbox(context.Background(), map[string]any{
+		"command": "printf sandbox-ok",
+	}, engine)
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected host sandbox command to run, got %s: %s; meta=%#v", result.Status, result.Output, result.Meta)
+	}
+	if !strings.Contains(result.Output, "sandbox-ok") {
+		t.Fatalf("expected sandbox command output, got %q", result.Output)
+	}
+	if result.Meta["sandbox_backend"] != string(backend.Name) || result.Meta["sandbox_wrapped"] != "true" {
+		t.Fatalf("sandbox metadata = %#v, want wrapped host backend %s", result.Meta, backend.Name)
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -17,6 +17,10 @@ type RunOptions struct {
 	Sandbox           *sandbox.Engine
 }
 
+type sandboxAwareTool interface {
+	RunWithSandbox(ctx context.Context, args map[string]any, engine *sandbox.Engine) Result
+}
+
 func NewRegistry() *Registry {
 	return &Registry{tools: make(map[string]Tool)}
 }
@@ -79,6 +83,11 @@ func (registry *Registry) RunWithOptions(ctx context.Context, name string, args 
 		return errorResult("Error: Permission denied for " + name + ": " + tool.Safety().Reason)
 	}
 
+	if options.Sandbox != nil {
+		if sandboxed, ok := tool.(sandboxAwareTool); ok {
+			return sandboxed.RunWithSandbox(ctx, args, options.Sandbox)
+		}
+	}
 	return tool.Run(ctx, args)
 }
 


### PR DESCRIPTION
## Summary

Adds real sandbox-aware command execution for the Go runtime sandbox path. The sandbox backend now builds executable command plans for platform adapters instead of only reporting policy metadata. Shell tool execution uses the sandbox engine when the agent/CLI supplies one, so approved bash calls can run through the selected OS sandbox adapter.

## What changed

- Added a sandbox command runner that can wrap commands with Linux `bubblewrap` or macOS `sandbox-exec`, with a policy-only fallback for platforms or machines without an adapter.
- Wired the bash tool through the sandbox engine after policy/grant evaluation, preserving direct execution only when no engine is provided.
- Added sandbox execution metadata to tool results and propagated it through agent callbacks, JSON output, stream-json output, and persisted session events.
- Updated sandbox policy plan output so users can see whether shell commands will be wrapped by the selected backend.
- Added coverage for wrapped command plans, disabled policy-only fallback, outside-workspace rejection, registry-to-bash sandbox wiring, stream-json metadata, and real host adapter execution when available.

## Impact

This closes the remaining M6 backend gap where the policy engine existed but shell command execution was not routed through an OS sandbox adapter. On macOS hosts with `sandbox-exec`, approved shell commands now launch through the wrapper path. Linux hosts with `bwrap` get the corresponding wrapped plan; unsupported hosts retain explicit policy-only fallback behavior.

## Validation

- `go test -count=1 -p 1 ./...`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test ./tests --timeout 15000`
- `bun run build`
- `bun run smoke:build`
- `bun run smoke:go`
- `./zero --help`
- `./zero sandbox policy --json`
- `git diff --check origin/main..HEAD`

Requested review from @Vasanthdev2004 and @anandh8x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results now capture execution metadata including sandbox backend and command wrapping information
  * Bash tool now supports execution through sandbox environments
  * Stream JSON events expanded to include optional metadata fields
  * Enhanced command planning with improved metadata tracking for tool execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->