### PR TITLE
Add specialist execution foundation

### DIFF
--- a/internal/specialist/envelope.go
+++ b/internal/specialist/envelope.go
@@ -1,0 +1,46 @@
+package specialist
+
+import (
+	"fmt"
+	"strings"
+)
+
+func WrapSystemPrompt(name string, systemPrompt string, prompt string, description string) string {
+	var builder strings.Builder
+	builder.WriteString("# Specialist Invocation\n\n")
+	fmt.Fprintf(&builder, "Specialist: %s\n", strings.TrimSpace(name))
+	if trimmed := strings.TrimSpace(description); trimmed != "" {
+		fmt.Fprintf(&builder, "Task description: %s\n", trimmed)
+	}
+	builder.WriteString("\n")
+	builder.WriteString("You are a specialized sub-agent invoked by another Zero agent.\n")
+	builder.WriteString("Stay strictly within the assigned task. Do not broaden scope or start unrelated work.\n")
+	builder.WriteString("Complete the task, report concrete outcomes, and stop when done.\n\n")
+	if trimmed := strings.TrimSpace(systemPrompt); trimmed != "" {
+		builder.WriteString("## Specialist Instructions\n\n")
+		builder.WriteString(trimmed)
+		builder.WriteString("\n\n")
+	}
+	builder.WriteString("## Assigned Task\n\n")
+	builder.WriteString(strings.TrimSpace(prompt))
+	builder.WriteString("\n\n")
+	builder.WriteString("## Reporting\n\n")
+	builder.WriteString("- Summarize actions taken and outcomes.\n")
+	builder.WriteString("- Mention blockers, uncertainty, or follow-up only when relevant.\n")
+	builder.WriteString("- Return the requested result without extra commentary.\n")
+	return strings.TrimSpace(builder.String())
+}
+
+func WrapResumePrompt(prompt string) string {
+	return strings.TrimSpace(strings.Join([]string{
+		"# Follow-up Instructions",
+		"",
+		strings.TrimSpace(prompt),
+		"",
+		"## Reporting",
+		"",
+		"- Continue the existing specialist session.",
+		"- Summarize new actions and outcomes.",
+		"- Stop when the follow-up is complete.",
+	}, "\n"))
+}

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -44,8 +44,9 @@ type BuildResumeArgsInput struct {
 }
 
 type BuildArgsResult struct {
-	Args       []string
-	SessionID  string
+	Args      []string
+	SessionID string
+	// PromptFile is created for large prompts; callers own cleanup after exec finishes.
 	PromptFile string
 }
 
@@ -60,6 +61,7 @@ func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error
 	if err != nil {
 		return BuildArgsResult{}, err
 	}
