### PR TITLE
Real-world hardening: graceful shutdown + crash capture

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/observability"
 	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
@@ -129,7 +130,10 @@ func userAgent() string {
 	return "zero/" + version
 }
 
-func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) (exitCode int) {
+	// Convert an unexpected panic anywhere in the CLI into a saved crash report and
+	// a brief notice, rather than a raw stack trace dumped at the user.
+	defer observability.Recover(observability.DefaultCrashDir(), "cli", stderr, &exitCode)
 	deps = fillAppDeps(deps)
 
 	if len(args) == 0 {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,6 +26,9 @@ const (
 	exitCrash    = 1
 	exitUsage    = 2
 	exitProvider = 3
+	// exitInterrupted is the conventional shell exit code for a process stopped by
+	// SIGINT (128 + signal number 2).
+	exitInterrupted = 130
 )
 
 type execOutputFormat string
@@ -279,7 +283,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// user, so ask_user degrades to a "proceed with your best assumption" result
 	// rather than blocking. (Future enhancement: collect answers over stream-json
 	// input when a controlling client is attached.)
-	result, err := agent.Run(context.Background(), agentPrompt, provider, agent.Options{
+	// Cancel the agent run on Ctrl+C / SIGTERM so a long headless run shuts down
+	// cleanly (the loop honors context cancellation) instead of being killed.
+	runCtx, stopSignals := signalContext()
+	defer stopSignals()
+	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
 		ContextWindow:    modelContextWindow(modelRegistry, resolved.Provider.Model),
 		SessionID:        preparedSession.Session.SessionID,
@@ -346,6 +354,20 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return exitCrash
 	}
 	if err != nil {
+		// A Ctrl+C / SIGTERM cancellation is a clean shutdown, not a provider error.
+		if errors.Is(err, context.Canceled) || runCtx.Err() != nil {
+			sessionRecorder.append(sessions.EventError, map[string]any{"message": "interrupted"})
+			if options.outputFormat == execOutputStreamJSON {
+				writer.errorEvent("interrupted", "run cancelled by signal", false)
+				writer.runEnd("interrupted", exitInterrupted)
+				if writer.err != nil {
+					return exitCrash
+				}
+			} else {
+				fmt.Fprintln(stderr, "Interrupted.")
+			}
+			return exitInterrupted
+		}
 		sessionRecorder.append(sessions.EventError, map[string]any{"message": err.Error()})
 		if options.outputFormat == execOutputStreamJSON {
 			writer.errorEvent("provider_error", err.Error(), false)

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// signalContext returns a context that is cancelled when the process receives an
+// interrupt (Ctrl+C / SIGINT) or SIGTERM, plus a stop function that releases the
+// signal handler (call it when the operation completes). The agent loop honors
+// context cancellation, so wrapping a long run in this context turns a Ctrl+C
+// into a clean shutdown — the in-flight provider call is cancelled and the run
+// returns context.Canceled — instead of an abrupt process kill that leaks the
+// HTTP request and any spawned children.
+func signalContext() (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+}

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignalContextNotCancelledInitially(t *testing.T) {
+	ctx, stop := signalContext()
+	defer stop()
+	if ctx.Err() != nil {
+		t.Fatalf("signalContext should not be cancelled before a signal, got %v", ctx.Err())
+	}
+}
+
+func TestSignalContextStopCancels(t *testing.T) {
+	ctx, stop := signalContext()
+	stop()
+	select {
+	case <-ctx.Done():
+		// stop() releases the handler and cancels the context — expected.
+	case <-time.After(time.Second):
+		t.Fatal("stop() should cancel the signal context")
+	}
+}

--- a/internal/observability/crash.go
+++ b/internal/observability/crash.go
@@ -1,0 +1,63 @@
+// Package observability provides dependency-free crash capture for the CLI: a
+// recovered panic is written to a local crash report (timestamp, label, stack)
+// and surfaced to the user as a brief notice instead of a raw stack trace. It is
+// the fail-open foundation for remote crash/metrics reporting — a Sentry/OTEL
+// adapter can hook the same Recover/report path when configured — without
+// pulling those dependencies into the base build.
+package observability
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"time"
+)
+
+// crashExitCode is returned when a top-level panic is recovered.
+const crashExitCode = 1
+
+// FormatCrashReport renders a human-readable crash report.
+func FormatCrashReport(label string, recovered any, stack []byte, ts time.Time) string {
+	return fmt.Sprintf("zero crash report\ntime:  %s\nlabel: %s\npanic: %v\n\nstack:\n%s\n",
+		ts.UTC().Format(time.RFC3339), label, recovered, stack)
+}
+
+// WriteCrashReport writes a crash report file into dir and returns its path.
+func WriteCrashReport(dir, label string, recovered any, stack []byte, ts time.Time) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, "crash-"+ts.UTC().Format("20060102-150405")+".log")
+	if err := os.WriteFile(path, []byte(FormatCrashReport(label, recovered, stack, ts)), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// DefaultCrashDir is where crash reports are written by default.
+func DefaultCrashDir() string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".zero", "crashes")
+	}
+	return filepath.Join(os.TempDir(), "zero-crashes")
+}
+
+// Recover is deferred at a top-level entrypoint. On a panic it captures the
+// stack, writes a crash report under dir, prints a brief notice to stderr, and
+// sets *code to a crash exit code. It is fail-open: if the report can't be
+// written it still reports the crash with the stack inline. No panic escapes.
+func Recover(dir, label string, stderr io.Writer, code *int) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+	stack := debug.Stack()
+	if path, err := WriteCrashReport(dir, label, recovered, stack, time.Now()); err == nil {
+		fmt.Fprintf(stderr, "zero crashed: %v\nA crash report was saved to %s\n", recovered, path)
+	} else {
+		fmt.Fprintf(stderr, "zero crashed: %v\n%s\n", recovered, stack)
+	}
+	*code = crashExitCode
+}

