### PR TITLE
zero repo-info: local (network-free) repository characterizer

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -205,6 +205,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runChanges(args[1:], stdout, stderr, deps)
 	case "usage":
 		return runUsage(args[1:], stdout, stderr, deps)
+	case "repo-info", "repoinfo":
+		return runRepoInfo(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
 	case "zeroline":
@@ -473,6 +475,7 @@ Commands:
   verify     Detect and run local verification checks
   changes    Inspect and commit local git changes
   usage      Summarize token usage and estimated cost
+  repo-info  Characterize the current repository (local git only)
   serve      Run Zero protocol servers
   zeroline    Launch the interactive TUI with the Zeroline reskin
   help       Show this help

--- a/internal/cli/repoinfo.go
+++ b/internal/cli/repoinfo.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/repoinfo"
+)
+
+type repoInfoOptions struct {
+	json bool
+	cwd  string
+}
+
+func runRepoInfo(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseRepoInfoArgs(args)
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitUsage
+	}
+	if help {
+		writeRepoInfoHelp(stdout)
+		return exitSuccess
+	}
+	workspaceRoot, err := resolveWorkspaceRoot(options.cwd, deps)
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitUsage
+	}
+	now := time.Now
+	if deps.now != nil {
+		now = deps.now
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	info, err := repoinfo.Collect(ctx, repoinfo.Options{Cwd: workspaceRoot, Now: now()})
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitCrash
+	}
+	if options.json {
+		data, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return exitCrash
+		}
+		fmt.Fprintln(stdout, string(data))
+		return exitSuccess
+	}
+	fmt.Fprint(stdout, formatRepoInfo(info))
+	return exitSuccess
+}
+
+func parseRepoInfoArgs(args []string) (repoInfoOptions, bool, error) {
+	var options repoInfoOptions
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "-C" || arg == "--cwd":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.cwd = value
+			index = next
+		case strings.HasPrefix(arg, "--cwd="):
+			options.cwd = strings.TrimSpace(strings.TrimPrefix(arg, "--cwd="))
+		default:
+			return options, false, execUsageError{fmt.Sprintf("Unknown repo-info flag: %s", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+const repoInfoTopLanguages = 8
+
+func formatRepoInfo(info repoinfo.Info) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Files:        %d\n", info.FileCount)
+	fmt.Fprintf(&b, "Directories:  %d (max depth %d)\n", info.DirectoryCount, info.MaxDepth)
+	fmt.Fprintf(&b, "Est. LOC:     %d\n", info.LOCEstimate)
+	if info.PrimaryLanguage != "" {
+		fmt.Fprintf(&b, "Primary lang: %s\n", info.PrimaryLanguage)
+	}
+	if len(info.Languages) > 0 {
+		b.WriteString("Languages:\n")
+		shown := info.Languages
+		extra := 0
+		if len(shown) > repoInfoTopLanguages {
+			extra = len(shown) - repoInfoTopLanguages
+			shown = shown[:repoInfoTopLanguages]
+		}
+		for _, lang := range shown {
+			fmt.Fprintf(&b, "  %-14s ~%d LOC  (%d files)\n", lang.Name, lang.LOCEstimate, lang.FileCount)
+		}
+		if extra > 0 {
+			fmt.Fprintf(&b, "  +%d more\n", extra)
+		}
+	}
+	fmt.Fprintf(&b, "Workspace:    %s", info.WorkspaceType)
+	if info.WorkspacePackageCount > 0 {
+		fmt.Fprintf(&b, " (%d packages)", info.WorkspacePackageCount)
+	}
+	b.WriteString("\n")
+	writeRepoInfoList(&b, "Build tools", info.BuildTools)
+	writeRepoInfoList(&b, "Test tools", info.TestTools)
+	writeRepoInfoList(&b, "CI/CD", info.CICD)
+	if info.Branch != "" {
+		fmt.Fprintf(&b, "Branch:       %s\n", info.Branch)
+	}
+	if info.RemoteURL != "" {
+		fmt.Fprintf(&b, "Remote:       %s\n", info.RemoteURL)
+	}
+	if info.AgeDays != nil {
+		fmt.Fprintf(&b, "Age:          %d days\n", *info.AgeDays)
+	}
+	if info.Contributors90d != nil {
+		fmt.Fprintf(&b, "Contributors: %d (last 90d)\n", *info.Contributors90d)
+	}
+	if info.CommitVelocity30d != nil {
+		fmt.Fprintf(&b, "Velocity:     %d commits (last 30d)\n", *info.CommitVelocity30d)
+	}
+	return b.String()
+}
+
+func writeRepoInfoList(b *strings.Builder, label string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	sorted := append([]string{}, items...)
+	sort.Strings(sorted)
+	fmt.Fprintf(b, "%-13s %s\n", label+":", strings.Join(sorted, ", "))
+}
+
+func writeRepoInfoHelp(w io.Writer) {
+	fmt.Fprint(w, `zero repo-info — characterize the current repository (local git only)
+
+Usage:
+  zero repo-info [--json] [--cwd <dir>]
+
+Flags:
+  --json        Emit the full characterization as JSON.
+  -C, --cwd     Run against a different directory.
+`)
+}

--- a/internal/cli/repoinfo_test.go
+++ b/internal/cli/repoinfo_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -38,8 +41,9 @@ func TestFormatRepoInfoText(t *testing.T) {
 }
 
 func TestRunRepoInfoJSON(t *testing.T) {
+	dir := initTempGitRepo(t) // hermetic: do not depend on running inside a checkout
 	var stdout, stderr bytes.Buffer
-	code := runRepoInfo([]string{"--json"}, &stdout, &stderr, testRepoInfoDeps())
+	code := runRepoInfo([]string{"--json", "--cwd", dir}, &stdout, &stderr, testRepoInfoDeps())
 	if code != 0 {
 		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
 	}
@@ -50,6 +54,38 @@ func TestRunRepoInfoJSON(t *testing.T) {
 	if info["hasGit"] != true {
 		t.Fatalf("expected hasGit=true, got %v", info["hasGit"])
 	}
+	if info["primaryLanguage"] != "Go" {
+		t.Fatalf("expected primaryLanguage Go, got %v", info["primaryLanguage"])
+	}
+}
+
+// initTempGitRepo creates a throwaway git repo with a single Go file committed,
+// so the command can be exercised end-to-end without depending on the test being
+// run inside a git checkout.
+func initTempGitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	git := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git("init")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-m", "init")
+	return dir
 }
 
 func repoInfoTestData(age, contrib int) repoinfo.Info {

--- a/internal/cli/repoinfo_test.go
+++ b/internal/cli/repoinfo_test.go
@@ -57,6 +57,28 @@ func TestRunRepoInfoJSON(t *testing.T) {
 	if info["primaryLanguage"] != "Go" {
 		t.Fatalf("expected primaryLanguage Go, got %v", info["primaryLanguage"])
 	}
+	if strings.Contains(stdout.String(), "ghp_TESTSECRET") {
+		t.Fatalf("credential leaked into --json output:\n%s", stdout.String())
+	}
+	if info["remoteURL"] != "https://github.com/o/r.git" {
+		t.Fatalf("remoteURL=%v want sanitized (no credentials)", info["remoteURL"])
+	}
+}
+
+func TestRunRepoInfoTextNoCredentials(t *testing.T) {
+	dir := initTempGitRepo(t)
+	var stdout, stderr bytes.Buffer
+	code := runRepoInfo([]string{"--cwd", dir}, &stdout, &stderr, testRepoInfoDeps())
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "ghp_TESTSECRET") {
+		t.Fatalf("credential leaked into text output:\n%s", out)
+	}
+	if !strings.Contains(out, "github.com/o/r.git") {
+		t.Fatalf("expected sanitized remote in text output:\n%s", out)
+	}
 }
 
 // initTempGitRepo creates a throwaway git repo with a single Go file committed,
@@ -85,6 +107,8 @@ func initTempGitRepo(t *testing.T) string {
 	}
 	git("add", ".")
 	git("commit", "-m", "init")
+	// A remote whose URL embeds a credential, to prove the report never leaks it.
+	git("remote", "add", "origin", "https://x-access-token:ghp_TESTSECRET@github.com/o/r.git")
 	return dir
 }
 

--- a/internal/cli/repoinfo_test.go
+++ b/internal/cli/repoinfo_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/repoinfo"
+)
+
+func TestParseRepoInfoArgs(t *testing.T) {
+	opts, help, err := parseRepoInfoArgs([]string{"--json", "--cwd", "/tmp/x"})
+	if err != nil || help {
+		t.Fatalf("parse: help=%v err=%v", help, err)
+	}
+	if !opts.json || opts.cwd != "/tmp/x" {
+		t.Fatalf("got %+v", opts)
+	}
+	if _, h, _ := parseRepoInfoArgs([]string{"--help"}); !h {
+		t.Fatal("expected help")
+	}
+	if _, _, err := parseRepoInfoArgs([]string{"--bogus"}); err == nil {
+		t.Fatal("expected error for unknown flag")
+	}
+}
+
+func TestFormatRepoInfoText(t *testing.T) {
+	age := 42
+	contrib := 3
+	info := repoInfoTestData(age, contrib)
+	out := formatRepoInfo(info)
+	for _, want := range []string{"Files", "TypeScript", "main", "GitHub Actions", "42", "3"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunRepoInfoJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runRepoInfo([]string{"--json"}, &stdout, &stderr, testRepoInfoDeps())
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	var info map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &info); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if info["hasGit"] != true {
+		t.Fatalf("expected hasGit=true, got %v", info["hasGit"])
+	}
+}
+
+func repoInfoTestData(age, contrib int) repoinfo.Info {
+	return repoinfo.Info{
+		FileCount: 10, DirectoryCount: 3, MaxDepth: 2, LOCEstimate: 500,
+		Languages:       []repoinfo.LangStat{{Name: "TypeScript", LOCEstimate: 400, FileCount: 4}},
+		PrimaryLanguage: "TypeScript", LanguageCount: 1,
+		WorkspaceType: "none", CICD: []string{"GitHub Actions"},
+		HasGit: true, Branch: "main", AgeDays: &age, Contributors90d: &contrib,
+	}
+}
+
+func testRepoInfoDeps() appDeps {
+	return defaultAppDeps()
+}

