### PR TITLE
Add TUI interaction foundation

### DIFF
--- a/internal/tui/ask_user_test.go
+++ b/internal/tui/ask_user_test.go
@@ -147,3 +147,67 @@ func TestAskUserPromptBlocksNormalSubmit(t *testing.T) {
 		t.Fatal("expected ask_user prompt to remain pending after answering one question")
 	}
 }
+
+func TestAskUserRequestClearsComposerDraft(t *testing.T) {
+	var answers [][]string
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m = typeRunes(t, m, "hidden followup")
+	if !m.composerActive || m.composerValue() == "" {
+		t.Fatalf("test setup expected active composer draft, got active=%v value=%q", m.composerActive, m.composerValue())
+	}
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID: 7,
+		request: agent.AskUserRequest{
+			ToolCallID: "call_1",
+			Questions:  []agent.AskUserQuestion{{Question: "Proceed?"}},
+		},
+		answer: func(values []string) {
+			answers = append(answers, values)
+		},
+	})
+	next := updated.(model)
+
+	if next.composerActive || next.composerValue() != "" {
+		t.Fatalf("ask_user should clear composer draft, active=%v value=%q", next.composerActive, next.composerValue())
+	}
+	next.input.SetValue("yes")
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if len(answers) != 1 || answers[0][0] != "yes" {
+		t.Fatalf("expected answer to use ask_user input only, got %#v", answers)
+	}
+	if transcriptContains(next.transcript, "hidden followup") {
+		t.Fatalf("hidden composer draft leaked into transcript: %#v", next.transcript)
+	}
+}
+
+func TestAskUserRequestClearsStaleSuggestions(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	m.suggestions = []commandSuggestion{{Name: "/model", Desc: "Pick a model."}}
+	m.suggestionIdx = 0
+	m.suggestionsAreFiles = true
+
+	updated, _ := m.Update(askUserRequestMsg{
+		runID: 7,
+		request: agent.AskUserRequest{
+			ToolCallID: "call_1",
+			Questions:  []agent.AskUserQuestion{{Question: "Proceed?"}},
+		},
+		answer: func([]string) {},
+	})
+	next := updated.(model)
+
+	if len(next.suggestions) != 0 || next.suggestionsAreFiles {
+		t.Fatalf("ask_user should clear stale suggestions, got suggestions=%#v files=%v", next.suggestions, next.suggestionsAreFiles)
+	}
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if len(next.suggestions) != 0 || next.suggestionsAreFiles {
+		t.Fatalf("ask_user resolve should keep suggestions clear, got suggestions=%#v files=%v", next.suggestions, next.suggestionsAreFiles)
+	}
+}

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -4,6 +4,8 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/workspaceindex"
 )
 
 // commandSuggestion is one row in the slash-command autocomplete overlay: the
