### PR TITLE
zero cron: dep-free file-backed scheduled agents (foreground runner)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -205,6 +205,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runChanges(args[1:], stdout, stderr, deps)
 	case "usage":
 		return runUsage(args[1:], stdout, stderr, deps)
+	case "cron":
+		return runCron(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
 	case "zeroline":
@@ -474,6 +476,7 @@ Commands:
   verify     Detect and run local verification checks
   changes    Inspect and commit local git changes
   usage      Summarize token usage and estimated cost
+  cron       Schedule agent jobs (foreground, file-backed)
   serve      Run Zero protocol servers
   zeroline    Launch the interactive TUI with the Zeroline reskin
   help       Show this help

--- a/internal/cli/cron.go
+++ b/internal/cli/cron.go
@@ -116,7 +116,11 @@ func cronAdd(store *cron.Store, now func() time.Time, args []string, stdout io.W
 			prompt = r.Prompt
 		}
 	}
-	if len(positional) > 0 && expr == "" {
+	if len(positional) > 1 {
+		fmt.Fprintf(stderr, "Unexpected extra arguments: %s\n", strings.Join(positional[1:], " "))
+		return exitUsage
+	}
+	if len(positional) == 1 && expr == "" {
 		expr = positional[0]
 	}
 	if expr == "" {
@@ -230,9 +234,19 @@ func cronResume(store *cron.Store, now func() time.Time, args []string, stderr i
 		return exitUsage
 	}
 	job.Status = cron.StatusActive
-	if sched, perr := cron.Parse(job.Expr); perr == nil {
-		job.NextRunAt = sched.Next(now())
+	// Don't reactivate a job whose schedule can't advance (corrupt expr or an
+	// impossible spec) — it would leave a stale/zero NextRunAt for the runner.
+	sched, perr := cron.Parse(job.Expr)
+	if perr != nil {
+		fmt.Fprintln(stderr, perr.Error())
+		return exitUsage
 	}
+	next := sched.Next(now())
+	if next.IsZero() {
+		fmt.Fprintln(stderr, "That schedule never fires.")
+		return exitUsage
+	}
+	job.NextRunAt = next
 	if err := store.Update(job); err != nil {
 		fmt.Fprintln(stderr, err.Error())
 		return exitCrash

--- a/internal/cli/cron.go
+++ b/internal/cli/cron.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/cron"
+)
+
+// runCron is the dispatch entry for `zero cron`.
+func runCron(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	now := time.Now
+	if deps.now != nil {
+		now = deps.now
+	}
+	store := cron.NewStore(cron.StoreOptions{Now: now})
+	return runCronWith(store, now, args, stdout, stderr)
+}
+
+// runCronWith is the testable core (store + clock injected). `run` is handled in
+// cron_run.go (Task 6).
+func runCronWith(store *cron.Store, now func() time.Time, args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Usage: zero cron <add|list|rm|pause|resume|run> ...")
+		return exitUsage
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "-h", "--help", "help":
+		writeCronHelp(stdout)
+		return exitSuccess
+	case "add":
+		return cronAdd(store, now, rest, stdout, stderr)
+	case "list", "ls":
+		return cronList(store, now, stdout, stderr)
+	case "rm", "remove":
+		return cronSimple(store, rest, stderr, func(id string) error { return store.Remove(id) }, "removed")
+	case "pause":
+		return cronSetStatus(store, rest, stderr, cron.StatusPaused)
+	case "resume":
+		return cronResume(store, now, rest, stderr)
+	case "run":
+		// Task 6 wires the real cronRun; for now signal not yet implemented.
+		fmt.Fprintln(stderr, "zero cron run: not yet implemented (coming in Task 6)")
+		return exitUsage
+	default:
+		fmt.Fprintf(stderr, "Unknown cron subcommand: %s\n", sub)
+		return exitUsage
+	}
+}
+
+func cronAdd(store *cron.Store, now func() time.Time, args []string, stdout io.Writer, stderr io.Writer) int {
+	var expr, prompt, recipe, cwd, model string
+	runNow := false
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		switch a := args[i]; {
+		case a == "--prompt":
+			v, n, err := nextFlagValue(args, i, a)
+			if err != nil {
+				fmt.Fprintln(stderr, err.Error())
+				return exitUsage
+			}
+			prompt, i = v, n
+		case strings.HasPrefix(a, "--prompt="):
+			prompt = strings.TrimSpace(strings.TrimPrefix(a, "--prompt="))
+		case a == "--recipe":
+			v, n, err := nextFlagValue(args, i, a)
+			if err != nil {
+				fmt.Fprintln(stderr, err.Error())
+				return exitUsage
+			}
+			recipe, i = v, n
+		case strings.HasPrefix(a, "--recipe="):
+			recipe = strings.TrimSpace(strings.TrimPrefix(a, "--recipe="))
+		case a == "--cwd":
+			v, n, err := nextFlagValue(args, i, a)
+			if err != nil {
+				fmt.Fprintln(stderr, err.Error())
+				return exitUsage
+			}
+			cwd, i = v, n
+		case strings.HasPrefix(a, "--cwd="):
+			cwd = strings.TrimSpace(strings.TrimPrefix(a, "--cwd="))
+		case a == "--model":
+			v, n, err := nextFlagValue(args, i, a)
+			if err != nil {
+				fmt.Fprintln(stderr, err.Error())
+				return exitUsage
+			}
+			model, i = v, n
+		case strings.HasPrefix(a, "--model="):
+			model = strings.TrimSpace(strings.TrimPrefix(a, "--model="))
+		case a == "--run-now":
+			runNow = true
+		case strings.HasPrefix(a, "-"):
+			fmt.Fprintf(stderr, "Unknown cron add flag: %s\n", a)
+			return exitUsage
+		default:
+			positional = append(positional, a)
+		}
+	}
+
+	if recipe != "" {
+		r, ok := cron.Recipe(recipe)
+		if !ok {
+			fmt.Fprintf(stderr, "Unknown recipe %q. Available: %s\n", recipe, recipeIDs())
+			return exitUsage
+		}
+		if expr == "" {
+			expr = r.Expr
+		}
+		if prompt == "" {
+			prompt = r.Prompt
+		}
+	}
+	if len(positional) > 0 && expr == "" {
+		expr = positional[0]
+	}
+	if expr == "" {
+		fmt.Fprintln(stderr, "A cron expression is required (e.g. `zero cron add \"0 9 * * *\" --prompt ...`).")
+		return exitUsage
+	}
+	schedule, err := cron.Parse(expr)
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitUsage
+	}
+	if prompt == "" {
+		home, _ := os.UserHomeDir()
+		jobCwd := cwd
+		if jobCwd == "" {
+			jobCwd, _ = os.Getwd()
+		}
+		prompt, err = cron.ResolveLoopPrompt(jobCwd, home)
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return exitCrash
+		}
+	}
+	next := schedule.Next(now())
+	if !runNow && next.IsZero() {
+		fmt.Fprintln(stderr, "That schedule never fires.")
+		return exitUsage
+	}
+	if runNow {
+		next = now()
+	}
+	job, err := store.Add(cron.Job{Expr: expr, Prompt: prompt, Cwd: cwd, Model: model, Status: cron.StatusActive, NextRunAt: next})
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitCrash
+	}
+	fmt.Fprintf(stdout, "Added cron job %s (%s); next run %s.\n", job.ID, expr, formatCronTime(job.NextRunAt))
+	fmt.Fprintln(stdout, "Note: the prompt is stored in plaintext on disk — do not embed secrets.")
+	return exitSuccess
+}
+
+func cronList(store *cron.Store, now func() time.Time, stdout io.Writer, stderr io.Writer) int {
+	jobs, err := store.List()
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitCrash
+	}
+	if len(jobs) == 0 {
+		fmt.Fprintln(stdout, "No scheduled jobs.")
+		return exitSuccess
+	}
+	sort.Slice(jobs, func(i, j int) bool {
+		ai, aj := jobs[i].Status == cron.StatusActive, jobs[j].Status == cron.StatusActive
+		if ai != aj {
+			return ai // active first
+		}
+		if !jobs[i].NextRunAt.Equal(jobs[j].NextRunAt) {
+			return jobs[i].NextRunAt.Before(jobs[j].NextRunAt)
+		}
+		return jobs[i].ID < jobs[j].ID
+	})
+	for _, j := range jobs {
+		fmt.Fprintf(stdout, "%s · %s · %s (next: %s) · #%d · %s\n",
+			j.ID, j.Status, j.Expr, formatCronTime(j.NextRunAt), j.FireCount, promptExcerpt(j.Prompt))
+	}
+	return exitSuccess
+}
+
+func cronSimple(store *cron.Store, args []string, stderr io.Writer, fn func(string) error, verb string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "An id is required.")
+		return exitUsage
+	}
+	if err := fn(args[0]); err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitUsage
+	}
+	return exitSuccess
+}
+
+func cronSetStatus(store *cron.Store, args []string, stderr io.Writer, status string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "An id is required.")
+		return exitUsage
+	}
+	job, err := store.Get(args[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitUsage
+	}
+	job.Status = status
+	if err := store.Update(job); err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// cronResume sets a job active and recomputes NextRunAt.
+func cronResume(store *cron.Store, now func() time.Time, args []string, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "An id is required.")
+		return exitUsage
+	}
+	job, err := store.Get(args[0])
+	if err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitUsage
+	}
+	job.Status = cron.StatusActive
+	if sched, perr := cron.Parse(job.Expr); perr == nil {
+		job.NextRunAt = sched.Next(now())
+	}
+	if err := store.Update(job); err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func recipeIDs() string {
+	var ids []string
+	for _, r := range cron.Recipes() {
+		ids = append(ids, r.ID)
+	}
+	return strings.Join(ids, ", ")
+}
+
+func formatCronTime(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	return t.UTC().Format("2006-01-02 15:04 MST")
+}
+
+func promptExcerpt(p string) string {
+	p = strings.TrimSpace(strings.ReplaceAll(p, "\n", " "))
+	if len(p) > 48 {
+		return p[:47] + "…"
+	}
+	return p
+}
+
+func writeCronHelp(w io.Writer) {
+	fmt.Fprint(w, `zero cron — schedule agent jobs (foreground, file-backed)
+
+Usage:
+  zero cron add <cron-expr> [--prompt P | --recipe R] [--cwd D] [--model M] [--run-now]
+  zero cron list
+  zero cron pause <id> | resume <id> | rm <id>
+  zero cron run [--once] [--catch-up] [id...]
+
+Cron expression: standard 5 fields "minute hour day-of-month month day-of-week".
+`)
+}