--- a/internal/repoinfo/detect.go
+++ b/internal/repoinfo/detect.go
@@ -1,0 +1,62 @@
+package repoinfo
+
+import (
+	"sort"
+	"strings"
+)
+
+// buildToolFiles are basenames that indicate a build system.
+var buildToolFiles = map[string]bool{
+	"Makefile": true, "go.mod": true, "Cargo.toml": true, "package.json": true,
+	"pyproject.toml": true, "setup.py": true, "pom.xml": true,
+	"build.gradle": true, "build.gradle.kts": true, "CMakeLists.txt": true,
+	"Gemfile": true, "composer.json": true,
+}
+
+// testToolFiles are basenames that indicate a test framework/config.
+var testToolFiles = map[string]bool{
+	"jest.config.js": true, "jest.config.ts": true, "jest.config.mjs": true,
+	"vitest.config.ts": true, "vitest.config.js": true,
+	"pytest.ini": true, "tox.ini": true, "phpunit.xml": true,
+	".mocharc.json": true, ".mocharc.js": true, ".mocharc.yml": true,
+	"playwright.config.ts": true, "playwright.config.js": true, "karma.conf.js": true,
+}
+
+// workspaceMarkers maps a marker basename to a monorepo workspace type.
+var workspaceMarkers = map[string]string{
+	"pnpm-workspace.yaml": "pnpm",
+	"go.work":             "go-work",
+	"lerna.json":          "lerna",
+	"nx.json":             "nx",
+}
+
+// cicdForPath returns a CI/CD system name for a repo-relative path, or "".
+func cicdForPath(filePath string) string {
+	switch {
+	case strings.HasPrefix(filePath, ".github/workflows/"):
+		return "GitHub Actions"
+	case filePath == ".gitlab-ci.yml":
+		return "GitLab CI"
+	case filePath == ".circleci/config.yml":
+		return "CircleCI"
+	case filePath == "Jenkinsfile":
+		return "Jenkins"
+	case filePath == "azure-pipelines.yml":
+		return "Azure Pipelines"
+	case filePath == ".travis.yml":
+		return "Travis CI"
+	case filePath == "bitbucket-pipelines.yml":
+		return "Bitbucket Pipelines"
+	}
+	return ""
+}
+
+// sortedUnique returns the keys of set as a sorted slice (never nil).
+func sortedUnique(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/repoinfo/detect_test.go
+++ b/internal/repoinfo/detect_test.go
@@ -1,0 +1,54 @@
+package repoinfo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLanguageForExt(t *testing.T) {
+	cases := map[string]string{"go": "Go", "ts": "TypeScript", "tsx": "TypeScript", "py": "Python", "rs": "Rust", "cpp": "C++"}
+	for ext, want := range cases {
+		if got, ok := languageForExt(ext); !ok || got != want {
+			t.Fatalf("languageForExt(%q)=%q,%v want %q", ext, got, ok, want)
+		}
+	}
+	if _, ok := languageForExt("unknownext"); ok {
+		t.Fatal("unknown ext must not resolve")
+	}
+}
+
+func TestCicdForPath(t *testing.T) {
+	cases := map[string]string{
+		".github/workflows/ci.yml": "GitHub Actions",
+		".gitlab-ci.yml":           "GitLab CI",
+		"Jenkinsfile":              "Jenkins",
+		"src/main.go":              "",
+	}
+	for p, want := range cases {
+		if got := cicdForPath(p); got != want {
+			t.Fatalf("cicdForPath(%q)=%q want %q", p, got, want)
+		}
+	}
+}
+
+func TestDetectionTables(t *testing.T) {
+	if !buildToolFiles["go.mod"] || !buildToolFiles["package.json"] {
+		t.Fatal("expected build tool files")
+	}
+	if !testToolFiles["pytest.ini"] {
+		t.Fatal("expected test tool file")
+	}
+	if workspaceMarkers["pnpm-workspace.yaml"] != "pnpm" || workspaceMarkers["go.work"] != "go-work" {
+		t.Fatal("expected workspace markers")
+	}
+}
+
+func TestSortedUnique(t *testing.T) {
+	got := sortedUnique(map[string]bool{"b": true, "a": true})
+	if !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("sortedUnique=%v", got)
+	}
+	if got := sortedUnique(map[string]bool{}); len(got) != 0 {
+		t.Fatalf("empty set should give empty slice, got %v", got)
+	}
+}

