### PR TITLE
feat(specialist): add exec metadata flags

### DIFF
--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -82,7 +82,14 @@ type PermissionEvent struct {
 }
 
 type Options struct {
-	MaxTurns            int
+	MaxTurns int
+	// Specialist/sub-agent metadata is carried through exec now and consumed by
+	// the specialist runtime in later slices.
+	CallingSessionID    string
+	CallingToolUseID    string
+	Tag                 string
+	Depth               int
+	SessionTitle        string
 	Registry            *tools.Registry
 	PermissionMode      PermissionMode
 	Autonomy            string

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -412,9 +412,16 @@ Flags:
                                     Select prompt input format
   -o, --output-format text|json|stream-json
                                     Select text, JSON, or schema-versioned JSONL output
+                                    ("debug" is accepted as a stream-json alias)
       --prompt <prompt>              Provide prompt text as a flag
       --resume [id]                  Resume a session; omit id to use the latest
       --fork <id>                    Fork an existing session into a new session
+      --calling-session-id <id>      Parent session id for specialist child runs
+      --calling-tool-use-id <id>     Parent tool-call id for specialist child runs
+      --tag <tag>                    Attach runtime tag metadata to the exec run
+      --depth <number>               Set specialist nesting depth metadata
+      --session-title <text>         Set the created session title
+      --init-session-id <id>         Create a new exec session with this id
       --skip-permissions-unsafe      Allow prompt-gated tools without approval
 `)
 	return err

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -53,6 +53,12 @@ type execOptions struct {
 	resume                string
 	resumeLatest          bool
 	fork                  string
+	callingSessionID      string
+	callingToolUseID      string
+	tag                   string
+	depth                 int
+	sessionTitle          string
+	initSessionID         string
 	worktree              bool
 	worktreeName          string
 	worktreeDir           string
@@ -159,7 +165,8 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	agentPrompt := prompt
 	if shouldUseExecSession(options) {
 		preparedSession, err = sessions.PrepareExec(sessions.PrepareExecOptions{
-			Title:        createSessionTitle(prompt),
+			SessionID:    options.initSessionID,
+			Title:        execSessionTitle(options, prompt),
 			Cwd:          workspaceRoot,
 			ModelID:      resolved.Provider.Model,
 			Provider:     runMetadata.Provider,
@@ -202,14 +209,19 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	})
 
 	result, err := agent.Run(context.Background(), agentPrompt, provider, agent.Options{
-		MaxTurns:       resolved.MaxTurns,
-		Registry:       registry,
-		PermissionMode: permissionMode,
-		Autonomy:       options.autonomy,
-		Sandbox:        sandboxEngine,
-		EnabledTools:   options.enabledTools,
-		DisabledTools:  options.disabledTools,
-		OnText:         writer.text,
+		MaxTurns:         resolved.MaxTurns,
+		CallingSessionID: options.callingSessionID,
+		CallingToolUseID: options.callingToolUseID,
+		Tag:              options.tag,
+		Depth:            options.depth,
+		SessionTitle:     options.sessionTitle,
+		Registry:         registry,
+		PermissionMode:   permissionMode,
+		Autonomy:         options.autonomy,
+		Sandbox:          sandboxEngine,
+		EnabledTools:     options.enabledTools,
+		DisabledTools:    options.disabledTools,
+		OnText:           writer.text,
 		OnToolCall: func(call agent.ToolCall) {
 			writer.toolCall(call, registry)
 			sessionRecorder.append(sessions.EventToolCall, map[string]any{

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -136,6 +136,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
+	sessionTitle := execSessionTitle(options, prompt)
 
 	overrides := config.Overrides{}
 	if options.model != "" {
@@ -166,7 +167,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if shouldUseExecSession(options) {
 		preparedSession, err = sessions.PrepareExec(sessions.PrepareExecOptions{
 			SessionID:    options.initSessionID,
-			Title:        execSessionTitle(options, prompt),
+			Title:        sessionTitle,
 			Cwd:          workspaceRoot,
 			ModelID:      resolved.Provider.Model,
 			Provider:     runMetadata.Provider,
@@ -214,7 +215,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		CallingToolUseID: options.callingToolUseID,
 		Tag:              options.tag,
 		Depth:            options.depth,
-		SessionTitle:     options.sessionTitle,
+		SessionTitle:     sessionTitle,
 		Registry:         registry,
 		PermissionMode:   permissionMode,
 		Autonomy:         options.autonomy,

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/sessions"
 )
 
 func parseExecArgs(args []string) (execOptions, bool, error) {
@@ -176,6 +178,88 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--fork="):
 			options.fork = strings.TrimSpace(strings.TrimPrefix(arg, "--fork="))
+		case arg == "--calling-session-id":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.callingSessionID = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--calling-session-id="):
+			value, err := requiredInlineFlagValue(arg, "--calling-session-id")
+			if err != nil {
+				return options, false, err
+			}
+			options.callingSessionID = value
+		case arg == "--calling-tool-use-id":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.callingToolUseID = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--calling-tool-use-id="):
+			value, err := requiredInlineFlagValue(arg, "--calling-tool-use-id")
+			if err != nil {
+				return options, false, err
+			}
+			options.callingToolUseID = value
+		case arg == "--tag":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.tag = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--tag="):
+			value, err := requiredInlineFlagValue(arg, "--tag")
+			if err != nil {
+				return options, false, err
+			}
+			options.tag = value
+		case arg == "--depth":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			depth, err := parseExecDepth(value)
+			if err != nil {
+				return options, false, err
+			}
+			options.depth = depth
+			index = next
+		case strings.HasPrefix(arg, "--depth="):
+			depth, err := parseExecDepth(strings.TrimSpace(strings.TrimPrefix(arg, "--depth=")))
+			if err != nil {
+				return options, false, err
+			}
+			options.depth = depth
+		case arg == "--session-title":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.sessionTitle = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--session-title="):
+			value, err := requiredInlineFlagValue(arg, "--session-title")
+			if err != nil {
+				return options, false, err
+			}
+			options.sessionTitle = value
+		case arg == "--init-session-id":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.initSessionID = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--init-session-id="):
+			value, err := requiredInlineFlagValue(arg, "--init-session-id")
+			if err != nil {
+				return options, false, err
+			}
+			options.initSessionID = value
 		case arg == "-w" || arg == "--worktree":
 			options.worktree = true
 			if index+1 < len(args) && !flagValueLooksLikeOption(strings.TrimSpace(args[index+1])) && strings.TrimSpace(args[index+1]) != "" {
@@ -207,11 +291,17 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
 		return options, false, execUsageError{"Use either --resume or --fork, not both."}
 	}
+	if options.initSessionID != "" && (options.resume != "" || options.resumeLatest) {
+		return options, false, execUsageError{"Use --init-session-id only when creating or forking a session."}
+	}
 	if options.worktree && options.fork != "" {
 		return options, false, execUsageError{"--fork cannot be used with --worktree. Forked sessions must continue in the source session workspace."}
 	}
 	if options.worktreeDir != "" && !options.worktree {
 		return options, false, execUsageError{"--worktree-dir requires --worktree."}
+	}
+	if options.initSessionID != "" && !sessions.ValidSessionID(options.initSessionID) {
+		return options, false, execUsageError{fmt.Sprintf("invalid --init-session-id %q", options.initSessionID)}
 	}
 	if options.inputFormat == execInputStreamJSON && strings.TrimSpace(strings.Join(options.promptParts, " ")) != "" {
 		return options, false, execUsageError{"Stream-json input does not accept positional prompt text. Pipe JSONL or use --file."}
@@ -220,6 +310,18 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 		return options, false, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
 	}
 	return options, false, nil
+}
+
+func parseExecDepth(value string) (int, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, execUsageError{"--depth requires a value"}
+	}
+	depth, err := strconv.Atoi(trimmed)
+	if err != nil || depth < 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid --depth %q. Expected a non-negative integer.", value)}
+	}
+	return depth, nil
 }
 
 func parseExecMaxTurns(value string) (int, error) {
@@ -245,6 +347,14 @@ func nextFlagValue(args []string, index int, flag string) (string, int, error) {
 	return next, index + 1, nil
 }
 
+func requiredInlineFlagValue(arg string, flag string) (string, error) {
+	value := strings.TrimSpace(strings.TrimPrefix(arg, flag+"="))
+	if value == "" {
+		return "", execUsageError{fmt.Sprintf("%s requires a value", flag)}
+	}
+	return value, nil
+}
+
 func flagValueLooksLikeOption(value string) bool {
 	if !strings.HasPrefix(value, "-") {
 		return false
@@ -261,7 +371,7 @@ func parseExecOutputFormat(value string) (execOutputFormat, error) {
 		return execOutputText, nil
 	case string(execOutputJSON):
 		return execOutputJSON, nil
-	case string(execOutputStreamJSON):
+	case string(execOutputStreamJSON), "debug":
 		return execOutputStreamJSON, nil
 	default:
 		return "", execUsageError{fmt.Sprintf("invalid output format %q. Expected text, json, or stream-json.", value)}

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -374,7 +374,7 @@ func parseExecOutputFormat(value string) (execOutputFormat, error) {
 	case string(execOutputStreamJSON), "debug":
 		return execOutputStreamJSON, nil
 	default:
-		return "", execUsageError{fmt.Sprintf("invalid output format %q. Expected text, json, or stream-json.", value)}
+		return "", execUsageError{fmt.Sprintf("invalid output format %q. Expected text, json, stream-json, or debug.", value)}
 	}
 }
 

--- a/internal/cli/exec_sessions.go
+++ b/internal/cli/exec_sessions.go
@@ -15,7 +15,8 @@ func shouldUseExecSession(options execOptions) bool {
 	return options.outputFormat == execOutputStreamJSON ||
 		options.resume != "" ||
 		options.resumeLatest ||
-		options.fork != ""
+		options.fork != "" ||
+		options.initSessionID != ""
 }
 
 func preflightExecSession(options execOptions) error {
@@ -65,6 +66,13 @@ func createSessionTitle(prompt string) string {
 		return "Zero exec session"
 	}
 	return title
+}
+
+func execSessionTitle(options execOptions, prompt string) string {
+	if title := strings.TrimSpace(options.sessionTitle); title != "" {
+		return title
+	}
+	return createSessionTitle(prompt)
 }
 
 func (recorder *execSessionRecorder) append(eventType sessions.EventType, payload any) {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -444,7 +444,7 @@ func TestRunExecRejectsInvalidOutputFormatBeforeRuntime(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Fatalf("expected empty stdout before runtime, got %q", stdout.String())
 	}
-	if got := stderr.String(); !strings.Contains(got, `invalid output format "yaml"`) {
+	if got := stderr.String(); !strings.Contains(got, `invalid output format "yaml"`) || !strings.Contains(got, "debug") {
 		t.Fatalf("expected output format validation error, got %q", got)
 	}
 	if strings.Contains(stdout.String()+stderr.String(), "Go agent runtime ready") {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -41,6 +42,12 @@ func TestRunExecHelpDocumentsM1Flags(t *testing.T) {
 				"-C, --cwd",
 				"-o, --output-format text|json",
 				"--prompt",
+				"--calling-session-id",
+				"--calling-tool-use-id",
+				"--tag <tag>",
+				"--depth <number>",
+				"--session-title",
+				"--init-session-id",
 				"--skip-permissions-unsafe",
 			} {
 				if !strings.Contains(stdout.String(), want) {
@@ -120,6 +127,104 @@ func TestRunExecMaxTurnsReachesConfigOverrides(t *testing.T) {
 	}
 	if gotMaxTurns != 7 {
 		t.Fatalf("overrides.MaxTurns = %d, want 7", gotMaxTurns)
+	}
+}
+
+func TestParseExecSpecialistMetadataFlags(t *testing.T) {
+	options, help, err := parseExecArgs([]string{
+		"--calling-session-id", "parent_session",
+		"--calling-tool-use-id=toolu_123",
+		"--tag", "specialist",
+		"--depth=2",
+		"--session-title", "Explorer child",
+		"--init-session-id", "child_session",
+		"--output-format", "debug",
+		"inspect the parser",
+	})
+	if err != nil {
+		t.Fatalf("parseExecArgs returned error: %v", err)
+	}
+	if help {
+		t.Fatal("help = true, want false")
+	}
+	if options.callingSessionID != "parent_session" ||
+		options.callingToolUseID != "toolu_123" ||
+		options.tag != "specialist" ||
+		options.depth != 2 ||
+		options.sessionTitle != "Explorer child" ||
+		options.initSessionID != "child_session" {
+		t.Fatalf("metadata flags did not parse correctly: %#v", options)
+	}
+	if options.outputFormat != execOutputStreamJSON {
+		t.Fatalf("outputFormat = %q, want stream-json debug alias", options.outputFormat)
+	}
+	if strings.Join(options.promptParts, " ") != "inspect the parser" {
+		t.Fatalf("promptParts = %#v", options.promptParts)
+	}
+}
+
+func TestParseExecSpecialistMetadataRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "negative depth", args: []string{"--depth=-1", "hello"}, want: "invalid --depth"},
+		{name: "non numeric depth", args: []string{"--depth", "many", "hello"}, want: "invalid --depth"},
+		{name: "empty tag", args: []string{"--tag=", "hello"}, want: "--tag requires a value"},
+		{name: "bad init session", args: []string{"--init-session-id", "../escape", "hello"}, want: "invalid --init-session-id"},
+		{name: "init with resume", args: []string{"--init-session-id", "child", "--resume", "parent", "hello"}, want: "Use --init-session-id only"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseExecArgs(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRunExecUsesInitSessionIDAndSessionTitle(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--init-session-id", "specialist_child",
+		"--session-title", "Explorer child",
+		"hello",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: filepath.Join(dataHome, "zero", "sessions")})
+	session, err := store.Get("specialist_child")
+	if err != nil {
+		t.Fatalf("Get session returned error: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected initialized session specialist_child")
+	}
+	if session.Title != "Explorer child" {
+		t.Fatalf("session title = %q, want Explorer child", session.Title)
+	}
+	if session.Cwd != cwd {
+		t.Fatalf("session cwd = %q, want %q", session.Cwd, cwd)
 	}
 }
 


### PR DESCRIPTION
Summary:
- adds specialist-oriented zero exec metadata flags: calling session/tool ids, tag, depth, session title, and init session id
- propagates the metadata into agent.Options for later specialist runtime slices
- lets --init-session-id preallocate a new exec session id and accepts debug as a stream-json output alias

Scope:
- does not add the Task tool or runtime specialist spawning yet
- does not depend on PR #101

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/cli ./internal/agent
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--calling-session-id`, `--calling-tool-use-id`, `--tag`, `--depth`, `--session-title`, and `--init-session-id` to `zero exec`; session titles can be set via `--session-title`.
  * `--output-format debug` added as an alias for JSON streaming.

* **Documentation**
  * Updated `zero exec` help text to document the new flags and aliases.

* **Bug Fixes / Validation**
  * New validation for `--depth` (non-negative) and `--init-session-id` usage (only when creating/forking).

* **Tests**
  * Added tests covering new flags, validations, and session initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->