### PR TITLE
Harden specialist background lifecycle

### DIFF
--- a/internal/background/manager.go
+++ b/internal/background/manager.go
@@ -198,6 +198,30 @@ func (manager *Manager) UpdateStatus(taskID string, status Status, exitCode int)
 	return nil
 }
 
+func (manager *Manager) MarkExited(taskID string, status Status, exitCode int) error {
+	taskID = strings.TrimSpace(taskID)
+	if status != StatusCompleted && status != StatusError {
+		return fmt.Errorf("invalid background task exit status %q", status)
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("background task not found: %s", taskID)
+	}
+	if task.Status != StatusRunning {
+		return nil
+	}
+	task.Status = status
+	task.ExitCode = exitCode
+	if task.CompletedAt.IsZero() {
+		task.CompletedAt = manager.now()
+	}
+	manager.tasks[taskID] = task
+	return nil
+}
+
 func (manager *Manager) Get(taskID string) (Task, bool) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()

--- a/internal/background/manager.go
+++ b/internal/background/manager.go
@@ -221,6 +221,19 @@ func (manager *Manager) Kill(taskID string) error {
 	return manager.markKilledIfStillRunning(taskID, pid)
 }
 
+func (manager *Manager) KillRunning() error {
+	var errs []error
+	for _, task := range manager.List() {
+		if task.Status != StatusRunning {
+			continue
+		}
+		if err := manager.Kill(task.ID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (manager *Manager) killTarget(taskID string) (int, error) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -177,6 +177,56 @@ func TestManagerKillDoesNotClobberCompletedTask(t *testing.T) {
 	}
 }
 
+func TestManagerKillRunningStopsOnlyRunningTasks(t *testing.T) {
+	now := sequenceClock(
+		time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 9, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 7, 9, 0, 2, 0, time.UTC),
+	)
+	killed := []int{}
+	manager, err := NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		Now:     now,
+		KillProcess: func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "running_1", Type: "specialist", PID: 11}); err != nil {
+		t.Fatalf("Register running_1 returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "done", Type: "specialist", PID: 22}); err != nil {
+		t.Fatalf("Register done returned error: %v", err)
+	}
+	if err := manager.UpdateStatus("done", StatusCompleted, 0); err != nil {
+		t.Fatalf("UpdateStatus returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "running_2", Type: "specialist", PID: 33}); err != nil {
+		t.Fatalf("Register running_2 returned error: %v", err)
+	}
+
+	if err := manager.KillRunning(); err != nil {
+		t.Fatalf("KillRunning returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(killed, []int{33, 11}) {
+		t.Fatalf("killed pids = %#v", killed)
+	}
+	for _, id := range []string{"running_1", "running_2"} {
+		task, ok := manager.Get(id)
+		if !ok || task.Status != StatusKilled {
+			t.Fatalf("%s status = %#v", id, task)
+		}
+	}
+	done, ok := manager.Get("done")
+	if !ok || done.Status != StatusCompleted {
+		t.Fatalf("completed task was changed: %#v", done)
+	}
+}
+
 func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
 	got := DefaultRoot(map[string]string{
 		"XDG_DATA_HOME": "/tmp/zero-data",

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -177,6 +177,31 @@ func TestManagerKillDoesNotClobberCompletedTask(t *testing.T) {
 	}
 }
 
+func TestManagerMarkExitedDoesNotClobberKilledTask(t *testing.T) {
+	manager, err := NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		KillProcess: func(pid int) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task", Type: "specialist", PID: 42}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if err := manager.Kill("task"); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+	if err := manager.MarkExited("task", StatusError, 1); err != nil {
+		t.Fatalf("MarkExited returned error: %v", err)
+	}
+	task, ok := manager.Get("task")
+	if !ok || task.Status != StatusKilled || task.ExitCode != -1 {
+		t.Fatalf("MarkExited clobbered killed task: %#v", task)
+	}
+}
+
 func TestManagerKillRunningStopsOnlyRunningTasks(t *testing.T) {
 	now := sequenceClock(
 		time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC),

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -276,9 +276,11 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
-	if err := registerSpecialistTools(registry, workspaceRoot); err != nil {
+	specialistRuntime, err := registerSpecialistTools(registry, workspaceRoot)
+	if err != nil {
 		return writeAppError(stderr, "failed to initialize specialist tools: "+err.Error(), 1)
 	}
+	defer closeSpecialistRuntime(stderr, specialistRuntime)
 	mcpRuntime, err := registerMCPToolsForWorkspace(context.Background(), workspaceRoot, registry, deps, mcp.AutonomyLow)
 	if err != nil {
 		return writeAppError(stderr, err.Error(), 1)
@@ -331,10 +333,10 @@ func newCoreRegistry(workspaceRoot string) *tools.Registry {
 	return registry
 }
 
-func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) error {
+func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) (*specialist.Runtime, error) {
 	paths, err := specialist.DefaultPaths(workspaceRoot)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return specialist.RegisterTools(registry, specialist.Executor{Paths: paths})
 }
@@ -352,6 +354,15 @@ func closeMCPRuntime(stderr io.Writer, runtime mcpToolRuntime) {
 	}
 	if err := runtime.Close(); err != nil {
 		_, _ = fmt.Fprintf(stderr, "[zero] mcp_close_error: %s\n", err)
+	}
+}
+
+func closeSpecialistRuntime(stderr io.Writer, runtime *specialist.Runtime) {
+	if runtime == nil {
+		return
+	}
+	if err := runtime.Close(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "[zero] specialist_cleanup_error: %s\n", err)
 	}
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specialist"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/worktrees"
 )
@@ -103,10 +104,14 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
+	var specialistRuntime *specialist.Runtime
 	if shouldRegisterExecSpecialistTools(options) {
-		if err := registerSpecialistTools(registry, workspaceRoot); err != nil {
+		var err error
+		specialistRuntime, err = registerSpecialistTools(registry, workspaceRoot)
+		if err != nil {
 			return writeExecProviderError(stdout, stderr, options.outputFormat, "specialist_error", err.Error())
 		}
+		defer closeSpecialistRuntime(stderr, specialistRuntime)
 	}
 	permissionMode, err := resolveExecPermissionMode(options)
 	if err != nil {

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -316,7 +316,7 @@ func (executor Executor) runBackground(ctx context.Context, built BuildArgsResul
 		if exitCode != 0 {
 			status = background.StatusError
 		}
-		_ = manager.UpdateStatus(built.SessionID, status, exitCode)
+		_ = manager.MarkExited(built.SessionID, status, exitCode)
 		executor.cleanupBackgroundPromptFile(built.SessionID, built.PromptFile)
 	})
 	if err != nil {

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -45,6 +45,7 @@ type Executor struct {
 	SessionStore          *sessions.Store
 	BackgroundManager     *background.Manager
 	BackgroundManagerFunc BackgroundManagerFunc
+	BackgroundRuntime     *Runtime
 }
 
 type BuildArgsInput struct {
@@ -308,6 +309,7 @@ func (executor Executor) runBackground(ctx context.Context, built BuildArgsResul
 		}
 		return ExecResult{}, err
 	}
+	executor.trackBackgroundPromptFile(built.SessionID, built.PromptFile)
 
 	pid, err := executor.launchBackground(binaryPath, built.Args, outputFile, func(exitCode int) {
 		status := background.StatusCompleted
@@ -315,22 +317,16 @@ func (executor Executor) runBackground(ctx context.Context, built BuildArgsResul
 			status = background.StatusError
 		}
 		_ = manager.UpdateStatus(built.SessionID, status, exitCode)
-		if built.PromptFile != "" {
-			cleanupPromptFile(built.PromptFile)
-		}
+		executor.cleanupBackgroundPromptFile(built.SessionID, built.PromptFile)
 	})
 	if err != nil {
 		_ = manager.UpdateStatus(built.SessionID, background.StatusError, -1)
-		if built.PromptFile != "" {
-			cleanupPromptFile(built.PromptFile)
-		}
+		executor.cleanupBackgroundPromptFile(built.SessionID, built.PromptFile)
 		return ExecResult{}, err
 	}
 	if pid > 0 {
 		if err := manager.SetPID(built.SessionID, pid); err != nil {
-			if built.PromptFile != "" {
-				cleanupPromptFile(built.PromptFile)
-			}
+			executor.cleanupBackgroundPromptFile(built.SessionID, built.PromptFile)
 			return ExecResult{}, err
 		}
 	}
@@ -452,6 +448,9 @@ func (executor Executor) launchBackground(binaryPath string, args []string, outp
 }
 
 func (executor Executor) backgroundManager() (*background.Manager, error) {
+	if executor.BackgroundRuntime != nil {
+		return executor.BackgroundRuntime.Manager()
+	}
 	if executor.BackgroundManager != nil {
 		return executor.BackgroundManager, nil
 	}
@@ -459,6 +458,26 @@ func (executor Executor) backgroundManager() (*background.Manager, error) {
 		return executor.BackgroundManagerFunc()
 	}
 	return background.NewManager("")
+}
+
+func (executor Executor) trackBackgroundPromptFile(taskID string, promptFile string) {
+	if promptFile == "" {
+		return
+	}
+	if executor.BackgroundRuntime != nil {
+		executor.BackgroundRuntime.TrackPromptFile(taskID, promptFile)
+	}
+}
+
+func (executor Executor) cleanupBackgroundPromptFile(taskID string, promptFile string) {
+	if promptFile == "" {
+		return
+	}
+	if executor.BackgroundRuntime != nil {
+		executor.BackgroundRuntime.UntrackPromptFile(taskID)
+		return
+	}
+	cleanupPromptFile(promptFile)
 }
 
 func appendModelArgs(args []string, manifest Manifest, parentModel string, parentReasoningEffort string) []string {

--- a/internal/specialist/registry.go
+++ b/internal/specialist/registry.go
@@ -10,9 +10,10 @@ func RegisterTools(registry *tools.Registry, executor Executor) (*Runtime, error
 			ManagerFunc: executor.BackgroundManagerFunc,
 		})
 	}
-	executor.BackgroundRuntime = runtime
-	executor.BackgroundManagerFunc = runtime.Manager
-	registry.Register(NewTaskTool(executor))
+	toolExecutor := executor
+	toolExecutor.BackgroundRuntime = runtime
+	toolExecutor.BackgroundManagerFunc = runtime.Manager
+	registry.Register(NewTaskTool(toolExecutor))
 	registry.Register(newOutputToolWithManagerFunc(runtime.Manager))
 	registry.Register(newStopToolWithManagerFunc(runtime.Manager))
 	return runtime, nil

--- a/internal/specialist/registry.go
+++ b/internal/specialist/registry.go
@@ -1,44 +1,19 @@
 package specialist
 
-import (
-	"sync"
+import "github.com/Gitlawb/zero/internal/tools"
 
-	"github.com/Gitlawb/zero/internal/background"
-	"github.com/Gitlawb/zero/internal/tools"
-)
-
-func RegisterTools(registry *tools.Registry, executor Executor) error {
-	managerFunc := executor.BackgroundManagerFunc
-	if executor.BackgroundManager != nil {
-		manager := executor.BackgroundManager
-		managerFunc = func() (*background.Manager, error) {
-			return manager, nil
-		}
+func RegisterTools(registry *tools.Registry, executor Executor) (*Runtime, error) {
+	runtime := executor.BackgroundRuntime
+	if runtime == nil {
+		runtime = NewRuntime(RuntimeOptions{
+			Manager:     executor.BackgroundManager,
+			ManagerFunc: executor.BackgroundManagerFunc,
+		})
 	}
-	if managerFunc == nil {
-		managerFunc = lazyBackgroundManager()
-	}
-	executor.BackgroundManagerFunc = managerFunc
+	executor.BackgroundRuntime = runtime
+	executor.BackgroundManagerFunc = runtime.Manager
 	registry.Register(NewTaskTool(executor))
-	registry.Register(newOutputToolWithManagerFunc(managerFunc))
-	registry.Register(newStopToolWithManagerFunc(managerFunc))
-	return nil
-}
-
-func lazyBackgroundManager() BackgroundManagerFunc {
-	var mu sync.Mutex
-	var manager *background.Manager
-	return func() (*background.Manager, error) {
-		mu.Lock()
-		defer mu.Unlock()
-		if manager != nil {
-			return manager, nil
-		}
-		created, err := background.NewManager("")
-		if err != nil {
-			return nil, err
-		}
-		manager = created
-		return manager, nil
-	}
+	registry.Register(newOutputToolWithManagerFunc(runtime.Manager))
+	registry.Register(newStopToolWithManagerFunc(runtime.Manager))
+	return runtime, nil
 }

--- a/internal/specialist/runtime.go
+++ b/internal/specialist/runtime.go
@@ -1,0 +1,100 @@
+package specialist
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/Gitlawb/zero/internal/background"
+)
+
+type RuntimeOptions struct {
+	Manager     *background.Manager
+	ManagerFunc BackgroundManagerFunc
+}
+
+type Runtime struct {
+	mu          sync.Mutex
+	manager     *background.Manager
+	managerFunc BackgroundManagerFunc
+	promptFiles map[string]string
+}
+
+func NewRuntime(options RuntimeOptions) *Runtime {
+	return &Runtime{
+		manager:     options.Manager,
+		managerFunc: options.ManagerFunc,
+		promptFiles: map[string]string{},
+	}
+}
+
+func (runtime *Runtime) Manager() (*background.Manager, error) {
+	if runtime == nil {
+		return background.NewManager("")
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.manager != nil {
+		return runtime.manager, nil
+	}
+	managerFunc := runtime.managerFunc
+	if managerFunc == nil {
+		managerFunc = func() (*background.Manager, error) {
+			return background.NewManager("")
+		}
+	}
+	manager, err := managerFunc()
+	if err != nil {
+		return nil, err
+	}
+	runtime.manager = manager
+	return manager, nil
+}
+
+func (runtime *Runtime) TrackPromptFile(taskID string, promptFile string) {
+	if runtime == nil || taskID == "" || promptFile == "" {
+		return
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.promptFiles[taskID] = promptFile
+}
+
+func (runtime *Runtime) UntrackPromptFile(taskID string) {
+	if runtime == nil || taskID == "" {
+		return
+	}
+	promptFile := ""
+	runtime.mu.Lock()
+	if runtime.promptFiles != nil {
+		promptFile = runtime.promptFiles[taskID]
+		delete(runtime.promptFiles, taskID)
+	}
+	runtime.mu.Unlock()
+	cleanupPromptFile(promptFile)
+}
+
+func (runtime *Runtime) Close() error {
+	if runtime == nil {
+		return nil
+	}
+	var manager *background.Manager
+	promptFiles := []string{}
+	runtime.mu.Lock()
+	manager = runtime.manager
+	for taskID, promptFile := range runtime.promptFiles {
+		promptFiles = append(promptFiles, promptFile)
+		delete(runtime.promptFiles, taskID)
+	}
+	runtime.mu.Unlock()
+
+	var errs []error
+	if manager != nil {
+		if err := manager.KillRunning(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, promptFile := range promptFiles {
+		cleanupPromptFile(promptFile)
+	}
+	return errors.Join(errs...)
+}

--- a/internal/specialist/runtime_test.go
+++ b/internal/specialist/runtime_test.go
@@ -1,6 +1,7 @@
 package specialist
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -66,5 +67,60 @@ func TestRuntimeCloseKillsRunningTasksAndCleansPromptFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(promptFile); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("prompt file cleanup error = %v", err)
+	}
+}
+
+func TestRuntimeClosePreservesKilledTaskAfterChildExit(t *testing.T) {
+	manager, err := background.NewManagerWithOptions(background.ManagerOptions{
+		RootDir: t.TempDir(),
+		KillProcess: func(pid int) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	runtime := NewRuntime(RuntimeOptions{Manager: manager})
+	var exitCallback func(int)
+	executor := Executor{
+		BinaryPath:        "/usr/local/bin/zero",
+		BackgroundRuntime: runtime,
+		NewSessionID:      func() (string, error) { return "child_task", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		LaunchBackground: func(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error) {
+			exitCallback = onExit
+			return 42, nil
+		},
+	}
+
+	result, err := executor.Run(context.Background(), TaskParameters{
+		Name:            "worker",
+		Prompt:          "inspect auth",
+		RunInBackground: true,
+	}, TaskRunOptions{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.SessionID != "child_task" {
+		t.Fatalf("session id = %q", result.SessionID)
+	}
+	if exitCallback == nil {
+		t.Fatal("background launch did not capture exit callback")
+	}
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	exitCallback(1)
+
+	task, ok := manager.Get("child_task")
+	if !ok || task.Status != background.StatusKilled || task.ExitCode != -1 {
+		t.Fatalf("child exit clobbered killed task: %#v", task)
 	}
 }

--- a/internal/specialist/runtime_test.go
+++ b/internal/specialist/runtime_test.go
@@ -1,0 +1,70 @@
+package specialist
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/background"
+)
+
+func TestRuntimeCloseDoesNotCreateUnusedManager(t *testing.T) {
+	created := false
+	runtime := NewRuntime(RuntimeOptions{
+		ManagerFunc: func() (*background.Manager, error) {
+			created = true
+			return background.NewManager(t.TempDir())
+		},
+	})
+
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if created {
+		t.Fatal("Close created an unused background manager")
+	}
+}
+
+func TestRuntimeCloseKillsRunningTasksAndCleansPromptFiles(t *testing.T) {
+	killed := []int{}
+	manager, err := background.NewManagerWithOptions(background.ManagerOptions{
+		RootDir: t.TempDir(),
+		KillProcess: func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(background.RegisterInput{TaskID: "child_task", Type: "specialist", PID: 42}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	promptDir := filepath.Join(t.TempDir(), "zero-specialist-test")
+	if err := os.MkdirAll(promptDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	promptFile := filepath.Join(promptDir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("prompt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime := NewRuntime(RuntimeOptions{Manager: manager})
+	runtime.TrackPromptFile("child_task", promptFile)
+
+	if err := runtime.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(killed, []int{42}) {
+		t.Fatalf("killed pids = %#v", killed)
+	}
+	task, ok := manager.Get("child_task")
+	if !ok || task.Status != background.StatusKilled {
+		t.Fatalf("task after close = %#v", task)
+	}
+	if _, err := os.Stat(promptFile); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("prompt file cleanup error = %v", err)
+	}
+}


### PR DESCRIPTION
Summary:
- adds a specialist Runtime owner for the lazy background manager
- closes running specialist background tasks when the CLI/TUI runtime exits
- tracks background prompt temp files and cleans them on child exit or runtime close
- adds background.Manager KillRunning for shutdown cleanup

Self-review:
- Runtime.Close does not create background storage if no background task was used
- cleanup is wired into both interactive TUI and headless exec registration paths
- this intentionally does not implement hook command execution; the hooks package currently only supports selection/audit primitives

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/background ./internal/specialist ./internal/cli
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime abstraction added to manage specialist-tool lifecycles and track temporary prompt files.

* **Improvements**
  * Background task handling and shutdown improved to ensure running tasks are stopped and resources cleaned.
  * Specialist tool registration now provides a runtime handle so background resources are reliably closed.

* **Tests**
  * Added tests covering task exit transitions, bulk-kill behavior, runtime close semantics, and prompt-file cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->