### PR TITLE
Add repo intelligence map

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -857,6 +857,40 @@ func TestBuildSystemPromptInjectsWorkspaceContext(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPromptInjectsRepoMap(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "go.mod"), []byte("module example.com/app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cwd, "internal", "service"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "internal", "service", "service.go"), []byte("package service\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cwd, "node_modules", "leftpad"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "node_modules", "leftpad", "index.js"), []byte("module.exports = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prompt := buildSystemPrompt(Options{Cwd: cwd})
+	for _, want := range []string{
+		"## Repo map",
+		"Important files: go.mod",
+		"Languages:",
+		"internal/service/service.go",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("expected repo map marker %q in prompt, got %q", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "node_modules/leftpad") {
+		t.Fatalf("repo map should omit ignored dependency dirs, got %q", prompt)
+	}
+}
+
 func TestBuildSystemPromptAllowsSpecModeOverride(t *testing.T) {
 	prompt := buildSystemPrompt(Options{SystemPrompt: specmode.DraftSystemPrompt})
 	if !strings.HasPrefix(prompt, "Specification drafting is active.") {

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -104,6 +104,9 @@ func workspaceContext(cwd string) string {
 }
 
 func repoMapContext(cwd string) string {
+	// repomap.Scan is best-effort supplemental context for the prompt. If it
+	// fails, omit the repo map instead of failing the agent run; successful scans
+	// are still capped by repomap.RenderPrompt and maxRepoMapContextBytes.
 	snapshot, err := repomap.Scan(cwd, repomap.Options{
 		MaxFiles: 300,
 		MaxDepth: 5,

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/repomap"
 )
 
 // coreSystemPrompt is the de-branded coding-craft instruction set: identity,
@@ -33,6 +35,10 @@ var projectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
 // maxProjectContextBytes caps how much of a project doc is injected so a large
 // guidelines file can't blow the context budget.
 const maxProjectContextBytes = 8 << 10 // 8 KiB
+
+// maxRepoMapContextBytes keeps the repository map useful but compact enough to
+// remain stable across normal agent turns.
+const maxRepoMapContextBytes = 4 << 10 // 4 KiB
 
 // buildSystemPrompt assembles the full system prompt for a run: the core
 // coding-craft instructions, dynamic workspace context (cwd, git branch, project
@@ -91,7 +97,21 @@ func workspaceContext(cwd string) string {
 		b.WriteString("\n\n## Project guidelines (" + name + ")\n\n" + content)
 		break // first match wins
 	}
+	if repoMap := repoMapContext(cwd); repoMap != "" {
+		b.WriteString("\n\n## Repo map\n\n" + repoMap)
+	}
 	return b.String()
+}
+
+func repoMapContext(cwd string) string {
+	snapshot, err := repomap.Scan(cwd, repomap.Options{
+		MaxFiles: 300,
+		MaxDepth: 5,
+	})
+	if err != nil {
+		return ""
+	}
+	return repomap.RenderPrompt(snapshot, maxRepoMapContextBytes)
 }
 
 // gitBranchForPrompt reads the current branch (or short SHA when detached) for

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -180,6 +180,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runDoctor(args[1:], stdout, stderr, deps)
 	case "context":
 		return runContext(args[1:], stdout, stderr, deps)
+	case "repo-map", "repomap":
+		return runRepoMap(args[1:], stdout, stderr, deps)
 	case "search", "find":
 		return runSearch(args[1:], stdout, stderr, deps)
 	case "sessions", "session":
@@ -469,6 +471,7 @@ Commands:
   providers  Inspect resolved provider profiles
   doctor     Run backend health checks for config and provider setup
   context    Report workspace context budget usage
+  repo-map   Build a deterministic repository map for agent context
   search     Search persisted local Zero session events
   find       Alias for search
   sessions   Inspect local Zero session lineage

--- a/internal/cli/repo_map.go
+++ b/internal/cli/repo_map.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/repomap"
+)
+
+const defaultRepoMapOutputFiles = 40
+
+type repoMapOptions struct {
+	json     bool
+	query    string
+	maxFiles int
+	maxDepth int
+}
+
+type repoMapReport struct {
+	Root           string                 `json:"root"`
+	Summary        repoMapSummary         `json:"summary"`
+	Languages      []repomap.Count        `json:"languages"`
+	Extensions     []repomap.Count        `json:"extensions"`
+	ImportantFiles []string               `json:"importantFiles,omitempty"`
+	Files          []repomap.File         `json:"files"`
+	Matches        []repomap.SearchResult `json:"matches,omitempty"`
+}
+
+type repoMapSummary struct {
+	FileCount      int  `json:"fileCount"`
+	DirectoryCount int  `json:"directoryCount"`
+	MaxDepth       int  `json:"maxDepth"`
+	Truncated      bool `json:"truncated,omitempty"`
+}
+
+func runRepoMap(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseRepoMapArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeRepoMapHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	snapshot, err := repomap.Scan(workspaceRoot, repomap.Options{MaxDepth: options.maxDepth})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	report := buildRepoMapReport(snapshot, options)
+	if options.json {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(report); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if options.query != "" {
+		if _, err := fmt.Fprint(stdout, formatRepoMapMatches(options.query, report.Matches)); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprint(stdout, formatRepoMapSummary(report)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseRepoMapArgs(args []string) (repoMapOptions, bool, error) {
+	options := repoMapOptions{
+		maxFiles: defaultRepoMapOutputFiles,
+		maxDepth: repomap.DefaultMaxDepth,
+	}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--query":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.query = value
+			index = next
+		case strings.HasPrefix(arg, "--query="):
+			options.query = strings.TrimSpace(strings.TrimPrefix(arg, "--query="))
+		case arg == "--max-files":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			parsed, err := parsePositiveRepoMapInt("--max-files", value)
+			if err != nil {
+				return options, false, err
+			}
+			options.maxFiles = parsed
+			index = next
+		case strings.HasPrefix(arg, "--max-files="):
+			parsed, err := parsePositiveRepoMapInt("--max-files", strings.TrimPrefix(arg, "--max-files="))
+			if err != nil {
+				return options, false, err
+			}
+			options.maxFiles = parsed
+		case arg == "--max-depth":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			parsed, err := parseNonNegativeRepoMapInt("--max-depth", value)
+			if err != nil {
+				return options, false, err
+			}
+			options.maxDepth = parsed
+			index = next
+		case strings.HasPrefix(arg, "--max-depth="):
+			parsed, err := parseNonNegativeRepoMapInt("--max-depth", strings.TrimPrefix(arg, "--max-depth="))
+			if err != nil {
+				return options, false, err
+			}
+			options.maxDepth = parsed
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown repo-map flag %q", arg)}
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unexpected repo-map argument %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parsePositiveRepoMapInt(name string, value string) (int, error) {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed <= 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid %s: %s", name, value)}
+	}
+	return parsed, nil
+}
+
+func parseNonNegativeRepoMapInt(name string, value string) (int, error) {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed < 0 {
+		return 0, execUsageError{fmt.Sprintf("invalid %s: %s", name, value)}
+	}
+	return parsed, nil
+}
+
+func buildRepoMapReport(snapshot repomap.Snapshot, options repoMapOptions) repoMapReport {
+	files := limitedRepoMapFiles(snapshot.Files, options.maxFiles)
+	var matches []repomap.SearchResult
+	if options.query != "" {
+		matches = repomap.Search(snapshot, options.query, options.maxFiles)
+		files = files[:0]
+		for _, match := range matches {
+			if file, ok := repoMapFileByPath(snapshot.Files, match.Path); ok {
+				files = append(files, file)
+			}
+		}
+	}
+	return repoMapReport{
+		Root: snapshot.Root,
+		Summary: repoMapSummary{
+			FileCount:      snapshot.FileCount,
+			DirectoryCount: snapshot.DirectoryCount,
+			MaxDepth:       snapshot.MaxDepth,
+			Truncated:      snapshot.Truncated,
+		},
+		Languages:      snapshot.LanguageCounts,
+		Extensions:     snapshot.ExtensionCounts,
+		ImportantFiles: snapshot.ImportantFiles,
+		Files:          files,
+		Matches:        matches,
+	}
+}
+
+func limitedRepoMapFiles(files []repomap.File, limit int) []repomap.File {
+	if limit <= 0 || len(files) <= limit {
+		return append([]repomap.File{}, files...)
+	}
+	return append([]repomap.File{}, files[:limit]...)
+}
+
+func repoMapFileByPath(files []repomap.File, path string) (repomap.File, bool) {
+	for _, file := range files {
+		if file.Path == path {
+			return file, true
+		}
+	}
+	return repomap.File{}, false
+}
+
+func formatRepoMapSummary(report repoMapReport) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "Repo map")
+	fmt.Fprintf(&b, "Root: %s\n", report.Root)
+	fmt.Fprintf(&b, "Files: %d  Directories: %d  Max depth: %d\n", report.Summary.FileCount, report.Summary.DirectoryCount, report.Summary.MaxDepth)
+	if report.Summary.Truncated {
+		fmt.Fprintln(&b, "Truncated: true")
+	}
+	fmt.Fprintf(&b, "Languages: %s\n", formatRepoMapCounts(report.Languages))
+	fmt.Fprintf(&b, "Important files: %s\n", formatRepoMapStrings(report.ImportantFiles))
+	fmt.Fprintln(&b, "Files:")
+	for _, file := range report.Files {
+		fmt.Fprintf(&b, "  %s", file.Path)
+		if file.Language != "" {
+			fmt.Fprintf(&b, "  %s", file.Language)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func formatRepoMapMatches(query string, matches []repomap.SearchResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Repo map matches for %q\n", query)
+	fmt.Fprintln(&b, "Rank  Score  Reason          Path")
+	for index, match := range matches {
+		fmt.Fprintf(&b, "%-5d %-6d %-15s %s\n", index+1, match.Score, match.Reason, match.Path)
+	}
+	if len(matches) == 0 {
+		fmt.Fprintln(&b, "No matches.")
+	}
+	return b.String()
+}
+
+func formatRepoMapCounts(counts []repomap.Count) string {
+	if len(counts) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(counts))
+	for _, count := range counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", count.Name, count.Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatRepoMapStrings(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}
+
+func writeRepoMapHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero repo-map [flags]
+
+Builds a deterministic repository map for agent context and local inspection.
+
+Flags:
+      --json                Print JSON report
+      --query <text>        Print ranked file matches for a query
+      --max-files <number>  Limit files or query matches shown
+      --max-depth <number>  Limit scan depth
+  -h, --help                Show this help
+`)
+	return err
+}

--- a/internal/cli/repo_map.go
+++ b/internal/cli/repo_map.go
@@ -164,6 +164,10 @@ func buildRepoMapReport(snapshot repomap.Snapshot, options repoMapOptions) repoM
 	if options.query != "" {
 		matches = repomap.Search(snapshot, options.query, options.maxFiles)
 		files = files[:0]
+		// repomap.Search returns paths from snapshot.Files, so repoMapFileByPath
+		// should always find match.Path. If it does not, Search and the snapshot
+		// are inconsistent; skip the stale match instead of emitting a partial
+		// file record with fabricated metadata.
 		for _, match := range matches {
 			if file, ok := repoMapFileByPath(snapshot.Files, match.Path); ok {
 				files = append(files, file)

--- a/internal/cli/repo_map.go
+++ b/internal/cli/repo_map.go
@@ -13,10 +13,11 @@ import (
 const defaultRepoMapOutputFiles = 40
 
 type repoMapOptions struct {
-	json     bool
-	query    string
-	maxFiles int
-	maxDepth int
+	json         bool
+	query        string
+	outputFiles  int
+	scanMaxFiles int
+	maxDepth     int
 }
 
 type repoMapReport struct {
@@ -52,7 +53,10 @@ func runRepoMap(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
-	snapshot, err := repomap.Scan(workspaceRoot, repomap.Options{MaxDepth: options.maxDepth})
+	snapshot, err := repomap.Scan(workspaceRoot, repomap.Options{
+		MaxFiles: options.scanMaxFiles,
+		MaxDepth: options.maxDepth,
+	})
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
@@ -80,8 +84,9 @@ func runRepoMap(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 
 func parseRepoMapArgs(args []string) (repoMapOptions, bool, error) {
 	options := repoMapOptions{
-		maxFiles: defaultRepoMapOutputFiles,
-		maxDepth: repomap.DefaultMaxDepth,
+		outputFiles:  defaultRepoMapOutputFiles,
+		scanMaxFiles: repomap.DefaultMaxFiles,
+		maxDepth:     repomap.DefaultMaxDepth,
 	}
 	for index := 0; index < len(args); index++ {
 		arg := args[index]
@@ -108,14 +113,31 @@ func parseRepoMapArgs(args []string) (repoMapOptions, bool, error) {
 			if err != nil {
 				return options, false, err
 			}
-			options.maxFiles = parsed
+			options.outputFiles = parsed
 			index = next
 		case strings.HasPrefix(arg, "--max-files="):
 			parsed, err := parsePositiveRepoMapInt("--max-files", strings.TrimPrefix(arg, "--max-files="))
 			if err != nil {
 				return options, false, err
 			}
-			options.maxFiles = parsed
+			options.outputFiles = parsed
+		case arg == "--scan-max-files":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			parsed, err := parsePositiveRepoMapInt("--scan-max-files", value)
+			if err != nil {
+				return options, false, err
+			}
+			options.scanMaxFiles = parsed
+			index = next
+		case strings.HasPrefix(arg, "--scan-max-files="):
+			parsed, err := parsePositiveRepoMapInt("--scan-max-files", strings.TrimPrefix(arg, "--scan-max-files="))
+			if err != nil {
+				return options, false, err
+			}
+			options.scanMaxFiles = parsed
 		case arg == "--max-depth":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -159,10 +181,10 @@ func parseNonNegativeRepoMapInt(name string, value string) (int, error) {
 }
 
 func buildRepoMapReport(snapshot repomap.Snapshot, options repoMapOptions) repoMapReport {
-	files := limitedRepoMapFiles(snapshot.Files, options.maxFiles)
+	files := limitedRepoMapFiles(snapshot.Files, options.outputFiles)
 	var matches []repomap.SearchResult
 	if options.query != "" {
-		matches = repomap.Search(snapshot, options.query, options.maxFiles)
+		matches = repomap.Search(snapshot, options.query, options.outputFiles)
 		files = files[:0]
 		// repomap.Search returns paths from snapshot.Files, so repoMapFileByPath
 		// should always find match.Path. If it does not, Search and the snapshot
@@ -268,6 +290,7 @@ Flags:
       --json                Print JSON report
       --query <text>        Print ranked file matches for a query
       --max-files <number>  Limit files or query matches shown
+      --scan-max-files <n>  Limit files scanned before truncation
       --max-depth <number>  Limit scan depth
   -h, --help                Show this help
 `)

--- a/internal/cli/repo_map_test.go
+++ b/internal/cli/repo_map_test.go
@@ -1,0 +1,216 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRepoMapHelpDocumentsFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"repo-map", "--help"}, &stdout, &stderr, appDeps{})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	for _, want := range []string{"Usage:", "zero repo-map [flags]", "--json", "--query", "--max-files", "--max-depth"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected repo-map help to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunRepoMapTextSummaryUsesCurrentWorkingDirectory(t *testing.T) {
+	cwd := newRepoMapFixture(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"repo-map", "--max-files", "3", "--max-depth", "2"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	for _, want := range []string{"Repo map", "Root: " + cwd, "Files:", "Languages:", "cmd/zero/main.go"} {
+		if !repoMapOutputContains(stdout.String(), want) {
+			t.Fatalf("expected repo-map output to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if repoMapOutputContains(stdout.String(), "docs/deep/nested/notes.md") {
+		t.Fatalf("expected --max-depth 2 to omit deep file, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunRepoMapJSONSummary(t *testing.T) {
+	cwd := newRepoMapFixture(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"repo-map", "--json", "--max-files", "2", "--max-depth", "2"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var report struct {
+		Root    string `json:"root"`
+		Summary struct {
+			FileCount      int `json:"fileCount"`
+			DirectoryCount int `json:"directoryCount"`
+			MaxDepth       int `json:"maxDepth"`
+		} `json:"summary"`
+		Languages []struct {
+			Name      string `json:"name"`
+			FileCount int    `json:"fileCount"`
+		} `json:"languages"`
+		Files []struct {
+			Path     string `json:"path"`
+			Language string `json:"language"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("repo-map JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.Root != cwd {
+		t.Fatalf("Root = %q, want %q", report.Root, cwd)
+	}
+	if report.Summary.FileCount == 0 {
+		t.Fatalf("Summary.FileCount = 0, want scanned files")
+	}
+	if report.Summary.DirectoryCount == 0 {
+		t.Fatalf("Summary.DirectoryCount = 0, want scanned directories")
+	}
+	if report.Summary.MaxDepth > 2 {
+		t.Fatalf("Summary.MaxDepth = %d, want <= 2", report.Summary.MaxDepth)
+	}
+	if len(report.Files) == 0 || len(report.Files) > 2 {
+		t.Fatalf("Files length = %d, want 1..2", len(report.Files))
+	}
+	if len(report.Languages) == 0 {
+		t.Fatalf("Languages length = 0, want detected languages")
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunRepoMapQueryPrintsRankedMatches(t *testing.T) {
+	cwd := newRepoMapFixture(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"repo-map", "--query", "agent runtime", "--max-files", "1"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(strings.ToLower(out), "rank") {
+		t.Fatalf("expected ranked query output, got %q", out)
+	}
+	if !repoMapOutputContains(out, "internal/agent/runtime.go") {
+		t.Fatalf("expected query output to include best match, got %q", out)
+	}
+	if repoMapOutputContains(out, "cmd/zero/main.go") {
+		t.Fatalf("expected --max-files 1 to limit query output, got %q", out)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunRepoMapRejectsInvalidLimits(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "max files", args: []string{"repo-map", "--max-files", "0"}, want: "invalid --max-files"},
+		{name: "max depth", args: []string{"repo-map", "--max-depth", "-1"}, want: "invalid --max-depth"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			exitCode := runWithDeps(tt.args, &stdout, &stderr, appDeps{})
+
+			if exitCode != exitUsage {
+				t.Fatalf("expected exit code %d, got %d", exitUsage, exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected empty stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("expected stderr to contain %q, got %q", tt.want, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunHelpIncludesRepoMap(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"--help"}, &stdout, &stderr, appDeps{})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "repo-map") {
+		t.Fatalf("expected global help to include repo-map, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func newRepoMapFixture(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeRepoMapFixtureFile(t, dir, "go.mod", "module example.test/repo-map\n\ngo 1.24\n")
+	writeRepoMapFixtureFile(t, dir, "cmd/zero/main.go", "package main\n\nfunc main() {}\n")
+	writeRepoMapFixtureFile(t, dir, "internal/agent/runtime.go", "package agent\n\n// Agent runtime coordinates tools and model calls.\nfunc RunAgentRuntime() {}\n")
+	writeRepoMapFixtureFile(t, dir, "web/app.js", "export function renderApp() { return 'ui'; }\n")
+	writeRepoMapFixtureFile(t, dir, "docs/deep/nested/notes.md", "# Deep notes\n\nThis file is beyond max depth two.\n")
+	return dir
+}
+
+func writeRepoMapFixtureFile(t *testing.T, root string, name string, contents string) {
+	t.Helper()
+
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func repoMapOutputContains(output string, want string) bool {
+	normalizedOutput := filepath.ToSlash(output)
+	normalizedWant := filepath.ToSlash(want)
+	return strings.Contains(normalizedOutput, normalizedWant)
+}

--- a/internal/cli/repo_map_test.go
+++ b/internal/cli/repo_map_test.go
@@ -18,7 +18,7 @@ func TestRunRepoMapHelpDocumentsFlags(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
 	}
-	for _, want := range []string{"Usage:", "zero repo-map [flags]", "--json", "--query", "--max-files", "--max-depth"} {
+	for _, want := range []string{"Usage:", "zero repo-map [flags]", "--json", "--query", "--max-files", "--scan-max-files", "--max-depth"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("expected repo-map help to contain %q, got %q", want, stdout.String())
 		}
@@ -140,6 +140,46 @@ func TestRunRepoMapQueryPrintsRankedMatches(t *testing.T) {
 	}
 }
 
+func TestRunRepoMapScanMaxFilesBoundsSummary(t *testing.T) {
+	cwd := newRepoMapFixture(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"repo-map", "--json", "--scan-max-files", "1", "--max-files", "5"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	var report struct {
+		Summary struct {
+			FileCount int  `json:"fileCount"`
+			Truncated bool `json:"truncated"`
+		} `json:"summary"`
+		Files []struct {
+			Path string `json:"path"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("repo-map JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if report.Summary.FileCount != 1 {
+		t.Fatalf("Summary.FileCount = %d, want 1", report.Summary.FileCount)
+	}
+	if !report.Summary.Truncated {
+		t.Fatal("Summary.Truncated=false want true")
+	}
+	if len(report.Files) != 1 {
+		t.Fatalf("Files length = %d, want 1", len(report.Files))
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
 func TestRunRepoMapRejectsInvalidLimits(t *testing.T) {
 	for _, tt := range []struct {
 		name string
@@ -147,6 +187,7 @@ func TestRunRepoMapRejectsInvalidLimits(t *testing.T) {
 		want string
 	}{
 		{name: "max files", args: []string{"repo-map", "--max-files", "0"}, want: "invalid --max-files"},
+		{name: "scan max files", args: []string{"repo-map", "--scan-max-files", "0"}, want: "invalid --scan-max-files"},
 		{name: "max depth", args: []string{"repo-map", "--max-depth", "-1"}, want: "invalid --max-depth"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/repomap/prompt.go
+++ b/internal/repomap/prompt.go
@@ -1,0 +1,224 @@
+package repomap
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+const clippedMarker = "\n...[clipped]"
+
+// RenderPrompt renders a compact, deterministic repository map without
+// exceeding budget bytes. For very small budgets it returns an empty string.
+func RenderPrompt(snapshot Snapshot, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
+
+	files := normalizePromptFiles(snapshot.Root, snapshot.Files)
+	fileCount := snapshot.FileCount
+	if fileCount <= 0 {
+		fileCount = len(files)
+	}
+	dirCount := snapshot.DirectoryCount
+	if dirCount <= 0 {
+		dirCount = countPromptDirs(files)
+	}
+
+	languageCounts := snapshot.LanguageCounts
+	if len(languageCounts) == 0 {
+		languageCounts = countLanguages(files)
+	}
+	extensionCounts := snapshot.ExtensionCounts
+	if len(extensionCounts) == 0 {
+		extensionCounts = countExtensions(files)
+	}
+	importantFiles := normalizePromptPaths(snapshot.Root, snapshot.ImportantFiles)
+	if len(importantFiles) == 0 {
+		importantFiles = importantFilePaths(files)
+	}
+
+	var builder strings.Builder
+	writePromptLine(&builder, "Repo: %s", repoName(snapshot.Root))
+	writePromptLine(&builder, "Counts: files=%d dirs=%d", fileCount, dirCount)
+	if snapshot.Truncated {
+		writePromptLine(&builder, "Truncated: true")
+	}
+	writePromptLine(&builder, "Important files: %s", formatStringList(importantFiles))
+	writePromptLine(&builder, "Languages: %s", formatCounts(languageCounts))
+	writePromptLine(&builder, "Extensions: %s", formatCounts(extensionCounts))
+	builder.WriteByte('\n')
+	builder.WriteString("Files:")
+	for _, file := range files {
+		builder.WriteByte('\n')
+		builder.WriteString("  ")
+		builder.WriteString(file.Path)
+	}
+
+	return clampBudget(builder.String(), budget)
+}
+
+func normalizePromptFiles(root string, files []File) []File {
+	seen := map[string]struct{}{}
+	normalized := make([]File, 0, len(files))
+	for _, file := range files {
+		rel := relativePromptPath(root, file.Path)
+		if rel == "" {
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		ext := file.Extension
+		if ext == "" {
+			ext = strings.ToLower(path.Ext(rel))
+		}
+		lang := file.Language
+		if lang == "" {
+			lang = languageForExt(ext)
+		}
+		normalized = append(normalized, File{
+			Path:      rel,
+			Language:  lang,
+			Extension: ext,
+			Depth:     fileDepth(rel),
+		})
+	}
+	sortFiles(normalized)
+	return normalized
+}
+
+func normalizePromptPaths(root string, values []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]File, 0, len(values))
+	for _, value := range values {
+		rel := relativePromptPath(root, value)
+		if rel == "" {
+			continue
+		}
+		if _, ok := seen[rel]; ok {
+			continue
+		}
+		seen[rel] = struct{}{}
+		normalized = append(normalized, File{Path: rel})
+	}
+	sortFiles(normalized)
+	out := make([]string, 0, len(normalized))
+	for _, file := range normalized {
+		out = append(out, file.Path)
+	}
+	return out
+}
+
+func relativePromptPath(root string, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	cleanRoot := filepath.Clean(root)
+	cleanValue := filepath.Clean(value)
+	if root != "" && filepath.IsAbs(cleanValue) {
+		if rel, err := filepath.Rel(cleanRoot, cleanValue); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+	}
+	value = strings.ReplaceAll(value, "\\", "/")
+	cleanRootSlash := strings.TrimSuffix(strings.ReplaceAll(cleanRoot, "\\", "/"), "/")
+	if cleanRootSlash != "" && strings.HasPrefix(value, cleanRootSlash+"/") {
+		value = strings.TrimPrefix(value, cleanRootSlash+"/")
+	}
+	value = path.Clean(value)
+	value = strings.TrimPrefix(value, "/")
+	for strings.HasPrefix(value, "./") {
+		value = strings.TrimPrefix(value, "./")
+	}
+	if value == "." {
+		return ""
+	}
+	return value
+}
+
+func repoName(root string) string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "repo"
+	}
+	clean := filepath.Clean(root)
+	base := filepath.Base(clean)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return "repo"
+	}
+	return base
+}
+
+func countPromptDirs(files []File) int {
+	dirs := map[string]struct{}{}
+	for _, file := range files {
+		dir := path.Dir(file.Path)
+		for dir != "." && dir != "/" && dir != "" {
+			dirs[dir] = struct{}{}
+			dir = path.Dir(dir)
+		}
+	}
+	return len(dirs)
+}
+
+func formatStringList(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}
+
+func formatCounts(counts []Count) string {
+	if len(counts) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(counts))
+	for _, count := range counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", count.Name, count.Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func writePromptLine(builder *strings.Builder, format string, args ...any) {
+	if builder.Len() > 0 {
+		builder.WriteByte('\n')
+	}
+	builder.WriteString(fmt.Sprintf(format, args...))
+}
+
+func clampBudget(text string, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
+	if len(text) <= budget {
+		return text
+	}
+	if budget < len(clippedMarker) {
+		return ""
+	}
+	prefixBudget := budget - len(clippedMarker)
+	prefix := trimValidUTF8(text, prefixBudget)
+	prefix = strings.TrimRight(prefix, "\n")
+	if prefix == "" {
+		return strings.TrimSpace(clippedMarker)
+	}
+	return prefix + clippedMarker
+}
+
+func trimValidUTF8(text string, budget int) string {
+	if budget <= 0 {
+		return ""
+	}
+	if len(text) <= budget {
+		return text
+	}
+	for budget > 0 && !utf8.ValidString(text[:budget]) {
+		budget--
+	}
+	return text[:budget]
+}

--- a/internal/repomap/prompt_test.go
+++ b/internal/repomap/prompt_test.go
@@ -1,0 +1,114 @@
+package repomap
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderPromptIncludesRepoSummaryAndRelativePaths(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "Zero"))
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	repo := RepoMap{
+		Root: root,
+		Files: []File{
+			{Path: filepath.Join(root, "web", "app.ts")},
+			{Path: filepath.Join(root, "internal", "repomap", "prompt.go")},
+			{Path: filepath.Join(root, "README.md")},
+			{Path: filepath.Join(root, "go.mod")},
+			{Path: filepath.Join(root, "cmd", "zero", "main.go")},
+		},
+	}
+
+	got := RenderPrompt(repo, 2048)
+
+	for _, want := range []string{
+		"Repo: Zero",
+		"Counts: files=5 dirs=5",
+		"Important files: README.md, go.mod",
+		"Languages: Go=2, Markdown=1, TypeScript=1",
+		"Extensions: .go=2, .md=1, .mod=1, .ts=1",
+		"Files:",
+		"  cmd/zero/main.go",
+		"  internal/repomap/prompt.go",
+		"  web/app.ts",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderPrompt() missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, root) || strings.Contains(got, filepath.ToSlash(root)) {
+		t.Fatalf("RenderPrompt() leaked absolute root %q in:\n%s", root, got)
+	}
+}
+
+func TestRenderPromptIsDeterministicAndDeduplicatesPaths(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("testdata", "Zero"))
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	left := RepoMap{
+		Root: root,
+		Files: []File{
+			{Path: filepath.Join(root, "b", "two.go")},
+			{Path: filepath.Join(root, "a", "one.go")},
+			{Path: filepath.Join(root, "b", "two.go")},
+		},
+	}
+	right := RepoMap{
+		Root: root,
+		Files: []File{
+			{Path: filepath.Join(root, "a", "one.go")},
+			{Path: filepath.Join(root, "b", "two.go")},
+		},
+	}
+
+	gotLeft := RenderPrompt(left, 1024)
+	gotRight := RenderPrompt(right, 1024)
+
+	if gotLeft != gotRight {
+		t.Fatalf("RenderPrompt() should be deterministic after sorting/deduping:\nleft:\n%s\nright:\n%s", gotLeft, gotRight)
+	}
+	if strings.Index(gotLeft, "  a/one.go") > strings.Index(gotLeft, "  b/two.go") {
+		t.Fatalf("RenderPrompt() file list is not sorted:\n%s", gotLeft)
+	}
+	if strings.Count(gotLeft, "b/two.go") != 1 {
+		t.Fatalf("RenderPrompt() should dedupe repeated paths:\n%s", gotLeft)
+	}
+}
+
+func TestRenderPromptHonorsBudget(t *testing.T) {
+	repo := RepoMap{
+		Root: "Zero",
+		Files: []File{
+			{Path: "cmd/zero/main.go"},
+			{Path: "internal/agent/loop.go"},
+			{Path: "internal/agent/system_prompt.go"},
+			{Path: "internal/repomap/prompt.go"},
+			{Path: "internal/repomap/prompt_test.go"},
+			{Path: "README.md"},
+			{Path: "AGENTS.md"},
+		},
+	}
+
+	for _, budget := range []int{1, 8, 32, 80, 120, 200} {
+		got := RenderPrompt(repo, budget)
+		if len(got) > budget {
+			t.Fatalf("RenderPrompt() length=%d exceeds budget=%d:\n%s", len(got), budget, got)
+		}
+	}
+
+	got := RenderPrompt(repo, 80)
+	if got != "" && !strings.Contains(got, "[clipped]") {
+		t.Fatalf("RenderPrompt() should mark clipped output when possible, got:\n%s", got)
+	}
+}
+
+func TestRenderPromptReturnsEmptyForNonPositiveBudget(t *testing.T) {
+	got := RenderPrompt(RepoMap{Root: "Zero", Files: []File{{Path: "main.go"}}}, 0)
+	if got != "" {
+		t.Fatalf("RenderPrompt() with zero budget=%q want empty", got)
+	}
+}

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -1,0 +1,435 @@
+// Package repomap scans a workspace into a compact, deterministic repository map.
+package repomap
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	DefaultMaxFiles = 2000
+	DefaultMaxDepth = 6
+)
+
+var errStopWalk = errors.New("repo map scan stopped")
+
+type Options struct {
+	MaxFiles            int
+	MaxDepth            int
+	MaxBytesPerFileName int
+}
+
+type Snapshot struct {
+	Root            string   `json:"root"`
+	Files           []File   `json:"files"`
+	FileCount       int      `json:"fileCount"`
+	DirectoryCount  int      `json:"directoryCount"`
+	MaxDepth        int      `json:"maxDepth"`
+	LanguageCounts  []Count  `json:"languages"`
+	ExtensionCounts []Count  `json:"extensions"`
+	ImportantFiles  []string `json:"importantFiles"`
+	Tree            []string `json:"tree"`
+	Truncated       bool     `json:"truncated,omitempty"`
+}
+
+// RepoMap is kept as a semantic alias for call sites/tests that use the product
+// term instead of the storage term.
+type RepoMap = Snapshot
+
+type File struct {
+	Path      string `json:"path"`
+	Language  string `json:"language,omitempty"`
+	Extension string `json:"extension,omitempty"`
+	Depth     int    `json:"depth,omitempty"`
+}
+
+type Count struct {
+	Name  string `json:"name"`
+	Count int    `json:"fileCount"`
+}
+
+func Scan(root string, options Options) (Snapshot, error) {
+	cleanRoot, err := filepath.Abs(strings.TrimSpace(root))
+	if err != nil {
+		return Snapshot{}, err
+	}
+	cleanRoot = filepath.Clean(cleanRoot)
+
+	maxFiles := options.MaxFiles
+	if maxFiles <= 0 {
+		maxFiles = DefaultMaxFiles
+	}
+	maxDepth := options.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = DefaultMaxDepth
+	}
+
+	var files []File
+	dirs := map[string]struct{}{}
+	truncated := false
+	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if current == cleanRoot {
+			return nil
+		}
+
+		rel, err := filepath.Rel(cleanRoot, current)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		if entry.IsDir() {
+			if shouldSkipDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			if isSymlink(entry) {
+				return filepath.SkipDir
+			}
+			if pathDepth(rel) > maxDepth {
+				truncated = true
+				return filepath.SkipDir
+			}
+			dirs[rel] = struct{}{}
+			return nil
+		}
+
+		if isSymlink(entry) {
+			return nil
+		}
+		if shouldSkipFile(rel) {
+			return nil
+		}
+		depth := fileDepth(rel)
+		if depth > maxDepth {
+			truncated = true
+			return nil
+		}
+		if options.MaxBytesPerFileName > 0 && len(rel) > options.MaxBytesPerFileName {
+			truncated = true
+			return nil
+		}
+		if len(files) >= maxFiles {
+			truncated = true
+			return errStopWalk
+		}
+
+		ext := strings.ToLower(path.Ext(rel))
+		files = append(files, File{
+			Path:      rel,
+			Language:  languageForExt(ext),
+			Extension: ext,
+			Depth:     depth,
+		})
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
+		return Snapshot{}, walkErr
+	}
+
+	sortFiles(files)
+	snapshot := Snapshot{
+		Root:           cleanRoot,
+		Files:          files,
+		FileCount:      len(files),
+		DirectoryCount: len(dirs),
+		MaxDepth:       maxFileDepth(files),
+		Truncated:      truncated,
+	}
+	snapshot.LanguageCounts = countLanguages(files)
+	snapshot.ExtensionCounts = countExtensions(files)
+	snapshot.ImportantFiles = importantFilePaths(files)
+	snapshot.Tree = buildTree(files)
+	return snapshot, nil
+}
+
+func shouldSkipDir(name string) bool {
+	switch name {
+	case ".cache", ".git", ".next", ".worktrees", ".zero", "build", "coverage", "dist", "node_modules", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldSkipFile(rel string) bool {
+	base := strings.ToLower(path.Base(rel))
+	switch base {
+	case ".git", ".ds_store":
+		return true
+	}
+	switch strings.ToLower(path.Ext(base)) {
+	case ".a", ".class", ".dll", ".dylib", ".exe", ".gz", ".jar", ".o", ".so", ".tar", ".tgz", ".zip":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSymlink(entry fs.DirEntry) bool {
+	return entry.Type()&fs.ModeSymlink != 0
+}
+
+func pathDepth(rel string) int {
+	if rel == "" || rel == "." {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(rel), "/") + 1
+}
+
+func fileDepth(rel string) int {
+	if rel == "" || !strings.Contains(rel, "/") {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(rel), "/")
+}
+
+func languageForExt(ext string) string {
+	switch strings.TrimPrefix(strings.ToLower(ext), ".") {
+	case "bash", "sh", "zsh":
+		return "Shell"
+	case "c":
+		return "C"
+	case "cc", "cpp", "cxx", "hh", "hpp":
+		return "C++"
+	case "cs":
+		return "C#"
+	case "css":
+		return "CSS"
+	case "dart":
+		return "Dart"
+	case "ex", "exs":
+		return "Elixir"
+	case "go":
+		return "Go"
+	case "html", "htm":
+		return "HTML"
+	case "java":
+		return "Java"
+	case "js", "jsx", "mjs", "cjs":
+		return "JavaScript"
+	case "json":
+		return "JSON"
+	case "kt", "kts":
+		return "Kotlin"
+	case "lua":
+		return "Lua"
+	case "md", "markdown":
+		return "Markdown"
+	case "php":
+		return "PHP"
+	case "proto":
+		return "Protobuf"
+	case "py":
+		return "Python"
+	case "rb":
+		return "Ruby"
+	case "rs":
+		return "Rust"
+	case "sass", "scss":
+		return "SCSS"
+	case "sql":
+		return "SQL"
+	case "svelte":
+		return "Svelte"
+	case "swift":
+		return "Swift"
+	case "tf":
+		return "Terraform"
+	case "ts", "tsx":
+		return "TypeScript"
+	case "vue":
+		return "Vue"
+	default:
+		return ""
+	}
+}
+
+func maxFileDepth(files []File) int {
+	maxDepth := 0
+	for _, file := range files {
+		if file.Depth > maxDepth {
+			maxDepth = file.Depth
+		}
+	}
+	return maxDepth
+}
+
+func countLanguages(files []File) []Count {
+	counts := map[string]int{}
+	for _, file := range files {
+		if file.Language != "" {
+			counts[file.Language]++
+		}
+	}
+	return sortedCounts(counts)
+}
+
+func countExtensions(files []File) []Count {
+	counts := map[string]int{}
+	for _, file := range files {
+		if file.Extension != "" {
+			counts[file.Extension]++
+		}
+	}
+	return sortedCounts(counts)
+}
+
+func sortedCounts(counts map[string]int) []Count {
+	result := make([]Count, 0, len(counts))
+	for name, count := range counts {
+		if name == "" || count <= 0 {
+			continue
+		}
+		result = append(result, Count{Name: name, Count: count})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
+		}
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func importantFilePaths(files []File) []string {
+	type important struct {
+		path     string
+		priority int
+	}
+	values := []important{}
+	for _, file := range files {
+		if priority, ok := importantPriority(file.Path); ok {
+			values = append(values, important{path: file.Path, priority: priority})
+		}
+	}
+	sort.Slice(values, func(i, j int) bool {
+		if values[i].priority != values[j].priority {
+			return values[i].priority < values[j].priority
+		}
+		return values[i].path < values[j].path
+	})
+	paths := make([]string, 0, len(values))
+	for _, value := range values {
+		paths = append(paths, value.path)
+	}
+	return paths
+}
+
+func importantPriority(file string) (int, bool) {
+	base := strings.ToLower(path.Base(file))
+	switch base {
+	case "agents.md":
+		return 10, true
+	case "zero.md":
+		return 20, true
+	case "readme.md":
+		return 30, true
+	case "contributing.md":
+		return 40, true
+	case "go.mod":
+		return 50, true
+	case "go.sum":
+		return 55, true
+	case "package.json":
+		return 60, true
+	case "cargo.toml":
+		return 70, true
+	case "pyproject.toml":
+		return 80, true
+	case "requirements.txt":
+		return 90, true
+	case "makefile":
+		return 100, true
+	case "dockerfile", "docker-compose.yml", "docker-compose.yaml":
+		return 110, true
+	default:
+		return 0, false
+	}
+}
+
+func buildTree(files []File) []string {
+	root := newTreeNode()
+	for _, file := range files {
+		insertFile(root, file.Path)
+	}
+	lines := []string{"."}
+	appendTreeLines(&lines, root, 0)
+	return lines
+}
+
+type treeNode struct {
+	dirs  map[string]*treeNode
+	files map[string]struct{}
+}
+
+func newTreeNode() *treeNode {
+	return &treeNode{dirs: map[string]*treeNode{}, files: map[string]struct{}{}}
+}
+
+func insertFile(root *treeNode, rel string) {
+	parts := strings.Split(rel, "/")
+	if len(parts) == 0 {
+		return
+	}
+	node := root
+	for _, part := range parts[:len(parts)-1] {
+		if part == "" {
+			continue
+		}
+		if node.dirs[part] == nil {
+			node.dirs[part] = newTreeNode()
+		}
+		node = node.dirs[part]
+	}
+	name := parts[len(parts)-1]
+	if name != "" {
+		node.files[name] = struct{}{}
+	}
+}
+
+func appendTreeLines(lines *[]string, node *treeNode, depth int) {
+	for _, entry := range sortedTreeEntries(node) {
+		prefix := strings.Repeat("  ", depth)
+		if entry.dir {
+			*lines = append(*lines, prefix+entry.name+"/")
+			appendTreeLines(lines, node.dirs[entry.name], depth+1)
+			continue
+		}
+		*lines = append(*lines, prefix+entry.name)
+	}
+}
+
+type treeEntry struct {
+	name string
+	dir  bool
+}
+
+func sortedTreeEntries(node *treeNode) []treeEntry {
+	entries := make([]treeEntry, 0, len(node.dirs)+len(node.files))
+	for name := range node.dirs {
+		entries = append(entries, treeEntry{name: name, dir: true})
+	}
+	for name := range node.files {
+		entries = append(entries, treeEntry{name: name})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].name != entries[j].name {
+			return entries[i].name < entries[j].name
+		}
+		return entries[i].dir && !entries[j].dir
+	})
+	return entries
+}
+
+func sortFiles(files []File) {
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+}

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -74,9 +74,8 @@ func Scan(root string, options Options) (Snapshot, error) {
 	dirs := map[string]struct{}{}
 	truncated := false
 	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			truncated = true
-			return walkErr
+		if handled, err := handleWalkError(cleanRoot, current, entry, walkErr, &truncated); handled {
+			return err
 		}
 		if current == cleanRoot {
 			return nil
@@ -150,6 +149,20 @@ func Scan(root string, options Options) (Snapshot, error) {
 		return snapshot, walkErr
 	}
 	return snapshot, nil
+}
+
+func handleWalkError(cleanRoot string, current string, entry fs.DirEntry, walkErr error, truncated *bool) (bool, error) {
+	if walkErr == nil {
+		return false, nil
+	}
+	*truncated = true
+	if current == cleanRoot {
+		return true, walkErr
+	}
+	if entry != nil && entry.IsDir() {
+		return true, filepath.SkipDir
+	}
+	return true, nil
 }
 
 func shouldSkipDir(name string) bool {

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -18,7 +18,9 @@ const (
 var errStopWalk = errors.New("repo map scan stopped")
 
 type Options struct {
-	MaxFiles            int
+	MaxFiles int
+	// MaxDepth is measured as path separators below the root. Zero means root
+	// files only; negative values use DefaultMaxDepth.
 	MaxDepth            int
 	MaxBytesPerFileName int
 }
@@ -64,24 +66,26 @@ func Scan(root string, options Options) (Snapshot, error) {
 		maxFiles = DefaultMaxFiles
 	}
 	maxDepth := options.MaxDepth
-	if maxDepth <= 0 {
+	if maxDepth < 0 {
 		maxDepth = DefaultMaxDepth
 	}
 
 	var files []File
 	dirs := map[string]struct{}{}
 	truncated := false
-	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
+	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			truncated = true
+			return walkErr
 		}
 		if current == cleanRoot {
 			return nil
 		}
 
-		rel, err := filepath.Rel(cleanRoot, current)
-		if err != nil {
-			return nil
+		rel, relErr := filepath.Rel(cleanRoot, current)
+		if relErr != nil {
+			truncated = true
+			return relErr
 		}
 		rel = filepath.ToSlash(rel)
 
@@ -129,10 +133,6 @@ func Scan(root string, options Options) (Snapshot, error) {
 		})
 		return nil
 	})
-	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
-		return Snapshot{}, walkErr
-	}
-
 	sortFiles(files)
 	snapshot := Snapshot{
 		Root:           cleanRoot,
@@ -146,6 +146,9 @@ func Scan(root string, options Options) (Snapshot, error) {
 	snapshot.ExtensionCounts = countExtensions(files)
 	snapshot.ImportantFiles = importantFilePaths(files)
 	snapshot.Tree = buildTree(files)
+	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
+		return snapshot, walkErr
+	}
 	return snapshot, nil
 }
 

--- a/internal/repomap/repomap_test.go
+++ b/internal/repomap/repomap_test.go
@@ -1,6 +1,7 @@
 package repomap
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -139,6 +140,34 @@ func TestScanReturnsFilesystemErrorsWithTruncatedSnapshot(t *testing.T) {
 	}
 }
 
+func TestHandleWalkErrorKeepsScanningAfterUnreadableSubdir(t *testing.T) {
+	truncated := false
+	handled, err := handleWalkError("root", "root/blocked", fakeDirEntry{dir: true}, os.ErrPermission, &truncated)
+	if !handled {
+		t.Fatal("handled=false want true")
+	}
+	if err != filepath.SkipDir {
+		t.Fatalf("err=%v want filepath.SkipDir", err)
+	}
+	if !truncated {
+		t.Fatal("truncated=false want true")
+	}
+}
+
+func TestHandleWalkErrorReturnsRootErrors(t *testing.T) {
+	truncated := false
+	handled, err := handleWalkError("root", "root", nil, os.ErrNotExist, &truncated)
+	if !handled {
+		t.Fatal("handled=false want true")
+	}
+	if err == nil {
+		t.Fatal("err=nil want root error")
+	}
+	if !truncated {
+		t.Fatal("truncated=false want true")
+	}
+}
+
 func TestScanHonorsTraversalCaps(t *testing.T) {
 	t.Run("max files keeps the first deterministic files", func(t *testing.T) {
 		root := t.TempDir()
@@ -251,4 +280,27 @@ func contains(values []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+type fakeDirEntry struct {
+	dir bool
+}
+
+func (entry fakeDirEntry) Name() string {
+	return "fake"
+}
+
+func (entry fakeDirEntry) IsDir() bool {
+	return entry.dir
+}
+
+func (entry fakeDirEntry) Type() fs.FileMode {
+	if entry.dir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (entry fakeDirEntry) Info() (fs.FileInfo, error) {
+	return nil, os.ErrInvalid
 }

--- a/internal/repomap/repomap_test.go
+++ b/internal/repomap/repomap_test.go
@@ -1,0 +1,221 @@
+package repomap
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestScanBuildsDeterministicSnapshot(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "go.mod", "module example.test/repo\n")
+	writeFile(t, root, "README.md", "# Example\n")
+	writeFile(t, root, "package.json", `{"name":"example"}`)
+	writeFile(t, root, "cmd/zero/main.go", "package main\n")
+	writeFile(t, root, "internal/app/app.go", "package app\n")
+	writeFile(t, root, "web/app.ts", "export const app = true\n")
+	writeFile(t, root, "zero.exe", "ignored binary")
+	writeFile(t, root, ".git/config", "[core]\n")
+	writeFile(t, root, ".zero/state.json", "{}")
+	writeFile(t, root, "node_modules/pkg/index.js", "ignored")
+	writeFile(t, root, "vendor/lib/lib.go", "ignored")
+	writeFile(t, root, "dist/bundle.js", "ignored")
+	writeFile(t, root, "coverage/out.txt", "ignored")
+	writeFile(t, root, ".next/cache.js", "ignored")
+	writeFile(t, root, ".cache/blob", "ignored")
+
+	got, err := Scan(root, Options{})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if got.Root != filepath.Clean(root) {
+		t.Fatalf("Root=%q want %q", got.Root, filepath.Clean(root))
+	}
+	wantFiles := []string{
+		"README.md",
+		"cmd/zero/main.go",
+		"go.mod",
+		"internal/app/app.go",
+		"package.json",
+		"web/app.ts",
+	}
+	if !reflect.DeepEqual(pathsOf(got.Files), wantFiles) {
+		t.Fatalf("Files=%v want %v", pathsOf(got.Files), wantFiles)
+	}
+	if got.FileCount != len(wantFiles) {
+		t.Fatalf("FileCount=%d want %d", got.FileCount, len(wantFiles))
+	}
+	if got.DirectoryCount != 5 {
+		t.Fatalf("DirectoryCount=%d want 5", got.DirectoryCount)
+	}
+	assertCounts(t, "LanguageCounts", got.LanguageCounts, []Count{
+		{Name: "Go", Count: 2},
+		{Name: "JSON", Count: 1},
+		{Name: "Markdown", Count: 1},
+		{Name: "TypeScript", Count: 1},
+	})
+	assertCounts(t, "ExtensionCounts", got.ExtensionCounts, []Count{
+		{Name: ".go", Count: 2},
+		{Name: ".json", Count: 1},
+		{Name: ".md", Count: 1},
+		{Name: ".mod", Count: 1},
+		{Name: ".ts", Count: 1},
+	})
+	wantImportant := []string{"README.md", "go.mod", "package.json"}
+	if !reflect.DeepEqual(got.ImportantFiles, wantImportant) {
+		t.Fatalf("ImportantFiles=%v want %v", got.ImportantFiles, wantImportant)
+	}
+	wantTree := []string{
+		".",
+		"README.md",
+		"cmd/",
+		"  zero/",
+		"    main.go",
+		"go.mod",
+		"internal/",
+		"  app/",
+		"    app.go",
+		"package.json",
+		"web/",
+		"  app.ts",
+	}
+	if !reflect.DeepEqual(got.Tree, wantTree) {
+		t.Fatalf("Tree=%v want %v", got.Tree, wantTree)
+	}
+}
+
+func TestScanDoesNotFollowSymlinkedDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "main.go", "package main\n")
+	target := filepath.Join(root, "target")
+	writeFile(t, target, "hidden.go", "package hidden\n")
+	link := filepath.Join(root, "linked")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	got, err := Scan(root, Options{})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	want := []string{"main.go", "target/hidden.go"}
+	if !reflect.DeepEqual(pathsOf(got.Files), want) {
+		t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+	}
+	if contains(pathsOf(got.Files), "linked/hidden.go") || contains(pathsOf(got.Files), "linked") {
+		t.Fatalf("symlinked directory was included: %v", got.Files)
+	}
+}
+
+func TestScanSkipsGitMetadataFile(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, ".git", "gitdir: ../.git/worktrees/zero\n")
+	writeFile(t, root, "main.go", "package main\n")
+
+	got, err := Scan(root, Options{})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	want := []string{"main.go"}
+	if !reflect.DeepEqual(pathsOf(got.Files), want) {
+		t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+	}
+}
+
+func TestScanHonorsTraversalCaps(t *testing.T) {
+	t.Run("max files keeps the first deterministic files", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "a.go", "package a\n")
+		writeFile(t, root, "b.go", "package b\n")
+		writeFile(t, root, "c.go", "package c\n")
+
+		got, err := Scan(root, Options{MaxFiles: 2})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		want := []string{"a.go", "b.go"}
+		if !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+
+	t.Run("max depth stops descent below the cap", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "top.go", "package top\n")
+		writeFile(t, root, "pkg/one.go", "package pkg\n")
+		writeFile(t, root, "pkg/deep/two.go", "package deep\n")
+
+		got, err := Scan(root, Options{MaxDepth: 1})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		want := []string{"pkg/one.go", "top.go"}
+		if !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+		}
+		if got.DirectoryCount != 1 {
+			t.Fatalf("DirectoryCount=%d want 1", got.DirectoryCount)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+
+	t.Run("max bytes per file name skips overlong entries", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "short.go", "package short\n")
+		writeFile(t, root, "longname.go", "package longname\n")
+
+		got, err := Scan(root, Options{MaxBytesPerFileName: len("short.go")})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		want := []string{"short.go"}
+		if !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+}
+
+func writeFile(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func assertCounts(t *testing.T, name string, got, want []Count) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s=%v want %v", name, got, want)
+	}
+}
+
+func pathsOf(files []File) []string {
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		paths = append(paths, file.Path)
+	}
+	return paths
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/repomap/repomap_test.go
+++ b/internal/repomap/repomap_test.go
@@ -25,7 +25,7 @@ func TestScanBuildsDeterministicSnapshot(t *testing.T) {
 	writeFile(t, root, ".next/cache.js", "ignored")
 	writeFile(t, root, ".cache/blob", "ignored")
 
-	got, err := Scan(root, Options{})
+	got, err := Scan(root, Options{MaxDepth: DefaultMaxDepth})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestScanDoesNotFollowSymlinkedDirectories(t *testing.T) {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 
-	got, err := Scan(root, Options{})
+	got, err := Scan(root, Options{MaxDepth: DefaultMaxDepth})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
@@ -114,13 +114,28 @@ func TestScanSkipsGitMetadataFile(t *testing.T) {
 	writeFile(t, root, ".git", "gitdir: ../.git/worktrees/zero\n")
 	writeFile(t, root, "main.go", "package main\n")
 
-	got, err := Scan(root, Options{})
+	got, err := Scan(root, Options{MaxDepth: DefaultMaxDepth})
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
 	want := []string{"main.go"}
 	if !reflect.DeepEqual(pathsOf(got.Files), want) {
 		t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+	}
+}
+
+func TestScanReturnsFilesystemErrorsWithTruncatedSnapshot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+
+	got, err := Scan(root, Options{MaxDepth: DefaultMaxDepth})
+	if err == nil {
+		t.Fatal("Scan missing root error=nil, want error")
+	}
+	if got.Root != filepath.Clean(root) {
+		t.Fatalf("Root=%q want %q", got.Root, filepath.Clean(root))
+	}
+	if !got.Truncated {
+		t.Fatal("Truncated=false want true")
 	}
 }
 
@@ -160,6 +175,24 @@ func TestScanHonorsTraversalCaps(t *testing.T) {
 		}
 		if got.DirectoryCount != 1 {
 			t.Fatalf("DirectoryCount=%d want 1", got.DirectoryCount)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+
+	t.Run("zero max depth includes root files only", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "top.go", "package top\n")
+		writeFile(t, root, "pkg/one.go", "package pkg\n")
+
+		got, err := Scan(root, Options{MaxDepth: 0})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		want := []string{"top.go"}
+		if !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
 		}
 		if !got.Truncated {
 			t.Fatal("Truncated=false want true")

--- a/internal/repomap/search.go
+++ b/internal/repomap/search.go
@@ -4,6 +4,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -182,7 +183,7 @@ func fuzzyMatch(filePath string, query string) bool {
 		if index < 0 {
 			return false
 		}
-		position += index + len(string(char))
+		position += index + utf8.RuneLen(char)
 	}
 	return true
 }

--- a/internal/repomap/search.go
+++ b/internal/repomap/search.go
@@ -1,0 +1,188 @@
+package repomap
+
+import (
+	"path"
+	"sort"
+	"strings"
+)
+
+const (
+	MatchReasonExactBasename  = "exact-basename"
+	MatchReasonPrefixBasename = "prefix-basename"
+	MatchReasonPathSegment    = "path-segment"
+	MatchReasonSubstring      = "substring"
+	MatchReasonFuzzy          = "fuzzy"
+	MatchReasonMultiTerm      = "multi-term"
+)
+
+const (
+	scoreExactBasename  = 1000
+	scorePrefixBasename = 800
+	scorePathSegment    = 600
+	scoreSubstring      = 400
+	scoreFuzzy          = 200
+	scoreAllTermsBonus  = 300
+)
+
+type SearchResult struct {
+	Path   string
+	Score  int
+	Reason string
+}
+
+func Search(snapshot Snapshot, query string, limit int) []SearchResult {
+	normalizedQuery := normalizeSearchQuery(query)
+	if normalizedQuery == "" || limit <= 0 {
+		return []SearchResult{}
+	}
+	terms := searchTerms(normalizedQuery)
+	if len(terms) == 0 {
+		return []SearchResult{}
+	}
+
+	results := []SearchResult{}
+	for _, file := range snapshot.Files {
+		displayPath := strings.TrimSpace(file.Path)
+		normalizedPath := normalizeSearchPath(displayPath)
+		if normalizedPath == "" {
+			continue
+		}
+		score, reason, ok := scoreSearchPath(normalizedPath, normalizedQuery, terms)
+		if !ok {
+			continue
+		}
+		results = append(results, SearchResult{
+			Path:   displayPath,
+			Score:  score,
+			Reason: reason,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].Path < results[j].Path
+	})
+	if len(results) > limit {
+		return results[:limit]
+	}
+	return results
+}
+
+func normalizeSearchQuery(query string) string {
+	normalized := strings.TrimSpace(query)
+	normalized = strings.TrimPrefix(normalized, "@")
+	normalized = strings.TrimSpace(normalized)
+	normalized = strings.ReplaceAll(normalized, "\\", "/")
+	normalized = strings.Trim(normalized, "/")
+	return strings.ToLower(normalized)
+}
+
+func searchTerms(query string) []string {
+	fields := strings.FieldsFunc(query, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+	terms := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.Trim(field, "/")
+		if field != "" {
+			terms = append(terms, field)
+		}
+	}
+	return terms
+}
+
+func normalizeSearchPath(filePath string) string {
+	normalized := strings.TrimSpace(filePath)
+	normalized = strings.ReplaceAll(normalized, "\\", "/")
+	for strings.HasPrefix(normalized, "./") {
+		normalized = strings.TrimPrefix(normalized, "./")
+	}
+	return strings.ToLower(normalized)
+}
+
+func scoreSearchPath(filePath string, query string, terms []string) (int, string, bool) {
+	if len(terms) == 1 {
+		return scorePath(filePath, query)
+	}
+	score := 0
+	matched := 0
+	bestReason := ""
+	for _, term := range terms {
+		_, reason, ok := scorePath(filePath, term)
+		if ok {
+			termScore := scoreForMultiTermReason(reason)
+			score += termScore
+			matched++
+			if bestReason == "" || termScore > scoreForMultiTermReason(bestReason) {
+				bestReason = reason
+			}
+		}
+	}
+	if matched == 0 {
+		return 0, "", false
+	}
+	if matched == len(terms) {
+		score += scoreAllTermsBonus
+		score += scoreSubstring
+		return score, MatchReasonMultiTerm, true
+	}
+	return score, bestReason, true
+}
+
+func scorePath(filePath string, query string) (int, string, bool) {
+	basename := path.Base(filePath)
+	switch {
+	case basename == query:
+		return scoreExactBasename, MatchReasonExactBasename, true
+	case strings.HasPrefix(basename, query):
+		return scorePrefixBasename, MatchReasonPrefixBasename, true
+	case hasPathSegment(filePath, query):
+		return scorePathSegment, MatchReasonPathSegment, true
+	case strings.Contains(filePath, query):
+		return scoreSubstring, MatchReasonSubstring, true
+	case fuzzyMatch(filePath, query):
+		return scoreFuzzy, MatchReasonFuzzy, true
+	default:
+		return 0, "", false
+	}
+}
+
+func scoreForMultiTermReason(reason string) int {
+	switch reason {
+	case MatchReasonExactBasename:
+		return 700
+	case MatchReasonPathSegment:
+		return 650
+	case MatchReasonPrefixBasename:
+		return 500
+	case MatchReasonSubstring:
+		return 350
+	case MatchReasonFuzzy:
+		return 100
+	default:
+		return 0
+	}
+}
+
+func hasPathSegment(filePath string, query string) bool {
+	for _, segment := range strings.Split(filePath, "/") {
+		if segment == query {
+			return true
+		}
+	}
+	return false
+}
+
+func fuzzyMatch(filePath string, query string) bool {
+	position := 0
+	for _, char := range query {
+		index := strings.IndexRune(filePath[position:], char)
+		if index < 0 {
+			return false
+		}
+		position += index + len(string(char))
+	}
+	return true
+}

--- a/internal/repomap/search_test.go
+++ b/internal/repomap/search_test.go
@@ -1,0 +1,101 @@
+package repomap
+
+import "testing"
+
+func TestSearchRanksPathMatchesByReason(t *testing.T) {
+	snapshot := Snapshot{Files: []File{
+		{Path: "docs/app-config-guide.md"},
+		{Path: "c/o/n/f/i/g.txt"},
+		{Path: "cmd/config/main.go"},
+		{Path: "internal/config.go"},
+	}}
+
+	results := Search(snapshot, "@config", 10)
+
+	want := []struct {
+		path   string
+		reason string
+	}{
+		{"internal/config.go", MatchReasonPrefixBasename},
+		{"cmd/config/main.go", MatchReasonPathSegment},
+		{"docs/app-config-guide.md", MatchReasonSubstring},
+		{"c/o/n/f/i/g.txt", MatchReasonFuzzy},
+	}
+	if len(results) != len(want) {
+		t.Fatalf("Search returned %d results, want %d: %#v", len(results), len(want), results)
+	}
+	for i, expected := range want {
+		if results[i].Path != expected.path || results[i].Reason != expected.reason {
+			t.Fatalf("result %d = %#v, want path %q reason %q", i, results[i], expected.path, expected.reason)
+		}
+	}
+	for i := 1; i < len(results); i++ {
+		if results[i-1].Score <= results[i].Score {
+			t.Fatalf("scores should descend by match quality, got %#v", results)
+		}
+	}
+}
+
+func TestSearchOrdersTiedScoresByPath(t *testing.T) {
+	snapshot := Snapshot{Files: []File{
+		{Path: "internal/search/search.go"},
+		{Path: "internal/repomap/search.go"},
+	}}
+
+	results := Search(snapshot, "search.go", 10)
+
+	if len(results) != 2 {
+		t.Fatalf("Search returned %d results, want 2: %#v", len(results), results)
+	}
+	if results[0].Path != "internal/repomap/search.go" || results[1].Path != "internal/search/search.go" {
+		t.Fatalf("expected tied exact basename matches to sort by path, got %#v", results)
+	}
+	if results[0].Score != results[1].Score {
+		t.Fatalf("expected exact basename matches to tie on score, got %#v", results)
+	}
+	for _, result := range results {
+		if result.Reason != MatchReasonExactBasename {
+			t.Fatalf("expected exact basename reason, got %#v", results)
+		}
+	}
+}
+
+func TestSearchRanksCompleteMultiTermMatchesAheadOfPartialMatches(t *testing.T) {
+	snapshot := Snapshot{Files: []File{
+		{Path: "internal/zeroruntime/runtime.go"},
+		{Path: "internal/agent/runtime.go"},
+		{Path: "internal/agent/loop.go"},
+	}}
+
+	results := Search(snapshot, "agent runtime", 10)
+
+	if len(results) != 3 {
+		t.Fatalf("Search returned %d results, want 3: %#v", len(results), results)
+	}
+	if results[0].Path != "internal/agent/runtime.go" || results[0].Reason != MatchReasonMultiTerm {
+		t.Fatalf("expected complete multi-term match first, got %#v", results)
+	}
+	if results[1].Score <= results[2].Score {
+		t.Fatalf("expected stronger partial match before weaker partial match, got %#v", results)
+	}
+}
+
+func TestSearchAppliesLimitAndIgnoresBlankQueries(t *testing.T) {
+	snapshot := Snapshot{Files: []File{
+		{Path: "cmd/zero/main.go"},
+		{Path: "internal/agent/loop.go"},
+		{Path: "internal/cli/serve.go"},
+	}}
+
+	results := Search(snapshot, "go", 2)
+	if len(results) != 2 {
+		t.Fatalf("Search returned %d results, want 2: %#v", len(results), results)
+	}
+
+	if results := Search(snapshot, "   @   ", 10); len(results) != 0 {
+		t.Fatalf("blank query returned results: %#v", results)
+	}
+	if results := Search(snapshot, "go", 0); len(results) != 0 {
+		t.Fatalf("zero limit returned results: %#v", results)
+	}
+}


### PR DESCRIPTION
## Summary

Adds Go-native repository intelligence for Zero so the agent starts each run with a compact source map instead of only cwd/project docs.

- adds `internal/repomap` for deterministic workspace scanning, language/extension counts, important files, source-focused artifact skips, compact prompt rendering, and ranked path search
- adds `zero repo-map` with text, JSON, and `--query` modes for local inspection
- injects a capped `## Repo map` section into the agent system prompt through the existing `Options.Cwd` path

## Why

This is the next high-leverage agent-quality slice: before editing, Zero needs lightweight awareness of repo layout, important files, and likely file targets without adding embeddings, MCP, plugins, or external dependencies.

## Validation

- `gofmt -l internal\repomap\repomap.go internal\repomap\prompt.go internal\repomap\search.go internal\repomap\repomap_test.go internal\repomap\prompt_test.go internal\repomap\search_test.go internal\cli\repo_map.go internal\cli\repo_map_test.go internal\cli\app.go internal\agent\system_prompt.go internal\agent\loop_test.go`
- `go test ./...`
- `go vet ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `git diff --check` (passed; Windows printed CRLF conversion warnings only)
- manual: `go run ./cmd/zero repo-map --max-files 8 --max-depth 2`
- manual: `go run ./cmd/zero repo-map --json --max-files 2 --max-depth 2`
- manual: `go run ./cmd/zero repo-map --query "agent runtime" --max-files 5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repo-map CLI to scan workspaces and produce deterministic repository maps; included in help output.
  * Repo map is now auto-included in AI system prompts when scanning succeeds, with size capping and clipped markers.
  * Multiple output modes: human-readable, JSON, or query-ranked matches; search supports multi-term ranking and result limits.

* **Tests**
  * Comprehensive tests for scanning, rendering, search/ranking, output formats, truncation/limit behavior, help text, and determinism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->