@@ -21,10 +23,16 @@ const maxCommandSuggestions = 8
 // handling: the input is a slash-command fragment, there is at least one match,
 // and no modal (permission / questionnaire) is competing for keys.
 func (m model) suggestionsActive() bool {
-	if m.pendingPermission != nil || m.pendingAskUser != nil {
+	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil {
 		return false
 	}
 	return len(m.suggestions) > 0
+}
+
+func (m *model) clearSuggestions() {
+	m.suggestions = nil
+	m.suggestionIdx = 0
+	m.suggestionsAreFiles = false
 }
 
 // recomputeSuggestions rebuilds the autocomplete match list from the current
@@ -32,9 +40,8 @@ func (m model) suggestionsActive() bool {
 // disappear once the user starts typing arguments. Modals suppress matching
 // entirely. The selected index is preserved when still in range, otherwise reset.
 func (m *model) recomputeSuggestions() {
-	if m.pendingPermission != nil || m.pendingAskUser != nil {
-		m.suggestions = nil
-		m.suggestionIdx = 0
+	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil {
+		m.clearSuggestions()
 		return
 	}
 
@@ -202,8 +209,7 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 		// could be traversed in full on each keystroke and stall the TUI.
 		visited++
 		if d.IsDir() {
-			name := d.Name()
-			if path != cwd && (name == ".git" || name == "node_modules" || name == "vendor" || name == "dist" || strings.HasPrefix(name, ".")) {
+			if path != cwd && workspaceindex.ShouldSkipDir(d.Name()) {
 				return fs.SkipDir
 			}
 			return nil
@@ -215,6 +221,9 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 		// Emit forward-slash paths on every platform (filepath.Rel uses "\" on
 		// Windows) so the inserted "@path" token is portable and matchable.
 		rel = filepath.ToSlash(rel)
+		if workspaceindex.ShouldSkipFile(rel) {
+			return nil
+		}
 		if needle == "" || strings.Contains(strings.ToLower(rel), needle) {
 			out = append(out, commandSuggestion{Name: "@" + rel, Desc: "file"})
 		}

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -203,6 +203,21 @@ func TestSuggestionsSuppressedDuringModals(t *testing.T) {
 	}
 }
 
+func TestSuggestionsSuppressedDuringSpecReview(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.suggestions = []commandSuggestion{{Name: "/model", Desc: "Pick a model."}}
+	m.pendingSpecReview = &pendingSpecReviewPrompt{SpecID: "spec-1", SpecFilePath: ".zero/specs/spec-1.md"}
+
+	if m.suggestionsActive() {
+		t.Fatal("stale suggestions must stay suppressed while spec review is active")
+	}
+
+	m = typeRunes(t, m, "/mo")
+	if m.suggestionsActive() {
+		t.Fatal("new suggestions must stay suppressed while spec review is active")
+	}
+}
+
 func TestSuggestionOverlayRenders(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.width, m.height = 96, 30
@@ -239,6 +254,33 @@ func TestFileSuggestionsMatchesAndSkipsVCSDirs(t *testing.T) {
 	for _, name := range all {
 		if strings.Contains(name, ".git/") || strings.Contains(name, "node_modules/") {
 			t.Fatalf("walk must skip VCS/dependency dirs, got %q", name)
+		}
+	}
+}
+
+func TestFileSuggestionsUseWorkspaceIndexSkipRules(t *testing.T) {
+	root := t.TempDir()
+	mustWrite := func(rel string) {
+		t.Helper()
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("internal/keep.go")
+	mustWrite("build/generated.go") // workspaceindex.ShouldSkipDir skips build
+	mustWrite("assets/logo.png")    // workspaceindex.ShouldSkipFile skips binary assets
+
+	got := suggestionTokens(fileSuggestions(root, ""))
+	if !contains(got, "@internal/keep.go") {
+		t.Fatalf("expected normal source file in suggestions, got %v", got)
+	}
+	for _, skipped := range []string{"@build/generated.go", "@assets/logo.png"} {
+		if contains(got, skipped) {
+			t.Fatalf("file suggestions must use workspaceindex skip rules; found %s in %v", skipped, got)
 		}
 	}
 }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -31,6 +31,7 @@ const (
 	commandStyle
 	commandTheme
 	commandInputStyle
+	commandTranscript
 	commandBash
 	commandImage
 	commandUnknown
@@ -154,6 +155,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Show or request transcript compaction state.",
 		kind:        commandCompact,
+	},
+	{
+		name:        "/transcript",
+		usage:       "/transcript",
+		group:       commandGroupSession,
+		description: "Toggle the detailed transcript view.",
+		kind:        commandTranscript,
 	},
 	{
 		name:        "/rewind",

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -1,0 +1,249 @@
+package tui
+
+import (
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type composerState struct {
+	text   string
+	cursor int
+}
+
+func insertComposerText(state composerState, text string) composerState {
+	state = normalizeComposerState(state)
+	if text == "" {
+		return state
+	}
+	runes := []rune(state.text)
+	insert := []rune(text)
+	out := make([]rune, 0, len(runes)+len(insert))
+	out = append(out, runes[:state.cursor]...)
+	out = append(out, insert...)
+	out = append(out, runes[state.cursor:]...)
+	return composerState{text: string(out), cursor: state.cursor + len(insert)}
+}
+
+func deleteComposerWordBefore(state composerState) composerState {
+	state = normalizeComposerState(state)
+	if state.cursor == 0 {
+		return state
+	}
+	runes := []rune(state.text)
+	start := state.cursor
+	for start > 0 && !unicode.IsSpace(runes[start-1]) {
+		start--
+	}
+	return deleteComposerRange(state, start, state.cursor)
+}
+
+func deleteComposerWordAfter(state composerState) composerState {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	if state.cursor >= len(runes) {
+		return state
+	}
+	end := state.cursor
+	for end < len(runes) && unicode.IsSpace(runes[end]) {
+		end++
+	}
+	for end < len(runes) && !unicode.IsSpace(runes[end]) {
+		end++
+	}
+	for end < len(runes) && runes[end] != '\n' && unicode.IsSpace(runes[end]) {
+		end++
+	}
+	return deleteComposerRange(state, state.cursor, end)
+}
+
+func deleteComposerLineBefore(state composerState) composerState {
+	state = normalizeComposerState(state)
+	return deleteComposerRange(state, composerLineStart(state), state.cursor)
+}
+
+func deleteComposerLineAfter(state composerState) composerState {
+	state = normalizeComposerState(state)
+	return deleteComposerRange(state, state.cursor, composerLineEnd(state))
+}
+
+func sanitizeComposerPaste(text string) string {
+	var out strings.Builder
+	runes := []rune(text)
+	for i := 0; i < len(runes); i++ {
+		switch r := runes[i]; r {
+		case '\r':
+			out.WriteRune('\n')
+			if i+1 < len(runes) && runes[i+1] == '\n' {
+				i++
+			}
+		case '\n':
+			out.WriteRune('\n')
+		case '\t':
+			out.WriteString("    ")
+		default:
+			if !unicode.IsControl(r) {
+				out.WriteRune(r)
+			}
+		}
+	}
+	return out.String()
+}
+
+func sanitizeComposerInput(text string) string {
+	return sanitizeComposerPaste(strings.ReplaceAll(text, "\n", ""))
+}
+
+func (m model) composerValue() string {
+	if m.composerActive {
+		return m.composer.text
+	}
+	return m.input.Value()
+}
+
+func (m model) currentComposerState() composerState {
+	if m.composerActive {
+		return normalizeComposerState(m.composer)
+	}
+	return composerState{text: m.input.Value(), cursor: m.input.Position()}
+}
+
+func (m *model) setComposerState(state composerState) {
+	m.composer = normalizeComposerState(state)
+	m.composerActive = true
+	m.syncInputFromComposer()
+}
+
+func (m *model) clearComposer() {
+	m.composer = composerState{}
+	m.composerActive = false
+	m.input.SetValue("")
+}
+
+func (m *model) resetComposerFromInput() {
+	m.composer = composerState{}
+	m.composerActive = false
+}
+
+func (m *model) syncInputFromComposer() {
+	display := strings.ReplaceAll(m.composer.text, "\n", " ")
+	m.input.SetValue(display)
+	m.input.SetCursor(composerDisplayCursor(m.composer))
+}
+
+func composerDisplayCursor(state composerState) int {
+	state = normalizeComposerState(state)
+	return len([]rune(strings.ReplaceAll(string([]rune(state.text)[:state.cursor]), "\n", " ")))
+}
+
+func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
+	state := m.currentComposerState()
+	switch {
+	case msg.Type == tea.KeyEnter && msg.Alt:
+		m.setComposerState(insertComposerText(state, "\n"))
+	case msg.Type == tea.KeyCtrlJ:
+		m.setComposerState(insertComposerText(state, "\n"))
+	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "d":
+		m.setComposerState(deleteComposerWordAfter(state))
+	case msg.Type == tea.KeySpace:
+		m.setComposerState(insertComposerText(state, " "))
+	case msg.Type == tea.KeyRunes && !msg.Alt:
+		text := string(msg.Runes)
+		if msg.Paste {
+			text = sanitizeComposerPaste(text)
+		} else {
+			text = sanitizeComposerInput(text)
+		}
+		m.setComposerState(insertComposerText(state, text))
+	case msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlB:
+		state.cursor--
+		m.setComposerState(state)
+	case msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlF:
+		state.cursor++
+		m.setComposerState(state)
+	case msg.Type == tea.KeyHome || msg.Type == tea.KeyCtrlA:
+		state.cursor = composerLineStart(state)
+		m.setComposerState(state)
+	case msg.Type == tea.KeyEnd || msg.Type == tea.KeyCtrlE:
+		state.cursor = composerLineEnd(state)
+		m.setComposerState(state)
+	case msg.Type == tea.KeyCtrlU:
+		m.setComposerState(deleteComposerLineBefore(state))
+	case msg.Type == tea.KeyCtrlK:
+		m.setComposerState(deleteComposerLineAfter(state))
+	case msg.Type == tea.KeyCtrlW || (msg.Alt && (msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH)):
+		m.setComposerState(deleteComposerWordBefore(state))
+	case msg.Alt && msg.Type == tea.KeyDelete:
+		m.setComposerState(deleteComposerWordAfter(state))
+	case msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH:
+		m.setComposerState(deleteComposerRange(state, state.cursor-1, state.cursor))
+	case msg.Type == tea.KeyDelete || msg.Type == tea.KeyCtrlD:
+		m.setComposerState(deleteComposerRange(state, state.cursor, state.cursor+1))
+	default:
+		return m, false
+	}
+
+	if strings.Contains(m.composer.text, "\n") {
+		m.clearSuggestions()
+	} else {
+		m.recomputeSuggestions()
+	}
+	return m, true
+}
+
+func renderComposerState(state composerState, prompt string, width int) string {
+	state = normalizeComposerState(state)
+	lines := strings.Split(state.text, "\n")
+	for index, line := range lines {
+		prefix := "  "
+		if index == 0 {
+			prefix = prompt
+		}
+		lines[index] = fitStyledLine(prefix+line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func deleteComposerRange(state composerState, start int, end int) composerState {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	start = clamp(start, 0, len(runes))
+	end = clamp(end, 0, len(runes))
+	if end < start {
+		start, end = end, start
+	}
+	if start == end {
+		return state
+	}
+	out := make([]rune, 0, len(runes)-(end-start))
+	out = append(out, runes[:start]...)
+	out = append(out, runes[end:]...)
+	return composerState{text: string(out), cursor: start}
+}
+
+func normalizeComposerState(state composerState) composerState {
+	runes := []rune(state.text)
+	state.cursor = clamp(state.cursor, 0, len(runes))
+	return state
+}
+
+func composerLineStart(state composerState) int {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	pos := state.cursor
+	for pos > 0 && runes[pos-1] != '\n' {
+		pos--
+	}
+	return pos
+}
+
+func composerLineEnd(state composerState) int {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	pos := state.cursor
+	for pos < len(runes) && runes[pos] != '\n' {
+		pos++
+	}
+	return pos
+}

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -134,7 +134,11 @@ func (m *model) syncInputFromComposer() {
 
 func composerDisplayCursor(state composerState) int {
 	state = normalizeComposerState(state)
-	return len([]rune(strings.ReplaceAll(string([]rune(state.text)[:state.cursor]), "\n", " ")))
+	count := 0
+	for range []rune(state.text)[:state.cursor] {
+		count++
+	}
+	return count
 }
 
 func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -65,7 +66,7 @@ func TestModifiedEnterInsertsNewlineWithoutSubmitting(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newModel(nil, Options{Provider: &fakeProvider{}, ProviderName: "test", ModelName: "test-model"})
+			m := newModel(context.Background(), Options{Provider: &fakeProvider{}, ProviderName: "test", ModelName: "test-model"})
 			m.input.SetValue("first")
 			m.input.CursorEnd()
 
@@ -86,7 +87,7 @@ func TestModifiedEnterInsertsNewlineWithoutSubmitting(t *testing.T) {
 }
 
 func TestMultilineComposerEditingDoesNotFallBackToFlatInput(t *testing.T) {
-	m := newModel(nil, Options{})
+	m := newModel(context.Background(), Options{})
 	m.setComposerState(composerState{text: "alpha\nbeta gamma", cursor: len([]rune("alpha\nbeta"))})
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
@@ -109,7 +110,7 @@ func TestMultilineComposerEditingDoesNotFallBackToFlatInput(t *testing.T) {
 }
 
 func TestMultilineComposerAcceptsSpaceKey(t *testing.T) {
-	m := newModel(nil, Options{})
+	m := newModel(context.Background(), Options{})
 	m.setComposerState(composerState{text: "alpha\nbetagamma", cursor: len([]rune("alpha\nbeta"))})
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestComposerInsertNewlineAtCursor(t *testing.T) {
+	state := composerState{text: "helloworld", cursor: 5}
+
+	got := insertComposerText(state, "\n")
+
+	if got.text != "hello\nworld" {
+		t.Fatalf("text = %q, want %q", got.text, "hello\nworld")
+	}
+	if got.cursor != len([]rune("hello\n")) {
+		t.Fatalf("cursor = %d, want %d", got.cursor, len([]rune("hello\n")))
+	}
+}
+
+func TestComposerDeleteWordBeforeCursor(t *testing.T) {
+	state := composerState{text: "alpha beta  gamma", cursor: len([]rune("alpha beta  gamma"))}
+
+	got := deleteComposerWordBefore(state)
+
+	if got.text != "alpha beta  " {
+		t.Fatalf("text = %q, want %q", got.text, "alpha beta  ")
+	}
+	if got.cursor != len([]rune("alpha beta  ")) {
+		t.Fatalf("cursor = %d, want %d", got.cursor, len([]rune("alpha beta  ")))
+	}
+}
+
+func TestComposerDeleteWordAfterCursor(t *testing.T) {
+	state := composerState{text: "alpha  beta gamma", cursor: len([]rune("alpha  "))}
+
+	got := deleteComposerWordAfter(state)
+
+	if got.text != "alpha  gamma" {
+		t.Fatalf("text = %q, want %q", got.text, "alpha  gamma")
+	}
+	if got.cursor != len([]rune("alpha  ")) {
+		t.Fatalf("cursor = %d, want %d", got.cursor, len([]rune("alpha  ")))
+	}
+}
+
+func TestSanitizeComposerPastePreservesNewlines(t *testing.T) {
+	got := sanitizeComposerPaste("alpha\tbeta\x00\nsecond\r\nthird\x1b[31m")
+	want := "alpha    beta\nsecond\nthird[31m"
+
+	if got != want {
+		t.Fatalf("sanitized paste = %q, want %q", got, want)
+	}
+}
+
+func TestModifiedEnterInsertsNewlineWithoutSubmitting(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "alt enter", key: tea.KeyMsg{Type: tea.KeyEnter, Alt: true}},
+		{name: "shift enter", key: tea.KeyMsg{Type: tea.KeyCtrlJ}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newModel(nil, Options{Provider: &fakeProvider{}, ProviderName: "test", ModelName: "test-model"})
+			m.input.SetValue("first")
+			m.input.CursorEnd()
+
+			updated, cmd := m.Update(tc.key)
+			next := updated.(model)
+
+			if cmd != nil {
+				t.Fatal("modified Enter should not launch a run")
+			}
+			if next.pending {
+				t.Fatal("modified Enter should leave the model idle")
+			}
+			if got := next.composerValue(); got != "first\n" {
+				t.Fatalf("input = %q, want %q", got, "first\n")
+			}
+		})
+	}
+}
+
+func TestMultilineComposerEditingDoesNotFallBackToFlatInput(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.setComposerState(composerState{text: "alpha\nbeta gamma", cursor: len([]rune("alpha\nbeta"))})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	next := updated.(model)
+	if got := next.composerValue(); got != "alpha\n gamma" {
+		t.Fatalf("ctrl+u composer value = %q, want current line prefix removed", got)
+	}
+	if !next.composerActive {
+		t.Fatal("ctrl+u should keep multiline composer state active")
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyCtrlK})
+	next = updated.(model)
+	if got := next.composerValue(); got != "alpha\n" {
+		t.Fatalf("ctrl+k composer value = %q, want current line suffix removed", got)
+	}
+	if !next.composerActive {
+		t.Fatal("ctrl+k should keep multiline composer state active")
+	}
+}
+
+func TestMultilineComposerAcceptsSpaceKey(t *testing.T) {
+	m := newModel(nil, Options{})
+	m.setComposerState(composerState{text: "alpha\nbetagamma", cursor: len([]rune("alpha\nbeta"))})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next := updated.(model)
+
+	if got := next.composerValue(); got != "alpha\nbeta gamma" {
+		t.Fatalf("composer value = %q, want space inserted in multiline state", got)
+	}
+	if !next.composerActive {
+		t.Fatal("space insertion should keep multiline composer state active")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -52,16 +52,20 @@ type model struct {
 	unpricedRequests   int
 	unpricedTokens     int
 	transcript         []transcriptRow
+	transcriptDetailed bool
 	input              textinput.Model
+	composer           composerState
+	composerActive     bool
 	// spinner animates the running-tool glyph in card heads. Its tick is started
 	// with each run and stops itself once pending clears (the TickMsg is simply
 	// not forwarded), so an idle UI schedules no timers.
-	spinner     spinner.Model
-	pending     bool
-	exiting     bool
-	runCancel   context.CancelFunc
-	runID       int
-	activeRunID int
+	spinner       spinner.Model
+	pending       bool
+	queuedMessage string
+	exiting       bool
+	runCancel     context.CancelFunc
+	runID         int
+	activeRunID   int
 	// flushRunIDs holds the ids of runs cancelled while still in flight, mapped
 	// to the session they were recording into AT CANCEL TIME. Each cancelled
 	// agent goroutine keeps running to completion and returns its accumulated
@@ -354,7 +358,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			return m, tea.Quit
+		case tea.KeyCtrlO:
+			return m.toggleDetailedTranscript(), nil
 		case tea.KeyEsc:
+			if m.transcriptDetailed {
+				m.transcriptDetailed = false
+				return m, nil
+			}
 			// An active questionnaire is cancelled (not the whole run): deliver
 			// whatever answers were collected so the agent loop unblocks and
 			// degrades to its best-assumption path.
@@ -373,14 +383,23 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.suggestionsActive() {
 				return m.dismissSuggestions(), nil
 			}
-			m.input.SetValue("")
-			m.suggestions = nil
-			m.suggestionIdx = 0
+			if m.hasQueuedMessage() {
+				return m.clearQueuedMessage(), nil
+			}
+			m.clearComposer()
+			m.clearSuggestions()
 			if m.pending {
 				m.cancelRun()
 			}
 			return m, nil
 		case tea.KeyEnter:
+			if m.transcriptDetailed {
+				if command := parseCommand(m.input.Value()); command.kind == commandTranscript {
+					m.input.SetValue("")
+					return m.toggleDetailedTranscript(), nil
+				}
+				return m, nil
+			}
 			if m.pendingPermission != nil {
 				return m, nil
 			}
@@ -393,13 +412,23 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.picker != nil {
 				return m.choosePicker()
 			}
+			if msg.Alt {
+				if next, ok := m.applyComposerKey(msg); ok {
+					return next, nil
+				}
+			}
 			// Enter on a highlighted suggestion completes the input rather than
 			// submitting; Enter with no active suggestion submits as today.
 			if m.suggestionsActive() {
-				return m.completeSuggestion(), nil
+				next := m.completeSuggestion()
+				next.resetComposerFromInput()
+				return next, nil
 			}
 			return m.handleSubmit()
 		case tea.KeyShiftTab:
+			if m.transcriptDetailed {
+				return m, nil
+			}
 			// shift+tab toggles the permission mode between Auto and Ask (Unsafe
 			// is intentionally not reachable by a casual keypress — see
 			// nextPermissionMode), but only when nothing modal is up: a permission
@@ -410,11 +439,17 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case tea.KeyTab:
+			if m.transcriptDetailed {
+				return m, nil
+			}
 			if m.picker == nil && m.suggestionsActive() {
 				m.moveSuggestion(1)
 				return m, nil
 			}
 		case tea.KeyDown:
+			if m.transcriptDetailed {
+				return m, nil
+			}
 			if m.picker != nil {
 				m.picker.move(1)
 				return m, nil
@@ -427,6 +462,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.recallHistory(1), nil
 			}
 		case tea.KeyUp:
+			if m.transcriptDetailed {
+				return m, nil
+			}
 			if m.picker != nil {
 				m.picker.move(-1)
 				return m, nil
@@ -438,6 +476,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.historyRecallActive() {
 				return m.recallHistory(-1), nil
 			}
+		}
+		if m.transcriptDetailed {
+			return m, nil
 		}
 		if m.pendingAskUser != nil {
 			// While a questionnaire is active, all other keys feed the text input
@@ -461,19 +502,27 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// inserts the matching starter suggestion instead of typing the digit.
 		// !pending mirrors the render condition exactly — the chips are off
 		// screen during a run (e.g. after /clear mid-run), so digits must type.
-		if m.transcriptEmpty() && !m.pending && strings.TrimSpace(m.input.Value()) == "" {
+		if m.transcriptEmpty() && !m.pending && strings.TrimSpace(m.composerValue()) == "" {
 			if k := msg.String(); len(k) == 1 && k >= "1" && k <= "3" {
 				if index := int(k[0] - '1'); index < len(emptyStateSuggestions) {
 					m.input.SetValue(emptyStateSuggestions[index])
 					m.input.CursorEnd()
+					m.resetComposerFromInput()
 					return m, nil
 				}
 			}
+		}
+		if next, ok := m.applyComposerKey(msg); ok {
+			return next, nil
+		}
+		if m.composerActive && strings.Contains(m.composer.text, "\n") {
+			return m, nil
 		}
 		// The key fell through to the text input: let it update, then refresh the
 		// autocomplete match list from the new value.
 		var cmd tea.Cmd
 		m.input, cmd = m.input.Update(msg)
+		m.resetComposerFromInput()
 		m.recomputeSuggestions()
 		return m, cmd
 	case tea.FocusMsg:
@@ -550,7 +599,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			answer:  msg.answer,
 			answers: make([]string, 0, len(msg.request.Questions)),
 		}
-		m.input.SetValue("")
+		m.clearComposer()
+		m.clearSuggestions()
 		return m, nil
 	case agentResponseMsg:
 		if msg.runID != m.activeRunID {
@@ -648,7 +698,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.notifier != nil {
 			m.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
 		}
-		return m, nil
+		return m.launchQueuedMessageIfReady()
 	case agentRowMsg:
 		if msg.runID != m.activeRunID {
 			return m, nil
@@ -676,6 +726,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
+	if m.transcriptDetailed {
+		return m.detailedTranscriptView()
+	}
 	return m.transcriptView()
 }
 
@@ -757,6 +810,10 @@ func (m model) transcriptView() string {
 	builder.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
 	builder.WriteString("\n")
 	builder.WriteString(m.composerLine(width))
+	if queued := renderQueuedMessagePreview(m.queuedMessage, width); queued != "" {
+		builder.WriteString("\n")
+		builder.WriteString(queued)
+	}
 	if overlay := m.suggestionOverlay(width); overlay != "" {
 		builder.WriteString("\n")
 		builder.WriteString(overlay)
@@ -803,8 +860,17 @@ func (m model) composerLine(width int) string {
 	switch {
 	case m.pending:
 		hint = zeroTheme.faint.Render("esc stop")
-	case strings.TrimSpace(m.input.Value()) != "":
+	case strings.TrimSpace(m.composerValue()) != "":
 		hint = zeroTheme.faint.Render("run ↵")
+	}
+	if m.composerActive && strings.Contains(m.composer.text, "\n") {
+		line := renderComposerState(m.composer, m.input.Prompt, width)
+		if hint == "" {
+			return line
+		}
+		lines := strings.Split(line, "\n")
+		lines[len(lines)-1] = joinHeaderLine(fitStyledLine(lines[len(lines)-1], width-lipgloss.Width(hint)-2), hint, width)
+		return strings.Join(lines, "\n")
 	}
 	line := input.View()
 	if hint == "" {
@@ -889,6 +955,7 @@ func (m model) resolveAskUser(cancelled bool) (tea.Model, tea.Cmd) {
 		pending.answer(answers)
 	}
 	m.pendingAskUser = nil
+	m.clearSuggestions()
 	return m, nil
 }
 
@@ -937,17 +1004,20 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleSubmit() (tea.Model, tea.Cmd) {
-	command := parseCommand(m.input.Value())
+	input := m.composerValue()
+	command := parseCommand(input)
 	// While exiting (Ctrl+C waiting on the cancelled run's checkpoint flush) a
 	// new run must not start: the deferred tea.Quit would abort it mid-flight
 	// and orphan its checkpoint blobs — the exact loss flushRunIDs prevents.
-	if command.kind == commandPrompt && (m.pending || m.exiting) {
+	if command.kind == commandPrompt && m.exiting {
 		return m, nil
 	}
-	m.rememberInput(m.input.Value())
-	m.input.SetValue("")
-	m.suggestions = nil
-	m.suggestionIdx = 0
+	if command.kind == commandPrompt && m.pending {
+		return m.queueMessage(command.text), nil
+	}
+	m.rememberInput(input)
+	m.clearComposer()
+	m.clearSuggestions()
 
 	switch command.kind {
 	case commandEmpty:
@@ -1056,6 +1126,8 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m, text = m.handleCompactCommand(command.text)
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
+	case commandTranscript:
+		return m.toggleDetailedTranscript(), nil
 	case commandRewind:
 		text := ""
 		m, text = m.handleRewindCommand(command.text)
@@ -1122,64 +1194,80 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "$ " + cmdText})
 		return m, runBashEscape(m.cwd, cmdText)
 	case commandPrompt:
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendUser, text: command.text})
-		if m.provider == nil {
-			m.transcript = reduceTranscript(m.transcript, transcriptAction{
-				kind: actionAppendAssistant,
-				text: "No provider configured.",
-			})
-			return m, nil
-		}
-		var err error
-		m, err = m.ensureActiveSession(command.text)
-		if err != nil {
-			m.transcript = reduceTranscript(m.transcript, transcriptAction{
-				kind: actionAppendError,
-				text: "session create error: " + err.Error(),
-			})
-		} else {
-			agentPrompt := m.sessionPrompt(command.text)
-			m, err = m.appendSessionEvent(sessions.EventMessage, map[string]any{
-				"role":    "user",
-				"content": command.text,
-			})
-			if err != nil {
-				m.transcript = reduceTranscript(m.transcript, transcriptAction{
-					kind: actionAppendError,
-					text: "session record error: " + err.Error(),
-				})
-			}
-			command.text = agentPrompt
-		}
-		// Re-check vision support against the CURRENT effective model at submit
-		// time, not just at /image attach time: the user may have attached on a
-		// vision model and then /model-switched to a non-vision one. If the active
-		// model can't accept images, drop them (with an inline notice mirroring
-		// exec's drop+warn wording) rather than sending them to a model that
-		// rejects them. Pending state is cleared either way below.
-		turnImages := m.pendingImages
-		if len(turnImages) > 0 && !modelSupportsVisionTUI(m.modelName) {
-			name := m.modelName
-			if name == "" {
-				name = "the active model"
-			}
-			m.transcript = reduceTranscript(m.transcript, transcriptAction{
-				kind: actionAppendSystem,
-				text: fmt.Sprintf("Model %s does not support image input; ignoring %d image(s).", name, len(turnImages)),
-			})
-			turnImages = nil
-		}
-		m.pendingImages = nil
-		m.pendingImageLabels = nil
-		runCtx, cancel := context.WithCancel(m.ctx)
-		m.runID++
-		m.activeRunID = m.runID
-		m.runCancel = cancel
-		m.pending = true
-		return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, command.text, turnImages), m.spinner.Tick)
+		return m.launchPrompt(command.text)
 	default:
 		return m, nil
 	}
+}
+
+// launchPrompt starts a normal agent turn from text already accepted by the
+// composer. Queued prompts use this path too, so session and image behavior
+// stays identical to immediate submissions.
+func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendUser, text: prompt})
+	if m.provider == nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendAssistant,
+			text: "No provider configured.",
+		})
+		return m, nil
+	}
+	var err error
+	m, err = m.ensureActiveSession(prompt)
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendError,
+			text: "session create error: " + err.Error(),
+		})
+	} else {
+		agentPrompt := m.sessionPrompt(prompt)
+		m, err = m.appendSessionEvent(sessions.EventMessage, map[string]any{
+			"role":    "user",
+			"content": prompt,
+		})
+		if err != nil {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{
+				kind: actionAppendError,
+				text: "session record error: " + err.Error(),
+			})
+		}
+		prompt = agentPrompt
+	}
+	// Re-check vision support against the CURRENT effective model at submit
+	// time, not just at /image attach time: the user may have attached on a
+	// vision model and then /model-switched to a non-vision one. If the active
+	// model can't accept images, drop them (with an inline notice mirroring
+	// exec's drop+warn wording) rather than sending them to a model that
+	// rejects them. Pending state is cleared either way below.
+	turnImages := m.pendingImages
+	if len(turnImages) > 0 && !modelSupportsVisionTUI(m.modelName) {
+		name := m.modelName
+		if name == "" {
+			name = "the active model"
+		}
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendSystem,
+			text: fmt.Sprintf("Model %s does not support image input; ignoring %d image(s).", name, len(turnImages)),
+		})
+		turnImages = nil
+	}
+	m.pendingImages = nil
+	m.pendingImageLabels = nil
+	runCtx, cancel := context.WithCancel(m.ctx)
+	m.runID++
+	m.activeRunID = m.runID
+	m.runCancel = cancel
+	m.pending = true
+	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, turnImages), m.spinner.Tick)
+}
+
+func (m model) launchQueuedMessageIfReady() (model, tea.Cmd) {
+	if !m.hasQueuedMessage() || m.pending || m.exiting || m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil {
+		return m, nil
+	}
+	prompt := m.queuedMessage
+	m.queuedMessage = ""
+	return m.launchPrompt(prompt)
 }
 
 // historyRecallActive reports whether ↑/↓ should navigate previously submitted
