### PR TITLE
Model registry: deprecation fallback, mode presets, reasoning-effort, alias patterns

### DIFF
--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -38,7 +38,69 @@ func DefaultModelEntries() []ModelEntry {
 		googleModel("gemini-2.5-flash", "Gemini 2.5 Flash", "gemini-2.5-flash", ModelStatusActive, []string{"google:gemini-2.5-flash", "gemini-flash"}, ContextLimits{ContextWindow: 1_048_576, MaxOutputTokens: 65_536}, ModelCost{InputPerMillion: 0.3, CachedInputPerMillion: 0.03, OutputPerMillion: 2.5}, []ModelCapability{ModelCapabilityVision, ModelCapabilityJSONMode, ModelCapabilityReasoning, ModelCapabilityLongContext}, standardReasoningEfforts(), "Google Flash model for low-latency coding interactions."),
 		googleModel("gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite", "gemini-2.5-flash-lite", ModelStatusActive, []string{"google:gemini-2.5-flash-lite", "gemini-flash-lite"}, ContextLimits{ContextWindow: 1_048_576, MaxOutputTokens: 65_536}, ModelCost{InputPerMillion: 0.1, CachedInputPerMillion: 0.01, OutputPerMillion: 0.4}, []ModelCapability{ModelCapabilityVision, ModelCapabilityJSONMode, ModelCapabilityReasoning, ModelCapabilityLongContext}, standardReasoningEfforts(), "Google low-cost Flash model for background routing and summaries."),
 	}
+	decorateModelDepth(entries)
 	return cloneModelEntries(entries)
