### PR TITLE
Agent: per-category context token budget (system / tools / messages)

### DIFF
--- a/internal/agent/context_measurement.go
+++ b/internal/agent/context_measurement.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"encoding/json"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Context budget.
+//
+// MeasureContext breaks a request's estimated token footprint into the
+// categories that actually compete for the window — the system prompt, the
+// advertised tool definitions, and the conversation messages — so the agent can
+// report context utilization (e.g. "62% used: 4k system, 6k tools, 30k history")
+// and reason about what to compact. Counts are estimates (see estimateTokens),
+// not a real tokenizer: good for proportions and budget bars, not billing.
+
+// ContextBreakdown is a per-category estimate of a request's token footprint.
+type ContextBreakdown struct {
+	SystemTokens  int     // leading system messages (prompt + injected context)
+	ToolTokens    int     // advertised tool definitions
+	MessageTokens int     // non-system conversation messages
+	TotalTokens   int     // SystemTokens + ToolTokens + MessageTokens
+	ContextWindow int     // model context window; 0 when unknown
+	UsedFraction  float64 // TotalTokens / ContextWindow; 0 when window unknown
+}
+
+// MeasureContext estimates the per-category token footprint of a request: the
+// leading system messages, the advertised tool definitions, and the remaining
+// conversation messages.
+func MeasureContext(messages []zeroruntime.Message, tools []zeroruntime.ToolDefinition, contextWindow int) ContextBreakdown {
+	systemEnd := 0
+	for systemEnd < len(messages) && messages[systemEnd].Role == zeroruntime.MessageRoleSystem {
+		systemEnd++
+	}
+
+	breakdown := ContextBreakdown{
+		SystemTokens:  estimateTokens(messages[:systemEnd]),
+		MessageTokens: estimateTokens(messages[systemEnd:]),
+		ToolTokens:    estimateToolTokens(tools),
+		ContextWindow: contextWindow,
+	}
+	breakdown.TotalTokens = breakdown.SystemTokens + breakdown.ToolTokens + breakdown.MessageTokens
+	if contextWindow > 0 {
+		breakdown.UsedFraction = float64(breakdown.TotalTokens) / float64(contextWindow)
+	}
+	return breakdown
+}
+
+// estimateToolTokens approximates the token footprint of advertised tool
+// definitions (name + description + JSON schema), matching estimateTokens'
+// ~4-chars/token heuristic so all categories use the same scale.
+func estimateToolTokens(tools []zeroruntime.ToolDefinition) int {
+	total := 0
+	for _, tool := range tools {
+		total += len(tool.Name) / 4
+		total += len(tool.Description) / 4
+		if len(tool.Parameters) > 0 {
+			if encoded, err := json.Marshal(tool.Parameters); err == nil {
+				total += len(encoded) / 4
+			}
+		}
+		total += 4 // per-tool overhead
+	}
+	return total
+}

