### PR TITLE
Add provider health diagnostics

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/observability"
 	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/selfverify"
@@ -38,6 +39,7 @@ type appDeps struct {
 	resolveConfig        func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
 	resolveMCPConfig     func(workspaceRoot string) (config.MCPConfig, error)
 	newProvider          func(config.ProviderProfile) (zeroruntime.Provider, error)
+	probeProviderHealth  func(context.Context, providerhealth.Options) providerhealth.Result
 	newSessionStore      func() *sessions.Store
 	loadPlugins          func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks            func(hooks.LoadOptions) (hooks.LoadResult, error)
@@ -97,6 +99,7 @@ func defaultAppDeps() appDeps {
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
 			return providers.New(profile, providers.Options{UserAgent: userAgent()})
 		},
+		probeProviderHealth: providerhealth.Probe,
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
 		},
@@ -239,6 +242,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.newProvider == nil {
 		deps.newProvider = defaults.newProvider
+	}
+	if deps.probeProviderHealth == nil {
+		deps.probeProviderHealth = defaults.probeProviderHealth
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore

--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -434,6 +434,7 @@ Inspects resolved provider profiles and provider catalog descriptors without pri
 
 Flags:
       --json                    Print JSON summary
+      --connectivity            Probe provider endpoint for providers check
       --transport <transport>   Filter catalog descriptors by transport
 
 Add flags:

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -414,6 +416,133 @@ func TestRunProvidersCheckConstructsProvider(t *testing.T) {
 	if !strings.Contains(output, "Provider check") || !strings.Contains(output, "status: ok") {
 		t.Fatalf("unexpected check output: %q", output)
 	}
+}
+
+func TestRunProvidersCheckConnectivityJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("path = %q, want /models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test-secret" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"custom-model"}]}`))
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      server.URL,
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		}
+		return config.ResolvedConfig{ActiveProvider: "local", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+	deps.newProvider = func(config.ProviderProfile) (zeroruntime.Provider, error) {
+		return commandCenterProvider{}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "local", "--connectivity", "--json"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	var payload struct {
+		Status string `json:"status"`
+		Health struct {
+			Status string `json:"status"`
+			Checks []struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+			} `json:"checks"`
+		} `json:"health"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("providers check JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if payload.Status != "ok" || payload.Health.Status != "pass" {
+		t.Fatalf("unexpected health payload: %#v", payload)
+	}
+	if !providerHealthCheckStatus(payload.Health.Checks, "provider.connectivity", "pass") {
+		t.Fatalf("missing provider.connectivity pass: %#v", payload.Health.Checks)
+	}
+}
+
+func TestRunProvidersCheckConnectivityJSONReturnsHealthFailure(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://user:base-secret@example.invalid/v1?api_key=query-secret",
+		}
+		return config.ResolvedConfig{ActiveProvider: "local", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+	deps.newProvider = func(config.ProviderProfile) (zeroruntime.Provider, error) {
+		t.Fatal("newProvider should not run before emitting connectivity health")
+		return nil, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "local", "--connectivity", "--json"}, &stdout, &stderr, deps)
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected exit code %d, got %d: %s", exitProvider, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	var payload struct {
+		Status string `json:"status"`
+		Health struct {
+			Status  string `json:"status"`
+			BaseURL string `json:"baseURL"`
+			Checks  []struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+			} `json:"checks"`
+		} `json:"health"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("providers check JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if payload.Status != "fail" || payload.Health.Status != "fail" {
+		t.Fatalf("unexpected health failure payload: %#v", payload)
+	}
+	if !providerHealthCheckStatus(payload.Health.Checks, "provider.config", "fail") {
+		t.Fatalf("missing provider.config failure: %#v", payload.Health.Checks)
+	}
+	output := stdout.String()
+	for _, secret := range []string{"base-secret", "query-secret"} {
+		if strings.Contains(output, secret) {
+			t.Fatalf("secret %q leaked in providers check JSON: %s", secret, output)
+		}
+	}
+	if strings.Contains(output, "user:") {
+		t.Fatalf("URL userinfo leaked in providers check JSON: %s", output)
+	}
+}
+
+func providerHealthCheckStatus(checks []struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}, id string, status string) bool {
+	for _, check := range checks {
+		if check.ID == id && check.Status == status {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRunProvidersCheckAcceptsAuthHeaderValueCredential(t *testing.T) {

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/zerocommands"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -419,18 +418,6 @@ func TestRunProvidersCheckConstructsProvider(t *testing.T) {
 }
 
 func TestRunProvidersCheckConnectivityJSON(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/models" {
-			t.Fatalf("path = %q, want /models", r.URL.Path)
-		}
-		if got := r.Header.Get("Authorization"); got != "Bearer sk-test-secret" {
-			t.Fatalf("Authorization = %q", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"custom-model"}]}`))
-	}))
-	defer server.Close()
-
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	deps := commandCenterDeps(t)
@@ -438,11 +425,22 @@ func TestRunProvidersCheckConnectivityJSON(t *testing.T) {
 		profile := config.ProviderProfile{
 			Name:         "local",
 			ProviderKind: config.ProviderKindOpenAICompatible,
-			BaseURL:      server.URL,
+			BaseURL:      "https://api.example.com/v1",
 			APIKey:       "sk-test-secret",
 			Model:        "custom-model",
 		}
 		return config.ResolvedConfig{ActiveProvider: "local", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+	deps.probeProviderHealth = func(_ context.Context, options providerhealth.Options) providerhealth.Result {
+		if !options.Connectivity || options.Profile.Name != "local" {
+			t.Fatalf("unexpected health probe options: %#v", options)
+		}
+		return providerhealth.Result{
+			Status: providerhealth.StatusPass,
+			Checks: []providerhealth.Check{
+				{ID: "provider.connectivity", Status: providerhealth.StatusPass, Message: "reachable"},
+			},
+		}
 	}
 	deps.newProvider = func(config.ProviderProfile) (zeroruntime.Provider, error) {
 		t.Fatal("newProvider should not run during connectivity health check")
@@ -475,6 +473,48 @@ func TestRunProvidersCheckConnectivityJSON(t *testing.T) {
 	}
 	if !providerHealthCheckStatus(payload.Health.Checks, "provider.connectivity", "pass") {
 		t.Fatalf("missing provider.connectivity pass: %#v", payload.Health.Checks)
+	}
+}
+
+func TestRunProvidersCheckConnectivityJSONSurfacesWarningStatus(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		profile := config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		}
+		return config.ResolvedConfig{ActiveProvider: "local", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
+	}
+	deps.probeProviderHealth = func(context.Context, providerhealth.Options) providerhealth.Result {
+		return providerhealth.Result{
+			Status: providerhealth.StatusWarn,
+			Checks: []providerhealth.Check{
+				{ID: "provider.connectivity", Status: providerhealth.StatusWarn, Category: providerhealth.CategoryRateLimit, Message: "rate limited"},
+			},
+		}
+	}
+
+	exitCode := runWithDeps([]string{"providers", "check", "local", "--connectivity", "--json"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var payload struct {
+		Status string `json:"status"`
+		Health struct {
+			Status string `json:"status"`
+		} `json:"health"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("providers check JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if payload.Status != "warn" || payload.Health.Status != "warn" {
+		t.Fatalf("unexpected warning payload: %#v", payload)
 	}
 }
 

--- a/internal/cli/command_center_test.go
+++ b/internal/cli/command_center_test.go
@@ -445,7 +445,8 @@ func TestRunProvidersCheckConnectivityJSON(t *testing.T) {
 		return config.ResolvedConfig{ActiveProvider: "local", Provider: profile, Providers: []config.ProviderProfile{profile}, MaxTurns: 7}, nil
 	}
 	deps.newProvider = func(config.ProviderProfile) (zeroruntime.Provider, error) {
-		return commandCenterProvider{}, nil
+		t.Fatal("newProvider should not run during connectivity health check")
+		return nil, nil
 	}
 
 	exitCode := runWithDeps([]string{"providers", "check", "local", "--connectivity", "--json"}, &stdout, &stderr, deps)

--- a/internal/cli/observability.go
+++ b/internal/cli/observability.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/doctor"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	zsearch "github.com/Gitlawb/zero/internal/search"
 	"github.com/Gitlawb/zero/internal/sessions"
 )
@@ -48,14 +50,24 @@ func runDoctor(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 	if resolved, resolveErr := deps.resolveConfig(workspaceRoot, config.Overrides{}); resolveErr == nil {
 		provider = resolved.Provider
 	}
+	var health *providerhealth.Result
+	if options.connectivity && config.HasProviderProfile(provider) {
+		probe := deps.probeProviderHealth(context.Background(), providerhealth.Options{
+			Profile:      provider,
+			Connectivity: true,
+			UserAgent:    userAgent(),
+		})
+		health = &probe
+	}
 
 	report := doctor.Run(doctor.Options{
-		Now:           deps.now,
-		Runtime:       "go",
-		UserConfig:    userConfig,
-		ProjectConfig: projectConfig,
-		Provider:      provider,
-		Connectivity:  options.connectivity,
+		Now:            deps.now,
+		Runtime:        "go",
+		UserConfig:     userConfig,
+		ProjectConfig:  projectConfig,
+		Provider:       provider,
+		Connectivity:   options.connectivity,
+		ProviderHealth: health,
 	})
 	if options.json {
 		if err := writePrettyJSON(stdout, report); err != nil {

--- a/internal/cli/observability.go
+++ b/internal/cli/observability.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -52,7 +51,9 @@ func runDoctor(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 	}
 	var health *providerhealth.Result
 	if options.connectivity && config.HasProviderProfile(provider) {
-		probe := deps.probeProviderHealth(context.Background(), providerhealth.Options{
+		ctx, stop := signalContext()
+		defer stop()
+		probe := deps.probeProviderHealth(ctx, providerhealth.Options{
 			Profile:      provider,
 			Connectivity: true,
 			UserAgent:    userAgent(),

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -2,10 +2,9 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/sessions"
 )
 
@@ -60,17 +60,10 @@ func TestRunDoctorFormatsRedactedProviderDiagnostics(t *testing.T) {
 }
 
 func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/models" {
-			t.Fatalf("path = %q, want /models", r.URL.Path)
-		}
-		_, _ = w.Write([]byte(`{"data":[{"id":"custom-model"}]}`))
-	}))
-	defer server.Close()
-
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cwd := t.TempDir()
+	probed := false
 
 	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
 		getwd: func() (string, error) {
@@ -80,11 +73,23 @@ func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
 			profile := config.ProviderProfile{
 				Name:         "local",
 				ProviderKind: config.ProviderKindOpenAICompatible,
-				BaseURL:      server.URL,
+				BaseURL:      "https://api.example.com/v1",
 				APIKey:       "sk-test-secret",
 				Model:        "custom-model",
 			}
 			return config.ResolvedConfig{Provider: profile, Providers: []config.ProviderProfile{profile}, ActiveProvider: "local"}, nil
+		},
+		probeProviderHealth: func(_ context.Context, options providerhealth.Options) providerhealth.Result {
+			probed = true
+			if !options.Connectivity || options.Profile.Name != "local" {
+				t.Fatalf("unexpected health probe options: %#v", options)
+			}
+			return providerhealth.Result{
+				Status: providerhealth.StatusPass,
+				Checks: []providerhealth.Check{
+					{ID: "provider.connectivity", Status: providerhealth.StatusPass, Message: "reachable"},
+				},
+			}
 		},
 		now: fixedCLITime("2026-06-04T16:00:00Z"),
 	})
@@ -95,6 +100,9 @@ func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
 	output := stdout.String()
 	if !strings.Contains(output, "[pass] provider.connectivity") {
 		t.Fatalf("expected provider.connectivity pass, got %q", output)
+	}
+	if !probed {
+		t.Fatal("doctor did not call probeProviderHealth")
 	}
 	if strings.Contains(output, "not wired") {
 		t.Fatalf("doctor still returned placeholder connectivity message: %q", output)

--- a/internal/cli/observability_test.go
+++ b/internal/cli/observability_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,6 +56,119 @@ func TestRunDoctorFormatsRedactedProviderDiagnostics(t *testing.T) {
 	}
 	if strings.Contains(output, "sk-proj-secret") {
 		t.Fatalf("doctor output leaked secret: %q", output)
+	}
+}
+
+func TestRunDoctorConnectivityProbesProvider(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			t.Fatalf("path = %q, want /models", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"custom-model"}]}`))
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+
+	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			profile := config.ProviderProfile{
+				Name:         "local",
+				ProviderKind: config.ProviderKindOpenAICompatible,
+				BaseURL:      server.URL,
+				APIKey:       "sk-test-secret",
+				Model:        "custom-model",
+			}
+			return config.ResolvedConfig{Provider: profile, Providers: []config.ProviderProfile{profile}, ActiveProvider: "local"}, nil
+		},
+		now: fixedCLITime("2026-06-04T16:00:00Z"),
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "[pass] provider.connectivity") {
+		t.Fatalf("expected provider.connectivity pass, got %q", output)
+	}
+	if strings.Contains(output, "not wired") {
+		t.Fatalf("doctor still returned placeholder connectivity message: %q", output)
+	}
+}
+
+func TestRunDoctorConnectivityReportsProviderHealthFailure(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+
+	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			profile := config.ProviderProfile{
+				Name:         "openai",
+				ProviderKind: config.ProviderKindOpenAI,
+				BaseURL:      config.OpenAIBaseURL,
+				Model:        "gpt-4.1",
+			}
+			return config.ResolvedConfig{Provider: profile, Providers: []config.ProviderProfile{profile}, ActiveProvider: "openai"}, nil
+		},
+		now: fixedCLITime("2026-06-04T16:05:00Z"),
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected exit code %d, got %d: %s", exitProvider, exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "[fail] provider.connectivity") {
+		t.Fatalf("expected provider.connectivity failure, got %q", output)
+	}
+	if !strings.Contains(output, "requires API credentials") {
+		t.Fatalf("expected concrete auth failure, got %q", output)
+	}
+	if strings.Contains(output, "completed without a connectivity check") || strings.Contains(output, "not wired") {
+		t.Fatalf("doctor returned generic connectivity message: %q", output)
+	}
+}
+
+func TestRunDoctorConnectivityDoesNotMaskConfigHealthFailure(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+
+	exitCode := runWithDeps([]string{"doctor", "--connectivity"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			profile := config.ProviderProfile{
+				Name:         "local",
+				ProviderKind: config.ProviderKindOpenAICompatible,
+				BaseURL:      "https://example.invalid/v1",
+			}
+			return config.ResolvedConfig{Provider: profile, Providers: []config.ProviderProfile{profile}, ActiveProvider: "local"}, nil
+		},
+		now: fixedCLITime("2026-06-04T16:06:00Z"),
+	})
+
+	if exitCode != exitProvider {
+		t.Fatalf("expected exit code %d, got %d: %s", exitProvider, exitCode, stderr.String())
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "[fail] provider.connectivity") || !strings.Contains(output, "requires model") {
+		t.Fatalf("expected concrete config health failure, got %q", output)
+	}
+	if strings.Contains(output, "runtime did not resolve") || strings.Contains(output, "completed without a connectivity check") {
+		t.Fatalf("doctor masked provider health failure: %q", output)
 	}
 }
 

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/zerocommands"
 )
 
