### PR TITLE
Add provider catalog foundation

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -351,7 +351,7 @@ func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string) int 
 }
 
 func buildProvider(resolved config.ResolvedConfig, deps appDeps) (zeroruntime.Provider, error) {
-	if resolved.Provider == (config.ProviderProfile{}) {
+	if !config.HasProviderProfile(resolved.Provider) {
 		return nil, nil
 	}
 	return deps.newProvider(resolved.Provider)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -34,6 +34,7 @@ var version = "dev"
 type appDeps struct {
 	getwd                func() (string, error)
 	stdin                io.Reader
+	userConfigPath       func() (string, error)
 	resolveConfig        func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
 	resolveMCPConfig     func(workspaceRoot string) (config.MCPConfig, error)
 	newProvider          func(config.ProviderProfile) (zeroruntime.Provider, error)
@@ -75,8 +76,9 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 
 func defaultAppDeps() appDeps {
 	return appDeps{
-		getwd: os.Getwd,
-		stdin: os.Stdin,
+		getwd:          os.Getwd,
+		stdin:          os.Stdin,
+		userConfigPath: config.DefaultUserConfigPath,
 		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
 			options, err := config.DefaultResolveOptions(workspaceRoot)
 			if err != nil {
@@ -213,6 +215,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.stdin == nil {
 		deps.stdin = defaults.stdin
+	}
+	if deps.userConfigPath == nil {
+		deps.userConfigPath = defaults.userConfigPath
 	}
 	if deps.resolveConfig == nil {
 		deps.resolveConfig = defaults.resolveConfig

--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
@@ -385,8 +386,10 @@ func displayCLIValue(value string, fallback string) string {
 
 func formatProviderCatalogValue(value string, fallback string) string {
 	value = displayCLIValue(value, fallback)
-	if strings.ContainsAny(value, " \t\n\"") {
-		return strconv.Quote(value)
+	for _, r := range value {
+		if unicode.IsSpace(r) || unicode.IsControl(r) || r == '"' {
+			return strconv.Quote(value)
+		}
 	}
 	return value
 }

--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -65,6 +65,12 @@ func runProviders(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		}
 		return exitSuccess
 	}
+	if command == "add" {
+		return runProvidersAdd(args, stdout, stderr, deps)
+	}
+	if command == "check" {
+		return runProvidersCheck(args, stdout, stderr, deps)
+	}
 	if command != "list" && command != "current" && command != "catalog" {
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown providers command %q", command))
 	}
@@ -338,7 +344,7 @@ func formatProviderCatalogSummaries(providers []providerCatalogSummary) string {
 }
 
 func formatProviderCatalogLine(provider providerCatalogSummary) string {
-	return fmt.Sprintf("id=%s name=%s transport=%s defaultModel=%s defaultBaseURL=%s authEnvVars=%s requiresAuth=%t local=%t",
+	return fmt.Sprintf("id=%s name=%s transport=%s defaultModel=%s defaultBaseURL=%s authEnvVars=%s requiresAuth=%t local=%t runtimeSupported=%t",
 		formatProviderCatalogValue(provider.ID, "unknown"),
 		formatProviderCatalogValue(provider.Name, "unknown"),
 		formatProviderCatalogValue(provider.Transport, "unknown"),
@@ -347,6 +353,7 @@ func formatProviderCatalogLine(provider providerCatalogSummary) string {
 		formatProviderCatalogValue(strings.Join(provider.AuthEnvVars, ","), "none"),
 		provider.RequiresAuth,
 		provider.Local,
+		provider.RuntimeSupported,
 	)
 }
 
@@ -417,12 +424,25 @@ func writeProvidersHelp(w io.Writer) error {
   zero providers current [flags]
   zero providers list [flags]
   zero providers catalog [flags]
+  zero providers add <catalog-id> [flags]
+  zero providers check [name] [flags]
 
 Inspects resolved provider profiles and provider catalog descriptors without printing secrets.
 
 Flags:
       --json                    Print JSON summary
       --transport <transport>   Filter catalog descriptors by transport
+
+Add flags:
+      --name <name>             Saved provider profile name
+      --model <model>           Override catalog default model
+      --base-url <url>          Override catalog default base URL
+      --api-key-env <name>      Environment variable that contains the API key
+      --auth-header <header>    Custom API-key header name
+      --auth-scheme <scheme>    Auth scheme prefix, for example Bearer or Token
+      --auth-header-value <v>   Exact auth header value; stored in config
+      --header <key=value>      Custom provider header; repeatable
+      --set-active              Make the added provider active
   -h, --help                    Show this help
 `)
 	return err

--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
@@ -14,15 +15,17 @@ import (
 type commandCenterOptions struct {
 	json              bool
 	provider          string
+	transport         string
 	includeDeprecated bool
 }
 
 type configSummary = zerocommands.ConfigSnapshot
 type providerSummary = zerocommands.ProviderSnapshot
 type modelSummary = zerocommands.ModelSnapshot
+type providerCatalogSummary = zerocommands.ProviderCatalogSnapshot
 
 func runConfig(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
-	options, help, err := parseCommandCenterArgs(args, false)
+	options, help, err := parseCommandCenterArgs(args, false, false)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -62,15 +65,31 @@ func runProviders(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 		}
 		return exitSuccess
 	}
-	if command != "list" && command != "current" {
+	if command != "list" && command != "current" && command != "catalog" {
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown providers command %q", command))
 	}
-	options, help, err := parseCommandCenterArgs(args, false)
+	options, help, err := parseCommandCenterArgs(args, false, command == "catalog")
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
 	if help {
 		if err := writeProvidersHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if command == "catalog" {
+		catalog, err := listProviderCatalogSummaries(options)
+		if err != nil {
+			return writeExecUsageError(stderr, err.Error())
+		}
+		if options.json {
+			if err := writePrettyJSON(stdout, map[string]any{"providers": catalog}); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		}
+		if _, err := fmt.Fprintln(stdout, formatProviderCatalogSummaries(catalog)); err != nil {
 			return exitCrash
 		}
 		return exitSuccess
@@ -117,7 +136,7 @@ func runModels(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) > 0 && (args[0] == "list" || args[0] == "ls") {
 		args = args[1:]
 	}
-	options, help, err := parseCommandCenterArgs(args, true)
+	options, help, err := parseCommandCenterArgs(args, true, false)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -160,7 +179,7 @@ func resolveCommandCenterConfig(stderr io.Writer, deps appDeps) (config.Resolved
 	return resolved, exitSuccess
 }
 
-func parseCommandCenterArgs(args []string, allowModelFilters bool) (commandCenterOptions, bool, error) {
+func parseCommandCenterArgs(args []string, allowModelFilters bool, allowProviderCatalogFilters bool) (commandCenterOptions, bool, error) {
 	options := commandCenterOptions{}
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
@@ -179,7 +198,24 @@ func parseCommandCenterArgs(args []string, allowModelFilters bool) (commandCente
 			options.provider = value
 			index = next
 		case allowModelFilters && strings.HasPrefix(arg, "--provider="):
-			options.provider = strings.TrimSpace(strings.TrimPrefix(arg, "--provider="))
+			value, err := requiredInlineFlagValue(arg, "--provider")
+			if err != nil {
+				return options, false, err
+			}
+			options.provider = value
+		case allowProviderCatalogFilters && arg == "--transport":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.transport = value
+			index = next
+		case allowProviderCatalogFilters && strings.HasPrefix(arg, "--transport="):
+			value, err := requiredInlineFlagValue(arg, "--transport")
+			if err != nil {
+				return options, false, err
+			}
+			options.transport = value
 		case strings.HasPrefix(arg, "-"):
 			return options, false, execUsageError{fmt.Sprintf("unknown flag %q", arg)}
 		default:
@@ -213,6 +249,19 @@ func listModelSummaries(registry modelregistry.Registry, options commandCenterOp
 			return summaries[i].ID < summaries[j].ID
 		}
 		return summaries[i].Provider < summaries[j].Provider
+	})
+	return summaries, nil
+}
+
+func listProviderCatalogSummaries(options commandCenterOptions) ([]providerCatalogSummary, error) {
+	summaries, err := zerocommands.ProviderCatalogSnapshots(zerocommands.ProviderCatalogSnapshotOptions{
+		Transport: options.transport,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(summaries, func(i int, j int) bool {
+		return summaries[i].ID < summaries[j].ID
 	})
 	return summaries, nil
 }
@@ -276,6 +325,31 @@ func formatProviderLine(provider providerSummary) string {
 	return line
 }
 
+func formatProviderCatalogSummaries(providers []providerCatalogSummary) string {
+	lines := []string{"Provider Catalog"}
+	if len(providers) == 0 {
+		lines = append(lines, "  (none)")
+		return strings.Join(lines, "\n")
+	}
+	for _, provider := range providers {
+		lines = append(lines, "  "+formatProviderCatalogLine(provider))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatProviderCatalogLine(provider providerCatalogSummary) string {
+	return fmt.Sprintf("id=%s name=%s transport=%s defaultModel=%s defaultBaseURL=%s authEnvVars=%s requiresAuth=%t local=%t",
+		formatProviderCatalogValue(provider.ID, "unknown"),
+		formatProviderCatalogValue(provider.Name, "unknown"),
+		formatProviderCatalogValue(provider.Transport, "unknown"),
+		formatProviderCatalogValue(provider.DefaultModel, "none"),
+		formatProviderCatalogValue(provider.DefaultBaseURL, "none"),
+		formatProviderCatalogValue(strings.Join(provider.AuthEnvVars, ","), "none"),
+		provider.RequiresAuth,
+		provider.Local,
+	)
+}
+
 func formatModelSummaries(models []modelSummary) string {
 	lines := []string{"Models"}
 	if len(models) == 0 {
@@ -298,6 +372,14 @@ func apiKeyState(set bool) string {
 func displayCLIValue(value string, fallback string) string {
 	if strings.TrimSpace(value) == "" {
 		return fallback
+	}
+	return value
+}
+
+func formatProviderCatalogValue(value string, fallback string) string {
+	value = displayCLIValue(value, fallback)
+	if strings.ContainsAny(value, " \t\n\"") {
+		return strconv.Quote(value)
 	}
 	return value
 }
@@ -334,12 +416,14 @@ func writeProvidersHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero providers current [flags]
   zero providers list [flags]
+  zero providers catalog [flags]
 
-Inspects resolved provider profiles without printing secrets.
+Inspects resolved provider profiles and provider catalog descriptors without printing secrets.
 
 Flags:
-      --json      Print JSON summary
-  -h, --help      Show this help
+      --json                    Print JSON summary
+      --transport <transport>   Filter catalog descriptors by transport
+  -h, --help                    Show this help
 `)
 	return err
 }

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -452,6 +452,36 @@ func TestRunProvidersCheckAcceptsAuthHeaderValueCredential(t *testing.T) {
 	}
 }
 
+func TestRunProvidersCheckAcceptsOfficialAuthHeaderValueCredential(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var checked config.ProviderProfile
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:            "manual-openai",
+			ProviderKind:    config.ProviderKindOpenAI,
+			BaseURL:         config.OpenAIBaseURL,
+			AuthHeaderValue: "Bearer direct-secret",
+			Model:           "gpt-4.1",
+		}
+		return config.ResolvedConfig{ActiveProvider: "manual-openai", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+	deps.newProvider = func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+		checked = profile
+		return commandCenterProvider{}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "manual-openai"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if checked.AuthHeaderValue != "Bearer direct-secret" || checked.APIKey != "" {
+		t.Fatalf("checked profile = %#v, want direct auth header value without API key", checked)
+	}
+}
+
 func TestRunProvidersCheckFailsWhenCatalogAuthEnvIsMissing(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -407,6 +407,42 @@ func TestRunProvidersCheckConstructsProvider(t *testing.T) {
 	}
 }
 
+func TestRunProvidersCheckAcceptsAuthHeaderValueCredential(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var checked config.ProviderProfile
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:            "groq",
+			ProviderKind:    config.ProviderKindOpenAICompatible,
+			CatalogID:       "groq",
+			BaseURL:         "https://api.groq.com/openai/v1",
+			APIKeyEnv:       "GROQ_API_KEY",
+			AuthHeader:      "X-API-Key",
+			AuthHeaderValue: "direct-secret",
+			Model:           "llama-3.3-70b-versatile",
+		}
+		return config.ResolvedConfig{ActiveProvider: "groq", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+	deps.newProvider = func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+		checked = profile
+		return commandCenterProvider{}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "groq"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if checked.AuthHeaderValue != "direct-secret" || checked.APIKey != "" {
+		t.Fatalf("checked profile = %#v, want direct auth header value without API key", checked)
+	}
+	if !strings.Contains(stdout.String(), "status: ok") {
+		t.Fatalf("expected successful check output, got %q", stdout.String())
+	}
+}
+
 func TestRunProvidersCheckFailsWhenCatalogAuthEnvIsMissing(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -215,6 +216,14 @@ func TestRunProvidersCatalogListsDescriptors(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestFormatProviderCatalogValueQuotesControlCharacters(t *testing.T) {
+	value := formatProviderCatalogValue("bad\rvalue", "none")
+
+	if value != strconv.Quote("bad\rvalue") {
+		t.Fatalf("formatProviderCatalogValue() = %q, want quoted control character value", value)
 	}
 }
 

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -300,6 +302,140 @@ func TestRunProvidersCatalogRejectsUnknownFlags(t *testing.T) {
 	}
 }
 
+func TestRunProvidersAddWritesCatalogProfile(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	exitCode := runWithDeps([]string{"providers", "add", "groq", "--name", "fast", "--set-active"}, &stdout, &stderr, providerSetupDeps(configPath))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	cfg := readFileConfig(t, configPath)
+	if cfg.ActiveProvider != "fast" {
+		t.Fatalf("ActiveProvider = %q, want fast", cfg.ActiveProvider)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("providers = %#v, want one provider", cfg.Providers)
+	}
+	profile := cfg.Providers[0]
+	if profile.Name != "fast" ||
+		profile.CatalogID != "groq" ||
+		profile.ProviderKind != config.ProviderKindOpenAICompatible ||
+		profile.BaseURL != "https://api.groq.com/openai/v1" ||
+		profile.Model != "llama-3.3-70b-versatile" ||
+		profile.APIKeyEnv != "GROQ_API_KEY" {
+		t.Fatalf("unexpected provider profile: %#v", profile)
+	}
+	if profile.APIKey != "" {
+		t.Fatalf("providers add must not persist raw API keys: %#v", profile)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Added provider fast") || !strings.Contains(output, configPath) {
+		t.Fatalf("unexpected add output: %q", output)
+	}
+}
+
+func TestRunProvidersAddWritesCustomHeaders(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "config.json")
+
+	exitCode := runWithDeps([]string{
+		"providers", "add", "custom-openai-compatible",
+		"--name", "gateway",
+		"--base-url", "https://gateway.example/v1",
+		"--model", "gateway-model",
+		"--api-key-env", "GATEWAY_API_KEY",
+		"--auth-header", "X-API-Key",
+		"--auth-scheme", "Token",
+		"--header", "HTTP-Referer=https://zero.dev",
+		"--header", "X-Title=Zero",
+	}, &stdout, &stderr, providerSetupDeps(configPath))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	profile := readFileConfig(t, configPath).Providers[0]
+	if profile.AuthHeader != "X-API-Key" || profile.AuthScheme != "Token" {
+		t.Fatalf("unexpected auth override: %#v", profile)
+	}
+	if profile.CustomHeaders["HTTP-Referer"] != "https://zero.dev" || profile.CustomHeaders["X-Title"] != "Zero" {
+		t.Fatalf("unexpected custom headers: %#v", profile.CustomHeaders)
+	}
+}
+
+func TestRunProvidersAddRejectsCatalogOnlyTransports(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"providers", "add", "bedrock"}, &stdout, &stderr, providerSetupDeps(filepath.Join(t.TempDir(), "config.json")))
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "native adapter") {
+		t.Fatalf("expected native adapter warning, got %q", stderr.String())
+	}
+}
+
+func TestRunProvidersCheckConstructsProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var checked config.ProviderProfile
+	deps := commandCenterDeps(t)
+	deps.newProvider = func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+		checked = profile
+		return commandCenterProvider{}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "work"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if checked.Name != "work" || checked.Model != "gpt-4.1" {
+		t.Fatalf("checked profile = %#v, want work provider", checked)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Provider check") || !strings.Contains(output, "status: ok") {
+		t.Fatalf("unexpected check output: %q", output)
+	}
+}
+
+func TestRunProvidersCheckFailsWhenCatalogAuthEnvIsMissing(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:         "groq",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			CatalogID:    "groq",
+			BaseURL:      "https://api.groq.com/openai/v1",
+			APIKeyEnv:    "GROQ_API_KEY",
+			Model:        "llama-3.3-70b-versatile",
+		}
+		return config.ResolvedConfig{ActiveProvider: "groq", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "groq"}, &stdout, &stderr, deps)
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected exit code %d, got %d", exitProvider, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "GROQ_API_KEY") || strings.Contains(stderr.String(), "sk-") {
+		t.Fatalf("expected missing env error without secret leak, got %q", stderr.String())
+	}
+}
+
 func TestRunProvidersPositionalHelp(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -411,6 +547,28 @@ func providerCatalogDeps(t *testing.T) appDeps {
 			return nil, nil
 		},
 	}
+}
+
+func providerSetupDeps(configPath string) appDeps {
+	return appDeps{
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+	}
+}
+
+func readFileConfig(t *testing.T, path string) config.FileConfig {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config %s: %v", path, err)
+	}
+	var cfg config.FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config %s: %v\n%s", path, err, string(data))
+	}
+	return cfg
 }
 
 func findProviderCatalogSnapshot(t *testing.T, snapshots []zerocommands.ProviderCatalogSnapshot, id string) zerocommands.ProviderCatalogSnapshot {

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/zerocommands"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -184,6 +186,120 @@ func TestRunProvidersCurrentJSONIncludesRuntimeMetadata(t *testing.T) {
 	}
 }
 
