### PR TITLE
Model harness: per-model system prompts + summarizer fallback

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -344,7 +344,20 @@ func summarizeWithFallback(ctx context.Context, provider Provider, messages []ze
 	if rightErr != nil {
 		return "", rightErr
 	}
-	return strings.TrimSpace(left + "\n\n" + right), nil
+
+	// Re-summarize the two partial summaries into ONE so the persisted summary
+	// stays a single, further-summarizable unit — not an ever-growing concatenated
+	// blob that a later compaction (which can't split a single message) would fail
+	// on. If even the combined partials don't fit (extreme), fall back to the
+	// joined text: still better than failing, and each half is already compacted.
+	combined := strings.TrimSpace(left + "\n\n" + right)
+	reduced, reduceErr := summarizeMessagesOnce(ctx, provider, []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: combined},
+	})
+	if reduceErr != nil {
+		return combined, nil
+	}
+	return reduced, nil
 }
 
 // summarizeMessagesOnce performs a single tool-less summarization call.

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -315,27 +315,60 @@ func (state *compactionState) recover(
 // OnUsage callbacks, so compaction stays invisible on the user-facing surface.
 func summarizeClosure(ctx context.Context, provider Provider) func([]zeroruntime.Message) (string, error) {
 	return func(toSummarize []zeroruntime.Message) (string, error) {
-		request := zeroruntime.CompletionRequest{
-			Messages: []zeroruntime.Message{
-				{Role: zeroruntime.MessageRoleSystem, Content: summaryInstructions},
-				{Role: zeroruntime.MessageRoleUser, Content: "Summarize this conversation:\n\n" + renderTranscript(toSummarize)},
-			},
-			// No tools: this is a plain text summarization call.
-		}
-		stream, err := provider.StreamCompletion(ctx, request)
-		if err != nil {
-			return "", err
-		}
-		collected := zeroruntime.CollectStream(ctx, stream)
-		if collected.Error != "" {
-			return "", errors.New(collected.Error)
-		}
-		summary := strings.TrimSpace(collected.Text)
-		if summary == "" {
-			return "", errors.New("summarizer returned no text")
-		}
+		return summarizeWithFallback(ctx, provider, toSummarize)
+	}
+}
+
+// summarizeWithFallback summarizes messages in a single provider call. If that
+// call fails with a context-limit error — the slice to summarize is itself too
+// large for the model's input window — it splits the slice in half, summarizes
+// each half recursively, and joins the partial summaries. This keeps compaction
+// working when the elided middle is bigger than the summarizer's own context.
+// Non-context-limit errors (and a single message that still won't fit) surface
+// to the caller unchanged.
+func summarizeWithFallback(ctx context.Context, provider Provider, messages []zeroruntime.Message) (string, error) {
+	summary, err := summarizeMessagesOnce(ctx, provider, messages)
+	if err == nil {
 		return summary, nil
 	}
+	if len(messages) < 2 || !isContextLimitError(err.Error()) {
+		return "", err
+	}
+
+	mid := len(messages) / 2
+	left, leftErr := summarizeWithFallback(ctx, provider, messages[:mid])
+	if leftErr != nil {
+		return "", leftErr
+	}
+	right, rightErr := summarizeWithFallback(ctx, provider, messages[mid:])
+	if rightErr != nil {
+		return "", rightErr
+	}
+	return strings.TrimSpace(left + "\n\n" + right), nil
+}
+
+// summarizeMessagesOnce performs a single tool-less summarization call.
+func summarizeMessagesOnce(ctx context.Context, provider Provider, messages []zeroruntime.Message) (string, error) {
+	request := zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: summaryInstructions},
+			{Role: zeroruntime.MessageRoleUser, Content: "Summarize this conversation:\n\n" + renderTranscript(messages)},
+		},
+		// No tools: this is a plain text summarization call.
+	}
+	stream, err := provider.StreamCompletion(ctx, request)
+	if err != nil {
+		return "", err
+	}
+	collected := zeroruntime.CollectStream(ctx, stream)
+	if collected.Error != "" {
+		return "", errors.New(collected.Error)
+	}
+	summary := strings.TrimSpace(collected.Text)
+	if summary == "" {
+		return "", errors.New("summarizer returned no text")
+	}
+	return summary, nil
 }
 
 // renderTranscript flattens messages into a plain-text transcript for the

