### PR TITLE
zeroline TUI: fix slash palette, token readout, @ files, ! bash

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -137,10 +137,16 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 	deps = fillAppDeps(deps)
 
 	if len(args) == 0 {
-		return runInteractiveTUI(stderr, deps)
+		return runInteractiveTUI(stderr, deps, agent.PermissionModeAsk)
 	}
 
 	switch args[0] {
+	case "--skip-permissions-unsafe":
+		// Launch the interactive TUI directly in unsafe mode. Without this, the
+		// flag fell through to the unknown-command path, so a user could never
+		// reach unsafe mode in the shell — and the "!" shell escape (which is
+		// gated behind unsafe) was therefore unreachable.
+		return runInteractiveTUI(stderr, deps, agent.PermissionModeUnsafe)
 	case "-h", "--help", "help":
 		if err := writeHelp(stdout); err != nil {
 			return 1
@@ -280,11 +286,11 @@ func fillAppDeps(deps appDeps) appDeps {
 	return deps
 }
 
-func runInteractiveTUI(stderr io.Writer, deps appDeps) int {
-	return runInteractiveTUIWithSkin(stderr, deps, "")
+func runInteractiveTUI(stderr io.Writer, deps appDeps, permissionMode agent.PermissionMode) int {
+	return runInteractiveTUIWithSkin(stderr, deps, "", permissionMode)
 }
 
-func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string) int {
+func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string, permissionMode agent.PermissionMode) int {
 	workspaceRoot, err := deps.getwd()
 	if err != nil {
 		return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), 1)
@@ -325,8 +331,12 @@ func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string) int 
 	// only PermissionAllow tools, so prompt-gated tools (write_file/edit_file/bash/
 	// apply_patch) would never be offered to the model — the TUI could neither edit
 	// files nor run shell. Ask advertises them and routes each through the existing
-	// OnPermissionRequest flow; shift+tab lets the user switch modes live.
-	permissionMode := agent.PermissionModeAsk
+	// OnPermissionRequest flow; shift+tab lets the user switch modes live. An
+	// explicit --skip-permissions-unsafe launch overrides this to unsafe (the only
+	// way to reach unsafe, since shift+tab deliberately cycles auto↔ask only).
+	if permissionMode == "" {
+		permissionMode = agent.PermissionModeAsk
+	}
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:             workspaceRoot,
 		ProviderName:    resolved.Provider.Name,
@@ -440,9 +450,10 @@ Commands:
   version    Print version
 
 Flags:
-  -h, --help       Show this help
-  -v, --version    Print version
-  -p, --prompt     Run a one-shot prompt
+  -h, --help                     Show this help
+  -v, --version                  Print version
+  -p, --prompt                   Run a one-shot prompt
+      --skip-permissions-unsafe  Launch the interactive shell in unsafe mode (enables the ! shell escape)
 `)
 	return err
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -200,6 +200,79 @@ func TestRunNoArgsLaunchesTUIInAskPermissionMode(t *testing.T) {
 	}
 }
 
+func TestRunSkipPermissionsUnsafeLaunchesTUIInUnsafeMode(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	launched := false
+	var launchedOptions tui.Options
+
+	// "zero --skip-permissions-unsafe" must launch the interactive TUI in unsafe
+	// mode (not fall through to "unknown command"). This is the only way to reach
+	// unsafe mode in the shell, which the "!" escape is gated behind.
+	exitCode := runWithDeps([]string{"--skip-permissions-unsafe"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 3}, nil
+		},
+		runTUI: func(_ context.Context, options tui.Options) int {
+			launched = true
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if !launched {
+		t.Fatal("expected the interactive TUI to launch, but runTUI was never called")
+	}
+	if launchedOptions.PermissionMode != agent.PermissionModeUnsafe {
+		t.Fatalf("PermissionMode = %q, want %q", launchedOptions.PermissionMode, agent.PermissionModeUnsafe)
+	}
+	if launchedOptions.AgentOptions.PermissionMode != agent.PermissionModeUnsafe {
+		t.Fatalf("AgentOptions.PermissionMode = %q, want %q", launchedOptions.AgentOptions.PermissionMode, agent.PermissionModeUnsafe)
+	}
+}
+
+func TestRunZerolineSkipPermissionsUnsafeLaunchesInUnsafeMode(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	launched := false
+	var launchedOptions tui.Options
+
+	exitCode := runWithDeps([]string{"zeroline", "--skip-permissions-unsafe"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 3}, nil
+		},
+		runTUI: func(_ context.Context, options tui.Options) int {
+			launched = true
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if !launched {
+		t.Fatal("expected the zeroline TUI to launch, but runTUI was never called")
+	}
+	if launchedOptions.Skin != "zeroline" {
+		t.Fatalf("Skin = %q, want zeroline", launchedOptions.Skin)
+	}
+	if launchedOptions.PermissionMode != agent.PermissionModeUnsafe {
+		t.Fatalf("PermissionMode = %q, want %q", launchedOptions.PermissionMode, agent.PermissionModeUnsafe)
+	}
+}
+
 func TestRunNoArgsReportsConfigErrorsWithoutLaunchingTUI(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/zeroline.go
+++ b/internal/cli/zeroline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/zeroline"
 )
 
@@ -27,6 +28,7 @@ func runZeroline(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 	stream := fs.Bool("stream", false, "show a streaming assistant response in the chat snapshot")
 	width := fs.Int("width", 100, "snapshot width")
 	height := fs.Int("height", 30, "snapshot height")
+	skipUnsafe := fs.Bool("skip-permissions-unsafe", false, "launch in unsafe permission mode (enables the ! shell escape)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -81,5 +83,9 @@ func runZeroline(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return 0
 	}
 
-	return runInteractiveTUIWithSkin(stderr, deps, "zeroline")
+	permissionMode := agent.PermissionModeAsk
+	if *skipUnsafe {
+		permissionMode = agent.PermissionModeUnsafe
+	}
+	return runInteractiveTUIWithSkin(stderr, deps, "zeroline", permissionMode)
 }

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -168,11 +168,21 @@ func replaceTrailingAtToken(value, path string) string {
 	return path
 }
 
+// maxFileWalk bounds how many filesystem entries the "@file" picker visits per
+// keystroke so a large workspace tree can't stall the TUI.
+const maxFileWalk = 4000
+
 // fileSuggestions lists workspace files whose path matches partial (case-
 // insensitive substring), for the "@file" picker. The walk skips VCS/dependency/
 // hidden directories and is bounded so it stays responsive per keystroke. Each
 // suggestion's Name is the "@<relpath>" token that completion inserts.
 func fileSuggestions(cwd, partial string) []commandSuggestion {
+	return fileSuggestionsBounded(cwd, partial, maxFileWalk)
+}
+
+// fileSuggestionsBounded is fileSuggestions with an explicit walk budget so the
+// per-keystroke bound is unit-testable without materializing maxFileWalk entries.
+func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSuggestion {
 	cwd = strings.TrimSpace(cwd)
 	if cwd == "" {
 		return nil
@@ -180,14 +190,17 @@ func fileSuggestions(cwd, partial string) []commandSuggestion {
 	needle := strings.ToLower(strings.TrimSpace(partial))
 	out := make([]commandSuggestion, 0, maxCommandSuggestions)
 	visited := 0
-	const maxVisited = 4000
 	_ = filepath.WalkDir(cwd, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if visited > maxVisited || len(out) >= maxCommandSuggestions {
+		if visited >= maxVisited || len(out) >= maxCommandSuggestions {
 			return fs.SkipAll
 		}
+		// Count every entry (directories included) so the walk is bounded even in
+		// directory-heavy trees where few entries are files; otherwise a deep tree
+		// could be traversed in full on each keystroke and stall the TUI.
+		visited++
 		if d.IsDir() {
 			name := d.Name()
 			if path != cwd && (name == ".git" || name == "node_modules" || name == "vendor" || name == "dist" || strings.HasPrefix(name, ".")) {
@@ -195,7 +208,6 @@ func fileSuggestions(cwd, partial string) []commandSuggestion {
 			}
 			return nil
 		}
-		visited++
 		rel, relErr := filepath.Rel(cwd, path)
 		if relErr != nil {
 			rel = filepath.Base(path)

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -200,6 +200,9 @@ func fileSuggestions(cwd, partial string) []commandSuggestion {
 		if relErr != nil {
 			rel = filepath.Base(path)
 		}
+		// Emit forward-slash paths on every platform (filepath.Rel uses "\" on
+		// Windows) so the inserted "@path" token is portable and matchable.
+		rel = filepath.ToSlash(rel)
 		if needle == "" || strings.Contains(strings.ToLower(rel), needle) {
 			out = append(out, commandSuggestion{Name: "@" + rel, Desc: "file"})
 		}

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -1,6 +1,10 @@
 package tui
 
-import "strings"
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
 
 // commandSuggestion is one row in the slash-command autocomplete overlay: the
 // canonical command name and its short description.
@@ -35,18 +39,29 @@ func (m *model) recomputeSuggestions() {
 	}
 
 	value := m.input.Value()
+
+	// File reference: a trailing "@token" (even mid-prompt) drives a workspace
+	// file picker. Checked before the slash path so "@" is handled distinctly.
+	if token, ok := trailingAtToken(value); ok {
+		m.suggestionsAreFiles = true
+		m.suggestions = fileSuggestions(m.cwd, token)
+		if m.suggestionIdx >= len(m.suggestions) || m.suggestionIdx < 0 {
+			m.suggestionIdx = 0
+		}
+		return
+	}
+	m.suggestionsAreFiles = false
+
 	trimmed := strings.TrimLeft(value, " ")
-	// Only a single bare "/token" (no whitespace, so no argument started yet)
-	// drives suggestions.
+	// A leading slash token (no whitespace yet) drives the command palette. A bare
+	// "/" now lists the full palette (the footer advertises "/ commands").
 	if !strings.HasPrefix(trimmed, "/") || strings.ContainsAny(trimmed, " \t") {
 		m.suggestions = nil
 		m.suggestionIdx = 0
 		return
 	}
 	token := strings.TrimSpace(trimmed)
-	if token == "" || token == "/" {
-		// "/" alone surfaces nothing until at least one more char is typed; this
-		// keeps the overlay from popping for an empty slash.
+	if token == "" {
 		m.suggestions = nil
 		m.suggestionIdx = 0
 		return
@@ -116,11 +131,81 @@ func (m model) completeSuggestion() model {
 	if idx < 0 || idx >= len(m.suggestions) {
 		idx = 0
 	}
-	m.input.SetValue(m.suggestions[idx].Name + " ")
+	chosen := m.suggestions[idx].Name
+	if m.suggestionsAreFiles {
+		// Replace only the trailing "@token" with the chosen path so any preceding
+		// prompt text ("read @foo") is preserved.
+		m.input.SetValue(replaceTrailingAtToken(m.input.Value(), chosen) + " ")
+	} else {
+		m.input.SetValue(chosen + " ")
+	}
 	m.input.CursorEnd()
 	m.suggestions = nil
 	m.suggestionIdx = 0
+	m.suggestionsAreFiles = false
 	return m
+}
+
+// trailingAtToken returns the file-reference fragment at the end of value: the
+// part AFTER an "@" in the last whitespace-delimited word (empty for a bare "@").
+// ok is false when that word does not start with "@".
+func trailingAtToken(value string) (string, bool) {
+	last := value
+	if i := strings.LastIndexAny(value, " \t\n"); i >= 0 {
+		last = value[i+1:]
+	}
+	if !strings.HasPrefix(last, "@") {
+		return "", false
+	}
+	return last[1:], true
+}
+
+// replaceTrailingAtToken swaps the trailing "@token" word in value for path.
+func replaceTrailingAtToken(value, path string) string {
+	if i := strings.LastIndexAny(value, " \t\n"); i >= 0 {
+		return value[:i+1] + path
+	}
+	return path
+}
+
+// fileSuggestions lists workspace files whose path matches partial (case-
+// insensitive substring), for the "@file" picker. The walk skips VCS/dependency/
+// hidden directories and is bounded so it stays responsive per keystroke. Each
+// suggestion's Name is the "@<relpath>" token that completion inserts.
+func fileSuggestions(cwd, partial string) []commandSuggestion {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return nil
+	}
+	needle := strings.ToLower(strings.TrimSpace(partial))
+	out := make([]commandSuggestion, 0, maxCommandSuggestions)
+	visited := 0
+	const maxVisited = 4000
+	_ = filepath.WalkDir(cwd, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if visited > maxVisited || len(out) >= maxCommandSuggestions {
+			return fs.SkipAll
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != cwd && (name == ".git" || name == "node_modules" || name == "vendor" || name == "dist" || strings.HasPrefix(name, ".")) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		visited++
+		rel, relErr := filepath.Rel(cwd, path)
+		if relErr != nil {
+			rel = filepath.Base(path)
+		}
+		if needle == "" || strings.Contains(strings.ToLower(rel), needle) {
+			out = append(out, commandSuggestion{Name: "@" + rel, Desc: "file"})
+		}
+		return nil
+	})
+	return out
 }
 
 // dismissSuggestions clears the overlay without touching the input or the run.

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -224,4 +226,72 @@ func TestSuggestionOverlayRendersInZerolineSkin(t *testing.T) {
 	if !strings.Contains(view, "/model") || !strings.Contains(view, "/mode") {
 		t.Fatal("zeroline chat view should render the suggestion overlay")
 	}
+}
+
+func TestFileSuggestionsMatchesAndSkipsVCSDirs(t *testing.T) {
+	root := t.TempDir()
+	mustWrite := func(rel string) {
+		t.Helper()
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("cmd/server/main.go")
+	mustWrite(".git/config")             // hidden VCS dir: must be skipped
+	mustWrite("node_modules/dep/index.js") // dependency dir: must be skipped
+
+	got := suggestionTokens(fileSuggestions(root, "main"))
+	if !contains(got, "@cmd/server/main.go") {
+		t.Fatalf("expected @cmd/server/main.go in %v", got)
+	}
+
+	all := suggestionTokens(fileSuggestions(root, ""))
+	for _, name := range all {
+		if strings.Contains(name, ".git/") || strings.Contains(name, "node_modules/") {
+			t.Fatalf("walk must skip VCS/dependency dirs, got %q", name)
+		}
+	}
+}
+
+// TestFileSuggestionsBoundCountsDirectories proves the walk budget counts
+// directory entries (not just files): with a tiny budget, a match that sits
+// behind many directories is never reached, so the per-keystroke walk stays
+// bounded in directory-heavy trees.
+func TestFileSuggestionsBoundCountsDirectories(t *testing.T) {
+	root := t.TempDir()
+	// Many empty directories sort before "zzz" lexically, so WalkDir visits them
+	// first and exhausts the budget before reaching the matching file.
+	for i := 0; i < 50; i++ {
+		if err := os.MkdirAll(filepath.Join(root, "dir"+string(rune('a'+i%26))+string(rune('0'+i/26))), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deep := filepath.Join(root, "zzz")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "needle.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Budget smaller than the directory count: must bail before the match.
+	if got := suggestionTokens(fileSuggestionsBounded(root, "needle", 5)); contains(got, "@zzz/needle.go") {
+		t.Fatalf("walk should have hit the budget before the deep match, got %v", got)
+	}
+	// Ample budget: the match is reachable.
+	if got := suggestionTokens(fileSuggestionsBounded(root, "needle", maxFileWalk)); !contains(got, "@zzz/needle.go") {
+		t.Fatalf("with an ample budget the match should be found, got %v", got)
+	}
+}
+
+func suggestionTokens(s []commandSuggestion) []string {
+	names := make([]string, 0, len(s))
+	for _, c := range s {
+		names = append(names, c.Name)
+	}
+	return names
 }

--- a/internal/tui/command_bash.go
+++ b/internal/tui/command_bash.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// bashEscapeTimeout bounds a "!cmd" shell escape so a hung command can't freeze
+// the agent indefinitely.
+const bashEscapeTimeout = 30 * time.Second
+
+// bashResultMsg carries the combined output of a "!cmd" shell escape back to the
+// model for display in the transcript.
+type bashResultMsg struct {
+	command string
+	output  string
+}
+
+// runBashEscape runs a user-typed "!cmd" in the workspace and returns its
+// combined output as a message. The user typed it explicitly, so it runs
+// directly (a deliberate shell escape, outside the agent sandbox), bounded by a
+// timeout and executed asynchronously so the UI stays responsive.
+func runBashEscape(cwd, command string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), bashEscapeTimeout)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "bash", "-c", command)
+		if strings.TrimSpace(cwd) != "" {
+			cmd.Dir = cwd
+		}
+		out, err := cmd.CombinedOutput()
+		text := strings.TrimRight(string(out), "\n")
+
+		switch {
+		case ctx.Err() == context.DeadlineExceeded:
+			text = appendNote(text, "[timed out after "+bashEscapeTimeout.String()+"]")
+		case err != nil:
+			text = appendNote(text, "[exit error: "+err.Error()+"]")
+		}
+		if strings.TrimSpace(text) == "" {
+			text = "(no output)"
+		}
+		return bashResultMsg{command: command, output: text}
+	}
+}
+
+func appendNote(text, note string) string {
+	if text == "" {
+		return note
+	}
+	return text + "\n" + note
+}

--- a/internal/tui/command_bash.go
+++ b/internal/tui/command_bash.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -29,7 +30,8 @@ func runBashEscape(cwd, command string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), bashEscapeTimeout)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "bash", "-c", command)
+		name, shellArgs := escapeShell(command)
+		cmd := exec.CommandContext(ctx, name, shellArgs...)
 		if strings.TrimSpace(cwd) != "" {
 			cmd.Dir = cwd
 		}
@@ -47,6 +49,17 @@ func runBashEscape(cwd, command string) tea.Cmd {
 		}
 		return bashResultMsg{command: command, output: text}
 	}
+}
+
+// escapeShell returns the platform shell and arguments for a "!cmd" escape,
+// matching the agent bash tool: cmd.exe on Windows, /bin/sh elsewhere. Hardcoding
+// "bash" broke the escape on stock Windows (no bash on PATH) and anywhere bash is
+// not installed at a predictable path.
+func escapeShell(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", []string{"/d", "/s", "/c", command}
+	}
+	return "/bin/sh", []string{"-c", command}
 }
 
 func appendNote(text, note string) string {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -31,6 +31,7 @@ const (
 	commandStyle
 	commandTheme
 	commandInputStyle
+	commandBash
 	commandUnknown
 )
 
@@ -223,6 +224,11 @@ func parseCommand(input string) parsedCommand {
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "" {
 		return parsedCommand{kind: commandEmpty}
+	}
+
+	// "!cmd" is a shell escape (the footer advertises "! bash"): run it directly.
+	if strings.HasPrefix(trimmed, "!") {
+		return parsedCommand{kind: commandBash, text: strings.TrimSpace(trimmed[1:])}
 	}
 
 	if strings.HasPrefix(trimmed, "/") {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -85,6 +85,10 @@ type model struct {
 	// row. Active only when suggestionsActive() (no modal, non-empty matches).
 	suggestions   []commandSuggestion
 	suggestionIdx int
+	// suggestionsAreFiles is true when the overlay is showing "@file" matches
+	// rather than "/command" matches, so completion inserts a path token instead
+	// of replacing the whole input.
+	suggestionsAreFiles bool
 
 	// picker, when non-nil, is an open interactive selector overlay (/model,
 	// /theme, /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and
@@ -482,6 +486,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.transcript = appendTranscriptRow(m.transcript, msg.row)
 		return m, nil
+	case bashResultMsg:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})
+		return m, nil
 	}
 
 	var cmd tea.Cmd
@@ -850,6 +857,15 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			text: "unknown command: " + command.text,
 		})
 		return m, nil
+	case commandBash:
+		m.showSplash = false
+		cmdText := strings.TrimSpace(command.text)
+		if cmdText == "" {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Usage: !<shell command>"})
+			return m, nil
+		}
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "$ " + cmdText})
+		return m, runBashEscape(m.cwd, cmdText)
 	case commandPrompt:
 		m.showSplash = false
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendUser, text: command.text})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -864,6 +864,17 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Usage: !<shell command>"})
 			return m, nil
 		}
+		// A "!cmd" shell escape runs OUTSIDE the agent sandbox, so gate it behind
+		// the explicit unsafe permission mode. In auto/ask mode it is not executed;
+		// the user is told how to enable it. This keeps a sandbox-bypassing exec
+		// from running without a deliberate safety posture.
+		if m.permissionMode != agent.PermissionModeUnsafe {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{
+				kind: actionAppendSystem,
+				text: "Shell escape (!) is disabled in " + string(m.permissionMode) + " mode — it bypasses the sandbox. Relaunch with --skip-permissions-unsafe to run shell commands directly.",
+			})
+			return m, nil
+		}
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "$ " + cmdText})
 		return m, runBashEscape(m.cwd, cmdText)
 	case commandPrompt:

--- a/internal/tui/tui_fixes_test.go
+++ b/internal/tui/tui_fixes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -38,6 +39,25 @@ func TestBashEscapeGatedByPermissionMode(t *testing.T) {
 	_, cmd := m.handleSubmit()
 	if cmd == nil {
 		t.Fatal("unsafe mode: !cmd should execute (non-nil cmd)")
+	}
+}
+
+// The "!" escape must use the platform shell (cmd.exe on Windows, /bin/sh
+// elsewhere), not a hardcoded "bash" that is absent on stock Windows.
+func TestEscapeShellWrapsCommandForPlatform(t *testing.T) {
+	name, args := escapeShell("echo hi")
+	if name == "" {
+		t.Fatal("escapeShell returned an empty executable")
+	}
+	if len(args) == 0 || args[len(args)-1] != "echo hi" {
+		t.Fatalf("escapeShell args = %v, want the command as the final arg", args)
+	}
+	if runtime.GOOS == "windows" {
+		if name != "cmd.exe" || args[0] != "/d" {
+			t.Fatalf("windows shell = %q %v, want cmd.exe /d /s /c", name, args)
+		}
+	} else if name != "/bin/sh" || args[0] != "-c" {
+		t.Fatalf("unix shell = %q %v, want /bin/sh -c", name, args)
 	}
 }
 

--- a/internal/tui/tui_fixes_test.go
+++ b/internal/tui/tui_fixes_test.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FIX 1: a bare "/" surfaces the full command palette (was suppressed).
+func TestBareSlashListsCommandPalette(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/")
+	if !m.suggestionsActive() {
+		t.Fatal("a bare / should surface the command palette")
+	}
+	if len(m.suggestions) == 0 {
+		t.Fatal("expected command suggestions for a bare /")
+	}
+	if m.suggestionsAreFiles {
+		t.Fatal("a bare / should be command suggestions, not files")
+	}
+}
+
+// FIX 4: "@" helpers — trailing-token detection and replacement.
+func TestTrailingAtToken(t *testing.T) {
+	cases := []struct {
+		in    string
+		token string
+		ok    bool
+	}{
+		{"@", "", true},
+		{"@foo", "foo", true},
+		{"read @foo/bar", "foo/bar", true},
+		{"hello", "", false},
+		{"read @foo done", "", false}, // trailing word is "done", not an @token
+		{"", "", false},
+	}
+	for _, c := range cases {
+		token, ok := trailingAtToken(c.in)
+		if ok != c.ok || token != c.token {
+			t.Errorf("trailingAtToken(%q) = (%q,%v), want (%q,%v)", c.in, token, ok, c.token, c.ok)
+		}
+	}
+}
+
+func TestReplaceTrailingAtToken(t *testing.T) {
+	if got := replaceTrailingAtToken("read @fo", "@internal/loop.go"); got != "read @internal/loop.go" {
+		t.Fatalf("replaceTrailingAtToken mid-prompt = %q", got)
+	}
+	if got := replaceTrailingAtToken("@m", "@main.go"); got != "@main.go" {
+		t.Fatalf("replaceTrailingAtToken whole-input = %q", got)
+	}
+}
+
+// FIX 4: "@" surfaces workspace files, filters, and skips VCS dirs.
+func TestFileSuggestionsListsAndFiltersWorkspaceFiles(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "main.go"))
+	mustWrite(t, filepath.Join(dir, "internal", "loop.go"))
+	mustWrite(t, filepath.Join(dir, ".git", "config")) // must be skipped
+
+	all := suggestionNames2(fileSuggestions(dir, ""))
+	if !contains(all, "@main.go") || !contains(all, "@internal/loop.go") {
+		t.Fatalf("expected workspace files, got %v", all)
+	}
+	for _, s := range all {
+		if strings.Contains(s, ".git/") {
+			t.Fatalf("file suggestions must skip .git, got %v", all)
+		}
+	}
+	filtered := suggestionNames2(fileSuggestions(dir, "loop"))
+	if !contains(filtered, "@internal/loop.go") || contains(filtered, "@main.go") {
+		t.Fatalf("filter 'loop' = %v, want only loop.go", filtered)
+	}
+}
+
+// FIX 2: the zeroline header reflects cost + cumulative tokens from the tracker.
+func TestZerolineHeaderReflectsUsage(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	if m.usageTracker == nil {
+		t.Skip("no usage tracker")
+	}
+	m.unpricedTokens = 1234 // fallback path when nothing is priced yet
+	h := m.zerolineHeader()
+	if h.TotalTokens != 1234 {
+		t.Fatalf("header TotalTokens = %d, want 1234 (unpriced fallback)", h.TotalTokens)
+	}
+}
+
+// FIX 3: "!cmd" parses as a shell escape, not a chat prompt.
+func TestParseCommandBangIsShellEscape(t *testing.T) {
+	got := parseCommand("!ls -la")
+	if got.kind != commandBash || got.text != "ls -la" {
+		t.Fatalf("parseCommand(!ls -la) = {kind:%v text:%q}, want commandBash/\"ls -la\"", got.kind, got.text)
+	}
+	if parseCommand("/help").kind == commandBash {
+		t.Fatal("/help must not parse as bash")
+	}
+	if parseCommand("just chatting").kind != commandPrompt {
+		t.Fatal("plain text must still parse as a prompt")
+	}
+}
+
+func mustWrite(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func suggestionNames2(s []commandSuggestion) []string {
+	out := make([]string, 0, len(s))
+	for _, x := range s {
+		out = append(out, x.Name)
+	}
+	return out
+}

--- a/internal/tui/tui_fixes_test.go
+++ b/internal/tui/tui_fixes_test.go
@@ -6,7 +6,40 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
 )
+
+// FIX 3 (safety): "!cmd" runs only in unsafe permission mode; auto/ask gate it.
+func TestBashEscapeGatedByPermissionMode(t *testing.T) {
+	lastSystemText := func(m model) string {
+		for i := len(m.transcript) - 1; i >= 0; i-- {
+			if m.transcript[i].kind == rowSystem {
+				return m.transcript[i].text
+			}
+		}
+		return ""
+	}
+
+	for _, mode := range []agent.PermissionMode{agent.PermissionModeAuto, agent.PermissionModeAsk} {
+		m := newModel(context.Background(), Options{PermissionMode: mode})
+		m.input.SetValue("!rm -rf /")
+		updated, cmd := m.handleSubmit()
+		if cmd != nil {
+			t.Fatalf("%s mode: !cmd must be gated (nil cmd), got a command to run", mode)
+		}
+		if msg := lastSystemText(updated.(model)); !strings.Contains(msg, "disabled") || !strings.Contains(msg, "unsafe") {
+			t.Fatalf("%s mode: expected a gate message naming unsafe, got %q", mode, msg)
+		}
+	}
+
+	m := newModel(context.Background(), Options{PermissionMode: agent.PermissionModeUnsafe})
+	m.input.SetValue("!echo hi")
+	_, cmd := m.handleSubmit()
+	if cmd == nil {
+		t.Fatal("unsafe mode: !cmd should execute (non-nil cmd)")
+	}
+}
 
 // FIX 1: a bare "/" surfaces the full command palette (was suppressed).
 func TestBareSlashListsCommandPalette(t *testing.T) {

--- a/internal/tui/zeroline_view.go
+++ b/internal/tui/zeroline_view.go
@@ -42,6 +42,27 @@ func (m model) handleZerolineKeys(msg tea.KeyMsg) (model, bool) {
 	return m, false
 }
 
+// zerolineHeader builds the zeroline header, including the live cost and
+// cumulative token total from the usage tracker (with the unpriced fallback) so
+// the top/bottom bars actually reflect consumption instead of always showing $0.
+func (m model) zerolineHeader() zeroline.Header {
+	h := zeroline.Header{
+		Cwd:      m.cwd,
+		Branch:   m.gitBranch,
+		Model:    m.modelName,
+		Provider: m.providerName,
+	}
+	if m.usageTracker != nil {
+		summary := m.usageTracker.Summary()
+		h.Cost = summary.TotalCost
+		h.TotalTokens = summary.TotalTokens
+	}
+	if h.TotalTokens == 0 && m.unpricedTokens > 0 {
+		h.TotalTokens = m.unpricedTokens
+	}
+	return h
+}
+
 func (m model) zerolineView() string {
 	width, height := m.width, m.height
 	if width <= 0 {
@@ -56,12 +77,7 @@ func (m model) zerolineView() string {
 		return zeroline.RenderBoot(m.themeVariant, m.themeDark, m.frame, width, height)
 	}
 
-	header := zeroline.Header{
-		Cwd:      m.cwd,
-		Branch:   m.gitBranch,
-		Model:    m.modelName,
-		Provider: m.providerName,
-	}
+	header := m.zerolineHeader()
 
 	// Home until the first turn is submitted.
 	if m.showSplash {

--- a/internal/zeroline/render.go
+++ b/internal/zeroline/render.go
@@ -17,6 +17,7 @@ type Header struct {
 	Dirty                        bool
 	CtxPct                       int
 	Cost                         float64
+	TotalTokens                  int
 }
 
 // Row is one rendered transcript entry, mapped from the TUI's live state.
@@ -539,7 +540,8 @@ func (s styles) botBar(run string, h Header, variant, tokS, w int) string {
 		tps = s.green.Render(strconv.Itoa(tokS))
 	}
 	left := b1(dot+" "+stStyle.Render(stTxt)) + b2(s.dim.Render("utf-8")) +
-		b2(s.mute.Render("tok/s ")+tps)
+		b2(s.mute.Render("tok/s ")+tps) +
+		b2(s.mute.Render("tok ")+s.fg.Render(humanTokens(h.TotalTokens)))
 	right := b2(s.mute.Render("ctx ")+s.gauge(float64(h.CtxPct)/100, 8)) +
 		b2(s.mute.Render(ThemeName(variant))) +
 		b1(s.mute.Render("1-5 theme · ^L light"))
@@ -1113,6 +1115,17 @@ func firstLine(s string) string {
 		return s[:i]
 	}
 	return s
+}
+
+// humanTokens formats a cumulative token count compactly (e.g. 1234 -> "1.2k").
+func humanTokens(n int) string {
+	if n < 0 {
+		n = 0
+	}
+	if n < 1000 {
+		return strconv.Itoa(n)
+	}
+	return strings.Replace(fmt.Sprintf("%.1fk", float64(n)/1000), ".0k", "k", 1)
 }
 
 func wrap(text string, w int) []string {

--- a/internal/zeroline/render.go
+++ b/internal/zeroline/render.go
@@ -1117,7 +1117,9 @@ func firstLine(s string) string {
 	return s
 }
 
-// humanTokens formats a cumulative token count compactly (e.g. 1234 -> "1.2k").
+// humanTokens formats a cumulative token count compactly (e.g. 1234 -> "1.2k",
+// 1_500_000 -> "1.5M"). Counts climb into the millions on large-context models,
+// so the readout switches to "M" past a million rather than showing "1000k".
 func humanTokens(n int) string {
 	if n < 0 {
 		n = 0
@@ -1125,7 +1127,10 @@ func humanTokens(n int) string {
 	if n < 1000 {
 		return strconv.Itoa(n)
 	}
-	return strings.Replace(fmt.Sprintf("%.1fk", float64(n)/1000), ".0k", "k", 1)
+	if n < 1_000_000 {
+		return strings.Replace(fmt.Sprintf("%.1fk", float64(n)/1000), ".0k", "k", 1)
+	}
+	return strings.Replace(fmt.Sprintf("%.1fM", float64(n)/1_000_000), ".0M", "M", 1)
 }
 
 func wrap(text string, w int) []string {

--- a/internal/zeroline/tokens_test.go
+++ b/internal/zeroline/tokens_test.go
@@ -1,0 +1,23 @@
+package zeroline
+
+import "testing"
+
+func TestHumanTokens(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{-1, "0"},    // negative clamps to zero
+		{0, "0"},     //
+		{999, "999"}, // under 1k stays exact
+		{1000, "1k"}, // .0 trimmed
+		{1234, "1.2k"},
+		{1500, "1.5k"},
+		{999999, "1000k"}, // rounds up but stays in k (documented behavior)
+	}
+	for _, c := range cases {
+		if got := humanTokens(c.in); got != c.want {
+			t.Errorf("humanTokens(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/zeroline/tokens_test.go
+++ b/internal/zeroline/tokens_test.go
@@ -13,7 +13,11 @@ func TestHumanTokens(t *testing.T) {
 		{1000, "1k"}, // .0 trimmed
 		{1234, "1.2k"},
 		{1500, "1.5k"},
-		{999999, "1000k"}, // rounds up but stays in k (documented behavior)
+		{999999, "1000k"},   // just under 1M: rounds up but stays in k
+		{1000000, "1M"},     // .0 trimmed at the M boundary
+		{1500000, "1.5M"},
+		{5000000, "5M"},
+		{12345678, "12.3M"}, // large counts read in M, not thousands of k
 	}
 	for _, c := range cases {
 		if got := humanTokens(c.in); got != c.want {


### PR DESCRIPTION
## zeroline TUI: fix slash palette, token readout, @ files, ! bash

The zeroline home footer advertised six affordances but the code didn't keep four of them. Found via a multi-agent audit of `internal/tui` + `internal/zeroline`; each fix is verified against the code path.

### Fixes
- **`/` command palette** — `autocomplete.go` explicitly suppressed a bare `/` (you had to type `/h` first), yet the footer says **"/ commands"**. Now a bare `/` lists the full palette (capped at 8).
- **Token / cost readout** — the zeroline header was built without `Cost`/`TotalTokens`, so the bars always read `$ 0.00` with no token total. `zerolineHeader()` now threads `usageTracker.Summary()` (cost + cumulative tokens, with the unpriced fallback); the bottom bar gains a `tok <N>` segment.
- **`@ files`** — `@` now drives a workspace **file picker** in the existing suggestion overlay (bounded walk; skips `.git`/`node_modules`/`vendor`/`dist`/hidden). Selecting inserts the `@path`, preserving any preceding prompt text. Previously `@…` was silently sent to the agent as chat.
- **`! bash`** — `!cmd` now runs as a **shell escape** (async, 30s timeout, in the workspace), output shown in the transcript. Previously `!cmd` was sent to the agent as chat.
- **`1-5 theme`** — left as-is: it works when the input is empty (the home screen), and gating on empty input keeps digits typable in prompts.

### Testing
bare-`/` palette, `@`-token detection/replacement, file listing+filter+skip-dirs, `!cmd` parsing, header usage; all existing autocomplete tests still pass. build / vet / `go test ./...` / `-race` / Windows green. No new deps.

> Note: the `@`/`!`/`/` interactions are unit-tested at the logic layer; a quick manual `zero zeroline` pass (type `/`, `@`, `!ls`) is worth doing before merge since Bubble Tea key-routing isn't exercised by unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace file-path autocomplete via trailing @ (mid-prompt, case-insensitive substring matches, skips VCS/deps/hidden dirs, bounded results)
  * Shell-escape via ! to run a shell command and append formatted output/notes (exec only in unsafe permission mode)
  * CLI flag to launch interactive TUI in unsafe mode (--skip-permissions-unsafe)

* **Bug Fixes**
  * Improved autocomplete mode switching and replacement (preserves surrounding text, appends space)
  * Header shows cumulative token totals with compact formatting and sensible fallback

* **Tests**
  * Regression and unit tests for parsing, suggestions, permission gating, and token-formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->