### PR TITLE
Mid-run model escalation: escalate_model tool + --allow-escalation

### DIFF
--- a/internal/agent/escalate_loop_test.go
+++ b/internal/agent/escalate_loop_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/tools"
@@ -105,5 +107,174 @@ func TestExecuteToolCallNoEscalationMetaLeavesRequestedModelEmpty(t *testing.T) 
 	}
 	if result.RequestedModel != "" {
 		t.Fatalf("expected empty RequestedModel without escalation meta, got %q", result.RequestedModel)
+	}
+}
+
+// escalateThenAnswerTurns builds a two-turn provider script: turn 1 calls the
+// escalate tool, turn 2 returns a final answer. Reused by the switch tests.
+func escalateThenAnswerTurns(answer string) [][]zeroruntime.StreamEvent {
+	return [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "c1", ToolName: "escalate"},
+			{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "c1"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+		{
+			{Type: zeroruntime.StreamEventText, Content: answer},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}
+}
+
+// TestRunSwitchesProviderOnEscalationRequest verifies that when a tool requests
+// a model and a ModelSwitcher is wired, the loop swaps the active provider (the
+// NEXT turn streams from the new provider) and updates options.Model.
+func TestRunSwitchesProviderOnEscalationRequest(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	firstProvider := &mockProvider{turns: escalateThenAnswerTurns("done")}
+	secondProvider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventText, Content: "answered on the upgraded model"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}}
+
+	var switchedTo string
+	switchCount := 0
+	result, err := Run(context.Background(), "go", firstProvider, Options{
+		Registry: registry,
+		Model:    "claude-sonnet-4.5",
+		MaxTurns: 4,
+		ModelSwitcher: func(_ context.Context, modelID string) (Provider, error) {
+			switchCount++
+			switchedTo = modelID
+			return secondProvider, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if switchCount != 1 {
+		t.Fatalf("expected exactly one switch, got %d", switchCount)
+	}
+	if switchedTo != "claude-opus-4.1" {
+		t.Fatalf("expected switch to claude-opus-4.1, got %q", switchedTo)
+	}
+	// The first provider only handled the escalation turn (1 request); the second
+	// provider handled the answer turn (1 request) — proving the swap took effect.
+	if len(firstProvider.requests) != 1 {
+		t.Fatalf("expected first provider to handle exactly the escalation turn, got %d requests", len(firstProvider.requests))
+	}
+	if len(secondProvider.requests) != 1 {
+		t.Fatalf("expected second provider to handle the post-switch turn, got %d requests", len(secondProvider.requests))
+	}
+	if result.FinalAnswer != "answered on the upgraded model" {
+		t.Fatalf("expected final answer from the swapped provider, got %q", result.FinalAnswer)
+	}
+}
+
+// TestRunIgnoresEscalationWhenSwitcherNil verifies that without a ModelSwitcher
+// the escalation request is ignored: the original provider serves every turn.
+func TestRunIgnoresEscalationWhenSwitcherNil(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	provider := &mockProvider{turns: escalateThenAnswerTurns("done on original")}
+
+	result, err := Run(context.Background(), "go", provider, Options{
+		Registry: registry,
+		Model:    "claude-sonnet-4.5",
+		MaxTurns: 4,
+		// ModelSwitcher intentionally nil.
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Both turns (escalate + answer) must run on the single original provider.
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected the original provider to serve both turns, got %d requests", len(provider.requests))
+	}
+	if result.FinalAnswer != "done on original" {
+		t.Fatalf("expected final answer from the original provider, got %q", result.FinalAnswer)
+	}
+}
+
+// TestRunEscalationSwitcherErrorIsNonFatal verifies a ModelSwitcher error does
+// not abort the run: the loop continues on the current provider and a note is
+// recorded in the transcript.
+func TestRunEscalationSwitcherErrorIsNonFatal(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	provider := &mockProvider{turns: escalateThenAnswerTurns("recovered")}
+
+	result, err := Run(context.Background(), "go", provider, Options{
+		Registry: registry,
+		Model:    "claude-sonnet-4.5",
+		MaxTurns: 4,
+		ModelSwitcher: func(_ context.Context, _ string) (Provider, error) {
+			return nil, errors.New("provider build blew up")
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected escalation error to be non-fatal, got %v", err)
+	}
+	// The run continues on the same provider through the answer turn.
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected the run to continue on the original provider, got %d requests", len(provider.requests))
+	}
+	if result.FinalAnswer != "recovered" {
+		t.Fatalf("expected final answer after non-fatal switch error, got %q", result.FinalAnswer)
+	}
+	// A brief note about the failed switch must reach the model on the next turn.
+	var sawNote bool
+	for _, m := range provider.requests[1].Messages {
+		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(strings.ToLower(m.Content), "could not switch") {
+			sawNote = true
+		}
+	}
+	if !sawNote {
+		t.Fatalf("expected a non-fatal switch-failure note on the next turn, messages: %+v", provider.requests[1].Messages)
+	}
+}
+
+// TestRunSwitchesAtMostOncePerTurn verifies that when a single turn carries two
+// escalation requests, only the first triggers a switch.
+func TestRunSwitchesAtMostOncePerTurn(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	firstProvider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "c1", ToolName: "escalate"},
+			{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "c1"},
+			{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "c2", ToolName: "escalate"},
+			{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "c2"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}}
+	secondProvider := &mockProvider{turns: [][]zeroruntime.StreamEvent{
+		{
+			{Type: zeroruntime.StreamEventText, Content: "done"},
+			{Type: zeroruntime.StreamEventDone},
+		},
+	}}
+
+	switchCount := 0
+	if _, err := Run(context.Background(), "go", firstProvider, Options{
+		Registry: registry,
+		Model:    "claude-sonnet-4.5",
+		MaxTurns: 4,
+		ModelSwitcher: func(_ context.Context, _ string) (Provider, error) {
+			switchCount++
+			return secondProvider, nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if switchCount != 1 {
+		t.Fatalf("expected at most one switch per turn, got %d", switchCount)
 	}
 }

--- a/internal/agent/escalate_loop_test.go
+++ b/internal/agent/escalate_loop_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -40,4 +41,69 @@ func TestToolResultRequestedModelFieldExists(t *testing.T) {
 	}
 	// Keep the zeroruntime import load-bearing so the file compiles standalone.
 	_ = zeroruntime.MessageRoleAssistant
+}
+
+// escalatingTool is a registered fake tool that returns the escalation signal
+// in result Meta (mirroring the real escalate_model tool's contract), used to
+// drive the loop-level switch in tests without depending on the tools package.
+type escalatingTool struct {
+	target string
+}
+
+func (t escalatingTool) Name() string       { return "escalate" }
+func (t escalatingTool) Description() string { return "requests a model switch for testing" }
+func (t escalatingTool) Parameters() tools.Schema {
+	return tools.Schema{Type: "object", AdditionalProperties: false}
+}
+func (t escalatingTool) Safety() tools.Safety {
+	return tools.Safety{SideEffect: tools.SideEffectRead, Permission: tools.PermissionAllow}
+}
+func (t escalatingTool) Run(_ context.Context, _ map[string]any) tools.Result {
+	meta := map[string]string{}
+	if t.target != "" {
+		meta["escalate_to_model"] = t.target
+	}
+	return tools.Result{Status: tools.StatusOK, Output: "escalating", Meta: meta}
+}
+
+// TestExecuteToolCallLiftsEscalationMeta verifies executeToolCall promotes the
+// tool's Meta["escalate_to_model"] into ToolResult.RequestedModel.
+func TestExecuteToolCallLiftsEscalationMeta(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	result, abortErr := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{ID: "c1", Name: "escalate"},
+		PermissionModeAuto,
+		Options{},
+	)
+	if abortErr != nil {
+		t.Fatal(abortErr)
+	}
+	if result.RequestedModel != "claude-opus-4.1" {
+		t.Fatalf("expected RequestedModel lifted from meta, got %q", result.RequestedModel)
+	}
+}
+
+// TestExecuteToolCallNoEscalationMetaLeavesRequestedModelEmpty verifies a normal
+// tool result (no escalate_to_model meta) leaves RequestedModel empty.
+func TestExecuteToolCallNoEscalationMetaLeavesRequestedModelEmpty(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: ""})
+
+	result, abortErr := executeToolCall(
+		context.Background(),
+		registry,
+		ToolCall{ID: "c1", Name: "escalate"},
+		PermissionModeAuto,
+		Options{},
+	)
+	if abortErr != nil {
+		t.Fatal(abortErr)
+	}
+	if result.RequestedModel != "" {
+		t.Fatalf("expected empty RequestedModel without escalation meta, got %q", result.RequestedModel)
+	}
 }

--- a/internal/agent/escalate_loop_test.go
+++ b/internal/agent/escalate_loop_test.go
@@ -52,7 +52,7 @@ type escalatingTool struct {
 	target string
 }
 
-func (t escalatingTool) Name() string       { return "escalate" }
+func (t escalatingTool) Name() string        { return "escalate" }
 func (t escalatingTool) Description() string { return "requests a model switch for testing" }
 func (t escalatingTool) Parameters() tools.Schema {
 	return tools.Schema{Type: "object", AdditionalProperties: false}
@@ -237,6 +237,44 @@ func TestRunEscalationSwitcherErrorIsNonFatal(t *testing.T) {
 	}
 	if !sawNote {
 		t.Fatalf("expected a non-fatal switch-failure note on the next turn, messages: %+v", provider.requests[1].Messages)
+	}
+}
+
+// TestRunEscalationSwitcherNilProviderKeepsOriginal verifies that when a
+// ModelSwitcher returns (nil, nil) — no error, but also no replacement provider —
+// the loop does NOT null out the active provider. The run must continue on the
+// ORIGINAL provider and return a result rather than panic on a nil provider.
+func TestRunEscalationSwitcherNilProviderKeepsOriginal(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(escalatingTool{target: "claude-opus-4.1"})
+
+	provider := &mockProvider{turns: escalateThenAnswerTurns("answered on original")}
+
+	switchCount := 0
+	result, err := Run(context.Background(), "go", provider, Options{
+		Registry: registry,
+		Model:    "claude-sonnet-4.5",
+		MaxTurns: 4,
+		ModelSwitcher: func(_ context.Context, _ string) (Provider, error) {
+			switchCount++
+			// No error, but no provider either: the loop must NOT swap to nil.
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected (nil,nil) switch to be non-fatal, got %v", err)
+	}
+	if switchCount != 1 {
+		t.Fatalf("expected exactly one switch attempt, got %d", switchCount)
+	}
+	// Both turns (escalate + answer) must run on the single original provider; if
+	// the loop nil'd out the provider on a (nil,nil) return, the second turn would
+	// panic or never run.
+	if len(provider.requests) != 2 {
+		t.Fatalf("expected the original provider to serve both turns, got %d requests", len(provider.requests))
+	}
+	if result.FinalAnswer != "answered on original" {
+		t.Fatalf("expected final answer from the original provider, got %q", result.FinalAnswer)
 	}
 }
 

--- a/internal/agent/escalate_loop_test.go
+++ b/internal/agent/escalate_loop_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// TestOptionsModelSwitcherFieldExists asserts the escalation hook is an
+// assignable field on Options with the agreed signature, and that nil is its
+// zero value (escalation disabled by default).
+func TestOptionsModelSwitcherFieldExists(t *testing.T) {
+	var options Options
+	if options.ModelSwitcher != nil {
+		t.Fatalf("expected ModelSwitcher to default to nil, got non-nil")
+	}
+	options.ModelSwitcher = func(_ context.Context, modelID string) (Provider, error) {
+		return &mockProvider{}, nil
+	}
+	provider, err := options.ModelSwitcher(context.Background(), "claude-sonnet-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := provider.(*mockProvider); !ok {
+		t.Fatalf("expected ModelSwitcher to return a Provider, got %T", provider)
+	}
+}
+
+// TestToolResultRequestedModelFieldExists asserts the loop-level escalation
+// signal field is present on ToolResult and empty for a normal result.
+func TestToolResultRequestedModelFieldExists(t *testing.T) {
+	var result ToolResult
+	if result.RequestedModel != "" {
+		t.Fatalf("expected RequestedModel to default to empty, got %q", result.RequestedModel)
+	}
+	result.RequestedModel = "claude-opus-4.1"
+	if result.RequestedModel != "claude-opus-4.1" {
+		t.Fatalf("expected RequestedModel to round-trip, got %q", result.RequestedModel)
+	}
+	// Keep the zeroruntime import load-bearing so the file compiles standalone.
+	_ = zeroruntime.MessageRoleAssistant
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -272,6 +272,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 				// context-window sizing, and usage attribution follow the new model.
 				provider = newProvider
 				options.Model = turnRequestedModel
+				// KNOWN LIMITATION (deferred): the compactor's context-window budget
+				// is fixed at run start from options.ContextWindow and is NOT updated
+				// here, so a switch to a model with a different window keeps compacting
+				// against the original budget. Fixing it needs a ModelSwitcher contract
+				// change (return the new window) — out of scope for this change.
 			}
 		}
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -396,6 +396,11 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		Redacted:     result.Redacted,
 		ChangedFiles: result.ChangedFiles,
 		Display:      result.Display,
+		// A tool may signal a mid-run model escalation by carrying the target id
+		// in Meta["escalate_to_model"]. Lift it into the typed loop-level field;
+		// the Run turn loop performs the actual provider switch. Empty for every
+		// ordinary tool result.
+		RequestedModel: result.Meta["escalate_to_model"],
 	}, nil
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -28,6 +28,12 @@ const abortedToolResultNotice = "aborted: run halted by the repeated-failure gua
 const droppedToolCallNotice = "Your previous tool call was malformed (it was missing a tool name) and was not executed. " +
 	"Re-issue the tool call with a valid tool name and JSON arguments, or reply with your final answer."
 
+// escalationFailedNoticePrefix introduces the brief, user-role note recorded
+// when a requested mid-run model switch could not be performed (the
+// ModelSwitcher returned an error). The run continues on the current model;
+// escalation is best-effort, never fatal.
+const escalationFailedNoticePrefix = "Note: could not switch to the requested model"
+
 // The system prompt (core coding-craft instructions + workspace context + safety
 // confirmation policy) is assembled in system_prompt.go via buildSystemPrompt.
 
@@ -188,6 +194,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		guards.observeTurn(collected)
 
 		failureHint := ""
+		// turnRequestedModel records the FIRST mid-run escalation target requested
+		// during this turn's tool batch. The actual provider switch happens once,
+		// after the batch, so every tool_result is recorded first and at most one
+		// switch occurs per turn.
+		turnRequestedModel := ""
 		for index, call := range collected.ToolCalls {
 			if options.OnToolCall != nil {
 				options.OnToolCall(call)
@@ -195,6 +206,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			toolResult, abortErr := executeToolCall(ctx, registry, call, permissionMode, options)
 			if options.OnToolResult != nil {
 				options.OnToolResult(toolResult)
+			}
+			if turnRequestedModel == "" && toolResult.RequestedModel != "" {
+				turnRequestedModel = toolResult.RequestedModel
 			}
 			messages = append(messages, zeroruntime.Message{
 				Role:       zeroruntime.MessageRoleTool,
@@ -237,6 +251,27 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			}
 			if outcome.InjectHint && failureHint == "" {
 				failureHint = toolFailureHint(call.Name, toolSchemaJSON(registry, call.Name), toolResult.Output)
+			}
+		}
+
+		// Mid-run model escalation: if a tool asked to switch models this turn and
+		// a switcher is wired, rebuild the provider on the new model for the rest
+		// of the run. At most one switch per turn (first request wins). A switcher
+		// error is NON-FATAL — record a brief note and continue on the current
+		// model. nil switcher ⇒ requests are ignored entirely (escalation off).
+		if turnRequestedModel != "" && options.ModelSwitcher != nil {
+			newProvider, switchErr := options.ModelSwitcher(ctx, turnRequestedModel)
+			if switchErr != nil {
+				messages = append(messages, zeroruntime.Message{
+					Role:    zeroruntime.MessageRoleUser,
+					Content: escalationFailedNoticePrefix + " (" + turnRequestedModel + "): " + switchErr.Error() + ". Continuing on " + options.Model + ".",
+				})
+			} else if newProvider != nil {
+				// Reassign the local provider so the next turn's StreamCompletion and
+				// compaction use it; update options.Model so subsequent RunOptions.Model,
+				// context-window sizing, and usage attribution follow the new model.
+				provider = newProvider
+				options.Model = turnRequestedModel
 			}
 		}
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -47,6 +47,11 @@ type ToolResult struct {
 	// DenialReason categorizes why a tool call was blocked (empty when it ran).
 	// It lets a surface distinguish the cause precisely instead of parsing Output.
 	DenialReason DenialCategory
+	// RequestedModel is the model id a tool asked the loop to switch to for the
+	// rest of the run (lifted from the tool's Meta["escalate_to_model"]). Empty
+	// for every normal tool result; the Run loop performs the switch when it is
+	// set and Options.ModelSwitcher is wired.
+	RequestedModel string
 }
 
 // DenialCategory classifies why a tool call was blocked before it executed.
@@ -158,6 +163,13 @@ type Options struct {
 	// budget of the request about to be sent, so a surface (TUI/CLI) can show
 	// context utilization. Opt-in like the other callbacks; nil is a no-op.
 	OnContext func(ContextBreakdown)
+	// ModelSwitcher, when set, lets a tool escalate the run to a stronger model
+	// mid-run: the loop calls it with the requested model id and, on success,
+	// swaps the active provider and updates Options.Model for the rest of the
+	// run. nil DISABLES escalation entirely (the loop ignores any switch
+	// request), so every existing caller is unaffected. A returned error is
+	// non-fatal: the run continues on the current model.
+	ModelSwitcher func(ctx context.Context, modelID string) (Provider, error)
 }
 
 type Result struct {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -512,6 +512,7 @@ Flags:
       --session-title <text>         Set the created session title
       --init-session-id <id>         Create a new exec session with this id
       --skip-permissions-unsafe      Allow prompt-gated tools without approval
+      --allow-escalation             Let the agent escalate to a stronger model mid-run via escalate_model
 `)
 	return err
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -248,6 +248,25 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
 	}
+
+	// currentModel tracks the model in force for usage attribution. It starts at
+	// the resolved model and is reassigned by the model switcher on a mid-run
+	// escalation so post-switch turns are attributed to the escalated model.
+	currentModel := resolved.Provider.Model
+	var modelSwitcher func(context.Context, string) (agent.Provider, error)
+	if options.allowEscalation {
+		modelSwitcher = func(_ context.Context, modelID string) (agent.Provider, error) {
+			switchedProfile := resolved.Provider
+			switchedProfile.Model = modelID
+			switchedProvider, err := deps.newProvider(switchedProfile)
+			if err != nil {
+				return nil, err
+			}
+			currentModel = modelID
+			return switchedProvider, nil
+		}
+	}
+
 	runMetadata, err := resolveExecRunMetadata(resolved.Provider)
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
@@ -332,6 +351,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		Depth:            options.depth,
 		SessionTitle:     sessionTitle,
 		Model:            resolved.Provider.Model,
+		ModelSwitcher:    modelSwitcher,
 		ReasoningEffort:  options.reasoningEffort,
 		Cwd:              workspaceRoot,
 		Images:           images,
@@ -380,6 +400,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		OnUsage: func(usage agent.Usage) {
 			writer.usage(usage)
 			sessionRecorder.append(sessions.EventUsage, map[string]any{
+				"model":            currentModel,
 				"promptTokens":     usage.EffectiveInputTokens(),
 				"completionTokens": usage.EffectiveOutputTokens(),
 				"totalTokens":      usage.TotalTokens(),

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -399,12 +399,20 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		},
 		OnUsage: func(usage agent.Usage) {
 			writer.usage(usage)
-			sessionRecorder.append(sessions.EventUsage, map[string]any{
-				"model":            currentModel,
+			payload := map[string]any{
 				"promptTokens":     usage.EffectiveInputTokens(),
 				"completionTokens": usage.EffectiveOutputTokens(),
 				"totalTokens":      usage.TotalTokens(),
-			})
+			}
+			// Attribute usage to a specific model ONLY when escalation is enabled:
+			// the model in force can change mid-run only under --allow-escalation, so
+			// the "model" key is meaningful exclusively then. Omitting it otherwise
+			// keeps a non-escalation run's persisted usage payload byte-identical to
+			// before this feature (the origin/main guarantee).
+			if options.allowEscalation {
+				payload["model"] = currentModel
+			}
+			sessionRecorder.append(sessions.EventUsage, payload)
 		},
 	})
 	if writer.err != nil {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/specialist"
 	"github.com/Gitlawb/zero/internal/streamjson"
+	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -133,6 +134,14 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	}
 
 	registry := newCoreRegistry(workspaceRoot)
+	// Register the escalate_model tool only when the run opted into mid-run
+	// escalation. It is registered before --list-tools formatting and
+	// validateExecToolFilters so the tool is both listable and filter-validatable.
+	// The no-arg constructor builds its own default registry internally (and
+	// degrades to an inert tool if the catalog fails), so no registry is threaded.
+	if options.allowEscalation {
+		registry.Register(tools.NewEscalateModelTool())
+	}
 	var specialistRuntime *specialist.Runtime
 	if shouldRegisterExecSpecialistTools(options) {
 		var err error

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -262,7 +262,13 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			if err != nil {
 				return nil, err
 			}
-			currentModel = modelID
+			// Mirror the agent loop's switch guard (it only reassigns the provider
+			// when newProvider != nil). Updating currentModel only on a non-nil
+			// provider keeps usage attribution consistent with whether the loop
+			// actually switched — a (nil, nil) return leaves both untouched.
+			if switchedProvider != nil {
+				currentModel = modelID
+			}
 			return switchedProvider, nil
 		}
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -78,6 +78,11 @@ type execOptions struct {
 	worktreeName          string
 	worktreeDir           string
 	skipPermissionsUnsafe bool
+	// allowEscalation opts the run into mid-run model escalation: it registers
+	// the escalate_model tool and wires agent.Options.ModelSwitcher. Off by
+	// default — a run without the flag is byte-identical to before (no tool, nil
+	// switcher).
+	allowEscalation bool
 }
 
 type execUsageError struct {

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -23,6 +23,8 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			options.skipPermissionsUnsafe = true
 		case arg == "--list-tools":
 			options.listTools = true
+		case arg == "--allow-escalation":
+			options.allowEscalation = true
 		case arg == "--auto":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1163,3 +1163,20 @@ func TestParseExecAllowEscalationFlag(t *testing.T) {
 		}
 	})
 }
+
+func TestRunExecHelpDocumentsAllowEscalation(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec", "--help"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "--allow-escalation") {
+		t.Fatalf("expected exec help to document --allow-escalation, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1209,18 +1209,26 @@ func TestRunExecRegistersEscalateModelOnlyWithFlag(t *testing.T) {
 	}
 }
 
-// escalatingExecProvider emits an escalate_model tool call on its first turn,
-// then a final text answer. It lets an exec run exercise the mid-run switch
-// without a live model.
+// escalatingExecProvider drives an exec run through a mid-run switch without a
+// live model. Each instance tracks how many turns IT served (turns) so a test
+// can assert exactly which provider handled which turn across a switch.
+//
+// escalateOnce controls behavior: when true, the FIRST turn this instance serves
+// emits an escalate_model tool call (later turns answer); when false, every turn
+// emits a final text answer. Pointing escalateOnce at distinct instances lets a
+// test prove the post-switch turn lands on the SECOND (escalated) provider.
 type escalatingExecProvider struct {
-	calls *int
+	// turns counts how many StreamCompletion calls THIS instance handled.
+	turns int
+	// escalateOnce makes this instance's first served turn request an escalation.
+	escalateOnce bool
 }
 
-func (provider escalatingExecProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
-	turn := *provider.calls
-	*provider.calls++
+func (provider *escalatingExecProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	turn := provider.turns
+	provider.turns++
 	ch := make(chan zeroruntime.StreamEvent, 4)
-	if turn == 0 {
+	if provider.escalateOnce && turn == 0 {
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_escalate", ToolName: "escalate_model"}
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_escalate", ArgumentsFragment: "{}"}
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_escalate"}
@@ -1240,7 +1248,14 @@ func TestRunExecWiresModelSwitcherUnderFlag(t *testing.T) {
 	cwd := t.TempDir()
 
 	var providerModels []string
-	calls := 0
+	// Each newProvider build returns a DISTINCT provider instance with its OWN
+	// turn counter, mirroring the agent-layer firstProvider/secondProvider split.
+	// The first build (escalation source) must handle exactly the escalation turn;
+	// the second build (escalation target) must handle exactly the post-switch
+	// answer turn. Sharing a single counter would hide a dropped `provider =
+	// newProvider` in loop.go — here it is mutation-proven by the per-instance
+	// turn assertions below.
+	var builtProviders []*escalatingExecProvider
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := runWithDeps([]string{"exec", "--allow-escalation", "--model", "claude-haiku-4.5", "escalate please"}, &stdout, &stderr, appDeps{
@@ -1262,7 +1277,11 @@ func TestRunExecWiresModelSwitcherUnderFlag(t *testing.T) {
 		},
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
 			providerModels = append(providerModels, profile.Model)
-			return escalatingExecProvider{calls: &calls}, nil
+			// First build escalates; every later build answers. Each instance owns
+			// its turn counter so we can assert exactly-one-turn per provider.
+			provider := &escalatingExecProvider{escalateOnce: len(builtProviders) == 0}
+			builtProviders = append(builtProviders, provider)
+			return provider, nil
 		},
 	})
 	if exitCode != exitSuccess {
@@ -1282,6 +1301,19 @@ func TestRunExecWiresModelSwitcherUnderFlag(t *testing.T) {
 	if providerModels[1] != target {
 		t.Fatalf("escalated provider model = %q, want %q", providerModels[1], target)
 	}
+	if len(builtProviders) != 2 {
+		t.Fatalf("built %d providers, want 2", len(builtProviders))
+	}
+	// The original (escalation-source) provider handled ONLY the escalation turn;
+	// the escalated (target) provider handled ONLY the post-switch answer turn.
+	// This FAILS if loop.go drops `provider = newProvider` (the second provider
+	// would then handle zero turns and the first would handle both).
+	if builtProviders[0].turns != 1 {
+		t.Fatalf("first (source) provider handled %d turns, want exactly 1 (the escalation turn)", builtProviders[0].turns)
+	}
+	if builtProviders[1].turns != 1 {
+		t.Fatalf("second (escalated) provider handled %d turns, want exactly 1 (the post-switch answer turn)", builtProviders[1].turns)
+	}
 }
 
 func mustUpgradeTarget(t *testing.T, id string) (string, bool) {
@@ -1300,7 +1332,6 @@ func TestRunExecNoSwitcherWithoutFlag(t *testing.T) {
 	cwd := t.TempDir()
 
 	var providerModels []string
-	calls := 0
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := runWithDeps([]string{"exec", "--model", "claude-haiku-4.5", "escalate please"}, &stdout, &stderr, appDeps{
@@ -1322,7 +1353,7 @@ func TestRunExecNoSwitcherWithoutFlag(t *testing.T) {
 		},
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
 			providerModels = append(providerModels, profile.Model)
-			return escalatingExecProvider{calls: &calls}, nil
+			return &escalatingExecProvider{escalateOnce: true}, nil
 		},
 	})
 	if exitCode != exitSuccess {
@@ -1346,7 +1377,10 @@ func TestRunExecAttributesUsageToEscalatedModel(t *testing.T) {
 		t.Skip("registry has no upgrade target for claude-haiku-4.5")
 	}
 
-	calls := 0
+	// The escalation turn (turn 0, pre-switch) emits usage with distinct tokens so
+	// it can be told apart from the post-switch usage; the first build escalates,
+	// the second answers.
+	builds := 0
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := runWithDeps([]string{
@@ -1373,7 +1407,11 @@ func TestRunExecAttributesUsageToEscalatedModel(t *testing.T) {
 			return cfg, nil
 		},
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
-			return usageEmittingEscalatingProvider{calls: &calls}, nil
+			// First build = escalation source (escalate + usage 3/4 pre-switch);
+			// second build = escalation target (answer + usage 5/7 post-switch).
+			escalate := builds == 0
+			builds++
+			return &usageEmittingEscalatingProvider{escalate: escalate}, nil
 		},
 	})
 	if exitCode != exitSuccess {
@@ -1385,8 +1423,11 @@ func TestRunExecAttributesUsageToEscalatedModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadEvents returned error: %v", err)
 	}
-	var lastUsageModel string
-	var sawUsage bool
+	// Collect every usage model attribution IN ORDER. The pre-switch usage must
+	// attribute to the ORIGINAL model and the post-switch usage to the escalated
+	// target — proving the loop's ordering guarantee (usage is attributed to the
+	// model that produced it, not retroactively reassigned after the switch).
+	var usageModels []string
 	for _, event := range events {
 		if event.Type != sessions.EventUsage {
 			continue
@@ -1395,34 +1436,143 @@ func TestRunExecAttributesUsageToEscalatedModel(t *testing.T) {
 		if err := json.Unmarshal(event.Payload, &payload); err != nil {
 			t.Fatalf("unmarshal usage payload: %v", err)
 		}
-		if model, ok := payload["model"].(string); ok {
-			lastUsageModel = model
-			sawUsage = true
+		model, _ := payload["model"].(string)
+		usageModels = append(usageModels, model)
+	}
+	if len(usageModels) != 2 {
+		t.Fatalf("recorded usage model attributions = %#v, want exactly 2 (pre- and post-switch)", usageModels)
+	}
+	if usageModels[0] != "claude-haiku-4.5" {
+		t.Fatalf("first (pre-switch) usage model = %q, want claude-haiku-4.5", usageModels[0])
+	}
+	if usageModels[1] != target {
+		t.Fatalf("second (post-switch) usage model = %q, want escalated target %q", usageModels[1], target)
+	}
+}
+
+// usageEmittingEscalatingProvider emits a usage event on every turn it serves so
+// usage attribution can be traced across a mid-run switch. When escalate is set,
+// its turn requests an escalation (and emits pre-switch usage tokens 3/4);
+// otherwise it answers (post-switch usage tokens 5/7).
+type usageEmittingEscalatingProvider struct {
+	escalate bool
+}
+
+func (provider *usageEmittingEscalatingProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	ch := make(chan zeroruntime.StreamEvent, 6)
+	if provider.escalate {
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_escalate", ToolName: "escalate_model"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_escalate", ArgumentsFragment: "{}"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_escalate"}
+		// Pre-switch usage: still attributed to the ORIGINAL model.
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 3, OutputTokens: 4}}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "done"}
+	// Post-switch usage: attributed to the escalated model.
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 5, OutputTokens: 7}}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+// usageEmittingEchoProvider answers in a single turn and emits a usage event. It
+// has no escalation behavior, so it exercises a plain (flag-OFF) run that still
+// records usage.
+type usageEmittingEchoProvider struct{}
+
+func (usageEmittingEchoProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	ch := make(chan zeroruntime.StreamEvent, 3)
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "done"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 5, OutputTokens: 7}}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+// TestRunExecUsageOmitsModelKeyWithoutEscalationFlag verifies the back-compat
+// guarantee: a run WITHOUT --allow-escalation persists EventUsage payloads that
+// carry NO "model" key (byte-identical to before the escalation feature), since
+// the model can never change mid-run when escalation is off. The flag-ON,
+// post-escalation case is covered by TestRunExecAttributesUsageToEscalatedModel.
+func TestRunExecUsageOmitsModelKeyWithoutEscalationFlag(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--model", "claude-haiku-4.5",
+		"--init-session-id", "no_escalation_run",
+		"hello",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-haiku-4.5"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return usageEmittingEchoProvider{}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: filepath.Join(dataHome, "zero", "sessions")})
+	events, err := store.ReadEvents("no_escalation_run")
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	var sawUsage bool
+	for _, event := range events {
+		if event.Type != sessions.EventUsage {
+			continue
+		}
+		sawUsage = true
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal usage payload: %v", err)
+		}
+		if _, ok := payload["model"]; ok {
+			t.Fatalf("flag-OFF usage payload must NOT carry a model key, got %#v", payload)
 		}
 	}
 	if !sawUsage {
-		t.Fatal("no usage event carried a model attribution")
-	}
-	if lastUsageModel != target {
-		t.Fatalf("last usage model = %q, want escalated target %q", lastUsageModel, target)
+		t.Fatal("expected at least one usage event to be recorded")
 	}
 }
 
-// usageEmittingEscalatingProvider escalates on turn 0 and emits a usage event on
-// turn 1 (after the switch) so the recorded usage must be attributed to the
-// escalated model.
-type usageEmittingEscalatingProvider struct {
-	calls *int
+// usageThenAnswerProvider serves a two-turn run on ONE instance: turn 0 requests
+// an escalation and emits usage, turn 1 answers and emits usage. It is used by
+// the switch-error test where no second provider is ever built, so a single
+// instance must serve both turns on the original model.
+type usageThenAnswerProvider struct {
+	turns int
 }
 
-func (provider usageEmittingEscalatingProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
-	turn := *provider.calls
-	*provider.calls++
-	ch := make(chan zeroruntime.StreamEvent, 5)
+func (provider *usageThenAnswerProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	turn := provider.turns
+	provider.turns++
+	ch := make(chan zeroruntime.StreamEvent, 6)
 	if turn == 0 {
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_escalate", ToolName: "escalate_model"}
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_escalate", ArgumentsFragment: "{}"}
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_escalate"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 3, OutputTokens: 4}}
 		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
 		close(ch)
 		return ch, nil
@@ -1432,4 +1582,144 @@ func (provider usageEmittingEscalatingProvider) StreamCompletion(ctx context.Con
 	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
 	close(ch)
 	return ch, nil
+}
+
+// TestRunExecSwitcherErrorKeepsOriginalModelAttribution verifies that when the
+// ModelSwitcher fails on the rebuild (deps.newProvider errors for the escalation
+// target), the run is NON-FATAL and stays on the original provider — and every
+// usage event, including the one AFTER the failed switch, stays attributed to the
+// ORIGINAL model (currentModel is never reassigned on a failed switch).
+func TestRunExecSwitcherErrorKeepsOriginalModelAttribution(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	if _, ok := mustUpgradeTarget(t, "claude-haiku-4.5"); !ok {
+		t.Skip("registry has no upgrade target for claude-haiku-4.5")
+	}
+
+	builds := 0
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--allow-escalation",
+		"--model", "claude-haiku-4.5",
+		"--init-session-id", "switch_error_run",
+		"escalate please",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-haiku-4.5"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			builds++
+			// The first build (original model) succeeds; the rebuild on escalation
+			// FAILS, so the switcher returns an error and the run continues on the
+			// original provider.
+			if builds >= 2 {
+				return nil, errors.New("provider rebuild failed")
+			}
+			return &usageThenAnswerProvider{}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("expected non-fatal switch error, exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	if builds != 2 {
+		t.Fatalf("newProvider builds = %d, want 2 (initial + one failed rebuild attempt)", builds)
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: filepath.Join(dataHome, "zero", "sessions")})
+	events, err := store.ReadEvents("switch_error_run")
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	var usageModels []string
+	for _, event := range events {
+		if event.Type != sessions.EventUsage {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal usage payload: %v", err)
+		}
+		model, _ := payload["model"].(string)
+		usageModels = append(usageModels, model)
+	}
+	if len(usageModels) != 2 {
+		t.Fatalf("recorded usage attributions = %#v, want 2", usageModels)
+	}
+	// Both usages (pre- AND post-failed-switch) stay on the ORIGINAL model.
+	for i, model := range usageModels {
+		if model != "claude-haiku-4.5" {
+			t.Fatalf("usage[%d] model = %q, want claude-haiku-4.5 (currentModel must not change on a failed switch)", i, model)
+		}
+	}
+}
+
+// TestRunExecTopTierDeclineNoSwitch verifies an end-to-end flag-ON run where the
+// agent calls escalate_model while ALREADY on a top-tier model (claude-opus-4.1):
+// the tool returns the informational no-meta result, NO switch happens
+// (newProvider is called exactly once), and the run succeeds.
+func TestRunExecTopTierDeclineNoSwitch(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	// Sanity: claude-opus-4.1 must genuinely be top-tier (no upgrade target), or
+	// the scenario is meaningless.
+	if _, ok := mustUpgradeTarget(t, "claude-opus-4.1"); ok {
+		t.Skip("registry unexpectedly has an upgrade target for claude-opus-4.1")
+	}
+
+	var providerModels []string
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--allow-escalation",
+		"--model", "claude-opus-4.1",
+		"escalate please",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-opus-4.1"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			providerModels = append(providerModels, profile.Model)
+			return &escalatingExecProvider{escalateOnce: true}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	// The escalate_model call resolved to a no-target informational result, so the
+	// loop never requested a switch and newProvider was built exactly once.
+	if len(providerModels) != 1 {
+		t.Fatalf("newProvider built for %#v, want exactly 1 (top-tier decline performs no switch)", providerModels)
+	}
+	if providerModels[0] != "claude-opus-4.1" {
+		t.Fatalf("provider model = %q, want claude-opus-4.1", providerModels[0])
+	}
 }

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1180,3 +1180,31 @@ func TestRunExecHelpDocumentsAllowEscalation(t *testing.T) {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
 }
+
+func TestRunExecRegistersEscalateModelOnlyWithFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantTool bool
+	}{
+		{name: "absent", args: []string{"exec", "--list-tools"}, wantTool: false},
+		{name: "present", args: []string{"exec", "--allow-escalation", "--list-tools"}, wantTool: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			exitCode := runWithDeps(tc.args, &stdout, &stderr, appDeps{
+				getwd: func() (string, error) {
+					return t.TempDir(), nil
+				},
+			})
+			if exitCode != exitSuccess {
+				t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+			}
+			hasTool := strings.Contains(stdout.String(), "  escalate_model ")
+			if hasTool != tc.wantTool {
+				t.Fatalf("escalate_model visibility = %v, want %v; output:\n%s", hasTool, tc.wantTool, stdout.String())
+			}
+		})
+	}
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1208,3 +1208,88 @@ func TestRunExecRegistersEscalateModelOnlyWithFlag(t *testing.T) {
 		})
 	}
 }