--- a/internal/repoinfo/languages.go
+++ b/internal/repoinfo/languages.go
@@ -9,7 +9,9 @@ var extToLanguage = map[string]string{
 	"cs": "C#", "rb": "Ruby", "php": "PHP", "swift": "Swift", "scala": "Scala",
 	"sh": "Shell", "bash": "Shell", "zsh": "Shell",
 	"sql": "SQL", "html": "HTML", "htm": "HTML", "css": "CSS", "scss": "SCSS", "sass": "SCSS",
-	"json": "JSON", "yaml": "YAML", "yml": "YAML", "toml": "TOML", "md": "Markdown",
+	// Pure data/prose formats (json/yaml/toml/md) are intentionally NOT languages:
+	// they would drown out the "primary language" signal. Markup-code (html/css)
+	// is kept since it is authored frontend code.
 	"proto": "Protobuf", "lua": "Lua", "dart": "Dart", "ex": "Elixir", "exs": "Elixir",
 	"clj": "Clojure", "hs": "Haskell", "ml": "OCaml", "r": "R", "jl": "Julia",
 	"vue": "Vue", "svelte": "Svelte", "pl": "Perl", "pm": "Perl", "groovy": "Groovy",

--- a/internal/repoinfo/languages.go
+++ b/internal/repoinfo/languages.go
@@ -1,0 +1,23 @@
+package repoinfo
+
+// extToLanguage maps a lowercase file extension (no dot) to a display language.
+var extToLanguage = map[string]string{
+	"go": "Go", "ts": "TypeScript", "tsx": "TypeScript", "js": "JavaScript",
+	"jsx": "JavaScript", "mjs": "JavaScript", "cjs": "JavaScript",
+	"py": "Python", "rs": "Rust", "java": "Java", "kt": "Kotlin", "kts": "Kotlin",
+	"c": "C", "h": "C", "cc": "C++", "cpp": "C++", "cxx": "C++", "hpp": "C++", "hh": "C++",
+	"cs": "C#", "rb": "Ruby", "php": "PHP", "swift": "Swift", "scala": "Scala",
+	"sh": "Shell", "bash": "Shell", "zsh": "Shell",
+	"sql": "SQL", "html": "HTML", "htm": "HTML", "css": "CSS", "scss": "SCSS", "sass": "SCSS",
+	"json": "JSON", "yaml": "YAML", "yml": "YAML", "toml": "TOML", "md": "Markdown",
+	"proto": "Protobuf", "lua": "Lua", "dart": "Dart", "ex": "Elixir", "exs": "Elixir",
+	"clj": "Clojure", "hs": "Haskell", "ml": "OCaml", "r": "R", "jl": "Julia",
+	"vue": "Vue", "svelte": "Svelte", "pl": "Perl", "pm": "Perl", "groovy": "Groovy",
+	"tf": "Terraform", "zig": "Zig", "nim": "Nim",
+}
+
+// languageForExt returns the language for a lowercase extension (no leading dot).
+func languageForExt(ext string) (string, bool) {
+	lang, ok := extToLanguage[ext]
+	return lang, ok
+}

--- a/internal/repoinfo/repoinfo.go
+++ b/internal/repoinfo/repoinfo.go
@@ -1,0 +1,288 @@
+// Package repoinfo characterizes a repository from local git commands only
+// (no network). It powers the `zero repo-info` command.
+package repoinfo
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	bytesPerLine   = 50    // LOC estimate heuristic (matches the source module)
+	maxCommitsWalk = 10000 // bound history walking on very active repos
+)
+
+// ErrNotGitRepo is returned when the directory is not a git repository or HEAD
+// has no commits (git ls-tree against HEAD fails).
+var ErrNotGitRepo = errors.New("not a git repository, or it has no commits yet")
+
+// LangStat is a per-language rollup.
+type LangStat struct {
+	Name        string `json:"name"`
+	LOCEstimate int    `json:"locEstimate"`
+	FileCount   int    `json:"fileCount"`
+}
+
+// Info is the collected repository characterization.
+type Info struct {
+	FileCount             int        `json:"fileCount"`
+	DirectoryCount        int        `json:"directoryCount"`
+	MaxDepth              int        `json:"maxDepth"`
+	LOCEstimate           int        `json:"locEstimate"`
+	Languages             []LangStat `json:"languages"`
+	PrimaryLanguage       string     `json:"primaryLanguage,omitempty"`
+	LanguageCount         int        `json:"languageCount"`
+	WorkspaceType         string     `json:"workspaceType"`
+	WorkspacePackageCount int        `json:"workspacePackageCount"`
+	BuildTools            []string   `json:"buildTools"`
+	TestTools             []string   `json:"testTools"`
+	CICD                  []string   `json:"cicd"`
+	HasGit                bool       `json:"hasGit"`
+	Branch                string     `json:"branch,omitempty"`
+	RemoteURL             string     `json:"remoteURL,omitempty"`
+	AgeDays               *int       `json:"ageDays,omitempty"`
+	Contributors90d       *int       `json:"contributors90d,omitempty"`
+	CommitVelocity30d     *int       `json:"commitVelocity30d,omitempty"`
+}
+
+// RunGit runs a git subcommand in dir and returns raw stdout. A non-zero exit
+// (or spawn failure) MUST return a non-nil error.
+type RunGit func(ctx context.Context, dir string, args ...string) (string, error)
+
+// Options configures Collect. Now and RunGit are injectable for tests.
+type Options struct {
+	Cwd    string
+	Now    time.Time
+	RunGit RunGit
+}
+
+// Collect gathers repository metadata from local git only. It never performs a
+// network operation. Returns ErrNotGitRepo when the directory has no readable
+// HEAD tree; individual history metrics fail soft (omitted, not fatal).
+func Collect(ctx context.Context, opts Options) (Info, error) {
+	run := opts.RunGit
+	if run == nil {
+		run = defaultRunGit
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	dir := opts.Cwd
+
+	tree, err := run(ctx, dir, "ls-tree", "-r", "-l", "HEAD")
+	if err != nil {
+		return Info{}, ErrNotGitRepo
+	}
+
+	info := Info{HasGit: true, WorkspaceType: "none", Languages: []LangStat{}}
+	langBytes := map[string]int{}
+	langFiles := map[string]int{}
+	buildSet := map[string]bool{}
+	testSet := map[string]bool{}
+	cicdSet := map[string]bool{}
+	pkgDirs := map[string]bool{}
+	appDirs := map[string]bool{}
+	lastDir := ""
+	hasPackageJSON := false
+	hasCargoToml := false
+
+	scanner := bufio.NewScanner(strings.NewReader(tree))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		tab := strings.IndexByte(line, '\t')
+		if tab < 0 {
+			continue
+		}
+		fields := strings.Fields(line[:tab])
+		if len(fields) < 4 {
+			continue
+		}
+		size, convErr := strconv.Atoi(fields[3]) // "-" for gitlinks -> skip
+		if convErr != nil {
+			continue
+		}
+		filePath := line[tab+1:]
+		info.FileCount++
+
+		dirName := path.Dir(filePath)
+		if dirName != lastDir && dirName != "." {
+			info.DirectoryCount++
+			lastDir = dirName
+			if depth := strings.Count(filePath, "/"); depth > info.MaxDepth {
+				info.MaxDepth = depth
+			}
+		}
+
+		base := path.Base(filePath)
+		ext := strings.ToLower(strings.TrimPrefix(path.Ext(base), "."))
+		if lang, ok := languageForExt(ext); ok {
+			langBytes[lang] += size
+			langFiles[lang]++
+		}
+		if buildToolFiles[base] {
+			buildSet[base] = true
+		}
+		if testToolFiles[base] {
+			testSet[base] = true
+		}
+		if ci := cicdForPath(filePath); ci != "" {
+			cicdSet[ci] = true
+		}
+		if ws, ok := workspaceMarkers[base]; ok && info.WorkspaceType == "none" {
+			info.WorkspaceType = ws
+		}
+		if filePath == "package.json" {
+			hasPackageJSON = true
+		}
+		if filePath == "Cargo.toml" {
+			hasCargoToml = true
+		}
+		if sub, ok := topSubdir(filePath, "packages/"); ok {
+			pkgDirs[sub] = true
+		}
+		if sub, ok := topSubdir(filePath, "apps/"); ok {
+			appDirs[sub] = true
+		}
+	}
+
+	// Total LOCEstimate is the SUM of the per-language estimates so the parts
+	// always add up to the whole (a single per-file truncation would not).
+	for name, b := range langBytes {
+		loc := b / bytesPerLine
+		info.Languages = append(info.Languages, LangStat{Name: name, LOCEstimate: loc, FileCount: langFiles[name]})
+		info.LOCEstimate += loc
+	}
+	sort.Slice(info.Languages, func(i, j int) bool {
+		if info.Languages[i].LOCEstimate != info.Languages[j].LOCEstimate {
+			return info.Languages[i].LOCEstimate > info.Languages[j].LOCEstimate
+		}
+		return info.Languages[i].Name < info.Languages[j].Name
+	})
+	info.LanguageCount = len(info.Languages)
+	if len(info.Languages) > 0 {
+		info.PrimaryLanguage = info.Languages[0].Name
+	}
+	info.BuildTools = sortedUnique(buildSet)
+	info.TestTools = sortedUnique(testSet)
+	info.CICD = sortedUnique(cicdSet)
+	info.WorkspacePackageCount = len(pkgDirs) + len(appDirs)
+
+	if info.WorkspaceType == "none" && hasPackageJSON && hasNpmWorkspaces(dir) {
+		info.WorkspaceType = "npm-workspaces"
+	}
+	if info.WorkspaceType == "none" && hasCargoToml && hasCargoWorkspace(dir) {
+		info.WorkspaceType = "cargo-workspace"
+	}
+
+	if branch, err := run(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		info.Branch = strings.TrimSpace(branch)
+	}
+	if remote, err := run(ctx, dir, "remote", "get-url", "origin"); err == nil {
+		info.RemoteURL = strings.TrimSpace(remote)
+	}
+	if first, err := run(ctx, dir, "log", "--reverse", "-1", "--format=%ct"); err == nil {
+		if ts, perr := strconv.ParseInt(strings.TrimSpace(first), 10, 64); perr == nil {
+			days := int((now.Unix() - ts) / 86400)
+			if days < 0 {
+				days = 0
+			}
+			info.AgeDays = &days
+		}
+	}
+	if authors, err := run(ctx, dir, "log", "--since=90 days ago", "--max-count="+strconv.Itoa(maxCommitsWalk), "--format=%aN"); err == nil {
+		info.Contributors90d = countUnique(authors)
+	}
+	if count, err := run(ctx, dir, "rev-list", "--count", "--since=30 days ago", "--max-count="+strconv.Itoa(maxCommitsWalk), "HEAD"); err == nil {
+		if n, perr := strconv.Atoi(strings.TrimSpace(count)); perr == nil {
+			info.CommitVelocity30d = &n
+		}
+	}
+
+	return info, nil
+}
+
+// topSubdir returns the first path segment under prefix (e.g. "packages/a/x" ->
+// "a"), and false when filePath is not under prefix or has no subdir.
+func topSubdir(filePath, prefix string) (string, bool) {
+	if !strings.HasPrefix(filePath, prefix) {
+		return "", false
+	}
+	rest := filePath[len(prefix):]
+	slash := strings.IndexByte(rest, '/')
+	if slash <= 0 {
+		return "", false
+	}
+	return rest[:slash], true
+}
+
+// countUnique counts distinct non-empty trimmed lines.
+func countUnique(out string) *int {
+	set := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			set[line] = true
+		}
+	}
+	n := len(set)
+	return &n
+}
+
+// hasNpmWorkspaces reports whether the root package.json declares workspaces
+// (array or {packages:[]} object). Local file read only.
+func hasNpmWorkspaces(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Workspaces any `json:"workspaces"`
+	}
+	if json.Unmarshal(data, &pkg) != nil {
+		return false
+	}
+	switch ws := pkg.Workspaces.(type) {
+	case []any:
+		return len(ws) > 0
+	case map[string]any:
+		return len(ws) > 0
+	}
+	return false
+}
+
+// hasCargoWorkspace reports whether the root Cargo.toml has a [workspace] table.
+// Local file read only.
+func hasCargoWorkspace(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "Cargo.toml"))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "[workspace]")
+}
+
+// defaultRunGit shells the local `git` binary. It never contacts the network for
+// the read-only subcommands Collect uses (ls-tree, rev-parse, remote get-url,
+// log, rev-list).
+func defaultRunGit(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return stdout.String(), nil
+}

