### PR TITLE
Sound / completion notifier: terminal bell + OSC-9 on turn completion & awaiting-input

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -368,6 +368,7 @@ func runInteractiveTUIWithSkin(stderr io.Writer, deps appDeps, skin string, perm
 		PermissionMode: permissionMode,
 		Skin:           skin,
 		ThemeDark:      true,
+		Notify:         resolved.Notify,
 	})
 }
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -523,6 +523,9 @@ Flags:
       --init-session-id <id>         Create a new exec session with this id
       --skip-permissions-unsafe      Allow prompt-gated tools without approval
       --allow-escalation             Let the agent escalate to a stronger model mid-run via escalate_model
+      --notify <off|bell|notify|both>
+                                    Override notification mode for this run
+      --no-notify                   Disable notifications for this run
 `)
 	return err
 }

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -301,6 +301,13 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if err != nil {
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "provider_error", err.Error())
 	}
+	// Notify on completion via stderr (never stdout, which may carry stream-json).
+	// Headless has no terminal-focus signal, so focus gating does not apply here:
+	// always emit when a mode is configured (focusMode is a TUI-only concept).
+	notifier := notify.New(stderr, notify.Config{
+		Mode:      notify.Mode(strings.TrimSpace(execNotifyMode(options, resolved))),
+		FocusMode: notify.FocusAlways,
+	})
 	if options.useSpec {
 		return runExecSpecDraft(execSpecDraftRun{
 			options:            options,
@@ -319,6 +326,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			images:             images,
 			reasoningEffort:    runReasoningEffort,
 			specPermissionMode: permissionMode,
+			notifier:           notifier,
 		})
 	}
 
@@ -381,14 +389,6 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	sessionRecorder.append(sessions.EventMessage, map[string]any{
 		"role":    "user",
 		"content": prompt,
-	})
-
-	// Build the completion notifier targeting stderr so it never pollutes stdout
-	// (which may carry stream-json). The notifier fires once after agent.Run
-	// returns regardless of success or error.
-	notifier := notify.New(stderr, notify.Config{
-		Mode:      notify.Mode(strings.TrimSpace(execNotifyMode(options, resolved))),
-		FocusMode: notify.FocusMode(strings.TrimSpace(resolved.Notify.FocusMode)),
 	})
 
 	// OnAskUser is intentionally left unset: headless runs have no interactive

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/imageinput"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -88,6 +89,11 @@ type execOptions struct {
 	// default — a run without the flag is byte-identical to before (no tool, nil
 	// switcher).
 	allowEscalation bool
+	// notifyMode overrides config.Notify.Mode for this run. Mutually exclusive
+	// with noNotify.
+	notifyMode string
+	// noNotify forces ModeOff for this run. Mutually exclusive with notifyMode.
+	noNotify bool
 }
 
 type execUsageError struct {
@@ -377,6 +383,14 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		"content": prompt,
 	})
 
+	// Build the completion notifier targeting stderr so it never pollutes stdout
+	// (which may carry stream-json). The notifier fires once after agent.Run
+	// returns regardless of success or error.
+	notifier := notify.New(stderr, notify.Config{
+		Mode:      notify.Mode(strings.TrimSpace(execNotifyMode(options, resolved))),
+		FocusMode: notify.FocusMode(strings.TrimSpace(resolved.Notify.FocusMode)),
+	})
+
 	// OnAskUser is intentionally left unset: headless runs have no interactive
 	// user, so ask_user degrades to a "proceed with your best assumption" result
 	// rather than blocking. (Future enhancement: collect answers over stream-json
@@ -459,6 +473,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			sessionRecorder.append(sessions.EventUsage, payload)
 		},
 	})
+	notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
 	if writer.err != nil {
 		return exitCrash
 	}
@@ -843,4 +858,17 @@ func sessionPermissionEventType(event agent.PermissionEvent) sessions.EventType 
 		return sessions.EventPermissionDecision
 	}
 	return sessions.EventPermission
+}
+
+// execNotifyMode resolves the effective notification mode for a run:
+// --no-notify forces "off", --notify <mode> overrides config, otherwise the
+// config value is used.
+func execNotifyMode(options execOptions, resolved config.ResolvedConfig) string {
+	if options.noNotify {
+		return string(notify.ModeOff)
+	}
+	if options.notifyMode != "" {
+		return options.notifyMode
+	}
+	return resolved.Notify.Mode
 }

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -363,6 +363,13 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 	if options.noNotify && options.notifyMode != "" {
 		return options, false, execUsageError{"Use either --notify or --no-notify, not both."}
 	}
+	if options.notifyMode != "" {
+		switch options.notifyMode {
+		case "off", "bell", "notify", "both":
+		default:
+			return options, false, execUsageError{fmt.Sprintf("invalid --notify %q. Expected off, bell, notify, or both.", options.notifyMode)}
+		}
+	}
 	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
 		return options, false, execUsageError{"Use either --resume or --fork, not both."}
 	}

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -26,6 +26,21 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			options.listTools = true
 		case arg == "--allow-escalation":
 			options.allowEscalation = true
+		case arg == "--no-notify":
+			options.noNotify = true
+		case arg == "--notify":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.notifyMode = strings.TrimSpace(value)
+			index = next
+		case strings.HasPrefix(arg, "--notify="):
+			value, err := requiredInlineFlagValue(arg, "--notify")
+			if err != nil {
+				return options, false, err
+			}
+			options.notifyMode = value
 		case arg == "--auto":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -345,6 +360,9 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 		}
 	}
 
+	if options.noNotify && options.notifyMode != "" {
+		return options, false, execUsageError{"Use either --notify or --no-notify, not both."}
+	}
 	if (options.resume != "" || options.resumeLatest) && options.fork != "" {
 		return options, false, execUsageError{"Use either --resume or --fork, not both."}
 	}

--- a/internal/cli/exec_spec.go
+++ b/internal/cli/exec_spec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/specmode"
@@ -35,6 +36,7 @@ type execSpecDraftRun struct {
 	images             []zeroruntime.ImageBlock
 	reasoningEffort    string
 	specPermissionMode agent.PermissionMode
+	notifier           *notify.Notifier
 }
 
 type execSpecDraftInfo struct {
@@ -154,6 +156,7 @@ func runExecSpecDraft(run execSpecDraftRun) int {
 			})
 		},
 	})
+	run.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
 	if writer.err != nil {
 		return exitCrash
 	}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1773,6 +1773,45 @@ func TestRunExecSwitcherErrorKeepsOriginalModelAttribution(t *testing.T) {
 // agent calls escalate_model while ALREADY on a top-tier model (claude-opus-4.1):
 // the tool returns the informational no-meta result, NO switch happens
 // (newProvider is called exactly once), and the run succeeds.
+func TestParseExecNotifyFlag(t *testing.T) {
+	opts, _, err := parseExecArgs([]string{"--notify", "both", "hello"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if opts.notifyMode != "both" || opts.noNotify {
+		t.Fatalf("got mode=%q noNotify=%v", opts.notifyMode, opts.noNotify)
+	}
+}
+
+func TestParseExecNoNotifyFlag(t *testing.T) {
+	opts, _, err := parseExecArgs([]string{"--no-notify", "hello"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !opts.noNotify {
+		t.Fatal("expected noNotify=true")
+	}
+}
+
+func TestParseExecNotifyConflict(t *testing.T) {
+	if _, _, err := parseExecArgs([]string{"--notify", "bell", "--no-notify", "hi"}); err == nil {
+		t.Fatal("expected error for --notify with --no-notify")
+	}
+}
+
+func TestExecNotifyModeResolution(t *testing.T) {
+	resolved := config.ResolvedConfig{Notify: config.NotifyConfig{Mode: "bell"}}
+	if got := execNotifyMode(execOptions{}, resolved); got != "bell" {
+		t.Fatalf("config passthrough got %q", got)
+	}
+	if got := execNotifyMode(execOptions{notifyMode: "both"}, resolved); got != "both" {
+		t.Fatalf("flag override got %q", got)
+	}
+	if got := execNotifyMode(execOptions{noNotify: true}, resolved); got != "off" {
+		t.Fatalf("--no-notify got %q", got)
+	}
+}
+
 func TestRunExecTopTierDeclineNoSwitch(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1799,6 +1799,20 @@ func TestParseExecNotifyConflict(t *testing.T) {
 	}
 }
 
+func TestParseExecNotifyInvalidValue(t *testing.T) {
+	for _, arg := range [][]string{{"--notify", "buzz", "hi"}, {"--notify=loud", "hi"}} {
+		if _, _, err := parseExecArgs(arg); err == nil {
+			t.Fatalf("expected error for invalid notify value in %v", arg)
+		}
+	}
+	// Valid values still parse.
+	for _, mode := range []string{"off", "bell", "notify", "both"} {
+		if _, _, err := parseExecArgs([]string{"--notify", mode, "hi"}); err != nil {
+			t.Fatalf("valid --notify %s rejected: %v", mode, err)
+		}
+	}
+}
+
 func TestExecNotifyModeResolution(t *testing.T) {
 	resolved := config.ResolvedConfig{Notify: config.NotifyConfig{Mode: "bell"}}
 	if got := execNotifyMode(execOptions{}, resolved); got != "bell" {

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/sandbox"
 )
@@ -57,6 +58,20 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 			return ResolvedConfig{}, fmt.Errorf("invalid sandbox.maxAutonomy %q: expected low, medium, or high", maxAutonomy)
 		}
 	}
+	if mode := strings.TrimSpace(cfg.Notify.Mode); mode != "" {
+		switch notify.Mode(mode) {
+		case notify.ModeOff, notify.ModeBell, notify.ModeNotify, notify.ModeBoth:
+		default:
+			return ResolvedConfig{}, fmt.Errorf("invalid notify.mode %q: expected off, bell, notify, or both", mode)
+		}
+	}
+	if focusMode := strings.TrimSpace(cfg.Notify.FocusMode); focusMode != "" {
+		switch notify.FocusMode(focusMode) {
+		case notify.FocusUnfocused, notify.FocusAlways, notify.FocusFocused:
+		default:
+			return ResolvedConfig{}, fmt.Errorf("invalid notify.focusMode %q: expected unfocused, always, or focused", focusMode)
+		}
+	}
 
 	providers, active, err := normalizeProviders(cfg.Providers, cfg.ActiveProvider, options.Env)
 	if err != nil {
@@ -70,6 +85,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		MaxTurns:       cfg.MaxTurns,
 		MCP:            cfg.MCP,
 		Sandbox:        cfg.Sandbox,
+		Notify:         cfg.Notify,
 	}, nil
 }
 
@@ -117,6 +133,12 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	if maxAutonomy := strings.TrimSpace(src.Sandbox.MaxAutonomy); maxAutonomy != "" {
 		dst.Sandbox.MaxAutonomy = maxAutonomy
 	}
+	if mode := strings.TrimSpace(src.Notify.Mode); mode != "" {
+		dst.Notify.Mode = mode
+	}
+	if focusMode := strings.TrimSpace(src.Notify.FocusMode); focusMode != "" {
+		dst.Notify.FocusMode = focusMode
+	}
 }
 
 func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
@@ -136,6 +158,12 @@ func mergeProjectConfig(dst *FileConfig, src FileConfig) error {
 	mergeMCPConfig(&dst.MCP, src.MCP)
 	if maxAutonomy := strings.TrimSpace(src.Sandbox.MaxAutonomy); maxAutonomy != "" {
 		dst.Sandbox.MaxAutonomy = maxAutonomy
+	}
+	if mode := strings.TrimSpace(src.Notify.Mode); mode != "" {
+		dst.Notify.Mode = mode
+	}
+	if focusMode := strings.TrimSpace(src.Notify.FocusMode); focusMode != "" {
+		dst.Notify.FocusMode = focusMode
 	}
 	return nil
 }
@@ -440,6 +468,12 @@ func applyOverrides(cfg *FileConfig, overrides Overrides) {
 	}
 	if maxAutonomy := strings.TrimSpace(overrides.Sandbox.MaxAutonomy); maxAutonomy != "" {
 		cfg.Sandbox.MaxAutonomy = maxAutonomy
+	}
+	if mode := strings.TrimSpace(overrides.Notify.Mode); mode != "" {
+		cfg.Notify.Mode = mode
+	}
+	if focusMode := strings.TrimSpace(overrides.Notify.FocusMode); focusMode != "" {
+		cfg.Notify.FocusMode = focusMode
 	}
 	for _, provider := range overrides.Providers {
 		mergeProvider(cfg, provider)

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1284,6 +1284,42 @@ func TestResolveSandboxMaxAutonomyValidResolves(t *testing.T) {
 	}
 }
 
+func TestResolveNotifyValid(t *testing.T) {
+	path := writeConfig(t, `{"notify":{"mode":"both","focusMode":"always"}}`)
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.Notify.Mode != "both" || resolved.Notify.FocusMode != "always" {
+		t.Fatalf("got %+v", resolved.Notify)
+	}
+}
+
+func TestResolveNotifyInvalidMode(t *testing.T) {
+	path := writeConfig(t, `{"notify":{"mode":"buzz"}}`)
+	if _, err := Resolve(ResolveOptions{UserConfigPath: path}); err == nil {
+		t.Fatal("expected error for invalid notify.mode")
+	}
+}
+
+func TestResolveNotifyInvalidFocusMode(t *testing.T) {
+	path := writeConfig(t, `{"notify":{"focusMode":"sideways"}}`)
+	if _, err := Resolve(ResolveOptions{UserConfigPath: path}); err == nil {
+		t.Fatal("expected error for invalid notify.focusMode")
+	}
+}
+
+func TestResolveNotifyDefaultEmpty(t *testing.T) {
+	path := writeConfig(t, `{}`)
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if resolved.Notify.Mode != "" || resolved.Notify.FocusMode != "" {
+		t.Fatalf("unset notify should be empty, got %+v", resolved.Notify)
+	}
+}
+
 func writeConfig(t *testing.T, body string) string {
 	t.Helper()
 

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1286,7 +1286,7 @@ func TestResolveSandboxMaxAutonomyValidResolves(t *testing.T) {
 
 func TestResolveNotifyValid(t *testing.T) {
 	path := writeConfig(t, `{"notify":{"mode":"both","focusMode":"always"}}`)
-	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -1297,21 +1297,21 @@ func TestResolveNotifyValid(t *testing.T) {
 
 func TestResolveNotifyInvalidMode(t *testing.T) {
 	path := writeConfig(t, `{"notify":{"mode":"buzz"}}`)
-	if _, err := Resolve(ResolveOptions{UserConfigPath: path}); err == nil {
+	if _, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}}); err == nil {
 		t.Fatal("expected error for invalid notify.mode")
 	}
 }
 
 func TestResolveNotifyInvalidFocusMode(t *testing.T) {
 	path := writeConfig(t, `{"notify":{"focusMode":"sideways"}}`)
-	if _, err := Resolve(ResolveOptions{UserConfigPath: path}); err == nil {
+	if _, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}}); err == nil {
 		t.Fatal("expected error for invalid notify.focusMode")
 	}
 }
 
 func TestResolveNotifyDefaultEmpty(t *testing.T) {
 	path := writeConfig(t, `{}`)
-	resolved, err := Resolve(ResolveOptions{UserConfigPath: path})
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -58,12 +58,18 @@ type SandboxConfig struct {
 	MaxAutonomy string `json:"maxAutonomy,omitempty"`
 }
 
+type NotifyConfig struct {
+	Mode      string `json:"mode,omitempty"`
+	FocusMode string `json:"focusMode,omitempty"`
+}
+
 type FileConfig struct {
 	ActiveProvider string            `json:"activeProvider,omitempty"`
 	Providers      []ProviderProfile `json:"providers,omitempty"`
 	MaxTurns       int               `json:"maxTurns,omitempty"`
 	MCP            MCPConfig         `json:"mcp,omitempty"`
 	Sandbox        SandboxConfig     `json:"sandbox,omitempty"`
+	Notify         NotifyConfig      `json:"notify,omitempty"`
 }
 
 type ResolveOptions struct {
@@ -81,6 +87,7 @@ type Overrides struct {
 	MaxTurns       int
 	MCP            MCPConfig
 	Sandbox        SandboxConfig
+	Notify         NotifyConfig
 }
 
 type ResolvedConfig struct {
@@ -90,6 +97,7 @@ type ResolvedConfig struct {
 	MaxTurns       int
 	MCP            MCPConfig
 	Sandbox        SandboxConfig
+	Notify         NotifyConfig
 }
 
 type MCPConfig struct {
@@ -114,6 +122,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		MaxTurns        int                        `json:"maxTurns"`
 		MCP             MCPConfig                  `json:"mcp"`
 		Sandbox         SandboxConfig              `json:"sandbox"`
+		Notify          NotifyConfig               `json:"notify"`
 		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
 	}
@@ -127,6 +136,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.MaxTurns = raw.MaxTurns
 	cfg.MCP = raw.MCP
 	cfg.Sandbox = raw.Sandbox
+	cfg.Notify = raw.Notify
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,139 @@
+// Package notify emits dep-free terminal notifications (BEL and/or OSC-9
+// desktop notifications) when Zero finishes a turn or needs user input.
+package notify
+
+import (
+	"io"
+	"strings"
+	"sync"
+)
+
+// Mode selects the notification mechanism.
+type Mode string
+
+const (
+	ModeOff    Mode = "off"
+	ModeBell   Mode = "bell"
+	ModeNotify Mode = "notify" // OSC-9 desktop notification
+	ModeBoth   Mode = "both"
+)
+
+// FocusMode gates emission on terminal focus (a TUI concept).
+type FocusMode string
+
+const (
+	FocusUnfocused FocusMode = "unfocused" // default: only when terminal is NOT focused
+	FocusAlways    FocusMode = "always"
+	FocusFocused   FocusMode = "focused"
+)
+
+// Event is the moment that triggered a notification.
+type Event int
+
+const (
+	Completion Event = iota
+	AwaitingInput
+)
+
+// Config is the resolved notifier policy. Zero value (Mode=="") is silent.
+type Config struct {
+	Mode      Mode
+	FocusMode FocusMode
+}
+
+const maxMessageLen = 120
+
+// Notifier emits notifications to w according to cfg. Safe for concurrent use.
+type Notifier struct {
+	w   io.Writer
+	cfg Config // immutable after New; reads outside the lock are safe
+
+	mu      sync.Mutex
+	focused bool
+}
+
+// New returns a Notifier. focused defaults to false so a headless caller (no
+// focus signal) still emits under the default "unfocused" focus mode; an
+// interactive caller should call SetFocused(true) at launch.
+func New(w io.Writer, cfg Config) *Notifier {
+	return &Notifier{w: w, cfg: cfg}
+}
+
+// SetFocused records the terminal focus state (TUI FocusMsg/BlurMsg).
+func (n *Notifier) SetFocused(focused bool) {
+	n.mu.Lock()
+	n.focused = focused
+	n.mu.Unlock()
+}
+
+// Notify emits a notification for event if policy allows. message is the OSC-9
+// body (ignored for bell). Write errors are intentionally ignored — a failed
+// notification must never disrupt the run.
+func (n *Notifier) Notify(event Event, message string) {
+	if n.w == nil || n.cfg.Mode == ModeOff || n.cfg.Mode == "" {
+		return
+	}
+	seq := sequence(n.cfg.Mode, message)
+	if seq == "" {
+		return
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if !shouldEmit(n.cfg, event, n.focused) {
+		return
+	}
+	_, _ = io.WriteString(n.w, seq)
+}
+
+// DefaultMessage is the generic OSC-9 body for an event (no prompt content).
+func DefaultMessage(event Event) string {
+	if event == AwaitingInput {
+		return "Zero: needs input"
+	}
+	return "Zero: ready"
+}
+
+func shouldEmit(cfg Config, _ Event, focused bool) bool {
+	if cfg.Mode == ModeOff || cfg.Mode == "" {
+		return false
+	}
+	switch cfg.FocusMode {
+	case FocusAlways:
+		return true
+	case FocusFocused:
+		return focused
+	default: // FocusUnfocused, "", or unknown
+		return !focused
+	}
+}
+
+func sequence(mode Mode, message string) string {
+	switch mode {
+	case ModeBell:
+		return "\x07"
+	case ModeNotify:
+		return "\x1b]9;" + sanitizeMessage(message) + "\x07"
+	case ModeBoth:
+		return "\x07\x1b]9;" + sanitizeMessage(message) + "\x07"
+	default:
+		return ""
+	}
+}
+
+// sanitizeMessage drops control bytes (so the message can't break the escape or
+// inject terminal control) and clamps to maxMessageLen runes.
+func sanitizeMessage(s string) string {
+	var b strings.Builder
+	count := 0
+	for _, r := range s {
+		if r == 0x1b || r == 0x07 || r < 0x20 || r == 0x7f {
+			continue
+		}
+		b.WriteRune(r)
+		count++
+		if count >= maxMessageLen {
+			break
+		}
+	}
+	return b.String()
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -120,6 +120,11 @@ func sequence(mode Mode, message string) string {
 	}
 }
 
+// Enabled reports whether mode will ever emit a notification.
+func Enabled(mode Mode) bool {
+	return mode != "" && mode != ModeOff
+}
+
 // sanitizeMessage drops control bytes (so the message can't break the escape or
 // inject terminal control) and clamps to maxMessageLen runes.
 func sanitizeMessage(s string) string {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,119 @@
+package notify
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestShouldEmit(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		event   Event
+		focused bool
+		want    bool
+	}{
+		{"off never", Config{Mode: ModeOff, FocusMode: FocusAlways}, Completion, false, false},
+		{"empty mode never", Config{}, Completion, false, false},
+		{"always when focused", Config{Mode: ModeBell, FocusMode: FocusAlways}, Completion, true, true},
+		{"always when unfocused", Config{Mode: ModeBell, FocusMode: FocusAlways}, Completion, false, true},
+		{"unfocused emits when unfocused", Config{Mode: ModeBell, FocusMode: FocusUnfocused}, Completion, false, true},
+		{"unfocused silent when focused", Config{Mode: ModeBell, FocusMode: FocusUnfocused}, Completion, true, false},
+		{"empty focusmode == unfocused", Config{Mode: ModeBell}, Completion, true, false},
+		{"focused emits when focused", Config{Mode: ModeBell, FocusMode: FocusFocused}, AwaitingInput, true, true},
+		{"focused silent when unfocused", Config{Mode: ModeBell, FocusMode: FocusFocused}, AwaitingInput, false, false},
+		{"awaiting-input also eligible", Config{Mode: ModeBoth, FocusMode: FocusAlways}, AwaitingInput, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldEmit(tc.cfg, tc.event, tc.focused); got != tc.want {
+				t.Fatalf("shouldEmit=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSequence(t *testing.T) {
+	if got := sequence(ModeBell, "hi"); got != "\x07" {
+		t.Fatalf("bell seq=%q", got)
+	}
+	if got := sequence(ModeNotify, "hi"); got != "\x1b]9;hi\x07" {
+		t.Fatalf("notify seq=%q", got)
+	}
+	if got := sequence(ModeBoth, "hi"); got != "\x07\x1b]9;hi\x07" {
+		t.Fatalf("both seq=%q", got)
+	}
+	if got := sequence(ModeOff, "hi"); got != "" {
+		t.Fatalf("off seq=%q", got)
+	}
+}
+
+func TestSanitizeMessage(t *testing.T) {
+	if got := sanitizeMessage("ok\x1b]0;evil\x07more\nx"); got != "ok]0;evilmorex" {
+		t.Fatalf("sanitize=%q", got)
+	}
+	long := strings.Repeat("a", 500)
+	if got := sanitizeMessage(long); len([]rune(got)) != maxMessageLen {
+		t.Fatalf("clamp len=%d want %d", len([]rune(got)), maxMessageLen)
+	}
+}
+
+func TestNotifyWritesAndRespectsPolicy(t *testing.T) {
+	var buf bytes.Buffer
+	n := New(&buf, Config{Mode: ModeBoth, FocusMode: FocusAlways})
+	n.Notify(Completion, "Zero: ready")
+	if buf.String() != "\x07\x1b]9;Zero: ready\x07" {
+		t.Fatalf("emitted=%q", buf.String())
+	}
+
+	buf.Reset()
+	off := New(&buf, Config{Mode: ModeOff})
+	off.Notify(Completion, "x")
+	if buf.Len() != 0 {
+		t.Fatalf("off should emit nothing, got %q", buf.String())
+	}
+
+	buf.Reset()
+	uf := New(&buf, Config{Mode: ModeBell, FocusMode: FocusUnfocused})
+	uf.SetFocused(true)
+	uf.Notify(Completion, "x")
+	if buf.Len() != 0 {
+		t.Fatalf("focused+unfocused-mode should be silent, got %q", buf.String())
+	}
+	uf.SetFocused(false)
+	uf.Notify(Completion, "x")
+	if buf.String() != "\x07" {
+		t.Fatalf("unfocused should bell, got %q", buf.String())
+	}
+}
+
+func TestNotifierDefaultFocusFalse(t *testing.T) {
+	var buf bytes.Buffer
+	n := New(&buf, Config{Mode: ModeBell, FocusMode: FocusUnfocused})
+	n.Notify(Completion, "x")
+	if buf.String() != "\x07" {
+		t.Fatalf("default-focus headless should bell, got %q", buf.String())
+	}
+}
+
+func TestNotifyRaceSafe(t *testing.T) {
+	n := New(&bytes.Buffer{}, Config{Mode: ModeBell, FocusMode: FocusAlways})
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); n.SetFocused(true) }()
+		go func() { defer wg.Done(); n.Notify(Completion, "x") }()
+	}
+	wg.Wait()
+}
+
+func TestDefaultMessage(t *testing.T) {
+	if DefaultMessage(Completion) != "Zero: ready" {
+		t.Fatal("completion message")
+	}
+	if DefaultMessage(AwaitingInput) != "Zero: needs input" {
+		t.Fatal("awaiting message")
+	}
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -117,3 +117,12 @@ func TestDefaultMessage(t *testing.T) {
 		t.Fatal("awaiting message")
 	}
 }
+
+func TestEnabled(t *testing.T) {
+	if Enabled(ModeOff) || Enabled("") {
+		t.Fatal("off/empty should be disabled")
+	}
+	if !Enabled(ModeBell) || !Enabled(ModeNotify) || !Enabled(ModeBoth) {
+		t.Fatal("bell/notify/both should be enabled")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -41,6 +42,7 @@ type model struct {
 	usageTracker       *usage.Tracker
 	runtimeMessageSink func(tea.Msg)
 	agentOptions       agent.Options
+	notifier           *notify.Notifier
 	permissionMode     agent.PermissionMode
 	reasoningEffort    modelregistry.ReasoningEffort
 	responseStyle      string
@@ -228,6 +230,12 @@ func newModel(ctx context.Context, options Options) model {
 	}
 	input.Focus()
 
+	notifier := notify.New(os.Stderr, notify.Config{
+		Mode:      notify.Mode(strings.TrimSpace(options.Notify.Mode)),
+		FocusMode: notify.FocusMode(strings.TrimSpace(options.Notify.FocusMode)),
+	})
+	notifier.SetFocused(true)
+
 	return model{
 		skin:               options.Skin,
 		themeVariant:       options.ThemeVariant,
@@ -253,6 +261,7 @@ func newModel(ctx context.Context, options Options) model {
 		input:              input,
 		showSplash:         true,
 		now:                time.Now,
+		notifier:           notifier,
 	}
 }
 
@@ -398,6 +407,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.input, cmd = m.input.Update(msg)
 		m.recomputeSuggestions()
 		return m, cmd
+	case tea.FocusMsg:
+		if m.notifier != nil {
+			m.notifier.SetFocused(true)
+		}
+		return m, nil
+	case tea.BlurMsg:
+		if m.notifier != nil {
+			m.notifier.SetFocused(false)
+		}
+		return m, nil
 	case zerolineTickMsg:
 		if m.skin != "zeroline" {
 			return m, nil
@@ -515,6 +534,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.specReview != nil {
 			m = m.activateSpecReview(*msg.specReview)
+		}
+		if m.notifier != nil {
+			m.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
 		}
 		return m, nil
 	case agentRowMsg:
@@ -1075,6 +1097,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 			if m.runtimeMessageSink == nil {
 				return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission prompt unavailable"}, nil
 			}
+			if m.notifier != nil {
+				m.notifier.Notify(notify.AwaitingInput, notify.DefaultMessage(notify.AwaitingInput))
+			}
 			decisionCh := make(chan agent.PermissionDecision, 1)
 			m.sendPermissionRequest(runID, request, func(decision agent.PermissionDecision) {
 				select {
@@ -1105,6 +1130,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 			if m.runtimeMessageSink == nil {
 				// No interactive surface: let the loop degrade gracefully.
 				return agent.AskUserResponse{}, fmt.Errorf("ask_user prompt unavailable")
+			}
+			if m.notifier != nil {
+				m.notifier.Notify(notify.AwaitingInput, notify.DefaultMessage(notify.AwaitingInput))
 			}
 			answerCh := make(chan []string, 1)
 			m.sendAskUserRequest(runID, request, func(answers []string) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1131,7 +1131,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				// No interactive surface: let the loop degrade gracefully.
 				return agent.AskUserResponse{}, fmt.Errorf("ask_user prompt unavailable")
 			}
-			if m.notifier != nil {
+			// Only notify when there is actually something to answer — a request
+			// with no questions auto-resolves without ever prompting the user.
+			if m.notifier != nil && len(request.Questions) > 0 {
 				m.notifier.Notify(notify.AwaitingInput, notify.DefaultMessage(notify.AwaitingInput))
 			}
 			answerCh := make(chan []string, 1)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -1292,5 +1294,34 @@ func TestNextPermissionModeFoldsUnsafeToAsk(t *testing.T) {
 	// must not make it less strict).
 	if got := nextPermissionMode(agent.PermissionModeUnsafe); got != agent.PermissionModeAsk {
 		t.Fatalf("Unsafe -> %s, want Ask", got)
+	}
+}
+
+func TestModelNotifierFocusAndCompletion(t *testing.T) {
+	var buf bytes.Buffer
+	m := model{notifier: notify.New(&buf, notify.Config{Mode: notify.ModeBell, FocusMode: notify.FocusUnfocused})}
+	m.notifier.SetFocused(true)
+
+	// Focused → completion under unfocused-mode is silent.
+	m.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
+	if buf.Len() != 0 {
+		t.Fatalf("focused should be silent, got %q", buf.String())
+	}
+
+	// BlurMsg flips focus; completion now bells.
+	updated, _ := m.Update(tea.BlurMsg{})
+	m = updated.(model)
+	m.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
+	if buf.String() != "\x07" {
+		t.Fatalf("unfocused should bell, got %q", buf.String())
+	}
+
+	// FocusMsg flips back.
+	updated, _ = m.Update(tea.FocusMsg{})
+	m = updated.(model)
+	buf.Reset()
+	m.notifier.Notify(notify.Completion, "x")
+	if buf.Len() != 0 {
+		t.Fatalf("refocused should be silent, got %q", buf.String())
 	}
 }

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -37,4 +37,7 @@ type Options struct {
 	Skin         string
 	ThemeVariant int  // zeroline color theme index (0-4)
 	ThemeDark    bool // zeroline light/dark mode
+
+	// Notify configures completion / awaiting-input notifications.
+	Notify config.NotifyConfig
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -3,8 +3,11 @@ package tui
 import (
 	"context"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/notify"
 )
 
 // Run starts the Zero Bubble Tea shell and returns a process-style exit code.
@@ -24,7 +27,9 @@ func Run(ctx context.Context, options Options) int {
 		tea.WithContext(ctx),
 		tea.WithInput(os.Stdin),
 		tea.WithOutput(os.Stdout),
-		tea.WithReportFocus(),
+	}
+	if notify.Enabled(notify.Mode(strings.TrimSpace(options.Notify.Mode))) {
+		programOpts = append(programOpts, tea.WithReportFocus())
 	}
 	// NOTE: we intentionally do NOT enable mouse capture. Mouse cell-motion
 	// reporting routes clicks/drags to the program, which breaks the terminal's

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -24,6 +24,7 @@ func Run(ctx context.Context, options Options) int {
 		tea.WithContext(ctx),
 		tea.WithInput(os.Stdin),
 		tea.WithOutput(os.Stdout),
+		tea.WithReportFocus(),
 	}
 	// NOTE: we intentionally do NOT enable mouse capture. Mouse cell-motion
 	// reporting routes clicks/drags to the program, which breaks the terminal's


### PR DESCRIPTION
## Summary

Adds a dep-free **completion / awaiting-input notifier**: a terminal bell and/or OSC-9 desktop notification when Zero finishes a turn or needs your input. Opt-in and **byte-identical when unconfigured** (default `off`). No new module dependencies.

- **Mechanism** (`notify.mode`): `off` (default) | `bell` (BEL) | `notify` (OSC-9 desktop notification `ESC ]9; <msg> BEL`) | `both`.
- **Triggers:** run **completion** (ready for input) and **awaiting-input** (a permission prompt or `ask_user` question).
- **Focus gating** (`notify.focusMode`, TUI only): `unfocused` (default — only when the terminal is NOT focused) | `always` | `focused`. Uses Bubble Tea focus reporting.
- **Surface:** config keys + `zero exec --notify <mode>` / `--no-notify`. A TUI `/notify` picker is a deliberate follow-up.

## Design

- **`internal/notify`** (new, pure, stdlib-only): `Mode`/`FocusMode`/`Event`, `Notifier{New, SetFocused, Notify}`, `DefaultMessage`, `Enabled`. Two pure helpers (`shouldEmit`, `sequence`) carry the policy and are fully unit-tested without a terminal. Messages are **generic** ("Zero: ready" / "Zero: needs input") — no prompt/response content (privacy) — and **sanitized** (ESC/BEL/control stripped, clamped to 120 runes) so they can't break the escape.
- **Config** (`internal/config`): `notify.mode` / `notify.focusMode`, validated at `Resolve` (invalid → error), mirroring the `SandboxConfig` pattern (incl. `Overrides`/merge threading, for parity with the existing forward-plumbing pattern).
- **TUI** (`internal/tui`): focus reporting enabled **only when notify is on** (so `off` stays byte-identical); `FocusMsg`/`BlurMsg` track focus; completion fires once per finished foreground run (excluded from cancel/quit/background-drain paths); permission/`ask_user` wrappers fire awaiting-input. Notifier writes to **os.Stderr** (out-of-band; never the stdout render target).
- **exec** (`internal/cli`): notifier on **stderr** (never stdout — may carry stream-json); fires completion after `agent.Run` on both the normal and `--use-spec` paths, on success and error. Headless has no focus signal, so `exec` **ignores `focusMode`** and always emits when a mode is set.

## Test Plan

- [x] `go build ./...` / `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `go vet ./...` clean; `gofmt` clean (touched files)
- [x] `go test ./...` green (new tests across `notify`, `config`, `cli`, `tui`)
- [x] `go test -race ./internal/{notify,config,cli,tui}/...` green
- [x] Adversarial whole-diff review: found + fixed a real gap (`exec --use-spec` never notified) and hardened headless focus handling + off-state byte-identity

### Reviewer focus
- **Off = byte-identical:** with `mode` unset/off, no notifier output and focus reporting is not enabled.
- **No stdout corruption:** both TUI and exec notifiers target stderr; stdout (stream-json) is never the sink.
- **Completion fires once** on the foreground run, on success and error, never on cancel/drain.

### Known follow-ups (not blockers)
- An invalid `--notify <value>` is silently no-op (config values are validated and error). A small `notify.Valid(mode)` guard for the flag is a clean follow-up.
- TUI `/notify` interactive picker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to control per-run notifications (--notify / --no-notify) and updated help text
  * Notifications for task completion and when awaiting user input; TUI integrates and respects focus state
  * Configurable modes: bell, desktop notification, or both

* **Config**
  * Persistent notification settings with validation and merge/override support

* **Tests**
  * Unit tests for flag parsing, mode resolution, config validation, notifier behavior, and TUI focus handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->