### PR TITLE
TUI shell: ask_user modal, pickers, autocomplete, zeroline skin

### DIFF
--- a/internal/sessions/checkpoint.go
+++ b/internal/sessions/checkpoint.go
@@ -76,23 +76,29 @@ func (store *Store) CaptureToolCheckpoint(sessionID, workspaceRoot, tool string,
 	}
 	defer unlock()
 
-	payload, ok := store.snapshotForCheckpoint(sessionID, workspaceRoot, tool, paths)
+	payload, ok := store.SnapshotForCheckpoint(sessionID, workspaceRoot, tool, paths)
 	if !ok {
 		return Event{}, nil
 	}
 	return store.appendEventLocked(sessionID, AppendEventInput{Type: EventSessionCheckpoint, Payload: payload})
 }
 
-// snapshotForCheckpoint reads and stores the before-mutation blobs for paths and
-// returns the checkpoint payload WITHOUT appending an event. It is intentionally
-// package-private: the blob writes and the referencing EventSessionCheckpoint
-// must be committed atomically under the same session lock, which only its sole
-// caller CaptureToolCheckpoint guarantees. A snapshot-only entry point exposed to
-// external callers would let blobs be written that a concurrent
-// pruneOrphanBlobs/ApplyRewind could delete before the event is recorded.
+// SnapshotForCheckpoint reads and stores the before-mutation blobs for paths and
+// returns the checkpoint payload WITHOUT appending an event.
+//
+// CONTRACT: the returned payload references blobs that are ORPHAN-VULNERABLE — a
+// concurrent pruneOrphanBlobs/ApplyRewind can delete them — until the caller
+// appends an EventSessionCheckpoint carrying this payload. The caller therefore
+// MUST record that event promptly, including on cancellation paths. Prefer
+// CaptureToolCheckpoint, which writes the blobs AND appends the event atomically
+// under one session lock; use SnapshotForCheckpoint only when the event must be
+// batched IN ORDER with other session events (the TUI captures before each
+// mutating tool, batches the checkpoint with the run's other events to preserve
+// recorded ordering, and flushes them at end-of-run and on cancel).
+//
 // Returns ok=false when there is nothing to record (disabled, no paths, or no
 // capturable files).
