### PR TITLE
feat(zerocommands): add typed sandbox policy, risk, violation, and decision snapshots

### DIFF
--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -115,6 +115,13 @@ func copyWrapperFixture(t *testing.T) string {
 		t.Fatalf("ReadFile wrapper: %v", err)
 	}
 	dir := t.TempDir()
+	// Create a package.json with "type": "module" so the isolated .js fixture
+	// is treated as ESM (matching how it runs when installed from the real package.json).
+	// Without this, Node treats .js as CJS on all platforms, causing top-level import
+	// to fail with SyntaxError before reaching the missing-binary logic.
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"type":"module"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile package.json fixture: %v", err)
+	}
 	binDir := filepath.Join(dir, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll bin: %v", err)

--- a/internal/zerocommands/sandbox_snapshots.go
+++ b/internal/zerocommands/sandbox_snapshots.go
@@ -1,0 +1,202 @@
+package zerocommands
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+// SandboxPolicySnapshot is the typed view of the live sandbox policy
+// as it is exposed to the TUI render path, the headless
+// `zero sandbox policy --json` command, and PR/CI automation. The
+// snapshot is a strict superset of the on-disk policy shape: every
+// field of sandbox.Policy is copied verbatim, and an EffectiveMode
+// field is added so consumers do not have to translate the empty
+// string into the enforced default themselves.
+type SandboxPolicySnapshot struct {
+	Mode                  string `json:"mode"`
+	Network               string `json:"network"`
+	EnforceWorkspace      bool   `json:"enforceWorkspace"`
+	DenyDestructiveShell  bool   `json:"denyDestructiveShell"`
+	AllowPolicyOnlyRunner bool   `json:"allowPolicyOnlyRunner"`
+	EffectiveMode         string `json:"effectiveMode,omitempty"`
+}
+
+// SandboxRiskSnapshot is the typed view of a sandbox.Risk as it is
+// exposed to the TUI render path and PR/CI automation. The snapshot
+// copies Level and Reason verbatim and sorts Categories
+// alphabetically so the JSON output is deterministic.
+type SandboxRiskSnapshot struct {
+	Level      string   `json:"level"`
+	Categories []string `json:"categories"`
+	Reason     string   `json:"reason"`
+}
+
+// SandboxViolationSnapshot is the typed view of a sandbox.Violation
+// as it is exposed to the TUI render path, the audit log, and
+// PR/CI automation. The Path field is preserved because the
+// operator needs it to triage an out-of-workspace or symlink
+// traversal violation.
+type SandboxViolationSnapshot struct {
+	Code        string `json:"code"`
+	ToolName    string `json:"toolName,omitempty"`
+	Action      string `json:"action"`
+	Path        string `json:"path,omitempty"`
+	Reason      string `json:"reason"`
+	Recoverable bool   `json:"recoverable"`
+}
+
+// SandboxBackendSnapshot is the typed view of a sandbox.Backend as
+// it is exposed to the TUI render path, the headless
+// `zero sandbox policy --json` command, and PR/CI automation. The
+// snapshot is a strict superset of the on-disk backend shape: every
+// field of sandbox.Backend is copied verbatim, and a NativeIsolation
+// field is preserved so the JSON shape matches what consumers
+// already expect.
+type SandboxBackendSnapshot struct {
+	Name            string `json:"name"`
+	Available       bool   `json:"available"`
+	Platform        string `json:"platform,omitempty"`
+	Fallback        bool   `json:"fallback"`
+	CommandWrapping bool   `json:"commandWrapping"`
+	NativeIsolation bool   `json:"nativeIsolation"`
+	Executable      string `json:"executable,omitempty"`
+	Message         string `json:"message,omitempty"`
+}
+
+// SandboxPlanSnapshot is the typed view of a sandbox.BackendPlan as
+// it is exposed to the TUI render path, the headless
+// `zero sandbox policy --json` command, and PR/CI automation. The
+// snapshot bundles the policy, the backend, and the human-readable
+// restriction warnings so the operator gets one payload describing
+// the entire sandbox posture.
+type SandboxPlanSnapshot struct {
+	Policy       SandboxPolicySnapshot  `json:"policy"`
+	Backend      SandboxBackendSnapshot `json:"backend"`
+	Restrictions []string               `json:"restrictions"`
+	WorkspaceRoot string                `json:"workspaceRoot,omitempty"`
+}
+
+// SandboxDecisionSnapshot is the typed view of a live sandbox.Decision
+// as it is exposed to the TUI render path, the audit log, and
+// PR/CI automation. The snapshot includes the resolved grant
+// (when the decision was driven by a persistent grant) and the
+// violation (when the decision was a deny) so consumers do not
+// have to reach back into the sandbox package to render the
+// outcome.
+type SandboxDecisionSnapshot struct {
+	Action       string                      `json:"action"`
+	Reason       string                      `json:"reason,omitempty"`
+	Risk         SandboxRiskSnapshot         `json:"risk"`
+	GrantMatched bool                        `json:"grantMatched"`
+	Grant        *SandboxGrantSnapshot       `json:"grant,omitempty"`
+	Violation    *SandboxViolationSnapshot   `json:"violation,omitempty"`
+}
+
+// SandboxPolicySnapshotFromPolicy converts a sandbox.Policy into its
+// typed snapshot. The EffectiveMode field is the resolved policy
+// mode: an empty Mode falls back to ModeEnforce, which is the
+// runtime default. Consumers can read EffectiveMode to render the
+// "what is actually in effect" line without re-implementing the
+// default.
+func SandboxPolicySnapshotFromPolicy(policy sandbox.Policy) SandboxPolicySnapshot {
+	mode := strings.TrimSpace(string(policy.Mode))
+	if mode == "" {
+		mode = string(sandbox.ModeEnforce)
+	}
+	return SandboxPolicySnapshot{
+		Mode:                  string(policy.Mode),
+		Network:               string(policy.Network),
+		EnforceWorkspace:      policy.EnforceWorkspace,
+		DenyDestructiveShell:  policy.DenyDestructiveShell,
+		AllowPolicyOnlyRunner: policy.AllowPolicyOnlyRunner,
+		EffectiveMode:         mode,
+	}
+}
+
+// SandboxRiskSnapshotFromRisk converts a sandbox.Risk into its
+// typed snapshot. The Categories slice is sorted alphabetically
+// and copied so the snapshot does not alias the input.
+func SandboxRiskSnapshotFromRisk(risk sandbox.Risk) SandboxRiskSnapshot {
+	categories := append([]string(nil), risk.Categories...)
+	sort.Strings(categories)
+	return SandboxRiskSnapshot{
+		Level:      string(risk.Level),
+		Categories: categories,
+		Reason:     strings.TrimSpace(risk.Reason),
+	}
+}
+
+// SandboxViolationSnapshotFromViolation converts a sandbox.Violation
+// into its typed snapshot. A nil input returns a zero snapshot so
+// the helper is safe to call when the decision did not produce a
+// violation.
+func SandboxViolationSnapshotFromViolation(violation *sandbox.Violation) *SandboxViolationSnapshot {
+	if violation == nil {
+		return nil
+	}
+	return &SandboxViolationSnapshot{
+		Code:        string(violation.Code),
+		ToolName:    strings.TrimSpace(violation.ToolName),
+		Action:      string(violation.Action),
+		Path:        strings.TrimSpace(violation.Path),
+		Reason:      strings.TrimSpace(violation.Reason),
+		Recoverable: violation.Recoverable,
+	}
+}
+
+// SandboxBackendSnapshotFromBackend converts a sandbox.Backend into
+// its typed snapshot. Every field is copied verbatim.
+func SandboxBackendSnapshotFromBackend(backend sandbox.Backend) SandboxBackendSnapshot {
+	return SandboxBackendSnapshot{
+		Name:            string(backend.Name),
+		Available:       backend.Available,
+		Platform:        strings.TrimSpace(backend.Platform),
+		Fallback:        backend.Fallback,
+		CommandWrapping: backend.CommandWrapping,
+		NativeIsolation: backend.NativeIsolation,
+		Executable:      strings.TrimSpace(backend.Executable),
+		Message:         strings.TrimSpace(backend.Message),
+	}
+}
+
+// SandboxPlanSnapshotFromPlan converts a sandbox.BackendPlan into its
+// typed snapshot. Each entry of the Restrictions slice is trimmed,
+// the slice is sorted alphabetically, and the result is copied so
+// the snapshot does not alias the input.
+func SandboxPlanSnapshotFromPlan(plan sandbox.BackendPlan) SandboxPlanSnapshot {
+	restrictions := make([]string, 0, len(plan.Restrictions))
+	for _, restriction := range plan.Restrictions {
+		if trimmed := strings.TrimSpace(restriction); trimmed != "" {
+			restrictions = append(restrictions, trimmed)
+		}
+	}
+	sort.Strings(restrictions)
+	return SandboxPlanSnapshot{
+		Policy:        SandboxPolicySnapshotFromPolicy(plan.Policy),
+		Backend:       SandboxBackendSnapshotFromBackend(plan.Backend),
+		Restrictions:  restrictions,
+		WorkspaceRoot: strings.TrimSpace(plan.WorkspaceRoot),
+	}
+}
+
+// SandboxDecisionSnapshotFromDecision converts a sandbox.Decision
+// into its typed snapshot. The optional Grant and Violation fields
+// are converted with their respective helpers so the snapshot
+// always carries the same JSON shape regardless of the decision
+// outcome.
+func SandboxDecisionSnapshotFromDecision(decision sandbox.Decision) SandboxDecisionSnapshot {
+	snapshot := SandboxDecisionSnapshot{
+		Action:       string(decision.Action),
+		Reason:       strings.TrimSpace(decision.Reason),
+		Risk:         SandboxRiskSnapshotFromRisk(decision.Risk),
+		GrantMatched: decision.GrantMatched,
+	}
+	if decision.Grant != nil {
+		grant := SandboxGrantSnapshotFromGrant(*decision.Grant)
+		snapshot.Grant = &grant
+	}
+	snapshot.Violation = SandboxViolationSnapshotFromViolation(decision.Violation)
+	return snapshot
+}

--- a/internal/zerocommands/sandbox_snapshots_test.go
+++ b/internal/zerocommands/sandbox_snapshots_test.go
@@ -1,0 +1,267 @@
+package zerocommands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+func TestSandboxPolicySnapshotFromPolicyFillsEffectiveMode(t *testing.T) {
+	enforced := SandboxPolicySnapshotFromPolicy(sandbox.Policy{
+		Mode:                  sandbox.ModeEnforce,
+		Network:               sandbox.NetworkDeny,
+		EnforceWorkspace:      true,
+		DenyDestructiveShell:  true,
+		AllowPolicyOnlyRunner: true,
+	})
+	if enforced.EffectiveMode != string(sandbox.ModeEnforce) {
+		t.Fatalf("EffectiveMode = %q, want %q", enforced.EffectiveMode, sandbox.ModeEnforce)
+	}
+	if !enforced.EnforceWorkspace || !enforced.DenyDestructiveShell || !enforced.AllowPolicyOnlyRunner {
+		t.Fatalf("boolean fields not preserved: %#v", enforced)
+	}
+
+	disabled := SandboxPolicySnapshotFromPolicy(sandbox.Policy{Mode: sandbox.ModeDisabled})
+	if disabled.EffectiveMode != string(sandbox.ModeDisabled) {
+		t.Fatalf("disabled EffectiveMode = %q, want %q", disabled.EffectiveMode, sandbox.ModeDisabled)
+	}
+
+	defaulted := SandboxPolicySnapshotFromPolicy(sandbox.Policy{})
+	if defaulted.EffectiveMode != string(sandbox.ModeEnforce) {
+		t.Fatalf("defaulted EffectiveMode = %q, want %q (runtime default)", defaulted.EffectiveMode, sandbox.ModeEnforce)
+	}
+	if defaulted.Mode != "" {
+		t.Fatalf("defaulted Mode = %q, want empty (untouched)", defaulted.Mode)
+	}
+}
+
+func TestSandboxRiskSnapshotFromRiskSortsCategoriesAndTrimsReason(t *testing.T) {
+	risk := sandbox.Risk{
+		Level:      sandbox.RiskHigh,
+		Categories: []string{"shell", "absolute_path", "destructive"},
+		Reason:     "  destructive shell command  ",
+	}
+	snapshot := SandboxRiskSnapshotFromRisk(risk)
+	if snapshot.Level != string(sandbox.RiskHigh) {
+		t.Fatalf("Level = %q, want %q", snapshot.Level, sandbox.RiskHigh)
+	}
+	if snapshot.Reason != "destructive shell command" {
+		t.Fatalf("Reason not trimmed: %q", snapshot.Reason)
+	}
+	want := []string{"absolute_path", "destructive", "shell"}
+	if len(snapshot.Categories) != len(want) {
+		t.Fatalf("Categories length = %d, want %d", len(snapshot.Categories), len(want))
+	}
+	for index, category := range want {
+		if snapshot.Categories[index] != category {
+			t.Fatalf("Categories[%d] = %q, want %q", index, snapshot.Categories[index], category)
+		}
+	}
+
+	snapshot = SandboxRiskSnapshotFromRisk(sandbox.Risk{Level: sandbox.RiskLow, Categories: nil})
+	if snapshot.Categories != nil {
+		t.Fatalf("expected nil Categories for nil input, got %#v", snapshot.Categories)
+	}
+}
+
+func TestSandboxViolationSnapshotFromViolationHandlesNilAndTrims(t *testing.T) {
+	if got := SandboxViolationSnapshotFromViolation(nil); got != nil {
+		t.Fatalf("expected nil snapshot for nil violation, got %#v", got)
+	}
+
+	violation := &sandbox.Violation{
+		Code:        sandbox.ViolationOutsideWorkspace,
+		ToolName:    "  write_file  ",
+		Action:      sandbox.ActionDeny,
+		Path:        "  /etc/hosts  ",
+		Reason:      "  path escapes workspace  ",
+		Recoverable: true,
+	}
+	snapshot := SandboxViolationSnapshotFromViolation(violation)
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot for non-nil violation")
+	}
+	if snapshot.Code != string(sandbox.ViolationOutsideWorkspace) {
+		t.Fatalf("Code = %q, want %q", snapshot.Code, sandbox.ViolationOutsideWorkspace)
+	}
+	if snapshot.ToolName != "write_file" {
+		t.Fatalf("ToolName not trimmed: %q", snapshot.ToolName)
+	}
+	if snapshot.Path != "/etc/hosts" {
+		t.Fatalf("Path not trimmed: %q", snapshot.Path)
+	}
+	if snapshot.Reason != "path escapes workspace" {
+		t.Fatalf("Reason not trimmed: %q", snapshot.Reason)
+	}
+	if !snapshot.Recoverable {
+		t.Fatal("Recoverable should round-trip")
+	}
+}
+
+func TestSandboxBackendSnapshotFromBackendCopiesAllFields(t *testing.T) {
+	backend := sandbox.Backend{
+		Name:            sandbox.BackendBubblewrap,
+		Available:       true,
+		Platform:        "linux",
+		Fallback:        false,
+		CommandWrapping: true,
+		NativeIsolation: true,
+		Executable:      "  bwrap  ",
+		Message:         "  bubblewrap is available  ",
+	}
+	snapshot := SandboxBackendSnapshotFromBackend(backend)
+	if snapshot.Name != string(sandbox.BackendBubblewrap) {
+		t.Fatalf("Name = %q, want %q", snapshot.Name, sandbox.BackendBubblewrap)
+	}
+	if !snapshot.Available || !snapshot.CommandWrapping || !snapshot.NativeIsolation {
+		t.Fatalf("boolean fields not preserved: %#v", snapshot)
+	}
+	if snapshot.Executable != "bwrap" {
+		t.Fatalf("Executable not trimmed: %q", snapshot.Executable)
+	}
+	if snapshot.Message != "bubblewrap is available" {
+		t.Fatalf("Message not trimmed: %q", snapshot.Message)
+	}
+}
+
+func TestSandboxPlanSnapshotFromPlanSortsRestrictionsAndTrimsRoot(t *testing.T) {
+	plan := sandbox.BackendPlan{
+		Backend: sandbox.Backend{Name: sandbox.BackendSandboxExec, Platform: "darwin"},
+		Policy:  sandbox.Policy{Mode: sandbox.ModeEnforce, Network: sandbox.NetworkDeny},
+		Restrictions: []string{
+			"  native process isolation unavailable on darwin  ",
+			"network access is blocked by sandbox policy",
+		},
+		WorkspaceRoot: "  /repo  ",
+	}
+	snapshot := SandboxPlanSnapshotFromPlan(plan)
+	if snapshot.Policy.EffectiveMode != string(sandbox.ModeEnforce) {
+		t.Fatalf("Policy.EffectiveMode = %q, want %q", snapshot.Policy.EffectiveMode, sandbox.ModeEnforce)
+	}
+	if snapshot.Backend.Name != string(sandbox.BackendSandboxExec) {
+		t.Fatalf("Backend.Name = %q, want %q", snapshot.Backend.Name, sandbox.BackendSandboxExec)
+	}
+	if snapshot.WorkspaceRoot != "/repo" {
+		t.Fatalf("WorkspaceRoot not trimmed: %q", snapshot.WorkspaceRoot)
+	}
+	if len(snapshot.Restrictions) != 2 {
+		t.Fatalf("Restrictions length = %d, want 2", len(snapshot.Restrictions))
+	}
+	if snapshot.Restrictions[0] != "native process isolation unavailable on darwin" {
+		t.Fatalf("Restrictions[0] not trimmed: %q", snapshot.Restrictions[0])
+	}
+	if snapshot.Restrictions[1] != "network access is blocked by sandbox policy" {
+		t.Fatalf("Restrictions[1] = %q, want %q", snapshot.Restrictions[1], snapshot.Restrictions[1])
+	}
+}
+
+func TestSandboxDecisionSnapshotFromDecisionAllowBranchHasNoViolation(t *testing.T) {
+	decision := sandbox.Decision{
+		Action: sandbox.ActionAllow,
+		Reason: "tool safety allows execution",
+		Risk:   sandbox.Risk{Level: sandbox.RiskLow, Categories: []string{"read"}, Reason: "low risk: read"},
+	}
+	snapshot := SandboxDecisionSnapshotFromDecision(decision)
+	if snapshot.Action != string(sandbox.ActionAllow) {
+		t.Fatalf("Action = %q, want %q", snapshot.Action, sandbox.ActionAllow)
+	}
+	if snapshot.GrantMatched {
+		t.Fatal("GrantMatched should be false when no grant was matched")
+	}
+	if snapshot.Grant != nil {
+		t.Fatalf("Grant should be nil for grantless decision, got %#v", snapshot.Grant)
+	}
+	if snapshot.Violation != nil {
+		t.Fatalf("Violation should be nil for allow decision, got %#v", snapshot.Violation)
+	}
+	if snapshot.Risk.Level != string(sandbox.RiskLow) {
+		t.Fatalf("Risk.Level = %q, want %q", snapshot.Risk.Level, sandbox.RiskLow)
+	}
+}
+
+func TestSandboxDecisionSnapshotFromDecisionPersistentDenyCarriesGrantAndViolation(t *testing.T) {
+	decision := sandbox.Decision{
+		Action:       sandbox.ActionDeny,
+		Reason:       "persistent sandbox deny grant matched",
+		Risk:         sandbox.Risk{Level: sandbox.RiskHigh, Categories: []string{"shell"}, Reason: "high risk: shell"},
+		GrantMatched: true,
+		Grant: &sandbox.Grant{
+			ToolName:    "bash",
+			Decision:    sandbox.GrantDeny,
+			MaxAutonomy: sandbox.AutonomyHigh,
+			ApprovedAt:  "2026-06-04T10:00:00Z",
+			Reason:      "user marked bash as destructive",
+		},
+		Violation: &sandbox.Violation{
+			Code:        sandbox.ViolationPersistentDeny,
+			ToolName:    "bash",
+			Action:      sandbox.ActionDeny,
+			Reason:      "persistent sandbox deny grant matched",
+			Recoverable: true,
+		},
+	}
+	snapshot := SandboxDecisionSnapshotFromDecision(decision)
+	if !snapshot.GrantMatched {
+		t.Fatal("GrantMatched should be true")
+	}
+	if snapshot.Grant == nil {
+		t.Fatal("Grant should be present")
+	}
+	if snapshot.Grant.ToolName != "bash" {
+		t.Fatalf("Grant.ToolName = %q, want bash", snapshot.Grant.ToolName)
+	}
+	if snapshot.Grant.Decision != string(sandbox.GrantDeny) {
+		t.Fatalf("Grant.Decision = %q, want %q", snapshot.Grant.Decision, sandbox.GrantDeny)
+	}
+	if snapshot.Violation == nil {
+		t.Fatal("Violation should be present on deny decision")
+	}
+	if snapshot.Violation.Code != string(sandbox.ViolationPersistentDeny) {
+		t.Fatalf("Violation.Code = %q, want %q", snapshot.Violation.Code, sandbox.ViolationPersistentDeny)
+	}
+}
+
+func TestSandboxDecisionSnapshotJSONShapeIsStable(t *testing.T) {
+	snapshot := SandboxDecisionSnapshot{
+		Action: string(sandbox.ActionPrompt),
+		Reason: "tool requires approval before execution",
+		Risk: SandboxRiskSnapshot{
+			Level:      string(sandbox.RiskHigh),
+			Categories: []string{"shell"},
+			Reason:     "high risk: shell",
+		},
+	}
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	decoded := map[string]any{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	for _, key := range []string{"action", "reason", "risk", "grantMatched"} {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("expected key %q in decision JSON, got %q", key, string(encoded))
+		}
+	}
+	if _, ok := decoded["violation"]; ok {
+		t.Fatalf("violation should be omitted when nil, got %q", string(encoded))
+	}
+	if _, ok := decoded["grant"]; ok {
+		t.Fatalf("grant should be omitted when nil, got %q", string(encoded))
+	}
+}
+
+func TestSandboxPolicySnapshotJSONOmitsEmptyEffectiveMode(t *testing.T) {
+	policy := SandboxPolicySnapshot{Mode: string(sandbox.ModeEnforce), Network: string(sandbox.NetworkDeny)}
+	policy.EffectiveMode = ""
+	encoded, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(encoded), `"effectiveMode"`) {
+		t.Fatalf("expected effectiveMode omitted when empty, got %q", string(encoded))
+	}
+}


