### PR TITLE
feat(specialist): add profile management

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -158,6 +158,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runSearch(args[1:], stdout, stderr, deps)
 	case "sessions", "session":
 		return runSessions(args[1:], stdout, stderr, deps)
+	case "specialists", "specialist":
+		return runSpecialists(args[1:], stdout, stderr, deps)
 	case "plugins", "plugin":
 		return runPlugins(args[1:], stdout, stderr, deps)
 	case "hooks":
@@ -359,6 +361,7 @@ Commands:
   search     Search persisted local Zero session events
   find       Alias for search
   sessions   Inspect local Zero session lineage
+  specialist Inspect local Zero specialist profiles
   plugins    Inspect local Zero plugin manifests
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings

--- a/internal/cli/specialist.go
+++ b/internal/cli/specialist.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/specialist"
+)
+
+type specialistOptions struct {
+	json bool
+}
+
+func runSpecialists(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	command, remaining, options, help, err := parseSpecialistArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSpecialistHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	paths, err := specialist.DefaultPaths(workspaceRoot)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	switch command {
+	case "list":
+		if len(remaining) != 0 {
+			return writeExecUsageError(stderr, "specialist list does not accept positional arguments")
+		}
+		return runSpecialistList(paths, options, stdout, stderr)
+	case "show":
+		if len(remaining) != 1 {
+			return writeExecUsageError(stderr, "specialist show requires a specialist name")
+		}
+		return runSpecialistShow(paths, remaining[0], options, stdout, stderr)
+	case "path":
+		if len(remaining) != 0 {
+			return writeExecUsageError(stderr, "specialist path does not accept positional arguments")
+		}
+		return runSpecialistPath(paths, options, stdout)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown specialist command %q", command))
+	}
+}
+
+func parseSpecialistArgs(args []string) (string, []string, specialistOptions, bool, error) {
+	command := "list"
+	commandExplicit := false
+	remaining := []string{}
+	options := specialistOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return command, remaining, options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return command, remaining, options, false, fmt.Errorf("unknown specialist flag %q", arg)
+			}
+			if !commandExplicit {
+				command = arg
+				commandExplicit = true
+			} else {
+				remaining = append(remaining, arg)
+			}
+		}
+	}
+	return command, remaining, options, false, nil
+}
+
+func runSpecialistList(paths specialist.Paths, options specialistOptions, stdout io.Writer, stderr io.Writer) int {
+	result, err := specialist.Load(specialist.LoadOptions{Paths: paths})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, struct {
+			Paths       specialist.Paths     `json:"paths"`
+			Specialists []specialist.Summary `json:"specialists"`
+		}{
+			Paths:       result.Paths,
+			Specialists: specialist.Summaries(result.Specialists),
+		}); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, specialist.FormatList(result)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSpecialistShow(paths specialist.Paths, name string, options specialistOptions, stdout io.Writer, stderr io.Writer) int {
+	result, err := specialist.Load(specialist.LoadOptions{Paths: paths})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	manifest, ok := specialist.Find(result, name)
+	if !ok {
+		return writeExecUsageError(stderr, "Zero specialist not found: "+name)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, manifest); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, specialist.FormatShow(manifest)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSpecialistPath(paths specialist.Paths, options specialistOptions, stdout io.Writer) int {
+	if options.json {
+		if err := writePrettyJSON(stdout, paths); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, specialist.FormatPaths(paths)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func writeSpecialistHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero specialist [command] [flags]
+
+Commands:
+  list       List built-in, user, and project specialists
+  show NAME  Show one specialist profile
+  path       Print specialist directories
+  help       Show this help
+
+Flags:
+  --json     Print JSON output
+`)
+	return err
+}

--- a/internal/cli/specialist.go
+++ b/internal/cli/specialist.go
@@ -104,9 +104,11 @@ func runSpecialistList(paths specialist.Paths, options specialistOptions, stdout
 		if err := writePrettyJSON(stdout, struct {
 			Paths       specialist.Paths     `json:"paths"`
 			Specialists []specialist.Summary `json:"specialists"`
+			Warnings    []string             `json:"warnings,omitempty"`
 		}{
 			Paths:       result.Paths,
 			Specialists: specialist.Summaries(result.Specialists),
+			Warnings:    result.Warnings,
 		}); err != nil {
 			return exitCrash
 		}

--- a/internal/cli/specialist.go
+++ b/internal/cli/specialist.go
@@ -24,6 +24,10 @@ func runSpecialists(args []string, stdout io.Writer, stderr io.Writer, deps appD
 		return exitSuccess
 	}
 
+	if err := validateSpecialistCommand(command, remaining); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+
 	workspaceRoot, err := resolveWorkspaceRoot("", deps)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
@@ -35,19 +39,10 @@ func runSpecialists(args []string, stdout io.Writer, stderr io.Writer, deps appD
 
 	switch command {
 	case "list":
-		if len(remaining) != 0 {
-			return writeExecUsageError(stderr, "specialist list does not accept positional arguments")
-		}
 		return runSpecialistList(paths, options, stdout, stderr)
 	case "show":
-		if len(remaining) != 1 {
-			return writeExecUsageError(stderr, "specialist show requires a specialist name")
-		}
 		return runSpecialistShow(paths, remaining[0], options, stdout, stderr)
 	case "path":
-		if len(remaining) != 0 {
-			return writeExecUsageError(stderr, "specialist path does not accept positional arguments")
-		}
 		return runSpecialistPath(paths, options, stdout)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown specialist command %q", command))
@@ -78,6 +73,26 @@ func parseSpecialistArgs(args []string) (string, []string, specialistOptions, bo
 		}
 	}
 	return command, remaining, options, false, nil
+}
+
+func validateSpecialistCommand(command string, remaining []string) error {
+	switch command {
+	case "list":
+		if len(remaining) != 0 {
+			return fmt.Errorf("specialist list does not accept positional arguments")
+		}
+	case "show":
+		if len(remaining) != 1 {
+			return fmt.Errorf("specialist show requires a specialist name")
+		}
+	case "path":
+		if len(remaining) != 0 {
+			return fmt.Errorf("specialist path does not accept positional arguments")
+		}
+	default:
+		return fmt.Errorf("unknown specialist command %q", command)
+	}
+	return nil
 }
 
 func runSpecialistList(paths specialist.Paths, options specialistOptions, stdout io.Writer, stderr io.Writer) int {

--- a/internal/cli/specialist_test.go
+++ b/internal/cli/specialist_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunSpecialistListShowAndPath(t *testing.T) {
+	cwd := t.TempDir()
+	configRoot := setSpecialistConfigRoot(t)
+	userDir := filepath.Join(configRoot, "zero", "specialists")
+	writeSpecialistManifest(t, filepath.Join(userDir, "triage.md"), `---
+name: triage
+description: Triage failing tests
+tools: [read-only]
+---
+Find the likely failure area.`)
+	deps := appDeps{getwd: func() (string, error) { return cwd, nil }}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"specialist", "list"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"Zero Specialists", "worker [builtin]", "triage [user]", "code-review"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("list output missing %q: %s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"specialist", "show", "triage"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Zero Specialist: triage") || !strings.Contains(stdout.String(), "Find the likely failure area.") {
+		t.Fatalf("unexpected show output: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"specialist", "path"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), userDir) || !strings.Contains(stdout.String(), filepath.Join(cwd, ".zero", "specialists")) {
+		t.Fatalf("unexpected path output: %s", stdout.String())
+	}
+}
+
+func TestRunSpecialistListJSON(t *testing.T) {
+	cwd := t.TempDir()
+	setSpecialistConfigRoot(t)
+	deps := appDeps{getwd: func() (string, error) { return cwd, nil }}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"specialists", "list", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var payload struct {
+		Specialists []struct {
+			Name     string `json:"name"`
+			Location string `json:"location"`
+		} `json:"specialists"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Specialists) == 0 || payload.Specialists[0].Name == "" {
+		t.Fatalf("unexpected JSON payload: %#v", payload)
+	}
+}
+
+func TestRunSpecialistShowMissingReturnsUsage(t *testing.T) {
+	setSpecialistConfigRoot(t)
+	deps := appDeps{getwd: func() (string, error) { return t.TempDir(), nil }}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"specialist", "show", "missing"}, &stdout, &stderr, deps)
+
+	if exitCode != exitUsage {
+		t.Fatalf("exitCode = %d, want usage", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("expected not found error, got %q", stderr.String())
+	}
+}
+
+func setSpecialistConfigRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("APPDATA", root)
+	case "darwin":
+		t.Setenv("HOME", root)
+	default:
+		t.Setenv("XDG_CONFIG_HOME", root)
+	}
+	configRoot, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error = %v", err)
+	}
+	return configRoot
+}
+
+func writeSpecialistManifest(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create manifest dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}

