### PR TITLE
feat(tui): surface sandbox permission events

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -277,6 +277,16 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 		return writeAppError(stderr, err.Error(), 1)
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)
+	sandboxStore, err := deps.newSandboxStore()
+	if err != nil {
+		return writeAppError(stderr, "failed to initialize sandbox grants: "+err.Error(), 1)
+	}
+	sandboxEngine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: workspaceRoot,
+		Policy:        sandbox.DefaultPolicy(),
+		Store:         sandboxStore,
+		Backend:       deps.selectSandboxBackend(sandbox.BackendOptions{}),
+	})
 	permissionMode := agent.PermissionModeAuto
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:             workspaceRoot,
@@ -287,10 +297,13 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 		NewProvider:     deps.newProvider,
 		Registry:        registry,
 		SessionStore:    deps.newSessionStore(),
+		SandboxStore:    sandboxStore,
 		AgentOptions: agent.Options{
 			MaxTurns:       resolved.MaxTurns,
 			Registry:       registry,
 			PermissionMode: permissionMode,
+			Autonomy:       string(sandbox.AutonomyLow),
+			Sandbox:        sandboxEngine,
 		},
 		PermissionMode: permissionMode,
 	})

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
 	"github.com/Gitlawb/zero/internal/update"
@@ -545,6 +546,15 @@ func assertAgentOptions(t *testing.T, options tui.Options, maxTurns int, permiss
 	}
 	if options.AgentOptions.PermissionMode != permissionMode {
 		t.Fatalf("AgentOptions.PermissionMode = %q, want %q", options.AgentOptions.PermissionMode, permissionMode)
+	}
+	if options.AgentOptions.Autonomy != string(sandbox.AutonomyLow) {
+		t.Fatalf("AgentOptions.Autonomy = %q, want %q", options.AgentOptions.Autonomy, sandbox.AutonomyLow)
+	}
+	if options.AgentOptions.Sandbox == nil {
+		t.Fatal("AgentOptions.Sandbox = nil, want sandbox engine")
+	}
+	if options.SandboxStore == nil {
+		t.Fatal("SandboxStore = nil, want sandbox grant store")
 	}
 	if options.PermissionMode != permissionMode {
 		t.Fatalf("PermissionMode = %q, want %q", options.PermissionMode, permissionMode)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -80,7 +80,7 @@ var commandDefinitions = []commandDefinition{
 		name:        "/permissions",
 		usage:       "/permissions",
 		group:       commandGroupRuntime,
-		description: "Show the active permission mode.",
+		description: "Show the active permission mode and sandbox grants.",
 		kind:        commandPermissions,
 	},
 	{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,38 +26,39 @@ const tuiToolOutputLimit = 240
 const defaultResponseStyle = "balanced"
 
 type model struct {
-	ctx              context.Context
-	cwd              string
-	gitBranch        string
-	providerName     string
-	modelName        string
-	providerProfile  config.ProviderProfile
-	provider         zeroruntime.Provider
-	newProvider      func(config.ProviderProfile) (zeroruntime.Provider, error)
-	registry         *tools.Registry
-	sessionStore     *sessions.Store
-	sandboxStore     *sandbox.GrantStore
-	activeSession    sessions.Metadata
-	sessionEvents    []sessions.Event
-	usageTracker     *usage.Tracker
-	agentOptions     agent.Options
-	permissionMode   agent.PermissionMode
-	reasoningEffort  modelregistry.ReasoningEffort
-	responseStyle    string
-	compactRequests  int
-	unpricedRequests int
-	unpricedTokens   int
-	transcript       []transcriptRow
-	input            textinput.Model
-	showSplash       bool
-	pending          bool
-	exiting          bool
-	runCancel        context.CancelFunc
-	runID            int
-	activeRunID      int
-	width            int
-	height           int
-	now              func() time.Time
+	ctx                context.Context
+	cwd                string
+	gitBranch          string
+	providerName       string
+	modelName          string
+	providerProfile    config.ProviderProfile
+	provider           zeroruntime.Provider
+	newProvider        func(config.ProviderProfile) (zeroruntime.Provider, error)
+	registry           *tools.Registry
+	sessionStore       *sessions.Store
+	sandboxStore       *sandbox.GrantStore
+	activeSession      sessions.Metadata
+	sessionEvents      []sessions.Event
+	usageTracker       *usage.Tracker
+	runtimeMessageSink func(tea.Msg)
+	agentOptions       agent.Options
+	permissionMode     agent.PermissionMode
+	reasoningEffort    modelregistry.ReasoningEffort
+	responseStyle      string
+	compactRequests    int
+	unpricedRequests   int
+	unpricedTokens     int
+	transcript         []transcriptRow
+	input              textinput.Model
+	showSplash         bool
+	pending            bool
+	exiting            bool
+	runCancel          context.CancelFunc
+	runID              int
+	activeRunID        int
+	width              int
+	height             int
+	now                func() time.Time
 }
 
 type agentResponseMsg struct {
@@ -67,6 +68,11 @@ type agentResponseMsg struct {
 	usageModelID  string
 	sessionEvents []pendingSessionEvent
 	err           error
+}
+
+type agentRowMsg struct {
+	runID int
+	row   transcriptRow
 }
 
 func newModel(ctx context.Context, options Options) model {
@@ -112,26 +118,27 @@ func newModel(ctx context.Context, options Options) model {
 	input.Focus()
 
 	return model{
-		ctx:             ctx,
-		cwd:             cwd,
-		gitBranch:       gitBranch(cwd),
-		providerName:    options.ProviderName,
-		modelName:       options.ModelName,
-		providerProfile: options.ProviderProfile,
-		provider:        options.Provider,
-		newProvider:     options.NewProvider,
-		registry:        registry,
-		sessionStore:    sessionStore,
-		sandboxStore:    sandboxStore,
-		agentOptions:    options.AgentOptions,
-		permissionMode:  permissionMode,
-		reasoningEffort: options.ReasoningEffort,
-		responseStyle:   defaultedResponseStyle(options.ResponseStyle),
-		usageTracker:    usageTracker,
-		transcript:      initialTranscript(),
-		input:           input,
-		showSplash:      true,
-		now:             time.Now,
+		ctx:                ctx,
+		cwd:                cwd,
+		gitBranch:          gitBranch(cwd),
+		providerName:       options.ProviderName,
+		modelName:          options.ModelName,
+		providerProfile:    options.ProviderProfile,
+		provider:           options.Provider,
+		newProvider:        options.NewProvider,
+		registry:           registry,
+		sessionStore:       sessionStore,
+		sandboxStore:       sandboxStore,
+		agentOptions:       options.AgentOptions,
+		runtimeMessageSink: options.RuntimeMessageSink,
+		permissionMode:     permissionMode,
+		reasoningEffort:    options.ReasoningEffort,
+		responseStyle:      defaultedResponseStyle(options.ResponseStyle),
+		usageTracker:       usageTracker,
+		transcript:         initialTranscript(),
+		input:              input,
+		showSplash:         true,
+		now:                time.Now,
 	}
 }
 
@@ -188,6 +195,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				text: msg.err.Error(),
 			})
 		}
+		return m, nil
+	case agentRowMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		m.transcript = appendTranscriptRow(m.transcript, msg.row)
 		return m, nil
 	}
 