--- a/internal/agent/compaction_summarizer_test.go
+++ b/internal/agent/compaction_summarizer_test.go
@@ -51,6 +51,50 @@ func (p *errorSummarizer) StreamCompletion(_ context.Context, _ zeroruntime.Comp
 	return ch, nil
 }
 
+// compressingSummarizer fails on more than maxMarkers messages but returns a
+// SHORT marker-free summary, so two partial summaries combine into something that
+// fits — modelling real summarization that shrinks its input.
+type compressingSummarizer struct {
+	maxMarkers int
+	calls      int32
+}
+
+func (p *compressingSummarizer) StreamCompletion(_ context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	atomic.AddInt32(&p.calls, 1)
+	text := request.Messages[len(request.Messages)-1].Content
+	ch := make(chan zeroruntime.StreamEvent, 2)
+	if len(markerPattern.FindAllString(text, -1)) > p.maxMarkers {
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: "context length exceeded"}
+		close(ch)
+		return ch, nil
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "S"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func TestSummarizeWithFallbackReSummarizesPartialsIntoOne(t *testing.T) {
+	messages := make([]zeroruntime.Message, 4)
+	for i := range messages {
+		messages[i] = zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: fmt.Sprintf("msg-%d body", i)}
+	}
+	provider := &compressingSummarizer{maxMarkers: 2}
+
+	summary, err := summarizeWithFallback(context.Background(), provider, messages)
+	if err != nil {
+		t.Fatalf("summarizeWithFallback failed: %v", err)
+	}
+	// The two chunk summaries ("S" / "S") are re-summarized into ONE unit, not
+	// returned as the joined "S\n\nS" blob — so a later compaction can shrink it.
+	if strings.Contains(summary, "\n\n") {
+		t.Fatalf("expected a single re-summarized result, got a joined blob: %q", summary)
+	}
+	if summary != "S" {
+		t.Fatalf("summary = %q, want the reduced %q", summary, "S")
+	}
+}
+
 func TestSummarizeWithFallbackChunksOnContextLimit(t *testing.T) {
 	const n = 8
 	messages := make([]zeroruntime.Message, n)

--- a/internal/agent/compaction_summarizer_test.go
+++ b/internal/agent/compaction_summarizer_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+var markerPattern = regexp.MustCompile(`msg-\d+`)
+
+// sizeLimitedSummarizer returns a context-limit error when the rendered
+// transcript carries more than maxMarkers messages, and otherwise "summarizes"
+// by echoing the message markers it saw — so a successful summary records exactly
+// which messages it covered.
+type sizeLimitedSummarizer struct {
+	maxMarkers int
+	calls      int32
+}
+
+func (p *sizeLimitedSummarizer) StreamCompletion(_ context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	atomic.AddInt32(&p.calls, 1)
+	text := request.Messages[len(request.Messages)-1].Content
+	markers := markerPattern.FindAllString(text, -1)
+	ch := make(chan zeroruntime.StreamEvent, 2)
+	if len(markers) > p.maxMarkers {
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: "context length exceeded"}
+		close(ch)
+		return ch, nil
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: strings.Join(markers, " ")}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+type errorSummarizer struct {
+	message string
+	calls   int32
+}
+
+func (p *errorSummarizer) StreamCompletion(_ context.Context, _ zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	atomic.AddInt32(&p.calls, 1)
+	ch := make(chan zeroruntime.StreamEvent, 1)
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: p.message}
+	close(ch)
+	return ch, nil
+}
+
+func TestSummarizeWithFallbackChunksOnContextLimit(t *testing.T) {
+	const n = 8
+	messages := make([]zeroruntime.Message, n)
+	for i := range messages {
+		messages[i] = zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: fmt.Sprintf("msg-%d some content", i)}
+	}
+	// The summarizer can only handle 2 messages per call, so the 8-message slice
+	// must be split recursively until each chunk fits.
+	provider := &sizeLimitedSummarizer{maxMarkers: 2}
+
+	summary, err := summarizeWithFallback(context.Background(), provider, messages)
+	if err != nil {
+		t.Fatalf("summarizeWithFallback failed: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		if !strings.Contains(summary, fmt.Sprintf("msg-%d", i)) {
+			t.Fatalf("combined summary missing msg-%d: %q", i, summary)
+		}
+	}
+	if got := atomic.LoadInt32(&provider.calls); got < 2 {
+		t.Fatalf("expected multiple calls from splitting, got %d", got)
+	}
+}
+
+func TestSummarizeWithFallbackPropagatesNonContextErrors(t *testing.T) {
+	provider := &errorSummarizer{message: "auth error: invalid key"}
+	_, err := summarizeWithFallback(context.Background(), provider, []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: "msg-0"},
+		{Role: zeroruntime.MessageRoleUser, Content: "msg-1"},
+	})
+	if err == nil {
+		t.Fatal("expected a non-context-limit error to propagate")
+	}
+	if got := atomic.LoadInt32(&provider.calls); got != 1 {
+		t.Fatalf("a non-context error must not trigger splitting/retry, calls=%d", got)
+	}
+}
+
+func TestSummarizeWithFallbackSingleMessageContextLimitSurfaces(t *testing.T) {
+	// A single message that still won't fit can't be split further → error surfaces.
+	provider := &sizeLimitedSummarizer{maxMarkers: 0}
+	_, err := summarizeWithFallback(context.Background(), provider, []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: "msg-0 too big"},
+	})
+	if err == nil {
+		t.Fatal("expected the context-limit error to surface for an unsplittable single message")
+	}
+}

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -44,6 +44,9 @@ func buildSystemPrompt(options Options) string {
 		core = fallbackSystemPrompt
 	}
 	sections := []string{core}
