### PR TITLE
Report sandbox platform capabilities

### DIFF
--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -314,9 +314,17 @@ func formatSandboxPolicy(workspaceRoot string, policy zeroSandbox.Policy, backen
 		"mode: " + string(policy.Mode),
 		"network: " + string(policy.Network),
 		"backend: " + string(backend.Name),
-		"backend_available: " + fmt.Sprintf("%t", backend.Available),
-		"grants: " + grantsPath,
 	}
+	if backend.Platform != "" {
+		lines = append(lines, "backend_platform: "+backend.Platform)
+	}
+	lines = append(lines,
+		"backend_available: "+fmt.Sprintf("%t", backend.Available),
+		"backend_fallback: "+fmt.Sprintf("%t", backend.Fallback),
+		"backend_command_wrapping: "+fmt.Sprintf("%t", backend.CommandWrapping),
+		"backend_native_isolation: "+fmt.Sprintf("%t", backend.NativeIsolation),
+		"grants: "+grantsPath,
+	)
 	if backend.Message != "" {
 		lines = append(lines, "backend_message: "+backend.Message)
 	}

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -105,7 +105,12 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 		getwd:           func() (string, error) { return t.TempDir(), nil },
 		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
 		selectSandboxBackend: func(options sandbox.BackendOptions) sandbox.Backend {
-			return sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"}
+			return sandbox.Backend{
+				Name:     sandbox.BackendPolicyOnly,
+				Platform: "windows",
+				Fallback: true,
+				Message:  "policy-only fallback: Windows native sandbox adapter is not implemented",
+			}
 		},
 	}
 
@@ -127,7 +132,10 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 				var payload struct {
 					Policy  sandbox.Policy  `json:"policy"`
 					Backend sandbox.Backend `json:"backend"`
-					Grants  string          `json:"grantsPath"`
+					Plan    struct {
+						Restrictions []string `json:"restrictions"`
+					} `json:"plan"`
+					Grants string `json:"grantsPath"`
 				}
 				if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 					t.Fatalf("decode policy JSON: %v\n%s", err, stdout.String())
@@ -135,8 +143,27 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 				if payload.Policy.Mode != sandbox.ModeEnforce || payload.Backend.Name != sandbox.BackendPolicyOnly || payload.Grants == "" {
 					t.Fatalf("unexpected policy JSON: %#v", payload)
 				}
-			} else if !strings.Contains(stdout.String(), "Zero sandbox policy") || !strings.Contains(stdout.String(), "policy-only") {
-				t.Fatalf("unexpected policy text: %q", stdout.String())
+				if payload.Backend.Platform != "windows" || !payload.Backend.Fallback || payload.Backend.NativeIsolation || payload.Backend.CommandWrapping {
+					t.Fatalf("unexpected backend capability JSON: %#v", payload.Backend)
+				}
+				if !sandboxPolicyRestrictionContains(payload.Plan.Restrictions, "native process isolation unavailable on windows") {
+					t.Fatalf("expected JSON plan to document Windows fallback, got %#v", payload.Plan.Restrictions)
+				}
+			} else {
+				output := stdout.String()
+				for _, want := range []string{
+					"Zero sandbox policy",
+					"backend: policy-only",
+					"backend_fallback: true",
+					"backend_command_wrapping: false",
+					"backend_native_isolation: false",
+					"backend_platform: windows",
+					"Windows native sandbox adapter is not implemented",
+				} {
+					if !strings.Contains(output, want) {
+						t.Fatalf("expected policy text to contain %q, got %q", want, output)
+					}
+				}
 			}
 		})
 	}
@@ -177,4 +204,13 @@ func newSandboxTestStore(t *testing.T) *sandbox.GrantStore {
 		t.Fatalf("NewGrantStore returned error: %v", err)
 	}
 	return store