@@ -423,12 +436,15 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 
 		onToolCall := options.OnToolCall
 		options.OnToolCall = func(call agent.ToolCall) {
-			rows = append(rows, transcriptRow{
+			row := transcriptRow{
 				kind:   rowToolCall,
+				id:     call.ID,
 				text:   "tool call: " + call.Name,
 				tool:   call.Name,
 				detail: argHint(call.Arguments),
-			})
+			}
+			rows = append(rows, row)
+			m.sendAgentRow(runID, row)
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type: sessions.EventToolCall,
 				Payload: map[string]any{
@@ -444,13 +460,16 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 
 		onToolResult := options.OnToolResult
 		options.OnToolResult = func(result agent.ToolResult) {
-			rows = append(rows, transcriptRow{
+			row := transcriptRow{
 				kind:   rowToolResult,
+				id:     result.ToolCallID,
 				text:   toolResultRowText(result),
 				tool:   result.Name,
 				status: result.Status,
 				detail: result.Output,
-			})
+			}
+			rows = append(rows, row)
+			m.sendAgentRow(runID, row)
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type: sessions.EventToolResult,
 				Payload: map[string]any{
@@ -467,7 +486,9 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 
 		onPermission := options.OnPermission
 		options.OnPermission = func(event agent.PermissionEvent) {
-			rows = append(rows, permissionTranscriptRow(event))
+			row := permissionTranscriptRow(event)
+			rows = append(rows, row)
+			m.sendAgentRow(runID, row)
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type:    sessions.EventPermission,
 				Payload: event,
@@ -511,6 +532,13 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		})
 		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents}
 	}
+}
+
+func (m model) sendAgentRow(runID int, row transcriptRow) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(agentRowMsg{runID: runID, row: row})
 }
 
 func toolResultRowText(result agent.ToolResult) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,9 +14,11 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/usage"
