### PR TITLE
Streaming reliability: SSE idle-watchdog, dropped-call handling, finish_reason, usage

### DIFF
--- a/internal/providers/anthropic/dropped_test.go
+++ b/internal/providers/anthropic/dropped_test.go
@@ -1,0 +1,66 @@
+package anthropic
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// A tool_use content_block_start that arrives without a usable name/id can't be
+// dispatched. The provider must signal a dropped tool call (once) so the agent
+// can ask the model to retry, mirroring the OpenAI provider's behavior, instead
+// of silently dropping it.
+func TestStreamCompletionEmitsDroppedOnNamelessToolUseBlock(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"","name":""}}`)
+		writeSSEEvent(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "claude-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	events := collectProviderEvents(t, provider)
+
+	var dropped, started int
+	for _, e := range events {
+		switch e.Type {
+		case zeroruntime.StreamEventToolCallDropped:
+			dropped++
+		case zeroruntime.StreamEventToolCallStart:
+			started++
+		}
+	}
+	if started != 0 {
+		t.Errorf("a nameless tool_use block must not start a tool call, got %d starts", started)
+	}
+	if dropped != 1 {
+		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
+	}
+}
+
+// A well-formed tool_use block must NOT emit a dropped signal.
+func TestStreamCompletionDoesNotDropValidToolUseBlock(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file"}}`)
+		writeSSEEvent(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "claude-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	events := collectProviderEvents(t, provider)
+
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventToolCallDropped {
+			t.Errorf("valid tool_use block must not be dropped; events: %+v", events)
+		}
+	}
+}

--- a/internal/providers/anthropic/finish_reason_test.go
+++ b/internal/providers/anthropic/finish_reason_test.go
@@ -1,0 +1,52 @@
+package anthropic
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// A message_delta with stop_reason=="max_tokens" means the response was
+// truncated at the output cap. The provider must surface it on the done event so
+// the agent does not treat a clipped answer as complete.
+func TestStreamCompletionSurfacesMaxTokensStopReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":5,"output_tokens":0}}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"cut"}}`)
+		writeSSEEvent(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":7}}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var doneReason string
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			doneReason = e.FinishReason
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+	if doneReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("done FinishReason = %q, want %q", doneReason, zeroruntime.FinishReasonLength)
+	}
+}
+
+// A normal end_turn stop_reason must leave the done event's FinishReason empty.
+func TestStreamCompletionNormalStopReasonHasNoFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`)
+		writeSSEEvent(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != "" {
+			t.Fatalf("normal stop leaked FinishReason %q", e.FinishReason)
+		}
+	}
+}

--- a/internal/providers/anthropic/finish_reason_test.go
+++ b/internal/providers/anthropic/finish_reason_test.go
@@ -44,9 +44,16 @@ func TestStreamCompletionNormalStopReasonHasNoFinishReason(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
+	var sawDone bool
 	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != "" {
-			t.Fatalf("normal stop leaked FinishReason %q", e.FinishReason)
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != "" {
+				t.Fatalf("normal stop leaked FinishReason %q", e.FinishReason)
+			}
 		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
 	}
 }

--- a/internal/providers/anthropic/idle_test.go
+++ b/internal/providers/anthropic/idle_test.go
@@ -1,0 +1,67 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// A stalled-but-open Anthropic upstream (sends one event, then hangs without
+// message_stop or closing) must abort on the idle timeout instead of blocking
+// the agent forever.
+func TestStreamCompletionIdleTimeoutAbortsStalledStream(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`)
+		select {
+		case <-r.Context().Done():
+		case <-released:
+		}
+	}))
+	defer server.Close()
+	defer close(released)
+
+	provider, err := New(Options{
+		BaseURL:           server.URL + "/",
+		Model:             "claude-test",
+		StreamIdleTimeout: 80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+
+	done := make(chan []zeroruntime.StreamEvent, 1)
+	go func() { done <- readAll(stream) }()
+	var events []zeroruntime.StreamEvent
+	select {
+	case events = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream did not terminate on idle — it hung")
+	}
+
+	var gotText, gotIdleError bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventText && e.Content == "hi" {
+			gotText = true
+		}
+		if e.Type == zeroruntime.StreamEventError && strings.Contains(strings.ToLower(e.Error), "idle") {
+			gotIdleError = true
+		}
+	}
+	if !gotText {
+		t.Error("expected the first token before the stall")
+	}
+	if !gotIdleError {
+		t.Errorf("expected a surfaced idle-timeout error, got events: %+v", events)
+	}
+}

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/providers/providerio"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -17,6 +18,11 @@ import (
 const defaultBaseURL = "https://api.anthropic.com"
 const defaultVersion = "2023-06-01"
 const defaultMaxTokens = 4096
+
+// defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
+// without closing the connection, so a stalled-but-open upstream cannot hang the
+// agent forever.
+const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures an Anthropic Messages API provider.
 type Options struct {
@@ -28,18 +34,22 @@ type Options struct {
 	Beta       string
 	HTTPClient *http.Client
 	UserAgent  string
+	// StreamIdleTimeout aborts the stream if no data arrives for this long.
+	// Zero uses defaultStreamIdleTimeout.
+	StreamIdleTimeout time.Duration
 }
 
 // Provider streams completions from Anthropic's Messages API.
 type Provider struct {
-	apiKey     string
-	baseURL    string
-	model      string
-	maxTokens  int
-	version    string
-	beta       string
-	httpClient *http.Client
-	userAgent  string
+	apiKey            string
+	baseURL           string
+	model             string
+	maxTokens         int
+	version           string
+	beta              string
+	httpClient        *http.Client
+	userAgent         string
+	streamIdleTimeout time.Duration
 }
 
 // New creates an Anthropic provider.
@@ -60,15 +70,20 @@ func New(options Options) (*Provider, error) {
 	if version == "" {
 		version = defaultVersion
 	}
+	idleTimeout := options.StreamIdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = defaultStreamIdleTimeout
+	}
 	return &Provider{
-		apiKey:     options.APIKey,
-		baseURL:    baseURL,
-		model:      model,
-		maxTokens:  maxTokens,
-		version:    version,
-		beta:       strings.TrimSpace(options.Beta),
-		httpClient: providerio.HTTPClient(options.HTTPClient),
-		userAgent:  options.UserAgent,
+		apiKey:            options.APIKey,
+		baseURL:           baseURL,
+		model:             model,
+		maxTokens:         maxTokens,
+		version:           version,
+		beta:              strings.TrimSpace(options.Beta),
+		httpClient:        providerio.HTTPClient(options.HTTPClient),
+		userAgent:         options.UserAgent,
+		streamIdleTimeout: idleTimeout,
 	}, nil
 }
 
@@ -95,7 +110,12 @@ func (provider *Provider) StreamCompletion(
 }
 
 func (provider *Provider) stream(ctx context.Context, body []byte, events chan<- zeroruntime.StreamEvent) {
-	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.baseURL+"/v1/messages", bytes.NewReader(body))
+	// streamCtx lets the idle watchdog abort an in-flight body read by cancelling
+	// the request, which unblocks the SSE reader goroutine.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	httpRequest, err := http.NewRequestWithContext(streamCtx, http.MethodPost, provider.baseURL+"/v1/messages", bytes.NewReader(body))
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
 		return
@@ -127,9 +147,17 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	}
 
 	state := newStreamState()
-	err = providerio.ScanSSEData(response.Body, func(data string) bool {
+	err = providerio.ScanSSEDataWithContext(streamCtx, cancelStream, response.Body, provider.streamIdleTimeout, func(data string) bool {
 		return provider.emitPayload(ctx, data, state, events)
 	})
+	if errors.Is(err, providerio.ErrStreamIdle) {
+		state.closeOpen(ctx, events)
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact(fmt.Sprintf("provider stream error: idle timeout after %s (upstream stopped sending data)", provider.streamIdleTimeout)),
+		})
+		return
+	}
 	if err != nil {
 		state.closeOpen(ctx, events)
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
@@ -163,7 +191,14 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 			state.recordUsage(payload.Message.Usage)
 		}
 	case "content_block_start":
-		if payload.ContentBlock != nil && payload.ContentBlock.Type == "tool_use" && payload.ContentBlock.ID != "" && payload.ContentBlock.Name != "" {
+		if payload.ContentBlock != nil && payload.ContentBlock.Type == "tool_use" {
+			if payload.ContentBlock.ID == "" || payload.ContentBlock.Name == "" {
+				// A tool_use block without a usable id/name can't be dispatched.
+				// Signal a drop once so the agent can ask the model to retry
+				// instead of silently ending the turn (mirrors OpenAI).
+				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDropped})
+				return true
+			}
 			state.startTool(ctx, payload.Index, payload.ContentBlock.ID, payload.ContentBlock.Name, events)
 			if len(payload.ContentBlock.Input) > 0 {
 				encoded, err := json.Marshal(payload.ContentBlock.Input)
@@ -191,6 +226,11 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 	case "message_delta":
 		if payload.Usage != nil {
 			state.recordUsage(*payload.Usage)
+		}
+		if payload.Delta != nil {
+			if reason := mapStopReason(payload.Delta.StopReason); reason != "" {
+				state.finishReason = reason
+			}
 		}
 	case "message_stop":
 		provider.emitDone(ctx, state, events)
@@ -221,7 +261,7 @@ func (provider *Provider) emitDone(ctx context.Context, state *streamState, even
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: usage})
 		}
 	}
