### PR TITLE
Add context budget report

### DIFF
--- a/internal/agent/system_prompt_preview.go
+++ b/internal/agent/system_prompt_preview.go
@@ -1,0 +1,8 @@
+package agent
+
+// BuildSystemPromptPreview returns the same system prompt a run would seed for
+// the supplied options. It is intended for non-runtime reporting surfaces that
+// need to estimate prompt footprint without starting a provider call.
+func BuildSystemPromptPreview(options Options) string {
+	return buildSystemPrompt(options)
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -167,6 +167,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runProviders(args[1:], stdout, stderr, deps)
 	case "doctor":
 		return runDoctor(args[1:], stdout, stderr, deps)
+	case "context":
+		return runContext(args[1:], stdout, stderr, deps)
 	case "search", "find":
 		return runSearch(args[1:], stdout, stderr, deps)
 	case "sessions", "session":
@@ -421,6 +423,7 @@ Commands:
   models     List Zero model registry entries
   providers  Inspect resolved provider profiles
   doctor     Run backend health checks for config and provider setup
+  context    Report workspace context budget usage
   search     Search persisted local Zero session events
   find       Alias for search
   sessions   Inspect local Zero session lineage

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -562,6 +562,7 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"models",
 		"providers",
 		"doctor",
+		"context",
 		"search",
 		"plugins",
 		"hooks",

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -35,7 +35,10 @@ func runContext(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 		return writeAppError(stderr, err.Error(), exitProvider)
 	}
 
-	modelRegistry, _ := modelregistry.DefaultRegistry()
+	modelRegistry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
 	report, err := contextreport.Build(contextreport.Options{
 		WorkspaceRoot: workspaceRoot,
 		Provider:      resolved.Provider,

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/contextreport"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+)
+
+type contextOptions struct {
+	json bool
+}
+
+func runContext(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseContextArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeContextHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
+	}
+
+	modelRegistry, _ := modelregistry.DefaultRegistry()
+	report, err := contextreport.Build(contextreport.Options{
+		WorkspaceRoot: workspaceRoot,
+		Provider:      resolved.Provider,
+		Registry:      newCoreRegistry(workspaceRoot),
+		ContextWindow: modelContextWindow(modelRegistry, resolved.Provider.Model),
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, contextreport.Format(report)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseContextArgs(args []string) (contextOptions, bool, error) {
+	options := contextOptions{}
+	for _, arg := range args {
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown context flag %q", arg)}
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unexpected context argument %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func writeContextHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero context [flags]
+
+Reports the current workspace context budget.
+
+Flags:
+      --json      Print JSON report
+  -h, --help      Show this help
+`)
+	return err
+}

--- a/internal/cli/context_test.go
+++ b/internal/cli/context_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestRunContextHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"context", "--help"}, &stdout, &stderr, appDeps{})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	for _, want := range []string{"Usage:", "zero context [flags]", "--json", "-h, --help"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected context help to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunContextTextReport(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+
+	exitCode := runWithDeps([]string{"context"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.ResolvedConfig{
+				Provider: config.ProviderProfile{
+					Name:         "openai",
+					ProviderKind: config.ProviderKindOpenAI,
+					Model:        "gpt-4.1",
+				},
+			}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	for _, want := range []string{"Zero context report", "root: " + cwd, "model: gpt-4.1"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected context output to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunContextJSONReport(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+
+	exitCode := runWithDeps([]string{"context", "--json"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{
+				Provider: config.ProviderProfile{
+					Name:         "openai",
+					ProviderKind: config.ProviderKindOpenAI,
+					Model:        "gpt-4.1",
+				},
+			}, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var report struct {
+		Root          string `json:"root"`
+		ModelID       string `json:"modelId"`
+		ContextWindow int    `json:"contextWindow"`
+		ToolCount     int    `json:"toolCount"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("context JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.Root != cwd {
+		t.Fatalf("Root = %q, want %q", report.Root, cwd)
+	}
+	if report.ModelID != "gpt-4.1" {
+		t.Fatalf("ModelID = %q, want gpt-4.1", report.ModelID)
+	}
+	if report.ContextWindow <= 0 {
+		t.Fatalf("ContextWindow = %d, want > 0", report.ContextWindow)
+	}
+	if report.ToolCount <= 0 {
+		t.Fatalf("ToolCount = %d, want > 0", report.ToolCount)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunContextRejectsUnknownFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"context", "--wat"}, &stdout, &stderr, appDeps{})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `unknown context flag "--wat"`) {
+		t.Fatalf("expected unknown flag error, got %q", stderr.String())
+	}
+}

--- a/internal/contextreport/contextreport.go
+++ b/internal/contextreport/contextreport.go
@@ -29,6 +29,9 @@ var defaultProjectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.
 
 const maxProjectContextBytes = 8 << 10
 
+// toolDefinitionOverheadTokens approximates per-tool JSON/message framing.
+const toolDefinitionOverheadTokens = 4
+
 type Options struct {
 	WorkspaceRoot       string
 	Provider            config.ProviderProfile
@@ -207,7 +210,7 @@ func estimateRegistryTools(registry *tools.Registry) (int, int) {
 		if encoded, err := json.Marshal(tool.Parameters()); err == nil {
 			total += estimateTextTokens(string(encoded))
 		}
-		total += 4
+		total += toolDefinitionOverheadTokens
 	}
 	return len(all), total
 }

--- a/internal/contextreport/contextreport.go
+++ b/internal/contextreport/contextreport.go
@@ -1,0 +1,271 @@
+package contextreport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const ContractV1 = "zero.context.report.v1"
+const RuntimeGo = "go"
+
+const (
+	CategorySystemPrompt      = "system_prompt"
+	CategoryProjectGuidelines = "project_guidelines"
+	CategoryTools             = "tools"
+	CategoryFree              = "free"
+)
+
+var defaultProjectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
+
+const maxProjectContextBytes = 8 << 10
+
+type Options struct {
+	WorkspaceRoot       string
+	Provider            config.ProviderProfile
+	Registry            *tools.Registry
+	ContextWindow       int
+	ProjectContextFiles []string
+}
+
+type Report struct {
+	Contract             string     `json:"contract"`
+	Runtime              string     `json:"runtime"`
+	Root                 string     `json:"root"`
+	ProviderName         string     `json:"providerName,omitempty"`
+	ProviderKind         string     `json:"providerKind,omitempty"`
+	ModelID              string     `json:"modelId,omitempty"`
+	APIModel             string     `json:"apiModel,omitempty"`
+	ContextWindow        int        `json:"contextWindow"`
+	UsedTokens           int        `json:"usedTokens"`
+	FreeTokens           int        `json:"freeTokens"`
+	UsedFraction         float64    `json:"usedFraction"`
+	ToolCount            int        `json:"toolCount"`
+	ProjectGuidelineFile string     `json:"projectGuidelineFile,omitempty"`
+	Categories           []Category `json:"categories"`
+}
+
+type Category struct {
+	Key     string  `json:"key"`
+	Name    string  `json:"name"`
+	Tokens  int     `json:"tokens"`
+	Percent float64 `json:"percent"`
+}
+
+func Build(options Options) (Report, error) {
+	root := strings.TrimSpace(options.WorkspaceRoot)
+	if root == "" {
+		root = "."
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+
+	provider := options.Provider
+	report := Report{
+		Contract:     ContractV1,
+		Runtime:      RuntimeGo,
+		Root:         root,
+		ProviderName: strings.TrimSpace(provider.Name),
+		ModelID:      strings.TrimSpace(provider.Model),
+	}
+	if metadata, err := providers.ResolveRuntimeMetadata(provider, providers.Options{}); err == nil {
+		report.ProviderKind = string(metadata.ProviderKind)
+		report.APIModel = metadata.APIModel
+		if report.ModelID == "" {
+			report.ModelID = metadata.APIModel
+		}
+	}
+
+	report.ContextWindow = options.ContextWindow
+	if report.ContextWindow <= 0 {
+		report.ContextWindow = contextWindowForModel(report.ModelID, report.APIModel)
+	}
+
+	categories := []Category{}
+	basePrompt := systemPromptFootprint(root, report.ModelID)
+	categories = append(categories, category(CategorySystemPrompt, "System prompt", estimateTextTokens(basePrompt), report.ContextWindow))
+
+	projectGuidelines, guidelineFile := readProjectGuidelines(root, options.ProjectContextFiles)
+	if guidelineFile != "" {
+		report.ProjectGuidelineFile = guidelineFile
+		categories = append(categories, category(CategoryProjectGuidelines, "Project guidelines", estimateTextTokens(projectGuidelines), report.ContextWindow))
+	}
+
+	toolCount, toolTokens := estimateRegistryTools(options.Registry)
+	report.ToolCount = toolCount
+	if toolTokens > 0 {
+		categories = append(categories, category(CategoryTools, "Tools", toolTokens, report.ContextWindow))
+	}
+
+	used := 0
+	for _, cat := range categories {
+		used += cat.Tokens
+	}
+	report.UsedTokens = used
+	if report.ContextWindow > 0 {
+		report.UsedFraction = float64(report.UsedTokens) / float64(report.ContextWindow)
+		report.FreeTokens = report.ContextWindow - report.UsedTokens
+		if report.FreeTokens < 0 {
+			report.FreeTokens = 0
+		}
+	}
+	categories = append(categories, category(CategoryFree, "Free", report.FreeTokens, report.ContextWindow))
+	report.Categories = categories
+	return report, nil
+}
+
+func systemPromptFootprint(root string, modelID string) string {
+	parts := []string{agent.BuildSystemPromptPreview(agent.Options{Model: modelID}), "runtime: go"}
+	if root = strings.TrimSpace(root); root != "" {
+		parts = append(parts, "workspace: "+root)
+	}
+	if modelID = strings.TrimSpace(modelID); modelID != "" {
+		parts = append(parts, "model: "+modelID)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func Format(report Report) string {
+	lines := []string{
+		"Zero context report",
+		"root: " + report.Root,
+	}
+	if report.ProviderName != "" {
+		lines = append(lines, "provider: "+report.ProviderName)
+	}
+	if report.ModelID != "" {
+		lines = append(lines, "model: "+report.ModelID)
+	}
+	if report.APIModel != "" {
+		lines = append(lines, "api_model: "+report.APIModel)
+	}
+	if report.ContextWindow > 0 {
+		lines = append(lines, fmt.Sprintf("usage: %s/%s tokens (%.1f%%)", compactNumber(report.UsedTokens), compactNumber(report.ContextWindow), report.UsedFraction*100))
+	} else {
+		lines = append(lines, fmt.Sprintf("usage: %s tokens (context window unknown)", compactNumber(report.UsedTokens)))
+	}
+	if report.ToolCount > 0 {
+		lines = append(lines, fmt.Sprintf("tools: %d", report.ToolCount))
+	}
+	if report.ProjectGuidelineFile != "" {
+		lines = append(lines, "project_guidelines: "+report.ProjectGuidelineFile)
+	}
+	lines = append(lines, "", "Categories:")
+	for _, cat := range report.Categories {
+		if report.ContextWindow > 0 {
+			lines = append(lines, fmt.Sprintf("  %s: %s tokens (%.1f%%)", cat.Name, compactNumber(cat.Tokens), cat.Percent))
+		} else {
+			lines = append(lines, fmt.Sprintf("  %s: %s tokens", cat.Name, compactNumber(cat.Tokens)))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func contextWindowForModel(modelID string, apiModel string) int {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return 0
+	}
+	for _, candidate := range []string{modelID, apiModel} {
+		if model, ok := registry.Get(candidate); ok {
+			return model.ContextLimits.ContextWindow
+		}
+	}
+	return 0
+}
+
+func category(key string, name string, tokens int, contextWindow int) Category {
+	cat := Category{Key: key, Name: name, Tokens: maxInt(tokens, 0)}
+	if contextWindow > 0 {
+		cat.Percent = float64(cat.Tokens) / float64(contextWindow) * 100
+	}
+	return cat
+}
+
+func estimateRegistryTools(registry *tools.Registry) (int, int) {
+	if registry == nil {
+		return 0, 0
+	}
+	all := registry.All()
+	sort.Slice(all, func(left int, right int) bool {
+		return all[left].Name() < all[right].Name()
+	})
+	total := 0
+	for _, tool := range all {
+		total += estimateTextTokens(tool.Name())
+		total += estimateTextTokens(tool.Description())
+		if encoded, err := json.Marshal(tool.Parameters()); err == nil {
+			total += estimateTextTokens(string(encoded))
+		}
+		total += 4
+	}
+	return len(all), total
+}
+
+func readProjectGuidelines(root string, names []string) (string, string) {
+	if len(names) == 0 {
+		names = defaultProjectContextFiles
+	}
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			continue
+		}
+		content := strings.TrimSpace(string(data))
+		if content == "" {
+			continue
+		}
+		if len(content) > maxProjectContextBytes {
+			content = content[:maxProjectContextBytes]
+		}
+		return content, filepath.ToSlash(name)
+	}
+	return "", ""
+}
+
+func estimateTextTokens(value string) int {
+	if value == "" {
+		return 0
+	}
+	tokens := len(value) / 4
+	if tokens == 0 {
+		return 1
+	}
+	return tokens
+}
+
+func compactNumber(value int) string {
+	if value < 1000 {
+		return fmt.Sprintf("%d", value)
+	}
+	if value < 1_000_000 {
+		return trimFloat(float64(value)/1000) + "k"
+	}
+	return trimFloat(float64(value)/1_000_000) + "m"
+}
+
+func trimFloat(value float64) string {
+	text := fmt.Sprintf("%.1f", value)
+	return strings.TrimSuffix(text, ".0")
+}
+
+func maxInt(left int, right int) int {
+	if left > right {
+		return left
+	}
+	return right
+}

--- a/internal/contextreport/contextreport_test.go
+++ b/internal/contextreport/contextreport_test.go
@@ -1,0 +1,249 @@
+package contextreport
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestBuildCountsProjectGuidelinesAndFreeBudget(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "AGENTS.md", strings.Repeat("project rules\n", 200))
+
+	registry := tools.NewRegistry()
+	for _, tool := range tools.CoreTools(root) {
+		registry.Register(tool)
+	}
+
+	report, err := Build(Options{
+		WorkspaceRoot: root,
+		Provider: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			Model:        "gpt-4.1",
+		},
+		Registry:      registry,
+		ContextWindow: 10_000,
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if report.Contract != ContractV1 {
+		t.Fatalf("Contract = %q, want %q", report.Contract, ContractV1)
+	}
+	if report.Runtime != RuntimeGo {
+		t.Fatalf("Runtime = %q, want %q", report.Runtime, RuntimeGo)
+	}
+	if report.Root != root {
+		t.Fatalf("Root = %q, want %q", report.Root, root)
+	}
+	if report.ProviderName != "openai" || report.ModelID != "gpt-4.1" || report.APIModel != "gpt-4.1" {
+		t.Fatalf("provider metadata = %#v", report)
+	}
+	if report.ContextWindow != 10_000 {
+		t.Fatalf("ContextWindow = %d, want 10000", report.ContextWindow)
+	}
+	if report.ProjectGuidelineFile != "AGENTS.md" {
+		t.Fatalf("ProjectGuidelineFile = %q, want AGENTS.md", report.ProjectGuidelineFile)
+	}
+	if report.ToolCount == 0 {
+		t.Fatal("ToolCount = 0, want core tools counted")
+	}
+	if report.UsedTokens <= 0 {
+		t.Fatalf("UsedTokens = %d, want > 0", report.UsedTokens)
+	}
+	if report.FreeTokens <= 0 {
+		t.Fatalf("FreeTokens = %d, want > 0", report.FreeTokens)
+	}
+	if report.FreeTokens+report.UsedTokens != report.ContextWindow {
+		t.Fatalf("free + used = %d, want %d", report.FreeTokens+report.UsedTokens, report.ContextWindow)
+	}
+	if !hasCategory(report, CategoryProjectGuidelines) {
+		t.Fatalf("missing project guideline category: %#v", report.Categories)
+	}
+	if !hasCategory(report, CategoryTools) {
+		t.Fatalf("missing tools category: %#v", report.Categories)
+	}
+	if !hasCategory(report, CategoryFree) {
+		t.Fatalf("missing free category: %#v", report.Categories)
+	}
+}
+
+func TestBuildHasStableJSONContractAndCategoryMath(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "ZERO.md", strings.Repeat("zero rules\n", 16))
+
+	registry := tools.NewRegistry()
+	for _, tool := range tools.CoreTools(root) {
+		registry.Register(tool)
+	}
+
+	report, err := Build(Options{
+		WorkspaceRoot:       root,
+		Registry:            registry,
+		ContextWindow:       50_000,
+		ProjectContextFiles: []string{"AGENTS.md", "ZERO.md"},
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	keys := categoryKeys(report)
+	for _, want := range []string{CategorySystemPrompt, CategoryProjectGuidelines, CategoryTools, CategoryFree} {
+		if !contains(keys, want) {
+			t.Fatalf("missing category %q in %v", want, keys)
+		}
+	}
+	if report.ProjectGuidelineFile != "ZERO.md" {
+		t.Fatalf("ProjectGuidelineFile = %q, want ZERO.md", report.ProjectGuidelineFile)
+	}
+	if report.FreeTokens+report.UsedTokens != report.ContextWindow {
+		t.Fatalf("free + used = %d, want %d", report.FreeTokens+report.UsedTokens, report.ContextWindow)
+	}
+	if report.UsedFraction != float64(report.UsedTokens)/float64(report.ContextWindow) {
+		t.Fatalf("UsedFraction = %v, want used/context ratio", report.UsedFraction)
+	}
+
+	var decoded struct {
+		Contract   string     `json:"contract"`
+		Runtime    string     `json:"runtime"`
+		Categories []Category `json:"categories"`
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if decoded.Contract != ContractV1 || decoded.Runtime != RuntimeGo {
+		t.Fatalf("decoded identity = %q/%q", decoded.Contract, decoded.Runtime)
+	}
+	if len(decoded.Categories) != len(report.Categories) {
+		t.Fatalf("decoded %d categories, want %d", len(decoded.Categories), len(report.Categories))
+	}
+}
+
+func TestBuildClampsFreeBudgetWhenOverContextWindow(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "AGENTS.md", strings.Repeat("very large project rule\n", 1000))
+
+	report, err := Build(Options{
+		WorkspaceRoot: root,
+		ContextWindow: 10,
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if report.UsedTokens <= report.ContextWindow {
+		t.Fatalf("UsedTokens = %d, want over tiny context window %d", report.UsedTokens, report.ContextWindow)
+	}
+	if report.FreeTokens != 0 {
+		t.Fatalf("FreeTokens = %d, want clamp to 0", report.FreeTokens)
+	}
+	free := categoryByKey(report, CategoryFree)
+	if free == nil {
+		t.Fatalf("missing free category: %#v", report.Categories)
+	}
+	if free.Tokens != 0 {
+		t.Fatalf("free category tokens = %d, want 0", free.Tokens)
+	}
+}
+
+func TestBuildWithoutProviderStillReturnsReport(t *testing.T) {
+	root := t.TempDir()
+
+	report, err := Build(Options{WorkspaceRoot: root})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	if report.Root != root {
+		t.Fatalf("Root = %q, want %q", report.Root, root)
+	}
+	if report.ProviderName != "" || report.ModelID != "" || report.APIModel != "" {
+		t.Fatalf("provider fields = %q/%q/%q, want empty", report.ProviderName, report.ModelID, report.APIModel)
+	}
+	if report.ContextWindow != 0 || report.UsedFraction != 0 || report.FreeTokens != 0 {
+		t.Fatalf("unknown budget fields should be zero, got %#v", report)
+	}
+	if !hasCategory(report, CategorySystemPrompt) {
+		t.Fatalf("missing system prompt category: %#v", report.Categories)
+	}
+	if !hasCategory(report, CategoryFree) {
+		t.Fatalf("missing free category: %#v", report.Categories)
+	}
+}
+
+func TestFormatIncludesRootModelAndCategories(t *testing.T) {
+	report := Report{
+		Contract:      ContractV1,
+		Runtime:       RuntimeGo,
+		Root:          "D:/repo",
+		ProviderName:  "openai",
+		ModelID:       "gpt-4.1",
+		APIModel:      "gpt-4.1",
+		ContextWindow: 1000,
+		UsedTokens:    250,
+		FreeTokens:    750,
+		UsedFraction:  0.25,
+		ToolCount:     2,
+		Categories:    []Category{{Key: CategorySystemPrompt, Name: "System prompt", Tokens: 100, Percent: 10}, {Key: CategoryFree, Name: "Free", Tokens: 750, Percent: 75}},
+	}
+
+	formatted := Format(report)
+
+	for _, want := range []string{"Zero context report", "root: D:/repo", "model: gpt-4.1", "api_model: gpt-4.1", "System prompt", "Free"} {
+		if !strings.Contains(formatted, want) {
+			t.Fatalf("Format missing %q:\n%s", want, formatted)
+		}
+	}
+}
+
+func hasCategory(report Report, key string) bool {
+	return categoryByKey(report, key) != nil
+}
+
+func categoryByKey(report Report, key string) *Category {
+	for _, category := range report.Categories {
+		if category.Key == key {
+			return &category
+		}
+	}
+	return nil
+}
+
+func categoryKeys(report Report) []string {
+	keys := make([]string, 0, len(report.Categories))
+	for _, category := range report.Categories {
+		keys = append(keys, category.Key)
+	}
+	return keys
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTestFile(t *testing.T, root string, name string, content string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+}

--- a/internal/contextreport/contextreport_test.go
+++ b/internal/contextreport/contextreport_test.go
@@ -207,6 +207,36 @@ func TestFormatIncludesRootModelAndCategories(t *testing.T) {
 	}
 }
 
+func TestFormatHandlesUnknownContextWindow(t *testing.T) {
+	report := Report{
+		Contract:     ContractV1,
+		Runtime:      RuntimeGo,
+		Root:         "D:/repo",
+		ProviderName: "openai",
+		ModelID:      "gpt-4.1",
+		APIModel:     "gpt-4.1",
+		UsedTokens:   250,
+		ToolCount:    2,
+		Categories:   []Category{{Key: CategorySystemPrompt, Name: "System prompt", Tokens: 100}, {Key: CategoryFree, Name: "Free"}},
+	}
+
+	formatted := Format(report)
+
+	for _, want := range []string{
+		"Zero context report",
+		"root: D:/repo",
+		"model: gpt-4.1",
+		"api_model: gpt-4.1",
+		"usage: 250 tokens (context window unknown)",
+		"System prompt: 100 tokens",
+		"Free: 0 tokens",
+	} {
+		if !strings.Contains(formatted, want) {
+			t.Fatalf("Format missing %q:\n%s", want, formatted)
+		}
+	}
+}
+
 func hasCategory(report Report, key string) bool {
 	return categoryByKey(report, key) != nil
 }


### PR DESCRIPTION
## Summary
- Add a Go-native `contextreport` package that estimates static workspace context usage across system prompt, project guidelines, tools, and free budget.
- Add `zero context` with text and `--json` output for preflight context inspection.
- Expose a small agent system prompt preview helper so the report estimates the real runtime prompt path instead of a placeholder.

## Validation
- `go test ./internal/contextreport ./internal/cli`
- `go test ./...`
- `go run ./cmd/zero context`
- `go run ./cmd/zero context --json`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `zero context` CLI command to report workspace context: resolved workspace root, active model, context window, token usage breakdown (system prompt, project guidelines, tools) and tool count; supports human-readable and JSON (`--json`) output.
* **Documentation**
  * CLI help updated to include the new `context` command and its usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->