+	sessionID = strings.TrimSpace(sessionID)
 	if !sessions.ValidSessionID(sessionID) {
 		return BuildArgsResult{}, fmt.Errorf("invalid specialist session id %q", sessionID)
 	}

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -1,0 +1,182 @@
+package specialist
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+const (
+	sessionTagSpecialist     = "specialist"
+	promptFileThresholdBytes = 4 * 1024
+)
+
+type NewSessionIDFunc func() (string, error)
+type WritePromptFileFunc func(prompt string) (string, error)
+
+type Executor struct {
+	NewSessionID      NewSessionIDFunc
+	WritePromptFile   WritePromptFileFunc
+	PromptFileMaxSize int
+}
+
+type BuildArgsInput struct {
+	Manifest              Manifest
+	Prompt                string
+	ParentSessionID       string
+	ParentToolUseID       string
+	ParentModel           string
+	ParentReasoningEffort string
+	CurrentDepth          int
+	Description           string
+}
+
+type BuildResumeArgsInput struct {
+	SessionID    string
+	Prompt       string
+	CurrentDepth int
+}
+
+type BuildArgsResult struct {
+	Args       []string
+	SessionID  string
+	PromptFile string
+}
+
+func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error) {
+	if input.CurrentDepth < 0 {
+		return BuildArgsResult{}, fmt.Errorf("current depth cannot be negative")
+	}
+	if strings.TrimSpace(input.Prompt) == "" {
+		return BuildArgsResult{}, fmt.Errorf("specialist prompt is required")
+	}
+	sessionID, err := executor.newSessionID()
+	if err != nil {
+		return BuildArgsResult{}, err
+	}
+	if !sessions.ValidSessionID(sessionID) {
+		return BuildArgsResult{}, fmt.Errorf("invalid specialist session id %q", sessionID)
+	}
+	wrappedPrompt := WrapSystemPrompt(input.Manifest.Metadata.Name, input.Manifest.SystemPrompt, input.Prompt, input.Description)
+	promptArgs, promptFile, err := executor.buildPromptArgs(wrappedPrompt)
+	if err != nil {
+		return BuildArgsResult{}, err
+	}
+
+	args := []string{"exec", "--init-session-id", sessionID}
+	args = append(args, promptArgs...)
+	args = appendModelArgs(args, input.Manifest, input.ParentModel, input.ParentReasoningEffort)
+	args = append(args, "--auto", "high", "--output-format", "stream-json")
+	if len(input.Manifest.ResolvedTools) > 0 {
+		args = append(args, "--enabled-tools", strings.Join(input.Manifest.ResolvedTools, ","))
+	}
+	args = append(args, "--depth", strconv.Itoa(input.CurrentDepth+1), "--tag", sessionTagSpecialist)
+	if parentSessionID := strings.TrimSpace(input.ParentSessionID); parentSessionID != "" {
+		args = append(args, "--calling-session-id", parentSessionID)
+	}
+	if parentToolUseID := strings.TrimSpace(input.ParentToolUseID); parentToolUseID != "" {
+		args = append(args, "--calling-tool-use-id", parentToolUseID)
+	}
+	if description := strings.TrimSpace(input.Description); description != "" {
+		args = append(args, "--session-title", strings.TrimSpace(input.Manifest.Metadata.Name)+": "+description)
+	}
+	return BuildArgsResult{Args: args, SessionID: sessionID, PromptFile: promptFile}, nil
+}
+
+func (executor Executor) BuildResumeArgs(input BuildResumeArgsInput) (BuildArgsResult, error) {
+	sessionID := strings.TrimSpace(input.SessionID)
+	if sessionID == "" {
+		return BuildArgsResult{}, fmt.Errorf("resume session id is required")
+	}
+	if !sessions.ValidSessionID(sessionID) {
+		return BuildArgsResult{}, fmt.Errorf("invalid resume session id %q", sessionID)
+	}
+	if input.CurrentDepth < 0 {
+		return BuildArgsResult{}, fmt.Errorf("current depth cannot be negative")
+	}
+	if strings.TrimSpace(input.Prompt) == "" {
+		return BuildArgsResult{}, fmt.Errorf("specialist prompt is required")
+	}
+	promptArgs, promptFile, err := executor.buildPromptArgs(WrapResumePrompt(input.Prompt))
+	if err != nil {
+		return BuildArgsResult{}, err
+	}
+	args := []string{"exec", "--resume", sessionID}
+	args = append(args, promptArgs...)
+	args = append(args, "--auto", "high", "--output-format", "stream-json")
+	args = append(args, "--depth", strconv.Itoa(input.CurrentDepth+1), "--tag", sessionTagSpecialist)
+	return BuildArgsResult{Args: args, SessionID: sessionID, PromptFile: promptFile}, nil
+}
+
+func appendModelArgs(args []string, manifest Manifest, parentModel string, parentReasoningEffort string) []string {
+	resolvedModel := strings.TrimSpace(manifest.Metadata.Model)
+	if resolvedModel == "" {
+		resolvedModel = strings.TrimSpace(parentModel)
+	}
+	if resolvedModel != "" {
+		args = append(args, "--model", resolvedModel)
+	}
+
+	reasoningEffort := strings.TrimSpace(manifest.Metadata.ReasoningEffort)
+	if reasoningEffort == "" && strings.TrimSpace(manifest.Metadata.Model) == "" {
+		reasoningEffort = strings.TrimSpace(parentReasoningEffort)
+	}
+	if reasoningEffort != "" {
+		args = append(args, "--reasoning-effort", reasoningEffort)
+	}
+	return args
+}
+
+func (executor Executor) buildPromptArgs(prompt string) ([]string, string, error) {
+	threshold := executor.PromptFileMaxSize
+	if threshold <= 0 {
+		threshold = promptFileThresholdBytes
+	}
+	if len([]byte(prompt)) <= threshold {
+		return []string{prompt}, "", nil
+	}
+	path, err := executor.writePromptFile(prompt)
+	if err != nil {
+		return nil, "", err
+	}
+	return []string{"--file", path}, path, nil
+}
+
+func (executor Executor) newSessionID() (string, error) {
+	if executor.NewSessionID != nil {
+		return executor.NewSessionID()
+	}
+	random := make([]byte, 12)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("create specialist session id: %w", err)
+	}
+	return "specialist_" + hex.EncodeToString(random), nil
+}
+
+func (executor Executor) writePromptFile(prompt string) (string, error) {
+	if executor.WritePromptFile != nil {
+		return executor.WritePromptFile(prompt)
+	}
+	return writePromptFile(prompt)
+}
+
+func writePromptFile(prompt string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "zero-specialist-")
+	if err != nil {
+		return "", fmt.Errorf("create specialist prompt temp dir: %w", err)
+	}
+	if err := os.Chmod(tmpDir, 0o700); err != nil {
+		return "", fmt.Errorf("secure specialist prompt temp dir: %w", err)
+	}
+	promptPath := filepath.Join(tmpDir, "prompt.md")
+	if err := os.WriteFile(promptPath, []byte(prompt), 0o600); err != nil {
+		return "", fmt.Errorf("write specialist prompt file: %w", err)
+	}
+	return promptPath, nil
+}

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -1,0 +1,193 @@
+package specialist
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBuildArgsCreatesFreshSpecialistExecInvocation(t *testing.T) {
+	executor := Executor{
+		NewSessionID: func() (string, error) { return "child_session", nil },
+	}
+	manifest := Manifest{
+		Metadata: Metadata{
+			Name:            "reviewer",
+			Description:     "Reviews code",
+			Model:           "claude-sonnet-4.5",
+			ReasoningEffort: "high",
+		},
+		SystemPrompt:  "Review carefully.",
+		ResolvedTools: []string{"grep", "read_file"},
+	}
+
+	result, err := executor.BuildArgs(BuildArgsInput{
+		Manifest:              manifest,
+		Prompt:                "Review this patch",
+		ParentSessionID:       "parent_session",
+		ParentToolUseID:       "toolu_123",
+		ParentModel:           "gpt-4.1",
+		ParentReasoningEffort: "medium",
+		CurrentDepth:          1,
+		Description:           "Auth diff",
+	})
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	if result.SessionID != "child_session" || result.PromptFile != "" {
+		t.Fatalf("unexpected result metadata: %#v", result)
+	}
+	wantArgs := []string{
+		"exec", "--init-session-id", "child_session",
+		result.Args[3],
+		"--model", "claude-sonnet-4.5",
+		"--reasoning-effort", "high",
+		"--auto", "high",
+		"--output-format", "stream-json",
+		"--enabled-tools", "grep,read_file",
+		"--depth", "2",
+		"--tag", "specialist",
+		"--calling-session-id", "parent_session",
+		"--calling-tool-use-id", "toolu_123",
+		"--session-title", "reviewer: Auth diff",
+	}
+	if !reflect.DeepEqual(result.Args, wantArgs) {
+		t.Fatalf("args mismatch\ngot:  %#v\nwant: %#v", result.Args, wantArgs)
+	}
+	prompt := result.Args[3]
+	for _, want := range []string{"Specialist: reviewer", "Task description: Auth diff", "Review carefully.", "Review this patch"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("wrapped prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestBuildArgsInheritsParentModelAndReasoning(t *testing.T) {
+	executor := Executor{NewSessionID: func() (string, error) { return "child", nil }}
+	manifest := Manifest{
+		Metadata:      Metadata{Name: "worker", Description: "Works"},
+		SystemPrompt:  "Do work.",
+		ResolvedTools: []string{"read_file"},
+	}
+
+	result, err := executor.BuildArgs(BuildArgsInput{
+		Manifest:              manifest,
+		Prompt:                "Do the thing",
+		ParentModel:           "gpt-4.1",
+		ParentReasoningEffort: "medium",
+	})
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	if !containsSequence(result.Args, []string{"--model", "gpt-4.1"}) {
+		t.Fatalf("args missing inherited model: %#v", result.Args)
+	}
+	if !containsSequence(result.Args, []string{"--reasoning-effort", "medium"}) {
+		t.Fatalf("args missing inherited reasoning effort: %#v", result.Args)
+	}
+}
+
+func TestBuildArgsWritesLargePromptFile(t *testing.T) {
+	root := t.TempDir()
+	var writtenPrompt string
+	executor := Executor{
+		NewSessionID:      func() (string, error) { return "child", nil },
+		PromptFileMaxSize: 16,
+		WritePromptFile: func(prompt string) (string, error) {
+			writtenPrompt = prompt
+			path := filepath.Join(root, "prompt.md")
+			return path, os.WriteFile(path, []byte(prompt), 0o600)
+		},
+	}
+
+	result, err := executor.BuildArgs(BuildArgsInput{
+		Manifest: Manifest{
+			Metadata:     Metadata{Name: "worker", Description: "Works"},
+			SystemPrompt: strings.Repeat("system ", 10),
+		},
+		Prompt: "Do the large thing",
+	})
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	if result.PromptFile != filepath.Join(root, "prompt.md") {
+		t.Fatalf("PromptFile = %q", result.PromptFile)
+	}
+	if !reflect.DeepEqual(result.Args[:5], []string{"exec", "--init-session-id", "child", "--file", result.PromptFile}) {
+		t.Fatalf("prompt file args = %#v", result.Args[:5])
+	}
+	if !strings.Contains(writtenPrompt, "Do the large thing") {
+		t.Fatalf("written prompt missing task: %s", writtenPrompt)
+	}
+}
+
+func TestBuildResumeArgsUsesExistingSession(t *testing.T) {
+	result, err := (Executor{}).BuildResumeArgs(BuildResumeArgsInput{
+		SessionID:    "child_session",
+		Prompt:       "Follow up",
+		CurrentDepth: 2,
+	})
+	if err != nil {
+		t.Fatalf("BuildResumeArgs returned error: %v", err)
+	}
+	wantPrefix := []string{"exec", "--resume", "child_session"}
+	if !reflect.DeepEqual(result.Args[:3], wantPrefix) {
+		t.Fatalf("resume args prefix = %#v", result.Args[:3])
+	}
+	if !containsSequence(result.Args, []string{"--auto", "high"}) ||
+		!containsSequence(result.Args, []string{"--output-format", "stream-json"}) ||
+		!containsSequence(result.Args, []string{"--depth", "3"}) ||
+		!containsSequence(result.Args, []string{"--tag", "specialist"}) {
+		t.Fatalf("resume args missing required flags: %#v", result.Args)
+	}
+	if !strings.Contains(result.Args[3], "Follow-up Instructions") || !strings.Contains(result.Args[3], "Follow up") {
+		t.Fatalf("resume prompt not wrapped correctly: %s", result.Args[3])
+	}
+}
+
+func TestBuildArgsRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input BuildArgsInput
+		want  string
+	}{
+		{name: "negative depth", input: BuildArgsInput{Prompt: "hi", CurrentDepth: -1}, want: "depth"},
+		{name: "empty prompt", input: BuildArgsInput{CurrentDepth: 0}, want: "prompt"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := (Executor{}).BuildArgs(tc.input)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("BuildArgs error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildArgsRejectsInvalidSessionIDs(t *testing.T) {
+	_, err := (Executor{NewSessionID: func() (string, error) { return "../escape", nil }}).BuildArgs(BuildArgsInput{
+		Prompt: "hi",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid specialist session id") {
+		t.Fatalf("BuildArgs error = %v", err)
+	}
+
+	_, err = (Executor{}).BuildResumeArgs(BuildResumeArgsInput{
+		SessionID: "../escape",
+		Prompt:    "hi",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid resume session id") {
+		t.Fatalf("BuildResumeArgs error = %v", err)
+	}
+}
+
+func containsSequence(values []string, sequence []string) bool {
+	for index := 0; index+len(sequence) <= len(values); index++ {
+		if reflect.DeepEqual(values[index:index+len(sequence)], sequence) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -183,6 +183,21 @@ func TestBuildArgsRejectsInvalidSessionIDs(t *testing.T) {
 	}
 }
 
+func TestBuildArgsNormalizesGeneratedSessionID(t *testing.T) {
+	result, err := (Executor{
+		NewSessionID: func() (string, error) { return " child_session ", nil },
+	}).BuildArgs(BuildArgsInput{Prompt: "hi"})
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	if result.SessionID != "child_session" {
+		t.Fatalf("SessionID = %q, want child_session", result.SessionID)
+	}
+	if !containsSequence(result.Args, []string{"--init-session-id", "child_session"}) {
+		t.Fatalf("args missing normalized session id: %#v", result.Args)
+	}
+}
+
 func containsSequence(values []string, sequence []string) bool {
 	for index := 0; index+len(sequence) <= len(values); index++ {
 		if reflect.DeepEqual(values[index:index+len(sequence)], sequence) {

--- a/internal/specialist/streamer.go
+++ b/internal/specialist/streamer.go
@@ -1,0 +1,121 @@
+package specialist
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type StreamResult struct {
+	Events    []streamjson.Event
+	SessionID string
+	Text      string
+	Tools     []string
+	Errors    []string
+	Status    string
+	ExitCode  int
+}
+
+func ParseStream(reader io.Reader) ([]streamjson.Event, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	events := []streamjson.Event{}
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event streamjson.Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			return nil, fmt.Errorf("parse stream-json line %d: %w", lineNumber, err)
+		}
+		if event.Type == "" {
+			return nil, fmt.Errorf("parse stream-json line %d: type is required", lineNumber)
+		}
+		events = append(events, event)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read stream-json output: %w", err)
+	}
+	return events, nil
+}
+
+func SummarizeStream(events []streamjson.Event, processExitCode int) StreamResult {
+	result := StreamResult{Events: append([]streamjson.Event(nil), events...), ExitCode: processExitCode}
+	textParts := []string{}
+	finalText := ""
+	seenTools := map[string]bool{}
+	for _, event := range events {
+		if result.SessionID == "" && strings.TrimSpace(event.SessionID) != "" {
+			result.SessionID = strings.TrimSpace(event.SessionID)
+		}
+		switch event.Type {
+		case streamjson.EventText:
+			textParts = append(textParts, event.Delta)
+		case streamjson.EventFinal:
+			finalText = event.Text
+		case streamjson.EventToolCall:
+			if name := strings.TrimSpace(event.Name); name != "" && !seenTools[name] {
+				seenTools[name] = true
+				result.Tools = append(result.Tools, name)
+			}
+		case streamjson.EventError:
+			message := strings.TrimSpace(event.Message)
+			if message == "" {
+				message = strings.TrimSpace(event.Code)
+			}
+			if message != "" {
+				result.Errors = append(result.Errors, message)
+			}
+		case streamjson.EventRunEnd:
+			result.Status = strings.TrimSpace(event.Status)
+			if event.ExitCode != nil {
+				result.ExitCode = *event.ExitCode
+			}
+		}
+	}
+	if finalText != "" {
+		result.Text = strings.TrimSpace(finalText)
+	} else {
+		result.Text = strings.TrimSpace(strings.Join(textParts, ""))
+	}
+	return result
+}
+
+func BuildFinalResult(events []streamjson.Event, stderrOutput string, processExitCode int) tools.Result {
+	summary := SummarizeStream(events, processExitCode)
+	hasErrors := len(summary.Errors) > 0 || summary.ExitCode != 0
+	if summary.Status != "" && summary.Status != "success" && summary.Status != "ok" {
+		hasErrors = true
+	}
+	if !hasErrors {
+		output := summary.Text
+		if summary.SessionID != "" {
+			output = "session_id: " + summary.SessionID + "\n" + output
+		}
+		return tools.Result{Status: tools.StatusOK, Output: strings.TrimSpace(output)}
+	}
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "Subagent failed (exit %d)\n", summary.ExitCode)
+	if len(summary.Errors) > 0 {
+		fmt.Fprintf(&builder, "errors: %s\n", strings.Join(summary.Errors, "; "))
+	}
+	if stderr := strings.TrimSpace(stderrOutput); stderr != "" {
+		fmt.Fprintf(&builder, "stderr:\n%s\n", stderr)
+	}
+	if len(summary.Tools) > 0 {
+		fmt.Fprintf(&builder, "tools executed: %s\n", strings.Join(summary.Tools, ", "))
+	}
+	if text := strings.TrimSpace(summary.Text); text != "" {
+		fmt.Fprintf(&builder, "\n%s\n", text)
+	}
+	return tools.Result{Status: tools.StatusError, Output: strings.TrimSpace(builder.String())}
+}

--- a/internal/specialist/streamer_test.go
+++ b/internal/specialist/streamer_test.go
@@ -1,0 +1,82 @@
+package specialist
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestParseStreamAndBuildFinalResultSuccess(t *testing.T) {
+	events, err := ParseStream(strings.NewReader(strings.Join([]string{
+		`{"schemaVersion":1,"type":"run_start","runId":"run_1","sessionId":"child","cwd":"/repo"}`,
+		`{"schemaVersion":1,"type":"text","runId":"run_1","delta":"part "}`,
+		`{"schemaVersion":1,"type":"text","runId":"run_1","delta":"one"}`,
+		`{"schemaVersion":1,"type":"tool_call","runId":"run_1","id":"call_1","name":"grep"}`,
+		`{"schemaVersion":1,"type":"final","runId":"run_1","text":"done"}`,
+		`{"schemaVersion":1,"type":"run_end","runId":"run_1","status":"success","exitCode":0}`,
+		"",
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseStream returned error: %v", err)
+	}
+
+	summary := SummarizeStream(events, 0)
+	if summary.SessionID != "child" || summary.Text != "done" || summary.ExitCode != 0 || len(summary.Tools) != 1 || summary.Tools[0] != "grep" {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+	result := BuildFinalResult(events, "", 0)
+	if result.Status != tools.StatusOK || result.Output != "session_id: child\ndone" {
+		t.Fatalf("unexpected final result: %#v", result)
+	}
+}
+
+func TestBuildFinalResultUsesTextDeltasWhenFinalMissing(t *testing.T) {
+	events, err := ParseStream(strings.NewReader(strings.Join([]string{
+		`{"schemaVersion":1,"type":"run_start","runId":"run_1","sessionId":"child"}`,
+		`{"schemaVersion":1,"type":"text","runId":"run_1","delta":"hello"}`,
+		`{"schemaVersion":1,"type":"text","runId":"run_1","delta":" world"}`,
+		"",
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseStream returned error: %v", err)
+	}
+	result := BuildFinalResult(events, "", 0)
+	if result.Status != tools.StatusOK || result.Output != "session_id: child\nhello world" {
+		t.Fatalf("unexpected final result: %#v", result)
+	}
+}
+
+func TestBuildFinalResultErrorIncludesDiagnostics(t *testing.T) {
+	events, err := ParseStream(strings.NewReader(strings.Join([]string{
+		`{"schemaVersion":1,"type":"run_start","runId":"run_1","sessionId":"child"}`,
+		`{"schemaVersion":1,"type":"tool_call","runId":"run_1","id":"call_1","name":"bash"}`,
+		`{"schemaVersion":1,"type":"error","runId":"run_1","code":"provider_error","message":"model failed"}`,
+		`{"schemaVersion":1,"type":"run_end","runId":"run_1","status":"error","exitCode":3}`,
+		"",
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseStream returned error: %v", err)
+	}
+	result := BuildFinalResult(events, "stderr text", 0)
+	if result.Status != tools.StatusError {
+		t.Fatalf("Status = %s, want error", result.Status)
+	}
+	for _, want := range []string{"Subagent failed (exit 3)", "model failed", "stderr text", "tools executed: bash"} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("error output missing %q:\n%s", want, result.Output)
+		}
+	}
+}
+
+func TestParseStreamRejectsInvalidLines(t *testing.T) {
+	_, err := ParseStream(strings.NewReader(`{"schemaVersion":1,"runId":"run_1"}` + "\n"))
+	if err == nil || !strings.Contains(err.Error(), "type is required") {
+		t.Fatalf("expected missing type error, got %v", err)
+	}
+
+	_, err = ParseStream(strings.NewReader(`not-json` + "\n"))
+	if err == nil || !strings.Contains(err.Error(), "parse stream-json line 1") {
+		t.Fatalf("expected json parse error, got %v", err)
+	}
+}


### PR DESCRIPTION
Summary:
- adds specialist prompt envelopes for fresh and resumed child runs
- adds Executor arg builders for fresh and resumed zero exec invocations
- supports generated child session IDs, prompt-file fallback, model/reasoning inheritance, resolved tool allowlists, depth/tag metadata, parent session/tool linkage, and session titles
- adds stream-json parsing/summarization and final tools.Result mapping for child output/error diagnostics

Self-review:
- intentionally does not wire the user-facing Task tool or spawn child processes yet
- keeps this as the bridge between resolved manifests and the later runtime executor
- validates generated/resume session IDs before handing args to zero exec

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist
- GOCACHE=/tmp/zero-go-cache go test ./...
- GOCACHE=/tmp/zero-go-cache GOOS=windows go test -c ./internal/specialist
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specialist session management with automatic, normalized session IDs and resume support.
  * Secure handling of large prompts with automatic file-based offloading when needed.
  * Constructed system and follow-up prompt wrappers for clearer specialist instructions.
  * Stream processing of specialist output into summarized results (text deltas, tools used, errors, exit status).
  * Stronger input validation and clearer error reporting for malformed or invalid inputs.

* **Tests**
  * Added comprehensive tests covering execution args, resume behavior, prompt offloading, stream parsing, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->