--- a/internal/cli/specialist_test.go
+++ b/internal/cli/specialist_test.go
@@ -55,6 +55,48 @@ Find the likely failure area.`)
 	}
 }
 
+func TestRunSpecialistShowAndPathJSON(t *testing.T) {
+	cwd := t.TempDir()
+	setSpecialistConfigRoot(t)
+	deps := appDeps{getwd: func() (string, error) { return cwd, nil }}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"specialist", "show", "worker", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("show --json exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var showPayload struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Location string `json:"location"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &showPayload); err != nil {
+		t.Fatalf("failed to decode show JSON: %v\n%s", err, stdout.String())
+	}
+	if showPayload.Metadata.Name != "worker" || showPayload.Location == "" {
+		t.Fatalf("unexpected show JSON: %#v", showPayload)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"specialist", "path", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("path --json exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var pathPayload struct {
+		UserDir    string `json:"userDir"`
+		ProjectDir string `json:"projectDir"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &pathPayload); err != nil {
+		t.Fatalf("failed to decode path JSON: %v\n%s", err, stdout.String())
+	}
+	if pathPayload.UserDir == "" || pathPayload.ProjectDir != filepath.Join(cwd, ".zero", "specialists") {
+		t.Fatalf("unexpected path JSON: %#v", pathPayload)
+	}
+}
+
 func TestRunSpecialistListJSON(t *testing.T) {
 	cwd := t.TempDir()
 	setSpecialistConfigRoot(t)
@@ -116,6 +158,35 @@ func TestRunSpecialistUnknownCommandDoesNotResolveWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), `unknown specialist command "missing"`) {
 		t.Fatalf("expected unknown command error, got %q", stderr.String())
+	}
+}
+
+func TestRunSpecialistArgCountErrors(t *testing.T) {
+	setSpecialistConfigRoot(t)
+	deps := appDeps{getwd: func() (string, error) {
+		t.Fatal("getwd should not be called for invalid specialist arguments")
+		return "", nil
+	}}
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"specialist", "list", "extra"}, want: "does not accept positional"},
+		{args: []string{"specialist", "show"}, want: "show requires a specialist name"},
+		{args: []string{"specialist", "path", "extra"}, want: "path does not accept positional"},
+	}
+	for _, tc := range tests {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(tc.args, &stdout, &stderr, deps)
+			if exitCode != exitUsage {
+				t.Fatalf("exitCode = %d, want usage", exitCode)
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("expected %q error, got %q", tc.want, stderr.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/specialist_test.go
+++ b/internal/cli/specialist_test.go
@@ -75,8 +75,13 @@ func TestRunSpecialistListJSON(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("failed to decode JSON: %v\n%s", err, stdout.String())
 	}
-	if len(payload.Specialists) == 0 || payload.Specialists[0].Name == "" {
+	if len(payload.Specialists) == 0 {
 		t.Fatalf("unexpected JSON payload: %#v", payload)
+	}
+	for _, item := range payload.Specialists {
+		if item.Name == "" || item.Location == "" {
+			t.Fatalf("specialist JSON item missing name or location: %#v", item)
+		}
 	}
 }
 
@@ -93,6 +98,24 @@ func TestRunSpecialistShowMissingReturnsUsage(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "not found") {
 		t.Fatalf("expected not found error, got %q", stderr.String())
+	}
+}
+
+func TestRunSpecialistUnknownCommandDoesNotResolveWorkspace(t *testing.T) {
+	deps := appDeps{getwd: func() (string, error) {
+		t.Fatal("getwd should not be called for an unknown specialist command")
+		return "", nil
+	}}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"specialist", "missing"}, &stdout, &stderr, deps)
+
+	if exitCode != exitUsage {
+		t.Fatalf("exitCode = %d, want usage", exitCode)
+	}
+	if !strings.Contains(stderr.String(), `unknown specialist command "missing"`) {
+		t.Fatalf("expected unknown command error, got %q", stderr.String())
 	}
 }
 

--- a/internal/specialist/builtin.go
+++ b/internal/specialist/builtin.go
@@ -8,6 +8,7 @@ func Builtins() []Manifest {
 			Metadata: Metadata{
 				Name:        "worker",
 				Description: "Handles general delegated coding tasks and reports concrete outcomes.",
+				Tools:       []string{"read-only", "edit", "execute", "plan"},
 			},
 			SystemPrompt: workerPrompt,
 			Location:     LocationBuiltin,

--- a/internal/specialist/builtin.go
+++ b/internal/specialist/builtin.go
@@ -1,0 +1,58 @@
+package specialist
+
+import "fmt"
+
+func Builtins() []Manifest {
+	builtins := []Manifest{
+		{
+			Metadata: Metadata{
+				Name:        "worker",
+				Description: "Handles general delegated coding tasks and reports concrete outcomes.",
+			},
+			SystemPrompt: workerPrompt,
+			Location:     LocationBuiltin,
+			FilePath:     "(builtin)",
+		},
+		{
+			Metadata: Metadata{
+				Name:        "explorer",
+				Description: "Performs fast read-only codebase exploration without modifying files.",
+				Tools:       []string{"read-only"},
+			},
+			SystemPrompt: explorerPrompt,
+			Location:     LocationBuiltin,
+			FilePath:     "(builtin)",
+		},
+		{
+			Metadata: Metadata{
+				Name:        "code-review",
+				Description: "Reviews code changes for correctness, regressions, and missing tests.",
+				Tools:       []string{"read-only"},
+			},
+			SystemPrompt: codeReviewPrompt,
+			Location:     LocationBuiltin,
+			FilePath:     "(builtin)",
+		},
+	}
+	for index := range builtins {
+		if err := Validate(&builtins[index]); err != nil {
+			panic(fmt.Sprintf("invalid built-in specialist %q: %s", builtins[index].Metadata.Name, err))
+		}
+	}
+	return builtins
+}
+
+const workerPrompt = `You are a focused task specialist inside Zero.
+
+Complete the assigned task precisely, stay within scope, and report:
+- the concrete work performed
+- the outcome
+- any blockers or follow-ups`
+
+const explorerPrompt = `You are a read-only codebase exploration specialist inside Zero.
+
+Find relevant files, symbols, tests, and behavior quickly. Do not edit files or run shell commands. Report concise findings with paths and line references when useful.`
+
+const codeReviewPrompt = `You are a code review specialist inside Zero.
+
+Review changes for correctness bugs, regressions, unsafe behavior, and missing tests. Prioritize actionable findings over style feedback.`

--- a/internal/specialist/format.go
+++ b/internal/specialist/format.go
@@ -1,0 +1,70 @@
+package specialist
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatList(result LoadResult) string {
+	lines := []string{"Zero Specialists:"}
+	if len(result.Specialists) == 0 {
+		lines = append(lines, "  (none)")
+		return strings.Join(lines, "\n")
+	}
+	for _, manifest := range result.Specialists {
+		lines = append(lines, fmt.Sprintf("  %s [%s] - %s", manifest.Metadata.Name, manifest.Location, manifest.Metadata.Description))
+		tools := formatTools(manifest)
+		if tools != "" {
+			lines = append(lines, "    tools: "+tools)
+		}
+		if len(manifest.Warnings) > 0 {
+			lines = append(lines, "    warnings: "+strings.Join(manifest.Warnings, "; "))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func FormatShow(manifest Manifest) string {
+	lines := []string{
+		"Zero Specialist: " + manifest.Metadata.Name,
+		"location: " + string(manifest.Location),
+		"path: " + manifest.FilePath,
+		"description: " + manifest.Metadata.Description,
+	}
+	if manifest.Metadata.Model != "" {
+		lines = append(lines, "model: "+manifest.Metadata.Model)
+	}
+	if manifest.Metadata.ReasoningEffort != "" {
+		lines = append(lines, "reasoning effort: "+manifest.Metadata.ReasoningEffort)
+	}
+	tools := formatTools(manifest)
+	if tools != "" {
+		lines = append(lines, "tools: "+tools)
+	}
+	if len(manifest.Warnings) > 0 {
+		lines = append(lines, "warnings: "+strings.Join(manifest.Warnings, "; "))
+	}
+	lines = append(lines, "", strings.TrimSpace(manifest.SystemPrompt))
+	return strings.Join(lines, "\n")
+}
+
+func FormatPaths(paths Paths) string {
+	lines := []string{
+		"Zero Specialist Paths:",
+		"  user: " + paths.UserDir,
+	}
+	if paths.ProjectDir != "" {
+		lines = append(lines, "  project: "+paths.ProjectDir)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatTools(manifest Manifest) string {
+	if len(manifest.Metadata.Tools) == 0 {
+		return "all"
+	}
+	if len(manifest.ResolvedTools) == 0 {
+		return strings.Join(manifest.Metadata.Tools, ", ")
+	}
+	return strings.Join(manifest.ResolvedTools, ", ")
+}

--- a/internal/specialist/format.go
+++ b/internal/specialist/format.go
@@ -7,6 +7,9 @@ import (
 
 func FormatList(result LoadResult) string {
 	lines := []string{"Zero Specialists:"}
+	for _, warning := range result.Warnings {
+		lines = append(lines, "  warning: "+warning)
+	}
 	if len(result.Specialists) == 0 {
 		lines = append(lines, "  (none)")
 		return strings.Join(lines, "\n")
@@ -60,8 +63,8 @@ func FormatPaths(paths Paths) string {
 }
 
 func formatTools(manifest Manifest) string {
-	if len(manifest.Metadata.Tools) == 0 {
-		return "all"
+	if len(manifest.Metadata.Tools) == 0 && len(manifest.ResolvedTools) > 0 {
+		return strings.Join(manifest.ResolvedTools, ", ") + " (default)"
 	}
 	if len(manifest.ResolvedTools) == 0 {
 		return strings.Join(manifest.Metadata.Tools, ", ")

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -117,18 +117,16 @@ func Load(options LoadOptions) (LoadResult, error) {
 	}
 
 	manifests := Builtins()
+	projectManifests, err := loadDirectory(paths.ProjectDir, LocationProject)
+	if err != nil {
+		return LoadResult{}, err
+	}
+	manifests = append(manifests, projectManifests...)
 	userManifests, err := loadDirectory(paths.UserDir, LocationUser)
 	if err != nil {
 		return LoadResult{}, err
 	}
 	manifests = append(manifests, userManifests...)
-	if strings.TrimSpace(paths.ProjectDir) != "" {
-		projectManifests, err := loadDirectory(paths.ProjectDir, LocationProject)
-		if err != nil {
-			return LoadResult{}, err
-		}
-		manifests = append(manifests, projectManifests...)
-	}
 
 	return LoadResult{Paths: paths, Specialists: mergeByName(manifests)}, nil
 }

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -1,6 +1,7 @@
 package specialist
 
 import (
+	"encoding/csv"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
 )
 
 type Location string
@@ -61,6 +64,7 @@ type LoadOptions struct {
 type LoadResult struct {
 	Paths       Paths      `json:"paths"`
 	Specialists []Manifest `json:"specialists"`
+	Warnings    []string   `json:"warnings,omitempty"`
 }
 
 var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
@@ -79,6 +83,10 @@ var toolCategories = map[string][]string{
 	"execute":   {"read_file", "list_directory", "grep", "glob", "bash"},
 	"plan":      {"update_plan"},
 }
+
+// defaultToolSelection keeps omitted tools conservative until runtime task
+// execution has its own permission policy.
+var defaultToolSelection = []string{"read-only"}
 
 var knownToolNames = map[string]bool{
 	"read_file":      true,
@@ -117,18 +125,21 @@ func Load(options LoadOptions) (LoadResult, error) {
 	}
 
 	manifests := Builtins()
-	projectManifests, err := loadDirectory(paths.ProjectDir, LocationProject)
+	warnings := []string{}
+	projectManifests, projectWarnings, err := loadDirectory(paths.ProjectDir, LocationProject)
 	if err != nil {
 		return LoadResult{}, err
 	}
+	warnings = append(warnings, projectWarnings...)
 	manifests = append(manifests, projectManifests...)
-	userManifests, err := loadDirectory(paths.UserDir, LocationUser)
+	userManifests, userWarnings, err := loadDirectory(paths.UserDir, LocationUser)
 	if err != nil {
 		return LoadResult{}, err
 	}
+	warnings = append(warnings, userWarnings...)
 	manifests = append(manifests, userManifests...)
 
-	return LoadResult{Paths: paths, Specialists: mergeByName(manifests)}, nil
+	return LoadResult{Paths: paths, Specialists: mergeByName(manifests), Warnings: warnings}, nil
 }
 
 func Find(result LoadResult, name string) (Manifest, bool) {
@@ -205,6 +216,24 @@ func Validate(manifest *Manifest) error {
 	if manifest.Metadata.Description == "" {
 		return fmt.Errorf("specialist %q requires a description", manifest.Metadata.Name)
 	}
+	if manifest.Metadata.Model != "" {
+		registry, err := modelregistry.DefaultRegistry()
+		if err != nil {
+			return fmt.Errorf("load model registry: %w", err)
+		}
+		modelID, ok := registry.ResolveID(manifest.Metadata.Model)
+		if !ok {
+			return fmt.Errorf("specialist %q references unknown model %q", manifest.Metadata.Name, manifest.Metadata.Model)
+		}
+		manifest.Metadata.Model = modelID
+	}
+	if manifest.Metadata.ReasoningEffort != "" {
+		effort := strings.ToLower(manifest.Metadata.ReasoningEffort)
+		if !modelregistry.ValidReasoningEffort(modelregistry.ReasoningEffort(effort)) {
+			return fmt.Errorf("specialist %q references unknown reasoning effort %q", manifest.Metadata.Name, manifest.Metadata.ReasoningEffort)
+		}
+		manifest.Metadata.ReasoningEffort = effort
+	}
 	resolved, err := ResolveTools(manifest.Metadata.Tools)
 	if err != nil {
 		return fmt.Errorf("specialist %q: %w", manifest.Metadata.Name, err)
@@ -215,7 +244,7 @@ func Validate(manifest *Manifest) error {
 
 func ResolveTools(selection []string) ([]string, error) {
 	if len(selection) == 0 {
-		return nil, nil
+		selection = defaultToolSelection
 	}
 	resolved := []string{}
 	seen := map[string]bool{}
@@ -263,6 +292,7 @@ func parseFrontmatter(frontmatter string) (map[string]any, error) {
 		return raw, nil
 	}
 	lines := strings.Split(frontmatter, "\n")
+	seen := map[string]int{}
 	for index := 0; index < len(lines); index++ {
 		line := strings.TrimSpace(lines[index])
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -277,6 +307,10 @@ func parseFrontmatter(frontmatter string) (map[string]any, error) {
 		if key == "" {
 			return nil, fmt.Errorf("invalid empty frontmatter key on line %d", index+1)
 		}
+		if previous, ok := seen[key]; ok {
+			return nil, fmt.Errorf("duplicate frontmatter key %q on line %d; first seen on line %d", key, index+1, previous)
+		}
+		seen[key] = index + 1
 		if value == "" && isListKey(key) {
 			values, next, err := parseBlockList(lines, index+1)
 			if err != nil {
@@ -356,7 +390,13 @@ func parseInlineList(value string) ([]string, error) {
 		return []string{}, nil
 	}
 	values := []string{}
-	for _, part := range strings.Split(inner, ",") {
+	reader := csv.NewReader(strings.NewReader(inner))
+	reader.TrimLeadingSpace = true
+	fields, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	for _, part := range fields {
 		item := strings.TrimSpace(part)
 		if item == "" {
 			continue
@@ -386,30 +426,37 @@ func stringValue(value any) string {
 	return ""
 }
 
-func loadDirectory(dir string, location Location) ([]Manifest, error) {
+func loadDirectory(dir string, location Location) ([]Manifest, []string, error) {
 	if strings.TrimSpace(dir) == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, fmt.Errorf("read specialist directory %s: %w", dir, err)
+		return nil, nil, fmt.Errorf("read specialist directory %s: %w", dir, err)
 	}
 	manifests := []Manifest{}
+	warnings := []string{}
 	for _, entry := range entries {
 		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".md" {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			warnings = append(warnings, fmt.Sprintf("skipped symlink specialist manifest: %s", filepath.Join(dir, entry.Name())))
 			continue
 		}
 		path := filepath.Join(dir, entry.Name())
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("read specialist manifest %s: %w", path, err)
+			warnings = append(warnings, fmt.Sprintf("skipped unreadable specialist manifest %s: %s", path, err))
+			continue
 		}
 		manifest, err := ParseMarkdown(string(data))
 		if err != nil {
-			return nil, fmt.Errorf("parse specialist manifest %s: %w", path, err)
+			warnings = append(warnings, fmt.Sprintf("skipped invalid specialist manifest %s: %s", path, err))
+			continue
 		}
 		manifest.Location = location
 		manifest.FilePath = path
@@ -418,7 +465,7 @@ func loadDirectory(dir string, location Location) ([]Manifest, error) {
 		}
 		manifests = append(manifests, manifest)
 	}
-	return manifests, nil
+	return manifests, warnings, nil
 }
 
 func mergeByName(manifests []Manifest) []Manifest {

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -1,0 +1,441 @@
+package specialist
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Location string
+
+const (
+	LocationBuiltin Location = "builtin"
+	LocationUser    Location = "user"
+	LocationProject Location = "project"
+)
+
+type Metadata struct {
+	Name            string   `json:"name"`
+	Description     string   `json:"description"`
+	Model           string   `json:"model,omitempty"`
+	ReasoningEffort string   `json:"reasoningEffort,omitempty"`
+	Tools           []string `json:"tools,omitempty"`
+}
+
+type Manifest struct {
+	Metadata      Metadata  `json:"metadata"`
+	SystemPrompt  string    `json:"systemPrompt"`
+	ResolvedTools []string  `json:"resolvedTools,omitempty"`
+	Location      Location  `json:"location"`
+	FilePath      string    `json:"filePath"`
+	LastModified  time.Time `json:"lastModified,omitempty"`
+	Warnings      []string  `json:"warnings,omitempty"`
+}
+
+type Summary struct {
+	Name            string   `json:"name"`
+	Description     string   `json:"description"`
+	Model           string   `json:"model,omitempty"`
+	ReasoningEffort string   `json:"reasoningEffort,omitempty"`
+	Tools           []string `json:"tools,omitempty"`
+	ResolvedTools   []string `json:"resolvedTools,omitempty"`
+	Location        Location `json:"location"`
+	FilePath        string   `json:"filePath"`
+	Warnings        []string `json:"warnings,omitempty"`
+}
+
+type Paths struct {
+	UserDir    string `json:"userDir"`
+	ProjectDir string `json:"projectDir,omitempty"`
+}
+
+type LoadOptions struct {
+	Paths Paths
+}
+
+type LoadResult struct {
+	Paths       Paths      `json:"paths"`
+	Specialists []Manifest `json:"specialists"`
+}
+
+var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+
+var knownMetadataKeys = map[string]bool{
+	"name":            true,
+	"description":     true,
+	"model":           true,
+	"reasoningEffort": true,
+	"tools":           true,
+}
+
+var toolCategories = map[string][]string{
+	"read-only": {"read_file", "list_directory", "grep", "glob"},
+	"edit":      {"read_file", "list_directory", "grep", "glob", "write_file", "edit_file", "apply_patch"},
+	"execute":   {"read_file", "list_directory", "grep", "glob", "bash"},
+	"plan":      {"update_plan"},
+}
+
+var knownToolNames = map[string]bool{
+	"read_file":      true,
+	"list_directory": true,
+	"glob":           true,
+	"grep":           true,
+	"write_file":     true,
+	"edit_file":      true,
+	"apply_patch":    true,
+	"update_plan":    true,
+	"bash":           true,
+}
+
+func DefaultPaths(workspaceRoot string) (Paths, error) {
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		return Paths{}, fmt.Errorf("resolve user config directory: %w", err)
+	}
+	paths := Paths{
+		UserDir: filepath.Join(userConfigDir, "zero", "specialists"),
+	}
+	if strings.TrimSpace(workspaceRoot) != "" {
+		paths.ProjectDir = filepath.Join(filepath.Clean(workspaceRoot), ".zero", "specialists")
+	}
+	return paths, nil
+}
+
+func Load(options LoadOptions) (LoadResult, error) {
+	paths := options.Paths
+	if strings.TrimSpace(paths.UserDir) == "" {
+		resolved, err := DefaultPaths("")
+		if err != nil {
+			return LoadResult{}, err
+		}
+		paths.UserDir = resolved.UserDir
+	}
+
+	manifests := Builtins()
+	userManifests, err := loadDirectory(paths.UserDir, LocationUser)
+	if err != nil {
+		return LoadResult{}, err
+	}
+	manifests = append(manifests, userManifests...)
+	if strings.TrimSpace(paths.ProjectDir) != "" {
+		projectManifests, err := loadDirectory(paths.ProjectDir, LocationProject)
+		if err != nil {
+			return LoadResult{}, err
+		}
+		manifests = append(manifests, projectManifests...)
+	}
+
+	return LoadResult{Paths: paths, Specialists: mergeByName(manifests)}, nil
+}
+
+func Find(result LoadResult, name string) (Manifest, bool) {
+	name = strings.TrimSpace(name)
+	for _, manifest := range result.Specialists {
+		if manifest.Metadata.Name == name {
+			return manifest, true
+		}
+	}
+	return Manifest{}, false
+}
+
+func Summaries(manifests []Manifest) []Summary {
+	summaries := make([]Summary, 0, len(manifests))
+	for _, manifest := range manifests {
+		summaries = append(summaries, Summary{
+			Name:            manifest.Metadata.Name,
+			Description:     manifest.Metadata.Description,
+			Model:           manifest.Metadata.Model,
+			ReasoningEffort: manifest.Metadata.ReasoningEffort,
+			Tools:           append([]string(nil), manifest.Metadata.Tools...),
+			ResolvedTools:   append([]string(nil), manifest.ResolvedTools...),
+			Location:        manifest.Location,
+			FilePath:        manifest.FilePath,
+			Warnings:        append([]string(nil), manifest.Warnings...),
+		})
+	}
+	return summaries
+}
+
+func ParseMarkdown(content string) (Manifest, error) {
+	frontmatter, body, err := splitFrontmatter(content)
+	if err != nil {
+		return Manifest{}, err
+	}
+	raw, err := parseFrontmatter(frontmatter)
+	if err != nil {
+		return Manifest{}, err
+	}
+	manifest, err := manifestFromRaw(raw)
+	if err != nil {
+		return Manifest{}, err
+	}
+	manifest.SystemPrompt = strings.TrimSpace(body)
+	for key := range raw {
+		if !knownMetadataKeys[key] {
+			manifest.Warnings = append(manifest.Warnings, "unknown frontmatter key: "+key)
+		}
+	}
+	if manifest.SystemPrompt == "" {
+		if manifest.Metadata.Description == "" {
+			return Manifest{}, fmt.Errorf("system prompt cannot be empty")
+		}
+		manifest.SystemPrompt = manifest.Metadata.Description
+		manifest.Warnings = append(manifest.Warnings, "using description as system prompt")
+	}
+	if err := Validate(&manifest); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func Validate(manifest *Manifest) error {
+	manifest.Metadata.Name = strings.TrimSpace(manifest.Metadata.Name)
+	manifest.Metadata.Description = strings.TrimSpace(manifest.Metadata.Description)
+	manifest.Metadata.Model = strings.TrimSpace(manifest.Metadata.Model)
+	manifest.Metadata.ReasoningEffort = strings.TrimSpace(manifest.Metadata.ReasoningEffort)
+	if manifest.Metadata.Name == "" {
+		return fmt.Errorf("specialist name is required")
+	}
+	if !namePattern.MatchString(manifest.Metadata.Name) {
+		return fmt.Errorf("invalid specialist name %q: use lowercase letters, numbers, and dashes", manifest.Metadata.Name)
+	}
+	if manifest.Metadata.Description == "" {
+		return fmt.Errorf("specialist %q requires a description", manifest.Metadata.Name)
+	}
+	resolved, err := ResolveTools(manifest.Metadata.Tools)
+	if err != nil {
+		return fmt.Errorf("specialist %q: %w", manifest.Metadata.Name, err)
+	}
+	manifest.ResolvedTools = resolved
+	return nil
+}
+
+func ResolveTools(selection []string) ([]string, error) {
+	if len(selection) == 0 {
+		return nil, nil
+	}
+	resolved := []string{}
+	seen := map[string]bool{}
+	for _, item := range selection {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		tools, ok := toolCategories[item]
+		if !ok {
+			if !knownToolNames[item] {
+				return nil, fmt.Errorf("unknown tool or category %q", item)
+			}
+			tools = []string{item}
+		}
+		for _, tool := range tools {
+			if seen[tool] {
+				continue
+			}
+			seen[tool] = true
+			resolved = append(resolved, tool)
+		}
+	}
+	sort.Strings(resolved)
+	return resolved, nil
+}
+
+func splitFrontmatter(content string) (string, string, error) {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", strings.TrimSpace(normalized), nil
+	}
+	for index := 1; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) == "---" {
+			return strings.Join(lines[1:index], "\n"), strings.Join(lines[index+1:], "\n"), nil
+		}
+	}
+	return "", "", fmt.Errorf("frontmatter is missing closing ---")
+}
+
+func parseFrontmatter(frontmatter string) (map[string]any, error) {
+	raw := map[string]any{}
+	if strings.TrimSpace(frontmatter) == "" {
+		return raw, nil
+	}
+	lines := strings.Split(frontmatter, "\n")
+	for index := 0; index < len(lines); index++ {
+		line := strings.TrimSpace(lines[index])
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid frontmatter line %d", index+1)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("invalid empty frontmatter key on line %d", index+1)
+		}
+		if value == "" && isListKey(key) {
+			values, next, err := parseBlockList(lines, index+1)
+			if err != nil {
+				return nil, err
+			}
+			raw[key] = values
+			index = next - 1
+			continue
+		}
+		if isListKey(key) {
+			values, err := parseInlineList(value)
+			if err != nil {
+				return nil, fmt.Errorf("%s must be an array", key)
+			}
+			raw[key] = values
+			continue
+		}
+		raw[key] = unquote(value)
+	}
+	return raw, nil
+}
+
+func manifestFromRaw(raw map[string]any) (Manifest, error) {
+	metadata := Metadata{}
+	for key, value := range raw {
+		switch key {
+		case "name":
+			metadata.Name = stringValue(value)
+		case "description":
+			metadata.Description = stringValue(value)
+		case "model":
+			metadata.Model = stringValue(value)
+		case "reasoningEffort":
+			metadata.ReasoningEffort = stringValue(value)
+		case "tools":
+			values, ok := value.([]string)
+			if !ok {
+				return Manifest{}, fmt.Errorf("tools must be an array")
+			}
+			metadata.Tools = values
+		}
+	}
+	return Manifest{Metadata: metadata}, nil
+}
+
+func isListKey(key string) bool {
+	return key == "tools"
+}
+
+func parseBlockList(lines []string, start int) ([]string, int, error) {
+	values := []string{}
+	index := start
+	for ; index < len(lines); index++ {
+		line := strings.TrimSpace(lines[index])
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "- ") {
+			break
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+		if value == "" {
+			return nil, index, fmt.Errorf("empty list item on frontmatter line %d", index+1)
+		}
+		values = append(values, unquote(value))
+	}
+	return values, index, nil
+}
+
+func parseInlineList(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("not an inline array")
+	}
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "["), "]"))
+	if inner == "" {
+		return []string{}, nil
+	}
+	values := []string{}
+	for _, part := range strings.Split(inner, ",") {
+		item := strings.TrimSpace(part)
+		if item == "" {
+			continue
+		}
+		values = append(values, unquote(item))
+	}
+	return values, nil
+}
+
+func unquote(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'')) {
+		if value[0] == '"' {
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				return strings.TrimSpace(unquoted)
+			}
+		}
+		return strings.TrimSpace(value[1 : len(value)-1])
+	}
+	return value
+}
+
+func stringValue(value any) string {
+	if text, ok := value.(string); ok {
+		return strings.TrimSpace(text)
+	}
+	return ""
+}
+
+func loadDirectory(dir string, location Location) ([]Manifest, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read specialist directory %s: %w", dir, err)
+	}
+	manifests := []Manifest{}
+	for _, entry := range entries {
+		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".md" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read specialist manifest %s: %w", path, err)
+		}
+		manifest, err := ParseMarkdown(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("parse specialist manifest %s: %w", path, err)
+		}
+		manifest.Location = location
+		manifest.FilePath = path
+		if info, err := entry.Info(); err == nil {
+			manifest.LastModified = info.ModTime()
+		}
+		manifests = append(manifests, manifest)
+	}
+	return manifests, nil
+}
+
+func mergeByName(manifests []Manifest) []Manifest {
+	byName := map[string]Manifest{}
+	for _, manifest := range manifests {
+		byName[manifest.Metadata.Name] = manifest
+	}
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	merged := make([]Manifest, 0, len(names))
+	for _, name := range names {
+		merged = append(merged, byName[name])
+	}
+	return merged
+}

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -3,8 +3,11 @@ package specialist
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 func TestParseMarkdownValidatesAndResolvesTools(t *testing.T) {
@@ -56,6 +59,128 @@ description: Greets the user
 	}
 	if len(manifest.Warnings) != 1 || !strings.Contains(manifest.Warnings[0], "description") {
 		t.Fatalf("expected description fallback warning, got %#v", manifest.Warnings)
+	}
+	for _, want := range []string{"glob", "grep", "list_directory", "read_file"} {
+		if !contains(manifest.ResolvedTools, want) {
+			t.Fatalf("default resolved tools missing %q: %#v", want, manifest.ResolvedTools)
+		}
+	}
+	if contains(manifest.ResolvedTools, "bash") || contains(manifest.ResolvedTools, "write_file") {
+		t.Fatalf("default tools should be read-only, got %#v", manifest.ResolvedTools)
+	}
+}
+
+func TestParseMarkdownValidatesModelAndReasoningEffort(t *testing.T) {
+	manifest, err := ParseMarkdown(`---
+name: reviewer
+description: Reviews code
+model: sonnet-4.5
+reasoningEffort: HIGH
+---
+Review.`)
+	if err != nil {
+		t.Fatalf("ParseMarkdown returned error: %v", err)
+	}
+	if manifest.Metadata.Model != "claude-sonnet-4.5" {
+		t.Fatalf("Model = %q, want canonical claude-sonnet-4.5", manifest.Metadata.Model)
+	}
+	if manifest.Metadata.ReasoningEffort != "high" {
+		t.Fatalf("ReasoningEffort = %q, want high", manifest.Metadata.ReasoningEffort)
+	}
+
+	_, err = ParseMarkdown(`---
+name: reviewer
+description: Reviews code
+model: fake-9000
+---
+Review.`)
+	if err == nil || !strings.Contains(err.Error(), "unknown model") {
+		t.Fatalf("expected unknown model error, got %v", err)
+	}
+
+	_, err = ParseMarkdown(`---
+name: reviewer
+description: Reviews code
+reasoningEffort: ULTRA
+---
+Review.`)
+	if err == nil || !strings.Contains(err.Error(), "unknown reasoning effort") {
+		t.Fatalf("expected unknown reasoning effort error, got %v", err)
+	}
+}
+
+func TestParseMarkdownRejectsInvalidNamesUnknownToolsAndDuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "invalid name",
+			content: `---
+name: ../escape
+description: Bad name
+---
+Prompt.`,
+			want: "invalid specialist name",
+		},
+		{
+			name: "unknown tool",
+			content: `---
+name: explorer
+description: Explores code
+tools: [web_search]
+---
+Prompt.`,
+			want: "unknown tool or category",
+		},
+		{
+			name: "duplicate key",
+			content: `---
+name: explorer
+name: explorer-two
+description: Explores code
+---
+Prompt.`,
+			want: "duplicate frontmatter key",
+		},
+		{
+			name: "malformed frontmatter",
+			content: `---
+name explorer
+description: Explores code
+---
+Prompt.`,
+			want: "invalid frontmatter line",
+		},
+		{
+			name: "empty prompt",
+			content: `---
+name: empty
+description:
+---`,
+			want: "system prompt cannot be empty",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseMarkdown(tc.content)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestParseMarkdownInlineListHonorsQuotedCommas(t *testing.T) {
+	_, err := ParseMarkdown(`---
+name: quoted
+description: Quoted list
+tools: ["read-only", "grep,glob"]
+---
+Prompt.`)
+	if err == nil || !strings.Contains(err.Error(), `unknown tool or category "grep,glob"`) {
+		t.Fatalf("expected quoted comma to stay in one token, got %v", err)
 	}
 }
 
@@ -112,6 +237,65 @@ User conflict prompt.`)
 	}
 	if conflict.Location != LocationUser || conflict.SystemPrompt != "User conflict prompt." || contains(conflict.ResolvedTools, "bash") {
 		t.Fatalf("user manifest should win same-name conflict, got %#v", conflict)
+	}
+}
+
+func TestLoadSkipsBadFilesAndSymlinksWithWarnings(t *testing.T) {
+	root := t.TempDir()
+	userDir := filepath.Join(root, "user")
+	writeManifest(t, filepath.Join(userDir, "valid.md"), `---
+name: valid
+description: Valid specialist
+---
+Prompt.`)
+	writeManifest(t, filepath.Join(userDir, "bad.md"), `---
+name: bad
+tools: [missing]
+---
+Prompt.`)
+	target := filepath.Join(userDir, "valid.md")
+	link := filepath.Join(userDir, "linked.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable on this platform: %v", err)
+	}
+
+	result, err := Load(LoadOptions{Paths: Paths{UserDir: userDir}})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if _, ok := Find(result, "valid"); !ok {
+		t.Fatalf("valid manifest should still load: %#v", result)
+	}
+	if _, ok := Find(result, "bad"); ok {
+		t.Fatalf("bad manifest should be skipped: %#v", result)
+	}
+	warnings := strings.Join(result.Warnings, "\n")
+	if !strings.Contains(warnings, "skipped invalid specialist manifest") || !strings.Contains(warnings, "skipped symlink specialist manifest") {
+		t.Fatalf("expected invalid-file and symlink warnings, got %#v", result.Warnings)
+	}
+}
+
+func TestKnownToolNamesMatchCoreRegistry(t *testing.T) {
+	core := tools.CoreTools(t.TempDir())
+	got := make([]string, 0, len(knownToolNames))
+	for name := range knownToolNames {
+		got = append(got, name)
+	}
+	want := make([]string, 0, len(core))
+	for _, tool := range core {
+		want = append(want, tool.Name())
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("knownToolNames drifted from core registry\ngot:  %#v\nwant: %#v", got, want)
+	}
+	for category, names := range toolCategories {
+		for _, name := range names {
+			if !knownToolNames[name] {
+				t.Fatalf("category %q references unknown tool %q", category, name)
+			}
+		}
 	}
 }
 

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -75,6 +75,18 @@ description: Project worker override
 tools: [execute]
 ---
 Project prompt.`)
+	writeManifest(t, filepath.Join(projectDir, "conflict.md"), `---
+name: conflict
+description: Project conflict
+tools: [execute]
+---
+Project conflict prompt.`)
+	writeManifest(t, filepath.Join(userDir, "conflict.md"), `---
+name: conflict
+description: User conflict
+tools: [read-only]
+---
+User conflict prompt.`)
 
 	result, err := Load(LoadOptions{Paths: Paths{UserDir: userDir, ProjectDir: projectDir}})
 	if err != nil {
@@ -93,6 +105,13 @@ Project prompt.`)
 	}
 	if worker.Location != LocationProject || !contains(worker.ResolvedTools, "bash") {
 		t.Fatalf("unexpected worker override: %#v", worker)
+	}
+	conflict, ok := Find(result, "conflict")
+	if !ok {
+		t.Fatal("conflict not found")
+	}
+	if conflict.Location != LocationUser || conflict.SystemPrompt != "User conflict prompt." || contains(conflict.ResolvedTools, "bash") {
+		t.Fatalf("user manifest should win same-name conflict, got %#v", conflict)
 	}
 }
 

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -1,0 +1,128 @@
+package specialist
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseMarkdownValidatesAndResolvesTools(t *testing.T) {
+	manifest, err := ParseMarkdown(`---
+name: code-review
+description: Reviews a change
+tools: [read-only, apply_patch]
+unknown: kept
+---
+Review the diff.`)
+	if err != nil {
+		t.Fatalf("ParseMarkdown returned error: %v", err)
+	}
+	if manifest.Metadata.Name != "code-review" || manifest.SystemPrompt != "Review the diff." {
+		t.Fatalf("unexpected manifest: %#v", manifest)
+	}
+	for _, want := range []string{"apply_patch", "glob", "grep", "list_directory", "read_file"} {
+		if !contains(manifest.ResolvedTools, want) {
+			t.Fatalf("resolved tools missing %q: %#v", want, manifest.ResolvedTools)
+		}
+	}
+	if len(manifest.Warnings) != 1 || !strings.Contains(manifest.Warnings[0], "unknown") {
+		t.Fatalf("expected unknown key warning, got %#v", manifest.Warnings)
+	}
+}
+
+func TestParseMarkdownRejectsScalarTools(t *testing.T) {
+	_, err := ParseMarkdown(`---
+name: explorer
+description: Explores code
+tools: read-only
+---
+Explore.`)
+	if err == nil || !strings.Contains(err.Error(), "tools must be an array") {
+		t.Fatalf("expected tools array error, got %v", err)
+	}
+}
+
+func TestParseMarkdownUsesDescriptionFallback(t *testing.T) {
+	manifest, err := ParseMarkdown(`---
+name: greeter
+description: Greets the user
+---`)
+	if err != nil {
+		t.Fatalf("ParseMarkdown returned error: %v", err)
+	}
+	if manifest.SystemPrompt != "Greets the user" {
+		t.Fatalf("SystemPrompt = %q, want description fallback", manifest.SystemPrompt)
+	}
+	if len(manifest.Warnings) != 1 || !strings.Contains(manifest.Warnings[0], "description") {
+		t.Fatalf("expected description fallback warning, got %#v", manifest.Warnings)
+	}
+}
+
+func TestLoadMergesBuiltinsUserAndProjectByPrecedence(t *testing.T) {
+	root := t.TempDir()
+	userDir := filepath.Join(root, "user")
+	projectDir := filepath.Join(root, "project")
+	writeManifest(t, filepath.Join(userDir, "explorer.md"), `---
+name: explorer
+description: User explorer override
+tools: [read-only]
+---
+User prompt.`)
+	writeManifest(t, filepath.Join(projectDir, "worker.md"), `---
+name: worker
+description: Project worker override
+tools: [execute]
+---
+Project prompt.`)
+
+	result, err := Load(LoadOptions{Paths: Paths{UserDir: userDir, ProjectDir: projectDir}})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	explorer, ok := Find(result, "explorer")
+	if !ok {
+		t.Fatal("explorer not found")
+	}
+	if explorer.Location != LocationUser || explorer.SystemPrompt != "User prompt." {
+		t.Fatalf("unexpected explorer override: %#v", explorer)
+	}
+	worker, ok := Find(result, "worker")
+	if !ok {
+		t.Fatal("worker not found")
+	}
+	if worker.Location != LocationProject || !contains(worker.ResolvedTools, "bash") {
+		t.Fatalf("unexpected worker override: %#v", worker)
+	}
+}
+
+func TestFormatListUsesSpecialistTerminology(t *testing.T) {
+	result := LoadResult{Specialists: []Manifest{{
+		Metadata: Metadata{Name: "worker", Description: "Does work"},
+		Location: LocationBuiltin,
+		FilePath: "(builtin)",
+	}}}
+	output := FormatList(result)
+	if !strings.Contains(output, "Zero Specialists") || !strings.Contains(output, "worker [builtin]") {
+		t.Fatalf("unexpected list output: %s", output)
+	}
+}
+
+func writeManifest(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create manifest dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add specialist manifest parsing and validation
- Add built-in `worker`, `explorer`, and `code-review` profiles
- Add `zero specialist list/show/path` with JSON output

## Self-Review

- This intentionally does not add the runtime `task` tool or child-process execution yet.
- Specialist paths follow existing Zero conventions: user profiles under `~/.config/zero/specialists`, project profiles under `.zero/specialists`.
- Tool names match the current Go registry IDs, such as `read_file`, `grep`, and `apply_patch`.

## Validation

- `GOCACHE=/tmp/zero-go-cache go test ./internal/specialist ./internal/cli`
- `GOCACHE=/tmp/zero-go-cache go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `specialist` (and alias `specialists`) CLI with `list`, `show <name>`, and `path` subcommands to inspect local specialist profiles
  * Introduced three built-in specialists: worker, explorer, and code-review
  * Added `--json` output option for machine-readable results

* **Tests**
  * Added end-to-end and parsing tests covering specialist commands, JSON output, and manifest handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->