@@ -25,8 +27,9 @@ type providerAddOptions struct {
 }
 
 type providerCheckOptions struct {
-	name string
-	json bool
+	name         string
+	json         bool
+	connectivity bool
 }
 
 func runProvidersAdd(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -90,22 +93,58 @@ func runProvidersCheck(args []string, stdout io.Writer, stderr io.Writer, deps a
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	if err := validateProviderRuntimeReady(profile); err != nil {
-		return writeAppError(stderr, err.Error(), exitProvider)
-	}
-	if _, err := deps.newProvider(profile); err != nil {
-		return writeAppError(stderr, err.Error(), exitProvider)
+	var health providerhealth.Result
+	if options.connectivity {
+		health = deps.probeProviderHealth(context.Background(), providerhealth.Options{
+			Profile:      profile,
+			Connectivity: true,
+			UserAgent:    userAgent(),
+		})
+	} else {
+		if err := validateProviderRuntimeReady(profile); err != nil {
+			return writeAppError(stderr, err.Error(), exitProvider)
+		}
+		if _, err := deps.newProvider(profile); err != nil {
+			return writeAppError(stderr, err.Error(), exitProvider)
+		}
 	}
 
 	snapshot := zerocommands.ProviderSnapshotFromProfile(profile, profile.Name == resolved.ActiveProvider)
 	if options.json {
-		if err := writePrettyJSON(stdout, map[string]any{"provider": snapshot, "status": "ok"}); err != nil {
+		payload := map[string]any{"provider": snapshot, "status": "ok"}
+		if options.connectivity {
+			payload["health"] = health
+			if health.Status == providerhealth.StatusFail {
+				payload["status"] = "fail"
+			}
+		}
+		if err := writePrettyJSON(stdout, payload); err != nil {
 			return exitCrash
+		}
+		if options.connectivity && health.Status == providerhealth.StatusFail {
+			return exitProvider
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintf(stdout, "Provider check\nname: %s\nstatus: ok\nkind: %s\nmodel: %s\napi model: %s\n", snapshot.Name, snapshot.ProviderKind, snapshot.Model, snapshot.APIModel); err != nil {
+	status := "ok"
+	if options.connectivity && health.Status == providerhealth.StatusFail {
+		status = "fail"
+	}
+	if _, err := fmt.Fprintf(stdout, "Provider check\nname: %s\nstatus: %s\nkind: %s\nmodel: %s\napi model: %s\n", snapshot.Name, status, snapshot.ProviderKind, snapshot.Model, snapshot.APIModel); err != nil {
 		return exitCrash
+	}
+	if options.connectivity {
+		if _, err := fmt.Fprintf(stdout, "connectivity: %s\n", health.Status); err != nil {
+			return exitCrash
+		}
+		if check := health.PrimaryCheck(); check != nil {
+			if _, err := fmt.Fprintf(stdout, "%s: %s\n", check.ID, check.Message); err != nil {
+				return exitCrash
+			}
+		}
+		if health.Status == providerhealth.StatusFail {
+			return exitProvider
+		}
 	}
 	return exitSuccess
 }
@@ -249,6 +288,8 @@ func parseProviderCheckArgs(args []string) (providerCheckOptions, bool, error) {
 			return options, true, nil
 		case arg == "--json":
 			options.json = true
+		case arg == "--connectivity":
+			options.connectivity = true
 		case strings.HasPrefix(arg, "-"):
 			return options, false, execUsageError{fmt.Sprintf("unknown flag %q", arg)}
 		default:

--- a/internal/cli/provider_setup.go
+++ b/internal/cli/provider_setup.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -95,7 +94,9 @@ func runProvidersCheck(args []string, stdout io.Writer, stderr io.Writer, deps a
 	}
 	var health providerhealth.Result
 	if options.connectivity {
-		health = deps.probeProviderHealth(context.Background(), providerhealth.Options{
+		ctx, stop := signalContext()
+		defer stop()
+		health = deps.probeProviderHealth(ctx, providerhealth.Options{
 			Profile:      profile,
 			Connectivity: true,
 			UserAgent:    userAgent(),
@@ -114,9 +115,7 @@ func runProvidersCheck(args []string, stdout io.Writer, stderr io.Writer, deps a
 		payload := map[string]any{"provider": snapshot, "status": "ok"}
 		if options.connectivity {
 			payload["health"] = health
-			if health.Status == providerhealth.StatusFail {
-				payload["status"] = "fail"
-			}
+			payload["status"] = providerHealthStatusLabel(health.Status)
 		}
 		if err := writePrettyJSON(stdout, payload); err != nil {
 			return exitCrash
@@ -127,8 +126,8 @@ func runProvidersCheck(args []string, stdout io.Writer, stderr io.Writer, deps a
 		return exitSuccess
 	}
 	status := "ok"
-	if options.connectivity && health.Status == providerhealth.StatusFail {
-		status = "fail"
+	if options.connectivity {
+		status = providerHealthStatusLabel(health.Status)
 	}
 	if _, err := fmt.Fprintf(stdout, "Provider check\nname: %s\nstatus: %s\nkind: %s\nmodel: %s\napi model: %s\n", snapshot.Name, status, snapshot.ProviderKind, snapshot.Model, snapshot.APIModel); err != nil {
 		return exitCrash
@@ -147,6 +146,17 @@ func runProvidersCheck(args []string, stdout io.Writer, stderr io.Writer, deps a
 		}
 	}
 	return exitSuccess
+}
+
+func providerHealthStatusLabel(status providerhealth.Status) string {
+	switch status {
+	case providerhealth.StatusFail:
+		return "fail"
+	case providerhealth.StatusWarn:
+		return "warn"
+	default:
+		return "ok"
+	}
 }
 
 func parseProviderAddArgs(args []string) (providerAddOptions, bool, error) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
@@ -37,12 +38,13 @@ type Report struct {
 }
 
 type Options struct {
-	Now           func() time.Time
-	Runtime       string
-	UserConfig    string
-	ProjectConfig string
-	Provider      config.ProviderProfile
-	Connectivity  bool
+	Now            func() time.Time
+	Runtime        string
+	UserConfig     string
+	ProjectConfig  string
+	Provider       config.ProviderProfile
+	Connectivity   bool
+	ProviderHealth *providerhealth.Result
 }
 
 func Run(options Options) Report {
@@ -59,7 +61,7 @@ func Run(options Options) Report {
 	checks = append(checks, providerCheck)
 	modelCheck := providerModelCheck(options.Provider)
 	checks = append(checks, modelCheck)
-	checks = append(checks, connectivityCheck(options.Provider, options.Connectivity, modelCheck.Status))
+	checks = append(checks, connectivityCheck(options.Provider, options.Connectivity, modelCheck.Status, options.ProviderHealth))
 
 	report := Report{
 		GeneratedAt: now().UTC().Format(time.RFC3339),
@@ -159,14 +161,34 @@ func providerModelCheck(profile config.ProviderProfile) Check {
 	})
 }
 
-func connectivityCheck(profile config.ProviderProfile, enabled bool, modelStatus Status) Check {
+func connectivityCheck(profile config.ProviderProfile, enabled bool, modelStatus Status, health *providerhealth.Result) Check {
+	if !enabled {
+		if emptyProviderProfile(profile) || modelStatus == StatusFail {
+			return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity check was skipped because provider runtime did not resolve.", nil)
+		}
+		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probe skipped. Run `zero doctor --connectivity` to probe the provider endpoint.", map[string]any{"baseURL": profile.BaseURL})
+	}
+	if health != nil {
+		if providerCheck := health.PrimaryCheck(); providerCheck != nil {
+			return check("provider.connectivity", "Provider connectivity", doctorStatus(providerCheck.Status), providerCheck.Message, providerCheck.Details)
+		}
+		return check("provider.connectivity", "Provider connectivity", doctorStatus(health.Status), "Provider health probe completed without a connectivity check.", map[string]any{"healthStatus": health.Status})
+	}
 	if emptyProviderProfile(profile) || modelStatus == StatusFail {
 		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity check was skipped because provider runtime did not resolve.", nil)
 	}
-	if !enabled {
-		return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probe skipped. Run `zero doctor --connectivity` to probe the provider endpoint.", map[string]any{"baseURL": profile.BaseURL})
-	}
 	return check("provider.connectivity", "Provider connectivity", StatusWarn, "Connectivity probing is not wired in the Go doctor backend yet.", map[string]any{"baseURL": profile.BaseURL})
+}
+
+func doctorStatus(status providerhealth.Status) Status {
+	switch status {
+	case providerhealth.StatusPass:
+		return StatusPass
+	case providerhealth.StatusFail:
+		return StatusFail
+	default:
+		return StatusWarn
+	}
 }
 
 func emptyProviderProfile(profile config.ProviderProfile) bool {

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -1,0 +1,465 @@
+// Package providerhealth validates provider configuration and optionally probes
+// the configured provider endpoint with a bounded, non-generating request.
+package providerhealth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+type Status string
+
+const (
+	StatusPass Status = "pass"
+	StatusWarn Status = "warn"
+	StatusFail Status = "fail"
+)
+
+type Category string
+
+const (
+	CategoryConfig        Category = "config"
+	CategoryUnsupported   Category = "unsupported"
+	CategoryAuth          Category = "auth"
+	CategoryRateLimit     Category = "rate_limit"
+	CategoryNetwork       Category = "network"
+	CategoryTimeout       Category = "timeout"
+	CategoryProvider      Category = "provider_error"
+	CategoryProviderError          = CategoryProvider
+	CategoryConnectivity  Category = "connectivity"
+)
+
+const defaultTimeout = 5 * time.Second
+
+type Options struct {
+	Profile      config.ProviderProfile
+	Connectivity bool
+	HTTPClient   *http.Client
+	Timeout      time.Duration
+	UserAgent    string
+}
+
+type Result struct {
+	Status       Status  `json:"status"`
+	ProviderName string  `json:"providerName,omitempty"`
+	ProviderKind string  `json:"providerKind,omitempty"`
+	Model        string  `json:"model,omitempty"`
+	APIModel     string  `json:"apiModel,omitempty"`
+	BaseURL      string  `json:"baseURL,omitempty"`
+	Checks       []Check `json:"checks"`
+}
+
+type Check struct {
+	ID       string         `json:"id"`
+	Label    string         `json:"label"`
+	Status   Status         `json:"status"`
+	Category Category       `json:"category,omitempty"`
+	Message  string         `json:"message"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+func (result Result) Check(id string) *Check {
+	for index := range result.Checks {
+		if result.Checks[index].ID == id {
+			return &result.Checks[index]
+		}
+	}
+	return nil
+}
+
+func (result Result) PrimaryCheck() *Check {
+	if connectivity := result.Check("provider.connectivity"); connectivity != nil {
+		return connectivity
+	}
+	for index := range result.Checks {
+		if result.Checks[index].Status == StatusFail {
+			return &result.Checks[index]
+		}
+	}
+	for index := range result.Checks {
+		if result.Checks[index].Status == StatusWarn {
+			return &result.Checks[index]
+		}
+	}
+	if len(result.Checks) == 0 {
+		return nil
+	}
+	return &result.Checks[0]
+}
+
+func Probe(ctx context.Context, options Options) Result {
+	profile := options.Profile
+	result := Result{
+		Status:       StatusPass,
+		ProviderName: redact(strings.TrimSpace(profile.Name), profile),
+		ProviderKind: redact(strings.TrimSpace(string(profile.ProviderKind)), profile),
+		Model:        redact(strings.TrimSpace(profile.Model), profile),
+		BaseURL:      redactBaseURL(profile.BaseURL, profile),
+		Checks:       []Check{},
+	}
+
+	if !config.HasProviderProfile(profile) {
+		result.add(check("provider.config", "Provider config", StatusFail, CategoryConfig, "No LLM provider is configured.", nil, profile))
+		return result.finalize()
+	}
+	if strings.TrimSpace(profile.Model) == "" {
+		result.add(check("provider.config", "Provider config", StatusFail, CategoryConfig, fmt.Sprintf("Provider %s requires model.", providerName(profile)), nil, profile))
+		return result.finalize()
+	}
+	result.add(check("provider.config", "Provider config", StatusPass, CategoryConfig, fmt.Sprintf("Provider config loaded for %s.", providerName(profile)), map[string]any{
+		"name":     profile.Name,
+		"provider": profile.ProviderKind,
+		"baseURL":  profile.BaseURL,
+		"model":    profile.Model,
+	}, profile))
+
+	if unsupported := unsupportedCatalogCheck(profile); unsupported != nil {
+		result.add(*unsupported)
+		return result.finalize()
+	}
+
+	metadata, err := providers.ResolveRuntimeMetadata(profile, providers.Options{})
+	if err != nil {
+		result.add(check("provider.runtime", "Provider runtime", StatusFail, CategoryConfig, "Provider runtime did not resolve: "+err.Error(), nil, profile))
+		return result.finalize()
+	}
+	result.ProviderKind = redact(string(metadata.ProviderKind), profile)
+	result.APIModel = redact(metadata.APIModel, profile)
+	result.add(check("provider.runtime", "Provider runtime", StatusPass, CategoryConfig, fmt.Sprintf("Provider runtime resolves %s as %s.", providerName(profile), metadata.ProviderKind), map[string]any{
+		"apiModel":     metadata.APIModel,
+		"providerKind": metadata.ProviderKind,
+	}, profile))
+
+	if credentialRequired(profile) && !hasCredential(profile) {
+		result.add(check("provider.auth", "Provider auth", StatusFail, CategoryAuth, fmt.Sprintf("Provider %s requires API credentials.", providerName(profile)), credentialDetails(profile), profile))
+		return result.finalize()
+	}
+	if hasCredential(profile) {
+		result.add(check("provider.auth", "Provider auth", StatusPass, CategoryAuth, fmt.Sprintf("Provider %s has credentials configured.", providerName(profile)), credentialDetails(profile), profile))
+	} else {
+		result.add(check("provider.auth", "Provider auth", StatusPass, CategoryAuth, fmt.Sprintf("Provider %s does not require API credentials.", providerName(profile)), credentialDetails(profile), profile))
+	}
+
+	if !options.Connectivity {
+		return result.finalize()
+	}
+	result.add(connectivityCheck(ctx, profile, metadata.ProviderKind, options))
+	return result.finalize()
+}
+
+func (result *Result) add(check Check) {
+	result.Checks = append(result.Checks, check)
+}
+
+func (result Result) finalize() Result {
+	status := StatusPass
+	for _, check := range result.Checks {
+		if check.Status == StatusFail {
+			status = StatusFail
+			break
+		}
+		if check.Status == StatusWarn {
+			status = StatusWarn
+		}
+	}
+	result.Status = status
+	return result
+}
+
+func unsupportedCatalogCheck(profile config.ProviderProfile) *Check {
+	if strings.TrimSpace(profile.CatalogID) == "" {
+		return nil
+	}
+	descriptor, err := providercatalog.Require(profile.CatalogID)
+	if err != nil {
+		out := check("provider.runtime", "Provider runtime", StatusFail, CategoryConfig, err.Error(), nil, profile)
+		return &out
+	}
+	if providercatalog.RuntimeSupported(descriptor) {
+		return nil
+	}
+	out := check("provider.runtime", "Provider runtime", StatusFail, CategoryUnsupported, fmt.Sprintf("Provider %q uses transport %q: %s.", descriptor.ID, descriptor.Transport, providercatalog.RuntimeUnsupportedReason(descriptor)), map[string]any{
+		"transport": descriptor.Transport,
+	}, profile)
+	return &out
+}
+
+func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind config.ProviderKind, options Options) Check {
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	request, err := healthRequest(requestCtx, profile, kind, options)
+	if err != nil {
+		return check("provider.connectivity", "Provider connectivity", StatusFail, CategoryConfig, err.Error(), nil, profile)
+	}
+	client := options.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return classifyTransportError(err, profile)
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
+		return check("provider.connectivity", "Provider connectivity", StatusPass, CategoryConnectivity, fmt.Sprintf("Provider endpoint reachable (%d).", response.StatusCode), map[string]any{
+			"statusCode": response.StatusCode,
+			"endpoint":   request.URL.String(),
+		}, profile)
+	}
+
+	category := CategoryProvider
+	status := StatusFail
+	switch response.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		category = CategoryAuth
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable, 529:
+		category = CategoryRateLimit
+		status = StatusWarn
+	}
+	message := responseMessage(response.StatusCode, body)
+	return check("provider.connectivity", "Provider connectivity", status, category, message, map[string]any{
+		"statusCode": response.StatusCode,
+		"endpoint":   request.URL.String(),
+	}, profile)
+}
+
+func healthRequest(ctx context.Context, profile config.ProviderProfile, kind config.ProviderKind, options Options) (*http.Request, error) {
+	baseURL, err := resolvedBaseURL(profile, kind)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := baseURL + healthPath(kind)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if options.UserAgent != "" {
+		request.Header.Set("User-Agent", options.UserAgent)
+	}
+	applyAuth(request, profile, kind)
+	return request, nil
+}
+
+func resolvedBaseURL(profile config.ProviderProfile, kind config.ProviderKind) (string, error) {
+	baseURL := strings.TrimSpace(profile.BaseURL)
+	switch kind {
+	case config.ProviderKindOpenAI:
+		return providerio.NormalizeBaseURL(baseURL, config.OpenAIBaseURL, "OpenAI")
+	case config.ProviderKindAnthropic:
+		return providerio.NormalizeBaseURL(baseURL, config.AnthropicBaseURL, "Anthropic")
+	case config.ProviderKindGoogle:
+		return providerio.NormalizeBaseURL(baseURL, config.GoogleBaseURL, "Google")
+	case config.ProviderKindOpenAICompatible, config.ProviderKindAnthropicCompat:
+		if baseURL == "" {
+			return "", fmt.Errorf("%s provider %s requires baseURL for connectivity probing", kind, providerName(profile))
+		}
+		return providerio.NormalizeBaseURL(baseURL, "", string(kind))
+	default:
+		return "", fmt.Errorf("unsupported provider kind %q", kind)
+	}
+}
+
+func healthPath(kind config.ProviderKind) string {
+	switch kind {
+	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
+		return "/v1/models"
+	case config.ProviderKindGoogle:
+		return "/v1beta/models"
+	default:
+		return "/models"
+	}
+}
+
+func applyAuth(request *http.Request, profile config.ProviderProfile, kind config.ProviderKind) {
+	switch kind {
+	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
+		request.Header.Set("anthropic-version", "2023-06-01")
+		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+			APIKey:            profile.APIKey,
+			DefaultAuthHeader: "x-api-key",
+			AuthHeader:        profile.AuthHeader,
+			AuthScheme:        profile.AuthScheme,
+			AuthHeaderValue:   profile.AuthHeaderValue,
+			CustomHeaders:     profile.CustomHeaders,
+		})
+	case config.ProviderKindGoogle:
+		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+			APIKey:            profile.APIKey,
+			DefaultAuthHeader: "x-goog-api-key",
+			AuthHeader:        profile.AuthHeader,
+			AuthScheme:        profile.AuthScheme,
+			AuthHeaderValue:   profile.AuthHeaderValue,
+			CustomHeaders:     profile.CustomHeaders,
+		})
+	default:
+		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+			APIKey:            profile.APIKey,
+			DefaultAuthHeader: "Authorization",
+			DefaultAuthScheme: "Bearer",
+			AuthHeader:        profile.AuthHeader,
+			AuthScheme:        profile.AuthScheme,
+			AuthHeaderValue:   profile.AuthHeaderValue,
+			CustomHeaders:     profile.CustomHeaders,
+		})
+	}
+}
+
+func classifyTransportError(err error, profile config.ProviderProfile) Check {
+	category := CategoryNetwork
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		category = CategoryTimeout
+	} else {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			category = CategoryTimeout
+		}
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			if errors.Is(urlErr.Err, context.DeadlineExceeded) || errors.Is(urlErr.Err, context.Canceled) {
+				category = CategoryTimeout
+			}
+		}
+	}
+	return check("provider.connectivity", "Provider connectivity", StatusFail, category, "Provider connectivity failed: "+err.Error(), nil, profile)
+}
+
+func responseMessage(statusCode int, body []byte) string {
+	message := strings.TrimSpace(string(body))
+	var parsed struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		if parsed.Error.Message != "" {
+			message = parsed.Error.Message
+		} else if parsed.Message != "" {
+			message = parsed.Message
+		}
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+	return fmt.Sprintf("Provider endpoint returned %d: %s", statusCode, message)
+}
+
+func check(id string, label string, status Status, category Category, message string, details map[string]any, profile config.ProviderProfile) Check {
+	out := Check{
+		ID:       id,
+		Label:    label,
+		Status:   status,
+		Category: category,
+		Message:  redact(message, profile),
+	}
+	if len(details) > 0 {
+		out.Details = map[string]any{}
+		for key, value := range details {
+			out.Details[key] = redactAny(key, value, profile)
+		}
+	}
+	return out
+}
+
+func redactAny(key string, value any, profile config.ProviderProfile) any {
+	if text, ok := value.(string); ok {
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		if strings.Contains(normalizedKey, "url") || strings.Contains(normalizedKey, "endpoint") {
+			return redactBaseURL(text, profile)
+		}
+		return redact(text, profile)
+	}
+	return value
+}
+
+func redactBaseURL(baseURL string, profile config.ProviderProfile) string {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(baseURL)
+	if err == nil && parsed.User != nil {
+		parsed.User = nil
+		baseURL = parsed.String()
+	}
+	return redact(baseURL, profile)
+}
+
+func redact(message string, profile config.ProviderProfile) string {
+	secrets := providerSecrets(profile)
+	return redaction.RedactString(providerio.Redact(message, secrets...), redaction.Options{
+		ExtraSecretValues: secrets,
+	})
+}
+
+func providerSecrets(profile config.ProviderProfile) []string {
+	secrets := []string{profile.APIKey, profile.AuthHeaderValue}
+	for _, value := range profile.CustomHeaders {
+		if strings.TrimSpace(value) != "" {
+			secrets = append(secrets, value)
+		}
+	}
+	return secrets
+}
+
+func credentialDetails(profile config.ProviderProfile) map[string]any {
+	details := map[string]any{}
+	if strings.TrimSpace(profile.APIKeyEnv) != "" {
+		details["apiKeyEnv"] = profile.APIKeyEnv
+	}
+	if strings.TrimSpace(profile.AuthHeader) != "" {
+		details["authHeader"] = profile.AuthHeader
+	}
+	return details
+}
+
+func hasCredential(profile config.ProviderProfile) bool {
+	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
+}
+
+func credentialRequired(profile config.ProviderProfile) bool {
+	if strings.TrimSpace(profile.CatalogID) != "" {
+		if descriptor, err := providercatalog.Require(profile.CatalogID); err == nil {
+			return descriptor.RequiresAuth
+		}
+	}
+	switch profile.ProviderKind {
+	case config.ProviderKindOpenAI, config.ProviderKindAnthropic, config.ProviderKindGoogle:
+		return true
+	default:
+		return false
+	}
+}
+
+func providerName(profile config.ProviderProfile) string {
+	if strings.TrimSpace(profile.Name) != "" {
+		return strings.TrimSpace(profile.Name)
+	}
+	if strings.TrimSpace(string(profile.ProviderKind)) != "" {
+		return strings.TrimSpace(string(profile.ProviderKind))
+	}
+	return strings.TrimSpace(profile.Provider)
+}

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 	"time"
@@ -32,15 +33,14 @@ const (
 type Category string
 
 const (
-	CategoryConfig        Category = "config"
-	CategoryUnsupported   Category = "unsupported"
-	CategoryAuth          Category = "auth"
-	CategoryRateLimit     Category = "rate_limit"
-	CategoryNetwork       Category = "network"
-	CategoryTimeout       Category = "timeout"
-	CategoryProvider      Category = "provider_error"
-	CategoryProviderError          = CategoryProvider
-	CategoryConnectivity  Category = "connectivity"
+	CategoryConfig       Category = "config"
+	CategoryUnsupported  Category = "unsupported"
+	CategoryAuth         Category = "auth"
+	CategoryRateLimit    Category = "rate_limit"
+	CategoryNetwork      Category = "network"
+	CategoryTimeout      Category = "timeout"
+	CategoryProvider     Category = "provider_error"
+	CategoryConnectivity Category = "connectivity"
 )
 
 const defaultTimeout = 5 * time.Second
@@ -49,8 +49,71 @@ type Options struct {
 	Profile      config.ProviderProfile
 	Connectivity bool
 	HTTPClient   *http.Client
+	Resolver     Resolver
 	Timeout      time.Duration
 	UserAgent    string
+}
+
+type Resolver interface {
+	LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error)
+}
+
+type defaultResolver struct{}
+
+func (defaultResolver) LookupNetIP(ctx context.Context, network string, host string) ([]netip.Addr, error) {
+	return net.DefaultResolver.LookupNetIP(ctx, network, host)
+}
+
+type blockedPrefix struct {
+	prefix netip.Prefix
+	reason string
+}
+
+type embeddedIPv4Prefix struct {
+	prefix     netip.Prefix
+	byteOffset int
+}
+
+var blockedAddrPrefixes = []blockedPrefix{
+	{prefix: netip.MustParsePrefix("0.0.0.0/8"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("10.0.0.0/8"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("100.64.0.0/10"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("127.0.0.0/8"), reason: "loopback hosts are blocked"},
+	{prefix: netip.MustParsePrefix("169.254.0.0/16"), reason: "link-local hosts are blocked"},
+	{prefix: netip.MustParsePrefix("172.16.0.0/12"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.0.0.0/24"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.0.2.0/24"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.88.99.0/24"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("192.168.0.0/16"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("198.18.0.0/15"), reason: "benchmark network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("198.51.100.0/24"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("203.0.113.0/24"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("224.0.0.0/4"), reason: "multicast hosts are blocked"},
+	{prefix: netip.MustParsePrefix("240.0.0.0/4"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("::/128"), reason: "unspecified hosts are blocked"},
+	{prefix: netip.MustParsePrefix("::1/128"), reason: "loopback hosts are blocked"},
+	{prefix: netip.MustParsePrefix("100::/64"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("2001::/23"), reason: "special-use hosts are blocked"},
+	{prefix: netip.MustParsePrefix("2001:2::/48"), reason: "benchmark network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("2001:db8::/32"), reason: "documentation hosts are blocked"},
+	{prefix: netip.MustParsePrefix("fc00::/7"), reason: "private network hosts are blocked"},
+	{prefix: netip.MustParsePrefix("fe80::/10"), reason: "link-local hosts are blocked"},
+	{prefix: netip.MustParsePrefix("ff00::/8"), reason: "multicast hosts are blocked"},
+}
+
+var embeddedIPv4Prefixes = []embeddedIPv4Prefix{
+	{prefix: netip.MustParsePrefix("::/96"), byteOffset: 12},
+	{prefix: netip.MustParsePrefix("64:ff9b::/96"), byteOffset: 12},
+	{prefix: netip.MustParsePrefix("64:ff9b:1::/48"), byteOffset: 6},
+	{prefix: netip.MustParsePrefix("2002::/16"), byteOffset: 2},
+}
+
+type endpointSafetyError struct {
+	message string
+}
+
+func (err endpointSafetyError) Error() string {
+	return err.message
 }
 
 type Result struct {
@@ -82,9 +145,6 @@ func (result Result) Check(id string) *Check {
 }
 
 func (result Result) PrimaryCheck() *Check {
-	if connectivity := result.Check("provider.connectivity"); connectivity != nil {
-		return connectivity
-	}
 	for index := range result.Checks {
 		if result.Checks[index].Status == StatusFail {
 			return &result.Checks[index]
@@ -94,6 +154,9 @@ func (result Result) PrimaryCheck() *Check {
 		if result.Checks[index].Status == StatusWarn {
 			return &result.Checks[index]
 		}
+	}
+	if connectivity := result.Check("provider.connectivity"); connectivity != nil {
+		return connectivity
 	}
 	if len(result.Checks) == 0 {
 		return nil
@@ -208,7 +271,12 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 
 	request, err := healthRequest(requestCtx, profile, kind, options)
 	if err != nil {
-		return check("provider.connectivity", "Provider connectivity", StatusFail, CategoryConfig, err.Error(), nil, profile)
+		category := CategoryConfig
+		var safety endpointSafetyError
+		if errors.As(err, &safety) {
+			category = CategoryNetwork
+		}
+		return check("provider.connectivity", "Provider connectivity", StatusFail, category, err.Error(), nil, profile)
 	}
 	client := options.HTTPClient
 	if client == nil {
@@ -222,7 +290,13 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 		_ = response.Body.Close()
 	}()
 
-	body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	body, err := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	if err != nil {
+		return check("provider.connectivity", "Provider connectivity", StatusFail, CategoryProvider, "Provider response body could not be read: "+err.Error(), map[string]any{
+			"statusCode": response.StatusCode,
+			"endpoint":   request.URL.String(),
+		}, profile)
+	}
 	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
 		return check("provider.connectivity", "Provider connectivity", StatusPass, CategoryConnectivity, fmt.Sprintf("Provider endpoint reachable (%d).", response.StatusCode), map[string]any{
 			"statusCode": response.StatusCode,
@@ -235,7 +309,7 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 	switch response.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
 		category = CategoryAuth
-	case http.StatusTooManyRequests, http.StatusServiceUnavailable, 529:
+	case http.StatusTooManyRequests, 529:
 		category = CategoryRateLimit
 		status = StatusWarn
 	}
@@ -252,6 +326,9 @@ func healthRequest(ctx context.Context, profile config.ProviderProfile, kind con
 		return nil, err
 	}
 	endpoint := baseURL + healthPath(kind)
+	if err := validateEndpoint(ctx, endpoint, options.Resolver); err != nil {
+		return nil, err
+	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -280,6 +357,72 @@ func resolvedBaseURL(profile config.ProviderProfile, kind config.ProviderKind) (
 	default:
 		return "", fmt.Errorf("unsupported provider kind %q", kind)
 	}
+}
+
+func validateEndpoint(ctx context.Context, endpoint string, resolver Resolver) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("provider connectivity URL must use http or https")
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return fmt.Errorf("provider connectivity URL requires a host")
+	}
+	normalized := strings.TrimSuffix(strings.ToLower(host), ".")
+	if normalized == "localhost" || strings.HasSuffix(normalized, ".localhost") {
+		return endpointSafetyError{message: "provider connectivity URL is unsafe: localhost hosts are blocked"}
+	}
+	if addr, err := netip.ParseAddr(normalized); err == nil {
+		if reason := blockedAddrReason(addr); reason != "" {
+			return endpointSafetyError{message: "provider connectivity URL is unsafe: " + reason}
+		}
+		return nil
+	}
+	if resolver == nil {
+		resolver = defaultResolver{}
+	}
+	addrs, err := resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil {
+		return endpointSafetyError{message: "provider connectivity host could not be resolved safely: " + err.Error()}
+	}
+	if len(addrs) == 0 {
+		return endpointSafetyError{message: "provider connectivity host resolved to no addresses"}
+	}
+	for _, addr := range addrs {
+		if reason := blockedAddrReason(addr); reason != "" {
+			return endpointSafetyError{message: "provider connectivity URL is unsafe: " + reason}
+		}
+	}
+	return nil
+}
+
+func blockedAddrReason(addr netip.Addr) string {
+	addr = addr.Unmap()
+	for _, embedded := range embeddedIPv4Prefixes {
+		if !embedded.prefix.Contains(addr) {
+			continue
+		}
+		bytes := addr.As16()
+		if embedded.byteOffset+4 > len(bytes) {
+			continue
+		}
+		addr = netip.AddrFrom4([4]byte{
+			bytes[embedded.byteOffset],
+			bytes[embedded.byteOffset+1],
+			bytes[embedded.byteOffset+2],
+			bytes[embedded.byteOffset+3],
+		})
+		break
+	}
+	for _, blocked := range blockedAddrPrefixes {
+		if blocked.prefix.Contains(addr) {
+			return blocked.reason
+		}
+	}
+	return ""
 }
 
 func healthPath(kind config.ProviderKind) string {
@@ -329,7 +472,7 @@ func applyAuth(request *http.Request, profile config.ProviderProfile, kind confi
 
 func classifyTransportError(err error, profile config.ProviderProfile) Check {
 	category := CategoryNetwork
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		category = CategoryTimeout
 	} else {
 		var netErr net.Error
@@ -338,7 +481,7 @@ func classifyTransportError(err error, profile config.ProviderProfile) Check {
 		}
 		var urlErr *url.Error
 		if errors.As(err, &urlErr) {
-			if errors.Is(urlErr.Err, context.DeadlineExceeded) || errors.Is(urlErr.Err, context.Canceled) {
+			if errors.Is(urlErr.Err, context.DeadlineExceeded) {
 				category = CategoryTimeout
 			}
 		}

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -144,7 +144,7 @@ func Probe(ctx context.Context, options Options) Result {
 		"providerKind": metadata.ProviderKind,
 	}, profile))
 
-	if credentialRequired(profile) && !hasCredential(profile) {
+	if credentialRequired(profile, metadata.ProviderKind) && !hasCredential(profile) {
 		result.add(check("provider.auth", "Provider auth", StatusFail, CategoryAuth, fmt.Sprintf("Provider %s requires API credentials.", providerName(profile)), credentialDetails(profile), profile))
 		return result.finalize()
 	}
@@ -440,13 +440,13 @@ func hasCredential(profile config.ProviderProfile) bool {
 	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
 }
 
-func credentialRequired(profile config.ProviderProfile) bool {
+func credentialRequired(profile config.ProviderProfile, providerKind config.ProviderKind) bool {
 	if strings.TrimSpace(profile.CatalogID) != "" {
 		if descriptor, err := providercatalog.Require(profile.CatalogID); err == nil {
 			return descriptor.RequiresAuth
 		}
 	}
-	switch profile.ProviderKind {
+	switch providerKind {
 	case config.ProviderKindOpenAI, config.ProviderKindAnthropic, config.ProviderKindGoogle:
 		return true
 	default:

--- a/internal/providerhealth/providerhealth_additional_test.go
+++ b/internal/providerhealth/providerhealth_additional_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -98,6 +99,7 @@ func TestProbeConnectivityClassifiesRateLimitAsWarning(t *testing.T) {
 		},
 		Connectivity: true,
 		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 	})
 
 	check := result.Check("provider.connectivity")
@@ -121,6 +123,7 @@ func TestProbeConnectivityClassifiesNetworkError(t *testing.T) {
 		},
 		Connectivity: true,
 		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 	})
 
 	check := result.Check("provider.connectivity")
@@ -152,10 +155,11 @@ func TestProbeConnectivityRedactsProviderErrorDetails(t *testing.T) {
 		},
 		Connectivity: true,
 		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 	})
 
 	check := result.Check("provider.connectivity")
-	if check == nil || check.Category != CategoryProviderError {
+	if check == nil || check.Category != CategoryProvider {
 		t.Fatalf("connectivity check = %#v, want provider error", check)
 	}
 	rendered := check.Message + " " + fmt.Sprint(check.Details)

--- a/internal/providerhealth/providerhealth_additional_test.go
+++ b/internal/providerhealth/providerhealth_additional_test.go
@@ -1,0 +1,168 @@
+package providerhealth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestProbeConfigOnlyValidProviderPassesWithoutNetwork(t *testing.T) {
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("network should not be reached")
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "http://localhost:11434/v1",
+			Model:        "local-model",
+		},
+		HTTPClient: client,
+	})
+
+	if result.Status != StatusPass {
+		t.Fatalf("Status = %q, want %q: %#v", result.Status, StatusPass, result.Checks)
+	}
+	if called {
+		t.Fatal("HTTP client was called during config-only probe")
+	}
+}
+
+func TestProbeConfigValidationClassifiesMissingModel(t *testing.T) {
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://example.invalid/v1",
+		},
+	})
+
+	check := result.Check("provider.config")
+	if check == nil || check.Category != CategoryConfig || check.Status != StatusFail {
+		t.Fatalf("provider.config = %#v, want config failure", check)
+	}
+}
+
+func TestProbeRedactsTopLevelAndDetailURLs(t *testing.T) {
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://user:base-secret@example.invalid/v1?api_key=query-secret",
+			Model:        "custom-model",
+		},
+	})
+
+	raw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal health result: %v", err)
+	}
+	rendered := string(raw)
+	for _, secret := range []string{"base-secret", "query-secret"} {
+		if strings.Contains(rendered, secret) {
+			t.Fatalf("secret %q leaked in health result: %s", secret, rendered)
+		}
+	}
+	if strings.Contains(rendered, "user:") {
+		t.Fatalf("URL userinfo leaked in health result: %s", rendered)
+	}
+}
+
+func TestProbeConnectivityClassifiesRateLimitAsWarning(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"slow down"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://example.invalid/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+	})
+
+	check := result.Check("provider.connectivity")
+	if result.Status != StatusWarn || check == nil || check.Category != CategoryRateLimit {
+		t.Fatalf("result = %#v, connectivity = %#v, want rate limit warning", result, check)
+	}
+}
+
+func TestProbeConnectivityClassifiesNetworkError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("dial tcp: no route to host")
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://example.invalid/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+	})
+
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Category != CategoryNetwork || check.Status != StatusFail {
+		t.Fatalf("connectivity check = %#v, want network failure", check)
+	}
+}
+
+func TestProbeConnectivityRedactsProviderErrorDetails(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Status:     "502 Bad Gateway",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"upstream saw sk-test-secret and custom-secret-token"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://example.invalid/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+			CustomHeaders: map[string]string{
+				"X-Api-Key": "custom-secret-token",
+			},
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+	})
+
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Category != CategoryProviderError {
+		t.Fatalf("connectivity check = %#v, want provider error", check)
+	}
+	rendered := check.Message + " " + fmt.Sprint(check.Details)
+	if strings.Contains(rendered, "sk-test-secret") {
+		t.Fatalf("secret leaked in connectivity check: %s", rendered)
+	}
+	if strings.Contains(rendered, "custom-secret-token") {
+		t.Fatalf("custom header secret leaked in connectivity check: %s", rendered)
+	}
+}

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -1,0 +1,148 @@
+package providerhealth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestProbeConfigOnlyMissingProviderFails(t *testing.T) {
+	result := Probe(context.Background(), Options{})
+
+	if result.Status != StatusFail {
+		t.Fatalf("Status = %q, want %q", result.Status, StatusFail)
+	}
+	check := result.Check("provider.config")
+	if check == nil || check.Status != StatusFail {
+		t.Fatalf("missing provider.config failure: %#v", result.Checks)
+	}
+}
+
+func TestProbeConnectivityOpenAIModelsEndpointPasses(t *testing.T) {
+	var gotPath string
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4.1"}]}`))
+	}))
+	defer server.Close()
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "openai-test",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      server.URL,
+			APIKey:       "sk-test-secret",
+			Model:        "gpt-4.1",
+		},
+		Connectivity: true,
+		HTTPClient:   server.Client(),
+	})
+
+	if result.Status != StatusPass {
+		t.Fatalf("Status = %q, want pass: %#v", result.Status, result.Checks)
+	}
+	if gotPath != "/models" {
+		t.Fatalf("probe path = %q, want /models", gotPath)
+	}
+	if gotAuth != "Bearer sk-test-secret" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Status != StatusPass {
+		t.Fatalf("missing connectivity pass: %#v", result.Checks)
+	}
+}
+
+func TestProbeConnectivityClassifiesAndRedactsAuthError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad key sk-test-secret"}}`))
+	}))
+	defer server.Close()
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "openai-test",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      server.URL,
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   server.Client(),
+	})
+
+	if result.Status != StatusFail {
+		t.Fatalf("Status = %q, want fail: %#v", result.Status, result.Checks)
+	}
+	check := result.Check("provider.connectivity")
+	if check == nil {
+		t.Fatalf("missing connectivity check: %#v", result.Checks)
+	}
+	if check.Category != CategoryAuth {
+		t.Fatalf("Category = %q, want %q", check.Category, CategoryAuth)
+	}
+	if strings.Contains(check.Message, "sk-test-secret") {
+		t.Fatalf("secret leaked in message: %q", check.Message)
+	}
+}
+
+func TestProbeConnectivityClassifiesTimeout(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "openai-test",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://example.invalid/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Timeout:      time.Millisecond,
+	})
+
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Category != CategoryTimeout {
+		t.Fatalf("connectivity check = %#v, want timeout category", check)
+	}
+}
+
+func TestProbeConnectivityUnsupportedTransportWarnsWithoutNetwork(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("network should not be reached")
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:      "bedrock",
+			CatalogID: "bedrock",
+			Model:     "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+	})
+
+	check := result.Check("provider.runtime")
+	if check == nil || check.Category != CategoryUnsupported {
+		t.Fatalf("runtime check = %#v, want unsupported category", check)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -3,8 +3,9 @@ package providerhealth
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
-	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -27,31 +28,35 @@ func TestProbeConfigOnlyMissingProviderFails(t *testing.T) {
 func TestProbeConnectivityOpenAIModelsEndpointPasses(t *testing.T) {
 	var gotPath string
 	var gotAuth string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4.1"}]}`))
-	}))
-	defer server.Close()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"data":[{"id":"gpt-4.1"}]}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
 
 	result := Probe(context.Background(), Options{
 		Profile: config.ProviderProfile{
 			Name:         "openai-test",
 			ProviderKind: config.ProviderKindOpenAICompatible,
-			BaseURL:      server.URL,
+			BaseURL:      "https://api.example.com/v1",
 			APIKey:       "sk-test-secret",
 			Model:        "gpt-4.1",
 		},
 		Connectivity: true,
-		HTTPClient:   server.Client(),
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 	})
 
 	if result.Status != StatusPass {
 		t.Fatalf("Status = %q, want pass: %#v", result.Status, result.Checks)
 	}
-	if gotPath != "/models" {
-		t.Fatalf("probe path = %q, want /models", gotPath)
+	if gotPath != "/v1/models" {
+		t.Fatalf("probe path = %q, want /v1/models", gotPath)
 	}
 	if gotAuth != "Bearer sk-test-secret" {
 		t.Fatalf("Authorization = %q", gotAuth)
@@ -63,22 +68,26 @@ func TestProbeConnectivityOpenAIModelsEndpointPasses(t *testing.T) {
 }
 
 func TestProbeConnectivityClassifiesAndRedactsAuthError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":{"message":"bad key sk-test-secret"}}`))
-	}))
-	defer server.Close()
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad key sk-test-secret"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
 
 	result := Probe(context.Background(), Options{
 		Profile: config.ProviderProfile{
 			Name:         "openai-test",
 			ProviderKind: config.ProviderKindOpenAICompatible,
-			BaseURL:      server.URL,
+			BaseURL:      "https://api.example.com/v1",
 			APIKey:       "sk-test-secret",
 			Model:        "custom-model",
 		},
 		Connectivity: true,
-		HTTPClient:   server.Client(),
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 	})
 
 	if result.Status != StatusFail {
@@ -126,25 +135,29 @@ func TestProbeResolvedKindRequiresAuthWhenUnset(t *testing.T) {
 
 func TestProbeResolvedKindConnectivityAuthErrorRedactsSecret(t *testing.T) {
 	authHeader := make(chan string, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		select {
 		case authHeader <- r.Header.Get("Authorization"):
 		default:
 		}
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":{"message":"bad key sk-test-secret"}}`))
-	}))
-	defer server.Close()
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad key sk-test-secret"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
 
 	result := Probe(context.Background(), Options{
 		Profile: config.ProviderProfile{
 			Name:    "openai-test",
-			BaseURL: server.URL,
+			BaseURL: "https://api.example.com/v1",
 			APIKey:  "sk-test-secret",
 			Model:   "custom-model",
 		},
 		Connectivity: true,
-		HTTPClient:   server.Client(),
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 	})
 
 	if result.Status != StatusFail {
@@ -182,12 +195,134 @@ func TestProbeConnectivityClassifiesTimeout(t *testing.T) {
 		},
 		Connectivity: true,
 		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
 		Timeout:      time.Millisecond,
 	})
 
 	check := result.Check("provider.connectivity")
 	if check == nil || check.Category != CategoryTimeout {
 		t.Fatalf("connectivity check = %#v, want timeout category", check)
+	}
+}
+
+func TestProbeConnectivityBlocksLocalhostBeforeNetwork(t *testing.T) {
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("network should not be reached")
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "http://localhost:11434/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "local-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+	})
+
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Status != StatusFail || check.Category != CategoryNetwork {
+		t.Fatalf("connectivity check = %#v, want blocked network failure", check)
+	}
+	if called {
+		t.Fatal("HTTP client was called for a blocked localhost URL")
+	}
+}
+
+func TestProbeConnectivityBlocksPrivateResolvedHostBeforeNetwork(t *testing.T) {
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("network should not be reached")
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "private",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://private.example/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("10.0.0.5")},
+	})
+
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Status != StatusFail || check.Category != CategoryNetwork {
+		t.Fatalf("connectivity check = %#v, want blocked private-network failure", check)
+	}
+	if called {
+		t.Fatal("HTTP client was called for a blocked private resolved host")
+	}
+}
+
+func TestProbeConnectivityServiceUnavailableFails(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"maintenance"}}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
+	})
+
+	check := result.Check("provider.connectivity")
+	if result.Status != StatusFail || check == nil || check.Category != CategoryProvider {
+		t.Fatalf("result = %#v, connectivity = %#v, want provider failure", result, check)
+	}
+}
+
+func TestProbeConnectivityContextCanceledIsNetworkFailure(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.Canceled
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			APIKey:       "sk-test-secret",
+			Model:        "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+		Resolver:     staticResolver{addr: netip.MustParseAddr("93.184.216.34")},
+	})
+
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Category != CategoryNetwork {
+		t.Fatalf("connectivity check = %#v, want network category for context.Canceled", check)
+	}
+}
+
+func TestPrimaryCheckPrefersFailuresOverPassingConnectivity(t *testing.T) {
+	result := Result{Checks: []Check{
+		{ID: "provider.connectivity", Status: StatusPass, Message: "reachable"},
+		{ID: "provider.auth", Status: StatusFail, Message: "missing auth"},
+	}}
+
+	if got := result.PrimaryCheck(); got == nil || got.ID != "provider.auth" {
+		t.Fatalf("PrimaryCheck = %#v, want provider.auth failure", got)
 	}
 }
 