--- a/internal/repoinfo/repoinfo.go
+++ b/internal/repoinfo/repoinfo.go
@@ -3,7 +3,6 @@
 package repoinfo
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -81,7 +80,10 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 	}
 	dir := opts.Cwd
 
-	tree, err := run(ctx, dir, "ls-tree", "-r", "-l", "HEAD")
+	// -z gives NUL-terminated records with UNQUOTED paths; without it git wraps
+	// non-ASCII/special filenames in C-quoted "..." (core.quotePath), which would
+	// corrupt extension/tooling matching and silently drop those files.
+	tree, err := run(ctx, dir, "ls-tree", "-r", "-l", "-z", "HEAD")
 	if err != nil {
 		return Info{}, ErrNotGitRepo
 	}
@@ -94,19 +96,19 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 	cicdSet := map[string]bool{}
 	pkgDirs := map[string]bool{}
 	appDirs := map[string]bool{}
-	lastDir := ""
+	dirSet := map[string]bool{}
 	hasPackageJSON := false
 	hasCargoToml := false
 
-	scanner := bufio.NewScanner(strings.NewReader(tree))
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		tab := strings.IndexByte(line, '\t')
+	for _, entry := range strings.Split(tree, "\x00") {
+		if entry == "" {
+			continue
+		}
+		tab := strings.IndexByte(entry, '\t')
 		if tab < 0 {
 			continue
 		}
-		fields := strings.Fields(line[:tab])
+		fields := strings.Fields(entry[:tab])
 		if len(fields) < 4 {
 			continue
 		}
@@ -114,16 +116,19 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 		if convErr != nil {
 			continue
 		}
-		filePath := line[tab+1:]
+		filePath := entry[tab+1:]
 		info.FileCount++
 
-		dirName := path.Dir(filePath)
-		if dirName != lastDir && dirName != "." {
-			info.DirectoryCount++
-			lastDir = dirName
-			if depth := strings.Count(filePath, "/"); depth > info.MaxDepth {
-				info.MaxDepth = depth
+		// Count every directory on the path to this file, including "passthrough"
+		// directories that hold only subdirectories: git ls-tree -r lists blobs
+		// only, so we expand each file's ancestors rather than count file parents.
+		if dirName := path.Dir(filePath); dirName != "." {
+			for d := dirName; d != "." && !dirSet[d]; d = path.Dir(d) {
+				dirSet[d] = true
 			}
+		}
+		if depth := strings.Count(filePath, "/"); depth > info.MaxDepth {
+			info.MaxDepth = depth
 		}
 
 		base := path.Base(filePath)
@@ -157,6 +162,8 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 			appDirs[sub] = true
 		}
 	}
+
+	info.DirectoryCount = len(dirSet)
 
 	// Total LOCEstimate is the SUM of the per-language estimates so the parts
 	// always add up to the whole (a single per-file truncation would not).

--- a/internal/repoinfo/repoinfo.go
+++ b/internal/repoinfo/repoinfo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -198,7 +199,7 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 		info.Branch = strings.TrimSpace(branch)
 	}
 	if remote, err := run(ctx, dir, "remote", "get-url", "origin"); err == nil {
-		info.RemoteURL = strings.TrimSpace(remote)
+		info.RemoteURL = sanitizeRemoteURL(remote)
 	}
 	// Age = time since the FIRST commit. Use --max-parents=0 (root commits) — NOT
 	// `log --reverse -1`, where git applies the -1 limit BEFORE reversing and so
