### PR TITLE
Add specialist background task tools

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -336,8 +336,7 @@ func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) err
 	if err != nil {
 		return err
 	}
-	specialist.RegisterTools(registry, specialist.Executor{Paths: paths})
-	return nil
+	return specialist.RegisterTools(registry, specialist.Executor{Paths: paths})
 }
 
 func shouldRegisterExecSpecialistTools(options execOptions) bool {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -207,9 +207,11 @@ func TestRunExecRegistersTaskOnlyForUnsafeTopLevelRuns(t *testing.T) {
 			if exitCode != exitSuccess {
 				t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
 			}
-			hasTask := strings.Contains(stdout.String(), "  Task ")
-			if hasTask != tc.wantTask {
-				t.Fatalf("Task visibility = %v, want %v; output:\n%s", hasTask, tc.wantTask, stdout.String())
+			for _, toolName := range []string{"Task", "TaskOutput", "TaskStop"} {
+				hasTool := strings.Contains(stdout.String(), "  "+toolName+" ")
+				if hasTool != tc.wantTask {
+					t.Fatalf("%s visibility = %v, want %v; output:\n%s", toolName, hasTool, tc.wantTask, stdout.String())
+				}
 			}
 		})
 	}

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -261,8 +261,20 @@ func (executor Executor) runResume(ctx context.Context, params TaskParameters, o
 }
 
 func (executor Executor) runBackground(ctx context.Context, built BuildArgsResult, manifest Manifest, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
+	if err := ctx.Err(); err != nil {
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
 	manager, err := executor.backgroundManager()
 	if err != nil {
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		if built.PromptFile != "" {
 			cleanupPromptFile(built.PromptFile)
 		}
@@ -283,6 +295,13 @@ func (executor Executor) runBackground(ctx context.Context, built BuildArgsResul
 	}
 	binaryPath, err := executor.binaryPath()
 	if err != nil {
+		_ = manager.UpdateStatus(built.SessionID, background.StatusError, -1)
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		_ = manager.UpdateStatus(built.SessionID, background.StatusError, -1)
 		if built.PromptFile != "" {
 			cleanupPromptFile(built.PromptFile)

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/background"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -29,16 +30,21 @@ type NewSessionIDFunc func() (string, error)
 type WritePromptFileFunc func(prompt string) (string, error)
 type LoadFunc func(LoadOptions) (LoadResult, error)
 type RunChildFunc func(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error)
+type LaunchBackgroundFunc func(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error)
+type BackgroundManagerFunc func() (*background.Manager, error)
 
 type Executor struct {
-	NewSessionID      NewSessionIDFunc
-	WritePromptFile   WritePromptFileFunc
-	PromptFileMaxSize int
-	Load              LoadFunc
-	RunChild          RunChildFunc
-	BinaryPath        string
-	Paths             Paths
-	SessionStore      *sessions.Store
+	NewSessionID          NewSessionIDFunc
+	WritePromptFile       WritePromptFileFunc
+	PromptFileMaxSize     int
+	Load                  LoadFunc
+	RunChild              RunChildFunc
+	LaunchBackground      LaunchBackgroundFunc
+	BinaryPath            string
+	Paths                 Paths
+	SessionStore          *sessions.Store
+	BackgroundManager     *background.Manager
+	BackgroundManagerFunc BackgroundManagerFunc
 }
 
 type BuildArgsInput struct {
@@ -69,10 +75,11 @@ type BuildArgsResult struct {
 }
 
 type TaskParameters struct {
-	Name        string
-	Prompt      string
-	Description string
-	Resume      string
+	Name            string
+	Prompt          string
+	Description     string
+	RunInBackground bool
+	Resume          string
 }
 
 type TaskRunOptions struct {
@@ -106,6 +113,9 @@ func (executor Executor) Run(ctx context.Context, params TaskParameters, options
 		return ExecResult{}, fmt.Errorf("specialist prompt is required")
 	}
 	if strings.TrimSpace(params.Resume) != "" {
+		if params.RunInBackground {
+			return ExecResult{}, fmt.Errorf("specialist resume cannot run in background")
+		}
 		return executor.runResume(ctx, params, options)
 	}
 	return executor.runFresh(ctx, params, options)
@@ -215,6 +225,9 @@ func (executor Executor) runFresh(ctx context.Context, params TaskParameters, op
 	if err != nil {
 		return ExecResult{}, err
 	}
+	if params.RunInBackground {
+		return executor.runBackground(ctx, built, manifest, params, options)
+	}
 	return executor.runBuiltArgs(ctx, built)
 }
 
@@ -245,6 +258,90 @@ func (executor Executor) runResume(ctx context.Context, params TaskParameters, o
 		return ExecResult{}, err
 	}
 	return executor.runBuiltArgs(ctx, built)
+}
+
+func (executor Executor) runBackground(ctx context.Context, built BuildArgsResult, manifest Manifest, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
+	manager, err := executor.backgroundManager()
+	if err != nil {
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
+	outputFile, err := manager.Register(background.RegisterInput{
+		TaskID:         built.SessionID,
+		Type:           "specialist",
+		SpecialistName: manifest.Metadata.Name,
+		Description:    params.Description,
+		ParentID:       options.ParentSessionID,
+	})
+	if err != nil {
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
+	binaryPath, err := executor.binaryPath()
+	if err != nil {
+		_ = manager.UpdateStatus(built.SessionID, background.StatusError, -1)
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
+
+	pid, err := executor.launchBackground(binaryPath, built.Args, outputFile, func(exitCode int) {
+		status := background.StatusCompleted
+		if exitCode != 0 {
+			status = background.StatusError
+		}
+		_ = manager.UpdateStatus(built.SessionID, status, exitCode)
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+	})
+	if err != nil {
+		_ = manager.UpdateStatus(built.SessionID, background.StatusError, -1)
+		if built.PromptFile != "" {
+			cleanupPromptFile(built.PromptFile)
+		}
+		return ExecResult{}, err
+	}
+	if pid > 0 {
+		if err := manager.SetPID(built.SessionID, pid); err != nil {
+			if built.PromptFile != "" {
+				cleanupPromptFile(built.PromptFile)
+			}
+			return ExecResult{}, err
+		}
+	}
+
+	output := fmt.Sprintf(`Task launched in background.
+task_id: %s
+pid: %d
+specialist: %s
+description: %s
+
+Use TaskOutput with task_id "%s" to check progress.
+Use TaskStop with task_id "%s" to stop it.`,
+		built.SessionID,
+		pid,
+		manifest.Metadata.Name,
+		strings.TrimSpace(params.Description),
+		built.SessionID,
+		built.SessionID,
+	)
+	return ExecResult{
+		Result: tools.Result{
+			Status: tools.StatusOK,
+			Output: strings.TrimSpace(output),
+			Meta: map[string]string{
+				"task_id":    built.SessionID,
+				"session_id": built.SessionID,
+			},
+		},
+		SessionID: built.SessionID,
+	}, nil
 }
 
 func (executor Executor) resumeSession(sessionID string) (*sessions.Metadata, error) {
@@ -326,6 +423,23 @@ func (executor Executor) runChild(ctx context.Context, binaryPath string, args [
 		return executor.RunChild(ctx, binaryPath, append([]string(nil), args...))
 	}
 	return runChildProcess(ctx, binaryPath, args)
+}
+
+func (executor Executor) launchBackground(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error) {
+	if executor.LaunchBackground != nil {
+		return executor.LaunchBackground(binaryPath, append([]string(nil), args...), outputFile, onExit)
+	}
+	return launchBackgroundProcess(binaryPath, args, outputFile, onExit)
+}
+
+func (executor Executor) backgroundManager() (*background.Manager, error) {
+	if executor.BackgroundManager != nil {
+		return executor.BackgroundManager, nil
+	}
+	if executor.BackgroundManagerFunc != nil {
+		return executor.BackgroundManagerFunc()
+	}
+	return background.NewManager("")
 }
 
 func appendModelArgs(args []string, manifest Manifest, parentModel string, parentReasoningEffort string) []string {
@@ -435,4 +549,36 @@ func runChildProcess(ctx context.Context, binaryPath string, args []string) (Chi
 		return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode}, err
 	}
 	return ChildRunResult{Events: events, Stderr: stderr.String(), ExitCode: exitCode}, nil
+}
+
+func launchBackgroundProcess(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error) {
+	file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("open specialist background output: %w", err)
+	}
+	command := osexec.Command(binaryPath, args...)
+	command.Stdout = file
+	command.Stderr = file
+	command.Stdin = nil
+	if err := command.Start(); err != nil {
+		_ = file.Close()
+		return 0, fmt.Errorf("launch specialist background child: %w", err)
+	}
+	pid := command.Process.Pid
+	go func() {
+		exitCode := 0
+		if err := command.Wait(); err != nil {
+			var exitErr *osexec.ExitError
+			if errors.As(err, &exitErr) {
+				exitCode = exitErr.ExitCode()
+			} else {
+				exitCode = 1
+			}
+		}
+		_ = file.Close()
+		if onExit != nil {
+			onExit(exitCode)
+		}
+	}()
+	return pid, nil
 }

--- a/internal/specialist/output_tool.go
+++ b/internal/specialist/output_tool.go
@@ -121,12 +121,20 @@ func (tool *OutputTool) blockOnOutput(ctx context.Context, manager *background.M
 		}
 		select {
 		case <-ctx.Done():
-			return tool.readOutput(task)
+			return tool.readLatestOutput(manager, taskID)
 		case <-timer.C:
-			return tool.readOutput(task)
+			return tool.readLatestOutput(manager, taskID)
 		case <-ticker.C:
 		}
 	}
+}
+
+func (tool *OutputTool) readLatestOutput(manager *background.Manager, taskID string) tools.Result {
+	task, ok := manager.Get(taskID)
+	if !ok {
+		return taskError(fmt.Errorf("background task not found: %s", taskID))
+	}
+	return tool.readOutput(task)
 }
 
 func (tool *OutputTool) readOutput(task background.Task) tools.Result {
@@ -270,13 +278,14 @@ func summarizeTaskData(data string, exitCode int) (StreamResult, []string) {
 	events := []streamjson.Event{}
 	rawLines := []string{}
 	for _, line := range strings.Split(data, "\n") {
-		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
-		if line == "" {
+		rawLine := strings.TrimSuffix(line, "\r")
+		trimmed := strings.TrimSpace(rawLine)
+		if trimmed == "" {
 			continue
 		}
 		var event streamjson.Event
-		if err := json.Unmarshal([]byte(line), &event); err != nil || event.Type == "" {
-			rawLines = append(rawLines, line)
+		if err := json.Unmarshal([]byte(trimmed), &event); err != nil || event.Type == "" {
+			rawLines = append(rawLines, rawLine)
 			continue
 		}
 		events = append(events, event)

--- a/internal/specialist/output_tool.go
+++ b/internal/specialist/output_tool.go
@@ -1,0 +1,285 @@
+package specialist
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const (
+	defaultTaskOutputPollInterval = 500 * time.Millisecond
+	defaultTaskOutputTimeout      = 30 * time.Second
+	maxTaskOutputTimeout          = 20 * time.Minute
+)
+
+type OutputTool struct {
+	manager        *background.Manager
+	managerFunc    BackgroundManagerFunc
+	PollInterval   time.Duration
+	DefaultTimeout time.Duration
+	MaxTimeout     time.Duration
+}
+
+type outputParameters struct {
+	TaskID    string
+	Block     bool
+	TimeoutMS int
+}
+
+func NewOutputTool(manager *background.Manager) *OutputTool {
+	return &OutputTool{manager: manager}
+}
+
+func newOutputToolWithManagerFunc(managerFunc BackgroundManagerFunc) *OutputTool {
+	return &OutputTool{managerFunc: managerFunc}
+}
+
+func (tool *OutputTool) Name() string {
+	return "TaskOutput"
+}
+
+func (tool *OutputTool) Description() string {
+	return "Poll the output of a background Zero specialist task."
+}
+
+func (tool *OutputTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"task_id": {
+				Type:        "string",
+				Description: "Background task id returned by Task.",
+			},
+			"block": {
+				Type:        "boolean",
+				Description: "Wait for the task to finish before returning, up to timeout.",
+				Default:     false,
+			},
+			"timeout": {
+				Type:        "integer",
+				Description: "Maximum wait time in milliseconds when block is true.",
+				Default:     30000,
+			},
+		},
+		Required:             []string{"task_id"},
+		AdditionalProperties: false,
+	}
+}
+
+func (tool *OutputTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect: tools.SideEffectRead,
+		Permission: tools.PermissionAllow,
+		Reason:     "Reads a background specialist task output file.",
+	}
+}
+
+func (tool *OutputTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	params, err := parseOutputParameters(args)
+	if err != nil {
+		return taskError(err)
+	}
+	manager, err := tool.backgroundManager()
+	if err != nil {
+		return taskError(err)
+	}
+	task, ok := manager.Get(params.TaskID)
+	if !ok {
+		return taskError(fmt.Errorf("background task not found: %s", params.TaskID))
+	}
+	if !params.Block {
+		return tool.readOutput(task)
+	}
+	return tool.blockOnOutput(ctx, manager, task.ID, params.TimeoutMS)
+}
+
+func (tool *OutputTool) blockOnOutput(ctx context.Context, manager *background.Manager, taskID string, timeoutMS int) tools.Result {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeout := tool.timeout(timeoutMS)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	interval := tool.pollInterval()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		task, ok := manager.Get(taskID)
+		if !ok {
+			return taskError(fmt.Errorf("background task not found: %s", taskID))
+		}
+		if task.Status != background.StatusRunning {
+			return tool.readOutput(task)
+		}
+		select {
+		case <-ctx.Done():
+			return tool.readOutput(task)
+		case <-timer.C:
+			return tool.readOutput(task)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (tool *OutputTool) readOutput(task background.Task) tools.Result {
+	data, err := os.ReadFile(task.OutputFile)
+	if err != nil {
+		return taskError(err)
+	}
+	return tools.Result{
+		Status: tools.StatusOK,
+		Output: formatTaskOutput(task, string(data)),
+		Meta: map[string]string{
+			"task_id": string(task.ID),
+			"status":  string(task.Status),
+		},
+	}
+}
+
+func (tool *OutputTool) backgroundManager() (*background.Manager, error) {
+	if tool.manager != nil {
+		return tool.manager, nil
+	}
+	if tool.managerFunc != nil {
+		return tool.managerFunc()
+	}
+	return nil, fmt.Errorf("background manager is not configured")
+}
+
+func (tool *OutputTool) pollInterval() time.Duration {
+	if tool.PollInterval > 0 {
+		return tool.PollInterval
+	}
+	return defaultTaskOutputPollInterval
+}
+
+func (tool *OutputTool) timeout(timeoutMS int) time.Duration {
+	timeout := time.Duration(timeoutMS) * time.Millisecond
+	if timeout <= 0 {
+		timeout = tool.DefaultTimeout
+	}
+	if timeout <= 0 {
+		timeout = defaultTaskOutputTimeout
+	}
+	maxTimeout := tool.MaxTimeout
+	if maxTimeout <= 0 {
+		maxTimeout = maxTaskOutputTimeout
+	}
+	if timeout > maxTimeout {
+		return maxTimeout
+	}
+	return timeout
+}
+
+func parseOutputParameters(args map[string]any) (outputParameters, error) {
+	taskID, err := optionalTaskString(args, "task_id")
+	if err != nil {
+		return outputParameters{}, err
+	}
+	block, err := optionalTaskBool(args, "block")
+	if err != nil {
+		return outputParameters{}, err
+	}
+	timeout, err := optionalTaskInt(args, "timeout")
+	if err != nil {
+		return outputParameters{}, err
+	}
+	params := outputParameters{
+		TaskID:    strings.TrimSpace(taskID),
+		Block:     block,
+		TimeoutMS: timeout,
+	}
+	if params.TaskID == "" {
+		return outputParameters{}, fmt.Errorf("task output requires task_id")
+	}
+	return params, nil
+}
+
+func optionalTaskInt(args map[string]any, key string) (int, error) {
+	if args == nil {
+		return 0, nil
+	}
+	value, ok := args[key]
+	if !ok || value == nil {
+		return 0, nil
+	}
+	switch number := value.(type) {
+	case int:
+		return number, nil
+	case int64:
+		return int(number), nil
+	case float64:
+		if number != float64(int(number)) {
+			return 0, fmt.Errorf("task %s must be an integer", key)
+		}
+		return int(number), nil
+	default:
+		return 0, fmt.Errorf("task %s must be an integer", key)
+	}
+}
+
+func formatTaskOutput(task background.Task, data string) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "task_id: %s\n", task.ID)
+	fmt.Fprintf(&builder, "status: %s\n", task.Status)
+	if task.SpecialistName != "" {
+		fmt.Fprintf(&builder, "specialist: %s\n", task.SpecialistName)
+	}
+	if task.Description != "" {
+		fmt.Fprintf(&builder, "description: %s\n", task.Description)
+	}
+	if task.PID > 0 {
+		fmt.Fprintf(&builder, "pid: %d\n", task.PID)
+	}
+	if !task.StartedAt.IsZero() {
+		fmt.Fprintf(&builder, "started_at: %s\n", task.StartedAt.Format(time.RFC3339))
+	}
+	if !task.CompletedAt.IsZero() {
+		fmt.Fprintf(&builder, "completed_at: %s\n", task.CompletedAt.Format(time.RFC3339))
+		fmt.Fprintf(&builder, "exit_code: %d\n", task.ExitCode)
+	}
+
+	summary, rawLines := summarizeTaskData(data, task.ExitCode)
+	if summary.Text != "" {
+		fmt.Fprintf(&builder, "\noutput:\n%s\n", summary.Text)
+	}
+	if len(summary.Tools) > 0 {
+		fmt.Fprintf(&builder, "\ntools: %s\n", strings.Join(summary.Tools, ", "))
+	}
+	if len(summary.Errors) > 0 {
+		fmt.Fprintf(&builder, "\nerrors: %s\n", strings.Join(summary.Errors, "; "))
+	}
+	if len(rawLines) > 0 {
+		fmt.Fprintf(&builder, "\nraw:\n%s\n", strings.Join(rawLines, "\n"))
+	}
+	if summary.Text == "" && len(summary.Tools) == 0 && len(summary.Errors) == 0 && len(rawLines) == 0 {
+		builder.WriteString("\noutput: <empty>\n")
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func summarizeTaskData(data string, exitCode int) (StreamResult, []string) {
+	events := []streamjson.Event{}
+	rawLines := []string{}
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" {
+			continue
+		}
+		var event streamjson.Event
+		if err := json.Unmarshal([]byte(line), &event); err != nil || event.Type == "" {
+			rawLines = append(rawLines, line)
+			continue
+		}
+		events = append(events, event)
+	}
+	return SummarizeStream(events, exitCode), rawLines
+}

--- a/internal/specialist/output_tool_test.go
+++ b/internal/specialist/output_tool_test.go
@@ -1,0 +1,125 @@
+package specialist
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestOutputToolReadsCompletedTaskSummary(t *testing.T) {
+	manager, err := background.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+	outputFile, err := manager.Register(background.RegisterInput{
+		TaskID:         "child_task",
+		Type:           "specialist",
+		SpecialistName: "worker",
+		Description:    "Auth check",
+		PID:            1234,
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if err := os.WriteFile(outputFile, []byte(strings.Join([]string{
+		`{"schemaVersion":1,"type":"run_start","runId":"run_1","sessionId":"child_task"}`,
+		`{"schemaVersion":1,"type":"tool_call","runId":"run_1","id":"call_1","name":"Read"}`,
+		`{"schemaVersion":1,"type":"final","runId":"run_1","text":"done"}`,
+		`{"schemaVersion":1,"type":"run_end","runId":"run_1","status":"success","exitCode":0}`,
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if err := manager.UpdateStatus("child_task", background.StatusCompleted, 0); err != nil {
+		t.Fatalf("UpdateStatus returned error: %v", err)
+	}
+
+	result := NewOutputTool(manager).Run(context.Background(), map[string]any{"task_id": "child_task"})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("TaskOutput status = %s, output=%s", result.Status, result.Output)
+	}
+	for _, want := range []string{"task_id: child_task", "status: completed", "specialist: worker", "output:\ndone", "tools: Read"} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("TaskOutput missing %q:\n%s", want, result.Output)
+		}
+	}
+	if result.Meta["task_id"] != "child_task" || result.Meta["status"] != string(background.StatusCompleted) {
+		t.Fatalf("TaskOutput meta = %#v", result.Meta)
+	}
+}
+
+func TestOutputToolFallsBackToRawLines(t *testing.T) {
+	manager, err := background.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+	outputFile, err := manager.Register(background.RegisterInput{TaskID: "child_task", Type: "specialist"})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if err := os.WriteFile(outputFile, []byte("stderr text\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	result := NewOutputTool(manager).Run(context.Background(), map[string]any{"task_id": "child_task"})
+
+	if result.Status != tools.StatusOK || !strings.Contains(result.Output, "raw:\nstderr text") {
+		t.Fatalf("TaskOutput raw result = %#v", result)
+	}
+}
+
+func TestOutputToolBlocksUntilTaskCompletes(t *testing.T) {
+	manager, err := background.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+	outputFile, err := manager.Register(background.RegisterInput{TaskID: "child_task", Type: "specialist"})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		_ = os.WriteFile(outputFile, []byte(`{"schemaVersion":1,"type":"final","runId":"run_1","text":"finished"}`+"\n"), 0o600)
+		_ = manager.UpdateStatus("child_task", background.StatusCompleted, 0)
+	}()
+	tool := NewOutputTool(manager)
+	tool.PollInterval = time.Millisecond
+
+	result := tool.Run(context.Background(), map[string]any{
+		"task_id": "child_task",
+		"block":   true,
+		"timeout": 100,
+	})
+
+	if result.Status != tools.StatusOK || !strings.Contains(result.Output, "output:\nfinished") {
+		t.Fatalf("blocking TaskOutput result = %#v", result)
+	}
+}
+
+func TestOutputToolRejectsInvalidParameters(t *testing.T) {
+	result := NewOutputTool(nil).Run(context.Background(), map[string]any{"block": "yes"})
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "block") {
+		t.Fatalf("invalid TaskOutput result = %#v", result)
+	}
+}
+
+func TestSummarizeTaskDataCollectsErrors(t *testing.T) {
+	exitCode := 3
+	summary, raw := summarizeTaskData(strings.Join([]string{
+		`{"schemaVersion":1,"type":"error","runId":"run_1","message":"failed"}`,
+		`{"schemaVersion":1,"type":"run_end","runId":"run_1","status":"error","exitCode":3}`,
+		`stderr text`,
+	}, "\n"), 0)
+	if summary.ExitCode != exitCode || len(summary.Errors) != 1 || summary.Errors[0] != "failed" {
+		t.Fatalf("summary = %#v", summary)
+	}
+	if len(raw) != 1 || raw[0] != "stderr text" {
+		t.Fatalf("raw = %#v", raw)
+	}
+}

--- a/internal/specialist/output_tool_test.go
+++ b/internal/specialist/output_tool_test.go
@@ -114,12 +114,12 @@ func TestSummarizeTaskDataCollectsErrors(t *testing.T) {
 	summary, raw := summarizeTaskData(strings.Join([]string{
 		`{"schemaVersion":1,"type":"error","runId":"run_1","message":"failed"}`,
 		`{"schemaVersion":1,"type":"run_end","runId":"run_1","status":"error","exitCode":3}`,
-		`stderr text`,
+		`  stderr text  `,
 	}, "\n"), 0)
 	if summary.ExitCode != exitCode || len(summary.Errors) != 1 || summary.Errors[0] != "failed" {
 		t.Fatalf("summary = %#v", summary)
 	}
-	if len(raw) != 1 || raw[0] != "stderr text" {
+	if len(raw) != 1 || raw[0] != "  stderr text  " {
 		t.Fatalf("raw = %#v", raw)
 	}
 }

--- a/internal/specialist/registry.go
+++ b/internal/specialist/registry.go
@@ -1,7 +1,44 @@
 package specialist
 
-import "github.com/Gitlawb/zero/internal/tools"
+import (
+	"sync"
 
-func RegisterTools(registry *tools.Registry, executor Executor) {
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func RegisterTools(registry *tools.Registry, executor Executor) error {
+	managerFunc := executor.BackgroundManagerFunc
+	if executor.BackgroundManager != nil {
+		manager := executor.BackgroundManager
+		managerFunc = func() (*background.Manager, error) {
+			return manager, nil
+		}
+	}
+	if managerFunc == nil {
+		managerFunc = lazyBackgroundManager()
+	}
+	executor.BackgroundManagerFunc = managerFunc
 	registry.Register(NewTaskTool(executor))
+	registry.Register(newOutputToolWithManagerFunc(managerFunc))
+	registry.Register(newStopToolWithManagerFunc(managerFunc))
+	return nil
+}
+
+func lazyBackgroundManager() BackgroundManagerFunc {
+	var mu sync.Mutex
+	var manager *background.Manager
+	return func() (*background.Manager, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if manager != nil {
+			return manager, nil
+		}
+		created, err := background.NewManager("")
+		if err != nil {
+			return nil, err
+		}
+		manager = created
+		return manager, nil
+	}
 }

--- a/internal/specialist/stop_tool.go
+++ b/internal/specialist/stop_tool.go
@@ -1,0 +1,102 @@
+package specialist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type StopTool struct {
+	manager     *background.Manager
+	managerFunc BackgroundManagerFunc
+}
+
+type stopParameters struct {
+	TaskID string
+}
+
+func NewStopTool(manager *background.Manager) *StopTool {
+	return &StopTool{manager: manager}
+}
+
+func newStopToolWithManagerFunc(managerFunc BackgroundManagerFunc) *StopTool {
+	return &StopTool{managerFunc: managerFunc}
+}
+
+func (tool *StopTool) Name() string {
+	return "TaskStop"
+}
+
+func (tool *StopTool) Description() string {
+	return "Stop a running background Zero specialist task."
+}
+
+func (tool *StopTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"task_id": {
+				Type:        "string",
+				Description: "Background task id returned by Task.",
+			},
+		},
+		Required:             []string{"task_id"},
+		AdditionalProperties: false,
+	}
+}
+
+func (tool *StopTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectShell,
+		Permission:      tools.PermissionPrompt,
+		Reason:          "Terminates a background specialist process.",
+		AdvertiseInAuto: true,
+	}
+}
+
+func (tool *StopTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	params, err := parseStopParameters(args)
+	if err != nil {
+		return taskError(err)
+	}
+	manager, err := tool.backgroundManager()
+	if err != nil {
+		return taskError(err)
+	}
+	if err := manager.Kill(params.TaskID); err != nil {
+		return taskError(err)
+	}
+	return tools.Result{
+		Status: tools.StatusOK,
+		Output: fmt.Sprintf("task_id: %s\nstatus: killed", params.TaskID),
+		Meta: map[string]string{
+			"task_id": params.TaskID,
+			"status":  string(background.StatusKilled),
+		},
+	}
+}
+
+func (tool *StopTool) backgroundManager() (*background.Manager, error) {
+	if tool.manager != nil {
+		return tool.manager, nil
+	}
+	if tool.managerFunc != nil {
+		return tool.managerFunc()
+	}
+	return nil, fmt.Errorf("background manager is not configured")
+}
+
+func parseStopParameters(args map[string]any) (stopParameters, error) {
+	taskID, err := optionalTaskString(args, "task_id")
+	if err != nil {
+		return stopParameters{}, err
+	}
+	params := stopParameters{TaskID: strings.TrimSpace(taskID)}
+	if params.TaskID == "" {
+		return stopParameters{}, fmt.Errorf("task stop requires task_id")
+	}
+	return params, nil
+}

--- a/internal/specialist/stop_tool_test.go
+++ b/internal/specialist/stop_tool_test.go
@@ -1,0 +1,59 @@
+package specialist
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestStopToolKillsBackgroundTask(t *testing.T) {
+	killed := []int{}
+	manager, err := background.NewManagerWithOptions(background.ManagerOptions{
+		RootDir: t.TempDir(),
+		KillProcess: func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(background.RegisterInput{TaskID: "child_task", Type: "specialist", PID: 4321}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+
+	result := NewStopTool(manager).Run(context.Background(), map[string]any{"task_id": "child_task"})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("TaskStop status = %s, output=%s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "status: killed") || result.Meta["status"] != string(background.StatusKilled) {
+		t.Fatalf("TaskStop result = %#v", result)
+	}
+	if !reflect.DeepEqual(killed, []int{4321}) {
+		t.Fatalf("killed pids = %#v", killed)
+	}
+	task, ok := manager.Get("child_task")
+	if !ok || task.Status != background.StatusKilled {
+		t.Fatalf("task status = %#v", task)
+	}
+}
+
+func TestStopToolRejectsInvalidParameters(t *testing.T) {
+	result := NewStopTool(nil).Run(context.Background(), map[string]any{})
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "task_id") {
+		t.Fatalf("invalid TaskStop result = %#v", result)
+	}
+}
+
+func TestStopToolIsAdvertisedInAutoMode(t *testing.T) {
+	tool := NewStopTool(nil)
+	if !agent.ToolVisible(tool, agent.PermissionModeAuto, nil, nil) {
+		t.Fatal("TaskStop should be visible in auto mode so the TUI can request permission")
+	}
+}

--- a/internal/specialist/task_tool.go
+++ b/internal/specialist/task_tool.go
@@ -42,12 +42,17 @@ func (tool *TaskTool) Parameters() tools.Schema {
 				Type:        "string",
 				Description: "Short label for the child session.",
 			},
+			"run_in_background": {
+				Type:        "boolean",
+				Description: "Run the specialist in the background and return a task_id immediately.",
+				Default:     false,
+			},
 			"resume": {
 				Type:        "string",
 				Description: "Existing specialist session id to resume.",
 			},
 		},
-		Required:             []string{"name", "prompt"},
+		Required:             []string{"prompt"},
 		AdditionalProperties: false,
 	}
 }
@@ -107,13 +112,18 @@ func parseTaskParameters(args map[string]any) (TaskParameters, error) {
 	if err != nil {
 		return TaskParameters{}, err
 	}
-	params := TaskParameters{
-		Name:        strings.TrimSpace(name),
-		Prompt:      strings.TrimSpace(prompt),
-		Description: strings.TrimSpace(description),
-		Resume:      strings.TrimSpace(resume),
+	runInBackground, err := optionalTaskBool(args, "run_in_background")
+	if err != nil {
+		return TaskParameters{}, err
 	}
-	if params.Name == "" {
+	params := TaskParameters{
+		Name:            strings.TrimSpace(name),
+		Prompt:          strings.TrimSpace(prompt),
+		Description:     strings.TrimSpace(description),
+		RunInBackground: runInBackground,
+		Resume:          strings.TrimSpace(resume),
+	}
+	if params.Name == "" && params.Resume == "" {
 		return TaskParameters{}, fmt.Errorf("task requires name")
 	}
 	if params.Prompt == "" {
@@ -135,6 +145,21 @@ func optionalTaskString(args map[string]any, key string) (string, error) {
 		return "", fmt.Errorf("task %s must be a string", key)
 	}
 	return text, nil
+}
+
+func optionalTaskBool(args map[string]any, key string) (bool, error) {
+	if args == nil {
+		return false, nil
+	}
+	value, ok := args[key]
+	if !ok || value == nil {
+		return false, nil
+	}
+	flag, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("task %s must be a boolean", key)
+	}
+	return flag, nil
 }
 
 func taskError(err error) tools.Result {

--- a/internal/specialist/task_tool.go
+++ b/internal/specialist/task_tool.go
@@ -124,7 +124,7 @@ func parseTaskParameters(args map[string]any) (TaskParameters, error) {
 		Resume:          strings.TrimSpace(resume),
 	}
 	if params.Name == "" && params.Resume == "" {
-		return TaskParameters{}, fmt.Errorf("task requires name")
+		return TaskParameters{}, fmt.Errorf("task requires name or resume")
 	}
 	if params.Prompt == "" {
 		return TaskParameters{}, fmt.Errorf("task requires prompt")

--- a/internal/specialist/task_tool_test.go
+++ b/internal/specialist/task_tool_test.go
@@ -136,6 +136,29 @@ func TestTaskToolRunsResumeSpecialist(t *testing.T) {
 	}
 }
 
+func TestTaskToolRejectsBackgroundResume(t *testing.T) {
+	calledRunChild := false
+	executor := Executor{
+		RunChild: func(ctx context.Context, binaryPath string, args []string) (ChildRunResult, error) {
+			calledRunChild = true
+			return ChildRunResult{}, nil
+		},
+	}
+
+	result := NewTaskTool(executor).RunWithOptions(context.Background(), map[string]any{
+		"prompt":            "follow up",
+		"resume":            "child_task",
+		"run_in_background": true,
+	}, tools.RunOptions{Depth: 2})
+
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "cannot run in background") {
+		t.Fatalf("background resume result = %#v", result)
+	}
+	if calledRunChild {
+		t.Fatal("RunChild was called for rejected background resume")
+	}
+}
+
 func TestTaskToolRejectsResumeSpecialistMismatch(t *testing.T) {
 	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
 	if _, err := store.Create(sessions.CreateInput{
@@ -226,6 +249,39 @@ func TestTaskToolRunsBackgroundSpecialist(t *testing.T) {
 	}
 }
 
+func TestTaskToolRejectsCanceledBackgroundBeforeRegistering(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calledManager := false
+	executor := Executor{
+		NewSessionID: func() (string, error) { return "child_task", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		BackgroundManagerFunc: func() (*background.Manager, error) {
+			calledManager = true
+			return background.NewManager(t.TempDir())
+		},
+	}
+
+	result := NewTaskTool(executor).RunWithOptions(ctx, map[string]any{
+		"name":              "worker",
+		"prompt":            "inspect auth",
+		"run_in_background": true,
+	}, tools.RunOptions{SessionID: "parent_session"})
+
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, context.Canceled.Error()) {
+		t.Fatalf("canceled background result = %#v", result)
+	}
+	if calledManager {
+		t.Fatal("background manager was created after context cancellation")
+	}
+}
+
 func TestTaskToolCleansPromptFileAfterChildRun(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "spill")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -273,6 +329,11 @@ func TestTaskToolRejectsInvalidParameters(t *testing.T) {
 	result := NewTaskTool(Executor{}).Run(context.Background(), map[string]any{"name": "worker"})
 	if result.Status != tools.StatusError || !strings.Contains(result.Output, "prompt") {
 		t.Fatalf("missing prompt result = %#v", result)
+	}
+
+	result = NewTaskTool(Executor{}).Run(context.Background(), map[string]any{"prompt": "work"})
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "name or resume") {
+		t.Fatalf("missing name/resume result = %#v", result)
 	}
 }
 

--- a/internal/specialist/task_tool_test.go
+++ b/internal/specialist/task_tool_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/background"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -116,7 +117,6 @@ func TestTaskToolRunsResumeSpecialist(t *testing.T) {
 	}
 
 	result := NewTaskTool(executor).RunWithOptions(context.Background(), map[string]any{
-		"name":   "worker",
 		"prompt": "follow up",
 		"resume": "child_task",
 	}, tools.RunOptions{Depth: 2})
@@ -155,6 +155,74 @@ func TestTaskToolRejectsResumeSpecialistMismatch(t *testing.T) {
 
 	if result.Status != tools.StatusError || !strings.Contains(result.Output, `belongs to specialist "worker"`) {
 		t.Fatalf("mismatch result = %#v", result)
+	}
+}
+
+func TestTaskToolRunsBackgroundSpecialist(t *testing.T) {
+	manager, err := background.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+	var gotOutputFile string
+	var gotArgs []string
+	executor := Executor{
+		BinaryPath:        "/usr/local/bin/zero",
+		BackgroundManager: manager,
+		NewSessionID:      func() (string, error) { return "child_task", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		LaunchBackground: func(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error) {
+			if binaryPath != "/usr/local/bin/zero" {
+				t.Fatalf("binaryPath = %q", binaryPath)
+			}
+			gotArgs = append([]string(nil), args...)
+			gotOutputFile = outputFile
+			return 4321, nil
+		},
+	}
+
+	result := NewTaskTool(executor).RunWithOptions(context.Background(), map[string]any{
+		"name":              "worker",
+		"prompt":            "inspect auth",
+		"description":       "Auth check",
+		"run_in_background": true,
+	}, tools.RunOptions{SessionID: "parent_session"})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("Task status = %s, output=%s", result.Status, result.Output)
+	}
+	for _, want := range []string{"Task launched in background.", "task_id: child_task", "pid: 4321", `Use TaskOutput with task_id "child_task"`} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("background output missing %q:\n%s", want, result.Output)
+		}
+	}
+	if result.Meta["task_id"] != "child_task" || result.Meta["session_id"] != "child_task" {
+		t.Fatalf("background meta = %#v", result.Meta)
+	}
+	if gotOutputFile != manager.OutputPath("child_task") {
+		t.Fatalf("output file = %q, manager path = %q", gotOutputFile, manager.OutputPath("child_task"))
+	}
+	task, ok := manager.Get("child_task")
+	if !ok {
+		t.Fatal("background task was not registered")
+	}
+	if task.Status != background.StatusRunning || task.PID != 4321 || task.ParentID != "parent_session" || task.SpecialistName != "worker" {
+		t.Fatalf("background task = %#v", task)
+	}
+	for _, want := range [][]string{
+		{"exec", "--init-session-id", "child_task"},
+		{"--output-format", "stream-json"},
+		{"--enabled-tools", "read_file"},
+		{"--tag", "specialist"},
+	} {
+		if !containsSequence(gotArgs, want) {
+			t.Fatalf("background args missing %v: %#v", want, gotArgs)
+		}
 	}
 }
 


### PR DESCRIPTION
Summary:
- adds Task run_in_background support with background child launch, task metadata, and output-file tracking
- registers TaskOutput and TaskStop with a shared lazy background manager
- lets Task resume by session id without requiring a redundant name, while still rejecting background resume

Self-review:
- background manager creation is lazy so TUI startup and --list-tools do not write to the data dir
- prompt temp files are kept for background children and cleaned up on child exit/start failure
- TaskStop remains prompt-gated but visible in auto mode; TaskOutput is read-only

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist ./internal/cli ./internal/background ./internal/agent ./internal/tools
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run tasks in the background (async execution).
  * Stop running background tasks.
  * Retrieve background task output and status immediately or by polling.

* **Bug Fixes**
  * Tool registration now correctly propagates registration errors.

* **Tests**
  * Expanded test coverage for background execution paths, output retrieval/polling, task stopping, and parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->