### PR TITLE
CLI wiring: skills/zeroline commands, --mode presets, exec checkpoints, sandbox --effective, sessions rewind

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/selfverify"
 	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/skills"
 	"github.com/Gitlawb/zero/internal/specialist"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
@@ -38,6 +39,7 @@ type appDeps struct {
 	newSessionStore      func() *sessions.Store
 	loadPlugins          func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks            func(hooks.LoadOptions) (hooks.LoadResult, error)
+	skillsDir            func() string
 	newMCPStore          func() (*mcp.PermissionStore, error)
 	newSandboxStore      func() (*sandbox.GrantStore, error)
 	selectSandboxBackend func(sandbox.BackendOptions) sandbox.Backend
@@ -97,6 +99,9 @@ func defaultAppDeps() appDeps {
 		},
 		loadPlugins: plugins.Load,
 		loadHooks:   hooks.LoadConfig,
+		skillsDir: func() string {
+			return skills.DefaultDir(nil)
+		},
 		newMCPStore: func() (*mcp.PermissionStore, error) {
 			return mcp.NewPermissionStore(mcp.StoreOptions{})
 		},
@@ -166,6 +171,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runSpecialists(args[1:], stdout, stderr, deps)
 	case "plugins", "plugin":
 		return runPlugins(args[1:], stdout, stderr, deps)
+	case "skills", "skill":
+		return runSkills(args[1:], stdout, stderr, deps)
 	case "hooks":
 		return runHooks(args[1:], stdout, stderr, deps)
 	case "mcp":
@@ -182,6 +189,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runChanges(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
+	case "zeroline":
+		return runZeroline(args[1:], stdout, stderr, deps)
 	default:
 		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
 			return 1
@@ -218,6 +227,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.loadHooks == nil {
 		deps.loadHooks = defaults.loadHooks
+	}
+	if deps.skillsDir == nil {
+		deps.skillsDir = defaults.skillsDir
 	}
 	if deps.newMCPStore == nil {
 		deps.newMCPStore = defaults.newMCPStore
@@ -265,6 +277,10 @@ func fillAppDeps(deps appDeps) appDeps {
 }
 
 func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
+	return runInteractiveTUIWithSkin(stderr, deps, "")
+}
+
+func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string) int {
 	workspaceRoot, err := deps.getwd()
 	if err != nil {
 		return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), 1)
@@ -301,7 +317,12 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 		Store:         sandboxStore,
 		Backend:       deps.selectSandboxBackend(sandbox.BackendOptions{}),
 	})
-	permissionMode := agent.PermissionModeAuto
+	// Ask (not Auto) is the interactive default: in Auto, ToolAdvertised exposes
+	// only PermissionAllow tools, so prompt-gated tools (write_file/edit_file/bash/
+	// apply_patch) would never be offered to the model — the TUI could neither edit
+	// files nor run shell. Ask advertises them and routes each through the existing
+	// OnPermissionRequest flow; shift+tab lets the user switch modes live.
+	permissionMode := agent.PermissionModeAsk
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:             workspaceRoot,
 		ProviderName:    resolved.Provider.Name,
@@ -320,6 +341,8 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
 			Sandbox:        sandboxEngine,
 		},
 		PermissionMode: permissionMode,
+		Skin:           skin,
+		ThemeDark:      true,
 	})
 }
 
@@ -399,6 +422,7 @@ Commands:
   sessions   Inspect local Zero session lineage
   specialist Manage local Zero specialist profiles
   plugins    Inspect local Zero plugin manifests
+  skills     Inspect local Zero skills
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings
   sandbox    Inspect sandbox policy and persistent grants
@@ -407,6 +431,7 @@ Commands:
   verify     Detect and run local verification checks
   changes    Inspect and commit local git changes
   serve      Run Zero protocol servers
+  zeroline    Launch the interactive TUI with the Zeroline reskin
   help       Show this help
   version    Print version
 
@@ -433,6 +458,7 @@ Runs a one-shot prompt through the Go agent runtime.
 
 Flags:
   -f, --file <path>                  Read prompt text from a file
+      --mode <name>                  Apply a preset (smart, deep, fast, large, precise); explicit flags override it
   -m, --model <model>                Select the model for provider setup
       --max-turns <number>           Override the maximum agent loop turns
       --auto <low|medium|high>       Set exec autonomy; high enables unsafe tools

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -101,7 +101,7 @@ func TestRunNoArgsLaunchesTUIWithNilProviderWhenNoProviderConfigured(t *testing.
 		t.Fatalf("provider metadata = %q/%q, want empty", launchedOptions.ProviderName, launchedOptions.ModelName)
 	}
 	assertCoreRegistry(t, launchedOptions.Registry)
-	assertAgentOptions(t, launchedOptions, 12, agent.PermissionModeAuto)
+	assertAgentOptions(t, launchedOptions, 12, agent.PermissionModeAsk)
 }
 
 func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {
@@ -164,7 +164,40 @@ func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
 	assertCoreRegistry(t, launchedOptions.Registry)
-	assertAgentOptions(t, launchedOptions, 5, agent.PermissionModeAuto)
+	assertAgentOptions(t, launchedOptions, 5, agent.PermissionModeAsk)
+}
+
+func TestRunNoArgsLaunchesTUIInAskPermissionMode(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	var launchedOptions tui.Options
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 3}, nil
+		},
+		runTUI: func(_ context.Context, options tui.Options) int {
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	// Auto only advertises PermissionAllow tools, so write_file/edit_file/bash/
+	// apply_patch (PermissionPrompt) would never be offered to the model. Ask
+	// advertises them and gates each through the permission flow.
+	if launchedOptions.PermissionMode != agent.PermissionModeAsk {
+		t.Fatalf("PermissionMode = %q, want %q", launchedOptions.PermissionMode, agent.PermissionModeAsk)
+	}
+	if launchedOptions.AgentOptions.PermissionMode != agent.PermissionModeAsk {
+		t.Fatalf("AgentOptions.PermissionMode = %q, want %q", launchedOptions.AgentOptions.PermissionMode, agent.PermissionModeAsk)
+	}
 }
 
 func TestRunNoArgsReportsConfigErrorsWithoutLaunchingTUI(t *testing.T) {
@@ -218,6 +251,8 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"session"},
 		{"plugins"},
 		{"plugin"},
+		{"skills"},
+		{"skill"},
 		{"hooks"},
 		{"mcp"},
 		{"sandbox"},
@@ -536,6 +571,7 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"worktrees",
 		"verify",
 		"serve",
+		"zeroline",
 		"--version",
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -38,9 +39,15 @@ const (
 )
 
 type execOptions struct {
-	promptParts           []string
-	file                  string
-	model                 string
+	promptParts []string
+	file        string
+	mode        string
+	model       string
+	// modelProfile captures the legacy --profile flag. It is accepted for
+	// backward compatibility (so old invocations do not error) but is
+	// intentionally inert: nothing consumes it. Model selection is driven by
+	// --model / --mode instead. See writeExecHelp ("Accept legacy model profile
+	// selection") and TestRunExecAcceptsLegacyModelProfileFlags.
 	modelProfile          string
 	reasoningEffort       string
 	maxTurns              int
@@ -84,6 +91,16 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			return exitCrash
 		}
 		return exitSuccess