-func (store *Store) snapshotForCheckpoint(sessionID, workspaceRoot, tool string, paths []string) (CheckpointPayload, bool) {
+func (store *Store) SnapshotForCheckpoint(sessionID, workspaceRoot, tool string, paths []string) (CheckpointPayload, bool) {
 	if !CheckpointsEnabled() || len(paths) == 0 {
 		return CheckpointPayload{}, false
 	}

--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+func testAskUserRequest() agent.AskUserRequest {
+	return agent.AskUserRequest{
+		ToolCallID: "call_1",
+		Header:     "Need a couple of details",
+		Questions: []agent.AskUserQuestion{
+			{Question: "Which framework?", Options: []string{"React", "Vue"}},
+			{Question: "TypeScript?"},
+		},
+	}
+}
+
+func TestAskUserRequestShowsFocusedPrompt(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.showSplash = false
+	m.pending = true
+	m.activeRunID = 7
+	m.width = 96
+
+	updated, cmd := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: testAskUserRequest(),
+	})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected ask_user request to update TUI state synchronously")
+	}
+	if next.pendingAskUser == nil {
+		t.Fatalf("expected ask_user prompt to be pending, got %#v", next)
+	}
+	if countTranscriptRows(next.transcript, rowAskUser) != 1 {
+		t.Fatalf("expected one ask_user transcript row, got %#v", next.transcript)
+	}
+	view := next.View()
+	for _, want := range []string{"Which framework?", "React", "Vue", "question 1 of 2"} {
+		assertContains(t, view, want)
+	}
+}
+
+func TestAskUserPromptCollectsAnswersInOrder(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: testAskUserRequest(),
+		answer: func(values []string) {
+			answers = append(answers, values)
+		},
+	})
+	next := updated.(model)
+
+	// Answer the first question.
+	next.input.SetValue("React")
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected first answer to advance synchronously")
+	}
+	if next.pendingAskUser == nil {
+		t.Fatal("expected prompt to remain pending after first answer")
+	}
+	if len(answers) != 0 {
+		t.Fatalf("expected no answers delivered until all questions answered, got %#v", answers)
+	}
+
+	// Answer the second (final) question.
+	next.input.SetValue("yes")
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected final answer to resolve synchronously")
+	}
+	if next.pendingAskUser != nil {
+		t.Fatalf("expected prompt to clear after final answer, got %#v", next.pendingAskUser)
+	}
+	if len(answers) != 1 {
+		t.Fatalf("expected one delivery of answers, got %#v", answers)
+	}
+	if len(answers[0]) != 2 || answers[0][0] != "React" || answers[0][1] != "yes" {
+		t.Fatalf("expected answers [React yes], got %#v", answers[0])
+	}
+}
+
+func TestAskUserPromptEscDeliversCollectedAnswers(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: testAskUserRequest(),
+		answer: func(values []string) {
+			answers = append(answers, values)
+		},
+	})
+	next := updated.(model)
+
+	// Esc while an ask_user prompt is active cancels the questionnaire and must
+	// still deliver a (partial/empty) answer set so the run never deadlocks.
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	next = updated.(model)
+
+	if next.pendingAskUser != nil {
+		t.Fatalf("expected ask_user prompt to clear after Esc, got %#v", next.pendingAskUser)
+	}
+	if len(answers) != 1 {
+		t.Fatalf("expected the answer callback to fire on Esc, got %#v", answers)
+	}
+	if next.pending {
+		// cancelRun is the normal Esc path; here we only cancel the prompt, the
+		// run continues with the degraded answers.
+	}
+}
+
+func TestAskUserPromptBlocksNormalSubmit(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: testAskUserRequest(),
+		answer:  func([]string) {},
+	})
+	next := updated.(model)
+	next.input.SetValue("/help")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if transcriptContains(next.transcript, "Available commands") {
+		t.Fatalf("ask_user prompt should capture Enter, not run commands: %#v", next.transcript)
+	}
+	if next.pendingAskUser == nil {
+		t.Fatal("expected ask_user prompt to remain pending after answering one question")
+	}
+}

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -1,0 +1,131 @@
+package tui
+
+import "strings"
+
+// commandSuggestion is one row in the slash-command autocomplete overlay: the
+// canonical command name and its short description.
+type commandSuggestion struct {
+	Name string
+	Desc string
+}
+
+// maxCommandSuggestions caps how many rows the autocomplete overlay shows so a
+// short prefix can't flood the screen.
+const maxCommandSuggestions = 8
+
+// suggestionsActive reports whether the autocomplete overlay should drive key
+// handling: the input is a slash-command fragment, there is at least one match,
+// and no modal (permission / questionnaire) is competing for keys.
+func (m model) suggestionsActive() bool {
+	if m.pendingPermission != nil || m.pendingAskUser != nil {
+		return false
+	}
+	return len(m.suggestions) > 0
+}
+
+// recomputeSuggestions rebuilds the autocomplete match list from the current
+// input. It only matches a leading slash token (no spaces yet) so suggestions
+// disappear once the user starts typing arguments. Modals suppress matching
+// entirely. The selected index is preserved when still in range, otherwise reset.
+func (m *model) recomputeSuggestions() {
+	if m.pendingPermission != nil || m.pendingAskUser != nil {
+		m.suggestions = nil
+		m.suggestionIdx = 0
+		return
+	}
+
+	value := m.input.Value()
+	trimmed := strings.TrimLeft(value, " ")
+	// Only a single bare "/token" (no whitespace, so no argument started yet)
+	// drives suggestions.
+	if !strings.HasPrefix(trimmed, "/") || strings.ContainsAny(trimmed, " \t") {
+		m.suggestions = nil
+		m.suggestionIdx = 0
+		return
+	}
+	token := strings.TrimSpace(trimmed)
+	if token == "" || token == "/" {
+		// "/" alone surfaces nothing until at least one more char is typed; this
+		// keeps the overlay from popping for an empty slash.
+		m.suggestions = nil
+		m.suggestionIdx = 0
+		return
+	}
+
+	matches := matchCommandSuggestions(token)
+	m.suggestions = matches
+	if m.suggestionIdx >= len(matches) {
+		m.suggestionIdx = 0
+	}
+	if m.suggestionIdx < 0 {
+		m.suggestionIdx = 0
+	}
+}
+
+// matchCommandSuggestions returns commands whose canonical name or any alias has
+// the typed prefix (case-insensitive), preserving commandDefinitions order and
+// capped at maxCommandSuggestions. A command matched via an alias is still listed
+// by its canonical name (completing always inserts the canonical form).
+func matchCommandSuggestions(token string) []commandSuggestion {
+	prefix := strings.ToLower(strings.TrimSpace(token))
+	if prefix == "" {
+		return nil
+	}
+	out := make([]commandSuggestion, 0, maxCommandSuggestions)
+	for _, command := range commandDefinitions {
+		if !commandHasPrefix(command, prefix) {
+			continue
+		}
+		out = append(out, commandSuggestion{Name: command.name, Desc: command.description})
+		if len(out) >= maxCommandSuggestions {
+			break
+		}
+	}
+	return out
+}
+
+func commandHasPrefix(command commandDefinition, prefix string) bool {
+	if strings.HasPrefix(command.name, prefix) {
+		return true
+	}
+	for _, alias := range command.aliases {
+		if strings.HasPrefix(alias, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// moveSuggestion advances (delta +1) or rewinds (delta -1) the selected
+// suggestion, wrapping at both ends.
+func (m *model) moveSuggestion(delta int) {
+	n := len(m.suggestions)
+	if n == 0 {
+		return
+	}
+	m.suggestionIdx = ((m.suggestionIdx+delta)%n + n) % n
+}
+
+// completeSuggestion replaces the input with the selected command name plus a
+// trailing space (ready for arguments) and dismisses the overlay.
+func (m model) completeSuggestion() model {
+	if !m.suggestionsActive() {
+		return m
+	}
+	idx := m.suggestionIdx
+	if idx < 0 || idx >= len(m.suggestions) {
+		idx = 0
+	}
+	m.input.SetValue(m.suggestions[idx].Name + " ")
+	m.input.CursorEnd()
+	m.suggestions = nil
+	m.suggestionIdx = 0
+	return m
+}
+
+// dismissSuggestions clears the overlay without touching the input or the run.
+func (m model) dismissSuggestions() model {
+	m.suggestions = nil
+	m.suggestionIdx = 0
+	return m
+}

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -1,0 +1,227 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+// typeRunes feeds each rune of s through Update as an individual key press,
+// exercising the same recompute-after-input path the real loop uses.
+func typeRunes(t *testing.T, m model, s string) model {
+	t.Helper()
+	for _, r := range s {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(model)
+	}
+	return m
+}
+
+func suggestionNames(m model) []string {
+	names := make([]string, 0, len(m.suggestions))
+	for _, s := range m.suggestions {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func contains(names []string, want string) bool {
+	for _, name := range names {
+		if name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSuggestionsSurfaceMatchingCommands(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/mo")
+
+	if !m.suggestionsActive() {
+		t.Fatal("expected suggestions active after typing /mo")
+	}
+	names := suggestionNames(m)
+	if !contains(names, "/model") || !contains(names, "/mode") {
+		t.Fatalf("expected /model and /mode in suggestions, got %v", names)
+	}
+}
+
+func TestSuggestionsMatchAliasButListCanonical(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/find") // alias of /search
+
+	names := suggestionNames(m)
+	if !contains(names, "/search") {
+		t.Fatalf("expected alias /find to surface canonical /search, got %v", names)
+	}
+}
+
+func TestSuggestionsInactiveWithoutSlashOrToken(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+
+	m1 := typeRunes(t, m, "hello")
+	if m1.suggestionsActive() {
+		t.Fatal("plain text should not surface suggestions")
+	}
+
+	// A slash followed by a space (an argument has started) drops suggestions.
+	m2 := typeRunes(t, m, "/model ")
+	if m2.suggestionsActive() {
+		t.Fatal("suggestions should clear once an argument is typed")
+	}
+}
+
+func TestTabCyclesSuggestions(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/mo")
+	start := m.suggestionIdx
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(model)
+	if m.suggestionIdx == start {
+		t.Fatal("Tab should advance the selected suggestion")
+	}
+
+	// Tab past the end wraps to 0.
+	for i := 0; i < len(m.suggestions); i++ {
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(model)
+	}
+	if m.suggestionIdx != m.suggestionIdx%len(m.suggestions) {
+		t.Fatal("selection index out of range after cycling")
+	}
+}
+
+func TestUpDownMoveSuggestions(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/mo")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(model)
+	if m.suggestionIdx != 1 {
+		t.Fatalf("Down should select index 1, got %d", m.suggestionIdx)
+	}
+	// Up from index 0 wraps to the last suggestion.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(model)
+	if m.suggestionIdx != len(m.suggestions)-1 {
+		t.Fatalf("Up past the top should wrap to last (%d), got %d", len(m.suggestions)-1, m.suggestionIdx)
+	}
+}
+
+func TestEnterCompletesSuggestion(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/mod") // selects /model first
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("Enter on a suggestion should complete, not submit a run")
+	}
+	if got := m.input.Value(); got != "/model " {
+		t.Fatalf("expected input completed to %q, got %q", "/model ", got)
+	}
+	if m.suggestionsActive() {
+		t.Fatal("completing a suggestion should dismiss the overlay")
+	}
+}
+
+func TestTabCompletesAfterSelection(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/mo")
+
+	// Move to /mode, then Tab again -> per spec Tab cycles, so we use Down then
+	// Enter to lock the selection; verify Tab keeps cycling not completing.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(model)
+	if m.input.Value() != "/mo" {
+		t.Fatalf("Tab should cycle, not yet complete; input=%q", m.input.Value())
+	}
+}
+
+func TestEscDismissesSuggestionsWithoutClearingInput(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/mo")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+
+	if m.suggestionsActive() {
+		t.Fatal("Esc should dismiss the suggestion overlay")
+	}
+	if m.input.Value() != "/mo" {
+		t.Fatalf("Esc should not clear the input, got %q", m.input.Value())
+	}
+}
+
+func TestEscWithoutSuggestionsClearsInputAsBefore(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "hello") // no suggestions
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+	if m.input.Value() != "" {
+		t.Fatalf("Esc with no suggestions should clear input, got %q", m.input.Value())
+	}
+}
+
+func TestEnterWithNoSuggestionStillSubmits(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("hello zero") // plain prompt, no suggestions
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if next.input.Value() != "" {
+		t.Fatal("Enter should submit (and clear) a plain prompt")
+	}
+	if !transcriptContains(next.transcript, "hello zero") {
+		t.Fatal("submitted prompt should appear in the transcript")
+	}
+}
+
+func TestSuggestionsSuppressedDuringModals(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.pendingAskUser = &pendingAskUserPrompt{
+		request: agent.AskUserRequest{Questions: []agent.AskUserQuestion{{Question: "name?"}}},
+		answer:  func([]string) {},
+	}
+	// Typing while a questionnaire is active feeds the answer field; no overlay.
+	m = typeRunes(t, m, "/mo")
+	if m.suggestionsActive() {
+		t.Fatal("suggestions must stay suppressed while a questionnaire is active")
+	}
+}
+
+func TestSuggestionOverlayRendersInDefaultSkin(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width, m.height = 96, 30
+	m.showSplash = false
+	m = typeRunes(t, m, "/mo")
+
+	view := m.View()
+	if !strings.Contains(view, "/model") || !strings.Contains(view, "/mode") {
+		t.Fatal("default-skin view should render the suggestion overlay")
+	}
+}
+
+func TestSuggestionOverlayRendersInZerolineSkin(t *testing.T) {
+	m := newModel(context.Background(), Options{Skin: "zeroline", ThemeDark: true})
+	m.width, m.height = 100, 30
+	m.booted = true
+	m.showSplash = false
+	m = typeRunes(t, m, "/mo")
+
+	view := m.View()
+	if !strings.Contains(view, "/model") || !strings.Contains(view, "/mode") {
+		t.Fatal("zeroline chat view should render the suggestion overlay")
+	}
+}

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
@@ -111,9 +112,9 @@ func (m model) handleModelCommand(args string) (model, string) {
 	if err != nil {
 		return m, "Model\nFailed to load model catalog: " + err.Error()
 	}
-	entry, err := registry.Require(args)
-	if err != nil {
-		return m, "Model\n" + err.Error()
+	entry, notice, ok := registry.ResolveWithFallback(args)
+	if !ok {
+		return m, "Model\nunknown Zero model " + strconv.Quote(args)
 	}
 	if m.providerProfile == (config.ProviderProfile{}) {
 		return m, "Model\nNo provider profile is available for TUI model switching."
@@ -138,19 +139,145 @@ func (m model) handleModelCommand(args string) (model, string) {
 	m.provider = nextProvider
 	m.providerName = displayValue(nextProfile.Name, string(metadata.ProviderKind))
 	m.modelName = entry.ID
-	effortLine := "effort: " + m.effortDisplay()
-	if m.reasoningEffort != "" && !reasoningEffortAllowed(registry.ReasoningEfforts(entry.ID), m.reasoningEffort) {
+	resetEffort := false
+	if m.reasoningEffort != "" && !reasoningEffortAllowed(entry.ReasoningEfforts, m.reasoningEffort) {
+		// Drop an unsupported carry-over preference and fall back to the
+		// model's effective default for the new model.
 		m.reasoningEffort = ""
-		effortLine = "effort: auto (unsupported preference reset)"
+		resetEffort = true
 	}
-	return m, strings.Join([]string{
-		"Model",
+	effortLine := "effort: " + m.effortDisplay()
+	if resetEffort {
+		// Preference was dropped: show "auto" (model default applies), not a
+		// concrete value that would read as an explicit setting.
+		effortLine += " (unsupported preference reset)"
+	} else if effective := modelregistry.EffectiveReasoningEffort(entry, m.reasoningEffort); effective != modelregistry.ReasoningEffortNone {
+		effortLine = "effort: " + string(effective)
+	}
+	lines := []string{"Model"}
+	if notice != "" {
+		lines = append(lines, notice)
+	}
+	lines = append(lines,
 		"Switched model for this TUI session.",
-		"model: " + entry.ID,
-		"provider: " + string(metadata.ProviderKind),
-		"api model: " + metadata.APIModel,
+		"model: "+entry.ID,
+		"provider: "+string(metadata.ProviderKind),
+		"api model: "+metadata.APIModel,
 		effortLine,
-	}, "\n")
+	)
+	return m, strings.Join(lines, "\n")
+}
+
+// handleModeCommand applies a preset that bundles model, reasoning effort, and
+// turn budget. "/mode" with no argument lists the presets; "/mode <name>"
+// switches the active model (rebuilding the provider, like /model), the reasoning
+// effort (like /effort), and the agent-loop turn budget for this TUI session. It
+// mirrors the state mutations in handleModelCommand/handleEffortCommand so a mode
+// switch is equivalent to running those commands in sequence.
+func (m model) handleModeCommand(args string) (model, string) {
+	args = strings.TrimSpace(args)
+	switch strings.ToLower(args) {
+	case "":
+		return m, m.modeListText()
+	case "list", "ls":
+		return m, m.modeListText()
+	}
+
+	mode, ok := modelregistry.LookupMode(args)
+	if !ok {
+		return m, "Mode\nunknown mode " + strconv.Quote(args) + "\navailable: " + strings.Join(modelregistry.ModeNames(), ", ")
+	}
+	if m.pending {
+		return m, "Mode\nCannot switch modes while a run is active."
+	}
+
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return m, "Mode\nFailed to load model catalog: " + err.Error()
+	}
+	entry, notice, ok := registry.ResolveWithFallback(mode.Model)
+	if !ok {
+		return m, "Mode\nmode " + strconv.Quote(mode.Name) + " references unknown model " + strconv.Quote(mode.Model)
+	}
+	if m.providerProfile == (config.ProviderProfile{}) {
+		return m, "Mode\nNo provider profile is available for TUI mode switching."
+	}
+	if m.newProvider == nil {
+		return m, "Mode\nProvider rebuild is not available for this TUI session."
+	}
+
+	nextProfile := m.providerProfile
+	nextProfile.Model = entry.ID
+	metadata, err := providers.ResolveRuntimeMetadata(nextProfile, providers.Options{})
+	if err != nil {
+		return m, "Mode\n" + err.Error()
+	}
+	nextProvider, err := m.newProvider(nextProfile)
+	if err != nil {
+		return m, "Mode\n" + err.Error()
+	}
+
+	m.providerProfile = nextProfile
+	m.provider = nextProvider
+	m.providerName = displayValue(nextProfile.Name, string(metadata.ProviderKind))
+	m.modelName = entry.ID
+
+	// Apply the mode's reasoning effort when the resolved model supports it;
+	// otherwise fall back to auto (the model's effective default) so we never
+	// store an unsupported preference.
+	effortLine := "effort: auto"
+	if mode.Effort != "" && reasoningEffortAllowed(entry.ReasoningEfforts, mode.Effort) {
+		m.reasoningEffort = mode.Effort
+		effortLine = "effort: " + string(mode.Effort)
+	} else {
+		m.reasoningEffort = ""
+		if mode.Effort != "" {
+			effortLine = "effort: auto (mode effort unsupported by model)"
+		}
+	}
+
+	turnsLine := fmt.Sprintf("max turns: %d (unchanged)", m.agentOptions.MaxTurns)
+	if mode.MaxTurns > 0 {
+		m.agentOptions.MaxTurns = mode.MaxTurns
+		turnsLine = fmt.Sprintf("max turns: %d", mode.MaxTurns)
+	}
+
+	lines := []string{"Mode"}
+	if notice != "" {
+		lines = append(lines, notice)
+	}
+	lines = append(lines,
+		"Switched to mode "+mode.Name+" for this TUI session.",
+		mode.Description,
+		"model: "+entry.ID,
+		"provider: "+string(metadata.ProviderKind),
+		effortLine,
+		turnsLine,
+	)
+	return m, strings.Join(lines, "\n")
+}
+
+func (m model) modeListText() string {
+	lines := make([]string, 0, len(modelregistry.Modes()))
+	for _, mode := range modelregistry.Modes() {
+		detail := fmt.Sprintf("model=%s", mode.Model)
+		if mode.Effort != "" {
+			detail += " effort=" + string(mode.Effort)
+		}
+		if mode.MaxTurns > 0 {
+			detail += fmt.Sprintf(" turns=%d", mode.MaxTurns)
+		}
+		lines = append(lines, commandBullet(fmt.Sprintf("%s - %s (%s)", mode.Name, mode.Description, detail)))
+	}
+	return renderCommandOutput(commandOutput{
+		Title:  "Mode",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Available",
+			Lines: lines,
+		}},
+		Hints: []string{"use /mode <name> to switch model, effort, and turns"},
+	})
 }
 
 func apiKeyState(set bool) string {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -17,6 +17,7 @@ const (
 	commandPermissions
 	commandProvider
 	commandModel
+	commandMode
 	commandContext
 	commandConfig
 	commandDebug
@@ -25,6 +26,7 @@ const (
 	commandSearch
 	commandResume
 	commandCompact
+	commandRewind
 	commandEffort
 	commandStyle
 	commandTheme
@@ -74,6 +76,13 @@ var commandDefinitions = []commandDefinition{
 		description:  "Show or switch the active model.",
 		kind:         commandModel,
 		startupOrder: 4,
+	},
+	{
+		name:        "/mode",
+		usage:       "/mode [name]",
+		group:       commandGroupModel,
+		description: "List agent modes or switch model, effort, and turns at once.",
+		kind:        commandMode,
 	},
 	{
 		name:         "/plan",
@@ -134,6 +143,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Show or request transcript compaction state.",
 		kind:        commandCompact,
+	},
+	{
+		name:        "/rewind",
+		usage:       "/rewind [latest|<sequence>]",
+		group:       commandGroupSession,
+		description: "Restore workspace files to a checkpoint and truncate the session.",
+		kind:        commandRewind,
 	},
 	{
 		name:        "/effort",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -54,10 +55,46 @@ type model struct {
 	runCancel          context.CancelFunc
 	runID              int
 	activeRunID        int
-	pendingPermission  *pendingPermissionPrompt
-	width              int
-	height             int
-	now                func() time.Time
+	// flushRunIDs holds the ids of runs cancelled while still in flight. Each
+	// cancelled agent goroutine keeps running to completion and returns its
+	// accumulated sessionEvents (including EventSessionCheckpoint payloads captured
+	// before each mutating tool) in a final agentResponseMsg. activeRunID is
+	// already zeroed by then, so without this the message would be dropped and the
+	// checkpoint blobs already written to disk would be orphaned (breaking
+	// /rewind). It is a SET (not a single id) so a second cancel before the first
+	// goroutine returns doesn't overwrite/lose the first run's pending flush. The
+	// agentResponseMsg handler persists each such run's session events (only) so
+	// the checkpoints stay referenced, then removes the id.
+	flushRunIDs       map[int]struct{}
+	pendingPermission *pendingPermissionPrompt
+	pendingAskUser    *pendingAskUserPrompt
+	width             int
+	height            int
+	now               func() time.Time
+
+	skin             string // "" default shell, "zeroline" reskin
+	themeVariant     int    // zeroline color theme (0-4)
+	themeDark        bool   // zeroline light/dark
+	frame            int    // animation frame counter (zeroline spinner)
+	booted           bool   // zeroline boot splash finished
+	streamingText    string // live assistant text for the current segment
+	streamStartFrame int    // frame the current stream segment began (tok/s)
+
+	// Slash-command autocomplete (purely additive UI state). suggestions is the
+	// live match list for the current "/token"; suggestionIdx is the highlighted
+	// row. Active only when suggestionsActive() (no modal, non-empty matches).
+	suggestions   []commandSuggestion
+	suggestionIdx int
+
+	// picker, when non-nil, is an open interactive selector overlay (/model,
+	// /theme, /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and
+	// applies the chosen value through the existing command handlers.
+	picker *commandPicker
+}
+
+type agentTextMsg struct {
+	runID int
+	delta string
 }
 
 type agentResponseMsg struct {
@@ -91,6 +128,25 @@ type permissionRequestMsg struct {
 type pendingPermissionPrompt struct {
 	request agent.PermissionRequest
 	decide  func(agent.PermissionDecision)
+}
+
+// askUserRequestMsg is the TUI-loop equivalent of permissionRequestMsg: the
+// agent goroutine sends it (via the runtime sink) and blocks until the model
+// hands answers back through the answer callback.
+type askUserRequestMsg struct {
+	runID   int
+	request agent.AskUserRequest
+	answer  func([]string)
+}
+
+// pendingAskUserPrompt tracks an in-progress questionnaire. Answers are collected
+// one question at a time; once every question has an answer (or the user cancels)
+// the answer callback is invoked exactly once.
+type pendingAskUserPrompt struct {
+	request agent.AskUserRequest
+	answer  func([]string)
+	index   int
+	answers []string
 }
 
 func newModel(ctx context.Context, options Options) model {
@@ -133,9 +189,16 @@ func newModel(ctx context.Context, options Options) model {
 	input := textinput.New()
 	input.Prompt = "zero > "
 	input.Placeholder = "Ask Zero to inspect, edit, explain, or run a command..."
+	if options.Skin == "zeroline" {
+		input.Prompt = "❯ "
+		input.Placeholder = "message zero — / commands · @ files · ! bash"
+	}
 	input.Focus()
 
 	return model{
+		skin:               options.Skin,
+		themeVariant:       options.ThemeVariant,
+		themeDark:          options.ThemeDark,
 		ctx:                ctx,
 		cwd:                cwd,
 		gitBranch:          gitBranch(cwd),
@@ -161,6 +224,9 @@ func newModel(ctx context.Context, options Options) model {
 }
 
 func (m model) Init() tea.Cmd {
+	if m.skin == "zeroline" {
+		return tea.Batch(textinput.Blink, zerolineTick())
+	}
 	return textinput.Blink
 }
 
@@ -169,11 +235,45 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyCtrlC:
+			// cancelRun records the in-flight run into flushRunIDs and writes the
+			// "Run cancelled." marker, exactly like the Esc path. If a run was still
+			// in flight we must NOT quit yet: the cancelled goroutine returns its
+			// accumulated session events (including the EventSessionCheckpoint blobs it
+			// already wrote to disk before each mutating tool) in a final
+			// agentResponseMsg, and quitting now would drop that message, orphaning the
+			// checkpoints and breaking /rewind for Ctrl+C'd runs. Defer the quit until
+			// that flush lands; the agentResponseMsg handler fires tea.Quit once
+			// flushRunIDs drains. With no run in flight there is nothing to flush, so
+			// quit immediately as before.
+			pendingFlush := false
+			if m.pending && m.activeRunID != 0 {
+				pendingFlush = true
+			}
 			m.cancelRun()
 			m.exiting = true
+			if pendingFlush && len(m.flushRunIDs) > 0 {
+				return m, nil
+			}
 			return m, tea.Quit
 		case tea.KeyEsc:
+			// An active questionnaire is cancelled (not the whole run): deliver
+			// whatever answers were collected so the agent loop unblocks and
+			// degrades to its best-assumption path.
+			if m.pendingAskUser != nil {
+				return m.resolveAskUser(true)
+			}
+			// An open picker cancels first; then an active suggestion overlay is
+			// dismissed. Neither cancels the run or clears the input.
+			if m.picker != nil {
+				m.picker = nil
+				return m, nil
+			}
+			if m.suggestionsActive() {
+				return m.dismissSuggestions(), nil
+			}
 			m.input.SetValue("")
+			m.suggestions = nil
+			m.suggestionIdx = 0
 			if m.pending {
 				m.cancelRun()
 			}
@@ -182,11 +282,99 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingPermission != nil {
 				return m, nil
 			}
+			if m.pendingAskUser != nil {
+				return m.submitAskUserAnswer()
+			}
+			if m.picker != nil {
+				return m.choosePicker()
+			}
+			// Enter on a highlighted suggestion completes the input rather than
+			// submitting; Enter with no active suggestion submits as today.
+			if m.suggestionsActive() {
+				return m.completeSuggestion(), nil
+			}
 			return m.handleSubmit()
+		case tea.KeyShiftTab:
+			// shift+tab toggles the permission mode between Auto and Ask (Unsafe
+			// is intentionally not reachable by a casual keypress — see
+			// nextPermissionMode), but only when nothing modal is up: a permission
+			// prompt, ask_user questionnaire, or open picker all take precedence
+			// and let the key fall through to their own handlers below.
+			if m.pendingPermission == nil && m.pendingAskUser == nil && m.picker == nil {
+				m.permissionMode = nextPermissionMode(m.permissionMode)
+				return m, nil
+			}
+		case tea.KeyTab:
+			if m.picker == nil && m.suggestionsActive() {
+				m.moveSuggestion(1)
+				return m, nil
+			}
+		case tea.KeyDown:
+			if m.picker != nil {
+				m.picker.move(1)
+				return m, nil
+			}
+			if m.suggestionsActive() {
+				m.moveSuggestion(1)
+				return m, nil
+			}
+		case tea.KeyUp:
+			if m.picker != nil {
+				m.picker.move(-1)
+				return m, nil
+			}
+			if m.suggestionsActive() {
+				m.moveSuggestion(-1)
+				return m, nil
+			}
+		}
+		if m.pendingAskUser != nil {
+			// While a questionnaire is active, all other keys feed the text input
+			// (the answer field); nothing else should react.
+			var cmd tea.Cmd
+			m.input, cmd = m.input.Update(msg)
+			return m, cmd
 		}
 		if m.pendingPermission != nil {
 			return m.handlePermissionKey(msg)
 		}
+		// An open picker is modal over the input: swallow remaining keys so they
+		// neither type into the field nor trigger zeroline theme shortcuts.
+		// ↑/↓/Enter/Esc were already handled above.
+		if m.picker != nil {
+			return m, nil
+		}
+		if m.skin == "zeroline" {
+			m.booted = true // any key dismisses the boot splash
+			if nm, handled := m.handleZerolineKeys(msg); handled {
+				return nm, nil
+			}
+		}
+		// The key fell through to the text input: let it update, then refresh the
+		// autocomplete match list from the new value.
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		m.recomputeSuggestions()
+		return m, cmd
+	case zerolineTickMsg:
+		if m.skin != "zeroline" {
+			return m, nil
+		}
+		m.frame++
+		if m.frame >= bootFrames {
+			m.booted = true
+		}
+		return m, zerolineTick()
+	case agentTextMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		if m.streamingText == "" {
+			m.streamStartFrame = m.frame
+		}
+		m.streamingText += msg.delta
+		m.showSplash = false
+		return m, nil
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -204,14 +392,46 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	case askUserRequestMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		m.showSplash = false
+		m.transcript = appendTranscriptRow(m.transcript, askUserTranscriptRow(msg.request))
+		m.pendingAskUser = &pendingAskUserPrompt{
+			request: msg.request,
+			answer:  msg.answer,
+			answers: make([]string, 0, len(msg.request.Questions)),
+		}
+		m.input.SetValue("")
+		return m, nil
 	case agentResponseMsg:
 		if msg.runID != m.activeRunID {
+			// A run cancelled while in flight still finishes in its goroutine and
+			// returns its accumulated session events here. Persist ONLY those events
+			// (notably the EventSessionCheckpoint payloads captured before each
+			// mutating tool) so the checkpoint blobs stay referenced and /rewind
+			// works; the cancel path already wrote the "Run cancelled." marker, so
+			// skip transcript rows, the trailing cancellation error, and any pending
+			// state changes.
+			if _, flushing := m.flushRunIDs[msg.runID]; flushing {
+				delete(m.flushRunIDs, msg.runID)
+				m, _ = m.appendSessionEvents(flushableSessionEvents(msg.sessionEvents))
+				// A Ctrl+C during an in-flight run defers its quit until the run's
+				// checkpoint session events have been flushed (above). Now that the
+				// last pending flush is drained, fire the deferred quit.
+				if m.exiting && len(m.flushRunIDs) == 0 {
+					return m, tea.Quit
+				}
+			}
 			return m, nil
 		}
 		m.pending = false
 		m.runCancel = nil
 		m.activeRunID = 0
 		m.pendingPermission = nil
+		m.pendingAskUser = nil
+		m.streamingText = ""
 		for _, event := range msg.usageEvents {
 			var usageRows []transcriptRow
 			m, usageRows = m.recordUsageEvent(msg.usageModelID, event)
@@ -238,6 +458,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.runID != m.activeRunID {
 			return m, nil
 		}
+		// a tool call ends the current streamed text segment
+		if msg.row.kind == rowToolCall {
+			m.streamingText = ""
+		}
 		m.transcript = appendTranscriptRow(m.transcript, msg.row)
 		return m, nil
 	}
@@ -248,6 +472,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
+	if m.skin == "zeroline" {
+		return m.zerolineView()
+	}
 	if m.showSplash {
 		return m.startupView()
 	}
@@ -271,9 +498,12 @@ func (m model) transcriptView() string {
 
 	if m.pending {
 		builder.WriteString("\n")
-		if m.pendingPermission != nil {
+		switch {
+		case m.pendingPermission != nil:
 			builder.WriteString(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
-		} else {
+		case m.pendingAskUser != nil:
+			builder.WriteString(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
+		default:
 			builder.WriteString(zeroTheme.zero.Render("◇ zero") + "  " + zeroTheme.muted.Render("working…"))
 		}
 		builder.WriteString("\n")
@@ -281,6 +511,14 @@ func (m model) transcriptView() string {
 
 	builder.WriteString("\n")
 	builder.WriteString(borderedBlock(width, []string{m.input.View()}))
+	if overlay := m.suggestionOverlay(width); overlay != "" {
+		builder.WriteString("\n")
+		builder.WriteString(overlay)
+	}
+	if picker := m.pickerOverlay(width); picker != "" {
+		builder.WriteString("\n")
+		builder.WriteString(picker)
+	}
 	builder.WriteString("\n")
 	builder.WriteString(m.statusLine(width))
 
@@ -327,6 +565,45 @@ func (m model) resolvePermission(decision permissionDecision) (tea.Model, tea.Cm
 	return m, nil
 }
 
+// submitAskUserAnswer records the answer to the current question and advances to
+// the next one; once every question is answered it delivers the full answer set.
+func (m model) submitAskUserAnswer() (tea.Model, tea.Cmd) {
+	pending := m.pendingAskUser
+	if pending == nil {
+		return m, nil
+	}
+	pending.answers = append(pending.answers, strings.TrimSpace(m.input.Value()))
+	pending.index++
+	m.input.SetValue("")
+	if pending.index >= len(pending.request.Questions) {
+		return m.resolveAskUser(false)
+	}
+	return m, nil
+}
+
+// resolveAskUser delivers the collected answers (padding to one-per-question when
+// cancelled early) and clears the prompt. cancelled answers stay empty so the
+// loop can degrade to its best-assumption path without deadlocking.
+func (m model) resolveAskUser(cancelled bool) (tea.Model, tea.Cmd) {
+	pending := m.pendingAskUser
+	if pending == nil {
+		return m, nil
+	}
+	answers := pending.answers
+	if cancelled {
+		// Record the question currently on screen as unanswered too.
+		m.input.SetValue("")
+	}
+	for len(answers) < len(pending.request.Questions) {
+		answers = append(answers, "")
+	}
+	if pending.answer != nil {
+		pending.answer(answers)
+	}
+	m.pendingAskUser = nil
+	return m, nil
+}
+
 func permissionDecisionReason(decision permissionDecision) string {
 	switch decision {
 	case permissionDecisionAllow:
@@ -340,12 +617,52 @@ func permissionDecisionReason(decision permissionDecision) string {
 	}
 }
 
+// choosePicker applies the highlighted picker item through the same handler the
+// typed command would have used, appends the resulting status text, and closes
+// the picker. Behavior is identical to running "/model <id>", "/effort <v>",
+// "/mode <name>", or selecting a zeroline theme by key.
+func (m model) choosePicker() (tea.Model, tea.Cmd) {
+	picker := m.picker
+	m.picker = nil
+	if picker == nil {
+		return m, nil
+	}
+	item, ok := picker.current()
+	if !ok {
+		return m, nil
+	}
+	switch picker.kind {
+	case pickerModel:
+		m.showSplash = false
+		text := ""
+		m, text = m.handleModelCommand(item.Value)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+	case pickerEffort:
+		m.showSplash = false
+		text := ""
+		m, text = m.handleEffortCommand(item.Value)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+	case pickerMode:
+		m.showSplash = false
+		text := ""
+		m, text = m.handleModeCommand(item.Value)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+	case pickerTheme:
+		// Theme selection mirrors the zeroline number-key shortcut: set the active
+		// variant by its catalog index.
+		m.themeVariant = picker.selected
+	}
+	return m, nil
+}
+
 func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	command := parseCommand(m.input.Value())
 	if command.kind == commandPrompt && m.pending {
 		return m, nil
 	}
 	m.input.SetValue("")
+	m.suggestions = nil
+	m.suggestionIdx = 0
 
 	switch command.kind {
 	case commandEmpty:
@@ -374,9 +691,37 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.providerText()})
 		return m, nil
 	case commandModel:
+		if strings.TrimSpace(command.text) == "" {
+			if m.pending {
+				m.showSplash = false
+				m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: pickerBusyText(command.name)})
+				return m, nil
+			}
+			if picker := m.newModelPicker(); picker != nil {
+				m.picker = picker
+				return m, nil
+			}
+		}
 		m.showSplash = false
 		text := ""
 		m, text = m.handleModelCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		return m, nil
+	case commandMode:
+		if strings.TrimSpace(command.text) == "" {
+			if m.pending {
+				m.showSplash = false
+				m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: pickerBusyText(command.name)})
+				return m, nil
+			}
+			if picker := m.newModePicker(); picker != nil {
+				m.picker = picker
+				return m, nil
+			}
+		}
+		m.showSplash = false
+		text := ""
+		m, text = m.handleModeCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandContext:
@@ -424,7 +769,24 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m, text = m.handleCompactCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
+	case commandRewind:
+		m.showSplash = false
+		text := ""
+		m, text = m.handleRewindCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+		return m, nil
 	case commandEffort:
+		if strings.TrimSpace(command.text) == "" {
+			if m.pending {
+				m.showSplash = false
+				m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: pickerBusyText(command.name)})
+				return m, nil
+			}
+			if picker := m.newEffortPicker(); picker != nil {
+				m.picker = picker
+				return m, nil
+			}
+		}
 		m.showSplash = false
 		text := ""
 		m, text = m.handleEffortCommand(command.text)
@@ -436,7 +798,27 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m, text = m.handleStyleCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
-	case commandTheme, commandInputStyle:
+	case commandTheme:
+		// Only the zeroline skin renders themes; there a no-argument /theme opens
+		// the picker. The default skin keeps its existing shell-only message.
+		if m.skin == "zeroline" && strings.TrimSpace(command.text) == "" {
+			if m.pending {
+				m.showSplash = false
+				m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: pickerBusyText(command.name)})
+				return m, nil
+			}
+			if picker := m.newThemePicker(); picker != nil {
+				m.picker = picker
+				return m, nil
+			}
+		}
+		m.showSplash = false
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendSystem,
+			text: shellOnlyCommandText(command.name),
+		})
+		return m, nil
+	case commandInputStyle:
 		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
 			kind: actionAppendSystem,
@@ -496,6 +878,16 @@ func (m *model) cancelRun() {
 	if m.runCancel != nil {
 		m.runCancel()
 	}
+	// Remember the in-flight run so its final agentResponseMsg is still drained
+	// for session-event persistence after activeRunID is cleared — otherwise the
+	// checkpoint blobs it captured before each mutating tool are orphaned on disk
+	// and /rewind can't reference them.
+	if m.pending && m.activeRunID != 0 {
+		if m.flushRunIDs == nil {
+			m.flushRunIDs = make(map[int]struct{})
+		}
+		m.flushRunIDs[m.activeRunID] = struct{}{}
+	}
 	if m.pending && m.activeSession.SessionID != "" {
 		if next, err := (*m).appendSessionEvent(sessions.EventError, map[string]any{
 			"message": "Run cancelled.",
@@ -507,6 +899,7 @@ func (m *model) cancelRun() {
 	m.runCancel = nil
 	m.activeRunID = 0
 	m.pendingPermission = nil
+	m.pendingAskUser = nil
 }
 
 func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cmd {
@@ -522,6 +915,17 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		options.Model = m.modelName
 		options.ReasoningEffort = string(m.reasoningEffort)
 		options.Cwd = m.cwd
+		// Enable agent-loop compaction sized to the active model's context
+		// window. An unknown/custom model resolves to 0, leaving compaction off.
+		options.ContextWindow = modelContextWindow(m.modelName)
+
+		onText := options.OnText
+		options.OnText = func(delta string) {
+			m.sendAgentText(runID, delta)
+			if onText != nil {
+				onText(delta)
+			}
+		}
 
 		onPermissionRequest := options.OnPermissionRequest
 		options.OnPermissionRequest = func(ctx context.Context, request agent.PermissionRequest) (agent.PermissionDecision, error) {
@@ -553,6 +957,34 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 			}
 		}
 
+		onAskUser := options.OnAskUser
+		options.OnAskUser = func(ctx context.Context, request agent.AskUserRequest) (agent.AskUserResponse, error) {
+			if onAskUser != nil {
+				return onAskUser(ctx, request)
+			}
+			if m.runtimeMessageSink == nil {
+				// No interactive surface: let the loop degrade gracefully.
+				return agent.AskUserResponse{}, fmt.Errorf("ask_user prompt unavailable")
+			}
+			answerCh := make(chan []string, 1)
+			m.sendAskUserRequest(runID, request, func(answers []string) {
+				select {
+				case answerCh <- answers:
+				default:
+				}
+			})
+			sessionEvents = append(sessionEvents, pendingSessionEvent{
+				Type:    sessions.EventMessage,
+				Payload: askUserSessionPayload(request),
+			})
+			select {
+			case answers := <-answerCh:
+				return agent.AskUserResponse{Answers: answers}, nil
+			case <-ctx.Done():
+				return agent.AskUserResponse{}, ctx.Err()
+			}
+		}
+
 		onToolCall := options.OnToolCall
 		options.OnToolCall = func(call agent.ToolCall) {
 			row := transcriptRow{
@@ -572,6 +1004,27 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 					"arguments": call.Arguments,
 				},
 			})
+			// Snapshot before-state of files this call will mutate, NOW (before the
+			// mutation runs), then batch the checkpoint event IN ORDER with the other
+			// session events so the recorded sequence matches execution (recording it
+			// out-of-band would reorder it ahead of the batched tool_call/result).
+			// SnapshotForCheckpoint writes the blobs; the batched event referencing
+			// them is flushed at end-of-run AND on cancel (flushRunIDs), so the blobs
+			// never stay orphaned — see its contract in internal/sessions.
+			if m.sessionStore != nil && m.activeSession.SessionID != "" {
+				var args map[string]any
+				if call.Arguments != "" {
+					_ = json.Unmarshal([]byte(call.Arguments), &args)
+				}
+				if targets := tools.MutationTargets(m.cwd, call.Name, args); len(targets) > 0 {
+					if payload, ok := m.sessionStore.SnapshotForCheckpoint(m.activeSession.SessionID, m.cwd, call.Name, targets); ok {
+						sessionEvents = append(sessionEvents, pendingSessionEvent{
+							Type:    sessions.EventSessionCheckpoint,
+							Payload: payload,
+						})
+					}
+				}
+			}
 			if onToolCall != nil {
 				onToolCall(call)
 			}
@@ -589,14 +1042,21 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 			}
 			rows = append(rows, row)
 			m.sendAgentRow(runID, row)
+			toolPayload := map[string]any{
+				"toolCallId": result.ToolCallID,
+				"name":       result.Name,
+				"status":     string(result.Status),
+				"output":     result.Output,
+			}
+			if result.Redacted {
+				toolPayload["redacted"] = true
+			}
+			if len(result.ChangedFiles) > 0 {
+				toolPayload["changedFiles"] = result.ChangedFiles
+			}
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
-				Type: sessions.EventToolResult,
-				Payload: map[string]any{
-					"toolCallId": result.ToolCallID,
-					"name":       result.Name,
-					"status":     string(result.Status),
-					"output":     result.Output,
-				},
+				Type:    sessions.EventToolResult,
+				Payload: toolPayload,
 			})
 			if onToolResult != nil {
 				onToolResult(result)
@@ -660,6 +1120,13 @@ func (m model) sendPermissionRequest(runID int, request agent.PermissionRequest,
 	m.runtimeMessageSink(permissionRequestMsg{runID: runID, request: request, decide: decide})
 }
 
+func (m model) sendAskUserRequest(runID int, request agent.AskUserRequest, answer func([]string)) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(askUserRequestMsg{runID: runID, request: request, answer: answer})
+}
+
 func tuiPermissionEventType(event agent.PermissionEvent) sessions.EventType {
 	if event.Action == agent.PermissionActionPrompt {
 		return sessions.EventPermissionRequest
@@ -675,6 +1142,13 @@ func (m model) sendAgentRow(runID int, row transcriptRow) {
 		return
 	}
 	m.runtimeMessageSink(agentRowMsg{runID: runID, row: row})
+}
+
+func (m model) sendAgentText(runID int, delta string) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(agentTextMsg{runID: runID, delta: delta})
 }
 
 func toolResultRowText(result agent.ToolResult) string {

--- a/internal/tui/model_catalog.go
+++ b/internal/tui/model_catalog.go
@@ -51,6 +51,25 @@ func (m model) modelListText() string {
 	})
 }
 
+// modelContextWindow resolves the active model's context window (max input
+// tokens) from the model registry to size agent-loop compaction. An unknown or
+// custom model resolves to 0, leaving compaction DISABLED as a safe default.
+func modelContextWindow(modelName string) int {
+	trimmed := strings.TrimSpace(modelName)
+	if trimmed == "" {
+		return 0
+	}
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return 0
+	}
+	entry, ok := registry.Resolve(trimmed)
+	if !ok {
+		return 0
+	}
+	return entry.ContextLimits.ContextWindow
+}
+
 func activeModelID(registry modelregistry.Registry, modelName string) string {
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1064,6 +1064,90 @@ func TestToolResultRowTruncatesLongOutput(t *testing.T) {
 	}
 }
 
+func TestShiftTabCyclesPermissionMode(t *testing.T) {
+	m := newModel(context.Background(), Options{PermissionMode: agent.PermissionModeAuto})
+	m.width = 96
+
+	// shift+tab toggles Auto<->Ask only; Unsafe is intentionally NOT reachable by
+	// a casual keypress (it disables permission prompts).
+	for _, want := range []agent.PermissionMode{
+		agent.PermissionModeAsk,
+		agent.PermissionModeAuto,
+	} {
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatalf("expected shift+tab to cycle mode synchronously, got command")
+		}
+		if m.permissionMode != want {
+			t.Fatalf("expected permission mode %q after shift+tab, got %q", want, m.permissionMode)
+		}
+		if m.permissionMode == agent.PermissionModeUnsafe {
+			t.Fatalf("shift+tab must never land on Unsafe")
+		}
+	}
+
+	// The rendered status label tracks the cycled mode.
+	label, _ := m.modeLabel()
+	if label != "auto-approve edits" {
+		t.Fatalf("expected mode label to track cycled mode, got %q", label)
+	}
+}
+
+func TestShiftTabDoesNotCycleWhileModalsActive(t *testing.T) {
+	// Permission modal, ask_user prompt, and an open picker all take precedence:
+	// shift+tab must not change the mode while any is up.
+	t.Run("permission", func(t *testing.T) {
+		m := newModel(context.Background(), Options{PermissionMode: agent.PermissionModeAuto})
+		m.pending = true
+		m.activeRunID = 7
+		updated, _ := m.Update(permissionRequestMsg{runID: 7, request: testPromptPermissionRequest()})
+		next := updated.(model)
+		updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+		next = updated.(model)
+		if next.permissionMode != agent.PermissionModeAuto {
+			t.Fatalf("expected mode unchanged while permission modal is up, got %q", next.permissionMode)
+		}
+		if next.pendingPermission == nil {
+			t.Fatal("expected permission prompt to remain pending")
+		}
+	})
+	t.Run("ask_user", func(t *testing.T) {
+		m := newModel(context.Background(), Options{PermissionMode: agent.PermissionModeAuto})
+		m.pending = true
+		m.activeRunID = 7
+		updated, _ := m.Update(askUserRequestMsg{runID: 7, request: testAskUserRequest(), answer: func([]string) {}})
+		next := updated.(model)
+		updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+		next = updated.(model)
+		if next.permissionMode != agent.PermissionModeAuto {
+			t.Fatalf("expected mode unchanged while ask_user prompt is up, got %q", next.permissionMode)
+		}
+		if next.pendingAskUser == nil {
+			t.Fatal("expected ask_user prompt to remain pending")
+		}
+	})
+	t.Run("picker", func(t *testing.T) {
+		m := newModel(context.Background(), Options{
+			ProviderName:   "openai",
+			ModelName:      "gpt-4.1",
+			Provider:       &fakeProvider{},
+			PermissionMode: agent.PermissionModeAuto,
+		})
+		m.input.SetValue("/model")
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		next := updated.(model)
+		if next.picker == nil {
+			t.Skip("model picker unavailable in test environment")
+		}
+		updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+		next = updated.(model)
+		if next.permissionMode != agent.PermissionModeAuto {
+			t.Fatalf("expected mode unchanged while picker is open, got %q", next.permissionMode)
+		}
+	})
+}
+
 func TestCtrlCExits(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -31,4 +31,10 @@ type Options struct {
 	PermissionMode  agent.PermissionMode
 	ReasoningEffort modelregistry.ReasoningEffort
 	ResponseStyle   string
+
+	// Skin selects the rendering style. "" is the default Zero shell; "zeroline"
+	// renders the Zen home / Statusline chat surface with switchable color themes.
+	Skin         string
+	ThemeVariant int  // zeroline color theme index (0-4)
+	ThemeDark    bool // zeroline light/dark mode
 }

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/zeroline"
+)
+
+// pickerKind identifies which command a picker selection feeds back into.
+type pickerKind int
+
+const (
+	pickerModel pickerKind = iota
+	pickerTheme
+	pickerEffort
+	pickerMode
+)
+
+// pickerItem is one selectable row: Label is shown, Value is passed to the
+// underlying command handler when chosen.
+type pickerItem struct {
+	Label string
+	Value string
+}
+
+// commandPicker is a generic single-select overlay reused by /model, /theme,
+// /effort, and /mode (invoked with no argument). It owns only list state; the
+// chosen value is applied through the existing command handlers.
+type commandPicker struct {
+	kind     pickerKind
+	title    string
+	items    []pickerItem
+	selected int
+}
+
+func (p *commandPicker) move(delta int) {
+	n := len(p.items)
+	if n == 0 {
+		return
+	}
+	p.selected = ((p.selected+delta)%n + n) % n
+}
+
+func (p *commandPicker) current() (pickerItem, bool) {
+	if p.selected < 0 || p.selected >= len(p.items) {
+		return pickerItem{}, false
+	}
+	return p.items[p.selected], true
+}
+
+// newModelPicker lists active (non-deprecated) models, preselecting the active
+// one. Returns nil when the catalog is unavailable so the caller falls back to
+// the plain status text.
+func (m model) newModelPicker() *commandPicker {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return nil
+	}
+	entries := registry.List(modelregistry.ListOptions{})
+	if len(entries) == 0 {
+		return nil
+	}
+	items := make([]pickerItem, 0, len(entries))
+	selected := 0
+	for i, entry := range entries {
+		label := entry.DisplayName
+		if label == "" {
+			label = entry.ID
+		}
+		items = append(items, pickerItem{Label: label + "  " + entry.ID, Value: entry.ID})
+		if entry.ID == m.modelName {
+			selected = i
+		}
+	}
+	return &commandPicker{kind: pickerModel, title: "select model", items: items, selected: selected}
+}
+
+// newThemePicker lists the zeroline color themes, preselecting the active one.
+func (m model) newThemePicker() *commandPicker {
+	items := make([]pickerItem, 0, len(zeroline.Themes))
+	for _, theme := range zeroline.Themes {
+		items = append(items, pickerItem{Label: theme.Name, Value: theme.Name})
+	}
+	selected := m.themeVariant
+	if selected < 0 || selected >= len(items) {
+		selected = 0
+	}
+	return &commandPicker{kind: pickerTheme, title: "select theme", items: items, selected: selected}
+}
+
+// newEffortPicker lists the reasoning efforts the active model supports plus an
+// "auto" option, preselecting the current preference. Returns nil when the model
+// exposes no effort controls so the caller falls back to status text.
+func (m model) newEffortPicker() *commandPicker {
+	efforts := m.availableReasoningEfforts()
+	if len(efforts) == 0 {
+		return nil
+	}
+	items := []pickerItem{{Label: "auto", Value: "auto"}}
+	selected := 0
+	for _, effort := range efforts {
+		items = append(items, pickerItem{Label: string(effort), Value: string(effort)})
+		if m.reasoningEffort != "" && effort == m.reasoningEffort {
+			selected = len(items) - 1
+		}
+	}
+	return &commandPicker{kind: pickerEffort, title: "select reasoning effort", items: items, selected: selected}
+}
+
+// newModePicker lists the agent modes, preselecting none (modes don't carry a
+// single "active" identity).
+func (m model) newModePicker() *commandPicker {
+	modes := modelregistry.Modes()
+	if len(modes) == 0 {
+		return nil
+	}
+	items := make([]pickerItem, 0, len(modes))
+	for _, mode := range modes {
+		label := mode.Name
+		if mode.Description != "" {
+			label += " — " + mode.Description
+		}
+		items = append(items, pickerItem{Label: label, Value: mode.Name})
+	}
+	return &commandPicker{kind: pickerMode, title: "select mode", items: items, selected: 0}
+}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -1,0 +1,198 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestModelPickerOpensAndCancels(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "claude-sonnet-4.5"})
+	m.input.SetValue("/model")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("opening the model picker should not start a run")
+	}
+	if m.picker == nil || m.picker.kind != pickerModel {
+		t.Fatalf("expected an open model picker, got %#v", m.picker)
+	}
+
+	// Esc cancels the picker without touching the run or transcript.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+	if m.picker != nil {
+		t.Fatal("Esc should close the picker")
+	}
+}
+
+func TestModelPickerNavigatesAndChoosesAppliesHandler(t *testing.T) {
+	next := &fakeProvider{}
+	m := newModel(context.Background(), Options{
+		ProviderName:    "anthropic",
+		ModelName:       "claude-sonnet-4.5",
+		Provider:        &fakeProvider{},
+		ProviderProfile: anthropicTestProfile("claude-sonnet-4.5"),
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			return next, nil
+		},
+	})
+	m.input.SetValue("/model")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.picker == nil {
+		t.Fatal("expected model picker open")
+	}
+
+	// Point the picker at a concrete, different model in the same provider family
+	// and choose it (cross-provider switches require a matching profile).
+	target := -1
+	for i, item := range m.picker.items {
+		if item.Value == "claude-haiku-4.5" {
+			target = i
+			break
+		}
+	}
+	if target < 0 {
+		t.Fatal("expected claude-haiku-4.5 in the model picker")
+	}
+	m.picker.selected = target
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.picker != nil {
+		t.Fatal("choosing should close the picker")
+	}
+	if m.modelName != "claude-haiku-4.5" {
+		t.Fatalf("expected model switched to claude-haiku-4.5 via handler, got %q", m.modelName)
+	}
+	if !transcriptContains(m.transcript, "Model") {
+		t.Fatal("choosing should append the model handler's status text")
+	}
+}
+
+func TestEffortPickerOpensForSupportedModel(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "claude-sonnet-4.5"})
+	m.input.SetValue("/effort")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.picker == nil || m.picker.kind != pickerEffort {
+		t.Fatalf("expected an open effort picker, got %#v", m.picker)
+	}
+	// "auto" is always offered as the first option.
+	if len(m.picker.items) == 0 || m.picker.items[0].Value != "auto" {
+		t.Fatalf("expected auto as the first effort option, got %#v", m.picker.items)
+	}
+
+	// Choose the highlighted effort; the handler stores the preference.
+	for i, item := range m.picker.items {
+		if item.Value == "high" {
+			m.picker.selected = i
+		}
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.reasoningEffort != "high" {
+		t.Fatalf("expected effort applied via handler, got %q", m.reasoningEffort)
+	}
+}
+
+func TestThemePickerOnlyInZerolineSkin(t *testing.T) {
+	// Default skin keeps the existing shell-only message; no picker opens.
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/theme")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.picker != nil {
+		t.Fatal("default skin should not open a theme picker")
+	}
+
+	// Zeroline skin opens the theme picker and choosing sets the variant.
+	z := newModel(context.Background(), Options{Skin: "zeroline", ThemeDark: true})
+	z.input.SetValue("/theme")
+	updatedZ, _ := z.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	z = updatedZ.(model)
+	if z.picker == nil || z.picker.kind != pickerTheme {
+		t.Fatalf("zeroline /theme should open a theme picker, got %#v", z.picker)
+	}
+	z.picker.selected = 2
+	updatedZ, _ = z.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	z = updatedZ.(model)
+	if z.themeVariant != 2 {
+		t.Fatalf("choosing a theme should set the variant, got %d", z.themeVariant)
+	}
+}
+
+func TestPickersRefuseToOpenWhileRunPending(t *testing.T) {
+	// A picker opened while a run is in flight would have its selection refused
+	// after the run, so opening it at all is misleading. Each no-arg picker command
+	// must no-op into a brief "while a run is in progress" message instead.
+	cases := []struct {
+		name    string
+		command string
+		skin    string
+	}{
+		{name: "model", command: "/model"},
+		{name: "mode", command: "/mode"},
+		{name: "effort", command: "/effort"},
+		{name: "theme", command: "/theme", skin: "zeroline"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newModel(context.Background(), Options{
+				Skin:      tc.skin,
+				ThemeDark: true,
+				ModelName: "claude-sonnet-4.5",
+			})
+			m.pending = true
+			m.input.SetValue(tc.command)
+
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			next := updated.(model)
+			if cmd != nil {
+				t.Fatalf("%s while pending should not start a run", tc.command)
+			}
+			if next.picker != nil {
+				t.Fatalf("%s should not open a picker while a run is in progress, got %#v", tc.command, next.picker)
+			}
+			if !transcriptContains(next.transcript, "while a run is in progress") {
+				t.Fatalf("%s should explain it can't change settings while a run is in progress, got %q", tc.command, transcriptText(next.transcript))
+			}
+			if !next.pending {
+				t.Fatalf("%s must not clear the in-flight run", tc.command)
+			}
+		})
+	}
+}
+
+func TestPickerRendersInBothSkins(t *testing.T) {
+	// Default skin.
+	m := newModel(context.Background(), Options{ModelName: "claude-sonnet-4.5"})
+	m.width, m.height = 96, 30
+	m.showSplash = false
+	m.input.SetValue("/model")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if !strings.Contains(m.View(), "select model") {
+		t.Fatal("default-skin view should render the picker title")
+	}
+
+	// Zeroline skin.
+	z := newModel(context.Background(), Options{Skin: "zeroline", ThemeDark: true, ModelName: "claude-sonnet-4.5"})
+	z.width, z.height = 100, 30
+	z.booted = true
+	z.showSplash = false
+	z.input.SetValue("/model")
+	updatedZ, _ := z.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	z = updatedZ.(model)
+	if !strings.Contains(z.View(), "select model") {
+		t.Fatal("zeroline view should render the picker title")
+	}
+}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/agent"
@@ -19,6 +20,22 @@ func (m model) runState() string {
 		return "running"
 	}
 	return "ready"