+	"github.com/Gitlawb/zero/internal/zerocommands"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -34,6 +36,7 @@ type model struct {
 	newProvider      func(config.ProviderProfile) (zeroruntime.Provider, error)
 	registry         *tools.Registry
 	sessionStore     *sessions.Store
+	sandboxStore     *sandbox.GrantStore
 	activeSession    sessions.Metadata
 	sessionEvents    []sessions.Event
 	usageTracker     *usage.Tracker
@@ -89,6 +92,7 @@ func newModel(ctx context.Context, options Options) model {
 	if sessionStore == nil {
 		sessionStore = sessions.NewStore(sessions.StoreOptions{})
 	}
+	sandboxStore := options.SandboxStore
 	usageTracker := options.UsageTracker
 	if usageTracker == nil {
 		usageTracker = usage.NewTracker(usage.TrackerOptions{})
@@ -118,6 +122,7 @@ func newModel(ctx context.Context, options Options) model {
 		newProvider:     options.NewProvider,
 		registry:        registry,
 		sessionStore:    sessionStore,
+		sandboxStore:    sandboxStore,
 		agentOptions:    options.AgentOptions,
 		permissionMode:  permissionMode,
 		reasoningEffort: options.ReasoningEffort,
@@ -460,6 +465,18 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 			}
 		}
 
+		onPermission := options.OnPermission
+		options.OnPermission = func(event agent.PermissionEvent) {
+			rows = append(rows, permissionTranscriptRow(event))
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type:    sessions.EventPermission,
+				Payload: event,
+			})
+			if onPermission != nil {
+				onPermission(event)
+			}
+		}
+
 		onUsage := options.OnUsage
 		options.OnUsage = func(event zeroruntime.Usage) {
 			usageEvents = append(usageEvents, event)
@@ -531,7 +548,35 @@ func (m model) toolsText() string {
 }
 
 func (m model) permissionsText() string {
-	return "Permission mode: " + string(m.permissionMode)
+	lines := []string{"Permission mode: " + string(m.permissionMode)}
+	if m.sandboxStore == nil {
+		lines = append(lines, "Sandbox grants: unavailable")
+		return strings.Join(lines, "\n")
+	}
+
+	grants, err := m.sandboxStore.List()
+	if err != nil {
+		lines = append(lines, "Sandbox grants: error: "+err.Error())
+		return strings.Join(lines, "\n")
+	}
+	snapshots := zerocommands.SandboxGrantSnapshots(grants)
+	if len(snapshots) == 0 {
+		lines = append(lines, "Sandbox grants: none")
+		return strings.Join(lines, "\n")
+	}
+
+	lines = append(lines, "Sandbox grants:")
+	for _, grant := range snapshots {
+		line := fmt.Sprintf("- %s [%s/%s]", grant.ToolName, grant.Decision, grant.MaxAutonomy)
+		if grant.ApprovedAt != "" {
+			line += " approved " + grant.ApprovedAt
+		}
+		if grant.Reason != "" {
+			line += " - " + grant.Reason
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m model) providerText() string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -260,6 +262,51 @@ func TestToolsCommandListsRegisteredTools(t *testing.T) {
 	if !transcriptContains(next.transcript, "read_file") {
 		t.Fatalf("expected tools transcript to list read_file, got %#v", next.transcript)
 	}
+}
+
+func TestPermissionsCommandListsPersistentSandboxGrants(t *testing.T) {
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.Grant(sandbox.GrantInput{
+		ToolName:    "bash",
+		Decision:    sandbox.GrantAllow,
+		MaxAutonomy: sandbox.AutonomyHigh,
+		Reason:      "sk-proj-sensitive trusted shell",
+	}); err != nil {
+		t.Fatalf("Grant bash returned error: %v", err)
+	}
+	if _, err := store.Grant(sandbox.GrantInput{
+		ToolName:    "write_file",
+		Decision:    sandbox.GrantDeny,
+		MaxAutonomy: sandbox.AutonomyLow,
+	}); err != nil {
+		t.Fatalf("Grant write_file returned error: %v", err)
+	}
+	m := newModel(context.Background(), Options{
+		PermissionMode: agent.PermissionModeAsk,
+		SandboxStore:   store,
+	})
+	m.input.SetValue("/permissions")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /permissions to be handled without starting an agent run")
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{
+		"Permission mode: ask",
+		"Sandbox grants:",
+		"bash [allow/high]",
+		"write_file [deny/low]",
+		"[REDACTED]",
+	} {
+		assertContains(t, text, want)
+	}
+	assertNotContains(t, text, "sk-proj-sensitive")
 }
 
 func TestPlanCommandShowsCurrentPlan(t *testing.T) {
@@ -722,6 +769,71 @@ func TestAgentResponsePreservesToolResultMetadata(t *testing.T) {
 	assertContains(t, renderRow(row, 80), "@@ -1 +1 @@")
 }
 
+func TestAgentResponsePreservesPermissionMetadata(t *testing.T) {
+	event := agent.PermissionEvent{
+		ToolCallID:     "call_1",
+		ToolName:       "write_file",
+		Action:         agent.PermissionActionPrompt,
+		Permission:     "prompt",
+		PermissionMode: agent.PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		SideEffect:     "write",
+		Reason:         "Creates or overwrites files.",
+		Risk:           sandbox.Risk{Level: sandbox.RiskHigh},
+	}
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+
+	updated, _ := m.Update(agentResponseMsg{
+		runID: 7,
+		rows:  []transcriptRow{permissionTranscriptRow(event)},
+	})
+	next := updated.(model)
+
+	row, ok := findTranscriptRow(next.transcript, rowPermission)
+	if !ok {
+		t.Fatalf("expected permission row, got %#v", next.transcript)
+	}
+	if row.tool != "write_file" || row.permission == nil || row.permission.ToolCallID != "call_1" {
+		t.Fatalf("permission metadata was not preserved: %#v", row)
+	}
+	rendered := renderRow(row, 96)
+	for _, want := range []string{"permission", "write_file", "prompt", "risk:high", "mode=ask", "Creates or overwrites files."} {
+		assertContains(t, rendered, want)
+	}
+}
+
+func TestPermissionRowRendersSandboxViolations(t *testing.T) {
+	violation := sandbox.Violation{
+		Code:        sandbox.ViolationOutsideWorkspace,
+		ToolName:    "write_file",
+		Action:      sandbox.ActionDeny,
+		Risk:        sandbox.Risk{Level: sandbox.RiskCritical},
+		Path:        "../secret.txt",
+		Reason:      "writes must stay inside workspace",
+		Recoverable: false,
+	}
+	event := agent.PermissionEvent{
+		ToolCallID:     "call_2",
+		ToolName:       "write_file",
+		Action:         agent.PermissionActionDeny,
+		Permission:     "prompt",
+		PermissionMode: agent.PermissionModeUnsafe,
+		Autonomy:       string(sandbox.AutonomyHigh),
+		SideEffect:     "write",
+		Reason:         "workspace boundary enforced",
+		Risk:           sandbox.Risk{Level: sandbox.RiskCritical},
+		Violation:      &violation,
+	}
+
+	rendered := renderRow(permissionTranscriptRow(event), 96)
+
+	for _, want := range []string{"permission", "write_file", "denied", "risk:critical", "violation=outside_workspace", "../secret.txt"} {
+		assertContains(t, rendered, want)
+	}
+}
+
 func TestAgentEventRenderingMappingCoversRuntimeContract(t *testing.T) {
 	surfaces := map[zeroruntime.AgentEventType]string{
 		zeroruntime.AgentEventText:       "assistant transcript row",
@@ -866,6 +978,17 @@ func transcriptContains(rows []transcriptRow, want string) bool {
 		}
 	}
 	return false
+}
+
+func transcriptText(rows []transcriptRow) string {
+	parts := make([]string, 0, len(rows))
+	for _, row := range rows {
+		parts = append(parts, row.text)
+		if row.detail != "" {
+			parts = append(parts, row.detail)
+		}
+	}
+	return strings.Join(parts, "\n")
 }
 
 func findTranscriptRow(rows []transcriptRow, kind rowKind) (transcriptRow, bool) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -823,14 +823,34 @@ func TestPermissionRowRendersSandboxViolations(t *testing.T) {
 		Autonomy:       string(sandbox.AutonomyHigh),
 		SideEffect:     "write",
 		Reason:         "workspace boundary enforced",
-		Risk:           sandbox.Risk{Level: sandbox.RiskCritical},
+		Risk:           sandbox.Risk{Level: sandbox.RiskHigh},
 		Violation:      &violation,
 	}
 
 	rendered := renderRow(permissionTranscriptRow(event), 96)
 
-	for _, want := range []string{"permission", "write_file", "denied", "risk:critical", "violation=outside_workspace", "../secret.txt"} {
+	for _, want := range []string{"permission", "write_file", "denied", "risk:high", "violation=outside_workspace risk=critical", "../secret.txt"} {
 		assertContains(t, rendered, want)
+	}
+}
+
+func TestAppendTranscriptRowDedupesRuntimeRowsByID(t *testing.T) {
+	event := agent.PermissionEvent{
+		ToolCallID: "call_1",
+		ToolName:   "write_file",
+		Action:     agent.PermissionActionPrompt,
+	}
+	rows := initialTranscript()
+	rows = appendTranscriptRow(rows, transcriptRow{kind: rowToolCall, id: "call_1", text: "tool call: write_file", tool: "write_file"})
+	rows = appendTranscriptRow(rows, permissionTranscriptRow(event))
+	rows = appendTranscriptRow(rows, transcriptRow{kind: rowToolResult, id: "call_1", text: "tool result: write_file error", tool: "write_file", status: tools.StatusError})
+
+	rows = appendTranscriptRow(rows, transcriptRow{kind: rowToolCall, id: "call_1", text: "tool call: write_file", tool: "write_file"})
+	rows = appendTranscriptRow(rows, permissionTranscriptRow(event))
+	rows = appendTranscriptRow(rows, transcriptRow{kind: rowToolResult, id: "call_1", text: "tool result: write_file error", tool: "write_file", status: tools.StatusError})
+
+	if len(rows) != 4 {
+		t.Fatalf("expected welcome plus three unique runtime rows, got %#v", rows)
 	}
 }
 
@@ -989,6 +1009,16 @@ func transcriptText(rows []transcriptRow) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+func countTranscriptRows(rows []transcriptRow, kind rowKind) int {
+	count := 0
+	for _, row := range rows {
+		if row.kind == kind {
+			count++
+		}
+	}
+	return count
 }
 
 func findTranscriptRow(rows []transcriptRow, kind rowKind) (transcriptRow, bool) {

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
@@ -13,16 +15,17 @@ import (
 
 // Options configures the reusable Zero terminal UI shell.
 type Options struct {
-	Cwd             string
-	ProviderName    string
-	ModelName       string
-	ProviderProfile config.ProviderProfile
-	Provider        zeroruntime.Provider
-	NewProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
-	Registry        *tools.Registry
-	SessionStore    *sessions.Store
-	SandboxStore    *sandbox.GrantStore
-	UsageTracker    *usage.Tracker
+	Cwd                string
+	ProviderName       string
+	ModelName          string
+	ProviderProfile    config.ProviderProfile
+	Provider           zeroruntime.Provider
+	NewProvider        func(config.ProviderProfile) (zeroruntime.Provider, error)
+	RuntimeMessageSink func(tea.Msg)
+	Registry           *tools.Registry
+	SessionStore       *sessions.Store
+	SandboxStore       *sandbox.GrantStore
+	UsageTracker       *usage.Tracker
 
 	AgentOptions    agent.Options
 	PermissionMode  agent.PermissionMode

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/usage"
@@ -20,6 +21,7 @@ type Options struct {
 	NewProvider     func(config.ProviderProfile) (zeroruntime.Provider, error)
 	Registry        *tools.Registry
 	SessionStore    *sessions.Store
+	SandboxStore    *sandbox.GrantStore
 	UsageTracker    *usage.Tracker
 
 	AgentOptions    agent.Options

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -103,6 +103,8 @@ func renderRow(row transcriptRow, width int) string {
 		return renderToolCallRow(row)
 	case rowToolResult:
 		return renderToolResultRow(row, width)
+	case rowPermission:
+		return renderPermissionRow(row)
 	default:
 		return row.text
 	}
@@ -116,6 +118,46 @@ func renderToolCallRow(row transcriptRow) string {
 	line := zeroTheme.tool.Render("▸ ") + zeroTheme.text.Render(name)
 	if hint := strings.TrimSpace(row.detail); hint != "" {
 		line += "  " + zeroTheme.muted.Render(hint)
+	}
+	return line
+}
+
+func renderPermissionRow(row transcriptRow) string {
+	event := row.permission
+	if event == nil {
+		return zeroTheme.amber.Render("permission") + "  " + zeroTheme.text.Render(row.text)
+	}
+
+	name := event.ToolName
+	if name == "" {
+		name = row.tool
+	}
+	action := strings.TrimSpace(string(event.Action))
+	if action == "" {
+		action = "prompt"
+	}
+
+	actionStyle := zeroTheme.amber
+	actionLabel := action
+	switch event.Action {
+	case "allow":
+		actionStyle = zeroTheme.green
+	case "deny":
+		actionStyle = zeroTheme.red
+		actionLabel = "denied"
+	case "prompt":
+		actionStyle = zeroTheme.amber
+	}
+
+	line := zeroTheme.amber.Render("permission") + "  " + zeroTheme.text.Render(name) + "  " + actionStyle.Render(actionLabel)
+	if event.Risk.Level != "" {
+		line += "  " + zeroTheme.muted.Render("risk:"+string(event.Risk.Level))
+	}
+	if event.GrantMatched {
+		line += "  " + zeroTheme.green.Render("grant")
+	}
+	if detail := strings.TrimSpace(row.detail); detail != "" {
+		line += "\n" + indentText(zeroTheme.muted.Render(detail), 2)
 	}
 	return line
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -9,7 +9,18 @@ import (
 
 // Run starts the Zero Bubble Tea shell and returns a process-style exit code.
 func Run(ctx context.Context, options Options) int {
-	program := tea.NewProgram(
+	externalSink := options.RuntimeMessageSink
+	var program *tea.Program
+	options.RuntimeMessageSink = func(msg tea.Msg) {
+		if externalSink != nil {
+			externalSink(msg)
+		}
+		if program != nil {
+			program.Send(msg)
+		}
+	}
+
+	program = tea.NewProgram(
 		newModel(ctx, options),
 		tea.WithContext(ctx),
 		tea.WithInput(os.Stdin),

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -183,6 +183,7 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			}
 			rows = append(rows, transcriptRow{
 				kind:   rowToolCall,
+				id:     payloadString(payload, "id"),
 				text:   "tool call: " + name,
 				tool:   name,
 				detail: argHint(payloadString(payload, "arguments")),
@@ -201,6 +202,7 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			output := payloadString(payload, "output")
 			rows = append(rows, transcriptRow{
 				kind:   rowToolResult,
+				id:     firstNonEmptyString(payloadString(payload, "toolCallId"), payloadString(payload, "id")),
 				text:   fmt.Sprintf("tool result: %s %s %s", name, status, truncateTUIOutput(output, tuiToolOutputLimit)),
 				tool:   name,
 				status: status,

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 )
@@ -185,6 +187,8 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 				tool:   name,
 				detail: argHint(payloadString(payload, "arguments")),
 			})
+		case sessions.EventPermission:
+			rows = append(rows, permissionTranscriptRow(permissionEventFromPayload(payload)))
 		case sessions.EventToolResult:
 			name := payloadString(payload, "name")
 			if name == "" {
@@ -225,6 +229,49 @@ func sessionPayload(event sessions.Event) map[string]any {
 	return payload
 }
 
+func permissionEventFromPayload(payload map[string]any) agent.PermissionEvent {
+	name := payloadString(payload, "name")
+	if name == "" {
+		name = payloadString(payload, "toolName")
+	}
+	event := agent.PermissionEvent{
+		ToolCallID:        firstNonEmptyString(payloadString(payload, "toolCallId"), payloadString(payload, "id")),
+		ToolName:          name,
+		Action:            agent.PermissionAction(payloadString(payload, "action")),
+		Permission:        payloadString(payload, "permission"),
+		PermissionGranted: payloadBool(payload, "permissionGranted"),
+		PermissionMode:    agent.PermissionMode(payloadString(payload, "permissionMode")),
+		Autonomy:          payloadString(payload, "autonomy"),
+		SideEffect:        payloadString(payload, "sideEffect"),
+		Reason:            payloadString(payload, "reason"),
+		GrantMatched:      payloadBool(payload, "grantMatched"),
+	}
+	if risk, ok := payloadMap(payload, "risk"); ok {
+		event.Risk = sandbox.Risk{
+			Level:  sandbox.RiskLevel(payloadString(risk, "level")),
+			Reason: payloadString(risk, "reason"),
+		}
+	}
+	if violation, ok := payloadMap(payload, "violation"); ok {
+		event.Violation = &sandbox.Violation{
+			Code:        sandbox.ViolationCode(payloadString(violation, "code")),
+			ToolName:    payloadString(violation, "toolName"),
+			Action:      sandbox.Action(payloadString(violation, "action")),
+			Risk:        event.Risk,
+			Path:        payloadString(violation, "path"),
+			Reason:      payloadString(violation, "reason"),
+			Recoverable: payloadBool(violation, "recoverable"),
+		}
+		if nestedRisk, ok := payloadMap(violation, "risk"); ok {
+			event.Violation.Risk = sandbox.Risk{
+				Level:  sandbox.RiskLevel(payloadString(nestedRisk, "level")),
+				Reason: payloadString(nestedRisk, "reason"),
+			}
+		}
+	}
+	return event
+}
+
 func payloadString(payload map[string]any, key string) string {
 	value := payload[key]
 	switch typed := value.(type) {
@@ -241,4 +288,30 @@ func payloadString(payload map[string]any, key string) string {
 		}
 		return string(data)
 	}
+}
+
+func payloadBool(payload map[string]any, key string) bool {
+	value := payload[key]
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
+}
+
+func payloadMap(payload map[string]any, key string) (map[string]any, bool) {
+	value, ok := payload[key].(map[string]any)
+	return value, ok
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -10,6 +10,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -192,6 +194,84 @@ func TestPromptSubmitPersistsToolSessionEvents(t *testing.T) {
 	assertPayloadField(t, events[3], "content", "read complete")
 }
 
+func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
+	store := testSessionStore(t)
+	root := t.TempDir()
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_write", ToolName: "write_file"},
+			{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_write", ArgumentsFragment: `{"path":"notes.txt","content":"hello"}`},
+			{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_write"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+		{
+			{Type: zeroruntime.StreamEventText, Content: "write blocked"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	m := newModel(context.Background(), Options{
+		Cwd:            root,
+		ProviderName:   "openai",
+		ModelName:      "gpt-4.1",
+		Provider:       provider,
+		Registry:       registry,
+		SessionStore:   store,
+		PermissionMode: agent.PermissionModeAsk,
+		AgentOptions: agent.Options{
+			Autonomy: string(sandbox.AutonomyMedium),
+			Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+				WorkspaceRoot: root,
+				Policy:        sandbox.DefaultPolicy(),
+			}),
+		},
+	})
+	m.input.SetValue("write notes")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	if _, err := os.Stat(filepath.Join(root, "notes.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected prompt-gated write to stay blocked, stat error: %v", err)
+	}
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one session, got %d", len(list))
+	}
+	events, err := store.ReadEvents(list[0].SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
+		sessions.EventMessage,
+		sessions.EventToolCall,
+		sessions.EventPermission,
+		sessions.EventToolResult,
+		sessions.EventMessage,
+	}) {
+		t.Fatalf("unexpected event sequence: %#v", got)
+	}
+	assertPayloadField(t, events[2], "toolCallId", "call_write")
+	assertPayloadField(t, events[2], "name", "write_file")
+	assertPayloadField(t, events[2], "action", "prompt")
+	assertPayloadField(t, events[2], "permission", "prompt")
+	assertPayloadField(t, events[2], "permissionMode", "ask")
+	assertPayloadField(t, events[2], "sideEffect", "write")
+	assertPayloadField(t, events[4], "content", "write blocked")
+	if !transcriptContains(next.transcript, "permission: write_file prompt") {
+		t.Fatalf("expected permission row in transcript, got %#v", next.transcript)
+	}
+}
+
 func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	store := testSessionStore(t)
 	session, err := store.Create(sessions.CreateInput{Title: "Hydrate me", Cwd: "repo", ModelID: "gpt-4.1", Provider: "openai"})
@@ -200,6 +280,15 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	}
 	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "user", "content": "previous request"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventToolCall, map[string]any{"id": "call_1", "name": "grep", "arguments": `{"pattern":"Zero"}`})
+	appendTestEvent(t, store, session.SessionID, sessions.EventPermission, map[string]any{
+		"toolCallId":     "call_1",
+		"name":           "grep",
+		"action":         "allow",
+		"permission":     "allow",
+		"permissionMode": "auto",
+		"sideEffect":     "read",
+		"risk":           map[string]any{"level": "low"},
+	})
 	appendTestEvent(t, store, session.SessionID, sessions.EventToolResult, map[string]any{"toolCallId": "call_1", "name": "grep", "status": "error", "output": "matches"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "previous answer"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventError, map[string]any{"message": "old error"})
@@ -213,7 +302,7 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /resume to hydrate synchronously")
 	}
-	for _, want := range []string{"Resumed Zero session", session.SessionID, "previous request", "tool call: grep", "tool result: grep error matches", "previous answer", "old error"} {
+	for _, want := range []string{"Resumed Zero session", session.SessionID, "previous request", "tool call: grep", "permission: grep allow", "tool result: grep error matches", "previous answer", "old error"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected resumed transcript to contain %q, got %#v", want, next.transcript)
 		}
@@ -221,6 +310,10 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	toolCall, ok := findTranscriptRow(next.transcript, rowToolCall)
 	if !ok || toolCall.tool != "grep" || toolCall.detail != "Zero" {
 		t.Fatalf("expected hydrated tool call metadata, got ok=%v row=%#v", ok, toolCall)
+	}
+	permissionRow, ok := findTranscriptRow(next.transcript, rowPermission)
+	if !ok || permissionRow.tool != "grep" || permissionRow.permission == nil || permissionRow.permission.Action != agent.PermissionActionAllow {
+		t.Fatalf("expected hydrated permission metadata, got ok=%v row=%#v", ok, permissionRow)
 	}
 	toolResult, ok := findTranscriptRow(next.transcript, rowToolResult)
 	if !ok || toolResult.tool != "grep" || toolResult.status != tools.StatusError || toolResult.detail != "matches" {

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -211,6 +211,7 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	}}
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewWriteFileTool(root))
+	runtimeMessages := []tea.Msg{}
 	m := newModel(context.Background(), Options{
 		Cwd:            root,
 		ProviderName:   "openai",
@@ -219,6 +220,9 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 		Registry:       registry,
 		SessionStore:   store,
 		PermissionMode: agent.PermissionModeAsk,
+		RuntimeMessageSink: func(msg tea.Msg) {
+			runtimeMessages = append(runtimeMessages, msg)
+		},
 		AgentOptions: agent.Options{
 			Autonomy: string(sandbox.AutonomyMedium),
 			Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
@@ -234,7 +238,23 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected prompt submit to start an agent run")
 	}
-	updated, _ = next.Update(cmd())
+	finalMsg := cmd()
+	if len(runtimeMessages) != 3 {
+		t.Fatalf("expected live tool call, permission, and result messages, got %#v", runtimeMessages)
+	}
+	for _, runtimeMsg := range runtimeMessages {
+		updated, _ = next.Update(runtimeMsg)
+		next = updated.(model)
+	}
+	if !next.pending {
+		t.Fatal("expected live runtime rows to leave run pending until final response")
+	}
+	for _, want := range []string{"tool call: write_file", "permission: write_file prompt", "tool result: write_file error"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected live transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	updated, _ = next.Update(finalMsg)
 	next = updated.(model)
 
 	if _, err := os.Stat(filepath.Join(root, "notes.txt")); !os.IsNotExist(err) {
@@ -269,6 +289,9 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	assertPayloadField(t, events[4], "content", "write blocked")
 	if !transcriptContains(next.transcript, "permission: write_file prompt") {
 		t.Fatalf("expected permission row in transcript, got %#v", next.transcript)
+	}
+	if countTranscriptRows(next.transcript, rowPermission) != 1 {
+		t.Fatalf("expected final response to avoid duplicate permission rows, got %#v", next.transcript)
 	}
 }
 

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -15,16 +16,18 @@ const (
 	rowAssistant
 	rowToolCall
 	rowToolResult
+	rowPermission
 	rowSystem
 	rowError
 )
 
 type transcriptRow struct {
-	kind   rowKind
-	text   string
-	tool   string       // tool name, for tool call/result rows
-	status tools.Status // result status, for tool result rows
-	detail string       // raw multi-line output (e.g. a diff to render as a card)
+	kind       rowKind
+	text       string
+	tool       string       // tool name, for tool call/result rows
+	status     tools.Status // result status, for tool result rows
+	detail     string       // raw multi-line output (e.g. a diff to render as a card)
+	permission *agent.PermissionEvent
 }
 
 type transcriptActionKind int
@@ -96,6 +99,69 @@ func appendTranscriptRow(rows []transcriptRow, row transcriptRow) []transcriptRo
 	next := append([]transcriptRow{}, rows...)
 	next = append(next, row)
 	return next
+}
+
+func permissionTranscriptRow(event agent.PermissionEvent) transcriptRow {
+	return transcriptRow{
+		kind:       rowPermission,
+		text:       permissionRowText(event),
+		tool:       event.ToolName,
+		detail:     permissionDetailText(event),
+		permission: &event,
+	}
+}
+
+func permissionRowText(event agent.PermissionEvent) string {
+	parts := []string{"permission:"}
+	if event.ToolName != "" {
+		parts = append(parts, event.ToolName)
+	}
+	if event.Action != "" {
+		parts = append(parts, string(event.Action))
+	}
+	if event.Risk.Level != "" {
+		parts = append(parts, "risk:"+string(event.Risk.Level))
+	}
+	if event.Violation != nil && event.Violation.Code != "" {
+		parts = append(parts, "violation:"+string(event.Violation.Code))
+	}
+	return strings.Join(parts, " ")
+}
+
+func permissionDetailText(event agent.PermissionEvent) string {
+	parts := []string{}
+	if event.Permission != "" {
+		parts = append(parts, "permission="+event.Permission)
+	}
+	if event.PermissionMode != "" {
+		parts = append(parts, "mode="+string(event.PermissionMode))
+	}
+	if event.Autonomy != "" {
+		parts = append(parts, "autonomy="+event.Autonomy)
+	}
+	if event.SideEffect != "" {
+		parts = append(parts, "side_effect="+event.SideEffect)
+	}
+	if event.Risk.Level != "" {
+		parts = append(parts, "risk="+string(event.Risk.Level))
+	}
+	if event.GrantMatched {
+		parts = append(parts, "grant=matched")
+	}
+	if event.Reason != "" {
+		parts = append(parts, event.Reason)
+	}
+	if event.Violation != nil {
+		violation := "violation=" + string(event.Violation.Code)
+		if event.Violation.Path != "" {
+			violation += " path=" + event.Violation.Path
+		}
+		if event.Violation.Reason != "" {
+			violation += " " + event.Violation.Reason
+		}
+		parts = append(parts, violation)
+	}
+	return strings.Join(parts, "  ")
 }
 
 func truncateTUIOutput(output string, limit int) string {

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -23,6 +23,7 @@ const (
 
 type transcriptRow struct {
 	kind       rowKind
+	id         string
 	text       string
 	tool       string       // tool name, for tool call/result rows
 	status     tools.Status // result status, for tool result rows
@@ -96,14 +97,45 @@ func appendRow(rows []transcriptRow, kind rowKind, text string) []transcriptRow 
 }
 
 func appendTranscriptRow(rows []transcriptRow, row transcriptRow) []transcriptRow {
+	if hasTranscriptRow(rows, row) {
+		return rows
+	}
 	next := append([]transcriptRow{}, rows...)
 	next = append(next, row)
 	return next
 }
 
+func hasTranscriptRow(rows []transcriptRow, row transcriptRow) bool {
+	key := transcriptRowKey(row)
+	if key == "" {
+		return false
+	}
+	for _, existing := range rows {
+		if transcriptRowKey(existing) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func transcriptRowKey(row transcriptRow) string {
+	switch row.kind {
+	case rowToolCall, rowToolResult:
+		if row.id != "" {
+			return fmt.Sprintf("%d:%s", row.kind, row.id)
+		}
+	case rowPermission:
+		if row.permission != nil && row.permission.ToolCallID != "" {
+			return fmt.Sprintf("%d:%s", row.kind, row.permission.ToolCallID)
+		}
+	}
+	return ""
+}
+
 func permissionTranscriptRow(event agent.PermissionEvent) transcriptRow {
 	return transcriptRow{
 		kind:       rowPermission,
+		id:         event.ToolCallID,
 		text:       permissionRowText(event),
 		tool:       event.ToolName,
 		detail:     permissionDetailText(event),
@@ -153,6 +185,9 @@ func permissionDetailText(event agent.PermissionEvent) string {
 	}
 	if event.Violation != nil {
 		violation := "violation=" + string(event.Violation.Code)
+		if event.Violation.Risk.Level != "" {
+			violation += " risk=" + string(event.Violation.Risk.Level)
+		}
 		if event.Violation.Path != "" {
 			violation += " path=" + event.Violation.Path
 		}


### PR DESCRIPTION
## Summary
- wire interactive TUI runs to the sandbox grant store and engine
- render live permission rows between tool calls and tool results
- persist and hydrate permission events in TUI sessions
- expand /permissions to show redacted persistent sandbox grant snapshots

## Validation
- go test ./internal/tui
- go test ./internal/cli
- go test ./...
- bun run typecheck
- bun test ./tests --timeout 15000
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox grant support integrated into CLI and TUI; grants shown alongside permission mode.
  * Permission decisions persisted and displayed as transcript rows (with de-duplication and detailed rendering).
  * Tool call/result rows now stream to the UI as they occur.
  * Runtime message forwarding now ensures external sinks and the UI both receive runtime messages.

* **Tests**
  * Added/expanded tests covering sandbox grants, permission rows, and transcript hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->