### PR TITLE
Image (multimodal) input: exec --image, stream-json images, TUI /image across all 3 providers

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -51,7 +51,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		permissionMode = PermissionModeAuto
 	}
 
-	messages := zeroruntime.SeedMessages(buildSystemPrompt(options), prompt)
+	messages := zeroruntime.SeedMessagesWithImages(buildSystemPrompt(options), prompt, options.Images)
 
 	guards := newGuardState()
 	compactor := newCompactionState(options)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -913,6 +913,9 @@ func copyMessages(messages []Message) []Message {
 		if message.ToolCalls != nil {
 			copied[index].ToolCalls = append([]ToolCall{}, message.ToolCalls...)
 		}
+		// Deep-copy image attachments (slice AND each Data byte slice) so the
+		// raw image bytes are never aliased across history/request/result copies.
+		copied[index].Images = zeroruntime.CloneImageBlocks(message.Images)
 	}
 	return copied
 }

--- a/internal/agent/loop_images_test.go
+++ b/internal/agent/loop_images_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// imageEchoProvider records the messages of the first request it receives, then
+// returns an empty final answer so the loop terminates after one turn.
+type imageEchoProvider struct {
+	seen []zeroruntime.Message
+}
+
+func (p *imageEchoProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	if p.seen == nil {
+		p.seen = append([]zeroruntime.Message{}, request.Messages...)
+	}
+	events := make(chan zeroruntime.StreamEvent)
+	close(events)
+	return events, nil
+}
+
+func TestRunSeedsImagesIntoUserTurn(t *testing.T) {
+	provider := &imageEchoProvider{}
+	images := []zeroruntime.ImageBlock{{MediaType: "image/png", Data: []byte{0x89, 0x50}}}
+
+	if _, err := Run(context.Background(), "look at this", provider, Options{
+		MaxTurns: 1,
+		Images:   images,
+	}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(provider.seen) < 2 {
+		t.Fatalf("provider saw %d messages, want >= 2", len(provider.seen))
+	}
+	user := provider.seen[len(provider.seen)-1]
+	if user.Role != zeroruntime.MessageRoleUser {
+		t.Fatalf("last seeded message role = %q, want user", user.Role)
+	}
+	if len(user.Images) != 1 || user.Images[0].MediaType != "image/png" {
+		t.Fatalf("user.Images = %#v, want one image/png block", user.Images)
+	}
+}
+
+func TestRunWithoutImagesSeedsNilImages(t *testing.T) {
+	provider := &imageEchoProvider{}
+	if _, err := Run(context.Background(), "hello", provider, Options{MaxTurns: 1}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	user := provider.seen[len(provider.seen)-1]
+	if user.Images != nil {
+		t.Fatalf("user.Images = %#v, want nil for text-only run", user.Images)
+	}
+}

--- a/internal/agent/loop_images_test.go
+++ b/internal/agent/loop_images_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -42,6 +43,35 @@ func TestRunSeedsImagesIntoUserTurn(t *testing.T) {
 	}
 	if len(user.Images) != 1 || user.Images[0].MediaType != "image/png" {
 		t.Fatalf("user.Images = %#v, want one image/png block", user.Images)
+	}
+}
+
+// TestCopyMessagesDeepCopiesImageBytes locks the anti-aliasing guarantee for
+// copyMessages: copies must carry INDEPENDENT image bytes, so mutating the
+// source message's Data never bleeds into a history/request/result copy.
+func TestCopyMessagesDeepCopiesImageBytes(t *testing.T) {
+	source := []Message{
+		{
+			Role:    zeroruntime.MessageRoleUser,
+			Content: "look",
+			Images: []zeroruntime.ImageBlock{
+				{MediaType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}},
+			},
+		},
+	}
+
+	copied := copyMessages(source)
+	if len(copied) != 1 || len(copied[0].Images) != 1 {
+		t.Fatalf("unexpected copy shape: %#v", copied)
+	}
+
+	// Mutating the source bytes must not change the copy.
+	source[0].Images[0].Data[0] = 0x00
+	if !bytes.Equal(copied[0].Images[0].Data, []byte{0x89, 0x50, 0x4e, 0x47}) {
+		t.Fatalf("copy image bytes aliased the source: %v", copied[0].Images[0].Data)
+	}
+	if &source[0].Images[0].Data[0] == &copied[0].Images[0].Data[0] {
+		t.Fatal("copy Data shares backing array with source")
 	}
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -129,6 +129,10 @@ type Options struct {
 	Model            string
 	ReasoningEffort  string
 	Cwd              string
+	// Images are optional image attachments to seed onto the initial user turn.
+	// nil for text-only runs (the seeded message then carries no images, exactly
+	// as before).
+	Images []zeroruntime.ImageBlock
 	// ContextWindow is the model's maximum input token budget. When > 0 the agent
 	// loop compacts long conversations once the estimated size crosses a fraction
 	// of this window. 0 DISABLES compaction entirely (every existing caller/test

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -481,6 +481,7 @@ Runs a one-shot prompt through the Go agent runtime.
 
 Flags:
   -f, --file <path>                  Read prompt text from a file
+      --image <path>                 Attach a local image (repeatable; vision models only)
       --mode <name>                  Apply a preset (smart, deep, fast, large, precise); explicit flags override it
   -m, --model <model>                Select the model for provider setup
       --max-turns <number>           Override the maximum agent loop turns

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/imageinput"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
@@ -19,6 +20,7 @@ import (
 	"github.com/Gitlawb/zero/internal/specialist"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/worktrees"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 const (
@@ -483,6 +485,29 @@ func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reade
 		return "", execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
 	}
 	return prompt, nil
+}
+
+// resolveExecImages loads each --image attachment through the shared
+// imageinput.LoadFile loader (read, sniff, normalize, 10-MiB cap), resolving
+// relative paths against workspaceRoot. It is a thin per-path loop: the actual
+// read/sniff/cap logic lives in internal/imageinput so the CLI and TUI surfaces
+// never duplicate it. Any loader error (missing file, unsupported type,
+// oversized) is wrapped into an execUsageError so the run reports it as a usage
+// problem rather than reaching a provider with an invalid image. Returns nil for
+// an empty path list (text-only behavior unchanged).
+func resolveExecImages(paths []string, workspaceRoot string) ([]zeroruntime.ImageBlock, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	images := make([]zeroruntime.ImageBlock, 0, len(paths))
+	for _, path := range paths {
+		image, err := imageinput.LoadFile(path, workspaceRoot)
+		if err != nil {
+			return nil, execUsageError{err.Error()}
+		}
+		images = append(images, image)
+	}
+	return images, nil
 }
 
 func writeExecUsageError(stderr io.Writer, message string) int {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -166,7 +166,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "sandbox_error", err.Error())
 	}
 
-	prompt, err := resolveExecPrompt(options, workspaceRoot, deps.stdin)
+	prompt, streamImages, err := resolveExecPrompt(options, workspaceRoot, deps.stdin)
 	if err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
@@ -204,6 +204,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
+	// Merge stream-json message images with --image attachments so BOTH input
+	// sources flow through the same vision gate (drop+warn) and the same
+	// agent.Options.Images wiring below. Without this merge, images sent over
+	// stream-json are parsed and validated but never reach the agent.
+	images = append(images, streamImages...)
 	// Gate against the EFFECTIVE resolved model (not the --model override). An
 	// unknown/custom id can't be confirmed vision-capable, so drop+warn rather
 	// than error: image input is best-effort, never fatal to the run.
@@ -445,7 +450,12 @@ func resolveWorkspaceRoot(cwd string, deps appDeps) (string, error) {
 	return workspaceRoot, nil
 }
 
-func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reader) (string, error) {
+// resolveExecPrompt resolves the run's prompt text and, for stream-json input,
+// the images carried on its message events. The returned image slice is nil for
+// text input and for stream-json input that carries no images; it is merged with
+// any --image attachments by the caller before the shared vision gate, so both
+// sources flow through the same drop+warn and agent.Options.Images wiring.
+func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reader) (string, []zeroruntime.ImageBlock, error) {
 	if options.inputFormat == execInputStreamJSON {
 		input := ""
 		if options.file != "" {
@@ -455,21 +465,29 @@ func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reade
 			}
 			data, err := os.ReadFile(promptPath)
 			if err != nil {
-				return "", execUsageError{fmt.Sprintf("prompt file not found: %s", promptPath)}
+				return "", nil, execUsageError{fmt.Sprintf("prompt file not found: %s", promptPath)}
 			}
 			input = string(data)
 		} else {
 			data, err := io.ReadAll(stdin)
 			if err != nil {
-				return "", execUsageError{fmt.Sprintf("failed to read stream-json input: %v", err)}
+				return "", nil, execUsageError{fmt.Sprintf("failed to read stream-json input: %v", err)}
 			}
 			input = string(data)
 		}
-		prompt, err := streamjson.ParsePrompt(input)
+		events, err := streamjson.ParseInput(input)
 		if err != nil {
-			return "", execUsageError{err.Error()}
+			return "", nil, execUsageError{err.Error()}
 		}
-		return prompt, nil
+		prompt, err := streamjson.ResolvePrompt(events)
+		if err != nil {
+			return "", nil, execUsageError{err.Error()}
+		}
+		streamImages, err := streamjson.ResolveImages(events)
+		if err != nil {
+			return "", nil, execUsageError{err.Error()}
+		}
+		return prompt, streamImages, nil
 	}
 
 	parts := []string{}
@@ -485,20 +503,20 @@ func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reade
 		}
 		data, err := os.ReadFile(promptPath)
 		if err != nil {
-			return "", execUsageError{fmt.Sprintf("prompt file not found: %s", promptPath)}
+			return "", nil, execUsageError{fmt.Sprintf("prompt file not found: %s", promptPath)}
 		}
 		filePrompt := strings.TrimSpace(string(data))
 		if filePrompt == "" {
-			return "", execUsageError{fmt.Sprintf("prompt file is empty: %s", promptPath)}
+			return "", nil, execUsageError{fmt.Sprintf("prompt file is empty: %s", promptPath)}
 		}
 		parts = append(parts, filePrompt)
 	}
 
 	prompt := strings.TrimSpace(strings.Join(parts, "\n\n"))
 	if prompt == "" {
-		return "", execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
+		return "", nil, execUsageError{"Prompt required. Use `zero exec \"prompt\"` or `zero exec --file prompt.txt`."}
 	}