+}
+
+// pickerBusyText explains that a settings picker (/model, /mode, /effort, /theme)
+// can't be opened while a run is in flight. Opening it then would silently refuse
+// the selection once the run lands, so the no-arg command no-ops into this notice.
+func pickerBusyText(name string) string {
+	label := strings.TrimPrefix(name, "/")
+	return renderCommandOutput(commandOutput{
+		Title:  label,
+		Status: commandStatusWarning,
+		Sections: []commandSection{{
+			Title: "Busy",
+			Lines: []string{"Can't change " + label + " while a run is in progress."},
+		}},
+		Hints: []string{"press Esc to cancel the run, then try again"},
+	})
 }
 
 func shellOnlyCommandText(name string) string {
@@ -113,9 +130,19 @@ func renderRow(row transcriptRow, width int) string {
 		return renderToolResultRow(row, width)
 	case rowPermission:
 		return renderPermissionRow(row)
+	case rowAskUser:
+		return renderAskUserRow(row)
 	default:
 		return row.text
 	}
+}
+
+func renderAskUserRow(row transcriptRow) string {
+	line := zeroTheme.zero.Render("ask zero") + "  " + zeroTheme.text.Render(strings.TrimPrefix(row.text, "ask_user: "))
+	if detail := strings.TrimSpace(row.detail); detail != "" {
+		line += "\n" + indentText(zeroTheme.muted.Render(detail), 2)
+	}
+	return line
 }
 
 func renderToolCallRow(row transcriptRow) string {
@@ -196,6 +223,37 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, width int) s
 	}
 
 	return borderedBlock(width, []string{header, choices})