--- a/internal/cli/cron.go
+++ b/internal/cli/cron.go
@@ -44,9 +44,7 @@ func runCronWith(store *cron.Store, now func() time.Time, args []string, stdout 
 	case "resume":
 		return cronResume(store, now, rest, stderr)
 	case "run":
-		// Task 6 wires the real cronRun; for now signal not yet implemented.
-		fmt.Fprintln(stderr, "zero cron run: not yet implemented (coming in Task 6)")
-		return exitUsage
+		return cronRun(store, now, rest, stdout, stderr, Run)
 	default:
 		fmt.Fprintf(stderr, "Unknown cron subcommand: %s\n", sub)
 		return exitUsage

--- a/internal/cli/cron.go
+++ b/internal/cli/cron.go
@@ -140,8 +140,11 @@ func cronAdd(store *cron.Store, now func() time.Time, args []string, stdout io.W
 			return exitCrash
 		}
 	}
+	// Reject an impossible schedule (e.g. "0 0 30 2 *") regardless of --run-now,
+	// so a job that can never advance is never persisted (it would otherwise
+	// re-fire every tick under `cron run`).
 	next := schedule.Next(now())
-	if !runNow && next.IsZero() {
+	if next.IsZero() {
 		fmt.Fprintln(stderr, "That schedule never fires.")
 		return exitUsage
 	}
@@ -161,8 +164,8 @@ func cronAdd(store *cron.Store, now func() time.Time, args []string, stdout io.W
 func cronList(store *cron.Store, now func() time.Time, stdout io.Writer, stderr io.Writer) int {
 	jobs, err := store.List()
 	if err != nil {
-		fmt.Fprintln(stderr, err.Error())
-		return exitCrash
+		// A corrupt job is surfaced as a warning; the listable jobs are still shown.
+		fmt.Fprintln(stderr, "warning:", err.Error())
 	}
 	if len(jobs) == 0 {
 		fmt.Fprintln(stdout, "No scheduled jobs.")

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -50,7 +50,7 @@ func cronRun(store *cron.Store, now func() time.Time, args []string, stdout io.W
 			if !selected(j) || j.NextRunAt.After(now()) {
 				continue
 			}
-			fireJob(store, now, j, stdout, exec)
+			fireJob(store, now, j, stdout, stderr, exec)
 		}
 	}
 
@@ -118,7 +118,9 @@ func reconcileOverdue(store *cron.Store, now func() time.Time, ids []string, std
 		if sched, perr := cron.Parse(j.Expr); perr == nil {
 			if nxt := sched.Next(now()); !nxt.IsZero() {
 				j.NextRunAt = nxt
-				_ = store.Update(j)
+				if err := store.Update(j); err != nil {
+					fmt.Fprintf(stderr, "warning: failed to reschedule %s: %v\n", j.ID, err)
+				}
 			}
 		}
 	}
@@ -127,7 +129,7 @@ func reconcileOverdue(store *cron.Store, now func() time.Time, ids []string, std
 // fireJob runs one job via the exec runner, records the outcome, advances the
 // schedule, and persists. The foreground loop is single-goroutine, so the
 // previous fire has already returned before the next tick — no overlap.
-func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Writer, exec execRunner) {
+func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Writer, stderr io.Writer, exec execRunner) {
 	fired := now()
 	args := []string{"exec", "--output-format", "stream-json", "--session-title", "cron:" + job.ID}
 	if job.Cwd != "" {
@@ -165,8 +167,12 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 	} else {
 		job.NextRunAt = nxt
 	}
-	_ = store.AppendRun(job.ID, rec)
-	_ = store.Update(job)
+	if err := store.AppendRun(job.ID, rec); err != nil {
+		fmt.Fprintf(stderr, "warning: failed to record run for %s: %v\n", job.ID, err)
+	}
+	if err := store.Update(job); err != nil {
+		fmt.Fprintf(stderr, "warning: failed to persist job state for %s: %v\n", job.ID, err)
+	}
 	fmt.Fprintf(stdout, "fired %s -> exit %d (next: %s)\n", job.ID, code, formatCronTime(job.NextRunAt))
 }
 

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -44,8 +44,7 @@ func cronRun(store *cron.Store, now func() time.Time, args []string, stdout io.W
 	fireDue := func() {
 		jobs, err := store.List()
 		if err != nil {
-			fmt.Fprintln(stderr, err.Error())
-			return
+			fmt.Fprintln(stderr, "warning:", err.Error()) // jobs still valid; never fatal
 		}
 		for _, j := range jobs {
 			if !selected(j) || j.NextRunAt.After(now()) {
@@ -56,29 +55,17 @@ func cronRun(store *cron.Store, now func() time.Time, args []string, stdout io.W
 	}
 
 	if once {
+		// --once fires every currently-due job once and exits, so --catch-up is a
+		// no-op when combined with --once. Intended for use under an external
+		// scheduler (system cron / launchd).
 		fireDue()
 		return exitSuccess
 	}
 
-	// Startup: reconcile overdue jobs. Without --catch-up, an overdue job is
-	// rescheduled to its next future slot (skip) instead of firing the backlog.
+	// Forever-mode startup: unless --catch-up, push STRICTLY-overdue jobs to their
+	// next future slot (skip the backlog) without firing.
 	if !catchUp {
-		jobs, err := store.List()
-		if err != nil {
-			fmt.Fprintln(stderr, err.Error())
-			return exitCrash
-		}
-		for _, j := range jobs {
-			if !selected(j) || j.NextRunAt.After(now()) {
-				continue
-			}
-			if sched, perr := cron.Parse(j.Expr); perr == nil {
-				if nxt := sched.Next(now()); !nxt.IsZero() {
-					j.NextRunAt = nxt
-					_ = store.Update(j)
-				}
-			}
-		}
+		reconcileOverdue(store, now, ids, stderr)
 	}
 
 	ctx, stop := signalContext()
@@ -107,6 +94,36 @@ func contains(ss []string, want string) bool {
 	return false
 }
 
+// reconcileOverdue (forever-mode startup, non --catch-up) reschedules jobs that
+// are STRICTLY overdue (NextRunAt before the current minute) to their next future
+// slot without firing the backlog. A job due within the current minute is left
+// for the fireDue pass so it still fires now. List errors are warnings, never
+// fatal (jobs remains valid).
+func reconcileOverdue(store *cron.Store, now func() time.Time, ids []string, stderr io.Writer) {
+	jobs, err := store.List()
+	if err != nil {
+		fmt.Fprintln(stderr, "warning:", err.Error())
+	}
+	nowMin := now().Truncate(time.Minute)
+	for _, j := range jobs {
+		if j.Status != cron.StatusActive {
+			continue
+		}
+		if len(ids) > 0 && !contains(ids, j.ID) {
+			continue
+		}
+		if !j.NextRunAt.Before(nowMin) {
+			continue // not strictly overdue
+		}
+		if sched, perr := cron.Parse(j.Expr); perr == nil {
+			if nxt := sched.Next(now()); !nxt.IsZero() {
+				j.NextRunAt = nxt
+				_ = store.Update(j)
+			}
+		}
+	}
+}
+
 // fireJob runs one job via the exec runner, records the outcome, advances the
 // schedule, and persists. The foreground loop is single-goroutine, so the
 // previous fire has already returned before the next tick — no overlap.
@@ -119,16 +136,43 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 	if job.Model != "" {
 		args = append(args, "--model", job.Model)
 	}
-	args = append(args, "--prompt", job.Prompt)
+	// Inline --prompt= form: a bare "--prompt" "<value>" makes exec reject a
+	// dash-leading prompt as a misplaced flag; the =VALUE form is taken verbatim.
+	args = append(args, "--prompt="+job.Prompt)
 
 	var outBuf, errBuf strings.Builder
 	code := exec(args, &outBuf, &errBuf)
-	_ = store.AppendRun(job.ID, cron.RunRecord{JobID: job.ID, At: fired, ExitCode: code, SessionTitle: "cron:" + job.ID})
+
+	rec := cron.RunRecord{JobID: job.ID, At: fired, ExitCode: code, SessionTitle: "cron:" + job.ID}
+	if code != 0 {
+		rec.Error = cronTruncate(strings.TrimSpace(errBuf.String()), 500)
+	}
 
 	job.FireCount++
-	if sched, err := cron.Parse(job.Expr); err == nil {
-		job.NextRunAt = sched.Next(fired)
+	// Advance the schedule. If the expression can no longer produce a future run
+	// (became invalid, or is an impossible spec whose Next is zero), pause the job
+	// so it cannot re-fire on every tick.
+	if sched, perr := cron.Parse(job.Expr); perr != nil {
+		job.Status = cron.StatusPaused
+		if rec.Error == "" {
+			rec.Error = "invalid schedule; job paused: " + perr.Error()
+		}
+	} else if nxt := sched.Next(fired); nxt.IsZero() {
+		job.Status = cron.StatusPaused
+		if rec.Error == "" {
+			rec.Error = "schedule no longer fires; job paused"
+		}
+	} else {
+		job.NextRunAt = nxt
 	}
+	_ = store.AppendRun(job.ID, rec)
 	_ = store.Update(job)
 	fmt.Fprintf(stdout, "fired %s -> exit %d (next: %s)\n", job.ID, code, formatCronTime(job.NextRunAt))
+}
+
+func cronTruncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/cron"
+)
+
+// execRunner runs a `zero exec ...` invocation and returns its exit code. The
+// default is cli.Run; tests inject a fake.
+type execRunner func(args []string, stdout, stderr io.Writer) int
+
+// cronRun implements `zero cron run [--once] [--catch-up] [id...]`.
+func cronRun(store *cron.Store, now func() time.Time, args []string, stdout io.Writer, stderr io.Writer, exec execRunner) int {
+	once, catchUp := false, false
+	var ids []string
+	for _, a := range args {
+		switch {
+		case a == "--once":
+			once = true
+		case a == "--catch-up":
+			catchUp = true
+		case strings.HasPrefix(a, "-"):
+			fmt.Fprintf(stderr, "Unknown cron run flag: %s\n", a)
+			return exitUsage
+		default:
+			ids = append(ids, a)
+		}
+	}
+
+	selected := func(j cron.Job) bool {
+		if j.Status != cron.StatusActive {
+			return false
+		}
+		if len(ids) == 0 {
+			return true
+		}
+		return contains(ids, j.ID)
+	}
+
+	fireDue := func() {
+		jobs, err := store.List()
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return
+		}
+		for _, j := range jobs {
+			if !selected(j) || j.NextRunAt.After(now()) {
+				continue
+			}
+			fireJob(store, now, j, stdout, exec)
+		}
+	}
+
+	if once {
+		fireDue()
+		return exitSuccess
+	}
+
+	// Startup: reconcile overdue jobs. Without --catch-up, an overdue job is
+	// rescheduled to its next future slot (skip) instead of firing the backlog.
+	if !catchUp {
+		jobs, err := store.List()
+		if err != nil {
+			fmt.Fprintln(stderr, err.Error())
+			return exitCrash
+		}
+		for _, j := range jobs {
+			if !selected(j) || j.NextRunAt.After(now()) {
+				continue
+			}
+			if sched, perr := cron.Parse(j.Expr); perr == nil {
+				if nxt := sched.Next(now()); !nxt.IsZero() {
+					j.NextRunAt = nxt
+					_ = store.Update(j)
+				}
+			}
+		}
+	}
+
+	ctx, stop := signalContext()
+	defer stop()
+	fireDue() // fire anything already due before the first tick
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Fprintln(stdout, "cron scheduler stopped.")
+			return exitSuccess
+		case <-ticker.C:
+			fireDue()
+		}
+	}
+}
+
+// contains reports whether ss contains want.
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// fireJob runs one job via the exec runner, records the outcome, advances the
+// schedule, and persists. The foreground loop is single-goroutine, so the
+// previous fire has already returned before the next tick — no overlap.
+func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Writer, exec execRunner) {
+	fired := now()
+	args := []string{"exec", "--output-format", "stream-json", "--session-title", "cron:" + job.ID}
+	if job.Cwd != "" {
+		args = append(args, "--cwd", job.Cwd)
+	}
+	if job.Model != "" {
+		args = append(args, "--model", job.Model)
+	}
+	args = append(args, "--prompt", job.Prompt)
+
+	var outBuf, errBuf strings.Builder
+	code := exec(args, &outBuf, &errBuf)
+	_ = store.AppendRun(job.ID, cron.RunRecord{JobID: job.ID, At: fired, ExitCode: code, SessionTitle: "cron:" + job.ID})
+
+	job.FireCount++
+	if sched, err := cron.Parse(job.Expr); err == nil {
+		job.NextRunAt = sched.Next(fired)
+	}
+	_ = store.Update(job)
+	fmt.Fprintf(stdout, "fired %s -> exit %d (next: %s)\n", job.ID, code, formatCronTime(job.NextRunAt))
+}

--- a/internal/cli/cron_run_test.go
+++ b/internal/cli/cron_run_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/cron"
+)
+
+// fakeExec records each invocation and returns a fixed exit code.
+type fakeExec struct {
+	mu    sync.Mutex
+	calls [][]string
+	code  int
+}
+
+func (f *fakeExec) run(args []string, stdout, stderr io.Writer) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, args)
+	return f.code
+}
+
+func TestCronRunOnceFiresDueJobs(t *testing.T) {
+	now := time.Date(2026, 6, 9, 9, 0, 0, 0, time.UTC)
+	store := cron.NewStore(cron.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return now }})
+	due, _ := store.Add(cron.Job{Expr: "0 9 * * *", Prompt: "fire me", Status: cron.StatusActive, NextRunAt: now.Add(-time.Minute)})
+	notDue, _ := store.Add(cron.Job{Expr: "0 9 * * *", Prompt: "later", Status: cron.StatusActive, NextRunAt: now.Add(time.Hour)})
+	paused, _ := store.Add(cron.Job{Expr: "0 9 * * *", Prompt: "paused", Status: cron.StatusPaused, NextRunAt: now.Add(-time.Hour)})
+
+	fx := &fakeExec{}
+	var out, errb bytes.Buffer
+	code := cronRun(store, func() time.Time { return now }, []string{"--once"}, &out, &errb, fx.run)
+	if code != 0 {
+		t.Fatalf("run --once exit=%d err=%s", code, errb.String())
+	}
+	if len(fx.calls) != 1 {
+		t.Fatalf("expected exactly 1 fire (the due job), got %d: %v", len(fx.calls), fx.calls)
+	}
+	args := fx.calls[0]
+	if args[0] != "exec" || !contains(args, "--prompt") || !contains(args, "fire me") {
+		t.Fatalf("fire must shell exec with --prompt: %v", args)
+	}
+	if !contains(args, "--output-format") || !contains(args, "stream-json") {
+		t.Fatalf("fire must use stream-json for session persistence: %v", args)
+	}
+	// due job rescheduled forward + fireCount incremented + run recorded
+	d, _ := store.Get(due.ID)
+	if d.FireCount != 1 || !d.NextRunAt.After(now) {
+		t.Fatalf("due job not advanced: %+v", d)
+	}
+	runs, _ := store.Runs(due.ID)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run record, got %d", len(runs))
+	}
+	if r, _ := store.Get(notDue.ID); r.FireCount != 0 {
+		t.Fatal("not-due job must not fire")
+	}
+	if r, _ := store.Get(paused.ID); r.FireCount != 0 {
+		t.Fatal("paused job must not fire")
+	}
+}
+
+func TestCronRunOnceSkipsOverdueWithoutCatchUp(t *testing.T) {
+	now := time.Date(2026, 6, 9, 9, 0, 0, 0, time.UTC)
+	store := cron.NewStore(cron.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return now }})
+	// NextRunAt far in the past, but we still fire once because it's due; the
+	// distinction this test pins: after firing, it reschedules to a FUTURE slot.
+	job, _ := store.Add(cron.Job{Expr: "0 9 * * *", Prompt: "x", Status: cron.StatusActive, NextRunAt: now.Add(-72 * time.Hour)})
+	fx := &fakeExec{}
+	var out, errb bytes.Buffer
+	cronRun(store, func() time.Time { return now }, []string{"--once"}, &out, &errb, fx.run)
+	d, _ := store.Get(job.ID)
+	if !d.NextRunAt.After(now) {
+		t.Fatalf("after firing, next run must be in the future, got %v", d.NextRunAt)
+	}
+}

