### PR TITLE
Add specialist lifecycle accounting

### DIFF
--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -67,9 +67,9 @@ func TestNodeWrapperReportsMissingNativeBinary(t *testing.T) {
 	node := requireNode(t)
 	wrapperPath := copyWrapperFixture(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), nodeWrapperTimeout())
 	defer cancel()
-	command := exec.CommandContext(ctx, node, wrapperPath, "--version")
+	command := nodeWrapperCommand(ctx, node, wrapperPath, "--version")
 	output, err := command.CombinedOutput()
 	if ctx.Err() != nil {
 		t.Fatalf("wrapper timed out reporting missing native binary: %v; output: %s", ctx.Err(), output)
@@ -98,9 +98,9 @@ func TestNodeWrapperLaunchesNativeBinary(t *testing.T) {
 		t.Fatalf("WriteFile native fixture: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), nodeWrapperTimeout())
 	defer cancel()
-	command := exec.CommandContext(ctx, node, wrapperPath, "--version")
+	command := nodeWrapperCommand(ctx, node, wrapperPath, "--version")
 	output, err := command.CombinedOutput()
 	if ctx.Err() != nil {
 		t.Fatalf("wrapper timed out launching native binary: %v; output: %s", ctx.Err(), output)
@@ -149,6 +149,22 @@ func requireNode(t *testing.T) string {
 		t.Skip("node is not available")
 	}
 	return node
+}
+
+func nodeWrapperCommand(ctx context.Context, node string, wrapperPath string, args ...string) *exec.Cmd {
+	commandArgs := append([]string{wrapperPath}, args...)
+	command := exec.CommandContext(ctx, node, commandArgs...)
+	// Keep wrapper behavior independent from developer or runner Node settings
+	// such as --inspect-brk, which would block this smoke test.
+	command.Env = append(os.Environ(), "NODE_OPTIONS=")
+	return command
+}
+
+func nodeWrapperTimeout() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 30 * time.Second
+	}
+	return 10 * time.Second
 }
 
 func repoRoot(t *testing.T) string {

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -37,6 +37,8 @@ const (
 	EventCompaction         EventType = "session_compaction"
 	EventSessionFork        EventType = "session_fork"
 	EventSessionChild       EventType = "session_child"
+	EventSpecialistStart    EventType = "specialist_start"
+	EventSpecialistStop     EventType = "specialist_stop"
 )
 
 type SessionKind string

--- a/internal/specialist/accounting.go
+++ b/internal/specialist/accounting.go
@@ -1,0 +1,191 @@
+package specialist
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+const specialistAccountingSource = "specialist"
+
+type specialistAccountingInput struct {
+	ParentSessionID string
+	ChildSessionID  string
+	SpecialistName  string
+	Description     string
+	ToolCallID      string
+	Mode            string
+	Background      bool
+	PID             int
+}
+
+func (executor Executor) recordSpecialistStart(input specialistAccountingInput) {
+	payload := baseSpecialistPayload(input)
+	_, _ = appendSpecialistSessionEvent(executor.SessionStore, input.ParentSessionID, sessions.EventSpecialistStart, payload)
+}
+
+func (executor Executor) recordSpecialistStop(input specialistAccountingInput, summary StreamResult, status string, exitCode int, runErr error, usageRolledUp bool) {
+	store := accountingStore(executor.SessionStore)
+	if specialistEventExists(store, input.ParentSessionID, sessions.EventSpecialistStop, input.ChildSessionID, summary.RunID) {
+		return
+	}
+	payload := baseSpecialistPayload(input)
+	if summary.RunID != "" {
+		payload["runId"] = summary.RunID
+	}
+	payload["status"] = specialistStopStatus(status, exitCode, runErr)
+	payload["exitCode"] = exitCode
+	payload["usageRolledUp"] = usageRolledUp
+	if runErr != nil {
+		payload["error"] = runErr.Error()
+	}
+	if len(summary.Errors) > 0 {
+		payload["errors"] = append([]string(nil), summary.Errors...)
+	}
+	_, _ = appendSpecialistSessionEvent(store, input.ParentSessionID, sessions.EventSpecialistStop, payload)
+}
+
+func (executor Executor) rollUpSpecialistUsage(input specialistAccountingInput, summary StreamResult) bool {
+	rolledUp, _ := appendSpecialistUsageRollup(executor.SessionStore, input, summary)
+	return rolledUp
+}
+
+func (executor Executor) recordBackgroundTaskAccounting(task background.Task, summary StreamResult) {
+	if task.Status == background.StatusRunning {
+		return
+	}
+	input := specialistAccountingInput{
+		ParentSessionID: strings.TrimSpace(task.ParentID),
+		ChildSessionID:  strings.TrimSpace(task.ID),
+		SpecialistName:  strings.TrimSpace(task.SpecialistName),
+		Description:     strings.TrimSpace(task.Description),
+		Mode:            "background",
+		Background:      true,
+		PID:             task.PID,
+	}
+	rolledUp := executor.rollUpSpecialistUsage(input, summary)
+	executor.recordSpecialistStop(input, summary, string(task.Status), task.ExitCode, nil, rolledUp)
+}
+
+func appendSpecialistUsageRollup(store *sessions.Store, input specialistAccountingInput, summary StreamResult) (bool, error) {
+	if !summary.Usage.HasUsage() {
+		return false, nil
+	}
+	if strings.TrimSpace(input.ParentSessionID) == "" || strings.TrimSpace(input.ChildSessionID) == "" || !sessions.ValidSessionID(input.ParentSessionID) {
+		return false, nil
+	}
+	store = accountingStore(store)
+	if specialistEventExists(store, input.ParentSessionID, sessions.EventUsage, input.ChildSessionID, summary.RunID) {
+		return false, nil
+	}
+	payload := baseSpecialistPayload(input)
+	if summary.RunID != "" {
+		payload["runId"] = summary.RunID
+	}
+	payload["promptTokens"] = summary.Usage.PromptTokens
+	payload["completionTokens"] = summary.Usage.CompletionTokens
+	payload["totalTokens"] = summary.Usage.EffectiveTotalTokens()
+	payload["usageEvents"] = summary.Usage.Events
+	if _, err := appendSpecialistSessionEvent(store, input.ParentSessionID, sessions.EventUsage, payload); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func appendSpecialistSessionEvent(store *sessions.Store, parentSessionID string, eventType sessions.EventType, payload map[string]any) (sessions.Event, error) {
+	parentSessionID = strings.TrimSpace(parentSessionID)
+	if parentSessionID == "" || !sessions.ValidSessionID(parentSessionID) {
+		return sessions.Event{}, nil
+	}
+	store = accountingStore(store)
+	return store.AppendEvent(parentSessionID, sessions.AppendEventInput{Type: eventType, Payload: payload})
+}
+
+func specialistEventExists(store *sessions.Store, parentSessionID string, eventType sessions.EventType, childSessionID string, runID string) bool {
+	parentSessionID = strings.TrimSpace(parentSessionID)
+	childSessionID = strings.TrimSpace(childSessionID)
+	runID = strings.TrimSpace(runID)
+	if parentSessionID == "" || childSessionID == "" || !sessions.ValidSessionID(parentSessionID) {
+		return false
+	}
+	events, err := store.ReadEvents(parentSessionID)
+	if err != nil {
+		return false
+	}
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+		payload := map[string]any{}
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			continue
+		}
+		if specialistPayloadString(payload, "source") != specialistAccountingSource {
+			continue
+		}
+		if specialistPayloadString(payload, "childSessionId") != childSessionID && specialistPayloadString(payload, "taskId") != childSessionID {
+			continue
+		}
+		if runID == "" || specialistPayloadString(payload, "runId") == runID {
+			return true
+		}
+	}
+	return false
+}
+
+func baseSpecialistPayload(input specialistAccountingInput) map[string]any {
+	childSessionID := strings.TrimSpace(input.ChildSessionID)
+	payload := map[string]any{
+		"source":         specialistAccountingSource,
+		"childSessionId": childSessionID,
+		"taskId":         childSessionID,
+		"mode":           strings.TrimSpace(input.Mode),
+		"background":     input.Background,
+	}
+	if specialistName := strings.TrimSpace(input.SpecialistName); specialistName != "" {
+		payload["specialist"] = specialistName
+	}
+	if description := strings.TrimSpace(input.Description); description != "" {
+		payload["description"] = description
+	}
+	if toolCallID := strings.TrimSpace(input.ToolCallID); toolCallID != "" {
+		payload["toolCallId"] = toolCallID
+	}
+	if input.PID > 0 {
+		payload["pid"] = input.PID
+	}
+	return payload
+}
+
+func specialistStopStatus(status string, exitCode int, runErr error) string {
+	status = strings.TrimSpace(status)
+	if status != "" {
+		return status
+	}
+	if runErr != nil || exitCode != 0 {
+		return "error"
+	}
+	return "success"
+}
+
+func specialistPayloadString(payload map[string]any, key string) string {
+	value, ok := payload[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return ""
+	}
+}
+
+func accountingStore(store *sessions.Store) *sessions.Store {
+	if store != nil {
+		return store
+	}
+	return sessions.NewStore(sessions.StoreOptions{})
+}

--- a/internal/specialist/accounting_test.go
+++ b/internal/specialist/accounting_test.go
@@ -1,0 +1,214 @@
+package specialist
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestExecutorRecordsForegroundLifecycleAndUsageRollup(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	parent, err := store.Create(sessions.CreateInput{SessionID: "parent_session"})
+	if err != nil {
+		t.Fatalf("Create parent returned error: %v", err)
+	}
+	zero := 0
+	executor := Executor{
+		BinaryPath:   "/usr/local/bin/zero",
+		SessionStore: store,
+		NewSessionID: func() (string, error) { return "child_task", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		RunChild: func(context.Context, string, []string) (ChildRunResult, error) {
+			return ChildRunResult{
+				Events: []streamjson.Event{
+					{Type: streamjson.EventRunStart, RunID: "run_1", SessionID: "child_task"},
+					{Type: streamjson.EventUsage, RunID: "run_1", PromptTokens: ptrInt(12), CompletionTokens: ptrInt(5), TotalTokens: ptrInt(17)},
+					{Type: streamjson.EventFinal, RunID: "run_1", Text: "done"},
+					{Type: streamjson.EventRunEnd, RunID: "run_1", Status: "success", ExitCode: &zero},
+				},
+				ExitCode: 0,
+			}, nil
+		},
+	}
+
+	result, err := executor.Run(context.Background(), TaskParameters{
+		Name:        "worker",
+		Prompt:      "inspect auth",
+		Description: "Auth check",
+	}, TaskRunOptions{
+		ParentSessionID: parent.SessionID,
+		ToolCallID:      "call_1",
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if result.Result.Status != tools.StatusOK {
+		t.Fatalf("Run status = %s, output=%s", result.Result.Status, result.Result.Output)
+	}
+
+	events, err := store.ReadEvents(parent.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if got, want := eventTypes(events), []sessions.EventType{sessions.EventSpecialistStart, sessions.EventUsage, sessions.EventSpecialistStop}; strings.Join(eventTypesString(got), ",") != strings.Join(eventTypesString(want), ",") {
+		t.Fatalf("event types = %#v, want %#v", got, want)
+	}
+	startPayload := eventPayload(t, events[0])
+	if payloadString(startPayload, "source") != "specialist" ||
+		payloadString(startPayload, "childSessionId") != "child_task" ||
+		payloadString(startPayload, "specialist") != "worker" ||
+		payloadString(startPayload, "toolCallId") != "call_1" ||
+		payloadString(startPayload, "mode") != "foreground" ||
+		payloadBool(startPayload, "background") {
+		t.Fatalf("start payload = %#v", startPayload)
+	}
+	usagePayload := eventPayload(t, events[1])
+	if payloadString(usagePayload, "source") != "specialist" ||
+		payloadString(usagePayload, "childSessionId") != "child_task" ||
+		payloadString(usagePayload, "runId") != "run_1" ||
+		payloadInt(usagePayload, "promptTokens") != 12 ||
+		payloadInt(usagePayload, "completionTokens") != 5 ||
+		payloadInt(usagePayload, "totalTokens") != 17 ||
+		payloadInt(usagePayload, "usageEvents") != 1 {
+		t.Fatalf("usage payload = %#v", usagePayload)
+	}
+	stopPayload := eventPayload(t, events[2])
+	if payloadString(stopPayload, "status") != "success" ||
+		payloadInt(stopPayload, "exitCode") != 0 ||
+		!payloadBool(stopPayload, "usageRolledUp") {
+		t.Fatalf("stop payload = %#v", stopPayload)
+	}
+}
+
+func TestOutputToolRollsUpCompletedBackgroundUsageOnce(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	parent, err := store.Create(sessions.CreateInput{SessionID: "parent_session"})
+	if err != nil {
+		t.Fatalf("Create parent returned error: %v", err)
+	}
+	manager, err := background.NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager returned error: %v", err)
+	}
+	outputFile, err := manager.Register(background.RegisterInput{
+		TaskID:         "child_task",
+		Type:           "specialist",
+		SpecialistName: "worker",
+		Description:    "Auth check",
+		ParentID:       parent.SessionID,
+	})
+	if err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+	if err := os.WriteFile(outputFile, []byte(strings.Join([]string{
+		`{"schemaVersion":1,"type":"run_start","runId":"run_1","sessionId":"child_task"}`,
+		`{"schemaVersion":1,"type":"usage","runId":"run_1","promptTokens":20,"completionTokens":8,"totalTokens":28}`,
+		`{"schemaVersion":1,"type":"final","runId":"run_1","text":"done"}`,
+		`{"schemaVersion":1,"type":"run_end","runId":"run_1","status":"success","exitCode":0}`,
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if err := manager.UpdateStatus("child_task", background.StatusCompleted, 0); err != nil {
+		t.Fatalf("UpdateStatus returned error: %v", err)
+	}
+	tool := NewOutputTool(manager)
+	tool.SessionStore = store
+
+	first := tool.Run(context.Background(), map[string]any{"task_id": "child_task"})
+	second := tool.Run(context.Background(), map[string]any{"task_id": "child_task"})
+
+	if first.Status != tools.StatusOK || second.Status != tools.StatusOK {
+		t.Fatalf("TaskOutput results = %#v %#v", first, second)
+	}
+	events, err := store.ReadEvents(parent.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	if usageEvents := eventsOfType(events, sessions.EventUsage); len(usageEvents) != 1 {
+		t.Fatalf("usage events = %#v", events)
+	}
+	if stopEvents := eventsOfType(events, sessions.EventSpecialistStop); len(stopEvents) != 1 {
+		t.Fatalf("stop events = %#v", events)
+	}
+	usagePayload := eventPayload(t, eventsOfType(events, sessions.EventUsage)[0])
+	if payloadString(usagePayload, "mode") != "background" ||
+		payloadInt(usagePayload, "promptTokens") != 20 ||
+		payloadInt(usagePayload, "completionTokens") != 8 ||
+		payloadInt(usagePayload, "totalTokens") != 28 {
+		t.Fatalf("background usage payload = %#v", usagePayload)
+	}
+}
+
+func ptrInt(value int) *int {
+	return &value
+}
+
+func eventTypes(events []sessions.Event) []sessions.EventType {
+	types := make([]sessions.EventType, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.Type)
+	}
+	return types
+}
+
+func eventTypesString(types []sessions.EventType) []string {
+	values := make([]string, 0, len(types))
+	for _, eventType := range types {
+		values = append(values, string(eventType))
+	}
+	return values
+}
+
+func eventsOfType(events []sessions.Event, eventType sessions.EventType) []sessions.Event {
+	matches := []sessions.Event{}
+	for _, event := range events {
+		if event.Type == eventType {
+			matches = append(matches, event)
+		}
+	}
+	return matches
+}
+
+func eventPayload(t *testing.T, event sessions.Event) map[string]any {
+	t.Helper()
+	payload := map[string]any{}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload returned error: %v", err)
+	}
+	return payload
+}
+
+func payloadString(payload map[string]any, key string) string {
+	value, _ := payload[key].(string)
+	return value
+}
+
+func payloadBool(payload map[string]any, key string) bool {
+	value, _ := payload[key].(bool)
+	return value
+}
+
+func payloadInt(payload map[string]any, key string) int {
+	switch value := payload[key].(type) {
+	case int:
+		return value
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}

--- a/internal/specialist/accounting_test.go
+++ b/internal/specialist/accounting_test.go
@@ -67,30 +67,69 @@ func TestExecutorRecordsForegroundLifecycleAndUsageRollup(t *testing.T) {
 		t.Fatalf("event types = %#v, want %#v", got, want)
 	}
 	startPayload := eventPayload(t, events[0])
-	if payloadString(startPayload, "source") != "specialist" ||
-		payloadString(startPayload, "childSessionId") != "child_task" ||
-		payloadString(startPayload, "specialist") != "worker" ||
-		payloadString(startPayload, "toolCallId") != "call_1" ||
-		payloadString(startPayload, "mode") != "foreground" ||
-		payloadBool(startPayload, "background") {
-		t.Fatalf("start payload = %#v", startPayload)
-	}
+	requirePayloadString(t, startPayload, "source", "specialist")
+	requirePayloadString(t, startPayload, "childSessionId", "child_task")
+	requirePayloadString(t, startPayload, "specialist", "worker")
+	requirePayloadString(t, startPayload, "toolCallId", "call_1")
+	requirePayloadString(t, startPayload, "mode", "foreground")
+	requirePayloadBool(t, startPayload, "background", false)
+
 	usagePayload := eventPayload(t, events[1])
-	if payloadString(usagePayload, "source") != "specialist" ||
-		payloadString(usagePayload, "childSessionId") != "child_task" ||
-		payloadString(usagePayload, "runId") != "run_1" ||
-		payloadInt(usagePayload, "promptTokens") != 12 ||
-		payloadInt(usagePayload, "completionTokens") != 5 ||
-		payloadInt(usagePayload, "totalTokens") != 17 ||
-		payloadInt(usagePayload, "usageEvents") != 1 {
-		t.Fatalf("usage payload = %#v", usagePayload)
-	}
+	requirePayloadString(t, usagePayload, "source", "specialist")
+	requirePayloadString(t, usagePayload, "childSessionId", "child_task")
+	requirePayloadString(t, usagePayload, "runId", "run_1")
+	requirePayloadInt(t, usagePayload, "promptTokens", 12)
+	requirePayloadInt(t, usagePayload, "completionTokens", 5)
+	requirePayloadInt(t, usagePayload, "totalTokens", 17)
+	requirePayloadInt(t, usagePayload, "usageEvents", 1)
+
 	stopPayload := eventPayload(t, events[2])
-	if payloadString(stopPayload, "status") != "success" ||
-		payloadInt(stopPayload, "exitCode") != 0 ||
-		!payloadBool(stopPayload, "usageRolledUp") {
-		t.Fatalf("stop payload = %#v", stopPayload)
+	requirePayloadString(t, stopPayload, "status", "success")
+	requirePayloadInt(t, stopPayload, "exitCode", 0)
+	requirePayloadBool(t, stopPayload, "usageRolledUp", true)
+}
+
+func TestExecutorRecordsStartedChildErrorExitCode(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	parent, err := store.Create(sessions.CreateInput{SessionID: "parent_session"})
+	if err != nil {
+		t.Fatalf("Create parent returned error: %v", err)
 	}
+	executor := Executor{
+		BinaryPath:   "/usr/local/bin/zero",
+		SessionStore: store,
+		NewSessionID: func() (string, error) { return "child_task", nil },
+		Load: func(LoadOptions) (LoadResult, error) {
+			return LoadResult{Specialists: []Manifest{{
+				Metadata:      Metadata{Name: "worker", Description: "Does focused work"},
+				SystemPrompt:  "Work carefully.",
+				ResolvedTools: []string{"read_file"},
+			}}}, nil
+		},
+		RunChild: func(context.Context, string, []string) (ChildRunResult, error) {
+			return ChildRunResult{ExitCode: 7, Started: true}, os.ErrPermission
+		},
+	}
+
+	_, err = executor.Run(context.Background(), TaskParameters{
+		Name:   "worker",
+		Prompt: "inspect auth",
+	}, TaskRunOptions{ParentSessionID: parent.SessionID})
+	if err == nil {
+		t.Fatal("Run returned nil error")
+	}
+
+	events, err := store.ReadEvents(parent.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	stopEvents := eventsOfType(events, sessions.EventSpecialistStop)
+	if len(stopEvents) != 1 {
+		t.Fatalf("stop events = %#v", events)
+	}
+	stopPayload := eventPayload(t, stopEvents[0])
+	requirePayloadString(t, stopPayload, "status", "error")
+	requirePayloadInt(t, stopPayload, "exitCode", 7)
 }
 
 func TestOutputToolRollsUpCompletedBackgroundUsageOnce(t *testing.T) {
@@ -145,12 +184,10 @@ func TestOutputToolRollsUpCompletedBackgroundUsageOnce(t *testing.T) {
 		t.Fatalf("stop events = %#v", events)
 	}
 	usagePayload := eventPayload(t, eventsOfType(events, sessions.EventUsage)[0])
-	if payloadString(usagePayload, "mode") != "background" ||
-		payloadInt(usagePayload, "promptTokens") != 20 ||
-		payloadInt(usagePayload, "completionTokens") != 8 ||
-		payloadInt(usagePayload, "totalTokens") != 28 {
-		t.Fatalf("background usage payload = %#v", usagePayload)
-	}
+	requirePayloadString(t, usagePayload, "mode", "background")
+	requirePayloadInt(t, usagePayload, "promptTokens", 20)
+	requirePayloadInt(t, usagePayload, "completionTokens", 8)
+	requirePayloadInt(t, usagePayload, "totalTokens", 28)
 }
 
 func ptrInt(value int) *int {
@@ -192,23 +229,52 @@ func eventPayload(t *testing.T, event sessions.Event) map[string]any {
 	return payload
 }
 
-func payloadString(payload map[string]any, key string) string {
-	value, _ := payload[key].(string)
-	return value
+func requirePayloadString(t *testing.T, payload map[string]any, key string, want string) {
+	t.Helper()
+	value, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload missing %q: %#v", key, payload)
+	}
+	got, ok := value.(string)
+	if !ok {
+		t.Fatalf("payload %q = %#v, want string %q", key, value, want)
+	}
+	if got != want {
+		t.Fatalf("payload %q = %q, want %q", key, got, want)
+	}
 }
 
-func payloadBool(payload map[string]any, key string) bool {
-	value, _ := payload[key].(bool)
-	return value
+func requirePayloadBool(t *testing.T, payload map[string]any, key string, want bool) {
+	t.Helper()
+	value, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload missing %q: %#v", key, payload)
+	}
+	got, ok := value.(bool)
+	if !ok {
+		t.Fatalf("payload %q = %#v, want bool %v", key, value, want)
+	}
+	if got != want {
+		t.Fatalf("payload %q = %v, want %v", key, got, want)
+	}
 }
 
-func payloadInt(payload map[string]any, key string) int {
-	switch value := payload[key].(type) {
+func requirePayloadInt(t *testing.T, payload map[string]any, key string, want int) {
+	t.Helper()
+	value, ok := payload[key]
+	if !ok {
+		t.Fatalf("payload missing %q: %#v", key, payload)
+	}
+	got := 0
+	switch typed := value.(type) {
 	case int:
-		return value
+		got = typed
 	case float64:
-		return int(value)
+		got = int(typed)
 	default:
-		return 0
+		t.Fatalf("payload %q = %#v, want int %d", key, value, want)
+	}
+	if got != want {
+		t.Fatalf("payload %q = %d, want %d", key, got, want)
 	}
 }

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -229,7 +229,7 @@ func (executor Executor) runFresh(ctx context.Context, params TaskParameters, op
 	if params.RunInBackground {
 		return executor.runBackground(ctx, built, manifest, params, options)
 	}
-	return executor.runBuiltArgs(ctx, built)
+	return executor.runBuiltArgs(ctx, built, manifest, params, options, "foreground")
 }
 
 func (executor Executor) runResume(ctx context.Context, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
@@ -258,7 +258,7 @@ func (executor Executor) runResume(ctx context.Context, params TaskParameters, o
 	if err != nil {
 		return ExecResult{}, err
 	}
-	return executor.runBuiltArgs(ctx, built)
+	return executor.runBuiltArgs(ctx, built, manifest, params, options, "resume")
 }
 
 func (executor Executor) runBackground(ctx context.Context, built BuildArgsResult, manifest Manifest, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
@@ -311,17 +311,35 @@ func (executor Executor) runBackground(ctx context.Context, built BuildArgsResul
 	}
 	executor.trackBackgroundPromptFile(built.SessionID, built.PromptFile)
 
+	accounting := specialistAccountingInput{
+		ParentSessionID: options.ParentSessionID,
+		ChildSessionID:  built.SessionID,
+		SpecialistName:  manifest.Metadata.Name,
+		Description:     params.Description,
+		ToolCallID:      options.ToolCallID,
+		Mode:            "background",
+		Background:      true,
+	}
+	executor.recordSpecialistStart(accounting)
 	pid, err := executor.launchBackground(binaryPath, built.Args, outputFile, func(exitCode int) {
 		status := background.StatusCompleted
 		if exitCode != 0 {
 			status = background.StatusError
 		}
 		_ = manager.MarkExited(built.SessionID, status, exitCode)
+		if task, ok := manager.Get(built.SessionID); ok {
+			summary := StreamResult{ExitCode: task.ExitCode}
+			if data, err := os.ReadFile(task.OutputFile); err == nil {
+				summary, _ = summarizeTaskData(string(data), task.ExitCode)
+			}
+			executor.recordBackgroundTaskAccounting(task, summary)
+		}
 		executor.cleanupBackgroundPromptFile(built.SessionID, built.PromptFile)
 	})
 	if err != nil {
 		_ = manager.UpdateStatus(built.SessionID, background.StatusError, -1)
 		executor.cleanupBackgroundPromptFile(built.SessionID, built.PromptFile)
+		executor.recordSpecialistStop(accounting, StreamResult{ExitCode: -1}, "error", -1, err, false)
 		return ExecResult{}, err
 	}
 	if pid > 0 {
@@ -384,7 +402,7 @@ func (executor Executor) resumeSession(sessionID string) (*sessions.Metadata, er
 	return session, nil
 }
 
-func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult) (ExecResult, error) {
+func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult, manifest Manifest, params TaskParameters, options TaskRunOptions, mode string) (ExecResult, error) {
 	if built.PromptFile != "" {
 		defer cleanupPromptFile(built.PromptFile)
 	}
@@ -392,10 +410,24 @@ func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult
 	if err != nil {
 		return ExecResult{}, err
 	}
+	accounting := specialistAccountingInput{
+		ParentSessionID: options.ParentSessionID,
+		ChildSessionID:  built.SessionID,
+		SpecialistName:  manifest.Metadata.Name,
+		Description:     params.Description,
+		ToolCallID:      options.ToolCallID,
+		Mode:            mode,
+		Background:      false,
+	}
+	executor.recordSpecialistStart(accounting)
 	run, err := executor.runChild(ctx, binaryPath, built.Args)
 	if err != nil {
+		executor.recordSpecialistStop(accounting, StreamResult{ExitCode: -1}, "error", -1, err, false)
 		return ExecResult{}, err
 	}
+	summary := SummarizeStream(run.Events, run.ExitCode)
+	rolledUp := executor.rollUpSpecialistUsage(accounting, summary)
+	executor.recordSpecialistStop(accounting, summary, summary.Status, summary.ExitCode, nil, rolledUp)
 	return ExecResult{
 		Result:    BuildFinalResult(run.Events, run.Stderr, run.ExitCode),
 		SessionID: built.SessionID,

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -101,6 +101,7 @@ type ChildRunResult struct {
 	Events   []streamjson.Event
 	Stderr   string
 	ExitCode int
+	Started  bool
 }
 
 func (executor Executor) Run(ctx context.Context, params TaskParameters, options TaskRunOptions) (ExecResult, error) {
@@ -422,7 +423,9 @@ func (executor Executor) runBuiltArgs(ctx context.Context, built BuildArgsResult
 	executor.recordSpecialistStart(accounting)
 	run, err := executor.runChild(ctx, binaryPath, built.Args)
 	if err != nil {
-		executor.recordSpecialistStop(accounting, StreamResult{ExitCode: -1}, "error", -1, err, false)
+		exitCode := run.exitCodeOr(-1)
+		summary := SummarizeStream(run.Events, exitCode)
+		executor.recordSpecialistStop(accounting, summary, "error", summary.ExitCode, err, false)
 		return ExecResult{}, err
 	}
 	summary := SummarizeStream(run.Events, run.ExitCode)
@@ -606,19 +609,30 @@ func runChildProcess(ctx context.Context, binaryPath string, args []string) (Chi
 	command.Stderr = &stderr
 
 	exitCode := 0
+	started := false
 	if err := command.Run(); err != nil {
 		var exitErr *osexec.ExitError
 		if errors.As(err, &exitErr) {
+			started = true
 			exitCode = exitErr.ExitCode()
 		} else {
-			return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode}, fmt.Errorf("run specialist child: %w", err)
+			return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode, Started: started}, fmt.Errorf("run specialist child: %w", err)
 		}
+	} else {
+		started = true
 	}
 	events, err := ParseStream(bytes.NewReader(stdout.Bytes()))
 	if err != nil {
-		return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode}, err
+		return ChildRunResult{Stderr: stderr.String(), ExitCode: exitCode, Started: started}, err
 	}
-	return ChildRunResult{Events: events, Stderr: stderr.String(), ExitCode: exitCode}, nil
+	return ChildRunResult{Events: events, Stderr: stderr.String(), ExitCode: exitCode, Started: started}, nil
+}
+
+func (run ChildRunResult) exitCodeOr(defaultExitCode int) int {
+	if run.Started || run.ExitCode != 0 {
+		return run.ExitCode
+	}
+	return defaultExitCode
 }
 
 func launchBackgroundProcess(binaryPath string, args []string, outputFile string, onExit func(exitCode int)) (int, error) {

--- a/internal/specialist/output_tool.go
+++ b/internal/specialist/output_tool.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
 )
@@ -22,6 +23,7 @@ const (
 type OutputTool struct {
 	manager        *background.Manager
 	managerFunc    BackgroundManagerFunc
+	SessionStore   *sessions.Store
 	PollInterval   time.Duration
 	DefaultTimeout time.Duration
 	MaxTimeout     time.Duration
@@ -37,8 +39,8 @@ func NewOutputTool(manager *background.Manager) *OutputTool {
 	return &OutputTool{manager: manager}
 }
 
-func newOutputToolWithManagerFunc(managerFunc BackgroundManagerFunc) *OutputTool {
-	return &OutputTool{managerFunc: managerFunc}
+func newOutputToolWithManagerFunc(managerFunc BackgroundManagerFunc, sessionStore *sessions.Store) *OutputTool {
+	return &OutputTool{managerFunc: managerFunc, SessionStore: sessionStore}
 }
 
 func (tool *OutputTool) Name() string {
@@ -142,9 +144,14 @@ func (tool *OutputTool) readOutput(task background.Task) tools.Result {
 	if err != nil {
 		return taskError(err)
 	}
+	dataString := string(data)
+	summary, rawLines := summarizeTaskData(dataString, task.ExitCode)
+	if task.Status != background.StatusRunning {
+		Executor{SessionStore: tool.SessionStore}.recordBackgroundTaskAccounting(task, summary)
+	}
 	return tools.Result{
 		Status: tools.StatusOK,
-		Output: formatTaskOutput(task, string(data)),
+		Output: formatTaskOutputSummary(task, summary, rawLines),
 		Meta: map[string]string{
 			"task_id": string(task.ID),
 			"status":  string(task.Status),
@@ -235,6 +242,11 @@ func optionalTaskInt(args map[string]any, key string) (int, error) {
 }
 
 func formatTaskOutput(task background.Task, data string) string {
+	summary, rawLines := summarizeTaskData(data, task.ExitCode)
+	return formatTaskOutputSummary(task, summary, rawLines)
+}
+
+func formatTaskOutputSummary(task background.Task, summary StreamResult, rawLines []string) string {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "task_id: %s\n", task.ID)
 	fmt.Fprintf(&builder, "status: %s\n", task.Status)
@@ -255,7 +267,6 @@ func formatTaskOutput(task background.Task, data string) string {
 		fmt.Fprintf(&builder, "exit_code: %d\n", task.ExitCode)
 	}
 
-	summary, rawLines := summarizeTaskData(data, task.ExitCode)
 	if summary.Text != "" {
 		fmt.Fprintf(&builder, "\noutput:\n%s\n", summary.Text)
 	}

--- a/internal/specialist/registry.go
+++ b/internal/specialist/registry.go
@@ -14,7 +14,7 @@ func RegisterTools(registry *tools.Registry, executor Executor) (*Runtime, error
 	toolExecutor.BackgroundRuntime = runtime
 	toolExecutor.BackgroundManagerFunc = runtime.Manager
 	registry.Register(NewTaskTool(toolExecutor))
-	registry.Register(newOutputToolWithManagerFunc(runtime.Manager))
+	registry.Register(newOutputToolWithManagerFunc(runtime.Manager, executor.SessionStore))
 	registry.Register(newStopToolWithManagerFunc(runtime.Manager))
 	registry.Register(NewGenerateTool(NewStorage(executor.Paths)))
 	return runtime, nil

--- a/internal/specialist/streamer.go
+++ b/internal/specialist/streamer.go
@@ -13,12 +13,32 @@ import (
 
 type StreamResult struct {
 	Events    []streamjson.Event
+	RunID     string
 	SessionID string
 	Text      string
 	Tools     []string
 	Errors    []string
 	Status    string
 	ExitCode  int
+	Usage     StreamUsage
+}
+
+type StreamUsage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+	Events           int
+}
+
+func (usage StreamUsage) HasUsage() bool {
+	return usage.Events > 0 || usage.PromptTokens != 0 || usage.CompletionTokens != 0 || usage.TotalTokens != 0
+}
+
+func (usage StreamUsage) EffectiveTotalTokens() int {
+	if usage.TotalTokens != 0 {
+		return usage.TotalTokens
+	}
+	return usage.PromptTokens + usage.CompletionTokens
 }
 
 func ParseStream(reader io.Reader) ([]streamjson.Event, error) {
@@ -53,6 +73,9 @@ func SummarizeStream(events []streamjson.Event, processExitCode int) StreamResul
 	finalText := ""
 	seenTools := map[string]bool{}
 	for _, event := range events {
+		if result.RunID == "" && strings.TrimSpace(event.RunID) != "" {
+			result.RunID = strings.TrimSpace(event.RunID)
+		}
 		if result.SessionID == "" && strings.TrimSpace(event.SessionID) != "" {
 			result.SessionID = strings.TrimSpace(event.SessionID)
 		}
@@ -78,6 +101,17 @@ func SummarizeStream(events []streamjson.Event, processExitCode int) StreamResul
 			result.Status = strings.TrimSpace(event.Status)
 			if event.ExitCode != nil {
 				result.ExitCode = *event.ExitCode
+			}
+		case streamjson.EventUsage:
+			result.Usage.Events++
+			if event.PromptTokens != nil {
+				result.Usage.PromptTokens += *event.PromptTokens
+			}
+			if event.CompletionTokens != nil {
+				result.Usage.CompletionTokens += *event.CompletionTokens
+			}
+			if event.TotalTokens != nil {
+				result.Usage.TotalTokens += *event.TotalTokens
 			}
 		}
 	}

--- a/internal/specialist/streamer.go
+++ b/internal/specialist/streamer.go
@@ -35,10 +35,7 @@ func (usage StreamUsage) HasUsage() bool {
 }
 
 func (usage StreamUsage) EffectiveTotalTokens() int {
-	if usage.TotalTokens != 0 {
-		return usage.TotalTokens
-	}
-	return usage.PromptTokens + usage.CompletionTokens
+	return usage.TotalTokens
 }
 
 func ParseStream(reader io.Reader) ([]streamjson.Event, error) {
@@ -104,14 +101,20 @@ func SummarizeStream(events []streamjson.Event, processExitCode int) StreamResul
 			}
 		case streamjson.EventUsage:
 			result.Usage.Events++
+			eventPromptTokens := 0
+			eventCompletionTokens := 0
 			if event.PromptTokens != nil {
-				result.Usage.PromptTokens += *event.PromptTokens
+				eventPromptTokens = *event.PromptTokens
+				result.Usage.PromptTokens += eventPromptTokens
 			}
 			if event.CompletionTokens != nil {
-				result.Usage.CompletionTokens += *event.CompletionTokens
+				eventCompletionTokens = *event.CompletionTokens
+				result.Usage.CompletionTokens += eventCompletionTokens
 			}
 			if event.TotalTokens != nil {
 				result.Usage.TotalTokens += *event.TotalTokens
+			} else {
+				result.Usage.TotalTokens += eventPromptTokens + eventCompletionTokens
 			}
 		}
 	}

--- a/internal/specialist/streamer_test.go
+++ b/internal/specialist/streamer_test.go
@@ -47,6 +47,30 @@ func TestBuildFinalResultUsesTextDeltasWhenFinalMissing(t *testing.T) {
 	}
 }
 
+func TestSummarizeStreamAccumulatesMixedUsageFormats(t *testing.T) {
+	events, err := ParseStream(strings.NewReader(strings.Join([]string{
+		`{"schemaVersion":1,"type":"usage","runId":"run_1","promptTokens":10,"completionTokens":4,"totalTokens":14}`,
+		`{"schemaVersion":1,"type":"usage","runId":"run_1","promptTokens":8,"completionTokens":3}`,
+		"",
+	}, "\n")))
+	if err != nil {
+		t.Fatalf("ParseStream returned error: %v", err)
+	}
+	summary := SummarizeStream(events, 0)
+	if summary.Usage.Events != 2 {
+		t.Fatalf("usage events = %d, want 2", summary.Usage.Events)
+	}
+	if summary.Usage.PromptTokens != 18 {
+		t.Fatalf("prompt tokens = %d, want 18", summary.Usage.PromptTokens)
+	}
+	if summary.Usage.CompletionTokens != 7 {
+		t.Fatalf("completion tokens = %d, want 7", summary.Usage.CompletionTokens)
+	}
+	if summary.Usage.EffectiveTotalTokens() != 25 {
+		t.Fatalf("effective total tokens = %d, want 25", summary.Usage.EffectiveTotalTokens())
+	}
+}
+
 func TestBuildFinalResultErrorIncludesDiagnostics(t *testing.T) {
 	events, err := ParseStream(strings.NewReader(strings.Join([]string{
 		`{"schemaVersion":1,"type":"run_start","runId":"run_1","sessionId":"child"}`,


### PR DESCRIPTION
Summary:
- records specialist_start and specialist_stop session events for foreground, resume, and background specialist runs
- rolls child stream-json usage events into a single parent provider_usage event
- makes background TaskOutput roll-up idempotent so persisted completed tasks are safe to read repeatedly

Self-review:
- this intentionally uses session events/accounting, not shell hook execution; the hooks package currently only defines configuration/audit events
- no user-facing CLI surface changes are added
- .omx/ remains untracked and is not part of this PR

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specialist
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds specialist session start/stop events and aggregates usage (token/event rollups) per run.
  * Background task accounting now records completion status, rollups once, and cleans up resources.
  * Output handling now summarizes streams with run IDs and usage summaries.

* **Bug Fixes**
  * More accurate stop status and exit-code handling for child tasks; prevents duplicate rollups.

* **Tests**
  * New tests for lifecycle, usage rollup, mixed usage formats, and background output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->