### PR TITLE
Add first-run provider setup

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -178,6 +178,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runProviders(args[1:], stdout, stderr, deps)
 	case "doctor":
 		return runDoctor(args[1:], stdout, stderr, deps)
+	case "setup":
+		return runSetup(args[1:], stdout, stderr, deps)
 	case "context":
 		return runContext(args[1:], stdout, stderr, deps)
 	case "repo-map", "repomap":
@@ -308,6 +310,10 @@ func fillAppDeps(deps appDeps) appDeps {
 }
 
 func runInteractiveTUI(stderr io.Writer, deps appDeps, permissionMode agent.PermissionMode) int {
+	return runInteractiveTUIWithSetup(stderr, deps, permissionMode, false)
+}
+
+func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode agent.PermissionMode, forceSetup bool) int {
 	workspaceRoot, err := deps.getwd()
 	if err != nil {
 		return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), 1)
@@ -320,6 +326,16 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps, permissionMode agent.Perm
 	userConfigPath, err := deps.userConfigPath()
 	if err != nil {
 		return writeAppError(stderr, "failed to resolve user config path: "+err.Error(), 1)
+	}
+
+	needsSetup := setupRequired(resolved)
+	setupVisible := forceSetup || needsSetup
+	configPath := ""
+	if setupVisible {
+		configPath, err = deps.userConfigPath()
+		if err != nil {
+			return writeAppError(stderr, err.Error(), 1)
+		}
 	}
 
 	provider, err := buildProvider(resolved, deps)
@@ -390,6 +406,15 @@ func runInteractiveTUI(stderr io.Writer, deps appDeps, permissionMode agent.Perm
 		},
 		PermissionMode: permissionMode,
 		Notify:         resolved.Notify,
+		Setup: tui.SetupOptions{
+			Visible:    setupVisible,
+			Required:   needsSetup,
+			ConfigPath: configPath,
+			Providers:  setupProviderOptions(),
+			Save: func(selection tui.SetupSelection) (tui.SetupResult, error) {
+				return saveSetupProvider(deps, selection, setupSaveOptions{})
+			},
+		},
 	})
 }
 
@@ -463,6 +488,7 @@ Usage:
 
 Commands:
   exec       Run a one-shot prompt through the Go agent runtime
+  setup      Guide first-run provider setup
   config     Inspect resolved Go configuration without leaking secrets
   models     List Zero model registry entries
   providers  Inspect resolved provider profiles

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -57,7 +58,7 @@ func TestRunPrintsHelp(t *testing.T) {
 	}
 }
 
-func TestRunNoArgsLaunchesTUIWithNilProviderWhenNoProviderConfigured(t *testing.T) {
+func TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cwd := t.TempDir()
@@ -107,6 +108,12 @@ func TestRunNoArgsLaunchesTUIWithNilProviderWhenNoProviderConfigured(t *testing.
 	}
 	if launchedOptions.ProviderName != "" || launchedOptions.ModelName != "" {
 		t.Fatalf("provider metadata = %q/%q, want empty", launchedOptions.ProviderName, launchedOptions.ModelName)
+	}
+	if !launchedOptions.Setup.Visible || !launchedOptions.Setup.Required {
+		t.Fatalf("Setup = %#v, want visible required setup", launchedOptions.Setup)
+	}
+	if launchedOptions.Setup.ConfigPath != userConfigPath {
+		t.Fatalf("Setup.ConfigPath = %q, want %q", launchedOptions.Setup.ConfigPath, userConfigPath)
 	}
 	assertCoreRegistry(t, launchedOptions.Registry)
 	assertAgentOptions(t, launchedOptions, 12, agent.PermissionModeAsk)
@@ -171,6 +178,9 @@ func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {
 	}
 	if launchedOptions.ModelName != "gpt-test" {
 		t.Fatalf("ModelName = %q, want gpt-test", launchedOptions.ModelName)
+	}
+	if launchedOptions.Setup.Visible {
+		t.Fatalf("Setup.Visible = true, want false for credentialed provider")
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("expected empty stdout, got %q", stdout.String())
@@ -294,6 +304,7 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 		{"version"},
 		{"wat"},
 		{"exec"},
+		{"setup", "--help"},
 		{"config"},
 		{"models"},
 		{"providers"},
@@ -331,6 +342,92 @@ func TestRunCommandsDoNotLaunchTUI(t *testing.T) {
 				t.Fatalf("TUI launcher should not be called for args %#v", args)
 			}
 		})
