### PR TITLE
Add guarded web fetch tool

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -162,6 +162,32 @@ func TestRunAdvertisesRuntimeToolDefinitions(t *testing.T) {
 	}
 }
 
+func TestRunAdvertisesWebFetchInAutoMode(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWebFetchTool())
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{{
+			{Type: zeroruntime.StreamEventText, Content: "done"},
+			{Type: zeroruntime.StreamEventDone},
+		}},
+	}
+
+	_, err := Run(context.Background(), "what tools exist?", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAuto,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(provider.requests))
+	}
+	if len(provider.requests[0].Tools) != 1 || provider.requests[0].Tools[0].Name != "web_fetch" {
+		t.Fatalf("expected web_fetch to be advertised in auto mode, got %#v", provider.requests[0].Tools)
+	}
+}
+
 func TestRunFiltersAdvertisedTools(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -631,6 +631,7 @@ func assertCoreRegistry(t *testing.T, registry *tools.Registry) {
 		"apply_patch",
 		"update_plan",
 		"bash",
+		"web_fetch",
 	} {
 		if _, ok := registry.Get(name); !ok {
 			t.Fatalf("expected registry to include core tool %q", name)

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -31,7 +31,7 @@ func TestRunServeMCPListsReadOnlyToolsByDefault(t *testing.T) {
 			t.Fatalf("expected MCP output to contain %q, got %q", want, output)
 		}
 	}
-	for _, unwanted := range []string{"write_file", "apply_patch", "bash"} {
+	for _, unwanted := range []string{"write_file", "apply_patch", "bash", "web_fetch"} {
 		if strings.Contains(output, unwanted) {
 			t.Fatalf("did not expect default MCP output to contain %q: %q", unwanted, output)
 		}
@@ -53,7 +53,7 @@ func TestRunServeMCPAllowsUnsafeToolsWithExplicitFlag(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d; stderr=%q", exitCode, stderr.String())
 	}
 	output := stdout.String()
-	for _, want := range []string{"read_file", "write_file", "apply_patch", "bash"} {
+	for _, want := range []string{"read_file", "write_file", "apply_patch", "bash", "web_fetch"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected unsafe MCP output to contain %q, got %q", want, output)
 		}

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -208,6 +208,29 @@ func TestEngineClassifiesNetworkAndDestructiveShellCommands(t *testing.T) {
 	}
 }
 
+func TestEngineDeniesNetworkSideEffectWhenPolicyBlocksNetwork(t *testing.T) {
+	engine := NewEngine(EngineOptions{WorkspaceRoot: t.TempDir(), Policy: DefaultPolicy()})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "web_fetch",
+		SideEffect:     SideEffectNetwork,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionUnsafe,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"url": "https://example.com"},
+	})
+
+	if decision.Action != ActionDeny || decision.Violation == nil {
+		t.Fatalf("network tool decision = %#v, want deny violation", decision)
+	}
+	if decision.Violation.Code != ViolationNetwork {
+		t.Fatalf("violation code = %q, want %q", decision.Violation.Code, ViolationNetwork)
+	}
+	if decision.Risk.Level != RiskHigh {
+		t.Fatalf("risk level = %q, want %q", decision.Risk.Level, RiskHigh)
+	}
+}
+
 func TestEngineReportsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -108,6 +108,7 @@ var knownToolNames = map[string]bool{
 	"apply_patch":    true,
 	"update_plan":    true,
 	"bash":           true,
+	"web_fetch":      true,
 }
 
 func DefaultPaths(workspaceRoot string) (Paths, error) {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -159,9 +159,16 @@ func CoreShellTools(workspaceRoot string) []Tool {
 	}
 }
 
+func CoreNetworkTools() []Tool {
+	return []Tool{
+		NewWebFetchTool(),
+	}
+}
+
 func CoreTools(workspaceRoot string) []Tool {
 	tools := append([]Tool{}, CoreReadOnlyTools(workspaceRoot)...)
 	tools = append(tools, CoreWriteTools(workspaceRoot)...)
 	tools = append(tools, CoreShellTools(workspaceRoot)...)
+	tools = append(tools, CoreNetworkTools()...)
 	return tools
 }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -60,8 +60,16 @@ func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
 	if safety.SideEffect != SideEffectNetwork || safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
 		t.Fatalf("unexpected web_fetch safety metadata: %#v", safety)
 	}
-	if tool.Parameters().Properties["url"].Type != "string" {
-		t.Fatalf("expected web_fetch url schema, got %#v", tool.Parameters())
+	schema := tool.Parameters()
+	if schema.Properties == nil {
+		t.Fatal("web_fetch schema properties are nil")
+	}
+	urlProperty, ok := schema.Properties["url"]
+	if !ok {
+		t.Fatal("web_fetch schema missing url property")
+	}
+	if urlProperty.Type != "string" {
+		t.Fatalf("web_fetch url type = %s, want string", urlProperty.Type)
 	}
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -46,6 +46,45 @@ func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	}
 }
 
