### PR TITLE
Add spec mode review flow

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -181,6 +181,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runSearch(args[1:], stdout, stderr, deps)
 	case "sessions", "session":
 		return runSessions(args[1:], stdout, stderr, deps)
+	case "spec":
+		return runSpec(args[1:], stdout, stderr, deps)
 	case "specialists", "specialist":
 		return runSpecialists(args[1:], stdout, stderr, deps)
 	case "plugins", "plugin":
@@ -393,6 +395,9 @@ func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) (*s
 }
 
 func shouldRegisterExecSpecialistTools(options execOptions) bool {
+	if options.useSpec {
+		return false
+	}
 	if strings.EqualFold(strings.TrimSpace(options.tag), specialist.SessionTagSpecialist) {
 		return false
 	}
@@ -444,6 +449,7 @@ Commands:
   search     Search persisted local Zero session events
   find       Alias for search
   sessions   Inspect local Zero session lineage
+  spec       Review and approve saved spec-mode drafts
   specialist Manage local Zero specialist profiles
   plugins    Inspect local Zero plugin manifests
   skills     Inspect local Zero skills
@@ -487,6 +493,10 @@ Flags:
       --image <path>                 Attach a local image (repeatable; vision models only)
       --mode <name>                  Apply a preset (smart, deep, fast, large, precise); explicit flags override it
   -m, --model <model>                Select the model for provider setup
+      --use-spec                     Draft a spec first and stop for review
+      --spec-model <model>           Override the draft model when --use-spec is set
+      --spec-reasoning-effort <effort>
+                                    Override draft reasoning effort when --use-spec is set
       --max-turns <number>           Override the maximum agent loop turns
       --auto <low|medium|high>       Set exec autonomy; high enables unsafe tools
       --enabled-tools <tools>        Only expose these comma or space separated tools

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/specialist"
+	"github.com/Gitlawb/zero/internal/specmode"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -57,6 +58,9 @@ type execOptions struct {
 	// selection") and TestRunExecAcceptsLegacyModelProfileFlags.
 	modelProfile          string
 	reasoningEffort       string
+	useSpec               bool
+	specModel             string
+	specReasoningEffort   string
 	maxTurns              int
 	cwd                   string
 	inputFormat           execInputFormat
@@ -141,11 +145,17 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
+	if options.useSpec {
+		permissionMode = agent.PermissionModeSpecDraft
+	}
 	mcpRuntime, err := registerMCPToolsForWorkspace(context.Background(), workspaceRoot, registry, deps, execMCPAutonomy(options))
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "mcp_error", err.Error())
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)
+	if options.useSpec {
+		specmode.RegisterDraftTools(registry, workspaceRoot, deps.now)
+	}
 	if err := validateExecToolFilters(options, registry); err != nil {
 		return writeExecFormatUsageError(stdout, stderr, options.outputFormat, err.Error())
 	}
@@ -177,8 +187,12 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	modelRegistry, _ := modelregistry.DefaultRegistry()
 
 	overrides := config.Overrides{}
