### PR TITLE
Skills & plugins: skill tool, skills loader, plugin manifests

### DIFF
--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -81,6 +81,23 @@ type HookExtension struct {
 	Args        []string  `json:"args"`
 }
 
+// PluginAuthor is optional manifest authorship metadata. All fields are
+// best-effort; missing values stay empty.
+type PluginAuthor struct {
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+	URL   string `json:"url,omitempty"`
+}
+
+// PluginInterface is optional presentation metadata describing how a plugin
+// surfaces in a UI. All fields are optional and default to empty.
+type PluginInterface struct {
+	DisplayName    string   `json:"displayName,omitempty"`
+	Category       string   `json:"category,omitempty"`
+	BrandColor     string   `json:"brandColor,omitempty"`
+	DefaultPrompts []string `json:"defaultPrompts,omitempty"`
+}
+
 type LoadedPlugin struct {
 	SchemaVersion int             `json:"schemaVersion"`
 	ID            string          `json:"id"`
@@ -96,6 +113,12 @@ type LoadedPlugin struct {
 	Prompts       []PathExtension `json:"prompts"`
 	Skills        []PathExtension `json:"skills"`
 	Hooks         []HookExtension `json:"hooks"`
+	// Optional, additive metadata (omitempty so existing plugins are unchanged).
+	Author    PluginAuthor    `json:"author,omitempty"`
+	License   string          `json:"license,omitempty"`
+	Keywords  []string        `json:"keywords,omitempty"`
+	Homepage  string          `json:"homepage,omitempty"`
+	Interface PluginInterface `json:"interface,omitempty"`
 }
 
 type LoadResult struct {
@@ -300,6 +323,11 @@ func ParseManifest(raw any, options ParseManifestOptions) (LoadedPlugin, error) 
 		return LoadedPlugin{}, err
 	}
 
+	// NOTE: the tools/prompts/skills/hooks extensions parsed below are validated
+	// for DISCOVERY only (the `zero plugins` listing + backend snapshots). They
+	// are not yet registered into the tool registry / hook dispatcher / skills
+	// loader at runtime — that wiring is tracked as a separate feature, so these
+	// parsed-but-unconsumed fields are intentional, not dead code.
 	tools, err := parseTools(obj["tools"], options.AllowManifestToolAutoApproval)
 	if err != nil {
 		return LoadedPlugin{}, err
@@ -332,7 +360,79 @@ func ParseManifest(raw any, options ParseManifestOptions) (LoadedPlugin, error) 
 		Prompts:       prompts,
 		Skills:        skills,
 		Hooks:         hooks,
+		Author:        parseAuthor(obj["author"]),
+		License:       optionalMetaString(obj["license"]),
+		Keywords:      coerceMetaStringSlice(obj["keywords"]),
+		Homepage:      optionalMetaString(obj["homepage"]),
+		Interface:     parseInterface(obj["interface"]),
 	}, nil
+}
+
+// parseAuthor reads optional authorship metadata. It is intentionally tolerant:
+// an absent, non-object, or partially-typed value yields zero/empty fields so it
+// never fails an otherwise-valid manifest.
+func parseAuthor(raw any) PluginAuthor {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return PluginAuthor{}
+	}
+	return PluginAuthor{
+		Name:  optionalMetaString(obj["name"]),
+		Email: optionalMetaString(obj["email"]),
+		URL:   optionalMetaString(obj["url"]),
+	}
+}
+
+// parseInterface reads optional presentation metadata, tolerating missing keys.
+func parseInterface(raw any) PluginInterface {
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return PluginInterface{}
+	}
+	return PluginInterface{
+		DisplayName:    optionalMetaString(obj["displayName"]),
+		Category:       optionalMetaString(obj["category"]),
+		BrandColor:     optionalMetaString(obj["brandColor"]),
+		DefaultPrompts: coerceMetaStringSlice(firstNonNil(obj["defaultPrompts"], obj["defaultPrompt"])),
+	}
+}
+
+// optionalMetaString returns a trimmed string for additive metadata fields, or
+// "" for anything that is not a usable string. It never errors — optional
+// metadata must not fail validation of an otherwise-valid manifest.
+func optionalMetaString(raw any) string {
+	if text, ok := raw.(string); ok {
+		return strings.TrimSpace(text)
+	}
+	return ""
+}
+
+// coerceMetaStringSlice extracts a []string from a JSON array of strings,
+// silently dropping non-string entries and returning nil for non-arrays.
+func coerceMetaStringSlice(raw any) []string {
+	items, ok := raw.([]any)
+	if !ok {
+		return nil
+	}
+	values := make([]string, 0, len(items))
+	for _, item := range items {
+		if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
+			values = append(values, strings.TrimSpace(text))
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
+func firstNonNil(values ...any) any {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
 }
 
 func FormatList(plugins []LoadedPlugin, diagnostics []Diagnostic) string {
@@ -348,6 +448,9 @@ func FormatList(plugins []LoadedPlugin, diagnostics []Diagnostic) string {
 				state = "disabled"
 			}
 			lines = append(lines, fmt.Sprintf("  %s@%s %s [%s] %s - %s", plugin.ID, plugin.Version, plugin.Name, plugin.Source, state, counts))
+			for _, meta := range formatPluginMetadata(plugin) {
+				lines = append(lines, "    "+meta)
+			}
 		}
 	}
 
@@ -362,6 +465,32 @@ func FormatList(plugins []LoadedPlugin, diagnostics []Diagnostic) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// formatPluginMetadata renders only the optional metadata fields that are
+// present, one entry per line, so listings stay clean for plugins that omit them.
+func formatPluginMetadata(plugin LoadedPlugin) []string {
+	meta := []string{}
+	if author := formatAuthor(plugin.Author); author != "" {
+		meta = append(meta, "author: "+author)
+	}
+	if plugin.License != "" {
+		meta = append(meta, "license: "+plugin.License)
+	}
+	if len(plugin.Keywords) > 0 {
+		meta = append(meta, "keywords: "+strings.Join(plugin.Keywords, ", "))
+	}
+	return meta
+}
+
+func formatAuthor(author PluginAuthor) string {
+	if author.Name == "" {
+		return ""
+	}
+	if author.Email != "" {
+		return fmt.Sprintf("%s <%s>", author.Name, author.Email)
+	}
+	return author.Name
 }
 
 func formatDiagnosticLocation(diagnostic Diagnostic) string {

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -114,11 +114,14 @@ type LoadedPlugin struct {
 	Skills        []PathExtension `json:"skills"`
 	Hooks         []HookExtension `json:"hooks"`
 	// Optional, additive metadata (omitempty so existing plugins are unchanged).
-	Author    PluginAuthor    `json:"author,omitempty"`
-	License   string          `json:"license,omitempty"`
-	Keywords  []string        `json:"keywords,omitempty"`
-	Homepage  string          `json:"homepage,omitempty"`
-	Interface PluginInterface `json:"interface,omitempty"`
+	// Author/Interface are pointers: a non-pointer struct is never "empty" to
+	// encoding/json, so omitempty would still emit `author:{}` / `interface:{}`
+	// and change the serialized form of plugins that don't set them.
+	Author    *PluginAuthor    `json:"author,omitempty"`
+	License   string           `json:"license,omitempty"`
+	Keywords  []string         `json:"keywords,omitempty"`
+	Homepage  string           `json:"homepage,omitempty"`
+	Interface *PluginInterface `json:"interface,omitempty"`
 }
 
 type LoadResult struct {
@@ -371,30 +374,38 @@ func ParseManifest(raw any, options ParseManifestOptions) (LoadedPlugin, error) 
 // parseAuthor reads optional authorship metadata. It is intentionally tolerant:
 // an absent, non-object, or partially-typed value yields zero/empty fields so it
 // never fails an otherwise-valid manifest.
-func parseAuthor(raw any) PluginAuthor {
+func parseAuthor(raw any) *PluginAuthor {
 	obj, ok := raw.(map[string]any)
 	if !ok {
-		return PluginAuthor{}
+		return nil
 	}
-	return PluginAuthor{
+	author := PluginAuthor{
 		Name:  optionalMetaString(obj["name"]),
 		Email: optionalMetaString(obj["email"]),
 		URL:   optionalMetaString(obj["url"]),
 	}
+	if author.Name == "" && author.Email == "" && author.URL == "" {
+		return nil
+	}
+	return &author
 }
 
 // parseInterface reads optional presentation metadata, tolerating missing keys.
-func parseInterface(raw any) PluginInterface {
+func parseInterface(raw any) *PluginInterface {
 	obj, ok := raw.(map[string]any)
 	if !ok {
-		return PluginInterface{}
+		return nil
 	}
-	return PluginInterface{
+	iface := PluginInterface{
 		DisplayName:    optionalMetaString(obj["displayName"]),
 		Category:       optionalMetaString(obj["category"]),
 		BrandColor:     optionalMetaString(obj["brandColor"]),
 		DefaultPrompts: coerceMetaStringSlice(firstNonNil(obj["defaultPrompts"], obj["defaultPrompt"])),
 	}
+	if iface.DisplayName == "" && iface.Category == "" && iface.BrandColor == "" && len(iface.DefaultPrompts) == 0 {
+		return nil
+	}
+	return &iface
 }
 
 // optionalMetaString returns a trimmed string for additive metadata fields, or
@@ -483,8 +494,8 @@ func formatPluginMetadata(plugin LoadedPlugin) []string {
 	return meta
 }
 
-func formatAuthor(author PluginAuthor) string {
-	if author.Name == "" {
+func formatAuthor(author *PluginAuthor) string {
+	if author == nil || author.Name == "" {
 		return ""
 	}
 	if author.Email != "" {

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -427,8 +427,10 @@ func coerceMetaStringSlice(raw any) []string {
 	}
 	values := make([]string, 0, len(items))
 	for _, item := range items {
-		if text, ok := item.(string); ok && strings.TrimSpace(text) != "" {
-			values = append(values, strings.TrimSpace(text))
+		if text, ok := item.(string); ok {
+			if trimmed := strings.TrimSpace(text); trimmed != "" {
+				values = append(values, trimmed)
+			}
 		}
 	}
 	if len(values) == 0 {

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -63,6 +63,111 @@ func TestParseManifestNormalizesExtensionsAndPaths(t *testing.T) {
 	}
 }
 
+func TestParseManifestReadsOptionalMetadata(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "plugins")
+	pluginDir := filepath.Join(root, "zero-demo")
+	manifestPath := filepath.Join(pluginDir, "plugin.json")
+
+	plugin, err := ParseManifest(map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.demo",
+		"name":          "Zero Demo",
+		"version":       "0.1.0",
+		"author": map[string]any{
+			"name":  "OpenAI",
+			"email": "support@openai.com",
+			"url":   "https://openai.com/",
+		},
+		"license":  "Proprietary",
+		"keywords": []any{"automation", "macos"},
+		"homepage": "https://openai.com/",
+		"interface": map[string]any{
+			"displayName":   "Computer Use",
+			"category":      "Productivity",
+			"brandColor":    "#0F172A",
+			"defaultPrompt": []any{"Play a playlist", "Build my project"},
+		},
+	}, ParseManifestOptions{
+		Source:       SourceProject,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: manifestPath,
+	})
+	if err != nil {
+		t.Fatalf("ParseManifest returned error: %v", err)
+	}
+	if plugin.Author.Name != "OpenAI" || plugin.Author.Email != "support@openai.com" || plugin.Author.URL != "https://openai.com/" {
+		t.Fatalf("author = %#v", plugin.Author)
+	}
+	if plugin.License != "Proprietary" {
+		t.Fatalf("license = %q", plugin.License)
+	}
+	if len(plugin.Keywords) != 2 || plugin.Keywords[0] != "automation" {
+		t.Fatalf("keywords = %#v", plugin.Keywords)
+	}
+	if plugin.Homepage != "https://openai.com/" {
+		t.Fatalf("homepage = %q", plugin.Homepage)
+	}
+	if plugin.Interface.DisplayName != "Computer Use" || plugin.Interface.Category != "Productivity" || plugin.Interface.BrandColor != "#0F172A" {
+		t.Fatalf("interface = %#v", plugin.Interface)
+	}
+	if len(plugin.Interface.DefaultPrompts) != 2 || plugin.Interface.DefaultPrompts[0] != "Play a playlist" {
+		t.Fatalf("default prompts = %#v", plugin.Interface.DefaultPrompts)
+	}
+}
+
+func TestParseManifestWithoutOptionalMetadataLeavesZeroValues(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "plugins")
+	pluginDir := filepath.Join(root, "zero-bare")
+	manifestPath := filepath.Join(pluginDir, "plugin.json")
+
+	plugin, err := ParseManifest(map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.bare",
+		"name":          "Bare",
+		"version":       "0.1.0",
+	}, ParseManifestOptions{
+		Source:       SourceUser,
+		Root:         root,
+		PluginDir:    pluginDir,
+		ManifestPath: manifestPath,
+	})
+	if err != nil {
+		t.Fatalf("ParseManifest returned error: %v", err)
+	}
+	if plugin.Author != (PluginAuthor{}) {
+		t.Fatalf("author should be zero value, got %#v", plugin.Author)
+	}
+	if plugin.License != "" || plugin.Homepage != "" {
+		t.Fatalf("license/homepage should be empty, got %q / %q", plugin.License, plugin.Homepage)
+	}
+	if len(plugin.Keywords) != 0 {
+		t.Fatalf("keywords should be empty, got %#v", plugin.Keywords)
+	}
+	if plugin.Interface.DisplayName != "" || plugin.Interface.Category != "" || plugin.Interface.BrandColor != "" || len(plugin.Interface.DefaultPrompts) != 0 {
+		t.Fatalf("interface should be zero value, got %#v", plugin.Interface)
+	}
+}
+
+func TestFormatListSurfacesOptionalMetadata(t *testing.T) {
+	output := FormatList([]LoadedPlugin{{
+		SchemaVersion: 1,
+		ID:            "zero.demo",
+		Name:          "Zero Demo",
+		Version:       "0.1.0",
+		Enabled:       true,
+		Source:        SourceUser,
+		Author:        PluginAuthor{Name: "OpenAI"},
+		License:       "MIT",
+		Keywords:      []string{"automation", "macos"},
+	}}, nil)
+	for _, want := range []string{"author: OpenAI", "license: MIT", "keywords: automation, macos"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("FormatList output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestParseManifestClampsAutoApprovalByDefault(t *testing.T) {
 	root := t.TempDir()
 	pluginDir := filepath.Join(root, "zero-demo")

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -135,8 +135,8 @@ func TestParseManifestWithoutOptionalMetadataLeavesZeroValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseManifest returned error: %v", err)
 	}
-	if plugin.Author != (PluginAuthor{}) {
-		t.Fatalf("author should be zero value, got %#v", plugin.Author)
+	if plugin.Author != nil {
+		t.Fatalf("author should be nil when absent, got %#v", plugin.Author)
 	}
 	if plugin.License != "" || plugin.Homepage != "" {
 		t.Fatalf("license/homepage should be empty, got %q / %q", plugin.License, plugin.Homepage)
@@ -144,8 +144,8 @@ func TestParseManifestWithoutOptionalMetadataLeavesZeroValues(t *testing.T) {
 	if len(plugin.Keywords) != 0 {
 		t.Fatalf("keywords should be empty, got %#v", plugin.Keywords)
 	}
-	if plugin.Interface.DisplayName != "" || plugin.Interface.Category != "" || plugin.Interface.BrandColor != "" || len(plugin.Interface.DefaultPrompts) != 0 {
-		t.Fatalf("interface should be zero value, got %#v", plugin.Interface)
+	if plugin.Interface != nil {
+		t.Fatalf("interface should be nil when absent, got %#v", plugin.Interface)
 	}
 }
 
@@ -157,7 +157,7 @@ func TestFormatListSurfacesOptionalMetadata(t *testing.T) {
 		Version:       "0.1.0",
 		Enabled:       true,
 		Source:        SourceUser,
-		Author:        PluginAuthor{Name: "OpenAI"},
+		Author:        &PluginAuthor{Name: "OpenAI"},
 		License:       "MIT",
 		Keywords:      []string{"automation", "macos"},
 	}}, nil)

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -93,6 +93,26 @@ func Duplicates(dir string) ([]DuplicateName, error) {
 	return dups, err
 }
 
+// confineSkillPath resolves manifestPath through symlinks and returns the real
+// path only if it stays within rootReal (the already-symlink-resolved skills
+// root). This stops a symlinked SKILL.md — or a symlinked skill directory — from
+// making the permission-allow skill tool read files outside the skills root.
+// ok=false also covers a missing path or one that is a directory.
+func confineSkillPath(rootReal string, manifestPath string) (string, bool) {
+	real, err := filepath.EvalSymlinks(manifestPath)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(rootReal, real)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false
+	}
+	return real, true
+}
+
 // load is the shared scanner behind Load and Duplicates: it parses every
 // SKILL.md, deduplicates by frontmatter name (first directory wins) and reports
 // the dropped collisions.
@@ -109,6 +129,20 @@ func load(dir string) ([]Skill, []DuplicateName, error) {
 		return nil, nil, err
 	}
 
+	// Resolve the skills root through symlinks so each SKILL.md can be confined to
+	// it. skill is a permission-allow read-only core/MCP tool, so the loader must
+	// never follow a symlinked SKILL.md (or skill dir) out of the root and become
+	// an arbitrary-file reader. Fall back to an absolute dir if EvalSymlinks fails
+	// so confinement still has a stable root.
+	rootReal, rootErr := filepath.EvalSymlinks(dir)
+	if rootErr != nil {
+		if abs, absErr := filepath.Abs(dir); absErr == nil {
+			rootReal = abs
+		} else {
+			rootReal = dir
+		}
+	}
+
 	skills := make([]Skill, 0, len(entries))
 	// byName maps a frontmatter name to the index of the winning skill in skills,
 	// so a later same-name duplicate can be recognized and dropped deterministically.
@@ -119,10 +153,15 @@ func load(dir string) ([]Skill, []DuplicateName, error) {
 			continue
 		}
 		manifestPath := filepath.Join(dir, entry.Name(), skillFileName)
-		data, err := os.ReadFile(manifestPath)
+		realPath, ok := confineSkillPath(rootReal, manifestPath)
+		if !ok {
+			// Missing/unreadable SKILL.md, a directory, or a symlink escaping the
+			// skills root: skip it rather than read a file outside the root. One bad
+			// or hostile skill must not hide the rest or leak external files.
+			continue
+		}
+		data, err := os.ReadFile(realPath)
 		if err != nil {
-			// Missing or unreadable SKILL.md (including the case where it is a
-			// directory) is skipped, not fatal — one bad skill must not hide the rest.
 			continue
 		}
 		absPath := manifestPath

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,247 @@
+// Package skills discovers reusable instruction "skills" stored on disk as
+// */SKILL.md files. Each skill is a directory containing a SKILL.md whose
+// optional YAML-ish frontmatter carries a name/description and whose markdown
+// body is the skill content the model can pull in on demand (PRD F15).
+//
+// The loader is deliberately dependency-free: frontmatter is hand-parsed (no
+// YAML library) and malformed files are skipped rather than failing the whole
+// load, so a single bad skill never hides the good ones.
+package skills
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Skill is a single discovered skill. Name and Description come from the
+// SKILL.md frontmatter (Name falls back to the directory name); Content is the
+// markdown body; Path is the absolute path to the SKILL.md file.
+type Skill struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Content     string `json:"content,omitempty"`
+	Path        string `json:"path"`
+}
+
+const skillFileName = "SKILL.md"
+
+// DefaultDir resolves the skills directory, mirroring sessions.DefaultRoot. An
+// explicit ZERO_SKILLS_DIR override wins; otherwise it is
+// $XDG_DATA_HOME/zero/skills or ~/.local/share/zero/skills. The directory is
+// NOT created — a missing directory simply yields no skills.
+func DefaultDir(env map[string]string) string {
+	if override := strings.TrimSpace(envValue(env, "ZERO_SKILLS_DIR")); override != "" {
+		return override
+	}
+	dataHome := strings.TrimSpace(envValue(env, "XDG_DATA_HOME"))
+	home := strings.TrimSpace(envValue(env, "HOME"))
+	if home == "" {
+		if userHome, err := os.UserHomeDir(); err == nil {
+			home = userHome
+		}
+	}
+	base := dataHome
+	if base == "" {
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "zero", "skills")
+}
+
+// DuplicateName records two skills that resolved to the same frontmatter name.
+// Winner is the SKILL.md path of the skill that was kept (the one in the
+// lexicographically-first directory); Loser is the path that was dropped.
+type DuplicateName struct {
+	Name   string
+	Winner string
+	Loser  string
+}
+
+// Load scans dir for */SKILL.md files and returns the parsed skills sorted by
+// name. A missing directory yields an empty slice with no error; individual
+// malformed skill files are skipped rather than failing the whole load.
+//
+// When two skills declare the SAME frontmatter name, resolution is made
+// DETERMINISTIC by a documented rule: the skill in the lexicographically-first
+// directory name wins (os.ReadDir returns entries sorted by filename, so the
+// first one encountered is kept and later same-name duplicates are dropped).
+// This guarantees Load/List/Get always resolve a duplicated name to the same
+// winner regardless of sort stability. Use Duplicates to surface a warning about
+// any such collisions.
+//
+// NOTE: Load currently scans a single root (ZERO_SKILLS_DIR / the data dir).
+// Plugin-declared skill paths (the plugins manifest "skills" array) are NOT yet
+// merged into this lookup; multi-root loading is tracked as a separate feature.
+func Load(dir string) ([]Skill, error) {
+	skills, _, err := load(dir)
+	return skills, err
+}
+
+// Duplicates returns the duplicate-name collisions Load resolved by the
+// first-directory-wins rule, so a caller can warn the user that a shadowed skill
+// was dropped. A missing directory yields no duplicates and no error.
+func Duplicates(dir string) ([]DuplicateName, error) {
+	_, dups, err := load(dir)
+	return dups, err
+}
+
+// load is the shared scanner behind Load and Duplicates: it parses every
+// SKILL.md, deduplicates by frontmatter name (first directory wins) and reports
+// the dropped collisions.
+func load(dir string) ([]Skill, []DuplicateName, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return []Skill{}, nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []Skill{}, nil, nil
+		}
+		return nil, nil, err
+	}
+
+	skills := make([]Skill, 0, len(entries))
+	// byName maps a frontmatter name to the index of the winning skill in skills,
+	// so a later same-name duplicate can be recognized and dropped deterministically.
+	byName := make(map[string]int, len(entries))
+	duplicates := []DuplicateName{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		manifestPath := filepath.Join(dir, entry.Name(), skillFileName)
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			// Missing or unreadable SKILL.md (including the case where it is a
+			// directory) is skipped, not fatal — one bad skill must not hide the rest.
+			continue
+		}
+		absPath := manifestPath
+		if resolved, absErr := filepath.Abs(manifestPath); absErr == nil {
+			absPath = resolved
+		}
+		skill := parseSkill(entry.Name(), absPath, string(data))
+		if winnerIdx, clash := byName[skill.Name]; clash {
+			// os.ReadDir yields entries sorted by directory name, so the skill already
+			// recorded came from the lexicographically-first directory and wins; this
+			// later one is dropped (but reported as a duplicate).
+			duplicates = append(duplicates, DuplicateName{
+				Name:   skill.Name,
+				Winner: skills[winnerIdx].Path,
+				Loser:  skill.Path,
+			})
+			continue
+		}
+		byName[skill.Name] = len(skills)
+		skills = append(skills, skill)
+	}
+
+	// Names are unique after dedup, so this sort is fully deterministic.
+	sort.Slice(skills, func(left int, right int) bool {
+		return skills[left].Name < skills[right].Name
+	})
+	return skills, duplicates, nil
+}
+
+// List loads the skills directory and returns each skill without its (possibly
+// large) Content body — handy for `zero skills` listings.
+func List(dir string) ([]Skill, error) {
+	loaded, err := Load(dir)
+	if err != nil {
+		return nil, err
+	}
+	listed := make([]Skill, 0, len(loaded))
+	for _, skill := range loaded {
+		skill.Content = ""
+		listed = append(listed, skill)
+	}
+	return listed, nil
+}
+
+// Get loads the named skill from dir, returning false if it is not found.
+func Get(dir string, name string) (Skill, bool) {
+	loaded, err := Load(dir)
+	if err != nil {
+		return Skill{}, false
+	}
+	target := strings.TrimSpace(name)
+	for _, skill := range loaded {
+		if skill.Name == target {
+			return skill, true
+		}
+	}
+	return Skill{}, false
+}
+
+// parseSkill splits optional `---`-delimited frontmatter from the markdown body.
+// Frontmatter is a simple line parser for `name:`/`description:` keys (no YAML
+// dependency). Without frontmatter, Name defaults to the directory name and
+// Description is empty.
+func parseSkill(dirName string, path string, raw string) Skill {
+	body := raw
+	name := dirName
+	description := ""
+
+	normalized := strings.ReplaceAll(raw, "\r\n", "\n")
+	if frontmatter, remainder, ok := splitFrontmatter(normalized); ok {
+		body = remainder
+		if parsedName := frontmatterValue(frontmatter, "name"); parsedName != "" {
+			name = parsedName
+		}
+		description = frontmatterValue(frontmatter, "description")
+	}
+
+	return Skill{
+		Name:        name,
+		Description: description,
+		Content:     strings.TrimSpace(body),
+		Path:        path,
+	}
+}
+
+// splitFrontmatter detects a leading `---` line, captures lines up to the
+// closing `---`, and returns the frontmatter block plus the remaining body. It
+// reports ok=false when there is no opening delimiter or no closing delimiter
+// (in which case the whole input is treated as body).
+func splitFrontmatter(normalized string) (string, string, bool) {
+	if !strings.HasPrefix(normalized, "---\n") && normalized != "---" {
+		return "", "", false
+	}
+	lines := strings.Split(normalized, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for index := 1; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) == "---" {
+			frontmatter := strings.Join(lines[1:index], "\n")
+			body := strings.Join(lines[index+1:], "\n")
+			return frontmatter, body, true
+		}
+	}
+	// No closing delimiter — not valid frontmatter; treat the whole file as body.
+	return "", "", false
+}
+
+// frontmatterValue reads a single `key: value` pair from the frontmatter block.
+// Matching is case-insensitive on the key; the first occurrence wins.
+func frontmatterValue(frontmatter string, key string) string {
+	prefix := strings.ToLower(key) + ":"
+	for _, line := range strings.Split(frontmatter, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), prefix) {
+			value := strings.TrimSpace(trimmed[len(prefix):])
+			return strings.Trim(value, `"'`)
+		}
+	}
+	return ""
+}
+
+func envValue(env map[string]string, key string) string {
+	if env != nil {
+		return env[key]
+	}
+	return os.Getenv(key)
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -110,6 +110,13 @@ func confineSkillPath(rootReal string, manifestPath string) (string, bool) {
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
 		return "", false
 	}
+	// Only read regular files. A non-regular in-root target (directory, FIFO,
+	// device, socket) named SKILL.md would otherwise make os.ReadFile block
+	// indefinitely — skill is a permission-allow tool over a user-controlled dir.
+	info, err := os.Lstat(real)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", false
+	}
 	return real, true
 }
 

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -45,6 +45,12 @@ func DefaultDir(env map[string]string) string {
 	}
 	base := dataHome
 	if base == "" {
+		if home == "" {
+			// No XDG_DATA_HOME and no resolvable home: returning a relative path
+			// here (".local/share/zero/skills") would bind skills to the process
+			// CWD, so signal "no skills dir" and let the caller handle it.
+			return ""
+		}
 		base = filepath.Join(home, ".local", "share")
 	}
 	return filepath.Join(base, "zero", "skills")

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,253 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSkill(t *testing.T, dir string, name string, content string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", skillDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func TestLoadParsesFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "confirmation-policy", "---\nname: confirmation-policy\ndescription: When to ask the user before risky actions.\n---\n\n# Confirmation Policy\n\nAsk first.\n")
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	skill := loaded[0]
+	if skill.Name != "confirmation-policy" {
+		t.Fatalf("Name = %q, want confirmation-policy", skill.Name)
+	}
+	if skill.Description != "When to ask the user before risky actions." {
+		t.Fatalf("Description = %q", skill.Description)
+	}
+	wantContent := "# Confirmation Policy\n\nAsk first."
+	if skill.Content != wantContent {
+		t.Fatalf("Content = %q, want %q", skill.Content, wantContent)
+	}
+	if skill.Path == "" {
+		t.Fatalf("Path is empty")
+	}
+}
+
+func TestLoadDerivesNameFromDirectoryWithoutFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "no-frontmatter", "# Just markdown\n\nNo frontmatter here.\n")
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(loaded))
+	}
+	skill := loaded[0]
+	if skill.Name != "no-frontmatter" {
+		t.Fatalf("Name = %q, want no-frontmatter", skill.Name)
+	}
+	if skill.Description != "" {
+		t.Fatalf("Description = %q, want empty", skill.Description)
+	}
+	if skill.Content != "# Just markdown\n\nNo frontmatter here." {
+		t.Fatalf("Content = %q", skill.Content)
+	}
+}
+
+func TestLoadSkipsMalformedAndContinues(t *testing.T) {
+	dir := t.TempDir()
+	// A directory whose SKILL.md is a directory itself (unreadable as a file) is skipped.
+	badDir := filepath.Join(dir, "broken")
+	if err := os.MkdirAll(filepath.Join(badDir, "SKILL.md"), 0o755); err != nil {
+		t.Fatalf("mkdir broken: %v", err)
+	}
+	writeSkill(t, dir, "good", "---\nname: good\ndescription: works\n---\nbody\n")
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 skill (malformed skipped), got %d", len(loaded))
+	}
+	if loaded[0].Name != "good" {
+		t.Fatalf("Name = %q, want good", loaded[0].Name)
+	}
+}
+
+func TestLoadIgnoresDirectoriesWithoutSkillFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "empty"), 0o755); err != nil {
+		t.Fatalf("mkdir empty: %v", err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expected 0 skills, got %d", len(loaded))
+	}
+}
+
+func TestLoadMissingDirYieldsEmpty(t *testing.T) {
+	loaded, err := Load(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("Load on missing dir returned error: %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expected 0 skills for missing dir, got %d", len(loaded))
+	}
+}
+
+func TestLoadSortsByName(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "zeta", "body")
+	writeSkill(t, dir, "alpha", "body")
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(loaded))
+	}
+	if loaded[0].Name != "alpha" || loaded[1].Name != "zeta" {
+		t.Fatalf("skills not sorted: %q, %q", loaded[0].Name, loaded[1].Name)
+	}
+}
+
+func TestLoadDuplicateFrontmatterNamePicksStableWinner(t *testing.T) {
+	dir := t.TempDir()
+	// Two skill directories whose frontmatter declares the SAME name. The documented
+	// rule: the skill in the lexicographically-first directory name wins, so resolution
+	// is deterministic regardless of os.ReadDir / sort ordering.
+	writeSkill(t, dir, "aaa-first", "---\nname: shared\ndescription: from aaa\n---\nbody from aaa\n")
+	writeSkill(t, dir, "zzz-second", "---\nname: shared\ndescription: from zzz\n---\nbody from zzz\n")
+
+	// Loading repeatedly must always yield the same single winner.
+	for i := 0; i < 20; i++ {
+		loaded, err := Load(dir)
+		if err != nil {
+			t.Fatalf("Load returned error: %v", err)
+		}
+		shared := 0
+		var winner Skill
+		for _, skill := range loaded {
+			if skill.Name == "shared" {
+				shared++
+				winner = skill
+			}
+		}
+		if shared != 1 {
+			t.Fatalf("expected exactly one skill named shared after dedup, got %d", shared)
+		}
+		if winner.Description != "from aaa" || winner.Content != "body from aaa" {
+			t.Fatalf("expected the aaa-first directory to win, got desc=%q content=%q", winner.Description, winner.Content)
+		}
+	}
+
+	// Get must resolve to the same documented winner.
+	got, ok := Get(dir, "shared")
+	if !ok {
+		t.Fatal("Get(shared) not found")
+	}
+	if got.Content != "body from aaa" {
+		t.Fatalf("Get resolved to non-winner: %q", got.Content)
+	}
+}
+
+func TestDuplicatesReportsCollidingNames(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "aaa-first", "---\nname: shared\n---\nbody\n")
+	writeSkill(t, dir, "zzz-second", "---\nname: shared\n---\nbody\n")
+	writeSkill(t, dir, "solo", "---\nname: solo\n---\nbody\n")
+
+	dups, err := Duplicates(dir)
+	if err != nil {
+		t.Fatalf("Duplicates returned error: %v", err)
+	}
+	if len(dups) != 1 {
+		t.Fatalf("expected exactly one duplicated name, got %d: %#v", len(dups), dups)
+	}
+	if dups[0].Name != "shared" {
+		t.Fatalf("expected the duplicated name to be shared, got %q", dups[0].Name)
+	}
+	// The winner is the lexicographically-first directory; the loser is reported too.
+	if dups[0].Winner == "" || dups[0].Loser == "" {
+		t.Fatalf("expected both winner and loser paths recorded, got %#v", dups[0])
+	}
+	if !strings.Contains(dups[0].Winner, "aaa-first") || !strings.Contains(dups[0].Loser, "zzz-second") {
+		t.Fatalf("expected aaa-first to win and zzz-second to lose, got winner=%q loser=%q", dups[0].Winner, dups[0].Loser)
+	}
+}
+
+func TestGetByName(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "one", "---\nname: one\ndescription: first\n---\ncontent one\n")
+
+	skill, ok := Get(dir, "one")
+	if !ok {
+		t.Fatalf("Get(one) not found")
+	}
+	if skill.Content != "content one" {
+		t.Fatalf("Content = %q", skill.Content)
+	}
+
+	if _, ok := Get(dir, "missing"); ok {
+		t.Fatalf("Get(missing) should not be found")
+	}
+}
+
+func TestListReturnsNamesAndDescriptions(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "b", "---\nname: b\ndescription: bee\n---\nbody")
+	writeSkill(t, dir, "a", "---\nname: a\ndescription: ay\n---\nbody")
+
+	listed, err := List(dir)
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("expected 2, got %d", len(listed))
+	}
+	if listed[0].Name != "a" || listed[0].Description != "ay" {
+		t.Fatalf("unexpected first skill: %+v", listed[0])
+	}
+}
+
+func TestDefaultDirHonorsEnvOverride(t *testing.T) {
+	got := DefaultDir(map[string]string{"ZERO_SKILLS_DIR": "/custom/skills"})
+	if got != "/custom/skills" {
+		t.Fatalf("DefaultDir override = %q, want /custom/skills", got)
+	}
+}
+
+func TestDefaultDirHonorsXDGDataHome(t *testing.T) {
+	got := DefaultDir(map[string]string{"XDG_DATA_HOME": "/xdg/data"})
+	want := filepath.Join("/xdg/data", "zero", "skills")
+	if got != want {
+		t.Fatalf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultDirFallsBackToHome(t *testing.T) {
+	got := DefaultDir(map[string]string{"HOME": "/home/zero"})
+	want := filepath.Join("/home/zero", ".local", "share", "zero", "skills")
+	if got != want {
+		t.Fatalf("DefaultDir = %q, want %q", got, want)
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -227,6 +227,13 @@ func TestListReturnsNamesAndDescriptions(t *testing.T) {
 	if listed[0].Name != "a" || listed[0].Description != "ay" {
 		t.Fatalf("unexpected first skill: %+v", listed[0])
 	}
+	// List must strip Content so a listing never leaks full skill bodies (the
+	// skills above all have a non-empty "body"); only Get/Load return Content.
+	for _, skill := range listed {
+		if skill.Content != "" {
+			t.Fatalf("List must strip Content, got %q for %q", skill.Content, skill.Name)
+		}
+	}
 }
 
 func TestDefaultDirHonorsEnvOverride(t *testing.T) {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -18,6 +18,40 @@ func writeSkill(t *testing.T, dir string, name string, content string) {
 	}
 }
 
+// Regression: skill is a permission-allow read-only tool, so a SKILL.md that is a
+// symlink pointing OUTSIDE the skills root must be skipped — never read — so the
+// tool can't be turned into an arbitrary-file reader.
+func TestLoadSkipsSymlinkedSkillFileEscapingRoot(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "good", "---\nname: good\ndescription: ok\n---\nbody")
+
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.md")
+	if err := os.WriteFile(secret, []byte("---\nname: evil\ndescription: leaked\n---\nTOP SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	evilDir := filepath.Join(dir, "evil")
+	if err := os.MkdirAll(evilDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(evilDir, "SKILL.md")); err != nil {
+		t.Skipf("symlink unavailable on this platform: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	for _, s := range loaded {
+		if s.Name == "evil" || strings.Contains(s.Content, "TOP SECRET") {
+			t.Fatalf("symlinked SKILL.md escaping the root must be skipped, got %+v", s)
+		}
+	}
+	if len(loaded) != 1 || loaded[0].Name != "good" {
+		t.Fatalf("expected only the in-root skill, got %+v", loaded)
+	}
+}
+
 func TestLoadParsesFrontmatter(t *testing.T) {
 	dir := t.TempDir()
 	writeSkill(t, dir, "confirmation-policy", "---\nname: confirmation-policy\ndescription: When to ask the user before risky actions.\n---\n\n# Confirmation Policy\n\nAsk first.\n")

--- a/internal/skills/skills_unix_test.go
+++ b/internal/skills/skills_unix_test.go
@@ -1,0 +1,49 @@
+//go:build unix
+
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Regression: a SKILL.md that is a FIFO (or other non-regular in-root file) must
+// be skipped, never read. os.ReadFile on a FIFO blocks until a writer appears, so
+// without the IsRegular guard the permission-allow skill loader would hang.
+func TestLoadSkipsNonRegularSkillFile(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "good", "---\nname: good\ndescription: ok\n---\nbody")
+
+	fifoDir := filepath.Join(dir, "fifo")
+	if err := os.MkdirAll(fifoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(fifoDir, "SKILL.md"), 0o644); err != nil {
+		t.Skipf("mkfifo unavailable on this platform: %v", err)
+	}
+
+	type result struct {
+		skills []Skill
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		skills, err := Load(dir)
+		done <- result{skills, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Load returned error: %v", got.err)
+		}
+		if len(got.skills) != 1 || got.skills[0].Name != "good" {
+			t.Fatalf("expected only the regular skill, got %+v", got.skills)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Load blocked on a FIFO SKILL.md; it must skip non-regular files")
+	}
+}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -103,6 +103,7 @@ var knownToolNames = map[string]bool{
 	"list_directory": true,
 	"glob":           true,
 	"grep":           true,
+	"skill":          true,
 	"write_file":     true,
 	"edit_file":      true,
 	"apply_patch":    true,

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -171,6 +171,9 @@ func CoreReadOnlyTools(workspaceRoot string) []Tool {
 		NewListDirectoryTool(workspaceRoot),
 		NewGlobTool(workspaceRoot),
 		NewGrepTool(workspaceRoot),
+		// skill reads reusable instruction files from the skills dir (it resolves
+		// skills.DefaultDir itself); read-only, so it is safe in the core/MCP set.
+		NewSkillTool(""),
 		// NOTE: ask_user (NewAskUserTool) is intentionally NOT registered in core
 		// yet. It needs the agent loop's interactive intercept (OnAskUser); without
 		// it the tool only returns the non-interactive fallback. The agent module

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
-	if len(toolset) != 4 {
-		t.Fatalf("expected 4 core read-only tools, got %d", len(toolset))
+	if len(toolset) != 5 {
+		t.Fatalf("expected 5 core read-only tools, got %d", len(toolset))
 	}
 
 	for _, tool := range toolset {

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -1,0 +1,73 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/skills"
+)
+
+// skillTool lets the model pull a reusable instruction "skill" into context on
+// demand (PRD F15). It reads the skills directory itself via the internal/skills
+// loader and returns the named skill's markdown body as its Output, so the model
+// can opt into reusable guidance only when relevant. It is read-only.
+type skillTool struct {
+	baseTool
+	dir string
+}
+
+// NewSkillTool builds the skill tool. An empty dir resolves to the standard
+// skills data directory (skills.DefaultDir); pass an explicit dir in tests.
+func NewSkillTool(dir string) *skillTool {
+	if strings.TrimSpace(dir) == "" {
+		dir = skills.DefaultDir(nil)
+	}
+	return &skillTool{
+		dir: dir,
+		baseTool: baseTool{
+			name: "skill",
+			description: "Load a named Zero skill and return its instructions as the tool output. " +
+				"Skills are reusable, on-demand instruction sets (e.g. project conventions or confirmation policies). " +
+				"Call this when a relevant skill exists; an unknown name returns the list of available skills.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"name": {
+						Type:        "string",
+						Description: "The name of the skill to load.",
+					},
+				},
+				Required:             []string{"name"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Reads a local skill file; gathers reusable instructions only."),
+		},
+	}
+}
+
+// Run loads the named skill and returns its Content. Unknown names return a
+// clear error listing the available skill names so the model can self-correct.
+func (tool *skillTool) Run(_ context.Context, args map[string]any) Result {
+	name, err := aliasedStringArg(args, []string{"name", "skill"}, "", true, false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for skill: " + err.Error())
+	}
+
+	loaded, err := skills.Load(tool.dir)
+	if err != nil {
+		return errorResult("Error: failed to load skills: " + err.Error())
+	}
+	if len(loaded) == 0 {
+		return errorResult(fmt.Sprintf("Error: no skills are available (looked in %s).", tool.dir))
+	}
+
+	names := make([]string, 0, len(loaded))
+	for _, skill := range loaded {
+		if skill.Name == name {
+			return okResult(skill.Content)
+		}
+		names = append(names, skill.Name)
+	}
+	return errorResult(fmt.Sprintf("Error: unknown skill %q. Available skills: %s.", name, strings.Join(names, ", ")))
+}

--- a/internal/tools/skill.go
+++ b/internal/tools/skill.go
@@ -37,8 +37,15 @@ func NewSkillTool(dir string) *skillTool {
 						Type:        "string",
 						Description: "The name of the skill to load.",
 					},
+					"skill": {
+						Type:        "string",
+						Description: "Alias for name; supply either name or skill.",
+					},
 				},
-				Required:             []string{"name"},
+				// Intentionally no strict Required: the tool needs exactly one of
+				// name/skill, which Run enforces via aliasedStringArg. Declaring both
+				// here keeps the alias usable under schema validators that reject
+				// unknown keys (AdditionalProperties:false).
 				AdditionalProperties: false,
 			},
 			safety: readOnlySafety("Reads a local skill file; gathers reusable instructions only."),

--- a/internal/tools/skill_test.go
+++ b/internal/tools/skill_test.go
@@ -1,0 +1,98 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSkillFile(t *testing.T, dir string, name string, content string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", skillDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func TestSkillToolIsReadOnly(t *testing.T) {
+	tool := NewSkillTool(t.TempDir())
+	if tool.Name() != "skill" {
+		t.Fatalf("Name = %q, want skill", tool.Name())
+	}
+	if tool.Safety().SideEffect != SideEffectRead {
+		t.Fatalf("SideEffect = %s, want read", tool.Safety().SideEffect)
+	}
+	if tool.Safety().Permission != PermissionAllow {
+		t.Fatalf("Permission = %s, want allow", tool.Safety().Permission)
+	}
+	if tool.Parameters().Type != "object" {
+		t.Fatalf("schema type = %s, want object", tool.Parameters().Type)
+	}
+}
+
+func TestSkillToolReturnsContentForKnownSkill(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "confirmation-policy", "---\nname: confirmation-policy\ndescription: ask first\n---\n\n# Confirmation Policy\n\nAsk before risky actions.")
+
+	tool := NewSkillTool(dir)
+	result := tool.Run(context.Background(), map[string]any{"name": "confirmation-policy"})
+	if result.Status != StatusOK {
+		t.Fatalf("Status = %s, want ok (output: %s)", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "Ask before risky actions.") {
+		t.Fatalf("Output missing skill body: %q", result.Output)
+	}
+}
+
+func TestSkillToolAcceptsSkillAlias(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "demo", "body of demo")
+
+	tool := NewSkillTool(dir)
+	result := tool.Run(context.Background(), map[string]any{"skill": "demo"})
+	if result.Status != StatusOK {
+		t.Fatalf("Status = %s, want ok (output: %s)", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "body of demo") {
+		t.Fatalf("Output = %q", result.Output)
+	}
+}
+
+func TestSkillToolUnknownSkillErrorsAndListsAvailable(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, dir, "alpha", "a")
+	writeSkillFile(t, dir, "beta", "b")
+
+	tool := NewSkillTool(dir)
+	result := tool.Run(context.Background(), map[string]any{"name": "missing"})
+	if result.Status != StatusError {
+		t.Fatalf("Status = %s, want error", result.Status)
+	}
+	if !strings.Contains(result.Output, "alpha") || !strings.Contains(result.Output, "beta") {
+		t.Fatalf("error should list available skills, got: %q", result.Output)
+	}
+}
+
+func TestSkillToolMissingNameErrors(t *testing.T) {
+	tool := NewSkillTool(t.TempDir())
+	result := tool.Run(context.Background(), map[string]any{})
+	if result.Status != StatusError {
+		t.Fatalf("Status = %s, want error", result.Status)
+	}
+}
+
+func TestSkillToolNoSkillsAvailable(t *testing.T) {
+	tool := NewSkillTool(filepath.Join(t.TempDir(), "missing"))
+	result := tool.Run(context.Background(), map[string]any{"name": "anything"})
+	if result.Status != StatusError {
+		t.Fatalf("Status = %s, want error", result.Status)
+	}
+	if !strings.Contains(strings.ToLower(result.Output), "no skills") {
+		t.Fatalf("expected a no-skills message, got: %q", result.Output)
+	}
+}


### PR DESCRIPTION
## Module — skills & plugins

Next reviewable slice of the runtime-core split (off `main`, now that #119 tools merged). **Clean extract** — `internal/skills` is new, `internal/plugins` had zero drift on main. No new deps.

### What's in it
- **`internal/skills`** — loads `*/SKILL.md` frontmatter from the skills dir (resolves its own XDG `~/.local/share/zero/skills`); no YAML dependency.
- **`skill` tool** (`internal/tools/skill.go`), read-only, registered in `CoreReadOnlyTools` (so it's in the agent core **and** the MCP read-only default via `serve.go`). **Path-safe by construction:** it `Load()`s all skills and matches by exact `name` — it never builds a filesystem path from the model-supplied arg, so there's no traversal surface. The dir is read via `os.ReadDir`, not user input.
- **`internal/plugins`** — plugin manifest metadata enrichment (Author/License/Keywords/Interface). **Forward code** — the cli plugin-loading wiring lands in a later PR.

### Cross-package
`specialist.knownToolNames` gains `"skill"` (the `TestKnownToolNamesMatchCoreRegistry` invariant — `skill` is now a core tool); the `CoreReadOnlyTools` count test goes 4→5.

### Testing
`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./internal/skills/ ./internal/tools/`, and `GOOS=windows go build ./...` all green.

> **MCP hardening** (nested-schema passthrough + hung-server timeout fix) is a **separate follow-up PR** to keep this reviewable. The TUI shell + cli wiring remain blocked on the agent module.

Part of decomposing #101 (draft); subagents excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local "skills" system for authoring, discovering, and retrieving reusable instruction skills.
  * Built-in read-only skill tool to fetch skill content by name.
  * Plugin manifests can include optional author, license, keywords, homepage, and UI/interface metadata.

* **Improvements**
  * Manifest parsing is tolerant of missing/malformed optional metadata; listings surface available metadata (author, license, keywords).
  * Skills loader normalizes content, deduplicates deterministically, sorts results, respects env/default locations, and skips unsafe symlinks.

* **Tests**
  * Added tests for manifest parsing, metadata listing, skills loading, duplicates, lookup, defaults, and tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->