--- a/internal/observability/crash_test.go
+++ b/internal/observability/crash_test.go
@@ -1,0 +1,65 @@
+package observability
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteAndFormatCrashReport(t *testing.T) {
+	dir := t.TempDir()
+	ts := time.Date(2026, 6, 8, 10, 30, 0, 0, time.UTC)
+	path, err := WriteCrashReport(dir, "cli", "boom", []byte("goroutine 1 [running]:\nmain.x()"), ts)
+	if err != nil {
+		t.Fatalf("WriteCrashReport: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	report := string(data)
+	for _, want := range []string{"boom", "cli", "2026-06-08T10:30:00Z", "goroutine 1"} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q:\n%s", want, report)
+		}
+	}
+}
+
+func TestRecoverCapturesPanic(t *testing.T) {
+	dir := t.TempDir()
+	var stderr bytes.Buffer
+	code := 0
+
+	func() {
+		defer Recover(dir, "test", &stderr, &code)
+		panic("kaboom")
+	}()
+
+	if code != crashExitCode {
+		t.Fatalf("exit code = %d, want %d", code, crashExitCode)
+	}
+	if !strings.Contains(stderr.String(), "zero crashed") || !strings.Contains(stderr.String(), "kaboom") {
+		t.Fatalf("missing crash notice: %q", stderr.String())
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Fatalf("expected one crash report written, got %d", len(entries))
+	}
+}
+
+func TestRecoverNoPanicIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	var stderr bytes.Buffer
+	code := 7
+	func() {
+		defer Recover(dir, "test", &stderr, &code)
+	}()
+	if code != 7 {
+		t.Fatalf("code changed without a panic: %d", code)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected output without a panic: %q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Real-world hardening: graceful shutdown + crash capture

Two fail-open robustness improvements for headless runs and the CLI entrypoint.

### 1. Graceful shutdown of `zero exec` (Ctrl+C)
`internal/cli/shutdown.go` — `zero exec` wrapped `agent.Run` in `context.Background()`, so Ctrl+C / SIGTERM killed the process abruptly, leaking the in-flight provider request and any spawned children. `runExec` now wraps the run in a signal-aware context (`signalContext`): a signal cancels the run, the loop returns cleanly, and exec reports `Interrupted.` with exit **130** (stream-json: an `interrupted` run-end). Scoped to `runExec` — no dispatch-wide signature churn.

> ⚠️ The signal *runtime* delivery can't be exercised in a unit test — please do one manual `zero exec "<long task>"` + Ctrl+C to confirm the path. The helper + no-regression of the exec suite are unit-tested.

### 2. Crash capture (panic → saved report)
`internal/observability/crash.go` — a recovered top-level panic is written to a local crash report (timestamp, label, full stack) under `~/.zero/crashes` and surfaced as a brief notice, instead of a raw stack trace. Wired into `runWithDeps` via a named-return defer. Dependency-free and fail-open; this is the hook a Sentry/OTEL adapter can attach to later for remote reporting (deferred — needs a real endpoint to verify).

### Testing
`signalContext` (not-cancelled-initially, stop-cancels); crash report formatting/writing, panic capture sets the crash exit code + writes one report, no-panic is a no-op. build / vet / `go test ./...` / `-race` / Windows green. No new deps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crash reporting: Unexpected application crashes are now automatically captured and saved as timestamped crash reports containing stack traces and metadata, instead of displaying raw error output to the user.
  * Signal handling: Pressing Ctrl+C or sending termination signals now triggers graceful shutdown with appropriate exit codes, replacing the previous behavior of exiting with provider error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->