+	if addendum := modelPromptAddendum(options.Model); addendum != "" {
+		sections = append(sections, addendum)
+	}
 	if ws := workspaceContext(options.Cwd); ws != "" {
 		sections = append(sections, ws)
 	}

--- a/internal/agent/system_prompt_models.go
+++ b/internal/agent/system_prompt_models.go
@@ -1,0 +1,77 @@
+package agent
+
+import "strings"
+
+// Per-model prompt specialization.
+//
+// Different model families respond to different framing: the GPT family benefits
+// from an explicit markdown/output spec and a strong "prefer native tools" nudge;
+// Gemini benefits from explicit tool-preference and conciseness guidance; the
+// Claude family is already well-aligned with the core prompt and only needs a
+// light comment-discipline nudge. modelPromptAddendum returns the family-specific
+// block appended after the core prompt. Classification is by model id (the agent
+// only has the model string — no registry dependency).
+
+const (
+	familyOpenAI    = "openai"
+	familyGemini    = "gemini"
+	familyAnthropic = "anthropic"
+)
+
+// modelFamily classifies a model id into a prompt-tuning family, or "" when
+// unknown (in which case no addendum is added).
+func modelFamily(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	switch {
+	case m == "":
+		return ""
+	case strings.HasPrefix(m, "gpt"), strings.HasPrefix(m, "o1"), strings.HasPrefix(m, "o3"),
+		strings.HasPrefix(m, "o4"), strings.Contains(m, "openai"):
+		return familyOpenAI
+	case strings.HasPrefix(m, "gemini"), strings.Contains(m, "google"):
+		return familyGemini
+	case strings.HasPrefix(m, "claude"), strings.Contains(m, "anthropic"):
+		return familyAnthropic
+	default:
+		return ""
+	}
+}
+
+// modelPromptAddendum returns the family-specific prompt block for a model id,
+// or "" when the family is unknown.
+func modelPromptAddendum(model string) string {
+	switch modelFamily(model) {
+	case familyOpenAI:
+		return openAIPromptAddendum
+	case familyGemini:
+		return geminiPromptAddendum
+	case familyAnthropic:
+		return anthropicPromptAddendum
+	default:
+		return ""
+	}
+}
+
+const openAIPromptAddendum = `<model_guidance>
+- Output your final responses in GitHub-flavored Markdown: headings to structure
+  longer answers, fenced code blocks for code, and ` + "`inline code`" + ` for paths,
+  commands, and symbols.
+- Strongly prefer the native file tools (read_file, list_directory, grep, glob,
+  write_file, edit_file, apply_patch) over shelling out to cat/sed/awk/python for
+  file work. Make one tool call per file; do not batch file writes into a script.
+- Persist until the task is fully handled this turn: gather context, implement,
+  run the validators, and report — do not stop at a partial result.
+</model_guidance>`
+
+const geminiPromptAddendum = `<model_guidance>
+- Prefer the dedicated tools (read_file, grep, glob, edit_file, apply_patch) over
+  equivalent shell commands; they are safer and produce cleaner diffs.
+- Be concise and concrete. When you run a shell command with side effects, state
+  in one short clause why it is needed.
+- Use update_plan for any multi-step task and keep it current.
+</model_guidance>`
+
+const anthropicPromptAddendum = `<model_guidance>
+- Do not add code comments unless the user asks or the surrounding code is
+  comment-dense; match the file's existing comment density.
+</model_guidance>`

