### PR TITLE
Add first-run model picker

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -359,7 +359,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.MouseMsg:
 		if m.setup.visible {
-			return m, nil
+			return m.handleSetupMouse(msg)
 		}
 		switch msg.Button {
 		case tea.MouseButtonWheelUp:
@@ -795,6 +795,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case providerModelsDiscoveredMsg:
 		return m.applyProviderModelsDiscovered(msg), nil
+	case setupModelsDiscoveredMsg:
+		return m.applySetupModelsDiscovered(msg), nil
 	case modelPickerModelsDiscoveredMsg:
 		return m.applyModelPickerModelsDiscovered(msg), nil
 	}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -1,12 +1,19 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
+	"github.com/Gitlawb/zero/internal/redaction"
 )
 
 type setupStage int
@@ -15,6 +22,7 @@ const (
 	setupStageWelcome setupStage = iota
 	setupStageProvider
 	setupStageCredentials
+	setupStageModel
 	setupStageSafety
 	setupStageReady
 )
@@ -30,6 +38,19 @@ type setupState struct {
 	stage      setupStage
 	err        string
 	apiKey     textinput.Model
+	models     []providerWizardModel
+	modelIndex int
+	modelQuery string
+	modelForID string
+	modelLoad  bool
+	modelErr   string
+	modelSrc   string
+}
+
+type setupModelsDiscoveredMsg struct {
+	providerID string
+	models     []providermodeldiscovery.Model
+	err        error
 }
 
 func newSetupState(options SetupOptions) setupState {
@@ -85,30 +106,63 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyEnter:
-		if m.setup.stage == setupStageProvider || m.setup.stage == setupStageReady {
+		if m.setup.stage == setupStageProvider || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
 			return m.advanceSetup()
 		}
 		return m, nil
 	case tea.KeySpace:
-		if m.setup.stage < setupStageReady && m.setup.stage != setupStageProvider {
+		if m.setup.stage < setupStageReady && m.setup.stage != setupStageProvider && m.setup.stage != setupStageModel {
 			return m.advanceSetup()
 		}
 		return m, nil
 	case tea.KeyUp:
 		if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(-1)
+		} else if m.setup.stage == setupStageModel {
+			m.moveSetupModel(-1)
 		}
 		return m, nil
 	case tea.KeyDown:
 		if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(1)
+		} else if m.setup.stage == setupStageModel {
+			m.moveSetupModel(1)
+		}
+		return m, nil
+	case tea.KeyRunes:
+		if m.setup.stage == setupStageModel {
+			m.appendSetupModelQuery(msg.Runes)
+			return m, nil
+		}
+		switch msg.String() {
+		case "q":
+			return m, tea.Quit
+		case "k":
+			if m.setup.stage == setupStageProvider {
+				m.moveSetupProvider(-1)
+			}
+		case "j":
+			if m.setup.stage == setupStageProvider {
+				m.moveSetupProvider(1)
+			}
+		}
+		return m, nil
+	case tea.KeyBackspace, tea.KeyCtrlH:
+		if m.setup.stage == setupStageModel {
+			m.deleteSetupModelQueryRune()
+		}
+		return m, nil
+	case tea.KeyCtrlU:
+		if m.setup.stage == setupStageModel {
+			m.setup.modelQuery = ""
+			m.setup.modelIndex = 0
 		}
 		return m, nil
 	}
 
 	switch msg.String() {
 	case " ":
-		if m.setup.stage < setupStageReady && m.setup.stage != setupStageProvider {
+		if m.setup.stage < setupStageReady && m.setup.stage != setupStageProvider && m.setup.stage != setupStageModel {
 			return m.advanceSetup()
 		}
 	case "q":
@@ -116,10 +170,32 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "k":
 		if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(-1)
+		} else if m.setup.stage == setupStageModel {
+			m.moveSetupModel(-1)
 		}
 	case "j":
 		if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(1)
+		} else if m.setup.stage == setupStageModel {
+			m.moveSetupModel(1)
+		}
+	}
+	return m, nil
+}
+
+func (m model) handleSetupMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		if m.setup.stage == setupStageProvider {
+			m.moveSetupProvider(-1)
+		} else if m.setup.stage == setupStageModel {
+			m.moveSetupModel(-1)
+		}
+	case tea.MouseButtonWheelDown:
+		if m.setup.stage == setupStageProvider {
+			m.moveSetupProvider(1)
+		} else if m.setup.stage == setupStageModel {
+			m.moveSetupModel(1)
 		}
 	}
 	return m, nil
@@ -130,8 +206,23 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 		if m.setup.stage == setupStageProvider {
 			m.setup.apiKey.SetValue("")
 		}
+		if m.setup.stage == setupStageModel && m.setup.modelLoad {
+			m.setup.err = "Models are still loading."
+			return m, nil
+		}
+		if m.setup.stage == setupStageModel && m.setupCurrentModel().ID == "" {
+			m.setup.err = "Choose a matching model before continuing."
+			return m, nil
+		}
 		m.setup.stage++
 		m.setup.err = ""
+		if m.setup.stage == setupStageModel {
+			m.resetSetupModels()
+			m.setup.modelErr = ""
+			cmd := m.setupModelDiscoveryCmd()
+			m.setup.modelLoad = cmd != nil
+			return m, cmd
+		}
 		return m, nil
 	}
 	return m.completeSetup()
@@ -143,6 +234,7 @@ func (m *model) moveSetupProvider(delta int) {
 	}
 	m.setup.selected = ((m.setup.selected+delta)%len(m.setup.providers) + len(m.setup.providers)) % len(m.setup.providers)
 	m.setup.apiKey.SetValue("")