+func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
+	toolset := CoreNetworkTools()
+	if len(toolset) != 1 {
+		t.Fatalf("expected 1 core network tool, got %d", len(toolset))
+	}
+
+	tool := toolset[0]
+	if tool.Name() != "web_fetch" {
+		t.Fatalf("expected web_fetch network tool, got %q", tool.Name())
+	}
+	safety := tool.Safety()
+	if safety.SideEffect != SideEffectNetwork || safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
+		t.Fatalf("unexpected web_fetch safety metadata: %#v", safety)
+	}
+	if tool.Parameters().Properties["url"].Type != "string" {
+		t.Fatalf("expected web_fetch url schema, got %#v", tool.Parameters())
+	}
+}
+
+func TestCoreToolsIncludeWebFetchButReadOnlyToolsDoNot(t *testing.T) {
+	readOnly := CoreReadOnlyTools(t.TempDir())
+	for _, tool := range readOnly {
+		if tool.Name() == "web_fetch" {
+			t.Fatal("web_fetch should not be exposed by read-only core tools")
+		}
+	}
+
+	found := false
+	for _, tool := range CoreTools(t.TempDir()) {
+		if tool.Name() == "web_fetch" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected CoreTools to include web_fetch")
+	}
+}
+
 func TestRegistryRunsToolsThroughSafePath(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(NewReadFileTool(t.TempDir()))
@@ -59,6 +98,22 @@ func TestRegistryRunsToolsThroughSafePath(t *testing.T) {
 	}
 	if result.Output == "" {
 		t.Fatalf("expected an error output")
+	}
+}
+
+func TestRegistryRequiresPermissionForWebFetch(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(NewWebFetchTool())
+
+	result := registry.Run(context.Background(), "web_fetch", map[string]any{
+		"url": "https://example.com",
+	})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected permission error status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Output, "Permission required for web_fetch") {
+		t.Fatalf("unexpected permission output: %q", result.Output)
 	}
 }
 

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -1,0 +1,331 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+const (
+	defaultWebFetchMaxBytes = 64 * 1024
+	maxWebFetchMaxBytes     = 512 * 1024
+	webFetchTimeout         = 10 * time.Second
+	webFetchRedirectLimit   = 5
+	webFetchErrorBodyLimit  = 4 * 1024
+)
+
+type webFetchTool struct {
+	baseTool
+	client   *http.Client
+	resolver webFetchResolver
+}
+
+type webFetchResolver interface {
+	LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error)
+}
+
+type defaultWebFetchResolver struct{}
+
+func (defaultWebFetchResolver) LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error) {
+	return net.DefaultResolver.LookupNetIP(ctx, network, host)
+}
+
+func NewWebFetchTool() Tool {
+	return newWebFetchToolWithClientAndResolver(nil, defaultWebFetchResolver{})
+}
+
+func newWebFetchToolWithClient(client *http.Client) Tool {
+	return newWebFetchToolWithClientAndResolver(client, nil)
+}
+
+func newWebFetchToolWithClientAndResolver(client *http.Client, resolver webFetchResolver) Tool {
+	if client == nil {
+		client = &http.Client{Timeout: webFetchTimeout}
+	}
+	return webFetchTool{
+		baseTool: baseTool{
+			name:        "web_fetch",
+			description: "Fetch text from an http or https URL after network permission is granted.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"url": {
+						Type:        "string",
+						Description: "HTTP or HTTPS URL to fetch.",
+					},
+					"max_bytes": {
+						Type:        "integer",
+						Description: "Maximum response body bytes to return.",
+						Default:     defaultWebFetchMaxBytes,
+						Minimum:     intPtr(1),
+						Maximum:     intPtr(maxWebFetchMaxBytes),
+					},
+				},
+				Required:             []string{"url"},
+				AdditionalProperties: false,
+			},
+			safety: Safety{
+				SideEffect:      SideEffectNetwork,
+				Permission:      PermissionPrompt,
+				Reason:          "Fetches remote URL content over the network.",
+				AdvertiseInAuto: true,
+			},
+		},
+		client:   client,
+		resolver: resolver,
+	}
+}
+
+func (tool webFetchTool) Run(ctx context.Context, args map[string]any) Result {
+	rawURL, err := stringArg(args, "url", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for web_fetch: " + err.Error())
+	}
+	maxBytes, err := intArg(args, "max_bytes", defaultWebFetchMaxBytes, 1, maxWebFetchMaxBytes)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for web_fetch: " + err.Error())
+	}
+
+	parsedURL, err := validateWebFetchURL(ctx, rawURL, tool.resolver)
+	if err != nil {
+		return errorResult("Error: Unsafe URL for web_fetch: " + err.Error())
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return errorResult("Error: Invalid URL for web_fetch: " + err.Error())
+	}
+	request.Header.Set("User-Agent", "zero-web-fetch/0.1")
+	request.Header.Set("Accept", "text/*, application/json, application/xhtml+xml, application/xml;q=0.9, */*;q=0.5")
+
+	client := tool.clientForRun()
+	response, err := client.Do(request)
+	if err != nil {
+		return errorResult("Error fetching URL: " + redactWebFetchText(err.Error()))
+	}
+	if response.Body == nil {
+		response.Body = io.NopCloser(strings.NewReader(""))
+	}
+	defer response.Body.Close()
+
+	finalURL := redactWebFetchURL(parsedURL)
+	if response.Request != nil && response.Request.URL != nil {
+		finalURL = redactWebFetchURL(response.Request.URL)
+	}
+	contentType := response.Header.Get("Content-Type")
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		body, _, _ := readWebFetchBody(response.Body, min(maxBytes, webFetchErrorBodyLimit))
+		message := fmt.Sprintf("Error fetching URL: HTTP %s", webFetchStatusLine(response))
+		if strings.TrimSpace(body) != "" {
+			message += "\n\n" + redactWebFetchText(body)
+		}
+		return Result{
+			Status: StatusError,
+			Output: message,
+			Meta: map[string]string{
+				"url":          finalURL,
+				"status_code":  strconv.Itoa(response.StatusCode),
+				"content_type": contentType,
+			},
+		}
+	}
+
+	body, truncated, err := readWebFetchBody(response.Body, maxBytes)
+	if err != nil {
+		return errorResult("Error reading response body: " + redactWebFetchText(err.Error()))
+	}
+	body = redactWebFetchText(body)
+
+	output := strings.Join([]string{
+		"URL: " + finalURL,
+		"Status: " + webFetchStatusLine(response),
+		"Content-Type: " + firstNonEmptyString(contentType, "unknown"),
+		"Bytes: " + strconv.Itoa(len(body)),
+		"",
+		body,
+	}, "\n")
+
+	return Result{
+		Status:    StatusOK,
+		Output:    output,
+		Truncated: truncated,
+		Meta: map[string]string{
+			"url":          finalURL,
+			"status_code":  strconv.Itoa(response.StatusCode),
+			"content_type": contentType,
+			"bytes":        strconv.Itoa(len(body)),
+			"truncated":    strconv.FormatBool(truncated),
+		},
+	}
+}
+
+func (tool webFetchTool) clientForRun() http.Client {
+	if tool.client == nil {
+		return http.Client{Timeout: webFetchTimeout, CheckRedirect: webFetchRedirectPolicy(nil, tool.resolver)}
+	}
+	client := *tool.client
+	client.CheckRedirect = webFetchRedirectPolicy(tool.client.CheckRedirect, tool.resolver)
+	return client
+}
+
+func webFetchRedirectPolicy(previous func(*http.Request, []*http.Request) error, resolver webFetchResolver) func(*http.Request, []*http.Request) error {
+	return func(request *http.Request, via []*http.Request) error {
+		if len(via) >= webFetchRedirectLimit {
+			return fmt.Errorf("too many redirects: maximum is %d", webFetchRedirectLimit)
+		}
+		if err := validateParsedWebFetchURL(request.Context(), request.URL, resolver); err != nil {
+			return fmt.Errorf("Unsafe redirect URL: %w", err)
+		}
+		if previous != nil {
+			return previous(request, via)
+		}
+		return nil
+	}
+}
+
+func readWebFetchBody(body io.Reader, maxBytes int) (string, bool, error) {
+	raw, err := io.ReadAll(io.LimitReader(body, int64(maxBytes)+1))
+	if err != nil {
+		return "", false, err
+	}
+	truncated := len(raw) > maxBytes
+	if truncated {
+		raw = raw[:maxBytes]
+	}
+	return string(raw), truncated, nil
+}
+
+func validateWebFetchURL(ctx context.Context, rawURL string, resolver webFetchResolver) (*url.URL, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return nil, fmt.Errorf("url is required")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateParsedWebFetchURL(ctx, parsed, resolver); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func validateParsedWebFetchURL(ctx context.Context, parsed *url.URL, resolver webFetchResolver) error {
+	if parsed == nil {
+		return fmt.Errorf("url is required")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("only http and https URLs are supported")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("URLs with user info are not allowed")
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("URL host is required")
+	}
+	if strings.Contains(host, "%") {
+		return fmt.Errorf("URL host zones are not allowed")
+	}
+	if err := rejectUnsafeWebFetchHost(ctx, host, resolver); err != nil {
+		return err
+	}
+	return nil
+}
+
+func rejectUnsafeWebFetchHost(ctx context.Context, host string, resolver webFetchResolver) error {
+	normalized := strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
+	if normalized == "" {
+		return fmt.Errorf("URL host is required")
+	}
+	switch {
+	case normalized == "localhost" || strings.HasSuffix(normalized, ".localhost"):
+		return fmt.Errorf("localhost hosts are blocked")
+	case normalized == "metadata" || normalized == "metadata.google.internal":
+		return fmt.Errorf("metadata service hosts are blocked")
+	case strings.HasSuffix(normalized, ".local"):
+		return fmt.Errorf("local network hosts are blocked")
+	}
+
+	addr, err := netip.ParseAddr(normalized)
+	if err == nil {
+		return rejectUnsafeWebFetchAddr(addr)
+	}
+	if resolver == nil {
+		return nil
+	}
+
+	addrs, err := resolver.LookupNetIP(ctx, "ip", normalized)
+	if err != nil {
+		return fmt.Errorf("resolve host: %w", err)
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("host did not resolve to an IP address")
+	}
+	for _, addr := range addrs {
+		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectUnsafeWebFetchAddr(addr netip.Addr) error {
+	if !addr.IsValid() {
+		return fmt.Errorf("invalid resolved host address")
+	}
+	addr = addr.Unmap()
+	switch {
+	case addr.IsLoopback():
+		return fmt.Errorf("loopback hosts are blocked")
+	case addr.IsPrivate():
+		return fmt.Errorf("private network hosts are blocked")
+	case addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast():
+		return fmt.Errorf("link-local hosts are blocked")
+	case addr.IsMulticast():
+		return fmt.Errorf("multicast hosts are blocked")
+	case addr.IsUnspecified():
+		return fmt.Errorf("unspecified hosts are blocked")
+	}
+	return nil
+}
+
+func redactWebFetchURL(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	return redactWebFetchText(value.String())
+}
+
+func redactWebFetchText(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
+}
+
+func webFetchStatusLine(response *http.Response) string {
+	if response == nil {
+		return ""
+	}
+	if strings.TrimSpace(response.Status) != "" {
+		return response.Status
+	}
+	return strings.TrimSpace(strconv.Itoa(response.StatusCode) + " " + http.StatusText(response.StatusCode))
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -41,6 +42,50 @@ type defaultWebFetchResolver struct{}
 
 func (defaultWebFetchResolver) LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error) {
 	return net.DefaultResolver.LookupNetIP(ctx, network, host)
+}
+
+type webFetchBlockedPrefix struct {
+	prefix netip.Prefix
+	reason string
+}
+
+type webFetchEmbeddedIPv4Prefix struct {
+	prefix     netip.Prefix
+	byteOffset int
+}
+
+var webFetchBlockedAddrPrefixes = []webFetchBlockedPrefix{
+	{prefix: netip.MustParsePrefix("0.0.0.0/8"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("10.0.0.0/8"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("100.64.0.0/10"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("127.0.0.0/8"), reason: "loopback hosts are blocked"},
+	{prefix: netip.MustParsePrefix("169.254.0.0/16"), reason: "link-local hosts are blocked"},
+	{prefix: netip.MustParsePrefix("172.16.0.0/12"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.0.0.0/24"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.0.2.0/24"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.88.99.0/24"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.168.0.0/16"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("198.18.0.0/15"), reason: "benchmark network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("198.51.100.0/24"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("203.0.113.0/24"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("224.0.0.0/4"), reason: "multicast hosts are blocked"},
+	{prefix: netip.MustParsePrefix("240.0.0.0/4"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("::/128"), reason: "unspecified hosts are blocked"},
+	{prefix: netip.MustParsePrefix("::1/128"), reason: "loopback hosts are blocked"},
+	{prefix: netip.MustParsePrefix("100::/64"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("2001::/23"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("2001:2::/48"), reason: "benchmark network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("2001:db8::/32"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("fc00::/7"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("fe80::/10"), reason: "link-local hosts are blocked"},
+	{prefix: netip.MustParsePrefix("ff00::/8"), reason: "multicast hosts are blocked"},
+}
+
+var webFetchEmbeddedIPv4Prefixes = []webFetchEmbeddedIPv4Prefix{
+	{prefix: netip.MustParsePrefix("::/96"), byteOffset: 12},
+	{prefix: netip.MustParsePrefix("64:ff9b::/96"), byteOffset: 12},
+	{prefix: netip.MustParsePrefix("64:ff9b:1::/48"), byteOffset: 6},
+	{prefix: netip.MustParsePrefix("2002::/16"), byteOffset: 2},
 }
 
 func NewWebFetchTool() Tool {
@@ -125,7 +170,7 @@ func (tool webFetchTool) Run(ctx context.Context, args map[string]any) Result {
 	if response.Request != nil && response.Request.URL != nil {
 		finalURL = redactWebFetchURL(response.Request.URL)
 	}
-	contentType := response.Header.Get("Content-Type")
+	contentType := redactWebFetchText(response.Header.Get("Content-Type"))
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		body, _, _ := readWebFetchBody(response.Body, min(maxBytes, webFetchErrorBodyLimit))
 		message := fmt.Sprintf("Error fetching URL: HTTP %s", webFetchStatusLine(response))
@@ -289,10 +334,31 @@ func validateParsedWebFetchURL(ctx context.Context, parsed *url.URL, resolver we
 	if strings.Contains(host, "%") {
 		return fmt.Errorf("URL host zones are not allowed")
 	}
+	if err := validateWebFetchPort(parsed); err != nil {
+		return err
+	}
 	if err := rejectUnsafeWebFetchHost(ctx, host, resolver); err != nil {
 		return err
 	}
 	return nil
+}
+
+func validateWebFetchPort(parsed *url.URL) error {
+	port := parsed.Port()
+	if port == "" {
+		return nil
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http":
+		if port == "80" {
+			return nil
+		}
+	case "https":
+		if port == "443" {
+			return nil
+		}
+	}
+	return fmt.Errorf("only default ports are allowed for %s URLs", parsed.Scheme)
 }
 
 func rejectUnsafeWebFetchHost(ctx context.Context, host string, resolver webFetchResolver) error {
@@ -348,19 +414,41 @@ func rejectUnsafeWebFetchAddr(addr netip.Addr) error {
 		return fmt.Errorf("invalid resolved host address")
 	}
 	addr = addr.Unmap()
-	switch {
-	case addr.IsLoopback():
-		return fmt.Errorf("loopback hosts are blocked")
-	case addr.IsPrivate():
-		return fmt.Errorf("private network hosts are blocked")
-	case addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast():
-		return fmt.Errorf("link-local hosts are blocked")
-	case addr.IsMulticast():
-		return fmt.Errorf("multicast hosts are blocked")
-	case addr.IsUnspecified():
-		return fmt.Errorf("unspecified hosts are blocked")
+	if embedded, ok := webFetchEmbeddedIPv4(addr); ok {
+		return rejectUnsafeWebFetchAddr(embedded)
+	}
+	for _, blocked := range webFetchBlockedAddrPrefixes {
+		if blocked.prefix.Contains(addr) {
+			return errors.New(blocked.reason)
+		}
+	}
+	if !addr.IsGlobalUnicast() {
+		return fmt.Errorf("non-global hosts are blocked")
 	}
 	return nil
+}
+
+func webFetchEmbeddedIPv4(addr netip.Addr) (netip.Addr, bool) {
+	if addr.Is4() {
+		return netip.Addr{}, false
+	}
+	bytes := addr.As16()
+	for _, candidate := range webFetchEmbeddedIPv4Prefixes {
+		if !candidate.prefix.Contains(addr) {
+			continue
+		}
+		if candidate.byteOffset < 0 || candidate.byteOffset+4 > len(bytes) {
+			continue
+		}
+		embedded := [4]byte{
+			bytes[candidate.byteOffset],
+			bytes[candidate.byteOffset+1],
+			bytes[candidate.byteOffset+2],
+			bytes[candidate.byteOffset+3],
+		}
+		return netip.AddrFrom4(embedded), true
+	}
+	return netip.Addr{}, false
 }
 
 func redactWebFetchURL(value *url.URL) string {

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -33,6 +33,10 @@ type webFetchResolver interface {
 	LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error)
 }
 
+type webFetchDialer interface {
+	DialContext(ctx context.Context, network string, address string) (net.Conn, error)
+}
+
 type defaultWebFetchResolver struct{}
 
 func (defaultWebFetchResolver) LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error) {
@@ -170,11 +174,59 @@ func (tool webFetchTool) Run(ctx context.Context, args map[string]any) Result {
 
 func (tool webFetchTool) clientForRun() http.Client {
 	if tool.client == nil {
-		return http.Client{Timeout: webFetchTimeout, CheckRedirect: webFetchRedirectPolicy(nil, tool.resolver)}
+		return http.Client{
+			Timeout:       webFetchTimeout,
+			Transport:     webFetchSafeTransport(nil, tool.resolver),
+			CheckRedirect: webFetchRedirectPolicy(nil, tool.resolver),
+		}
 	}
 	client := *tool.client
+	client.Transport = webFetchSafeTransport(client.Transport, tool.resolver)
 	client.CheckRedirect = webFetchRedirectPolicy(tool.client.CheckRedirect, tool.resolver)
 	return client
+}
+
+func webFetchSafeTransport(roundTripper http.RoundTripper, resolver webFetchResolver) http.RoundTripper {
+	var transport *http.Transport
+	switch typed := roundTripper.(type) {
+	case nil:
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	case *http.Transport:
+		transport = typed.Clone()
+	default:
+		return roundTripper
+	}
+
+	dialer := &net.Dialer{Timeout: webFetchTimeout, KeepAlive: 30 * time.Second}
+	transport.Proxy = nil
+	transport.DialContext = webFetchSafeDialContext(resolver, dialer)
+	transport.DialTLSContext = nil
+	return transport
+}
+
+func webFetchSafeDialContext(resolver webFetchResolver, dialer webFetchDialer) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network string, address string) (net.Conn, error) {
+		pinnedAddress, err := webFetchSafeDialAddress(ctx, resolver, address)
+		if err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, network, pinnedAddress)
+	}
+}
+
+func webFetchSafeDialAddress(ctx context.Context, resolver webFetchResolver, address string) (string, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", fmt.Errorf("validate dial target: %w", err)
+	}
+	addrs, err := resolveWebFetchHostAddrs(ctx, host, firstWebFetchResolver(resolver), true)
+	if err != nil {
+		return "", err
+	}
+	if len(addrs) == 0 {
+		return "", fmt.Errorf("host did not resolve to an IP address")
+	}
+	return net.JoinHostPort(addrs[0].String(), port), nil
 }
 
 func webFetchRedirectPolicy(previous func(*http.Request, []*http.Request) error, resolver webFetchResolver) func(*http.Request, []*http.Request) error {
@@ -244,40 +296,51 @@ func validateParsedWebFetchURL(ctx context.Context, parsed *url.URL, resolver we
 }
 
 func rejectUnsafeWebFetchHost(ctx context.Context, host string, resolver webFetchResolver) error {
+	_, err := resolveWebFetchHostAddrs(ctx, host, resolver, false)
+	return err
+}
+
+func resolveWebFetchHostAddrs(ctx context.Context, host string, resolver webFetchResolver, requireResolver bool) ([]netip.Addr, error) {
 	normalized := strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
 	if normalized == "" {
-		return fmt.Errorf("URL host is required")
+		return nil, fmt.Errorf("URL host is required")
 	}
 	switch {
 	case normalized == "localhost" || strings.HasSuffix(normalized, ".localhost"):
-		return fmt.Errorf("localhost hosts are blocked")
+		return nil, fmt.Errorf("localhost hosts are blocked")
 	case normalized == "metadata" || normalized == "metadata.google.internal":
-		return fmt.Errorf("metadata service hosts are blocked")
+		return nil, fmt.Errorf("metadata service hosts are blocked")
 	case strings.HasSuffix(normalized, ".local"):
-		return fmt.Errorf("local network hosts are blocked")
+		return nil, fmt.Errorf("local network hosts are blocked")
 	}
 
 	addr, err := netip.ParseAddr(normalized)
 	if err == nil {
-		return rejectUnsafeWebFetchAddr(addr)
+		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
+			return nil, err
+		}
+		return []netip.Addr{addr.Unmap()}, nil
 	}
 	if resolver == nil {
-		return nil
+		if requireResolver {
+			return nil, fmt.Errorf("host resolver is required")
+		}
+		return nil, nil
 	}
 
 	addrs, err := resolver.LookupNetIP(ctx, "ip", normalized)
 	if err != nil {
-		return fmt.Errorf("resolve host: %w", err)
+		return nil, fmt.Errorf("resolve host: %w", err)
 	}
 	if len(addrs) == 0 {
-		return fmt.Errorf("host did not resolve to an IP address")
+		return nil, fmt.Errorf("host did not resolve to an IP address")
 	}
 	for _, addr := range addrs {
 		if err := rejectUnsafeWebFetchAddr(addr); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return addrs, nil
 }
 
 func rejectUnsafeWebFetchAddr(addr netip.Addr) error {
@@ -328,4 +391,11 @@ func firstNonEmptyString(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstWebFetchResolver(resolver webFetchResolver) webFetchResolver {
+	if resolver != nil {
+		return resolver
+	}
+	return defaultWebFetchResolver{}
 }

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -127,6 +127,14 @@ func TestWebFetchToolRejectsUnsafeURLsBeforeNetwork(t *testing.T) {
 		"http://127.0.0.1/admin",
 		"http://localhost/status",
 		"http://169.254.169.254/latest/meta-data",
+		"http://100.64.0.1/internal",
+		"http://0.1.2.3/internal",
+		"http://255.255.255.255/internal",
+		"http://[64:ff9b::7f00:1]/internal",
+		"http://[64:ff9b::a9fe:a9fe]/latest/meta-data",
+		"http://[64:ff9b:1:7f00:1::]/internal",
+		"http://[2002:7f00:1::]/internal",
+		"http://[::7f00:1]/internal",
 		"http://user:pass@example.com/private",
 	} {
 		t.Run(rawURL, func(t *testing.T) {
@@ -136,6 +144,29 @@ func TestWebFetchToolRejectsUnsafeURLsBeforeNetwork(t *testing.T) {
 			}
 			if !strings.Contains(result.Output, "Unsafe URL") {
 				t.Fatalf("expected unsafe URL message, got %q", result.Output)
+			}
+		})
+	}
+}
+
+func TestWebFetchToolRejectsNonDefaultPorts(t *testing.T) {
+	tool := newWebFetchToolWithClient(webFetchTestClient(func(*http.Request) (*http.Response, error) {
+		t.Fatal("non-default port should be rejected before network transport")
+		return nil, nil
+	}))
+
+	for _, rawURL := range []string{
+		"http://example.com:22/",
+		"https://example.com:80/",
+		"https://example.com:6379/",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			result := tool.Run(context.Background(), map[string]any{"url": rawURL})
+			if result.Status != StatusError {
+				t.Fatalf("expected unsafe URL error, got %s: %s", result.Status, result.Output)
+			}
+			if !strings.Contains(result.Output, "default port") {
+				t.Fatalf("expected default-port message, got %q", result.Output)
 			}
 		})
 	}
@@ -217,7 +248,7 @@ func TestWebFetchSafeDialPinsResolvedPublicAddress(t *testing.T) {
 			if network != "ip" || host != "public.example" {
 				t.Fatalf("unexpected lookup network=%q host=%q", network, host)
 			}
-			return []netip.Addr{netip.MustParseAddr("203.0.113.10")}, nil
+			return []netip.Addr{netip.MustParseAddr("8.8.8.8")}, nil
 		}),
 		webFetchDialFunc(func(_ context.Context, _ string, address string) (net.Conn, error) {
 			dialedAddress = address
@@ -230,25 +261,50 @@ func TestWebFetchSafeDialPinsResolvedPublicAddress(t *testing.T) {
 	if !errors.Is(err, stop) {
 		t.Fatalf("expected captured dial error, got %v", err)
 	}
-	if dialedAddress != "203.0.113.10:443" {
+	if dialedAddress != "8.8.8.8:443" {
 		t.Fatalf("dialed address = %q, want resolved IP address", dialedAddress)
 	}
 }
 
 func TestWebFetchToolRejectsUnsafeRedirects(t *testing.T) {
+	for _, location := range []string{
+		"http://127.0.0.1/private",
+		"http://100.64.0.1/internal",
+	} {
+		t.Run(location, func(t *testing.T) {
+			tool := newWebFetchToolWithClient(webFetchTestClient(func(request *http.Request) (*http.Response, error) {
+				response := webFetchTestResponse(request, http.StatusFound, "text/plain", "redirect")
+				response.Header.Set("Location", location)
+				return response, nil
+			}))
+
+			result := tool.Run(context.Background(), map[string]any{"url": "https://example.com/start"})
+
+			if result.Status != StatusError {
+				t.Fatalf("expected redirect safety error, got %s: %s", result.Status, result.Output)
+			}
+			if !strings.Contains(result.Output, "Unsafe redirect URL") {
+				t.Fatalf("expected unsafe redirect message, got %q", result.Output)
+			}
+		})
+	}
+}
+
+func TestWebFetchToolRedactsContentType(t *testing.T) {
 	tool := newWebFetchToolWithClient(webFetchTestClient(func(request *http.Request) (*http.Response, error) {
-		response := webFetchTestResponse(request, http.StatusFound, "text/plain", "redirect")
-		response.Header.Set("Location", "http://127.0.0.1/private")
-		return response, nil
+		return webFetchTestResponse(request, http.StatusOK, "text/plain; token=secret-token", "hello"), nil
 	}))
 
-	result := tool.Run(context.Background(), map[string]any{"url": "https://example.com/start"})
+	result := tool.Run(context.Background(), map[string]any{"url": "https://example.com/redact"})
 
-	if result.Status != StatusError {
-		t.Fatalf("expected redirect safety error, got %s: %s", result.Status, result.Output)
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
 	}
-	if !strings.Contains(result.Output, "Unsafe redirect URL") {
-		t.Fatalf("expected unsafe redirect message, got %q", result.Output)
+	if strings.Contains(result.Output, "secret-token") || strings.Contains(result.Meta["content_type"], "secret-token") {
+		t.Fatalf("expected content type to be redacted, output=%q meta=%#v", result.Output, result.Meta)
+	}
+	if !strings.Contains(result.Output, "token=[REDACTED]") || !strings.Contains(result.Meta["content_type"], "token=[REDACTED]") {
+		t.Fatalf("expected redacted token in content type, output=%q meta=%#v", result.Output, result.Meta)
 	}
 }
 

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -2,7 +2,9 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/netip"
 	"strconv"
@@ -20,6 +22,12 @@ type webFetchResolverFunc func(context.Context, string, string) ([]netip.Addr, e
 
 func (fn webFetchResolverFunc) LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error) {
 	return fn(ctx, network, host)
+}
+
+type webFetchDialFunc func(context.Context, string, string) (net.Conn, error)
+
+func (fn webFetchDialFunc) DialContext(ctx context.Context, network string, address string) (net.Conn, error) {
+	return fn(ctx, network, address)
 }
 
 func TestWebFetchToolSafetyAndSchema(t *testing.T) {
@@ -154,6 +162,76 @@ func TestWebFetchToolRejectsHostnamesResolvingToPrivateAddresses(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "private network hosts are blocked") {
 		t.Fatalf("expected private host message, got %q", result.Output)
+	}
+}
+
+func TestWebFetchToolConfiguresDialTimeSafetyForDefaultTransport(t *testing.T) {
+	tool, ok := NewWebFetchTool().(webFetchTool)
+	if !ok {
+		t.Fatalf("NewWebFetchTool returned %T, want webFetchTool", NewWebFetchTool())
+	}
+
+	client := tool.clientForRun()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport = %T, want *http.Transport", client.Transport)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected web_fetch transport to install a safe DialContext")
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected web_fetch transport to disable proxy resolution")
+	}
+}
+
+func TestWebFetchSafeDialRejectsPrivateRebindAddress(t *testing.T) {
+	dialCalled := false
+	dial := webFetchSafeDialContext(
+		webFetchResolverFunc(func(_ context.Context, network string, host string) ([]netip.Addr, error) {
+			if network != "ip" || host != "rebind.example" {
+				t.Fatalf("unexpected lookup network=%q host=%q", network, host)
+			}
+			return []netip.Addr{netip.MustParseAddr("127.0.0.1")}, nil
+		}),
+		webFetchDialFunc(func(context.Context, string, string) (net.Conn, error) {
+			dialCalled = true
+			return nil, errors.New("dial should not run")
+		}),
+	)
+
+	_, err := dial(context.Background(), "tcp", "rebind.example:443")
+
+	if err == nil || !strings.Contains(err.Error(), "loopback hosts are blocked") {
+		t.Fatalf("expected loopback rejection, got %v", err)
+	}
+	if dialCalled {
+		t.Fatal("dialer was called after unsafe DNS result")
+	}
+}
+
+func TestWebFetchSafeDialPinsResolvedPublicAddress(t *testing.T) {
+	var dialedAddress string
+	stop := errors.New("stop after address capture")
+	dial := webFetchSafeDialContext(
+		webFetchResolverFunc(func(_ context.Context, network string, host string) ([]netip.Addr, error) {
+			if network != "ip" || host != "public.example" {
+				t.Fatalf("unexpected lookup network=%q host=%q", network, host)
+			}
+			return []netip.Addr{netip.MustParseAddr("203.0.113.10")}, nil
+		}),
+		webFetchDialFunc(func(_ context.Context, _ string, address string) (net.Conn, error) {
+			dialedAddress = address
+			return nil, stop
+		}),
+	)
+
+	_, err := dial(context.Background(), "tcp", "public.example:443")
+
+	if !errors.Is(err, stop) {
+		t.Fatalf("expected captured dial error, got %v", err)
+	}
+	if dialedAddress != "203.0.113.10:443" {
+		t.Fatalf("dialed address = %q, want resolved IP address", dialedAddress)
 	}
 }
 

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -1,0 +1,212 @@
+package tools
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/netip"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+type webFetchResolverFunc func(context.Context, string, string) ([]netip.Addr, error)
+
+func (fn webFetchResolverFunc) LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error) {
+	return fn(ctx, network, host)
+}
+
+func TestWebFetchToolSafetyAndSchema(t *testing.T) {
+	tool := NewWebFetchTool()
+
+	if tool.Name() != "web_fetch" {
+		t.Fatalf("Name = %q, want web_fetch", tool.Name())
+	}
+	if tool.Description() == "" {
+		t.Fatal("Description is empty")
+	}
+	safety := tool.Safety()
+	if safety.SideEffect != SideEffectNetwork || safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
+		t.Fatalf("unexpected safety metadata: %#v", safety)
+	}
+	if safety.Reason == "" {
+		t.Fatal("Safety reason is empty")
+	}
+
+	schema := tool.Parameters()
+	if schema.Type != "object" || schema.AdditionalProperties {
+		t.Fatalf("unexpected schema envelope: %#v", schema)
+	}
+	if len(schema.Required) != 1 || schema.Required[0] != "url" {
+		t.Fatalf("required fields = %#v, want url only", schema.Required)
+	}
+	if schema.Properties["url"].Type != "string" {
+		t.Fatalf("url schema = %#v, want string", schema.Properties["url"])
+	}
+	maxBytes := schema.Properties["max_bytes"]
+	if maxBytes.Type != "integer" || maxBytes.Minimum == nil || *maxBytes.Minimum != 1 || maxBytes.Maximum == nil {
+		t.Fatalf("max_bytes schema = %#v, want bounded integer", maxBytes)
+	}
+}
+
+func TestWebFetchToolFetchesHTTPText(t *testing.T) {
+	tool := newWebFetchToolWithClient(webFetchTestClient(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", request.Method)
+		}
+		if request.Header.Get("User-Agent") == "" {
+			t.Fatal("expected User-Agent header")
+		}
+		return webFetchTestResponse(request, http.StatusOK, "text/plain; charset=utf-8", "hello zero"), nil
+	}))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"url": "https://example.com/guide?token=secret-token",
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	for _, want := range []string{"URL: https://example.com/guide?token=[REDACTED]", "Status: 200 OK", "Content-Type: text/plain; charset=utf-8", "hello zero"} {
+		if !strings.Contains(result.Output, want) {
+			t.Fatalf("expected output to contain %q, got %q", want, result.Output)
+		}
+	}
+	if strings.Contains(result.Output, "secret-token") {
+		t.Fatalf("expected URL secrets to be redacted, got %q", result.Output)
+	}
+	if result.Meta["status_code"] != "200" || result.Meta["content_type"] != "text/plain; charset=utf-8" || result.Meta["truncated"] != "false" {
+		t.Fatalf("unexpected metadata: %#v", result.Meta)
+	}
+}
+
+func TestWebFetchToolTruncatesAtMaxBytes(t *testing.T) {
+	tool := newWebFetchToolWithClient(webFetchTestClient(func(request *http.Request) (*http.Response, error) {
+		return webFetchTestResponse(request, http.StatusOK, "text/plain", "abcdefg"), nil
+	}))
+
+	result := tool.Run(context.Background(), map[string]any{
+		"url":       "https://example.com/long",
+		"max_bytes": 4,
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if !result.Truncated || result.Meta["truncated"] != "true" || result.Meta["bytes"] != "4" {
+		t.Fatalf("expected truncation metadata, got truncated=%v meta=%#v", result.Truncated, result.Meta)
+	}
+	if !strings.Contains(result.Output, "abcd") || strings.Contains(result.Output, "efg") {
+		t.Fatalf("expected output to contain only truncated body, got %q", result.Output)
+	}
+}
+
+func TestWebFetchToolRejectsUnsafeURLsBeforeNetwork(t *testing.T) {
+	tool := newWebFetchToolWithClient(webFetchTestClient(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unsafe URL should be rejected before network transport")
+		return nil, nil
+	}))
+
+	for _, rawURL := range []string{
+		"file:///tmp/secret",
+		"ftp://example.com/file",
+		"http://127.0.0.1/admin",
+		"http://localhost/status",
+		"http://169.254.169.254/latest/meta-data",
+		"http://user:pass@example.com/private",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			result := tool.Run(context.Background(), map[string]any{"url": rawURL})
+			if result.Status != StatusError {
+				t.Fatalf("expected unsafe URL error, got %s: %s", result.Status, result.Output)
+			}
+			if !strings.Contains(result.Output, "Unsafe URL") {
+				t.Fatalf("expected unsafe URL message, got %q", result.Output)
+			}
+		})
+	}
+}
+
+func TestWebFetchToolRejectsHostnamesResolvingToPrivateAddresses(t *testing.T) {
+	tool := newWebFetchToolWithClientAndResolver(
+		webFetchTestClient(func(*http.Request) (*http.Response, error) {
+			t.Fatal("private resolved host should be rejected before network transport")
+			return nil, nil
+		}),
+		webFetchResolverFunc(func(_ context.Context, network string, host string) ([]netip.Addr, error) {
+			if network != "ip" || host != "private.example" {
+				t.Fatalf("unexpected lookup network=%q host=%q", network, host)
+			}
+			return []netip.Addr{netip.MustParseAddr("10.0.0.12")}, nil
+		}),
+	)
+
+	result := tool.Run(context.Background(), map[string]any{"url": "https://private.example/status"})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected private resolved host error, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "private network hosts are blocked") {
+		t.Fatalf("expected private host message, got %q", result.Output)
+	}
+}
+
+func TestWebFetchToolRejectsUnsafeRedirects(t *testing.T) {
+	tool := newWebFetchToolWithClient(webFetchTestClient(func(request *http.Request) (*http.Response, error) {
+		response := webFetchTestResponse(request, http.StatusFound, "text/plain", "redirect")
+		response.Header.Set("Location", "http://127.0.0.1/private")
+		return response, nil
+	}))
+
+	result := tool.Run(context.Background(), map[string]any{"url": "https://example.com/start"})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected redirect safety error, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "Unsafe redirect URL") {
+		t.Fatalf("expected unsafe redirect message, got %q", result.Output)
+	}
+}
+
+func TestWebFetchToolRejectsNonSuccessStatus(t *testing.T) {
+	tool := newWebFetchToolWithClient(webFetchTestClient(func(request *http.Request) (*http.Response, error) {
+		return webFetchTestResponse(request, http.StatusNotFound, "text/plain", "missing page"), nil
+	}))
+
+	result := tool.Run(context.Background(), map[string]any{"url": "https://example.com/missing"})
+
+	if result.Status != StatusError {
+		t.Fatalf("expected status error, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "HTTP 404 Not Found") || !strings.Contains(result.Output, "missing page") {
+		t.Fatalf("unexpected non-success output: %q", result.Output)
+	}
+}
+
+func webFetchTestClient(handler func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{Transport: roundTripFunc(handler)}
+}
+
+func webFetchTestResponse(request *http.Request, statusCode int, contentType string, body string) *http.Response {
+	response := &http.Response{
+		StatusCode: statusCode,
+		Status:     httpStatusLine(statusCode),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}
+	if contentType != "" {
+		response.Header.Set("Content-Type", contentType)
+	}
+	return response
+}
+
+func httpStatusLine(statusCode int) string {
+	return strings.TrimSpace(strings.Join([]string{strconv.Itoa(statusCode), http.StatusText(statusCode)}, " "))
+}


### PR DESCRIPTION
## Summary
- Add first-party `web_fetch` as a guarded core network tool.
- Enforce prompt safety metadata, bounded response reads, URL/body redaction, redirect validation, and private/loopback/link-local host blocking.
- Wire `web_fetch` into core tools while keeping it out of read-only MCP defaults.

## Tests
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `go run ./cmd/zero exec --list-tools --enabled-tools web_fetch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web_fetch tool for HTTP/HTTPS retrieval with size limits, timeouts, redaction, and robust network-safety checks.

* **CLI / Configuration**
  * Tool exposure now follows allowlist/unsafe-tools settings; web_fetch is hidden by default and becomes available when unsafe tools are enabled.
  * Manifests and core tool registry recognize web_fetch as a known network tool.

* **Tests**
  * Extensive tests added for schema, safety gating, permission/advertisement behavior, redirects, truncation, and policy enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->