### PR TITLE
feat(update): expose release check target options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ zero doctor [--connectivity] [--json]        # health checks
 zero config [--json]                          # inspect resolved configuration
 zero sandbox policy [--json]                 # inspect sandbox backend support
 zero serve --mcp [-C <path>]                  # expose Zero read-only tools over MCP stdio
-zero update --check [--json]                  # check for a newer release
+zero update --check [--json --repo owner/name] # check for a newer release
 ```
 
 ## Providers & models

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,21 +2,33 @@
 
 `zero update --check` checks the latest GitHub release for `Gitlawb/zero` and compares it with the local CLI version.
 
+```bash
+zero update --check
+zero update --check --json
+zero update --check --repo Gitlawb/zero
+zero update --check --endpoint https://api.github.com/repos/Gitlawb/zero/releases/latest
+zero update --check --timeout 3s
+```
+
 For M2 this command is intentionally check-only:
 
 - It does not replace the running binary.
 - It exits with code `0` when the check succeeds, even when an update is available.
 - It exits with code `1` when the release check cannot be completed.
 - `--json` prints the same result in a machine-readable format for scripts and CI.
+- `--repo <owner/repo>` checks a different GitHub repository when no endpoint is provided.
+- `--endpoint <url|owner/repo>` checks a specific release API URL or repository slug.
+- `--timeout <duration>` overrides the default release check timeout.
 - Release checks time out after 5 seconds by default.
 - It validates that the latest release includes the expected archive and matching `.sha256` asset for the current platform.
 
 The release endpoint resolves in this order:
 
-- `Options.Endpoint` when calling `update.Check` from code.
+- `--endpoint` from the CLI, or `Options.Endpoint` when calling `update.Check` from code.
 - `ZERO_UPDATE_RELEASE_URL` from the environment.
+- `--repo` from the CLI, or `Options.Repository` when calling `update.Check` from code.
 - `https://api.github.com/repos/Gitlawb/zero/releases/latest`.
 
-`options.endpoint` and `ZERO_UPDATE_RELEASE_URL` may be a full URL or an `owner/repo` slug.
+`--endpoint`, `Options.Endpoint`, and `ZERO_UPDATE_RELEASE_URL` may be a full URL or an `owner/repo` slug.
 
 Installer scripts download the matching release asset for the local platform and verify its `.sha256` file. If Zero is already installed, use this command before re-running the installer.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
@@ -324,6 +325,38 @@ func TestRunUpdateCheckTextAndJSON(t *testing.T) {
 	}
 }
 
