### PR TITLE
Provider: prompt caching (system + tools)

### DIFF
--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -254,8 +254,13 @@ func (provider *Provider) emitDone(ctx context.Context, state *streamState, even
 	state.closeOpen(ctx, events)
 	if state.hasInputUsage || state.hasOutputUsage {
 		usage, err := zeroruntime.NormalizeUsage(zeroruntime.TokenUsage{
-			InputTokens:  state.inputTokens,
-			OutputTokens: state.outputTokens,
+			// Anthropic reports input_tokens (uncached), cache_read, and
+			// cache_creation SEPARATELY. The runtime models the cached count as a
+			// SUBSET of total input (it clamps cached <= input), so report the full
+			// prompt size as InputTokens and the cache hits as CachedInputTokens.
+			InputTokens:       state.inputTokens + state.cacheReadTokens + state.cacheCreationTokens,
+			CachedInputTokens: state.cacheReadTokens,
+			OutputTokens:      state.outputTokens,
 		})
 		if err == nil {
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: usage})
@@ -292,8 +297,20 @@ func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest
 		Model:     provider.model,
 		MaxTokens: provider.maxTokens,
 		Messages:  messages,
-		System:    system,
 		Stream:    true,
+	}
+	// Prompt caching: send the (stable, per-run) system prompt as a cacheable text
+	// block so the system instructions + tool definitions are not re-billed on
+	// every turn. The cache_control breakpoint on the last system block covers the
+	// whole system prompt; the breakpoint on the last tool covers all tool defs.
+	// Cache hits show up as cache_read_input_tokens in the usage. Non-caching
+	// providers ignore the field, and Anthropic accepts an empty/omitted system.
+	if strings.TrimSpace(system) != "" {
+		mapped.System = []systemBlock{{
+			Type:         "text",
+			Text:         system,
+			CacheControl: &cacheControl{Type: cacheEphemeral},
+		}}
 	}
 	if len(request.Tools) > 0 {
 		mapped.Tools = make([]anthropicTool, 0, len(request.Tools))
@@ -304,6 +321,7 @@ func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest
 				InputSchema: tool.Parameters,
 			})
 		}
+		mapped.Tools[len(mapped.Tools)-1].CacheControl = &cacheControl{Type: cacheEphemeral}
 	}
 	return mapped, nil
 }
@@ -434,13 +452,15 @@ type toolBlock struct {
 }
 
 type streamState struct {
-	tools          map[int]toolBlock
-	inputTokens    int
-	outputTokens   int
-	hasInputUsage  bool
-	hasOutputUsage bool
-	finishReason   string // normalized terminal stop reason (empty for normal stop)
-	done           bool
+	tools               map[int]toolBlock
+	inputTokens         int
+	outputTokens        int
+	cacheReadTokens     int // prompt-cache hits (cheap, re-billed reads)
+	cacheCreationTokens int // tokens written to the cache this turn
+	hasInputUsage       bool
+	hasOutputUsage      bool
+	finishReason        string // normalized terminal stop reason (empty for normal stop)
+	done                bool
 }
 
 // mapStopReason maps Anthropic's message_delta stop_reason onto the runtime's
