### PR TITLE
MCP hardening: nested-schema passthrough + hung-server timeout

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -46,9 +46,30 @@ type Client struct {
 	mu      sync.Mutex
 	closeMu sync.Mutex
 	nextID  int
+
+	// dispatchMu guards the response-dispatch state shared with the single
+	// reader goroutine. It is never held across a blocking read.
+	dispatchMu sync.Mutex
+	readerOnce sync.Once
+	pending    map[int]chan dispatchResult
+	readErr    error
+	readDone   bool
+}
+
+// dispatchResult carries one matched JSON-RPC response (or a terminal reader
+// error) to a waiting caller.
+type dispatchResult struct {
+	message rpcMessage
+	err     error
 }
 
 const stdioCloseWaitTimeout = 500 * time.Millisecond
+
+const (
+	// initializeTimeout bounds the MCP handshake so a non-responsive peer fails
+	// fast instead of hanging startup.
+	initializeTimeout = 30 * time.Second
+)
 
 func Connect(ctx context.Context, server Server) (ToolClient, error) {
 	switch server.Type {
@@ -99,11 +120,16 @@ func connectStdio(ctx context.Context, server Server) (*Client, error) {
 	return client, nil
 }
 
+// initialize performs the MCP handshake under a bounded timeout so a
+// non-responsive peer fails fast instead of hanging startup.
 func (client *Client) initialize(ctx context.Context) error {
+	initCtx, cancel := context.WithTimeout(ctx, initializeTimeout)
+	defer cancel()
+
 	var result struct {
 		ProtocolVersion string `json:"protocolVersion"`
 	}
-	if err := client.request(ctx, "initialize", map[string]any{
+	if err := client.request(initCtx, "initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
 		"capabilities":    map[string]any{},
 		"clientInfo": map[string]any{
@@ -140,6 +166,11 @@ func (client *Client) CallTool(ctx context.Context, name string, args map[string
 func (client *Client) Close() error {
 	client.closeMu.Lock()
 	defer client.closeMu.Unlock()
+
+	// Fail any callers still waiting on a response. The blocking read in the
+	// reader goroutine is released below when stdin closes and the process
+	// exits (or is killed), EOFing stdout.
+	client.failAll(errors.New("MCP client closed"))
 
 	var err error
 	stdin := client.stdin
@@ -183,34 +214,55 @@ func (client *Client) request(ctx context.Context, method string, params any, ta
 		return err
 	}
 
-	client.mu.Lock()
-	defer client.mu.Unlock()
+	client.ensureReader()
 
-	id := client.nextID
-	client.nextID++
 	rawParams, err := json.Marshal(params)
 	if err != nil {
 		return err
 	}
+
+	// Allocate an id, register a response channel, and write the request while
+	// holding client.mu. The mutex serializes writes and id allocation but is
+	// released before the (potentially unbounded) wait for the response, so a
+	// hung server never holds the lock and blocks other callers/Close.
+	client.mu.Lock()
+	id := client.nextID
+	client.nextID++
+
+	responses := make(chan dispatchResult, 1)
+	client.dispatchMu.Lock()
+	if client.readDone {
+		readErr := client.readErr
+		client.dispatchMu.Unlock()
+		client.mu.Unlock()
+		if readErr != nil {
+			return readErr
+		}
+		return fmt.Errorf("MCP %s failed: connection closed", method)
+	}
+	client.pending[id] = responses
+	client.dispatchMu.Unlock()
+
 	if err := client.writer.write(rpcMessage{
 		ID:     id,
 		Method: method,
 		Params: rawParams,
 	}); err != nil {
+		client.removePending(id)
+		client.mu.Unlock()
 		return err
 	}
+	client.mu.Unlock()
 
-	for {
-		message, err := client.reader.read()
-		if err != nil {
-			return err
+	select {
+	case <-ctx.Done():
+		client.removePending(id)
+		return ctx.Err()
+	case result := <-responses:
+		if result.err != nil {
+			return result.err
 		}
-		if message.ID == nil {
-			continue
-		}
-		if !rpcIDMatches(message.ID, id) {
-			continue
-		}
+		message := result.message
 		if message.Error != nil {
 			return fmt.Errorf("MCP %s failed: %s", method, message.Error.Message)
 		}
@@ -220,6 +272,98 @@ func (client *Client) request(ctx context.Context, method string, params any, ta
 			}
 		}
 		return nil
+	}
+}
+
+// ensureReader lazily starts the single reader goroutine. It runs once per
+// client; subsequent calls are no-ops.
+func (client *Client) ensureReader() {
+	client.readerOnce.Do(func() {
+		client.dispatchMu.Lock()
+		if client.pending == nil {
+			client.pending = make(map[int]chan dispatchResult)
+		}
+		client.dispatchMu.Unlock()
+		go client.readLoop()
+	})
+}
+
+// readLoop is the single consumer of the message reader. It dispatches each
+// response to the waiting caller by id and, on a terminal read error (EOF,
+// closed pipe, or a Close-triggered cancel), fails all pending callers so none
+// block forever.
+func (client *Client) readLoop() {
+	for {
+		message, err := client.reader.read()
+		if err != nil {
+			client.failAll(err)
+			return
+		}
+		if message.ID == nil {
+			continue
+		}
+		id, ok := rpcMessageID(message.ID)
+		if !ok {
+			continue
+		}
+		client.dispatchMu.Lock()
+		responses := client.pending[id]
+		if responses != nil {
+			delete(client.pending, id)
+		}
+		client.dispatchMu.Unlock()
+		if responses != nil {
+			responses <- dispatchResult{message: message}
+		}
+	}
+}
+
+func (client *Client) removePending(id int) {
+	client.dispatchMu.Lock()
+	delete(client.pending, id)
+	client.dispatchMu.Unlock()
+}
+
+func (client *Client) failAll(err error) {
+	client.dispatchMu.Lock()
+	if client.readDone {
+		client.dispatchMu.Unlock()
+		return
+	}
+	client.readDone = true
+	client.readErr = err
+	pending := client.pending
+	client.pending = make(map[int]chan dispatchResult)
+	client.dispatchMu.Unlock()
+	for _, responses := range pending {
+		responses <- dispatchResult{err: err}
+	}
+}
+
+// rpcMessageID extracts the integer id from a JSON-RPC id value across the
+// numeric/string encodings a server may use.
+func rpcMessageID(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		return int(typed), true
+	case float64:
+		return int(typed), true
+	case json.Number:
+		parsed, err := typed.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(parsed), true
+	case string:
+		parsed, err := strconv.Atoi(typed)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
 	}
 }
 

--- a/internal/mcp/hang_test.go
+++ b/internal/mcp/hang_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// TestMCPStdioHangHelperProcess is a stdio MCP server that starts but never
+// responds, simulating a non-responsive peer during the handshake.
+func TestMCPStdioHangHelperProcess(t *testing.T) {
+	if os.Getenv("ZERO_MCP_STDIO_HANG_HELPER") != "1" {
+		return
+	}
+	select {}
+}
+
+// Connect must fail fast (within the connect deadline) when a stdio server
+// starts but never answers the initialize handshake, instead of hanging.
+func TestConnectStdioFailsFastOnNonResponsiveInitialize(t *testing.T) {
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		client, connectErr := Connect(ctx, Server{
+			Name:    "hang",
+			Type:    ServerTypeStdio,
+			Command: executable,
+			Args:    []string{"-test.run=TestMCPStdioHangHelperProcess", "--"},
+			Env:     map[string]string{"ZERO_MCP_STDIO_HANG_HELPER": "1"},
+		})
+		if connectErr == nil && client != nil {
+			_ = client.Close()
+		}
+		done <- connectErr
+	}()
+
+	select {
+	case connectErr := <-done:
+		if connectErr == nil {
+			t.Fatal("Connect() error = nil, want handshake timeout error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Connect() hung on a non-responsive initialize handshake")
+	}
+}
+
+// blockingReader blocks every Read until closed, simulating a hung peer that
+// keeps the connection open but never sends data.
+type blockingReader struct {
+	release chan struct{}
+}
+
+func newBlockingReader() *blockingReader {
+	return &blockingReader{release: make(chan struct{})}
+}
+
+func (reader *blockingReader) Read(p []byte) (int, error) {
+	<-reader.release
+	return 0, io.EOF
+}
+
+func (reader *blockingReader) Close() error {
+	select {
+	case <-reader.release:
+	default:
+		close(reader.release)
+	}
+	return nil
+}
+
+// A hung stdio server must not block Client.request forever: a cancelled
+// per-call context must unblock the wait and surface ctx.Err(), and it must
+// not hold client.mu (a second caller must still be able to proceed).
+func TestClientRequestUnblocksOnContextCancel(t *testing.T) {
+	reader := newBlockingReader()
+	defer reader.Close()
+
+	client := &Client{
+		reader: newMessageReader(reader),
+		writer: newMessageWriter(io.Discard),
+		nextID: 1,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- client.request(ctx, "tools/list", map[string]any{}, nil)
+	}()
+
+	// The request is now parked waiting for a response that never comes.
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("request() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("request() hung on a non-responsive server")
+	}
+
+	// The lock must be free: a second request under an already-cancelled
+	// context must return immediately rather than block.
+	cancelled, cancel2 := context.WithCancel(context.Background())
+	cancel2()
+	second := make(chan error, 1)
+	go func() {
+		second <- client.request(cancelled, "tools/list", map[string]any{}, nil)
+	}()
+	select {
+	case err := <-second:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("second request() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("second request() blocked — client.mu was held across the hung read")
+	}
+}
+
+// Serve must honor context cancellation even when the input reader is parked in
+// a blocking read, so a non-responsive peer cannot hang shutdown.
+func TestServeReturnsOnContextCancelWithBlockingReader(t *testing.T) {
+	reader := newBlockingReader()
+	defer reader.Close()
+
+	registry := tools.NewRegistry()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Serve(ctx, reader, io.Discard, registry, ServeOptions{})
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Serve() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve() hung on a non-responsive peer instead of honoring ctx")
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -45,6 +45,13 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 		}
 	}
 
+	// Registration is atomic per call: validate and stage every server's tools
+	// first, then commit to the caller's registry only once they all succeed. If a
+	// LATER server fails mid-registration, nothing was committed, so the registry
+	// never ends up holding dead tools that point at a (now-closed) client for an
+	// earlier server.
+	staged := make([]registryTool, 0)
+	stagedNames := make(map[string]struct{})
 	for _, server := range servers {
 		client, err := factory(ctx, server)
 		if err != nil {
@@ -64,12 +71,24 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 				return nil, fmt.Errorf("MCP server %s returned a tool without a name", server.Name)
 			}
 			tool := newRegistryTool(server, remote, client, options)
+			// Conflict detection spans both the existing registry and tools staged so
+			// far in this call (two MCP tools whose names collapse to the same
+			// sanitized name conflict even though neither is in the registry yet).
 			if existing, ok := registry.Get(tool.Name()); ok {
 				_ = runtime.Close()
 				return nil, fmt.Errorf("MCP tool %s from %s conflicts with existing tool %s", remote.Name, server.Name, existing.Name())
 			}
-			registry.Register(tool)
+			if _, ok := stagedNames[tool.Name()]; ok {
+				_ = runtime.Close()
+				return nil, fmt.Errorf("MCP tool %s from %s conflicts with another MCP tool named %s", remote.Name, server.Name, tool.Name())
+			}
+			stagedNames[tool.Name()] = struct{}{}
+			staged = append(staged, tool)
 		}
+	}
+	// Every server succeeded — commit the staged tools to the registry.
+	for _, tool := range staged {
+		registry.Register(tool)
 	}
 	return runtime, nil
 }

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -114,6 +115,72 @@ func TestRegisterToolsMarksPersistentlyApprovedToolsAllow(t *testing.T) {
 	if tool.Safety().Permission != tools.PermissionAllow {
 		t.Fatalf("Safety.Permission = %q, want allow from persistent MCP grant", tool.Safety().Permission)
 	}
+}
+
+func TestRegisterToolsRollsBackEarlierServerToolsWhenLaterServerFails(t *testing.T) {
+	// NormalizeConfig sorts server names, so "alpha" registers before "zebra".
+	// "zebra" fails mid-registration; registration must be atomic, so "alpha"'s
+	// tools must NOT be left dangling in the caller's registry.
+	registry := tools.NewRegistry()
+	alphaClient := &fakeToolClient{listed: []RemoteTool{{Name: "lookup", Description: "Lookup documentation"}}}
+
+	_, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"alpha": {Type: "stdio", Command: "alpha-mcp"},
+		"zebra": {Type: "stdio", Command: "zebra-mcp"},
+	}}, RegisterOptions{
+		ClientFactory: func(_ context.Context, server Server) (ToolClient, error) {
+			if server.Name == "zebra" {
+				return nil, errors.New("zebra connect failed")
+			}
+			return alphaClient, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected RegisterTools to fail when a later server fails")
+	}
+	if _, ok := registry.Get("mcp_alpha_lookup"); ok {
+		t.Fatal("expected earlier server's tools to be rolled back when a later server fails")
+	}
+}
+
+func TestRegisterToolsPreservesPriorRegistryStateOnFailure(t *testing.T) {
+	// A tool that predates the MCP registration must survive a failed RegisterTools
+	// call: rollback removes only what this call added.
+	registry := tools.NewRegistry()
+	registry.Register(&fakePreexistingTool{name: "preexisting"})
+
+	_, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"alpha": {Type: "stdio", Command: "alpha-mcp"},
+		"zebra": {Type: "stdio", Command: "zebra-mcp"},
+	}}, RegisterOptions{
+		ClientFactory: func(_ context.Context, server Server) (ToolClient, error) {
+			if server.Name == "zebra" {
+				return nil, errors.New("zebra connect failed")
+			}
+			return &fakeToolClient{listed: []RemoteTool{{Name: "lookup"}}}, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected RegisterTools to fail when a later server fails")
+	}
+	if _, ok := registry.Get("preexisting"); !ok {
+		t.Fatal("expected pre-existing tool to survive a failed MCP registration")
+	}
+	if _, ok := registry.Get("mcp_alpha_lookup"); ok {
+		t.Fatal("expected the failed call to add no MCP tools")
+	}
+}
+
+type fakePreexistingTool struct {
+	name string
+}
+
+func (t *fakePreexistingTool) Name() string            { return t.name }
+func (t *fakePreexistingTool) Description() string      { return "preexisting tool" }
+func (t *fakePreexistingTool) Parameters() tools.Schema { return tools.Schema{} }
+func (t *fakePreexistingTool) Safety() tools.Safety     { return tools.Safety{} }
+func (t *fakePreexistingTool) Run(context.Context, map[string]any) tools.Result {
+	return tools.Result{Status: tools.StatusOK}
 }
 
 type fakeToolClient struct {

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -74,6 +74,19 @@ func propertyToMCP(property tools.PropertySchema) map[string]any {
 	if property.Maximum != nil {
 		output["maximum"] = *property.Maximum
 	}
+	if property.Items != nil {
+		output["items"] = propertyToMCP(*property.Items)
+	}
+	if len(property.Properties) > 0 {
+		nested := make(map[string]any, len(property.Properties))
+		for name, child := range property.Properties {
+			nested[name] = propertyToMCP(child)
+		}
+		output["properties"] = nested
+	}
+	if len(property.Required) > 0 {
+		output["required"] = append([]string{}, property.Required...)
+	}
 	return output
 }
 
@@ -90,6 +103,24 @@ func propertyFromMCP(input map[string]any) tools.PropertySchema {
 	if max, ok := intValue(input["maximum"]); ok {
 		property.Maximum = &max
 	}
+	if items, ok := input["items"].(map[string]any); ok {
+		child := propertyFromMCP(items)
+		property.Items = &child
+	}
+	if properties, ok := input["properties"].(map[string]any); ok {
+		nested := make(map[string]tools.PropertySchema, len(properties))
+		for name, raw := range properties {
+			propertyMap, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			nested[name] = propertyFromMCP(propertyMap)
+		}
+		if len(nested) > 0 {
+			property.Properties = nested
+		}
+	}
+	property.Required = append(property.Required, stringSlice(input["required"])...)
 	return property
 }
 

--- a/internal/mcp/schema_test.go
+++ b/internal/mcp/schema_test.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func intPtr(value int) *int {
+	return &value
+}
+
+// A property describing an array of objects must round-trip its nested element
+// shape (items + nested properties + required) through both MCP directions.
+func TestPropertyToMCPMapsNestedArrayAndObjectShape(t *testing.T) {
+	property := tools.PropertySchema{
+		Type: "array",
+		Items: &tools.PropertySchema{
+			Type: "object",
+			Properties: map[string]tools.PropertySchema{
+				"path":   {Type: "string", Description: "file path"},
+				"line":   {Type: "integer", Minimum: intPtr(1)},
+				"nested": {Type: "object", Properties: map[string]tools.PropertySchema{"x": {Type: "string"}}, Required: []string{"x"}},
+			},
+			Required: []string{"path"},
+		},
+	}
+
+	out := propertyToMCP(property)
+	items, ok := out["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("items missing or wrong type: %#v", out)
+	}
+	if items["type"] != "object" {
+		t.Fatalf("items type = %#v, want object", items["type"])
+	}
+	props, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("items.properties missing: %#v", items)
+	}
+	pathProp, ok := props["path"].(map[string]any)
+	if !ok || pathProp["description"] != "file path" {
+		t.Fatalf("items.properties.path = %#v", props["path"])
+	}
+	required, ok := items["required"].([]string)
+	if !ok || len(required) != 1 || required[0] != "path" {
+		t.Fatalf("items.required = %#v, want [path]", items["required"])
+	}
+	nested, ok := props["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested property missing: %#v", props)
+	}
+	if _, ok := nested["properties"].(map[string]any); !ok {
+		t.Fatalf("nested.properties missing: %#v", nested)
+	}
+	if nestedReq, ok := nested["required"].([]string); !ok || len(nestedReq) != 1 || nestedReq[0] != "x" {
+		t.Fatalf("nested.required = %#v, want [x]", nested["required"])
+	}
+}
+
+// propertyFromMCP must reconstruct the same nested shape propertyToMCP emits.
+func TestPropertyFromMCPMapsNestedArrayAndObjectShape(t *testing.T) {
+	input := map[string]any{
+		"type": "array",
+		"items": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{"type": "string", "description": "file path"},
+				"line": map[string]any{"type": "integer", "minimum": float64(1)},
+			},
+			"required": []any{"path"},
+		},
+	}
+
+	property := propertyFromMCP(input)
+	if property.Type != "array" {
+		t.Fatalf("type = %q, want array", property.Type)
+	}
+	if property.Items == nil {
+		t.Fatal("Items is nil, want reconstructed element schema")
+	}
+	if property.Items.Type != "object" {
+		t.Fatalf("Items.Type = %q, want object", property.Items.Type)
+	}
+	if len(property.Items.Properties) != 2 {
+		t.Fatalf("Items.Properties = %#v, want 2 entries", property.Items.Properties)
+	}
+	if property.Items.Properties["path"].Description != "file path" {
+		t.Fatalf("Items.Properties.path = %#v", property.Items.Properties["path"])
+	}
+	if line := property.Items.Properties["line"]; line.Minimum == nil || *line.Minimum != 1 {
+		t.Fatalf("Items.Properties.line.Minimum = %#v, want 1", line.Minimum)
+	}
+	if len(property.Items.Required) != 1 || property.Items.Required[0] != "path" {
+		t.Fatalf("Items.Required = %#v, want [path]", property.Items.Required)
+	}
+}
+
+// A full round-trip (tools -> MCP -> tools) must preserve nested object/array shape.
+func TestSchemaRoundTripPreservesNestedShape(t *testing.T) {
+	original := tools.PropertySchema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"edits": {
+				Type: "array",
+				Items: &tools.PropertySchema{
+					Type:       "object",
+					Properties: map[string]tools.PropertySchema{"old": {Type: "string"}, "new": {Type: "string"}},
+					Required:   []string{"old", "new"},
+				},
+			},
+		},
+		Required: []string{"edits"},
+	}
+
+	round := propertyFromMCP(propertyToMCP(original))
+	if !reflect.DeepEqual(round, original) {
+		t.Fatalf("round-trip mismatch:\n got = %#v\nwant = %#v", round, original)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -38,19 +38,46 @@ func Serve(ctx context.Context, input io.Reader, output io.Writer, registry *too
 		writer:   writer,
 	}
 
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
+	// Run the blocking reads on a goroutine and select on ctx so a
+	// non-responsive peer cannot hang shutdown: a cancelled ctx returns
+	// immediately instead of blocking on the next read.
+	type readResult struct {
+		message rpcMessage
+		err     error
+	}
+	reads := make(chan readResult)
+	go func() {
+		defer close(reads)
+		for {
+			message, err := reader.read()
+			select {
+			case reads <- readResult{message: message, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
 		}
-		message, err := reader.read()
-		if err != nil {
-			if errors.Is(err, io.EOF) {
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case result, ok := <-reads:
+			if !ok {
 				return nil
 			}
-			return err
-		}
-		if err := server.handle(ctx, message); err != nil {
-			return err
+			if result.err != nil {
+				if errors.Is(result.err, io.EOF) {
+					return nil
+				}
+				return result.err
+			}
+			if err := server.handle(ctx, result.message); err != nil {
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Module — MCP hardening

Independent slice of the runtime-core split (off `main`). `internal/mcp` had **zero drift** on main, so this is a clean extract of the zenline MCP improvements. Deps (`config`, `tools`) are on main; uses `tools.PropertySchema.Properties/Required` from #119. No new deps.

### What's in it
- **Nested-schema passthrough** (`schema.go`) — when converting `tools.PropertySchema` ⇄ MCP JSON schema, serialize nested object `Properties`/`Required` (and object-typed `Items`) instead of flattening them, so tools with nested args are advertised faithfully to/from MCP hosts. *(audit H6.)*
- **Hung-server timeout** (`client.go`/`server.go`) — bound the MCP stdio handshake/calls so a hung or non-responsive MCP server can't block the caller forever; surface a timeout instead. *(audit H9; `hang_test.go` covers it.)*
- `registry.go` recognizes the hardened paths; `registry_test.go`/`schema_test.go` added.

### Testing
`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./internal/mcp/`, `GOOS=windows go build ./...` all green.

> Companion to #123 (skills & plugins). Together these are the "extensibility" layer. The TUI shell + cli wiring remain blocked on the agent module.

Part of decomposing #101 (draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for complex nested parameter schemas, including arrays and objects.

* **Bug Fixes**
  * Fixed connection hangs when MCP servers don't respond to initialization requests.
  * Fixed server shutdown hangs when peer connections become unresponsive.
  * Made tool registration atomic—all tools register successfully or none do if any validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->