+func TestRunProvidersCatalogListsDescriptors(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"providers", "catalog"}, &stdout, &stderr, providerCatalogDeps(t))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Provider Catalog",
+		"id=openai",
+		"name=OpenAI",
+		"transport=openai",
+		"defaultModel=gpt-4.1",
+		"defaultBaseURL=https://api.openai.com/v1",
+		"authEnvVars=OPENAI_API_KEY",
+		"requiresAuth=true",
+		"local=false",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected providers catalog output to contain %q, got %q", want, output)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunProvidersCatalogJSONIncludesDescriptors(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"providers", "catalog", "--json"}, &stdout, &stderr, providerCatalogDeps(t))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var payload struct {
+		Providers []zerocommands.ProviderCatalogSnapshot `json:"providers"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode providers catalog JSON: %v\n%s", err, stdout.String())
+	}
+	openai := findProviderCatalogSnapshot(t, payload.Providers, "openai")
+	if openai.Name != "OpenAI" ||
+		openai.Transport != "openai" ||
+		openai.DefaultBaseURL != "https://api.openai.com/v1" ||
+		openai.DefaultModel != "gpt-4.1" ||
+		!openai.RequiresAuth ||
+		openai.Local {
+		t.Fatalf("unexpected OpenAI catalog descriptor: %#v", openai)
+	}
+	if len(openai.AuthEnvVars) != 1 || openai.AuthEnvVars[0] != "OPENAI_API_KEY" {
+		t.Fatalf("unexpected OpenAI auth env vars: %#v", openai.AuthEnvVars)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunProvidersCatalogFiltersByTransport(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"providers", "catalog", "--transport", "openai"}, &stdout, &stderr, providerCatalogDeps(t))
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "id=openai") || !strings.Contains(output, "transport=openai") {
+		t.Fatalf("expected OpenAI transport providers in filtered catalog output, got %q", output)
+	}
+	if strings.Contains(output, "(none)") {
+		t.Fatalf("expected non-empty HTTP catalog output, got %q", output)
+	}
+}
+
+func TestRunProvidersCatalogRejectsUnknownTransport(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"providers", "catalog", "--transport", "space-link"}, &stdout, &stderr, providerCatalogDeps(t))
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `unknown provider transport "space-link"`) {
+		t.Fatalf("expected unknown transport error, got %q", stderr.String())
+	}
+}
+
+func TestRunProvidersCatalogRejectsUnknownFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"providers", "catalog", "--include-deprecated"}, &stdout, &stderr, providerCatalogDeps(t))
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `unknown flag "--include-deprecated"`) {
+		t.Fatalf("expected unknown flag error, got %q", stderr.String())
+	}
+}
+
 func TestRunProvidersPositionalHelp(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -194,7 +310,7 @@ func TestRunProvidersPositionalHelp(t *testing.T) {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
 	output := stdout.String()
-	for _, want := range []string{"Usage:", "zero providers", "list", "current"} {
+	for _, want := range []string{"Usage:", "zero providers", "list", "current", "catalog"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("expected providers help to contain %q, got %q", want, output)
 		}
@@ -280,6 +396,33 @@ func commandCenterSecretBaseURLDeps(t *testing.T) appDeps {
 		}, nil
 	}
 	return deps
+}
+
+func providerCatalogDeps(t *testing.T) appDeps {
+	t.Helper()
+
+	return appDeps{
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			t.Fatalf("providers catalog should not resolve runtime config")
+			return config.ResolvedConfig{}, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			t.Fatalf("providers catalog should not construct runtime providers")
+			return nil, nil
+		},
+	}
+}
+
+func findProviderCatalogSnapshot(t *testing.T, snapshots []zerocommands.ProviderCatalogSnapshot, id string) zerocommands.ProviderCatalogSnapshot {
+	t.Helper()
+
+	for _, snapshot := range snapshots {
+		if snapshot.ID == id {
+			return snapshot
+		}
+	}
+	t.Fatalf("catalog descriptor %q not found in %#v", id, snapshots)
+	return zerocommands.ProviderCatalogSnapshot{}
 }
 
 type commandCenterProvider struct{}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -194,7 +194,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
 	}
-	if resolved.Provider == (config.ProviderProfile{}) {
+	if !config.HasProviderProfile(resolved.Provider) {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", "No provider configured. Set OPENAI_MODEL/OPENAI_API_KEY or add .zero/config.json.")
 	}
 	// Evaluate the --reasoning-effort advisory against the EFFECTIVE resolved

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -323,6 +323,7 @@ func selectProviderForCheck(resolved config.ResolvedConfig, name string) (config
 }
 
 func validateProviderRuntimeReady(profile config.ProviderProfile) error {
+	hasCredential := providerProfileHasCredential(profile)
 	if profile.CatalogID != "" {
 		descriptor, err := providercatalog.Require(profile.CatalogID)
 		if err != nil {
@@ -331,7 +332,7 @@ func validateProviderRuntimeReady(profile config.ProviderProfile) error {
 		if !providercatalog.RuntimeSupported(descriptor) {
 			return fmt.Errorf("provider %q uses transport %q: %s", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor))
 		}
-		if descriptor.RequiresAuth && strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.AuthHeaderValue) == "" {
+		if descriptor.RequiresAuth && !hasCredential {
 			apiKeyEnv := strings.TrimSpace(profile.APIKeyEnv)
 			if apiKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
 				apiKeyEnv = descriptor.AuthEnvVars[0]
@@ -345,11 +346,15 @@ func validateProviderRuntimeReady(profile config.ProviderProfile) error {
 	}
 	switch profile.ProviderKind {
 	case config.ProviderKindOpenAI, config.ProviderKindAnthropic, config.ProviderKindGoogle:
-		if strings.TrimSpace(profile.APIKey) == "" {
+		if !hasCredential {
 			return fmt.Errorf("provider %s requires API key", profile.Name)
 		}
 	}
 	return nil
+}
+
+func providerProfileHasCredential(profile config.ProviderProfile) bool {
+	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
 }
 
 func providerKindForDescriptor(descriptor providercatalog.Descriptor) config.ProviderKind {

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -1,0 +1,409 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+type providerAddOptions struct {
+	catalogID       string
+	name            string
+	model           string
+	baseURL         string
+	apiKeyEnv       string
+	authHeader      string
+	authScheme      string
+	authHeaderValue string
+	customHeaders   map[string]string
+	setActive       bool
+	json            bool
+}
+
+type providerCheckOptions struct {
+	name string
+	json bool
+}
+
+func runProvidersAdd(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseProviderAddArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeProvidersHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	profile, err := providerProfileForAdd(options)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	cfg, err := config.UpsertProvider(configPath, profile, options.setActive)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	if options.json {
+		if err := writePrettyJSON(stdout, map[string]any{
+			"configPath":     configPath,
+			"activeProvider": cfg.ActiveProvider,
+			"provider":       zerocommands.ProviderSnapshotFromProfile(profile, cfg.ActiveProvider == profile.Name),
+		}); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "Added provider %s to %s\n", profile.Name, configPath); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runProvidersCheck(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseProviderCheckArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeProvidersHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	resolved, exitCode := resolveCommandCenterConfig(stderr, deps)
+	if exitCode != exitSuccess {
+		return exitCode
+	}
+	profile, err := selectProviderForCheck(resolved, options.name)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if err := validateProviderRuntimeReady(profile); err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
+	}
+	if _, err := deps.newProvider(profile); err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
+	}
+
+	snapshot := zerocommands.ProviderSnapshotFromProfile(profile, profile.Name == resolved.ActiveProvider)
+	if options.json {
+		if err := writePrettyJSON(stdout, map[string]any{"provider": snapshot, "status": "ok"}); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "Provider check\nname: %s\nstatus: ok\nkind: %s\nmodel: %s\napi model: %s\n", snapshot.Name, snapshot.ProviderKind, snapshot.Model, snapshot.APIModel); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseProviderAddArgs(args []string) (providerAddOptions, bool, error) {
+	options := providerAddOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--set-active":
+			options.setActive = true
+		case arg == "--name":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.name = value
+			index = next
+		case strings.HasPrefix(arg, "--name="):
+			value, err := requiredInlineFlagValue(arg, "--name")
+			if err != nil {
+				return options, false, err
+			}
+			options.name = value
+		case arg == "--model":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.model = value
+			index = next
+		case strings.HasPrefix(arg, "--model="):
+			value, err := requiredInlineFlagValue(arg, "--model")
+			if err != nil {
+				return options, false, err
+			}
+			options.model = value
+		case arg == "--base-url":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.baseURL = value
+			index = next
+		case strings.HasPrefix(arg, "--base-url="):
+			value, err := requiredInlineFlagValue(arg, "--base-url")
+			if err != nil {
+				return options, false, err
+			}
+			options.baseURL = value
+		case arg == "--api-key-env":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.apiKeyEnv = value
+			index = next
+		case strings.HasPrefix(arg, "--api-key-env="):
+			value, err := requiredInlineFlagValue(arg, "--api-key-env")
+			if err != nil {
+				return options, false, err
+			}
+			options.apiKeyEnv = value
+		case arg == "--auth-header":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.authHeader = value
+			index = next
+		case strings.HasPrefix(arg, "--auth-header="):
+			value, err := requiredInlineFlagValue(arg, "--auth-header")
+			if err != nil {
+				return options, false, err
+			}
+			options.authHeader = value
+		case arg == "--auth-scheme":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.authScheme = value
+			index = next
+		case strings.HasPrefix(arg, "--auth-scheme="):
+			options.authScheme = strings.TrimSpace(strings.TrimPrefix(arg, "--auth-scheme="))
+		case arg == "--auth-header-value":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.authHeaderValue = value
+			index = next
+		case strings.HasPrefix(arg, "--auth-header-value="):
+			value, err := requiredInlineFlagValue(arg, "--auth-header-value")
+			if err != nil {
+				return options, false, err
+			}
+			options.authHeaderValue = value
+		case arg == "--header":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			if err := addCustomHeader(&options, value); err != nil {
+				return options, false, err
+			}
+			index = next
+		case strings.HasPrefix(arg, "--header="):
+			value, err := requiredInlineFlagValue(arg, "--header")
+			if err != nil {
+				return options, false, err
+			}
+			if err := addCustomHeader(&options, value); err != nil {
+				return options, false, err
+			}
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown flag %q", arg)}
+		default:
+			if options.catalogID != "" {
+				return options, false, execUsageError{fmt.Sprintf("unexpected argument %q", arg)}
+			}
+			options.catalogID = arg
+		}
+	}
+	if strings.TrimSpace(options.catalogID) == "" {
+		return options, false, execUsageError{"provider catalog id is required"}
+	}
+	return options, false, nil
+}
+
+func parseProviderCheckArgs(args []string) (providerCheckOptions, bool, error) {
+	options := providerCheckOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown flag %q", arg)}
+		default:
+			if options.name != "" {
+				return options, false, execUsageError{fmt.Sprintf("unexpected argument %q", arg)}
+			}
+			options.name = arg
+		}
+	}
+	return options, false, nil
+}
+
+func addCustomHeader(options *providerAddOptions, value string) error {
+	key, headerValue, ok := strings.Cut(value, "=")
+	key = strings.TrimSpace(key)
+	if !ok || key == "" {
+		return execUsageError{fmt.Sprintf("invalid header %q; want key=value", value)}
+	}
+	if options.customHeaders == nil {
+		options.customHeaders = map[string]string{}
+	}
+	options.customHeaders[key] = strings.TrimSpace(headerValue)
+	return nil
+}
+
+func providerProfileForAdd(options providerAddOptions) (config.ProviderProfile, error) {
+	descriptor, err := providercatalog.Require(options.catalogID)
+	if err != nil {
+		return config.ProviderProfile{}, err
+	}
+	if !providercatalog.RuntimeSupported(descriptor) {
+		return config.ProviderProfile{}, fmt.Errorf("provider %q uses transport %q: %s", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor))
+	}
+	name := strings.TrimSpace(options.name)
+	if name == "" {
+		name = descriptor.ID
+	}
+	apiKeyEnv := strings.TrimSpace(options.apiKeyEnv)
+	if apiKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
+		apiKeyEnv = descriptor.AuthEnvVars[0]
+	}
+	profile := config.ProviderProfile{
+		Name:            name,
+		ProviderKind:    providerKindForDescriptor(descriptor),
+		CatalogID:       descriptor.ID,
+		BaseURL:         firstNonEmptyCLI(options.baseURL, descriptor.DefaultBaseURL),
+		APIKeyEnv:       apiKeyEnv,
+		APIFormat:       firstAPIFormat(descriptor),
+		AuthHeader:      strings.TrimSpace(options.authHeader),
+		AuthScheme:      normalizeAuthScheme(options.authScheme),
+		AuthHeaderValue: strings.TrimSpace(options.authHeaderValue),
+		CustomHeaders:   copyProviderHeaders(options.customHeaders),
+		Model:           firstNonEmptyCLI(options.model, descriptor.DefaultModel),
+	}
+	return profile, nil
+}
+
+func selectProviderForCheck(resolved config.ResolvedConfig, name string) (config.ProviderProfile, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		if config.HasProviderProfile(resolved.Provider) {
+			return resolved.Provider, nil
+		}
+		return config.ProviderProfile{}, fmt.Errorf("no active provider configured")
+	}
+	for _, profile := range resolved.Providers {
+		if profile.Name == name {
+			return profile, nil
+		}
+	}
+	return config.ProviderProfile{}, fmt.Errorf("provider %q not found", name)
+}
+
+func validateProviderRuntimeReady(profile config.ProviderProfile) error {
+	if profile.CatalogID != "" {
+		descriptor, err := providercatalog.Require(profile.CatalogID)
+		if err != nil {
+			return err
+		}
+		if !providercatalog.RuntimeSupported(descriptor) {
+			return fmt.Errorf("provider %q uses transport %q: %s", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor))
+		}
+		if descriptor.RequiresAuth && strings.TrimSpace(profile.APIKey) == "" {
+			apiKeyEnv := strings.TrimSpace(profile.APIKeyEnv)
+			if apiKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
+				apiKeyEnv = descriptor.AuthEnvVars[0]
+			}
+			if apiKeyEnv != "" {
+				return fmt.Errorf("provider %s requires API key; set %s", profile.Name, apiKeyEnv)
+			}
+			return fmt.Errorf("provider %s requires API key", profile.Name)
+		}
+		return nil
+	}
+	switch profile.ProviderKind {
+	case config.ProviderKindOpenAI, config.ProviderKindAnthropic, config.ProviderKindGoogle:
+		if strings.TrimSpace(profile.APIKey) == "" {
+			return fmt.Errorf("provider %s requires API key", profile.Name)
+		}
+	}
+	return nil
+}
+
+func providerKindForDescriptor(descriptor providercatalog.Descriptor) config.ProviderKind {
+	switch descriptor.Transport {
+	case providercatalog.TransportOpenAI:
+		return config.ProviderKindOpenAI
+	case providercatalog.TransportAnthropic:
+		return config.ProviderKindAnthropic
+	case providercatalog.TransportAnthropicCompatible:
+		return config.ProviderKindAnthropicCompat
+	case providercatalog.TransportGoogle:
+		return config.ProviderKindGoogle
+	case providercatalog.TransportOpenAICompatible:
+		return config.ProviderKindOpenAICompatible
+	default:
+		return config.ProviderKind(strings.ToLower(string(descriptor.Transport)))
+	}
+}
+
+func firstAPIFormat(descriptor providercatalog.Descriptor) string {
+	if descriptor.Transport == providercatalog.TransportOpenAI || descriptor.Transport == providercatalog.TransportOpenAICompatible {
+		return string(providercatalog.APIFormatOpenAIChatCompletions)
+	}
+	if len(descriptor.SupportedAPIFormats) == 0 {
+		return ""
+	}
+	return string(descriptor.SupportedAPIFormats[0])
+}
+
+func firstNonEmptyCLI(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizeAuthScheme(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, "none") || strings.EqualFold(value, "raw") {
+		return ""
+	}
+	return value
+}
+
+func copyProviderHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
+}

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -331,7 +331,7 @@ func validateProviderRuntimeReady(profile config.ProviderProfile) error {
 		if !providercatalog.RuntimeSupported(descriptor) {
 			return fmt.Errorf("provider %q uses transport %q: %s", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor))
 		}
-		if descriptor.RequiresAuth && strings.TrimSpace(profile.APIKey) == "" {
+		if descriptor.RequiresAuth && strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.AuthHeaderValue) == "" {
 			apiKeyEnv := strings.TrimSpace(profile.APIKeyEnv)
 			if apiKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
 				apiKeyEnv = descriptor.AuthEnvVars[0]

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -30,7 +30,7 @@ func LoadProviderCommand(command string) (FileConfig, error) {
 		return FileConfig{}, fmt.Errorf("provider command returned no providers")
 	}
 
-	providers, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, map[string]string{})
+	providers, _, err := normalizeProvidersWithoutModelDefaults(cfg.Providers, cfg.ActiveProvider, map[string]string{})
 	if err != nil {
 		return FileConfig{}, err
 	}

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -30,7 +30,7 @@ func LoadProviderCommand(command string) (FileConfig, error) {
 		return FileConfig{}, fmt.Errorf("provider command returned no providers")
 	}
 
-	providers, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider)
+	providers, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, nil)
 	if err != nil {
 		return FileConfig{}, err
 	}

--- a/internal/config/command.go
+++ b/internal/config/command.go
@@ -30,7 +30,7 @@ func LoadProviderCommand(command string) (FileConfig, error) {
 		return FileConfig{}, fmt.Errorf("provider command returned no providers")
 	}
 
-	providers, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, nil)
+	providers, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, map[string]string{})
 	if err != nil {
 		return FileConfig{}, err
 	}

--- a/internal/config/command_test.go
+++ b/internal/config/command_test.go
@@ -28,6 +28,26 @@ func TestLoadProviderCommandSuccess(t *testing.T) {
 	}
 }
 
+func TestLoadProviderCommandDoesNotResolveAPIKeyEnvFromProcess(t *testing.T) {
+	t.Setenv("ZERO_CMD_API_KEY", "sk-process")
+	command := writeCommand(t, commandScript{
+		Stdout: `{"name":"cmd","provider":"openai","apiKeyEnv":"ZERO_CMD_API_KEY","model":"gpt-command"}`,
+	})
+
+	cfg, err := LoadProviderCommand(command)
+	if err != nil {
+		t.Fatalf("LoadProviderCommand() error = %v", err)
+	}
+
+	provider := cfg.Providers[0]
+	if provider.APIKey != "" {
+		t.Fatalf("APIKey = %q, want unresolved provider-command apiKeyEnv", provider.APIKey)
+	}
+	if provider.APIKeyEnv != "ZERO_CMD_API_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want command apiKeyEnv preserved", provider.APIKeyEnv)
+	}
+}
+
 func TestLoadProviderCommandFailureIncludesExitAndRedactsOutput(t *testing.T) {
 	command := writeCommand(t, commandScript{
 		Stderr:   "failed with sk-command-secret",

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -10,12 +10,12 @@ import (
 // DefaultResolveOptions builds config resolution inputs from the local process
 // environment and workspace.
 func DefaultResolveOptions(workspaceRoot string) (ResolveOptions, error) {
-	userConfigDir, err := os.UserConfigDir()
+	userConfigPath, err := DefaultUserConfigPath()
 	if err != nil {
-		return ResolveOptions{}, fmt.Errorf("resolve user config directory: %w", err)
+		return ResolveOptions{}, err
 	}
 
-	userConfigPath, err := existingConfigFile(filepath.Join(userConfigDir, "zero", "config.json"))
+	userConfigPath, err = existingConfigFile(userConfigPath)
 	if err != nil {
 		return ResolveOptions{}, err
 	}
@@ -30,6 +30,14 @@ func DefaultResolveOptions(workspaceRoot string) (ResolveOptions, error) {
 		ProjectConfigPath: projectConfigPath,
 		ProviderCommand:   strings.TrimSpace(os.Getenv("ZERO_PROVIDER_COMMAND")),
 	}, nil
+}
+
+func DefaultUserConfigPath() (string, error) {
+	userConfigDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user config directory: %w", err)
+	}
+	return filepath.Join(userConfigDir, "zero", "config.json"), nil
 }
 
 func existingConfigFile(path string) (string, error) {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -18,15 +18,21 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		MaxTurns: defaultMaxTurns,
 	}
 
-	for _, path := range []string{options.UserConfigPath, options.ProjectConfigPath} {
-		if path == "" {
-			continue
-		}
-		fileConfig, err := loadConfigFile(path)
+	if options.UserConfigPath != "" {
+		fileConfig, err := loadConfigFile(options.UserConfigPath)
 		if err != nil {
 			return ResolvedConfig{}, err
 		}
 		mergeConfig(&cfg, fileConfig)
+	}
+	if options.ProjectConfigPath != "" {
+		fileConfig, err := loadConfigFile(options.ProjectConfigPath)
+		if err != nil {
+			return ResolvedConfig{}, err
+		}
+		if err := mergeProjectConfig(&cfg, fileConfig); err != nil {
+			return ResolvedConfig{}, err
+		}
 	}
 
 	applyEnv(&cfg, options.Env)
@@ -98,14 +104,26 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	mergeMCPConfig(&dst.MCP, src.MCP)
 }
 
+func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
+	if activeProvider := strings.TrimSpace(src.ActiveProvider); activeProvider != "" {
+		dst.ActiveProvider = activeProvider
+	}
+	if src.MaxTurns > 0 {
+		dst.MaxTurns = src.MaxTurns
+	}
+	for _, provider := range src.Providers {
+		candidate := providerMergeCandidate(*dst, provider)
+		if err := validateProjectProviderMerge(provider, candidate); err != nil {
+			return err
+		}
+		mergeProvider(dst, provider)
+	}
+	mergeMCPConfig(&dst.MCP, src.MCP)
+	return nil
+}
+
 func mergeProvider(cfg *FileConfig, provider ProviderProfile) {
-	provider.Name = strings.TrimSpace(provider.Name)
-	if provider.Name == "" {
-		provider.Name = strings.TrimSpace(cfg.ActiveProvider)
-	}
-	if provider.Name == "" {
-		provider.Name = string(ProviderKindOpenAI)
-	}
+	provider.Name = providerMergeName(*cfg, provider)
 
 	for index := range cfg.Providers {
 		if cfg.Providers[index].Name == provider.Name {
@@ -114,6 +132,138 @@ func mergeProvider(cfg *FileConfig, provider ProviderProfile) {
 		}
 	}
 	cfg.Providers = append(cfg.Providers, provider)
+}
+
+func providerMergeCandidate(cfg FileConfig, provider ProviderProfile) ProviderProfile {
+	provider.Name = providerMergeName(cfg, provider)
+	for _, existing := range cfg.Providers {
+		if existing.Name == provider.Name {
+			return mergeProfile(existing, provider)
+		}
+	}
+	return provider
+}
+
+func providerMergeName(cfg FileConfig, provider ProviderProfile) string {
+	name := strings.TrimSpace(provider.Name)
+	if name == "" {
+		name = strings.TrimSpace(cfg.ActiveProvider)
+	}
+	if name == "" {
+		name = string(ProviderKindOpenAI)
+	}
+	return name
+}
+
+func validateProjectProviderMerge(project ProviderProfile, candidate ProviderProfile) error {
+	if strings.TrimSpace(project.APIKeyEnv) != "" &&
+		projectEndpointNeedsCredentialGuard(candidate) &&
+		!projectAPIKeyEnvAllowed(candidate, project.APIKeyEnv) {
+		return providerError(candidate, "project provider %s cannot bind apiKeyEnv to custom provider endpoint", candidate.Name)
+	}
+	if strings.TrimSpace(project.BaseURL) != "" &&
+		projectEndpointNeedsCredentialGuard(candidate) &&
+		hasInheritedProviderCredentialMaterial(project, candidate) &&
+		!projectBaseURLAllowed(candidate) {
+		return providerError(candidate, "project provider %s cannot override baseURL for a credentialed custom provider endpoint", candidate.Name)
+	}
+	return nil
+}
+
+func projectEndpointNeedsCredentialGuard(profile ProviderProfile) bool {
+	kind := effectiveProviderKind(profile)
+	switch kind {
+	case ProviderKindOpenAICompatible, ProviderKindAnthropicCompat:
+		return strings.TrimSpace(profile.BaseURL) != "" || strings.TrimSpace(profile.CatalogID) != ""
+	case ProviderKindOpenAI:
+		return profile.BaseURL != "" && !isOfficialOpenAIBaseURL(profile.BaseURL)
+	case ProviderKindAnthropic:
+		return profile.BaseURL != "" && !isOfficialAnthropicBaseURL(profile.BaseURL)
+	case ProviderKindGoogle:
+		return profile.BaseURL != "" && !isOfficialGoogleBaseURL(profile.BaseURL)
+	default:
+		return strings.TrimSpace(profile.BaseURL) != ""
+	}
+}
+
+func projectAPIKeyEnvAllowed(profile ProviderProfile, envName string) bool {
+	descriptor, ok := catalogDescriptorForProfile(profile)
+	if !ok {
+		return false
+	}
+	baseURL := strings.TrimSpace(profile.BaseURL)
+	if baseURL == "" {
+		baseURL = descriptor.DefaultBaseURL
+	}
+	if !sameBaseURL(baseURL, descriptor.DefaultBaseURL) {
+		return false
+	}
+	return containsStringFold(descriptor.AuthEnvVars, envName)
+}
+
+func projectBaseURLAllowed(profile ProviderProfile) bool {
+	descriptor, ok := catalogDescriptorForProfile(profile)
+	return ok && sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)
+}
+
+func hasInheritedProviderCredentialMaterial(project ProviderProfile, candidate ProviderProfile) bool {
+	if strings.TrimSpace(project.APIKey) == "" && strings.TrimSpace(candidate.APIKey) != "" {
+		return true
+	}
+	if strings.TrimSpace(project.APIKeyEnv) == "" && strings.TrimSpace(candidate.APIKeyEnv) != "" {
+		return true
+	}
+	if strings.TrimSpace(project.AuthHeaderValue) == "" && strings.TrimSpace(candidate.AuthHeaderValue) != "" {
+		return true
+	}
+	if project.CustomHeaders == nil && hasCustomHeaderMaterial(candidate.CustomHeaders) {
+		return true
+	}
+	return false
+}
+
+func hasCustomHeaderMaterial(headers map[string]string) bool {
+	for _, value := range headers {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func effectiveProviderKind(profile ProviderProfile) ProviderKind {
+	if kind := ProviderKind(strings.TrimSpace(strings.ToLower(string(profile.ProviderKind)))); kind != "" {
+		return kind
+	}
+	if provider := strings.TrimSpace(strings.ToLower(profile.Provider)); provider != "" {
+		return ProviderKind(provider)
+	}
+	if descriptor, ok := catalogDescriptorForProfile(profile); ok {
+		return providerKindForCatalogTransport(descriptor.Transport)
+	}
+	return ""
+}
+
+func catalogDescriptorForProfile(profile ProviderProfile) (providercatalog.Descriptor, bool) {
+	catalogID := providercatalog.NormalizeID(profile.CatalogID)
+	if catalogID == "" {
+		return providercatalog.Descriptor{}, false
+	}
+	descriptor, err := providercatalog.Require(catalogID)
+	if err != nil {
+		return providercatalog.Descriptor{}, false
+	}
+	return descriptor, true
+}
+
+func containsStringFold(values []string, target string) bool {
+	target = strings.TrimSpace(target)
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), target) {
+			return true
+		}
+	}
+	return false
 }
 
 func mergeProfile(base ProviderProfile, next ProviderProfile) ProviderProfile {
@@ -387,6 +537,7 @@ func normalizeProvider(profile ProviderProfile, env map[string]string, options n
 	profile.ProviderKind = ProviderKind(strings.TrimSpace(strings.ToLower(string(profile.ProviderKind))))
 	profile.CatalogID = providercatalog.NormalizeID(profile.CatalogID)
 	profile.BaseURL = strings.TrimSpace(profile.BaseURL)
+	explicitBaseURL := profile.BaseURL != ""
 	profile.APIKeyEnv = strings.TrimSpace(profile.APIKeyEnv)
 	profile.APIFormat = strings.TrimSpace(profile.APIFormat)
 	profile.AuthHeader = strings.TrimSpace(profile.AuthHeader)
@@ -405,7 +556,7 @@ func normalizeProvider(profile ProviderProfile, env map[string]string, options n
 		if !providercatalog.RuntimeSupported(descriptor) {
 			return ProviderProfile{}, providerError(profile, "provider %q uses transport %q: %s", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor))
 		}
-		applyCatalogDescriptor(&profile, descriptor)
+		applyCatalogDescriptor(&profile, descriptor, explicitBaseURL)
 	}
 	if profile.ProviderKind == "" && profile.Provider != "" {
 		profile.ProviderKind = ProviderKind(strings.ToLower(profile.Provider))
@@ -460,7 +611,7 @@ func normalizeProvider(profile ProviderProfile, env map[string]string, options n
 	}
 }
 
-func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog.Descriptor) {
+func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog.Descriptor, explicitBaseURL bool) {
 	if descriptor.ID != "" {
 		profile.CatalogID = descriptor.ID
 	}
@@ -473,9 +624,16 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 	if profile.Model == "" {
 		profile.Model = descriptor.DefaultModel
 	}
-	if profile.APIKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
+	if profile.APIKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 && (!explicitBaseURL || sameBaseURL(profile.BaseURL, descriptor.DefaultBaseURL)) {
 		profile.APIKeyEnv = descriptor.AuthEnvVars[0]
 	}
+}
+
+func sameBaseURL(left string, right string) bool {
+	return strings.EqualFold(
+		strings.TrimRight(strings.TrimSpace(left), "/"),
+		strings.TrimRight(strings.TrimSpace(right), "/"),
+	)
 }
 
 func isOfficialAnthropicBaseURL(baseURL string) bool {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providercatalog"
 )
 
 const defaultMaxTurns = 12
@@ -39,7 +40,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 
 	applyOverrides(&cfg, options.Overrides)
 
-	providers, active, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider)
+	providers, active, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, options.Env)
 	if err != nil {
 		return ResolvedConfig{}, err
 	}
@@ -124,11 +125,32 @@ func mergeProfile(base ProviderProfile, next ProviderProfile) ProviderProfile {
 	if next.ProviderKind != "" {
 		base.ProviderKind = next.ProviderKind
 	}
+	if next.CatalogID != "" {
+		base.CatalogID = next.CatalogID
+	}
 	if next.BaseURL != "" {
 		base.BaseURL = next.BaseURL
 	}
 	if next.APIKey != "" {
 		base.APIKey = next.APIKey
+	}
+	if next.APIKeyEnv != "" {
+		base.APIKeyEnv = next.APIKeyEnv
+	}
+	if next.APIFormat != "" {
+		base.APIFormat = next.APIFormat
+	}
+	if next.AuthHeader != "" {
+		base.AuthHeader = next.AuthHeader
+	}
+	if next.AuthScheme != "" {
+		base.AuthScheme = next.AuthScheme
+	}
+	if next.AuthHeaderValue != "" {
+		base.AuthHeaderValue = next.AuthHeaderValue
+	}
+	if next.CustomHeaders != nil {
+		base.CustomHeaders = copyStringMap(next.CustomHeaders)
 	}
 	if next.Model != "" {
 		base.Model = next.Model
@@ -304,17 +326,15 @@ func copyMCPStringMap(values map[string]string) map[string]string {
 }
 
 func hasProviderFields(profile ProviderProfile) bool {
-	return profile.Name != "" ||
-		profile.Provider != "" ||
-		profile.ProviderKind != "" ||
-		profile.BaseURL != "" ||
-		profile.APIKey != "" ||
-		profile.Model != "" ||
-		profile.Description != ""
+	return HasProviderProfile(profile)
 }
 
-func normalizeProviders(providers []ProviderProfile, activeName string) ([]ProviderProfile, ProviderProfile, error) {
+func normalizeProviders(providers []ProviderProfile, activeName string, envMaps ...map[string]string) ([]ProviderProfile, ProviderProfile, error) {
 	activeName = strings.TrimSpace(activeName)
+	var env map[string]string
+	if len(envMaps) > 0 {
+		env = envMaps[0]
+	}
 	if len(providers) == 0 {
 		if activeName != "" {
 			return nil, ProviderProfile{}, fmt.Errorf("active provider %q not found", activeName)
@@ -330,7 +350,7 @@ func normalizeProviders(providers []ProviderProfile, activeName string) ([]Provi
 	var active ProviderProfile
 	activeFound := false
 	for _, provider := range providers {
-		next, err := normalizeProvider(provider)
+		next, err := normalizeProvider(provider, env)
 		if err != nil {
 			return nil, ProviderProfile{}, err
 		}
@@ -351,21 +371,37 @@ func normalizeProviders(providers []ProviderProfile, activeName string) ([]Provi
 	return normalized, active, nil
 }
 
-func normalizeProvider(profile ProviderProfile) (ProviderProfile, error) {
+func normalizeProvider(profile ProviderProfile, env map[string]string) (ProviderProfile, error) {
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.Provider = strings.TrimSpace(profile.Provider)
 	profile.ProviderKind = ProviderKind(strings.TrimSpace(strings.ToLower(string(profile.ProviderKind))))
+	profile.CatalogID = providercatalog.NormalizeID(profile.CatalogID)
 	profile.BaseURL = strings.TrimSpace(profile.BaseURL)
+	profile.APIKeyEnv = strings.TrimSpace(profile.APIKeyEnv)
+	profile.APIFormat = strings.TrimSpace(profile.APIFormat)
+	profile.AuthHeader = strings.TrimSpace(profile.AuthHeader)
+	profile.AuthScheme = strings.TrimSpace(profile.AuthScheme)
+	profile.AuthHeaderValue = strings.TrimSpace(profile.AuthHeaderValue)
 	profile.Model = strings.TrimSpace(profile.Model)
 
 	if profile.Name == "" {
 		profile.Name = string(ProviderKindOpenAI)
+	}
+	if profile.CatalogID != "" {
+		descriptor, err := providercatalog.Require(profile.CatalogID)
+		if err != nil {
+			return ProviderProfile{}, providerError(profile, "%s", err.Error())
+		}
+		applyCatalogDescriptor(&profile, descriptor)
 	}
 	if profile.ProviderKind == "" && profile.Provider != "" {
 		profile.ProviderKind = ProviderKind(strings.ToLower(profile.Provider))
 	}
 	if profile.ProviderKind == "" {
 		profile.ProviderKind = ProviderKindOpenAI
+	}
+	if strings.TrimSpace(profile.APIKey) == "" && profile.APIKeyEnv != "" {
+		profile.APIKey = strings.TrimSpace(envValue(env, profile.APIKeyEnv))
 	}
 
 	switch profile.ProviderKind {
@@ -388,6 +424,14 @@ func normalizeProvider(profile ProviderProfile) (ProviderProfile, error) {
 			profile.BaseURL = AnthropicBaseURL
 		}
 		return profile, nil
+	case ProviderKindAnthropicCompat:
+		if profile.BaseURL == "" {
+			return ProviderProfile{}, providerError(profile, "anthropic-compatible provider %s requires baseURL", profile.Name)
+		}
+		if strings.TrimRight(profile.BaseURL, "/") == strings.TrimRight(AnthropicBaseURL, "/") {
+			return ProviderProfile{}, providerError(profile, "anthropic-compatible provider %s requires custom baseURL", profile.Name)
+		}
+		return profile, nil
 	case ProviderKindGoogle:
 		if profile.BaseURL == "" {
 			profile.BaseURL = GoogleBaseURL
@@ -395,6 +439,41 @@ func normalizeProvider(profile ProviderProfile) (ProviderProfile, error) {
 		return profile, nil
 	default:
 		return ProviderProfile{}, providerError(profile, "unknown provider kind %q for provider %s", profile.ProviderKind, profile.Name)
+	}
+}
+
+func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog.Descriptor) {
+	if descriptor.ID != "" {
+		profile.CatalogID = descriptor.ID
+	}
+	if profile.ProviderKind == "" && strings.TrimSpace(profile.Provider) == "" {
+		profile.ProviderKind = providerKindForCatalogTransport(descriptor.Transport)
+	}
+	if profile.BaseURL == "" {
+		profile.BaseURL = descriptor.DefaultBaseURL
+	}
+	if profile.Model == "" {
+		profile.Model = descriptor.DefaultModel
+	}
+	if profile.APIKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
+		profile.APIKeyEnv = descriptor.AuthEnvVars[0]
+	}
+}
+
+func providerKindForCatalogTransport(transport providercatalog.Transport) ProviderKind {
+	switch transport {
+	case providercatalog.TransportOpenAI:
+		return ProviderKindOpenAI
+	case providercatalog.TransportAnthropic:
+		return ProviderKindAnthropic
+	case providercatalog.TransportAnthropicCompatible:
+		return ProviderKindAnthropicCompat
+	case providercatalog.TransportGoogle:
+		return ProviderKindGoogle
+	case providercatalog.TransportOpenAICompatible:
+		return ProviderKindOpenAICompatible
+	default:
+		return ProviderKind(strings.ToLower(string(transport)))
 	}
 }
 
@@ -410,5 +489,5 @@ func providerError(profile ProviderProfile, format string, args ...any) error {
 	if profile.APIKey != "" {
 		message += " (apiKey=[REDACTED])"
 	}
-	return fmt.Errorf("%s", redactSecrets(message, profile.APIKey))
+	return fmt.Errorf("%s", redactSecrets(message, profile.APIKey, profile.AuthHeaderValue))
 }

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -428,7 +429,7 @@ func normalizeProvider(profile ProviderProfile, env map[string]string) (Provider
 		if profile.BaseURL == "" {
 			return ProviderProfile{}, providerError(profile, "anthropic-compatible provider %s requires baseURL", profile.Name)
 		}
-		if strings.TrimRight(profile.BaseURL, "/") == strings.TrimRight(AnthropicBaseURL, "/") {
+		if isOfficialAnthropicBaseURL(profile.BaseURL) {
 			return ProviderProfile{}, providerError(profile, "anthropic-compatible provider %s requires custom baseURL", profile.Name)
 		}
 		return profile, nil
@@ -458,6 +459,22 @@ func applyCatalogDescriptor(profile *ProviderProfile, descriptor providercatalog
 	if profile.APIKeyEnv == "" && len(descriptor.AuthEnvVars) > 0 {
 		profile.APIKeyEnv = descriptor.AuthEnvVars[0]
 	}
+}
+
+func isOfficialAnthropicBaseURL(baseURL string) bool {
+	normalized := strings.TrimSpace(baseURL)
+	if strings.TrimRight(normalized, "/") == strings.TrimRight(AnthropicBaseURL, "/") {
+		return true
+	}
+	parsed, err := url.Parse(normalized)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	official, err := url.Parse(AnthropicBaseURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, official.Host)
 }
 
 func providerKindForCatalogTransport(transport providercatalog.Transport) ProviderKind {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -199,9 +199,6 @@ func applyProviderEnv(cfg *FileConfig, providerKind ProviderKind, env envProfile
 	apiKey := strings.TrimSpace(env.APIKey)
 	baseURL := strings.TrimSpace(env.BaseURL)
 	model := strings.TrimSpace(env.Model)
-	if providerKind == ProviderKindOpenAI && apiKey != "" && model == "" && isOfficialOpenAIBaseURL(baseURL) {
-		model = modelregistry.DefaultModelID
-	}
 	if apiKey == "" && baseURL == "" && model == "" {
 		return
 	}
@@ -330,7 +327,19 @@ func hasProviderFields(profile ProviderProfile) bool {
 	return HasProviderProfile(profile)
 }
 
+type normalizeOptions struct {
+	defaultOpenAIModel bool
+}
+
 func normalizeProviders(providers []ProviderProfile, activeName string, envMaps ...map[string]string) ([]ProviderProfile, ProviderProfile, error) {
+	return normalizeProvidersWithOptions(providers, activeName, normalizeOptions{defaultOpenAIModel: true}, envMaps...)
+}
+
+func normalizeProvidersWithoutModelDefaults(providers []ProviderProfile, activeName string, envMaps ...map[string]string) ([]ProviderProfile, ProviderProfile, error) {
+	return normalizeProvidersWithOptions(providers, activeName, normalizeOptions{}, envMaps...)
+}
+
+func normalizeProvidersWithOptions(providers []ProviderProfile, activeName string, options normalizeOptions, envMaps ...map[string]string) ([]ProviderProfile, ProviderProfile, error) {
 	activeName = strings.TrimSpace(activeName)
 	var env map[string]string
 	if len(envMaps) > 0 {
@@ -351,7 +360,7 @@ func normalizeProviders(providers []ProviderProfile, activeName string, envMaps 
 	var active ProviderProfile
 	activeFound := false
 	for _, provider := range providers {
-		next, err := normalizeProvider(provider, env)
+		next, err := normalizeProvider(provider, env, options)
 		if err != nil {
 			return nil, ProviderProfile{}, err
 		}
@@ -372,7 +381,7 @@ func normalizeProviders(providers []ProviderProfile, activeName string, envMaps 
 	return normalized, active, nil
 }
 
-func normalizeProvider(profile ProviderProfile, env map[string]string) (ProviderProfile, error) {
+func normalizeProvider(profile ProviderProfile, env map[string]string, options normalizeOptions) (ProviderProfile, error) {
 	profile.Name = strings.TrimSpace(profile.Name)
 	profile.Provider = strings.TrimSpace(profile.Provider)
 	profile.ProviderKind = ProviderKind(strings.TrimSpace(strings.ToLower(string(profile.ProviderKind))))
@@ -393,6 +402,9 @@ func normalizeProvider(profile ProviderProfile, env map[string]string) (Provider
 		if err != nil {
 			return ProviderProfile{}, providerError(profile, "%s", err.Error())
 		}
+		if !providercatalog.RuntimeSupported(descriptor) {
+			return ProviderProfile{}, providerError(profile, "provider %q uses transport %q: %s", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor))
+		}
 		applyCatalogDescriptor(&profile, descriptor)
 	}
 	if profile.ProviderKind == "" && profile.Provider != "" {
@@ -409,6 +421,9 @@ func normalizeProvider(profile ProviderProfile, env map[string]string) (Provider
 	case ProviderKindOpenAI:
 		if profile.BaseURL == "" || isOfficialOpenAIBaseURL(profile.BaseURL) {
 			profile.BaseURL = OpenAIBaseURL
+			if options.defaultOpenAIModel && profile.Model == "" {
+				profile.Model = modelregistry.DefaultModelID
+			}
 			return profile, nil
 		}
 		return ProviderProfile{}, providerError(profile, "openai provider %s requires official baseURL %s", profile.Name, OpenAIBaseURL)
@@ -421,10 +436,11 @@ func normalizeProvider(profile ProviderProfile, env map[string]string) (Provider
 		}
 		return profile, nil
 	case ProviderKindAnthropic:
-		if profile.BaseURL == "" {
+		if profile.BaseURL == "" || isOfficialAnthropicBaseURL(profile.BaseURL) {
 			profile.BaseURL = AnthropicBaseURL
+			return profile, nil
 		}
-		return profile, nil
+		return ProviderProfile{}, providerError(profile, "anthropic provider %s requires official baseURL %s", profile.Name, AnthropicBaseURL)
 	case ProviderKindAnthropicCompat:
 		if profile.BaseURL == "" {
 			return ProviderProfile{}, providerError(profile, "anthropic-compatible provider %s requires baseURL", profile.Name)
@@ -434,10 +450,11 @@ func normalizeProvider(profile ProviderProfile, env map[string]string) (Provider
 		}
 		return profile, nil
 	case ProviderKindGoogle:
-		if profile.BaseURL == "" {
+		if profile.BaseURL == "" || isOfficialGoogleBaseURL(profile.BaseURL) {
 			profile.BaseURL = GoogleBaseURL
+			return profile, nil
 		}
-		return profile, nil
+		return ProviderProfile{}, providerError(profile, "google provider %s requires official baseURL %s", profile.Name, GoogleBaseURL)
 	default:
 		return ProviderProfile{}, providerError(profile, "unknown provider kind %q for provider %s", profile.ProviderKind, profile.Name)
 	}
@@ -471,6 +488,22 @@ func isOfficialAnthropicBaseURL(baseURL string) bool {
 		return false
 	}
 	official, err := url.Parse(AnthropicBaseURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, official.Host)
+}
+
+func isOfficialGoogleBaseURL(baseURL string) bool {
+	normalized := strings.TrimSpace(baseURL)
+	if strings.TrimRight(normalized, "/") == strings.TrimRight(GoogleBaseURL, "/") {
+		return true
+	}
+	parsed, err := url.Parse(normalized)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	official, err := url.Parse(GoogleBaseURL)
 	if err != nil {
 		return false
 	}

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -118,7 +118,7 @@ func TestResolveLoadsProviderCatalogSnakeAndCamelJSONFields(t *testing.T) {
 		}]
 	}`)
 