-	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone, FinishReason: state.finishReason})
 	state.done = true
 }
 
@@ -399,7 +439,18 @@ type streamState struct {
 	outputTokens   int
 	hasInputUsage  bool
 	hasOutputUsage bool
+	finishReason   string // normalized terminal stop reason (empty for normal stop)
 	done           bool
+}
+
+// mapStopReason maps Anthropic's message_delta stop_reason onto the runtime's
+// normalized terminal reasons. A normal stop ("end_turn"/"tool_use"/"stop_sequence"/"")
+// returns "".
+func mapStopReason(reason string) string {
+	if reason == "max_tokens" {
+		return zeroruntime.FinishReasonLength
+	}
+	return ""
 }
 
 func newStreamState() *streamState {

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -33,6 +33,7 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 			APIKey:     profile.APIKey,
 			BaseURL:    resolved.baseURL,
 			Model:      resolved.apiModel,
+			MaxTokens:  resolved.maxOutputTokens,
 			HTTPClient: options.HTTPClient,
 			UserAgent:  options.UserAgent,
 		})

--- a/internal/providers/gemini/done_test.go
+++ b/internal/providers/gemini/done_test.go
@@ -1,0 +1,35 @@
+package gemini
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// emitDone must mark the shared state done so callers observe it through the
+// pointer (a by-value receiver would make state.done a dead store).
+func TestEmitDoneMarksStateDoneThroughPointer(t *testing.T) {
+	provider, err := New(Options{Model: "gemini-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	events := make(chan zeroruntime.StreamEvent, 4)
+	state := &streamState{}
+	provider.emitDone(context.Background(), state, events)
+	close(events)
+
+	if !state.done {
+		t.Fatal("emitDone did not mark state.done = true through the pointer")
+	}
+	var sawDone bool
+	for event := range events {
+		if event.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatal("emitDone did not emit a done event")
+	}
+}

--- a/internal/providers/gemini/finish_reason_test.go
+++ b/internal/providers/gemini/finish_reason_test.go
@@ -38,10 +38,17 @@ func TestStreamCompletionSurfacesSafetyFinishReason(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
+	var sawDone bool
 	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != zeroruntime.FinishReasonContentFilter {
-			t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != zeroruntime.FinishReasonContentFilter {
+				t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+			}
 		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
 	}
 }
 
@@ -52,10 +59,17 @@ func TestStreamCompletionNormalFinishReasonHasNoReason(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
+	var sawDone bool
 	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != "" {
-			t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != "" {
+				t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+			}
 		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
 	}
 }
 
@@ -116,9 +130,16 @@ func TestStreamCompletionDoesNotDropValidFunctionCall(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
+	var sawStart bool
 	for _, e := range events {
 		if e.Type == zeroruntime.StreamEventToolCallDropped {
 			t.Errorf("valid functionCall must not be dropped; events: %+v", events)
 		}
+		if e.Type == zeroruntime.StreamEventToolCallStart && e.ToolName == "read_file" {
+			sawStart = true
+		}
+	}
+	if !sawStart {
+		t.Fatalf("valid functionCall did not start a read_file tool call; events: %+v", events)
 	}
 }

--- a/internal/providers/gemini/finish_reason_test.go
+++ b/internal/providers/gemini/finish_reason_test.go
@@ -1,0 +1,124 @@
+package gemini
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// A candidate finishReason of MAX_TOKENS means the response was truncated at the
+// output cap. The provider must surface it on the done event.
+func TestStreamCompletionSurfacesMaxTokensFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"cut"}]},"finishReason":"MAX_TOKENS"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var doneReason string
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			doneReason = e.FinishReason
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+	if doneReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("done FinishReason = %q, want %q", doneReason, zeroruntime.FinishReasonLength)
+	}
+}
+
+// A SAFETY finishReason maps to the runtime's content-filter reason.
+func TestStreamCompletionSurfacesSafetyFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"SAFETY"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != zeroruntime.FinishReasonContentFilter {
+			t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+		}
+	}
+}
+
+// A normal STOP finishReason must leave the done event's FinishReason empty.
+func TestStreamCompletionNormalFinishReasonHasNoReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != "" {
+			t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+		}
+	}
+}
+
+// A functionCall part with an empty Name can't be dispatched. The provider must
+// signal a dropped tool call (once) so the agent can ask the model to retry,
+// rather than silently skipping it.
+func TestStreamCompletionEmitsDroppedOnNamelessFunctionCallPart(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"","args":{"a":1}}}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var dropped, started int
+	for _, e := range events {
+		switch e.Type {
+		case zeroruntime.StreamEventToolCallDropped:
+			dropped++
+		case zeroruntime.StreamEventToolCallStart:
+			started++
+		}
+	}
+	if started != 0 {
+		t.Errorf("a nameless functionCall must not start a tool call, got %d starts", started)
+	}
+	if dropped != 1 {
+		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
+	}
+}
+
+// A nameless top-level functionCall must also be signalled as dropped.
+func TestStreamCompletionEmitsDroppedOnNamelessTopLevelFunctionCall(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"functionCalls":[{"name":"","args":{"a":1}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var dropped, started int
+	for _, e := range events {
+		switch e.Type {
+		case zeroruntime.StreamEventToolCallDropped:
+			dropped++
+		case zeroruntime.StreamEventToolCallStart:
+			started++
+		}
+	}
+	if started != 0 {
+		t.Errorf("a nameless functionCall must not start a tool call, got %d starts", started)
+	}
+	if dropped != 1 {
+		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
+	}
+}
+
+// A well-formed functionCall must NOT emit a dropped signal.
+func TestStreamCompletionDoesNotDropValidFunctionCall(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"x"}}}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventToolCallDropped {
+			t.Errorf("valid functionCall must not be dropped; events: %+v", events)
+		}
+	}
+}