@@ -1197,7 +1285,7 @@ func (m model) recallHistory(direction int) model {
 		if direction > 0 {
 			return m
 		}
-		m.historyDraft = m.input.Value()
+		m.historyDraft = m.composerValue()
 	}
 	next := clamp(m.historyIdx+direction, 0, len(m.inputHistory))
 	if next == m.historyIdx {
@@ -1210,6 +1298,7 @@ func (m model) recallHistory(direction int) model {
 		m.input.SetValue(m.inputHistory[next])
 	}
 	m.input.CursorEnd()
+	m.resetComposerFromInput()
 	m.recomputeSuggestions()
 	return m
 }

--- a/internal/tui/queued_message.go
+++ b/internal/tui/queued_message.go
@@ -1,0 +1,33 @@
+package tui
+
+import "strings"
+
+func (m model) queueMessage(text string) model {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return m
+	}
+	m.queuedMessage = text
+	m.rememberInput(text)
+	m.clearComposer()
+	m.clearSuggestions()
+	return m
+}
+
+func (m model) clearQueuedMessage() model {
+	m.queuedMessage = ""
+	return m
+}
+
+func (m model) hasQueuedMessage() bool {
+	return strings.TrimSpace(m.queuedMessage) != ""
+}
+
+func renderQueuedMessagePreview(message string, width int) string {
+	message = strings.Join(strings.Fields(message), " ")
+	if message == "" {
+		return ""
+	}
+	line := zeroTheme.accent.Render("[queued]") + " " + zeroTheme.muted.Render(message)
+	return fitStyledLine(line, width)
+}