--- a/internal/cli/cron_run_test.go
+++ b/internal/cli/cron_run_test.go
@@ -41,8 +41,8 @@ func TestCronRunOnceFiresDueJobs(t *testing.T) {
 		t.Fatalf("expected exactly 1 fire (the due job), got %d: %v", len(fx.calls), fx.calls)
 	}
 	args := fx.calls[0]
-	if args[0] != "exec" || !contains(args, "--prompt") || !contains(args, "fire me") {
-		t.Fatalf("fire must shell exec with --prompt: %v", args)
+	if args[0] != "exec" || !contains(args, "--prompt=fire me") {
+		t.Fatalf("fire must shell exec with inline --prompt=: %v", args)
 	}
 	if !contains(args, "--output-format") || !contains(args, "stream-json") {
 		t.Fatalf("fire must use stream-json for session persistence: %v", args)
@@ -76,5 +76,53 @@ func TestCronRunOnceSkipsOverdueWithoutCatchUp(t *testing.T) {
 	d, _ := store.Get(job.ID)
 	if !d.NextRunAt.After(now) {
 		t.Fatalf("after firing, next run must be in the future, got %v", d.NextRunAt)
+	}
+}
+
+func TestCronRunPausesUnadvanceableJob(t *testing.T) {
+	now := time.Date(2026, 6, 9, 9, 0, 0, 0, time.UTC)
+	store := cron.NewStore(cron.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return now }})
+	// An impossible schedule stored directly (cronAdd would reject it). After it
+	// fires once it cannot advance, so it must be paused, not re-fired forever.
+	job, _ := store.Add(cron.Job{Expr: "0 0 30 2 *", Prompt: "x", Status: cron.StatusActive, NextRunAt: now.Add(-time.Minute)})
+	fx := &fakeExec{}
+	var out, errb bytes.Buffer
+	cronRun(store, func() time.Time { return now }, []string{"--once"}, &out, &errb, fx.run)
+	d, _ := store.Get(job.ID)
+	if d.Status != cron.StatusPaused {
+		t.Fatalf("unadvanceable job must be paused, got status=%q", d.Status)
+	}
+	runs, _ := store.Runs(job.ID)
+	if len(runs) != 1 || runs[0].Error == "" {
+		t.Fatalf("expected one run record with an error, got %+v", runs)
+	}
+}
+
+func TestCronRunDashLeadingPromptUsesInlineForm(t *testing.T) {
+	now := time.Date(2026, 6, 9, 9, 0, 0, 0, time.UTC)
+	store := cron.NewStore(cron.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return now }})
+	if _, err := store.Add(cron.Job{Expr: "* * * * *", Prompt: "- do a thing", Status: cron.StatusActive, NextRunAt: now.Add(-time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	fx := &fakeExec{}
+	var out, errb bytes.Buffer
+	cronRun(store, func() time.Time { return now }, []string{"--once"}, &out, &errb, fx.run)
+	if len(fx.calls) != 1 || !contains(fx.calls[0], "--prompt=- do a thing") {
+		t.Fatalf("dash-leading prompt must use inline --prompt= form: %v", fx.calls)
+	}
+}
+
+func TestReconcileOverdueKeepsExactlyDueJob(t *testing.T) {
+	now := time.Date(2026, 6, 9, 9, 0, 0, 0, time.UTC)
+	store := cron.NewStore(cron.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return now }})
+	exact, _ := store.Add(cron.Job{Expr: "0 9 * * *", Prompt: "exact", Status: cron.StatusActive, NextRunAt: now})
+	overdue, _ := store.Add(cron.Job{Expr: "0 9 * * *", Prompt: "old", Status: cron.StatusActive, NextRunAt: now.Add(-24 * time.Hour)})
+	var errb bytes.Buffer
+	reconcileOverdue(store, func() time.Time { return now }, nil, &errb)
+	if e, _ := store.Get(exact.ID); !e.NextRunAt.Equal(now) {
+		t.Fatalf("exactly-due job must not be rescheduled, got %v", e.NextRunAt)
+	}
+	if o, _ := store.Get(overdue.ID); !o.NextRunAt.After(now) {
+		t.Fatalf("strictly-overdue job must be pushed to the future, got %v", o.NextRunAt)
 	}
 }