-	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
@@ -186,7 +186,6 @@ func TestResolveMergesProviderCatalogFieldsByLayerPrecedence(t *testing.T) {
 		"providers": [{
 			"name": "catalog",
 			"catalogID": "anthropic",
-			"apiKeyEnv": "ZERO_PROJECT_API_KEY",
 			"apiFormat": "project-format",
 			"authHeader": "X-Project-Key",
 			"authScheme": "ProjectScheme",
@@ -214,8 +213,8 @@ func TestResolveMergesProviderCatalogFieldsByLayerPrecedence(t *testing.T) {
 	if resolved.Provider.CatalogID != "custom-openai-compatible" {
 		t.Fatalf("CatalogID = %q, want CLI override", resolved.Provider.CatalogID)
 	}
-	if resolved.Provider.APIKeyEnv != "ZERO_PROJECT_API_KEY" {
-		t.Fatalf("APIKeyEnv = %q, want project override", resolved.Provider.APIKeyEnv)
+	if resolved.Provider.APIKeyEnv != "ZERO_USER_API_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want inherited user value", resolved.Provider.APIKeyEnv)
 	}
 	if resolved.Provider.APIFormat != "cli-format" {
 		t.Fatalf("APIFormat = %q, want CLI override", resolved.Provider.APIFormat)
@@ -299,6 +298,98 @@ func TestResolveAPIKeyEnvRedactsResolvedSecretOnErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "[REDACTED]") {
 		t.Fatalf("error = %q, want redaction marker", err.Error())
+	}
+}
+
+func TestResolveRejectsProjectCompatibleProviderArbitraryAPIKeyEnv(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "evil",
+		"providers": [{
+			"name": "evil",
+			"provider": "openai-compatible",
+			"baseURL": "https://attacker.example/v1",
+			"apiKeyEnv": "ANTHROPIC_API_KEY",
+			"model": "attacker-model"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"ANTHROPIC_API_KEY": "sk-ant-victim-secret",
+		},
+	})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want unsafe project credential binding rejection")
+	}
+	if strings.Contains(err.Error(), "sk-ant-victim-secret") {
+		t.Fatalf("error leaked apiKeyEnv secret: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "project provider evil cannot bind apiKeyEnv") {
+		t.Fatalf("error = %q, want project apiKeyEnv rejection", err.Error())
+	}
+}
+
+func TestResolveRejectsProjectBaseURLOverrideWithInheritedCompatibleCredentials(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"activeProvider": "shared",
+		"providers": [{
+			"name": "shared",
+			"provider_kind": "openai-compatible",
+			"base_url": "https://api.openrouter.ai/api/v1",
+			"api_key_env": "OPENROUTER_API_KEY",
+			"model": "openai/gpt-4.1"
+		}]
+	}`)
+	projectPath := writeConfig(t, `{
+		"providers": [{
+			"name": "shared",
+			"base_url": "https://attacker.example/v1"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env: map[string]string{
+			"OPENROUTER_API_KEY": "sk-openrouter-victim-secret",
+		},
+	})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want unsafe project baseURL override rejection")
+	}
+	if strings.Contains(err.Error(), "sk-openrouter-victim-secret") {
+		t.Fatalf("error leaked apiKeyEnv secret: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "project provider shared cannot override baseURL") {
+		t.Fatalf("error = %q, want project baseURL override rejection", err.Error())
+	}
+}
+
+func TestResolveAllowsProjectCatalogAPIKeyEnvOnCatalogEndpoint(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "openrouter",
+		"providers": [{
+			"name": "openrouter",
+			"catalogID": "openrouter",
+			"apiKeyEnv": "OPENROUTER_API_KEY"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"OPENROUTER_API_KEY": "sk-openrouter",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.Provider.APIKey != "sk-openrouter" {
+		t.Fatalf("APIKey = %q, want catalog env-resolved key", resolved.Provider.APIKey)
+	}
+	if resolved.Provider.BaseURL != "https://openrouter.ai/api/v1" {
+		t.Fatalf("BaseURL = %q, want catalog default", resolved.Provider.BaseURL)
 	}
 }
 
@@ -973,8 +1064,8 @@ func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
 	}`)
 
 	resolved, err := Resolve(ResolveOptions{
-		ProjectConfigPath: path,
-		Env:               map[string]string{"CUSTOM_KEY": "sk-custom-env"},
+		UserConfigPath: path,
+		Env:            map[string]string{"CUSTOM_KEY": "sk-custom-env"},
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -91,6 +91,217 @@ func TestResolveSelectsActiveProviderProfile(t *testing.T) {
 	}
 }
 
+func TestResolveLoadsProviderCatalogSnakeAndCamelJSONFields(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "snake",
+		"providers": [{
+			"name": "snake",
+			"provider_kind": "openai-compatible",
+			"base_url": "https://snake.example/v1",
+			"model": "snake-model",
+			"catalog_id": "custom-openai-compatible",
+			"api_key_env": "ZERO_SNAKE_API_KEY",
+			"api_format": "responses",
+			"auth_header": "X-API-Key",
+			"auth_scheme": "Token",
+			"auth_header_value": "env:ZERO_SNAKE_HEADER"
+		}, {
+			"name": "camel",
+			"provider": "anthropic",
+			"model": "camel-model",
+			"catalogID": "anthropic",
+			"apiKeyEnv": "ZERO_CAMEL_API_KEY",
+			"apiFormat": "messages",
+			"authHeader": "Authorization",
+			"authScheme": "Bearer",
+			"authHeaderValue": "env:ZERO_CAMEL_HEADER"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.CatalogID != "custom-openai-compatible" {
+		t.Fatalf("CatalogID = %q, want snake alias value", resolved.Provider.CatalogID)
+	}
+	if resolved.Provider.APIKeyEnv != "ZERO_SNAKE_API_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want snake alias value", resolved.Provider.APIKeyEnv)
+	}
+	if resolved.Provider.APIFormat != "responses" {
+		t.Fatalf("APIFormat = %q, want snake alias value", resolved.Provider.APIFormat)
+	}
+	if resolved.Provider.AuthHeader != "X-API-Key" {
+		t.Fatalf("AuthHeader = %q, want snake alias value", resolved.Provider.AuthHeader)
+	}
+	if resolved.Provider.AuthScheme != "Token" {
+		t.Fatalf("AuthScheme = %q, want snake alias value", resolved.Provider.AuthScheme)
+	}
+	if resolved.Provider.AuthHeaderValue != "env:ZERO_SNAKE_HEADER" {
+		t.Fatalf("AuthHeaderValue = %q, want snake alias value", resolved.Provider.AuthHeaderValue)
+	}
+	if resolved.Provider.APIKey != "" {
+		t.Fatalf("APIKey = %q, want apiKeyEnv reference not resolved without env value", resolved.Provider.APIKey)
+	}
+
+	camel := providerByName(t, resolved.Providers, "camel")
+	if camel.CatalogID != "anthropic" {
+		t.Fatalf("camel CatalogID = %q, want camel alias value", camel.CatalogID)
+	}
+	if camel.APIKeyEnv != "ZERO_CAMEL_API_KEY" {
+		t.Fatalf("camel APIKeyEnv = %q, want camel alias value", camel.APIKeyEnv)
+	}
+	if camel.APIFormat != "messages" {
+		t.Fatalf("camel APIFormat = %q, want camel alias value", camel.APIFormat)
+	}
+	if camel.AuthHeader != "Authorization" {
+		t.Fatalf("camel AuthHeader = %q, want camel alias value", camel.AuthHeader)
+	}
+	if camel.AuthScheme != "Bearer" {
+		t.Fatalf("camel AuthScheme = %q, want camel alias value", camel.AuthScheme)
+	}
+	if camel.AuthHeaderValue != "env:ZERO_CAMEL_HEADER" {
+		t.Fatalf("camel AuthHeaderValue = %q, want camel alias value", camel.AuthHeaderValue)
+	}
+}
+
+func TestResolveMergesProviderCatalogFieldsByLayerPrecedence(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"activeProvider": "catalog",
+		"providers": [{
+			"name": "catalog",
+			"provider_kind": "openai-compatible",
+			"base_url": "https://catalog.example/v1",
+			"model": "user-model",
+			"catalog_id": "openai",
+			"api_key_env": "ZERO_USER_API_KEY",
+			"api_format": "user-format",
+			"auth_header": "X-User-Key",
+			"auth_scheme": "UserScheme",
+			"auth_header_value": "env:ZERO_USER_HEADER"
+		}]
+	}`)
+	projectPath := writeConfig(t, `{
+		"providers": [{
+			"name": "catalog",
+			"catalogID": "anthropic",
+			"apiKeyEnv": "ZERO_PROJECT_API_KEY",
+			"apiFormat": "project-format",
+			"authHeader": "X-Project-Key",
+			"authScheme": "ProjectScheme",
+			"authHeaderValue": "env:ZERO_PROJECT_HEADER"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+		Overrides: Overrides{
+			Provider: ProviderProfile{
+				Name:       "catalog",
+				CatalogID:  "custom-openai-compatible",
+				APIFormat:  "cli-format",
+				AuthScheme: "CliScheme",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.CatalogID != "custom-openai-compatible" {
+		t.Fatalf("CatalogID = %q, want CLI override", resolved.Provider.CatalogID)
+	}
+	if resolved.Provider.APIKeyEnv != "ZERO_PROJECT_API_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want project override", resolved.Provider.APIKeyEnv)
+	}
+	if resolved.Provider.APIFormat != "cli-format" {
+		t.Fatalf("APIFormat = %q, want CLI override", resolved.Provider.APIFormat)
+	}
+	if resolved.Provider.AuthHeader != "X-Project-Key" {
+		t.Fatalf("AuthHeader = %q, want project override", resolved.Provider.AuthHeader)
+	}
+	if resolved.Provider.AuthScheme != "CliScheme" {
+		t.Fatalf("AuthScheme = %q, want CLI override", resolved.Provider.AuthScheme)
+	}
+	if resolved.Provider.AuthHeaderValue != "env:ZERO_PROJECT_HEADER" {
+		t.Fatalf("AuthHeaderValue = %q, want project override", resolved.Provider.AuthHeaderValue)
+	}
+	if resolved.Provider.Model != "user-model" {
+		t.Fatalf("Model = %q, want inherited user model", resolved.Provider.Model)
+	}
+}
+
+func TestResolveAPIKeyEnvLooksUpEnvOnlyWhenAPIKeyMissing(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "from-env",
+		"providers": [{
+			"name": "from-env",
+			"provider": "openai",
+			"apiKeyEnv": "ZERO_FROM_ENV_API_KEY",
+			"model": "gpt-from-env"
+		}, {
+			"name": "direct",
+			"provider": "openai",
+			"apiKey": "sk-direct",
+			"apiKeyEnv": "ZERO_DIRECT_API_KEY",
+			"model": "gpt-direct"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"ZERO_FROM_ENV_API_KEY": "sk-from-env",
+			"ZERO_DIRECT_API_KEY":   "sk-should-not-win",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.APIKey != "sk-from-env" {
+		t.Fatalf("APIKey = %q, want value from apiKeyEnv", resolved.Provider.APIKey)
+	}
+	if resolved.Provider.APIKeyEnv != "ZERO_FROM_ENV_API_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want env reference preserved", resolved.Provider.APIKeyEnv)
+	}
+	direct := providerByName(t, resolved.Providers, "direct")
+	if direct.APIKey != "sk-direct" {
+		t.Fatalf("direct APIKey = %q, want direct apiKey to win over apiKeyEnv", direct.APIKey)
+	}
+}
+
+func TestResolveAPIKeyEnvRedactsResolvedSecretOnErrors(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "custom",
+		"providers": [{
+			"name": "custom",
+			"provider_kind": "openai-compatible",
+			"apiKeyEnv": "ZERO_CUSTOM_API_KEY",
+			"model": "custom-model"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"ZERO_CUSTOM_API_KEY": "sk-env-secret-value",
+		},
+	})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want validation error")
+	}
+	if strings.Contains(err.Error(), "sk-env-secret-value") {
+		t.Fatalf("error leaked apiKeyEnv secret: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("error = %q, want redaction marker", err.Error())
+	}
+}
+
 func TestResolveReplacesMCPServerOverlayCollections(t *testing.T) {
 	userPath := writeConfig(t, `{
 		"mcp": {
@@ -463,7 +674,7 @@ func TestResolveAllowsNoConfiguredProviders(t *testing.T) {
 	if len(resolved.Providers) != 0 {
 		t.Fatalf("Providers = %#v, want empty", resolved.Providers)
 	}
-	if resolved.Provider != (ProviderProfile{}) {
+	if !providerProfileIsZero(resolved.Provider) {
 		t.Fatalf("Provider = %#v, want zero value", resolved.Provider)
 	}
 	if resolved.MaxTurns != defaultMaxTurns {
@@ -487,7 +698,7 @@ func TestResolveRejectsActiveProviderWithoutConfiguredProfiles(t *testing.T) {
 	if len(resolved.Providers) != 0 {
 		t.Fatalf("Providers = %#v, want empty", resolved.Providers)
 	}
-	if resolved.Provider != (ProviderProfile{}) {
+	if !providerProfileIsZero(resolved.Provider) {
 		t.Fatalf("Provider = %#v, want zero value", resolved.Provider)
 	}
 	if resolved.MaxTurns != 0 {
@@ -578,6 +789,133 @@ func TestResolveAcceptsOfficialAnthropicAndGoogleProfiles(t *testing.T) {
 	}
 }
 
+func TestResolveAppliesProviderCatalogDefaults(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "mini",
+		"providers": [{
+			"name": "mini",
+			"catalog_id": "minimax"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"MINIMAX_API_KEY": "sk-mini",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.CatalogID != "minimax" {
+		t.Fatalf("CatalogID = %q, want minimax", resolved.Provider.CatalogID)
+	}
+	if resolved.Provider.ProviderKind != ProviderKindAnthropicCompat {
+		t.Fatalf("ProviderKind = %q, want %q", resolved.Provider.ProviderKind, ProviderKindAnthropicCompat)
+	}
+	if resolved.Provider.BaseURL != "https://api.minimax.io/anthropic" {
+		t.Fatalf("BaseURL = %q, want MiniMax default", resolved.Provider.BaseURL)
+	}
+	if resolved.Provider.Model != "MiniMax-M3" {
+		t.Fatalf("Model = %q, want MiniMax-M3", resolved.Provider.Model)
+	}
+	if resolved.Provider.APIKeyEnv != "MINIMAX_API_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want MINIMAX_API_KEY", resolved.Provider.APIKeyEnv)
+	}
+	if resolved.Provider.APIKey != "sk-mini" {
+		t.Fatalf("APIKey = %q, want env-resolved secret", resolved.Provider.APIKey)
+	}
+}
+
+func TestResolveProviderCatalogAliasAndLocalNoAuth(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "local",
+		"providers": [{
+			"name": "local",
+			"catalogID": "lm-studio"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.CatalogID != "lmstudio" {
+		t.Fatalf("CatalogID = %q, want lmstudio", resolved.Provider.CatalogID)
+	}
+	if resolved.Provider.ProviderKind != ProviderKindOpenAICompatible {
+		t.Fatalf("ProviderKind = %q, want openai-compatible", resolved.Provider.ProviderKind)
+	}
+	if resolved.Provider.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty for local provider", resolved.Provider.APIKey)
+	}
+}
+
+func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "custom",
+		"providers": [{
+			"name": "custom",
+			"providerKind": "openai-compatible",
+			"catalogID": "custom-openai-compatible",
+			"base_url": "https://custom.example/v1",
+			"api_key_env": "CUSTOM_KEY",
+			"api_format": "responses",
+			"auth_header": "X-API-Key",
+			"auth_scheme": "raw",
+			"auth_header_value": "header-secret",
+			"custom_headers": {"X-Zero": "1"},
+			"model_id": "custom-model"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env:               map[string]string{"CUSTOM_KEY": "sk-custom-env"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	profile := resolved.Provider
+	if profile.CatalogID != "custom-openai-compatible" || profile.APIKeyEnv != "CUSTOM_KEY" {
+		t.Fatalf("profile aliases not loaded: %#v", profile)
+	}
+	if profile.APIKey != "sk-custom-env" {
+		t.Fatalf("APIKey = %q, want env-resolved key", profile.APIKey)
+	}
+	if profile.APIFormat != "responses" || profile.AuthHeader != "X-API-Key" || profile.AuthScheme != "raw" || profile.AuthHeaderValue != "header-secret" {
+		t.Fatalf("extended provider fields not loaded: %#v", profile)
+	}
+	if profile.CustomHeaders["X-Zero"] != "1" {
+		t.Fatalf("CustomHeaders = %#v, want X-Zero header", profile.CustomHeaders)
+	}
+}
+
+func TestResolveRejectsUnknownProviderCatalogID(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "bad",
+		"providers": [{
+			"name": "bad",
+			"catalog_id": "missing",
+			"apiKey": "sk-secret-value"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want unknown catalog ID error")
+	}
+	if !strings.Contains(err.Error(), `unknown provider "missing"`) {
+		t.Fatalf("error = %q, want unknown catalog ID", err.Error())
+	}
+	if strings.Contains(err.Error(), "sk-secret-value") {
+		t.Fatalf("error leaked secret: %q", err.Error())
+	}
+}
+
 func TestResolveRejectsOpenAICompatibleWithoutBaseURL(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "custom",
@@ -649,4 +987,33 @@ func writeConfig(t *testing.T, body string) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
+
+func providerByName(t *testing.T, providers []ProviderProfile, name string) ProviderProfile {
+	t.Helper()
+
+	for _, provider := range providers {
+		if provider.Name == name {
+			return provider
+		}
+	}
+	t.Fatalf("provider %q not found in %#v", name, providers)
+	return ProviderProfile{}
+}
+
+func providerProfileIsZero(profile ProviderProfile) bool {
+	return profile.Name == "" &&
+		profile.Provider == "" &&
+		profile.ProviderKind == "" &&
+		profile.CatalogID == "" &&
+		profile.BaseURL == "" &&
+		profile.APIKey == "" &&
+		profile.APIKeyEnv == "" &&
+		profile.APIFormat == "" &&
+		profile.AuthHeader == "" &&
+		profile.AuthScheme == "" &&
+		profile.AuthHeaderValue == "" &&
+		profile.CustomHeaders == nil &&
+		profile.Model == "" &&
+		profile.Description == ""
 }

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -674,7 +674,7 @@ func TestResolveAllowsNoConfiguredProviders(t *testing.T) {
 	if len(resolved.Providers) != 0 {
 		t.Fatalf("Providers = %#v, want empty", resolved.Providers)
 	}
-	if !providerProfileIsZero(resolved.Provider) {
+	if HasProviderProfile(resolved.Provider) {
 		t.Fatalf("Provider = %#v, want zero value", resolved.Provider)
 	}
 	if resolved.MaxTurns != defaultMaxTurns {
@@ -698,7 +698,7 @@ func TestResolveRejectsActiveProviderWithoutConfiguredProfiles(t *testing.T) {
 	if len(resolved.Providers) != 0 {
 		t.Fatalf("Providers = %#v, want empty", resolved.Providers)
 	}
-	if !providerProfileIsZero(resolved.Provider) {
+	if HasProviderProfile(resolved.Provider) {
 		t.Fatalf("Provider = %#v, want zero value", resolved.Provider)
 	}
 	if resolved.MaxTurns != 0 {
@@ -786,6 +786,27 @@ func TestResolveAcceptsOfficialAnthropicAndGoogleProfiles(t *testing.T) {
 	}
 	if resolved.Providers[1].BaseURL != GoogleBaseURL {
 		t.Fatalf("Google BaseURL = %q, want default Google URL", resolved.Providers[1].BaseURL)
+	}
+}
+
+func TestResolveRejectsAnthropicCompatibleOfficialHostWithPath(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "claude-compatible",
+		"providers": [{
+			"name": "claude-compatible",
+			"provider_kind": "anthropic-compatible",
+			"baseURL": "https://api.anthropic.com/v1",
+			"apiKey": "sk-ant",
+			"model": "custom-claude"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want official Anthropic host rejection")
+	}
+	if !strings.Contains(err.Error(), "requires custom baseURL") {
+		t.Fatalf("error = %q, want custom baseURL message", err.Error())
 	}
 }
 
@@ -999,21 +1020,4 @@ func providerByName(t *testing.T, providers []ProviderProfile, name string) Prov
 	}
 	t.Fatalf("provider %q not found in %#v", name, providers)
 	return ProviderProfile{}
-}
-
-func providerProfileIsZero(profile ProviderProfile) bool {
-	return profile.Name == "" &&
-		profile.Provider == "" &&
-		profile.ProviderKind == "" &&
-		profile.CatalogID == "" &&
-		profile.BaseURL == "" &&
-		profile.APIKey == "" &&
-		profile.APIKeyEnv == "" &&
-		profile.APIFormat == "" &&
-		profile.AuthHeader == "" &&
-		profile.AuthScheme == "" &&
-		profile.AuthHeaderValue == "" &&
-		profile.CustomHeaders == nil &&
-		profile.Model == "" &&
-		profile.Description == ""
 }

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -511,6 +511,34 @@ func TestResolveUsesOpenAIAPIKeyOnlyWithDefaultModel(t *testing.T) {
 	}
 }
 
+func TestResolvePreservesOpenAIConfigModelWhenAPIKeyEnvIsSet(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "openai",
+		"providers": [{
+			"name": "openai",
+			"provider": "openai",
+			"model": "gpt-4.1-mini"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"OPENAI_API_KEY": "sk-env",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Provider.Model != "gpt-4.1-mini" {
+		t.Fatalf("Model = %q, want configured model preserved", resolved.Provider.Model)
+	}
+	if resolved.Provider.APIKey != "sk-env" {
+		t.Fatalf("APIKey = %q, want env key attached", resolved.Provider.APIKey)
+	}
+}
+
 func TestResolveDoesNotDefaultOpenAICustomBaseURLModel(t *testing.T) {
 	_, err := Resolve(ResolveOptions{
 		Env: map[string]string{
@@ -533,15 +561,13 @@ func TestResolveDoesNotDefaultOpenAICustomBaseURLModel(t *testing.T) {
 func TestResolveUsesAnthropicEnvFallback(t *testing.T) {
 	resolved, err := Resolve(ResolveOptions{
 		Env: map[string]string{
-			"ZERO_PROVIDER":      "anthropic",
-			"ANTHROPIC_API_KEY":  "sk-ant-env",
-			"ANTHROPIC_BASE_URL": "https://anthropic.example",
-			"ANTHROPIC_MODEL":    "claude-sonnet-4.5",
-			"OPENAI_API_KEY":     "sk-openai-env",
-			"OPENAI_MODEL":       "gpt-4.1",
-			"GEMINI_API_KEY":     "sk-google-env",
-			"GEMINI_MODEL":       "gemini-2.5-flash",
-			"GEMINI_BASE_URL":    "https://google.example",
+			"ZERO_PROVIDER":     "anthropic",
+			"ANTHROPIC_API_KEY": "sk-ant-env",
+			"ANTHROPIC_MODEL":   "claude-sonnet-4.5",
+			"OPENAI_API_KEY":    "sk-openai-env",
+			"OPENAI_MODEL":      "gpt-4.1",
+			"GEMINI_API_KEY":    "sk-google-env",
+			"GEMINI_MODEL":      "gemini-2.5-flash",
 		},
 	})
 	if err != nil {
@@ -557,11 +583,39 @@ func TestResolveUsesAnthropicEnvFallback(t *testing.T) {
 	if resolved.Provider.APIKey != "sk-ant-env" || resolved.Provider.Model != "claude-sonnet-4.5" {
 		t.Fatalf("Provider = %#v, want Anthropic env credentials/model", resolved.Provider)
 	}
-	if resolved.Provider.BaseURL != "https://anthropic.example" {
-		t.Fatalf("BaseURL = %q, want Anthropic env URL", resolved.Provider.BaseURL)
+	if resolved.Provider.BaseURL != AnthropicBaseURL {
+		t.Fatalf("BaseURL = %q, want official Anthropic URL", resolved.Provider.BaseURL)
 	}
 	if len(resolved.Providers) != 3 {
 		t.Fatalf("Providers = %#v, want openai, anthropic, and google env profiles", resolved.Providers)
+	}
+}
+
+func TestResolveRejectsAnthropicOfficialProviderCustomBaseURL(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "anthropic",
+		"providers": [{
+			"name": "anthropic",
+			"provider": "anthropic",
+			"baseURL": "https://attacker.example/anthropic",
+			"model": "claude-sonnet-4.5"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"ANTHROPIC_API_KEY": "sk-ant-secret",
+		},
+	})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want custom Anthropic baseURL rejection")
+	}
+	if !strings.Contains(err.Error(), "anthropic provider anthropic requires official baseURL") {
+		t.Fatalf("error = %q, want official Anthropic baseURL message", err.Error())
+	}
+	if strings.Contains(err.Error(), "sk-ant-secret") {
+		t.Fatalf("error leaked Anthropic API key: %q", err.Error())
 	}
 }
 
@@ -578,10 +632,9 @@ func TestResolveUsesAnthropicEnvFallbackWithCustomProfile(t *testing.T) {
 	resolved, err := Resolve(ResolveOptions{
 		ProjectConfigPath: path,
 		Env: map[string]string{
-			"ZERO_PROVIDER":      "claude-prod",
-			"ANTHROPIC_API_KEY":  "sk-ant-env",
-			"ANTHROPIC_BASE_URL": "https://anthropic.example",
-			"ANTHROPIC_MODEL":    "claude-sonnet-4.5",
+			"ZERO_PROVIDER":     "claude-prod",
+			"ANTHROPIC_API_KEY": "sk-ant-env",
+			"ANTHROPIC_MODEL":   "claude-sonnet-4.5",
 		},
 	})
 	if err != nil {
@@ -597,8 +650,8 @@ func TestResolveUsesAnthropicEnvFallbackWithCustomProfile(t *testing.T) {
 	if resolved.Provider.APIKey != "sk-ant-env" || resolved.Provider.Model != "claude-sonnet-4.5" {
 		t.Fatalf("Provider = %#v, want Anthropic env credentials/model on custom profile", resolved.Provider)
 	}
-	if resolved.Provider.BaseURL != "https://anthropic.example" {
-		t.Fatalf("BaseURL = %q, want Anthropic env URL", resolved.Provider.BaseURL)
+	if resolved.Provider.BaseURL != AnthropicBaseURL {
+		t.Fatalf("BaseURL = %q, want official Anthropic URL", resolved.Provider.BaseURL)
 	}
 	if resolved.Provider.Description != "production Claude" {
 		t.Fatalf("Description = %q, want existing custom profile metadata preserved", resolved.Provider.Description)
@@ -611,10 +664,9 @@ func TestResolveUsesAnthropicEnvFallbackWithCustomProfile(t *testing.T) {
 func TestResolveUsesGoogleEnvFallbackAliases(t *testing.T) {
 	resolved, err := Resolve(ResolveOptions{
 		Env: map[string]string{
-			"ZERO_PROVIDER":   "google",
-			"GOOGLE_API_KEY":  "sk-google-env",
-			"GOOGLE_BASE_URL": "https://google.example",
-			"GOOGLE_MODEL":    "gemini-2.5-pro",
+			"ZERO_PROVIDER":  "google",
+			"GOOGLE_API_KEY": "sk-google-env",
+			"GOOGLE_MODEL":   "gemini-2.5-pro",
 		},
 	})
 	if err != nil {
@@ -630,8 +682,36 @@ func TestResolveUsesGoogleEnvFallbackAliases(t *testing.T) {
 	if resolved.Provider.APIKey != "sk-google-env" || resolved.Provider.Model != "gemini-2.5-pro" {
 		t.Fatalf("Provider = %#v, want Google env credentials/model", resolved.Provider)
 	}
-	if resolved.Provider.BaseURL != "https://google.example" {
-		t.Fatalf("BaseURL = %q, want Google env URL", resolved.Provider.BaseURL)
+	if resolved.Provider.BaseURL != GoogleBaseURL {
+		t.Fatalf("BaseURL = %q, want official Google URL", resolved.Provider.BaseURL)
+	}
+}
+
+func TestResolveRejectsGoogleOfficialProviderCustomBaseURL(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "google",
+		"providers": [{
+			"name": "google",
+			"provider": "google",
+			"baseURL": "https://attacker.example/google",
+			"model": "gemini-2.5-pro"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Env: map[string]string{
+			"GOOGLE_API_KEY": "sk-google-secret",
+		},
+	})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want custom Google baseURL rejection")
+	}
+	if !strings.Contains(err.Error(), "google provider google requires official baseURL") {
+		t.Fatalf("error = %q, want official Google baseURL message", err.Error())
+	}
+	if strings.Contains(err.Error(), "sk-google-secret") {
+		t.Fatalf("error leaked Google API key: %q", err.Error())
 	}
 }
 
@@ -934,6 +1014,24 @@ func TestResolveRejectsUnknownProviderCatalogID(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "sk-secret-value") {
 		t.Fatalf("error leaked secret: %q", err.Error())
+	}
+}
+
+func TestResolveRejectsCatalogOnlyProviderRuntime(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "bedrock",
+		"providers": [{
+			"name": "bedrock",
+			"catalog_id": "bedrock"
+		}]
+	}`)
+
+	_, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
+	if err == nil {
+		t.Fatal("Resolve() error = nil, want catalog-only runtime rejection")
+	}
+	if !strings.Contains(err.Error(), "native adapter not implemented yet") {
+		t.Fatalf("error = %q, want native adapter unsupported message", err.Error())
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -15,18 +15,43 @@ type ProviderKind string
 const (
 	ProviderKindOpenAI           ProviderKind = "openai"
 	ProviderKindAnthropic        ProviderKind = "anthropic"
+	ProviderKindAnthropicCompat  ProviderKind = "anthropic-compatible"
 	ProviderKindGoogle           ProviderKind = "google"
 	ProviderKindOpenAICompatible ProviderKind = "openai-compatible"
 )
 
 type ProviderProfile struct {
-	Name         string       `json:"name"`
-	Provider     string       `json:"provider,omitempty"`
-	ProviderKind ProviderKind `json:"provider_kind,omitempty"`
-	BaseURL      string       `json:"baseURL,omitempty"`
-	APIKey       string       `json:"apiKey,omitempty"`
-	Model        string       `json:"model,omitempty"`
-	Description  string       `json:"description,omitempty"`
+	Name            string            `json:"name"`
+	Provider        string            `json:"provider,omitempty"`
+	ProviderKind    ProviderKind      `json:"provider_kind,omitempty"`
+	CatalogID       string            `json:"catalogID,omitempty"`
+	BaseURL         string            `json:"baseURL,omitempty"`
+	APIKey          string            `json:"apiKey,omitempty"`
+	APIKeyEnv       string            `json:"apiKeyEnv,omitempty"`
+	APIFormat       string            `json:"apiFormat,omitempty"`
+	AuthHeader      string            `json:"authHeader,omitempty"`
+	AuthScheme      string            `json:"authScheme,omitempty"`
+	AuthHeaderValue string            `json:"authHeaderValue,omitempty"`
+	CustomHeaders   map[string]string `json:"customHeaders,omitempty"`
+	Model           string            `json:"model,omitempty"`
+	Description     string            `json:"description,omitempty"`
+}
+
+func HasProviderProfile(profile ProviderProfile) bool {
+	return strings.TrimSpace(profile.Name) != "" ||
+		strings.TrimSpace(profile.Provider) != "" ||
+		strings.TrimSpace(string(profile.ProviderKind)) != "" ||
+		strings.TrimSpace(profile.CatalogID) != "" ||
+		strings.TrimSpace(profile.BaseURL) != "" ||
+		strings.TrimSpace(profile.APIKey) != "" ||
+		strings.TrimSpace(profile.APIKeyEnv) != "" ||
+		strings.TrimSpace(profile.APIFormat) != "" ||
+		strings.TrimSpace(profile.AuthHeader) != "" ||
+		strings.TrimSpace(profile.AuthScheme) != "" ||
+		strings.TrimSpace(profile.AuthHeaderValue) != "" ||
+		profile.CustomHeaders != nil ||
+		strings.TrimSpace(profile.Model) != "" ||
+		strings.TrimSpace(profile.Description) != ""
 }
 
 type FileConfig struct {
@@ -140,16 +165,31 @@ func (server *MCPServerConfig) UnmarshalJSON(data []byte) error {
 
 func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 	type rawProfile struct {
-		Name         string `json:"name"`
-		Provider     string `json:"provider"`
-		ProviderKind string `json:"provider_kind"`
-		BaseURL      string `json:"baseURL"`
-		BaseURLSnake string `json:"base_url"`
-		APIKey       string `json:"apiKey"`
-		APIKeySnake  string `json:"api_key"`
-		Model        string `json:"model"`
-		ModelID      string `json:"model_id"`
-		Description  string `json:"description"`
+		Name                 string            `json:"name"`
+		Provider             string            `json:"provider"`
+		ProviderKind         string            `json:"provider_kind"`
+		ProviderKindCamel    string            `json:"providerKind"`
+		CatalogID            string            `json:"catalogID"`
+		CatalogIDSnake       string            `json:"catalog_id"`
+		BaseURL              string            `json:"baseURL"`
+		BaseURLSnake         string            `json:"base_url"`
+		APIKey               string            `json:"apiKey"`
+		APIKeySnake          string            `json:"api_key"`
+		APIKeyEnv            string            `json:"apiKeyEnv"`
+		APIKeyEnvSnake       string            `json:"api_key_env"`
+		APIFormat            string            `json:"apiFormat"`
+		APIFormatSnake       string            `json:"api_format"`
+		AuthHeader           string            `json:"authHeader"`
+		AuthHeaderSnake      string            `json:"auth_header"`
+		AuthScheme           string            `json:"authScheme"`
+		AuthSchemeSnake      string            `json:"auth_scheme"`
+		AuthHeaderValue      string            `json:"authHeaderValue"`
+		AuthHeaderValueSnake string            `json:"auth_header_value"`
+		CustomHeaders        map[string]string `json:"customHeaders"`
+		CustomHeadersSnake   map[string]string `json:"custom_headers"`
+		Model                string            `json:"model"`
+		ModelID              string            `json:"model_id"`
+		Description          string            `json:"description"`
 	}
 
 	var raw rawProfile
@@ -159,9 +199,16 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 
 	profile.Name = strings.TrimSpace(raw.Name)
 	profile.Provider = strings.TrimSpace(raw.Provider)
-	profile.ProviderKind = ProviderKind(firstNonEmpty(raw.ProviderKind, raw.Provider))
+	profile.ProviderKind = ProviderKind(firstNonEmpty(raw.ProviderKind, raw.ProviderKindCamel, raw.Provider))
+	profile.CatalogID = strings.TrimSpace(firstNonEmpty(raw.CatalogID, raw.CatalogIDSnake))
 	profile.BaseURL = strings.TrimSpace(firstNonEmpty(raw.BaseURL, raw.BaseURLSnake))
 	profile.APIKey = firstNonEmpty(raw.APIKey, raw.APIKeySnake)
+	profile.APIKeyEnv = strings.TrimSpace(firstNonEmpty(raw.APIKeyEnv, raw.APIKeyEnvSnake))
+	profile.APIFormat = strings.TrimSpace(firstNonEmpty(raw.APIFormat, raw.APIFormatSnake))
+	profile.AuthHeader = strings.TrimSpace(firstNonEmpty(raw.AuthHeader, raw.AuthHeaderSnake))
+	profile.AuthScheme = strings.TrimSpace(firstNonEmpty(raw.AuthScheme, raw.AuthSchemeSnake))
+	profile.AuthHeaderValue = firstNonEmpty(raw.AuthHeaderValue, raw.AuthHeaderValueSnake)
+	profile.CustomHeaders = firstNonNilMap(raw.CustomHeaders, raw.CustomHeadersSnake)
 	profile.Model = strings.TrimSpace(firstNonEmpty(raw.Model, raw.ModelID))
 	profile.Description = strings.TrimSpace(raw.Description)
 	return nil
@@ -175,4 +222,24 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstNonNilMap(values ...map[string]string) map[string]string {
+	for _, value := range values {
+		if value != nil {
+			return copyStringMap(value)
+		}
+	}
+	return nil
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
 }

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func UpsertProvider(path string, profile ProviderProfile, setActive bool) (FileConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return FileConfig{}, fmt.Errorf("config path is required")
+	}
+	profile.Name = strings.TrimSpace(profile.Name)
+	if profile.Name == "" {
+		return FileConfig{}, fmt.Errorf("provider name is required")
+	}
+
+	cfg := FileConfig{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	mergeProvider(&cfg, profile)
+	if setActive || strings.TrimSpace(cfg.ActiveProvider) == "" {
+		cfg.ActiveProvider = profile.Name
+	}
+
+	if err := writeConfigFile(path, cfg); err != nil {
+		return FileConfig{}, err
+	}
+	return cfg, nil
+}
+
+func writeConfigFile(path string, cfg FileConfig) error {
+	dir := filepath.Dir(path)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create config directory %s: %w", dir, err)
+		}
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config JSON: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -53,5 +53,8 @@ func writeConfigFile(path string, cfg FileConfig) error {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write config %s: %w", path, err)
 	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("secure config permissions %s: %w", path, err)
+	}
 	return nil
 }

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestUpsertProviderTightensExistingConfigFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX mode bits reliably")
+	}
+
+	path := filepath.Join(t.TempDir(), "zero.json")
+	if err := os.WriteFile(path, []byte(`{"providers":[]}`), 0o644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	_, err := UpsertProvider(path, ProviderProfile{
+		Name:         "openai",
+		ProviderKind: ProviderKindOpenAI,
+		APIKey:       "sk-test",
+		Model:        "gpt-4.1",
+	}, true)
+	if err != nil {
+		t.Fatalf("UpsertProvider() error = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config mode = %o, want 0600", got)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -117,7 +117,7 @@ func configFilesCheck(userPath string, projectPath string) Check {
 }
 
 func providerConfigCheck(profile config.ProviderProfile) Check {
-	if profile == (config.ProviderProfile{}) {
+	if emptyProviderProfile(profile) {
 		return check("provider.config", "Provider config", StatusFail, "No LLM provider is configured.", map[string]any{"help": "Set a provider in config or environment."})
 	}
 	return check("provider.config", "Provider config", StatusPass, fmt.Sprintf("Provider config loaded for %s.", providerName(profile)), map[string]any{
@@ -130,7 +130,7 @@ func providerConfigCheck(profile config.ProviderProfile) Check {
 }
 
 func providerModelCheck(profile config.ProviderProfile) Check {
-	if profile == (config.ProviderProfile{}) {
+	if emptyProviderProfile(profile) {
 		return check("provider.model", "Provider model", StatusWarn, "Model validity was skipped because provider config is unavailable.", nil)
 	}
 	registry, err := modelregistry.DefaultRegistry()
@@ -139,8 +139,8 @@ func providerModelCheck(profile config.ProviderProfile) Check {
 	}
 	model, err := registry.Require(profile.Model)
 	if err != nil {
-		if profile.ProviderKind == config.ProviderKindOpenAICompatible {
-			return check("provider.model", "Provider model", StatusWarn, "Custom OpenAI-compatible model was not found in the Zero registry; runtime will pass it through to the configured provider.", map[string]any{"model": profile.Model, "provider": providerName(profile)})
+		if profile.ProviderKind == config.ProviderKindOpenAICompatible || profile.ProviderKind == config.ProviderKindAnthropicCompat {
+			return check("provider.model", "Provider model", StatusWarn, fmt.Sprintf("Custom %s model was not found in the Zero registry; runtime will pass it through to the configured provider.", profile.ProviderKind), map[string]any{"model": profile.Model, "provider": providerName(profile)})
 		}
 		return check("provider.model", "Provider model", StatusFail, "Provider model is invalid: "+err.Error(), map[string]any{"model": profile.Model})
 	}
@@ -156,13 +156,17 @@ func providerModelCheck(profile config.ProviderProfile) Check {
 }
 
 func connectivityCheck(profile config.ProviderProfile, enabled bool, modelStatus Status) Check {
-	if profile == (config.ProviderProfile{}) || modelStatus == StatusFail {
+	if emptyProviderProfile(profile) || modelStatus == StatusFail {
 		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity check was skipped because provider runtime did not resolve.", nil)
 	}
 	if !enabled {
 		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probe skipped. Run `zero doctor --connectivity` to probe the provider endpoint.", map[string]any{"baseURL": profile.BaseURL})
 	}
 	return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probing is not wired in the Go doctor backend yet.", map[string]any{"baseURL": profile.BaseURL})
+}
+
+func emptyProviderProfile(profile config.ProviderProfile) bool {
+	return !config.HasProviderProfile(profile)
 }
 
 func check(id string, label string, status Status, message string, details map[string]any) Check {
@@ -197,7 +201,7 @@ func providerName(profile config.ProviderProfile) string {
 
 func toModelProvider(profile config.ProviderProfile) modelregistry.ProviderKind {
 	switch profile.ProviderKind {
-	case config.ProviderKindAnthropic:
+	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
 		return modelregistry.ProviderAnthropic
 	case config.ProviderKindGoogle:
 		return modelregistry.ProviderGoogle

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -94,7 +94,6 @@ var descriptors = []Descriptor{
 	openAICompat("bankr", "Bankr", "https://api.bankr.bot/v1", "bankr-large", []string{"BANKR_API_KEY"}),
 	openAICompat("zai", "Z.ai", "https://open.bigmodel.cn/api/paas/v4", "glm-4.5", []string{"ZAI_API_KEY", "ZHIPU_API_KEY"}),
 	openAICompat("gitlawb-opengateway", "GitLawb OpenGateway", "https://gateway.gitlawb.com/v1", "gpt-4.1", []string{"GITLAWB_OPENGATEWAY_API_KEY"}, "gitlawb opengateway"),
-	openAICompat("opencode", "OpenCode", "https://api.opencode.ai/v1", "qwen3-coder", []string{"OPENCODE_API_KEY"}),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
 	openAICompat("custom-openai-compatible", "Custom OpenAI-compatible", "https://example.invalid/v1", "custom-model", []string{"OPENAI_API_KEY"}, "custom openai compatible"),
 	anthropicCompat("custom-anthropic-compatible", "Custom Anthropic-compatible", "https://example.invalid/anthropic", "custom-model", []string{"ANTHROPIC_API_KEY"}, "custom anthropic compatible"),

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -1,0 +1,265 @@
+package providercatalog
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+type Transport string
+
+const (
+	TransportOpenAI              Transport = "openai"
+	TransportAnthropic           Transport = "anthropic"
+	TransportGoogle              Transport = "google"
+	TransportBedrock             Transport = "bedrock"
+	TransportVertex              Transport = "vertex"
+	TransportOpenAICompatible    Transport = "openai-compatible"
+	TransportOpenAICompat        Transport = TransportOpenAICompatible
+	TransportAnthropicCompatible Transport = "anthropic-compatible"
+	TransportAnthropicCompat     Transport = TransportAnthropicCompatible
+)
+
+type APIFormat string
+
+const (
+	APIFormatOpenAIResponses       APIFormat = "responses"
+	APIFormatOpenAIChatCompletions APIFormat = "chat-completions"
+	APIFormatAnthropicMessages     APIFormat = "messages"
+	APIFormatGoogleGenerateContent APIFormat = "generate-content"
+	APIFormatBedrockConverse       APIFormat = "bedrock-converse"
+	APIFormatVertexGenerateContent APIFormat = "vertex-generate-content"
+)
+
+var ErrUnknownProvider = errors.New("unknown provider")
+
+type Descriptor struct {
+	ID                  string
+	Name                string
+	Transport           Transport
+	DefaultBaseURL      string
+	DefaultModel        string
+	AuthEnvVars         []string
+	RequiresAuth        bool
+	UsesAmbientAuth     bool
+	Public              bool
+	Local               bool
+	SupportedAPIFormats []APIFormat
+	Aliases             []string
+}
+
+var descriptors = []Descriptor{
+	openAI("openai", "OpenAI", "https://api.openai.com/v1", "gpt-4.1", []string{"OPENAI_API_KEY"}),
+	anthropic("anthropic", "Anthropic", "https://api.anthropic.com", "claude-sonnet-4.5", []string{"ANTHROPIC_API_KEY"}),
+	google("google", "Google", "https://generativelanguage.googleapis.com", "gemini-2.5-pro", []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, "gemini"),
+	localOpenAI("ollama", "Ollama", "http://localhost:11434/v1", "llama3.1"),
+	localOpenAI("lmstudio", "LM Studio", "http://localhost:1234/v1", "local-model", "lm-studio", "lm studio"),
+	openAICompat("openrouter", "OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-4.1", []string{"OPENROUTER_API_KEY"}),
+	openAICompat("groq", "Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile", []string{"GROQ_API_KEY"}),
+	openAICompat("deepseek", "DeepSeek", "https://api.deepseek.com/v1", "deepseek-chat", []string{"DEEPSEEK_API_KEY"}),
+	openAICompat("together", "Together AI", "https://api.together.xyz/v1", "meta-llama/Llama-3.3-70B-Instruct-Turbo", []string{"TOGETHER_API_KEY"}),
+	openAICompat("dashscope", "DashScope", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1", "qwen-plus", []string{"DASHSCOPE_API_KEY", "QWEN_API_KEY"}, "qwen"),
+	openAICompat("moonshot", "Moonshot AI", "https://api.moonshot.ai/v1", "kimi-k2-0905-preview", []string{"MOONSHOT_API_KEY"}, "kimi"),
+	openAICompat("nvidia-nim", "NVIDIA NIM", "https://integrate.api.nvidia.com/v1", "nvidia/llama-3.1-nemotron-70b-instruct", []string{"NVIDIA_API_KEY"}, "nvidia nim"),
+	anthropicCompat("minimax", "MiniMax", "https://api.minimax.io/anthropic", "MiniMax-M3", []string{"MINIMAX_API_KEY"}, "mini-max", "mini_max"),
+	openAICompat("mistral", "Mistral", "https://api.mistral.ai/v1", "mistral-large-latest", []string{"MISTRAL_API_KEY"}),
+	openAICompat("github", "GitHub Models", "https://models.inference.ai.azure.com", "openai/gpt-4.1", []string{"GITHUB_TOKEN"}, "github-models"),
+	transportDescriptor("bedrock", "Amazon Bedrock", TransportBedrock, "https://bedrock-runtime.${AWS_REGION}.amazonaws.com", "anthropic.claude-3-5-sonnet-20241022-v2:0", []string{"AWS_ACCESS_KEY_ID", "AWS_PROFILE"}, []APIFormat{APIFormatBedrockConverse}, true),
+	transportDescriptor("vertex", "Vertex AI", TransportVertex, "https://aiplatform.googleapis.com", "gemini-2.5-pro", []string{"GOOGLE_APPLICATION_CREDENTIALS"}, []APIFormat{APIFormatVertexGenerateContent}, true),
+	openAICompat("xai", "xAI", "https://api.x.ai/v1", "grok-4", []string{"XAI_API_KEY"}),
+	openAICompat("venice", "Venice AI", "https://api.venice.ai/api/v1", "qwen-2.5-qwq-32b", []string{"VENICE_API_KEY"}),
+	openAICompat("xiaomi-mimo", "Xiaomi MiMo", "https://api.mimo.xiaomi.com/openai/v1", "mimo-vl", []string{"MIMO_API_KEY", "XIAOMI_API_KEY"}, "xiaomi mimo"),
+	openAICompat("bankr", "Bankr", "https://api.bankr.bot/v1", "bankr-large", []string{"BANKR_API_KEY"}),
+	openAICompat("zai", "Z.ai", "https://open.bigmodel.cn/api/paas/v4", "glm-4.5", []string{"ZAI_API_KEY", "ZHIPU_API_KEY"}),
+	openAICompat("gitlawb-opengateway", "GitLawb OpenGateway", "https://gateway.gitlawb.com/v1", "gpt-4.1", []string{"GITLAWB_OPENGATEWAY_API_KEY"}, "gitlawb opengateway"),
+	openAICompat("opencode", "OpenCode", "https://api.opencode.ai/v1", "qwen3-coder", []string{"OPENCODE_API_KEY"}),
+	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
+	openAICompat("custom-openai-compatible", "Custom OpenAI-compatible", "https://example.invalid/v1", "custom-model", []string{"OPENAI_API_KEY"}, "custom openai compatible"),
+	anthropicCompat("custom-anthropic-compatible", "Custom Anthropic-compatible", "https://example.invalid/anthropic", "custom-model", []string{"ANTHROPIC_API_KEY"}, "custom anthropic compatible"),
+}
+
+func All() []Descriptor {
+	copied := make([]Descriptor, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		copied = append(copied, cloneDescriptor(descriptor))
+	}
+	return copied
+}
+
+func IDs() []string {
+	ids := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		ids = append(ids, descriptor.ID)
+	}
+	return ids
+}
+
+func Get(id string) (Descriptor, bool) {
+	normalized := NormalizeID(id)
+	for _, descriptor := range descriptors {
+		if descriptor.ID == normalized {
+			return cloneDescriptor(descriptor), true
+		}
+		for _, alias := range descriptor.Aliases {
+			if NormalizeID(alias) == normalized {
+				return cloneDescriptor(descriptor), true
+			}
+		}
+	}
+	return Descriptor{}, false
+}
+
+func Require(id string) (Descriptor, error) {
+	normalized := NormalizeID(id)
+	descriptor, ok := Get(normalized)
+	if !ok {
+		return Descriptor{}, fmt.Errorf("%w %q", ErrUnknownProvider, normalized)
+	}
+	return descriptor, nil
+}
+
+func ListByTransport(transport Transport) []Descriptor {
+	normalized := Transport(NormalizeID(string(transport)))
+	items := make([]Descriptor, 0)
+	for _, descriptor := range descriptors {
+		if descriptor.Transport == normalized {
+			items = append(items, cloneDescriptor(descriptor))
+		}
+	}
+	return items
+}
+
+func ValidTransport(transport Transport) bool {
+	switch Transport(NormalizeID(string(transport))) {
+	case TransportOpenAI, TransportAnthropic, TransportGoogle, TransportBedrock, TransportVertex, TransportOpenAICompatible, TransportAnthropicCompatible:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidAPIFormat(format APIFormat) bool {
+	switch format {
+	case APIFormatOpenAIResponses, APIFormatOpenAIChatCompletions, APIFormatAnthropicMessages, APIFormatGoogleGenerateContent, APIFormatBedrockConverse, APIFormatVertexGenerateContent:
+		return true
+	default:
+		return false
+	}
+}
+
+func NormalizeID(id string) string {
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(id)) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			builder.WriteRune(r)
+			lastDash = false
+		default:
+			if builder.Len() > 0 && !lastDash {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
+func openAI(id string, name string, baseURL string, model string, env []string, aliases ...string) Descriptor {
+	return Descriptor{
+		ID:                  id,
+		Name:                name,
+		Transport:           TransportOpenAI,
+		DefaultBaseURL:      baseURL,
+		DefaultModel:        model,
+		AuthEnvVars:         env,
+		RequiresAuth:        true,
+		SupportedAPIFormats: []APIFormat{APIFormatOpenAIResponses, APIFormatOpenAIChatCompletions},
+		Aliases:             aliases,
+	}
+}
+
+func anthropic(id string, name string, baseURL string, model string, env []string, aliases ...string) Descriptor {
+	return Descriptor{
+		ID:                  id,
+		Name:                name,
+		Transport:           TransportAnthropic,
+		DefaultBaseURL:      baseURL,
+		DefaultModel:        model,
+		AuthEnvVars:         env,
+		RequiresAuth:        true,
+		SupportedAPIFormats: []APIFormat{APIFormatAnthropicMessages},
+		Aliases:             aliases,
+	}
+}
+
+func google(id string, name string, baseURL string, model string, env []string, aliases ...string) Descriptor {
+	return Descriptor{
+		ID:                  id,
+		Name:                name,
+		Transport:           TransportGoogle,
+		DefaultBaseURL:      baseURL,
+		DefaultModel:        model,
+		AuthEnvVars:         env,
+		RequiresAuth:        true,
+		SupportedAPIFormats: []APIFormat{APIFormatGoogleGenerateContent},
+		Aliases:             aliases,
+	}
+}
+
+func localOpenAI(id string, name string, baseURL string, model string, aliases ...string) Descriptor {
+	descriptor := openAICompat(id, name, baseURL, model, nil, aliases...)
+	descriptor.RequiresAuth = false
+	descriptor.Local = true
+	return descriptor
+}
+
+func openAICompat(id string, name string, baseURL string, model string, env []string, aliases ...string) Descriptor {
+	return Descriptor{
+		ID:                  id,
+		Name:                name,
+		Transport:           TransportOpenAICompatible,
+		DefaultBaseURL:      baseURL,
+		DefaultModel:        model,
+		AuthEnvVars:         env,
+		RequiresAuth:        len(env) > 0,
+		SupportedAPIFormats: []APIFormat{APIFormatOpenAIChatCompletions},
+		Aliases:             aliases,
+	}
+}
+
+func anthropicCompat(id string, name string, baseURL string, model string, env []string, aliases ...string) Descriptor {
+	return Descriptor{
+		ID:                  id,
+		Name:                name,
+		Transport:           TransportAnthropicCompatible,
+		DefaultBaseURL:      baseURL,
+		DefaultModel:        model,
+		AuthEnvVars:         env,
+		RequiresAuth:        len(env) > 0,
+		SupportedAPIFormats: []APIFormat{APIFormatAnthropicMessages},
+		Aliases:             aliases,
+	}
+}
+
+func transportDescriptor(id string, name string, transport Transport, baseURL string, model string, env []string, formats []APIFormat, ambient bool) Descriptor {
+	return Descriptor{
+		ID:                  id,
+		Name:                name,
+		Transport:           transport,
+		DefaultBaseURL:      baseURL,
+		DefaultModel:        model,
+		AuthEnvVars:         env,
+		RequiresAuth:        len(env) > 0 || ambient,
+		UsesAmbientAuth:     ambient,
+		SupportedAPIFormats: append([]APIFormat{}, formats...),
+	}
+}
+
+func cloneDescriptor(descriptor Descriptor) Descriptor {
+	descriptor.AuthEnvVars = append([]string{}, descriptor.AuthEnvVars...)
+	descriptor.SupportedAPIFormats = append([]APIFormat{}, descriptor.SupportedAPIFormats...)
+	descriptor.Aliases = append([]string{}, descriptor.Aliases...)
+	return descriptor
+}

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -49,6 +49,27 @@ type Descriptor struct {
 	Aliases             []string
 }
 
+func RuntimeSupported(descriptor Descriptor) bool {
+	switch descriptor.Transport {
+	case TransportOpenAI, TransportOpenAICompatible, TransportAnthropic, TransportAnthropicCompatible, TransportGoogle:
+		return true
+	default:
+		return false
+	}
+}
+
+func RuntimeUnsupportedReason(descriptor Descriptor) string {
+	if RuntimeSupported(descriptor) {
+		return ""
+	}
+	switch descriptor.Transport {
+	case TransportBedrock, TransportVertex:
+		return "native adapter not implemented yet"
+	default:
+		return "provider transport not implemented yet"
+	}
+}
+
 var descriptors = []Descriptor{
 	openAI("openai", "OpenAI", "https://api.openai.com/v1", "gpt-4.1", []string{"OPENAI_API_KEY"}),
 	anthropic("anthropic", "Anthropic", "https://api.anthropic.com", "claude-sonnet-4.5", []string{"ANTHROPIC_API_KEY"}),

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -1,0 +1,251 @@
+package providercatalog
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var expectedCatalogIDs = []string{
+	"openai",
+	"anthropic",
+	"google",
+	"ollama",
+	"lmstudio",
+	"openrouter",
+	"groq",
+	"deepseek",
+	"together",
+	"dashscope",
+	"moonshot",
+	"nvidia-nim",
+	"minimax",
+	"mistral",
+	"github",
+	"bedrock",
+	"vertex",
+	"xai",
+	"venice",
+	"xiaomi-mimo",
+	"bankr",
+	"zai",
+	"gitlawb-opengateway",
+	"opencode",
+	"atomic-chat",
+	"custom-openai-compatible",
+	"custom-anthropic-compatible",
+}
+
+func TestAllHasStableUniqueIDs(t *testing.T) {
+	descriptors := All()
+	if len(descriptors) != len(expectedCatalogIDs) {
+		t.Fatalf("All() returned %d descriptors, want %d", len(descriptors), len(expectedCatalogIDs))
+	}
+
+	seen := map[string]bool{}
+	for index, descriptor := range descriptors {
+		if descriptor.ID != expectedCatalogIDs[index] {
+			t.Fatalf("All()[%d].ID = %q, want %q", index, descriptor.ID, expectedCatalogIDs[index])
+		}
+		if seen[descriptor.ID] {
+			t.Fatalf("duplicate descriptor ID %q", descriptor.ID)
+		}
+		seen[descriptor.ID] = true
+	}
+	if !reflect.DeepEqual(IDs(), expectedCatalogIDs) {
+		t.Fatalf("IDs() = %#v, want %#v", IDs(), expectedCatalogIDs)
+	}
+}
+
+func TestCatalogDescriptorsExposeRequiredDefaults(t *testing.T) {
+	for _, descriptor := range All() {
+		if descriptor.ID == "" {
+			t.Fatal("provider ID is required")
+		}
+		if descriptor.Name == "" {
+			t.Fatalf("provider %q should expose a display name", descriptor.ID)
+		}
+		if descriptor.Transport == "" {
+			t.Fatalf("provider %q should expose a transport", descriptor.ID)
+		}
+		if !ValidTransport(descriptor.Transport) {
+			t.Fatalf("provider %q has unknown transport %q", descriptor.ID, descriptor.Transport)
+		}
+		if descriptor.DefaultBaseURL == "" {
+			t.Fatalf("provider %q should expose a default base URL", descriptor.ID)
+		}
+		if descriptor.DefaultModel == "" {
+			t.Fatalf("provider %q should expose a default model", descriptor.ID)
+		}
+		if len(descriptor.SupportedAPIFormats) == 0 {
+			t.Fatalf("provider %q should expose at least one supported API format", descriptor.ID)
+		}
+		for _, format := range descriptor.SupportedAPIFormats {
+			if !ValidAPIFormat(format) {
+				t.Fatalf("provider %q has unknown API format %q", descriptor.ID, format)
+			}
+		}
+	}
+	if ValidTransport("missing") {
+		t.Fatal("ValidTransport should reject unknown transports")
+	}
+	if ValidAPIFormat("missing") {
+		t.Fatal("ValidAPIFormat should reject unknown API formats")
+	}
+}
+
+func TestRemoteProvidersDeclareAuthOrExplicitPublicAccess(t *testing.T) {
+	for _, descriptor := range All() {
+		if descriptor.Local {
+			continue
+		}
+		if descriptor.RequiresAuth && (len(descriptor.AuthEnvVars) > 0 || descriptor.UsesAmbientAuth) {
+			continue
+		}
+		if descriptor.Public && !descriptor.RequiresAuth {
+			continue
+		}
+		t.Fatalf("%s is remote but declares neither credential env vars, ambient auth, nor public access", descriptor.ID)
+	}
+}
+
+func TestLocalProvidersDoNotRequireAuth(t *testing.T) {
+	for _, id := range []string{"ollama", "lmstudio"} {
+		descriptor, err := Require(id)
+		if err != nil {
+			t.Fatalf("Require(%q) error = %v", id, err)
+		}
+		if !descriptor.Local {
+			t.Fatalf("%s Local = false, want true", id)
+		}
+		if descriptor.RequiresAuth {
+			t.Fatalf("%s RequiresAuth = true, want false", id)
+		}
+		if len(descriptor.AuthEnvVars) != 0 {
+			t.Fatalf("%s AuthEnvVars = %#v, want empty", id, descriptor.AuthEnvVars)
+		}
+	}
+}
+
+func TestLookupNormalizesIDsAndAliases(t *testing.T) {
+	cases := map[string]string{
+		" OpenAI ":                     "openai",
+		"Gemini":                       "google",
+		"lm-studio":                    "lmstudio",
+		"mini_max":                     "minimax",
+		"Moonshot":                     "moonshot",
+		"nvidia nim":                   "nvidia-nim",
+		"xiaomi mimo":                  "xiaomi-mimo",
+		"custom_openai_compatible":     "custom-openai-compatible",
+		"custom--anthropic compatible": "custom-anthropic-compatible",
+		"GitLawb OpenGateway":          "gitlawb-opengateway",
+	}
+	for input, want := range cases {
+		descriptor, ok := Get(input)
+		if !ok {
+			t.Fatalf("Get(%q) returned false", input)
+		}
+		if descriptor.ID != want {
+			t.Fatalf("Get(%q).ID = %q, want %q", input, descriptor.ID, want)
+		}
+
+		required, err := Require(input)
+		if err != nil {
+			t.Fatalf("Require(%q) error = %v", input, err)
+		}
+		if required.ID != want {
+			t.Fatalf("Require(%q).ID = %q, want %q", input, required.ID, want)
+		}
+	}
+
+	if normalized := NormalizeID("custom--anthropic compatible"); normalized != "custom-anthropic-compatible" {
+		t.Fatalf("NormalizeID() = %q, want custom-anthropic-compatible", normalized)
+	}
+	if _, ok := Get("unknown-provider"); ok {
+		t.Fatal("Get should reject unknown provider IDs")
+	}
+	if _, err := Require("  Not_A_Provider  "); err == nil {
+		t.Fatal("Require should reject unknown provider IDs")
+	} else {
+		if !errors.Is(err, ErrUnknownProvider) {
+			t.Fatalf("Require error = %v, want ErrUnknownProvider", err)
+		}
+		if !strings.Contains(err.Error(), `unknown provider "not-a-provider"`) {
+			t.Fatalf("Require error = %q, want normalized provider ID", err.Error())
+		}
+	}
+}
+
+func TestListByTransportPreservesCatalogOrder(t *testing.T) {
+	cases := map[Transport][]string{
+		TransportOpenAI:          {"openai"},
+		TransportAnthropic:       {"anthropic"},
+		TransportGoogle:          {"google"},
+		TransportBedrock:         {"bedrock"},
+		TransportVertex:          {"vertex"},
+		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
+		TransportOpenAICompat:    {"ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "opencode", "atomic-chat", "custom-openai-compatible"},
+	}
+
+	for transport, wantIDs := range cases {
+		descriptors := ListByTransport(transport)
+		gotIDs := make([]string, 0, len(descriptors))
+		for _, descriptor := range descriptors {
+			if descriptor.Transport != Transport(NormalizeID(string(transport))) {
+				t.Fatalf("ListByTransport(%q) returned provider %q with transport %q", transport, descriptor.ID, descriptor.Transport)
+			}
+			gotIDs = append(gotIDs, descriptor.ID)
+		}
+		if !reflect.DeepEqual(gotIDs, wantIDs) {
+			t.Fatalf("ListByTransport(%q) IDs = %#v, want %#v", transport, gotIDs, wantIDs)
+		}
+	}
+	if descriptors := ListByTransport("missing"); len(descriptors) != 0 {
+		t.Fatalf("ListByTransport(missing) returned %#v, want empty", descriptors)
+	}
+	if gotIDs := descriptorIDs(ListByTransport(TransportOpenAICompatible)); !reflect.DeepEqual(gotIDs, cases[TransportOpenAICompat]) {
+		t.Fatalf("ListByTransport(openai-compatible alias) IDs = %#v, want %#v", gotIDs, cases[TransportOpenAICompat])
+	}
+	if gotIDs := descriptorIDs(ListByTransport(TransportAnthropicCompatible)); !reflect.DeepEqual(gotIDs, cases[TransportAnthropicCompat]) {
+		t.Fatalf("ListByTransport(anthropic-compatible alias) IDs = %#v, want %#v", gotIDs, cases[TransportAnthropicCompat])
+	}
+}
+
+func TestReturnedDescriptorsAreCopies(t *testing.T) {
+	descriptors := All()
+	descriptors[0].ID = "changed"
+	descriptors[0].AuthEnvVars[0] = "BROKEN"
+	descriptors[0].SupportedAPIFormats[0] = "broken"
+
+	descriptor, ok := Get("openai")
+	if !ok {
+		t.Fatal("Get(openai) returned false")
+	}
+	if descriptor.ID != "openai" {
+		t.Fatalf("catalog entry mutated through All(): %#v", descriptor)
+	}
+	if descriptor.AuthEnvVars[0] != "OPENAI_API_KEY" {
+		t.Fatalf("descriptor auth env vars are shared, got %q", descriptor.AuthEnvVars[0])
+	}
+	if descriptor.SupportedAPIFormats[0] != APIFormatOpenAIResponses {
+		t.Fatalf("descriptor API formats are shared, got %q", descriptor.SupportedAPIFormats[0])
+	}
+
+	descriptor.AuthEnvVars[0] = "BROKEN-AGAIN"
+	next, ok := Get("openai")
+	if !ok {
+		t.Fatal("Get(openai) returned false on second lookup")
+	}
+	if next.AuthEnvVars[0] != "OPENAI_API_KEY" {
+		t.Fatalf("descriptor slices are shared, got %q", next.AuthEnvVars[0])
+	}
+}
+
+func descriptorIDs(descriptors []Descriptor) []string {
+	ids := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		ids = append(ids, descriptor.ID)
+	}
+	return ids
+}

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -31,7 +31,6 @@ var expectedCatalogIDs = []string{
 	"bankr",
 	"zai",
 	"gitlawb-opengateway",
-	"opencode",
 	"atomic-chat",
 	"custom-openai-compatible",
 	"custom-anthropic-compatible",
@@ -185,7 +184,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "opencode", "atomic-chat", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -25,14 +25,18 @@ const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures an Anthropic Messages API provider.
 type Options struct {
-	APIKey     string
-	BaseURL    string
-	Model      string
-	MaxTokens  int
-	Version    string
-	Beta       string
-	HTTPClient *http.Client
-	UserAgent  string
+	APIKey          string
+	BaseURL         string
+	Model           string
+	MaxTokens       int
+	Version         string
+	Beta            string
+	AuthHeader      string
+	AuthScheme      string
+	AuthHeaderValue string
+	CustomHeaders   map[string]string
+	HTTPClient      *http.Client
+	UserAgent       string
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
 	// Zero uses defaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
@@ -46,6 +50,10 @@ type Provider struct {
 	maxTokens         int
 	version           string
 	beta              string
+	authHeader        string
+	authScheme        string
+	authHeaderValue   string
+	customHeaders     map[string]string
 	httpClient        *http.Client
 	userAgent         string
 	streamIdleTimeout time.Duration
@@ -80,6 +88,10 @@ func New(options Options) (*Provider, error) {
 		maxTokens:         maxTokens,
 		version:           version,
 		beta:              strings.TrimSpace(options.Beta),
+		authHeader:        strings.TrimSpace(options.AuthHeader),
+		authScheme:        strings.TrimSpace(options.AuthScheme),
+		authHeaderValue:   strings.TrimSpace(options.AuthHeaderValue),
+		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
 		httpClient:        providerio.HTTPClient(options.HTTPClient),
 		userAgent:         options.UserAgent,
 		streamIdleTimeout: idleTimeout,
@@ -117,15 +129,20 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, provider.baseURL+"/v1/messages", body, func(request *http.Request) {
 		request.Header.Set("Content-Type", "application/json")
 		request.Header.Set("anthropic-version", provider.version)
-		if provider.apiKey != "" {
-			request.Header.Set("x-api-key", provider.apiKey)
-		}
 		if provider.beta != "" {
 			request.Header.Set("anthropic-beta", provider.beta)
 		}
 		if provider.userAgent != "" {
 			request.Header.Set("User-Agent", provider.userAgent)
 		}
+		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+			APIKey:            provider.apiKey,
+			DefaultAuthHeader: "x-api-key",
+			AuthHeader:        provider.authHeader,
+			AuthScheme:        provider.authScheme,
+			AuthHeaderValue:   provider.authHeaderValue,
+			CustomHeaders:     provider.customHeaders,
+		})
 	}, 0)
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
@@ -423,11 +440,11 @@ func parseErrorMessage(body []byte) string {
 }
 
 func (provider *Provider) classifiedError(statusCode int, message string) string {
-	return providerio.ClassifiedError(statusCode, message, provider.apiKey)
+	return providerio.ClassifiedError(statusCode, message, provider.apiKey, provider.authHeaderValue)
 }
 
 func (provider *Provider) redact(message string) string {
-	return providerio.Redact(message, provider.apiKey)
+	return providerio.Redact(message, provider.apiKey, provider.authHeaderValue)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -122,6 +122,48 @@ func TestStreamCompletionPostsMessagesRequest(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionAppliesCustomAuthAndHeaders(t *testing.T) {
+	var gotDefaultAuth string
+	var gotCustomAuth string
+	var gotTenant string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotDefaultAuth = r.Header.Get("x-api-key")
+		gotCustomAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Tenant")
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:        "sk-ant",
+		BaseURL:       server.URL,
+		Model:         "claude-test",
+		AuthHeader:    "Authorization",
+		AuthScheme:    "Bearer",
+		CustomHeaders: map[string]string{"X-Tenant": "zero"},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if gotDefaultAuth != "" {
+		t.Fatalf("x-api-key = %q, want empty when custom auth header is used", gotDefaultAuth)
+	}
+	if gotCustomAuth != "Bearer sk-ant" {
+		t.Fatalf("Authorization = %q, want bearer token", gotCustomAuth)
+	}
+	if gotTenant != "zero" {
+		t.Fatalf("X-Tenant = %q, want custom header", gotTenant)
+	}
+}
+
 func TestStreamCompletionEmitsTextUsageAndDone(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSEEvent(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":25}}}`)

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -37,7 +37,7 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 			HTTPClient: options.HTTPClient,
 			UserAgent:  options.UserAgent,
 		})
-	case config.ProviderKindAnthropic:
+	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
 		return anthropic.New(anthropic.Options{
 			APIKey:     profile.APIKey,
 			BaseURL:    resolved.baseURL,
@@ -106,6 +106,10 @@ func resolveProfile(profile config.ProviderProfile, options Options) (resolvedPr
 		if providerKind == config.ProviderKindOpenAICompatible {
 			if !entry.AllowsProvider(modelregistry.ProviderOpenAICompatible) {
 				return resolvedProfile{}, fmt.Errorf("zero model %s belongs to %s, not %s", entry.ID, entry.Provider, modelregistry.ProviderOpenAICompatible)
+			}
+		} else if providerKind == config.ProviderKindAnthropicCompat {
+			if !entry.AllowsProvider(modelregistry.ProviderAnthropic) {
+				return resolvedProfile{}, fmt.Errorf("zero model %s belongs to %s, not %s", entry.ID, entry.Provider, providerKind)
 			}
 		} else if providerKind != modelProvider {
 			return resolvedProfile{}, fmt.Errorf("zero model %s belongs to %s, not %s", entry.ID, entry.Provider, providerKind)

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -30,30 +30,42 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 	switch resolved.providerKind {
 	case config.ProviderKindOpenAI, config.ProviderKindOpenAICompatible:
 		return openai.New(openai.Options{
-			APIKey:     profile.APIKey,
-			BaseURL:    resolved.baseURL,
-			Model:      resolved.apiModel,
-			MaxTokens:  resolved.maxOutputTokens,
-			HTTPClient: options.HTTPClient,
-			UserAgent:  options.UserAgent,
+			APIKey:          profile.APIKey,
+			BaseURL:         resolved.baseURL,
+			Model:           resolved.apiModel,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
+			MaxTokens:       resolved.maxOutputTokens,
+			HTTPClient:      options.HTTPClient,
+			UserAgent:       options.UserAgent,
 		})
 	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
 		return anthropic.New(anthropic.Options{
-			APIKey:     profile.APIKey,
-			BaseURL:    resolved.baseURL,
-			Model:      resolved.apiModel,
-			MaxTokens:  resolved.maxOutputTokens,
-			HTTPClient: options.HTTPClient,
-			UserAgent:  options.UserAgent,
+			APIKey:          profile.APIKey,
+			BaseURL:         resolved.baseURL,
+			Model:           resolved.apiModel,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
+			MaxTokens:       resolved.maxOutputTokens,
+			HTTPClient:      options.HTTPClient,
+			UserAgent:       options.UserAgent,
 		})
 	case config.ProviderKindGoogle:
 		return gemini.New(gemini.Options{
-			APIKey:     profile.APIKey,
-			BaseURL:    resolved.baseURL,
-			Model:      resolved.apiModel,
-			MaxTokens:  resolved.maxOutputTokens,
-			HTTPClient: options.HTTPClient,
-			UserAgent:  options.UserAgent,
+			APIKey:          profile.APIKey,
+			BaseURL:         resolved.baseURL,
+			Model:           resolved.apiModel,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
+			MaxTokens:       resolved.maxOutputTokens,
+			HTTPClient:      options.HTTPClient,
+			UserAgent:       options.UserAgent,
 		})
 	default:
 		return nil, fmt.Errorf("unsupported provider kind %q", resolved.providerKind)

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -55,6 +55,45 @@ func TestNewCreatesOpenAIProviderWithFactoryOptions(t *testing.T) {
 	}
 }
 
+func TestNewThreadsCustomProviderHeaders(t *testing.T) {
+	transport := &captureTransport{
+		responseBody: "data: [DONE]\n\n",
+	}
+	client := &http.Client{Transport: transport}
+
+	provider, err := New(config.ProviderProfile{
+		Name:          "gateway",
+		ProviderKind:  config.ProviderKindOpenAICompatible,
+		BaseURL:       "https://gateway.example/v1",
+		APIKey:        "sk-gateway",
+		AuthHeader:    "X-API-Key",
+		AuthScheme:    "Token",
+		CustomHeaders: map[string]string{"HTTP-Referer": "https://zero.dev"},
+		Model:         "gateway-model",
+	}, Options{HTTPClient: client})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+
+	if transport.request.Header.Get("Authorization") != "" {
+		t.Fatalf("Authorization = %q, want empty when custom auth header is set", transport.request.Header.Get("Authorization"))
+	}
+	if transport.request.Header.Get("X-API-Key") != "Token sk-gateway" {
+		t.Fatalf("X-API-Key = %q, want custom auth header", transport.request.Header.Get("X-API-Key"))
+	}
+	if transport.request.Header.Get("HTTP-Referer") != "https://zero.dev" {
+		t.Fatalf("HTTP-Referer = %q, want custom provider header", transport.request.Header.Get("HTTP-Referer"))
+	}
+}
+
 func TestNewSupportsOpenAIProviderKind(t *testing.T) {
 	provider, err := New(config.ProviderProfile{
 		Name:         "openai",

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -25,12 +25,16 @@ const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures a Gemini streamGenerateContent provider.
 type Options struct {
-	APIKey     string
-	BaseURL    string
-	Model      string
-	MaxTokens  int
-	HTTPClient *http.Client
-	UserAgent  string
+	APIKey          string
+	BaseURL         string
+	Model           string
+	MaxTokens       int
+	AuthHeader      string
+	AuthScheme      string
+	AuthHeaderValue string
+	CustomHeaders   map[string]string
+	HTTPClient      *http.Client
+	UserAgent       string
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
 	// Zero uses defaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
@@ -42,6 +46,10 @@ type Provider struct {
 	baseURL           string
 	model             string
 	maxTokens         int
+	authHeader        string
+	authScheme        string
+	authHeaderValue   string
+	customHeaders     map[string]string
 	httpClient        *http.Client
 	userAgent         string
 	streamIdleTimeout time.Duration
@@ -70,6 +78,10 @@ func New(options Options) (*Provider, error) {
 		baseURL:           baseURL,
 		model:             model,
 		maxTokens:         maxTokens,
+		authHeader:        strings.TrimSpace(options.AuthHeader),
+		authScheme:        strings.TrimSpace(options.AuthScheme),
+		authHeaderValue:   strings.TrimSpace(options.AuthHeaderValue),
+		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
 		httpClient:        providerio.HTTPClient(options.HTTPClient),
 		userAgent:         options.UserAgent,
 		streamIdleTimeout: idleTimeout,
@@ -106,12 +118,17 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 
 	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, provider.streamURL(), body, func(request *http.Request) {
 		request.Header.Set("Content-Type", "application/json")
-		if provider.apiKey != "" {
-			request.Header.Set("x-goog-api-key", provider.apiKey)
-		}
 		if provider.userAgent != "" {
 			request.Header.Set("User-Agent", provider.userAgent)
 		}
+		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+			APIKey:            provider.apiKey,
+			DefaultAuthHeader: "x-goog-api-key",
+			AuthHeader:        provider.authHeader,
+			AuthScheme:        provider.authScheme,
+			AuthHeaderValue:   provider.authHeaderValue,
+			CustomHeaders:     provider.customHeaders,
+		})
 	}, 0)
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
@@ -420,11 +437,11 @@ func (provider *Provider) streamURL() string {
 }
 
 func (provider *Provider) classifiedError(statusCode int, message string) string {
-	return providerio.ClassifiedError(statusCode, message, provider.apiKey)
+	return providerio.ClassifiedError(statusCode, message, provider.apiKey, provider.authHeaderValue)
 }
 
 func (provider *Provider) redact(message string) string {
-	return providerio.Redact(message, provider.apiKey)
+	return providerio.Redact(message, provider.apiKey, provider.authHeaderValue)
 }
 
 func normalizeModel(model string) string {

--- a/internal/providers/gemini/provider_test.go
+++ b/internal/providers/gemini/provider_test.go
@@ -116,6 +116,48 @@ func TestStreamCompletionPostsGenerateContentRequest(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionAppliesCustomAuthAndHeaders(t *testing.T) {
+	var gotDefaultAuth string
+	var gotCustomAuth string
+	var gotTenant string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotDefaultAuth = r.Header.Get("x-goog-api-key")
+		gotCustomAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Tenant")
+		writeSSE(w, `{}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:        "sk-google",
+		BaseURL:       server.URL,
+		Model:         "gemini-test",
+		AuthHeader:    "Authorization",
+		AuthScheme:    "Bearer",
+		CustomHeaders: map[string]string{"X-Tenant": "zero"},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if gotDefaultAuth != "" {
+		t.Fatalf("x-goog-api-key = %q, want empty when custom auth header is used", gotDefaultAuth)
+	}
+	if gotCustomAuth != "Bearer sk-google" {
+		t.Fatalf("Authorization = %q, want bearer token", gotCustomAuth)
+	}
+	if gotTenant != "zero" {
+		t.Fatalf("X-Tenant = %q, want custom header", gotTenant)
+	}
+}
+
 func TestStreamCompletionEmitsTextUsageAndReasoningTokens(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}`)

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -24,11 +24,15 @@ const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures an OpenAI-compatible chat completions provider.
 type Options struct {
-	APIKey     string
-	BaseURL    string
-	Model      string
-	HTTPClient *http.Client
-	UserAgent  string
+	APIKey          string
+	BaseURL         string
+	Model           string
+	AuthHeader      string
+	AuthScheme      string
+	AuthHeaderValue string
+	CustomHeaders   map[string]string
+	HTTPClient      *http.Client
+	UserAgent       string
 	// MaxTokens caps the model's output tokens. Zero omits the cap (the model's
 	// own default applies). Resolved from the model registry by the factory.
 	MaxTokens int
@@ -42,6 +46,10 @@ type Provider struct {
 	apiKey            string
 	baseURL           string
 	model             string
+	authHeader        string
+	authScheme        string
+	authHeaderValue   string
+	customHeaders     map[string]string
 	maxTokens         int
 	httpClient        *http.Client
 	userAgent         string
@@ -83,6 +91,10 @@ func New(options Options) (*Provider, error) {
 		apiKey:            options.APIKey,
 		baseURL:           baseURL,
 		model:             model,
+		authHeader:        strings.TrimSpace(options.AuthHeader),
+		authScheme:        strings.TrimSpace(options.AuthScheme),
+		authHeaderValue:   strings.TrimSpace(options.AuthHeaderValue),
+		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
 		maxTokens:         maxTokens,
 		httpClient:        httpClient,
 		userAgent:         options.UserAgent,
@@ -126,9 +138,15 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		if provider.userAgent != "" {
 			request.Header.Set("User-Agent", provider.userAgent)
 		}
-		if provider.apiKey != "" {
-			request.Header.Set("Authorization", "Bearer "+provider.apiKey)
-		}
+		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+			APIKey:            provider.apiKey,
+			DefaultAuthHeader: "Authorization",
+			DefaultAuthScheme: "Bearer",
+			AuthHeader:        provider.authHeader,
+			AuthScheme:        provider.authScheme,
+			AuthHeaderValue:   provider.authHeaderValue,
+			CustomHeaders:     provider.customHeaders,
+		})
 	}, 0)
 	if err != nil {
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
@@ -269,11 +287,11 @@ func (provider *Provider) emitHTTPError(ctx context.Context, response *http.Resp
 }
 
 func (provider *Provider) classifiedError(statusCode int, message string) string {
-	return providerio.ClassifiedError(statusCode, message, provider.apiKey)
+	return providerio.ClassifiedError(statusCode, message, provider.apiKey, provider.authHeaderValue)
 }
 
 func (provider *Provider) redact(message string) string {
-	return providerio.Redact(message, provider.apiKey)
+	return providerio.Redact(message, provider.apiKey, provider.authHeaderValue)
 }
 
 func sendEvent(ctx context.Context, events chan<- zeroruntime.StreamEvent, event zeroruntime.StreamEvent) {

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -147,6 +147,48 @@ func TestStreamCompletionOmitsAuthAndToolsWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionAppliesCustomAuthAndHeaders(t *testing.T) {
+	var gotAuth string
+	var gotAltAuth string
+	var gotReferer string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAltAuth = r.Header.Get("X-API-Key")
+		gotReferer = r.Header.Get("HTTP-Referer")
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:        "sk-custom",
+		BaseURL:       server.URL,
+		Model:         "custom-model",
+		AuthHeader:    "X-API-Key",
+		AuthScheme:    "Token",
+		CustomHeaders: map[string]string{"HTTP-Referer": "https://zero.dev"},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if gotAuth != "" {
+		t.Fatalf("Authorization = %q, want empty when custom auth header is used", gotAuth)
+	}
+	if gotAltAuth != "Token sk-custom" {
+		t.Fatalf("X-API-Key = %q, want custom scheme token", gotAltAuth)
+	}
+	if gotReferer != "https://zero.dev" {
+		t.Fatalf("HTTP-Referer = %q, want custom header", gotReferer)
+	}
+}
+
 func TestStreamCompletionEmitsTextUsageAndDone(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"content":"hello "}}]}`)

--- a/internal/providers/providerio/headers.go
+++ b/internal/providers/providerio/headers.go
@@ -1,0 +1,64 @@
+package providerio
+
+import (
+	"net/http"
+	"strings"
+)
+
+type AuthHeaders struct {
+	APIKey            string
+	DefaultAuthHeader string
+	DefaultAuthScheme string
+	AuthHeader        string
+	AuthScheme        string
+	AuthHeaderValue   string
+	CustomHeaders     map[string]string
+}
+
+func ApplyAuthHeaders(request *http.Request, options AuthHeaders) {
+	for key, value := range options.CustomHeaders {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		request.Header.Set(key, strings.TrimSpace(value))
+	}
+
+	header := strings.TrimSpace(options.AuthHeader)
+	customHeader := header != ""
+	if header == "" {
+		header = strings.TrimSpace(options.DefaultAuthHeader)
+	}
+	if header == "" {
+		return
+	}
+
+	value := strings.TrimSpace(options.AuthHeaderValue)
+	if value == "" {
+		apiKey := strings.TrimSpace(options.APIKey)
+		if apiKey == "" {
+			return
+		}
+		scheme := strings.TrimSpace(options.AuthScheme)
+		if !customHeader && scheme == "" {
+			scheme = strings.TrimSpace(options.DefaultAuthScheme)
+		}
+		if scheme != "" && !strings.EqualFold(scheme, "none") && !strings.EqualFold(scheme, "raw") {
+			value = scheme + " " + apiKey
+		} else {
+			value = apiKey
+		}
+	}
+	request.Header.Set(header, value)
+}
+
+func CopyHeaders(headers map[string]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
+}

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -194,7 +194,7 @@ func ScanSSEDataWithContext(
 }
 
 // ClassifiedError normalizes provider HTTP/stream errors and redacts secrets.
-func ClassifiedError(statusCode int, message string, apiKey string) string {
+func ClassifiedError(statusCode int, message string, secrets ...string) string {
 	prefix := "provider error: "
 	switch statusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
@@ -206,13 +206,15 @@ func ClassifiedError(statusCode int, message string, apiKey string) string {
 			prefix = "provider request error: "
 		}
 	}
-	return Redact(prefix+message, apiKey)
+	return Redact(prefix+message, secrets...)
 }
 
 // Redact removes known API-key and bearer-token forms from provider messages.
-func Redact(message string, apiKey string) string {
-	if apiKey != "" {
-		message = strings.ReplaceAll(message, apiKey, "[REDACTED]")
+func Redact(message string, secrets ...string) string {
+	for _, secret := range secrets {
+		if secret != "" {
+			message = strings.ReplaceAll(message, secret, "[REDACTED]")
+		}
 	}
 	words := strings.Fields(message)
 	for index := 0; index < len(words)-1; index++ {

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -116,7 +116,7 @@ func (m model) handleModelCommand(args string) (model, string) {
 	if !ok {
 		return m, "Model\nunknown Zero model " + strconv.Quote(args)
 	}
-	if m.providerProfile == (config.ProviderProfile{}) {
+	if !config.HasProviderProfile(m.providerProfile) {
 		return m, "Model\nNo provider profile is available for TUI model switching."
 	}
 	if m.newProvider == nil {
@@ -199,7 +199,7 @@ func (m model) handleModeCommand(args string) (model, string) {
 	if !ok {
 		return m, "Mode\nmode " + strconv.Quote(mode.Name) + " references unknown model " + strconv.Quote(mode.Model)
 	}
-	if m.providerProfile == (config.ProviderProfile{}) {
+	if !config.HasProviderProfile(m.providerProfile) {
 		return m, "Mode\nNo provider profile is available for TUI mode switching."
 	}
 	if m.newProvider == nil {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -100,7 +100,7 @@ func (m model) providerText() string {
 		"provider: " + displayValue(m.providerName, "none"),
 		"model: " + displayValue(m.modelName, "none"),
 	}
-	if m.providerProfile != (config.ProviderProfile{}) {
+	if config.HasProviderProfile(m.providerProfile) {
 		snapshot := zerocommands.ProviderSnapshotFromProfile(m.providerProfile, true)
 		profileLines = append(profileLines,
 			"kind: "+displayValue(snapshot.ProviderKind, "unknown"),

--- a/internal/zerocommands/contracts.go
+++ b/internal/zerocommands/contracts.go
@@ -76,14 +76,16 @@ type ProviderCatalogSnapshotOptions struct {
 }
 
 type ProviderCatalogSnapshot struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	Transport      string   `json:"transport"`
-	DefaultBaseURL string   `json:"defaultBaseUrl,omitempty"`
-	DefaultModel   string   `json:"defaultModel,omitempty"`
-	AuthEnvVars    []string `json:"authEnvVars,omitempty"`
-	RequiresAuth   bool     `json:"requiresAuth"`
-	Local          bool     `json:"local"`
+	ID                       string   `json:"id"`
+	Name                     string   `json:"name"`
+	Transport                string   `json:"transport"`
+	DefaultBaseURL           string   `json:"defaultBaseUrl,omitempty"`
+	DefaultModel             string   `json:"defaultModel,omitempty"`
+	AuthEnvVars              []string `json:"authEnvVars,omitempty"`
+	RequiresAuth             bool     `json:"requiresAuth"`
+	Local                    bool     `json:"local"`
+	RuntimeSupported         bool     `json:"runtimeSupported"`
+	RuntimeUnsupportedReason string   `json:"runtimeUnsupportedReason,omitempty"`
 }
 
 type SessionSnapshot struct {
@@ -220,14 +222,16 @@ func knownProviderCatalogTransport(transport string) bool {
 
 func ProviderCatalogSnapshotFromDescriptor(descriptor providercatalog.Descriptor) ProviderCatalogSnapshot {
 	return ProviderCatalogSnapshot{
-		ID:             descriptor.ID,
-		Name:           descriptor.Name,
-		Transport:      string(descriptor.Transport),
-		DefaultBaseURL: descriptor.DefaultBaseURL,
-		DefaultModel:   descriptor.DefaultModel,
-		AuthEnvVars:    append([]string{}, descriptor.AuthEnvVars...),
-		RequiresAuth:   descriptor.RequiresAuth,
-		Local:          descriptor.Local,
+		ID:                       descriptor.ID,
+		Name:                     descriptor.Name,
+		Transport:                string(descriptor.Transport),
+		DefaultBaseURL:           descriptor.DefaultBaseURL,
+		DefaultModel:             descriptor.DefaultModel,
+		AuthEnvVars:              append([]string{}, descriptor.AuthEnvVars...),
+		RequiresAuth:             descriptor.RequiresAuth,
+		Local:                    descriptor.Local,
+		RuntimeSupported:         providercatalog.RuntimeSupported(descriptor),
+		RuntimeUnsupportedReason: providercatalog.RuntimeUnsupportedReason(descriptor),
 	}
 }
 

--- a/internal/zerocommands/contracts.go
+++ b/internal/zerocommands/contracts.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -68,6 +69,21 @@ type ModelSnapshot struct {
 	Capabilities     []string `json:"capabilities"`
 	ReasoningEfforts []string `json:"reasoningEfforts,omitempty"`
 	Description      string   `json:"description,omitempty"`
+}
+
+type ProviderCatalogSnapshotOptions struct {
+	Transport string
+}
+
+type ProviderCatalogSnapshot struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Transport      string   `json:"transport"`
+	DefaultBaseURL string   `json:"defaultBaseUrl,omitempty"`
+	DefaultModel   string   `json:"defaultModel,omitempty"`
+	AuthEnvVars    []string `json:"authEnvVars,omitempty"`
+	RequiresAuth   bool     `json:"requiresAuth"`
+	Local          bool     `json:"local"`
 }
 
 type SessionSnapshot struct {
@@ -171,6 +187,48 @@ func ModelSnapshots(registry modelregistry.Registry, options ModelSnapshotOption
 		return snapshots[i].Provider < snapshots[j].Provider
 	})
 	return snapshots, nil
+}
+
+func ProviderCatalogSnapshots(options ProviderCatalogSnapshotOptions) ([]ProviderCatalogSnapshot, error) {
+	transportFilter := strings.TrimSpace(strings.ToLower(options.Transport))
+	if transportFilter != "" && !knownProviderCatalogTransport(transportFilter) {
+		return nil, UsageError(fmt.Sprintf("unknown provider transport %q", options.Transport))
+	}
+
+	descriptors := providercatalog.All()
+	snapshots := make([]ProviderCatalogSnapshot, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		if transportFilter != "" && strings.ToLower(string(descriptor.Transport)) != transportFilter {
+			continue
+		}
+		snapshots = append(snapshots, ProviderCatalogSnapshotFromDescriptor(descriptor))
+	}
+	sort.SliceStable(snapshots, func(i int, j int) bool {
+		return snapshots[i].ID < snapshots[j].ID
+	})
+	return snapshots, nil
+}
+
+func knownProviderCatalogTransport(transport string) bool {
+	for _, descriptor := range providercatalog.All() {
+		if strings.ToLower(string(descriptor.Transport)) == transport {
+			return true
+		}
+	}
+	return false
+}
+
+func ProviderCatalogSnapshotFromDescriptor(descriptor providercatalog.Descriptor) ProviderCatalogSnapshot {
+	return ProviderCatalogSnapshot{
+		ID:             descriptor.ID,
+		Name:           descriptor.Name,
+		Transport:      string(descriptor.Transport),
+		DefaultBaseURL: descriptor.DefaultBaseURL,
+		DefaultModel:   descriptor.DefaultModel,
+		AuthEnvVars:    append([]string{}, descriptor.AuthEnvVars...),
+		RequiresAuth:   descriptor.RequiresAuth,
+		Local:          descriptor.Local,
+	}
 }
 
 func modelMatchesProvider(model modelregistry.ModelEntry, providerFilter modelregistry.ProviderKind) bool {

--- a/internal/zerocommands/contracts_test.go
+++ b/internal/zerocommands/contracts_test.go
@@ -155,6 +155,68 @@ func TestModelSnapshotsRejectUnknownProvider(t *testing.T) {
 	}
 }
 
+func TestProviderCatalogSnapshotsExposeStableDescriptors(t *testing.T) {
+	snapshots, err := ProviderCatalogSnapshots(ProviderCatalogSnapshotOptions{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) < 4 {
+		t.Fatalf("expected provider catalog descriptors, got %#v", snapshots)
+	}
+	for index, snapshot := range snapshots {
+		if snapshot.ID == "" || snapshot.Name == "" || snapshot.Transport == "" {
+			t.Fatalf("catalog snapshot missing identity fields: %#v", snapshot)
+		}
+		if index > 0 && snapshots[index-1].ID > snapshot.ID {
+			t.Fatalf("provider catalog snapshots are not sorted by id: %#v", snapshots)
+		}
+	}
+	openai := findCatalogSnapshot(t, snapshots, "openai")
+	if openai.Name != "OpenAI" ||
+		openai.Transport != "openai" ||
+		openai.DefaultBaseURL != config.OpenAIBaseURL ||
+		openai.DefaultModel != modelregistry.DefaultModelID ||
+		!openai.RequiresAuth ||
+		openai.Local {
+		t.Fatalf("unexpected OpenAI catalog snapshot: %#v", openai)
+	}
+	if len(openai.AuthEnvVars) != 1 || openai.AuthEnvVars[0] != "OPENAI_API_KEY" {
+		t.Fatalf("unexpected OpenAI auth env vars: %#v", openai.AuthEnvVars)
+	}
+}
+
+func TestProviderCatalogSnapshotsFilterByTransport(t *testing.T) {
+	snapshots, err := ProviderCatalogSnapshots(ProviderCatalogSnapshotOptions{Transport: "OPENAI"})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) == 0 {
+		t.Fatal("expected OpenAI provider catalog descriptors")
+	}
+	for _, snapshot := range snapshots {
+		if snapshot.Transport != "openai" {
+			t.Fatalf("unexpected transport in filtered catalog: %#v", snapshot)
+		}
+	}
+}
+
+func TestProviderCatalogSnapshotsRejectUnknownTransport(t *testing.T) {
+	_, err := ProviderCatalogSnapshots(ProviderCatalogSnapshotOptions{Transport: "space-link"})
+
+	if err == nil {
+		t.Fatal("expected unknown transport error")
+	}
+	commandErr, ok := err.(CommandError)
+	if !ok {
+		t.Fatalf("expected CommandError, got %T: %v", err, err)
+	}
+	if commandErr.Kind != ErrorKindUsage || !strings.Contains(commandErr.Message, `unknown provider transport "space-link"`) {
+		t.Fatalf("unexpected command error: %#v", commandErr)
+	}
+}
+
 func TestSessionSnapshotsPreserveLineageFields(t *testing.T) {
 	items := []sessions.Metadata{
 		{
@@ -193,6 +255,18 @@ func TestSessionSnapshotsPreserveLineageFields(t *testing.T) {
 	if child.Tag != "specialist" || child.Depth != 1 {
 		t.Fatalf("session specialist metadata was not preserved: %#v", child)
 	}
+}
+
+func findCatalogSnapshot(t *testing.T, snapshots []ProviderCatalogSnapshot, id string) ProviderCatalogSnapshot {
+	t.Helper()
+
+	for _, snapshot := range snapshots {
+		if snapshot.ID == id {
+			return snapshot
+		}
+	}
+	t.Fatalf("catalog descriptor %q not found in %#v", id, snapshots)
+	return ProviderCatalogSnapshot{}
 }
 
 func TestSessionTreeSnapshotConvertsChildren(t *testing.T) {

--- a/internal/zerocommands/contracts_test.go
+++ b/internal/zerocommands/contracts_test.go
@@ -178,11 +178,20 @@ func TestProviderCatalogSnapshotsExposeStableDescriptors(t *testing.T) {
 		openai.DefaultBaseURL != config.OpenAIBaseURL ||
 		openai.DefaultModel != modelregistry.DefaultModelID ||
 		!openai.RequiresAuth ||
-		openai.Local {
+		openai.Local ||
+		!openai.RuntimeSupported {
 		t.Fatalf("unexpected OpenAI catalog snapshot: %#v", openai)
 	}
 	if len(openai.AuthEnvVars) != 1 || openai.AuthEnvVars[0] != "OPENAI_API_KEY" {
 		t.Fatalf("unexpected OpenAI auth env vars: %#v", openai.AuthEnvVars)
+	}
+
+	bedrock := findCatalogSnapshot(t, snapshots, "bedrock")
+	if bedrock.RuntimeSupported {
+		t.Fatalf("Bedrock must stay catalog-only until the native adapter lands: %#v", bedrock)
+	}
+	if !strings.Contains(bedrock.RuntimeUnsupportedReason, "native adapter") {
+		t.Fatalf("Bedrock unsupported reason = %q, want native adapter reason", bedrock.RuntimeUnsupportedReason)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a data-only provider catalog with OpenClaude-level provider coverage and transport/API format metadata.
- Extend Go provider profiles with catalog IDs, env-backed API key refs, API format/auth header fields, and custom headers.
- Add `zero providers catalog [--json] [--transport <transport>]` with runtime support metadata so Bedrock/Vertex are clearly catalog-only until native adapters land.
- Add `zero providers add <catalog-id>` to save compatible provider profiles into user config without persisting raw API keys.
- Add `zero providers check [name]` to validate resolved provider readiness and runtime construction.
- Route Anthropic-compatible profiles through the existing Anthropic wire adapter and thread custom auth/header config through OpenAI, Anthropic, and Gemini clients.

## Runtime coverage
- Working through existing transports: OpenAI, Anthropic, Google/Gemini, OpenAI-compatible providers, Anthropic-compatible providers.
- Catalog-only for now: Bedrock and Vertex, marked `runtimeSupported=false` because native adapters are not implemented yet.

## Validation
- go test ./internal/providercatalog ./internal/zerocommands ./internal/config ./internal/providers ./internal/providers/openai ./internal/providers/anthropic ./internal/providers/gemini ./internal/providers/providerio ./internal/cli
- go test ./...
- go run ./cmd/zero-release build
- go run ./cmd/zero-release smoke
- Manual temp-config smoke:
  - go run ./cmd/zero providers add groq --name fast --set-active
  - go run ./cmd/zero providers check fast with missing GROQ_API_KEY, expected failure
  - go run ./cmd/zero providers check fast with GROQ_API_KEY set, expected success
  - go run ./cmd/zero providers catalog --transport bedrock, expected runtimeSupported=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "providers catalog" command: browse provider catalog (filter by transport; pretty or JSON) with runtime support info.
  * CLI provider management: add providers to user config, set active provider, and run readiness checks (JSON or formatted).
  * Accept catalog IDs and configurable auth header/scheme/value plus custom headers when adding providers.

* **Bug Fixes / Improvements**
  * More consistent “no provider” detection and stronger secret redaction.
  * Safer config path resolution and tightened config file permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->