### PR TITLE
feat(zerocommands): add typed SandboxGrantSnapshot contract

### DIFF
--- a/internal/zerocommands/sandbox_snapshot.go
+++ b/internal/zerocommands/sandbox_snapshot.go
@@ -1,0 +1,86 @@
+package zerocommands
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+// SandboxGrantSnapshot is the typed view of a single persistent
+// sandbox grant as it is exposed to TUI, headless, and PR/CI
+// automation. The snapshot guarantees that no secret material from
+// the grant's Reason field is leaked: the field is always run
+// through the standard redaction pipeline before it is copied into
+// the snapshot. ToolName, Decision, MaxAutonomy, and ApprovedAt
+// are non-secret metadata and are copied verbatim.
+type SandboxGrantSnapshot struct {
+	ToolName    string `json:"toolName"`
+	Decision    string `json:"decision"`
+	MaxAutonomy string `json:"maxAutonomy"`
+	ApprovedAt  string `json:"approvedAt,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// SandboxGrantMatchSnapshot is the typed view returned to consumers
+// who look up a grant for a specific tool call. It pairs the
+// underlying grant snapshot with a Matched flag so callers can tell
+// the difference between "grant existed and matched" and "no grant
+// recorded for this tool" without inspecting an error or a typed
+// zero value.
+type SandboxGrantMatchSnapshot struct {
+	ToolName string                `json:"toolName"`
+	Matched  bool                  `json:"matched"`
+	Grant    *SandboxGrantSnapshot `json:"grant,omitempty"`
+}
+
+// SandboxGrantSnapshotFromGrant converts a sandbox.Grant into its
+// typed snapshot. The Reason field is run through redaction so any
+// secret material is masked before the snapshot leaves the runtime.
+// An empty or whitespace-only Reason becomes an empty Reason in the
+// snapshot, which keeps the JSON shape stable for downstream
+// consumers.
+func SandboxGrantSnapshotFromGrant(grant sandbox.Grant) SandboxGrantSnapshot {
+	return SandboxGrantSnapshot{
+		ToolName:    strings.TrimSpace(grant.ToolName),
+		Decision:    string(grant.Decision),
+		MaxAutonomy: string(grant.MaxAutonomy),
+		ApprovedAt:  strings.TrimSpace(grant.ApprovedAt),
+		Reason:      redaction.RedactString(strings.TrimSpace(grant.Reason), redaction.Options{}),
+	}
+}
+
+// SandboxGrantSnapshots converts a slice of sandbox grants into a
+// stable, sorted slice of typed snapshots. The output is sorted
+// alphabetically by tool name so consumers (TUI, headless, JSON
+// output) get a deterministic ordering. An empty input produces an
+// empty (non-nil) slice so the JSON output is always `[]` and never
+// `null`.
+func SandboxGrantSnapshots(grants []sandbox.Grant) []SandboxGrantSnapshot {
+	snapshots := make([]SandboxGrantSnapshot, 0, len(grants))
+	for _, grant := range grants {
+		snapshots = append(snapshots, SandboxGrantSnapshotFromGrant(grant))
+	}
+	sort.SliceStable(snapshots, func(left, right int) bool {
+		return snapshots[left].ToolName < snapshots[right].ToolName
+	})
+	return snapshots
+}
+
+// SandboxGrantMatchSnapshotFromLookup converts a sandbox.GrantLookup
+// into its typed snapshot. When the lookup did not match, the
+// returned snapshot has Matched=false and a nil Grant pointer so
+// consumers can render the absence without consulting an error.
+func SandboxGrantMatchSnapshotFromLookup(toolName string, lookup sandbox.GrantLookup) SandboxGrantMatchSnapshot {
+	match := SandboxGrantMatchSnapshot{
+		ToolName: strings.TrimSpace(toolName),
+		Matched:  lookup.Matched,
+	}
+	if !lookup.Matched {
+		return match
+	}
+	snapshot := SandboxGrantSnapshotFromGrant(lookup.Grant)
+	match.Grant = &snapshot
+	return match
+}

--- a/internal/zerocommands/sandbox_snapshot_test.go
+++ b/internal/zerocommands/sandbox_snapshot_test.go
@@ -1,0 +1,143 @@
+package zerocommands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+func TestSandboxGrantSnapshotFromGrantRedactsReasonAndTrimsFields(t *testing.T) {
+	grant := sandbox.Grant{
+		ToolName:    "  bash  ",
+		Decision:    sandbox.GrantAllow,
+		MaxAutonomy: sandbox.AutonomyHigh,
+		ApprovedAt:  "  2026-06-04T10:00:00Z  ",
+		Reason:      "auth token sk-proj-abcdefghijklmnopqrstuvwxyz0123456789 leaked",
+	}
+
+	snapshot := SandboxGrantSnapshotFromGrant(grant)
+
+	if snapshot.ToolName != "bash" {
+		t.Fatalf("ToolName not trimmed: %q", snapshot.ToolName)
+	}
+	if snapshot.ApprovedAt != "2026-06-04T10:00:00Z" {
+		t.Fatalf("ApprovedAt not trimmed: %q", snapshot.ApprovedAt)
+	}
+	if snapshot.Decision != string(sandbox.GrantAllow) {
+		t.Fatalf("Decision = %q, want %q", snapshot.Decision, sandbox.GrantAllow)
+	}
+	if snapshot.MaxAutonomy != string(sandbox.AutonomyHigh) {
+		t.Fatalf("MaxAutonomy = %q, want %q", snapshot.MaxAutonomy, sandbox.AutonomyHigh)
+	}
+	if strings.Contains(snapshot.Reason, "sk-proj-") {
+		t.Fatalf("expected reason secret to be redacted, got %q", snapshot.Reason)
+	}
+	if !strings.Contains(snapshot.Reason, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in reason, got %q", snapshot.Reason)
+	}
+}
+
+func TestSandboxGrantSnapshotFromGrantEmptyReasonBecomesEmpty(t *testing.T) {
+	grant := sandbox.Grant{
+		ToolName:    "bash",
+		Decision:    sandbox.GrantDeny,
+		MaxAutonomy: sandbox.AutonomyLow,
+		ApprovedAt:  "2026-06-04T10:00:00Z",
+		Reason:      "   ",
+	}
+	snapshot := SandboxGrantSnapshotFromGrant(grant)
+	if snapshot.Reason != "" {
+		t.Fatalf("expected empty reason after trim, got %q", snapshot.Reason)
+	}
+}
+
+func TestSandboxGrantSnapshotsSortsByToolNameAndReturnsEmptySliceForEmptyInput(t *testing.T) {
+	grants := []sandbox.Grant{
+		{ToolName: "write_file", Decision: sandbox.GrantAllow, MaxAutonomy: sandbox.AutonomyMedium, ApprovedAt: "2026-06-04T10:00:00Z"},
+		{ToolName: "bash", Decision: sandbox.GrantAllow, MaxAutonomy: sandbox.AutonomyHigh, ApprovedAt: "2026-06-04T10:00:00Z"},
+		{ToolName: "edit_file", Decision: sandbox.GrantDeny, MaxAutonomy: sandbox.AutonomyLow, ApprovedAt: "2026-06-04T10:00:00Z"},
+	}
+	snapshots := SandboxGrantSnapshots(grants)
+	if len(snapshots) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+	}
+	if snapshots[0].ToolName != "bash" || snapshots[1].ToolName != "edit_file" || snapshots[2].ToolName != "write_file" {
+		t.Fatalf("snapshots not sorted by toolName: %#v", snapshots)
+	}
+
+	empty := SandboxGrantSnapshots(nil)
+	if empty == nil {
+		t.Fatal("expected non-nil empty slice so JSON output is [] not null")
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty slice, got %d", len(empty))
+	}
+	encoded, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Fatalf("expected JSON [] for empty input, got %q", string(encoded))
+	}
+}
+
+func TestSandboxGrantMatchSnapshotFromLookupMatchedAndUnmatched(t *testing.T) {
+	matched := SandboxGrantMatchSnapshotFromLookup("  bash  ", sandbox.GrantLookup{
+		Matched: true,
+		Grant: sandbox.Grant{
+			ToolName:    "bash",
+			Decision:    sandbox.GrantAllow,
+			MaxAutonomy: sandbox.AutonomyHigh,
+			ApprovedAt:  "2026-06-04T10:00:00Z",
+			Reason:      "user pressed always",
+		},
+	})
+	if !matched.Matched {
+		t.Fatal("expected Matched=true")
+	}
+	if matched.ToolName != "bash" {
+		t.Fatalf("expected trimmed toolName, got %q", matched.ToolName)
+	}
+	if matched.Grant == nil {
+		t.Fatal("expected non-nil Grant pointer for matched lookup")
+	}
+	if matched.Grant.Decision != string(sandbox.GrantAllow) {
+		t.Fatalf("Grant.Decision = %q, want %q", matched.Grant.Decision, sandbox.GrantAllow)
+	}
+
+	unmatched := SandboxGrantMatchSnapshotFromLookup("bash", sandbox.GrantLookup{Matched: false})
+	if unmatched.Matched {
+		t.Fatal("expected Matched=false")
+	}
+	if unmatched.Grant != nil {
+		t.Fatalf("expected nil Grant pointer for unmatched lookup, got %#v", unmatched.Grant)
+	}
+	if unmatched.ToolName != "bash" {
+		t.Fatalf("expected toolName preserved, got %q", unmatched.ToolName)
+	}
+}
+
+func TestSandboxGrantSnapshotJSONShapeIsStable(t *testing.T) {
+	snapshot := SandboxGrantSnapshot{
+		ToolName:    "bash",
+		Decision:    "allow",
+		MaxAutonomy: "high",
+		ApprovedAt:  "2026-06-04T10:00:00Z",
+		Reason:      "user approved",
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	decoded := map[string]any{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	for _, key := range []string{"toolName", "decision", "maxAutonomy", "approvedAt", "reason"} {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("expected key %q in JSON output, got %q", key, string(encoded))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The merged permission and verification event contracts added typed snapshots for config, providers, models, and sessions, but the persistent sandbox grant store (`internal/sandbox/grants.go`) still exposes only `sandbox.Grant` directly. The TUI render path, the headless `zero sandbox` command, and PR/CI automation all need a typed snapshot so they do not hand-roll `map[string]any` payloads and do not accidentally leak grant reasons that contain API keys or tokens.

This commit adds `SandboxGrantSnapshot` alongside the existing `ProviderSnapshot`, `ModelSnapshot`, `SessionSnapshot`, and `SessionTreeSnapshot` in `internal/zerocommands`. The snapshot mirrors the format of the existing typed contracts:

- `ToolName`, `Decision`, `MaxAutonomy`, `ApprovedAt` are copied verbatim from the underlying grant. They are non-secret metadata.
- `Reason` is run through the standard redaction pipeline before it is copied, so any secret material the user typed when granting is masked before the snapshot leaves the runtime.
- All string fields are trimmed. An empty or whitespace-only `Reason` becomes an empty `Reason` in the snapshot so JSON output omits the field.

Two constructors are provided:

- `SandboxGrantSnapshotFromGrant(grant)` for a single grant.
- `SandboxGrantSnapshots(grants)` for a slice. Output is sorted alphabetically by `ToolName` so consumers (TUI, headless, JSON output) see a deterministic ordering. An empty input returns a non-nil empty slice so JSON output is always `[]` and never `null`.

A matched/unmatched helper is also added:

- `SandboxGrantMatchSnapshotFromLookup(toolName, lookup)` pairs the typed snapshot with a `Matched` boolean. When the lookup did not match, the returned snapshot has `Matched=false` and a nil `Grant` pointer, so consumers can render the absence without inspecting an error or a typed zero value.

## Tests

- `TestSandboxGrantSnapshotFromGrantRedactsReasonAndTrimsFields`: verifies the secret in the reason is masked and the surrounding fields are trimmed.
- `TestSandboxGrantSnapshotFromGrantEmptyReasonBecomesEmpty`: verifies whitespace-only reasons normalize to the empty string.
- `TestSandboxGrantSnapshotsSortsByToolNameAndReturnsEmptySliceForEmptyInput`: verifies alphabetical sort and that nil input returns a non-nil empty slice whose JSON encoding is `[]`.
- `TestSandboxGrantMatchSnapshotFromLookupMatchedAndUnmatched`: verifies the matched and unmatched code paths.
- `TestSandboxGrantSnapshotJSONShapeIsStable`: verifies every JSON key is present so downstream consumers can rely on the shape.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -count=1 -p 1 ./internal/zerocommands/... ./internal/sandbox/... ./internal/redaction/...`

## DRI

Gnanam (runtime core owner per `docs/WORK_SPLIT_PRD.md` §4). Connects `zero sandbox` command rendering, the TUI grants panel, and PR/CI automation consumers to the persistent grant store without leaking grant reasons.

## Out of scope

This PR only adds the typed contract and the constructors. The TUI render path, the `zero sandbox` headless command, and the PR/CI automation consumer are follow-up work in their respective owners' lanes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for sandbox grant snapshot behavior, including field trimming, reason redaction, sorting, and JSON serialization.

* **Chores**
  * Added internal snapshot export helper functions and data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->