--- a/internal/cli/cron_test.go
+++ b/internal/cli/cron_test.go
@@ -77,3 +77,28 @@ func TestCronAddRecipe(t *testing.T) {
 		t.Fatalf("recipe job not stored: %+v", jobs)
 	}
 }
+
+func TestCronAddRejectsExtraArgs(t *testing.T) {
+	store := testCronStore(t)
+	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }
+	var out, errb bytes.Buffer
+	if code := runCronWith(store, now, []string{"add", "0 9 * * *", "extra", "--prompt", "x"}, &out, &errb); code == 0 {
+		t.Fatal("expected non-zero exit for extra positional args")
+	}
+	if jobs, _ := store.List(); len(jobs) != 0 {
+		t.Fatalf("no job should be stored on a usage error, got %v", jobs)
+	}
+}
+
+func TestCronResumeRejectsImpossibleSchedule(t *testing.T) {
+	store := testCronStore(t)
+	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }
+	job, _ := store.Add(cron.Job{Expr: "0 0 30 2 *", Prompt: "x", Status: cron.StatusPaused})
+	var out, errb bytes.Buffer
+	if code := runCronWith(store, now, []string{"resume", job.ID}, &out, &errb); code == 0 {
+		t.Fatal("resume of an impossible schedule must be rejected")
+	}
+	if j, _ := store.Get(job.ID); j.Status != cron.StatusPaused {
+		t.Fatalf("job must remain paused after a rejected resume, got %q", j.Status)
+	}
+}