-	return prompt, nil
+	return prompt, nil, nil
 }
 
 // resolveExecImages loads each --image attachment through the shared

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -45,6 +45,7 @@ const (
 type execOptions struct {
 	promptParts []string
 	file        string
+	imagePaths  []string
 	mode        string
 	model       string
 	// modelProfile captures the legacy --profile flag. It is accepted for

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -200,6 +200,19 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if !config.HasProviderProfile(resolved.Provider) {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", "No provider configured. Set OPENAI_MODEL/OPENAI_API_KEY or add .zero/config.json.")
 	}
+	images, err := resolveExecImages(options.imagePaths, workspaceRoot)
+	if err != nil {
+		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
+	}
+	// Gate against the EFFECTIVE resolved model (not the --model override). An
+	// unknown/custom id can't be confirmed vision-capable, so drop+warn rather
+	// than error: image input is best-effort, never fatal to the run.
+	if len(images) > 0 && !modelregistry.SupportsVision(modelRegistry, resolved.Provider.Model) {
+		if _, err := fmt.Fprintf(stderr, "Model %s does not support image input; ignoring %d image(s).\n", resolved.Provider.Model, len(images)); err != nil {
+			return exitCrash
+		}
+		images = nil
+	}
 	// Evaluate the --reasoning-effort advisory against the EFFECTIVE resolved
 	// model (resolved.Provider.Model), not the override. Without an explicit
 	// --model the override model is empty, so checking it here would silently
@@ -302,6 +315,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		Model:            resolved.Provider.Model,
 		ReasoningEffort:  options.reasoningEffort,
 		Cwd:              workspaceRoot,
+		Images:           images,
 		Registry:         registry,
 		PermissionMode:   permissionMode,
 		Autonomy:         options.autonomy,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -502,13 +502,20 @@ func resolveExecPrompt(options execOptions, workspaceRoot string, stdin io.Reade
 		if err != nil {
 			return "", nil, execUsageError{err.Error()}
 		}
-		prompt, err := streamjson.ResolvePrompt(events)
-		if err != nil {
-			return "", nil, execUsageError{err.Error()}
-		}
 		streamImages, err := streamjson.ResolveImages(events)
 		if err != nil {
 			return "", nil, execUsageError{err.Error()}
+		}
+		prompt, perr := streamjson.ResolvePrompt(events)
+		if perr != nil {
+			// An image-only turn (a message event with empty content but at least
+			// one image) is valid: ResolvePrompt rejects empty content, but with
+			// images present the run proceeds with an empty prompt. Only a turn
+			// with neither text nor images is a real error.
+			if len(streamImages) == 0 {
+				return "", nil, execUsageError{perr.Error()}
+			}
+			prompt = ""
 		}
 		return prompt, streamImages, nil
 	}

--- a/internal/cli/exec_images_gate_test.go
+++ b/internal/cli/exec_images_gate_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRunExecDropsImagesOnNonVisionModelWithWarning drives a full exec run with
+// an --image attachment against a custom (catalog-unknown) model id. The vision
+// gate cannot confirm vision support for an unknown id, so it must warn on
+// stderr and proceed text-only (exit 0), never erroring the run.
+func TestRunExecDropsImagesOnNonVisionModelWithWarning(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "shot.png"), pngBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, _, stderr := runExecWithEcho(t, []string{
+		"exec", "--cwd", root,
+		"--model", "my-custom-vision-less-model",
+		"--image", "shot.png",
+		"describe the screenshot",
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 (drop+warn, never error), got %d: %s", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "does not support image input") {
+		t.Fatalf("expected non-vision warning on stderr, got %q", stderr)
+	}
+}
+
+// TestRunExecRejectsUnsupportedImageType confirms the usage-error path is wired
+// into the run (a .txt sniffs as text -> unsupported, exit 2).
+func TestRunExecRejectsUnsupportedImageType(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("not an image at all"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode, _, stderr := runExecWithEcho(t, []string{
+		"exec", "--cwd", root,
+		"--image", "notes.txt",
+		"look",
+	})
+
+	if exitCode != 2 {
+		t.Fatalf("expected usage exit code 2, got %d: %s", exitCode, stderr)
+	}
+	if !strings.Contains(stderr, "unsupported image type") {
+		t.Fatalf("expected unsupported-image-type error on stderr, got %q", stderr)
+	}
+}

--- a/internal/cli/exec_images_test.go
+++ b/internal/cli/exec_images_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pngBytes is a minimal valid PNG (8-byte signature is enough for
+// http.DetectContentType to sniff "image/png").
+var pngBytes = []byte{
+	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+	0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+}
+
+func TestResolveExecImagesValidSingle(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "shot.png"), pngBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	images, err := resolveExecImages([]string{"shot.png"}, root)
+	if err != nil {
+		t.Fatalf("resolveExecImages error: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("len(images) = %d, want 1", len(images))
+	}
+	if images[0].MediaType != "image/png" {
+		t.Fatalf("MediaType = %q, want image/png", images[0].MediaType)
+	}
+	if !bytes.Equal(images[0].Data, pngBytes) {
+		t.Fatalf("Data = %v, want raw png bytes", images[0].Data)
+	}
+}
+
+func TestResolveExecImagesRepeatedAndRelativeToRoot(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "media")
+	if err := os.MkdirAll(sub, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.png"), pngBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.png"), pngBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	images, err := resolveExecImages([]string{"a.png", "media/b.png"}, root)
+	if err != nil {
+		t.Fatalf("resolveExecImages error: %v", err)
+	}
+	if len(images) != 2 {
+		t.Fatalf("len(images) = %d, want 2", len(images))
+	}
+}
+
+func TestResolveExecImagesMissingFileIsUsageError(t *testing.T) {
+	root := t.TempDir()
+	_, err := resolveExecImages([]string{"nope.png"}, root)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, ok := err.(execUsageError); !ok {
+		t.Fatalf("error type = %T, want execUsageError", err)
+	}
+	if !strings.Contains(err.Error(), "image file not found") {
+		t.Fatalf("error = %q, want image-file-not-found", err.Error())
+	}
+}
+
+func TestResolveExecImagesUnsupportedTypeIsUsageError(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("just some text, not an image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveExecImages([]string{"notes.txt"}, root)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, ok := err.(execUsageError); !ok {
+		t.Fatalf("error type = %T, want execUsageError", err)
+	}
+	if !strings.Contains(err.Error(), "unsupported image type") {
+		t.Fatalf("error = %q, want unsupported-image-type", err.Error())
+	}
+}
+
+func TestResolveExecImagesOversizedIsUsageError(t *testing.T) {
+	root := t.TempDir()
+	big := make([]byte, (10<<20)+1)
+	copy(big, pngBytes) // keep a valid png sniff at the head
+	if err := os.WriteFile(filepath.Join(root, "huge.png"), big, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := resolveExecImages([]string{"huge.png"}, root)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if _, ok := err.(execUsageError); !ok {
+		t.Fatalf("error type = %T, want execUsageError", err)
+	}
+	if !strings.Contains(err.Error(), "10 MiB") {
+		t.Fatalf("error = %q, want size-cap message", err.Error())
+	}
+}
+
+func TestResolveExecImagesEmptyReturnsNil(t *testing.T) {
+	images, err := resolveExecImages(nil, t.TempDir())
+	if err != nil {
+		t.Fatalf("resolveExecImages error: %v", err)
+	}
+	if images != nil {
+		t.Fatalf("images = %#v, want nil", images)
+	}
+}

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -59,6 +59,15 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--file="):
 			options.file = strings.TrimSpace(strings.TrimPrefix(arg, "--file="))
+		case arg == "--image":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.imagePaths = append(options.imagePaths, value)
+			index = next
+		case strings.HasPrefix(arg, "--image="):
+			options.imagePaths = append(options.imagePaths, strings.TrimSpace(strings.TrimPrefix(arg, "--image=")))
 		case arg == "--mode":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -67,7 +67,11 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			options.imagePaths = append(options.imagePaths, value)
 			index = next
 		case strings.HasPrefix(arg, "--image="):
-			options.imagePaths = append(options.imagePaths, strings.TrimSpace(strings.TrimPrefix(arg, "--image=")))
+			value, err := requiredInlineFlagValue(arg, "--image")
+			if err != nil {
+				return options, false, err
+			}
+			options.imagePaths = append(options.imagePaths, value)
 		case arg == "--mode":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/exec_parse_image_test.go
+++ b/internal/cli/exec_parse_image_test.go
@@ -37,3 +37,13 @@ func TestParseExecImageFlagRequiresValue(t *testing.T) {
 		t.Fatalf("expected --image requires a value error, got %v", err)
 	}
 }
+
+// TestParseExecImageInlineFlagRejectsEmpty locks that the inline `--image=` form
+// rejects an empty value (the same empty-rejection the other inline flags use)
+// instead of appending an empty image path.
+func TestParseExecImageInlineFlagRejectsEmpty(t *testing.T) {
+	if _, _, err := parseExecArgs([]string{"--image=", "prompt"}); err == nil ||
+		!strings.Contains(err.Error(), "--image requires a value") {
+		t.Fatalf("expected --image requires a value error for empty inline value, got %v", err)
+	}
+}

--- a/internal/cli/exec_parse_image_test.go
+++ b/internal/cli/exec_parse_image_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseExecImageFlagRepeatable(t *testing.T) {
+	options, help, err := parseExecArgs([]string{
+		"--image", "one.png",
+		"--image=two.jpg",
+		"describe these",
+	})
+	if err != nil {
+		t.Fatalf("parseExecArgs returned error: %v", err)
+	}
+	if help {
+		t.Fatal("help = true, want false")
+	}
+	want := []string{"one.png", "two.jpg"}
+	if len(options.imagePaths) != len(want) {
+		t.Fatalf("imagePaths = %#v, want %#v", options.imagePaths, want)
+	}
+	for i := range want {
+		if options.imagePaths[i] != want[i] {
+			t.Fatalf("imagePaths[%d] = %q, want %q", i, options.imagePaths[i], want[i])
+		}
+	}
+	if strings.Join(options.promptParts, " ") != "describe these" {
+		t.Fatalf("promptParts = %#v", options.promptParts)
+	}
+}
+
+func TestParseExecImageFlagRequiresValue(t *testing.T) {
+	if _, _, err := parseExecArgs([]string{"--image"}); err == nil ||
+		!strings.Contains(err.Error(), "--image requires a value") {
+		t.Fatalf("expected --image requires a value error, got %v", err)
+	}
+}

--- a/internal/cli/exec_streamjson_images_test.go
+++ b/internal/cli/exec_streamjson_images_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// capturingImageProvider records the images carried on the last user turn of the
+// request it receives, so a test can assert what reached agent.Options.Images
+// end-to-end (the agent seeds Options.Images onto the initial user message).
+type capturingImageProvider struct {
+	mu     sync.Mutex
+	images []zeroruntime.ImageBlock
+}
+
+func (provider *capturingImageProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	provider.mu.Lock()
+	for index := len(request.Messages) - 1; index >= 0; index-- {
+		if request.Messages[index].Role == zeroruntime.MessageRoleUser {
+			provider.images = append([]zeroruntime.ImageBlock(nil), request.Messages[index].Images...)
+			break
+		}
+	}
+	provider.mu.Unlock()
+
+	ch := make(chan zeroruntime.StreamEvent, 2)
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "ok"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+// TestRunExecStreamJSONImageReachesAgent locks the end-to-end wiring: a base64
+// image carried on a stream-json `message` event, fed via stdin on a vision
+// model, must reach agent.Options.Images (and therefore the provider request's
+// user turn). Before the fix, stream-json images were parsed and validated but
+// silently dropped — never threaded into the agent run.
+func TestRunExecStreamJSONImageReachesAgent(t *testing.T) {
+	cwd := t.TempDir()
+
+	// A minimal PNG, base64-encoded for the stream-json image payload.
+	png := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+	}
+	encoded := base64.StdEncoding.EncodeToString(png)
+	input := `{"schemaVersion":1,"type":"message","role":"user","content":"describe this","images":[{"mediaType":"image/png","data":"` + encoded + `"}]}` + "\n"
+
+	provider := &capturingImageProvider{}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--cwd", cwd,
+		"--input-format", "stream-json",
+		// gpt-4.1 is a registry-known vision model, so the gate keeps the image.
+		"--model", "gpt-4.1",
+	}, &stdout, &stderr, appDeps{
+		stdin: strings.NewReader(input),
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "gpt-4.1"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			return config.ResolvedConfig{
+				ActiveProvider: "echo",
+				Provider: config.ProviderProfile{
+					Name:         "echo",
+					ProviderKind: config.ProviderKindOpenAICompatible,
+					BaseURL:      "http://127.0.0.1/v1",
+					Model:        model,
+				},
+				MaxTurns: 3,
+			}, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return provider, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.images) != 1 {
+		t.Fatalf("expected 1 image to reach the agent run, got %d (stderr=%q)", len(provider.images), stderr.String())
+	}
+	if provider.images[0].MediaType != "image/png" {
+		t.Fatalf("image media type = %q, want image/png", provider.images[0].MediaType)
+	}
+	if !bytes.Equal(provider.images[0].Data, png) {
+		t.Fatalf("image bytes = %v, want decoded png", provider.images[0].Data)
+	}
+}

--- a/internal/cli/exec_streamjson_images_test.go
+++ b/internal/cli/exec_streamjson_images_test.go
@@ -105,3 +105,68 @@ func TestRunExecStreamJSONImageReachesAgent(t *testing.T) {
 		t.Fatalf("image bytes = %v, want decoded png", provider.images[0].Data)
 	}
 }
+
+// TestRunExecStreamJSONImageOnlyMessageProceeds locks that an IMAGE-ONLY turn
+// (a message event with EMPTY content but at least one image) is accepted: the
+// run proceeds with an empty prompt and the image still reaches the agent. Before
+// the fix, ResolvePrompt's "must include at least one prompt or user message
+// event" error was returned before images were considered, rejecting the turn.
+func TestRunExecStreamJSONImageOnlyMessageProceeds(t *testing.T) {
+	cwd := t.TempDir()
+
+	png := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+	}
+	encoded := base64.StdEncoding.EncodeToString(png)
+	// Empty content, one image: the image-only turn.
+	input := `{"schemaVersion":1,"type":"message","role":"user","content":"","images":[{"mediaType":"image/png","data":"` + encoded + `"}]}` + "\n"
+
+	provider := &capturingImageProvider{}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--cwd", cwd,
+		"--input-format", "stream-json",
+		"--model", "gpt-4.1",
+	}, &stdout, &stderr, appDeps{
+		stdin: strings.NewReader(input),
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "gpt-4.1"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			return config.ResolvedConfig{
+				ActiveProvider: "echo",
+				Provider: config.ProviderProfile{
+					Name:         "echo",
+					ProviderKind: config.ProviderKindOpenAICompatible,
+					BaseURL:      "http://127.0.0.1/v1",
+					Model:        model,
+				},
+				MaxTurns: 3,
+			}, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return provider, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("image-only turn rejected: exit code %d (want %d): %s", exitCode, exitSuccess, stderr.String())
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.images) != 1 {
+		t.Fatalf("expected 1 image to reach the agent run, got %d (stderr=%q)", len(provider.images), stderr.String())
+	}
+	if provider.images[0].MediaType != "image/png" || !bytes.Equal(provider.images[0].Data, png) {
+		t.Fatalf("image not threaded: %#v", provider.images[0])
+	}
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -37,6 +37,7 @@ func TestRunExecHelpDocumentsM1Flags(t *testing.T) {
 			}
 			for _, want := range []string{
 				"-f, --file",
+				"--image <path>",
 				"--mode <name>",
 				"-m, --model",
 				"--max-turns",

--- a/internal/imageinput/imageinput.go
+++ b/internal/imageinput/imageinput.go
@@ -1,0 +1,50 @@
+// Package imageinput is the single shared loader for local image files used by
+// every input surface (CLI exec --image, TUI /image). It reads a file, sniffs +
+// normalizes its media type against the allow-list, enforces the per-image size
+// cap, and returns a raw-bytes ImageBlock. Keeping it here means the CLI and TUI
+// never duplicate the read/sniff/normalize/cap logic.
+package imageinput
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// MaxImageBytes is the per-image decoded-size cap (10 MiB). Bytes above this are
+// rejected at every input boundary so an unbounded request body never reaches a
+// provider.
+const MaxImageBytes = 10 << 20
+
+// LoadFile reads the image at path (resolved against workspaceRoot when
+// relative), validates its type and size, and returns a raw-bytes ImageBlock.
+// Errors are plain (callers wrap them into surface-specific usage/notice text).
+func LoadFile(path string, workspaceRoot string) (zeroruntime.ImageBlock, error) {
+	resolved := path
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(workspaceRoot, resolved)
+	}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("image file not found: %s", path)
+	}
+
+	if len(data) > MaxImageBytes {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("image %s is larger than the 10 MiB limit", path)
+	}
+
+	sniffLen := len(data)
+	if sniffLen > 512 {
+		sniffLen = 512
+	}
+	mediaType := zeroruntime.NormalizeImageMediaType(http.DetectContentType(data[:sniffLen]))
+	if mediaType == "" {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("unsupported image type for %s (allowed: png, jpeg, gif, webp)", path)
+	}
+
+	return zeroruntime.ImageBlock{MediaType: mediaType, Data: data}, nil
+}

--- a/internal/imageinput/imageinput.go
+++ b/internal/imageinput/imageinput.go
@@ -28,11 +28,24 @@ func LoadFile(path string, workspaceRoot string) (zeroruntime.ImageBlock, error)
 		resolved = filepath.Join(workspaceRoot, resolved)
 	}
 
+	// Reject oversized files via Stat BEFORE reading them into memory, so a huge
+	// file never allocates a multi-gigabyte buffer just to be discarded by the
+	// post-read cap. A missing file surfaces the same "not found" notice as a
+	// failed read.
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("image file not found: %s", path)
+	}
+	if info.Size() > MaxImageBytes {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("image %s is larger than the 10 MiB limit", path)
+	}
+
 	data, err := os.ReadFile(resolved)
 	if err != nil {
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image file not found: %s", path)
 	}
 
+	// TOCTOU backstop: the file could have grown between Stat and ReadFile.
 	if len(data) > MaxImageBytes {
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image %s is larger than the 10 MiB limit", path)
 	}

--- a/internal/imageinput/imageinput.go
+++ b/internal/imageinput/imageinput.go
@@ -7,6 +7,7 @@ package imageinput
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -40,12 +41,24 @@ func LoadFile(path string, workspaceRoot string) (zeroruntime.ImageBlock, error)
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image %s is larger than the 10 MiB limit", path)
 	}
 