@@ -245,6 +246,29 @@ func topSubdir(filePath, prefix string) (string, bool) {
 		return "", false
 	}
 	return rest[:slash], true
+}
+
+// sanitizeRemoteURL strips any credentials (userinfo) from a git remote URL so
+// they never leak into the report. A remote can embed secrets, e.g.
+// "https://x-access-token:ghp_…@github.com/o/r.git". URL forms have their
+// user:password@ component removed; scp-like forms ("[user@]host:path") drop a
+// leading "user@".
+func sanitizeRemoteURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		u.User = nil
+		return u.String()
+	}
+	// scp-like form (no scheme): user@host:path -> host:path.
+	if at := strings.IndexByte(raw, '@'); at >= 0 && !strings.Contains(raw, "://") {
+		if rest := raw[at+1:]; strings.Contains(rest, ":") {
+			return rest
+		}
+	}
+	return raw
 }
 
 // countUnique counts distinct non-empty trimmed lines.

--- a/internal/repoinfo/repoinfo.go
+++ b/internal/repoinfo/repoinfo.go
@@ -193,9 +193,21 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 	if remote, err := run(ctx, dir, "remote", "get-url", "origin"); err == nil {
 		info.RemoteURL = strings.TrimSpace(remote)
 	}
-	if first, err := run(ctx, dir, "log", "--reverse", "-1", "--format=%ct"); err == nil {
-		if ts, perr := strconv.ParseInt(strings.TrimSpace(first), 10, 64); perr == nil {
-			days := int((now.Unix() - ts) / 86400)
+	// Age = time since the FIRST commit. Use --max-parents=0 (root commits) — NOT
+	// `log --reverse -1`, where git applies the -1 limit BEFORE reversing and so
+	// returns the LATEST commit (age would always be ~0). Output is tiny (one root
+	// for a normal repo; take the oldest across multiple roots).
+	if roots, err := run(ctx, dir, "log", "--max-parents=0", "--format=%ct"); err == nil {
+		oldest, found := int64(0), false
+		for _, line := range strings.Split(roots, "\n") {
+			if ts, perr := strconv.ParseInt(strings.TrimSpace(line), 10, 64); perr == nil {
+				if !found || ts < oldest {
+					oldest, found = ts, true
+				}
+			}
+		}
+		if found {
+			days := int((now.Unix() - oldest) / 86400)
 			if days < 0 {
 				days = 0
 			}

--- a/internal/repoinfo/repoinfo_test.go
+++ b/internal/repoinfo/repoinfo_test.go
@@ -1,0 +1,178 @@
+package repoinfo
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeGit returns canned output per subcommand and records every subcommand used.
+func fakeGit(t *testing.T, out map[string]string, used *[]string) RunGit {
+	t.Helper()
+	return func(_ context.Context, _ string, args ...string) (string, error) {
+		if used != nil && len(args) > 0 {
+			*used = append(*used, args[0])
+		}
+		key := args[0]
+		v, ok := out[key]
+		if !ok {
+			return "", errors.New("no canned output for " + key)
+		}
+		return v, nil
+	}
+}
+
+const lsTree = "" +
+	"100644 blob aaa 5000\tmain.go\n" +
+	"100644 blob bbb 2500\tinternal/util.go\n" +
+	"100644 blob ccc 100\tgo.mod\n" +
+	"100644 blob ddd 9000\tweb/app.ts\n" +
+	"100644 blob eee 50\t.github/workflows/ci.yml\n" +
+	"160000 commit fff -\tvendored\n"
+
+func TestCollectCoreMetrics(t *testing.T) {
+	now := time.Unix(100*86400, 0) // 100 days after first commit ts=0
+	info, err := Collect(context.Background(), Options{
+		Now: now,
+		RunGit: fakeGit(t, map[string]string{
+			"ls-tree":   lsTree,
+			"rev-parse": "main\n",
+			"remote":    "https://github.com/x/y.git\n",
+			"log":       "0\n",
+			"rev-list":  "12\n",
+		}, nil),
+	})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if !info.HasGit {
+		t.Fatal("HasGit should be true")
+	}
+	if info.FileCount != 5 { // gitlink ("-" size) skipped
+		t.Fatalf("FileCount=%d want 5", info.FileCount)
+	}
+	if info.PrimaryLanguage != "TypeScript" { // 9000 bytes > Go's 7500
+		t.Fatalf("PrimaryLanguage=%q want TypeScript", info.PrimaryLanguage)
+	}
+	if info.LanguageCount != 2 {
+		t.Fatalf("LanguageCount=%d want 2 (Go, TypeScript)", info.LanguageCount)
+	}
+	if len(info.BuildTools) != 1 || info.BuildTools[0] != "go.mod" {
+		t.Fatalf("BuildTools=%v", info.BuildTools)
+	}
+	if len(info.CICD) != 1 || info.CICD[0] != "GitHub Actions" {
+		t.Fatalf("CICD=%v", info.CICD)
+	}
+	if info.Branch != "main" {
+		t.Fatalf("Branch=%q", info.Branch)
+	}
+	if info.RemoteURL != "https://github.com/x/y.git" {
+		t.Fatalf("RemoteURL=%q", info.RemoteURL)
+	}
+	if info.AgeDays == nil || *info.AgeDays != 100 {
+		t.Fatalf("AgeDays=%v want 100", info.AgeDays)
+	}
+	if info.CommitVelocity30d == nil || *info.CommitVelocity30d != 12 {
+		t.Fatalf("CommitVelocity30d=%v want 12", info.CommitVelocity30d)
+	}
+}
+
+func TestCollectContributorsUnique(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) (string, error) {
+		switch args[0] {
+		case "ls-tree":
+			return lsTree, nil
+		case "log":
+			for _, a := range args {
+				if a == "--format=%aN" {
+					return "Ann\nBob\nAnn\n\n", nil
+				}
+			}
+			return "0\n", nil // first-commit ts
+		case "rev-parse":
+			return "main\n", nil
+		case "rev-list":
+			return "3\n", nil
+		case "remote":
+			return "", errors.New("no remote")
+		}
+		return "", errors.New("unexpected " + args[0])
+	}
+	info, err := Collect(context.Background(), Options{Now: time.Unix(0, 0), RunGit: run})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if info.Contributors90d == nil || *info.Contributors90d != 2 {
+		t.Fatalf("Contributors90d=%v want 2", info.Contributors90d)
+	}
+	if info.RemoteURL != "" {
+		t.Fatalf("RemoteURL should be empty when origin missing, got %q", info.RemoteURL)
+	}
+}
+
+func TestCollectHistoryMetricsFailSoft(t *testing.T) {
+	// The author-list log fails, but first-commit log + rev-list succeed: only
+	// Contributors90d is omitted; the rest of the report still renders.
+	run := func(_ context.Context, _ string, args ...string) (string, error) {
+		switch args[0] {
+		case "ls-tree":
+			return lsTree, nil
+		case "rev-parse":
+			return "main\n", nil
+		case "remote":
+			return "u\n", nil
+		case "rev-list":
+			return "4\n", nil
+		case "log":
+			for _, a := range args {
+				if a == "--format=%aN" {
+					return "", errors.New("boom")
+				}
+			}
+			return "0\n", nil
+		}
+		return "", errors.New("unexpected " + args[0])
+	}
+	info, err := Collect(context.Background(), Options{Now: time.Unix(0, 0), RunGit: run})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if info.Contributors90d != nil {
+		t.Fatalf("Contributors90d should be nil on log failure, got %d", *info.Contributors90d)
+	}
+	if info.AgeDays == nil {
+		t.Fatal("AgeDays should still be set (first-commit log succeeded)")
+	}
+	if info.CommitVelocity30d == nil {
+		t.Fatal("CommitVelocity30d should still be set")
+	}
+}
+
+func TestCollectNotGitRepo(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) (string, error) {
+		return "", errors.New("fatal: not a git repository")
+	}
+	if _, err := Collect(context.Background(), Options{RunGit: run}); !errors.Is(err, ErrNotGitRepo) {
+		t.Fatalf("expected ErrNotGitRepo, got %v", err)
+	}
+}
+
+func TestCollectOnlyReadOnlyLocalSubcommands(t *testing.T) {
+	allowed := map[string]bool{"ls-tree": true, "rev-parse": true, "remote": true, "log": true, "rev-list": true}
+	var used []string
+	_, err := Collect(context.Background(), Options{
+		Now: time.Unix(0, 0),
+		RunGit: fakeGit(t, map[string]string{
+			"ls-tree": lsTree, "rev-parse": "main\n", "remote": "u\n", "log": "0\n", "rev-list": "1\n",
+		}, &used),
+	})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	for _, sub := range used {
+		if !allowed[sub] {
+			t.Fatalf("disallowed git subcommand used: %q (network-free invariant)", sub)
+		}
+	}
+}

--- a/internal/repoinfo/repoinfo_test.go
+++ b/internal/repoinfo/repoinfo_test.go
@@ -3,6 +3,7 @@ package repoinfo
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -190,6 +191,54 @@ func TestCollectAgeFromOldestRootCommit(t *testing.T) {
 	}
 	if info.AgeDays == nil || *info.AgeDays != 10 {
 		t.Fatalf("AgeDays=%v want 10 (now - oldest root 100)", info.AgeDays)
+	}
+}
+
+func TestSanitizeRemoteURL(t *testing.T) {
+	cases := map[string]string{
+		"https://x-access-token:ghp_secret@github.com/o/r.git": "https://github.com/o/r.git",
+		"https://user:pass@gitlab.com/o/r.git":                 "https://gitlab.com/o/r.git",
+		"https://github.com/o/r.git":                           "https://github.com/o/r.git",
+		"ssh://git@github.com/o/r.git":                         "ssh://github.com/o/r.git",
+		"git@github.com:o/r.git":                               "github.com:o/r.git",
+		"":                                                     "",
+	}
+	for in, want := range cases {
+		got := sanitizeRemoteURL(in)
+		if got != want {
+			t.Fatalf("sanitizeRemoteURL(%q)=%q want %q", in, got, want)
+		}
+		if strings.Contains(got, "secret") || strings.Contains(got, "pass") || strings.Contains(got, "ghp_") {
+			t.Fatalf("credential leaked for %q: %q", in, got)
+		}
+	}
+}
+
+func TestCollectStripsRemoteCredentials(t *testing.T) {
+	run := func(_ context.Context, _ string, args ...string) (string, error) {
+		switch args[0] {
+		case "ls-tree":
+			return lsTree, nil
+		case "remote":
+			return "https://x-access-token:ghp_SECRET@github.com/o/r.git\n", nil
+		case "rev-parse":
+			return "main\n", nil
+		case "log":
+			return "0\n", nil
+		case "rev-list":
+			return "1\n", nil
+		}
+		return "", errors.New("unexpected " + args[0])
+	}
+	info, err := Collect(context.Background(), Options{Now: time.Unix(0, 0), RunGit: run})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if info.RemoteURL != "https://github.com/o/r.git" {
+		t.Fatalf("RemoteURL=%q want sanitized", info.RemoteURL)
+	}
+	if strings.Contains(info.RemoteURL, "ghp_SECRET") {
+		t.Fatal("credential leaked into RemoteURL")
 	}
 }
 

--- a/internal/repoinfo/repoinfo_test.go
+++ b/internal/repoinfo/repoinfo_test.go
@@ -23,13 +23,14 @@ func fakeGit(t *testing.T, out map[string]string, used *[]string) RunGit {
 	}
 }
 