+	m.resetSetupModels()
 }
 
 func (m model) completeSetup() (tea.Model, tea.Cmd) {
@@ -157,7 +249,7 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 
 	result, err := m.setupSave(SetupSelection{
 		CatalogID: option.ID,
-		Model:     option.DefaultModel,
+		Model:     m.setupCurrentModel().ID,
 		APIKey:    m.setupCredentialAPIKey(option),
 	})
 	if err != nil {
@@ -180,6 +272,182 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 	}
 
 	return m.exitSetupToChat()
+}
+
+func (m *model) resetSetupModels() {
+	option := m.setupProvider()
+	provider := setupProviderDescriptor(option)
+	models := providerWizardModelOptions(provider)
+	m.setup.models = models
+	m.setup.modelIndex = 0
+	m.setup.modelQuery = ""
+	m.setup.modelForID = provider.ID
+	m.setup.modelLoad = false
+	m.setup.modelErr = ""
+	m.setup.modelSrc = "fallback"
+}
+
+func (m model) setupModelDiscoveryCmd() tea.Cmd {
+	option := m.setupProvider()
+	provider := setupProviderDescriptor(option)
+	if provider.ID == "" || !providercatalog.RuntimeSupported(provider) {
+		return nil
+	}
+	profile := providerWizardDiscoveryProfile(provider, m.setupCredentialAPIKey(option))
+	discover := m.discoverProviderModels
+	if discover == nil {
+		discover = func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return providermodeldiscovery.DiscoverCatalog(ctx, provider, profile, providermodeldiscovery.Options{})
+		}
+	}
+	providerID := provider.ID
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
+		defer cancel()
+		models, err := discover(ctx, profile)
+		return setupModelsDiscoveredMsg{providerID: providerID, models: models, err: err}
+	}
+}
+
+func (m model) applySetupModelsDiscovered(msg setupModelsDiscoveredMsg) model {
+	if !m.setup.visible || m.setup.stage != setupStageModel || m.setupProviderDescriptor().ID != msg.providerID {
+		return m
+	}
+	m.setup.modelLoad = false
+	m.setup.err = ""
+	if msg.err != nil {
+		profile := providerWizardDiscoveryProfile(m.setupProviderDescriptor(), m.setupCredentialAPIKey(m.setupProvider()))
+		m.setup.modelErr = redaction.RedactString(msg.err.Error(), redaction.Options{ExtraSecretValues: []string{m.setup.apiKey.Value(), profile.APIKey}})
+		m.setup.modelSrc = "fallback"
+		if len(m.setup.models) == 0 {
+			m.resetSetupModels()
+		}
+		return m
+	}
+	models := providerWizardModelsFromDiscovery(msg.models)
+	if len(models) == 0 {
+		m.setup.modelErr = "models endpoint returned no model ids"
+		m.setup.modelSrc = "fallback"
+		if len(m.setup.models) == 0 {
+			m.resetSetupModels()
+		}
+		return m
+	}
+	currentID := m.setupCurrentModel().ID
+	m.setup.models = models
+	m.setup.modelIndex = 0
+	m.setup.modelSrc = providerWizardModelsSource(msg.models)
+	if m.setup.modelSrc == "" {
+		m.setup.modelSrc = "live"
+	}
+	m.setup.modelErr = ""
+	if currentID != "" {
+		for index, model := range m.setupFilteredModels() {
+			if model.ID == currentID {
+				m.setup.modelIndex = index
+				break
+			}
+		}
+	}
+	return m
+}
+
+func (m model) setupProviderDescriptor() providercatalog.Descriptor {
+	return setupProviderDescriptor(m.setupProvider())
+}
+
+func setupProviderDescriptor(option SetupProviderOption) providercatalog.Descriptor {
+	if descriptor, ok := providercatalog.Get(option.ID); ok {
+		return descriptor
+	}
+	descriptor := providercatalog.Descriptor{
+		ID:           strings.TrimSpace(option.ID),
+		Name:         strings.TrimSpace(option.Name),
+		DefaultModel: strings.TrimSpace(option.DefaultModel),
+		RequiresAuth: option.RequiresAuth,
+		Local:        option.Local,
+		AuthEnvVars:  cleanSetupEnvVar(option.EnvVar),
+	}
+	return descriptor
+}
+
+func cleanSetupEnvVar(envVar string) []string {
+	if envVar = strings.TrimSpace(envVar); envVar != "" {
+		return []string{envVar}
+	}
+	return nil
+}
+
+func (m model) setupCurrentModel() providerWizardModel {
+	m.ensureSetupModels()
+	models := m.setupFilteredModels()
+	if len(models) == 0 {
+		return providerWizardModel{Description: "no matching models"}
+	}
+	index := clamp(m.setup.modelIndex, 0, len(models)-1)
+	return models[index]
+}
+
+func (m *model) ensureSetupModels() {
+	option := m.setupProvider()
+	providerID := setupProviderDescriptor(option).ID
+	if len(m.setup.models) > 0 && m.setup.modelForID == providerID {
+		return
+	}
+	m.resetSetupModels()
+}
+
+func (m model) setupFilteredModels() []providerWizardModel {
+	query := strings.ToLower(strings.TrimSpace(m.setup.modelQuery))
+	if query == "" {
+		return append([]providerWizardModel{}, m.setup.models...)
+	}
+	models := make([]providerWizardModel, 0, len(m.setup.models))
+	for _, model := range m.setup.models {
+		if model.matches(query) {
+			models = append(models, model)
+		}
+	}
+	return models
+}
+
+func (m *model) moveSetupModel(delta int) {
+	if m.setup.modelLoad {
+		return
+	}
+	m.ensureSetupModels()
+	models := m.setupFilteredModels()
+	if len(models) == 0 {
+		return
+	}
+	m.setup.modelIndex = ((m.setup.modelIndex+delta)%len(models) + len(models)) % len(models)
+}
+
+func (m *model) appendSetupModelQuery(runes []rune) {
+	if m.setup.modelLoad {
+		return
+	}
+	for _, r := range runes {
+		if r < 32 || r == 127 {
+			continue
+		}
+		m.setup.modelQuery += string(r)
+	}
+	m.setup.modelIndex = 0
+	m.setup.err = ""
+}
+
+func (m *model) deleteSetupModelQueryRune() {
+	if m.setup.modelLoad {
+		return
+	}
+	if m.setup.modelQuery == "" {
+		return
+	}
+	runes := []rune(m.setup.modelQuery)
+	m.setup.modelQuery = string(runes[:len(runes)-1])
+	m.setup.modelIndex = 0
+	m.setup.err = ""
 }
 
 func (m model) exitSetupToChat() (tea.Model, tea.Cmd) {
@@ -265,6 +533,8 @@ func (m model) setupStageLines(width int, height int) []string {
 		return m.setupProviderLines(width, height)
 	case setupStageCredentials:
 		return m.setupCredentialLines(width)
+	case setupStageModel:
+		return m.setupModelLines(width, height)
 	case setupStageSafety:
 		return []string{
 			zeroTheme.ink.Bold(true).Render("Safety"),
@@ -276,12 +546,13 @@ func (m model) setupStageLines(width int, height int) []string {
 		}
 	case setupStageReady:
 		option := m.setupProvider()
+		model := m.setupCurrentModel()
 		return []string{
 			zeroTheme.ink.Bold(true).Render("Ready"),
 			"",
 			"Zero will save this setup and open chat.",
 			"provider: " + displayValue(option.Name, option.ID),
-			"model: " + displayValue(option.DefaultModel, "default"),
+			"model: " + displayValue(model.ID, option.DefaultModel),
 			"credentials: " + m.setupCredentialSummary(option),
 			"config: " + displayValue(m.setup.configPath, "user config"),
 			"",
@@ -297,8 +568,135 @@ func (m model) setupStageLines(width int, height int) []string {
 	}
 }
 
+func (m model) setupModelLines(width int, height int) []string {
+	m.ensureSetupModels()
+	if m.setup.modelLoad {
+		return m.setupModelLoadingLines(width)
+	}
+	rowWidth := setupModelBlockWidth(width, m.setup.models)
+	models := m.setupFilteredModels()
+	maxVisible := setupModelMaxVisible(height, len(models))
+	start := selectableListStart(len(models), maxVisible, m.setup.modelIndex)
+	lines := []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("Choose a model"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+m.setupModelSearchLine(rowWidth-2), rowWidth),
+	}
+	if status := m.setupModelStatus(); status != "" {
+		lines = append(lines, padSetupLine("  "+zeroTheme.faint.Render(status), rowWidth))
+	}
+	lines = append(lines, blankSetupBlockLine(rowWidth))
+	if len(models) == 0 {
+		lines = append(lines, padSetupLine("  "+zeroTheme.faint.Render("No matching models"), rowWidth))
+		return lines
+	}
+	visibleModels := models[start : start+maxVisible]
+	for offset, model := range visibleModels {
+		lines = append(lines, m.setupModelRow(rowWidth, start+offset, model))
+	}
+	if hidden := len(models) - maxVisible; hidden > 0 {
+		lines = append(lines, padSetupLine("  "+zeroTheme.faint.Render(fmt.Sprintf("%d more models", hidden)), rowWidth))
+	}
+	if detail := setupModelSelectedDetail(m.setupCurrentModel()); detail != "" {
+		lines = append(lines,
+			blankSetupBlockLine(rowWidth),
+			padSetupLine("  "+zeroTheme.faint.Render(detail), rowWidth),
+		)
+	}
+	return lines
+}
+
+func (m model) setupModelLoadingLines(width int) []string {
+	rowWidth := setupModelLoadingBlockWidth(width)
+	return []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("Choose a model"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render("Checking available models..."), rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render("Built-in models will be used if discovery fails."), rowWidth),
+	}
+}
+
+func setupModelMaxVisible(height int, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	maxVisible := height - 12
+	if maxVisible < 5 {
+		maxVisible = 5
+	}
+	if maxVisible > 18 {
+		maxVisible = 18
+	}
+	if maxVisible > total {
+		return total
+	}
+	return maxVisible
+}
+
+func setupModelLoadingBlockWidth(terminalWidth int) int {
+	available := maxInt(34, minInt(terminalWidth-8, 72))
+	target := maxInt(lipgloss.Width("  Choose a model"), lipgloss.Width("  Built-in models will be used if discovery fails."))
+	return minInt(maxInt(target, 42), available)
+}
+
+func setupModelBlockWidth(terminalWidth int, models []providerWizardModel) int {
+	available := maxInt(34, minInt(terminalWidth-8, 72))
+	target := lipgloss.Width("  Choose a model")
+	target = maxInt(target, lipgloss.Width("  search > Search model"))
+	for _, model := range models {
+		target = maxInt(target, 4+lipgloss.Width(model.displayLabel()))
+		if detail := setupModelSelectedDetail(model); detail != "" {
+			target = maxInt(target, lipgloss.Width("  "+detail))
+		}
+	}
+	target = maxInt(target, 42)
+	return minInt(target, available)
+}
+
+func (m model) setupModelSearchLine(width int) string {
+	query := strings.TrimSpace(m.setup.modelQuery)
+	prompt := zeroTheme.userPrompt.Render("search > ")
+	cursor := zeroTheme.accent.Render("▌")
+	if query == "" {
+		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render("model name..."), width)
+	}
+	return fitStyledLine(prompt+zeroTheme.ink.Render(query)+cursor, width)
+}
+
+func (m model) setupModelStatus() string {
+	if m.setup.modelLoad {
+		return "Refreshing available models"
+	}
+	if m.setup.modelErr != "" {
+		return "Using built-in model list"
+	}
+	return ""
+}
+
+func (m model) setupModelRow(width int, index int, model providerWizardModel) string {
+	selected := index == m.setup.modelIndex
+	marker := "  "
+	style := zeroTheme.ink
+	if selected {
+		marker = "❯ "
+		style = zeroTheme.accent.Bold(true)
+	}
+	left := marker + style.Render(model.displayLabel())
+	return padSetupLine(left, width)
+}
+
+func setupModelSelectedDetail(model providerWizardModel) string {
+	parts := []string{}
+	if secondary := strings.TrimSpace(model.secondaryText()); secondary != "" && !providerWizardGenericModelDescription(secondary) {
+		parts = append(parts, secondary)
+	}
+	if meta := strings.TrimSpace(model.Meta); meta != "" {
+		parts = append(parts, meta)
+	}
+	return strings.Join(parts, " · ")
+}
+
 func (m model) setupProviderLines(width int, height int) []string {
-	option := m.setupProvider()
 	rowWidth := setupProviderBlockWidth(width, m.setup.providers)
 	maxVisible := setupProviderMaxVisible(height, len(m.setup.providers))
 	start := selectableListStart(len(m.setup.providers), maxVisible, m.setup.selected)
@@ -318,10 +716,6 @@ func (m model) setupProviderLines(width int, height int) []string {
 		line := marker + style.Render(displayValue(option.Name, option.ID))
 		lines = append(lines, padSetupLine(line, rowWidth))
 	}
-	lines = append(lines,
-		blankSetupBlockLine(rowWidth),
-		padSetupLine("  "+zeroTheme.faint.Render(setupProviderDetail(option)), rowWidth),
-	)
 	return lines
 }
 