-	data, err := os.ReadFile(resolved)
+	// Bounded read: the os.Stat above is only a fast-path hint (a non-regular
+	// file reports a misleading size, and the file can grow between Stat and the
+	// read). A LimitReader of MaxImageBytes+1 is the real bound — at most one byte
+	// past the cap is ever buffered, so an oversized or unbounded source (e.g. a
+	// FIFO) can never allocate a multi-gigabyte buffer just to be discarded.
+	file, err := os.Open(resolved)
+	if err != nil {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("image file not found: %s", path)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, MaxImageBytes+1))
 	if err != nil {
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image file not found: %s", path)
 	}
 
-	// TOCTOU backstop: the file could have grown between Stat and ReadFile.
+	// The LimitReader yields at most MaxImageBytes+1 bytes; more than the cap means
+	// the source was oversized (caught here regardless of any stat/read race).
 	if len(data) > MaxImageBytes {
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image %s is larger than the 10 MiB limit", path)
 	}

--- a/internal/imageinput/imageinput.go
+++ b/internal/imageinput/imageinput.go
@@ -37,6 +37,13 @@ func LoadFile(path string, workspaceRoot string) (zeroruntime.ImageBlock, error)
 	if err != nil {
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image file not found: %s", path)
 	}
+	// Reject non-regular files (directories, FIFOs, devices) up front. os.Stat
+	// follows symlinks, so a symlink to a regular file still passes. This guards
+	// against os.Open blocking forever on a writerless FIFO (an --image/ /image
+	// path pointing at a named pipe would otherwise hang the process/UI).
+	if !info.Mode().IsRegular() {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("image file must be a regular file: %s", path)
+	}
 	if info.Size() > MaxImageBytes {
 		return zeroruntime.ImageBlock{}, fmt.Errorf("image %s is larger than the 10 MiB limit", path)
 	}

--- a/internal/imageinput/imageinput_test.go
+++ b/internal/imageinput/imageinput_test.go
@@ -68,6 +68,22 @@ func TestLoadFileUnsupportedType(t *testing.T) {
 	}
 }
 
+func TestLoadFileRejectsNonRegular(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "adir"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A directory is non-regular like a FIFO/device; the guard must reject it
+	// before os.Open (a writerless FIFO would otherwise block the read forever).
+	_, err := LoadFile("adir", root)
+	if err == nil {
+		t.Fatal("expected error for a non-regular file")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("error %q should mention regular file", err.Error())
+	}
+}
+
 func TestLoadFileOversizeRejected(t *testing.T) {
 	root := t.TempDir()
 	big := make([]byte, (10<<20)+1)

--- a/internal/imageinput/imageinput_test.go
+++ b/internal/imageinput/imageinput_test.go
@@ -1,0 +1,86 @@
+package imageinput
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadFileReadsAndNormalizes(t *testing.T) {
+	root := t.TempDir()
+	// 1x1 PNG (real PNG signature so http.DetectContentType returns image/png).
+	png := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+		0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+		0x42, 0x60, 0x82,
+	}
+	if err := os.WriteFile(filepath.Join(root, "pic.png"), png, 0o644); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+
+	// Relative path resolves against workspaceRoot.
+	block, err := LoadFile("pic.png", root)
+	if err != nil {
+		t.Fatalf("LoadFile relative: %v", err)
+	}
+	if block.MediaType != "image/png" {
+		t.Fatalf("MediaType = %q, want image/png", block.MediaType)
+	}
+	if len(block.Data) != len(png) {
+		t.Fatalf("Data length = %d, want %d", len(block.Data), len(png))
+	}
+
+	// Absolute path is used as-is.
+	if _, err := LoadFile(filepath.Join(root, "pic.png"), root); err != nil {
+		t.Fatalf("LoadFile absolute: %v", err)
+	}
+}
+
+func TestLoadFileMissing(t *testing.T) {
+	root := t.TempDir()
+	_, err := LoadFile("nope.png", root)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "nope.png") {
+		t.Fatalf("error %q should name the path", err.Error())
+	}
+}
+
+func TestLoadFileUnsupportedType(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("just some plain text, not an image at all"), 0o644); err != nil {
+		t.Fatalf("write txt: %v", err)
+	}
+	_, err := LoadFile("notes.txt", root)
+	if err == nil {
+		t.Fatal("expected error for non-image content")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("error %q should mention unsupported", err.Error())
+	}
+}
+
+func TestLoadFileOversizeRejected(t *testing.T) {
+	root := t.TempDir()
+	big := make([]byte, (10<<20)+1)
+	// Make it sniff as a GIF so size is the only failing condition.
+	copy(big, []byte("GIF89a"))
+	if err := os.WriteFile(filepath.Join(root, "big.gif"), big, 0o644); err != nil {
+		t.Fatalf("write big: %v", err)
+	}
+	_, err := LoadFile("big.gif", root)
+	if err == nil {
+		t.Fatal("expected error for oversize image")
+	}
+	if !strings.Contains(err.Error(), "10") {
+		t.Fatalf("error %q should mention the size limit", err.Error())
+	}
+}

--- a/internal/modelregistry/vision.go
+++ b/internal/modelregistry/vision.go
@@ -1,0 +1,15 @@
+package modelregistry
+
+// SupportsVision reports whether the model identified by modelID is known to the
+// registry and advertises the vision capability. It returns false when the model
+// cannot be resolved (e.g. a custom or openai-compatible id absent from the
+// catalog): an unknown model is treated as "cannot confirm", so callers drop
+// images rather than send them to a model that may reject them.
+//
+// modelID is resolved through the registry's normal alias/pattern matching, so
+// any spelling that Get accepts works here too. This helper is the single
+// capability check shared by the headless (exec) and interactive (TUI) input
+// surfaces; the warn-and-drop behavior lives at those call sites.
+func SupportsVision(registry Registry, modelID string) bool {
+	return registry.SupportsCapability(modelID, ModelCapabilityVision)
+}

--- a/internal/modelregistry/vision_test.go
+++ b/internal/modelregistry/vision_test.go
@@ -1,0 +1,46 @@
+package modelregistry
+
+import "testing"
+
+func TestSupportsVision(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry returned error: %v", err)
+	}
+
+	// A registry containing exactly one non-vision model so the false case is
+	// covered even though every entry in the default catalog has vision.
+	nonVision := validModelEntry()
+	nonVision.ID = "no-vision-model"
+	nonVision.APIModel = "no-vision-model"
+	nonVision.Aliases = []string{"openai:no-vision-model"}
+	nonVision.Capabilities = ModelCapabilities{ModelCapabilityChat}
+	if nonVision.Supports(ModelCapabilityVision) {
+		t.Fatal("test fixture should not advertise vision")
+	}
+	nonVisionRegistry, err := NewRegistry([]ModelEntry{nonVision})
+	if err != nil {
+		t.Fatalf("NewRegistry returned error: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		registry Registry
+		modelID  string
+		want     bool
+	}{
+		{name: "vision model is supported", registry: registry, modelID: "gemini-2.5-pro", want: true},
+		{name: "vision model resolves via alias", registry: registry, modelID: "gemini-pro", want: true},
+		{name: "non-vision model is not supported", registry: nonVisionRegistry, modelID: "no-vision-model", want: false},
+		{name: "unknown model is not supported", registry: registry, modelID: "totally-made-up-model", want: false},
+		{name: "empty model id is not supported", registry: registry, modelID: "", want: false},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := SupportsVision(testCase.registry, testCase.modelID); got != testCase.want {
+				t.Fatalf("SupportsVision(%q) = %v, want %v", testCase.modelID, got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/providers/anthropic/image_test.go
+++ b/internal/providers/anthropic/image_test.go
@@ -1,0 +1,140 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// captureRequestBody runs one StreamCompletion against a stub server that
+// records the decoded JSON request body, then returns it for assertions.
+func captureRequestBody(t *testing.T, request zeroruntime.CompletionRequest) map[string]any {
+	t.Helper()
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	provider, err := New(Options{APIKey: "sk-ant", BaseURL: server.URL, Model: "claude-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), request)
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+	if gotBody == nil {
+		t.Fatal("server did not capture a request body")
+	}
+	return gotBody
+}
+
+// firstUserContentBlocks returns the content blocks of the first user message.
+func firstUserContentBlocks(t *testing.T, body map[string]any) []any {
+	t.Helper()
+	messages, ok := body["messages"].([]any)
+	if !ok || len(messages) == 0 {
+		t.Fatalf("messages = %#v, want at least one", body["messages"])
+	}
+	user, ok := messages[0].(map[string]any)
+	if !ok || user["role"] != "user" {
+		t.Fatalf("first message = %#v, want a user message", messages[0])
+	}
+	blocks, ok := user["content"].([]any)
+	if !ok {
+		t.Fatalf("user content = %#v, want a blocks array", user["content"])
+	}
+	return blocks
+}
+
+// TestUserTextOnlyTurnUnchanged pins the text-only wire shape: a single
+// user message whose content is a one-element text-block array.
+func TestUserTextOnlyTurnUnchanged(t *testing.T) {
+	body := captureRequestBody(t, zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "Describe this."},
+		},
+	})
+	blocks := firstUserContentBlocks(t, body)
+	if len(blocks) != 1 {
+		t.Fatalf("text-only blocks = %#v, want exactly one", blocks)
+	}
+	text := blocks[0].(map[string]any)
+	if text["type"] != "text" || text["text"] != "Describe this." {
+		t.Fatalf("text-only block = %#v, want a text block", text)
+	}
+}
+
+// TestUserImagePlusTextTurn asserts a text block followed by one image
+// source block carrying base64 of the RAW bytes.
+func TestUserImagePlusTextTurn(t *testing.T) {
+	raw := []byte{0x89, 0x50, 0x4e, 0x47, 0x01, 0x02}
+	body := captureRequestBody(t, zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{
+				Role:    zeroruntime.MessageRoleUser,
+				Content: "Describe this.",
+				Images:  []zeroruntime.ImageBlock{{MediaType: "image/png", Data: raw}},
+			},
+		},
+	})
+	blocks := firstUserContentBlocks(t, body)
+	if len(blocks) != 2 {
+		t.Fatalf("image+text blocks = %#v, want text then image", blocks)
+	}
+	text := blocks[0].(map[string]any)
+	if text["type"] != "text" || text["text"] != "Describe this." {
+		t.Fatalf("first block = %#v, want a text block", text)
+	}
+	image := blocks[1].(map[string]any)
+	if image["type"] != "image" {
+		t.Fatalf("second block = %#v, want an image block", image)
+	}
+	source := image["source"].(map[string]any)
+	if source["type"] != "base64" || source["media_type"] != "image/png" {
+		t.Fatalf("image source = %#v, want base64 png", source)
+	}
+	if source["data"] != base64.StdEncoding.EncodeToString(raw) {
+		t.Fatalf("image data = %v, want base64 of raw bytes", source["data"])
+	}
+}
+
+// TestUserImageOnlyTurnEmits asserts an image-only user turn (empty Content)
+// still produces a user message with a single image block.
+func TestUserImageOnlyTurnEmits(t *testing.T) {
+	raw := []byte{0xff, 0xd8, 0xff, 0xe0}
+	body := captureRequestBody(t, zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{
+				Role:   zeroruntime.MessageRoleUser,
+				Images: []zeroruntime.ImageBlock{{MediaType: "image/jpeg", Data: raw}},
+			},
+		},
+	})
+	messages := body["messages"].([]any)
+	if len(messages) != 1 {
+		t.Fatalf("messages = %#v, want exactly one user turn for image-only", messages)
+	}
+	blocks := firstUserContentBlocks(t, body)
+	if len(blocks) != 1 {
+		t.Fatalf("image-only blocks = %#v, want a single image block", blocks)
+	}
+	image := blocks[0].(map[string]any)
+	if image["type"] != "image" {
+		t.Fatalf("image-only block = %#v, want an image block", image)
+	}
+	source := image["source"].(map[string]any)
+	if source["media_type"] != "image/jpeg" || source["data"] != base64.StdEncoding.EncodeToString(raw) {
+		t.Fatalf("image-only source = %#v, want base64 jpeg of raw bytes", source)
+	}
+}

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -383,8 +384,22 @@ func mapMessages(messages []zeroruntime.Message) (string, []anthropicMessage, er
 			}
 			mapped = append(mapped, anthropicMessage{Role: "assistant", Content: messageContent})
 		default:
+			blocks := []map[string]any{}
 			if hasContent {
-				appendUserBlocks(&mapped, []map[string]any{{"type": "text", "text": content}})
+				blocks = append(blocks, map[string]any{"type": "text", "text": content})
+			}
+			for _, image := range message.Images {
+				blocks = append(blocks, map[string]any{
+					"type": "image",
+					"source": map[string]any{
+						"type":       "base64",
+						"media_type": image.MediaType,
+						"data":       base64.StdEncoding.EncodeToString(image.Data),
+					},
+				})
+			}
+			if len(blocks) > 0 {
+				appendUserBlocks(&mapped, blocks)
 			}
 		}
 	}

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -1,0 +1,28 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGeminiPartTextOnlySerializationOmitsInlineData(t *testing.T) {
+	part := geminiPart{Text: "hello"}
+	got, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if string(got) != `{"text":"hello"}` {
+		t.Fatalf("text-only part = %s, want byte-identical {\"text\":\"hello\"}", got)
+	}
+}
+
+func TestGeminiInlineDataSerialization(t *testing.T) {
+	part := geminiPart{InlineData: &geminiInlineData{MimeType: "image/png", Data: "QUJD"}}
+	got, err := json.Marshal(part)
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if string(got) != `{"inlineData":{"mimeType":"image/png","data":"QUJD"}}` {
+		t.Fatalf("inlineData part = %s, want mimeType+data", got)
+	}
+}

