### PR TITLE
Add specialist extends resolution

### DIFF
--- a/internal/specialist/format.go
+++ b/internal/specialist/format.go
@@ -37,6 +37,9 @@ func FormatShow(manifest Manifest) string {
 	if manifest.Metadata.Model != "" {
 		lines = append(lines, "model: "+manifest.Metadata.Model)
 	}
+	if manifest.Metadata.Extends != "" {
+		lines = append(lines, "extends: "+manifest.Metadata.Extends)
+	}
 	if manifest.Metadata.ReasoningEffort != "" {
 		lines = append(lines, "reasoning effort: "+manifest.Metadata.ReasoningEffort)
 	}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -25,6 +25,7 @@ const (
 type Metadata struct {
 	Name            string   `json:"name"`
 	Description     string   `json:"description"`
+	Extends         string   `json:"extends,omitempty"`
 	Model           string   `json:"model,omitempty"`
 	ReasoningEffort string   `json:"reasoningEffort,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
@@ -43,6 +44,7 @@ type Manifest struct {
 type Summary struct {
 	Name            string   `json:"name"`
 	Description     string   `json:"description"`
+	Extends         string   `json:"extends,omitempty"`
 	Model           string   `json:"model,omitempty"`
 	ReasoningEffort string   `json:"reasoningEffort,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
@@ -72,6 +74,7 @@ var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
 var knownMetadataKeys = map[string]bool{
 	"name":            true,
 	"description":     true,
+	"extends":         true,
 	"model":           true,
 	"reasoningEffort": true,
 	"tools":           true,
@@ -139,7 +142,12 @@ func Load(options LoadOptions) (LoadResult, error) {
 	warnings = append(warnings, userWarnings...)
 	manifests = append(manifests, userManifests...)
 
-	return LoadResult{Paths: paths, Specialists: mergeByName(manifests), Warnings: warnings}, nil
+	merged := mergeByName(manifests)
+	resolved, err := resolveExtends(merged)
+	if err != nil {
+		return LoadResult{}, err
+	}
+	return LoadResult{Paths: paths, Specialists: resolved, Warnings: warnings}, nil
 }
 
 func Find(result LoadResult, name string) (Manifest, bool) {
@@ -158,6 +166,7 @@ func Summaries(manifests []Manifest) []Summary {
 		summaries = append(summaries, Summary{
 			Name:            manifest.Metadata.Name,
 			Description:     manifest.Metadata.Description,
+			Extends:         manifest.Metadata.Extends,
 			Model:           manifest.Metadata.Model,
 			ReasoningEffort: manifest.Metadata.ReasoningEffort,
 			Tools:           append([]string(nil), manifest.Metadata.Tools...),
@@ -190,11 +199,12 @@ func ParseMarkdown(content string) (Manifest, error) {
 		}
 	}
 	if manifest.SystemPrompt == "" {
-		if manifest.Metadata.Description == "" {
+		if manifest.Metadata.Description != "" {
+			manifest.SystemPrompt = manifest.Metadata.Description
+			manifest.Warnings = append(manifest.Warnings, "using description as system prompt")
+		} else if manifest.Metadata.Extends == "" {
 			return Manifest{}, fmt.Errorf("system prompt cannot be empty")
 		}
-		manifest.SystemPrompt = manifest.Metadata.Description
-		manifest.Warnings = append(manifest.Warnings, "using description as system prompt")
 	}
 	if err := Validate(&manifest); err != nil {
 		return Manifest{}, err
@@ -205,6 +215,7 @@ func ParseMarkdown(content string) (Manifest, error) {
 func Validate(manifest *Manifest) error {
 	manifest.Metadata.Name = strings.TrimSpace(manifest.Metadata.Name)
 	manifest.Metadata.Description = strings.TrimSpace(manifest.Metadata.Description)
+	manifest.Metadata.Extends = strings.TrimSpace(manifest.Metadata.Extends)
 	manifest.Metadata.Model = strings.TrimSpace(manifest.Metadata.Model)
 	manifest.Metadata.ReasoningEffort = strings.TrimSpace(manifest.Metadata.ReasoningEffort)
 	if manifest.Metadata.Name == "" {
@@ -213,8 +224,11 @@ func Validate(manifest *Manifest) error {
 	if !namePattern.MatchString(manifest.Metadata.Name) {
 		return fmt.Errorf("invalid specialist name %q: use lowercase letters, numbers, and dashes", manifest.Metadata.Name)
 	}
-	if manifest.Metadata.Description == "" {
+	if manifest.Metadata.Description == "" && manifest.Metadata.Extends == "" {
 		return fmt.Errorf("specialist %q requires a description", manifest.Metadata.Name)
+	}
+	if manifest.Metadata.Extends != "" && !namePattern.MatchString(manifest.Metadata.Extends) {
+		return fmt.Errorf("invalid base specialist name %q: use lowercase letters, numbers, and dashes", manifest.Metadata.Extends)
 	}
 	if manifest.Metadata.Model != "" {
 		registry, err := modelregistry.DefaultRegistry()
@@ -341,6 +355,8 @@ func manifestFromRaw(raw map[string]any) (Manifest, error) {
 			metadata.Name = stringValue(value)
 		case "description":
 			metadata.Description = stringValue(value)
+		case "extends":
+			metadata.Extends = stringValue(value)
 		case "model":
 			metadata.Model = stringValue(value)
 		case "reasoningEffort":
@@ -482,5 +498,85 @@ func mergeByName(manifests []Manifest) []Manifest {
 	for _, name := range names {
 		merged = append(merged, byName[name])
 	}
+	return merged
+}
+
+func resolveExtends(manifests []Manifest) ([]Manifest, error) {
+	byName := map[string]Manifest{}
+	for _, manifest := range manifests {
+		byName[manifest.Metadata.Name] = manifest
+	}
+	cache := map[string]Manifest{}
+	resolved := make([]Manifest, 0, len(manifests))
+	for _, manifest := range manifests {
+		item, err := resolveManifestExtends(manifest.Metadata.Name, byName, cache, map[string]bool{})
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, item)
+	}
+	return resolved, nil
+}
+
+func resolveManifestExtends(name string, byName map[string]Manifest, cache map[string]Manifest, stack map[string]bool) (Manifest, error) {
+	if manifest, ok := cache[name]; ok {
+		return manifest, nil
+	}
+	manifest, ok := byName[name]
+	if !ok {
+		return Manifest{}, fmt.Errorf("specialist %q not found", name)
+	}
+	if stack[name] {
+		return Manifest{}, fmt.Errorf("cycle detected in specialist extends chain at %q", name)
+	}
+	stack[name] = true
+	defer delete(stack, name)
+
+	baseName := strings.TrimSpace(manifest.Metadata.Extends)
+	if baseName == "" {
+		cache[name] = manifest
+		return manifest, nil
+	}
+	base, ok := byName[baseName]
+	if !ok {
+		return Manifest{}, fmt.Errorf("base specialist %q for %q not found", baseName, manifest.Metadata.Name)
+	}
+	base, err := resolveManifestExtends(base.Metadata.Name, byName, cache, stack)
+	if err != nil {
+		return Manifest{}, err
+	}
+	merged := mergeExtends(base, manifest)
+	if err := Validate(&merged); err != nil {
+		return Manifest{}, err
+	}
+	cache[name] = merged
+	return merged, nil
+}
+
+func mergeExtends(base Manifest, child Manifest) Manifest {
+	merged := child
+	if merged.Metadata.Description == "" {
+		merged.Metadata.Description = base.Metadata.Description
+	}
+	if merged.Metadata.Model == "" {
+		merged.Metadata.Model = base.Metadata.Model
+	}
+	if merged.Metadata.ReasoningEffort == "" {
+		merged.Metadata.ReasoningEffort = base.Metadata.ReasoningEffort
+	}
+	if len(merged.Metadata.Tools) == 0 {
+		merged.Metadata.Tools = append([]string(nil), base.Metadata.Tools...)
+	} else {
+		merged.Metadata.Tools = append([]string(nil), merged.Metadata.Tools...)
+	}
+	switch {
+	case strings.TrimSpace(base.SystemPrompt) == "":
+		merged.SystemPrompt = strings.TrimSpace(merged.SystemPrompt)
+	case strings.TrimSpace(merged.SystemPrompt) == "":
+		merged.SystemPrompt = strings.TrimSpace(base.SystemPrompt)
+	default:
+		merged.SystemPrompt = strings.TrimSpace(base.SystemPrompt) + "\n\n" + strings.TrimSpace(merged.SystemPrompt)
+	}
+	merged.Warnings = append(append([]string(nil), base.Warnings...), child.Warnings...)
 	return merged
 }

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -14,6 +14,7 @@ func TestParseMarkdownValidatesAndResolvesTools(t *testing.T) {
 	manifest, err := ParseMarkdown(`---
 name: code-review
 description: Reviews a change
+extends: worker
 tools: [read-only, apply_patch]
 unknown: kept
 ---
@@ -23,6 +24,9 @@ Review the diff.`)
 	}
 	if manifest.Metadata.Name != "code-review" || manifest.SystemPrompt != "Review the diff." {
 		t.Fatalf("unexpected manifest: %#v", manifest)
+	}
+	if manifest.Metadata.Extends != "worker" {
+		t.Fatalf("Extends = %q, want worker", manifest.Metadata.Extends)
 	}
 	for _, want := range []string{"apply_patch", "glob", "grep", "list_directory", "read_file"} {
 		if !contains(manifest.ResolvedTools, want) {
@@ -240,6 +244,94 @@ User conflict prompt.`)
 	}
 }
 
+func TestLoadResolvesExtendsChainsAndChildOverrides(t *testing.T) {
+	root := t.TempDir()
+	userDir := filepath.Join(root, "user")
+	writeManifest(t, filepath.Join(userDir, "base.md"), `---
+name: base
+description: Base specialist
+tools: [execute]
+---
+Base prompt.`)
+	writeManifest(t, filepath.Join(userDir, "reviewer.md"), `---
+name: reviewer
+description: Reviews code
+extends: base
+---
+Reviewer prompt.`)
+	writeManifest(t, filepath.Join(userDir, "strict-reviewer.md"), `---
+name: strict-reviewer
+description: Reviews strictly
+extends: reviewer
+tools: [read-only]
+---
+Strict prompt.`)
+
+	result, err := Load(LoadOptions{Paths: Paths{UserDir: userDir}})
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	reviewer, ok := Find(result, "reviewer")
+	if !ok {
+		t.Fatal("reviewer not found")
+	}
+	if reviewer.SystemPrompt != "Base prompt.\n\nReviewer prompt." {
+		t.Fatalf("reviewer prompt = %q", reviewer.SystemPrompt)
+	}
+	if reviewer.Metadata.Extends != "base" || !contains(reviewer.ResolvedTools, "bash") {
+		t.Fatalf("reviewer did not inherit base metadata/tools: %#v", reviewer)
+	}
+
+	strict, ok := Find(result, "strict-reviewer")
+	if !ok {
+		t.Fatal("strict-reviewer not found")
+	}
+	if strict.SystemPrompt != "Base prompt.\n\nReviewer prompt.\n\nStrict prompt." {
+		t.Fatalf("strict prompt = %q", strict.SystemPrompt)
+	}
+	if strict.Metadata.Extends != "reviewer" || contains(strict.ResolvedTools, "bash") || !contains(strict.ResolvedTools, "read_file") {
+		t.Fatalf("strict reviewer should override inherited tools with read-only: %#v", strict)
+	}
+}
+
+func TestLoadRejectsMissingExtendsBaseAndCycles(t *testing.T) {
+	t.Run("missing base", func(t *testing.T) {
+		userDir := filepath.Join(t.TempDir(), "user")
+		writeManifest(t, filepath.Join(userDir, "child.md"), `---
+name: child
+description: Child specialist
+extends: ghost
+---
+Child prompt.`)
+
+		_, err := Load(LoadOptions{Paths: Paths{UserDir: userDir}})
+		if err == nil || !strings.Contains(err.Error(), `base specialist "ghost" for "child" not found`) {
+			t.Fatalf("expected missing base error, got %v", err)
+		}
+	})
+
+	t.Run("cycle", func(t *testing.T) {
+		userDir := filepath.Join(t.TempDir(), "user")
+		writeManifest(t, filepath.Join(userDir, "a.md"), `---
+name: a
+description: A specialist
+extends: b
+---
+A prompt.`)
+		writeManifest(t, filepath.Join(userDir, "b.md"), `---
+name: b
+description: B specialist
+extends: a
+---
+B prompt.`)
+
+		_, err := Load(LoadOptions{Paths: Paths{UserDir: userDir}})
+		if err == nil || !strings.Contains(err.Error(), "cycle detected in specialist extends chain") {
+			t.Fatalf("expected cycle error, got %v", err)
+		}
+	})
+}
+
 func TestLoadSkipsBadFilesAndSymlinksWithWarnings(t *testing.T) {
 	root := t.TempDir()
 	userDir := filepath.Join(root, "user")
@@ -301,13 +393,17 @@ func TestKnownToolNamesMatchCoreRegistry(t *testing.T) {
 
 func TestFormatListUsesSpecialistTerminology(t *testing.T) {
 	result := LoadResult{Specialists: []Manifest{{
-		Metadata: Metadata{Name: "worker", Description: "Does work"},
+		Metadata: Metadata{Name: "worker", Description: "Does work", Extends: "base"},
 		Location: LocationBuiltin,
 		FilePath: "(builtin)",
 	}}}
 	output := FormatList(result)
 	if !strings.Contains(output, "Zero Specialists") || !strings.Contains(output, "worker [builtin]") {
 		t.Fatalf("unexpected list output: %s", output)
+	}
+	show := FormatShow(result.Specialists[0])
+	if !strings.Contains(show, "extends: base") {
+		t.Fatalf("show output missing extends: %s", show)
 	}
 }
 


### PR DESCRIPTION
Summary:
- adds extends frontmatter support to specialist manifests and JSON summaries
- resolves inherited specialist chains after built-in/project/user precedence is known
- merges prompts base-first, lets child fields win, and lets child tools replace inherited tools
- rejects missing base specialists and extends cycles during load

Self-review:
- intentionally no new user command surface; existing zero specialist show now prints extends when present
- keeps Load consumers receiving fully resolved manifests before later BuildArgs/Task execution work
- tests cover transitive inheritance, child tool overrides, missing bases, and cycles

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist
- GOCACHE=/tmp/zero-go-cache go test ./internal/cli
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Specialists can now extend/inherit from other specialists, automatically inheriting properties like model configuration, tools, and reasoning effort.
  * System prompts are intelligently combined when extending.

* **Improvements**
  * Circular dependencies in specialist inheritance chains are now detected and prevented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->