### PR TITLE
Background: escalate process termination from SIGTERM to SIGKILL

### DIFF
--- a/internal/background/manager.go
+++ b/internal/background/manager.go
@@ -267,10 +267,21 @@ func (manager *Manager) Kill(taskID string) error {
 	if !manager.isRunningPID(taskID, pid) {
 		return nil
 	}
+	// Record the kill intent BEFORE terminating. terminateProcess can block until
+	// the child exits, during which the background Wait-goroutine may reap it and
+	// call MarkExited; marking killed first makes that MarkExited a no-op (it only
+	// acts on a running task), so a user-initiated stop stays "killed" instead of
+	// being clobbered to "error".
+	if err := manager.markKilledIfStillRunning(taskID, pid); err != nil {
+		return err
+	}
 	if err := manager.killProcess(pid); err != nil {
+		// Couldn't terminate — undo the optimistic kill mark so the still-running
+		// task is not falsely reported as killed.
+		manager.restoreRunningAfterFailedKill(taskID, pid)
 		return fmt.Errorf("kill background task %s: %w", taskID, err)
 	}
-	return manager.markKilledIfStillRunning(taskID, pid)
+	return nil
 }
 
 func (manager *Manager) KillRunning() error {
@@ -332,6 +343,26 @@ func (manager *Manager) markKilledIfStillRunning(taskID string, pid int) error {
 	}
 	manager.tasks[taskID] = task
 	return nil
+}
+
+// restoreRunningAfterFailedKill reverts a task that was optimistically marked
+// killed back to running when the terminate failed (the process is presumed
+// still alive). It only touches a task still killed with the same pid, so a real
+// exit recorded meanwhile is left untouched.
+func (manager *Manager) restoreRunningAfterFailedKill(taskID string, pid int) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	task, ok := manager.tasks[taskID]
+	if !ok || task.Status != StatusKilled || task.PID != pid {
+		return
+	}
+	task.Status = StatusRunning
+	task.ExitCode = 0
+	task.CompletedAt = time.Time{}
+	if err := manager.persistTaskLocked(task); err != nil {
+		return
+	}
+	manager.tasks[taskID] = task
 }
 
 func (manager *Manager) loadTasks() error {

--- a/internal/background/manager.go
+++ b/internal/background/manager.go
@@ -272,14 +272,23 @@ func (manager *Manager) Kill(taskID string) error {
 	// call MarkExited; marking killed first makes that MarkExited a no-op (it only
 	// acts on a running task), so a user-initiated stop stays "killed" instead of
 	// being clobbered to "error".
-	if err := manager.markKilledIfStillRunning(taskID, pid); err != nil {
+	marked, err := manager.markKilledIfStillRunning(taskID, pid)
+	if err != nil {
 		return err
+	}
+	if !marked {
+		// The task exited (or was reused) between the running check and now — the
+		// pid may be stale, so do NOT signal it.
+		return nil
 	}
 	if err := manager.killProcess(pid); err != nil {
 		// Couldn't terminate — undo the optimistic kill mark so the still-running
 		// task is not falsely reported as killed.
-		manager.restoreRunningAfterFailedKill(taskID, pid)
-		return fmt.Errorf("kill background task %s: %w", taskID, err)
+		killErr := fmt.Errorf("kill background task %s: %w", taskID, err)
+		if restoreErr := manager.restoreRunningAfterFailedKill(taskID, pid); restoreErr != nil {
+			return errors.Join(killErr, fmt.Errorf("restore running state for %s: %w", taskID, restoreErr))
+		}
+		return killErr
 	}
 	return nil
 }
@@ -320,18 +329,22 @@ func (manager *Manager) isRunningPID(taskID string, pid int) bool {
 	return ok && task.Status == StatusRunning && task.PID == pid
 }
 
-func (manager *Manager) markKilledIfStillRunning(taskID string, pid int) error {
+// markKilledIfStillRunning marks the task killed if it is still running. The
+// bool reports whether it actually marked: false means the task already exited
+// (or was reused), in which case the caller must NOT signal the pid — it may be
+// stale.
+func (manager *Manager) markKilledIfStillRunning(taskID string, pid int) (bool, error) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	task, ok := manager.tasks[taskID]
 	if !ok {
-		return fmt.Errorf("background task not found: %s", taskID)
+		return false, fmt.Errorf("background task not found: %s", taskID)
 	}
 	if task.Status != StatusRunning {
-		return nil
+		return false, nil
 	}
 	if task.PID != pid {
-		return fmt.Errorf("background task %s pid changed before kill completed", taskID)
+		return false, fmt.Errorf("background task %s pid changed before kill completed", taskID)
 	}
 	task.Status = StatusKilled
 	task.ExitCode = -1
@@ -339,30 +352,33 @@ func (manager *Manager) markKilledIfStillRunning(taskID string, pid int) error {
 		task.CompletedAt = manager.now()
 	}
 	if err := manager.persistTaskLocked(task); err != nil {
-		return err
+		return false, err
 	}
 	manager.tasks[taskID] = task
-	return nil
+	return true, nil
 }
 
 // restoreRunningAfterFailedKill reverts a task that was optimistically marked
 // killed back to running when the terminate failed (the process is presumed
 // still alive). It only touches a task still killed with the same pid, so a real
-// exit recorded meanwhile is left untouched.
-func (manager *Manager) restoreRunningAfterFailedKill(taskID string, pid int) {
+// exit recorded meanwhile is left untouched. It returns the persistence error so
+// the caller can surface a failed rollback rather than leaving the task wrongly
+// marked killed.
+func (manager *Manager) restoreRunningAfterFailedKill(taskID string, pid int) error {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	task, ok := manager.tasks[taskID]
 	if !ok || task.Status != StatusKilled || task.PID != pid {
-		return
+		return nil
 	}
 	task.Status = StatusRunning
 	task.ExitCode = 0
 	task.CompletedAt = time.Time{}
 	if err := manager.persistTaskLocked(task); err != nil {
-		return
+		return err
 	}
 	manager.tasks[taskID] = task
+	return nil
 }
 
 func (manager *Manager) loadTasks() error {

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -450,6 +450,30 @@ func TestManagerKillStaysKilledWhenExitWaiterReapsDuringTerminate(t *testing.T) 
 	}
 }
 
+func TestMarkKilledIfStillRunningReportsWhetherItMarked(t *testing.T) {
+	manager, err := NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		Now:     sequenceClock(time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "t", Type: "specialist", PID: 7}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+
+	marked, err := manager.markKilledIfStillRunning("t", 7)
+	if err != nil || !marked {
+		t.Fatalf("first call: marked=%v err=%v, want true/nil", marked, err)
+	}
+	// Already killed (not running) → must report not-marked so Kill skips signaling
+	// a possibly-stale pid.
+	marked, err = manager.markKilledIfStillRunning("t", 7)
+	if err != nil || marked {
+		t.Fatalf("second call: marked=%v err=%v, want false/nil", marked, err)
+	}
+}
+
 func sequenceClock(times ...time.Time) func() time.Time {
 	index := 0
 	return func() time.Time {

--- a/internal/background/manager_test.go
+++ b/internal/background/manager_test.go
@@ -409,6 +409,47 @@ func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
 	}
 }
 
+// TestManagerKillStaysKilledWhenExitWaiterReapsDuringTerminate reproduces the
+// lifecycle race created by a blocking terminateProcess: while Kill waits for the
+// child to exit, the background Wait-goroutine reaps it and calls MarkExited. The
+// task must stay "killed" (the user's intent), not be clobbered to "error".
+func TestManagerKillStaysKilledWhenExitWaiterReapsDuringTerminate(t *testing.T) {
+	now := sequenceClock(
+		time.Date(2026, 6, 8, 9, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 8, 9, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 8, 9, 0, 2, 0, time.UTC),
+	)
+	var manager *Manager
+	var err error
+	manager, err = NewManagerWithOptions(ManagerOptions{
+		RootDir: t.TempDir(),
+		Now:     now,
+		KillProcess: func(int) error {
+			// terminateProcess blocks until exit; simulate the Wait-goroutine
+			// reaping the child and marking it exited mid-kill.
+			_ = manager.MarkExited("task_1", StatusError, -1)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManagerWithOptions returned error: %v", err)
+	}
+	if _, err := manager.Register(RegisterInput{TaskID: "task_1", Type: "specialist", SpecialistName: "worker", ParentID: "p", PID: 4242}); err != nil {
+		t.Fatalf("Register returned error: %v", err)
+	}
+
+	if err := manager.Kill("task_1"); err != nil {
+		t.Fatalf("Kill returned error: %v", err)
+	}
+	task, ok := manager.Get("task_1")
+	if !ok {
+		t.Fatal("task_1 not found after Kill")
+	}
+	if task.Status != StatusKilled {
+		t.Fatalf("status = %q, want %q — the exit waiter must not clobber a user-initiated kill", task.Status, StatusKilled)
+	}
+}
+
 func sequenceClock(times ...time.Time) func() time.Time {
 	index := 0
 	return func() time.Time {

--- a/internal/background/process_posix.go
+++ b/internal/background/process_posix.go
@@ -3,14 +3,65 @@
 package background
 
 import (
+	"errors"
 	"os"
 	"syscall"
+	"time"
 )
 
+// terminationGracePeriod is how long a process has to exit after SIGTERM before
+// it is force-killed with SIGKILL. Vars (not consts) so tests can shorten them.
+var (
+	terminationGracePeriod  = 3 * time.Second
+	terminationPollInterval = 50 * time.Millisecond
+)
+
+// terminateProcess stops a background process. It first asks politely with
+// SIGTERM (so the process can flush/clean up), then escalates to SIGKILL if the
+// process is still alive after terminationGracePeriod — so a process that traps
+// or ignores SIGTERM cannot leak. It returns nil once the process is gone.
 func terminateProcess(pid int) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return err
 	}
-	return process.Signal(syscall.SIGTERM)
+
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		if processGoneError(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Poll liveness so we return promptly once the process exits, rather than
+	// always waiting out the full grace period.
+	deadline := time.Now().Add(terminationGracePeriod)
+	for time.Now().Before(deadline) {
+		if !processAlive(process) {
+			return nil
+		}
+		time.Sleep(terminationPollInterval)
+	}
+	if !processAlive(process) {
+		return nil
+	}
+
+	// Still alive after the grace period: force-kill.
+	if err := process.Kill(); err != nil && !processGoneError(err) {
+		return err
+	}
+	return nil
+}
+
+// processAlive reports whether the process can still be signalled (signal 0 is
+// the standard liveness probe — it performs error checking without sending a
+// signal).
+func processAlive(process *os.Process) bool {
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
+// processGoneError reports whether an error means the process has already exited
+// (so termination is effectively done).
+func processGoneError(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
 }

--- a/internal/background/process_posix_test.go
+++ b/internal/background/process_posix_test.go
@@ -4,21 +4,29 @@ package background
 
 import (
 	"bufio"
+	"errors"
 	"os/exec"
+	"syscall"
 	"testing"
 	"time"
 )
 
-// withShortGrace shrinks the termination timings for fast tests and restores them.
-func withShortGrace(t *testing.T) {
-	t.Helper()
-	grace, poll := terminationGracePeriod, terminationPollInterval
-	terminationGracePeriod, terminationPollInterval = 300*time.Millisecond, 20*time.Millisecond
-	t.Cleanup(func() { terminationGracePeriod, terminationPollInterval = grace, poll })
+// terminatingSignal returns the signal that killed a process from its cmd.Wait()
+// error, or 0 if it exited normally / for another reason.
+func terminatingSignal(err error) syscall.Signal {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			return status.Signal()
+		}
+	}
+	return 0
 }
 
 func TestTerminateProcessEscalatesToSIGKILL(t *testing.T) {
-	withShortGrace(t)
+	grace, poll := terminationGracePeriod, terminationPollInterval
+	terminationGracePeriod, terminationPollInterval = 300*time.Millisecond, 20*time.Millisecond
+	t.Cleanup(func() { terminationGracePeriod, terminationPollInterval = grace, poll })
 
 	// A process that traps and ignores SIGTERM — only SIGKILL can stop it. The
 	// while-loop keeps the trap-holding shell as the process (a trailing single
@@ -35,8 +43,8 @@ func TestTerminateProcessEscalatesToSIGKILL(t *testing.T) {
 	if _, err := bufio.NewReader(stdout).ReadString('\n'); err != nil {
 		t.Fatalf("waiting for trap to install: %v", err)
 	}
-	done := make(chan struct{})
-	go func() { _ = cmd.Wait(); close(done) }()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
 
 	start := time.Now()
 	if err := terminateProcess(cmd.Process.Pid); err != nil {
@@ -44,7 +52,10 @@ func TestTerminateProcessEscalatesToSIGKILL(t *testing.T) {
 	}
 
 	select {
-	case <-done:
+	case waitErr := <-done:
+		if sig := terminatingSignal(waitErr); sig != syscall.SIGKILL {
+			t.Fatalf("process terminated by %v, want SIGKILL (it ignores SIGTERM)", sig)
+		}
 	case <-time.After(2 * time.Second):
 		_ = cmd.Process.Kill()
 		t.Fatal("process not killed — SIGKILL escalation failed")
@@ -65,15 +76,20 @@ func TestTerminateProcessGracefulSIGTERM(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	done := make(chan struct{})
-	go func() { _ = cmd.Wait(); close(done) }()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
 
 	start := time.Now()
 	if err := terminateProcess(cmd.Process.Pid); err != nil {
 		t.Fatalf("terminateProcess: %v", err)
 	}
 	select {
-	case <-done:
+	case waitErr := <-done:
+		// Must die from SIGTERM, not SIGKILL — proves we ask politely first and
+		// don't regress to an immediate force-kill.
+		if sig := terminatingSignal(waitErr); sig != syscall.SIGTERM {
+			t.Fatalf("process terminated by %v, want SIGTERM", sig)
+		}
 	case <-time.After(3 * time.Second):
 		_ = cmd.Process.Kill()
 		t.Fatal("process not killed on SIGTERM")

--- a/internal/background/process_posix_test.go
+++ b/internal/background/process_posix_test.go
@@ -1,0 +1,96 @@
+//go:build !windows
+
+package background
+
+import (
+	"bufio"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// withShortGrace shrinks the termination timings for fast tests and restores them.
+func withShortGrace(t *testing.T) {
+	t.Helper()
+	grace, poll := terminationGracePeriod, terminationPollInterval
+	terminationGracePeriod, terminationPollInterval = 300*time.Millisecond, 20*time.Millisecond
+	t.Cleanup(func() { terminationGracePeriod, terminationPollInterval = grace, poll })
+}
+
+func TestTerminateProcessEscalatesToSIGKILL(t *testing.T) {
+	withShortGrace(t)
+
+	// A process that traps and ignores SIGTERM — only SIGKILL can stop it. The
+	// while-loop keeps the trap-holding shell as the process (a trailing single
+	// command would be exec-optimized, dropping the trap); "ready" is printed
+	// AFTER the trap is installed so we don't signal before it takes effect.
+	cmd := exec.Command("sh", "-c", "trap '' TERM; echo ready; while true; do sleep 0.2; done")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if _, err := bufio.NewReader(stdout).ReadString('\n'); err != nil {
+		t.Fatalf("waiting for trap to install: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+
+	start := time.Now()
+	if err := terminateProcess(cmd.Process.Pid); err != nil {
+		t.Fatalf("terminateProcess: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("process not killed — SIGKILL escalation failed")
+	}
+	if elapsed := time.Since(start); elapsed < terminationGracePeriod {
+		t.Fatalf("process died in %v, before the grace period — SIGTERM should be tried first", elapsed)
+	}
+}
+
+func TestTerminateProcessGracefulSIGTERM(t *testing.T) {
+	// Longer grace so we can prove a well-behaved process dies on SIGTERM,
+	// well before any SIGKILL escalation would fire.
+	grace, poll := terminationGracePeriod, terminationPollInterval
+	terminationGracePeriod, terminationPollInterval = 5*time.Second, 20*time.Millisecond
+	t.Cleanup(func() { terminationGracePeriod, terminationPollInterval = grace, poll })
+
+	cmd := exec.Command("sh", "-c", "sleep 30") // default disposition: SIGTERM kills it
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+
+	start := time.Now()
+	if err := terminateProcess(cmd.Process.Pid); err != nil {
+		t.Fatalf("terminateProcess: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("process not killed on SIGTERM")
+	}
+	if elapsed := time.Since(start); elapsed >= terminationGracePeriod {
+		t.Fatalf("took %v — should have died on SIGTERM, not waited for SIGKILL", elapsed)
+	}
+}
+
+func TestTerminateProcessAlreadyExited(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	_ = cmd.Wait() // reap; the pid is now gone
+
+	if err := terminateProcess(cmd.Process.Pid); err != nil {
+		t.Fatalf("terminateProcess on an exited process should be a no-op, got %v", err)
+	}
+}


### PR DESCRIPTION
## Background: escalate process termination from SIGTERM to SIGKILL

`terminateProcess` (POSIX) sent **only SIGTERM**, so a background process that traps or ignores it kept running after `Kill`/`KillRunning` — a process **leak** (notably on a Ctrl+C shutdown that kills running tasks).

### What changed
- **`internal/background/process_posix.go`** — SIGTERM (so the process can flush/clean up) → poll liveness with signal 0 until a **3s grace** deadline → **SIGKILL** if still alive. An already-exited process (ESRCH / `ErrProcessDone`) is treated as success. Grace/poll are package vars so tests run fast.
- **Windows is unchanged** — it already force-kills via `taskkill /T /F`.

### Why
A force-kill that can't actually force-kill isn't one. This guarantees a killed task is gone.

### Testing
- A SIGTERM-ignoring process (`trap '' TERM` + a readiness handshake so we don't signal before the trap installs) is killed **only after** the grace period — proving SIGTERM is tried first, then escalated.
- A well-behaved process dies on SIGTERM **well before** escalation.
- An already-exited pid is a no-op.

`-race` + full suite + `GOOS=windows` build green. No new deps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix-like process termination: send graceful termination, poll during a configurable grace period, then escalate to forceful termination; treat already-exited processes as successful no-ops.
  * Ensure tasks marked as killed remain consistently recorded; on failed kills, restore running state to avoid inconsistent status.

* **Tests**
  * Added POSIX-only tests for escalation to forceful termination, graceful shutdown within the grace period, already-exited handling, and task-kill race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->