+}
+
+// decorateModelDepth layers slice-3 registry-depth metadata (fuzzy match
+// patterns, default reasoning efforts, and deprecation fallbacks) onto the base
+// catalog entries. Kept separate from the constructor helpers so the core
+// catalog stays terse and the depth wiring is easy to audit.
+func decorateModelDepth(entries []ModelEntry) {
+	depth := map[string]struct {
+		defaultEffort ReasoningEffort
+		patterns      []string
+		deprecation   *DeprecationRule
+	}{
+		"claude-sonnet-4.5": {
+			defaultEffort: ReasoningEffortMedium,
+			patterns:      []string{`(?i)^sonnet[^a-z0-9]*4[.\s]?5$`},
+		},
+		"claude-opus-4.1": {
+			defaultEffort: ReasoningEffortHigh,
+			patterns:      []string{`(?i)^opus[^a-z0-9]*4[.\s]?1$`},
+		},
+		"claude-haiku-4.5": {
+			defaultEffort: ReasoningEffortLow,
+			patterns:      []string{`(?i)^haiku[^a-z0-9]*4[.\s]?5$`},
+		},
+		"gemini-2.5-pro": {
+			defaultEffort: ReasoningEffortMedium,
+			patterns:      []string{`(?i)^gemini[^a-z0-9]*pro$`},
+		},
+		"gemini-2.5-flash": {
+			defaultEffort: ReasoningEffortLow,
+		},
+		"gpt-4-turbo": {
+			deprecation: &DeprecationRule{
+				FallbackID: "gpt-4.1",
+				SoftDate:   "2025-04-14",
+				WarningMsg: "gpt-4-turbo is deprecated; using gpt-4.1 instead",
+			},
+		},
+		"claude-haiku-3.5": {
+			deprecation: &DeprecationRule{
+				FallbackID: "claude-haiku-4.5",
+				SoftDate:   "2025-10-01",
+				WarningMsg: "claude-haiku-3.5 is deprecated; using claude-haiku-4.5 instead",
+			},
+		},
+	}
+	for index := range entries {
+		extra, ok := depth[entries[index].ID]
+		if !ok {
+			continue
+		}
+		if extra.defaultEffort != "" {
+			entries[index].DefaultReasoningEffort = extra.defaultEffort
+		}
+		if len(extra.patterns) > 0 {
+			entries[index].MatchPatterns = append(entries[index].MatchPatterns, extra.patterns...)
+		}
+		if extra.deprecation != nil {
+			entries[index].Deprecation = extra.deprecation.Clone()
+		}
+	}
 }
 
 func (registry Registry) List(options ListOptions) []ModelEntry {
@@ -198,6 +260,8 @@ func cloneModelEntry(entry ModelEntry) ModelEntry {
 	entry.ReasoningEfforts = append([]ReasoningEffort{}, entry.ReasoningEfforts...)
 	entry.Capabilities = append([]ModelCapability{}, entry.Capabilities...)
 	entry.Aliases = append([]string{}, entry.Aliases...)
+	entry.MatchPatterns = append([]string{}, entry.MatchPatterns...)
+	entry.Deprecation = entry.Deprecation.Clone()
 	entry.Cost.Tiers = append([]ModelCostTier{}, entry.Cost.Tiers...)
 	entry.Cost.Notes = append([]string{}, entry.Cost.Notes...)
 	return entry

--- a/internal/modelregistry/catalog_test.go
+++ b/internal/modelregistry/catalog_test.go
@@ -146,6 +146,76 @@ func TestDefaultRegistryReasoningAndProviderAssertions(t *testing.T) {
 	}
 }
 
+func TestDefaultRegistryResolvesFuzzyMatchPatterns(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry returned error: %v", err)
+	}
+	cases := map[string]string{
+		"sonnet 4.5": "claude-sonnet-4.5",
+		"Sonnet 4.5": "claude-sonnet-4.5",
+		"opus 4.1":   "claude-opus-4.1",
+		"gemini pro": "gemini-2.5-pro",
+	}
+	for input, want := range cases {
+		model, ok := registry.Resolve(input)
+		if !ok || model.ID != want {
+			t.Fatalf("Resolve(%q) = %q/%v, want %q", input, model.ID, ok, want)
+		}
+	}
+}
+
+func TestDefaultRegistryDeprecatedModelsRedirect(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry returned error: %v", err)
+	}
+	cases := map[string]string{
+		"gpt-4-turbo":      "gpt-4.1",
+		"claude-haiku-3.5": "claude-haiku-4.5",
+	}
+	for input, want := range cases {
+		model, notice, ok := registry.ResolveWithFallback(input)
+		if !ok {
+			t.Fatalf("ResolveWithFallback(%q) failed", input)
+		}
+		if model.ID != want {
+			t.Fatalf("ResolveWithFallback(%q) = %q, want fallback %q", input, model.ID, want)
+		}
+		if notice == "" {
+			t.Fatalf("ResolveWithFallback(%q) should return a deprecation notice", input)
+		}
+	}
+}
+
+func TestDefaultRegistryReasoningModelsHaveDefaultEffort(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry returned error: %v", err)
+	}
+	for _, id := range []string{"claude-sonnet-4.5", "claude-opus-4.1", "gemini-2.5-pro"} {
+		model, err := registry.Require(id)
+		if err != nil {
+			t.Fatalf("Require(%q) returned error: %v", id, err)
+		}
+		if model.DefaultReasoningEffort == "" {
+			t.Fatalf("reasoning model %q should declare a default reasoning effort", id)
+		}
+		if !reasoningEffortAllowedIn(model.ReasoningEfforts, model.DefaultReasoningEffort) {
+			t.Fatalf("model %q default effort %q is not among supported efforts %v", id, model.DefaultReasoningEffort, model.ReasoningEfforts)
+		}
+	}
+}
+
+func reasoningEffortAllowedIn(efforts []ReasoningEffort, want ReasoningEffort) bool {
+	for _, effort := range efforts {
+		if effort == want {
+			return true
+		}
+	}
+	return false
+}
+
 func containsModelID(models []ModelEntry, id string) bool {
 	for _, model := range models {
 		if model.ID == id {

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -2,6 +2,7 @@ package modelregistry
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -83,11 +84,37 @@ type ModelEntry struct {
 	APIProviders     []ProviderKind
 	ContextLimits    ContextLimits
 	ReasoningEfforts []ReasoningEffort
-	Capabilities     ModelCapabilities
-	Cost             ModelCost
-	Status           ModelStatus
-	Aliases          []string
-	Description      string
+	// DefaultReasoningEffort is the effort used when the caller does not specify
+	// one (must be a member of ReasoningEfforts, or empty for non-reasoning models).
+	DefaultReasoningEffort ReasoningEffort
+	Capabilities           ModelCapabilities
+	Cost                   ModelCost
+	Status                 ModelStatus
+	Aliases                []string
+	// MatchPatterns are regular expressions that resolve fuzzy user input to this
+	// model (e.g. `sonnet[^a-z0-9]*4[.\s]?5` -> the canonical id).
+	MatchPatterns []string
+	// Deprecation, when set, redirects this model to a replacement.
+	Deprecation *DeprecationRule
+	Description string
+}
+
+// DeprecationRule describes how a deprecated model is phased out and what to use
+// instead. FallbackID is required; the date/warning fields are advisory.
+type DeprecationRule struct {
+	FallbackID string // model id to redirect to
+	SoftDate   string // ISO-8601: warn but keep working from this date
+	HardDate   string // ISO-8601: treat as fully retired from this date
+	WarningMsg string // user-facing notice
+}
+
+// Clone returns a deep copy of the rule (or nil).
+func (rule *DeprecationRule) Clone() *DeprecationRule {
+	if rule == nil {
+		return nil
+	}
+	copied := *rule
+	return &copied
 }
 
 func (model ModelEntry) Validate() error {
@@ -124,6 +151,26 @@ func (model ModelEntry) Validate() error {
 		if !ValidReasoningEffort(effort) {
 			return fmt.Errorf("unknown reasoning effort %q", effort)
 		}
+	}
+	if model.DefaultReasoningEffort != "" {
+		if !ValidReasoningEffort(model.DefaultReasoningEffort) {
+			return fmt.Errorf("unknown default reasoning effort %q", model.DefaultReasoningEffort)
+		}
+		// The default must be one the model actually supports, else
+		// EffectiveReasoningEffort would hand back an unsupported effort.
+		supported := false
+		for _, effort := range model.ReasoningEfforts {
+			if effort == model.DefaultReasoningEffort {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			return fmt.Errorf("default reasoning effort %q is not in the model's supported efforts", model.DefaultReasoningEffort)
+		}
+	}
+	if model.Deprecation != nil && strings.TrimSpace(model.Deprecation.FallbackID) == "" {
+		return fmt.Errorf("deprecation rule requires a fallback id")
 	}
 	if err := model.Cost.Validate(); err != nil {
 		return err
@@ -231,8 +278,14 @@ func (model ModelEntry) AllowsProvider(provider ProviderKind) bool {
 }
 
 type Registry struct {
-	entries map[string]ModelEntry
-	models  []ModelEntry
+	entries  map[string]ModelEntry
+	models   []ModelEntry
+	patterns []compiledMatch
+}
+
+type compiledMatch struct {
+	re      *regexp.Regexp
+	modelID string
 }
 
 func NewRegistry(entries []ModelEntry) (Registry, error) {
@@ -265,7 +318,29 @@ func NewRegistry(entries []ModelEntry) (Registry, error) {
 				return Registry{}, err
 			}
 		}
+		for _, pattern := range entry.MatchPatterns {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return Registry{}, fmt.Errorf("invalid match pattern %q for model %q: %w", pattern, entry.ID, err)
+			}
+			registry.patterns = append(registry.patterns, compiledMatch{re: re, modelID: clonedEntry.ID})
+		}
 		registry.models = append(registry.models, clonedEntry)
+	}
+	// Cross-entry validation (needs every model registered first): a deprecation
+	// rule's FallbackID must resolve to a real model, otherwise ResolveWithFallback
+	// would silently ignore the rule at runtime instead of failing loudly here.
+	for _, entry := range registry.models {
+		if entry.Deprecation == nil {
+			continue
+		}
+		fallbackID := strings.TrimSpace(entry.Deprecation.FallbackID)
+		if fallbackID == "" {
+			continue
+		}
+		if _, ok := registry.Get(fallbackID); !ok {
+			return Registry{}, fmt.Errorf("model %q deprecation fallback %q does not resolve to a known model", entry.ID, fallbackID)
+		}
 	}
 	return registry, nil
 }

--- a/internal/modelregistry/modes.go
+++ b/internal/modelregistry/modes.go
@@ -1,0 +1,104 @@
+package modelregistry
+
+import "strings"
+
+// Mode bundles a model selection, reasoning effort, agent-loop turn budget, and
+// an optional tool filter behind a single short name. Modes are presets that let
+// callers switch the whole agent profile (smart/deep/fast/...) with one flag or
+// command instead of tuning --model/--reasoning-effort/--max-turns by hand.
+//
+// Model holds a registry id or alias (resolved through Resolve/ResolveWithFallback
+// at apply time so deprecation fallbacks and fuzzy aliases stay honored). MaxTurns
+// of 0 means "leave the configured/default turn budget untouched". Effort of ""
+// means "let the model's effective default apply".
+type Mode struct {
+	Name        string
+	Description string
+	Model       string
+	Effort      ReasoningEffort
+	MaxTurns    int
+	// EnabledTools / DisabledTools optionally narrow the tool surface for the
+	// mode. Empty slices leave the existing tool selection untouched.
+	EnabledTools  []string
+	DisabledTools []string
+}
+
+// defaultModes is the canonical preset catalog. It is kept data-driven so the
+// CLI flag, the TUI command, and tests all read from one source of truth. Models
+// reference real registry ids (see catalog.go); efforts reference real
+// ReasoningEffort values.
+var defaultModes = []Mode{
+	{
+		Name:        "smart",
+		Description: "Balanced daily driver for high-quality agent work.",
+		Model:       "claude-sonnet-4.5",
+		Effort:      ReasoningEffortMedium,
+	},
+	{
+		Name:        "deep",
+		Description: "Hardest tasks: deep reasoning with a larger turn budget.",
+		Model:       "claude-opus-4.1",
+		Effort:      ReasoningEffortHigh,
+		MaxTurns:    50,
+	},
+	{
+		Name:        "fast",
+		Description: "Low-latency support for quick edits and summaries.",
+		Model:       "claude-haiku-4.5",
+		Effort:      ReasoningEffortLow,
+		MaxTurns:    15,
+	},
+	{
+		Name:        "large",
+		Description: "Long-context work over large inputs.",
+		Model:       "gemini-2.5-pro",
+		Effort:      ReasoningEffortMedium,
+	},
+	{
+		Name:        "precise",
+		Description: "Careful, high-effort reasoning for exacting changes.",
+		Model:       "claude-sonnet-4.5",
+		Effort:      ReasoningEffortHigh,
+	},
+}
+
+// Modes returns a copy of the preset catalog, preserving declaration order so
+// list output and help text stay stable.
+func Modes() []Mode {
+	modes := make([]Mode, len(defaultModes))
+	for index, mode := range defaultModes {
+		modes[index] = cloneMode(mode)
+	}
+	return modes
+}
+
+// LookupMode returns the preset registered under name (case-insensitive,
+// whitespace-trimmed). The second result reports whether a preset matched.
+func LookupMode(name string) (Mode, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "" {
+		return Mode{}, false
+	}
+	for _, mode := range defaultModes {
+		if mode.Name == normalized {
+			return cloneMode(mode), true
+		}
+	}
+	return Mode{}, false
+}
+
+// ModeNames returns the preset names in declaration order, handy for usage and
+// error messages that need to list the valid modes.
+func ModeNames() []string {
+	names := make([]string, len(defaultModes))
+	for index, mode := range defaultModes {
+		names[index] = mode.Name
+	}
+	return names
+}
+
+func cloneMode(mode Mode) Mode {
+	mode.EnabledTools = append([]string{}, mode.EnabledTools...)
+	mode.DisabledTools = append([]string{}, mode.DisabledTools...)
+	return mode
+}

--- a/internal/modelregistry/modes_test.go
+++ b/internal/modelregistry/modes_test.go
@@ -1,0 +1,89 @@
+package modelregistry
+
+import "testing"
+
+func TestLookupModeKnown(t *testing.T) {
+	for _, name := range []string{"smart", "deep", "fast", "large", "precise"} {
+		mode, ok := LookupMode(name)
+		if !ok {
+			t.Fatalf("LookupMode(%q) = _, false; want a registered mode", name)
+		}
+		if mode.Name != name {
+			t.Fatalf("LookupMode(%q).Name = %q; want %q", name, mode.Name, name)
+		}
+		if mode.Description == "" {
+			t.Fatalf("LookupMode(%q).Description is empty", name)
+		}
+		if mode.Model == "" {
+			t.Fatalf("LookupMode(%q).Model is empty", name)
+		}
+	}
+}
+
+func TestLookupModeIsCaseInsensitiveAndTrimmed(t *testing.T) {
+	mode, ok := LookupMode("  DEEP ")
+	if !ok {
+		t.Fatal("LookupMode(\"  DEEP \") = _, false; want match")
+	}
+	if mode.Name != "deep" {
+		t.Fatalf("LookupMode normalized name = %q; want deep", mode.Name)
+	}
+}
+
+func TestLookupModeUnknown(t *testing.T) {
+	for _, name := range []string{"", "   ", "turbo", "genius"} {
+		if _, ok := LookupMode(name); ok {
+			t.Fatalf("LookupMode(%q) = _, true; want false", name)
+		}
+	}
+}
+
+func TestModesReturnsIndependentCopies(t *testing.T) {
+	modes := Modes()
+	if len(modes) == 0 {
+		t.Fatal("Modes() returned no presets")
+	}
+	modes[0].Name = "mutated"
+	if again := Modes(); again[0].Name == "mutated" {
+		t.Fatal("Modes() should return defensive copies, not shared state")
+	}
+}
+
+func TestModeNamesMatchCatalogOrder(t *testing.T) {
+	names := ModeNames()
+	modes := Modes()
+	if len(names) != len(modes) {
+		t.Fatalf("ModeNames length %d != Modes length %d", len(names), len(modes))
+	}
+	for index := range names {
+		if names[index] != modes[index].Name {
+			t.Fatalf("ModeNames[%d] = %q; want %q", index, names[index], modes[index].Name)
+		}
+	}
+}
+
+func TestEveryModeResolvesToRealRegistryModel(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	for _, mode := range Modes() {
+		entry, ok := registry.Resolve(mode.Model)
+		if !ok {
+			t.Fatalf("mode %q references model %q that does not resolve in the registry", mode.Name, mode.Model)
+		}
+		if mode.Effort != "" {
+			if !ValidReasoningEffort(mode.Effort) {
+				t.Fatalf("mode %q has invalid effort %q", mode.Name, mode.Effort)
+			}
+			// The effort the mode requests should be honored by the resolved
+			// model (so the preset never silently downgrades on apply).
+			if effective := EffectiveReasoningEffort(entry, mode.Effort); effective != mode.Effort {
+				t.Fatalf("mode %q effort %q is not supported by %s (effective %q)", mode.Name, mode.Effort, entry.ID, effective)
+			}
+		}
+		if mode.MaxTurns < 0 {
+			t.Fatalf("mode %q has negative MaxTurns %d", mode.Name, mode.MaxTurns)
+		}
+	}
+}

--- a/internal/modelregistry/resolve.go
+++ b/internal/modelregistry/resolve.go
@@ -1,0 +1,66 @@
+package modelregistry
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Resolve maps user input to a model: exact id/api-model/alias first, then a
+// regex MatchPattern (e.g. "sonnet 4.5" -> the canonical id). It does NOT apply
+// deprecation fallbacks — use ResolveWithFallback for that.
+func (registry Registry) Resolve(input string) (ModelEntry, bool) {
+	if model, ok := registry.Get(input); ok {
+		return model, true
+	}
+	trimmed := strings.TrimSpace(input)
+	for _, pattern := range registry.patterns {
+		if pattern.re.MatchString(trimmed) {
+			return registry.Get(pattern.modelID)
+		}
+	}
+	return ModelEntry{}, false
+}
+
+// ResolveWithFallback resolves input (exact/alias/pattern) and, when the resolved
+// model is deprecated and declares a fallback, redirects to the replacement. The
+// returned notice is non-empty when a redirect happened or a soft-deprecation
+// warning applies, so callers can surface it to the user.
+func (registry Registry) ResolveWithFallback(input string) (ModelEntry, string, bool) {
+	model, ok := registry.Resolve(input)
+	if !ok {
+		return ModelEntry{}, "", false
+	}
+	if model.Status == ModelStatusDeprecated && model.Deprecation != nil && strings.TrimSpace(model.Deprecation.FallbackID) != "" {
+		if fallback, ok := registry.Get(model.Deprecation.FallbackID); ok {
+			notice := strings.TrimSpace(model.Deprecation.WarningMsg)
+			if notice == "" {
+				notice = fmt.Sprintf("%s is deprecated; using %s instead", model.ID, fallback.ID)
+			}
+			return fallback, notice, true
+		}
+	}
+	if model.Deprecation != nil && strings.TrimSpace(model.Deprecation.WarningMsg) != "" {
+		return model, strings.TrimSpace(model.Deprecation.WarningMsg), true
+	}
+	return model, "", true
+}
+
+// EffectiveReasoningEffort returns the effort to use for a model: the requested
+// value if the model supports it, otherwise the model's default (or first
+// supported, or none).
+func EffectiveReasoningEffort(model ModelEntry, requested ReasoningEffort) ReasoningEffort {
+	if requested != "" {
+		for _, effort := range model.ReasoningEfforts {
+			if effort == requested {
+				return requested
+			}
+		}
+	}
+	if model.DefaultReasoningEffort != "" {
+		return model.DefaultReasoningEffort
+	}
+	if len(model.ReasoningEfforts) > 0 {
+		return model.ReasoningEfforts[0]
+	}
+	return ReasoningEffortNone
+}

--- a/internal/modelregistry/resolve_test.go
+++ b/internal/modelregistry/resolve_test.go
@@ -1,0 +1,81 @@
+package modelregistry
+
+import "testing"
+
+func mkEntry(id, alias string) ModelEntry {
+	return ModelEntry{
+		ID: id, DisplayName: id, APIModel: id, Provider: ProviderAnthropic,
+		ContextLimits: ContextLimits{ContextWindow: 200000, MaxOutputTokens: 64000},
+		Capabilities:  ModelCapabilities{ModelCapabilityChat},
+		Status:        ModelStatusActive, Aliases: []string{alias},
+		Cost: ModelCost{
+			Currency: "USD", Unit: "per_1m_tokens",
+			InputPerMillion: 1, OutputPerMillion: 2,
+			Source: "test", SourceLastVerified: "2026-06-06",
+		},
+	}
+}
+
+func resolveTestRegistry(t *testing.T) Registry {
+	t.Helper()
+	sonnet := mkEntry("claude-sonnet-4-5", "sonnet-4.5")
+	sonnet.MatchPatterns = []string{`(?i)sonnet[^a-z0-9]*4[.\s]?5`}
+	sonnet.ReasoningEfforts = []ReasoningEffort{ReasoningEffortNone, ReasoningEffortLow, ReasoningEffortHigh}
+	sonnet.DefaultReasoningEffort = ReasoningEffortLow
+
+	old := mkEntry("claude-sonnet-4-0", "sonnet-4.0")
+	old.Status = ModelStatusDeprecated
+	old.Deprecation = &DeprecationRule{FallbackID: "claude-sonnet-4-5", WarningMsg: "sonnet-4-0 retired; use 4.5"}
+
+	reg, err := NewRegistry([]ModelEntry{sonnet, old})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return reg
+}
+
+func TestResolveRegexAlias(t *testing.T) {
+	reg := resolveTestRegistry(t)
+	for _, in := range []string{"claude-sonnet-4-5", "sonnet-4.5", "Sonnet 4.5", "sonnet4.5"} {
+		m, ok := reg.Resolve(in)
+		if !ok || m.ID != "claude-sonnet-4-5" {
+			t.Errorf("Resolve(%q) = %q,%v; want claude-sonnet-4-5", in, m.ID, ok)
+		}
+	}
+	if _, ok := reg.Resolve("totally-unknown"); ok {
+		t.Error("unknown input should not resolve")
+	}
+}
+
+func TestResolveWithFallbackRedirectsDeprecated(t *testing.T) {
+	reg := resolveTestRegistry(t)
+	m, notice, ok := reg.ResolveWithFallback("claude-sonnet-4-0")
+	if !ok || m.ID != "claude-sonnet-4-5" {
+		t.Fatalf("expected redirect to 4.5, got %q,%v", m.ID, ok)
+	}
+	if notice == "" {
+		t.Error("expected a deprecation notice")
+	}
+}
+
+func TestResolveWithFallbackActiveNoNotice(t *testing.T) {
+	reg := resolveTestRegistry(t)
+	m, notice, ok := reg.ResolveWithFallback("Sonnet 4.5")
+	if !ok || m.ID != "claude-sonnet-4-5" || notice != "" {
+		t.Fatalf("active model should resolve cleanly, got %q notice=%q", m.ID, notice)
+	}
+}
+
+func TestEffectiveReasoningEffort(t *testing.T) {
+	reg := resolveTestRegistry(t)
+	m, _ := reg.Get("claude-sonnet-4-5")
+	if got := EffectiveReasoningEffort(m, ReasoningEffortHigh); got != ReasoningEffortHigh {
+		t.Errorf("supported effort = %q; want high", got)
+	}
+	if got := EffectiveReasoningEffort(m, ReasoningEffortXHigh); got != ReasoningEffortLow {
+		t.Errorf("unsupported effort should fall back to default low, got %q", got)
+	}
+	if got := EffectiveReasoningEffort(m, ""); got != ReasoningEffortLow {
+		t.Errorf("empty effort should use default low, got %q", got)
+	}
+}


### PR DESCRIPTION
## Module 2 of N — Model registry

Second reviewable slice of the runtime-core split (off `main`, after #105 merged). **Scope: `internal/modelregistry` only** (7 files, ~556 lines incl. tests). Fully additive — the whole tree builds unchanged against it; no new deps.

### What's in it
- **Alias patterns**: regex `MatchPatterns` + pattern-based `Resolve` so models resolve from provider-qualified ids, short aliases, and patterns.
- **Deprecation + fallback**: `DeprecationRule{FallbackID, WarningMsg}`; `ResolveWithFallback` returns the active fallback model plus a user-facing notice for deprecated ids. `NewRegistry` validates that every `Deprecation.FallbackID` resolves to a real model — a misconfigured rule fails at startup instead of being silently ignored.
- **Reasoning effort**: per-model `ReasoningEfforts` + `DefaultReasoningEffort` (validated to be a member of the model's supported set) + `EffectiveReasoningEffort()`.
- **Mode presets** (`modes.go`): `smart`/`deep`/`fast`/`large`/`precise` → concrete model id + reasoning effort.

### Scope note
This is the registry-capability layer. The **CLI/agent adoption** of it — `--model` deprecation-fallback, the `--mode` flag, `-r/--reasoning-effort`, and the enhanced `zero models` table — lands in a **later module** so each PR stays reviewable. The new functions are exercised by the package's own tests (`resolve_test.go`, `modes_test.go`, `catalog_test.go`).

### Testing
`go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race ./internal/modelregistry/` all green.

Part of decomposing #101 (draft) into reviewable PRs; subagents excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added fuzzy pattern matching to resolve models from flexible user input formats
- Introduced model deprecation with automatic fallback redirects and user-friendly notices
- Added preset conversation modes (smart, deep, fast, large, precise) with predefined reasoning and tool settings
- Enhanced reasoning effort handling with configurable defaults and smart fallback selection

**Tests**
- Added comprehensive test coverage for model resolution, deprecation behavior, reasoning effort validation, and mode discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->