+}
+
+func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, input string, width int) string {
+	questions := prompt.request.Questions
+	total := len(questions)
+	index := prompt.index
+	if index >= total {
+		index = total - 1
+	}
+	if index < 0 {
+		index = 0
+	}
+
+	lines := []string{}
+	heading := zeroTheme.zero.Render("ask zero")
+	if header := strings.TrimSpace(prompt.request.Header); header != "" {
+		heading += "  " + zeroTheme.text.Render(header)
+	}
+	lines = append(lines, heading)
+
+	if total > 0 {
+		question := questions[index]
+		lines = append(lines, zeroTheme.muted.Render(fmt.Sprintf("question %d of %d", index+1, total)))
+		lines = append(lines, zeroTheme.text.Render(question.Question))
+		if len(question.Options) > 0 {
+			lines = append(lines, zeroTheme.muted.Render("options: "+strings.Join(question.Options, ", ")))
+		}
+	}
+	lines = append(lines, zeroTheme.muted.Render("type an answer, Enter to submit · Esc to skip"))
+
+	return borderedBlock(width, lines)
 }
 
 func renderToolResultRow(row transcriptRow, width int) string {

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -20,12 +20,17 @@ func Run(ctx context.Context, options Options) int {
 		}
 	}
 
-	program = tea.NewProgram(
-		newModel(ctx, options),
+	programOpts := []tea.ProgramOption{
 		tea.WithContext(ctx),
 		tea.WithInput(os.Stdin),
 		tea.WithOutput(os.Stdout),
-	)
+	}
+	// NOTE: we intentionally do NOT enable mouse capture. Mouse cell-motion
+	// reporting routes clicks/drags to the program, which breaks the terminal's
+	// native text selection + copy and surprises users who expect normal
+	// click/select/copy/paste. The permission modal is fully keyboard-driven
+	// (a/y/d/Esc), so capturing the mouse buys little and costs core UX.
+	program = tea.NewProgram(newModel(ctx, options), programOpts...)
 
 	if _, err := program.Run(); err != nil {
 		return 1

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -70,6 +70,23 @@ func (m model) appendSessionEvents(events []pendingSessionEvent) (model, []trans
 	return m, rows
 }
 
+// flushableSessionEvents selects the events worth persisting from a run that was
+// cancelled mid-flight. The cancel path already records a single "Run cancelled."
+// error, so the goroutine's trailing EventError (the ctx-cancellation error) is
+// dropped to avoid a duplicate; everything else it accumulated before the cancel
+// — tool calls/results, permission events, usage, and the EventSessionCheckpoint
+// blobs that /rewind depends on — is kept.
+func flushableSessionEvents(events []pendingSessionEvent) []pendingSessionEvent {
+	flushable := make([]pendingSessionEvent, 0, len(events))
+	for _, event := range events {
+		if event.Type == sessions.EventError {
+			continue
+		}
+		flushable = append(flushable, event)
+	}
+	return flushable
+}
+
 func tuiSessionTitle(prompt string) string {
 	title := strings.Join(strings.Fields(prompt), " ")
 	if len(title) > tuiSessionTitleLimit {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/usage"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -162,6 +164,58 @@ func (m model) handleCompactCommand(args string) (model, string) {
 	}
 	m.compactRequests++
 	return m, m.compactText(true)
+}
+
+// handleRewindCommand restores workspace files to a checkpoint and truncates the
+// session log. "/rewind" or "/rewind latest" undoes the most recent checkpoint;
+// "/rewind <n>" rewinds to a specific event sequence.
+func (m model) handleRewindCommand(args string) (model, string) {
+	if m.sessionStore == nil || m.activeSession.SessionID == "" {
+		return m, "Rewind\nno active session to rewind."
+	}
+	if m.pending {
+		return m, "Rewind\ncannot rewind while a run is in progress."
+	}
+	arg := strings.TrimSpace(strings.ToLower(args))
+	target, err := m.resolveRewindTarget(arg)
+	if err != nil {
+		return m, "Rewind\n" + err.Error()
+	}
+	report, err := m.sessionStore.ApplyRewind(m.activeSession.SessionID, m.cwd, target)
+	if err != nil {
+		return m, "Rewind\n" + err.Error()
+	}
+	summary := fmt.Sprintf("Rewound to sequence %d\n%d file(s) restored, %d deleted, %d skipped.",
+		target, report.FilesRestored, report.FilesDeleted, len(report.Skipped))
+	if len(report.Skipped) > 0 {
+		summary += "\nskipped (not recoverable): " + strings.Join(report.Skipped, ", ")
+	}
+	return m, summary
+}
+
+// resolveRewindTarget maps a /rewind argument to a keep-through event sequence.
+func (m model) resolveRewindTarget(arg string) (int, error) {
+	events, err := m.sessionStore.ReadEvents(m.activeSession.SessionID)
+	if err != nil {
+		return 0, err
+	}
+	if arg == "" || arg == "latest" {
+		lastCheckpoint := 0
+		for _, ev := range events {
+			if ev.Type == sessions.EventSessionCheckpoint && ev.Sequence > lastCheckpoint {
+				lastCheckpoint = ev.Sequence
+			}
+		}
+		if lastCheckpoint == 0 {
+			return 0, fmt.Errorf("no checkpoints to rewind")
+		}
+		return lastCheckpoint - 1, nil // undo the most recent checkpoint
+	}
+	seq, err := strconv.Atoi(arg)
+	if err != nil || seq < 0 {
+		return 0, fmt.Errorf("usage: /rewind [latest|<sequence>]")
+	}
+	return seq, nil
 }
 
 func (m model) compactText(requested bool) string {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -185,6 +185,23 @@ func (m model) handleRewindCommand(args string) (model, string) {
 	if err != nil {
 		return m, "Rewind\n" + err.Error()
 	}
+
+	// ApplyRewind truncated the persisted event log, restored files, and appended a
+	// rewind marker — so reload the in-memory session state. Otherwise the dropped
+	// events would still (a) be re-sent to the agent as ContextEvents on the next
+	// prompt (sessionPrompt sends m.sessionEvents) and (b) linger in the transcript.
+	if meta, getErr := m.sessionStore.Get(m.activeSession.SessionID); getErr == nil {
+		m.activeSession = *meta
+	}
+	if events, readErr := m.sessionStore.ReadEvents(m.activeSession.SessionID); readErr == nil {
+		m.sessionEvents = append([]sessions.Event{}, events...)
+		rows := initialTranscript()
+		for _, row := range transcriptRowsFromSessionEvents(events) {
+			rows = appendTranscriptRow(rows, row)
+		}
+		m.transcript = rows
+	}
+
 	summary := fmt.Sprintf("Rewound to sequence %d\n%d file(s) restored, %d deleted, %d skipped.",
 		target, report.FilesRestored, report.FilesDeleted, len(report.Skipped))
 	if len(report.Skipped) > 0 {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -310,8 +310,65 @@ func TestModelSwitchClearsUnsupportedEffortPreference(t *testing.T) {
 	if next.reasoningEffort != "" {
 		t.Fatalf("expected unsupported effort preference to reset, got %q", next.reasoningEffort)
 	}
-	if !transcriptContains(next.transcript, "unsupported preference reset") {
+	if !transcriptContains(next.transcript, "effort: auto (unsupported preference reset)") {
 		t.Fatalf("expected model switch transcript to mention effort reset, got %#v", next.transcript)
+	}
+}
+
+func TestModelSwitchRedirectsDeprecatedModelWithNotice(t *testing.T) {
+	nextProvider := &fakeProvider{}
+	m := newModel(context.Background(), Options{
+		ProviderName:    "openai",
+		ModelName:       "gpt-4.1",
+		Provider:        &fakeProvider{},
+		ProviderProfile: openAITestProfile("gpt-4.1"),
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			if profile.Model != "gpt-4.1" {
+				t.Fatalf("expected deprecated model to redirect to gpt-4.1, got %#v", profile)
+			}
+			return nextProvider, nil
+		},
+	})
+	m.input.SetValue("/model gpt-4-turbo")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /model to be handled without starting an agent run")
+	}
+	if next.modelName != "gpt-4.1" {
+		t.Fatalf("expected active model to be gpt-4.1 after redirect, got %q", next.modelName)
+	}
+	if !transcriptContains(next.transcript, "deprecated") {
+		t.Fatalf("expected deprecation notice in transcript, got %#v", next.transcript)
+	}
+	if !transcriptContains(next.transcript, "model: gpt-4.1") {
+		t.Fatalf("expected switch to canonical fallback id, got %#v", next.transcript)
+	}
+}
+
+func TestModelSwitchUnknownModelReportsError(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName:    "openai",
+		ModelName:       "gpt-4.1",
+		Provider:        &fakeProvider{},
+		ProviderProfile: openAITestProfile("gpt-4.1"),
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			t.Fatal("provider should not be rebuilt for an unknown model")
+			return nil, nil
+		},
+	})
+	m.input.SetValue("/model totally-unknown-model")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if next.modelName != "gpt-4.1" {
+		t.Fatalf("expected active model to stay gpt-4.1, got %q", next.modelName)
+	}
+	if !transcriptContains(next.transcript, "unknown Zero model") {
+		t.Fatalf("expected unknown model error, got %#v", next.transcript)
 	}
 }
 
