### PR TITLE
feat(tui): polish command output

### DIFF
--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -40,33 +40,59 @@ func (m model) searchText(query string) string {
 func (m model) resumeText(args string) string {
 	args = strings.TrimSpace(args)
 	if args != "" {
-		return strings.Join([]string{
-			"Sessions",
-			"TUI resume hydration is not wired yet.",
-			"Use zero exec --resume " + args + " for headless resume.",
-		}, "\n")
+		return renderCommandOutput(commandOutput{
+			Title:  "Sessions",
+			Status: commandStatusInfo,
+			Sections: []commandSection{{
+				Title: "Resume",
+				Lines: []string{"requested session: " + args},
+			}},
+			Hints: []string{"use /resume " + args + " to hydrate this TUI session"},
+		})
 	}
 	sessions, err := m.sessionStore.List()
 	if err != nil {
-		return "Sessions\nerror: " + err.Error()
+		return renderCommandOutput(commandOutput{
+			Title:  "Sessions",
+			Status: commandStatusBlocked,
+			Sections: []commandSection{{
+				Title: "Store",
+				Lines: []string{"error: " + err.Error()},
+			}},
+		})
 	}
-	lines := []string{"Sessions"}
 	if len(sessions) == 0 {
-		return "Sessions\n  (none)"
+		return renderCommandOutput(commandOutput{
+			Title:  "Sessions",
+			Status: commandStatusInfo,
+			Sections: []commandSection{{
+				Title: "Recent",
+				Lines: []string{"none"},
+			}},
+		})
 	}
 	limit := len(sessions)
 	if limit > 8 {
 		limit = 8
 	}
+	lines := []string{fmt.Sprintf("recent sessions: %d", len(sessions))}
 	for index := 0; index < limit; index++ {
 		session := sessions[index]
 		title := displayValue(session.Title, "untitled")
-		lines = append(lines, fmt.Sprintf("  %s  %s  model=%s provider=%s events=%d updated=%s", session.SessionID, title, displayValue(session.ModelID, "none"), displayValue(session.Provider, "none"), session.EventCount, session.UpdatedAt))
+		lines = append(lines, commandBullet(fmt.Sprintf("%s  %s  model=%s provider=%s events=%d updated=%s", session.SessionID, title, displayValue(session.ModelID, "none"), displayValue(session.Provider, "none"), session.EventCount, session.UpdatedAt)))
 	}
 	if len(sessions) > limit {
-		lines = append(lines, fmt.Sprintf("  ... %d more", len(sessions)-limit))
+		lines = append(lines, fmt.Sprintf("... %d more", len(sessions)-limit))
 	}
-	return strings.Join(lines, "\n")
+	return renderCommandOutput(commandOutput{
+		Title:  "Sessions",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Recent",
+			Lines: lines,
+		}},
+		Hints: []string{"use /resume latest or /resume <id> to load a session"},
+	})
 }
 
 func (m model) handleModelCommand(args string) (model, string) {

--- a/internal/tui/command_output.go
+++ b/internal/tui/command_output.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"regexp"
+	"strings"
+)
+
+var commandOutputSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\bsk-[A-Za-z0-9._-]+\b`),
+}
+
+type commandStatus string
+
+const (
+	commandStatusOK      commandStatus = "ok"
+	commandStatusWarning commandStatus = "warning"
+	commandStatusBlocked commandStatus = "blocked"
+	commandStatusInfo    commandStatus = "info"
+)
+
+type commandOutput struct {
+	Title    string
+	Status   commandStatus
+	Sections []commandSection
+	Hints    []string
+}
+
+type commandSection struct {
+	Title  string
+	Fields []commandField
+	Lines  []string
+	Rows   []commandRow
+	Hints  []string
+}
+
+type commandField struct {
+	Key   string
+	Value string
+}
+
+type commandRow struct {
+	Text string
+}
+
+func formatCommandOutput(output commandOutput) string {
+	lines := []string{}
+
+	status := normalizeCommandStatus(output.Status)
+	title := compactCommandOutputText(output.Title)
+	if title == "" {
+		lines = append(lines, "Zero")
+	} else {
+		lines = append(lines, title)
+	}
+	lines = append(lines, "status: "+string(status))
+
+	for _, section := range output.Sections {
+		lines = append(lines, formatCommandSection(section)...)
+	}
+	for _, hint := range output.Hints {
+		if text := compactCommandOutputText(hint); text != "" {
+			lines = append(lines, "hint: "+text)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func formatCommandSection(section commandSection) []string {
+	lines := []string{}
+
+	if title := compactCommandOutputText(section.Title); title != "" {
+		lines = append(lines, title)
+	}
+	for _, field := range section.Fields {
+		key := compactCommandOutputText(field.Key)
+		value := compactCommandOutputText(field.Value)
+		if key == "" || value == "" {
+			continue
+		}
+		lines = append(lines, "  "+key+": "+value)
+	}
+	for _, line := range section.Lines {
+		if text := compactCommandOutputText(line); text != "" {
+			lines = append(lines, "  "+text)
+		}
+	}
+	for _, row := range section.Rows {
+		if text := compactCommandOutputText(row.Text); text != "" {
+			lines = append(lines, "  - "+text)
+		}
+	}
+	for _, hint := range section.Hints {
+		if text := compactCommandOutputText(hint); text != "" {
+			lines = append(lines, "  hint: "+text)
+		}
+	}
+
+	return lines
+}
+
+func normalizeCommandStatus(status commandStatus) commandStatus {
+	switch status {
+	case commandStatusOK, commandStatusWarning, commandStatusBlocked, commandStatusInfo:
+		return status
+	default:
+		return commandStatusInfo
+	}
+}
+
+func compactCommandOutputText(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	for _, pattern := range commandOutputSecretPatterns {
+		text = pattern.ReplaceAllString(text, "[REDACTED]")
+	}
+	return text
+}
+
+func renderCommandOutput(output commandOutput) string {
+	return formatCommandOutput(output)
+}
+
+func commandFieldLine(key string, value string) string {
+	return compactCommandOutputText(key) + ": " + displayValue(compactCommandOutputText(value), "none")
+}
+
+func commandBullet(value string) string {
+	return "- " + compactCommandOutputText(value)
+}
+
+func boolText(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/tui/command_output.go
+++ b/internal/tui/command_output.go
@@ -1,13 +1,10 @@
 package tui
 
 import (
-	"regexp"
 	"strings"
-)
 
-var commandOutputSecretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\bsk-[A-Za-z0-9._-]+\b`),
-}
+	"github.com/Gitlawb/zero/internal/redaction"
+)
 
 type commandStatus string
 
