### PR TITLE
feat: add runtime permission decisions

### DIFF
--- a/docs/STREAM_JSON_PROTOCOL.md
+++ b/docs/STREAM_JSON_PROTOCOL.md
@@ -39,6 +39,8 @@ Unknown fields are rejected so protocol clients catch drift early.
 { "schemaVersion": 1, "type": "run_start", "runId": "run_20260603_abc123", "sessionId": "zero_20260603100000_abc123", "cwd": "/repo", "provider": "openai", "model": "gpt-4.1", "apiModel": "gpt-4.1" }
 { "schemaVersion": 1, "type": "text", "runId": "run_20260603_abc123", "delta": "..." }
 { "schemaVersion": 1, "type": "tool_call", "runId": "run_20260603_abc123", "id": "call_1", "name": "read_file", "args": { "path": "README.md" }, "sideEffect": "read" }
+{ "schemaVersion": 1, "type": "permission_request", "runId": "run_20260603_abc123", "id": "call_2", "name": "write_file", "action": "prompt", "permission": "prompt", "permissionMode": "ask", "sideEffect": "write", "reason": "Creates or overwrites files." }
+{ "schemaVersion": 1, "type": "permission_decision", "runId": "run_20260603_abc123", "id": "call_2", "name": "write_file", "action": "allow", "permission": "prompt", "permissionGranted": true, "decisionReason": "approved in TUI" }
 { "schemaVersion": 1, "type": "tool_result", "runId": "run_20260603_abc123", "id": "call_1", "status": "ok", "output": "...", "truncated": false }
 { "schemaVersion": 1, "type": "usage", "runId": "run_20260603_abc123", "promptTokens": 12, "completionTokens": 8, "totalTokens": 20 }
 { "schemaVersion": 1, "type": "final", "runId": "run_20260603_abc123", "text": "..." }
@@ -46,6 +48,11 @@ Unknown fields are rejected so protocol clients catch drift early.
 ```
 
 Errors are part of the protocol and are followed by `run_end`.
+
+Headless `exec` has no interactive permission responder. If a prompt-gated tool
+is not pre-approved, Zero may emit `permission_request` followed by a denied
+`tool_result`; interactive surfaces emit `permission_decision` when the user
+allows, denies, or always-allows the request.
 
 ```json
 { "schemaVersion": 1, "type": "error", "runId": "run_20260603_abc123", "code": "provider_error", "message": "...", "recoverable": false }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sort"
+	"strings"
 
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -123,6 +124,43 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		permissionGranted = true
 	}
 
+	var preflightDecision *sandbox.Decision
+	if toolFound && options.Sandbox != nil {
+		decision := options.Sandbox.Evaluate(ctx, sandboxRequest(call.Name, tool, args, permissionGranted, permissionMode, options))
+		preflightDecision = &decision
+	}
+
+	decisionReason := ""
+	if toolFound && options.OnPermissionRequest != nil && shouldRequestPermission(tool, permissionGranted, preflightDecision) {
+		requestEvent, ok := buildPermissionEvent(call, tool, args, permissionGranted, permissionMode, options, preflightDecision)
+		if !ok {
+			requestEvent = fallbackPermissionEvent(call, tool, args, permissionMode, options)
+		}
+		request := permissionRequestFromEvent(requestEvent, args)
+		decision, err := requestPermission(ctx, request, options)
+		if err != nil {
+			decision = PermissionDecision{Action: PermissionDecisionDeny, Reason: err.Error()}
+		}
+		decision.Action = normalizePermissionDecisionAction(decision.Action)
+		decisionReason = strings.TrimSpace(decision.Reason)
+		switch decision.Action {
+		case PermissionDecisionAllow:
+			permissionGranted = true
+		case PermissionDecisionAlwaysAllow:
+			permissionGranted = true
+			grant, err := persistPermissionGrant(call.Name, decisionReason, options)
+			if err != nil {
+				emitDeniedPermission(options, call, requestEvent, "failed to persist permission grant: "+err.Error())
+				return deniedPermissionResult(call, "failed to persist permission grant: "+err.Error(), requestEvent)
+			}
+			requestEvent.GrantMatched = true
+			requestEvent.Grant = &grant
+		default:
+			emitDeniedPermission(options, call, requestEvent, decisionReason)
+			return deniedPermissionResult(call, decisionReason, requestEvent)
+		}
+	}
+
 	result := registry.RunWithOptions(ctx, call.Name, args, tools.RunOptions{
 		PermissionGranted: permissionGranted,
 		PermissionMode:    string(permissionMode),
@@ -135,6 +173,7 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	sandboxDecision := result.SandboxDecision
 	if toolFound && options.OnPermission != nil {
 		if event, ok := buildPermissionEvent(call, tool, args, permissionGranted, permissionMode, options, sandboxDecision); ok {
+			event.DecisionReason = decisionReason
 			options.OnPermission(event)
 		}
 	}
@@ -144,6 +183,112 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		Status:     result.Status,
 		Output:     result.Output,
 		Meta:       result.Meta,
+	}
+}
+
+func sandboxRequest(toolName string, tool tools.Tool, args map[string]any, permissionGranted bool, permissionMode PermissionMode, options Options) sandbox.Request {
+	safety := tool.Safety()
+	return sandbox.Request{
+		WorkspaceRoot:     "",
+		ToolName:          toolName,
+		SideEffect:        sandbox.SideEffect(safety.SideEffect),
+		Permission:        sandbox.Permission(safety.Permission),
+		PermissionGranted: permissionGranted,
+		PermissionMode:    sandbox.PermissionMode(permissionMode),
+		Autonomy:          sandbox.Autonomy(options.Autonomy),
+		Args:              args,
+		Reason:            safety.Reason,
+	}
+}
+
+func shouldRequestPermission(tool tools.Tool, permissionGranted bool, decision *sandbox.Decision) bool {
+	if permissionGranted || tool.Safety().Permission != tools.PermissionPrompt {
+		return false
+	}
+	if decision != nil {
+		return decision.Action == sandbox.ActionPrompt
+	}
+	return true
+}
+
+func requestPermission(ctx context.Context, request PermissionRequest, options Options) (PermissionDecision, error) {
+	if options.OnPermissionRequest == nil {
+		return PermissionDecision{Action: PermissionDecisionDeny, Reason: request.Reason}, nil
+	}
+	return options.OnPermissionRequest(ctx, request)
+}
+
+func normalizePermissionDecisionAction(action PermissionDecisionAction) PermissionDecisionAction {
+	switch action {
+	case PermissionDecisionAllow, PermissionDecisionAlwaysAllow:
+		return action
+	default:
+		return PermissionDecisionDeny
+	}
+}
+
+func persistPermissionGrant(toolName string, reason string, options Options) (sandbox.Grant, error) {
+	if options.Sandbox == nil {
+		return sandbox.Grant{}, errors.New("sandbox engine is not configured")
+	}
+	maxAutonomy := sandbox.Autonomy(options.Autonomy)
+	if maxAutonomy == "" {
+		maxAutonomy = sandbox.AutonomyMedium
+	}
+	if normalized, err := sandbox.NormalizeAutonomy(maxAutonomy); err == nil {
+		maxAutonomy = normalized
+	}
+	return options.Sandbox.Grant(sandbox.GrantInput{
+		ToolName:    toolName,
+		Decision:    sandbox.GrantAllow,
+		MaxAutonomy: maxAutonomy,
+		Reason:      reason,
+	})
+}
+
+func emitDeniedPermission(options Options, call ToolCall, requestEvent PermissionEvent, reason string) {
+	if options.OnPermission == nil {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = requestEvent.Reason
+	}
+	event := requestEvent
+	event.ToolCallID = call.ID
+	event.ToolName = call.Name
+	event.Action = PermissionActionDeny
+	event.PermissionGranted = false
+	event.DecisionReason = reason
+	options.OnPermission(event)
+}
+
+func deniedPermissionResult(call ToolCall, reason string, requestEvent PermissionEvent) ToolResult {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = requestEvent.Reason
+	}
+	if reason == "" {
+		reason = "tool requires approval before execution"
+	}
+	event := requestEvent
+	event.Action = PermissionActionDeny
+	event.PermissionGranted = false
+	event.DecisionReason = reason
+	if event.Risk.Level == "" {
+		event.Risk = sandbox.Risk{Level: sandbox.RiskMedium, Reason: reason}
+	}
+	if requestEvent.ToolName == "" {
+		event.ToolName = call.Name
+	}
+	return ToolResult{
+		ToolCallID: call.ID,
+		Name:       call.Name,
+		Status:     tools.StatusError,
+		Output:     "Error: Permission denied for " + call.Name + ": " + reason,
+		Meta: map[string]string{
+			"permission_action": string(event.Action),
+		},
 	}
 }
 