--- a/internal/providers/gemini/idle_test.go
+++ b/internal/providers/gemini/idle_test.go
@@ -1,0 +1,66 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// A stalled-but-open Gemini upstream (sends one chunk, then hangs without
+// closing) must abort on the idle timeout instead of blocking the agent forever.
+func TestStreamCompletionIdleTimeoutAbortsStalledStream(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`)
+		select {
+		case <-r.Context().Done():
+		case <-released:
+		}
+	}))
+	defer server.Close()
+	defer close(released)
+
+	provider, err := New(Options{
+		BaseURL:           server.URL + "/",
+		Model:             "gemini-test",
+		StreamIdleTimeout: 80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+
+	done := make(chan []zeroruntime.StreamEvent, 1)
+	go func() { done <- readAll(stream) }()
+	var events []zeroruntime.StreamEvent
+	select {
+	case events = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream did not terminate on idle — it hung")
+	}
+
+	var gotText, gotIdleError bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventText && e.Content == "hi" {
+			gotText = true
+		}
+		if e.Type == zeroruntime.StreamEventError && strings.Contains(strings.ToLower(e.Error), "idle") {
+			gotIdleError = true
+		}
+	}
+	if !gotText {
+		t.Error("expected the first token before the stall")
+	}
+	if !gotIdleError {
+		t.Errorf("expected a surfaced idle-timeout error, got events: %+v", events)
+	}
+}

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/providers/providerio"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -17,6 +18,11 @@ import (
 
 const defaultBaseURL = "https://generativelanguage.googleapis.com"
 const defaultMaxTokens = 8192
+
+// defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
+// without closing the connection, so a stalled-but-open upstream cannot hang the
+// agent forever.
+const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures a Gemini streamGenerateContent provider.
 type Options struct {
@@ -26,16 +32,20 @@ type Options struct {
 	MaxTokens  int
 	HTTPClient *http.Client
 	UserAgent  string
+	// StreamIdleTimeout aborts the stream if no data arrives for this long.
+	// Zero uses defaultStreamIdleTimeout.
+	StreamIdleTimeout time.Duration
 }
 
 // Provider streams completions from the Gemini API.
 type Provider struct {
-	apiKey     string
-	baseURL    string
-	model      string
-	maxTokens  int
-	httpClient *http.Client
-	userAgent  string
+	apiKey            string
+	baseURL           string
+	model             string
+	maxTokens         int
+	httpClient        *http.Client
+	userAgent         string
+	streamIdleTimeout time.Duration
 }
 
 // New creates a Gemini provider.
@@ -52,13 +62,18 @@ func New(options Options) (*Provider, error) {
 	if err != nil {
 		return nil, err
 	}
+	idleTimeout := options.StreamIdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = defaultStreamIdleTimeout
+	}
 	return &Provider{
-		apiKey:     options.APIKey,
-		baseURL:    baseURL,
-		model:      model,
-		maxTokens:  maxTokens,
-		httpClient: providerio.HTTPClient(options.HTTPClient),
-		userAgent:  options.UserAgent,
+		apiKey:            options.APIKey,
+		baseURL:           baseURL,
+		model:             model,
+		maxTokens:         maxTokens,
+		httpClient:        providerio.HTTPClient(options.HTTPClient),
+		userAgent:         options.UserAgent,
+		streamIdleTimeout: idleTimeout,
 	}, nil
 }
 
@@ -85,7 +100,12 @@ func (provider *Provider) StreamCompletion(
 }
 
 func (provider *Provider) stream(ctx context.Context, body []byte, events chan<- zeroruntime.StreamEvent) {
-	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.streamURL(), bytes.NewReader(body))
+	// streamCtx lets the idle watchdog abort an in-flight body read by cancelling
+	// the request, which unblocks the SSE reader goroutine.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	httpRequest, err := http.NewRequestWithContext(streamCtx, http.MethodPost, provider.streamURL(), bytes.NewReader(body))
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
 		return
@@ -113,9 +133,16 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	}
 
 	state := streamState{}
-	err = providerio.ScanSSEData(response.Body, func(data string) bool {
+	err = providerio.ScanSSEDataWithContext(streamCtx, cancelStream, response.Body, provider.streamIdleTimeout, func(data string) bool {
 		return provider.emitPayload(ctx, data, &state, events)
 	})
+	if errors.Is(err, providerio.ErrStreamIdle) {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact(fmt.Sprintf("provider stream error: idle timeout after %s (upstream stopped sending data)", provider.streamIdleTimeout)),
+		})
+		return
+	}
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return
@@ -125,7 +152,7 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		return
 	}
 	if !state.done {
-		provider.emitDone(ctx, state, events)
+		provider.emitDone(ctx, &state, events)
 	}
 }
 
@@ -168,6 +195,9 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 		state.hasUsage = true
 	}
 	for _, candidate := range payload.Candidates {
+		if reason := mapFinishReason(candidate.FinishReason); reason != "" {
+			state.finishReason = reason
+		}
 		if candidate.Content == nil {
 			continue
 		}
@@ -175,7 +205,14 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 			if part.Text != "" {
 				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: part.Text})
 			}
-			if part.FunctionCall != nil && part.FunctionCall.Name != "" {
+			if part.FunctionCall != nil {
+				if part.FunctionCall.Name == "" {
+					// A functionCall without a usable name can't be dispatched.
+					// Signal a drop once so the agent can ask the model to retry
+					// instead of silently ending the turn (mirrors OpenAI/Anthropic).
+					providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDropped})
+					continue
+				}
 				state.syntheticToolIndex++
 				if !provider.emitToolCall(ctx, *part.FunctionCall, state.syntheticToolIndex, events) {
 					state.done = true
@@ -186,6 +223,9 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 	}
 	for _, functionCall := range payload.FunctionCalls {
 		if functionCall.Name == "" {
+			// Nameless top-level functionCall: signal a drop once rather than
+			// silently skipping it.
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDropped})
 			continue
 		}
 		state.syntheticToolIndex++
@@ -197,7 +237,7 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 	return true
 }
 
-func (provider *Provider) emitDone(ctx context.Context, state streamState, events chan<- zeroruntime.StreamEvent) {
+func (provider *Provider) emitDone(ctx context.Context, state *streamState, events chan<- zeroruntime.StreamEvent) {
 	if state.hasUsage {
 		usage, err := zeroruntime.NormalizeUsage(zeroruntime.TokenUsage{
 			InputTokens:     state.inputTokens,
@@ -208,7 +248,7 @@ func (provider *Provider) emitDone(ctx context.Context, state streamState, event
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: usage})
 		}
 	}
-	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone, FinishReason: state.finishReason})
 	state.done = true
 }
 
@@ -424,5 +464,19 @@ type streamState struct {
 	reasoningTokens    int
 	hasUsage           bool
 	syntheticToolIndex int
+	finishReason       string // normalized terminal stop reason (empty for normal stop)
 	done               bool
+}
+
+// mapFinishReason maps a Gemini candidate finishReason onto the runtime's
+// normalized terminal reasons. A normal stop ("STOP"/"") returns "".
+func mapFinishReason(reason string) string {
+	switch reason {
+	case "MAX_TOKENS":
+		return zeroruntime.FinishReasonLength
+	case "SAFETY", "PROHIBITED_CONTENT", "BLOCKLIST", "SPII":
+		return zeroruntime.FinishReasonContentFilter
+	default:
+		return ""
+	}
 }

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -150,6 +150,14 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 			_ = resp.Body.Close()
 			continue
 		}
+		// If the 5xx retry backoff above returned false because ctx was canceled
+		// (rather than because retries were exhausted), report the cancellation
+		// instead of misclassifying the upstream 5xx as the failure cause.
+		if ctx.Err() != nil {
+			_ = resp.Body.Close()
+			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + ctx.Err().Error())})
+			return
+		}
 		response = resp
 		break
 	}

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -11,11 +10,18 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/Gitlawb/zero/internal/providers/providerio"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 const defaultBaseURL = "https://api.openai.com/v1"
+
+// defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
+// without closing the connection. Hosted gateways (e.g. Ollama Cloud) sometimes
+// stall mid-stream after a tool-call delta; without this the agent blocks forever.
+const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures an OpenAI-compatible chat completions provider.
 type Options struct {
@@ -24,15 +30,23 @@ type Options struct {
 	Model      string
 	HTTPClient *http.Client
 	UserAgent  string
+	// MaxTokens caps the model's output tokens. Zero omits the cap (the model's
+	// own default applies). Resolved from the model registry by the factory.
+	MaxTokens int
+	// StreamIdleTimeout aborts the stream if no data arrives for this long.
+	// Zero uses defaultStreamIdleTimeout.
+	StreamIdleTimeout time.Duration
 }
 
 // Provider streams completions from an OpenAI-compatible chat completions API.
 type Provider struct {
-	apiKey     string
-	baseURL    string
-	model      string
-	httpClient *http.Client
-	userAgent  string
+	apiKey            string
+	baseURL           string
+	model             string
+	maxTokens         int
+	httpClient        *http.Client
+	userAgent         string
+	streamIdleTimeout time.Duration
 }
 
 // New creates an OpenAI-compatible provider.
@@ -56,12 +70,24 @@ func New(options Options) (*Provider, error) {
 		httpClient = http.DefaultClient
 	}
 
+	idleTimeout := options.StreamIdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = defaultStreamIdleTimeout
+	}
+
+	maxTokens := options.MaxTokens
+	if maxTokens < 0 {
+		maxTokens = 0
+	}
+
 	return &Provider{
-		apiKey:     options.APIKey,
-		baseURL:    baseURL,
-		model:      model,
-		httpClient: httpClient,
-		userAgent:  options.UserAgent,
+		apiKey:            options.APIKey,
+		baseURL:           baseURL,
+		model:             model,
+		maxTokens:         maxTokens,
+		httpClient:        httpClient,
+		userAgent:         options.UserAgent,
+		streamIdleTimeout: idleTimeout,
 	}, nil
 }
 
@@ -86,23 +112,46 @@ func (provider *Provider) StreamCompletion(
 
 func (provider *Provider) stream(ctx context.Context, body []byte, events chan<- zeroruntime.StreamEvent) {
 	endpoint := provider.baseURL + "/chat/completions"
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
-		return
-	}
-	request.Header.Set("Content-Type", "application/json")
-	if provider.userAgent != "" {
-		request.Header.Set("User-Agent", provider.userAgent)
-	}
-	if provider.apiKey != "" {
-		request.Header.Set("Authorization", "Bearer "+provider.apiKey)
-	}
 
-	response, err := provider.httpClient.Do(request)
-	if err != nil {
-		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
-		return
+	// streamCtx lets the idle watchdog abort an in-flight body read by cancelling
+	// the request, rather than closing response.Body directly (which would race
+	// with the deferred Close below). Cancelling unblocks the reader goroutine.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	// Retry transient failures (network errors and 5xx) before surfacing them.
+	// Hosted OpenAI-compatible gateways (e.g. Ollama Cloud) return intermittent
+	// 500s that succeed on a quick retry.
+	const maxAttempts = 3
+	var response *http.Response
+	for attempt := 1; ; attempt++ {
+		request, err := http.NewRequestWithContext(streamCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
+			return
+		}
+		request.Header.Set("Content-Type", "application/json")
+		if provider.userAgent != "" {
+			request.Header.Set("User-Agent", provider.userAgent)
+		}
+		if provider.apiKey != "" {
+			request.Header.Set("Authorization", "Bearer "+provider.apiKey)
+		}
+
+		resp, err := provider.httpClient.Do(request)
+		if err != nil {
+			if attempt < maxAttempts && ctx.Err() == nil && backoff(ctx, attempt) {
+				continue
+			}
+			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+			return
+		}
+		if resp.StatusCode >= http.StatusInternalServerError && attempt < maxAttempts && backoff(ctx, attempt) {
+			_ = resp.Body.Close()
+			continue
+		}
+		response = resp
+		break
 	}
 	defer func() {
 		_ = response.Body.Close()
@@ -114,53 +163,61 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	}
 
 	state := newToolState()
-	scanner := bufio.NewScanner(response.Body)
-	scanner.Buffer(make([]byte, 0, 4096), 16*1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "data:") {
-			continue
-		}
-		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-		if data == "" {
-			continue
-		}
-		if data == "[DONE]" {
-			state.closeOpen(ctx, events)
-			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
-			return
-		}
-
-		var chunk streamChunk
-		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			state.closeOpen(ctx, events)
-			sendEvent(ctx, events, zeroruntime.StreamEvent{
-				Type:  zeroruntime.StreamEventError,
-				Error: provider.redact("provider stream error: malformed JSON: " + err.Error()),
-			})
-			return
-		}
-		if chunk.Error != nil {
-			state.closeOpen(ctx, events)
-			sendEvent(ctx, events, zeroruntime.StreamEvent{
-				Type:  zeroruntime.StreamEventError,
-				Error: provider.classifiedError(http.StatusInternalServerError, chunk.Error.Message),
-			})
-			return
-		}
-		provider.emitChunk(ctx, chunk, state, events)
+	// Use the shared SSE reader (also used by the Anthropic/Gemini providers) so
+	// multi-line "data:" continuation fields are joined into one payload, and the
+	// idle watchdog / context cancellation are handled uniformly.
+	err := providerio.ScanSSEDataWithContext(streamCtx, cancelStream, response.Body, provider.streamIdleTimeout, func(data string) bool {
+		return provider.emitPayload(ctx, data, state, events)
+	})
+	if errors.Is(err, providerio.ErrStreamIdle) {
+		state.closeOpen(ctx, events)
+		sendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact(fmt.Sprintf("provider stream error: idle timeout after %s (upstream stopped sending data)", provider.streamIdleTimeout)),
+		})
+		return
 	}
-
-	state.closeOpen(ctx, events)
-	if err := scanner.Err(); err != nil {
+	if err != nil {
+		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return
 	}
-	if err := ctx.Err(); err != nil {
-		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		state.closeOpen(ctx, events)
+		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + ctxErr.Error())})
 		return
 	}
-	sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	if !state.done {
+		state.closeOpen(ctx, events)
+		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone, FinishReason: state.finishReason})
+	}
+}
+
+// emitPayload handles one accumulated SSE data payload ([DONE]/blank lines are
+// already filtered by the shared reader). It returns false to abort the stream
+// after emitting a terminal error.
+func (provider *Provider) emitPayload(ctx context.Context, data string, state *toolState, events chan<- zeroruntime.StreamEvent) bool {
+	var chunk streamChunk
+	if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+		state.closeOpen(ctx, events)
+		sendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.redact("provider stream error: malformed JSON: " + err.Error()),
+		})
+		state.done = true
+		return false
+	}
+	if chunk.Error != nil {
+		state.closeOpen(ctx, events)
+		sendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: provider.classifiedError(http.StatusInternalServerError, chunk.Error.Message),
+		})
+		state.done = true
+		return false
+	}
+	provider.emitChunk(ctx, chunk, state, events)
+	return true
 }
 
 func (provider *Provider) emitChunk(
@@ -182,6 +239,9 @@ func (provider *Provider) emitChunk(
 		if choice.FinishReason == "tool_calls" {
 			state.closeOpen(ctx, events)
 		}
+		if reason := mapFinishReason(choice.FinishReason); reason != "" {
+			state.finishReason = reason
+		}
 	}
 
 	if chunk.Usage != nil {
@@ -193,6 +253,19 @@ func (provider *Provider) emitChunk(
 				CachedInputTokens: chunk.Usage.PromptTokensDetails.CachedTokens,
 			},
 		})
+	}
+}
+
+// mapFinishReason maps OpenAI's finish_reason onto the runtime's normalized
+// terminal reasons. A normal finish ("stop"/"tool_calls"/"") returns "".
+func mapFinishReason(reason string) string {
+	switch reason {
+	case "length":
+		return zeroruntime.FinishReasonLength
+	case "content_filter":
+		return zeroruntime.FinishReasonContentFilter
+	default:
+		return ""
 	}
 }
 
@@ -215,32 +288,24 @@ func (provider *Provider) emitHTTPError(ctx context.Context, response *http.Resp
 }
 
 func (provider *Provider) classifiedError(statusCode int, message string) string {
-	prefix := "provider error: "
-	switch statusCode {
-	case http.StatusUnauthorized, http.StatusForbidden:
-		prefix = "auth error: "
-	case http.StatusTooManyRequests:
-		prefix = "rate limit error: "
-	default:
-		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
-			prefix = "provider request error: "
-		}
-	}
-	return provider.redact(prefix + message)
+	return providerio.ClassifiedError(statusCode, message, provider.apiKey)
 }
 
 func (provider *Provider) redact(message string) string {
-	if provider.apiKey != "" {
-		message = strings.ReplaceAll(message, provider.apiKey, "[REDACTED]")
+	return providerio.Redact(message, provider.apiKey)
+}
+
+// backoff waits before a retry attempt, returning false if the context is
+// cancelled while waiting.
+func backoff(ctx context.Context, attempt int) bool {
+	timer := time.NewTimer(time.Duration(attempt) * 400 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
-	words := strings.Fields(message)
-	for index := 0; index < len(words)-1; index++ {
-		if strings.EqualFold(strings.TrimRight(words[index], ":"), "Bearer") {
-			words[index] = "authorization"
-			words[index+1] = "[REDACTED]"
-		}
-	}
-	return strings.Join(words, " ")
 }
 
 func sendEvent(ctx context.Context, events chan<- zeroruntime.StreamEvent, event zeroruntime.StreamEvent) {
@@ -266,6 +331,12 @@ func (provider *Provider) openAIRequest(request zeroruntime.CompletionRequest) c
 		Model:    provider.model,
 		Messages: messages,
 		Stream:   true,
+		// Request the terminal usage chunk; OpenAI omits it on streams otherwise,
+		// which silently zeroes token accounting.
+		StreamOptions: &streamOptions{IncludeUsage: true},
+	}
+	if provider.maxTokens > 0 {
+		mapped.MaxCompletionTokens = provider.maxTokens
 	}
 	if len(request.Tools) > 0 {
 		mapped.Tools = make([]toolDefinition, 0, len(request.Tools))

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -578,10 +578,17 @@ func TestStreamCompletionSurfacesContentFilterFinishReason(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
+	var sawDone bool
 	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != zeroruntime.FinishReasonContentFilter {
-			t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != zeroruntime.FinishReasonContentFilter {
+				t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+			}
 		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
 	}
 }
 
@@ -593,10 +600,17 @@ func TestStreamCompletionNormalFinishHasNoReason(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
+	var sawDone bool
 	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != "" {
-			t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != "" {
+				t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+			}
 		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
 	}
 }
 

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -77,8 +77,12 @@ func TestStreamCompletionPostsChatCompletionRequest(t *testing.T) {
 	if gotBody["model"] != "gpt-test" || gotBody["stream"] != true {
 		t.Fatalf("unexpected model/stream: %#v", gotBody)
 	}
-	if _, ok := gotBody["stream_options"]; ok {
-		t.Fatalf("stream_options should be omitted in M0 request: %#v", gotBody["stream_options"])
+	streamOpts, ok := gotBody["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_options missing or wrong type: %#v", gotBody["stream_options"])
+	}
+	if streamOpts["include_usage"] != true {
+		t.Fatalf("stream_options.include_usage = %#v, want true", streamOpts["include_usage"])
 	}
 	messages := gotBody["messages"].([]any)
 	assistant := messages[2].(map[string]any)
@@ -217,6 +221,8 @@ func TestStreamCompletionClassifiesHTTPErrorsAndRedactsToken(t *testing.T) {
 	}{
 		{"auth", http.StatusUnauthorized, `{"error":{"message":"bad key sk-secret","type":"invalid_request_error"}}`, "auth error:"},
 		{"rate limit", http.StatusTooManyRequests, `{"error":{"message":"slow down"}}`, "rate limit error:"},
+		{"service unavailable", http.StatusServiceUnavailable, `{"error":{"message":"overloaded"}}`, "rate limit error:"},
+		{"overloaded 529", 529, `{"error":{"message":"overloaded"}}`, "rate limit error:"},
 		{"bad request", http.StatusBadRequest, `{"error":{"message":"bad request"}}`, "provider request error:"},
 		{"server", http.StatusInternalServerError, `server saw Bearer sk-secret`, "provider error:"},
 	}
@@ -415,5 +421,256 @@ func TestStreamCompletionSkipsNamelessToolCallOnEOF(t *testing.T) {
 	}
 	if len(eventsOfType(events, zeroruntime.StreamEventDone)) != 1 {
 		t.Fatalf("events = %#v, want done event", events)
+	}
+}
+
+func TestStreamCompletionIdleTimeoutAbortsStalledStream(t *testing.T) {
+	released := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Send one token, then hang without sending [DONE] or closing —
+		// simulating a stalled upstream (the freeze in the screenshot).
+		writeSSE(w, `{"choices":[{"delta":{"content":"hi"}}]}`)
+		select {
+		case <-r.Context().Done():
+		case <-released:
+		}
+	}))
+	defer server.Close()
+	defer close(released)
+
+	provider, err := New(Options{
+		BaseURL:           server.URL + "/",
+		Model:             "gpt-test",
+		StreamIdleTimeout: 80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+
+	// Must terminate (channel closes) rather than hang forever.
+	done := make(chan []zeroruntime.StreamEvent, 1)
+	go func() { done <- readAll(stream) }()
+	var events []zeroruntime.StreamEvent
+	select {
+	case events = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("stream did not terminate on idle — it hung")
+	}
+
+	var gotText, gotIdleError bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventText && e.Content == "hi" {
+			gotText = true
+		}
+		if e.Type == zeroruntime.StreamEventError && strings.Contains(strings.ToLower(e.Error), "idle") {
+			gotIdleError = true
+		}
+	}
+	if !gotText {
+		t.Error("expected the first token before the stall")
+	}
+	if !gotIdleError {
+		t.Errorf("expected a surfaced idle-timeout error, got events: %+v", events)
+	}
+}
+
+func TestStreamCompletionSendsMaxCompletionTokens(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "gpt-test", MaxTokens: 1234})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	got, ok := gotBody["max_completion_tokens"]
+	if !ok {
+		t.Fatalf("max_completion_tokens missing from request: %#v", gotBody)
+	}
+	if n, _ := got.(float64); int(n) != 1234 {
+		t.Fatalf("max_completion_tokens = %#v, want 1234", got)
+	}
+}
+
+func TestStreamCompletionOmitsMaxCompletionTokensWhenUnset(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "gpt-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if _, ok := gotBody["max_completion_tokens"]; ok {
+		t.Fatalf("max_completion_tokens should be omitted when unset: %#v", gotBody["max_completion_tokens"])
+	}
+}
+
+// A finish_reason of "length" means the response was truncated at the output cap.
+// The provider must surface it on the done event so a clipped answer is not
+// mistaken for a complete one.
+func TestStreamCompletionSurfacesLengthFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"content":"truncated"}}]}`)
+		writeSSE(w, `{"choices":[{"delta":{},"finish_reason":"length"}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var doneReason string
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			doneReason = e.FinishReason
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+	if doneReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("done FinishReason = %q, want %q", doneReason, zeroruntime.FinishReasonLength)
+	}
+
+	// And it round-trips through the runtime collector as Truncated.
+	collected := zeroruntime.CollectStream(context.Background(), replay(events))
+	if !collected.Truncated() || collected.FinishReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("collected = %+v, want truncated length", collected)
+	}
+}
+
+// A content_filter finish_reason maps to the runtime's content-filter reason.
+func TestStreamCompletionSurfacesContentFilterFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{},"finish_reason":"content_filter"}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != zeroruntime.FinishReasonContentFilter {
+			t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+		}
+	}
+}
+
+// A normal "stop" finish must leave FinishReason empty on the done event.
+func TestStreamCompletionNormalFinishHasNoReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone && e.FinishReason != "" {
+			t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+		}
+	}
+}
+
+// The shared SSE reader must join multi-line "data:" continuation fields into a
+// single payload (the OpenAI provider previously parsed one line at a time and
+// would drop the continuation, producing malformed JSON).
+func TestStreamCompletionJoinsMultiLineDataFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// One SSE event whose JSON payload is split across two data: lines.
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":\ndata: {\"content\":\"joined\"}}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "gpt-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	events := collectProviderEvents(t, provider)
+	var text string
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventText {
+			text += e.Content
+		}
+		if e.Type == zeroruntime.StreamEventError {
+			t.Fatalf("multi-line data field produced an error: %q", e.Error)
+		}
+	}
+	if text != "joined" {
+		t.Fatalf("text = %q, want %q (continuation data: line dropped?)", text, "joined")
+	}
+}
+
+func replay(events []zeroruntime.StreamEvent) <-chan zeroruntime.StreamEvent {
+	ch := make(chan zeroruntime.StreamEvent, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch
+}
+
+func TestStreamCompletionEmitsDroppedOnNamelessToolCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A tool call with arguments + finish_reason but no function name.
+		writeSSE(w, `{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_x","function":{"arguments":"{}"}}]}}]}`)
+		writeSSE(w, `{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`)
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "gpt-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	events := collectProviderEvents(t, provider)
+
+	var dropped, started bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventToolCallDropped {
+			dropped = true
+		}
+		if e.Type == zeroruntime.StreamEventToolCallStart {
+			started = true
+		}
+	}
+	if started {
+		t.Error("a nameless tool call must not start")
+	}
+	if !dropped {
+		t.Errorf("expected a dropped-tool-call signal, got events: %+v", events)
 	}
 }

