### PR TITLE
Add session context compaction flow

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -51,6 +51,23 @@ type CompactionOptions struct {
 	Summarize func(toSummarize []zeroruntime.Message) (string, error)
 }
 
+// CompactionResult is the metadata-bearing result returned by CompactMessages.
+type CompactionResult struct {
+	// Messages is the original conversation or the compacted replacement.
+	Messages []zeroruntime.Message
+	// RemovedCount is the number of original messages summarized away.
+	RemovedCount int
+	// PreservedCount is the number of original messages kept verbatim, including
+	// leading system messages and the preserved suffix.
+	PreservedCount int
+	// SummaryText is the trimmed text returned by the summarizer. The injected
+	// summary message also includes summaryLabel and any preserved structured
+	// state needed by later compactions.
+	SummaryText string
+	// Compacted reports whether Messages contains an injected summary.
+	Compacted bool
+}
+
 // estimateTokens is a cheap, dependency-free token estimate (~4 chars/token)
 // across message content plus tool call names/arguments. It deliberately uses no
 // real tokenizer; it only needs to be monotonic and roughly proportional so the
@@ -96,12 +113,23 @@ func compactionThreshold(contextWindow int) int {
 // Compact is pure: it performs no provider I/O. A Summarize error is returned to
 // the caller, which decides how to recover.
 func Compact(messages []zeroruntime.Message, opts CompactionOptions) ([]zeroruntime.Message, error) {
+	result, err := CompactMessages(messages, opts)
+	if err != nil {
+		return nil, err
+	}
+	return result.Messages, nil
+}
+
+// CompactMessages summarizes the oldest middle of a conversation and returns
+// both the replacement messages and UI/session-friendly metadata about what
+// changed. It uses the same compaction rules as Compact.
+func CompactMessages(messages []zeroruntime.Message, opts CompactionOptions) (CompactionResult, error) {
 	preserveLast := opts.PreserveLast
 	if preserveLast <= 0 {
 		preserveLast = defaultCompactionPreserveLast
 	}
 	if opts.Summarize == nil {
-		return nil, errors.New("compaction requires a Summarize function")
+		return CompactionResult{}, errors.New("compaction requires a Summarize function")
 	}
 
 	// Leading system messages are kept verbatim at the head.
@@ -121,12 +149,15 @@ func Compact(messages []zeroruntime.Message, opts CompactionOptions) ([]zerorunt
 	middle := messages[systemEnd:boundary]
 	if len(middle) == 0 {
 		// Nothing to summarize once system + preserved suffix are removed.
-		return messages, nil
+		return CompactionResult{
+			Messages:       messages,
+			PreservedCount: len(messages),
+		}, nil
 	}
 
 	summary, err := opts.Summarize(middle)
 	if err != nil {
-		return nil, err
+		return CompactionResult{}, err
 	}
 	summary = strings.TrimSpace(summary)
 
@@ -141,7 +172,13 @@ func Compact(messages []zeroruntime.Message, opts CompactionOptions) ([]zerorunt
 		Content: content,
 	})
 	compacted = append(compacted, messages[boundary:]...)
-	return compacted, nil
+	return CompactionResult{
+		Messages:       compacted,
+		RemovedCount:   len(middle),
+		PreservedCount: len(messages) - len(middle),
+		SummaryText:    summary,
+		Compacted:      true,
+	}, nil
 }
 
 // safeSuffixBoundary walks the preserve boundary backward (toward systemEnd) so

--- a/internal/agent/compaction_metadata_test.go
+++ b/internal/agent/compaction_metadata_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestCompactMessagesReturnsMetadataForManualCompaction(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system prompt"},
+		{Role: zeroruntime.MessageRoleUser, Content: "first question"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "first answer"},
+		{Role: zeroruntime.MessageRoleUser, Content: "second question"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "recent answer"},
+		{Role: zeroruntime.MessageRoleUser, Content: "latest question"},
+	}
+
+	var captured []zeroruntime.Message
+	result, err := CompactMessages(messages, CompactionOptions{
+		PreserveLast: 2,
+		Summarize: func(toSummarize []zeroruntime.Message) (string, error) {
+			captured = append([]zeroruntime.Message(nil), toSummarize...)
+			return "  manual summary  ", nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !result.Compacted {
+		t.Fatal("expected compaction to be reported")
+	}
+	if result.RemovedCount != 3 {
+		t.Fatalf("RemovedCount = %d, want 3", result.RemovedCount)
+	}
+	if result.PreservedCount != 3 {
+		t.Fatalf("PreservedCount = %d, want 3", result.PreservedCount)
+	}
+	if result.SummaryText != "manual summary" {
+		t.Fatalf("SummaryText = %q, want trimmed summary", result.SummaryText)
+	}
+	if len(captured) != 3 || captured[0].Content != "first question" || captured[2].Content != "second question" {
+		t.Fatalf("summarized middle = %#v, want the three non-preserved non-system messages", captured)
+	}
+	if len(result.Messages) != 4 {
+		t.Fatalf("compacted message count = %d, want 4", len(result.Messages))
+	}
+	if result.Messages[0].Content != "system prompt" {
+		t.Fatalf("system message was not preserved at head: %#v", result.Messages)
+	}
+	if result.Messages[1].Role != zeroruntime.MessageRoleUser {
+		t.Fatalf("summary message role = %s, want user", result.Messages[1].Role)
+	}
+	if !strings.Contains(result.Messages[1].Content, summaryLabel) || !strings.Contains(result.Messages[1].Content, "manual summary") {
+		t.Fatalf("summary message did not include label and body: %q", result.Messages[1].Content)
+	}
+	if result.Messages[2].Content != "recent answer" || result.Messages[3].Content != "latest question" {
+		t.Fatalf("preserved suffix changed: %#v", result.Messages[2:])
+	}
+}
+
+func TestCompactMessagesNoopReturnsUncompactedMetadata(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "hi"},
+	}
+	called := false
+
+	result, err := CompactMessages(messages, CompactionOptions{
+		PreserveLast: 8,
+		Summarize: func([]zeroruntime.Message) (string, error) {
+			called = true
+			return "summary", nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if called {
+		t.Fatal("Summarize should not be called for a no-op compaction")
+	}
+	if result.Compacted {
+		t.Fatal("Compacted = true for a no-op")
+	}
+	if result.RemovedCount != 0 {
+		t.Fatalf("RemovedCount = %d, want 0", result.RemovedCount)
+	}
+	if result.PreservedCount != len(messages) {
+		t.Fatalf("PreservedCount = %d, want %d", result.PreservedCount, len(messages))
+	}
+	if result.SummaryText != "" {
+		t.Fatalf("SummaryText = %q, want empty", result.SummaryText)
+	}
+	if !reflect.DeepEqual(result.Messages, messages) {
+		t.Fatalf("Messages changed on no-op: %#v", result.Messages)
+	}
+}
+
+func TestCompactMessagesPropagatesSummarizeError(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "first question"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "first answer"},
+		{Role: zeroruntime.MessageRoleUser, Content: "second question"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "recent answer"},
+		{Role: zeroruntime.MessageRoleUser, Content: "latest question"},
+	}
+
+	_, err := CompactMessages(messages, CompactionOptions{
+		PreserveLast: 2,
+		Summarize: func([]zeroruntime.Message) (string, error) {
+			return "", errors.New("summarizer unavailable")
+		},
+	})
+	if err == nil {
+		t.Fatal("expected summarizer error")
+	}
+	if !strings.Contains(err.Error(), "summarizer unavailable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/agent/compaction_preserve.go
+++ b/internal/agent/compaction_preserve.go
@@ -10,23 +10,32 @@ import (
 
 // Compaction preservation.
 //
-// A plain prose summary loses two things the model needs to keep working: the
-// active plan (issued via the update_plan tool) and any skill instructions it
-// loaded (via the skill tool). When those turns fall into the elided middle,
-// the plan and skill bodies vanish from context. To prevent that, Compact
-// appends them VERBATIM to the injected summary so structured state survives a
-// compaction exactly rather than being paraphrased away.
+// A plain prose summary loses structured state the model needs to keep working:
+// the active plan, loaded deferred-tool schemas, loaded skills, and project
+// instruction blocks. When those turns fall into the elided middle, Compact
+// appends that state to the injected summary as JSON so it survives exactly
+// rather than being paraphrased away.
 
 const (
 	toolNameUpdatePlan = "update_plan"
+	toolNameToolSearch = "tool_search"
 	toolNameSkill      = "skill"
 )
 
-// preservedStateLabel heads the preserved-state block. The block body is a
-// single line of JSON (see formatPreservedState): JSON escapes everything, so a
-// skill body containing markdown headings (## / ###), code fences, or quotes
-// round-trips losslessly across repeated compactions — unlike a markdown-
-// delimited format, which would be truncated or mis-split when re-parsed.
+const (
+	projectInstructionsHeadingPrefix = "# "
+	projectInstructionsHeadingMarker = " instructions for "
+	projectInstructionsOpenTag       = "<INSTRUCTIONS>"
+	projectInstructionsCloseTag      = "</INSTRUCTIONS>"
+)
+
+// preservedStateLabel heads the preserved-state block. Keep this label stable so
+// summaries created by earlier builds remain parseable; the JSON body may carry
+// more fields than the historical label names.
+//
+// The block body is a single line of JSON (see formatPreservedState): JSON
+// escapes everything, so markdown headings, code fences, or quotes round-trip
+// losslessly across repeated compactions.
 const preservedStateLabel = "## Preserved state (active plan + loaded skills; carried across compaction)"
 
 // maxPreservedSkillBytes caps how much of each loaded skill body is carried
@@ -60,7 +69,9 @@ func formatPlanArguments(arguments string) string {
 	var parsed struct {
 		Plan []struct {
 			Content string `json:"content"`
+			Step    string `json:"step"`
 			Status  string `json:"status"`
+			Notes   string `json:"notes"`
 		} `json:"plan"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed); err != nil {
@@ -70,18 +81,26 @@ func formatPlanArguments(arguments string) string {
 	for _, item := range parsed.Plan {
 		content := strings.TrimSpace(item.Content)
 		if content == "" {
+			content = strings.TrimSpace(item.Step)
+		}
+		if content == "" {
 			continue
 		}
 		status := strings.TrimSpace(item.Status)
 		if status == "" {
 			status = "pending"
 		}
-		lines = append(lines, "- ["+status+"] "+content)
+		line := "- [" + status + "] " + content
+		if notes := strings.TrimSpace(item.Notes); notes != "" {
+			line += "\n  Notes: " + notes
+		}
+		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
 }
 
-// skillEntry is one loaded skill: its name and (capped) body.
+// skillEntry is a named preserved body. It began as loaded-skill state and is
+// reused for loaded tools and project instruction blocks.
 type skillEntry struct {
 	name string
 	body string
@@ -133,16 +152,136 @@ func loadedSkills(messages []zeroruntime.Message) []skillEntry {
 	return entries
 }
 
+// loadedToolSchemas returns tool_search-loaded schemas from their normal tool
+// result text. ToolResult.Meta is not part of zeroruntime.Message history, so the
+// rendered "Loaded N tools" output is the durable transcript format.
+func loadedToolSchemas(messages []zeroruntime.Message) []skillEntry {
+	toolSearchIDs := map[string]bool{}
+	for _, message := range messages {
+		for _, call := range message.ToolCalls {
+			if call.Name == toolNameToolSearch && call.ID != "" {
+				toolSearchIDs[call.ID] = true
+			}
+		}
+	}
+	if len(toolSearchIDs) == 0 {
+		return nil
+	}
+
+	bodyByName := map[string]string{}
+	nameOrder := make([]string, 0)
+	for _, message := range messages {
+		if message.Role != zeroruntime.MessageRoleTool || !toolSearchIDs[message.ToolCallID] {
+			continue
+		}
+		for _, entry := range loadedToolEntriesFromOutput(message.Content) {
+			if _, seen := bodyByName[entry.name]; !seen {
+				nameOrder = append(nameOrder, entry.name)
+			}
+			bodyByName[entry.name] = entry.body
+		}
+	}
+
+	entries := make([]skillEntry, 0, len(nameOrder))
+	for _, name := range nameOrder {
+		entries = append(entries, skillEntry{name: name, body: bodyByName[name]})
+	}
+	return entries
+}
+
+func loadedToolEntriesFromOutput(output string) []skillEntry {
+	output = strings.TrimSpace(output)
+	if !strings.HasPrefix(output, "Loaded ") || !strings.Contains(output, "Full schemas follow") {
+		return nil
+	}
+	lines := strings.Split(output, "\n")
+	var entries []skillEntry
+	for i := 0; i < len(lines); i++ {
+		name, ok := strings.CutPrefix(strings.TrimSpace(lines[i]), "## ")
+		if !ok {
+			continue
+		}
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		start := i
+		end := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			if strings.HasPrefix(strings.TrimSpace(lines[j]), "## ") {
+				end = j
+				break
+			}
+		}
+		entries = append(entries, skillEntry{name: name, body: capBody(strings.TrimSpace(strings.Join(lines[start:end], "\n")))})
+		i = end - 1
+	}
+	return entries
+}
+
+func projectInstructionEntries(messages []zeroruntime.Message) []skillEntry {
+	bodyBySource := map[string]string{}
+	sourceOrder := make([]string, 0)
+	for _, message := range messages {
+		if message.Role != zeroruntime.MessageRoleUser {
+			continue
+		}
+		source, body := projectInstructionBlock(message.Content)
+		if body == "" {
+			continue
+		}
+		if _, seen := bodyBySource[source]; !seen {
+			sourceOrder = append(sourceOrder, source)
+		}
+		bodyBySource[source] = body
+	}
+
+	entries := make([]skillEntry, 0, len(sourceOrder))
+	for _, source := range sourceOrder {
+		entries = append(entries, skillEntry{name: source, body: bodyBySource[source]})
+	}
+	return entries
+}
+
+func projectInstructionBlock(content string) (string, string) {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, projectInstructionsHeadingPrefix) {
+		return "", ""
+	}
+	firstLineEnd := strings.IndexByte(content, '\n')
+	if firstLineEnd < 0 {
+		return "", ""
+	}
+	heading := strings.TrimSpace(content[:firstLineEnd])
+	if !strings.Contains(heading, projectInstructionsHeadingMarker) {
+		return "", ""
+	}
+	open := strings.Index(content, projectInstructionsOpenTag)
+	close := strings.Index(content, projectInstructionsCloseTag)
+	if open < 0 || close < open {
+		return "", ""
+	}
+	close += len(projectInstructionsCloseTag)
+
+	source := strings.TrimPrefix(heading, "# ")
+	body := strings.TrimSpace(heading + "\n\n" + strings.TrimSpace(content[open:close]))
+	return source, body
+}
+
 // skillNameFromArguments pulls the "name" field from a skill tool call's JSON
 // arguments ({"name":"..."}). Returns "" on malformed arguments.
 func skillNameFromArguments(arguments string) string {
 	var parsed struct {
-		Name string `json:"name"`
+		Name  string `json:"name"`
+		Skill string `json:"skill"`
 	}
 	if err := json.Unmarshal([]byte(strings.TrimSpace(arguments)), &parsed); err != nil {
 		return ""
 	}
-	return strings.TrimSpace(parsed.Name)
+	if name := strings.TrimSpace(parsed.Name); name != "" {
+		return name
+	}
+	return strings.TrimSpace(parsed.Skill)
 }
 
 // truncationNote is appended to a capped skill body. Its length is reserved
@@ -170,8 +309,15 @@ func capBody(body string) string {
 
 // preservedState is the JSON shape of the carried-across-compaction block.
 type preservedState struct {
-	Plan   string           `json:"plan,omitempty"`
-	Skills []preservedSkill `json:"skills,omitempty"`
+	Plan                string                 `json:"plan,omitempty"`
+	Tools               []preservedTool        `json:"tools,omitempty"`
+	Skills              []preservedSkill       `json:"skills,omitempty"`
+	ProjectInstructions []preservedInstruction `json:"project_instructions,omitempty"`
+}
+
+type preservedTool struct {
+	Name string `json:"name"`
+	Body string `json:"body"`
 }
 
 type preservedSkill struct {
@@ -179,45 +325,62 @@ type preservedSkill struct {
 	Body string `json:"body"`
 }
 
-// appendPreservedState appends the active plan and loaded skills to a compaction
-// summary as a single JSON block, so structured state survives verbatim. middle
-// is the slice being summarized away.
+type preservedInstruction struct {
+	Source string `json:"source"`
+	Body   string `json:"body"`
+}
+
+// appendPreservedState appends active structured state to a compaction summary
+// as a single JSON block. middle is the slice being summarized away.
 //
-// It is robust across REPEATED compactions: after the first compaction the plan
-// and skills live only inside the injected summary message, which on a later
-// compaction lands in middle with no real tool calls left to extract. So when
-// middle has no fresh update_plan / skill tool calls, the preserved state is
-// carried forward by re-parsing the prior block (JSON → lossless for arbitrary
-// markdown bodies). Fresh tool calls always override the carried-forward copy.
+// It is robust across repeated compactions: after the first compaction the state
+// may live only inside the injected summary message, which on a later compaction
+// lands in middle with no real tool calls left to extract. Fresh tool calls and
+// instruction blocks override the carried-forward copy by name/source.
 func appendPreservedState(summary string, middle []zeroruntime.Message) string {
-	priorPlan, priorSkills := parsePreservedState(latestSummaryContent(middle))
+	priorState := parsePreservedStateBlock(latestSummaryContent(middle))
 
 	// Plan: a fresh update_plan in middle is authoritative; otherwise carry the
 	// plan preserved by an earlier compaction.
 	plan := extractLatestPlan(middle)
 	if plan == "" {
-		plan = priorPlan
+		plan = priorState.Plan
 	}
+
+	// Tools: preserve deferred tool_search schemas from the transcript. Fresh
+	// loads override older carried copies by name.
+	tools := mergeSkillEntries(preservedToolsToEntries(priorState.Tools), loadedToolSchemas(middle))
 
 	// Skills: merge skills preserved earlier (older) with fresh loads (newer wins
 	// per name), so a loaded skill survives repeated compactions.
-	skills := mergeSkillEntries(priorSkills, loadedSkills(middle))
+	skills := mergeSkillEntries(preservedSkillsToEntries(priorState.Skills), loadedSkills(middle))
 
-	if block := formatPreservedState(plan, skills); block != "" {
+	instructions := mergeSkillEntries(
+		preservedInstructionsToEntries(priorState.ProjectInstructions),
+		projectInstructionEntries(middle),
+	)
+
+	if block := formatPreservedState(plan, tools, skills, instructions); block != "" {
 		summary += "\n\n" + block
 	}
 	return summary
 }
 
-// formatPreservedState renders the plan + skills as the labelled, single-line
+// formatPreservedState renders state as the labelled, single-line
 // JSON block. Returns "" when there is nothing to preserve.
-func formatPreservedState(plan string, skills []skillEntry) string {
-	if plan == "" && len(skills) == 0 {
+func formatPreservedState(plan string, tools, skills, instructions []skillEntry) string {
+	if plan == "" && len(tools) == 0 && len(skills) == 0 && len(instructions) == 0 {
 		return ""
 	}
 	state := preservedState{Plan: plan}
+	for _, t := range tools {
+		state.Tools = append(state.Tools, preservedTool{Name: t.name, Body: t.body})
+	}
 	for _, s := range skills {
 		state.Skills = append(state.Skills, preservedSkill{Name: s.name, Body: s.body})
+	}
+	for _, i := range instructions {
+		state.ProjectInstructions = append(state.ProjectInstructions, preservedInstruction{Source: i.name, Body: i.body})
 	}
 	encoded, err := json.Marshal(state)
 	if err != nil {
@@ -231,9 +394,14 @@ func formatPreservedState(plan string, skills []skillEntry) string {
 // markdown headings, code fences, or quotes. Returns ("", nil) when absent or
 // malformed.
 func parsePreservedState(summaryContent string) (string, []skillEntry) {
+	state := parsePreservedStateBlock(summaryContent)
+	return state.Plan, preservedSkillsToEntries(state.Skills)
+}
+
+func parsePreservedStateBlock(summaryContent string) preservedState {
 	idx := strings.LastIndex(summaryContent, preservedStateLabel)
 	if idx < 0 {
-		return "", nil
+		return preservedState{}
 	}
 	rest := strings.TrimPrefix(summaryContent[idx+len(preservedStateLabel):], "\n")
 	// The JSON is a single line (json.Marshal escapes newlines).
@@ -242,20 +410,46 @@ func parsePreservedState(summaryContent string) (string, []skillEntry) {
 	}
 	rest = strings.TrimSpace(rest)
 	if rest == "" {
-		return "", nil
+		return preservedState{}
 	}
 	var state preservedState
 	if err := json.Unmarshal([]byte(rest), &state); err != nil {
-		return "", nil
+		return preservedState{}
 	}
-	entries := make([]skillEntry, 0, len(state.Skills))
-	for _, s := range state.Skills {
+	return state
+}
+
+func preservedToolsToEntries(tools []preservedTool) []skillEntry {
+	entries := make([]skillEntry, 0, len(tools))
+	for _, t := range tools {
+		if t.Name == "" {
+			continue
+		}
+		entries = append(entries, skillEntry{name: t.Name, body: t.Body})
+	}
+	return entries
+}
+
+func preservedSkillsToEntries(skills []preservedSkill) []skillEntry {
+	entries := make([]skillEntry, 0, len(skills))
+	for _, s := range skills {
 		if s.Name == "" {
 			continue
 		}
 		entries = append(entries, skillEntry{name: s.Name, body: s.Body})
 	}
-	return state.Plan, entries
+	return entries
+}
+
+func preservedInstructionsToEntries(instructions []preservedInstruction) []skillEntry {
+	entries := make([]skillEntry, 0, len(instructions))
+	for _, i := range instructions {
+		if i.Source == "" {
+			continue
+		}
+		entries = append(entries, skillEntry{name: i.Source, body: i.Body})
+	}
+	return entries
 }
 
 // latestSummaryContent returns the content of the most recent injected summary

--- a/internal/agent/compaction_preserve_test.go
+++ b/internal/agent/compaction_preserve_test.go
@@ -69,6 +69,56 @@ func TestCompactPreservesLoadedSkills(t *testing.T) {
 	}
 }
 
+func TestCompactPreservesLoadedToolSearchSchemas(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "load weather tool"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "loading", ToolCalls: []zeroruntime.ToolCall{
+			{ID: "t1", Name: "tool_search", Arguments: `{"query":"select:weather_lookup"}`},
+		}},
+		{Role: zeroruntime.MessageRoleTool, ToolCallID: "t1", Content: "Loaded 1 tool. Full schemas follow; call them on the next turn.\n\n## weather_lookup\nLook up weather.\ninput schema:\n{\n  \"type\": \"object\"\n}"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "ready"},
+		{Role: zeroruntime.MessageRoleUser, Content: "continue"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+	}
+	summary := compactStateConversation(t, messages)
+	if !strings.Contains(summary, `"name":"weather_lookup"`) || !strings.Contains(summary, "input schema") {
+		t.Fatalf("loaded tool schema not preserved in %q", summary)
+	}
+}
+
+func TestCompactPreservesProjectInstructions(t *testing.T) {
+	projectInstructions := "# AGENTS.md instructions for D:\\repo\n\n<INSTRUCTIONS>\nUse `go test ./internal/agent` for agent changes.\nDo not touch TUI code.\n</INSTRUCTIONS>\n\n<environment_context>\nignored runtime context\n</environment_context>"
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: projectInstructions},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "ack"},
+		{Role: zeroruntime.MessageRoleUser, Content: "work on compaction"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "working"},
+		{Role: zeroruntime.MessageRoleUser, Content: "continue"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+	}
+	summary := compactStateConversation(t, messages)
+	state := parsePreservedStateBlock(summary)
+	if len(state.ProjectInstructions) != 1 {
+		t.Fatalf("expected one preserved project instruction block, got %#v", state.ProjectInstructions)
+	}
+	body := state.ProjectInstructions[0].Body
+	if state.ProjectInstructions[0].Source != "AGENTS.md instructions for D:\\repo" ||
+		!strings.Contains(body, "# AGENTS.md instructions for D:\\repo") ||
+		!strings.Contains(body, "Do not touch TUI code.") ||
+		strings.Contains(body, "ignored runtime context") {
+		t.Fatalf("project instructions not preserved cleanly in %#v", state.ProjectInstructions[0])
+	}
+}
+
+func TestProjectInstructionBlockAcceptsProjectGuidelineFilename(t *testing.T) {
+	source, body := projectInstructionBlock("# ZERO.md instructions for /repo\n\n<INSTRUCTIONS>\nPrefer Go commands.\n</INSTRUCTIONS>")
+	if source != "ZERO.md instructions for /repo" || !strings.Contains(body, "Prefer Go commands.") {
+		t.Fatalf("expected ZERO.md instruction block to parse, got source=%q body=%q", source, body)
+	}
+}
+
 func TestCompactWithoutStateHasNoPreserveSections(t *testing.T) {
 	messages := []zeroruntime.Message{
 		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
@@ -123,6 +173,51 @@ func TestCompactCarriesPreservedStateAcrossRepeatedCompaction(t *testing.T) {
 	}
 	if !strings.Contains(newSummary, `"name":"deploy"`) || !strings.Contains(newSummary, "make deploy") {
 		t.Fatalf("loaded skill lost on the second compaction: %q", newSummary)
+	}
+}
+
+func TestCompactCarriesLoadedToolsAndProjectInstructionsAcrossRepeatedCompaction(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleSystem, Content: "system"},
+		{Role: zeroruntime.MessageRoleUser, Content: "# AGENTS.md instructions for /repo\n\n<INSTRUCTIONS>\nStay in internal/agent.\n</INSTRUCTIONS>"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "loading", ToolCalls: []zeroruntime.ToolCall{
+			{ID: "t1", Name: "tool_search", Arguments: `{"query":"select:weather_lookup"}`},
+		}},
+		{Role: zeroruntime.MessageRoleTool, ToolCallID: "t1", Content: "Loaded 1 tool. Full schemas follow; call them on the next turn.\n\n## weather_lookup\nLook up weather.\ninput schema:\n{\n  \"type\": \"object\"\n}"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "ready"},
+		{Role: zeroruntime.MessageRoleUser, Content: "continue"},
+		{Role: zeroruntime.MessageRoleAssistant, Content: "continuing"},
+	}
+
+	first, err := Compact(messages, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "FIRST SUMMARY", nil },
+	})
+	if err != nil {
+		t.Fatalf("first Compact: %v", err)
+	}
+	second := append(append([]zeroruntime.Message{}, first...),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "more"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "ok"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "again"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "fine"},
+	)
+
+	out, err := Compact(second, CompactionOptions{
+		PreserveLast: 2,
+		Summarize:    func([]zeroruntime.Message) (string, error) { return "SECOND SUMMARY", nil },
+	})
+	if err != nil {
+		t.Fatalf("second Compact: %v", err)
+	}
+	state := parsePreservedStateBlock(out[1].Content)
+	if len(state.Tools) != 1 || state.Tools[0].Name != "weather_lookup" || !strings.Contains(state.Tools[0].Body, "input schema") {
+		t.Fatalf("loaded tool state was not carried forward: %#v", state.Tools)
+	}
+	if len(state.ProjectInstructions) != 1 ||
+		state.ProjectInstructions[0].Source != "AGENTS.md instructions for /repo" ||
+		!strings.Contains(state.ProjectInstructions[0].Body, "Stay in internal/agent.") {
+		t.Fatalf("project instructions were not carried forward: %#v", state.ProjectInstructions)
 	}
 }
 
@@ -188,6 +283,22 @@ func TestExtractLatestPlanReturnsMostRecent(t *testing.T) {
 	}
 }
 
+func TestFormatPlanArgumentsAcceptsStepAlias(t *testing.T) {
+	got := formatPlanArguments(`{"plan":[{"step":"write failing test","status":"in_progress"},{"content":"keep existing shape","status":"pending"}]}`)
+	for _, want := range []string{"- [in_progress] write failing test", "- [pending] keep existing shape"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in formatted plan, got %q", want, got)
+		}
+	}
+}
+
+func TestFormatPlanArgumentsPreservesNotes(t *testing.T) {
+	got := formatPlanArguments(`{"plan":[{"content":"finish preservation","status":"in_progress","notes":"keep TUI untouched"}]}`)
+	if !strings.Contains(got, "- [in_progress] finish preservation") || !strings.Contains(got, "Notes: keep TUI untouched") {
+		t.Fatalf("expected plan content and notes to be preserved, got %q", got)
+	}
+}
+
 func TestCapBodyShortBodyUnchanged(t *testing.T) {
 	body := "short skill body"
 	if got := capBody(body); got != body {
@@ -237,5 +348,18 @@ func TestLoadedSkillsSkipsCallsWithoutResult(t *testing.T) {
 	}
 	if got := loadedSkills(messages); len(got) != 0 {
 		t.Fatalf("expected no skills without a result body, got %#v", got)
+	}
+}
+
+func TestLoadedSkillsAcceptsSkillArgumentAlias(t *testing.T) {
+	messages := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleAssistant, ToolCalls: []zeroruntime.ToolCall{
+			{ID: "s1", Name: "skill", Arguments: `{"skill":"deploy"}`},
+		}},
+		{Role: zeroruntime.MessageRoleTool, ToolCallID: "s1", Content: "deploy instructions"},
+	}
+	got := loadedSkills(messages)
+	if len(got) != 1 || got[0].name != "deploy" || got[0].body != "deploy instructions" {
+		t.Fatalf("loadedSkills should honor skill alias, got %#v", got)
 	}
 }

--- a/internal/sessions/exec_session.go
+++ b/internal/sessions/exec_session.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -67,7 +68,7 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		if parent == nil {
 			return PreparedExec{}, ExecError{"Zero session not found: " + forkID}
 		}
-		contextEvents, err := store.ReadRehydratedEvents(parent.SessionID)
+		contextEvents, err := readExecContextEvents(store, parent.SessionID)
 		if err != nil {
 			return PreparedExec{}, err
 		}
@@ -103,7 +104,7 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		if session == nil {
 			return PreparedExec{}, ExecError{"Zero session not found: " + sessionID}
 		}
-		contextEvents, err := store.ReadRehydratedEvents(session.SessionID)
+		contextEvents, err := readExecContextEvents(store, session.SessionID)
 		if err != nil {
 			return PreparedExec{}, err
 		}
@@ -140,6 +141,19 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		return PreparedExec{}, err
 	}
 	return PreparedExec{Mode: ModeNew, Session: session, ContextEvents: []Event{}, Store: store}, nil
+}
+
+func readExecContextEvents(store *Store, sessionID string) ([]Event, error) {
+	contextEvents, err := store.ReadRehydratedEvents(sessionID)
+	if err == nil {
+		return contextEvents, nil
+	}
+	rawEvents, rawErr := store.ReadEvents(sessionID)
+	if rawErr != nil {
+		return nil, err
+	}
+	log.Printf("zero sessions: failed to rehydrate compaction events for %s; falling back to raw events: %v", sessionID, err)
+	return rawEvents, nil
 }
 
 func FormatExecPrompt(prompt string, prepared PreparedExec) string {

--- a/internal/sessions/exec_session.go
+++ b/internal/sessions/exec_session.go
@@ -67,7 +67,7 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		if parent == nil {
 			return PreparedExec{}, ExecError{"Zero session not found: " + forkID}
 		}
-		contextEvents, err := store.ReadEvents(parent.SessionID)
+		contextEvents, err := store.ReadRehydratedEvents(parent.SessionID)
 		if err != nil {
 			return PreparedExec{}, err
 		}
@@ -103,7 +103,7 @@ func PrepareExec(options PrepareExecOptions) (PreparedExec, error) {
 		if session == nil {
 			return PreparedExec{}, ExecError{"Zero session not found: " + sessionID}
 		}
-		contextEvents, err := store.ReadEvents(session.SessionID)
+		contextEvents, err := store.ReadRehydratedEvents(session.SessionID)
 		if err != nil {
 			return PreparedExec{}, err
 		}
@@ -217,6 +217,9 @@ func extractText(value any) string {
 		}
 		return strings.Join(parts, " ")
 	case map[string]any:
+		if summary, ok := typed["summary"].(string); ok && strings.TrimSpace(summary) != "" {
+			return summary
+		}
 		parts := []string{}
 		for _, item := range typed {
 			if text := extractText(item); text != "" {

--- a/internal/sessions/replay.go
+++ b/internal/sessions/replay.go
@@ -51,6 +51,26 @@ type CompactionPlan struct {
 	Truncated         bool       `json:"truncated,omitempty"`
 }
 
+type RecordCompactionInput struct {
+	Plan    CompactionPlan
+	Summary string
+}
+
+// CompactionPayload is the payload of an EventCompaction event. It records the
+// summary that should replace compacted-away events during replay.
+type CompactionPayload struct {
+	Summary                  string     `json:"summary"`
+	PreserveLast             int        `json:"preserveLast"`
+	CompactableCount         int        `json:"compactableCount"`
+	PreservedCount           int        `json:"preservedCount"`
+	CompactedThroughEventID  string     `json:"compactedThroughEventId,omitempty"`
+	CompactedThroughSequence int        `json:"compactedThroughSequence,omitempty"`
+	CompactableEvents        []EventRef `json:"compactableEvents,omitempty"`
+	PreservedEvents          []EventRef `json:"preservedEvents,omitempty"`
+	PromptChars              int        `json:"promptChars,omitempty"`
+	Truncated                bool       `json:"truncated,omitempty"`
+}
+
 const defaultCompactionPreserveLast = 8
 const defaultCompactionMaxPromptChars = 8000
 
@@ -156,6 +176,126 @@ func (store *Store) PlanCompaction(sessionID string, options CompactionOptions) 
 		PromptChars:       len(prompt),
 		Truncated:         truncated,
 	}, nil
+}
+
+func (store *Store) RecordCompaction(sessionID string, input RecordCompactionInput) (Event, error) {
+	if !ValidSessionID(sessionID) {
+		return Event{}, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	if strings.TrimSpace(input.Plan.SessionID) != "" && input.Plan.SessionID != sessionID {
+		return Event{}, fmt.Errorf("compaction plan session %s does not match %s", input.Plan.SessionID, sessionID)
+	}
+	payload, err := CompactionPayloadFromPlan(input.Summary, input.Plan)
+	if err != nil {
+		return Event{}, err
+	}
+	return store.AppendEvent(sessionID, AppendEventInput{Type: EventCompaction, Payload: payload})
+}
+
+func CompactionPayloadFromPlan(summary string, plan CompactionPlan) (CompactionPayload, error) {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return CompactionPayload{}, fmt.Errorf("compaction summary is required")
+	}
+	if len(plan.CompactableEvents) == 0 {
+		return CompactionPayload{}, fmt.Errorf("compaction plan has no compactable events")
+	}
+	lastCompactable := plan.CompactableEvents[len(plan.CompactableEvents)-1]
+	return CompactionPayload{
+		Summary:                  summary,
+		PreserveLast:             plan.PreserveLast,
+		CompactableCount:         plan.CompactableCount,
+		PreservedCount:           plan.PreservedCount,
+		CompactedThroughEventID:  lastCompactable.ID,
+		CompactedThroughSequence: lastCompactable.Sequence,
+		CompactableEvents:        cloneEventRefs(plan.CompactableEvents),
+		PreservedEvents:          cloneEventRefs(plan.PreservedEvents),
+		PromptChars:              plan.PromptChars,
+		Truncated:                plan.Truncated,
+	}, nil
+}
+
+func (store *Store) ReadRehydratedEvents(sessionID string) ([]Event, error) {
+	events, err := store.ReadEvents(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return RehydrateEvents(events)
+}
+
+func (store *Store) ReadReplayEvents(sessionID string) ([]Event, error) {
+	return store.ReadRehydratedEvents(sessionID)
+}
+
+func RehydrateEvents(events []Event) ([]Event, error) {
+	index := -1
+	var payload CompactionPayload
+	for i, event := range events {
+		if event.Type != EventCompaction {
+			continue
+		}
+		decoded, err := decodeCompactionPayload(event)
+		if err != nil {
+			return nil, err
+		}
+		index = i
+		payload = decoded
+	}
+	if index < 0 {
+		return cloneEvents(events), nil
+	}
+	return rehydrateEventsWithCompaction(events, events[index], payload), nil
+}
+
+func ReplayEvents(events []Event) ([]Event, error) {
+	return RehydrateEvents(events)
+}
+
+func decodeCompactionPayload(event Event) (CompactionPayload, error) {
+	var payload CompactionPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return CompactionPayload{}, fmt.Errorf("decode compaction payload seq %d: %w", event.Sequence, err)
+	}
+	if strings.TrimSpace(payload.Summary) == "" {
+		return CompactionPayload{}, fmt.Errorf("decode compaction payload seq %d: summary is required", event.Sequence)
+	}
+	return payload, nil
+}
+
+func rehydrateEventsWithCompaction(events []Event, compaction Event, payload CompactionPayload) []Event {
+	skipIDs := map[string]bool{}
+	for _, ref := range payload.CompactableEvents {
+		if ref.ID != "" {
+			skipIDs[ref.ID] = true
+		}
+	}
+	useSequenceCutoff := len(skipIDs) == 0 && payload.CompactedThroughSequence > 0
+	shouldSkip := func(event Event) bool {
+		if skipIDs[event.ID] {
+			return true
+		}
+		return useSequenceCutoff && event.Sequence <= payload.CompactedThroughSequence
+	}
+
+	rehydrated := make([]Event, 0, len(events))
+	insertedSummary := false
+	for _, event := range events {
+		if event.ID == compaction.ID {
+			continue
+		}
+		if shouldSkip(event) {
+			if !insertedSummary {
+				rehydrated = append(rehydrated, compaction)
+				insertedSummary = true
+			}
+			continue
+		}
+		rehydrated = append(rehydrated, event)
+	}
+	if !insertedSummary {
+		return append([]Event{compaction}, rehydrated...)
+	}
+	return rehydrated
 }
 
 func buildCompactionPrompt(events []Event, maxChars int) (string, bool) {
@@ -274,4 +414,22 @@ func eventRefs(events []Event) []EventRef {
 		})
 	}
 	return refs
+}
+
+func cloneEventRefs(refs []EventRef) []EventRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	cloned := make([]EventRef, len(refs))
+	copy(cloned, refs)
+	return cloned
+}
+
+func cloneEvents(events []Event) []Event {
+	if len(events) == 0 {
+		return []Event{}
+	}
+	cloned := make([]Event, len(events))
+	copy(cloned, events)
+	return cloned
 }

--- a/internal/sessions/replay.go
+++ b/internal/sessions/replay.go
@@ -182,7 +182,10 @@ func (store *Store) RecordCompaction(sessionID string, input RecordCompactionInp
 	if !ValidSessionID(sessionID) {
 		return Event{}, fmt.Errorf("invalid zero session id %q", sessionID)
 	}
-	if strings.TrimSpace(input.Plan.SessionID) != "" && input.Plan.SessionID != sessionID {
+	if strings.TrimSpace(input.Plan.SessionID) == "" {
+		return Event{}, fmt.Errorf("compaction plan session id is required")
+	}
+	if input.Plan.SessionID != sessionID {
 		return Event{}, fmt.Errorf("compaction plan session %s does not match %s", input.Plan.SessionID, sessionID)
 	}
 	payload, err := CompactionPayloadFromPlan(input.Summary, input.Plan)
@@ -228,23 +231,17 @@ func (store *Store) ReadReplayEvents(sessionID string) ([]Event, error) {
 }
 
 func RehydrateEvents(events []Event) ([]Event, error) {
-	index := -1
-	var payload CompactionPayload
-	for i, event := range events {
-		if event.Type != EventCompaction {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Type != EventCompaction {
 			continue
 		}
-		decoded, err := decodeCompactionPayload(event)
+		payload, err := decodeCompactionPayload(events[i])
 		if err != nil {
 			return nil, err
 		}
-		index = i
-		payload = decoded
+		return rehydrateEventsWithCompaction(events, events[i], payload), nil
 	}
-	if index < 0 {
-		return cloneEvents(events), nil
-	}
-	return rehydrateEventsWithCompaction(events, events[index], payload), nil
+	return cloneEvents(events), nil
 }
 
 func ReplayEvents(events []Event) ([]Event, error) {

--- a/internal/sessions/replay_test.go
+++ b/internal/sessions/replay_test.go
@@ -252,6 +252,33 @@ func TestStoreRecordsCompactionEventPayload(t *testing.T) {
 	}
 }
 
+func TestStoreRecordCompactionRequiresPlanSessionID(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	session, err := store.Create(CreateInput{SessionID: "compactmissingplan"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{"alpha", "beta", "gamma"} {
+		if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": content}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := store.PlanCompaction(session.SessionID, CompactionOptions{PreserveLast: 1, MaxPromptChars: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan.SessionID = ""
+
+	_, err = store.RecordCompaction(session.SessionID, RecordCompactionInput{
+		Plan:    plan,
+		Summary: "summarized",
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "compaction plan session id is required") {
+		t.Fatalf("expected missing plan session id error, got %v", err)
+	}
+}
+
 func TestStoreReadRehydratedEventsReplacesCompactedPrefixWithSummary(t *testing.T) {
 	store := NewStore(StoreOptions{RootDir: t.TempDir()})
 	session, err := store.Create(CreateInput{SessionID: "rehydrate"})
@@ -307,10 +334,49 @@ func TestStoreReadRehydratedEventsReplacesCompactedPrefixWithSummary(t *testing.
 	}
 }
 
+func TestRehydrateEventsDecodesOnlyLatestCompactionPayload(t *testing.T) {
+	events := []Event{
+		{ID: "rehydratelatest:1", SessionID: "rehydratelatest", Sequence: 1, Type: EventMessage, CreatedAt: "2026-06-11T10:00:00Z", Payload: json.RawMessage(`{"content":"first"}`)},
+		{ID: "rehydratelatest:2", SessionID: "rehydratelatest", Sequence: 2, Type: EventCompaction, CreatedAt: "2026-06-11T10:00:01Z", Payload: json.RawMessage(`{"summary":""}`)},
+		{ID: "rehydratelatest:3", SessionID: "rehydratelatest", Sequence: 3, Type: EventMessage, CreatedAt: "2026-06-11T10:00:02Z", Payload: json.RawMessage(`{"content":"second"}`)},
+		{ID: "rehydratelatest:4", SessionID: "rehydratelatest", Sequence: 4, Type: EventCompaction, CreatedAt: "2026-06-11T10:00:03Z", Payload: mustRawJSON(t, CompactionPayload{
+			Summary:                 "Latest compacted summary.",
+			CompactableCount:        2,
+			PreservedCount:          1,
+			CompactedThroughEventID: "rehydratelatest:3",
+			CompactableEvents: []EventRef{
+				{ID: "rehydratelatest:2", Sequence: 2, Type: EventCompaction},
+				{ID: "rehydratelatest:3", Sequence: 3, Type: EventMessage},
+			},
+		})},
+		{ID: "rehydratelatest:5", SessionID: "rehydratelatest", Sequence: 5, Type: EventMessage, CreatedAt: "2026-06-11T10:00:04Z", Payload: json.RawMessage(`{"content":"tail"}`)},
+	}
+
+	rehydrated, err := RehydrateEvents(events)
+
+	if err != nil {
+		t.Fatalf("RehydrateEvents returned error for historical malformed payload: %v", err)
+	}
+	gotIDs := eventIDs(rehydrated)
+	wantIDs := []string{"rehydratelatest:1", "rehydratelatest:4", "rehydratelatest:5"}
+	if strings.Join(gotIDs, ",") != strings.Join(wantIDs, ",") {
+		t.Fatalf("rehydrated ids = %#v, want %#v", gotIDs, wantIDs)
+	}
+}
+
 func eventIDs(events []Event) []string {
 	ids := make([]string, 0, len(events))
 	for _, event := range events {
 		ids = append(ids, event.ID)
 	}
 	return ids
+}
+
+func mustRawJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
 }

--- a/internal/sessions/replay_test.go
+++ b/internal/sessions/replay_test.go
@@ -1,6 +1,7 @@
 package sessions
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -184,4 +185,132 @@ func TestStoreCompactionPromptCanBeTruncated(t *testing.T) {
 	if !plan.Truncated || len(plan.SummaryPrompt) > 80 {
 		t.Fatalf("expected truncated summary prompt within limit, got %#v", plan)
 	}
+}
+
+func TestStoreRecordsCompactionEventPayload(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: sequenceClock([]time.Time{
+		time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 11, 10, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 11, 10, 0, 2, 0, time.UTC),
+		time.Date(2026, 6, 11, 10, 0, 3, 0, time.UTC),
+		time.Date(2026, 6, 11, 10, 0, 4, 0, time.UTC),
+		time.Date(2026, 6, 11, 10, 0, 5, 0, time.UTC),
+	})})
+	session, err := store.Create(CreateInput{SessionID: "compactrecord"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{"raw-alpha-context", "raw-beta-context", "gamma", "delta"} {
+		if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": content}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := store.PlanCompaction(session.SessionID, CompactionOptions{PreserveLast: 2, MaxPromptChars: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event, err := store.RecordCompaction(session.SessionID, RecordCompactionInput{
+		Plan:    plan,
+		Summary: "Alpha and beta have been summarized for replay.",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Type != EventCompaction || event.ID != "compactrecord:5" {
+		t.Fatalf("compaction event = %#v", event)
+	}
+	var payload CompactionPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("decode compaction payload: %v", err)
+	}
+	if payload.Summary != "Alpha and beta have been summarized for replay." {
+		t.Fatalf("summary = %q", payload.Summary)
+	}
+	if payload.CompactedThroughEventID != "compactrecord:2" || payload.CompactedThroughSequence != 2 {
+		t.Fatalf("compacted-through fields = %#v", payload)
+	}
+	if payload.PreserveLast != 2 || payload.CompactableCount != 2 || payload.PreservedCount != 2 {
+		t.Fatalf("compaction counts = %#v", payload)
+	}
+	if payload.PromptChars != plan.PromptChars || payload.Truncated != plan.Truncated {
+		t.Fatalf("compact-plan parity fields = %#v, plan = %#v", payload, plan)
+	}
+	if len(payload.CompactableEvents) != 2 || payload.CompactableEvents[0].ID != "compactrecord:1" || payload.CompactableEvents[1].ID != "compactrecord:2" {
+		t.Fatalf("compactable refs = %#v", payload.CompactableEvents)
+	}
+	if len(payload.PreservedEvents) != 2 || payload.PreservedEvents[0].ID != "compactrecord:3" || payload.PreservedEvents[1].ID != "compactrecord:4" {
+		t.Fatalf("preserved refs = %#v", payload.PreservedEvents)
+	}
+	loaded, err := store.Get(session.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil || loaded.EventCount != 5 || loaded.LastEventType != EventCompaction {
+		t.Fatalf("metadata after compaction = %#v", loaded)
+	}
+}
+
+func TestStoreReadRehydratedEventsReplacesCompactedPrefixWithSummary(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	session, err := store.Create(CreateInput{SessionID: "rehydrate"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{"raw-alpha-context", "raw-beta-context", "gamma", "delta"} {
+		if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": content}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plan, err := store.PlanCompaction(session.SessionID, CompactionOptions{PreserveLast: 2, MaxPromptChars: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordCompaction(session.SessionID, RecordCompactionInput{
+		Plan:    plan,
+		Summary: "Early context summary.",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": "epsilon"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := store.ReadRehydratedEvents(session.SessionID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotIDs := eventIDs(events)
+	wantIDs := []string{"rehydrate:5", "rehydrate:3", "rehydrate:4", "rehydrate:6"}
+	if strings.Join(gotIDs, ",") != strings.Join(wantIDs, ",") {
+		t.Fatalf("rehydrated ids = %#v, want %#v", gotIDs, wantIDs)
+	}
+	prepared, err := PrepareExec(PrepareExecOptions{Store: store, Resume: session.SessionID})
+	if err != nil {
+		t.Fatalf("PrepareExec returned error: %v", err)
+	}
+	if got := eventIDs(prepared.ContextEvents); strings.Join(got, ",") != strings.Join(wantIDs, ",") {
+		t.Fatalf("prepared context ids = %#v, want %#v", got, wantIDs)
+	}
+	prompt := FormatExecPrompt("continue", prepared)
+	for _, want := range []string{"Early context summary.", "gamma", "delta", "epsilon"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("rehydrated prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, dropped := range []string{"raw-alpha-context", "raw-beta-context"} {
+		if strings.Contains(prompt, dropped) {
+			t.Fatalf("rehydrated prompt should not include compacted event %q:\n%s", dropped, prompt)
+		}
+	}
+}
+
+func eventIDs(events []Event) []string {
+	ids := make([]string, 0, len(events))
+	for _, event := range events {
+		ids = append(ids, event.ID)
+	}
+	return ids
 }

--- a/internal/sessions/replay_test.go
+++ b/internal/sessions/replay_test.go
@@ -334,6 +334,40 @@ func TestStoreReadRehydratedEventsReplacesCompactedPrefixWithSummary(t *testing.
 	}
 }
 
+func TestPrepareExecFallsBackToRawEventsWhenLatestCompactionIsMalformed(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	session, err := store.Create(CreateInput{SessionID: "malformed_compaction"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]string{"content": "before compaction"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventCompaction, Payload: json.RawMessage(`{"summary":""}`)}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ReadRehydratedEvents(session.SessionID); err == nil {
+		t.Fatal("expected malformed latest compaction to fail direct rehydration")
+	}
+
+	resumed, err := PrepareExec(PrepareExecOptions{Store: store, Resume: session.SessionID})
+	if err != nil {
+		t.Fatalf("PrepareExec resume should fall back to raw events, got error: %v", err)
+	}
+	if got := eventIDs(resumed.ContextEvents); strings.Join(got, ",") != "malformed_compaction:1,malformed_compaction:2" {
+		t.Fatalf("resume context ids = %#v, want raw event ids", got)
+	}
+
+	forked, err := PrepareExec(PrepareExecOptions{Store: store, Fork: session.SessionID, SessionID: "malformed_compaction_fork"})
+	if err != nil {
+		t.Fatalf("PrepareExec fork should fall back to raw events, got error: %v", err)
+	}
+	if got := eventIDs(forked.ContextEvents); strings.Join(got, ",") != "malformed_compaction:1,malformed_compaction:2" {
+		t.Fatalf("fork context ids = %#v, want raw parent event ids", got)
+	}
+}
+
 func TestRehydrateEventsDecodesOnlyLatestCompactionPayload(t *testing.T) {
 	events := []Event{
 		{ID: "rehydratelatest:1", SessionID: "rehydratelatest", Sequence: 1, Type: EventMessage, CreatedAt: "2026-06-11T10:00:00Z", Payload: json.RawMessage(`{"content":"first"}`)},

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -112,6 +112,54 @@ const (
 	sessionsCardFieldSep = "\x1f"
 )
 
+type modelSwitchCompactionRequest struct {
+	CurrentModel         string
+	TargetModel          string
+	CurrentProvider      string
+	TargetProvider       string
+	CurrentContextWindow int
+	TargetContextWindow  int
+	EstimatedTokens      int
+	SessionEventCount    int
+	CompactRequests      int
+}
+
+type modelSwitchCompactionDecision struct {
+	RequestCompaction bool
+	Reason            string
+}
+
+type modelSwitchCompactionPolicy interface {
+	BeforeModelSwitch(modelSwitchCompactionRequest) modelSwitchCompactionDecision
+}
+
+type defaultModelSwitchCompactionPolicy struct{}
+
+func (defaultModelSwitchCompactionPolicy) BeforeModelSwitch(request modelSwitchCompactionRequest) modelSwitchCompactionDecision {
+	if request.CompactRequests > 0 || request.SessionEventCount <= tuiCompactionPreserveLast {
+		return modelSwitchCompactionDecision{}
+	}
+	if request.TargetContextWindow <= 0 || request.EstimatedTokens <= 0 {
+		return modelSwitchCompactionDecision{}
+	}
+	threshold := int(float64(request.TargetContextWindow) * 0.8)
+	if request.EstimatedTokens < threshold {
+		return modelSwitchCompactionDecision{}
+	}
+	return modelSwitchCompactionDecision{
+		RequestCompaction: true,
+		Reason:            fmt.Sprintf("estimated context %s tokens is near target context %s tokens", formatContextWindow(request.EstimatedTokens), formatContextWindow(request.TargetContextWindow)),
+	}
+}
+
+type noopModelSwitchCompactionPolicy struct{}
+
+func (noopModelSwitchCompactionPolicy) BeforeModelSwitch(modelSwitchCompactionRequest) modelSwitchCompactionDecision {
+	return modelSwitchCompactionDecision{}
+}
+
+var modelSwitchCompactionGuard modelSwitchCompactionPolicy = defaultModelSwitchCompactionPolicy{}
+
 // sanitizeCardField strips the card protocol's separator bytes from
 // user-controlled values (titles can legally contain anything --session-title
 // was given), so a hostile or accidental \x1f / newline cannot shift fields
@@ -177,6 +225,14 @@ func (m model) handleModelCommand(args string) (model, string) {
 	metadata, err := providers.ResolveRuntimeMetadata(nextProfile, providers.Options{})
 	if err != nil {
 		return m, "Model\n" + err.Error()
+	}
+
+	if guarded, text, requested := m.requestCompactionBeforeModelSwitch(modelSwitchCompactionRequest{
+		TargetModel:         target.modelID,
+		TargetProvider:      string(metadata.ProviderKind),
+		TargetContextWindow: modelContextWindow(target.modelID),
+	}, "Model"); requested {
+		return guarded, text
 	}
 
 	nextProvider, err := m.newProvider(nextProfile)
@@ -297,6 +353,13 @@ func (m model) handleModeCommand(args string) (model, string) {
 	if err != nil {
 		return m, "Mode\n" + err.Error()
 	}
+	if guarded, text, requested := m.requestCompactionBeforeModelSwitch(modelSwitchCompactionRequest{
+		TargetModel:         entry.ID,
+		TargetProvider:      string(metadata.ProviderKind),
+		TargetContextWindow: modelContextWindow(entry.ID),
+	}, "Mode"); requested {
+		return guarded, text
+	}
 	nextProvider, err := m.newProvider(nextProfile)
 	if err != nil {
 		return m, "Mode\n" + err.Error()
@@ -340,6 +403,40 @@ func (m model) handleModeCommand(args string) (model, string) {
 		turnsLine,
 	)
 	return m, strings.Join(lines, "\n")
+}
+
+func (m model) requestCompactionBeforeModelSwitch(request modelSwitchCompactionRequest, title string) (model, string, bool) {
+	if modelSwitchCompactionGuard == nil {
+		return m, "", false
+	}
+	request.CurrentModel = m.modelName
+	request.CurrentProvider = m.providerName
+	request.CurrentContextWindow = modelContextWindow(m.modelName)
+	request.EstimatedTokens = estimateTranscriptTokens(m.transcript)
+	request.SessionEventCount = len(m.sessionEvents)
+	request.CompactRequests = m.compactRequests
+
+	decision := modelSwitchCompactionGuard.BeforeModelSwitch(request)
+	if !decision.RequestCompaction {
+		return m, "", false
+	}
+
+	m.compactRequests++
+	lines := []string{
+		title,
+		"Context compaction requested before switching models.",
+		"The active model/provider is unchanged until compaction can run.",
+		"from model: " + displayValue(request.CurrentModel, "none"),
+		"to model: " + displayValue(request.TargetModel, "none"),
+	}
+	if request.TargetProvider != "" {
+		lines = append(lines, "target provider: "+request.TargetProvider)
+	}
+	if reason := strings.TrimSpace(decision.Reason); reason != "" {
+		lines = append(lines, "reason: "+reason)
+	}
+	lines = append(lines, "compaction: "+m.compactionStatus())
+	return m, strings.Join(lines, "\n"), true
 }
 
 func (m model) modeListText() string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -54,6 +54,8 @@ type model struct {
 	reasoningEffort        modelregistry.ReasoningEffort
 	responseStyle          string
 	compactRequests        int
+	compactInFlight        bool
+	compactFrame           int
 	lastCompactResult      *CompactResult
 	lastCompactError       string
 	unpricedRequests       int
@@ -623,11 +625,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinner.TickMsg:
 		// Not forwarding the tick while idle stops the spinner's self-scheduling,
 		// so no timer fires between runs.
-		if !m.pending {
+		if !m.pending && !m.compactInFlight {
 			return m, nil
 		}
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
+		if m.compactInFlight {
+			m.compactFrame++
+			m = m.setCompactStatusRow(m.compactText(true))
+		}
 		return m, cmd
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -778,6 +784,28 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))
 		}
 		return m.launchQueuedMessageIfReady()
+	case compactResultMsg:
+		if !m.compactInFlight {
+			return m, nil
+		}
+		m.compactInFlight = false
+		m.compactFrame = 0
+		m.lastCompactResult = nil
+		m.lastCompactError = ""
+		if msg.err != nil {
+			m.lastCompactError = msg.err.Error()
+			m = m.setCompactStatusRow(m.compactText(true))
+			return m, nil
+		}
+		if msg.hasSessionSnapshot {
+			m.activeSession = msg.activeSession
+			m.sessionEvents = append([]sessions.Event{}, msg.sessionEvents...)
+			m.transcript = append([]transcriptRow{}, msg.transcript...)
+			m.resetFlushFrontier("· compacted ·")
+		}
+		m.lastCompactResult = &msg.result
+		m = m.setCompactStatusRow(m.compactText(true))
+		return m, nil
 	case agentRowMsg:
 		if msg.runID != m.activeRunID {
 			return m, nil
@@ -1159,6 +1187,13 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	if command.kind == commandPrompt && m.pending {
 		return m.queueMessage(command.text), nil
 	}
+	if command.kind == commandPrompt && m.compactInFlight {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{
+			kind: actionAppendSystem,
+			text: "Compact\nstatus: warning\nCompaction is running. Your next prompt will use the compacted context when this finishes.",
+		})
+		return m, nil
+	}
 	m.rememberInput(input)
 	m.clearComposer()
 	m.clearSuggestions()
@@ -1277,9 +1312,10 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		return m.handleSpecCommand(command.text)
 	case commandCompact:
 		text := ""
-		m, text = m.handleCompactCommand(command.text)
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
-		return m, nil
+		var compactCmd tea.Cmd
+		m, text, compactCmd = m.handleCompactCommand(command.text)
+		m = m.setCompactStatusRow(text)
+		return m, compactCmd
 	case commandTranscript:
 		return m.toggleDetailedTranscript(), nil
 	case commandRewind:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -46,6 +46,7 @@ type model struct {
 	activeSession          sessions.Metadata
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
+	sessionCompactor       SessionCompactor
 	runtimeMessageSink     func(tea.Msg)
 	agentOptions           agent.Options
 	notifier               *notify.Notifier
@@ -53,6 +54,8 @@ type model struct {
 	reasoningEffort        modelregistry.ReasoningEffort
 	responseStyle          string
 	compactRequests        int
+	lastCompactResult      *CompactResult
+	lastCompactError       string
 	unpricedRequests       int
 	unpricedTokens         int
 	transcript             []transcriptRow
@@ -294,6 +297,7 @@ func newModel(ctx context.Context, options Options) model {
 		sessionStore:           sessionStore,
 		sandboxStore:           sandboxStore,
 		agentOptions:           options.AgentOptions,
+		sessionCompactor:       options.SessionCompactor,
 		runtimeMessageSink:     options.RuntimeMessageSink,
 		permissionMode:         permissionMode,
 		reasoningEffort:        options.ReasoningEffort,

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -487,6 +487,101 @@ func TestModelCommandSwitchesSessionModel(t *testing.T) {
 	}
 }
 
+type stubModelSwitchCompactionGuard struct {
+	decision modelSwitchCompactionDecision
+	requests []modelSwitchCompactionRequest
+}
+
+func (guard *stubModelSwitchCompactionGuard) BeforeModelSwitch(request modelSwitchCompactionRequest) modelSwitchCompactionDecision {
+	guard.requests = append(guard.requests, request)
+	return guard.decision
+}
+
+func TestDefaultModelSwitchCompactionPolicyRequestsCompactionForLargeTargetWindowUsage(t *testing.T) {
+	decision := defaultModelSwitchCompactionPolicy{}.BeforeModelSwitch(modelSwitchCompactionRequest{
+		CurrentModel:        "gpt-4.1",
+		TargetModel:         "small-context-model",
+		TargetContextWindow: 1000,
+		EstimatedTokens:     850,
+		SessionEventCount:   20,
+		CompactRequests:     0,
+	})
+
+	if !decision.RequestCompaction {
+		t.Fatalf("expected default policy to request compaction, got %#v", decision)
+	}
+	if !strings.Contains(decision.Reason, "target context") {
+		t.Fatalf("expected reason to mention target context, got %q", decision.Reason)
+	}
+}
+
+func TestModelCommandRequestsCompactionBeforeDirtyContextSwitch(t *testing.T) {
+	guard := &stubModelSwitchCompactionGuard{
+		decision: modelSwitchCompactionDecision{
+			RequestCompaction: true,
+			Reason:            "dirty context uses most of the target window",
+		},
+	}
+	previousGuard := modelSwitchCompactionGuard
+	modelSwitchCompactionGuard = guard
+	defer func() { modelSwitchCompactionGuard = previousGuard }()
+
+	originalProvider := &fakeProvider{}
+	rebuilds := 0
+	m := newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      config.OpenAIBaseURL,
+			APIKey:       "sk-test",
+			Model:        "gpt-4.1",
+		},
+		Provider: originalProvider,
+		NewProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			rebuilds++
+			return &fakeProvider{}, nil
+		},
+	})
+	m.sessionEvents = []sessions.Event{{Sequence: 1, Type: sessions.EventMessage}}
+	m.input.SetValue("/model gpt-4.1-mini")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /model to be handled without starting an agent run")
+	}
+	if rebuilds != 0 {
+		t.Fatalf("provider should not be rebuilt before requested compaction, got %d rebuilds", rebuilds)
+	}
+	if next.modelName != "gpt-4.1" || next.provider != originalProvider {
+		t.Fatalf("expected active model/provider to remain unchanged, got model=%q provider=%#v", next.modelName, next.provider)
+	}
+	if next.compactRequests != 1 {
+		t.Fatalf("expected model switch to request compaction, got %d requests", next.compactRequests)
+	}
+	if len(guard.requests) != 1 {
+		t.Fatalf("expected one compaction guard request, got %d", len(guard.requests))
+	}
+	request := guard.requests[0]
+	if request.CurrentModel != "gpt-4.1" || request.TargetModel != "gpt-4.1-mini" {
+		t.Fatalf("unexpected guard model transition: %#v", request)
+	}
+	if request.SessionEventCount != 1 {
+		t.Fatalf("expected dirty session event count in guard request, got %#v", request)
+	}
+	for _, want := range []string{
+		"Context compaction requested before switching models.",
+		"dirty context uses most of the target window",
+	} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected model transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
 func TestModelCommandRequiresProviderRebuildForSwitch(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		ModelName: "gpt-4.1",

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -31,6 +31,7 @@ type Options struct {
 	SessionStore           *sessions.Store
 	SandboxStore           *sandbox.GrantStore
 	UsageTracker           *usage.Tracker
+	SessionCompactor       SessionCompactor
 
 	AgentOptions    agent.Options
 	PermissionMode  agent.PermissionMode

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -201,6 +201,9 @@ func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext
 		if row.tool == "sessions" {
 			return renderSessionsCards(row.text, width)
 		}
+		if row.id == compactStatusRowID && strings.HasPrefix(strings.TrimSpace(row.text), "Compressing session") {
+			return renderCompactRunningCard(row.text, width)
+		}
 		return renderSystemNote(row.text, width)
 	case rowError:
 		return renderErrorRow(row, width)
@@ -406,6 +409,27 @@ func doneLine(row transcriptRow, failed bool) string {
 // the panel surface inside a line border. Content is passed through unchanged.
 func renderSystemNote(text string, width int) string {
 	return noteBox(text, width, zeroTheme.line, zeroTheme.onPanel(zeroTheme.faint))
+}
+
+func renderCompactRunningCard(text string, width int) string {
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(text, "\r\n", "\n"), "\n"), "\n")
+	lines := make([]string, 0, len(raw)+1)
+	for index, line := range raw {
+		switch index {
+		case 0:
+			lines = append(lines, zeroTheme.amber.Bold(true).Render(line))
+		case 1:
+			lines = append(lines, zeroTheme.muted.Render(line))
+		case 2:
+			lines = append(lines, zeroTheme.amber.Bold(true).Render(line))
+		default:
+			lines = append(lines, zeroTheme.faint.Render(line))
+		}
+		if index == 0 {
+			lines = append(lines, "")
+		}
+	}
+	return styledBlock(width, lines, zeroTheme.amber)
 }
 
 func renderErrorRow(row transcriptRow, width int) string {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -204,6 +204,9 @@ func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext
 		if row.id == compactStatusRowID && strings.HasPrefix(strings.TrimSpace(row.text), "Compressing session") {
 			return renderCompactRunningCard(row.text, width)
 		}
+		if row.id == compactStatusRowID && strings.HasPrefix(strings.TrimSpace(row.text), "Compression complete") {
+			return renderCompactCompleteCard(row.text, width)
+		}
 		return renderSystemNote(row.text, width)
 	case rowError:
 		return renderErrorRow(row, width)
@@ -430,6 +433,25 @@ func renderCompactRunningCard(text string, width int) string {
 		}
 	}
 	return styledBlock(width, lines, zeroTheme.amber)
+}
+
+func renderCompactCompleteCard(text string, width int) string {
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(text, "\r\n", "\n"), "\n"), "\n")
+	lines := make([]string, 0, len(raw)+1)
+	for index, line := range raw {
+		switch index {
+		case 0:
+			lines = append(lines, zeroTheme.green.Bold(true).Render(line))
+		case 1:
+			lines = append(lines, zeroTheme.ink.Render(line))
+		default:
+			lines = append(lines, zeroTheme.muted.Render(line))
+		}
+		if index == 0 {
+			lines = append(lines, "")
+		}
+	}
+	return styledBlock(width, lines, zeroTheme.green)
 }
 
 func renderErrorRow(row transcriptRow, width int) string {

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -280,6 +280,10 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			if message := payloadString(payload, "message"); message != "" {
 				rows = append(rows, transcriptRow{kind: rowError, text: message})
 			}
+		case sessions.EventCompaction:
+			if summary := payloadString(payload, "summary"); summary != "" {
+				rows = append(rows, transcriptRow{kind: rowSystem, text: summary})
+			}
 		case sessions.EventSessionFork:
 			parentID := payloadString(payload, "parentSessionId")
 			if parentID != "" {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,6 +13,30 @@ import (
 )
 
 var responseStyles = []string{"balanced", "concise", "explanatory", "review"}
+
+const tuiCompactionPreserveLast = 8
+const tuiCompactionMaxPromptChars = 8000
+
+type SessionCompactor interface {
+	CompactSession(context.Context, CompactRequest) (CompactResult, error)
+}
+
+type CompactRequest struct {
+	SessionID             string
+	ModelName             string
+	ContextWindow         int
+	SessionEventCount     int
+	EstimatedTokens       int
+	VisibleTranscriptRows int
+	CompactRequests       int
+}
+
+type CompactResult struct {
+	Compacted    bool
+	BeforeTokens int
+	AfterTokens  int
+	Summary      string
+}
 
 func (m model) handleEffortCommand(args string) (model, string) {
 	args = strings.TrimSpace(strings.ToLower(args))
@@ -163,6 +188,25 @@ func (m model) handleCompactCommand(args string) (model, string) {
 		return m, "Compact\nusage: /compact [status]"
 	}
 	m.compactRequests++
+	m.lastCompactError = ""
+	if m.sessionCompactor != nil {
+		result, err := m.sessionCompactor.CompactSession(m.ctx, m.compactRequest())
+		if err != nil {
+			m.lastCompactResult = nil
+			m.lastCompactError = err.Error()
+			return m, m.compactText(true)
+		}
+		m.lastCompactResult = &result
+	} else if m.hasSessionBackedCompactor() {
+		next, result, err := m.compactActiveSession()
+		if err != nil {
+			m.lastCompactResult = nil
+			m.lastCompactError = err.Error()
+			return m, m.compactText(true)
+		}
+		m = next
+		m.lastCompactResult = &result
+	}
 	return m, m.compactText(true)
 }
 
@@ -254,33 +298,237 @@ func (m model) compactText(requested bool) string {
 	status := commandStatusInfo
 	if requested {
 		status = commandStatusWarning
+		if m.lastCompactResult != nil {
+			status = commandStatusOK
+		}
+		if m.lastCompactError != "" {
+			status = commandStatusBlocked
+		}
 	}
-	return renderCommandOutput(commandOutput{
-		Title:  "Compact",
-		Status: status,
-		Sections: []commandSection{
-			{
-				Title: "State",
-				Lines: []string{
-					"summary: " + m.compactionStatus(),
-					"requested: " + boolText(m.compactRequests > 0),
-					fmt.Sprintf("visible transcript rows: %d", len(m.transcript)),
-				},
-			},
-			{
-				Title: "Backend",
-				Lines: []string{"state: pending integration"},
+	request := m.compactRequest()
+	sections := []commandSection{
+		{
+			Title: "State",
+			Lines: []string{
+				"summary: " + m.compactionStatus(),
+				"requested: " + boolText(m.compactRequests > 0),
+				"model: " + displayValue(request.ModelName, "none"),
+				"context window: " + compactContextWindowText(request.ContextWindow),
+				fmt.Sprintf("estimated transcript: %d tokens", request.EstimatedTokens),
+				fmt.Sprintf("visible transcript rows: %d", request.VisibleTranscriptRows),
+				m.compactabilityText(request),
 			},
 		},
-		Hints: []string{"compaction request is tracked for this TUI session"},
+	}
+	if m.lastCompactResult != nil {
+		sections = append(sections, commandSection{
+			Title: "Result",
+			Lines: compactResultLines(*m.lastCompactResult),
+		})
+	} else if m.lastCompactError != "" {
+		sections = append(sections, commandSection{
+			Title: "Result",
+			Lines: []string{
+				"compacted: no",
+				"error: " + m.lastCompactError,
+			},
+		})
+	} else if requested && m.sessionCompactor == nil {
+		sections = append(sections, commandSection{
+			Title: "Result",
+			Lines: []string{
+				"compacted: no",
+				"reason: manual compactor unavailable",
+			},
+		})
+	}
+	return renderCommandOutput(commandOutput{
+		Title:    "Compact",
+		Status:   status,
+		Sections: sections,
+		Hints:    []string{"manual compaction affects this TUI session when a compactor is available"},
 	})
 }
 
 func (m model) compactionStatus() string {
+	if m.lastCompactResult != nil {
+		if m.lastCompactResult.Compacted {
+			return "compacted manually"
+		}
+		return "manual compactor completed without changes"
+	}
+	if m.lastCompactError != "" {
+		return "manual compaction failed"
+	}
 	if m.compactRequests > 0 {
-		return "requested, not yet compacted"
+		return "requested, awaiting manual compactor"
 	}
 	return "not compacted"
+}
+
+func (m model) compactRequest() CompactRequest {
+	return CompactRequest{
+		SessionID:             strings.TrimSpace(m.activeSession.SessionID),
+		ModelName:             strings.TrimSpace(m.modelName),
+		ContextWindow:         modelContextWindow(m.modelName),
+		SessionEventCount:     len(m.sessionEvents),
+		EstimatedTokens:       estimateTranscriptTokens(m.transcript),
+		VisibleTranscriptRows: len(m.transcript),
+		CompactRequests:       m.compactRequests,
+	}
+}
+
+func (m model) compactabilityText(request CompactRequest) string {
+	if m.sessionCompactor == nil && !m.hasSessionBackedCompactor() {
+		return "compactable: no (manual compactor unavailable)"
+	}
+	if m.sessionCompactor == nil && request.SessionEventCount <= tuiCompactionPreserveLast {
+		return "compactable: no (not enough session history yet)"
+	}
+	if request.ContextWindow <= 0 {
+		return "compactable: no (unknown model context window)"
+	}
+	if request.EstimatedTokens <= 0 {
+		return "compactable: no (empty transcript)"
+	}
+	return "compactable: yes"
+}
+
+func (m model) hasSessionBackedCompactor() bool {
+	return m.sessionStore != nil && strings.TrimSpace(m.activeSession.SessionID) != ""
+}
+
+func (m model) compactActiveSession() (model, CompactResult, error) {
+	if m.sessionStore == nil || strings.TrimSpace(m.activeSession.SessionID) == "" {
+		return m, CompactResult{}, fmt.Errorf("no active session to compact")
+	}
+	beforeEvents := append([]sessions.Event{}, m.sessionEvents...)
+	beforeTokens := estimateTranscriptTokens(m.transcript)
+	plan, err := m.sessionStore.PlanCompaction(m.activeSession.SessionID, sessions.CompactionOptions{
+		PreserveLast:   tuiCompactionPreserveLast,
+		MaxPromptChars: tuiCompactionMaxPromptChars,
+	})
+	if err != nil {
+		return m, CompactResult{}, err
+	}
+	if plan.CompactableCount == 0 {
+		return m, CompactResult{
+			Compacted:    false,
+			BeforeTokens: beforeTokens,
+			AfterTokens:  beforeTokens,
+			Summary:      "not enough session history to compact yet",
+		}, nil
+	}
+
+	summary, err := m.summarizeCompactionPlan(plan)
+	if err != nil {
+		return m, CompactResult{}, err
+	}
+	if _, err := m.sessionStore.RecordCompaction(m.activeSession.SessionID, sessions.RecordCompactionInput{
+		Plan:    plan,
+		Summary: summary,
+	}); err != nil {
+		return m, CompactResult{}, err
+	}
+	if meta, err := m.sessionStore.Get(m.activeSession.SessionID); err == nil && meta != nil {
+		m.activeSession = *meta
+	}
+	events, err := m.sessionStore.ReadRehydratedEvents(m.activeSession.SessionID)
+	if err != nil {
+		m.sessionEvents = nil
+		return m, CompactResult{}, fmt.Errorf("reload compacted session: %w", err)
+	}
+	m.sessionEvents = append([]sessions.Event{}, events...)
+	rows := initialTranscript()
+	for _, row := range transcriptRowsFromSessionEvents(events) {
+		rows = appendTranscriptRow(rows, row)
+	}
+	m.transcript = rows
+	m.resetFlushFrontier("· compacted ·")
+
+	return m, CompactResult{
+		Compacted:    len(events) < len(beforeEvents)+1,
+		BeforeTokens: beforeTokens,
+		AfterTokens:  estimateTranscriptTokens(m.transcript),
+		Summary:      summary,
+	}, nil
+}
+
+func (m model) summarizeCompactionPlan(plan sessions.CompactionPlan) (string, error) {
+	if m.provider == nil {
+		return deterministicCompactionSummary(plan), nil
+	}
+	stream, err := m.provider.StreamCompletion(m.ctx, zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "Summarize compacted Zero session events for future coding context. Preserve user goals, decisions, files, tool outcomes, blockers, and exact next steps. Omit secrets and do not invent details."},
+			{Role: zeroruntime.MessageRoleUser, Content: plan.SummaryPrompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("summarize compacted session: %w", err)
+	}
+	collected := zeroruntime.CollectStream(m.ctx, stream)
+	if collected.Error != "" {
+		return "", fmt.Errorf("summarize compacted session: %s", collected.Error)
+	}
+	summary := strings.TrimSpace(collected.Text)
+	if summary == "" {
+		return "", fmt.Errorf("summarize compacted session: empty summary")
+	}
+	return summary, nil
+}
+
+func deterministicCompactionSummary(plan sessions.CompactionPlan) string {
+	lines := []string{
+		fmt.Sprintf("Compacted earlier session context: %d event(s) summarized, %d recent event(s) preserved.", plan.CompactableCount, plan.PreservedCount),
+	}
+	if len(plan.CompactableEvents) > 0 {
+		first := plan.CompactableEvents[0]
+		last := plan.CompactableEvents[len(plan.CompactableEvents)-1]
+		lines = append(lines, fmt.Sprintf("Compacted range: #%d %s through #%d %s.", first.Sequence, first.Type, last.Sequence, last.Type))
+	}
+	if len(plan.PreservedEvents) > 0 {
+		first := plan.PreservedEvents[0]
+		last := plan.PreservedEvents[len(plan.PreservedEvents)-1]
+		lines = append(lines, fmt.Sprintf("Preserved recent range: #%d %s through #%d %s.", first.Sequence, first.Type, last.Sequence, last.Type))
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func compactContextWindowText(window int) string {
+	if window <= 0 {
+		return "unknown"
+	}
+	return formatContextWindow(window) + " tokens"
+}
+
+func estimateTranscriptTokens(rows []transcriptRow) int {
+	total := 0
+	for _, row := range rows {
+		text := row.text + "\n" + row.detail + "\n" + row.tool + "\n" + row.arg
+		text = strings.TrimSpace(text)
+		if text == "" {
+			continue
+		}
+		total += len(text)/4 + 4
+	}
+	return total
+}
+
+func compactResultLines(result CompactResult) []string {
+	lines := []string{
+		"compacted: " + boolText(result.Compacted),
+	}
+	if result.BeforeTokens > 0 {
+		lines = append(lines, fmt.Sprintf("before: %d tokens", result.BeforeTokens))
+	}
+	if result.AfterTokens > 0 {
+		lines = append(lines, fmt.Sprintf("after: %d tokens", result.AfterTokens))
+	}
+	if summary := strings.TrimSpace(result.Summary); summary != "" {
+		lines = append(lines, "summary: "+summary)
+	}
+	return lines
 }
 
 func (m model) recordUsageEvent(modelID string, event zeroruntime.Usage) (model, []transcriptRow) {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -20,12 +20,7 @@ const tuiCompactionPreserveLast = 8
 const tuiCompactionMaxPromptChars = 8000
 const compactStatusRowID = "compact/status"
 
-var compactFrames = []string{"[=   ]", "[==  ]", "[=== ]", "[====]"}
-var compactQuotes = []string{
-	"compress the noise, keep the intent",
-	"small context, sharp memory",
-	"fold the scrollback, keep the thread",
-}
+var compactFrames = []string{"⠂", "⠒", "⠲", "⠴"}
 
 type SessionCompactor interface {
 	CompactSession(context.Context, CompactRequest) (CompactResult, error)
@@ -393,17 +388,11 @@ func (m model) compactText(requested bool) string {
 }
 
 func (m model) compactRunningText() string {
-	request := m.compactRequest()
-	lines := []string{
-		"Compacting context",
+	return strings.Join([]string{
+		"Compressing session",
+		"Keep typing - messages will queue and send after compression finishes.",
 		m.compactAnimationLine(),
-		compactModelAdaptationLine(request),
-		"next prompt will use the compressed session",
-	}
-	if quote := compactQuote(m.compactRequests); quote != "" {
-		lines = append(lines, quote)
-	}
-	return strings.Join(lines, "\n")
+	}, "\n")
 }
 
 func compactCompleteText(result CompactResult) string {
@@ -606,22 +595,7 @@ func compactResultLines(result CompactResult) []string {
 
 func (m model) compactAnimationLine() string {
 	frame := compactFrames[m.compactFrame%len(compactFrames)]
-	return frame + " compacting context for Gitlawb"
-}
-
-func compactQuote(requests int) string {
-	if requests <= 0 {
-		requests = 1
-	}
-	return compactQuotes[(requests-1)%len(compactQuotes)]
-}
-
-func compactModelAdaptationLine(request CompactRequest) string {
-	model := displayValue(strings.TrimSpace(request.ModelName), "active model")
-	if strings.TrimSpace(request.ModelName) == "" {
-		return "active model · preserving recent turns"
-	}
-	return fmt.Sprintf("%s · %s estimated tokens · preserving recent turns", model, formatContextWindow(request.EstimatedTokens))
+	return frame + " Compressing history..."
 }
 
 func (m model) setCompactStatusRow(text string) model {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -330,12 +330,16 @@ func (m model) resolveRewindTarget(arg string) (int, error) {
 }
 
 func (m model) compactText(requested bool) string {
+	if m.compactInFlight {
+		return m.compactRunningText()
+	}
+	if requested && m.lastCompactResult != nil {
+		return compactCompleteText(*m.lastCompactResult)
+	}
 	status := commandStatusInfo
 	if requested {
 		status = commandStatusWarning
-		if m.compactInFlight {
-			status = commandStatusWarning
-		} else if m.lastCompactResult != nil {
+		if m.lastCompactResult != nil {
 			status = commandStatusOK
 		}
 		if m.lastCompactError != "" {
@@ -358,16 +362,7 @@ func (m model) compactText(requested bool) string {
 			},
 		},
 	}
-	if m.compactInFlight {
-		sections = append(sections, commandSection{
-			Title: "Progress",
-			Lines: []string{
-				m.compactAnimationLine(),
-				"quote: " + compactQuote(m.compactRequests),
-				"model adaptive: " + compactModelAdaptationLine(request),
-			},
-		})
-	} else if m.lastCompactResult != nil {
+	if m.lastCompactResult != nil {
 		sections = append(sections, commandSection{
 			Title: "Result",
 			Lines: compactResultLines(*m.lastCompactResult),
@@ -395,6 +390,34 @@ func (m model) compactText(requested bool) string {
 		Sections: sections,
 		Hints:    []string{"manual compaction affects this TUI session when a compactor is available"},
 	})
+}
+
+func (m model) compactRunningText() string {
+	request := m.compactRequest()
+	lines := []string{
+		"Compacting context",
+		m.compactAnimationLine(),
+		compactModelAdaptationLine(request),
+		"next prompt will use the compressed session",
+	}
+	if quote := compactQuote(m.compactRequests); quote != "" {
+		lines = append(lines, quote)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func compactCompleteText(result CompactResult) string {
+	lines := []string{
+		"Compact complete",
+		"summary ready · previous context compressed",
+	}
+	if result.BeforeTokens > 0 && result.AfterTokens > 0 {
+		lines = append(lines, fmt.Sprintf("%d → %d estimated tokens", result.BeforeTokens, result.AfterTokens))
+	}
+	if summary := strings.TrimSpace(result.Summary); summary != "" {
+		lines = append(lines, summary)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m model) compactionStatus() string {
@@ -567,7 +590,6 @@ func estimateTranscriptTokens(rows []transcriptRow) int {
 
 func compactResultLines(result CompactResult) []string {
 	lines := []string{
-		"phase: compact complete",
 		"compacted: " + boolText(result.Compacted),
 	}
 	if result.BeforeTokens > 0 {
@@ -584,7 +606,7 @@ func compactResultLines(result CompactResult) []string {
 
 func (m model) compactAnimationLine() string {
 	frame := compactFrames[m.compactFrame%len(compactFrames)]
-	return frame + " compacting context for Gitlawb..."
+	return frame + " compacting context for Gitlawb"
 }
 
 func compactQuote(requests int) string {
@@ -595,11 +617,11 @@ func compactQuote(requests int) string {
 }
 
 func compactModelAdaptationLine(request CompactRequest) string {
-	window := compactContextWindowText(request.ContextWindow)
+	model := displayValue(strings.TrimSpace(request.ModelName), "active model")
 	if strings.TrimSpace(request.ModelName) == "" {
-		return "using the active model context window"
+		return "active model · preserving recent turns"
 	}
-	return fmt.Sprintf("%s uses %s; preserving the latest %d session events", request.ModelName, window, tuiCompactionPreserveLast)
+	return fmt.Sprintf("%s · %s estimated tokens · preserving recent turns", model, formatContextWindow(request.EstimatedTokens))
 }
 
 func (m model) setCompactStatusRow(text string) model {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/usage"
@@ -16,6 +18,14 @@ var responseStyles = []string{"balanced", "concise", "explanatory", "review"}
 
 const tuiCompactionPreserveLast = 8
 const tuiCompactionMaxPromptChars = 8000
+const compactStatusRowID = "compact/status"
+
+var compactFrames = []string{"[=   ]", "[==  ]", "[=== ]", "[====]"}
+var compactQuotes = []string{
+	"compress the noise, keep the intent",
+	"small context, sharp memory",
+	"fold the scrollback, keep the thread",
+}
 
 type SessionCompactor interface {
 	CompactSession(context.Context, CompactRequest) (CompactResult, error)
@@ -36,6 +46,15 @@ type CompactResult struct {
 	BeforeTokens int
 	AfterTokens  int
 	Summary      string
+}
+
+type compactResultMsg struct {
+	result             CompactResult
+	err                error
+	activeSession      sessions.Metadata
+	sessionEvents      []sessions.Event
+	transcript         []transcriptRow
+	hasSessionSnapshot bool
 }
 
 func (m model) handleEffortCommand(args string) (model, string) {
@@ -179,35 +198,51 @@ func responseStyleAllowed(value string) bool {
 	return false
 }
 
-func (m model) handleCompactCommand(args string) (model, string) {
+func (m model) handleCompactCommand(args string) (model, string, tea.Cmd) {
 	args = strings.TrimSpace(strings.ToLower(args))
 	if args == "status" {
-		return m, m.compactText(false)
+		return m, m.compactText(false), nil
 	}
 	if args != "" {
-		return m, "Compact\nusage: /compact [status]"
+		return m, "Compact\nusage: /compact [status]", nil
+	}
+	if m.compactInFlight {
+		return m, m.compactText(true), nil
 	}
 	m.compactRequests++
 	m.lastCompactError = ""
+	m.lastCompactResult = nil
+	if m.sessionCompactor == nil && !m.hasSessionBackedCompactor() {
+		return m, m.compactText(true), nil
+	}
+	m.compactInFlight = true
+	m.compactFrame = 0
+	return m, m.compactText(true), tea.Batch(m.runCompact(), m.spinner.Tick)
+}
+
+func (m model) runCompact() tea.Cmd {
+	request := m.compactRequest()
 	if m.sessionCompactor != nil {
-		result, err := m.sessionCompactor.CompactSession(m.ctx, m.compactRequest())
-		if err != nil {
-			m.lastCompactResult = nil
-			m.lastCompactError = err.Error()
-			return m, m.compactText(true)
+		compactor := m.sessionCompactor
+		ctx := m.ctx
+		return func() tea.Msg {
+			result, err := compactor.CompactSession(ctx, request)
+			return compactResultMsg{result: result, err: err}
 		}
-		m.lastCompactResult = &result
-	} else if m.hasSessionBackedCompactor() {
+	}
+	return func() tea.Msg {
 		next, result, err := m.compactActiveSession()
 		if err != nil {
-			m.lastCompactResult = nil
-			m.lastCompactError = err.Error()
-			return m, m.compactText(true)
+			return compactResultMsg{err: err}
 		}
-		m = next
-		m.lastCompactResult = &result
+		return compactResultMsg{
+			result:             result,
+			activeSession:      next.activeSession,
+			sessionEvents:      append([]sessions.Event{}, next.sessionEvents...),
+			transcript:         append([]transcriptRow{}, next.transcript...),
+			hasSessionSnapshot: true,
+		}
 	}
-	return m, m.compactText(true)
 }
 
 // handleRewindCommand restores workspace files to a checkpoint and truncates the
@@ -298,7 +333,9 @@ func (m model) compactText(requested bool) string {
 	status := commandStatusInfo
 	if requested {
 		status = commandStatusWarning
-		if m.lastCompactResult != nil {
+		if m.compactInFlight {
+			status = commandStatusWarning
+		} else if m.lastCompactResult != nil {
 			status = commandStatusOK
 		}
 		if m.lastCompactError != "" {
@@ -314,13 +351,23 @@ func (m model) compactText(requested bool) string {
 				"requested: " + boolText(m.compactRequests > 0),
 				"model: " + displayValue(request.ModelName, "none"),
 				"context window: " + compactContextWindowText(request.ContextWindow),
+				"auto compaction: model adaptive at ~80% of context window",
 				fmt.Sprintf("estimated transcript: %d tokens", request.EstimatedTokens),
 				fmt.Sprintf("visible transcript rows: %d", request.VisibleTranscriptRows),
 				m.compactabilityText(request),
 			},
 		},
 	}
-	if m.lastCompactResult != nil {
+	if m.compactInFlight {
+		sections = append(sections, commandSection{
+			Title: "Progress",
+			Lines: []string{
+				m.compactAnimationLine(),
+				"quote: " + compactQuote(m.compactRequests),
+				"model adaptive: " + compactModelAdaptationLine(request),
+			},
+		})
+	} else if m.lastCompactResult != nil {
 		sections = append(sections, commandSection{
 			Title: "Result",
 			Lines: compactResultLines(*m.lastCompactResult),
@@ -351,6 +398,9 @@ func (m model) compactText(requested bool) string {
 }
 
 func (m model) compactionStatus() string {
+	if m.compactInFlight {
+		return "compacting context"
+	}
 	if m.lastCompactResult != nil {
 		if m.lastCompactResult.Compacted {
 			return "compacted manually"
@@ -517,6 +567,7 @@ func estimateTranscriptTokens(rows []transcriptRow) int {
 
 func compactResultLines(result CompactResult) []string {
 	lines := []string{
+		"phase: compact complete",
 		"compacted: " + boolText(result.Compacted),
 	}
 	if result.BeforeTokens > 0 {
@@ -529,6 +580,38 @@ func compactResultLines(result CompactResult) []string {
 		lines = append(lines, "summary: "+summary)
 	}
 	return lines
+}
+
+func (m model) compactAnimationLine() string {
+	frame := compactFrames[m.compactFrame%len(compactFrames)]
+	return frame + " compacting context for Gitlawb..."
+}
+
+func compactQuote(requests int) string {
+	if requests <= 0 {
+		requests = 1
+	}
+	return compactQuotes[(requests-1)%len(compactQuotes)]
+}
+
+func compactModelAdaptationLine(request CompactRequest) string {
+	window := compactContextWindowText(request.ContextWindow)
+	if strings.TrimSpace(request.ModelName) == "" {
+		return "using the active model context window"
+	}
+	return fmt.Sprintf("%s uses %s; preserving the latest %d session events", request.ModelName, window, tuiCompactionPreserveLast)
+}
+
+func (m model) setCompactStatusRow(text string) model {
+	row := transcriptRow{kind: rowSystem, id: compactStatusRowID, text: text}
+	for i := len(m.transcript) - 1; i >= 0; i-- {
+		if m.transcript[i].id == compactStatusRowID {
+			m.transcript[i] = row
+			return m
+		}
+	}
+	m.transcript = appendTranscriptRow(m.transcript, row)
+	return m
 }
 
 func (m model) recordUsageEvent(modelID string, event zeroruntime.Usage) (model, []transcriptRow) {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -397,14 +397,12 @@ func (m model) compactRunningText() string {
 
 func compactCompleteText(result CompactResult) string {
 	lines := []string{
-		"Compact complete",
-		"summary ready · previous context compressed",
+		"Compression complete",
+		"Session summary saved.",
+		"Ready for the next prompt.",
 	}
-	if result.BeforeTokens > 0 && result.AfterTokens > 0 {
-		lines = append(lines, fmt.Sprintf("%d → %d estimated tokens", result.BeforeTokens, result.AfterTokens))
-	}
-	if summary := strings.TrimSpace(result.Summary); summary != "" {
-		lines = append(lines, summary)
+	if result.Compacted && result.BeforeTokens > 0 && result.AfterTokens > 0 && result.AfterTokens < result.BeforeTokens {
+		lines = append(lines, fmt.Sprintf("Estimated context reduced by %s tokens.", formatContextWindow(result.BeforeTokens-result.AfterTokens)))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -390,7 +390,7 @@ func (m model) compactText(requested bool) string {
 func (m model) compactRunningText() string {
 	return strings.Join([]string{
 		"Compressing session",
-		"Keep typing - messages will queue and send after compression finishes.",
+		"Keep editing your draft; press Enter after compression finishes to send.",
 		m.compactAnimationLine(),
 	}, "\n")
 }

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -157,12 +157,18 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 		t.Fatal("expected compaction to be marked in flight")
 	}
 	for _, want := range []string{
-		"status: warning",
 		"compacting context for Gitlawb",
-		"model adaptive",
+		"gpt-4.1",
+		"preserving recent turns",
+		"next prompt will use the compressed session",
 	} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected compact start transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	for _, unwanted := range []string{"context window:", "compactable:", "hint:", "State"} {
+		if transcriptContains(next.transcript, unwanted) {
+			t.Fatalf("compact running transcript should not contain diagnostic %q, got %#v", unwanted, next.transcript)
 		}
 	}
 	msg := execCmd(cmd)
@@ -191,15 +197,17 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 		t.Fatalf("expected one compact request, got %d", next.compactRequests)
 	}
 	for _, want := range []string{
-		"Compact",
-		"status: ok",
-		"compact complete",
-		"compacted: yes",
-		"after: 42 tokens",
+		"Compact complete",
+		"summary ready",
 		"summarized earlier turns",
 	} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected compact transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	for _, unwanted := range []string{"context window:", "compactable:", "hint:"} {
+		if transcriptContains(next.transcript, unwanted) {
+			t.Fatalf("compact completion transcript should not contain diagnostic %q, got %#v", unwanted, next.transcript)
 		}
 	}
 	if got := next.compactionStatus(); !strings.Contains(got, "compacted manually") {
@@ -235,6 +243,9 @@ func TestCompactSpinnerTickRefreshesProgressFrame(t *testing.T) {
 	}
 	if !strings.Contains(after, "compacting context for Gitlawb") {
 		t.Fatalf("expected animated compact copy, got %q", after)
+	}
+	if strings.Contains(after, "context window:") || strings.Contains(after, "compactable:") {
+		t.Fatalf("animated compact copy should stay concise, got %q", after)
 	}
 }
 

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -89,7 +90,220 @@ func TestStyleCommandListsAndSetsSessionPreference(t *testing.T) {
 	}
 }
 
-func TestCompactCommandRecordsShellRequest(t *testing.T) {
+func TestCompactStatusShowsManualFlowState(t *testing.T) {
+	called := false
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		SessionCompactor: compactSessionFunc(func(context.Context, CompactRequest) (CompactResult, error) {
+			called = true
+			return CompactResult{}, nil
+		}),
+	})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: strings.Repeat("abcd ", 80)})
+	m.input.SetValue("/compact status")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /compact status to be handled without starting an agent run")
+	}
+	if called {
+		t.Fatal("status should not invoke the manual compactor")
+	}
+	if next.compactRequests != 0 {
+		t.Fatalf("status should not add compact requests, got %d", next.compactRequests)
+	}
+	for _, want := range []string{
+		"Compact",
+		"status: info",
+		"model: gpt-4.1",
+		"context window: 1M tokens",
+		"estimated transcript:",
+		"compactable: yes",
+	} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected compact status transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+}
+
+func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
+	var request CompactRequest
+	calls := 0
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		SessionCompactor: compactSessionFunc(func(_ context.Context, req CompactRequest) (CompactResult, error) {
+			calls++
+			request = req
+			return CompactResult{
+				Compacted:    true,
+				BeforeTokens: req.EstimatedTokens,
+				AfterTokens:  42,
+				Summary:      "summarized earlier turns",
+			}, nil
+		}),
+	})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: strings.Repeat("context ", 90)})
+	m.input.SetValue("/compact")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /compact to be handled without starting an agent run")
+	}
+	if calls != 1 {
+		t.Fatalf("expected one manual compaction call, got %d", calls)
+	}
+	if request.ModelName != "gpt-4.1" {
+		t.Fatalf("expected request model gpt-4.1, got %q", request.ModelName)
+	}
+	if request.ContextWindow != modelContextWindow("gpt-4.1") {
+		t.Fatalf("expected request context window %d, got %d", modelContextWindow("gpt-4.1"), request.ContextWindow)
+	}
+	if request.EstimatedTokens <= 0 || request.VisibleTranscriptRows != len(m.transcript) {
+		t.Fatalf("expected request estimate and transcript count, got %#v", request)
+	}
+	if next.compactRequests != 1 {
+		t.Fatalf("expected one compact request, got %d", next.compactRequests)
+	}
+	for _, want := range []string{
+		"Compact",
+		"status: ok",
+		"compacted: yes",
+		"after: 42 tokens",
+		"summarized earlier turns",
+	} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected compact transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	if got := next.compactionStatus(); !strings.Contains(got, "compacted manually") {
+		t.Fatalf("expected compacted status after manual compaction, got %q", got)
+	}
+}
+
+func TestCompactCommandRecordsSessionCompactionAndShrinksReplayContext(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	m := newModel(context.Background(), Options{
+		ModelName:    "gpt-4.1",
+		SessionStore: store,
+	})
+	var err error
+	m, err = m.ensureActiveSession("compact this session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{
+		"alpha old user intent",
+		"beta old assistant answer",
+		"gamma old tool result",
+		"delta old follow-up",
+		"epsilon recent",
+		"zeta recent",
+		"eta recent",
+		"theta recent",
+		"iota recent",
+		"kappa recent",
+		"lambda recent",
+		"mu recent",
+	} {
+		m, err = m.appendSessionEvent(sessions.EventMessage, map[string]any{
+			"role":    "user",
+			"content": content,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: content})
+	}
+	eventsBefore := len(m.sessionEvents)
+	m.input.SetValue("/compact")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /compact to be handled without starting an agent run")
+	}
+	if next.lastCompactResult == nil || !next.lastCompactResult.Compacted {
+		t.Fatalf("expected session-backed compaction result, got %#v", next.lastCompactResult)
+	}
+	if len(next.sessionEvents) >= eventsBefore {
+		t.Fatalf("expected in-memory context to shrink after compaction, before=%d after=%d", eventsBefore, len(next.sessionEvents))
+	}
+	if !transcriptContains(next.transcript, "Compacted earlier session context") {
+		t.Fatalf("expected transcript to render compaction summary, got %#v", next.transcript)
+	}
+	prompt := next.sessionPrompt("next task")
+	for _, dropped := range []string{"alpha old user intent", "beta old assistant answer", "gamma old tool result", "delta old follow-up"} {
+		if strings.Contains(prompt, dropped) {
+			t.Fatalf("compacted-away event %q reached the next prompt:\n%s", dropped, prompt)
+		}
+	}
+	if !strings.Contains(prompt, "Compacted earlier session context") || !strings.Contains(prompt, "mu recent") {
+		t.Fatalf("prompt missing compacted summary or preserved recent event:\n%s", prompt)
+	}
+}
+
+func TestCompactCommandUsesProviderSummaryWhenAvailable(t *testing.T) {
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "Provider summary keeps the actual old decisions."},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		SessionStore: store,
+	})
+	var err error
+	m, err = m.ensureActiveSession("compact with provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{
+		"old decision A",
+		"old decision B",
+		"old file note",
+		"old blocker",
+		"recent one",
+		"recent two",
+		"recent three",
+		"recent four",
+		"recent five",
+		"recent six",
+		"recent seven",
+		"recent eight",
+	} {
+		m, err = m.appendSessionEvent(sessions.EventMessage, map[string]any{"role": "user", "content": content})
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: content})
+	}
+	m.input.SetValue("/compact")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one provider summarization request, got %d", len(provider.requests))
+	}
+	if next.lastCompactResult == nil || next.lastCompactResult.Summary != "Provider summary keeps the actual old decisions." {
+		t.Fatalf("expected provider summary result, got %#v", next.lastCompactResult)
+	}
+	prompt := next.sessionPrompt("continue")
+	if !strings.Contains(prompt, "Provider summary keeps the actual old decisions.") {
+		t.Fatalf("next prompt missing provider summary:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "old decision A") {
+		t.Fatalf("next prompt should not include raw compacted event:\n%s", prompt)
+	}
+}
+
+func TestCompactCommandRecordsRequestWhenNoCompactorIsAvailable(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.input.SetValue("/compact")
 
@@ -102,12 +316,12 @@ func TestCompactCommandRecordsShellRequest(t *testing.T) {
 	if next.compactRequests != 1 {
 		t.Fatalf("expected one compact request, got %d", next.compactRequests)
 	}
-	for _, want := range []string{"Compact", "requested, not yet compacted", "state: pending integration"} {
+	for _, want := range []string{"Compact", "requested, awaiting manual compactor", "compactable: no", "manual compactor unavailable"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected compact transcript to contain %q, got %#v", want, next.transcript)
 		}
 	}
-	if transcriptContains(next.transcript, "future compaction backend") || transcriptContains(next.transcript, "not wired") {
+	if transcriptContains(next.transcript, "pending integration") || transcriptContains(next.transcript, "future compaction backend") || transcriptContains(next.transcript, "not wired") {
 		t.Fatalf("compact transcript should avoid shell-only placeholder text, got %#v", next.transcript)
 	}
 
@@ -124,6 +338,12 @@ func TestCompactCommandRecordsShellRequest(t *testing.T) {
 	if got := next.transcript[len(next.transcript)-1].text; !strings.Contains(got, "status: info") {
 		t.Fatalf("expected /compact status to render info status, got %q", got)
 	}
+}
+
+type compactSessionFunc func(context.Context, CompactRequest) (CompactResult, error)
+
+func (f compactSessionFunc) CompactSession(ctx context.Context, request CompactRequest) (CompactResult, error) {
+	return f(ctx, request)
 }
 
 func TestUsageEventsUpdateFooterAndContext(t *testing.T) {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -157,10 +157,9 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 		t.Fatal("expected compaction to be marked in flight")
 	}
 	for _, want := range []string{
-		"compacting context for Gitlawb",
-		"gpt-4.1",
-		"preserving recent turns",
-		"next prompt will use the compressed session",
+		"Compressing session",
+		"Keep typing - messages will queue and send after compression finishes.",
+		"Compressing history",
 	} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected compact start transcript to contain %q, got %#v", want, next.transcript)
@@ -241,11 +240,45 @@ func TestCompactSpinnerTickRefreshesProgressFrame(t *testing.T) {
 	if before == after {
 		t.Fatalf("expected spinner tick to refresh compact status, still %q", after)
 	}
-	if !strings.Contains(after, "compacting context for Gitlawb") {
+	if !strings.Contains(after, "Compressing history") {
 		t.Fatalf("expected animated compact copy, got %q", after)
 	}
 	if strings.Contains(after, "context window:") || strings.Contains(after, "compactable:") {
 		t.Fatalf("animated compact copy should stay concise, got %q", after)
+	}
+}
+
+func TestCompactRunningRowRendersAsAmberCompressionCard(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		SessionCompactor: compactSessionFunc(func(context.Context, CompactRequest) (CompactResult, error) {
+			return CompactResult{Compacted: true, Summary: "done"}, nil
+		}),
+	})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: strings.Repeat("context ", 90)})
+	m.input.SetValue("/compact")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	rendered := plainRender(t, next.renderRow(transcriptRow{
+		kind: rowSystem,
+		id:   compactStatusRowID,
+		text: compactStatusText(next.transcript),
+	}, 92, buildRowContext(next.transcript)))
+
+	for _, want := range []string{
+		"╭",
+		"╰",
+		"Compressing session",
+		"Keep typing - messages will queue and send after compression finishes.",
+		"Compressing history",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected compact card render to contain %q, got:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "context window:") || strings.Contains(rendered, "compactable:") {
+		t.Fatalf("compact card should not include diagnostic status text:\n%s", rendered)
 	}
 }
 

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -196,15 +196,15 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 		t.Fatalf("expected one compact request, got %d", next.compactRequests)
 	}
 	for _, want := range []string{
-		"Compact complete",
-		"summary ready",
-		"summarized earlier turns",
+		"Compression complete",
+		"Session summary saved",
+		"Ready for the next prompt",
 	} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected compact transcript to contain %q, got %#v", want, next.transcript)
 		}
 	}
-	for _, unwanted := range []string{"context window:", "compactable:", "hint:"} {
+	for _, unwanted := range []string{"context window:", "compactable:", "hint:", "summarized earlier turns"} {
 		if transcriptContains(next.transcript, unwanted) {
 			t.Fatalf("compact completion transcript should not contain diagnostic %q, got %#v", unwanted, next.transcript)
 		}
@@ -279,6 +279,37 @@ func TestCompactRunningRowRendersAsAmberCompressionCard(t *testing.T) {
 	}
 	if strings.Contains(rendered, "context window:") || strings.Contains(rendered, "compactable:") {
 		t.Fatalf("compact card should not include diagnostic status text:\n%s", rendered)
+	}
+}
+
+func TestCompactCompleteRowRendersAsSuccessCard(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	rendered := plainRender(t, m.renderRow(transcriptRow{
+		kind: rowSystem,
+		id:   compactStatusRowID,
+		text: compactCompleteText(CompactResult{
+			Compacted:    true,
+			BeforeTokens: 320,
+			AfterTokens:  120,
+			Summary:      "raw model summary should stay hidden",
+		}),
+	}, 92, rowContext{}))
+
+	for _, want := range []string{
+		"╭",
+		"╰",
+		"Compression complete",
+		"Session summary saved",
+		"Ready for the next prompt",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected compact complete card to contain %q, got:\n%s", want, rendered)
+		}
+	}
+	for _, unwanted := range []string{"raw model summary", "context window:", "compactable:"} {
+		if strings.Contains(rendered, unwanted) {
+			t.Fatalf("compact complete card should not contain %q, got:\n%s", unwanted, rendered)
+		}
 	}
 }
 

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -150,8 +150,30 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
+	if cmd == nil {
+		t.Fatal("expected /compact to start an async compaction command")
+	}
+	if !next.compactInFlight {
+		t.Fatal("expected compaction to be marked in flight")
+	}
+	for _, want := range []string{
+		"status: warning",
+		"compacting context for Gitlawb",
+		"model adaptive",
+	} {
+		if !transcriptContains(next.transcript, want) {
+			t.Fatalf("expected compact start transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	msg := execCmd(cmd)
+	if msg == nil {
+		t.Fatal("expected async compact command to return a completion message")
+	}
+	updated, cmd = next.Update(msg)
+	next = updated.(model)
+
 	if cmd != nil {
-		t.Fatal("expected /compact to be handled without starting an agent run")
+		t.Fatal("expected compact completion to be handled without starting another command")
 	}
 	if calls != 1 {
 		t.Fatalf("expected one manual compaction call, got %d", calls)
@@ -171,6 +193,7 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 	for _, want := range []string{
 		"Compact",
 		"status: ok",
+		"compact complete",
 		"compacted: yes",
 		"after: 42 tokens",
 		"summarized earlier turns",
@@ -181,6 +204,37 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 	}
 	if got := next.compactionStatus(); !strings.Contains(got, "compacted manually") {
 		t.Fatalf("expected compacted status after manual compaction, got %q", got)
+	}
+}
+
+func TestCompactSpinnerTickRefreshesProgressFrame(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ModelName: "gpt-4.1",
+		SessionCompactor: compactSessionFunc(func(context.Context, CompactRequest) (CompactResult, error) {
+			return CompactResult{Compacted: true, Summary: "done"}, nil
+		}),
+	})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: strings.Repeat("context ", 90)})
+	m.input.SetValue("/compact")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd == nil || !next.compactInFlight {
+		t.Fatal("expected /compact to start an in-flight animated compaction")
+	}
+	before := compactStatusText(next.transcript)
+	updated, _ = next.Update(next.spinner.Tick())
+	next = updated.(model)
+	after := compactStatusText(next.transcript)
+	if before == "" || after == "" {
+		t.Fatalf("expected compact status row before=%q after=%q", before, after)
+	}
+	if before == after {
+		t.Fatalf("expected spinner tick to refresh compact status, still %q", after)
+	}
+	if !strings.Contains(after, "compacting context for Gitlawb") {
+		t.Fatalf("expected animated compact copy, got %q", after)
 	}
 }
 
@@ -224,8 +278,17 @@ func TestCompactCommandRecordsSessionCompactionAndShrinksReplayContext(t *testin
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
+	if cmd == nil {
+		t.Fatal("expected /compact to start an async session-backed compaction command")
+	}
+	msg := execCmd(cmd)
+	if msg == nil {
+		t.Fatal("expected async compact command to return a completion message")
+	}
+	updated, cmd = next.Update(msg)
+	next = updated.(model)
 	if cmd != nil {
-		t.Fatal("expected /compact to be handled without starting an agent run")
+		t.Fatal("expected compact completion to be handled without starting another command")
 	}
 	if next.lastCompactResult == nil || !next.lastCompactResult.Compacted {
 		t.Fatalf("expected session-backed compaction result, got %#v", next.lastCompactResult)
@@ -285,8 +348,20 @@ func TestCompactCommandUsesProviderSummaryWhenAvailable(t *testing.T) {
 	}
 	m.input.SetValue("/compact")
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected /compact to start an async provider-backed compaction command")
+	}
+	msg := execCmd(cmd)
+	if msg == nil {
+		t.Fatal("expected async compact command to return a completion message")
+	}
+	updated, cmd = next.Update(msg)
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected compact completion to be handled without starting another command")
+	}
 
 	if len(provider.requests) != 1 {
 		t.Fatalf("expected one provider summarization request, got %d", len(provider.requests))
@@ -344,6 +419,15 @@ type compactSessionFunc func(context.Context, CompactRequest) (CompactResult, er
 
 func (f compactSessionFunc) CompactSession(ctx context.Context, request CompactRequest) (CompactResult, error) {
 	return f(ctx, request)
+}
+
+func compactStatusText(rows []transcriptRow) string {
+	for i := len(rows) - 1; i >= 0; i-- {
+		if rows[i].id == compactStatusRowID {
+			return rows[i].text
+		}
+	}
+	return ""
 }
 
 func TestUsageEventsUpdateFooterAndContext(t *testing.T) {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -158,7 +158,7 @@ func TestCompactCommandCallsInjectedCompactorAndReportsResult(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Compressing session",
-		"Keep typing - messages will queue and send after compression finishes.",
+		"Keep editing your draft; press Enter after compression finishes to send.",
 		"Compressing history",
 	} {
 		if !transcriptContains(next.transcript, want) {
@@ -270,7 +270,7 @@ func TestCompactRunningRowRendersAsAmberCompressionCard(t *testing.T) {
 		"╭",
 		"╰",
 		"Compressing session",
-		"Keep typing - messages will queue and send after compression finishes.",
+		"Keep editing your draft; press Enter after compression finishes to send.",
 		"Compressing history",
 	} {
 		if !strings.Contains(rendered, want) {


### PR DESCRIPTION
## Summary
- Adds metadata-bearing agent compaction results and preserves active plan, loaded tools/skills, and project instructions across repeated compactions.
- Adds persisted session compaction events plus rehydrated replay so resume/fork prompts replace compacted-away history with a summary.
- Wires `/compact` in the TUI to perform real session compaction, using the active provider for a compact summary when available, and adds a conservative model-switch compaction guard.

## Why
Long Zero sessions already had automatic agent compaction, but manual/session replay compaction was still mostly a shell. This makes `/compact` affect the actual future context path instead of only reporting status.

## Validation
- `go test ./...`
- `go vet ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`

## Notes
- Full session event logs remain available via `ReadEvents`; prompt replay uses `ReadRehydratedEvents`/`ReadReplayEvents` so compacted raw events are not re-sent.
- Provider-backed `/compact` records only the returned summary; no-provider sessions use a deterministic fallback summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich session compaction: preserved structured state (plans, tools/schemas, skills, project instructions), persistent compaction events, replay/rehydration, model/mode compaction gating, /compact UI with status, and a pluggable session compactor API.

* **Bug Fixes**
  * Validation for missing summarizers, trimmed/injected summaries, explicit no-op handling, clearer error propagation, and safer fallback when compaction payloads are malformed.

* **Tests**
  * Expanded unit/integration coverage for compaction metadata, preserved-state behavior, replay/rehydration, and TUI compaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->