+// ls-tree -z output: NUL-terminated records, paths unquoted.
 const lsTree = "" +
-	"100644 blob aaa 5000\tmain.go\n" +
-	"100644 blob bbb 2500\tinternal/util.go\n" +
-	"100644 blob ccc 100\tgo.mod\n" +
-	"100644 blob ddd 9000\tweb/app.ts\n" +
-	"100644 blob eee 50\t.github/workflows/ci.yml\n" +
-	"160000 commit fff -\tvendored\n"
+	"100644 blob aaa 5000\tmain.go\x00" +
+	"100644 blob bbb 2500\tinternal/util.go\x00" +
+	"100644 blob ccc 100\tgo.mod\x00" +
+	"100644 blob ddd 9000\tweb/app.ts\x00" +
+	"100644 blob eee 50\t.github/workflows/ci.yml\x00" +
+	"160000 commit fff -\tvendored\x00"
 
 func TestCollectCoreMetrics(t *testing.T) {
 	now := time.Unix(100*86400, 0) // 100 days after first commit ts=0
@@ -51,6 +52,13 @@ func TestCollectCoreMetrics(t *testing.T) {
 	}
 	if info.FileCount != 5 { // gitlink ("-" size) skipped
 		t.Fatalf("FileCount=%d want 5", info.FileCount)
+	}
+	// Dirs: internal, web, .github, .github/workflows (passthrough .github counted).
+	if info.DirectoryCount != 4 {
+		t.Fatalf("DirectoryCount=%d want 4", info.DirectoryCount)
+	}
+	if info.MaxDepth != 2 {
+		t.Fatalf("MaxDepth=%d want 2", info.MaxDepth)
 	}
 	if info.PrimaryLanguage != "TypeScript" { // 9000 bytes > Go's 7500
 		t.Fatalf("PrimaryLanguage=%q want TypeScript", info.PrimaryLanguage)
@@ -146,6 +154,42 @@ func TestCollectHistoryMetricsFailSoft(t *testing.T) {
 	}
 	if info.CommitVelocity30d == nil {
 		t.Fatal("CommitVelocity30d should still be set")
+	}
+}
+
+func TestCollectAgeFromOldestRootCommit(t *testing.T) {
+	// Age must come from the FIRST commit (root, via --max-parents=0), and the
+	// OLDEST root when there are several — not the latest commit. This fails
+	// against the old `log --reverse -1` form (which returned the latest commit).
+	run := func(_ context.Context, _ string, args ...string) (string, error) {
+		switch args[0] {
+		case "ls-tree":
+			return lsTree, nil
+		case "rev-parse":
+			return "main\n", nil
+		case "remote":
+			return "", errors.New("no remote")
+		case "rev-list":
+			return "1\n", nil
+		case "log":
+			for _, a := range args {
+				if a == "--max-parents=0" {
+					return "500\n100\n", nil // two roots; oldest is 100
+				}
+				if a == "--format=%aN" {
+					return "Ann\n", nil
+				}
+			}
+			return "", errors.New("unexpected log args")
+		}
+		return "", errors.New("unexpected " + args[0])
+	}
+	info, err := Collect(context.Background(), Options{Now: time.Unix(100+10*86400, 0), RunGit: run})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if info.AgeDays == nil || *info.AgeDays != 10 {
+		t.Fatalf("AgeDays=%v want 10 (now - oldest root 100)", info.AgeDays)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `zero repo-info [--json] [--cwd <dir>]` — a repository characterizer that reads **local git only** (no network). Dep-free, additive (a brand-new command + package; nothing else changes).

Reports: file / directory / max-depth / estimated-LOC counts; per-language breakdown (LOC + file counts) with primary language; workspace type + package count; build / test / CI tooling; and bounded git-history metrics (branch, remote URL, age, contributors-90d, commit-velocity-30d).

This is the network-free residue of the upstream telemetry module — the OTEL/metrics-egress half is intentionally **not** ported.

## Design

- **`internal/repoinfo`** (new, stdlib-only): `Collect(ctx, Options{Cwd, Now, RunGit}) (Info, error)` behind an injectable `RunGit` (default shells local `git`). Streams `git ls-tree -r -l -z HEAD`, plus `rev-parse` / `remote get-url origin` / `log` / `rev-list`. `languages.go` (extension→language map) and `detect.go` (build/test/CI + workspace tables) are pure helpers.
- **`internal/cli/repoinfo.go`**: `runRepoInfo` formats text or `--json`; dispatch `case "repo-info"` in `app.go` + help line.

## Guarantees

- **Network-free:** only the read-only local subcommands `ls-tree`, `rev-parse`, `remote get-url`, `log`, `rev-list` are ever invoked; manifest reads are local `os.ReadFile`. Enforced by a test that records every subcommand against an allowlist.
- **Robust parsing:** `-z` (NUL-terminated, unquoted paths) so non-ASCII/special filenames aren't dropped; gitlinks (size `-`) skipped; `DirectoryCount` counts passthrough directories (expands each file's ancestors), verified against `git ls-tree -r -t`.
- **Correct age:** first-commit via `log --max-parents=0` (NOT `log --reverse -1`, which returns the latest commit); oldest root chosen for multi-root repos.
- **Fail-soft:** non-git / no-commits → friendly message (stderr, exit 1); each history metric is omitted (not fatal) on error; a 20s context bounds runtime; `--max-count` bounds history walking.
- **Defaults / scope:** focused field set (not the upstream 11-category config taxonomy); pure data/prose formats (json/yaml/toml/md) are excluded from the language ranking so "primary language" stays meaningful (markup-code like html/css is kept).

## Test Plan

- [x] `go build ./...` / `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `go vet ./...` clean; `gofmt` clean
- [x] `go test ./...` green (repoinfo: parse/languages/detect/age/contributors/network-free; cli: parse/format/hermetic-JSON)
- [x] `go test -race ./internal/{repoinfo,cli}/...` green
- [x] Smoke: `zero repo-info` / `--json` on this repo (Go primary, DirectoryCount matches `git ls-tree -r -t`, real age)
- [x] Adversarial whole-diff review: caught + fixed DirectoryCount undercount and `core.quotePath` filename corruption

### Reviewer focus
- Network-free invariant (allowlisted subcommands; no fetch/ls-remote).
- `-z` parsing + ancestor-based DirectoryCount.
- Age from root commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repo-info (alias: repoinfo) CLI command with help entry; supports --json and --cwd and prints text or pretty-JSON summaries.
  * Reports file/dir counts, language breakdown and LOC estimates, workspace/package hints, and optional Git metadata (branch, sanitized remote URL, repo age, contributors, commit velocity).

* **Tests**
  * Added unit and end-to-end tests for argument parsing, output formatting, detection heuristics, remote-URL sanitization, and repository metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->