### PR TITLE
Verify update release assets

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -9,10 +9,11 @@ For M2 this command is intentionally check-only:
 - It exits with code `1` when the release check cannot be completed.
 - `--json` prints the same result in a machine-readable format for scripts and CI.
 - Release checks time out after 5 seconds by default.
+- It validates that the latest release includes the expected archive and matching `.sha256` asset for the current platform.
 
 The release endpoint resolves in this order:
 
-- `options.endpoint` when calling `checkForUpdate` from code.
+- `Options.Endpoint` when calling `update.Check` from code.
 - `ZERO_UPDATE_RELEASE_URL` from the environment.
 - `https://api.github.com/repos/Gitlawb/zero/releases/latest`.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -246,10 +246,21 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 
 func TestRunUpdateCheckTextAndJSON(t *testing.T) {
 	result := update.Result{
-		CurrentVersion:  "dev",
-		LatestVersion:   "0.2.0",
-		ReleaseURL:      "https://github.com/Gitlawb/zero/releases/tag/v0.2.0",
-		TagName:         "v0.2.0",
+		CurrentVersion: "dev",
+		LatestVersion:  "0.2.0",
+		ReleaseURL:     "https://github.com/Gitlawb/zero/releases/tag/v0.2.0",
+		TagName:        "v0.2.0",
+		ReleaseAsset: update.AssetCheck{
+			Platform:      "linux",
+			Arch:          "x64",
+			ArchiveName:   "zero-v0.2.0-linux-x64.tar.gz",
+			ArchiveURL:    "https://example.test/zero-v0.2.0-linux-x64.tar.gz",
+			ChecksumName:  "zero-v0.2.0-linux-x64.tar.gz.sha256",
+			ChecksumURL:   "https://example.test/zero-v0.2.0-linux-x64.tar.gz.sha256",
+			ArchiveFound:  true,
+			ChecksumFound: true,
+			Verified:      true,
+		},
 		UpdateAvailable: true,
 	}
 	deps := appDeps{
@@ -268,6 +279,9 @@ func TestRunUpdateCheckTextAndJSON(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Update available: dev -> 0.2.0") {
 		t.Fatalf("unexpected update text: %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "Release asset: zero-v0.2.0-linux-x64.tar.gz") || !strings.Contains(stdout.String(), "Checksum asset: zero-v0.2.0-linux-x64.tar.gz.sha256") {
+		t.Fatalf("unexpected update asset text: %q", stdout.String())
+	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
@@ -279,11 +293,20 @@ func TestRunUpdateCheckTextAndJSON(t *testing.T) {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
 	var payload struct {
-		CurrentVersion  string `json:"currentVersion"`
-		LatestVersion   string `json:"latestVersion"`
-		ReleaseURL      string `json:"releaseUrl"`
-		TagName         string `json:"tagName"`
-		UpdateAvailable bool   `json:"updateAvailable"`
+		CurrentVersion string `json:"currentVersion"`
+		LatestVersion  string `json:"latestVersion"`
+		ReleaseURL     string `json:"releaseUrl"`
+		TagName        string `json:"tagName"`
+		ReleaseAsset   struct {
+			Platform      string `json:"platform"`
+			Arch          string `json:"arch"`
+			ArchiveName   string `json:"archiveName"`
+			ChecksumName  string `json:"checksumName"`
+			ArchiveFound  bool   `json:"archiveFound"`
+			ChecksumFound bool   `json:"checksumFound"`
+			Verified      bool   `json:"verified"`
+		} `json:"releaseAsset"`
+		UpdateAvailable bool `json:"updateAvailable"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("update JSON did not decode: %v\n%s", err, stdout.String())
@@ -292,6 +315,9 @@ func TestRunUpdateCheckTextAndJSON(t *testing.T) {
 		payload.LatestVersion != result.LatestVersion ||
 		payload.ReleaseURL != result.ReleaseURL ||
 		payload.TagName != result.TagName ||
+		payload.ReleaseAsset.ArchiveName != result.ReleaseAsset.ArchiveName ||
+		payload.ReleaseAsset.ChecksumName != result.ReleaseAsset.ChecksumName ||
+		!payload.ReleaseAsset.Verified ||
 		payload.UpdateAvailable != result.UpdateAvailable {
 		t.Fatalf("unexpected update JSON: %#v", payload)
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -19,16 +20,35 @@ const (
 )
 
 type Release struct {
-	TagName string `json:"tag_name"`
-	HTMLURL string `json:"html_url"`
+	TagName string  `json:"tag_name"`
+	HTMLURL string  `json:"html_url"`
+	Assets  []Asset `json:"assets"`
+}
+
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url,omitempty"`
 }
 
 type Result struct {
-	CurrentVersion  string `json:"currentVersion"`
-	LatestVersion   string `json:"latestVersion"`
-	ReleaseURL      string `json:"releaseUrl"`
-	TagName         string `json:"tagName"`
-	UpdateAvailable bool   `json:"updateAvailable"`
+	CurrentVersion  string     `json:"currentVersion"`
+	LatestVersion   string     `json:"latestVersion"`
+	ReleaseURL      string     `json:"releaseUrl"`
+	TagName         string     `json:"tagName"`
+	ReleaseAsset    AssetCheck `json:"releaseAsset"`
+	UpdateAvailable bool       `json:"updateAvailable"`
+}
+
+type AssetCheck struct {
+	Platform      string `json:"platform"`
+	Arch          string `json:"arch"`
+	ArchiveName   string `json:"archiveName"`
+	ArchiveURL    string `json:"archiveUrl,omitempty"`
+	ChecksumName  string `json:"checksumName"`
+	ChecksumURL   string `json:"checksumUrl,omitempty"`
+	ArchiveFound  bool   `json:"archiveFound"`
+	ChecksumFound bool   `json:"checksumFound"`
+	Verified      bool   `json:"verified"`
 }
 
 // Options configures a release update check.
@@ -39,6 +59,8 @@ type Options struct {
 	Endpoint   string
 	Repository string
 	Timeout    time.Duration
+	GOOS       string
+	GOARCH     string
 	// Fetch overrides the release fetcher for tests and alternate transports.
 	Fetch func(context.Context, string) (Release, error)
 }
@@ -119,6 +141,10 @@ func Check(ctx context.Context, options Options) (Result, error) {
 	if releaseURL == "" {
 		releaseURL = fmt.Sprintf("https://github.com/%s/releases/tag/%s", repository, release.TagName)
 	}
+	assetCheck, err := verifyReleaseAssets(release, latestVersion, options)
+	if err != nil {
+		return Result{}, err
+	}
 	latestParts, err := parseSemverNormalized(latestVersion)
 	if err != nil {
 		return Result{}, err
@@ -132,22 +158,38 @@ func Check(ctx context.Context, options Options) (Result, error) {
 		LatestVersion:   latestVersion,
 		ReleaseURL:      releaseURL,
 		TagName:         release.TagName,
+		ReleaseAsset:    assetCheck,
 		UpdateAvailable: compareSemverParts(latestParts, currentParts) > 0,
 	}, nil
 }
 
 func Format(result Result) string {
 	if result.UpdateAvailable {
-		return strings.Join([]string{
+		lines := []string{
 			fmt.Sprintf("[zero] Update available: %s -> %s", result.CurrentVersion, result.LatestVersion),
 			"Release: " + result.ReleaseURL,
-			"Download the matching release asset for your platform, then replace the current zero binary.",
-		}, "\n")
+		}
+		lines = appendAssetLines(lines, result.ReleaseAsset)
+		lines = append(lines, "Download the matching release asset for your platform, then replace the current zero binary.")
+		return strings.Join(lines, "\n")
 	}
-	return strings.Join([]string{
+	lines := []string{
 		fmt.Sprintf("[zero] up to date (%s)", result.CurrentVersion),
 		"Latest release: " + result.ReleaseURL,
-	}, "\n")
+	}
+	lines = appendAssetLines(lines, result.ReleaseAsset)
+	return strings.Join(lines, "\n")
+}
+
+func appendAssetLines(lines []string, asset AssetCheck) []string {
+	if asset.ArchiveName == "" {
+		return lines
+	}
+	lines = append(lines, "Release asset: "+asset.ArchiveName)
+	if asset.ChecksumName != "" {
+		lines = append(lines, "Checksum asset: "+asset.ChecksumName)
+	}
+	return lines
 }
 
 func fetchRelease(ctx context.Context, endpoint string) (release Release, err error) {
@@ -207,6 +249,82 @@ func resolveEndpoint(endpointOrRepository string, repository string) (string, er
 		return "", fmt.Errorf("invalid update endpoint %q: use a full URL or an owner/repo slug like %s", value, repository)
 	}
 	return value, nil
+}
+
+func verifyReleaseAssets(release Release, version string, options Options) (AssetCheck, error) {
+	assetCheck, err := expectedAssetCheck(version, options.GOOS, options.GOARCH)
+	if err != nil {
+		return AssetCheck{}, err
+	}
+	for _, asset := range release.Assets {
+		name := strings.TrimSpace(asset.Name)
+		switch name {
+		case assetCheck.ArchiveName:
+			assetCheck.ArchiveFound = true
+			assetCheck.ArchiveURL = strings.TrimSpace(asset.BrowserDownloadURL)
+		case assetCheck.ChecksumName:
+			assetCheck.ChecksumFound = true
+			assetCheck.ChecksumURL = strings.TrimSpace(asset.BrowserDownloadURL)
+		}
+	}
+	assetCheck.Verified = assetCheck.ArchiveFound && assetCheck.ChecksumFound
+	if assetCheck.Verified {
+		return assetCheck, nil
+	}
+	missing := []string{}
+	if !assetCheck.ArchiveFound {
+		missing = append(missing, assetCheck.ArchiveName)
+	}
+	if !assetCheck.ChecksumFound {
+		missing = append(missing, assetCheck.ChecksumName)
+	}
+	return AssetCheck{}, fmt.Errorf("release metadata missing expected asset(s) for %s-%s: %s", assetCheck.Platform, assetCheck.Arch, strings.Join(missing, ", "))
+}
+
+func expectedAssetCheck(version string, goos string, goarch string) (AssetCheck, error) {
+	platform, err := releasePlatform(firstNonEmpty(goos, runtime.GOOS))
+	if err != nil {
+		return AssetCheck{}, err
+	}
+	arch, err := releaseArch(firstNonEmpty(goarch, runtime.GOARCH))
+	if err != nil {
+		return AssetCheck{}, err
+	}
+	extension := "tar.gz"
+	if platform == "windows" {
+		extension = "zip"
+	}
+	archiveName := fmt.Sprintf("zero-v%s-%s-%s.%s", version, platform, arch, extension)
+	return AssetCheck{
+		Platform:     platform,
+		Arch:         arch,
+		ArchiveName:  archiveName,
+		ChecksumName: archiveName + ".sha256",
+	}, nil
+}
+
+func releasePlatform(goos string) (string, error) {
+	switch strings.TrimSpace(goos) {
+	case "linux":
+		return "linux", nil
+	case "darwin":
+		return "macos", nil
+	case "windows":
+		return "windows", nil
+	default:
+		return "", fmt.Errorf("unsupported release platform: %s", goos)
+	}
+}
+
+func releaseArch(goarch string) (string, error) {
+	switch strings.TrimSpace(goarch) {
+	case "amd64":
+		return "x64", nil
+	case "arm64":
+		return "arm64", nil
+	default:
+		return "", fmt.Errorf("unsupported release architecture: %s", goarch)
+	}
 }
 
 func normalizeVersionTag(version string) (string, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -55,11 +55,13 @@ func TestNormalizeVersionTagAndCompareReportInvalidInput(t *testing.T) {
 func TestCheckReportsAvailableUpdate(t *testing.T) {
 	result, err := Check(context.Background(), Options{
 		CurrentVersion: "0.1.0",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
 		Fetch: func(_ context.Context, endpoint string) (Release, error) {
 			if endpoint != Endpoint(DefaultRepository) {
 				t.Fatalf("endpoint = %q, want default", endpoint)
 			}
-			return Release{TagName: "v0.2.0", HTMLURL: "https://github.com/Gitlawb/zero/releases/tag/v0.2.0"}, nil
+			return releaseForTarget(t, "v0.2.0", "linux", "amd64"), nil
 		},
 	})
 	if err != nil {
@@ -67,6 +69,9 @@ func TestCheckReportsAvailableUpdate(t *testing.T) {
 	}
 	if !result.UpdateAvailable || result.LatestVersion != "0.2.0" {
 		t.Fatalf("unexpected update result: %#v", result)
+	}
+	if !result.ReleaseAsset.Verified || result.ReleaseAsset.ArchiveName != "zero-v0.2.0-linux-x64.tar.gz" || result.ReleaseAsset.ChecksumName != "zero-v0.2.0-linux-x64.tar.gz.sha256" {
+		t.Fatalf("unexpected release asset check: %#v", result.ReleaseAsset)
 	}
 }
 
@@ -147,8 +152,12 @@ func TestCheckFallsBackReleaseURL(t *testing.T) {
 	result, err := Check(context.Background(), Options{
 		CurrentVersion: "0.1.0",
 		Repository:     "Gitlawb/zero",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
 		Fetch: func(context.Context, string) (Release, error) {
-			return Release{TagName: "v0.2.0"}, nil
+			release := releaseForTarget(t, "v0.2.0", "linux", "amd64")
+			release.HTMLURL = ""
+			return release, nil
 		},
 	})
 	if err != nil {
@@ -162,17 +171,94 @@ func TestCheckFallsBackReleaseURL(t *testing.T) {
 }
 
 func TestCheckFetchesDataEndpoint(t *testing.T) {
-	payload := url.QueryEscape(`{"tag_name":"v0.2.0","html_url":"https://example.test/release"}`)
+	payload := url.QueryEscape(`{"tag_name":"v0.2.0","html_url":"https://example.test/release","assets":[{"name":"zero-v0.2.0-linux-x64.tar.gz","browser_download_url":"https://example.test/zero-v0.2.0-linux-x64.tar.gz"},{"name":"zero-v0.2.0-linux-x64.tar.gz.sha256","browser_download_url":"https://example.test/zero-v0.2.0-linux-x64.tar.gz.sha256"}]}`)
 
 	result, err := Check(context.Background(), Options{
 		CurrentVersion: "0.1.0",
 		Endpoint:       "data:application/json," + payload,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
 	})
 	if err != nil {
 		t.Fatalf("Check returned error: %v", err)
 	}
-	if !result.UpdateAvailable || result.ReleaseURL != "https://example.test/release" {
+	if !result.UpdateAvailable || result.ReleaseURL != "https://example.test/release" || !result.ReleaseAsset.Verified {
 		t.Fatalf("unexpected data endpoint result: %#v", result)
+	}
+}
+
+func TestCheckRejectsMissingReleaseAssets(t *testing.T) {
+	_, err := Check(context.Background(), Options{
+		CurrentVersion: "0.1.0",
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Fetch: func(context.Context, string) (Release, error) {
+			return Release{
+				TagName: "v0.2.0",
+				Assets: []Asset{
+					{Name: "zero-v0.2.0-linux-arm64.tar.gz"},
+				},
+			}, nil
+		},
+	})
+
+	if err == nil {
+		t.Fatal("Check should reject release metadata without expected assets")
+	}
+	if !strings.Contains(err.Error(), "zero-v0.2.0-linux-x64.tar.gz") || !strings.Contains(err.Error(), "zero-v0.2.0-linux-x64.tar.gz.sha256") {
+		t.Fatalf("Check error = %v, want missing archive and checksum names", err)
+	}
+}
+
+func TestExpectedAssetCheckUsesInstallerArchiveNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		goos        string
+		goarch      string
+		archiveName string
+		platform    string
+		arch        string
+	}{
+		{
+			name:        "linux amd64",
+			version:     "0.2.0",
+			goos:        "linux",
+			goarch:      "amd64",
+			archiveName: "zero-v0.2.0-linux-x64.tar.gz",
+			platform:    "linux",
+			arch:        "x64",
+		},
+		{
+			name:        "macos arm64",
+			version:     "0.2.0",
+			goos:        "darwin",
+			goarch:      "arm64",
+			archiveName: "zero-v0.2.0-macos-arm64.tar.gz",
+			platform:    "macos",
+			arch:        "arm64",
+		},
+		{
+			name:        "windows amd64",
+			version:     "0.2.0",
+			goos:        "windows",
+			goarch:      "amd64",
+			archiveName: "zero-v0.2.0-windows-x64.zip",
+			platform:    "windows",
+			arch:        "x64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check, err := expectedAssetCheck(tt.version, tt.goos, tt.goarch)
+			if err != nil {
+				t.Fatalf("expectedAssetCheck returned error: %v", err)
+			}
+			if check.ArchiveName != tt.archiveName || check.ChecksumName != tt.archiveName+".sha256" || check.Platform != tt.platform || check.Arch != tt.arch {
+				t.Fatalf("expectedAssetCheck = %#v, want archive %s", check, tt.archiveName)
+			}
+		})
 	}
 }
 
@@ -248,10 +334,14 @@ func TestFormatResult(t *testing.T) {
 		LatestVersion:   "0.2.0",
 		ReleaseURL:      "https://github.com/Gitlawb/zero/releases/tag/v0.2.0",
 		TagName:         "v0.2.0",
+		ReleaseAsset:    assetCheckForTest(t, "v0.2.0", "linux", "amd64"),
 		UpdateAvailable: true,
 	})
 	if !strings.Contains(output, "Update available: 0.1.0 -> 0.2.0") {
 		t.Fatalf("unexpected update output: %q", output)
+	}
+	if !strings.Contains(output, "Release asset: zero-v0.2.0-linux-x64.tar.gz") || !strings.Contains(output, "Checksum asset: zero-v0.2.0-linux-x64.tar.gz.sha256") {
+		t.Fatalf("update output did not include release assets: %q", output)
 	}
 
 	output = Format(Result{
@@ -259,9 +349,39 @@ func TestFormatResult(t *testing.T) {
 		LatestVersion:   "0.2.0",
 		ReleaseURL:      "https://github.com/Gitlawb/zero/releases/tag/v0.2.0",
 		TagName:         "v0.2.0",
+		ReleaseAsset:    assetCheckForTest(t, "v0.2.0", "linux", "amd64"),
 		UpdateAvailable: false,
 	})
 	if !strings.Contains(output, "up to date") {
 		t.Fatalf("unexpected up-to-date output: %q", output)
 	}
+}
+
+func releaseForTarget(t *testing.T, tag string, goos string, goarch string) Release {
+	t.Helper()
+	check := assetCheckForTest(t, tag, goos, goarch)
+	return Release{
+		TagName: tag,
+		HTMLURL: "https://github.com/Gitlawb/zero/releases/tag/" + tag,
+		Assets: []Asset{
+			{Name: check.ArchiveName, BrowserDownloadURL: "https://example.test/" + check.ArchiveName},
+			{Name: check.ChecksumName, BrowserDownloadURL: "https://example.test/" + check.ChecksumName},
+		},
+	}
+}
+
+func assetCheckForTest(t *testing.T, tag string, goos string, goarch string) AssetCheck {
+	t.Helper()
+	version, err := NormalizeVersionTag(tag)
+	if err != nil {
+		t.Fatalf("NormalizeVersionTag(%q): %v", tag, err)
+	}
+	check, err := expectedAssetCheck(version, goos, goarch)
+	if err != nil {
+		t.Fatalf("expectedAssetCheck(%q, %q, %q): %v", version, goos, goarch, err)
+	}
+	check.ArchiveFound = true
+	check.ChecksumFound = true
+	check.Verified = true
+	return check
 }


### PR DESCRIPTION
## Summary
- parse latest-release assets and validate the expected platform archive plus matching .sha256 file
- add releaseAsset details to zero update --check JSON/text output
- document that update checks now validate release archive metadata

## Scope
This is metadata verification only. It does not download release assets or replace the local binary.

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./internal/update -run 'Normalize|CheckReportsAvailableUpdate|CheckReturnsFetchError|CheckRespectsContextCancellation|CheckRejectsNegativeTimeout|CheckRejectsMissingTagName|CheckRejectsInvalidLatestVersion|CheckFallsBackReleaseURL|CheckFetchesDataEndpoint|CheckRejectsMissingReleaseAssets|ExpectedAssetCheck|ResolveEndpoint|FormatResult'
- GOCACHE=/tmp/zero-go-cache go test ./internal/cli -run Update
- go test ./...
- env GOCACHE=/tmp/zero-go-cache ZERO_UPDATE_RELEASE_URL='data:application/json,%7B%22tag_name%22%3A%22v0.2.0%22%2C%22html_url%22%3A%22https%3A%2F%2Fexample.test%2Frelease%22%2C%22assets%22%3A%5B%7B%22name%22%3A%22zero-v0.2.0-linux-x64.tar.gz%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-linux-x64.tar.gz%22%7D%2C%7B%22name%22%3A%22zero-v0.2.0-linux-x64.tar.gz.sha256%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-linux-x64.tar.gz.sha256%22%7D%5D%7D' go run -ldflags '-X github.com/Gitlawb/zero/internal/cli.version=0.1.0' ./cmd/zero update --check --json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `update --check` now validates platform-specific release assets (archive and checksum) before reporting available updates.
  * Release asset details (filename and checksum information) are displayed in command output and JSON responses.

* **Documentation**
  * Clarified `update --check` return codes and release validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->