@@ -110,18 +107,11 @@ func normalizeCommandStatus(status commandStatus) commandStatus {
 
 func compactCommandOutputText(text string) string {
 	text = strings.Join(strings.Fields(text), " ")
-	for _, pattern := range commandOutputSecretPatterns {
-		text = pattern.ReplaceAllString(text, "[REDACTED]")
-	}
-	return text
+	return redaction.RedactString(text, redaction.Options{})
 }
 
 func renderCommandOutput(output commandOutput) string {
 	return formatCommandOutput(output)
-}
-
-func commandFieldLine(key string, value string) string {
-	return compactCommandOutputText(key) + ": " + displayValue(compactCommandOutputText(value), "none")
 }
 
 func commandBullet(value string) string {

--- a/internal/tui/command_output_test.go
+++ b/internal/tui/command_output_test.go
@@ -109,15 +109,25 @@ func TestFormatCommandOutputRedactsTokenLikeText(t *testing.T) {
 		Status: commandStatusOK,
 		Sections: []commandSection{{
 			Title: "Sandbox grants",
-			Lines: []string{"bash [allow/high] - sk-sensitive approved shell"},
+			Lines: []string{
+				"bash [allow/high] - sk-proj-sensitive-token-value approved shell",
+				"anthropic: sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+				"google: AIza1234567890abcdef",
+			},
 		}},
 	})
 
-	if strings.Contains(got, "sk-sensitive") {
-		t.Fatalf("expected token-like text to be redacted, got:\n%s", got)
+	for _, secret := range []string{
+		"sk-proj-sensitive-token-value",
+		"sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+		"AIza1234567890abcdef",
+	} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("expected token-like text to be redacted, got:\n%s", got)
+		}
 	}
 	if !strings.Contains(got, "[REDACTED] approved shell") {
-		t.Fatalf("expected redaction marker in command output, got:\n%s", got)
+		t.Fatalf("expected token-like text to be redacted, got:\n%s", got)
 	}
 }
 