--- a/internal/cli/cron_test.go
+++ b/internal/cli/cron_test.go
@@ -22,7 +22,10 @@ func TestCronAddListRemove(t *testing.T) {
 	if code := runCronWith(store, now, []string{"add", "0 9 * * *", "--prompt", "daily"}, &out, &errb); code != 0 {
 		t.Fatalf("add exit=%d err=%s", code, errb.String())
 	}
-	jobs, _ := store.List()
+	jobs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
 	if len(jobs) != 1 || jobs[0].Expr != "0 9 * * *" || jobs[0].Prompt != "daily" {
 		t.Fatalf("job not stored: %+v", jobs)
 	}
@@ -41,14 +44,22 @@ func TestCronAddListRemove(t *testing.T) {
 	if code := runCronWith(store, now, []string{"pause", jobs[0].ID}, &out, &errb); code != 0 {
 		t.Fatalf("pause exit=%d", code)
 	}
-	if j, _ := store.Get(jobs[0].ID); j.Status != cron.StatusPaused {
+	j, err := store.Get(jobs[0].ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if j.Status != cron.StatusPaused {
 		t.Fatalf("pause did not persist, status=%q", j.Status)
 	}
 
 	if code := runCronWith(store, now, []string{"rm", jobs[0].ID}, &out, &errb); code != 0 {
 		t.Fatalf("rm exit=%d", code)
 	}
-	if jobs, _ := store.List(); len(jobs) != 0 {
+	jobs, err = store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(jobs) != 0 {
 		t.Fatalf("expected removed, got %v", jobs)
 	}
 }
@@ -72,7 +83,10 @@ func TestCronAddRecipe(t *testing.T) {
 	if code := runCronWith(store, now, []string{"add", "--recipe", "git-recap"}, &out, &errb); code != 0 {
 		t.Fatalf("add --recipe exit=%d err=%s", code, errb.String())
 	}
-	jobs, _ := store.List()
+	jobs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
 	if len(jobs) != 1 || jobs[0].Expr != "*/30 * * * *" {
 		t.Fatalf("recipe job not stored: %+v", jobs)
 	}
@@ -85,7 +99,11 @@ func TestCronAddRejectsExtraArgs(t *testing.T) {
 	if code := runCronWith(store, now, []string{"add", "0 9 * * *", "extra", "--prompt", "x"}, &out, &errb); code == 0 {
 		t.Fatal("expected non-zero exit for extra positional args")
 	}
-	if jobs, _ := store.List(); len(jobs) != 0 {
+	jobs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(jobs) != 0 {
 		t.Fatalf("no job should be stored on a usage error, got %v", jobs)
 	}
 }
@@ -93,12 +111,19 @@ func TestCronAddRejectsExtraArgs(t *testing.T) {
 func TestCronResumeRejectsImpossibleSchedule(t *testing.T) {
 	store := testCronStore(t)
 	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }
-	job, _ := store.Add(cron.Job{Expr: "0 0 30 2 *", Prompt: "x", Status: cron.StatusPaused})
+	job, err := store.Add(cron.Job{Expr: "0 0 30 2 *", Prompt: "x", Status: cron.StatusPaused})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
 	var out, errb bytes.Buffer
 	if code := runCronWith(store, now, []string{"resume", job.ID}, &out, &errb); code == 0 {
 		t.Fatal("resume of an impossible schedule must be rejected")
 	}
-	if j, _ := store.Get(job.ID); j.Status != cron.StatusPaused {
+	j, err := store.Get(job.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if j.Status != cron.StatusPaused {
 		t.Fatalf("job must remain paused after a rejected resume, got %q", j.Status)
 	}
 }

--- a/internal/cli/cron_test.go
+++ b/internal/cli/cron_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/cron"
+)
+
+func testCronStore(t *testing.T) *cron.Store {
+	t.Helper()
+	return cron.NewStore(cron.StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }})
+}
+
+func TestCronAddListRemove(t *testing.T) {
+	store := testCronStore(t)
+	var out, errb bytes.Buffer
+	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }
+
+	if code := runCronWith(store, now, []string{"add", "0 9 * * *", "--prompt", "daily"}, &out, &errb); code != 0 {
+		t.Fatalf("add exit=%d err=%s", code, errb.String())
+	}
+	jobs, _ := store.List()
+	if len(jobs) != 1 || jobs[0].Expr != "0 9 * * *" || jobs[0].Prompt != "daily" {
+		t.Fatalf("job not stored: %+v", jobs)
+	}
+	if jobs[0].NextRunAt.IsZero() {
+		t.Fatal("NextRunAt should be set on add")
+	}
+
+	out.Reset()
+	if code := runCronWith(store, now, []string{"list"}, &out, &errb); code != 0 {
+		t.Fatalf("list exit=%d", code)
+	}
+	if !strings.Contains(out.String(), jobs[0].ID) || !strings.Contains(out.String(), "0 9 * * *") {
+		t.Fatalf("list output missing job:\n%s", out.String())
+	}
+
+	if code := runCronWith(store, now, []string{"pause", jobs[0].ID}, &out, &errb); code != 0 {
+		t.Fatalf("pause exit=%d", code)
+	}
+	if j, _ := store.Get(jobs[0].ID); j.Status != cron.StatusPaused {
+		t.Fatalf("pause did not persist, status=%q", j.Status)
+	}
+
+	if code := runCronWith(store, now, []string{"rm", jobs[0].ID}, &out, &errb); code != 0 {
+		t.Fatalf("rm exit=%d", code)
+	}
+	if jobs, _ := store.List(); len(jobs) != 0 {
+		t.Fatalf("expected removed, got %v", jobs)
+	}
+}
+
+func TestCronAddRejectsBadExpr(t *testing.T) {
+	store := testCronStore(t)
+	var out, errb bytes.Buffer
+	now := func() time.Time { return time.Now() }
+	if code := runCronWith(store, now, []string{"add", "99 * * * *", "--prompt", "x"}, &out, &errb); code == 0 {
+		t.Fatal("expected non-zero exit for invalid cron expr")
+	}
+	if !strings.Contains(errb.String(), "minute") {
+		t.Fatalf("error should name the bad field, got %q", errb.String())
+	}
+}
+
+func TestCronAddRecipe(t *testing.T) {
+	store := testCronStore(t)
+	var out, errb bytes.Buffer
+	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }
+	if code := runCronWith(store, now, []string{"add", "--recipe", "git-recap"}, &out, &errb); code != 0 {
+		t.Fatalf("add --recipe exit=%d err=%s", code, errb.String())
+	}
+	jobs, _ := store.List()
+	if len(jobs) != 1 || jobs[0].Expr != "*/30 * * * *" {
+		t.Fatalf("recipe job not stored: %+v", jobs)
+	}
+}

--- a/internal/cron/loopprompt.go
+++ b/internal/cron/loopprompt.go
@@ -1,0 +1,49 @@
+package cron
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxLoopPromptBytes = 25000
+
+const builtinLoopPrompt = "Continue the ongoing task in this repository.\n" +
+	"Inspect recent changes, make incremental progress, and stop when you reach a natural checkpoint.\n" +
+	"Do not take destructive actions without strong justification.\n" +
+	"Report what you did succinctly."
+
+// ResolveLoopPrompt returns the loop prompt for a scheduled job: the first
+// readable loop.md found in <cwd>/.zero, <cwd>/.agents, <home>/.zero,
+// <home>/.agents, else the built-in fallback. Files over maxLoopPromptBytes
+// return an error; symlinks are skipped (never read) to prevent exfiltration.
+func ResolveLoopPrompt(cwd, home string) (string, error) {
+	dirs := []string{
+		filepath.Join(cwd, ".zero"),
+		filepath.Join(cwd, ".agents"),
+		filepath.Join(home, ".zero"),
+		filepath.Join(home, ".agents"),
+	}
+	for _, dir := range dirs {
+		path := filepath.Join(dir, "loop.md")
+		info, err := os.Lstat(path)
+		if err != nil {
+			continue // not present
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			continue // never follow a symlinked loop.md
+		}
+		if info.Size() > maxLoopPromptBytes {
+			return "", fmt.Errorf("loop prompt %s exceeds %d bytes", path, maxLoopPromptBytes)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if text := strings.TrimSpace(string(data)); text != "" {
+			return text, nil
+		}
+	}
+	return builtinLoopPrompt, nil
+}

--- a/internal/cron/loopprompt_test.go
+++ b/internal/cron/loopprompt_test.go
@@ -1,0 +1,90 @@
+package cron
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecipesHaveValidSchedules(t *testing.T) {
+	if len(Recipes()) == 0 {
+		t.Fatal("expected preset recipes")
+	}
+	for _, r := range Recipes() {
+		if _, err := Parse(r.Expr); err != nil {
+			t.Fatalf("recipe %q has invalid expr %q: %v", r.ID, r.Expr, err)
+		}
+		if strings.TrimSpace(r.Prompt) == "" || strings.TrimSpace(r.ID) == "" {
+			t.Fatalf("recipe %q missing id/prompt", r.ID)
+		}
+	}
+	if _, ok := Recipe("git-recap"); !ok {
+		t.Fatal("expected a git-recap recipe")
+	}
+	if _, ok := Recipe("nope"); ok {
+		t.Fatal("unknown recipe must not resolve")
+	}
+}
+
+func TestResolveLoopPromptPriority(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	// built-in fallback when nothing present
+	got, err := ResolveLoopPrompt(cwd, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != builtinLoopPrompt {
+		t.Fatalf("expected built-in fallback, got %q", got)
+	}
+	// home/.zero/loop.md is used when cwd has none
+	mustWrite(t, filepath.Join(home, ".zero", "loop.md"), "HOME PROMPT")
+	if got, _ = ResolveLoopPrompt(cwd, home); got != "HOME PROMPT" {
+		t.Fatalf("home loop.md not used, got %q", got)
+	}
+	// cwd/.zero/loop.md wins over home
+	mustWrite(t, filepath.Join(cwd, ".zero", "loop.md"), "CWD PROMPT")
+	if got, _ = ResolveLoopPrompt(cwd, home); got != "CWD PROMPT" {
+		t.Fatalf("cwd loop.md should win, got %q", got)
+	}
+}
+
+func TestResolveLoopPromptRejectsSymlinkAndCap(t *testing.T) {
+	cwd := t.TempDir()
+	home := t.TempDir()
+	// oversize file -> error
+	big := filepath.Join(cwd, ".zero", "loop.md")
+	mustWrite(t, big, strings.Repeat("a", maxLoopPromptBytes+1))
+	if _, err := ResolveLoopPrompt(cwd, home); err == nil {
+		t.Fatal("expected error for oversize loop.md")
+	}
+	// symlink -> rejected (skipped), falls through to built-in
+	cwd2 := t.TempDir()
+	target := filepath.Join(cwd2, "real.md")
+	mustWrite(t, target, "SECRET")
+	link := filepath.Join(cwd2, ".zero", "loop.md")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks unsupported")
+	}
+	got, err := ResolveLoopPrompt(cwd2, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "SECRET" {
+		t.Fatal("symlinked loop.md must not be read")
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cron/next_test.go
+++ b/internal/cron/next_test.go
@@ -1,0 +1,64 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func mustParse(t *testing.T, expr string) Schedule {
+	t.Helper()
+	s, err := Parse(expr)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", expr, err)
+	}
+	return s
+}
+
+func TestNext(t *testing.T) {
+	utc := time.UTC
+	cases := []struct {
+		expr  string
+		after time.Time
+		want  time.Time
+	}{
+		// every minute -> next minute
+		{"* * * * *", time.Date(2026, 6, 9, 10, 0, 30, 0, utc), time.Date(2026, 6, 9, 10, 1, 0, 0, utc)},
+		// every 15 min
+		{"*/15 * * * *", time.Date(2026, 6, 9, 10, 7, 0, 0, utc), time.Date(2026, 6, 9, 10, 15, 0, 0, utc)},
+		// hourly at :00 crossing the hour
+		{"0 * * * *", time.Date(2026, 6, 9, 10, 30, 0, 0, utc), time.Date(2026, 6, 9, 11, 0, 0, 0, utc)},
+		// daily 09:00 -> next day when already past
+		{"0 9 * * *", time.Date(2026, 6, 9, 10, 0, 0, 0, utc), time.Date(2026, 6, 10, 9, 0, 0, 0, utc)},
+		// month rollover: Jan 31 23:59 -> next match Feb? "0 0 1 * *" first of month
+		{"0 0 1 * *", time.Date(2026, 1, 31, 23, 59, 0, 0, utc), time.Date(2026, 2, 1, 0, 0, 0, 0, utc)},
+		// year rollover
+		{"0 0 1 1 *", time.Date(2026, 6, 9, 0, 0, 0, 0, utc), time.Date(2027, 1, 1, 0, 0, 0, 0, utc)},
+		// weekday: next Monday 00:00
+		{"0 0 * * MON", time.Date(2026, 6, 9, 12, 0, 0, 0, utc), time.Date(2026, 6, 15, 0, 0, 0, 0, utc)}, // 2026-06-09 is a Tue
+		// DOM/DOW OR: fires on the 1st OR any Monday
+		{"0 0 1 * MON", time.Date(2026, 6, 9, 0, 0, 0, 0, utc), time.Date(2026, 6, 15, 0, 0, 0, 0, utc)}, // next Monday before next 1st
+	}
+	for _, c := range cases {
+		got := mustParse(t, c.expr).Next(c.after)
+		if !got.Equal(c.want) {
+			t.Fatalf("Next(%q, %v) = %v want %v", c.expr, c.after, got, c.want)
+		}
+	}
+}
+
+func TestNextImpossibleReturnsZero(t *testing.T) {
+	// Feb 30 never occurs.
+	got := mustParse(t, "0 0 30 2 *").Next(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if !got.IsZero() {
+		t.Fatalf("impossible schedule should return zero time, got %v", got)
+	}
+}
+
+func TestNextIsStrictlyAfter(t *testing.T) {
+	// Exactly on a match -> returns the NEXT one, not the same instant.
+	at := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
+	got := mustParse(t, "0 * * * *").Next(at)
+	if !got.After(at) {
+		t.Fatalf("Next must be strictly after input; got %v for %v", got, at)
+	}
+}

--- a/internal/cron/next_test.go
+++ b/internal/cron/next_test.go
@@ -62,3 +62,35 @@ func TestNextIsStrictlyAfter(t *testing.T) {
 		t.Fatalf("Next must be strictly after input; got %v for %v", got, at)
 	}
 }
+
+func TestNextDSTSpringForwardTerminates(t *testing.T) {
+	// 2026-03-08 is the US spring-forward day: 02:00-02:59 local does not exist in
+	// America/New_York. A "30 2 * * *" schedule must not hang (the old hour-advance
+	// stalled here); it should skip the missing 02:30 and fire the next day.
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skip("tzdata unavailable")
+	}
+	after := time.Date(2026, 3, 8, 0, 0, 0, 0, ny)
+	done := make(chan time.Time, 1)
+	go func() { done <- mustParse(t, "30 2 * * *").Next(after) }()
+	select {
+	case got := <-done:
+		want := time.Date(2026, 3, 9, 2, 30, 0, 0, ny) // missing 03-08 02:30 -> next day
+		if !got.Equal(want) {
+			t.Fatalf("DST: Next = %v want %v", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Next did not terminate on a DST spring-forward gap (infinite loop)")
+	}
+}
+
+func TestNextLeapYearCenturyGap(t *testing.T) {
+	// 2100 is NOT a leap year, so the next Feb 29 after 2096 is 2104 (an 8-year
+	// gap). The search window must be wide enough to find it (not report zero).
+	got := mustParse(t, "0 0 29 2 *").Next(time.Date(2096, 3, 1, 0, 0, 0, 0, time.UTC))
+	want := time.Date(2104, 2, 29, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("leap-gap: Next = %v want %v", got, want)
+	}
+}

--- a/internal/cron/recipes.go
+++ b/internal/cron/recipes.go
@@ -1,0 +1,28 @@
+package cron
+
+// RecipeDef is a named preset job (cron expression + prompt).
+type RecipeDef struct {
+	ID     string
+	Expr   string
+	Prompt string
+}
+
+var recipes = []RecipeDef{
+	{ID: "git-recap", Expr: "*/30 * * * *", Prompt: "Summarize the git commits since your last run; note anything risky."},
+	{ID: "ci-watch", Expr: "*/15 * * * *", Prompt: "Check CI status for the current branch and report failures with the failing step."},
+	{ID: "todo-pulse", Expr: "0 * * * *", Prompt: "Scan the working tree for new TODO/FIXME markers added recently and list them."},
+	{ID: "daily-summary", Expr: "0 9 * * *", Prompt: "Write a short progress summary of what changed in this repo over the last day."},
+}
+
+// Recipes returns the built-in preset recipes.
+func Recipes() []RecipeDef { return append([]RecipeDef(nil), recipes...) }
+
+// Recipe returns the preset with the given id.
+func Recipe(id string) (RecipeDef, bool) {
+	for _, r := range recipes {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return RecipeDef{}, false
+}

--- a/internal/cron/schedule.go
+++ b/internal/cron/schedule.go
@@ -158,33 +158,44 @@ func parseValue(tok string, min, max int, names map[string]int) (int, error) {
 	return n, nil
 }
 
-const nextSearchYears = 5
+// nextSearchYears bounds the forward search. It must exceed the worst-case gap
+// between consecutive valid days for any field — notably Feb 29, whose gap can be
+// 8 years across a century non-leap-year (e.g. 2096 -> 2104).
+const nextSearchYears = 9
 
 // Next returns the first scheduled instant strictly after `after`, evaluated in
 // after's location. It returns the zero time.Time if no match occurs within
-// nextSearchYears (an impossible schedule such as Feb 30).
+// nextSearchYears (an impossible schedule such as Feb 30). It is robust to DST
+// gaps: a per-iteration forward-progress guard prevents stalling on a
+// non-existent local instant (e.g. 02:30 on a spring-forward day).
 func (s Schedule) Next(after time.Time) time.Time {
 	loc := after.Location()
 	t := after.Truncate(time.Minute).Add(time.Minute)
 	yearCap := after.Year() + nextSearchYears
 	for t.Year() <= yearCap {
-		if !has(s.month, int(t.Month())) {
+		start := t
+		switch {
+		case !has(s.month, int(t.Month())):
 			t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, loc) // first of next month
-			continue
-		}
-		if !s.dayMatches(t) {
+		case !s.dayMatches(t):
 			t = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, loc) // next day 00:00
-			continue
-		}
-		if !has(s.hour, t.Hour()) {
-			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour()+1, 0, 0, 0, loc) // next hour :00
-			continue
-		}
-		if !has(s.minute, t.Minute()) {
+		case !has(s.hour, t.Hour()):
+			// Advance to the next hour by ABSOLUTE addition from this hour's :00.
+			// Using time.Date(..., Hour()+1, ...) can map back into a DST spring-
+			// forward gap (02:00 -> 01:00) and stall; adding an hour always moves
+			// forward in absolute time and correctly skips the missing hour.
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, loc).Add(time.Hour)
+		case !has(s.minute, t.Minute()):
 			t = t.Add(time.Minute)
-			continue
+		default:
+			return t
 		}
-		return t
+		// Forward-progress guard: if a wall-clock jump landed on a non-existent
+		// local instant (DST gap) and did not advance, step a minute so the search
+		// always terminates.
+		if !t.After(start) {
+			t = start.Add(time.Minute)
+		}
 	}
 	return time.Time{}
 }

--- a/internal/cron/schedule.go
+++ b/internal/cron/schedule.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Schedule is a parsed 5-field cron expression. Field sets are bitsets over the
@@ -155,4 +156,55 @@ func parseValue(tok string, min, max int, names map[string]int) (int, error) {
 		return 0, fmt.Errorf("value %d out of range %d-%d", n, min, max)
 	}
 	return n, nil
+}
+
+const nextSearchYears = 5
+
+// Next returns the first scheduled instant strictly after `after`, evaluated in
+// after's location. It returns the zero time.Time if no match occurs within
+// nextSearchYears (an impossible schedule such as Feb 30).
+func (s Schedule) Next(after time.Time) time.Time {
+	loc := after.Location()
+	t := after.Truncate(time.Minute).Add(time.Minute)
+	yearCap := after.Year() + nextSearchYears
+	for t.Year() <= yearCap {
+		if !has(s.month, int(t.Month())) {
+			t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, loc) // first of next month
+			continue
+		}
+		if !s.dayMatches(t) {
+			t = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, loc) // next day 00:00
+			continue
+		}
+		if !has(s.hour, t.Hour()) {
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour()+1, 0, 0, 0, loc) // next hour :00
+			continue
+		}
+		if !has(s.minute, t.Minute()) {
+			t = t.Add(time.Minute)
+			continue
+		}
+		return t
+	}
+	return time.Time{}
+}
+
+func has(set uint64, n int) bool { return set&(1<<uint(n)) != 0 }
+
+// dayMatches applies standard Vixie day-of-month / day-of-week semantics: when
+// both fields are restricted (neither was "*"), a day matches if EITHER matches;
+// otherwise only the restricted field constrains.
+func (s Schedule) dayMatches(t time.Time) bool {
+	domMatch := has(s.dom, t.Day())
+	dowMatch := has(s.dow, int(t.Weekday()))
+	switch {
+	case s.domStar && s.dowStar:
+		return true
+	case s.domStar:
+		return dowMatch
+	case s.dowStar:
+		return domMatch
+	default:
+		return domMatch || dowMatch
+	}
 }

--- a/internal/cron/schedule.go
+++ b/internal/cron/schedule.go
@@ -1,0 +1,158 @@
+// Package cron implements a small, dependency-free standard 5-field cron parser
+// and next-run evaluator for the `zero cron` scheduler.
+package cron
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Schedule is a parsed 5-field cron expression. Field sets are bitsets over the
+// field's value range. domStar/dowStar record whether the day-of-month /
+// day-of-week field was "*", which selects the standard Vixie OR semantics.
+type Schedule struct {
+	minute  uint64 // bits 0-59
+	hour    uint64 // bits 0-23
+	dom     uint64 // bits 1-31
+	month   uint64 // bits 1-12
+	dow     uint64 // bits 0-6 (Sunday = 0)
+	domStar bool
+	dowStar bool
+	expr    string
+}
+
+func (s Schedule) String() string { return s.expr }
+
+// full returns a bitset with every value in [min,max] set.
+func full(min, max int) uint64 {
+	var m uint64
+	for n := min; n <= max; n++ {
+		m |= 1 << uint(n)
+	}
+	return m
+}
+
+var monthNames = map[string]int{"jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6, "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12}
+var dowNames = map[string]int{"sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6}
+
+// Parse parses a standard 5-field cron expression: minute hour day-of-month
+// month day-of-week. Supports *, lists (a,b), ranges (a-b), steps (*/s, a-b/s,
+// a/s), 3-letter month/weekday names, and 7 as Sunday.
+func Parse(expr string) (Schedule, error) {
+	fields := strings.Fields(strings.TrimSpace(expr))
+	if len(fields) != 5 {
+		return Schedule{}, fmt.Errorf("cron expression must have 5 fields (minute hour day-of-month month day-of-week), got %d", len(fields))
+	}
+	var s Schedule
+	var err error
+	if s.minute, _, err = parseField(fields[0], 0, 59, nil); err != nil {
+		return Schedule{}, fmt.Errorf("minute field: %w", err)
+	}
+	if s.hour, _, err = parseField(fields[1], 0, 23, nil); err != nil {
+		return Schedule{}, fmt.Errorf("hour field: %w", err)
+	}
+	if s.dom, s.domStar, err = parseField(fields[2], 1, 31, nil); err != nil {
+		return Schedule{}, fmt.Errorf("day-of-month field: %w", err)
+	}
+	if s.month, _, err = parseField(fields[3], 1, 12, monthNames); err != nil {
+		return Schedule{}, fmt.Errorf("month field: %w", err)
+	}
+	if s.dow, s.dowStar, err = parseField(fields[4], 0, 7, dowNames); err != nil {
+		return Schedule{}, fmt.Errorf("day-of-week field: %w", err)
+	}
+	// Normalize 7 -> 0 (Sunday) in the dow bitset.
+	if s.dow&(1<<7) != 0 {
+		s.dow = (s.dow &^ (1 << 7)) | 1
+	}
+	s.expr = strings.Join(fields, " ")
+	return s, nil
+}
+
+// parseField parses one cron field into a bitset over [min,max]. It returns the
+// bitset, whether the field was exactly "*", and any error. names maps lowercase
+// 3-letter names to numbers (nil if the field has no names).
+func parseField(field string, min, max int, names map[string]int) (uint64, bool, error) {
+	if field == "*" {
+		return full(min, max), true, nil
+	}
+	var set uint64
+	for _, item := range strings.Split(field, ",") {
+		if item == "" {
+			return 0, false, fmt.Errorf("empty list element in %q", field)
+		}
+		bitsForItem, err := parseItem(item, min, max, names)
+		if err != nil {
+			return 0, false, err
+		}
+		set |= bitsForItem
+	}
+	return set, false, nil
+}
+
+func parseItem(item string, min, max int, names map[string]int) (uint64, error) {
+	rangePart := item
+	step := 1
+	if slash := strings.IndexByte(item, '/'); slash >= 0 {
+		rangePart = item[:slash]
+		stepStr := item[slash+1:]
+		n, err := strconv.Atoi(stepStr)
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("invalid step %q in %q", stepStr, item)
+		}
+		step = n
+	}
+
+	var lo, hi int
+	switch {
+	case rangePart == "*":
+		lo, hi = min, max
+	case strings.IndexByte(rangePart, '-') >= 0:
+		dash := strings.IndexByte(rangePart, '-')
+		var err error
+		if lo, err = parseValue(rangePart[:dash], min, max, names); err != nil {
+			return 0, err
+		}
+		if hi, err = parseValue(rangePart[dash+1:], min, max, names); err != nil {
+			return 0, err
+		}
+		if lo > hi {
+			return 0, fmt.Errorf("range start %d after end %d in %q", lo, hi, item)
+		}
+	default:
+		v, err := parseValue(rangePart, min, max, names)
+		if err != nil {
+			return 0, err
+		}
+		lo = v
+		// A bare "n/s" means n..max step s; a bare "n" is just n.
+		if step > 1 {
+			hi = max
+		} else {
+			hi = v
+		}
+	}
+
+	var set uint64
+	for n := lo; n <= hi; n += step {
+		set |= 1 << uint(n)
+	}
+	return set, nil
+}
+
+func parseValue(tok string, min, max int, names map[string]int) (int, error) {
+	tok = strings.TrimSpace(tok)
+	if names != nil {
+		if v, ok := names[strings.ToLower(tok)]; ok {
+			return v, nil
+		}
+	}
+	n, err := strconv.Atoi(tok)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value %q (expected %d-%d or a name)", tok, min, max)
+	}
+	if n < min || n > max {
+		return 0, fmt.Errorf("value %d out of range %d-%d", n, min, max)
+	}
+	return n, nil
+}