+
+// escalatingExecProvider emits an escalate_model tool call on its first turn,
+// then a final text answer. It lets an exec run exercise the mid-run switch
+// without a live model.
+type escalatingExecProvider struct {
+	calls *int
+}
+
+func (provider escalatingExecProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	turn := *provider.calls
+	*provider.calls++
+	ch := make(chan zeroruntime.StreamEvent, 4)
+	if turn == 0 {
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_escalate", ToolName: "escalate_model"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_escalate", ArgumentsFragment: "{}"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_escalate"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "done"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunExecWiresModelSwitcherUnderFlag(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	var providerModels []string
+	calls := 0
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--allow-escalation", "--model", "claude-haiku-4.5", "escalate please"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-haiku-4.5"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			// The escalation chain (haiku -> sonnet) is anthropic; declare the
+			// provider kind to match so provider-metadata resolution accepts it.
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			providerModels = append(providerModels, profile.Model)
+			return escalatingExecProvider{calls: &calls}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	// Initial provider build + one rebuild for the escalation target.
+	if len(providerModels) != 2 {
+		t.Fatalf("newProvider called for models %#v, want exactly 2 builds (initial + escalated)", providerModels)
+	}
+	if providerModels[0] != "claude-haiku-4.5" {
+		t.Fatalf("initial provider model = %q, want claude-haiku-4.5", providerModels[0])
+	}
+	target, ok := mustUpgradeTarget(t, "claude-haiku-4.5")
+	if !ok {
+		t.Skip("registry has no upgrade target for claude-haiku-4.5")
+	}
+	if providerModels[1] != target {
+		t.Fatalf("escalated provider model = %q, want %q", providerModels[1], target)
+	}
+}
+
+func mustUpgradeTarget(t *testing.T, id string) (string, bool) {
+	t.Helper()
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	entry, ok := registry.UpgradeTarget(id)
+	return entry.ID, ok
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1135,3 +1135,31 @@ func TestRunExecInvalidAutoValidatedWithSkipPermissions(t *testing.T) {
 		t.Fatalf("expected autonomy validation error, got %q", got)
 	}
 }
+
+func TestParseExecAllowEscalationFlag(t *testing.T) {
+	t.Run("absent defaults to false", func(t *testing.T) {
+		options, help, err := parseExecArgs([]string{"hello"})
+		if err != nil {
+			t.Fatalf("parseExecArgs returned error: %v", err)
+		}
+		if help {
+			t.Fatal("help = true, want false")
+		}
+		if options.allowEscalation {
+			t.Fatal("allowEscalation = true, want false by default")
+		}
+	})
+
+	t.Run("flag sets true", func(t *testing.T) {
+		options, _, err := parseExecArgs([]string{"--allow-escalation", "hello"})
+		if err != nil {
+			t.Fatalf("parseExecArgs returned error: %v", err)
+		}
+		if !options.allowEscalation {
+			t.Fatal("allowEscalation = false, want true")
+		}
+		if strings.Join(options.promptParts, " ") != "hello" {
+			t.Fatalf("promptParts = %#v, want [hello]", options.promptParts)
+		}
+	})
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1293,3 +1293,45 @@ func mustUpgradeTarget(t *testing.T, id string) (string, bool) {
 	entry, ok := registry.UpgradeTarget(id)
 	return entry.ID, ok
 }
+
+func TestRunExecNoSwitcherWithoutFlag(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	var providerModels []string
+	calls := 0
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"exec", "--model", "claude-haiku-4.5", "escalate please"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-haiku-4.5"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			// The escalation chain (haiku -> sonnet) is anthropic; declare the
+			// provider kind to match so provider-metadata resolution accepts it.
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			providerModels = append(providerModels, profile.Model)
+			return escalatingExecProvider{calls: &calls}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	if len(providerModels) != 1 {
+		t.Fatalf("newProvider called for %#v, want exactly 1 build (no switcher wired)", providerModels)
+	}
+	if providerModels[0] != "claude-haiku-4.5" {
+		t.Fatalf("provider model = %q, want claude-haiku-4.5", providerModels[0])
+	}
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1335,3 +1335,101 @@ func TestRunExecNoSwitcherWithoutFlag(t *testing.T) {
 		t.Fatalf("provider model = %q, want claude-haiku-4.5", providerModels[0])
 	}
 }
+
+func TestRunExecAttributesUsageToEscalatedModel(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	target, ok := mustUpgradeTarget(t, "claude-haiku-4.5")
+	if !ok {
+		t.Skip("registry has no upgrade target for claude-haiku-4.5")
+	}
+
+	calls := 0
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--allow-escalation",
+		"--model", "claude-haiku-4.5",
+		"--init-session-id", "escalation_run",
+		"escalate please",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-haiku-4.5"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			// The escalation chain (haiku -> sonnet) is anthropic; declare the
+			// provider kind to match so provider-metadata resolution accepts it.
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			return usageEmittingEscalatingProvider{calls: &calls}, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: filepath.Join(dataHome, "zero", "sessions")})
+	events, err := store.ReadEvents("escalation_run")
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	var lastUsageModel string
+	var sawUsage bool
+	for _, event := range events {
+		if event.Type != sessions.EventUsage {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal usage payload: %v", err)
+		}
+		if model, ok := payload["model"].(string); ok {
+			lastUsageModel = model
+			sawUsage = true
+		}
+	}
+	if !sawUsage {
+		t.Fatal("no usage event carried a model attribution")
+	}
+	if lastUsageModel != target {
+		t.Fatalf("last usage model = %q, want escalated target %q", lastUsageModel, target)
+	}
+}
+
+// usageEmittingEscalatingProvider escalates on turn 0 and emits a usage event on
+// turn 1 (after the switch) so the recorded usage must be attributed to the
+// escalated model.
+type usageEmittingEscalatingProvider struct {
+	calls *int
+}
+
+func (provider usageEmittingEscalatingProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	turn := *provider.calls
+	*provider.calls++
+	ch := make(chan zeroruntime.StreamEvent, 5)
+	if turn == 0 {
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_escalate", ToolName: "escalate_model"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_escalate", ArgumentsFragment: "{}"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_escalate"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "done"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 5, OutputTokens: 7}}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1450,6 +1450,107 @@ func TestRunExecAttributesUsageToEscalatedModel(t *testing.T) {
 	}
 }
 
