### PR TITLE
Session checkpoints & safe rewind: content-addressed blobs, atomic restore, file locking

### DIFF
--- a/internal/sessions/checkpoint.go
+++ b/internal/sessions/checkpoint.go
@@ -76,19 +76,23 @@ func (store *Store) CaptureToolCheckpoint(sessionID, workspaceRoot, tool string,
 	}
 	defer unlock()
 
-	payload, ok := store.SnapshotForCheckpoint(sessionID, workspaceRoot, tool, paths)
+	payload, ok := store.snapshotForCheckpoint(sessionID, workspaceRoot, tool, paths)
 	if !ok {
 		return Event{}, nil
 	}
 	return store.appendEventLocked(sessionID, AppendEventInput{Type: EventSessionCheckpoint, Payload: payload})
 }
 
-// SnapshotForCheckpoint reads and stores the before-mutation blobs for paths and
-// returns the checkpoint payload WITHOUT appending an event. Callers that batch
-// session events (e.g. the TUI) snapshot here — before the mutation runs — then
-// append the EventSessionCheckpoint themselves. Returns ok=false when there is
-// nothing to record (disabled, no paths, or no capturable files).
-func (store *Store) SnapshotForCheckpoint(sessionID, workspaceRoot, tool string, paths []string) (CheckpointPayload, bool) {
+// snapshotForCheckpoint reads and stores the before-mutation blobs for paths and
+// returns the checkpoint payload WITHOUT appending an event. It is intentionally
+// package-private: the blob writes and the referencing EventSessionCheckpoint
+// must be committed atomically under the same session lock, which only its sole
+// caller CaptureToolCheckpoint guarantees. A snapshot-only entry point exposed to
+// external callers would let blobs be written that a concurrent
+// pruneOrphanBlobs/ApplyRewind could delete before the event is recorded.
+// Returns ok=false when there is nothing to record (disabled, no paths, or no
+// capturable files).
+func (store *Store) snapshotForCheckpoint(sessionID, workspaceRoot, tool string, paths []string) (CheckpointPayload, bool) {
 	if !CheckpointsEnabled() || len(paths) == 0 {
 		return CheckpointPayload{}, false
 	}
@@ -96,11 +100,26 @@ func (store *Store) SnapshotForCheckpoint(sessionID, workspaceRoot, tool string,
 	files := make([]CheckpointFile, 0, len(paths))
 	for _, rel := range paths {
 		entry := CheckpointFile{Path: rel}
-		abs := filepath.Join(workspaceRoot, rel)
+		// Confine every capture target to the workspace using the SAME guard the
+		// restore path uses (EvalSymlinks-resolved, no "../" escape). A target that
+		// does not resolve inside the workspace is Skipped — never read into a blob,
+		// and never recorded as Absent (which would delete it on rewind).
+		abs, ok := resolveWithinWorkspace(workspaceRoot, rel)
+		if !ok {
+			entry.Skipped = true
+			files = append(files, entry)
+			continue
+		}
 		info, statErr := os.Stat(abs)
 		if statErr != nil {
-			// Treat anything we cannot stat as absent (new file) — restore deletes it.
-			entry.Absent = true
+			if os.IsNotExist(statErr) {
+				// Genuinely new file — restore deletes it.
+				entry.Absent = true
+			} else {
+				// Permission / IO / symlink-loop errors must NOT be rewound as a
+				// delete; record them as skipped so restore leaves the file alone.
+				entry.Skipped = true
+			}
 			files = append(files, entry)
 			continue
 		}

--- a/internal/sessions/checkpoint.go
+++ b/internal/sessions/checkpoint.go
@@ -1,0 +1,317 @@
+package sessions
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+)
+
+// CheckpointsDir is the per-session subdirectory holding content-addressed blobs.
+const CheckpointsDir = "checkpoints"
+
+const defaultMaxCheckpointBytes = 5 << 20 // 5 MiB
+
+// CheckpointFile records the before-mutation state of one workspace file.
+type CheckpointFile struct {
+	Path    string `json:"path"`
+	Blob    string `json:"blob,omitempty"`    // sha256 of prior content, "" if absent/skipped
+	Absent  bool   `json:"absent,omitempty"`  // file did not exist before (restore -> delete)
+	Skipped bool   `json:"skipped,omitempty"` // exceeded size cap; not recoverable
+	Bytes   int    `json:"bytes,omitempty"`
+	Mode    uint32 `json:"mode,omitempty"` // unix permission bits of the prior file; 0 if unknown (restore preserves existing mode)
+}
+
+// CheckpointPayload is the payload of an EventSessionCheckpoint event. It indexes
+// the before-state blobs captured for one mutating tool call.
+type CheckpointPayload struct {
+	Tool  string           `json:"tool"`
+	Files []CheckpointFile `json:"files"`
+}
+
+// CheckpointsEnabled reports whether checkpoint capture is enabled (default on;
+// disabled with ZERO_CHECKPOINTS=off).
+func CheckpointsEnabled() bool {
+	return os.Getenv("ZERO_CHECKPOINTS") != "off"
+}
+
+func maxCheckpointBytes() int {
+	if raw := os.Getenv("ZERO_CHECKPOINT_MAX_BYTES"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxCheckpointBytes
+}
+
+func (store *Store) blobsDir(sessionID string) string {
+	return filepath.Join(store.sessionPath(sessionID), CheckpointsDir, "blobs")
+}
+
+func (store *Store) blobPath(sessionID, hash string) string {
+	return filepath.Join(store.blobsDir(sessionID), hash)
+}
+
+// CaptureToolCheckpoint snapshots the current (before-mutation) content of each
+// path and records an EventSessionCheckpoint indexing the blobs. Capture is
+// best-effort: an unreadable file is recorded as skipped rather than failing the
+// caller. Returns the appended event (or a zero Event if there was nothing to do).
+func (store *Store) CaptureToolCheckpoint(sessionID, workspaceRoot, tool string, paths []string) (Event, error) {
+	if !ValidSessionID(sessionID) {
+		return Event{}, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	if !CheckpointsEnabled() || len(paths) == 0 {
+		return Event{}, nil
+	}
+	// Hold the session lock across writing the blobs AND appending the
+	// referencing event so a concurrent pruneOrphanBlobs cannot delete a blob in
+	// the gap between writeBlob and the event that references it.
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return Event{}, err
+	}
+	defer unlock()
+
+	payload, ok := store.SnapshotForCheckpoint(sessionID, workspaceRoot, tool, paths)
+	if !ok {
+		return Event{}, nil
+	}
+	return store.appendEventLocked(sessionID, AppendEventInput{Type: EventSessionCheckpoint, Payload: payload})
+}
+
+// SnapshotForCheckpoint reads and stores the before-mutation blobs for paths and
+// returns the checkpoint payload WITHOUT appending an event. Callers that batch
+// session events (e.g. the TUI) snapshot here — before the mutation runs — then
+// append the EventSessionCheckpoint themselves. Returns ok=false when there is
+// nothing to record (disabled, no paths, or no capturable files).
+func (store *Store) SnapshotForCheckpoint(sessionID, workspaceRoot, tool string, paths []string) (CheckpointPayload, bool) {
+	if !CheckpointsEnabled() || len(paths) == 0 {
+		return CheckpointPayload{}, false
+	}
+	capBytes := int64(maxCheckpointBytes())
+	files := make([]CheckpointFile, 0, len(paths))
+	for _, rel := range paths {
+		entry := CheckpointFile{Path: rel}
+		abs := filepath.Join(workspaceRoot, rel)
+		info, statErr := os.Stat(abs)
+		if statErr != nil {
+			// Treat anything we cannot stat as absent (new file) — restore deletes it.
+			entry.Absent = true
+			files = append(files, entry)
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		// Compare sizes as int64 so a file larger than the cap is never silently
+		// truncated past the cap via an int overflow on a 32-bit platform.
+		if info.Size() > capBytes {
+			entry.Skipped = true
+			if info.Size() <= int64(^uint(0)>>1) {
+				entry.Bytes = int(info.Size())
+			}
+			files = append(files, entry)
+			continue
+		}
+		// Record the prior permission bits so a restore can put them back (an
+		// executable script must not return as 0o644).
+		entry.Mode = uint32(info.Mode().Perm())
+		content, readErr := os.ReadFile(abs)
+		if readErr != nil {
+			entry.Skipped = true
+			files = append(files, entry)
+			continue
+		}
+		hash, writeErr := store.writeBlob(sessionID, content)
+		if writeErr != nil {
+			entry.Skipped = true
+			files = append(files, entry)
+			continue
+		}
+		entry.Blob = hash
+		entry.Bytes = len(content)
+		files = append(files, entry)
+	}
+	if len(files) == 0 {
+		return CheckpointPayload{}, false
+	}
+	return CheckpointPayload{Tool: tool, Files: files}, true
+}
+
+// writeBlob stores content under its sha256 (content-addressed, deduplicated) and
+// returns the hex hash. An existing blob with the same hash is left untouched.
+func (store *Store) writeBlob(sessionID string, content []byte) (string, error) {
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+	dir := store.blobsDir(sessionID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create checkpoint blob dir: %w", err)
+	}
+	path := store.blobPath(sessionID, hash)
+	if _, err := os.Stat(path); err == nil {
+		return hash, nil // dedup: identical content already stored
+	}
+	tmp := fmt.Sprintf("%s.tmp-%d", path, store.idCounter.Add(1))
+	if err := os.WriteFile(tmp, content, 0o600); err != nil {
+		return "", fmt.Errorf("write checkpoint blob: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("commit checkpoint blob: %w", err)
+	}
+	return hash, nil
+}
+
+// copyBlobs copies every checkpoint blob from src into dst's blobs dir. It is
+// used by Fork so a forked session carries the parent's content-addressed blobs
+// and a rewind on the fork can restore file content. Blobs are content-addressed
+// (the filename is the sha256), so an already-present blob is left untouched.
+// A missing source blobs dir is not an error (the session had no checkpoints).
+func (store *Store) copyBlobs(srcSessionID, dstSessionID string) error {
+	srcDir := store.blobsDir(srcSessionID)
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read checkpoint blobs: %w", err)
+	}
+	dstDir := store.blobsDir(dstSessionID)
+	madeDir := false
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		dstPath := store.blobPath(dstSessionID, entry.Name())
+		if _, err := os.Stat(dstPath); err == nil {
+			continue // content-addressed: identical blob already present
+		}
+		content, err := os.ReadFile(store.blobPath(srcSessionID, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("read checkpoint blob %s: %w", entry.Name(), err)
+		}
+		if !madeDir {
+			if err := os.MkdirAll(dstDir, 0o700); err != nil {
+				return fmt.Errorf("create checkpoint blob dir: %w", err)
+			}
+			madeDir = true
+		}
+		tmp := fmt.Sprintf("%s.tmp-%d", dstPath, store.idCounter.Add(1))
+		if err := os.WriteFile(tmp, content, 0o600); err != nil {
+			return fmt.Errorf("write checkpoint blob: %w", err)
+		}
+		if err := os.Rename(tmp, dstPath); err != nil {
+			_ = os.Remove(tmp)
+			return fmt.Errorf("commit checkpoint blob: %w", err)
+		}
+	}
+	return nil
+}
+
+// readBlob returns the content stored under a hash, verifying that the content
+// still hashes to the requested sha256. A mismatch (corruption/tampering) is
+// returned as an error so the caller skips the path rather than writing
+// untrusted content as truth.
+func (store *Store) readBlob(sessionID, hash string) ([]byte, error) {
+	content, err := os.ReadFile(store.blobPath(sessionID, hash))
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(content)
+	if got := hex.EncodeToString(sum[:]); got != hash {
+		return nil, fmt.Errorf("checkpoint blob %s failed integrity check (got %s)", hash, got)
+	}
+	return content, nil
+}
+
+// pruneOrphanBlobs removes blobs not referenced by any checkpoint event (e.g. after
+// a rewind discards later checkpoints). Best-effort; returns count removed. It
+// acquires the session lock so it cannot delete a blob that a concurrent
+// CaptureToolCheckpoint has just written but not yet referenced by its event.
+func (store *Store) pruneOrphanBlobs(sessionID string) (int, error) {
+	if !ValidSessionID(sessionID) {
+		return 0, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return 0, err
+	}
+	defer unlock()
+	return store.pruneOrphanBlobsLocked(sessionID)
+}
+
+// pruneOrphanBlobsLocked is the body of pruneOrphanBlobs WITHOUT acquiring the
+// session lock. The caller MUST already hold store.lockSession(sessionID).
+// Holding the lock around referencedBlobs + ReadDir + Remove is what closes the
+// race with a concurrent CaptureToolCheckpoint (which writes a blob and appends
+// the referencing event under the same lock): the prune either sees the blob
+// before it is written, or sees the event that references it — never the gap.
+func (store *Store) pruneOrphanBlobsLocked(sessionID string) (int, error) {
+	referenced, err := store.referencedBlobs(sessionID)
+	if err != nil {
+		return 0, err
+	}
+	entries, err := os.ReadDir(store.blobsDir(sessionID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	removed := 0
+	for _, e := range entries {
+		if e.IsDir() || referenced[e.Name()] {
+			continue
+		}
+		if err := os.Remove(store.blobPath(sessionID, e.Name())); err == nil {
+			removed++
+		}
+	}
+	return removed, nil
+}
+
+func (store *Store) referencedBlobs(sessionID string) (map[string]bool, error) {
+	events, err := store.ReadEvents(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	refs := map[string]bool{}
+	for _, ev := range events {
+		if ev.Type != EventSessionCheckpoint {
+			continue
+		}
+		var payload CheckpointPayload
+		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+			continue
+		}
+		for _, f := range payload.Files {
+			if f.Blob != "" {
+				refs[f.Blob] = true
+			}
+		}
+	}
+	return refs, nil
+}
+
+// sortedCheckpointsAfter returns checkpoint events with Sequence > targetSeq,
+// newest first (so restoring applies the snapshot closest to the target last).
+func (store *Store) sortedCheckpointsAfter(sessionID string, targetSeq int) ([]Event, error) {
+	events, err := store.ReadEvents(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	var checkpoints []Event
+	for _, ev := range events {
+		if ev.Type == EventSessionCheckpoint && ev.Sequence > targetSeq {
+			checkpoints = append(checkpoints, ev)
+		}
+	}
+	sort.Slice(checkpoints, func(i, j int) bool {
+		return checkpoints[i].Sequence > checkpoints[j].Sequence
+	})
+	return checkpoints, nil
+}

--- a/internal/sessions/checkpoint_test.go
+++ b/internal/sessions/checkpoint_test.go
@@ -256,6 +256,17 @@ func TestRestoreRejectsPathTraversal(t *testing.T) {
 	}
 }
 
+func TestRestoreFailsOnCorruptCheckpointPayload(t *testing.T) {
+	store, ws := newCkStore(t)
+	target := mustAppend(t, store, AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	// A checkpoint event whose payload does not decode into CheckpointPayload must
+	// abort the rewind, not be silently skipped (which could restore a later state).
+	mustAppend(t, store, AppendEventInput{Type: EventSessionCheckpoint, Payload: "corrupt-not-a-checkpoint"})
+	if _, err := store.RestoreToSequence("s", ws, target.Sequence); err == nil {
+		t.Fatal("expected rewind to fail on undecodable checkpoint payload")
+	}
+}
+
 func TestTruncateToZeroProducesEmptyFile(t *testing.T) {
 	store, _ := newCkStore(t)
 	mustAppend(t, store, AppendEventInput{Type: EventMessage, Payload: map[string]any{}})

--- a/internal/sessions/checkpoint_test.go
+++ b/internal/sessions/checkpoint_test.go
@@ -48,15 +48,18 @@ func TestCaptureToolCheckpointWritesBlobAndEvent(t *testing.T) {
 
 func TestCaptureDedupsIdenticalContent(t *testing.T) {
 	store, ws := newCkStore(t)
-	_ = os.WriteFile(filepath.Join(ws, "a.txt"), []byte("same"), 0o644)
-	_ = os.WriteFile(filepath.Join(ws, "b.txt"), []byte("same"), 0o644)
+	mustWriteFile(t, filepath.Join(ws, "a.txt"), "same")
+	mustWriteFile(t, filepath.Join(ws, "b.txt"), "same")
 	if _, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"a.txt"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"b.txt"}); err != nil {
 		t.Fatal(err)
 	}
-	entries, _ := os.ReadDir(store.blobsDir("s"))
+	entries, err := os.ReadDir(store.blobsDir("s"))
+	if err != nil {
+		t.Fatalf("read blobs dir: %v", err)
+	}
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 deduped blob, got %d", len(entries))
 	}
@@ -69,20 +72,49 @@ func TestCaptureRecordsAbsentForNewFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := decodeCk(t, ev)
+	if len(p.Files) != 1 {
+		t.Fatalf("expected 1 file entry, got %+v", p.Files)
+	}
 	if !p.Files[0].Absent || p.Files[0].Blob != "" {
 		t.Fatalf("expected absent marker, got %+v", p.Files[0])
+	}
+}
+
+func TestCaptureRejectsTraversalTargets(t *testing.T) {
+	store, ws := newCkStore(t)
+	// A file outside the workspace must never be read into a blob or marked
+	// Absent (which would delete it on rewind). Regression for capture-side
+	// path-traversal confinement.
+	outside := filepath.Join(filepath.Dir(ws), "secret.txt")
+	mustWriteFile(t, outside, "top secret")
+	ev, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"../secret.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := decodeCk(t, ev)
+	if len(p.Files) != 1 {
+		t.Fatalf("expected 1 file entry, got %+v", p.Files)
+	}
+	if f := p.Files[0]; !f.Skipped || f.Absent || f.Blob != "" {
+		t.Fatalf("traversal target must be skipped (not captured/absent), got %+v", f)
+	}
+	if got, rerr := os.ReadFile(outside); rerr != nil || string(got) != "top secret" {
+		t.Fatalf("outside file must remain untouched: got %q err %v", got, rerr)
 	}
 }
 
 func TestCaptureSkipsOversizeFiles(t *testing.T) {
 	t.Setenv("ZERO_CHECKPOINT_MAX_BYTES", "4")
 	store, ws := newCkStore(t)
-	_ = os.WriteFile(filepath.Join(ws, "big.txt"), []byte("123456"), 0o644)
+	mustWriteFile(t, filepath.Join(ws, "big.txt"), "123456")
 	ev, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"big.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	p := decodeCk(t, ev)
+	if len(p.Files) != 1 {
+		t.Fatalf("expected 1 file entry, got %+v", p.Files)
+	}
 	if !p.Files[0].Skipped || p.Files[0].Blob != "" {
 		t.Fatalf("expected skipped, got %+v", p.Files[0])
 	}
@@ -91,7 +123,7 @@ func TestCaptureSkipsOversizeFiles(t *testing.T) {
 func TestCaptureDisabled(t *testing.T) {
 	t.Setenv("ZERO_CHECKPOINTS", "off")
 	store, ws := newCkStore(t)
-	_ = os.WriteFile(filepath.Join(ws, "a.txt"), []byte("v1"), 0o644)
+	mustWriteFile(t, filepath.Join(ws, "a.txt"), "v1")
 	ev, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"a.txt"})
 	if err != nil || ev.Type != "" {
 		t.Fatalf("expected no-op when disabled, got ev=%+v err=%v", ev, err)
@@ -111,7 +143,10 @@ func TestTruncateEvents(t *testing.T) {
 	if err := store.TruncateEvents("s", seqs[1]); err != nil {
 		t.Fatal(err)
 	}
-	events, _ := store.ReadEvents("s")
+	events, err := store.ReadEvents("s")
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
 	if len(events) != 2 || events[len(events)-1].Sequence != seqs[1] {
 		t.Fatalf("expected 2 events through seq %d, got %d", seqs[1], len(events))
 	}
@@ -125,13 +160,16 @@ func TestRestoreToSequenceRevertsFileContent(t *testing.T) {
 	mustCapture(t, store, ws, "write_file", "a.txt") // captures "original"
 	mustWriteFile(t, path, "edited1")
 	mustCapture(t, store, ws, "edit_file", "a.txt") // captures "edited1"
-	_ = os.WriteFile(path, []byte("edited2"), 0o644)
+	mustWriteFile(t, path, "edited2")
 
 	report, err := store.RestoreToSequence("s", ws, target.Sequence)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, _ := os.ReadFile(path)
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
 	if string(got) != "original" {
 		t.Fatalf("restore should yield 'original', got %q", got)
 	}
@@ -171,10 +209,20 @@ func TestApplyRewindRestoresAndTruncates(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, _ := os.ReadFile(path); string(got) != "original" {
+	got, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatalf("read restored file: %v", rerr)
+	}
+	if string(got) != "original" {
 		t.Fatalf("file not restored: %q", got)
 	}
-	events, _ := store.ReadEvents("s")
+	events, err := store.ReadEvents("s")
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	if len(events) < 2 {
+		t.Fatalf("expected >=2 events, got %d", len(events))
+	}
 	last := events[len(events)-1]
 	if last.Type != EventSessionRewind {
 		t.Fatalf("expected trailing rewind marker, got %s", last.Type)
@@ -214,7 +262,10 @@ func TestTruncateToZeroProducesEmptyFile(t *testing.T) {
 	if err := store.TruncateEvents("s", 0); err != nil {
 		t.Fatal(err)
 	}
-	events, _ := store.ReadEvents("s")
+	events, err := store.ReadEvents("s")
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
 	if len(events) != 0 {
 		t.Fatalf("expected 0 events after truncate-to-0, got %d", len(events))
 	}

--- a/internal/sessions/checkpoint_test.go
+++ b/internal/sessions/checkpoint_test.go
@@ -1,0 +1,247 @@
+package sessions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newCkStore(t *testing.T) (*Store, string) {
+	t.Helper()
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	if _, err := store.Create(CreateInput{SessionID: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	return store, t.TempDir() // store, workspaceRoot
+}
+
+func decodeCk(t *testing.T, ev Event) CheckpointPayload {
+	t.Helper()
+	var p CheckpointPayload
+	if err := json.Unmarshal(ev.Payload, &p); err != nil {
+		t.Fatalf("decode checkpoint payload: %v", err)
+	}
+	return p
+}
+
+func TestCaptureToolCheckpointWritesBlobAndEvent(t *testing.T) {
+	store, ws := newCkStore(t)
+	if err := os.WriteFile(filepath.Join(ws, "a.txt"), []byte("v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ev, err := store.CaptureToolCheckpoint("s", ws, "edit_file", []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Type != EventSessionCheckpoint {
+		t.Fatalf("event type = %s", ev.Type)
+	}
+	p := decodeCk(t, ev)
+	if len(p.Files) != 1 || p.Files[0].Path != "a.txt" || p.Files[0].Blob == "" || p.Files[0].Bytes != 2 {
+		t.Fatalf("unexpected payload: %+v", p)
+	}
+	if _, err := store.readBlob("s", p.Files[0].Blob); err != nil {
+		t.Fatalf("blob not stored: %v", err)
+	}
+}
+
+func TestCaptureDedupsIdenticalContent(t *testing.T) {
+	store, ws := newCkStore(t)
+	_ = os.WriteFile(filepath.Join(ws, "a.txt"), []byte("same"), 0o644)
+	_ = os.WriteFile(filepath.Join(ws, "b.txt"), []byte("same"), 0o644)
+	if _, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"a.txt"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"b.txt"}); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(store.blobsDir("s"))
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 deduped blob, got %d", len(entries))
+	}
+}
+
+func TestCaptureRecordsAbsentForNewFile(t *testing.T) {
+	store, ws := newCkStore(t)
+	ev, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"new.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := decodeCk(t, ev)
+	if !p.Files[0].Absent || p.Files[0].Blob != "" {
+		t.Fatalf("expected absent marker, got %+v", p.Files[0])
+	}
+}
+
+func TestCaptureSkipsOversizeFiles(t *testing.T) {
+	t.Setenv("ZERO_CHECKPOINT_MAX_BYTES", "4")
+	store, ws := newCkStore(t)
+	_ = os.WriteFile(filepath.Join(ws, "big.txt"), []byte("123456"), 0o644)
+	ev, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"big.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := decodeCk(t, ev)
+	if !p.Files[0].Skipped || p.Files[0].Blob != "" {
+		t.Fatalf("expected skipped, got %+v", p.Files[0])
+	}
+}
+
+func TestCaptureDisabled(t *testing.T) {
+	t.Setenv("ZERO_CHECKPOINTS", "off")
+	store, ws := newCkStore(t)
+	_ = os.WriteFile(filepath.Join(ws, "a.txt"), []byte("v1"), 0o644)
+	ev, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{"a.txt"})
+	if err != nil || ev.Type != "" {
+		t.Fatalf("expected no-op when disabled, got ev=%+v err=%v", ev, err)
+	}
+}
+
+func TestTruncateEvents(t *testing.T) {
+	store, _ := newCkStore(t)
+	var seqs []int
+	for i := 0; i < 3; i++ {
+		ev, err := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{"i": i}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		seqs = append(seqs, ev.Sequence)
+	}
+	if err := store.TruncateEvents("s", seqs[1]); err != nil {
+		t.Fatal(err)
+	}
+	events, _ := store.ReadEvents("s")
+	if len(events) != 2 || events[len(events)-1].Sequence != seqs[1] {
+		t.Fatalf("expected 2 events through seq %d, got %d", seqs[1], len(events))
+	}
+}
+
+func TestRestoreToSequenceRevertsFileContent(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	path := filepath.Join(ws, "a.txt")
+	mustWriteFile(t, path, "original")
+	mustCapture(t, store, ws, "write_file", "a.txt") // captures "original"
+	mustWriteFile(t, path, "edited1")
+	mustCapture(t, store, ws, "edit_file", "a.txt") // captures "edited1"
+	_ = os.WriteFile(path, []byte("edited2"), 0o644)
+
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "original" {
+		t.Fatalf("restore should yield 'original', got %q", got)
+	}
+	if report.FilesRestored < 1 {
+		t.Fatalf("expected FilesRestored>=1, got %+v", report)
+	}
+}
+
+func TestRestoreDeletesFileThatWasAbsent(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	path := filepath.Join(ws, "new.txt")
+	mustCapture(t, store, ws, "write_file", "new.txt") // absent before
+	mustWriteFile(t, path, "created")
+
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected file deleted on restore, stat err=%v", err)
+	}
+	if report.FilesDeleted < 1 {
+		t.Fatalf("expected FilesDeleted>=1, got %+v", report)
+	}
+}
+
+func TestApplyRewindRestoresAndTruncates(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	path := filepath.Join(ws, "a.txt")
+	mustWriteFile(t, path, "original")
+	mustCapture(t, store, ws, "write_file", "a.txt")
+	mustWriteFile(t, path, "changed")
+
+	report, err := store.ApplyRewind("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "original" {
+		t.Fatalf("file not restored: %q", got)
+	}
+	events, _ := store.ReadEvents("s")
+	last := events[len(events)-1]
+	if last.Type != EventSessionRewind {
+		t.Fatalf("expected trailing rewind marker, got %s", last.Type)
+	}
+	// kept events through target + the appended rewind marker
+	if events[len(events)-2].Sequence != target.Sequence {
+		t.Fatalf("expected truncation to target seq %d", target.Sequence)
+	}
+	_ = report
+}
+
+func TestRestoreRejectsPathTraversal(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	// Hand-craft a tampered checkpoint event with a traversal path.
+	outside := filepath.Join(filepath.Dir(ws), "evil.txt")
+	mustWriteFile(t, outside, "keep me")
+	mustAppend(t, store, AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "write_file",
+		Files: []CheckpointFile{{Path: "../evil.txt", Absent: true}},
+	}})
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("restore must NOT delete files outside the workspace: %v", err)
+	}
+	if len(report.Skipped) == 0 {
+		t.Errorf("expected traversal path reported as skipped, got %+v", report)
+	}
+}
+
+func TestTruncateToZeroProducesEmptyFile(t *testing.T) {
+	store, _ := newCkStore(t)
+	mustAppend(t, store, AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	if err := store.TruncateEvents("s", 0); err != nil {
+		t.Fatal(err)
+	}
+	events, _ := store.ReadEvents("s")
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events after truncate-to-0, got %d", len(events))
+	}
+}
+
+// mustWriteFile / mustCapture / mustAppend are setup helpers that fail the test
+// immediately on error, so a setup failure is diagnosed at its source instead of
+// surfacing as a confusing downstream assertion.
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustCapture(t *testing.T, store *Store, ws, tool, path string) {
+	t.Helper()
+	if _, err := store.CaptureToolCheckpoint("s", ws, tool, []string{path}); err != nil {
+		t.Fatalf("CaptureToolCheckpoint(%s, %s): %v", tool, path, err)
+	}
+}
+
+func mustAppend(t *testing.T, store *Store, input AppendEventInput) Event {
+	t.Helper()
+	ev, err := store.AppendEvent("s", input)
+	if err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	return ev
+}

--- a/internal/sessions/checkpoint_test.go
+++ b/internal/sessions/checkpoint_test.go
@@ -256,6 +256,33 @@ func TestRestoreRejectsPathTraversal(t *testing.T) {
 	}
 }
 
+func TestRestoreDedupesEquivalentRawPaths(t *testing.T) {
+	store, ws := newCkStore(t)
+	target := mustAppend(t, store, AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	path := filepath.Join(ws, "a.txt")
+
+	// Closest-to-target checkpoint captures "closest" via raw path "a.txt".
+	mustWriteFile(t, path, "closest")
+	mustCapture(t, store, ws, "write_file", "a.txt")
+	// A NEWER checkpoint references the SAME file via an equivalent raw path.
+	mustWriteFile(t, path, "newer")
+	mustCapture(t, store, ws, "edit_file", "./a.txt")
+	mustWriteFile(t, path, "current")
+
+	if _, err := store.RestoreToSequence("s", ws, target.Sequence); err != nil {
+		t.Fatal(err)
+	}
+	// The closest-to-target snapshot must win; the newer entry under the
+	// equivalent raw path must not overwrite it.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(got) != "closest" {
+		t.Fatalf("equivalent raw path bypassed dedupe: got %q, want \"closest\"", got)
+	}
+}
+
 func TestRestoreFailsOnCorruptCheckpointPayload(t *testing.T) {
 	store, ws := newCkStore(t)
 	target := mustAppend(t, store, AppendEventInput{Type: EventMessage, Payload: map[string]any{}})

--- a/internal/sessions/filelock_other.go
+++ b/internal/sessions/filelock_other.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package sessions
+
+// acquireFileLock is a no-op fallback on platforms without flock; the in-memory
+// per-Store mutex still serializes mutations within a process.
+func (store *Store) acquireFileLock(sessionID string) (func(), error) {
+	return func() {}, nil
+}

--- a/internal/sessions/filelock_other.go
+++ b/internal/sessions/filelock_other.go
@@ -1,9 +1,0 @@
-//go:build windows
-
-package sessions
-
-// acquireFileLock is a no-op fallback on platforms without flock; the in-memory
-// per-Store mutex still serializes mutations within a process.
-func (store *Store) acquireFileLock(sessionID string) (func(), error) {
-	return func() {}, nil
-}

--- a/internal/sessions/filelock_unix.go
+++ b/internal/sessions/filelock_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package sessions
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// acquireFileLock takes an exclusive OS advisory lock (flock) on the session's
+// .lock file so concurrent processes sharing the same RootDir (e.g. CLI rewind
+// vs TUI) serialize their session mutations. It blocks until the lock is
+// available and returns a release function. The lock is held via an open file
+// descriptor; closing it releases the lock.
+func (store *Store) acquireFileLock(sessionID string) (func(), error) {
+	path := store.lockPath(sessionID)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open zero session lock: %w", err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock zero session: %w", err)
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/sessions/filelock_windows.go
+++ b/internal/sessions/filelock_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package sessions
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireFileLock takes an exclusive OS lock (LockFileEx) on the session's .lock
+// file so concurrent processes — and separate Store instances within one process
+// — sharing the same RootDir serialize their session mutations, matching the
+// flock behavior on unix. It blocks until the lock is available and returns a
+// release function; closing the handle and unlocking the region releases it.
+func (store *Store) acquireFileLock(sessionID string) (func(), error) {
+	path := store.lockPath(sessionID)
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open zero session lock: %w", err)
+	}
+	handle := windows.Handle(file.Fd())
+	overlapped := new(windows.Overlapped)
+	// Lock a fixed 1-byte region. A blocking exclusive lock (no
+	// LOCKFILE_FAIL_IMMEDIATELY) waits until any current holder releases.
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("lock zero session: %w", err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, overlapped)
+		_ = file.Close()
+	}, nil
+}

--- a/internal/sessions/rewind.go
+++ b/internal/sessions/rewind.go
@@ -56,7 +56,10 @@ func (store *Store) restoreToSequenceLocked(sessionID, workspaceRoot string, tar
 		ev := checkpoints[i]
 		var payload CheckpointPayload
 		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
-			continue
+			// Fail the rewind rather than skipping: silently continuing would let a
+			// NEWER checkpoint win for that path and restore a later state than the
+			// caller asked for. Corruption is a hard error.
+			return report, fmt.Errorf("decode checkpoint payload seq %d: %w", ev.Sequence, err)
 		}
 		for _, f := range payload.Files {
 			// Process only the CLOSEST-to-target entry per path. We iterate

--- a/internal/sessions/rewind.go
+++ b/internal/sessions/rewind.go
@@ -1,0 +1,279 @@
+package sessions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RestoreReport summarizes a workspace restore.
+type RestoreReport struct {
+	TargetSequence int      `json:"targetSequence"`
+	FilesRestored  int      `json:"filesRestored"`
+	FilesDeleted   int      `json:"filesDeleted"`
+	Skipped        []string `json:"skipped,omitempty"` // paths whose before-state was not recoverable
+}
+
+// RewindMarker is the payload of the EventSessionRewind event appended after a rewind.
+type RewindMarker struct {
+	TargetSequence int           `json:"targetSequence"`
+	Report         RestoreReport `json:"report"`
+}
+
+// RestoreToSequence reverts workspace files to their state at targetSeq by applying
+// the before-snapshots of every checkpoint after the target, newest-first (so the
+// snapshot closest to the target wins). It does not modify the event log.
+func (store *Store) RestoreToSequence(sessionID, workspaceRoot string, targetSeq int) (RestoreReport, error) {
+	report := RestoreReport{TargetSequence: targetSeq}
+	if !ValidSessionID(sessionID) {
+		return report, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return report, err
+	}
+	defer unlock()
+	return store.restoreToSequenceLocked(sessionID, workspaceRoot, targetSeq)
+}
+
+// restoreToSequenceLocked is the body of RestoreToSequence WITHOUT acquiring the
+// session lock. The caller MUST already hold store.lockSession(sessionID). It
+// lets ApplyRewind run restore/truncate/prune/marker atomically under one lock.
+func (store *Store) restoreToSequenceLocked(sessionID, workspaceRoot string, targetSeq int) (RestoreReport, error) {
+	report := RestoreReport{TargetSequence: targetSeq}
+	checkpoints, err := store.sortedCheckpointsAfter(sessionID, targetSeq)
+	if err != nil {
+		return report, err
+	}
+	// sortedCheckpointsAfter returns newest-first; iterate oldest-first
+	// (closest-to-target first) so the per-path short-circuit below keeps the
+	// snapshot closest to the target and ignores all newer ones.
+	restored := map[string]bool{}
+	for i := len(checkpoints) - 1; i >= 0; i-- {
+		ev := checkpoints[i]
+		var payload CheckpointPayload
+		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+			continue
+		}
+		for _, f := range payload.Files {
+			// Process only the CLOSEST-to-target entry per path. We iterate
+			// closest-to-target first, so the first time we see a path here is its
+			// closest-to-target snapshot; any newer (already-handled) entry for the
+			// same path must be ignored. This prevents a newer blob from
+			// overwriting an older Skipped entry and avoids double-counting
+			// FilesRestored/FilesDeleted.
+			if restored[f.Path] {
+				continue
+			}
+			restored[f.Path] = true
+
+			// Defense in depth: never write/delete outside the workspace, even if
+			// a checkpoint event was tampered with (path traversal via "../") or
+			// an in-workspace symlink points outside the root.
+			abs, ok := resolveWithinWorkspace(workspaceRoot, f.Path)
+			if !ok {
+				report.Skipped = append(report.Skipped, f.Path)
+				continue
+			}
+			switch {
+			case f.Skipped:
+				report.Skipped = append(report.Skipped, f.Path)
+			case f.Absent:
+				if err := os.Remove(abs); err == nil || os.IsNotExist(err) {
+					report.FilesDeleted++
+				} else {
+					report.Skipped = append(report.Skipped, f.Path)
+				}
+			case f.Blob != "":
+				content, rerr := store.readBlob(sessionID, f.Blob)
+				if rerr != nil {
+					report.Skipped = append(report.Skipped, f.Path)
+					continue
+				}
+				if err := store.writeFileAtomic(abs, content, f.Mode); err != nil {
+					report.Skipped = append(report.Skipped, f.Path)
+					continue
+				}
+				report.FilesRestored++
+			}
+		}
+	}
+	return report, nil
+}
+
+// resolveWithinWorkspace joins rel to root and confirms the result stays inside
+// root. It rejects lexical traversal ("../") and absolute escapes, AND resolves
+// symlinks (like tools.resolveWorkspaceTargetPath): it EvalSymlinks the deepest
+// existing ancestor, re-joins the missing segments, and verifies the result is
+// under EvalSymlinks(root). This blocks an in-workspace symlink that points
+// outside the workspace from redirecting a restore write/delete outside it.
+func resolveWithinWorkspace(root, rel string) (string, bool) {
+	cleanRoot, err := filepath.EvalSymlinks(filepath.Clean(root))
+	if err != nil {
+		return "", false
+	}
+
+	abs := filepath.Join(cleanRoot, rel)
+
+	// Walk down from the target to the deepest ancestor that exists on disk,
+	// collecting the not-yet-created trailing segments.
+	existing := abs
+	missingSegments := []string{}
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		} else if os.IsNotExist(err) {
+			parent := filepath.Dir(existing)
+			if parent == existing {
+				return "", false
+			}
+			missingSegments = append([]string{filepath.Base(existing)}, missingSegments...)
+			existing = parent
+			continue
+		} else {
+			return "", false
+		}
+	}
+
+	resolved, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", false
+	}
+	for _, segment := range missingSegments {
+		resolved = filepath.Join(resolved, segment)
+	}
+
+	within, err := filepath.Rel(cleanRoot, resolved)
+	if err != nil {
+		return "", false
+	}
+	if within == ".." || strings.HasPrefix(within, ".."+string(filepath.Separator)) || filepath.IsAbs(within) {
+		return "", false
+	}
+	return resolved, true
+}
+
+// TruncateEvents atomically rewrites events.jsonl keeping only events with
+// Sequence <= keepThroughSequence, and updates metadata EventCount.
+func (store *Store) TruncateEvents(sessionID string, keepThroughSequence int) error {
+	if !ValidSessionID(sessionID) {
+		return fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return store.truncateEventsLocked(sessionID, keepThroughSequence)
+}
+
+// truncateEventsLocked is the body of TruncateEvents WITHOUT acquiring the
+// session lock. The caller MUST already hold store.lockSession(sessionID).
+func (store *Store) truncateEventsLocked(sessionID string, keepThroughSequence int) error {
+	events, err := store.ReadEvents(sessionID)
+	if err != nil {
+		return err
+	}
+	var kept [][]byte
+	keptCount := 0
+	for _, ev := range events {
+		if ev.Sequence > keepThroughSequence {
+			continue
+		}
+		data, err := json.Marshal(ev)
+		if err != nil {
+			return fmt.Errorf("encode kept event: %w", err)
+		}
+		kept = append(kept, data)
+		keptCount++
+	}
+	var encoded []byte
+	if len(kept) > 0 {
+		encoded = append(bytes.Join(kept, []byte{'\n'}), '\n')
+	}
+	path := store.eventsPath(sessionID)
+	tmp := fmt.Sprintf("%s.tmp-%d", path, store.idCounter.Add(1))
+	if err := os.WriteFile(tmp, encoded, 0o600); err != nil {
+		return fmt.Errorf("write truncated events: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("commit truncated events: %w", err)
+	}
+	session, err := store.readMetadata(sessionID)
+	if err != nil {
+		return err
+	}
+	session.EventCount = keptCount
+	session.UpdatedAt = store.timestamp()
+	return store.writeMetadata(session)
+}
+
+// ApplyRewind performs a full safe rewind: restore workspace files to targetSeq,
+// truncate the event log, prune now-orphaned blobs, and append an EventSessionRewind
+// marker. Returns the restore report.
+func (store *Store) ApplyRewind(sessionID, workspaceRoot string, targetSeq int) (RestoreReport, error) {
+	if !ValidSessionID(sessionID) {
+		return RestoreReport{TargetSequence: targetSeq}, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	// Hold the session lock ONCE across restore + truncate + prune + marker so a
+	// concurrent writer cannot interleave between the sub-steps. The sub-steps
+	// use *Locked variants that assume the lock is already held; re-locking here
+	// would deadlock the non-reentrant in-process mutex.
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return RestoreReport{TargetSequence: targetSeq}, err
+	}
+	defer unlock()
+
+	report, err := store.restoreToSequenceLocked(sessionID, workspaceRoot, targetSeq)
+	if err != nil {
+		return report, err
+	}
+	if err := store.truncateEventsLocked(sessionID, targetSeq); err != nil {
+		return report, err
+	}
+	_, _ = store.pruneOrphanBlobsLocked(sessionID)
+	if _, err := store.appendEventLocked(sessionID, AppendEventInput{
+		Type:    EventSessionRewind,
+		Payload: RewindMarker{TargetSequence: targetSeq, Report: report},
+	}); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// writeFileAtomic writes content to path via a temp file + rename. mode is the
+// checkpoint-recorded permission bits to restore; when it is 0 (mode unknown —
+// e.g. an old checkpoint without the field) the original mode of the file being
+// overwritten is preserved, falling back to 0o644 for a newly created file.
+func (store *Store) writeFileAtomic(path string, content []byte, mode uint32) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	perm := os.FileMode(0o644)
+	if mode != 0 {
+		perm = os.FileMode(mode).Perm()
+	} else if info, err := os.Stat(path); err == nil {
+		// Mode not captured: preserve the existing file's permission bits.
+		perm = info.Mode().Perm()
+	}
+	tmp := fmt.Sprintf("%s.zero-restore-tmp-%d", path, store.idCounter.Add(1))
+	if err := os.WriteFile(tmp, content, perm); err != nil {
+		return err
+	}
+	// WriteFile only applies perm on creation and is subject to umask; force the
+	// exact bits so an executable script's mode is faithfully restored.
+	if err := os.Chmod(tmp, perm); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/internal/sessions/rewind.go
+++ b/internal/sessions/rewind.go
@@ -62,22 +62,12 @@ func (store *Store) restoreToSequenceLocked(sessionID, workspaceRoot string, tar
 			return report, fmt.Errorf("decode checkpoint payload seq %d: %w", ev.Sequence, err)
 		}
 		for _, f := range payload.Files {
-			// Process only the CLOSEST-to-target entry per path. We iterate
-			// closest-to-target first, so the first time we see a path here is its
-			// closest-to-target snapshot; any newer (already-handled) entry for the
-			// same path must be ignored. This prevents a newer blob from
-			// overwriting an older Skipped entry and avoids double-counting
-			// FilesRestored/FilesDeleted.
-			if restored[f.Path] {
-				continue
-			}
-			restored[f.Path] = true
-
-			// Defense in depth: never write/delete outside the workspace, even if
-			// a checkpoint event was tampered with (path traversal via "../") or
-			// an in-workspace symlink points outside the root. The boundary is
-			// re-resolved here, immediately before the mutation, to keep the
-			// check-to-use window small.
+			// Resolve/confine the target FIRST so the dedupe key below is the
+			// canonical workspace path. Defense in depth: never write/delete outside
+			// the workspace, even if a checkpoint event was tampered with (path
+			// traversal via "../") or an in-workspace symlink points outside the
+			// root. The boundary is re-resolved here, immediately before the
+			// mutation, to keep the check-to-use window small.
 			//
 			// Residual: a symlink-swap TOCTOU remains — a concurrent process with
 			// workspace write access could replace a validated intermediate
@@ -88,6 +78,24 @@ func (store *Store) restoreToSequenceLocked(sessionID, workspaceRoot string, tar
 			// the CLI/TUI rewind-wiring work. The narrow window plus the
 			// workspace-write-access precondition make this low-risk here.
 			abs, ok := resolveWithinWorkspace(workspaceRoot, f.Path)
+
+			// Process only the CLOSEST-to-target entry per RESOLVED path. We iterate
+			// closest-to-target first, so the first time we see a resolved path is
+			// its closest-to-target snapshot; any newer (already-handled) entry for
+			// the SAME underlying file must be ignored — even when it was recorded
+			// under an equivalent-but-different raw path (./a.txt, dir/../a.txt, a
+			// symlink alias). Deduping on the raw path would let such an alias slip
+			// past and overwrite the closest snapshot. Unresolvable targets dedupe
+			// on their raw path (there is no canonical key for them).
+			key := f.Path
+			if ok {
+				key = abs
+			}
+			if restored[key] {
+				continue
+			}
+			restored[key] = true
+
 			if !ok {
 				report.Skipped = append(report.Skipped, f.Path)
 				continue

--- a/internal/sessions/rewind.go
+++ b/internal/sessions/rewind.go
@@ -72,7 +72,18 @@ func (store *Store) restoreToSequenceLocked(sessionID, workspaceRoot string, tar
 
 			// Defense in depth: never write/delete outside the workspace, even if
 			// a checkpoint event was tampered with (path traversal via "../") or
-			// an in-workspace symlink points outside the root.
+			// an in-workspace symlink points outside the root. The boundary is
+			// re-resolved here, immediately before the mutation, to keep the
+			// check-to-use window small.
+			//
+			// Residual: a symlink-swap TOCTOU remains — a concurrent process with
+			// workspace write access could replace a validated intermediate
+			// directory with a symlink between this check and the
+			// os.Remove/writeFileAtomic below. Fully closing it needs
+			// descriptor-based traversal (openat2 RESOLVE_BENEATH on Linux /
+			// per-component O_NOFOLLOW), which is platform-specific; tracked for
+			// the CLI/TUI rewind-wiring work. The narrow window plus the
+			// workspace-write-access precondition make this low-risk here.
 			abs, ok := resolveWithinWorkspace(workspaceRoot, f.Path)
 			if !ok {
 				report.Skipped = append(report.Skipped, f.Path)

--- a/internal/sessions/rewind_test.go
+++ b/internal/sessions/rewind_test.go
@@ -1,0 +1,403 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Finding 6: when several checkpoints touch the same path, only the
+// closest-to-target (oldest) entry must take effect. If that entry is Skipped
+// but a newer entry has a blob, the file must NOT be restored from the newer
+// blob, and FilesRestored must not be double-counted.
+func TestRestoreClosestToTargetSkippedWins(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+
+	// Seed a blob so the newer (further-from-target) checkpoint references it.
+	hash, err := store.writeBlob("s", []byte("newer-blob-content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Oldest checkpoint (closest to target) marks the path Skipped (not recoverable).
+	store.AppendEvent("s", AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "edit_file",
+		Files: []CheckpointFile{{Path: "a.txt", Skipped: true}},
+	}})
+	// Newer checkpoint (further from target) has a real blob.
+	store.AppendEvent("s", AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "edit_file",
+		Files: []CheckpointFile{{Path: "a.txt", Blob: hash}},
+	}})
+
+	// Current on-disk state the user wants reverted.
+	path := filepath.Join(ws, "a.txt")
+	if err := os.WriteFile(path, []byte("current"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The closest-to-target entry is Skipped: the file must be left as-is.
+	got, _ := os.ReadFile(path)
+	if string(got) != "current" {
+		t.Fatalf("Skipped closest entry must not be overwritten by a newer blob, got %q", got)
+	}
+	if report.FilesRestored != 0 {
+		t.Fatalf("FilesRestored = %d, want 0 (closest entry Skipped)", report.FilesRestored)
+	}
+	if len(report.Skipped) != 1 {
+		t.Fatalf("Skipped = %v, want exactly one entry for a.txt", report.Skipped)
+	}
+}
+
+// Finding 6 (LOW double-count): a path touched by several blob checkpoints must
+// be restored once, not once per checkpoint.
+func TestRestoreDoesNotDoubleCountFilesRestored(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+
+	oldHash, err := store.writeBlob("s", []byte("closest-content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newHash, err := store.writeBlob("s", []byte("newer-content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AppendEvent("s", AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "edit_file",
+		Files: []CheckpointFile{{Path: "a.txt", Blob: oldHash}},
+	}})
+	store.AppendEvent("s", AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "edit_file",
+		Files: []CheckpointFile{{Path: "a.txt", Blob: newHash}},
+	}})
+
+	path := filepath.Join(ws, "a.txt")
+	_ = os.WriteFile(path, []byte("current"), 0o644)
+
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Closest-to-target blob must win, and the count must be 1 (not 2).
+	if got, _ := os.ReadFile(path); string(got) != "closest-content" {
+		t.Fatalf("closest-to-target blob should win, got %q", got)
+	}
+	if report.FilesRestored != 1 {
+		t.Fatalf("FilesRestored = %d, want 1 (no double count)", report.FilesRestored)
+	}
+}
+
+// Finding 9: readBlob must verify the content matches the requested sha256. A
+// corrupted blob must be reported as Skipped, not written as truth.
+func TestReadBlobRejectsCorruptContent(t *testing.T) {
+	store, _ := newCkStore(t)
+	hash, err := store.writeBlob("s", []byte("trusted-content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt the blob on disk without changing its (content-addressed) name.
+	if err := os.WriteFile(store.blobPath("s", hash), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.readBlob("s", hash); err == nil {
+		t.Fatalf("readBlob must error on sha256 mismatch, got nil")
+	}
+}
+
+func TestRestoreSkipsCorruptBlob(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	hash, err := store.writeBlob("s", []byte("trusted-content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AppendEvent("s", AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "edit_file",
+		Files: []CheckpointFile{{Path: "a.txt", Blob: hash}},
+	}})
+	// Corrupt the stored blob.
+	_ = os.WriteFile(store.blobPath("s", hash), []byte("tampered-evil"), 0o600)
+
+	path := filepath.Join(ws, "a.txt")
+	_ = os.WriteFile(path, []byte("current"), 0o644)
+
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) == "tampered-evil" {
+		t.Fatalf("corrupt blob must not be written as truth, got %q", got)
+	}
+	if report.FilesRestored != 0 || len(report.Skipped) != 1 {
+		t.Fatalf("corrupt blob must be Skipped, report = %+v", report)
+	}
+}
+
+// Finding 7: an in-workspace symlink that points outside the workspace must not
+// let a restore write outside the root. resolveWithinWorkspace must resolve
+// symlinks, not just reject lexical "..".
+func TestRestoreRejectsInWorkspaceSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+
+	// A directory outside the workspace holding a file we must not clobber.
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// An in-workspace symlink "link" -> outsideDir. The relative path
+	// "link/secret.txt" is lexically clean (no ".."), so a purely lexical check
+	// would let the write escape the workspace.
+	if err := os.Symlink(outsideDir, filepath.Join(ws, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	hash, err := store.writeBlob("s", []byte("attacker-content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AppendEvent("s", AppendEventInput{Type: EventSessionCheckpoint, Payload: CheckpointPayload{
+		Tool:  "write_file",
+		Files: []CheckpointFile{{Path: "link/secret.txt", Blob: hash}},
+	}})
+
+	report, err := store.RestoreToSequence("s", ws, target.Sequence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(outsideFile); string(got) != "keep me" {
+		t.Fatalf("restore escaped the workspace via symlink, outside file = %q", got)
+	}
+	if report.FilesRestored != 0 {
+		t.Fatalf("FilesRestored = %d, want 0 (symlink escape must be skipped)", report.FilesRestored)
+	}
+	if len(report.Skipped) != 1 {
+		t.Fatalf("expected symlink-escape path reported as skipped, got %+v", report.Skipped)
+	}
+}
+
+// Audit finding (HIGH): Fork must copy content-addressed checkpoint blobs into
+// the fork, not just the checkpoint EVENTS. Otherwise an ApplyRewind on the
+// fork reads a blob that does not exist in the fork's blobs dir and silently
+// skips the file instead of restoring it.
+func TestForkRewindRestoresFromCopiedBlobs(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	ws := t.TempDir()
+	if _, err := store.Create(CreateInput{SessionID: "parent"}); err != nil {
+		t.Fatal(err)
+	}
+	target, err := store.AppendEvent("parent", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Capture "original" into a checkpoint, then mutate on disk.
+	path := filepath.Join(ws, "a.txt")
+	mustWriteFile(t, path, "original")
+	if _, err := store.CaptureToolCheckpoint("parent", ws, "write_file", []string{"a.txt"}); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, path, "changed")
+
+	fork, err := store.Fork("parent", ForkInput{SessionID: "fork"})
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+
+	// The fork must carry the parent's blobs so rewind can read them.
+	parentBlobs, _ := os.ReadDir(store.blobsDir("parent"))
+	if len(parentBlobs) == 0 {
+		t.Fatal("precondition: parent should have at least one blob")
+	}
+	for _, b := range parentBlobs {
+		if _, err := os.Stat(store.blobPath(fork.SessionID, b.Name())); err != nil {
+			t.Fatalf("fork is missing parent blob %s: %v", b.Name(), err)
+		}
+	}
+
+	// Rewind on the fork (target seq matches the copied EventMessage) must
+	// restore "original" from the copied blob.
+	report, err := store.ApplyRewind(fork.SessionID, ws, target.Sequence)
+	if err != nil {
+		t.Fatalf("ApplyRewind on fork: %v", err)
+	}
+	if report.FilesRestored != 1 {
+		t.Fatalf("FilesRestored = %d, want 1 (blob must be present in fork)", report.FilesRestored)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "original" {
+		t.Fatalf("fork rewind did not restore from copied blob, got %q", got)
+	}
+}
+
+// Audit finding (LOW): restoring a checkpointed blob must preserve the original
+// file permission bits (an executable script must not come back as 0o644).
+func TestRestorePreservesExecutableMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes do not apply on windows")
+	}
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	path := filepath.Join(ws, "run.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustCapture(t, store, ws, "write_file", "run.sh") // captures 0o755 content
+	// Mutate content (and clobber mode) as a tool edit would.
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho bye\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chmod(path, 0o644)
+
+	if _, err := store.RestoreToSequence("s", ws, target.Sequence); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("restored file lost its executable bit: mode=%v", info.Mode().Perm())
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("restored mode = %v, want 0o755", info.Mode().Perm())
+	}
+}
+
+// Audit finding (MED): ApplyRewind must hold the session lock once across all
+// sub-steps and must NOT deadlock by re-acquiring the non-reentrant mutex.
+func TestApplyRewindDoesNotDeadlock(t *testing.T) {
+	store, ws := newCkStore(t)
+	target, _ := store.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}})
+	path := filepath.Join(ws, "a.txt")
+	mustWriteFile(t, path, "original")
+	mustCapture(t, store, ws, "write_file", "a.txt")
+	mustWriteFile(t, path, "changed")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.ApplyRewind("s", ws, target.Sequence)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ApplyRewind: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ApplyRewind deadlocked (likely re-acquired the session lock)")
+	}
+	if got, _ := os.ReadFile(path); string(got) != "original" {
+		t.Fatalf("file not restored: %q", got)
+	}
+}
+
+// Audit findings (MED): a concurrent CaptureToolCheckpoint and pruneOrphanBlobs
+// must not race or delete a freshly-written-but-referenced blob, and must not
+// deadlock. Exercised under -race.
+func TestCaptureAndPruneConcurrent(t *testing.T) {
+	store, ws := newCkStore(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		name := filepath.Join(ws, "f"+string(rune('a'+i%10))+".txt")
+		mustWriteFile(t, name, "content-"+string(rune('0'+i%10)))
+	}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			rel := "f" + string(rune('a'+i%10)) + ".txt"
+			if _, err := store.CaptureToolCheckpoint("s", ws, "write_file", []string{rel}); err != nil {
+				t.Errorf("CaptureToolCheckpoint: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			if _, err := store.pruneOrphanBlobs("s"); err != nil {
+				t.Errorf("pruneOrphanBlobs: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	// Every blob referenced by a surviving checkpoint event must still exist on
+	// disk: prune must not have deleted a blob that capture had referenced.
+	refs, err := store.referencedBlobs("s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for hash := range refs {
+		if _, err := store.readBlob("s", hash); err != nil {
+			t.Fatalf("referenced blob %s missing after concurrent prune: %v", hash, err)
+		}
+	}
+}
+
+// Finding 8: an OS-level file lock must serialize session mutations across
+// separate Store instances on the same RootDir (e.g. CLI rewind vs TUI). While
+// one Store holds the session lock, another Store's AppendEvent must block.
+func TestSessionFileLockSerializesAcrossStores(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock semantics differ on windows")
+	}
+	root := t.TempDir()
+	storeA := NewStore(StoreOptions{RootDir: root})
+	if _, err := storeA.Create(CreateInput{SessionID: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	storeB := NewStore(StoreOptions{RootDir: root})
+
+	// storeA grabs the OS lock and holds it.
+	unlock, err := storeA.lockSession("s")
+	if err != nil {
+		t.Fatalf("lockSession: %v", err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(started)
+		// This must block until storeA releases the OS lock.
+		if _, err := storeB.AppendEvent("s", AppendEventInput{Type: EventMessage, Payload: map[string]any{}}); err != nil {
+			t.Errorf("storeB AppendEvent: %v", err)
+		}
+		close(done)
+	}()
+
+	<-started
+	select {
+	case <-done:
+		t.Fatalf("storeB AppendEvent completed while storeA held the OS lock")
+	case <-time.After(150 * time.Millisecond):
+		// Expected: still blocked.
+	}
+
+	unlock()
+
+	select {
+	case <-done:
+		// storeB proceeded once the lock was released.
+	case <-time.After(2 * time.Second):
+		t.Fatalf("storeB AppendEvent did not proceed after lock release")
+	}
+	wg.Wait()
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -32,6 +32,7 @@ const (
 	EventProviderUsage      EventType = "provider_usage"
 	EventUsage              EventType = EventProviderUsage
 	EventError              EventType = "error"
+	EventSessionCheckpoint  EventType = "session_checkpoint"
 	EventSessionRewind      EventType = "session_rewind"
 	EventCompaction         EventType = "session_compaction"
 	EventSessionFork        EventType = "session_fork"
@@ -134,9 +135,18 @@ type StoreOptions struct {
 }
 
 type Store struct {
-	RootDir      string
-	now          func() time.Time
-	locksMu      sync.Mutex
+	RootDir string
+	now     func() time.Time
+	locksMu sync.Mutex
+	// sessionLocks holds one in-process mutex per session id. Entries are never
+	// removed: doing so safely would require reference counting (a goroutine
+	// blocked on a mutex must not have it deleted and recreated out from under
+	// it, which would break mutual exclusion). The cost of leaving them is a
+	// single *sync.Mutex per distinct session id touched by this Store's
+	// lifetime, which is small and bounded in practice — the CLI process is
+	// short-lived and the TUI works with a bounded set of sessions. There is no
+	// session-close/delete lifecycle hook to prune against, so unbounded growth
+	// is accepted deliberately rather than risk an unsafe eviction.
 	sessionLocks map[string]*sync.Mutex
 	idCounter    atomic.Uint64
 }
@@ -325,6 +335,13 @@ func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, err
 			return Metadata{}, err
 		}
 	}
+	// Copy the parent's content-addressed checkpoint blobs into the fork so the
+	// copied EventSessionCheckpoint events resolve to real blobs and a rewind on
+	// the fork can restore file content (otherwise rewind reads missing blobs
+	// and silently skips the files).
+	if err := store.copyBlobs(parent.SessionID, fork.SessionID); err != nil {
+		return Metadata{}, err
+	}
 	if _, err := store.AppendEvent(fork.SessionID, AppendEventInput{
 		Type: EventSessionFork,
 		Payload: map[string]any{
@@ -351,10 +368,21 @@ func (store *Store) AppendEvent(sessionID string, input AppendEventInput) (Event
 	if strings.TrimSpace(string(input.Type)) == "" {
 		return Event{}, fmt.Errorf("zero session event type is required")
 	}
-	lock := store.sessionLock(sessionID)
-	lock.Lock()
-	defer lock.Unlock()
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return Event{}, err
+	}
+	defer unlock()
 
+	return store.appendEventLocked(sessionID, input)
+}
+
+// appendEventLocked appends an event WITHOUT acquiring the session lock. The
+// caller MUST already hold store.lockSession(sessionID). It exists so multi-step
+// operations (e.g. ApplyRewind) can append the trailing marker atomically under
+// the single lock they already hold, instead of re-locking (which would deadlock
+// on the non-reentrant in-process mutex).
+func (store *Store) appendEventLocked(sessionID string, input AppendEventInput) (Event, error) {
 	session, err := store.readMetadata(sessionID)
 	if err != nil {
 		return Event{}, err
@@ -446,6 +474,30 @@ func (store *Store) sessionLock(sessionID string) *sync.Mutex {
 	return lock
 }
 
+// lockSession serializes mutations to a session both in-process (the existing
+// per-Store mutex) and across processes (an OS file lock on a per-session
+// .lock file), so a CLI rewind and a TUI sharing the same RootDir cannot
+// interleave writes. It returns an unlock function that releases both locks in
+// reverse order. The OS lock is best-effort: if it cannot be acquired (e.g. an
+// unsupported platform) the in-memory mutex still applies.
+func (store *Store) lockSession(sessionID string) (func(), error) {
+	mu := store.sessionLock(sessionID)
+	mu.Lock()
+	release, err := store.acquireFileLock(sessionID)
+	if err != nil {
+		mu.Unlock()
+		return nil, err
+	}
+	return func() {
+		release()
+		mu.Unlock()
+	}, nil
+}
+
+func (store *Store) lockPath(sessionID string) string {
+	return filepath.Join(store.sessionPath(sessionID), "session.lock")
+}
+
 func (store *Store) sessionPath(sessionID string) string {
 	return filepath.Join(store.RootDir, sessionID)
 }
@@ -476,11 +528,12 @@ func (store *Store) writeMetadata(session Metadata) error {
 		return fmt.Errorf("encode zero session metadata: %w", err)
 	}
 	path := store.metadataPath(session.SessionID)
-	tmp := path + ".tmp"
+	tmp := fmt.Sprintf("%s.tmp-%d", path, store.idCounter.Add(1))
 	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write zero session metadata: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
 		return fmt.Errorf("replace zero session metadata: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Module 4 of N — Session checkpoints & safe rewind

Fourth slice of the runtime-core split. **Scope: `internal/sessions` only** (7 files, +1346/−7). Unlike the earlier modules this package had drifted on `main` (#106 added `Tag`/`Depth`), so this was **3-way merged** onto the current `main` — #106's Tag/Depth is preserved, `store.go` merged with no conflicts. No new deps (file locking uses stdlib `syscall`).

### What's in it
- **Content-addressed checkpoints**: `CaptureToolCheckpoint` snapshots a tool's target files into sha256 blobs before a mutating tool runs; records file mode; skips oversize files; dedupes identical content.
- **Safe rewind**: `RestoreToSequence` reverts to a target sequence — applies only the **closest-to-target** checkpoint per path, **verifies each blob's sha256** before writing, preserves file mode, and **confines paths with `EvalSymlinks`** (no symlink escape). `ApplyRewind` runs restore + truncate + prune + marker **atomically under one session lock**.
- **Concurrency/robustness**: cross-process **flock** serializes session mutations; `Fork` copies checkpoint blobs so a fork can rewind; `writeMetadata` uses a unique tmp suffix.

### Forward code (compiles now, wired later)
This is the persistence layer. The CLI `zero sessions rewind` and the TUI `/rewind` + pre-tool checkpoint capture wiring land in later modules; the API is exercised here by `checkpoint_test.go` / `rewind_test.go`.

### Testing
`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./internal/sessions/`, and `GOOS=windows go build ./internal/sessions/` all green.

Part of decomposing #101 (draft); subagents excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-session workspace checkpoints with content-addressed storage and deduplication
  * Restore/rewind to prior snapshots, fork-aware restores, orphan snapshot pruning
  * Cross-process session file locking to serialize concurrent session operations

* **Bug Fixes / Safety**
  * Skips oversized/unreadable files and enforces workspace-boundary checks
  * Rejects corrupt checkpoint data rather than silently restoring tampered content
  * Prevents path-traversal escapes during capture and restore

* **Tests**
  * Expanded coverage for capture/restore, deduplication, concurrency, locking, and permissions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->