-	if options.model != "" {
-		resolvedModel, notice := resolveSelectedModel(modelRegistry, options.model)
+	modelOverride := options.model
+	if options.useSpec && options.specModel != "" {
+		modelOverride = options.specModel
+	}
+	if modelOverride != "" {
+		resolvedModel, notice := resolveSelectedModel(modelRegistry, modelOverride)
 		overrides.Provider.Model = resolvedModel
 		if notice != "" {
 			if _, err := fmt.Fprintln(stderr, notice); err != nil {
@@ -218,12 +232,16 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "sandbox_error", err.Error())
 	}
+	runReasoningEffort := options.reasoningEffort
+	if options.useSpec && options.specReasoningEffort != "" {
+		runReasoningEffort = options.specReasoningEffort
+	}
 	// Evaluate the --reasoning-effort advisory against the EFFECTIVE resolved
 	// model (resolved.Provider.Model), not the override. Without an explicit
 	// --model the override model is empty, so checking it here would silently
 	// skip the advisory even though the run uses a concrete effective model.
-	if options.reasoningEffort != "" {
-		if notice := reasoningEffortNotice(modelRegistry, resolved.Provider.Model, options.reasoningEffort); notice != "" {
+	if runReasoningEffort != "" {
+		if notice := reasoningEffortNotice(modelRegistry, resolved.Provider.Model, runReasoningEffort); notice != "" {
 			if _, err := fmt.Fprintln(stderr, notice); err != nil {
 				return exitCrash
 			}
@@ -237,6 +255,26 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	runMetadata, err := resolveExecRunMetadata(resolved.Provider)
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
+	}
+	if options.useSpec {
+		return runExecSpecDraft(execSpecDraftRun{
+			options:            options,
+			stdout:             stdout,
+			stderr:             stderr,
+			deps:               deps,
+			workspaceRoot:      workspaceRoot,
+			registry:           registry,
+			modelRegistry:      modelRegistry,
+			resolved:           resolved,
+			runMetadata:        runMetadata,
+			provider:           provider,
+			sandboxEngine:      sandboxEngine,
+			prompt:             prompt,
+			sessionTitle:       sessionTitle,
+			images:             images,
+			reasoningEffort:    runReasoningEffort,
+			specPermissionMode: permissionMode,
+		})
 	}
 
 	preparedSession := sessions.PreparedExec{}
@@ -318,7 +356,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		Depth:            options.depth,
 		SessionTitle:     sessionTitle,
 		Model:            resolved.Provider.Model,
-		ReasoningEffort:  options.reasoningEffort,
+		ReasoningEffort:  runReasoningEffort,
 		Cwd:              workspaceRoot,
 		Images:           images,
 		Registry:         registry,

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specialist"
 )
 
 func parseExecArgs(args []string) (execOptions, bool, error) {
@@ -112,6 +113,34 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--reasoning-effort="):
 			options.reasoningEffort = strings.TrimSpace(strings.TrimPrefix(arg, "--reasoning-effort="))
+		case arg == "--use-spec":
+			options.useSpec = true
+		case arg == "--spec-model":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.specModel = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--spec-model="):
+			value, err := requiredInlineFlagValue(arg, "--spec-model")
+			if err != nil {
+				return options, false, err
+			}
+			options.specModel = value
+		case arg == "--spec-reasoning-effort":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.specReasoningEffort = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--spec-reasoning-effort="):
+			value, err := requiredInlineFlagValue(arg, "--spec-reasoning-effort")
+			if err != nil {
+				return options, false, err
+			}
+			options.specReasoningEffort = value
 		case arg == "--max-turns":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -316,6 +345,18 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 
 	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
 		return options, false, execUsageError{"Use either --resume or --fork, not both."}
+	}
+	if options.useSpec && (options.resume != "" || options.resumeLatest || options.fork != "") {
+		return options, false, execUsageError{"--use-spec cannot be combined with --resume or --fork."}
+	}
+	if options.useSpec && strings.EqualFold(strings.TrimSpace(options.tag), specialist.SessionTagSpecialist) {
+		return options, false, execUsageError{"--use-spec cannot be used inside a specialist child session."}
+	}
+	if !options.useSpec && options.specModel != "" {
+		return options, false, execUsageError{"--spec-model requires --use-spec."}
+	}
+	if !options.useSpec && options.specReasoningEffort != "" {
+		return options, false, execUsageError{"--spec-reasoning-effort requires --use-spec."}
 	}
 	if options.initSessionID != "" && (options.resume != "" || options.resumeLatest) {
 		return options, false, execUsageError{"Use --init-session-id only when creating or forking a session."}

--- a/internal/cli/exec_spec.go
+++ b/internal/cli/exec_spec.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specmode"
+	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+type execSpecDraftRun struct {
+	options            execOptions
+	stdout             io.Writer
+	stderr             io.Writer
+	deps               appDeps
+	workspaceRoot      string
+	registry           *tools.Registry
+	modelRegistry      modelregistry.Registry
+	resolved           config.ResolvedConfig
+	runMetadata        execRunMetadata
+	provider           zeroruntime.Provider
+	sandboxEngine      *sandbox.Engine
+	prompt             string
+	sessionTitle       string
+	images             []zeroruntime.ImageBlock
+	reasoningEffort    string
+	specPermissionMode agent.PermissionMode
+}
+
+type execSpecDraftInfo struct {
+	SpecID         string
+	SpecTitle      string
+	SpecFilePath   string
+	RelativePath   string
+	DraftSessionID string
+}
+
+func runExecSpecDraft(run execSpecDraftRun) int {
+	store := run.deps.newSessionStore()
+	draftSession, err := store.Create(sessions.CreateInput{
+		SessionID:          run.options.initSessionID,
+		SessionKind:        sessions.SessionKindSpecDraft,
+		Title:              run.sessionTitle,
+		Cwd:                run.workspaceRoot,
+		ModelID:            run.resolved.Provider.Model,
+		Provider:           run.runMetadata.Provider,
+		SpecDraftModelID:   run.resolved.Provider.Model,
+		SpecDraftReasoning: run.reasoningEffort,
+	})
+	if err != nil {
+		return writeExecFormatUsageError(run.stdout, run.stderr, run.options.outputFormat, err.Error())
+	}
+	runID, err := streamjson.CreateRunID(run.deps.now())
+	if err != nil {
+		return writeAppError(run.stderr, "failed to create run id: "+err.Error(), exitCrash)
+	}
+	writer := execEventWriter{
+		stdout:       run.stdout,
+		stderr:       run.stderr,
+		format:       run.options.outputFormat,
+		runID:        runID,
+		sessionID:    draftSession.SessionID,
+		streamedText: &strings.Builder{},
+	}
+	writer.runStart(run.workspaceRoot, run.runMetadata, run.specPermissionMode)
+	if writer.err != nil {
+		return exitCrash
+	}
+
+	preparedSession := sessions.PreparedExec{
+		Mode:    sessions.ModeNew,
+		Session: draftSession,
+		Store:   store,
+	}
+	sessionRecorder := execSessionRecorder{prepared: preparedSession}
+	sessionRecorder.append(sessions.EventMessage, map[string]any{
+		"role":    "user",
+		"content": run.prompt,
+	})
+
+	var draftInfo execSpecDraftInfo
+	runCtx, stopSignals := signalContext()
+	defer stopSignals()
+	result, err := agent.Run(runCtx, run.prompt, run.provider, agent.Options{
+		MaxTurns:        run.resolved.MaxTurns,
+		ContextWindow:   modelContextWindow(run.modelRegistry, run.resolved.Provider.Model),
+		SessionID:       draftSession.SessionID,
+		SessionTitle:    run.sessionTitle,
+		Model:           run.resolved.Provider.Model,
+		ReasoningEffort: run.reasoningEffort,
+		Cwd:             run.workspaceRoot,
+		SystemPrompt:    specmode.DraftSystemPrompt,
+		Images:          run.images,
+		Registry:        run.registry,
+		PermissionMode:  agent.PermissionModeSpecDraft,
+		Autonomy:        "low",
+		Sandbox:         run.sandboxEngine,
+		EnabledTools:    run.options.enabledTools,
+		DisabledTools:   run.options.disabledTools,
+		OnText:          writer.text,
+		OnToolCall: func(call agent.ToolCall) {
+			writer.toolCall(call, run.registry)
+			sessionRecorder.append(sessions.EventToolCall, map[string]any{
+				"id":        call.ID,
+				"name":      call.Name,
+				"arguments": call.Arguments,
+			})
+			if checkpoint, ok := sessionRecorder.captureCheckpoint(run.workspaceRoot, call); ok {
+				writer.checkpoint(checkpoint)
+			}
+		},
+		OnPermission: func(event agent.PermissionEvent) {
+			writer.permission(event)
+			sessionRecorder.append(sessionPermissionEventType(event), event)
+		},
+		OnToolResult: func(result agent.ToolResult) {
+			writer.toolResult(result)
+			if info, ok := execSpecDraftInfoFromToolResult(result); ok {
+				draftInfo = info
+			}
+			payload := map[string]any{
+				"toolCallId": result.ToolCallID,
+				"name":       result.Name,
+				"status":     string(result.Status),
+				"output":     result.Output,
+			}
+			if len(result.Meta) > 0 {
+				payload["meta"] = result.Meta
+			}
+			if result.Redacted {
+				payload["redacted"] = true
+			}
+			if len(result.ChangedFiles) > 0 {
+				payload["changedFiles"] = result.ChangedFiles
+			}
+			sessionRecorder.append(sessions.EventToolResult, payload)
+		},
+		OnUsage: func(usage agent.Usage) {
+			writer.usage(usage)
+			sessionRecorder.append(sessions.EventUsage, map[string]any{
+				"promptTokens":     usage.EffectiveInputTokens(),
+				"completionTokens": usage.EffectiveOutputTokens(),
+				"totalTokens":      usage.TotalTokens(),
+			})
+		},
+	})
+	if writer.err != nil {
+		return exitCrash
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) || runCtx.Err() != nil {
+			sessionRecorder.append(sessions.EventError, map[string]any{"message": "interrupted"})
+			if run.options.outputFormat == execOutputStreamJSON {
+				writer.errorEvent("interrupted", "run cancelled by signal", false)
+				writer.runEnd("interrupted", exitInterrupted)
+				if writer.err != nil {
+					return exitCrash
+				}
+			} else {
+				fmt.Fprintln(run.stderr, "Interrupted.")
+			}
+			return exitInterrupted
+		}
+		sessionRecorder.append(sessions.EventError, map[string]any{"message": err.Error()})
+		return writeExecSpecDraftProviderError(&writer, run.options.outputFormat, err.Error())
+	}
+	if result.StopReason != agent.StopReasonSpecReviewRequired || draftInfo.SpecID == "" || draftInfo.SpecFilePath == "" {
+		message := "spec draft ended without submit_spec"
+		sessionRecorder.append(sessions.EventError, map[string]any{"message": message})
+		return writeExecSpecDraftProviderError(&writer, run.options.outputFormat, message)
+	}
+	draftInfo.DraftSessionID = draftSession.SessionID
+	if _, _, err := store.RecordSpec(draftSession.SessionID, sessions.RecordSpecInput{
+		SpecID:             draftInfo.SpecID,
+		SpecFilePath:       draftInfo.SpecFilePath,
+		SpecStatus:         sessions.SpecStatusDraft,
+		SpecDraftModelID:   run.resolved.Provider.Model,
+		SpecDraftReasoning: run.reasoningEffort,
+	}); err != nil {
+		return writeAppError(run.stderr, err.Error(), exitCrash)
+	}
+
+	if emittedTerminal := writer.specReviewRequired(draftInfo); !emittedTerminal {
+		writer.runEnd(string(agent.StopReasonSpecReviewRequired), exitSuccess)
+	}
+	if writer.err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func execSpecDraftInfoFromToolResult(result agent.ToolResult) (execSpecDraftInfo, bool) {
+	if result.Name != specmode.SubmitToolName || result.Meta["control"] != specmode.ControlSpecReviewRequired {
+		return execSpecDraftInfo{}, false
+	}
+	return execSpecDraftInfo{
+		SpecID:       strings.TrimSpace(result.Meta["specId"]),
+		SpecTitle:    strings.TrimSpace(result.Meta["specTitle"]),
+		SpecFilePath: strings.TrimSpace(result.Meta["specFilePath"]),
+		RelativePath: strings.TrimSpace(result.Meta["relativePath"]),
+	}, true
+}
+
+func writeExecSpecDraftProviderError(writer *execEventWriter, format execOutputFormat, message string) int {
+	if format == execOutputStreamJSON {
+		writer.errorEvent("provider_error", message, false)
+		writer.runEnd("error", exitProvider)
+		if writer.err != nil {
+			return exitCrash
+		}
+		return exitProvider
+	}
+	if format == execOutputJSON {
+		writer.errorEvent("provider_error", message, false)
+		writer.writeJSON(map[string]any{"type": "done", "exit_code": exitProvider})
+		if writer.err != nil {
+			return exitCrash
+		}
+		return exitProvider
+	}
+	writer.errorEvent("provider_error", message, false)
+	if writer.err != nil {
+		return exitCrash
+	}
+	return exitProvider
+}
+
+func (writer *execEventWriter) specReviewRequired(info execSpecDraftInfo) bool {
+	summary := formatExecSpecDraftSummary(info)
+	switch writer.format {
+	case execOutputJSON:
+		writer.writeJSON(map[string]any{
+			"type":             string(agent.StopReasonSpecReviewRequired),
+			"status":           string(sessions.SpecStatusDraft),
+			"stop_reason":      string(agent.StopReasonSpecReviewRequired),
+			"spec_id":          info.SpecID,
+			"spec_title":       info.SpecTitle,
+			"spec_file_path":   info.SpecFilePath,
+			"relative_path":    info.RelativePath,
+			"draft_session_id": info.DraftSessionID,
+		})
+		writer.writeJSON(map[string]any{"type": "done", "exit_code": exitSuccess})
+		return true
+	case execOutputStreamJSON:
+		writer.writeStreamJSON(streamjson.Event{
+			Type:  streamjson.EventFinal,
+			RunID: writer.runID,
+			Text:  summary,
+			Meta: map[string]string{
+				"status":         string(sessions.SpecStatusDraft),
+				"stopReason":     string(agent.StopReasonSpecReviewRequired),
+				"specId":         info.SpecID,
+				"specTitle":      info.SpecTitle,
+				"specFilePath":   info.SpecFilePath,
+				"relativePath":   info.RelativePath,
+				"draftSessionId": info.DraftSessionID,
+			},
+		})
+		return false
+	default:
+		if writer.streamedText.Len() > 0 && !strings.HasSuffix(writer.streamedText.String(), "\n") {
+			writer.writeStdout("\n")
+		}
+		writer.writeStdout(summary + "\n")
+		return true
+	}
+}
+
+func formatExecSpecDraftSummary(info execSpecDraftInfo) string {
+	path := strings.TrimSpace(info.RelativePath)
+	if path == "" {
+		path = info.SpecFilePath
+	}
+	lines := []string{
+		"Spec draft saved for review.",
+		"  spec: " + redact(info.SpecID),
+		"  path: " + redact(path),
+		"  draft session: " + redact(info.DraftSessionID),
+		"Next: zero spec show " + redact(info.SpecID) + "; zero spec approve " + redact(info.SpecID),
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/cli/exec_spec_test.go
+++ b/internal/cli/exec_spec_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specmode"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestRunExecUseSpecCreatesDraftSession(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir(), Now: fixedCLISpecTime})
+	provider := &submitSpecExecProvider{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--cwd", workspaceRoot,
+		"--use-spec",
+		"--spec-model", "draft-model",
+		"--spec-reasoning-effort", "high",
+		"-o", "json",
+		"plan the review flow",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return workspaceRoot, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "default-model"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			return config.ResolvedConfig{
+				ActiveProvider: "test",
+				Provider: config.ProviderProfile{
+					Name:         "test",
+					ProviderKind: config.ProviderKindOpenAICompatible,
+					BaseURL:      "http://127.0.0.1/v1",
+					Model:        model,
+				},
+				MaxTurns: 3,
+			}, nil
+		},
+		resolveMCPConfig: func(string) (config.MCPConfig, error) {
+			return config.MCPConfig{}, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return provider, nil
+		},
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+		newSandboxStore: func() (*sandbox.GrantStore, error) {
+			return sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: t.TempDir() + "/grants.json"})
+		},
+		now: fixedCLISpecTime,
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s stdout=%s", exitCode, stderr.String(), stdout.String())
+	}
+	events := decodeJSONLines(t, stdout.String())
+	if !slicesContains(jsonEventTypes(events), string(agent.StopReasonSpecReviewRequired)) {
+		t.Fatalf("missing spec_review_required event in %v", jsonEventTypes(events))
+	}
+	items, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("session count = %d, want 1: %#v", len(items), items)
+	}
+	draft := items[0]
+	if draft.SessionKind != sessions.SessionKindSpecDraft || draft.SpecStatus != sessions.SpecStatusDraft {
+		t.Fatalf("unexpected draft session: %#v", draft)
+	}
+	if draft.SpecID == "" || !strings.Contains(filepath.ToSlash(draft.SpecFilePath), ".zero/specs/") {
+		t.Fatalf("draft spec metadata missing: %#v", draft)
+	}
+	if draft.SpecDraftModelID != "draft-model" || draft.ModelID != "draft-model" || draft.SpecDraftReasoning != "high" {
+		t.Fatalf("draft model metadata = %#v", draft)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("provider request count = %d, want 1", len(provider.requests))
+	}
+	if !provider.requestIncludesTool(specmode.SubmitToolName) {
+		t.Fatalf("provider tools missing submit_spec: %#v", provider.requests[0].Tools)
+	}
+}
+
+func TestParseExecUseSpecRejectsResume(t *testing.T) {
+	_, _, err := parseExecArgs([]string{"--use-spec", "--resume", "zero_1", "plan"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("expected --use-spec/--resume validation, got %v", err)
+	}
+}
+
+func TestParseExecSpecOverridesRequireUseSpec(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "spec model",
+			args: []string{"--spec-model", "gpt-5", "plan"},
+			want: "--spec-model requires --use-spec",
+		},
+		{
+			name: "spec reasoning effort",
+			args: []string{"--spec-reasoning-effort", "high", "plan"},
+			want: "--spec-reasoning-effort requires --use-spec",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseExecArgs(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q validation, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRunExecUseSpecRejectsSpecialistTag(t *testing.T) {
+	exitCode, _, stderr := runExecWithEcho(t, []string{"exec", "--use-spec", "--tag", "specialist", "plan"})
+	if exitCode != exitUsage {
+		t.Fatalf("exit = %d, want %d stderr=%s", exitCode, exitUsage, stderr)
+	}
+	if !strings.Contains(stderr, "specialist child session") {
+		t.Fatalf("expected --use-spec specialist tag validation, got %q", stderr)
+	}
+}
+
+func TestRunExecUseSpecRejectsFiltersThatHideSubmitSpec(t *testing.T) {
+	for _, args := range [][]string{
+		{"exec", "--use-spec", "--disabled-tools", specmode.SubmitToolName, "plan"},
+		{"exec", "--use-spec", "--enabled-tools", "read_file", "plan"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			exitCode, _, stderr := runExecWithEcho(t, args)
+			if exitCode != exitUsage {
+				t.Fatalf("exit = %d, want %d stderr=%s", exitCode, exitUsage, stderr)
+			}
+			if !strings.Contains(stderr, "submit_spec") {
+				t.Fatalf("expected submit_spec validation, got %q", stderr)
+			}
+		})
+	}
+}
+
+type submitSpecExecProvider struct {
+	requests []zeroruntime.CompletionRequest
+}
+
+func (provider *submitSpecExecProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	provider.requests = append(provider.requests, request)
+	arguments, _ := json.Marshal(map[string]string{
+		"title": "Review Flow",
+		"plan":  "# Goal\n\nAdd the review flow.",
+	})
+	ch := make(chan zeroruntime.StreamEvent, 4)
+	select {
+	case <-ctx.Done():
+		close(ch)
+		return ch, ctx.Err()
+	case ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: specmode.SubmitToolName}:
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: string(arguments)}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func (provider *submitSpecExecProvider) requestIncludesTool(name string) bool {
+	if len(provider.requests) == 0 {
+		return false
+	}
+	for _, tool := range provider.requests[0].Tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func slicesContains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/exec_tools.go
+++ b/internal/cli/exec_tools.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/specmode"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -47,7 +48,24 @@ func validateExecToolFilters(options execOptions, registry *tools.Registry) erro
 			return execUsageError{fmt.Sprintf("Tool cannot be both enabled and disabled: %s", name)}
 		}
 	}
+	if options.useSpec {
+		if disabled[specmode.SubmitToolName] {
+			return execUsageError{"--use-spec requires submit_spec; remove it from --disabled-tools."}
+		}
+		if len(options.enabledTools) > 0 && !toolListContains(options.enabledTools, specmode.SubmitToolName) {
+			return execUsageError{"--use-spec requires submit_spec; include it in --enabled-tools."}
+		}
+	}
 	return nil
+}
+
+func toolListContains(names []string, want string) bool {
+	for _, name := range names {
+		if name == want {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveExecPermissionMode(options execOptions) (agent.PermissionMode, error) {

--- a/internal/cli/spec.go
+++ b/internal/cli/spec.go
@@ -1,0 +1,366 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specmode"
+)
+
+type specCommandOptions struct {
+	json            bool
+	comment         string
+	commentProvided bool
+	reason          string
+	reasonProvided  bool
+}
+
+type specCommandResult struct {
+	Status                  string `json:"status"`
+	SpecID                  string `json:"specId,omitempty"`
+	SpecFilePath            string `json:"specFilePath,omitempty"`
+	DraftSessionID          string `json:"draftSessionId,omitempty"`
+	ImplementationSessionID string `json:"implementationSessionId,omitempty"`
+	Message                 string `json:"message,omitempty"`
+	Next                    string `json:"next,omitempty"`
+}
+
+func runSpec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	command, target, options, help, err := parseSpecArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSpecHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	store := deps.newSessionStore()
+	draft, err := resolveSpecReviewTarget(store, target)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	switch command {
+	case "show":
+		return runSpecShow(store, draft, options, stdout, stderr)
+	case "approve":
+		return runSpecApprove(store, draft, options, stdout, stderr)
+	case "reject":
+		return runSpecReject(store, draft, options, stdout, stderr)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown spec command %q", command))
+	}
+}
+
+func parseSpecArgs(args []string) (string, string, specCommandOptions, bool, error) {
+	options := specCommandOptions{}
+	if len(args) == 0 {
+		return "", "", options, false, execUsageError{"spec command required. Use `zero spec show <spec>`."}
+	}
+	command := ""
+	target := ""
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return command, target, options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--comment":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return command, target, options, false, err
+			}
+			options.comment = value
+			options.commentProvided = true
+			index = next
+		case strings.HasPrefix(arg, "--comment="):
+			value, err := requiredInlineFlagValue(arg, "--comment")
+			if err != nil {
+				return command, target, options, false, err
+			}
+			options.comment = value
+			options.commentProvided = true
+		case arg == "--reason":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return command, target, options, false, err
+			}
+			options.reason = value
+			options.reasonProvided = true
+			index = next
+		case strings.HasPrefix(arg, "--reason="):
+			value, err := requiredInlineFlagValue(arg, "--reason")
+			if err != nil {
+				return command, target, options, false, err
+			}
+			options.reason = value
+			options.reasonProvided = true
+		case strings.HasPrefix(arg, "-"):
+			return command, target, options, false, execUsageError{fmt.Sprintf("unknown spec flag %q", arg)}
+		default:
+			if command == "" {
+				command = arg
+				continue
+			}
+			if target == "" {
+				target = arg
+				continue
+			}
+			return command, target, options, false, execUsageError{fmt.Sprintf("unexpected spec argument %q", arg)}
+		}
+	}
+	command = strings.TrimSpace(command)
+	switch command {
+	case "show", "approve", "reject":
+	default:
+		return command, target, options, false, execUsageError{fmt.Sprintf("unknown spec command %q", command)}
+	}
+	if strings.TrimSpace(target) == "" {
+		return command, target, options, false, execUsageError{fmt.Sprintf("zero spec %s requires a spec id or draft session id", command)}
+	}
+	if options.commentProvided && command != "approve" {
+		return command, target, options, false, execUsageError{"--comment is only valid for zero spec approve"}
+	}
+	if options.reasonProvided && command != "reject" {
+		return command, target, options, false, execUsageError{"--reason is only valid for zero spec reject"}
+	}
+	return command, strings.TrimSpace(target), options, false, nil
+}
+
+func resolveSpecReviewTarget(store *sessions.Store, target string) (sessions.Metadata, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return sessions.Metadata{}, fmt.Errorf("spec id or draft session id is required")
+	}
+	if sessions.ValidSessionID(target) {
+		session, err := store.Get(target)
+		if err != nil {
+			return sessions.Metadata{}, err
+		}
+		if session != nil {
+			if session.SpecID == "" || session.SpecFilePath == "" {
+				return sessions.Metadata{}, fmt.Errorf("zero session has no recorded spec: %s", redact(target))
+			}
+			return *session, nil
+		}
+	}
+	items, err := store.List()
+	if err != nil {
+		return sessions.Metadata{}, err
+	}
+	matches := []sessions.Metadata{}
+	draftMatches := []sessions.Metadata{}
+	for _, item := range items {
+		if item.SpecID == target && item.SpecFilePath != "" {
+			matches = append(matches, item)
+			if item.SessionKind == sessions.SessionKindSpecDraft {
+				draftMatches = append(draftMatches, item)
+			}
+		}
+	}
+	if len(draftMatches) == 1 {
+		return draftMatches[0], nil
+	}
+	if len(draftMatches) > 1 {
+		return sessions.Metadata{}, fmt.Errorf("zero spec id is ambiguous: %s; use the draft session id", redact(target))
+	}
+	if len(matches) == 0 {
+		return sessions.Metadata{}, fmt.Errorf("zero spec not found: %s", redact(target))
+	}
+	if len(matches) > 1 {
+		return sessions.Metadata{}, fmt.Errorf("zero spec id is ambiguous: %s; use the draft session id", redact(target))
+	}
+	return matches[0], nil
+}
+
+func runSpecShow(store *sessions.Store, draft sessions.Metadata, options specCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	body, path, err := specmode.LoadSpecFile(draft.Cwd, draft.SpecFilePath)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		payload := map[string]any{
+			"specId":         draft.SpecID,
+			"specFilePath":   path,
+			"draftSessionId": draft.SessionID,
+			"specStatus":     draft.SpecStatus,
+			"content":        body,
+		}
+		if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, body); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSpecApprove(store *sessions.Store, draft sessions.Metadata, options specCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	if draft.SessionKind != sessions.SessionKindSpecDraft {
+		return writeExecUsageError(stderr, "zero spec approve requires a spec-draft session")
+	}
+	if draft.SpecStatus == sessions.SpecStatusRejected {
+		return writeExecUsageError(stderr, "zero spec approve cannot approve a rejected spec")
+	}
+	if draft.SpecStatus == sessions.SpecStatusApproved && draft.SpecImplSessionID != "" {
+		return writeSpecResult(stdout, options, specCommandResult{
+			Status:                  string(sessions.SpecStatusApproved),
+			SpecID:                  draft.SpecID,
+			SpecFilePath:            draft.SpecFilePath,
+			DraftSessionID:          draft.SessionID,
+			ImplementationSessionID: draft.SpecImplSessionID,
+			Message:                 "Spec already approved.",
+			Next:                    "zero exec --resume " + draft.SpecImplSessionID + ` "Start implementation"`,
+		})
+	}
+	body, path, err := specmode.LoadSpecFile(draft.Cwd, draft.SpecFilePath)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	prompt := specmode.ImplementationPrompt(body, path, draft.SessionID, options.comment)
+	impl, _, err := store.EnsureSpecImplementation(sessions.EnsureSpecImplementationInput{
+		Title:               specImplementationTitle(draft),
+		Cwd:                 draft.Cwd,
+		ModelID:             draft.ModelID,
+		Provider:            draft.Provider,
+		RootSessionID:       firstNonEmptyString(draft.RootSessionID, draft.SessionID),
+		SpecID:              draft.SpecID,
+		SpecFilePath:        path,
+		SpecDraftModelID:    draft.SpecDraftModelID,
+		SpecDraftReasoning:  draft.SpecDraftReasoning,
+		SpecUserComment:     options.comment,
+		SpecSourceSessionID: draft.SessionID,
+		Prompt:              prompt,
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	updated, _, err := store.RecordSpec(draft.SessionID, sessions.RecordSpecInput{
+		SpecID:              draft.SpecID,
+		SpecFilePath:        path,
+		SpecStatus:          sessions.SpecStatusApproved,
+		SpecDraftModelID:    draft.SpecDraftModelID,
+		SpecDraftReasoning:  draft.SpecDraftReasoning,
+		SpecUserComment:     options.comment,
+		SpecImplSessionID:   impl.SessionID,
+		SpecSourceSessionID: draft.SessionID,
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	return writeSpecResult(stdout, options, specCommandResult{
+		Status:                  string(updated.SpecStatus),
+		SpecID:                  updated.SpecID,
+		SpecFilePath:            updated.SpecFilePath,
+		DraftSessionID:          updated.SessionID,
+		ImplementationSessionID: impl.SessionID,
+		Message:                 "Spec approved.",
+		Next:                    "zero exec --resume " + impl.SessionID + ` "Start implementation"`,
+	})
+}
+
+func runSpecReject(store *sessions.Store, draft sessions.Metadata, options specCommandOptions, stdout io.Writer, stderr io.Writer) int {
+	if draft.SessionKind != sessions.SessionKindSpecDraft {
+		return writeExecUsageError(stderr, "zero spec reject requires a spec-draft session")
+	}
+	if draft.SpecStatus == sessions.SpecStatusApproved && draft.SpecImplSessionID != "" {
+		return writeExecUsageError(stderr, "zero spec reject cannot reject an approved spec with an implementation session")
+	}
+	updated, _, err := store.RecordSpec(draft.SessionID, sessions.RecordSpecInput{
+		SpecID:              draft.SpecID,
+		SpecFilePath:        draft.SpecFilePath,
+		SpecStatus:          sessions.SpecStatusRejected,
+		SpecDraftModelID:    draft.SpecDraftModelID,
+		SpecDraftReasoning:  draft.SpecDraftReasoning,
+		SpecRejectReason:    options.reason,
+		SpecSourceSessionID: draft.SessionID,
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	return writeSpecResult(stdout, options, specCommandResult{
+		Status:         string(updated.SpecStatus),
+		SpecID:         updated.SpecID,
+		SpecFilePath:   updated.SpecFilePath,
+		DraftSessionID: updated.SessionID,
+		Message:        "Spec rejected.",
+		Next:           "Run zero exec --use-spec again with a revised task.",
+	})
+}
+
+func writeSpecResult(stdout io.Writer, options specCommandOptions, result specCommandResult) int {
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(result, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	lines := []string{result.Message}
+	if result.SpecID != "" {
+		lines = append(lines, "  spec: "+redact(result.SpecID))
+	}
+	if result.SpecFilePath != "" {
+		lines = append(lines, "  path: "+redact(result.SpecFilePath))
+	}
+	if result.DraftSessionID != "" {
+		lines = append(lines, "  draft session: "+redact(result.DraftSessionID))
+	}
+	if result.ImplementationSessionID != "" {
+		lines = append(lines, "  implementation session: "+redact(result.ImplementationSessionID))
+	}
+	if result.Next != "" {
+		lines = append(lines, "Next: "+redact(result.Next))
+	}
+	if _, err := fmt.Fprintln(stdout, strings.Join(lines, "\n")); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func specImplementationTitle(draft sessions.Metadata) string {
+	title := strings.TrimSpace(draft.Title)
+	if title == "" {
+		title = strings.TrimSpace(draft.SpecID)
+	}
+	if title == "" {
+		return "Spec implementation"
+	}
+	return title + " implementation"
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func writeSpecHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero spec show <spec-id|draft-session-id> [--json]
+  zero spec approve <spec-id|draft-session-id> [--comment <text>] [--json]
+  zero spec reject <spec-id|draft-session-id> [--reason <text>] [--json]
+
+Commands:
+  show      Print the saved draft spec
+  approve   Mark a draft approved and create a spec implementation session
+  reject    Mark a draft rejected
+
+Flags:
+      --json            Print JSON output
+      --comment <text>  Approval note to include in the implementation prompt
+      --reason <text>   Rejection reason
+  -h, --help            Show this help
+`)
+	return err
+}

--- a/internal/cli/spec_test.go
+++ b/internal/cli/spec_test.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specmode"
+)
+
+func TestRunSpecApproveCreatesImplementationSession(t *testing.T) {
+	store, deps, draft := seedSpecDraft(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"spec", "approve", draft.SpecID, "--comment", "Keep changes focused.", "--json"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s", exitCode, stderr.String())
+	}
+	var payload specCommandResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode approve json: %v\n%s", err, stdout.String())
+	}
+	if payload.Status != string(sessions.SpecStatusApproved) || payload.ImplementationSessionID == "" {
+		t.Fatalf("unexpected approve payload: %#v", payload)
+	}
+	updatedDraft, err := store.Get(draft.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedDraft.SpecStatus != sessions.SpecStatusApproved || updatedDraft.SpecImplSessionID != payload.ImplementationSessionID {
+		t.Fatalf("draft metadata not updated: %#v", updatedDraft)
+	}
+	impl, err := store.Get(payload.ImplementationSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if impl == nil || impl.SessionKind != sessions.SessionKindSpecImpl || impl.SpecSourceSessionID != draft.SessionID {
+		t.Fatalf("unexpected impl session: %#v", impl)
+	}
+	events, err := store.ReadEvents(payload.ImplementationSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Type != sessions.EventMessage {
+		t.Fatalf("implementation events = %#v", events)
+	}
+	if !strings.Contains(string(events[0].Payload), "Keep changes focused.") || !strings.Contains(string(events[0].Payload), "# Goal") {
+		t.Fatalf("implementation prompt missing approved spec context: %s", string(events[0].Payload))
+	}
+}
+
+func TestRunSpecApproveIsIdempotent(t *testing.T) {
+	store, deps, draft := seedSpecDraft(t)
+
+	var first bytes.Buffer
+	if exitCode := runWithDeps([]string{"spec", "approve", draft.SessionID, "--json"}, &first, &bytes.Buffer{}, deps); exitCode != exitSuccess {
+		t.Fatalf("first approve exit = %d", exitCode)
+	}
+	var firstPayload specCommandResult
+	if err := json.Unmarshal(first.Bytes(), &firstPayload); err != nil {
+		t.Fatal(err)
+	}
+
+	var second bytes.Buffer
+	if exitCode := runWithDeps([]string{"spec", "approve", draft.SpecID, "--json"}, &second, &bytes.Buffer{}, deps); exitCode != exitSuccess {
+		t.Fatalf("second approve exit = %d", exitCode)
+	}
+	var secondPayload specCommandResult
+	if err := json.Unmarshal(second.Bytes(), &secondPayload); err != nil {
+		t.Fatal(err)
+	}
+	if secondPayload.ImplementationSessionID != firstPayload.ImplementationSessionID {
+		t.Fatalf("approve created a second implementation session: first=%q second=%q", firstPayload.ImplementationSessionID, secondPayload.ImplementationSessionID)
+	}
+	items, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	implCount := 0
+	for _, item := range items {
+		if item.SessionKind == sessions.SessionKindSpecImpl {
+			implCount++
+		}
+	}
+	if implCount != 1 {
+		t.Fatalf("implementation session count = %d, want 1", implCount)
+	}
+}
+
+func TestRunSpecRejectMarksDraftRejected(t *testing.T) {
+	store, deps, draft := seedSpecDraft(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"spec", "reject", draft.SpecID, "--reason=Needs narrower scope"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s", exitCode, stderr.String())
+	}
+	updated, err := store.Get(draft.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.SpecStatus != sessions.SpecStatusRejected || updated.SpecRejectReason != "Needs narrower scope" {
+		t.Fatalf("draft metadata not rejected: %#v", updated)
+	}
+	if !strings.Contains(stdout.String(), "Spec rejected.") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestParseSpecRejectsCommandSpecificFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "comment on show",
+			args: []string{"show", "draft", "--comment", "ship it"},
+			want: "--comment is only valid for zero spec approve",
+		},
+		{
+			name: "reason on approve",
+			args: []string{"approve", "draft", "--reason", "too broad"},
+			want: "--reason is only valid for zero spec reject",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, err := parseSpecArgs(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q validation, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRunSpecShowPrintsSavedDraft(t *testing.T) {
+	_, deps, draft := seedSpecDraft(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"spec", "show", draft.SessionID}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "# Goal") || !strings.Contains(stdout.String(), "Add review flow.") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func seedSpecDraft(t *testing.T) (*sessions.Store, appDeps, sessions.Metadata) {
+	t.Helper()
+	workspaceRoot := t.TempDir()
+	saved, err := specmode.SaveDraft(specmode.SaveOptions{
+		WorkspaceRoot: workspaceRoot,
+		Title:         "Review Flow",
+		Plan:          "# Goal\n\nAdd review flow.",
+		Now:           fixedCLISpecTime,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	storeRoot := t.TempDir()
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: storeRoot, Now: fixedCLISpecTime})
+	draft, err := store.Create(sessions.CreateInput{
+		SessionKind:        sessions.SessionKindSpecDraft,
+		Title:              "Review flow",
+		Cwd:                workspaceRoot,
+		ModelID:            "test-model",
+		Provider:           "test",
+		SpecID:             saved.ID,
+		SpecFilePath:       saved.Path,
+		SpecStatus:         sessions.SpecStatusDraft,
+		SpecDraftModelID:   "test-model",
+		SpecDraftReasoning: "high",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps := appDeps{
+		newSessionStore: func() *sessions.Store {
+			return store
+		},
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(storeRoot)
+	})
+	return store, deps, draft
+}
+
+func fixedCLISpecTime() time.Time {
+	return time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+}

--- a/internal/sessions/spec_impl.go
+++ b/internal/sessions/spec_impl.go
@@ -1,0 +1,150 @@
+package sessions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type EnsureSpecImplementationInput struct {
+	Title               string
+	Cwd                 string
+	ModelID             string
+	Provider            string
+	SpecID              string
+	SpecFilePath        string
+	SpecDraftModelID    string
+	SpecDraftReasoning  string
+	SpecUserComment     string
+	SpecSourceSessionID string
+	RootSessionID       string
+	Prompt              string
+}
+
+func (store *Store) FindSpecImplementation(specID string, sourceSessionID string) (*Metadata, error) {
+	specID = strings.TrimSpace(specID)
+	sourceSessionID = strings.TrimSpace(sourceSessionID)
+	if specID == "" || sourceSessionID == "" {
+		return nil, nil
+	}
+	if !ValidSessionID(sourceSessionID) {
+		return nil, fmt.Errorf("invalid zero session id %q", sourceSessionID)
+	}
+	items, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item.SessionKind == SessionKindSpecImpl && item.SpecID == specID && item.SpecSourceSessionID == sourceSessionID {
+			matched := item
+			return &matched, nil
+		}
+	}
+	return nil, nil
+}
+
+func (store *Store) EnsureSpecImplementation(input EnsureSpecImplementationInput) (Metadata, []Event, error) {
+	specID := strings.TrimSpace(input.SpecID)
+	sourceSessionID := strings.TrimSpace(input.SpecSourceSessionID)
+	prompt := input.Prompt
+	if specID == "" {
+		return Metadata{}, nil, fmt.Errorf("zero spec id is required")
+	}
+	if sourceSessionID == "" {
+		return Metadata{}, nil, fmt.Errorf("zero spec source session id is required")
+	}
+	if !ValidSessionID(sourceSessionID) {
+		return Metadata{}, nil, fmt.Errorf("invalid zero session id %q", sourceSessionID)
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return Metadata{}, nil, fmt.Errorf("zero spec implementation prompt is required")
+	}
+	source, err := store.Get(sourceSessionID)
+	if err != nil {
+		return Metadata{}, nil, err
+	}
+	if source == nil {
+		return Metadata{}, nil, fmt.Errorf("zero session not found: %s", sourceSessionID)
+	}
+
+	unlock, err := store.lockSession(sourceSessionID)
+	if err != nil {
+		return Metadata{}, nil, err
+	}
+	defer unlock()
+
+	impl, err := store.FindSpecImplementation(specID, sourceSessionID)
+	if err != nil {
+		return Metadata{}, nil, err
+	}
+	if impl == nil {
+		created, err := store.Create(CreateInput{
+			SessionKind:         SessionKindSpecImpl,
+			Title:               input.Title,
+			Cwd:                 input.Cwd,
+			ModelID:             input.ModelID,
+			Provider:            input.Provider,
+			ParentSessionID:     sourceSessionID,
+			RootSessionID:       firstNonEmpty(input.RootSessionID, sourceSessionID),
+			SpecID:              specID,
+			SpecFilePath:        input.SpecFilePath,
+			SpecStatus:          SpecStatusApproved,
+			SpecDraftModelID:    input.SpecDraftModelID,
+			SpecDraftReasoning:  input.SpecDraftReasoning,
+			SpecUserComment:     input.SpecUserComment,
+			SpecSourceSessionID: sourceSessionID,
+		})
+		if err != nil {
+			return Metadata{}, nil, err
+		}
+		impl = &created
+	}
+
+	events, err := store.ReadEvents(impl.SessionID)
+	if err != nil {
+		return Metadata{}, nil, err
+	}
+	if !eventsContainUserPrompt(events, prompt) {
+		if _, err := store.AppendEvent(impl.SessionID, AppendEventInput{
+			Type: EventMessage,
+			Payload: map[string]any{
+				"role":    "user",
+				"content": prompt,
+			},
+		}); err != nil {
+			return Metadata{}, nil, err
+		}
+		events, err = store.ReadEvents(impl.SessionID)
+		if err != nil {
+			return Metadata{}, nil, err
+		}
+	}
+
+	loaded, err := store.Get(impl.SessionID)
+	if err != nil {
+		return Metadata{}, nil, err
+	}
+	if loaded == nil {
+		return Metadata{}, nil, fmt.Errorf("zero session not found: %s", impl.SessionID)
+	}
+	return *loaded, events, nil
+}
+
+func eventsContainUserPrompt(events []Event, prompt string) bool {
+	for _, event := range events {
+		if event.Type != EventMessage {
+			continue
+		}
+		var payload struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			continue
+		}
+		if payload.Role == "user" && payload.Content == prompt {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -500,6 +500,70 @@ func TestRecordSpecUpdatesMetadataAndAppendsEvents(t *testing.T) {
 	}
 }
 
+func TestEnsureSpecImplementationReusesExistingPromptSession(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: sequenceClock([]time.Time{
+		time.Date(2026, 6, 8, 11, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 8, 11, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 8, 11, 0, 2, 0, time.UTC),
+		time.Date(2026, 6, 8, 11, 0, 3, 0, time.UTC),
+	})})
+	draft, err := store.Create(CreateInput{
+		SessionID:   "draft",
+		SessionKind: SessionKindSpecDraft,
+		Title:       "Draft spec",
+		Cwd:         "/repo",
+		ModelID:     "gpt-5",
+		Provider:    "openai",
+		SpecID:      "2026-06-08-spec",
+		SpecStatus:  SpecStatusDraft,
+	})
+	if err != nil {
+		t.Fatalf("Create draft returned error: %v", err)
+	}
+	input := EnsureSpecImplementationInput{
+		Title:               "Draft spec implementation",
+		Cwd:                 draft.Cwd,
+		ModelID:             draft.ModelID,
+		Provider:            draft.Provider,
+		SpecID:              draft.SpecID,
+		SpecFilePath:        "/repo/.zero/specs/2026-06-08-spec.md",
+		SpecDraftModelID:    "gpt-5",
+		SpecDraftReasoning:  "high",
+		SpecUserComment:     "ship it",
+		SpecSourceSessionID: draft.SessionID,
+		Prompt:              "Implement the approved spec.",
+	}
+
+	first, firstEvents, err := store.EnsureSpecImplementation(input)
+	if err != nil {
+		t.Fatalf("EnsureSpecImplementation first returned error: %v", err)
+	}
+	second, secondEvents, err := store.EnsureSpecImplementation(input)
+	if err != nil {
+		t.Fatalf("EnsureSpecImplementation second returned error: %v", err)
+	}
+
+	if second.SessionID != first.SessionID {
+		t.Fatalf("implementation session was not reused: first=%s second=%s", first.SessionID, second.SessionID)
+	}
+	if len(firstEvents) != 1 || len(secondEvents) != 1 || second.EventCount != 1 {
+		t.Fatalf("expected one implementation prompt event, first=%#v second=%#v metadata=%#v", firstEvents, secondEvents, second)
+	}
+	items, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	implCount := 0
+	for _, item := range items {
+		if item.SessionKind == SessionKindSpecImpl {
+			implCount++
+		}
+	}
+	if implCount != 1 {
+		t.Fatalf("implementation session count = %d, want 1", implCount)
+	}
+}
+
 func fixedClock(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/specmode/review.go
+++ b/internal/specmode/review.go
@@ -1,0 +1,78 @@
+package specmode
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func LoadSpecFile(workspaceRoot string, specFilePath string) (string, string, error) {
+	path, err := ResolveSpecFilePath(workspaceRoot, specFilePath)
+	if err != nil {
+		return "", "", err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", "", fmt.Errorf("stat spec file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", "", fmt.Errorf("spec file is not a regular file: %s", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", fmt.Errorf("read spec file: %w", err)
+	}
+	body := strings.TrimRight(string(data), "\n")
+	if strings.TrimSpace(body) == "" {
+		return "", "", fmt.Errorf("spec file is empty: %s", path)
+	}
+	return body, path, nil
+}
+
+func ResolveSpecFilePath(workspaceRoot string, specFilePath string) (string, error) {
+	root := strings.TrimSpace(workspaceRoot)
+	if root == "" {
+		return "", fmt.Errorf("workspace root is required")
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace root: %w", err)
+	}
+	path := strings.TrimSpace(specFilePath)
+	if path == "" {
+		return "", fmt.Errorf("spec file path is required")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(absoluteRoot, filepath.FromSlash(path))
+	}
+	path = filepath.Clean(path)
+	specDir := filepath.Join(absoluteRoot, filepath.FromSlash(SpecDirName))
+	if err := ensureSpecPathContained(specDir, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func ImplementationPrompt(specBody string, specFilePath string, draftSessionID string, userComment string) string {
+	body := strings.TrimSpace(specBody)
+	lines := []string{
+		"Implement the following approved spec:",
+		"",
+	}
+	if comment := strings.TrimSpace(userComment); comment != "" {
+		lines = append(lines, "User note: "+comment, "")
+	}
+	lines = append(lines, body, "")
+	if path := strings.TrimSpace(specFilePath); path != "" {
+		lines = append(lines, "Spec file: "+path)
+	}
+	if sessionID := strings.TrimSpace(draftSessionID); sessionID != "" {
+		lines = append(lines, "Planning session: "+sessionID)
+	}
+	lines = append(lines,
+		"",
+		"If you need details that are not in the spec, inspect the workspace again. The spec is the approved source of truth for scope.",
+	)
+	return strings.Join(lines, "\n")
+}

--- a/internal/specmode/specmode_test.go
+++ b/internal/specmode/specmode_test.go
@@ -125,6 +125,48 @@ func TestSubmitToolRejectsInvalidArgs(t *testing.T) {
 	}
 }
 
+func TestLoadSpecFileRejectsPathsOutsideSpecDirectory(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(root, "notes.md")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := LoadSpecFile(root, outside)
+	if err == nil {
+		t.Fatal("expected LoadSpecFile to reject a path outside .zero/specs")
+	}
+}
+
+func TestLoadSpecFileRejectsNonRegularFiles(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(".zero/specs/not-a-file.md"))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := LoadSpecFile(root, dir)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("expected non-regular file error, got %v", err)
+	}
+}
+
+func TestImplementationPromptIncludesReviewContext(t *testing.T) {
+	prompt := ImplementationPrompt("# Goal\n\nShip it.", "/repo/.zero/specs/plan.md", "zero_1", "Keep tests focused.")
+
+	for _, want := range []string{
+		"Implement the following approved spec:",
+		"User note: Keep tests focused.",
+		"# Goal\n\nShip it.",
+		"Spec file: /repo/.zero/specs/plan.md",
+		"Planning session: zero_1",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q: %s", want, prompt)
+		}
+	}
+}
+
 func fixedSpecTime(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -25,6 +25,7 @@ const (
 	commandPlan
 	commandSearch
 	commandResume
+	commandSpec
 	commandCompact
 	commandRewind
 	commandEffort
@@ -145,6 +146,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "List recent sessions or show resume guidance.",
 		kind:        commandResume,
+	},
+	{
+		name:        "/spec",
+		usage:       "/spec <task>",
+		group:       commandGroupSession,
+		description: "Draft an implementation spec for review before editing.",
+		kind:        commandSpec,
 	},
 	{
 		name:        "/compact",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -68,6 +68,7 @@ type model struct {
 	flushRunIDs       map[int]struct{}
 	pendingPermission *pendingPermissionPrompt
 	pendingAskUser    *pendingAskUserPrompt
+	pendingSpecReview *pendingSpecReviewPrompt
 	width             int
 	height            int
 	now               func() time.Time
@@ -119,6 +120,7 @@ type agentResponseMsg struct {
 	usageEvents   []zeroruntime.Usage
 	usageModelID  string
 	sessionEvents []pendingSessionEvent
+	specReview    *pendingSpecReviewPrompt
 	err           error
 }
 
@@ -163,6 +165,21 @@ type pendingAskUserPrompt struct {
 	answer  func([]string)
 	index   int
 	answers []string
+}
+
+type pendingSpecReviewPrompt struct {
+	SpecID         string
+	SpecTitle      string
+	SpecFilePath   string
+	RelativePath   string
+	DraftSessionID string
+}
+
+type tuiAgentRunOptions struct {
+	registry       *tools.Registry
+	permissionMode agent.PermissionMode
+	systemPrompt   string
+	specDraft      bool
 }
 
 func newModel(ctx context.Context, options Options) model {
@@ -278,6 +295,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingAskUser != nil {
 				return m.resolveAskUser(true)
 			}
+			if m.pendingSpecReview != nil {
+				return m.cancelSpecReview()
+			}
 			// An open picker cancels first; then an active suggestion overlay is
 			// dismissed. Neither cancels the run or clears the input.
 			if m.picker != nil {
@@ -301,6 +321,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.pendingAskUser != nil {
 				return m.submitAskUserAnswer()
 			}
+			if m.pendingSpecReview != nil {
+				return m, nil
+			}
 			if m.picker != nil {
 				return m.choosePicker()
 			}
@@ -316,7 +339,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// nextPermissionMode), but only when nothing modal is up: a permission
 			// prompt, ask_user questionnaire, or open picker all take precedence
 			// and let the key fall through to their own handlers below.
-			if m.pendingPermission == nil && m.pendingAskUser == nil && m.picker == nil {
+			if m.pendingPermission == nil && m.pendingAskUser == nil && m.pendingSpecReview == nil && m.picker == nil {
 				m.permissionMode = nextPermissionMode(m.permissionMode)
 				return m, nil
 			}
@@ -350,6 +373,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)
 			return m, cmd
+		}
+		if m.pendingSpecReview != nil {
+			return m.handleSpecReviewKey(msg)
 		}
 		if m.pendingPermission != nil {
 			return m.handlePermissionKey(msg)
@@ -487,6 +513,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				text: msg.err.Error(),
 			})
 		}
+		if msg.specReview != nil {
+			m = m.activateSpecReview(*msg.specReview)
+		}
 		return m, nil
 	case agentRowMsg:
 		if msg.runID != m.activeRunID {
@@ -543,6 +572,11 @@ func (m model) transcriptView() string {
 		default:
 			builder.WriteString(zeroTheme.zero.Render("◇ zero") + "  " + zeroTheme.muted.Render("working…"))
 		}
+		builder.WriteString("\n")
+	}
+	if m.pendingSpecReview != nil {
+		builder.WriteString("\n")
+		builder.WriteString(renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width))
 		builder.WriteString("\n")
 	}
 
@@ -804,6 +838,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		}
 		return m, nil
+	case commandSpec:
+		m.showSplash = false
+		return m.handleSpecCommand(command.text)
 	case commandCompact:
 		m.showSplash = false
 		text := ""
@@ -988,14 +1025,28 @@ func (m *model) cancelRun() {
 }
 
 func (m model) runAgent(runID int, runCtx context.Context, prompt string, images []zeroruntime.ImageBlock) tea.Cmd {
+	return m.runAgentWithOptions(runID, runCtx, prompt, images, tuiAgentRunOptions{})
+}
+
+func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt string, images []zeroruntime.ImageBlock, runOptions tuiAgentRunOptions) tea.Cmd {
 	return func() tea.Msg {
 		rows := []transcriptRow{}
 		usageEvents := []zeroruntime.Usage{}
 		sessionEvents := []pendingSessionEvent{}
 		usageModelID := m.modelName
+		var specReview *pendingSpecReviewPrompt
 		options := m.agentOptions
 		options.Registry = m.registry
+		if runOptions.registry != nil {
+			options.Registry = runOptions.registry
+		}
 		options.PermissionMode = m.permissionMode
+		if runOptions.permissionMode != "" {
+			options.PermissionMode = runOptions.permissionMode
+		}
+		if runOptions.systemPrompt != "" {
+			options.SystemPrompt = runOptions.systemPrompt
+		}
 		options.SessionID = m.activeSession.SessionID
 		options.Model = m.modelName
 		options.ReasoningEffort = string(m.reasoningEffort)
@@ -1121,6 +1172,11 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string, images
 
 		onToolResult := options.OnToolResult
 		options.OnToolResult = func(result agent.ToolResult) {
+			if runOptions.specDraft {
+				if info, ok := tuiSpecReviewFromToolResult(result, m.activeSession.SessionID); ok {
+					specReview = &info
+				}
+			}
 			row := transcriptRow{
 				kind:   rowToolResult,
 				id:     result.ToolCallID,
@@ -1139,6 +1195,9 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string, images
 			}
 			if result.Redacted {
 				toolPayload["redacted"] = true
+			}
+			if len(result.Meta) > 0 {
+				toolPayload["meta"] = result.Meta
 			}
 			if len(result.ChangedFiles) > 0 {
 				toolPayload["changedFiles"] = result.ChangedFiles
@@ -1189,6 +1248,17 @@ func (m model) runAgent(runID int, runCtx context.Context, prompt string, images
 				Payload: map[string]any{"message": err.Error()},
 			})
 			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, err: err}
+		}
+		if runOptions.specDraft {
+			if result.StopReason != agent.StopReasonSpecReviewRequired || specReview == nil || specReview.SpecID == "" || specReview.SpecFilePath == "" {
+				err := fmt.Errorf("spec draft ended without submit_spec")
+				sessionEvents = append(sessionEvents, pendingSessionEvent{
+					Type:    sessions.EventError,
+					Payload: map[string]any{"message": err.Error()},
+				})
+				return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, err: err}
+			}
+			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, specReview: specReview}
 		}
 		rows = append(rows, transcriptRow{kind: rowAssistant, text: result.FinalAnswer})
 		sessionEvents = append(sessionEvents, pendingSessionEvent{

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -55,6 +55,7 @@ func TestParseCommand(t *testing.T) {
 		{input: "/find needle", kind: commandSearch, text: "needle"},
 		{input: "/resume", kind: commandResume},
 		{input: "/sessions", kind: commandResume},
+		{input: "/spec add review flow", kind: commandSpec, text: "add review flow"},
 		{input: "/compact", kind: commandCompact},
 		{input: "/effort high", kind: commandEffort, text: "high"},
 		{input: "/style concise", kind: commandStyle, text: "concise"},
@@ -86,7 +87,7 @@ func TestCommandRegistryResolvesAliasesAndFormatsHelp(t *testing.T) {
 	}
 
 	help := strings.Join(formatCommandHelpLines(), "\n")
-	for _, want := range []string{"/model", "/context", "/debug", "/permissions", "model"} {
+	for _, want := range []string{"/model", "/context", "/debug", "/permissions", "/spec", "model"} {
 		assertContains(t, help, want)
 	}
 }

--- a/internal/tui/spec_mode.go
+++ b/internal/tui/spec_mode.go
@@ -1,0 +1,296 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specmode"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func (m model) handleSpecCommand(task string) (tea.Model, tea.Cmd) {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Usage: /spec <task>"})
+		return m, nil
+	}
+	if m.pending {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "Cannot start spec mode while a run is active."})
+		return m, nil
+	}
+	if m.pendingSpecReview != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Review the pending spec before drafting another one."})
+		return m, nil
+	}
+	if m.provider == nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendAssistant, text: "No provider configured."})
+		return m, nil
+	}
+
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendUser, text: "/spec " + task})
+	var err error
+	m, err = m.createSpecDraftSession(task)
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "session create error: " + err.Error()})
+		return m, nil
+	}
+	m, err = m.appendSessionEvent(sessions.EventMessage, map[string]any{
+		"role":    "user",
+		"content": task,
+	})
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "session record error: " + err.Error()})
+	}
+
+	turnImages := m.pendingImages
+	if len(turnImages) > 0 && !modelSupportsVisionTUI(m.modelName) {
+		name := m.modelName
+		if name == "" {
+			name = "the active model"
+		}
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendSystem,
+			text: fmt.Sprintf("Model %s does not support image input; ignoring %d image(s).", name, len(turnImages)),
+		})
+		turnImages = nil
+	}
+	m.pendingImages = nil
+	m.pendingImageLabels = nil
+
+	specRegistry := cloneToolRegistry(m.registry)
+	specmode.RegisterDraftTools(specRegistry, m.cwd, m.now)
+	runCtx, cancel := context.WithCancel(m.ctx)
+	m.runID++
+	m.activeRunID = m.runID
+	m.runCancel = cancel
+	m.pending = true
+	return m, m.runAgentWithOptions(m.activeRunID, runCtx, task, turnImages, tuiAgentRunOptions{
+		registry:       specRegistry,
+		permissionMode: agent.PermissionModeSpecDraft,
+		systemPrompt:   specmode.DraftSystemPrompt,
+		specDraft:      true,
+	})
+}
+
+func (m model) createSpecDraftSession(task string) (model, error) {
+	session, err := m.sessionStore.Create(sessions.CreateInput{
+		SessionKind:        sessions.SessionKindSpecDraft,
+		Title:              tuiSessionTitle(task),
+		Cwd:                m.cwd,
+		ModelID:            m.modelName,
+		Provider:           m.providerName,
+		SpecDraftModelID:   m.modelName,
+		SpecDraftReasoning: string(m.reasoningEffort),
+	})
+	if err != nil {
+		return m, err
+	}
+	m.activeSession = session
+	m.sessionEvents = []sessions.Event{}
+	return m, nil
+}
+
+func tuiSpecReviewFromToolResult(result agent.ToolResult, draftSessionID string) (pendingSpecReviewPrompt, bool) {
+	if result.Name != specmode.SubmitToolName || result.Meta["control"] != specmode.ControlSpecReviewRequired {
+		return pendingSpecReviewPrompt{}, false
+	}
+	return pendingSpecReviewPrompt{
+		SpecID:         strings.TrimSpace(result.Meta["specId"]),
+		SpecTitle:      strings.TrimSpace(result.Meta["specTitle"]),
+		SpecFilePath:   strings.TrimSpace(result.Meta["specFilePath"]),
+		RelativePath:   strings.TrimSpace(result.Meta["relativePath"]),
+		DraftSessionID: strings.TrimSpace(draftSessionID),
+	}, true
+}
+
+func (m model) activateSpecReview(review pendingSpecReviewPrompt) model {
+	updated, event, err := m.sessionStore.RecordSpec(review.DraftSessionID, sessions.RecordSpecInput{
+		SpecID:             review.SpecID,
+		SpecFilePath:       review.SpecFilePath,
+		SpecStatus:         sessions.SpecStatusDraft,
+		SpecDraftModelID:   m.modelName,
+		SpecDraftReasoning: string(m.reasoningEffort),
+	})
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "spec record error: " + err.Error()})
+		return m
+	}
+	if m.activeSession.SessionID == updated.SessionID {
+		m.activeSession = updated
+		m.sessionEvents = append(m.sessionEvents, event)
+	}
+	m.pendingSpecReview = &review
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: specReviewSummary(review)})
+	return m
+}
+
+func (m model) handleSpecReviewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch strings.ToLower(msg.String()) {
+	case "a":
+		return m.approveSpecReview()
+	case "r":
+		return m.rejectSpecReview("")
+	case "e":
+		review := m.pendingSpecReview
+		if review == nil {
+			return m, nil
+		}
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendSystem,
+			text: "Edit the saved spec file, then press a to approve or r to reject.\npath: " + reviewDisplayPath(*review),
+		})
+		return m, nil
+	case "c":
+		return m.cancelSpecReview()
+	default:
+		return m, nil
+	}
+}
+
+func (m model) approveSpecReview() (tea.Model, tea.Cmd) {
+	review := m.pendingSpecReview
+	if review == nil {
+		return m, nil
+	}
+	if m.provider == nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendAssistant, text: "No provider configured."})
+		return m, nil
+	}
+	body, path, err := specmode.LoadSpecFile(m.cwd, review.SpecFilePath)
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "spec read error: " + err.Error()})
+		return m, nil
+	}
+	prompt := specmode.ImplementationPrompt(body, path, review.DraftSessionID, "")
+	impl, events, err := m.sessionStore.EnsureSpecImplementation(sessions.EnsureSpecImplementationInput{
+		Title:               specImplementationTitle(*review),
+		Cwd:                 m.cwd,
+		ModelID:             m.modelName,
+		Provider:            m.providerName,
+		RootSessionID:       review.DraftSessionID,
+		SpecID:              review.SpecID,
+		SpecFilePath:        path,
+		SpecDraftModelID:    m.modelName,
+		SpecDraftReasoning:  string(m.reasoningEffort),
+		SpecSourceSessionID: review.DraftSessionID,
+		Prompt:              prompt,
+	})
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "session create error: " + err.Error()})
+		return m, nil
+	}
+	if _, _, err := m.sessionStore.RecordSpec(review.DraftSessionID, sessions.RecordSpecInput{
+		SpecID:             review.SpecID,
+		SpecFilePath:       path,
+		SpecStatus:         sessions.SpecStatusApproved,
+		SpecDraftModelID:   m.modelName,
+		SpecDraftReasoning: string(m.reasoningEffort),
+		SpecImplSessionID:  impl.SessionID,
+	}); err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "spec approve error: " + err.Error()})
+		return m, nil
+	}
+	m.pendingSpecReview = nil
+	m.activeSession = impl
+	m.sessionEvents = append([]sessions.Event{}, events...)
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Spec approved. Starting implementation session " + impl.SessionID + "."})
+	runCtx, cancel := context.WithCancel(m.ctx)
+	m.runID++
+	m.activeRunID = m.runID
+	m.runCancel = cancel
+	m.pending = true
+	return m, m.runAgent(m.activeRunID, runCtx, prompt, nil)
+}
+
+func (m model) rejectSpecReview(reason string) (tea.Model, tea.Cmd) {
+	review := m.pendingSpecReview
+	if review == nil {
+		return m, nil
+	}
+	updated, event, err := m.sessionStore.RecordSpec(review.DraftSessionID, sessions.RecordSpecInput{
+		SpecID:             review.SpecID,
+		SpecFilePath:       review.SpecFilePath,
+		SpecStatus:         sessions.SpecStatusRejected,
+		SpecDraftModelID:   m.modelName,
+		SpecDraftReasoning: string(m.reasoningEffort),
+		SpecRejectReason:   reason,
+	})
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "spec reject error: " + err.Error()})
+		return m, nil
+	}
+	if m.activeSession.SessionID == updated.SessionID {
+		m.activeSession = updated
+		m.sessionEvents = append(m.sessionEvents, event)
+	}
+	m.pendingSpecReview = nil
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Spec rejected. Use /spec <task> to draft again."})
+	return m, nil
+}
+
+func (m model) cancelSpecReview() (tea.Model, tea.Cmd) {
+	m.pendingSpecReview = nil
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Spec review canceled. The draft remains saved."})
+	return m, nil
+}
+
+func cloneToolRegistry(registry *tools.Registry) *tools.Registry {
+	clone := tools.NewRegistry()
+	if registry == nil {
+		return clone
+	}
+	for _, tool := range registry.All() {
+		clone.Register(tool)
+	}
+	return clone
+}
+
+func renderFocusedSpecReviewPrompt(review pendingSpecReviewPrompt, width int) string {
+	lines := []string{
+		zeroTheme.zero.Render("◇ spec review"),
+		"path: " + reviewDisplayPath(review),
+		"[a] approve  [r] reject  [e] edit file  [esc] cancel",
+	}
+	return borderedBlock(width, lines)
+}
+
+func specReviewSummary(review pendingSpecReviewPrompt) string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Spec draft ready",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "Review",
+			Lines: []string{
+				"spec: " + review.SpecID,
+				"path: " + reviewDisplayPath(review),
+				"keys: a approve, r reject, e edit file, esc cancel",
+			},
+		}},
+	})
+}
+
+func reviewDisplayPath(review pendingSpecReviewPrompt) string {
+	if strings.TrimSpace(review.RelativePath) != "" {
+		return review.RelativePath
+	}
+	return review.SpecFilePath
+}
+
+func specImplementationTitle(review pendingSpecReviewPrompt) string {
+	title := strings.TrimSpace(review.SpecTitle)
+	if title == "" {
+		title = strings.TrimSpace(review.SpecID)
+	}
+	if title == "" {
+		return "Spec implementation"
+	}
+	if len(title) > tuiSessionTitleLimit {
+		title = title[:tuiSessionTitleLimit]
+	}
+	return title + " implementation"
+}

--- a/internal/tui/spec_mode_test.go
+++ b/internal/tui/spec_mode_test.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/specmode"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestSpecCommandCreatesDraftReview(t *testing.T) {
+	store := testSessionStore(t)
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		submitSpecScript("call-1", "Review Flow", "# Goal\n\nAdd review flow."),
+	}}
+	m := newSpecModeTestModel(t.TempDir(), provider, store)
+	m.input.SetValue("/spec add review flow")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected /spec to start a draft run")
+	}
+
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	if next.pendingSpecReview == nil {
+		t.Fatalf("expected pending spec review, got %#v", next)
+	}
+	if next.activeSession.SessionKind != sessions.SessionKindSpecDraft || next.activeSession.SpecStatus != sessions.SpecStatusDraft {
+		t.Fatalf("unexpected active spec session: %#v", next.activeSession)
+	}
+	if !strings.Contains(next.pendingSpecReview.RelativePath, ".zero/specs/") {
+		t.Fatalf("spec path not recorded: %#v", next.pendingSpecReview)
+	}
+	if !providerRequestIncludesTool(provider.requests[0], specmode.SubmitToolName) {
+		t.Fatalf("submit_spec was not advertised: %#v", provider.requests[0].Tools)
+	}
+	if providerRequestIncludesTool(provider.requests[0], "write_file") {
+		t.Fatalf("spec draft must not advertise write_file: %#v", provider.requests[0].Tools)
+	}
+}
+
+func TestSpecApproveStartsImplementationSession(t *testing.T) {
+	store := testSessionStore(t)
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		submitSpecScript("call-1", "Review Flow", "# Goal\n\nAdd review flow."),
+		textScript("implemented from approved spec"),
+	}}
+	m := newSpecModeTestModel(t.TempDir(), provider, store)
+	m.input.SetValue("/spec add review flow")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+	review := next.pendingSpecReview
+	if review == nil {
+		t.Fatal("expected pending review before approval")
+	}
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	next = updated.(model)
+	if cmd == nil {
+		t.Fatal("expected approval to start implementation run")
+	}
+	if next.pendingSpecReview != nil {
+		t.Fatal("expected pending review to clear on approval")
+	}
+	if next.activeSession.SessionKind != sessions.SessionKindSpecImpl {
+		t.Fatalf("expected active implementation session, got %#v", next.activeSession)
+	}
+
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+	if !transcriptContains(next.transcript, "implemented from approved spec") {
+		t.Fatalf("implementation answer missing from transcript: %#v", next.transcript)
+	}
+	draft, err := store.Get(review.DraftSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if draft == nil || draft.SpecStatus != sessions.SpecStatusApproved || draft.SpecImplSessionID != next.activeSession.SessionID {
+		t.Fatalf("draft metadata not approved: %#v", draft)
+	}
+	if len(provider.requests) != 2 {
+		t.Fatalf("provider request count = %d, want 2", len(provider.requests))
+	}
+	last := provider.requests[1].Messages[len(provider.requests[1].Messages)-1]
+	if !strings.Contains(last.Content, "Implement the following approved spec") || !strings.Contains(last.Content, "# Goal") {
+		t.Fatalf("implementation prompt missing spec body: %#v", last)
+	}
+}
+
+func TestSpecReviewBlocksShiftTabModeCycle(t *testing.T) {
+	m := newModel(context.Background(), Options{PermissionMode: agent.PermissionModeAuto})
+	m.pendingSpecReview = &pendingSpecReviewPrompt{SpecID: "spec", SpecFilePath: ".zero/specs/spec.md"}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	next := updated.(model)
+
+	if next.permissionMode != agent.PermissionModeAuto {
+		t.Fatalf("expected permission mode unchanged during spec review, got %q", next.permissionMode)
+	}
+	if next.pendingSpecReview == nil {
+		t.Fatal("expected spec review to remain pending")
+	}
+}
+
+func newSpecModeTestModel(root string, provider zeroruntime.Provider, store *sessions.Store) model {
+	registry := tools.NewRegistry()
+	for _, tool := range tools.CoreTools(root) {
+		registry.Register(tool)
+	}
+	return newModel(context.Background(), Options{
+		Cwd:            root,
+		ProviderName:   "openai",
+		ModelName:      "gpt-4.1",
+		Provider:       provider,
+		Registry:       registry,
+		SessionStore:   store,
+		PermissionMode: agent.PermissionModeAsk,
+	})
+}
+
+func submitSpecScript(callID string, title string, plan string) []zeroruntime.StreamEvent {
+	args, _ := json.Marshal(map[string]string{
+		"title": title,
+		"plan":  plan,
+	})
+	return []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: callID, ToolName: specmode.SubmitToolName},
+		{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: callID, ArgumentsFragment: string(args)},
+		{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: callID},
+		{Type: zeroruntime.StreamEventDone},
+	}
+}
+
+func providerRequestIncludesTool(request zeroruntime.CompletionRequest, name string) bool {
+	for _, tool := range request.Tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Summary:
- adds zero exec --use-spec with draft sessions, submit_spec review-required output, and spec model/reasoning overrides
- adds zero spec show/approve/reject for saved drafts and implementation-session handoff
- adds TUI /spec draft flow with approve/reject/cancel review handling and implementation start on approval

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/specmode ./internal/tui ./internal/cli -run 'TestRunExecUseSpec|TestParseExecUseSpec|TestRunSpec|TestSpec|TestParseCommand|TestCommandRegistryResolvesAliasesAndFormatsHelp'
- GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/sessions ./internal/zerocommands ./internal/specmode ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds `zero spec` CLI (show/approve/reject), `zero exec --use-spec` with spec-specific model/reasoning flags, and interactive `/spec` TUI flow with spec-review modal and spec-draft runs that emit structured review-required outputs.
  * Creates or reuses implementation sessions when approving specs; builds implementation prompts from approved specs.

* **Validation**
  * CLI/TUI enforce incompatible flags, require the submit-spec tool for spec runs, and validate spec file paths/content.

* **Tests**
  * Comprehensive CLI, TUI, session, and unit tests covering the full spec lifecycle and file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->