### PR TITLE
feat(zerocommands): add typed MCP, hooks, and plugins snapshots

### DIFF
--- a/internal/zerocommands/backend_snapshots.go
+++ b/internal/zerocommands/backend_snapshots.go
@@ -1,6 +1,7 @@
 package zerocommands
 
 import (
+	"net/url"
 	"sort"
 	"strings"
 
@@ -89,13 +90,18 @@ type BackendLifecycleSnapshot struct {
 
 // MCPServerSnapshotFromServer converts a single mcp.Server into its
 // typed snapshot. Secret material in `Env` and `Headers` is never
-// copied; only the key counts are recorded.
+// copied; only the key counts are recorded. The URL field is run
+// through stripURLCredentialsFromURL so any userinfo embedded in
+// the URL (https://user:token@host) is removed before the snapshot
+// leaves the runtime. A URL that fails to parse is returned
+// trimmed, not empty, so the operator still sees the configured
+// endpoint when triaging a malformed MCP configuration.
 func MCPServerSnapshotFromServer(server mcp.Server) MCPServerSnapshot {
 	return MCPServerSnapshot{
 		Name:        strings.TrimSpace(server.Name),
 		Type:        string(server.Type),
 		Identity:    strings.TrimSpace(server.Identity),
-		URL:         strings.TrimSpace(server.URL),
+		URL:         stripURLCredentialsFromURL(server.URL),
 		Command:     strings.TrimSpace(server.Command),
 		ArgCount:    len(server.Args),
 		EnvKeyCount: len(server.Env),
@@ -250,21 +256,46 @@ func NewBackendLifecycleSnapshot(servers []mcp.Server, hookDefs []hooks.Definiti
 
 // redactStringSlice runs every element of the input slice through
 // the standard redaction pipeline and trims surrounding whitespace.
-// A nil or empty input returns nil so the JSON output omits the
-// field entirely.
+// Position is preserved: a fully-redacted element becomes an empty
+// string in the output, and a whitespace-only input becomes an
+// empty string. The output length always matches the input length
+// so consumers can rely on arg position when correlating with the
+// source definition. A nil or empty input returns nil so the JSON
+// output omits the field entirely.
 func redactStringSlice(values []string) []string {
 	if len(values) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(values))
-	for _, value := range values {
-		redacted := redaction.RedactString(strings.TrimSpace(value), redaction.Options{})
-		if redacted != "" {
-			out = append(out, redacted)
+	out := make([]string, len(values))
+	for index, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			out[index] = ""
+			continue
 		}
-	}
-	if len(out) == 0 {
-		return nil
+		out[index] = redaction.RedactString(trimmed, redaction.Options{})
 	}
 	return out
+}
+
+// stripURLCredentialsFromURL returns value with any embedded
+// userinfo (https://user:token@host) removed. The helper is
+// tolerant of malformed input: a URL that fails to parse is
+// returned trimmed, not empty, so the operator still sees the
+// configured endpoint when triaging an MCP configuration that
+// contains an unparseable URL. A blank input returns blank.
+func stripURLCredentialsFromURL(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed == nil {
+		return trimmed
+	}
+	if parsed.User == nil {
+		return trimmed
+	}
+	parsed.User = nil
+	return parsed.String()
 }

--- a/internal/zerocommands/backend_snapshots.go
+++ b/internal/zerocommands/backend_snapshots.go
@@ -1,0 +1,270 @@
+package zerocommands
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+// MCPServerSnapshot is the typed view of a single configured MCP
+// server as it is exposed to the TUI render path, the headless
+// `zero mcp` command, and PR/CI automation. The snapshot strips
+// every field that can carry a secret. Command arguments are
+// preserved because the tool surface (path, flags) is the part a
+// maintainer needs to see when triaging an MCP failure. Environment
+// variables and HTTP headers are summarised as redacted key counts
+// instead of being copied verbatim, so a token in MCP_AUTH_TOKEN
+// never reaches the headless JSON output.
+type MCPServerSnapshot struct {
+	Name         string   `json:"name"`
+	Type         string   `json:"type"`
+	Identity     string   `json:"identity,omitempty"`
+	URL          string   `json:"url,omitempty"`
+	Command      string   `json:"command,omitempty"`
+	ArgCount     int      `json:"argCount"`
+	EnvKeyCount  int      `json:"envKeyCount"`
+	HeaderCount  int      `json:"headerCount"`
+	ToolCount    int      `json:"toolCount"`
+	AllowGranted int      `json:"allowGranted"`
+	DenyGranted  int      `json:"denyGranted"`
+}
+
+// HookSnapshot is the typed view of a single configured hook as it
+// is exposed to the TUI render path, the headless `zero hooks`
+// command, and PR/CI automation. The command and arguments are
+// preserved because they are the operator's primary tool for
+// understanding which shell command will run. The matcher is
+// preserved because it is the operator's primary tool for
+// understanding when the hook will fire.
+type HookSnapshot struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Event       string   `json:"event"`
+	Matcher     string   `json:"matcher,omitempty"`
+	Command     string   `json:"command"`
+	Args        []string `json:"args,omitempty"`
+	Enabled     bool     `json:"enabled"`
+	Source      string   `json:"source,omitempty"`
+}
+
+// PluginSnapshot is the typed view of a single loaded plugin as it
+// is exposed to the TUI render path, the headless `zero plugins`
+// command, and PR/CI automation. The path fields are preserved
+// because the operator needs to know where the manifest came from
+// when triaging a load failure. Counts replace the full slice of
+// tools, hooks, prompts, and skills so the headless JSON output
+// stays small even for plugins with many extensions.
+type PluginSnapshot struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Version       string `json:"version,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Enabled       bool   `json:"enabled"`
+	Source        string `json:"source"`
+	Root          string `json:"root,omitempty"`
+	PluginDir     string `json:"pluginDir,omitempty"`
+	ManifestPath  string `json:"manifestPath,omitempty"`
+	ToolCount     int    `json:"toolCount"`
+	PromptCount   int    `json:"promptCount"`
+	SkillCount    int    `json:"skillCount"`
+	HookCount     int    `json:"hookCount"`
+}
+
+// BackendLifecycleSnapshot bundles the typed snapshots for the
+// three backend surfaces that the WorkSplit PRD places in Gnanam's
+// lane: MCP servers, hooks, and plugins. `zero doctor` and the
+// headless `zero config` command can return one of these to give
+// the operator a single payload describing the full extensibility
+// surface. The three inner slices are always non-nil so JSON
+// output is `[]` and never `null`.
+type BackendLifecycleSnapshot struct {
+	MCPServers []MCPServerSnapshot `json:"mcpServers"`
+	Hooks      []HookSnapshot      `json:"hooks"`
+	Plugins    []PluginSnapshot    `json:"plugins"`
+}
+
+// MCPServerSnapshotFromServer converts a single mcp.Server into its
+// typed snapshot. Secret material in `Env` and `Headers` is never
+// copied; only the key counts are recorded.
+func MCPServerSnapshotFromServer(server mcp.Server) MCPServerSnapshot {
+	return MCPServerSnapshot{
+		Name:        strings.TrimSpace(server.Name),
+		Type:        string(server.Type),
+		Identity:    strings.TrimSpace(server.Identity),
+		URL:         strings.TrimSpace(server.URL),
+		Command:     strings.TrimSpace(server.Command),
+		ArgCount:    len(server.Args),
+		EnvKeyCount: len(server.Env),
+		HeaderCount: len(server.Headers),
+	}
+}
+
+// MCPServerSnapshots converts a slice of mcp.Server into a stable,
+// sorted slice of typed snapshots. Output is sorted alphabetically
+// by Name so consumers (TUI, headless, JSON output) see a
+// deterministic ordering. An empty input returns a non-nil empty
+// slice so JSON output is always `[]` and never `null`.
+func MCPServerSnapshots(servers []mcp.Server) []MCPServerSnapshot {
+	snapshots := make([]MCPServerSnapshot, 0, len(servers))
+	for _, server := range servers {
+		snapshots = append(snapshots, MCPServerSnapshotFromServer(server))
+	}
+	sort.SliceStable(snapshots, func(left, right int) bool {
+		return snapshots[left].Name < snapshots[right].Name
+	})
+	return snapshots
+}
+
+// MCPServerSnapshotWithCounts returns a snapshot that also records
+// how many tools the server exposes and how many persistent
+// approvals are currently recorded. A nil counts struct is treated
+// as zero values so callers that do not have a live registry can
+// still call this helper.
+func MCPServerSnapshotWithCounts(server mcp.Server, counts *MCPServerCounts) MCPServerSnapshot {
+	snapshot := MCPServerSnapshotFromServer(server)
+	if counts == nil {
+		return snapshot
+	}
+	snapshot.ToolCount = counts.ToolCount
+	snapshot.AllowGranted = counts.AllowGranted
+	snapshot.DenyGranted = counts.DenyGranted
+	return snapshot
+}
+
+// MCPServerCounts is the optional runtime count bundle that the
+// snapshot can carry. The struct is split out so callers that
+// have a live tool registry and a live permission store can
+// supply the values without the snapshot helper needing to know
+// about either backend.
+type MCPServerCounts struct {
+	ToolCount    int
+	AllowGranted int
+	DenyGranted  int
+}
+
+// HookSnapshotFromDefinition converts a hooks.Definition into its
+// typed snapshot. The source is the only field that is not on the
+// definition itself; callers that have it from hooks.LoadResult
+// should pass it through. An empty source stays empty in the
+// snapshot.
+func HookSnapshotFromDefinition(def hooks.Definition, source hooks.ConfigSource) HookSnapshot {
+	return HookSnapshot{
+		ID:      strings.TrimSpace(def.ID),
+		Name:    strings.TrimSpace(def.Name),
+		Event:   string(def.Event),
+		Matcher: strings.TrimSpace(def.Matcher),
+		Command: redaction.RedactString(strings.TrimSpace(def.Command), redaction.Options{}),
+		Args:    redactStringSlice(def.Args),
+		Enabled: def.Enabled,
+		Source:  string(source),
+	}
+}
+
+// HookSnapshots converts a slice of hooks.Definition into a
+// stable, sorted slice of typed snapshots. Output is sorted
+// alphabetically by ID, then by event, so consumers see a
+// deterministic ordering. An empty input returns a non-nil empty
+// slice so JSON output is always `[]` and never `null`.
+func HookSnapshots(definitions []hooks.Definition) []HookSnapshot {
+	return hookSnapshotsWithSource(definitions, "")
+}
+
+// HookSnapshotsWithSource converts a slice of hooks.Definition and
+// tags every snapshot with the same source string. The helper
+// exists so callers that have a single hooks.LoadResult can build
+// the snapshot slice in one pass.
+func HookSnapshotsWithSource(definitions []hooks.Definition, source hooks.ConfigSource) []HookSnapshot {
+	return hookSnapshotsWithSource(definitions, source)
+}
+
+func hookSnapshotsWithSource(definitions []hooks.Definition, source hooks.ConfigSource) []HookSnapshot {
+	snapshots := make([]HookSnapshot, 0, len(definitions))
+	for _, def := range definitions {
+		snapshots = append(snapshots, HookSnapshotFromDefinition(def, source))
+	}
+	sort.SliceStable(snapshots, func(left, right int) bool {
+		if snapshots[left].ID != snapshots[right].ID {
+			return snapshots[left].ID < snapshots[right].ID
+		}
+		return snapshots[left].Event < snapshots[right].Event
+	})
+	return snapshots
+}
+
+// PluginSnapshotFromPlugin converts a plugins.LoadedPlugin into its
+// typed snapshot. The full slice of tools, hooks, prompts, and
+// skills is collapsed to counts so the headless JSON output stays
+// small. The Path fields are preserved verbatim because the
+// operator needs them to triage a load failure.
+func PluginSnapshotFromPlugin(plugin plugins.LoadedPlugin) PluginSnapshot {
+	return PluginSnapshot{
+		ID:           strings.TrimSpace(plugin.ID),
+		Name:         strings.TrimSpace(plugin.Name),
+		Version:      strings.TrimSpace(plugin.Version),
+		Description:  strings.TrimSpace(plugin.Description),
+		Enabled:      plugin.Enabled,
+		Source:       string(plugin.Source),
+		Root:         strings.TrimSpace(plugin.Root),
+		PluginDir:    strings.TrimSpace(plugin.PluginDir),
+		ManifestPath: strings.TrimSpace(plugin.ManifestPath),
+		ToolCount:    len(plugin.Tools),
+		PromptCount:  len(plugin.Prompts),
+		SkillCount:   len(plugin.Skills),
+		HookCount:    len(plugin.Hooks),
+	}
+}
+
+// PluginSnapshots converts a slice of plugins.LoadedPlugin into a
+// stable, sorted slice of typed snapshots. Output is sorted
+// alphabetically by ID so consumers (TUI, headless, JSON output)
+// see a deterministic ordering. An empty input returns a non-nil
+// empty slice so JSON output is always `[]` and never `null`.
+func PluginSnapshots(loaded []plugins.LoadedPlugin) []PluginSnapshot {
+	snapshots := make([]PluginSnapshot, 0, len(loaded))
+	for _, plugin := range loaded {
+		snapshots = append(snapshots, PluginSnapshotFromPlugin(plugin))
+	}
+	sort.SliceStable(snapshots, func(left, right int) bool {
+		return snapshots[left].ID < snapshots[right].ID
+	})
+	return snapshots
+}
+
+// NewBackendLifecycleSnapshot builds the bundled snapshot. Each
+// argument may be nil; the snapshot slice stays non-nil for each
+// surface so JSON output is always `[]` and never `null`. The
+// caller is expected to have already loaded the data using the
+// existing mcp.NormalizeConfig, hooks.Load, and plugins.Load
+// helpers.
+func NewBackendLifecycleSnapshot(servers []mcp.Server, hookDefs []hooks.Definition, loaded []plugins.LoadedPlugin) BackendLifecycleSnapshot {
+	return BackendLifecycleSnapshot{
+		MCPServers: MCPServerSnapshots(servers),
+		Hooks:      HookSnapshots(hookDefs),
+		Plugins:    PluginSnapshots(loaded),
+	}
+}
+
+// redactStringSlice runs every element of the input slice through
+// the standard redaction pipeline and trims surrounding whitespace.
+// A nil or empty input returns nil so the JSON output omits the
+// field entirely.
+func redactStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		redacted := redaction.RedactString(strings.TrimSpace(value), redaction.Options{})
+		if redacted != "" {
+			out = append(out, redacted)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/zerocommands/backend_snapshots_test.go
+++ b/internal/zerocommands/backend_snapshots_test.go
@@ -1,0 +1,287 @@
+package zerocommands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+)
+
+func TestMCPServerSnapshotFromServerStripsSecretsAndCountsMaps(t *testing.T) {
+	server := mcp.Server{
+		Name:    "  work  ",
+		Type:    mcp.ServerTypeStdio,
+		Command: "npx",
+		Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
+		Env: map[string]string{
+			"MCP_AUTH_TOKEN": "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+			"LOG_LEVEL":      "info",
+		},
+		Headers: map[string]string{
+			"Authorization": "Bearer sk-proj-zyxwvu",
+		},
+		Identity: "  work-fs  ",
+	}
+
+	snapshot := MCPServerSnapshotFromServer(server)
+
+	if snapshot.Name != "work" {
+		t.Fatalf("Name not trimmed: %q", snapshot.Name)
+	}
+	if snapshot.Identity != "work-fs" {
+		t.Fatalf("Identity not trimmed: %q", snapshot.Identity)
+	}
+	if snapshot.Command != "npx" {
+		t.Fatalf("Command not trimmed: %q", snapshot.Command)
+	}
+	if snapshot.Type != "stdio" {
+		t.Fatalf("Type = %q, want stdio", snapshot.Type)
+	}
+	if snapshot.ArgCount != 3 {
+		t.Fatalf("ArgCount = %d, want 3", snapshot.ArgCount)
+	}
+	if snapshot.EnvKeyCount != 2 {
+		t.Fatalf("EnvKeyCount = %d, want 2 (counts, not values)", snapshot.EnvKeyCount)
+	}
+	if snapshot.HeaderCount != 1 {
+		t.Fatalf("HeaderCount = %d, want 1 (counts, not values)", snapshot.HeaderCount)
+	}
+
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	serialized := string(encoded)
+	if strings.Contains(serialized, "sk-proj-") {
+		t.Fatalf("snapshot must not serialize secret material, got %q", serialized)
+	}
+	if strings.Contains(serialized, "Bearer") {
+		t.Fatalf("snapshot must not serialize authorization header value, got %q", serialized)
+	}
+	if strings.Contains(serialized, "MCP_AUTH_TOKEN") {
+		t.Fatalf("snapshot must not serialize env var name or value, got %q", serialized)
+	}
+}
+
+func TestMCPServerSnapshotWithCountsMergesRuntimeCounts(t *testing.T) {
+	server := mcp.Server{Name: "work", Type: mcp.ServerTypeStdio, Command: "npx"}
+	base := MCPServerSnapshotFromServer(server)
+	if base.ToolCount != 0 || base.AllowGranted != 0 || base.DenyGranted != 0 {
+		t.Fatalf("expected zero counts on base snapshot, got %#v", base)
+	}
+
+	with := MCPServerSnapshotWithCounts(server, &MCPServerCounts{
+		ToolCount:    4,
+		AllowGranted: 3,
+		DenyGranted:  1,
+	})
+	if with.ToolCount != 4 || with.AllowGranted != 3 || with.DenyGranted != 1 {
+		t.Fatalf("expected counts merged, got %#v", with)
+	}
+
+	nilCounts := MCPServerSnapshotWithCounts(server, nil)
+	if nilCounts.ToolCount != 0 || nilCounts.AllowGranted != 0 || nilCounts.DenyGranted != 0 {
+		t.Fatalf("expected nil counts to leave snapshot zero, got %#v", nilCounts)
+	}
+}
+
+func TestMCPServerSnapshotsSortsAndReturnsEmptySliceForEmptyInput(t *testing.T) {
+	servers := []mcp.Server{
+		{Name: "zulu", Type: mcp.ServerTypeHTTP, URL: "https://zulu.test"},
+		{Name: "alpha", Type: mcp.ServerTypeStdio, Command: "alpha"},
+		{Name: "mike", Type: mcp.ServerTypeSSE, URL: "https://mike.test"},
+	}
+	snapshots := MCPServerSnapshots(servers)
+	if len(snapshots) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+	}
+	if snapshots[0].Name != "alpha" || snapshots[1].Name != "mike" || snapshots[2].Name != "zulu" {
+		t.Fatalf("snapshots not sorted by name: %#v", snapshots)
+	}
+
+	empty := MCPServerSnapshots(nil)
+	if empty == nil {
+		t.Fatal("expected non-nil empty slice so JSON output is [] not null")
+	}
+	encoded, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Fatalf("expected JSON [] for empty input, got %q", string(encoded))
+	}
+}
+
+func TestHookSnapshotFromDefinitionRedactsCommandAndTrimsFields(t *testing.T) {
+	def := hooks.Definition{
+		ID:      "  hook-1  ",
+		Name:    "  pre-tool safety  ",
+		Event:   hooks.EventBeforeTool,
+		Matcher: "  write_file  ",
+		Command: "sh",
+		Args:    []string{"-c", "auth token sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"},
+		Enabled: true,
+	}
+
+	snapshot := HookSnapshotFromDefinition(def, hooks.SourceUser)
+
+	if snapshot.ID != "hook-1" {
+		t.Fatalf("ID not trimmed: %q", snapshot.ID)
+	}
+	if snapshot.Name != "pre-tool safety" {
+		t.Fatalf("Name not trimmed: %q", snapshot.Name)
+	}
+	if snapshot.Matcher != "write_file" {
+		t.Fatalf("Matcher not trimmed: %q", snapshot.Matcher)
+	}
+	if snapshot.Event != string(hooks.EventBeforeTool) {
+		t.Fatalf("Event = %q, want %q", snapshot.Event, hooks.EventBeforeTool)
+	}
+	if snapshot.Source != string(hooks.SourceUser) {
+		t.Fatalf("Source = %q, want %q", snapshot.Source, hooks.SourceUser)
+	}
+	if !snapshot.Enabled {
+		t.Fatal("expected Enabled=true to round-trip")
+	}
+	for _, arg := range snapshot.Args {
+		if strings.Contains(arg, "sk-proj-") {
+			t.Fatalf("hook arg should be redacted, got %q", arg)
+		}
+	}
+}
+
+func TestHookSnapshotsSortsByIDAndEvent(t *testing.T) {
+	defs := []hooks.Definition{
+		{ID: "zulu", Event: hooks.EventAfterTool, Command: "echo", Args: []string{"z"}},
+		{ID: "alpha", Event: hooks.EventSessionStart, Command: "echo", Args: []string{"a"}},
+		{ID: "alpha", Event: hooks.EventBeforeTool, Command: "echo", Args: []string{"a"}},
+	}
+	snapshots := HookSnapshots(defs)
+	if len(snapshots) != 3 {
+		t.Fatalf("expected 3 snapshots, got %d", len(snapshots))
+	}
+	if snapshots[0].ID != "alpha" || snapshots[0].Event != string(hooks.EventBeforeTool) {
+		t.Fatalf("expected alpha/beforeTool first, got %q/%q", snapshots[0].ID, snapshots[0].Event)
+	}
+	if snapshots[1].ID != "alpha" || snapshots[1].Event != string(hooks.EventSessionStart) {
+		t.Fatalf("expected alpha/sessionStart second, got %q/%q", snapshots[1].ID, snapshots[1].Event)
+	}
+	if snapshots[2].ID != "zulu" {
+		t.Fatalf("expected zulu third, got %q", snapshots[2].ID)
+	}
+}
+
+func TestHookSnapshotsWithSourceTagsEverySnapshot(t *testing.T) {
+	defs := []hooks.Definition{
+		{ID: "h1", Event: hooks.EventSessionStart, Command: "echo", Args: []string{"hi"}},
+		{ID: "h2", Event: hooks.EventSessionEnd, Command: "echo", Args: []string{"bye"}},
+	}
+	snapshots := HookSnapshotsWithSource(defs, hooks.SourceProject)
+	for _, snap := range snapshots {
+		if snap.Source != string(hooks.SourceProject) {
+			t.Fatalf("expected project source, got %q on %q", snap.Source, snap.ID)
+		}
+	}
+}
+
+func TestPluginSnapshotFromPluginCollapsesSlicesToCounts(t *testing.T) {
+	plugin := plugins.LoadedPlugin{
+		ID:           "  example  ",
+		Name:         "  Example Plugin  ",
+		Version:      "  1.2.3  ",
+		Description: "  A demo plugin.  ",
+		Enabled:      true,
+		Source:       plugins.SourceCustom,
+		Root:         "  /home/user/.config/zero/plugins/example  ",
+		PluginDir:    "  /home/user/.config/zero/plugins/example/v1  ",
+		ManifestPath: "  /home/user/.config/zero/plugins/example/v1/manifest.json  ",
+		Tools: []plugins.ToolExtension{
+			{Name: "t1", Command: "echo", Args: []string{"t1"}},
+			{Name: "t2", Command: "echo", Args: []string{"t2"}},
+		},
+		Prompts: []plugins.PathExtension{{Name: "p1", Path: "/p1"}},
+		Skills:  []plugins.PathExtension{{Name: "s1", Path: "/s1"}},
+		Hooks: []plugins.HookExtension{
+			{Name: "h1", Event: plugins.HookBeforeTool, Command: "echo", Args: []string{"h1"}},
+		},
+	}
+
+	snapshot := PluginSnapshotFromPlugin(plugin)
+
+	if snapshot.ID != "example" {
+		t.Fatalf("ID not trimmed: %q", snapshot.ID)
+	}
+	if snapshot.Name != "Example Plugin" {
+		t.Fatalf("Name not trimmed: %q", snapshot.Name)
+	}
+	if snapshot.Version != "1.2.3" {
+		t.Fatalf("Version not trimmed: %q", snapshot.Version)
+	}
+	if snapshot.Description != "A demo plugin." {
+		t.Fatalf("Description not trimmed: %q", snapshot.Description)
+	}
+	if snapshot.Source != string(plugins.SourceCustom) {
+		t.Fatalf("Source = %q, want %q", snapshot.Source, plugins.SourceCustom)
+	}
+	if snapshot.ToolCount != 2 || snapshot.PromptCount != 1 || snapshot.SkillCount != 1 || snapshot.HookCount != 1 {
+		t.Fatalf("counts wrong: %#v", snapshot)
+	}
+}
+
+func TestPluginSnapshotsSortsByIDAndReturnsEmptySliceForEmptyInput(t *testing.T) {
+	loaded := []plugins.LoadedPlugin{
+		{ID: "zulu", Name: "Zulu", Tools: []plugins.ToolExtension{{Name: "t"}}},
+		{ID: "alpha", Name: "Alpha"},
+	}
+	snapshots := PluginSnapshots(loaded)
+	if len(snapshots) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snapshots))
+	}
+	if snapshots[0].ID != "alpha" || snapshots[1].ID != "zulu" {
+		t.Fatalf("snapshots not sorted by id: %#v", snapshots)
+	}
+
+	empty := PluginSnapshots(nil)
+	if empty == nil {
+		t.Fatal("expected non-nil empty slice so JSON output is [] not null")
+	}
+	encoded, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if string(encoded) != "[]" {
+		t.Fatalf("expected JSON [] for empty input, got %q", string(encoded))
+	}
+}
+
+func TestNewBackendLifecycleSnapshotBundlesAndDefaultsNilsToEmpty(t *testing.T) {
+	snapshot := NewBackendLifecycleSnapshot(nil, nil, nil)
+	if snapshot.MCPServers == nil || snapshot.Hooks == nil || snapshot.Plugins == nil {
+		t.Fatalf("expected all three slices non-nil, got %#v", snapshot)
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"mcpServers":[]`) {
+		t.Fatalf("expected empty mcpServers in JSON, got %q", string(encoded))
+	}
+	if !strings.Contains(string(encoded), `"hooks":[]`) {
+		t.Fatalf("expected empty hooks in JSON, got %q", string(encoded))
+	}
+	if !strings.Contains(string(encoded), `"plugins":[]`) {
+		t.Fatalf("expected empty plugins in JSON, got %q", string(encoded))
+	}
+
+	full := NewBackendLifecycleSnapshot(
+		[]mcp.Server{{Name: "alpha", Type: mcp.ServerTypeStdio, Command: "x"}},
+		[]hooks.Definition{{ID: "h1", Event: hooks.EventBeforeTool, Command: "echo"}},
+		[]plugins.LoadedPlugin{{ID: "p1", Name: "P"}},
+	)
+	if len(full.MCPServers) != 1 || len(full.Hooks) != 1 || len(full.Plugins) != 1 {
+		t.Fatalf("expected one of each, got %#v", full)
+	}
+}

--- a/internal/zerocommands/backend_snapshots_test.go
+++ b/internal/zerocommands/backend_snapshots_test.go
@@ -146,10 +146,88 @@ func TestHookSnapshotFromDefinitionRedactsCommandAndTrimsFields(t *testing.T) {
 	if !snapshot.Enabled {
 		t.Fatal("expected Enabled=true to round-trip")
 	}
+	if len(snapshot.Args) != len(def.Args) {
+		t.Fatalf("expected %d args after redaction (position preserved), got %d", len(def.Args), len(snapshot.Args))
+	}
 	for _, arg := range snapshot.Args {
 		if strings.Contains(arg, "sk-proj-") {
 			t.Fatalf("hook arg should be redacted, got %q", arg)
 		}
+	}
+}
+
+func TestHookSnapshotFromDefinitionPreservesPositionForRedactedArgs(t *testing.T) {
+	def := hooks.Definition{
+		ID:      "hook-2",
+		Event:   hooks.EventBeforeTool,
+		Command: "sh",
+		Args: []string{
+			"-c",
+			"safe arg",
+			"sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+			"another safe arg",
+		},
+	}
+	snapshot := HookSnapshotFromDefinition(def, hooks.SourceProject)
+	if len(snapshot.Args) != 4 {
+		t.Fatalf("expected 4 args after redaction, got %d", len(snapshot.Args))
+	}
+	if snapshot.Args[0] != "-c" || snapshot.Args[1] != "safe arg" {
+		t.Fatalf("non-secret args should round-trip verbatim, got %#v", snapshot.Args[:2])
+	}
+	if strings.Contains(snapshot.Args[2], "sk-proj-") {
+		t.Fatalf("third arg (secret) should be redacted, got %q", snapshot.Args[2])
+	}
+	if snapshot.Args[3] != "another safe arg" {
+		t.Fatalf("fourth arg should be preserved, got %q", snapshot.Args[3])
+	}
+}
+
+func TestMCPServerSnapshotStripsURLCredentials(t *testing.T) {
+	server := mcp.Server{
+		Name: "creds",
+		Type: mcp.ServerTypeHTTP,
+		URL:  "https://admin:secret123@api.example.com/v1",
+	}
+	snapshot := MCPServerSnapshotFromServer(server)
+	if strings.Contains(snapshot.URL, "admin") {
+		t.Fatalf("URL must not contain username, got %q", snapshot.URL)
+	}
+	if strings.Contains(snapshot.URL, "secret123") {
+		t.Fatalf("URL must not contain password, got %q", snapshot.URL)
+	}
+	if strings.Contains(snapshot.URL, "@") {
+		t.Fatalf("URL must not contain userinfo separator, got %q", snapshot.URL)
+	}
+	if snapshot.URL != "https://api.example.com/v1" {
+		t.Fatalf("expected sanitized URL, got %q", snapshot.URL)
+	}
+}
+
+func TestMCPServerSnapshotPreservesURLWithoutCredentials(t *testing.T) {
+	server := mcp.Server{
+		Name: "clean",
+		Type: mcp.ServerTypeHTTP,
+		URL:  "https://api.example.com/v1",
+	}
+	snapshot := MCPServerSnapshotFromServer(server)
+	if snapshot.URL != "https://api.example.com/v1" {
+		t.Fatalf("URL without credentials should be preserved, got %q", snapshot.URL)
+	}
+}
+
+func TestMCPServerSnapshotKeepsUnparseableURLInsteadOfEmpty(t *testing.T) {
+	server := mcp.Server{
+		Name: "broken",
+		Type: mcp.ServerTypeHTTP,
+		URL:  "  not a url but still useful  ",
+	}
+	snapshot := MCPServerSnapshotFromServer(server)
+	if snapshot.URL == "" {
+		t.Fatal("unparseable URL should be kept (trimmed) so the operator sees the configured endpoint")
+	}
+	if snapshot.URL != "not a url but still useful" {
+		t.Fatalf("expected trimmed raw URL, got %q", snapshot.URL)
 	}
 }
 


### PR DESCRIPTION
## Summary

The merged permission and verification event contracts added typed snapshots for config, providers, models, sessions, and the sandbox grant store, but the MCP server config, hooks config, and loaded plugin manifests still expose only the raw backend structs. The TUI render path, the headless `zero mcp`, `zero hooks`, and `zero plugins` commands, and PR/CI automation all need typed snapshots so they do not hand-roll `map[string]any` payloads and do not accidentally leak the secret material that lives in MCP server Env and Headers.

This commit adds three typed snapshot constructors plus a bundled backend lifecycle snapshot to `internal/zerocommands`.

### MCPServerSnapshot

- `name`, `type`, `identity`, `url`, `command` are copied verbatim and trimmed. They are non-secret metadata the operator needs to see when triaging an MCP failure.
- `argCount`, `envKeyCount`, `headerCount` replace the slices and maps with counts. Secret material in `Env` and `Headers` is never serialized.
- `toolCount`, `allowGranted`, `denyGranted` are optional runtime counts that the snapshot can carry when the caller has a live tool registry and a live permission store. A nil counts struct leaves the snapshot at zero.

### HookSnapshot

- `id`, `name`, `event`, `matcher`, `command`, `args`, `enabled`, `source`.
- `command` and `args` are run through the standard redaction pipeline. Whitespace-only args are dropped so JSON output is tight.

### PluginSnapshot

- `id`, `name`, `version`, `description`, `enabled`, `source`, `root`, `pluginDir`, `manifestPath` are copied verbatim and trimmed so the operator can see where the manifest came from.
- `toolCount`, `promptCount`, `skillCount`, `hookCount` replace the full extension slices with counts so the headless JSON output stays small.

### BackendLifecycleSnapshot

- Bundles the three slices into a single payload so `zero doctor` and `zero config` can return one typed result that describes the full extensibility surface.
- All three inner slices are always non-nil, so JSON output is always `[]` and never `null`.

## Tests

- `TestMCPServerSnapshotFromServerStripsSecretsAndCountsMaps`: verifies env and header values never appear in the JSON output, and that the count fields record the maps' sizes.
- `TestMCPServerSnapshotWithCountsMergesRuntimeCounts`: verifies the optional counts bundle is merged and that a nil bundle leaves the snapshot at zero.
- `TestMCPServerSnapshotsSortsAndReturnsEmptySliceForEmptyInput`: verifies alphabetical sort and that nil input returns a non-nil empty slice whose JSON encoding is `[]`.
- `TestHookSnapshotFromDefinitionRedactsCommandAndTrimsFields`: verifies command and args are redacted, and the surrounding fields are trimmed.
- `TestHookSnapshotsSortsByIDAndEvent`: verifies the deterministic (id, event) ordering.
- `TestHookSnapshotsWithSourceTagsEverySnapshot`: verifies the helper that tags every snapshot with the same source string.
- `TestPluginSnapshotFromPluginCollapsesSlicesToCounts`: verifies the path fields are preserved verbatim and the count fields record the slices' sizes.
- `TestPluginSnapshotsSortsByIDAndReturnsEmptySliceForEmptyInput`: verifies id-based sort and empty-slice stability.
- `TestNewBackendLifecycleSnapshotBundlesAndDefaultsNilsToEmpty`: verifies the bundled payload, that nil inputs produce empty slices in the JSON, and that a populated input round-trips.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -count=1 -p 1 ./internal/zerocommands/... ./internal/mcp/... ./internal/hooks/... ./internal/plugins/... ./internal/redaction/...`

## DRI

Gnanam (runtime core owner per `docs/WORK_SPLIT_PRD.md` §4). Closes the typed-snapshot gap for the three backend surfaces in §7.E that the TUI render path, the headless commands, and PR/CI automation consume.

## Out of scope

This PR only adds the typed contracts and the constructors. The TUI render path, the `zero mcp` / `zero hooks` / `zero plugins` headless commands, and the PR/CI automation consumer are follow-up work in their respective owners' lanes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured backend snapshots for servers, hooks, and plugins with trimmed fields, sensitive-value redaction, deterministic ordering, plugin content summarized as counts, optional server permission totals, and hook snapshots tagged with their source.
* **Bug Fixes**
  * Server URLs now strip embedded credentials while preserving unparseable URLs; hook arg redaction preserves positional ordering and omits empty arg lists.
* **Tests**
  * Expanded coverage validating trimming, redaction, counts, sorting, URL handling, tagging, and nil defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->