--- a/internal/agent/context_measurement_test.go
+++ b/internal/agent/context_measurement_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestMeasureContextSplitsByCategory(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: filler(2000)},
+		{Role: zeroruntime.MessageRoleUser, Content: filler(400)},
+		{Role: zeroruntime.MessageRoleAssistant, Content: filler(400)},
+	}
+	tools := []zeroruntime.ToolDefinition{
+		{Name: "read_file", Description: filler(200), Parameters: map[string]any{"type": "object"}},
+	}
+
+	breakdown := MeasureContext(messages, tools, 100_000)
+
+	if breakdown.SystemTokens <= 0 || breakdown.MessageTokens <= 0 || breakdown.ToolTokens <= 0 {
+		t.Fatalf("expected all categories non-zero, got %#v", breakdown)
+	}
+	if got := breakdown.SystemTokens + breakdown.ToolTokens + breakdown.MessageTokens; got != breakdown.TotalTokens {
+		t.Fatalf("TotalTokens %d != sum of categories %d", breakdown.TotalTokens, got)
+	}
+	// System content (2000 chars) dominates the conversation (800 chars total).
+	if breakdown.SystemTokens <= breakdown.MessageTokens {
+		t.Fatalf("expected system to dominate messages, got system=%d messages=%d", breakdown.SystemTokens, breakdown.MessageTokens)
+	}
+	wantFraction := float64(breakdown.TotalTokens) / 100_000
+	if breakdown.UsedFraction != wantFraction {
+		t.Fatalf("UsedFraction = %v, want %v", breakdown.UsedFraction, wantFraction)
+	}
+}
+
+func TestMeasureContextUnknownWindowHasZeroFraction(t *testing.T) {
+	breakdown := MeasureContext([]zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: "hi"},
+	}, nil, 0)
+	if breakdown.UsedFraction != 0 {
+		t.Fatalf("UsedFraction = %v, want 0 when context window unknown", breakdown.UsedFraction)
+	}
+	if breakdown.ToolTokens != 0 {
+		t.Fatalf("ToolTokens = %d, want 0 with no tools", breakdown.ToolTokens)
+	}
+}
+
+func TestMeasureContextNoSystemMessage(t *testing.T) {
+	breakdown := MeasureContext([]zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: filler(400)},
+	}, nil, 1000)
+	if breakdown.SystemTokens != 0 {
+		t.Fatalf("SystemTokens = %d, want 0 when there is no system message", breakdown.SystemTokens)
+	}
+	if breakdown.MessageTokens <= 0 {
+		t.Fatalf("MessageTokens = %d, want > 0", breakdown.MessageTokens)
+	}
+}
+
+// filler returns a string of n characters for sizing assertions.
+func filler(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 'x'
+	}
+	return string(b)
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -86,6 +86,12 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			Tools:    toolDefinitions(registry, permissionMode, options),
 		}
 
+		// Report the per-category context budget for this turn so a surface can
+		// show utilization. Opt-in: a no-op when OnContext is unset.
+		if options.OnContext != nil {
+			options.OnContext(MeasureContext(messages, request.Tools, options.ContextWindow))
+		}
+
 		stream, err := provider.StreamCompletion(ctx, request)
 		if err != nil {
 			// REACTIVE compaction: a context-limit failure on the call itself

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -137,6 +137,10 @@ type Options struct {
 	OnAskUser              func(context.Context, AskUserRequest) (AskUserResponse, error)
 	OnToolResult           func(ToolResult)
 	OnUsage                func(Usage)
+	// OnContext, when set, is called once per turn with the per-category context
+	// budget of the request about to be sent, so a surface (TUI/CLI) can show
+	// context utilization. Opt-in like the other callbacks; nil is a no-op.
+	OnContext func(ContextBreakdown)
 }
 
 type Result struct {


### PR DESCRIPTION
## Agent: per-category context token budget

Adds `MeasureContext`, which breaks a request's estimated token footprint into the categories that actually compete for the window — **system prompt**, **tool definitions**, and **conversation messages** — plus the **used fraction** of the model context window.

### What changed
- **`internal/agent/context_measurement.go`** — `ContextBreakdown` + `MeasureContext` (reuses `estimateTokens` for messages; `estimateToolTokens` estimates tool defs on the same ~4-chars/token scale).
- **`Options.OnContext`** — opt-in per-turn callback (mirrors `OnText`/`OnUsage`), emitted with the budget of the request about to be sent so a surface (TUI/CLI) can show utilization like *"62% used: 4k system, 6k tools, 30k history"*. Nil is a no-op.

### Why
The loop already estimates a single total for compaction decisions, but had no per-category view. This is the data foundation for context-utilization UI and smarter compaction (which category to shed). Tested measurement primitive; the TUI surfacing is a small follow-up.

### Testing
per-category split + total, system-dominant proportion, used-fraction math, unknown-window and no-system/no-tools edge cases. build / vet / `go test ./...` / `-race` / Windows all green. No new deps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent operations now track and measure context usage with detailed breakdowns by category: system messages, tool definitions, and conversation content.
  * Optional callback mechanism enables applications to receive per-turn context utilization reports for monitoring and optimization.

* **Tests**
  * Added comprehensive unit tests validating accurate token measurement across various message configurations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->