--- a/internal/providers/openai/tool_state.go
+++ b/internal/providers/openai/tool_state.go
@@ -9,6 +9,13 @@ import (
 
 type toolState struct {
 	calls map[int]*pendingToolCall
+	// finishReason holds the normalized terminal stop reason (zeroruntime
+	// FinishReason*) when the response ended abnormally (length/content_filter),
+	// so the provider can attach it to the done event. Empty for a normal finish.
+	finishReason string
+	// done is set once a terminal event (error) has been emitted so the post-scan
+	// path does not emit a second done after the stream already ended.
+	done bool
 }
 
 type pendingToolCall struct {
@@ -34,10 +41,14 @@ func (state *toolState) applyDelta(
 		state.calls[delta.Index] = call
 	}
 
-	if delta.ID != "" {
+	// Set id and name once. Some OpenAI-compatible backends (e.g. minimax via
+	// Ollama) occasionally stream a second tool_calls entry at the same index;
+	// overwriting id/name there corrupts the in-flight call and leaks a phantom
+	// nameless call into the collector ("Unknown tool \"\""). Keep the first.
+	if delta.ID != "" && call.id == "" {
 		call.id = delta.ID
 	}
-	if delta.Function.Name != "" {
+	if delta.Function.Name != "" && call.name == "" {
 		call.name = delta.Function.Name
 	}
 	if delta.Function.Arguments != "" {
@@ -75,7 +86,17 @@ func (state *toolState) closeOpen(ctx context.Context, events chan<- zeroruntime
 
 	for _, index := range indexes {
 		call := state.calls[index]
-		if call == nil || call.ended || call.id == "" || call.name == "" {
+		if call == nil || call.ended {
+			continue
+		}
+		// A call that lacks a usable name/id can't be dispatched. If the model
+		// nonetheless attempted one (it streamed an id or arguments), signal a
+		// drop once so the agent can ask it to retry instead of silently ending.
+		if call.id == "" || call.name == "" {
+			if call.id != "" || call.name != "" || call.arguments != "" {
+				call.ended = true
+				sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDropped})
+			}
 			continue
 		}
 		if !call.started {

--- a/internal/providers/openai/types.go
+++ b/internal/providers/openai/types.go
@@ -1,10 +1,19 @@
 package openai
 
 type chatCompletionRequest struct {
-	Model    string           `json:"model"`
-	Messages []chatMessage    `json:"messages"`
-	Tools    []toolDefinition `json:"tools,omitempty"`
-	Stream   bool             `json:"stream"`
+	Model               string           `json:"model"`
+	Messages            []chatMessage    `json:"messages"`
+	Tools               []toolDefinition `json:"tools,omitempty"`
+	MaxCompletionTokens int              `json:"max_completion_tokens,omitempty"`
+	Stream              bool             `json:"stream"`
+	StreamOptions       *streamOptions   `json:"stream_options,omitempty"`
+}
+
+// streamOptions requests the final usage chunk on a streaming response. Without
+// include_usage the OpenAI streaming API never sends the usage object, so token
+// accounting is silently zero for real OpenAI streams.
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type chatMessage struct {

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -115,10 +115,6 @@ func ScanSSEDataWithContext(
 	idleTimeout time.Duration,
 	handle func(data string) bool,
 ) error {
-	if idleTimeout <= 0 {
-		return ScanSSEData(reader, handle)
-	}
-
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 4096), maxSSELineBytes)
 
@@ -140,16 +136,24 @@ func ScanSSEDataWithContext(
 		close(payloads)
 	}()
 
-	idle := time.NewTimer(idleTimeout)
-	defer idle.Stop()
-	resetIdle := func() {
-		if !idle.Stop() {
-			select {
-			case <-idle.C:
-			default:
+	// The idle watchdog is optional. When idleTimeout <= 0 it is disabled, but we
+	// STILL run the goroutine + select loop so ctx cancellation is always honored
+	// (a nil idleC channel simply never fires in the select).
+	var idleC <-chan time.Time
+	resetIdle := func() {}
+	if idleTimeout > 0 {
+		idle := time.NewTimer(idleTimeout)
+		defer idle.Stop()
+		idleC = idle.C
+		resetIdle = func() {
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
 			}
+			idle.Reset(idleTimeout)
 		}
-		idle.Reset(idleTimeout)
 	}
 
 	for {
@@ -160,7 +164,7 @@ func ScanSSEDataWithContext(
 			// that only the request-context cancel can interrupt).
 			cancel()
 			return ctx.Err()
-		case <-idle.C:
+		case <-idleC:
 			// Upstream went silent without closing. Abort the read and surface
 			// a timeout instead of blocking the agent forever.
 			cancel()

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -3,16 +3,22 @@ package providerio
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 const maxSSELineBytes = 16 * 1024 * 1024
+
+// ErrStreamIdle reports that a streaming upstream stopped sending data without
+// closing the connection. Callers surface it as an idle-timeout error.
+var ErrStreamIdle = errors.New("idle timeout (upstream stopped sending data)")
 
 // NormalizeBaseURL trims trailing slashes and validates an HTTP API base URL.
 func NormalizeBaseURL(baseURL string, defaultBaseURL string, label string) (string, error) {
@@ -53,7 +59,13 @@ func SendEvent(ctx context.Context, events chan<- zeroruntime.StreamEvent, event
 func ScanSSEData(reader io.Reader, handle func(data string) bool) error {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 4096), maxSSELineBytes)
+	return scanSSEPayloads(scanner, handle)
+}
 
+// scanSSEPayloads accumulates SSE "data:" lines into payloads (joined across
+// continuation lines, flushed on a blank line or EOF) and forwards each to
+// handle. It is the shared core of ScanSSEData and the idle-aware variant.
+func scanSSEPayloads(scanner *bufio.Scanner, handle func(data string) bool) error {
 	dataLines := []string{}
 	flush := func() bool {
 		if len(dataLines) == 0 {
@@ -87,6 +99,94 @@ func ScanSSEData(reader io.Reader, handle func(data string) bool) error {
 	}
 	flush()
 	return nil
+}
+
+// ScanSSEDataWithContext parses SSE data payloads while enforcing an idle
+// timeout and honoring ctx cancellation. The blocking scan runs on a goroutine
+// that forwards each completed payload over a buffered channel; this consumer
+// selects on ctx.Done, the idle timer, and incoming payloads. When the upstream
+// goes silent for idleTimeout, cancel is invoked to abort the in-flight request
+// (unblocking the reader) and ErrStreamIdle is returned. On ctx cancellation
+// ctx.Err() is returned. A non-positive idleTimeout disables the watchdog.
+func ScanSSEDataWithContext(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	reader io.Reader,
+	idleTimeout time.Duration,
+	handle func(data string) bool,
+) error {
+	if idleTimeout <= 0 {
+		return ScanSSEData(reader, handle)
+	}
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 4096), maxSSELineBytes)
+
+	type payload struct {
+		data string
+	}
+	payloads := make(chan payload)
+	scanDone := make(chan error, 1)
+
+	go func() {
+		scanDone <- scanSSEPayloads(scanner, func(data string) bool {
+			select {
+			case payloads <- payload{data: data}:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		})
+		close(payloads)
+	}()
+
+	idle := time.NewTimer(idleTimeout)
+	defer idle.Stop()
+	resetIdle := func() {
+		if !idle.Stop() {
+			select {
+			case <-idle.C:
+			default:
+			}
+		}
+		idle.Reset(idleTimeout)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Abort the in-flight request so the reader goroutine unblocks and
+			// exits on its own; do not wait for it (it may be parked in a read
+			// that only the request-context cancel can interrupt).
+			cancel()
+			return ctx.Err()
+		case <-idle.C:
+			// Upstream went silent without closing. Abort the read and surface
+			// a timeout instead of blocking the agent forever.
+			cancel()
+			return ErrStreamIdle
+		case item, ok := <-payloads:
+			if !ok {
+				// Reader finished: deliver its terminal status (EOF -> nil,
+				// scanner error, or ctx cancel observed inside the goroutine).
+				if err := <-scanDone; err != nil {
+					return err
+				}
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return nil
+			}
+			resetIdle()
+			if !handle(item.data) {
+				// The provider asked to stop (e.g. it already emitted an error
+				// for this payload). Abort the read and end like ScanSSEData:
+				// return nil so callers fall through to their post-scan checks.
+				cancel()
+				return nil
+			}
+		}
+	}
 }
 
 // ClassifiedError normalizes provider HTTP/stream errors and redacts secrets.

--- a/internal/providers/providerio/providerio_test.go
+++ b/internal/providers/providerio/providerio_test.go
@@ -72,6 +72,37 @@ func TestScanSSEDataWithContextHonorsContextCancel(t *testing.T) {
 	}
 }
 
+// ctx cancellation must unblock a hung read EVEN WHEN the idle watchdog is
+// disabled (idleTimeout <= 0). Regression: the helper used to skip the
+// goroutine + select loop when idle was off, so a context cancel could not
+// interrupt a parked read and the call hung forever.
+func TestScanSSEDataWithContextHonorsCancelWhenIdleDisabled(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		// idleTimeout == 0 disables the watchdog; only ctx cancel can return.
+		done <- ScanSSEDataWithContext(ctx, cancel, pr, 0, func(string) bool { return true })
+	}()
+
+	// Cancel shortly after the call has parked in a blocking read with no data.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("ScanSSEDataWithContext hung with idle watchdog disabled; ctx cancel ignored")
+	}
+}
+
 // Normal completion (EOF) must return nil after delivering all data payloads,
 // matching ScanSSEData's multi-line accumulation semantics.
 func TestScanSSEDataWithContextDeliversThenEOF(t *testing.T) {

--- a/internal/providers/providerio/providerio_test.go
+++ b/internal/providers/providerio/providerio_test.go
@@ -1,0 +1,90 @@
+package providerio
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A stalled-but-open upstream must not block forever: the helper aborts after
+// the idle timeout, cancels the request context, and returns ErrStreamIdle.
+func TestScanSSEDataWithContextAbortsOnIdle(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	// Send one event, then never send anything else and never close.
+	go func() {
+		_, _ = io.WriteString(pw, "data: first\n\n")
+	}()
+
+	cancelled := false
+	cancel := func() { cancelled = true }
+
+	var got []string
+	done := make(chan error, 1)
+	go func() {
+		done <- ScanSSEDataWithContext(context.Background(), cancel, pr, 60*time.Millisecond, func(data string) bool {
+			got = append(got, data)
+			return true
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrStreamIdle) {
+			t.Fatalf("err = %v, want ErrStreamIdle", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("ScanSSEDataWithContext hung on a stalled stream")
+	}
+
+	if len(got) != 1 || got[0] != "first" {
+		t.Fatalf("got payloads %#v, want [first]", got)
+	}
+	if !cancelled {
+		t.Fatal("idle abort did not cancel the request context")
+	}
+}
+
+// ctx cancellation must unblock a hung read and surface ctx.Err().
+func TestScanSSEDataWithContextHonorsContextCancel(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- ScanSSEDataWithContext(ctx, cancel, pr, time.Hour, func(string) bool { return true })
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("ScanSSEDataWithContext did not honor context cancellation")
+	}
+}
+
+// Normal completion (EOF) must return nil after delivering all data payloads,
+// matching ScanSSEData's multi-line accumulation semantics.
+func TestScanSSEDataWithContextDeliversThenEOF(t *testing.T) {
+	body := "data: line-a\ndata: line-b\n\ndata: [DONE]\n\n"
+	var got []string
+	err := ScanSSEDataWithContext(context.Background(), func() {}, strings.NewReader(body), time.Hour, func(data string) bool {
+		got = append(got, data)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil on EOF", err)
+	}
+	if len(got) != 1 || got[0] != "line-a\nline-b" {
+		t.Fatalf("got %#v, want one accumulated payload", got)
+	}
+}

--- a/internal/zeroruntime/empty_toolcall_test.go
+++ b/internal/zeroruntime/empty_toolcall_test.go
@@ -1,0 +1,81 @@
+package zeroruntime
+
+import (
+	"context"
+	"testing"
+)
+
+// A malformed (nameless) tool call must never reach the agent — it would dispatch
+// an empty tool name ("Unknown tool \"\""). Valid calls still pass through.
+func TestCollectStreamDropsNamelessToolCalls(t *testing.T) {
+	events := make(chan StreamEvent, 8)
+	// valid call
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "a", ToolName: "read_file"}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "a", ArgumentsFragment: `{"path":"x"}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd, ToolCallID: "a"}
+	// malformed: a delta/end for an id that never got a (named) start
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "b", ArgumentsFragment: `{"path":"y"}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd, ToolCallID: "b"}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if len(got.ToolCalls) != 1 {
+		t.Fatalf("expected 1 valid tool call, got %d: %+v", len(got.ToolCalls), got.ToolCalls)
+	}
+	if got.ToolCalls[0].Name != "read_file" {
+		t.Errorf("kept call name = %q, want read_file", got.ToolCalls[0].Name)
+	}
+	for _, c := range got.ToolCalls {
+		if c.Name == "" {
+			t.Error("a nameless tool call leaked to the agent")
+		}
+	}
+}
+
+// An empty-id DELTA that arrives BEFORE its start event must not orphan its
+// buffered arguments: a following empty-id start should adopt the in-flight
+// call so the name and the early-buffered arguments end up on the same call.
+func TestCollectStreamEmptyIDDeltaBeforeStartIsAdopted(t *testing.T) {
+	events := make(chan StreamEvent, 8)
+	// delta arrives first, with an empty id and no start yet
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ArgumentsFragment: `{"path":`}
+	// start (empty id) arrives afterwards carrying the name
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolName: "read_file"}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ArgumentsFragment: `"x"}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if len(got.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d: %+v", len(got.ToolCalls), got.ToolCalls)
+	}
+	if got.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("call name = %q, want read_file", got.ToolCalls[0].Name)
+	}
+	if got.ToolCalls[0].Arguments != `{"path":"x"}` {
+		t.Fatalf("arguments = %q, want full buffered args (early delta orphaned?)", got.ToolCalls[0].Arguments)
+	}
+	if got.DroppedToolCalls != 0 {
+		t.Fatalf("DroppedToolCalls = %d, want 0 (early delta should not orphan into a nameless call)", got.DroppedToolCalls)
+	}
+}
+
+// A provider-signalled dropped (nameless) tool call must be counted so the agent
+// can tell the model to retry instead of silently treating it as a final answer.
+func TestCollectStreamCountsDroppedToolCalls(t *testing.T) {
+	events := make(chan StreamEvent, 4)
+	events <- StreamEvent{Type: StreamEventText, Content: "I'll write the file."}
+	events <- StreamEvent{Type: StreamEventToolCallDropped}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if len(got.ToolCalls) != 0 {
+		t.Fatalf("expected no usable tool calls, got %d", len(got.ToolCalls))
+	}
+	if got.DroppedToolCalls != 1 {
+		t.Fatalf("expected DroppedToolCalls=1, got %d", got.DroppedToolCalls)
+	}
+}

--- a/internal/zeroruntime/finish_reason_test.go
+++ b/internal/zeroruntime/finish_reason_test.go
@@ -1,0 +1,40 @@
+package zeroruntime
+
+import (
+	"context"
+	"testing"
+)
+
+// A terminal finish reason carried on the done event must be recorded so a
+// truncated (length-capped) response is not mistaken for a normal completion.
+func TestCollectStreamRecordsFinishReason(t *testing.T) {
+	events := make(chan StreamEvent, 4)
+	events <- StreamEvent{Type: StreamEventText, Content: "partial answer that got cut"}
+	events <- StreamEvent{Type: StreamEventDone, FinishReason: FinishReasonLength}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if got.FinishReason != FinishReasonLength {
+		t.Fatalf("FinishReason = %q, want %q", got.FinishReason, FinishReasonLength)
+	}
+	if !got.Truncated() {
+		t.Fatal("Truncated() = false, want true for a length-capped response")
+	}
+}
+
+// A finish reason may also arrive on an earlier event (e.g. a usage event) and
+// must still be captured; a normal completion leaves it empty.
+func TestCollectStreamFinishReasonEmptyOnNormalCompletion(t *testing.T) {
+	events := make(chan StreamEvent, 4)
+	events <- StreamEvent{Type: StreamEventText, Content: "complete answer"}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if got.FinishReason != "" {
+		t.Fatalf("FinishReason = %q, want empty for a normal completion", got.FinishReason)
+	}
+	if got.Truncated() {
+		t.Fatal("Truncated() = true, want false for a normal completion")
+	}
+}

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -1,13 +1,28 @@
 package zeroruntime
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // CollectedStream is the non-streaming summary of provider events.
 type CollectedStream struct {
-	Text      string
-	ToolCalls []ToolCall
-	Usage     Usage
-	Error     string
+	Text             string
+	ToolCalls        []ToolCall
+	Usage            Usage
+	Error            string
+	DroppedToolCalls int // malformed tool calls the provider could not dispatch
+	// FinishReason is the provider's normalized terminal stop reason when the
+	// response did not end normally (FinishReasonLength / FinishReasonContentFilter).
+	// It is empty for a normal completion. Truncated reports whether it is set.
+	FinishReason string
+}
+
+// Truncated reports whether the response ended for a non-normal reason (the
+// output was cut at the token cap or withheld by a content filter), so callers
+// can warn instead of treating a clipped answer as complete.
+func (collected CollectedStream) Truncated() bool {
+	return collected.FinishReason != ""
 }
 
 // CollectOptions provides callbacks for consumers that need live stream updates.
@@ -32,19 +47,26 @@ func CollectStream(ctx context.Context, events <-chan StreamEvent) CollectedStre
 // CollectStreamWithOptions drains provider events and emits optional live callbacks.
 func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, options CollectOptions) CollectedStream {
 	collected := CollectedStream{}
-	pendingToolCalls := make(map[string]*ToolCall)
-	toolCallOrder := []string{}
+	collector := newToolCallCollector()
 
 	for {
 		select {
 		case <-ctx.Done():
 			collected.Error = ctx.Err().Error()
-			appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
+			collector.flush(&collected)
 			return collected
 		case event, ok := <-events:
 			if !ok {
-				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
+				collector.flush(&collected)
 				return collected
+			}
+
+			// A non-normal terminal stop reason can ride on any event (providers
+			// attach it to their done/terminal event). Record it regardless of
+			// type so a truncated/filtered response is never mistaken for a
+			// normal completion.
+			if event.FinishReason != "" {
+				collected.FinishReason = event.FinishReason
 			}
 
 			switch event.Type {
@@ -54,16 +76,13 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 					options.OnText(event.Content)
 				}
 			case StreamEventToolCallStart:
-				toolCall := ensurePendingToolCall(event.ToolCallID, pendingToolCalls, &toolCallOrder)
-				toolCall.Name = event.ToolName
+				collector.start(event.ToolCallID, event.ToolName)
 			case StreamEventToolCallDelta:
-				toolCall := ensurePendingToolCall(event.ToolCallID, pendingToolCalls, &toolCallOrder)
-				toolCall.Arguments += event.ArgumentsFragment
+				collector.delta(event.ToolCallID, event.ArgumentsFragment)
 			case StreamEventToolCallEnd:
-				if toolCall, ok := pendingToolCalls[event.ToolCallID]; ok {
-					collected.ToolCalls = append(collected.ToolCalls, *toolCall)
-					delete(pendingToolCalls, event.ToolCallID)
-				}
+				collector.end(event.ToolCallID)
+			case StreamEventToolCallDropped:
+				collected.DroppedToolCalls++
 			case StreamEventUsage:
 				inputTokens := event.Usage.EffectiveInputTokens()
 				outputTokens := event.Usage.EffectiveOutputTokens()
@@ -78,43 +97,139 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 				}
 			case StreamEventError:
 				collected.Error = event.Error
-				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
+				collector.flush(&collected)
 				return collected
 			case StreamEventDone:
-				appendOpenToolCalls(&collected, toolCallOrder, pendingToolCalls)
+				collector.flush(&collected)
 				return collected
 			}
 		}
 	}
 }
 
-func ensurePendingToolCall(
-	toolCallID string,
-	pendingToolCalls map[string]*ToolCall,
-	toolCallOrder *[]string,
-) *ToolCall {
-	toolCall, ok := pendingToolCalls[toolCallID]
-	if ok {
-		return toolCall
-	}
-
-	toolCall = &ToolCall{ID: toolCallID}
-	pendingToolCalls[toolCallID] = toolCall
-	*toolCallOrder = append(*toolCallOrder, toolCallID)
-	return toolCall
+// toolCallCollector accumulates streamed tool calls in start order. Calls are
+// keyed by an internal key (the ToolCallID when non-empty, or a synthetic
+// per-stream key for empty IDs) so distinct simultaneous calls that share an
+// empty/duplicate ID never merge. Completed calls are NOT emitted at end time;
+// flush emits every collected call in one ordered pass so output always follows
+// model/start order regardless of the order calls finished.
+type toolCallCollector struct {
+	calls       map[string]*ToolCall
+	order       []string
+	openEmptyID []string // stack of synthetic keys for in-flight empty-id calls
+	synthetic   int
+	// pendingEmptyDelta is the synthetic key of an empty-id call that was opened
+	// by a delta arriving before any start (so its buffered arguments aren't
+	// orphaned). The next empty-id start adopts it instead of opening a new call.
+	pendingEmptyDelta string
 }
 
-func appendOpenToolCalls(
-	collected *CollectedStream,
-	toolCallOrder []string,
-	pendingToolCalls map[string]*ToolCall,
-) {
-	for _, id := range toolCallOrder {
-		toolCall, ok := pendingToolCalls[id]
+func newToolCallCollector() *toolCallCollector {
+	return &toolCallCollector{calls: make(map[string]*ToolCall)}
+}
+
+// start begins a tool call. A non-empty ID reuses any open call with that ID
+// (some backends re-emit the same start); an empty ID always begins a fresh
+// synthetic call so concurrent empty-id calls stay distinct.
+func (collector *toolCallCollector) start(id string, name string) {
+	key := id
+	if id == "" {
+		// Adopt an empty-id call that a delta opened before this start, so its
+		// already-buffered arguments and this start's name land on one call.
+		if collector.pendingEmptyDelta != "" {
+			key = collector.pendingEmptyDelta
+			collector.pendingEmptyDelta = ""
+		} else {
+			collector.synthetic++
+			key = fmt.Sprintf("\x00synthetic-%d", collector.synthetic)
+			collector.openEmptyID = append(collector.openEmptyID, key)
+		}
+	}
+	call := collector.ensure(key, id)
+	// Only set the name when non-empty and still unset, so a duplicate or
+	// nameless follow-up start cannot clobber an already-resolved name.
+	if name != "" && call.Name == "" {
+		call.Name = name
+	}
+}
+
+func (collector *toolCallCollector) delta(id string, fragment string) {
+	key, ok := collector.resolveKey(id)
+	if !ok {
+		if id == "" {
+			// An empty-id delta with no in-flight empty-id call: open one and
+			// remember it so a following empty-id start adopts it instead of
+			// orphaning these buffered arguments under a nameless call.
+			collector.synthetic++
+			key = fmt.Sprintf("\x00synthetic-%d", collector.synthetic)
+			collector.openEmptyID = append(collector.openEmptyID, key)
+			collector.pendingEmptyDelta = key
+		} else {
+			key = id
+		}
+		collector.ensure(key, id)
+	}
+	collector.calls[key].Arguments += fragment
+}
+
+// end closes an in-flight call. It does not emit anything; flush does, in start
+// order. For empty IDs it pops the in-flight empty-id call off the stack so a
+// following empty-id delta/end can't attach to an already-closed call.
+func (collector *toolCallCollector) end(id string) {
+	if id == "" {
+		if len(collector.openEmptyID) > 0 {
+			closed := collector.openEmptyID[len(collector.openEmptyID)-1]
+			collector.openEmptyID = collector.openEmptyID[:len(collector.openEmptyID)-1]
+			// If a delta-opened call is closed before any start adopts it, drop
+			// the pending pointer so a later start can't attach to a closed call.
+			if closed == collector.pendingEmptyDelta {
+				collector.pendingEmptyDelta = ""
+			}
+		}
+	}
+}
+
+// resolveKey maps an event ID to its internal key. Empty IDs route to the most
+// recently started, not-yet-ended empty-id call.
+func (collector *toolCallCollector) resolveKey(id string) (string, bool) {
+	if id == "" {
+		if len(collector.openEmptyID) == 0 {
+			return "", false
+		}
+		return collector.openEmptyID[len(collector.openEmptyID)-1], true
+	}
+	if _, ok := collector.calls[id]; ok {
+		return id, true
+	}
+	return "", false
+}
+
+func (collector *toolCallCollector) ensure(key string, id string) *ToolCall {
+	if call, ok := collector.calls[key]; ok {
+		return call
+	}
+	call := &ToolCall{ID: id}
+	collector.calls[key] = call
+	collector.order = append(collector.order, key)
+	return call
+}
+
+// flush emits every collected call once, in start order. Malformed (nameless)
+// calls are dropped so the agent never dispatches an empty tool name.
+func (collector *toolCallCollector) flush(collected *CollectedStream) {
+	for _, key := range collector.order {
+		call, ok := collector.calls[key]
 		if !ok {
 			continue
 		}
-		collected.ToolCalls = append(collected.ToolCalls, *toolCall)
-		delete(pendingToolCalls, id)
+		delete(collector.calls, key)
+		if call.Name != "" {
+			collected.ToolCalls = append(collected.ToolCalls, *call)
+		} else {
+			collected.DroppedToolCalls++
+		}
 	}
+	collector.order = collector.order[:0]
+	collector.openEmptyID = collector.openEmptyID[:0]
+	collector.pendingEmptyDelta = ""
 }

--- a/internal/zeroruntime/order_test.go
+++ b/internal/zeroruntime/order_test.go
@@ -1,0 +1,80 @@
+package zeroruntime
+
+import (
+	"context"
+	"testing"
+)
+
+// Collected tool calls must follow model/start order, even when an
+// earlier-started call ends after a later-started one. Previously calls were
+// appended at End-event time, so a call that ended first jumped ahead of a
+// call that started first.
+func TestCollectStreamPreservesStartOrderRegardlessOfEndOrder(t *testing.T) {
+	events := make(chan StreamEvent, 16)
+	// call "a" starts first, "b" starts second, but "b" ends before "a".
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "a", ToolName: "first"}
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "b", ToolName: "second"}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "b", ArgumentsFragment: `{"k":"b"}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd, ToolCallID: "b"}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "a", ArgumentsFragment: `{"k":"a"}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd, ToolCallID: "a"}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if len(got.ToolCalls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d: %+v", len(got.ToolCalls), got.ToolCalls)
+	}
+	if got.ToolCalls[0].Name != "first" || got.ToolCalls[1].Name != "second" {
+		t.Fatalf("tool calls out of start order: %+v", got.ToolCalls)
+	}
+	if got.ToolCalls[0].Arguments != `{"k":"a"}` || got.ToolCalls[1].Arguments != `{"k":"b"}` {
+		t.Fatalf("arguments mismatched to calls: %+v", got.ToolCalls)
+	}
+}
+
+// Two distinct simultaneous calls that both arrive with an empty ToolCallID
+// must NOT collapse into one. Each start begins a new call; its delta/end map
+// to the in-flight (most recently started, not-yet-ended) empty-id call.
+func TestCollectStreamDoesNotMergeDistinctEmptyIDCalls(t *testing.T) {
+	events := make(chan StreamEvent, 16)
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolName: "alpha"}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ArgumentsFragment: `{"n":1}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd}
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolName: "beta"}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ArgumentsFragment: `{"n":2}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if len(got.ToolCalls) != 2 {
+		t.Fatalf("distinct empty-id calls collapsed: got %d: %+v", len(got.ToolCalls), got.ToolCalls)
+	}
+	if got.ToolCalls[0].Name != "alpha" || got.ToolCalls[0].Arguments != `{"n":1}` {
+		t.Fatalf("first empty-id call wrong: %+v", got.ToolCalls[0])
+	}
+	if got.ToolCalls[1].Name != "beta" || got.ToolCalls[1].Arguments != `{"n":2}` {
+		t.Fatalf("second empty-id call wrong: %+v", got.ToolCalls[1])
+	}
+}
+
+// A duplicate non-empty start for an already-open call must not overwrite its
+// name once set (some OpenAI-compatible backends re-emit the same index).
+func TestCollectStreamKeepsFirstNameOnDuplicateStart(t *testing.T) {
+	events := make(chan StreamEvent, 16)
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "a", ToolName: "read_file"}
+	events <- StreamEvent{Type: StreamEventToolCallStart, ToolCallID: "a", ToolName: ""}
+	events <- StreamEvent{Type: StreamEventToolCallDelta, ToolCallID: "a", ArgumentsFragment: `{"path":"x"}`}
+	events <- StreamEvent{Type: StreamEventToolCallEnd, ToolCallID: "a"}
+	events <- StreamEvent{Type: StreamEventDone}
+	close(events)
+
+	got := CollectStream(context.Background(), events)
+	if len(got.ToolCalls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %+v", len(got.ToolCalls), got.ToolCalls)
+	}
+	if got.ToolCalls[0].Name != "read_file" {
+		t.Fatalf("duplicate start overwrote name: %+v", got.ToolCalls[0])
+	}
+}

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -35,9 +35,28 @@ const (
 	StreamEventToolCallStart StreamEventType = "tool-call-start"
 	StreamEventToolCallDelta StreamEventType = "tool-call-delta"
 	StreamEventToolCallEnd   StreamEventType = "tool-call-end"
-	StreamEventUsage         StreamEventType = "usage"
-	StreamEventDone          StreamEventType = "done"
-	StreamEventError         StreamEventType = "error"
+	// StreamEventToolCallDropped signals the model attempted a tool call that
+	// was malformed (no usable name/id) and could not be dispatched. The agent
+	// uses this to ask the model to retry instead of silently ending the turn.
+	StreamEventToolCallDropped StreamEventType = "tool-call-dropped"
+	StreamEventUsage           StreamEventType = "usage"
+	StreamEventDone            StreamEventType = "done"
+	StreamEventError           StreamEventType = "error"
+)
+
+// Normalized terminal finish reasons for responses that did not end normally.
+// Providers map their native stop reasons onto these so consumers can detect a
+// truncated or filtered response regardless of which provider produced it. A
+// normal completion leaves the finish reason empty.
+const (
+	// FinishReasonLength means the response was truncated at the output token
+	// cap (OpenAI finish_reason=="length", Anthropic stop_reason=="max_tokens",
+	// Gemini finishReason=="MAX_TOKENS").
+	FinishReasonLength = "length"
+	// FinishReasonContentFilter means the response was withheld or cut off by a
+	// content/safety filter (OpenAI finish_reason=="content_filter",
+	// Gemini finishReason=="SAFETY").
+	FinishReasonContentFilter = "content_filter"
 )
 
 // ToolCall is a normalized assistant request to run a tool.
@@ -114,6 +133,11 @@ type StreamEvent struct {
 	ArgumentsFragment string
 	Usage             Usage
 	Error             string
+	// FinishReason carries the provider's normalized terminal stop reason when a
+	// response did not end normally (e.g. FinishReasonLength when the output hit
+	// the token cap, or FinishReasonContentFilter when it was filtered). It is
+	// empty for a normal completion. Providers set it on the terminal/done event.
+	FinishReason string
 }
 
 // CompletionRequest groups provider input messages and available tools.


### PR DESCRIPTION
## Module 1 of N — Streaming reliability

First reviewable slice of the runtime-core work, split out of the large integration branch (#101, now draft) so the team can review module-by-module. **Scope: `internal/zeroruntime` + `internal/providers` only.** Fully backward-compatible/additive — the rest of the tree builds unchanged against it.

### What's in it
- **SSE idle-timeout watchdog** across OpenAI / Anthropic / Gemini (reader goroutine + idle timer + ctx-cancel, via `providerio.ScanSSEDataWithContext`) — a stalled-but-open upstream no longer blocks the agent forever.
- **Hardened streamed tool-call assembly**: nameless/dropped tool calls are reported (`StreamEventToolCallDropped`) instead of silently lost; collected calls keep model/start order; distinct empty-id calls no longer merge.
- **Terminal finish/stop reason surfaced** (`CollectedStream.FinishReason` + `Truncated()`) so `length`/`content_filter` responses aren't mistaken for normal completions.
- **OpenAI**: requests `stream_options.include_usage` (token usage no longer silently 0); delegates error/redaction to `providerio` (503/529 classified as rate-limit); joins multi-line SSE `data:` continuations; wires `max_completion_tokens`.

### Testing
`go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/zeroruntime/ ./internal/providers/...` all green. No new dependencies; `go.mod` unchanged.

### Context
Part of decomposing #101 into reviewable PRs. Subsequent modules (model registry, sandbox, sessions, tools, agent loop, TUI, extensions) will follow one at a time after this merges. The subagent/`task` feature is intentionally **excluded** (separate developer's area).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming idle-timeout watchdog across providers
  * Finish-reason propagation on completion events (e.g., length/content-filter)
  * Emission of a dropped-tool-call event for malformed tool/function calls
  * Configurable max-token limit for OpenAI-compatible provider

* **Bug Fixes**
  * Improved stalled-stream detection and termination
  * Retry/backoff for transient OpenAI network errors
  * More robust handling of incomplete/duplicate tool-call fragments

* **Tests**
  * Extensive tests for idle timeouts, finish reasons, and tool-call behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->