+	}
+
+	// A mode seeds model/effort/max-turns/tool filters as a preset. Expand it up
+	// front — before tool-filter validation and the --list-tools branch — so a
+	// mode-injected tool filter is validated and reflected in --list-tools, and a
+	// mode-supplied model flows through the same resolution (and deprecation
+	// notice) path as an explicit --model. Explicit flags still win: applyExecMode
+	// only fills fields the caller left unset.
+	if err := applyExecMode(&options); err != nil {
+		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
 
 	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
@@ -148,9 +165,21 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 	sessionTitle := execSessionTitle(options, prompt)
 
+	// Build the model registry once and reuse it across every model-aware
+	// lookup in this exec run (model resolution, reasoning-effort advisory, and
+	// context-window sizing). DefaultRegistry builds the full catalog and
+	// compiles its match patterns, so rebuilding it per lookup is wasteful.
+	// modelRegistry is the zero Registry when the catalog fails to build; the
+	// helpers below degrade to safe no-op behavior in that case.
+	modelRegistry, _ := modelregistry.DefaultRegistry()
+
 	overrides := config.Overrides{}
 	if options.model != "" {
-		overrides.Provider.Model = options.model
+		resolvedModel, notice := resolveSelectedModel(modelRegistry, options.model)
+		overrides.Provider.Model = resolvedModel
+		if notice != "" {
+			fmt.Fprintln(stderr, notice)
+		}
 	}
 	if options.maxTurns > 0 {
 		overrides.MaxTurns = options.maxTurns
@@ -161,6 +190,15 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 	if resolved.Provider == (config.ProviderProfile{}) {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", "No provider configured. Set OPENAI_MODEL/OPENAI_API_KEY or add .zero/config.json.")
+	}
+	// Evaluate the --reasoning-effort advisory against the EFFECTIVE resolved
+	// model (resolved.Provider.Model), not the override. Without an explicit
+	// --model the override model is empty, so checking it here would silently
+	// skip the advisory even though the run uses a concrete effective model.
+	if options.reasoningEffort != "" {
+		if notice := reasoningEffortNotice(modelRegistry, resolved.Provider.Model, options.reasoningEffort); notice != "" {
+			fmt.Fprintln(stderr, notice)
+		}
 	}
 
 	provider, err := buildProvider(resolved, deps)
@@ -212,8 +250,16 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if writer.err != nil {
 		return exitCrash
 	}
-	if options.skipPermissionsUnsafe {
-		writer.warning("Unsafe permissions are active for this run because --skip-permissions-unsafe was passed.")
+	// Surface the unsafe-permissions warning whenever the run resolves to unsafe
+	// mode, covering BOTH --skip-permissions-unsafe and --auto high (which also
+	// resolves to PermissionModeUnsafe). Previously only the explicit flag path
+	// warned, so --auto high silently ran without notice.
+	if permissionMode == agent.PermissionModeUnsafe {
+		reason := "--auto high"
+		if options.skipPermissionsUnsafe {
+			reason = "--skip-permissions-unsafe"
+		}
+		writer.warning(fmt.Sprintf("Unsafe permissions are active for this run because %s was passed.", reason))
 		if writer.err != nil {
 			return exitCrash
 		}
@@ -225,8 +271,13 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		"content": prompt,
 	})
 
+	// OnAskUser is intentionally left unset: headless runs have no interactive
+	// user, so ask_user degrades to a "proceed with your best assumption" result
+	// rather than blocking. (Future enhancement: collect answers over stream-json
+	// input when a controlling client is attached.)
 	result, err := agent.Run(context.Background(), agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
+		ContextWindow:    modelContextWindow(modelRegistry, resolved.Provider.Model),
 		SessionID:        preparedSession.Session.SessionID,
 		CallingSessionID: options.callingSessionID,
 		CallingToolUseID: options.callingToolUseID,
@@ -250,6 +301,10 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 				"name":      call.Name,
 				"arguments": call.Arguments,
 			})
+			// Snapshot before-state of files this call will mutate (safe rewind).
+			if checkpoint, ok := sessionRecorder.captureCheckpoint(workspaceRoot, call); ok {
+				writer.checkpoint(checkpoint)
+			}
 		},
 		OnPermission: func(event agent.PermissionEvent) {
 			writer.permission(event)
@@ -265,6 +320,12 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			}
 			if len(result.Meta) > 0 {
 				payload["meta"] = result.Meta
+			}
+			if result.Redacted {
+				payload["redacted"] = true
+			}
+			if len(result.ChangedFiles) > 0 {
+				payload["changedFiles"] = result.ChangedFiles
 			}
 			sessionRecorder.append(sessions.EventToolResult, payload)
 		},
@@ -435,6 +496,102 @@ func writeExecProviderError(stdout io.Writer, stderr io.Writer, format execOutpu
 		return exitCrash
 	}
 	return exitProvider