+func TestRunExecNilSwitchProviderKeepsOriginalAttribution(t *testing.T) {
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	cwd := t.TempDir()
+
+	if _, ok := mustUpgradeTarget(t, "claude-haiku-4.5"); !ok {
+		t.Skip("registry has no upgrade target for claude-haiku-4.5")
+	}
+
+	// The escalation rebuild returns (nil, nil): the loop must NOT swap the
+	// provider, and the CLI switcher must leave currentModel unchanged so usage
+	// after the declined switch stays attributed to the ORIGINAL model. Without
+	// the switchedProvider != nil guard, currentModel would advance to the target
+	// even though no switch happened, misattributing the post-turn usage.
+	builds := 0
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{
+		"exec",
+		"--allow-escalation",
+		"--model", "claude-haiku-4.5",
+		"--init-session-id", "nil_switch_run",
+		"escalate please",
+	}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveConfig: func(_ string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			model := "claude-haiku-4.5"
+			if overrides.Provider.Model != "" {
+				model = overrides.Provider.Model
+			}
+			cfg := execResolvedConfig()
+			cfg.Provider.ProviderKind = config.ProviderKindAnthropic
+			cfg.Provider.Model = model
+			cfg.MaxTurns = 3
+			return cfg, nil
+		},
+		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			builds++
+			// First build = the original (haiku). The escalation rebuild returns
+			// (nil, nil), so the loop keeps the original provider for every turn.
+			if builds == 1 {
+				return &escalateThenAnswerProvider{}, nil
+			}
+			return nil, nil
+		},
+	})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: filepath.Join(dataHome, "zero", "sessions")})
+	events, err := store.ReadEvents("nil_switch_run")
+	if err != nil {
+		t.Fatalf("ReadEvents returned error: %v", err)
+	}
+	sawUsage := false
+	for _, event := range events {
+		if event.Type != sessions.EventUsage {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal usage payload: %v", err)
+		}
+		sawUsage = true
+		if model, _ := payload["model"].(string); model != "claude-haiku-4.5" {
+			t.Fatalf("usage attributed to %q after a (nil,nil) switch, want original claude-haiku-4.5", model)
+		}
+	}
+	if !sawUsage {
+		t.Fatal("expected at least one usage event")
+	}
+}
+
+// escalateThenAnswerProvider escalates on its first turn and answers afterward,
+// so a single instance can serve an entire run when no provider swap occurs
+// (e.g. a (nil,nil) switcher). It emits usage on every turn for attribution.
+type escalateThenAnswerProvider struct {
+	turns int
+}
+
+func (provider *escalateThenAnswerProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	turn := provider.turns
+	provider.turns++
+	ch := make(chan zeroruntime.StreamEvent, 6)
+	if turn == 0 {
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call_escalate", ToolName: "escalate_model"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call_escalate", ArgumentsFragment: "{}"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call_escalate"}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 3, OutputTokens: 4}}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+		close(ch)
+		return ch, nil
+	}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: "done"}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 5, OutputTokens: 7}}
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
 // usageEmittingEscalatingProvider emits a usage event on every turn it serves so
 // usage attribution can be traced across a mid-run switch. When escalate is set,
 // its turn requests an escalation (and emits pre-switch usage tokens 3/4);

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -390,6 +390,8 @@ func streamJSONSideEffect(name string, registry *tools.Registry) string {
 		return "shell"
 	case tools.SideEffectNetwork:
 		return "network"
+	case tools.SideEffectNone:
+		return "none"
 	default:
 		return "unknown"
 	}

