### PR TITLE
feat(update): verify release metadata by target

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ zero doctor [--connectivity] [--json]        # health checks
 zero config [--json]                          # inspect resolved configuration
 zero sandbox policy [--json]                 # inspect sandbox backend support
 zero serve --mcp [-C <path>]                  # expose Zero read-only tools over MCP stdio
-zero update --check [--json --repo owner/name] # check for a newer release
+zero update --check [--json --target windows-x64] # check for a newer release
 ```
 
 ## Providers & models

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -8,6 +8,7 @@ zero update --check --json
 zero update --check --repo Gitlawb/zero
 zero update --check --endpoint https://api.github.com/repos/Gitlawb/zero/releases/latest
 zero update --check --timeout 3s
+zero update --check --target windows-x64
 ```
 
 For M2 this command is intentionally check-only:
@@ -19,8 +20,11 @@ For M2 this command is intentionally check-only:
 - `--repo <owner/repo>` checks a different GitHub repository when no endpoint is provided.
 - `--endpoint <url|owner/repo>` checks a specific release API URL or repository slug.
 - `--timeout <duration>` overrides the default release check timeout.
+- `--target <platform-arch>` validates release metadata for another supported target from the current machine.
 - Release checks time out after 5 seconds by default.
-- It validates that the latest release includes the expected archive and matching `.sha256` asset for the current platform.
+- It validates that the latest release includes the expected archive and matching `.sha256` asset for the selected platform target.
+
+Supported targets are `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64`, and `windows-arm64`. Without `--target`, Zero checks the current platform.
 
 The release endpoint resolves in this order:
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -358,24 +358,36 @@ func TestRunUpdatePassesCheckOptions(t *testing.T) {
 }
 
 func TestRunUpdateRejectsInvalidTarget(t *testing.T) {
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-
-	exitCode := runWithDeps([]string{"update", "--check", "--target", "solaris-sparc"}, &stdout, &stderr, appDeps{
-		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
-			t.Fatal("checkUpdate should not run for invalid target")
-			return update.Result{}, nil
-		},
-	})
-
-	if exitCode != exitUsage {
-		t.Fatalf("expected usage exit code, got %d", exitCode)
+	tests := []struct {
+		args      []string
+		errorText string
+	}{
+		{args: []string{"update", "--check", "--target", "solaris-sparc"}, errorText: "unsupported update target"},
+		{args: []string{"update", "--check", "--target="}, errorText: "--target requires a non-empty value"},
 	}
-	if stdout.Len() != 0 {
-		t.Fatalf("expected empty stdout, got %q", stdout.String())
-	}
-	if got := stderr.String(); !strings.Contains(got, "unsupported update target") {
-		t.Fatalf("expected target usage error, got %q", got)
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			exitCode := runWithDeps(tt.args, &stdout, &stderr, appDeps{
+				checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+					t.Fatal("checkUpdate should not run for invalid target")
+					return update.Result{}, nil
+				},
+			})
+
+			if exitCode != exitUsage {
+				t.Fatalf("expected usage exit code, got %d", exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if got := stderr.String(); !strings.Contains(got, tt.errorText) {
+				t.Fatalf("expected target usage error %q, got %q", tt.errorText, got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -330,7 +330,7 @@ func TestRunUpdatePassesCheckOptions(t *testing.T) {
 	var stderr bytes.Buffer
 
 	var got update.Options
-	exitCode := runWithDeps([]string{"update", "--check", "--repo=Gitlawb/fork", "--endpoint", "https://example.test/releases/latest", "--timeout", "750ms", "--json"}, &stdout, &stderr, appDeps{
+	exitCode := runWithDeps([]string{"update", "--check", "--repo=Gitlawb/fork", "--endpoint", "https://example.test/releases/latest", "--timeout", "750ms", "--target", "windows-x64", "--json"}, &stdout, &stderr, appDeps{
 		checkUpdate: func(_ context.Context, options update.Options) (update.Result, error) {
 			got = options
 			return update.Result{
@@ -346,7 +346,7 @@ func TestRunUpdatePassesCheckOptions(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	if got.CurrentVersion != "dev" || got.Repository != "Gitlawb/fork" || got.Endpoint != "https://example.test/releases/latest" || got.Timeout != 750*time.Millisecond {
+	if got.CurrentVersion != "dev" || got.Repository != "Gitlawb/fork" || got.Endpoint != "https://example.test/releases/latest" || got.Timeout != 750*time.Millisecond || got.GOOS != "windows" || got.GOARCH != "amd64" {
 		t.Fatalf("unexpected update options: %#v", got)
 	}
 	if stdout.Len() == 0 {
@@ -354,6 +354,28 @@ func TestRunUpdatePassesCheckOptions(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunUpdateRejectsInvalidTarget(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"update", "--check", "--target", "solaris-sparc"}, &stdout, &stderr, appDeps{
+		checkUpdate: func(context.Context, update.Options) (update.Result, error) {
+			t.Fatal("checkUpdate should not run for invalid target")
+			return update.Result{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit code, got %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "unsupported update target") {
+		t.Fatalf("expected target usage error, got %q", got)
 	}
 }
 
@@ -434,7 +456,7 @@ func TestRunUpdateHelpDocumentsCheckFlag(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	for _, want := range []string{"--check", "--repo", "--endpoint", "--timeout"} {
+	for _, want := range []string{"--check", "--repo", "--endpoint", "--timeout", "--target"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("expected update help to document %s, got %q", want, stdout.String())
 		}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -114,10 +114,18 @@ func parseUpdateArgs(args []string) (updateOptions, bool, error) {
 			if err != nil {
 				return options, false, err
 			}
-			options.target = strings.TrimSpace(value)
+			target, err := parseUpdateTarget(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.target = target
 			index = next
 		case strings.HasPrefix(arg, "--target="):
-			options.target = strings.TrimSpace(strings.TrimPrefix(arg, "--target="))
+			target, err := parseUpdateTarget(strings.TrimPrefix(arg, "--target="))
+			if err != nil {
+				return options, false, err
+			}
+			options.target = target
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unknown update flag %q", arg)}
 		}
@@ -134,6 +142,14 @@ func parseUpdateTimeout(value string) (time.Duration, error) {
 		return 0, execUsageError{fmt.Sprintf("invalid update timeout %q: timeout must be a positive duration", value)}
 	}
 	return timeout, nil
+}
+
+func parseUpdateTarget(value string) (string, error) {
+	target := strings.TrimSpace(value)
+	if target == "" {
+		return "", execUsageError{"--target requires a non-empty value"}
+	}
+	return target, nil
 }
 
 func writeUpdateHelp(w io.Writer) error {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -16,6 +16,7 @@ type updateOptions struct {
 	repository string
 	endpoint   string
 	timeout    time.Duration
+	target     string
 }
 
 func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -32,12 +33,21 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 	if !options.check {
 		return writeUsageError(stderr, "Only `zero update --check` is available right now.")
 	}
-	result, err := deps.checkUpdate(context.Background(), update.Options{
+	checkOptions := update.Options{
 		CurrentVersion: version,
 		Repository:     options.repository,
 		Endpoint:       options.endpoint,
 		Timeout:        options.timeout,
-	})
+	}
+	if options.target != "" {
+		target, err := update.ResolveTarget(options.target)
+		if err != nil {
+			return writeUsageError(stderr, err.Error())
+		}
+		checkOptions.GOOS = target.GOOS
+		checkOptions.GOARCH = target.GOARCH
+	}
+	result, err := deps.checkUpdate(context.Background(), checkOptions)
 	if err != nil {
 		return writeAppError(stderr, "Could not check for updates: "+err.Error(), exitCrash)
 	}
@@ -99,6 +109,15 @@ func parseUpdateArgs(args []string) (updateOptions, bool, error) {
 				return options, false, err
 			}
 			options.timeout = timeout
+		case arg == "--target":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.target = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--target="):
+			options.target = strings.TrimSpace(strings.TrimPrefix(arg, "--target="))
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unknown update flag %q", arg)}
 		}
@@ -127,6 +146,7 @@ Flags:
       --repo <owner/repo>     Repository to check when no endpoint is provided
       --endpoint <url|repo>   Release API URL or owner/repo slug to check
       --timeout <duration>    Release check timeout (default 5s)
+      --target <platform>     Release target to verify (for example windows-x64)
   -h, --help                  Show this help
 `)
 	return err

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -51,6 +51,15 @@ type AssetCheck struct {
 	Verified      bool   `json:"verified"`
 }
 
+// Target identifies a supported release archive target.
+type Target struct {
+	Name     string `json:"name"`
+	GOOS     string `json:"goos"`
+	GOARCH   string `json:"goarch"`
+	Platform string `json:"platform"`
+	Arch     string `json:"arch"`
+}
+
 // Options configures a release update check.
 type Options struct {
 	CurrentVersion string
@@ -98,6 +107,28 @@ func CompareSemver(left string, right string) (int, error) {
 		return 0, err
 	}
 	return compareSemverParts(leftParts, rightParts), nil
+}
+
+// ResolveTarget maps a release target name like windows-x64 to Go build
+// coordinates and release asset naming fields.
+func ResolveTarget(target string) (Target, error) {
+	value := strings.TrimSpace(strings.ToLower(target))
+	switch value {
+	case "linux-x64":
+		return Target{Name: value, GOOS: "linux", GOARCH: "amd64", Platform: "linux", Arch: "x64"}, nil
+	case "linux-arm64":
+		return Target{Name: value, GOOS: "linux", GOARCH: "arm64", Platform: "linux", Arch: "arm64"}, nil
+	case "macos-x64":
+		return Target{Name: value, GOOS: "darwin", GOARCH: "amd64", Platform: "macos", Arch: "x64"}, nil
+	case "macos-arm64":
+		return Target{Name: value, GOOS: "darwin", GOARCH: "arm64", Platform: "macos", Arch: "arm64"}, nil
+	case "windows-x64":
+		return Target{Name: value, GOOS: "windows", GOARCH: "amd64", Platform: "windows", Arch: "x64"}, nil
+	case "windows-arm64":
+		return Target{Name: value, GOOS: "windows", GOARCH: "arm64", Platform: "windows", Arch: "arm64"}, nil
+	default:
+		return Target{}, fmt.Errorf("unsupported update target %q: expected one of linux-x64, linux-arm64, macos-x64, macos-arm64, windows-x64, windows-arm64", target)
+	}
 }
 
 func Check(ctx context.Context, options Options) (Result, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -77,28 +77,30 @@ func TestCheckReportsAvailableUpdate(t *testing.T) {
 
 func TestResolveTarget(t *testing.T) {
 	tests := []struct {
-		target   string
+		input    string
+		name     string
 		goos     string
 		goarch   string
 		platform string
 		arch     string
 	}{
-		{target: "linux-x64", goos: "linux", goarch: "amd64", platform: "linux", arch: "x64"},
-		{target: "linux-arm64", goos: "linux", goarch: "arm64", platform: "linux", arch: "arm64"},
-		{target: "macos-x64", goos: "darwin", goarch: "amd64", platform: "macos", arch: "x64"},
-		{target: "macos-arm64", goos: "darwin", goarch: "arm64", platform: "macos", arch: "arm64"},
-		{target: "windows-x64", goos: "windows", goarch: "amd64", platform: "windows", arch: "x64"},
-		{target: "windows-arm64", goos: "windows", goarch: "arm64", platform: "windows", arch: "arm64"},
+		{input: "linux-x64", name: "linux-x64", goos: "linux", goarch: "amd64", platform: "linux", arch: "x64"},
+		{input: " Linux-X64 ", name: "linux-x64", goos: "linux", goarch: "amd64", platform: "linux", arch: "x64"},
+		{input: "linux-arm64", name: "linux-arm64", goos: "linux", goarch: "arm64", platform: "linux", arch: "arm64"},
+		{input: "macos-x64", name: "macos-x64", goos: "darwin", goarch: "amd64", platform: "macos", arch: "x64"},
+		{input: "MacOS-Arm64", name: "macos-arm64", goos: "darwin", goarch: "arm64", platform: "macos", arch: "arm64"},
+		{input: "windows-x64", name: "windows-x64", goos: "windows", goarch: "amd64", platform: "windows", arch: "x64"},
+		{input: " WINDOWS-ARM64 ", name: "windows-arm64", goos: "windows", goarch: "arm64", platform: "windows", arch: "arm64"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.target, func(t *testing.T) {
-			target, err := ResolveTarget(tt.target)
+		t.Run(tt.input, func(t *testing.T) {
+			target, err := ResolveTarget(tt.input)
 			if err != nil {
 				t.Fatalf("ResolveTarget returned error: %v", err)
 			}
-			if target.GOOS != tt.goos || target.GOARCH != tt.goarch || target.Platform != tt.platform || target.Arch != tt.arch {
-				t.Fatalf("ResolveTarget(%q) = %#v", tt.target, target)
+			if target.Name != tt.name || target.GOOS != tt.goos || target.GOARCH != tt.goarch || target.Platform != tt.platform || target.Arch != tt.arch {
+				t.Fatalf("ResolveTarget(%q) = %#v", tt.input, target)
 			}
 		})
 	}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -75,6 +75,39 @@ func TestCheckReportsAvailableUpdate(t *testing.T) {
 	}
 }
 
+func TestResolveTarget(t *testing.T) {
+	tests := []struct {
+		target   string
+		goos     string
+		goarch   string
+		platform string
+		arch     string
+	}{
+		{target: "linux-x64", goos: "linux", goarch: "amd64", platform: "linux", arch: "x64"},
+		{target: "linux-arm64", goos: "linux", goarch: "arm64", platform: "linux", arch: "arm64"},
+		{target: "macos-x64", goos: "darwin", goarch: "amd64", platform: "macos", arch: "x64"},
+		{target: "macos-arm64", goos: "darwin", goarch: "arm64", platform: "macos", arch: "arm64"},
+		{target: "windows-x64", goos: "windows", goarch: "amd64", platform: "windows", arch: "x64"},
+		{target: "windows-arm64", goos: "windows", goarch: "arm64", platform: "windows", arch: "arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			target, err := ResolveTarget(tt.target)
+			if err != nil {
+				t.Fatalf("ResolveTarget returned error: %v", err)
+			}
+			if target.GOOS != tt.goos || target.GOARCH != tt.goarch || target.Platform != tt.platform || target.Arch != tt.arch {
+				t.Fatalf("ResolveTarget(%q) = %#v", tt.target, target)
+			}
+		})
+	}
+
+	if _, err := ResolveTarget("solaris-sparc"); err == nil || !strings.Contains(err.Error(), "unsupported update target") {
+		t.Fatalf("ResolveTarget invalid error = %v, want unsupported target", err)
+	}
+}
+
 func TestCheckReturnsFetchError(t *testing.T) {
 	wantErr := errors.New("network failure")
 


### PR DESCRIPTION
## Summary
- add update target resolution for release asset names such as windows-x64 and macos-arm64
- expose zero update --check --target <platform-arch> so one machine can validate another platform's release metadata
- keep default behavior as current-platform validation when --target is omitted
- document supported targets and add CLI/backend tests

## Validation
- GOCACHE=/tmp/zero-go-cache go test ./internal/update ./internal/cli -run 'TestResolveTarget|TestCheck|TestRunUpdate'
- GOCACHE=/tmp/zero-go-cache go test ./...
- GOCACHE=/tmp/zero-go-cache go run ./cmd/zero-release build
- ./zero update --check --target windows-x64 --endpoint 'data:application/json,%7B%22tag_name%22%3A%22v0.2.0%22%2C%22html_url%22%3A%22https%3A%2F%2Fexample.test%2Frelease%22%2C%22assets%22%3A%5B%7B%22name%22%3A%22zero-v0.2.0-windows-x64.zip%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-windows-x64.zip%22%7D%2C%7B%22name%22%3A%22zero-v0.2.0-windows-x64.zip.sha256%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-windows-x64.zip.sha256%22%7D%5D%7D' --json
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--target` flag to `zero update --check` to allow checking releases for specific platforms (Linux, macOS, Windows; x64/arm64), instead of only the current system.

* **Documentation**
  * Updated command docs and examples to describe `--target <platform-arch>`, supported targets, and platform-specific release checks.

* **Tests**
  * Added tests covering target resolution, validation, and invalid-target behavior for the update check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->