### PR TITLE
CLI: doctor config validation, autonomy ceiling, changes --base, usage report

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -323,7 +323,7 @@ func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string, perm
 	}
 	sandboxEngine := sandbox.NewEngine(sandbox.EngineOptions{
 		WorkspaceRoot: workspaceRoot,
-		Policy:        sandbox.DefaultPolicy(),
+		Policy:        applyConfiguredAutonomyCeiling(sandbox.DefaultPolicy(), resolved.Sandbox.MaxAutonomy),
 		Store:         sandboxStore,
 		Backend:       deps.selectSandboxBackend(sandbox.BackendOptions{}),
 	})

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -197,6 +197,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runVerifyCommand(args[1:], stdout, stderr, deps)
 	case "changes", "change":
 		return runChanges(args[1:], stdout, stderr, deps)
+	case "usage":
+		return runUsage(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
 	case "zeroline":
@@ -444,6 +446,7 @@ Commands:
   worktrees  Prepare isolated git worktrees
   verify     Detect and run local verification checks
   changes    Inspect and commit local git changes
+  usage      Summarize token usage and estimated cost
   serve      Run Zero protocol servers
   zeroline    Launch the interactive TUI with the Zeroline reskin
   help       Show this help

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -644,6 +644,7 @@ func assertHelpOutput(t *testing.T, args []string) {
 		"worktrees",
 		"verify",
 		"serve",
+		"usage",
 		"zeroline",
 		"--version",
 	} {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -158,10 +158,6 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err := preflightExecSession(options); err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
-	sandboxEngine, err := buildExecSandboxEngine(workspaceRoot, deps)
-	if err != nil {
-		return writeExecProviderError(stdout, stderr, options.outputFormat, "sandbox_error", err.Error())
-	}
 
 	prompt, err := resolveExecPrompt(options, workspaceRoot, deps.stdin)
 	if err != nil {
@@ -196,6 +192,10 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 	if resolved.Provider == (config.ProviderProfile{}) {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", "No provider configured. Set OPENAI_MODEL/OPENAI_API_KEY or add .zero/config.json.")
+	}
+	sandboxEngine, err := buildExecSandboxEngine(workspaceRoot, resolved, deps)
+	if err != nil {
+		return writeExecProviderError(stdout, stderr, options.outputFormat, "sandbox_error", err.Error())
 	}
 	// Evaluate the --reasoning-effort advisory against the EFFECTIVE resolved
 	// model (resolved.Provider.Model), not the override. Without an explicit
@@ -392,12 +392,12 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	return exitSuccess
 }
 
-func buildExecSandboxEngine(workspaceRoot string, deps appDeps) (*sandbox.Engine, error) {
+func buildExecSandboxEngine(workspaceRoot string, resolved config.ResolvedConfig, deps appDeps) (*sandbox.Engine, error) {
 	store, err := deps.newSandboxStore()
 	if err != nil {
 		return nil, err
 	}
-	policy := sandbox.DefaultPolicy()
+	policy := applyConfiguredAutonomyCeiling(sandbox.DefaultPolicy(), resolved.Sandbox.MaxAutonomy)
 	backend := deps.selectSandboxBackend(sandbox.BackendOptions{})
 	return sandbox.NewEngine(sandbox.EngineOptions{
 		WorkspaceRoot: workspaceRoot,
@@ -405,6 +405,23 @@ func buildExecSandboxEngine(workspaceRoot string, deps appDeps) (*sandbox.Engine
 		Store:         store,
 		Backend:       backend,
 	}), nil
+}
+
+// applyConfiguredAutonomyCeiling overlays a config-sourced autonomy ceiling onto
+// a policy. An empty ceiling is a no-op so the default High ceiling is preserved
+// (backward compatible). An unrecognised value is ignored so a malformed config
+// never silently lowers or raises the ceiling.
+func applyConfiguredAutonomyCeiling(policy sandbox.Policy, maxAutonomy string) sandbox.Policy {
+	trimmed := strings.TrimSpace(maxAutonomy)
+	if trimmed == "" {
+		return policy
+	}
+	normalized, err := sandbox.NormalizeAutonomy(sandbox.Autonomy(trimmed))
+	if err != nil {
+		return policy
+	}
+	policy.MaxAutonomy = normalized
+	return policy
 }
 
 func resolveWorkspaceRoot(cwd string, deps appDeps) (string, error) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -409,8 +409,13 @@ func buildExecSandboxEngine(workspaceRoot string, resolved config.ResolvedConfig
 
 // applyConfiguredAutonomyCeiling overlays a config-sourced autonomy ceiling onto
 // a policy. An empty ceiling is a no-op so the default High ceiling is preserved
-// (backward compatible). An unrecognised value is ignored so a malformed config
-// never silently lowers or raises the ceiling.
+// (backward compatible).
+//
+// A non-empty but unrecognised value FAILS CLOSED: it clamps to the most
+// restrictive ceiling (AutonomyLow) rather than leaving the policy unchanged.
+// config.Resolve already rejects invalid values, so this branch is defense in
+// depth — it guarantees that even a direct/programmatic caller passing a typo
+// can never WIDEN the ceiling back to the High default.
 func applyConfiguredAutonomyCeiling(policy sandbox.Policy, maxAutonomy string) sandbox.Policy {
 	trimmed := strings.TrimSpace(maxAutonomy)
 	if trimmed == "" {
@@ -418,6 +423,7 @@ func applyConfiguredAutonomyCeiling(policy sandbox.Policy, maxAutonomy string) s
 	}
 	normalized, err := sandbox.NormalizeAutonomy(sandbox.Autonomy(trimmed))
 	if err != nil {
+		policy.MaxAutonomy = sandbox.AutonomyLow
 		return policy
 	}
 	policy.MaxAutonomy = normalized

--- a/internal/cli/observability.go
+++ b/internal/cli/observability.go
@@ -34,16 +34,28 @@ func runDoctor(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{})
-	if err != nil {
-		return writeAppError(stderr, err.Error(), exitProvider)
+
+	// Resolve config paths for the validation check even if resolution itself
+	// fails on malformed JSON — that failure is exactly what config.validation
+	// is meant to report, so it must not abort the run.
+	var userConfig, projectConfig string
+	if resolveOptions, optErr := config.DefaultResolveOptions(workspaceRoot); optErr == nil {
+		userConfig = resolveOptions.UserConfigPath
+		projectConfig = resolveOptions.ProjectConfigPath
+	}
+
+	var provider config.ProviderProfile
+	if resolved, resolveErr := deps.resolveConfig(workspaceRoot, config.Overrides{}); resolveErr == nil {
+		provider = resolved.Provider
 	}
 
 	report := doctor.Run(doctor.Options{
-		Now:          deps.now,
-		Runtime:      "go",
-		Provider:     resolved.Provider,
-		Connectivity: options.connectivity,
+		Now:           deps.now,
+		Runtime:       "go",
+		UserConfig:    userConfig,
+		ProjectConfig: projectConfig,
+		Provider:      provider,
+		Connectivity:  options.connectivity,
 	})
 	if options.json {
 		if err := writePrettyJSON(stdout, report); err != nil {

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -266,6 +266,9 @@ func TestRunDoctorReportsConfigValidationForMalformedFile(t *testing.T) {
 	if exitCode != exitProvider {
 		t.Fatalf("expected provider exit %d, got %d: %s", exitProvider, exitCode, stderr.String())
 	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
 	var report struct {
 		OK     bool `json:"ok"`
 		Checks []struct {

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -237,6 +240,56 @@ func TestRunSearchJSONRedactsQueryAndSessionMetadata(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "[REDACTED]") {
 		t.Fatalf("expected redacted metadata marker in JSON output: %q", stdout.String())
+	}
+}
+
+func TestRunDoctorReportsConfigValidationForMalformedFile(t *testing.T) {
+	cwd := t.TempDir()
+	zeroDir := filepath.Join(cwd, ".zero")
+	if err := os.MkdirAll(zeroDir, 0o755); err != nil {
+		t.Fatalf("mkdir .zero: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(zeroDir, "config.json"), []byte("{\n  \"activeProvider\": \"openai\",\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"doctor", "--json"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, fmt.Errorf("invalid config JSON %s: unexpected end of JSON input", filepath.Join(zeroDir, "config.json"))
+		},
+		now: fixedCLITime("2026-06-08T11:00:00Z"),
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected provider exit %d, got %d: %s", exitProvider, exitCode, stderr.String())
+	}
+	var report struct {
+		OK     bool `json:"ok"`
+		Checks []struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("doctor JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.OK {
+		t.Fatalf("expected ok=false for malformed config, got %#v", report)
+	}
+	found := false
+	for _, check := range report.Checks {
+		if check.ID == "config.validation" {
+			found = true
+			if check.Status != "fail" {
+				t.Fatalf("expected config.validation fail, got %q", check.Status)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected config.validation check in report: %#v", report)
 	}
 }
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/config"
 	zeroSandbox "github.com/Gitlawb/zero/internal/sandbox"
 )
 
@@ -55,6 +56,9 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
 	policy := zeroSandbox.DefaultPolicy()
+	if resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{}); err == nil {
+		policy = applyConfiguredAutonomyCeiling(policy, resolved.Sandbox.MaxAutonomy)
+	}
 	backend := deps.selectSandboxBackend(zeroSandbox.BackendOptions{})
 	plan := backend.BuildPlan(workspaceRoot, policy)
 	if options.effective {

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -147,6 +147,7 @@ func formatEffectiveSandboxPolicy(workspaceRoot string, policy zeroSandbox.Polic
 		"enforce_workspace: " + fmt.Sprintf("%t", policy.EnforceWorkspace),
 		"deny_destructive_shell: " + fmt.Sprintf("%t", policy.DenyDestructiveShell),
 		"allow_policy_only_runner: " + fmt.Sprintf("%t", policy.AllowPolicyOnlyRunner),
+		"max_autonomy: " + string(policy.MaxAutonomy),
 		"backend: " + string(backend.Name),
 		"support_level: " + string(plan.SupportLevel),
 		"interactive_command_guard: " + enabledLabel(guards.InteractiveCommand),
@@ -416,6 +417,7 @@ func formatSandboxPolicy(workspaceRoot string, policy zeroSandbox.Policy, backen
 		"root: " + workspaceRoot,
 		"mode: " + string(policy.Mode),
 		"network: " + string(policy.Network),
+		"max_autonomy: " + string(policy.MaxAutonomy),
 		"backend: " + string(backend.Name),
 		"support_level: " + string(plan.SupportLevel),
 	}

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -55,10 +55,15 @@ func runSandboxPolicy(args []string, stdout io.Writer, stderr io.Writer, deps ap
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
-	policy := zeroSandbox.DefaultPolicy()
-	if resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{}); err == nil {
-		policy = applyConfiguredAutonomyCeiling(policy, resolved.Sandbox.MaxAutonomy)
+	// Surface config resolution failures instead of silently falling back to
+	// DefaultPolicy() (High): an unresolvable config (e.g. an invalid
+	// sandbox.maxAutonomy that now errors at resolve time) would otherwise
+	// misreport the trust posture as the permissive default.
+	resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
 	}
+	policy := applyConfiguredAutonomyCeiling(zeroSandbox.DefaultPolicy(), resolved.Sandbox.MaxAutonomy)
 	backend := deps.selectSandboxBackend(zeroSandbox.BackendOptions{})
 	plan := backend.BuildPlan(workspaceRoot, policy)
 	if options.effective {

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -326,6 +326,33 @@ func TestRunSandboxPolicyAppliesConfiguredCeiling(t *testing.T) {
 	}
 }
 
+func TestRunSandboxPolicyTextShowsMaxAutonomy(t *testing.T) {
+	store := newSandboxTestStore(t)
+	deps := appDeps{
+		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{Sandbox: config.SandboxConfig{MaxAutonomy: "medium"}}, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runWithDeps([]string{"sandbox", "policy"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("policy exit = %d, stderr %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "max_autonomy: medium") {
+		t.Fatalf("policy text missing max_autonomy line:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWithDeps([]string{"sandbox", "policy", "--effective"}, &stdout, &stderr, deps); code != exitSuccess {
+		t.Fatalf("effective policy exit = %d, stderr %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "max_autonomy: medium") {
+		t.Fatalf("effective policy text missing max_autonomy line:\n%s", stdout.String())
+	}
+}
+
 func newSandboxTestStore(t *testing.T) *sandbox.GrantStore {
 	t.Helper()
 	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -353,6 +353,38 @@ func TestRunSandboxPolicyTextShowsMaxAutonomy(t *testing.T) {
 	}
 }
 
+func TestApplyConfiguredAutonomyCeiling(t *testing.T) {
+	cases := []struct {
+		name        string
+		maxAutonomy string
+		want        sandbox.Autonomy
+	}{
+		// Empty is a no-op: the default High ceiling is preserved.
+		{name: "empty keeps default high", maxAutonomy: "", want: sandbox.AutonomyHigh},
+		{name: "whitespace keeps default high", maxAutonomy: "   ", want: sandbox.AutonomyHigh},
+		{name: "valid low", maxAutonomy: "low", want: sandbox.AutonomyLow},
+		{name: "valid medium", maxAutonomy: "medium", want: sandbox.AutonomyMedium},
+		{name: "valid high", maxAutonomy: "high", want: sandbox.AutonomyHigh},
+		{name: "case-insensitive medium", maxAutonomy: "MEDIUM", want: sandbox.AutonomyMedium},
+		// Fail-closed: an invalid non-empty value clamps to the most restrictive
+		// ceiling instead of leaving the High default in place.
+		{name: "invalid banana clamps to low", maxAutonomy: "banana", want: sandbox.AutonomyLow},
+		{name: "invalid moderate clamps to low", maxAutonomy: "moderate", want: sandbox.AutonomyLow},
+		{name: "invalid med clamps to low", maxAutonomy: "med", want: sandbox.AutonomyLow},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if base := sandbox.DefaultPolicy(); base.MaxAutonomy != sandbox.AutonomyHigh {
+				t.Fatalf("precondition: DefaultPolicy().MaxAutonomy = %q, want high", base.MaxAutonomy)
+			}
+			policy := applyConfiguredAutonomyCeiling(sandbox.DefaultPolicy(), tc.maxAutonomy)
+			if policy.MaxAutonomy != tc.want {
+				t.Fatalf("applyConfiguredAutonomyCeiling(_, %q).MaxAutonomy = %q, want %q", tc.maxAutonomy, policy.MaxAutonomy, tc.want)
+			}
+		})
+	}
+}
+
 func newSandboxTestStore(t *testing.T) *sandbox.GrantStore {
 	t.Helper()
 	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -105,6 +106,9 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 	deps := appDeps{
 		getwd:           func() (string, error) { return t.TempDir(), nil },
 		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
 		selectSandboxBackend: func(options sandbox.BackendOptions) sandbox.Backend {
 			return sandbox.Backend{
 				Name:     sandbox.BackendPolicyOnly,
@@ -188,6 +192,9 @@ func TestRunSandboxPolicyEffectiveTextAndJSON(t *testing.T) {
 	deps := appDeps{
 		getwd:           func() (string, error) { return t.TempDir(), nil },
 		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
 		selectSandboxBackend: func(options sandbox.BackendOptions) sandbox.Backend {
 			return sandbox.Backend{
 				Name:     sandbox.BackendPolicyOnly,
@@ -350,6 +357,29 @@ func TestRunSandboxPolicyTextShowsMaxAutonomy(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "max_autonomy: medium") {
 		t.Fatalf("effective policy text missing max_autonomy line:\n%s", stdout.String())
+	}
+}
+
+func TestRunSandboxPolicySurfacesResolveConfigError(t *testing.T) {
+	store := newSandboxTestStore(t)
+	deps := appDeps{
+		getwd:           func() (string, error) { return t.TempDir(), nil },
+		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, fmt.Errorf("invalid sandbox.maxAutonomy %q", "moderate")
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "policy"}, &stdout, &stderr, deps)
+	if exitCode != exitProvider {
+		t.Fatalf("policy exit = %d, want provider exit %d (resolve error surfaced, not silent DefaultPolicy fallback)", exitCode, exitProvider)
+	}
+	if !strings.Contains(stderr.String(), "invalid sandbox.maxAutonomy") {
+		t.Fatalf("expected surfaced resolve error in stderr, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout on resolve error, got %q", stdout.String())
 	}
 }
 

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
@@ -297,6 +298,31 @@ func TestRunSandboxHelpDoesNotOpenStore(t *testing.T) {
 				t.Fatalf("expected help output")
 			}
 		})
+	}
+}
+
+func TestRunSandboxPolicyAppliesConfiguredCeiling(t *testing.T) {
+	store := newSandboxTestStore(t)
+	deps := appDeps{
+		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{Sandbox: config.SandboxConfig{MaxAutonomy: "medium"}}, nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "policy", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("policy exit = %d, stderr %q", exitCode, stderr.String())
+	}
+	var payload struct {
+		Policy sandbox.Policy `json:"policy"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode policy JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.Policy.MaxAutonomy != sandbox.AutonomyMedium {
+		t.Fatalf("policy.MaxAutonomy = %q, want medium", payload.Policy.MaxAutonomy)
 	}
 }
 

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -112,8 +113,9 @@ func runUsage(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	// Parse the pre-redaction --stat: redaction can rewrite the numeric summary
-	// line, so net-LOC must be derived from the raw stat before any scrubbing.
+	// The --stat summary line ("N files changed, A insertions(+), B deletions(-)")
+	// carries no secret-bearing tokens, so parsing the already-redacted DiffStat
+	// returned by zerogit.Inspect is safe.
 	diff := zerogit.ParseDiffStat(summary.DiffStat)
 
 	registry, err := modelregistry.DefaultRegistry()
@@ -182,10 +184,17 @@ func parseUsageArgs(args []string) (usageOptions, bool, error) {
 			if err != nil {
 				return options, false, err
 			}
+			if _, parseErr := time.Parse("2006-01-02", value); parseErr != nil {
+				return options, false, execUsageError{fmt.Sprintf("invalid --since %q: expected YYYY-MM-DD", value)}
+			}
 			options.since = value
 			index = next
 		case strings.HasPrefix(arg, "--since="):
-			options.since = strings.TrimSpace(strings.TrimPrefix(arg, "--since="))
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--since="))
+			if _, parseErr := time.Parse("2006-01-02", value); parseErr != nil {
+				return options, false, execUsageError{fmt.Sprintf("invalid --since %q: expected YYYY-MM-DD", value)}
+			}
+			options.since = value
 		case arg == "--session" || arg == "--session-id":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -60,15 +60,24 @@ func filterEventsSince(events []sessions.Event, since string) []sessions.Event {
 	}
 	filtered := make([]sessions.Event, 0, len(events))
 	for _, event := range events {
-		date := event.CreatedAt
-		if len(date) >= 10 {
-			date = date[:10]
-		}
-		if date >= since {
+		if eventUTCDate(event.CreatedAt) >= since {
 			filtered = append(filtered, event)
 		}
 	}
 	return filtered
+}
+
+// eventUTCDate maps an RFC3339 timestamp to its UTC calendar date (YYYY-MM-DD)
+// so the --since/--days cutoff compares against the same UTC day the report
+// buckets under. On a parse failure it falls back to the leading-10 slice.
+func eventUTCDate(createdAt string) string {
+	if parsed, err := time.Parse(time.RFC3339, createdAt); err == nil {
+		return parsed.UTC().Format("2006-01-02")
+	}
+	if len(createdAt) >= 10 {
+		return createdAt[:10]
+	}
+	return createdAt
 }
 
 func runUsage(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -200,12 +209,23 @@ func parseUsageArgs(args []string) (usageOptions, bool, error) {
 			if err != nil {
 				return options, false, err
 			}
-			options.sessionID = value
+			if strings.TrimSpace(value) == "" {
+				return options, false, execUsageError{fmt.Sprintf("%s requires a value", arg)}
+			}
+			options.sessionID = strings.TrimSpace(value)
 			index = next
 		case strings.HasPrefix(arg, "--session="):
-			options.sessionID = strings.TrimSpace(strings.TrimPrefix(arg, "--session="))
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--session="))
+			if value == "" {
+				return options, false, execUsageError{"--session requires a value"}
+			}
+			options.sessionID = value
 		case strings.HasPrefix(arg, "--session-id="):
-			options.sessionID = strings.TrimSpace(strings.TrimPrefix(arg, "--session-id="))
+			value := strings.TrimSpace(strings.TrimPrefix(arg, "--session-id="))
+			if value == "" {
+				return options, false, execUsageError{"--session-id requires a value"}
+			}
+			options.sessionID = value
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unknown usage flag %q", arg)}
 		}

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -1,0 +1,286 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/usage"
+	"github.com/Gitlawb/zero/internal/zerogit"
+)
+
+type usageOptions struct {
+	json      bool
+	days      int
+	since     string
+	sessionID string
+}
+
+// usageEventSet keeps the persisted events paired with the session metadata they
+// were read alongside, so cost reconstruction can resolve each event's owning
+// model id during aggregation.
+type usageEventSet struct {
+	events []sessions.Event
+	meta   []sessions.Metadata
+}
+
+// collectUsageData reads every persisted session's events (optionally limited to
+// a single session id) and returns them flattened alongside the matching session
+// metadata. It mirrors runSearch's persisted-event traversal over the injected
+// session store.
+func collectUsageData(store *sessions.Store, sessionFilter string) (usageEventSet, error) {
+	metadata, err := store.List()
+	if err != nil {
+		return usageEventSet{}, err
+	}
+	set := usageEventSet{}
+	for _, meta := range metadata {
+		if sessionFilter != "" && meta.SessionID != sessionFilter {
+			continue
+		}
+		set.meta = append(set.meta, meta)
+		sessionEvents, err := store.ReadEvents(meta.SessionID)
+		if err != nil {
+			return usageEventSet{}, err
+		}
+		set.events = append(set.events, sessionEvents...)
+	}
+	return set, nil
+}
+
+// filterEventsSince drops events whose UTC calendar date precedes the inclusive
+// lower bound. An empty since returns the events unchanged.
+func filterEventsSince(events []sessions.Event, since string) []sessions.Event {
+	if since == "" {
+		return events
+	}
+	filtered := make([]sessions.Event, 0, len(events))
+	for _, event := range events {
+		date := event.CreatedAt
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+		if date >= since {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+func runUsage(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	subcommand := "report"
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		subcommand = strings.ToLower(strings.TrimSpace(args[0]))
+		args = args[1:]
+	}
+	if subcommand == "help" {
+		if err := writeUsageHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if subcommand != "report" {
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown usage command %q", subcommand))
+	}
+
+	options, help, err := parseUsageArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeUsageHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	set, err := collectUsageData(deps.newSessionStore(), options.sessionID)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	since := usageSinceCutoff(options, deps)
+	events := filterEventsSince(set.events, since)
+
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	summary, err := deps.inspectChanges(context.Background(), zerogit.InspectOptions{Cwd: workspaceRoot})
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	// Parse the pre-redaction --stat: redaction can rewrite the numeric summary
+	// line, so net-LOC must be derived from the raw stat before any scrubbing.
+	diff := zerogit.ParseDiffStat(summary.DiffStat)
+
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	report, err := usage.BuildReport(events, set.meta, &registry, diff.NetLOC())
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, FormatReport(report, diff.Insertions, diff.Deletions)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// usageSinceCutoff resolves the inclusive lower-bound date (YYYY-MM-DD). An
+// explicit --since wins; otherwise --days N derives a cutoff relative to the
+// injected clock. An empty result means "no lower bound".
+func usageSinceCutoff(options usageOptions, deps appDeps) string {
+	if strings.TrimSpace(options.since) != "" {
+		return options.since
+	}
+	if options.days > 0 {
+		cutoff := deps.now().UTC().AddDate(0, 0, -(options.days - 1))
+		return cutoff.Format("2006-01-02")
+	}
+	return ""
+}
+
+func parseUsageArgs(args []string) (usageOptions, bool, error) {
+	options := usageOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--days":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			days, err := parsePositiveOrZeroInt(value, "--days")
+			if err != nil {
+				return options, false, err
+			}
+			options.days = days
+			index = next
+		case strings.HasPrefix(arg, "--days="):
+			days, err := parsePositiveOrZeroInt(strings.TrimSpace(strings.TrimPrefix(arg, "--days=")), "--days")
+			if err != nil {
+				return options, false, err
+			}
+			options.days = days
+		case arg == "--since":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.since = value
+			index = next
+		case strings.HasPrefix(arg, "--since="):
+			options.since = strings.TrimSpace(strings.TrimPrefix(arg, "--since="))
+		case arg == "--session" || arg == "--session-id":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.sessionID = value
+			index = next
+		case strings.HasPrefix(arg, "--session="):
+			options.sessionID = strings.TrimSpace(strings.TrimPrefix(arg, "--session="))
+		case strings.HasPrefix(arg, "--session-id="):
+			options.sessionID = strings.TrimSpace(strings.TrimPrefix(arg, "--session-id="))
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown usage flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+// FormatReport renders a usage Report as a per-day table plus totals and net-LOC
+// efficiency ratios. Cost and net-LOC are labeled as estimates: persisted usage
+// events carry no model id or cost (cost is reconstructed from session
+// metadata), and net-LOC is a working-tree diff proxy. The insertions/deletions
+// counts come straight from the parsed working-tree --stat.
+func FormatReport(report usage.Report, insertions int, deletions int) string {
+	var builder strings.Builder
+	builder.WriteString("Usage report (cost is a reconstructed estimate)\n\n")
+	builder.WriteString(fmt.Sprintf("%-12s %10s %14s %14s\n", "date", "requests", "tokens", "est. cost"))
+	for _, bucket := range report.Buckets {
+		builder.WriteString(fmt.Sprintf("%-12s %10d %14s %14s\n",
+			bucket.Date, bucket.Requests, groupThousands(bucket.TotalTokens), formatUSD(bucket.TotalCost)))
+	}
+	builder.WriteString(fmt.Sprintf("\n%-12s %10d %14s %14s\n",
+		"total", report.Total.Requests, groupThousands(report.Total.TotalTokens), formatUSD(report.Total.TotalCost)))
+
+	builder.WriteString(fmt.Sprintf("\nnet LOC (estimate): +%d / -%d = %d\n",
+		insertions, deletions, report.NetLOC))
+	if report.NetLOCPositive {
+		builder.WriteString(fmt.Sprintf("tokens per net LOC: %.1f\n", report.TokensPerNetLOC))
+		builder.WriteString(fmt.Sprintf("est. cost per net LOC: %s\n", formatUSD(report.CostPerNetLOC)))
+	} else {
+		builder.WriteString("tokens per net LOC: n/a (net LOC <= 0)\n")
+		builder.WriteString("est. cost per net LOC: n/a (net LOC <= 0)\n")
+	}
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func formatUSD(value float64) string {
+	formatted, err := modelregistry.FormatCostUSD(value)
+	if err != nil {
+		return "$0.0000"
+	}
+	return formatted
+}
+
+// groupThousands renders an integer with comma thousands separators, preserving
+// a leading minus sign.
+func groupThousands(value int) string {
+	sign := ""
+	if value < 0 {
+		sign = "-"
+		value = -value
+	}
+	digits := fmt.Sprintf("%d", value)
+	if len(digits) <= 3 {
+		return sign + digits
+	}
+	var out []byte
+	prefix := len(digits) % 3
+	if prefix == 0 {
+		prefix = 3
+	}
+	out = append(out, digits[:prefix]...)
+	for index := prefix; index < len(digits); index += 3 {
+		out = append(out, ',')
+		out = append(out, digits[index:index+3]...)
+	}
+	return sign + string(out)
+}
+
+func writeUsageHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero usage report [flags]
+
+Summarizes token usage and reconstructed (estimated) cost from persisted local
+Zero session usage events, plus a working-tree net-LOC efficiency estimate.
+
+Flags:
+      --json                 Print JSON report
+      --days <number>        Only include the most recent N days
+      --since <YYYY-MM-DD>    Only include events on or after this date
+      --session <id>         Limit the report to one session
+  -h, --help                 Show this help
+
+Cost is reconstructed from session model metadata and is an estimate; net LOC
+is a working-tree diff proxy and is labeled as an estimate.
+`)
+	return err
+}

--- a/internal/cli/usage_test.go
+++ b/internal/cli/usage_test.go
@@ -156,6 +156,41 @@ func TestRunUsageUnknownFlag(t *testing.T) {
 	}
 }
 
+// TestRunUsageEmptySessionRejected verifies that an empty --session/--session-id
+// value is rejected with exitUsage and the value-required error, matching the
+// --since validation style, rather than silently filtering to no session.
+func TestRunUsageEmptySessionRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "session equals empty", args: []string{"usage", "report", "--session="}, flag: "--session"},
+		{name: "session-id equals empty", args: []string{"usage", "report", "--session-id="}, flag: "--session-id"},
+		{name: "session spaced empty", args: []string{"usage", "report", "--session", "   "}, flag: "--session"},
+		{name: "session-id spaced empty", args: []string{"usage", "report", "--session-id", ""}, flag: "--session-id"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exitCode := runWithDeps(tc.args, &stdout, &stderr, appDeps{
+				newSessionStore: func() *sessions.Store {
+					return sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+				},
+				inspectChanges: stubInspectChanges(""),
+			})
+			if exitCode != exitUsage {
+				t.Fatalf("%s: expected exitUsage (%d), got %d", tc.flag, exitUsage, exitCode)
+			}
+			msg := stderr.String()
+			if !strings.Contains(msg, tc.flag+" requires a value") {
+				t.Fatalf("%s: expected value-required error in stderr, got %q", tc.flag, msg)
+			}
+		})
+	}
+}
+
 // seedUsageStoreDates creates a store with usage events spread across two
 // different calendar dates. The "recent" session's events fall on recentDate
 // and the "old" session's events fall on oldDate. Both dates must be

--- a/internal/cli/usage_test.go
+++ b/internal/cli/usage_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/zerogit"
+)
+
+func seedUsageStore(t *testing.T) *sessions.Store {
+	t.Helper()
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLITime("2026-06-01T09:00:00Z")})
+	session, err := store.Create(sessions.CreateInput{SessionID: "usage_s1", Title: "Usage", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	for _, payload := range []map[string]any{
+		{"promptTokens": 1000, "completionTokens": 200, "totalTokens": 1200},
+		{"promptTokens": 500, "completionTokens": 100, "totalTokens": 600},
+	} {
+		if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{Type: sessions.EventUsage, Payload: payload}); err != nil {
+			t.Fatalf("AppendEvent returned error: %v", err)
+		}
+	}
+	return store
+}
+
+func stubInspectChanges(stat string) func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error) {
+	return func(context.Context, zerogit.InspectOptions) (zerogit.ChangeSummary, error) {
+		return zerogit.ChangeSummary{Root: "/repo", DiffStat: stat}, nil
+	}
+}
+
+func TestRunUsageTextReport(t *testing.T) {
+	store := seedUsageStore(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(" 1 file changed, 100 insertions(+), 30 deletions(-)"),
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{"2026-06-01", "1,800", "estimate", "net LOC", "+100", "-30"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("usage report missing %q in:\n%s", want, output)
+		}
+	}
+}
+
+func TestRunUsageDefaultsToReport(t *testing.T) {
+	store := seedUsageStore(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(""),
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "2026-06-01") {
+		t.Fatalf("expected default report output, got %q", stdout.String())
+	}
+}
+
+func TestRunUsageJSONReport(t *testing.T) {
+	store := seedUsageStore(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report", "--json"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(" 1 file changed, 100 insertions(+), 30 deletions(-)"),
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var report struct {
+		NetLOC int `json:"netLOC"`
+		Total  struct {
+			Requests    int `json:"requests"`
+			TotalTokens int `json:"totalTokens"`
+		} `json:"total"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("usage JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.NetLOC != 70 || report.Total.Requests != 2 || report.Total.TotalTokens != 1800 {
+		t.Fatalf("unexpected usage JSON: %+v", report)
+	}
+}
+
+func TestRunUsageSinceFilter(t *testing.T) {
+	store := seedUsageStore(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report", "--since", "2026-07-01"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(""),
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "2026-06-01") {
+		t.Fatalf("expected --since to filter out June events, got %q", stdout.String())
+	}
+}
+
+func TestRunUsageSessionFilter(t *testing.T) {
+	store := seedUsageStore(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report", "--json", "--session", "missing_session"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(""),
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var report struct {
+		Total struct {
+			Requests int `json:"requests"`
+		} `json:"total"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("usage JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.Total.Requests != 0 {
+		t.Fatalf("expected unknown session to yield 0 requests, got %d", report.Total.Requests)
+	}
+}
+
+func TestRunUsageHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "--help"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	for _, want := range []string{"zero usage report", "--json", "--days", "--since", "--session"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("usage help missing %q in:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRunUsageUnknownFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report", "--bogus"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "unknown usage flag") {
+		t.Fatalf("expected unknown-flag error, got %q", stderr.String())
+	}
+}

--- a/internal/cli/usage_test.go
+++ b/internal/cli/usage_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/zerogit"
@@ -152,5 +153,152 @@ func TestRunUsageUnknownFlag(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "unknown usage flag") {
 		t.Fatalf("expected unknown-flag error, got %q", stderr.String())
+	}
+}
+
+// seedUsageStoreDates creates a store with usage events spread across two
+// different calendar dates. The "recent" session's events fall on recentDate
+// and the "old" session's events fall on oldDate. Both dates must be
+// YYYY-MM-DD strings that parse as time.RFC3339 with a T00:00:00Z suffix.
+func seedUsageStoreDates(t *testing.T, recentDate, oldDate string) (*sessions.Store, func() time.Time) {
+	t.Helper()
+
+	// The store's Now function is used to timestamp every appended event.
+	// We swap it via this pointer so we can stamp the two sessions differently.
+	currentTime := mustParseTime(t, recentDate+"T09:00:00Z")
+	nowFunc := func() time.Time { return currentTime }
+
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: nowFunc})
+
+	// Session whose events fall on recentDate.
+	sess, err := store.Create(sessions.CreateInput{SessionID: "days_recent", Title: "Recent", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create recent session: %v", err)
+	}
+	if _, err := store.AppendEvent(sess.SessionID, sessions.AppendEventInput{
+		Type:    sessions.EventUsage,
+		Payload: map[string]any{"promptTokens": 100, "completionTokens": 20, "totalTokens": 120},
+	}); err != nil {
+		t.Fatalf("AppendEvent recent: %v", err)
+	}
+
+	// Swap the clock to oldDate before creating the old session's events.
+	currentTime = mustParseTime(t, oldDate+"T09:00:00Z")
+
+	sessOld, err := store.Create(sessions.CreateInput{SessionID: "days_old", Title: "Old", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("Create old session: %v", err)
+	}
+	if _, err := store.AppendEvent(sessOld.SessionID, sessions.AppendEventInput{
+		Type:    sessions.EventUsage,
+		Payload: map[string]any{"promptTokens": 200, "completionTokens": 40, "totalTokens": 240},
+	}); err != nil {
+		t.Fatalf("AppendEvent old: %v", err)
+	}
+
+	// Return the store and a fixed-time now func anchored at recentDate.
+	return store, fixedCLITime(recentDate + "T12:00:00Z")
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("mustParseTime %q: %v", value, err)
+	}
+	return parsed
+}
+
+// TestRunUsageDaysFilter verifies that --days N excludes events outside the
+// rolling window and includes events inside it.
+func TestRunUsageDaysFilter(t *testing.T) {
+	// recentDate is within the last 3 days; oldDate is 10 days ago.
+	recentDate := "2026-06-06"
+	oldDate := "2026-05-29"
+	store, nowFunc := seedUsageStoreDates(t, recentDate, oldDate)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report", "--days", "3"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(""),
+		now:             nowFunc, // anchored at 2026-06-06T12:00:00Z
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	// The recent event (recentDate) must appear.
+	if !strings.Contains(output, recentDate) {
+		t.Fatalf("--days 3 should include %s, got:\n%s", recentDate, output)
+	}
+	// The old event (oldDate) must be excluded.
+	if strings.Contains(output, oldDate) {
+		t.Fatalf("--days 3 should exclude %s, got:\n%s", oldDate, output)
+	}
+}
+
+// TestRunUsageInvalidSince verifies that malformed --since values are rejected
+// with exitUsage and the expected validation message, while a valid YYYY-MM-DD
+// date is accepted.
+func TestRunUsageInvalidSince(t *testing.T) {
+	cases := []struct {
+		since       string
+		expectError bool
+	}{
+		{"foo", true},
+		{"2026-6-1", true},    // unpadded month/day
+		{"06/01/2026", true},  // wrong separator
+		{"2026-06-01", false}, // valid
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run("since="+tc.since, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exitCode := runWithDeps([]string{"usage", "report", "--since", tc.since}, &stdout, &stderr, appDeps{
+				newSessionStore: func() *sessions.Store {
+					return sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+				},
+				inspectChanges: stubInspectChanges(""),
+			})
+			if tc.expectError {
+				if exitCode != exitUsage {
+					t.Fatalf("--since %q: expected exitUsage (%d), got %d", tc.since, exitUsage, exitCode)
+				}
+				msg := stderr.String()
+				if !strings.Contains(msg, "invalid --since") {
+					t.Fatalf("--since %q: expected validation error in stderr, got %q", tc.since, msg)
+				}
+				if !strings.Contains(msg, "YYYY-MM-DD") {
+					t.Fatalf("--since %q: expected YYYY-MM-DD hint in stderr, got %q", tc.since, msg)
+				}
+			} else {
+				if exitCode != exitSuccess {
+					t.Fatalf("--since %q: expected exitSuccess (%d), got %d: %s", tc.since, exitSuccess, exitCode, stderr.String())
+				}
+			}
+		})
+	}
+}
+
+// TestRunUsageEmptyStore verifies that running `usage report` against a store
+// with no usage events exits successfully, prints the header, shows a zero
+// total, and does not panic.
+func TestRunUsageEmptyStore(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"usage", "report"}, &stdout, &stderr, appDeps{
+		newSessionStore: func() *sessions.Store { return store },
+		inspectChanges:  stubInspectChanges(""),
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("empty store: expected exit %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Usage report") {
+		t.Fatalf("empty store: expected header in output, got:\n%s", output)
+	}
+	// Total row must show zero requests / tokens.
+	if !strings.Contains(output, "total") {
+		t.Fatalf("empty store: expected 'total' row in output, got:\n%s", output)
 	}
 }

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -497,6 +497,37 @@ func TestRunChangesInspectAndCommit(t *testing.T) {
 	})
 }
 
+func TestParseChangesArgsBaseRef(t *testing.T) {
+	for _, args := range [][]string{
+		{"--base", "main"},
+		{"--base=main"},
+	} {
+		options, help, err := parseChangesArgs(args, "inspect")
+		if err != nil {
+			t.Fatalf("parseChangesArgs(%v) error: %v", args, err)
+		}
+		if help {
+			t.Fatalf("parseChangesArgs(%v) returned help", args)
+		}
+		if options.baseRef != "main" {
+			t.Fatalf("baseRef = %q, want main (args %v)", options.baseRef, args)
+		}
+	}
+}
+
+func TestParseChangesArgsRejectsBaseOnCommit(t *testing.T) {
+	_, _, err := parseChangesArgs([]string{"--base", "main"}, "commit")
+	if err == nil || !strings.Contains(err.Error(), "--base") {
+		t.Fatalf("expected --base rejection on commit, got %v", err)
+	}
+}
+
+func TestParseChangesArgsRequiresBaseValue(t *testing.T) {
+	if _, _, err := parseChangesArgs([]string{"--base"}, "inspect"); err == nil {
+		t.Fatalf("expected error when --base has no value")
+	}
+}
+
 func TestRunExecWorktreeUsesPreparedWorkspace(t *testing.T) {
 	root := t.TempDir()
 	worktreeDir := t.TempDir()

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -497,6 +497,64 @@ func TestRunChangesInspectAndCommit(t *testing.T) {
 	})
 }
 
+func TestRunChangesInspectThreadsBaseRef(t *testing.T) {
+	cwd := t.TempDir()
+	summary := zerogit.ChangeSummary{
+		Root:   cwd,
+		Branch: "feature",
+		Base:   "main",
+		Files:  []zerogit.FileChange{{Path: "feature.md", Status: "added"}},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"changes", "inspect", "--base", "main"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		inspectChanges: func(ctx context.Context, options zerogit.InspectOptions) (zerogit.ChangeSummary, error) {
+			if options.BaseRef != "main" {
+				t.Fatalf("InspectOptions.BaseRef = %q, want main", options.BaseRef)
+			}
+			return summary, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "base: main") {
+		t.Fatalf("expected base line in output, got %q", stdout.String())
+	}
+}
+
+func TestRunChangesCommitRejectsBaseRef(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"changes", "commit", "--base", "main"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return t.TempDir(), nil },
+		commitChanges: func(context.Context, zerogit.CommitOptions) (zerogit.CommitResult, error) {
+			t.Fatal("commitChanges should not be called when --base is rejected")
+			return zerogit.CommitResult{}, nil
+		},
+	})
+
+	if exitCode != exitUsage {
+		t.Fatalf("expected usage exit %d, got %d", exitUsage, exitCode)
+	}
+	if !strings.Contains(stderr.String(), "--base") {
+		t.Fatalf("expected --base rejection error, got %q", stderr.String())
+	}
+}
+
+func TestWriteChangesHelpMentionsBase(t *testing.T) {
+	var out bytes.Buffer
+	if err := writeChangesHelp(&out); err != nil {
+		t.Fatalf("writeChangesHelp error: %v", err)
+	}
+	if !strings.Contains(out.String(), "--base") {
+		t.Fatalf("expected --base in changes help, got %q", out.String())
+	}
+}
+
 func TestParseChangesArgsBaseRef(t *testing.T) {
 	for _, args := range [][]string{
 		{"--base", "main"},

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -180,6 +180,7 @@ func runChanges(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 	case "inspect", "status":
 		summary, err := deps.inspectChanges(context.Background(), zerogit.InspectOptions{
 			Cwd:          workspaceRoot,
+			BaseRef:      options.baseRef,
 			MaxDiffBytes: options.maxDiffBytes,
 		})
 		if err != nil {
@@ -630,6 +631,9 @@ func formatChangeSummary(summary zerogit.ChangeSummary) string {
 	if summary.Branch != "" {
 		lines = append(lines, "branch: "+summary.Branch)
 	}
+	if summary.Base != "" {
+		lines = append(lines, "base: "+summary.Base)
+	}
 	if summary.Commit != "" {
 		lines = append(lines, "commit: "+summary.Commit)
 	}
@@ -700,6 +704,7 @@ Inspects local git changes and optionally creates a commit.
 
 Flags:
   -C, --cwd <path>        Workspace directory
+      --base <ref>        Diff against <ref>...HEAD instead of the working tree
       --diff-bytes <n>    Maximum diff bytes to include
   -m, --message <text>    Commit message for `+"`zero changes commit`"+`
       --dry-run           Preview commit metadata without mutating git state

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -33,6 +33,7 @@ type verifyCommandOptions struct {
 type changesCommandOptions struct {
 	json         bool
 	cwd          string
+	baseRef      string
 	message      string
 	dryRun       bool
 	maxDiffBytes int
@@ -374,6 +375,15 @@ func parseChangesArgs(args []string, command string) (changesCommandOptions, boo
 			index = next
 		case strings.HasPrefix(arg, "--cwd="):
 			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
+		case arg == "--base":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.baseRef = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--base="):
+			options.baseRef = strings.TrimSpace(strings.TrimPrefix(arg, "--base="))
 		case arg == "-m" || arg == "--message":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -408,6 +418,9 @@ func parseChangesArgs(args []string, command string) (changesCommandOptions, boo
 	}
 	if command != "commit" && (options.message != "" || options.dryRun) {
 		return options, false, execUsageError{"--message and --dry-run are only valid with `zero changes commit`"}
+	}
+	if command == "commit" && options.baseRef != "" {
+		return options, false, execUsageError{"--base is only valid with `zero changes inspect`"}
 	}
 	return options, false, nil
 }

--- a/internal/cli/workflows.go
+++ b/internal/cli/workflows.go
@@ -384,7 +384,11 @@ func parseChangesArgs(args []string, command string) (changesCommandOptions, boo
 			options.baseRef = strings.TrimSpace(value)
 			index = next
 		case strings.HasPrefix(arg, "--base="):
-			options.baseRef = strings.TrimSpace(strings.TrimPrefix(arg, "--base="))
+			v := strings.TrimSpace(strings.TrimPrefix(arg, "--base="))
+			if v == "" || flagValueLooksLikeOption(v) {
+				return options, false, execUsageError{"--base requires a value"}
+			}
+			options.baseRef = v
 		case arg == "-m" || arg == "--message":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -495,6 +499,7 @@ func redactVerifyLoopReport(report selfverify.Report) selfverify.Report {
 
 func redactChangeSummary(summary zerogit.ChangeSummary) zerogit.ChangeSummary {
 	summary.Root = redactCLIString(summary.Root)
+	summary.Base = redactCLIString(summary.Base)
 	summary.Branch = redactCLIString(summary.Branch)
 	summary.Commit = redactCLIString(summary.Commit)
 	summary.DiffStat = redactCLIString(summary.DiffStat)

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -50,6 +50,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Provider:       active,
 		MaxTurns:       cfg.MaxTurns,
 		MCP:            cfg.MCP,
+		Sandbox:        cfg.Sandbox,
 	}, nil
 }
 
@@ -94,6 +95,9 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 		mergeProvider(dst, provider)
 	}
 	mergeMCPConfig(&dst.MCP, src.MCP)
+	if maxAutonomy := strings.TrimSpace(src.Sandbox.MaxAutonomy); maxAutonomy != "" {
+		dst.Sandbox.MaxAutonomy = maxAutonomy
+	}
 }
 
 func mergeProvider(cfg *FileConfig, provider ProviderProfile) {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -149,6 +149,10 @@ func applyEnv(cfg *FileConfig, env map[string]string) {
 		cfg.ActiveProvider = activeProvider
 	}
 
+	if maxAutonomy := strings.TrimSpace(envValue(env, "ZERO_SANDBOX_MAX_AUTONOMY")); maxAutonomy != "" {
+		cfg.Sandbox.MaxAutonomy = maxAutonomy
+	}
+
 	applyProviderEnv(cfg, ProviderKindOpenAI, envProfile{
 		Name:    string(ProviderKindOpenAI),
 		APIKey:  envValue(env, "OPENAI_API_KEY"),
@@ -249,6 +253,9 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 	}
 	if overrides.MaxTurns > 0 {
 		cfg.MaxTurns = overrides.MaxTurns
+	}
+	if maxAutonomy := strings.TrimSpace(overrides.Sandbox.MaxAutonomy); maxAutonomy != "" {
+		cfg.Sandbox.MaxAutonomy = maxAutonomy
 	}
 	for _, provider := range overrides.Providers {
 		mergeProvider(cfg, provider)

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 const defaultMaxTurns = 12
@@ -38,6 +39,16 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 	}
 
 	applyOverrides(&cfg, options.Overrides)
+
+	if maxAutonomy := strings.TrimSpace(cfg.Sandbox.MaxAutonomy); maxAutonomy != "" {
+		// Fail loud on an invalid ceiling. An unvalidated typo (e.g. "moderate")
+		// would otherwise survive Resolve untouched, reach the sandbox bridge,
+		// fail to normalize there, and silently leave the default High ceiling in
+		// place — fail-open on a security boundary. Reject it here instead.
+		if _, err := sandbox.NormalizeAutonomy(sandbox.Autonomy(maxAutonomy)); err != nil {
+			return ResolvedConfig{}, fmt.Errorf("invalid sandbox.maxAutonomy %q: expected low, medium, or high", maxAutonomy)
+		}
+	}
 
 	providers, active, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider)
 	if err != nil {

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -701,6 +701,40 @@ func TestResolveSandboxMaxAutonomyOverride(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxMaxAutonomyInvalidFailsLoud(t *testing.T) {
+	// A typo'd ceiling must be rejected at resolve time rather than silently
+	// surviving (which would fail-open and keep the default High ceiling).
+	for _, value := range []string{"moderate", "med", "HIGHEST"} {
+		path := writeConfig(t, `{
+			"sandbox": {"maxAutonomy": "`+value+`"},
+			"providers": [{"name": "openai", "provider": "openai", "api_key": "sk", "model": "gpt"}]
+		}`)
+		_, err := Resolve(ResolveOptions{ProjectConfigPath: path})
+		if err == nil {
+			t.Fatalf("Resolve() error = nil for invalid maxAutonomy %q, want failure", value)
+		}
+		if !strings.Contains(err.Error(), "invalid sandbox.maxAutonomy") {
+			t.Fatalf("Resolve() error = %v, want invalid sandbox.maxAutonomy for %q", err, value)
+		}
+	}
+}
+
+func TestResolveSandboxMaxAutonomyValidResolves(t *testing.T) {
+	for _, value := range []string{"low", "medium", "high", "HIGH", " medium "} {
+		path := writeConfig(t, `{
+			"sandbox": {"maxAutonomy": "`+value+`"},
+			"providers": [{"name": "openai", "provider": "openai", "api_key": "sk", "model": "gpt"}]
+		}`)
+		resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path})
+		if err != nil {
+			t.Fatalf("Resolve() error = %v for valid maxAutonomy %q", err, value)
+		}
+		if strings.TrimSpace(resolved.Sandbox.MaxAutonomy) == "" {
+			t.Fatalf("resolved.Sandbox.MaxAutonomy empty for valid input %q", value)
+		}
+	}
+}
+
 func writeConfig(t *testing.T, body string) string {
 	t.Helper()
 

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -661,6 +661,46 @@ func TestResolveSandboxMaxAutonomyFromFile(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxMaxAutonomyPrecedence(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"sandbox": {"maxAutonomy": "low"},
+		"providers": [{"name": "openai", "provider": "openai", "api_key": "sk-user", "model": "gpt-user"}]
+	}`)
+	projectPath := writeConfig(t, `{
+		"sandbox": {"maxAutonomy": "medium"},
+		"providers": [{"name": "openai", "provider": "openai", "api_key": "sk-proj", "model": "gpt-proj"}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{"ZERO_SANDBOX_MAX_AUTONOMY": "high"},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.Sandbox.MaxAutonomy != "high" {
+		t.Fatalf("resolved.Sandbox.MaxAutonomy = %q, want high (env overrides project overrides user)", resolved.Sandbox.MaxAutonomy)
+	}
+}
+
+func TestResolveSandboxMaxAutonomyOverride(t *testing.T) {
+	path := writeConfig(t, `{
+		"sandbox": {"maxAutonomy": "low"},
+		"providers": [{"name": "openai", "provider": "openai", "api_key": "sk", "model": "gpt"}]
+	}`)
+	resolved, err := Resolve(ResolveOptions{
+		ProjectConfigPath: path,
+		Overrides:         Overrides{Sandbox: SandboxConfig{MaxAutonomy: "high"}},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.Sandbox.MaxAutonomy != "high" {
+		t.Fatalf("resolved.Sandbox.MaxAutonomy = %q, want high (override wins)", resolved.Sandbox.MaxAutonomy)
+	}
+}
+
 func writeConfig(t *testing.T, body string) string {
 	t.Helper()
 

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -652,7 +652,7 @@ func TestResolveSandboxMaxAutonomyFromFile(t *testing.T) {
 		}]
 	}`)
 
-	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path})
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
@@ -692,6 +692,7 @@ func TestResolveSandboxMaxAutonomyOverride(t *testing.T) {
 	resolved, err := Resolve(ResolveOptions{
 		ProjectConfigPath: path,
 		Overrides:         Overrides{Sandbox: SandboxConfig{MaxAutonomy: "high"}},
+		Env:               map[string]string{},
 	})
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
@@ -709,7 +710,7 @@ func TestResolveSandboxMaxAutonomyInvalidFailsLoud(t *testing.T) {
 			"sandbox": {"maxAutonomy": "`+value+`"},
 			"providers": [{"name": "openai", "provider": "openai", "api_key": "sk", "model": "gpt"}]
 		}`)
-		_, err := Resolve(ResolveOptions{ProjectConfigPath: path})
+		_, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
 		if err == nil {
 			t.Fatalf("Resolve() error = nil for invalid maxAutonomy %q, want failure", value)
 		}
@@ -725,7 +726,7 @@ func TestResolveSandboxMaxAutonomyValidResolves(t *testing.T) {
 			"sandbox": {"maxAutonomy": "`+value+`"},
 			"providers": [{"name": "openai", "provider": "openai", "api_key": "sk", "model": "gpt"}]
 		}`)
-		resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path})
+		resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path, Env: map[string]string{}})
 		if err != nil {
 			t.Fatalf("Resolve() error = %v for valid maxAutonomy %q", err, value)
 		}

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -641,6 +641,26 @@ func TestResolveRedactsSecretsFromErrors(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxMaxAutonomyFromFile(t *testing.T) {
+	path := writeConfig(t, `{
+		"sandbox": {"maxAutonomy": "medium"},
+		"providers": [{
+			"name": "openai",
+			"provider": "openai",
+			"api_key": "sk-test",
+			"model": "gpt-test"
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{ProjectConfigPath: path})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.Sandbox.MaxAutonomy != "medium" {
+		t.Fatalf("resolved.Sandbox.MaxAutonomy = %q, want medium", resolved.Sandbox.MaxAutonomy)
+	}
+}
+
 func writeConfig(t *testing.T, body string) string {
 	t.Helper()
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -29,11 +29,16 @@ type ProviderProfile struct {
 	Description  string       `json:"description,omitempty"`
 }
 
+type SandboxConfig struct {
+	MaxAutonomy string `json:"maxAutonomy,omitempty"`
+}
+
 type FileConfig struct {
 	ActiveProvider string            `json:"activeProvider,omitempty"`
 	Providers      []ProviderProfile `json:"providers,omitempty"`
 	MaxTurns       int               `json:"maxTurns,omitempty"`
 	MCP            MCPConfig         `json:"mcp,omitempty"`
+	Sandbox        SandboxConfig     `json:"sandbox,omitempty"`
 }
 
 type ResolveOptions struct {
@@ -58,6 +63,7 @@ type ResolvedConfig struct {
 	Provider       ProviderProfile
 	MaxTurns       int
 	MCP            MCPConfig
+	Sandbox        SandboxConfig
 }
 
 type MCPConfig struct {
@@ -81,6 +87,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		Providers       []ProviderProfile          `json:"providers"`
 		MaxTurns        int                        `json:"maxTurns"`
 		MCP             MCPConfig                  `json:"mcp"`
+		Sandbox         SandboxConfig              `json:"sandbox"`
 		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
 	}
@@ -93,6 +100,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.Providers = raw.Providers
 	cfg.MaxTurns = raw.MaxTurns
 	cfg.MCP = raw.MCP
+	cfg.Sandbox = raw.Sandbox
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -55,6 +55,7 @@ type Overrides struct {
 	Provider       ProviderProfile
 	MaxTurns       int
 	MCP            MCPConfig
+	Sandbox        SandboxConfig
 }
 
 type ResolvedConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -34,6 +34,21 @@ func ValidateFile(path string) (FileConfig, []Issue) {
 	return cfg, issues
 }
 
+// ValidateBytes parses data as a Zero FileConfig and runs the same semantic
+// provider/model rules as ValidateFile. It returns the parsed config (zero
+// value on parse failure) plus any structured issues. A parse failure yields a
+// single issue whose Message wraps the underlying JSON error (path-less form:
+// "invalid config JSON: <err>") so callers can extract *json.SyntaxError /
+// *json.UnmarshalTypeError offsets via errors.As.
+func ValidateBytes(data []byte) (FileConfig, []Issue) {
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return FileConfig{}, []Issue{{Message: fmt.Errorf("invalid config JSON: %w", err).Error()}}
+	}
+	issues := validateSemantics(cfg)
+	return cfg, issues
+}
+
 func validateSemantics(cfg FileConfig) []Issue {
 	if _, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider); err != nil {
 		// normalizeProviders already redacts secrets via providerError.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Issue is a single structured problem found while validating a config file.
+// Message is already routed through the package secret redaction.
+type Issue struct {
+	FieldPath string `json:"fieldPath,omitempty"`
+	Message   string `json:"message"`
+}
+
+// ValidateFile reads and parses path as a Zero FileConfig and runs the same
+// semantic provider/model rules used during resolution. It returns the parsed
+// config (zero value on parse failure) plus any structured issues. A parse
+// failure yields a single issue whose Message wraps the underlying JSON error
+// so callers can extract *json.SyntaxError / *json.UnmarshalTypeError offsets
+// via errors.As.
+func ValidateFile(path string) (FileConfig, []Issue) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return FileConfig{}, []Issue{{Message: fmt.Sprintf("read config %s: %v", path, err)}}
+	}
+
+	var cfg FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return FileConfig{}, []Issue{{Message: fmt.Errorf("invalid config JSON %s: %w", path, err).Error()}}
+	}
+
+	issues := validateSemantics(cfg)
+	return cfg, issues
+}
+
+func validateSemantics(cfg FileConfig) []Issue {
+	if _, _, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider); err != nil {
+		// normalizeProviders already redacts secrets via providerError.
+		return []Issue{{FieldPath: "providers", Message: err.Error()}}
+	}
+	return nil
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeValidateFixture(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestValidateFileReturnsParseIssueForMalformedJSON(t *testing.T) {
+	path := writeValidateFixture(t, `{"activeProvider": "openai",`)
+
+	_, issues := ValidateFile(path)
+	if len(issues) == 0 {
+		t.Fatalf("expected parse issue, got none")
+	}
+	if !strings.Contains(issues[0].Message, "invalid config JSON") {
+		t.Fatalf("expected parse issue message, got %#v", issues)
+	}
+}
+
+func TestValidateFileSurfacesSemanticIssue(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "baseURL": "https://example.test/v1", "model": "gpt-4.1"}
+		]
+	}`)
+
+	cfg, issues := ValidateFile(path)
+	if cfg.ActiveProvider != "main" {
+		t.Fatalf("expected parsed config, got %#v", cfg)
+	}
+	if len(issues) == 0 {
+		t.Fatalf("expected semantic issue for openai custom baseURL, got none")
+	}
+}
+
+func TestValidateFileRedactsSecretInIssue(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "baseURL": "https://example.test/v1", "apiKey": "sk-proj-secret1234567890", "model": "gpt-4.1"}
+		]
+	}`)
+
+	_, issues := ValidateFile(path)
+	if len(issues) == 0 {
+		t.Fatalf("expected semantic issue, got none")
+	}
+	for _, issue := range issues {
+		if strings.Contains(issue.Message, "sk-proj-secret") {
+			t.Fatalf("issue leaked apiKey: %q", issue.Message)
+		}
+	}
+}
+
+func TestValidateFileMissingModelWarns(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "anthropic"}
+		]
+	}`)
+
+	_, issues := ValidateFile(path)
+	if len(issues) == 0 {
+		t.Fatalf("expected requires-model issue, got none")
+	}
+	if !strings.Contains(issues[0].Message, "requires model") {
+		t.Fatalf("expected requires-model issue, got %#v", issues)
+	}
+}
+
+func TestValidateFileValidConfigHasNoIssues(t *testing.T) {
+	path := writeValidateFixture(t, `{
+		"activeProvider": "main",
+		"providers": [
+			{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}
+		]
+	}`)
+
+	_, issues := ValidateFile(path)
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues for valid config, got %#v", issues)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -244,14 +244,16 @@ func configValidationCheck(userPath string, projectPath string) Check {
 	issueCount := 0
 	details := map[string]any{}
 	for _, path := range paths {
-		data, readErr := osReadFile(path)
+		data, readErr := os.ReadFile(path)
 		if readErr != nil {
-			// File unreadable (e.g. does not exist) — skip; configFilesCheck
-			// already surfaces presence issues.
+			// configFilesCheck only checks that path strings are non-empty, not
+			// that files are readable. DefaultResolveOptions returns "" for paths
+			// that fail to stat, so a non-empty resolved path that still can't be
+			// read is essentially unreachable — skip defensively.
 			continue
 		}
 		if line, col, ok := jsonParsePosition(data); ok {
-			_, issues := config.ValidateFile(path)
+			_, issues := config.ValidateBytes(data)
 			errMsg := ""
 			if len(issues) > 0 {
 				errMsg = issues[0].Message
@@ -263,7 +265,7 @@ func configValidationCheck(userPath string, projectPath string) Check {
 			issueCount++
 			continue
 		}
-		_, issues := config.ValidateFile(path)
+		_, issues := config.ValidateBytes(data)
 		if len(issues) == 0 {
 			continue
 		}
@@ -302,10 +304,6 @@ func jsonParsePosition(data []byte) (int, int, bool) {
 	}
 	// Non-positional JSON error (e.g. unexpected EOF without offset) — still a parse failure.
 	return 1, 1, true
-}
-
-func osReadFile(path string) ([]byte, error) {
-	return os.ReadFile(path)
 }
 
 func passFail(ok bool) string {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,7 +1,10 @@
 package doctor
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -50,6 +53,7 @@ func Run(options Options) Report {
 	checks := []Check{
 		runtimeCheck(options.Runtime),
 		configFilesCheck(options.UserConfig, options.ProjectConfig),
+		configValidationCheck(options.UserConfig, options.ProjectConfig),
 	}
 	providerCheck := providerConfigCheck(options.Provider)
 	checks = append(checks, providerCheck)
@@ -223,6 +227,85 @@ func formatDetails(details map[string]any) string {
 		parts = append(parts, fmt.Sprintf("%s: %v", redaction.RedactString(key, redaction.Options{}), redaction.RedactValue(value, redaction.Options{})))
 	}
 	return strings.Join(parts, " | ")
+}
+
+func configValidationCheck(userPath string, projectPath string) Check {
+	paths := make([]string, 0, 2)
+	for _, path := range []string{userPath, projectPath} {
+		if strings.TrimSpace(path) != "" {
+			paths = append(paths, path)
+		}
+	}
+	if len(paths) == 0 {
+		return check("config.validation", "Config validation", StatusWarn, "No Zero config files were available to validate.", nil)
+	}
+
+	status := StatusPass
+	issueCount := 0
+	details := map[string]any{}
+	for _, path := range paths {
+		data, readErr := osReadFile(path)
+		if readErr != nil {
+			// File unreadable (e.g. does not exist) — skip; configFilesCheck
+			// already surfaces presence issues.
+			continue
+		}
+		if line, col, ok := jsonParsePosition(data); ok {
+			_, issues := config.ValidateFile(path)
+			errMsg := ""
+			if len(issues) > 0 {
+				errMsg = issues[0].Message
+			}
+			details[path] = map[string]any{"line": line, "col": col, "error": errMsg}
+			details["line"] = line
+			details["col"] = col
+			status = StatusFail
+			issueCount++
+			continue
+		}
+		_, issues := config.ValidateFile(path)
+		if len(issues) == 0 {
+			continue
+		}
+		messages := make([]string, 0, len(issues))
+		for _, issue := range issues {
+			messages = append(messages, issue.Message)
+		}
+		details[path] = map[string]any{"issues": messages}
+		status = StatusFail
+		issueCount += len(issues)
+	}
+
+	if status == StatusPass {
+		return check("config.validation", "Config validation", StatusPass, "Zero config files parsed and validated successfully.", nil)
+	}
+	return check("config.validation", "Config validation", StatusFail, fmt.Sprintf("Zero config validation found %d issue(s).", issueCount), details)
+}
+
+// jsonParsePosition reports whether data fails to parse as JSON and, if so, the
+// 1-based line/col of the failure using the concrete json error offset.
+func jsonParsePosition(data []byte) (int, int, bool) {
+	var probe any
+	err := json.Unmarshal(data, &probe)
+	if err == nil {
+		return 0, 0, false
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		line, col := offsetToLineCol(data, syntaxErr.Offset)
+		return line, col, true
+	}
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		line, col := offsetToLineCol(data, typeErr.Offset)
+		return line, col, true
+	}
+	// Non-positional JSON error (e.g. unexpected EOF without offset) — still a parse failure.
+	return 1, 1, true
+}
+
+func osReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
 }
 
 func passFail(ok bool) string {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -231,3 +231,26 @@ func passFail(ok bool) string {
 	}
 	return "fail"
 }
+
+// offsetToLineCol converts a byte offset (as reported by *json.SyntaxError /
+// *json.UnmarshalTypeError) into a 1-based line and column. Offsets out of range
+// are clamped into [0, len(data)].
+func offsetToLineCol(data []byte, offset int64) (int, int) {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > int64(len(data)) {
+		offset = int64(len(data))
+	}
+	line := 1
+	col := 1
+	for index := int64(0); index < offset; index++ {
+		if data[index] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -246,10 +246,17 @@ func configValidationCheck(userPath string, projectPath string) Check {
 	for _, path := range paths {
 		data, readErr := os.ReadFile(path)
 		if readErr != nil {
-			// configFilesCheck only checks that path strings are non-empty, not
-			// that files are readable. DefaultResolveOptions returns "" for paths
-			// that fail to stat, so a non-empty resolved path that still can't be
-			// read is essentially unreachable — skip defensively.
+			// A genuinely-missing path is configFilesCheck's job to report, and a
+			// "missing" path must stay a skip — so a not-exist read error is ignored
+			// here. Any OTHER read error (permissions, is-a-directory) means a
+			// present-but-unreadable config that would otherwise silently pass
+			// validation, so surface it as a failing per-path detail.
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			details[path] = map[string]any{"error": "unreadable: " + readErr.Error()}
+			status = StatusFail
+			issueCount++
 			continue
 		}
 		if line, col, ok := jsonParsePosition(data); ok {
@@ -307,8 +314,10 @@ func jsonParsePosition(data []byte) (int, int, bool) {
 		line, col := offsetToLineCol(data, typeErr.Offset)
 		return line, col, true
 	}
-	// Non-positional JSON error (e.g. unexpected EOF without offset) — still a parse failure.
-	return 1, 1, true
+	// Non-positional JSON error (e.g. unexpected EOF without offset): do not
+	// fabricate a (1,1) position. Returning ok=false routes the error through the
+	// no-position ValidateBytes path so it is reported without a fake line/col.
+	return 0, 0, false
 }
 
 func passFail(ok bool) string {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -259,8 +259,6 @@ func configValidationCheck(userPath string, projectPath string) Check {
 				errMsg = issues[0].Message
 			}
 			details[path] = map[string]any{"line": line, "col": col, "error": errMsg}
-			details["line"] = line
-			details["col"] = col
 			status = StatusFail
 			issueCount++
 			continue
@@ -286,8 +284,15 @@ func configValidationCheck(userPath string, projectPath string) Check {
 
 // jsonParsePosition reports whether data fails to parse as JSON and, if so, the
 // 1-based line/col of the failure using the concrete json error offset.
+//
+// The probe is a config.FileConfig (not `any`) so that a structurally-valid
+// document with a wrong field type (e.g. {"maxTurns":"twelve"}) surfaces a
+// *json.UnmarshalTypeError carrying the offset. FileConfig.UnmarshalJSON returns
+// the underlying json error unchanged, preserving that offset. Documents that
+// are structurally valid AND type-correct unmarshal cleanly (ok=false) and fall
+// through to the semantic ValidateBytes branch.
 func jsonParsePosition(data []byte) (int, int, bool) {
-	var probe any
+	var probe config.FileConfig
 	err := json.Unmarshal(data, &probe)
 	if err == nil {
 		return 0, 0, false

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,6 +1,8 @@
 package doctor
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +83,83 @@ func TestRunReportWarnsForUnknownOpenAICompatibleModel(t *testing.T) {
 	}
 	if check := report.Check("provider.model"); check == nil || check.Status != StatusWarn || !strings.Contains(check.Message, "pass it through") {
 		t.Fatalf("expected custom model warning: %#v", report.Checks)
+	}
+}
+
+func writeDoctorConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestConfigValidationCheckPassesForValidConfig(t *testing.T) {
+	path := writeDoctorConfig(t, `{
+		"activeProvider": "main",
+		"providers": [{"name": "main", "provider_kind": "openai", "model": "gpt-4.1"}]
+	}`)
+
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:00:00Z"), Runtime: "go", ProjectConfig: path})
+
+	check := report.Check("config.validation")
+	if check == nil || check.Status != StatusPass {
+		t.Fatalf("expected config.validation pass, got %#v", report.Checks)
+	}
+}
+
+func TestConfigValidationCheckFailsMalformedJSONWithLineCol(t *testing.T) {
+	path := writeDoctorConfig(t, "{\n  \"activeProvider\": \"openai\",\n")
+
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:05:00Z"), Runtime: "go", ProjectConfig: path})
+
+	if report.OK {
+		t.Fatalf("malformed config should fail report: %#v", report)
+	}
+	check := report.Check("config.validation")
+	if check == nil || check.Status != StatusFail {
+		t.Fatalf("expected config.validation fail, got %#v", report.Checks)
+	}
+	if check.Details["line"] == nil || check.Details["col"] == nil {
+		t.Fatalf("expected line/col in details, got %#v", check.Details)
+	}
+}
+
+func TestConfigValidationCheckFailsSemanticIssue(t *testing.T) {
+	path := writeDoctorConfig(t, `{
+		"activeProvider": "main",
+		"providers": [{"name": "main", "provider_kind": "openai", "baseURL": "https://example.test/v1", "model": "gpt-4.1"}]
+	}`)
+
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:10:00Z"), Runtime: "go", ProjectConfig: path})
+
+	check := report.Check("config.validation")
+	if check == nil || check.Status != StatusFail {
+		t.Fatalf("expected semantic fail, got %#v", report.Checks)
+	}
+}
+
+func TestConfigValidationCheckSkippedWhenNoPaths(t *testing.T) {
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:15:00Z"), Runtime: "go"})
+
+	check := report.Check("config.validation")
+	if check == nil || check.Status != StatusWarn {
+		t.Fatalf("expected config.validation warn-skip, got %#v", report.Checks)
+	}
+}
+
+func TestConfigValidationCheckDoesNotLeakSecret(t *testing.T) {
+	path := writeDoctorConfig(t, `{
+		"activeProvider": "main",
+		"providers": [{"name": "main", "provider_kind": "openai", "baseURL": "https://example.test/v1", "apiKey": "sk-proj-secret1234567890", "model": "gpt-4.1"}]
+	}`)
+
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:20:00Z"), Runtime: "go", ProjectConfig: path})
+
+	if strings.Contains(Format(report), "sk-proj-secret") {
+		t.Fatalf("config.validation leaked apiKey: %q", Format(report))
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -111,6 +111,8 @@ func TestConfigValidationCheckPassesForValidConfig(t *testing.T) {
 }
 
 func TestConfigValidationCheckFailsMalformedJSONWithLineCol(t *testing.T) {
+	// Unterminated object: the trailing comma + EOF yields a *json.SyntaxError
+	// whose offset is the end of the 32-byte document (line 3, col 1).
 	path := writeDoctorConfig(t, "{\n  \"activeProvider\": \"openai\",\n")
 
 	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:05:00Z"), Runtime: "go", ProjectConfig: path})
@@ -122,8 +124,51 @@ func TestConfigValidationCheckFailsMalformedJSONWithLineCol(t *testing.T) {
 	if check == nil || check.Status != StatusFail {
 		t.Fatalf("expected config.validation fail, got %#v", report.Checks)
 	}
-	if check.Details["line"] == nil || check.Details["col"] == nil {
-		t.Fatalf("expected line/col in details, got %#v", check.Details)
+	entry, ok := check.Details[path].(map[string]any)
+	if !ok {
+		t.Fatalf("expected per-path map entry for %q, got %#v", path, check.Details)
+	}
+	// Redaction widens ints to int64 as it round-trips the details map.
+	if entry["line"] != int64(3) || entry["col"] != int64(1) {
+		t.Fatalf("line/col = (%v,%v), want (3,1): %#v", entry["line"], entry["col"], entry)
+	}
+	// The colliding flat top-level keys must be gone (they were ambiguous across
+	// multiple malformed files).
+	if _, exists := check.Details["line"]; exists {
+		t.Fatalf("flat details[\"line\"] should be removed, got %#v", check.Details)
+	}
+	if _, exists := check.Details["col"]; exists {
+		t.Fatalf("flat details[\"col\"] should be removed, got %#v", check.Details)
+	}
+}
+
+func TestConfigValidationCheckFailsTypeMismatchWithLineCol(t *testing.T) {
+	// {"maxTurns":"twelve"} is structurally valid JSON but the wrong type for
+	// FileConfig.MaxTurns. The probe (var probe config.FileConfig) surfaces a
+	// *json.UnmarshalTypeError carrying the offset, exercising the branch that a
+	// `var probe any` probe could never reach.
+	path := writeDoctorConfig(t, `{"maxTurns":"twelve"}`)
+
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:07:00Z"), Runtime: "go", ProjectConfig: path})
+
+	if report.OK {
+		t.Fatalf("type-mismatch config should fail report: %#v", report)
+	}
+	check := report.Check("config.validation")
+	if check == nil || check.Status != StatusFail {
+		t.Fatalf("expected config.validation fail, got %#v", report.Checks)
+	}
+	entry, ok := check.Details[path].(map[string]any)
+	if !ok {
+		t.Fatalf("expected per-path map entry for %q, got %#v", path, check.Details)
+	}
+	if entry["line"] == nil || entry["col"] == nil {
+		t.Fatalf("expected non-nil line/col for type mismatch, got %#v", entry)
+	}
+	// offset=20 in a single-line document -> line 1, col 21. Redaction widens
+	// ints to int64 as it round-trips the details map.
+	if entry["line"] != int64(1) || entry["col"] != int64(21) {
+		t.Fatalf("line/col = (%v,%v), want (1,21): %#v", entry["line"], entry["col"], entry)
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -167,19 +167,25 @@ func TestOffsetToLineCol(t *testing.T) {
 	data := []byte("{\n  \"a\": 1,\n  bad\n}")
 	cases := []struct {
 		name     string
+		data     []byte
 		offset   int64
 		wantLine int
 		wantCol  int
 	}{
-		{name: "start", offset: 0, wantLine: 1, wantCol: 1},
-		{name: "after first newline", offset: 2, wantLine: 2, wantCol: 1},
-		{name: "mid second line", offset: 7, wantLine: 2, wantCol: 6},
-		{name: "negative clamps to start", offset: -5, wantLine: 1, wantCol: 1},
-		{name: "past end clamps to last", offset: 9999, wantLine: 4, wantCol: 2},
+		{name: "start", data: data, offset: 0, wantLine: 1, wantCol: 1},
+		{name: "after first newline", data: data, offset: 2, wantLine: 2, wantCol: 1},
+		{name: "mid second line", data: data, offset: 7, wantLine: 2, wantCol: 6},
+		{name: "negative clamps to start", data: data, offset: -5, wantLine: 1, wantCol: 1},
+		{name: "past end clamps to last", data: data, offset: 9999, wantLine: 4, wantCol: 2},
+		// Multi-byte UTF-8: the rune '£' is 2 bytes (0xC2 0xA3).  The JSON parser
+		// reports byte offsets, so the column after '£' is byte-column 3, not
+		// rune-column 2.  This documents that offsetToLineCol counts BYTES, not
+		// runes.
+		{name: "utf8 multibyte byte columns", data: []byte("{\"£\": bad}"), offset: 6, wantLine: 1, wantCol: 7},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			line, col := offsetToLineCol(data, tc.offset)
+			line, col := offsetToLineCol(tc.data, tc.offset)
 			if line != tc.wantLine || col != tc.wantCol {
 				t.Fatalf("offsetToLineCol(%d) = (%d,%d), want (%d,%d)", tc.offset, line, col, tc.wantLine, tc.wantCol)
 			}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -186,6 +186,37 @@ func TestConfigValidationCheckFailsSemanticIssue(t *testing.T) {
 	}
 }
 
+func TestConfigValidationCheckFailsUnreadableConfig(t *testing.T) {
+	// A present-but-unreadable path (here: a directory, which os.ReadFile rejects
+	// with a non-not-exist error) must surface as a failing detail rather than
+	// silently passing validation. A missing path stays a skip (covered by
+	// TestRunReportRedactsProviderSecretsAndWarnsWithoutConnectivity), so this
+	// guards only the non-not-exist branch.
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "config.json")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:13:00Z"), Runtime: "go", ProjectConfig: configDir})
+
+	if report.OK {
+		t.Fatalf("unreadable config should fail report: %#v", report)
+	}
+	check := report.Check("config.validation")
+	if check == nil || check.Status != StatusFail {
+		t.Fatalf("expected config.validation fail for unreadable path, got %#v", report.Checks)
+	}
+	entry, ok := check.Details[configDir].(map[string]any)
+	if !ok {
+		t.Fatalf("expected per-path map entry for %q, got %#v", configDir, check.Details)
+	}
+	message, _ := entry["error"].(string)
+	if !strings.Contains(message, "unreadable:") {
+		t.Fatalf("expected unreadable error detail, got %#v", entry)
+	}
+}
+
 func TestConfigValidationCheckSkippedWhenNoPaths(t *testing.T) {
 	report := Run(Options{Now: fixedDoctorClock("2026-06-08T10:15:00Z"), Runtime: "go"})
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -84,6 +84,30 @@ func TestRunReportWarnsForUnknownOpenAICompatibleModel(t *testing.T) {
 	}
 }
 
+func TestOffsetToLineCol(t *testing.T) {
+	data := []byte("{\n  \"a\": 1,\n  bad\n}")
+	cases := []struct {
+		name     string
+		offset   int64
+		wantLine int
+		wantCol  int
+	}{
+		{name: "start", offset: 0, wantLine: 1, wantCol: 1},
+		{name: "after first newline", offset: 2, wantLine: 2, wantCol: 1},
+		{name: "mid second line", offset: 7, wantLine: 2, wantCol: 6},
+		{name: "negative clamps to start", offset: -5, wantLine: 1, wantCol: 1},
+		{name: "past end clamps to last", offset: 9999, wantLine: 4, wantCol: 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			line, col := offsetToLineCol(data, tc.offset)
+			if line != tc.wantLine || col != tc.wantCol {
+				t.Fatalf("offsetToLineCol(%d) = (%d,%d), want (%d,%d)", tc.offset, line, col, tc.wantLine, tc.wantCol)
+			}
+		})
+	}
+}
+
 func fixedDoctorClock(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/sandbox/batch.go
+++ b/internal/sandbox/batch.go
@@ -1,0 +1,33 @@
+package sandbox
+
+// RequiredAutonomyForBatch returns the highest autonomy tier required to run a
+// batch of operations without further prompting, given each operation's
+// classified risk. RiskCritical and RiskHigh both map to AutonomyHigh because
+// the autonomy ladder has three tiers and the risk ladder has four. Any risk
+// level that is empty or unrecognised fails closed to AutonomyHigh so an
+// unclassified operation can never silently lower the batch ceiling. An empty
+// batch requires only AutonomyLow.
+func RequiredAutonomyForBatch(risks []Risk) Autonomy {
+	required := AutonomyLow
+	for _, risk := range risks {
+		tier := riskToAutonomy(risk.Level)
+		if autonomyRank[tier] > autonomyRank[required] {
+			required = tier
+		}
+	}
+	return required
+}
+
+func riskToAutonomy(level RiskLevel) Autonomy {
+	switch level {
+	case RiskLow:
+		return AutonomyLow
+	case RiskMedium:
+		return AutonomyMedium
+	case RiskHigh, RiskCritical:
+		return AutonomyHigh
+	default:
+		// Unknown / empty risk is treated as the highest tier (fail-closed).
+		return AutonomyHigh
+	}
+}

--- a/internal/sandbox/batch_test.go
+++ b/internal/sandbox/batch_test.go
@@ -1,0 +1,26 @@
+package sandbox
+
+import "testing"
+
+func TestRequiredAutonomyForBatch(t *testing.T) {
+	cases := []struct {
+		name  string
+		risks []Risk
+		want  Autonomy
+	}{
+		{"empty slice is low", nil, AutonomyLow},
+		{"single low", []Risk{{Level: RiskLow}}, AutonomyLow},
+		{"mixed low and medium is medium", []Risk{{Level: RiskLow}, {Level: RiskMedium}}, AutonomyMedium},
+		{"any high is high", []Risk{{Level: RiskLow}, {Level: RiskHigh}}, AutonomyHigh},
+		{"any critical is high", []Risk{{Level: RiskMedium}, {Level: RiskCritical}}, AutonomyHigh},
+		{"unknown risk fails closed to high", []Risk{{Level: RiskLevel("weird")}}, AutonomyHigh},
+		{"empty-level risk fails closed to high", []Risk{{Level: RiskLevel("")}}, AutonomyHigh},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RequiredAutonomyForBatch(tc.risks); got != tc.want {
+				t.Fatalf("RequiredAutonomyForBatch(%v) = %q, want %q", tc.risks, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -86,6 +86,15 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 				decision.Grant = &grant
 				return decision
 			}
+			if !autonomyAllowed(request.Autonomy, policy.MaxAutonomy) {
+				return Decision{
+					Action:       ActionPrompt,
+					Reason:       "above policy ceiling",
+					Risk:         risk,
+					GrantMatched: true,
+					Grant:        &grant,
+				}
+			}
 			return Decision{
 				Action:       ActionAllow,
 				Reason:       "persistent sandbox allow grant matched",
@@ -99,6 +108,9 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
 	}
 	if request.PermissionGranted || request.PermissionMode == PermissionUnsafe {
+		if !autonomyAllowed(request.Autonomy, policy.MaxAutonomy) {
+			return Decision{Action: ActionPrompt, Risk: risk, Reason: "above policy ceiling"}
+		}
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
 	}
 	return Decision{Action: ActionPrompt, Risk: risk, Reason: permissionReason(request)}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -66,7 +66,11 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	request.SideEffect = NormalizeSideEffect(request.SideEffect)
 	autonomy, err := NormalizeAutonomy(request.Autonomy)
 	if err != nil {
-		autonomy = AutonomyLow
+		// Fail CLOSED: a genuinely-invalid autonomy (NormalizeAutonomy("") is Low,
+		// not an error, so only bogus values land here) is treated as the highest
+		// tier so it exceeds any Medium/Low ceiling and clamps to Prompt rather than
+		// slipping under the ceiling as Low and auto-allowing on the grant/unsafe path.
+		autonomy = AutonomyHigh
 	}
 	request.Autonomy = autonomy
 	risk := Classify(request)

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+// reasonAboveCeiling is the Decision.Reason emitted when a grant-allow or unsafe
+// escalation is clamped to a prompt because it exceeds the configured autonomy ceiling.
+const reasonAboveCeiling = "above policy ceiling"
+
 type EngineOptions struct {
 	WorkspaceRoot string
 	Policy        Policy
@@ -48,6 +52,14 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	if policy.Mode == "" {
 		policy = DefaultPolicy()
 	}
+	if policy.MaxAutonomy == "" {
+		// A directly-constructed Policy{} (bypassing DefaultPolicy) leaves the
+		// ceiling empty, which NormalizeAutonomy would read as Low and clamp every
+		// Medium/High decision to Prompt. Default empty to High so the ceiling is a
+		// no-op unless explicitly configured (fail-open is correct here: the empty
+		// value signals "unset", not "lock everything down").
+		policy.MaxAutonomy = AutonomyHigh
+	}
 	request.WorkspaceRoot = firstNonEmpty(request.WorkspaceRoot, engine.workspaceRoot)
 	request.Permission = NormalizePermission(request.Permission)
 	request.PermissionMode = NormalizePermissionMode(request.PermissionMode)
@@ -89,7 +101,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 			if !autonomyAllowed(request.Autonomy, policy.MaxAutonomy) {
 				return Decision{
 					Action:       ActionPrompt,
-					Reason:       "above policy ceiling",
+					Reason:       reasonAboveCeiling,
 					Risk:         risk,
 					GrantMatched: true,
 					Grant:        &grant,
@@ -109,7 +121,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	}
 	if request.PermissionGranted || request.PermissionMode == PermissionUnsafe {
 		if !autonomyAllowed(request.Autonomy, policy.MaxAutonomy) {
-			return Decision{Action: ActionPrompt, Risk: risk, Reason: "above policy ceiling"}
+			return Decision{Action: ActionPrompt, Risk: risk, Reason: reasonAboveCeiling}
 		}
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
 	}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -64,12 +64,16 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	request.Permission = NormalizePermission(request.Permission)
 	request.PermissionMode = NormalizePermissionMode(request.PermissionMode)
 	request.SideEffect = NormalizeSideEffect(request.SideEffect)
+	// Preserve the raw requested autonomy for the ceiling checks below. A
+	// genuinely-invalid value (NormalizeAutonomy("") is Low, not an error, so only
+	// bogus values land here) gets a safe High placeholder for risk classification
+	// and grant lookup, but the ceiling check uses rawAutonomy so autonomyAllowed's
+	// unknown-tier guard fails it CLOSED (clamps to Prompt) under ANY ceiling —
+	// including the default High, where a normalized-High value would wrongly pass
+	// autonomyAllowed(High, High).
+	rawAutonomy := request.Autonomy
 	autonomy, err := NormalizeAutonomy(request.Autonomy)
 	if err != nil {
-		// Fail CLOSED: a genuinely-invalid autonomy (NormalizeAutonomy("") is Low,
-		// not an error, so only bogus values land here) is treated as the highest
-		// tier so it exceeds any Medium/Low ceiling and clamps to Prompt rather than
-		// slipping under the ceiling as Low and auto-allowing on the grant/unsafe path.
 		autonomy = AutonomyHigh
 	}
 	request.Autonomy = autonomy
@@ -102,7 +106,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 				decision.Grant = &grant
 				return decision
 			}
-			if !autonomyAllowed(request.Autonomy, policy.MaxAutonomy) {
+			if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {
 				return Decision{
 					Action:       ActionPrompt,
 					Reason:       reasonAboveCeiling,
@@ -124,7 +128,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
 	}
 	if request.PermissionGranted || request.PermissionMode == PermissionUnsafe {
-		if !autonomyAllowed(request.Autonomy, policy.MaxAutonomy) {
+		if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {
 			return Decision{Action: ActionPrompt, Risk: risk, Reason: reasonAboveCeiling}
 		}
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -249,6 +249,13 @@ func TestEngineReportsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestDefaultPolicyMaxAutonomyIsHigh(t *testing.T) {
+	policy := DefaultPolicy()
+	if policy.MaxAutonomy != AutonomyHigh {
+		t.Fatalf("DefaultPolicy().MaxAutonomy = %q, want %q (no-op ceiling)", policy.MaxAutonomy, AutonomyHigh)
+	}
+}
+
 func fixedSandboxTime(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -289,8 +289,8 @@ func TestEnginePolicyCeilingOverridesGrant(t *testing.T) {
 	if decision.Action != ActionPrompt {
 		t.Fatalf("decision.Action = %q, want %q (clamped above ceiling, not allow)", decision.Action, ActionPrompt)
 	}
-	if decision.Reason != "above policy ceiling" {
-		t.Fatalf("decision.Reason = %q, want \"above policy ceiling\"", decision.Reason)
+	if decision.Reason != reasonAboveCeiling {
+		t.Fatalf("decision.Reason = %q, want %q", decision.Reason, reasonAboveCeiling)
 	}
 }
 
@@ -308,7 +308,7 @@ func TestEnginePolicyCeilingBlocksUnsafeEscalation(t *testing.T) {
 		Autonomy:       AutonomyHigh,
 		Args:           map[string]any{"path": "notes.txt"},
 	})
-	if decision.Action != ActionPrompt || decision.Reason != "above policy ceiling" {
+	if decision.Action != ActionPrompt || decision.Reason != reasonAboveCeiling {
 		t.Fatalf("unsafe high-autonomy decision = %#v, want prompt above policy ceiling", decision)
 	}
 }
@@ -327,6 +327,39 @@ func TestEngineDefaultCeilingIsNoOp(t *testing.T) {
 	})
 	if decision.Action != ActionAllow {
 		t.Fatalf("default-High ceiling decision = %#v, want allow (backward compatible)", decision)
+	}
+}
+
+// TestEngineEmptyPolicyCeilingDefaultsToHigh guards the defensive default in
+// Evaluate: a Policy built directly (bypassing DefaultPolicy) leaves MaxAutonomy
+// empty, which would otherwise be read as Low and clamp this High-autonomy unsafe
+// escalation to Prompt. Evaluate must treat the empty ceiling as High (no-op) and
+// allow the request, so the over-restriction trap stays closed.
+func TestEngineEmptyPolicyCeilingDefaultsToHigh(t *testing.T) {
+	root := t.TempDir()
+	// Real enforce mode, but MaxAutonomy deliberately left empty (the landmine).
+	policy := Policy{
+		Mode:             ModeEnforce,
+		EnforceWorkspace: true,
+	}
+	if policy.MaxAutonomy != "" {
+		t.Fatalf("test precondition failed: MaxAutonomy = %q, want empty", policy.MaxAutonomy)
+	}
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: policy})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionUnsafe,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionAllow {
+		t.Fatalf("empty-ceiling decision = %#v, want allow (empty ceiling defaults to High, not clamped to prompt)", decision)
+	}
+	if decision.Reason == reasonAboveCeiling {
+		t.Fatalf("empty-ceiling decision clamped to %q, want allow without ceiling clamp", reasonAboveCeiling)
 	}
 }
 

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -364,10 +364,12 @@ func TestEngineEmptyPolicyCeilingDefaultsToHigh(t *testing.T) {
 }
 
 // TestEngineInvalidAutonomyFailsClosedOnUnsafeEscalation guards the fail-closed
-// default in Evaluate: a genuinely-invalid Autonomy must NOT be sanitized down to
-// Low (which would slip under a Medium ceiling and auto-allow the unsafe
-// escalation). It must be treated as the highest tier so it exceeds the ceiling
-// and clamps to Prompt.
+// A genuinely-invalid Autonomy must clamp to Prompt, not auto-allow: Evaluate
+// preserves the RAW requested value for the ceiling check so autonomyAllowed's
+// unknown-tier guard fails it closed under ANY ceiling. These two use a Medium
+// ceiling; the *UnderDefaultCeiling* variants below cover the default High
+// ceiling, where a value normalized to High would wrongly pass
+// autonomyAllowed(High, High).
 func TestEngineInvalidAutonomyFailsClosedOnUnsafeEscalation(t *testing.T) {
 	root := t.TempDir()
 	policy := DefaultPolicy()
@@ -428,6 +430,62 @@ func TestEngineInvalidAutonomyFailsClosedOnGrantAllow(t *testing.T) {
 	}
 	if decision.Reason != reasonAboveCeiling {
 		t.Fatalf("decision.Reason = %q, want %q", decision.Reason, reasonAboveCeiling)
+	}
+}
+
+// TestEngineInvalidAutonomyFailsClosedUnderDefaultCeilingUnsafe covers the case
+// flagged in review: under the DEFAULT High ceiling, an invalid autonomy
+// normalized to High would pass autonomyAllowed(High, High) and auto-allow.
+// Preserving the raw value clamps it to Prompt.
+func TestEngineInvalidAutonomyFailsClosedUnderDefaultCeilingUnsafe(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()}) // MaxAutonomy == High
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionUnsafe,
+		Autonomy:       Autonomy("bogus"),
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt || decision.Reason != reasonAboveCeiling {
+		t.Fatalf("invalid-autonomy unsafe under default High ceiling = %#v, want prompt", decision)
+	}
+}
+
+// TestEngineInvalidAutonomyFailsClosedUnderDefaultCeilingGrant is the persistent
+// grant-allow counterpart under the default High ceiling.
+func TestEngineInvalidAutonomyFailsClosedUnderDefaultCeilingGrant(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewGrantStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),
+		Now:      fixedSandboxTime("2026-06-05T14:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.Grant(GrantInput{
+		ToolName:    "write_file",
+		Decision:    GrantAllow,
+		MaxAutonomy: AutonomyHigh,
+		Reason:      "broad grant",
+	}); err != nil {
+		t.Fatalf("Grant allow returned error: %v", err)
+	}
+
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Store: store}) // MaxAutonomy == High
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       Autonomy("bogus"),
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt || decision.Reason != reasonAboveCeiling {
+		t.Fatalf("invalid-autonomy grant under default High ceiling = %#v, want prompt", decision)
 	}
 }
 

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -363,6 +363,74 @@ func TestEngineEmptyPolicyCeilingDefaultsToHigh(t *testing.T) {
 	}
 }
 
+// TestEngineInvalidAutonomyFailsClosedOnUnsafeEscalation guards the fail-closed
+// default in Evaluate: a genuinely-invalid Autonomy must NOT be sanitized down to
+// Low (which would slip under a Medium ceiling and auto-allow the unsafe
+// escalation). It must be treated as the highest tier so it exceeds the ceiling
+// and clamps to Prompt.
+func TestEngineInvalidAutonomyFailsClosedOnUnsafeEscalation(t *testing.T) {
+	root := t.TempDir()
+	policy := DefaultPolicy()
+	policy.MaxAutonomy = AutonomyMedium
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: policy})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionUnsafe,
+		Autonomy:       Autonomy("bogus"),
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt {
+		t.Fatalf("invalid-autonomy unsafe decision = %#v, want prompt (fail closed above ceiling, not allow)", decision)
+	}
+	if decision.Reason != reasonAboveCeiling {
+		t.Fatalf("decision.Reason = %q, want %q", decision.Reason, reasonAboveCeiling)
+	}
+}
+
+// TestEngineInvalidAutonomyFailsClosedOnGrantAllow exercises the persistent
+// grant-allow path: an invalid requested autonomy must exceed a Medium ceiling
+// and clamp to Prompt instead of matching the grant and auto-allowing.
+func TestEngineInvalidAutonomyFailsClosedOnGrantAllow(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewGrantStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),
+		Now:      fixedSandboxTime("2026-06-05T14:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.Grant(GrantInput{
+		ToolName:    "write_file",
+		Decision:    GrantAllow,
+		MaxAutonomy: AutonomyHigh,
+		Reason:      "broad grant",
+	}); err != nil {
+		t.Fatalf("Grant allow returned error: %v", err)
+	}
+
+	policy := DefaultPolicy()
+	policy.MaxAutonomy = AutonomyMedium
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: policy, Store: store})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       Autonomy("bogus"),
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt {
+		t.Fatalf("invalid-autonomy grant decision = %#v, want prompt (fail closed above ceiling, not grant allow)", decision)
+	}
+	if decision.Reason != reasonAboveCeiling {
+		t.Fatalf("decision.Reason = %q, want %q", decision.Reason, reasonAboveCeiling)
+	}
+}
+
 func fixedSandboxTime(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -256,6 +256,80 @@ func TestDefaultPolicyMaxAutonomyIsHigh(t *testing.T) {
 	}
 }
 
+func TestEnginePolicyCeilingOverridesGrant(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewGrantStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),
+		Now:      fixedSandboxTime("2026-06-05T14:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.Grant(GrantInput{
+		ToolName:    "write_file",
+		Decision:    GrantAllow,
+		MaxAutonomy: AutonomyHigh,
+		Reason:      "broad grant",
+	}); err != nil {
+		t.Fatalf("Grant allow returned error: %v", err)
+	}
+
+	policy := DefaultPolicy()
+	policy.MaxAutonomy = AutonomyMedium
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: policy, Store: store})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt {
+		t.Fatalf("decision.Action = %q, want %q (clamped above ceiling, not allow)", decision.Action, ActionPrompt)
+	}
+	if decision.Reason != "above policy ceiling" {
+		t.Fatalf("decision.Reason = %q, want \"above policy ceiling\"", decision.Reason)
+	}
+}
+
+func TestEnginePolicyCeilingBlocksUnsafeEscalation(t *testing.T) {
+	root := t.TempDir()
+	policy := DefaultPolicy()
+	policy.MaxAutonomy = AutonomyMedium
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: policy})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionUnsafe,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt || decision.Reason != "above policy ceiling" {
+		t.Fatalf("unsafe high-autonomy decision = %#v, want prompt above policy ceiling", decision)
+	}
+}
+
+func TestEngineDefaultCeilingIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionUnsafe,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionAllow {
+		t.Fatalf("default-High ceiling decision = %#v, want allow (backward compatible)", decision)
+	}
+}
+
 func fixedSandboxTime(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/sandbox/normalize.go
+++ b/internal/sandbox/normalize.go
@@ -66,5 +66,18 @@ func NormalizeGrantDecision(value GrantDecision) (GrantDecision, error) {
 }
 
 func autonomyAllowed(requested Autonomy, max Autonomy) bool {
-	return autonomyRank[requested] <= autonomyRank[max]
+	requestedNorm, requestedErr := NormalizeAutonomy(requested)
+	maxNorm, maxErr := NormalizeAutonomy(max)
+	// An unknown requested tier ranks above every valid tier so it is never
+	// allowed (fail-closed), even against a High ceiling. An unknown ceiling
+	// ranks below every valid tier so it admits nothing above Low (fail-closed).
+	requestedScore := autonomyRank[requestedNorm]
+	if requestedErr != nil {
+		requestedScore = autonomyRank[AutonomyHigh] + 1
+	}
+	maxScore := autonomyRank[maxNorm]
+	if maxErr != nil {
+		maxScore = autonomyRank[AutonomyLow] - 1
+	}
+	return requestedScore <= maxScore
 }

--- a/internal/sandbox/normalize_test.go
+++ b/internal/sandbox/normalize_test.go
@@ -1,0 +1,32 @@
+package sandbox
+
+import "testing"
+
+func TestAutonomyRankOrdering(t *testing.T) {
+	if !(autonomyRank[AutonomyLow] < autonomyRank[AutonomyMedium] && autonomyRank[AutonomyMedium] < autonomyRank[AutonomyHigh]) {
+		t.Fatalf("autonomyRank not strictly ordered: %v", autonomyRank)
+	}
+}
+
+func TestAutonomyAllowedNormalizesBothOperands(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested Autonomy
+		max       Autonomy
+		want      bool
+	}{
+		{"low under high", AutonomyLow, AutonomyHigh, true},
+		{"high under medium ceiling", AutonomyHigh, AutonomyMedium, false},
+		{"equal medium", AutonomyMedium, AutonomyMedium, true},
+		{"uppercase requested still ranked", Autonomy("HIGH"), AutonomyMedium, false},
+		{"unknown requested fails closed against high ceiling", Autonomy("bogus"), AutonomyHigh, false},
+		{"unknown ceiling fails closed against high request", AutonomyHigh, Autonomy("bogus"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autonomyAllowed(tc.requested, tc.max); got != tc.want {
+				t.Fatalf("autonomyAllowed(%q, %q) = %v, want %v", tc.requested, tc.max, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -104,6 +104,7 @@ type Policy struct {
 	EnforceWorkspace      bool        `json:"enforceWorkspace"`
 	DenyDestructiveShell  bool        `json:"denyDestructiveShell"`
 	AllowPolicyOnlyRunner bool        `json:"allowPolicyOnlyRunner"`
+	MaxAutonomy           Autonomy    `json:"maxAutonomy,omitempty"`
 }
 
 type Request struct {
@@ -167,5 +168,6 @@ func DefaultPolicy() Policy {
 		EnforceWorkspace:      true,
 		DenyDestructiveShell:  true,
 		AllowPolicyOnlyRunner: true,
+		MaxAutonomy:           AutonomyHigh,
 	}
 }

--- a/internal/usage/report.go
+++ b/internal/usage/report.go
@@ -1,0 +1,137 @@
+package usage
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// usageEventPayload mirrors the persisted EventUsage payload written by the exec
+// runtime. Only token counts are stored — model id, cost, and the cached /
+// reasoning split are not persisted — so report cost is reconstructed from each
+// session's Metadata.ModelID and is therefore a labeled estimate.
+type usageEventPayload struct {
+	PromptTokens     int `json:"promptTokens"`
+	CompletionTokens int `json:"completionTokens"`
+	TotalTokens      int `json:"totalTokens"`
+}
+
+// DayBucket aggregates usage events sharing the same UTC calendar date.
+type DayBucket struct {
+	Date         string  `json:"date"`
+	Requests     int     `json:"requests"`
+	InputTokens  int     `json:"inputTokens"`
+	OutputTokens int     `json:"outputTokens"`
+	TotalTokens  int     `json:"totalTokens"`
+	TotalCost    float64 `json:"totalCost"`
+}
+
+// Totals carries report-wide sums across every bucket.
+type Totals struct {
+	Requests     int     `json:"requests"`
+	InputTokens  int     `json:"inputTokens"`
+	OutputTokens int     `json:"outputTokens"`
+	TotalTokens  int     `json:"totalTokens"`
+	TotalCost    float64 `json:"totalCost"`
+}
+
+// Report is the aggregated usage view rendered by `zero usage report`. Cost is a
+// reconstructed estimate (see usageEventPayload) and NetLOC is a working-tree
+// estimate; both are surfaced as estimates in the rendered output.
+type Report struct {
+	Buckets         []DayBucket `json:"buckets"`
+	Total           Totals      `json:"total"`
+	NetLOC          int         `json:"netLOC"`
+	NetLOCPositive  bool        `json:"netLOCPositive"`
+	TokensPerNetLOC float64     `json:"tokensPerNetLOC"`
+	CostPerNetLOC   float64     `json:"costPerNetLOC"`
+	LOCEstimated    bool        `json:"locEstimated"`
+	CostEstimated   bool        `json:"costEstimated"`
+}
+
+// BuildReport aggregates persisted EventUsage events into per-day buckets and a
+// report-wide total, reconstructing cost from the owning session's
+// Metadata.ModelID via modelregistry.CalculateCost. Sessions whose model id is
+// empty or unknown contribute token counts but no cost. The per-net-LOC ratios
+// are guarded against a non-positive netLOC.
+func BuildReport(events []sessions.Event, meta []sessions.Metadata, registry *modelregistry.Registry, netLOC int) (Report, error) {
+	modelBySession := map[string]string{}
+	for _, m := range meta {
+		modelBySession[m.SessionID] = m.ModelID
+	}
+
+	buckets := map[string]*DayBucket{}
+	report := Report{
+		NetLOC:        netLOC,
+		LOCEstimated:  true,
+		CostEstimated: true,
+	}
+
+	for _, event := range events {
+		if event.Type != sessions.EventUsage {
+			continue
+		}
+		var payload usageEventPayload
+		if len(event.Payload) > 0 {
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				return Report{}, err
+			}
+		}
+
+		date := event.CreatedAt
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+		bucket, ok := buckets[date]
+		if !ok {
+			bucket = &DayBucket{Date: date}
+			buckets[date] = bucket
+		}
+
+		bucket.Requests++
+		bucket.InputTokens += payload.PromptTokens
+		bucket.OutputTokens += payload.CompletionTokens
+		bucket.TotalTokens += payload.TotalTokens
+
+		report.Total.Requests++
+		report.Total.InputTokens += payload.PromptTokens
+		report.Total.OutputTokens += payload.CompletionTokens
+		report.Total.TotalTokens += payload.TotalTokens
+
+		modelID := modelBySession[event.SessionID]
+		if modelID == "" || registry == nil {
+			continue
+		}
+		model, err := registry.Require(modelID)
+		if err != nil {
+			continue
+		}
+		cost, err := modelregistry.CalculateCost(model, zeroruntime.Usage{
+			InputTokens:  payload.PromptTokens,
+			OutputTokens: payload.CompletionTokens,
+		})
+		if err != nil {
+			continue
+		}
+		bucket.TotalCost += cost.TotalCost
+		report.Total.TotalCost += cost.TotalCost
+	}
+
+	report.Buckets = make([]DayBucket, 0, len(buckets))
+	for _, bucket := range buckets {
+		report.Buckets = append(report.Buckets, *bucket)
+	}
+	sort.SliceStable(report.Buckets, func(left int, right int) bool {
+		return report.Buckets[left].Date < report.Buckets[right].Date
+	})
+
+	if netLOC > 0 {
+		report.NetLOCPositive = true
+		report.TokensPerNetLOC = float64(report.Total.TotalTokens) / float64(netLOC)
+		report.CostPerNetLOC = report.Total.TotalCost / float64(netLOC)
+	}
+	return report, nil
+}

--- a/internal/usage/report.go
+++ b/internal/usage/report.go
@@ -3,6 +3,7 @@ package usage
 import (
 	"encoding/json"
 	"sort"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -81,10 +82,7 @@ func BuildReport(events []sessions.Event, meta []sessions.Metadata, registry *mo
 			}
 		}
 
-		date := event.CreatedAt
-		if len(date) >= 10 {
-			date = date[:10]
-		}
+		date := utcDayBucket(event.CreatedAt)
 		bucket, ok := buckets[date]
 		if !ok {
 			bucket = &DayBucket{Date: date}
@@ -134,4 +132,19 @@ func BuildReport(events []sessions.Event, meta []sessions.Metadata, registry *mo
 		report.CostPerNetLOC = report.Total.TotalCost / float64(netLOC)
 	}
 	return report, nil
+}
+
+// utcDayBucket maps an RFC3339 timestamp to its UTC calendar date (YYYY-MM-DD).
+// Normalizing to UTC first keeps an offset timestamp (e.g. ...T23:30:00-07:00,
+// which is the next UTC day) bucketed by its true UTC day. On a parse failure it
+// falls back to the leading-10 slice so malformed timestamps still bucket
+// defensively rather than collapsing into one empty-string bucket.
+func utcDayBucket(createdAt string) string {
+	if parsed, err := time.Parse(time.RFC3339, createdAt); err == nil {
+		return parsed.UTC().Format("2006-01-02")
+	}
+	if len(createdAt) >= 10 {
+		return createdAt[:10]
+	}
+	return createdAt
 }

--- a/internal/usage/report_test.go
+++ b/internal/usage/report_test.go
@@ -37,10 +37,15 @@ func TestBuildReportBucketsByDayAndSumsTokens(t *testing.T) {
 		usageEvent(t, "s1", 1, "2026-06-01T09:00:00Z", 1000, 200),
 		usageEvent(t, "s1", 2, "2026-06-01T11:00:00Z", 500, 100),
 		usageEvent(t, "s2", 1, "2026-06-02T09:00:00Z", 2000, 400),
+		// Non-UTC offset event: local day is 2026-06-01, but its UTC instant is
+		// 2026-06-02T06:30:00Z, so it must bucket under 2026-06-02 (the UTC day),
+		// not 2026-06-01.
+		usageEvent(t, "s3", 1, "2026-06-01T23:30:00-07:00", 300, 50),
 	}
 	meta := []sessions.Metadata{
 		{SessionID: "s1", ModelID: "gpt-4.1"},
 		{SessionID: "s2", ModelID: "gpt-4.1"},
+		{SessionID: "s3", ModelID: "gpt-4.1"},
 	}
 
 	report, err := BuildReport(events, meta, &registry, 70)
@@ -56,7 +61,12 @@ func TestBuildReportBucketsByDayAndSumsTokens(t *testing.T) {
 	if report.Buckets[0].Requests != 2 || report.Buckets[0].TotalTokens != 1800 {
 		t.Fatalf("day-1 aggregation wrong: %+v", report.Buckets[0])
 	}
-	if report.Total.Requests != 3 || report.Total.TotalTokens != 4200 {
+	// Day-2 holds the UTC 2026-06-02 event (2400 tokens) plus the offset event
+	// whose UTC day is also 2026-06-02 (350 tokens) = 2 requests, 2750 tokens.
+	if report.Buckets[1].Requests != 2 || report.Buckets[1].TotalTokens != 2750 {
+		t.Fatalf("day-2 aggregation wrong (offset event must bucket under UTC 2026-06-02): %+v", report.Buckets[1])
+	}
+	if report.Total.Requests != 4 || report.Total.TotalTokens != 4550 {
 		t.Fatalf("totals wrong: %+v", report.Total)
 	}
 	if !report.LOCEstimated {

--- a/internal/usage/report_test.go
+++ b/internal/usage/report_test.go
@@ -1,0 +1,144 @@
+package usage
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func usageEvent(t *testing.T, sessionID string, sequence int, createdAt string, prompt int, completion int) sessions.Event {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"promptTokens":     prompt,
+		"completionTokens": completion,
+		"totalTokens":      prompt + completion,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return sessions.Event{
+		SessionID: sessionID,
+		Sequence:  sequence,
+		Type:      sessions.EventUsage,
+		CreatedAt: createdAt,
+		Payload:   payload,
+	}
+}
+
+func TestBuildReportBucketsByDayAndSumsTokens(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	events := []sessions.Event{
+		usageEvent(t, "s1", 1, "2026-06-01T09:00:00Z", 1000, 200),
+		usageEvent(t, "s1", 2, "2026-06-01T11:00:00Z", 500, 100),
+		usageEvent(t, "s2", 1, "2026-06-02T09:00:00Z", 2000, 400),
+	}
+	meta := []sessions.Metadata{
+		{SessionID: "s1", ModelID: "gpt-4.1"},
+		{SessionID: "s2", ModelID: "gpt-4.1"},
+	}
+
+	report, err := BuildReport(events, meta, &registry, 70)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	if len(report.Buckets) != 2 {
+		t.Fatalf("expected 2 day buckets, got %d", len(report.Buckets))
+	}
+	if report.Buckets[0].Date != "2026-06-01" || report.Buckets[1].Date != "2026-06-02" {
+		t.Fatalf("buckets not sorted by date: %+v", report.Buckets)
+	}
+	if report.Buckets[0].Requests != 2 || report.Buckets[0].TotalTokens != 1800 {
+		t.Fatalf("day-1 aggregation wrong: %+v", report.Buckets[0])
+	}
+	if report.Total.Requests != 3 || report.Total.TotalTokens != 4200 {
+		t.Fatalf("totals wrong: %+v", report.Total)
+	}
+	if !report.LOCEstimated {
+		t.Fatalf("expected LOCEstimated=true")
+	}
+	if report.NetLOC != 70 {
+		t.Fatalf("NetLOC = %d, want 70", report.NetLOC)
+	}
+}
+
+func TestBuildReportReconstructsCostFromMetadataModel(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	events := []sessions.Event{
+		usageEvent(t, "s1", 1, "2026-06-01T09:00:00Z", 1000, 200),
+	}
+	meta := []sessions.Metadata{{SessionID: "s1", ModelID: "gpt-4.1"}}
+
+	report, err := BuildReport(events, meta, &registry, 10)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+
+	model, err := registry.Require("gpt-4.1")
+	if err != nil {
+		t.Fatalf("Require: %v", err)
+	}
+	want, err := modelregistry.CalculateCost(model, zeroruntime.Usage{InputTokens: 1000, OutputTokens: 200})
+	if err != nil {
+		t.Fatalf("CalculateCost: %v", err)
+	}
+	if report.Total.TotalCost != want.TotalCost {
+		t.Fatalf("reconstructed cost = %v, want %v", report.Total.TotalCost, want.TotalCost)
+	}
+}
+
+func TestBuildReportRatiosGuardNetZero(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	events := []sessions.Event{usageEvent(t, "s1", 1, "2026-06-01T09:00:00Z", 1000, 200)}
+	meta := []sessions.Metadata{{SessionID: "s1", ModelID: "gpt-4.1"}}
+
+	report, err := BuildReport(events, meta, &registry, 0)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	if report.TokensPerNetLOC != 0 || report.CostPerNetLOC != 0 {
+		t.Fatalf("expected zeroed ratios for net<=0, got tokens=%v cost=%v", report.TokensPerNetLOC, report.CostPerNetLOC)
+	}
+	if report.NetLOCPositive {
+		t.Fatalf("expected NetLOCPositive=false for net=0")
+	}
+
+	report, err = BuildReport(events, meta, &registry, 600)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	if !report.NetLOCPositive || report.TokensPerNetLOC != 2 {
+		t.Fatalf("expected tokens/net = 1200/600 = 2, got %v (positive=%v)", report.TokensPerNetLOC, report.NetLOCPositive)
+	}
+}
+
+func TestBuildReportIgnoresNonUsageEvents(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	events := []sessions.Event{
+		{SessionID: "s1", Sequence: 1, Type: sessions.EventMessage, CreatedAt: "2026-06-01T09:00:00Z"},
+		usageEvent(t, "s1", 2, "2026-06-01T09:30:00Z", 1000, 200),
+	}
+	meta := []sessions.Metadata{{SessionID: "s1", ModelID: "gpt-4.1"}}
+
+	report, err := BuildReport(events, meta, &registry, 10)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	if report.Total.Requests != 1 {
+		t.Fatalf("expected non-usage event ignored, got %d requests", report.Total.Requests)
+	}
+}

--- a/internal/zerocommands/sandbox_snapshots.go
+++ b/internal/zerocommands/sandbox_snapshots.go
@@ -20,6 +20,7 @@ type SandboxPolicySnapshot struct {
 	EnforceWorkspace      bool   `json:"enforceWorkspace"`
 	DenyDestructiveShell  bool   `json:"denyDestructiveShell"`
 	AllowPolicyOnlyRunner bool   `json:"allowPolicyOnlyRunner"`
+	MaxAutonomy           string `json:"maxAutonomy,omitempty"`
 	EffectiveMode         string `json:"effectiveMode,omitempty"`
 }
 
@@ -111,6 +112,7 @@ func SandboxPolicySnapshotFromPolicy(policy sandbox.Policy) SandboxPolicySnapsho
 		EnforceWorkspace:      policy.EnforceWorkspace,
 		DenyDestructiveShell:  policy.DenyDestructiveShell,
 		AllowPolicyOnlyRunner: policy.AllowPolicyOnlyRunner,
+		MaxAutonomy:           string(policy.MaxAutonomy),
 		EffectiveMode:         mode,
 	}
 }

--- a/internal/zerocommands/sandbox_snapshots_test.go
+++ b/internal/zerocommands/sandbox_snapshots_test.go
@@ -265,3 +265,13 @@ func TestSandboxPolicySnapshotJSONOmitsEmptyEffectiveMode(t *testing.T) {
 		t.Fatalf("expected effectiveMode omitted when empty, got %q", string(encoded))
 	}
 }
+
+func TestSandboxPolicySnapshotCopiesMaxAutonomy(t *testing.T) {
+	policy := sandbox.DefaultPolicy()
+	policy.MaxAutonomy = sandbox.AutonomyMedium
+
+	snapshot := SandboxPolicySnapshotFromPolicy(policy)
+	if snapshot.MaxAutonomy != string(sandbox.AutonomyMedium) {
+		t.Fatalf("snapshot.MaxAutonomy = %q, want medium", snapshot.MaxAutonomy)
+	}
+}

--- a/internal/zerogit/contracts.go
+++ b/internal/zerogit/contracts.go
@@ -15,6 +15,7 @@ type ChangeSnapshot struct {
 	Runtime   string       `json:"runtime"`
 	Root      string       `json:"root"`
 	Branch    string       `json:"branch,omitempty"`
+	Base      string       `json:"base,omitempty"`
 	Commit    string       `json:"commit,omitempty"`
 	Clean     bool         `json:"clean"`
 	Files     []FileChange `json:"files"`
@@ -47,6 +48,7 @@ func SnapshotFromSummary(summary ChangeSummary) ChangeSnapshot {
 		Runtime:   RuntimeGo,
 		Root:      redactText(summary.Root),
 		Branch:    redactText(summary.Branch),
+		Base:      redactText(summary.Base),
 		Commit:    redactText(summary.Commit),
 		Clean:     summary.Clean,
 		Files:     files,

--- a/internal/zerogit/contracts_test.go
+++ b/internal/zerogit/contracts_test.go
@@ -43,6 +43,29 @@ func TestSnapshotFromSummaryRedactsDiffAndBuildsEvents(t *testing.T) {
 	}
 }
 
+func TestSnapshotFromSummaryCarriesBase(t *testing.T) {
+	summary := ChangeSummary{
+		Root:   "/repo",
+		Branch: "feature",
+		Base:   "main",
+		Files:  []FileChange{{Path: "a.txt", Status: "added"}},
+	}
+	snapshot := SnapshotFromSummary(summary)
+	if snapshot.Base != "main" {
+		t.Fatalf("snapshot.Base = %q, want main", snapshot.Base)
+	}
+	if snapshot.Branch != "feature" {
+		t.Fatalf("snapshot.Branch = %q, want feature", snapshot.Branch)
+	}
+}
+
+func TestSnapshotFromSummaryOmitsEmptyBase(t *testing.T) {
+	snapshot := SnapshotFromSummary(ChangeSummary{Root: "/repo"})
+	if snapshot.Base != "" {
+		t.Fatalf("snapshot.Base = %q, want empty", snapshot.Base)
+	}
+}
+
 func TestEventsFromSummaryHandlesCleanRepository(t *testing.T) {
 	snapshot := SnapshotFromSummary(ChangeSummary{Root: "/repo", Branch: "main", Clean: true})
 	events := snapshot.Events

--- a/internal/zerogit/diffstat.go
+++ b/internal/zerogit/diffstat.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// DiffStat is the parsed summary line of a `git diff --stat` invocation. It is
-// derived from the pre-redaction stat string: redaction can rewrite the numeric
-// summary line, so callers must parse the raw stat before any secret scrubbing.
+// DiffStat is the parsed summary line of a `git diff --stat` invocation. The
+// summary line ("N files changed, A insertions(+), B deletions(-)") carries no
+// secret-bearing tokens, so it is safe to parse from an already-redacted stat.
 type DiffStat struct {
 	FilesChanged int
 	Insertions   int

--- a/internal/zerogit/diffstat.go
+++ b/internal/zerogit/diffstat.go
@@ -1,0 +1,62 @@
+package zerogit
+
+import (
+	"strconv"
+	"strings"
+)
+
+// DiffStat is the parsed summary line of a `git diff --stat` invocation. It is
+// derived from the pre-redaction stat string: redaction can rewrite the numeric
+// summary line, so callers must parse the raw stat before any secret scrubbing.
+type DiffStat struct {
+	FilesChanged int
+	Insertions   int
+	Deletions    int
+}
+
+// NetLOC reports insertions minus deletions. The value may be zero or negative
+// when a change removes at least as many lines as it adds.
+func (stat DiffStat) NetLOC() int {
+	return stat.Insertions - stat.Deletions
+}
+
+// ParseDiffStat extracts file/insertion/deletion counts from the trailing
+// summary line of a `git diff --stat` output, e.g.
+// "3 files changed, 12 insertions(+), 4 deletions(-)". Missing insertion or
+// deletion clauses default to zero, and any malformed input yields a zero-value
+// DiffStat without panicking.
+func ParseDiffStat(stat string) DiffStat {
+	summary := ""
+	for _, line := range strings.Split(stat, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "changed,") || strings.Contains(trimmed, "changed ") {
+			if strings.Contains(trimmed, "file") {
+				summary = trimmed
+			}
+		}
+	}
+	if summary == "" {
+		return DiffStat{}
+	}
+	result := DiffStat{}
+	for _, segment := range strings.Split(summary, ",") {
+		segment = strings.TrimSpace(segment)
+		fields := strings.Fields(segment)
+		if len(fields) < 2 {
+			continue
+		}
+		count, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(fields[1], "file"):
+			result.FilesChanged = count
+		case strings.HasPrefix(fields[1], "insertion"):
+			result.Insertions = count
+		case strings.HasPrefix(fields[1], "deletion"):
+			result.Deletions = count
+		}
+	}
+	return result
+}

--- a/internal/zerogit/diffstat_test.go
+++ b/internal/zerogit/diffstat_test.go
@@ -1,0 +1,67 @@
+package zerogit
+
+import "testing"
+
+func TestParseDiffStat(t *testing.T) {
+	cases := []struct {
+		name string
+		stat string
+		want DiffStat
+	}{
+		{
+			name: "both insertions and deletions",
+			stat: " 3 files changed, 12 insertions(+), 4 deletions(-)",
+			want: DiffStat{FilesChanged: 3, Insertions: 12, Deletions: 4},
+		},
+		{
+			name: "single file singular nouns",
+			stat: " 1 file changed, 1 insertion(+), 1 deletion(-)",
+			want: DiffStat{FilesChanged: 1, Insertions: 1, Deletions: 1},
+		},
+		{
+			name: "insertions only",
+			stat: " 2 files changed, 7 insertions(+)",
+			want: DiffStat{FilesChanged: 2, Insertions: 7, Deletions: 0},
+		},
+		{
+			name: "deletions only",
+			stat: " 1 file changed, 5 deletions(-)",
+			want: DiffStat{FilesChanged: 1, Insertions: 0, Deletions: 5},
+		},
+		{
+			name: "multi-line stat with trailing summary",
+			stat: " a.go | 2 +-\n b.go | 3 ++-\n 2 files changed, 3 insertions(+), 2 deletions(-)",
+			want: DiffStat{FilesChanged: 2, Insertions: 3, Deletions: 2},
+		},
+		{
+			name: "empty",
+			stat: "",
+			want: DiffStat{},
+		},
+		{
+			name: "malformed numbers do not panic",
+			stat: " x files changed, y insertions(+), z deletions(-)",
+			want: DiffStat{},
+		},
+		{
+			name: "no summary line",
+			stat: " a.go | 2 +-\n b.go | 3 ++-",
+			want: DiffStat{},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := ParseDiffStat(testCase.stat)
+			if got != testCase.want {
+				t.Fatalf("ParseDiffStat(%q) = %+v, want %+v", testCase.stat, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestDiffStatNetLOC(t *testing.T) {
+	stat := DiffStat{FilesChanged: 1, Insertions: 10, Deletions: 3}
+	if got := stat.NetLOC(); got != 7 {
+		t.Fatalf("NetLOC() = %d, want 7", got)
+	}
+}

--- a/internal/zerogit/zerogit.go
+++ b/internal/zerogit/zerogit.go
@@ -23,6 +23,7 @@ type CommandResult struct {
 
 type InspectOptions struct {
 	Cwd          string
+	BaseRef      string
 	MaxDiffBytes int
 	RunGit       Runner
 	RunGitEnv    EnvRunner
@@ -48,6 +49,7 @@ type FileChange struct {
 type ChangeSummary struct {
 	Root      string       `json:"root"`
 	Branch    string       `json:"branch,omitempty"`
+	Base      string       `json:"base,omitempty"`
 	Commit    string       `json:"commit,omitempty"`
 	Clean     bool         `json:"clean"`
 	Files     []FileChange `json:"files"`
@@ -81,6 +83,38 @@ func Inspect(ctx context.Context, options InspectOptions) (ChangeSummary, error)
 	root = filepath.Clean(root)
 	branch, _ := gitOutput(ctx, runGit, root, "rev-parse", "--abbrev-ref", "HEAD")
 	commit, _ := gitOutput(ctx, runGit, root, "rev-parse", "--short", "HEAD")
+
+	maxDiffBytes := firstPositive(options.MaxDiffBytes, defaultMaxDiffBytes)
+
+	base := strings.TrimSpace(options.BaseRef)
+	if base != "" {
+		nameStatus, err := gitRawOutput(ctx, runGit, root, "diff", "--name-status", base+"...HEAD", "--")
+		if err != nil {
+			return ChangeSummary{}, fmt.Errorf("inspect base diff status: %w", err)
+		}
+		diffStat, err := gitRawOutput(ctx, runGit, root, "diff", "--stat", base+"...HEAD", "--")
+		if err != nil {
+			return ChangeSummary{}, fmt.Errorf("inspect base diff stat: %w", err)
+		}
+		diff, err := gitRawOutput(ctx, runGit, root, "diff", base+"...HEAD", "--")
+		if err != nil {
+			return ChangeSummary{}, fmt.Errorf("inspect base diff: %w", err)
+		}
+		redactedDiff, truncated := truncateString(redactText(diff), maxDiffBytes)
+		files := parseNameStatus(nameStatus)
+		return ChangeSummary{
+			Root:      root,
+			Branch:    redactText(branch),
+			Base:      redactText(base),
+			Commit:    redactText(commit),
+			Clean:     len(files) == 0,
+			Files:     files,
+			DiffStat:  redactText(diffStat),
+			Diff:      redactedDiff,
+			Truncated: truncated,
+		}, nil
+	}
+
 	status, err := gitRawOutput(ctx, runGit, root, "status", "--short", "--untracked-files=all")
 	if err != nil {
 		return ChangeSummary{}, fmt.Errorf("inspect git status: %w", err)
@@ -90,7 +124,6 @@ func Inspect(ctx context.Context, options InspectOptions) (ChangeSummary, error)
 		return ChangeSummary{}, err
 	}
 
-	maxDiffBytes := firstPositive(options.MaxDiffBytes, defaultMaxDiffBytes)
 	redactedDiff, truncated := truncateString(redactText(diff), maxDiffBytes)
 	files := parseStatus(status)
 	return ChangeSummary{
@@ -199,6 +232,51 @@ func parseStatus(status string) []FileChange {
 		})
 	}
 	return files
+}
+
+func parseNameStatus(output string) []FileChange {
+	files := []FileChange{}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+		code := strings.TrimSpace(fields[0])
+		if code == "" {
+			continue
+		}
+		path := strings.TrimSpace(fields[len(fields)-1])
+		if path == "" {
+			continue
+		}
+		files = append(files, FileChange{
+			Path:   redactText(path),
+			Status: nameStatusName(code[:1]),
+		})
+	}
+	return files
+}
+
+func nameStatusName(letter string) string {
+	switch letter {
+	case "A":
+		return "added"
+	case "D":
+		return "deleted"
+	case "R":
+		return "renamed"
+	case "C":
+		return "copied"
+	case "U":
+		return "conflicted"
+	case "T":
+		return "modified"
+	default:
+		return "modified"
+	}
 }
 
 func statusName(code string) string {

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -207,6 +207,85 @@ func TestInspectPreviewWorksWithUnbornHead(t *testing.T) {
 	}
 }
 
+func TestInspectBaseRefUsesThreeDotDiff(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},                                                   // rev-parse --show-toplevel
+		{Stdout: "feature/m5\n"},                                                // rev-parse --abbrev-ref HEAD
+		{Stdout: "abc1234\n"},                                                   // rev-parse --short HEAD
+		{Stdout: "M\ta.txt\nA\tb.txt\n"},                                        // diff --name-status main...HEAD
+		{Stdout: " a.txt | 1 +\n b.txt | 1 +\n 2 files changed, 2 insertions(+)\n"}, // diff --stat main...HEAD
+		{Stdout: "diff --git a/internal/changes/changes.go b/internal/changes/changes.go\n+token sk-proj-abcdefghijklmnopqrstuvwxyz\n"}, // diff main...HEAD
+	}}
+
+	summary, err := Inspect(context.Background(), InspectOptions{
+		Cwd:          root,
+		BaseRef:      "main",
+		MaxDiffBytes: 80,
+		RunGit:       runner.Run,
+	})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+
+	if summary.Base != "main" {
+		t.Fatalf("Base = %q, want main", summary.Base)
+	}
+	if summary.Branch != "feature/m5" {
+		t.Fatalf("Branch = %q, want feature/m5 (HEAD branch must be preserved)", summary.Branch)
+	}
+	if summary.Clean {
+		t.Fatalf("Clean = true, want false")
+	}
+	if len(summary.Files) != 2 {
+		t.Fatalf("expected two files from name-status, got %#v", summary.Files)
+	}
+	if summary.Files[0].Path != "a.txt" || summary.Files[0].Status != "modified" {
+		t.Fatalf("unexpected first file: %#v", summary.Files[0])
+	}
+	if summary.Files[1].Path != "b.txt" || summary.Files[1].Status != "added" {
+		t.Fatalf("unexpected second file: %#v", summary.Files[1])
+	}
+	if strings.Contains(summary.Diff, "sk-proj-abcdefghijklmnopqrstuvwxyz") || !strings.Contains(summary.Diff, "[REDACTED]") {
+		t.Fatalf("expected redacted diff, got %q", summary.Diff)
+	}
+	if !summary.Truncated {
+		t.Fatalf("expected diff to be marked truncated")
+	}
+	if got := runner.commandLine(3); got != "git diff --name-status main...HEAD --" {
+		t.Fatalf("name-status command = %q", got)
+	}
+	if got := runner.commandLine(4); got != "git diff --stat main...HEAD --" {
+		t.Fatalf("stat command = %q", got)
+	}
+	if got := runner.commandLine(5); got != "git diff main...HEAD --" {
+		t.Fatalf("diff command = %q", got)
+	}
+}
+
+func TestInspectBaseRefEmptyDiffIsClean(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},
+		{Stdout: "main\n"},
+		{Stdout: "abc1234\n"},
+		{Stdout: ""}, // diff --name-status (no changes vs base)
+		{Stdout: ""}, // diff --stat
+		{Stdout: ""}, // diff
+	}}
+
+	summary, err := Inspect(context.Background(), InspectOptions{Cwd: root, BaseRef: "main", RunGit: runner.Run})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+	if !summary.Clean || len(summary.Files) != 0 {
+		t.Fatalf("expected clean base diff, got %#v", summary)
+	}
+	if summary.Base != "main" {
+		t.Fatalf("Base = %q, want main", summary.Base)
+	}
+}
+
 func TestTruncateStringHonorsMaxBytesWithRedactionMarker(t *testing.T) {
 	value := strings.Repeat("a", 32) + redaction.RedactedSecret + strings.Repeat("b", 32)
 	for maxBytes := 1; maxBytes < len(redaction.RedactedSecret)+len("\n[truncated]"); maxBytes++ {

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -207,6 +207,70 @@ func TestInspectPreviewWorksWithUnbornHead(t *testing.T) {
 	}
 }
 
+func TestInspectBaseRefEmptyUsesSnapshotPath(t *testing.T) {
+	root := t.TempDir()
+	runner := &fakeRunner{results: []CommandResult{
+		{Stdout: root + "\n"},
+		{Stdout: "main\n"},
+		{Stdout: "abc1234\n"},
+		{Stdout: " M README.md\n"},
+		{Stdout: "abc1234\n"},
+		{},
+		{},
+		{Stdout: " README.md | 1 +\n"},
+		{Stdout: "diff --git a/README.md b/README.md\n"},
+	}}
+
+	summary, err := Inspect(context.Background(), InspectOptions{Cwd: root, RunGit: runner.Run})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+	if summary.Base != "" {
+		t.Fatalf("Base = %q, want empty for default path", summary.Base)
+	}
+	if got := runner.commandLine(3); got != "git status --short --untracked-files=all" {
+		t.Fatalf("default path must use git status, got %q", got)
+	}
+	if got := runner.commandLine(6); got != "git add -A" {
+		t.Fatalf("default path must use snapshot index, got %q", got)
+	}
+	for _, call := range runner.calls {
+		joined := strings.Join(call.args, " ")
+		if strings.Contains(joined, "...HEAD") {
+			t.Fatalf("default path must not issue a three-dot diff, saw %q", joined)
+		}
+	}
+}
+
+func TestInspectBaseRefRealGitDiffsBranchAgainstBase(t *testing.T) {
+	root := initGitRepo(t, true)
+	baseRef := runGitCommand(t, root, "rev-parse", "HEAD")
+	runGitCommand(t, root, "checkout", "-q", "-b", "feature")
+	writeTestFile(t, filepath.Join(root, "feature.md"), "branch only\n")
+	runGitCommand(t, root, "add", "feature.md")
+	runGitCommand(t, root, "-c", "user.name=Zero", "-c", "user.email=zero@example.invalid", "commit", "-m", "Add feature")
+
+	summary, err := Inspect(context.Background(), InspectOptions{Cwd: root, BaseRef: strings.TrimSpace(baseRef)})
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+	if summary.Clean {
+		t.Fatalf("Clean = true, want false")
+	}
+	if len(summary.Files) != 1 || summary.Files[0].Path != "feature.md" || summary.Files[0].Status != "added" {
+		t.Fatalf("unexpected base diff files: %#v", summary.Files)
+	}
+	if summary.Branch != "feature" {
+		t.Fatalf("Branch = %q, want feature (HEAD branch preserved)", summary.Branch)
+	}
+	if !strings.Contains(summary.Diff, "+branch only") {
+		t.Fatalf("diff missing branch content: %q", summary.Diff)
+	}
+	if staged := runGitCommand(t, root, "diff", "--cached", "--name-only"); strings.TrimSpace(staged) != "" {
+		t.Fatalf("Inspect mutated the real index, staged files: %q", staged)
+	}
+}
+
 func TestInspectBaseRefUsesThreeDotDiff(t *testing.T) {
 	root := t.TempDir()
 	runner := &fakeRunner{results: []CommandResult{

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -350,6 +350,48 @@ func TestInspectBaseRefEmptyDiffIsClean(t *testing.T) {
 	}
 }
 
+func TestParseNameStatusRenameAndCopy(t *testing.T) {
+	cases := []struct {
+		name       string
+		line       string
+		wantPath   string
+		wantStatus string
+	}{
+		{
+			name:       "rename uses new path",
+			line:       "R100\told.txt\tnew.txt",
+			wantPath:   "new.txt",
+			wantStatus: "renamed",
+		},
+		{
+			name:       "copy uses destination path",
+			line:       "C75\tsrc.txt\tdst.txt",
+			wantPath:   "dst.txt",
+			wantStatus: "copied",
+		},
+		{
+			name:       "modify two-field no regression",
+			line:       "M\ta.txt",
+			wantPath:   "a.txt",
+			wantStatus: "modified",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := parseNameStatus(tc.line)
+			if len(files) != 1 {
+				t.Fatalf("expected 1 file entry, got %d: %#v", len(files), files)
+			}
+			if files[0].Path != tc.wantPath {
+				t.Fatalf("Path = %q, want %q", files[0].Path, tc.wantPath)
+			}
+			if files[0].Status != tc.wantStatus {
+				t.Fatalf("Status = %q, want %q", files[0].Status, tc.wantStatus)
+			}
+		})
+	}
+}
+
 func TestTruncateStringHonorsMaxBytesWithRedactionMarker(t *testing.T) {
 	value := strings.Repeat("a", 32) + redaction.RedactedSecret + strings.Repeat("b", 32)
 	for maxBytes := 1; maxBytes < len(redaction.RedactedSecret)+len("\n[truncated]"); maxBytes++ {


### PR DESCRIPTION
## Summary

Four small, dependency-free CLI improvements, batched into one PR:

- **`zero doctor` now validates config files.** A new `config.validation` check parses each resolved config file and reports malformed JSON with **line/col** (including type-mismatch offsets, e.g. a string where an int is expected) plus semantic provider issues — all redaction-safe. Also fixes a pre-existing gap where `doctor` received no config paths and aborted on bad JSON before any check ran; it now degrades gracefully. (`internal/config`, `internal/doctor`, `internal/cli`)

- **Admin autonomy ceiling for the sandbox.** A new config key `sandbox.maxAutonomy` (`low|medium|high`, env `ZERO_SANDBOX_MAX_AUTONOMY`) caps the autonomy a persistent grant or unsafe mode can reach. Enforced **inside** `sandbox.Engine.Evaluate()` — a request above the ceiling is clamped to a permission prompt (not silently auto-allowed). Defaults to `high` (a no-op, fully backward compatible); an invalid value fails **loud** at config resolve and **closed** at the engine bridge. Surfaced in `zero sandbox policy`. (`internal/sandbox`, `internal/config`, `internal/cli`, `internal/zerocommands`)

- **`zero changes --base <ref>`.** Inspect the changes a branch introduced via a three-dot merge-base diff (`git diff <base>...HEAD`) instead of the working tree, with `Files` from `--name-status`. Additive flag on `changes inspect`/`status` (rejected on `commit`); the existing working-tree path is unchanged. (`internal/zerogit`, `internal/cli`)

- **`zero usage report`.** A local token/cost report aggregated from already-persisted session usage events (no new persistence), bucketed per day, with a tokens/cost **per net-LOC** efficiency metric. Cost is reconstructed from the session model and **labeled an estimate**; net-LOC is a working-tree diff proxy, also labeled an estimate. `--json`, `--days N`, `--since YYYY-MM-DD`, `--session <id>`. (`internal/zerogit`, `internal/usage`, `internal/cli`)

No new module dependencies. All changes are additive and backward-compatible.

## Test Plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` green (new tests across `config`, `doctor`, `sandbox`, `zerogit`, `usage`, `cli`, `zerocommands`)
- [x] `go test -race ./internal/{sandbox,config,doctor,zerogit,usage,cli}/...` green
- [x] `GOOS=windows GOARCH=amd64 go build ./...` green
- [x] `git diff --check` clean

### Reviewer focus
- **Security:** the autonomy ceiling is enforced in `Evaluate()` (not just UI), clamps to Prompt (Deny still wins), and an invalid `sandbox.maxAutonomy` fails closed — confirm the tests pin this.
- **Redaction:** secrets never reach doctor details, the usage report, or the `changes --base` diff/base field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `zero usage report` (default `usage`) with token/cost estimation, date/session filters, JSON/text output, and help listing `usage`
  * Added `--base <ref>` to `zero changes inspect` to diff against a specified ref

* **Improvements**
  * Configurable sandbox autonomy ceiling (config/env/overrides) and policy outputs now show `max_autonomy`
  * `doctor` reports config validation with JSON parse positions and semantic issues
  * Richer git diff/stat parsing and change snapshots

* **Bug Fixes**
  * Reject empty `--session`/`--session-id` and tighten CLI flag validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->