### PR TITLE
Add specialist authoring tools

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -491,6 +491,9 @@ func propertyToRuntimeMap(property tools.PropertySchema) map[string]any {
 	if property.Default != nil {
 		schema["default"] = property.Default
 	}
+	if property.Items != nil {
+		schema["items"] = propertyToRuntimeMap(*property.Items)
+	}
 	if property.Minimum != nil {
 		schema["minimum"] = *property.Minimum
 	}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -49,6 +49,7 @@ type appDeps struct {
 	inspectChanges       func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error)
 	commitChanges        func(context.Context, zerogit.CommitOptions) (zerogit.CommitResult, error)
 	runTUI               func(context.Context, tui.Options) int
+	runEditor            func(string) error
 	checkUpdate          func(context.Context, update.Options) (update.Result, error)
 	now                  func() time.Time
 }
@@ -113,6 +114,7 @@ func defaultAppDeps() appDeps {
 		inspectChanges:   zerogit.Inspect,
 		commitChanges:    zerogit.Commit,
 		runTUI:           tui.Run,
+		runEditor:        openEditor,
 		checkUpdate:      update.Check,
 		now:              time.Now,
 	}
@@ -392,7 +394,7 @@ Commands:
   search     Search persisted local Zero session events
   find       Alias for search
   sessions   Inspect local Zero session lineage
-  specialist Inspect local Zero specialist profiles
+  specialist Manage local Zero specialist profiles
   plugins    Inspect local Zero plugin manifests
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -252,6 +252,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	if deps.runTUI == nil {
 		deps.runTUI = defaults.runTUI
 	}