@@ -322,5 +379,118 @@ func openAITestProfile(modelID string) config.ProviderProfile {
 		BaseURL:      config.OpenAIBaseURL,
 		APIKey:       "sk-test",
 		Model:        modelID,
+	}
+}
+
+func anthropicTestProfile(modelID string) config.ProviderProfile {
+	return config.ProviderProfile{
+		Name:         "anthropic",
+		ProviderKind: config.ProviderKindAnthropic,
+		BaseURL:      config.AnthropicBaseURL,
+		APIKey:       "sk-test",
+		Model:        modelID,
+	}
+}
+
+func TestModeCommandListsPresets(t *testing.T) {
+	// "/mode list" prints the preset list (no picker for an explicit subcommand).
+	m := newModel(context.Background(), Options{ModelName: "claude-sonnet-4.5"})
+	m.input.SetValue("/mode list")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /mode list to be handled without starting an agent run")
+	}
+	for _, want := range []string{"Mode", "smart", "deep", "fast", "large", "precise", "model=claude-opus-4.1", "turns=50"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected mode list transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
+func TestModeCommandNoArgOpensPicker(t *testing.T) {
+	// A bare "/mode" opens the interactive picker instead of printing status.
+	m := newModel(context.Background(), Options{ModelName: "claude-sonnet-4.5"})
+	m.input.SetValue("/mode")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /mode picker open without starting an agent run")
+	}
+	if next.picker == nil || next.picker.kind != pickerMode {
+		t.Fatalf("expected an open mode picker, got %#v", next.picker)
+	}
+	if len(next.picker.items) == 0 {
+		t.Fatal("expected mode picker to list presets")
+	}
+}
+
+func TestModeCommandSwitchesModelEffortAndTurns(t *testing.T) {
+	nextProvider := &fakeProvider{}
+	m := newModel(context.Background(), Options{
+		ProviderName:    "anthropic",
+		ModelName:       "claude-sonnet-4.5",
+		Provider:        &fakeProvider{},
+		ProviderProfile: anthropicTestProfile("claude-sonnet-4.5"),
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			if profile.Model != "claude-opus-4.1" {
+				t.Fatalf("expected provider rebuild for claude-opus-4.1, got %#v", profile)
+			}
+			return nextProvider, nil
+		},
+		AgentOptions: agent.Options{MaxTurns: 12},
+	})
+	m.input.SetValue("/mode deep")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /mode deep to be handled without starting an agent run")
+	}
+	if next.modelName != "claude-opus-4.1" {
+		t.Fatalf("expected model claude-opus-4.1, got %q", next.modelName)
+	}
+	if next.reasoningEffort != modelregistry.ReasoningEffortHigh {
+		t.Fatalf("expected effort high, got %q", next.reasoningEffort)
+	}
+	if next.agentOptions.MaxTurns != 50 {
+		t.Fatalf("expected max turns 50, got %d", next.agentOptions.MaxTurns)
+	}
+	if next.provider != nextProvider {
+		t.Fatal("expected provider to be rebuilt for the mode model")
+	}
+	for _, want := range []string{"mode deep", "model: claude-opus-4.1", "effort: high", "max turns: 50"} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected mode switch transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
+func TestModeCommandUnknownReportsError(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName:    "anthropic",
+		ModelName:       "claude-sonnet-4.5",
+		Provider:        &fakeProvider{},
+		ProviderProfile: anthropicTestProfile("claude-sonnet-4.5"),
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			t.Fatal("provider should not be rebuilt for an unknown mode")
+			return nil, nil
+		},
+	})
+	m.input.SetValue("/mode turbo")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if next.modelName != "claude-sonnet-4.5" {
+		t.Fatalf("expected active model to stay claude-sonnet-4.5, got %q", next.modelName)
+	}
+	if !transcriptContains(next.transcript, "unknown mode") {
+		t.Fatalf("expected unknown mode error, got %#v", next.transcript)
 	}
 }

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -608,6 +608,51 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	}
 }
 