+}
+
+// applyExecMode expands a --mode preset onto the exec options. The preset only
+// fills fields the caller left unset, so an explicit --model / --reasoning-effort
+// / --max-turns / tool filter always wins over the mode. The mode's model is left
+// as the preset's raw id/alias so the shared --model resolution path resolves it
+// through the registry (canonical ids/deprecation fallbacks) AND surfaces any
+// deprecation notice on stderr, exactly like an explicit --model. An unknown mode
+// is a usage error listing the valid presets.
+func applyExecMode(options *execOptions) error {
+	name := strings.TrimSpace(options.mode)
+	if name == "" {
+		return nil
+	}
+	mode, ok := modelregistry.LookupMode(name)
+	if !ok {
+		return execUsageError{fmt.Sprintf("unknown mode %q. Valid modes: %s.", options.mode, strings.Join(modelregistry.ModeNames(), ", "))}
+	}
+	if options.model == "" && mode.Model != "" {
+		options.model = mode.Model
+	}
+	if options.reasoningEffort == "" && mode.Effort != "" {
+		options.reasoningEffort = string(mode.Effort)
+	}
+	if options.maxTurns == 0 && mode.MaxTurns > 0 {
+		options.maxTurns = mode.MaxTurns
+	}
+	if len(options.enabledTools) == 0 && len(mode.EnabledTools) > 0 {
+		options.enabledTools = append([]string{}, mode.EnabledTools...)
+	}
+	if len(options.disabledTools) == 0 && len(mode.DisabledTools) > 0 {
+		options.disabledTools = append([]string{}, mode.DisabledTools...)
+	}
+	return nil
+}
+
+// resolveSelectedModel routes a user-supplied --model value through the model
+// registry so that fuzzy aliases (e.g. "sonnet 4.5") resolve to canonical ids
+// and deprecated models auto-redirect to their fallback. It returns the model id
+// to use plus a non-empty notice when a deprecation redirect or warning applies.
+// Inputs that the registry does not recognize (e.g. custom openai-compatible
+// model names) are returned unchanged so provider passthrough still works.
+func resolveSelectedModel(registry modelregistry.Registry, input string) (string, string) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return input, ""
+	}
+	entry, notice, ok := registry.ResolveWithFallback(trimmed)
+	if !ok {
+		return input, ""
+	}
+	return entry.ID, notice
+}
+
+// modelContextWindow returns the resolved model's context window (max input
+// tokens) from the model registry, used to enable agent-loop compaction. An
+// unknown model (e.g. a custom openai-compatible name) returns 0, which leaves
+// compaction DISABLED — a safe default that never compacts unexpectedly.
+func modelContextWindow(registry modelregistry.Registry, modelID string) int {
+	trimmed := strings.TrimSpace(modelID)
+	if trimmed == "" {
+		return 0
+	}
+	entry, ok := registry.Resolve(trimmed)
+	if !ok {
+		return 0
+	}
+	return entry.ContextLimits.ContextWindow
+}
+
+// reasoningEffortNotice resolves the requested --reasoning-effort against the
+// selected model's supported efforts via EffectiveReasoningEffort and returns a
+// short advisory when the requested value is unsupported (and was coerced to the
+// model default).
+//
+// NOTE: the effective effort is not yet forwarded to the provider request — the
+// zeroruntime.CompletionRequest / provider wire schemas carry no effort field.
+// Full provider-request propagation is deferred (see slice-3 report).
+func reasoningEffortNotice(registry modelregistry.Registry, modelID string, requested string) string {
+	trimmed := strings.TrimSpace(modelID)
+	if trimmed == "" {
+		return ""
+	}
+	entry, ok := registry.Get(trimmed)
+	if !ok {
+		return ""
+	}
+	want := modelregistry.ReasoningEffort(strings.TrimSpace(strings.ToLower(requested)))
+	effective := modelregistry.EffectiveReasoningEffort(entry, want)
+	if effective == modelregistry.ReasoningEffortNone {
+		return fmt.Sprintf("%s does not support reasoning effort; ignoring --reasoning-effort %s", entry.ID, requested)
+	}
+	if want != "" && effective != want {
+		return fmt.Sprintf("reasoning effort %q is not supported by %s; using %s instead", requested, entry.ID, effective)
+	}
+	return ""
 }
 
 func resolveExecRunMetadata(profile config.ProviderProfile) (execRunMetadata, error) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -178,7 +178,9 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		resolvedModel, notice := resolveSelectedModel(modelRegistry, options.model)
 		overrides.Provider.Model = resolvedModel
 		if notice != "" {
-			fmt.Fprintln(stderr, notice)
+			if _, err := fmt.Fprintln(stderr, notice); err != nil {
+				return exitCrash
+			}
 		}
 	}
 	if options.maxTurns > 0 {
@@ -197,7 +199,9 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// skip the advisory even though the run uses a concrete effective model.
 	if options.reasoningEffort != "" {
 		if notice := reasoningEffortNotice(modelRegistry, resolved.Provider.Model, options.reasoningEffort); notice != "" {
-			fmt.Fprintln(stderr, notice)
+			if _, err := fmt.Fprintln(stderr, notice); err != nil {
+				return exitCrash
+			}
 		}
 	}
 

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -59,6 +59,15 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--file="):
 			options.file = strings.TrimSpace(strings.TrimPrefix(arg, "--file="))
+		case arg == "--mode":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.mode = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--mode="):
+			options.mode = strings.TrimSpace(strings.TrimPrefix(arg, "--mode="))
 		case arg == "-m" || arg == "--model":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -67,7 +67,11 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			options.mode = strings.TrimSpace(value)
 			index = next
 		case strings.HasPrefix(arg, "--mode="):
-			options.mode = strings.TrimSpace(strings.TrimPrefix(arg, "--mode="))
+			value, err := requiredInlineFlagValue(arg, "--mode")
+			if err != nil {
+				return options, false, err
+			}
+			options.mode = value
 		case arg == "-m" || arg == "--model":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/exec_sessions.go
+++ b/internal/cli/exec_sessions.go
@@ -1,14 +1,39 @@
 package cli
 
 import (
+	"encoding/json"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 type execSessionRecorder struct {
 	prepared sessions.PreparedExec
 	err      error
+}
+
+// captureCheckpoint snapshots the before-state of files a tool call will mutate.
+// Best-effort: failures never affect the run. Returns the checkpoint event and
+// true when one was recorded.
+func (recorder *execSessionRecorder) captureCheckpoint(workspaceRoot string, call agent.ToolCall) (sessions.Event, bool) {
+	if recorder.prepared.Store == nil || recorder.prepared.Session.SessionID == "" {
+		return sessions.Event{}, false
+	}
+	var args map[string]any
+	if call.Arguments != "" {
+		_ = json.Unmarshal([]byte(call.Arguments), &args)
+	}
+	targets := tools.MutationTargets(workspaceRoot, call.Name, args)
+	if len(targets) == 0 {
+		return sessions.Event{}, false
+	}
+	event, err := recorder.prepared.Store.CaptureToolCheckpoint(recorder.prepared.Session.SessionID, workspaceRoot, call.Name, targets)
+	if err != nil || event.Type == "" {
+		return sessions.Event{}, false
+	}
+	return event, true
 }
 
 func shouldUseExecSession(options execOptions) bool {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -35,6 +37,7 @@ func TestRunExecHelpDocumentsM1Flags(t *testing.T) {
 			}
 			for _, want := range []string{
 				"-f, --file",
+				"--mode <name>",
 				"-m, --model",
 				"--max-turns",
 				"--profile <profile>",
@@ -317,6 +320,190 @@ func TestRunExecPersistsCallingSessionChildMetadata(t *testing.T) {
 	}
 }
 
+func TestRunExecModeSeedsModelAndTurnOverrides(t *testing.T) {
+	cwd := t.TempDir()
+	var gotModel string
+	var gotMaxTurns int
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--mode", "deep", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			gotModel = overrides.Provider.Model
+			gotMaxTurns = overrides.MaxTurns
+			return config.ResolvedConfig{}, errors.New("stop before provider")
+		},
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d", exitProvider, exitCode)
+	}
+	if gotModel != "claude-opus-4.1" {
+		t.Fatalf("overrides.Provider.Model = %q, want claude-opus-4.1", gotModel)
+	}
+	if gotMaxTurns != 50 {
+		t.Fatalf("overrides.MaxTurns = %d, want 50", gotMaxTurns)
+	}
+}
+
+func TestRunExecExplicitModelOverridesMode(t *testing.T) {
+	cwd := t.TempDir()
+	var gotModel string
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--mode", "deep", "--model", "gpt-4.1", "hello"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			gotModel = overrides.Provider.Model
+			return config.ResolvedConfig{}, errors.New("stop before provider")
+		},
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d", exitProvider, exitCode)
+	}
+	if gotModel != "gpt-4.1" {
+		t.Fatalf("explicit --model should override mode: got %q, want gpt-4.1", gotModel)
+	}
+}
+
+func TestRunExecModeRoutesModelThroughRegistry(t *testing.T) {
+	cwd := t.TempDir()
+	var gotModel string
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	// "smart" maps to claude-sonnet-4.5; the mode's model must be routed through
+	// the registry (Resolve) so the canonical id reaches the overrides.
+	exitCode := runWithDeps([]string{"exec", "--mode", "smart", "hi"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			gotModel = overrides.Provider.Model
+			return config.ResolvedConfig{}, errors.New("stop before provider")
+		},
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d", exitProvider, exitCode)
+	}
+	if gotModel != "claude-sonnet-4.5" {
+		t.Fatalf("expected mode smart to select claude-sonnet-4.5, got %q", gotModel)
+	}
+}
+
+func TestRunExecUnknownModeErrors(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec", "--mode", "turbo", "hello"}, &stdout, &stderr)
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "unknown mode") {
+		t.Fatalf("expected unknown mode error, got %q", stderr.String())
+	}
+	for _, want := range []string{"smart", "deep", "fast", "large", "precise"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected error to list valid mode %q, got %q", want, stderr.String())
+		}
+	}
+}
+
+func TestApplyExecModeLeavesRawModelForSharedResolution(t *testing.T) {
+	// applyExecMode must NOT pre-resolve the mode's model: leaving the raw id/alias
+	// lets the shared --model resolution path resolve it AND surface any deprecation
+	// notice on stderr (the bug was that applyExecMode resolved it and discarded the
+	// notice). The raw alias must be the preset's exact Model value.
+	mode, ok := modelregistry.LookupMode("deep")
+	if !ok {
+		t.Fatal("expected built-in mode deep")
+	}
+	options := execOptions{mode: "deep"}
+	if err := applyExecMode(&options); err != nil {
+		t.Fatalf("applyExecMode returned error: %v", err)
+	}
+	if options.model != mode.Model {
+		t.Fatalf("options.model = %q, want raw mode model %q (resolution must be delegated)", options.model, mode.Model)
+	}
+}
+
+func TestRunExecModeModelSurfacesDeprecationNoticeViaSharedPath(t *testing.T) {
+	// A mode-supplied model must flow through the same resolution path as an
+	// explicit --model, so a deprecated id redirects AND prints a notice. No
+	// built-in mode references a deprecated model, so emulate one by setting the
+	// raw mode model directly through applyExecMode and threading it through the
+	// shared resolver, exactly as runExec does after the reorder.
+	options := execOptions{mode: "smart"}
+	if err := applyExecMode(&options); err != nil {
+		t.Fatalf("applyExecMode returned error: %v", err)
+	}
+	// Sanity: the shared resolver surfaces a notice + redirect for a deprecated id,
+	// which is the path the mode model now feeds into.
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	resolved, notice := resolveSelectedModel(registry, "gpt-4-turbo")
+	if resolved != "gpt-4.1" {
+		t.Fatalf("expected deprecated model to redirect to gpt-4.1, got %q", resolved)
+	}
+	if !strings.Contains(notice, "deprecated") {
+		t.Fatalf("expected shared resolver to surface a deprecation notice, got %q", notice)
+	}
+}
+
+func TestRunExecListToolsAppliesModeBeforeListing(t *testing.T) {
+	// applyExecMode now runs before tool-filter validation and the --list-tools
+	// branch, so a --mode preset is expanded for --list-tools. Combining a mode
+	// with --list-tools must still succeed and never resolve a provider.
+	cwd := t.TempDir()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"exec", "--list-tools", "--mode", "deep"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, errors.New("provider should not be resolved for --list-tools")
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Tools visible to model") {
+		t.Fatalf("expected --list-tools --mode to list tools, got %q", stdout.String())
+	}
+}
+
+func TestRunExecModeToolFilterReflectedInListTools(t *testing.T) {
+	// The reorder also means a mode-injected tool filter would be reflected in
+	// --list-tools. No built-in mode ships a tool filter, so drive the equivalent
+	// surface through applyExecMode + formatExecToolList: a filter seeded onto the
+	// options before the listing must narrow the tools the model can see.
+	options := execOptions{enabledTools: []string{"read_file", "grep"}}
+	registry := newCoreRegistry(t.TempDir())
+	list := formatExecToolList(registry, options, agent.PermissionModeAuto)
+	for _, want := range []string{"read_file", "grep"} {
+		if !strings.Contains(list, want) {
+			t.Fatalf("expected tool list to contain %q, got %q", want, list)
+		}
+	}
+	if strings.Contains(list, "bash") {
+		t.Fatalf("expected mode-style tool filter to hide bash, got %q", list)
+	}
+}
+
 func TestRunExecAcceptsLegacyModelProfileFlags(t *testing.T) {
 	exitCode, stdout, stderr := runExecWithEcho(t, []string{
 		"exec",
@@ -588,6 +775,77 @@ func TestRunExecJSONOutputsNDJSONEvents(t *testing.T) {
 	}
 }
 
+func TestRunExecResolvesCanonicalModelAlias(t *testing.T) {
+	root := t.TempDir()
+
+	// "openai:gpt-4.1" is a registry alias for the canonical gpt-4.1 id; the
+	// selection boundary should normalize it before the provider sees it.
+	exitCode, stdout, stderr := runExecWithEcho(t, []string{"exec", "--cwd", root, "-m", "openai:gpt-4.1", "-o", "json", "hi"})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr for active model, got %q", stderr)
+	}
+	events := decodeJSONLines(t, stdout)
+	if got := events[0]["model"]; got != "gpt-4.1" {
+		t.Fatalf("expected alias to resolve to gpt-4.1, got %v", got)
+	}
+}
+
+func TestRunExecRedirectsDeprecatedModelWithNotice(t *testing.T) {
+	root := t.TempDir()
+
+	exitCode, stdout, stderr := runExecWithEcho(t, []string{"exec", "--cwd", root, "-m", "gpt-4-turbo", "-o", "json", "hi"})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "deprecated") || !strings.Contains(stderr, "gpt-4.1") {
+		t.Fatalf("expected deprecation notice on stderr, got %q", stderr)
+	}
+	events := decodeJSONLines(t, stdout)
+	if got := events[0]["model"]; got != "gpt-4.1" {
+		t.Fatalf("expected deprecated model to redirect to gpt-4.1, got %v", got)
+	}
+}
+
+func TestRunExecReasoningEffortNoticeForNonReasoningModel(t *testing.T) {
+	root := t.TempDir()
+
+	exitCode, stdout, stderr := runExecWithEcho(t, []string{"exec", "--cwd", root, "-m", "gpt-4.1", "-r", "high", "-o", "json", "hi"})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "does not support reasoning effort") {
+		t.Fatalf("expected non-reasoning effort notice on stderr, got %q", stderr)
+	}
+	if stdout == "" {
+		t.Fatal("expected run output on stdout")
+	}
+}
+
+func TestReasoningEffortNoticeCoercesUnsupportedEffort(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	// claude-sonnet-4.5 supports low/medium/high with a medium default; xhigh is
+	// unsupported and should be coerced to the model default.
+	notice := reasoningEffortNotice(registry, "claude-sonnet-4.5", "xhigh")
+	if !strings.Contains(notice, "not supported") || !strings.Contains(notice, "medium") {
+		t.Fatalf("expected coercion notice to default medium, got %q", notice)
+	}
+	if got := reasoningEffortNotice(registry, "claude-sonnet-4.5", "high"); got != "" {
+		t.Fatalf("expected no notice for a supported effort, got %q", got)
+	}
+	if got := reasoningEffortNotice(registry, "gpt-4.1", "high"); !strings.Contains(got, "does not support") {
+		t.Fatalf("expected unsupported-model notice, got %q", got)
+	}
+}
+
 func TestRunExecJSONUnsafeOutputsWarningEvent(t *testing.T) {
 	exitCode, stdout, stderr := runExecWithEcho(t, []string{"exec", "--skip-permissions-unsafe", "-o", "json", "hello"})
 
@@ -779,4 +1037,100 @@ func jsonEventTypes(events []map[string]any) []string {
 		types = append(types, eventType)
 	}
 	return types
+}
+
+// runExecWithEffectiveModel runs exec with the echo provider but forces the
+// resolved (effective) model regardless of any --model flag, so tests can
+// exercise behavior that depends on the effective model rather than the
+// override-supplied one.
+func runExecWithEffectiveModel(t *testing.T, effectiveModel string, args []string) (int, string, string) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	exitCode := runWithDeps(args, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, _ config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{
+				ActiveProvider: "echo",
+				Provider: config.ProviderProfile{
+					Name:         "echo",
+					ProviderKind: config.ProviderKindOpenAICompatible,
+					BaseURL:      "http://127.0.0.1/v1",
+					Model:        effectiveModel,
+				},
+				MaxTurns: 3,
+			}, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return echoExecProvider{}, nil
+		},
+	})
+	return exitCode, stdout.String(), stderr.String()
+}
+
+// TestRunExecReasoningEffortNoticeUsesEffectiveModel asserts that
+// --reasoning-effort is validated against the EFFECTIVE (resolved) model even
+// when --model is omitted, so the advisory notice still surfaces.
+func TestRunExecReasoningEffortNoticeUsesEffectiveModel(t *testing.T) {
+	// gpt-4.1 is a registry-known non-reasoning model. With no --model the
+	// override model is empty, so the notice must be evaluated against the
+	// effective model resolved by resolveConfig.
+	exitCode, stdout, stderr := runExecWithEffectiveModel(t, "gpt-4.1", []string{
+		"exec", "-r", "high", "hi",
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "does not support reasoning effort") {
+		t.Fatalf("expected effort notice for effective model on stderr, got %q", stderr)
+	}
+	if stdout == "" {
+		t.Fatal("expected run output on stdout")
+	}
+}
+
+// TestRunExecAutoHighEmitsUnsafeWarning asserts that --auto high (which resolves
+// to PermissionModeUnsafe) surfaces the same unsafe warning as
+// --skip-permissions-unsafe.
+func TestRunExecAutoHighEmitsUnsafeWarning(t *testing.T) {
+	exitCode, stdout, stderr := runExecWithEcho(t, []string{
+		"exec", "--auto", "high", "-o", "json", "hello",
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+
+	events := decodeJSONLines(t, stdout)
+	if !slices.Contains(jsonEventTypes(events), "warning") {
+		t.Fatalf("expected JSON warning event for --auto high, got %v; output %q", jsonEventTypes(events), stdout)
+	}
+	if got := events[0]["permission_mode"]; got != "unsafe" {
+		t.Fatalf("expected run_start permission_mode unsafe, got %v", got)
+	}
+}
+
+// TestRunExecInvalidAutoValidatedWithSkipPermissions asserts that an invalid
+// --auto value is still rejected even when --skip-permissions-unsafe is also
+// passed (the unsafe path must not short-circuit --auto validation).
+func TestRunExecInvalidAutoValidatedWithSkipPermissions(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec", "--auto", "bogus", "--skip-permissions-unsafe", "hello"}, &stdout, &stderr)
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+	}
+	if got := stderr.String(); !strings.Contains(got, "Invalid autonomy level") {
+		t.Fatalf("expected autonomy validation error, got %q", got)
+	}
 }

--- a/internal/cli/exec_tools.go
+++ b/internal/cli/exec_tools.go
@@ -51,17 +51,23 @@ func validateExecToolFilters(options execOptions, registry *tools.Registry) erro
 }
 
 func resolveExecPermissionMode(options execOptions) (agent.PermissionMode, error) {
-	if options.skipPermissionsUnsafe {
-		return agent.PermissionModeUnsafe, nil
-	}
+	// Validate --auto first, regardless of --skip-permissions-unsafe, so an
+	// invalid autonomy value is always rejected. (Previously the unsafe path
+	// short-circuited before validation, letting "--auto bogus" slip through
+	// whenever --skip-permissions-unsafe was also set.)
+	var mode agent.PermissionMode
 	switch strings.ToLower(strings.TrimSpace(options.autonomy)) {
 	case "", "low", "medium":
-		return agent.PermissionModeAuto, nil
+		mode = agent.PermissionModeAuto
 	case "high":
-		return agent.PermissionModeUnsafe, nil
+		mode = agent.PermissionModeUnsafe
 	default:
 		return "", execUsageError{fmt.Sprintf("Invalid autonomy level %q. Expected low, medium, or high.", options.autonomy)}
 	}
+	if options.skipPermissionsUnsafe {
+		return agent.PermissionModeUnsafe, nil
+	}
+	return mode, nil
 }
 
 func writeExecToolList(w io.Writer, registry *tools.Registry, options execOptions, permissionMode agent.PermissionMode) error {

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
 )
@@ -102,6 +103,33 @@ func (writer *execEventWriter) toolCall(call agent.ToolCall, registry *tools.Reg
 	writer.writeStderr("[tool] " + call.Name + "\n")
 }
 
+func (writer *execEventWriter) checkpoint(event sessions.Event) {
+	var payload sessions.CheckpointPayload
+	if len(event.Payload) > 0 {
+		_ = json.Unmarshal(event.Payload, &payload)
+	}
+	files := make([]string, 0, len(payload.Files))
+	for _, f := range payload.Files {
+		files = append(files, f.Path)
+	}
+	switch writer.format {
+	case execOutputStreamJSON:
+		writer.writeStreamJSON(streamjson.Event{
+			Type:       streamjson.EventCheckpoint,
+			RunID:      writer.runID,
+			Checkpoint: &streamjson.CheckpointInfo{Sequence: event.Sequence, Tool: payload.Tool, Files: files},
+		})
+	case execOutputJSON:
+		writer.writeJSON(map[string]any{
+			"type":     "checkpoint",
+			"sequence": event.Sequence,
+			"tool":     payload.Tool,
+			"files":    files,
+		})
+	}
+	// Plain text mode stays silent: checkpoints are background safety, not output.
+}
+
 func (writer *execEventWriter) toolResult(result agent.ToolResult) {
 	if writer.format == execOutputJSON {
 		payload := map[string]any{
@@ -114,21 +142,39 @@ func (writer *execEventWriter) toolResult(result agent.ToolResult) {
 		if len(result.Meta) > 0 {
 			payload["meta"] = result.Meta
 		}
+		if result.Redacted {
+			payload["redacted"] = true
+		}
+		if len(result.ChangedFiles) > 0 {
+			payload["changed_files"] = result.ChangedFiles
+		}
+		if result.Display.Summary != "" || result.Display.Kind != "" {
+			payload["display"] = map[string]string{"summary": result.Display.Summary, "kind": result.Display.Kind}
+		}
 		writer.writeJSON(payload)
 		return
 	}
 	if writer.format == execOutputStreamJSON {
 		output, truncated := truncateForStreamJSONOutput(result.Output)
-		writer.writeStreamJSON(streamjson.Event{
-			Type:      streamjson.EventToolResult,
-			RunID:     writer.runID,
-			ID:        result.ToolCallID,
-			Name:      result.Name,
-			Status:    string(result.Status),
-			Output:    output,
-			Truncated: &truncated,
-			Meta:      result.Meta,
-		})
+		event := streamjson.Event{
+			Type:         streamjson.EventToolResult,
+			RunID:        writer.runID,
+			ID:           result.ToolCallID,
+			Name:         result.Name,
+			Status:       string(result.Status),
+			Output:       output,
+			Truncated:    &truncated,
+			ChangedFiles: result.ChangedFiles,
+			Meta:         result.Meta,
+		}
+		if result.Redacted {
+			redacted := true
+			event.Redacted = &redacted
+		}
+		if result.Display.Summary != "" || result.Display.Kind != "" {
+			event.Display = &streamjson.Display{Summary: result.Display.Summary, Kind: result.Display.Kind}
+		}
+		writer.writeStreamJSON(event)
 		return
 	}
 	writer.writeStderr("[result] " + truncateForStatus(result.Output) + "\n")

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -9,10 +9,11 @@ import (
 )
 
 type sandboxCommandOptions struct {
-	json     bool
-	confirm  bool
-	autonomy string
-	reason   string
+	json      bool
+	confirm   bool
+	effective bool
+	autonomy  string
+	reason    string
 }
 
 func runSandbox(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -35,7 +36,7 @@ func runSandbox(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 }
 
 func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
-	options, help, err := parseSandboxCommandOptions(args, false)
+	options, help, err := parseSandboxCommandOptions(args, sandboxCommandFlags{allowEffective: true})
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -56,6 +57,9 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 	policy := zeroSandbox.DefaultPolicy()
 	backend := deps.selectSandboxBackend(zeroSandbox.BackendOptions{})
 	plan := backend.BuildPlan(workspaceRoot, policy)
+	if options.effective {
+		return runSandboxPolicyEffective(options, workspaceRoot, policy, backend, plan, store.FilePath(), stdout)
+	}
 	if options.json {
 		payload := struct {
 			Policy     zeroSandbox.Policy      `json:"policy"`
@@ -79,6 +83,93 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 	return exitSuccess
 }
 
+// sandboxGuards is the resolved set of pre-execution safety guards the engine
+// applies for the effective policy. There is no layered/merged config today, so
+// the "effective" view is the fully-resolved DefaultPolicy plus the platform
+// backend and the always-on static guards.
+type sandboxGuards struct {
+	InteractiveCommand bool `json:"interactiveCommand"`
+	DestructiveShell   bool `json:"destructiveShell"`
+	Network            bool `json:"network"`
+	Workspace          bool `json:"workspace"`
+}
+
+func resolveSandboxGuards(policy zeroSandbox.Policy) sandboxGuards {
+	return sandboxGuards{
+		// Interactive-command detection is a static pre-exec guard that always
+		// runs in the bash tool regardless of policy toggles.
+		InteractiveCommand: true,
+		DestructiveShell:   policy.DenyDestructiveShell,
+		Network:            policy.Network == zeroSandbox.NetworkDeny,
+		Workspace:          policy.EnforceWorkspace,
+	}
+}
+
+func runSandboxPolicyEffective(options sandboxCommandOptions, workspaceRoot string, policy zeroSandbox.Policy, backend zeroSandbox.Backend, plan zeroSandbox.BackendPlan, grantsPath string, stdout io.Writer) int {
+	guards := resolveSandboxGuards(policy)
+	if options.json {
+		payload := struct {
+			WorkspaceRoot string                  `json:"workspaceRoot"`
+			Policy        zeroSandbox.Policy      `json:"policy"`
+			Backend       zeroSandbox.Backend     `json:"backend"`
+			Plan          zeroSandbox.BackendPlan `json:"plan"`
+			Guards        sandboxGuards           `json:"guards"`
+			GrantsPath    string                  `json:"grantsPath"`
+		}{
+			WorkspaceRoot: workspaceRoot,
+			Policy:        policy,
+			Backend:       backend,
+			Plan:          plan,
+			Guards:        guards,
+			GrantsPath:    grantsPath,
+		}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatEffectiveSandboxPolicy(workspaceRoot, policy, backend, plan, guards, grantsPath)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func formatEffectiveSandboxPolicy(workspaceRoot string, policy zeroSandbox.Policy, backend zeroSandbox.Backend, plan zeroSandbox.BackendPlan, guards sandboxGuards, grantsPath string) string {
+	lines := []string{
+		"Zero effective sandbox policy",
+		"root: " + workspaceRoot,
+		"mode: " + string(policy.Mode),
+		"network: " + string(policy.Network),
+		"enforce_workspace: " + fmt.Sprintf("%t", policy.EnforceWorkspace),
+		"deny_destructive_shell: " + fmt.Sprintf("%t", policy.DenyDestructiveShell),
+		"allow_policy_only_runner: " + fmt.Sprintf("%t", policy.AllowPolicyOnlyRunner),
+		"backend: " + string(backend.Name),
+		"support_level: " + string(plan.SupportLevel),
+		"interactive_command_guard: " + enabledLabel(guards.InteractiveCommand),
+		"destructive_shell_guard: " + enabledLabel(guards.DestructiveShell),
+		"network_guard: " + enabledLabel(guards.Network),
+		"workspace_guard: " + enabledLabel(guards.Workspace),
+		"grants: " + grantsPath,
+	}
+	if backend.Platform != "" {
+		lines = append(lines, "backend_platform: "+backend.Platform)
+	}
+	for _, restriction := range plan.Restrictions {
+		lines = append(lines, "restriction: "+restriction)
+	}
+	for _, warning := range plan.Warnings {
+		lines = append(lines, "warning: "+warning)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func enabledLabel(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
 func runSandboxGrants(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
 	if len(args) == 0 {
 		return writeExecUsageError(stderr, "sandbox grants subcommand required. Use `zero sandbox grants list`.")
@@ -90,7 +181,7 @@ func runSandboxGrants(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		}
 		return exitSuccess
 	case "list":
-		options, help, err := parseSandboxCommandOptions(args[1:], false)
+		options, help, err := parseSandboxCommandOptions(args[1:], sandboxCommandFlags{})
 		if err != nil {
 			return writeExecUsageError(stderr, err.Error())
 		}
@@ -213,7 +304,7 @@ func runSandboxGrantRevoke(args []string, stdout io.Writer, stderr io.Writer, de
 }
 
 func runSandboxGrantClear(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
-	options, help, err := parseSandboxCommandOptions(args, true)
+	options, help, err := parseSandboxCommandOptions(args, sandboxCommandFlags{allowConfirm: true})
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -248,7 +339,12 @@ func runSandboxGrantClear(args []string, stdout io.Writer, stderr io.Writer, dep
 	return exitSuccess
 }
 
-func parseSandboxCommandOptions(args []string, allowConfirm bool) (sandboxCommandOptions, bool, error) {
+type sandboxCommandFlags struct {
+	allowConfirm   bool
+	allowEffective bool
+}
+
+func parseSandboxCommandOptions(args []string, flags sandboxCommandFlags) (sandboxCommandOptions, bool, error) {
 	options := sandboxCommandOptions{autonomy: string(zeroSandbox.AutonomyLow)}
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
@@ -257,8 +353,10 @@ func parseSandboxCommandOptions(args []string, allowConfirm bool) (sandboxComman
 			return options, true, nil
 		case arg == "--json":
 			options.json = true
-		case allowConfirm && arg == "--confirm":
+		case flags.allowConfirm && arg == "--confirm":
 			options.confirm = true
+		case flags.allowEffective && arg == "--effective":
+			options.effective = true
 		case strings.HasPrefix(arg, "-"):
 			return options, false, execUsageError{fmt.Sprintf("unknown sandbox flag %q", arg)}
 		default:
@@ -353,6 +451,7 @@ func writeSandboxPolicyHelp(w io.Writer) error {
   zero sandbox policy [flags]
 
 Flags:
+      --effective         Print the resolved effective policy (merged config + guards)
       --json              Print JSON output
   -h, --help              Show this help
 `)

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -182,6 +182,99 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 	}
 }
 
+func TestRunSandboxPolicyEffectiveTextAndJSON(t *testing.T) {
+	store := newSandboxTestStore(t)
+	deps := appDeps{
+		getwd:           func() (string, error) { return t.TempDir(), nil },
+		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		selectSandboxBackend: func(options sandbox.BackendOptions) sandbox.Backend {
+			return sandbox.Backend{
+				Name:     sandbox.BackendPolicyOnly,
+				Platform: "darwin",
+				Fallback: true,
+				Message:  "policy-only fallback",
+			}
+		},
+	}
+
+	t.Run("text", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		exitCode := runWithDeps([]string{"sandbox", "policy", "--effective"}, &stdout, &stderr, deps)
+		if exitCode != exitSuccess {
+			t.Fatalf("effective exit = %d, stderr %q", exitCode, stderr.String())
+		}
+		output := stdout.String()
+		for _, want := range []string{
+			"Zero effective sandbox policy",
+			"mode: enforce",
+			"network: deny",
+			"enforce_workspace: true",
+			"deny_destructive_shell: true",
+			"interactive_command_guard: enabled",
+			"support_level: policy-only",
+		} {
+			if !strings.Contains(output, want) {
+				t.Fatalf("effective text missing %q, got %q", want, output)
+			}
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		exitCode := runWithDeps([]string{"sandbox", "policy", "--effective", "--json"}, &stdout, &stderr, deps)
+		if exitCode != exitSuccess {
+			t.Fatalf("effective json exit = %d, stderr %q", exitCode, stderr.String())
+		}
+		var payload struct {
+			Policy struct {
+				Mode                 string `json:"mode"`
+				Network              string `json:"network"`
+				EnforceWorkspace     bool   `json:"enforceWorkspace"`
+				DenyDestructiveShell bool   `json:"denyDestructiveShell"`
+			} `json:"policy"`
+			Backend struct {
+				Name string `json:"name"`
+			} `json:"backend"`
+			Plan struct {
+				SupportLevel string `json:"supportLevel"`
+			} `json:"plan"`
+			Guards struct {
+				InteractiveCommand bool `json:"interactiveCommand"`
+				DestructiveShell   bool `json:"destructiveShell"`
+				Network            bool `json:"network"`
+				Workspace          bool `json:"workspace"`
+			} `json:"guards"`
+			GrantsPath string `json:"grantsPath"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+			t.Fatalf("decode effective JSON: %v\n%s", err, stdout.String())
+		}
+		if payload.Policy.Mode != "enforce" || payload.Policy.Network != "deny" {
+			t.Fatalf("unexpected effective policy: %#v", payload.Policy)
+		}
+		if !payload.Policy.EnforceWorkspace || !payload.Policy.DenyDestructiveShell {
+			t.Fatalf("expected workspace + destructive guards enabled: %#v", payload.Policy)
+		}
+		if !payload.Guards.InteractiveCommand || !payload.Guards.DestructiveShell {
+			t.Fatalf("expected guards reported: %#v", payload.Guards)
+		}
+		if payload.Plan.SupportLevel != string(sandbox.BackendSupportPolicyOnly) || payload.GrantsPath == "" {
+			t.Fatalf("unexpected effective plan/grants: %#v %q", payload.Plan, payload.GrantsPath)
+		}
+	})
+}
+
+func TestRunSandboxPolicyEffectiveHelpListed(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "policy", "--help"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitSuccess {
+		t.Fatalf("help exit = %d, stderr %q", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "--effective") {
+		t.Fatalf("policy help should document --effective, got %q", stdout.String())
+	}
+}
+
 func TestRunSandboxHelpDoesNotOpenStore(t *testing.T) {
 	deps := appDeps{newSandboxStore: func() (*sandbox.GrantStore, error) {
 		t.Fatal("newSandboxStore should not be called for help")

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -61,6 +61,11 @@ func runSessions(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 			return writeExecUsageError(stderr, "sessions rewind-plan requires a session id")
 		}
 		return runSessionsRewindPlan(store, remaining[0], options, stdout, stderr)
+	case "rewind":
+		if len(remaining) != 1 {
+			return writeExecUsageError(stderr, "sessions rewind requires a session id")
+		}
+		return runSessionsRewind(store, remaining[0], options, stdout, stderr)
 	case "compact-plan":
 		if len(remaining) != 1 {
 			return writeExecUsageError(stderr, "sessions compact-plan requires a session id")
@@ -200,8 +205,8 @@ func isSessionsCommand(command string) bool {
 
 func validateSessionCommandFlags(command string, options sessionCommandOptions) error {
 	hasRewindFlag := options.sequence > 0 || strings.TrimSpace(options.eventID) != "" || options.excludeTarget
-	if hasRewindFlag && command != "rewind-plan" {
-		return execUsageError{"--sequence, --event, and --exclude-target are only valid for sessions rewind-plan"}
+	if hasRewindFlag && command != "rewind-plan" && command != "rewind" {
+		return execUsageError{"--sequence, --event, and --exclude-target are only valid for sessions rewind-plan and rewind"}
 	}
 	hasCompactionFlag := options.preserveLast > 0 || options.maxPromptChars > 0
 	if hasCompactionFlag && command != "compact-plan" {
@@ -298,6 +303,43 @@ func runSessionsRewindPlan(store *sessions.Store, sessionID string, options sess
 		return exitSuccess
 	}
 	if _, err := fmt.Fprintln(stdout, formatRewindPlan(plan)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSessionsRewind(store *sessions.Store, sessionID string, options sessionCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	plan, err := store.PlanRewind(sessionID, sessions.RewindOptions{
+		TargetSequence: options.sequence,
+		TargetEventID:  options.eventID,
+		KeepTarget:     !options.excludeTarget,
+	})
+	if err != nil {
+		return writeSessionCommandError(stderr, err)
+	}
+	session, err := store.Get(sessionID)
+	if err != nil {
+		return writeSessionCommandError(stderr, err)
+	}
+	if session == nil {
+		return writeExecUsageError(stderr, "Zero session not found: "+sessionID)
+	}
+	workspaceRoot := strings.TrimSpace(session.Cwd)
+	if workspaceRoot == "" {
+		return writeExecUsageError(stderr, "session has no recorded workspace (cwd); cannot restore files")
+	}
+	report, err := store.ApplyRewind(sessionID, workspaceRoot, plan.TargetSequence)
+	if err != nil {
+		return writeSessionCommandError(stderr, err)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(report, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "Rewound %s to sequence %d: %d file(s) restored, %d deleted, %d skipped.\n",
+		sessionID, plan.TargetSequence, report.FilesRestored, report.FilesDeleted, len(report.Skipped)); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -429,13 +471,14 @@ Commands:
   lineage <id>          Print the root-to-session lineage path
   tree <id>             Print a child-session tree
   rewind-plan <id>      Preview events kept and dropped by a rewind
+  rewind <id>           Restore workspace files and truncate the log to a checkpoint
   compact-plan <id>     Preview events compacted and preserved by compaction
 
 Flags:
       --json            Print JSON output
-      --sequence <n>    Rewind target sequence for rewind-plan
-      --event <id>      Rewind target event id for rewind-plan
-      --exclude-target  Drop the target event in rewind-plan
+      --sequence <n>    Rewind target sequence (rewind-plan, rewind)
+      --event <id>      Rewind target event id (rewind-plan, rewind)
+      --exclude-target  Drop the target event (rewind-plan, rewind)
       --preserve-last <n> Keep recent events in compact-plan
       --max-prompt-chars <n> Limit compact-plan summary prompt
   -h, --help            Show this help

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -196,7 +196,7 @@ func parseNonEmptySessionsFlag(flag string, value string) (string, error) {
 
 func isSessionsCommand(command string) bool {
 	switch command {
-	case "list", "children", "lineage", "tree", "rewind-plan", "compact-plan":
+	case "list", "children", "lineage", "tree", "rewind-plan", "rewind", "compact-plan":
 		return true
 	default:
 		return false
@@ -322,13 +322,20 @@ func runSessionsRewind(store *sessions.Store, sessionID string, options sessionC
 		return writeSessionCommandError(stderr, err)
 	}
 	if session == nil {
-		return writeExecUsageError(stderr, "Zero session not found: "+sessionID)
+		return writeExecUsageError(stderr, "Zero session not found: "+redact(sessionID))
 	}
 	workspaceRoot := strings.TrimSpace(session.Cwd)
 	if workspaceRoot == "" {
 		return writeExecUsageError(stderr, "session has no recorded workspace (cwd); cannot restore files")
 	}
-	report, err := store.ApplyRewind(sessionID, workspaceRoot, plan.TargetSequence)
+	// Honor --exclude-target: ApplyRewind keeps events THROUGH the given sequence,
+	// so when the target event itself must be dropped (KeepTarget=false), apply
+	// through the sequence BEFORE it — matching what rewind-plan reports.
+	keepThrough := plan.TargetSequence
+	if !plan.KeepTarget {
+		keepThrough = plan.TargetSequence - 1
+	}
+	report, err := store.ApplyRewind(sessionID, workspaceRoot, keepThrough)
 	if err != nil {
 		return writeSessionCommandError(stderr, err)
 	}
@@ -339,7 +346,7 @@ func runSessionsRewind(store *sessions.Store, sessionID string, options sessionC
 		return exitSuccess
 	}
 	if _, err := fmt.Fprintf(stdout, "Rewound %s to sequence %d: %d file(s) restored, %d deleted, %d skipped.\n",
-		sessionID, plan.TargetSequence, report.FilesRestored, report.FilesDeleted, len(report.Skipped)); err != nil {
+		redact(sessionID), keepThrough, report.FilesRestored, report.FilesDeleted, len(report.Skipped)); err != nil {
 		return exitCrash
 	}
 	return exitSuccess

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -131,6 +131,45 @@ func TestRunSessionsPlansRewindAndCompaction(t *testing.T) {
 	}
 }
 
+// Regression: `sessions rewind` must be reachable (the parser whitelist), and the
+// destructive path must honor --exclude-target (apply BEFORE the target event).
+func TestRunSessionsRewindIsReachableAndHonorsExcludeTarget(t *testing.T) {
+	makeStore := func() (*sessions.Store, string) {
+		store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T19:30:00Z")})
+		session, err := store.Create(sessions.CreateInput{SessionID: "rw", Title: "Rewind", Cwd: t.TempDir()})
+		if err != nil {
+			t.Fatalf("Create returned error: %v", err)
+		}
+		for _, content := range []string{"alpha", "beta", "gamma", "delta"} {
+			if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventMessage, Payload: map[string]string{"content": content}}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return store, session.SessionID
+	}
+	remainingAfterRewind := func(extra ...string) int {
+		store, id := makeStore()
+		var stdout, stderr bytes.Buffer
+		args := append([]string{"sessions", "rewind", id, "--sequence", "2"}, extra...)
+		if ec := runWithDeps(args, &stdout, &stderr, appDeps{
+			newSessionStore: func() *sessions.Store { return store },
+		}); ec != exitSuccess {
+			t.Fatalf("sessions rewind %v exit = %d, stderr = %q", extra, ec, stderr.String())
+		}
+		events, err := store.ReadEvents(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(events)
+	}
+
+	keepTarget := remainingAfterRewind()                      // keep through seq 2
+	excludeTarget := remainingAfterRewind("--exclude-target") // keep through seq 1
+	if excludeTarget >= keepTarget {
+		t.Fatalf("--exclude-target should keep fewer events than keep-target: keep=%d exclude=%d", keepTarget, excludeTarget)
+	}
+}
+
 func TestRunSessionsValidatesArgs(t *testing.T) {
 	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-04T19:30:00Z")})
 

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/skills"
+)
+
+type skillListOptions struct {
+	json bool
+}
+
+func runSkills(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	command := "list"
+	rest := args
+	if len(args) > 0 {
+		switch args[0] {
+		case "-h", "--help", "help":
+			if err := writeSkillsHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		case "list":
+			command, rest = "list", args[1:]
+		default:
+			// Treat a leading flag (e.g. --json) as belonging to the implicit
+			// `list` command so `zero skills --json` works like `zero plugins`.
+			if !strings.HasPrefix(args[0], "-") {
+				return writeExecUsageError(stderr, fmt.Sprintf("unknown skills subcommand %q", args[0]))
+			}
+		}
+	}
+
+	switch command {
+	case "list":
+		options, help, err := parseSkillListArgs(rest)
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		if help {
+			if err := writeSkillsListHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		return runSkillsList(deps.skillsDir(), options, stdout, stderr)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown skills subcommand %q", command))
+	}
+}
+
+func runSkillsList(dir string, options skillListOptions, stdout io.Writer, stderr io.Writer) int {
+	discovered, err := skills.List(dir)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		payload := struct {
+			Skills []skills.Skill `json:"skills"`
+		}{Skills: discovered}
+		if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	output := redaction.RedactString(formatSkillList(discovered, dir), redaction.Options{})
+	if _, err := fmt.Fprintln(stdout, output); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func formatSkillList(discovered []skills.Skill, dir string) string {
+	if len(discovered) == 0 {
+		return fmt.Sprintf("No Zero skills found in %s.", dir)
+	}
+	lines := []string{"Zero Skills:"}
+	for _, skill := range discovered {
+		line := "  " + skill.Name
+		if skill.Description != "" {
+			line += " - " + skill.Description
+		}
+		lines = append(lines, line)
+		lines = append(lines, "    "+skill.Path)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func parseSkillListArgs(args []string) (skillListOptions, bool, error) {
+	options := skillListOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown skills list flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func writeSkillsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero skills <command>
+
+Commands:
+  list    List discovered Zero skills
+`)
+	return err
+}
+
+func writeSkillsListHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero skills list [flags]
+
+Flags:
+      --json    Print discovered skills as JSON
+  -h, --help    Show this help
+`)
+	return err
+}

--- a/internal/cli/skills_test.go
+++ b/internal/cli/skills_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tui"
+)
+
+func writeSkillFixture(t *testing.T, dir string, name string, content string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", skillDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func TestRunSkillsListText(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFixture(t, dir, "confirmation-policy", "---\nname: confirmation-policy\ndescription: Ask before risky actions.\n---\nbody")
+
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"skills", "list"}, &stdout, &stderr, appDeps{
+		skillsDir: func() string { return dir },
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, stderr = %s", exit, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"confirmation-policy", "Ask before risky actions."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSkillsDefaultsToList(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFixture(t, dir, "demo", "body")
+
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"skills"}, &stdout, &stderr, appDeps{
+		skillsDir: func() string { return dir },
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "demo") {
+		t.Fatalf("output missing demo:\n%s", stdout.String())
+	}
+}
+
+func TestRunSkillsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFixture(t, dir, "demo", "---\nname: demo\ndescription: a demo\n---\nbody")
+
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"skills", "list", "--json"}, &stdout, &stderr, appDeps{
+		skillsDir: func() string { return dir },
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, stderr = %s", exit, stderr.String())
+	}
+	var payload struct {
+		Skills []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Path        string `json:"path"`
+			Content     string `json:"content"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(payload.Skills))
+	}
+	if payload.Skills[0].Name != "demo" || payload.Skills[0].Description != "a demo" {
+		t.Fatalf("unexpected skill: %#v", payload.Skills[0])
+	}
+	if payload.Skills[0].Path == "" {
+		t.Fatalf("path should be present")
+	}
+}
+
+func TestRunSkillsEmptyDir(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"skills", "list"}, &stdout, &stderr, appDeps{
+		skillsDir: func() string { return filepath.Join(t.TempDir(), "missing") },
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(strings.ToLower(stdout.String()), "no") {
+		t.Fatalf("expected a no-skills message, got:\n%s", stdout.String())
+	}
+}
+
+func TestRunSkillsDoesNotLaunchTUI(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	launchCalled := false
+	_ = runWithDeps([]string{"skills"}, &stdout, &stderr, appDeps{
+		skillsDir: func() string { return t.TempDir() },
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			launchCalled = true
+			return 0
+		},
+	})
+	if launchCalled {
+		t.Fatalf("TUI launcher should not be called for skills command")
+	}
+}

--- a/internal/cli/zeroline.go
+++ b/internal/cli/zeroline.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/Gitlawb/zero/internal/zeroline"
+)
+
+// runZeroline launches the interactive Zero TUI with the "zeroline" skin: a Zen
+// home page and a Statusline chat page with 5 switchable color themes. It reuses
+// the exact same runtime wiring as the default `zero` shell (provider, tools,
+// sandbox, permissions, sessions) — only the rendering differs.
+//
+// With --snapshot it renders a single static frame (home page) to stdout for
+// local verification without a TTY.
+func runZeroline(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	fs := flag.NewFlagSet("zeroline", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	snapshot := fs.Bool("snapshot", false, "render a single frame to stdout and exit (no TTY)")
+	page := fs.String("page", "home", "snapshot page: home|chat")
+	variant := fs.Int("variant", 1, "color theme 1-5 (1 Phosphor, 2 Cyan, 3 Sage, 4 Violet, 5 Mono)")
+	light := fs.Bool("light", false, "use the light variant for the snapshot")
+	perm := fs.Bool("perm", false, "show the centered permission modal in the chat snapshot")
+	boot := fs.Int("boot", -1, "render the boot splash at the given animation frame")
+	stream := fs.Bool("stream", false, "show a streaming assistant response in the chat snapshot")
+	width := fs.Int("width", 100, "snapshot width")
+	height := fs.Int("height", 30, "snapshot height")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *snapshot {
+		v := *variant - 1
+		if v < 0 || v >= len(zeroline.Themes) {
+			v = 0
+		}
+		if *boot >= 0 {
+			if _, err := fmt.Fprintln(stdout, zeroline.RenderBoot(v, !*light, *boot, *width, *height)); err != nil {
+				return 1
+			}
+			return 0
+		}
+		hdr := zeroline.Header{Cwd: "~/src/zero", Branch: "main", Model: "claude-sonnet-4.5", Provider: "anthropic"}
+		var frame string
+		if *page == "chat" {
+			cd := zeroline.ChatData{
+				Variant: v, Dark: !*light, Width: *width, Height: *height, Header: hdr,
+				Rows: []zeroline.Row{
+					{Kind: "user", Text: "refactor internal/agent/loop.go to extract tool execution"},
+					{Kind: "toolcall", Tool: "list_directory", Detail: "internal/agent"},
+					{Kind: "toolresult", Tool: "list_directory", Status: "ok", Detail: "Contents of internal/agent:\n\nloop.go\ntypes.go\nloop_test.go"},
+					{Kind: "toolcall", Tool: "read_file", Detail: "internal/agent/loop.go"},
+					{Kind: "toolresult", Tool: "read_file", Status: "ok", Detail: "File: internal/agent/loop.go (164 lines)\n\n118 | func (l *Loop) run(ctx context.Context) error {"},
+					{Kind: "toolcall", Tool: "edit_file", Detail: "exec.go (new) · loop.go"},
+					{Kind: "toolresult", Tool: "edit_file", Status: "ok", Detail: "--- a/internal/agent/loop.go\n+++ b/internal/agent/exec.go\n@@ -141,6 +141,3 @@\n-\tswitch t := call.Tool.(type) {\n-\tcase ReadFileTool: out, err = l.readFile(ctx, t)\n+\tout, err := l.exec.Dispatch(call)"},
+					{Kind: "assistant", Text: "Done. Extracted a `ToolExecutor`:\n\n```go\nfunc (e *ToolExecutor) Dispatch(c Call) (Out, error) {\n\treturn e.route(c)\n}\n```\n\nThe switch in loop.go now delegates to one call. Tests pass."},
+				},
+				Input: "❯ ",
+			}
+			if *perm {
+				cd.Perm = &zeroline.Perm{Tool: "edit_file", Risk: "medium", Reason: "writes internal/agent/exec.go and loop.go", Summary: "write"}
+			}
+			if *stream {
+				cd.Rows = cd.Rows[:len(cd.Rows)-1] // drop the final assistant row
+				cd.Working = true
+				cd.Stream = "Done. I extracted a `ToolExecutor` and collapsed the dispatch switch in loop.go to a single delegated call — the"
+				cd.TokS = 84
+			}
+			frame = zeroline.RenderChat(cd)
+		} else {
+			frame = zeroline.RenderHome(zeroline.HomeData{
+				Variant: v, Dark: !*light, Width: *width, Height: *height, Header: hdr,
+				Input: "❯ message zero — / commands · @ files · ! bash",
+			})
+		}
+		if _, err := fmt.Fprintln(stdout, frame); err != nil {
+			return 1
+		}
+		return 0
+	}
+
+	return runInteractiveTUIWithSkin(stderr, deps, "zeroline")
+}

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -24,6 +24,8 @@ const (
 	EventPermissionRequest  EventType = "permission_request"
 	EventPermissionDecision EventType = "permission_decision"
 	EventToolResult         EventType = "tool_result"
+	EventCheckpoint         EventType = "checkpoint"
+	EventRestore            EventType = "restore"
 	EventUsage              EventType = "usage"
 	EventFinal              EventType = "final"
 	EventWarning            EventType = "warning"
@@ -37,6 +39,22 @@ const (
 	InputPrompt  InputType = "prompt"
 	InputMessage InputType = "message"
 )
+
+// Display is a compact structured summary of a tool result.
+type Display struct {
+	Summary string `json:"summary,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+}
+
+// CheckpointInfo describes a captured file checkpoint or an applied restore.
+type CheckpointInfo struct {
+	Sequence      int      `json:"sequence,omitempty"`
+	Tool          string   `json:"tool,omitempty"`
+	Files         []string `json:"files,omitempty"`
+	FilesRestored int      `json:"filesRestored,omitempty"`
+	FilesDeleted  int      `json:"filesDeleted,omitempty"`
+	Skipped       []string `json:"skipped,omitempty"`
+}
 
 type Event struct {
 	SchemaVersion     int                `json:"schemaVersion"`
@@ -66,6 +84,10 @@ type Event struct {
 	Status            string             `json:"status,omitempty"`
 	Output            string             `json:"output,omitempty"`
 	Truncated         *bool              `json:"truncated,omitempty"`
+	Redacted          *bool              `json:"redacted,omitempty"`
+	ChangedFiles      []string           `json:"changedFiles,omitempty"`
+	Display           *Display           `json:"display,omitempty"`
+	Checkpoint        *CheckpointInfo    `json:"checkpoint,omitempty"`
 	Meta              map[string]string  `json:"meta,omitempty"`
 	PromptTokens      *int               `json:"promptTokens,omitempty"`
 	CompletionTokens  *int               `json:"completionTokens,omitempty"`

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -154,3 +154,61 @@ func TestCreateRunIDUsesStablePrefix(t *testing.T) {
 func boolPtr(value bool) *bool {
 	return &value
 }
+
+func TestEventRoundTripsStructuredToolResultFields(t *testing.T) {
+	redacted := true
+	truncated := false
+	ev := Event{
+		SchemaVersion: 1,
+		Type:          EventToolResult,
+		Output:        "Edited f.go",
+		Truncated:     &truncated,
+		Redacted:      &redacted,
+		ChangedFiles:  []string{"f.go"},
+		Display:       &Display{Summary: "Edited f.go", Kind: "diff"},
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Event
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Redacted == nil || !*back.Redacted {
+		t.Error("redacted lost in round-trip")
+	}
+	if len(back.ChangedFiles) != 1 || back.ChangedFiles[0] != "f.go" {
+		t.Errorf("changedFiles lost: %v", back.ChangedFiles)
+	}
+	if back.Display == nil || back.Display.Kind != "diff" {
+		t.Errorf("display lost: %+v", back.Display)
+	}
+	// omitempty: a bare event must not emit the new keys
+	bare, _ := json.Marshal(Event{SchemaVersion: 1, Type: EventText})
+	for _, k := range []string{"redacted", "changedFiles", "display"} {
+		if strings.Contains(string(bare), k) {
+			t.Errorf("expected %q omitted on bare event, got %s", k, bare)
+		}
+	}
+}
+
+func TestEventRoundTripsCheckpointInfo(t *testing.T) {
+	ev := Event{
+		SchemaVersion: 1,
+		Type:          EventCheckpoint,
+		Checkpoint:    &CheckpointInfo{Sequence: 5, Tool: "edit_file", Files: []string{"a.go"}},
+	}
+	data, _ := json.Marshal(ev)
+	var back Event
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Checkpoint == nil || back.Checkpoint.Tool != "edit_file" || back.Checkpoint.Sequence != 5 {
+		t.Errorf("checkpoint lost: %+v", back.Checkpoint)
+	}
+	bare, _ := json.Marshal(Event{SchemaVersion: 1, Type: EventText})
+	if strings.Contains(string(bare), "checkpoint") {
+		t.Errorf("checkpoint should be omitted on bare event: %s", bare)
+	}
+}


### PR DESCRIPTION
## CLI wiring — skills/zeroline commands, --mode presets, exec checkpoints, sandbox --effective, sessions rewind

The **final module** of the runtime-core decomposition. Wires the new runtime features into the cli while **preserving main's merged specialist cli**.

The source branch predates the specialist work and *drops* it; this PR keeps it by 3-way merging each drifted cli file from the common base (`2d41e24`) — specialist is a main-only (ours) addition, the reskin features are theirs-only, so both survive (only `app.go`/`exec.go` had real conflicts, resolved to include both).

### What's in it
- **Commands** — `zero skills` (lists `internal/skills`); `zero zeroline` (interactive TUI with the zeroline skin, via `runInteractiveTUIWithSkin`).
- **exec** — `--mode` presets (smart/deep/fast/large/precise) via `applyExecMode`; model-registry alias resolution + deprecation/effort notices; `ContextWindow` sizing; before-mutation **checkpoint recording** in `OnToolCall`; enhanced tool-result output (`ChangedFiles`/`Redacted`/`Display`); permission-mode validation fix.
- **sandbox** — `policy --effective` (resolved guards).
- **sessions** — `rewind` (executes the rewind plan).
- **interactive TUI** — defaults to **Ask** mode (advertises write/edit/bash + gates via prompts).
- **`internal/streamjson`** — `EventCheckpoint`/`EventRestore` + `CheckpointInfo`.

### Specialist preserved
`specialist.go`, the specialist flags (`--calling-session-id`/`--tag`/`--depth`/`--init-session-id`/…), the specialist runtime registration, and all specialist tests are intact and passing.

### Testing
build / vet / `go test ./...` / `go test -race ./internal/cli/` / `GOOS=windows go build ./...` all green. No new deps.

Completes the decomposition of #101.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `skills` command (text and JSON output)
  * Added `zeroline` interactive TUI skin with snapshot rendering
  * Added `sessions rewind` command to restore files from checkpoints
  * Added `--mode` presets to `exec`
  * Added `sandbox policy --effective` for resolved policy views

* **Changes**
  * Interactive TUI defaults to Ask permission mode
  * Tool results/events now include redaction, changed-files, display summaries and checkpoint/restore events
  * Exec model resolution, reasoning-effort notices, and permission validation improved
<!-- end of auto-generated comment: release notes by coderabbit.ai -->