### PR TITLE
Agent: preserve active plan + loaded skills across compaction

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -35,7 +35,9 @@ const summaryLabel = "[Summary of earlier conversation]"
 const summaryInstructions = "You are compacting a coding-assistant conversation to save context. " +
 	"Write a dense, factual summary of the conversation so far. Preserve: the user's goals and explicit constraints; " +
 	"decisions made and why; files created or modified (with paths) and key code changes; commands run and their important " +
-	"results; and anything still in progress or unresolved. Omit pleasantries. Use terse bullet points. Do not invent details."
+	"results; and anything still in progress or unresolved. Omit pleasantries. Use terse bullet points. Do not invent details. " +
+	"If the conversation already begins with an earlier summary block, treat its facts as established context and carry them " +
+	"forward into the new summary — never drop earlier information."
 
 // CompactionOptions configure a single Compact call.
 type CompactionOptions struct {
@@ -128,11 +130,15 @@ func Compact(messages []zeroruntime.Message, opts CompactionOptions) ([]zerorunt
 	}
 	summary = strings.TrimSpace(summary)
 
+	// Preserve structured state (active plan + loaded skills) from the elided
+	// middle verbatim, so it is not lost or paraphrased away by the prose summary.
+	content := appendPreservedState(summaryLabel+"\n"+summary, middle)
+
 	compacted := make([]zeroruntime.Message, 0, systemEnd+1+(len(messages)-boundary))
 	compacted = append(compacted, messages[:systemEnd]...)
 	compacted = append(compacted, zeroruntime.Message{
 		Role:    zeroruntime.MessageRoleUser,
-		Content: summaryLabel + "\n" + summary,
+		Content: content,
 	})
 	compacted = append(compacted, messages[boundary:]...)
 	return compacted, nil

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -1,0 +1,166 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Compaction preservation.
+//
+// A plain prose summary loses two things the model needs to keep working: the
+// active plan (issued via the update_plan tool) and any skill instructions it
+// loaded (via the skill tool). When those turns fall into the elided middle,
+// the plan and skill bodies vanish from context. To prevent that, Compact
+// appends them VERBATIM to the injected summary so structured state survives a
+// compaction exactly rather than being paraphrased away.
+
+const (
+	toolNameUpdatePlan = "update_plan"
+	toolNameSkill      = "skill"
+)
+
+// planPreserveLabel / skillsPreserveLabel head the preserved sections so they
+// are unmistakable in the transcript (and so tests can assert on them).
+const planPreserveLabel = "## Active plan (preserved across compaction)"
+const skillsPreserveLabel = "## Loaded skills (preserved across compaction)"
+
+// maxPreservedSkillBytes caps how much of each loaded skill body is carried
+// across a compaction, so a large skill can't defeat the compaction it is part
+// of. The skill's name and head survive; the model can re-load it in full if it
+// needs the rest.
+const maxPreservedSkillBytes = 2 << 10 // 2 KiB
+
+// extractLatestPlan returns a formatted view of the most recent update_plan tool
+// call in messages, so an in-progress plan survives when its turns are elided by
+// compaction. Returns "" when no plan was issued.
+func extractLatestPlan(messages []zeroruntime.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		calls := messages[i].ToolCalls
+		for j := len(calls) - 1; j >= 0; j-- {
+			if calls[j].Name != toolNameUpdatePlan {
+				continue
+			}
+			if formatted := formatPlanArguments(calls[j].Arguments); formatted != "" {
+				return formatted
+			}
+		}
+	}
+	return ""
+}
+
+// formatPlanArguments renders an update_plan tool call's JSON arguments
+// ({"plan":[{content,status,...}]}) as terse status-tagged bullet lines. Returns
+// "" on malformed arguments or an empty plan.
+func formatPlanArguments(arguments string) string {
+	var parsed struct {
+		Plan []struct {
+			Content string `json:"content"`
+			Status  string `json:"status"`
+		} `json:"plan"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed); err != nil {
+		return ""
+	}
+	lines := make([]string, 0, len(parsed.Plan))
+	for _, item := range parsed.Plan {
+		content := strings.TrimSpace(item.Content)
+		if content == "" {
+			continue
+		}
+		status := strings.TrimSpace(item.Status)
+		if status == "" {
+			status = "pending"
+		}
+		lines = append(lines, "- ["+status+"] "+content)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// extractLoadedSkills returns the names and bodies of skills loaded via the skill
+// tool in messages, so loaded skill instructions survive compaction. Each skill
+// tool call is matched to its tool result by id; the latest body per skill wins,
+// and bodies are capped at maxPreservedSkillBytes. Returns "" when none loaded.
+func extractLoadedSkills(messages []zeroruntime.Message) string {
+	nameByID := map[string]string{}
+	for _, message := range messages {
+		for _, call := range message.ToolCalls {
+			if call.Name == toolNameSkill && call.ID != "" {
+				nameByID[call.ID] = skillNameFromArguments(call.Arguments)
+			}
+		}
+	}
+	if len(nameByID) == 0 {
+		return ""
+	}
+
+	bodyByName := map[string]string{}
+	nameOrder := make([]string, 0, len(nameByID))
+	for _, message := range messages {
+		if message.Role != zeroruntime.MessageRoleTool || message.ToolCallID == "" {
+			continue
+		}
+		name, ok := nameByID[message.ToolCallID]
+		if !ok {
+			continue
+		}
+		if name == "" {
+			name = "(unnamed)"
+		}
+		body := strings.TrimSpace(message.Content)
+		if body == "" {
+			continue
+		}
+		if _, seen := bodyByName[name]; !seen {
+			nameOrder = append(nameOrder, name)
+		}
+		bodyByName[name] = capBody(body)
+	}
+	if len(nameOrder) == 0 {
+		return ""
+	}
+
+	sections := make([]string, 0, len(nameOrder))
+	for _, name := range nameOrder {
+		sections = append(sections, "### "+name+"\n"+bodyByName[name])
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+// skillNameFromArguments pulls the "name" field from a skill tool call's JSON
+// arguments ({"name":"..."}). Returns "" on malformed arguments.
+func skillNameFromArguments(arguments string) string {
+	var parsed struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Name)
+}
+
+// capBody truncates an over-long skill body at a rune boundary with a note.
+func capBody(body string) string {
+	if len(body) <= maxPreservedSkillBytes {
+		return body
+	}
+	runes := []rune(body)
+	if len(runes) > maxPreservedSkillBytes {
+		runes = runes[:maxPreservedSkillBytes]
+	}
+	return string(runes) + "\n… (truncated; re-load the skill for the full body)"
+}
+
+// appendPreservedState appends the active plan and loaded-skill sections found
+// in the elided messages to a compaction summary, so structured state survives
+// verbatim. middle is the slice being summarized away.
+func appendPreservedState(summary string, middle []zeroruntime.Message) string {
+	if plan := extractLatestPlan(middle); plan != "" {
+		summary += "\n\n" + planPreserveLabel + "\n" + plan
+	}
+	if skills := extractLoadedSkills(middle); skills != "" {
+		summary += "\n\n" + skillsPreserveLabel + "\n" + skills
+	}
+	return summary
+}

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -84,6 +84,19 @@ func formatPlanArguments(arguments string) string {
 // tool call is matched to its tool result by id; the latest body per skill wins,
 // and bodies are capped at maxPreservedSkillBytes. Returns "" when none loaded.
 func extractLoadedSkills(messages []zeroruntime.Message) string {
+	return formatSkills(loadedSkills(messages))
+}
+
+// skillEntry is one loaded skill: its name and (capped) body.
+type skillEntry struct {
+	name string
+	body string
+}
+
+// loadedSkills returns the skills loaded via the skill tool in messages — the
+// latest body per name, in first-seen order — matching each skill tool call to
+// its tool result by id.
+func loadedSkills(messages []zeroruntime.Message) []skillEntry {
 	nameByID := map[string]string{}
 	for _, message := range messages {
 		for _, call := range message.ToolCalls {
@@ -93,7 +106,7 @@ func extractLoadedSkills(messages []zeroruntime.Message) string {
 		}
 	}
 	if len(nameByID) == 0 {
-		return ""
+		return nil
 	}
 
 	bodyByName := map[string]string{}
@@ -118,13 +131,22 @@ func extractLoadedSkills(messages []zeroruntime.Message) string {
 		}
 		bodyByName[name] = capBody(body)
 	}
-	if len(nameOrder) == 0 {
+
+	entries := make([]skillEntry, 0, len(nameOrder))
+	for _, name := range nameOrder {
+		entries = append(entries, skillEntry{name: name, body: bodyByName[name]})
+	}
+	return entries
+}
+
+// formatSkills renders skill entries as "### name\nbody" blocks.
+func formatSkills(entries []skillEntry) string {
+	if len(entries) == 0 {
 		return ""
 	}
-
-	sections := make([]string, 0, len(nameOrder))
-	for _, name := range nameOrder {
-		sections = append(sections, "### "+name+"\n"+bodyByName[name])
+	sections := make([]string, 0, len(entries))
+	for _, e := range entries {
+		sections = append(sections, "### "+e.name+"\n"+e.body)
 	}
 	return strings.Join(sections, "\n\n")
 }
@@ -164,15 +186,115 @@ func capBody(body string) string {
 	return body[:limit] + truncationNote
 }
 
-// appendPreservedState appends the active plan and loaded-skill sections found
-// in the elided messages to a compaction summary, so structured state survives
-// verbatim. middle is the slice being summarized away.
+// appendPreservedState appends the active plan and loaded-skill sections to a
+// compaction summary so structured state survives verbatim. middle is the slice
+// being summarized away.
+//
+// It is robust across REPEATED compactions: after the first compaction the plan
+// and skills live only as text inside the injected summary message, which on a
+// later compaction lands in middle with no real tool calls left to extract. So
+// when middle has no fresh update_plan / skill tool calls, the preserved
+// sections are carried forward from the prior summary instead of being lost.
+// Fresh tool calls always override the carried-forward copy.
 func appendPreservedState(summary string, middle []zeroruntime.Message) string {
-	if plan := extractLatestPlan(middle); plan != "" {
+	prior := latestSummaryContent(middle)
+
+	// Plan: a fresh update_plan in middle is authoritative; otherwise carry
+	// forward the plan section preserved by an earlier compaction.
+	plan := extractLatestPlan(middle)
+	if plan == "" {
+		plan = sectionText(prior, planPreserveLabel)
+	}
+	if plan != "" {
 		summary += "\n\n" + planPreserveLabel + "\n" + plan
 	}
-	if skills := extractLoadedSkills(middle); skills != "" {
-		summary += "\n\n" + skillsPreserveLabel + "\n" + skills
+
+	// Skills: merge skills preserved by an earlier compaction (older) with fresh
+	// skill loads in middle (newer wins per name), so a loaded skill survives
+	// repeated compactions even when the summarizer drops the section.
+	skills := mergeSkillEntries(parseSkillSection(sectionText(prior, skillsPreserveLabel)), loadedSkills(middle))
+	if formatted := formatSkills(skills); formatted != "" {
+		summary += "\n\n" + skillsPreserveLabel + "\n" + formatted
 	}
 	return summary
+}
+
+// latestSummaryContent returns the content of the most recent injected summary
+// message in messages (a user message beginning with summaryLabel), or "".
+func latestSummaryContent(messages []zeroruntime.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.Role == zeroruntime.MessageRoleUser && strings.HasPrefix(strings.TrimSpace(m.Content), summaryLabel) {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+// sectionText returns the body of the preserved section introduced by label in
+// content (from the LAST occurrence — the authoritative copy this code appended
+// — up to the next "## " heading or the end), or "".
+func sectionText(content, label string) string {
+	idx := strings.LastIndex(content, label)
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimPrefix(content[idx+len(label):], "\n")
+	if next := strings.Index(rest, "\n## "); next >= 0 {
+		rest = rest[:next]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// parseSkillSection parses a preserved skills section ("### name\nbody" blocks)
+// back into ordered skill entries.
+func parseSkillSection(text string) []skillEntry {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	var entries []skillEntry
+	for _, block := range strings.Split(text, "### ") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		name, body := block, ""
+		if nl := strings.IndexByte(block, '\n'); nl >= 0 {
+			name = strings.TrimSpace(block[:nl])
+			body = strings.TrimSpace(block[nl+1:])
+		}
+		if name != "" {
+			entries = append(entries, skillEntry{name: name, body: body})
+		}
+	}
+	return entries
+}
+
+// mergeSkillEntries overlays newer skill loads onto older preserved entries by
+// name (newer body wins), keeping the older order and appending genuinely-new
+// skills after.
+func mergeSkillEntries(older, newer []skillEntry) []skillEntry {
+	if len(newer) == 0 {
+		return older
+	}
+	newBody := make(map[string]string, len(newer))
+	for _, e := range newer {
+		newBody[e.name] = e.body
+	}
+	merged := make([]skillEntry, 0, len(older)+len(newer))
+	seen := make(map[string]bool, len(older))
+	for _, e := range older {
+		if b, ok := newBody[e.name]; ok {
+			e.body = b
+		}
+		merged = append(merged, e)
+		seen[e.name] = true
+	}
+	for _, e := range newer {
+		if !seen[e.name] {
+			merged = append(merged, e)
+		}
+	}
+	return merged
 }

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -22,10 +22,12 @@ const (
 	toolNameSkill      = "skill"
 )
 
-// planPreserveLabel / skillsPreserveLabel head the preserved sections so they
-// are unmistakable in the transcript (and so tests can assert on them).
-const planPreserveLabel = "## Active plan (preserved across compaction)"
-const skillsPreserveLabel = "## Loaded skills (preserved across compaction)"
+// preservedStateLabel heads the preserved-state block. The block body is a
+// single line of JSON (see formatPreservedState): JSON escapes everything, so a
+// skill body containing markdown headings (## / ###), code fences, or quotes
+// round-trips losslessly across repeated compactions — unlike a markdown-
+// delimited format, which would be truncated or mis-split when re-parsed.
+const preservedStateLabel = "## Preserved state (active plan + loaded skills; carried across compaction)"
 
 // maxPreservedSkillBytes caps how much of each loaded skill body is carried
 // across a compaction, so a large skill can't defeat the compaction it is part
@@ -77,14 +79,6 @@ func formatPlanArguments(arguments string) string {
 		lines = append(lines, "- ["+status+"] "+content)
 	}
 	return strings.Join(lines, "\n")
-}
-
-// extractLoadedSkills returns the names and bodies of skills loaded via the skill
-// tool in messages, so loaded skill instructions survive compaction. Each skill
-// tool call is matched to its tool result by id; the latest body per skill wins,
-// and bodies are capped at maxPreservedSkillBytes. Returns "" when none loaded.
-func extractLoadedSkills(messages []zeroruntime.Message) string {
-	return formatSkills(loadedSkills(messages))
 }
 
 // skillEntry is one loaded skill: its name and (capped) body.
@@ -139,18 +133,6 @@ func loadedSkills(messages []zeroruntime.Message) []skillEntry {
 	return entries
 }
 
-// formatSkills renders skill entries as "### name\nbody" blocks.
-func formatSkills(entries []skillEntry) string {
-	if len(entries) == 0 {
-		return ""
-	}
-	sections := make([]string, 0, len(entries))
-	for _, e := range entries {
-		sections = append(sections, "### "+e.name+"\n"+e.body)
-	}
-	return strings.Join(sections, "\n\n")
-}
-
 // skillNameFromArguments pulls the "name" field from a skill tool call's JSON
 // arguments ({"name":"..."}). Returns "" on malformed arguments.
 func skillNameFromArguments(arguments string) string {
@@ -186,37 +168,94 @@ func capBody(body string) string {
 	return body[:limit] + truncationNote
 }
 
-// appendPreservedState appends the active plan and loaded-skill sections to a
-// compaction summary so structured state survives verbatim. middle is the slice
-// being summarized away.
+// preservedState is the JSON shape of the carried-across-compaction block.
+type preservedState struct {
+	Plan   string           `json:"plan,omitempty"`
+	Skills []preservedSkill `json:"skills,omitempty"`
+}
+
+type preservedSkill struct {
+	Name string `json:"name"`
+	Body string `json:"body"`
+}
+
+// appendPreservedState appends the active plan and loaded skills to a compaction
+// summary as a single JSON block, so structured state survives verbatim. middle
+// is the slice being summarized away.
 //
 // It is robust across REPEATED compactions: after the first compaction the plan
-// and skills live only as text inside the injected summary message, which on a
-// later compaction lands in middle with no real tool calls left to extract. So
-// when middle has no fresh update_plan / skill tool calls, the preserved
-// sections are carried forward from the prior summary instead of being lost.
-// Fresh tool calls always override the carried-forward copy.
+// and skills live only inside the injected summary message, which on a later
+// compaction lands in middle with no real tool calls left to extract. So when
+// middle has no fresh update_plan / skill tool calls, the preserved state is
+// carried forward by re-parsing the prior block (JSON → lossless for arbitrary
+// markdown bodies). Fresh tool calls always override the carried-forward copy.
 func appendPreservedState(summary string, middle []zeroruntime.Message) string {
-	prior := latestSummaryContent(middle)
+	priorPlan, priorSkills := parsePreservedState(latestSummaryContent(middle))
 
-	// Plan: a fresh update_plan in middle is authoritative; otherwise carry
-	// forward the plan section preserved by an earlier compaction.
+	// Plan: a fresh update_plan in middle is authoritative; otherwise carry the
+	// plan preserved by an earlier compaction.
 	plan := extractLatestPlan(middle)
 	if plan == "" {
-		plan = sectionText(prior, planPreserveLabel)
-	}
-	if plan != "" {
-		summary += "\n\n" + planPreserveLabel + "\n" + plan
+		plan = priorPlan
 	}
 
-	// Skills: merge skills preserved by an earlier compaction (older) with fresh
-	// skill loads in middle (newer wins per name), so a loaded skill survives
-	// repeated compactions even when the summarizer drops the section.
-	skills := mergeSkillEntries(parseSkillSection(sectionText(prior, skillsPreserveLabel)), loadedSkills(middle))
-	if formatted := formatSkills(skills); formatted != "" {
-		summary += "\n\n" + skillsPreserveLabel + "\n" + formatted
+	// Skills: merge skills preserved earlier (older) with fresh loads (newer wins
+	// per name), so a loaded skill survives repeated compactions.
+	skills := mergeSkillEntries(priorSkills, loadedSkills(middle))
+
+	if block := formatPreservedState(plan, skills); block != "" {
+		summary += "\n\n" + block
 	}
 	return summary
+}
+
+// formatPreservedState renders the plan + skills as the labelled, single-line
+// JSON block. Returns "" when there is nothing to preserve.
+func formatPreservedState(plan string, skills []skillEntry) string {
+	if plan == "" && len(skills) == 0 {
+		return ""
+	}
+	state := preservedState{Plan: plan}
+	for _, s := range skills {
+		state.Skills = append(state.Skills, preservedSkill{Name: s.name, Body: s.body})
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		return ""
+	}
+	return preservedStateLabel + "\n" + string(encoded)
+}
+
+// parsePreservedState recovers the plan + skills from a prior summary's preserved
+// block. JSON escaping makes this lossless even when a skill body contains
+// markdown headings, code fences, or quotes. Returns ("", nil) when absent or
+// malformed.
+func parsePreservedState(summaryContent string) (string, []skillEntry) {
+	idx := strings.LastIndex(summaryContent, preservedStateLabel)
+	if idx < 0 {
+		return "", nil
+	}
+	rest := strings.TrimPrefix(summaryContent[idx+len(preservedStateLabel):], "\n")
+	// The JSON is a single line (json.Marshal escapes newlines).
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		rest = rest[:nl]
+	}
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "", nil
+	}
+	var state preservedState
+	if err := json.Unmarshal([]byte(rest), &state); err != nil {
+		return "", nil
+	}
+	entries := make([]skillEntry, 0, len(state.Skills))
+	for _, s := range state.Skills {
+		if s.Name == "" {
+			continue
+		}
+		entries = append(entries, skillEntry{name: s.Name, body: s.Body})
+	}
+	return state.Plan, entries
 }
 
 // latestSummaryContent returns the content of the most recent injected summary
@@ -229,46 +268,6 @@ func latestSummaryContent(messages []zeroruntime.Message) string {
 		}
 	}
 	return ""
-}
-
-// sectionText returns the body of the preserved section introduced by label in
-// content (from the LAST occurrence — the authoritative copy this code appended
-// — up to the next "## " heading or the end), or "".
-func sectionText(content, label string) string {
-	idx := strings.LastIndex(content, label)
-	if idx < 0 {
-		return ""
-	}
-	rest := strings.TrimPrefix(content[idx+len(label):], "\n")
-	if next := strings.Index(rest, "\n## "); next >= 0 {
-		rest = rest[:next]
-	}
-	return strings.TrimSpace(rest)
-}
-
-// parseSkillSection parses a preserved skills section ("### name\nbody" blocks)
-// back into ordered skill entries.
-func parseSkillSection(text string) []skillEntry {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil
-	}
-	var entries []skillEntry
-	for _, block := range strings.Split(text, "### ") {
-		block = strings.TrimSpace(block)
-		if block == "" {
-			continue
-		}
-		name, body := block, ""
-		if nl := strings.IndexByte(block, '\n'); nl >= 0 {
-			name = strings.TrimSpace(block[:nl])
-			body = strings.TrimSpace(block[nl+1:])
-		}
-		if name != "" {
-			entries = append(entries, skillEntry{name: name, body: body})
-		}
-	}
-	return entries
 }
 
 // mergeSkillEntries overlays newer skill loads onto older preserved entries by

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -140,16 +141,27 @@ func skillNameFromArguments(arguments string) string {
 	return strings.TrimSpace(parsed.Name)
 }
 
-// capBody truncates an over-long skill body at a rune boundary with a note.
+// truncationNote is appended to a capped skill body. Its length is reserved
+// within the byte budget so the result never exceeds maxPreservedSkillBytes.
+const truncationNote = "\n… (truncated; re-load the skill for the full body)"
+
+// capBody truncates an over-long skill body to maxPreservedSkillBytes BYTES,
+// cutting on a UTF-8 rune boundary (never splitting a multibyte rune) and
+// reserving room for the note so the result stays within the byte budget. The
+// note is added only when the body is actually truncated.
 func capBody(body string) string {
 	if len(body) <= maxPreservedSkillBytes {
 		return body
 	}
-	runes := []rune(body)
-	if len(runes) > maxPreservedSkillBytes {
-		runes = runes[:maxPreservedSkillBytes]
+	limit := maxPreservedSkillBytes - len(truncationNote)
+	if limit < 0 {
+		limit = 0
 	}
-	return string(runes) + "\n… (truncated; re-load the skill for the full body)"
+	// Walk back to the start of a rune so a multibyte sequence is never split.
+	for limit > 0 && !utf8.RuneStart(body[limit]) {
+		limit--
+	}
+	return body[:limit] + truncationNote
 }
 
 // appendPreservedState appends the active plan and loaded-skill sections found

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -85,6 +85,47 @@ func TestCompactWithoutStateHasNoPreserveSections(t *testing.T) {
 	}
 }
 
+func TestCompactCarriesPreservedStateAcrossRepeatedCompaction(t *testing.T) {
+	// First compaction: real update_plan + skill load in the elided middle.
+	first, err := Compact(stateConversation(), CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "FIRST SUMMARY", nil },
+	})
+	if err != nil {
+		t.Fatalf("first Compact: %v", err)
+	}
+
+	// Grow the history so the first summary (which holds the preserved sections,
+	// but no real tool calls) falls into the SECOND compaction's middle.
+	second := append([]zeroruntime.Message{}, first...)
+	second = append(second,
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "what next"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "keep going"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "done"},
+	)
+
+	// The second summarizer deliberately DROPS the preserved sections.
+	out, err := Compact(second, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "SECOND SUMMARY with no preserved sections", nil },
+	})
+	if err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+	if len(out) < 2 || out[1].Role != zeroruntime.MessageRoleUser {
+		t.Fatalf("unexpected compacted shape: %#v", out)
+	}
+	newSummary := out[1].Content
+	// Plan and skill must survive even though the summarizer didn't copy them.
+	if !strings.Contains(newSummary, planPreserveLabel) || !strings.Contains(newSummary, "write code") {
+		t.Fatalf("active plan lost on the second compaction: %q", newSummary)
+	}
+	if !strings.Contains(newSummary, "### deploy") || !strings.Contains(newSummary, "make deploy") {
+		t.Fatalf("loaded skill lost on the second compaction: %q", newSummary)
+	}
+}
+
 func TestExtractLatestPlanReturnsMostRecent(t *testing.T) {
 	messages := []zeroruntime.Message{
 		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -152,6 +152,9 @@ func TestCompactPreservesSkillBodyWithMarkdownHeadings(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s Compact: %v", label, err)
 		}
+		if len(out) < 2 || out[1].Role != zeroruntime.MessageRoleUser {
+			t.Fatalf("%s: unexpected compacted shape: %#v", label, out)
+		}
 		_, skills := parsePreservedState(out[1].Content)
 		if len(skills) != 1 || skills[0].name != "guide" || skills[0].body != body {
 			t.Fatalf("%s: skill body not round-tripped intact: %#v", label, skills)

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -96,6 +97,47 @@ func TestExtractLatestPlanReturnsMostRecent(t *testing.T) {
 	got := extractLatestPlan(messages)
 	if !strings.Contains(got, "new step") || strings.Contains(got, "old step") {
 		t.Fatalf("extractLatestPlan should return the most recent plan, got %q", got)
+	}
+}
+
+func TestCapBodyShortBodyUnchanged(t *testing.T) {
+	body := "short skill body"
+	if got := capBody(body); got != body {
+		t.Fatalf("capBody changed a short body: %q", got)
+	}
+	if strings.Contains(capBody(body), "truncated") {
+		t.Fatalf("note added without truncation")
+	}
+}
+
+func TestCapBodyRespectsByteBudgetForMultibyte(t *testing.T) {
+	// Each '世' is 3 bytes; build a body well over the byte budget.
+	body := strings.Repeat("世", maxPreservedSkillBytes)
+	got := capBody(body)
+	if len(got) > maxPreservedSkillBytes {
+		t.Fatalf("capBody returned %d bytes, want <= %d (byte budget)", len(got), maxPreservedSkillBytes)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected truncation note on an over-budget body")
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("capBody split a multibyte rune (invalid UTF-8)")
+	}
+}
+
+func TestCapBodyNoteOnlyWhenTruncated(t *testing.T) {
+	// A body whose RUNE count is under the cap but BYTE length is over it must
+	// still be byte-capped (the old rune-based check mishandled this case).
+	body := strings.Repeat("世", (maxPreservedSkillBytes/3)+100)
+	if len(body) <= maxPreservedSkillBytes {
+		t.Fatalf("test setup: body should exceed the byte budget, got %d", len(body))
+	}
+	got := capBody(body)
+	if len(got) > maxPreservedSkillBytes {
+		t.Fatalf("capBody returned %d bytes, want <= %d", len(got), maxPreservedSkillBytes)
+	}
+	if !strings.Contains(got, "truncated") || !utf8.ValidString(got) {
+		t.Fatalf("expected a valid, truncated body, got %q", got)
 	}
 }
 

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// stateConversation is a long enough conversation that Compact elides a middle
+// containing an update_plan call and a loaded skill (call + result).
+func stateConversation() []zeroruntime.Message {
+	return []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "build the thing"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "planning", ToolCalls: []zeroruntime.ToolCall{
+			{ID: "p1", Name: "update_plan", Arguments: `{"plan":[{"content":"write code","status":"in_progress"},{"content":"add tests","status":"pending"}]}`},
+		}},
+		{Role: zeroruntime.MessageRoleTool, Content: "plan updated", ToolCallID: "p1"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "loading skill", ToolCalls: []zeroruntime.ToolCall{
+			{ID: "s1", Name: "skill", Arguments: `{"name":"deploy"}`},
+		}},
+		{Role: zeroruntime.MessageRoleTool, Content: "Deploy skill: run `make deploy` then tag the release.", ToolCallID: "s1"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "done step 1"},
+		{Role: zeroruntime.MessageRoleUser, Content: "continue"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+	}
+}
+
+func compactStateConversation(t *testing.T, messages []zeroruntime.Message) string {
+	t.Helper()
+	compacted, err := Compact(messages, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "SUMMARY", nil },
+	})
+	if err != nil {
+		t.Fatalf("Compact returned error: %v", err)
+	}
+	// [system, summaryUserMsg, ...suffix] — the summary is the message after system.
+	if len(compacted) < 2 || compacted[1].Role != zeroruntime.MessageRoleUser {
+		t.Fatalf("unexpected compacted shape: %#v", compacted)
+	}
+	if !strings.Contains(compacted[1].Content, summaryLabel) {
+		t.Fatalf("summary message missing label: %q", compacted[1].Content)
+	}
+	return compacted[1].Content
+}
+
+func TestCompactPreservesActivePlan(t *testing.T) {
+	summary := compactStateConversation(t, stateConversation())
+	if !strings.Contains(summary, planPreserveLabel) {
+		t.Fatalf("expected plan preserve section, got %q", summary)
+	}
+	for _, want := range []string{"- [in_progress] write code", "- [pending] add tests"} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("plan item %q not preserved in %q", want, summary)
+		}
+	}
+}
+
+func TestCompactPreservesLoadedSkills(t *testing.T) {
+	summary := compactStateConversation(t, stateConversation())
+	if !strings.Contains(summary, skillsPreserveLabel) {
+		t.Fatalf("expected skills preserve section, got %q", summary)
+	}
+	if !strings.Contains(summary, "### deploy") || !strings.Contains(summary, "make deploy") {
+		t.Fatalf("skill name/body not preserved in %q", summary)
+	}
+}
+
+func TestCompactWithoutStateHasNoPreserveSections(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "hello"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "hi there"},
+		{Role: zeroruntime.MessageRoleUser, Content: "tell me more"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "sure"},
+		{Role: zeroruntime.MessageRoleUser, Content: "and more"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "ok"},
+	}
+	summary := compactStateConversation(t, messages)
+	if strings.Contains(summary, planPreserveLabel) || strings.Contains(summary, skillsPreserveLabel) {
+		t.Fatalf("did not expect preserve sections without plan/skill: %q", summary)
+	}
+}
+
+func TestExtractLatestPlanReturnsMostRecent(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+			{ID: "a", Name: "update_plan", Arguments: `{"plan":[{"content":"old step","status":"completed"}]}`},
+		}},
+		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+			{ID: "b", Name: "update_plan", Arguments: `{"plan":[{"content":"new step","status":"in_progress"}]}`},
+		}},
+	}
+	got := extractLatestPlan(messages)
+	if !strings.Contains(got, "new step") || strings.Contains(got, "old step") {
+		t.Fatalf("extractLatestPlan should return the most recent plan, got %q", got)
+	}
+}
+
+func TestExtractLoadedSkillsSkipsCallsWithoutResult(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+			{ID: "s1", Name: "skill", Arguments: `{"name":"ghost"}`}, // no matching tool result
+		}},
+	}
+	if got := extractLoadedSkills(messages); got != "" {
+		t.Fatalf("expected no skills without a result body, got %q", got)
+	}
+}

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -49,8 +49,8 @@ func compactStateConversation(t *testing.T, messages []zeroruntime.Message) stri
 
 func TestCompactPreservesActivePlan(t *testing.T) {
 	summary := compactStateConversation(t, stateConversation())
-	if !strings.Contains(summary, planPreserveLabel) {
-		t.Fatalf("expected plan preserve section, got %q", summary)
+	if !strings.Contains(summary, preservedStateLabel) {
+		t.Fatalf("expected preserved-state block, got %q", summary)
 	}
 	for _, want := range []string{"- [in_progress] write code", "- [pending] add tests"} {
 		if !strings.Contains(summary, want) {
@@ -61,10 +61,10 @@ func TestCompactPreservesActivePlan(t *testing.T) {
 
 func TestCompactPreservesLoadedSkills(t *testing.T) {
 	summary := compactStateConversation(t, stateConversation())
-	if !strings.Contains(summary, skillsPreserveLabel) {
-		t.Fatalf("expected skills preserve section, got %q", summary)
+	if !strings.Contains(summary, preservedStateLabel) {
+		t.Fatalf("expected preserved-state block, got %q", summary)
 	}
-	if !strings.Contains(summary, "### deploy") || !strings.Contains(summary, "make deploy") {
+	if !strings.Contains(summary, `"name":"deploy"`) || !strings.Contains(summary, "make deploy") {
 		t.Fatalf("skill name/body not preserved in %q", summary)
 	}
 }
@@ -80,8 +80,8 @@ func TestCompactWithoutStateHasNoPreserveSections(t *testing.T) {
 		{Role: zeroruntime.MessageRoleAssistant, Content: "ok"},
 	}
 	summary := compactStateConversation(t, messages)
-	if strings.Contains(summary, planPreserveLabel) || strings.Contains(summary, skillsPreserveLabel) {
-		t.Fatalf("did not expect preserve sections without plan/skill: %q", summary)
+	if strings.Contains(summary, preservedStateLabel) {
+		t.Fatalf("did not expect a preserved-state block without plan/skill: %q", summary)
 	}
 }
 
@@ -118,12 +118,56 @@ func TestCompactCarriesPreservedStateAcrossRepeatedCompaction(t *testing.T) {
 	}
 	newSummary := out[1].Content
 	// Plan and skill must survive even though the summarizer didn't copy them.
-	if !strings.Contains(newSummary, planPreserveLabel) || !strings.Contains(newSummary, "write code") {
+	if !strings.Contains(newSummary, preservedStateLabel) || !strings.Contains(newSummary, "write code") {
 		t.Fatalf("active plan lost on the second compaction: %q", newSummary)
 	}
-	if !strings.Contains(newSummary, "### deploy") || !strings.Contains(newSummary, "make deploy") {
+	if !strings.Contains(newSummary, `"name":"deploy"`) || !strings.Contains(newSummary, "make deploy") {
 		t.Fatalf("loaded skill lost on the second compaction: %q", newSummary)
 	}
+}
+
+// TestCompactPreservesSkillBodyWithMarkdownHeadings is CodeRabbit's regression:
+// a verbatim skill body containing ## / ### headings (and a code fence) must
+// round-trip across TWO compactions without truncation or bogus extra skills —
+// which the old markdown-delimited format could not guarantee.
+func TestCompactPreservesSkillBodyWithMarkdownHeadings(t *testing.T) {
+	body := "## Usage\nrun it\n### Examples\n```\nzero do\n```\n## Notes\ndone"
+	conv := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "load a skill"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "loading", ToolCalls: []zeroruntime.ToolCall{
+			{ID: "s1", Name: "skill", Arguments: `{"name":"guide"}`},
+		}},
+		{Role: zeroruntime.MessageRoleTool, Content: body, ToolCallID: "s1"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "done step 1"},
+		{Role: zeroruntime.MessageRoleUser, Content: "continue"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+	}
+
+	mustContainBody := func(label string, messages []zeroruntime.Message) []zeroruntime.Message {
+		out, err := Compact(messages, CompactionOptions{
+			PreserveLast: 2,
+			Summarize:    func([]zeroruntime.Message) (string, error) { return "SUMMARY", nil },
+		})
+		if err != nil {
+			t.Fatalf("%s Compact: %v", label, err)
+		}
+		_, skills := parsePreservedState(out[1].Content)
+		if len(skills) != 1 || skills[0].name != "guide" || skills[0].body != body {
+			t.Fatalf("%s: skill body not round-tripped intact: %#v", label, skills)
+		}
+		return out
+	}
+
+	first := mustContainBody("first", conv)
+	// Second compaction with NO fresh tool calls and a summarizer that drops it.
+	second := append(append([]zeroruntime.Message{}, first...),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "more"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "ok"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "again"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "fine"},
+	)
+	mustContainBody("second", second)
 }
 
 func TestExtractLatestPlanReturnsMostRecent(t *testing.T) {
@@ -182,13 +226,13 @@ func TestCapBodyNoteOnlyWhenTruncated(t *testing.T) {
 	}
 }
 
-func TestExtractLoadedSkillsSkipsCallsWithoutResult(t *testing.T) {
+func TestLoadedSkillsSkipsCallsWithoutResult(t *testing.T) {
 	messages := []zeroruntime.Message{
 		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
 			{ID: "s1", Name: "skill", Arguments: `{"name":"ghost"}`}, // no matching tool result
 		}},
 	}
-	if got := extractLoadedSkills(messages); got != "" {
-		t.Fatalf("expected no skills without a result body, got %q", got)
+	if got := loadedSkills(messages); len(got) != 0 {
+		t.Fatalf("expected no skills without a result body, got %#v", got)
 	}
 }


### PR DESCRIPTION
## Agent: preserve active plan + loaded skills across compaction

Compaction summarized the elided middle into prose, which silently dropped two pieces of **structured state** the model needs to keep working: the **active plan** (`update_plan`) and any **loaded skill** instructions (`skill` tool). After a compaction, the model would lose its own plan and any skill it had pulled into context.

### What changed
- **`internal/agent/compaction_preserve.go`** (new):
  - `extractLatestPlan` — the most recent `update_plan`, rendered as status-tagged bullets (`- [in_progress] write code`).
  - `extractLoadedSkills` — `skill` tool calls matched to their result bodies by id, latest-per-name, each body capped at 2 KiB so a large skill can't defeat the compaction it's part of.
  - `appendPreservedState` — folds both into the injected summary under clear, labelled sections.
- **`internal/agent/compaction.go`** — `Compact` appends the preserved state verbatim (structured state survives exactly, not paraphrased); `summaryInstructions` now tell the summarizer to **integrate any earlier summary block**, so repeated compactions accumulate rather than lose older facts (delta-aware summarization).

### Why
The plumbing for compaction was correct (boundary widening, no dangling tool results), but a plain prose summary is lossy for exactly the state the agent relies on between turns. Preserving it verbatim keeps long sessions coherent.

### Testing
Plan + skill preservation through `Compact`, no sections when absent, latest-plan-wins, skill calls without a result body skipped. build / vet / `go test ./...` / `-race` / Windows all green. No new deps.

Builds on the existing compaction (#125). Next in the series: per-category context token budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Conversation compaction now appends a preserved-state block to summaries, carrying prior summary context forward, preserving the latest active plan and loaded skills across repeated compactions, merging newer skill content while preserving order, and capping preserved skill bodies (~2 KiB) with UTF‑8-safe truncation and a truncation note; the preserved block is omitted when there’s nothing to preserve.

* **Tests**
  * Added tests validating state preservation, plan/status rendering, skill preservation and ordering, truncation behavior, and conversations with no preserved state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->