### PR TITLE
Test: de-flake the npm-wrapper Windows spawn timeout

### DIFF
--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -162,7 +162,10 @@ func nodeWrapperCommand(ctx context.Context, node string, wrapperPath string, ar
 
 func nodeWrapperTimeout() time.Duration {
 	if runtime.GOOS == "windows" {
-		return 30 * time.Second
+		// Windows CI runners cold-start node slowly under load; 30s intermittently
+		// timed out with empty output (a flake, not a wrapper bug — the same run
+		// passes in ~2.5s on a warm runner), so give the spawn ample headroom.
+		return 90 * time.Second
 	}
 	return 10 * time.Second
 }


### PR DESCRIPTION
`TestNodeWrapperReportsMissingNativeBinary` intermittently hit its **30s Windows deadline with empty output** on the #137 merge run, then **passed in ~2.5s on the next run** — a CI runner flake (cold/contended node spawn), not a wrapper or #137 regression (that package wasn't touched by #137). Raises the Windows timeout to **90s** so a slow cold start has headroom; non-Windows stays 10s. build / Windows-build / package test green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Adjusted test timeout configuration for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->