@@ -214,6 +359,40 @@ func buildPermissionEvent(call ToolCall, tool tools.Tool, args map[string]any, p
 		GrantMatched:      grantMatched,
 		Grant:             grant,
 	}, true
+}
+
+func fallbackPermissionEvent(call ToolCall, tool tools.Tool, args map[string]any, permissionMode PermissionMode, options Options) PermissionEvent {
+	event, _ := buildPermissionEvent(call, tool, args, false, permissionMode, options, nil)
+	return event
+}
+
+func permissionRequestFromEvent(event PermissionEvent, args map[string]any) PermissionRequest {
+	return PermissionRequest{
+		ToolCallID:     event.ToolCallID,
+		ToolName:       event.ToolName,
+		Action:         event.Action,
+		Permission:     event.Permission,
+		PermissionMode: event.PermissionMode,
+		Autonomy:       event.Autonomy,
+		SideEffect:     event.SideEffect,
+		Reason:         event.Reason,
+		Risk:           event.Risk,
+		Args:           cloneArgs(args),
+		Violation:      event.Violation,
+		GrantMatched:   event.GrantMatched,
+		Grant:          event.Grant,
+	}
+}
+
+func cloneArgs(args map[string]any) map[string]any {
+	if len(args) == 0 {
+		return nil
+	}
+	copied := make(map[string]any, len(args))
+	for key, value := range args {
+		copied[key] = value
+	}
+	return copied
 }
 
 func permissionActionFromSandbox(action sandbox.Action) PermissionAction {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -354,6 +354,166 @@ func TestRunDeniesPromptToolWithoutUnsafePermission(t *testing.T) {
 	}
 }
 