--- a/internal/providers/gemini/images_test.go
+++ b/internal/providers/gemini/images_test.go
@@ -1,8 +1,11 @@
 package gemini
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 func TestGeminiPartTextOnlySerializationOmitsInlineData(t *testing.T) {
@@ -24,5 +27,82 @@ func TestGeminiInlineDataSerialization(t *testing.T) {
 	}
 	if string(got) != `{"inlineData":{"mimeType":"image/png","data":"QUJD"}}` {
 		t.Fatalf("inlineData part = %s, want mimeType+data", got)
+	}
+}
+
+func TestMapMessagesTextOnlyUserUnchanged(t *testing.T) {
+	_, contents, err := mapMessages([]zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: "Read the file."},
+	})
+	if err != nil {
+		t.Fatalf("mapMessages returned error: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("contents = %#v, want one user content", contents)
+	}
+	parts := contents[0].Parts
+	if len(parts) != 1 || parts[0].Text != "Read the file." || parts[0].InlineData != nil {
+		t.Fatalf("parts = %#v, want single text part with no inlineData", parts)
+	}
+}
+
+func TestMapMessagesImageAndTextUserTurn(t *testing.T) {
+	raw := []byte("ABC")
+	_, contents, err := mapMessages([]zeroruntime.Message{
+		{
+			Role:    zeroruntime.MessageRoleUser,
+			Content: "What is this?",
+			Images:  []zeroruntime.ImageBlock{{MediaType: "image/png", Data: raw}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("mapMessages returned error: %v", err)
+	}
+	if len(contents) != 1 || contents[0].Role != "user" {
+		t.Fatalf("contents = %#v, want one user content", contents)
+	}
+	parts := contents[0].Parts
+	if len(parts) != 2 {
+		t.Fatalf("parts = %#v, want text part then inlineData part", parts)
+	}
+	if parts[0].Text != "What is this?" || parts[0].InlineData != nil {
+		t.Fatalf("parts[0] = %#v, want leading text part", parts[0])
+	}
+	if parts[1].InlineData == nil {
+		t.Fatalf("parts[1] = %#v, want inlineData part", parts[1])
+	}
+	if parts[1].InlineData.MimeType != "image/png" {
+		t.Fatalf("mimeType = %q, want image/png", parts[1].InlineData.MimeType)
+	}
+	if parts[1].InlineData.Data != "QUJD" {
+		t.Fatalf("data = %q, want base64 of raw bytes (QUJD)", parts[1].InlineData.Data)
+	}
+}
+
+func TestMapMessagesImageOnlyUserTurn(t *testing.T) {
+	_, contents, err := mapMessages([]zeroruntime.Message{
+		{
+			Role:   zeroruntime.MessageRoleUser,
+			Images: []zeroruntime.ImageBlock{{MediaType: "image/jpeg", Data: bytes.Repeat([]byte{0xFF}, 3)}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("mapMessages returned error: %v", err)
+	}
+	if len(contents) != 1 || contents[0].Role != "user" {
+		t.Fatalf("contents = %#v, want one user content for image-only turn", contents)
+	}
+	parts := contents[0].Parts
+	if len(parts) != 1 {
+		t.Fatalf("parts = %#v, want single inlineData part (no empty text part)", parts)
+	}
+	if parts[0].InlineData == nil || parts[0].InlineData.MimeType != "image/jpeg" {
+		t.Fatalf("parts[0] = %#v, want image/jpeg inlineData", parts[0])
+	}
+	if parts[0].Text != "" {
+		t.Fatalf("parts[0].Text = %q, want empty (no text part emitted)", parts[0].Text)
+	}
+	if parts[0].InlineData.Data != "////" {
+		t.Fatalf("data = %q, want base64 of three 0xFF bytes (////)", parts[0].InlineData.Data)
 	}
 }

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -375,8 +376,18 @@ func mapMessages(messages []zeroruntime.Message) (*geminiContent, []geminiConten
 				contents = append(contents, geminiContent{Role: "model", Parts: parts})
 			}
 		default:
+			parts := []geminiPart{}
 			if hasContent {
-				appendUserParts(&contents, []geminiPart{{Text: content}})
+				parts = append(parts, geminiPart{Text: content})
+			}
+			for _, image := range message.Images {
+				parts = append(parts, geminiPart{InlineData: &geminiInlineData{
+					MimeType: image.MediaType,
+					Data:     base64.StdEncoding.EncodeToString(image.Data),
+				}})
+			}
+			if len(parts) > 0 {
+				appendUserParts(&contents, parts)
 			}
 		}
 	}

--- a/internal/providers/gemini/types.go
+++ b/internal/providers/gemini/types.go
@@ -18,8 +18,14 @@ type geminiContent struct {
 
 type geminiPart struct {
 	Text             string                  `json:"text,omitempty"`
+	InlineData       *geminiInlineData       `json:"inlineData,omitempty"`
 	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+type geminiInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
 }
 
 type geminiFunctionCall struct {

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -347,7 +347,12 @@ func mapMessage(message zeroruntime.Message) chatMessage {
 		ToolCallID: message.ToolCallID,
 	}
 
-	if len(message.Images) == 0 {
+	// Image content-parts are only valid on a user turn. Anthropic/Gemini emit
+	// images solely from their user branches; OpenAI funnels every role through
+	// this one mapper, so guard the parts path to the user role. A non-user
+	// message that happens to carry Images keeps the plain string/nil content
+	// path (its images are simply not serialized).
+	if len(message.Images) == 0 || message.Role != zeroruntime.MessageRoleUser {
 		// Preserve today's behavior exactly: a string assigned only when
 		// non-empty, leaving Content nil otherwise so the `omitempty` tag still
 		// drops the key. An empty string boxed in `any` would NOT be omitted.

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -343,9 +344,33 @@ func (provider *Provider) openAIRequest(request zeroruntime.CompletionRequest) c
 func mapMessage(message zeroruntime.Message) chatMessage {
 	mapped := chatMessage{
 		Role:       string(message.Role),
-		Content:    message.Content,
 		ToolCallID: message.ToolCallID,
 	}
+
+	if len(message.Images) == 0 {
+		// Preserve today's behavior exactly: a string assigned only when
+		// non-empty, leaving Content nil otherwise so the `omitempty` tag still
+		// drops the key. An empty string boxed in `any` would NOT be omitted.
+		if message.Content != "" {
+			mapped.Content = message.Content
+		}
+	} else {
+		parts := make([]contentPart, 0, len(message.Images)+1)
+		if message.Content != "" {
+			parts = append(parts, contentPart{Type: "text", Text: message.Content})
+		}
+		for _, image := range message.Images {
+			parts = append(parts, contentPart{
+				Type: "image_url",
+				ImageURL: &imageURLPart{
+					URL: "data:" + image.MediaType + ";base64," +
+						base64.StdEncoding.EncodeToString(image.Data),
+				},
+			})
+		}
+		mapped.Content = parts
+	}
+
 	if len(message.ToolCalls) > 0 {
 		mapped.ToolCalls = make([]requestToolCall, 0, len(message.ToolCalls))
 		for _, toolCall := range message.ToolCalls {

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -806,3 +806,97 @@ func TestContentPartImageURLMarshalsDataURI(t *testing.T) {
 		t.Fatalf("text part must omit nil image_url, got: %s", textOnly)
 	}
 }
+
+func TestOpenAIRequestEmptyContentStaysOmittedAfterAnyRefactor(t *testing.T) {
+	provider, err := New(Options{Model: "gpt-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	got, err := json.Marshal(provider.openAIRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{
+				Role:    zeroruntime.MessageRoleAssistant,
+				Content: "",
+				ToolCalls: []zeroruntime.ToolCall{{
+					ID:        "call_1",
+					Name:      "read_file",
+					Arguments: `{}`,
+				}},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	if err := json.Unmarshal(got, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := raw.Messages[0]["content"]; present {
+		t.Fatalf("empty content boxed in any must stay omitted, got: %#v", raw.Messages[0])
+	}
+}
+
+func TestMapMessageBuildsImageURLContentParts(t *testing.T) {
+	msg := mapMessage(zeroruntime.Message{
+		Role:    zeroruntime.MessageRoleUser,
+		Content: "describe these",
+		Images: []zeroruntime.ImageBlock{
+			{MediaType: "image/png", Data: []byte("ABC")},
+			{MediaType: "image/jpeg", Data: []byte{0xff, 0xd8, 0xff}},
+		},
+	})
+
+	parts, ok := msg.Content.([]contentPart)
+	if !ok {
+		t.Fatalf("Content type = %T, want []contentPart", msg.Content)
+	}
+	if len(parts) != 3 {
+		t.Fatalf("len(parts) = %d, want 3 (1 text + 2 images)", len(parts))
+	}
+	if parts[0].Type != "text" || parts[0].Text != "describe these" {
+		t.Fatalf("part[0] = %#v, want text part", parts[0])
+	}
+	// Data "ABC" base64-encodes to "QUJD".
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil ||
+		parts[1].ImageURL.URL != "data:image/png;base64,QUJD" {
+		t.Fatalf("part[1] = %#v, want png data URI", parts[1])
+	}
+	// {0xff,0xd8,0xff} base64-encodes to "/9j/".
+	if parts[2].ImageURL == nil || parts[2].ImageURL.URL != "data:image/jpeg;base64,/9j/" {
+		t.Fatalf("part[2] = %#v, want jpeg data URI", parts[2])
+	}
+}
+
+func TestMapMessageImageOnlyOmitsTextPart(t *testing.T) {
+	msg := mapMessage(zeroruntime.Message{
+		Role:    zeroruntime.MessageRoleUser,
+		Content: "",
+		Images:  []zeroruntime.ImageBlock{{MediaType: "image/png", Data: []byte("A")}},
+	})
+	parts, ok := msg.Content.([]contentPart)
+	if !ok {
+		t.Fatalf("Content type = %T, want []contentPart", msg.Content)
+	}
+	if len(parts) != 1 {
+		t.Fatalf("len(parts) = %d, want 1 (image only, no text part)", len(parts))
+	}
+	// Data "A" base64-encodes to "QQ==".
+	if parts[0].Type != "image_url" || parts[0].ImageURL == nil ||
+		parts[0].ImageURL.URL != "data:image/png;base64,QQ==" {
+		t.Fatalf("part[0] = %#v, want image-only png part", parts[0])
+	}
+}
+
+func TestMapMessageTextOnlyKeepsStringContent(t *testing.T) {
+	msg := mapMessage(zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "hi"})
+	if got, ok := msg.Content.(string); !ok || got != "hi" {
+		t.Fatalf("Content = %#v, want string \"hi\"", msg.Content)
+	}
+	empty := mapMessage(zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: ""})
+	if empty.Content != nil {
+		t.Fatalf("empty text content = %#v, want nil so omitempty drops it", empty.Content)
+	}
+}

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -781,3 +781,28 @@ func TestOpenAIRequestTextOnlyOmitsEmptyContent(t *testing.T) {
 		t.Fatalf("user content = %#v, want \"hello\"", raw.Messages[1]["content"])
 	}
 }
+
+func TestContentPartImageURLMarshalsDataURI(t *testing.T) {
+	parts := []contentPart{
+		{Type: "text", Text: "look"},
+		{Type: "image_url", ImageURL: &imageURLPart{URL: "data:image/png;base64,QUJD"}},
+	}
+	got, err := json.Marshal(parts)
+	if err != nil {
+		t.Fatalf("marshal content parts: %v", err)
+	}
+	want := `[{"type":"text","text":"look"},{"type":"image_url","image_url":{"url":"data:image/png;base64,QUJD"}}]`
+	if string(got) != want {
+		t.Fatalf("content parts JSON =\n  %s\nwant\n  %s", got, want)
+	}
+
+	// The text field is omitted on an image-only part; image_url is omitted on a text part.
+	imgOnly, _ := json.Marshal(contentPart{Type: "image_url", ImageURL: &imageURLPart{URL: "data:image/png;base64,QQ=="}})
+	if strings.Contains(string(imgOnly), `"text"`) {
+		t.Fatalf("image-only part must omit empty text, got: %s", imgOnly)
+	}
+	textOnly, _ := json.Marshal(contentPart{Type: "text", Text: "hi"})
+	if strings.Contains(string(textOnly), `"image_url"`) {
+		t.Fatalf("text part must omit nil image_url, got: %s", textOnly)
+	}
+}

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -730,3 +730,54 @@ func TestStreamCompletionEmitsDroppedOnNamelessToolCall(t *testing.T) {
 		t.Errorf("expected a dropped-tool-call signal, got events: %+v", events)
 	}
 }
+
+func TestOpenAIRequestTextOnlyOmitsEmptyContent(t *testing.T) {
+	provider, err := New(Options{Model: "gpt-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	got, err := json.Marshal(provider.openAIRequest(zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+			{Role: zeroruntime.MessageRoleUser, Content: "hello"},
+			{
+				Role:    zeroruntime.MessageRoleAssistant,
+				Content: "", // assistant turn that is *only* a tool call -> empty content must drop
+				ToolCalls: []zeroruntime.ToolCall{{
+					ID:        "call_1",
+					Name:      "read_file",
+					Arguments: `{"path":"README.md"}`,
+				}},
+			},
+			{Role: zeroruntime.MessageRoleTool, Content: "contents", ToolCallID: "call_1"},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	// String content round-trips as a JSON string, and empty content is omitted.
+	if !strings.Contains(string(got), `"content":"hello"`) {
+		t.Fatalf("user content not serialized as string: %s", got)
+	}
+	if strings.Contains(string(got), `"content":""`) {
+		t.Fatalf("empty assistant content must be omitted, got: %s", got)
+	}
+
+	// Decode the assistant message and assert no content key at all.
+	var decoded chatCompletionRequest
+	var raw struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	if err := json.Unmarshal(got, &raw); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	_ = decoded
+	if _, present := raw.Messages[2]["content"]; present {
+		t.Fatalf("assistant (tool-only) message must omit content key, got: %#v", raw.Messages[2])
+	}
+	if raw.Messages[1]["content"] != "hello" {
+		t.Fatalf("user content = %#v, want \"hello\"", raw.Messages[1]["content"])
+	}
+}

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -900,3 +900,58 @@ func TestMapMessageTextOnlyKeepsStringContent(t *testing.T) {
 		t.Fatalf("empty text content = %#v, want nil so omitempty drops it", empty.Content)
 	}
 }
+
+func TestStreamCompletionSerializesImageContentParts(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"choices":[]}`)
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{
+		APIKey:  "sk-secret",
+		BaseURL: server.URL + "/",
+		Model:   "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{
+			Role:    zeroruntime.MessageRoleUser,
+			Content: "what is this",
+			Images:  []zeroruntime.ImageBlock{{MediaType: "image/png", Data: []byte("ABC")}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	messages := gotBody["messages"].([]any)
+	user := messages[0].(map[string]any)
+	content, ok := user["content"].([]any)
+	if !ok {
+		t.Fatalf("user content not an array: %#v", user["content"])
+	}
+	if len(content) != 2 {
+		t.Fatalf("content parts = %d, want 2", len(content))
+	}
+	textPart := content[0].(map[string]any)
+	if textPart["type"] != "text" || textPart["text"] != "what is this" {
+		t.Fatalf("text part = %#v", textPart)
+	}
+	imagePart := content[1].(map[string]any)
+	if imagePart["type"] != "image_url" {
+		t.Fatalf("image part type = %#v, want image_url", imagePart["type"])
+	}
+	imageURL := imagePart["image_url"].(map[string]any)
+	if imageURL["url"] != "data:image/png;base64,QUJD" {
+		t.Fatalf("image url = %#v, want data:image/png;base64,QUJD", imageURL["url"])
+	}
+}

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -901,6 +901,28 @@ func TestMapMessageTextOnlyKeepsStringContent(t *testing.T) {
 	}
 }
 
+// TestMapMessageNonUserRolesNeverCarryImages locks the invariant that only the
+// user role emits image content-parts. Anthropic/Gemini only attach images on
+// their user branches; OpenAI funnels every role through mapMessage, so an
+// assistant/tool/system message that happens to carry Images must still
+// serialize plain string content (never a content-parts array).
+func TestMapMessageNonUserRolesNeverCarryImages(t *testing.T) {
+	images := []zeroruntime.ImageBlock{{MediaType: "image/png", Data: []byte("ABC")}}
+	for _, role := range []zeroruntime.MessageRole{
+		zeroruntime.MessageRoleAssistant,
+		zeroruntime.MessageRoleTool,
+		zeroruntime.MessageRoleSystem,
+	} {
+		msg := mapMessage(zeroruntime.Message{Role: role, Content: "plain", Images: images})
+		if got, ok := msg.Content.(string); !ok || got != "plain" {
+			t.Fatalf("role %q content = %#v, want plain string (no content-parts)", role, msg.Content)
+		}
+		if _, isParts := msg.Content.([]contentPart); isParts {
+			t.Fatalf("role %q must not emit image content-parts", role)
+		}
+	}
+}
+
 func TestStreamCompletionSerializesImageContentParts(t *testing.T) {
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/openai/types.go
+++ b/internal/providers/openai/types.go
@@ -18,9 +18,22 @@ type streamOptions struct {
 
 type chatMessage struct {
 	Role       string            `json:"role"`
-	Content    string            `json:"content,omitempty"`
+	Content    any               `json:"content,omitempty"`
 	ToolCalls  []requestToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string            `json:"tool_call_id,omitempty"`
+}
+
+// contentPart is one element of an OpenAI multimodal `content` array. A part is
+// either text (Type "text") or an inline image data URI (Type "image_url").
+type contentPart struct {
+	Type     string        `json:"type"`
+	Text     string        `json:"text,omitempty"`
+	ImageURL *imageURLPart `json:"image_url,omitempty"`
+}
+
+// imageURLPart carries an inline image as a `data:<media>;base64,<b64>` URI.
+type imageURLPart struct {
+	URL string `json:"url"`
 }
 
 type requestToolCall struct {

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -2,6 +2,7 @@ package streamjson
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 const SchemaVersion = 1
@@ -197,6 +199,34 @@ func ResolvePrompt(events []InputEvent) (string, error) {
 		return "", ProtocolError{"Stream-json input must include at least one prompt or user message event."}
 	}
 	return strings.Join(parts, "\n\n"), nil
+}
+
+// maxStreamImageBytes caps a single decoded image at 10 MiB to bound request bodies.
+const maxStreamImageBytes = 10 << 20
+
+// ResolveImages decodes every base64 image attached to the input events into
+// raw-byte ImageBlocks. Each image's media type is normalized and validated
+// against the supported allow-list, and its decoded size is capped. Returns nil
+// when no events carry images.
+func ResolveImages(events []InputEvent) ([]zeroruntime.ImageBlock, error) {
+	var images []zeroruntime.ImageBlock
+	for _, event := range events {
+		for _, image := range event.Images {
+			data, err := base64.StdEncoding.DecodeString(image.Data)
+			if err != nil {
+				return nil, ProtocolError{fmt.Sprintf("Stream-json image data is not valid base64: %s", err.Error())}
+			}
+			if len(data) > maxStreamImageBytes {
+				return nil, ProtocolError{fmt.Sprintf("Stream-json image exceeds the %d byte limit.", maxStreamImageBytes)}
+			}
+			mediaType := zeroruntime.NormalizeImageMediaType(image.MediaType)
+			if mediaType == "" {
+				return nil, ProtocolError{fmt.Sprintf("Stream-json image has an unsupported image media type %q.", image.MediaType)}
+			}
+			images = append(images, zeroruntime.ImageBlock{MediaType: mediaType, Data: data})
+		}
+	}
+	return images, nil
 }
 
 func ParsePrompt(input string) (string, error) {

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -252,6 +252,7 @@ func validateInputFields(raw map[string]json.RawMessage) error {
 	}
 	if inputType == string(InputMessage) {
 		allowed["role"] = true
+		allowed["images"] = true
 	}
 	for key := range raw {
 		if !allowed[key] {

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -101,10 +101,19 @@ type Event struct {
 }
 
 type InputEvent struct {
-	SchemaVersion int       `json:"schemaVersion"`
-	Type          InputType `json:"type"`
-	Role          string    `json:"role,omitempty"`
-	Content       string    `json:"content"`
+	SchemaVersion int          `json:"schemaVersion"`
+	Type          InputType    `json:"type"`
+	Role          string       `json:"role,omitempty"`
+	Content       string       `json:"content"`
+	Images        []InputImage `json:"images,omitempty"`
+}
+
+// InputImage carries a base64-encoded image attached to a stream-json
+// message event. MediaType is a MIME type (e.g. "image/png"); Data is the
+// standard base64 encoding of the raw image bytes (no data: URI prefix).
+type InputImage struct {
+	MediaType string `json:"mediaType"`
+	Data      string `json:"data"`
 }
 
 type ProtocolError struct {

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -212,10 +212,18 @@ func ResolveImages(events []InputEvent) ([]zeroruntime.ImageBlock, error) {
 	var images []zeroruntime.ImageBlock
 	for _, event := range events {
 		for _, image := range event.Images {
+			// Reject an oversized payload from the ENCODED length BEFORE decoding,
+			// so a multi-gigabyte base64 blob is never allocated just to be capped
+			// after the fact. DecodedLen is the upper bound on the decoded size.
+			if base64.StdEncoding.DecodedLen(len(image.Data)) > maxStreamImageBytes {
+				return nil, ProtocolError{fmt.Sprintf("Stream-json image exceeds the %d byte limit.", maxStreamImageBytes)}
+			}
 			data, err := base64.StdEncoding.DecodeString(image.Data)
 			if err != nil {
 				return nil, ProtocolError{fmt.Sprintf("Stream-json image data is not valid base64: %s", err.Error())}
 			}
+			// Backstop: the exact decoded length (padding makes DecodedLen an upper
+			// bound) must also stay within the cap.
 			if len(data) > maxStreamImageBytes {
 				return nil, ProtocolError{fmt.Sprintf("Stream-json image exceeds the %d byte limit.", maxStreamImageBytes)}
 			}

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -224,7 +224,7 @@ func validateInputEvent(event InputEvent) error {
 	if event.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("schemaVersion must be %d", SchemaVersion)
 	}
-	if strings.TrimSpace(event.Content) == "" {
+	if strings.TrimSpace(event.Content) == "" && len(event.Images) == 0 {
 		return fmt.Errorf("content is required")
 	}
 	switch event.Type {

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -155,6 +155,42 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
+func TestInputEventImagesRoundTripAndOmitempty(t *testing.T) {
+	ev := InputEvent{
+		SchemaVersion: 1,
+		Type:          InputMessage,
+		Role:          "user",
+		Content:       "look at this",
+		Images: []InputImage{
+			{MediaType: "image/png", Data: "aGVsbG8="},
+		},
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"mediaType":"image/png"`) {
+		t.Fatalf("expected mediaType key, got %s", data)
+	}
+	if !strings.Contains(string(data), `"data":"aGVsbG8="`) {
+		t.Fatalf("expected data key, got %s", data)
+	}
+
+	var back InputEvent
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.Images) != 1 || back.Images[0].MediaType != "image/png" || back.Images[0].Data != "aGVsbG8=" {
+		t.Fatalf("images lost in round-trip: %+v", back.Images)
+	}
+
+	// omitempty: a text-only event must not emit the new key.
+	bare, _ := json.Marshal(InputEvent{SchemaVersion: 1, Type: InputPrompt, Content: "hi"})
+	if strings.Contains(string(bare), "images") {
+		t.Fatalf("expected images omitted on text-only event, got %s", bare)
+	}
+}
+
 func TestEventRoundTripsStructuredToolResultFields(t *testing.T) {
 	redacted := true
 	truncated := false

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -155,6 +155,30 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
+func TestParseInputImagesAcceptedOnlyOnMessageEvents(t *testing.T) {
+	// images allowed on a message event
+	msg := `{"schemaVersion":1,"type":"message","role":"user","content":"look","images":[{"mediaType":"image/png","data":"aGVsbG8="}]}`
+	events, err := ParseInput(msg)
+	if err != nil {
+		t.Fatalf("message+images should parse, got %v", err)
+	}
+	if len(events) != 1 || len(events[0].Images) != 1 || events[0].Images[0].Data != "aGVsbG8=" {
+		t.Fatalf("images not parsed: %+v", events)
+	}
+
+	// images rejected on a prompt event (not whitelisted there)
+	prompt := `{"schemaVersion":1,"type":"prompt","content":"look","images":[{"mediaType":"image/png","data":"aGVsbG8="}]}`
+	if _, err := ParseInput(prompt); err == nil || !strings.Contains(err.Error(), "unknown field images") {
+		t.Fatalf("expected images rejected on prompt event, got %v", err)
+	}
+
+	// truly unknown field still rejected on a message event
+	bad := `{"schemaVersion":1,"type":"message","role":"user","content":"look","extra":true}`
+	if _, err := ParseInput(bad); err == nil || !strings.Contains(err.Error(), "unknown field extra") {
+		t.Fatalf("expected unknown field still rejected, got %v", err)
+	}
+}
+
 func TestInputEventImagesRoundTripAndOmitempty(t *testing.T) {
 	ev := InputEvent{
 		SchemaVersion: 1,

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -1,6 +1,7 @@
 package streamjson
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -153,6 +154,66 @@ func TestCreateRunIDUsesStablePrefix(t *testing.T) {
 
 func boolPtr(value bool) *bool {
 	return &value
+}
+
+func TestResolveImagesDecodesNormalizesAndCaps(t *testing.T) {
+	// happy path: two images across two events, jpg media type normalized to image/jpeg
+	rawPNG := []byte("\x89PNG fake bytes")
+	rawJPG := []byte("\xff\xd8\xff fake jpeg")
+	events := []InputEvent{
+		{SchemaVersion: 1, Type: InputMessage, Role: "user", Content: "a", Images: []InputImage{
+			{MediaType: "image/png", Data: base64.StdEncoding.EncodeToString(rawPNG)},
+		}},
+		{SchemaVersion: 1, Type: InputMessage, Role: "user", Content: "b", Images: []InputImage{
+			{MediaType: "jpg", Data: base64.StdEncoding.EncodeToString(rawJPG)},
+		}},
+	}
+	images, err := ResolveImages(events)
+	if err != nil {
+		t.Fatalf("ResolveImages returned error: %v", err)
+	}
+	if len(images) != 2 {
+		t.Fatalf("expected 2 images, got %d", len(images))
+	}
+	if images[0].MediaType != "image/png" || string(images[0].Data) != string(rawPNG) {
+		t.Fatalf("png image not resolved: %+v", images[0])
+	}
+	if images[1].MediaType != "image/jpeg" || string(images[1].Data) != string(rawJPG) {
+		t.Fatalf("jpg image not normalized/decoded: %+v", images[1])
+	}
+
+	// no images -> nil, no error
+	none, err := ResolveImages([]InputEvent{{SchemaVersion: 1, Type: InputPrompt, Content: "x"}})
+	if err != nil {
+		t.Fatalf("ResolveImages with no images errored: %v", err)
+	}
+	if none != nil {
+		t.Fatalf("expected nil for no images, got %+v", none)
+	}
+}
+
+func TestResolveImagesRejectsBadInputs(t *testing.T) {
+	// invalid base64
+	badB64 := []InputEvent{{SchemaVersion: 1, Type: InputMessage, Role: "user", Content: "a",
+		Images: []InputImage{{MediaType: "image/png", Data: "not base64!!"}}}}
+	if _, err := ResolveImages(badB64); err == nil || !strings.Contains(err.Error(), "base64") {
+		t.Fatalf("expected base64 decode error, got %v", err)
+	}
+
+	// unsupported media type
+	badType := []InputEvent{{SchemaVersion: 1, Type: InputMessage, Role: "user", Content: "a",
+		Images: []InputImage{{MediaType: "image/svg+xml", Data: base64.StdEncoding.EncodeToString([]byte("x"))}}}}
+	if _, err := ResolveImages(badType); err == nil || !strings.Contains(err.Error(), "unsupported image media type") {
+		t.Fatalf("expected unsupported media type error, got %v", err)
+	}
+
+	// oversized image (> 10 MiB decoded)
+	oversize := make([]byte, (10<<20)+1)
+	bigEvent := []InputEvent{{SchemaVersion: 1, Type: InputMessage, Role: "user", Content: "a",
+		Images: []InputImage{{MediaType: "image/png", Data: base64.StdEncoding.EncodeToString(oversize)}}}}
+	if _, err := ResolveImages(bigEvent); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversize rejection, got %v", err)
+	}
 }
 
 func TestValidateInputEventAllowsImageOnlyMessage(t *testing.T) {

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -216,6 +216,29 @@ func TestResolveImagesRejectsBadInputs(t *testing.T) {
 	}
 }
 
+// TestResolveImagesRejectsOversizedEncodedLengthBeforeDecode asserts that an
+// over-encoded-length payload is rejected from its ENCODED length BEFORE the
+// expensive base64 decode runs — so a huge blob never allocates a decode buffer
+// just to be capped after the fact. The Data here is NOT valid base64 ('@' is
+// outside the alphabet); reaching DecodeString would surface a "base64" error,
+// so an "exceeds" error proves the size gate fired first, before any decode.
+func TestResolveImagesRejectsOversizedEncodedLengthBeforeDecode(t *testing.T) {
+	// Encoded length whose DecodedLen exceeds the cap, made of non-base64 bytes
+	// so a decode attempt would fail loudly rather than silently allocate.
+	encodedLen := base64.StdEncoding.EncodedLen(maxStreamImageBytes) + 8
+	huge := strings.Repeat("@", encodedLen)
+	event := []InputEvent{{SchemaVersion: 1, Type: InputMessage, Role: "user", Content: "a",
+		Images: []InputImage{{MediaType: "image/png", Data: huge}}}}
+
+	_, err := ResolveImages(event)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected pre-decode oversize rejection, got %v", err)
+	}
+	if strings.Contains(err.Error(), "base64") {
+		t.Fatalf("decode ran before the size gate: %v", err)
+	}
+}
+
 func TestValidateInputEventAllowsImageOnlyMessage(t *testing.T) {
 	// image-only message (empty content) is valid
 	imageOnly := `{"schemaVersion":1,"type":"message","role":"user","content":"","images":[{"mediaType":"image/png","data":"aGVsbG8="}]}`

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -155,6 +155,30 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
+func TestValidateInputEventAllowsImageOnlyMessage(t *testing.T) {
+	// image-only message (empty content) is valid
+	imageOnly := `{"schemaVersion":1,"type":"message","role":"user","content":"","images":[{"mediaType":"image/png","data":"aGVsbG8="}]}`
+	events, err := ParseInput(imageOnly)
+	if err != nil {
+		t.Fatalf("image-only message should be valid, got %v", err)
+	}
+	if len(events) != 1 || len(events[0].Images) != 1 {
+		t.Fatalf("image-only event not parsed: %+v", events)
+	}
+
+	// empty content AND no images is still rejected
+	empty := `{"schemaVersion":1,"type":"message","role":"user","content":""}`
+	if _, err := ParseInput(empty); err == nil || !strings.Contains(err.Error(), "content is required") {
+		t.Fatalf("expected empty-content rejection, got %v", err)
+	}
+
+	// prompt event with empty content is still rejected (no images allowed there)
+	emptyPrompt := `{"schemaVersion":1,"type":"prompt","content":""}`
+	if _, err := ParseInput(emptyPrompt); err == nil || !strings.Contains(err.Error(), "content is required") {
+		t.Fatalf("expected empty prompt rejection, got %v", err)
+	}
+}
+
 func TestParseInputImagesAcceptedOnlyOnMessageEvents(t *testing.T) {
 	// images allowed on a message event
 	msg := `{"schemaVersion":1,"type":"message","role":"user","content":"look","images":[{"mediaType":"image/png","data":"aGVsbG8="}]}`

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -300,6 +300,47 @@ func TestInputEventImagesRoundTripAndOmitempty(t *testing.T) {
 	}
 }
 
+func TestParseInputThenResolveImagesRoundTrip(t *testing.T) {
+	raw := []byte("\x89PNG round trip bytes")
+	line := `{"schemaVersion":1,"type":"message","role":"user","content":"describe","images":[{"mediaType":"png","data":"` +
+		base64.StdEncoding.EncodeToString(raw) + `"}]}`
+
+	events, err := ParseInput(line)
+	if err != nil {
+		t.Fatalf("ParseInput: %v", err)
+	}
+
+	// prompt resolution is unaffected by images
+	prompt, err := ResolvePrompt(events)
+	if err != nil {
+		t.Fatalf("ResolvePrompt: %v", err)
+	}
+	if prompt != "describe" {
+		t.Fatalf("prompt = %q", prompt)
+	}
+
+	images, err := ResolveImages(events)
+	if err != nil {
+		t.Fatalf("ResolveImages: %v", err)
+	}
+	if len(images) != 1 || images[0].MediaType != "image/png" || string(images[0].Data) != string(raw) {
+		t.Fatalf("round-trip image mismatch: %+v", images)
+	}
+
+	// text-only input still resolves to nil images, non-empty prompt
+	textOnly, err := ParseInput(`{"schemaVersion":1,"type":"prompt","content":"hello"}`)
+	if err != nil {
+		t.Fatalf("ParseInput text-only: %v", err)
+	}
+	imgs, err := ResolveImages(textOnly)
+	if err != nil {
+		t.Fatalf("ResolveImages text-only: %v", err)
+	}
+	if imgs != nil {
+		t.Fatalf("expected nil images for text-only input, got %+v", imgs)
+	}
+}
+
 func TestEventRoundTripsStructuredToolResultFields(t *testing.T) {
 	redacted := true
 	truncated := false

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -32,6 +32,7 @@ const (
 	commandTheme
 	commandInputStyle
 	commandBash
+	commandImage
 	commandUnknown
 )
 
@@ -114,6 +115,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Show current workspace and runtime context.",
 		kind:        commandContext,
+	},
+	{
+		name:        "/image",
+		usage:       "/image <path> | clear",
+		group:       commandGroupSession,
+		description: "Attach a local image to the next message (vision models). /image clear removes pending attachments.",
+		kind:        commandImage,
 	},
 	{
 		name:        "/clear",

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -111,3 +111,34 @@ func commandTestStringSliceContains(values []string, want string) bool {
 	}
 	return false
 }
+
+func TestParseImageCommand(t *testing.T) {
+	cases := []struct {
+		input string
+		kind  commandKind
+		text  string
+	}{
+		{input: "/image photo.png", kind: commandImage, text: "photo.png"},
+		{input: "/image ./a b.png", kind: commandImage, text: "./a b.png"},
+		{input: "/image clear", kind: commandImage, text: "clear"},
+		{input: "/image", kind: commandImage, text: ""},
+	}
+	for _, tc := range cases {
+		got := parseCommand(tc.input)
+		if got.kind != tc.kind || got.text != tc.text {
+			t.Fatalf("%q: got kind=%v text=%q, want kind=%v text=%q", tc.input, got.kind, got.text, tc.kind, tc.text)
+		}
+	}
+}
+
+func TestImageCommandIsDiscoverable(t *testing.T) {
+	found := false
+	for _, name := range listCommandNames() {
+		if name == "/image" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("/image should be listed so it appears in help and autocomplete")
+	}
+}

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -1,0 +1,23 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+)
+
+// modelSupportsVisionTUI reports whether the active model can accept image input.
+// An unknown / custom id (not in the catalog) returns false: we cannot confirm
+// vision support, so the TUI refuses to attach rather than silently sending
+// images a model may reject. Mirrors the CLI/headless vision gate (component E).
+func modelSupportsVisionTUI(modelName string) bool {
+	trimmed := strings.TrimSpace(modelName)
+	if trimmed == "" {
+		return false
+	}
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return false
+	}
+	return modelregistry.SupportsVision(registry, trimmed)
+}

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -1,8 +1,10 @@
 package tui
 
 import (
+	"path/filepath"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/imageinput"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 )
 
@@ -20,4 +22,56 @@ func modelSupportsVisionTUI(modelName string) bool {
 		return false
 	}
 	return modelregistry.SupportsVision(registry, trimmed)
+}
+
+// handleImageCommand processes "/image <path>" and "/image clear". A bare
+// "/image" prints usage. Attaching to a non-vision model is refused inline (the
+// active model can be checked synchronously). Attachment failures (missing file,
+// unsupported type, oversize) surface as an inline notice and attach nothing.
+func (m model) handleImageCommand(arg string) model {
+	trimmed := strings.TrimSpace(arg)
+	switch {
+	case trimmed == "":
+		return m.appendImageNotice("Usage: /image <path>  (or /image clear)")
+	case strings.EqualFold(trimmed, "clear"):
+		m.pendingImages = nil
+		m.pendingImageLabels = nil
+		return m.appendImageNotice("Cleared pending image attachments.")
+	}
+
+	if !modelSupportsVisionTUI(m.modelName) {
+		name := m.modelName
+		if name == "" {
+			name = "the active model"
+		}
+		return m.appendImageNotice("Model " + name + " does not support image input; attachment refused.")
+	}
+
+	block, err := imageinput.LoadFile(trimmed, m.cwd)
+	if err != nil {
+		return m.appendImageNotice(err.Error())
+	}
+
+	m.pendingImages = append(m.pendingImages, block)
+	m.pendingImageLabels = append(m.pendingImageLabels, filepath.Base(trimmed))
+	return m.appendImageNotice("Attached " + filepath.Base(trimmed) + " (" + block.MediaType + ").")
+}
+
+func (m model) appendImageNotice(text string) model {
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
+	return m
+}
+
+// renderImageChips builds a one-line "[img: a.png] [img: b.png]" row for the
+// pending attachments, or "" when there are none. Kept plain so both the default
+// and zeroline skins can wrap/style it consistently.
+func renderImageChips(labels []string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	chips := make([]string, 0, len(labels))
+	for _, label := range labels {
+		chips = append(chips, "[img: "+label+"]")
+	}
+	return strings.Join(chips, " ")
 }

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -211,3 +211,65 @@ func TestSubmitThreadsImagesThenClears(t *testing.T) {
 		t.Fatal("expected captureRunImages to be invoked with the staged image")
 	}
 }
+
+// TestSubmitDropsImagesWhenModelSwitchedToNonVision attaches an image on a vision
+// model, then simulates a /model switch to a non-vision id before submit. The
+// submit-time re-check must drop the images (the agent run receives none), append
+// an inline notice mirroring exec's drop+warn wording, and still clear pending
+// state.
+func TestSubmitDropsImagesWhenModelSwitchedToNonVision(t *testing.T) {
+	root := t.TempDir()
+	writeTestPNG(t, root, "photo.png")
+
+	captured := make(chan []zeroruntime.ImageBlock, 1)
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "ok"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+
+	m := newModel(context.Background(), Options{
+		Cwd:          root,
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
+	})
+	m.agentOptions.OnText = func(string) {}
+	m.captureRunImages = func(imgs []zeroruntime.ImageBlock) { captured <- imgs }
+
+	// Attach on the vision model.
+	m.input.SetValue("/image photo.png")
+	updated, _ := m.handleSubmit()
+	m = updated.(model)
+	if len(m.pendingImages) != 1 {
+		t.Fatalf("setup: expected 1 staged image, got %d", len(m.pendingImages))
+	}
+
+	// Simulate a /model switch to a non-vision (catalog-unknown) model.
+	m.modelName = "totally-unknown-custom"
+
+	m.input.SetValue("describe this")
+	updated, cmd := m.handleSubmit()
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected a prompt submit to start a run")
+	}
+	if len(next.pendingImages) != 0 || len(next.pendingImageLabels) != 0 {
+		t.Fatalf("submit must clear pending images, got %d/%d", len(next.pendingImages), len(next.pendingImageLabels))
+	}
+	if notice := lastTranscriptText(next); !strings.Contains(notice, "does not support image input") {
+		t.Fatalf("expected an inline drop notice, got %q", notice)
+	}
+
+	cmd() // run the agent goroutine; it invokes captureRunImages
+
+	select {
+	case imgs := <-captured:
+		if len(imgs) != 0 {
+			t.Fatalf("non-vision model must receive no images, got %#v", imgs)
+		}
+	default:
+		t.Fatal("expected captureRunImages to be invoked (with no images)")
+	}
+}

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -130,3 +130,30 @@ func TestImageCommandMissingFileNotice(t *testing.T) {
 		t.Fatalf("expected a notice naming the missing file, got %q", notice)
 	}
 }
+
+func TestTranscriptViewShowsImageChips(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4.1"})
+	m.width = 100
+	m.height = 30
+	m.showSplash = false
+	m.pendingImageLabels = []string{"photo.png", "diagram.gif"}
+
+	view := m.transcriptView()
+	if !strings.Contains(view, "photo.png") || !strings.Contains(view, "diagram.gif") {
+		t.Fatalf("transcript view should show pending image chips, got:\n%s", view)
+	}
+}
+
+func TestZerolineViewShowsImageChips(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4.1", Skin: "zeroline"})
+	m.width = 100
+	m.height = 30
+	m.showSplash = false
+	m.booted = true
+	m.pendingImageLabels = []string{"photo.png"}
+
+	view := m.zerolineView()
+	if !strings.Contains(view, "photo.png") {
+		t.Fatalf("zeroline view should show pending image chip, got:\n%s", view)
+	}
+}

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
 func TestModelSupportsVisionTUI(t *testing.T) {
@@ -155,5 +158,56 @@ func TestZerolineViewShowsImageChips(t *testing.T) {
 	view := m.zerolineView()
 	if !strings.Contains(view, "photo.png") {
 		t.Fatalf("zeroline view should show pending image chip, got:\n%s", view)
+	}
+}
+
+func TestSubmitThreadsImagesThenClears(t *testing.T) {
+	root := t.TempDir()
+	writeTestPNG(t, root, "photo.png")
+
+	captured := make(chan []zeroruntime.ImageBlock, 1)
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "ok"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+
+	m := newModel(context.Background(), Options{
+		Cwd:          root,
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
+	})
+	// Capture the Images the agent run is launched with.
+	m.agentOptions.OnText = func(string) {}
+	m.captureRunImages = func(imgs []zeroruntime.ImageBlock) { captured <- imgs }
+
+	m.input.SetValue("/image photo.png")
+	updated, _ := m.handleSubmit()
+	m = updated.(model)
+	if len(m.pendingImages) != 1 {
+		t.Fatalf("setup: expected 1 staged image, got %d", len(m.pendingImages))
+	}
+
+	m.input.SetValue("describe this")
+	updated, cmd := m.handleSubmit()
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected a prompt submit to start a run")
+	}
+	if len(next.pendingImages) != 0 || len(next.pendingImageLabels) != 0 {
+		t.Fatalf("submit must clear pending images, got %d/%d", len(next.pendingImages), len(next.pendingImageLabels))
+	}
+
+	cmd() // run the agent goroutine; it invokes captureRunImages
+
+	select {
+	case imgs := <-captured:
+		if len(imgs) != 1 || imgs[0].MediaType != "image/png" {
+			t.Fatalf("agent run should receive 1 png image, got %#v", imgs)
+		}
+	default:
+		t.Fatal("expected captureRunImages to be invoked with the staged image")
 	}
 }

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -1,6 +1,12 @@
 package tui
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestModelSupportsVisionTUI(t *testing.T) {
 	cases := []struct {
@@ -18,5 +24,109 @@ func TestModelSupportsVisionTUI(t *testing.T) {
 		if got != tc.want {
 			t.Fatalf("modelSupportsVisionTUI(%q) = %v, want %v", tc.modelName, got, tc.want)
 		}
+	}
+}
+
+func writeTestPNG(t *testing.T, dir, name string) string {
+	t.Helper()
+	png := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+		0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+		0x42, 0x60, 0x82,
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, png, 0o644); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	return path
+}
+
+func lastTranscriptText(m model) string {
+	if len(m.transcript) == 0 {
+		return ""
+	}
+	return m.transcript[len(m.transcript)-1].text
+}
+
+func TestImageCommandAttachRendersChip(t *testing.T) {
+	root := t.TempDir()
+	writeTestPNG(t, root, "photo.png")
+
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "gpt-4.1"})
+	m.input.SetValue("/image photo.png")
+	updated, _ := m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingImages) != 1 {
+		t.Fatalf("expected 1 pending image, got %d", len(next.pendingImages))
+	}
+	if next.pendingImages[0].MediaType != "image/png" {
+		t.Fatalf("MediaType = %q, want image/png", next.pendingImages[0].MediaType)
+	}
+	if len(next.pendingImageLabels) != 1 || next.pendingImageLabels[0] != "photo.png" {
+		t.Fatalf("labels = %v, want [photo.png]", next.pendingImageLabels)
+	}
+	if chips := renderImageChips(next.pendingImageLabels); chips == "" {
+		t.Fatal("expected a chip row for pending images")
+	} else if !strings.Contains(chips, "photo.png") {
+		t.Fatalf("chip row %q should name the image", chips)
+	}
+}
+
+func TestImageCommandClear(t *testing.T) {
+	root := t.TempDir()
+	writeTestPNG(t, root, "photo.png")
+
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "gpt-4.1"})
+	m.input.SetValue("/image photo.png")
+	updated, _ := m.handleSubmit()
+	m = updated.(model)
+
+	m.input.SetValue("/image clear")
+	updated, _ = m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingImages) != 0 || len(next.pendingImageLabels) != 0 {
+		t.Fatalf("expected cleared pending images, got %d/%d", len(next.pendingImages), len(next.pendingImageLabels))
+	}
+}
+
+func TestImageCommandNonVisionRefuses(t *testing.T) {
+	root := t.TempDir()
+	writeTestPNG(t, root, "photo.png")
+
+	// A custom/unknown model id is treated as non-vision (can't confirm).
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "totally-unknown-custom"})
+	m.input.SetValue("/image photo.png")
+	updated, _ := m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingImages) != 0 {
+		t.Fatalf("non-vision model must refuse: got %d pending images", len(next.pendingImages))
+	}
+	notice := lastTranscriptText(next)
+	if !strings.Contains(notice, "does not support image input") {
+		t.Fatalf("expected an inline refusal notice, got %q", notice)
+	}
+}
+
+func TestImageCommandMissingFileNotice(t *testing.T) {
+	root := t.TempDir()
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "gpt-4.1"})
+	m.input.SetValue("/image nope.png")
+	updated, _ := m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingImages) != 0 {
+		t.Fatal("a missing file must not attach")
+	}
+	if notice := lastTranscriptText(next); !strings.Contains(notice, "nope.png") {
+		t.Fatalf("expected a notice naming the missing file, got %q", notice)
 	}
 }

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -1,0 +1,22 @@
+package tui
+
+import "testing"
+
+func TestModelSupportsVisionTUI(t *testing.T) {
+	cases := []struct {
+		modelName string
+		want      bool
+	}{
+		{modelName: "gpt-4.1", want: true},                  // vision model in the catalog
+		{modelName: "claude-sonnet-4.5", want: true},        // vision model in the catalog
+		{modelName: "claude-haiku-3.5", want: true},         // has vision capability
+		{modelName: "totally-unknown-custom", want: false},  // not in catalog -> can't confirm
+		{modelName: "", want: false},
+	}
+	for _, tc := range cases {
+		got := modelSupportsVisionTUI(tc.modelName)
+		if got != tc.want {
+			t.Fatalf("modelSupportsVisionTUI(%q) = %v, want %v", tc.modelName, got, tc.want)
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -101,6 +101,11 @@ type model struct {
 	// no attachments = today's text-only behavior exactly.
 	pendingImages      []zeroruntime.ImageBlock
 	pendingImageLabels []string
+
+	// captureRunImages, when set, is invoked with the images a run is launched
+	// with. Nil in production; used by tests to assert image threading without a
+	// real provider round-trip.
+	captureRunImages func([]zeroruntime.ImageBlock)
 }
 
 type agentTextMsg struct {
@@ -923,12 +928,15 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			}
 			command.text = agentPrompt
 		}
+		turnImages := m.pendingImages
+		m.pendingImages = nil
+		m.pendingImageLabels = nil
 		runCtx, cancel := context.WithCancel(m.ctx)
 		m.runID++
 		m.activeRunID = m.runID
 		m.runCancel = cancel
 		m.pending = true
-		return m, m.runAgent(m.activeRunID, runCtx, command.text)
+		return m, m.runAgent(m.activeRunID, runCtx, command.text, turnImages)
 	default:
 		return m, nil
 	}
@@ -962,7 +970,7 @@ func (m *model) cancelRun() {
 	m.pendingAskUser = nil
 }
 
-func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cmd {
+func (m model) runAgent(runID int, runCtx context.Context, prompt string, images []zeroruntime.ImageBlock) tea.Cmd {
 	return func() tea.Msg {
 		rows := []transcriptRow{}
 		usageEvents := []zeroruntime.Usage{}
@@ -975,6 +983,10 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string) tea.Cm
 		options.Model = m.modelName
 		options.ReasoningEffort = string(m.reasoningEffort)
 		options.Cwd = m.cwd
+		options.Images = images
+		if m.captureRunImages != nil {
+			m.captureRunImages(images)
+		}
 		// Enable agent-loop compaction sized to the active model's context
 		// window. An unknown/custom model resolves to 0, leaving compaction off.
 		options.ContextWindow = modelContextWindow(m.modelName)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -94,6 +94,13 @@ type model struct {
 	// /theme, /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and
 	// applies the chosen value through the existing command handlers.
 	picker *commandPicker
+
+	// pendingImages holds image attachments staged by /image for the next user
+	// turn; pendingImageLabels are their display names (base(path)) for the chip
+	// row. Both are cleared after a prompt is submitted (or /image clear). nil =
+	// no attachments = today's text-only behavior exactly.
+	pendingImages      []zeroruntime.ImageBlock
+	pendingImageLabels []string
 }
 
 type agentTextMsg struct {
@@ -849,6 +856,10 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			kind: actionAppendSystem,
 			text: shellOnlyCommandText(command.name),
 		})
+		return m, nil
+	case commandImage:
+		m.showSplash = false
+		m = m.handleImageCommand(command.text)
 		return m, nil
 	case commandUnknown:
 		m.showSplash = false

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -928,7 +928,24 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			}
 			command.text = agentPrompt
 		}