+	}
+}
+
+func TestRunSetupNoArgsForcesSetupTUI(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	var launchedOptions tui.Options
+
+	exitCode := runWithDeps([]string{"setup"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{
+				ActiveProvider: "work",
+				Provider: config.ProviderProfile{
+					Name:         "work",
+					ProviderKind: config.ProviderKindOpenAI,
+					BaseURL:      config.OpenAIBaseURL,
+					APIKey:       "sk-test",
+					Model:        "gpt-test",
+				},
+				MaxTurns: 3,
+			}, nil
+		},
+		newProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return &cliFakeProvider{}, nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	if !launchedOptions.Setup.Visible {
+		t.Fatalf("Setup.Visible = false, want forced setup")
+	}
+	if launchedOptions.Setup.Required {
+		t.Fatalf("Setup.Required = true, want false for credentialed provider")
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected no output, stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunSetupProviderWritesActiveConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "config.json")
+
+	exitCode := runWithDeps([]string{"setup", "ollama"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("expected exit code %d, got %d: %s", exitSuccess, exitCode, stderr.String())
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg config.FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config: %v\n%s", err, string(data))
+	}
+	if cfg.ActiveProvider != "ollama" {
+		t.Fatalf("ActiveProvider = %q, want ollama", cfg.ActiveProvider)
+	}
+	if len(cfg.Providers) != 1 || cfg.Providers[0].CatalogID != "ollama" || cfg.Providers[0].Model == "" {
+		t.Fatalf("Providers = %#v, want ollama provider with model", cfg.Providers)
+	}
+	if !strings.Contains(stdout.String(), "Zero setup complete") || !strings.Contains(stdout.String(), "next: zero") {
+		t.Fatalf("unexpected setup output: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
 	}
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,0 +1,315 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/tui"
+)
+
+type setupOptions struct {
+	catalogID string
+	name      string
+	model     string
+	baseURL   string
+	apiKeyEnv string
+	json      bool
+}
+
+func runSetup(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseSetupArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSetupHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if strings.TrimSpace(options.catalogID) == "" {
+		return runInteractiveTUIWithSetup(stderr, deps, "", true)
+	}
+
+	result, err := saveSetupProvider(deps, tui.SetupSelection{
+		CatalogID: options.catalogID,
+		Model:     options.model,
+	}, setupSaveOptions{
+		name:      options.name,
+		baseURL:   options.baseURL,
+		apiKeyEnv: options.apiKeyEnv,
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, map[string]any{
+			"configPath": result.ConfigPath,
+			"provider":   result.Provider.Name,
+			"model":      result.Provider.Model,
+			"catalogID":  result.Provider.CatalogID,
+		}); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatSetupComplete(result)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseSetupArgs(args []string) (setupOptions, bool, error) {
+	options := setupOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--name":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.name = value
+			index = next
+		case strings.HasPrefix(arg, "--name="):
+			value, err := requiredInlineFlagValue(arg, "--name")
+			if err != nil {
+				return options, false, err
+			}
+			options.name = value
+		case arg == "--model":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.model = value
+			index = next
+		case strings.HasPrefix(arg, "--model="):
+			value, err := requiredInlineFlagValue(arg, "--model")
+			if err != nil {
+				return options, false, err
+			}
+			options.model = value
+		case arg == "--base-url":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.baseURL = value
+			index = next
+		case strings.HasPrefix(arg, "--base-url="):
+			value, err := requiredInlineFlagValue(arg, "--base-url")
+			if err != nil {
+				return options, false, err
+			}
+			options.baseURL = value
+		case arg == "--api-key-env":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			options.apiKeyEnv = value
+			index = next
+		case strings.HasPrefix(arg, "--api-key-env="):
+			value, err := requiredInlineFlagValue(arg, "--api-key-env")
+			if err != nil {
+				return options, false, err
+			}
+			options.apiKeyEnv = value
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown flag %q", arg)}
+		default:
+			if options.catalogID != "" {
+				return options, false, execUsageError{fmt.Sprintf("unexpected argument %q", arg)}
+			}
+			options.catalogID = arg
+		}
+	}
+	return options, false, nil
+}
+
+type setupSaveOptions struct {
+	name      string
+	baseURL   string
+	apiKeyEnv string
+}
+
+func saveSetupProvider(deps appDeps, selection tui.SetupSelection, options setupSaveOptions) (tui.SetupResult, error) {
+	profile, err := providerProfileForAdd(providerAddOptions{
+		catalogID: selection.CatalogID,
+		name:      options.name,
+		model:     firstNonEmptyCLI(selection.Model),
+		baseURL:   options.baseURL,
+		apiKeyEnv: options.apiKeyEnv,
+		setActive: true,
+	})
+	if err != nil {
+		return tui.SetupResult{}, err
+	}
+	if apiKey := strings.TrimSpace(selection.APIKey); apiKey != "" {
+		profile.APIKey = apiKey
+		profile.APIKeyEnv = ""
+	}
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return tui.SetupResult{}, err
+	}
+	if _, err := config.UpsertProvider(configPath, profile, true); err != nil {
+		return tui.SetupResult{}, err
+	}
+	return tui.SetupResult{ConfigPath: configPath, Provider: profile}, nil
+}
+
+func setupProviderOptions() []tui.SetupProviderOption {
+	descriptors := providercatalog.All()
+	options := make([]tui.SetupProviderOption, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		if !providercatalog.RuntimeSupported(descriptor) {
+			continue
+		}
+		options = append(options, tui.SetupProviderOption{
+			ID:           descriptor.ID,
+			Name:         descriptor.Name,
+			DefaultModel: descriptor.DefaultModel,
+			EnvVar:       setupProviderEnvVar(descriptor),
+			RequiresAuth: descriptor.RequiresAuth,
+			Local:        descriptor.Local,
+		})
+	}
+	return options
+}
+
+func setupProviderEnvVar(descriptor providercatalog.Descriptor) string {
+	for _, envVar := range descriptor.AuthEnvVars {
+		if envVar = strings.TrimSpace(envVar); envVar != "" {
+			return envVar
+		}
+	}
+	return ""
+}
+
+func setupRequired(resolved config.ResolvedConfig) bool {
+	if !config.HasProviderProfile(resolved.Provider) {
+		return true
+	}
+	_, missing := setupMissingCredentialEnv(resolved.Provider)
+	return missing
+}
+
+func formatSetupComplete(result tui.SetupResult) string {
+	lines := []string{"Zero setup complete"}
+	if result.Provider.Name != "" {
+		lines = append(lines, "provider: "+result.Provider.Name)
+	}
+	if result.Provider.Model != "" {
+		lines = append(lines, "model: "+result.Provider.Model)
+	}
+	if result.ConfigPath != "" {
+		lines = append(lines, "config: "+result.ConfigPath)
+	}
+	if envVar, ok := setupMissingCredentialEnv(result.Provider); ok {
+		if envVar != "" {
+			lines = append(lines, "next: set "+envVar+" in your shell")
+		} else {
+			lines = append(lines, "next: set provider credentials in your shell")
+		}
+	}
+	lines = append(lines, "next: "+setupCheckCommand(result.Provider.Name), "next: zero")
+	return strings.Join(lines, "\n")
+}
+
+func setupMissingCredentialEnv(profile config.ProviderProfile) (string, bool) {
+	if providerProfileHasCredential(profile) {
+		return "", false
+	}
+	if catalogID := strings.TrimSpace(profile.CatalogID); catalogID != "" {
+		descriptor, err := providercatalog.Require(catalogID)
+		if err != nil || !descriptor.RequiresAuth {
+			return "", false
+		}
+		return firstNonEmptyCLI(profile.APIKeyEnv, setupProviderEnvVar(descriptor)), true
+	}
+
+	switch normalizedSetupProviderKind(profile) {
+	case config.ProviderKindOpenAI, config.ProviderKindOpenAICompatible:
+		return firstNonEmptyCLI(profile.APIKeyEnv, "OPENAI_API_KEY"), true
+	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
+		return firstNonEmptyCLI(profile.APIKeyEnv, "ANTHROPIC_API_KEY"), true
+	case config.ProviderKindGoogle:
+		return firstNonEmptyCLI(profile.APIKeyEnv, "GEMINI_API_KEY"), true
+	default:
+		if strings.TrimSpace(profile.APIKeyEnv) != "" {
+			return strings.TrimSpace(profile.APIKeyEnv), true
+		}
+		return "", false
+	}
+}
+
+func normalizedSetupProviderKind(profile config.ProviderProfile) config.ProviderKind {
+	if kind := strings.TrimSpace(string(profile.ProviderKind)); kind != "" {
+		return config.ProviderKind(strings.ToLower(kind))
+	}
+	if provider := strings.TrimSpace(profile.Provider); provider != "" {
+		return config.ProviderKind(strings.ToLower(provider))
+	}
+	return ""
+}
+
+func setupCheckCommand(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "zero providers check --connectivity"
+	}
+	return "zero providers check " + setupCommandArg(name) + " --connectivity"
+}
+
+func setupCommandArg(value string) string {
+	if value == "" {
+		return strconv.Quote(value)
+	}
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		switch r {
+		case '-', '_', '.', '/', ':', '@':
+			continue
+		default:
+			return strconv.Quote(value)
+		}
+	}
+	return value
+}
+
+func writeSetupHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero setup [provider] [flags]
+
+Guides first-run Zero setup. Without a provider, opens the setup UI. With a
+provider catalog id, writes that provider as the active provider.
+
+Examples:
+  zero setup
+  zero setup openai --api-key-env OPENAI_API_KEY
+  zero setup ollama
+  zero setup ollama-cloud
+
+Flags:
+      --name <name>             Provider profile name
+      --model <model>           Override the default model
+      --base-url <url>          Override provider base URL
+      --api-key-env <name>      Store an API key environment variable name
+      --json                    Print machine-readable setup result
+  -h, --help                    Show this help
+`)
+	return err
+}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/tui"
+)
+
+func TestSetupMissingCredentialEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile config.ProviderProfile
+		wantEnv string
+		want    bool
+	}{
+		{
+			name: "catalog provider",
+			profile: config.ProviderProfile{
+				Name:      "groq",
+				CatalogID: "groq",
+			},
+			wantEnv: "GROQ_API_KEY",
+			want:    true,
+		},
+		{
+			name: "openai compatible without catalog",
+			profile: config.ProviderProfile{
+				Name:         "custom",
+				ProviderKind: config.ProviderKindOpenAICompatible,
+			},
+			wantEnv: "OPENAI_API_KEY",
+			want:    true,
+		},
+		{
+			name: "local provider",
+			profile: config.ProviderProfile{
+				Name:      "local",
+				CatalogID: "ollama",
+			},
+			want: false,
+		},
+		{
+			name: "ollama cloud provider",
+			profile: config.ProviderProfile{
+				Name:      "ollama-cloud",
+				CatalogID: "ollama-cloud",
+			},
+			wantEnv: "OLLAMA_API_KEY",
+			want:    true,
+		},
+		{
+			name: "credential resolved",
+			profile: config.ProviderProfile{
+				Name:         "openai",
+				ProviderKind: config.ProviderKindOpenAI,
+				APIKey:       "sk-test",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEnv, got := setupMissingCredentialEnv(tt.profile)
+			if got != tt.want || gotEnv != tt.wantEnv {
+				t.Fatalf("setupMissingCredentialEnv() = (%q, %v), want (%q, %v)", gotEnv, got, tt.wantEnv, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetupProviderOptionsUseRuntimeSupportedCatalog(t *testing.T) {
+	options := setupProviderOptions()
+	got := make([]string, 0, len(options))
+	for _, option := range options {
+		got = append(got, option.ID)
+	}
+
+	want := make([]string, 0)
+	for _, descriptor := range providercatalog.All() {
+		if providercatalog.RuntimeSupported(descriptor) {
+			want = append(want, descriptor.ID)
+		}
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("setupProviderOptions IDs = %#v, want runtime-supported catalog IDs %#v", got, want)
+	}
+	for _, excluded := range []string{"bedrock", "vertex"} {
+		for _, id := range got {
+			if id == excluded {
+				t.Fatalf("setupProviderOptions included unsupported provider %q in %#v", excluded, got)
+			}
+		}
+	}
+}
+
+func TestSaveSetupProviderStoresPastedAPIKey(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	result, err := saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+	}, tui.SetupSelection{
+		CatalogID: "ollama-cloud",
+		Model:     "qwen3-coder:480b",
+		APIKey:    "sk-pasted-secret",
+	}, setupSaveOptions{})
+	if err != nil {
+		t.Fatalf("saveSetupProvider() error = %v", err)
+	}
+
+	if result.Provider.APIKey != "sk-pasted-secret" {
+		t.Fatalf("Provider.APIKey = %q, want pasted key", result.Provider.APIKey)
+	}
+	if result.Provider.APIKeyEnv != "" {
+		t.Fatalf("Provider.APIKeyEnv = %q, want empty when API key is pasted", result.Provider.APIKeyEnv)
+	}
+
+	cfg := readFileConfig(t, configPath)
+	if cfg.ActiveProvider != "ollama-cloud" {
+		t.Fatalf("ActiveProvider = %q, want ollama-cloud", cfg.ActiveProvider)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("Providers = %#v, want one provider", cfg.Providers)
+	}
+	if cfg.Providers[0].APIKey != "sk-pasted-secret" || cfg.Providers[0].APIKeyEnv != "" {
+		t.Fatalf("stored provider credentials = APIKey %q APIKeyEnv %q, want pasted key only", cfg.Providers[0].APIKey, cfg.Providers[0].APIKeyEnv)
+	}
+}

--- a/internal/tui/flush.go
+++ b/internal/tui/flush.go
@@ -69,6 +69,13 @@ func (m model) settledRow(row transcriptRow, rc rowContext) bool {
 // of the unflushed tail is rendered once and queued for scrollback. It returns
 // the (possibly nil) print command for the queued batch.
 func (m model) settleTranscript() (model, tea.Cmd) {
+	// In alt-screen mode there is no native scrollback surface for tea.Println:
+	// Bubble Tea drops that output by design. Keep rows in the managed view so
+	// the chat behaves like a fullscreen app and cannot reveal prior shell
+	// history by scrolling.
+	if m.altScreen {
+		return m, nil
+	}
 	// Never freeze history at the pre-WindowSizeMsg default width: the first
 	// real WindowSizeMsg arrives before any user-visible content settles, and
 	// flushing earlier would hard-wrap startup rows at 96 cols forever.

--- a/internal/tui/flush_test.go
+++ b/internal/tui/flush_test.go
@@ -36,6 +36,26 @@ func TestSettledRowsAdvanceFrontierAndLeaveLiveView(t *testing.T) {
 	}
 }
 
+func TestAltScreenKeepsSettledRowsInManagedView(t *testing.T) {
+	m := newModel(context.Background(), Options{AltScreen: true})
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = updated.(model)
+	m.transcript = appendRow(m.transcript, rowUser, "hello there")
+	m.transcript = appendRow(m.transcript, rowSystem, "noted")
+
+	next, cmd := m.settleTranscript()
+	if cmd != nil {
+		t.Fatal("alt-screen mode should not print rows into native scrollback")
+	}
+	if next.flushed != 0 {
+		t.Fatalf("alt-screen mode should keep the flush frontier unchanged, got %d", next.flushed)
+	}
+	view := next.View()
+	if !strings.Contains(view, "hello there") || !strings.Contains(view, "noted") {
+		t.Fatalf("settled rows should remain in the managed alt-screen view, got %q", view)
+	}
+}
+
 func TestRunningToolCallBlocksFrontierUntilResult(t *testing.T) {
 	m := sizedTestModel(80)
 	m.pending = true

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -27,6 +27,7 @@ import (
 
 const tuiToolOutputLimit = 240
 const defaultResponseStyle = "balanced"
+const chatWheelScrollLines = 3
 
 type model struct {
 	ctx                    context.Context
@@ -59,6 +60,9 @@ type model struct {
 	input                  textinput.Model
 	composer               composerState
 	composerActive         bool
+	altScreen              bool
+	setup                  setupState
+	setupSave              func(SetupSelection) (SetupResult, error)
 	// spinner animates the running-tool glyph in card heads. Its tick is started
 	// with each run and stops itself once pending clears (the TickMsg is simply
 	// not forwarded), so an idle UI schedules no timers.
@@ -90,11 +94,14 @@ type model struct {
 	width             int
 	height            int
 	now               func() time.Time
+	chatScrollOffset  int
 
-	// Flush-frontier state (see flush.go). transcript[:flushed] is already in
-	// native scrollback; flushedAny gates the first turn-separator blank line;
-	// flushQueue/printInFlight serialize the ordered scrollback prints;
-	// headerPrinted records the one-time title-bar print at startup.
+	// Flush-frontier state (see flush.go). In inline mode, transcript[:flushed]
+	// is already in native scrollback; in alt-screen mode this frontier stays
+	// idle so history cannot reveal prior shell output.
+	// flushedAny gates the first turn-separator blank line; flushQueue/
+	// printInFlight serialize ordered scrollback prints; headerPrinted records
+	// the one-time title-bar print at startup.
 	flushed       int
 	flushedAny    bool
 	flushQueue    []string
@@ -297,6 +304,9 @@ func newModel(ctx context.Context, options Options) model {
 		spinner:                runSpinner,
 		now:                    time.Now,
 		notifier:               notifier,
+		altScreen:              options.AltScreen,
+		setup:                  newSetupState(options.Setup),
+		setupSave:              options.Setup.Save,
 	}
 }
 
@@ -322,8 +332,8 @@ func (m model) Init() tea.Cmd {
 }
 
 // Update routes every message through updateModel, then advances the flush
-// frontier: any transcript rows the message settled are queued for native
-// scrollback before the next frame paints (see flush.go).
+// frontier for inline rendering. Alt-screen runs keep rows in the managed view
+// instead of printing into terminal scrollback (see flush.go).
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if _, ok := msg.(flushedMsg); ok {
 		m.printInFlight = false
@@ -347,7 +357,22 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.MouseMsg:
+		if m.setup.visible {
+			return m, nil
+		}
+		switch msg.Type {
+		case tea.MouseWheelUp:
+			return m.scrollChat(chatWheelScrollLines), nil
+		case tea.MouseWheelDown:
+			return m.scrollChat(-chatWheelScrollLines), nil
+		default:
+			return m, nil
+		}
 	case tea.KeyMsg:
+		if m.setup.visible {
+			return m.handleSetupKey(msg)
+		}
 		switch msg.Type {
 		case tea.KeyCtrlC:
 			// cancelRun records the in-flight run into flushRunIDs and writes the
@@ -474,6 +499,16 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.moveSuggestion(1)
 				return m, nil
 			}
+		case tea.KeyPgUp:
+			if m.transcriptDetailed {
+				return m, nil
+			}
+			return m.scrollChat(m.chatPageScrollLines()), nil
+		case tea.KeyPgDown:
+			if m.transcriptDetailed {
+				return m, nil
+			}
+			return m.scrollChat(-m.chatPageScrollLines()), nil
 		case tea.KeyDown:
 			if m.transcriptDetailed {
 				return m, nil
@@ -596,10 +631,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Size the composer so long input scrolls horizontally with the cursor
 		// visible instead of being clipped invisibly past the right edge.
 		m.input.Width = maxInt(20, chatWidth(msg.Width)-14)
-		// The title bar prints once into native scrollback (so history scrolls
-		// above it naturally), at the first real width — never the 96-col
-		// default the pre-WindowSizeMsg frame uses.
-		if !m.headerPrinted && msg.Width > 0 {
+		// The title bar prints once into native scrollback when the inline
+		// renderer is active. In alt-screen mode tea.Println is ignored, so the
+		// title stays managed inside View.
+		if !m.altScreen && !m.headerPrinted && msg.Width > 0 {
 			m.headerPrinted = true
 			m.flushQueue = append(m.flushQueue, m.titleBar(chatWidth(msg.Width)))
 		}
@@ -770,6 +805,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
+	if m.setup.visible {
+		return m.setupView(chatWidth(m.width))
+	}
 	if m.transcriptDetailed {
 		return m.detailedTranscriptView()
 	}
@@ -787,26 +825,25 @@ func (m model) transcriptEmpty() bool {
 	return true
 }
 
-// transcriptView renders the LIVE TAIL of the chat surface: only rows the
-// flush frontier hasn't settled into native scrollback yet (running tool
-// cards, undecided prompts), plus the streaming/modal blocks and composer
-// chrome. History lives above in the terminal's own scrollback (see flush.go),
-// so this stays O(live tail) per frame regardless of session length.
+// transcriptView renders the visible chat surface: in inline mode this is the
+// live tail not yet settled into native scrollback; in alt-screen mode it is
+// the managed conversation view. Streaming/modal blocks and composer chrome are
+// always rendered here.
 func (m model) transcriptView() string {
 	width := chatWidth(m.width)
 
-	var builder strings.Builder
+	var body strings.Builder
 	// The title bar prints once into scrollback on the first WindowSizeMsg;
 	// until then (the very first frame) it renders managed so the surface
 	// never appears headless.
 	if !m.headerPrinted {
-		builder.WriteString(m.titleBar(width))
-		builder.WriteString("\n")
+		body.WriteString(m.titleBar(width))
+		body.WriteString("\n")
 	}
 
 	if m.transcriptEmpty() && !m.pending {
-		builder.WriteString(m.emptyState(width))
-		builder.WriteString("\n")
+		body.WriteString(m.emptyState(width))
+		body.WriteString("\n")
 	} else {
 		rc := buildRowContext(m.transcript)
 		shownAny := false
@@ -820,62 +857,115 @@ func (m model) transcriptView() string {
 			// Blank-line separation before turns — including between the flushed
 			// history above and the first live row.
 			if (shownAny || m.flushedAny) && startsTurn(row.kind) {
-				builder.WriteString("\n")
+				body.WriteString("\n")
 			}
-			builder.WriteString(m.renderRow(row, width, rc))
-			builder.WriteString("\n")
+			body.WriteString(m.renderRow(row, width, rc))
+			body.WriteString("\n")
 			shownAny = true
 		}
 	}
 
 	if m.pending {
-		builder.WriteString("\n")
+		body.WriteString("\n")
 		switch {
 		case m.pendingPermission != nil:
-			builder.WriteString(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
+			body.WriteString(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
 		case m.pendingAskUser != nil:
-			builder.WriteString(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
+			body.WriteString(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
 		default:
-			builder.WriteString(m.interimBlock(width))
+			body.WriteString(m.interimBlock(width))
 		}
-		builder.WriteString("\n")
+		body.WriteString("\n")
 	}
 	if m.pendingSpecReview != nil {
-		builder.WriteString("\n")
-		builder.WriteString(renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width))
-		builder.WriteString("\n")
+		body.WriteString("\n")
+		body.WriteString(renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width))
+		body.WriteString("\n")
 	}
 
-	builder.WriteString("\n")
+	var footer strings.Builder
+	footer.WriteString("\n")
 	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
-		builder.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
-		builder.WriteString("\n")
+		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
+		footer.WriteString("\n")
 	}
-	builder.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
-	builder.WriteString("\n")
-	builder.WriteString(m.composerLine(width))
+	footer.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
+	footer.WriteString("\n")
+	footer.WriteString(m.composerLine(width))
 	if queued := renderQueuedMessagePreview(m.queuedMessage, width); queued != "" {
-		builder.WriteString("\n")
-		builder.WriteString(queued)
+		footer.WriteString("\n")
+		footer.WriteString(queued)
 	}
 	if overlay := m.suggestionOverlay(width); overlay != "" {
-		builder.WriteString("\n")
-		builder.WriteString(overlay)
+		footer.WriteString("\n")
+		footer.WriteString(overlay)
 	}
 	if wizard := m.providerWizardOverlay(width); wizard != "" {
-		builder.WriteString("\n")
-		builder.WriteString(wizard)
+		footer.WriteString("\n")
+		footer.WriteString(wizard)
 	}
 	if picker := m.pickerOverlay(width); picker != "" {
-		builder.WriteString("\n")
-		builder.WriteString(picker)
+		footer.WriteString("\n")
+		footer.WriteString(picker)
 	}
-	builder.WriteString("\n")
-	builder.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
-	builder.WriteString("\n")
-	builder.WriteString(m.statusLine(width))
+	footer.WriteString("\n")
+	footer.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
+	footer.WriteString("\n")
+	footer.WriteString(m.statusLine(width))
 
-	return builder.String()
+	if m.altScreen && m.height > 0 {
+		return m.scrollableTranscriptView(body.String(), footer.String(), width)
+	}
+
+	return body.String() + footer.String()
+}
+
+func (m model) scrollableTranscriptView(body string, footer string, width int) string {
+	bodyLines := viewLines(body)
+	footerLines := viewLines(footer)
+	available := m.height - len(footerLines)
+	if available < 1 {
+		available = 1
+	}
+	maxOffset := maxInt(0, len(bodyLines)-available)
+	offset := clamp(m.chatScrollOffset, 0, maxOffset)
+	start := maxInt(0, len(bodyLines)-available-offset)
+	end := minInt(len(bodyLines), start+available)
+
+	lines := make([]string, 0, available+len(footerLines))
+	if start < end {
+		lines = append(lines, bodyLines[start:end]...)
+	}
+	for len(lines) < available {
+		lines = append(lines, "")
+	}
+	lines = append(lines, footerLines...)
+	for index, line := range lines {
+		lines[index] = fitStyledLine(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func viewLines(value string) []string {
+	if value == "" {
+		return nil
+	}
+	return strings.Split(strings.TrimSuffix(value, "\n"), "\n")
+}
+
+func (m model) scrollChat(delta int) model {
+	if !m.altScreen || delta == 0 {
+		return m
+	}
+	m.chatScrollOffset = maxInt(0, m.chatScrollOffset+delta)
+	return m
+}
+
+func (m model) chatPageScrollLines() int {
+	if m.height <= 0 {
+		return 10
+	}
+	return maxInt(3, m.height-8)
 }
 
 // interimBlock renders the live assistant text while a turn streams: muted
@@ -1066,6 +1156,7 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	m.rememberInput(input)
 	m.clearComposer()
 	m.clearSuggestions()
+	m.chatScrollOffset = 0
 
 	switch command.kind {
 	case commandEmpty:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -361,10 +361,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.setup.visible {
 			return m, nil
 		}
-		switch msg.Type {
-		case tea.MouseWheelUp:
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
 			return m.scrollChat(chatWheelScrollLines), nil
-		case tea.MouseWheelDown:
+		case tea.MouseButtonWheelDown:
 			return m.scrollChat(-chatWheelScrollLines), nil
 		default:
 			return m, nil

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -443,15 +443,6 @@ func setupProgressText(stage setupStage) string {
 	return zeroTheme.faint.Render(fmt.Sprintf("%d/%d", int(stage)+1, setupStageCount))
 }
 
-func firstNonEmptyTUI(values ...string) string {
-	for _, value := range values {
-		if value = strings.TrimSpace(value); value != "" {
-			return value
-		}
-	}
-	return ""
-}
-
 func padSetupLine(line string, width int) string {
 	if width <= 0 {
 		return line

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -1,0 +1,463 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type setupStage int
+
+const (
+	setupStageWelcome setupStage = iota
+	setupStageProvider
+	setupStageCredentials
+	setupStageSafety
+	setupStageReady
+)
+
+const setupStageCount = int(setupStageReady) + 1
+
+type setupState struct {
+	visible    bool
+	required   bool
+	configPath string
+	providers  []SetupProviderOption
+	selected   int
+	stage      setupStage
+	err        string
+	apiKey     textinput.Model
+}
+
+func newSetupState(options SetupOptions) setupState {
+	providers := append([]SetupProviderOption{}, options.Providers...)
+	if len(providers) == 0 {
+		providers = []SetupProviderOption{{
+			ID:           "openai",
+			Name:         "OpenAI",
+			DefaultModel: "gpt-4.1",
+			EnvVar:       "OPENAI_API_KEY",
+			RequiresAuth: true,
+		}}
+	}
+	apiKey := textinput.New()
+	apiKey.Prompt = ""
+	apiKey.PromptStyle = zeroTheme.faint
+	apiKey.TextStyle = zeroTheme.ink
+	apiKey.PlaceholderStyle = zeroTheme.faint
+	apiKey.Placeholder = "paste key or leave blank"
+	apiKey.EchoMode = textinput.EchoPassword
+	apiKey.EchoCharacter = '*'
+	apiKey.Focus()
+	return setupState{
+		visible:    options.Visible,
+		required:   options.Required,
+		configPath: strings.TrimSpace(options.ConfigPath),
+		providers:  providers,
+		apiKey:     apiKey,
+	}
+}
+
+func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.setupCredentialInputActive() {
+		return m.handleSetupCredentialKey(msg)
+	}
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		if m.setup.stage > setupStageWelcome {
+			m.setup.stage--
+			m.setup.err = ""
+			return m, nil
+		}
+		if m.setup.required {
+			return m, tea.Quit
+		}
+		return m.exitSetupToChat()
+	case tea.KeyLeft:
+		if m.setup.stage > setupStageWelcome {
+			m.setup.stage--
+			m.setup.err = ""
+		}
+		return m, nil
+	case tea.KeyEnter:
+		if m.setup.stage == setupStageProvider || m.setup.stage == setupStageReady {
+			return m.advanceSetup()
+		}
+		return m, nil
+	case tea.KeySpace:
+		if m.setup.stage < setupStageReady && m.setup.stage != setupStageProvider {
+			return m.advanceSetup()
+		}
+		return m, nil
+	case tea.KeyUp:
+		if m.setup.stage == setupStageProvider {
+			m.moveSetupProvider(-1)
+		}
+		return m, nil
+	case tea.KeyDown:
+		if m.setup.stage == setupStageProvider {
+			m.moveSetupProvider(1)
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case " ":
+		if m.setup.stage < setupStageReady && m.setup.stage != setupStageProvider {
+			return m.advanceSetup()
+		}
+	case "q":
+		return m, tea.Quit
+	case "k":
+		if m.setup.stage == setupStageProvider {
+			m.moveSetupProvider(-1)
+		}
+	case "j":
+		if m.setup.stage == setupStageProvider {
+			m.moveSetupProvider(1)
+		}
+	}
+	return m, nil
+}
+
+func (m model) advanceSetup() (tea.Model, tea.Cmd) {
+	if m.setup.stage < setupStageReady {
+		if m.setup.stage == setupStageProvider {
+			m.setup.apiKey.SetValue("")
+		}
+		m.setup.stage++
+		m.setup.err = ""
+		return m, nil
+	}
+	return m.completeSetup()
+}
+
+func (m *model) moveSetupProvider(delta int) {
+	if len(m.setup.providers) == 0 {
+		return
+	}
+	m.setup.selected = ((m.setup.selected+delta)%len(m.setup.providers) + len(m.setup.providers)) % len(m.setup.providers)
+	m.setup.apiKey.SetValue("")
+}
+
+func (m model) completeSetup() (tea.Model, tea.Cmd) {
+	option := m.setupProvider()
+	if option.ID == "" {
+		m.setup.err = "No provider option is available."
+		return m, nil
+	}
+	if m.setupSave == nil {
+		return m.exitSetupToChat()
+	}
+
+	result, err := m.setupSave(SetupSelection{
+		CatalogID: option.ID,
+		Model:     option.DefaultModel,
+		APIKey:    m.setupCredentialAPIKey(option),
+	})
+	if err != nil {
+		m.setup.err = err.Error()
+		return m, nil
+	}
+
+	if result.ConfigPath != "" {
+		m.setup.configPath = result.ConfigPath
+	}
+	if result.Provider.Name != "" {
+		m.providerProfile = result.Provider
+		m.providerName = result.Provider.Name
+		m.modelName = result.Provider.Model
+		if m.newProvider != nil {
+			if provider, providerErr := m.newProvider(result.Provider); providerErr == nil {
+				m.provider = provider
+			}
+		}
+	}
+
+	return m.exitSetupToChat()
+}
+
+func (m model) exitSetupToChat() (tea.Model, tea.Cmd) {
+	m.setup.visible = false
+	m.headerPrinted = false
+	m.flushQueue = nil
+	m.printInFlight = false
+	return m, nil
+}
+
+func (m model) setupCredentialInputActive() bool {
+	return m.setup.stage == setupStageCredentials && setupProviderAcceptsAPIKey(m.setupProvider())
+}
+
+func (m model) handleSetupCredentialKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc, tea.KeyLeft:
+		m.setup.stage--
+		m.setup.err = ""
+		return m, nil
+	case tea.KeyEnter:
+		return m.advanceSetup()
+	case tea.KeyUp, tea.KeyDown:
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.setup.apiKey, cmd = m.setup.apiKey.Update(msg)
+	m.setup.err = ""
+	return m, cmd
+}
+
+func setupProviderAcceptsAPIKey(option SetupProviderOption) bool {
+	return option.RequiresAuth && !option.Local
+}
+
+func (m model) setupCredentialAPIKey(option SetupProviderOption) string {
+	if !setupProviderAcceptsAPIKey(option) {
+		return ""
+	}
+	return strings.TrimSpace(m.setup.apiKey.Value())
+}
+
+func (m model) setupProvider() SetupProviderOption {
+	if len(m.setup.providers) == 0 {
+		return SetupProviderOption{}
+	}
+	index := clamp(m.setup.selected, 0, len(m.setup.providers)-1)
+	return m.setup.providers[index]
+}
+
+func (m model) setupView(width int) string {
+	if width <= 0 {
+		width = defaultStartupWidth
+	}
+	height := normalizedStartupHeight(m.height)
+	content := m.setupStageLines(width, height)
+	if m.setup.err != "" {
+		content = append(content, "", zeroTheme.red.Render("error: "+m.setup.err))
+	}
+	progress := setupProgressText(m.setup.stage)
+	footer := m.setupFooter()
+
+	topGap := maxInt(0, (height-len(content)-3)/2)
+	bottomGap := maxInt(0, height-topGap-len(content)-2)
+	lines := make([]string, 0, height)
+	for i := 0; i < topGap; i++ {
+		lines = append(lines, "")
+	}
+	lines = append(lines, centerSetupLines(content, width)...)
+	for i := 0; i < bottomGap; i++ {
+		lines = append(lines, "")
+	}
+	lines = append(lines, centerLine(fitStyledLine(progress, width), width))
+	lines = append(lines, centerLine(fitStyledLine(footer, width), width))
+	return strings.Join(lines, "\n")
+}
+
+func (m model) setupStageLines(width int, height int) []string {
+	switch m.setup.stage {
+	case setupStageProvider:
+		return m.setupProviderLines(width, height)
+	case setupStageCredentials:
+		return m.setupCredentialLines(width)
+	case setupStageSafety:
+		return []string{
+			zeroTheme.ink.Bold(true).Render("Safety"),
+			"",
+			"Zero asks before running shell commands or changing files.",
+			"Unsafe mode stays off unless you explicitly enable it.",
+			"",
+			zeroTheme.faint.Render("Default: ask before risky work."),
+		}
+	case setupStageReady:
+		option := m.setupProvider()
+		return []string{
+			zeroTheme.ink.Bold(true).Render("Ready"),
+			"",
+			"Zero will save this setup and open chat.",
+			"provider: " + displayValue(option.Name, option.ID),
+			"model: " + displayValue(option.DefaultModel, "default"),
+			"credentials: " + m.setupCredentialSummary(option),
+			"config: " + displayValue(m.setup.configPath, "user config"),
+			"",
+			zeroTheme.faint.Render("Later, use /provider, /doctor, or /help anytime."),
+		}
+	default:
+		return []string{
+			zeroTheme.accent.Render("Welcome to Zero"),
+			"",
+			zeroTheme.ink.Render("A terminal agent for changing real code."),
+			zeroTheme.faint.Render("Plan changes, edit with approval, run checks, and resume sessions."),
+		}
+	}
+}
+
+func (m model) setupProviderLines(width int, height int) []string {
+	option := m.setupProvider()
+	rowWidth := setupProviderBlockWidth(width, m.setup.providers)
+	maxVisible := setupProviderMaxVisible(height, len(m.setup.providers))
+	start := selectableListStart(len(m.setup.providers), maxVisible, m.setup.selected)
+	visibleProviders := m.setup.providers[start : start+maxVisible]
+	lines := []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("Choose a provider"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+	}
+	for index, option := range visibleProviders {
+		absoluteIndex := start + index
+		marker := "  "
+		style := zeroTheme.ink
+		if absoluteIndex == m.setup.selected {
+			marker = "❯ "
+			style = zeroTheme.accent.Bold(true)
+		}
+		line := marker + style.Render(displayValue(option.Name, option.ID))
+		lines = append(lines, padSetupLine(line, rowWidth))
+	}
+	lines = append(lines,
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render(setupProviderDetail(option)), rowWidth),
+	)
+	return lines
+}
+
+func setupProviderMaxVisible(height int, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	maxVisible := height - 10
+	if maxVisible < 6 {
+		maxVisible = 6
+	}
+	if maxVisible > total {
+		return total
+	}
+	return maxVisible
+}
+
+func setupProviderBlockWidth(terminalWidth int, providers []SetupProviderOption) int {
+	available := maxInt(24, minInt(terminalWidth-8, 44))
+	target := maxInt(lipgloss.Width("  step 2/5"), lipgloss.Width("  Choose a provider"))
+	for _, provider := range providers {
+		target = maxInt(target, 2+lipgloss.Width(displayValue(provider.Name, provider.ID)))
+		target = maxInt(target, lipgloss.Width("  "+setupProviderDetail(provider)))
+	}
+	target = maxInt(target, 32)
+	return minInt(target, available)
+}
+
+func blankSetupBlockLine(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return strings.Repeat(" ", width)
+}
+
+func setupProviderDetail(option SetupProviderOption) string {
+	if option.Local {
+		return "Local provider. Default model: " + displayValue(option.DefaultModel, "local-model")
+	}
+	return "Default model: " + displayValue(option.DefaultModel, "provider default")
+}
+
+func (m model) setupCredentialLines(width int) []string {
+	option := m.setupProvider()
+	lines := []string{
+		zeroTheme.ink.Bold(true).Render("Credentials"),
+		"",
+	}
+	if option.Local || !option.RequiresAuth {
+		lines = append(lines,
+			displayValue(option.Name, option.ID)+" does not need an API key.",
+			"Start the local server before sending a prompt.",
+		)
+		return lines
+	}
+	envVar := displayValue(option.EnvVar, "the provider API key env var")
+	lines = append(lines,
+		"Paste your "+displayValue(option.Name, option.ID)+" API key",
+		"or leave blank to use "+envVar+" from your shell.",
+		"",
+		m.setupAPIKeyInputLine(width),
+		"",
+		zeroTheme.faint.Render("Saved keys stay in your user config."),
+		zeroTheme.faint.Render("Blank uses "+envVar+" from your shell."),
+	)
+	return lines
+}
+
+func (m model) setupAPIKeyInputLine(width int) string {
+	input := m.setup.apiKey
+	if strings.TrimSpace(input.Value()) == "" {
+		return input.PlaceholderStyle.Render(input.Placeholder)
+	}
+	contentWidth := lipgloss.Width(input.Value())
+	if contentWidth == 0 {
+		contentWidth = lipgloss.Width(input.Placeholder)
+	}
+	input.Width = minInt(maxInt(contentWidth, 1), maxInt(1, width-lipgloss.Width(input.Prompt)))
+	return input.View()
+}
+
+func (m model) setupCredentialSummary(option SetupProviderOption) string {
+	if !setupProviderAcceptsAPIKey(option) {
+		return "not required"
+	}
+	if m.setupCredentialAPIKey(option) != "" {
+		return "saved API key"
+	}
+	return "env var " + displayValue(option.EnvVar, "provider API key")
+}
+
+func (m model) setupFooter() string {
+	switch m.setup.stage {
+	case setupStageReady:
+		return zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" to save and start chat")
+	case setupStageCredentials:
+		if m.setupCredentialInputActive() {
+			return zeroTheme.faint.Render("paste key optional   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   left back")
+		}
+		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to continue")
+	case setupStageProvider:
+		return zeroTheme.faint.Render("↑/↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   q quit")
+	case setupStageWelcome:
+		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to set up Zero")
+	default:
+		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to continue")
+	}
+}
+
+func centerSetupLines(lines []string, width int) []string {
+	fitted := make([]string, 0, len(lines))
+	for _, line := range lines {
+		fitted = append(fitted, centerLine(fitStyledLine(line, width), width))
+	}
+	return fitted
+}
+
+func setupProgressText(stage setupStage) string {
+	return zeroTheme.faint.Render(fmt.Sprintf("%d/%d", int(stage)+1, setupStageCount))
+}
+
+func firstNonEmptyTUI(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func padSetupLine(line string, width int) string {
+	if width <= 0 {
+		return line
+	}
+	if pad := width - lipgloss.Width(line); pad > 0 {
+		return line + strings.Repeat(" ", pad)
+	}
+	return fitStyledLine(line, width)
+}

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -1,0 +1,653 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
+	var saved SetupSelection
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible:    true,
+			Required:   true,
+			ConfigPath: "/tmp/zero/config.json",
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+				{ID: "ollama", Name: "Ollama Local", DefaultModel: "llama3.1", Local: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				saved = selection
+				return SetupResult{
+					ConfigPath: "/tmp/zero/config.json",
+					Provider: config.ProviderProfile{
+						Name:      selection.CatalogID,
+						CatalogID: selection.CatalogID,
+						Model:     selection.Model,
+					},
+				}, nil
+			},
+		},
+	})
+	m.width = 100
+	m.height = 30
+
+	if view := m.View(); !strings.Contains(view, "Welcome to Zero") || !strings.Contains(view, "Space to set up Zero") || !strings.Contains(view, "terminal agent for changing real code") {
+		t.Fatalf("setup welcome view missing expected text:\n%s", view)
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	if cmd != nil {
+		t.Fatal("setup navigation should not launch a command")
+	}
+	m = updated.(model)
+	if m.setup.stage != setupStageProvider {
+		t.Fatalf("stage = %v, want provider", m.setup.stage)
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(model)
+	if got := m.setupProvider().ID; got != "ollama" {
+		t.Fatalf("selected provider = %q, want ollama", got)
+	}
+
+	for m.setup.stage != setupStageReady {
+		m = pressSetupContinue(m)
+	}
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("setup completion should stay in the fullscreen chat surface")
+	}
+
+	if m.setup.visible {
+		t.Fatal("setup should hide after save")
+	}
+	if saved.CatalogID != "ollama" || saved.Model != "llama3.1" {
+		t.Fatalf("saved selection = %#v, want ollama llama3.1", saved)
+	}
+	if m.providerName != "ollama" || m.modelName != "llama3.1" {
+		t.Fatalf("provider state = %q/%q, want ollama/llama3.1", m.providerName, m.modelName)
+	}
+	if !m.transcriptEmpty() {
+		t.Fatalf("setup completion should open the normal empty chat surface, transcript: %#v", m.transcript)
+	}
+}
+
+func TestSetupCompletionResetsChatSurfaceInsideAltScreen(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				return SetupResult{
+					ConfigPath: "/tmp/zero/config.json",
+					Provider: config.ProviderProfile{
+						Name:      selection.CatalogID,
+						CatalogID: selection.CatalogID,
+						Model:     selection.Model,
+					},
+				}, nil
+			},
+		},
+	})
+	m.width = 100
+	m.height = 30
+	m.setup.stage = setupStageReady
+	m.headerPrinted = true
+	m.flushQueue = []string{"stale setup title"}
+	m.printInFlight = true
+
+	updated, cmd := m.completeSetup()
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("setup completion should not exit the alt-screen")
+	}
+	if m.setup.visible {
+		t.Fatal("setup should be hidden")
+	}
+	if m.headerPrinted {
+		t.Fatal("chat header should be reset so the normal surface can render it")
+	}
+	if len(m.flushQueue) != 0 {
+		t.Fatalf("stale setup flush queue should be cleared, got %#v", m.flushQueue)
+	}
+	if m.printInFlight {
+		t.Fatal("stale setup print state should be cleared")
+	}
+	if !m.transcriptEmpty() {
+		t.Fatalf("setup completion should keep the chat empty state, transcript: %#v", m.transcript)
+	}
+}
+
+func TestSetupTakeoverBlocksPromptSubmission(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1"},
+			},
+		},
+	})
+	m.input.SetValue("run tests")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("setup enter should not launch an agent run")
+	}
+	if m.pending {
+		t.Fatal("setup enter should not start a prompt")
+	}
+	if m.setup.stage != setupStageWelcome {
+		t.Fatalf("stage = %v, want welcome because Enter is not advertised here", m.setup.stage)
+	}
+}
+
+func TestSetupRightArrowDoesNotAdvance(t *testing.T) {
+	saveCalls := 0
+	for _, stage := range []setupStage{
+		setupStageWelcome,
+		setupStageProvider,
+		setupStageCredentials,
+		setupStageReady,
+	} {
+		m := newModel(context.Background(), Options{
+			Setup: SetupOptions{
+				Visible: true,
+				Providers: []SetupProviderOption{
+					{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+				},
+				Save: func(selection SetupSelection) (SetupResult, error) {
+					saveCalls++
+					return SetupResult{}, nil
+				},
+			},
+		})
+		m.setup.stage = stage
+
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatalf("right arrow at stage %v should not return a command", stage)
+		}
+		if m.setup.stage != stage {
+			t.Fatalf("right arrow advanced stage %v to %v", stage, m.setup.stage)
+		}
+		if !m.setup.visible {
+			t.Fatalf("right arrow at stage %v should not hide setup", stage)
+		}
+	}
+	if saveCalls != 0 {
+		t.Fatalf("right arrow should not save setup, got %d save calls", saveCalls)
+	}
+}
+
+func TestSetupEnterDoesNotAdvanceSpaceOnlyStages(t *testing.T) {
+	saveCalls := 0
+	for _, stage := range []setupStage{
+		setupStageWelcome,
+		setupStageCredentials,
+		setupStageSafety,
+	} {
+		m := newModel(context.Background(), Options{
+			Setup: SetupOptions{
+				Visible: true,
+				Providers: []SetupProviderOption{
+					{ID: "ollama", Name: "Ollama Local", DefaultModel: "llama3.1", Local: true},
+				},
+				Save: func(selection SetupSelection) (SetupResult, error) {
+					saveCalls++
+					return SetupResult{}, nil
+				},
+			},
+		})
+		m.setup.stage = stage
+
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatalf("enter at stage %v should not return a command", stage)
+		}
+		if m.setup.stage != stage {
+			t.Fatalf("enter advanced stage %v to %v", stage, m.setup.stage)
+		}
+		if !m.setup.visible {
+			t.Fatalf("enter at stage %v should not hide setup", stage)
+		}
+	}
+	if saveCalls != 0 {
+		t.Fatalf("enter on space-only steps should not save setup, got %d save calls", saveCalls)
+	}
+}
+
+func TestSetupProviderRequiresEnter(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageProvider
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("space on provider step should not return a command")
+	}
+	if m.setup.stage != setupStageProvider {
+		t.Fatalf("space on provider step advanced to %v", m.setup.stage)
+	}
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("enter on provider step should not return a command")
+	}
+	if m.setup.stage != setupStageCredentials {
+		t.Fatalf("enter on provider step should advance to credentials, got %v", m.setup.stage)
+	}
+}
+
+func TestSetupReadyRequiresEnter(t *testing.T) {
+	saveCalls := 0
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				saveCalls++
+				return SetupResult{
+					Provider: config.ProviderProfile{
+						Name:      selection.CatalogID,
+						CatalogID: selection.CatalogID,
+						Model:     selection.Model,
+					},
+				}, nil
+			},
+		},
+	})
+	m.setup.stage = setupStageReady
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("space on ready step should not return a command")
+	}
+	if saveCalls != 0 {
+		t.Fatalf("space on ready step should not save setup, got %d calls", saveCalls)
+	}
+	if !m.setup.visible || m.setup.stage != setupStageReady {
+		t.Fatalf("space on ready step should keep setup visible at ready, visible=%v stage=%v", m.setup.visible, m.setup.stage)
+	}
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("enter on ready step should stay in the fullscreen chat surface")
+	}
+	if saveCalls != 1 {
+		t.Fatalf("enter on ready step should save once, got %d calls", saveCalls)
+	}
+	if m.setup.visible {
+		t.Fatal("enter on ready step should open chat")
+	}
+}
+
+func TestSetupCredentialsAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T) {
+	const secret = "sk-pasted-secret"
+	var saved SetupSelection
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama-cloud", Name: "Ollama Cloud", DefaultModel: "qwen3-coder:480b", EnvVar: "OLLAMA_API_KEY", RequiresAuth: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				saved = selection
+				return SetupResult{
+					ConfigPath: "/tmp/zero/config.json",
+					Provider: config.ProviderProfile{
+						Name:      selection.CatalogID,
+						CatalogID: selection.CatalogID,
+						Model:     selection.Model,
+						APIKey:    selection.APIKey,
+					},
+				}, nil
+			},
+		},
+	})
+	m.width = 96
+	m.height = 30
+	m.setup.stage = setupStageCredentials
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(secret)})
+	m = updated.(model)
+	view := plainRender(t, m.View())
+	if strings.Contains(view, secret) {
+		t.Fatalf("setup view leaked pasted API key:\n%s", view)
+	}
+	if !strings.Contains(view, strings.Repeat("*", len(secret))) {
+		t.Fatalf("setup view should show masked API key, got:\n%s", view)
+	}
+
+	for m.setup.stage != setupStageReady {
+		m = pressSetupContinue(m)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if saved.APIKey != secret {
+		t.Fatalf("saved APIKey = %q, want pasted secret", saved.APIKey)
+	}
+	if m.providerProfile.APIKey != secret {
+		t.Fatalf("providerProfile APIKey = %q, want pasted secret", m.providerProfile.APIKey)
+	}
+}
+
+func TestSetupProviderStepKeepsModelInSelectedDetail(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+				{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5", EnvVar: "ANTHROPIC_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 180
+	m.height = 30
+	m.setup.stage = setupStageProvider
+
+	foundProviderRow := false
+	foundDefaultDetail := false
+	titleColumn := -1
+	providerColumn := -1
+	defaultColumn := -1
+	for _, line := range strings.Split(plainRender(t, m.View()), "\n") {
+		row := strings.TrimSpace(line)
+		if strings.Contains(row, "Choose a provider") {
+			titleColumn = displayColumn(line, "Choose a provider")
+		}
+		if strings.Contains(row, "Default model: gpt-4.1") {
+			foundDefaultDetail = true
+			defaultColumn = displayColumn(line, "Default model")
+		}
+		if !strings.Contains(row, "OpenAI") {
+			continue
+		}
+		foundProviderRow = true
+		providerColumn = displayColumn(line, "OpenAI")
+		if strings.Contains(row, "gpt-4.1") {
+			t.Fatalf("provider row should not render model as a column: %q", row)
+		}
+		if got := lipgloss.Width(row); got > 44 {
+			t.Fatalf("provider row width = %d, want <= 44: %q", got, row)
+		}
+	}
+	if !foundProviderRow {
+		t.Fatal("provider row missing from setup view")
+	}
+	if !foundDefaultDetail {
+		t.Fatal("selected provider default model detail missing from setup view")
+	}
+	if providerColumn < 0 || defaultColumn < 0 || providerColumn != defaultColumn {
+		t.Fatalf("default model detail should align with provider names, provider column %d detail column %d", providerColumn, defaultColumn)
+	}
+	if titleColumn < 0 || titleColumn != providerColumn {
+		t.Fatalf("provider title should align with provider names, title column %d provider column %d", titleColumn, providerColumn)
+	}
+}
+
+func TestSetupProviderSelectionDoesNotShiftBlock(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+				{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5", EnvVar: "ANTHROPIC_API_KEY", RequiresAuth: true},
+				{ID: "ollama", Name: "Ollama Local", DefaultModel: "llama3.1", Local: true},
+			},
+		},
+	})
+	m.width = 120
+	m.height = 30
+	m.setup.stage = setupStageProvider
+
+	openAIColumn := displayColumnForVisibleLine(t, m.View(), "OpenAI")
+	titleColumn := displayColumnForVisibleLine(t, m.View(), "Choose a provider")
+
+	m.moveSetupProvider(1)
+	if got := displayColumnForVisibleLine(t, m.View(), "OpenAI"); got != openAIColumn {
+		t.Fatalf("OpenAI column shifted after selecting Anthropic: got %d want %d", got, openAIColumn)
+	}
+	if got := displayColumnForVisibleLine(t, m.View(), "Choose a provider"); got != titleColumn {
+		t.Fatalf("title column shifted after selecting Anthropic: got %d want %d", got, titleColumn)
+	}
+
+	m.moveSetupProvider(1)
+	if got := displayColumnForVisibleLine(t, m.View(), "OpenAI"); got != openAIColumn {
+		t.Fatalf("OpenAI column shifted after selecting Ollama: got %d want %d", got, openAIColumn)
+	}
+	if got := displayColumnForVisibleLine(t, m.View(), "Choose a provider"); got != titleColumn {
+		t.Fatalf("title column shifted after selecting Ollama: got %d want %d", got, titleColumn)
+	}
+}
+
+func TestSetupProviderLongCatalogUsesVisibleWindow(t *testing.T) {
+	providers := make([]SetupProviderOption, 0, 14)
+	for index := 0; index < 14; index++ {
+		providers = append(providers, SetupProviderOption{
+			ID:           "provider",
+			Name:         "Provider " + string(rune('A'+index)),
+			DefaultModel: "model",
+		})
+	}
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible:   true,
+			Providers: providers,
+		},
+	})
+	m.width = 96
+	m.height = 18
+	m.setup.stage = setupStageProvider
+
+	initial := plainRender(t, m.View())
+	if !strings.Contains(initial, "Provider A") || strings.Contains(initial, "Provider N") {
+		t.Fatalf("initial provider window should show the first rows only:\n%s", initial)
+	}
+
+	m.setup.selected = len(providers) - 1
+	scrolled := plainRender(t, m.View())
+	if !strings.Contains(scrolled, "Provider N") || strings.Contains(scrolled, "Provider A") {
+		t.Fatalf("scrolled provider window should follow the selected row:\n%s", scrolled)
+	}
+}
+
+func TestSetupOllamaCloudCredentialCopyMentionsAPIKey(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama-cloud", Name: "Ollama Cloud", DefaultModel: "qwen3-coder:480b", EnvVar: "OLLAMA_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageCredentials
+
+	view := plainRender(t, m.View())
+	for _, want := range []string{"Paste your Ollama Cloud API key", "leave blank to use OLLAMA_API_KEY from your shell", "Saved keys stay in your user config"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("credential copy missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestSetupCredentialLinesCenterLikeWelcome(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama-cloud", Name: "Ollama Cloud", DefaultModel: "qwen3-coder:480b", EnvVar: "OLLAMA_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 120
+	m.height = 30
+	m.setup.stage = setupStageCredentials
+
+	view := m.View()
+	assertSetupLineCentered(t, view, "Credentials", m.width)
+	assertSetupLineCentered(t, view, "Paste your", m.width)
+	assertSetupLineCentered(t, view, "paste key", m.width)
+	assertSetupLineCentered(t, view, "Saved keys", m.width)
+}
+
+func TestSetupCredentialEmptyInputDoesNotHighlightPlaceholder(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama-cloud", Name: "Ollama Cloud", DefaultModel: "qwen3-coder:480b", EnvVar: "OLLAMA_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageCredentials
+
+	line := m.setupAPIKeyInputLine(80)
+	plain := plainRender(t, line)
+	if plain != "paste key or leave blank" {
+		t.Fatalf("empty API key input = %q, want placeholder only", plain)
+	}
+	if strings.Count(plain, "paste") != 1 {
+		t.Fatalf("empty API key input should render placeholder once, got %q", plain)
+	}
+}
+
+func TestSetupProgressRendersAboveFooter(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 96
+	m.height = 24
+	m.setup.stage = setupStageProvider
+
+	lines := strings.Split(plainRender(t, m.View()), "\n")
+	stepIndex := -1
+	footerIndex := -1
+	for index, line := range lines {
+		if strings.Contains(line, "2/5") {
+			stepIndex = index
+		}
+		if strings.Contains(line, "Enter continue") {
+			footerIndex = index
+		}
+		if strings.Contains(line, "Choose a provider") && strings.Contains(line, "2/5") {
+			t.Fatalf("progress should not render in setup body: %q", line)
+		}
+	}
+	if stepIndex < 0 || footerIndex < 0 {
+		t.Fatalf("missing setup progress/footer, step=%d footer=%d view:\n%s", stepIndex, footerIndex, strings.Join(lines, "\n"))
+	}
+	if stepIndex != footerIndex-1 {
+		t.Fatalf("progress should render immediately above footer, step line %d footer line %d", stepIndex, footerIndex)
+	}
+}
+
+func TestSetupReadyFooterUsesEnter(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 96
+	m.height = 24
+	m.setup.stage = setupStageReady
+
+	view := plainRender(t, m.View())
+	if !strings.Contains(view, "Enter to save and start chat") {
+		t.Fatalf("ready footer should use Enter, got:\n%s", view)
+	}
+	if strings.Contains(view, "Space to save and start chat") {
+		t.Fatalf("ready footer should not advertise Space, got:\n%s", view)
+	}
+}
+
+func pressSetupContinue(m model) model {
+	if m.setup.stage == setupStageProvider || m.setupCredentialInputActive() || m.setup.stage == setupStageReady {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		return updated.(model)
+	}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	return updated.(model)
+}
+
+func displayColumnForVisibleLine(t *testing.T, view string, marker string) int {
+	t.Helper()
+	for _, line := range strings.Split(plainRender(t, view), "\n") {
+		if strings.Contains(line, marker) {
+			return displayColumn(line, marker)
+		}
+	}
+	t.Fatalf("marker %q missing from view:\n%s", marker, view)
+	return -1
+}
+
+func displayColumn(line string, marker string) int {
+	index := strings.Index(line, marker)
+	if index < 0 {
+		return -1
+	}
+	return lipgloss.Width(line[:index])
+}
+
+func assertSetupLineCentered(t *testing.T, view string, marker string, width int) {
+	t.Helper()
+	line := visibleLineForMarker(t, view, marker)
+	trimmed := strings.TrimSpace(line)
+	start := lipgloss.Width(line[:strings.Index(line, strings.TrimLeft(line, " "))])
+	midpoint := start + lipgloss.Width(trimmed)/2
+	want := width / 2
+	if delta := absInt(midpoint - want); delta > 2 {
+		t.Fatalf("line %q midpoint = %d, want near %d (delta %d)", trimmed, midpoint, want, delta)
+	}
+}
+
+func visibleLineForMarker(t *testing.T, view string, marker string) string {
+	t.Helper()
+	for _, line := range strings.Split(plainRender(t, view), "\n") {
+		if strings.Contains(line, marker) {
+			return line
+		}
+	}
+	t.Fatalf("marker %q missing from view:\n%s", marker, view)
+	return ""
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -39,4 +39,45 @@ type Options struct {
 
 	// Notify configures completion / awaiting-input notifications.
 	Notify config.NotifyConfig
+
+	// AltScreen tells the model it is running inside Bubble Tea's alternate
+	// screen. Run sets this for the interactive app; tests can leave it false
+	// to exercise the native scrollback renderer.
+	AltScreen bool
+
+	// Setup configures the first-run/setup takeover. It is shown before the
+	// normal chat surface when Visible is true.
+	Setup SetupOptions
+}
+
+// SetupOptions configures the guided first-run provider setup takeover.
+type SetupOptions struct {
+	Visible    bool
+	Required   bool
+	ConfigPath string
+	Providers  []SetupProviderOption
+	Save       func(SetupSelection) (SetupResult, error)
+}
+
+// SetupProviderOption is one provider choice offered by the setup takeover.
+type SetupProviderOption struct {
+	ID           string
+	Name         string
+	DefaultModel string
+	EnvVar       string
+	RequiresAuth bool
+	Local        bool
+}
+
+// SetupSelection is the user's setup choice.
+type SetupSelection struct {
+	CatalogID string
+	Model     string
+	APIKey    string
+}
+
+// SetupResult describes a completed setup write.
+type SetupResult struct {
+	ConfigPath string
+	Provider   config.ProviderProfile
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -23,20 +23,23 @@ func Run(ctx context.Context, options Options) int {
 			program.Send(msg)
 		}
 	}
+	options.AltScreen = useAltScreen(options)
 
 	programOpts := []tea.ProgramOption{
 		tea.WithContext(ctx),
 		tea.WithInput(os.Stdin),
 		tea.WithOutput(os.Stdout),
 	}
+	if options.AltScreen {
+		programOpts = append(programOpts, tea.WithAltScreen())
+		programOpts = append(programOpts, tea.WithMouseCellMotion())
+	}
 	if notify.Enabled(notify.Mode(strings.TrimSpace(options.Notify.Mode))) {
 		programOpts = append(programOpts, tea.WithReportFocus())
 	}
-	// NOTE: we intentionally do NOT enable mouse capture. Mouse cell-motion
-	// reporting routes clicks/drags to the program, which breaks the terminal's
-	// native text selection + copy and surprises users who expect normal
-	// click/select/copy/paste. The permission modal is fully keyboard-driven
-	// (a/y/d/Esc), so capturing the mouse buys little and costs core UX.
+	// Mouse capture is scoped to the alt-screen app so wheel events scroll the
+	// managed transcript instead of being translated into ↑/↓ keypresses by the
+	// terminal, which would recall composer history.
 	program = tea.NewProgram(newModel(ctx, options), programOpts...)
 
 	if _, err := program.Run(); err != nil {
@@ -46,4 +49,8 @@ func Run(ctx context.Context, options Options) int {
 		return 1
 	}
 	return 0
+}
+
+func useAltScreen(_ Options) bool {
+	return true
 }

--- a/internal/tui/run_test.go
+++ b/internal/tui/run_test.go
@@ -1,0 +1,12 @@
+package tui
+
+import "testing"
+
+func TestUseAltScreenForInteractiveChat(t *testing.T) {
+	if !useAltScreen(Options{}) {
+		t.Fatal("normal chat should use the alternate screen")
+	}
+	if !useAltScreen(Options{Setup: SetupOptions{Visible: true}}) {
+		t.Fatal("setup takeover should also use the alternate screen")
+	}
+}

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -18,7 +18,7 @@ func TestMouseWheelScrollsChatWithoutRecallingInputHistory(t *testing.T) {
 		m.transcript = appendRow(m.transcript, rowAssistant, "message "+string(rune('A'+index)))
 	}
 
-	updated, cmd := m.Update(tea.MouseMsg{Type: tea.MouseWheelUp})
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
 	m = updated.(model)
 	if cmd != nil {
 		t.Fatal("mouse wheel should not return a command")

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestMouseWheelScrollsChatWithoutRecallingInputHistory(t *testing.T) {
+	m := newModel(context.Background(), Options{AltScreen: true})
+	m.width = 90
+	m.height = 14
+	m.inputHistory = []string{"old prompt"}
+	m.historyIdx = len(m.inputHistory)
+	for index := 0; index < 12; index++ {
+		m.transcript = appendRow(m.transcript, rowAssistant, "message "+string(rune('A'+index)))
+	}
+
+	updated, cmd := m.Update(tea.MouseMsg{Type: tea.MouseWheelUp})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("mouse wheel should not return a command")
+	}
+	if got := m.input.Value(); got != "" {
+		t.Fatalf("mouse wheel should not recall input history, got %q", got)
+	}
+	if m.chatScrollOffset != chatWheelScrollLines {
+		t.Fatalf("chatScrollOffset = %d, want %d", m.chatScrollOffset, chatWheelScrollLines)
+	}
+}
+
+func TestAltScreenTranscriptScrollKeepsFooterFixed(t *testing.T) {
+	m := newModel(context.Background(), Options{AltScreen: true, ProviderName: "openai", ModelName: "gpt-4.1"})
+	m.width = 90
+	m.height = 10
+	for index := 0; index < 14; index++ {
+		m.transcript = appendRow(m.transcript, rowAssistant, "message "+string(rune('A'+index)))
+	}
+
+	bottom := plainRender(t, m.View())
+	if strings.Contains(bottom, "message A") {
+		t.Fatalf("bottom view should start near recent history, got:\n%s", bottom)
+	}
+	if !strings.Contains(bottom, "describe a task for zero") || !strings.Contains(bottom, "openai") {
+		t.Fatalf("bottom view should keep composer/status fixed, got:\n%s", bottom)
+	}
+
+	m = m.scrollChat(80)
+	scrolled := plainRender(t, m.View())
+	if !strings.Contains(scrolled, "message A") {
+		t.Fatalf("scrolled view should reveal older history, got:\n%s", scrolled)
+	}
+	if !strings.Contains(scrolled, "describe a task for zero") || !strings.Contains(scrolled, "openai") {
+		t.Fatalf("scrolled view should keep composer/status fixed, got:\n%s", scrolled)
+	}
+}
+
+func TestPageKeysScrollAltScreenTranscript(t *testing.T) {
+	m := newModel(context.Background(), Options{AltScreen: true})
+	m.width = 90
+	m.height = 20
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = updated.(model)
+	if m.chatScrollOffset != m.chatPageScrollLines() {
+		t.Fatalf("page up offset = %d, want %d", m.chatScrollOffset, m.chatPageScrollLines())
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = updated.(model)
+	if m.chatScrollOffset != 0 {
+		t.Fatalf("page down should return to bottom, got offset %d", m.chatScrollOffset)
+	}
+}

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -13,9 +13,18 @@ const (
 	minStartupWidth      = 58
 )
 
-// zeroGlyphLines is the block-art `0` shown on the empty chat surface,
-// derived from the O columns of the old ANSI Shadow wordmark.
-var zeroGlyphLines = []string{
+// zeroWordmarkPrefixLines is the white `ZER` part of the empty-state ANSI
+// Shadow-style wordmark. zeroWordmarkOLines keeps the old lime `O` glyph.
+var zeroWordmarkPrefixLines = []string{
+	`███████╗███████╗██████╗ `,
+	`╚══███╔╝██╔════╝██╔══██╗`,
+	`  ███╔╝ █████╗  ██████╔╝`,
+	` ███╔╝  ██╔══╝  ██╔══██╗`,
+	`███████╗███████╗██║  ██║`,
+	`╚══════╝╚══════╝╚═╝  ╚═╝`,
+}
+
+var zeroWordmarkOLines = []string{
 	` ██████╗ `,
 	`██╔═══██╗`,
 	`██║   ██║`,
@@ -31,8 +40,8 @@ const emptyStateTagline = "a std-lib-first coding agent · bring your own key ·
 // hint, and the three starter-suggestion chips (inserted by keys 1–3).
 func (m model) emptyState(width int) string {
 	lines := []string{}
-	for _, glyph := range zeroGlyphLines {
-		lines = append(lines, centerLine(zeroTheme.accent.Render(glyph), width))
+	for _, glyph := range zeroWordmarkLines() {
+		lines = append(lines, centerLine(glyph, width))
 	}
 	lines = append(lines, "")
 	lines = append(lines, centerLine(zeroTheme.muted.Render(emptyStateTagline), width))
@@ -50,6 +59,14 @@ func (m model) emptyState(width int) string {
 	height := normalizedStartupHeight(m.height)
 	gap := clamp((height-6-len(lines))/2, 0, 12)
 	return strings.Repeat("\n", gap) + strings.Join(lines, "\n") + strings.Repeat("\n", gap)
+}
+
+func zeroWordmarkLines() []string {
+	lines := make([]string, 0, minInt(len(zeroWordmarkPrefixLines), len(zeroWordmarkOLines)))
+	for index := 0; index < len(zeroWordmarkPrefixLines) && index < len(zeroWordmarkOLines); index++ {
+		lines = append(lines, zeroTheme.ink.Render(zeroWordmarkPrefixLines[index])+zeroTheme.accent.Render(zeroWordmarkOLines[index]))
+	}
+	return lines
 }
 
 func (m model) emptyStateModelHint() string {

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -12,7 +12,8 @@ func TestEmptyStateShowsBrandTaglineAndSuggestions(t *testing.T) {
 	m := newModel(context.Background(), Options{ProviderName: "anthropic", ModelName: "claude-sonnet-4.5"})
 	m.width, m.height = 100, 30
 
-	view := m.View()
+	view := plainRender(t, m.View())
+	assertContains(t, view, "███████╗███████╗██████╗  ██████╗")
 	assertContains(t, view, emptyStateTagline)
 	assertContains(t, view, "running zero against ")
 	assertContains(t, view, "anthropic/claude-sonnet-4.5")


### PR DESCRIPTION
## Summary
- add `zero setup` and first-run provider onboarding when no usable provider credentials are configured
- source onboarding choices from the runtime-supported provider catalog, including Ollama Cloud/Local handling
- save selected providers into user config, including optional pasted API keys
- keep the interactive TUI in alt-screen and add managed transcript scrolling so wheel/PageUp/PageDown do not recall composer history

## Tests
- `GOCACHE=/tmp/zero-go-cache go test ./...`
- `git diff --check`

## Notes
Draft for visual review of the onboarding flow and fullscreen chat scroll behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive setup flow guides first-time provider configuration.
  * New `setup` command enables credential configuration directly from CLI.
  * Scrollable chat transcript with mouse wheel and PageUp/PageDown navigation.

* **Improvements**
  * Enhanced terminal display rendering in alternate screen mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->