### PR TITLE
Add specialist Task runtime

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -166,6 +166,12 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		PermissionMode:    string(permissionMode),
 		Autonomy:          options.Autonomy,
 		Sandbox:           options.Sandbox,
+		ToolCallID:        call.ID,
+		SessionID:         options.SessionID,
+		Model:             options.Model,
+		ReasoningEffort:   options.ReasoningEffort,
+		Depth:             options.Depth,
+		Cwd:               options.Cwd,
 		// Note: we no longer rely on OnSandboxDecision callback for capture here
 		// (it is still supported for other observers and is invoked asynchronously in the registry).
 		// The sandbox decision (if any) is now returned synchronously on the Result for permission event building.
@@ -499,7 +505,7 @@ func ToolAdvertised(tool tools.Tool, permissionMode PermissionMode) bool {
 		return false
 	}
 	if permissionMode == PermissionModeAuto {
-		return tool.Safety().Permission == tools.PermissionAllow
+		return tool.Safety().Permission == tools.PermissionAllow || tool.Safety().AdvertiseInAuto
 	}
 	return true
 }

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -85,11 +85,15 @@ type Options struct {
 	MaxTurns int
 	// Specialist/sub-agent metadata is carried through exec now and consumed by
 	// the specialist runtime in later slices.
+	SessionID           string
 	CallingSessionID    string
 	CallingToolUseID    string
 	Tag                 string
 	Depth               int
 	SessionTitle        string
+	Model               string
+	ReasoningEffort     string
+	Cwd                 string
 	Registry            *tools.Registry
 	PermissionMode      PermissionMode
 	Autonomy            string

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
@@ -16,6 +17,7 @@ import (
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/selfverify"
 	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specialist"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
 	"github.com/Gitlawb/zero/internal/update"
@@ -274,6 +276,9 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
+	if err := registerSpecialistTools(registry, workspaceRoot); err != nil {
+		return writeAppError(stderr, "failed to initialize specialist tools: "+err.Error(), 1)
+	}
 	mcpRuntime, err := registerMCPToolsForWorkspace(context.Background(), workspaceRoot, registry, deps, mcp.AutonomyLow)
 	if err != nil {
 		return writeAppError(stderr, err.Error(), 1)
@@ -324,6 +329,22 @@ func newCoreRegistry(workspaceRoot string) *tools.Registry {
 		registry.Register(tool)
 	}
 	return registry
+}
+
+func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) error {
+	paths, err := specialist.DefaultPaths(workspaceRoot)
+	if err != nil {
+		return err
+	}
+	specialist.RegisterTools(registry, specialist.Executor{Paths: paths})
+	return nil
+}
+
+func shouldRegisterExecSpecialistTools(options execOptions) bool {
+	if strings.EqualFold(strings.TrimSpace(options.tag), specialist.SessionTagSpecialist) {
+		return false
+	}
+	return options.skipPermissionsUnsafe || strings.EqualFold(strings.TrimSpace(options.autonomy), "high")
 }
 
 func closeMCPRuntime(stderr io.Writer, runtime mcpToolRuntime) {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -621,6 +621,7 @@ func assertCoreRegistry(t *testing.T, registry *tools.Registry) {
 	}
 
 	for _, name := range []string{
+		"Task",
 		"read_file",
 		"list_directory",
 		"glob",

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -103,6 +103,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
+	if shouldRegisterExecSpecialistTools(options) {
+		if err := registerSpecialistTools(registry, workspaceRoot); err != nil {
+			return writeExecProviderError(stdout, stderr, options.outputFormat, "specialist_error", err.Error())
+		}
+	}
 	permissionMode, err := resolveExecPermissionMode(options)
 	if err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
@@ -166,16 +171,20 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	agentPrompt := prompt
 	if shouldUseExecSession(options) {
 		preparedSession, err = sessions.PrepareExec(sessions.PrepareExecOptions{
-			SessionID:    options.initSessionID,
-			Title:        sessionTitle,
-			Cwd:          workspaceRoot,
-			ModelID:      resolved.Provider.Model,
-			Provider:     runMetadata.Provider,
-			Tag:          options.tag,
-			Depth:        options.depth,
-			Resume:       options.resume,
-			ResumeLatest: options.resumeLatest,
-			Fork:         options.fork,
+			SessionID:        options.initSessionID,
+			Title:            sessionTitle,
+			Cwd:              workspaceRoot,
+			ModelID:          resolved.Provider.Model,
+			Provider:         runMetadata.Provider,
+			Tag:              options.tag,
+			Depth:            options.depth,
+			CallingSessionID: options.callingSessionID,
+			CallingToolUseID: options.callingToolUseID,
+			AgentName:        specialistAgentName(options.sessionTitle),
+			TaskID:           options.initSessionID,
+			Resume:           options.resume,
+			ResumeLatest:     options.resumeLatest,
+			Fork:             options.fork,
 		})
 		if err != nil {
 			return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
@@ -213,11 +222,15 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 
 	result, err := agent.Run(context.Background(), agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
+		SessionID:        preparedSession.Session.SessionID,
 		CallingSessionID: options.callingSessionID,
 		CallingToolUseID: options.callingToolUseID,
 		Tag:              options.tag,
 		Depth:            options.depth,
 		SessionTitle:     sessionTitle,
+		Model:            resolved.Provider.Model,
+		ReasoningEffort:  options.reasoningEffort,
+		Cwd:              workspaceRoot,
 		Registry:         registry,
 		PermissionMode:   permissionMode,
 		Autonomy:         options.autonomy,

--- a/internal/cli/exec_sessions.go
+++ b/internal/cli/exec_sessions.go
@@ -75,6 +75,17 @@ func execSessionTitle(options execOptions, prompt string) string {
 	return createSessionTitle(prompt)
 }
 
+func specialistAgentName(sessionTitle string) string {
+	title := strings.TrimSpace(sessionTitle)
+	if title == "" {
+		return ""
+	}
+	if name, _, ok := strings.Cut(title, ":"); ok {
+		return strings.TrimSpace(name)
+	}
+	return title
+}
+
 func (recorder *execSessionRecorder) append(eventType sessions.EventType, payload any) {
 	if recorder.err != nil || recorder.prepared.Store == nil || recorder.prepared.Session.SessionID == "" {
 		return

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -185,6 +185,36 @@ func TestParseExecSpecialistMetadataRejectsInvalidValues(t *testing.T) {
 	}
 }
 
+func TestRunExecRegistersTaskOnlyForUnsafeTopLevelRuns(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantTask bool
+	}{
+		{name: "default headless", args: []string{"exec", "--list-tools"}, wantTask: false},
+		{name: "unsafe headless", args: []string{"exec", "--auto", "high", "--list-tools"}, wantTask: true},
+		{name: "specialist child", args: []string{"exec", "--auto", "high", "--tag", "specialist", "--list-tools"}, wantTask: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(tc.args, &stdout, &stderr, appDeps{
+				getwd: func() (string, error) {
+					return t.TempDir(), nil
+				},
+			})
+			if exitCode != exitSuccess {
+				t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+			}
+			hasTask := strings.Contains(stdout.String(), "  Task ")
+			if hasTask != tc.wantTask {
+				t.Fatalf("Task visibility = %v, want %v; output:\n%s", hasTask, tc.wantTask, stdout.String())
+			}
+		})
+	}
+}
+
 func TestRunExecUsesInitSessionIDAndSessionTitle(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)
@@ -227,6 +257,61 @@ func TestRunExecUsesInitSessionIDAndSessionTitle(t *testing.T) {
 	}
 	if session.Cwd != cwd {
 		t.Fatalf("session cwd = %q, want %q", session.Cwd, cwd)
+	}
+}
+
+func TestRunExecPersistsCallingSessionChildMetadata(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: filepath.Join(dataHome, "zero", "sessions")})
+	parent, err := store.Create(sessions.CreateInput{SessionID: "parent_session", Title: "Parent", Cwd: "/repo", ModelID: "gpt-parent", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create parent returned error: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--output-format", "stream-json",
+		"--init-session-id", "child_session",
+		"--session-title", "worker: Auth check",
+		"--tag", "specialist",
+		"--depth", "1",
+		"--calling-session-id", parent.SessionID,
+		"--calling-tool-use-id", "toolu_123",
+		"hello",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return t.TempDir(), nil
+		},
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return execResolvedConfig(), nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+
+	child, err := store.Get("child_session")
+	if err != nil {
+		t.Fatalf("Get child returned error: %v", err)
+	}
+	if child == nil {
+		t.Fatal("expected child session metadata")
+	}
+	if child.SessionKind != sessions.SessionKindChild ||
+		child.ParentSessionID != parent.SessionID ||
+		child.RootSessionID != parent.SessionID ||
+		child.AgentName != "worker" ||
+		child.TaskID != "child_session" ||
+		child.SpawnedFromEventID != "toolu_123" ||
+		child.Tag != "specialist" ||
+		child.Depth != 1 {
+		t.Fatalf("unexpected child metadata: %#v", child)
 	}
 }
 

--- a/internal/sessions/exec_session.go
+++ b/internal/sessions/exec_session.go
@@ -23,17 +23,21 @@ func (err ExecError) Error() string {
 }
 
 type PrepareExecOptions struct {
-	Store        *Store
-	SessionID    string
-	Title        string
-	Cwd          string
-	ModelID      string
-	Provider     string
-	Tag          string
-	Depth        int
-	Resume       string
-	ResumeLatest bool
-	Fork         string
+	Store            *Store
+	SessionID        string
+	Title            string
+	Cwd              string
+	ModelID          string
+	Provider         string
+	Tag              string
+	Depth            int
+	CallingSessionID string
+	CallingToolUseID string
+	AgentName        string
+	TaskID           string
+	Resume           string
+	ResumeLatest     bool
+	Fork             string
 }
 
 type PreparedExec struct {
@@ -106,7 +110,7 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		return PreparedExec{Mode: ModeResume, Session: *session, ContextEvents: contextEvents, Store: store}, nil
 	}
 
-	session, err := store.Create(CreateInput{
+	createInput := CreateInput{
 		SessionID: options.SessionID,
 		Title:     options.Title,
 		Cwd:       options.Cwd,
@@ -114,7 +118,24 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		Provider:  options.Provider,
 		Tag:       options.Tag,
 		Depth:     options.Depth,
-	})
+	}
+	if strings.TrimSpace(options.CallingSessionID) != "" {
+		parentSessionID := strings.TrimSpace(options.CallingSessionID)
+		parent, err := store.Get(parentSessionID)
+		if err != nil {
+			return PreparedExec{}, err
+		}
+		if parent == nil {
+			return PreparedExec{}, ExecError{"Zero parent session not found: " + parentSessionID}
+		}
+		createInput.SessionKind = SessionKindChild
+		createInput.ParentSessionID = parent.SessionID
+		createInput.RootSessionID = firstNonEmpty(parent.RootSessionID, parent.SessionID)
+		createInput.AgentName = strings.TrimSpace(options.AgentName)
+		createInput.TaskID = strings.TrimSpace(firstNonEmpty(options.TaskID, options.SessionID))
+		createInput.SpawnedFromEventID = strings.TrimSpace(options.CallingToolUseID)
+	}
+	session, err := store.Create(createInput)
 	if err != nil {
 		return PreparedExec{}, err
 	}

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -38,6 +38,7 @@ type Executor struct {
 	RunChild          RunChildFunc
 	BinaryPath        string
 	Paths             Paths
+	SessionStore      *sessions.Store
 }
 
 type BuildArgsInput struct {
@@ -218,7 +219,18 @@ func (executor Executor) runFresh(ctx context.Context, params TaskParameters, op
 }
 
 func (executor Executor) runResume(ctx context.Context, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
-	manifest, err := executor.loadManifest(params.Name)
+	session, err := executor.resumeSession(params.Resume)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	specialistName := strings.TrimSpace(session.AgentName)
+	if specialistName == "" {
+		return ExecResult{}, fmt.Errorf("resume session %q does not identify a specialist", session.SessionID)
+	}
+	if requestedName := strings.TrimSpace(params.Name); requestedName != "" && requestedName != specialistName {
+		return ExecResult{}, fmt.Errorf("resume session %q belongs to specialist %q, not %q", session.SessionID, specialistName, requestedName)
+	}
+	manifest, err := executor.loadManifest(specialistName)
 	if err != nil {
 		return ExecResult{}, err
 	}
@@ -233,6 +245,31 @@ func (executor Executor) runResume(ctx context.Context, params TaskParameters, o
 		return ExecResult{}, err
 	}
 	return executor.runBuiltArgs(ctx, built)
+}
+
+func (executor Executor) resumeSession(sessionID string) (*sessions.Metadata, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, fmt.Errorf("resume session id is required")
+	}
+	if !sessions.ValidSessionID(sessionID) {
+		return nil, fmt.Errorf("invalid resume session id %q", sessionID)
+	}
+	store := executor.SessionStore
+	if store == nil {
+		store = sessions.NewStore(sessions.StoreOptions{})
+	}
+	session, err := store.Get(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if session == nil {
+		return nil, fmt.Errorf("resume session not found: %s", sessionID)
+	}
+	if session.SessionKind != sessions.SessionKindChild || strings.TrimSpace(session.Tag) != sessionTagSpecialist {
+		return nil, fmt.Errorf("resume session %q is not a specialist child session", sessionID)
+	}
+	return session, nil
 }
 
 func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult) (ExecResult, error) {

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -1,15 +1,21 @@
 package specialist
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 const (
@@ -17,13 +23,21 @@ const (
 	promptFileThresholdBytes = 4 * 1024
 )
 
+const SessionTagSpecialist = sessionTagSpecialist
+
 type NewSessionIDFunc func() (string, error)
 type WritePromptFileFunc func(prompt string) (string, error)
+type LoadFunc func(LoadOptions) (LoadResult, error)
+type RunChildFunc func(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error)
 
 type Executor struct {
 	NewSessionID      NewSessionIDFunc
 	WritePromptFile   WritePromptFileFunc
 	PromptFileMaxSize int
+	Load              LoadFunc
+	RunChild          RunChildFunc
+	BinaryPath        string
+	Paths             Paths
 }
 
 type BuildArgsInput struct {
@@ -35,12 +49,15 @@ type BuildArgsInput struct {
 	ParentReasoningEffort string
 	CurrentDepth          int
 	Description           string
+	Cwd                   string
 }
 
 type BuildResumeArgsInput struct {
 	SessionID    string
 	Prompt       string
 	CurrentDepth int
+	Manifest     Manifest
+	Cwd          string
 }
 
 type BuildArgsResult struct {
@@ -48,6 +65,49 @@ type BuildArgsResult struct {
 	SessionID string
 	// PromptFile is created for large prompts; callers own cleanup after exec finishes.
 	PromptFile string
+}
+
+type TaskParameters struct {
+	Name        string
+	Prompt      string
+	Description string
+	Resume      string
+}
+
+type TaskRunOptions struct {
+	ToolCallID            string
+	ParentSessionID       string
+	ParentModel           string
+	ParentReasoningEffort string
+	CurrentDepth          int
+	Cwd                   string
+}
+
+type ExecResult struct {
+	Result    tools.Result
+	SessionID string
+}
+
+type ChildRunResult struct {
+	Events   []streamjson.Event
+	Stderr   string
+	ExitCode int
+}
+
+func (executor Executor) Run(ctx context.Context, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if options.CurrentDepth < 0 {
+		return ExecResult{}, fmt.Errorf("current depth cannot be negative")
+	}
+	if strings.TrimSpace(params.Prompt) == "" {
+		return ExecResult{}, fmt.Errorf("specialist prompt is required")
+	}
+	if strings.TrimSpace(params.Resume) != "" {
+		return executor.runResume(ctx, params, options)
+	}
+	return executor.runFresh(ctx, params, options)
 }
 
 func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error) {
@@ -75,9 +135,14 @@ func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error
 	args = append(args, promptArgs...)
 	args = appendModelArgs(args, input.Manifest, input.ParentModel, input.ParentReasoningEffort)
 	args = append(args, "--auto", "high", "--output-format", "stream-json")
-	if len(input.Manifest.ResolvedTools) > 0 {
-		args = append(args, "--enabled-tools", strings.Join(input.Manifest.ResolvedTools, ","))
+	toolAllowlist, err := resolvedToolAllowlist(input.Manifest)
+	if err != nil {
+		return BuildArgsResult{}, err
 	}
+	if len(toolAllowlist) == 0 {
+		return BuildArgsResult{}, fmt.Errorf("specialist %q resolved no enabled tools", input.Manifest.Metadata.Name)
+	}
+	args = append(args, "--enabled-tools", strings.Join(toolAllowlist, ","))
 	args = append(args, "--depth", strconv.Itoa(input.CurrentDepth+1), "--tag", sessionTagSpecialist)
 	if parentSessionID := strings.TrimSpace(input.ParentSessionID); parentSessionID != "" {
 		args = append(args, "--calling-session-id", parentSessionID)
@@ -87,6 +152,9 @@ func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error
 	}
 	if description := strings.TrimSpace(input.Description); description != "" {
 		args = append(args, "--session-title", strings.TrimSpace(input.Manifest.Metadata.Name)+": "+description)
+	}
+	if cwd := strings.TrimSpace(input.Cwd); cwd != "" {
+		args = append(args, "--cwd", cwd)
 	}
 	return BuildArgsResult{Args: args, SessionID: sessionID, PromptFile: promptFile}, nil
 }
@@ -112,8 +180,115 @@ func (executor Executor) BuildResumeArgs(input BuildResumeArgsInput) (BuildArgsR
 	args := []string{"exec", "--resume", sessionID}
 	args = append(args, promptArgs...)
 	args = append(args, "--auto", "high", "--output-format", "stream-json")
+	toolAllowlist, err := resolvedToolAllowlist(input.Manifest)
+	if err != nil {
+		return BuildArgsResult{}, err
+	}
+	if len(toolAllowlist) == 0 {
+		return BuildArgsResult{}, fmt.Errorf("specialist %q resolved no enabled tools", input.Manifest.Metadata.Name)
+	}
+	args = append(args, "--enabled-tools", strings.Join(toolAllowlist, ","))
 	args = append(args, "--depth", strconv.Itoa(input.CurrentDepth+1), "--tag", sessionTagSpecialist)
+	if cwd := strings.TrimSpace(input.Cwd); cwd != "" {
+		args = append(args, "--cwd", cwd)
+	}
 	return BuildArgsResult{Args: args, SessionID: sessionID, PromptFile: promptFile}, nil
+}
+
+func (executor Executor) runFresh(ctx context.Context, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
+	manifest, err := executor.loadManifest(params.Name)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	built, err := executor.BuildArgs(BuildArgsInput{
+		Manifest:              manifest,
+		Prompt:                params.Prompt,
+		ParentSessionID:       options.ParentSessionID,
+		ParentToolUseID:       options.ToolCallID,
+		ParentModel:           options.ParentModel,
+		ParentReasoningEffort: options.ParentReasoningEffort,
+		CurrentDepth:          options.CurrentDepth,
+		Description:           params.Description,
+		Cwd:                   options.Cwd,
+	})
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return executor.runBuiltArgs(ctx, built)
+}
+
+func (executor Executor) runResume(ctx context.Context, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
+	manifest, err := executor.loadManifest(params.Name)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	built, err := executor.BuildResumeArgs(BuildResumeArgsInput{
+		SessionID:    params.Resume,
+		Prompt:       params.Prompt,
+		CurrentDepth: options.CurrentDepth,
+		Manifest:     manifest,
+		Cwd:          options.Cwd,
+	})
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return executor.runBuiltArgs(ctx, built)
+}
+
+func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult) (ExecResult, error) {
+	if built.PromptFile != "" {
+		defer cleanupPromptFile(built.PromptFile)
+	}
+	binaryPath, err := executor.binaryPath()
+	if err != nil {
+		return ExecResult{}, err
+	}
+	run, err := executor.runChild(ctx, binaryPath, built.Args)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return ExecResult{
+		Result:    BuildFinalResult(run.Events, run.Stderr, run.ExitCode),
+		SessionID: built.SessionID,
+	}, nil
+}
+
+func (executor Executor) loadManifest(name string) (Manifest, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Manifest{}, fmt.Errorf("specialist name is required")
+	}
+	load := executor.Load
+	if load == nil {
+		load = Load
+	}
+	result, err := load(LoadOptions{Paths: executor.Paths})
+	if err != nil {
+		return Manifest{}, err
+	}
+	manifest, ok := Find(result, name)
+	if !ok {
+		return Manifest{}, fmt.Errorf("specialist %q not found", name)
+	}
+	return manifest, nil
+}
+
+func (executor Executor) binaryPath() (string, error) {
+	if path := strings.TrimSpace(executor.BinaryPath); path != "" {
+		return path, nil
+	}
+	path, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve zero executable: %w", err)
+	}
+	return path, nil
+}
+
+func (executor Executor) runChild(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error) {
+	if executor.RunChild != nil {
+		return executor.RunChild(ctx, binaryPath, append([]string(nil), args...))
+	}
+	return runChildProcess(ctx, binaryPath, args)
 }
 
 func appendModelArgs(args []string, manifest Manifest, parentModel string, parentReasoningEffort string) []string {
@@ -133,6 +308,13 @@ func appendModelArgs(args []string, manifest Manifest, parentModel string, paren
 		args = append(args, "--reasoning-effort", reasoningEffort)
 	}
 	return args
+}
+
+func resolvedToolAllowlist(manifest Manifest) ([]string, error) {
+	if len(manifest.ResolvedTools) > 0 {
+		return append([]string(nil), manifest.ResolvedTools...), nil
+	}
+	return ResolveTools(manifest.Metadata.Tools)
 }
 
 func (executor Executor) buildPromptArgs(prompt string) ([]string, string, error) {
@@ -181,4 +363,39 @@ func writePromptFile(prompt string) (string, error) {
 		return "", fmt.Errorf("write specialist prompt file: %w", err)
 	}
 	return promptPath, nil
+}
+
+func cleanupPromptFile(promptFile string) {
+	if promptFile == "" {
+		return
+	}
+	dir := filepath.Dir(promptFile)
+	if strings.HasPrefix(filepath.Base(dir), "zero-specialist-") {
+		_ = os.RemoveAll(dir)
+		return
+	}
+	_ = os.Remove(promptFile)
+}
+
+func runChildProcess(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command := osexec.CommandContext(ctx, binaryPath, args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	exitCode := 0
+	if err := command.Run(); err != nil {
+		var exitErr *osexec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode}, fmt.Errorf("run specialist child: %w", err)
+		}
+	}
+	events, err := ParseStream(bytes.NewReader(stdout.Bytes()))
+	if err != nil {
+		return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode}, err
+	}
+	return ChildRunResult{Events: events, Stderr: stderr.String(), ExitCode: exitCode}, nil
 }

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -89,6 +89,24 @@ func TestBuildArgsInheritsParentModelAndReasoning(t *testing.T) {
 	}
 }
 
+func TestBuildArgsDefaultsToReadOnlyToolAllowlist(t *testing.T) {
+	executor := Executor{NewSessionID: func() (string, error) { return "child", nil }}
+
+	result, err := executor.BuildArgs(BuildArgsInput{
+		Manifest: Manifest{
+			Metadata:     Metadata{Name: "worker", Description: "Works"},
+			SystemPrompt: "Do work.",
+		},
+		Prompt: "Do the thing",
+	})
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	if !containsSequence(result.Args, []string{"--enabled-tools", "glob,grep,list_directory,read_file"}) {
+		t.Fatalf("args missing default read-only allowlist: %#v", result.Args)
+	}
+}
+
 func TestBuildArgsWritesLargePromptFile(t *testing.T) {
 	root := t.TempDir()
 	var writtenPrompt string

--- a/internal/specialist/registry.go
+++ b/internal/specialist/registry.go
@@ -1,0 +1,7 @@
+package specialist
+
+import "github.com/Gitlawb/zero/internal/tools"
+
+func RegisterTools(registry *tools.Registry, executor Executor) {
+	registry.Register(NewTaskTool(executor))
+}

--- a/internal/specialist/task_tool.go
+++ b/internal/specialist/task_tool.go
@@ -114,10 +114,10 @@ func parseTaskParameters(args map[string]any) (TaskParameters, error) {
 		Resume:      strings.TrimSpace(resume),
 	}
 	if params.Name == "" {
-		return TaskParameters{}, fmt.Errorf("Task requires name")
+		return TaskParameters{}, fmt.Errorf("task requires name")
 	}
 	if params.Prompt == "" {
-		return TaskParameters{}, fmt.Errorf("Task requires prompt")
+		return TaskParameters{}, fmt.Errorf("task requires prompt")
 	}
 	return params, nil
 }
@@ -132,7 +132,7 @@ func optionalTaskString(args map[string]any, key string) (string, error) {
 	}
 	text, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("Task %s must be a string", key)
+		return "", fmt.Errorf("task %s must be a string", key)
 	}
 	return text, nil
 }