@@ -329,7 +723,7 @@ func setupProviderMaxVisible(height int, total int) int {
 	if total <= 0 {
 		return 0
 	}
-	maxVisible := height - 10
+	maxVisible := height - 8
 	if maxVisible < 6 {
 		maxVisible = 6
 	}
@@ -341,10 +735,9 @@ func setupProviderMaxVisible(height int, total int) int {
 
 func setupProviderBlockWidth(terminalWidth int, providers []SetupProviderOption) int {
 	available := maxInt(24, minInt(terminalWidth-8, 44))
-	target := maxInt(lipgloss.Width("  step 2/5"), lipgloss.Width("  Choose a provider"))
+	target := maxInt(lipgloss.Width("  2/6"), lipgloss.Width("  Choose a provider"))
 	for _, provider := range providers {
 		target = maxInt(target, 2+lipgloss.Width(displayValue(provider.Name, provider.ID)))
-		target = maxInt(target, lipgloss.Width("  "+setupProviderDetail(provider)))
 	}
 	target = maxInt(target, 32)
 	return minInt(target, available)
@@ -355,13 +748,6 @@ func blankSetupBlockLine(width int) string {
 		return ""
 	}
 	return strings.Repeat(" ", width)
-}
-
-func setupProviderDetail(option SetupProviderOption) string {
-	if option.Local {
-		return "Local provider. Default model: " + displayValue(option.DefaultModel, "local-model")
-	}
-	return "Default model: " + displayValue(option.DefaultModel, "provider default")
 }
 
 func (m model) setupCredentialLines(width int) []string {
@@ -424,6 +810,11 @@ func (m model) setupFooter() string {
 		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to continue")
 	case setupStageProvider:
 		return zeroTheme.faint.Render("↑/↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   q quit")
+	case setupStageModel:
+		if m.setup.modelLoad {
+			return zeroTheme.faint.Render("checking models...")
+		}
+		return zeroTheme.faint.Render("↑/↓ choose   type search   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue")
 	case setupStageWelcome:
 		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to set up Zero")
 	default:

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -45,12 +45,15 @@ type setupState struct {
 	modelLoad  bool
 	modelErr   string
 	modelSrc   string
+	modelGen   uint64
 }
 
 type setupModelsDiscoveredMsg struct {
-	providerID string
-	models     []providermodeldiscovery.Model
-	err        error
+	providerID       string
+	gen              uint64
+	redactionSecrets []string
+	models           []providermodeldiscovery.Model
+	err              error
 }
 
 func newSetupState(options SetupOptions) setupState {
@@ -219,7 +222,8 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 		if m.setup.stage == setupStageModel {
 			m.resetSetupModels()
 			m.setup.modelErr = ""
-			cmd := m.setupModelDiscoveryCmd()
+			m.setup.modelGen++
+			cmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
 			m.setup.modelLoad = cmd != nil
 			return m, cmd
 		}
@@ -234,6 +238,7 @@ func (m *model) moveSetupProvider(delta int) {
 	}
 	m.setup.selected = ((m.setup.selected+delta)%len(m.setup.providers) + len(m.setup.providers)) % len(m.setup.providers)
 	m.setup.apiKey.SetValue("")
+	m.setup.modelGen++
 	m.resetSetupModels()
 }
 
@@ -287,13 +292,14 @@ func (m *model) resetSetupModels() {
 	m.setup.modelSrc = "fallback"
 }
 
-func (m model) setupModelDiscoveryCmd() tea.Cmd {
+func (m model) setupModelDiscoveryCmd(gen uint64) tea.Cmd {
 	option := m.setupProvider()
 	provider := setupProviderDescriptor(option)
 	if provider.ID == "" || !providercatalog.RuntimeSupported(provider) {
 		return nil
 	}
 	profile := providerWizardDiscoveryProfile(provider, m.setupCredentialAPIKey(option))
+	redactionSecrets := []string{m.setup.apiKey.Value(), profile.APIKey}
 	discover := m.discoverProviderModels
 	if discover == nil {
 		discover = func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
@@ -305,19 +311,18 @@ func (m model) setupModelDiscoveryCmd() tea.Cmd {
 		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
 		defer cancel()
 		models, err := discover(ctx, profile)
-		return setupModelsDiscoveredMsg{providerID: providerID, models: models, err: err}
+		return setupModelsDiscoveredMsg{providerID: providerID, gen: gen, redactionSecrets: redactionSecrets, models: models, err: err}
 	}
 }
 
 func (m model) applySetupModelsDiscovered(msg setupModelsDiscoveredMsg) model {
-	if !m.setup.visible || m.setup.stage != setupStageModel || m.setupProviderDescriptor().ID != msg.providerID {
+	if !m.setup.visible || m.setup.stage != setupStageModel || m.setupProviderDescriptor().ID != msg.providerID || m.setup.modelGen != msg.gen {
 		return m
 	}
 	m.setup.modelLoad = false
 	m.setup.err = ""
 	if msg.err != nil {
-		profile := providerWizardDiscoveryProfile(m.setupProviderDescriptor(), m.setupCredentialAPIKey(m.setupProvider()))
-		m.setup.modelErr = redaction.RedactString(msg.err.Error(), redaction.Options{ExtraSecretValues: []string{m.setup.apiKey.Value(), profile.APIKey}})
+		m.setup.modelErr = redaction.RedactString(msg.err.Error(), redaction.Options{ExtraSecretValues: msg.redactionSecrets})
 		m.setup.modelSrc = "fallback"
 		if len(m.setup.models) == 0 {
 			m.resetSetupModels()
@@ -475,8 +480,13 @@ func (m model) handleSetupCredentialKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyUp, tea.KeyDown:
 		return m, nil
 	}
+	previousAPIKey := m.setup.apiKey.Value()
 	var cmd tea.Cmd
 	m.setup.apiKey, cmd = m.setup.apiKey.Update(msg)
+	if m.setup.apiKey.Value() != previousAPIKey {
+		m.setup.modelGen++
+		m.resetSetupModels()
+	}
 	m.setup.err = ""
 	return m, cmd
 }

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -767,6 +767,7 @@ func TestSetupModelDiscoveryDoesNotApplyAfterLeavingModelStep(t *testing.T) {
 
 	updated := m.applySetupModelsDiscovered(setupModelsDiscoveredMsg{
 		providerID: "groq",
+		gen:        m.setup.modelGen,
 		models: []providermodeldiscovery.Model{
 			{ID: "live-coder", Description: "Live Coder"},
 		},
@@ -803,6 +804,7 @@ func TestSetupModelDiscoveryPreservesSelectedModel(t *testing.T) {
 
 	updated := m.applySetupModelsDiscovered(setupModelsDiscoveredMsg{
 		providerID: "groq",
+		gen:        m.setup.modelGen,
 		models: []providermodeldiscovery.Model{
 			{ID: "live-coder", Description: "Live Coder"},
 			{ID: target, Description: "GPT OSS"},
@@ -811,6 +813,71 @@ func TestSetupModelDiscoveryPreservesSelectedModel(t *testing.T) {
 
 	if got := updated.setupCurrentModel().ID; got != target {
 		t.Fatalf("selected model after discovery = %q, want %q", got, target)
+	}
+}
+
+func TestSetupModelDiscoveryIgnoresStaleGeneration(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+	m.setup.modelGen = 2
+	m.setup.modelLoad = true
+
+	updated := m.applySetupModelsDiscovered(setupModelsDiscoveredMsg{
+		providerID: "groq",
+		gen:        1,
+		models: []providermodeldiscovery.Model{
+			{ID: "live-coder", Description: "Live Coder"},
+		},
+	})
+
+	if !updated.setup.modelLoad {
+		t.Fatal("stale discovery result should not clear the active loading state")
+	}
+	for _, model := range updated.setup.models {
+		if model.ID == "live-coder" {
+			t.Fatalf("stale discovery result should not replace model list: %#v", updated.setup.models)
+		}
+	}
+}
+
+func TestSetupModelDiscoveryRedactsRequestAPIKey(t *testing.T) {
+	const oldSecret = "old-provider-token"
+	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("models failed with " + profile.APIKey)
+		},
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama-cloud", Name: "Ollama Cloud", DefaultModel: "qwen3-coder:480b", EnvVar: "OLLAMA_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageCredentials
+	m.setup.apiKey.SetValue(oldSecret)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("entering model step should start discovery")
+	}
+	m.setup.apiKey.SetValue("new-provider-token")
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+
+	if strings.Contains(m.setup.modelErr, oldSecret) {
+		t.Fatalf("model discovery error leaked request API key: %q", m.setup.modelErr)
+	}
+	if !strings.Contains(m.setup.modelErr, "[REDACTED]") {
+		t.Fatalf("model discovery error should redact request API key: %q", m.setup.modelErr)
 	}
 }
 

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,11 +10,15 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 )
 
 func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 	var saved SetupSelection
 	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
 		Setup: SetupOptions{
 			Visible:    true,
 			Required:   true,
@@ -82,6 +87,9 @@ func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 
 func TestSetupCompletionResetsChatSurfaceInsideAltScreen(t *testing.T) {
 	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
 		Setup: SetupOptions{
 			Visible: true,
 			Providers: []SetupProviderOption{
@@ -130,6 +138,9 @@ func TestSetupCompletionResetsChatSurfaceInsideAltScreen(t *testing.T) {
 
 func TestSetupTakeoverBlocksPromptSubmission(t *testing.T) {
 	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
 		Setup: SetupOptions{
 			Visible: true,
 			Providers: []SetupProviderOption{
@@ -158,6 +169,7 @@ func TestSetupRightArrowDoesNotAdvance(t *testing.T) {
 		setupStageWelcome,
 		setupStageProvider,
 		setupStageCredentials,
+		setupStageModel,
 		setupStageReady,
 	} {
 		m := newModel(context.Background(), Options{
@@ -188,6 +200,91 @@ func TestSetupRightArrowDoesNotAdvance(t *testing.T) {
 	}
 	if saveCalls != 0 {
 		t.Fatalf("right arrow should not save setup, got %d save calls", saveCalls)
+	}
+}
+
+func TestSetupProviderMouseWheelChangesSelection(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+				{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5", EnvVar: "ANTHROPIC_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageProvider
+
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("provider wheel should not return a command")
+	}
+	if got := m.setupProvider().ID; got != "anthropic" {
+		t.Fatalf("provider after wheel down = %q, want anthropic", got)
+	}
+
+	updated, cmd = m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("provider wheel should not return a command")
+	}
+	if got := m.setupProvider().ID; got != "openai" {
+		t.Fatalf("provider after wheel up = %q, want openai", got)
+	}
+}
+
+func TestSetupModelMouseWheelChangesSelection(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("model wheel should not return a command")
+	}
+	if got := m.setupCurrentModel().ID; got == "" || got == "llama-3.3-70b-versatile" {
+		t.Fatalf("model after wheel down = %q, want non-default model", got)
+	}
+
+	updated, cmd = m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("model wheel should not return a command")
+	}
+	if got := m.setupCurrentModel().ID; got != "llama-3.3-70b-versatile" {
+		t.Fatalf("model after wheel up = %q, want default model", got)
+	}
+}
+
+func TestSetupModelMouseWheelIgnoredWhileLoading(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+	m.setup.modelLoad = true
+
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("loading model wheel should not return a command")
+	}
+	if got := m.setup.modelIndex; got != 0 {
+		t.Fatalf("model index after wheel while loading = %d, want 0", got)
 	}
 }
 
@@ -231,6 +328,9 @@ func TestSetupEnterDoesNotAdvanceSpaceOnlyStages(t *testing.T) {
 
 func TestSetupProviderRequiresEnter(t *testing.T) {
 	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
 		Setup: SetupOptions{
 			Visible: true,
 			Providers: []SetupProviderOption{
@@ -310,6 +410,9 @@ func TestSetupCredentialsAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T)
 	const secret = "sk-pasted-secret"
 	var saved SetupSelection
 	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
 		Setup: SetupOptions{
 			Visible: true,
 			Providers: []SetupProviderOption{
@@ -357,7 +460,361 @@ func TestSetupCredentialsAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T)
 	}
 }
 
-func TestSetupProviderStepKeepsModelInSelectedDetail(t *testing.T) {
+func TestSetupModelStepSavesCatalogModelChoice(t *testing.T) {
+	var saved SetupSelection
+	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				saved = selection
+				return SetupResult{
+					Provider: config.ProviderProfile{
+						Name:      selection.CatalogID,
+						CatalogID: selection.CatalogID,
+						Model:     selection.Model,
+					},
+				}, nil
+			},
+		},
+	})
+	m.width = 120
+	m.height = 30
+	m.setup.stage = setupStageCredentials
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.setup.stage != setupStageModel {
+		t.Fatalf("stage = %v, want model", m.setup.stage)
+	}
+	if cmd == nil {
+		t.Fatal("entering the model step should start model discovery")
+	}
+	view := plainRender(t, m.View())
+	if !strings.Contains(view, "Checking available models") || strings.Contains(view, "llama-3.3-70b-versatile") {
+		t.Fatalf("model step should wait for discovery before showing fallback models:\n%s", view)
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+	view = plainRender(t, m.View())
+	for _, want := range []string{"Choose a model", "llama-3.3-70b-versatile", "openai/gpt-oss-120b"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("model step missing %q:\n%s", want, view)
+		}
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(model)
+	selected := m.setupCurrentModel().ID
+	if selected == "" || selected == "llama-3.3-70b-versatile" {
+		t.Fatalf("selected model after down = %q, want a non-default catalog model", selected)
+	}
+	for m.setup.stage != setupStageReady {
+		m = pressSetupContinue(m)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if saved.Model != selected {
+		t.Fatalf("saved model = %q, want selected model %q", saved.Model, selected)
+	}
+	if m.modelName != selected {
+		t.Fatalf("active model = %q, want %q", m.modelName, selected)
+	}
+}
+
+func TestSetupModelSearchFiltersAndSavesMatch(t *testing.T) {
+	var saved SetupSelection
+	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				saved = selection
+				return SetupResult{Provider: config.ProviderProfile{Name: selection.CatalogID, CatalogID: selection.CatalogID, Model: selection.Model}}, nil
+			},
+		},
+	})
+	m.setup.stage = setupStageCredentials
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("entering the model step should start model discovery")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("oss")})
+	m = updated.(model)
+	if got := m.setupCurrentModel().ID; got != "openai/gpt-oss-120b" {
+		t.Fatalf("filtered model = %q, want openai/gpt-oss-120b", got)
+	}
+	view := plainRender(t, m.View())
+	if !strings.Contains(view, "openai/gpt-oss-120b") || strings.Contains(view, "llama-3.3-70b-versatile") {
+		t.Fatalf("model search did not filter to oss models:\n%s", view)
+	}
+	for m.setup.stage != setupStageReady {
+		m = pressSetupContinue(m)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if saved.Model != "openai/gpt-oss-120b" {
+		t.Fatalf("saved model = %q, want openai/gpt-oss-120b", saved.Model)
+	}
+}
+
+func TestSetupModelLoadingBlocksSelectionAndSearch(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return []providermodeldiscovery.Model{{ID: "live-coder", Description: "Live Coder"}}, nil
+		},
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 120
+	m.height = 30
+	m.setup.stage = setupStageCredentials
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("entering the model step should start model discovery")
+	}
+	view := plainRender(t, m.View())
+	if !strings.Contains(view, "Checking available models") || strings.Contains(view, "llama-3.3-70b-versatile") {
+		t.Fatalf("loading model step should not render fallback models:\n%s", view)
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("oss")})
+	m = updated.(model)
+	if m.setup.modelQuery != "" {
+		t.Fatalf("model query while loading = %q, want empty", m.setup.modelQuery)
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.setup.stage != setupStageModel {
+		t.Fatalf("enter while loading advanced stage to %v", m.setup.stage)
+	}
+	if !strings.Contains(m.setup.err, "still loading") {
+		t.Fatalf("loading enter error = %q, want still loading", m.setup.err)
+	}
+}
+
+func TestSetupModelSearchAcceptsQ(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("q should search on the model step, not quit setup")
+	}
+	if m.setup.modelQuery != "q" {
+		t.Fatalf("model query = %q, want q", m.setup.modelQuery)
+	}
+}
+
+func TestSetupModelFooterUsesEnter(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 96
+	m.height = 24
+	m.setup.stage = setupStageModel
+
+	view := plainRender(t, m.View())
+	if !strings.Contains(view, "type search") || !strings.Contains(view, "Enter continue") {
+		t.Fatalf("model footer should advertise search and Enter, got:\n%s", view)
+	}
+	if strings.Contains(view, "Space to continue") {
+		t.Fatalf("model footer should not advertise Space, got:\n%s", view)
+	}
+}
+
+func TestSetupModelSearchPlaceholderPutsCursorBeforeHint(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+
+	empty := plainRender(t, m.setupModelSearchLine(60))
+	if !strings.Contains(empty, "search > ▌model name...") {
+		t.Fatalf("empty search line = %q, want cursor before placeholder", empty)
+	}
+	if strings.Contains(empty, "model name...▌") {
+		t.Fatalf("empty search line should not place cursor after placeholder: %q", empty)
+	}
+
+	m.setup.modelQuery = "qwen"
+	filled := plainRender(t, m.setupModelSearchLine(60))
+	if !strings.Contains(filled, "search > qwen▌") {
+		t.Fatalf("filled search line = %q, want cursor after query", filled)
+	}
+}
+
+func TestSetupModelStepDoesNotSpinWithoutDiscovery(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "custom-provider", Name: "Custom Provider", DefaultModel: "custom-model"},
+			},
+		},
+	})
+	m.setup.stage = setupStageCredentials
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("custom setup provider should not start model discovery")
+	}
+	if m.setup.modelLoad {
+		t.Fatal("model step should not show a loading state when no discovery command starts")
+	}
+}
+
+func TestSetupModelStepUsesDiscoveredModels(t *testing.T) {
+	var captured config.ProviderProfile
+	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			captured = profile
+			return []providermodeldiscovery.Model{
+				{ID: "live-coder", Description: "Live Coder", ContextWindow: 128000, ToolCall: true},
+				{ID: "live-fast", Description: "Live Fast"},
+			}, nil
+		},
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama", Name: "Ollama Local", DefaultModel: "llama3.1", Local: true},
+			},
+		},
+	})
+	m.width = 120
+	m.height = 30
+	m.setup.stage = setupStageCredentials
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
+	m = updated.(model)
+	if m.setup.stage != setupStageModel {
+		t.Fatalf("stage = %v, want model", m.setup.stage)
+	}
+	if cmd == nil {
+		t.Fatal("entering setup model step should start discovery")
+	}
+	view := plainRender(t, m.View())
+	if !strings.Contains(view, "Checking available models") || strings.Contains(view, "llama3.1") {
+		t.Fatalf("setup should wait for discovered models before showing fallback list:\n%s", view)
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+
+	if captured.CatalogID != "ollama" {
+		t.Fatalf("discovery profile = %#v, want ollama", captured)
+	}
+	view = plainRender(t, m.View())
+	if !strings.Contains(view, "Live Coder") || !strings.Contains(view, "live-coder") || !strings.Contains(view, "128K ctx") || strings.Contains(view, "details") || strings.Contains(view, "llama3.1") {
+		t.Fatalf("setup model step should render discovered models only:\n%s", view)
+	}
+}
+
+func TestSetupModelDiscoveryDoesNotApplyAfterLeavingModelStep(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+	m.setup.stage = setupStageSafety
+
+	updated := m.applySetupModelsDiscovered(setupModelsDiscoveredMsg{
+		providerID: "groq",
+		models: []providermodeldiscovery.Model{
+			{ID: "live-coder", Description: "Live Coder"},
+		},
+	})
+
+	for _, model := range updated.setup.models {
+		if model.ID == "live-coder" {
+			t.Fatalf("late discovery result should not replace model selection after leaving step: %#v", updated.setup.models)
+		}
+	}
+}
+
+func TestSetupModelDiscoveryPreservesSelectedModel(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "groq", Name: "Groq", DefaultModel: "llama-3.3-70b-versatile", EnvVar: "GROQ_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+	target := "openai/gpt-oss-120b"
+	for index, model := range m.setupFilteredModels() {
+		if model.ID == target {
+			m.setup.modelIndex = index
+			break
+		}
+	}
+	if got := m.setupCurrentModel().ID; got != target {
+		t.Fatalf("test setup selected %q, want %q", got, target)
+	}
+
+	updated := m.applySetupModelsDiscovered(setupModelsDiscoveredMsg{
+		providerID: "groq",
+		models: []providermodeldiscovery.Model{
+			{ID: "live-coder", Description: "Live Coder"},
+			{ID: target, Description: "GPT OSS"},
+		},
+	})
+
+	if got := updated.setupCurrentModel().ID; got != target {
+		t.Fatalf("selected model after discovery = %q, want %q", got, target)
+	}
+}
+
+func TestSetupProviderStepOmitsModelDetails(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		Setup: SetupOptions{
 			Visible: true,
@@ -372,18 +829,16 @@ func TestSetupProviderStepKeepsModelInSelectedDetail(t *testing.T) {
 	m.setup.stage = setupStageProvider
 
 	foundProviderRow := false
-	foundDefaultDetail := false
 	titleColumn := -1
 	providerColumn := -1
-	defaultColumn := -1
-	for _, line := range strings.Split(plainRender(t, m.View()), "\n") {
+	view := plainRender(t, m.View())
+	if strings.Contains(view, "Default model:") || strings.Contains(view, "gpt-4.1") || strings.Contains(view, "claude-sonnet-4.5") {
+		t.Fatalf("provider step should not render model details:\n%s", view)
+	}
+	for _, line := range strings.Split(view, "\n") {
 		row := strings.TrimSpace(line)
 		if strings.Contains(row, "Choose a provider") {
 			titleColumn = displayColumn(line, "Choose a provider")
-		}
-		if strings.Contains(row, "Default model: gpt-4.1") {
-			foundDefaultDetail = true
-			defaultColumn = displayColumn(line, "Default model")
 		}
 		if !strings.Contains(row, "OpenAI") {
 			continue
@@ -399,12 +854,6 @@ func TestSetupProviderStepKeepsModelInSelectedDetail(t *testing.T) {
 	}
 	if !foundProviderRow {
 		t.Fatal("provider row missing from setup view")
-	}
-	if !foundDefaultDetail {
-		t.Fatal("selected provider default model detail missing from setup view")
-	}
-	if providerColumn < 0 || defaultColumn < 0 || providerColumn != defaultColumn {
-		t.Fatalf("default model detail should align with provider names, provider column %d detail column %d", providerColumn, defaultColumn)
 	}
 	if titleColumn < 0 || titleColumn != providerColumn {
 		t.Fatalf("provider title should align with provider names, title column %d provider column %d", titleColumn, providerColumn)
@@ -554,13 +1003,13 @@ func TestSetupProgressRendersAboveFooter(t *testing.T) {
 	stepIndex := -1
 	footerIndex := -1
 	for index, line := range lines {
-		if strings.Contains(line, "2/5") {
+		if strings.Contains(line, "2/6") {
 			stepIndex = index
 		}
 		if strings.Contains(line, "Enter continue") {
 			footerIndex = index
 		}
-		if strings.Contains(line, "Choose a provider") && strings.Contains(line, "2/5") {
+		if strings.Contains(line, "Choose a provider") && strings.Contains(line, "2/6") {
 			t.Fatalf("progress should not render in setup body: %q", line)
 		}
 	}
@@ -595,12 +1044,19 @@ func TestSetupReadyFooterUsesEnter(t *testing.T) {
 }
 
 func pressSetupContinue(m model) model {
-	if m.setup.stage == setupStageProvider || m.setupCredentialInputActive() || m.setup.stage == setupStageReady {
-		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-		return updated.(model)
+	var updated tea.Model
+	var cmd tea.Cmd
+	if m.setup.stage == setupStageProvider || m.setupCredentialInputActive() || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
+		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	} else {
+		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
 	}
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})
-	return updated.(model)
+	m = updated.(model)
+	if cmd != nil {
+		updated, _ = m.Update(cmd())
+		m = updated.(model)
+	}
+	return m
 }
 
 func displayColumnForVisibleLine(t *testing.T, view string, marker string) int {


### PR DESCRIPTION
Summary:
- Add a model selection step to first-run onboarding using catalog/discovery models.
- Avoid fallback-list flicker while discovery is loading and save the chosen model.
- Add mouse-wheel support and clean up provider/model picker layout.

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model selection stage to onboarding with search, filtering, loading states, and detailed model display
  * Model discovery runs asynchronously and integrates discovered models into the setup flow
  * Keyboard and mouse navigation extended for model/provider and model-list interaction

* **Bug Fixes**
  * Mouse interactions are now handled during setup (no longer ignored)
  * Finalized setup saves the explicitly chosen model ID

* **Tests**
  * Expanded onboarding tests covering discovery, selection, search, mouse/keyboard behaviors, and error redaction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->