+// Regression: after /rewind the in-memory session state must be reloaded so the
+// rewound-away events don't linger in the transcript or get re-sent to the agent
+// as ContextEvents on the next prompt.
+func TestRewindRefreshesInMemorySessionState(t *testing.T) {
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "Rewind me", Cwd: t.TempDir(), ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "user", "content": "first request"})
+	// A checkpoint to rewind back through, then events that must be dropped.
+	appendTestEvent(t, store, session.SessionID, sessions.EventSessionCheckpoint, map[string]any{"tool": "write_file", "files": []any{}})
+	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "assistant", "content": "DROPPED-AFTER-CHECKPOINT"})
+
+	m := newModel(context.Background(), Options{SessionStore: store})
+	m.input.SetValue("/resume " + session.SessionID)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if !transcriptContains(m.transcript, "DROPPED-AFTER-CHECKPOINT") {
+		t.Fatalf("setup: resumed transcript should include the post-checkpoint message")
+	}
+	eventsBefore := len(m.sessionEvents)
+
+	m, out := m.handleRewindCommand("latest")
+	if !strings.Contains(out, "Rewound") {
+		t.Fatalf("expected a rewind summary, got %q", out)
+	}
+
+	if len(m.sessionEvents) >= eventsBefore {
+		t.Fatalf("expected sessionEvents to shrink after rewind, before=%d after=%d", eventsBefore, len(m.sessionEvents))
+	}
+	for _, ev := range m.sessionEvents {
+		if ev.Type == sessions.EventSessionCheckpoint {
+			t.Fatalf("rewound-away checkpoint still in m.sessionEvents: %#v", m.sessionEvents)
+		}
+	}
+	if transcriptContains(m.transcript, "DROPPED-AFTER-CHECKPOINT") {
+		t.Fatalf("rewound-away message still visible in transcript: %#v", m.transcript)
+	}
+	// The crux: the next prompt must NOT re-send the rewound-away content.
+	if prompt := m.sessionPrompt("next request"); strings.Contains(prompt, "DROPPED-AFTER-CHECKPOINT") {
+		t.Fatalf("rewound-away content leaked into the next prompt: %q", prompt)
+	}
+}
+
 func TestResumeCommandIsBlockedWhileRunPending(t *testing.T) {
 	store := testSessionStore(t)
 	active, err := store.Create(sessions.CreateInput{Title: "Active"})

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -285,6 +285,7 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
 		sessions.EventMessage,
 		sessions.EventToolCall,
+		sessions.EventSessionCheckpoint,
 		sessions.EventPermissionRequest,
 		sessions.EventPermissionDecision,
 		sessions.EventToolResult,
@@ -292,15 +293,15 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 	}) {
 		t.Fatalf("unexpected event sequence: %#v", got)
 	}
-	assertPayloadField(t, events[2], "toolCallId", "call_write")
-	assertPayloadField(t, events[2], "name", "write_file")
-	assertPayloadField(t, events[2], "action", "prompt")
-	assertPayloadField(t, events[2], "permission", "prompt")
-	assertPayloadField(t, events[2], "permissionMode", "ask")
-	assertPayloadField(t, events[2], "sideEffect", "write")
-	assertPayloadField(t, events[3], "action", "deny")
-	assertPayloadField(t, events[3], "decisionReason", "denied in TUI")
-	assertPayloadField(t, events[5], "content", "write blocked")
+	assertPayloadField(t, events[3], "toolCallId", "call_write")
+	assertPayloadField(t, events[3], "name", "write_file")
+	assertPayloadField(t, events[3], "action", "prompt")
+	assertPayloadField(t, events[3], "permission", "prompt")
+	assertPayloadField(t, events[3], "permissionMode", "ask")
+	assertPayloadField(t, events[3], "sideEffect", "write")
+	assertPayloadField(t, events[4], "action", "deny")
+	assertPayloadField(t, events[4], "decisionReason", "denied in TUI")
+	assertPayloadField(t, events[6], "content", "write blocked")
 	if !transcriptContains(next.transcript, "permission: write_file prompt") {
 		t.Fatalf("expected permission row in transcript, got %#v", next.transcript)
 	}