--- a/internal/specialist/task_tool.go
+++ b/internal/specialist/task_tool.go
@@ -1,0 +1,142 @@
+package specialist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const TaskToolName = "Task"
+
+type TaskTool struct {
+	executor Executor
+}
+
+func NewTaskTool(executor Executor) *TaskTool {
+	return &TaskTool{executor: executor}
+}
+
+func (tool *TaskTool) Name() string {
+	return TaskToolName
+}
+
+func (tool *TaskTool) Description() string {
+	return "Launch a Zero specialist sub-agent for a focused delegated task."
+}
+
+func (tool *TaskTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"name": {
+				Type:        "string",
+				Description: "Specialist name to invoke, such as worker, explorer, or code-review.",
+			},
+			"prompt": {
+				Type:        "string",
+				Description: "The focused task to give the specialist.",
+			},
+			"description": {
+				Type:        "string",
+				Description: "Short label for the child session.",
+			},
+			"resume": {
+				Type:        "string",
+				Description: "Existing specialist session id to resume.",
+			},
+		},
+		Required:             []string{"name", "prompt"},
+		AdditionalProperties: false,
+	}
+}
+
+func (tool *TaskTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectShell,
+		Permission:      tools.PermissionPrompt,
+		Reason:          "Spawns a Zero specialist sub-agent process.",
+		AdvertiseInAuto: true,
+	}
+}
+
+func (tool *TaskTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return tool.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+
+func (tool *TaskTool) RunWithOptions(ctx context.Context, args map[string]any, options tools.RunOptions) tools.Result {
+	params, err := parseTaskParameters(args)
+	if err != nil {
+		return taskError(err)
+	}
+	result, err := tool.executor.Run(ctx, params, TaskRunOptions{
+		ToolCallID:            options.ToolCallID,
+		ParentSessionID:       options.SessionID,
+		ParentModel:           options.Model,
+		ParentReasoningEffort: options.ReasoningEffort,
+		CurrentDepth:          options.Depth,
+		Cwd:                   options.Cwd,
+	})
+	if err != nil {
+		return taskError(err)
+	}
+	if result.Result.Meta == nil {
+		result.Result.Meta = map[string]string{}
+	}
+	if result.SessionID != "" {
+		result.Result.Meta["session_id"] = result.SessionID
+	}
+	return result.Result
+}
+
+func parseTaskParameters(args map[string]any) (TaskParameters, error) {
+	name, err := optionalTaskString(args, "name")
+	if err != nil {
+		return TaskParameters{}, err
+	}
+	prompt, err := optionalTaskString(args, "prompt")
+	if err != nil {
+		return TaskParameters{}, err
+	}
+	description, err := optionalTaskString(args, "description")
+	if err != nil {
+		return TaskParameters{}, err
+	}
+	resume, err := optionalTaskString(args, "resume")
+	if err != nil {
+		return TaskParameters{}, err
+	}
+	params := TaskParameters{
+		Name:        strings.TrimSpace(name),
+		Prompt:      strings.TrimSpace(prompt),
+		Description: strings.TrimSpace(description),
+		Resume:      strings.TrimSpace(resume),
+	}
+	if params.Name == "" {
+		return TaskParameters{}, fmt.Errorf("Task requires name")
+	}
+	if params.Prompt == "" {
+		return TaskParameters{}, fmt.Errorf("Task requires prompt")
+	}
+	return params, nil
+}
+
+func optionalTaskString(args map[string]any, key string) (string, error) {
+	if args == nil {
+		return "", nil
+	}
+	value, ok := args[key]
+	if !ok || value == nil {
+		return "", nil
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("Task %s must be a string", key)
+	}
+	return text, nil
+}
+
+func taskError(err error) tools.Result {
+	return tools.Result{Status: tools.StatusError, Output: "Error: " + err.Error()}
+}

--- a/internal/specialist/task_tool_test.go
+++ b/internal/specialist/task_tool_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
 )
