### PR TITLE
Add shared workspace index foundation

### DIFF
--- a/internal/contextreport/contextreport.go
+++ b/internal/contextreport/contextreport.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/repomap"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -21,6 +22,7 @@ const RuntimeGo = "go"
 const (
 	CategorySystemPrompt      = "system_prompt"
 	CategoryProjectGuidelines = "project_guidelines"
+	CategoryWorkspaceMap      = "workspace_map"
 	CategoryTools             = "tools"
 	CategoryFree              = "free"
 )
@@ -28,6 +30,7 @@ const (
 var defaultProjectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
 
 const maxProjectContextBytes = 8 << 10
+const maxWorkspaceMapContextBytes = 4 << 10
 
 // toolDefinitionOverheadTokens approximates per-tool JSON/message framing.
 const toolDefinitionOverheadTokens = 4
@@ -104,6 +107,10 @@ func Build(options Options) (Report, error) {
 		categories = append(categories, category(CategoryProjectGuidelines, "Project guidelines", estimateTextTokens(projectGuidelines), report.ContextWindow))
 	}
 
+	if workspaceMap := workspaceMapFootprint(root); workspaceMap != "" {
+		categories = append(categories, category(CategoryWorkspaceMap, "Workspace map", estimateTextTokens(workspaceMap), report.ContextWindow))
+	}
+
 	toolCount, toolTokens := estimateRegistryTools(options.Registry)
 	report.ToolCount = toolCount
 	if toolTokens > 0 {
@@ -125,6 +132,14 @@ func Build(options Options) (Report, error) {
 	categories = append(categories, category(CategoryFree, "Free", report.FreeTokens, report.ContextWindow))
 	report.Categories = categories
 	return report, nil
+}
+
+func workspaceMapFootprint(root string) string {
+	snapshot, err := repomap.Scan(root, repomap.Options{MaxFiles: 300, MaxDepth: 5})
+	if err != nil {
+		return ""
+	}
+	return repomap.RenderPrompt(snapshot, maxWorkspaceMapContextBytes)
 }
 
 func systemPromptFootprint(root string, modelID string) string {

--- a/internal/contextreport/contextreport.go
+++ b/internal/contextreport/contextreport.go
@@ -107,7 +107,9 @@ func Build(options Options) (Report, error) {
 		categories = append(categories, category(CategoryProjectGuidelines, "Project guidelines", estimateTextTokens(projectGuidelines), report.ContextWindow))
 	}
 
-	if workspaceMap := workspaceMapFootprint(root); workspaceMap != "" {
+	if workspaceMap, err := workspaceMapFootprint(root); err != nil {
+		categories = append(categories, category(CategoryWorkspaceMap, "Workspace map (error: "+err.Error()+")", 0, report.ContextWindow))
+	} else if workspaceMap != "" {
 		categories = append(categories, category(CategoryWorkspaceMap, "Workspace map", estimateTextTokens(workspaceMap), report.ContextWindow))
 	}
 
@@ -134,12 +136,12 @@ func Build(options Options) (Report, error) {
 	return report, nil
 }
 
-func workspaceMapFootprint(root string) string {
+func workspaceMapFootprint(root string) (string, error) {
 	snapshot, err := repomap.Scan(root, repomap.Options{MaxFiles: 300, MaxDepth: 5})
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return repomap.RenderPrompt(snapshot, maxWorkspaceMapContextBytes)
+	return repomap.RenderPrompt(snapshot, maxWorkspaceMapContextBytes), nil
 }
 
 func systemPromptFootprint(root string, modelID string) string {

--- a/internal/contextreport/contextreport_test.go
+++ b/internal/contextreport/contextreport_test.go
@@ -157,6 +157,33 @@ func TestBuildClampsFreeBudgetWhenOverContextWindow(t *testing.T) {
 	}
 }
 
+func TestBuildAccountsForWorkspaceMapContext(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module example.test/repo\n")
+	writeTestFile(t, root, "cmd/zero/main.go", "package main\n")
+	writeTestFile(t, root, "README.md", "# Example\n")
+
+	report, err := Build(Options{
+		WorkspaceRoot: root,
+		ContextWindow: 10_000,
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	cat := categoryByKey(report, CategoryWorkspaceMap)
+	if cat == nil {
+		t.Fatalf("missing workspace map category: %#v", report.Categories)
+	}
+	if cat.Tokens <= 0 {
+		t.Fatalf("workspace map tokens = %d, want > 0", cat.Tokens)
+	}
+	formatted := Format(report)
+	if !strings.Contains(formatted, "Workspace map") {
+		t.Fatalf("Format missing workspace map category:\n%s", formatted)
+	}
+}
+
 func TestBuildWithoutProviderStillReturnsReport(t *testing.T) {
 	root := t.TempDir()
 

--- a/internal/contextreport/contextreport_test.go
+++ b/internal/contextreport/contextreport_test.go
@@ -159,6 +159,19 @@ func TestBuildClampsFreeBudgetWhenOverContextWindow(t *testing.T) {
 
 func TestBuildAccountsForWorkspaceMapContext(t *testing.T) {
 	root := t.TempDir()
+
+	baseline, err := Build(Options{
+		WorkspaceRoot: root,
+		ContextWindow: 10_000,
+	})
+	if err != nil {
+		t.Fatalf("Build baseline returned error: %v", err)
+	}
+	baselineCat := categoryByKey(baseline, CategoryWorkspaceMap)
+	if baselineCat == nil {
+		t.Fatalf("baseline missing workspace map category: %#v", baseline.Categories)
+	}
+
 	writeTestFile(t, root, "go.mod", "module example.test/repo\n")
 	writeTestFile(t, root, "cmd/zero/main.go", "package main\n")
 	writeTestFile(t, root, "README.md", "# Example\n")
@@ -178,9 +191,45 @@ func TestBuildAccountsForWorkspaceMapContext(t *testing.T) {
 	if cat.Tokens <= 0 {
 		t.Fatalf("workspace map tokens = %d, want > 0", cat.Tokens)
 	}
+	workspaceDelta := cat.Tokens - baselineCat.Tokens
+	if workspaceDelta <= 0 {
+		t.Fatalf("workspace map token delta = %d, want > 0 (baseline=%d final=%d)", workspaceDelta, baselineCat.Tokens, cat.Tokens)
+	}
+	if usedDelta := report.UsedTokens - baseline.UsedTokens; usedDelta != workspaceDelta {
+		t.Fatalf("used token delta = %d, want workspace map delta %d", usedDelta, workspaceDelta)
+	}
+	if freeDelta := baseline.FreeTokens - report.FreeTokens; freeDelta != workspaceDelta {
+		t.Fatalf("free token delta = %d, want workspace map delta %d", freeDelta, workspaceDelta)
+	}
 	formatted := Format(report)
 	if !strings.Contains(formatted, "Workspace map") {
 		t.Fatalf("Format missing workspace map category:\n%s", formatted)
+	}
+}
+
+func TestBuildShowsWorkspaceMapScanErrors(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing")
+
+	report, err := Build(Options{
+		WorkspaceRoot: root,
+		ContextWindow: 10_000,
+	})
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+
+	cat := categoryByKey(report, CategoryWorkspaceMap)
+	if cat == nil {
+		t.Fatalf("missing workspace map error category: %#v", report.Categories)
+	}
+	if cat.Tokens != 0 {
+		t.Fatalf("workspace map error tokens = %d, want 0", cat.Tokens)
+	}
+	if !strings.Contains(cat.Name, "Workspace map (error:") {
+		t.Fatalf("workspace map category name = %q, want visible error", cat.Name)
+	}
+	if formatted := Format(report); !strings.Contains(formatted, "Workspace map (error:") {
+		t.Fatalf("Format missing workspace map error:\n%s", formatted)
 	}
 }
 

--- a/internal/repoinfo/detect_test.go
+++ b/internal/repoinfo/detect_test.go
@@ -17,6 +17,35 @@ func TestLanguageForExt(t *testing.T) {
 	}
 }
 
+func TestLanguageForPathOverlapExtensions(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"cmd/zero/main.go", "Go", true},
+		{"web/app.ts", "TypeScript", true},
+		{"web/component.tsx", "TypeScript", true},
+		{"web/app.js", "JavaScript", true},
+		{"web/component.jsx", "JavaScript", true},
+		{"README.md", "", false},
+		{"package.json", "", false},
+		{".github/workflows/ci.yml", "", false},
+		{"config.yaml", "", false},
+		{"scripts/install.sh", "Shell", true},
+		{"scripts/install.bash", "Shell", true},
+		{"tools/report.py", "Python", true},
+		{"crates/zero/src/lib.rs", "Rust", true},
+		{"LICENSE", "", false},
+	}
+	for _, tt := range cases {
+		got, ok := languageForPath(tt.path)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("languageForPath(%q)=%q,%v want %q,%v", tt.path, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
 func TestCicdForPath(t *testing.T) {
 	cases := map[string]string{
 		".github/workflows/ci.yml": "GitHub Actions",

--- a/internal/repoinfo/languages.go
+++ b/internal/repoinfo/languages.go
@@ -1,5 +1,12 @@
 package repoinfo
 
+import (
+	"path"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/workspaceindex"
+)
+
 // extToLanguage maps a lowercase file extension (no dot) to a display language.
 var extToLanguage = map[string]string{
 	"go": "Go", "ts": "TypeScript", "tsx": "TypeScript", "js": "JavaScript",
@@ -22,4 +29,23 @@ var extToLanguage = map[string]string{
 func languageForExt(ext string) (string, bool) {
 	lang, ok := extToLanguage[ext]
 	return lang, ok
+}
+
+// languageForPath is the repoinfo adapter for path-based language detection.
+// It delegates shared overlap cases to workspaceindex while preserving
+// repoinfo's current rollup behavior for prose/data formats and legacy entries.
+func languageForPath(filePath string) (string, bool) {
+	if lang := workspaceindex.LanguageForPath(filePath); lang != "" {
+		switch lang {
+		case "JSON", "Markdown", "TOML", "YAML":
+			return "", false
+		default:
+			return lang, true
+		}
+	}
+	return languageForExt(extForPath(filePath))
+}
+
+func extForPath(filePath string) string {
+	return strings.ToLower(strings.TrimPrefix(path.Ext(path.Base(filePath)), "."))
 }

--- a/internal/repoinfo/repoinfo.go
+++ b/internal/repoinfo/repoinfo.go
@@ -133,8 +133,7 @@ func Collect(ctx context.Context, opts Options) (Info, error) {
 		}
 
 		base := path.Base(filePath)
-		ext := strings.ToLower(strings.TrimPrefix(path.Ext(base), "."))
-		if lang, ok := languageForExt(ext); ok {
+		if lang, ok := languageForPath(filePath); ok {
 			langBytes[lang] += size
 			langFiles[lang]++
 		}

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -86,36 +86,12 @@ func handleWalkError(cleanRoot string, current string, entry fs.DirEntry, walkEr
 	return workspaceindex.HandleWalkError(cleanRoot, current, entry, walkErr, truncated)
 }
 
-func shouldSkipDir(name string) bool {
-	return workspaceindex.ShouldSkipDir(name)
-}
-
-func shouldSkipFile(rel string) bool {
-	return workspaceindex.ShouldSkipFile(rel)
-}
-
-func isSymlink(entry fs.DirEntry) bool {
-	return entry.Type()&fs.ModeSymlink != 0
-}
-
-func pathDepth(rel string) int {
-	return workspaceindex.PathDepth(rel)
-}
-
 func fileDepth(rel string) int {
 	return workspaceindex.FileDepth(rel)
 }
 
 func languageForExt(ext string) string {
 	return workspaceindex.LanguageForPath("file" + ext)
-}
-
-func maxFileDepth(files []File) int {
-	indexFiles := make([]workspaceindex.File, 0, len(files))
-	for _, file := range files {
-		indexFiles = append(indexFiles, workspaceindex.File{Depth: file.Depth})
-	}
-	return workspaceindex.MaxFileDepth(indexFiles)
 }
 
 func countLanguages(files []File) []Count {

--- a/internal/repomap/repomap.go
+++ b/internal/repomap/repomap.go
@@ -2,20 +2,17 @@
 package repomap
 
 import (
-	"errors"
 	"io/fs"
-	"path"
-	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/workspaceindex"
 )
 
 const (
-	DefaultMaxFiles = 2000
-	DefaultMaxDepth = 6
+	DefaultMaxFiles = workspaceindex.DefaultMaxFiles
+	DefaultMaxDepth = workspaceindex.DefaultMaxDepth
 )
-
-var errStopWalk = errors.New("repo map scan stopped")
 
 type Options struct {
 	MaxFiles int
@@ -55,137 +52,46 @@ type Count struct {
 }
 
 func Scan(root string, options Options) (Snapshot, error) {
-	cleanRoot, err := filepath.Abs(strings.TrimSpace(root))
-	if err != nil {
-		return Snapshot{}, err
-	}
-	cleanRoot = filepath.Clean(cleanRoot)
-
-	maxFiles := options.MaxFiles
-	if maxFiles <= 0 {
-		maxFiles = DefaultMaxFiles
-	}
-	maxDepth := options.MaxDepth
-	if maxDepth < 0 {
-		maxDepth = DefaultMaxDepth
-	}
-
-	var files []File
-	dirs := map[string]struct{}{}
-	truncated := false
-	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, walkErr error) error {
-		if handled, err := handleWalkError(cleanRoot, current, entry, walkErr, &truncated); handled {
-			return err
-		}
-		if current == cleanRoot {
-			return nil
-		}
-
-		rel, relErr := filepath.Rel(cleanRoot, current)
-		if relErr != nil {
-			truncated = true
-			return relErr
-		}
-		rel = filepath.ToSlash(rel)
-
-		if entry.IsDir() {
-			if shouldSkipDir(entry.Name()) {
-				return filepath.SkipDir
-			}
-			if isSymlink(entry) {
-				return filepath.SkipDir
-			}
-			if pathDepth(rel) > maxDepth {
-				truncated = true
-				return filepath.SkipDir
-			}
-			dirs[rel] = struct{}{}
-			return nil
-		}
-
-		if isSymlink(entry) {
-			return nil
-		}
-		if shouldSkipFile(rel) {
-			return nil
-		}
-		depth := fileDepth(rel)
-		if depth > maxDepth {
-			truncated = true
-			return nil
-		}
-		if options.MaxBytesPerFileName > 0 && len(rel) > options.MaxBytesPerFileName {
-			truncated = true
-			return nil
-		}
-		if len(files) >= maxFiles {
-			truncated = true
-			return errStopWalk
-		}
-
-		ext := strings.ToLower(path.Ext(rel))
-		files = append(files, File{
-			Path:      rel,
-			Language:  languageForExt(ext),
-			Extension: ext,
-			Depth:     depth,
-		})
-		return nil
+	summary, err := workspaceindex.Scan(root, workspaceindex.Options{
+		MaxFiles:            options.MaxFiles,
+		MaxDepth:            options.MaxDepth,
+		MaxBytesPerFileName: options.MaxBytesPerFileName,
 	})
+	files := make([]File, 0, len(summary.Files))
+	for _, file := range summary.Files {
+		files = append(files, File{
+			Path:      file.Path,
+			Language:  file.Language,
+			Extension: file.Ext,
+			Depth:     file.Depth,
+		})
+	}
 	sortFiles(files)
 	snapshot := Snapshot{
-		Root:           cleanRoot,
+		Root:           summary.Root,
 		Files:          files,
-		FileCount:      len(files),
-		DirectoryCount: len(dirs),
-		MaxDepth:       maxFileDepth(files),
-		Truncated:      truncated,
+		FileCount:      summary.TotalFiles,
+		DirectoryCount: summary.DirectoryCount,
+		MaxDepth:       summary.MaxDepth,
+		Truncated:      summary.Truncated,
 	}
-	snapshot.LanguageCounts = countLanguages(files)
-	snapshot.ExtensionCounts = countExtensions(files)
+	snapshot.LanguageCounts = sortedCounts(summary.LanguageCounts)
+	snapshot.ExtensionCounts = sortedCounts(summary.ExtensionCounts)
 	snapshot.ImportantFiles = importantFilePaths(files)
 	snapshot.Tree = buildTree(files)
-	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
-		return snapshot, walkErr
-	}
-	return snapshot, nil
+	return snapshot, err
 }
 
 func handleWalkError(cleanRoot string, current string, entry fs.DirEntry, walkErr error, truncated *bool) (bool, error) {
-	if walkErr == nil {
-		return false, nil
-	}
-	*truncated = true
-	if current == cleanRoot {
-		return true, walkErr
-	}
-	if entry != nil && entry.IsDir() {
-		return true, filepath.SkipDir
-	}
-	return true, nil
+	return workspaceindex.HandleWalkError(cleanRoot, current, entry, walkErr, truncated)
 }
 
 func shouldSkipDir(name string) bool {
-	switch name {
-	case ".cache", ".git", ".next", ".worktrees", ".zero", "build", "coverage", "dist", "node_modules", "vendor":
-		return true
-	default:
-		return false
-	}
+	return workspaceindex.ShouldSkipDir(name)
 }
 
 func shouldSkipFile(rel string) bool {
-	base := strings.ToLower(path.Base(rel))
-	switch base {
-	case ".git", ".ds_store":
-		return true
-	}
-	switch strings.ToLower(path.Ext(base)) {
-	case ".a", ".class", ".dll", ".dylib", ".exe", ".gz", ".jar", ".o", ".so", ".tar", ".tgz", ".zip":
-		return true
-	default:
-		return false
-	}
+	return workspaceindex.ShouldSkipFile(rel)
 }
 
 func isSymlink(entry fs.DirEntry) bool {
@@ -193,88 +99,23 @@ func isSymlink(entry fs.DirEntry) bool {
 }
 
 func pathDepth(rel string) int {
-	if rel == "" || rel == "." {
-		return 0
-	}
-	return strings.Count(filepath.ToSlash(rel), "/") + 1
+	return workspaceindex.PathDepth(rel)
 }
 
 func fileDepth(rel string) int {
-	if rel == "" || !strings.Contains(rel, "/") {
-		return 0
-	}
-	return strings.Count(filepath.ToSlash(rel), "/")
+	return workspaceindex.FileDepth(rel)
 }
 
 func languageForExt(ext string) string {
-	switch strings.TrimPrefix(strings.ToLower(ext), ".") {
-	case "bash", "sh", "zsh":
-		return "Shell"
-	case "c":
-		return "C"
-	case "cc", "cpp", "cxx", "hh", "hpp":
-		return "C++"
-	case "cs":
-		return "C#"
-	case "css":
-		return "CSS"
-	case "dart":
-		return "Dart"
-	case "ex", "exs":
-		return "Elixir"
-	case "go":
-		return "Go"
-	case "html", "htm":
-		return "HTML"
-	case "java":
-		return "Java"
-	case "js", "jsx", "mjs", "cjs":
-		return "JavaScript"
-	case "json":
-		return "JSON"
-	case "kt", "kts":
-		return "Kotlin"
-	case "lua":
-		return "Lua"
-	case "md", "markdown":
-		return "Markdown"
-	case "php":
-		return "PHP"
-	case "proto":
-		return "Protobuf"
-	case "py":
-		return "Python"
-	case "rb":
-		return "Ruby"
-	case "rs":
-		return "Rust"
-	case "sass", "scss":
-		return "SCSS"
-	case "sql":
-		return "SQL"
-	case "svelte":
-		return "Svelte"
-	case "swift":
-		return "Swift"
-	case "tf":
-		return "Terraform"
-	case "ts", "tsx":
-		return "TypeScript"
-	case "vue":
-		return "Vue"
-	default:
-		return ""
-	}
+	return workspaceindex.LanguageForPath("file" + ext)
 }
 
 func maxFileDepth(files []File) int {
-	maxDepth := 0
+	indexFiles := make([]workspaceindex.File, 0, len(files))
 	for _, file := range files {
-		if file.Depth > maxDepth {
-			maxDepth = file.Depth
-		}
+		indexFiles = append(indexFiles, workspaceindex.File{Depth: file.Depth})
 	}
-	return maxDepth
+	return workspaceindex.MaxFileDepth(indexFiles)
 }
 
 func countLanguages(files []File) []Count {
@@ -339,35 +180,7 @@ func importantFilePaths(files []File) []string {
 }
 
 func importantPriority(file string) (int, bool) {
-	base := strings.ToLower(path.Base(file))
-	switch base {
-	case "agents.md":
-		return 10, true
-	case "zero.md":
-		return 20, true
-	case "readme.md":
-		return 30, true
-	case "contributing.md":
-		return 40, true
-	case "go.mod":
-		return 50, true
-	case "go.sum":
-		return 55, true
-	case "package.json":
-		return 60, true
-	case "cargo.toml":
-		return 70, true
-	case "pyproject.toml":
-		return 80, true
-	case "requirements.txt":
-		return 90, true
-	case "makefile":
-		return 100, true
-	case "dockerfile", "docker-compose.yml", "docker-compose.yaml":
-		return 110, true
-	default:
-		return 0, false
-	}
+	return workspaceindex.ImportantPriority(file)
 }
 
 func buildTree(files []File) []string {

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -263,7 +263,10 @@ func TestGrepSkipsAlwaysExcludedDirectories(t *testing.T) {
 	}
 	mustWrite("keep.txt", "needle here")
 	mustWrite(".git/config", "needle here")
+	mustWrite(".zero/state.json", "needle here")
 	mustWrite("node_modules/pkg/index.js", "needle here")
+	mustWrite("vendor/pkg/lib.go", "needle here")
+	mustWrite(".worktrees/branch/main.go", "needle here")
 
 	res := NewGrepTool(root).Run(context.Background(), map[string]any{
 		"pattern":     "needle",
@@ -272,10 +275,69 @@ func TestGrepSkipsAlwaysExcludedDirectories(t *testing.T) {
 	if res.Status != StatusOK {
 		t.Fatalf("status=%s output=%s", res.Status, res.Output)
 	}
-	if strings.Contains(res.Output, ".git") || strings.Contains(res.Output, "node_modules") {
-		t.Fatalf("grep must not descend into excluded dirs, got:\n%s", res.Output)
+	for _, forbidden := range []string{".git", ".zero", "node_modules", "vendor", ".worktrees"} {
+		if strings.Contains(res.Output, forbidden) {
+			t.Fatalf("grep must not descend into excluded dir %q, got:\n%s", forbidden, res.Output)
+		}
 	}
 	if !strings.Contains(res.Output, "keep.txt") {
 		t.Fatalf("expected keep.txt in results, got:\n%s", res.Output)
+	}
+}
+
+func TestGrepSkipsBinaryLikeFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "keep.txt"), "needle here")
+	writeTestFile(t, filepath.Join(root, "image.png"), "needle hidden")
+	writeTestFile(t, filepath.Join(root, "archive.zip"), "needle hidden")
+
+	res := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":     "needle",
+		"output_mode": "files_with_matches",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "image.png") || strings.Contains(res.Output, "archive.zip") {
+		t.Fatalf("grep must skip binary-like files, got:\n%s", res.Output)
+	}
+	if strings.TrimSpace(res.Output) != "keep.txt" {
+		t.Fatalf("expected only keep.txt, got:\n%s", res.Output)
+	}
+
+	direct := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern": "needle",
+		"path":    "image.png",
+	})
+	if direct.Status != StatusOK {
+		t.Fatalf("direct status=%s output=%s", direct.Status, direct.Output)
+	}
+	if strings.Contains(direct.Output, "image.png") || strings.Contains(direct.Output, "needle hidden") {
+		t.Fatalf("direct binary-like grep should be skipped, got:\n%s", direct.Output)
+	}
+}
+
+func TestGlobSkipsWorkspaceExcludedDirectoriesAndBinaryFiles(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "keep.txt"), "keep")
+	writeTestFile(t, filepath.Join(root, ".zero", "state.json"), "{}")
+	writeTestFile(t, filepath.Join(root, "vendor", "pkg", "lib.go"), "package lib")
+	writeTestFile(t, filepath.Join(root, ".worktrees", "branch", "main.go"), "package main")
+	writeTestFile(t, filepath.Join(root, "image.png"), "binary")
+
+	res := NewGlobTool(root).Run(context.Background(), map[string]any{
+		"pattern": "**/*",
+		"limit":   20,
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status=%s output=%s", res.Status, res.Output)
+	}
+	for _, forbidden := range []string{".zero", "vendor", ".worktrees", "image.png"} {
+		if strings.Contains(res.Output, forbidden) {
+			t.Fatalf("glob must skip %q, got:\n%s", forbidden, res.Output)
+		}
+	}
+	if strings.TrimSpace(res.Output) != "keep.txt" {
+		t.Fatalf("expected only keep.txt, got:\n%s", res.Output)
 	}
 }

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -97,7 +97,13 @@ func scanGlob(root string, matcher *regexp.Regexp, includeDirs bool) ([]string, 
 	matches := []string{}
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			return walkErr
+			if path == root {
+				return walkErr
+			}
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if path == root {
 			return nil
@@ -114,6 +120,9 @@ func scanGlob(root string, matcher *regexp.Regexp, includeDirs bool) ([]string, 
 			return err
 		}
 		normalized := filepath.ToSlash(relative)
+		if !entry.IsDir() && shouldSkipWorkspaceFile(normalized) {
+			return nil
+		}
 		if matcher.MatchString(normalized) {
 			matches = append(matches, normalized)
 		}

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -199,6 +199,9 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 		if !ok {
 			return []string{}, nil
 		}
+		if shouldSkipWorkspaceFile(relative) {
+			return []string{}, nil
+		}
 		if globMatcher == nil || globMatcher.MatchString(relative) {
 			return []string{target}, nil
 		}
@@ -208,7 +211,13 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 	files := []string{}
 	err = filepath.WalkDir(target, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			return walkErr
+			if path == target {
+				return walkErr
+			}
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if path == target {
 			return nil
@@ -223,6 +232,9 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 		// pointing to a file OUTSIDE the root must be skipped, not searched.
 		relative, _, ok := confineGrepFile(resolvedRoot, path)
 		if !ok {
+			return nil
+		}
+		if shouldSkipWorkspaceFile(relative) {
 			return nil
 		}
 		if globMatcher == nil || globMatcher.MatchString(relative) {
@@ -244,6 +256,9 @@ func collectGrepMatches(resolvedRoot string, files []string, compiled *regexp.Re
 		// workspace-relative path used in output.
 		relative, resolvedPath, ok := confineGrepFile(resolvedRoot, file)
 		if !ok {
+			continue
+		}
+		if shouldSkipWorkspaceFile(relative) {
 			continue
 		}
 		// Read the symlink-RESOLVED path that confineGrepFile validated, not the

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/workspaceindex"
 )
 
 var ignoredDirectories = map[string]bool{
@@ -195,5 +197,9 @@ func recheckWorkspaceWriteTarget(workspaceRoot string, requestedPath string) err
 }
 
 func shouldSkipDirectory(name string) bool {
-	return ignoredDirectories[name]
+	return ignoredDirectories[name] || workspaceindex.ShouldSkipDir(name)
+}
+
+func shouldSkipWorkspaceFile(path string) bool {
+	return workspaceindex.ShouldSkipFile(path)
 }

--- a/internal/workspaceindex/workspaceindex.go
+++ b/internal/workspaceindex/workspaceindex.go
@@ -65,6 +65,7 @@ func Scan(root string, options Options) (Summary, error) {
 
 	files := []File{}
 	dirs := map[string]struct{}{}
+	maxDepthSeen := 0
 	truncated := false
 	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, walkErr error) error {
 		if handled, err := HandleWalkError(cleanRoot, current, entry, walkErr, &truncated); handled {
@@ -85,9 +86,13 @@ func Scan(root string, options Options) (Summary, error) {
 			if ShouldSkipDir(entry.Name()) || isSymlink(entry) {
 				return filepath.SkipDir
 			}
-			if pathDepth(rel) > maxDepth {
+			depth := pathDepth(rel)
+			if depth > maxDepth {
 				truncated = true
 				return filepath.SkipDir
+			}
+			if depth > maxDepthSeen {
+				maxDepthSeen = depth
 			}
 			dirs[rel] = struct{}{}
 			return nil
@@ -100,6 +105,9 @@ func Scan(root string, options Options) (Summary, error) {
 		if depth > maxDepth {
 			truncated = true
 			return nil
+		}
+		if depth > maxDepthSeen {
+			maxDepthSeen = depth
 		}
 		if options.MaxBytesPerFileName > 0 && len(rel) > options.MaxBytesPerFileName {
 			truncated = true
@@ -135,7 +143,7 @@ func Scan(root string, options Options) (Summary, error) {
 		ExtensionCounts: extensionCounts(files),
 		TotalFiles:      len(files),
 		DirectoryCount:  len(dirs),
-		MaxDepth:        MaxFileDepth(files),
+		MaxDepth:        maxDepthSeen,
 		Truncated:       truncated,
 	}
 	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
@@ -296,10 +304,11 @@ func PathDepth(rel string) int {
 }
 
 func FileDepth(rel string) int {
-	if rel == "" || !strings.Contains(rel, "/") {
+	normalized := filepath.ToSlash(rel)
+	if normalized == "" || !strings.Contains(normalized, "/") {
 		return 0
 	}
-	return strings.Count(filepath.ToSlash(rel), "/")
+	return strings.Count(normalized, "/")
 }
 
 func MaxFileDepth(files []File) int {

--- a/internal/workspaceindex/workspaceindex.go
+++ b/internal/workspaceindex/workspaceindex.go
@@ -297,18 +297,23 @@ func ImportantPriority(file string) (int, bool) {
 }
 
 func PathDepth(rel string) int {
-	if rel == "" || rel == "." {
+	normalized := normalizeSeparators(rel)
+	if normalized == "" || normalized == "." {
 		return 0
 	}
-	return strings.Count(filepath.ToSlash(rel), "/") + 1
+	return strings.Count(normalized, "/") + 1
 }
 
 func FileDepth(rel string) int {
-	normalized := filepath.ToSlash(rel)
+	normalized := normalizeSeparators(rel)
 	if normalized == "" || !strings.Contains(normalized, "/") {
 		return 0
 	}
 	return strings.Count(normalized, "/")
+}
+
+func normalizeSeparators(rel string) string {
+	return strings.ReplaceAll(filepath.ToSlash(rel), "\\", "/")
 }
 
 func MaxFileDepth(files []File) int {

--- a/internal/workspaceindex/workspaceindex.go
+++ b/internal/workspaceindex/workspaceindex.go
@@ -1,0 +1,347 @@
+// Package workspaceindex provides shared deterministic workspace scanning
+// primitives for repo intelligence, tools, and context accounting.
+package workspaceindex
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	DefaultMaxFiles = 2000
+	DefaultMaxDepth = 6
+)
+
+var errStopWalk = errors.New("workspace index scan stopped")
+
+type Options struct {
+	MaxFiles int
+	// MaxDepth is measured as path separators below the root. Zero means root
+	// files only; negative values use DefaultMaxDepth.
+	MaxDepth            int
+	MaxBytesPerFileName int
+}
+
+type Summary struct {
+	Root            string
+	Files           []File
+	LanguageCounts  map[string]int
+	ExtensionCounts map[string]int
+	TotalFiles      int
+	DirectoryCount  int
+	MaxDepth        int
+	Truncated       bool
+}
+
+type File struct {
+	Path      string
+	Name      string
+	Ext       string
+	Language  string
+	Size      int64
+	Depth     int
+	Important bool
+}
+
+func Scan(root string, options Options) (Summary, error) {
+	cleanRoot, err := filepath.Abs(strings.TrimSpace(root))
+	if err != nil {
+		return Summary{}, err
+	}
+	cleanRoot = filepath.Clean(cleanRoot)
+
+	maxFiles := options.MaxFiles
+	if maxFiles <= 0 {
+		maxFiles = DefaultMaxFiles
+	}
+	maxDepth := options.MaxDepth
+	if maxDepth < 0 {
+		maxDepth = DefaultMaxDepth
+	}
+
+	files := []File{}
+	dirs := map[string]struct{}{}
+	truncated := false
+	walkErr := filepath.WalkDir(cleanRoot, func(current string, entry fs.DirEntry, walkErr error) error {
+		if handled, err := HandleWalkError(cleanRoot, current, entry, walkErr, &truncated); handled {
+			return err
+		}
+		if current == cleanRoot {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(cleanRoot, current)
+		if relErr != nil {
+			truncated = true
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+
+		if entry.IsDir() {
+			if ShouldSkipDir(entry.Name()) || isSymlink(entry) {
+				return filepath.SkipDir
+			}
+			if pathDepth(rel) > maxDepth {
+				truncated = true
+				return filepath.SkipDir
+			}
+			dirs[rel] = struct{}{}
+			return nil
+		}
+
+		if isSymlink(entry) || ShouldSkipFile(rel) {
+			return nil
+		}
+		depth := FileDepth(rel)
+		if depth > maxDepth {
+			truncated = true
+			return nil
+		}
+		if options.MaxBytesPerFileName > 0 && len(rel) > options.MaxBytesPerFileName {
+			truncated = true
+			return nil
+		}
+		if len(files) >= maxFiles {
+			truncated = true
+			return errStopWalk
+		}
+
+		size := int64(0)
+		if info, err := entry.Info(); err == nil {
+			size = info.Size()
+		}
+		ext := strings.ToLower(path.Ext(rel))
+		files = append(files, File{
+			Path:      rel,
+			Name:      path.Base(rel),
+			Ext:       ext,
+			Language:  LanguageForPath(rel),
+			Size:      size,
+			Depth:     depth,
+			Important: IsImportantPath(rel),
+		})
+		return nil
+	})
+
+	SortFiles(files)
+	summary := Summary{
+		Root:            cleanRoot,
+		Files:           files,
+		LanguageCounts:  languageCounts(files),
+		ExtensionCounts: extensionCounts(files),
+		TotalFiles:      len(files),
+		DirectoryCount:  len(dirs),
+		MaxDepth:        MaxFileDepth(files),
+		Truncated:       truncated,
+	}
+	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
+		return summary, walkErr
+	}
+	return summary, nil
+}
+
+func HandleWalkError(cleanRoot string, current string, entry fs.DirEntry, walkErr error, truncated *bool) (bool, error) {
+	if walkErr == nil {
+		return false, nil
+	}
+	*truncated = true
+	if current == cleanRoot {
+		return true, walkErr
+	}
+	if entry != nil && entry.IsDir() {
+		return true, filepath.SkipDir
+	}
+	return true, nil
+}
+
+func ShouldSkipDir(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case ".cache", ".git", ".next", ".worktrees", ".zero", "build", "coverage", "dist", "node_modules", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func ShouldSkipFile(rel string) bool {
+	base := strings.ToLower(path.Base(filepath.ToSlash(rel)))
+	switch base {
+	case ".git", ".ds_store":
+		return true
+	default:
+		return LooksBinaryPath(rel)
+	}
+}
+
+func LooksBinaryPath(file string) bool {
+	switch strings.ToLower(path.Ext(filepath.ToSlash(file))) {
+	case ".a", ".avif", ".bmp", ".class", ".dll", ".dylib", ".exe", ".gif", ".gz", ".ico", ".jar", ".jpeg", ".jpg", ".o", ".pdf", ".png", ".so", ".tar", ".tgz", ".webp", ".zip":
+		return true
+	default:
+		return false
+	}
+}
+
+func LanguageForPath(file string) string {
+	switch strings.TrimPrefix(strings.ToLower(path.Ext(filepath.ToSlash(file))), ".") {
+	case "bash", "sh", "zsh":
+		return "Shell"
+	case "c", "h":
+		return "C"
+	case "cc", "cpp", "cxx", "hh", "hpp":
+		return "C++"
+	case "cs":
+		return "C#"
+	case "css":
+		return "CSS"
+	case "dart":
+		return "Dart"
+	case "ex", "exs":
+		return "Elixir"
+	case "go":
+		return "Go"
+	case "html", "htm":
+		return "HTML"
+	case "java":
+		return "Java"
+	case "js", "jsx", "mjs", "cjs":
+		return "JavaScript"
+	case "json":
+		return "JSON"
+	case "kt", "kts":
+		return "Kotlin"
+	case "lua":
+		return "Lua"
+	case "md", "markdown":
+		return "Markdown"
+	case "php":
+		return "PHP"
+	case "proto":
+		return "Protobuf"
+	case "py":
+		return "Python"
+	case "rb":
+		return "Ruby"
+	case "rs":
+		return "Rust"
+	case "sass", "scss":
+		return "SCSS"
+	case "sql":
+		return "SQL"
+	case "svelte":
+		return "Svelte"
+	case "swift":
+		return "Swift"
+	case "tf":
+		return "Terraform"
+	case "toml":
+		return "TOML"
+	case "ts", "tsx":
+		return "TypeScript"
+	case "vue":
+		return "Vue"
+	case "yaml", "yml":
+		return "YAML"
+	default:
+		return ""
+	}
+}
+
+func IsImportantPath(file string) bool {
+	_, ok := ImportantPriority(file)
+	return ok
+}
+
+func ImportantPriority(file string) (int, bool) {
+	base := strings.ToLower(path.Base(filepath.ToSlash(file)))
+	switch base {
+	case "agents.md":
+		return 10, true
+	case "zero.md":
+		return 20, true
+	case "readme.md":
+		return 30, true
+	case "contributing.md":
+		return 40, true
+	case "go.mod":
+		return 50, true
+	case "go.sum":
+		return 55, true
+	case "package.json":
+		return 60, true
+	case "cargo.toml":
+		return 70, true
+	case "pyproject.toml":
+		return 80, true
+	case "requirements.txt":
+		return 90, true
+	case "makefile":
+		return 100, true
+	case "dockerfile", "docker-compose.yml", "docker-compose.yaml":
+		return 110, true
+	default:
+		return 0, false
+	}
+}
+
+func PathDepth(rel string) int {
+	if rel == "" || rel == "." {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(rel), "/") + 1
+}
+
+func FileDepth(rel string) int {
+	if rel == "" || !strings.Contains(rel, "/") {
+		return 0
+	}
+	return strings.Count(filepath.ToSlash(rel), "/")
+}
+
+func MaxFileDepth(files []File) int {
+	maxDepth := 0
+	for _, file := range files {
+		if file.Depth > maxDepth {
+			maxDepth = file.Depth
+		}
+	}
+	return maxDepth
+}
+
+func SortFiles(files []File) {
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+}
+
+func isSymlink(entry fs.DirEntry) bool {
+	return entry.Type()&fs.ModeSymlink != 0
+}
+
+func pathDepth(rel string) int {
+	return PathDepth(rel)
+}
+
+func languageCounts(files []File) map[string]int {
+	counts := map[string]int{}
+	for _, file := range files {
+		if file.Language != "" {
+			counts[file.Language]++
+		}
+	}
+	return counts
+}
+
+func extensionCounts(files []File) map[string]int {
+	counts := map[string]int{}
+	for _, file := range files {
+		if file.Ext != "" {
+			counts[file.Ext]++
+		}
+	}
+	return counts
+}

--- a/internal/workspaceindex/workspaceindex_test.go
+++ b/internal/workspaceindex/workspaceindex_test.go
@@ -98,6 +98,24 @@ func TestScanHonorsTraversalCaps(t *testing.T) {
 		}
 	})
 
+	t.Run("max depth includes retained directories without files", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "a", "b", "c"), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+
+		got, err := Scan(root, Options{MaxDepth: 3})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if got.DirectoryCount != 3 {
+			t.Fatalf("DirectoryCount=%d want 3", got.DirectoryCount)
+		}
+		if got.MaxDepth != 3 {
+			t.Fatalf("MaxDepth=%d want deepest retained directory depth 3", got.MaxDepth)
+		}
+	})
+
 	t.Run("max bytes per file name skips overlong entries", func(t *testing.T) {
 		root := t.TempDir()
 		writeFile(t, root, "short.go", "package short\n")
@@ -145,6 +163,21 @@ func TestHelpersClassifySharedWorkspaceRules(t *testing.T) {
 	}
 	if !IsImportantPath("docs/AGENTS.md") || !IsImportantPath("go.mod") {
 		t.Fatal("expected AGENTS.md and go.mod to be important")
+	}
+}
+
+func TestFileDepthHandlesNativeSeparators(t *testing.T) {
+	for rel, want := range map[string]int{
+		"main.go":               0,
+		"pkg/one.go":            1,
+		`pkg\one.go`:            1,
+		`internal\app\app.go`:   2,
+		"internal/app/app.go":   2,
+		`internal/app\mixed.go`: 2,
+	} {
+		if got := FileDepth(rel); got != want {
+			t.Fatalf("FileDepth(%q)=%d want %d", rel, got, want)
+		}
 	}
 }
 

--- a/internal/workspaceindex/workspaceindex_test.go
+++ b/internal/workspaceindex/workspaceindex_test.go
@@ -1,0 +1,205 @@
+package workspaceindex
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestScanBuildsDeterministicWorkspaceSummary(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "go.mod", "module example.test/repo\n")
+	writeFile(t, root, "README.md", "# Example\n")
+	writeFile(t, root, "package.json", `{"name":"example"}`)
+	writeFile(t, root, "cmd/zero/main.go", "package main\n")
+	writeFile(t, root, "internal/app/app.go", "package app\n")
+	writeFile(t, root, "web/app.ts", "export const app = true\n")
+	writeFile(t, root, "zero.exe", "ignored binary")
+	writeFile(t, root, ".git/config", "[core]\n")
+	writeFile(t, root, ".zero/state.json", "{}")
+	writeFile(t, root, "node_modules/pkg/index.js", "ignored")
+	writeFile(t, root, "vendor/lib/lib.go", "ignored")
+	writeFile(t, root, "dist/bundle.js", "ignored")
+	writeFile(t, root, "coverage/out.txt", "ignored")
+	writeFile(t, root, ".next/cache.js", "ignored")
+	writeFile(t, root, ".cache/blob", "ignored")
+
+	got, err := Scan(root, Options{MaxDepth: DefaultMaxDepth})
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if got.Root != filepath.Clean(root) {
+		t.Fatalf("Root=%q want %q", got.Root, filepath.Clean(root))
+	}
+	wantFiles := []string{
+		"README.md",
+		"cmd/zero/main.go",
+		"go.mod",
+		"internal/app/app.go",
+		"package.json",
+		"web/app.ts",
+	}
+	if !reflect.DeepEqual(pathsOf(got.Files), wantFiles) {
+		t.Fatalf("Files=%v want %v", pathsOf(got.Files), wantFiles)
+	}
+	if got.TotalFiles != len(wantFiles) {
+		t.Fatalf("TotalFiles=%d want %d", got.TotalFiles, len(wantFiles))
+	}
+	wantLanguages := map[string]int{
+		"Go":         2,
+		"JSON":       1,
+		"Markdown":   1,
+		"TypeScript": 1,
+	}
+	if !reflect.DeepEqual(got.LanguageCounts, wantLanguages) {
+		t.Fatalf("LanguageCounts=%v want %v", got.LanguageCounts, wantLanguages)
+	}
+	if !got.Files[0].Important || got.Files[0].Path != "README.md" {
+		t.Fatalf("README.md should be marked important, got %#v", got.Files[0])
+	}
+}
+
+func TestScanHonorsTraversalCaps(t *testing.T) {
+	t.Run("max files keeps first deterministic files", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "a.go", "package a\n")
+		writeFile(t, root, "b.go", "package b\n")
+		writeFile(t, root, "c.go", "package c\n")
+
+		got, err := Scan(root, Options{MaxFiles: 2})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if want := []string{"a.go", "b.go"}; !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+
+	t.Run("max depth zero includes root files only", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "top.go", "package top\n")
+		writeFile(t, root, "pkg/one.go", "package pkg\n")
+
+		got, err := Scan(root, Options{MaxDepth: 0})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if want := []string{"top.go"}; !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+
+	t.Run("max bytes per file name skips overlong entries", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, root, "short.go", "package short\n")
+		writeFile(t, root, "longname.go", "package longname\n")
+
+		got, err := Scan(root, Options{MaxBytesPerFileName: len("short.go")})
+		if err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		if want := []string{"short.go"}; !reflect.DeepEqual(pathsOf(got.Files), want) {
+			t.Fatalf("Files=%v want %v", pathsOf(got.Files), want)
+		}
+		if !got.Truncated {
+			t.Fatal("Truncated=false want true")
+		}
+	})
+}
+
+func TestHelpersClassifySharedWorkspaceRules(t *testing.T) {
+	for _, name := range []string{".git", ".zero", ".cache", ".next", "node_modules", "vendor", "dist", "build", "coverage", ".worktrees"} {
+		if !ShouldSkipDir(name) {
+			t.Fatalf("ShouldSkipDir(%q)=false want true", name)
+		}
+	}
+	for _, file := range []string{".git", ".DS_Store", "bin/app.exe", "archive.tar", "archive.tgz", "lib.so", "image.png"} {
+		if !ShouldSkipFile(file) {
+			t.Fatalf("ShouldSkipFile(%q)=false want true", file)
+		}
+		if file != ".git" && file != ".DS_Store" && !LooksBinaryPath(file) {
+			t.Fatalf("LooksBinaryPath(%q)=false want true", file)
+		}
+	}
+	for path, want := range map[string]string{
+		"main.go":          "Go",
+		"src/app.tsx":      "TypeScript",
+		"src/app.jsx":      "JavaScript",
+		"README.md":        "Markdown",
+		"config.yaml":      "YAML",
+		"Cargo.toml":       "TOML",
+		"unknown.zerolang": "",
+	} {
+		if got := LanguageForPath(path); got != want {
+			t.Fatalf("LanguageForPath(%q)=%q want %q", path, got, want)
+		}
+	}
+	if !IsImportantPath("docs/AGENTS.md") || !IsImportantPath("go.mod") {
+		t.Fatal("expected AGENTS.md and go.mod to be important")
+	}
+}
+
+func TestHandleWalkErrorKeepsScanningAfterUnreadableSubdir(t *testing.T) {
+	truncated := false
+	handled, err := HandleWalkError("root", "root/blocked", fakeDirEntry{dir: true}, os.ErrPermission, &truncated)
+	if !handled {
+		t.Fatal("handled=false want true")
+	}
+	if err != filepath.SkipDir {
+		t.Fatalf("err=%v want filepath.SkipDir", err)
+	}
+	if !truncated {
+		t.Fatal("truncated=false want true")
+	}
+}
+
+func writeFile(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func pathsOf(files []File) []string {
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		paths = append(paths, file.Path)
+	}
+	return paths
+}
+
+type fakeDirEntry struct {
+	dir bool
+}
+
+func (entry fakeDirEntry) Name() string {
+	return "fake"
+}
+
+func (entry fakeDirEntry) IsDir() bool {
+	return entry.dir
+}
+
+func (entry fakeDirEntry) Type() fs.FileMode {
+	if entry.dir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (entry fakeDirEntry) Info() (fs.FileInfo, error) {
+	return nil, os.ErrInvalid
+}

--- a/internal/workspaceindex/workspaceindex_test.go
+++ b/internal/workspaceindex/workspaceindex_test.go
@@ -179,6 +179,16 @@ func TestFileDepthHandlesNativeSeparators(t *testing.T) {
 			t.Fatalf("FileDepth(%q)=%d want %d", rel, got, want)
 		}
 	}
+	for rel, want := range map[string]int{
+		"pkg":                  1,
+		"pkg/nested":           2,
+		`pkg\nested`:           2,
+		`internal\app\service`: 3,
+	} {
+		if got := PathDepth(rel); got != want {
+			t.Fatalf("PathDepth(%q)=%d want %d", rel, got, want)
+		}
+	}
 }
 
 func TestHandleWalkErrorKeepsScanningAfterUnreadableSubdir(t *testing.T) {


### PR DESCRIPTION
﻿## Summary

Adds a shared `internal/workspaceindex` package for deterministic workspace scanning and moves repo intelligence consumers toward one source of truth for skip rules, language detection, binary filtering, depth caps, and important-file detection.

## What changed

- Added `internal/workspaceindex` with deterministic scan output, shared skip/file classification helpers, language counts, extension counts, and traversal caps.
- Refactored `internal/repomap.Scan` to consume the shared scanner while preserving the public repo-map API.
- Added `Workspace map` accounting to `zero context` so repo-map prompt cost is visible instead of hidden inside the free budget.
- Updated `repoinfo` to reuse shared language detection through a git-based adapter while still excluding prose/data formats from primary-language stats.
- Aligned grep/glob skip behavior with repo-intelligence rules for `.zero`, `.worktrees`, `vendor`, binary/archive/image-like files, and safe non-root walk errors.

## Validation

- `go test ./...`
- `go vet ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero context`
- `go run ./cmd/zero repo-map --max-files 8`

## Notes

No TUI, provider, docs, or release workflow files were touched. The main checkout had unrelated dirty TUI work, so this PR was built from a clean linked worktree at latest `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace map added to context reports; deterministic workspace scanning/indexing provides a snapshot and path-based language detection improves classification.
* **Bug Fixes**
  * Workspace-map scan errors are now surfaced in reports (shown with zero tokens and error indicator); rendered workspace-map size is capped.
* **Tests**
  * Expanded test coverage for workspace indexing, workspace map behavior, traversal limits, language detection, and grep/glob filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->