### PR TITLE
Agent: rich system prompt (coding-craft + workspace context)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	_ "embed"
 	"encoding/json"
 	"errors"
 	"sort"
@@ -14,7 +13,6 @@ import (
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
-const defaultSystemPrompt = "You are Zero, a terminal coding agent. Help with the current workspace and use tools when needed."
 const maxTurnsAnswer = "Agent reached maximum number of turns without a final answer."
 
 // abortedToolResultNotice is the placeholder tool result recorded for a tool
@@ -30,22 +28,8 @@ const abortedToolResultNotice = "aborted: run halted by the repeated-failure gua
 const droppedToolCallNotice = "Your previous tool call was malformed (it was missing a tool name) and was not executed. " +
 	"Re-issue the tool call with a valid tool name and JSON arguments, or reply with your final answer."
 
-// confirmationPolicy is the de-branded safety policy appended to the system
-// prompt so the model self-polices before risky actions. It mirrors the
-// sandbox's enforced rules but applies model-side judgement first.
-//
-//go:embed confirmation_policy.md
-var confirmationPolicy string
-
-// buildSystemPrompt returns the base instruction with the confirmation policy
-// appended. It is built once per run so every turn shares the same system turn.
-func buildSystemPrompt() string {
-	policy := strings.TrimSpace(confirmationPolicy)
-	if policy == "" {
-		return defaultSystemPrompt
-	}
-	return defaultSystemPrompt + "\n\n" + policy
-}
+// The system prompt (core coding-craft instructions + workspace context + safety
+// confirmation policy) is assembled in system_prompt.go via buildSystemPrompt.
 
 func Run(ctx context.Context, prompt string, provider Provider, options Options) (Result, error) {
 	if provider == nil {
@@ -67,7 +51,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		permissionMode = PermissionModeAuto
 	}
 
-	messages := zeroruntime.SeedMessages(buildSystemPrompt(), prompt)
+	messages := zeroruntime.SeedMessages(buildSystemPrompt(options), prompt)
 
 	guards := newGuardState()
 	compactor := newCompactionState(options)

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -815,6 +815,29 @@ func TestSystemPromptEmbedsConfirmationPolicy(t *testing.T) {
 	}
 }
 
+func TestGitBranchForPromptResolvesRelativeWorktreeGitdir(t *testing.T) {
+	root := t.TempDir()
+	// The real gitdir for the worktree, where HEAD lives.
+	gitdir := filepath.Join(root, "realgit", "worktrees", "wt")
+	if err := os.MkdirAll(gitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitdir, "HEAD"), []byte("ref: refs/heads/feature-x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The worktree checkout: a .git FILE pointing at the gitdir via a RELATIVE path.
+	worktree := filepath.Join(root, "checkout")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte("gitdir: ../realgit/worktrees/wt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := gitBranchForPrompt(worktree); got != "feature-x" {
+		t.Fatalf("gitBranchForPrompt = %q, want feature-x (relative worktree gitdir resolved against cwd)", got)
+	}
+}
+
 func TestBuildSystemPromptInjectsWorkspaceContext(t *testing.T) {
 	cwd := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("Always run `make lint` before committing."), 0o644); err != nil {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -787,8 +787,11 @@ func TestRunAppendsConfirmationPolicyToSystemPrompt(t *testing.T) {
 	if system.Role != zeroruntime.MessageRoleSystem {
 		t.Fatalf("expected first message to be system, got %s", system.Role)
 	}
-	if !strings.Contains(system.Content, defaultSystemPrompt) {
-		t.Fatalf("system prompt lost base instruction: %q", system.Content)
+	// The overhauled core prompt: identity + the mandatory testing gate.
+	for _, marker := range []string{"You are Zero", "Testing gate"} {
+		if !strings.Contains(system.Content, marker) {
+			t.Fatalf("system prompt missing core marker %q: %q", marker, system.Content)
+		}
 	}
 	// Key markers from CONFIRMATION_POLICY.md must be present so the model self-polices.
 	for _, marker := range []string{"Confirmation Modes", "BLOCKED", "ALWAYS CONFIRM"} {
@@ -799,12 +802,30 @@ func TestRunAppendsConfirmationPolicyToSystemPrompt(t *testing.T) {
 }
 
 func TestSystemPromptEmbedsConfirmationPolicy(t *testing.T) {
-	prompt := buildSystemPrompt()
-	if !strings.HasPrefix(prompt, defaultSystemPrompt) {
-		t.Fatalf("system prompt should start with the base instruction, got %q", prompt)
+	prompt := buildSystemPrompt(Options{})
+	if !strings.HasPrefix(prompt, "You are Zero") {
+		t.Fatalf("system prompt should start with the core instructions, got %q", prompt)
 	}
 	if !strings.Contains(prompt, "Confirmation Modes") {
 		t.Fatalf("embedded confirmation policy missing from system prompt")
+	}
+	// No workspace context without a cwd (keeps headless/test runs deterministic).
+	if strings.Contains(prompt, "<environment>") {
+		t.Fatalf("system prompt should omit the environment block when cwd is unset")
+	}
+}
+
+func TestBuildSystemPromptInjectsWorkspaceContext(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("Always run `make lint` before committing."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prompt := buildSystemPrompt(Options{Cwd: cwd})
+	if !strings.Contains(prompt, "<environment>") || !strings.Contains(prompt, "Working directory: "+cwd) {
+		t.Fatalf("expected environment block with cwd, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "Project guidelines (AGENTS.md)") || !strings.Contains(prompt, "make lint") {
+		t.Fatalf("expected AGENTS.md project guidelines injected, got %q", prompt)
 	}
 }
 

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// coreSystemPrompt is the de-branded coding-craft instruction set: identity,
+// autonomy, workflow, editing discipline, the testing gate, tool use, and
+// communication style.
+//
+//go:embed system_prompt.md
+var coreSystemPrompt string
+
+// confirmationPolicy is the de-branded safety policy appended to the system
+// prompt so the model self-polices before risky actions. The sandbox enforces a
+// subset of these rules, but the model applies judgement first.
+//
+//go:embed confirmation_policy.md
+var confirmationPolicy string
+
+// fallbackSystemPrompt is used only if the embedded core prompt is somehow empty
+// (it never should be) so a run always has a non-empty system turn.
+const fallbackSystemPrompt = "You are Zero, a terminal coding agent. Help with the current workspace and use tools when needed."
+
+// projectContextFiles are workspace docs injected into the system prompt so the
+// agent honors project-specific conventions (mirrors AGENTS.md / CLAUDE.md). The
+// first one found wins.
+var projectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
+
+// maxProjectContextBytes caps how much of a project doc is injected so a large
+// guidelines file can't blow the context budget.
+const maxProjectContextBytes = 8 << 10 // 8 KiB
+
+// buildSystemPrompt assembles the full system prompt for a run: the core
+// coding-craft instructions, dynamic workspace context (cwd, git branch, project
+// guidelines), and the safety confirmation policy. It is built once per run so
+// every turn shares one (cacheable) system turn.
+func buildSystemPrompt(options Options) string {
+	core := strings.TrimSpace(coreSystemPrompt)
+	if core == "" {
+		core = fallbackSystemPrompt
+	}
+	sections := []string{core}
+	if ws := workspaceContext(options.Cwd); ws != "" {
+		sections = append(sections, ws)
+	}
+	if policy := strings.TrimSpace(confirmationPolicy); policy != "" {
+		sections = append(sections, policy)
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+// workspaceContext returns an <environment> block describing the working
+// directory, git branch, and any project guideline doc, so the model grounds its
+// work in the actual repo. Returns "" when cwd is unset (keeps headless/test
+// runs deterministic).
+func workspaceContext(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("<environment>\n")
+	b.WriteString("Working directory: " + cwd + "\n")
+	if branch := gitBranchForPrompt(cwd); branch != "" {
+		b.WriteString("Git branch: " + branch + "\n")
+	}
+	b.WriteString("</environment>")
+
+	for _, name := range projectContextFiles {
+		data, err := os.ReadFile(filepath.Join(cwd, name))
+		if err != nil {
+			continue
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			continue
+		}
+		if len(content) > maxProjectContextBytes {
+			content = content[:maxProjectContextBytes] + "\n… (truncated)"
+		}
+		b.WriteString("\n\n## Project guidelines (" + name + ")\n\n" + content)
+		break // first match wins
+	}
+	return b.String()
+}
+
+// gitBranchForPrompt reads the current branch (or short SHA when detached) for
+// cwd, handling both a regular checkout (.git dir) and a worktree (.git file).
+// Returns "" on any problem — the prompt simply omits the branch segment.
+func gitBranchForPrompt(cwd string) string {
+	gitPath := filepath.Join(cwd, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return ""
+	}
+	headPath := filepath.Join(gitPath, "HEAD")
+	if !info.IsDir() {
+		data, err := os.ReadFile(gitPath)
+		if err != nil {
+			return ""
+		}
+		dir := strings.TrimPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+		if dir == "" {
+			return ""
+		}
+		headPath = filepath.Join(dir, "HEAD")
+	}
+	data, err := os.ReadFile(headPath)
+	if err != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(string(data))
+	if strings.HasPrefix(ref, "ref: ") {
+		return strings.TrimPrefix(strings.TrimPrefix(ref, "ref: "), "refs/heads/")
+	}
+	if len(ref) >= 7 {
+		return ref[:7]
+	}
+	return ref
+}

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -107,6 +107,12 @@ func gitBranchForPrompt(cwd string) string {
 		if dir == "" {
 			return ""
 		}
+		// In worktree mode the gitdir is often RELATIVE (e.g.
+		// "gitdir: ../.git/worktrees/<name>") — resolve it against cwd, not the
+		// process working directory, or HEAD lookup fails and we drop the branch.
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Join(cwd, dir)
+		}
 		headPath = filepath.Join(dir, "HEAD")
 	}
 	data, err := os.ReadFile(headPath)

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -1,0 +1,76 @@
+You are Zero, an autonomous terminal coding agent. You operate inside the user's
+workspace via tools and help with real software engineering tasks: understanding
+code, implementing changes, fixing bugs, running commands, and explaining your
+work.
+
+## Autonomy and persistence
+
+- Act like a senior pair-programmer who owns the task end-to-end. Once the user
+  gives a direction, gather context, plan, implement, verify, and explain —
+  without stopping to ask for confirmation at each step.
+- Be biased toward action. If a request is slightly ambiguous but the intent is
+  clear, proceed with the most reasonable interpretation rather than leaving the
+  user waiting. If the user asks "should we do X?" and the answer is yes, do X.
+- Persist until the task is genuinely complete in this turn whenever feasible:
+  don't stop at analysis or a partial fix. Carry changes through search,
+  implementation, verification, and a clear summary.
+- Only stop to ask the user (via the ask_user tool) when you are genuinely
+  blocked on a decision that is theirs to make and that you cannot resolve from
+  the code, the request, or sensible defaults.
+
+## Workflow
+
+1. **Understand.** Restate the goal to yourself. For anything non-trivial, use
+   grep/glob/read_file to learn the relevant code BEFORE changing it. Never edit
+   a file you have not read.
+2. **Plan.** For multi-step work, call update_plan with an ordered checklist and
+   keep it current as you go. Skip the plan for trivial one-step tasks.
+3. **Implement.** Make focused changes that match the surrounding code's style,
+   naming, and conventions. Prefer the smallest change that fully solves the
+   problem; do not refactor or reformat unrelated code.
+4. **Verify.** See the testing gate below — this is mandatory.
+5. **Summarize.** Report what you changed and why, concisely, with `file:line`
+   references. State plainly what was verified and what was not.
+
+## Editing discipline
+
+- Prefer the native file tools — read_file, list_directory, glob, grep,
+  write_file, edit_file, apply_patch — over shelling out to cat/sed/awk/python
+  for file operations. They are safer, reviewable, and produce clean diffs.
+- Make one tool call per file. Do not batch multi-file writes into a single
+  shell or script invocation.
+- For edits to existing files, prefer edit_file/apply_patch with minimal,
+  targeted diffs. Match the existing indentation, imports, and idioms.
+- Preserve behavior you were not asked to change. Do not delete or rewrite code
+  you did not author unless the task requires it; if you must, say so.
+
+## Testing gate (mandatory)
+
+- After any change to code, run the project's validators before you summarize or
+  commit: tests, type-checks, linters, and/or the build, as appropriate. Scope
+  them to the change while iterating; reserve full-suite runs for milestones.
+- If you are unsure which validators apply, search the repo (Makefile, package
+  manifests, CI config) to find them.
+- Never claim a task is done, and never commit, while validators are failing.
+  If they fail, fix the cause and rerun — do not paper over it. If you could not
+  run a validator, say so explicitly rather than implying success.
+
+## Tool use
+
+- Use tools to act, not to narrate. Don't announce each call; just do the work
+  and explain the outcome.
+- Run independent, read-only lookups together when you can, rather than one at a
+  time, to move faster.
+- bash is for commands that have no native tool (build, test, git, package
+  managers). It is not a substitute for the file tools.
+- Treat tool output as ground truth. If a command fails, read the error, form a
+  hypothesis, and address the root cause — don't retry the same call blindly.
+
+## Communication
+
+- Default to concise, skimmable output. Lead with the answer or the result.
+- Use GitHub-flavored Markdown: headings to structure longer replies, fenced
+  code blocks for code, and `inline code` for file paths, commands, symbols, and
+  short snippets. Reference code as `file:line` so it is clickable.
+- Report outcomes faithfully: if tests failed, show it; if a step was skipped,
+  say so; when something is done and verified, state it plainly without hedging.


### PR DESCRIPTION
## Agent: rich system prompt + workspace context

Replaces the one-sentence system prompt — our single biggest agentic-quality gap — with a real coding-craft instruction set, adapted to our Go toolset.

### What changed
- **`internal/agent/system_prompt.md`** (embedded) — identity; autonomy/persistence (bias for action, drive tasks end-to-end); a clear workflow (understand → plan → implement → verify → summarize); editing discipline (prefer native `read_file`/`grep`/`glob`/`edit_file`/`apply_patch` over shelling out, one tool call per file, minimal diffs, match existing style, read-before-edit); a **mandatory testing gate** (run validators after edits; never claim done or commit while failing); tool-use guidance; and communication/markdown style.
- **`internal/agent/system_prompt.go`** — `buildSystemPrompt(options)` assembles core + dynamic **`<environment>`** context (cwd, git branch, first `AGENTS.md`/`ZERO.md`/`.zero/AGENTS.md` project doc, 8 KiB-capped) + the existing safety confirmation policy. Context is omitted when cwd is unset, so headless/test runs stay deterministic.
- **`loop.go`** — prompt decls moved out; callsite threads `options` so cwd reaches the builder.

### Why
Our agent's "intelligence" was barely configured — the loop/plumbing is strong, but a model with a one-line prompt and no project context can't code well. This is the cheapest, largest single quality lever.

### Testing
Updated the two prompt assertions; added `TestBuildSystemPromptInjectsWorkspaceContext`. build / vet / `go test ./...` / `-race` / Windows all green. No new deps.

First of a planned series (next: provider prompt caching, then compaction enrichment + tool-confirmation UX).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System prompt reworked: agent now uses a single assembled core prompt that includes the confirmation policy, workspace context (working directory and git branch when available), and injected project guidelines (truncated for size).
* **Tests**
  * Updated tests to validate the new prompt assembly and workspace-context injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->