@@ -89,8 +90,18 @@ func TestTaskToolRunsForegroundSpecialist(t *testing.T) {
 
 func TestTaskToolRunsResumeSpecialist(t *testing.T) {
 	var gotArgs []string
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	if _, err := store.Create(sessions.CreateInput{
+		SessionID:   "child_task",
+		SessionKind: sessions.SessionKindChild,
+		Tag:         SessionTagSpecialist,
+		AgentName:   "worker",
+	}); err != nil {
+		t.Fatalf("Create resume session returned error: %v", err)
+	}
 	executor := Executor{
 		NewSessionID: func() (string, error) { return "unused", nil },
+		SessionStore: store,
 		Load: func(LoadOptions) (LoadResult, error) {
 			return LoadResult{Specialists: []Manifest{{
 				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
@@ -122,6 +133,28 @@ func TestTaskToolRunsResumeSpecialist(t *testing.T) {
 		if !containsSequence(gotArgs, want) {
 			t.Fatalf("resume args missing %v: %#v", want, gotArgs)
 		}
+	}
+}
+
+func TestTaskToolRejectsResumeSpecialistMismatch(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	if _, err := store.Create(sessions.CreateInput{
+		SessionID:   "child_task",
+		SessionKind: sessions.SessionKindChild,
+		Tag:         SessionTagSpecialist,
+		AgentName:   "worker",
+	}); err != nil {
+		t.Fatalf("Create resume session returned error: %v", err)
+	}
+
+	result := NewTaskTool(Executor{SessionStore: store}).Run(context.Background(), map[string]any{
+		"name":   "explorer",
+		"prompt": "follow up",
+		"resume": "child_task",
+	})
+
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, `belongs to specialist "worker"`) {
+		t.Fatalf("mismatch result = %#v", result)
 	}
 }
 

--- a/internal/specialist/task_tool_test.go
+++ b/internal/specialist/task_tool_test.go
@@ -1,0 +1,183 @@
+package specialist
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestTaskToolRunsForegroundSpecialist(t *testing.T) {
+	zero := 0
+	var gotBinary string
+	var gotArgs []string
+	executor := Executor{
+		BinaryPath:   "/usr/local/bin/zero",
+		NewSessionID: func() (string, error) { return "child_task", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata: Metadata{
+					Name:        "worker",
+					Description: "Does focused work",
+					Tools:       []string{"read-only"},
+				},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"grep", "read_file"},
+			}}}, nil
+		},
+		RunChild: func(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error) {
+			gotBinary = binaryPath
+			gotArgs = append([]string(nil), args...)
+			return ChildRunResult{
+				Events: []streamjson.Event{
+					{Type: streamjson.EventRunStart, SessionID: "child_task"},
+					{Type: streamjson.EventFinal, Text: "child finished"},
+					{Type: streamjson.EventRunEnd, Status: "success", ExitCode: &zero},
+				},
+			}, nil
+		},
+	}
+
+	result := NewTaskTool(executor).RunWithOptions(context.Background(), map[string]any{
+		"name":        "worker",
+		"prompt":      "inspect auth",
+		"description": "Auth check",
+	}, tools.RunOptions{
+		ToolCallID:      "call_1",
+		SessionID:       "parent_session",
+		Model:           "gpt-4.1",
+		ReasoningEffort: "medium",
+		Depth:           1,
+		Cwd:             "/repo",
+	})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("Task status = %s, output=%s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "session_id: child_task") || !strings.Contains(result.Output, "child finished") {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+	if result.Meta["session_id"] != "child_task" {
+		t.Fatalf("session meta = %#v", result.Meta)
+	}
+	if gotBinary != "/usr/local/bin/zero" {
+		t.Fatalf("binary = %q", gotBinary)
+	}
+	for _, want := range [][]string{
+		{"exec", "--init-session-id", "child_task"},
+		{"--model", "gpt-4.1"},
+		{"--reasoning-effort", "medium"},
+		{"--enabled-tools", "grep,read_file"},
+		{"--depth", "2"},
+		{"--tag", "specialist"},
+		{"--calling-session-id", "parent_session"},
+		{"--calling-tool-use-id", "call_1"},
+		{"--session-title", "worker: Auth check"},
+		{"--cwd", "/repo"},
+	} {
+		if !containsSequence(gotArgs, want) {
+			t.Fatalf("args missing %v: %#v", want, gotArgs)
+		}
+	}
+}
+
+func TestTaskToolRunsResumeSpecialist(t *testing.T) {
+	var gotArgs []string
+	executor := Executor{
+		NewSessionID: func() (string, error) { return "unused", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		RunChild: func(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error) {
+			gotArgs = append([]string(nil), args...)
+			return ChildRunResult{Events: []streamjson.Event{{Type: streamjson.EventFinal, Text: "resumed"}}}, nil
+		},
+	}
+
+	result := NewTaskTool(executor).RunWithOptions(context.Background(), map[string]any{
+		"name":   "worker",
+		"prompt": "follow up",
+		"resume": "child_task",
+	}, tools.RunOptions{Depth: 2})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("Task status = %s, output=%s", result.Status, result.Output)
+	}
+	for _, want := range [][]string{
+		{"exec", "--resume", "child_task"},
+		{"--enabled-tools", "read_file"},
+		{"--depth", "3"},
+		{"--tag", "specialist"},
+	} {
+		if !containsSequence(gotArgs, want) {
+			t.Fatalf("resume args missing %v: %#v", want, gotArgs)
+		}
+	}
+}
+
+func TestTaskToolCleansPromptFileAfterChildRun(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "spill")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	promptFile := filepath.Join(dir, "prompt.md")
+	executor := Executor{
+		NewSessionID:      func() (string, error) { return "child_task", nil },
+		PromptFileMaxSize: 1,
+		WritePromptFile: func(prompt string) (string, error) {
+			return promptFile, os.WriteFile(promptFile, []byte(prompt), 0o600)
+		},
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		RunChild: func(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error) {
+			if _, err := os.Stat(promptFile); err != nil {
+				t.Fatalf("prompt file should exist during child run: %v", err)
+			}
+			if !reflect.DeepEqual(args[:5], []string{"exec", "--init-session-id", "child_task", "--file", promptFile}) {
+				t.Fatalf("prompt file args = %#v", args[:5])
+			}
+			return ChildRunResult{Events: []streamjson.Event{{Type: streamjson.EventFinal, Text: "ok"}}}, nil
+		},
+	}
+
+	result := NewTaskTool(executor).Run(context.Background(), map[string]any{
+		"name":   "worker",
+		"prompt": strings.Repeat("large ", 20),
+	})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("Task status = %s, output=%s", result.Status, result.Output)
+	}
+	if _, err := os.Stat(promptFile); !os.IsNotExist(err) {
+		t.Fatalf("prompt file cleanup error = %v", err)
+	}
+}
+
+func TestTaskToolRejectsInvalidParameters(t *testing.T) {
+	result := NewTaskTool(Executor{}).Run(context.Background(), map[string]any{"name": "worker"})
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "prompt") {
+		t.Fatalf("missing prompt result = %#v", result)
+	}
+}
+
+func TestTaskToolIsAdvertisedInAutoMode(t *testing.T) {
+	tool := NewTaskTool(Executor{})
+	if !agent.ToolVisible(tool, agent.PermissionModeAuto, nil, nil) {
+		t.Fatal("Task should be visible in auto mode so the TUI can request permission")
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -16,10 +16,20 @@ type RunOptions struct {
 	Autonomy          string
 	Sandbox           *sandbox.Engine
 	OnSandboxDecision func(sandbox.Decision)
+	ToolCallID        string
+	SessionID         string
+	Model             string
+	ReasoningEffort   string
+	Depth             int
+	Cwd               string
 }
 
 type sandboxAwareTool interface {
 	RunWithSandbox(ctx context.Context, args map[string]any, engine *sandbox.Engine) Result
+}
+
+type optionsAwareTool interface {
+	RunWithOptions(ctx context.Context, args map[string]any, options RunOptions) Result
 }
 
 func NewRegistry() *Registry {
@@ -102,6 +112,14 @@ func (registry *Registry) RunWithOptions(ctx context.Context, name string, args 
 	default:
 		res := errorResult("Error: Permission denied for " + name + ": " + tool.Safety().Reason)
 		res.SandboxDecision = sandboxDecision
+		return res
+	}
+
+	if optioned, ok := tool.(optionsAwareTool); ok {
+		res := optioned.RunWithOptions(ctx, args, options)
+		if res.SandboxDecision == nil {
+			res.SandboxDecision = sandboxDecision
+		}
 		return res
 	}
 

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -33,6 +33,9 @@ type Safety struct {
 	SideEffect SideEffect
 	Permission Permission
 	Reason     string
+	// AdvertiseInAuto allows selected prompt-gated tools to be visible while
+	// still requiring the normal permission flow before execution.
+	AdvertiseInAuto bool
 }
 
 type Schema struct {
@@ -52,11 +55,11 @@ type PropertySchema struct {
 }
 
 type Result struct {
-	Status            Status
-	Output            string
-	Truncated         bool
-	Meta              map[string]string
-	SandboxDecision   *sandbox.Decision `json:"-"`
+	Status          Status
+	Output          string
+	Truncated       bool
+	Meta            map[string]string
+	SandboxDecision *sandbox.Decision `json:"-"`
 }
 
 type Tool interface {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -518,6 +518,10 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		options := m.agentOptions
 		options.Registry = m.registry
 		options.PermissionMode = m.permissionMode
+		options.SessionID = m.activeSession.SessionID
+		options.Model = m.modelName
+		options.ReasoningEffort = string(m.reasoningEffort)
+		options.Cwd = m.cwd
 
 		onPermissionRequest := options.OnPermissionRequest
 		options.OnPermissionRequest = func(ctx context.Context, request agent.PermissionRequest) (agent.PermissionDecision, error) {


### PR DESCRIPTION
Summary:
- adds the LLM-facing Task tool and registers it in the TUI/top-level runtime
- runs specialists as foreground child zero exec processes with stream-json parsing, prompt-file cleanup, cwd/model/reasoning inheritance, and explicit tool allowlists
- persists child session metadata from calling-session/calling-tool-use flags and hides Task inside specialist child runs

Scope:
- foreground Task only; background TaskOutput/TaskStop, lifecycle hooks, usage rollup, and create/delete CLI management stay for follow-up PRs
- headless zero exec only exposes Task when explicitly unsafe/high autonomy; normal headless runs and specialist child runs do not expose it

Self-review:
- verified no shell command string construction for child args; process spawn uses argv slices
- tightened default allowlist so child runs always pass --enabled-tools, avoiding empty-tools == all-tools behavior
- added session metadata regression so child sessions preserve parent id, task id, tag, depth, and tool-use id

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist ./internal/cli ./internal/agent ./internal/tools ./internal/tui ./internal/sessions
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --cached --check
- GOCACHE=/tmp/zero-go-cache GOOS=windows go test -c ./internal/specialist
- GOCACHE=/tmp/zero-go-cache go build ./cmd/zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Task specialist tool and automatic specialist tool registration into interactive and exec flows.
  * Agent runs now receive richer session/context metadata (session IDs, model, reasoning effort, depth, working directory) propagated end-to-end.
  * Tool advertisement in auto-permission mode widened to include select advertise-eligible tools.

* **Tests**
  * Expanded tests for specialist execution, session metadata persistence, advertisement behavior, and prompt-file handling/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->