### PR TITLE
feat(sandbox): report backend capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ zero models list [--provider anthropic]     # inspect the model registry
 zero search "<query>" [--json --session <id> --type <event>]   # search local sessions
 zero doctor [--connectivity] [--json]        # health checks
 zero config [--json]                          # inspect resolved configuration
+zero sandbox policy [--json]                 # inspect sandbox backend support
 zero serve --mcp [-C <path>]                  # expose Zero read-only tools over MCP stdio
 zero update --check [--json]                  # check for a newer release
 ```

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -55,6 +55,7 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 	}
 	policy := zeroSandbox.DefaultPolicy()
 	backend := deps.selectSandboxBackend(zeroSandbox.BackendOptions{})
+	plan := backend.BuildPlan(workspaceRoot, policy)
 	if options.json {
 		payload := struct {
 			Policy     zeroSandbox.Policy      `json:"policy"`
@@ -64,7 +65,7 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		}{
 			Policy:     policy,
 			Backend:    backend,
-			Plan:       backend.BuildPlan(workspaceRoot, policy),
+			Plan:       plan,
 			GrantsPath: store.FilePath(),
 		}
 		if err := writePrettyJSON(stdout, payload); err != nil {
@@ -72,7 +73,7 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, formatSandboxPolicy(workspaceRoot, policy, backend, store.FilePath())); err != nil {
+	if _, err := fmt.Fprintln(stdout, formatSandboxPolicy(workspaceRoot, policy, backend, plan, store.FilePath())); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -307,13 +308,14 @@ func parseSandboxPositionalOptions(args []string) (sandboxCommandOptions, []stri
 	return options, positional, false, nil
 }
 
-func formatSandboxPolicy(workspaceRoot string, policy zeroSandbox.Policy, backend zeroSandbox.Backend, grantsPath string) string {
+func formatSandboxPolicy(workspaceRoot string, policy zeroSandbox.Policy, backend zeroSandbox.Backend, plan zeroSandbox.BackendPlan, grantsPath string) string {
 	lines := []string{
 		"Zero sandbox policy",
 		"root: " + workspaceRoot,
 		"mode: " + string(policy.Mode),
 		"network: " + string(policy.Network),
 		"backend: " + string(backend.Name),
+		"support_level: " + string(plan.SupportLevel),
 	}
 	if backend.Platform != "" {
 		lines = append(lines, "backend_platform: "+backend.Platform)
@@ -327,6 +329,9 @@ func formatSandboxPolicy(workspaceRoot string, policy zeroSandbox.Policy, backen
 	)
 	if backend.Message != "" {
 		lines = append(lines, "backend_message: "+backend.Message)
+	}
+	for _, warning := range plan.Warnings {
+		lines = append(lines, "warning: "+warning)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -133,7 +133,10 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 					Policy  sandbox.Policy  `json:"policy"`
 					Backend sandbox.Backend `json:"backend"`
 					Plan    struct {
-						Restrictions []string `json:"restrictions"`
+						SupportLevel string                      `json:"supportLevel"`
+						Capabilities []sandbox.BackendCapability `json:"capabilities"`
+						Restrictions []string                    `json:"restrictions"`
+						Warnings     []string                    `json:"warnings"`
 					} `json:"plan"`
 					Grants string `json:"grantsPath"`
 				}
@@ -146,14 +149,24 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 				if payload.Backend.Platform != "windows" || !payload.Backend.Fallback || payload.Backend.NativeIsolation || payload.Backend.CommandWrapping {
 					t.Fatalf("unexpected backend capability JSON: %#v", payload.Backend)
 				}
+				if payload.Plan.SupportLevel != string(sandbox.BackendSupportPolicyOnly) {
+					t.Fatalf("support level = %q, want policy-only", payload.Plan.SupportLevel)
+				}
+				if sandboxPolicyCapabilityStatus(payload.Plan.Capabilities, "native_process_isolation") != sandbox.CapabilityUnavailable {
+					t.Fatalf("expected native isolation unavailable, got %#v", payload.Plan.Capabilities)
+				}
 				if !sandboxPolicyRestrictionContains(payload.Plan.Restrictions, "native process isolation unavailable on windows") {
 					t.Fatalf("expected JSON plan to document Windows fallback, got %#v", payload.Plan.Restrictions)
+				}
+				if !sandboxPolicyRestrictionContains(payload.Plan.Warnings, "Windows native sandbox adapter is not implemented") {
+					t.Fatalf("expected JSON warnings to document Windows fallback, got %#v", payload.Plan.Warnings)
 				}
 			} else {
 				output := stdout.String()
 				for _, want := range []string{
 					"Zero sandbox policy",
 					"backend: policy-only",
+					"support_level: policy-only",
 					"backend_fallback: true",
 					"backend_command_wrapping: false",
 					"backend_native_isolation: false",
@@ -213,4 +226,13 @@ func sandboxPolicyRestrictionContains(restrictions []string, value string) bool 
 		}
 	}
 	return false
+}
+
+func sandboxPolicyCapabilityStatus(capabilities []sandbox.BackendCapability, key string) sandbox.CapabilityStatus {
+	for _, capability := range capabilities {
+		if capability.Key == key {
+			return capability.Status
+		}
+	}
+	return ""
 }

--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -22,10 +22,19 @@ type Backend struct {
 }
 
 type BackendPlan struct {
-	Backend       Backend  `json:"backend"`
-	WorkspaceRoot string   `json:"workspaceRoot"`
-	Policy        Policy   `json:"policy"`
-	Restrictions  []string `json:"restrictions"`
+	Backend       Backend             `json:"backend"`
+	WorkspaceRoot string              `json:"workspaceRoot"`
+	Policy        Policy              `json:"policy"`
+	SupportLevel  BackendSupportLevel `json:"supportLevel"`
+	Capabilities  []BackendCapability `json:"capabilities"`
+	Restrictions  []string            `json:"restrictions"`
+	Warnings      []string            `json:"warnings,omitempty"`
+}
+
+type BackendCapability struct {
+	Key    string           `json:"key"`
+	Status CapabilityStatus `json:"status"`
+	Detail string           `json:"detail"`
 }
 
 func SelectBackend(options BackendOptions) Backend {
@@ -109,6 +118,90 @@ func (backend Backend) BuildPlan(workspaceRoot string, policy Policy) BackendPla
 		Backend:       backend,
 		WorkspaceRoot: workspaceRoot,
 		Policy:        effectivePolicy,
+		SupportLevel:  backend.SupportLevel(),
+		Capabilities:  backend.Capabilities(effectivePolicy),
 		Restrictions:  restrictions,
+		Warnings:      backend.Warnings(),
 	}
+}
+
+func (backend Backend) SupportLevel() BackendSupportLevel {
+	if backend.Available && backend.NativeIsolation && backend.CommandWrapping {
+		return BackendSupportNative
+	}
+	return BackendSupportPolicyOnly
+}
+
+func (backend Backend) Warnings() []string {
+	if backend.SupportLevel() == BackendSupportNative {
+		return nil
+	}
+	platform := backend.Platform
+	if platform == "" {
+		platform = "this platform"
+	}
+	warnings := []string{
+		"native process isolation unavailable on " + platform,
+		"shell commands are not wrapped by a native platform sandbox",
+	}
+	if backend.Platform == "windows" {
+		warnings[0] = "Windows native sandbox adapter is not implemented; using policy-only preflight checks"
+	}
+	return warnings
+}
+
+func (backend Backend) Capabilities(policy Policy) []BackendCapability {
+	if policy.Mode == "" {
+		policy = DefaultPolicy()
+	}
+	capabilities := []BackendCapability{
+		{
+			Key:    "policy_evaluation",
+			Status: policyCapabilityStatus(policy.Mode, true),
+			Detail: "tool requests are evaluated against sandbox policy before execution",
+		},
+		{
+			Key:    "workspace_write_guard",
+			Status: policyCapabilityStatus(policy.Mode, policy.EnforceWorkspace),
+			Detail: "filesystem writes are checked against the workspace root before execution",
+		},
+		{
+			Key:    "network_guard",
+			Status: policyCapabilityStatus(policy.Mode, policy.Network == NetworkDeny),
+			Detail: "network-capable tool requests are denied before execution",
+		},
+		{
+			Key:    "destructive_shell_guard",
+			Status: policyCapabilityStatus(policy.Mode, policy.DenyDestructiveShell),
+			Detail: "destructive shell patterns are denied before execution",
+		},
+	}
+	nativeIsolation := BackendCapability{
+		Key:    "native_process_isolation",
+		Status: CapabilityUnavailable,
+		Detail: "no native process sandbox is active for this platform",
+	}
+	if backend.NativeIsolation {
+		nativeIsolation.Status = CapabilityNative
+		nativeIsolation.Detail = "tool subprocesses can run inside " + string(backend.Name)
+	} else if backend.Platform == "windows" {
+		nativeIsolation.Detail = "Windows native sandbox adapter is not implemented yet"
+	}
+	commandWrapping := BackendCapability{
+		Key:    "command_wrapping",
+		Status: CapabilityUnavailable,
+		Detail: "shell commands are not wrapped by a native platform sandbox",
+	}
+	if backend.CommandWrapping {
+		commandWrapping.Status = CapabilityNative
+		commandWrapping.Detail = "shell commands can be launched through " + string(backend.Name)
+	}
+	return append(capabilities, nativeIsolation, commandWrapping)
+}
+
+func policyCapabilityStatus(mode PolicyMode, enabled bool) CapabilityStatus {
+	if mode == ModeDisabled || !enabled {
+		return CapabilityDisabled
+	}
+	return CapabilityPreflight
 }

--- a/internal/sandbox/adapters_test.go
+++ b/internal/sandbox/adapters_test.go
@@ -24,6 +24,13 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 		if backend.Platform != "linux" || backend.Fallback || !backend.CommandWrapping || !backend.NativeIsolation {
 			t.Fatalf("linux backend capabilities = %#v, want native wrapping", backend)
 		}
+		plan := backend.BuildPlan(t.TempDir(), DefaultPolicy())
+		if plan.SupportLevel != BackendSupportNative || len(plan.Warnings) != 0 {
+			t.Fatalf("linux plan = %#v, want native support without warnings", plan)
+		}
+		if capabilityStatus(plan.Capabilities, "native_process_isolation") != CapabilityNative {
+			t.Fatalf("linux native isolation capability = %#v, want native", plan.Capabilities)
+		}
 	})
 
 	t.Run("darwin sandbox exec available", func(t *testing.T) {
@@ -57,6 +64,16 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 		}
 		if !strings.Contains(backend.Message, "Windows native sandbox adapter is not implemented") {
 			t.Fatalf("expected Windows fallback message, got %q", backend.Message)
+		}
+		plan := backend.BuildPlan(t.TempDir(), DefaultPolicy())
+		if plan.SupportLevel != BackendSupportPolicyOnly {
+			t.Fatalf("windows support level = %q, want policy-only", plan.SupportLevel)
+		}
+		if capabilityStatus(plan.Capabilities, "native_process_isolation") != CapabilityUnavailable {
+			t.Fatalf("windows native isolation capability = %#v, want unavailable", plan.Capabilities)
+		}
+		if !restrictionContains(plan.Warnings, "Windows native sandbox adapter is not implemented") {
+			t.Fatalf("windows warnings = %#v, want adapter warning", plan.Warnings)
 		}
 	})
 
@@ -101,6 +118,23 @@ func TestBackendBuildPlanDocumentsBestEffortIsolation(t *testing.T) {
 	}
 }
 
+func TestBackendCapabilitiesReflectDisabledPolicy(t *testing.T) {
+	backend := SelectBackend(BackendOptions{
+		GOOS:             "windows",
+		LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },
+	})
+	plan := backend.BuildPlan(t.TempDir(), Policy{Mode: ModeDisabled})
+
+	for _, key := range []string{"policy_evaluation", "workspace_write_guard", "network_guard", "destructive_shell_guard"} {
+		if got := capabilityStatus(plan.Capabilities, key); got != CapabilityDisabled {
+			t.Fatalf("capability %s = %q, want disabled in %#v", key, got, plan.Capabilities)
+		}
+	}
+	if got := capabilityStatus(plan.Capabilities, "command_wrapping"); got != CapabilityUnavailable {
+		t.Fatalf("command_wrapping = %q, want unavailable", got)
+	}
+}
+
 func restrictionContains(restrictions []string, value string) bool {
 	for _, restriction := range restrictions {
 		if strings.Contains(restriction, value) {
@@ -108,4 +142,13 @@ func restrictionContains(restrictions []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func capabilityStatus(capabilities []BackendCapability, key string) CapabilityStatus {
+	for _, capability := range capabilities {
+		if capability.Key == key {
+			return capability.Status
+		}
+	}
+	return ""
 }

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -13,6 +13,8 @@ type RiskLevel string
 type ViolationCode string
 type GrantDecision string
 type BackendName string
+type BackendSupportLevel string
+type CapabilityStatus string
 
 const (
 	SideEffectRead           SideEffect = "read"
@@ -82,6 +84,18 @@ const (
 	BackendBubblewrap  BackendName = "bubblewrap"
 	BackendSandboxExec BackendName = "sandbox-exec"
 	BackendPolicyOnly  BackendName = "policy-only"
+)
+
+const (
+	BackendSupportNative     BackendSupportLevel = "native"
+	BackendSupportPolicyOnly BackendSupportLevel = "policy-only"
+)
+
+const (
+	CapabilityNative      CapabilityStatus = "native"
+	CapabilityPreflight   CapabilityStatus = "preflight"
+	CapabilityUnavailable CapabilityStatus = "unavailable"
+	CapabilityDisabled    CapabilityStatus = "disabled"
 )
 
 type Policy struct {


### PR DESCRIPTION
## Summary
- add sandbox backend support levels and machine-readable capability statuses
- surface capability warnings in zero sandbox policy text and JSON output
- document Windows policy-only fallback without overstating native isolation support
- add tests for native, Windows fallback, and disabled-policy capability reporting

## Validation
- GOCACHE=/tmp/zero-go-cache go test ./internal/sandbox ./internal/cli -run 'TestSelectBackend|TestBackend|TestRunSandbox'
- GOCACHE=/tmp/zero-go-cache go test ./...
- GOCACHE=/tmp/zero-go-cache go run ./cmd/zero-release build
- ./zero sandbox policy --json
- git diff --check

## Coordination
This is platform/backend sandbox capability reporting. It does not overlap the TUI rendering work in #93; that PR owns user-facing permission rows and /permissions UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `zero sandbox policy` command now displays backend support level (native or policy-only) and platform-specific warnings in both text and JSON output.
  * JSON output includes detailed capability information showing which features are supported, unavailable, or disabled.

* **Documentation**
  * Updated README with the new `zero sandbox policy [--json]` command reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->