--- a/internal/cli/exec_writer_test.go
+++ b/internal/cli/exec_writer_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// escalate_model is a control-only tool (SideEffectNone). The stream-json tool
+// call must report sideEffect "none", not "unknown", so automation sees the
+// promised value.
+func TestStreamJSONSideEffectReportsNoneForControlTool(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewEscalateModelTool())
+	if got := streamJSONSideEffect("escalate_model", registry); got != "none" {
+		t.Fatalf("streamJSONSideEffect(escalate_model) = %q, want none", got)
+	}
+}

--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -51,10 +51,12 @@ func decorateModelDepth(entries []ModelEntry) {
 		defaultEffort ReasoningEffort
 		patterns      []string
 		deprecation   *DeprecationRule
+		upgradeTarget string
 	}{
 		"claude-sonnet-4.5": {
 			defaultEffort: ReasoningEffortMedium,
 			patterns:      []string{`(?i)^sonnet[^a-z0-9]*4[.\s]?5$`},
+			upgradeTarget: "claude-opus-4.1",
 		},
 		"claude-opus-4.1": {
 			defaultEffort: ReasoningEffortHigh,
@@ -63,6 +65,7 @@ func decorateModelDepth(entries []ModelEntry) {
 		"claude-haiku-4.5": {
 			defaultEffort: ReasoningEffortLow,
 			patterns:      []string{`(?i)^haiku[^a-z0-9]*4[.\s]?5$`},
+			upgradeTarget: "claude-sonnet-4.5",
 		},
 		"gemini-2.5-pro": {
 			defaultEffort: ReasoningEffortMedium,
@@ -70,6 +73,19 @@ func decorateModelDepth(entries []ModelEntry) {
 		},
 		"gemini-2.5-flash": {
 			defaultEffort: ReasoningEffortLow,
+			upgradeTarget: "gemini-2.5-pro",
+		},
+		"gemini-2.5-flash-lite": {
+			upgradeTarget: "gemini-2.5-flash",
+		},
+		"gpt-4.1-mini": {
+			upgradeTarget: "gpt-4.1",
+		},
+		"gpt-4.1-nano": {
+			upgradeTarget: "gpt-4.1-mini",
+		},
+		"gpt-4o-mini": {
+			upgradeTarget: "gpt-4o",
 		},
 		"gpt-4-turbo": {
 			deprecation: &DeprecationRule{
@@ -99,6 +115,9 @@ func decorateModelDepth(entries []ModelEntry) {
 		}
 		if extra.deprecation != nil {
 			entries[index].Deprecation = extra.deprecation.Clone()
+		}
+		if extra.upgradeTarget != "" {
+			entries[index].UpgradeTargetID = extra.upgradeTarget
 		}
 	}
 }

--- a/internal/modelregistry/catalog_test.go
+++ b/internal/modelregistry/catalog_test.go
@@ -216,6 +216,49 @@ func reasoningEffortAllowedIn(efforts []ReasoningEffort, want ReasoningEffort) b
 	return false
 }
 
+func TestDefaultRegistryUpgradeTargets(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry returned error: %v", err)
+	}
+
+	// Seeded escalation chains across the concrete catalog ids.
+	chains := map[string]string{
+		"claude-haiku-4.5":      "claude-sonnet-4.5",
+		"claude-sonnet-4.5":     "claude-opus-4.1",
+		"gpt-4.1-mini":          "gpt-4.1",
+		"gpt-4.1-nano":          "gpt-4.1-mini",
+		"gpt-4o-mini":           "gpt-4o",
+		"gemini-2.5-flash-lite": "gemini-2.5-flash",
+		"gemini-2.5-flash":      "gemini-2.5-pro",
+	}
+	for source, want := range chains {
+		target, ok := registry.UpgradeTarget(source)
+		if !ok {
+			t.Fatalf("UpgradeTarget(%q) returned no target, want %q", source, want)
+		}
+		if target.ID != want {
+			t.Fatalf("UpgradeTarget(%q) = %q, want %q", source, target.ID, want)
+		}
+	}
+
+	// Top-tier models declare no escalation target.
+	for _, topTier := range []string{"claude-opus-4.1", "gpt-4.1", "gemini-2.5-pro"} {
+		if target, ok := registry.UpgradeTarget(topTier); ok {
+			t.Fatalf("top-tier model %q should have no upgrade target, got %q", topTier, target.ID)
+		}
+	}
+
+	// The seeded field is present on the decorated entry, not only via the method.
+	haiku, err := registry.Require("claude-haiku-4.5")
+	if err != nil {
+		t.Fatalf("Require(claude-haiku-4.5) returned error: %v", err)
+	}
+	if haiku.UpgradeTargetID != "claude-sonnet-4.5" {
+		t.Fatalf("claude-haiku-4.5 UpgradeTargetID = %q, want claude-sonnet-4.5", haiku.UpgradeTargetID)
+	}
+}
+
 func containsModelID(models []ModelEntry, id string) bool {
 	for _, model := range models {
 		if model.ID == id {

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -346,6 +346,18 @@ func NewRegistry(entries []ModelEntry) (Registry, error) {
 			return Registry{}, fmt.Errorf("model %q deprecation fallback %q does not resolve to a known model", entry.ID, fallbackID)
 		}
 	}
+	// A non-empty UpgradeTargetID must resolve to a known model. Otherwise
+	// UpgradeTarget would silently disable escalation at runtime (a catalog typo)
+	// instead of failing loudly here — mirroring the deprecation fallback check.
+	for _, entry := range registry.models {
+		targetID := strings.TrimSpace(entry.UpgradeTargetID)
+		if targetID == "" {
+			continue
+		}
+		if _, ok := registry.Get(targetID); !ok {
+			return Registry{}, fmt.Errorf("model %q upgrade target %q does not resolve to a known model", entry.ID, targetID)
+		}
+	}
 	return registry, nil
 }
 

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -96,7 +96,11 @@ type ModelEntry struct {
 	MatchPatterns []string
 	// Deprecation, when set, redirects this model to a replacement.
 	Deprecation *DeprecationRule
-	Description string
+	// UpgradeTargetID, when set, names the stronger model this one escalates to
+	// during mid-run escalation. Empty means no escalation target (e.g. top-tier
+	// models). Resolved and availability-checked by Registry.UpgradeTarget.
+	UpgradeTargetID string
+	Description     string
 }
 
 // DeprecationRule describes how a deprecated model is phased out and what to use

--- a/internal/modelregistry/upgrade.go
+++ b/internal/modelregistry/upgrade.go
@@ -1,0 +1,28 @@
+package modelregistry
+
+import "strings"
+
+// UpgradeTarget resolves the stronger model that id escalates to during mid-run
+// escalation. It resolves id to a concrete entry, reads its UpgradeTargetID,
+// resolves THAT to a concrete entry, and returns it only when the target is
+// available and not deprecated. It returns (_, false) when id is unknown, has no
+// configured target, or the target resolves to an unavailable/deprecated model.
+// Pure and registry-only: applies no deprecation fallback redirection.
+func (registry Registry) UpgradeTarget(id string) (ModelEntry, bool) {
+	source, ok := registry.Resolve(id)
+	if !ok {
+		return ModelEntry{}, false
+	}
+	targetID := strings.TrimSpace(source.UpgradeTargetID)
+	if targetID == "" {
+		return ModelEntry{}, false
+	}
+	target, ok := registry.Resolve(targetID)
+	if !ok {
+		return ModelEntry{}, false
+	}
+	if target.Status == ModelStatusDeprecated {
+		return ModelEntry{}, false
+	}
+	return target, true
+}

--- a/internal/modelregistry/upgrade_test.go
+++ b/internal/modelregistry/upgrade_test.go
@@ -1,6 +1,9 @@
 package modelregistry
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // upgradeEntry builds a minimal valid active entry with an upgrade target set.
 func upgradeEntry(id, alias, upgradeTargetID string) ModelEntry {
@@ -21,10 +24,7 @@ func upgradeTestRegistry(t *testing.T) Registry {
 	retired.Status = ModelStatusDeprecated
 	retired.Deprecation = &DeprecationRule{FallbackID: "claude-opus-4-1", WarningMsg: "retired"}
 
-	// A model whose target id does not resolve to any entry.
-	dangling := upgradeEntry("dangling-mini", "dangling-m", "does-not-exist")
-
-	reg, err := NewRegistry([]ModelEntry{haiku, sonnet, opus, legacy, retired, dangling})
+	reg, err := NewRegistry([]ModelEntry{haiku, sonnet, opus, legacy, retired})
 	if err != nil {
 		t.Fatalf("NewRegistry returned error: %v", err)
 	}
@@ -69,10 +69,17 @@ func TestUpgradeTargetDeprecatedTargetRejected(t *testing.T) {
 	}
 }
 
-func TestUpgradeTargetDanglingTargetRejected(t *testing.T) {
-	reg := upgradeTestRegistry(t)
-	if _, ok := reg.UpgradeTarget("dangling-mini"); ok {
-		t.Fatal("unresolvable target id should not yield an upgrade target")
+func TestNewRegistryRejectsDanglingUpgradeTarget(t *testing.T) {
+	// A non-empty UpgradeTargetID that does not resolve to a known model is a
+	// catalog typo; NewRegistry must fail loudly rather than silently disabling
+	// escalation at runtime (mirrors the deprecation-fallback validation).
+	dangling := upgradeEntry("dangling-mini", "dangling-m", "does-not-exist")
+	_, err := NewRegistry([]ModelEntry{dangling})
+	if err == nil {
+		t.Fatal("NewRegistry should reject an unresolvable upgrade target")
+	}
+	if !strings.Contains(err.Error(), "upgrade target") {
+		t.Fatalf("error %q should mention the upgrade target", err.Error())
 	}
 }
 

--- a/internal/modelregistry/upgrade_test.go
+++ b/internal/modelregistry/upgrade_test.go
@@ -1,0 +1,92 @@
+package modelregistry
+
+import "testing"
+
+// upgradeEntry builds a minimal valid active entry with an upgrade target set.
+func upgradeEntry(id, alias, upgradeTargetID string) ModelEntry {
+	entry := mkEntry(id, alias)
+	entry.UpgradeTargetID = upgradeTargetID
+	return entry
+}
+
+func upgradeTestRegistry(t *testing.T) Registry {
+	t.Helper()
+	haiku := upgradeEntry("claude-haiku-4-5", "haiku-4.5", "claude-sonnet-4-5")
+	sonnet := upgradeEntry("claude-sonnet-4-5", "sonnet-4.5", "claude-opus-4-1")
+	opus := mkEntry("claude-opus-4-1", "opus-4.1") // top-tier: no UpgradeTargetID
+
+	// A model whose target points at a deprecated entry must not escalate.
+	legacy := upgradeEntry("legacy-mini", "legacy-m", "legacy-retired")
+	retired := mkEntry("legacy-retired", "legacy-r")
+	retired.Status = ModelStatusDeprecated
+	retired.Deprecation = &DeprecationRule{FallbackID: "claude-opus-4-1", WarningMsg: "retired"}
+
+	// A model whose target id does not resolve to any entry.
+	dangling := upgradeEntry("dangling-mini", "dangling-m", "does-not-exist")
+
+	reg, err := NewRegistry([]ModelEntry{haiku, sonnet, opus, legacy, retired, dangling})
+	if err != nil {
+		t.Fatalf("NewRegistry returned error: %v", err)
+	}
+	return reg
+}
+
+func TestUpgradeTargetResolvesConcreteEntry(t *testing.T) {
+	reg := upgradeTestRegistry(t)
+
+	target, ok := reg.UpgradeTarget("claude-haiku-4-5")
+	if !ok {
+		t.Fatal("haiku should escalate to its upgrade target")
+	}
+	if target.ID != "claude-sonnet-4-5" {
+		t.Fatalf("UpgradeTarget(haiku) = %q, want claude-sonnet-4-5", target.ID)
+	}
+
+	// Resolution should also work through an alias for the source model.
+	if target, ok := reg.UpgradeTarget("sonnet-4.5"); !ok || target.ID != "claude-opus-4-1" {
+		t.Fatalf("UpgradeTarget(sonnet alias) = %q/%v, want claude-opus-4-1/true", target.ID, ok)
+	}
+}
+
+func TestUpgradeTargetTopTierHasNone(t *testing.T) {
+	reg := upgradeTestRegistry(t)
+	if target, ok := reg.UpgradeTarget("claude-opus-4-1"); ok {
+		t.Fatalf("top-tier model should have no upgrade target, got %q", target.ID)
+	}
+}
+
+func TestUpgradeTargetUnknownSource(t *testing.T) {
+	reg := upgradeTestRegistry(t)
+	if _, ok := reg.UpgradeTarget("not-a-real-model"); ok {
+		t.Fatal("unknown source model should not yield an upgrade target")
+	}
+}
+
+func TestUpgradeTargetDeprecatedTargetRejected(t *testing.T) {
+	reg := upgradeTestRegistry(t)
+	if target, ok := reg.UpgradeTarget("legacy-mini"); ok {
+		t.Fatalf("deprecated target should be rejected, got %q", target.ID)
+	}
+}
+
+func TestUpgradeTargetDanglingTargetRejected(t *testing.T) {
+	reg := upgradeTestRegistry(t)
+	if _, ok := reg.UpgradeTarget("dangling-mini"); ok {
+		t.Fatal("unresolvable target id should not yield an upgrade target")
+	}
+}
+
+func TestUpgradeTargetReturnsIndependentCopy(t *testing.T) {
+	reg := upgradeTestRegistry(t)
+	target, ok := reg.UpgradeTarget("claude-haiku-4-5")
+	if !ok {
+		t.Fatal("haiku should escalate")
+	}
+	target.Aliases = append(target.Aliases, "mutated")
+	again, _ := reg.UpgradeTarget("claude-haiku-4-5")
+	for _, alias := range again.Aliases {
+		if alias == "mutated" {
+			t.Fatal("UpgradeTarget must return a defensive copy, not a shared entry")
+		}
+	}
+}

--- a/internal/sandbox/normalize.go
+++ b/internal/sandbox/normalize.go
@@ -48,7 +48,7 @@ func NormalizePermission(value Permission) Permission {
 func NormalizeSideEffect(value SideEffect) SideEffect {
 	normalized := SideEffect(strings.ToLower(strings.TrimSpace(string(value))))
 	switch normalized {
-	case SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectOutOfWorkspace:
+	case SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectOutOfWorkspace, SideEffectNone:
 		return normalized
 	default:
 		return SideEffectOutOfWorkspace

--- a/internal/sandbox/normalize_test.go
+++ b/internal/sandbox/normalize_test.go
@@ -30,3 +30,13 @@ func TestAutonomyAllowedNormalizesBothOperands(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeSideEffectPreservesNone(t *testing.T) {
+	if got := NormalizeSideEffect(SideEffectNone); got != SideEffectNone {
+		t.Fatalf("NormalizeSideEffect(none) = %q, want none (must not collapse to out_of_workspace)", got)
+	}
+	// An unrecognized value still fails closed to out_of_workspace.
+	if got := NormalizeSideEffect(SideEffect("bogus")); got != SideEffectOutOfWorkspace {
+		t.Fatalf("NormalizeSideEffect(bogus) = %q, want out_of_workspace", got)
+	}
+}

--- a/internal/sandbox/risk.go
+++ b/internal/sandbox/risk.go
@@ -83,6 +83,9 @@ func Classify(request Request) Risk {
 		add("network", RiskHigh)
 	case SideEffectOutOfWorkspace:
 		add("out_of_workspace", RiskCritical)
+	case SideEffectNone:
+		// Control-only tool (e.g. escalate_model): no read/write/shell/network
+		// effect, so it contributes no side-effect risk category and stays low.
 	}
 
 	// The bash tool accepts the command under any of these aliases; resolve the

--- a/internal/sandbox/risk_hardening_test.go
+++ b/internal/sandbox/risk_hardening_test.go
@@ -219,3 +219,13 @@ func TestClassifyRmLongFlagRootQuotedAndSeparator(t *testing.T) {
 		}
 	}
 }
+
+func TestClassifyNoneSideEffectIsLowRisk(t *testing.T) {
+	risk := Classify(Request{ToolName: "escalate_model", SideEffect: SideEffectNone})
+	if risk.Level != RiskLow {
+		t.Fatalf("none side-effect risk level = %s, want low", risk.Level)
+	}
+	if HasRiskCategory(risk, "out_of_workspace") {
+		t.Fatalf("control-only tool must not classify as out_of_workspace: %#v", risk)
+	}
+}

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -22,6 +22,10 @@ const (
 	SideEffectShell          SideEffect = "shell"
 	SideEffectNetwork        SideEffect = "network"
 	SideEffectOutOfWorkspace SideEffect = "out_of_workspace"
+	// SideEffectNone marks a control-only tool that performs no read/write/
+	// shell/network effect (e.g. escalate_model). It must be recognized so it is
+	// not normalized to out_of_workspace and falsely classified as critical.
+	SideEffectNone SideEffect = "none"
 )
 
 const (

--- a/internal/tools/escalate_model.go
+++ b/internal/tools/escalate_model.go
@@ -74,8 +74,9 @@ func (tool escalateModelTool) Run(ctx context.Context, args map[string]any) Resu
 // result. Status is OK either way (a "no escalation" outcome is not an error).
 func (tool escalateModelTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
 	// reason is optional and used only for transcript context; reject a non-string
-	// value but never require it.
-	if _, err := stringArg(args, "reason", "", false); err != nil {
+	// value but accept an absent OR explicitly empty string (allowEmpty) — reason
+	// is informational, so an empty reason must never fail the escalation.
+	if _, err := stringArgWithEmpty(args, "reason", "", false, true); err != nil {
 		return errorResult("Error: Invalid arguments for escalate_model: " + err.Error())
 	}
 

--- a/internal/tools/escalate_model.go
+++ b/internal/tools/escalate_model.go
@@ -1,0 +1,97 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+)
+
+// escalateToModelMetaKey is the result-metadata key the agent loop reads to
+// perform a mid-run model switch. The tool itself stays pure: it validates the
+// upgrade target and signals it here; the loop owns the provider swap.
+const escalateToModelMetaKey = "escalate_to_model"
+
+// escalateModelTool lets the agent escalate the current model to its configured
+// stronger upgrade target for the rest of the run. It is a control action: it
+// performs no read/write/shell/network effect and only signals the target via
+// result metadata. The agent loop wires the actual provider switch.
+type escalateModelTool struct {
+	baseTool
+	registry modelregistry.Registry
+}
+
+// NewEscalateModelTool builds the tool with the default model registry. If the
+// default registry cannot be built the tool degrades gracefully: every run then
+// reports "no escalation available" rather than failing.
+func NewEscalateModelTool() Tool {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		registry = modelregistry.Registry{}
+	}
+	return newEscalateModelTool(registry)
+}
+
+// newEscalateModelTool builds the tool with an explicit registry (used by the
+// exec wiring and tests so escalation resolves against the same catalog the run
+// uses).
+func newEscalateModelTool(registry modelregistry.Registry) escalateModelTool {
+	return escalateModelTool{
+		baseTool: baseTool{
+			name:        "escalate_model",
+			description: "Escalate the current model to its stronger upgrade target for the rest of this run. Use when the task is harder than expected. No effect if already on the strongest available model.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"reason": {
+						Type:        "string",
+						Description: "Optional short note on why a stronger model is needed (recorded for transcript context only).",
+					},
+				},
+				Required:             []string{},
+				AdditionalProperties: false,
+			},
+			safety: Safety{
+				SideEffect:      SideEffectNone,
+				Permission:      PermissionAllow,
+				Reason:          "Requests a mid-run switch to a stronger model; the agent loop performs the switch.",
+				AdvertiseInAuto: true,
+			},
+		},
+		registry: registry,
+	}
+}
+
+// Run satisfies the Tool interface for callers that do not supply RunOptions; it
+// has no current model to escalate from, so it reports no escalation. The real
+// path is RunWithOptions, which the registry invokes when RunOptions are present.
+func (tool escalateModelTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.RunWithOptions(ctx, args, RunOptions{})
+}
+
+// RunWithOptions reads the current model from options.Model, looks up its upgrade
+// target, and either signals the target via Meta or returns an informational
+// result. Status is OK either way (a "no escalation" outcome is not an error).
+func (tool escalateModelTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
+	// reason is optional and used only for transcript context; reject a non-string
+	// value but never require it.
+	if _, err := stringArg(args, "reason", "", false); err != nil {
+		return errorResult("Error: Invalid arguments for escalate_model: " + err.Error())
+	}
+
+	current := options.Model
+	target, ok := tool.registry.UpgradeTarget(current)
+	if !ok {
+		label := current
+		if label == "" {
+			label = "current model"
+		}
+		return okResult(fmt.Sprintf("Already using the strongest available model (%s); no escalation performed.", label))
+	}
+
+	return Result{
+		Status: StatusOK,
+		Output: fmt.Sprintf("Escalating from %s to %s for the rest of this run.", current, target.ID),
+		Meta:   map[string]string{escalateToModelMetaKey: target.ID},
+	}
+}

--- a/internal/tools/escalate_model_test.go
+++ b/internal/tools/escalate_model_test.go
@@ -82,6 +82,40 @@ func TestEscalateModelRunSignalsTarget(t *testing.T) {
 	}
 }
 
+// An explicitly empty reason (and an absent reason) is accepted: reason is
+// informational only, so it must never fail the escalation. Both forms still
+// return the escalation result with the target signalled via Meta.
+func TestEscalateModelRunAcceptsEmptyReason(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	target, ok := registry.UpgradeTarget("claude-haiku-4.5")
+	if !ok {
+		t.Skip("catalog has no upgrade target seeded for claude-haiku-4.5")
+	}
+	tool := newEscalateModelTool(registry)
+
+	cases := []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "explicit empty reason", args: map[string]any{"reason": ""}},
+		{name: "absent reason", args: map[string]any{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := tool.RunWithOptions(context.Background(), tc.args, RunOptions{Model: "claude-haiku-4.5"})
+			if res.Status != StatusOK {
+				t.Fatalf("status = %q output = %q, want ok (empty reason must not error)", res.Status, res.Output)
+			}
+			if got := res.Meta["escalate_to_model"]; got != target.ID {
+				t.Fatalf("meta escalate_to_model = %q, want %q", got, target.ID)
+			}
+		})
+	}
+}
+
 // A top-tier model (no upgrade target), an unknown model, and an empty model all
 // produce an informational, no-meta, OK result — the loop must not switch.
 func TestEscalateModelRunNoTarget(t *testing.T) {

--- a/internal/tools/escalate_model_test.go
+++ b/internal/tools/escalate_model_test.go
@@ -1,0 +1,165 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+)
+
+func TestEscalateModelToolMetadata(t *testing.T) {
+	tool := NewEscalateModelTool()
+
+	if tool.Name() != "escalate_model" {
+		t.Fatalf("name = %q, want escalate_model", tool.Name())
+	}
+	if tool.Description() == "" {
+		t.Fatal("description must not be empty")
+	}
+
+	safety := tool.Safety()
+	if safety.SideEffect != SideEffectNone {
+		t.Fatalf("side effect = %q, want none", safety.SideEffect)
+	}
+	if safety.Permission != PermissionAllow {
+		t.Fatalf("permission = %q, want allow", safety.Permission)
+	}
+	if !safety.AdvertiseInAuto {
+		t.Fatal("escalate_model must advertise in auto")
+	}
+
+	schema := tool.Parameters()
+	if schema.Type != "object" {
+		t.Fatalf("schema type = %q, want object", schema.Type)
+	}
+	if schema.AdditionalProperties {
+		t.Fatal("schema must disallow additional properties")
+	}
+	if len(schema.Required) != 0 {
+		t.Fatalf("escalate_model must have no required args, got %v", schema.Required)
+	}
+	if _, ok := schema.Properties["reason"]; !ok {
+		t.Fatal("schema must advertise an optional reason property")
+	}
+}
+
+// A non-string reason argument is a soft error, not a panic.
+func TestEscalateModelToolRejectsNonStringReason(t *testing.T) {
+	tool := NewEscalateModelTool()
+	res := tool.Run(context.Background(), map[string]any{"reason": 42})
+	if res.Status != StatusError {
+		t.Fatalf("status = %q, want error for non-string reason", res.Status)
+	}
+}
+
+// Resolving against the real catalog: a known mid-tier model escalates to its
+// configured stronger target and signals it via Meta["escalate_to_model"].
+func TestEscalateModelRunSignalsTarget(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	want, ok := registry.UpgradeTarget("claude-haiku-4.5")
+	if !ok {
+		t.Skip("catalog has no upgrade target seeded for claude-haiku-4.5")
+	}
+
+	tool := newEscalateModelTool(registry)
+	res := tool.RunWithOptions(context.Background(), map[string]any{"reason": "task is harder than expected"}, RunOptions{Model: "claude-haiku-4.5"})
+
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+	if got := res.Meta["escalate_to_model"]; got != want.ID {
+		t.Fatalf("meta escalate_to_model = %q, want %q", got, want.ID)
+	}
+	if !strings.Contains(res.Output, "claude-haiku-4.5") || !strings.Contains(res.Output, want.ID) {
+		t.Fatalf("output should name both models, got %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "Escalating") {
+		t.Fatalf("output should announce escalation, got %q", res.Output)
+	}
+}
+
+// A top-tier model (no upgrade target), an unknown model, and an empty model all
+// produce an informational, no-meta, OK result — the loop must not switch.
+func TestEscalateModelRunNoTarget(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	tool := newEscalateModelTool(registry)
+
+	cases := []struct {
+		name      string
+		model     string
+		wantInOut string
+	}{
+		{name: "top-tier", model: "claude-opus-4.1", wantInOut: "claude-opus-4.1"},
+		{name: "unknown", model: "not-a-real-model", wantInOut: "not-a-real-model"},
+		{name: "empty", model: "", wantInOut: "current model"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := tool.RunWithOptions(context.Background(), map[string]any{}, RunOptions{Model: tc.model})
+
+			if res.Status != StatusOK {
+				t.Fatalf("status = %q, want ok", res.Status)
+			}
+			if _, ok := res.Meta["escalate_to_model"]; ok {
+				t.Fatalf("no-target result must carry no escalate_to_model meta, got %v", res.Meta)
+			}
+			if !strings.Contains(res.Output, "no escalation performed") {
+				t.Fatalf("output should be informational, got %q", res.Output)
+			}
+			if !strings.Contains(res.Output, tc.wantInOut) {
+				t.Fatalf("output should name %q, got %q", tc.wantInOut, res.Output)
+			}
+		})
+	}
+}
+
+// Sanity: the empty-args path (no reason) is valid and does not switch when on a
+// top-tier model.
+func TestEscalateModelRunDefaultsToNoEscalation(t *testing.T) {
+	tool := newEscalateModelTool(modelregistry.Registry{})
+	res := tool.RunWithOptions(context.Background(), map[string]any{}, RunOptions{Model: "claude-opus-4.1"})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q, want ok", res.Status)
+	}
+	if len(res.Meta) != 0 {
+		t.Fatalf("empty registry must never signal a target, got meta %v", res.Meta)
+	}
+}
+
+// End-to-end through the Registry: RunWithOptions must route to the tool's
+// optionsAwareTool branch (threading options.Model) and, because the tool is
+// PermissionAllow, run without a permission grant.
+func TestEscalateModelThroughRegistryDispatch(t *testing.T) {
+	modelReg, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	target, ok := modelReg.UpgradeTarget("claude-haiku-4.5")
+	if !ok {
+		t.Skip("catalog has no upgrade target seeded for claude-haiku-4.5")
+	}
+
+	reg := NewRegistry()
+	reg.Register(newEscalateModelTool(modelReg))
+
+	res := reg.RunWithOptions(context.Background(), "escalate_model", map[string]any{}, RunOptions{
+		Model: "claude-haiku-4.5",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %q output = %q", res.Status, res.Output)
+	}
+	if got := res.Meta["escalate_to_model"]; got != target.ID {
+		t.Fatalf("meta escalate_to_model = %q, want %q", got, target.ID)
+	}
+	if !strings.Contains(res.Output, target.ID) {
+		t.Fatalf("output should name target %q, got %q", target.ID, res.Output)
+	}
+}

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -16,6 +16,10 @@ const (
 	SideEffectShell          SideEffect = "shell"
 	SideEffectNetwork        SideEffect = "network"
 	SideEffectOutOfWorkspace SideEffect = "out_of_workspace"
+	// SideEffectNone marks a control-only tool that performs no read/write/shell/
+	// network/out-of-workspace effect (e.g. escalate_model, whose only effect is a
+	// loop-level model switch the agent loop performs).
+	SideEffectNone SideEffect = "none"
 )
 
 const (

--- a/internal/tools/types_test.go
+++ b/internal/tools/types_test.go
@@ -1,0 +1,19 @@
+package tools
+
+import "testing"
+
+// SideEffectNone marks a control-only tool (no read/write/shell/network/
+// out-of-workspace effect). escalate_model is its first consumer.
+func TestSideEffectNoneConstant(t *testing.T) {
+	if SideEffectNone != "none" {
+		t.Fatalf("SideEffectNone = %q, want %q", SideEffectNone, "none")
+	}
+	// It must be distinct from every existing side-effect value.
+	for _, other := range []SideEffect{
+		SideEffectRead, SideEffectWrite, SideEffectShell, SideEffectNetwork, SideEffectOutOfWorkspace,
+	} {
+		if SideEffectNone == other {
+			t.Fatalf("SideEffectNone collides with existing side effect %q", other)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Lets the agent **escalate to a stronger model mid-run** by calling an `escalate_model` tool, gated behind `zero exec --allow-escalation`. The agent loop rebuilds the provider on the escalation target for the rest of the run. Strictly additive — with the flag off, no tool is registered and the model switcher is nil, so a run is byte-identical to today. No new module dependencies.

- **Registry upgrade map** (`internal/modelregistry`): `ModelEntry.UpgradeTargetID` + `Registry.UpgradeTarget(id)` — resolves each model's stronger target (e.g. `claude-haiku-4.5→claude-sonnet-4.5`, `claude-sonnet-4.5→claude-opus-4.1`, `gpt-4.1-mini→gpt-4.1`, `gemini-2.5-flash→gemini-2.5-pro`), returning it only if available and not deprecated. Top-tier models have no target.
- **Agent loop switch** (`internal/agent`): `Options.ModelSwitcher` + a typed `ToolResult.RequestedModel` (lifted from the tool's `Meta["escalate_to_model"]`). The turn loop performs the switch **at most once per turn**, after the turn's tool-results are recorded (transcript stays replay-valid); reassigns the provider and updates `options.Model` so subsequent turns, context sizing, and usage attribution follow. `nil` switcher ⇒ ignored; switcher error ⇒ transcript note + continue (non-fatal); `(nil,nil)` ⇒ no-op.
- **The tool** (`internal/tools/escalate_model.go`): `escalate_model` (`SideEffectNone`/`PermissionAllow`/`AdvertiseInAuto`), **no arbitrary-model arg** — escalates the *current* model to its `UpgradeTarget`, or returns an informational "already at the strongest available model" result with no switch.
- **Exec wiring** (`internal/cli`): `--allow-escalation` registers the tool and wires the `ModelSwitcher` (rebuilds via the resolved profile with `Model` overridden); post-switch usage events are attributed to the escalated model.

The source's proprietary auto-router half is dropped entirely; all naming is brand-neutral.

## Test Plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` green (new tests in `modelregistry`, `agent`, `tools`, `cli`)
- [x] `go test -race ./internal/{modelregistry,agent,tools,cli}/...` green
- [x] `GOOS=windows GOARCH=amd64 go build ./...` green

### Reviewer focus
- **Flag-off byte-identical:** without `--allow-escalation`, the tool isn't registered and the switcher is nil (mutation-tested: a usage event gains no `"model"` key, the provider builds exactly once).
- **The switch is real:** the post-switch turn streams from the rebuilt provider (mutation-tested — dropping `provider = newProvider` fails the test), and pre/post-switch usage is attributed to the original/escalated model respectively.
- **Cost:** escalation is opt-in (flag) and capped at one switch per turn; the agent can only escalate along the curated registry map (no arbitrary model).

### Known limitation (documented, deferred)
On a mid-run switch, the compaction context-window threshold isn't yet updated to the new model's window (compaction sizes against the original model's window — a conservative approximation). A follow-up can thread the new window through the `ModelSwitcher` contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mid-run model escalation: agents can request and switch to stronger models during a run when enabled.

* **CLI**
  * New --allow-escalation flag to opt into escalation; CLI wires conditional switching and model-aware usage attribution.

* **Model Registry**
  * Registry declares and resolves upgrade targets and chains; top-tier and deprecated targets handled.

* **Tools**
  * New escalate_model control tool to request escalation; new control-only side-effect value.

* **Behavior**
  * Escalation failures are non-fatal; at most one switch per turn; no-op for top-tier/no-target models.

* **Tests**
  * Extensive tests covering escalation flows, attribution, validation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->