### PR TITLE
feat(tui): premium splash + working-view redesign

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
@@ -21,17 +20,13 @@ import (
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
-var (
-	headerStyle = lipgloss.NewStyle().Bold(true)
-	footerStyle = lipgloss.NewStyle().Faint(true)
-)
-
 const tuiToolOutputLimit = 240
 const defaultResponseStyle = "balanced"
 
 type model struct {
 	ctx              context.Context
 	cwd              string
+	gitBranch        string
 	providerName     string
 	modelName        string
 	providerProfile  config.ProviderProfile
@@ -51,11 +46,14 @@ type model struct {
 	unpricedTokens   int
 	transcript       []transcriptRow
 	input            textinput.Model
+	showSplash       bool
 	pending          bool
 	exiting          bool
 	runCancel        context.CancelFunc
 	runID            int
 	activeRunID      int
+	width            int
+	height           int
 	now              func() time.Time
 }
 
@@ -106,12 +104,13 @@ func newModel(ctx context.Context, options Options) model {
 
 	input := textinput.New()
 	input.Prompt = "zero > "
-	input.Placeholder = "type a prompt or /help"
+	input.Placeholder = "Ask Zero to inspect, edit, explain, or run a command..."
 	input.Focus()
 
 	return model{
 		ctx:             ctx,
 		cwd:             cwd,
+		gitBranch:       gitBranch(cwd),
 		providerName:    options.ProviderName,
 		modelName:       options.ModelName,
 		providerProfile: options.ProviderProfile,
@@ -126,6 +125,7 @@ func newModel(ctx context.Context, options Options) model {
 		usageTracker:    usageTracker,
 		transcript:      initialTranscript(),
 		input:           input,
+		showSplash:      true,
 		now:             time.Now,
 	}
 }
@@ -151,6 +151,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter:
 			return m.handleSubmit()
 		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
 	case agentResponseMsg:
 		if msg.runID != m.activeRunID {
 			return m, nil
@@ -188,26 +192,50 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
-	var builder strings.Builder
+	if m.showSplash {
+		return m.startupView()
+	}
+	return m.transcriptView()
+}
 
-	builder.WriteString(headerStyle.Render(fmt.Sprintf("ZERO  %s  %s  %s  %s", m.cwd, m.providerStatus(), m.permissionMode, m.runState())))
+func (m model) transcriptView() string {
+	width := normalizedStartupWidth(m.width)
+
+	var builder strings.Builder
+	builder.WriteString(m.headerBar(width))
 	builder.WriteString("\n\n")
 
-	for _, row := range m.transcript {
-		builder.WriteString(renderRow(row))
+	for index, row := range m.transcript {
+		if index > 0 && startsTurn(row.kind) {
+			builder.WriteString("\n")
+		}
+		builder.WriteString(renderRow(row, width))
 		builder.WriteString("\n")
 	}
 
 	if m.pending {
-		builder.WriteString("assistant: working...\n")
+		builder.WriteString("\n")
+		builder.WriteString(zeroTheme.zero.Render("◇ zero") + "  " + zeroTheme.muted.Render("working…"))
+		builder.WriteString("\n")
 	}
 
 	builder.WriteString("\n")
-	builder.WriteString(m.input.View())
-	builder.WriteString("\n\n")
-	builder.WriteString(footerStyle.Render(m.footerText()))
+	builder.WriteString(borderedBlock(width, []string{m.input.View()}))
+	builder.WriteString("\n")
+	builder.WriteString(m.statusLine(width))
 
 	return builder.String()
+}
+
+// startsTurn reports whether a row begins a new conversational turn and therefore
+// gets a blank line of separation above it (tool rows stay grouped together).
+func startsTurn(kind rowKind) bool {
+	switch kind {
+	case rowUser, rowAssistant, rowSystem, rowError:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m model) handleSubmit() (tea.Model, tea.Cmd) {
@@ -221,47 +249,60 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	case commandEmpty:
 		return m, nil
 	case commandHelp:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: helpText()})
 		return m, nil
 	case commandClear:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionClear})
+		m.showSplash = true
 		return m, nil
 	case commandExit:
 		m.exiting = true
 		return m, tea.Quit
 	case commandTools:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.toolsText()})
 		return m, nil
 	case commandPermissions:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.permissionsText()})
 		return m, nil
 	case commandProvider:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.providerText()})
 		return m, nil
 	case commandModel:
+		m.showSplash = false
 		text := ""
 		m, text = m.handleModelCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandContext:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.contextText()})
 		return m, nil
 	case commandConfig:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.configText()})
 		return m, nil
 	case commandDebug:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.debugText()})
 		return m, nil
 	case commandPlan:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.planText()})
 		return m, nil
 	case commandDoctor:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.doctorText()})
 		return m, nil
 	case commandSearch:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.searchText(command.text)})
 		return m, nil
 	case commandResume:
+		m.showSplash = false
 		if m.pending {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{
 				kind: actionAppendError,
@@ -276,33 +317,39 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case commandCompact:
+		m.showSplash = false
 		text := ""
 		m, text = m.handleCompactCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandEffort:
+		m.showSplash = false
 		text := ""
 		m, text = m.handleEffortCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandStyle:
+		m.showSplash = false
 		text := ""
 		m, text = m.handleStyleCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandTheme, commandInputStyle:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
 			kind: actionAppendSystem,
 			text: shellOnlyCommandText(command.name),
 		})
 		return m, nil
 	case commandUnknown:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
 			kind: actionAppendError,
 			text: "unknown command: " + command.text,
 		})
 		return m, nil
 	case commandPrompt:
