### PR TITLE
Tool quality: per-tool denial categorization + secret scanning

### DIFF
--- a/internal/agent/denial_test.go
+++ b/internal/agent/denial_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestExecuteToolCallCategorizesFilteredDenial(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool(root))
+
+	result, _ := executeToolCall(context.Background(), registry, ToolCall{ID: "c1", Name: "read_file", Arguments: `{"path":"x"}`}, PermissionModeAuto, Options{
+		DisabledTools: []string{"read_file"},
+	})
+	if result.DenialReason != DenialFiltered {
+		t.Fatalf("DenialReason = %q, want %q", result.DenialReason, DenialFiltered)
+	}
+	if result.Status != tools.StatusError {
+		t.Fatalf("status = %q, want error", result.Status)
+	}
+}
+
+func TestDeniedPermissionResultCategories(t *testing.T) {
+	// Plain approval-declined.
+	plain := deniedPermissionResult(ToolCall{ID: "c1", Name: "bash"}, "needs approval", PermissionEvent{ToolName: "bash"})
+	if plain.DenialReason != DenialPermissionDenied {
+		t.Fatalf("plain denial = %q, want %q", plain.DenialReason, DenialPermissionDenied)
+	}
+	// Sandbox-violation-driven denial.
+	sandboxDenied := deniedPermissionResult(ToolCall{ID: "c2", Name: "bash"}, "outside workspace", PermissionEvent{
+		ToolName:  "bash",
+		Violation: &sandbox.Violation{Code: "outside_workspace"},
+	})
+	if sandboxDenied.DenialReason != DenialSandboxViolation {
+		t.Fatalf("sandbox denial = %q, want %q", sandboxDenied.DenialReason, DenialSandboxViolation)
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -305,10 +305,11 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	}
 	if !ToolAllowedByFilters(call.Name, options.EnabledTools, options.DisabledTools) {
 		return ToolResult{
-			ToolCallID: call.ID,
-			Name:       call.Name,
-			Status:     tools.StatusError,
-			Output:     `Error: Tool "` + call.Name + `" is not enabled for this run.`,
+			ToolCallID:   call.ID,
+			Name:         call.Name,
+			Status:       tools.StatusError,
+			Output:       `Error: Tool "` + call.Name + `" is not enabled for this run.`,
+			DenialReason: DenialFiltered,
 		}, nil
 	}
 
@@ -639,11 +640,18 @@ func deniedPermissionResult(call ToolCall, reason string, requestEvent Permissio
 	if requestEvent.ToolName == "" {
 		event.ToolName = call.Name
 	}
+	// A denial driven by a sandbox violation is categorized distinctly from a
+	// plain approval-declined so a surface can tell policy from user choice.
+	denial := DenialPermissionDenied
+	if requestEvent.Violation != nil {
+		denial = DenialSandboxViolation
+	}
 	return ToolResult{
-		ToolCallID: call.ID,
-		Name:       call.Name,
-		Status:     tools.StatusError,
-		Output:     "Error: Permission denied for " + call.Name + ": " + reason,
+		ToolCallID:   call.ID,
+		Name:         call.Name,
+		Status:       tools.StatusError,
+		Output:       "Error: Permission denied for " + call.Name + ": " + reason,
+		DenialReason: denial,
 		Meta: map[string]string{
 			"permission_action": string(event.Action),
 		},

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -408,6 +408,12 @@ func isRetriableToolError(result ToolResult) bool {
 	if result.Status != tools.StatusError {
 		return false
 	}
+	// A categorized denial (filtered / permission / sandbox) is a policy decision,
+	// not a transient failure — never retry it. This is robust to message wording
+	// (the text checks below remain as a fallback for results lacking the field).
+	if result.DenialReason != DenialNone {
+		return false
+	}
 	if result.Meta["permission_action"] == string(PermissionActionDeny) {
 		return false
 	}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -48,6 +48,10 @@ func TestIsRetriableToolError(t *testing.T) {
 		{"permission required", ToolResult{Status: tools.StatusError, Output: "Error: Permission required for x: approve first"}, false},
 		{"sandbox violation", ToolResult{Status: tools.StatusError, Output: "Error: Sandbox violation: outside_workspace"}, false},
 		{"sandbox approval", ToolResult{Status: tools.StatusError, Output: "Error: Sandbox approval required for x: network"}, false},
+		// Structured denial categories are authoritative regardless of message text.
+		{"denial: filtered", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialFiltered}, false},
+		{"denial: permission", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialPermissionDenied}, false},
+		{"denial: sandbox", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialSandboxViolation}, false},
 	}
 	for _, c := range cases {
 		if got := isRetriableToolError(c.result); got != c.want {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -44,7 +44,20 @@ type ToolResult struct {
 	Redacted     bool
 	ChangedFiles []string
 	Display      tools.Display
+	// DenialReason categorizes why a tool call was blocked (empty when it ran).
+	// It lets a surface distinguish the cause precisely instead of parsing Output.
+	DenialReason DenialCategory
 }
+
+// DenialCategory classifies why a tool call was blocked before it executed.
+type DenialCategory string
+
+const (
+	DenialNone             DenialCategory = ""
+	DenialFiltered         DenialCategory = "filtered"          // tool not enabled for this run
+	DenialPermissionDenied DenialCategory = "permission_denied" // approval declined
+	DenialSandboxViolation DenialCategory = "sandbox_violation" // blocked by the sandbox
+)
 
 type PermissionRequest struct {
 	ToolCallID     string             `json:"toolCallId"`

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -33,7 +33,9 @@ var patterns = []pattern{
 	{"slack_token", regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"google_api_key", regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`)},
 	{"openai_key", regexp.MustCompile(`sk-[A-Za-z0-9]{20,}`)},
-	{"private_key_block", regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----`)},
+	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
+	// included) so redaction removes the key material, not just the header.
+	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},
 	{"jwt", regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
 }
 

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -1,0 +1,83 @@
+// Package secrets provides a lightweight, dependency-free scanner for
+// high-confidence secret patterns (cloud keys, provider tokens, private keys,
+// JWTs). It complements the boundary scrubbing of the configured API key by
+// catching OTHER secrets that a command or diff happens to print, so they are
+// not echoed back into the model context. It deliberately favors precision over
+// recall: only well-shaped, distinctive patterns match, to avoid false positives
+// on ordinary output.
+package secrets
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Finding is one detected secret occurrence.
+type Finding struct {
+	Type  string // category, e.g. "aws_access_key_id"
+	Match string // the exact matched text (used for redaction)
+}
+
+type pattern struct {
+	typ string
+	re  *regexp.Regexp
+}
+
+// patterns are intentionally specific (fixed prefixes / structural shapes) so
+// they don't fire on arbitrary identifiers.
+var patterns = []pattern{
+	{"aws_access_key_id", regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
+	{"github_token", regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{36}`)},
+	{"github_pat", regexp.MustCompile(`github_pat_[A-Za-z0-9_]{22,}`)},
+	{"slack_token", regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)},
+	{"google_api_key", regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`)},
+	{"openai_key", regexp.MustCompile(`sk-[A-Za-z0-9]{20,}`)},
+	{"private_key_block", regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----`)},
+	{"jwt", regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
+}
+
+// Scan returns the distinct secrets found in text (deduplicated by match,
+// sorted by type then match for deterministic output).
+func Scan(text string) []Finding {
+	if text == "" {
+		return nil
+	}
+	seen := map[string]Finding{}
+	for _, p := range patterns {
+		for _, m := range p.re.FindAllString(text, -1) {
+			if _, ok := seen[m]; !ok {
+				seen[m] = Finding{Type: p.typ, Match: m}
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]Finding, 0, len(seen))
+	for _, f := range seen {
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return out[i].Match < out[j].Match
+	})
+	return out
+}
+
+// Redact replaces every detected secret in text with a typed placeholder and
+// returns the redacted text plus the findings. When nothing matches it returns
+// the input unchanged and a nil slice.
+func Redact(text string) (string, []Finding) {
+	findings := Scan(text)
+	if len(findings) == 0 {
+		return text, nil
+	}
+	redacted := text
+	for _, f := range findings {
+		redacted = strings.ReplaceAll(redacted, f.Match, "[REDACTED:"+f.Type+"]")
+	}
+	return redacted, findings
+}

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -11,7 +11,7 @@ func TestScanDetectsHighConfidenceSecrets(t *testing.T) {
 		"github_token":      "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
 		"slack_token":       "xoxb-1234567890-abcdefghijklmno",
 		"google_api_key":    "AIzaSyA1234567890abcdefghijklmnopqrstuv",
-		"private_key_block": "-----BEGIN OPENSSH PRIVATE KEY-----",
+		"private_key_block": "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAB\n-----END OPENSSH PRIVATE KEY-----",
 	}
 	for wantType, secret := range cases {
 		text := "log line before " + secret + " and after"
@@ -23,6 +23,25 @@ func TestScanDetectsHighConfidenceSecrets(t *testing.T) {
 		if findings[0].Type != wantType {
 			t.Errorf("%s: got type %q for %q", wantType, findings[0].Type, secret)
 		}
+	}
+}
+
+func TestRedactPrivateKeyBlockRemovesBody(t *testing.T) {
+	key := "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA_secret_body_line_1\n_secret_body_line_2\n-----END RSA PRIVATE KEY-----"
+	text := "here is a key:\n" + key + "\nbye"
+
+	redacted, findings := Redact(text)
+	if len(findings) != 1 || findings[0].Type != "private_key_block" {
+		t.Fatalf("findings = %#v, want one private_key_block", findings)
+	}
+	// The KEY BODY (not just the header) must be gone.
+	for _, leaked := range []string{"MIIEowIBAAKCAQEA", "_secret_body_line_1", "_secret_body_line_2", "PRIVATE KEY"} {
+		if strings.Contains(redacted, leaked) {
+			t.Fatalf("redaction leaked key material %q: %q", leaked, redacted)
+		}
+	}
+	if !strings.Contains(redacted, "[REDACTED:private_key_block]") {
+		t.Fatalf("missing placeholder: %q", redacted)
 	}
 }
 

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -1,0 +1,64 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanDetectsHighConfidenceSecrets(t *testing.T) {
+	cases := map[string]string{
+		"aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+		"github_token":      "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+		"slack_token":       "xoxb-1234567890-abcdefghijklmno",
+		"google_api_key":    "AIzaSyA1234567890abcdefghijklmnopqrstuv",
+		"private_key_block": "-----BEGIN OPENSSH PRIVATE KEY-----",
+	}
+	for wantType, secret := range cases {
+		text := "log line before " + secret + " and after"
+		findings := Scan(text)
+		if len(findings) == 0 {
+			t.Errorf("%s: expected a finding for %q", wantType, secret)
+			continue
+		}
+		if findings[0].Type != wantType {
+			t.Errorf("%s: got type %q for %q", wantType, findings[0].Type, secret)
+		}
+	}
+}
+
+func TestScanIgnoresOrdinaryText(t *testing.T) {
+	clean := []string{
+		"the quick brown fox jumps over the lazy dog",
+		"func main() { fmt.Println(\"hello\") }",
+		"commit a1b2c3d4 fixed the build",
+		"export PATH=/usr/local/bin:$PATH",
+		"",
+	}
+	for _, text := range clean {
+		if findings := Scan(text); len(findings) != 0 {
+			t.Errorf("false positive on %q: %#v", text, findings)
+		}
+	}
+}
+
+func TestRedactReplacesSecretsAndReports(t *testing.T) {
+	text := "key=AKIAIOSFODNN7EXAMPLE done"
+	redacted, findings := Redact(text)
+	if strings.Contains(redacted, "AKIAIOSFODNN7EXAMPLE") {
+		t.Fatalf("secret not redacted: %q", redacted)
+	}
+	if !strings.Contains(redacted, "[REDACTED:aws_access_key_id]") {
+		t.Fatalf("missing typed placeholder: %q", redacted)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1", len(findings))
+	}
+}
+
+func TestRedactNoMatchReturnsInputUnchanged(t *testing.T) {
+	text := "nothing secret here"
+	redacted, findings := Redact(text)
+	if redacted != text || findings != nil {
+		t.Fatalf("expected unchanged input and nil findings, got %q / %#v", redacted, findings)
+	}
+}

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	zeroSandbox "github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/secrets"
 )
 
 const defaultBashTimeoutMS = 120000
@@ -224,6 +225,11 @@ func formatBashOutput(stdout string, stderr string, exitCode int) string {
 	parts := []string{}
 	stdout = strings.TrimRight(stdout, "\r\n")
 	stderr = strings.TrimRight(stderr, "\r\n")
+	// Redact high-confidence secrets a command may have printed, so they are not
+	// echoed back into the model context (additive to the configured-key scrub
+	// done at the registry boundary).
+	stdout, outFindings := secrets.Redact(stdout)
+	stderr, errFindings := secrets.Redact(stderr)
 	if stdout != "" {
 		parts = append(parts, "stdout:\n"+stdout)
 	}
@@ -232,6 +238,9 @@ func formatBashOutput(stdout string, stderr string, exitCode int) string {
 	}
 	if exitCode != 0 {
 		parts = append(parts, fmt.Sprintf("exit_code: %d", exitCode))
+	}
+	if n := len(outFindings) + len(errFindings); n > 0 {
+		parts = append(parts, fmt.Sprintf("[zero] redacted %d likely secret(s) from this output before showing it.", n))
 	}
 	if len(parts) == 0 {
 		return "Command completed with no output."

--- a/internal/tools/bash_secrets_test.go
+++ b/internal/tools/bash_secrets_test.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatBashOutputRedactsSecrets(t *testing.T) {
+	out := formatBashOutput("aws key: AKIAIOSFODNN7EXAMPLE\n", "", 0)
+	if strings.Contains(out, "AKIAIOSFODNN7EXAMPLE") {
+		t.Fatalf("bash output leaked a secret: %q", out)
+	}
+	if !strings.Contains(out, "[REDACTED:aws_access_key_id]") {
+		t.Fatalf("expected typed redaction placeholder, got %q", out)
+	}
+	if !strings.Contains(out, "redacted 1 likely secret") {
+		t.Fatalf("expected a redaction notice, got %q", out)
+	}
+}
+
+func TestFormatBashOutputLeavesCleanOutputAlone(t *testing.T) {
+	out := formatBashOutput("build succeeded\n", "", 0)
+	if strings.Contains(out, "REDACTED") || strings.Contains(out, "redacted") {
+		t.Fatalf("clean output should not be altered, got %q", out)
+	}
+}


### PR DESCRIPTION
## Tool quality: per-tool denial categorization + secret scanning

Two additive improvements to tool execution.

### 1. Structured per-tool denial categorization
`internal/agent/types.go` / `loop.go` — adds `ToolResult.DenialReason` (`DenialCategory`: `filtered` / `permission_denied` / `sandbox_violation`) so a surface can tell *precisely* why a call was blocked instead of parsing `Output`. Set in the not-enabled path and `deniedPermissionResult`, with sandbox-violation denials categorized distinctly from approval-declined.

### 2. Secret scanning + redaction of bash output
`internal/secrets` (new) — a dependency-free, precision-first scanner for high-confidence secret shapes (AWS/Google keys, GitHub/Slack tokens, private-key blocks, JWTs). `bash` output now runs through `secrets.Redact`, so a command that prints a secret has it replaced with a typed placeholder + a redaction notice, instead of echoing it back into the model context. This is **additive** to the existing configured-key scrub at the registry boundary, and a built-in regex scanner fits the CLI without the heavy gitleaks dependency.

### Testing
denial categorization (filtered / sandbox-violation vs approval-declined); scanner detection, no-false-positives on ordinary text, redaction, and the bash wiring. build / vet / `go test ./...` / `-race` / Windows green. No new deps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool call denials now include explicit categories (filtered, permission denied, sandbox violation).
  * Detected secrets in command outputs are automatically redacted and a redaction count/message is shown.
  * Categorized denials are treated as non-retriable to avoid repeated retries.

* **Tests**
  * Added tests covering denial categorization and secret detection/redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->