+		// Re-check vision support against the CURRENT effective model at submit
+		// time, not just at /image attach time: the user may have attached on a
+		// vision model and then /model-switched to a non-vision one. If the active
+		// model can't accept images, drop them (with an inline notice mirroring
+		// exec's drop+warn wording) rather than sending them to a model that
+		// rejects them. Pending state is cleared either way below.
 		turnImages := m.pendingImages
+		if len(turnImages) > 0 && !modelSupportsVisionTUI(m.modelName) {
+			name := m.modelName
+			if name == "" {
+				name = "the active model"
+			}
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{
+				kind: actionAppendSystem,
+				text: fmt.Sprintf("Model %s does not support image input; ignoring %d image(s).", name, len(turnImages)),
+			})
+			turnImages = nil
+		}
 		m.pendingImages = nil
 		m.pendingImageLabels = nil
 		runCtx, cancel := context.WithCancel(m.ctx)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -542,6 +542,10 @@ func (m model) transcriptView() string {
 	}
 
 	builder.WriteString("\n")
+	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
+		builder.WriteString(zeroTheme.muted.Render(chips))
+		builder.WriteString("\n")
+	}
 	builder.WriteString(borderedBlock(width, []string{m.input.View()}))
 	if overlay := m.suggestionOverlay(width); overlay != "" {
 		builder.WriteString("\n")

--- a/internal/tui/zeroline_view.go
+++ b/internal/tui/zeroline_view.go
@@ -122,6 +122,7 @@ func (m model) zerolineView() string {
 		Perm:        m.zerolinePerm(),
 		AskUser:     askUser,
 		Input:       m.input.View(),
+		ImageChips:  renderImageChips(m.pendingImageLabels),
 		Suggestions: m.zerolineSuggestions(),
 		SelectedIdx: m.suggestionIdx,
 		Picker:      m.zerolinePicker(),

--- a/internal/zeroline/render.go
+++ b/internal/zeroline/render.go
@@ -95,6 +95,9 @@ type ChatData struct {
 	// skin instead of showing a misleading "working…".
 	AskUser *AskUser
 	Input   string
+	// ImageChips, when non-empty, is the pending-attachment chip row shown above
+	// the command input ("[img: a.png] [img: b.png]"); "" when nothing is staged.
+	ImageChips string
 	// Suggestions / SelectedIdx drive the slash-command autocomplete overlay; an
 	// empty slice means no overlay. Picker, when non-nil, is an open selector.
 	Suggestions []Suggestion
@@ -588,6 +591,10 @@ func (s styles) cmdRegion(d ChatData, w int) string {
 		return padRight(hint, w, p.Bg)
 	}
 	line := s.acc.Bold(true).Render(":") + " " + d.Input
+	if d.ImageChips != "" {
+		chips := s.mute.Render(d.ImageChips)
+		return padRight(chips, w, p.Bg) + "\n" + padRight(line, w, p.Bg)
+	}
 	return padRight(line, w, p.Bg)
 }
 

--- a/internal/zeroline/render.go
+++ b/internal/zeroline/render.go
@@ -251,12 +251,23 @@ func RenderChat(d ChatData) string {
 	bottom := s.botBar(run, d.Header, d.Variant, d.TokS, w)
 	cmd := s.cmdRegion(d, w)
 
+	// The command region is one row by default, but grows to TWO rows when a
+	// pending-attachment chip line is shown above the input (cmdRegion emits the
+	// chips on their own row). Account for that extra row so the composed frame
+	// (top + cmd + bottom = cmdRows+2 fixed rows, plus the body/overlay) stays
+	// exactly `h` rows instead of overflowing.
+	cmdRows := 1
+	if d.ImageChips != "" {
+		cmdRows = 2
+	}
+	fixedRows := cmdRows + 2 // top + cmd(cmdRows) + bottom
+
 	// The autocomplete / picker overlay (when present) sits between the command
 	// line and the bottom bar; its lines are subtracted from the transcript body
 	// so the frame keeps its fixed height. Cap the overlay so it can never push
-	// the body below one row (top + cmd + bottom = 3 fixed rows, plus >=1 body),
-	// which would otherwise overflow the frame's allotted height.
-	maxOverlay := h - 3 - 1
+	// the body below one row (fixed rows, plus >=1 body), which would otherwise
+	// overflow the frame's allotted height.
+	maxOverlay := h - fixedRows - 1
 	if maxOverlay < 0 {
 		maxOverlay = 0
 	}
@@ -266,7 +277,7 @@ func RenderChat(d ChatData) string {
 		overlayH = strings.Count(overlay, "\n") + 1
 	}
 
-	bodyH := h - 3 - overlayH
+	bodyH := h - fixedRows - overlayH
 	if bodyH < 1 {
 		bodyH = 1
 	}

--- a/internal/zeroline/render_test.go
+++ b/internal/zeroline/render_test.go
@@ -74,6 +74,40 @@ func TestRenderChatLiveData(t *testing.T) {
 	}
 }
 
+// TestRenderChatFrameHeightWithImageChips locks the frame-height accounting: the
+// composed frame must be EXACTLY Height rows whether or not the pending-attachment
+// chip row is present. cmdRegion emits two rows when ImageChips is set, so a body
+// computed for a one-row cmd would overflow the fixed frame by one line.
+func TestRenderChatFrameHeightWithImageChips(t *testing.T) {
+	base := ChatData{
+		Variant: 0, Dark: true, Width: 80, Height: 24,
+		Header: Header{Cwd: "~/src", Branch: "main", Model: "m", Provider: "p"},
+		Input:  "describe these",
+		Rows: []Row{
+			{Kind: "user", Text: "hello"},
+			{Kind: "assistant", Text: "hi there"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		chips string
+	}{
+		{"without chips", ""},
+		{"with chips", "[1] pic.png  [2] shot.jpg"},
+	} {
+		d := base
+		d.ImageChips = tc.chips
+		out := RenderChat(d)
+		if got := strings.Count(out, "\n") + 1; got != d.Height {
+			t.Errorf("%s: frame has %d rows, want exactly %d", tc.name, got, d.Height)
+		}
+		if tc.chips != "" && !strings.Contains(out, "pic.png") {
+			t.Errorf("%s: chip row not rendered", tc.name)
+		}
+	}
+}
+
 func TestRenderChatAskUserShowsQuestionNotSpinner(t *testing.T) {
 	d := ChatData{
 		Variant: 0, Dark: true, Width: 100, Height: 30,

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -39,12 +39,34 @@ func SeedMessages(systemPrompt string, userPrompt string) []Message {
 }
 
 // SeedMessagesWithImages creates the initial system and user turns and attaches
-// any image attachments to the user turn. images may be nil (text-only).
+// any image attachments to the user turn. images may be nil (text-only). The
+// images are deep-copied so the seeded message never aliases the caller's slice
+// or the underlying Data bytes (a later mutation of the caller's bytes can never
+// reach into the conversation history).
 func SeedMessagesWithImages(systemPrompt string, userPrompt string, images []ImageBlock) []Message {
 	return []Message{
 		{Role: MessageRoleSystem, Content: systemPrompt},
-		{Role: MessageRoleUser, Content: userPrompt, Images: images},
+		{Role: MessageRoleUser, Content: userPrompt, Images: CloneImageBlocks(images)},
 	}
+}
+
+// CloneImageBlocks deep-copies a slice of ImageBlock, including each Data byte
+// slice, so the returned blocks share no backing array with the input. It
+// returns nil for a nil or empty input (preserving the text-only "no images"
+// representation). Use it wherever image-carrying messages are seeded or copied
+// so raw image bytes are never aliased across history/request/result copies.
+func CloneImageBlocks(in []ImageBlock) []ImageBlock {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ImageBlock, len(in))
+	for index, block := range in {
+		out[index] = ImageBlock{
+			MediaType: block.MediaType,
+			Data:      append([]byte(nil), block.Data...),
+		}
+	}
+	return out
 }
 
 // CollectStream drains provider events into text, tool calls, usage, and error state.

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -31,11 +31,19 @@ type CollectOptions struct {
 	OnUsage func(Usage)
 }
 
-// SeedMessages creates the initial system and user turns for a request.
+// SeedMessages creates the initial system and user turns for a request. It is a
+// text-only convenience that delegates to SeedMessagesWithImages with no images
+// (the user turn's Images stays nil, byte-identical to the prior behavior).
 func SeedMessages(systemPrompt string, userPrompt string) []Message {
+	return SeedMessagesWithImages(systemPrompt, userPrompt, nil)
+}
+
+// SeedMessagesWithImages creates the initial system and user turns and attaches
+// any image attachments to the user turn. images may be nil (text-only).
+func SeedMessagesWithImages(systemPrompt string, userPrompt string, images []ImageBlock) []Message {
 	return []Message{
 		{Role: MessageRoleSystem, Content: systemPrompt},
-		{Role: MessageRoleUser, Content: userPrompt},
+		{Role: MessageRoleUser, Content: userPrompt, Images: images},
 	}
 }
 

--- a/internal/zeroruntime/image_types_test.go
+++ b/internal/zeroruntime/image_types_test.go
@@ -1,0 +1,38 @@
+package zeroruntime
+
+import "testing"
+
+func TestNormalizeImageMediaType(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare png", "png", "image/png"},
+		{"bare jpeg", "jpeg", "image/jpeg"},
+		{"jpg aliases to jpeg", "jpg", "image/jpeg"},
+		{"bare gif", "gif", "image/gif"},
+		{"bare webp", "webp", "image/webp"},
+		{"uppercase trimmed", "  PNG  ", "image/png"},
+		{"passthrough image/png", "image/png", "image/png"},
+		{"passthrough image/jpeg", "image/jpeg", "image/jpeg"},
+		{"passthrough image/gif", "image/gif", "image/gif"},
+		{"passthrough image/webp", "image/webp", "image/webp"},
+		{"image/jpg aliases to jpeg", "image/jpg", "image/jpeg"},
+		{"data uri png stripped", "data:image/png;base64,iVBORw0KGgo=", "image/png"},
+		{"data uri jpg stripped and aliased", "data:image/jpg;base64,AAAA", "image/jpeg"},
+		{"data uri bare jpg", "data:jpg;base64,AAAA", "image/jpeg"},
+		{"reject svg", "image/svg+xml", ""},
+		{"reject bmp", "bmp", ""},
+		{"reject empty", "", ""},
+		{"reject non-image mime", "text/plain", ""},
+		{"reject bare unknown", "tiff", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeImageMediaType(tc.in); got != tc.want {
+				t.Fatalf("NormalizeImageMediaType(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/zeroruntime/image_types_test.go
+++ b/internal/zeroruntime/image_types_test.go
@@ -36,3 +36,29 @@ func TestNormalizeImageMediaType(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageImagesFieldDefaultsNil(t *testing.T) {
+	// A text-only message must leave Images nil (today's behavior, byte-identical).
+	textOnly := Message{Role: MessageRoleUser, Content: "hello"}
+	if textOnly.Images != nil {
+		t.Fatalf("expected nil Images on a text-only message, got %#v", textOnly.Images)
+	}
+
+	// The field accepts ImageBlock values carrying raw bytes.
+	withImage := Message{
+		Role:    MessageRoleUser,
+		Content: "look",
+		Images: []ImageBlock{
+			{MediaType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}},
+		},
+	}
+	if len(withImage.Images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(withImage.Images))
+	}
+	if withImage.Images[0].MediaType != "image/png" {
+		t.Fatalf("unexpected media type: %q", withImage.Images[0].MediaType)
+	}
+	if string(withImage.Images[0].Data) != "\x89PNG" {
+		t.Fatalf("unexpected raw data: %q", withImage.Images[0].Data)
+	}
+}

--- a/internal/zeroruntime/seed_images_test.go
+++ b/internal/zeroruntime/seed_images_test.go
@@ -1,6 +1,9 @@
 package zeroruntime
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestSeedMessagesWithImagesThreadsImagesOntoUserTurn(t *testing.T) {
 	images := []ImageBlock{
@@ -26,6 +29,56 @@ func TestSeedMessagesWithImagesThreadsImagesOntoUserTurn(t *testing.T) {
 	}
 	if messages[1].Images[0].MediaType != "image/png" || messages[1].Images[1].MediaType != "image/jpeg" {
 		t.Fatalf("images not threaded in order: %#v", messages[1].Images)
+	}
+}
+
+// TestSeedMessagesWithImagesDeepCopiesData locks the anti-aliasing guarantee:
+// after seeding, mutating the caller's original Data bytes must NOT change the
+// bytes carried on the seeded user turn (the message owns an independent copy).
+func TestSeedMessagesWithImagesDeepCopiesData(t *testing.T) {
+	original := []byte{0x89, 0x50, 0x4e, 0x47}
+	images := []ImageBlock{{MediaType: "image/png", Data: original}}
+
+	messages := SeedMessagesWithImages("sys", "describe", images)
+	if len(messages) != 2 || len(messages[1].Images) != 1 {
+		t.Fatalf("unexpected seeded shape: %#v", messages)
+	}
+
+	// Mutate the caller's original bytes (and the caller's slice element) after
+	// seeding. An aliased buffer would leak this mutation into the message.
+	original[0] = 0x00
+	images[0].Data[1] = 0x00
+
+	got := messages[1].Images[0].Data
+	want := []byte{0x89, 0x50, 0x4e, 0x47}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("seeded image bytes = %v, want unchanged %v (data is aliased)", got, want)
+	}
+}
+
+// TestCloneImageBlocksIsIndependent verifies CloneImageBlocks returns nil for
+// nil/empty input and otherwise deep-copies both the slice and each Data buffer.
+func TestCloneImageBlocksIsIndependent(t *testing.T) {
+	if got := CloneImageBlocks(nil); got != nil {
+		t.Fatalf("CloneImageBlocks(nil) = %#v, want nil", got)
+	}
+	if got := CloneImageBlocks([]ImageBlock{}); got != nil {
+		t.Fatalf("CloneImageBlocks(empty) = %#v, want nil", got)
+	}
+
+	in := []ImageBlock{{MediaType: "image/png", Data: []byte{1, 2, 3}}}
+	out := CloneImageBlocks(in)
+	if len(out) != 1 || out[0].MediaType != "image/png" || !bytes.Equal(out[0].Data, []byte{1, 2, 3}) {
+		t.Fatalf("CloneImageBlocks copy = %#v", out)
+	}
+	// Mutating the input must not touch the clone.
+	in[0].Data[0] = 9
+	if out[0].Data[0] != 1 {
+		t.Fatalf("clone Data aliases input: got %d, want 1", out[0].Data[0])
+	}
+	// And the clone's backing array is distinct from the input's.
+	if &in[0].Data[0] == &out[0].Data[0] {
+		t.Fatal("clone Data shares backing array with input")
 	}
 }
 

--- a/internal/zeroruntime/seed_images_test.go
+++ b/internal/zeroruntime/seed_images_test.go
@@ -1,0 +1,46 @@
+package zeroruntime
+
+import "testing"
+
+func TestSeedMessagesWithImagesThreadsImagesOntoUserTurn(t *testing.T) {
+	images := []ImageBlock{
+		{MediaType: "image/png", Data: []byte{0x89, 0x50, 0x4e, 0x47}},
+		{MediaType: "image/jpeg", Data: []byte{0xff, 0xd8, 0xff}},
+	}
+	messages := SeedMessagesWithImages("you are a helper", "describe these", images)
+
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if messages[0].Role != MessageRoleSystem || messages[0].Content != "you are a helper" {
+		t.Fatalf("unexpected system message: %#v", messages[0])
+	}
+	if messages[0].Images != nil {
+		t.Fatalf("system message must not carry images, got %#v", messages[0].Images)
+	}
+	if messages[1].Role != MessageRoleUser || messages[1].Content != "describe these" {
+		t.Fatalf("unexpected user message: %#v", messages[1])
+	}
+	if len(messages[1].Images) != 2 {
+		t.Fatalf("expected 2 images on the user turn, got %d", len(messages[1].Images))
+	}
+	if messages[1].Images[0].MediaType != "image/png" || messages[1].Images[1].MediaType != "image/jpeg" {
+		t.Fatalf("images not threaded in order: %#v", messages[1].Images)
+	}
+}
+
+func TestSeedMessagesDelegatesWithNilImages(t *testing.T) {
+	// SeedMessages keeps its (system, user) signature and must leave Images nil
+	// so the text-only path is byte-identical to before.
+	messages := SeedMessages("sys", "usr")
+
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+	if messages[1].Role != MessageRoleUser || messages[1].Content != "usr" {
+		t.Fatalf("unexpected user message: %#v", messages[1])
+	}
+	if messages[0].Images != nil || messages[1].Images != nil {
+		t.Fatalf("SeedMessages must leave Images nil, got %#v / %#v", messages[0].Images, messages[1].Images)
+	}
+}

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -75,6 +75,7 @@ type Message struct {
 	Content    string
 	ToolCalls  []ToolCall
 	ToolCallID string
+	Images     []ImageBlock // optional; nil for text-only messages
 }
 
 // ToolDefinition describes a model-visible tool and its JSON-schema parameters.

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -1,6 +1,9 @@
 package zeroruntime
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // MessageRole identifies the origin of a conversation message.
 type MessageRole string
@@ -149,4 +152,48 @@ type CompletionRequest struct {
 // Provider streams normalized completion events for one request.
 type Provider interface {
 	StreamCompletion(ctx context.Context, request CompletionRequest) (<-chan StreamEvent, error)
+}
+
+// ImageBlock is a normalized image attachment carried on a Message. Data is the
+// RAW decoded image bytes (no base64, no data: prefix); each provider encodes it
+// into its own wire format. MediaType is a normalized MIME, e.g. "image/png".
+type ImageBlock struct {
+	MediaType string
+	Data      []byte
+}
+
+// NormalizeImageMediaType canonicalizes a caller-supplied image type to one of
+// the allow-listed MIME strings (image/png, image/jpeg, image/gif, image/webp)
+// or "" when the input is outside the allow-list (the caller then rejects it).
+//
+// It lowercases and trims the input, strips a leading "data:<m>;base64," prefix
+// (using <m>), maps a bare png|jpeg|jpg|gif|webp to image/<x> (jpg->jpeg), and
+// passes through an already-image/<x> value in the allow-list (image/jpg is
+// also folded to image/jpeg). It is pure and has no dependencies.
+func NormalizeImageMediaType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	// Strip a data: URI wrapper, keeping the media type between "data:" and ";".
+	if rest, ok := strings.CutPrefix(s, "data:"); ok {
+		if i := strings.IndexByte(rest, ';'); i >= 0 {
+			s = rest[:i]
+		} else {
+			s = rest
+		}
+		s = strings.TrimSpace(s)
+	}
+	switch s {
+	case "png", "image/png":
+		return "image/png"
+	case "jpeg", "jpg", "image/jpeg", "image/jpg":
+		return "image/jpeg"
+	case "gif", "image/gif":
+		return "image/gif"
+	case "webp", "image/webp":
+		return "image/webp"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
## Summary

Adds **image (multimodal) input** end-to-end: a user can attach local image files to a chat turn so a vision-capable model can see them, across all three providers and both input surfaces. Strictly additive — every text-only path is byte-for-byte unchanged. No new module dependencies.

- **Runtime** (`internal/zeroruntime`): optional `Message.Images []ImageBlock` (`ImageBlock{MediaType string; Data []byte}` — raw bytes), a `NormalizeImageMediaType` allow-list helper (png/jpeg[jpg→jpeg]/gif/webp), and `SeedMessagesWithImages` (`SeedMessages` delegates with nil — signature unchanged).
- **Providers** — all three serialize native image blocks when a user turn carries images, base64-encoding raw bytes: **Anthropic** `image`/`source.base64` content blocks, **Gemini** `inlineData` parts, **OpenAI** `image_url` data-URI parts (this required `chatMessage.Content` `string→any`; an empty-content `omitempty` guard keeps text-only requests byte-identical). Image-only turns still emit; only the user role carries images.
- **Capability gate** (`internal/modelregistry`): `SupportsVision`; when the effective model lacks vision, images are **dropped with a warning** (never errors the run). Unknown/custom model ids fail closed (drop).
- **CLI** (`internal/cli`): repeatable `zero exec --image <path>` — reads, sniffs MIME, normalizes, caps at 10 MiB, base64-encodes; threaded into the agent run through the vision gate.
- **stream-json** (`internal/streamjson`): an `images` field on `message` input events (whitelisted only on message events; allows empty content when images present), resolved end-to-end into the agent run.
- **TUI** (`internal/tui`): a `/image <path>` command with removable `[img: name]` chips above the input (both skins), `/image clear`, vision-refusal at attach **and** re-checked at submit; images thread into the turn and clear after.
- **Shared loader** (`internal/imageinput`): one `LoadFile` (read/sniff/normalize/cap, `os.Stat` pre-check) used by both the CLI and TUI — no duplicated logic.

Image sources are **local files only** (no remote URLs / clipboard). Allowed types: png, jpeg, gif, webp.

## Test Plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` green (new tests across `zeroruntime`, all 3 providers, `modelregistry`, `imageinput`, `cli`, `streamjson`, `tui`)
- [x] `go test -race ./internal/{cli,tui,imageinput,providers,streamjson,agent}/...` green
- [x] `GOOS=windows GOARCH=amd64 go build ./...` green
- [x] `git diff --check` clean

### Reviewer focus
- **OpenAI text-only byte-identical:** the `Content string→any` change keeps an empty-content message's `content` key omitted (regression-guarded; mutation-tested).
- **End-to-end image path:** a `--image` file and a stream-json `images` event both reach `agent.Options.Images` → the provider wire format (covered by `TestRunExecStreamJSONImageReachesAgent`).
- **Vision gate:** non-vision/unknown model → drop + warn (CLI and TUI, incl. TUI submit-time re-check after a model switch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach images via --image (zero exec), stream-json stdin, and TUI /image; images are threaded into runs for vision-capable models.
  * Chat messages support image attachments; providers now include images alongside text.

* **Behavior**
  * Non-vision models accept runs but drop images with a stderr warning; invalid, unsupported, or oversized images produce usage errors.

* **Tests**
  * Extensive tests added for image loading, parsing, CLI flows, provider serialization, agent seeding, and TUI image workflows.

* **Documentation**
  * Exec help now documents the --image flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->