--- a/internal/cron/schedule_test.go
+++ b/internal/cron/schedule_test.go
@@ -1,0 +1,57 @@
+package cron
+
+import "testing"
+
+func bits(ns ...int) uint64 {
+	var m uint64
+	for _, n := range ns {
+		m |= 1 << uint(n)
+	}
+	return m
+}
+
+func TestParseValidFields(t *testing.T) {
+	cases := []struct {
+		expr                        string
+		minute, hour, dom, mon, dow uint64
+		domStar, dowStar            bool
+	}{
+		{"* * * * *", full(0, 59), full(0, 23), full(1, 31), full(1, 12), full(0, 6), true, true},
+		{"0 9 * * *", bits(0), bits(9), full(1, 31), full(1, 12), full(0, 6), true, true},
+		{"*/15 * * * *", bits(0, 15, 30, 45), full(0, 23), full(1, 31), full(1, 12), full(0, 6), true, true},
+		{"0 0,12 * * *", bits(0), bits(0, 12), full(1, 31), full(1, 12), full(0, 6), true, true},
+		{"0 9-17 * * 1-5", bits(0), bits(9, 10, 11, 12, 13, 14, 15, 16, 17), full(1, 31), full(1, 12), bits(1, 2, 3, 4, 5), true, false},
+		{"0 0 1 */3 *", bits(0), bits(0), bits(1), bits(1, 4, 7, 10), full(0, 6), false, true},
+		{"0 0 * * SUN", bits(0), bits(0), full(1, 31), full(1, 12), bits(0), true, false},
+		{"0 0 * JAN,DEC *", bits(0), bits(0), full(1, 31), bits(1, 12), full(0, 6), true, true},
+		{"0 0 * * 7", bits(0), bits(0), full(1, 31), full(1, 12), bits(0), true, false}, // 7 => Sunday
+	}
+	for _, c := range cases {
+		s, err := Parse(c.expr)
+		if err != nil {
+			t.Fatalf("Parse(%q) error: %v", c.expr, err)
+		}
+		if s.minute != c.minute || s.hour != c.hour || s.dom != c.dom || s.month != c.mon || s.dow != c.dow {
+			t.Fatalf("Parse(%q) sets minute=%b hour=%b dom=%b mon=%b dow=%b", c.expr, s.minute, s.hour, s.dom, s.month, s.dow)
+		}
+		if s.domStar != c.domStar || s.dowStar != c.dowStar {
+			t.Fatalf("Parse(%q) star flags dom=%v dow=%v want %v/%v", c.expr, s.domStar, s.dowStar, c.domStar, c.dowStar)
+		}
+		if s.String() != c.expr {
+			t.Fatalf("String()=%q want %q", s.String(), c.expr)
+		}
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	bad := []string{
+		"", "* * * *", "* * * * * *", // wrong field count
+		"60 * * * *", "* 24 * * *", "* * 0 * *", "* * 32 * *", "* * * 0 *", "* * * 13 *", "* * * * 8", // out of range
+		"*/0 * * * *", "5-2 * * * *", "a * * * *", "* * * FOO *", "1- * * * *", "1,,2 * * * *",
+	}
+	for _, expr := range bad {
+		if _, err := Parse(expr); err == nil {
+			t.Fatalf("Parse(%q) expected error", expr)
+		}
+	}
+}

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -65,11 +65,20 @@ func NewStore(opts StoreOptions) *Store {
 // DefaultRoot mirrors sessions.DefaultRoot: <XDG_DATA_HOME|~/.local/share>/zero/cron.
 func DefaultRoot(env map[string]string) string {
 	dataHome := strings.TrimSpace(env["XDG_DATA_HOME"])
-	if dataHome == "" {
-		home := strings.TrimSpace(env["HOME"])
-		dataHome = filepath.Join(home, ".local", "share")
+	home := strings.TrimSpace(env["HOME"])
+	if home == "" {
+		// Mirror sessions.DefaultRoot: fall back to the OS user home so an unset
+		// HOME (Windows, restricted shells) doesn't yield a RELATIVE ".local/share"
+		// under the caller's cwd, which would scatter cron data per working dir.
+		if userHome, err := os.UserHomeDir(); err == nil {
+			home = userHome
+		}
 	}
-	return filepath.Join(dataHome, "zero", "cron")
+	base := dataHome
+	if base == "" {
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "zero", "cron")
 }
 
 func envMap() map[string]string {

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -1,0 +1,211 @@
+package cron
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	StatusActive = "active"
+	StatusPaused = "paused"
+)
+
+// Job is a stored scheduled job.
+type Job struct {
+	ID        string    `json:"id"`
+	Expr      string    `json:"expr"`
+	Prompt    string    `json:"prompt"`
+	Cwd       string    `json:"cwd,omitempty"`
+	Model     string    `json:"model,omitempty"`
+	Status    string    `json:"status"`
+	FireCount int       `json:"fireCount"`
+	NextRunAt time.Time `json:"nextRunAt"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// RunRecord is one fire's outcome, appended to the job's runs.jsonl.
+type RunRecord struct {
+	JobID        string    `json:"jobId"`
+	At           time.Time `json:"at"`
+	ExitCode     int       `json:"exitCode"`
+	SessionTitle string    `json:"sessionTitle,omitempty"`
+	Error        string    `json:"error,omitempty"`
+}
+
+// StoreOptions configures a Store. RootDir defaults to DefaultRoot(os env); Now
+// defaults to time.Now. Both injectable for tests.
+type StoreOptions struct {
+	RootDir string
+	Now     func() time.Time
+}
+
+type Store struct {
+	root string
+	now  func() time.Time
+}
+
+func NewStore(opts StoreOptions) *Store {
+	root := opts.RootDir
+	if root == "" {
+		root = DefaultRoot(envMap())
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{root: root, now: now}
+}
+
+// DefaultRoot mirrors sessions.DefaultRoot: <XDG_DATA_HOME|~/.local/share>/zero/cron.
+func DefaultRoot(env map[string]string) string {
+	dataHome := strings.TrimSpace(env["XDG_DATA_HOME"])
+	if dataHome == "" {
+		home := strings.TrimSpace(env["HOME"])
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(dataHome, "zero", "cron")
+}
+
+func envMap() map[string]string {
+	return map[string]string{"XDG_DATA_HOME": os.Getenv("XDG_DATA_HOME"), "HOME": os.Getenv("HOME")}
+}
+
+// Add assigns an ID + CreatedAt and writes the job's metadata.json.
+func (s *Store) Add(job Job) (Job, error) {
+	if job.Status == "" {
+		job.Status = StatusActive
+	}
+	job.CreatedAt = s.now().UTC()
+	id, err := s.allocID()
+	if err != nil {
+		return Job{}, err
+	}
+	job.ID = id
+	if err := s.writeJob(job); err != nil {
+		return Job{}, err
+	}
+	return job, nil
+}
+
+func (s *Store) allocID() (string, error) {
+	base := s.now().UTC().Format("20060102-150405")
+	for n := 0; n < 100; n++ {
+		id := base
+		if n > 0 {
+			id = fmt.Sprintf("%s-%d", base, n)
+		}
+		if _, err := os.Stat(filepath.Join(s.root, id)); errors.Is(err, os.ErrNotExist) {
+			return id, nil
+		}
+	}
+	return "", errors.New("could not allocate a unique cron job id")
+}
+
+func (s *Store) jobDir(id string) string { return filepath.Join(s.root, id) }
+
+func (s *Store) writeJob(job Job) error {
+	dir := s.jobDir(job.ID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(job, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(dir, "metadata.json.tmp")
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(dir, "metadata.json"))
+}
+
+func (s *Store) Get(id string) (Job, error) {
+	data, err := os.ReadFile(filepath.Join(s.jobDir(id), "metadata.json"))
+	if err != nil {
+		return Job{}, fmt.Errorf("cron job %q not found", id)
+	}
+	var job Job
+	if err := json.Unmarshal(data, &job); err != nil {
+		return Job{}, fmt.Errorf("cron job %q is corrupt: %w", id, err)
+	}
+	return job, nil
+}
+
+func (s *Store) Update(job Job) error {
+	if _, err := os.Stat(s.jobDir(job.ID)); err != nil {
+		return fmt.Errorf("cron job %q not found", job.ID)
+	}
+	return s.writeJob(job)
+}
+
+func (s *Store) Remove(id string) error {
+	if _, err := os.Stat(s.jobDir(id)); err != nil {
+		return fmt.Errorf("cron job %q not found", id)
+	}
+	return os.RemoveAll(s.jobDir(id))
+}
+
+func (s *Store) List() ([]Job, error) {
+	entries, err := os.ReadDir(s.root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var jobs []Job
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if job, err := s.Get(e.Name()); err == nil {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+func (s *Store) AppendRun(id string, rec RunRecord) error {
+	dir := s.jobDir(id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "runs.jsonl"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+func (s *Store) Runs(id string) ([]RunRecord, error) {
+	f, err := os.Open(filepath.Join(s.jobDir(id), "runs.jsonl"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var runs []RunRecord
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var rec RunRecord
+		if json.Unmarshal(scanner.Bytes(), &rec) == nil {
+			runs = append(runs, rec)
+		}
+	}
+	return runs, scanner.Err()
+}

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -109,6 +109,13 @@ func (s *Store) allocID() (string, error) {
 
 func (s *Store) jobDir(id string) string { return filepath.Join(s.root, id) }
 
+// validID rejects ids that could escape the store root (path separators or
+// traversal). allocID-generated timestamp ids always pass; this guards
+// externally-supplied ids (get/update/remove/append).
+func validID(id string) bool {
+	return id != "" && id != "." && id != ".." && !strings.ContainsAny(id, `/\`) && filepath.Base(id) == id
+}
+
 func (s *Store) writeJob(job Job) error {
 	dir := s.jobDir(job.ID)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -126,6 +133,9 @@ func (s *Store) writeJob(job Job) error {
 }
 
 func (s *Store) Get(id string) (Job, error) {
+	if !validID(id) {
+		return Job{}, fmt.Errorf("invalid cron job id %q", id)
+	}
 	data, err := os.ReadFile(filepath.Join(s.jobDir(id), "metadata.json"))
 	if err != nil {
 		return Job{}, fmt.Errorf("cron job %q not found", id)
@@ -138,6 +148,9 @@ func (s *Store) Get(id string) (Job, error) {
 }
 
 func (s *Store) Update(job Job) error {
+	if !validID(job.ID) {
+		return fmt.Errorf("invalid cron job id %q", job.ID)
+	}
 	if _, err := os.Stat(s.jobDir(job.ID)); err != nil {
 		return fmt.Errorf("cron job %q not found", job.ID)
 	}
@@ -145,6 +158,9 @@ func (s *Store) Update(job Job) error {
 }
 
 func (s *Store) Remove(id string) error {
+	if !validID(id) {
+		return fmt.Errorf("invalid cron job id %q", id)
+	}
 	if _, err := os.Stat(s.jobDir(id)); err != nil {
 		return fmt.Errorf("cron job %q not found", id)
 	}
@@ -160,18 +176,33 @@ func (s *Store) List() ([]Job, error) {
 		return nil, err
 	}
 	var jobs []Job
+	var corrupt []string
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
-		if job, err := s.Get(e.Name()); err == nil {
-			jobs = append(jobs, job)
+		if _, statErr := os.Stat(filepath.Join(s.jobDir(e.Name()), "metadata.json")); statErr != nil {
+			continue // a directory without metadata.json is not a job
 		}
+		job, gerr := s.Get(e.Name())
+		if gerr != nil {
+			corrupt = append(corrupt, e.Name())
+			continue
+		}
+		jobs = append(jobs, job)
+	}
+	// Surface corrupt jobs (jobs slice is still authoritative; callers treat this
+	// as a warning, not a fatal error, so one bad job never hides the rest).
+	if len(corrupt) > 0 {
+		return jobs, fmt.Errorf("skipped %d unreadable cron job(s): %s", len(corrupt), strings.Join(corrupt, ", "))
 	}
 	return jobs, nil
 }
 
 func (s *Store) AppendRun(id string, rec RunRecord) error {
+	if !validID(id) {
+		return fmt.Errorf("invalid cron job id %q", id)
+	}
 	dir := s.jobDir(id)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -211,16 +211,23 @@ func (s *Store) AppendRun(id string, rec RunRecord) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	line, err := json.Marshal(rec)
 	if err != nil {
+		_ = f.Close()
 		return err
 	}
-	_, err = f.Write(append(line, '\n'))
-	return err
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		_ = f.Close()
+		return err
+	}
+	// Surface a buffered-write failure that only materializes on Close.
+	return f.Close()
 }
 
 func (s *Store) Runs(id string) ([]RunRecord, error) {
+	if !validID(id) {
+		return nil, fmt.Errorf("invalid cron job id %q", id)
+	}
 	f, err := os.Open(filepath.Join(s.jobDir(id), "runs.jsonl"))
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -83,6 +83,9 @@ func TestStoreRejectsUnsafeID(t *testing.T) {
 		if _, err := s.Get(id); err == nil {
 			t.Fatalf("Get(%q) must be rejected", id)
 		}
+		if _, err := s.Runs(id); err == nil {
+			t.Fatalf("Runs(%q) must be rejected", id)
+		}
 	}
 	if _, err := os.Stat(sibling); err != nil {
 		t.Fatalf("traversal must not delete a sibling directory: %v", err)

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -66,6 +67,21 @@ func TestDefaultRootHonorsXDG(t *testing.T) {
 	root := DefaultRoot(map[string]string{"XDG_DATA_HOME": "/tmp/xdg"})
 	if root != filepath.Join("/tmp/xdg", "zero", "cron") {
 		t.Fatalf("DefaultRoot=%q", root)
+	}
+}
+
+func TestDefaultRootEmptyHomeFallsBackToUserHome(t *testing.T) {
+	// No XDG_DATA_HOME and no HOME: must NOT produce a relative ".local/share"
+	// under the caller's cwd (the bug). It falls back to the OS user home.
+	root := DefaultRoot(map[string]string{})
+	if !filepath.IsAbs(root) {
+		t.Fatalf("DefaultRoot with empty env must be absolute, got %q", root)
+	}
+	if strings.HasPrefix(root, ".local") || strings.HasPrefix(root, filepath.Join(".local", "share")) {
+		t.Fatalf("DefaultRoot leaked a relative .local/share path: %q", root)
+	}
+	if filepath.Base(root) != "cron" || filepath.Base(filepath.Dir(root)) != "zero" {
+		t.Fatalf("DefaultRoot tail = %q, want .../zero/cron", root)
 	}
 }
 

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -1,0 +1,69 @@
+package cron
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore(StoreOptions{RootDir: t.TempDir(), Now: func() time.Time { return time.Unix(1000, 0).UTC() }})
+}
+
+func TestStoreAddListGetRemove(t *testing.T) {
+	s := newTestStore(t)
+	job := Job{Expr: "0 9 * * *", Prompt: "hi", Status: StatusActive, NextRunAt: time.Unix(2000, 0).UTC()}
+	added, err := s.Add(job)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if added.ID == "" || added.CreatedAt.IsZero() {
+		t.Fatalf("Add must assign ID + CreatedAt, got %+v", added)
+	}
+	list, err := s.List()
+	if err != nil || len(list) != 1 || list[0].ID != added.ID {
+		t.Fatalf("List=%v err=%v", list, err)
+	}
+	got, err := s.Get(added.ID)
+	if err != nil || got.Prompt != "hi" || got.Expr != "0 9 * * *" {
+		t.Fatalf("Get=%+v err=%v", got, err)
+	}
+	got.Status = StatusPaused
+	if err := s.Update(got); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if reread, _ := s.Get(added.ID); reread.Status != StatusPaused {
+		t.Fatalf("Update not persisted, status=%q", reread.Status)
+	}
+	if err := s.Remove(added.ID); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if list, _ := s.List(); len(list) != 0 {
+		t.Fatalf("expected empty after remove, got %v", list)
+	}
+	if _, err := s.Get(added.ID); err == nil {
+		t.Fatal("Get of removed id must error")
+	}
+}
+
+func TestStoreAppendRun(t *testing.T) {
+	s := newTestStore(t)
+	job, _ := s.Add(Job{Expr: "* * * * *", Prompt: "x", Status: StatusActive})
+	for i := 0; i < 3; i++ {
+		if err := s.AppendRun(job.ID, RunRecord{JobID: job.ID, At: time.Unix(int64(i), 0).UTC(), ExitCode: i}); err != nil {
+			t.Fatalf("AppendRun: %v", err)
+		}
+	}
+	runs, err := s.Runs(job.ID)
+	if err != nil || len(runs) != 3 || runs[2].ExitCode != 2 {
+		t.Fatalf("Runs=%v err=%v", runs, err)
+	}
+}
+
+func TestDefaultRootHonorsXDG(t *testing.T) {
+	root := DefaultRoot(map[string]string{"XDG_DATA_HOME": "/tmp/xdg"})
+	if root != filepath.Join("/tmp/xdg", "zero", "cron") {
+		t.Fatalf("DefaultRoot=%q", root)
+	}
+}

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -65,5 +66,41 @@ func TestDefaultRootHonorsXDG(t *testing.T) {
 	root := DefaultRoot(map[string]string{"XDG_DATA_HOME": "/tmp/xdg"})
 	if root != filepath.Join("/tmp/xdg", "zero", "cron") {
 		t.Fatalf("DefaultRoot=%q", root)
+	}
+}
+
+func TestStoreRejectsUnsafeID(t *testing.T) {
+	root := t.TempDir()
+	s := NewStore(StoreOptions{RootDir: root, Now: func() time.Time { return time.Unix(0, 0).UTC() }})
+	sibling := filepath.Join(filepath.Dir(root), "victim")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"../victim", "a/b", "..", ""} {
+		if err := s.Remove(id); err == nil {
+			t.Fatalf("Remove(%q) must be rejected", id)
+		}
+		if _, err := s.Get(id); err == nil {
+			t.Fatalf("Get(%q) must be rejected", id)
+		}
+	}
+	if _, err := os.Stat(sibling); err != nil {
+		t.Fatalf("traversal must not delete a sibling directory: %v", err)
+	}
+}
+
+func TestListSurfacesCorruptJob(t *testing.T) {
+	s := newTestStore(t)
+	good, _ := s.Add(Job{Expr: "0 9 * * *", Prompt: "ok", Status: StatusActive})
+	bad, _ := s.Add(Job{Expr: "0 9 * * *", Prompt: "bad", Status: StatusActive})
+	if err := os.WriteFile(filepath.Join(s.jobDir(bad.ID), "metadata.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	jobs, err := s.List()
+	if err == nil {
+		t.Fatal("List should surface a corrupt job via a non-nil (warning) error")
+	}
+	if len(jobs) != 1 || jobs[0].ID != good.ID {
+		t.Fatalf("good job must still list despite a corrupt sibling, got %+v", jobs)
 	}
 }


### PR DESCRIPTION
## Summary

Adds `zero cron` — define file-backed scheduled agent jobs (standard 5-field cron) and a foreground `zero cron run` that fires due jobs by reusing the existing `zero exec` path. **Dep-free**, additive (new `internal/cron` package + new command).

This is the network-free, no-daemon residue of the upstream `05-daemon-cron` module — the entire `TuiDaemonAdapter`/daemon/IPC, the second "automations" job system, the TUI leave-warning, and locale time handling are intentionally **not** ported.

## Commands

```
zero cron add "<cron-expr>" [--prompt P | --recipe R] [--cwd D] [--model M] [--run-now]
zero cron list | pause <id> | resume <id> | rm <id>
zero cron run [--once] [--catch-up] [id...]
```

- **Schedule:** standard 5 fields `minute hour day-of-month month day-of-week` — a small dep-free parser (tokens `*`, lists, ranges, steps, month/weekday names, `7`=Sun) with standard Vixie DOM/DOW OR semantics, evaluated in **local time**.
- **`run`:** foreground loop (Ctrl+C/SIGTERM to stop); `--once` fires currently-due jobs and exits (wire it under an external scheduler); `--catch-up` fires overdue jobs on start, otherwise the default is skip-and-reschedule.
- **A fire** = `zero exec --output-format stream-json --session-title cron:<id> --prompt=<job prompt>`, reusing the agent + session persistence; the exit code is recorded to `runs.jsonl`.
- **Storage:** `$XDG_DATA_HOME/zero/cron/<id>/` (`metadata.json` + append-only `runs.jsonl`), mirroring `sessions.Store`.
- Preset `--recipe`s + `loop.md` prompt resolution (25KB cap, symlink-reject).

## Design

- **`internal/cron`** (pure, stdlib-only): `Schedule` (`Parse`/`Next`/`String`), file-backed `Store`, recipes, loop.md resolution. `Now`/`RootDir` injectable for tests.
- **`internal/cli/cron.go` + `cron_run.go`**: command group + foreground runner behind an injectable exec seam (default `cli.Run`) for testability. Dispatch case + help in `app.go`.

## Built with an adversarial workflow

Implemented via a multi-agent workflow (6 sequential TDD tasks, each verified) followed by a 3-lens adversarial panel (parser correctness, runner semantics, arg-safety). The panel found and this PR fixes **9 real issues**, including:

- **Critical:** `Next()` infinite loop on a DST spring-forward gap (`30 2 * * *` on the transition day) — fixed (absolute-time hour advance + forward-progress guard). Regression-tested against `America/New_York`.
- **High:** path traversal in the store (`cron rm ../..` could `RemoveAll` outside the root) — job ids now validated.
- **High:** runaway re-fire when a job's schedule can't advance (`--run-now` bypassed the impossible-spec guard) — impossible specs rejected at add; unadvanceable jobs auto-pause.
- **Medium/Low:** leap-year search window (Feb-29 across a century non-leap year), startup reconcile keeping exactly-due jobs, corrupt-job surfacing, `RunRecord.Error` capture, and dash-leading prompts via the inline `--prompt=` form.

## Test Plan

- [x] `go build ./...` / `GOOS=windows GOARCH=amd64 go build ./...` clean
- [x] `go vet ./...` clean; `gofmt` clean
- [x] `go test ./...` green (parser table, `Next` rollovers/DST/leap/impossible, store round-trip + traversal + corrupt, runner once/catch-up/overlap/pause/reconcile, CLI)
- [x] `go test -race ./internal/{cron,cli}/...` green
- [x] Smoke: add/list/run --once/rm; impossible spec rejected; traversal rejected

### Reviewer focus
- Dep-free parser + `Next` (local time, Vixie OR, DST gap, leap window).
- Foreground-only semantics: jobs fire only while `cron run` is active (documented); skip-and-reschedule default vs `--catch-up`.
- A prompt is stored in plaintext under the data dir (warned on `add`); unattended fires inherit the normal autonomy/sandbox ceiling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level cron command with subcommands to add, list, pause, resume, remove, and run jobs (once or continuous, with catch-up and run-now).
  * Added built-in recipes, loop-prompt resolution (search priority, size limits, symlink handling), a persistent job store with run history, safe ID handling, and a robust cron schedule engine.

* **Tests**
  * Extensive unit and integration tests covering scheduling logic, store operations, CLI flows, and cron run execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->