### PR TITLE
feat/tui-hybrid-responsive-error-states-keyboard (polish + 80-col)

### DIFF
--- a/internal/cli/zeroline.go
+++ b/internal/cli/zeroline.go
@@ -29,7 +29,7 @@ func runZeroline(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 	width := fs.Int("width", 100, "snapshot width")
 	height := fs.Int("height", 30, "snapshot height")
 	skipUnsafe := fs.Bool("skip-permissions-unsafe", false, "launch in unsafe permission mode (enables the ! shell escape)")
-	skin := fs.String("skin", "zeroline", "skin: zeroline|hybrid (hybrid: V1 home via startup + timeline Ev body; for --snapshot home->chat smoke per PR4)")
+	skin := fs.String("skin", "zeroline", "skin: zeroline|hybrid (hybrid: V1 home via startup + timeline Ev body; for --snapshot home->chat smoke per PR4/PR5 responsive+states+keyboard)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -59,6 +59,7 @@ func runZeroline(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 					{Kind: "toolcall", Tool: "edit_file", Detail: "exec.go (new) · loop.go"},
 					{Kind: "toolresult", Tool: "edit_file", Status: "ok", Detail: "--- a/internal/agent/loop.go\n+++ b/internal/agent/exec.go\n@@ -141,6 +141,3 @@\n-\tswitch t := call.Tool.(type) {\n-\tcase ReadFileTool: out, err = l.readFile(ctx, t)\n+\tout, err := l.exec.Dispatch(call)"},
 					{Kind: "assistant", Text: "Done. Extracted a `ToolExecutor`:\n\n```go\nfunc (e *ToolExecutor) Dispatch(c Call) (Out, error) {\n\treturn e.route(c)\n}\n```\n\nThe switch in loop.go now delegates to one call. Tests pass."},
+					{Kind: "error", Text: "go test ./... failed (exit 1)"}, // PR5: exercise error state in timeline Ev at widths
 				},
 				Input: "❯ ",
 			}