@@ -334,6 +335,7 @@ func TestPermissionPromptAllowWritesFileAndRecordsDecision(t *testing.T) {
 	if got := eventTypes(events); !equalEventTypes(got, []sessions.EventType{
 		sessions.EventMessage,
 		sessions.EventToolCall,
+		sessions.EventSessionCheckpoint,
 		sessions.EventPermissionRequest,
 		sessions.EventPermissionDecision,
 		sessions.EventToolResult,
@@ -341,10 +343,10 @@ func TestPermissionPromptAllowWritesFileAndRecordsDecision(t *testing.T) {
 	}) {
 		t.Fatalf("unexpected event sequence: %#v", got)
 	}
-	assertPayloadField(t, events[3], "action", "allow")
-	assertPayloadField(t, events[3], "decisionReason", "approved in TUI")
-	assertPayloadField(t, events[4], "status", "ok")
-	assertPayloadField(t, events[5], "content", "write allowed")
+	assertPayloadField(t, events[4], "action", "allow")
+	assertPayloadField(t, events[4], "decisionReason", "approved in TUI")
+	assertPayloadField(t, events[5], "status", "ok")
+	assertPayloadField(t, events[6], "content", "write allowed")
 	if !transcriptContains(next.transcript, "permission: write_file allow") {
 		t.Fatalf("expected allow decision in transcript, got %#v", next.transcript)
 	}
@@ -704,6 +706,164 @@ func TestEscCancelRecordsSessionError(t *testing.T) {
 	assertPayloadField(t, events[1], "message", "Run cancelled.")
 	if next.pending {
 		t.Fatal("expected Esc to clear pending state")
+	}
+}
+
+func TestCancelledRunFlushesCheckpointSessionEvents(t *testing.T) {
+	store := testSessionStore(t)
+	root := t.TempDir()
+	writeTestFile(t, root, "notes.txt", "before")
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		writeFileToolScript("call_write", "notes.txt", "after"),
+		textScript("never reached"),
+	}}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	runtimeMessageCh := make(chan tea.Msg, 8)
+	m := newPermissionTestModel(root, provider, registry, store, nil, runtimeMessageCh)
+	m.input.SetValue("rewrite notes")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+
+	finalCh := make(chan tea.Msg, 1)
+	go func() {
+		finalCh <- cmd()
+	}()
+
+	// Drain live runtime messages until the permission prompt is up. The tool call
+	// (and its checkpoint snapshot) is captured into the goroutine's in-flight
+	// sessionEvents before the run blocks on the permission decision.
+	cancelled := false
+	for !cancelled {
+		runtimeMsg := receiveRuntimeMessage(t, runtimeMessageCh)
+		updated, _ = next.Update(runtimeMsg)
+		next = updated.(model)
+		if _, ok := runtimeMsg.(permissionRequestMsg); ok {
+			// Cancel mid-run via Esc while the permission prompt is pending: this
+			// unblocks the goroutine through ctx cancellation.
+			updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			next = updated.(model)
+			cancelled = true
+		}
+	}
+	if next.pending {
+		t.Fatal("expected Esc to clear pending state")
+	}
+	if len(next.flushRunIDs) == 0 {
+		t.Fatal("expected cancelled run to be flagged for session-event flush")
+	}
+
+	// The cancelled goroutine still returns its accumulated session events. Deliver
+	// that final message; the checkpoint must be persisted even though activeRunID
+	// is already zeroed.
+	finalMsg := receiveFinalMessage(t, finalCh)
+	updated, _ = next.Update(finalMsg)
+	next = updated.(model)
+	if len(next.flushRunIDs) != 0 {
+		t.Fatalf("expected flush set to clear after draining cancelled run, got %v", next.flushRunIDs)
+	}
+
+	events := readOnlySessionEvents(t, store)
+	if countSessionEvents(events, sessions.EventSessionCheckpoint) != 1 {
+		t.Fatalf("expected the in-flight checkpoint to be persisted on cancel, got %#v", eventTypes(events))
+	}
+	if countSessionEvents(events, sessions.EventToolCall) != 1 {
+		t.Fatalf("expected the in-flight tool call to be persisted on cancel, got %#v", eventTypes(events))
+	}
+	// The cancel path records exactly one "Run cancelled." error; the goroutine's
+	// trailing cancellation error must be dropped, not double-recorded.
+	if got := countSessionEvents(events, sessions.EventError); got != 1 {
+		t.Fatalf("expected exactly one cancellation error event, got %d in %#v", got, eventTypes(events))
+	}
+	cancelErr := nthSessionEvent(t, events, sessions.EventError, 1)
+	assertPayloadField(t, cancelErr, "message", "Run cancelled.")
+}
+
+func TestCtrlCFlushesCheckpointSessionEvents(t *testing.T) {
+	store := testSessionStore(t)
+	root := t.TempDir()
+	writeTestFile(t, root, "notes.txt", "before")
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		writeFileToolScript("call_write", "notes.txt", "after"),
+		textScript("never reached"),
+	}}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	runtimeMessageCh := make(chan tea.Msg, 8)
+	m := newPermissionTestModel(root, provider, registry, store, nil, runtimeMessageCh)
+	m.input.SetValue("rewrite notes")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+
+	finalCh := make(chan tea.Msg, 1)
+	go func() {
+		finalCh <- cmd()
+	}()
+
+	// Drain live runtime messages until the permission prompt is up; the tool call
+	// and its checkpoint snapshot are captured into the goroutine's in-flight
+	// sessionEvents before the run blocks on the permission decision.
+	cancelled := false
+	for !cancelled {
+		runtimeMsg := receiveRuntimeMessage(t, runtimeMessageCh)
+		updated, _ = next.Update(runtimeMsg)
+		next = updated.(model)
+		if _, ok := runtimeMsg.(permissionRequestMsg); ok {
+			// Ctrl+C while the permission prompt is pending: this must cancel the
+			// in-flight run (unblocking the goroutine via ctx) AND mark the model
+			// exiting — but it must NOT quit before the in-flight run's final
+			// message has been drained, or the captured checkpoint is orphaned.
+			var exitCmd tea.Cmd
+			updated, exitCmd = next.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+			next = updated.(model)
+			if !next.exiting {
+				t.Fatal("expected Ctrl+C to mark model exiting")
+			}
+			if exitCmd != nil {
+				t.Fatal("expected Ctrl+C to defer quit while an in-flight run still needs flushing")
+			}
+			cancelled = true
+		}
+	}
+	if next.pending {
+		t.Fatal("expected Ctrl+C to clear pending state")
+	}
+	if len(next.flushRunIDs) == 0 {
+		t.Fatal("expected cancelled run to be flagged for session-event flush")
+	}
+
+	// The cancelled goroutine still returns its accumulated session events. Deliver
+	// that final message; the checkpoint must be persisted even though activeRunID
+	// is already zeroed, and the deferred quit must fire now.
+	finalMsg := receiveFinalMessage(t, finalCh)
+	updated, quitCmd := next.Update(finalMsg)
+	next = updated.(model)
+	if len(next.flushRunIDs) != 0 {
+		t.Fatalf("expected flush set to clear after draining cancelled run, got %v", next.flushRunIDs)
+	}
+	if quitCmd == nil {
+		t.Fatal("expected deferred quit to fire once the in-flight run is flushed on Ctrl+C")
+	}
+
+	events := readOnlySessionEvents(t, store)
+	if countSessionEvents(events, sessions.EventSessionCheckpoint) != 1 {
+		t.Fatalf("expected the in-flight checkpoint to be persisted on Ctrl+C, got %#v", eventTypes(events))
+	}
+	if countSessionEvents(events, sessions.EventToolCall) != 1 {
+		t.Fatalf("expected the in-flight tool call to be persisted on Ctrl+C, got %#v", eventTypes(events))
+	}
+	// The cancel path records exactly one "Run cancelled." error; the goroutine's
+	// trailing cancellation error must be dropped, not double-recorded.
+	if got := countSessionEvents(events, sessions.EventError); got != 1 {
+		t.Fatalf("expected exactly one cancellation error event, got %d in %#v", got, eventTypes(events))
 	}
 }
 

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -17,6 +17,7 @@ const (
 	rowToolCall
 	rowToolResult
 	rowPermission
+	rowAskUser
 	rowSystem
 	rowError
 )
@@ -29,6 +30,7 @@ type transcriptRow struct {
 	status     tools.Status // result status, for tool result rows
 	detail     string       // raw multi-line output (e.g. a diff to render as a card)
 	permission *agent.PermissionEvent
+	askUser    *agent.AskUserRequest
 }
 
 type transcriptActionKind int
@@ -128,8 +130,67 @@ func transcriptRowKey(row transcriptRow) string {
 		if row.permission != nil && row.permission.ToolCallID != "" {
 			return fmt.Sprintf("%d:%s:%s", row.kind, row.permission.ToolCallID, row.permission.Action)
 		}
+	case rowAskUser:
+		if row.askUser != nil && row.askUser.ToolCallID != "" {
+			return fmt.Sprintf("%d:%s", row.kind, row.askUser.ToolCallID)
+		}
 	}
 	return ""