@@ -216,4 +351,16 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return fn(request)
+}
+
+type staticResolver struct {
+	addr netip.Addr
+	err  error
+}
+
+func (resolver staticResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	if resolver.err != nil {
+		return nil, resolver.err
+	}
+	return []netip.Addr{resolver.addr}, nil
 }

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -96,6 +96,67 @@ func TestProbeConnectivityClassifiesAndRedactsAuthError(t *testing.T) {
 	}
 }
 
+func TestProbeResolvedKindRequiresAuthWhenUnset(t *testing.T) {
+	called := false
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("network should not be reached")
+	})}
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:  "openai-test",
+			Model: "gpt-4.1",
+		},
+		Connectivity: true,
+		HTTPClient:   client,
+	})
+
+	if result.Status != StatusFail {
+		t.Fatalf("Status = %q, want fail: %#v", result.Status, result.Checks)
+	}
+	check := result.Check("provider.auth")
+	if check == nil || check.Status != StatusFail || check.Category != CategoryAuth {
+		t.Fatalf("provider.auth = %#v, want auth failure", check)
+	}
+	if called {
+		t.Fatal("HTTP client was called after missing credentials")
+	}
+}
+
+func TestProbeResolvedKindConnectivityAuthErrorRedactsSecret(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test-secret" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad key sk-test-secret"}}`))
+	}))
+	defer server.Close()
+
+	result := Probe(context.Background(), Options{
+		Profile: config.ProviderProfile{
+			Name:    "openai-test",
+			BaseURL: server.URL,
+			APIKey:  "sk-test-secret",
+			Model:   "custom-model",
+		},
+		Connectivity: true,
+		HTTPClient:   server.Client(),
+	})
+
+	if result.Status != StatusFail {
+		t.Fatalf("Status = %q, want fail: %#v", result.Status, result.Checks)
+	}
+	check := result.Check("provider.connectivity")
+	if check == nil || check.Category != CategoryAuth {
+		t.Fatalf("provider.connectivity = %#v, want auth failure", check)
+	}
+	if strings.Contains(check.Message, "sk-test-secret") {
+		t.Fatalf("secret leaked in message: %q", check.Message)
+	}
+}
+
 func TestProbeConnectivityClassifiesTimeout(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, context.DeadlineExceeded

--- a/internal/providerhealth/providerhealth_test.go
+++ b/internal/providerhealth/providerhealth_test.go
@@ -125,9 +125,11 @@ func TestProbeResolvedKindRequiresAuthWhenUnset(t *testing.T) {
 }
 
 func TestProbeResolvedKindConnectivityAuthErrorRedactsSecret(t *testing.T) {
+	authHeader := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "Bearer sk-test-secret" {
-			t.Fatalf("Authorization = %q", got)
+		select {
+		case authHeader <- r.Header.Get("Authorization"):
+		default:
 		}
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":{"message":"bad key sk-test-secret"}}`))
@@ -147,6 +149,14 @@ func TestProbeResolvedKindConnectivityAuthErrorRedactsSecret(t *testing.T) {
 
 	if result.Status != StatusFail {
 		t.Fatalf("Status = %q, want fail: %#v", result.Status, result.Checks)
+	}
+	select {
+	case got := <-authHeader:
+		if got != "Bearer sk-test-secret" {
+			t.Fatalf("Authorization = %q", got)
+		}
+	default:
+		t.Fatal("expected connectivity probe request")
 	}
 	check := result.Check("provider.connectivity")
 	if check == nil || check.Category != CategoryAuth {


### PR DESCRIPTION
## Summary
- add a providerhealth package for config/runtime/auth checks plus bounded non-generating connectivity probes
- wire `zero providers check <name> --connectivity [--json]` to emit structured health diagnostics
- wire `zero doctor --connectivity` to use the real provider health probe and surface concrete failures

## Tests
- `go test ./internal/providerhealth ./internal/cli ./internal/doctor`
- `go test ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --connectivity mode to probe provider endpoint connectivity during provider checks and diagnostics
  * Connectivity probe results are surfaced in doctor/diagnostics output

* **Improvements**
  * JSON and human-readable health output now include categorized checks and an overall status label (ok/warn/fail)
  * Commands return provider-specific exit status on connectivity failures
  * Credentials and secrets are redacted from reported messages and details

* **Tests**
  * Expanded test coverage for connectivity probing, classification, redaction, and failure behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->