+}
+
+func sandboxPolicyRestrictionContains(restrictions []string, value string) bool {
+	for _, restriction := range restrictions {
+		if strings.Contains(restriction, value) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -11,10 +11,14 @@ type BackendOptions struct {
 }
 
 type Backend struct {
-	Name       BackendName `json:"name"`
-	Available  bool        `json:"available"`
-	Executable string      `json:"executable,omitempty"`
-	Message    string      `json:"message,omitempty"`
+	Name            BackendName `json:"name"`
+	Available       bool        `json:"available"`
+	Platform        string      `json:"platform,omitempty"`
+	Fallback        bool        `json:"fallback"`
+	CommandWrapping bool        `json:"commandWrapping"`
+	NativeIsolation bool        `json:"nativeIsolation"`
+	Executable      string      `json:"executable,omitempty"`
+	Message         string      `json:"message,omitempty"`
 }
 
 type BackendPlan struct {
@@ -36,16 +40,43 @@ func SelectBackend(options BackendOptions) Backend {
 	switch goos {
 	case "linux":
 		if path, err := lookup("bwrap"); err == nil && path != "" {
-			return Backend{Name: BackendBubblewrap, Available: true, Executable: path, Message: "bubblewrap sandbox available"}
+			return nativeBackend(goos, BackendBubblewrap, path, "bubblewrap sandbox available")
 		}
-		return Backend{Name: BackendPolicyOnly, Message: "policy-only fallback: bubblewrap is not installed"}
+		return policyOnlyBackend(goos, "policy-only fallback: bubblewrap is not installed")
 	case "darwin":
 		if path, err := lookup("sandbox-exec"); err == nil && path != "" {
-			return Backend{Name: BackendSandboxExec, Available: true, Executable: path, Message: "sandbox-exec backend available"}
+			return nativeBackend(goos, BackendSandboxExec, path, "sandbox-exec backend available")
 		}
-		return Backend{Name: BackendPolicyOnly, Message: "policy-only fallback: sandbox-exec is not available"}
+		return policyOnlyBackend(goos, "policy-only fallback: sandbox-exec is not available")
+	case "windows":
+		return policyOnlyBackend(goos, "policy-only fallback: Windows native sandbox adapter is not implemented")
 	default:
-		return Backend{Name: BackendPolicyOnly, Message: "policy-only fallback: no platform sandbox adapter is available for " + goos}
+		return policyOnlyBackend(goos, "policy-only fallback: no platform sandbox adapter is available for "+goos)
+	}
+}
+
+func nativeBackend(goos string, name BackendName, executable string, message string) Backend {
+	return Backend{
+		Name:            name,
+		Available:       true,
+		Platform:        goos,
+		Fallback:        false,
+		CommandWrapping: true,
+		NativeIsolation: true,
+		Executable:      executable,
+		Message:         message,
+	}
+}
+
+func policyOnlyBackend(goos string, message string) Backend {
+	return Backend{
+		Name:            BackendPolicyOnly,
+		Available:       false,
+		Platform:        goos,
+		Fallback:        true,
+		CommandWrapping: false,
+		NativeIsolation: false,
+		Message:         message,
 	}
 }
 
@@ -65,7 +96,12 @@ func (backend Backend) BuildPlan(workspaceRoot string, policy Policy) BackendPla
 		restrictions = append(restrictions, "destructive shell patterns denied before execution")
 	}
 	if backend.Name == BackendPolicyOnly {
-		restrictions = append(restrictions, "platform sandbox unavailable; policy engine still evaluates tool requests")
+		platform := backend.Platform
+		if platform == "" {
+			platform = "this platform"
+		}
+		restrictions = append(restrictions, "native process isolation unavailable on "+platform+"; policy engine still evaluates tool requests before execution")
+		restrictions = append(restrictions, "shell commands are not wrapped by a native platform sandbox")
 	} else if backend.Available {
 		restrictions = append(restrictions, "shell commands are wrapped through "+string(backend.Name)+" when launched by the sandbox engine")
 	}

--- a/internal/sandbox/adapters_test.go
+++ b/internal/sandbox/adapters_test.go
@@ -21,6 +21,9 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 		if backend.Name != BackendBubblewrap || !backend.Available || backend.Executable != "/usr/bin/bwrap" {
 			t.Fatalf("linux backend = %#v, want available bubblewrap", backend)
 		}
+		if backend.Platform != "linux" || backend.Fallback || !backend.CommandWrapping || !backend.NativeIsolation {
+			t.Fatalf("linux backend capabilities = %#v, want native wrapping", backend)
+		}
 	})
 
 	t.Run("darwin sandbox exec available", func(t *testing.T) {
@@ -36,6 +39,25 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 		if backend.Name != BackendSandboxExec || !backend.Available || backend.Executable != "/usr/bin/sandbox-exec" {
 			t.Fatalf("darwin backend = %#v, want available sandbox-exec", backend)
 		}
+		if backend.Platform != "darwin" || backend.Fallback || !backend.CommandWrapping || !backend.NativeIsolation {
+			t.Fatalf("darwin backend capabilities = %#v, want native wrapping", backend)
+		}
+	})
+
+	t.Run("windows falls back explicitly", func(t *testing.T) {
+		backend := SelectBackend(BackendOptions{
+			GOOS:             "windows",
+			LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },
+		})
+		if backend.Name != BackendPolicyOnly || backend.Available || backend.Platform != "windows" {
+			t.Fatalf("windows backend = %#v, want policy-only windows fallback", backend)
+		}
+		if !backend.Fallback || backend.CommandWrapping || backend.NativeIsolation {
+			t.Fatalf("windows backend capabilities = %#v, want no native wrapping", backend)
+		}
+		if !strings.Contains(backend.Message, "Windows native sandbox adapter is not implemented") {
+			t.Fatalf("expected Windows fallback message, got %q", backend.Message)
+		}
 	})
 
 	t.Run("unsupported platform falls back to policy only", func(t *testing.T) {
@@ -45,6 +67,9 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 		})
 		if backend.Name != BackendPolicyOnly || backend.Available {
 			t.Fatalf("fallback backend = %#v, want policy-only unavailable adapter", backend)
+		}
+		if backend.Platform != "plan9" || !backend.Fallback || backend.CommandWrapping || backend.NativeIsolation {
+			t.Fatalf("fallback backend capabilities = %#v, want explicit policy-only fallback", backend)
 		}
 		if !strings.Contains(backend.Message, "policy-only") {
 			t.Fatalf("expected fallback message, got %q", backend.Message)
@@ -71,4 +96,16 @@ func TestBackendBuildPlanDocumentsBestEffortIsolation(t *testing.T) {
 	if plan.Policy.Mode != policy.Mode {
 		t.Fatalf("plan policy = %#v, want %#v", plan.Policy, policy)
 	}
+	if plan.Backend.Name == BackendPolicyOnly && !restrictionContains(plan.Restrictions, "native process isolation unavailable") {
+		t.Fatalf("policy-only plan did not document native isolation fallback: %#v", plan.Restrictions)
+	}
+}
+
+func restrictionContains(restrictions []string, value string) bool {
+	for _, restriction := range restrictions {
+		if strings.Contains(restriction, value) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- report sandbox backend platform and capability fields in policy JSON/text output
- make Windows sandbox selection an explicit policy-only fallback until a native adapter exists
- document policy-only native isolation limits in backend plan restrictions

## Scope
This does not implement a real Windows native sandbox. It makes the current fallback explicit, machine-readable, and tested from non-Windows hosts.

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./internal/sandbox ./internal/cli -run 'Sandbox|SelectBackend|BackendBuildPlan'
- go test ./...
- GOCACHE=/tmp/zero-go-cache go run ./cmd/zero sandbox policy
- GOCACHE=/tmp/zero-go-cache go run ./cmd/zero sandbox policy --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox policy output now displays expanded backend capability details, including platform type, fallback support, and isolation features
  * Platform-specific restriction messages provide clearer information about isolation and command wrapping availability on different platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->