### PR TITLE
Fix all critical & high deep-audit findings

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -207,6 +207,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			Role:      zeroruntime.MessageRoleAssistant,
 			Content:   collected.Text,
 			ToolCalls: historySafeToolCalls(collected.ToolCalls),
+			// Preserve thinking blocks so the next turn can replay them; providers
+			// that use extended thinking reject tool conversations that drop them.
+			Reasoning: collected.ReasoningBlocks,
 		})
 
 		if len(collected.ToolCalls) == 0 {
@@ -1225,6 +1228,9 @@ func copyMessages(messages []Message) []Message {
 		copied[index] = message
 		if message.ToolCalls != nil {
 			copied[index].ToolCalls = append([]ToolCall{}, message.ToolCalls...)
+		}
+		if message.Reasoning != nil {
+			copied[index].Reasoning = append([]zeroruntime.ReasoningBlock{}, message.Reasoning...)
 		}
 		// Deep-copy image attachments (slice AND each Data byte slice) so the
 		// raw image bytes are never aliased across history/request/result copies.

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -84,8 +84,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 
 		exposed, reminder := partitionTools(registry, permissionMode, options, loaded)
 		request := zeroruntime.CompletionRequest{
-			Messages: copyMessages(messages),
-			Tools:    exposed,
+			Messages:        copyMessages(messages),
+			Tools:           exposed,
+			ReasoningEffort: options.ReasoningEffort,
 		}
 		if reminder != "" {
 			// Append to the per-turn request copy only — NEVER to persistent
@@ -120,8 +121,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 				// empty-loaded partition, re-hiding every already-loaded deferred tool
 				// and dropping the reminder when deferral is active.
 				request = zeroruntime.CompletionRequest{
-					Messages: copyMessages(messages),
-					Tools:    exposed,
+					Messages:        copyMessages(messages),
+					Tools:           exposed,
+					ReasoningEffort: options.ReasoningEffort,
 				}
 				if reminder != "" {
 					// Append to the per-turn retry copy only — NEVER to persistent
@@ -159,8 +161,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 				// Routing through an empty-loaded partition here would re-hide every
 				// already-loaded deferred tool and drop the reminder when deferral is active.
 				retryRequest := zeroruntime.CompletionRequest{
-					Messages: copyMessages(messages),
-					Tools:    exposed,
+					Messages:        copyMessages(messages),
+					Tools:           exposed,
+					ReasoningEffort: options.ReasoningEffort,
 				}
 				if reminder != "" {
 					// Append to the per-turn retry copy only — NEVER to persistent
@@ -401,7 +404,8 @@ func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages [
 		Content: maxTurnsFinalAnswerPrompt,
 	})
 	stream, err := provider.StreamCompletion(ctx, zeroruntime.CompletionRequest{
-		Messages: copyMessages(finalMessages),
+		Messages:        copyMessages(finalMessages),
+		ReasoningEffort: options.ReasoningEffort,
 	})
 	if err != nil {
 		return "", messages, ""

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -195,6 +195,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			return result, ctx.Err()
 		}
 
+		// Carry the turn's terminal stop reason so a final answer cut off at the
+		// output token cap (or by a content filter) is reported as truncated. A
+		// tool-call turn normalizes to "" and clears any prior reason.
+		result.FinishReason = collected.FinishReason
+
 		messages = append(messages, zeroruntime.Message{
 			Role:      zeroruntime.MessageRoleAssistant,
 			Content:   collected.Text,
@@ -377,8 +382,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		result.Messages = copyMessages(messages)
 		return result, ctx.Err()
 	}
-	if answer, finalMessages := finalAnswerAfterMaxTurns(ctx, provider, messages, options); strings.TrimSpace(answer) != "" {
+	if answer, finalMessages, finishReason := finalAnswerAfterMaxTurns(ctx, provider, messages, options); strings.TrimSpace(answer) != "" {
 		result.FinalAnswer = answer
+		result.FinishReason = finishReason
 		result.Messages = copyMessages(finalMessages)
 		return result, nil
 	}
@@ -388,7 +394,7 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	return result, nil
 }
 
-func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages []zeroruntime.Message, options Options) (string, []zeroruntime.Message) {
+func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages []zeroruntime.Message, options Options) (string, []zeroruntime.Message, string) {
 	finalMessages := copyMessages(messages)
 	finalMessages = append(finalMessages, zeroruntime.Message{
 		Role:    zeroruntime.MessageRoleUser,
@@ -398,20 +404,20 @@ func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages [
 		Messages: copyMessages(finalMessages),
 	})
 	if err != nil {
-		return "", messages
+		return "", messages, ""
 	}
 	collected := zeroruntime.CollectStreamWithOptions(ctx, stream, zeroruntime.CollectOptions{
 		OnText:  options.OnText,
 		OnUsage: options.OnUsage,
 	})
 	if ctx.Err() != nil || collected.Error != "" || strings.TrimSpace(collected.Text) == "" {
-		return "", messages
+		return "", messages, ""
 	}
 	finalMessages = append(finalMessages, zeroruntime.Message{
 		Role:    zeroruntime.MessageRoleAssistant,
 		Content: collected.Text,
 	})
-	return collected.Text, finalMessages
+	return collected.Text, finalMessages, collected.FinishReason
 }
 
 func historySafeToolCalls(calls []ToolCall) []ToolCall {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -88,6 +88,71 @@ func TestRunReturnsProviderText(t *testing.T) {
 	assertMessage(t, provider.requests[0].Messages[1], zeroruntime.MessageRoleUser, "say hi")
 }
 
+func TestRunReportsTruncationFinishReason(t *testing.T) {
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{{
+			{Type: zeroruntime.StreamEventText, Content: "partial answer"},
+			{Type: zeroruntime.StreamEventDone, FinishReason: zeroruntime.FinishReasonLength},
+		}},
+	}
+
+	result, err := Run(context.Background(), "write a long thing", provider, Options{
+		Registry: tools.NewRegistry(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "partial answer" {
+		t.Fatalf("final answer = %q", result.FinalAnswer)
+	}
+	if result.FinishReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("FinishReason = %q, want %q", result.FinishReason, zeroruntime.FinishReasonLength)
+	}
+	if !result.Truncated() {
+		t.Fatal("Truncated() = false, want true for a length-capped response")
+	}
+	if result.TruncationNotice() == "" {
+		t.Fatal("TruncationNotice() empty for a truncated response")
+	}
+}
+
+func TestRunNormalCompletionIsNotTruncated(t *testing.T) {
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{{
+			{Type: zeroruntime.StreamEventText, Content: "done"},
+			{Type: zeroruntime.StreamEventDone},
+		}},
+	}
+
+	result, err := Run(context.Background(), "hi", provider, Options{Registry: tools.NewRegistry()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Truncated() || result.TruncationNotice() != "" {
+		t.Fatalf("normal completion reported as truncated: reason=%q", result.FinishReason)
+	}
+}
+
+func TestResultTruncationNotice(t *testing.T) {
+	cases := map[string]struct {
+		reason     string
+		wantNotice bool
+	}{
+		"length":         {zeroruntime.FinishReasonLength, true},
+		"content_filter": {zeroruntime.FinishReasonContentFilter, true},
+		"unknown":        {"weird_reason", true},
+		"normal":         {"", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			notice := Result{FinishReason: tc.reason}.TruncationNotice()
+			if (notice != "") != tc.wantNotice {
+				t.Fatalf("notice = %q, wantNotice = %v", notice, tc.wantNotice)
+			}
+		})
+	}
+}
+
 func TestRunEmitsTextDeltas(t *testing.T) {
 	provider := &mockProvider{
 		turns: [][]zeroruntime.StreamEvent{{

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -196,4 +196,33 @@ type Result struct {
 	Turns       int
 	Messages    []Message
 	StopReason  StopReason
+	// FinishReason is the provider's normalized terminal stop reason for the turn
+	// that produced FinalAnswer: zeroruntime.FinishReasonLength when the output
+	// hit the token cap, FinishReasonContentFilter when it was filtered. Empty for
+	// a normal completion.
+	FinishReason string
+}
+
+// Truncated reports whether the final response ended abnormally (cut off at the
+// output token cap or withheld by a content filter) rather than completing
+// naturally. Callers can use it to warn the user that FinalAnswer is incomplete.
+func (result Result) Truncated() bool {
+	return result.FinishReason != ""
+}
+
+// TruncationNotice returns a user-facing warning when the final response was
+// truncated, or "" for a normal completion. Shared by the CLI and TUI so the
+// wording stays consistent.
+func (result Result) TruncationNotice() string {
+	switch result.FinishReason {
+	case zeroruntime.FinishReasonLength:
+		return "Response was cut off at the output token limit and may be incomplete. " +
+			"Raise the model's max output tokens or ask zero to continue."
+	case zeroruntime.FinishReasonContentFilter:
+		return "Response was withheld or cut off by the provider's content filter and may be incomplete."
+	case "":
+		return ""
+	default:
+		return "Response ended early (" + result.FinishReason + ") and may be incomplete."
+	}
 }

--- a/internal/cli/cron.go
+++ b/internal/cli/cron.go
@@ -103,6 +103,16 @@ func cronAdd(store *cron.Store, now func() time.Time, args []string, stdout io.W
 		}
 	}
 
+	if len(positional) > 1 {
+		fmt.Fprintf(stderr, "Unexpected extra arguments: %s\n", strings.Join(positional[1:], " "))
+		return exitUsage
+	}
+	// Consume an explicit positional expression BEFORE applying recipe defaults,
+	// so `cron add "0 9 * * *" --recipe X` keeps the user's schedule instead of
+	// silently dropping it in favor of the recipe's expr.
+	if len(positional) == 1 && expr == "" {
+		expr = positional[0]
+	}
 	if recipe != "" {
 		r, ok := cron.Recipe(recipe)
 		if !ok {
@@ -115,13 +125,6 @@ func cronAdd(store *cron.Store, now func() time.Time, args []string, stdout io.W
 		if prompt == "" {
 			prompt = r.Prompt
 		}
-	}
-	if len(positional) > 1 {
-		fmt.Fprintf(stderr, "Unexpected extra arguments: %s\n", strings.Join(positional[1:], " "))
-		return exitUsage
-	}
-	if len(positional) == 1 && expr == "" {
-		expr = positional[0]
 	}
 	if expr == "" {
 		fmt.Fprintln(stderr, "A cron expression is required (e.g. `zero cron add \"0 9 * * *\" --prompt ...`).")

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -172,10 +173,17 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 	// this, store.Update would clobber an external pause back to active. (A single
 	// scheduler is the supported model; this narrows but does not fully close the
 	// read-modify-write window — full atomicity needs file locking.)
-	if current, err := store.Get(job.ID); err != nil {
+	current, err := store.Get(job.ID)
+	switch {
+	case errors.Is(err, cron.ErrJobNotFound):
+		// Genuinely removed mid-run: don't recreate it by persisting.
 		fmt.Fprintf(stdout, "fired %s -> exit %d (job removed during run)\n", job.ID, code)
 		return
-	} else if current.Status == cron.StatusPaused {
+	case err != nil:
+		// A transient read failure (IO/permission) is NOT removal — warn but still
+		// record the run and persist the computed next state below.
+		fmt.Fprintf(stderr, "warning: could not re-read job %s before persist: %v\n", job.ID, err)
+	case current.Status == cron.StatusPaused:
 		job.Status = cron.StatusPaused
 	}
 	if err := store.AppendRun(job.ID, rec); err != nil {

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -167,6 +167,17 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 	} else {
 		job.NextRunAt = nxt
 	}
+	// Re-read before persisting: the job may have been paused or removed while it
+	// was executing, and this in-memory copy is stale from tick start. Without
+	// this, store.Update would clobber an external pause back to active. (A single
+	// scheduler is the supported model; this narrows but does not fully close the
+	// read-modify-write window — full atomicity needs file locking.)
+	if current, err := store.Get(job.ID); err != nil {
+		fmt.Fprintf(stdout, "fired %s -> exit %d (job removed during run)\n", job.ID, code)
+		return
+	} else if current.Status == cron.StatusPaused {
+		job.Status = cron.StatusPaused
+	}
 	if err := store.AppendRun(job.ID, rec); err != nil {
 		fmt.Fprintf(stderr, "warning: failed to record run for %s: %v\n", job.ID, err)
 	}

--- a/internal/cli/cron_test.go
+++ b/internal/cli/cron_test.go
@@ -92,6 +92,27 @@ func TestCronAddRecipe(t *testing.T) {
 	}
 }
 
+func TestCronAddExplicitExprOverridesRecipe(t *testing.T) {
+	store := testCronStore(t)
+	var out, errb bytes.Buffer
+	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }
+	// An explicit positional schedule must win over the recipe's default expr
+	// instead of being silently dropped.
+	if code := runCronWith(store, now, []string{"add", "0 9 * * *", "--recipe", "git-recap"}, &out, &errb); code != 0 {
+		t.Fatalf("add exit=%d err=%s", code, errb.String())
+	}
+	jobs, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Expr != "0 9 * * *" {
+		t.Fatalf("explicit expr should win over recipe, got: %+v", jobs)
+	}
+	if jobs[0].Prompt == "" {
+		t.Fatalf("recipe prompt should still fill in, got empty: %+v", jobs)
+	}
+}
+
 func TestCronAddRejectsExtraArgs(t *testing.T) {
 	store := testCronStore(t)
 	now := func() time.Time { return time.Date(2026, 6, 9, 8, 0, 0, 0, time.UTC) }

--- a/internal/cli/cron_test.go
+++ b/internal/cli/cron_test.go
@@ -108,8 +108,14 @@ func TestCronAddExplicitExprOverridesRecipe(t *testing.T) {
 	if len(jobs) != 1 || jobs[0].Expr != "0 9 * * *" {
 		t.Fatalf("explicit expr should win over recipe, got: %+v", jobs)
 	}
-	if jobs[0].Prompt == "" {
-		t.Fatalf("recipe prompt should still fill in, got empty: %+v", jobs)
+	// The recipe's prompt must actually propagate — assert the exact recipe text,
+	// not just non-empty (which a default prompt would also satisfy).
+	recipe, ok := cron.Recipe("git-recap")
+	if !ok {
+		t.Fatal("git-recap recipe missing")
+	}
+	if jobs[0].Prompt != recipe.Prompt {
+		t.Fatalf("recipe prompt not propagated: got %q want %q", jobs[0].Prompt, recipe.Prompt)
 	}
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -284,6 +284,9 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			}
 		}
 	}
+	// Effort to forward on the provider request, gated to the resolved model's
+	// supported levels (empty for non-reasoning models).
+	forwardEffort := forwardedReasoningEffort(modelRegistry, resolved.Provider.Model, runReasoningEffort)
 
 	provider, err := buildProvider(resolved, deps)
 	if err != nil {
@@ -341,7 +344,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			prompt:             prompt,
 			sessionTitle:       sessionTitle,
 			images:             images,
-			reasoningEffort:    runReasoningEffort,
+			reasoningEffort:    forwardEffort,
 			specPermissionMode: permissionMode,
 			notifier:           notifier,
 		})
@@ -429,7 +432,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		ProviderName:     resolved.Provider.Name,
 		Model:            resolved.Provider.Model,
 		ModelSwitcher:    modelSwitcher,
-		ReasoningEffort:  runReasoningEffort,
+		ReasoningEffort:  forwardEffort,
 		Cwd:              workspaceRoot,
 		Images:           images,
 		Registry:         registry,
@@ -865,6 +868,28 @@ func modelContextWindow(registry modelregistry.Registry, modelID string) int {
 // NOTE: the effective effort is not yet forwarded to the provider request — the
 // zeroruntime.CompletionRequest / provider wire schemas carry no effort field.
 // Full provider-request propagation is deferred (see slice-3 report).
+// forwardedReasoningEffort returns the effort to send on the provider request.
+// It mirrors reasoningEffortNotice: a known model that does not support reasoning
+// yields "" (matching the "ignoring" advisory, so the request never carries an
+// unsupported parameter); a known reasoning model yields its effective level; an
+// unknown model (e.g. a custom OpenAI-compatible endpoint) forwards the requested
+// value as-is, since no support claim can be made for it.
+func forwardedReasoningEffort(registry modelregistry.Registry, modelID string, requested string) string {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return ""
+	}
+	entry, ok := registry.Get(strings.TrimSpace(modelID))
+	if !ok {
+		return requested
+	}
+	effective := modelregistry.EffectiveReasoningEffort(entry, modelregistry.ReasoningEffort(strings.ToLower(requested)))
+	if effective == modelregistry.ReasoningEffortNone {
+		return ""
+	}
+	return string(effective)
+}
+
 func reasoningEffortNotice(registry modelregistry.Registry, modelID string, requested string) string {
 	trimmed := strings.TrimSpace(modelID)
 	if trimmed == "" {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -527,6 +527,9 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		"content": result.FinalAnswer,
 	})
 
+	if notice := result.TruncationNotice(); notice != "" {
+		writer.warning(notice)
+	}
 	writer.final(result.FinalAnswer)
 	writer.runEnd("success", exitSuccess)
 	if writer.err != nil {

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -847,6 +847,32 @@ func TestReasoningEffortNoticeCoercesUnsupportedEffort(t *testing.T) {
 	}
 }
 
+func TestForwardedReasoningEffortGating(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	cases := []struct {
+		name      string
+		model     string
+		requested string
+		want      string
+	}{
+		{"empty request", "claude-sonnet-4.5", "", ""},
+		{"supported reasoning model", "claude-sonnet-4.5", "high", "high"},
+		{"unsupported effort coerced to default", "claude-sonnet-4.5", "xhigh", "medium"},
+		{"known non-reasoning model suppressed", "gpt-4.1", "high", ""},
+		{"unknown model forwards as-is", "custom-endpoint-model", "high", "high"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forwardedReasoningEffort(registry, tc.model, tc.requested); got != tc.want {
+				t.Fatalf("forwardedReasoningEffort(%q, %q) = %q, want %q", tc.model, tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunExecJSONUnsafeOutputsWarningEvent(t *testing.T) {
 	exitCode, stdout, stderr := runExecWithEcho(t, []string{"exec", "--skip-permissions-unsafe", "-o", "json", "hello"})
 

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -16,6 +16,12 @@ const (
 	StatusPaused = "paused"
 )
 
+// ErrJobNotFound is returned (wrapped) by Get when a job's metadata file is
+// absent — a genuinely removed job. Callers use errors.Is to distinguish this
+// from a transient read failure (IO error, permission), which must NOT be
+// treated as "job removed".
+var ErrJobNotFound = errors.New("cron job not found")
+
 // Job is a stored scheduled job.
 type Job struct {
 	ID        string    `json:"id"`
@@ -147,7 +153,12 @@ func (s *Store) Get(id string) (Job, error) {
 	}
 	data, err := os.ReadFile(filepath.Join(s.jobDir(id), "metadata.json"))
 	if err != nil {
-		return Job{}, fmt.Errorf("cron job %q not found", id)
+		if errors.Is(err, os.ErrNotExist) {
+			return Job{}, fmt.Errorf("cron job %q: %w", id, ErrJobNotFound)
+		}
+		// A transient read failure (IO error, permission) is NOT a missing job;
+		// surface it as a distinct error so callers don't mistake it for removal.
+		return Job{}, fmt.Errorf("read cron job %q: %w", id, err)
 	}
 	var job Job
 	if err := json.Unmarshal(data, &job); err != nil {

--- a/internal/cron/store_test.go
+++ b/internal/cron/store_test.go
@@ -1,12 +1,37 @@
 package cron
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestStoreGetDistinguishesNotFoundFromReadError(t *testing.T) {
+	s := newTestStore(t)
+
+	// A genuinely absent job → ErrJobNotFound.
+	if _, err := s.Get("job_missing"); !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("missing job Get err = %v, want ErrJobNotFound", err)
+	}
+
+	// A job whose metadata.json can't be read (here it's a directory, so ReadFile
+	// fails with a non-ENOENT error) must NOT be reported as not-found — otherwise
+	// cron_run mislabels a transient IO failure as "job removed during run".
+	id := "job_unreadable"
+	if err := os.MkdirAll(filepath.Join(s.jobDir(id), "metadata.json"), 0o755); err != nil {
+		t.Fatalf("mkdir metadata.json-as-dir: %v", err)
+	}
+	_, err := s.Get(id)
+	if err == nil {
+		t.Fatal("expected an error reading a directory as metadata.json")
+	}
+	if errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("a read error must not be reported as ErrJobNotFound: %v", err)
+	}
+}
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -1,0 +1,236 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// defaultHookTimeout bounds a single hook command so a hung or slow hook cannot
+// stall the agent indefinitely.
+const defaultHookTimeout = 30 * time.Second
+
+// DispatchInput describes one lifecycle point at which hooks may run.
+type DispatchInput struct {
+	Event      Event
+	ToolName   string // for beforeTool/afterTool matching
+	ToolCallID string
+	// Payload is serialized to JSON and written to each hook command's stdin so a
+	// hook can inspect the tool call, its result, or session context.
+	Payload any
+}
+
+// DispatchOutcome reports what happened for one Dispatch call.
+type DispatchOutcome struct {
+	Ran       int    // hooks that executed
+	Blocked   bool   // a blocking-event hook exited non-zero, vetoing the action
+	BlockedBy string // ID of the hook that blocked (empty unless Blocked)
+	Reason    string // the blocking hook's stderr/stdout, for surfacing to the model
+}
+
+type commandResult struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	Err      error // set when the command could not be executed (not a non-zero exit)
+}
+
+// commandRunner executes one hook command. It is injectable so the dispatch
+// logic can be tested without spawning processes.
+type commandRunner func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult
+
+// DispatcherOptions configures a Dispatcher.
+type DispatcherOptions struct {
+	Config  Config
+	Audit   *AuditStore   // optional; when set, every run is recorded
+	Cwd     string        // working directory for hook commands
+	Env     []string      // extra environment entries appended to the process env
+	Timeout time.Duration // per-command timeout (defaults to defaultHookTimeout)
+	now     func() time.Time
+	run     commandRunner
+}
+
+// Dispatcher selects and runs the hooks configured for a lifecycle event,
+// recording each run to the audit store. A beforeTool hook that exits non-zero
+// blocks the tool; hooks for other events are advisory (failures are recorded
+// but do not interrupt the run).
+type Dispatcher struct {
+	config  Config
+	audit   *AuditStore
+	cwd     string
+	env     []string
+	timeout time.Duration
+	now     func() time.Time
+	run     commandRunner
+}
+
+// NewDispatcher builds a Dispatcher. A zero/empty config yields a dispatcher that
+// runs nothing, so callers can always construct one unconditionally.
+func NewDispatcher(options DispatcherOptions) *Dispatcher {
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = defaultHookTimeout
+	}
+	now := options.now
+	if now == nil {
+		now = time.Now
+	}
+	run := options.run
+	if run == nil {
+		run = execCommandRunner
+	}
+	return &Dispatcher{
+		config:  options.Config,
+		audit:   options.Audit,
+		cwd:     options.Cwd,
+		env:     options.Env,
+		timeout: timeout,
+		now:     now,
+		run:     run,
+	}
+}
+
+// blocksOn reports whether a non-zero exit for this event should veto the action.
+// Only beforeTool gates the tool; other events are observational.
+func blocksOn(event Event) bool {
+	return event == EventBeforeTool
+}
+
+// Dispatch runs every enabled hook configured for the input event (and matcher,
+// for tool events). It returns once all hooks have run, or early if a blocking
+// hook vetoes the action.
+func (dispatcher *Dispatcher) Dispatch(ctx context.Context, input DispatchInput) DispatchOutcome {
+	outcome := DispatchOutcome{}
+	if dispatcher == nil {
+		return outcome
+	}
+	selected := Select(dispatcher.config, SelectInput{Event: input.Event, ToolName: input.ToolName})
+	if len(selected) == 0 {
+		return outcome
+	}
+
+	payload, err := json.Marshal(input.Payload)
+	if err != nil {
+		payload = nil
+	}
+
+	for _, hook := range selected {
+		command := Command{Command: hook.Command, Args: hook.Args}
+		dispatcher.recordStarted(hook, input, command)
+
+		started := dispatcher.now()
+		result := dispatcher.runWithTimeout(ctx, hook, payload)
+		durationMs := int(dispatcher.now().Sub(started) / time.Millisecond)
+		outcome.Ran++
+
+		status, blocked := classifyResult(input.Event, result)
+		dispatcher.recordCompleted(hook, input, status, result, durationMs)
+
+		if blocked {
+			outcome.Blocked = true
+			outcome.BlockedBy = hook.ID
+			outcome.Reason = blockReason(result)
+			// Stop on the first veto: the action is already denied.
+			return outcome
+		}
+	}
+	return outcome
+}
+
+func (dispatcher *Dispatcher) runWithTimeout(ctx context.Context, hook Definition, stdin []byte) commandResult {
+	runCtx, cancel := context.WithTimeout(ctx, dispatcher.timeout)
+	defer cancel()
+	env := os.Environ()
+	if len(dispatcher.env) > 0 {
+		env = append(env, dispatcher.env...)
+	}
+	return dispatcher.run(runCtx, hook.Command, hook.Args, stdin, dispatcher.cwd, env)
+}
+
+// classifyResult maps a command result to an audit status and whether it vetoes
+// the action. A command that ran and exited non-zero blocks a beforeTool hook; a
+// command that could not be executed at all is an error but never blocks (a
+// missing hook binary must not wedge every tool call).
+func classifyResult(event Event, result commandResult) (AuditStatus, bool) {
+	if result.Err != nil {
+		return AuditError, false
+	}
+	if result.ExitCode != 0 {
+		if blocksOn(event) {
+			return AuditBlocked, true
+		}
+		return AuditError, false
+	}
+	return AuditCompleted, false
+}
+
+func blockReason(result commandResult) string {
+	for _, candidate := range []string{result.Stderr, result.Stdout} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return "hook exited non-zero"
+}
+
+func (dispatcher *Dispatcher) recordStarted(hook Definition, input DispatchInput, command Command) {
+	if dispatcher.audit == nil {
+		return
+	}
+	_, _ = dispatcher.audit.AppendStarted(AppendStartedInput{
+		HookID:     hook.ID,
+		Event:      input.Event,
+		Matcher:    hook.Matcher,
+		ToolCallID: input.ToolCallID,
+		Commands:   []AuditCommand{command},
+	})
+}
+
+func (dispatcher *Dispatcher) recordCompleted(hook Definition, input DispatchInput, status AuditStatus, result commandResult, durationMs int) {
+	if dispatcher.audit == nil {
+		return
+	}
+	_, _ = dispatcher.audit.AppendCompleted(AppendCompletedInput{
+		HookID:     hook.ID,
+		Event:      input.Event,
+		Matcher:    hook.Matcher,
+		ToolCallID: input.ToolCallID,
+		Status:     status,
+		Results:    []AuditResult{{ExitCode: result.ExitCode, Stdout: result.Stdout, Stderr: result.Stderr}},
+		DurationMs: durationMs,
+	})
+}
+
+// execCommandRunner runs a hook command directly (no shell), feeding the JSON
+// payload on stdin and capturing stdout/stderr. A non-zero exit is reported via
+// ExitCode (not Err); Err is reserved for commands that could not be launched.
+func execCommandRunner(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = cwd
+	cmd.Env = env
+	if len(stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	result := commandResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if err == nil {
+		return result
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		result.ExitCode = exitErr.ExitCode()
+		return result
+	}
+	// Could not launch (binary missing, timeout, etc.).
+	result.ExitCode = -1
+	result.Err = err
+	return result
+}

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -38,6 +38,7 @@ type commandResult struct {
 	Stdout   string
 	Stderr   string
 	Err      error // set when the command could not be executed (not a non-zero exit)
+	TimedOut bool  // the hook started but its deadline/cancellation fired before it returned
 }
 
 // commandRunner executes one hook command. It is injectable so the dispatch
@@ -149,7 +150,15 @@ func (dispatcher *Dispatcher) runWithTimeout(ctx context.Context, hook Definitio
 	if len(dispatcher.env) > 0 {
 		env = append(env, dispatcher.env...)
 	}
-	return dispatcher.run(runCtx, hook.Command, hook.Args, stdin, dispatcher.cwd, env)
+	result := dispatcher.run(runCtx, hook.Command, hook.Args, stdin, dispatcher.cwd, env)
+	// A deadline or cancellation that fired while the hook was running is distinct
+	// from a launch failure: the hook DID start, we just never got its verdict.
+	// classifyResult must fail CLOSED on this for a blocking event — a hung policy
+	// hook cannot be allowed to wave the tool through.
+	if runCtx.Err() != nil {
+		result.TimedOut = true
+	}
+	return result
 }
 
 // classifyResult maps a command result to an audit status and whether it vetoes
@@ -157,6 +166,16 @@ func (dispatcher *Dispatcher) runWithTimeout(ctx context.Context, hook Definitio
 // command that could not be executed at all is an error but never blocks (a
 // missing hook binary must not wedge every tool call).
 func classifyResult(event Event, result commandResult) (AuditStatus, bool) {
+	// A hook that started but was killed by its deadline (or a cancellation) never
+	// returned a verdict. For a blocking event we must fail CLOSED and veto: a
+	// hung beforeTool policy hook cannot be treated as approval. (A launch failure
+	// below still fails OPEN, so a misconfigured hook doesn't wedge every tool.)
+	if result.TimedOut {
+		if blocksOn(event) {
+			return AuditBlocked, true
+		}
+		return AuditError, false
+	}
 	if result.Err != nil {
 		return AuditError, false
 	}
@@ -170,6 +189,12 @@ func classifyResult(event Event, result commandResult) (AuditStatus, bool) {
 }
 
 func blockReason(result commandResult) string {
+	if result.TimedOut {
+		if trimmed := strings.TrimSpace(result.Stderr); trimmed != "" {
+			return "hook timed out: " + trimmed
+		}
+		return "hook timed out before returning a verdict"
+	}
 	for _, candidate := range []string{result.Stderr, result.Stdout} {
 		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
 			return trimmed

--- a/internal/hooks/dispatch_test.go
+++ b/internal/hooks/dispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func beforeToolConfig(hooks ...Definition) Config {
@@ -161,5 +162,44 @@ func TestExecCommandRunnerReportsLaunchFailureWithoutBlocking(t *testing.T) {
 	// A launch failure is an error, never a block, even for beforeTool.
 	if status, blocked := classifyResult(EventBeforeTool, result); blocked || status != AuditError {
 		t.Fatalf("classify = (%q, %v), want (error, false) for a launch failure", status, blocked)
+	}
+}
+
+func TestClassifyResultTimedOutFailsClosedForBeforeTool(t *testing.T) {
+	// Unlike a launch failure, a hook that STARTED but was killed by its deadline
+	// gave no verdict — a beforeTool policy hook must fail CLOSED (veto), or a hung
+	// hook would silently wave the tool through.
+	timedOut := commandResult{TimedOut: true, Err: context.DeadlineExceeded}
+	if status, blocked := classifyResult(EventBeforeTool, timedOut); !blocked || status != AuditBlocked {
+		t.Fatalf("beforeTool timeout classify = (%q, %v), want (blocked, true)", status, blocked)
+	}
+	// Observational events still never veto, even on timeout.
+	if status, blocked := classifyResult(EventAfterTool, timedOut); blocked || status != AuditError {
+		t.Fatalf("afterTool timeout classify = (%q, %v), want (error, false)", status, blocked)
+	}
+	if reason := blockReason(timedOut); !strings.Contains(reason, "timed out") {
+		t.Fatalf("blockReason = %q, want a timeout message", reason)
+	}
+}
+
+func TestDispatchBeforeToolFailsClosedWhenHookTimesOut(t *testing.T) {
+	// End-to-end: a beforeTool hook that hangs past the dispatcher timeout vetoes
+	// the tool. The injected runner blocks until its context is cancelled.
+	runner := func(ctx context.Context, _ string, _ []string, _ []byte, _ string, _ []string) commandResult {
+		<-ctx.Done()
+		return commandResult{Err: ctx.Err()}
+	}
+	config := beforeToolConfig(Definition{ID: "slow-guard", Event: EventBeforeTool, Command: "hang", Enabled: true})
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner, Timeout: 20 * time.Millisecond})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventBeforeTool, ToolName: "bash"})
+	if !outcome.Blocked {
+		t.Fatal("a timed-out beforeTool hook must fail closed (block the tool)")
+	}
+	if outcome.BlockedBy != "slow-guard" {
+		t.Fatalf("BlockedBy = %q, want slow-guard", outcome.BlockedBy)
+	}
+	if !strings.Contains(outcome.Reason, "timed out") {
+		t.Fatalf("Reason = %q, want a timeout reason", outcome.Reason)
 	}
 }

--- a/internal/hooks/dispatch_test.go
+++ b/internal/hooks/dispatch_test.go
@@ -1,0 +1,165 @@
+package hooks
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func beforeToolConfig(hooks ...Definition) Config {
+	return Config{Enabled: true, Hooks: hooks}
+}
+
+func TestDispatchRunsMatchingHooksAndRecordsAudit(t *testing.T) {
+	var calls []string
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		calls = append(calls, command)
+		return commandResult{ExitCode: 0, Stdout: "ok"}
+	}
+	audit, err := NewAuditStore(AuditStoreOptions{AuditPath: filepath.Join(t.TempDir(), "audit.jsonl")})
+	if err != nil {
+		t.Fatalf("NewAuditStore: %v", err)
+	}
+	config := beforeToolConfig(
+		Definition{ID: "h1", Event: EventBeforeTool, Matcher: "bash", Command: "guard", Enabled: true},
+		Definition{ID: "h2", Event: EventBeforeTool, Command: "log", Enabled: true}, // no matcher = always
+		Definition{ID: "h3", Event: EventBeforeTool, Matcher: "read_file", Command: "skip", Enabled: true},
+	)
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, Audit: audit, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventBeforeTool, ToolName: "bash", ToolCallID: "call_1"})
+	if outcome.Blocked {
+		t.Fatalf("unexpected block: %#v", outcome)
+	}
+	if outcome.Ran != 2 {
+		t.Fatalf("Ran = %d, want 2 (h1 matcher + h2 unmatched), calls=%v", outcome.Ran, calls)
+	}
+	events, err := audit.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	started, completed := 0, 0
+	for _, event := range events {
+		switch event.Type {
+		case "hook_execution_started":
+			started++
+		case "hook_execution_completed":
+			completed++
+			if event.Status != AuditCompleted {
+				t.Fatalf("status = %q, want completed", event.Status)
+			}
+		}
+	}
+	if started != 2 || completed != 2 {
+		t.Fatalf("audit events: started=%d completed=%d, want 2/2", started, completed)
+	}
+}
+
+func TestDispatchBeforeToolBlocksOnNonZeroExitAndStops(t *testing.T) {
+	ran := 0
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		ran++
+		if command == "deny" {
+			return commandResult{ExitCode: 2, Stderr: "policy violation"}
+		}
+		return commandResult{ExitCode: 0}
+	}
+	config := beforeToolConfig(
+		Definition{ID: "deny", Event: EventBeforeTool, Command: "deny", Enabled: true},
+		Definition{ID: "after-deny", Event: EventBeforeTool, Command: "second", Enabled: true},
+	)
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventBeforeTool, ToolName: "bash"})
+	if !outcome.Blocked || outcome.BlockedBy != "deny" {
+		t.Fatalf("outcome = %#v, want blocked by deny", outcome)
+	}
+	if outcome.Reason != "policy violation" {
+		t.Fatalf("reason = %q, want hook stderr", outcome.Reason)
+	}
+	if ran != 1 {
+		t.Fatalf("ran %d hooks, want 1 (must stop after the first veto)", ran)
+	}
+}
+
+func TestDispatchNonBlockingEventDoesNotVetoOnNonZero(t *testing.T) {
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		return commandResult{ExitCode: 1, Stderr: "noisy"}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "notify", Event: EventAfterTool, Command: "notify", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "bash"})
+	if outcome.Blocked {
+		t.Fatalf("afterTool must not block: %#v", outcome)
+	}
+	if outcome.Ran != 1 {
+		t.Fatalf("Ran = %d, want 1", outcome.Ran)
+	}
+}
+
+func TestDispatchSkipsWhenDisabledOrUnmatched(t *testing.T) {
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		t.Fatal("runner must not be called")
+		return commandResult{}
+	}
+	disabled := Config{Enabled: false, Hooks: []Definition{{ID: "h", Event: EventBeforeTool, Command: "x", Enabled: true}}}
+	if outcome := NewDispatcher(DispatcherOptions{Config: disabled, run: runner}).Dispatch(context.Background(), DispatchInput{Event: EventBeforeTool, ToolName: "bash"}); outcome.Ran != 0 {
+		t.Fatalf("disabled config ran hooks: %#v", outcome)
+	}
+	unmatched := beforeToolConfig(Definition{ID: "h", Event: EventBeforeTool, Matcher: "read_file", Command: "x", Enabled: true})
+	if outcome := NewDispatcher(DispatcherOptions{Config: unmatched, run: runner}).Dispatch(context.Background(), DispatchInput{Event: EventBeforeTool, ToolName: "bash"}); outcome.Ran != 0 {
+		t.Fatalf("unmatched matcher ran hooks: %#v", outcome)
+	}
+}
+
+func TestDispatchDeliversJSONPayloadOnStdin(t *testing.T) {
+	var gotStdin string
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		gotStdin = string(stdin)
+		return commandResult{ExitCode: 0}
+	}
+	config := beforeToolConfig(Definition{ID: "h", Event: EventBeforeTool, Command: "x", Enabled: true})
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	dispatcher.Dispatch(context.Background(), DispatchInput{
+		Event:    EventBeforeTool,
+		ToolName: "bash",
+		Payload:  map[string]any{"tool": "bash", "args": map[string]any{"command": "ls"}},
+	})
+	if !strings.Contains(gotStdin, `"tool":"bash"`) || !strings.Contains(gotStdin, `"command":"ls"`) {
+		t.Fatalf("stdin payload = %q, want serialized tool call", gotStdin)
+	}
+}
+
+func TestExecCommandRunnerCapturesExitAndStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh")
+	}
+	// Echoes stdin to stderr and exits non-zero so we exercise both paths.
+	result := execCommandRunner(context.Background(), "/bin/sh", []string{"-c", "cat 1>&2; exit 4"}, []byte("payload-123"), t.TempDir(), nil)
+	if result.Err != nil {
+		t.Fatalf("unexpected launch error: %v", result.Err)
+	}
+	if result.ExitCode != 4 {
+		t.Fatalf("exit code = %d, want 4", result.ExitCode)
+	}
+	if !strings.Contains(result.Stderr, "payload-123") {
+		t.Fatalf("stderr = %q, want stdin echoed", result.Stderr)
+	}
+}
+
+func TestExecCommandRunnerReportsLaunchFailureWithoutBlocking(t *testing.T) {
+	result := execCommandRunner(context.Background(), "definitely-not-a-real-binary-zzz", nil, nil, t.TempDir(), nil)
+	if result.Err == nil {
+		t.Fatal("expected launch error for a missing binary")
+	}
+	// A launch failure is an error, never a block, even for beforeTool.
+	if status, blocked := classifyResult(EventBeforeTool, result); blocked || status != AuditError {
+		t.Fatalf("classify = (%q, %v), want (error, false) for a launch failure", status, blocked)
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -3,11 +3,18 @@ package mcp
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 )
+
+// maxMessageBytes caps a single framed MCP message so a hostile or buggy peer
+// cannot drive an unbounded allocation with an enormous Content-Length header
+// (Atoi accepts values up to ~9.2e18). 64 MiB is far above any legitimate
+// JSON-RPC payload Zero exchanges.
+const maxMessageBytes = 64 * 1024 * 1024
 
 type rpcMessage struct {
 	JSONRPC string          `json:"jsonrpc,omitempty"`
@@ -39,37 +46,40 @@ func newMessageWriter(writer io.Writer) *messageWriter {
 	return &messageWriter{writer: bufio.NewWriter(writer)}
 }
 
+// read returns the next JSON-RPC message. The MCP stdio transport frames each
+// message as newline-delimited JSON (one message per line, no embedded
+// newlines); for backward compatibility it also accepts LSP-style
+// `Content-Length` framing. Both paths are bounded by maxMessageBytes so a
+// hostile peer cannot exhaust memory.
 func (reader *messageReader) read() (rpcMessage, error) {
-	contentLength := 0
 	for {
-		line, err := reader.reader.ReadString('\n')
+		line, err := reader.readLine()
 		if err != nil {
+			// A final message without a trailing newline still arrives with EOF.
+			if errors.Is(err, io.EOF) {
+				if trimmed := strings.TrimSpace(line); isJSONStart(trimmed) {
+					return decodeMessage([]byte(trimmed))
+				}
+			}
 			return rpcMessage{}, err
 		}
-		line = strings.TrimRight(line, "\r\n")
-		if line == "" {
-			break
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue // skip blank separator lines between messages
 		}
-		name, value, ok := strings.Cut(line, ":")
-		if !ok {
-			continue
+		if isJSONStart(trimmed) {
+			return decodeMessage([]byte(trimmed))
 		}
-		if strings.EqualFold(strings.TrimSpace(name), "content-length") {
-			parsed, err := strconv.Atoi(strings.TrimSpace(value))
-			if err != nil || parsed <= 0 {
-				return rpcMessage{}, fmt.Errorf("invalid MCP content length %q", value)
-			}
-			contentLength = parsed
-		}
+		// Not JSON — treat this line as the start of an LSP-style header block.
+		return reader.readHeaderFramed(strings.TrimRight(line, "\r\n"))
 	}
-	if contentLength <= 0 {
-		return rpcMessage{}, fmt.Errorf("missing MCP content length")
-	}
+}
 
-	body := make([]byte, contentLength)
-	if _, err := io.ReadFull(reader.reader, body); err != nil {
-		return rpcMessage{}, err
-	}
+func isJSONStart(s string) bool {
+	return s != "" && (s[0] == '{' || s[0] == '[')
+}
+
+func decodeMessage(body []byte) (rpcMessage, error) {
 	var message rpcMessage
 	if err := json.Unmarshal(body, &message); err != nil {
 		return rpcMessage{}, fmt.Errorf("invalid MCP JSON-RPC message: %w", err)
@@ -77,6 +87,64 @@ func (reader *messageReader) read() (rpcMessage, error) {
 	return message, nil
 }
 
+// readLine reads a single line (without the trailing newline), bounded to
+// maxMessageBytes so an unterminated stream cannot drive unbounded allocation.
+func (reader *messageReader) readLine() (string, error) {
+	var buf []byte
+	for {
+		chunk, err := reader.reader.ReadSlice('\n')
+		buf = append(buf, chunk...)
+		if len(buf) > maxMessageBytes {
+			return "", fmt.Errorf("MCP message exceeds %d-byte limit", maxMessageBytes)
+		}
+		if err == nil {
+			return string(buf), nil
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		return string(buf), err
+	}
+}
+
+// readHeaderFramed parses an LSP-style header block (starting with firstLine)
+// up to the blank separator, then reads the Content-Length body.
+func (reader *messageReader) readHeaderFramed(firstLine string) (rpcMessage, error) {
+	contentLength := 0
+	line := firstLine
+	for {
+		if name, value, ok := strings.Cut(line, ":"); ok && strings.EqualFold(strings.TrimSpace(name), "content-length") {
+			parsed, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil || parsed <= 0 {
+				return rpcMessage{}, fmt.Errorf("invalid MCP content length %q", value)
+			}
+			if parsed > maxMessageBytes {
+				return rpcMessage{}, fmt.Errorf("MCP content length %d exceeds %d-byte limit", parsed, maxMessageBytes)
+			}
+			contentLength = parsed
+		}
+		next, err := reader.readLine()
+		if err != nil {
+			return rpcMessage{}, err
+		}
+		if strings.TrimRight(next, "\r\n") == "" {
+			break
+		}
+		line = strings.TrimRight(next, "\r\n")
+	}
+	if contentLength <= 0 {
+		return rpcMessage{}, fmt.Errorf("missing MCP content length")
+	}
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(reader.reader, body); err != nil {
+		return rpcMessage{}, err
+	}
+	return decodeMessage(body)
+}
+
+// write emits a message using MCP stdio newline-delimited JSON framing. json
+// output contains no literal newlines, so the single trailing '\n' is the only
+// delimiter.
 func (writer *messageWriter) write(message rpcMessage) error {
 	if message.JSONRPC == "" {
 		message.JSONRPC = "2.0"
@@ -85,10 +153,10 @@ func (writer *messageWriter) write(message rpcMessage) error {
 	if err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(writer.writer, "Content-Length: %d\r\n\r\n", len(body)); err != nil {
+	if _, err := writer.writer.Write(body); err != nil {
 		return err
 	}
-	if _, err := writer.writer.Write(body); err != nil {
+	if err := writer.writer.WriteByte('\n'); err != nil {
 		return err
 	}
 	return writer.writer.Flush()

--- a/internal/mcp/protocol_test.go
+++ b/internal/mcp/protocol_test.go
@@ -35,6 +35,20 @@ func TestMessageReaderAcceptsNewlineDelimited(t *testing.T) {
 	}
 }
 
+func TestMessageReaderAcceptsFinalLineWithoutTrailingNewline(t *testing.T) {
+	// A final message that ends at EOF without a trailing newline must still be
+	// decoded (the read() EOF-tail branch), so a peer that doesn't terminate its
+	// last line isn't dropped.
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"tools/list"}`)
+	msg, err := newMessageReader(in).read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if msg.Method != "tools/list" {
+		t.Fatalf("method=%q want tools/list", msg.Method)
+	}
+}
+
 func TestMessageReaderAcceptsContentLengthFraming(t *testing.T) {
 	body := `{"jsonrpc":"2.0","method":"initialize"}`
 	framed := fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)

--- a/internal/mcp/protocol_test.go
+++ b/internal/mcp/protocol_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMessageWriterEmitsNewlineDelimitedJSON(t *testing.T) {
+	var out bytes.Buffer
+	if err := newMessageWriter(&out).write(rpcMessage{Method: "ping"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "Content-Length") {
+		t.Fatalf("writer must use newline-delimited framing, got %q", got)
+	}
+	if !strings.HasSuffix(got, "\n") || strings.Count(got, "\n") != 1 {
+		t.Fatalf("expected exactly one trailing newline, got %q", got)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(got), "{") {
+		t.Fatalf("expected a single JSON object line, got %q", got)
+	}
+}
+
+func TestMessageReaderAcceptsNewlineDelimited(t *testing.T) {
+	in := strings.NewReader(`{"jsonrpc":"2.0","method":"tools/list"}` + "\n")
+	msg, err := newMessageReader(in).read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if msg.Method != "tools/list" {
+		t.Fatalf("method=%q want tools/list", msg.Method)
+	}
+}
+
+func TestMessageReaderAcceptsContentLengthFraming(t *testing.T) {
+	body := `{"jsonrpc":"2.0","method":"initialize"}`
+	framed := fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)
+	msg, err := newMessageReader(strings.NewReader(framed)).read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if msg.Method != "initialize" {
+		t.Fatalf("method=%q want initialize", msg.Method)
+	}
+}
+
+func TestMessageReaderRejectsOversizedContentLength(t *testing.T) {
+	// A hostile Content-Length must be rejected before any allocation, not used
+	// to size a make([]byte, n).
+	framed := fmt.Sprintf("Content-Length: %d\r\n\r\n", maxMessageBytes+1)
+	_, err := newMessageReader(strings.NewReader(framed)).read()
+	if err == nil {
+		t.Fatal("expected oversized Content-Length to be rejected")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("expected limit error, got %v", err)
+	}
+}
+
+func TestMessageReaderWriterRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	w := newMessageWriter(&buf)
+	for _, method := range []string{"a", "b", "c"} {
+		if err := w.write(rpcMessage{Method: method}); err != nil {
+			t.Fatalf("write %s: %v", method, err)
+		}
+	}
+	r := newMessageReader(&buf)
+	for _, want := range []string{"a", "b", "c"} {
+		msg, err := r.read()
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if msg.Method != want {
+			t.Fatalf("method=%q want %q", msg.Method, want)
+		}
+	}
+}

--- a/internal/providerhealth/connectivity_client_test.go
+++ b/internal/providerhealth/connectivity_client_test.go
@@ -36,11 +36,27 @@ func TestDialValidatedAddrsFallsBackPastDeadAddress(t *testing.T) {
 
 func TestDialValidatedAddrsReturnsLastErrorWhenAllFail(t *testing.T) {
 	addrs := []netip.Addr{netip.MustParseAddr("203.0.113.1"), netip.MustParseAddr("203.0.113.2")}
+	firstErr := errors.New("first unreachable")
+	lastErr := errors.New("last unreachable")
+	attempts := 0
 	dial := func(_ context.Context, _ string) (net.Conn, error) {
-		return nil, errors.New("unreachable")
+		attempts++
+		if attempts == 1 {
+			return nil, firstErr
+		}
+		return nil, lastErr
 	}
-	if _, err := dialValidatedAddrs(context.Background(), addrs, "443", dial); err == nil {
+	_, err := dialValidatedAddrs(context.Background(), addrs, "443", dial)
+	if err == nil {
 		t.Fatal("expected an error when every address fails to dial")
+	}
+	// Distinct per-attempt errors lock in the "last error wins" contract — a
+	// regression that returned the first failure would otherwise pass.
+	if !errors.Is(err, lastErr) {
+		t.Fatalf("err = %v, want the last attempt's error", err)
+	}
+	if attempts != len(addrs) {
+		t.Fatalf("dialed %d addresses, want %d (every address tried)", attempts, len(addrs))
 	}
 }
 

--- a/internal/providerhealth/connectivity_client_test.go
+++ b/internal/providerhealth/connectivity_client_test.go
@@ -3,11 +3,50 @@ package providerhealth
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/netip"
 	"testing"
 	"time"
 )
+
+func TestDialValidatedAddrsFallsBackPastDeadAddress(t *testing.T) {
+	addrs := []netip.Addr{
+		netip.MustParseAddr("203.0.113.1"), // dead first record
+		netip.MustParseAddr("203.0.113.2"), // reachable second record
+	}
+	var dialed []string
+	dial := func(_ context.Context, address string) (net.Conn, error) {
+		dialed = append(dialed, address)
+		if address == "203.0.113.2:443" {
+			return stubConn{}, nil
+		}
+		return nil, errors.New("connection refused")
+	}
+
+	conn, err := dialValidatedAddrs(context.Background(), addrs, "443", dial)
+	if err != nil {
+		t.Fatalf("expected fallback to the reachable address, got err %v", err)
+	}
+	_ = conn.Close()
+	if len(dialed) != 2 || dialed[0] != "203.0.113.1:443" || dialed[1] != "203.0.113.2:443" {
+		t.Fatalf("expected both addresses dialed in order, got %v", dialed)
+	}
+}
+
+func TestDialValidatedAddrsReturnsLastErrorWhenAllFail(t *testing.T) {
+	addrs := []netip.Addr{netip.MustParseAddr("203.0.113.1"), netip.MustParseAddr("203.0.113.2")}
+	dial := func(_ context.Context, _ string) (net.Conn, error) {
+		return nil, errors.New("unreachable")
+	}
+	if _, err := dialValidatedAddrs(context.Background(), addrs, "443", dial); err == nil {
+		t.Fatal("expected an error when every address fails to dial")
+	}
+}
+
+type stubConn struct{ net.Conn }
+
+func (stubConn) Close() error { return nil }
 
 func TestSafeDialContextRejectsResolvedPrivateAddress(t *testing.T) {
 	dial := safeDialContext(staticResolver{addr: netip.MustParseAddr("10.0.0.5")})

--- a/internal/providerhealth/connectivity_client_test.go
+++ b/internal/providerhealth/connectivity_client_test.go
@@ -1,0 +1,68 @@
+package providerhealth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestSafeDialContextRejectsResolvedPrivateAddress(t *testing.T) {
+	dial := safeDialContext(staticResolver{addr: netip.MustParseAddr("10.0.0.5")})
+
+	conn, err := dial(context.Background(), "tcp", "api.example.com:443")
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("dialed a host that resolved to a private address")
+	}
+	var safety endpointSafetyError
+	if !errors.As(err, &safety) {
+		t.Fatalf("err = %v, want endpointSafetyError", err)
+	}
+}
+
+func TestSafeDialContextRejectsLiteralLinkLocalAddress(t *testing.T) {
+	// The cloud metadata address must be refused even when supplied as a literal,
+	// without consulting the resolver and without opening a socket.
+	dial := safeDialContext(staticResolver{err: errors.New("resolver must not be called")})
+
+	conn, err := dial(context.Background(), "tcp", "169.254.169.254:80")
+	if conn != nil {
+		_ = conn.Close()
+		t.Fatal("dialed a link-local literal address")
+	}
+	var safety endpointSafetyError
+	if !errors.As(err, &safety) {
+		t.Fatalf("err = %v, want endpointSafetyError", err)
+	}
+}
+
+func TestConnectivityClientRefusesRedirectToBlockedHost(t *testing.T) {
+	client := newConnectivityClient(5*time.Second, staticResolver{addr: netip.MustParseAddr("169.254.169.254")})
+	if client.CheckRedirect == nil {
+		t.Fatal("default connectivity client has no CheckRedirect guard")
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://metadata.internal/latest", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if err := client.CheckRedirect(req, nil); err == nil {
+		t.Fatal("CheckRedirect allowed a redirect to a metadata address")
+	}
+}
+
+func TestConnectivityClientRefusesTooManyRedirects(t *testing.T) {
+	client := newConnectivityClient(5*time.Second, staticResolver{addr: netip.MustParseAddr("93.184.216.34")})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/v1/models", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	via := make([]*http.Request, maxConnectivityRedirects)
+	if err := client.CheckRedirect(req, via); err == nil {
+		t.Fatalf("CheckRedirect allowed more than %d redirects", maxConnectivityRedirects)
+	}
+}

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -280,7 +280,7 @@ func connectivityCheck(ctx context.Context, profile config.ProviderProfile, kind
 	}
 	client := options.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = newConnectivityClient(timeout, options.Resolver)
 	}
 	response, err := client.Do(request)
 	if err != nil {
@@ -397,6 +397,75 @@ func validateEndpoint(ctx context.Context, endpoint string, resolver Resolver) e
 		}
 	}
 	return nil
+}
+
+// maxConnectivityRedirects bounds redirect following so a chain of redirects
+// cannot be used to amplify probing or stall the check.
+const maxConnectivityRedirects = 5
+
+// newConnectivityClient builds the HTTP client used for the default (no
+// caller-supplied client) connectivity probe. It is hardened against SSRF:
+//
+//   - CheckRedirect re-validates every redirect target with the same address
+//     rules as the initial endpoint, so a 3xx pointing at an internal address
+//     (e.g. 169.254.169.254) is refused rather than followed blindly.
+//   - the transport's DialContext re-resolves and validates the host at dial
+//     time and then dials the validated IP literal, closing the TOCTOU window
+//     between the pre-flight validateEndpoint check and the actual connection
+//     (DNS rebinding).
+func newConnectivityClient(timeout time.Duration, resolver Resolver) *http.Client {
+	if resolver == nil {
+		resolver = defaultResolver{}
+	}
+	transport, _ := http.DefaultTransport.(*http.Transport)
+	if transport != nil {
+		transport = transport.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	transport.DialContext = safeDialContext(resolver)
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxConnectivityRedirects {
+				return fmt.Errorf("provider connectivity exceeded %d redirects", maxConnectivityRedirects)
+			}
+			return validateEndpoint(req.Context(), req.URL.String(), resolver)
+		},
+	}
+}
+
+// safeDialContext returns a dial function that resolves the target host, refuses
+// the connection if any resolved address is blocked, then dials the validated IP
+// literal so the kernel cannot re-resolve to a different address after the check.
+func safeDialContext(resolver Resolver) func(context.Context, string, string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if addr, parseErr := netip.ParseAddr(host); parseErr == nil {
+			if reason := blockedAddrReason(addr); reason != "" {
+				return nil, endpointSafetyError{message: "provider connectivity URL is unsafe: " + reason}
+			}
+			return dialer.DialContext(ctx, network, address)
+		}
+		addrs, err := resolver.LookupNetIP(ctx, "ip", host)
+		if err != nil {
+			return nil, endpointSafetyError{message: "provider connectivity host could not be resolved safely: " + err.Error()}
+		}
+		if len(addrs) == 0 {
+			return nil, endpointSafetyError{message: "provider connectivity host resolved to no addresses"}
+		}
+		for _, addr := range addrs {
+			if reason := blockedAddrReason(addr); reason != "" {
+				return nil, endpointSafetyError{message: "provider connectivity URL is unsafe: " + reason}
+			}
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(addrs[0].String(), port))
+	}
 }
 
 func blockedAddrReason(addr netip.Addr) string {

--- a/internal/providerhealth/providerhealth.go
+++ b/internal/providerhealth/providerhealth.go
@@ -464,8 +464,29 @@ func safeDialContext(resolver Resolver) func(context.Context, string, string) (n
 				return nil, endpointSafetyError{message: "provider connectivity URL is unsafe: " + reason}
 			}
 		}
-		return dialer.DialContext(ctx, network, net.JoinHostPort(addrs[0].String(), port))
+		// Every resolved address passed validation; dial them in order until one
+		// connects so a dual-stack or multi-record provider isn't failed by a
+		// single dead/unroutable address (e.g. an unreachable IPv6 first record).
+		return dialValidatedAddrs(ctx, addrs, port, func(ctx context.Context, address string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, address)
+		})
 	}
+}
+
+// dialValidatedAddrs dials the already-validated addresses in order and returns
+// the first connection that succeeds, so one dead address among a dual-stack or
+// multi-record answer doesn't fail the whole probe. The last dial error is
+// returned when every address fails.
+func dialValidatedAddrs(ctx context.Context, addrs []netip.Addr, port string, dial func(context.Context, string) (net.Conn, error)) (net.Conn, error) {
+	var dialErr error
+	for _, addr := range addrs {
+		conn, err := dial(ctx, net.JoinHostPort(addr.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		dialErr = err
+	}
+	return nil, dialErr
 }
 
 func blockedAddrReason(addr netip.Addr) string {

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -690,5 +691,20 @@ func (state *streamState) stopTool(ctx context.Context, index int, events chan<-
 func (state *streamState) closeOpen(ctx context.Context, events chan<- zeroruntime.StreamEvent) {
 	for index := range state.tools {
 		state.stopTool(ctx, index, events)
+	}
+	// Finalize any thinking blocks still open at stream end — the SSE ended after
+	// thinking_delta/signature_delta but before content_block_stop. Without this
+	// they never reach state.reasoningBlocks and the synthetic `done` event drops
+	// them, making the next Anthropic replay inconsistent. Finalize in index order
+	// so multiple blocks are preserved in the order Anthropic emitted them.
+	if len(state.thinking) > 0 {
+		indices := make([]int, 0, len(state.thinking))
+		for index := range state.thinking {
+			indices = append(indices, index)
+		}
+		sort.Ints(indices)
+		for _, index := range indices {
+			state.stopThinking(index)
+		}
 	}
 }

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -19,6 +19,54 @@ const defaultBaseURL = "https://api.anthropic.com"
 const defaultVersion = "2023-06-01"
 const defaultMaxTokens = 4096
 
+// providerName tags reasoning blocks this adapter produces so only it replays
+// them (a mid-run switch to another provider ignores foreign blocks).
+const providerName = "anthropic"
+
+// Extended-thinking budget bounds. Anthropic counts thinking tokens against
+// max_tokens and requires a budget of at least 1024, so we reserve room for the
+// actual response on top of the budget.
+const (
+	minThinkingBudget = 1024
+	minResponseTokens = 4096
+)
+
+// thinkingBudgetForEffort maps a requested reasoning effort to a thinking token
+// budget. 0 means "no extended thinking".
+func thinkingBudgetForEffort(effort string) int {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "minimal":
+		return minThinkingBudget
+	case "low":
+		return 4096
+	case "medium":
+		return 10000
+	case "high":
+		return 24000
+	default:
+		return 0
+	}
+}
+
+// resolveThinking returns the thinking budget and the max_tokens to send. When a
+// budget is requested, max_tokens is raised if needed so the budget plus a
+// minimum response both fit (Anthropic rejects budget >= max_tokens). enabled is
+// false when no thinking was requested, leaving the request unchanged.
+func resolveThinking(effort string, maxTokens int) (budget int, effectiveMax int, enabled bool) {
+	budget = thinkingBudgetForEffort(effort)
+	if budget <= 0 {
+		return 0, maxTokens, false
+	}
+	effectiveMax = maxTokens
+	if effectiveMax <= 0 {
+		effectiveMax = defaultMaxTokens
+	}
+	if effectiveMax < budget+minResponseTokens {
+		effectiveMax = budget + minResponseTokens
+	}
+	return budget, effectiveMax, true
+}
+
 // defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
 // without closing the connection, so a stalled-but-open upstream cannot hang the
 // agent forever.
@@ -203,6 +251,10 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 			state.recordUsage(payload.Message.Usage)
 		}
 	case "content_block_start":
+		if payload.ContentBlock != nil && (payload.ContentBlock.Type == "thinking" || payload.ContentBlock.Type == "redacted_thinking") {
+			state.startThinking(payload.Index, payload.ContentBlock)
+			return true
+		}
 		if payload.ContentBlock != nil && payload.ContentBlock.Type == "tool_use" {
 			if payload.ContentBlock.ID == "" || payload.ContentBlock.Name == "" {
 				// A tool_use block without a usable id/name can't be dispatched.
@@ -232,8 +284,11 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 			if payload.Delta.PartialJSON != "" {
 				state.deltaTool(ctx, payload.Index, payload.Delta.PartialJSON, events)
 			}
+		case "thinking_delta", "signature_delta":
+			state.deltaThinking(payload.Index, payload.Delta)
 		}
 	case "content_block_stop":
+		state.stopThinking(payload.Index)
 		state.stopTool(ctx, payload.Index, events)
 	case "message_delta":
 		if payload.Usage != nil {
@@ -278,7 +333,11 @@ func (provider *Provider) emitDone(ctx context.Context, state *streamState, even
 			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventUsage, Usage: usage})
 		}
 	}
-	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone, FinishReason: state.finishReason})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:            zeroruntime.StreamEventDone,
+		FinishReason:    state.finishReason,
+		ReasoningBlocks: state.reasoningBlocks,
+	})
 	state.done = true
 }
 
@@ -310,6 +369,14 @@ func (provider *Provider) anthropicRequest(request zeroruntime.CompletionRequest
 		MaxTokens: provider.maxTokens,
 		Messages:  messages,
 		Stream:    true,
+	}
+	// Extended thinking: enable when a reasoning effort was requested. The budget
+	// is counted against max_tokens, so raise max_tokens to leave room for the
+	// response. Temperature is intentionally left unset (Anthropic requires the
+	// default when thinking is on).
+	if budget, effectiveMax, enabled := resolveThinking(request.ReasoningEffort, provider.maxTokens); enabled {
+		mapped.MaxTokens = effectiveMax
+		mapped.Thinking = &thinkingConfig{Type: "enabled", BudgetTokens: budget}
 	}
 	// Prompt caching: send the (stable, per-run) system prompt as a cacheable text
 	// block so the system instructions + tool definitions are not re-billed on
@@ -360,6 +427,20 @@ func mapMessages(messages []zeroruntime.Message) (string, []anthropicMessage, er
 			}})
 		case zeroruntime.MessageRoleAssistant:
 			blocks := []map[string]any{}
+			// Replay preserved thinking blocks first: Anthropic requires them at the
+			// start of the assistant turn and rejects tool conversations that drop
+			// them. Blocks from other providers are ignored.
+			for _, block := range message.Reasoning {
+				if block.Provider != providerName {
+					continue
+				}
+				switch block.Type {
+				case "thinking":
+					blocks = append(blocks, map[string]any{"type": "thinking", "thinking": block.Text, "signature": block.Signature})
+				case "redacted_thinking":
+					blocks = append(blocks, map[string]any{"type": "redacted_thinking", "data": block.Data})
+				}
+			}
 			if hasContent {
 				blocks = append(blocks, map[string]any{"type": "text", "text": content})
 			}
@@ -479,6 +560,8 @@ type toolBlock struct {
 
 type streamState struct {
 	tools               map[int]toolBlock
+	thinking            map[int]*thinkingBuf // open thinking/redacted_thinking blocks by index
+	reasoningBlocks     []zeroruntime.ReasoningBlock
 	inputTokens         int
 	outputTokens        int
 	cacheReadTokens     int // prompt-cache hits (cheap, re-billed reads)
@@ -487,6 +570,14 @@ type streamState struct {
 	hasOutputUsage      bool
 	finishReason        string // normalized terminal stop reason (empty for normal stop)
 	done                bool
+}
+
+// thinkingBuf accumulates one extended-thinking content block as it streams.
+type thinkingBuf struct {
+	kind      string // "thinking" or "redacted_thinking"
+	text      strings.Builder
+	signature string
+	data      string
 }
 
 // mapStopReason maps Anthropic's message_delta stop_reason onto the runtime's
@@ -500,7 +591,48 @@ func mapStopReason(reason string) string {
 }
 
 func newStreamState() *streamState {
-	return &streamState{tools: make(map[int]toolBlock)}
+	return &streamState{tools: make(map[int]toolBlock), thinking: make(map[int]*thinkingBuf)}
+}
+
+// startThinking opens a thinking/redacted_thinking block at the given index.
+// redacted_thinking arrives whole (its opaque data is on content_block_start).
+func (state *streamState) startThinking(index int, block *contentBlock) {
+	buf := &thinkingBuf{kind: block.Type}
+	if block.Type == "redacted_thinking" {
+		buf.data = block.Data
+	}
+	state.thinking[index] = buf
+}
+
+// deltaThinking applies a thinking_delta (reasoning text) or signature_delta to
+// the open block at the index.
+func (state *streamState) deltaThinking(index int, delta *streamDelta) {
+	buf, ok := state.thinking[index]
+	if !ok {
+		return
+	}
+	if delta.Thinking != "" {
+		buf.text.WriteString(delta.Thinking)
+	}
+	if delta.Signature != "" {
+		buf.signature = delta.Signature
+	}
+}
+
+// stopThinking finalizes the block at the index into a preserved ReasoningBlock.
+func (state *streamState) stopThinking(index int) {
+	buf, ok := state.thinking[index]
+	if !ok {
+		return
+	}
+	state.reasoningBlocks = append(state.reasoningBlocks, zeroruntime.ReasoningBlock{
+		Provider:  providerName,
+		Type:      buf.kind,
+		Text:      buf.text.String(),
+		Signature: buf.signature,
+		Data:      buf.data,
+	})
+	delete(state.thinking, index)
 }
 
 func (state *streamState) recordUsage(usage usage) {

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -311,6 +311,33 @@ func TestStreamCompletionCapturesThinkingBlocksForReplay(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionPreservesUnclosedThinkingBlockAtStreamEnd(t *testing.T) {
+	// The SSE ends after thinking_delta/signature_delta but BEFORE the thinking
+	// block's content_block_stop. The open buffer must still be finalized into the
+	// done event's ReasoningBlocks (via closeOpen), or the next Anthropic replay
+	// drops it and the tool-using conversation is rejected.
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Half a thought"}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-open"}}`)
+		// No content_block_stop for index 0 — the stream just ends here.
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	done := eventsOfType(events, zeroruntime.StreamEventDone)
+	if len(done) != 1 {
+		t.Fatalf("want exactly one done event, got %#v", events)
+	}
+	blocks := done[0].ReasoningBlocks
+	if len(blocks) != 1 {
+		t.Fatalf("reasoning blocks = %#v, want one preserved from the unclosed buffer", blocks)
+	}
+	if blocks[0].Type != "thinking" || blocks[0].Text != "Half a thought" || blocks[0].Signature != "sig-open" {
+		t.Fatalf("reasoning block = %#v", blocks[0])
+	}
+}
+
 func TestAnthropicRequestReplaysThinkingBlocksFirst(t *testing.T) {
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -216,6 +216,154 @@ func TestStreamCompletionReportsCacheTokens(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionEnablesThinkingWhenEffortRequested(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "claude-test", MaxTokens: 64_000})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages:        []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		ReasoningEffort: "high",
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	thinking, ok := gotBody["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking missing from request: %#v", gotBody)
+	}
+	if thinking["type"] != "enabled" {
+		t.Fatalf("thinking.type = %#v, want enabled", thinking["type"])
+	}
+	budget, _ := thinking["budget_tokens"].(float64)
+	if int(budget) != 24000 {
+		t.Fatalf("thinking.budget_tokens = %#v, want 24000", thinking["budget_tokens"])
+	}
+	// max_tokens must stay above the budget so the response has room.
+	if mt, _ := gotBody["max_tokens"].(float64); int(mt) <= int(budget) {
+		t.Fatalf("max_tokens %#v must exceed thinking budget %v", gotBody["max_tokens"], budget)
+	}
+}
+
+func TestStreamCompletionOmitsThinkingWithoutEffort(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "claude-test", MaxTokens: 64_000})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if _, ok := gotBody["thinking"]; ok {
+		t.Fatalf("thinking should be omitted without effort: %#v", gotBody["thinking"])
+	}
+	if mt, _ := gotBody["max_tokens"].(float64); int(mt) != 64_000 {
+		t.Fatalf("max_tokens = %#v, want unchanged 64000", gotBody["max_tokens"])
+	}
+}
+
+func TestStreamCompletionCapturesThinkingBlocksForReplay(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}`)
+		writeSSEEvent(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-abc"}}`)
+		writeSSEEvent(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"grep","input":{}}}`)
+		writeSSEEvent(w, "content_block_stop", `{"type":"content_block_stop","index":1}`)
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	done := eventsOfType(events, zeroruntime.StreamEventDone)
+	if len(done) != 1 {
+		t.Fatalf("want exactly one done event, got %#v", events)
+	}
+	blocks := done[0].ReasoningBlocks
+	if len(blocks) != 1 {
+		t.Fatalf("reasoning blocks = %#v, want one", blocks)
+	}
+	if blocks[0].Provider != providerName || blocks[0].Type != "thinking" || blocks[0].Text != "Let me think" || blocks[0].Signature != "sig-abc" {
+		t.Fatalf("reasoning block = %#v", blocks[0])
+	}
+}
+
+func TestAnthropicRequestReplaysThinkingBlocksFirst(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSEEvent(w, "message_stop", `{"type":"message_stop"}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "claude-test"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "go"},
+			{
+				Role:      zeroruntime.MessageRoleAssistant,
+				Content:   "I will grep.",
+				ToolCalls: []zeroruntime.ToolCall{{ID: "toolu_1", Name: "grep", Arguments: `{"pattern":"x"}`}},
+				Reasoning: []zeroruntime.ReasoningBlock{{Provider: providerName, Type: "thinking", Text: "reasoning", Signature: "sig-abc"}},
+			},
+			{Role: zeroruntime.MessageRoleTool, Content: "result", ToolCallID: "toolu_1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	messages := gotBody["messages"].([]any)
+	var assistant map[string]any
+	for _, raw := range messages {
+		m := raw.(map[string]any)
+		if m["role"] == "assistant" {
+			assistant = m
+			break
+		}
+	}
+	if assistant == nil {
+		t.Fatalf("no assistant message in %#v", messages)
+	}
+	blocks, ok := assistant["content"].([]any)
+	if !ok || len(blocks) == 0 {
+		t.Fatalf("assistant content = %#v, want block array", assistant["content"])
+	}
+	first := blocks[0].(map[string]any)
+	if first["type"] != "thinking" || first["thinking"] != "reasoning" || first["signature"] != "sig-abc" {
+		t.Fatalf("first block = %#v, want thinking block replayed first", first)
+	}
+}
+
 func TestStreamCompletionEmitsToolUseBlocks(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSEEvent(w, "content_block_start", `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file","input":{}}}`)

--- a/internal/providers/anthropic/types.go
+++ b/internal/providers/anthropic/types.go
@@ -7,9 +7,20 @@ type messagesRequest struct {
 	// System is either a plain string or a []systemBlock when prompt caching is
 	// enabled (Anthropic accepts both). The block form lets us attach a
 	// cache_control breakpoint to the stable system prompt.
-	System any             `json:"system,omitempty"`
-	Tools  []anthropicTool `json:"tools,omitempty"`
-	Stream bool            `json:"stream"`
+	System any `json:"system,omitempty"`
+	// Thinking enables extended thinking when a reasoning effort was requested.
+	// Omitted (nil) for normal requests so behavior is unchanged.
+	Thinking *thinkingConfig `json:"thinking,omitempty"`
+	Tools    []anthropicTool `json:"tools,omitempty"`
+	Stream   bool            `json:"stream"`
+}
+
+// thinkingConfig requests extended thinking with a token budget. Type is always
+// "enabled"; BudgetTokens is how many tokens the model may spend thinking (it is
+// counted against max_tokens).
+type thinkingConfig struct {
+	Type         string `json:"type"`
+	BudgetTokens int    `json:"budget_tokens"`
 }
 
 type anthropicMessage struct {
@@ -60,6 +71,9 @@ type contentBlock struct {
 	ID    string         `json:"id"`
 	Name  string         `json:"name"`
 	Input map[string]any `json:"input"`
+	// Data is the opaque payload of a redacted_thinking block (delivered whole in
+	// content_block_start, with no deltas).
+	Data string `json:"data"`
 }
 
 type streamDelta struct {
@@ -67,6 +81,10 @@ type streamDelta struct {
 	Text        string `json:"text"`
 	PartialJSON string `json:"partial_json"`
 	StopReason  string `json:"stop_reason"`
+	// Thinking/Signature carry extended-thinking deltas: thinking_delta streams the
+	// reasoning text, signature_delta delivers the block's verification signature.
+	Thinking  string `json:"thinking"`
+	Signature string `json:"signature"`
 }
 
 type usage struct {

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -19,6 +19,28 @@ import (
 const defaultBaseURL = "https://generativelanguage.googleapis.com"
 const defaultMaxTokens = 8192
 
+// providerName tags reasoning signatures this adapter binds to a tool call so
+// only it replays them.
+const providerName = "gemini"
+
+// thinkingBudgetForEffort maps a requested reasoning effort to a Gemini thinking
+// token budget, capped at 24576 (the lowest per-model ceiling among 2.5 models).
+// 0 means "no thinking config" (leave the request unchanged).
+func thinkingBudgetForEffort(effort string) int {
+	switch strings.ToLower(strings.TrimSpace(effort)) {
+	case "minimal":
+		return 1024
+	case "low":
+		return 4096
+	case "medium":
+		return 8192
+	case "high":
+		return 24576
+	default:
+		return 0
+	}
+}
+
 // defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
 // without closing the connection, so a stalled-but-open upstream cannot hang the
 // agent forever.
@@ -214,6 +236,10 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 			continue
 		}
 		for _, part := range candidate.Content.Parts {
+			// Skip thought summary parts: their text is reasoning, not the answer.
+			if part.Thought {
+				continue
+			}
 			if part.Text != "" {
 				providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: part.Text})
 			}
@@ -226,7 +252,9 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 					continue
 				}
 				state.syntheticToolIndex++
-				if !provider.emitToolCall(ctx, *part.FunctionCall, state.syntheticToolIndex, events) {
+				// The thought signature rides on the part beside the functionCall;
+				// preserve it for replay.
+				if !provider.emitToolCall(ctx, *part.FunctionCall, part.ThoughtSignature, state.syntheticToolIndex, events) {
 					state.done = true
 					return false
 				}
@@ -241,7 +269,7 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 			continue
 		}
 		state.syntheticToolIndex++
-		if !provider.emitToolCall(ctx, functionCall, state.syntheticToolIndex, events) {
+		if !provider.emitToolCall(ctx, functionCall, "", state.syntheticToolIndex, events) {
 			state.done = true
 			return false
 		}
@@ -264,7 +292,7 @@ func (provider *Provider) emitDone(ctx context.Context, state *streamState, even
 	state.done = true
 }
 
-func (provider *Provider) emitToolCall(ctx context.Context, functionCall functionCall, syntheticIndex int, events chan<- zeroruntime.StreamEvent) bool {
+func (provider *Provider) emitToolCall(ctx context.Context, functionCall functionCall, signature string, syntheticIndex int, events chan<- zeroruntime.StreamEvent) bool {
 	id := functionCall.ID
 	if id == "" {
 		id = fmt.Sprintf("gemini_tool_%d", syntheticIndex)
@@ -279,7 +307,7 @@ func (provider *Provider) emitToolCall(ctx context.Context, functionCall functio
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider error: " + err.Error())})
 		return false
 	}
-	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: id, ToolName: functionCall.Name})
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: id, ToolName: functionCall.Name, ToolCallSignature: signature})
 	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: id, ArgumentsFragment: string(encoded)})
 	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: id})
 	return true
@@ -312,6 +340,11 @@ func (provider *Provider) geminiRequest(request zeroruntime.CompletionRequest) (
 		SystemInstruction: systemInstruction,
 		Contents:          contents,
 		GenerationConfig:  generationConfig{MaxOutputTokens: provider.maxTokens},
+	}
+	// Thinking: enable a budget when a reasoning effort was requested. Omitted
+	// otherwise so default requests are unchanged.
+	if budget := thinkingBudgetForEffort(request.ReasoningEffort); budget > 0 {
+		mapped.GenerationConfig.ThinkingConfig = &thinkingConfig{ThinkingBudget: budget}
 	}
 	if len(request.Tools) > 0 {
 		declarations := make([]geminiFunctionDeclaration, 0, len(request.Tools))
@@ -366,11 +399,16 @@ func mapMessages(messages []zeroruntime.Message) (*geminiContent, []geminiConten
 					return nil, nil, err
 				}
 				toolNamesByID[toolCall.ID] = toolCall.Name
-				parts = append(parts, geminiPart{FunctionCall: &geminiFunctionCall{
-					ID:   toolCall.ID,
-					Name: toolCall.Name,
-					Args: args,
-				}})
+				parts = append(parts, geminiPart{
+					FunctionCall: &geminiFunctionCall{
+						ID:   toolCall.ID,
+						Name: toolCall.Name,
+						Args: args,
+					},
+					// Replay the thought signature so multi-turn function calling with
+					// thinking is not rejected. Empty for non-thinking runs.
+					ThoughtSignature: toolCall.Signature,
+				})
 			}
 			if len(parts) > 0 {
 				contents = append(contents, geminiContent{Role: "model", Parts: parts})

--- a/internal/providers/gemini/provider_test.go
+++ b/internal/providers/gemini/provider_test.go
@@ -116,6 +116,126 @@ func TestStreamCompletionPostsGenerateContentRequest(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionEnablesThinkingWhenEffortRequested(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"usageMetadata":{"promptTokenCount":1}}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{APIKey: "k", BaseURL: server.URL + "/", Model: "models/gemini-2.5-flash", MaxTokens: 65_536})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages:        []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		ReasoningEffort: "medium",
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	cfg := gotBody["generationConfig"].(map[string]any)
+	thinking, ok := cfg["thinkingConfig"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinkingConfig missing: %#v", cfg)
+	}
+	if budget, _ := thinking["thinkingBudget"].(float64); int(budget) != 8192 {
+		t.Fatalf("thinkingBudget = %#v, want 8192", thinking["thinkingBudget"])
+	}
+}
+
+func TestStreamCompletionOmitsThinkingWithoutEffort(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"usageMetadata":{"promptTokenCount":1}}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{APIKey: "k", BaseURL: server.URL + "/", Model: "models/gemini-2.5-flash", MaxTokens: 65_536})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	cfg := gotBody["generationConfig"].(map[string]any)
+	if _, ok := cfg["thinkingConfig"]; ok {
+		t.Fatalf("thinkingConfig should be omitted without effort: %#v", cfg["thinkingConfig"])
+	}
+}
+
+func TestStreamCompletionCapturesThoughtSignatureAndSkipsThoughtText(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		// A thought-summary part (must not surface as answer text) followed by a
+		// functionCall part carrying its thoughtSignature.
+		writeSSE(w, `{"candidates":[{"content":{"parts":[{"thought":true,"text":"internal reasoning"},{"functionCall":{"name":"grep","args":{"pattern":"x"}},"thoughtSignature":"sig-xyz"}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	for _, event := range events {
+		if event.Type == zeroruntime.StreamEventText && strings.Contains(event.Content, "internal reasoning") {
+			t.Fatalf("thought text leaked into answer: %#v", event)
+		}
+	}
+	starts := eventsOfType(events, zeroruntime.StreamEventToolCallStart)
+	if len(starts) != 1 {
+		t.Fatalf("want one tool-call start, got %#v", events)
+	}
+	if starts[0].ToolCallSignature != "sig-xyz" {
+		t.Fatalf("tool call signature = %q, want sig-xyz", starts[0].ToolCallSignature)
+	}
+}
+
+func TestGeminiRequestReplaysThoughtSignature(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `{"usageMetadata":{"promptTokenCount":1}}`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{APIKey: "k", BaseURL: server.URL + "/", Model: "models/gemini-2.5-flash"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "go"},
+			{
+				Role:      zeroruntime.MessageRoleAssistant,
+				ToolCalls: []zeroruntime.ToolCall{{ID: "call_1", Name: "grep", Arguments: `{"pattern":"x"}`, Signature: "sig-xyz"}},
+			},
+			{Role: zeroruntime.MessageRoleTool, Content: "result", ToolCallID: "call_1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	contents := gotBody["contents"].([]any)
+	modelParts := contents[1].(map[string]any)["parts"].([]any)
+	part := modelParts[0].(map[string]any)
+	if part["thoughtSignature"] != "sig-xyz" {
+		t.Fatalf("functionCall part missing replayed thoughtSignature: %#v", part)
+	}
+}
+
 func TestStreamCompletionAppliesCustomAuthAndHeaders(t *testing.T) {
 	var gotDefaultAuth string
 	var gotCustomAuth string

--- a/internal/providers/gemini/types.go
+++ b/internal/providers/gemini/types.go
@@ -12,9 +12,11 @@ type generationConfig struct {
 	ThinkingConfig  *thinkingConfig `json:"thinkingConfig,omitempty"`
 }
 
-// thinkingConfig requests a thinking token budget. Omitted (nil) for normal
-// requests so behavior is unchanged. IncludeThoughts is left false so thought
-// summaries are not streamed as answer text.
+// thinkingConfig requests a thinking token budget. It is omitted (nil) for
+// normal requests so behavior is unchanged, and is only set when the effort maps
+// to a positive budget — so Gemini is never sent {"thinkingBudget":0}. There is
+// no IncludeThoughts request field here; thought summaries are suppressed on the
+// response side by skipping streamed parts whose part.Thought is true.
 type thinkingConfig struct {
 	ThinkingBudget int `json:"thinkingBudget"`
 }

--- a/internal/providers/gemini/types.go
+++ b/internal/providers/gemini/types.go
@@ -8,7 +8,15 @@ type generateContentRequest struct {
 }
 
 type generationConfig struct {
-	MaxOutputTokens int `json:"maxOutputTokens"`
+	MaxOutputTokens int             `json:"maxOutputTokens"`
+	ThinkingConfig  *thinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+// thinkingConfig requests a thinking token budget. Omitted (nil) for normal
+// requests so behavior is unchanged. IncludeThoughts is left false so thought
+// summaries are not streamed as answer text.
+type thinkingConfig struct {
+	ThinkingBudget int `json:"thinkingBudget"`
 }
 
 type geminiContent struct {
@@ -21,6 +29,9 @@ type geminiPart struct {
 	InlineData       *geminiInlineData       `json:"inlineData,omitempty"`
 	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+	// ThoughtSignature replays the reasoning signature Gemini bound to a
+	// functionCall, required for multi-turn function calling with thinking.
+	ThoughtSignature string `json:"thoughtSignature,omitempty"`
 }
 
 type geminiInlineData struct {
@@ -69,8 +80,10 @@ type candidateContent struct {
 }
 
 type streamPart struct {
-	Text         string        `json:"text"`
-	FunctionCall *functionCall `json:"functionCall"`
+	Text             string        `json:"text"`
+	FunctionCall     *functionCall `json:"functionCall"`
+	ThoughtSignature string        `json:"thoughtSignature"`
+	Thought          bool          `json:"thought"`
 }
 
 type functionCall struct {

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -325,6 +325,12 @@ func (provider *Provider) openAIRequest(request zeroruntime.CompletionRequest) c
 	if provider.maxTokens > 0 {
 		mapped.MaxCompletionTokens = provider.maxTokens
 	}
+	// reasoning_effort is only valid for reasoning models; callers gate it against
+	// the model's capabilities, so an empty value (the default for non-reasoning
+	// models) is simply omitted. Only forward the values the API accepts.
+	if effort := openAIReasoningEffort(request.ReasoningEffort); effort != "" {
+		mapped.ReasoningEffort = effort
+	}
 	if len(request.Tools) > 0 {
 		mapped.Tools = make([]toolDefinition, 0, len(request.Tools))
 		for _, tool := range request.Tools {
@@ -339,6 +345,18 @@ func (provider *Provider) openAIRequest(request zeroruntime.CompletionRequest) c
 		}
 	}
 	return mapped
+}
+
+// openAIReasoningEffort normalizes a requested effort to a value the OpenAI chat
+// completions API accepts, or "" to omit the field. "none" (and anything else)
+// is dropped rather than risking a 400 on an unrecognized enum.
+func openAIReasoningEffort(requested string) string {
+	switch strings.ToLower(strings.TrimSpace(requested)) {
+	case "minimal", "low", "medium", "high":
+		return strings.ToLower(strings.TrimSpace(requested))
+	default:
+		return ""
+	}
 }
 
 func mapMessage(message zeroruntime.Message) chatMessage {

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -552,6 +552,66 @@ func TestStreamCompletionSendsMaxCompletionTokens(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionSendsReasoningEffort(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		writeSSE(w, `[DONE]`)
+	}))
+	defer server.Close()
+
+	provider, err := New(Options{BaseURL: server.URL + "/", Model: "o3"})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages:        []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+		ReasoningEffort: "high",
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned error: %v", err)
+	}
+	drain(stream)
+
+	if got := gotBody["reasoning_effort"]; got != "high" {
+		t.Fatalf("reasoning_effort = %#v, want \"high\"", got)
+	}
+}
+
+func TestStreamCompletionOmitsReasoningEffortWhenUnsetOrInvalid(t *testing.T) {
+	for _, effort := range []string{"", "none", "bogus"} {
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			writeSSE(w, `[DONE]`)
+		}))
+
+		provider, err := New(Options{BaseURL: server.URL + "/", Model: "gpt-test"})
+		if err != nil {
+			server.Close()
+			t.Fatalf("New returned error: %v", err)
+		}
+		stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+			Messages:        []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+			ReasoningEffort: effort,
+		})
+		if err != nil {
+			server.Close()
+			t.Fatalf("StreamCompletion returned error: %v", err)
+		}
+		drain(stream)
+		server.Close()
+
+		if _, ok := gotBody["reasoning_effort"]; ok {
+			t.Fatalf("reasoning_effort should be omitted for %q: %#v", effort, gotBody["reasoning_effort"])
+		}
+	}
+}
+
 func TestStreamCompletionOmitsMaxCompletionTokensWhenUnset(t *testing.T) {
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/openai/types.go
+++ b/internal/providers/openai/types.go
@@ -5,6 +5,7 @@ type chatCompletionRequest struct {
 	Messages            []chatMessage    `json:"messages"`
 	Tools               []toolDefinition `json:"tools,omitempty"`
 	MaxCompletionTokens int              `json:"max_completion_tokens,omitempty"`
+	ReasoningEffort     string           `json:"reasoning_effort,omitempty"`
 	Stream              bool             `json:"stream"`
 	StreamOptions       *streamOptions   `json:"stream_options,omitempty"`
 }

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -259,6 +259,36 @@ func defaultPath() string {
 	return "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 }
 
+// sandboxWritableDevices are the standard character devices that virtually every
+// command needs to write to (e.g. `> /dev/null`). The bubblewrap backend exposes
+// these via `--dev /dev`; the sandbox-exec profile must allow them explicitly or
+// the equivalent operations fail with "Operation not permitted".
+var sandboxWritableDevices = []string{
+	"/dev/null",
+	"/dev/zero",
+	"/dev/random",
+	"/dev/urandom",
+	"/dev/stdin",
+	"/dev/stdout",
+	"/dev/stderr",
+	"/dev/tty",
+	"/dev/dtracehelper",
+}
+
+// sandboxWritableSubpaths are non-workspace trees the sandbox-exec profile must
+// keep writable for parity with the bubblewrap backend's writable /tmp tmpfs.
+// macOS resolves /tmp and /var to their /private counterparts before the sandbox
+// check, so both forms are listed. /dev/fd covers process-substitution writes.
+var sandboxWritableSubpaths = []string{
+	"/tmp",
+	"/private/tmp",
+	"/var/tmp",
+	"/private/var/tmp",
+	"/var/folders",
+	"/private/var/folders",
+	"/dev/fd",
+}
+
 func sandboxExecProfile(workspaceRoot string, policy Policy) string {
 	networkRule := "(deny network*)"
 	if policy.Network == NetworkAllow {
@@ -266,7 +296,17 @@ func sandboxExecProfile(workspaceRoot string, policy Policy) string {
 	}
 	writeRule := "(allow file-write*)"
 	if policy.EnforceWorkspace {
-		writeRule = `(allow file-write* (subpath "` + sandboxProfileString(workspaceRoot) + `"))`
+		// The workspace is the only writable *project* location. Temp trees and the
+		// standard device nodes are the only additions, matching what the bubblewrap
+		// backend already grants (--tmpfs /tmp, --dev /dev).
+		filters := []string{`(subpath "` + sandboxProfileString(workspaceRoot) + `")`}
+		for _, subpath := range sandboxWritableSubpaths {
+			filters = append(filters, `(subpath "`+subpath+`")`)
+		}
+		for _, device := range sandboxWritableDevices {
+			filters = append(filters, `(literal "`+device+`")`)
+		}
+		writeRule = "(allow file-write*\n  " + strings.Join(filters, "\n  ") + ")"
 	}
 	return strings.Join([]string{
 		"(version 1)",

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -1,9 +1,11 @@
 package sandbox
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -80,7 +82,13 @@ func TestBuildCommandPlanWrapsSandboxExec(t *testing.T) {
 		t.Fatalf("sandbox-exec args = %#v, want profile and command", plan.Args)
 	}
 	profile := plan.Args[1]
-	for _, want := range []string{"(deny default)", "(deny network*)", `(allow file-write* (subpath "` + sandboxProfileString(resolvedRoot) + `"))`} {
+	for _, want := range []string{
+		"(deny default)",
+		"(deny network*)",
+		`(subpath "` + sandboxProfileString(resolvedRoot) + `")`,
+		`(literal "/dev/null")`,
+		`(subpath "/private/tmp")`,
+	} {
 		if !strings.Contains(profile, want) {
 			t.Fatalf("profile missing %q:\n%s", want, profile)
 		}
@@ -161,6 +169,46 @@ func assertArgsContainSequence(t *testing.T, args []string, sequence ...string) 
 		}
 	}
 	t.Fatalf("args %#v do not contain sequence %#v", args, sequence)
+}
+
+// TestSandboxExecProfileAllowsDevNullAndTemp reproduces the audit finding that
+// the generated sandbox-exec profile blocked `> /dev/null` and mktemp because
+// only the workspace was writable. It runs real commands through sandbox-exec
+// when that backend is available on the host.
+func TestSandboxExecProfileAllowsDevNullAndTemp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is macOS-only")
+	}
+	backend := SelectBackend(BackendOptions{})
+	if !backend.Available || backend.Name != BackendSandboxExec {
+		t.Skipf("sandbox-exec backend unavailable: %s", backend.Message)
+	}
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Backend: backend})
+
+	run := func(script string) (string, error) {
+		command, _, err := engine.CommandContext(context.Background(), CommandSpec{
+			Name: "/bin/sh",
+			Args: []string{"-c", script},
+			Dir:  root,
+		})
+		if err != nil {
+			return "", err
+		}
+		out, runErr := command.CombinedOutput()
+		return string(out), runErr
+	}
+
+	for _, script := range []string{"echo hi > /dev/null", "mktemp"} {
+		if out, err := run(script); err != nil {
+			t.Fatalf("sandboxed %q failed: %v\noutput: %s", script, err, out)
+		}
+	}
+
+	// The workspace remains writable; a sibling write still lands.
+	if out, err := run("echo ok > probe.txt && cat probe.txt"); err != nil {
+		t.Fatalf("workspace write failed: %v\noutput: %s", err, out)
+	}
 }
 
 func resolvedTestPath(t *testing.T, path string) string {

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -536,14 +536,28 @@ func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
 		}
 		return nil, fmt.Errorf("read zero session events: %w", err)
 	}
+	lines := bytes.Split(data, []byte{'\n'})
+	lastNonEmpty := -1
+	for index, line := range lines {
+		if len(bytes.TrimSpace(line)) > 0 {
+			lastNonEmpty = index
+		}
+	}
 	events := []Event{}
-	for index, line := range bytes.Split(data, []byte{'\n'}) {
+	for index, line := range lines {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
 		}
 		var event Event
 		if err := json.Unmarshal(line, &event); err != nil {
+			// Tolerate a torn tail: a crash mid-append leaves the final line
+			// truncated. Drop that partial record so resume still recovers every
+			// complete event. A malformed line anywhere earlier is real corruption
+			// and still fails loudly.
+			if index == lastNonEmpty {
+				break
+			}
 			return nil, fmt.Errorf("invalid json in zero session %s %s at line %d: %w", sessionID, EventsFile, index+1, err)
 		}
 		events = append(events, event)

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -536,6 +536,11 @@ func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
 		}
 		return nil, fmt.Errorf("read zero session events: %w", err)
 	}
+	// A genuine torn tail is an INCOMPLETE final write — a crash mid-append leaves
+	// the last line without its terminating newline. If the file ends with a
+	// newline, every record was fully flushed, so a malformed final line is real
+	// corruption and must still fail loudly.
+	tornTailPossible := len(data) > 0 && data[len(data)-1] != '\n'
 	lines := bytes.Split(data, []byte{'\n'})
 	lastNonEmpty := -1
 	for index, line := range lines {
@@ -552,10 +557,11 @@ func (store *Store) ReadEvents(sessionID string) ([]Event, error) {
 		var event Event
 		if err := json.Unmarshal(line, &event); err != nil {
 			// Tolerate a torn tail: a crash mid-append leaves the final line
-			// truncated. Drop that partial record so resume still recovers every
-			// complete event. A malformed line anywhere earlier is real corruption
-			// and still fails loudly.
-			if index == lastNonEmpty {
+			// truncated (and thus without a trailing newline). Drop that partial
+			// record so resume still recovers every complete event. A malformed
+			// line anywhere earlier — or a complete-but-corrupt final line — is real
+			// corruption and still fails loudly.
+			if index == lastNonEmpty && tornTailPossible {
 				break
 			}
 			return nil, fmt.Errorf("invalid json in zero session %s %s at line %d: %w", sessionID, EventsFile, index+1, err)

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -84,6 +84,61 @@ func TestStoreCreatesAppendsListsAndReadsEvents(t *testing.T) {
 	}
 }
 
+func TestReadEventsToleratesTornTail(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T10:00:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "zero_torn_1", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "ok"}}); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+	// Simulate a crash mid-append: a truncated final JSON line.
+	file, err := os.OpenFile(store.eventsPath(session.SessionID), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open events: %v", err)
+	}
+	if _, err := file.WriteString(`{"type":"message","payload":{"content":"tru`); err != nil {
+		t.Fatalf("write torn line: %v", err)
+	}
+	file.Close()
+
+	events, err := store.ReadEvents(session.SessionID)
+	if err != nil {
+		t.Fatalf("ReadEvents must tolerate a torn tail, got error: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 complete events (torn tail dropped), got %d", len(events))
+	}
+}
+
+func TestReadEventsFailsOnMidFileCorruption(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T10:00:00Z")})
+	session, err := store.Create(CreateInput{SessionID: "zero_corrupt_1", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "ok"}}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	// A corrupt line BEFORE a later valid line is real corruption, not a torn
+	// tail, and must still fail loudly.
+	file, err := os.OpenFile(store.eventsPath(session.SessionID), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open events: %v", err)
+	}
+	if _, err := file.WriteString("not json\n" + `{"type":"message","payload":{}}` + "\n"); err != nil {
+		t.Fatalf("write corruption: %v", err)
+	}
+	file.Close()
+
+	if _, err := store.ReadEvents(session.SessionID); err == nil {
+		t.Fatal("expected error on mid-file corruption")
+	}
+}
+
 func TestStoreForkCopiesEventsAndLineage(t *testing.T) {
 	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T11:00:00Z")})
 	parent, err := store.Create(CreateInput{SessionID: "parent", Title: "Parent", Cwd: "/repo", ModelID: "gpt-4.1", Provider: "openai"})

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -103,7 +103,9 @@ func TestReadEventsToleratesTornTail(t *testing.T) {
 	if _, err := file.WriteString(`{"type":"message","payload":{"content":"tru`); err != nil {
 		t.Fatalf("write torn line: %v", err)
 	}
-	file.Close()
+	if err := file.Close(); err != nil {
+		t.Fatalf("close events: %v", err)
+	}
 
 	events, err := store.ReadEvents(session.SessionID)
 	if err != nil {
@@ -132,7 +134,9 @@ func TestReadEventsFailsOnMidFileCorruption(t *testing.T) {
 	if _, err := file.WriteString("not json\n" + `{"type":"message","payload":{}}` + "\n"); err != nil {
 		t.Fatalf("write corruption: %v", err)
 	}
-	file.Close()
+	if err := file.Close(); err != nil {
+		t.Fatalf("close events: %v", err)
+	}
 
 	if _, err := store.ReadEvents(session.SessionID); err == nil {
 		t.Fatal("expected error on mid-file corruption")

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -163,8 +163,15 @@ func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error
 	if parentToolUseID := strings.TrimSpace(input.ParentToolUseID); parentToolUseID != "" {
 		args = append(args, "--calling-tool-use-id", parentToolUseID)
 	}
+	// Always record the specialist name in the session title. AgentName is
+	// derived from the title's "name:" prefix, and resume refuses a session whose
+	// AgentName is empty — so a description-less run (description is optional)
+	// must still carry the name or it can never be resumed.
+	name := strings.TrimSpace(input.Manifest.Metadata.Name)
 	if description := strings.TrimSpace(input.Description); description != "" {
-		args = append(args, "--session-title", strings.TrimSpace(input.Manifest.Metadata.Name)+": "+description)
+		args = append(args, "--session-title", name+": "+description)
+	} else {
+		args = append(args, "--session-title", name)
 	}
 	if cwd := strings.TrimSpace(input.Cwd); cwd != "" {
 		args = append(args, "--cwd", cwd)

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -64,6 +64,36 @@ func TestBuildArgsCreatesFreshSpecialistExecInvocation(t *testing.T) {
 	}
 }
 
+func TestBuildArgsSessionTitleFallsBackToNameWithoutDescription(t *testing.T) {
+	executor := Executor{NewSessionID: func() (string, error) { return "child", nil }}
+	manifest := Manifest{
+		Metadata:      Metadata{Name: "reviewer", Description: "Reviews code"},
+		SystemPrompt:  "Review carefully.",
+		ResolvedTools: []string{"read_file"},
+	}
+
+	// Description is optional. When omitted, the session title must still carry
+	// the specialist name so AgentName (derived from the title) is non-empty and
+	// the session remains resumable.
+	result, err := executor.BuildArgs(BuildArgsInput{
+		Manifest: manifest,
+		Prompt:   "Do the thing",
+	})
+	if err != nil {
+		t.Fatalf("BuildArgs returned error: %v", err)
+	}
+	if !containsSequence(result.Args, []string{"--session-title", "reviewer"}) {
+		t.Fatalf("args missing name-only session title: %#v", result.Args)
+	}
+	for index, arg := range result.Args {
+		if arg == "--session-title" && index+1 < len(result.Args) {
+			if got := result.Args[index+1]; got != "reviewer" {
+				t.Fatalf("session title = %q, want %q", got, "reviewer")
+			}
+		}
+	}
+}
+
 func TestBuildArgsInheritsParentModelAndReasoning(t *testing.T) {
 	executor := Executor{NewSessionID: func() (string, error) { return "child", nil }}
 	manifest := Manifest{

--- a/internal/streamjson/streamjson.go
+++ b/internal/streamjson/streamjson.go
@@ -307,9 +307,14 @@ func isValidID(value string) bool {
 }
 
 var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`sk-[A-Za-z0-9._-]+`),
+	// OpenAI-style keys: anchor on a word boundary and require a long key body so
+	// "sk-" inside ordinary words (e.g. "task-list") is never redacted while real
+	// keys ("sk-proj-…", "sk-…") still are.
+	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{16,}`),
 	regexp.MustCompile(`(?i)(api[_-]?key["'=:\s]+)[^"',\s)]+`),
-	regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._-]+`),
+	// Bearer tokens: require a credential-length token so prose such as
+	// "bearer of bad news" or "bearer token" is not mistaken for a secret.
+	regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._-]{16,}`),
 }
 
 func redactValue(value any) any {

--- a/internal/streamjson/streamjson_test.go
+++ b/internal/streamjson/streamjson_test.go
@@ -8,6 +8,33 @@ import (
 	"time"
 )
 
+func TestRedactStringDoesNotOverMatchProse(t *testing.T) {
+	// Ordinary prose must survive: the old unanchored patterns redacted "sk-"
+	// inside "task-list" and the word after a bare "bearer".
+	for _, clean := range []string{
+		"updated the task-list and the task-runner",
+		"the bearer of bad news arrived",
+		"set the bearer token in the header",
+	} {
+		if got := redactString(clean); got != clean {
+			t.Fatalf("redactString(%q) = %q, want unchanged", clean, got)
+		}
+	}
+
+	// Real secrets must still be redacted.
+	for _, secret := range []string{
+		"sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+		"Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdef",
+	} {
+		if got := redactString(secret); strings.Contains(got, "abcdef") && !strings.Contains(got, "[REDACTED]") {
+			t.Fatalf("redactString(%q) = %q, expected redaction", secret, got)
+		}
+		if !strings.Contains(redactString(secret), "[REDACTED]") {
+			t.Fatalf("redactString(%q) did not redact", secret)
+		}
+	}
+}
+
 func TestFormatEventRedactsSecretsAndSerializesOneLine(t *testing.T) {
 	secret := "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789"
 

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -193,9 +193,25 @@ func patchHeaderPaths(patch string) []string {
 
 // parseHunkCounts reads the old/new line counts from a "@@ -a,b +c,d @@" header.
 // A missing count (e.g. "@@ -a +c @@") means 1 per unified-diff convention.
+//
+// Only the range section BETWEEN the opening and closing "@@" is parsed. A hunk
+// header may carry a free-form section heading after the closing "@@" (e.g.
+// "@@ -1,1 +1,1 @@ func foo()"), and that text can itself contain "+"/"-"
+// tokens. Scanning the whole line would let a crafted heading like
+// "@@ -1,1 +1,1 @@ +1,999999" overwrite the real count, keep the parser stuck in
+// hunk mode, and swallow later "--- "/"+++ " file headers so they escape
+// validatePatchPaths / recheckPatchWriteTargets — a workspace-confinement bypass.
 func parseHunkCounts(line string) (int, int) {
+	_, rest, ok := strings.Cut(line, "@@")
+	if !ok {
+		return 0, 0
+	}
+	rangeSection := rest
+	if before, _, ok := strings.Cut(rest, "@@"); ok {
+		rangeSection = before // drop the section heading after the closing "@@"
+	}
 	old, next := 0, 0
-	for _, field := range strings.Fields(line) {
+	for _, field := range strings.Fields(rangeSection) {
 		switch {
 		case strings.HasPrefix(field, "-"):
 			old = hunkCount(field[1:])

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -101,70 +102,118 @@ func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result 
 func changedFilesFromPatch(relativeRoot string, patch string) []string {
 	seen := map[string]bool{}
 	var paths []string
-	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
-		for _, path := range patchPathsFromLine(line) {
-			if path == "" || path == "/dev/null" {
-				continue
-			}
-			workspacePath := path
-			if relativeRoot != "" && relativeRoot != "." {
-				workspacePath = filepath.ToSlash(filepath.Join(relativeRoot, path))
-			}
-			if seen[workspacePath] {
-				continue
-			}
-			seen[workspacePath] = true
-			paths = append(paths, workspacePath)
+	for _, path := range patchHeaderPaths(patch) {
+		if path == "" || path == "/dev/null" {
+			continue
 		}
+		workspacePath := path
+		if relativeRoot != "" && relativeRoot != "." {
+			workspacePath = filepath.ToSlash(filepath.Join(relativeRoot, path))
+		}
+		if seen[workspacePath] {
+			continue
+		}
+		seen[workspacePath] = true
+		paths = append(paths, workspacePath)
 	}
 	return paths
 }
 
 func validatePatchPaths(root string, patch string) error {
-	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
-		for _, path := range patchPathsFromLine(line) {
-			if path == "" || path == "/dev/null" {
-				continue
-			}
-			if filepath.IsAbs(path) || path == ".." || strings.HasPrefix(path, "../") {
-				return fmt.Errorf("patch path %q must stay inside the workspace", path)
-			}
-			if _, _, err := resolveWorkspaceTargetPath(root, path); err != nil {
-				return err
-			}
+	for _, path := range patchHeaderPaths(patch) {
+		if path == "" || path == "/dev/null" {
+			continue
+		}
+		if filepath.IsAbs(path) || path == ".." || strings.HasPrefix(path, "../") {
+			return fmt.Errorf("patch path %q must stay inside the workspace", path)
+		}
+		if _, _, err := resolveWorkspaceTargetPath(root, path); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
 func recheckPatchWriteTargets(root string, patch string) error {
-	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
-		for _, path := range patchPathsFromLine(line) {
-			if path == "" || path == "/dev/null" {
-				continue
-			}
-			if err := recheckWorkspaceWriteTarget(root, path); err != nil {
-				return err
-			}
+	for _, path := range patchHeaderPaths(patch) {
+		if path == "" || path == "/dev/null" {
+			continue
+		}
+		if err := recheckWorkspaceWriteTarget(root, path); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func patchPathsFromLine(line string) []string {
-	if strings.HasPrefix(line, "diff --git ") {
-		fields := strings.Fields(line)
-		if len(fields) >= 4 {
-			return []string{stripPatchPrefix(fields[2]), stripPatchPrefix(fields[3])}
+// patchHeaderPaths returns the file paths declared in a unified diff's headers
+// (`diff --git` and `---`/`+++` lines). It tracks hunk state by counting body
+// lines from each `@@ -a,b +c,d @@` header, so a removed/added content line that
+// merely begins with "--- "/"+++ " (e.g. the removal of a markdown line "-- x")
+// is NOT mistaken for a file header. This mirrors how `git apply` parses hunks,
+// so a line this skips is content git won't write to either — no security gap.
+func patchHeaderPaths(patch string) []string {
+	var paths []string
+	oldRemaining, newRemaining := 0, 0
+	inHunk := false
+	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
+		if inHunk && (oldRemaining > 0 || newRemaining > 0) {
+			switch {
+			case strings.HasPrefix(line, "-"):
+				oldRemaining--
+			case strings.HasPrefix(line, "+"):
+				newRemaining--
+			case strings.HasPrefix(line, "\\"):
+				// "\ No newline at end of file" — not a content line.
+			default: // context line (" ...") or a blank context line
+				oldRemaining--
+				newRemaining--
+			}
+			continue
+		}
+		inHunk = false
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			fields := strings.Fields(line)
+			if len(fields) >= 4 {
+				paths = append(paths, stripPatchPrefix(fields[2]), stripPatchPrefix(fields[3]))
+			}
+		case strings.HasPrefix(line, "@@"):
+			oldRemaining, newRemaining = parseHunkCounts(line)
+			inHunk = oldRemaining > 0 || newRemaining > 0
+		case strings.HasPrefix(line, "--- "), strings.HasPrefix(line, "+++ "):
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				paths = append(paths, stripPatchPrefix(fields[1]))
+			}
 		}
 	}
-	if strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") {
-		fields := strings.Fields(line)
-		if len(fields) >= 2 {
-			return []string{stripPatchPrefix(fields[1])}
+	return paths
+}
+
+// parseHunkCounts reads the old/new line counts from a "@@ -a,b +c,d @@" header.
+// A missing count (e.g. "@@ -a +c @@") means 1 per unified-diff convention.
+func parseHunkCounts(line string) (int, int) {
+	old, next := 0, 0
+	for _, field := range strings.Fields(line) {
+		switch {
+		case strings.HasPrefix(field, "-"):
+			old = hunkCount(field[1:])
+		case strings.HasPrefix(field, "+"):
+			next = hunkCount(field[1:])
 		}
 	}
-	return nil
+	return old, next
+}
+
+func hunkCount(spec string) int {
+	if _, count, ok := strings.Cut(spec, ","); ok {
+		if n, err := strconv.Atoi(count); err == nil {
+			return n
+		}
+		return 0
+	}
+	return 1
 }
 
 func stripPatchPrefix(path string) string {

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -105,6 +105,10 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 	command.Stdout = &stdout
 	command.Stderr = &stderr
 
+	// Kill the shell as a process group on timeout and bound the post-kill I/O
+	// wait, so a backgrounded child cannot outlive the command or hang Run().
+	hardenProcessLifetime(command)
+
 	err = command.Run()
 	exitCode := commandExitCode(err)
 	meta["exit_code"] = strconv.Itoa(exitCode)

--- a/internal/tools/bash_proc_unix.go
+++ b/internal/tools/bash_proc_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package tools
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// bashWaitDelay bounds how long Wait blocks for the I/O pipes to drain after the
+// process has exited or the context's Cancel has run. Without it, a backgrounded
+// child that inherited the shell's stdout/stderr keeps those pipes open and
+// Run() hangs long past the timeout waiting for EOF. Var (not const) so tests
+// can shorten it.
+var bashWaitDelay = 2 * time.Second
+
+// hardenProcessLifetime makes a bash command killable as a single unit so a
+// timeout cannot leak backgrounded children.
+//
+// Setpgid puts the shell into a new process group; since `sh -c` runs without
+// job control, every process it forks (including `&` jobs) inherits that group.
+// On context cancellation we signal the whole group (negative pid) instead of
+// just the shell, so orphaned children die with it. WaitDelay is the backstop:
+// if a child still holds the I/O pipes after the group is killed, Wait gives up
+// rather than blocking forever.
+func hardenProcessLifetime(command *exec.Cmd) {
+	if command.SysProcAttr == nil {
+		command.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	command.SysProcAttr.Setpgid = true
+	command.WaitDelay = bashWaitDelay
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		// Negative pid targets the process group led by the shell.
+		if err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/tools/bash_proc_windows.go
+++ b/internal/tools/bash_proc_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package tools
+
+import (
+	"os/exec"
+	"time"
+)
+
+// bashWaitDelay bounds how long Wait blocks for the I/O pipes to drain after the
+// process has exited or the context's Cancel has run, so a backgrounded child
+// holding the pipes cannot make Run() hang past the timeout. Var (not const) so
+// tests can shorten it.
+var bashWaitDelay = 2 * time.Second
+
+// hardenProcessLifetime sets WaitDelay so a leaked child cannot block Wait
+// indefinitely. Windows lacks POSIX process groups; tree-killing the shell's
+// descendants (taskkill /T) is not wired for the synchronous bash path, so the
+// default Cancel (Process.Kill on the shell) plus WaitDelay is used.
+func hardenProcessLifetime(command *exec.Cmd) {
+	command.WaitDelay = bashWaitDelay
+}

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -251,6 +251,42 @@ func TestBashToolTimesOut(t *testing.T) {
 	}
 }
 
+func TestBashToolTimeoutKillsBackgroundChildren(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process-group kill is POSIX-only")
+	}
+	root := t.TempDir()
+	sentinel := filepath.Join(root, "leaked")
+	// A backgrounded child sleeps well past the timeout, then drops a sentinel.
+	// `wait` keeps the foreground shell alive so the deadline fires while the
+	// child is still running. Without process-group kill the child is orphaned:
+	// it survives, eventually writes the sentinel, and (because it inherited the
+	// stdout pipe) blocks Run() until it exits.
+	command := fmt.Sprintf("(sleep 3; touch %s) & wait", shellQuote(sentinel))
+
+	start := time.Now()
+	result := NewBashTool(root).Run(context.Background(), map[string]any{
+		"command":    command,
+		"timeout_ms": 300,
+	})
+	elapsed := time.Since(start)
+
+	if result.Status != StatusError {
+		t.Fatalf("expected timeout error status, got %s: %q", result.Status, result.Output)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Run blocked %s past the 300ms timeout; background child held the pipes", elapsed)
+	}
+
+	// Give the child more than its 3s sleep to fire if it survived the timeout.
+	time.Sleep(3500 * time.Millisecond)
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatalf("background child survived the timeout and wrote %s", sentinel)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error stat-ing sentinel: %v", err)
+	}
+}
+
 func TestRegistryRunsBashThroughSandboxEngine(t *testing.T) {
 	root := t.TempDir()
 	registry := NewRegistry()

--- a/internal/tools/bash_tool_test.go
+++ b/internal/tools/bash_tool_test.go
@@ -255,14 +255,20 @@ func TestBashToolTimeoutKillsBackgroundChildren(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("process-group kill is POSIX-only")
 	}
+	// Shorten the post-kill I/O drain so this regression doesn't bake several
+	// seconds into every run; the child sleep below is correspondingly short.
+	defer func(prev time.Duration) { bashWaitDelay = prev }(bashWaitDelay)
+	bashWaitDelay = 200 * time.Millisecond
+
 	root := t.TempDir()
 	sentinel := filepath.Join(root, "leaked")
-	// A backgrounded child sleeps well past the timeout, then drops a sentinel.
-	// `wait` keeps the foreground shell alive so the deadline fires while the
-	// child is still running. Without process-group kill the child is orphaned:
-	// it survives, eventually writes the sentinel, and (because it inherited the
+	// A backgrounded child sleeps past the timeout, then drops a sentinel. `wait`
+	// keeps the foreground shell alive so the deadline fires while the child is
+	// still running. Without process-group kill the child is orphaned: it
+	// survives, eventually writes the sentinel, and (because it inherited the
 	// stdout pipe) blocks Run() until it exits.
-	command := fmt.Sprintf("(sleep 3; touch %s) & wait", shellQuote(sentinel))
+	const childSleep = time.Second
+	command := fmt.Sprintf("(sleep 1; touch %s) & wait", shellQuote(sentinel))
 
 	start := time.Now()
 	result := NewBashTool(root).Run(context.Background(), map[string]any{
@@ -274,12 +280,12 @@ func TestBashToolTimeoutKillsBackgroundChildren(t *testing.T) {
 	if result.Status != StatusError {
 		t.Fatalf("expected timeout error status, got %s: %q", result.Status, result.Output)
 	}
-	if elapsed > 2*time.Second {
+	if elapsed > time.Second {
 		t.Fatalf("Run blocked %s past the 300ms timeout; background child held the pipes", elapsed)
 	}
 
-	// Give the child more than its 3s sleep to fire if it survived the timeout.
-	time.Sleep(3500 * time.Millisecond)
+	// Give the child more than its sleep to fire if it survived the timeout.
+	time.Sleep(childSleep + 500*time.Millisecond)
 	if _, err := os.Stat(sentinel); err == nil {
 		t.Fatalf("background child survived the timeout and wrote %s", sentinel)
 	} else if !os.IsNotExist(err) {

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -144,6 +144,28 @@ func TestGrepToolSearchesContent(t *testing.T) {
 	}
 }
 
+// A glob is matched relative to the search directory, not the workspace root, so
+// `path=subdir glob=*.go` finds subdir/a.go (as "a.go"). Previously the glob was
+// matched against the workspace-relative "subdir/a.go", so a non-recursive "*.go"
+// found nothing.
+func TestGrepGlobMatchesRelativeToSearchDir(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "subdir", "a.go"), "package sub\nfunc target() {}\n")
+
+	result := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern": "func target",
+		"path":    "subdir",
+		"glob":    "*.go",
+	})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected ok status, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "subdir/a.go:2: func target() {}") {
+		t.Fatalf("expected subdir match with non-recursive glob, got %q", result.Output)
+	}
+}
+
 func TestGrepToolSupportsFilesAndCountModes(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "a.txt"), "needle\nneedle\n")

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -202,7 +202,9 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 		if shouldSkipWorkspaceFile(relative) {
 			return []string{}, nil
 		}
-		if globMatcher == nil || globMatcher.MatchString(relative) {
+		// A single explicit file is matched by its base name so a pattern like
+		// "*.go" applies regardless of how deep the file sits under the workspace.
+		if globMatcher == nil || globMatcher.MatchString(filepath.Base(target)) {
 			return []string{target}, nil
 		}
 		return []string{}, nil
@@ -237,7 +239,15 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 		if shouldSkipWorkspaceFile(relative) {
 			return nil
 		}
-		if globMatcher == nil || globMatcher.MatchString(relative) {
+		// Match the glob against the path relative to the SEARCH directory, not the
+		// workspace root, so "*.go" with path="subdir" matches subdir/a.go (as
+		// "a.go") — matching ripgrep's --glob semantics. Falls back to the
+		// workspace-relative path if Rel fails.
+		globPath := relative
+		if rel, relErr := filepath.Rel(target, path); relErr == nil {
+			globPath = filepath.ToSlash(rel)
+		}
+		if globMatcher == nil || globMatcher.MatchString(globPath) {
 			files = append(files, path)
 		}
 		return nil

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -356,6 +356,38 @@ func TestApplyPatchToolHandlesHunkBodyLookingLikeHeader(t *testing.T) {
 	}
 }
 
+func TestApplyPatchToolRejectsHunkCountInflationHidingEscapePath(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "safe.txt"), "old\n")
+	// A crafted section heading after the closing "@@" injects a "+9,999999"
+	// token. If parseHunkCounts scanned the whole line it would treat 999999 as
+	// the new-line count, stay stuck in hunk mode, and swallow the second file
+	// header below — hiding the ../escape.txt write from path validation.
+	patch := strings.Join([]string{
+		"diff --git a/safe.txt b/safe.txt",
+		"--- a/safe.txt",
+		"+++ b/safe.txt",
+		"@@ -1,1 +1,1 @@ +9,999999",
+		"-old",
+		"+new",
+		"--- a/../escape.txt",
+		"+++ b/../escape.txt",
+		"@@ -1,1 +1,1 @@",
+		"-secret",
+		"+pwned",
+		"",
+	}, "\n")
+
+	result := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"patch": patch})
+
+	if result.Status != StatusError {
+		t.Fatalf("crafted hunk header must not hide the out-of-workspace path, got %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "must stay inside the workspace") {
+		t.Fatalf("expected workspace-confinement rejection, got %q", result.Output)
+	}
+}
+
 func TestApplyPatchToolRejectsSymlinkPath(t *testing.T) {
 	root := t.TempDir()
 	realDirectory := filepath.Join(root, "real")

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -326,6 +326,36 @@ func TestApplyPatchToolAppliesUnifiedDiff(t *testing.T) {
 	}
 }
 
+// A hunk-body line that removes content beginning with "-- " appears in the diff
+// as "--- ..."; it must NOT be mistaken for a file header (which previously made
+// apply_patch reject a valid patch as targeting an outside path).
+func TestApplyPatchToolHandlesHunkBodyLookingLikeHeader(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.md"), "keep\n-- /etc/old\n")
+	patch := strings.Join([]string{
+		"diff --git a/notes.md b/notes.md",
+		"--- a/notes.md",
+		"+++ b/notes.md",
+		"@@ -1,2 +1,1 @@",
+		" keep",
+		"--- /etc/old",
+		"",
+	}, "\n")
+
+	result := NewApplyPatchTool(root).Run(context.Background(), map[string]any{"patch": patch})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected patch ok (hunk body must not be parsed as a header), got %s: %s", result.Status, result.Output)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "notes.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ReplaceAll(string(content), "\r\n", "\n") != "keep\n" {
+		t.Fatalf("unexpected patched content: %q", string(content))
+	}
+}
+
 func TestApplyPatchToolRejectsSymlinkPath(t *testing.T) {
 	root := t.TempDir()
 	realDirectory := filepath.Join(root, "real")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1781,6 +1781,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 			turnTools:   toolCalls,
 			turnElapsed: m.now().Sub(started),
 		})
+		if notice := result.TruncationNotice(); notice != "" {
+			rows = append(rows, transcriptRow{kind: rowSystem, text: notice})
+		}
 		sessionEvents = append(sessionEvents, pendingSessionEvent{
 			Type: sessions.EventMessage,
 			Payload: map[string]any{

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -115,7 +115,7 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 					options.OnText(event.Content)
 				}
 			case StreamEventToolCallStart:
-				collector.start(event.ToolCallID, event.ToolName)
+				collector.start(event.ToolCallID, event.ToolName, event.ToolCallSignature)
 			case StreamEventToolCallDelta:
 				collector.delta(event.ToolCallID, event.ArgumentsFragment)
 			case StreamEventToolCallEnd:
@@ -170,7 +170,7 @@ func newToolCallCollector() *toolCallCollector {
 // start begins a tool call. A non-empty ID reuses any open call with that ID
 // (some backends re-emit the same start); an empty ID always begins a fresh
 // synthetic call so concurrent empty-id calls stay distinct.
-func (collector *toolCallCollector) start(id string, name string) {
+func (collector *toolCallCollector) start(id string, name string, signature string) {
 	key := id
 	if id == "" {
 		// Adopt an empty-id call that a delta opened before this start, so its
@@ -189,6 +189,11 @@ func (collector *toolCallCollector) start(id string, name string) {
 	// nameless follow-up start cannot clobber an already-resolved name.
 	if name != "" && call.Name == "" {
 		call.Name = name
+	}
+	// Preserve the reasoning signature (Gemini thoughtSignature) so it can be
+	// replayed with the call on later turns.
+	if signature != "" && call.Signature == "" {
+		call.Signature = signature
 	}
 }
 

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -16,6 +16,10 @@ type CollectedStream struct {
 	// response did not end normally (FinishReasonLength / FinishReasonContentFilter).
 	// It is empty for a normal completion. Truncated reports whether it is set.
 	FinishReason string
+	// ReasoningBlocks are the response's preserved reasoning artifacts (Anthropic
+	// thinking blocks) that must be replayed on the next turn. Empty for providers
+	// or runs without extended thinking.
+	ReasoningBlocks []ReasoningBlock
 }
 
 // Truncated reports whether the response ended for a non-normal reason (the
@@ -97,6 +101,11 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 			// normal completion.
 			if event.FinishReason != "" {
 				collected.FinishReason = event.FinishReason
+			}
+			// Reasoning blocks (Anthropic thinking) can ride on any terminal event;
+			// accumulate them regardless of type so they survive for replay.
+			if len(event.ReasoningBlocks) > 0 {
+				collected.ReasoningBlocks = append(collected.ReasoningBlocks, event.ReasoningBlocks...)
 			}
 
 			switch event.Type {

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -154,6 +154,7 @@ type StreamEvent struct {
 	Content           string
 	ToolCallID        string
 	ToolName          string
+	ToolCallSignature string // opaque reasoning signature bound to this call (Gemini thoughtSignature)
 	ArgumentsFragment string
 	Usage             Usage
 	Error             string

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -67,6 +67,25 @@ type ToolCall struct {
 	ID        string
 	Name      string
 	Arguments string
+	// Signature carries a provider's opaque reasoning signature bound to this call
+	// (Gemini attaches a thoughtSignature to a functionCall part). It must be
+	// echoed back with the call on later turns or the provider may reject the
+	// multi-turn function-calling conversation. Empty for providers that do not
+	// use it. Only the originating adapter interprets it.
+	Signature string
+}
+
+// ReasoningBlock is a provider-emitted reasoning artifact that must be replayed
+// verbatim on later turns or the provider rejects the (tool-using) conversation:
+// Anthropic requires thinking / redacted_thinking blocks be passed back with
+// their signatures. Only the adapter named by Provider interprets a block; other
+// adapters ignore foreign blocks, so a mid-run provider switch is safe.
+type ReasoningBlock struct {
+	Provider  string // adapter that produced and can replay this block ("anthropic", "gemini")
+	Type      string // provider block type ("thinking", "redacted_thinking")
+	Text      string // human-readable reasoning text (empty for redacted/opaque blocks)
+	Signature string // cryptographic signature the provider requires on replay
+	Data      string // opaque provider payload (e.g. Anthropic redacted_thinking data)
 }
 
 // Message is a normalized conversation turn passed to providers.
@@ -75,7 +94,8 @@ type Message struct {
 	Content    string
 	ToolCalls  []ToolCall
 	ToolCallID string
-	Images     []ImageBlock // optional; nil for text-only messages
+	Images     []ImageBlock     // optional; nil for text-only messages
+	Reasoning  []ReasoningBlock // optional; preserved thinking blocks to replay
 }
 
 // ToolDefinition describes a model-visible tool and its JSON-schema parameters.
@@ -142,6 +162,10 @@ type StreamEvent struct {
 	// the token cap, or FinishReasonContentFilter when it was filtered). It is
 	// empty for a normal completion. Providers set it on the terminal/done event.
 	FinishReason string
+	// ReasoningBlocks carries completed reasoning artifacts (Anthropic thinking /
+	// redacted_thinking blocks) that must be preserved for replay. Providers attach
+	// them to the terminal/done event; the collector accumulates them.
+	ReasoningBlocks []ReasoningBlock
 }
 
 // CompletionRequest groups provider input messages and available tools.

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -148,6 +148,12 @@ type StreamEvent struct {
 type CompletionRequest struct {
 	Messages []Message
 	Tools    []ToolDefinition
+	// ReasoningEffort, when non-empty, asks a reasoning-capable model to spend the
+	// given level of thinking effort ("minimal"/"low"/"medium"/"high"). Each
+	// provider adapter maps it to its own API shape (OpenAI reasoning_effort,
+	// Anthropic/Gemini thinking budgets) and ignores it for models that do not
+	// support reasoning. Empty means "let the provider decide".
+	ReasoningEffort string
 }
 
 // Provider streams normalized completion events for one request.


### PR DESCRIPTION
## Summary

Resolves every **critical** and **high** finding from the deep audit. Each commit is scoped to a single finding and ships with a regression test; the full suite, `go vet`, and `gofmt` are clean.

- **MCP framing** — cap framed messages at 64 MiB and switch the stdio transport to newline-delimited JSON (Content-Length kept for back-compat). Closes an unbounded `make([]byte, contentLength)` allocation.
- **Provider connectivity probe** — SSRF-hardened: re-validate every redirect hop (capped at 5) and validate + pin the resolved IP at dial time, closing the DNS-rebinding TOCTOU.
- **bash tool** — kill the shell as a process group on timeout (`Setpgid` + group `SIGKILL` + `WaitDelay`) so backgrounded children can't outlive the command or hang `Run()`.
- **sandbox-exec profile** — allow the standard device nodes and temp trees for parity with the bubblewrap backend; workspace stays the only writable project location.
- **Reasoning effort** — thread `CompletionRequest.ReasoningEffort` through the agent loop and map it per provider: OpenAI `reasoning_effort`, Anthropic extended thinking (with thinking-block replay), Gemini thinking budget.
- **sessions** — tolerate a torn tail only when the final line is unterminated; a fully-flushed corrupt line still fails loudly.
- **streamjson** — anchor secret patterns so prose (`task-list`, `bearer of bad news`) is no longer over-redacted.
- **tools** — fix grep glob scope (ripgrep semantics) and apply_patch hunk-body misparse.
- **cli/cron** — honor an explicit expr over a recipe; preserve an external pause mid-run.
- **specialist** — keep the name in the session title so description-less runs resume.
- **agent** — surface response truncation (`finish_reason`) to the user.

### Partial (tracked in `docs/audit/2026-06-10-deep-audit-status.md`)
- **Hooks** — a `Dispatcher` that runs and audits configured hooks is added and tested, but it is **not yet wired** into the `beforeTool`/`afterTool` lifecycle and has no CLI `dispatch`/`edit` surface (behavioral change deferred to a design pass).
- **Cron** — the pause-clobber during a run is fixed; the concurrent-scheduler race (no flock/CAS in `internal/cron/store.go`) remains, with single-scheduler as the supported model.

## Test Plan
- [x] `go build ./...`
- [x] `go test ./...` (full suite green)
- [x] `go vet ./...`
- [x] `gofmt -l` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended “thinking”/reasoning support with configurable effort levels and preserved replayable reasoning across turns
  * Hook dispatch system for configurable event hooks

* **Bug Fixes**
  * Fixed MCP message framing/parsing
  * Improved truncation detection/reporting (CLI/TUI and run outputs now show truncation notices)
  * Better recovery from partial session logs
  * More robust patch parsing to avoid misinterpreting hunk content

* **Improvements**
  * Expanded sandbox write allowances for common temp/dev paths
  * Stricter secret-redaction patterns
  * Hardened process lifetime handling for executed commands
  * CLI cron argument parsing and run handling made more resilient
  * Safer provider connectivity checks and redirect handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->