+func TestRunUpdatePassesCheckOptions(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	var got update.Options
+	exitCode := runWithDeps([]string{"update", "--check", "--repo=Gitlawb/fork", "--endpoint", "https://example.test/releases/latest", "--timeout", "750ms", "--json"}, &stdout, &stderr, appDeps{
+		checkUpdate: func(_ context.Context, options update.Options) (update.Result, error) {
+			got = options
+			return update.Result{
+				CurrentVersion:  options.CurrentVersion,
+				LatestVersion:   "0.2.0",
+				ReleaseURL:      "https://example.test/releases/tag/v0.2.0",
+				TagName:         "v0.2.0",
+				UpdateAvailable: true,
+			}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if got.CurrentVersion != "dev" || got.Repository != "Gitlawb/fork" || got.Endpoint != "https://example.test/releases/latest" || got.Timeout != 750*time.Millisecond {
+		t.Fatalf("unexpected update options: %#v", got)
+	}
+	if stdout.Len() == 0 {
+		t.Fatalf("expected JSON output")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
 func TestRunUpdateRequiresCheckFlag(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -338,6 +371,28 @@ func TestRunUpdateRequiresCheckFlag(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "--check") {
 		t.Fatalf("expected --check usage error, got %q", got)
+	}
+}
+
+func TestRunUpdateRejectsInvalidTimeout(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"update", "--check", "--timeout", "fast"}, &stdout, &stderr, appDeps{
+		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+			t.Fatal("checkUpdate should not run for invalid timeout")
+			return update.Result{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit code, got %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "invalid update timeout") {
+		t.Fatalf("expected timeout usage error, got %q", got)
 	}
 }
 
@@ -371,8 +426,10 @@ func TestRunUpdateHelpDocumentsCheckFlag(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "--check") {
-		t.Fatalf("expected update help to document --check, got %q", stdout.String())
+	for _, want := range []string{"--check", "--repo", "--endpoint", "--timeout"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected update help to document %s, got %q", want, stdout.String())
+		}
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -375,24 +375,32 @@ func TestRunUpdateRequiresCheckFlag(t *testing.T) {
 }
 
 func TestRunUpdateRejectsInvalidTimeout(t *testing.T) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+	for _, args := range [][]string{
+		{"update", "--check", "--timeout", "fast"},
+		{"update", "--check", "--timeout", "0s"},
+		{"update", "--check", "--timeout=-1s"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
 
-	exitCode := runWithDeps([]string{"update", "--check", "--timeout", "fast"}, &stdout, &stderr, appDeps{
-		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
-			t.Fatal("checkUpdate should not run for invalid timeout")
-			return update.Result{}, nil
-		},
-	})
+			exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+				checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+					t.Fatal("checkUpdate should not run for invalid timeout")
+					return update.Result{}, nil
+				},
+			})
 
-	if exitCode != exitUsage {
-		t.Fatalf("expected usage exit code, got %d", exitCode)
-	}
-	if stdout.Len() != 0 {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if got := stderr.String(); !strings.Contains(got, "invalid update timeout") {
-		t.Fatalf("expected timeout usage error, got %q", got)
+			if exitCode != exitUsage {
+				t.Fatalf("expected usage exit code, got %d", exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, "invalid update timeout") {
+				t.Fatalf("expected timeout usage error, got %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/update"
 )
 
 type updateOptions struct {
-	check bool
-	json  bool
+	check      bool
+	json       bool
+	repository string
+	endpoint   string
+	timeout    time.Duration
 }
 
 func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -27,7 +32,12 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 	if !options.check {
 		return writeUsageError(stderr, "Only `zero update --check` is available right now.")
 	}
-	result, err := deps.checkUpdate(context.Background(), update.Options{CurrentVersion: version})
+	result, err := deps.checkUpdate(context.Background(), update.Options{
+		CurrentVersion: version,
+		Repository:     options.repository,
+		Endpoint:       options.endpoint,
+		Timeout:        options.timeout,
+	})
 	if err != nil {
 		return writeAppError(stderr, "Could not check for updates: "+err.Error(), exitCrash)
 	}
@@ -45,14 +55,50 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 
 func parseUpdateArgs(args []string) (updateOptions, bool, error) {
 	options := updateOptions{}
-	for _, arg := range args {
-		switch arg {
-		case "-h", "--help", "help":
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
 			return options, true, nil
-		case "--check":
+		case arg == "--check":
 			options.check = true
-		case "--json":
+		case arg == "--json":
 			options.json = true
+		case arg == "--repo":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.repository = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--repo="):
+			options.repository = strings.TrimSpace(strings.TrimPrefix(arg, "--repo="))
+		case arg == "--endpoint":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.endpoint = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--endpoint="):
+			options.endpoint = strings.TrimSpace(strings.TrimPrefix(arg, "--endpoint="))
+		case arg == "--timeout":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			timeout, err := parseUpdateTimeout(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.timeout = timeout
+			index = next
+		case strings.HasPrefix(arg, "--timeout="):
+			timeout, err := parseUpdateTimeout(strings.TrimPrefix(arg, "--timeout="))
+			if err != nil {
+				return options, false, err
+			}
+			options.timeout = timeout
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unknown update flag %q", arg)}
 		}
@@ -60,14 +106,25 @@ func parseUpdateArgs(args []string) (updateOptions, bool, error) {
 	return options, false, nil
 }
 
+func parseUpdateTimeout(value string) (time.Duration, error) {
+	timeout, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil {
+		return 0, execUsageError{fmt.Sprintf("invalid update timeout %q: use a duration like 5s or 750ms", value)}
+	}
+	return timeout, nil
+}
+
 func writeUpdateHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero update --check [flags]
 
 Flags:
-      --check    Check the latest GitHub release without installing
-      --json     Print the update check result as JSON
-  -h, --help     Show this help
+      --check                 Check the latest GitHub release without installing
+      --json                  Print the update check result as JSON
+      --repo <owner/repo>     Repository to check when no endpoint is provided
+      --endpoint <url|repo>   Release API URL or owner/repo slug to check
+      --timeout <duration>    Release check timeout (default 5s)
+  -h, --help                  Show this help
 `)
 	return err
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -111,6 +111,9 @@ func parseUpdateTimeout(value string) (time.Duration, error) {
 	if err != nil {
 		return 0, execUsageError{fmt.Sprintf("invalid update timeout %q: use a duration like 5s or 750ms", value)}
 	}
+	if timeout <= 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid update timeout %q: timeout must be a positive duration", value)}
+	}
 	return timeout, nil
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -187,6 +187,64 @@ func TestCheckFetchesDataEndpoint(t *testing.T) {
 	}
 }
 
+func TestCheckResolvesEndpointPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  Options
+		env      string
+		want     string
+		clearEnv bool
+	}{
+		{
+			name:    "endpoint option wins",
+			options: Options{Endpoint: "Gitlawb/option-zero", Repository: "Gitlawb/repo-zero"},
+			env:     "Gitlawb/env-zero",
+			want:    Endpoint("Gitlawb/option-zero"),
+		},
+		{
+			name:    "environment wins over repository",
+			options: Options{Repository: "Gitlawb/repo-zero"},
+			env:     "Gitlawb/env-zero",
+			want:    Endpoint("Gitlawb/env-zero"),
+		},
+		{
+			name:     "repository wins over default",
+			options:  Options{Repository: "Gitlawb/repo-zero"},
+			want:     Endpoint("Gitlawb/repo-zero"),
+			clearEnv: true,
+		},
+		{
+			name:     "default repository last",
+			want:     Endpoint(DefaultRepository),
+			clearEnv: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.clearEnv {
+				t.Setenv("ZERO_UPDATE_RELEASE_URL", "")
+			} else {
+				t.Setenv("ZERO_UPDATE_RELEASE_URL", tt.env)
+			}
+			options := tt.options
+			options.CurrentVersion = "0.1.0"
+			options.GOOS = "linux"
+			options.GOARCH = "amd64"
+			options.Fetch = func(_ context.Context, endpoint string) (Release, error) {
+				if endpoint != tt.want {
+					t.Fatalf("endpoint = %q, want %q", endpoint, tt.want)
+				}
+				return releaseForTarget(t, "v0.2.0", "linux", "amd64"), nil
+			}
+
+			if _, err := Check(context.Background(), options); err != nil {
+				t.Fatalf("Check returned error: %v", err)
+			}
+		})
+	}
+}
+
 func TestCheckRejectsMissingReleaseAssets(t *testing.T) {
 	_, err := Check(context.Background(), Options{
 		CurrentVersion: "0.1.0",


### PR DESCRIPTION
## Summary
- add zero update --check flags for --repo, --endpoint, and --timeout
- pass CLI flags into the existing update.Check release metadata verifier
- test CLI option passthrough, invalid timeout handling, help text, and endpoint precedence
- document CLI flag/env/default precedence for release checks

## Validation
- GOCACHE=/tmp/zero-go-cache go test ./internal/update ./internal/cli -run 'TestCheck|TestResolveEndpoint|TestRunUpdate'
- GOCACHE=/tmp/zero-go-cache go test ./...
- GOCACHE=/tmp/zero-go-cache go run ./cmd/zero-release build
- ./zero update --check --endpoint 'data:application/json,%7B%22tag_name%22%3A%22v0.2.0%22%2C%22html_url%22%3A%22https%3A%2F%2Fexample.test%2Frelease%22%2C%22assets%22%3A%5B%7B%22name%22%3A%22zero-v0.2.0-linux-x64.tar.gz%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-linux-x64.tar.gz%22%7D%2C%7B%22name%22%3A%22zero-v0.2.0-linux-x64.tar.gz.sha256%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-linux-x64.tar.gz.sha256%22%7D%5D%7D' --timeout=750ms --json
- git diff --check

## Coordination
This PR is in the update/release verification lane and does not touch the runtime permission decision work in #95.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--repo`, `--endpoint`, and `--timeout` flags to the update check command for greater flexibility in specifying release sources and behavior.

* **Documentation**
  * Enhanced docs with usage examples, flag descriptions, endpoint resolution precedence, timeout guidance, and exit-code expectations for check-only runs.

* **Tests**
  * Added tests covering flag forwarding, invalid timeout handling, help text, and endpoint-precedence resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->