### PR TITLE
Tools: arg-tolerance, ask_user, secret scrubbing, structured results, hardening

### DIFF
--- a/internal/sandbox/risk.go
+++ b/internal/sandbox/risk.go
@@ -193,7 +193,12 @@ func firstArgString(args map[string]any, keys ...string) string {
 
 func requestPaths(request Request) []string {
 	paths := []string{}
-	for _, key := range []string{"path", "cwd", "file", "dir"} {
+	// Keep this aligned with the path-arg alias lists the tools accept (see
+	// aliasedStringArg in write_file/edit_file/read_file/grep/glob/list). The
+	// sandbox gates by arg-key name, so any alias a tool resolves but the sandbox
+	// does not inspect would let a model route a write/read around the
+	// workspace+symlink boundary.
+	for _, key := range []string{"path", "file", "file_path", "filepath", "filename", "cwd", "dir", "directory"} {
 		if value := argString(request.Args, key); value != "" {
 			paths = append(paths, value)
 		}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -103,7 +103,6 @@ var knownToolNames = map[string]bool{
 	"list_directory": true,
 	"glob":           true,
 	"grep":           true,
-	"ask_user":       true,
 	"write_file":     true,
 	"edit_file":      true,
 	"apply_patch":    true,

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -103,6 +103,7 @@ var knownToolNames = map[string]bool{
 	"list_directory": true,
 	"glob":           true,
 	"grep":           true,
+	"ask_user":       true,
 	"write_file":     true,
 	"edit_file":      true,
 	"apply_patch":    true,

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -35,7 +35,7 @@ func NewApplyPatchTool(workspaceRoot string) Tool {
 }
 
 func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result {
-	patch, err := stringArg(args, "patch", "", true)
+	patch, err := aliasedStringArg(args, []string{"patch", "diff"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for apply_patch: " + err.Error())
 	}
@@ -83,10 +83,41 @@ func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result 
 		return errorResult("Error applying patch: " + message)
 	}
 
-	if relativeRoot == "." {
-		return okResult("Patch applied successfully.")
+	summary := "Patch applied successfully."
+	if relativeRoot != "." {
+		summary = "Patch applied successfully in " + relativeRoot + "."
 	}
-	return okResult("Patch applied successfully in " + relativeRoot + ".")
+	result := okResult(summary)
+	result.ChangedFiles = changedFilesFromPatch(relativeRoot, patch)
+	result.Display = Display{Summary: summary, Kind: "diff"}
+	return result
+}
+
+// changedFilesFromPatch extracts the unique, WORKSPACE-relative paths a patch
+// touches, reusing the same per-line parser used for validation. Patch paths are
+// relative to the apply cwd, so relativeRoot (the workspace-relative cwd, e.g.
+// "sub/dir", or "." for the workspace root) is prefixed so callers get true
+// workspace-relative paths regardless of cwd.
+func changedFilesFromPatch(relativeRoot string, patch string) []string {
+	seen := map[string]bool{}
+	var paths []string
+	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
+		for _, path := range patchPathsFromLine(line) {
+			if path == "" || path == "/dev/null" {
+				continue
+			}
+			workspacePath := path
+			if relativeRoot != "" && relativeRoot != "." {
+				workspacePath = filepath.ToSlash(filepath.Join(relativeRoot, path))
+			}
+			if seen[workspacePath] {
+				continue
+			}
+			seen[workspacePath] = true
+			paths = append(paths, workspacePath)
+		}
+	}
+	return paths
 }
 
 func validatePatchPaths(root string, patch string) error {
@@ -138,7 +169,10 @@ func patchPathsFromLine(line string) []string {
 
 func stripPatchPrefix(path string) string {
 	path = strings.TrimSpace(path)
-	path = strings.TrimPrefix(path, "a/")
-	path = strings.TrimPrefix(path, "b/")
+	// A unified-diff path carries exactly one of the a/ or b/ prefixes; strip a
+	// single one so a real directory literally named "a" or "b" is preserved.
+	if strings.HasPrefix(path, "a/") || strings.HasPrefix(path, "b/") {
+		path = path[2:]
+	}
 	return filepath.ToSlash(path)
 }

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 )
 
 func stringArg(args map[string]any, key string, fallback string, required bool) (string, error) {
@@ -28,17 +30,41 @@ func stringArgWithEmpty(args map[string]any, key string, fallback string, requir
 	return text, nil
 }
 
+// boolArg reads a boolean argument, tolerating the string/number forms models
+// commonly emit ("true"/"false", "yes"/"no", "on"/"off", 1/0) since not every
+// model sends a JSON boolean.
 func boolArg(args map[string]any, key string, fallback bool) (bool, error) {
 	value, ok := args[key]
 	if !ok || value == nil {
 		return fallback, nil
 	}
 
-	boolean, ok := value.(bool)
-	if !ok {
-		return false, fmt.Errorf("%s must be a boolean", key)
+	switch typed := value.(type) {
+	case bool:
+		return typed, nil
+	case string:
+		switch strings.ToLower(strings.TrimSpace(typed)) {
+		case "true", "yes", "on", "1":
+			return true, nil
+		case "false", "no", "off", "0":
+			return false, nil
+		}
+	case float64:
+		if typed == 1 {
+			return true, nil
+		}
+		if typed == 0 {
+			return false, nil
+		}
+	case int:
+		if typed == 1 {
+			return true, nil
+		}
+		if typed == 0 {
+			return false, nil
+		}
 	}
-	return boolean, nil
+	return false, fmt.Errorf("%s must be a boolean", key)
 }
 
 func intArg(args map[string]any, key string, fallback int, min int, max int) (int, error) {
@@ -60,6 +86,16 @@ func intArg(args map[string]any, key string, fallback int, min int, max int) (in
 			return 0, fmt.Errorf("%s must be an integer", key)
 		}
 		number = int(typed)
+	case string:
+		// Some models send numbers as strings ("5"); accept whole numbers.
+		trimmed := strings.TrimSpace(typed)
+		if parsed, perr := strconv.Atoi(trimmed); perr == nil {
+			number = parsed
+		} else if f, ferr := strconv.ParseFloat(trimmed, 64); ferr == nil && math.Trunc(f) == f {
+			number = int(f)
+		} else {
+			return 0, fmt.Errorf("%s must be an integer", key)
+		}
 	default:
 		return 0, fmt.Errorf("%s must be an integer", key)
 	}

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -67,6 +67,16 @@ func boolArg(args map[string]any, key string, fallback bool) (bool, error) {
 	return false, fmt.Errorf("%s must be a boolean", key)
 }
 
+// floatToInt converts a float to int only when it is finite, integral, and in
+// range; NaN/Inf/non-integer/out-of-range return ok=false so callers fail closed
+// before an implementation-defined cast.
+func floatToInt(f float64) (int, bool) {
+	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f || f > float64(math.MaxInt) || f < float64(math.MinInt) {
+		return 0, false
+	}
+	return int(f), true
+}
+
 func intArg(args map[string]any, key string, fallback int, min int, max int) (int, error) {
 	value, ok := args[key]
 	if !ok || value == nil {
@@ -82,17 +92,22 @@ func intArg(args map[string]any, key string, fallback int, min int, max int) (in
 	case int64:
 		number = int(typed)
 	case float64:
-		if math.Trunc(typed) != typed {
+		n, ok := floatToInt(typed)
+		if !ok {
 			return 0, fmt.Errorf("%s must be an integer", key)
 		}
-		number = int(typed)
+		number = n
 	case string:
 		// Some models send numbers as strings ("5"); accept whole numbers.
 		trimmed := strings.TrimSpace(typed)
 		if parsed, perr := strconv.Atoi(trimmed); perr == nil {
 			number = parsed
-		} else if f, ferr := strconv.ParseFloat(trimmed, 64); ferr == nil && math.Trunc(f) == f {
-			number = int(f)
+		} else if f, ferr := strconv.ParseFloat(trimmed, 64); ferr == nil {
+			n, ok := floatToInt(f)
+			if !ok {
+				return 0, fmt.Errorf("%s must be an integer", key)
+			}
+			number = n
 		} else {
 			return 0, fmt.Errorf("%s must be an integer", key)
 		}

--- a/internal/tools/args.go
+++ b/internal/tools/args.go
@@ -71,7 +71,11 @@ func boolArg(args map[string]any, key string, fallback bool) (bool, error) {
 // range; NaN/Inf/non-integer/out-of-range return ok=false so callers fail closed
 // before an implementation-defined cast.
 func floatToInt(f float64) (int, bool) {
-	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f || f > float64(math.MaxInt) || f < float64(math.MinInt) {
+	// Use >= against float64(math.MaxInt): that constant rounds UP to 2^63, so a
+	// strict > would let exactly 2^63 through to an out-of-range int(f) cast. The
+	// largest representable in-range float (2^63-1024) is still < it, so nothing
+	// valid is excluded. MinInt (-2^63) is exactly representable, so > is correct there.
+	if math.IsNaN(f) || math.IsInf(f, 0) || math.Trunc(f) != f || f >= float64(math.MaxInt) || f < float64(math.MinInt) {
 		return 0, false
 	}
 	return int(f), true

--- a/internal/tools/argtolerance.go
+++ b/internal/tools/argtolerance.go
@@ -1,0 +1,131 @@
+package tools
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// argtolerance.go is the shared, model-agnostic argument-tolerance layer for the
+// tools package. Different models (weak ones like minimax-m3 as well as strong
+// ones) emit the same conceptual argument under different key spellings. These
+// helpers let every tool accept the natural variants instead of hard-erroring,
+// while preserving the existing TYPE-strictness contract (a present-but-non-string
+// value still errors, scalars are never silently coerced to strings).
+
+// aliasedStringArg reads a string argument, trying each key in order (the primary
+// key first, then aliases) and returning the first present non-nil value. It
+// preserves the exact semantics of stringArg/stringArgWithEmpty:
+//
+//   - A present-but-non-string value errors "<primaryKey> must be a string"
+//     (type-strictness is preserved; scalars are NOT coerced to strings). The
+//     error always names the PRIMARY key so messages stay stable regardless of
+//     which alias the model happened to use.
+//   - Missing + required errors "<primaryKey> is required".
+//   - Missing + optional returns the fallback.
+//   - allowEmpty controls whether an empty string is accepted (when false, a
+//     present empty string errors "<primaryKey> must be a non-empty string").
+//
+// When allowEmpty=true, an empty-string value under one key does NOT mask a
+// populated value under a later alias: the scan skips empty values so a populated
+// alias wins (e.g. {"content":"","text":"hi"} -> "hi"). Only when EVERY present
+// key is empty does it return "" (empty preserved), and only when every key is
+// absent does it fall back / error required. Type errors (present-but-non-string)
+// still fire eagerly regardless of emptiness.
+//
+// keys must be non-empty; keys[0] is the canonical/primary key used in errors.
+func aliasedStringArg(args map[string]any, keys []string, fallback string, required bool, allowEmpty bool) (string, error) {
+	primary := ""
+	if len(keys) > 0 {
+		primary = keys[0]
+	}
+	sawPresentKey := false
+	for _, key := range keys {
+		value, ok := args[key]
+		if !ok || value == nil {
+			continue
+		}
+		text, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("%s must be a string", primary)
+		}
+		if text == "" {
+			if !allowEmpty {
+				return "", fmt.Errorf("%s must be a non-empty string", primary)
+			}
+			// allowEmpty: don't let an empty value under one key mask a populated
+			// alias under a later key. Remember it was present and keep scanning.
+			sawPresentKey = true
+			continue
+		}
+		return text, nil
+	}
+	// No populated value found. If a key was present-but-empty (allowEmpty path),
+	// preserve the empty string rather than falling back / erroring required.
+	if sawPresentKey {
+		return "", nil
+	}
+	if required {
+		return "", fmt.Errorf("%s is required", primary)
+	}
+	return fallback, nil
+}
+
+// coerceStringSlice turns whatever a model put in an array-shaped argument into a
+// string slice without ever failing. It accepts a []string, a []any of
+// strings/scalars/objects (label/value/text/name/title/option), or a single
+// newline-delimited string. Presentation-hint style arguments (e.g. ask_user
+// options) use this so a malformed shape never breaks the whole call.
+func coerceStringSlice(value any) []string {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s := scalarOrLabelString(item); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case string:
+		lines := strings.Split(strings.ReplaceAll(v, "\r\n", "\n"), "\n")
+		out := make([]string, 0, len(lines))
+		for _, line := range lines {
+			if t := strings.TrimSpace(line); t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
+	default:
+		if s := scalarOrLabelString(value); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+}
+
+// scalarOrLabelString best-effort renders a single list element to a string:
+// trimmed strings, scalars (bool/number), or an object's common label keys.
+// Returns "" when nothing usable is present.
+func scalarOrLabelString(item any) string {
+	switch v := item.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case bool:
+		return strconv.FormatBool(v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(v)
+	case map[string]any:
+		for _, key := range []string{"label", "value", "text", "name", "title", "option"} {
+			if s, ok := v[key].(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return ""
+}

--- a/internal/tools/argtolerance_test.go
+++ b/internal/tools/argtolerance_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -371,6 +372,20 @@ func TestIntArgCoercesStringNumbers(t *testing.T) {
 	}
 	if _, err := intArg(map[string]any{"n": "abc"}, "n", 0, 1, 0); err == nil {
 		t.Error("non-numeric string should error")
+	}
+	// Fail closed on non-finite / non-integral floats (and their string forms)
+	// before an implementation-defined cast.
+	if _, err := intArg(map[string]any{"n": math.NaN()}, "n", 0, 0, 0); err == nil {
+		t.Error("NaN float should error")
+	}
+	if _, err := intArg(map[string]any{"n": math.Inf(1)}, "n", 0, 0, 0); err == nil {
+		t.Error("+Inf float should error")
+	}
+	if _, err := intArg(map[string]any{"n": "NaN"}, "n", 0, 0, 0); err == nil {
+		t.Error("NaN string should error")
+	}
+	if _, err := intArg(map[string]any{"n": 5.5}, "n", 0, 0, 0); err == nil {
+		t.Error("non-integral float should error")
 	}
 }
 

--- a/internal/tools/argtolerance_test.go
+++ b/internal/tools/argtolerance_test.go
@@ -1,0 +1,390 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- shared helper unit tests -------------------------------------------------
+
+func TestAliasedStringArgPrefersPrimaryThenAliases(t *testing.T) {
+	// primary present wins over aliases.
+	got, err := aliasedStringArg(map[string]any{"path": "primary", "file": "alias"}, []string{"path", "file"}, "", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "primary" {
+		t.Fatalf("expected primary value, got %q", got)
+	}
+
+	// primary missing -> first present alias is used.
+	got, err = aliasedStringArg(map[string]any{"file": "alias"}, []string{"path", "file", "file_path"}, "", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "alias" {
+		t.Fatalf("expected alias value, got %q", got)
+	}
+
+	// alias order is respected: first matching alias in the list wins.
+	got, err = aliasedStringArg(map[string]any{"filename": "second", "file": "first"}, []string{"path", "file", "filename"}, "", true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "first" {
+		t.Fatalf("expected first alias by list order, got %q", got)
+	}
+}
+
+func TestAliasedStringArgMissingRequiredUsesPrimaryKeyInError(t *testing.T) {
+	_, err := aliasedStringArg(map[string]any{}, []string{"path", "file"}, "", true, false)
+	if err == nil || err.Error() != "path is required" {
+		t.Fatalf("expected \"path is required\", got %v", err)
+	}
+}
+
+func TestAliasedStringArgMissingOptionalUsesFallback(t *testing.T) {
+	got, err := aliasedStringArg(map[string]any{}, []string{"cwd", "dir"}, ".", false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "." {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+}
+
+func TestAliasedStringArgPresentNonStringErrorsWithPrimaryKey(t *testing.T) {
+	// Type-strictness is preserved: a present-but-non-string under ANY matched key
+	// errors using the PRIMARY key name, not the alias.
+	_, err := aliasedStringArg(map[string]any{"file": 42}, []string{"path", "file"}, "", true, false)
+	if err == nil || err.Error() != "path must be a string" {
+		t.Fatalf("expected \"path must be a string\", got %v", err)
+	}
+}
+
+func TestAliasedStringArgEmptySemantics(t *testing.T) {
+	// allowEmpty=false rejects an empty string.
+	_, err := aliasedStringArg(map[string]any{"path": ""}, []string{"path"}, "", true, false)
+	if err == nil || err.Error() != "path must be a non-empty string" {
+		t.Fatalf("expected non-empty error, got %v", err)
+	}
+	// allowEmpty=true accepts an empty string.
+	got, err := aliasedStringArg(map[string]any{"path": ""}, []string{"path"}, "fallback", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string preserved, got %q", got)
+	}
+}
+
+func TestAliasedStringArgAllowEmptySkipsEmptyPrimaryForPopulatedAlias(t *testing.T) {
+	// allowEmpty=true: an empty PRIMARY value must NOT mask a populated alias.
+	// {"content":"","text":"hi"} -> "hi" (write_file content/text data loss).
+	got, err := aliasedStringArg(map[string]any{"content": "", "text": "hi"}, []string{"content", "contents", "text", "body", "data", "file_content"}, "", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hi" {
+		t.Fatalf("expected populated alias to win over empty primary, got %q", got)
+	}
+
+	// {"path":"","file":"x"} -> "x" (list_directory/glob wrong dir).
+	got, err = aliasedStringArg(map[string]any{"path": "", "file": "x"}, []string{"path", "file", "file_path"}, ".", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "x" {
+		t.Fatalf("expected populated alias to win over empty primary, got %q", got)
+	}
+
+	// allowEmpty=true: when EVERY key is present-but-empty, return "" (preserving
+	// the existing empty-string-preserved contract, NOT the fallback).
+	got, err = aliasedStringArg(map[string]any{"path": "", "file": ""}, []string{"path", "file"}, "fallback", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty when all keys empty, got %q", got)
+	}
+
+	// allowEmpty=true, required=true: all keys present-but-empty still returns ""
+	// (must not regress TestAliasedStringArgEmptySemantics).
+	got, err = aliasedStringArg(map[string]any{"path": ""}, []string{"path"}, "fallback", true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty preserved for sole empty key, got %q", got)
+	}
+}
+
+func TestCoerceStringSliceShapes(t *testing.T) {
+	// []string passes through.
+	if got := coerceStringSlice([]string{"a", "b"}); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("[]string = %v", got)
+	}
+	// []any of strings/scalars/objects.
+	got := coerceStringSlice([]any{
+		"plain",
+		42.0,
+		map[string]any{"label": "Modern"},
+		map[string]any{"value": "Classic"},
+	})
+	if len(got) != 4 || got[0] != "plain" || got[1] != "42" || got[2] != "Modern" || got[3] != "Classic" {
+		t.Fatalf("[]any = %v", got)
+	}
+	// newline-delimited string.
+	if got := coerceStringSlice("A\r\nB\n\nC"); len(got) != 3 || got[0] != "A" || got[1] != "B" || got[2] != "C" {
+		t.Fatalf("string = %v", got)
+	}
+	// nil -> nil, never errors.
+	if got := coerceStringSlice(nil); got != nil {
+		t.Fatalf("nil = %v", got)
+	}
+}
+
+// --- per-tool alias acceptance tests -----------------------------------------
+
+func TestReadFileToolAcceptsPathAliases(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.txt"), "alpha\nbeta")
+	for _, key := range []string{"file", "file_path", "filepath", "filename"} {
+		res := NewReadFileTool(root).Run(context.Background(), map[string]any{key: "notes.txt"})
+		if res.Status != StatusOK {
+			t.Fatalf("alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if !strings.Contains(res.Output, "alpha") {
+			t.Fatalf("alias %q: expected file contents, got %q", key, res.Output)
+		}
+	}
+}
+
+func TestListDirectoryToolAcceptsDirAliases(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "sub", "x.txt"), "data")
+	for _, key := range []string{"directory", "dir"} {
+		res := NewListDirectoryTool(root).Run(context.Background(), map[string]any{key: "sub"})
+		if res.Status != StatusOK {
+			t.Fatalf("alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if !strings.Contains(res.Output, "x.txt") {
+			t.Fatalf("alias %q: expected listing, got %q", key, res.Output)
+		}
+	}
+}
+
+func TestGlobToolAcceptsPatternAndCwdAliases(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "sub", "a.go"), "package sub")
+	// pattern aliases
+	for _, key := range []string{"glob", "match", "query", "expression"} {
+		res := NewGlobTool(root).Run(context.Background(), map[string]any{key: "**/*.go"})
+		if res.Status != StatusOK {
+			t.Fatalf("pattern alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if !strings.Contains(res.Output, "sub/a.go") {
+			t.Fatalf("pattern alias %q: expected match, got %q", key, res.Output)
+		}
+	}
+	// cwd aliases (scope the scan to sub/)
+	for _, key := range []string{"dir", "directory", "path"} {
+		res := NewGlobTool(root).Run(context.Background(), map[string]any{"pattern": "*.go", key: "sub"})
+		if res.Status != StatusOK {
+			t.Fatalf("cwd alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if strings.TrimSpace(res.Output) != "a.go" {
+			t.Fatalf("cwd alias %q: expected a.go scoped match, got %q", key, res.Output)
+		}
+	}
+}
+
+func TestGrepToolAcceptsPatternAndPathAliases(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "sub", "main.go"), "func main() {}\n")
+	for _, key := range []string{"query", "regex", "search", "expression"} {
+		res := NewGrepTool(root).Run(context.Background(), map[string]any{key: "func main"})
+		if res.Status != StatusOK {
+			t.Fatalf("pattern alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if !strings.Contains(res.Output, "func main") {
+			t.Fatalf("pattern alias %q: expected hit, got %q", key, res.Output)
+		}
+	}
+	for _, key := range []string{"dir", "directory"} {
+		res := NewGrepTool(root).Run(context.Background(), map[string]any{"pattern": "func main", key: "sub"})
+		if res.Status != StatusOK {
+			t.Fatalf("path alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if !strings.Contains(res.Output, "main.go") {
+			t.Fatalf("path alias %q: expected hit, got %q", key, res.Output)
+		}
+	}
+}
+
+func TestOptionalPathArgsTreatEmptyAsDefault(t *testing.T) {
+	// Weak models sometimes send an explicit empty path/cwd. These optional
+	// path args should fall back to "." (workspace root) just as if the key
+	// were absent, rather than erroring with "must be a non-empty string".
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "main.go"), "func main() {}\n")
+
+	grepRes := NewGrepTool(root).Run(context.Background(), map[string]any{"pattern": "func main", "path": ""})
+	if grepRes.Status != StatusOK {
+		t.Fatalf("grep path:\"\" expected ok, got %s: %s", grepRes.Status, grepRes.Output)
+	}
+	if !strings.Contains(grepRes.Output, "main.go") {
+		t.Fatalf("grep path:\"\" expected hit, got %q", grepRes.Output)
+	}
+
+	globRes := NewGlobTool(root).Run(context.Background(), map[string]any{"pattern": "**/*.go", "cwd": ""})
+	if globRes.Status != StatusOK {
+		t.Fatalf("glob cwd:\"\" expected ok, got %s: %s", globRes.Status, globRes.Output)
+	}
+	if !strings.Contains(globRes.Output, "main.go") {
+		t.Fatalf("glob cwd:\"\" expected match, got %q", globRes.Output)
+	}
+
+	listRes := NewListDirectoryTool(root).Run(context.Background(), map[string]any{"path": ""})
+	if listRes.Status != StatusOK {
+		t.Fatalf("list_directory path:\"\" expected ok, got %s: %s", listRes.Status, listRes.Output)
+	}
+	if !strings.Contains(listRes.Output, "main.go") {
+		t.Fatalf("list_directory path:\"\" expected listing, got %q", listRes.Output)
+	}
+}
+
+func TestWriteFileToolAcceptsPathAliases(t *testing.T) {
+	root := t.TempDir()
+	for _, key := range []string{"file", "file_path", "filename"} {
+		res := NewWriteFileTool(root).Run(context.Background(), map[string]any{key: key + ".txt", "content": "x"})
+		if res.Status != StatusOK {
+			t.Fatalf("path alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if _, err := os.Stat(filepath.Join(root, key+".txt")); err != nil {
+			t.Fatalf("path alias %q: expected file written: %v", key, err)
+		}
+	}
+}
+
+func TestEditFileToolAcceptsAliases(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "code.go")
+	writeTestFile(t, path, "const a = 1\n")
+	// path/old/new aliases all at once.
+	res := NewEditFileTool(root).Run(context.Background(), map[string]any{
+		"file": "code.go",
+		"old":  "const a = 1",
+		"new":  "const a = 2",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("expected ok, got %s: %s", res.Status, res.Output)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "const a = 2\n" {
+		t.Fatalf("edit via aliases = %q", got)
+	}
+
+	// other alias spellings for old_string/new_string.
+	writeTestFile(t, path, "const a = 1\n")
+	res = NewEditFileTool(root).Run(context.Background(), map[string]any{
+		"file_path": "code.go",
+		"search":    "const a = 1",
+		"replace":   "const a = 3",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("expected ok, got %s: %s", res.Status, res.Output)
+	}
+	got, _ = os.ReadFile(path)
+	if string(got) != "const a = 3\n" {
+		t.Fatalf("edit via search/replace aliases = %q", got)
+	}
+}
+
+func TestApplyPatchToolAcceptsDiffAlias(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "hello.txt"), "hello\nold\n")
+	patch := strings.Join([]string{
+		"diff --git a/hello.txt b/hello.txt",
+		"--- a/hello.txt",
+		"+++ b/hello.txt",
+		"@@ -1,2 +1,2 @@",
+		" hello",
+		"-old",
+		"+new",
+		"",
+	}, "\n")
+	res := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"diff": patch})
+	if res.Status != StatusOK {
+		t.Skipf("git apply unavailable or failed: %s", res.Output)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "hello.txt"))
+	if strings.ReplaceAll(string(got), "\r\n", "\n") != "hello\nnew\n" {
+		t.Fatalf("diff alias patched content = %q", got)
+	}
+}
+
+func TestBashToolAcceptsCommandAliases(t *testing.T) {
+	root := t.TempDir()
+	for _, key := range []string{"cmd", "script", "shell"} {
+		res := NewBashTool(root).Run(context.Background(), map[string]any{key: "echo hi"})
+		if res.Status != StatusOK {
+			t.Fatalf("command alias %q: expected ok, got %s: %s", key, res.Status, res.Output)
+		}
+		if !strings.Contains(res.Output, "hi") {
+			t.Fatalf("command alias %q: expected echo output, got %q", key, res.Output)
+		}
+	}
+}
+
+func TestBoolArgCoercesModelVariants(t *testing.T) {
+	tru := []any{true, "true", "True", "yes", "on", "1", 1.0, 1}
+	for _, v := range tru {
+		if got, err := boolArg(map[string]any{"overwrite": v}, "overwrite", false); err != nil || !got {
+			t.Errorf("boolArg(%v=%T) = %v,%v; want true", v, v, got, err)
+		}
+	}
+	fal := []any{false, "false", "no", "off", "0", 0.0}
+	for _, v := range fal {
+		if got, err := boolArg(map[string]any{"overwrite": v}, "overwrite", true); err != nil || got {
+			t.Errorf("boolArg(%v=%T) = %v,%v; want false", v, v, got, err)
+		}
+	}
+	// genuinely uncoercible still errors
+	if _, err := boolArg(map[string]any{"overwrite": []any{1}}, "overwrite", false); err == nil {
+		t.Error("array should not coerce to bool")
+	}
+}
+
+func TestIntArgCoercesStringNumbers(t *testing.T) {
+	if got, err := intArg(map[string]any{"n": "5"}, "n", 0, 1, 0); err != nil || got != 5 {
+		t.Fatalf("intArg(\"5\") = %d,%v; want 5", got, err)
+	}
+	if got, err := intArg(map[string]any{"n": "7.0"}, "n", 0, 1, 0); err != nil || got != 7 {
+		t.Fatalf("intArg(\"7.0\") = %d,%v; want 7", got, err)
+	}
+	if _, err := intArg(map[string]any{"n": "abc"}, "n", 0, 1, 0); err == nil {
+		t.Error("non-numeric string should error")
+	}
+}
+
+func TestWriteFileAcceptsStringOverwrite(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "shop.html"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// minimax-style: overwrite as the string "true".
+	res := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path": "shop.html", "content": "new", "overwrite": "true",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("string overwrite should be accepted, got %s: %s", res.Status, res.Output)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "shop.html"))
+	if string(got) != "new" {
+		t.Fatalf("expected overwrite to replace content, got %q", got)
+	}
+}

--- a/internal/tools/argtolerance_test.go
+++ b/internal/tools/argtolerance_test.go
@@ -387,6 +387,14 @@ func TestIntArgCoercesStringNumbers(t *testing.T) {
 	if _, err := intArg(map[string]any{"n": 5.5}, "n", 0, 0, 0); err == nil {
 		t.Error("non-integral float should error")
 	}
+	// Exactly 2^63 is out of int64 range: float64(MaxInt) rounds up to it, so the
+	// guard must reject it (float and string forms) rather than cast.
+	if _, err := intArg(map[string]any{"n": 9223372036854775808.0}, "n", 0, 0, 0); err == nil {
+		t.Error("2^63 float should error (out of int64 range)")
+	}
+	if _, err := intArg(map[string]any{"n": "9223372036854775808"}, "n", 0, 0, 0); err == nil {
+		t.Error("2^63 string should error (out of int64 range)")
+	}
 }
 
 func TestWriteFileAcceptsStringOverwrite(t *testing.T) {

--- a/internal/tools/argtolerance_test.go
+++ b/internal/tools/argtolerance_test.go
@@ -319,7 +319,10 @@ func TestApplyPatchToolAcceptsDiffAlias(t *testing.T) {
 	}, "\n")
 	res := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"diff": patch})
 	if res.Status != StatusOK {
-		t.Skipf("git apply unavailable or failed: %s", res.Output)
+		if gitApplyUnavailable(res.Output) {
+			t.Skipf("git binary unavailable: %s", res.Output)
+		}
+		t.Fatalf("apply_patch via diff alias failed (possible regression): %s", res.Output)
 	}
 	got, _ := os.ReadFile(filepath.Join(root, "hello.txt"))
 	if strings.ReplaceAll(string(got), "\r\n", "\n") != "hello\nnew\n" {

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -124,10 +124,9 @@ func ParseAskUserQuestions(args map[string]any) ([]AskUserQuestion, error) {
 		if err != nil {
 			return nil, fmt.Errorf("question %d %s", index+1, err.Error())
 		}
-		multiSelect, err := boolArg(object, "multiSelect", false)
-		if err != nil {
-			return nil, fmt.Errorf("question %d %s", index+1, err.Error())
-		}
+		// multiSelect is a UI hint; treat an uncoercible value as the default rather
+		// than failing the whole call (mirrors the best-effort options path).
+		multiSelect, _ := boolArg(object, "multiSelect", false)
 		questions = append(questions, AskUserQuestion{
 			Question:    text,
 			Options:     coerceOptionStrings(object["options"]), // best-effort; never errors

--- a/internal/tools/ask_user.go
+++ b/internal/tools/ask_user.go
@@ -1,0 +1,182 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// AskUserQuestion is one clarifying question the agent wants the user to answer.
+// Options/MultiSelect are presentation hints for an interactive front-end; the
+// tool itself never blocks on input.
+type AskUserQuestion struct {
+	Question    string
+	Options     []string
+	MultiSelect bool
+}
+
+// askUserNonInteractiveMessage is returned both by the tool's own Run() fallback
+// and by the agent loop when no interactive user is wired up, so the model gets
+// identical, actionable guidance in either path.
+const askUserNonInteractiveMessage = "No interactive user is available to answer questions. " +
+	"Proceed with your best assumption, explicitly stating the assumptions you are making."
+
+type askUserTool struct {
+	baseTool
+}
+
+// NewAskUserTool builds the ask_user tool. It is read-only (it gathers input,
+// never mutates the workspace). The agent loop intercepts ask_user calls and
+// routes them to an interactive front-end when one exists; this tool's Run() is
+// the fallback used when nothing intercepts the call (e.g. headless runs).
+func NewAskUserTool() *askUserTool {
+	return &askUserTool{
+		baseTool: baseTool{
+			name: "ask_user",
+			description: "Ask the user one or more clarifying questions and wait for their answers. " +
+				"Use ONLY for genuinely blocking ambiguity that you cannot resolve from the workspace or reasonable assumptions. " +
+				"If no interactive user is available, this returns guidance to proceed with your best assumption instead of blocking.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"header": {
+						Type:        "string",
+						Description: "Optional short heading shown above the questions.",
+					},
+					"questions": {
+						Type:        "array",
+						Description: "One or more questions to ask the user.",
+						Items: &PropertySchema{
+							Type: "object",
+							Properties: map[string]PropertySchema{
+								"question": {Type: "string", Description: "The question to ask the user."},
+								"options": {
+									Type:        "array",
+									Description: "Optional list of suggested answer choices.",
+									Items:       &PropertySchema{Type: "string"},
+								},
+								"multiSelect": {
+									Type:        "boolean",
+									Description: "Whether multiple options may be selected (defaults to false).",
+								},
+							},
+							Required: []string{"question"},
+						},
+					},
+				},
+				Required:             []string{"questions"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Asks the user clarifying questions; gathers input only."),
+		},
+	}
+}
+
+// Run is the fallback path: it is only reached when nothing intercepted the call
+// (no interactive user). It validates the arguments so a malformed call still
+// gets useful feedback, then tells the model to proceed with its best assumption.
+// It never blocks on input.
+func (tool *askUserTool) Run(_ context.Context, args map[string]any) Result {
+	if _, err := ParseAskUserQuestions(args); err != nil {
+		return errorResult("Error: Invalid arguments for ask_user: " + err.Error())
+	}
+	return okResult(askUserNonInteractiveMessage)
+}
+
+// AskUserNonInteractiveMessage exposes the shared graceful-degradation message so
+// the agent loop and the tool fallback stay in lock-step.
+func AskUserNonInteractiveMessage() string {
+	return askUserNonInteractiveMessage
+}
+
+// ParseAskUserQuestions extracts the questionnaire from raw tool arguments. It is
+// shared by the tool's Run() fallback and the agent loop's interactive path so
+// both validate identically.
+func ParseAskUserQuestions(args map[string]any) ([]AskUserQuestion, error) {
+	raw, ok := args["questions"]
+	if !ok || raw == nil {
+		return nil, fmt.Errorf("questions is required")
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("questions must be an array")
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("questions must contain at least one question")
+	}
+
+	questions := make([]AskUserQuestion, 0, len(items))
+	for index, item := range items {
+		// Weak models sometimes send a question as a bare string instead of an
+		// object — accept that as a free-text question.
+		if text, ok := item.(string); ok {
+			if strings.TrimSpace(text) == "" {
+				return nil, fmt.Errorf("question %d must not be empty", index+1)
+			}
+			questions = append(questions, AskUserQuestion{Question: text})
+			continue
+		}
+		object, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("question %d must be an object or string", index+1)
+		}
+		text, err := questionTextArg(object)
+		if err != nil {
+			return nil, fmt.Errorf("question %d %s", index+1, err.Error())
+		}
+		multiSelect, err := boolArg(object, "multiSelect", false)
+		if err != nil {
+			return nil, fmt.Errorf("question %d %s", index+1, err.Error())
+		}
+		questions = append(questions, AskUserQuestion{
+			Question:    text,
+			Options:     coerceOptionStrings(object["options"]), // best-effort; never errors
+			MultiSelect: multiSelect,
+		})
+	}
+	return questions, nil
+}
+
+// questionTextArg reads the question text, accepting common key variants used by
+// weaker models. It enforces a non-empty trimmed string but, unlike
+// aliasedStringArg, treats a present-but-non-string or blank value as "not
+// present" and falls through to the next alias (question text is best-effort
+// across spellings, not type-strict).
+func questionTextArg(object map[string]any) (string, error) {
+	for _, key := range []string{"question", "prompt", "text", "q", "title"} {
+		if v, ok := object[key]; ok && v != nil {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				return s, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("question is required")
+}
+
+// coerceOptionStrings turns whatever a model put in "options" into a string slice
+// without ever failing — options are presentation hints, so a malformed shape must
+// not break the whole ask_user call. It delegates to the shared coerceStringSlice
+// so there is a single coercion path across the package.
+func coerceOptionStrings(value any) []string {
+	return coerceStringSlice(value)
+}
+
+// FormatAskUserAnswers renders question/answer pairs into a clear, model-readable
+// block. Missing answers are surfaced explicitly so the model never silently
+// treats an unanswered question as answered.
+func FormatAskUserAnswers(questions []AskUserQuestion, answers []string) string {
+	lines := make([]string, 0, len(questions)*3)
+	for index, question := range questions {
+		answer := ""
+		if index < len(answers) {
+			answer = strings.TrimSpace(answers[index])
+		}
+		if answer == "" {
+			answer = "(no answer provided)"
+		}
+		lines = append(lines, fmt.Sprintf("%d. [question] %s", index+1, question.Question))
+		lines = append(lines, "[answer] "+answer)
+		lines = append(lines, "")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}

--- a/internal/tools/ask_user_test.go
+++ b/internal/tools/ask_user_test.go
@@ -88,17 +88,9 @@ func TestAskUserToolRunRejectsMissingQuestions(t *testing.T) {
 	}
 }
 
-func TestAskUserToolIsRegisteredInReadOnlyCore(t *testing.T) {
-	found := false
-	for _, tool := range CoreReadOnlyTools(t.TempDir()) {
-		if tool.Name() == "ask_user" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatal("expected ask_user to be part of the core read-only tool set")
-	}
-}
+// NOTE: ask_user is intentionally NOT in CoreReadOnlyTools yet — it needs the
+// agent loop's interactive intercept (OnAskUser) to function. The agent module
+// registers it in core and wires the intercept together, with its own test.
 
 func TestParseAskUserQuestionsLenientOptions(t *testing.T) {
 	// minimax-style: options as array of objects with a label field.

--- a/internal/tools/ask_user_test.go
+++ b/internal/tools/ask_user_test.go
@@ -135,6 +135,18 @@ func TestParseAskUserQuestionsLenientOptions(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("missing options must be allowed: %v", err)
 	}
+
+	// multiSelect is a UI hint: an uncoercible value must NOT fail the call; it
+	// defaults to false (best-effort, like options).
+	qs, err = ParseAskUserQuestions(map[string]any{
+		"questions": []any{map[string]any{"question": "q", "multiSelect": "maybe"}},
+	})
+	if err != nil {
+		t.Fatalf("uncoercible multiSelect must not error: %v", err)
+	}
+	if qs[0].MultiSelect {
+		t.Fatalf("uncoercible multiSelect should default to false")
+	}
 }
 
 func TestParseAskUserQuestionsStringItem(t *testing.T) {

--- a/internal/tools/ask_user_test.go
+++ b/internal/tools/ask_user_test.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestAskUserToolSafetyIsReadOnly(t *testing.T) {
+	safety := NewAskUserTool().Safety()
+	if safety.Permission != PermissionAllow {
+		t.Fatalf("expected ask_user to be permission=allow, got %q", safety.Permission)
+	}
+	if safety.SideEffect != SideEffectRead {
+		t.Fatalf("expected ask_user side effect read, got %q", safety.SideEffect)
+	}
+}
+
+func TestAskUserToolAdvertisesQuestionSchema(t *testing.T) {
+	schema := NewAskUserTool().Parameters()
+	questions, ok := schema.Properties["questions"]
+	if !ok {
+		t.Fatal("expected ask_user to advertise a questions property")
+	}
+	if questions.Type != "array" || questions.Items == nil {
+		t.Fatalf("expected questions to be an array with item schema, got %#v", questions)
+	}
+	if questions.Items.Type != "object" {
+		t.Fatalf("expected question items to be objects, got %q", questions.Items.Type)
+	}
+	if _, ok := questions.Items.Properties["question"]; !ok {
+		t.Fatal("expected question item to document a question field")
+	}
+	if _, ok := questions.Items.Properties["options"]; !ok {
+		t.Fatal("expected question item to document an options field")
+	}
+	if _, ok := questions.Items.Properties["multiSelect"]; !ok {
+		t.Fatal("expected question item to document a multiSelect field")
+	}
+	requiredQuestion := false
+	for _, name := range questions.Items.Required {
+		if name == "question" {
+			requiredQuestion = true
+		}
+	}
+	if !requiredQuestion {
+		t.Fatalf("expected question field to be required, got %v", questions.Items.Required)
+	}
+	requiredQuestions := false
+	for _, name := range schema.Required {
+		if name == "questions" {
+			requiredQuestions = true
+		}
+	}
+	if !requiredQuestions {
+		t.Fatalf("expected questions to be required, got %v", schema.Required)
+	}
+}
+
+func TestAskUserToolRunFallsBackWhenNonInteractive(t *testing.T) {
+	// The tool's own Run() is only reached when nothing intercepted the call,
+	// i.e. there is no interactive user. It must degrade gracefully, never block.
+	result := NewAskUserTool().Run(context.Background(), map[string]any{
+		"questions": []any{
+			map[string]any{"question": "Which framework?"},
+		},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status from graceful fallback, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "no interactive user") {
+		t.Fatalf("expected no-interactive-user message, got %q", result.Output)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "assumption") {
+		t.Fatalf("expected guidance to proceed with assumptions, got %q", result.Output)
+	}
+}
+
+func TestAskUserToolRunRejectsMissingQuestions(t *testing.T) {
+	result := NewAskUserTool().Run(context.Background(), map[string]any{
+		"questions": []any{},
+	})
+	if result.Status != StatusError {
+		t.Fatalf("expected error status when no questions provided, got %s", result.Status)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "at least one question") {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}
+
+func TestAskUserToolIsRegisteredInReadOnlyCore(t *testing.T) {
+	found := false
+	for _, tool := range CoreReadOnlyTools(t.TempDir()) {
+		if tool.Name() == "ask_user" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected ask_user to be part of the core read-only tool set")
+	}
+}
+
+func TestParseAskUserQuestionsLenientOptions(t *testing.T) {
+	// minimax-style: options as array of objects with a label field.
+	qs, err := ParseAskUserQuestions(map[string]any{
+		"questions": []any{
+			map[string]any{"question": "Pick a style", "options": []any{
+				map[string]any{"label": "Modern"},
+				map[string]any{"value": "Classic"},
+				"Minimal",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("objects/strings options must not error: %v", err)
+	}
+	if got := qs[0].Options; len(got) != 3 || got[0] != "Modern" || got[1] != "Classic" || got[2] != "Minimal" {
+		t.Fatalf("coerced options = %v, want [Modern Classic Minimal]", got)
+	}
+
+	// options as a single newline-delimited string.
+	qs, err = ParseAskUserQuestions(map[string]any{
+		"questions": []any{map[string]any{"question": "q", "options": "A\nB"}},
+	})
+	if err != nil {
+		t.Fatalf("string options must not error: %v", err)
+	}
+	if got := qs[0].Options; len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("string-split options = %v, want [A B]", got)
+	}
+
+	// no options at all = valid free-text question.
+	if _, err := ParseAskUserQuestions(map[string]any{
+		"questions": []any{map[string]any{"question": "free text?"}},
+	}); err != nil {
+		t.Fatalf("missing options must be allowed: %v", err)
+	}
+}
+
+func TestParseAskUserQuestionsStringItem(t *testing.T) {
+	// minimax-style: a question item that is a bare string, not an object.
+	qs, err := ParseAskUserQuestions(map[string]any{"questions": []any{"What is your name?"}})
+	if err != nil {
+		t.Fatalf("string question item must not error: %v", err)
+	}
+	if len(qs) != 1 || qs[0].Question != "What is your name?" {
+		t.Fatalf("bare-string question = %+v", qs)
+	}
+}

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -52,7 +52,7 @@ func (tool bashTool) RunWithSandbox(ctx context.Context, args map[string]any, en
 }
 
 func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroSandbox.Engine) Result {
-	commandText, err := stringArg(args, "command", "", true)
+	commandText, err := aliasedStringArg(args, []string{"command", "cmd", "script", "shell"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for bash: " + err.Error())
 	}
@@ -63,6 +63,13 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 	timeoutMS, err := intArg(args, "timeout_ms", defaultBashTimeoutMS, 1, maxBashTimeoutMS)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for bash: " + err.Error())
+	}
+
+	// Pre-execution safety: refuse interactive commands (editors, pagers, REPLs,
+	// remote shells, etc.) that would hang the non-interactive agent until the
+	// timeout fires. This runs before the command is built or launched.
+	if interactive := zeroSandbox.DetectInteractiveCommand(commandText, runtime.GOOS); interactive.Interactive {
+		return interactiveBlockResult(interactive)
 	}
 
 	absoluteCwd, relativeCwd, err := resolveWorkspacePath(tool.workspaceRoot, cwd)
@@ -161,6 +168,30 @@ func addSandboxMeta(meta map[string]string, plan zeroSandbox.CommandPlan) {
 	}
 	if plan.SandboxDir != "" {
 		meta["sandbox_cwd"] = plan.SandboxDir
+	}
+}
+
+// interactiveBlockResult builds the structured tool Result returned when a
+// command is refused before execution because it would hang the agent. The
+// violation is surfaced both in Output (clearly delimited) and in Meta/Display
+// so downstream consumers and the TUI can render it consistently.
+func interactiveBlockResult(detection zeroSandbox.InteractiveCommandResult) Result {
+	message := fmt.Sprintf(
+		"Error: Blocked interactive command %q before execution: %s. This would hang the non-interactive agent.\nSuggestion: %s",
+		detection.Command, detection.Reason, detection.Suggestion,
+	)
+	return Result{
+		Status: StatusError,
+		Output: message,
+		Meta: map[string]string{
+			"exit_code":    "-1",
+			"safety_block": "interactive_command",
+			"safety_cmd":   detection.Command,
+		},
+		Display: Display{
+			Summary: "Blocked interactive command: " + detection.Command,
+			Kind:    "shell",
+		},
 	}
 }
 

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -299,6 +299,71 @@ func TestBashToolRunsWithHostSandboxBackendWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestBashToolBlocksInteractiveCommandBeforeExecution(t *testing.T) {
+	root := t.TempDir()
+
+	result := NewBashTool(root).Run(context.Background(), map[string]any{
+		"command": "vim main.go",
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status for interactive command, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "interactive") {
+		t.Fatalf("expected interactive guard message, got %q", result.Output)
+	}
+	if !strings.Contains(result.Output, "edit_file") && !strings.Contains(result.Output, "sed") {
+		t.Fatalf("expected actionable suggestion, got %q", result.Output)
+	}
+	// The command must NOT have run: exit_code metadata should mark a pre-exec block.
+	if result.Meta["exit_code"] != "-1" {
+		t.Fatalf("expected exit_code -1 (not executed), got %q", result.Meta["exit_code"])
+	}
+	if result.Meta["safety_block"] != "interactive_command" {
+		t.Fatalf("expected safety_block metadata, got %#v", result.Meta)
+	}
+	if result.Display.Kind != "shell" || !strings.Contains(result.Display.Summary, "Blocked") {
+		t.Fatalf("expected blocked display annotation, got %#v", result.Display)
+	}
+}
+
+func TestBashToolBlocksInteractiveCommandThroughSandbox(t *testing.T) {
+	root := t.TempDir()
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        sandbox.DefaultPolicy(),
+		Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+	})
+
+	result := NewBashTool(root).(interface {
+		RunWithSandbox(context.Context, map[string]any, *sandbox.Engine) Result
+	}).RunWithSandbox(context.Background(), map[string]any{
+		"command": "less /etc/hosts",
+	}, engine)
+
+	if result.Status != StatusError {
+		t.Fatalf("expected error status, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "interactive") || !strings.Contains(result.Output, "cat") {
+		t.Fatalf("expected pager guard message with cat suggestion, got %q", result.Output)
+	}
+}
+
+func TestBashToolAllowsNonInteractiveCommand(t *testing.T) {
+	root := t.TempDir()
+
+	result := NewBashTool(root).Run(context.Background(), map[string]any{
+		"command": helperCommand("success"),
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status for non-interactive command, got %s: %s", result.Status, result.Output)
+	}
+	if result.Meta["safety_block"] != "" {
+		t.Fatalf("did not expect a safety block, got %#v", result.Meta)
+	}
+}
+
 func helperCommand(name string) string {
 	executable := shellQuote(os.Args[0])
 	return executable + " --zero-bash-helper " + name

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -35,15 +35,15 @@ func NewEditFileTool(workspaceRoot string) Tool {
 }
 
 func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
-	requestedPath, err := stringArg(args, "path", "", true)
+	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
 	}
-	oldString, err := stringArg(args, "old_string", "", true)
+	oldString, err := aliasedStringArg(args, []string{"old_string", "old", "search", "find", "old_str"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
 	}
-	newString, err := stringArgWithEmpty(args, "new_string", "", true, true)
+	newString, err := aliasedStringArg(args, []string{"new_string", "new", "replace", "replacement", "new_str"}, "", true, true)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
 	}
@@ -90,5 +90,9 @@ func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
 	if replacedCount != 1 {
 		suffix = "s"
 	}
-	return okResult(fmt.Sprintf("Successfully edited %s (replaced %d occurrence%s).", relativePath, replacedCount, suffix))
+	summary := fmt.Sprintf("Successfully edited %s (replaced %d occurrence%s).", relativePath, replacedCount, suffix)
+	result := okResult(summary)
+	result.ChangedFiles = []string{relativePath}
+	result.Display = Display{Summary: fmt.Sprintf("Edited %s", relativePath), Kind: "diff"}
+	return result
 }

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -172,6 +172,73 @@ func TestGrepToolSupportsFilesAndCountModes(t *testing.T) {
 	}
 }
 
+// Finding 1: grep must not follow an in-workspace symlink that points to a file
+// OUTSIDE the workspace (confinement bypass). The symlinked secret must not be
+// searched or returned, mirroring read_file's EvalSymlinks confinement.
+func TestGrepDoesNotFollowSymlinkOutsideWorkspace(t *testing.T) {
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	secret := filepath.Join(outsideDir, "secret.txt")
+	writeTestFile(t, secret, "needle leaked from outside\n")
+	writeTestFile(t, filepath.Join(root, "keep.txt"), "needle inside\n")
+
+	link := filepath.Join(root, "escape.txt")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	res := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":     "needle",
+		"output_mode": "content",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "leaked from outside") || strings.Contains(res.Output, "escape.txt") {
+		t.Fatalf("grep followed symlink outside workspace, leaked:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "keep.txt") {
+		t.Fatalf("expected in-workspace match, got:\n%s", res.Output)
+	}
+}
+
+// Finding 2: when the workspace root itself lives under a symlink (e.g. macOS
+// /tmp -> /private/tmp), match paths must be clean workspace-relative paths with
+// NO leading "../" — because the walked paths are EvalSymlinks-resolved while the
+// root was previously only Abs-normalized.
+func TestGrepReturnsCleanRelativePathsUnderSymlinkedRoot(t *testing.T) {
+	realDir := t.TempDir()
+	writeTestFile(t, filepath.Join(realDir, "pkg", "main.go"), "func main() {}\n")
+
+	linkRoot := filepath.Join(t.TempDir(), "ws")
+	if err := os.Symlink(realDir, linkRoot); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	res := NewGrepTool(linkRoot).Run(context.Background(), map[string]any{
+		"pattern":     "func main",
+		"output_mode": "content",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "../") || strings.HasPrefix(strings.TrimSpace(res.Output), "/") {
+		t.Fatalf("expected clean workspace-relative path, got:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "pkg/main.go:1: func main") {
+		t.Fatalf("expected pkg/main.go match, got:\n%s", res.Output)
+	}
+
+	// files_with_matches mode must likewise be clean-relative.
+	res = NewGrepTool(linkRoot).Run(context.Background(), map[string]any{
+		"pattern":     "func main",
+		"output_mode": "files_with_matches",
+	})
+	if strings.TrimSpace(res.Output) != "pkg/main.go" {
+		t.Fatalf("expected pkg/main.go, got %q", res.Output)
+	}
+}
+
 func writeTestFile(t *testing.T, path string, content string) {
 	t.Helper()
 
@@ -180,5 +247,35 @@ func writeTestFile(t *testing.T, path string, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGrepSkipsAlwaysExcludedDirectories(t *testing.T) {
+	root := t.TempDir()
+	mustWrite := func(rel, body string) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("keep.txt", "needle here")
+	mustWrite(".git/config", "needle here")
+	mustWrite("node_modules/pkg/index.js", "needle here")
+
+	res := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":     "needle",
+		"output_mode": "files_with_matches",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, ".git") || strings.Contains(res.Output, "node_modules") {
+		t.Fatalf("grep must not descend into excluded dirs, got:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "keep.txt") {
+		t.Fatalf("expected keep.txt in results, got:\n%s", res.Output)
 	}
 }

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -38,13 +38,18 @@ func NewGlobTool(workspaceRoot string) Tool {
 }
 
 func (tool globTool) Run(_ context.Context, args map[string]any) Result {
-	pattern, err := stringArg(args, "pattern", "", true)
+	pattern, err := aliasedStringArg(args, []string{"pattern", "glob", "match", "query", "expression"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for glob: " + err.Error())
 	}
-	cwd, err := stringArg(args, "cwd", ".", false)
+	// Optional with a "." default: treat an explicit empty cwd (a common
+	// weak-model quirk) the same as the key being absent rather than erroring.
+	cwd, err := aliasedStringArg(args, []string{"cwd", "dir", "directory", "path"}, ".", false, true)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for glob: " + err.Error())
+	}
+	if cwd == "" {
+		cwd = "."
 	}
 	limit, err := intArg(args, "limit", 100, 1, 1000)
 	if err != nil {

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -48,13 +48,18 @@ func NewGrepTool(workspaceRoot string) Tool {
 }
 
 func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
-	pattern, err := stringArg(args, "pattern", "", true)
+	pattern, err := aliasedStringArg(args, []string{"pattern", "query", "regex", "search", "expression"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for grep: " + err.Error())
 	}
-	targetPath, err := stringArg(args, "path", ".", false)
+	// Optional with a "." default: treat an explicit empty path (a common
+	// weak-model quirk) the same as the key being absent rather than erroring.
+	targetPath, err := aliasedStringArg(args, []string{"path", "dir", "directory"}, ".", false, true)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for grep: " + err.Error())
+	}
+	if targetPath == "" {
+		targetPath = "."
 	}
 	globPattern, err := stringArg(args, "glob", "", false)
 	if err != nil {
@@ -93,6 +98,16 @@ func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
 		return errorResult("Error running grep: " + err.Error())
 	}
 
+	// Resolve the workspace root through symlinks ONCE so (a) confinement checks
+	// and (b) Rel computations both use the canonical root. tool.workspaceRoot is
+	// only Abs-normalized (no EvalSymlinks); using it directly would produce
+	// "../"-laden relative paths when the root itself lives under a symlink (e.g.
+	// macOS /tmp -> /private/tmp) and would not catch files that resolve outside.
+	resolvedRoot, err := filepath.EvalSymlinks(tool.workspaceRoot)
+	if err != nil {
+		return errorResult("Error running grep: " + err.Error())
+	}
+
 	var globMatcher *regexp.Regexp
 	if globPattern != "" {
 		globMatcher, err = compileGlob(globPattern)
@@ -101,12 +116,12 @@ func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
 		}
 	}
 
-	files, err := grepFiles(tool.workspaceRoot, target, globMatcher)
+	files, err := grepFiles(resolvedRoot, target, globMatcher)
 	if err != nil {
 		return errorResult("Error running grep: " + err.Error())
 	}
 
-	matches := collectGrepMatches(tool.workspaceRoot, files, compiled)
+	matches := collectGrepMatches(resolvedRoot, files, compiled)
 	if len(matches) == 0 {
 		if outputMode == "count" {
 			return okResult("0 matches found")
@@ -148,18 +163,40 @@ func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
 	}
 }
 
-func grepFiles(workspaceRoot string, target string, globMatcher *regexp.Regexp) ([]string, error) {
+// confineGrepFile resolves a candidate file through symlinks and returns its
+// clean, slash-separated path RELATIVE to the (already symlink-resolved) root.
+// It returns ok=false when the resolved file escapes the workspace root, so a
+// symlink inside the workspace that points outside is never searched/returned —
+// mirroring resolveWorkspaceTargetPath / read_file confinement. resolvedRoot must
+// already be EvalSymlinks-resolved so the Rel result is "../"-free for in-root
+// files even when the root lives under a symlink.
+func confineGrepFile(resolvedRoot string, path string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", false
+	}
+	relative, err := filepath.Rel(resolvedRoot, resolved)
+	if err != nil {
+		return "", false
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", false
+	}
+	return filepath.ToSlash(relative), true
+}
+
+func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) ([]string, error) {
 	info, err := os.Stat(target)
 	if err != nil {
 		return nil, err
 	}
 
 	if !info.IsDir() {
-		relative, err := filepath.Rel(workspaceRoot, target)
-		if err != nil {
-			return nil, err
+		relative, ok := confineGrepFile(resolvedRoot, target)
+		if !ok {
+			return []string{}, nil
 		}
-		if globMatcher == nil || globMatcher.MatchString(filepath.ToSlash(relative)) {
+		if globMatcher == nil || globMatcher.MatchString(relative) {
 			return []string{target}, nil
 		}
 		return []string{}, nil
@@ -179,11 +216,13 @@ func grepFiles(workspaceRoot string, target string, globMatcher *regexp.Regexp) 
 		if entry.IsDir() {
 			return nil
 		}
-		relative, err := filepath.Rel(workspaceRoot, path)
-		if err != nil {
-			return err
+		// Confine each candidate through symlinks: a symlink inside the workspace
+		// pointing to a file OUTSIDE the root must be skipped, not searched.
+		relative, ok := confineGrepFile(resolvedRoot, path)
+		if !ok {
+			return nil
 		}
-		if globMatcher == nil || globMatcher.MatchString(filepath.ToSlash(relative)) {
+		if globMatcher == nil || globMatcher.MatchString(relative) {
 			files = append(files, path)
 		}
 		return nil
@@ -195,14 +234,16 @@ func grepFiles(workspaceRoot string, target string, globMatcher *regexp.Regexp) 
 	return files, nil
 }
 
-func collectGrepMatches(workspaceRoot string, files []string, compiled *regexp.Regexp) []grepMatch {
+func collectGrepMatches(resolvedRoot string, files []string, compiled *regexp.Regexp) []grepMatch {
 	matches := []grepMatch{}
 	for _, file := range files {
-		content, err := os.ReadFile(file)
-		if err != nil {
+		// Re-confine at read time (defense-in-depth) AND to compute the clean
+		// workspace-relative path used in output.
+		relative, ok := confineGrepFile(resolvedRoot, file)
+		if !ok {
 			continue
 		}
-		relative, err := filepath.Rel(workspaceRoot, file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			continue
 		}
@@ -212,7 +253,7 @@ func collectGrepMatches(workspaceRoot string, files []string, compiled *regexp.R
 				continue
 			}
 			matches = append(matches, grepMatch{
-				file: filepath.ToSlash(relative),
+				file: relative,
 				line: index + 1,
 				text: strings.TrimRight(line, "\r"),
 				hits: len(lineMatches),

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -170,19 +170,22 @@ func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
 // mirroring resolveWorkspaceTargetPath / read_file confinement. resolvedRoot must
 // already be EvalSymlinks-resolved so the Rel result is "../"-free for in-root
 // files even when the root lives under a symlink.
-func confineGrepFile(resolvedRoot string, path string) (string, bool) {
+func confineGrepFile(resolvedRoot string, path string) (string, string, bool) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	relative, err := filepath.Rel(resolvedRoot, resolved)
 	if err != nil {
-		return "", false
+		return "", "", false
 	}
 	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
-		return "", false
+		return "", "", false
 	}
-	return filepath.ToSlash(relative), true
+	// Return the symlink-resolved absolute path too: callers must read THAT (not
+	// the unresolved input) so a symlink swap between this check and the read
+	// cannot escape the workspace boundary.
+	return filepath.ToSlash(relative), resolved, true
 }
 
 func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) ([]string, error) {
@@ -192,7 +195,7 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 	}
 
 	if !info.IsDir() {
-		relative, ok := confineGrepFile(resolvedRoot, target)
+		relative, _, ok := confineGrepFile(resolvedRoot, target)
 		if !ok {
 			return []string{}, nil
 		}
@@ -218,7 +221,7 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 		}
 		// Confine each candidate through symlinks: a symlink inside the workspace
 		// pointing to a file OUTSIDE the root must be skipped, not searched.
-		relative, ok := confineGrepFile(resolvedRoot, path)
+		relative, _, ok := confineGrepFile(resolvedRoot, path)
 		if !ok {
 			return nil
 		}
@@ -239,11 +242,13 @@ func collectGrepMatches(resolvedRoot string, files []string, compiled *regexp.Re
 	for _, file := range files {
 		// Re-confine at read time (defense-in-depth) AND to compute the clean
 		// workspace-relative path used in output.
-		relative, ok := confineGrepFile(resolvedRoot, file)
+		relative, resolvedPath, ok := confineGrepFile(resolvedRoot, file)
 		if !ok {
 			continue
 		}
-		content, err := os.ReadFile(file)
+		// Read the symlink-RESOLVED path that confineGrepFile validated, not the
+		// raw candidate, so a symlink swapped in after the check can't escape.
+		content, err := os.ReadFile(resolvedPath)
 		if err != nil {
 			continue
 		}

--- a/internal/tools/list_directory.go
+++ b/internal/tools/list_directory.go
@@ -35,9 +35,14 @@ func NewListDirectoryTool(workspaceRoot string) Tool {
 }
 
 func (tool listDirectoryTool) Run(_ context.Context, args map[string]any) Result {
-	requestedPath, err := stringArg(args, "path", ".", false)
+	// Optional with a "." default: treat an explicit empty path (a common
+	// weak-model quirk) the same as the key being absent rather than erroring.
+	requestedPath, err := aliasedStringArg(args, []string{"path", "directory", "dir"}, ".", false, true)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for list_directory: " + err.Error())
+	}
+	if requestedPath == "" {
+		requestedPath = "."
 	}
 	recursive, err := boolArg(args, "recursive", false)
 	if err != nil {

--- a/internal/tools/mutation_targets.go
+++ b/internal/tools/mutation_targets.go
@@ -1,0 +1,47 @@
+package tools
+
+// MutationTargets returns the workspace-relative paths a tool call will write to,
+// so the session layer can snapshot their before-state for safe rewind. It is a
+// pure helper (no I/O beyond path resolution) and returns nil for read-only tools
+// and for bash (whose affected paths are not knowable before execution).
+func MutationTargets(workspaceRoot string, name string, args map[string]any) []string {
+	switch name {
+	case "write_file", "edit_file":
+		// Resolve the path via the SAME alias key list write_file/edit_file use,
+		// so a checkpoint is captured even when the model writes via an alias key
+		// (e.g. {"file": ...}); otherwise /rewind could not undo the write.
+		path, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filename"}, "", true, false)
+		if err != nil {
+			return nil
+		}
+		_, relative, err := resolveWorkspaceTargetPath(workspaceRoot, path)
+		if err != nil {
+			return nil
+		}
+		return []string{relative}
+	case "apply_patch":
+		// Resolve the patch via the SAME alias key list apply_patch uses.
+		patch, err := aliasedStringArg(args, []string{"patch", "diff"}, "", true, false)
+		if err != nil {
+			return nil
+		}
+		// Mirror apply_patch's cwd handling so the returned targets are
+		// WORKSPACE-relative (cwd-prefixed) when cwd != ".". Without this, a
+		// patch applied under a subdir would snapshot the wrong rewind path.
+		cwd, err := stringArg(args, "cwd", ".", false)
+		if err != nil {
+			return nil
+		}
+		_, relativeRoot, err := resolveWorkspacePath(workspaceRoot, cwd)
+		if err != nil {
+			return nil
+		}
+		paths := changedFilesFromPatch(relativeRoot, patch)
+		if len(paths) == 0 {
+			return nil
+		}
+		return paths
+	default:
+		return nil
+	}
+}

--- a/internal/tools/mutation_targets.go
+++ b/internal/tools/mutation_targets.go
@@ -32,8 +32,14 @@ func MutationTargets(workspaceRoot string, name string, args map[string]any) []s
 		if err != nil {
 			return nil
 		}
-		_, relativeRoot, err := resolveWorkspacePath(workspaceRoot, cwd)
+		applyRoot, relativeRoot, err := resolveWorkspacePath(workspaceRoot, cwd)
 		if err != nil {
+			return nil
+		}
+		// Enforce the same workspace confinement apply_patch applies (against the
+		// resolved apply dir), so a patch with a traversal path (../x) never yields
+		// an out-of-workspace target.
+		if err := validatePatchPaths(applyRoot, patch); err != nil {
 			return nil
 		}
 		paths := changedFilesFromPatch(relativeRoot, patch)

--- a/internal/tools/mutation_targets_test.go
+++ b/internal/tools/mutation_targets_test.go
@@ -56,6 +56,12 @@ func TestMutationTargetsRejectsEscapingPaths(t *testing.T) {
 	if got := MutationTargets(root, "write_file", map[string]any{"path": "../escape.txt", "content": "x"}); len(got) != 0 {
 		t.Errorf("expected no targets for escaping path, got %v", got)
 	}
+	// apply_patch must also reject a patch whose paths escape the workspace, so it
+	// never returns an out-of-workspace checkpoint target.
+	escapePatch := "--- a/../escape.txt\n+++ b/../escape.txt\n@@ -1 +1 @@\n-one\n+two\n"
+	if got := MutationTargets(root, "apply_patch", map[string]any{"patch": escapePatch}); len(got) != 0 {
+		t.Errorf("expected no targets for escaping apply_patch, got %v", got)
+	}
 }
 
 // Finding 3: with cwd != ".", apply_patch's MutationTargets must return

--- a/internal/tools/mutation_targets_test.go
+++ b/internal/tools/mutation_targets_test.go
@@ -1,0 +1,101 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMutationTargets(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		tool string
+		args map[string]any
+		want []string
+	}{
+		{"write_file", map[string]any{"path": "a/b.txt", "content": "x"}, []string{"a/b.txt"}},
+		{"edit_file", map[string]any{"path": "c.txt", "old_string": "x", "new_string": "y"}, []string{"c.txt"}},
+		{"apply_patch", map[string]any{"patch": "--- a/d.txt\n+++ b/d.txt\n@@ -1 +1 @@\n-x\n+y\n"}, []string{"d.txt"}},
+		{"bash", map[string]any{"command": "echo hi"}, nil},
+		{"read_file", map[string]any{"path": "e.txt"}, nil},
+		{"grep", map[string]any{"pattern": "x"}, nil},
+	}
+	for _, tc := range cases {
+		got := MutationTargets(root, tc.tool, tc.args)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.tool, got, tc.want)
+		}
+	}
+}
+
+func TestMutationTargetsResolvesAliasKeys(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		name string
+		tool string
+		args map[string]any
+		want []string
+	}{
+		{"write_file file alias", "write_file", map[string]any{"file": "x.go", "content": "x"}, []string{"x.go"}},
+		{"write_file file_path alias", "write_file", map[string]any{"file_path": "y.go", "content": "x"}, []string{"y.go"}},
+		{"write_file filename alias", "write_file", map[string]any{"filename": "z.go", "content": "x"}, []string{"z.go"}},
+		{"edit_file file alias", "edit_file", map[string]any{"file": "e.go", "old_string": "a", "new_string": "b"}, []string{"e.go"}},
+		{"apply_patch diff alias", "apply_patch", map[string]any{"diff": "--- a/d.txt\n+++ b/d.txt\n@@ -1 +1 @@\n-x\n+y\n"}, []string{"d.txt"}},
+	}
+	for _, tc := range cases {
+		got := MutationTargets(root, tc.tool, tc.args)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMutationTargetsRejectsEscapingPaths(t *testing.T) {
+	root := t.TempDir()
+	if got := MutationTargets(root, "write_file", map[string]any{"path": "../escape.txt", "content": "x"}); len(got) != 0 {
+		t.Errorf("expected no targets for escaping path, got %v", got)
+	}
+}
+
+// Finding 3: with cwd != ".", apply_patch's MutationTargets must return
+// WORKSPACE-relative paths (cwd-prefixed), not paths relative to the patch cwd —
+// otherwise /rewind snapshots the wrong (workspace-root-relative) path.
+func TestMutationTargetsApplyPatchPrefixesCwd(t *testing.T) {
+	root := t.TempDir()
+	// cwd must exist for the patch to be applicable; MutationTargets resolves it
+	// the same way apply_patch does (resolveWorkspacePath -> EvalSymlinks).
+	if err := os.MkdirAll(filepath.Join(root, "sub", "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	patch := "--- a/d.txt\n+++ b/d.txt\n@@ -1 +1 @@\n-x\n+y\n"
+
+	got := MutationTargets(root, "apply_patch", map[string]any{"patch": patch, "cwd": "sub/dir"})
+	want := []string{"sub/dir/d.txt"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+
+	// cwd "." (the default) must keep paths unprefixed.
+	got = MutationTargets(root, "apply_patch", map[string]any{"patch": patch, "cwd": "."})
+	if !reflect.DeepEqual(got, []string{"d.txt"}) {
+		t.Fatalf("cwd=.: got %v, want [d.txt]", got)
+	}
+
+	// Absent cwd behaves like ".".
+	got = MutationTargets(root, "apply_patch", map[string]any{"patch": patch})
+	if !reflect.DeepEqual(got, []string{"d.txt"}) {
+		t.Fatalf("no cwd: got %v, want [d.txt]", got)
+	}
+}
+
+func TestStripPatchPrefixStripsOnlyOne(t *testing.T) {
+	root := t.TempDir()
+	// A workspace file under a directory literally named "b".
+	got := MutationTargets(root, "apply_patch", map[string]any{
+		"patch": "--- a/b/foo.txt\n+++ b/b/foo.txt\n@@ -1 +1 @@\n-x\n+y\n",
+	})
+	if len(got) != 1 || got[0] != "b/foo.txt" {
+		t.Fatalf("expected [b/foo.txt], got %v", got)
+	}
+}

--- a/internal/tools/plan_tool_test.go
+++ b/internal/tools/plan_tool_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -80,5 +81,93 @@ func TestUpdatePlanToolClearPlanResetsState(t *testing.T) {
 	}
 	if got := formatPlan(tool.CurrentPlan()); got != "Plan is currently empty." {
 		t.Fatalf("expected empty plan formatting after ClearPlan, got %q", got)
+	}
+}
+
+func TestUpdatePlanToolAcceptsItemsWithoutID(t *testing.T) {
+	tool := NewUpdatePlanTool()
+	result := tool.Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{"content": "First step", "status": "in_progress"},
+			map[string]any{"content": "Second step", "status": "pending"},
+		},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status when id omitted, got %s: %s", result.Status, result.Output)
+	}
+	plan := tool.CurrentPlan()
+	if len(plan) != 2 {
+		t.Fatalf("expected 2 plan items, got %d", len(plan))
+	}
+	if plan[0].ID != "1" || plan[1].ID != "2" {
+		t.Fatalf("expected ids auto-derived from index, got %q,%q", plan[0].ID, plan[1].ID)
+	}
+}
+
+func TestUpdatePlanToolDefaultsStatusToPending(t *testing.T) {
+	tool := NewUpdatePlanTool()
+	result := tool.Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{"content": "Only content"},
+		},
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status when status omitted, got %s: %s", result.Status, result.Output)
+	}
+	if got := tool.CurrentPlan(); got[0].Status != "pending" {
+		t.Fatalf("expected status to default to pending, got %q", got[0].Status)
+	}
+}
+
+func TestUpdatePlanToolRequiresContent(t *testing.T) {
+	result := NewUpdatePlanTool().Run(context.Background(), map[string]any{
+		"plan": []any{map[string]any{"status": "pending"}},
+	})
+	if result.Status != StatusError {
+		t.Fatalf("expected error when content missing, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "content is required") {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}
+
+func TestUpdatePlanToolConcurrentRunAndRead(t *testing.T) {
+	tool := NewUpdatePlanTool()
+	args := map[string]any{
+		"plan": []any{
+			map[string]any{"content": "First step", "status": "in_progress"},
+			map[string]any{"content": "Second step", "status": "pending"},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func() { defer wg.Done(); tool.Run(context.Background(), args) }()
+		go func() { defer wg.Done(); _ = tool.CurrentPlan() }()
+		go func() { defer wg.Done(); tool.ClearPlan() }()
+	}
+	wg.Wait()
+}
+
+func TestUpdatePlanToolAdvertisesItemSchema(t *testing.T) {
+	plan := NewUpdatePlanTool().Parameters().Properties["plan"]
+	if plan.Items == nil {
+		t.Fatal("expected plan to advertise an items schema to the model")
+	}
+	if plan.Items.Type != "object" {
+		t.Fatalf("expected items type object, got %q", plan.Items.Type)
+	}
+	found := false
+	for _, r := range plan.Items.Required {
+		if r == "content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected items schema to mark content required, got %v", plan.Items.Required)
+	}
+	if _, ok := plan.Items.Properties["status"]; !ok {
+		t.Fatal("expected items schema to document the status property")
 	}
 }

--- a/internal/tools/plan_tool_test.go
+++ b/internal/tools/plan_tool_test.go
@@ -152,22 +152,15 @@ func TestUpdatePlanToolConcurrentRunAndRead(t *testing.T) {
 
 func TestUpdatePlanToolAdvertisesItemSchema(t *testing.T) {
 	plan := NewUpdatePlanTool().Parameters().Properties["plan"]
-	if plan.Items == nil {
-		t.Fatal("expected plan to advertise an items schema to the model")
+	if plan.Type != "array" {
+		t.Fatalf("expected plan to be an array, got %q", plan.Type)
 	}
-	if plan.Items.Type != "object" {
-		t.Fatalf("expected items type object, got %q", plan.Items.Type)
-	}
-	found := false
-	for _, r := range plan.Items.Required {
-		if r == "content" {
-			found = true
+	// The structured nested-object Items schema is deferred until the agent's
+	// PropertySchema serializer passes nested Properties/Required through to
+	// providers; until then the item structure is documented in the description.
+	for _, want := range []string{"content", "status"} {
+		if !strings.Contains(plan.Description, want) {
+			t.Fatalf("plan description should document the %q field, got %q", want, plan.Description)
 		}
-	}
-	if !found {
-		t.Fatalf("expected items schema to mark content required, got %v", plan.Items.Required)
-	}
-	if _, ok := plan.Items.Properties["status"]; !ok {
-		t.Fatal("expected items schema to document the status property")
 	}
 }

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -36,7 +36,7 @@ func NewReadFileTool(workspaceRoot string) Tool {
 }
 
 func (tool readFileTool) Run(_ context.Context, args map[string]any) Result {
-	requestedPath, err := stringArg(args, "path", "", true)
+	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filepath", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
 	}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -154,6 +154,14 @@ func scrubResultSecrets(res Result) Result {
 		res.Display.Summary = scrubbed
 		res.Redacted = true
 	}
+	// Meta values carry model-controlled strings (e.g. glob pattern, bash cwd) and
+	// are forwarded into the transcript, so they are part of the boundary too.
+	for key, value := range res.Meta {
+		if scrubbed := redaction.RedactString(value, redaction.Options{}); scrubbed != value {
+			res.Meta[key] = scrubbed
+			res.Redacted = true
+		}
+	}
 	return res
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 
+	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
@@ -120,18 +121,28 @@ func (registry *Registry) RunWithOptions(ctx context.Context, name string, args 
 		if res.SandboxDecision == nil {
 			res.SandboxDecision = sandboxDecision
 		}
-		return res
+		return scrubResultSecrets(res)
 	}
 
 	if options.Sandbox != nil {
 		if sandboxed, ok := tool.(sandboxAwareTool); ok {
 			res := sandboxed.RunWithSandbox(ctx, args, options.Sandbox)
 			res.SandboxDecision = sandboxDecision
-			return res
+			return scrubResultSecrets(res)
 		}
 	}
 	res := tool.Run(ctx, args)
 	res.SandboxDecision = sandboxDecision
+	return scrubResultSecrets(res)
+}
+
+// scrubResultSecrets redacts known secret forms from a tool result's Output at
+// the registry boundary, so a tool can never leak a secret into the transcript.
+func scrubResultSecrets(res Result) Result {
+	if scrubbed := redaction.RedactString(res.Output, redaction.Options{}); scrubbed != res.Output {
+		res.Output = scrubbed
+		res.Redacted = true
+	}
 	return res
 }
 
@@ -141,6 +152,7 @@ func CoreReadOnlyTools(workspaceRoot string) []Tool {
 		NewListDirectoryTool(workspaceRoot),
 		NewGlobTool(workspaceRoot),
 		NewGrepTool(workspaceRoot),
+		NewAskUserTool(),
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -143,6 +143,12 @@ func scrubResultSecrets(res Result) Result {
 		res.Output = scrubbed
 		res.Redacted = true
 	}
+	// Display.Summary can echo command/output fragments, so scrub it too: a caller
+	// that prefers Display must not bypass the boundary redaction.
+	if scrubbed := redaction.RedactString(res.Display.Summary, redaction.Options{}); scrubbed != res.Display.Summary {
+		res.Display.Summary = scrubbed
+		res.Redacted = true
+	}
 	return res
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -163,7 +163,10 @@ func CoreReadOnlyTools(workspaceRoot string) []Tool {
 		NewListDirectoryTool(workspaceRoot),
 		NewGlobTool(workspaceRoot),
 		NewGrepTool(workspaceRoot),
-		NewAskUserTool(),
+		// NOTE: ask_user (NewAskUserTool) is intentionally NOT registered in core
+		// yet. It needs the agent loop's interactive intercept (OnAskUser); without
+		// it the tool only returns the non-interactive fallback. The agent module
+		// registers it in core when that intercept path lands.
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -58,7 +58,12 @@ func (registry *Registry) Run(ctx context.Context, name string, args map[string]
 	return registry.RunWithOptions(ctx, name, args, RunOptions{})
 }
 
-func (registry *Registry) RunWithOptions(ctx context.Context, name string, args map[string]any, options RunOptions) Result {
+func (registry *Registry) RunWithOptions(ctx context.Context, name string, args map[string]any, options RunOptions) (result Result) {
+	// Every return path passes through scrubResultSecrets exactly once, so denial,
+	// permission, and unknown-tool error messages (which can echo secret-bearing
+	// args/paths) are redacted at the boundary just like tool output.
+	defer func() { result = scrubResultSecrets(result) }()
+
 	tool, ok := registry.Get(name)
 	if !ok {
 		return errorResult(`Error: Unknown tool "` + name + `".`)
@@ -121,19 +126,19 @@ func (registry *Registry) RunWithOptions(ctx context.Context, name string, args 
 		if res.SandboxDecision == nil {
 			res.SandboxDecision = sandboxDecision
 		}
-		return scrubResultSecrets(res)
+		return res
 	}
 
 	if options.Sandbox != nil {
 		if sandboxed, ok := tool.(sandboxAwareTool); ok {
 			res := sandboxed.RunWithSandbox(ctx, args, options.Sandbox)
 			res.SandboxDecision = sandboxDecision
-			return scrubResultSecrets(res)
+			return res
 		}
 	}
 	res := tool.Run(ctx, args)
 	res.SandboxDecision = sandboxDecision
-	return scrubResultSecrets(res)
+	return res
 }
 
 // scrubResultSecrets redacts known secret forms from a tool result's Output at

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
-	if len(toolset) != 5 {
-		t.Fatalf("expected 5 core read-only tools, got %d", len(toolset))
+	if len(toolset) != 4 {
+		t.Fatalf("expected 4 core read-only tools, got %d", len(toolset))
 	}
 
 	for _, tool := range toolset {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -162,6 +162,37 @@ func (t secretTool) Run(context.Context, map[string]any) Result {
 	return Result{Status: StatusOK, Output: t.out, Display: Display{Summary: t.display}}
 }
 
+// denyTool is permission-denied so RunWithOptions returns early via the denial
+// path (before any tool execution); its Reason can carry secret-shaped text.
+type denyTool struct{ reason string }
+
+func (t denyTool) Name() string        { return "deny_tool" }
+func (t denyTool) Description() string { return "always denied" }
+func (t denyTool) Parameters() Schema  { return Schema{Type: "object", AdditionalProperties: false} }
+func (t denyTool) Safety() Safety {
+	return Safety{SideEffect: SideEffectShell, Permission: PermissionDeny, Reason: t.reason}
+}
+func (t denyTool) Run(context.Context, map[string]any) Result { return Result{Status: StatusOK} }
+
+// Regression (Vasanthdev2004): the EARLY denial/permission/unknown-tool returns
+// must be scrubbed too, not just the tool-execution paths.
+func TestRunWithOptionsScrubsSecretsOnDenialPaths(t *testing.T) {
+	secret := "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	reg := NewRegistry()
+	reg.Register(denyTool{reason: "blocked path=/tmp/" + secret})
+
+	res := reg.RunWithOptions(context.Background(), "deny_tool", map[string]any{}, RunOptions{PermissionGranted: true})
+	if res.Status != StatusError {
+		t.Fatalf("expected permission-denied error, got %s: %s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, secret) {
+		t.Fatalf("denial path must scrub secrets, leaked: %q", res.Output)
+	}
+	if !res.Redacted {
+		t.Error("expected Redacted=true on a scrubbed denial")
+	}
+}
+
 // Regression: secrets must be scrubbed at the registry boundary so EVERY caller
 // (agent loop AND MCP server) gets redacted output — not just the agent path.
 func TestRunWithOptionsScrubsSecretsForAllCallers(t *testing.T) {

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -150,7 +150,7 @@ func TestRegistryAllowsPromptToolWithPersistentSandboxGrant(t *testing.T) {
 	}
 }
 
-type secretTool struct{ out string }
+type secretTool struct{ out, display string }
 
 func (t secretTool) Name() string        { return "secret_tool" }
 func (t secretTool) Description() string { return "emits text" }
@@ -159,7 +159,7 @@ func (t secretTool) Safety() Safety {
 	return Safety{SideEffect: SideEffectRead, Permission: PermissionAllow}
 }
 func (t secretTool) Run(context.Context, map[string]any) Result {
-	return Result{Status: StatusOK, Output: t.out}
+	return Result{Status: StatusOK, Output: t.out, Display: Display{Summary: t.display}}
 }
 
 // Regression: secrets must be scrubbed at the registry boundary so EVERY caller
@@ -167,7 +167,7 @@ func (t secretTool) Run(context.Context, map[string]any) Result {
 func TestRunWithOptionsScrubsSecretsForAllCallers(t *testing.T) {
 	secret := "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	reg := NewRegistry()
-	reg.Register(secretTool{out: "token=" + secret})
+	reg.Register(secretTool{out: "token=" + secret, display: "ran token=" + secret})
 
 	res := reg.RunWithOptions(context.Background(), "secret_tool", map[string]any{}, RunOptions{PermissionGranted: true})
 	if res.Status != StatusOK {
@@ -175,6 +175,11 @@ func TestRunWithOptionsScrubsSecretsForAllCallers(t *testing.T) {
 	}
 	if strings.Contains(res.Output, secret) {
 		t.Fatalf("registry must scrub secrets, leaked: %q", res.Output)
+	}
+	// Display.Summary must be scrubbed too — a caller preferring Display must not
+	// bypass the boundary redaction.
+	if strings.Contains(res.Display.Summary, secret) {
+		t.Fatalf("registry must scrub Display.Summary, leaked: %q", res.Display.Summary)
 	}
 	if !res.Redacted {
 		t.Error("expected Redacted=true")

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -102,6 +102,37 @@ func TestRegistryAppliesSandboxBeforeToolExecution(t *testing.T) {
 	}
 }
 
+// Regression: write_file/edit_file accept path aliases (file_path, filename); the
+// sandbox must inspect those keys too, otherwise a model routes an out-of-workspace
+// write around the gate by choosing an alias the sandbox doesn't see.
+func TestRegistrySandboxGatesPathAliasKeys(t *testing.T) {
+	for _, key := range []string{"file_path", "filename", "filepath"} {
+		root := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "escape.txt")
+		registry := NewRegistry()
+		registry.Register(NewWriteFileTool(root))
+		engine := sandbox.NewEngine(sandbox.EngineOptions{WorkspaceRoot: root, Policy: sandbox.DefaultPolicy()})
+
+		result := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
+			key:         outside,
+			"content":   "escape",
+			"overwrite": true,
+		}, RunOptions{
+			PermissionGranted: true,
+			Sandbox:           engine,
+			PermissionMode:    string(sandbox.PermissionUnsafe),
+			Autonomy:          string(sandbox.AutonomyHigh),
+		})
+
+		if result.Status != StatusError || !strings.Contains(result.Output, "outside_workspace") {
+			t.Fatalf("alias %q bypassed the sandbox gate: %#v", key, result)
+		}
+		if _, err := os.Stat(outside); !os.IsNotExist(err) {
+			t.Fatalf("alias %q: file written outside workspace", key)
+		}
+	}
+}
+
 func TestRegistryAllowsPromptToolWithPersistentSandboxGrant(t *testing.T) {
 	root := t.TempDir()
 	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{
@@ -150,7 +181,10 @@ func TestRegistryAllowsPromptToolWithPersistentSandboxGrant(t *testing.T) {
 	}
 }
 
-type secretTool struct{ out, display string }
+type secretTool struct {
+	out, display string
+	meta         map[string]string
+}
 
 func (t secretTool) Name() string        { return "secret_tool" }
 func (t secretTool) Description() string { return "emits text" }
@@ -159,7 +193,7 @@ func (t secretTool) Safety() Safety {
 	return Safety{SideEffect: SideEffectRead, Permission: PermissionAllow}
 }
 func (t secretTool) Run(context.Context, map[string]any) Result {
-	return Result{Status: StatusOK, Output: t.out, Display: Display{Summary: t.display}}
+	return Result{Status: StatusOK, Output: t.out, Display: Display{Summary: t.display}, Meta: t.meta}
 }
 
 // denyTool is permission-denied so RunWithOptions returns early via the denial
@@ -198,7 +232,11 @@ func TestRunWithOptionsScrubsSecretsOnDenialPaths(t *testing.T) {
 func TestRunWithOptionsScrubsSecretsForAllCallers(t *testing.T) {
 	secret := "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	reg := NewRegistry()
-	reg.Register(secretTool{out: "token=" + secret, display: "ran token=" + secret})
+	reg.Register(secretTool{
+		out:     "token=" + secret,
+		display: "ran token=" + secret,
+		meta:    map[string]string{"pattern": "find " + secret},
+	})
 
 	res := reg.RunWithOptions(context.Background(), "secret_tool", map[string]any{}, RunOptions{PermissionGranted: true})
 	if res.Status != StatusOK {
@@ -207,10 +245,13 @@ func TestRunWithOptionsScrubsSecretsForAllCallers(t *testing.T) {
 	if strings.Contains(res.Output, secret) {
 		t.Fatalf("registry must scrub secrets, leaked: %q", res.Output)
 	}
-	// Display.Summary must be scrubbed too — a caller preferring Display must not
-	// bypass the boundary redaction.
+	// Display.Summary and Meta values must be scrubbed too — both are forwarded
+	// into the transcript, so a caller preferring either must not bypass redaction.
 	if strings.Contains(res.Display.Summary, secret) {
 		t.Fatalf("registry must scrub Display.Summary, leaked: %q", res.Display.Summary)
+	}
+	if strings.Contains(res.Meta["pattern"], secret) {
+		t.Fatalf("registry must scrub Meta values, leaked: %q", res.Meta["pattern"])
 	}
 	if !res.Redacted {
 		t.Error("expected Redacted=true")

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
-	if len(toolset) != 4 {
-		t.Fatalf("expected 4 core read-only tools, got %d", len(toolset))
+	if len(toolset) != 5 {
+		t.Fatalf("expected 5 core read-only tools, got %d", len(toolset))
 	}
 
 	for _, tool := range toolset {
@@ -147,5 +147,45 @@ func TestRegistryAllowsPromptToolWithPersistentSandboxGrant(t *testing.T) {
 	}
 	if string(content) != "granted" {
 		t.Fatalf("written content = %q, want granted", string(content))
+	}
+}
+
+type secretTool struct{ out string }
+
+func (t secretTool) Name() string        { return "secret_tool" }
+func (t secretTool) Description() string { return "emits text" }
+func (t secretTool) Parameters() Schema  { return Schema{Type: "object", AdditionalProperties: false} }
+func (t secretTool) Safety() Safety {
+	return Safety{SideEffect: SideEffectRead, Permission: PermissionAllow}
+}
+func (t secretTool) Run(context.Context, map[string]any) Result {
+	return Result{Status: StatusOK, Output: t.out}
+}
+
+// Regression: secrets must be scrubbed at the registry boundary so EVERY caller
+// (agent loop AND MCP server) gets redacted output — not just the agent path.
+func TestRunWithOptionsScrubsSecretsForAllCallers(t *testing.T) {
+	secret := "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	reg := NewRegistry()
+	reg.Register(secretTool{out: "token=" + secret})
+
+	res := reg.RunWithOptions(context.Background(), "secret_tool", map[string]any{}, RunOptions{PermissionGranted: true})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, secret) {
+		t.Fatalf("registry must scrub secrets, leaked: %q", res.Output)
+	}
+	if !res.Redacted {
+		t.Error("expected Redacted=true")
+	}
+}
+
+func TestRunWithOptionsLeavesCleanOutputUnchanged(t *testing.T) {
+	reg := NewRegistry()
+	reg.Register(secretTool{out: "nothing secret here"})
+	res := reg.RunWithOptions(context.Background(), "secret_tool", map[string]any{}, RunOptions{PermissionGranted: true})
+	if res.Redacted || res.Output != "nothing secret here" {
+		t.Fatalf("clean output altered: redacted=%v output=%q", res.Redacted, res.Output)
 	}
 }

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -53,6 +53,10 @@ type PropertySchema struct {
 	Items       *PropertySchema `json:"items,omitempty"`
 	Minimum     *int            `json:"minimum,omitempty"`
 	Maximum     *int            `json:"maximum,omitempty"`
+	// Properties/Required describe nested object fields (for Type "object" or an
+	// object-typed Items).
+	Properties map[string]PropertySchema `json:"properties,omitempty"`
+	Required   []string                  `json:"required,omitempty"`
 }
 
 type Result struct {
@@ -61,6 +65,19 @@ type Result struct {
 	Truncated       bool
 	Meta            map[string]string
 	SandboxDecision *sandbox.Decision `json:"-"`
+	// Redacted is set when secret scrubbing altered Output before it left the
+	// tool-execution boundary.
+	Redacted bool
+	// ChangedFiles lists workspace-relative paths a mutating tool wrote.
+	ChangedFiles []string
+	// Display carries a short, structured summary for the TUI / stream.
+	Display Display
+}
+
+// Display carries a short, structured summary of a tool result for the TUI/stream.
+type Display struct {
+	Summary string
+	Kind    string // e.g. file, diff, search, shell
 }
 
 type Tool interface {

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 type PlanItem struct {
@@ -15,18 +16,42 @@ type PlanItem struct {
 
 type updatePlanTool struct {
 	baseTool
+	// mu guards currentPlan: Run() writes it on the agent goroutine while
+	// CurrentPlan()/ClearPlan() are called from the TUI goroutine (e.g. /plan).
+	mu          sync.Mutex
 	currentPlan []PlanItem
 }
 
 func NewUpdatePlanTool() *updatePlanTool {
 	return &updatePlanTool{
 		baseTool: baseTool{
-			name:        "update_plan",
-			description: "Create or update the in-memory plan for the current task.",
+			name: "update_plan",
+			description: "Create or update the in-memory plan for the current task. " +
+				"Pass the full ordered list of steps each call; it replaces the previous plan. " +
+				"Each item needs a `content` string; `status` defaults to \"pending\" and `id` is " +
+				"auto-numbered, so you only need to supply `content` (and `status` as the task progresses).",
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
-					"plan": {Type: "array", Description: "Ordered list of plan items."},
+					"plan": {
+						Type:        "array",
+						Description: "Ordered list of plan items, replacing any previous plan.",
+						Items: &PropertySchema{
+							Type: "object",
+							Properties: map[string]PropertySchema{
+								"content": {Type: "string", Description: "What this step does."},
+								"status": {
+									Type:        "string",
+									Description: "Step status (defaults to pending).",
+									Enum:        []string{"pending", "in_progress", "completed", "failed"},
+									Default:     "pending",
+								},
+								"notes": {Type: "string", Description: "Optional notes for this step."},
+								"id":    {Type: "string", Description: "Optional stable id; auto-numbered from position when omitted."},
+							},
+							Required: []string{"content"},
+						},
+					},
 				},
 				Required:             []string{"plan"},
 				AdditionalProperties: false,
@@ -41,16 +66,22 @@ func (tool *updatePlanTool) Run(_ context.Context, args map[string]any) Result {
 	if err != nil {
 		return errorResult("Error: Invalid arguments for update_plan: " + err.Error())
 	}
+	tool.mu.Lock()
 	tool.currentPlan = plan
+	tool.mu.Unlock()
 	return okResult(formatPlan(plan))
 }
 
 func (tool *updatePlanTool) CurrentPlan() []PlanItem {
+	tool.mu.Lock()
+	defer tool.mu.Unlock()
 	return append([]PlanItem{}, tool.currentPlan...)
 }
 
 func (tool *updatePlanTool) ClearPlan() {
+	tool.mu.Lock()
 	tool.currentPlan = nil
+	tool.mu.Unlock()
 }
 
 func parsePlanItems(value any) ([]PlanItem, error) {
@@ -66,17 +97,26 @@ func parsePlanItems(value any) ([]PlanItem, error) {
 			return nil, fmt.Errorf("plan item %d must be an object", index+1)
 		}
 
-		id, err := stringArg(object, "id", "", true)
-		if err != nil {
-			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
-		}
 		content, err := stringArg(object, "content", "", true)
 		if err != nil {
 			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
 		}
-		status, err := stringArg(object, "status", "", true)
+		// id is optional: weaker models can't reliably mint stable ids, and the
+		// plan is displayed by 1-based position anyway. Auto-number when omitted.
+		id, err := stringArgWithEmpty(object, "id", fmt.Sprintf("%d", index+1), false, true)
 		if err != nil {
 			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
+		}
+		if id == "" {
+			id = fmt.Sprintf("%d", index+1)
+		}
+		// status is optional and defaults to pending.
+		status, err := stringArgWithEmpty(object, "status", "pending", false, true)
+		if err != nil {
+			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
+		}
+		if status == "" {
+			status = "pending"
 		}
 		if !isPlanStatus(status) {
 			return nil, fmt.Errorf("plan item %d status must be pending, in_progress, completed, or failed", index+1)

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -33,24 +33,14 @@ func NewUpdatePlanTool() *updatePlanTool {
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
+					// The item structure (content/status/id) is described textually
+					// above. A structured nested-object Items schema is deferred until
+					// the agent's PropertySchema serializer (propertyToRuntimeMap)
+					// passes nested Properties/Required through to providers; until then
+					// a nested schema here would be silently dropped, so keep it flat.
 					"plan": {
 						Type:        "array",
-						Description: "Ordered list of plan items, replacing any previous plan.",
-						Items: &PropertySchema{
-							Type: "object",
-							Properties: map[string]PropertySchema{
-								"content": {Type: "string", Description: "What this step does."},
-								"status": {
-									Type:        "string",
-									Description: "Step status (defaults to pending).",
-									Enum:        []string{"pending", "in_progress", "completed", "failed"},
-									Default:     "pending",
-								},
-								"notes": {Type: "string", Description: "Optional notes for this step."},
-								"id":    {Type: "string", Description: "Optional stable id; auto-numbered from position when omitted."},
-							},
-							Required: []string{"content"},
-						},
+						Description: "Ordered list of plan items, replacing any previous plan. Each item is an object with a required `content` string, an optional `status` (pending|in_progress|completed|failed, defaults to pending), optional `notes`, and an optional `id` (auto-numbered from position when omitted).",
 					},
 				},
 				Required:             []string{"plan"},

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -34,11 +34,11 @@ func NewWriteFileTool(workspaceRoot string) Tool {
 }
 
 func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
-	requestedPath, err := stringArg(args, "path", "", true)
+	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for write_file: " + err.Error())
 	}
-	content, err := stringArgWithEmpty(args, "content", "", true, true)
+	content, err := fileContentArg(args)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for write_file: " + err.Error())
 	}
@@ -72,8 +72,23 @@ func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
 
+	verb := "Created"
 	if existed {
-		return okResult(fmt.Sprintf("Overwrote %s (%d bytes).", relativePath, len([]byte(content))))
+		verb = "Overwrote"
 	}
-	return okResult(fmt.Sprintf("Created %s (%d bytes).", relativePath, len([]byte(content))))
+	summary := fmt.Sprintf("%s %s (%d bytes).", verb, relativePath, len([]byte(content)))
+	result := okResult(summary)
+	result.ChangedFiles = []string{relativePath}
+	result.Display = Display{Summary: summary, Kind: "file"}
+	return result
+}
+
+// fileContentArg reads the file body from "content" or a common alias that weaker
+// models sometimes use instead (contents/text/body/data/file_content). It
+// delegates to the shared aliasedStringArg so the present-but-non-string type
+// error ("content must be a string") and the required-but-missing error
+// ("content is required") stay consistent with every other tool. An empty string
+// is allowed (writing an empty file), so allowEmpty is true.
+func fileContentArg(args map[string]any) (string, error) {
+	return aliasedStringArg(args, []string{"content", "contents", "text", "body", "data", "file_content"}, "", true, true)
 }

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -384,3 +384,100 @@ func TestApplyPatchToolRejectsOutsideWorkspace(t *testing.T) {
 		t.Fatalf("expected workspace error, got %q", result.Output)
 	}
 }
+
+// Finding 3: apply_patch with cwd != "." must report WORKSPACE-relative
+// ChangedFiles (cwd-prefixed), not cwd-relative paths. Otherwise the session's
+// rewind/diff layer keys off the wrong path.
+func TestApplyPatchReportsWorkspaceRelativeChangedFilesUnderCwd(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "sub", "dir")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "a.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	patch := "--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-one\n+two\n"
+
+	res := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"patch": patch, "cwd": "sub/dir"})
+	if res.Status != StatusOK {
+		t.Skipf("git apply unavailable or failed: %s", res.Output)
+	}
+	if len(res.ChangedFiles) != 1 || res.ChangedFiles[0] != "sub/dir/a.txt" {
+		t.Fatalf("ChangedFiles = %v, want [sub/dir/a.txt]", res.ChangedFiles)
+	}
+}
+
+func TestWriteFileReportsChangedFileAndDisplay(t *testing.T) {
+	root := t.TempDir()
+	res := NewWriteFileTool(root).Run(context.Background(), map[string]any{"path": "notes.txt", "content": "hello"})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if len(res.ChangedFiles) != 1 || res.ChangedFiles[0] != "notes.txt" {
+		t.Fatalf("ChangedFiles = %v, want [notes.txt]", res.ChangedFiles)
+	}
+	if res.Display.Kind != "file" {
+		t.Errorf("Display.Kind = %q, want file", res.Display.Kind)
+	}
+	if res.Display.Summary == "" {
+		t.Error("expected a non-empty Display.Summary")
+	}
+}
+
+func TestEditFileReportsChangedFileAndDisplay(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("alpha beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := NewEditFileTool(root).Run(context.Background(), map[string]any{"path": "f.txt", "old_string": "alpha", "new_string": "gamma"})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if len(res.ChangedFiles) != 1 || res.ChangedFiles[0] != "f.txt" {
+		t.Fatalf("ChangedFiles = %v, want [f.txt]", res.ChangedFiles)
+	}
+	if res.Display.Kind != "diff" {
+		t.Errorf("Display.Kind = %q, want diff", res.Display.Kind)
+	}
+}
+
+func TestApplyPatchReportsChangedFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	patch := "--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-one\n+two\n"
+	res := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"patch": patch})
+	if res.Status != StatusOK {
+		t.Skipf("git apply unavailable or failed: %s", res.Output) // environment guard
+	}
+	found := false
+	for _, f := range res.ChangedFiles {
+		if f == "a.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a.txt in ChangedFiles, got %v", res.ChangedFiles)
+	}
+	if res.Display.Kind != "diff" {
+		t.Errorf("Display.Kind = %q, want diff", res.Display.Kind)
+	}
+}
+
+func TestWriteFileAcceptsContentAlias(t *testing.T) {
+	root := t.TempDir()
+	// minimax-style: content under an alias key instead of "content".
+	res := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path":     "shop.html",
+		"contents": "<html>hi</html>",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("alias content should write, got %s: %s", res.Status, res.Output)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "shop.html"))
+	if string(got) != "<html>hi</html>" {
+		t.Fatalf("file content = %q", got)
+	}
+}

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -401,7 +401,10 @@ func TestApplyPatchReportsWorkspaceRelativeChangedFilesUnderCwd(t *testing.T) {
 
 	res := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"patch": patch, "cwd": "sub/dir"})
 	if res.Status != StatusOK {
-		t.Skipf("git apply unavailable or failed: %s", res.Output)
+		if gitApplyUnavailable(res.Output) {
+			t.Skipf("git binary unavailable: %s", res.Output)
+		}
+		t.Fatalf("apply_patch with cwd failed (possible regression): %s", res.Output)
 	}
 	if len(res.ChangedFiles) != 1 || res.ChangedFiles[0] != "sub/dir/a.txt" {
 		t.Fatalf("ChangedFiles = %v, want [sub/dir/a.txt]", res.ChangedFiles)
@@ -450,7 +453,10 @@ func TestApplyPatchReportsChangedFiles(t *testing.T) {
 	patch := "--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-one\n+two\n"
 	res := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"patch": patch})
 	if res.Status != StatusOK {
-		t.Skipf("git apply unavailable or failed: %s", res.Output) // environment guard
+		if gitApplyUnavailable(res.Output) {
+			t.Skipf("git binary unavailable: %s", res.Output)
+		}
+		t.Fatalf("apply_patch failed (possible regression): %s", res.Output)
 	}
 	found := false
 	for _, f := range res.ChangedFiles {
@@ -480,4 +486,12 @@ func TestWriteFileAcceptsContentAlias(t *testing.T) {
 	if string(got) != "<html>hi</html>" {
 		t.Fatalf("file content = %q", got)
 	}
+}
+
+// gitApplyUnavailable reports whether an apply_patch failure is due to the git
+// binary being absent (an environment condition worth skipping) rather than a
+// real regression (which must fail the test). apply_patch shells out to
+// `git apply`; a missing binary surfaces as exec's "executable file not found".
+func gitApplyUnavailable(output string) bool {
+	return strings.Contains(output, "executable file not found")
 }


### PR DESCRIPTION
## Module — tools runtime (arg-tolerance, ask_user, scrubbing, structured results)

First of the `tools → agent → tui shell` chain (the TUI shell sits on top of these). **Scope: `internal/tools`** (24 files, +1,680/−51) **+ a 1-line `internal/specialist` vocabulary update**. No new deps; this was 3-way merged onto main's specialist drift.

### Reconciled with main's drift (kept)
`RunOptions` tool-context fields, `Safety.AdvertiseInAuto`, the `optionsAwareTool` dispatch + `OnSandboxDecision`, `PropertySchema` (Items/Min/Max), and the base structured `Result` — all preserved.

### Added (runtime-core)
- **Arg-tolerance layer** (`argtolerance.go`): alias-aware, type-strict arg resolution + slice/bool/int coercion, adopted across all tools so weak models' non-canonical arg shapes are accepted without losing type-strictness.
- **`ask_user` tool** wired into `CoreReadOnlyTools`; **nested `PropertySchema` (Properties/Required)** for its object-typed questions (and `update_plan`).
- **Secret scrubbing at the registry boundary** (`scrubResultSecrets` via `internal/redaction`) on every tool-execution path incl. the `optionsAwareTool` dispatch; **structured `Result`** (`Display`/`Redacted`/`ChangedFiles`).
- **`mutation_targets`** (paths a mutating tool will write, for session checkpointing) + hardened `grep` (symlink confinement), `apply_patch`, `bash`, `edit`/`write`.

### Excluded per the split
The blueprint **`task` tool** (subagents — another dev's area; the merged specialist `Task` is separate) and the **`skill` tool** (ships with the later skills module), plus their subagent-only registry helpers (`Without`/`isolateForChild`).

### Cross-package note
`ask_user` is now a core tool, so `specialist.knownToolNames` gains `"ask_user"` to satisfy `TestKnownToolNamesMatchCoreRegistry` (the invariant that the specialist tool-vocabulary covers the core registry).

### Testing
`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./internal/tools/`, and `GOOS=windows go build ./...` all green.

Part of decomposing #101 (draft); subagents excluded.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ask_user` tool for collecting interactive clarifications and user feedback.

* **Improvements**
  * Tools now accept flexible parameter aliases for common inputs (e.g., `path`/`file`, `patch`/`diff`).
  * Enhanced argument handling accepts multiple input formats (strings, numbers, booleans).
  * File operations report changed files and display summaries for better visibility.
  * Bash tool provides early safety feedback for interactive commands.
  * Tool outputs automatically redact sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->