+}
+
+func askUserTranscriptRow(request agent.AskUserRequest) transcriptRow {
+	return transcriptRow{
+		kind:    rowAskUser,
+		id:      request.ToolCallID,
+		text:    askUserRowText(request),
+		detail:  askUserDetailText(request),
+		askUser: &request,
+	}
+}
+
+func askUserRowText(request agent.AskUserRequest) string {
+	parts := []string{"ask_user:"}
+	if header := strings.TrimSpace(request.Header); header != "" {
+		parts = append(parts, header)
+	} else {
+		parts = append(parts, fmt.Sprintf("%d question(s)", len(request.Questions)))
+	}
+	return strings.Join(parts, " ")
+}
+
+func askUserDetailText(request agent.AskUserRequest) string {
+	lines := make([]string, 0, len(request.Questions))
+	for index, question := range request.Questions {
+		line := fmt.Sprintf("%d. %s", index+1, question.Question)
+		if len(question.Options) > 0 {
+			line += "  (" + strings.Join(question.Options, ", ") + ")"
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func askUserSessionPayload(request agent.AskUserRequest) map[string]any {
+	questions := make([]map[string]any, 0, len(request.Questions))
+	for _, question := range request.Questions {
+		entry := map[string]any{"question": question.Question}
+		if len(question.Options) > 0 {
+			entry["options"] = question.Options
+		}
+		if question.MultiSelect {
+			entry["multiSelect"] = true
+		}
+		questions = append(questions, entry)
+	}
+	payload := map[string]any{
+		"role":       "ask_user",
+		"toolCallId": request.ToolCallID,
+		"questions":  questions,
+	}
+	if header := strings.TrimSpace(request.Header); header != "" {
+		payload["header"] = header
+	}
+	return payload
 }
 
 func permissionTranscriptRow(event agent.PermissionEvent) transcriptRow {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -72,6 +72,22 @@ func (m model) modeSegment() string {
 	return style.Render("⏵⏵ "+label) + zeroTheme.muted.Render(" · shift+tab to cycle")
 }
 
+// nextPermissionMode toggles between the two prompt-respecting modes:
+// Auto ⇄ Ask. Unsafe (which disables permission prompts entirely) is
+// deliberately NOT reachable by a casual keypress — a single shift+tab landing
+// on it would let prompt-required tools run with no decision. Unsafe stays an
+// explicit opt-in (the launch/--skip-permissions-unsafe path), not a UI toggle.
+// Unsafe is folded back to Ask so the toggle always lands somewhere safe.
+func nextPermissionMode(mode agent.PermissionMode) agent.PermissionMode {
+	switch mode {
+	case agent.PermissionModeAuto:
+		return agent.PermissionModeAsk
+	default:
+		// Ask (and anything else, incl. an externally-set Unsafe) → Auto.
+		return agent.PermissionModeAuto
+	}
+}
+
 func (m model) modeLabel() (string, lipgloss.Style) {
 	switch m.permissionMode {
 	case agent.PermissionModeAuto:
@@ -199,6 +215,55 @@ func gitBranch(cwd string) string {
 		return ref[:7]
 	}
 	return ref
+}
+
+// suggestionOverlay renders the slash-command autocomplete list below the input
+// in the default skin: one row per match (name + dim description), the selected
+// row highlighted with a caret and the accent color. Returns "" when no overlay
+// should show.
+func (m model) suggestionOverlay(width int) string {
+	if !m.suggestionsActive() {
+		return ""
+	}
+	nameWidth := 0
+	for _, s := range m.suggestions {
+		if w := lipgloss.Width(s.Name); w > nameWidth {
+			nameWidth = w
+		}
+	}
+	lines := make([]string, 0, len(m.suggestions))
+	for index, s := range m.suggestions {
+		pad := strings.Repeat(" ", maxInt(0, nameWidth-lipgloss.Width(s.Name)))
+		marker := "  "
+		name := zeroTheme.text.Render(s.Name)
+		if index == m.suggestionIdx {
+			marker = zeroTheme.accent.Render("› ")
+			name = zeroTheme.accent.Render(s.Name)
+		}
+		line := marker + name + pad + "  " + zeroTheme.muted.Render(s.Desc)
+		lines = append(lines, fitStyledLine(line, width-2))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// pickerOverlay renders an open interactive selector below the input in the
+// default skin: a titled bordered list with the selected row highlighted.
+func (m model) pickerOverlay(width int) string {
+	if m.picker == nil {
+		return ""
+	}
+	lines := make([]string, 0, len(m.picker.items)+1)
+	lines = append(lines, zeroTheme.accent.Render(m.picker.title)+zeroTheme.muted.Render("  ↑/↓ move · ⏎ select · esc cancel"))
+	for index, item := range m.picker.items {
+		marker := "  "
+		label := zeroTheme.text.Render(item.Label)
+		if index == m.picker.selected {
+			marker = zeroTheme.accent.Render("› ")
+			label = zeroTheme.accent.Render(item.Label)
+		}
+		lines = append(lines, fitStyledLine(marker+label, width-4))
+	}
+	return borderedBlock(width, lines)
 }
 
 // argHint extracts the most representative argument from a tool call's raw JSON

--- a/internal/tui/zeroline_view.go
+++ b/internal/tui/zeroline_view.go
@@ -1,0 +1,237 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/zeroline"
+)
+
+// zerolineTickMsg advances the Zeroline animation frame (spinner) independently of
+// agent events so "working…" spins smoothly between row updates.
+type zerolineTickMsg time.Time
+
+// bootFrames is how many ~120ms ticks the boot splash plays before the home
+// page reveals (~1.9s), matching the mockup's splash timing.
+const bootFrames = 16
+
+func zerolineTick() tea.Cmd {
+	return tea.Tick(120*time.Millisecond, func(t time.Time) tea.Msg { return zerolineTickMsg(t) })
+}
+
+// handleZerolineKeys intercepts theme controls when the zeroline skin is active.
+// Digits 1-5 pick a color theme (only when the input is empty so they can still
+// be typed); ctrl+t cycles; ctrl+l toggles light/dark.
+func (m model) handleZerolineKeys(msg tea.KeyMsg) (model, bool) {
+	switch msg.String() {
+	case "ctrl+l":
+		m.themeDark = !m.themeDark
+		return m, true
+	case "ctrl+t":
+		m.themeVariant = (m.themeVariant + 1) % len(zeroline.Themes)
+		return m, true
+	}
+	if strings.TrimSpace(m.input.Value()) == "" {
+		if k := msg.String(); len(k) == 1 && k >= "1" && k <= "5" {
+			m.themeVariant = int(k[0] - '1')
+			return m, true
+		}
+	}
+	return m, false
+}
+
+func (m model) zerolineView() string {
+	width, height := m.width, m.height
+	if width <= 0 {
+		width = 100
+	}
+	if height <= 0 {
+		height = 30
+	}
+
+	// Boot splash reveals on launch, then the home page.
+	if !m.booted && m.showSplash {
+		return zeroline.RenderBoot(m.themeVariant, m.themeDark, m.frame, width, height)
+	}
+
+	header := zeroline.Header{
+		Cwd:      m.cwd,
+		Branch:   m.gitBranch,
+		Model:    m.modelName,
+		Provider: m.providerName,
+	}
+
+	// Home until the first turn is submitted.
+	if m.showSplash {
+		return zeroline.RenderHome(zeroline.HomeData{
+			Variant:     m.themeVariant,
+			Dark:        m.themeDark,
+			Width:       width,
+			Height:      height,
+			Header:      header,
+			Input:       m.input.View(),
+			Suggestions: m.zerolineSuggestions(),
+			SelectedIdx: m.suggestionIdx,
+			Picker:      m.zerolinePicker(),
+		})
+	}
+
+	rows := m.zerolineRows()
+	running := false
+	for _, r := range rows {
+		if r.Kind == "toolcall" && r.Running {
+			running = true
+		}
+	}
+	askUser := m.zerolineAskUser()
+	// A pending permission prompt or ask_user questionnaire is the focus: suppress
+	// the working/thinking spinner so the gate/question shows instead.
+	blocked := m.pendingPermission != nil || askUser != nil
+	thinking := m.pending && m.streamingText == "" && !running && !blocked
+
+	return zeroline.RenderChat(zeroline.ChatData{
+		Variant:     m.themeVariant,
+		Dark:        m.themeDark,
+		Width:       width,
+		Height:      height,
+		Header:      header,
+		Rows:        rows,
+		Working:     m.pending && !blocked,
+		Thinking:    thinking,
+		Stream:      m.streamingText,
+		TokS:        m.streamTokS(),
+		Spin:        m.frame,
+		Perm:        m.zerolinePerm(),
+		AskUser:     askUser,
+		Input:       m.input.View(),
+		Suggestions: m.zerolineSuggestions(),
+		SelectedIdx: m.suggestionIdx,
+		Picker:      m.zerolinePicker(),
+	})
+}
+
+// zerolineAskUser maps a pending ask_user questionnaire into zeroline render data,
+// or nil when none is active. The focused question is the one at the prompt's
+// current index.
+func (m model) zerolineAskUser() *zeroline.AskUser {
+	if m.pendingAskUser == nil {
+		return nil
+	}
+	prompt := m.pendingAskUser
+	total := len(prompt.request.Questions)
+	index := prompt.index
+	if index >= total {
+		index = total - 1
+	}
+	if index < 0 {
+		index = 0
+	}
+	out := &zeroline.AskUser{
+		Header: prompt.request.Header,
+		Index:  index,
+		Total:  total,
+		Input:  m.input.Value(),
+	}
+	if total > 0 {
+		question := prompt.request.Questions[index]
+		out.Question = question.Question
+		out.Options = question.Options
+	}
+	return out
+}
+
+// zerolineSuggestions maps the live autocomplete matches into zeroline render
+// data, or nil when the overlay is inactive (a modal is up or there are no
+// matches).
+func (m model) zerolineSuggestions() []zeroline.Suggestion {
+	if !m.suggestionsActive() {
+		return nil
+	}
+	out := make([]zeroline.Suggestion, 0, len(m.suggestions))
+	for _, s := range m.suggestions {
+		out = append(out, zeroline.Suggestion{Name: s.Name, Desc: s.Desc})
+	}
+	return out
+}
+
+// zerolinePicker maps an open selector into zeroline render data, or nil when no
+// picker is open.
+func (m model) zerolinePicker() *zeroline.Picker {
+	if m.picker == nil {
+		return nil
+	}
+	labels := make([]string, 0, len(m.picker.items))
+	for _, item := range m.picker.items {
+		labels = append(labels, item.Label)
+	}
+	return &zeroline.Picker{Title: m.picker.title, Items: labels, Selected: m.picker.selected}
+}
+
+// streamTokS estimates tokens/sec for the current streaming segment (~4 chars/token).
+func (m model) streamTokS() int {
+	if m.streamingText == "" {
+		return 0
+	}
+	frames := m.frame - m.streamStartFrame
+	if frames <= 0 {
+		return 0
+	}
+	secs := float64(frames) * 0.12
+	toks := float64(len([]rune(m.streamingText))) / 4.0
+	if secs <= 0 {
+		return 0
+	}
+	return int(toks / secs)
+}
+
+func (m model) zerolineRows() []zeroline.Row {
+	// a tool call is "running" until a result row with the same id arrives
+	resultIDs := make(map[string]bool)
+	for _, r := range m.transcript {
+		if r.kind == rowToolResult && r.id != "" {
+			resultIDs[r.id] = true
+		}
+	}
+	rows := make([]zeroline.Row, 0, len(m.transcript))
+	for _, r := range m.transcript {
+		switch r.kind {
+		case rowUser:
+			rows = append(rows, zeroline.Row{Kind: "user", Text: r.text})
+		case rowAssistant:
+			rows = append(rows, zeroline.Row{Kind: "assistant", Text: r.text})
+		case rowToolCall:
+			rows = append(rows, zeroline.Row{
+				Kind:    "toolcall",
+				Tool:    r.tool,
+				Detail:  r.detail,
+				Running: !(r.id != "" && resultIDs[r.id]),
+			})
+		case rowToolResult:
+			rows = append(rows, zeroline.Row{Kind: "toolresult", Tool: r.tool, Status: string(r.status), Detail: r.detail})
+		case rowPermission:
+			rows = append(rows, zeroline.Row{Kind: "permission", Text: r.text})
+		case rowAskUser:
+			rows = append(rows, zeroline.Row{Kind: "system", Text: r.text, Detail: r.detail})
+		case rowSystem:
+			rows = append(rows, zeroline.Row{Kind: "system", Text: r.text})
+		case rowError:
+			rows = append(rows, zeroline.Row{Kind: "error", Text: r.text})
+		}
+	}
+	return rows
+}
+
+func (m model) zerolinePerm() *zeroline.Perm {
+	if m.pendingPermission == nil {
+		return nil
+	}
+	req := m.pendingPermission.request
+	return &zeroline.Perm{
+		Tool:    req.ToolName,
+		Risk:    string(req.Risk.Level),
+		Reason:  req.Reason,
+		Summary: req.SideEffect,
+	}
+}

--- a/internal/tui/zeroline_view_test.go
+++ b/internal/tui/zeroline_view_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func newZerolineModel() model {
+	m := newModel(context.Background(), Options{
+		Skin:         "zeroline",
+		ThemeDark:    true,
+		Cwd:          "/home/you/src/zero",
+		ProviderName: "anthropic",
+		ModelName:    "claude-sonnet-4.5",
+	})
+	m.width, m.height = 100, 30
+	m.booted = true // skip the boot splash animation; these tests cover home/chat
+	return m
+}
+
+func TestZerolineHomeThenChat(t *testing.T) {
+	m := newZerolineModel()
+
+	// Home is shown until the first turn (showSplash true).
+	if !strings.Contains(m.View(), "Own your agent") {
+		t.Fatal("expected Zen home before first turn")
+	}
+
+	// Simulate an in-progress run with a live transcript.
+	m.showSplash = false
+	m.pending = true
+	m.transcript = []transcriptRow{
+		{kind: rowUser, text: "refactor internal/agent/loop.go"},
+		{kind: rowToolCall, id: "t1", tool: "grep", text: "tool call: grep", detail: "pattern: case"},
+		{kind: rowToolResult, id: "t1", tool: "grep", status: tools.StatusOK, detail: "3 matches"},
+	}
+	chat := m.View()
+	for _, want := range []string{"WORKING", "you", "grep", "claude-sonnet-4.5", "thinking"} {
+		if !strings.Contains(chat, want) {
+			t.Errorf("chat view missing %q", want)
+		}
+	}
+
+	// once tokens stream, the live text shows instead of the thinking line
+	m.streamingText = "here is the streamed answer"
+	if s := m.View(); !strings.Contains(s, "here is the streamed answer") {
+		t.Error("streaming text not rendered in chat view")
+	}
+}
+
+func TestZerolineAskUserRender(t *testing.T) {
+	m := newZerolineModel()
+	m.showSplash = false
+	m.pending = true
+	m.activeRunID = 7
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID:   7,
+		request: testAskUserRequest(),
+		answer:  func([]string) {},
+	})
+	next := updated.(model)
+	if next.pendingAskUser == nil {
+		t.Fatal("expected ask_user prompt to be pending")
+	}
+
+	out := next.View()
+	for _, want := range []string{"Which framework?", "React", "Vue", "question 1 of 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("zeroline ask_user view missing %q", want)
+		}
+	}
+	// The misleading "working…"/"thinking" spinner must be suppressed while a
+	// questionnaire is pending.
+	if strings.Contains(out, "thinking") {
+		t.Error("zeroline ask_user view should suppress the thinking spinner")
+	}
+}
+
+func TestZerolinePermissionRender(t *testing.T) {
+	m := newZerolineModel()
+	m.showSplash = false
+	m.pending = true
+	m.pendingPermission = &pendingPermissionPrompt{
+		request: agent.PermissionRequest{ToolName: "edit_file", SideEffect: "write"},
+	}
+	out := m.View()
+	for _, want := range []string{"BLOCKED", "permission required", "edit_file", "allow", "deny"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("permission view missing %q", want)
+		}
+	}
+}
+
+func TestZerolineThemeKeys(t *testing.T) {
+	m := newZerolineModel()
+	// digit selects theme when input empty
+	nm, handled := m.handleZerolineKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("3")})
+	if !handled || nm.themeVariant != 2 {
+		t.Fatalf("theme select failed handled=%v variant=%d", handled, nm.themeVariant)
+	}
+	// ctrl+l toggles light/dark
+	nm2, handled2 := nm.handleZerolineKeys(tea.KeyMsg{Type: tea.KeyCtrlL})
+	if !handled2 || nm2.themeDark == nm.themeDark {
+		t.Fatal("ctrl+l did not toggle dark")
+	}
+}


### PR DESCRIPTION
## TUI shell — ask_user modal, pickers, autocomplete, zeroline skin

Ports the interactive TUI shell from the reskin branch. **Stacked on #125 (agent runtime)** — it needs `agent.AskUserRequest`/`AskUserResponse`/`AskUserQuestion` + `Options.OnAskUser`/`ContextWindow` from that PR, so this targets the `agent-runtime` branch; I'll retarget it to `main` once #125 lands.

Built as a per-file 3-way merge of `internal/tui` (preserving main's #113 session-wiring drift — `SessionID`/`Model`/`ReasoningEffort`/`Cwd`), then a full **zenline→zeroline rename** (imports, identifiers, the `Skin` string, and `zenline_view.go`→`zeroline_view.go`) since the rendering package merged earlier as `internal/zeroline`.

### What's in it
- **ask_user** — interactive questionnaire modal wired to `agent.OnAskUser` via an answer channel; transcript rows + session payloads; degrades gracefully with no interactive surface.
- **Compaction sizing** — `modelContextWindow()` sets the agent's `ContextWindow` from the active model's registry entry; unknown/custom models → 0 (compaction off).
- **Pickers** (model / theme / effort / mode) + slash-command **autocomplete** overlay.
- **zeroline skin** rendering (boot / home / chat) behind `Options.Skin`.
- **Checkpoint recording** — before each mutating tool, the run batches an `EventSessionCheckpoint` *in order* and flushes it at end-of-run and on cancel.

### One cross-module change (called out)
The checkpoint flow needs the event batched **in order** with the run's other session events (recording it out-of-band reorders it, and breaks multi-call ordering). That requires the snapshot-only entry point, so I exposed `sessions.SnapshotForCheckpoint` **with an explicit orphan-blob safe-usage contract**: most callers should use the atomic `CaptureToolCheckpoint`; this one is for the batch-in-order pattern where the caller (the TUI) guarantees prompt recording incl. on cancel.

### Testing
115 tui tests pass. `go build ./...`, `go vet`, `go test ./...`, `go test -race ./internal/tui/ ./internal/sessions/`, `GOOS=windows go build ./...` all green. No new deps.

> Unblocks the **cli wiring** PR. Part of decomposing #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash-command autocomplete with keyboard navigation, alias matching, and completion; suppressed while modals/questionnaires are active
  * Expanded interactive pickers (model, effort, mode, theme) and questionnaire (ask-user) flows
  * `/mode` and `/rewind` commands enhanced; `/rewind` reports restored/deleted/skipped files
  * New "zeroline" UI skin with theme/dark-mode controls and tailored rendering

* **Bug Fixes**
  * Session checkpoint events and related state are reliably flushed/persisted when runs are cancelled; in-memory session state refreshes after rewind
<!-- end of auto-generated comment: release notes by coderabbit.ai -->