--- a/internal/tui/queued_message_test.go
+++ b/internal/tui/queued_message_test.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestEnterWhilePendingQueuesPromptWithoutStartingRun(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.input.SetValue("second prompt")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected queued prompt not to start another run immediately")
+	}
+	if !next.pending {
+		t.Fatal("expected existing run to remain pending")
+	}
+	if got := next.input.Value(); got != "" {
+		t.Fatalf("expected queued prompt to clear composer, got %q", got)
+	}
+	if transcriptContains(next.transcript, "second prompt") {
+		t.Fatalf("queued prompt should not append to transcript before it runs, got %#v", next.transcript)
+	}
+}
+
+func TestQueuedPromptPreviewAppearsInView(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.width = 96
+	m.input.SetValue("summarize the failing test output")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	view := next.View()
+	for _, want := range []string{"queued", "summarize the failing test output"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected queued prompt preview to contain %q, got:\n%s", want, view)
+		}
+	}
+}
+
+func TestAgentResponseLaunchesQueuedPrompt(t *testing.T) {
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "queued answer"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	m := newQueuedMessageTestModel(t)
+	m.provider = provider
+	m.pending = true
+	m.activeRunID = 7
+	m.runID = 7
+	m.input.SetValue("run queued followup")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected queued prompt not to launch until active run completes")
+	}
+
+	updated, cmd = next.Update(agentResponseMsg{runID: 7})
+	next = updated.(model)
+
+	if cmd == nil {
+		t.Fatal("expected queued prompt to launch after active run completes")
+	}
+	if !next.pending {
+		t.Fatal("expected queued prompt launch to mark model pending")
+	}
+	_ = execCmd(cmd)
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected queued prompt to make one provider request, got %d", len(provider.requests))
+	}
+	messages := provider.requests[0].Messages
+	if len(messages) == 0 || !strings.Contains(messages[len(messages)-1].Content, "run queued followup") {
+		t.Fatalf("expected provider request to contain queued prompt, got %#v", messages)
+	}
+}
+
+func TestEscClearsQueuedPromptBeforeCancelingRun(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	cancelled := false
+	m.pending = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.runCancel = func() { cancelled = true }
+	m.width = 96
+	m.input.SetValue("queued followup")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	next = updated.(model)
+
+	if cancelled {
+		t.Fatal("expected Esc to clear queued prompt before canceling the active run")
+	}
+	if !next.pending {
+		t.Fatal("expected active run to remain pending after clearing queued prompt")
+	}
+	if strings.Contains(next.View(), "queued followup") {
+		t.Fatalf("expected queued prompt preview to clear, got:\n%s", next.View())
+	}
+	if transcriptContains(next.transcript, "Run cancelled.") {
+		t.Fatalf("expected Esc not to cancel run while clearing queued prompt, got %#v", next.transcript)
+	}
+}
+
+func TestEnterWhileExitingDoesNotQueuePrompt(t *testing.T) {
+	m := newQueuedMessageTestModel(t)
+	m.pending = true
+	m.exiting = true
+	m.activeRunID = 1
+	m.runID = 1
+	m.input.SetValue("do not run during shutdown")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected submit during deferred exit to stay idle")
+	}
+	if next.hasQueuedMessage() {
+		t.Fatalf("expected no queued prompt while exiting, got %q", next.queuedMessage)
+	}
+	if got := next.input.Value(); got != "do not run during shutdown" {
+		t.Fatalf("expected composer to remain untouched, got %q", got)
+	}
+}
+
+func TestAgentResponseLaunchesQueuedPromptAfterError(t *testing.T) {
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventText, Content: "queued answer"},
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	m := newQueuedMessageTestModel(t)
+	m.provider = provider
+	m.pending = true
+	m.activeRunID = 9
+	m.runID = 9
+	m.input.SetValue("retry with more detail")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	updated, cmd := next.Update(agentResponseMsg{runID: 9, err: errors.New("first run failed")})
+
+	if cmd == nil {
+		t.Fatal("expected queued prompt to launch after active run errors")
+	}
+	next = updated.(model)
+	if !next.pending {
+		t.Fatal("expected queued prompt launch after error to mark model pending")
+	}
+}
+
+func newQueuedMessageTestModel(t *testing.T) model {
+	t.Helper()
+
+	return newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider: &fakeProvider{events: []zeroruntime.StreamEvent{
+			{Type: zeroruntime.StreamEventDone},
+		}},
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
+	})
+}

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -1,0 +1,215 @@
+package tui
+
+import (
+	"container/list"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+const (
+	defaultRenderCacheMaxEntries    = 256
+	defaultRenderCacheMaxCharacters = 512 * 1024
+)
+
+var defaultRenderCache = newStaticRenderCache(defaultRenderCacheMaxEntries, defaultRenderCacheMaxCharacters)
+
+type renderCacheStats struct {
+	Hits             int
+	Misses           int
+	Evictions        int
+	SkippedOversized int
+}
+
+type staticRenderCache struct {
+	mu            sync.Mutex
+	maxEntries    int
+	maxCharacters int
+	retained      int
+	items         map[string]*list.Element
+	lru           *list.List
+	statsData     renderCacheStats
+}
+
+type staticRenderCacheEntry struct {
+	key   string
+	value string
+	chars int
+}
+
+func newStaticRenderCache(maxEntries int, maxCharacters int) *staticRenderCache {
+	return &staticRenderCache{
+		maxEntries:    maxEntries,
+		maxCharacters: maxCharacters,
+		items:         map[string]*list.Element{},
+		lru:           list.New(),
+	}
+}
+
+func (c *staticRenderCache) render(key string, stable bool, render func() string) string {
+	if render == nil {
+		return ""
+	}
+	if c == nil || !stable || key == "" {
+		return render()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if element, ok := c.items[key]; ok {
+		c.statsData.Hits++
+		c.lru.MoveToFront(element)
+		return element.Value.(*staticRenderCacheEntry).value
+	}
+
+	c.statsData.Misses++
+	value := render()
+	chars := utf8.RuneCountInString(value)
+	if c.maxEntries <= 0 || c.maxCharacters <= 0 || chars > c.maxCharacters {
+		c.statsData.SkippedOversized++
+		return value
+	}
+
+	entry := &staticRenderCacheEntry{key: key, value: value, chars: chars}
+	c.items[key] = c.lru.PushFront(entry)
+	c.retained += chars
+	c.evictOverflow()
+	return value
+}
+
+func (c *staticRenderCache) evictOverflow() {
+	for len(c.items) > c.maxEntries || c.retained > c.maxCharacters {
+		element := c.lru.Back()
+		if element == nil {
+			c.retained = 0
+			return
+		}
+		entry := element.Value.(*staticRenderCacheEntry)
+		delete(c.items, entry.key)
+		c.lru.Remove(element)
+		c.retained -= entry.chars
+		c.statsData.Evictions++
+	}
+}
+
+func (c *staticRenderCache) stats() renderCacheStats {
+	if c == nil {
+		return renderCacheStats{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.statsData
+}
+
+func (c *staticRenderCache) retainedCharacters() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.retained
+}
+
+func (m model) renderRowCacheKey(row transcriptRow, width int, rc rowContext, opts cardRenderOptions, flush bool) (string, bool) {
+	stable := true
+	switch row.kind {
+	case rowWelcome:
+		return "", false
+	case rowToolCall:
+		if m.pending && row.runID != 0 && row.runID == m.activeRunID {
+			stable = false
+		}
+	case rowPermission:
+		event := row.permission
+		if event != nil && event.ToolCallID != "" && event.Action == agent.PermissionActionPrompt &&
+			!rc.decided[rcKey(row.runID, event.ToolCallID)] &&
+			m.pending && row.runID != 0 && row.runID == m.activeRunID {
+			stable = false
+		}
+	}
+
+	var b strings.Builder
+	appendRenderCacheField(&b, "render-row-v1")
+	appendRenderCacheField(&b, strconv.Itoa(width))
+	appendRenderCacheField(&b, strconv.FormatBool(flush))
+	appendRenderCacheField(&b, strconv.Itoa(opts.bodyCap))
+	appendRenderCacheField(&b, opts.cwd)
+	appendRenderCacheField(&b, strconv.Itoa(int(row.kind)))
+	appendRenderCacheField(&b, row.id)
+	appendRenderCacheField(&b, row.text)
+	appendRenderCacheField(&b, row.tool)
+	appendRenderCacheField(&b, fmt.Sprint(row.status))
+	appendRenderCacheField(&b, row.detail)
+	appendRenderCacheField(&b, row.arg)
+	appendRenderCacheField(&b, strconv.Itoa(row.runID))
+	appendRenderCacheField(&b, strconv.FormatBool(row.final))
+	appendRenderCacheField(&b, strconv.Itoa(row.turnTools))
+	appendRenderCacheField(&b, strconv.FormatInt(int64(row.turnElapsed), 10))
+
+	key := rcKey(row.runID, row.id)
+	appendRenderCacheField(&b, rc.hints[key])
+	appendRenderCacheField(&b, rc.args[key])
+	appendRenderCacheField(&b, strconv.FormatBool(rc.auto[key]))
+	appendRenderCacheField(&b, permissionCacheFingerprint(row.permission))
+	appendRenderCacheField(&b, askUserCacheFingerprint(row.askUser))
+	return b.String(), stable
+}
+
+func appendRenderCacheField(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte('|')
+}
+
+func permissionCacheFingerprint(event *agent.PermissionEvent) string {
+	if event == nil {
+		return ""
+	}
+	fields := []string{
+		event.ToolCallID,
+		event.ToolName,
+		string(event.Action),
+		event.Permission,
+		string(event.PermissionMode),
+		event.Autonomy,
+		event.SideEffect,
+		event.Reason,
+		string(event.Risk.Level),
+		strconv.FormatBool(event.GrantMatched),
+		strconv.FormatBool(event.Grant != nil),
+	}
+	if event.Violation != nil {
+		fields = append(fields,
+			string(event.Violation.Code),
+			string(event.Violation.Risk.Level),
+			event.Violation.Path,
+			event.Violation.Reason,
+		)
+	}
+	var b strings.Builder
+	for _, field := range fields {
+		appendRenderCacheField(&b, field)
+	}
+	return b.String()
+}
+
+func askUserCacheFingerprint(request *agent.AskUserRequest) string {
+	if request == nil {
+		return ""
+	}
+	var b strings.Builder
+	appendRenderCacheField(&b, request.ToolCallID)
+	appendRenderCacheField(&b, request.Header)
+	for _, question := range request.Questions {
+		appendRenderCacheField(&b, question.Question)
+		appendRenderCacheField(&b, strconv.FormatBool(question.MultiSelect))
+		for _, option := range question.Options {
+			appendRenderCacheField(&b, option)
+		}
+	}
+	return b.String()
+}

--- a/internal/tui/render_cache_test.go
+++ b/internal/tui/render_cache_test.go
@@ -1,0 +1,169 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+func TestStaticRenderCacheHitMiss(t *testing.T) {
+	cache := newStaticRenderCache(4, 100)
+	renders := 0
+
+	first := cache.render("row:1", true, func() string {
+		renders++
+		return "rendered"
+	})
+	second := cache.render("row:1", true, func() string {
+		renders++
+		return "changed"
+	})
+
+	if first != "rendered" || second != "rendered" {
+		t.Fatalf("cached values = %q, %q; want first render reused", first, second)
+	}
+	if renders != 1 {
+		t.Fatalf("render func called %d times, want 1", renders)
+	}
+	stats := cache.stats()
+	if stats.Hits != 1 || stats.Misses != 1 {
+		t.Fatalf("stats = %#v, want 1 hit and 1 miss", stats)
+	}
+}
+
+func TestStaticRenderCacheEvictsLeastRecentlyUsedEntry(t *testing.T) {
+	cache := newStaticRenderCache(2, 100)
+
+	cache.render("a", true, func() string { return "A" })
+	cache.render("b", true, func() string { return "B" })
+	cache.render("a", true, func() string { return "A2" })
+	cache.render("c", true, func() string { return "C" })
+
+	renders := 0
+	got := cache.render("b", true, func() string {
+		renders++
+		return "B2"
+	})
+
+	if got != "B2" || renders != 1 {
+		t.Fatalf("b render = %q with %d calls, want evicted entry to rerender", got, renders)
+	}
+	stats := cache.stats()
+	if stats.Evictions != 2 {
+		t.Fatalf("stats = %#v, want 2 evictions (c insertion, b reinsertion)", stats)
+	}
+}
+
+func TestStaticRenderCacheEvictsToRetainedCharacterLimit(t *testing.T) {
+	cache := newStaticRenderCache(10, 6)
+
+	cache.render("a", true, func() string { return "aaa" })
+	cache.render("b", true, func() string { return "bbb" })
+	cache.render("a", true, func() string { return "aaa" })
+	cache.render("c", true, func() string { return "cc" })
+
+	if got := cache.retainedCharacters(); got != 5 {
+		t.Fatalf("retained characters = %d, want 5", got)
+	}
+
+	renders := 0
+	got := cache.render("b", true, func() string {
+		renders++
+		return "bbb"
+	})
+	if got != "bbb" || renders != 1 {
+		t.Fatalf("b render = %q with %d calls, want retained-char eviction to rerender", got, renders)
+	}
+	if stats := cache.stats(); stats.Evictions != 2 {
+		t.Fatalf("stats = %#v, want 2 evictions (char-limit insertion, b reinsertion)", stats)
+	}
+}
+
+func TestStaticRenderCacheSkipsOversizedOutputs(t *testing.T) {
+	cache := newStaticRenderCache(4, 5)
+	renders := 0
+
+	for range 2 {
+		got := cache.render("huge", true, func() string {
+			renders++
+			return "123456"
+		})
+		if got != "123456" {
+			t.Fatalf("render = %q, want oversized value returned without caching", got)
+		}
+	}
+
+	stats := cache.stats()
+	if renders != 2 || stats.SkippedOversized != 2 || stats.Hits != 0 {
+		t.Fatalf("renders=%d stats=%#v, want rerendered oversized output with no hits", renders, stats)
+	}
+	if cache.retainedCharacters() != 0 {
+		t.Fatalf("retained characters = %d, want 0", cache.retainedCharacters())
+	}
+}
+
+func TestStaticRenderCacheSkipsUnstableRequests(t *testing.T) {
+	cache := newStaticRenderCache(4, 100)
+	renders := 0
+
+	for range 2 {
+		cache.render("spinner", false, func() string {
+			renders++
+			return "tick"
+		})
+	}
+
+	if renders != 2 {
+		t.Fatalf("render func called %d times, want 2 for unstable requests", renders)
+	}
+	if stats := cache.stats(); stats != (renderCacheStats{}) {
+		t.Fatalf("stats = %#v, want unstable requests to bypass cache accounting", stats)
+	}
+}
+
+func TestRenderRowCacheSkipsRunningToolRows(t *testing.T) {
+	cache := replaceDefaultRenderCache(t, newStaticRenderCache(8, 1000))
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 7
+	row := transcriptRow{kind: rowToolCall, id: "call_1", runID: 7, tool: "grep", detail: "internal/tui"}
+
+	for range 2 {
+		_ = m.renderRow(row, 80, buildRowContext([]transcriptRow{row}))
+	}
+
+	if stats := cache.stats(); stats != (renderCacheStats{}) {
+		t.Fatalf("stats = %#v, want running tool rows to bypass cache", stats)
+	}
+}
+
+func TestRenderRowCacheSkipsPendingPermissionPromptRows(t *testing.T) {
+	cache := replaceDefaultRenderCache(t, newStaticRenderCache(8, 1000))
+	m := newModel(context.Background(), Options{})
+	m.pending = true
+	m.activeRunID = 9
+	row := transcriptRow{kind: rowPermission, id: "call_1", runID: 9, permission: &agent.PermissionEvent{
+		ToolCallID: "call_1",
+		ToolName:   "bash",
+		Action:     agent.PermissionActionPrompt,
+	}}
+
+	for range 2 {
+		_ = m.renderRow(row, 80, buildRowContext([]transcriptRow{row}))
+	}
+
+	if stats := cache.stats(); stats != (renderCacheStats{}) {
+		t.Fatalf("stats = %#v, want pending permission prompts to bypass cache", stats)
+	}
+}
+
+func replaceDefaultRenderCache(t *testing.T, cache *staticRenderCache) *staticRenderCache {
+	t.Helper()
+	previous := defaultRenderCache
+	defaultRenderCache = cache
+	t.Cleanup(func() {
+		defaultRenderCache = previous
+	})
+	return cache
+}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -161,6 +161,18 @@ func (m model) renderRow(row transcriptRow, width int, rc rowContext) string {
 	return m.renderRowMode(row, width, rc, false)
 }
 
+func (m model) renderRowDetailed(row transcriptRow, width int, rc rowContext) string {
+	opts := cardRenderOptions{bodyCap: 0, cwd: m.cwd}
+	if defaultRenderCache != nil {
+		if key, stable := m.renderRowCacheKey(row, width, rc, opts, false); key != "" {
+			return defaultRenderCache.render(key, stable, func() string {
+				return m.renderRowModeUncached(row, width, rc, opts)
+			})
+		}
+	}
+	return m.renderRowModeUncached(row, width, rc, opts)
+}
+
 // renderRowMode renders a transcript row either for the live region (flush ==
 // false: tight body caps, spinner-capable) or for its one-time scrollback
 // flush (flush == true: deep body caps so edited code stays reviewable).
@@ -169,6 +181,17 @@ func (m model) renderRowMode(row transcriptRow, width int, rc rowContext, flush 
 	if flush {
 		opts.bodyCap = flushCardBodyMaxLines
 	}
+	if defaultRenderCache != nil {
+		if key, stable := m.renderRowCacheKey(row, width, rc, opts, flush); key != "" {
+			return defaultRenderCache.render(key, stable, func() string {
+				return m.renderRowModeUncached(row, width, rc, opts)
+			})
+		}
+	}
+	return m.renderRowModeUncached(row, width, rc, opts)
+}
+
+func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext, opts cardRenderOptions) string {
 	switch row.kind {
 	case rowUser:
 		return renderUserRow(row, width)
@@ -559,29 +582,6 @@ type cardBody struct {
 	headTag string
 }
 
-type toolBodyRequest struct {
-	name   string
-	hint   string
-	detail string
-	width  int
-	opts   cardRenderOptions
-}
-
-type toolBodyRenderer func(toolBodyRequest) cardBody
-
-var registeredToolBodyRenderers = map[string]toolBodyRenderer{
-	"read_file": func(req toolBodyRequest) cardBody { return readCardBody(req.detail, req.width, req.opts) },
-	"bash":      func(req toolBodyRequest) cardBody { return bashCardBody(req.hint, req.detail, req.width, req.opts) },
-	"grep":      func(req toolBodyRequest) cardBody { return grepCardBody(req.detail, req.width, req.opts) },
-}
-
-func toolBodyRendererFor(name string) toolBodyRenderer {
-	if renderer, ok := registeredToolBodyRenderers[name]; ok {
-		return renderer
-	}
-	return func(req toolBodyRequest) cardBody { return genericCardBody(req.detail, req.opts) }
-}
-
 // renderRunningToolCard draws the head-only card for a tool call that has no
 // result yet: spinner glyph while ITS run is live, a static placeholder for
 // orphans (cancelled/errored turns, rehydrated history) — keying off the
@@ -702,21 +702,9 @@ func toolCard(head string, body []string, footer string, borderStyle lipgloss.St
 	return strings.Join(lines, "\n")
 }
 
-// toolCardBody picks the body renderer by result shape, reusing the existing
-// diff detection; the other shapes key off the core tool names.
+// toolCardBody delegates result-shape selection to the tool body registry.
 func toolCardBody(name string, hint string, detail string, width int, opts cardRenderOptions) cardBody {
-	detail = strings.TrimRight(strings.ReplaceAll(detail, "\r\n", "\n"), "\n")
-	// Terminal tab stops are unknowable from here and break the width math
-	// (lipgloss measures \t as one cell, the terminal expands it further), so
-	// card bodies render tabs as a fixed indent.
-	detail = strings.ReplaceAll(detail, "\t", "    ")
-	if strings.TrimSpace(detail) == "" {
-		return cardBody{}
-	}
-	if looksLikeDiff(detail) {
-		return diffCardBody(detail, width, opts)
-	}
-	return toolBodyRendererFor(name)(toolBodyRequest{
+	return defaultToolBodyRegistry.render(toolBodyRequest{
 		name:   name,
 		hint:   hint,
 		detail: detail,

--- a/internal/tui/selectable_list.go
+++ b/internal/tui/selectable_list.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+type selectableListItem struct {
+	Label       string
+	Description string
+}
+
+type selectableListOptions struct {
+	Items      []selectableListItem
+	Selected   int
+	Width      int
+	MaxVisible int
+}
+
+const selectableListAnchorRow = 2
+
+func renderSelectableList(options selectableListOptions) string {
+	if len(options.Items) == 0 {
+		return ""
+	}
+	width := options.Width
+	if width <= 0 {
+		width = 80
+	}
+	maxVisible := options.MaxVisible
+	if maxVisible <= 0 || maxVisible > len(options.Items) {
+		maxVisible = len(options.Items)
+	}
+	selected := clampInt(options.Selected, 0, len(options.Items)-1)
+	start := selectableListStart(len(options.Items), maxVisible, selected)
+	visible := options.Items[start : start+maxVisible]
+
+	labelWidth := 0
+	for _, item := range visible {
+		if w := lipgloss.Width(item.Label); w > labelWidth {
+			labelWidth = w
+		}
+	}
+
+	lines := make([]string, 0, maxVisible+1)
+	for index, item := range visible {
+		absoluteIndex := start + index
+		surface := zeroTheme.onPanel
+		marker := surface(zeroTheme.faintest).Render("  ")
+		if absoluteIndex == selected {
+			surface = zeroTheme.onSel
+			marker = surface(zeroTheme.accent).Render("❯ ")
+		}
+
+		label := surface(zeroTheme.ink).Render(item.Label)
+		pad := surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(0, labelWidth-lipgloss.Width(item.Label))))
+		line := marker + label + pad
+		if strings.TrimSpace(item.Description) != "" {
+			descWidth := width - lipgloss.Width(marker) - labelWidth - 2
+			desc := truncateRunes(item.Description, maxInt(0, descWidth))
+			if desc != "" {
+				line += surface(zeroTheme.faint).Render("  " + desc)
+			}
+		}
+		lines = append(lines, fitStyledLine(line, width))
+	}
+
+	if hidden := len(options.Items) - len(visible); hidden > 0 {
+		lines = append(lines, fitStyledLine(zeroTheme.faint.Render(fmt.Sprintf("  %d more", hidden)), width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func selectableListStart(total, maxVisible, selected int) int {
+	if total <= maxVisible {
+		return 0
+	}
+	start := selected - selectableListAnchorRow
+	return clampInt(start, 0, total-maxVisible)
+}
+
+func clampInt(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/internal/tui/selectable_list_test.go
+++ b/internal/tui/selectable_list_test.go
@@ -1,0 +1,104 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestSelectableListAnchorsSelectionAroundThirdVisibleRow(t *testing.T) {
+	items := make([]selectableListItem, 10)
+	for i := range items {
+		items[i] = selectableListItem{Label: fmt.Sprintf("/cmd%d", i), Description: "command"}
+	}
+
+	rendered := renderSelectableList(selectableListOptions{
+		Items:      items,
+		Selected:   5,
+		Width:      40,
+		MaxVisible: 5,
+	})
+	lines := strings.Split(plainRender(t, rendered), "\n")
+
+	if len(lines) != 6 {
+		t.Fatalf("rendered %d lines, want 5 rows plus count line: %q", len(lines), lines)
+	}
+	for _, hidden := range []string{"/cmd0", "/cmd1", "/cmd2", "/cmd8", "/cmd9"} {
+		if strings.Contains(rendered, hidden) {
+			t.Fatalf("visible window should hide %s, got %q", hidden, plainRender(t, rendered))
+		}
+	}
+	for _, visible := range []string{"/cmd3", "/cmd4", "/cmd5", "/cmd6", "/cmd7"} {
+		if !strings.Contains(rendered, visible) {
+			t.Fatalf("visible window should include %s, got %q", visible, plainRender(t, rendered))
+		}
+	}
+	if !strings.Contains(lines[2], "❯ /cmd5") {
+		t.Fatalf("selected item should be anchored on third visible row, got %q", lines[2])
+	}
+	if !strings.Contains(lines[5], "5 more") {
+		t.Fatalf("count line should summarize hidden rows, got %q", lines[5])
+	}
+}
+
+func TestSelectableListAlignsAndTruncatesDescriptions(t *testing.T) {
+	rendered := renderSelectableList(selectableListOptions{
+		Items: []selectableListItem{
+			{Label: "/m", Description: "Short"},
+			{Label: "/model", Description: "Switch model and provider for this session"},
+		},
+		Selected:   0,
+		Width:      32,
+		MaxVisible: 8,
+	})
+	lines := strings.Split(plainRender(t, rendered), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("rendered lines = %d, want 2: %q", len(lines), lines)
+	}
+
+	shortAt := strings.Index(lines[0], "Short")
+	switchAt := strings.Index(lines[1], "Switch")
+	if shortAt < 0 || switchAt < 0 {
+		t.Fatalf("descriptions missing from rows: %q", lines)
+	}
+	shortColumn := lipgloss.Width(lines[0][:shortAt])
+	switchColumn := lipgloss.Width(lines[1][:switchAt])
+	if shortColumn != switchColumn {
+		t.Fatalf("descriptions should align, Short at column %d Switch at column %d in %q", shortColumn, switchColumn, lines)
+	}
+	if got := lipgloss.Width(lines[1]); got > 32 {
+		t.Fatalf("row width = %d, want <= 32: %q", got, lines[1])
+	}
+	if !strings.Contains(lines[1], "…") {
+		t.Fatalf("long description should truncate with ellipsis, got %q", lines[1])
+	}
+}
+
+func TestSelectableListMarksOnlySelectedRow(t *testing.T) {
+	rendered := renderSelectableList(selectableListOptions{
+		Items: []selectableListItem{
+			{Label: "/help", Description: "Show help"},
+			{Label: "/model", Description: "Switch model"},
+			{Label: "/quit", Description: "Quit"},
+		},
+		Selected:   1,
+		Width:      48,
+		MaxVisible: 8,
+	})
+
+	lines := strings.Split(plainRender(t, rendered), "\n")
+	selected := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "❯ ") {
+			selected++
+			if !strings.Contains(line, "/model") {
+				t.Fatalf("selected marker is on wrong row: %q", line)
+			}
+		}
+	}
+	if selected != 1 {
+		t.Fatalf("selected marker count = %d, want 1 in %q", selected, lines)
+	}
+}

--- a/internal/tui/spec_mode.go
+++ b/internal/tui/spec_mode.go
@@ -128,6 +128,7 @@ func (m model) activateSpecReview(review pendingSpecReviewPrompt) model {
 		m.sessionEvents = append(m.sessionEvents, event)
 	}
 	m.pendingSpecReview = &review
+	m.clearSuggestions()
 	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: specReviewSummary(review)})
 	return m
 }
@@ -233,13 +234,13 @@ func (m model) rejectSpecReview(reason string) (tea.Model, tea.Cmd) {
 	}
 	m.pendingSpecReview = nil
 	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Spec rejected. Use /spec <task> to draft again."})
-	return m, nil
+	return m.launchQueuedMessageIfReady()
 }
 
 func (m model) cancelSpecReview() (tea.Model, tea.Cmd) {
 	m.pendingSpecReview = nil
 	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Spec review canceled. The draft remains saved."})
-	return m, nil
+	return m.launchQueuedMessageIfReady()
 }
 
 func cloneToolRegistry(registry *tools.Registry) *tools.Registry {

--- a/internal/tui/spec_mode_test.go
+++ b/internal/tui/spec_mode_test.go
@@ -115,6 +115,65 @@ func TestSpecReviewBlocksShiftTabModeCycle(t *testing.T) {
 	}
 }
 
+func TestSpecReviewCancelLaunchesQueuedPrompt(t *testing.T) {
+	m := newSpecModeTestModel(t.TempDir(), &fakeProvider{
+		events: []zeroruntime.StreamEvent{{Type: zeroruntime.StreamEventDone}},
+	}, testSessionStore(t))
+	m.pendingSpecReview = &pendingSpecReviewPrompt{SpecID: "spec", SpecFilePath: ".zero/specs/spec.md"}
+	m.queuedMessage = "continue after cancel"
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	next := updated.(model)
+
+	if cmd == nil {
+		t.Fatal("expected queued prompt to launch after spec review cancel")
+	}
+	if next.pendingSpecReview != nil {
+		t.Fatal("expected spec review to clear")
+	}
+	if next.hasQueuedMessage() {
+		t.Fatalf("expected queued prompt to be consumed, got %q", next.queuedMessage)
+	}
+	if !next.pending {
+		t.Fatal("expected queued prompt launch to mark model pending")
+	}
+}
+
+func TestSpecReviewRejectLaunchesQueuedPrompt(t *testing.T) {
+	store := testSessionStore(t)
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		submitSpecScript("call-1", "Review Flow", "# Goal\n\nAdd review flow."),
+		textScript("queued after reject"),
+	}}
+	m := newSpecModeTestModel(t.TempDir(), provider, store)
+	m.input.SetValue("/spec add review flow")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, _ = next.Update(execCmd(cmd))
+	next = updated.(model)
+	if next.pendingSpecReview == nil {
+		t.Fatal("expected pending review before rejection")
+	}
+	next.queuedMessage = "continue after reject"
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	next = updated.(model)
+
+	if cmd == nil {
+		t.Fatal("expected queued prompt to launch after spec review reject")
+	}
+	if next.pendingSpecReview != nil {
+		t.Fatal("expected spec review to clear")
+	}
+	if next.hasQueuedMessage() {
+		t.Fatalf("expected queued prompt to be consumed, got %q", next.queuedMessage)
+	}
+	if !next.pending {
+		t.Fatal("expected queued prompt launch to mark model pending")
+	}
+}
+
 func newSpecModeTestModel(root string, provider zeroruntime.Provider, store *sessions.Store) model {
 	registry := tools.NewRegistry()
 	for _, tool := range tools.CoreTools(root) {

--- a/internal/tui/spec_mode_test.go
+++ b/internal/tui/spec_mode_test.go
@@ -116,9 +116,10 @@ func TestSpecReviewBlocksShiftTabModeCycle(t *testing.T) {
 }
 
 func TestSpecReviewCancelLaunchesQueuedPrompt(t *testing.T) {
-	m := newSpecModeTestModel(t.TempDir(), &fakeProvider{
-		events: []zeroruntime.StreamEvent{{Type: zeroruntime.StreamEventDone}},
-	}, testSessionStore(t))
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{{
+		{Type: zeroruntime.StreamEventDone},
+	}}}
+	m := newSpecModeTestModel(t.TempDir(), provider, testSessionStore(t))
 	m.pendingSpecReview = &pendingSpecReviewPrompt{SpecID: "spec", SpecFilePath: ".zero/specs/spec.md"}
 	m.queuedMessage = "continue after cancel"
 
@@ -136,6 +137,14 @@ func TestSpecReviewCancelLaunchesQueuedPrompt(t *testing.T) {
 	}
 	if !next.pending {
 		t.Fatal("expected queued prompt launch to mark model pending")
+	}
+	beforeRequests := len(provider.requests)
+	_ = execCmd(cmd)
+	if len(provider.requests) <= beforeRequests {
+		t.Fatalf("expected queued prompt to issue a provider request, before=%d after=%d", beforeRequests, len(provider.requests))
+	}
+	if !providerRequestsContain(provider.requests[beforeRequests:], "continue after cancel") {
+		t.Fatalf("expected queued prompt in launched request, got %#v", provider.requests[beforeRequests:])
 	}
 }
 
@@ -172,6 +181,14 @@ func TestSpecReviewRejectLaunchesQueuedPrompt(t *testing.T) {
 	if !next.pending {
 		t.Fatal("expected queued prompt launch to mark model pending")
 	}
+	beforeRequests := len(provider.requests)
+	_ = execCmd(cmd)
+	if len(provider.requests) <= beforeRequests {
+		t.Fatalf("expected queued reject follow-up to issue a provider request, before=%d after=%d", beforeRequests, len(provider.requests))
+	}
+	if !providerRequestsContain(provider.requests[beforeRequests:], "continue after reject") {
+		t.Fatalf("expected queued prompt in launched request, got %#v", provider.requests[beforeRequests:])
+	}
 }
 
 func newSpecModeTestModel(root string, provider zeroruntime.Provider, store *sessions.Store) model {
@@ -207,6 +224,17 @@ func providerRequestIncludesTool(request zeroruntime.CompletionRequest, name str
 	for _, tool := range request.Tools {
 		if tool.Name == name {
 			return true
+		}
+	}
+	return false
+}
+
+func providerRequestsContain(requests []zeroruntime.CompletionRequest, text string) bool {
+	for _, request := range requests {
+		for _, message := range request.Messages {
+			if strings.Contains(message.Content, text) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/tui/tool_render_registry.go
+++ b/internal/tui/tool_render_registry.go
@@ -1,0 +1,123 @@
+package tui
+
+import "strings"
+
+type toolBodyRequest struct {
+	name   string
+	hint   string
+	detail string
+	width  int
+	opts   cardRenderOptions
+}
+
+type toolBodyRenderer interface {
+	renderToolBody(toolBodyRequest) cardBody
+}
+
+type toolBodyRendererFunc func(toolBodyRequest) cardBody
+
+func (fn toolBodyRendererFunc) renderToolBody(req toolBodyRequest) cardBody {
+	return fn(req)
+}
+
+type toolBodyRegistry struct {
+	renderers map[string]toolBodyRenderer
+	fallback  toolBodyRenderer
+}
+
+var defaultToolBodyRegistry = newDefaultToolBodyRegistry()
+
+func newDefaultToolBodyRegistry() *toolBodyRegistry {
+	fallback := unknownToolBodyRenderer{}
+	registry := newToolBodyRegistry(fallback)
+
+	diffOrFallback := diffFirstToolBodyRenderer{next: fallback}
+	registry.register("edit_file", diffOrFallback)
+	registry.register("apply_patch", diffOrFallback)
+	registry.register("read_file", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return readCardBody(req.detail, req.width, req.opts)
+	})})
+	registry.register("bash", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return bashCardBody(req.hint, req.detail, req.width, req.opts)
+	})})
+	registry.register("grep", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return grepCardBody(req.detail, req.width, req.opts)
+	})})
+
+	return registry
+}
+
+func newToolBodyRegistry(fallback toolBodyRenderer) *toolBodyRegistry {
+	if fallback == nil {
+		fallback = unknownToolBodyRenderer{}
+	}
+	return &toolBodyRegistry{
+		renderers: map[string]toolBodyRenderer{},
+		fallback:  fallback,
+	}
+}
+
+func (registry *toolBodyRegistry) register(name string, renderer toolBodyRenderer) {
+	if registry == nil || strings.TrimSpace(name) == "" || renderer == nil {
+		return
+	}
+	if registry.renderers == nil {
+		registry.renderers = map[string]toolBodyRenderer{}
+	}
+	registry.renderers[name] = renderer
+}
+
+func (registry *toolBodyRegistry) render(req toolBodyRequest) cardBody {
+	req.detail = normalizeToolCardDetail(req.detail)
+	if strings.TrimSpace(req.detail) == "" {
+		return cardBody{}
+	}
+	return registry.rendererFor(req.name).renderToolBody(req)
+}
+
+func (registry *toolBodyRegistry) rendererFor(name string) toolBodyRenderer {
+	if registry != nil {
+		if renderer, ok := registry.renderers[name]; ok && renderer != nil {
+			return renderer
+		}
+		if registry.fallback != nil {
+			return registry.fallback
+		}
+	}
+	return unknownToolBodyRenderer{}
+}
+
+func toolBodyRendererFor(name string) toolBodyRenderer {
+	return defaultToolBodyRegistry.rendererFor(name)
+}
+
+func normalizeToolCardDetail(detail string) string {
+	detail = strings.TrimRight(strings.ReplaceAll(detail, "\r\n", "\n"), "\n")
+	// Terminal tab stops are unknowable from here and break the width math
+	// (lipgloss measures \t as one cell, the terminal expands it further), so
+	// card bodies render tabs as a fixed indent.
+	return strings.ReplaceAll(detail, "\t", "    ")
+}
+
+type diffFirstToolBodyRenderer struct {
+	next toolBodyRenderer
+}
+
+func (renderer diffFirstToolBodyRenderer) renderToolBody(req toolBodyRequest) cardBody {
+	if looksLikeDiff(req.detail) {
+		return diffCardBody(req.detail, req.width, req.opts)
+	}
+	if renderer.next == nil {
+		return unknownToolBodyRenderer{}.renderToolBody(req)
+	}
+	return renderer.next.renderToolBody(req)
+}
+
+type unknownToolBodyRenderer struct{}
+
+func (unknownToolBodyRenderer) renderToolBody(req toolBodyRequest) cardBody {
+	if looksLikeDiff(req.detail) {
+		return diffCardBody(req.detail, req.width, req.opts)
+	}
+	return genericCardBody(req.detail, req.opts)
+}