+func TestRunRequestsPromptToolPermissionBeforeExecution(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write approved")
+	var requests []PermissionRequest
+	var permissionEvents []PermissionEvent
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			requests = append(requests, request)
+			return PermissionDecision{Action: PermissionDecisionAllow, Reason: "approved for test"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "write approved" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("expected approved write content, got %q", content)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected one permission request, got %#v", requests)
+	}
+	request := requests[0]
+	if request.ToolCallID != "call-1" || request.ToolName != "write_file" || request.Action != PermissionActionPrompt {
+		t.Fatalf("unexpected permission request: %#v", request)
+	}
+	if request.PermissionMode != PermissionModeAsk || request.SideEffect != string(tools.SideEffectWrite) || request.Autonomy != string(sandbox.AutonomyMedium) {
+		t.Fatalf("unexpected request metadata: %#v", request)
+	}
+	if len(permissionEvents) != 1 {
+		t.Fatalf("expected one final permission event, got %#v", permissionEvents)
+	}
+	event := permissionEvents[0]
+	if event.Action != PermissionActionAllow || !event.PermissionGranted {
+		t.Fatalf("expected final allow event after approval, got %#v", event)
+	}
+	if event.DecisionReason != "approved for test" {
+		t.Fatalf("expected decision reason in final event, got %#v", event)
+	}
+}
+
+func TestRunDeniesPromptToolWhenPermissionRequestDenied(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write denied")
+	var requests []PermissionRequest
+	var permissionEvents []PermissionEvent
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			requests = append(requests, request)
+			return PermissionDecision{Action: PermissionDecisionDeny, Reason: "not this command"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "write denied" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	if _, err := os.Stat(filepath.Join(root, "notes.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected denied write to leave file missing, stat error: %v", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected one permission request, got %#v", requests)
+	}
+	lastMessage := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if !strings.Contains(lastMessage.Content, "Permission denied for write_file") || !strings.Contains(lastMessage.Content, "not this command") {
+		t.Fatalf("expected denied permission tool result, got %q", lastMessage.Content)
+	}
+	if len(permissionEvents) != 1 {
+		t.Fatalf("expected one final permission event, got %#v", permissionEvents)
+	}
+	event := permissionEvents[0]
+	if event.Action != PermissionActionDeny || event.PermissionGranted {
+		t.Fatalf("expected final deny event, got %#v", event)
+	}
+	if event.DecisionReason != "not this command" {
+		t.Fatalf("expected denial reason in final event, got %#v", event)
+	}
+}
+
+func TestRunPersistsAlwaysAllowPermissionDecision(t *testing.T) {
+	root := t.TempDir()
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write approved")
+	var permissionEvents []PermissionEvent
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        sandbox.DefaultPolicy(),
+			Store:         store,
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			if request.Risk.Level == "" {
+				t.Fatalf("expected request risk to be populated: %#v", request)
+			}
+			return PermissionDecision{Action: PermissionDecisionAlwaysAllow, Reason: "trust write_file for this workspace"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "write approved" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	lookup, err := store.Lookup("write_file", sandbox.AutonomyMedium)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lookup.Matched || lookup.Grant.Decision != sandbox.GrantAllow {
+		t.Fatalf("expected persistent allow grant, got %#v", lookup)
+	}
+	if len(permissionEvents) != 1 {
+		t.Fatalf("expected one final permission event, got %#v", permissionEvents)
+	}
+	event := permissionEvents[0]
+	if event.Action != PermissionActionAllow || !event.PermissionGranted || event.Grant == nil {
+		t.Fatalf("expected allow event with persisted grant, got %#v", event)
+	}
+	if event.Grant.Decision != sandbox.GrantAllow || event.Grant.ToolName != "write_file" {
+		t.Fatalf("unexpected persisted grant in event: %#v", event)
+	}
+}
+
 func TestRunGrantsPromptToolInUnsafeMode(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -13,6 +15,7 @@ type Usage = zeroruntime.Usage
 
 type PermissionMode string
 type PermissionAction string
+type PermissionDecisionAction string
 
 const (
 	PermissionModeAuto   PermissionMode = "auto"
@@ -26,12 +29,39 @@ const (
 	PermissionActionDeny   PermissionAction = "deny"
 )
 
+const (
+	PermissionDecisionAllow       PermissionDecisionAction = "allow"
+	PermissionDecisionDeny        PermissionDecisionAction = "deny"
+	PermissionDecisionAlwaysAllow PermissionDecisionAction = "always_allow"
+)
+
 type ToolResult struct {
 	ToolCallID string
 	Name       string
 	Status     tools.Status
 	Output     string
 	Meta       map[string]string
+}
+
+type PermissionRequest struct {
+	ToolCallID     string             `json:"toolCallId"`
+	ToolName       string             `json:"name"`
+	Action         PermissionAction   `json:"action"`
+	Permission     string             `json:"permission"`
+	PermissionMode PermissionMode     `json:"permissionMode"`
+	Autonomy       string             `json:"autonomy,omitempty"`
+	SideEffect     string             `json:"sideEffect"`
+	Reason         string             `json:"reason,omitempty"`
+	Risk           sandbox.Risk       `json:"risk"`
+	Args           map[string]any     `json:"args,omitempty"`
+	Violation      *sandbox.Violation `json:"violation,omitempty"`
+	GrantMatched   bool               `json:"grantMatched,omitempty"`
+	Grant          *sandbox.Grant     `json:"grant,omitempty"`
+}
+
+type PermissionDecision struct {
+	Action PermissionDecisionAction `json:"action"`
+	Reason string                   `json:"reason,omitempty"`
 }
 
 type PermissionEvent struct {
@@ -44,6 +74,7 @@ type PermissionEvent struct {
 	Autonomy          string             `json:"autonomy,omitempty"`
 	SideEffect        string             `json:"sideEffect"`
 	Reason            string             `json:"reason,omitempty"`
+	DecisionReason    string             `json:"decisionReason,omitempty"`
 	Risk              sandbox.Risk       `json:"risk"`
 	Violation         *sandbox.Violation `json:"violation,omitempty"`
 	GrantMatched      bool               `json:"grantMatched,omitempty"`
@@ -51,18 +82,19 @@ type PermissionEvent struct {
 }
 
 type Options struct {
-	MaxTurns       int
-	Registry       *tools.Registry
-	PermissionMode PermissionMode
-	Autonomy       string
-	Sandbox        *sandbox.Engine
-	EnabledTools   []string
-	DisabledTools  []string
-	OnText         func(string)
-	OnToolCall     func(ToolCall)
-	OnPermission   func(PermissionEvent)
-	OnToolResult   func(ToolResult)
-	OnUsage        func(Usage)
+	MaxTurns            int
+	Registry            *tools.Registry
+	PermissionMode      PermissionMode
+	Autonomy            string
+	Sandbox             *sandbox.Engine
+	EnabledTools        []string
+	DisabledTools       []string
+	OnText              func(string)
+	OnToolCall          func(ToolCall)
+	OnPermissionRequest func(context.Context, PermissionRequest) (PermissionDecision, error)
+	OnPermission        func(PermissionEvent)
+	OnToolResult        func(ToolResult)
+	OnUsage             func(Usage)
 }
 
 type Result struct {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -220,7 +220,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		},
 		OnPermission: func(event agent.PermissionEvent) {
 			writer.permission(event)
-			sessionRecorder.append(sessions.EventPermission, event)
+			sessionRecorder.append(sessionPermissionEventType(event), event)
 		},
 		OnToolResult: func(result agent.ToolResult) {
 			writer.toolResult(result)
@@ -442,4 +442,14 @@ func writeExecStreamJSONFinal(stdout io.Writer, cwd string, metadata execRunMeta
 		return exitCrash
 	}
 	return exitCode
+}
+
+func sessionPermissionEventType(event agent.PermissionEvent) sessions.EventType {
+	if event.Action == agent.PermissionActionPrompt {
+		return sessions.EventPermissionRequest
+	}
+	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny {
+		return sessions.EventPermissionDecision
+	}
+	return sessions.EventPermission
 }

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -374,10 +374,10 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 
 	events := decodeJSONLines(t, stdout.String())
 	eventTypes := jsonEventTypes(events)
-	if !slices.Contains(eventTypes, "permission") {
-		t.Fatalf("expected permission event in %v; output %q", eventTypes, stdout.String())
+	if !slices.Contains(eventTypes, "permission_request") {
+		t.Fatalf("expected permission_request event in %v; output %q", eventTypes, stdout.String())
 	}
-	permissionEvent := findJSONEvent(t, events, "permission")
+	permissionEvent := findJSONEvent(t, events, "permission_request")
 	if permissionEvent["id"] != "call_write" || permissionEvent["name"] != "write_file" || permissionEvent["action"] != "prompt" {
 		t.Fatalf("unexpected permission event: %#v", permissionEvent)
 	}
@@ -400,7 +400,7 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadEvents returned error: %v", err)
 	}
-	permissionRecord := findSessionEvent(t, recorded, sessions.EventPermission)
+	permissionRecord := findSessionEvent(t, recorded, sessions.EventPermissionRequest)
 	var payload map[string]any
 	if err := json.Unmarshal(permissionRecord.Payload, &payload); err != nil {
 		t.Fatalf("decode permission payload: %v", err)
@@ -438,7 +438,7 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 		t.Fatalf("approved exec wrote stderr = %q", stderr.String())
 	}
 	approvedEvents := decodeJSONLines(t, stdout.String())
-	approvedPermissionEvent := findJSONEvent(t, approvedEvents, "permission")
+	approvedPermissionEvent := findJSONEvent(t, approvedEvents, "permission_decision")
 	if approvedPermissionEvent["id"] != "call_write_approved" || approvedPermissionEvent["action"] != "allow" {
 		t.Fatalf("unexpected approved permission event: %#v", approvedPermissionEvent)
 	}
@@ -453,7 +453,7 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadEvents approved session returned error: %v", err)
 	}
-	approvedPermissionRecord := findSessionEvent(t, approvedRecorded, sessions.EventPermission)
+	approvedPermissionRecord := findSessionEvent(t, approvedRecorded, sessions.EventPermissionDecision)
 	payload = map[string]any{}
 	if err := json.Unmarshal(approvedPermissionRecord.Payload, &payload); err != nil {
 		t.Fatalf("decode approved permission payload: %v", err)
@@ -542,6 +542,43 @@ func TestExecEventWriterTruncatesStreamJSONToolResults(t *testing.T) {
 	output := events[0]["output"].(string)
 	if len(output) >= streamJSONToolResultOutputLimit+100 || !strings.Contains(output, "[truncated]") {
 		t.Fatalf("expected shortened output with marker, got len=%d", len(output))
+	}
+}
+
+func TestExecEventWriterEmitsPermissionDecisionReason(t *testing.T) {
+	var stdout bytes.Buffer
+	writer := execEventWriter{
+		stdout:       &stdout,
+		format:       execOutputStreamJSON,
+		runID:        "run_test",
+		sessionID:    "session_test",
+		streamedText: &strings.Builder{},
+	}
+
+	writer.permission(agent.PermissionEvent{
+		ToolCallID:        "call_1",
+		ToolName:          "write_file",
+		Action:            agent.PermissionActionAllow,
+		Permission:        string(tools.PermissionPrompt),
+		PermissionGranted: true,
+		PermissionMode:    agent.PermissionModeAuto,
+		SideEffect:        string(tools.SideEffectWrite),
+		Reason:            "write access required",
+		DecisionReason:    "approved by operator",
+	})
+
+	if writer.err != nil {
+		t.Fatalf("permission returned writer error: %v", writer.err)
+	}
+	events := decodeJSONLines(t, stdout.String())
+	if len(events) != 1 {
+		t.Fatalf("expected one permission event, got %#v", events)
+	}
+	if events[0]["type"] != "permission_decision" {
+		t.Fatalf("expected permission_decision event, got %#v", events[0])
+	}
+	if events[0]["decisionReason"] != "approved by operator" {
+		t.Fatalf("expected decisionReason to be preserved, got %#v", events[0])
 	}
 }
 

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -147,6 +147,7 @@ func (writer *execEventWriter) permission(event agent.PermissionEvent) {
 			"autonomy":           event.Autonomy,
 			"side_effect":        event.SideEffect,
 			"reason":             event.Reason,
+			"decision_reason":    event.DecisionReason,
 			"risk":               event.Risk,
 		}
 		if event.Violation != nil {
@@ -165,7 +166,7 @@ func (writer *execEventWriter) permission(event agent.PermissionEvent) {
 		risk := event.Risk
 		permissionGranted := event.PermissionGranted
 		writer.writeStreamJSON(streamjson.Event{
-			Type:              streamjson.EventPermission,
+			Type:              streamJSONPermissionEventType(event),
 			RunID:             writer.runID,
 			SessionID:         writer.sessionID,
 			ID:                event.ToolCallID,
@@ -177,6 +178,7 @@ func (writer *execEventWriter) permission(event agent.PermissionEvent) {
 			Autonomy:          event.Autonomy,
 			SideEffect:        event.SideEffect,
 			Reason:            event.Reason,
+			DecisionReason:    event.DecisionReason,
 			Risk:              &risk,
 			Violation:         event.Violation,
 			GrantMatched:      event.GrantMatched,
@@ -187,6 +189,16 @@ func (writer *execEventWriter) permission(event agent.PermissionEvent) {
 	if event.Action != agent.PermissionActionAllow {
 		writer.writeStderr("[permission] " + event.ToolName + " " + string(event.Action) + ": " + event.Reason + "\n")
 	}
+}
+
+func streamJSONPermissionEventType(event agent.PermissionEvent) streamjson.EventType {
+	if event.Action == agent.PermissionActionPrompt {
+		return streamjson.EventPermissionRequest
+	}
+	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny {
+		return streamjson.EventPermissionDecision
+	}
+	return streamjson.EventPermission
 }
 
 func (writer *execEventWriter) usage(usage agent.Usage) {

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"strings"
 )
 
@@ -101,6 +102,13 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
 	}
 	return Decision{Action: ActionPrompt, Risk: risk, Reason: permissionReason(request)}
+}
+
+func (engine *Engine) Grant(input GrantInput) (Grant, error) {
+	if engine == nil || engine.store == nil {
+		return Grant{}, errors.New("sandbox grant store is not configured")
+	}
+	return engine.store.Grant(input)
 }
 
 func deny(request Request, risk Risk, code ViolationCode, path string, reason string, recoverable bool) Decision {

--- a/internal/sessions/replay.go
+++ b/internal/sessions/replay.go
@@ -180,7 +180,7 @@ func buildCompactionPrompt(events []Event, maxChars int) (string, bool) {
 
 func shapedPayloadPreview(event Event) string {
 	switch event.Type {
-	case EventPermission:
+	case EventPermission, EventPermissionRequest, EventPermissionDecision:
 		return permissionPayloadPreview(event.Payload)
 	case EventToolCall:
 		return toolPayloadPreview(event.Payload, []string{"id", "name", "toolName"})

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -23,17 +23,19 @@ const (
 type EventType string
 
 const (
-	EventMessage       EventType = "message"
-	EventToolCall      EventType = "tool_call"
-	EventPermission    EventType = "permission"
-	EventToolResult    EventType = "tool_result"
-	EventProviderUsage EventType = "provider_usage"
-	EventUsage         EventType = EventProviderUsage
-	EventError         EventType = "error"
-	EventSessionRewind EventType = "session_rewind"
-	EventCompaction    EventType = "session_compaction"
-	EventSessionFork   EventType = "session_fork"
-	EventSessionChild  EventType = "session_child"
+	EventMessage            EventType = "message"
+	EventToolCall           EventType = "tool_call"
+	EventPermission         EventType = "permission"
+	EventPermissionRequest  EventType = "permission_request"
+	EventPermissionDecision EventType = "permission_decision"
+	EventToolResult         EventType = "tool_result"
+	EventProviderUsage      EventType = "provider_usage"
+	EventUsage              EventType = EventProviderUsage
+	EventError              EventType = "error"
+	EventSessionRewind      EventType = "session_rewind"
+	EventCompaction         EventType = "session_compaction"
+	EventSessionFork        EventType = "session_fork"
+	EventSessionChild       EventType = "session_child"
 )
 
 type SessionKind string

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -17,16 +17,18 @@ const SchemaVersion = 1
 type EventType string
 
 const (
-	EventRunStart   EventType = "run_start"
-	EventText       EventType = "text"
-	EventToolCall   EventType = "tool_call"
-	EventPermission EventType = "permission"
-	EventToolResult EventType = "tool_result"
-	EventUsage      EventType = "usage"
-	EventFinal      EventType = "final"
-	EventWarning    EventType = "warning"
-	EventError      EventType = "error"
-	EventRunEnd     EventType = "run_end"
+	EventRunStart           EventType = "run_start"
+	EventText               EventType = "text"
+	EventToolCall           EventType = "tool_call"
+	EventPermission         EventType = "permission"
+	EventPermissionRequest  EventType = "permission_request"
+	EventPermissionDecision EventType = "permission_decision"
+	EventToolResult         EventType = "tool_result"
+	EventUsage              EventType = "usage"
+	EventFinal              EventType = "final"
+	EventWarning            EventType = "warning"
+	EventError              EventType = "error"
+	EventRunEnd             EventType = "run_end"
 )
 
 type InputType string
@@ -56,6 +58,7 @@ type Event struct {
 	Autonomy          string             `json:"autonomy,omitempty"`
 	SideEffect        string             `json:"sideEffect,omitempty"`
 	Reason            string             `json:"reason,omitempty"`
+	DecisionReason    string             `json:"decisionReason,omitempty"`
 	Risk              *sandbox.Risk      `json:"risk,omitempty"`
 	Violation         *sandbox.Violation `json:"violation,omitempty"`
 	GrantMatched      bool               `json:"grantMatched,omitempty"`

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -84,6 +84,29 @@ func TestFormatEventRedactsSensitiveObjectKeys(t *testing.T) {
 	}
 }
 
+func TestFormatEventIncludesPermissionDecisionReason(t *testing.T) {
+	line, err := FormatEvent(Event{
+		SchemaVersion:  SchemaVersion,
+		Type:           EventPermissionDecision,
+		RunID:          "run_test",
+		ID:             "call_1",
+		Name:           "write_file",
+		Action:         "allow",
+		DecisionReason: "approved by operator",
+	})
+
+	if err != nil {
+		t.Fatalf("FormatEvent returned error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", line, err)
+	}
+	if decoded["type"] != "permission_decision" || decoded["decisionReason"] != "approved by operator" {
+		t.Fatalf("expected permission decision reason to be serialized, got %#v", decoded)
+	}
+}
+
 func TestParseInputPromptCombinesPromptAndUserMessages(t *testing.T) {
 	input := strings.Join([]string{
 		`{"schemaVersion":1,"type":"message","role":"user","content":"Inspect this repo."}`,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -56,6 +56,7 @@ type model struct {
 	runCancel          context.CancelFunc
 	runID              int
 	activeRunID        int
+	pendingPermission  *pendingPermissionPrompt
 	width              int
 	height             int
 	now                func() time.Time
@@ -73,6 +74,25 @@ type agentResponseMsg struct {
 type agentRowMsg struct {
 	runID int
 	row   transcriptRow
+}
+
+type permissionDecision = agent.PermissionDecisionAction
+
+const (
+	permissionDecisionAllow       permissionDecision = agent.PermissionDecisionAllow
+	permissionDecisionDeny        permissionDecision = agent.PermissionDecisionDeny
+	permissionDecisionAlwaysAllow permissionDecision = agent.PermissionDecisionAlwaysAllow
+)
+
+type permissionRequestMsg struct {
+	runID   int
+	request agent.PermissionRequest
+	decide  func(agent.PermissionDecision)
+}
+
+type pendingPermissionPrompt struct {
+	request agent.PermissionRequest
+	decide  func(agent.PermissionDecision)
 }
 
 func newModel(ctx context.Context, options Options) model {
@@ -161,11 +181,30 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case tea.KeyEnter:
+			if m.pendingPermission != nil {
+				return m, nil
+			}
 			return m.handleSubmit()
+		}
+		if m.pendingPermission != nil {
+			return m.handlePermissionKey(msg)
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		return m, nil
+	case permissionRequestMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		m.showSplash = false
+		m.transcript = appendTranscriptRow(m.transcript, permissionTranscriptRow(permissionEventFromRequest(msg.request)))
+		if msg.request.Action == agent.PermissionActionPrompt {
+			m.pendingPermission = &pendingPermissionPrompt{
+				request: msg.request,
+				decide:  msg.decide,
+			}
+		}
 		return m, nil
 	case agentResponseMsg:
 		if msg.runID != m.activeRunID {
@@ -174,6 +213,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pending = false
 		m.runCancel = nil
 		m.activeRunID = 0
+		m.pendingPermission = nil
 		for _, event := range msg.usageEvents {
 			var usageRows []transcriptRow
 			m, usageRows = m.recordUsageEvent(msg.usageModelID, event)
@@ -233,7 +273,11 @@ func (m model) transcriptView() string {
 
 	if m.pending {
 		builder.WriteString("\n")
-		builder.WriteString(zeroTheme.zero.Render("◇ zero") + "  " + zeroTheme.muted.Render("working…"))
+		if m.pendingPermission != nil {
+			builder.WriteString(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
+		} else {
+			builder.WriteString(zeroTheme.zero.Render("◇ zero") + "  " + zeroTheme.muted.Render("working…"))
+		}
 		builder.WriteString("\n")
 	}
 
@@ -253,6 +297,48 @@ func startsTurn(kind rowKind) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func (m model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch strings.ToLower(msg.String()) {
+	case "a":
+		return m.resolvePermission(permissionDecisionAllow)
+	case "d":
+		return m.resolvePermission(permissionDecisionDeny)
+	case "y":
+		return m.resolvePermission(permissionDecisionAlwaysAllow)
+	default:
+		return m, nil
+	}
+}
+
+func (m model) resolvePermission(decision permissionDecision) (tea.Model, tea.Cmd) {
+	pending := m.pendingPermission
+	if pending == nil {
+		return m, nil
+	}
+
+	if pending.decide != nil {
+		pending.decide(agent.PermissionDecision{
+			Action: decision,
+			Reason: permissionDecisionReason(decision),
+		})
+	}
+	m.pendingPermission = nil
+	return m, nil
+}
+
+func permissionDecisionReason(decision permissionDecision) string {
+	switch decision {
+	case permissionDecisionAllow:
+		return "approved in TUI"
+	case permissionDecisionAlwaysAllow:
+		return "persistently approved in TUI"
+	case permissionDecisionDeny:
+		return "denied in TUI"
+	default:
+		return "denied in TUI"
 	}
 }
 
@@ -422,6 +508,7 @@ func (m *model) cancelRun() {
 	m.pending = false
 	m.runCancel = nil
 	m.activeRunID = 0
+	m.pendingPermission = nil
 }
 
 func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cmd {
@@ -433,6 +520,36 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		options := m.agentOptions
 		options.Registry = m.registry
 		options.PermissionMode = m.permissionMode
+
+		onPermissionRequest := options.OnPermissionRequest
+		options.OnPermissionRequest = func(ctx context.Context, request agent.PermissionRequest) (agent.PermissionDecision, error) {
+			if onPermissionRequest != nil {
+				return onPermissionRequest(ctx, request)
+			}
+			if m.runtimeMessageSink == nil {
+				return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission prompt unavailable"}, nil
+			}
+			decisionCh := make(chan agent.PermissionDecision, 1)
+			m.sendPermissionRequest(runID, request, func(decision agent.PermissionDecision) {
+				select {
+				case decisionCh <- decision:
+				default:
+				}
+			})
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type:    sessions.EventPermissionRequest,
+				Payload: request,
+			})
+			select {
+			case decision := <-decisionCh:
+				if strings.TrimSpace(decision.Reason) == "" {
+					decision.Reason = permissionDecisionReason(permissionDecision(decision.Action))
+				}
+				return decision, nil
+			case <-ctx.Done():
+				return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: ctx.Err().Error()}, ctx.Err()
+			}
+		}
 
 		onToolCall := options.OnToolCall
 		options.OnToolCall = func(call agent.ToolCall) {
@@ -490,7 +607,7 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 			rows = append(rows, row)
 			m.sendAgentRow(runID, row)
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
-				Type:    sessions.EventPermission,
+				Type:    tuiPermissionEventType(event),
 				Payload: event,
 			})
 			if onPermission != nil {
@@ -532,6 +649,23 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		})
 		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents}
 	}
+}
+
+func (m model) sendPermissionRequest(runID int, request agent.PermissionRequest, decide func(agent.PermissionDecision)) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(permissionRequestMsg{runID: runID, request: request, decide: decide})
+}
+
+func tuiPermissionEventType(event agent.PermissionEvent) sessions.EventType {
+	if event.Action == agent.PermissionActionPrompt {
+		return sessions.EventPermissionRequest
+	}
+	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny {
+		return sessions.EventPermissionDecision
+	}
+	return sessions.EventPermission
 }
 
 func (m model) sendAgentRow(runID int, row transcriptRow) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -804,6 +804,109 @@ func TestAgentResponsePreservesPermissionMetadata(t *testing.T) {
 	}
 }
 
+func TestPermissionRequestShowsFocusedPrompt(t *testing.T) {
+	request := testPromptPermissionRequest()
+	m := newModel(context.Background(), Options{})
+	m.showSplash = false
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, cmd := m.Update(permissionRequestMsg{
+		runID:   7,
+		request: request,
+	})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected permission request to update TUI state synchronously")
+	}
+	if next.pendingPermission == nil {
+		t.Fatalf("expected permission prompt to be pending, got %#v", next)
+	}
+	if countTranscriptRows(next.transcript, rowPermission) != 1 {
+		t.Fatalf("expected permission request to append one permission row, got %#v", next.transcript)
+	}
+	view := next.View()
+	for _, want := range []string{"write_file", "[a] allow", "[d] deny", "[y] always", "risk:high", "Creates or overwrites files."} {
+		assertContains(t, view, want)
+	}
+}
+
+func TestPermissionPromptChoicesResolveDecision(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want permissionDecision
+	}{
+		{name: "allow", key: "a", want: permissionDecisionAllow},
+		{name: "deny", key: "d", want: permissionDecisionDeny},
+		{name: "always", key: "y", want: permissionDecisionAlwaysAllow},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			decisions := []permissionDecision{}
+			m := newModel(context.Background(), Options{})
+			m.pending = true
+			m.activeRunID = 7
+			updated, _ := m.Update(permissionRequestMsg{
+				runID:   7,
+				request: testPromptPermissionRequest(),
+				decide: func(decision agent.PermissionDecision) {
+					decisions = append(decisions, permissionDecision(decision.Action))
+				},
+			})
+			next := updated.(model)
+
+			updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tc.key)})
+			next = updated.(model)
+
+			if cmd != nil {
+				t.Fatal("expected permission choice to resolve synchronously")
+			}
+			if len(decisions) != 1 || decisions[0] != tc.want {
+				t.Fatalf("expected decision %q, got %#v", tc.want, decisions)
+			}
+			if next.pendingPermission != nil {
+				t.Fatalf("expected permission prompt to clear after choice, got %#v", next.pendingPermission)
+			}
+		})
+	}
+}
+
+func TestPermissionPromptBlocksNormalSubmit(t *testing.T) {
+	decisions := []permissionDecision{}
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	updated, _ := m.Update(permissionRequestMsg{
+		runID:   7,
+		request: testPromptPermissionRequest(),
+		decide: func(decision agent.PermissionDecision) {
+			decisions = append(decisions, permissionDecision(decision.Action))
+		},
+	})
+	next := updated.(model)
+	next.input.SetValue("second prompt")
+
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected Enter to be ignored while permission prompt is active")
+	}
+	if len(decisions) != 0 {
+		t.Fatalf("expected Enter not to choose a permission decision, got %#v", decisions)
+	}
+	if transcriptContains(next.transcript, "second prompt") {
+		t.Fatalf("permission prompt should block normal prompt submit, got %#v", next.transcript)
+	}
+	if next.pendingPermission == nil {
+		t.Fatal("expected permission prompt to remain pending after Enter")
+	}
+}
+
 func TestPermissionRowRendersSandboxViolations(t *testing.T) {
 	violation := sandbox.Violation{
 		Code:        sandbox.ViolationOutsideWorkspace,
@@ -1048,6 +1151,35 @@ func stringSliceContains(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func testPromptPermissionEvent() agent.PermissionEvent {
+	return agent.PermissionEvent{
+		ToolCallID:     "call_1",
+		ToolName:       "write_file",
+		Action:         agent.PermissionActionPrompt,
+		Permission:     "prompt",
+		PermissionMode: agent.PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		SideEffect:     "write",
+		Reason:         "Creates or overwrites files.",
+		Risk:           sandbox.Risk{Level: sandbox.RiskHigh},
+	}
+}
+
+func testPromptPermissionRequest() agent.PermissionRequest {
+	event := testPromptPermissionEvent()
+	return agent.PermissionRequest{
+		ToolCallID:     event.ToolCallID,
+		ToolName:       event.ToolName,
+		Action:         event.Action,
+		Permission:     event.Permission,
+		PermissionMode: event.PermissionMode,
+		Autonomy:       event.Autonomy,
+		SideEffect:     event.SideEffect,
+		Reason:         event.Reason,
+		Risk:           event.Risk,
+	}
 }
 
 func testSessionStore(t *testing.T) *sessions.Store {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -160,6 +161,34 @@ func renderPermissionRow(row transcriptRow) string {
 		line += "\n" + indentText(zeroTheme.muted.Render(detail), 2)
 	}
 	return line
+}
+
+func renderFocusedPermissionPrompt(request agent.PermissionRequest, width int) string {
+	name := strings.TrimSpace(request.ToolName)
+	if name == "" {
+		name = "tool"
+	}
+
+	header := zeroTheme.amber.Render("permission required") + "  " + zeroTheme.text.Render(name)
+	choices := zeroTheme.text.Render("[a] allow") + "  " +
+		zeroTheme.text.Render("[d] deny") + "  " +
+		zeroTheme.text.Render("[y] always")
+
+	details := []string{}
+	if request.Risk.Level != "" {
+		details = append(details, "risk:"+string(request.Risk.Level))
+	}
+	if request.Reason != "" {
+		details = append(details, request.Reason)
+	}
+	if request.SideEffect != "" {
+		details = append(details, "side_effect:"+request.SideEffect)
+	}
+	if len(details) > 0 {
+		choices += "\n" + zeroTheme.muted.Render(strings.Join(details, "  "))
+	}
+
+	return borderedBlock(width, []string{header, choices})
 }
 
 func renderToolResultRow(row transcriptRow, width int) string {

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -188,7 +188,7 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 				tool:   name,
 				detail: argHint(payloadString(payload, "arguments")),
 			})
-		case sessions.EventPermission:
+		case sessions.EventPermission, sessions.EventPermissionRequest, sessions.EventPermissionDecision:
 			rows = append(rows, permissionTranscriptRow(permissionEventFromPayload(payload)))
 		case sessions.EventToolResult:
 			name := payloadString(payload, "name")
@@ -246,6 +246,7 @@ func permissionEventFromPayload(payload map[string]any) agent.PermissionEvent {
 		Autonomy:          payloadString(payload, "autonomy"),
 		SideEffect:        payloadString(payload, "sideEffect"),
 		Reason:            payloadString(payload, "reason"),
+		DecisionReason:    payloadString(payload, "decisionReason"),
 		GrantMatched:      payloadBool(payload, "grantMatched"),
 	}
 	if risk, ok := payloadMap(payload, "risk"); ok {

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -212,6 +213,7 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewWriteFileTool(root))
 	runtimeMessages := []tea.Msg{}
+	runtimeMessageCh := make(chan tea.Msg, 8)
 	m := newModel(context.Background(), Options{
 		Cwd:            root,
 		ProviderName:   "openai",
@@ -222,6 +224,7 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 		PermissionMode: agent.PermissionModeAsk,
 		RuntimeMessageSink: func(msg tea.Msg) {
 			runtimeMessages = append(runtimeMessages, msg)
+			runtimeMessageCh <- msg
 		},
 		AgentOptions: agent.Options{
 			Autonomy: string(sandbox.AutonomyMedium),
@@ -238,22 +241,30 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected prompt submit to start an agent run")
 	}
-	finalMsg := cmd()
-	if len(runtimeMessages) != 3 {
-		t.Fatalf("expected live tool call, permission, and result messages, got %#v", runtimeMessages)
-	}
-	for _, runtimeMsg := range runtimeMessages {
+
+	finalCh := make(chan tea.Msg, 1)
+	go func() {
+		finalCh <- cmd()
+	}()
+
+	for received := 0; received < 4; received++ {
+		runtimeMsg := receiveRuntimeMessage(t, runtimeMessageCh)
 		updated, _ = next.Update(runtimeMsg)
 		next = updated.(model)
+		if _, ok := runtimeMsg.(permissionRequestMsg); ok {
+			updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+			next = updated.(model)
+		}
 	}
 	if !next.pending {
 		t.Fatal("expected live runtime rows to leave run pending until final response")
 	}
-	for _, want := range []string{"tool call: write_file", "permission: write_file prompt", "tool result: write_file error"} {
+	for _, want := range []string{"tool call: write_file", "permission: write_file prompt", "permission: write_file deny", "tool result: write_file error"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected live transcript to contain %q, got %#v", want, next.transcript)
 		}
 	}
+	finalMsg := receiveFinalMessage(t, finalCh)
 	updated, _ = next.Update(finalMsg)
 	next = updated.(model)
 
@@ -274,7 +285,8 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
 		sessions.EventMessage,
 		sessions.EventToolCall,
-		sessions.EventPermission,
+		sessions.EventPermissionRequest,
+		sessions.EventPermissionDecision,
 		sessions.EventToolResult,
 		sessions.EventMessage,
 	}) {
@@ -286,13 +298,260 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	assertPayloadField(t, events[2], "permission", "prompt")
 	assertPayloadField(t, events[2], "permissionMode", "ask")
 	assertPayloadField(t, events[2], "sideEffect", "write")
-	assertPayloadField(t, events[4], "content", "write blocked")
+	assertPayloadField(t, events[3], "action", "deny")
+	assertPayloadField(t, events[3], "decisionReason", "denied in TUI")
+	assertPayloadField(t, events[5], "content", "write blocked")
 	if !transcriptContains(next.transcript, "permission: write_file prompt") {
 		t.Fatalf("expected permission row in transcript, got %#v", next.transcript)
 	}
-	if countTranscriptRows(next.transcript, rowPermission) != 1 {
-		t.Fatalf("expected final response to avoid duplicate permission rows, got %#v", next.transcript)
+	if countTranscriptRows(next.transcript, rowPermission) != 2 {
+		t.Fatalf("expected request and decision permission rows, got %#v", next.transcript)
 	}
+}
+
+func TestPermissionPromptAllowWritesFileAndRecordsDecision(t *testing.T) {
+	store := testSessionStore(t)
+	root := t.TempDir()
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		writeFileToolScript("call_write", "notes.txt", "hello"),
+		textScript("write allowed"),
+	}}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	runtimeMessageCh := make(chan tea.Msg, 8)
+	m := newPermissionTestModel(root, provider, registry, store, nil, runtimeMessageCh)
+
+	next := submitAndDrivePermissionRun(t, m, "write notes", "a", runtimeMessageCh, 4)
+
+	content, err := os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("expected allow decision to write file, got %q", content)
+	}
+	events := readOnlySessionEvents(t, store)
+	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
+		sessions.EventMessage,
+		sessions.EventToolCall,
+		sessions.EventPermissionRequest,
+		sessions.EventPermissionDecision,
+		sessions.EventToolResult,
+		sessions.EventMessage,
+	}) {
+		t.Fatalf("unexpected event sequence: %#v", got)
+	}
+	assertPayloadField(t, events[3], "action", "allow")
+	assertPayloadField(t, events[3], "decisionReason", "approved in TUI")
+	assertPayloadField(t, events[4], "status", "ok")
+	assertPayloadField(t, events[5], "content", "write allowed")
+	if !transcriptContains(next.transcript, "permission: write_file allow") {
+		t.Fatalf("expected allow decision in transcript, got %#v", next.transcript)
+	}
+}
+
+func TestPermissionPromptAlwaysPersistsGrantAndSkipsLaterPrompt(t *testing.T) {
+	store := testSessionStore(t)
+	root := t.TempDir()
+	grantStore, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		writeFileToolScript("call_first", "notes.txt", "first"),
+		textScript("first write"),
+		writeFileToolScript("call_second", "notes.txt", "second"),
+		textScript("second write"),
+	}}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	runtimeMessageCh := make(chan tea.Msg, 8)
+	m := newPermissionTestModel(root, provider, registry, store, grantStore, runtimeMessageCh)
+
+	next := submitAndDrivePermissionRun(t, m, "write first", "y", runtimeMessageCh, 4)
+
+	lookup, err := grantStore.Lookup("write_file", sandbox.AutonomyMedium)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lookup.Matched || lookup.Grant.Decision != sandbox.GrantAllow {
+		t.Fatalf("expected always decision to persist allow grant, got %#v", lookup)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "first" {
+		t.Fatalf("expected first approved write, got %q", content)
+	}
+
+	runtimeMessageCh = make(chan tea.Msg, 8)
+	next.runtimeMessageSink = func(msg tea.Msg) {
+		runtimeMessageCh <- msg
+	}
+	next = submitAndDrivePermissionRun(t, next, "write second", "", runtimeMessageCh, 3)
+
+	content, err = os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "second" {
+		t.Fatalf("expected grant-backed second write, got %q", content)
+	}
+	events := readOnlySessionEvents(t, store)
+	if countSessionEvents(events, sessions.EventPermissionRequest) != 1 {
+		t.Fatalf("expected only first run to request permission, got %#v", eventTypes(events))
+	}
+	if countSessionEvents(events, sessions.EventPermissionDecision) != 2 {
+		t.Fatalf("expected both runs to record decisions, got %#v", eventTypes(events))
+	}
+	secondDecision := nthSessionEvent(t, events, sessions.EventPermissionDecision, 2)
+	assertPayloadField(t, secondDecision, "action", "allow")
+	assertPayloadField(t, secondDecision, "grantMatched", true)
+	if !transcriptContains(next.transcript, "second write") {
+		t.Fatalf("expected second run answer in transcript, got %#v", next.transcript)
+	}
+}
+
+func receiveRuntimeMessage(t *testing.T, messages <-chan tea.Msg) tea.Msg {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		return msg
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for runtime message")
+		return nil
+	}
+}
+
+func receiveFinalMessage(t *testing.T, messages <-chan tea.Msg) tea.Msg {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		return msg
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for final agent message")
+		return nil
+	}
+}
+
+func submitAndDrivePermissionRun(t *testing.T, m model, prompt string, key string, runtimeMessages <-chan tea.Msg, expectedRuntimeMessages int) model {
+	t.Helper()
+	m.input.SetValue(prompt)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+
+	finalCh := make(chan tea.Msg, 1)
+	go func() {
+		finalCh <- cmd()
+	}()
+
+	for received := 0; received < expectedRuntimeMessages; received++ {
+		runtimeMsg := receiveRuntimeMessage(t, runtimeMessages)
+		updated, _ = next.Update(runtimeMsg)
+		next = updated.(model)
+		if _, ok := runtimeMsg.(permissionRequestMsg); ok && key != "" {
+			updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)})
+			next = updated.(model)
+		}
+	}
+
+	finalMsg := receiveFinalMessage(t, finalCh)
+	updated, _ = next.Update(finalMsg)
+	return updated.(model)
+}
+
+func newPermissionTestModel(root string, provider zeroruntime.Provider, registry *tools.Registry, store *sessions.Store, grantStore *sandbox.GrantStore, runtimeMessages chan<- tea.Msg) model {
+	engineOptions := sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        sandbox.DefaultPolicy(),
+	}
+	if grantStore != nil {
+		engineOptions.Store = grantStore
+	}
+	return newModel(context.Background(), Options{
+		Cwd:            root,
+		ProviderName:   "openai",
+		ModelName:      "gpt-4.1",
+		Provider:       provider,
+		Registry:       registry,
+		SessionStore:   store,
+		SandboxStore:   grantStore,
+		PermissionMode: agent.PermissionModeAsk,
+		RuntimeMessageSink: func(msg tea.Msg) {
+			runtimeMessages <- msg
+		},
+		AgentOptions: agent.Options{
+			Autonomy: string(sandbox.AutonomyMedium),
+			Sandbox:  sandbox.NewEngine(engineOptions),
+		},
+	})
+}
+
+func writeFileToolScript(callID string, path string, content string) []zeroruntime.StreamEvent {
+	return []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: callID, ToolName: "write_file"},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: callID, ArgumentsFragment: `{"path":` + jsonString(path) + `,"content":` + jsonString(content) + `,"overwrite":true}`},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: callID},
+		{Type: zeroruntime.StreamEventDone},
+	}
+}
+
+func textScript(text string) []zeroruntime.StreamEvent {
+	return []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: text},
+		{Type: zeroruntime.StreamEventDone},
+	}
+}
+
+func jsonString(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}
+
+func readOnlySessionEvents(t *testing.T, store *sessions.Store) []sessions.Event {
+	t.Helper()
+	list, err := store.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected one session, got %d", len(list))
+	}
+	events, err := store.ReadEvents(list[0].SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	return events
+}
+
+func countSessionEvents(events []sessions.Event, eventType sessions.EventType) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType {
+			count++
+		}
+	}
+	return count
+}
+
+func nthSessionEvent(t *testing.T, events []sessions.Event, eventType sessions.EventType, ordinal int) sessions.Event {
+	t.Helper()
+	seen := 0
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+		seen++
+		if seen == ordinal {
+			return event
+		}
+	}
+	t.Fatalf("missing %s event #%d in %#v", eventType, ordinal, eventTypes(events))
+	return sessions.Event{}
 }
 
 func TestResumeCommandHydratesSessionTranscript(t *testing.T) {

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -126,7 +126,7 @@ func transcriptRowKey(row transcriptRow) string {
 		}
 	case rowPermission:
 		if row.permission != nil && row.permission.ToolCallID != "" {
-			return fmt.Sprintf("%d:%s", row.kind, row.permission.ToolCallID)
+			return fmt.Sprintf("%d:%s:%s", row.kind, row.permission.ToolCallID, row.permission.Action)
 		}
 	}
 	return ""