+	if deps.runEditor == nil {
+		deps.runEditor = defaults.runEditor
+	}
 	if deps.checkUpdate == nil {
 		deps.checkUpdate = defaults.checkUpdate
 	}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -207,7 +207,7 @@ func TestRunExecRegistersTaskOnlyForUnsafeTopLevelRuns(t *testing.T) {
 			if exitCode != exitSuccess {
 				t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
 			}
-			for _, toolName := range []string{"Task", "TaskOutput", "TaskStop"} {
+			for _, toolName := range []string{"Task", "TaskOutput", "TaskStop", "GenerateSpecialist"} {
 				hasTool := strings.Contains(stdout.String(), "  "+toolName+" ")
 				if hasTool != tc.wantTask {
 					t.Fatalf("%s visibility = %v, want %v; output:\n%s", toolName, hasTool, tc.wantTask, stdout.String())

--- a/internal/cli/specialist.go
+++ b/internal/cli/specialist.go
@@ -3,13 +3,23 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
+	osexec "os/exec"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/specialist"
 )
 
 type specialistOptions struct {
-	json bool
+	json            bool
+	location        specialist.Location
+	description     string
+	prompt          string
+	extends         string
+	model           string
+	reasoningEffort string
+	tools           []string
+	force           bool
 }
 
 func runSpecialists(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -42,6 +52,12 @@ func runSpecialists(args []string, stdout io.Writer, stderr io.Writer, deps appD
 		return runSpecialistList(paths, options, stdout, stderr)
 	case "show":
 		return runSpecialistShow(paths, remaining[0], options, stdout, stderr)
+	case "create":
+		return runSpecialistCreate(paths, remaining[0], options, stdout, stderr)
+	case "delete", "rm":
+		return runSpecialistDelete(paths, remaining[0], options, stdout, stderr)
+	case "edit":
+		return runSpecialistEdit(paths, remaining[0], options, stdout, stderr, deps)
 	case "path":
 		return runSpecialistPath(paths, options, stdout)
 	default:
@@ -54,13 +70,84 @@ func parseSpecialistArgs(args []string) (string, []string, specialistOptions, bo
 	commandExplicit := false
 	remaining := []string{}
 	options := specialistOptions{}
-	for _, arg := range args {
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
 		switch arg {
 		case "-h", "--help", "help":
 			return command, remaining, options, true, nil
 		case "--json":
 			options.json = true
+		case "--user":
+			options.location = specialist.LocationUser
+		case "--project":
+			options.location = specialist.LocationProject
+		case "--force":
+			options.force = true
+		case "--location", "--description", "--prompt", "--system-prompt", "--tools", "--extends", "--model", "--reasoning-effort":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return command, remaining, options, false, err
+			}
+			index = next
+			if err := applySpecialistOption(&options, arg, value); err != nil {
+				return command, remaining, options, false, err
+			}
 		default:
+			if strings.HasPrefix(arg, "--location=") {
+				value, err := requiredInlineFlagValue(arg, "--location")
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				if err := applySpecialistOption(&options, "--location", value); err != nil {
+					return command, remaining, options, false, err
+				}
+				continue
+			}
+			if strings.HasPrefix(arg, "--description=") {
+				value, err := requiredInlineFlagValue(arg, "--description")
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				if err := applySpecialistOption(&options, "--description", value); err != nil {
+					return command, remaining, options, false, err
+				}
+				continue
+			}
+			if strings.HasPrefix(arg, "--prompt=") || strings.HasPrefix(arg, "--system-prompt=") {
+				flag := "--prompt"
+				if strings.HasPrefix(arg, "--system-prompt=") {
+					flag = "--system-prompt"
+				}
+				value, err := requiredInlineFlagValue(arg, flag)
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				if err := applySpecialistOption(&options, flag, value); err != nil {
+					return command, remaining, options, false, err
+				}
+				continue
+			}
+			if strings.HasPrefix(arg, "--tools=") {
+				value, err := requiredInlineFlagValue(arg, "--tools")
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				if err := applySpecialistOption(&options, "--tools", value); err != nil {
+					return command, remaining, options, false, err
+				}
+				continue
+			}
+			if strings.HasPrefix(arg, "--extends=") || strings.HasPrefix(arg, "--model=") || strings.HasPrefix(arg, "--reasoning-effort=") {
+				flag, _, _ := strings.Cut(arg, "=")
+				value, err := requiredInlineFlagValue(arg, flag)
+				if err != nil {
+					return command, remaining, options, false, err
+				}
+				if err := applySpecialistOption(&options, flag, value); err != nil {
+					return command, remaining, options, false, err
+				}
+				continue
+			}
 			if strings.HasPrefix(arg, "-") {
 				return command, remaining, options, false, fmt.Errorf("unknown specialist flag %q", arg)
 			}
@@ -75,6 +162,36 @@ func parseSpecialistArgs(args []string) (string, []string, specialistOptions, bo
 	return command, remaining, options, false, nil
 }
 
+func applySpecialistOption(options *specialistOptions, flag string, value string) error {
+	value = strings.TrimSpace(value)
+	switch flag {
+	case "--location":
+		switch strings.ToLower(value) {
+		case "user":
+			options.location = specialist.LocationUser
+		case "project":
+			options.location = specialist.LocationProject
+		default:
+			return fmt.Errorf("--location must be user or project")
+		}
+	case "--description":
+		options.description = value
+	case "--prompt", "--system-prompt":
+		options.prompt = value
+	case "--tools":
+		options.tools = specialist.SplitToolList(value)
+	case "--extends":
+		options.extends = value
+	case "--model":
+		options.model = value
+	case "--reasoning-effort":
+		options.reasoningEffort = value
+	default:
+		return fmt.Errorf("unknown specialist flag %q", flag)
+	}
+	return nil
+}
+
 func validateSpecialistCommand(command string, remaining []string) error {
 	switch command {
 	case "list":
@@ -84,6 +201,18 @@ func validateSpecialistCommand(command string, remaining []string) error {
 	case "show":
 		if len(remaining) != 1 {
 			return fmt.Errorf("specialist show requires a specialist name")
+		}
+	case "create":
+		if len(remaining) != 1 {
+			return fmt.Errorf("specialist create requires a specialist name")
+		}
+	case "delete", "rm":
+		if len(remaining) != 1 {
+			return fmt.Errorf("specialist delete requires a specialist name")
+		}
+	case "edit":
+		if len(remaining) != 1 {
+			return fmt.Errorf("specialist edit requires a specialist name")
 		}
 	case "path":
 		if len(remaining) != 0 {
@@ -141,6 +270,77 @@ func runSpecialistShow(paths specialist.Paths, name string, options specialistOp
 	return exitSuccess
 }
 
+func runSpecialistCreate(paths specialist.Paths, name string, options specialistOptions, stdout io.Writer, stderr io.Writer) int {
+	storage := specialist.NewStorage(paths)
+	manifest, err := storage.Create(specialist.CreateInput{
+		Name:            name,
+		Description:     options.description,
+		SystemPrompt:    options.prompt,
+		Extends:         options.extends,
+		Model:           options.model,
+		ReasoningEffort: options.reasoningEffort,
+		Tools:           options.tools,
+		Location:        options.location,
+		Overwrite:       options.force,
+	})
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, manifest); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "Created specialist %s at %s\n", manifest.Metadata.Name, manifest.FilePath); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSpecialistDelete(paths specialist.Paths, name string, options specialistOptions, stdout io.Writer, stderr io.Writer) int {
+	storage := specialist.NewStorage(paths)
+	path, err := storage.Delete(specialist.DeleteInput{Name: name, Location: options.location})
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, map[string]any{"name": name, "path": path, "deleted": true}); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "Deleted specialist %s at %s\n", name, path); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSpecialistEdit(paths specialist.Paths, name string, options specialistOptions, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	storage := specialist.NewStorage(paths)
+	path, err := storage.Path(name, options.location)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return writeExecUsageError(stderr, "specialist not found: "+name)
+		}
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	runEditor := deps.runEditor
+	if runEditor == nil {
+		runEditor = openEditor
+	}
+	if err := runEditor(path); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if _, err := fmt.Fprintf(stdout, "Edited specialist %s at %s\n", name, path); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
 func runSpecialistPath(paths specialist.Paths, options specialistOptions, stdout io.Writer) int {
 	if options.json {
 		if err := writePrettyJSON(stdout, paths); err != nil {
@@ -161,11 +361,47 @@ func writeSpecialistHelp(w io.Writer) error {
 Commands:
   list       List built-in, user, and project specialists
   show NAME  Show one specialist profile
+  create NAME
+             Create a user specialist profile
+  delete NAME
+             Delete a user specialist profile
+  edit NAME  Open a user specialist profile in $VISUAL or $EDITOR
   path       Print specialist directories
   help       Show this help
 
 Flags:
-  --json     Print JSON output
+  --json                      Print JSON output
+  --user                      Use the user specialist directory (default)
+  --project                   Use the project .zero/specialists directory
+  --description <text>        Description for create
+  --prompt <text>             System prompt for create
+  --tools <list>              Tool ids/categories for create
+  --extends <name>            Base specialist for create
+  --model <model>             Model override for create
+  --reasoning-effort <value>  Reasoning effort override for create
+  --force                     Replace an existing specialist during create
 `)
 	return err
+}
+
+func openEditor(path string) error {
+	editor := strings.TrimSpace(os.Getenv("VISUAL"))
+	if editor == "" {
+		editor = strings.TrimSpace(os.Getenv("EDITOR"))
+	}
+	if editor == "" {
+		return fmt.Errorf("VISUAL or EDITOR must be set to edit specialists")
+	}
+	parts := strings.Fields(editor)
+	if len(parts) == 0 {
+		return fmt.Errorf("VISUAL or EDITOR must be set to edit specialists")
+	}
+	command := osexec.Command(parts[0], append(parts[1:], path)...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("editor failed: %w", err)
+	}
+	return nil
 }

--- a/internal/cli/specialist.go
+++ b/internal/cli/specialist.go
@@ -322,11 +322,15 @@ func runSpecialistEdit(paths specialist.Paths, name string, options specialistOp
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	if _, err := os.Stat(path); err != nil {
+	info, err := os.Lstat(path)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return writeExecUsageError(stderr, "specialist not found: "+name)
 		}
 		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return writeExecUsageError(stderr, "refusing to edit symlink specialist file: "+path)
 	}
 	runEditor := deps.runEditor
 	if runEditor == nil {

--- a/internal/cli/specialist_test.go
+++ b/internal/cli/specialist_test.go
@@ -185,6 +185,44 @@ func TestRunSpecialistCreateDeleteAndEdit(t *testing.T) {
 	}
 }
 
+func TestRunSpecialistEditRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs extra privileges on Windows")
+	}
+	cwd := t.TempDir()
+	configRoot := setSpecialistConfigRoot(t)
+	userDir := filepath.Join(configRoot, "zero", "specialists")
+	if err := os.MkdirAll(userDir, 0o700); err != nil {
+		t.Fatalf("create specialist dir: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "target.md")
+	if err := os.WriteFile(target, []byte("do not edit"), 0o600); err != nil {
+		t.Fatalf("write symlink target: %v", err)
+	}
+	link := filepath.Join(userDir, "linked.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("create symlink: %v", err)
+	}
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		runEditor: func(path string) error {
+			t.Fatalf("editor should not be invoked for symlink path %s", path)
+			return nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"specialist", "edit", "linked"}, &stdout, &stderr, deps)
+
+	if exitCode != exitUsage {
+		t.Fatalf("exitCode = %d, want usage; stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "refusing to edit symlink") {
+		t.Fatalf("expected symlink refusal, got %q", stderr.String())
+	}
+}
+
 func TestRunSpecialistCreateProjectAndRejectDuplicate(t *testing.T) {
 	cwd := t.TempDir()
 	setSpecialistConfigRoot(t)

--- a/internal/cli/specialist_test.go
+++ b/internal/cli/specialist_test.go
@@ -127,6 +127,90 @@ func TestRunSpecialistListJSON(t *testing.T) {
 	}
 }
 
+func TestRunSpecialistCreateDeleteAndEdit(t *testing.T) {
+	cwd := t.TempDir()
+	configRoot := setSpecialistConfigRoot(t)
+	userDir := filepath.Join(configRoot, "zero", "specialists")
+	deps := appDeps{getwd: func() (string, error) { return cwd, nil }}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"specialist", "create", "triage",
+		"--description", "Triage failures",
+		"--prompt", "Find the most likely failure.",
+		"--tools", "read-only,plan",
+	}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("create exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	path := filepath.Join(userDir, "triage.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected specialist file: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{`name: "triage"`, `description: "Triage failures"`, `"read-only"`, `"plan"`, "Find the most likely failure."} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("created file missing %q:\n%s", want, content)
+		}
+	}
+
+	var editedPath string
+	deps.runEditor = func(path string) error {
+		editedPath = path
+		return nil
+	}
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"specialist", "edit", "triage"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("edit exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if editedPath != path {
+		t.Fatalf("edited path = %q, want %q", editedPath, path)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"specialist", "delete", "triage", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("delete exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected specialist file deleted, stat err=%v", err)
+	}
+	if !strings.Contains(stdout.String(), `"deleted": true`) {
+		t.Fatalf("delete JSON missing deleted=true: %s", stdout.String())
+	}
+}
+
+func TestRunSpecialistCreateProjectAndRejectDuplicate(t *testing.T) {
+	cwd := t.TempDir()
+	setSpecialistConfigRoot(t)
+	deps := appDeps{getwd: func() (string, error) { return cwd, nil }}
+	args := []string{"specialist", "create", "project-helper", "--project", "--description=Project helper"}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps(args, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("create project exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".zero", "specialists", "project-helper.md")); err != nil {
+		t.Fatalf("expected project specialist file: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps(args, &stdout, &stderr, deps)
+	if exitCode != exitUsage {
+		t.Fatalf("duplicate exitCode = %d, want usage", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "already exists") {
+		t.Fatalf("duplicate error = %q", stderr.String())
+	}
+}
+
 func TestRunSpecialistShowMissingReturnsUsage(t *testing.T) {
 	setSpecialistConfigRoot(t)
 	deps := appDeps{getwd: func() (string, error) { return t.TempDir(), nil }}
@@ -173,6 +257,9 @@ func TestRunSpecialistArgCountErrors(t *testing.T) {
 	}{
 		{args: []string{"specialist", "list", "extra"}, want: "does not accept positional"},
 		{args: []string{"specialist", "show"}, want: "show requires a specialist name"},
+		{args: []string{"specialist", "create"}, want: "create requires a specialist name"},
+		{args: []string{"specialist", "delete"}, want: "delete requires a specialist name"},
+		{args: []string{"specialist", "edit"}, want: "edit requires a specialist name"},
 		{args: []string{"specialist", "path", "extra"}, want: "path does not accept positional"},
 	}
 	for _, tc := range tests {

--- a/internal/specialist/generate_tool.go
+++ b/internal/specialist/generate_tool.go
@@ -1,0 +1,256 @@
+package specialist
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type GenerateTool struct {
+	storage *Storage
+}
+
+type generateParameters struct {
+	Name         string
+	Description  string
+	SystemPrompt string
+	Location     Location
+	Tools        []string
+	Overwrite    bool
+}
+
+func NewGenerateTool(storage *Storage) *GenerateTool {
+	return &GenerateTool{storage: storage}
+}
+
+func (tool *GenerateTool) Name() string {
+	return "GenerateSpecialist"
+}
+
+func (tool *GenerateTool) Description() string {
+	return "Create a local Zero specialist profile from a designed name, description, and system prompt."
+}
+
+func (tool *GenerateTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"name": {
+				Type:        "string",
+				Description: "Specialist identifier, such as api-reviewer. Derived from description when omitted.",
+			},
+			"description": {
+				Type:        "string",
+				Description: "Short user-facing description of the specialist.",
+			},
+			"system_prompt": {
+				Type:        "string",
+				Description: "Full instructions the specialist should follow.",
+			},
+			"location": {
+				Type:        "string",
+				Description: "Where to save the specialist.",
+				Enum:        []string{"user", "project"},
+				Default:     "user",
+			},
+			"tools": {
+				Type:        "array",
+				Description: "Tool categories or tool ids for the specialist, such as read-only, edit, execute, or plan.",
+			},
+			"overwrite": {
+				Type:        "boolean",
+				Description: "Replace an existing specialist with the same name.",
+				Default:     false,
+			},
+		},
+		Required:             []string{"description"},
+		AdditionalProperties: false,
+	}
+}
+
+func (tool *GenerateTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectWrite,
+		Permission:      tools.PermissionPrompt,
+		Reason:          "Writes a specialist profile to disk.",
+		AdvertiseInAuto: true,
+	}
+}
+
+func (tool *GenerateTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	params, err := parseGenerateParameters(args)
+	if err != nil {
+		return taskError(err)
+	}
+	if tool.storage == nil {
+		return taskError(fmt.Errorf("specialist storage is not configured"))
+	}
+	systemPrompt := strings.TrimSpace(params.SystemPrompt)
+	if systemPrompt == "" {
+		systemPrompt = defaultGeneratedSystemPrompt(params.Description)
+	}
+	manifest, err := tool.storage.Create(CreateInput{
+		Name:         params.Name,
+		Description:  params.Description,
+		SystemPrompt: systemPrompt,
+		Location:     params.Location,
+		Tools:        params.Tools,
+		Overwrite:    params.Overwrite,
+	})
+	if err != nil {
+		return taskError(err)
+	}
+	return tools.Result{
+		Status: tools.StatusOK,
+		Output: fmt.Sprintf("specialist: %s\nlocation: %s\npath: %s", manifest.Metadata.Name, manifest.Location, manifest.FilePath),
+		Meta: map[string]string{
+			"name":     manifest.Metadata.Name,
+			"location": string(manifest.Location),
+			"path":     manifest.FilePath,
+		},
+	}
+}
+
+func parseGenerateParameters(args map[string]any) (generateParameters, error) {
+	description, err := optionalTaskString(args, "description")
+	if err != nil {
+		return generateParameters{}, err
+	}
+	name, err := optionalTaskString(args, "name")
+	if err != nil {
+		return generateParameters{}, err
+	}
+	systemPrompt, err := optionalTaskString(args, "system_prompt")
+	if err != nil {
+		return generateParameters{}, err
+	}
+	location, err := optionalTaskString(args, "location")
+	if err != nil {
+		return generateParameters{}, err
+	}
+	toolsValue, err := optionalStringList(args, "tools")
+	if err != nil {
+		return generateParameters{}, err
+	}
+	overwrite, err := optionalTaskBool(args, "overwrite")
+	if err != nil {
+		return generateParameters{}, err
+	}
+	description = strings.TrimSpace(description)
+	if description == "" {
+		return generateParameters{}, fmt.Errorf("generate specialist requires description")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = slugFromDescription(description)
+	}
+	locationValue, err := parseWritableLocation(location)
+	if err != nil {
+		return generateParameters{}, err
+	}
+	return generateParameters{
+		Name:         name,
+		Description:  description,
+		SystemPrompt: strings.TrimSpace(systemPrompt),
+		Location:     locationValue,
+		Tools:        toolsValue,
+		Overwrite:    overwrite,
+	}, nil
+}
+
+func optionalStringList(args map[string]any, key string) ([]string, error) {
+	if args == nil {
+		return nil, nil
+	}
+	value, ok := args[key]
+	if !ok || value == nil {
+		return nil, nil
+	}
+	switch typed := value.(type) {
+	case []string:
+		return trimStringList(typed), nil
+	case []any:
+		values := make([]string, 0, len(typed))
+		for _, item := range typed {
+			text, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("task %s must be an array of strings", key)
+			}
+			values = append(values, text)
+		}
+		return trimStringList(values), nil
+	case string:
+		return SplitToolList(typed), nil
+	default:
+		return nil, fmt.Errorf("task %s must be an array of strings", key)
+	}
+}
+
+func parseWritableLocation(value string) (Location, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "user":
+		return LocationUser, nil
+	case "project":
+		return LocationProject, nil
+	default:
+		return "", fmt.Errorf("generate specialist location must be user or project")
+	}
+}
+
+func defaultGeneratedSystemPrompt(description string) string {
+	description = strings.TrimSpace(description)
+	return strings.Join([]string{
+		"You are a focused Zero specialist.",
+		"",
+		"Purpose: " + description,
+		"",
+		"Stay within this purpose, use only the tools made available to you, and report concise findings or changes back to the parent agent.",
+	}, "\n")
+}
+
+func slugFromDescription(description string) string {
+	var builder strings.Builder
+	lastDash := false
+	for _, char := range strings.ToLower(description) {
+		switch {
+		case char >= 'a' && char <= 'z':
+			builder.WriteRune(char)
+			lastDash = false
+		case char >= '0' && char <= '9':
+			if builder.Len() > 0 {
+				builder.WriteRune(char)
+				lastDash = false
+			}
+		case unicode.IsSpace(char) || char == '-' || char == '_':
+			if builder.Len() > 0 && !lastDash {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+		if builder.Len() >= 64 {
+			break
+		}
+	}
+	slug := strings.Trim(builder.String(), "-")
+	if slug == "" || slug[0] < 'a' || slug[0] > 'z' {
+		return "specialist"
+	}
+	return slug
+}
+
+// SplitToolList parses comma- or whitespace-separated specialist tool selections.
+func SplitToolList(value string) []string {
+	items := []string{}
+	for _, item := range strings.FieldsFunc(value, func(char rune) bool {
+		return char == ',' || char == ' ' || char == '\t' || char == '\n' || char == '\r'
+	}) {
+		item = strings.TrimSpace(item)
+		if item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
+}

--- a/internal/specialist/generate_tool.go
+++ b/internal/specialist/generate_tool.go
@@ -31,7 +31,7 @@ func (tool *GenerateTool) Name() string {
 }
 
 func (tool *GenerateTool) Description() string {
-	return "Create a local Zero specialist profile from a designed name, description, and system prompt."
+	return "Create a project-local Zero specialist profile from a designed name, description, and system prompt."
 }
 
 func (tool *GenerateTool) Parameters() tools.Schema {
@@ -52,13 +52,14 @@ func (tool *GenerateTool) Parameters() tools.Schema {
 			},
 			"location": {
 				Type:        "string",
-				Description: "Where to save the specialist.",
-				Enum:        []string{"user", "project"},
-				Default:     "user",
+				Description: "Where to save the specialist. GenerateSpecialist is project-scoped.",
+				Enum:        []string{"project"},
+				Default:     "project",
 			},
 			"tools": {
 				Type:        "array",
 				Description: "Tool categories or tool ids for the specialist, such as read-only, edit, execute, or plan.",
+				Items:       &tools.PropertySchema{Type: "string"},
 			},
 			"overwrite": {
 				Type:        "boolean",
@@ -75,7 +76,7 @@ func (tool *GenerateTool) Safety() tools.Safety {
 	return tools.Safety{
 		SideEffect:      tools.SideEffectWrite,
 		Permission:      tools.PermissionPrompt,
-		Reason:          "Writes a specialist profile to disk.",
+		Reason:          "Writes a project specialist profile inside the workspace.",
 		AdvertiseInAuto: true,
 	}
 }
@@ -146,6 +147,8 @@ func parseGenerateParameters(args map[string]any) (generateParameters, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		name = slugFromDescription(description)
+	} else if !namePattern.MatchString(name) {
+		return generateParameters{}, fmt.Errorf("invalid specialist name %q: use lowercase letters, numbers, and dashes", name)
 	}
 	locationValue, err := parseWritableLocation(location)
 	if err != nil {
@@ -177,7 +180,7 @@ func optionalStringList(args map[string]any, key string) ([]string, error) {
 		for _, item := range typed {
 			text, ok := item.(string)
 			if !ok {
-				return nil, fmt.Errorf("task %s must be an array of strings", key)
+				return nil, fmt.Errorf("parameter %s must be an array of strings", key)
 			}
 			values = append(values, text)
 		}
@@ -185,18 +188,16 @@ func optionalStringList(args map[string]any, key string) ([]string, error) {
 	case string:
 		return SplitToolList(typed), nil
 	default:
-		return nil, fmt.Errorf("task %s must be an array of strings", key)
+		return nil, fmt.Errorf("parameter %s must be an array of strings", key)
 	}
 }
 
 func parseWritableLocation(value string) (Location, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "user":
-		return LocationUser, nil
-	case "project":
+	case "", "project":
 		return LocationProject, nil
 	default:
-		return "", fmt.Errorf("generate specialist location must be user or project")
+		return "", fmt.Errorf("generate specialist location must be project")
 	}
 }
 

--- a/internal/specialist/generate_tool_test.go
+++ b/internal/specialist/generate_tool_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestGenerateToolCreatesSpecialist(t *testing.T) {
-	userDir := filepath.Join(t.TempDir(), "user")
-	tool := NewGenerateTool(NewStorage(Paths{UserDir: userDir}))
+	projectDir := filepath.Join(t.TempDir(), "project")
+	tool := NewGenerateTool(NewStorage(Paths{ProjectDir: projectDir}))
 
 	result := tool.Run(context.Background(), map[string]any{
 		"description":   "API review helper",
@@ -24,7 +24,7 @@ func TestGenerateToolCreatesSpecialist(t *testing.T) {
 	if result.Status != tools.StatusOK {
 		t.Fatalf("GenerateSpecialist status = %s output=%s", result.Status, result.Output)
 	}
-	path := filepath.Join(userDir, "api-review.md")
+	path := filepath.Join(projectDir, "api-review.md")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("expected generated specialist file: %v", err)
@@ -35,18 +35,21 @@ func TestGenerateToolCreatesSpecialist(t *testing.T) {
 	if result.Meta["path"] != path || result.Meta["name"] != "api-review" {
 		t.Fatalf("unexpected result meta: %#v", result.Meta)
 	}
+	if result.Meta["location"] != string(LocationProject) {
+		t.Fatalf("location = %q, want project", result.Meta["location"])
+	}
 }
 
 func TestGenerateToolDerivesNameAndDefaultPrompt(t *testing.T) {
-	userDir := filepath.Join(t.TempDir(), "user")
-	tool := NewGenerateTool(NewStorage(Paths{UserDir: userDir}))
+	projectDir := filepath.Join(t.TempDir(), "project")
+	tool := NewGenerateTool(NewStorage(Paths{ProjectDir: projectDir}))
 
 	result := tool.Run(context.Background(), map[string]any{"description": "Security Audit Helper"})
 
 	if result.Status != tools.StatusOK {
 		t.Fatalf("GenerateSpecialist status = %s output=%s", result.Status, result.Output)
 	}
-	data, err := os.ReadFile(filepath.Join(userDir, "security-audit-helper.md"))
+	data, err := os.ReadFile(filepath.Join(projectDir, "security-audit-helper.md"))
 	if err != nil {
 		t.Fatalf("expected generated specialist file: %v", err)
 	}
@@ -56,14 +59,143 @@ func TestGenerateToolDerivesNameAndDefaultPrompt(t *testing.T) {
 }
 
 func TestGenerateToolRejectsInvalidLocation(t *testing.T) {
-	tool := NewGenerateTool(NewStorage(Paths{UserDir: t.TempDir()}))
+	tool := NewGenerateTool(NewStorage(Paths{ProjectDir: t.TempDir()}))
 
 	result := tool.Run(context.Background(), map[string]any{
 		"description": "Bad location",
 		"location":    "remote",
 	})
 
-	if result.Status != tools.StatusError || !strings.Contains(result.Output, "location must be user or project") {
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "location must be project") {
 		t.Fatalf("invalid location result = %#v", result)
+	}
+}
+
+func TestGenerateToolRejectsUserLocation(t *testing.T) {
+	tool := NewGenerateTool(NewStorage(Paths{ProjectDir: t.TempDir()}))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"description": "User-scoped profile",
+		"location":    "user",
+	})
+
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "location must be project") {
+		t.Fatalf("user location result = %#v", result)
+	}
+}
+
+func TestGenerateToolOverwriteAndToolFormats(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "project")
+	tool := NewGenerateTool(NewStorage(Paths{ProjectDir: projectDir}))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"description":   "API review",
+		"name":          "api-review",
+		"system_prompt": "First prompt.",
+		"tools":         "read-only, plan",
+	})
+	if result.Status != tools.StatusOK {
+		t.Fatalf("first create status = %s output=%s", result.Status, result.Output)
+	}
+	path := filepath.Join(projectDir, "api-review.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	for _, want := range []string{`"read-only"`, `"plan"`, "First prompt."} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("generated file missing %q:\n%s", want, string(data))
+		}
+	}
+
+	result = tool.Run(context.Background(), map[string]any{
+		"description":   "API review",
+		"name":          "api-review",
+		"system_prompt": "Second prompt.",
+	})
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "already exists") {
+		t.Fatalf("duplicate create result = %#v", result)
+	}
+
+	result = tool.Run(context.Background(), map[string]any{
+		"description":   "API review",
+		"name":          "api-review",
+		"system_prompt": "Second prompt.",
+		"tools":         []string{"execute"},
+		"overwrite":     true,
+	})
+	if result.Status != tools.StatusOK {
+		t.Fatalf("overwrite status = %s output=%s", result.Status, result.Output)
+	}
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read overwritten file: %v", err)
+	}
+	for _, want := range []string{`"execute"`, "Second prompt."} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("overwritten file missing %q:\n%s", want, string(data))
+		}
+	}
+}
+
+func TestGenerateToolValidationEdges(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{
+			name: "empty description",
+			args: map[string]any{"description": "   "},
+			want: "requires description",
+		},
+		{
+			name: "invalid name",
+			args: map[string]any{"description": "Bad name", "name": "../escape"},
+			want: "invalid specialist name",
+		},
+		{
+			name: "non string tools",
+			args: map[string]any{"description": "Bad tools", "tools": []any{"read-only", 12}},
+			want: "parameter tools must be an array of strings",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tool := NewGenerateTool(NewStorage(Paths{ProjectDir: t.TempDir()}))
+
+			result := tool.Run(context.Background(), tc.args)
+
+			if result.Status != tools.StatusError || !strings.Contains(result.Output, tc.want) {
+				t.Fatalf("result = %#v, want error containing %q", result, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateToolUsesFallbackSlugForSymbolsOnlyDescription(t *testing.T) {
+	projectDir := filepath.Join(t.TempDir(), "project")
+	tool := NewGenerateTool(NewStorage(Paths{ProjectDir: projectDir}))
+
+	result := tool.Run(context.Background(), map[string]any{"description": "123 !!!"})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("GenerateSpecialist status = %s output=%s", result.Status, result.Output)
+	}
+	if result.Meta["name"] != "specialist" {
+		t.Fatalf("name = %q, want specialist", result.Meta["name"])
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, "specialist.md")); err != nil {
+		t.Fatalf("expected fallback specialist file: %v", err)
+	}
+}
+
+func TestGenerateToolRejectsNilStorage(t *testing.T) {
+	tool := NewGenerateTool(nil)
+
+	result := tool.Run(context.Background(), map[string]any{"description": "Nil storage"})
+
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "storage is not configured") {
+		t.Fatalf("nil storage result = %#v", result)
 	}
 }

--- a/internal/specialist/generate_tool_test.go
+++ b/internal/specialist/generate_tool_test.go
@@ -1,0 +1,69 @@
+package specialist
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestGenerateToolCreatesSpecialist(t *testing.T) {
+	userDir := filepath.Join(t.TempDir(), "user")
+	tool := NewGenerateTool(NewStorage(Paths{UserDir: userDir}))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"description":   "API review helper",
+		"name":          "api-review",
+		"system_prompt": "Review API diffs.",
+		"tools":         []any{"read-only", "plan"},
+	})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("GenerateSpecialist status = %s output=%s", result.Status, result.Output)
+	}
+	path := filepath.Join(userDir, "api-review.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected generated specialist file: %v", err)
+	}
+	if !strings.Contains(string(data), `name: "api-review"`) || !strings.Contains(string(data), "Review API diffs.") {
+		t.Fatalf("unexpected generated file:\n%s", string(data))
+	}
+	if result.Meta["path"] != path || result.Meta["name"] != "api-review" {
+		t.Fatalf("unexpected result meta: %#v", result.Meta)
+	}
+}
+
+func TestGenerateToolDerivesNameAndDefaultPrompt(t *testing.T) {
+	userDir := filepath.Join(t.TempDir(), "user")
+	tool := NewGenerateTool(NewStorage(Paths{UserDir: userDir}))
+
+	result := tool.Run(context.Background(), map[string]any{"description": "Security Audit Helper"})
+
+	if result.Status != tools.StatusOK {
+		t.Fatalf("GenerateSpecialist status = %s output=%s", result.Status, result.Output)
+	}
+	data, err := os.ReadFile(filepath.Join(userDir, "security-audit-helper.md"))
+	if err != nil {
+		t.Fatalf("expected generated specialist file: %v", err)
+	}
+	if !strings.Contains(string(data), "Purpose: Security Audit Helper") {
+		t.Fatalf("default prompt missing purpose:\n%s", string(data))
+	}
+}
+
+func TestGenerateToolRejectsInvalidLocation(t *testing.T) {
+	tool := NewGenerateTool(NewStorage(Paths{UserDir: t.TempDir()}))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"description": "Bad location",
+		"location":    "remote",
+	})
+
+	if result.Status != tools.StatusError || !strings.Contains(result.Output, "location must be user or project") {
+		t.Fatalf("invalid location result = %#v", result)
+	}
+}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -87,6 +87,13 @@ var toolCategories = map[string][]string{
 	"plan":      {"update_plan"},
 }
 
+var forbiddenToolNames = map[string]bool{
+	"Task":               true,
+	"TaskOutput":         true,
+	"TaskStop":           true,
+	"GenerateSpecialist": true,
+}
+
 // defaultToolSelection keeps omitted tools conservative until runtime task
 // execution has its own permission policy.
 var defaultToolSelection = []string{"read-only"}
@@ -266,6 +273,9 @@ func ResolveTools(selection []string) ([]string, error) {
 		item = strings.TrimSpace(item)
 		if item == "" {
 			continue
+		}
+		if forbiddenToolNames[item] {
+			return nil, fmt.Errorf("forbidden specialist tool %q", item)
 		}
 		tools, ok := toolCategories[item]
 		if !ok {

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -139,6 +139,16 @@ Prompt.`,
 			want: "unknown tool or category",
 		},
 		{
+			name: "forbidden generation tool",
+			content: `---
+name: generator
+description: Generates specialists
+tools: [GenerateSpecialist]
+---
+Prompt.`,
+			want: "forbidden specialist tool",
+		},
+		{
 			name: "duplicate key",
 			content: `---
 name: explorer

--- a/internal/specialist/registry.go
+++ b/internal/specialist/registry.go
@@ -16,5 +16,6 @@ func RegisterTools(registry *tools.Registry, executor Executor) (*Runtime, error
 	registry.Register(NewTaskTool(toolExecutor))
 	registry.Register(newOutputToolWithManagerFunc(runtime.Manager))
 	registry.Register(newStopToolWithManagerFunc(runtime.Manager))
+	registry.Register(NewGenerateTool(NewStorage(executor.Paths)))
 	return runtime, nil
 }

--- a/internal/specialist/storage.go
+++ b/internal/specialist/storage.go
@@ -1,0 +1,202 @@
+package specialist
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type Storage struct {
+	paths Paths
+}
+
+type CreateInput struct {
+	Name            string
+	Description     string
+	SystemPrompt    string
+	Extends         string
+	Model           string
+	ReasoningEffort string
+	Tools           []string
+	Location        Location
+	Overwrite       bool
+}
+
+type DeleteInput struct {
+	Name     string
+	Location Location
+}
+
+func NewStorage(paths Paths) *Storage {
+	return &Storage{paths: paths}
+}
+
+func (storage *Storage) Create(input CreateInput) (Manifest, error) {
+	location := normalizeWritableLocation(input.Location)
+	path, err := storage.path(input.Name, location)
+	if err != nil {
+		return Manifest{}, err
+	}
+	systemPrompt := strings.TrimSpace(input.SystemPrompt)
+	if systemPrompt == "" && strings.TrimSpace(input.Extends) == "" {
+		systemPrompt = strings.TrimSpace(input.Description)
+	}
+	manifest := Manifest{
+		Metadata: Metadata{
+			Name:            strings.TrimSpace(input.Name),
+			Description:     strings.TrimSpace(input.Description),
+			Extends:         strings.TrimSpace(input.Extends),
+			Model:           strings.TrimSpace(input.Model),
+			ReasoningEffort: strings.TrimSpace(input.ReasoningEffort),
+			Tools:           trimStringList(input.Tools),
+		},
+		SystemPrompt: systemPrompt,
+		Location:     location,
+		FilePath:     path,
+	}
+	if err := Validate(&manifest); err != nil {
+		return Manifest{}, err
+	}
+	if strings.TrimSpace(manifest.SystemPrompt) == "" && manifest.Metadata.Extends == "" {
+		return Manifest{}, fmt.Errorf("specialist %q requires a system prompt", manifest.Metadata.Name)
+	}
+	content := FormatMarkdown(manifest)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return Manifest{}, fmt.Errorf("create specialist directory: %w", err)
+	}
+	if input.Overwrite {
+		info, err := os.Lstat(path)
+		if err != nil && !os.IsNotExist(err) {
+			return Manifest{}, fmt.Errorf("inspect specialist file: %w", err)
+		}
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return Manifest{}, fmt.Errorf("refusing to overwrite symlink specialist file: %s", path)
+		}
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if input.Overwrite {
+		flags |= os.O_TRUNC
+	} else {
+		flags |= os.O_EXCL
+	}
+	file, err := os.OpenFile(path, flags, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return Manifest{}, fmt.Errorf("specialist already exists: %s", manifest.Metadata.Name)
+		}
+		return Manifest{}, fmt.Errorf("write specialist file: %w", err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		return Manifest{}, fmt.Errorf("write specialist file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return Manifest{}, fmt.Errorf("close specialist file: %w", err)
+	}
+	return manifest, nil
+}
+
+func (storage *Storage) Delete(input DeleteInput) (string, error) {
+	location := normalizeWritableLocation(input.Location)
+	path, err := storage.path(input.Name, location)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("specialist not found: %s", strings.TrimSpace(input.Name))
+		}
+		return "", fmt.Errorf("delete specialist file: %w", err)
+	}
+	return path, nil
+}
+
+func (storage *Storage) Path(name string, location Location) (string, error) {
+	return storage.path(name, normalizeWritableLocation(location))
+}
+
+func FormatMarkdown(manifest Manifest) string {
+	var builder strings.Builder
+	builder.WriteString("---\n")
+	writeMetadataString(&builder, "name", manifest.Metadata.Name)
+	writeMetadataString(&builder, "description", manifest.Metadata.Description)
+	writeMetadataString(&builder, "extends", manifest.Metadata.Extends)
+	writeMetadataString(&builder, "model", manifest.Metadata.Model)
+	writeMetadataString(&builder, "reasoningEffort", manifest.Metadata.ReasoningEffort)
+	if len(manifest.Metadata.Tools) > 0 {
+		builder.WriteString("tools:\n")
+		for _, tool := range manifest.Metadata.Tools {
+			tool = strings.TrimSpace(tool)
+			if tool == "" {
+				continue
+			}
+			builder.WriteString("  - ")
+			builder.WriteString(strconv.Quote(tool))
+			builder.WriteByte('\n')
+		}
+	}
+	builder.WriteString("---\n\n")
+	builder.WriteString(strings.TrimSpace(manifest.SystemPrompt))
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+func (storage *Storage) path(name string, location Location) (string, error) {
+	name = strings.TrimSpace(name)
+	if !namePattern.MatchString(name) {
+		return "", fmt.Errorf("invalid specialist name %q: use lowercase letters, numbers, and dashes", name)
+	}
+	dir, err := storage.dir(location)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name+".md"), nil
+}
+
+func (storage *Storage) dir(location Location) (string, error) {
+	switch location {
+	case LocationUser:
+		if strings.TrimSpace(storage.paths.UserDir) == "" {
+			return "", fmt.Errorf("user specialist directory is not configured")
+		}
+		return storage.paths.UserDir, nil
+	case LocationProject:
+		if strings.TrimSpace(storage.paths.ProjectDir) == "" {
+			return "", fmt.Errorf("project specialist directory is not configured")
+		}
+		return storage.paths.ProjectDir, nil
+	default:
+		return "", fmt.Errorf("invalid specialist location %q", location)
+	}
+}
+
+func normalizeWritableLocation(location Location) Location {
+	if location == "" {
+		return LocationUser
+	}
+	return location
+}
+
+func trimStringList(values []string) []string {
+	out := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func writeMetadataString(builder *strings.Builder, key string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	builder.WriteString(key)
+	builder.WriteString(": ")
+	builder.WriteString(strconv.Quote(value))
+	builder.WriteByte('\n')
+}

--- a/internal/specialist/storage_test.go
+++ b/internal/specialist/storage_test.go
@@ -1,0 +1,91 @@
+package specialist
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStorageCreateWritesValidManifestAndDeleteRemovesIt(t *testing.T) {
+	userDir := filepath.Join(t.TempDir(), "user")
+	storage := NewStorage(Paths{UserDir: userDir})
+
+	manifest, err := storage.Create(CreateInput{
+		Name:         "triage",
+		Description:  "Triage failures",
+		SystemPrompt: "Find the likely failure area.",
+		Tools:        []string{"read-only", "plan"},
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if manifest.FilePath != filepath.Join(userDir, "triage.md") || manifest.Location != LocationUser {
+		t.Fatalf("unexpected manifest path/location: %#v", manifest)
+	}
+	data, err := os.ReadFile(manifest.FilePath)
+	if err != nil {
+		t.Fatalf("read created manifest: %v", err)
+	}
+	loaded, err := ParseMarkdown(string(data))
+	if err != nil {
+		t.Fatalf("created manifest did not parse: %v\n%s", err, string(data))
+	}
+	if loaded.Metadata.Name != "triage" || !contains(loaded.ResolvedTools, "update_plan") {
+		t.Fatalf("unexpected loaded manifest: %#v", loaded)
+	}
+
+	deleted, err := storage.Delete(DeleteInput{Name: "triage"})
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if deleted != manifest.FilePath {
+		t.Fatalf("deleted path = %q, want %q", deleted, manifest.FilePath)
+	}
+	if _, err := os.Stat(manifest.FilePath); !os.IsNotExist(err) {
+		t.Fatalf("expected file deleted, stat err=%v", err)
+	}
+}
+
+func TestStorageRejectsUnsafeNamesAndDuplicates(t *testing.T) {
+	storage := NewStorage(Paths{UserDir: t.TempDir()})
+	if _, err := storage.Create(CreateInput{Name: "../escape", Description: "Escape"}); err == nil || !strings.Contains(err.Error(), "invalid specialist name") {
+		t.Fatalf("unsafe Create error = %v", err)
+	}
+	if _, err := storage.Create(CreateInput{Name: "safe", Description: "Safe"}); err != nil {
+		t.Fatalf("Create safe returned error: %v", err)
+	}
+	if _, err := storage.Create(CreateInput{Name: "safe", Description: "Safe"}); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate Create error = %v", err)
+	}
+}
+
+func TestStorageCreateForceRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	userDir := filepath.Join(root, "user")
+	if err := os.MkdirAll(userDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "target.md")
+	if err := os.WriteFile(target, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(userDir, "safe.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	storage := NewStorage(Paths{UserDir: userDir})
+
+	_, err := storage.Create(CreateInput{Name: "safe", Description: "Safe", Overwrite: true})
+
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite symlink") {
+		t.Fatalf("symlink overwrite error = %v", err)
+	}
+	data, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(data) != "outside" {
+		t.Fatalf("symlink target was modified: %q", string(data))
+	}
+}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -46,12 +46,13 @@ type Schema struct {
 }
 
 type PropertySchema struct {
-	Type        string   `json:"type"`
-	Description string   `json:"description,omitempty"`
-	Enum        []string `json:"enum,omitempty"`
-	Default     any      `json:"default,omitempty"`
-	Minimum     *int     `json:"minimum,omitempty"`
-	Maximum     *int     `json:"maximum,omitempty"`
+	Type        string          `json:"type"`
+	Description string          `json:"description,omitempty"`
+	Enum        []string        `json:"enum,omitempty"`
+	Default     any             `json:"default,omitempty"`
+	Items       *PropertySchema `json:"items,omitempty"`
+	Minimum     *int            `json:"minimum,omitempty"`
+	Maximum     *int            `json:"maximum,omitempty"`
 }
 
 type Result struct {


### PR DESCRIPTION
Summary:
- Adds specialist Storage for safe markdown create/delete with user/project locations, overwrite handling, and symlink overwrite protection.
- Adds zero specialist create/delete/rm/edit with JSON-friendly output and project/user targeting.
- Registers GenerateSpecialist so the parent model can write a validated specialist profile from tool arguments, while specialist manifests explicitly forbid Task/TaskOutput/TaskStop/GenerateSpecialist.

Notes:
- GenerateSpecialist does not make a nested provider call; the current parent model supplies the designed name/description/system prompt as tool arguments and the tool validates/writes the file.
- Child specialist runs still do not receive specialist authoring tools because RegisterTools is skipped for --tag specialist.

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist ./internal/cli
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage specialist profiles from the CLI: create, edit (opens editor), delete, list, show, path
  * Project-scoped specialist generator tool with name/description/system-prompt defaults and tool selection
  * Persistent specialist storage: create/delete manifests in user/project locations
  * Improved tool parameter schemas (supports nested/array item schemas)

* **Bug Fixes**
  * Reject forbidden specialist tools and validate locations/names

* **Tests**
  * Added end-to-end and unit tests for specialist CLI, storage, and generator behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->