--- a/internal/tui/command_output_test.go
+++ b/internal/tui/command_output_test.go
@@ -1,0 +1,161 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatCommandOutputRendersSectionsFieldsRowsAndHints(t *testing.T) {
+	got := formatCommandOutput(commandOutput{
+		Title:  "Model",
+		Status: commandStatusOK,
+		Sections: []commandSection{
+			{
+				Title: "Active",
+				Fields: []commandField{
+					{Key: "provider", Value: "openai"},
+					{Key: "model", Value: "gpt-5"},
+				},
+				Rows: []commandRow{
+					{Text: "model shell is ready"},
+				},
+				Hints: []string{"use /model list to compare options"},
+			},
+			{
+				Title: "Available",
+				Rows: []commandRow{
+					{Text: "gpt-5"},
+					{Text: "claude-sonnet-4.5"},
+				},
+			},
+		},
+	})
+
+	want := strings.Join([]string{
+		"Model",
+		"status: ok",
+		"Active",
+		"  provider: openai",
+		"  model: gpt-5",
+		"  - model shell is ready",
+		"  hint: use /model list to compare options",
+		"Available",
+		"  - gpt-5",
+		"  - claude-sonnet-4.5",
+	}, "\n")
+
+	if got != want {
+		t.Fatalf("unexpected command output:\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatCommandOutputSupportsAllStatuses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status commandStatus
+		want   string
+	}{
+		{name: "ok", status: commandStatusOK, want: "Status\nstatus: ok"},
+		{name: "warning", status: commandStatusWarning, want: "Status\nstatus: warning"},
+		{name: "blocked", status: commandStatusBlocked, want: "Status\nstatus: blocked"},
+		{name: "info", status: commandStatusInfo, want: "Status\nstatus: info"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatCommandOutput(commandOutput{
+				Title:  "Status",
+				Status: tt.status,
+			})
+
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatCommandOutputRendersPlainLinesAndCommandBullets(t *testing.T) {
+	got := formatCommandOutput(commandOutput{
+		Title:  "Commands",
+		Status: commandStatusInfo,
+		Sections: []commandSection{
+			{
+				Title: "Model",
+				Lines: []string{
+					"/model [list|id] - Show the active model.",
+					commandBullet("gpt-5"),
+				},
+			},
+		},
+	})
+
+	want := strings.Join([]string{
+		"Commands",
+		"status: info",
+		"Model",
+		"  /model [list|id] - Show the active model.",
+		"  - gpt-5",
+	}, "\n")
+
+	if got != want {
+		t.Fatalf("unexpected command lines:\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+func TestFormatCommandOutputRedactsTokenLikeText(t *testing.T) {
+	got := formatCommandOutput(commandOutput{
+		Title:  "Permissions",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Sandbox grants",
+			Lines: []string{"bash [allow/high] - sk-sensitive approved shell"},
+		}},
+	})
+
+	if strings.Contains(got, "sk-sensitive") {
+		t.Fatalf("expected token-like text to be redacted, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[REDACTED] approved shell") {
+		t.Fatalf("expected redaction marker in command output, got:\n%s", got)
+	}
+}
+
+func TestFormatCommandOutputCompactsWhitespaceAndSkipsEmptyItems(t *testing.T) {
+	got := formatCommandOutput(commandOutput{
+		Title:  "  Doctor  ",
+		Status: commandStatusWarning,
+		Sections: []commandSection{
+			{
+				Title: " ",
+				Fields: []commandField{
+					{Key: " ", Value: "skip me"},
+					{Key: "sandbox", Value: "  danger-full-access\r\n(no prompt)  "},
+				},
+				Rows: []commandRow{
+					{Text: " "},
+					{Text: "checks complete\nneeds review"},
+				},
+				Hints: []string{
+					"  use /doctor for details\r\nsoon  ",
+				},
+			},
+		},
+		Hints: []string{
+			"  top-level hint\nis compacted  ",
+		},
+	})
+
+	want := strings.Join([]string{
+		"Doctor",
+		"status: warning",
+		"  sandbox: danger-full-access (no prompt)",
+		"  - checks complete needs review",
+		"  hint: use /doctor for details soon",
+		"hint: top-level hint is compacted",
+	}, "\n")
+
+	if got != want {
+		t.Fatalf("unexpected compact command output:\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}

--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -62,7 +62,7 @@ func TestProviderAndConfigCommandsUseStableStatusOutput(t *testing.T) {
 		t.Fatal("expected /provider to be handled without starting an agent run")
 	}
 	providerText := transcriptText(next.transcript)
-	for _, want := range []string{"Provider", "status: ok", "active: openai", "model: gpt-4.1", "api key: set"} {
+	for _, want := range []string{"Provider", "status: ok", "provider: openai", "model: gpt-4.1", "api key: set"} {
 		assertContains(t, providerText, want)
 	}
 	assertNotContains(t, providerText, "sk-sensitive")
@@ -151,7 +151,7 @@ func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
 		t.Fatal("expected /permissions to be handled without starting an agent run")
 	}
 	permissionText := transcriptText(next.transcript)
-	for _, want := range []string{"Permissions", "status: ok", "mode: ask", "persistent grants: 1", "bash [allow/high]", "[REDACTED]"} {
+	for _, want := range []string{"Permissions", "status: ok", "Permission mode: ask", "persistent grants: 1", "bash [allow/high]", "[REDACTED]"} {
 		assertContains(t, permissionText, want)
 	}
 	assertNotContains(t, permissionText, "sk-proj-sensitive")

--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -1,0 +1,177 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestHelpCommandRendersGroupedSections(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/help")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /help to be handled without starting an agent run")
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{
+		"Commands",
+		"Model",
+		"Session",
+		"Runtime",
+		"Tools",
+		"Meta",
+		"  /model [list|id]",
+		"  /permissions",
+		"hint: submit plain text to ask Zero",
+	} {
+		assertContains(t, text, want)
+	}
+	assertNotContains(t, text, "Commands:\n/provider")
+}
+
+func TestProviderAndConfigCommandsUseStableStatusOutput(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      config.OpenAIBaseURL,
+			APIKey:       "sk-sensitive",
+			Model:        "gpt-4.1",
+		},
+		AgentOptions: agent.Options{MaxTurns: 42},
+	})
+
+	m.input.SetValue("/provider")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /provider to be handled without starting an agent run")
+	}
+	providerText := transcriptText(next.transcript)
+	for _, want := range []string{"Provider", "status: ok", "active: openai", "model: gpt-4.1", "api key: set"} {
+		assertContains(t, providerText, want)
+	}
+	assertNotContains(t, providerText, "sk-sensitive")
+
+	next.input.SetValue("/config")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /config to be handled without starting an agent run")
+	}
+	configText := transcriptText(next.transcript)
+	for _, want := range []string{"Config", "status: ok", "runtime: go", "max turns: 42", "permission mode:"} {
+		assertContains(t, configText, want)
+	}
+	assertNotContains(t, configText, "sk-sensitive")
+}
+
+func TestProviderCommandRedactsCredentialBearingBaseURL(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      "https://user:super-secret@proxy.local/v1?api_key=query-secret",
+			APIKey:       "query-secret",
+			Model:        "gpt-4.1",
+		},
+	})
+	m.input.SetValue("/provider")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /provider to be handled without starting an agent run")
+	}
+	text := transcriptText(next.transcript)
+	for _, unwanted := range []string{"super-secret", "query-secret", "user:super-secret@"} {
+		assertNotContains(t, text, unwanted)
+	}
+	assertContains(t, text, "base url: https://proxy.local/v1?api_key=[REDACTED]")
+}
+
+func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool("."))
+
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.Grant(sandbox.GrantInput{
+		ToolName:    "bash",
+		Decision:    sandbox.GrantAllow,
+		MaxAutonomy: sandbox.AutonomyHigh,
+		Reason:      "sk-proj-sensitive approved shell",
+	}); err != nil {
+		t.Fatalf("Grant returned error: %v", err)
+	}
+
+	m := newModel(context.Background(), Options{
+		Cwd:            `D:\codings\Opensource\Zero`,
+		ProviderName:   "openai",
+		ModelName:      "gpt-4.1",
+		Registry:       registry,
+		SandboxStore:   store,
+		PermissionMode: agent.PermissionModeAsk,
+	})
+
+	m.input.SetValue("/context")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /context to be handled without starting an agent run")
+	}
+	contextText := transcriptText(next.transcript)
+	for _, want := range []string{"Context", "status: ok", "Runtime", "Session", "Tools", "cwd: D:\\codings\\Opensource\\Zero", "registered tools: 1"} {
+		assertContains(t, contextText, want)
+	}
+
+	next.input.SetValue("/permissions")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /permissions to be handled without starting an agent run")
+	}
+	permissionText := transcriptText(next.transcript)
+	for _, want := range []string{"Permissions", "status: ok", "mode: ask", "persistent grants: 1", "bash [allow/high]", "[REDACTED]"} {
+		assertContains(t, permissionText, want)
+	}
+	assertNotContains(t, permissionText, "sk-proj-sensitive")
+}
+
+func TestCompactCommandAvoidsShellOnlyPlaceholder(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/compact")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /compact to be handled without starting an agent run")
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{"Compact", "status: warning", "requested: yes", "visible transcript rows:"} {
+		assertContains(t, text, want)
+	}
+	if strings.Contains(text, "not wired") || strings.Contains(text, "future compaction backend") {
+		t.Fatalf("compact output should describe product state, got %q", text)
+	}
+}

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -46,7 +46,6 @@ func (m model) toolsText() string {
 func (m model) permissionsText() string {
 	stateLines := []string{
 		"Permission mode: " + string(m.permissionMode),
-		"mode: " + string(m.permissionMode),
 	}
 	if m.sandboxStore == nil {
 		return renderCommandOutput(commandOutput{
@@ -98,7 +97,6 @@ func (m model) permissionsText() string {
 
 func (m model) providerText() string {
 	profileLines := []string{
-		"active: " + displayValue(m.providerName, "none"),
 		"provider: " + displayValue(m.providerName, "none"),
 		"model: " + displayValue(m.modelName, "none"),
 	}
@@ -131,7 +129,7 @@ func (m model) modelText(args string) string {
 		Sections: []commandSection{{
 			Title: "Active",
 			Lines: []string{
-				"Active model: " + displayValue(m.modelName, "none"),
+				"model: " + displayValue(m.modelName, "none"),
 				"provider: " + displayValue(m.providerName, "none"),
 				"effort: " + m.effortDisplay(),
 			},
@@ -170,7 +168,6 @@ func (m model) contextText() string {
 			{
 				Title: "Tools",
 				Lines: []string{
-					fmt.Sprintf("tools: %d", toolCount),
 					fmt.Sprintf("registered tools: %d", toolCount),
 				},
 			},

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -1,0 +1,223 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+func (m model) toolsText() string {
+	registered := m.registry.All()
+	if len(registered) == 0 {
+		return renderCommandOutput(commandOutput{
+			Title:  "Tools",
+			Status: commandStatusWarning,
+			Sections: []commandSection{{
+				Title: "Registry",
+				Lines: []string{"registered tools: 0"},
+			}},
+		})
+	}
+
+	names := make([]string, 0, len(registered))
+	for _, tool := range registered {
+		names = append(names, commandBullet(tool.Name()))
+	}
+	sort.Strings(names)
+	return renderCommandOutput(commandOutput{
+		Title:  "Tools",
+		Status: commandStatusOK,
+		Sections: []commandSection{
+			{
+				Title: "Registry",
+				Lines: []string{fmt.Sprintf("registered tools: %d", len(names))},
+			},
+			{
+				Title: "Available",
+				Lines: names,
+			},
+		},
+	})
+}
+
+func (m model) permissionsText() string {
+	stateLines := []string{
+		"Permission mode: " + string(m.permissionMode),
+		"mode: " + string(m.permissionMode),
+	}
+	if m.sandboxStore == nil {
+		return renderCommandOutput(commandOutput{
+			Title:  "Permissions",
+			Status: commandStatusWarning,
+			Sections: []commandSection{
+				{Title: "State", Lines: stateLines},
+				{Title: "Sandbox grants:", Lines: []string{"persistent grants: unavailable"}},
+			},
+		})
+	}
+
+	grants, err := m.sandboxStore.List()
+	if err != nil {
+		return renderCommandOutput(commandOutput{
+			Title:  "Permissions",
+			Status: commandStatusBlocked,
+			Sections: []commandSection{
+				{Title: "State", Lines: stateLines},
+				{Title: "Sandbox grants:", Lines: []string{"error: " + err.Error()}},
+			},
+		})
+	}
+	snapshots := zerocommands.SandboxGrantSnapshots(grants)
+	grantLines := []string{fmt.Sprintf("persistent grants: %d", len(snapshots))}
+	if len(snapshots) == 0 {
+		grantLines = append(grantLines, "none")
+	} else {
+		for _, grant := range snapshots {
+			line := fmt.Sprintf("%s [%s/%s]", grant.ToolName, grant.Decision, grant.MaxAutonomy)
+			if grant.ApprovedAt != "" {
+				line += " approved " + grant.ApprovedAt
+			}
+			if grant.Reason != "" {
+				line += " - " + grant.Reason
+			}
+			grantLines = append(grantLines, commandBullet(line))
+		}
+	}
+	return renderCommandOutput(commandOutput{
+		Title:  "Permissions",
+		Status: commandStatusOK,
+		Sections: []commandSection{
+			{Title: "State", Lines: stateLines},
+			{Title: "Sandbox grants:", Lines: grantLines},
+		},
+	})
+}
+
+func (m model) providerText() string {
+	profileLines := []string{
+		"active: " + displayValue(m.providerName, "none"),
+		"provider: " + displayValue(m.providerName, "none"),
+		"model: " + displayValue(m.modelName, "none"),
+	}
+	if m.providerProfile != (config.ProviderProfile{}) {
+		snapshot := zerocommands.ProviderSnapshotFromProfile(m.providerProfile, true)
+		profileLines = append(profileLines,
+			"kind: "+displayValue(snapshot.ProviderKind, "unknown"),
+			"api model: "+displayValue(snapshot.APIModel, "unknown"),
+			"base url: "+displayValue(snapshot.BaseURL, "default"),
+			"api key: "+apiKeyState(snapshot.APIKeySet),
+		)
+		if snapshot.Message != "" {
+			profileLines = append(profileLines, "provider status: "+snapshot.Status+" - "+snapshot.Message)
+		}
+	}
+	return renderCommandOutput(commandOutput{
+		Title:  "Provider",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Active",
+			Lines: profileLines,
+		}},
+	})
+}
+
+func (m model) modelText(args string) string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Model",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Active",
+			Lines: []string{
+				"Active model: " + displayValue(m.modelName, "none"),
+				"provider: " + displayValue(m.providerName, "none"),
+				"effort: " + m.effortDisplay(),
+			},
+		}},
+		Hints: []string{"use /model list to inspect models or /model <id> to switch this TUI session"},
+	})
+}
+
+func (m model) contextText() string {
+	toolCount := len(m.registry.All())
+	return renderCommandOutput(commandOutput{
+		Title:  "Context",
+		Status: commandStatusOK,
+		Sections: []commandSection{
+			{
+				Title: "Runtime",
+				Lines: []string{
+					"cwd: " + displayValue(m.cwd, "unknown"),
+					"provider: " + displayValue(m.providerName, "none"),
+					"model: " + displayValue(m.modelName, "none"),
+					"permission mode: " + string(m.permissionMode),
+					"effort: " + m.effortDisplay(),
+					"style: " + m.responseStyle,
+					"usage: " + m.usageSummaryText(),
+					fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
+				},
+			},
+			{
+				Title: "Session",
+				Lines: []string{
+					"active session: " + displayValue(m.activeSession.SessionID, "none"),
+					"session root: " + displayValue(m.sessionStore.RootDir, "unknown"),
+					"compaction: " + m.compactionStatus(),
+				},
+			},
+			{
+				Title: "Tools",
+				Lines: []string{
+					fmt.Sprintf("tools: %d", toolCount),
+					fmt.Sprintf("registered tools: %d", toolCount),
+				},
+			},
+		},
+	})
+}
+
+func (m model) configText() string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Config",
+		Status: commandStatusOK,
+		Sections: []commandSection{
+			{
+				Title: "Runtime",
+				Lines: []string{
+					"runtime: go",
+					fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
+					"permission mode: " + string(m.permissionMode),
+				},
+			},
+			{
+				Title: "Provider",
+				Lines: []string{
+					"provider: " + displayValue(m.providerName, "none"),
+					"model: " + displayValue(m.modelName, "none"),
+					"api key: " + apiKeyState(strings.TrimSpace(m.providerProfile.APIKey) != ""),
+				},
+			},
+		},
+	})
+}
+
+func (m model) debugText() string {
+	state := "idle"
+	if m.pending {
+		state = "running"
+	}
+	return renderCommandOutput(commandOutput{
+		Title:  "Debug",
+		Status: commandStatusInfo,
+		Sections: []commandSection{{
+			Title: "Runtime",
+			Lines: []string{
+				"run state: " + state,
+				"active run: " + fmt.Sprint(m.activeRunID),
+				"pending permission: " + boolText(m.pendingPermission != nil),
+			},
+		}},
+	})
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -1,6 +1,9 @@
 package tui
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 type commandKind int
 
@@ -40,12 +43,13 @@ const (
 )
 
 type commandDefinition struct {
-	name        string
-	aliases     []string
-	usage       string
-	group       commandGroup
-	description string
-	kind        commandKind
+	name         string
+	aliases      []string
+	usage        string
+	group        commandGroup
+	description  string
+	kind         commandKind
+	startupOrder int
 }
 
 type parsedCommand struct {
@@ -56,25 +60,28 @@ type parsedCommand struct {
 
 var commandDefinitions = []commandDefinition{
 	{
-		name:        "/provider",
-		usage:       "/provider",
-		group:       commandGroupModel,
-		description: "Show the active provider.",
-		kind:        commandProvider,
+		name:         "/provider",
+		usage:        "/provider",
+		group:        commandGroupModel,
+		description:  "Show the active provider.",
+		kind:         commandProvider,
+		startupOrder: 5,
 	},
 	{
-		name:        "/model",
-		usage:       "/model [list|id]",
-		group:       commandGroupModel,
-		description: "Show the active model and model-shell status.",
-		kind:        commandModel,
+		name:         "/model",
+		usage:        "/model [list|id]",
+		group:        commandGroupModel,
+		description:  "Show or switch the active model.",
+		kind:         commandModel,
+		startupOrder: 4,
 	},
 	{
-		name:        "/plan",
-		usage:       "/plan",
-		group:       commandGroupSession,
-		description: "Show planning mode status.",
-		kind:        commandPlan,
+		name:         "/plan",
+		usage:        "/plan",
+		group:        commandGroupSession,
+		description:  "Show planning mode status.",
+		kind:         commandPlan,
+		startupOrder: 1,
 	},
 	{
 		name:        "/permissions",
@@ -84,11 +91,12 @@ var commandDefinitions = []commandDefinition{
 		kind:        commandPermissions,
 	},
 	{
-		name:        "/tools",
-		usage:       "/tools",
-		group:       commandGroupTools,
-		description: "List registered tools.",
-		kind:        commandTools,
+		name:         "/tools",
+		usage:        "/tools",
+		group:        commandGroupTools,
+		description:  "List registered tools.",
+		kind:         commandTools,
+		startupOrder: 3,
 	},
 	{
 		name:        "/context",
@@ -124,7 +132,7 @@ var commandDefinitions = []commandDefinition{
 		name:        "/compact",
 		usage:       "/compact [status]",
 		group:       commandGroupSession,
-		description: "Show or request transcript compaction shell status.",
+		description: "Show or request transcript compaction state.",
 		kind:        commandCompact,
 	},
 	{
@@ -145,7 +153,7 @@ var commandDefinitions = []commandDefinition{
 		name:        "/doctor",
 		usage:       "/doctor",
 		group:       commandGroupRuntime,
-		description: "Show local diagnostics shell status.",
+		description: "Show local diagnostics.",
 		kind:        commandDoctor,
 	},
 	{
@@ -156,25 +164,26 @@ var commandDefinitions = []commandDefinition{
 		kind:        commandConfig,
 	},
 	{
-		name:        "/debug",
-		aliases:     []string{"/debug-mode"},
-		usage:       "/debug",
-		group:       commandGroupRuntime,
-		description: "Show debug mode status.",
-		kind:        commandDebug,
+		name:         "/debug",
+		aliases:      []string{"/debug-mode"},
+		usage:        "/debug",
+		group:        commandGroupRuntime,
+		description:  "Show debug mode status.",
+		kind:         commandDebug,
+		startupOrder: 2,
 	},
 	{
 		name:        "/theme",
 		usage:       "/theme",
 		group:       commandGroupSession,
-		description: "Show theme shell status.",
+		description: "Show theme state.",
 		kind:        commandTheme,
 	},
 	{
 		name:        "/input-style",
 		usage:       "/input-style",
 		group:       commandGroupSession,
-		description: "Show input style shell status.",
+		description: "Show input style state.",
 		kind:        commandInputStyle,
 	},
 	{
@@ -248,13 +257,99 @@ func listCommandNames() []string {
 }
 
 func formatCommandHelpLines() []string {
-	lines := make([]string, 0, len(commandDefinitions))
-	for _, command := range commandDefinitions {
-		label := command.usage
-		if len(command.aliases) > 0 {
-			label += " (" + strings.Join(command.aliases, ", ") + ")"
+	return formatGroupedCommandHelpLines()
+}
+
+func formatGroupedCommandHelpLines() []string {
+	lines := make([]string, 0, len(commandDefinitions)+len(commandGroupOrder()))
+	for _, group := range commandGroupOrder() {
+		groupLines := commandHelpLinesForGroup(group)
+		if len(groupLines) == 0 {
+			continue
 		}
-		lines = append(lines, label+" - "+command.description)
+		lines = append(lines, string(group)+":")
+		lines = append(lines, groupLines...)
 	}
 	return lines
+}
+
+func formatGroupedCommandHelp() string {
+	lines := []string{"Commands", "status: info"}
+	for _, group := range commandGroupOrder() {
+		groupLines := commandHelpLinesForGroup(group)
+		if len(groupLines) == 0 {
+			continue
+		}
+		lines = append(lines, commandGroupTitle(group))
+		lines = append(lines, groupLines...)
+	}
+	lines = append(lines, "hint: submit plain text to ask Zero")
+	return strings.Join(lines, "\n")
+}
+
+func commandHelpLinesForGroup(group commandGroup) []string {
+	lines := []string{}
+	for _, command := range commandDefinitions {
+		if command.group != group {
+			continue
+		}
+		lines = append(lines, "  "+formatCommandHelpLine(command))
+	}
+	return lines
+}
+
+func formatCommandHelpLine(command commandDefinition) string {
+	label := command.usage
+	if len(command.aliases) > 0 {
+		label += " (" + strings.Join(command.aliases, ", ") + ")"
+	}
+	return label + " - " + command.description
+}
+
+func startupCommandNames() []string {
+	chips := make([]commandDefinition, 0, len(commandDefinitions))
+	for _, command := range commandDefinitions {
+		if command.startupOrder > 0 {
+			chips = append(chips, command)
+		}
+	}
+	sort.SliceStable(chips, func(left int, right int) bool {
+		if chips[left].startupOrder == chips[right].startupOrder {
+			return chips[left].name < chips[right].name
+		}
+		return chips[left].startupOrder < chips[right].startupOrder
+	})
+
+	names := make([]string, 0, len(chips))
+	for _, command := range chips {
+		names = append(names, command.name)
+	}
+	return names
+}
+
+func commandGroupOrder() []commandGroup {
+	return []commandGroup{
+		commandGroupModel,
+		commandGroupSession,
+		commandGroupRuntime,
+		commandGroupTools,
+		commandGroupMeta,
+	}
+}
+
+func commandGroupTitle(group commandGroup) string {
+	switch group {
+	case commandGroupModel:
+		return "Model"
+	case commandGroupSession:
+		return "Session"
+	case commandGroupRuntime:
+		return "Runtime"
+	case commandGroupTools:
+		return "Tools"
+	case commandGroupMeta:
+		return "Meta"
+	default:
+		return string(group)
+	}
 }

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestFormatCommandHelpLinesGroupsCommandsByStableOrder(t *testing.T) {
+	lines := formatCommandHelpLines()
+	help := strings.Join(lines, "\n")
+
+	groupOrder := []string{"model:", "session:", "runtime:", "tools:", "meta:"}
+	lastIndex := -1
+	for _, group := range groupOrder {
+		index := strings.Index(help, group)
+		if index < 0 {
+			t.Fatalf("expected grouped help to contain %q, got:\n%s", group, help)
+		}
+		if index <= lastIndex {
+			t.Fatalf("expected %q after previous groups, got:\n%s", group, help)
+		}
+		lastIndex = index
+	}
+
+	for _, want := range []string{
+		"model:",
+		"  /provider - Show the active provider.",
+		"  /model [list|id] - Show or switch the active model.",
+		"  /effort [list|low|medium|high|auto] - Show or set reasoning effort for supported models.",
+		"session:",
+		"  /plan - Show planning mode status.",
+		"runtime:",
+		"  /permissions - Show the active permission mode and sandbox grants.",
+		"  /debug (/debug-mode) - Show debug mode status.",
+		"tools:",
+		"  /search <query> (/find) - Search local session events. Requires a query argument.",
+		"meta:",
+		"  /exit (/quit) - Exit Zero.",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("expected grouped help to contain %q, got:\n%s", want, help)
+		}
+	}
+}
+
+func TestCommandDefinitionsExposeStartupChipsInStableOrder(t *testing.T) {
+	chips := startupCommandNames()
+	metadataChips := startupChipNamesFromDefinitions(t)
+	want := []string{"/plan", "/debug", "/tools", "/model", "/provider"}
+
+	if !reflect.DeepEqual(chips, want) {
+		t.Fatalf("expected startup chips %v, got %v", want, chips)
+	}
+	if !reflect.DeepEqual(chips, metadataChips) {
+		t.Fatalf("expected startup chips to come from metadata, helper=%v metadata=%v", chips, metadataChips)
+	}
+	for _, clutter := range []string{"Enter", "Tab", "Ctrl+C", "/clear", "/exit"} {
+		if commandTestStringSliceContains(chips, clutter) {
+			t.Fatalf("startup chips should stay compact and not contain %q: %v", clutter, chips)
+		}
+	}
+}
+
+func startupChipNamesFromDefinitions(t *testing.T) []string {
+	t.Helper()
+
+	definitionType := reflect.TypeOf(commandDefinition{})
+	orderField, ok := definitionType.FieldByName("startupOrder")
+	if !ok {
+		t.Fatal("commandDefinition should expose startupOrder metadata")
+	}
+	if orderField.Type.Kind() != reflect.Int {
+		t.Fatalf("startupOrder should be an int, got %s", orderField.Type)
+	}
+
+	type startupChip struct {
+		name  string
+		order int
+	}
+	chips := []startupChip{}
+	for _, command := range commandDefinitions {
+		value := reflect.ValueOf(command).FieldByName("startupOrder")
+		if value.Int() > 0 {
+			chips = append(chips, startupChip{
+				name:  command.name,
+				order: int(value.Int()),
+			})
+		}
+	}
+	sort.Slice(chips, func(left int, right int) bool {
+		if chips[left].order == chips[right].order {
+			return chips[left].name < chips[right].name
+		}
+		return chips[left].order < chips[right].order
+	})
+
+	names := make([]string, 0, len(chips))
+	for _, chip := range chips {
+		names = append(names, chip.name)
+	}
+	return names
+}
+
+func commandTestStringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/usage"
-	"github.com/Gitlawb/zero/internal/zerocommands"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -681,122 +679,4 @@ func toolResultRowText(result agent.ToolResult) string {
 		status = tools.StatusOK
 	}
 	return fmt.Sprintf("tool result: %s %s %s", result.Name, status, truncateTUIOutput(result.Output, tuiToolOutputLimit))
-}
-
-func (m model) providerStatus() string {
-	provider := m.providerName
-	if provider == "" {
-		provider = "provider:none"
-	}
-
-	if m.modelName == "" {
-		return provider
-	}
-	return provider + "/" + m.modelName
-}
-
-func (m model) toolsText() string {
-	registered := m.registry.All()
-	if len(registered) == 0 {
-		return "No tools registered."
-	}
-
-	names := make([]string, 0, len(registered))
-	for _, tool := range registered {
-		names = append(names, tool.Name())
-	}
-	sort.Strings(names)
-	return "Tools: " + strings.Join(names, ", ")
-}
-
-func (m model) permissionsText() string {
-	lines := []string{"Permission mode: " + string(m.permissionMode)}
-	if m.sandboxStore == nil {
-		lines = append(lines, "Sandbox grants: unavailable")
-		return strings.Join(lines, "\n")
-	}
-
-	grants, err := m.sandboxStore.List()
-	if err != nil {
-		lines = append(lines, "Sandbox grants: error: "+err.Error())
-		return strings.Join(lines, "\n")
-	}
-	snapshots := zerocommands.SandboxGrantSnapshots(grants)
-	if len(snapshots) == 0 {
-		lines = append(lines, "Sandbox grants: none")
-		return strings.Join(lines, "\n")
-	}
-
-	lines = append(lines, "Sandbox grants:")
-	for _, grant := range snapshots {
-		line := fmt.Sprintf("- %s [%s/%s]", grant.ToolName, grant.Decision, grant.MaxAutonomy)
-		if grant.ApprovedAt != "" {
-			line += " approved " + grant.ApprovedAt
-		}
-		if grant.Reason != "" {
-			line += " - " + grant.Reason
-		}
-		lines = append(lines, line)
-	}
-	return strings.Join(lines, "\n")
-}
-
-func (m model) providerText() string {
-	return strings.Join([]string{
-		"Provider",
-		"provider: " + displayValue(m.providerName, "none"),
-		"model: " + displayValue(m.modelName, "none"),
-	}, "\n")
-}
-
-func (m model) modelText(args string) string {
-	lines := []string{
-		"Model",
-		"Active model: " + displayValue(m.modelName, "none"),
-		"provider: " + displayValue(m.providerName, "none"),
-	}
-	lines = append(lines, "Use /model list to inspect models or /model <id> to switch this TUI session.")
-	return strings.Join(lines, "\n")
-}
-
-func (m model) contextText() string {
-	return strings.Join([]string{
-		"Context",
-		"cwd: " + displayValue(m.cwd, "unknown"),
-		"provider: " + displayValue(m.providerName, "none"),
-		"model: " + displayValue(m.modelName, "none"),
-		"permission mode: " + string(m.permissionMode),
-		"effort: " + m.effortDisplay(),
-		"style: " + m.responseStyle,
-		"usage: " + m.usageSummaryText(),
-		"compaction: " + m.compactionStatus(),
-		fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
-		"active session: " + displayValue(m.activeSession.SessionID, "none"),
-		"session root: " + displayValue(m.sessionStore.RootDir, "unknown"),
-		fmt.Sprintf("tools: %d", len(m.registry.All())),
-	}, "\n")
-}
-
-func (m model) configText() string {
-	return strings.Join([]string{
-		"Config",
-		"provider: " + displayValue(m.providerName, "none"),
-		"model: " + displayValue(m.modelName, "none"),
-		fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
-		"permission mode: " + string(m.permissionMode),
-		"api key: " + apiKeyState(strings.TrimSpace(m.providerProfile.APIKey) != ""),
-	}, "\n")
-}
-
-func (m model) debugText() string {
-	state := "idle"
-	if m.pending {
-		state = "running"
-	}
-	return strings.Join([]string{
-		"Debug",
-		"run state: " + state,
-		"active run: " + fmt.Sprint(m.activeRunID),
-		"Debug mode is not wired in Go TUI yet.",
-	}, "\n")
 }

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -15,12 +15,6 @@ func (m model) modelListText() string {
 	}
 
 	activeID := activeModelID(registry, m.modelName)
-	lines := []string{
-		"Models",
-		"Active model: " + displayValue(m.modelName, "none"),
-		"provider: " + displayValue(m.providerName, "none"),
-		"Available models:",
-	}
 	models := registry.List(modelregistry.ListOptions{})
 	sort.SliceStable(models, func(i, j int) bool {
 		if models[i].Provider == models[j].Provider {
@@ -28,14 +22,33 @@ func (m model) modelListText() string {
 		}
 		return models[i].Provider < models[j].Provider
 	})
+	modelLines := []string{}
 	for _, model := range models {
 		marker := " "
 		if activeID != "" && model.ID == activeID {
 			marker = "*"
 		}
-		lines = append(lines, fmt.Sprintf("%s %s (%s) - %s", marker, model.ID, model.Provider, model.DisplayName))
+		modelLines = append(modelLines, fmt.Sprintf("%s %s (%s) - %s", marker, model.ID, model.Provider, model.DisplayName))
 	}
-	return strings.Join(lines, "\n")
+	return renderCommandOutput(commandOutput{
+		Title:  "Models",
+		Status: commandStatusOK,
+		Sections: []commandSection{
+			{
+				Title: "Active",
+				Lines: []string{
+					"Active model: " + displayValue(m.modelName, "none"),
+					"provider: " + displayValue(m.providerName, "none"),
+					"effort: " + m.effortDisplay(),
+				},
+			},
+			{
+				Title: "Available models:",
+				Lines: modelLines,
+			},
+		},
+		Hints: []string{"use /model <id> to switch this TUI session"},
+	})
 }
 
 func activeModelID(registry modelregistry.Registry, modelName string) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -384,7 +384,7 @@ func TestContextCommandShowsSessionState(t *testing.T) {
 		"permission mode: ask",
 		"max turns:",
 		"session root:",
-		"tools: 1",
+		"registered tools: 1",
 	} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected context transcript to contain %q, got %#v", want, next.transcript)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1136,7 +1136,8 @@ func findTranscriptRow(rows []transcriptRow, kind rowKind) (transcriptRow, bool)
 func transcriptHasMarkedModelEntry(rows []transcriptRow) bool {
 	for _, row := range rows {
 		for _, line := range strings.Split(row.text, "\n") {
-			if strings.HasPrefix(line, "* ") && strings.Contains(line, " (") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "* ") && strings.Contains(trimmed, " (") {
 				return true
 			}
 		}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/agent"
@@ -23,11 +22,19 @@ func (m model) runState() string {
 }
 
 func shellOnlyCommandText(name string) string {
-	return fmt.Sprintf("%s is registered in the Go TUI shell but is not wired yet.", name)
+	return renderCommandOutput(commandOutput{
+		Title:  strings.TrimPrefix(name, "/"),
+		Status: commandStatusWarning,
+		Sections: []commandSection{{
+			Title: "State",
+			Lines: []string{"This control is available in the TUI but does not have a backend setting yet."},
+		}},
+		Hints: []string{"use /help to inspect active commands"},
+	})
 }
 
 func helpText() string {
-	return "Commands:\n" + strings.Join(formatCommandHelpLines(), "\n") + "\nSubmit text to ask the assistant."
+	return formatGroupedCommandHelp()
 }
 
 const defaultCommandFooterText = "/help  /model  /provider  /context  /compact  /effort  /style  /tools  /permissions  /clear  /exit  Esc clear  Ctrl+C quit"

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -148,14 +148,20 @@ func (m model) resolveResumeSession(args string) (*sessions.Metadata, error) {
 }
 
 func formatResumeSummary(session sessions.Metadata, eventCount int) string {
-	return strings.Join([]string{
-		"Resumed Zero session",
-		"id: " + session.SessionID,
-		"title: " + displayValue(session.Title, "untitled"),
-		"model: " + displayValue(session.ModelID, "none"),
-		"provider: " + displayValue(session.Provider, "none"),
-		fmt.Sprintf("events: %d", eventCount),
-	}, "\n")
+	return renderCommandOutput(commandOutput{
+		Title:  "Resumed Zero session",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Session",
+			Lines: []string{
+				"id: " + session.SessionID,
+				"title: " + displayValue(session.Title, "untitled"),
+				"model: " + displayValue(session.ModelID, "none"),
+				"provider: " + displayValue(session.Provider, "none"),
+				fmt.Sprintf("events: %d", eventCount),
+			},
+		}},
+	})
 }
 
 func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -48,18 +48,25 @@ func (m model) handleEffortCommand(args string) (model, string) {
 
 func (m model) effortText() string {
 	lines := []string{
-		"Effort",
 		"active effort: " + m.effortDisplay(),
 		"model: " + displayValue(m.modelName, "none"),
 	}
 	efforts := m.availableReasoningEfforts()
 	if len(efforts) == 0 {
 		lines = append(lines, "available: none for active model")
-		return strings.Join(lines, "\n")
+		return renderCommandOutput(commandOutput{
+			Title:    "Effort",
+			Status:   commandStatusWarning,
+			Sections: []commandSection{{Title: "State", Lines: lines}},
+		})
 	}
 	lines = append(lines, "available: "+joinReasoningEfforts(efforts))
-	lines = append(lines, "Use /effort <value> or /effort auto.")
-	return strings.Join(lines, "\n")
+	return renderCommandOutput(commandOutput{
+		Title:    "Effort",
+		Status:   commandStatusOK,
+		Sections: []commandSection{{Title: "State", Lines: lines}},
+		Hints:    []string{"use /effort <value> or /effort auto"},
+	})
 }
 
 func (m model) availableReasoningEfforts() []modelregistry.ReasoningEffort {
@@ -114,12 +121,18 @@ func (m model) handleStyleCommand(args string) (model, string) {
 }
 
 func (m model) styleText() string {
-	return strings.Join([]string{
-		"Style",
-		"active style: " + m.responseStyle,
-		"available: " + strings.Join(responseStyles, ", "),
-		"Use /style <value> to update this TUI session.",
-	}, "\n")
+	return renderCommandOutput(commandOutput{
+		Title:  "Style",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "State",
+			Lines: []string{
+				"active style: " + m.responseStyle,
+				"available: " + strings.Join(responseStyles, ", "),
+			},
+		}},
+		Hints: []string{"use /style <value> to update this TUI session"},
+	})
 }
 
 func defaultedResponseStyle(value string) string {
@@ -152,17 +165,31 @@ func (m model) handleCompactCommand(args string) (model, string) {
 }
 
 func (m model) compactText(requested bool) string {
-	lines := []string{
-		"Compact",
-		"status: " + m.compactionStatus(),
-		fmt.Sprintf("visible transcript rows: %d", len(m.transcript)),
-	}
+	status := commandStatusInfo
 	if requested {
-		lines = append(lines, "request recorded for future compaction backend.")
+		status = commandStatusWarning
 	} else {
-		lines = append(lines, "backend: not wired yet")
+		status = commandStatusWarning
 	}
-	return strings.Join(lines, "\n")
+	return renderCommandOutput(commandOutput{
+		Title:  "Compact",
+		Status: status,
+		Sections: []commandSection{
+			{
+				Title: "State",
+				Lines: []string{
+					"summary: " + m.compactionStatus(),
+					"requested: " + boolText(m.compactRequests > 0),
+					fmt.Sprintf("visible transcript rows: %d", len(m.transcript)),
+				},
+			},
+			{
+				Title: "Backend",
+				Lines: []string{"state: pending integration"},
+			},
+		},
+		Hints: []string{"compaction request is tracked for this TUI session"},
+	})
 }
 
 func (m model) compactionStatus() string {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -168,8 +168,6 @@ func (m model) compactText(requested bool) string {
 	status := commandStatusInfo
 	if requested {
 		status = commandStatusWarning
-	} else {
-		status = commandStatusWarning
 	}
 	return renderCommandOutput(commandOutput{
 		Title:  "Compact",

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -121,6 +121,9 @@ func TestCompactCommandRecordsShellRequest(t *testing.T) {
 	if next.compactRequests != 1 {
 		t.Fatalf("status should not add compact requests, got %d", next.compactRequests)
 	}
+	if got := next.transcript[len(next.transcript)-1].text; !strings.Contains(got, "status: info") {
+		t.Fatalf("expected /compact status to render info status, got %q", got)
+	}
 }
 
 func TestUsageEventsUpdateFooterAndContext(t *testing.T) {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -102,10 +102,13 @@ func TestCompactCommandRecordsShellRequest(t *testing.T) {
 	if next.compactRequests != 1 {
 		t.Fatalf("expected one compact request, got %d", next.compactRequests)
 	}
-	for _, want := range []string{"Compact", "requested, not yet compacted", "future compaction backend"} {
+	for _, want := range []string{"Compact", "requested, not yet compacted", "state: pending integration"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected compact transcript to contain %q, got %#v", want, next.transcript)
 		}
+	}
+	if transcriptContains(next.transcript, "future compaction backend") || transcriptContains(next.transcript, "not wired") {
+		t.Fatalf("compact transcript should avoid shell-only placeholder text, got %#v", next.transcript)
 	}
 
 	next.input.SetValue("/compact status")

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -151,7 +151,7 @@ func renderTwoToneLogo(line string) string {
 }
 
 func (m model) commandChips() string {
-	chips := []string{"/plan", "/debug", "/tools", "/model", "/provider"}
+	chips := startupCommandNames()
 	parts := make([]string, 0, len(chips))
 	for _, chip := range chips {
 		parts = append(parts, zeroTheme.border.Render("[ "+chip+" ]"))


### PR DESCRIPTION
## Summary
- Adds reusable TUI command output formatting with status, sections, fields, rows, hints, and redaction.
- Groups slash-command help and drives startup chips from command metadata.
- Polishes `/model`, `/provider`, `/config`, `/context`, `/permissions`, `/resume`, `/compact`, `/style`, `/effort`, and debug/theme shell-state outputs.
- Moves command readout code out of `model.go` into focused command view helpers.

## Tests
- `go test ./internal/tui`
- `go test ./...`
- `go build ./cmd/zero`

## Review Notes
- `/provider` uses redacted provider snapshots so credential-bearing base URLs are not leaked.
- Startup remains minimal; no extra context/history/session panels are shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commands now render as structured views with status indicators, grouped sections, hints, and compacted text
  * Help is organized into grouped command sections with stable ordering; startup command chips are deterministic
  * Session, model, compact, provider, context, permissions, and debug views show richer, clearer summaries; secrets/tokens are redacted

* **Tests**
  * Added broad tests validating command output formatting, status mappings, help grouping, startup ordering, and redaction behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->