@@ -460,6 +480,14 @@ func newStreamState() *streamState {
 func (state *streamState) recordUsage(usage usage) {
 	if usage.InputTokens != 0 {
 		state.inputTokens = usage.InputTokens
+		state.hasInputUsage = true
+	}
+	if usage.CacheReadInputTokens != 0 {
+		state.cacheReadTokens = usage.CacheReadInputTokens
+		state.hasInputUsage = true
+	}
+	if usage.CacheCreationInputTokens != 0 {
+		state.cacheCreationTokens = usage.CacheCreationInputTokens
 		state.hasInputUsage = true
 	}
 	if usage.OutputTokens != 0 {

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -83,8 +83,14 @@ func TestStreamCompletionPostsMessagesRequest(t *testing.T) {
 	if gotBody["model"] != "claude-test" || gotBody["stream"] != true || gotBody["max_tokens"] != float64(64_000) {
 		t.Fatalf("unexpected model/stream/max_tokens: %#v", gotBody)
 	}
-	if gotBody["system"] != "You are Zero." {
-		t.Fatalf("system = %#v, want system prompt", gotBody["system"])
+	// Prompt caching: system is sent as a cacheable text block, not a bare string.
+	system := gotBody["system"].([]any)
+	sysBlock := system[0].(map[string]any)
+	if sysBlock["type"] != "text" || sysBlock["text"] != "You are Zero." {
+		t.Fatalf("unexpected system block: %#v", gotBody["system"])
+	}
+	if cc, _ := sysBlock["cache_control"].(map[string]any); cc["type"] != "ephemeral" {
+		t.Fatalf("system block must carry ephemeral cache_control, got %#v", sysBlock["cache_control"])
 	}
 	messages := gotBody["messages"].([]any)
 	if len(messages) != 3 {
@@ -106,8 +112,13 @@ func TestStreamCompletionPostsMessagesRequest(t *testing.T) {
 		t.Fatalf("unexpected tool result: %#v", toolResultBlocks[0])
 	}
 	tools := gotBody["tools"].([]any)
-	if tools[0].(map[string]any)["input_schema"].(map[string]any)["type"] != "object" {
+	lastTool := tools[len(tools)-1].(map[string]any)
+	if lastTool["input_schema"].(map[string]any)["type"] != "object" {
 		t.Fatalf("unexpected tool schema: %#v", tools)
+	}
+	// The last tool carries the cache breakpoint so the whole tool block is cached.
+	if cc, _ := lastTool["cache_control"].(map[string]any); cc["type"] != "ephemeral" {
+		t.Fatalf("last tool must carry ephemeral cache_control, got %#v", lastTool["cache_control"])
 	}
 }
 
@@ -129,6 +140,37 @@ func TestStreamCompletionEmitsTextUsageAndDone(t *testing.T) {
 	}
 	if !reflect.DeepEqual(events, want) {
 		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+}
+
+func TestStreamCompletionReportsCacheTokens(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":10,"cache_read_input_tokens":200,"cache_creation_input_tokens":40}}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}`)
+		writeSSEEvent(w, "message_delta", `{"type":"message_delta","usage":{"output_tokens":5}}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	var usage *zeroruntime.Usage
+	for _, event := range collectProviderEvents(t, provider) {
+		if event.Type == zeroruntime.StreamEventUsage {
+			u := event.Usage
+			usage = &u
+		}
+	}
+	if usage == nil {
+		t.Fatal("expected a usage event")
+	}
+	// InputTokens is the full prompt (uncached + cache_read + cache_creation);
+	// CachedInputTokens is the cache-hit subset.
+	if usage.CachedInputTokens != 200 {
+		t.Fatalf("CachedInputTokens = %d, want 200", usage.CachedInputTokens)
+	}
+	if usage.InputTokens != 250 {
+		t.Fatalf("InputTokens = %d, want 250 (10 input + 200 cache_read + 40 cache_creation)", usage.InputTokens)
+	}
+	if usage.OutputTokens != 5 {
+		t.Fatalf("OutputTokens = %d, want 5", usage.OutputTokens)
 	}
 }
 

--- a/internal/providers/anthropic/types.go
+++ b/internal/providers/anthropic/types.go
@@ -4,9 +4,12 @@ type messagesRequest struct {
 	Model     string             `json:"model"`
 	MaxTokens int                `json:"max_tokens"`
 	Messages  []anthropicMessage `json:"messages"`
-	System    string             `json:"system,omitempty"`
-	Tools     []anthropicTool    `json:"tools,omitempty"`
-	Stream    bool               `json:"stream"`
+	// System is either a plain string or a []systemBlock when prompt caching is
+	// enabled (Anthropic accepts both). The block form lets us attach a
+	// cache_control breakpoint to the stable system prompt.
+	System any             `json:"system,omitempty"`
+	Tools  []anthropicTool `json:"tools,omitempty"`
+	Stream bool            `json:"stream"`
 }
 
 type anthropicMessage struct {
@@ -14,10 +17,28 @@ type anthropicMessage struct {
 	Content any    `json:"content"`
 }
 
+// systemBlock is a single text block of the system prompt. A cache_control
+// breakpoint on a block caches everything up to and including it.
+type systemBlock struct {
+	Type         string        `json:"type"`
+	Text         string        `json:"text"`
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
+// cacheControl marks a prompt-cache breakpoint. Only "ephemeral" is supported.
+type cacheControl struct {
+	Type string `json:"type"`
+}
+
+const cacheEphemeral = "ephemeral"
+
 type anthropicTool struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description,omitempty"`
 	InputSchema map[string]any `json:"input_schema,omitempty"`
+	// CacheControl on the LAST tool caches the whole (stable) tool-definition
+	// block so it is not re-billed every turn.
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
 }
 
 type streamPayload struct {
@@ -49,8 +70,10 @@ type streamDelta struct {
 }
 
 type usage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 }
 
 type apiError struct {


### PR DESCRIPTION
## Prompt caching (system + tools)

Caches the **stable per-run prefix** — the system prompt and tool definitions — so it isn't re-billed or re-processed on every turn. A direct **latency + token-cost win** on multi-turn sessions, and it pays off now that the system prompt is substantial (#129).

### What changed
- **`types.go`** — `system` can be sent as `[]systemBlock` (Anthropic accepts a string *or* blocks); added `cacheControl` and a `cache_control` breakpoint on the **last system block** and the **last tool** (two breakpoints covering the system prompt + the whole tool block); added `cache_read_input_tokens` / `cache_creation_input_tokens` to the usage struct.
- **`provider.go`** — `buildRequest` emits the cacheable system block and tags the last tool; the stream now captures cache read/creation tokens. Anthropic reports `input_tokens` (uncached), `cache_read`, and `cache_creation` **separately**, but the runtime models cached as a subset of input (clamps `cached ≤ input`), so we report the **full** prompt as `InputTokens` and the cache hits as `CachedInputTokens`.
- Caching is GA on `anthropic-version: 2023-06-01` (no beta header); the other providers are unaffected (the field is provider-local).

### Testing
Updated the request-shape assertions (system block + tool `cache_control`); added `TestStreamCompletionReportsCacheTokens`. build / vet / `go test ./...` / `-race` / Windows all green. No new deps.

Pairs with #129 (rich system prompt): the larger, structured prefix is exactly what benefits most from caching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled prompt caching for the Anthropic integration so system prompts and final tool definitions can be cached per run.
  * Improved usage accounting: reports include cached-read and cache-creation token components and reflect them in total input token counts.

* **Tests**
  * Added tests validating prompt-caching request structure and verifying cache token breakdown is reported during streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