### PR DESCRIPTION
## Summary

The merged permission and verification event contracts (#82) added typed snapshots for config, providers, models, and sessions, and PR #89 added the typed snapshot for the persistent sandbox grant store, but the live sandbox policy, the live risk classification, the live violation, and the live decision were still exposed as the raw backend structs. The TUI render path, the headless `zero sandbox policy --json` and `zero sandbox decide` commands, the audit log, and PR/CI automation all need typed snapshots so they do not hand-roll `map[string]any` payloads and so they do not have to re-implement the runtime default-mode translation themselves.

This commit adds five typed snapshot constructors and a bundled plan snapshot to `internal/zerocommands`.

### SandboxPolicySnapshot

- `mode`, `network`, `enforceWorkspace`, `denyDestructiveShell`, and `allowPolicyOnlyRunner` are copied verbatim from the underlying `sandbox.Policy`.
- `effectiveMode` is the resolved policy mode. An empty `Mode` in the input falls back to `ModeEnforce`, which is the runtime default. Consumers can read `EffectiveMode` to render the "what is actually in effect" line without re-implementing the default.
- `effectiveMode` is JSON-omitted when empty so the snapshot shape stays stable for downstream consumers.

### SandboxRiskSnapshot

- `level`, `categories`, `reason`.
- `categories` is copied and sorted alphabetically so the JSON output is deterministic.
- `reason` is trimmed.

### SandboxViolationSnapshot

- `code`, `toolName`, `action`, `path`, `reason`, `recoverable`.
- The pointer-returning helper returns nil for a nil input so callers can chain it through `SandboxDecisionSnapshot` without nil checks at the call site.

### SandboxBackendSnapshot

- `name`, `available`, `platform`, `fallback`, `commandWrapping`, `nativeIsolation`, `executable`, `message`.
- `executable` and `message` are trimmed.

### SandboxPlanSnapshot

- Bundles policy, backend, restrictions, and workspaceRoot into one payload so `zero sandbox policy --json` can return one typed result describing the full sandbox posture.
- Each entry of `restrictions` is trimmed, whitespace-only entries are dropped, and the result is sorted alphabetically.
- `workspaceRoot` is trimmed and JSON-omitted when empty.

### SandboxDecisionSnapshot

- `action`, `reason`, `risk`, `grantMatched`, `grant`, `violation`.
- The optional grant pointer is converted with `SandboxGrantSnapshotFromGrant` (from PR #89) so the JSON shape matches the persistent-grant snapshot exactly.
- The optional violation pointer is converted with `SandboxViolationSnapshotFromViolation` so the snapshot always carries the same shape regardless of the decision outcome.
- When grant or violation is nil, the field is JSON-omitted.

## Tests

- `TestSandboxPolicySnapshotFromPolicyFillsEffectiveMode`: verifies `EffectiveMode` is enforced for an empty `Mode`, set to `ModeDisabled` for an explicit disabled mode, and preserved for an explicit enforced mode.
- `TestSandboxRiskSnapshotFromRiskSortsCategoriesAndTrimsReason`: verifies alphabetical sort, trimmed reason, and that a nil `Categories` input produces a nil output (no spurious empty slice).
- `TestSandboxViolationSnapshotFromViolationHandlesNilAndTrims`: verifies the nil-input contract and the trim behaviour for every string field.
- `TestSandboxBackendSnapshotFromBackendCopiesAllFields`: verifies the boolean and string fields round-trip and the trim behaviour for the executable and message.
- `TestSandboxPlanSnapshotFromPlanSortsRestrictionsAndTrimsRoot`: verifies alphabetical sort, per-entry trim, and workspaceRoot trim.
- `TestSandboxDecisionSnapshotFromDecisionAllowBranchHasNoViolation`: verifies the allow path has no grant and no violation.
- `TestSandboxDecisionSnapshotFromDecisionPersistentDenyCarriesGrantAndViolation`: verifies the deny path carries both the resolved grant and the violation, and that the grant snapshot matches the persistent-grant snapshot shape from PR #89.
- `TestSandboxDecisionSnapshotJSONShapeIsStable`: verifies the stable keys and the nil-pointer omission.
- `TestSandboxPolicySnapshotJSONOmitsEmptyEffectiveMode`: verifies the `omitempty` tag.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -count=1 -p 1 ./internal/zerocommands/... ./internal/sandbox/... ./internal/redaction/...`

## DRI

Gnanam (runtime core owner per `docs/WORK_SPLIT_PRD.md` §4). Closes the typed-snapshot gap for the live sandbox surface that the TUI render path, the `zero sandbox` headless commands, the audit log, and PR/CI automation consume.

## Out of scope

This PR only adds the typed contracts and the constructors. The TUI render path, the `zero sandbox policy --json` and `zero sandbox decide` headless commands, the audit log sink, and the PR/CI automation consumer are follow-up work in their respective owners' lanes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an internal snapshot-based serialization layer for sandbox data with normalized fields and deterministic ordering.

* **Tests**
  * Added comprehensive tests for snapshot conversions and edge cases.
  * Adjusted a test fixture to ensure the wrapper executes as an ES module during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->