--- a/internal/tui/tool_render_registry.go
+++ b/internal/tui/tool_render_registry.go
@@ -58,7 +58,8 @@ func newToolBodyRegistry(fallback toolBodyRenderer) *toolBodyRegistry {
 }
 
 func (registry *toolBodyRegistry) register(name string, renderer toolBodyRenderer) {
-	if registry == nil || strings.TrimSpace(name) == "" || renderer == nil {
+	name = strings.TrimSpace(name)
+	if registry == nil || name == "" || renderer == nil {
 		return
 	}
 	if registry.renderers == nil {

--- a/internal/tui/tool_render_registry_test.go
+++ b/internal/tui/tool_render_registry_test.go
@@ -111,3 +111,21 @@ func TestToolBodyRegistryReplacementIsScopedToOneTool(t *testing.T) {
 		t.Fatalf("bash body = %q, want original bash renderer", got)
 	}
 }
+
+func TestToolBodyRegistryTrimsRegisteredNames(t *testing.T) {
+	registry := newToolBodyRegistry(unknownToolBodyRenderer{})
+	registry.register(" grep ", toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return cardBody{lines: []string{zeroTheme.onPanel(zeroTheme.ink).Render("trimmed grep body")}}
+	}))
+
+	body := registry.render(toolBodyRequest{
+		name:   "grep",
+		detail: "internal/tui/rendering.go:41: func render()",
+		width:  96,
+		opts:   cardRenderOptions{bodyCap: cardBodyMaxLines},
+	})
+
+	if got := plainRender(t, strings.Join(body.lines, "\n")); !strings.Contains(got, "trimmed grep body") {
+		t.Fatalf("grep body = %q, want trimmed registered renderer", got)
+	}
+}

