### PR TITLE
Add background task manager

### DIFF
--- a/internal/background/manager.go
+++ b/internal/background/manager.go
@@ -208,22 +208,62 @@ func (manager *Manager) Get(taskID string) (Task, bool) {
 func (manager *Manager) Kill(taskID string) error {
 	taskID = strings.TrimSpace(taskID)
 
+	pid, err := manager.killTarget(taskID)
+	if err != nil {
+		return err
+	}
+	if !manager.isRunningPID(taskID, pid) {
+		return nil
+	}
+	if err := manager.killProcess(pid); err != nil {
+		return fmt.Errorf("kill background task %s: %w", taskID, err)
+	}
+	return manager.markKilledIfStillRunning(taskID, pid)
+}
+
+func (manager *Manager) killTarget(taskID string) (int, error) {
 	manager.mu.Lock()
+	defer manager.mu.Unlock()
 	task, ok := manager.tasks[taskID]
-	manager.mu.Unlock()
+	if !ok {
+		return 0, fmt.Errorf("background task not found: %s", taskID)
+	}
+	if task.Status != StatusRunning {
+		return 0, fmt.Errorf("background task %s is %s", taskID, task.Status)
+	}
+	if task.PID <= 0 {
+		return 0, fmt.Errorf("background task %s has no pid", taskID)
+	}
+	return task.PID, nil
+}
+
+func (manager *Manager) isRunningPID(taskID string, pid int) bool {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[taskID]
+	return ok && task.Status == StatusRunning && task.PID == pid
+}
+
+func (manager *Manager) markKilledIfStillRunning(taskID string, pid int) error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[taskID]
 	if !ok {
 		return fmt.Errorf("background task not found: %s", taskID)
 	}
 	if task.Status != StatusRunning {
-		return fmt.Errorf("background task %s is %s", taskID, task.Status)
+		return nil
 	}
-	if task.PID <= 0 {
-		return fmt.Errorf("background task %s has no pid", taskID)
+	if task.PID != pid {
+		return fmt.Errorf("background task %s pid changed before kill completed", taskID)
 	}
-	if err := manager.killProcess(task.PID); err != nil {
-		return fmt.Errorf("kill background task %s: %w", taskID, err)
+	task.Status = StatusKilled
+	task.ExitCode = -1
+	if task.CompletedAt.IsZero() {
+		task.CompletedAt = manager.now()
 	}
-	return manager.UpdateStatus(taskID, StatusKilled, -1)
+	manager.tasks[taskID] = task
+	return nil
 }
 
 func (manager *Manager) OutputPath(taskID string) string {

--- a/internal/background/manager.go
+++ b/internal/background/manager.go
@@ -1,0 +1,309 @@
+package background
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Status string
+
+const (
+	StatusRunning   Status = "running"
+	StatusCompleted Status = "completed"
+	StatusError     Status = "error"
+	StatusKilled    Status = "killed"
+)
+
+type Task struct {
+	ID             string    `json:"id"`
+	Type           string    `json:"type"`
+	SpecialistName string    `json:"specialistName,omitempty"`
+	Description    string    `json:"description,omitempty"`
+	ParentID       string    `json:"parentId,omitempty"`
+	PID            int       `json:"pid,omitempty"`
+	Status         Status    `json:"status"`
+	OutputFile     string    `json:"outputFile"`
+	StartedAt      time.Time `json:"startedAt"`
+	CompletedAt    time.Time `json:"completedAt,omitempty"`
+	ExitCode       int       `json:"exitCode,omitempty"`
+}
+
+type RegisterInput struct {
+	TaskID         string
+	Type           string
+	SpecialistName string
+	Description    string
+	ParentID       string
+	PID            int
+	OutputFile     string
+}
+
+type ManagerOptions struct {
+	RootDir     string
+	Env         map[string]string
+	Now         func() time.Time
+	KillProcess func(pid int) error
+}
+
+type Manager struct {
+	mu          sync.Mutex
+	tasks       map[string]Task
+	rootDir     string
+	now         func() time.Time
+	killProcess func(pid int) error
+}
+
+var taskIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`)
+
+func NewManager(rootDir string) (*Manager, error) {
+	return NewManagerWithOptions(ManagerOptions{RootDir: rootDir})
+}
+
+func NewManagerWithOptions(options ManagerOptions) (*Manager, error) {
+	rootDir := strings.TrimSpace(options.RootDir)
+	if rootDir == "" {
+		rootDir = DefaultRoot(options.Env)
+	}
+	rootDir = filepath.Clean(rootDir)
+	if err := os.MkdirAll(rootDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create background task directory: %w", err)
+	}
+
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	killProcess := options.KillProcess
+	if killProcess == nil {
+		killProcess = terminateProcess
+	}
+	return &Manager{tasks: map[string]Task{}, rootDir: rootDir, now: now, killProcess: killProcess}, nil
+}
+
+func DefaultRoot(env map[string]string) string {
+	dataHome := strings.TrimSpace(envValue(env, "XDG_DATA_HOME"))
+	home := strings.TrimSpace(envValue(env, "HOME"))
+	if home == "" {
+		if userHome, err := os.UserHomeDir(); err == nil {
+			home = userHome
+		}
+	}
+	base := dataHome
+	if base == "" {
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "zero", "background")
+}
+
+func (manager *Manager) RootDir() string {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return manager.rootDir
+}
+
+func (manager *Manager) Register(input RegisterInput) (string, error) {
+	taskID := strings.TrimSpace(input.TaskID)
+	if !validTaskID(taskID) {
+		return "", fmt.Errorf("invalid background task id %q", input.TaskID)
+	}
+	taskType := strings.TrimSpace(input.Type)
+	if taskType == "" {
+		return "", fmt.Errorf("background task %s requires a type", taskID)
+	}
+	if input.PID < 0 {
+		return "", fmt.Errorf("invalid background task pid %d", input.PID)
+	}
+	outputFile, err := manager.outputFile(taskID, input.OutputFile)
+	if err != nil {
+		return "", err
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if _, exists := manager.tasks[taskID]; exists {
+		return "", fmt.Errorf("background task already registered: %s", taskID)
+	}
+	if err := os.MkdirAll(filepath.Dir(outputFile), 0o700); err != nil {
+		return "", fmt.Errorf("create background task output directory: %w", err)
+	}
+	file, err := os.OpenFile(outputFile, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return "", fmt.Errorf("background task output already exists: %s", outputFile)
+		}
+		return "", fmt.Errorf("create background task output file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("close background task output file: %w", err)
+	}
+
+	manager.tasks[taskID] = Task{
+		ID:             taskID,
+		Type:           taskType,
+		SpecialistName: strings.TrimSpace(input.SpecialistName),
+		Description:    strings.TrimSpace(input.Description),
+		ParentID:       strings.TrimSpace(input.ParentID),
+		PID:            input.PID,
+		Status:         StatusRunning,
+		OutputFile:     outputFile,
+		StartedAt:      manager.now(),
+	}
+	return outputFile, nil
+}
+
+func (manager *Manager) SetPID(taskID string, pid int) error {
+	taskID = strings.TrimSpace(taskID)
+	if pid <= 0 {
+		return fmt.Errorf("invalid background task pid %d", pid)
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("background task not found: %s", taskID)
+	}
+	task.PID = pid
+	manager.tasks[taskID] = task
+	return nil
+}
+
+func (manager *Manager) UpdateStatus(taskID string, status Status, exitCode int) error {
+	taskID = strings.TrimSpace(taskID)
+	if !validStatus(status) {
+		return fmt.Errorf("invalid background task status %q", status)
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("background task not found: %s", taskID)
+	}
+	task.Status = status
+	task.ExitCode = exitCode
+	if status == StatusRunning {
+		task.CompletedAt = time.Time{}
+	} else if task.CompletedAt.IsZero() {
+		task.CompletedAt = manager.now()
+	}
+	manager.tasks[taskID] = task
+	return nil
+}
+
+func (manager *Manager) Get(taskID string) (Task, bool) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[strings.TrimSpace(taskID)]
+	return task, ok
+}
+
+func (manager *Manager) Kill(taskID string) error {
+	taskID = strings.TrimSpace(taskID)
+
+	manager.mu.Lock()
+	task, ok := manager.tasks[taskID]
+	manager.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("background task not found: %s", taskID)
+	}
+	if task.Status != StatusRunning {
+		return fmt.Errorf("background task %s is %s", taskID, task.Status)
+	}
+	if task.PID <= 0 {
+		return fmt.Errorf("background task %s has no pid", taskID)
+	}
+	if err := manager.killProcess(task.PID); err != nil {
+		return fmt.Errorf("kill background task %s: %w", taskID, err)
+	}
+	return manager.UpdateStatus(taskID, StatusKilled, -1)
+}
+
+func (manager *Manager) OutputPath(taskID string) string {
+	task, ok := manager.Get(taskID)
+	if !ok {
+		return ""
+	}
+	return task.OutputFile
+}
+
+func (manager *Manager) ListByParent(parentID string) []Task {
+	parentID = strings.TrimSpace(parentID)
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	tasks := []Task{}
+	for _, task := range manager.tasks {
+		if task.ParentID == parentID {
+			tasks = append(tasks, task)
+		}
+	}
+	sortTasks(tasks)
+	return tasks
+}
+
+func (manager *Manager) List() []Task {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	tasks := make([]Task, 0, len(manager.tasks))
+	for _, task := range manager.tasks {
+		tasks = append(tasks, task)
+	}
+	sortTasks(tasks)
+	return tasks
+}
+
+func (manager *Manager) outputFile(taskID string, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return filepath.Join(manager.rootDir, taskID+".ndjson"), nil
+	}
+	path := requested
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(manager.rootDir, path)
+	}
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(manager.rootDir, path)
+	if err != nil {
+		return "", fmt.Errorf("resolve background task output file: %w", err)
+	}
+	if rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("background task output file must be inside %s", manager.rootDir)
+	}
+	return path, nil
+}
+
+func validTaskID(taskID string) bool {
+	return taskIDPattern.MatchString(strings.TrimSpace(taskID))
+}
+
+func validStatus(status Status) bool {
+	switch status {
+	case StatusRunning, StatusCompleted, StatusError, StatusKilled:
+		return true
+	default:
+		return false
+	}
+}
+
+func sortTasks(tasks []Task) {
+	sort.SliceStable(tasks, func(left int, right int) bool {
+		if tasks[left].StartedAt.Equal(tasks[right].StartedAt) {
+			return tasks[left].ID < tasks[right].ID
+		}
+		return tasks[left].StartedAt.After(tasks[right].StartedAt)
+	})
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -149,6 +149,34 @@ func TestManagerDoesNotMarkKilledWhenKillFails(t *testing.T) {
 	}
 }
 
+func TestManagerKillDoesNotClobberCompletedTask(t *testing.T) {
+	now := sequenceClock(
+		time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 9, 0, 1, 0, time.UTC),
+	)
+	var manager *Manager
+	manager, err := NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		Now:     now,
+		KillProcess: func(pid int) error {
+			return manager.UpdateStatus("task", StatusCompleted, 0)
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task", Type: "specialist", PID: 42}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if err := manager.Kill("task"); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+	task, ok := manager.Get("task")
+	if !ok || task.Status != StatusCompleted || task.ExitCode != 0 {
+		t.Fatalf("Kill clobbered completed task: %#v", task)
+	}
+}
+
 func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
 	got := DefaultRoot(map[string]string{
 		"XDG_DATA_HOME": "/tmp/zero-data",

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -46,7 +47,7 @@ func TestManagerRegistersListsAndKillsTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected output file to exist: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("output file permissions = %v, want 0600", info.Mode().Perm())
 	}
 	if err := manager.SetPID("task_1", 1234); err != nil {

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -1,0 +1,172 @@
+package background
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManagerRegistersListsAndKillsTask(t *testing.T) {
+	now := sequenceClock(
+		time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 9, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 7, 9, 0, 2, 0, time.UTC),
+	)
+	killed := []int{}
+	manager, err := NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		Now:     now,
+		KillProcess: func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+
+	outputFile, err := manager.Register(RegisterInput{
+		TaskID:         "task_1",
+		Type:           "specialist",
+		SpecialistName: "worker",
+		Description:    "Read the release notes",
+		ParentID:       "parent",
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if outputFile != filepath.Join(manager.RootDir(), "task_1.ndjson") {
+		t.Fatalf("output file = %q", outputFile)
+	}
+	info, err := os.Stat(outputFile)
+	if err != nil {
+		t.Fatalf("expected output file to exist: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("output file permissions = %v, want 0600", info.Mode().Perm())
+	}
+	if err := manager.SetPID("task_1", 1234); err != nil {
+		t.Fatalf("SetPID returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task_2", Type: "specialist", SpecialistName: "explorer", ParentID: "parent", PID: 5678}); err != nil {
+		t.Fatalf("Register second task returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "other", Type: "specialist", ParentID: "different-parent"}); err != nil {
+		t.Fatalf("Register other task returned error: %v", err)
+	}
+
+	task, ok := manager.Get("task_1")
+	if !ok {
+		t.Fatalf("Get did not find task")
+	}
+	if task.ID != "task_1" || task.PID != 1234 || task.Status != StatusRunning || task.SpecialistName != "worker" {
+		t.Fatalf("unexpected task: %#v", task)
+	}
+
+	parentTasks := manager.ListByParent("parent")
+	gotIDs := []string{}
+	for _, task := range parentTasks {
+		gotIDs = append(gotIDs, task.ID)
+	}
+	if !reflect.DeepEqual(gotIDs, []string{"task_2", "task_1"}) {
+		t.Fatalf("ListByParent ids = %#v, want newest first", gotIDs)
+	}
+
+	if err := manager.Kill("task_1"); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+	if !reflect.DeepEqual(killed, []int{1234}) {
+		t.Fatalf("killed pids = %#v", killed)
+	}
+	task, ok = manager.Get("task_1")
+	if !ok || task.Status != StatusKilled || task.ExitCode != -1 || task.CompletedAt.IsZero() {
+		t.Fatalf("killed task status was not recorded: %#v", task)
+	}
+}
+
+func TestManagerRejectsUnsafeTaskIDsAndOutputPaths(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+
+	for _, taskID := range []string{"", "../escape", "bad/name", `bad\name`} {
+		if _, err := manager.Register(RegisterInput{TaskID: taskID, Type: "specialist"}); err == nil {
+			t.Fatalf("Register accepted unsafe task id %q", taskID)
+		}
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "safe", Type: "specialist", OutputFile: "../escape.ndjson"}); err == nil || !strings.Contains(err.Error(), "inside") {
+		t.Fatalf("Register unsafe output file error = %v", err)
+	}
+}
+
+func TestManagerRejectsDuplicateAndMissingTasks(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task", Type: "specialist"}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task", Type: "specialist"}); err == nil || !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("duplicate Register error = %v", err)
+	}
+	if err := manager.SetPID("missing", 1); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("missing SetPID error = %v", err)
+	}
+	if err := manager.UpdateStatus("missing", StatusCompleted, 0); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("missing UpdateStatus error = %v", err)
+	}
+	if err := manager.Kill("missing"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("missing Kill error = %v", err)
+	}
+}
+
+func TestManagerDoesNotMarkKilledWhenKillFails(t *testing.T) {
+	manager, err := NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		KillProcess: func(pid int) error {
+			return errors.New("denied")
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task", Type: "specialist", PID: 42}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if err := manager.Kill("task"); err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("Kill error = %v", err)
+	}
+	task, ok := manager.Get("task")
+	if !ok || task.Status != StatusRunning || !task.CompletedAt.IsZero() {
+		t.Fatalf("failed kill mutated task: %#v", task)
+	}
+}
+
+func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
+	got := DefaultRoot(map[string]string{
+		"XDG_DATA_HOME": "/tmp/zero-data",
+		"HOME":          "/home/example",
+	})
+	want := filepath.Join("/tmp/zero-data", "zero", "background")
+	if got != want {
+		t.Fatalf("DefaultRoot = %q, want %q", got, want)
+	}
+}
+
+func sequenceClock(times ...time.Time) func() time.Time {
+	index := 0
+	return func() time.Time {
+		if index >= len(times) {
+			return times[len(times)-1]
+		}
+		next := times[index]
+		index++
+		return next
+	}
+}

--- a/internal/background/process_posix.go
+++ b/internal/background/process_posix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package background
+
+import (
+	"os"
+	"syscall"
+)
+
+func terminateProcess(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Signal(syscall.SIGTERM)
+}

--- a/internal/background/process_windows.go
+++ b/internal/background/process_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package background
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func terminateProcess(pid int) error {
+	if err := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run(); err == nil {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}


### PR DESCRIPTION
Summary:
- adds internal/background Manager for registering and tracking background specialist tasks
- stores safe per-task NDJSON output paths under the Zero data directory
- supports status updates, parent filtering, and cross-platform task termination hooks

Self-review:
- intentionally internal-only; no CLI or user-facing Task tools are wired in this PR
- Get/List return task snapshots instead of internal pointers
- task IDs and custom output paths are validated to avoid path traversal

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/background
- GOCACHE=/tmp/zero-go-cache go test ./...
- GOCACHE=/tmp/zero-go-cache GOOS=windows go test -c ./internal/background
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background task manager: register tasks, track status/PID, per-task output files, parent-child listing, and cross-platform termination behavior.

* **Bug Fixes & Safety**
  * Validates task IDs and output paths to prevent escapes/collisions; exclusive output-file creation and stable ordering by start time then ID.

* **Tests**
  * Comprehensive tests for registration, permissions, ordering, kill behavior, error cases, and default-root resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->