@@ -140,6 +140,23 @@ func permissionTranscriptRow(event agent.PermissionEvent) transcriptRow {
 		tool:       event.ToolName,
 		detail:     permissionDetailText(event),
 		permission: &event,
+	}
+}
+
+func permissionEventFromRequest(request agent.PermissionRequest) agent.PermissionEvent {
+	return agent.PermissionEvent{
+		ToolCallID:     request.ToolCallID,
+		ToolName:       request.ToolName,
+		Action:         request.Action,
+		Permission:     request.Permission,
+		PermissionMode: request.PermissionMode,
+		Autonomy:       request.Autonomy,
+		SideEffect:     request.SideEffect,
+		Reason:         request.Reason,
+		Risk:           request.Risk,
+		Violation:      request.Violation,
+		GrantMatched:   request.GrantMatched,
+		Grant:          request.Grant,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a blocking runtime permission request/decision contract for prompt-gated tools
- wire TUI allow / deny / always flows into the agent loop, including persistent sandbox grants
- split stream-json and session permission lifecycle into `permission_request` and `permission_decision`
- document the stream-json permission lifecycle and headless prompt behavior

## Tests
- git diff --check
- go test ./...
- go build ./cmd/zero

## Notes
- Subagents covered headless/session and TUI slices, then a final read-only review approved the combined diff.
- Headless exec still fails closed for prompt-gated tools unless already approved; interactive TUI now supplies decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented interactive permission prompts with allow/deny/always-allow options.
  * Added explicit `permission_request` and `permission_decision` events to the protocol.
  * Permission decisions now include reasoning details.
  * Introduced permission grant persistence for repeated tool access.

* **Documentation**
  * Updated Stream-JSON protocol examples with permission request/decision events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->