--- a/internal/tui/tool_render_registry_test.go
+++ b/internal/tui/tool_render_registry_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultToolBodyRegistrySelectsCoreRenderers(t *testing.T) {
+	registry := newDefaultToolBodyRegistry()
+	opts := cardRenderOptions{bodyCap: cardBodyMaxLines}
+
+	tests := []struct {
+		name   string
+		hint   string
+		detail string
+		want   []string
+	}{
+		{
+			name: "edit_file",
+			detail: strings.Join([]string{
+				"--- a/app.go",
+				"+++ b/app.go",
+				"@@ -1 +1 @@",
+				"-old",
+				"+new",
+			}, "\n"),
+			want: []string{"app.go", "-1", "+1", "new"},
+		},
+		{
+			name: "apply_patch",
+			detail: strings.Join([]string{
+				"--- a/app.go",
+				"+++ b/app.go",
+				"@@ -1 +1 @@",
+				"-old",
+				"+new",
+			}, "\n"),
+			want: []string{"app.go", "-1", "+1", "new"},
+		},
+		{
+			name:   "read_file",
+			detail: "File: README.md\n\n  7 | # Zero",
+			want:   []string{"# Zero", "L7"},
+		},
+		{
+			name:   "bash",
+			hint:   "go test ./internal/tui",
+			detail: "stdout:\nok\nexit_code: 0",
+			want:   []string{"go test ./internal/tui", "ok", "exit 0"},
+		},
+		{
+			name:   "grep",
+			detail: "internal/tui/rendering.go:41: func render()",
+			want:   []string{"internal/tui/rendering.go:41", "1 matches"},
+		},
+		{
+			name:   "unknown_tool",
+			detail: "raw output",
+			want:   []string{"raw output"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := registry.render(toolBodyRequest{
+				name:   tt.name,
+				hint:   tt.hint,
+				detail: normalizeToolCardDetail(tt.detail),
+				width:  96,
+				opts:   opts,
+			})
+			got := plainRender(t, strings.Join(append(append([]string{}, body.lines...), body.headTag, body.footer), "\n"))
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("%s body = %q, missing %q", tt.name, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestToolBodyRegistryReplacementIsScopedToOneTool(t *testing.T) {
+	registry := newDefaultToolBodyRegistry()
+	registry.register("grep", toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return cardBody{lines: []string{zeroTheme.onPanel(zeroTheme.ink).Render("replacement grep body")}}
+	}))
+
+	opts := cardRenderOptions{bodyCap: cardBodyMaxLines}
+	grepBody := registry.render(toolBodyRequest{
+		name:   "grep",
+		detail: "internal/tui/rendering.go:41: func render()",
+		width:  96,
+		opts:   opts,
+	})
+	if got := plainRender(t, strings.Join(grepBody.lines, "\n")); !strings.Contains(got, "replacement grep body") {
+		t.Fatalf("grep replacement body = %q, want replacement", got)
+	}
+
+	bashBody := registry.render(toolBodyRequest{
+		name:   "bash",
+		hint:   "go test ./internal/tui",
+		detail: normalizeToolCardDetail("stdout:\nok\nexit_code: 0"),
+		width:  96,
+		opts:   opts,
+	})
+	got := plainRender(t, strings.Join(append(append([]string{}, bashBody.lines...), bashBody.footer), "\n"))
+	if strings.Contains(got, "replacement grep body") {
+		t.Fatalf("bash body = %q, must not use grep replacement", got)
+	}
+	if !strings.Contains(got, "go test ./internal/tui") || !strings.Contains(got, "exit 0") {
+		t.Fatalf("bash body = %q, want original bash renderer", got)
+	}
+}

--- a/internal/tui/transcript_view.go
+++ b/internal/tui/transcript_view.go
@@ -1,0 +1,62 @@
+package tui
+
+import "strings"
+
+func (m model) toggleDetailedTranscript() model {
+	m.transcriptDetailed = !m.transcriptDetailed
+	m.clearSuggestions()
+	m.picker = nil
+	return m
+}
+
+func (m model) detailedTranscriptView() string {
+	width := chatWidth(m.width)
+	rc := buildRowContext(m.transcript)
+	renderer := m
+	renderer.pending = false
+	renderer.activeRunID = 0
+
+	var builder strings.Builder
+	builder.WriteString(detailedTranscriptHeader(width))
+	builder.WriteString("\n")
+	builder.WriteString(zeroTheme.line.Render(strings.Repeat("-", width)))
+	builder.WriteString("\n")
+
+	shownAny := false
+	for _, row := range m.transcript {
+		if rc.skip(row) {
+			continue
+		}
+		rendered := ""
+		if row.kind == rowWelcome {
+			rendered = fitStyledLine(zeroTheme.faint.Render(row.text), width)
+		} else {
+			rendered = renderer.renderRowDetailed(row, width, rc)
+		}
+		if rendered == "" {
+			continue
+		}
+		if shownAny && startsTurn(row.kind) {
+			builder.WriteString("\n")
+		}
+		builder.WriteString(rendered)
+		builder.WriteString("\n")
+		shownAny = true
+	}
+
+	if !shownAny {
+		builder.WriteString(zeroTheme.faint.Render("No transcript rows."))
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString(zeroTheme.line.Render(strings.Repeat("-", width)))
+	builder.WriteString("\n")
+	builder.WriteString(fitStyledLine(zeroTheme.faint.Render("Esc close | Ctrl+O toggle"), width))
+	return builder.String()
+}
+
+func detailedTranscriptHeader(width int) string {
+	title := zeroTheme.ink.Bold(true).Render("Transcript")
+	hint := zeroTheme.faint.Render("detailed")
+	return fitStyledLine(joinHeaderLine(title, hint, width), width)
+}

--- a/internal/tui/transcript_view_test.go
+++ b/internal/tui/transcript_view_test.go
@@ -1,0 +1,129 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestTranscriptCommandTogglesDetailedView(t *testing.T) {
+	m := transcriptViewTestModel()
+	m.input.SetValue("/transcript")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	assertContains(t, plainRender(t, next.View()), "Transcript")
+
+	next.input.SetValue("/transcript")
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	assertNotContains(t, plainRender(t, next.View()), "Transcript")
+}
+
+func TestCtrlOTogglesDetailedTranscriptView(t *testing.T) {
+	m := transcriptViewTestModel()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next := updated.(model)
+	assertContains(t, plainRender(t, next.View()), "Transcript")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next = updated.(model)
+	assertNotContains(t, plainRender(t, next.View()), "Transcript")
+}
+
+func TestEscExitsDetailedTranscriptView(t *testing.T) {
+	m := transcriptViewTestModel()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next := updated.(model)
+	assertContains(t, plainRender(t, next.View()), "Transcript")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	next = updated.(model)
+	assertNotContains(t, plainRender(t, next.View()), "Transcript")
+}
+
+func TestDetailedTranscriptIncludesToolOutputBeyondLiveCap(t *testing.T) {
+	m := transcriptViewTestModel()
+	output := numberedLines(flushCardBodyMaxLines + 4)
+	row := transcriptRow{kind: rowToolResult, id: "tool-1", tool: "custom_tool", status: tools.StatusOK, detail: output}
+	m.transcript = append(m.transcript, row)
+	m.flushed = len(m.transcript)
+
+	compact := plainRender(t, m.renderRow(row, m.width, buildRowContext(m.transcript)))
+	assertNotContains(t, compact, "line-020")
+	assertContains(t, compact, "more lines")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next := updated.(model)
+	view := plainRender(t, next.View())
+	assertContains(t, view, "line-404")
+	assertNotContains(t, view, "more lines")
+}
+
+func TestDetailedTranscriptViewNeverExceedsTerminalWidth(t *testing.T) {
+	for _, width := range []int{24, 40, 58, 80, 120} {
+		m := transcriptViewTestModel()
+		m.width = width
+		m.transcript = append(m.transcript,
+			transcriptRow{kind: rowUser, text: "please inspect this very long request and show the transcript without overflowing"},
+			transcriptRow{kind: rowToolResult, id: "wide", tool: "custom_tool", status: tools.StatusOK, detail: strings.Repeat("wide-output-", 30)},
+			transcriptRow{kind: rowAssistant, text: "done with a final answer that also needs wrapping", final: true, turnTools: 1},
+		)
+		m.flushed = len(m.transcript)
+
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+		next := updated.(model)
+		view := next.View()
+		assertContains(t, plainRender(t, view), "Transcript")
+		for index, line := range strings.Split(view, "\n") {
+			if got := lipgloss.Width(line); got > chatWidth(width) {
+				t.Fatalf("width %d: detailed transcript line %d is %d cells wide: %q", width, index, got, line)
+			}
+		}
+	}
+}
+
+func TestDetailedTranscriptSwallowsNormalChatSubmit(t *testing.T) {
+	m := transcriptViewTestModel()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next := updated.(model)
+	next.input.SetValue("this should not launch")
+
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("detailed transcript should not return a run command for Enter")
+	}
+	if transcriptContains(next.transcript, "this should not launch") {
+		t.Fatalf("detailed transcript should not submit composer text, got %#v", next.transcript)
+	}
+	assertContains(t, plainRender(t, next.View()), "Transcript")
+}
+
+func transcriptViewTestModel() model {
+	m := newModel(context.Background(), Options{
+		Cwd:          "/work/zero",
+		ProviderName: "openai",
+		ModelName:    "gpt-test",
+	})
+	m.width = 96
+	m.height = 30
+	m.headerPrinted = true
+	return m
+}
+
+func numberedLines(count int) string {
+	lines := make([]string, 0, count)
+	for i := 1; i <= count; i++ {
+		lines = append(lines, fmt.Sprintf("line-%03d", i))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -285,25 +286,38 @@ func (m model) suggestionOverlay(width int) string {
 	if !m.suggestionsActive() {
 		return ""
 	}
-	nameWidth := 0
-	for _, s := range m.suggestions {
-		if w := lipgloss.Width(s.Name); w > nameWidth {
-			nameWidth = w
+	return renderSelectableList(selectableListOptions{
+		Items:      selectableItems(m.suggestions, m.suggestionsAreFiles),
+		Selected:   m.suggestionIdx,
+		Width:      width - 2,
+		MaxVisible: maxCommandSuggestions,
+	})
+}
+
+func selectableItems(suggestions []commandSuggestion, files bool) []selectableListItem {
+	items := make([]selectableListItem, 0, len(suggestions))
+	for _, suggestion := range suggestions {
+		item := selectableListItem{Label: suggestion.Name, Description: suggestion.Desc}
+		if files {
+			item = fileSelectableItem(suggestion.Name)
 		}
+		items = append(items, item)
 	}
-	lines := make([]string, 0, len(m.suggestions))
-	for index, s := range m.suggestions {
-		surface := zeroTheme.onPanel
-		marker := surface(zeroTheme.faintest).Render("  ")
-		if index == m.suggestionIdx {
-			surface = zeroTheme.onSel
-			marker = surface(zeroTheme.accent).Render("❯ ")
-		}
-		pad := surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(0, nameWidth-lipgloss.Width(s.Name))))
-		line := marker + surface(zeroTheme.ink).Render(s.Name) + pad + surface(zeroTheme.faint).Render("  "+s.Desc)
-		lines = append(lines, fitStyledLine(line, width-2))
+	return items
+}
+
+func fileSelectableItem(token string) selectableListItem {
+	rel := strings.TrimPrefix(token, "@")
+	rel = filepath.ToSlash(rel)
+	base := path.Base(rel)
+	if base == "." || base == "/" || base == "" {
+		return selectableListItem{Label: token, Description: "file"}
 	}
-	return strings.Join(lines, "\n")
+	dir := path.Dir(rel)
+	if dir == "." || dir == "" {
+		return selectableListItem{Label: "@" + base, Description: "file"}
+	}
+	return selectableListItem{Label: "@" + base, Description: dir}
 }
 
 // pickerOverlay renders an open interactive selector below the composer: a


### PR DESCRIPTION
﻿## Summary
- Add multiline composer state for the Lime TUI, including newline insertion, cursor-aware edits, word/line deletion, paste sanitization, and safe syncing with the existing textinput.
- Add queued prompt UX, detailed transcript view, reusable selectable suggestions, and a tool-card renderer registry.
- Add a bounded static render cache for stable transcript rows, while bypassing running tools and live permission prompts.
- Tighten modal interactions around ask_user and spec review so stale composer/suggestion state and queued prompts do not leak across flows.

## Why
This is the next Go-native TUI interaction foundation layer inspired by the D flow, without touching Gnanam's visual split work. It improves real terminal coding-agent behavior: users can draft longer prompts, queue the next turn while a run is active, inspect full transcript/tool output, and get faster stable-row renders.

## Validation
- `gofmt -l internal/tui`
- `git diff --check`
- `go test ./internal/tui -count=1`
- `go test ./...`
- `go vet ./...`
- `go run ./cmd/zero-release build`

## Review Notes
This PR is intentionally scoped to `internal/tui`. It does not change provider logic, tools, docs, or the default shell skin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed transcript view mode (toggle via Ctrl+O or /transcript)
  * Multiline composer with rich editing keys and paste sanitization
  * Message queueing with on-screen queued preview
  * LRU render caching to improve TUI rendering performance

* **Improvements**
  * Better file suggestion filtering and suppression during modal prompts
  * Unified selectable-list rendering for command/picker overlays
  * Centralized tool-output rendering registry

* **Tests**
  * Extensive new unit tests covering composer, autocomplete, queued messages, rendering, selectable lists, spec review, and transcript view
<!-- end of auto-generated comment: release notes by coderabbit.ai -->