### PR TITLE
polish(update): clarify target-specific release output

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -201,7 +201,11 @@ func Format(result Result) string {
 			"Release: " + result.ReleaseURL,
 		}
 		lines = appendAssetLines(lines, result.ReleaseAsset)
-		lines = append(lines, "Download the matching release asset for your platform, then replace the current zero binary.")
+		if target := releaseAssetTarget(result.ReleaseAsset); target != "" {
+			lines = append(lines, "Download the verified "+target+" release asset, then replace the current zero binary.")
+		} else {
+			lines = append(lines, "Download the verified release asset, then replace the current zero binary.")
+		}
 		return strings.Join(lines, "\n")
 	}
 	lines := []string{
@@ -216,11 +220,21 @@ func appendAssetLines(lines []string, asset AssetCheck) []string {
 	if asset.ArchiveName == "" {
 		return lines
 	}
+	if target := releaseAssetTarget(asset); target != "" {
+		lines = append(lines, "Release target: "+target)
+	}
 	lines = append(lines, "Release asset: "+asset.ArchiveName)
 	if asset.ChecksumName != "" {
 		lines = append(lines, "Checksum asset: "+asset.ChecksumName)
 	}
 	return lines
+}
+
+func releaseAssetTarget(asset AssetCheck) string {
+	if asset.Platform == "" || asset.Arch == "" {
+		return ""
+	}
+	return asset.Platform + "-" + asset.Arch
 }
 
 func fetchRelease(ctx context.Context, endpoint string) (release Release, err error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -436,6 +436,12 @@ func TestFormatResult(t *testing.T) {
 	if !strings.Contains(output, "Release asset: zero-v0.2.0-linux-x64.tar.gz") || !strings.Contains(output, "Checksum asset: zero-v0.2.0-linux-x64.tar.gz.sha256") {
 		t.Fatalf("update output did not include release assets: %q", output)
 	}
+	if !strings.Contains(output, "Release target: linux-x64") || !strings.Contains(output, "Download the verified linux-x64 release asset") {
+		t.Fatalf("update output did not include target-specific guidance: %q", output)
+	}
+	if strings.Contains(output, "your platform") {
+		t.Fatalf("update output should not use ambiguous platform wording: %q", output)
+	}
 
 	output = Format(Result{
 		CurrentVersion:  "0.2.0",
@@ -447,6 +453,9 @@ func TestFormatResult(t *testing.T) {
 	})
 	if !strings.Contains(output, "up to date") {
 		t.Fatalf("unexpected up-to-date output: %q", output)
+	}
+	if !strings.Contains(output, "Release target: linux-x64") {
+		t.Fatalf("up-to-date output did not include release target: %q", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- include the verified release target in text update output
- replace ambiguous "your platform" wording with target-specific guidance
- cover update-available and up-to-date formatter output in tests

## Validation
- GOCACHE=/tmp/zero-go-cache go test ./internal/update
- GOCACHE=/tmp/zero-go-cache go test ./...
- GOCACHE=/tmp/zero-go-cache go run ./cmd/zero-release build
- ./zero update --check --target windows-x64 --endpoint 'data:application/json,%7B%22tag_name%22%3A%22v0.2.0%22%2C%22html_url%22%3A%22https%3A%2F%2Fexample.test%2Frelease%22%2C%22assets%22%3A%5B%7B%22name%22%3A%22zero-v0.2.0-windows-x64.zip%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-windows-x64.zip%22%7D%2C%7B%22name%22%3A%22zero-v0.2.0-windows-x64.zip.sha256%22%2C%22browser_download_url%22%3A%22https%3A%2F%2Fexample.test%2Fzero-v0.2.0-windows-x64.zip.sha256%22%7D%5D%7D'
- git diff --check

## Sample output
```
Release target: windows-x64
Release asset: zero-v0.2.0-windows-x64.zip
Checksum asset: zero-v0.2.0-windows-x64.zip.sha256
Download the verified windows-x64 release asset, then replace the current zero binary.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update availability messages to include platform and architecture-specific download instructions when release metadata is available, providing clearer guidance.

* **Tests**
  * Enhanced test coverage to verify platform-specific guidance and release target information are correctly included in update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->