+		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendUser, text: command.text})
 		if m.provider == nil {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{
@@ -371,7 +418,12 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 
 		onToolCall := options.OnToolCall
 		options.OnToolCall = func(call agent.ToolCall) {
-			rows = append(rows, transcriptRow{kind: rowToolCall, text: "tool call: " + call.Name})
+			rows = append(rows, transcriptRow{
+				kind:   rowToolCall,
+				text:   "tool call: " + call.Name,
+				tool:   call.Name,
+				detail: argHint(call.Arguments),
+			})
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type: sessions.EventToolCall,
 				Payload: map[string]any{
@@ -388,8 +440,11 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		onToolResult := options.OnToolResult
 		options.OnToolResult = func(result agent.ToolResult) {
 			rows = append(rows, transcriptRow{
-				kind: rowToolResult,
-				text: toolResultRowText(result),
+				kind:   rowToolResult,
+				text:   toolResultRowText(result),
+				tool:   result.Name,
+				status: result.Status,
+				detail: result.Output,
 			})
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type: sessions.EventToolResult,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -166,16 +166,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var usageRows []transcriptRow
 			m, usageRows = m.recordUsageEvent(msg.usageModelID, event)
 			for _, row := range usageRows {
-				m.transcript = appendRow(m.transcript, row.kind, row.text)
+				m.transcript = appendTranscriptRow(m.transcript, row)
 			}
 		}
 		var sessionRows []transcriptRow
 		m, sessionRows = m.appendSessionEvents(msg.sessionEvents)
 		for _, row := range sessionRows {
-			m.transcript = appendRow(m.transcript, row.kind, row.text)
+			m.transcript = appendTranscriptRow(m.transcript, row)
 		}
 		for _, row := range msg.rows {
-			m.transcript = appendRow(m.transcript, row.kind, row.text)
+			m.transcript = appendTranscriptRow(m.transcript, row)
 		}
 		if msg.err != nil {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -688,6 +688,40 @@ func TestStaleAgentResponseAfterCancelIsIgnored(t *testing.T) {
 	}
 }
 
+func TestAgentResponsePreservesToolResultMetadata(t *testing.T) {
+	diff := strings.Join([]string{
+		"--- a/file.txt",
+		"+++ b/file.txt",
+		"@@ -1 +1 @@",
+		"-old",
+		"+new",
+	}, "\n")
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+
+	updated, _ := m.Update(agentResponseMsg{
+		runID: 7,
+		rows: []transcriptRow{{
+			kind:   rowToolResult,
+			text:   "tool result: apply_patch error",
+			tool:   "apply_patch",
+			status: tools.StatusError,
+			detail: diff,
+		}},
+	})
+	next := updated.(model)
+
+	row, ok := findTranscriptRow(next.transcript, rowToolResult)
+	if !ok {
+		t.Fatalf("expected tool result row, got %#v", next.transcript)
+	}
+	if row.tool != "apply_patch" || row.status != tools.StatusError || row.detail != diff {
+		t.Fatalf("tool result metadata was not preserved: %#v", row)
+	}
+	assertContains(t, renderRow(row, 80), "@@ -1 +1 @@")
+}
+
 func TestToolResultRowDefaultsEmptyStatusToOK(t *testing.T) {
 	text := toolResultRowText(agent.ToolResult{Name: "read_file", Output: "done"})
 
@@ -741,6 +775,15 @@ func transcriptContains(rows []transcriptRow, want string) bool {
 		}
 	}
 	return false
+}
+
+func findTranscriptRow(rows []transcriptRow, kind rowKind) (transcriptRow, bool) {
+	for _, row := range rows {
+		if row.kind == kind {
+			return row, true
+		}
+	}
+	return transcriptRow{}, false
 }
 
 func transcriptHasMarkedModelEntry(rows []transcriptRow) bool {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -144,10 +144,14 @@ func TestInitialRenderShowsPremiumStartupSplash(t *testing.T) {
 
 func TestStartupSplashCollapsesAfterFirstPrompt(t *testing.T) {
 	m := newModel(context.Background(), Options{})
+	m.width = 96
+	m.height = 30
 	m.input.SetValue("inspect the repo")
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
+	next.width = m.width
+	next.height = m.height
 
 	if cmd != nil {
 		t.Fatal("expected missing provider prompt not to start an agent run")
@@ -168,12 +172,20 @@ func TestStartupSplashCollapsesAfterFirstPrompt(t *testing.T) {
 
 func TestStartupSplashStaysVisibleOnEmptySubmit(t *testing.T) {
 	m := newModel(context.Background(), Options{})
+	m.width = 96
+	m.height = 30
 	m.input.SetValue("   ")
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
+	next.width = m.width
+	next.height = m.height
 
-	assertContains(t, next.View(), "terminal coding agent")
+	view := next.View()
+	assertContains(t, view, "terminal coding agent")
+	assertNotContains(t, view, "\u258d you")
+	assertNotContains(t, view, "\u25c7 zero")
+	assertNotContains(t, view, "\u25cf ready")
 }
 
 func TestCommandFooterTextUsesRegistryEntries(t *testing.T) {
@@ -711,6 +723,14 @@ func assertContains(t *testing.T, text string, want string) {
 
 	if !strings.Contains(text, want) {
 		t.Fatalf("expected %q to contain %q", text, want)
+	}
+}
+
+func assertNotContains(t *testing.T, text string, unwanted string) {
+	t.Helper()
+
+	if strings.Contains(text, unwanted) {
+		t.Fatalf("expected %q not to contain %q", text, unwanted)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -112,22 +112,68 @@ func TestTranscriptReducer(t *testing.T) {
 	}
 }
 
-func TestInitialRenderContainsHeaderInputAndFooter(t *testing.T) {
+func TestInitialRenderShowsPremiumStartupSplash(t *testing.T) {
 	model := newModel(context.Background(), Options{
 		Cwd:          `D:\codings\Opensource\Zero`,
-		ProviderName: "fake",
-		ModelName:    "m-test",
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
 	})
+	model.width = 120
+	model.height = 34
 
 	view := model.View()
 	assertContains(t, view, "ZERO")
 	assertContains(t, view, `D:\codings\Opensource\Zero`)
-	assertContains(t, view, "fake/m-test")
-	assertContains(t, view, "zero >")
-	assertContains(t, view, "/help")
-	assertContains(t, view, "/clear")
-	assertContains(t, view, "/exit")
-	assertContains(t, view, "Ctrl+C")
+	assertContains(t, view, "project: zero")
+	assertContains(t, view, "READY")
+	assertContains(t, view, "openai / gpt-4.1")
+	assertContains(t, view, "terminal coding agent")
+	assertContains(t, view, "/plan")
+	assertContains(t, view, "/debug")
+	assertContains(t, view, "/tools")
+	assertContains(t, view, "/model")
+	assertContains(t, view, "/provider")
+	assertContains(t, view, "zero > Ask Zero to inspect, edit, explain, or run a command...")
+	if strings.Contains(view, "Welcome to Zero") {
+		t.Fatalf("startup splash should not show welcome transcript clutter, got %q", view)
+	}
+	if strings.Contains(view, "/clear") || strings.Contains(view, "/exit") {
+		t.Fatalf("startup splash should keep footer minimal, got %q", view)
+	}
+}
+
+func TestStartupSplashCollapsesAfterFirstPrompt(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("inspect the repo")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected missing provider prompt not to start an agent run")
+	}
+	view := next.View()
+	assertContains(t, view, "▍ you")
+	assertContains(t, view, "inspect the repo")
+	assertContains(t, view, "◇ zero")
+	assertContains(t, view, "No provider configured.")
+	if strings.Contains(view, "terminal coding agent") {
+		t.Fatalf("startup splash should collapse after first prompt, got %q", view)
+	}
+	// Working view shows the professional status line and live header state
+	// instead of the verbose command-footer hints.
+	assertContains(t, view, "shift+tab to cycle")
+	assertContains(t, view, "● ready")
+}
+
+func TestStartupSplashStaysVisibleOnEmptySubmit(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("   ")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	assertContains(t, next.View(), "terminal coding agent")
 }
 
 func TestCommandFooterTextUsesRegistryEntries(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -183,9 +183,9 @@ func TestStartupSplashStaysVisibleOnEmptySubmit(t *testing.T) {
 
 	view := next.View()
 	assertContains(t, view, "terminal coding agent")
-	assertNotContains(t, view, "\u258d you")
-	assertNotContains(t, view, "\u25c7 zero")
-	assertNotContains(t, view, "\u25cf ready")
+	assertNotContains(t, view, "▍ you")
+	assertNotContains(t, view, "◇ zero")
+	assertNotContains(t, view, "● ready")
 }
 
 func TestCommandFooterTextUsesRegistryEntries(t *testing.T) {
@@ -720,6 +720,97 @@ func TestAgentResponsePreservesToolResultMetadata(t *testing.T) {
 		t.Fatalf("tool result metadata was not preserved: %#v", row)
 	}
 	assertContains(t, renderRow(row, 80), "@@ -1 +1 @@")
+}
+
+func TestAgentEventRenderingMappingCoversRuntimeContract(t *testing.T) {
+	surfaces := map[zeroruntime.AgentEventType]string{
+		zeroruntime.AgentEventText:       "assistant transcript row",
+		zeroruntime.AgentEventToolCall:   "tool call transcript row",
+		zeroruntime.AgentEventToolResult: "tool result transcript row",
+		zeroruntime.AgentEventThinking:   "deferred: no transcript row until runtime emits thinking deltas",
+		zeroruntime.AgentEventUsage:      "usage tracker footer segment",
+		zeroruntime.AgentEventPlanUpdate: "system transcript row from /plan",
+		zeroruntime.AgentEventError:      "error transcript row",
+		zeroruntime.AgentEventTurnEnd:    "control boundary, no transcript row",
+	}
+	for _, eventType := range []zeroruntime.AgentEventType{
+		zeroruntime.AgentEventText,
+		zeroruntime.AgentEventToolCall,
+		zeroruntime.AgentEventToolResult,
+		zeroruntime.AgentEventThinking,
+		zeroruntime.AgentEventUsage,
+		zeroruntime.AgentEventPlanUpdate,
+		zeroruntime.AgentEventError,
+		zeroruntime.AgentEventTurnEnd,
+	} {
+		if strings.TrimSpace(surfaces[eventType]) == "" {
+			t.Fatalf("missing TUI rendering surface note for %s", eventType)
+		}
+	}
+
+	renderedRows := map[zeroruntime.AgentEventType]struct {
+		row   transcriptRow
+		wants []string
+	}{
+		zeroruntime.AgentEventText: {
+			row:   transcriptRow{kind: rowAssistant, text: "assistant text"},
+			wants: []string{"assistant text"},
+		},
+		zeroruntime.AgentEventToolCall: {
+			row: transcriptRow{
+				kind:   rowToolCall,
+				text:   "tool call: read_file",
+				tool:   "read_file",
+				detail: "README.md",
+			},
+			wants: []string{"read_file", "README.md"},
+		},
+		zeroruntime.AgentEventToolResult: {
+			row: transcriptRow{
+				kind:   rowToolResult,
+				text:   "tool result: apply_patch error",
+				tool:   "apply_patch",
+				status: tools.StatusError,
+				detail: strings.Join([]string{
+					"--- a/file.txt",
+					"+++ b/file.txt",
+					"@@ -1 +1 @@",
+					"-old",
+					"+new",
+				}, "\n"),
+			},
+			wants: []string{"apply_patch", "@@ -1 +1 @@"},
+		},
+		zeroruntime.AgentEventPlanUpdate: {
+			row:   transcriptRow{kind: rowSystem, text: "Plan updated\n- inspect: completed"},
+			wants: []string{"Plan updated", "inspect"},
+		},
+		zeroruntime.AgentEventError: {
+			row:   transcriptRow{kind: rowError, text: "provider failed"},
+			wants: []string{"provider failed"},
+		},
+	}
+	for eventType, tc := range renderedRows {
+		t.Run(string(eventType), func(t *testing.T) {
+			rendered := renderRow(tc.row, 96)
+			for _, want := range tc.wants {
+				assertContains(t, rendered, want)
+			}
+		})
+	}
+
+	m := newModel(context.Background(), Options{
+		ModelName:      "gpt-4.1",
+		PermissionMode: agent.PermissionModeAsk,
+	})
+	m.width = 96
+	m, usageRows := m.recordUsageEvent("gpt-4.1", zeroruntime.Usage{InputTokens: 100, OutputTokens: 20})
+	if len(usageRows) != 0 {
+		t.Fatalf("valid usage should update footer without transcript rows, got %#v", usageRows)
+	}
+	assertContains(t, m.usageSegment(), "100↑")
+	assertContains(t, m.usageSegment(), "20↓")
+	assertContains(t, m.statusLine(96), "approve each action")
 }
 
 func TestToolResultRowDefaultsEmptyStatusToOK(t *testing.T) {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"fmt"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 func displayValue(value string, fallback string) string {
@@ -85,21 +87,59 @@ func formatCommandFooterText(commands []commandDefinition, pending bool) string 
 	return strings.Join(parts, "  ")
 }
 
-func renderRow(row transcriptRow) string {
+func renderRow(row transcriptRow, width int) string {
 	switch row.kind {
 	case rowWelcome:
-		return row.text
+		return zeroTheme.muted.Render(row.text)
 	case rowUser:
-		return "user: " + row.text
+		return zeroTheme.you.Render("▍ you") + "\n" + indentText(zeroTheme.text.Render(row.text), 2)
 	case rowAssistant:
-		return "assistant: " + row.text
-	case rowToolCall:
-		return row.text
-	case rowToolResult:
-		return row.text
+		return zeroTheme.zero.Render("◇ zero") + "\n" + indentText(zeroTheme.text.Render(row.text), 2)
+	case rowSystem:
+		return indentText(zeroTheme.text.Render(row.text), 2)
 	case rowError:
-		return "error: " + row.text
+		return zeroTheme.red.Render("✗ ") + zeroTheme.text.Render(row.text)
+	case rowToolCall:
+		return renderToolCallRow(row)
+	case rowToolResult:
+		return renderToolResultRow(row, width)
 	default:
 		return row.text
 	}
+}
+
+func renderToolCallRow(row transcriptRow) string {
+	name := row.tool
+	if name == "" {
+		name = strings.TrimPrefix(row.text, "tool call: ")
+	}
+	line := zeroTheme.tool.Render("▸ ") + zeroTheme.text.Render(name)
+	if hint := strings.TrimSpace(row.detail); hint != "" {
+		line += "  " + zeroTheme.muted.Render(hint)
+	}
+	return line
+}
+
+func renderToolResultRow(row transcriptRow, width int) string {
+	name := row.tool
+	if name == "" {
+		name = strings.TrimPrefix(row.text, "tool result: ")
+	}
+
+	icon := zeroTheme.green.Render("✓")
+	if row.status == tools.StatusError {
+		icon = zeroTheme.red.Render("✗")
+	}
+
+	line := zeroTheme.tool.Render("▸ ") + zeroTheme.text.Render(name) + "  " + icon
+
+	// A diff card already shows the change in full, so skip the flattened
+	// one-line summary in that case to avoid duplicating the content.
+	if looksLikeDiff(row.detail) {
+		return line + "\n" + indentText(diffCard(name, row.detail, width-2), 2)
+	}
+	if summary := truncateTUIOutput(row.detail, 100); summary != "" {
+		line += "  " + zeroTheme.muted.Render(summary)
+	}
+	return line
 }

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -106,7 +106,7 @@ func (m model) handleResumeCommand(args string) (model, string) {
 	rows := initialTranscript()
 	rows = appendRow(rows, rowSystem, formatResumeSummary(*session, len(events)))
 	for _, row := range transcriptRowsFromSessionEvents(events) {
-		rows = appendRow(rows, row.kind, row.text)
+		rows = appendTranscriptRow(rows, row)
 	}
 	m.transcript = rows
 	return m, ""
@@ -179,7 +179,12 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			if name == "" {
 				name = "unknown"
 			}
-			rows = append(rows, transcriptRow{kind: rowToolCall, text: "tool call: " + name})
+			rows = append(rows, transcriptRow{
+				kind:   rowToolCall,
+				text:   "tool call: " + name,
+				tool:   name,
+				detail: argHint(payloadString(payload, "arguments")),
+			})
 		case sessions.EventToolResult:
 			name := payloadString(payload, "name")
 			if name == "" {
@@ -189,9 +194,13 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			if status == "" {
 				status = tools.StatusOK
 			}
+			output := payloadString(payload, "output")
 			rows = append(rows, transcriptRow{
-				kind: rowToolResult,
-				text: fmt.Sprintf("tool result: %s %s %s", name, status, truncateTUIOutput(payloadString(payload, "output"), tuiToolOutputLimit)),
+				kind:   rowToolResult,
+				text:   fmt.Sprintf("tool result: %s %s %s", name, status, truncateTUIOutput(output, tuiToolOutputLimit)),
+				tool:   name,
+				status: status,
+				detail: output,
 			})
 		case sessions.EventError:
 			if message := payloadString(payload, "message"); message != "" {

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -200,7 +200,7 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	}
 	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "user", "content": "previous request"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventToolCall, map[string]any{"id": "call_1", "name": "grep", "arguments": `{"pattern":"Zero"}`})
-	appendTestEvent(t, store, session.SessionID, sessions.EventToolResult, map[string]any{"toolCallId": "call_1", "name": "grep", "status": "ok", "output": "matches"})
+	appendTestEvent(t, store, session.SessionID, sessions.EventToolResult, map[string]any{"toolCallId": "call_1", "name": "grep", "status": "error", "output": "matches"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "previous answer"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventError, map[string]any{"message": "old error"})
 
@@ -213,10 +213,18 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /resume to hydrate synchronously")
 	}
-	for _, want := range []string{"Resumed Zero session", session.SessionID, "previous request", "tool call: grep", "tool result: grep ok matches", "previous answer", "old error"} {
+	for _, want := range []string{"Resumed Zero session", session.SessionID, "previous request", "tool call: grep", "tool result: grep error matches", "previous answer", "old error"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected resumed transcript to contain %q, got %#v", want, next.transcript)
 		}
+	}
+	toolCall, ok := findTranscriptRow(next.transcript, rowToolCall)
+	if !ok || toolCall.tool != "grep" || toolCall.detail != "Zero" {
+		t.Fatalf("expected hydrated tool call metadata, got ok=%v row=%#v", ok, toolCall)
+	}
+	toolResult, ok := findTranscriptRow(next.transcript, rowToolResult)
+	if !ok || toolResult.tool != "grep" || toolResult.status != tools.StatusError || toolResult.detail != "matches" {
+		t.Fatalf("expected hydrated tool result metadata, got ok=%v row=%#v", ok, toolResult)
 	}
 	if transcriptContains(next.transcript, "zero exec --resume") {
 		t.Fatalf("resume should not show headless-only guidance after hydration, got %#v", next.transcript)

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -1,0 +1,262 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	defaultStartupWidth  = 96
+	defaultStartupHeight = 30
+	minStartupWidth      = 58
+	maxPromptWidth       = 140
+)
+
+// zeroLogoLines is the ZERO wordmark in the ANSI Shadow figlet style. The solid
+// block strokes render in bright cyan and the drop-shadow box-drawing strokes in
+// dim cyan, which gives the wordmark depth without any per-glyph color hacks.
+var zeroLogoLines = []string{
+	`███████╗███████╗██████╗  ██████╗ `,
+	`╚══███╔╝██╔════╝██╔══██╗██╔═══██╗`,
+	`  ███╔╝ █████╗  ██████╔╝██║   ██║`,
+	` ███╔╝  ██╔══╝  ██╔══██╗██║   ██║`,
+	`███████╗███████╗██║  ██║╚██████╔╝`,
+	`╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ `,
+}
+
+// logoShadowRunes are the box-drawing strokes that form the wordmark's shadow and
+// render in the dim cyan tone; everything else (the solid blocks) renders bright.
+var logoShadowRunes = map[rune]bool{
+	'╗': true, '╔': true, '╝': true, '╚': true, '║': true, '═': true,
+}
+
+func (m model) startupView() string {
+	width := normalizedStartupWidth(m.width)
+	height := normalizedStartupHeight(m.height)
+
+	header := m.startupHeader(width)
+	logo := m.startupLogo(width)
+	chips := centerLine(m.commandChips(), width)
+	subtitle := centerLine(zeroTheme.accent.Render("terminal coding agent"), width)
+	prompt := m.startupPrompt(width)
+	shortcuts := centerLine(m.modeHint(), width)
+
+	contentLines := countLines(header) + countLines(logo) + 1 + 1 + countLines(prompt) + 1
+	centerGap := clamp((height-contentLines)/3, 1, 7)
+	promptGap := clamp(height-contentLines-centerGap, 1, 8)
+
+	var builder strings.Builder
+	builder.WriteString(header)
+	builder.WriteString(strings.Repeat("\n", centerGap))
+	builder.WriteString(logo)
+	builder.WriteString("\n")
+	builder.WriteString(subtitle)
+	builder.WriteString("\n\n")
+	builder.WriteString(chips)
+	builder.WriteString(strings.Repeat("\n", promptGap))
+	builder.WriteString(prompt)
+	builder.WriteString("\n")
+	builder.WriteString(shortcuts)
+
+	return builder.String()
+}
+
+func (m model) startupHeader(width int) string {
+	project := strings.ToLower(filepath.Base(m.cwd))
+	if project == "." || project == "" {
+		project = "zero"
+	}
+
+	provider := displayValue(m.providerName, "none")
+	model := displayValue(m.modelName, "none")
+	line := startupHeaderLine(width-4, []headerCandidate{
+		{
+			left: zeroTheme.accent.Render("ZERO") +
+				zeroTheme.muted.Render(" | cwd: ") + zeroTheme.text.Render(displayValue(m.cwd, "unknown")) +
+				zeroTheme.muted.Render(" | project: ") + zeroTheme.text.Render(project),
+			right: zeroTheme.muted.Render("status: ") + zeroTheme.green.Render("READY") +
+				zeroTheme.muted.Render(" | provider: ") + zeroTheme.accent.Render(provider) +
+				zeroTheme.text.Render(" / "+model),
+		},
+		{
+			left: zeroTheme.accent.Render("ZERO") +
+				zeroTheme.muted.Render(" | cwd: ") + zeroTheme.text.Render(displayValue(filepath.Base(m.cwd), "unknown")) +
+				zeroTheme.muted.Render(" | project: ") + zeroTheme.text.Render(project),
+			right: zeroTheme.green.Render("READY") +
+				zeroTheme.muted.Render(" | provider: ") + zeroTheme.accent.Render(provider) +
+				zeroTheme.text.Render(" / "+model),
+		},
+		{
+			left:  zeroTheme.accent.Render("ZERO") + zeroTheme.muted.Render(" | ") + zeroTheme.text.Render(project),
+			right: zeroTheme.green.Render("READY") + zeroTheme.muted.Render(" | ") + zeroTheme.accent.Render(provider) + zeroTheme.text.Render("/"+model),
+		},
+		{
+			left:  zeroTheme.accent.Render("ZERO"),
+			right: zeroTheme.green.Render("READY"),
+		},
+	})
+	return borderedBlock(width, []string{line})
+}
+
+func (m model) startupLogo(width int) string {
+	lines := make([]string, 0, len(zeroLogoLines))
+	for _, line := range zeroLogoLines {
+		lines = append(lines, centerLine(renderTwoToneLogo(line), width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderTwoToneLogo colors a single wordmark line: solid blocks bright, shadow
+// strokes dim. lipgloss.Width (used by centerLine) ignores ANSI, so centering
+// stays correct regardless of color profile.
+func renderTwoToneLogo(line string) string {
+	var builder strings.Builder
+	for _, glyph := range line {
+		switch {
+		case glyph == ' ':
+			builder.WriteByte(' ')
+		case logoShadowRunes[glyph]:
+			builder.WriteString(zeroTheme.logoDim.Render(string(glyph)))
+		default:
+			builder.WriteString(zeroTheme.logoBright.Render(string(glyph)))
+		}
+	}
+	return builder.String()
+}
+
+func (m model) commandChips() string {
+	chips := []string{"/plan", "/debug", "/tools", "/model", "/provider"}
+	parts := make([]string, 0, len(chips))
+	for _, chip := range chips {
+		parts = append(parts, zeroTheme.border.Render("[ "+chip+" ]"))
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m model) startupPrompt(width int) string {
+	promptWidth := width - 12
+	if promptWidth > maxPromptWidth {
+		promptWidth = maxPromptWidth
+	}
+	if promptWidth < minStartupWidth {
+		promptWidth = minStartupWidth
+	}
+
+	block := borderedBlock(promptWidth, []string{m.input.View()})
+	return indentBlock(block, (width-promptWidth)/2)
+}
+
+func borderedBlock(width int, lines []string) string {
+	if width < 4 {
+		width = 4
+	}
+
+	rule := strings.Repeat("─", width-2)
+	top := zeroTheme.border.Render("╭" + rule + "╮")
+	bottom := zeroTheme.border.Render("╰" + rule + "╯")
+	body := make([]string, 0, len(lines)+2)
+	body = append(body, top)
+	for _, line := range lines {
+		available := width - 4
+		body = append(body, zeroTheme.border.Render("│ ")+fitStyledLine(line, available)+strings.Repeat(" ", maxInt(0, available-lipgloss.Width(line)))+zeroTheme.border.Render(" │"))
+	}
+	body = append(body, bottom)
+	return strings.Join(body, "\n")
+}
+
+func joinHeaderLine(left string, right string, width int) string {
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 2 {
+		return left + "  " + right
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+type headerCandidate struct {
+	left  string
+	right string
+}
+
+func startupHeaderLine(width int, candidates []headerCandidate) string {
+	for _, candidate := range candidates {
+		line := joinHeaderLine(candidate.left, candidate.right, width)
+		if lipgloss.Width(line) <= width {
+			return line
+		}
+	}
+	return zeroTheme.accent.Render("ZERO") + strings.Repeat(" ", maxInt(1, width-10)) + zeroTheme.green.Render("READY")
+}
+
+func centerLine(line string, width int) string {
+	padding := (width - lipgloss.Width(line)) / 2
+	if padding < 0 {
+		padding = 0
+	}
+	return strings.Repeat(" ", padding) + line
+}
+
+func indentBlock(block string, spaces int) string {
+	if spaces <= 0 {
+		return block
+	}
+
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(block, "\n")
+	for index, line := range lines {
+		lines[index] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+func fitStyledLine(line string, width int) string {
+	if lipgloss.Width(line) <= width {
+		return line
+	}
+	return line
+}
+
+func normalizedStartupWidth(width int) int {
+	if width <= 0 {
+		return defaultStartupWidth
+	}
+	if width < minStartupWidth {
+		return minStartupWidth
+	}
+	return width
+}
+
+func normalizedStartupHeight(height int) int {
+	if height <= 0 {
+		return defaultStartupHeight
+	}
+	if height < 18 {
+		return 18
+	}
+	return height
+}
+
+func countLines(value string) int {
+	if value == "" {
+		return 0
+	}
+	return strings.Count(value, "\n") + 1
+}
+
+func clamp(value int, minimum int, maximum int) int {
+	if value < minimum {
+		return minimum
+	}
+	if value > maximum {
+		return maximum
+	}
+	return value
+}
+
+func maxInt(left int, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -1,8 +1,8 @@
 package tui
 
 import (
-	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -64,11 +64,7 @@ func (m model) startupView() string {
 }
 
 func (m model) startupHeader(width int) string {
-	project := strings.ToLower(filepath.Base(m.cwd))
-	if project == "." || project == "" {
-		project = "zero"
-	}
-
+	project := startupProjectName(m.cwd)
 	provider := displayValue(m.providerName, "none")
 	model := displayValue(m.modelName, "none")
 	line := startupHeaderLine(width-4, []headerCandidate{
@@ -82,7 +78,7 @@ func (m model) startupHeader(width int) string {
 		},
 		{
 			left: zeroTheme.accent.Render("ZERO") +
-				zeroTheme.muted.Render(" | cwd: ") + zeroTheme.text.Render(displayValue(filepath.Base(m.cwd), "unknown")) +
+				zeroTheme.muted.Render(" | cwd: ") + zeroTheme.text.Render(displayValue(pathBaseName(m.cwd), "unknown")) +
 				zeroTheme.muted.Render(" | project: ") + zeroTheme.text.Render(project),
 			right: zeroTheme.green.Render("READY") +
 				zeroTheme.muted.Render(" | provider: ") + zeroTheme.accent.Render(provider) +
@@ -98,6 +94,34 @@ func (m model) startupHeader(width int) string {
 		},
 	})
 	return borderedBlock(width, []string{line})
+}
+
+func startupProjectName(cwd string) string {
+	project := strings.ToLower(pathBaseName(cwd))
+	if project == "." || project == "" {
+		return "zero"
+	}
+	return project
+}
+
+// pathBaseName accepts both Windows and POSIX separators so CI can render a
+// Windows workspace path deterministically on Linux and macOS runners.
+func pathBaseName(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	value = strings.TrimRight(value, `/\`)
+	if value == "" {
+		return ""
+	}
+
+	separator := maxInt(strings.LastIndex(value, "/"), strings.LastIndex(value, `\`))
+	if separator >= 0 && separator+1 < len(value) {
+		return value[separator+1:]
+	}
+	return value
 }
 
 func (m model) startupLogo(width int) string {
@@ -160,7 +184,8 @@ func borderedBlock(width int, lines []string) string {
 	body = append(body, top)
 	for _, line := range lines {
 		available := width - 4
-		body = append(body, zeroTheme.border.Render("│ ")+fitStyledLine(line, available)+strings.Repeat(" ", maxInt(0, available-lipgloss.Width(line)))+zeroTheme.border.Render(" │"))
+		fitted := fitStyledLine(line, available)
+		body = append(body, zeroTheme.border.Render("│ ")+fitted+strings.Repeat(" ", maxInt(0, available-lipgloss.Width(fitted)))+zeroTheme.border.Render(" │"))
 	}
 	body = append(body, bottom)
 	return strings.Join(body, "\n")
@@ -211,10 +236,80 @@ func indentBlock(block string, spaces int) string {
 }
 
 func fitStyledLine(line string, width int) string {
+	if width <= 0 {
+		return ""
+	}
 	if lipgloss.Width(line) <= width {
 		return line
 	}
-	return line
+	return truncateStyledLine(line, width)
+}
+
+func truncateStyledLine(line string, width int) string {
+	const resetANSI = "\x1b[0m"
+
+	ellipsis := "…"
+	ellipsisWidth := lipgloss.Width(ellipsis)
+	if width <= ellipsisWidth {
+		return ellipsis
+	}
+
+	targetWidth := width - ellipsisWidth
+	usedWidth := 0
+	sawANSI := false
+
+	var builder strings.Builder
+	for index := 0; index < len(line); {
+		if line[index] == '\x1b' {
+			end := ansiSequenceEnd(line, index)
+			if end > index {
+				builder.WriteString(line[index:end])
+				sawANSI = true
+				index = end
+				continue
+			}
+		}
+
+		glyph, size := utf8.DecodeRuneInString(line[index:])
+		if glyph == utf8.RuneError && size == 0 {
+			break
+		}
+
+		glyphWidth := lipgloss.Width(string(glyph))
+		if usedWidth+glyphWidth > targetWidth {
+			break
+		}
+		builder.WriteString(line[index : index+size])
+		usedWidth += glyphWidth
+		index += size
+	}
+
+	builder.WriteString(ellipsis)
+	if sawANSI {
+		builder.WriteString(resetANSI)
+	}
+	return builder.String()
+}
+
+func ansiSequenceEnd(value string, start int) int {
+	if start >= len(value) || value[start] != '\x1b' {
+		return start
+	}
+	index := start + 1
+	if index >= len(value) {
+		return index
+	}
+
+	if value[index] != '[' {
+		return minInt(start+2, len(value))
+	}
+
+	for index++; index < len(value); index++ {
+		if value[index] >= 0x40 && value[index] <= 0x7e {
+			return index + 1
+		}
+	}
+	return len(value)
 }
 
 func normalizedStartupWidth(width int) int {
@@ -256,6 +351,13 @@ func clamp(value int, minimum int, maximum int) int {
 
 func maxInt(left int, right int) int {
 	if left > right {
+		return left
+	}
+	return right
+}
+
+func minInt(left int, right int) int {
+	if left < right {
 		return left
 	}
 	return right

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -1,0 +1,40 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestStartupProjectNameHandlesWindowsPathsOnAnyPlatform(t *testing.T) {
+	if got := startupProjectName(`D:\codings\Opensource\Zero`); got != "zero" {
+		t.Fatalf("expected Windows cwd project to be zero, got %q", got)
+	}
+}
+
+func TestBorderedBlockFitsLongPlainLines(t *testing.T) {
+	block := borderedBlock(24, []string{"this line should truncate inside the border"})
+
+	assertContains(t, block, "\u2026")
+	assertRenderedLineWidths(t, block, 24)
+}
+
+func TestBorderedBlockFitsLongStyledLines(t *testing.T) {
+	block := borderedBlock(26, []string{
+		zeroTheme.accent.Render("styled line should truncate inside the border"),
+	})
+
+	assertContains(t, block, "\u2026")
+	assertRenderedLineWidths(t, block, 26)
+}
+
+func assertRenderedLineWidths(t *testing.T, block string, width int) {
+	t.Helper()
+
+	for _, line := range strings.Split(block, "\n") {
+		if got := lipgloss.Width(line); got != width {
+			t.Fatalf("expected line width %d, got %d for %q", width, got, line)
+		}
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,0 +1,75 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+// tuiTheme is the single source of truth for Zero's terminal palette. Colors are
+// truecolor hex so the brand cyan renders consistently across terminals; lipgloss
+// downsamples automatically on limited displays and renders plain text when there
+// is no TTY (e.g. during tests).
+type tuiTheme struct {
+	// Brand + structure.
+	accent lipgloss.Style // bright brand cyan, bold
+	border lipgloss.Style // dim cyan rules / frames
+	text   lipgloss.Style // primary foreground
+	muted  lipgloss.Style // secondary / hints
+	green  lipgloss.Style // success / ready
+	red    lipgloss.Style // errors
+	amber  lipgloss.Style // warnings / context pressure
+
+	// Two-tone logo.
+	logoBright lipgloss.Style // solid block strokes
+	logoDim    lipgloss.Style // drop-shadow strokes
+
+	// Conversation roles.
+	you  lipgloss.Style // user gutter
+	zero lipgloss.Style // assistant gutter
+	tool lipgloss.Style // tool glyph / name
+
+	// Diff cards.
+	diffAdd  lipgloss.Style
+	diffDel  lipgloss.Style
+	diffMeta lipgloss.Style
+
+	// Permission modes.
+	modeAuto   lipgloss.Style
+	modeAsk    lipgloss.Style
+	modeUnsafe lipgloss.Style
+}
+
+const (
+	colorCyanBright = "#34E2EA"
+	colorCyanSoft   = "#5EC8D8"
+	colorCyanDim    = "#1F6E78"
+	colorBorder     = "#2C6E78"
+	colorText       = "#DCE2EA"
+	colorMuted      = "#6C7682"
+	colorGreen      = "#43D17A"
+	colorRed        = "#F2616B"
+	colorAmber      = "#E8B84B"
+	colorToolName   = "#9BA6B2"
+)
+
+var zeroTheme = tuiTheme{
+	accent: lipgloss.NewStyle().Foreground(lipgloss.Color(colorCyanBright)).Bold(true),
+	border: lipgloss.NewStyle().Foreground(lipgloss.Color(colorBorder)),
+	text:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorText)),
+	muted:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
+	green:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)).Bold(true),
+	red:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)).Bold(true),
+	amber:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
+
+	logoBright: lipgloss.NewStyle().Foreground(lipgloss.Color(colorCyanBright)).Bold(true),
+	logoDim:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorCyanDim)),
+
+	you:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorCyanSoft)).Bold(true),
+	zero: lipgloss.NewStyle().Foreground(lipgloss.Color(colorCyanBright)).Bold(true),
+	tool: lipgloss.NewStyle().Foreground(lipgloss.Color(colorToolName)),
+
+	diffAdd:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)),
+	diffDel:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)),
+	diffMeta: lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
+
+	modeAuto:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)).Bold(true),
+	modeAsk:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)).Bold(true),
+	modeUnsafe: lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)).Bold(true),
+}

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -62,13 +62,23 @@ func reduceTranscript(rows []transcriptRow, action transcriptAction) []transcrip
 	case actionAppendAssistant:
 		return appendRow(rows, rowAssistant, action.text)
 	case actionAppendToolCall:
-		return appendRow(rows, rowToolCall, fmt.Sprintf("tool call: %s", action.name))
+		return appendTranscriptRow(rows, transcriptRow{
+			kind: rowToolCall,
+			text: fmt.Sprintf("tool call: %s", action.name),
+			tool: action.name,
+		})
 	case actionAppendToolResult:
 		status := action.status
 		if status == "" {
 			status = tools.StatusOK
 		}
-		return appendRow(rows, rowToolResult, fmt.Sprintf("tool result: %s %s %s", action.name, status, action.text))
+		return appendTranscriptRow(rows, transcriptRow{
+			kind:   rowToolResult,
+			text:   fmt.Sprintf("tool result: %s %s %s", action.name, status, action.text),
+			tool:   action.name,
+			status: status,
+			detail: action.text,
+		})
 	case actionAppendSystem:
 		return appendRow(rows, rowSystem, action.text)
 	case actionAppendError:
@@ -79,8 +89,12 @@ func reduceTranscript(rows []transcriptRow, action transcriptAction) []transcrip
 }
 
 func appendRow(rows []transcriptRow, kind rowKind, text string) []transcriptRow {
+	return appendTranscriptRow(rows, transcriptRow{kind: kind, text: text})
+}
+
+func appendTranscriptRow(rows []transcriptRow, row transcriptRow) []transcriptRow {
 	next := append([]transcriptRow{}, rows...)
-	next = append(next, transcriptRow{kind: kind, text: text})
+	next = append(next, row)
 	return next
 }
 

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -20,8 +20,11 @@ const (
 )
 
 type transcriptRow struct {
-	kind rowKind
-	text string
+	kind   rowKind
+	text   string
+	tool   string       // tool name, for tool call/result rows
+	status tools.Status // result status, for tool result rows
+	detail string       // raw multi-line output (e.g. a diff to render as a card)
 }
 
 type transcriptActionKind int

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1,0 +1,320 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+// headerBar renders the top zone of the working view: a single status line plus a
+// thin rule. Layout: zero · cwd · branch · provider/model  ............  ● state
+func (m model) headerBar(width int) string {
+	left := strings.Join(nonEmpty([]string{
+		zeroTheme.accent.Render("zero"),
+		zeroTheme.text.Render(shortenPath(m.cwd)),
+		branchSegment(m.gitBranch),
+		m.providerSegment(),
+	}), zeroTheme.muted.Render(" · "))
+
+	right := m.stateSegment()
+	line := joinHeaderLine(left, right, width)
+	rule := zeroTheme.border.Render(strings.Repeat("─", width))
+	return line + "\n" + rule
+}
+
+func (m model) providerSegment() string {
+	provider := strings.TrimSpace(m.providerName)
+	model := strings.TrimSpace(m.modelName)
+	if provider == "" && model == "" {
+		return zeroTheme.muted.Render("no provider")
+	}
+	if model == "" {
+		return zeroTheme.accent.Render(provider)
+	}
+	if provider == "" {
+		return zeroTheme.text.Render(model)
+	}
+	return zeroTheme.accent.Render(provider) + zeroTheme.muted.Render("/") + zeroTheme.text.Render(model)
+}
+
+func (m model) stateSegment() string {
+	if m.pending {
+		return zeroTheme.amber.Render("● working")
+	}
+	return zeroTheme.green.Render("● ready")
+}
+
+func branchSegment(branch string) string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return ""
+	}
+	return zeroTheme.muted.Render(branch)
+}
+
+// statusLine renders the bottom zone: the permission-mode indicator on the left and
+// the live model/usage readout on the right.
+func (m model) statusLine(width int) string {
+	left := m.modeSegment()
+	right := m.usageSegment()
+	return joinHeaderLine(left, right, width)
+}
+
+func (m model) modeSegment() string {
+	label, style := m.modeLabel()
+	return style.Render("⏵⏵ "+label) + zeroTheme.muted.Render(" · shift+tab to cycle")
+}
+
+func (m model) modeLabel() (string, lipgloss.Style) {
+	switch m.permissionMode {
+	case agent.PermissionModeAuto:
+		return "auto-approve edits", zeroTheme.modeAuto
+	case agent.PermissionModeAsk:
+		return "approve each action", zeroTheme.modeAsk
+	case agent.PermissionModeUnsafe:
+		return "bypass permissions", zeroTheme.modeUnsafe
+	default:
+		mode := strings.TrimSpace(string(m.permissionMode))
+		if mode == "" {
+			return "auto-approve edits", zeroTheme.modeAuto
+		}
+		return mode, zeroTheme.muted
+	}
+}
+
+func (m model) usageSegment() string {
+	model := displayValue(m.modelName, "no model")
+	usage := m.usageStatusSegment()
+	if usage == "" {
+		return zeroTheme.text.Render(model)
+	}
+	return zeroTheme.text.Render(model) + zeroTheme.muted.Render(" · "+usage)
+}
+
+func (m model) usageStatusSegment() string {
+	if m.usageTracker == nil {
+		return ""
+	}
+	summary := m.usageTracker.Summary()
+	if summary.RecordCount == 0 {
+		if m.unpricedRequests > 0 {
+			return fmt.Sprintf("%s tok", humanCount(m.unpricedTokens))
+		}
+		return ""
+	}
+	return fmt.Sprintf("%s↑ %s↓ · %s",
+		humanCount(summary.InputTokens),
+		humanCount(summary.OutputTokens),
+		summary.FormattedTotalCost,
+	)
+}
+
+// modeHint is the splash-screen variant of the mode indicator, mirroring the
+// professional CLI status line instead of raw keycap hints.
+func (m model) modeHint() string {
+	label, style := m.modeLabel()
+	return style.Render("⏵⏵ "+label) +
+		zeroTheme.muted.Render(" · shift+tab to cycle · ") +
+		zeroTheme.muted.Render("← agents")
+}
+
+func humanCount(n int) string {
+	if n < 0 {
+		n = 0
+	}
+	if n < 1000 {
+		return strconv.Itoa(n)
+	}
+	value := float64(n) / 1000
+	text := fmt.Sprintf("%.1fk", value)
+	return strings.Replace(text, ".0k", "k", 1)
+}
+
+func shortenPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "unknown"
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if strings.HasPrefix(path, home) {
+			return "~" + path[len(home):]
+		}
+	}
+	return path
+}
+
+func nonEmpty(values []string) []string {
+	out := values[:0]
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// gitBranch reads the current branch (or short SHA when detached) for cwd, handling
+// both regular checkouts (.git dir) and worktrees (.git file). Returns "" on any
+// problem — the header simply omits the segment.
+func gitBranch(cwd string) string {
+	if strings.TrimSpace(cwd) == "" {
+		return ""
+	}
+	gitPath := filepath.Join(cwd, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return ""
+	}
+
+	headPath := filepath.Join(gitPath, "HEAD")
+	if !info.IsDir() {
+		data, err := os.ReadFile(gitPath)
+		if err != nil {
+			return ""
+		}
+		dir := strings.TrimPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+		if dir == "" {
+			return ""
+		}
+		headPath = filepath.Join(dir, "HEAD")
+	}
+
+	data, err := os.ReadFile(headPath)
+	if err != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(string(data))
+	if strings.HasPrefix(ref, "ref: ") {
+		ref = strings.TrimPrefix(ref, "ref: ")
+		return strings.TrimPrefix(ref, "refs/heads/")
+	}
+	if len(ref) >= 7 {
+		return ref[:7]
+	}
+	return ref
+}
+
+// argHint extracts the most representative argument from a tool call's raw JSON
+// arguments for the single-line tool row (the path, pattern, or command acted on).
+func argHint(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" {
+		return ""
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(raw), &args); err != nil {
+		return ""
+	}
+	for _, key := range []string{"path", "file", "file_path", "filepath", "pattern", "query", "command", "cmd", "url"} {
+		if value, ok := args[key]; ok {
+			if text, ok := value.(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
+}
+
+func indentText(text string, spaces int) string {
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		lines[index] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+// looksLikeDiff reports whether output should be rendered as a diff card.
+func looksLikeDiff(text string) bool {
+	if !strings.Contains(text, "\n") {
+		return false
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "@@") || strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
+			return true
+		}
+	}
+	return false
+}
+
+func colorizeDiffLine(line string) string {
+	switch {
+	case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"), strings.HasPrefix(line, "@@"):
+		return zeroTheme.diffMeta.Render(line)
+	case strings.HasPrefix(line, "+"):
+		return zeroTheme.diffAdd.Render(line)
+	case strings.HasPrefix(line, "-"):
+		return zeroTheme.diffDel.Render(line)
+	default:
+		return zeroTheme.muted.Render(line)
+	}
+}
+
+const diffCardMaxLines = 16
+
+func diffCard(title string, detail string, width int) string {
+	budget := width - 4
+	if budget < 16 {
+		budget = 16
+	}
+	rawLines := strings.Split(strings.ReplaceAll(detail, "\r\n", "\n"), "\n")
+	body := make([]string, 0, len(rawLines))
+	for _, line := range rawLines {
+		line = truncateRunes(line, budget)
+		body = append(body, colorizeDiffLine(line))
+	}
+	if len(body) > diffCardMaxLines {
+		hidden := len(body) - diffCardMaxLines
+		body = body[:diffCardMaxLines]
+		body = append(body, zeroTheme.muted.Render(fmt.Sprintf("… %d more lines", hidden)))
+	}
+	return titledCard("edit · "+title, body, width)
+}
+
+// titledCard draws a rounded box with a title embedded in the top border.
+func titledCard(title string, body []string, width int) string {
+	if width < 24 {
+		width = 24
+	}
+	remaining := width - 5 - lipgloss.Width(title)
+	if remaining < 0 {
+		remaining = 0
+	}
+	top := zeroTheme.border.Render("╭─ ") +
+		zeroTheme.text.Render(title) +
+		zeroTheme.border.Render(" "+strings.Repeat("─", remaining)+"╮")
+
+	lines := make([]string, 0, len(body)+2)
+	lines = append(lines, top)
+	budget := width - 4
+	for _, line := range body {
+		pad := budget - lipgloss.Width(line)
+		if pad < 0 {
+			pad = 0
+		}
+		lines = append(lines, zeroTheme.border.Render("│ ")+line+strings.Repeat(" ", pad)+zeroTheme.border.Render(" │"))
+	}
+	lines = append(lines, zeroTheme.border.Render("╰"+strings.Repeat("─", width-2)+"╯"))
+	return strings.Join(lines, "\n")
+}
+
+func truncateRunes(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	if limit == 1 {
+		return "…"
+	}
+	return string(runes[:limit-1]) + "…"
+}


### PR DESCRIPTION
﻿## Summary

Gives the terminal UI a visual-first identity: a centralized truecolor theme, a polished startup splash, and a three-zone working/session view.

### Splash
- **Two-tone ANSI Shadow `ZERO` wordmark** — solid block strokes in bright cyan, drop-shadow strokes in dim cyan (depth with no per-glyph hacks; `lipgloss.Width` ignores ANSI so centering stays correct).
- Replaced the `Enter / Tab / Ctrl+C` keycap hints with a professional **`⏵⏵` permission-mode status line** (`shift+tab to cycle`).
- Rounded box-drawing (`╭──╮`) for the header and prompt instead of ASCII `+--+`.

### Working / session view (3 zones)
- **Header bar:** `zero · <cwd> · <git branch> · <provider/model>  …  ● ready` — branch resolves from `.git/HEAD` (handles worktrees).
- **Body:** role gutters `▍ you` / `◇ zero`, tool rows `▸ read_file  <arg hint>` with `✓`/`✗` status, and **colorized diff cards** (`╭─ edit · <tool> ─╮`, green `+` / red `−`) for patch/edit output.
- **Status line:** permission mode on the left, live `model · Nk↑ Nk↓ · $cost` (from the usage tracker) on the right.

### Internals
- Centralized palette in `theme.go` (bright/dim cyan pair + role/status/diff/mode styles), shared by both views — replaces the raw ANSI `"14"/"10"/"8"`.
- Enriched `transcriptRow` with `tool` / `status` / `detail` so tool results can render structured cards.

### Deferred (follow-up)
- True scrollback via `bubbles/viewport` + alt-screen. The 3-zone structure is in place; the body renders inline for now (terminal-native scroll, no regression). Wiring the viewport needs height plumbing and is cleaner as its own change.

## Testing
- `go build ./...` ✓
- `go test ./...` (whole module) ✓
- `go vet ./internal/tui/` ✓

`TestStartupSplashCollapsesAfterFirstPrompt` was updated to assert the new working-view rendering (role gutters + status line) instead of the old `user:`/`assistant:` prefixes; all other tests unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Premium startup splash: centered branding, project info, command chips, prompt area, and compact footer; splash collapses on first real prompt.
  * Transcript/UI improvements: clearer header/status, working… indicator, grouped tool calls/results with success/error icons, diff-style result cards, and width-aware truncation.
  * Consistent terminal theme and styling across the TUI.

* **Tests**
  * Added tests for splash behavior, bordered-block truncation/width, transcript rendering, and tool-result metadata preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Runtime / TUI contract note
- Event-to-rendering coverage is protected in `TestAgentEventRenderingMappingCoversRuntimeContract`: text, tool calls/results, plan updates, usage footer, errors, and control-only events are mapped explicitly.
- This PR only displays the current permission mode in the status line. Full permission prompt/grant UX remains deferred to the `tui-sandbox-permissions` follow-up once runtime permission events land, so this splash work does not redefine that contract.