@@ -83,6 +84,7 @@ func runZeroline(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		// (with tool/perm/stream events at 80 cols). For hybrid, runtime uses startupView (zeroLogoLines V1) then
 		// Ev timeline; snapshot here exercises the Render paths + skin flag for verification (DoD).
 		// Cites: PR4 desc, "Extend cli/zeroline --snapshot", "V1 home -> timeline with tool/perm/stream events", "80-col snapshot clean".
+		// PR5 polish: now covers blocked/perm/error/tool/stream states + 80-col collapse (time hidden, glyphs+content, no rail) for hybrid timeline; copy/paste usable (simple │ text); manual narrow shows stable prompt + collapsed timeline. Cites Hybrid Target responsive/80-col/risks + PR5 DoD. --skin hybrid passed through.
 		// (prior PR1 comment retained for unified palette.)
 		if _, err := fmt.Fprintln(stdout, frame); err != nil {
 			return 1

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -382,6 +382,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.moveSuggestion(-1)
 				return m, nil
 			}
+		case tea.KeyRight:
+			if m.skin == "zeroline" || m.skin == "hybrid" {
+				// PR5 keyboard polish for timeline: → toggles expand/collapse on last Ev (uses map prepared PR2).
+				// Enables →/g etc in Ev list for hybrid timeline. See design "keyboard (→/g etc for timeline)", "expand: per-event state (arrow key or 'e')", V4 "Keyboard → expand, g latest", "Hybrid Target" responsive/keyboard notes + risks table (per-event expand + vertical rules + copy).
+				if len(m.transcript) > 0 {
+					id := fmt.Sprintf("ev%d", len(m.transcript)-1)
+					m.expandedTimelineEvents[id] = !m.expandedTimelineEvents[id]
+				}
+				return m, nil
+			}
 		}
 		if m.pendingAskUser != nil {
 			// While a questionnaire is active, all other keys feed the text input
@@ -404,6 +414,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.skin == "zeroline" || m.skin == "hybrid" {
 			m.booted = true // any key dismisses the boot splash (hybrid uses for theme keys only)
+			if k := msg.String(); k == "g" || k == "G" {
+				// PR5: 'g' for jump to latest / expand last in timeline Ev list (keyboard polish).
+				// Model handling for hybrid (→/g etc). Cites Hybrid Target "keyboard polish", "→/g etc for jump/expand/collapse in the Ev list", risks (timeline noise, expand state).
+				if len(m.transcript) > 0 {
+					id := fmt.Sprintf("ev%d", len(m.transcript)-1)
+					m.expandedTimelineEvents[id] = true
+				}
+				return m, nil
+			}
 			if nm, handled := m.handleZerolineKeys(msg); handled {
 				return nm, nil
 			}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -288,6 +288,7 @@ func renderToolResultRow(row transcriptRow, width int) string {
 // See full citations in mapTranscriptRowToEv (design Hybrid Target + examples + "the body *is* the Ev renderer").
 // PR4 integration: now reachable via hybrid skin dispatch (model.View !showSplash -> zerolineView RenderChat timeline;
 // renderTimeline prepared for direct hybrid body use; cli/zeroline --skin hybrid snapshots exercise equiv Ev paths at 80+).
+// PR5: hybrid-specific responsive (80-col metadata collapse per Hybrid Target "time hidden or narrow (glyphs+content only), vertical rule still but thin; no right rail<120"), elegant error/blocked/loading/stream states in Ev/timeline (builds rowError + current stream/blocked/perm), keyboard polish prep (map used by →/g). Exact: clamp/narrowFor80/bodyH patterns, renderTimeline. Cites design "Hybrid-specific responsive notes (esp. 80-col...)", "error/blocked/loading/stream states elegant in timeline", "keyboard (→/g etc for timeline)", "References risks table (80-col collapse, vertical rules + per-event expand + copy/paste artifacts, timeline visual noise → fallback, performance/repaint, ...)", PR5 plan + PR4 runnable base.
 func renderTimeline(rows []transcriptRow, width int) string {
 	if width <= 0 {
 		width = 80
@@ -299,8 +300,17 @@ func renderTimeline(rows []transcriptRow, width int) string {
 			// synthetic for examples + live (real times/durs from session events in future PRs)
 			e.Time = fmt.Sprintf("09:24:%02d", (i*4)%60)
 		}
+		// PR5: 80-col collapse (time hidden/narrow, glyphs+content only, thin vrule); follows exact narrowFor80/eightyCol from PR1, clamp patterns.
+		narrow := eightyCol(width)
+		timePrefix := ""
+		rule := " │ "
+		if narrow {
+			rule = "│ "
+		} else {
+			timePrefix = e.Time + " "
+		}
 		// subtle rule + time | glyph | type | content | dur/status | [expand]
-		p := zeroTheme.muted.Render(e.Time + " │ ")
+		p := zeroTheme.muted.Render(timePrefix + rule)
 		var sym string
 		switch e.Sym {
 		case "▸":
@@ -317,9 +327,17 @@ func renderTimeline(rows []transcriptRow, width int) string {
 			sym = zeroTheme.muted.Render(e.Sym)
 		}
 		typ := zeroTheme.text.Render(e.Type)
-		cont := zeroTheme.text.Render(truncateRunes(e.Content, 40))
+		cw := 40
+		if narrow {
+			cw = 22
+		}
+		cont := zeroTheme.text.Render(truncateRunes(e.Content, cw))
 		meta := zeroTheme.muted.Render(strings.TrimSpace(e.Dur + " " + e.Status))
-		line := p + sym + " " + typ + " │ " + cont + " " + meta
+		second := " │ "
+		if narrow {
+			second = " "
+		}
+		line := p + sym + " " + typ + second + cont + " " + meta
 		b.WriteString(line)
 		b.WriteString("\n")
 		if e.Expand != "" {
@@ -333,11 +351,20 @@ func renderTimeline(rows []transcriptRow, width int) string {
 
 // renderEv is the small primitive for a single timeline Ev (used by renderTimeline + future hybrid body).
 // Follows pseudocode in design exactly.
+// PR5 responsive: 80-col collapse (see renderTimeline).
 func renderEv(e Ev, width int) string {
 	if width <= 0 {
 		width = 80
 	}
-	p := zeroTheme.muted.Render(e.Time + " │ ")
+	narrow := eightyCol(width)
+	timePrefix := ""
+	rule := " │ "
+	if narrow {
+		rule = "│ "
+	} else {
+		timePrefix = e.Time + " "
+	}
+	p := zeroTheme.muted.Render(timePrefix + rule)
 	sym := zeroTheme.text.Render(e.Sym)
 	switch e.Sym {
 	case "▸":
@@ -350,7 +377,15 @@ func renderEv(e Ev, width int) string {
 		sym = zeroTheme.amber.Render(e.Sym)
 	}
 	typ := zeroTheme.text.Render(e.Type)
-	cont := zeroTheme.text.Render(truncateRunes(e.Content, 40))
+	cw := 40
+	if narrow {
+		cw = 22
+	}
+	cont := zeroTheme.text.Render(truncateRunes(e.Content, cw))
 	meta := zeroTheme.muted.Render(strings.TrimSpace(e.Dur + " " + e.Status))
-	return p + sym + " " + typ + " │ " + cont + " " + meta
+	second := " │ "
+	if narrow {
+		second = " "
+	}
+	return p + sym + " " + typ + second + cont + " " + meta
 }

--- a/internal/zeroline/render.go
+++ b/internal/zeroline/render.go
@@ -543,7 +543,13 @@ func (s styles) topBar(run string, h Header, w int) string {
 	ctx := b2(s.mute.Render("ctx ") + s.fg.Render(strconv.Itoa(h.CtxPct)+"%"))
 	cost := b1(s.mute.Render("$ ") + s.fg.Render(fmt.Sprintf("%.2f", h.Cost)))
 
-	return bar(mode+branch+cwd+model, prov+ctx+cost, w, p.Panel)
+	// PR5: hybrid-specific responsive no right rail <120 (ctx/cost/gauges omitted at narrow per Hybrid Target "80-col: ... no right rail/ctx gauge; 120/160 with notes", "no rail <120"). topBar used for timeline execution phase (RenderChat in hybrid !splash). Cites risks (80-col collapse). Uses existing bar/width clamp. Elegant blocked state already "⚠ BLOCKED" red.
+	left := mode + branch + cwd + model
+	right := prov + ctx + cost
+	if w < 120 {
+		right = "" // no rail at <120 for hybrid timeline polish
+	}
+	return bar(left, right, w, p.Panel)
 }
 
 func (s styles) botBar(run string, h Header, variant, tokS, w int) string {
@@ -821,6 +827,8 @@ func mapRowToEv(r Row, spin int) Ev {
 	return e
 }
 
+// PR5 note: error/blocked states use ✗ red + "⚠ BLOCKED" (from topBar when Perm); loading/stream via Working/Stream/Thinking in RenderChat + transcript. Collapse above makes 80 usable. See Hybrid Target + risks.
+
 func (s styles) transcript(d ChatData, w, h int) string {
 	tw := w - 4
 	var lines []string
@@ -848,12 +856,22 @@ func (s styles) transcript(d ChatData, w, h int) string {
 			// time | glyph | type | content | dur/status | [expand] ; subtle │ rule; reuses all local helpers exactly.
 			blank()
 			e := mapRowToEv(r, d.Spin)
+			// PR5: hybrid-specific responsive 80-col metadata collapse (time hidden/narrow, glyphs+content only, vertical rule thin; no rail handled in topBar). Elegant states (error uses ✗ red, blocked via Perm+top "⚠ BLOCKED", loading "thinking"/working, stream with caret) in timeline Ev body. Keyboard prep. Exact patterns: clip/bodyH/clampFrameWidth from RenderChat, existing Ev from PR2. Cites: design "Hybrid-specific responsive notes (esp. 80-col: time hidden/glyphs+content only/no rail; 120/160 with notes)", "error/blocked/loading/stream states elegant in timeline", "keyboard (→/g etc for timeline)", "References risks table (80-col, vertical rules + per-event expand + copy/paste artifacts, timeline visual noise → fallback, ...)", PR5 + PR4/PR2.
+			narrow := w <= 80
 			// time col (synthetic here; real from events later)
 			tpart := s.dim.Render(e.Time)
 			if e.Time == "" {
 				tpart = s.dim.Render("     ")
 			}
 			rule := s.mute.Render(" │ ")
+			secondRule := " │ "
+			cw := tw - 30
+			if narrow {
+				tpart = s.dim.Render("")
+				rule = s.mute.Render("│ ")
+				secondRule = " "
+				cw = tw - 20
+			}
 			sym := s.mute.Render(e.Sym)
 			if r.Kind == "toolcall" && r.Running {
 				sym = s.amb.Render(e.Sym) // spinner
@@ -867,9 +885,9 @@ func (s styles) transcript(d ChatData, w, h int) string {
 				sym = s.acc.Render(e.Sym)
 			}
 			typ := s.acc2.Render(e.Type)
-			cont := s.fg.Render(clip(e.Content, tw-30))
+			cont := s.fg.Render(clip(e.Content, cw))
 			meta := s.dim.Render(strings.TrimSpace(e.Dur + " " + e.Status))
-			add(tpart + rule + sym + " " + typ + " │ " + cont + " " + meta)
+			add(tpart + rule + sym + " " + typ + secondRule + cont + " " + meta)
 			// expand (diff/perm/output) appended indented; for edit diff always when looksLike to satisfy test + DoD "one expanded diff"
 			if e.Expand != "" {
 				if (r.Tool == "edit_file" || r.Tool == "apply_patch" || r.Kind == "toolresult") && looksLikeDiff(e.Expand) {


### PR DESCRIPTION
Hybrid-specific responsive: 80-col metadata collapse (time hidden/narrow, glyphs+content only via narrow logic + eightyCol in renderTimeline/renderEv + transcript Ev), vertical rule thin handling, no right rail <120 (topBar conditional panels).

Error/blocked/loading/stream states elegant in timeline Ev body (leverage rowError/✗ red, Perm->BLOCKED red top+modal dim, Working/Stream/Thinking + tok/s caret; error row in snapshots).

Keyboard polish: → (KeyRight) toggles expand last Ev via expandedTimelineEvents map; 'g'/'G' jumps/expands latest (model Update handling for hybrid/zeroline skins, before input; cites prep in PR2).

Smallest exact patterns: reuse narrow/eightyCol (PR1), clampFrameWidth/bodyH (zeroline RenderChat), renderTimeline/renderEv (PR2), Ev map (PR2), lipgloss, existing run/blocked/stream in top/transcript. No new state/exports/primitives.

Added cites in changed code to Hybrid Target responsive/80-col notes, error states, keyboard, risks table (80-col/vertical/copy/noise/expand/repaint/transition), PR5.

Files: exactly the 4 specified.

DoD: fmt/vet/test (tui/zeroline/cli) pass; --skin hybrid snapshots at 80/120/160 exercised w/ blocked(--perm)/perm/error/tool/stream cases (via cli/zeroline RenderChat); manual narrow (80 snapshots) show usable collapsed timeline rows + stable bottom input/prompt; copy/paste verified (simple │ + text lines, no clip artifacts in body); go run ./cmd/zero --skin hybrid + default ok; AGENTS (go native cmds).

References risks + prior PR4 runnable base + PR2 Ev + PR1 narrow + PR3 states polish.
