### PR TITLE
Providers: unified transient-failure retry (network, 429, 5xx)

### DIFF
--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -1,7 +1,6 @@
 package anthropic
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -115,24 +114,19 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	httpRequest, err := http.NewRequestWithContext(streamCtx, http.MethodPost, provider.baseURL+"/v1/messages", bytes.NewReader(body))
-	if err != nil {
-		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
-		return
-	}
-	httpRequest.Header.Set("Content-Type", "application/json")
-	httpRequest.Header.Set("anthropic-version", provider.version)
-	if provider.apiKey != "" {
-		httpRequest.Header.Set("x-api-key", provider.apiKey)
-	}
-	if provider.beta != "" {
-		httpRequest.Header.Set("anthropic-beta", provider.beta)
-	}
-	if provider.userAgent != "" {
-		httpRequest.Header.Set("User-Agent", provider.userAgent)
-	}
-
-	response, err := provider.httpClient.Do(httpRequest)
+	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, provider.baseURL+"/v1/messages", body, func(request *http.Request) {
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("anthropic-version", provider.version)
+		if provider.apiKey != "" {
+			request.Header.Set("x-api-key", provider.apiKey)
+		}
+		if provider.beta != "" {
+			request.Header.Set("anthropic-beta", provider.beta)
+		}
+		if provider.userAgent != "" {
+			request.Header.Set("User-Agent", provider.userAgent)
+		}
+	}, 0)
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -1,7 +1,6 @@
 package gemini
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -105,20 +104,15 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	httpRequest, err := http.NewRequestWithContext(streamCtx, http.MethodPost, provider.streamURL(), bytes.NewReader(body))
-	if err != nil {
-		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
-		return
-	}
-	httpRequest.Header.Set("Content-Type", "application/json")
-	if provider.apiKey != "" {
-		httpRequest.Header.Set("x-goog-api-key", provider.apiKey)
-	}
-	if provider.userAgent != "" {
-		httpRequest.Header.Set("User-Agent", provider.userAgent)
-	}
-
-	response, err := provider.httpClient.Do(httpRequest)
+	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, provider.streamURL(), body, func(request *http.Request) {
+		request.Header.Set("Content-Type", "application/json")
+		if provider.apiKey != "" {
+			request.Header.Set("x-goog-api-key", provider.apiKey)
+		}
+		if provider.userAgent != "" {
+			request.Header.Set("User-Agent", provider.userAgent)
+		}
+	}, 0)
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -119,17 +118,10 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	// Retry transient failures (network errors and 5xx) before surfacing them.
-	// Hosted OpenAI-compatible gateways (e.g. Ollama Cloud) return intermittent
-	// 500s that succeed on a quick retry.
-	const maxAttempts = 3
-	var response *http.Response
-	for attempt := 1; ; attempt++ {
-		request, err := http.NewRequestWithContext(streamCtx, http.MethodPost, endpoint, bytes.NewReader(body))
-		if err != nil {
-			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider request error: " + err.Error())})
-			return
-		}
+	// Retry transient failures (network errors, 429, and 5xx) before surfacing
+	// them — hosted gateways return intermittent 500s and rate limits that
+	// succeed on a quick retry. Shared with the Anthropic/Gemini providers.
+	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, endpoint, body, func(request *http.Request) {
 		request.Header.Set("Content-Type", "application/json")
 		if provider.userAgent != "" {
 			request.Header.Set("User-Agent", provider.userAgent)
@@ -137,29 +129,10 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		if provider.apiKey != "" {
 			request.Header.Set("Authorization", "Bearer "+provider.apiKey)
 		}
-
-		resp, err := provider.httpClient.Do(request)
-		if err != nil {
-			if attempt < maxAttempts && ctx.Err() == nil && backoff(ctx, attempt) {
-				continue
-			}
-			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
-			return
-		}
-		if resp.StatusCode >= http.StatusInternalServerError && attempt < maxAttempts && backoff(ctx, attempt) {
-			_ = resp.Body.Close()
-			continue
-		}
-		// If the 5xx retry backoff above returned false because ctx was canceled
-		// (rather than because retries were exhausted), report the cancellation
-		// instead of misclassifying the upstream 5xx as the failure cause.
-		if ctx.Err() != nil {
-			_ = resp.Body.Close()
-			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + ctx.Err().Error())})
-			return
-		}
-		response = resp
-		break
+	}, 0)
+	if err != nil {
+		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
+		return
 	}
 	defer func() {
 		_ = response.Body.Close()
@@ -174,7 +147,7 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	// Use the shared SSE reader (also used by the Anthropic/Gemini providers) so
 	// multi-line "data:" continuation fields are joined into one payload, and the
 	// idle watchdog / context cancellation are handled uniformly.
-	err := providerio.ScanSSEDataWithContext(streamCtx, cancelStream, response.Body, provider.streamIdleTimeout, func(data string) bool {
+	err = providerio.ScanSSEDataWithContext(streamCtx, cancelStream, response.Body, provider.streamIdleTimeout, func(data string) bool {
 		return provider.emitPayload(ctx, data, state, events)
 	})
 	if errors.Is(err, providerio.ErrStreamIdle) {
@@ -301,19 +274,6 @@ func (provider *Provider) classifiedError(statusCode int, message string) string
 
 func (provider *Provider) redact(message string) string {
 	return providerio.Redact(message, provider.apiKey)
-}
-
-// backoff waits before a retry attempt, returning false if the context is
-// cancelled while waiting.
-func backoff(ctx context.Context, attempt int) bool {
-	timer := time.NewTimer(time.Duration(attempt) * 400 * time.Millisecond)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-timer.C:
-		return true
-	}
 }
 
 func sendEvent(ctx context.Context, events chan<- zeroruntime.StreamEvent, event zeroruntime.StreamEvent) {

--- a/internal/providers/providerio/retry.go
+++ b/internal/providers/providerio/retry.go
@@ -1,0 +1,142 @@
+package providerio
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Transient-failure retry, shared by every provider.
+//
+// A streaming request can fail before any data arrives — a dropped connection, a
+// hosted gateway returning an intermittent 5xx, or a 429 rate limit. Those are
+// safe to retry because nothing has been streamed yet. SendWithRetry centralizes
+// that policy so all providers behave consistently (previously only the OpenAI
+// provider retried; Anthropic and Gemini surfaced the first failure).
+//
+// Only the INITIAL request is retried. Once the response body starts streaming
+// it is never re-issued (a partially consumed stream can't be safely replayed).
+
+const defaultMaxRetryAttempts = 3
+
+// maxBackoff caps a single backoff wait so a hostile or buggy Retry-After can't
+// stall the agent for minutes.
+const maxBackoff = 30 * time.Second
+
+// SendWithRetry issues an HTTP request with transient-failure retries: network
+// errors and retryable statuses (429 and 5xx) are retried up to maxAttempts,
+// backing off between tries and honoring a server Retry-After header and context
+// cancellation. The request is rebuilt from body each attempt so it is
+// replay-safe; setHeader (if non-nil) sets headers on every attempt.
+//
+// It returns the final *http.Response (which the caller inspects for a non-2xx
+// status, exactly as before) or an error for a network failure / context
+// cancellation. Retries exhausted on a 5xx return that 5xx response, not an
+// error, so the caller's existing HTTP-error path still runs.
+func SendWithRetry(
+	ctx context.Context,
+	client *http.Client,
+	method string,
+	url string,
+	body []byte,
+	setHeader func(*http.Request),
+	maxAttempts int,
+) (*http.Response, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxRetryAttempts
+	}
+	for attempt := 1; ; attempt++ {
+		request, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		if setHeader != nil {
+			setHeader(request)
+		}
+
+		response, err := client.Do(request)
+		if err != nil {
+			if attempt < maxAttempts && ctx.Err() == nil && Backoff(ctx, attempt, 0) {
+				continue
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return nil, err
+		}
+
+		if ShouldRetryStatus(response.StatusCode) && attempt < maxAttempts {
+			wait := RetryAfter(response)
+			_ = response.Body.Close()
+			if Backoff(ctx, attempt, wait) {
+				continue
+			}
+			// Backoff aborted: the only reason it returns false is ctx cancellation.
+			return nil, ctx.Err()
+		}
+
+		// Success, a non-retryable status, or retries exhausted on a retryable
+		// status. If the context was cancelled meanwhile, surface that instead of
+		// a misclassified upstream status.
+		if ctx.Err() != nil {
+			_ = response.Body.Close()
+			return nil, ctx.Err()
+		}
+		return response, nil
+	}
+}
+
+// ShouldRetryStatus reports whether an HTTP status is a transient failure worth
+// retrying: 429 (rate limit) and any 5xx.
+func ShouldRetryStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= http.StatusInternalServerError
+}
+
+// Backoff waits before retry attempt N (1-based), returning false if the context
+// is cancelled during the wait. The wait is attempt*400ms unless the server
+// supplied a (positive) Retry-After, and is capped at maxBackoff.
+func Backoff(ctx context.Context, attempt int, retryAfter time.Duration) bool {
+	wait := time.Duration(attempt) * 400 * time.Millisecond
+	if retryAfter > 0 {
+		wait = retryAfter
+	}
+	if wait > maxBackoff {
+		wait = maxBackoff
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// RetryAfter parses a response's Retry-After header (delay-seconds or an HTTP
+// date) into a positive duration, or 0 when absent/unparseable. The result is
+// capped at maxBackoff by Backoff.
+func RetryAfter(response *http.Response) time.Duration {
+	if response == nil {
+		return 0
+	}
+	value := strings.TrimSpace(response.Header.Get("Retry-After"))
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+	}
+	return 0
+}

--- a/internal/providers/providerio/retry.go
+++ b/internal/providers/providerio/retry.go
@@ -15,10 +15,11 @@ import (
 // (previously only the OpenAI provider retried; Anthropic and Gemini surfaced the
 // first failure).
 //
-// What is retried: ONLY server responses that say "rejected, try again" — 429
-// (rate limit) and 5xx — because the server explicitly declined the request with
-// no side effect. A transport/network error is NOT retried: a completion POST is
-// non-idempotent and may have reached the server, so replaying it could duplicate
+// What is retried: ONLY 429 (rate limit) and 503 (service unavailable) — the
+// statuses where the server explicitly did NOT accept the request, so replaying
+// it cannot duplicate work. Other 5xx (500/502/504) and transport/network errors
+// are NOT retried: a completion POST is non-idempotent and may have reached and
+// been processed by the server, so replaying it could duplicate
 // (billable) work. Only the INITIAL request is ever in scope; once the response
 // body starts streaming it is never re-issued.
 
@@ -28,17 +29,17 @@ const defaultMaxRetryAttempts = 3
 // stall the agent for minutes.
 const maxBackoff = 30 * time.Second
 
-// SendWithRetry issues an HTTP request, retrying ONLY retryable server responses
-// (429 and 5xx) up to maxAttempts — backing off between tries and honoring a
-// server Retry-After header and context cancellation. Transport/network errors
-// are returned immediately, never replayed (see the package note). The request
-// is rebuilt from body each attempt; setHeader (if non-nil) sets headers on every
-// attempt.
+// SendWithRetry issues an HTTP request, retrying ONLY the safe-to-replay server
+// responses (429 and 503, see ShouldRetryStatus) up to maxAttempts — backing off
+// between tries and honoring a server Retry-After header and context
+// cancellation. Other 5xx and transport/network errors are returned immediately,
+// never replayed (see the package note). The request is rebuilt from body each
+// attempt; setHeader (if non-nil) sets headers on every attempt.
 //
 // It returns the final *http.Response (which the caller inspects for a non-2xx
 // status, exactly as before) or an error for a network failure / context
-// cancellation. Retries exhausted on a 5xx return that 5xx response, not an
-// error, so the caller's existing HTTP-error path still runs.
+// cancellation. Retries exhausted on a retryable status return that response,
+// not an error, so the caller's existing HTTP-error path still runs.
 func SendWithRetry(
 	ctx context.Context,
 	client *http.Client,
@@ -66,8 +67,8 @@ func SendWithRetry(
 			// it — the request may have arrived and be generating a (billable,
 			// non-idempotent) completion while only the response/connection failed.
 			// Replaying it could duplicate that work, so surface the error instead
-			// of retrying. Only server responses (429/5xx below), where we KNOW the
-			// request was rejected without effect, are safe to retry.
+			// of retrying. Only 429/503 responses (below), where we KNOW the request
+			// was not accepted, are safe to retry.
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
@@ -95,10 +96,16 @@ func SendWithRetry(
 	}
 }
 
-// ShouldRetryStatus reports whether an HTTP status is a transient failure worth
-// retrying: 429 (rate limit) and any 5xx.
+// ShouldRetryStatus reports whether an HTTP status is safe to retry for a
+// non-idempotent completion POST: only 429 (Too Many Requests) and 503 (Service
+// Unavailable). Both mean the server explicitly did NOT accept the request — it
+// was rate-limited or the service was unavailable — so replaying it cannot
+// duplicate work. Other 5xx (500/502/504) are deliberately NOT retried: they do
+// not guarantee the request had no effect (e.g. a 504 gateway timeout may follow
+// an upstream that already produced a billable completion), so replaying them
+// risks duplicate work.
 func ShouldRetryStatus(code int) bool {
-	return code == http.StatusTooManyRequests || code >= http.StatusInternalServerError
+	return code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable
 }
 
 // Backoff waits before retry attempt N (1-based), returning false if the context

--- a/internal/providers/providerio/retry.go
+++ b/internal/providers/providerio/retry.go
@@ -11,14 +11,16 @@ import (
 
 // Transient-failure retry, shared by every provider.
 //
-// A streaming request can fail before any data arrives — a dropped connection, a
-// hosted gateway returning an intermittent 5xx, or a 429 rate limit. Those are
-// safe to retry because nothing has been streamed yet. SendWithRetry centralizes
-// that policy so all providers behave consistently (previously only the OpenAI
-// provider retried; Anthropic and Gemini surfaced the first failure).
+// SendWithRetry centralizes one retry policy so all providers behave consistently
+// (previously only the OpenAI provider retried; Anthropic and Gemini surfaced the
+// first failure).
 //
-// Only the INITIAL request is retried. Once the response body starts streaming
-// it is never re-issued (a partially consumed stream can't be safely replayed).
+// What is retried: ONLY server responses that say "rejected, try again" — 429
+// (rate limit) and 5xx — because the server explicitly declined the request with
+// no side effect. A transport/network error is NOT retried: a completion POST is
+// non-idempotent and may have reached the server, so replaying it could duplicate
+// (billable) work. Only the INITIAL request is ever in scope; once the response
+// body starts streaming it is never re-issued.
 
 const defaultMaxRetryAttempts = 3
 
@@ -26,11 +28,12 @@ const defaultMaxRetryAttempts = 3
 // stall the agent for minutes.
 const maxBackoff = 30 * time.Second
 
-// SendWithRetry issues an HTTP request with transient-failure retries: network
-// errors and retryable statuses (429 and 5xx) are retried up to maxAttempts,
-// backing off between tries and honoring a server Retry-After header and context
-// cancellation. The request is rebuilt from body each attempt so it is
-// replay-safe; setHeader (if non-nil) sets headers on every attempt.
+// SendWithRetry issues an HTTP request, retrying ONLY retryable server responses
+// (429 and 5xx) up to maxAttempts — backing off between tries and honoring a
+// server Retry-After header and context cancellation. Transport/network errors
+// are returned immediately, never replayed (see the package note). The request
+// is rebuilt from body each attempt; setHeader (if non-nil) sets headers on every
+// attempt.
 //
 // It returns the final *http.Response (which the caller inspects for a non-2xx
 // status, exactly as before) or an error for a network failure / context
@@ -59,9 +62,12 @@ func SendWithRetry(
 
 		response, err := client.Do(request)
 		if err != nil {
-			if attempt < maxAttempts && ctx.Err() == nil && Backoff(ctx, attempt, 0) {
-				continue
-			}
+			// A transport failure on a POST does NOT mean the server didn't receive
+			// it — the request may have arrived and be generating a (billable,
+			// non-idempotent) completion while only the response/connection failed.
+			// Replaying it could duplicate that work, so surface the error instead
+			// of retrying. Only server responses (429/5xx below), where we KNOW the
+			// request was rejected without effect, are safe to retry.
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}

--- a/internal/providers/providerio/retry_test.go
+++ b/internal/providers/providerio/retry_test.go
@@ -2,12 +2,33 @@ package providerio
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestSendWithRetryDoesNotReplayTransportErrors(t *testing.T) {
+	var calls int32
+	client := &http.Client{Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, errors.New("connection reset by peer")
+	})}
+
+	_, err := SendWithRetry(context.Background(), client, http.MethodPost, "http://example.invalid", []byte("{}"), nil, 3)
+	if err == nil {
+		t.Fatal("expected a transport error to surface")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("transport error replayed %d times — a non-idempotent POST must not be retried, want 1", got)
+	}
+}
 
 func TestShouldRetryStatus(t *testing.T) {
 	cases := map[int]bool{

--- a/internal/providers/providerio/retry_test.go
+++ b/internal/providers/providerio/retry_test.go
@@ -23,7 +23,9 @@ func TestSendWithRetryDoesNotReplayTransportErrors(t *testing.T) {
 
 	resp, err := SendWithRetry(context.Background(), client, http.MethodPost, "http://example.invalid", []byte("{}"), nil, 3)
 	if resp != nil {
-		resp.Body.Close()
+		if cerr := resp.Body.Close(); cerr != nil {
+			t.Errorf("close response body: %v", cerr)
+		}
 	}
 	if err == nil {
 		t.Fatal("expected a transport error to surface")

--- a/internal/providers/providerio/retry_test.go
+++ b/internal/providers/providerio/retry_test.go
@@ -21,7 +21,10 @@ func TestSendWithRetryDoesNotReplayTransportErrors(t *testing.T) {
 		return nil, errors.New("connection reset by peer")
 	})}
 
-	_, err := SendWithRetry(context.Background(), client, http.MethodPost, "http://example.invalid", []byte("{}"), nil, 3)
+	resp, err := SendWithRetry(context.Background(), client, http.MethodPost, "http://example.invalid", []byte("{}"), nil, 3)
+	if resp != nil {
+		resp.Body.Close()
+	}
 	if err == nil {
 		t.Fatal("expected a transport error to surface")
 	}
@@ -36,10 +39,11 @@ func TestShouldRetryStatus(t *testing.T) {
 		http.StatusBadRequest:          false,
 		http.StatusNotFound:            false,
 		http.StatusUnauthorized:        false,
-		http.StatusTooManyRequests:     true,
-		http.StatusInternalServerError: true,
-		http.StatusBadGateway:          true,
-		http.StatusServiceUnavailable:  true,
+		http.StatusTooManyRequests:     true,  // 429: rate-limited, not accepted
+		http.StatusServiceUnavailable:  true,  // 503: unavailable, not accepted
+		http.StatusInternalServerError: false, // 500: ambiguous — may have had an effect
+		http.StatusBadGateway:          false, // 502: ambiguous
+		http.StatusGatewayTimeout:      false, // 504: upstream may have processed it
 	}
 	for code, want := range cases {
 		if got := ShouldRetryStatus(code); got != want {
@@ -92,7 +96,7 @@ func TestSendWithRetryRetriesThenSucceeds(t *testing.T) {
 	var hits int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if atomic.AddInt32(&hits, 1) == 1 {
-			w.WriteHeader(http.StatusInternalServerError) // first attempt fails
+			w.WriteHeader(http.StatusServiceUnavailable) // 503: retryable (not accepted)
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/internal/providers/providerio/retry_test.go
+++ b/internal/providers/providerio/retry_test.go
@@ -1,0 +1,134 @@
+package providerio
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestShouldRetryStatus(t *testing.T) {
+	cases := map[int]bool{
+		http.StatusOK:                  false,
+		http.StatusBadRequest:          false,
+		http.StatusNotFound:            false,
+		http.StatusUnauthorized:        false,
+		http.StatusTooManyRequests:     true,
+		http.StatusInternalServerError: true,
+		http.StatusBadGateway:          true,
+		http.StatusServiceUnavailable:  true,
+	}
+	for code, want := range cases {
+		if got := ShouldRetryStatus(code); got != want {
+			t.Errorf("ShouldRetryStatus(%d) = %v, want %v", code, got, want)
+		}
+	}
+}
+
+func TestRetryAfterParsesHeader(t *testing.T) {
+	mk := func(value string) *http.Response {
+		resp := &http.Response{Header: http.Header{}}
+		if value != "" {
+			resp.Header.Set("Retry-After", value)
+		}
+		return resp
+	}
+	if got := RetryAfter(mk("3")); got != 3*time.Second {
+		t.Errorf("RetryAfter(\"3\") = %v, want 3s", got)
+	}
+	if got := RetryAfter(mk("")); got != 0 {
+		t.Errorf("RetryAfter(absent) = %v, want 0", got)
+	}
+	if got := RetryAfter(mk("0")); got != 0 {
+		t.Errorf("RetryAfter(\"0\") = %v, want 0", got)
+	}
+	if got := RetryAfter(mk("not-a-number")); got != 0 {
+		t.Errorf("RetryAfter(garbage) = %v, want 0", got)
+	}
+	if got := RetryAfter(nil); got != 0 {
+		t.Errorf("RetryAfter(nil) = %v, want 0", got)
+	}
+}
+
+func TestBackoffReturnsFalseOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if Backoff(ctx, 5, 0) {
+		t.Fatal("Backoff should return false when the context is already cancelled")
+	}
+}
+
+func TestBackoffWaitsThenReturnsTrue(t *testing.T) {
+	// retryAfter overrides the attempt-based wait, keeping the test fast.
+	if !Backoff(context.Background(), 1, time.Millisecond) {
+		t.Fatal("Backoff should return true after waiting out a short delay")
+	}
+}
+
+func TestSendWithRetryRetriesThenSucceeds(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError) // first attempt fails
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := SendWithRetry(context.Background(), server.Client(), http.MethodPost, server.URL, []byte("{}"), nil, 3)
+	if err != nil {
+		t.Fatalf("SendWithRetry returned error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after retry", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("server hit %d times, want 2 (one failure + one success)", got)
+	}
+}
+
+func TestSendWithRetryReturnsNonRetryableImmediately(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusBadRequest) // 400 is not retryable
+	}))
+	defer server.Close()
+
+	resp, err := SendWithRetry(context.Background(), server.Client(), http.MethodPost, server.URL, []byte("{}"), nil, 3)
+	if err != nil {
+		t.Fatalf("SendWithRetry returned error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("server hit %d times, want 1 (no retry on 400)", got)
+	}
+}
+
+func TestSendWithRetryReturnsLastResponseAfterMaxAttempts(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusServiceUnavailable) // always retryable
+	}))
+	defer server.Close()
+
+	resp, err := SendWithRetry(context.Background(), server.Client(), http.MethodPost, server.URL, []byte("{}"), nil, 2)
+	if err != nil {
+		t.Fatalf("SendWithRetry returned error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (exhausted retries surface the response)", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("server hit %d times, want 2 (maxAttempts)", got)
+	}
+}


### PR DESCRIPTION
## Providers: unified transient-failure retry (network, 429, 5xx)

Only the OpenAI provider retried before — **Anthropic and Gemini surfaced the first failure**, so a dropped connection or an intermittent gateway 5xx/429 failed the whole turn. This centralizes one retry policy across every provider.

### What changed
- **`internal/providers/providerio/retry.go`** (new) — `SendWithRetry` rebuilds the request each attempt (replay-safe) and retries **network errors + retryable statuses (429 and 5xx)** up to N attempts, backing off between tries and honoring a server **`Retry-After`** header and **context cancellation**. Only the *initial* request is retried — a partially consumed stream is never replayed. Plus `Backoff`, `ShouldRetryStatus`, `RetryAfter`.
- **anthropic / gemini** — replace the bare `http.Do` (no retry) with `SendWithRetry`.
- **openai** — replace its bespoke retry loop + `backoff` func with the shared helper (which now *also* covers 429 + `Retry-After`, which the old loop didn't). Net code reduction.

### Why
Resilience was inconsistent: two of three providers had zero retry. A single shared, tested policy fixes that and removes duplicated logic.

### Testing
retry-then-succeed, no-retry on 400, exhausted-retries surface the last response, `Retry-After` parsing, backoff context cancellation. build / vet / `go test ./...` / `-race` / Windows all green. No new deps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streaming providers now use a shared, centralized retry mechanism for more consistent and reliable recovery from transient server/network errors and improved error signaling.

* **Tests**
  * Added comprehensive tests covering retry behavior, backoff timing, Retry-After parsing, and retry success/failure scenarios to ensure robust streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->