--- a/internal/agent/system_prompt_models_test.go
+++ b/internal/agent/system_prompt_models_test.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestModelFamilyClassification(t *testing.T) {
+	cases := map[string]string{
+		"gpt-5":                  familyOpenAI,
+		"gpt-4o":                 familyOpenAI,
+		"o3-mini":                familyOpenAI,
+		"gemini-2.5-pro":         familyGemini,
+		"claude-opus-4-6":        familyAnthropic,
+		"anthropic/claude-haiku": familyAnthropic,
+		"some-unknown-model":     "",
+		"":                       "",
+	}
+	for model, want := range cases {
+		if got := modelFamily(model); got != want {
+			t.Errorf("modelFamily(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+func TestBuildSystemPromptAppendsModelAddendum(t *testing.T) {
+	// Assert on the addendum constants themselves (the core prompt shares phrases
+	// like "one tool call per file", so substring checks can't distinguish them).
+	if got := buildSystemPrompt(Options{Model: "gpt-5"}); !strings.Contains(got, openAIPromptAddendum) {
+		t.Fatalf("expected the OpenAI addendum in the gpt-5 prompt")
+	}
+	claude := buildSystemPrompt(Options{Model: "claude-opus-4-6"})
+	if !strings.Contains(claude, anthropicPromptAddendum) {
+		t.Fatalf("expected the Anthropic addendum in the claude prompt")
+	}
+	if strings.Contains(claude, openAIPromptAddendum) {
+		t.Fatalf("the claude prompt must not contain the OpenAI addendum")
+	}
+	// Unknown / unset model gets no family block.
+	if got := modelPromptAddendum(""); got != "" {
+		t.Fatalf("expected no addendum without a model, got %q", got)
+	}
+	if strings.Contains(buildSystemPrompt(Options{}), "<model_guidance>") {
+		t.Fatalf("expected no <model_guidance> block without a model")
+	}
+}


### PR DESCRIPTION
## Model harness: per-model system prompts + summarizer fallback

Two agent-quality improvements that compound with the rich system prompt (#129) and prompt caching (#130) already on main.

### 1. Per-model system-prompt specialization
`internal/agent/system_prompt_models.go` — `buildSystemPrompt` now appends a family-specific guidance block chosen by model id:
- **OpenAI family** (gpt/o1/o3/o4): markdown output spec + "prefer native file tools over shell, one call per file" + persistence.
- **Gemini**: tool-preference + conciseness + use `update_plan`.
- **Anthropic/Claude**: comment discipline (match existing density).

Classification is by model string (`modelFamily`) — no registry dependency. Unknown/unset model → no block.

### 2. Chunked summarization fallback
`internal/agent/compaction.go` — if the elided middle is itself **too large to summarize in one call** (a summary-time context-limit error), `summarizeWithFallback` splits it in half recursively and joins the partial summaries, so compaction keeps working past the summarizer's own input window. Non-context errors and an unsplittable single message surface unchanged. Adapted to our single-provider agent (the "multi-model fallback" idea, made to fit).

### Testing
`modelFamily` classification + addendum selection; chunked-fallback split-and-join, non-context propagation, single-message edge. build / vet / `go test ./...` / `-race` / Windows all green. No new deps.

First of three thematic PRs from the local feature set (next: hardening = graceful shutdown + crash capture; tool quality = denial categorization + secret scanning).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved summarization fallback: long conversations are automatically chunked, partial summaries are recombined and re-summarized to avoid context-limit failures.
  * Enhanced model-specific system prompt guidance so prompts include appropriate family-specific addenda.

* **Tests**
  * Added tests covering the fallback summarization behavior and model-family prompt selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->