### PR TITLE
Polish main TUI surface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.6
 	golang.org/x/sys v0.38.0
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -391,6 +391,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		ProviderName:    resolved.Provider.Name,
 		ModelName:       resolved.Provider.Model,
 		ProviderProfile: resolved.Provider,
+		FavoriteModels:  resolved.Preferences.FavoriteModels,
 		Provider:        provider,
 		NewProvider:     deps.newProvider,
 		Registry:        registry,

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -145,7 +145,8 @@ func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {
 					APIKey:       "sk-test",
 					Model:        "gpt-test",
 				},
-				MaxTurns: 5,
+				Preferences: config.PreferencesConfig{FavoriteModels: []string{"qwen3-coder:480b"}},
+				MaxTurns:    5,
 			}, nil
 		},
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
@@ -178,6 +179,9 @@ func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {
 	}
 	if launchedOptions.ModelName != "gpt-test" {
 		t.Fatalf("ModelName = %q, want gpt-test", launchedOptions.ModelName)
+	}
+	if len(launchedOptions.FavoriteModels) != 1 || launchedOptions.FavoriteModels[0] != "qwen3-coder:480b" {
+		t.Fatalf("FavoriteModels = %#v, want qwen3-coder:480b", launchedOptions.FavoriteModels)
 	}
 	if launchedOptions.Setup.Visible {
 		t.Fatalf("Setup.Visible = true, want false for credentialed provider")

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -103,6 +103,7 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 		Sandbox:        cfg.Sandbox,
 		Notify:         cfg.Notify,
 		Tools:          cfg.Tools,
+		Preferences:    cfg.Preferences,
 	}, nil
 }
 
@@ -162,6 +163,9 @@ func mergeConfig(dst *FileConfig, src FileConfig) {
 	if src.Tools.deferThresholdSet {
 		dst.Tools.DeferThreshold = src.Tools.DeferThreshold
 		dst.Tools.deferThresholdSet = true
+	}
+	if src.Preferences.FavoriteModels != nil {
+		dst.Preferences.FavoriteModels = normalizeFavoriteModels(src.Preferences.FavoriteModels)
 	}
 }
 

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -88,6 +89,40 @@ func TestResolveSelectsActiveProviderProfile(t *testing.T) {
 	}
 	if resolved.Provider.APIKey != "sk-beta" {
 		t.Fatalf("Provider.APIKey = %q, want sk-beta", resolved.Provider.APIKey)
+	}
+}
+
+func TestResolveLoadsFavoriteModelsFromUserConfigOnly(t *testing.T) {
+	userPath := writeConfig(t, `{
+		"activeProvider": "user",
+		"providers": [{
+			"name": "user",
+			"provider": "openai",
+			"apiKey": "sk-user",
+			"model": "gpt-user"
+		}],
+		"preferences": {
+			"favoriteModels": [" rnj-1:8b ", "qwen3-coder:480b", "rnj-1:8b"]
+		}
+	}`)
+	projectPath := writeConfig(t, `{
+		"preferences": {
+			"favoriteModels": ["project-model"]
+		}
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{
+		UserConfigPath:    userPath,
+		ProjectConfigPath: projectPath,
+		Env:               map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	want := []string{"qwen3-coder:480b", "rnj-1:8b"}
+	if !reflect.DeepEqual(resolved.Preferences.FavoriteModels, want) {
+		t.Fatalf("FavoriteModels = %#v, want %#v", resolved.Preferences.FavoriteModels, want)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -73,6 +73,10 @@ type ToolsConfig struct {
 	deferThresholdSet bool
 }
 
+type PreferencesConfig struct {
+	FavoriteModels []string `json:"favoriteModels,omitempty"`
+}
+
 // ToolsOverride builds a ToolsConfig that explicitly overrides the deferred-tool
 // threshold (including to 0, which disables deferral). Use this for programmatic
 // Overrides — a bare ToolsConfig{DeferThreshold: 0} is indistinguishable from
@@ -106,6 +110,7 @@ type FileConfig struct {
 	Sandbox        SandboxConfig     `json:"sandbox,omitempty"`
 	Notify         NotifyConfig      `json:"notify,omitempty"`
 	Tools          ToolsConfig       `json:"tools,omitempty"`
+	Preferences    PreferencesConfig `json:"preferences,omitempty"`
 }
 
 type ResolveOptions struct {
@@ -136,6 +141,7 @@ type ResolvedConfig struct {
 	Sandbox        SandboxConfig
 	Notify         NotifyConfig
 	Tools          ToolsConfig
+	Preferences    PreferencesConfig
 }
 
 type MCPConfig struct {
@@ -162,6 +168,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 		Sandbox         SandboxConfig              `json:"sandbox"`
 		Notify          NotifyConfig               `json:"notify"`
 		Tools           ToolsConfig                `json:"tools"`
+		Preferences     PreferencesConfig          `json:"preferences"`
 		MCPServers      map[string]MCPServerConfig `json:"mcpServers"`
 		MCPServersSnake map[string]MCPServerConfig `json:"mcp_servers"`
 	}
@@ -177,6 +184,7 @@ func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
 	cfg.Sandbox = raw.Sandbox
 	cfg.Notify = raw.Notify
 	cfg.Tools = raw.Tools
+	cfg.Preferences = raw.Preferences
 	if cfg.MCP.Servers == nil && (len(raw.MCPServers) > 0 || len(raw.MCPServersSnake) > 0) {
 		cfg.MCP.Servers = map[string]MCPServerConfig{}
 	}

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -69,6 +70,43 @@ func SetActiveProvider(path string, name string) (FileConfig, error) {
 	}
 
 	return FileConfig{}, fmt.Errorf("provider %q not found", name)
+}
+
+func SetFavoriteModels(path string, models []string) (FileConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return FileConfig{}, fmt.Errorf("config path is required")
+	}
+
+	cfg := FileConfig{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return FileConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return FileConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	cfg.Preferences.FavoriteModels = normalizeFavoriteModels(models)
+	if err := writeConfigFile(path, cfg); err != nil {
+		return FileConfig{}, err
+	}
+	return cfg, nil
+}
+
+func normalizeFavoriteModels(models []string) []string {
+	seen := map[string]bool{}
+	favorites := make([]string, 0, len(models))
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" || seen[model] {
+			continue
+		}
+		seen[model] = true
+		favorites = append(favorites, model)
+	}
+	sort.Strings(favorites)
+	return favorites
 }
 
 func writeConfigFile(path string, cfg FileConfig) error {

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -175,6 +176,49 @@ func TestUpsertProviderTightensExistingConfigFilePermissions(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("config mode = %o, want 0600", got)
+	}
+}
+
+func TestSetFavoriteModelsPersistsUserPreferences(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero.json")
+	writeConfigFixture(t, path, FileConfig{
+		ActiveProvider: "openai",
+		Providers: []ProviderProfile{
+			{Name: "openai", ProviderKind: ProviderKindOpenAI, Model: "gpt-4.1"},
+		},
+	}, 0o600)
+
+	cfg, err := SetFavoriteModels(path, []string{" qwen3-coder:480b ", "", "rnj-1:8b", "qwen3-coder:480b"})
+	if err != nil {
+		t.Fatalf("SetFavoriteModels() error = %v", err)
+	}
+
+	want := []string{"qwen3-coder:480b", "rnj-1:8b"}
+	if !reflect.DeepEqual(cfg.Preferences.FavoriteModels, want) {
+		t.Fatalf("FavoriteModels = %#v, want %#v", cfg.Preferences.FavoriteModels, want)
+	}
+	persisted := readConfigFixture(t, path)
+	if !reflect.DeepEqual(persisted.Preferences.FavoriteModels, want) {
+		t.Fatalf("persisted FavoriteModels = %#v, want %#v", persisted.Preferences.FavoriteModels, want)
+	}
+	if persisted.ActiveProvider != "openai" || len(persisted.Providers) != 1 {
+		t.Fatalf("provider config was not preserved: %#v", persisted)
+	}
+}
+
+func TestSetFavoriteModelsCreatesMissingConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	cfg, err := SetFavoriteModels(path, []string{"glm-5.1"})
+	if err != nil {
+		t.Fatalf("SetFavoriteModels() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(cfg.Preferences.FavoriteModels, []string{"glm-5.1"}) {
+		t.Fatalf("FavoriteModels = %#v, want glm-5.1", cfg.Preferences.FavoriteModels)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected config file to be created: %v", err)
 	}
 }
 

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -15,24 +15,32 @@ type commandSuggestion struct {
 	Desc string
 }
 
-// maxCommandSuggestions caps how many rows the autocomplete overlay shows so a
-// short prefix can't flood the screen.
-const maxCommandSuggestions = 8
+const (
+	// maxCommandSuggestions caps command matches kept in memory; rendering still
+	// shows a smaller window so a bare "/" can report the remaining commands.
+	maxCommandSuggestions = 32
+	maxFileSuggestions    = 16
+)
 
 // suggestionsActive reports whether the autocomplete overlay should drive key
-// handling: the input is a slash-command fragment, there is at least one match,
-// and no modal (permission / questionnaire) is competing for keys.
+// handling. A slash-command palette stays active even with zero matches so the
+// query remains in the palette instead of leaking back into the composer.
 func (m model) suggestionsActive() bool {
 	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil || m.providerWizard != nil {
 		return false
 	}
-	return len(m.suggestions) > 0
+	if len(m.suggestions) > 0 {
+		return true
+	}
+	return m.commandPaletteOpen || m.filePaletteOpen
 }
 
 func (m *model) clearSuggestions() {
 	m.suggestions = nil
 	m.suggestionIdx = 0
 	m.suggestionsAreFiles = false
+	m.commandPaletteOpen = false
+	m.filePaletteOpen = false
 }
 
 // recomputeSuggestions rebuilds the autocomplete match list from the current
@@ -50,6 +58,8 @@ func (m *model) recomputeSuggestions() {
 	// File reference: a trailing "@token" (even mid-prompt) drives a workspace
 	// file picker. Checked before the slash path so "@" is handled distinctly.
 	if token, ok := trailingAtToken(value); ok {
+		m.commandPaletteOpen = false
+		m.filePaletteOpen = true
 		m.suggestionsAreFiles = true
 		m.suggestions = fileSuggestions(m.cwd, token)
 		if m.suggestionIdx >= len(m.suggestions) || m.suggestionIdx < 0 {
@@ -59,21 +69,17 @@ func (m *model) recomputeSuggestions() {
 	}
 	m.suggestionsAreFiles = false
 
+	if !commandSuggestionsOpen(value) {
+		m.suggestions = nil
+		m.suggestionIdx = 0
+		m.commandPaletteOpen = false
+		m.filePaletteOpen = false
+		return
+	}
 	trimmed := strings.TrimLeft(value, " ")
-	// A leading slash token (no whitespace yet) drives the command palette. A bare
-	// "/" now lists the full palette (the footer advertises "/ commands").
-	if !strings.HasPrefix(trimmed, "/") || strings.ContainsAny(trimmed, " \t") {
-		m.suggestions = nil
-		m.suggestionIdx = 0
-		return
-	}
 	token := strings.TrimSpace(trimmed)
-	if token == "" {
-		m.suggestions = nil
-		m.suggestionIdx = 0
-		return
-	}
 
+	m.commandPaletteOpen = true
 	matches := matchCommandSuggestions(token)
 	m.suggestions = matches
 	if m.suggestionIdx >= len(matches) {
@@ -82,6 +88,16 @@ func (m *model) recomputeSuggestions() {
 	if m.suggestionIdx < 0 {
 		m.suggestionIdx = 0
 	}
+}
+
+func commandSuggestionsOpen(value string) bool {
+	trimmed := strings.TrimLeft(value, " ")
+	return strings.HasPrefix(trimmed, "/") && strings.TrimSpace(trimmed) != "" && !strings.ContainsAny(trimmed, " \t")
+}
+
+func fileSuggestionOnlyInput(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return strings.HasPrefix(trimmed, "@") && !strings.ContainsAny(trimmed, " \t\n")
 }
 
 // matchCommandSuggestions returns commands whose canonical name or any alias has
@@ -93,7 +109,7 @@ func matchCommandSuggestions(token string) []commandSuggestion {
 	if prefix == "" {
 		return nil
 	}
-	out := make([]commandSuggestion, 0, maxCommandSuggestions)
+	out := make([]commandSuggestion, 0, minInt(maxCommandSuggestions, len(commandDefinitions)))
 	for _, command := range commandDefinitions {
 		if !commandHasPrefix(command, prefix) {
 			continue
@@ -131,7 +147,7 @@ func (m *model) moveSuggestion(delta int) {
 // completeSuggestion replaces the input with the selected command name plus a
 // trailing space (ready for arguments) and dismisses the overlay.
 func (m model) completeSuggestion() model {
-	if !m.suggestionsActive() {
+	if !m.suggestionsActive() || len(m.suggestions) == 0 {
 		return m
 	}
 	idx := m.suggestionIdx
@@ -150,6 +166,8 @@ func (m model) completeSuggestion() model {
 	m.suggestions = nil
 	m.suggestionIdx = 0
 	m.suggestionsAreFiles = false
+	m.commandPaletteOpen = false
+	m.filePaletteOpen = false
 	return m
 }
 
@@ -175,6 +193,16 @@ func replaceTrailingAtToken(value, path string) string {
 	return path
 }
 
+func removeTrailingAtToken(value string) string {
+	if _, ok := trailingAtToken(value); !ok {
+		return value
+	}
+	if i := strings.LastIndexAny(value, " \t\n"); i >= 0 {
+		return value[:i+1]
+	}
+	return ""
+}
+
 // maxFileWalk bounds how many filesystem entries the "@file" picker visits per
 // keystroke so a large workspace tree can't stall the TUI.
 const maxFileWalk = 4000
@@ -195,13 +223,13 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 		return nil
 	}
 	needle := strings.ToLower(strings.TrimSpace(partial))
-	out := make([]commandSuggestion, 0, maxCommandSuggestions)
+	out := make([]commandSuggestion, 0, maxFileSuggestions)
 	visited := 0
 	_ = filepath.WalkDir(cwd, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if visited >= maxVisited || len(out) >= maxCommandSuggestions {
+		if visited >= maxVisited || len(out) >= maxFileSuggestions {
 			return fs.SkipAll
 		}
 		// Count every entry (directories included) so the walk is bounded even in
@@ -232,9 +260,20 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 	return out
 }
 
-// dismissSuggestions clears the overlay without touching the input or the run.
+// dismissSuggestions clears the overlay without touching the run. Command
+// palette dismissal also clears the leading slash fragment because the palette
+// owns that search text while it is open.
 func (m model) dismissSuggestions() model {
+	if m.suggestionsAreFiles {
+		m.input.SetValue(removeTrailingAtToken(m.input.Value()))
+		m.input.CursorEnd()
+	} else {
+		m.clearComposer()
+	}
 	m.suggestions = nil
 	m.suggestionIdx = 0
+	m.suggestionsAreFiles = false
+	m.commandPaletteOpen = false
+	m.filePaletteOpen = false
 	return m
 }

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -523,8 +523,14 @@ func fuzzySubsequenceGap(value, query string) (int, bool) {
 // owns that search text while it is open.
 func (m model) dismissSuggestions() model {
 	if m.suggestionsAreFiles {
-		m.input.SetValue(removeTrailingAtToken(m.input.Value()))
-		m.input.CursorEnd()
+		if query := extractPathQuery(m.input.Value(), m.input.Position()); query != nil {
+			runes := []rune(m.input.Value())
+			next := make([]rune, 0, len(runes)-(query.EndIndex-query.StartIndex))
+			next = append(next, runes[:query.StartIndex]...)
+			next = append(next, runes[query.EndIndex:]...)
+			m.input.SetValue(string(next))
+			m.input.SetCursor(query.StartIndex)
+		}
 		m.resetComposerFromInput()
 	} else {
 		m.clearComposer()

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -249,6 +249,14 @@ func (m model) selectedSuggestionIsDirectory() bool {
 	return fileSuggestionIsDirectory(m.suggestions[idx])
 }
 
+func (m model) selectedCommandSuggestionRequiresInput() bool {
+	if m.suggestionsAreFiles || len(m.suggestions) == 0 {
+		return false
+	}
+	idx := clampInt(m.suggestionIdx, 0, len(m.suggestions)-1)
+	return commandSelectionRequiresInput(m.suggestions[idx].Name)
+}
+
 func fileSuggestionIsDirectory(suggestion commandSuggestion) bool {
 	return suggestion.Desc == "directory" || strings.HasSuffix(suggestion.Name, "/")
 }

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -211,8 +211,9 @@ func (m *model) moveSuggestion(delta int) {
 	m.suggestionIdx = ((m.suggestionIdx+delta)%n + n) % n
 }
 
-// completeSuggestion replaces the input with the selected command name plus a
-// trailing space (ready for arguments) and dismisses the overlay.
+// completeSuggestion replaces the input with the selected suggestion and
+// dismisses the overlay. Required-argument commands stay tight ("/spec") so
+// the rendered argument hint can sit next to the cursor without dead padding.
 func (m model) completeSuggestion() model {
 	if !m.suggestionsActive() || len(m.suggestions) == 0 {
 		return m
@@ -230,7 +231,11 @@ func (m model) completeSuggestion() model {
 		m.input.SetValue(nextValue)
 		m.input.SetCursor(nextCursor)
 	} else {
-		m.input.SetValue(chosen + " ")
+		if commandSelectionRequiresInput(chosen) {
+			m.input.SetValue(chosen)
+		} else {
+			m.input.SetValue(chosen + " ")
+		}
 		m.input.CursorEnd()
 	}
 	m.suggestions = nil

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -2,8 +2,13 @@ package tui
 
 import (
 	"io/fs"
+	"path"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/workspaceindex"
 )
@@ -21,6 +26,28 @@ const (
 	maxCommandSuggestions = 32
 	maxFileSuggestions    = 16
 )
+
+const fileIndexTTL = 30 * time.Second
+
+type fileSuggestionIndex struct {
+	files []string
+	dirs  []string
+}
+
+type cachedFileSuggestionIndex struct {
+	index     fileSuggestionIndex
+	expiresAt time.Time
+}
+
+type fileSuggestionCandidate struct {
+	path  string
+	isDir bool
+}
+
+var fileSuggestionIndexCache = struct {
+	sync.Mutex
+	entries map[string]cachedFileSuggestionIndex
+}{entries: map[string]cachedFileSuggestionIndex{}}
 
 // suggestionsActive reports whether the autocomplete overlay should drive key
 // handling. A slash-command palette stays active even with zero matches so the
@@ -57,11 +84,11 @@ func (m *model) recomputeSuggestions() {
 
 	// File reference: a trailing "@token" (even mid-prompt) drives a workspace
 	// file picker. Checked before the slash path so "@" is handled distinctly.
-	if token, ok := trailingAtToken(value); ok {
+	if query := extractPathQuery(value, m.input.Position()); query != nil {
 		m.commandPaletteOpen = false
 		m.filePaletteOpen = true
 		m.suggestionsAreFiles = true
-		m.suggestions = fileSuggestions(m.cwd, token)
+		m.suggestions = fileSuggestions(m.cwd, query.Query)
 		if m.suggestionIdx >= len(m.suggestions) || m.suggestionIdx < 0 {
 			m.suggestionIdx = 0
 		}
@@ -98,6 +125,46 @@ func commandSuggestionsOpen(value string) bool {
 func fileSuggestionOnlyInput(value string) bool {
 	trimmed := strings.TrimSpace(value)
 	return strings.HasPrefix(trimmed, "@") && !strings.ContainsAny(trimmed, " \t\n")
+}
+
+type pathQuery struct {
+	Query      string
+	StartIndex int
+	EndIndex   int
+}
+
+func extractPathQuery(text string, cursorPos int) *pathQuery {
+	runes := []rune(text)
+	cursorPos = clampInt(cursorPos, 0, len(runes))
+	at := -1
+	for i := cursorPos - 1; i >= 0; i-- {
+		if runes[i] == '@' {
+			at = i
+			break
+		}
+		if isPathQueryBoundary(runes[i]) {
+			break
+		}
+	}
+	if at < 0 {
+		return nil
+	}
+	end := at + 1
+	for end < len(runes) && !isPathQueryBoundary(runes[end]) {
+		end++
+	}
+	if cursorPos > end {
+		return nil
+	}
+	return &pathQuery{
+		Query:      string(runes[at+1 : end]),
+		StartIndex: at,
+		EndIndex:   end,
+	}
+}
+
+func isPathQueryBoundary(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 }
 
 // matchCommandSuggestions returns commands whose canonical name or any alias has
@@ -156,19 +223,34 @@ func (m model) completeSuggestion() model {
 	}
 	chosen := m.suggestions[idx].Name
 	if m.suggestionsAreFiles {
+		isDir := fileSuggestionIsDirectory(m.suggestions[idx])
 		// Replace only the trailing "@token" with the chosen path so any preceding
 		// prompt text ("read @foo") is preserved.
-		m.input.SetValue(replaceTrailingAtToken(m.input.Value(), chosen) + " ")
+		nextValue, nextCursor := completePathQueryWithTrailingSpace(m.input.Value(), m.input.Position(), chosen, !isDir)
+		m.input.SetValue(nextValue)
+		m.input.SetCursor(nextCursor)
 	} else {
 		m.input.SetValue(chosen + " ")
+		m.input.CursorEnd()
 	}
-	m.input.CursorEnd()
 	m.suggestions = nil
 	m.suggestionIdx = 0
 	m.suggestionsAreFiles = false
 	m.commandPaletteOpen = false
 	m.filePaletteOpen = false
 	return m
+}
+
+func (m model) selectedSuggestionIsDirectory() bool {
+	if !m.suggestionsAreFiles || len(m.suggestions) == 0 {
+		return false
+	}
+	idx := clampInt(m.suggestionIdx, 0, len(m.suggestions)-1)
+	return fileSuggestionIsDirectory(m.suggestions[idx])
+}
+
+func fileSuggestionIsDirectory(suggestion commandSuggestion) bool {
+	return suggestion.Desc == "directory" || strings.HasSuffix(suggestion.Name, "/")
 }
 
 // trailingAtToken returns the file-reference fragment at the end of value: the
@@ -193,6 +275,29 @@ func replaceTrailingAtToken(value, path string) string {
 	return path
 }
 
+func completePathQuery(value string, cursorPos int, selectedPath string) (string, int) {
+	return completePathQueryWithTrailingSpace(value, cursorPos, selectedPath, true)
+}
+
+func completePathQueryWithTrailingSpace(value string, cursorPos int, selectedPath string, trailingSpace bool) (string, int) {
+	query := extractPathQuery(value, cursorPos)
+	suffix := ""
+	if trailingSpace {
+		suffix = " "
+	}
+	if query == nil {
+		next := replaceTrailingAtToken(value, selectedPath) + suffix
+		return next, len([]rune(next))
+	}
+	replacement := []rune(selectedPath + suffix)
+	runes := []rune(value)
+	out := make([]rune, 0, len(runes)-query.EndIndex+query.StartIndex+len(replacement))
+	out = append(out, runes[:query.StartIndex]...)
+	out = append(out, replacement...)
+	out = append(out, runes[query.EndIndex:]...)
+	return string(out), query.StartIndex + len(replacement)
+}
+
 func removeTrailingAtToken(value string) string {
 	if _, ok := trailingAtToken(value); !ok {
 		return value
@@ -207,10 +312,10 @@ func removeTrailingAtToken(value string) string {
 // keystroke so a large workspace tree can't stall the TUI.
 const maxFileWalk = 4000
 
-// fileSuggestions lists workspace files whose path matches partial (case-
-// insensitive substring), for the "@file" picker. The walk skips VCS/dependency/
-// hidden directories and is bounded so it stays responsive per keystroke. Each
-// suggestion's Name is the "@<relpath>" token that completion inserts.
+// fileSuggestions lists ranked workspace files and directories for the "@file"
+// picker. The walk skips VCS/dependency directories, is TTL-cached, and is
+// bounded so it stays responsive. Each suggestion's Name is the "@<relpath>"
+// token that completion inserts.
 func fileSuggestions(cwd, partial string) []commandSuggestion {
 	return fileSuggestionsBounded(cwd, partial, maxFileWalk)
 }
@@ -222,14 +327,35 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 	if cwd == "" {
 		return nil
 	}
-	needle := strings.ToLower(strings.TrimSpace(partial))
-	out := make([]commandSuggestion, 0, maxFileSuggestions)
+	index := cachedFileSuggestionsIndex(cwd, maxVisited)
+	return rankedFileSuggestions(index, partial, maxFileSuggestions)
+}
+
+func cachedFileSuggestionsIndex(cwd string, maxVisited int) fileSuggestionIndex {
+	key := filepath.Clean(cwd) + "\x00" + strconv.Itoa(maxVisited)
+	now := time.Now()
+	fileSuggestionIndexCache.Lock()
+	if cached, ok := fileSuggestionIndexCache.entries[key]; ok && now.Before(cached.expiresAt) {
+		fileSuggestionIndexCache.Unlock()
+		return cached.index
+	}
+	fileSuggestionIndexCache.Unlock()
+
+	index := buildFileSuggestionsIndex(cwd, maxVisited)
+	fileSuggestionIndexCache.Lock()
+	fileSuggestionIndexCache.entries[key] = cachedFileSuggestionIndex{index: index, expiresAt: now.Add(fileIndexTTL)}
+	fileSuggestionIndexCache.Unlock()
+	return index
+}
+
+func buildFileSuggestionsIndex(cwd string, maxVisited int) fileSuggestionIndex {
+	index := fileSuggestionIndex{}
 	visited := 0
-	_ = filepath.WalkDir(cwd, func(path string, d fs.DirEntry, err error) error {
+	_ = filepath.WalkDir(cwd, func(currentPath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
-		if visited >= maxVisited || len(out) >= maxFileSuggestions {
+		if visited >= maxVisited {
 			return fs.SkipAll
 		}
 		// Count every entry (directories included) so the walk is bounded even in
@@ -237,14 +363,21 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 		// could be traversed in full on each keystroke and stall the TUI.
 		visited++
 		if d.IsDir() {
-			if path != cwd && workspaceindex.ShouldSkipDir(d.Name()) {
+			if currentPath != cwd && workspaceindex.ShouldSkipDir(d.Name()) {
 				return fs.SkipDir
+			}
+			if currentPath != cwd {
+				rel, relErr := filepath.Rel(cwd, currentPath)
+				if relErr == nil {
+					rel = filepath.ToSlash(rel)
+					index.dirs = append(index.dirs, rel)
+				}
 			}
 			return nil
 		}
-		rel, relErr := filepath.Rel(cwd, path)
+		rel, relErr := filepath.Rel(cwd, currentPath)
 		if relErr != nil {
-			rel = filepath.Base(path)
+			rel = filepath.Base(currentPath)
 		}
 		// Emit forward-slash paths on every platform (filepath.Rel uses "\" on
 		// Windows) so the inserted "@path" token is portable and matchable.
@@ -252,12 +385,124 @@ func fileSuggestionsBounded(cwd, partial string, maxVisited int) []commandSugges
 		if workspaceindex.ShouldSkipFile(rel) {
 			return nil
 		}
-		if needle == "" || strings.Contains(strings.ToLower(rel), needle) {
-			out = append(out, commandSuggestion{Name: "@" + rel, Desc: "file"})
-		}
+		index.files = append(index.files, rel)
 		return nil
 	})
+	sort.Strings(index.files)
+	sort.Strings(index.dirs)
+	return index
+}
+
+func rankedFileSuggestions(index fileSuggestionIndex, partial string, limit int) []commandSuggestion {
+	query := strings.ToLower(strings.TrimSpace(partial))
+	candidates := make([]fileSuggestionCandidate, 0, len(index.files)+len(index.dirs))
+	for _, file := range index.files {
+		candidates = append(candidates, fileSuggestionCandidate{path: file})
+	}
+	for _, dir := range index.dirs {
+		candidates = append(candidates, fileSuggestionCandidate{path: dir, isDir: true})
+	}
+	type scoredCandidate struct {
+		candidate fileSuggestionCandidate
+		score     int
+	}
+	scored := make([]scoredCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		score, ok := scoreFileSuggestion(candidate, query)
+		if ok {
+			scored = append(scored, scoredCandidate{candidate: candidate, score: score})
+		}
+	}
+	sort.SliceStable(scored, func(i, j int) bool {
+		left, right := scored[i], scored[j]
+		if left.score != right.score {
+			return left.score < right.score
+		}
+		leftDepth := strings.Count(left.candidate.path, "/")
+		rightDepth := strings.Count(right.candidate.path, "/")
+		if leftDepth != rightDepth {
+			return leftDepth < rightDepth
+		}
+		if left.candidate.isDir != right.candidate.isDir {
+			return !left.candidate.isDir
+		}
+		return left.candidate.path < right.candidate.path
+	})
+
+	out := make([]commandSuggestion, 0, minInt(limit, len(scored)))
+	for _, item := range scored {
+		if len(out) >= limit {
+			break
+		}
+		name := "@" + item.candidate.path
+		desc := "file"
+		if item.candidate.isDir {
+			name += "/"
+			desc = "directory"
+		}
+		out = append(out, commandSuggestion{Name: name, Desc: desc})
+	}
 	return out
+}
+
+func scoreFileSuggestion(candidate fileSuggestionCandidate, query string) (int, bool) {
+	cleanPath := strings.TrimSuffix(filepath.ToSlash(candidate.path), "/")
+	base := strings.ToLower(path.Base(cleanPath))
+	full := strings.ToLower(cleanPath)
+	depth := strings.Count(cleanPath, "/")
+	dirPenalty := 0
+	if candidate.isDir {
+		dirPenalty = 5
+	}
+	if query == "" {
+		return depth*20 + len(base)/8 + dirPenalty, true
+	}
+	switch {
+	case base == query:
+		return 0 + depth + dirPenalty, true
+	case strings.HasPrefix(base, query):
+		return 20 + depth + dirPenalty, true
+	case strings.Contains(base, query):
+		return 40 + depth + dirPenalty, true
+	case strings.HasPrefix(full, query):
+		return 60 + depth + dirPenalty, true
+	case strings.Contains(full, query):
+		return 80 + depth + dirPenalty, true
+	default:
+		if gap, ok := fuzzySubsequenceGap(full, query); ok {
+			return 120 + gap + depth + dirPenalty, true
+		}
+		return 0, false
+	}
+}
+
+func fuzzySubsequenceGap(value, query string) (int, bool) {
+	if query == "" {
+		return 0, true
+	}
+	valueRunes := []rune(value)
+	gap := 0
+	last := -1
+	pos := 0
+	for _, q := range query {
+		found := -1
+		for pos < len(valueRunes) {
+			if valueRunes[pos] == q {
+				found = pos
+				pos++
+				break
+			}
+			pos++
+		}
+		if found < 0 {
+			return 0, false
+		}
+		if last >= 0 {
+			gap += found - last - 1
+		}
+		last = found
+	}
+	return gap, true
 }
 
 // dismissSuggestions clears the overlay without touching the run. Command

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -512,6 +512,7 @@ func (m model) dismissSuggestions() model {
 	if m.suggestionsAreFiles {
 		m.input.SetValue(removeTrailingAtToken(m.input.Value()))
 		m.input.CursorEnd()
+		m.resetComposerFromInput()
 	} else {
 		m.clearComposer()
 	}

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -258,6 +258,26 @@ func TestSuggestionOverlayRenders(t *testing.T) {
 	}
 }
 
+func TestSuggestionOverlayStaysVisibleWhenTranscriptScrolled(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width, m.height = 96, 32
+	m.altScreen = true
+	m.headerPrinted = true
+	for i := 0; i < 20; i++ {
+		m.transcript = appendRow(m.transcript, rowAssistant, "message "+string(rune('A'+i)))
+	}
+	m.chatScrollOffset = 12
+	m = typeRunes(t, m, "/")
+
+	plain := plainRender(t, m.View())
+	if !strings.Contains(plain, "Commands") || !strings.Contains(plain, "search >") {
+		t.Fatalf("suggestion overlay should stay visible above composer while transcript is scrolled, got %q", plain)
+	}
+	if got := len(strings.Split(plain, "\n")); got != m.height {
+		t.Fatalf("alt-screen view should keep terminal height, got %d lines want %d", got, m.height)
+	}
+}
+
 func TestSuggestionOverlayCapsRowsWithoutMoreText(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.width, m.height = 96, 30
@@ -282,7 +302,8 @@ func TestSuggestionOverlayCapsRowsWithoutMoreText(t *testing.T) {
 	if strings.Contains(plain, "more") {
 		t.Fatalf("scrolled palette should not render a more-count row, got %q", plain)
 	}
-	if !strings.Contains(plain, "│ ❯ clear") || strings.Contains(plain, "│ ❯ provider") || strings.Contains(plain, "│   provider") {
+	selected := strings.TrimPrefix(m.suggestions[m.suggestionIdx].Name, "/")
+	if !strings.Contains(plain, "│ ❯ "+selected) || strings.Contains(plain, "│ ❯ provider") || strings.Contains(plain, "│   provider") {
 		t.Fatalf("scrolled palette should move the visible command window, got %q", plain)
 	}
 }

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -495,6 +495,27 @@ func TestEscDismissesFilePaletteAndRemovesTrailingToken(t *testing.T) {
 	if got := m.composerValue(); got != "read x" {
 		t.Fatalf("Esc should keep composer state synced after removing @ token, got %q", got)
 	}
+
+	m = newModel(context.Background(), Options{Cwd: t.TempDir()})
+	m = typeRunes(t, m, "compare @old with @new")
+	m.input.SetCursor(len([]rune("compare @old")))
+	m.recomputeSuggestions()
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+
+	if m.suggestionsActive() {
+		t.Fatal("Esc should dismiss the cursor-local file palette")
+	}
+	if got := m.input.Value(); got != "compare  with @new" {
+		t.Fatalf("Esc should remove only the cursor-local @ token, got %q", got)
+	}
+	if got := m.input.Position(); got != len([]rune("compare ")) {
+		t.Fatalf("cursor after cursor-local removal = %d, want %d", got, len([]rune("compare ")))
+	}
+	if got := m.composerValue(); got != "compare  with @new" {
+		t.Fatalf("Esc should keep composer synced after cursor-local removal, got %q", got)
+	}
 }
 
 func TestExtractPathQueryUsesCursorPosition(t *testing.T) {

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -156,6 +156,41 @@ func TestEnterRunsCommandSuggestion(t *testing.T) {
 	}
 }
 
+func TestEnterPrefillsCommandSuggestionRequiringInput(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/sp") // selects /spec
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("Enter on an argument command suggestion should not start an agent run")
+	}
+	if got := m.input.Value(); got != "/spec " {
+		t.Fatalf("Enter should prefill command for arguments, got %q", got)
+	}
+	if m.suggestionsActive() {
+		t.Fatal("prefilling a command suggestion should dismiss the overlay")
+	}
+	if transcriptContains(m.transcript, "usage: /spec") {
+		t.Fatal("prefilling /spec should not run the command without a task")
+	}
+}
+
+func TestCommandSuggestionFooterReflectsInsertAction(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width, m.height = 96, 30
+	m = typeRunes(t, m, "/sp")
+
+	plain := plainRender(t, m.View())
+	if !strings.Contains(plain, "Enter insert") {
+		t.Fatalf("required-argument command footer should say Enter insert, got %q", plain)
+	}
+	if strings.Contains(plain, "Enter run") {
+		t.Fatalf("required-argument command footer should not say Enter run, got %q", plain)
+	}
+}
+
 func TestTabCompletesAfterSelection(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = typeRunes(t, m, "/mo")

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -367,6 +367,118 @@ func TestEscDismissesFilePaletteAndRemovesTrailingToken(t *testing.T) {
 	}
 }
 
+func TestExtractPathQueryUsesCursorPosition(t *testing.T) {
+	query := extractPathQuery("read @internal/file.go after", len([]rune("read @internal/file")))
+	if query == nil {
+		t.Fatal("expected path query at cursor")
+	}
+	if query.Query != "internal/file.go" || query.StartIndex != len([]rune("read ")) || query.EndIndex != len([]rune("read @internal/file.go")) {
+		t.Fatalf("query = %#v", query)
+	}
+	if got := extractPathQuery("read @internal/file.go after", len([]rune("read @internal/file.go after"))); got != nil {
+		t.Fatalf("cursor after mention should not be in path context, got %#v", got)
+	}
+}
+
+func TestCompletePathQueryReplacesActiveMentionOnly(t *testing.T) {
+	text := "compare @old and @ne"
+	cursor := len([]rune(text))
+	got, gotCursor := completePathQuery(text, cursor, "@new/file.go")
+	want := "compare @old and @new/file.go "
+	if got != want {
+		t.Fatalf("completePathQuery text = %q, want %q", got, want)
+	}
+	if gotCursor != len([]rune(want)) {
+		t.Fatalf("completePathQuery cursor = %d, want %d", gotCursor, len([]rune(want)))
+	}
+}
+
+func TestFilePaletteDisplaysFilenamesAndPaths(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "cmd/server/main.go")
+	mustWriteFile(t, root, "main.go")
+
+	m := newModel(context.Background(), Options{Cwd: root})
+	m.width, m.height = 96, 30
+	m = typeRunes(t, m, "@main")
+
+	plain := plainRender(t, m.View())
+	if strings.Contains(plain, "@main") {
+		t.Fatalf("file palette should not render @ prefixes, got %q", plain)
+	}
+	if !strings.Contains(plain, "main.go") || !strings.Contains(plain, "cmd/server") {
+		t.Fatalf("file palette should show filename plus parent path, got %q", plain)
+	}
+	if got := suggestionNames(m)[0]; got != "@main.go" {
+		t.Fatalf("basename prefix match should rank before nested path match, got first suggestion %q from %v", got, suggestionNames(m))
+	}
+}
+
+func TestFileSuggestionsIncludeDirectories(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal", "tui"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, root, "internal/tui/model.go")
+
+	got := suggestionTokens(fileSuggestions(root, "internal"))
+	if !contains(got, "@internal/") {
+		t.Fatalf("expected directory suggestion, got %v", got)
+	}
+}
+
+func TestEnterOnDirectorySuggestionKeepsFilePaletteOpen(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "internal/tui/model.go")
+	mustWriteFile(t, root, "internal/agent/loop.go")
+
+	m := newModel(context.Background(), Options{Cwd: root})
+	m = typeRunes(t, m, "@int")
+	if got := suggestionNames(m)[0]; got != "@internal/" {
+		t.Fatalf("expected internal directory first, got %q from %v", got, suggestionNames(m))
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("directory completion should not submit a prompt")
+	}
+	if got := m.input.Value(); got != "@internal/" {
+		t.Fatalf("directory completion should keep path active without trailing space, got %q", got)
+	}
+	if !m.suggestionsActive() || !m.suggestionsAreFiles {
+		t.Fatal("directory completion should keep the file palette open")
+	}
+	if names := suggestionNames(m); !contains(names, "@internal/tui/") || !contains(names, "@internal/agent/") {
+		t.Fatalf("directory completion should drill into that path, got %v", names)
+	}
+}
+
+func TestEnterOnFileSuggestionClosesFilePalette(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "internal/tui/model.go")
+
+	m := newModel(context.Background(), Options{Cwd: root})
+	m = typeRunes(t, m, "@model")
+	if got := suggestionNames(m)[0]; got != "@internal/tui/model.go" {
+		t.Fatalf("expected file suggestion first, got %q from %v", got, suggestionNames(m))
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("file completion should not submit a prompt")
+	}
+	if got := m.input.Value(); got != "@internal/tui/model.go " {
+		t.Fatalf("file completion should add trailing space, got %q", got)
+	}
+	if m.suggestionsActive() {
+		t.Fatal("file completion should close the file palette")
+	}
+}
+
 func TestFileSuggestionsMatchesAndSkipsVCSDirs(t *testing.T) {
 	root := t.TempDir()
 	mustWrite := func(rel string) {
@@ -460,4 +572,15 @@ func suggestionTokens(s []commandSuggestion) []string {
 		names = append(names, c.Name)
 	}
 	return names
+}
+
+func mustWriteFile(t *testing.T, root, rel string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -118,21 +118,41 @@ func TestUpDownMoveSuggestions(t *testing.T) {
 	}
 }
 
-func TestEnterCompletesSuggestion(t *testing.T) {
+func TestMouseWheelMovesSuggestions(t *testing.T) {
 	m := newModel(context.Background(), Options{})
-	m = typeRunes(t, m, "/mod") // selects /model first
+	m = typeRunes(t, m, "/")
+
+	updated, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m = updated.(model)
+	if m.suggestionIdx != 1 {
+		t.Fatalf("wheel down should select index 1, got %d", m.suggestionIdx)
+	}
+
+	updated, _ = m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	m = updated.(model)
+	if m.suggestionIdx != 0 {
+		t.Fatalf("wheel up should select index 0, got %d", m.suggestionIdx)
+	}
+}
+
+func TestEnterRunsCommandSuggestion(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/he") // selects /help
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(model)
 
 	if cmd != nil {
-		t.Fatal("Enter on a suggestion should complete, not submit a run")
+		t.Fatal("Enter on a command suggestion should not start an agent run")
 	}
-	if got := m.input.Value(); got != "/model " {
-		t.Fatalf("expected input completed to %q, got %q", "/model ", got)
+	if got := m.input.Value(); got != "" {
+		t.Fatalf("Enter on a command suggestion should clear input, got %q", got)
 	}
 	if m.suggestionsActive() {
-		t.Fatal("completing a suggestion should dismiss the overlay")
+		t.Fatal("running a command suggestion should dismiss the overlay")
+	}
+	if !transcriptContains(m.transcript, "Commands") {
+		t.Fatal("running /help from suggestions should append help output")
 	}
 }
 
@@ -149,7 +169,7 @@ func TestTabCompletesAfterSelection(t *testing.T) {
 	}
 }
 
-func TestEscDismissesSuggestionsWithoutClearingInput(t *testing.T) {
+func TestEscDismissesCommandSuggestionsAndClearsInput(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = typeRunes(t, m, "/mo")
 
@@ -159,8 +179,8 @@ func TestEscDismissesSuggestionsWithoutClearingInput(t *testing.T) {
 	if m.suggestionsActive() {
 		t.Fatal("Esc should dismiss the suggestion overlay")
 	}
-	if m.input.Value() != "/mo" {
-		t.Fatalf("Esc should not clear the input, got %q", m.input.Value())
+	if m.input.Value() != "" {
+		t.Fatalf("Esc should clear slash command input, got %q", m.input.Value())
 	}
 }
 
@@ -224,8 +244,126 @@ func TestSuggestionOverlayRenders(t *testing.T) {
 	m = typeRunes(t, m, "/mo")
 
 	view := m.View()
-	if !strings.Contains(view, "/model") || !strings.Contains(view, "/mode") {
+	plain := plainRender(t, view)
+	if !strings.Contains(plain, "model") || !strings.Contains(plain, "mode") {
 		t.Fatal("view should render the suggestion overlay")
+	}
+	if strings.Contains(plain, "/model") || strings.Contains(plain, "/mode") {
+		t.Fatalf("suggestion overlay should display command names without slash prefixes, got %q", plain)
+	}
+	for _, want := range []string{"╭── Commands", "╰", "search > mo", "↑/↓ move", "Enter run", "Esc close"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("suggestion overlay should include %q in %q", want, plain)
+		}
+	}
+}
+
+func TestSuggestionOverlayCapsRowsWithoutMoreText(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width, m.height = 96, 30
+	m = typeRunes(t, m, "/")
+
+	plain := plainRender(t, m.View())
+	if strings.Contains(plain, "more") {
+		t.Fatalf("bare slash palette should not render a more-count row, got %q", plain)
+	}
+	if !strings.Contains(plain, "│ ❯ provider") || !strings.Contains(plain, "│   context") {
+		t.Fatalf("top of palette should render first visible command window, got %q", plain)
+	}
+	if strings.Contains(plain, "compact") {
+		t.Fatalf("top of palette should cap hidden commands without rendering them, got %q", plain)
+	}
+
+	for range suggestionPaletteMaxVisible + 1 {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = updated.(model)
+	}
+	plain = plainRender(t, m.View())
+	if strings.Contains(plain, "more") {
+		t.Fatalf("scrolled palette should not render a more-count row, got %q", plain)
+	}
+	if !strings.Contains(plain, "│ ❯ clear") || strings.Contains(plain, "│ ❯ provider") || strings.Contains(plain, "│   provider") {
+		t.Fatalf("scrolled palette should move the visible command window, got %q", plain)
+	}
+}
+
+func TestCommandPaletteStaysOpenForNoMatches(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width, m.height = 96, 30
+	m = typeRunes(t, m, "/,")
+
+	if !m.suggestionsActive() {
+		t.Fatal("command palette should stay active for a no-match slash query")
+	}
+	if len(m.suggestions) != 0 {
+		t.Fatalf("expected no command matches, got %v", suggestionNames(m))
+	}
+	plain := plainRender(t, m.View())
+	for _, want := range []string{"search > ,", "no matching commands"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("no-match palette should include %q in %q", want, plain)
+		}
+	}
+	if strings.Contains(plain, "/,") {
+		t.Fatalf("slash query should stay inside palette display, got %q", plain)
+	}
+}
+
+func TestEnterOnNoMatchCommandPaletteDoesNotSubmit(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = typeRunes(t, m, "/,")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("Enter on no-match command palette should not start a command")
+	}
+	if m.input.Value() != "/," {
+		t.Fatalf("Enter on no-match command palette should preserve search input, got %q", m.input.Value())
+	}
+	if !m.suggestionsActive() {
+		t.Fatal("Enter on no-match command palette should keep palette open")
+	}
+	if transcriptContains(m.transcript, "unknown command") {
+		t.Fatal("Enter on no-match command palette should not submit an unknown command")
+	}
+}
+
+func TestFilePaletteStaysOpenForNoMatches(t *testing.T) {
+	m := newModel(context.Background(), Options{Cwd: t.TempDir()})
+	m.width, m.height = 96, 30
+	m = typeRunes(t, m, "@missing")
+
+	if !m.suggestionsActive() {
+		t.Fatal("file palette should stay active for a no-match @ query")
+	}
+	if len(m.suggestions) != 0 {
+		t.Fatalf("expected no file matches, got %v", suggestionNames(m))
+	}
+	plain := plainRender(t, m.View())
+	for _, want := range []string{"Files", "search > missing", "no matching files"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("no-match file palette should include %q in %q", want, plain)
+		}
+	}
+	if strings.Contains(plain, "@missing") {
+		t.Fatalf("bare @ query should stay inside palette display without @ prefix, got %q", plain)
+	}
+}
+
+func TestEscDismissesFilePaletteAndRemovesTrailingToken(t *testing.T) {
+	m := newModel(context.Background(), Options{Cwd: t.TempDir()})
+	m = typeRunes(t, m, "read @missing")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+
+	if m.suggestionsActive() {
+		t.Fatal("Esc should dismiss the file palette")
+	}
+	if got := m.input.Value(); got != "read " {
+		t.Fatalf("Esc should remove only the trailing @ token, got %q", got)
 	}
 }
 

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -295,6 +295,28 @@ func TestSuggestionOverlayStaysVisibleWhenTranscriptScrolled(t *testing.T) {
 	}
 }
 
+func TestOverlayViewportLinesPreservesTextOutsidePanel(t *testing.T) {
+	lines := []string{
+		"left edge text stays visible after panel",
+		"second row text stays visible after panel",
+		"third row text stays visible after panel",
+	}
+	overlay := strings.Join([]string{
+		"          ╭── Files ─╮",
+		"          │ row      │",
+		"          ╰──────────╯",
+	}, "\n")
+
+	got := overlayViewportLines(append([]string(nil), lines...), overlay, 48)
+	plain := plainRender(t, strings.Join(got, "\n"))
+	if !strings.Contains(plain, "left edge ╭── Files ─╮") {
+		t.Fatalf("overlay should preserve text left of the panel, got %q", plain)
+	}
+	if !strings.Contains(plain, "visible after panel") {
+		t.Fatalf("overlay should preserve text right of the panel, got %q", plain)
+	}
+}
+
 func TestSuggestionOverlayCapsRowsWithoutMoreText(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.width, m.height = 96, 30

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -273,8 +273,25 @@ func TestSuggestionOverlayStaysVisibleWhenTranscriptScrolled(t *testing.T) {
 	if !strings.Contains(plain, "Commands") || !strings.Contains(plain, "search >") {
 		t.Fatalf("suggestion overlay should stay visible above composer while transcript is scrolled, got %q", plain)
 	}
-	if got := len(strings.Split(plain, "\n")); got != m.height {
+	lines := strings.Split(plain, "\n")
+	if got := len(lines); got != m.height {
 		t.Fatalf("alt-screen view should keep terminal height, got %d lines want %d", got, m.height)
+	}
+	paletteLine := -1
+	composerLine := -1
+	for index, line := range lines {
+		switch {
+		case strings.Contains(line, "Commands"):
+			paletteLine = index
+		case strings.Contains(line, "no model") && strings.Contains(line, "auto-approve"):
+			composerLine = index
+		}
+	}
+	if paletteLine < 0 || composerLine < 0 {
+		t.Fatalf("expected palette and composer in view, palette=%d composer=%d view=%q", paletteLine, composerLine, plain)
+	}
+	if paletteLine >= composerLine-3 {
+		t.Fatalf("palette should be centered over chat, not anchored to composer; palette line %d composer line %d", paletteLine, composerLine)
 	}
 }
 

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -166,8 +166,38 @@ func TestEnterPrefillsCommandSuggestionRequiringInput(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("Enter on an argument command suggestion should not start an agent run")
 	}
-	if got := m.input.Value(); got != "/spec " {
+	if got := m.input.Value(); got != "/spec" {
 		t.Fatalf("Enter should prefill command for arguments, got %q", got)
+	}
+	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "/spec") || !strings.Contains(got, "[task]") {
+		t.Fatalf("prefilled command should show argument hint, got %q", got)
+	}
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("fix")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("typing the argument should not start an agent run")
+	}
+	if got := m.input.Value(); got != "/spec fix" {
+		t.Fatalf("typing after the hint should insert one argument separator, got %q", got)
+	}
+	for range "fix" {
+		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatal("backspacing the argument should not start an agent run")
+		}
+	}
+	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "/spec [task]") || strings.Contains(got, "/spec  [task]") {
+		t.Fatalf("empty argument command should render one visual separator, got %q", got)
+	}
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("typing after deleting the argument should not start an agent run")
+	}
+	if got := m.input.Value(); got != "/spec x" {
+		t.Fatalf("typing after deleting the argument should keep one separator, got %q", got)
 	}
 	if m.suggestionsActive() {
 		t.Fatal("prefilling a command suggestion should dismiss the overlay")

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -365,6 +365,11 @@ func TestEscDismissesFilePaletteAndRemovesTrailingToken(t *testing.T) {
 	if got := m.input.Value(); got != "read " {
 		t.Fatalf("Esc should remove only the trailing @ token, got %q", got)
 	}
+
+	m = typeRunes(t, m, "x")
+	if got := m.composerValue(); got != "read x" {
+		t.Fatalf("Esc should keep composer state synced after removing @ token, got %q", got)
+	}
 }
 
 func TestExtractPathQueryUsesCursorPosition(t *testing.T) {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -350,9 +350,34 @@ func commandSelectionRequiresInput(name string) bool {
 	return ok && commandUsageRequiresInput(command.usage)
 }
 
+func commandRequiredInputHint(name string) string {
+	command, ok := resolveCommand(name)
+	if !ok {
+		return ""
+	}
+	placeholder := commandUsageRequiredPlaceholder(command.usage)
+	if placeholder == "" {
+		return ""
+	}
+	return "[" + placeholder + "]"
+}
+
 func commandUsageRequiresInput(usage string) bool {
+	return commandUsageRequiredPlaceholder(usage) != ""
+}
+
+func commandUsageRequiredPlaceholder(usage string) string {
 	optionalDepth := 0
+	var placeholder strings.Builder
+	inPlaceholder := false
 	for _, char := range usage {
+		if inPlaceholder {
+			if char == '>' {
+				return strings.TrimSpace(placeholder.String())
+			}
+			placeholder.WriteRune(char)
+			continue
+		}
 		switch char {
 		case '[':
 			optionalDepth++
@@ -362,11 +387,11 @@ func commandUsageRequiresInput(usage string) bool {
 			}
 		case '<':
 			if optionalDepth == 0 {
-				return true
+				inPlaceholder = true
 			}
 		}
 	}
-	return false
+	return ""
 }
 
 func commandGroupOrder() []commandGroup {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -345,6 +345,30 @@ func formatCommandHelpLine(command commandDefinition) string {
 	return label + " - " + command.description
 }
 
+func commandSelectionRequiresInput(name string) bool {
+	command, ok := resolveCommand(name)
+	return ok && commandUsageRequiresInput(command.usage)
+}
+
+func commandUsageRequiresInput(usage string) bool {
+	optionalDepth := 0
+	for _, char := range usage {
+		switch char {
+		case '[':
+			optionalDepth++
+		case ']':
+			if optionalDepth > 0 {
+				optionalDepth--
+			}
+		case '<':
+			if optionalDepth == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func commandGroupOrder() []commandGroup {
 	return []commandGroup{
 		commandGroupModel,

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -71,6 +71,26 @@ func TestParseImageCommand(t *testing.T) {
 	}
 }
 
+func TestCommandSelectionRequiresInputFromUsage(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{name: "/spec", want: true},
+		{name: "/search", want: true},
+		{name: "/find", want: true},
+		{name: "/image", want: true},
+		{name: "/rewind", want: false},
+		{name: "/model", want: false},
+		{name: "/help", want: false},
+	}
+	for _, tc := range cases {
+		if got := commandSelectionRequiresInput(tc.name); got != tc.want {
+			t.Fatalf("commandSelectionRequiresInput(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestImageCommandIsDiscoverable(t *testing.T) {
 	found := false
 	for _, name := range listCommandNames() {

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -91,6 +91,24 @@ func TestCommandSelectionRequiresInputFromUsage(t *testing.T) {
 	}
 }
 
+func TestCommandRequiredInputHintFromUsage(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{name: "/spec", want: "[task]"},
+		{name: "/search", want: "[query]"},
+		{name: "/find", want: "[query]"},
+		{name: "/image", want: "[path]"},
+		{name: "/model", want: ""},
+	}
+	for _, tc := range cases {
+		if got := commandRequiredInputHint(tc.name); got != tc.want {
+			t.Fatalf("commandRequiredInputHint(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestImageCommandIsDiscoverable(t *testing.T) {
 	found := false
 	for _, name := range listCommandNames() {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -202,6 +203,9 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		} else {
 			text = sanitizeComposerInput(text)
 		}
+		if shouldInsertCommandArgumentSpace(state, text) {
+			text = " " + text
+		}
 		m.setComposerState(insertComposerText(state, text))
 	case msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlB:
 		state.cursor--
@@ -241,6 +245,24 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		m.recomputeSuggestions()
 	}
 	return m, true
+}
+
+func shouldInsertCommandArgumentSpace(state composerState, text string) bool {
+	if text == "" {
+		return false
+	}
+	first, _ := utf8.DecodeRuneInString(text)
+	if unicode.IsSpace(first) {
+		return false
+	}
+	state = normalizeComposerState(state)
+	if state.cursor != len([]rune(state.text)) {
+		return false
+	}
+	if strings.TrimRightFunc(state.text, unicode.IsSpace) != state.text {
+		return false
+	}
+	return commandArgumentHintForInput(state.text) != ""
 }
 
 func renderComposerState(state composerState, prompt string, width int) string {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -33,6 +33,9 @@ func deleteComposerWordBefore(state composerState) composerState {
 	}
 	runes := []rune(state.text)
 	start := state.cursor
+	for start > 0 && unicode.IsSpace(runes[start-1]) {
+		start--
+	}
 	for start > 0 && !unicode.IsSpace(runes[start-1]) {
 		start--
 	}
@@ -66,6 +69,34 @@ func deleteComposerLineBefore(state composerState) composerState {
 func deleteComposerLineAfter(state composerState) composerState {
 	state = normalizeComposerState(state)
 	return deleteComposerRange(state, state.cursor, composerLineEnd(state))
+}
+
+func moveComposerWordBefore(state composerState) composerState {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	pos := state.cursor
+	for pos > 0 && unicode.IsSpace(runes[pos-1]) {
+		pos--
+	}
+	for pos > 0 && !unicode.IsSpace(runes[pos-1]) {
+		pos--
+	}
+	state.cursor = pos
+	return state
+}
+
+func moveComposerWordAfter(state composerState) composerState {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	pos := state.cursor
+	for pos < len(runes) && unicode.IsSpace(runes[pos]) {
+		pos++
+	}
+	for pos < len(runes) && !unicode.IsSpace(runes[pos]) {
+		pos++
+	}
+	state.cursor = pos
+	return state
 }
 
 func sanitizeComposerPaste(text string) string {
@@ -150,6 +181,18 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		m.setComposerState(insertComposerText(state, "\n"))
 	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "d":
 		m.setComposerState(deleteComposerWordAfter(state))
+	case (msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlLeft) && msg.Alt:
+		m.setComposerState(moveComposerWordBefore(state))
+	case (msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlRight) && msg.Alt:
+		m.setComposerState(moveComposerWordAfter(state))
+	case msg.Type == tea.KeyCtrlLeft:
+		m.setComposerState(moveComposerWordBefore(state))
+	case msg.Type == tea.KeyCtrlRight:
+		m.setComposerState(moveComposerWordAfter(state))
+	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "b":
+		m.setComposerState(moveComposerWordBefore(state))
+	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "f":
+		m.setComposerState(moveComposerWordAfter(state))
 	case msg.Type == tea.KeySpace:
 		m.setComposerState(insertComposerText(state, " "))
 	case msg.Type == tea.KeyRunes && !msg.Alt:

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -224,7 +224,11 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 	case msg.Alt && msg.Type == tea.KeyDelete:
 		m.setComposerState(deleteComposerWordAfter(state))
 	case msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH:
-		m.setComposerState(deleteComposerRange(state, state.cursor-1, state.cursor))
+		if nextState, ok := deleteCompletedFileMentionBefore(state); ok && !m.suggestionsActive() {
+			m.setComposerState(nextState)
+		} else {
+			m.setComposerState(deleteComposerRange(state, state.cursor-1, state.cursor))
+		}
 	case msg.Type == tea.KeyDelete || msg.Type == tea.KeyCtrlD:
 		m.setComposerState(deleteComposerRange(state, state.cursor, state.cursor+1))
 	default:
@@ -250,6 +254,26 @@ func renderComposerState(state composerState, prompt string, width int) string {
 		lines[index] = fitStyledLine(prefix+line, width)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func deleteCompletedFileMentionBefore(state composerState) (composerState, bool) {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	if state.cursor <= 0 || state.cursor > len(runes) || !isPathQueryBoundary(runes[state.cursor-1]) {
+		return state, false
+	}
+	tokenEnd := state.cursor
+	for tokenEnd > 0 && isPathQueryBoundary(runes[tokenEnd-1]) {
+		tokenEnd--
+	}
+	tokenStart := tokenEnd
+	for tokenStart > 0 && !isPathQueryBoundary(runes[tokenStart-1]) {
+		tokenStart--
+	}
+	if tokenStart >= tokenEnd || runes[tokenStart] != '@' || tokenEnd-tokenStart <= 1 {
+		return state, false
+	}
+	return deleteComposerRange(state, tokenStart, state.cursor), true
 }
 
 func deleteComposerRange(state composerState, start int, end int) composerState {

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -59,6 +59,66 @@ func TestComposerDeleteWordAfterCursor(t *testing.T) {
 	}
 }
 
+func TestBackspaceAfterCompletedFileMentionRemovesWholeMention(t *testing.T) {
+	tests := []struct {
+		name       string
+		start      string
+		want       string
+		wantCursor int
+	}{
+		{
+			name:       "only mention",
+			start:      "@docs/NPM_WRAPPER_SMOKE.md ",
+			want:       "",
+			wantCursor: 0,
+		},
+		{
+			name:       "mention after prompt text",
+			start:      "read @docs/NPM_WRAPPER_SMOKE.md ",
+			want:       "read ",
+			wantCursor: len([]rune("read ")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newModel(context.Background(), Options{})
+			m.input.SetValue(tc.start)
+			m.input.CursorEnd()
+
+			updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+			next := updated.(model)
+
+			if got := next.composerValue(); got != tc.want {
+				t.Fatalf("composer value = %q, want %q", got, tc.want)
+			}
+			if got := next.currentComposerState().cursor; got != tc.wantCursor {
+				t.Fatalf("cursor = %d, want %d", got, tc.wantCursor)
+			}
+			if next.suggestionsActive() {
+				t.Fatal("completed mention deletion should not reopen the file picker")
+			}
+		})
+	}
+}
+
+func TestBackspaceInsideActiveFileMentionStillEditsQuery(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "docs/NPM_WRAPPER_SMOKE.md")
+	m := newModel(context.Background(), Options{Cwd: root})
+	m = typeRunes(t, m, "@docs")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	next := updated.(model)
+
+	if got := next.composerValue(); got != "@doc" {
+		t.Fatalf("composer value = %q, want active query edited", got)
+	}
+	if !next.suggestionsActive() || !next.suggestionsAreFiles {
+		t.Fatal("active file query backspace should keep the file picker open")
+	}
+}
+
 func TestSanitizeComposerPastePreservesNewlines(t *testing.T) {
 	got := sanitizeComposerPaste("alpha\tbeta\x00\nsecond\r\nthird\x1b[31m")
 	want := "alpha    beta\nsecond\nthird[31m"

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -33,6 +33,19 @@ func TestComposerDeleteWordBeforeCursor(t *testing.T) {
 	}
 }
 
+func TestComposerDeleteWordBeforeSkipsTrailingSpace(t *testing.T) {
+	state := composerState{text: "alpha beta  ", cursor: len([]rune("alpha beta  "))}
+
+	got := deleteComposerWordBefore(state)
+
+	if got.text != "alpha " {
+		t.Fatalf("text = %q, want %q", got.text, "alpha ")
+	}
+	if got.cursor != len([]rune("alpha ")) {
+		t.Fatalf("cursor = %d, want %d", got.cursor, len([]rune("alpha ")))
+	}
+}
+
 func TestComposerDeleteWordAfterCursor(t *testing.T) {
 	state := composerState{text: "alpha  beta gamma", cursor: len([]rune("alpha  "))}
 
@@ -121,5 +134,83 @@ func TestMultilineComposerAcceptsSpaceKey(t *testing.T) {
 	}
 	if !next.composerActive {
 		t.Fatal("space insertion should keep multiline composer state active")
+	}
+}
+
+func TestComposerTerminalWordKeybindings(t *testing.T) {
+	tests := []struct {
+		name       string
+		start      string
+		cursor     int
+		key        tea.KeyMsg
+		want       string
+		wantCursor int
+	}{
+		{
+			name:       "alt backspace skips trailing spaces",
+			start:      "alpha beta  ",
+			cursor:     len([]rune("alpha beta  ")),
+			key:        tea.KeyMsg{Type: tea.KeyBackspace, Alt: true},
+			want:       "alpha ",
+			wantCursor: len([]rune("alpha ")),
+		},
+		{
+			name:       "ctrl w skips trailing spaces",
+			start:      "alpha beta  ",
+			cursor:     len([]rune("alpha beta  ")),
+			key:        tea.KeyMsg{Type: tea.KeyCtrlW},
+			want:       "alpha ",
+			wantCursor: len([]rune("alpha ")),
+		},
+		{
+			name:       "alt b moves back a word",
+			start:      "alpha beta gamma",
+			cursor:     len([]rune("alpha beta gamma")),
+			key:        tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("b"), Alt: true},
+			want:       "alpha beta gamma",
+			wantCursor: len([]rune("alpha beta ")),
+		},
+		{
+			name:       "ctrl left moves back a word",
+			start:      "alpha beta gamma",
+			cursor:     len([]rune("alpha beta gamma")),
+			key:        tea.KeyMsg{Type: tea.KeyCtrlLeft},
+			want:       "alpha beta gamma",
+			wantCursor: len([]rune("alpha beta ")),
+		},
+		{
+			name:       "alt f moves forward a word",
+			start:      "alpha beta gamma",
+			cursor:     len([]rune("alpha ")),
+			key:        tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f"), Alt: true},
+			want:       "alpha beta gamma",
+			wantCursor: len([]rune("alpha beta")),
+		},
+		{
+			name:       "ctrl right moves forward a word",
+			start:      "alpha beta gamma",
+			cursor:     len([]rune("alpha ")),
+			key:        tea.KeyMsg{Type: tea.KeyCtrlRight},
+			want:       "alpha beta gamma",
+			wantCursor: len([]rune("alpha beta")),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newModel(context.Background(), Options{})
+			m.input.SetValue(tc.start)
+			m.input.SetCursor(tc.cursor)
+
+			updated, _ := m.Update(tc.key)
+			next := updated.(model)
+
+			if got := next.composerValue(); got != tc.want {
+				t.Fatalf("composer value = %q, want %q", got, tc.want)
+			}
+			if got := next.currentComposerState().cursor; got != tc.wantCursor {
+				t.Fatalf("cursor = %d, want %d", got, tc.wantCursor)
+			}
+		})
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -133,6 +133,10 @@ type model struct {
 	// of replacing the whole input.
 	suggestionsAreFiles bool
 	lastMouseSelection  mouseSelectionTarget
+	mouseCapture        bool
+	transcriptSelection transcriptSelectionState
+	copyStatus          string
+	copyStatusSeq       int
 
 	// picker, when non-nil, is an open interactive selector overlay (/model,
 	// /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and applies
@@ -347,14 +351,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if !ok {
 		return next, cmd
 	}
+	nm, mouseCmd := nm.syncMouseCapture()
 	nm, flushCmd := nm.settleTranscript()
-	switch {
-	case flushCmd == nil:
-		return nm, cmd
-	case cmd == nil:
-		return nm, flushCmd
+	return nm, batchCommands(cmd, mouseCmd, flushCmd)
+}
+
+func batchCommands(cmds ...tea.Cmd) tea.Cmd {
+	filtered := make([]tea.Cmd, 0, len(cmds))
+	for _, cmd := range cmds {
+		if cmd != nil {
+			filtered = append(filtered, cmd)
+		}
+	}
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
 	default:
-		return nm, tea.Batch(flushCmd, cmd)
+		return tea.Batch(filtered...)
 	}
 }
 
@@ -365,10 +380,24 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleSetupMouse(msg)
 		}
 		return m.handleMouse(msg)
+	case transcriptCopiedMsg:
+		m.transcriptSelection = transcriptSelectionState{}
+		m.copyStatusSeq++
+		m.copyStatus = "Copied!"
+		seq := m.copyStatusSeq
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+			return transcriptCopyStatusExpiredMsg{seq: seq}
+		})
+	case transcriptCopyStatusExpiredMsg:
+		if msg.seq == m.copyStatusSeq {
+			m.copyStatus = ""
+		}
+		return m, nil
 	case tea.KeyMsg:
 		if m.setup.visible {
 			return m.handleSetupKey(msg)
 		}
+		m.transcriptSelection = transcriptSelectionState{}
 		m.clearMouseSelection()
 		switch msg.Type {
 		case tea.KeyCtrlC:
@@ -835,15 +864,6 @@ func (m model) transcriptEmpty() bool {
 func (m model) transcriptView() string {
 	width := chatWidth(m.width)
 
-	var body strings.Builder
-	// The title bar prints once into scrollback on the first WindowSizeMsg;
-	// until then (the very first frame) it renders managed so the surface
-	// never appears headless.
-	if !m.headerPrinted {
-		body.WriteString(m.titleBar(width))
-		body.WriteString("\n")
-	}
-
 	suggestionOverlay := m.suggestionOverlay(width)
 	providerOverlay := m.providerWizardOverlay(width)
 	pickerOverlay := m.pickerOverlay(width)
@@ -856,51 +876,11 @@ func (m model) transcriptView() string {
 	case suggestionOverlay != "":
 		viewportOverlay = suggestionOverlay
 	}
-	if m.transcriptEmpty() && !m.pending {
-		if viewportOverlay != "" {
-			body.WriteString(m.emptyStateWithOverlay(width, viewportOverlay))
-		} else {
-			body.WriteString(m.emptyState(width))
-		}
-		body.WriteString("\n")
-	} else {
-		rc := buildRowContext(m.transcript)
-		shownAny := false
-		for index := m.flushed; index < len(m.transcript); index++ {
-			row := m.transcript[index]
-			// A welcome row carries no Lime visual (the empty state replaced it)
-			// and a resolved tool call collapses into its result's card.
-			if row.kind == rowWelcome || rc.skip(row) {
-				continue
-			}
-			// Blank-line separation before turns — including between the flushed
-			// history above and the first live row.
-			if (shownAny || m.flushedAny) && startsTurn(row.kind) {
-				body.WriteString("\n")
-			}
-			body.WriteString(m.renderRow(row, width, rc))
-			body.WriteString("\n")
-			shownAny = true
-		}
+	emptyOverlay := ""
+	if m.transcriptEmpty() && !m.pending && viewportOverlay != "" {
+		emptyOverlay = viewportOverlay
 	}
-
-	if m.pending {
-		body.WriteString("\n")
-		switch {
-		case m.pendingPermission != nil:
-			body.WriteString(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
-		case m.pendingAskUser != nil:
-			body.WriteString(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
-		default:
-			body.WriteString(m.interimBlock(width))
-		}
-		body.WriteString("\n")
-	}
-	if m.pendingSpecReview != nil {
-		body.WriteString("\n")
-		body.WriteString(renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width))
-		body.WriteString("\n")
-	}
+	body, _ := m.transcriptBody(width, emptyOverlay)
 
 	footer := m.footerView(width)
 
@@ -910,15 +890,13 @@ func (m model) transcriptView() string {
 	}
 
 	if m.altScreen && m.height > 0 {
-		return m.scrollableTranscriptView(body.String(), footer, width, overlayForViewport)
+		return m.scrollableTranscriptView(body, footer, width, overlayForViewport)
 	}
 
 	if overlayForViewport != "" {
-		body.WriteString("\n")
-		body.WriteString(overlayForViewport)
-		body.WriteString("\n")
+		body += "\n" + overlayForViewport + "\n"
 	}
-	return body.String() + footer
+	return body + footer
 }
 
 func (m model) footerView(width int) string {
@@ -926,6 +904,10 @@ func (m model) footerView(width int) string {
 	footer.WriteString("\n")
 	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
 		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
+		footer.WriteString("\n")
+	}
+	if copyStatus := strings.TrimSpace(m.copyStatus); copyStatus != "" {
+		footer.WriteString(rightAlignedLine(zeroTheme.ink.Render(copyStatus), width))
 		footer.WriteString("\n")
 	}
 	footer.WriteString(m.composerBox(width))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -319,14 +319,6 @@ const (
 	composerPlaceholderRunning = "running… esc to interrupt"
 )
 
-// emptyStateSuggestions are the three starter prompts offered on the empty
-// chat surface; pressing 1–3 while the composer is empty inserts one.
-var emptyStateSuggestions = []string{
-	"add a --version flag",
-	"explain internal/agent/loop.go",
-	"fix the failing test in internal/tools",
-}
-
 func (m model) Init() tea.Cmd {
 	return textinput.Blink
 }
@@ -572,20 +564,6 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.picker.appendQuery(msg.Runes)
 			}
 			return m, nil
-		}
-		// On the empty chat surface a bare 1–3 keypress (composer empty, no modal)
-		// inserts the matching starter suggestion instead of typing the digit.
-		// !pending mirrors the render condition exactly — the chips are off
-		// screen during a run (e.g. after /clear mid-run), so digits must type.
-		if m.transcriptEmpty() && !m.pending && strings.TrimSpace(m.composerValue()) == "" {
-			if k := msg.String(); len(k) == 1 && k >= "1" && k <= "3" {
-				if index := int(k[0] - '1'); index < len(emptyStateSuggestions) {
-					m.input.SetValue(emptyStateSuggestions[index])
-					m.input.CursorEnd()
-					m.resetComposerFromInput()
-					return m, nil
-				}
-			}
 		}
 		if next, ok := m.applyComposerKey(msg); ok {
 			return next, nil
@@ -891,9 +869,7 @@ func (m model) transcriptView() string {
 		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
 		footer.WriteString("\n")
 	}
-	footer.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
-	footer.WriteString("\n")
-	footer.WriteString(m.composerLine(width))
+	footer.WriteString(m.composerBox(width))
 	if queued := renderQueuedMessagePreview(m.queuedMessage, width); queued != "" {
 		footer.WriteString("\n")
 		footer.WriteString(queued)
@@ -910,8 +886,6 @@ func (m model) transcriptView() string {
 		footer.WriteString("\n")
 		footer.WriteString(picker)
 	}
-	footer.WriteString("\n")
-	footer.WriteString(zeroTheme.line.Render(strings.Repeat("─", width)))
 	footer.WriteString("\n")
 	footer.WriteString(m.statusLine(width))
 
@@ -1000,8 +974,6 @@ func (m model) composerLine(width int) string {
 	switch {
 	case m.pending:
 		hint = zeroTheme.faint.Render("esc stop")
-	case strings.TrimSpace(m.composerValue()) != "":
-		hint = zeroTheme.faint.Render("run ↵")
 	}
 	if m.composerActive && strings.Contains(m.composer.text, "\n") {
 		line := renderComposerState(m.composer, m.input.Prompt, width)
@@ -1017,6 +989,25 @@ func (m model) composerLine(width int) string {
 		return fitStyledLine(line, width)
 	}
 	return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
+}
+
+func (m model) composerBox(width int) string {
+	if width < 8 {
+		return fitStyledLine(m.composerLine(width), width)
+	}
+	innerWidth := maxInt(1, width-4)
+	content := m.composerLine(innerWidth)
+	lines := strings.Split(content, "\n")
+
+	rendered := make([]string, 0, len(lines)+2)
+	rendered = append(rendered, zeroTheme.lineStrong.Render("╭"+strings.Repeat("─", width-2)+"╮"))
+	for _, line := range lines {
+		fitted := fitStyledLine(line, innerWidth)
+		pad := strings.Repeat(" ", maxInt(0, innerWidth-lipgloss.Width(fitted)))
+		rendered = append(rendered, zeroTheme.lineStrong.Render("│ ")+fitted+pad+zeroTheme.lineStrong.Render(" │"))
+	}
+	rendered = append(rendered, m.composerDividerLine(width))
+	return strings.Join(rendered, "\n")
 }
 
 // startsTurn reports whether a row begins a new conversational turn and therefore

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -136,11 +136,14 @@ type model struct {
 	// picker, when non-nil, is an open interactive selector overlay (/model,
 	// /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and applies
 	// the chosen value through the existing command handlers.
-	picker                    *commandPicker
-	providerWizard            *providerWizardState
-	favoriteModels            map[string]bool
-	modelPickerLiveProviderID string
-	modelPickerLiveModels     []providermodeldiscovery.Model
+	picker                       *commandPicker
+	providerWizard               *providerWizardState
+	favoriteModels               map[string]bool
+	modelPickerLoading           bool
+	modelPickerLoadingProviderID string
+	modelPickerLoadError         string
+	modelPickerLiveProviderID    string
+	modelPickerLiveModels        []providermodeldiscovery.Model
 
 	// pendingImages holds image attachments staged by /image for the next user
 	// turn; pendingImageLabels are their display names (base(path)) for the chip
@@ -293,6 +296,7 @@ func newModel(ctx context.Context, options Options) model {
 		providerName:           options.ProviderName,
 		modelName:              options.ModelName,
 		providerProfile:        options.ProviderProfile,
+		favoriteModels:         favoriteModelSet(options.FavoriteModels),
 		provider:               options.Provider,
 		newProvider:            options.NewProvider,
 		discoverProviderModels: options.DiscoverProviderModels,
@@ -362,6 +366,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Button {
 		case tea.MouseButtonWheelUp:
 			if m.picker != nil {
+				if m.modelPickerIsLoading() {
+					return m, nil
+				}
 				m.picker.move(-1)
 				return m, nil
 			}
@@ -372,6 +379,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.scrollChat(chatWheelScrollLines), nil
 		case tea.MouseButtonWheelDown:
 			if m.picker != nil {
+				if m.modelPickerIsLoading() {
+					return m, nil
+				}
 				m.picker.move(1)
 				return m, nil
 			}
@@ -429,6 +439,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// An open picker cancels first; then an active suggestion overlay is
 			// dismissed. Neither cancels the run or clears the input.
 			if m.picker != nil {
+				if m.picker.kind == pickerModel {
+					m.clearModelPickerLoadState()
+				}
 				m.picker = nil
 				return m, nil
 			}
@@ -513,10 +526,16 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case tea.KeyCtrlF:
 			if m.picker != nil && m.picker.kind == pickerModel {
+				if m.modelPickerIsLoading() {
+					return m, nil
+				}
 				return m.toggleModelFavorite(), nil
 			}
 		case tea.KeyBackspace, tea.KeyCtrlH:
 			if m.picker != nil {
+				if m.modelPickerIsLoading() {
+					return m, nil
+				}
 				m.picker.deleteQueryRune()
 				return m, nil
 			}
@@ -549,6 +568,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.handleProviderWizardKey(msg)
 			}
 			if m.picker != nil {
+				if m.modelPickerIsLoading() {
+					return m, nil
+				}
 				m.picker.move(1)
 				return m, nil
 			}
@@ -567,6 +589,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.handleProviderWizardKey(msg)
 			}
 			if m.picker != nil {
+				if m.modelPickerIsLoading() {
+					return m, nil
+				}
 				m.picker.move(-1)
 				return m, nil
 			}
@@ -600,6 +625,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// An open picker is modal over the input: swallow remaining keys so they
 		// don't type into the field. ↑/↓/Enter/Esc were already handled above.
 		if m.picker != nil {
+			if m.modelPickerIsLoading() {
+				return m, nil
+			}
 			if msg.Type == tea.KeyRunes {
 				m.picker.appendQuery(msg.Runes)
 			}
@@ -1289,7 +1317,13 @@ func permissionDecisionReason(decision permissionDecision) string {
 // the picker. Behavior is identical to running "/model <id>", "/effort <v>",
 // or "/mode <name>".
 func (m model) choosePicker() (tea.Model, tea.Cmd) {
+	if m.modelPickerIsLoading() {
+		return m, nil
+	}
 	picker := m.picker
+	if picker != nil && picker.kind == pickerModel {
+		m.clearModelPickerLoadState()
+	}
 	m.picker = nil
 	if picker == nil {
 		return m, nil
@@ -1378,9 +1412,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 				m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: pickerBusyText(command.name)})
 				return m, nil
 			}
-			if picker := m.newModelPicker(); picker != nil {
-				m.picker = picker
-				return m, m.modelPickerDiscoveryCmd()
+			next, cmd := m.openModelPicker()
+			if next.picker != nil {
+				return next, cmd
 			}
 		}
 		text := ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -478,8 +478,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				wasFiles := m.suggestionsAreFiles
+				wasDirectory := m.selectedSuggestionIsDirectory()
 				next := m.completeSuggestion()
 				next.resetComposerFromInput()
+				if wasFiles && wasDirectory {
+					next.recomputeSuggestions()
+					return next, nil
+				}
 				if !wasFiles {
 					return next.handleSubmit()
 				}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -472,14 +472,16 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			// Enter on file suggestions inserts the @file token for continued
-			// composing. Enter on command suggestions executes the selected slash
-			// command immediately instead of echoing it into the composer.
+			// composing. Command suggestions execute only when the selected command
+			// is self-contained; commands that require a value are inserted so the
+			// user can finish the argument first.
 			if m.suggestionsActive() {
 				if len(m.suggestions) == 0 {
 					return m, nil
 				}
 				wasFiles := m.suggestionsAreFiles
 				wasDirectory := m.selectedSuggestionIsDirectory()
+				requiresInput := m.selectedCommandSuggestionRequiresInput()
 				next := m.completeSuggestion()
 				next.resetComposerFromInput()
 				if wasFiles && wasDirectory {
@@ -487,6 +489,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return next, nil
 				}
 				if !wasFiles {
+					if requiresInput {
+						return next, nil
+					}
 					return next.handleSubmit()
 				}
 				return next, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -119,9 +119,13 @@ type model struct {
 
 	// Slash-command autocomplete (purely additive UI state). suggestions is the
 	// live match list for the current "/token"; suggestionIdx is the highlighted
-	// row. Active only when suggestionsActive() (no modal, non-empty matches).
-	suggestions   []commandSuggestion
-	suggestionIdx int
+	// row. commandPaletteOpen keeps a zero-match command search active so invalid
+	// query text stays in the palette instead of leaking into the composer.
+	// filePaletteOpen does the same for a trailing "@token" file search.
+	suggestions        []commandSuggestion
+	suggestionIdx      int
+	commandPaletteOpen bool
+	filePaletteOpen    bool
 	// suggestionsAreFiles is true when the overlay is showing "@file" matches
 	// rather than "/command" matches, so completion inserts a path token instead
 	// of replacing the whole input.
@@ -355,8 +359,24 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.Button {
 		case tea.MouseButtonWheelUp:
+			if m.picker != nil {
+				m.picker.move(-1)
+				return m, nil
+			}
+			if m.suggestionsActive() {
+				m.moveSuggestion(-1)
+				return m, nil
+			}
 			return m.scrollChat(chatWheelScrollLines), nil
 		case tea.MouseButtonWheelDown:
+			if m.picker != nil {
+				m.picker.move(1)
+				return m, nil
+			}
+			if m.suggestionsActive() {
+				m.moveSuggestion(1)
+				return m, nil
+			}
 			return m.scrollChat(-chatWheelScrollLines), nil
 		default:
 			return m, nil
@@ -450,11 +470,19 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return next, nil
 				}
 			}
-			// Enter on a highlighted suggestion completes the input rather than
-			// submitting; Enter with no active suggestion submits as today.
+			// Enter on file suggestions inserts the @file token for continued
+			// composing. Enter on command suggestions executes the selected slash
+			// command immediately instead of echoing it into the composer.
 			if m.suggestionsActive() {
+				if len(m.suggestions) == 0 {
+					return m, nil
+				}
+				wasFiles := m.suggestionsAreFiles
 				next := m.completeSuggestion()
 				next.resetComposerFromInput()
+				if !wasFiles {
+					return next.handleSubmit()
+				}
 				return next, nil
 			}
 			return m.handleSubmit()
@@ -821,8 +849,13 @@ func (m model) transcriptView() string {
 		body.WriteString("\n")
 	}
 
+	suggestionOverlay := m.suggestionOverlay(width)
 	if m.transcriptEmpty() && !m.pending {
-		body.WriteString(m.emptyState(width))
+		if suggestionOverlay != "" {
+			body.WriteString(m.emptyStateWithOverlay(width, suggestionOverlay))
+		} else {
+			body.WriteString(m.emptyState(width))
+		}
 		body.WriteString("\n")
 	} else {
 		rc := buildRowContext(m.transcript)
@@ -843,6 +876,11 @@ func (m model) transcriptView() string {
 			body.WriteString("\n")
 			shownAny = true
 		}
+	}
+	if suggestionOverlay != "" && !(m.transcriptEmpty() && !m.pending) {
+		body.WriteString("\n")
+		body.WriteString(suggestionOverlay)
+		body.WriteString("\n")
 	}
 
 	if m.pending {
@@ -873,10 +911,6 @@ func (m model) transcriptView() string {
 	if queued := renderQueuedMessagePreview(m.queuedMessage, width); queued != "" {
 		footer.WriteString("\n")
 		footer.WriteString(queued)
-	}
-	if overlay := m.suggestionOverlay(width); overlay != "" {
-		footer.WriteString("\n")
-		footer.WriteString(overlay)
 	}
 	if wizard := m.providerWizardOverlay(width); wizard != "" {
 		footer.WriteString("\n")
@@ -969,6 +1003,11 @@ func (m model) composerLine(width int) string {
 	input := m.input
 	if m.pending {
 		input.Placeholder = composerPlaceholderRunning
+	}
+	if m.suggestionsActive() && (!m.suggestionsAreFiles || fileSuggestionOnlyInput(m.input.Value())) {
+		input.SetValue("")
+		input.Placeholder = ""
+		input.CursorEnd()
 	}
 	hint := ""
 	switch {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
@@ -975,15 +976,82 @@ func overlayViewportLines(lines []string, overlay string, width int) []string {
 	if len(overlayLines) == 0 {
 		return lines
 	}
+	left, overlayLines, overlayWidth := normalizeOverlayBlock(overlayLines, width)
+	if overlayWidth <= 0 {
+		return lines
+	}
 	start := maxInt(0, (len(lines)-len(overlayLines))/2)
 	for offset, line := range overlayLines {
 		target := start + offset
 		if target >= len(lines) {
 			break
 		}
-		lines[target] = fitStyledLine(line, width)
+		lines[target] = overlayViewportLine(lines[target], line, left, overlayWidth, width)
 	}
 	return lines
+}
+
+func normalizeOverlayBlock(lines []string, width int) (int, []string, int) {
+	left := -1
+	for _, line := range lines {
+		if strings.TrimSpace(ansi.Strip(line)) == "" {
+			continue
+		}
+		spaces := leadingPlainSpaces(line)
+		if left < 0 || spaces < left {
+			left = spaces
+		}
+	}
+	if left < 0 {
+		left = 0
+	}
+	left = minInt(left, maxInt(0, width-1))
+
+	trimmed := make([]string, 0, len(lines))
+	blockWidth := 0
+	for _, line := range lines {
+		if left > 0 && len(line) >= left {
+			line = line[left:]
+		}
+		trimmed = append(trimmed, line)
+		blockWidth = maxInt(blockWidth, lipgloss.Width(line))
+	}
+	blockWidth = minInt(blockWidth, maxInt(0, width-left))
+	return left, trimmed, blockWidth
+}
+
+func leadingPlainSpaces(line string) int {
+	spaces := 0
+	for spaces < len(line) && line[spaces] == ' ' {
+		spaces++
+	}
+	return spaces
+}
+
+func overlayViewportLine(base string, overlay string, left int, overlayWidth int, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	left = clampInt(left, 0, width)
+	overlayWidth = minInt(overlayWidth, width-left)
+	rightStart := minInt(width, left+overlayWidth)
+
+	base = fitStyledLine(base, width)
+	prefix := padStyledLine(ansi.Cut(base, 0, left), left)
+	panel := padStyledLine(overlay, overlayWidth)
+	suffix := padStyledLine(ansi.Cut(base, rightStart, width), width-rightStart)
+	return prefix + panel + suffix
+}
+
+func padStyledLine(line string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	line = fitStyledLine(line, width)
+	if pad := width - lipgloss.Width(line); pad > 0 {
+		line += strings.Repeat(" ", pad)
+	}
+	return line
 }
 
 func viewLines(value string) []string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -855,6 +855,7 @@ func (m model) transcriptView() string {
 	}
 
 	suggestionOverlay := m.suggestionOverlay(width)
+	suggestionInFooter := suggestionOverlay != "" && !(m.transcriptEmpty() && !m.pending)
 	if m.transcriptEmpty() && !m.pending {
 		if suggestionOverlay != "" {
 			body.WriteString(m.emptyStateWithOverlay(width, suggestionOverlay))
@@ -882,11 +883,6 @@ func (m model) transcriptView() string {
 			shownAny = true
 		}
 	}
-	if suggestionOverlay != "" && !(m.transcriptEmpty() && !m.pending) {
-		body.WriteString("\n")
-		body.WriteString(suggestionOverlay)
-		body.WriteString("\n")
-	}
 
 	if m.pending {
 		body.WriteString("\n")
@@ -908,6 +904,12 @@ func (m model) transcriptView() string {
 
 	var footer strings.Builder
 	footer.WriteString("\n")
+	if suggestionInFooter {
+		// Once real chat content exists, keep autocomplete anchored to the
+		// composer instead of appending it into the scrollable transcript.
+		footer.WriteString(suggestionOverlay)
+		footer.WriteString("\n")
+	}
 	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
 		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
 		footer.WriteString("\n")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -923,6 +923,10 @@ func (m model) footerView(width int) string {
 func (m model) scrollableTranscriptView(body string, footer string, width int, overlay string) string {
 	bodyLines := viewLines(body)
 	footerLines := viewLines(footer)
+	maxFooterLines := maxInt(0, m.height-1)
+	if len(footerLines) > maxFooterLines {
+		footerLines = footerLines[len(footerLines)-maxFooterLines:]
+	}
 	available := m.height - len(footerLines)
 	if available < 1 {
 		available = 1

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -855,7 +855,7 @@ func (m model) transcriptView() string {
 	}
 
 	suggestionOverlay := m.suggestionOverlay(width)
-	suggestionInFooter := suggestionOverlay != "" && !(m.transcriptEmpty() && !m.pending)
+	suggestionInViewport := suggestionOverlay != "" && !(m.transcriptEmpty() && !m.pending)
 	if m.transcriptEmpty() && !m.pending {
 		if suggestionOverlay != "" {
 			body.WriteString(m.emptyStateWithOverlay(width, suggestionOverlay))
@@ -904,12 +904,6 @@ func (m model) transcriptView() string {
 
 	var footer strings.Builder
 	footer.WriteString("\n")
-	if suggestionInFooter {
-		// Once real chat content exists, keep autocomplete anchored to the
-		// composer instead of appending it into the scrollable transcript.
-		footer.WriteString(suggestionOverlay)
-		footer.WriteString("\n")
-	}
 	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
 		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
 		footer.WriteString("\n")
@@ -931,13 +925,22 @@ func (m model) transcriptView() string {
 	footer.WriteString(m.statusLine(width))
 
 	if m.altScreen && m.height > 0 {
-		return m.scrollableTranscriptView(body.String(), footer.String(), width)
+		overlay := ""
+		if suggestionInViewport {
+			overlay = suggestionOverlay
+		}
+		return m.scrollableTranscriptView(body.String(), footer.String(), width, overlay)
 	}
 
+	if suggestionInViewport {
+		body.WriteString("\n")
+		body.WriteString(suggestionOverlay)
+		body.WriteString("\n")
+	}
 	return body.String() + footer.String()
 }
 
-func (m model) scrollableTranscriptView(body string, footer string, width int) string {
+func (m model) scrollableTranscriptView(body string, footer string, width int, overlay string) string {
 	bodyLines := viewLines(body)
 	footerLines := viewLines(footer)
 	available := m.height - len(footerLines)
@@ -956,11 +959,31 @@ func (m model) scrollableTranscriptView(body string, footer string, width int) s
 	for len(lines) < available {
 		lines = append(lines, "")
 	}
+	lines = overlayViewportLines(lines, overlay, width)
 	lines = append(lines, footerLines...)
 	for index, line := range lines {
 		lines[index] = fitStyledLine(line, width)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func overlayViewportLines(lines []string, overlay string, width int) []string {
+	if strings.TrimSpace(overlay) == "" || len(lines) == 0 {
+		return lines
+	}
+	overlayLines := viewLines(overlay)
+	if len(overlayLines) == 0 {
+		return lines
+	}
+	start := maxInt(0, (len(lines)-len(overlayLines))/2)
+	for offset, line := range overlayLines {
+		target := start + offset
+		if target >= len(lines) {
+			break
+		}
+		lines[target] = fitStyledLine(line, width)
+	}
+	return lines
 }
 
 func viewLines(value string) []string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -132,6 +132,7 @@ type model struct {
 	// rather than "/command" matches, so completion inserts a path token instead
 	// of replacing the whole input.
 	suggestionsAreFiles bool
+	lastMouseSelection  mouseSelectionTarget
 
 	// picker, when non-nil, is an open interactive selector overlay (/model,
 	// /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and applies
@@ -363,40 +364,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.setup.visible {
 			return m.handleSetupMouse(msg)
 		}
-		switch msg.Button {
-		case tea.MouseButtonWheelUp:
-			if m.picker != nil {
-				if m.modelPickerIsLoading() {
-					return m, nil
-				}
-				m.picker.move(-1)
-				return m, nil
-			}
-			if m.suggestionsActive() {
-				m.moveSuggestion(-1)
-				return m, nil
-			}
-			return m.scrollChat(chatWheelScrollLines), nil
-		case tea.MouseButtonWheelDown:
-			if m.picker != nil {
-				if m.modelPickerIsLoading() {
-					return m, nil
-				}
-				m.picker.move(1)
-				return m, nil
-			}
-			if m.suggestionsActive() {
-				m.moveSuggestion(1)
-				return m, nil
-			}
-			return m.scrollChat(-chatWheelScrollLines), nil
-		default:
-			return m, nil
-		}
+		return m.handleMouse(msg)
 	case tea.KeyMsg:
 		if m.setup.visible {
 			return m.handleSetupKey(msg)
 		}
+		m.clearMouseSelection()
 		switch msg.Type {
 		case tea.KeyCtrlC:
 			// cancelRun records the in-flight run into flushRunIDs and writes the
@@ -490,25 +463,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// is self-contained; commands that require a value are inserted so the
 			// user can finish the argument first.
 			if m.suggestionsActive() {
-				if len(m.suggestions) == 0 {
-					return m, nil
-				}
-				wasFiles := m.suggestionsAreFiles
-				wasDirectory := m.selectedSuggestionIsDirectory()
-				requiresInput := m.selectedCommandSuggestionRequiresInput()
-				next := m.completeSuggestion()
-				next.resetComposerFromInput()
-				if wasFiles && wasDirectory {
-					next.recomputeSuggestions()
-					return next, nil
-				}
-				if !wasFiles {
-					if requiresInput {
-						return next, nil
-					}
-					return next.handleSubmit()
-				}
-				return next, nil
+				return m.chooseSuggestion()
 			}
 			return m.handleSubmit()
 		case tea.KeyShiftTab:
@@ -947,6 +902,26 @@ func (m model) transcriptView() string {
 		body.WriteString("\n")
 	}
 
+	footer := m.footerView(width)
+
+	overlayForViewport := viewportOverlay
+	if m.transcriptEmpty() && !m.pending && viewportOverlay != "" {
+		overlayForViewport = ""
+	}
+
+	if m.altScreen && m.height > 0 {
+		return m.scrollableTranscriptView(body.String(), footer, width, overlayForViewport)
+	}
+
+	if overlayForViewport != "" {
+		body.WriteString("\n")
+		body.WriteString(overlayForViewport)
+		body.WriteString("\n")
+	}
+	return body.String() + footer
+}
+
+func (m model) footerView(width int) string {
 	var footer strings.Builder
 	footer.WriteString("\n")
 	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
@@ -960,22 +935,7 @@ func (m model) transcriptView() string {
 	}
 	footer.WriteString("\n")
 	footer.WriteString(m.statusLine(width))
-
-	overlayForViewport := viewportOverlay
-	if m.transcriptEmpty() && !m.pending && viewportOverlay != "" {
-		overlayForViewport = ""
-	}
-
-	if m.altScreen && m.height > 0 {
-		return m.scrollableTranscriptView(body.String(), footer.String(), width, overlayForViewport)
-	}
-
-	if overlayForViewport != "" {
-		body.WriteString("\n")
-		body.WriteString(overlayForViewport)
-		body.WriteString("\n")
-	}
-	return body.String() + footer.String()
+	return footer.String()
 }
 
 func (m model) scrollableTranscriptView(body string, footer string, width int, overlay string) string {
@@ -1347,6 +1307,28 @@ func (m model) choosePicker() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 	}
 	return m, nil
+}
+
+func (m model) chooseSuggestion() (tea.Model, tea.Cmd) {
+	if !m.suggestionsActive() || len(m.suggestions) == 0 {
+		return m, nil
+	}
+	wasFiles := m.suggestionsAreFiles
+	wasDirectory := m.selectedSuggestionIsDirectory()
+	requiresInput := m.selectedCommandSuggestionRequiresInput()
+	next := m.completeSuggestion()
+	next.resetComposerFromInput()
+	if wasFiles && wasDirectory {
+		next.recomputeSuggestions()
+		return next, nil
+	}
+	if !wasFiles {
+		if requiresInput {
+			return next, nil
+		}
+		return next.handleSubmit()
+	}
+	return next, nil
 }
 
 func (m model) handleSubmit() (tea.Model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -862,10 +862,20 @@ func (m model) transcriptView() string {
 	}
 
 	suggestionOverlay := m.suggestionOverlay(width)
-	suggestionInViewport := suggestionOverlay != "" && !(m.transcriptEmpty() && !m.pending)
+	providerOverlay := m.providerWizardOverlay(width)
+	pickerOverlay := m.pickerOverlay(width)
+	viewportOverlay := ""
+	switch {
+	case providerOverlay != "":
+		viewportOverlay = providerOverlay
+	case pickerOverlay != "":
+		viewportOverlay = pickerOverlay
+	case suggestionOverlay != "":
+		viewportOverlay = suggestionOverlay
+	}
 	if m.transcriptEmpty() && !m.pending {
-		if suggestionOverlay != "" {
-			body.WriteString(m.emptyStateWithOverlay(width, suggestionOverlay))
+		if viewportOverlay != "" {
+			body.WriteString(m.emptyStateWithOverlay(width, viewportOverlay))
 		} else {
 			body.WriteString(m.emptyState(width))
 		}
@@ -920,28 +930,21 @@ func (m model) transcriptView() string {
 		footer.WriteString("\n")
 		footer.WriteString(queued)
 	}
-	if wizard := m.providerWizardOverlay(width); wizard != "" {
-		footer.WriteString("\n")
-		footer.WriteString(wizard)
-	}
-	if picker := m.pickerOverlay(width); picker != "" {
-		footer.WriteString("\n")
-		footer.WriteString(picker)
-	}
 	footer.WriteString("\n")
 	footer.WriteString(m.statusLine(width))
 
-	if m.altScreen && m.height > 0 {
-		overlay := ""
-		if suggestionInViewport {
-			overlay = suggestionOverlay
-		}
-		return m.scrollableTranscriptView(body.String(), footer.String(), width, overlay)
+	overlayForViewport := viewportOverlay
+	if m.transcriptEmpty() && !m.pending && viewportOverlay != "" {
+		overlayForViewport = ""
 	}
 
-	if suggestionInViewport {
+	if m.altScreen && m.height > 0 {
+		return m.scrollableTranscriptView(body.String(), footer.String(), width, overlayForViewport)
+	}
+
+	if overlayForViewport != "" {
 		body.WriteString("\n")
-		body.WriteString(suggestionOverlay)
+		body.WriteString(overlayForViewport)
 		body.WriteString("\n")
 	}
 	return body.String() + footer.String()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -1126,11 +1127,46 @@ func (m model) composerLine(width int) string {
 		lines[len(lines)-1] = joinHeaderLine(fitStyledLine(lines[len(lines)-1], width-lipgloss.Width(hint)-2), hint, width)
 		return strings.Join(lines, "\n")
 	}
+	argumentHint := commandArgumentHintForInput(input.Value())
+	if argumentHint != "" && input.Position() != len([]rune(input.Value())) {
+		argumentHint = ""
+	}
+	if argumentHint != "" {
+		input.Width = 0
+		line := commandArgumentHintComposerLine(input, argumentHint)
+		if hint == "" {
+			return fitStyledLine(line, width)
+		}
+		return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
+	}
 	line := input.View()
 	if hint == "" {
 		return fitStyledLine(line, width)
 	}
 	return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
+}
+
+func commandArgumentHintComposerLine(input textinput.Model, argumentHint string) string {
+	hintRunes := []rune(argumentHint)
+	if len(hintRunes) == 0 {
+		return input.View()
+	}
+	input.Cursor.TextStyle = zeroTheme.faint
+	input.Cursor.SetChar(string(hintRunes[0]))
+	displayValue := strings.TrimRightFunc(input.Value(), unicode.IsSpace)
+	return input.PromptStyle.Render(input.Prompt) +
+		input.TextStyle.Inline(true).Render(displayValue) +
+		zeroTheme.faint.Render(" ") +
+		input.Cursor.View() +
+		zeroTheme.faint.Render(string(hintRunes[1:]))
+}
+
+func commandArgumentHintForInput(value string) string {
+	command := parseCommand(value)
+	if command.name == "" || strings.TrimSpace(command.text) != "" {
+		return ""
+	}
+	return commandRequiredInputHint(command.name)
 }
 
 func (m model) composerBox(width int) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -197,9 +197,9 @@ func TestInitialRenderShowsLimeChatSurface(t *testing.T) {
 	assertContains(t, view, "zero")
 	assertContains(t, view, "openai/gpt-4.1")
 	assertContains(t, view, emptyStateTagline)
-	assertContains(t, view, "running zero against ")
+	assertNotContains(t, view, "running zero against ")
 	assertContains(t, view, composerPlaceholderIdle)
-	assertContains(t, view, "interactive")
+	assertNotContains(t, view, "interactive")
 	if strings.Contains(view, "Welcome to Zero") {
 		t.Fatalf("empty chat surface should not show welcome transcript clutter, got %q", view)
 	}
@@ -229,9 +229,9 @@ func TestEmptyStateCollapsesAfterFirstPrompt(t *testing.T) {
 	if strings.Contains(view, emptyStateTagline) {
 		t.Fatalf("empty state should collapse after first prompt, got %q", view)
 	}
-	// Working view shows the status-line groups instead of footer hints.
-	assertContains(t, view, "interactive")
-	assertContains(t, view, "⏵⏵ auto-approve")
+	// Working view shows provider status and the composer divider model fallback.
+	assertNotContains(t, view, "interactive")
+	assertContains(t, view, "no model")
 }
 
 func TestEmptyStateStaysVisibleOnEmptySubmit(t *testing.T) {
@@ -1078,7 +1078,8 @@ func TestAgentEventRenderingMappingCoversRuntimeContract(t *testing.T) {
 		t.Fatalf("valid usage should update footer without transcript rows, got %#v", usageRows)
 	}
 	assertContains(t, m.usageStatusSegment(), "120 tok")
-	assertContains(t, m.statusLine(96), "⏵⏵ ask")
+	assertContains(t, m.composerDividerLine(96), "gpt-4.1")
+	assertContains(t, m.composerDividerLine(96), "ask")
 }
 
 func TestToolResultRowDefaultsEmptyStatusToOK(t *testing.T) {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -1,0 +1,294 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type mouseOverlayHit struct {
+	y int
+}
+
+type mouseSelectionTarget struct {
+	Scope string
+	Kind  int
+	Value string
+	Index int
+}
+
+func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if mouseLeftPress(msg) {
+		switch {
+		case m.providerWizard != nil:
+			if target, ok := m.selectProviderWizardAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.advanceProviderWizard()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
+		case m.picker != nil:
+			if target, ok := m.selectPickerAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.choosePicker()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
+		case m.suggestionsActive():
+			if target, ok := m.selectSuggestionAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.chooseSuggestion()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
+		}
+	}
+
+	switch {
+	case mouseWheelUp(msg):
+		m.clearMouseSelection()
+		if m.providerWizard != nil {
+			m.providerWizard.move(-1)
+			return m, nil
+		}
+		if m.picker != nil {
+			if m.modelPickerIsLoading() {
+				return m, nil
+			}
+			m.picker.move(-1)
+			return m, nil
+		}
+		if m.suggestionsActive() {
+			m.moveSuggestion(-1)
+			return m, nil
+		}
+		return m.scrollChat(chatWheelScrollLines), nil
+	case mouseWheelDown(msg):
+		m.clearMouseSelection()
+		if m.providerWizard != nil {
+			m.providerWizard.move(1)
+			return m, nil
+		}
+		if m.picker != nil {
+			if m.modelPickerIsLoading() {
+				return m, nil
+			}
+			m.picker.move(1)
+			return m, nil
+		}
+		if m.suggestionsActive() {
+			m.moveSuggestion(1)
+			return m, nil
+		}
+		return m.scrollChat(-chatWheelScrollLines), nil
+	default:
+		return m, nil
+	}
+}
+
+func (m model) repeatMouseSelection(target mouseSelectionTarget) bool {
+	return target.Scope != "" && m.lastMouseSelection == target
+}
+
+func (m *model) clearMouseSelection() {
+	m.lastMouseSelection = mouseSelectionTarget{}
+}
+
+func mouseLeftPress(msg tea.MouseMsg) bool {
+	return msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress || msg.Type == tea.MouseLeft
+}
+
+func mouseWheelUp(msg tea.MouseMsg) bool {
+	return msg.Button == tea.MouseButtonWheelUp || msg.Type == tea.MouseWheelUp
+}
+
+func mouseWheelDown(msg tea.MouseMsg) bool {
+	return msg.Button == tea.MouseButtonWheelDown || msg.Type == tea.MouseWheelDown
+}
+
+func (m *model) selectSuggestionAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if !m.suggestionsActive() || len(m.suggestions) == 0 {
+		return mouseSelectionTarget{}, false
+	}
+	width := chatWidth(m.width)
+	hit, ok := m.overlayMouseHit(msg, m.suggestionOverlay(width), width)
+	if !ok {
+		return mouseSelectionTarget{}, false
+	}
+	maxVisible := minInt(suggestionPaletteMaxVisible, len(m.suggestions))
+	start := selectableListStart(len(m.suggestions), maxVisible, clampInt(m.suggestionIdx, 0, len(m.suggestions)-1))
+	row := hit.y - 3
+	if row < 0 || row >= maxVisible {
+		return mouseSelectionTarget{}, false
+	}
+	index := start + row
+	m.suggestionIdx = index
+	scope := "command"
+	if m.suggestionsAreFiles {
+		scope = "file"
+	}
+	return mouseSelectionTarget{Scope: scope, Value: m.suggestions[index].Name, Index: index}, true
+}
+
+func (m *model) selectPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if m.picker == nil || len(m.picker.items) == 0 || m.modelPickerIsLoading() {
+		return mouseSelectionTarget{}, false
+	}
+	if m.picker.kind == pickerModel {
+		return m.selectModelPickerAtMouse(msg)
+	}
+	return m.selectGenericPickerAtMouse(msg)
+}
+
+func (m *model) selectModelPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	width := chatWidth(m.width)
+	hit, ok := m.overlayMouseHit(msg, m.modelPickerOverlay(width), width)
+	if !ok {
+		return mouseSelectionTarget{}, false
+	}
+	maxVisible := minInt(pickerOverlayMaxVisible, len(m.picker.items))
+	start := selectableListStart(len(m.picker.items), maxVisible, clampInt(m.picker.selected, 0, len(m.picker.items)-1))
+	rowStart := 3
+	if m.modelPickerLoadError != "" {
+		rowStart++
+	}
+	row := hit.y - rowStart
+	if row < 0 || row >= maxVisible {
+		return mouseSelectionTarget{}, false
+	}
+	index := start + row
+	m.picker.selected = index
+	return mouseSelectionTarget{Scope: "picker", Kind: int(m.picker.kind), Value: m.picker.items[index].Value, Index: index}, true
+}
+
+func (m *model) selectGenericPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	width := chatWidth(m.width)
+	hit, ok := m.overlayMouseHit(msg, m.pickerOverlay(width), width)
+	if !ok {
+		return mouseSelectionTarget{}, false
+	}
+	maxVisible := minInt(pickerOverlayMaxVisible, len(m.picker.items))
+	selected := clampInt(m.picker.selected, 0, len(m.picker.items)-1)
+	start := selectableListStart(len(m.picker.items), maxVisible, selected)
+	visible := m.picker.items[start : start+maxVisible]
+	line := 2
+	lastGroup := ""
+	for offset, item := range visible {
+		if item.Group != "" && item.Group != lastGroup {
+			if hit.y == line {
+				return mouseSelectionTarget{}, false
+			}
+			line++
+			lastGroup = item.Group
+		}
+		if hit.y == line {
+			index := start + offset
+			m.picker.selected = index
+			return mouseSelectionTarget{Scope: "picker", Kind: int(m.picker.kind), Value: item.Value, Index: index}, true
+		}
+		line++
+	}
+	return mouseSelectionTarget{}, false
+}
+
+func (m *model) selectProviderWizardAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if m.providerWizard == nil {
+		return mouseSelectionTarget{}, false
+	}
+	width := chatWidth(m.width)
+	hit, ok := m.overlayMouseHit(msg, m.providerWizardOverlay(width), width)
+	if !ok {
+		return mouseSelectionTarget{}, false
+	}
+	baseRow := 3
+	if m.providerWizard.err != "" {
+		baseRow += 2
+	}
+	switch m.providerWizard.step {
+	case providerWizardStepProvider:
+		if len(m.providerWizard.providers) == 0 {
+			return mouseSelectionTarget{}, false
+		}
+		maxVisible := minInt(maxProviderWizardProvidersVisible, len(m.providerWizard.providers))
+		selected := clampInt(m.providerWizard.selectedProvider, 0, len(m.providerWizard.providers)-1)
+		start := selectableListStart(len(m.providerWizard.providers), maxVisible, selected)
+		row := hit.y - (baseRow + 1)
+		if row < 0 || row >= maxVisible {
+			return mouseSelectionTarget{}, false
+		}
+		index := start + row
+		m.providerWizard.selectedProvider = index
+		m.providerWizard.apiKey = ""
+		m.providerWizard.refreshModels()
+		return mouseSelectionTarget{Scope: "provider-wizard", Kind: int(m.providerWizard.step), Value: m.providerWizard.providers[index].ID, Index: index}, true
+	case providerWizardStepModel:
+		if m.providerWizard.modelLoading {
+			return mouseSelectionTarget{}, false
+		}
+		m.providerWizard.refreshModels()
+		models := m.providerWizard.filteredModels()
+		if len(models) == 0 {
+			return mouseSelectionTarget{}, false
+		}
+		maxVisible := minInt(maxProviderWizardModelsVisible, len(models))
+		selected := clampInt(m.providerWizard.selectedModel, 0, len(models)-1)
+		start := selectableListStart(len(models), maxVisible, selected)
+		rowStart := baseRow + 2
+		if m.providerWizard.modelStatusText() != "" {
+			rowStart++
+		}
+		row := hit.y - rowStart
+		if row < 0 || row >= maxVisible {
+			return mouseSelectionTarget{}, false
+		}
+		index := start + row
+		m.providerWizard.selectedModel = index
+		return mouseSelectionTarget{Scope: "provider-wizard", Kind: int(m.providerWizard.step), Value: models[index].ID, Index: index}, true
+	default:
+		return mouseSelectionTarget{}, false
+	}
+}
+
+func (m model) overlayMouseHit(msg tea.MouseMsg, overlay string, width int) (mouseOverlayHit, bool) {
+	lines := viewLines(overlay)
+	if len(lines) == 0 {
+		return mouseOverlayHit{}, false
+	}
+	left, lines, overlayWidth := normalizeOverlayBlock(lines, width)
+	if overlayWidth <= 0 || len(lines) == 0 {
+		return mouseOverlayHit{}, false
+	}
+	top := m.overlayMouseTop(len(lines), width)
+	if msg.Y < top || msg.Y >= top+len(lines) {
+		return mouseOverlayHit{}, false
+	}
+	if msg.X < left || msg.X >= left+overlayWidth {
+		return mouseOverlayHit{}, false
+	}
+	return mouseOverlayHit{y: msg.Y - top}, true
+}
+
+func (m model) overlayMouseTop(overlayHeight int, width int) int {
+	if overlayHeight <= 0 {
+		return 0
+	}
+	if m.altScreen && m.height > 0 {
+		if m.transcriptEmpty() && !m.pending {
+			top := 0
+			available := normalizedStartupHeight(m.height) - 5
+			if !m.headerPrinted {
+				top += len(viewLines(m.titleBar(width)))
+				available -= 2
+			}
+			return top + maxInt(0, (available-overlayHeight)/2)
+		}
+		available := m.height - len(viewLines(m.footerView(width)))
+		if available < 1 {
+			available = 1
+		}
+		return maxInt(0, (available-overlayHeight)/2)
+	}
+	return maxInt(0, (normalizedStartupHeight(m.height)-overlayHeight)/2)
+}

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -126,6 +126,9 @@ func (m model) syncMouseCapture() (model, tea.Cmd) {
 	return m, tea.DisableMouse
 }
 
+// Bubble Tea's Type field is deprecated, but its parser still populates it for
+// compatibility cases such as left-button drag events. Keep these helpers
+// tolerant of both the current Button/Action pair and legacy Type values.
 func mouseLeftPress(msg tea.MouseMsg) bool {
 	return msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress ||
 		msg.Type == tea.MouseLeft && msg.Action == tea.MouseActionPress

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -45,6 +45,9 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	}
+	if next, cmd, ok := m.handleTranscriptSelectionMouse(msg); ok {
+		return next, cmd
+	}
 
 	switch {
 	case mouseWheelUp(msg):
@@ -96,8 +99,44 @@ func (m *model) clearMouseSelection() {
 	m.lastMouseSelection = mouseSelectionTarget{}
 }
 
+func (m model) wantsMouseCapture() bool {
+	return m.altScreen && (m.setupWantsMouseCapture() || m.chatWantsMouseCapture() || m.providerWizard != nil || m.picker != nil || m.suggestionsActive())
+}
+
+func (m model) setupWantsMouseCapture() bool {
+	if !m.setup.visible {
+		return false
+	}
+	return m.setup.stage == setupStageProvider || m.setup.stage == setupStageModel
+}
+
+func (m model) chatWantsMouseCapture() bool {
+	return !m.setup.visible
+}
+
+func (m model) syncMouseCapture() (model, tea.Cmd) {
+	want := m.wantsMouseCapture()
+	if m.mouseCapture == want {
+		return m, nil
+	}
+	m.mouseCapture = want
+	if want {
+		return m, tea.EnableMouseCellMotion
+	}
+	return m, tea.DisableMouse
+}
+
 func mouseLeftPress(msg tea.MouseMsg) bool {
-	return msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress || msg.Type == tea.MouseLeft
+	return msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress ||
+		msg.Type == tea.MouseLeft && msg.Action == tea.MouseActionPress
+}
+
+func mouseMotion(msg tea.MouseMsg) bool {
+	return msg.Action == tea.MouseActionMotion || msg.Type == tea.MouseMotion
+}
+
+func mouseRelease(msg tea.MouseMsg) bool {
+	return msg.Action == tea.MouseActionRelease || msg.Type == tea.MouseRelease
 }
 
 func mouseWheelUp(msg tea.MouseMsg) bool {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -324,7 +324,6 @@ func TestTranscriptSelectionUpdatesOnGenericMotion(t *testing.T) {
 	updated, _ = m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonNone,
 		Action: tea.MouseActionMotion,
-		Type:   tea.MouseMotion,
 		X:      7,
 		Y:      0,
 	})
@@ -343,11 +342,12 @@ func TestTranscriptSelectionLeftDragDoesNotResetAnchor(t *testing.T) {
 	updated, _ := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
-		Type:   tea.MouseLeft,
 		X:      0,
 		Y:      0,
 	})
 	m = updated.(model)
+	// Bubble Tea marks left-button drag motion as Type MouseLeft for backward
+	// compatibility; this must update the cursor without resetting the anchor.
 	updated, _ = m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionMotion,
@@ -377,7 +377,6 @@ func TestTranscriptSelectionReleaseExtendsRangeWithoutMotion(t *testing.T) {
 	updated, cmd := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonNone,
 		Action: tea.MouseActionRelease,
-		Type:   tea.MouseRelease,
 		X:      7,
 		Y:      0,
 	})

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -36,9 +37,7 @@ func TestMouseClickSelectsThenAppliesCommandSuggestionRow(t *testing.T) {
 
 	updated, cmd = next.Update(click)
 	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("required-argument second command click should not return a command")
-	}
+	_ = cmd
 	if got := next.input.Value(); got != "/spec" {
 		t.Fatalf("input after second command click = %q, want /spec", got)
 	}
@@ -60,6 +59,7 @@ func TestMouseClickSelectsThenAppliesPickerRow(t *testing.T) {
 		selected: 0,
 	}
 	m.picker.allItems = append([]pickerItem{}, m.picker.items...)
+	m.mouseCapture = true
 
 	width := chatWidth(m.width)
 	top := m.overlayMouseTop(len(viewLines(m.pickerOverlay(width))), width)
@@ -83,9 +83,7 @@ func TestMouseClickSelectsThenAppliesPickerRow(t *testing.T) {
 
 	updated, cmd = next.Update(click)
 	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("second picker click should not return a command")
-	}
+	_ = cmd
 	if next.picker != nil {
 		t.Fatalf("picker should close after second click apply, got %#v", next.picker)
 	}
@@ -100,6 +98,7 @@ func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
 	if m.providerWizard == nil || len(m.providerWizard.providers) < 2 {
 		t.Fatalf("expected multiple providers, got %#v", m.providerWizard)
 	}
+	m.mouseCapture = true
 
 	width := chatWidth(m.width)
 	top := m.overlayMouseTop(len(viewLines(m.providerWizardOverlay(width))), width)
@@ -123,9 +122,7 @@ func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
 
 	updated, cmd = next.Update(click)
 	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("second provider click should not return a command in this fixture")
-	}
+	_ = cmd
 	if next.providerWizard == nil || next.providerWizard.step == providerWizardStepProvider {
 		t.Fatalf("second provider click should advance, got %#v", next.providerWizard)
 	}
@@ -134,6 +131,7 @@ func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
 func TestMouseWheelMovesProviderWizardRows(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()
+	m.mouseCapture = true
 
 	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
 	next := updated.(model)
@@ -145,11 +143,354 @@ func TestMouseWheelMovesProviderWizardRows(t *testing.T) {
 	}
 }
 
+func TestMouseClickSelectsThenContinuesSetupProviderRow(t *testing.T) {
+	m := setupMouseTestModel()
+	m.mouseCapture = true
+	m.setup.stage = setupStageProvider
+
+	width := chatWidth(m.width)
+	height := normalizedStartupHeight(m.height)
+	rowWidth := setupProviderBlockWidth(width, m.setup.providers)
+	top := setupContentTop(height, len(m.setupProviderLines(width, height)), m.setup.err != "")
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      maxInt(0, (width-rowWidth)/2) + 2,
+		Y:      top + 3,
+	}
+	updated, cmd := m.Update(click)
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("first setup provider click should not return a command")
+	}
+	if next.setup.selected != 1 {
+		t.Fatalf("setup provider selection = %d, want 1", next.setup.selected)
+	}
+	if next.setup.stage != setupStageProvider {
+		t.Fatalf("first setup provider click advanced to %v", next.setup.stage)
+	}
+
+	updated, cmd = next.Update(click)
+	next = updated.(model)
+	_ = cmd
+	if next.setup.stage != setupStageCredentials {
+		t.Fatalf("second setup provider click should advance to credentials, got %v", next.setup.stage)
+	}
+}
+
+func TestMouseClickSelectsThenContinuesSetupModelRow(t *testing.T) {
+	m := setupMouseTestModel()
+	m.mouseCapture = true
+	m.setup.stage = setupStageModel
+	m.setup.models = []providerWizardModel{
+		{ID: "alpha"},
+		{ID: "beta", Meta: "128K ctx"},
+	}
+	m.setup.modelForID = m.setupProviderDescriptor().ID
+
+	width := chatWidth(m.width)
+	height := normalizedStartupHeight(m.height)
+	rowWidth := setupModelBlockWidth(width, m.setup.models)
+	top := setupContentTop(height, len(m.setupModelLines(width, height)), m.setup.err != "")
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      maxInt(0, (width-rowWidth)/2) + 2,
+		Y:      top + 5,
+	}
+	updated, cmd := m.Update(click)
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("first setup model click should not return a command")
+	}
+	if next.setup.modelIndex != 1 {
+		t.Fatalf("setup model selection = %d, want 1", next.setup.modelIndex)
+	}
+	if next.setup.stage != setupStageModel {
+		t.Fatalf("first setup model click advanced to %v", next.setup.stage)
+	}
+
+	updated, cmd = next.Update(click)
+	next = updated.(model)
+	_ = cmd
+	if next.setup.stage != setupStageSafety {
+		t.Fatalf("second setup model click should advance to safety, got %v", next.setup.stage)
+	}
+}
+
+func TestMouseCaptureOnlyWhileInteractiveSurfaceOpen(t *testing.T) {
+	m := mouseTestModel()
+	m.transcript = appendRow(m.transcript, rowUser, "hello")
+	if !m.wantsMouseCapture() {
+		t.Fatal("chat should capture mouse for Zero-owned transcript selection")
+	}
+
+	m = typeRunes(t, m, "/")
+	if !m.wantsMouseCapture() || !m.mouseCapture {
+		t.Fatalf("open command palette should capture mouse, wants=%v active=%v", m.wantsMouseCapture(), m.mouseCapture)
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+	_ = cmd
+	if !m.wantsMouseCapture() || !m.mouseCapture {
+		t.Fatalf("closed command palette should keep chat mouse capture, wants=%v active=%v", m.wantsMouseCapture(), m.mouseCapture)
+	}
+}
+
+func TestMouseCaptureOnEmptyChatSplash(t *testing.T) {
+	m := mouseTestModel()
+	if !m.wantsMouseCapture() {
+		t.Fatal("empty chat splash should capture mouse so only real transcript content becomes selectable")
+	}
+
+	m.transcript = appendRow(m.transcript, rowUser, "hello")
+	if !m.wantsMouseCapture() {
+		t.Fatal("chat with transcript rows should keep mouse capture for Zero-owned selection")
+	}
+}
+
+func TestTranscriptSelectionOnlyStartsOnTranscriptText(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendRow(m.transcript, rowUser, "hello world")
+
+	updated, cmd := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      40,
+		Y:      20,
+	})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("empty-area click should not return a command")
+	}
+	if next.transcriptSelection.active {
+		t.Fatal("empty-area click should not start transcript selection")
+	}
+
+	updated, cmd = next.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      0,
+		Y:      0,
+	})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("transcript press should not copy yet")
+	}
+	if !next.transcriptSelection.active {
+		t.Fatal("transcript text click should start transcript selection")
+	}
+}
+
+func TestTranscriptSelectionExtractsVisibleTextRange(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendRow(m.transcript, rowUser, "hello world")
+
+	updated, _ := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      0,
+		Y:      0,
+	})
+	m = updated.(model)
+	updated, _ = m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionMotion,
+		X:      7,
+		Y:      0,
+	})
+	m = updated.(model)
+
+	if got := m.selectedTranscriptText(); got != "hello" {
+		t.Fatalf("selectedTranscriptText() = %q, want hello", got)
+	}
+}
+
+func TestTranscriptSelectionUpdatesOnGenericMotion(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendRow(m.transcript, rowUser, "hello world")
+
+	updated, _ := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      0,
+		Y:      0,
+	})
+	m = updated.(model)
+	updated, _ = m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonNone,
+		Action: tea.MouseActionMotion,
+		Type:   tea.MouseMotion,
+		X:      7,
+		Y:      0,
+	})
+	m = updated.(model)
+
+	if got := m.selectedTranscriptText(); got != "hello" {
+		t.Fatalf("selectedTranscriptText() after generic motion = %q, want hello", got)
+	}
+}
+
+func TestTranscriptSelectionLeftDragDoesNotResetAnchor(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendRow(m.transcript, rowUser, "hello world")
+
+	updated, _ := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		Type:   tea.MouseLeft,
+		X:      0,
+		Y:      0,
+	})
+	m = updated.(model)
+	updated, _ = m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionMotion,
+		Type:   tea.MouseLeft,
+		X:      7,
+		Y:      0,
+	})
+	m = updated.(model)
+
+	if got := m.selectedTranscriptText(); got != "hello" {
+		t.Fatalf("selectedTranscriptText() after left-button drag = %q, want hello", got)
+	}
+}
+
+func TestTranscriptSelectionReleaseExtendsRangeWithoutMotion(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendRow(m.transcript, rowUser, "hello world")
+
+	updated, _ := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      0,
+		Y:      0,
+	})
+	m = updated.(model)
+	updated, cmd := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonNone,
+		Action: tea.MouseActionRelease,
+		Type:   tea.MouseRelease,
+		X:      7,
+		Y:      0,
+	})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("release after range selection should return copy command")
+	}
+	if got := m.selectedTranscriptText(); got != "hello" {
+		t.Fatalf("selectedTranscriptText() after release = %q, want hello", got)
+	}
+}
+
+func TestTranscriptSelectionClearsAfterCopy(t *testing.T) {
+	m := mouseTestModel()
+	m.transcriptSelection = transcriptSelectionState{active: true}
+
+	updated, cmd := m.Update(transcriptCopiedMsg{chars: 5})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("copy feedback should schedule a status clear")
+	}
+	if next.transcriptSelection.active {
+		t.Fatal("selection highlight should clear after copy feedback")
+	}
+	if next.copyStatus != "Copied!" {
+		t.Fatalf("copyStatus = %q, want Copied!", next.copyStatus)
+	}
+}
+
+func TestTranscriptCopyStatusClearsOnlyForLatestCopy(t *testing.T) {
+	m := mouseTestModel()
+
+	updated, _ := m.Update(transcriptCopiedMsg{chars: 5})
+	m = updated.(model)
+	firstSeq := m.copyStatusSeq
+
+	updated, _ = m.Update(transcriptCopiedMsg{chars: 8})
+	m = updated.(model)
+	secondSeq := m.copyStatusSeq
+
+	updated, _ = m.Update(transcriptCopyStatusExpiredMsg{seq: firstSeq})
+	m = updated.(model)
+	if m.copyStatus != "Copied!" {
+		t.Fatalf("stale expiry cleared status: %q", m.copyStatus)
+	}
+
+	updated, _ = m.Update(transcriptCopyStatusExpiredMsg{seq: secondSeq})
+	m = updated.(model)
+	if m.copyStatus != "" {
+		t.Fatalf("latest expiry left status = %q, want empty", m.copyStatus)
+	}
+}
+
+func TestTranscriptCopyStatusRendersAboveComposer(t *testing.T) {
+	m := mouseTestModel()
+	m.providerName = "ollama-cloud"
+	m.modelName = "qwen3-coder:480b"
+	m.copyStatus = "Copied!"
+
+	footer := plainRender(t, m.footerView(80))
+	lines := strings.Split(footer, "\n")
+	if len(lines) < 2 || !strings.Contains(lines[1], "Copied!") {
+		t.Fatalf("footer should show copy status above composer, got:\n%s", footer)
+	}
+	if strings.Contains(plainRender(t, m.statusLine(80)), "Copied!") {
+		t.Fatalf("status line should not contain copy feedback: %q", plainRender(t, m.statusLine(80)))
+	}
+}
+
+func TestMouseCaptureOnlyDuringInteractiveSetupStages(t *testing.T) {
+	m := setupMouseTestModel()
+	stages := []struct {
+		stage setupStage
+		want  bool
+	}{
+		{setupStageWelcome, false},
+		{setupStageProvider, true},
+		{setupStageCredentials, false},
+		{setupStageModel, true},
+		{setupStageSafety, false},
+		{setupStageReady, false},
+	}
+
+	for _, tt := range stages {
+		m.setup.stage = tt.stage
+		if got := m.wantsMouseCapture(); got != tt.want {
+			t.Fatalf("wantsMouseCapture at setup stage %v = %v, want %v", tt.stage, got, tt.want)
+		}
+	}
+}
+
 func mouseTestModel() model {
 	m := newModel(context.Background(), Options{})
 	m.width = 100
 	m.height = 30
 	m.altScreen = true
 	m.headerPrinted = true
+	return m
+}
+
+func setupMouseTestModel() model {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "openai", Name: "OpenAI", DefaultModel: "gpt-4.1", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+				{ID: "anthropic", Name: "Anthropic", DefaultModel: "claude-sonnet-4.5", EnvVar: "ANTHROPIC_API_KEY", RequiresAuth: true},
+				{ID: "ollama", Name: "Ollama Local", DefaultModel: "llama3.1", Local: true},
+			},
+		},
+	})
+	m.width = 100
+	m.height = 30
+	m.altScreen = true
 	return m
 }

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestMouseClickSelectsThenAppliesCommandSuggestionRow(t *testing.T) {
+	m := mouseTestModel()
+	m = typeRunes(t, m, "/sp")
+	if len(m.suggestions) == 0 {
+		t.Fatalf("expected command suggestions, got %#v", m.suggestions)
+	}
+
+	width := chatWidth(m.width)
+	top := m.overlayMouseTop(len(viewLines(m.suggestionOverlay(width))), width)
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      width / 2,
+		Y:      top + 3,
+	}
+	updated, cmd := m.Update(click)
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("first command click should not return a command")
+	}
+	if got := next.input.Value(); got != "/sp" {
+		t.Fatalf("input after first command click = %q, want /sp", got)
+	}
+	if !next.suggestionsActive() {
+		t.Fatal("suggestions should stay open after first command click")
+	}
+
+	updated, cmd = next.Update(click)
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("required-argument second command click should not return a command")
+	}
+	if got := next.input.Value(); got != "/spec" {
+		t.Fatalf("input after second command click = %q, want /spec", got)
+	}
+	if next.suggestionsActive() {
+		t.Fatalf("suggestions should close after second command click, got %#v", next.suggestions)
+	}
+}
+
+func TestMouseClickSelectsThenAppliesPickerRow(t *testing.T) {
+	m := mouseTestModel()
+	m.modelName = "claude-sonnet-4.5"
+	m.picker = &commandPicker{
+		kind:  pickerEffort,
+		title: "select reasoning effort",
+		items: []pickerItem{
+			{Label: "auto", Value: "auto"},
+			{Label: "high", Value: "high"},
+		},
+		selected: 0,
+	}
+	m.picker.allItems = append([]pickerItem{}, m.picker.items...)
+
+	width := chatWidth(m.width)
+	top := m.overlayMouseTop(len(viewLines(m.pickerOverlay(width))), width)
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      width / 2,
+		Y:      top + 3,
+	}
+	updated, cmd := m.Update(click)
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("first picker click should not return a command")
+	}
+	if next.picker == nil || next.picker.selected != 1 {
+		t.Fatalf("picker after first click = %#v, want selected index 1", next.picker)
+	}
+	if next.reasoningEffort != "" {
+		t.Fatalf("reasoning effort after first picker click = %q, want unchanged", next.reasoningEffort)
+	}
+
+	updated, cmd = next.Update(click)
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("second picker click should not return a command")
+	}
+	if next.picker != nil {
+		t.Fatalf("picker should close after second click apply, got %#v", next.picker)
+	}
+	if next.reasoningEffort != "high" {
+		t.Fatalf("reasoning effort after second picker click = %q, want high", next.reasoningEffort)
+	}
+}
+
+func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	if m.providerWizard == nil || len(m.providerWizard.providers) < 2 {
+		t.Fatalf("expected multiple providers, got %#v", m.providerWizard)
+	}
+
+	width := chatWidth(m.width)
+	top := m.overlayMouseTop(len(viewLines(m.providerWizardOverlay(width))), width)
+	click := tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      width / 2,
+		Y:      top + 5,
+	}
+	updated, cmd := m.Update(click)
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("mouse selection should not return a command")
+	}
+	if next.providerWizard == nil || next.providerWizard.selectedProvider != 1 {
+		t.Fatalf("provider selection = %#v, want selected index 1", next.providerWizard)
+	}
+	if next.providerWizard.step != providerWizardStepProvider {
+		t.Fatalf("first provider click should not advance, got step %v", next.providerWizard.step)
+	}
+
+	updated, cmd = next.Update(click)
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("second provider click should not return a command in this fixture")
+	}
+	if next.providerWizard == nil || next.providerWizard.step == providerWizardStepProvider {
+		t.Fatalf("second provider click should advance, got %#v", next.providerWizard)
+	}
+}
+
+func TestMouseWheelMovesProviderWizardRows(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("mouse wheel should not return a command")
+	}
+	if next.providerWizard == nil || next.providerWizard.selectedProvider != 1 {
+		t.Fatalf("provider selection after wheel = %#v, want selected index 1", next.providerWizard)
+	}
+}
+
+func mouseTestModel() model {
+	m := newModel(context.Background(), Options{})
+	m.width = 100
+	m.height = 30
+	m.altScreen = true
+	m.headerPrinted = true
+	return m
+}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -86,6 +86,7 @@ func newSetupState(options SetupOptions) setupState {
 }
 
 func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.clearMouseSelection()
 	if m.setupCredentialInputActive() {
 		return m.handleSetupCredentialKey(msg)
 	}
@@ -187,14 +188,39 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleSetupMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	switch msg.Button {
-	case tea.MouseButtonWheelUp:
+	if mouseLeftPress(msg) {
+		switch m.setup.stage {
+		case setupStageProvider:
+			if target, ok := m.selectSetupProviderAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.advanceSetup()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
+		case setupStageModel:
+			if target, ok := m.selectSetupModelAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.advanceSetup()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
+		}
+	}
+
+	switch {
+	case mouseWheelUp(msg):
+		m.clearMouseSelection()
 		if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(-1)
 		} else if m.setup.stage == setupStageModel {
 			m.moveSetupModel(-1)
 		}
-	case tea.MouseButtonWheelDown:
+	case mouseWheelDown(msg):
+		m.clearMouseSelection()
 		if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(1)
 		} else if m.setup.stage == setupStageModel {
@@ -202,6 +228,92 @@ func (m model) handleSetupMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return m, nil
+}
+
+func (m *model) selectSetupProviderAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if len(m.setup.providers) == 0 {
+		return mouseSelectionTarget{}, false
+	}
+	width := chatWidth(m.width)
+	height := normalizedStartupHeight(m.height)
+	rowWidth := setupProviderBlockWidth(width, m.setup.providers)
+	if !setupBlockContainsMouseX(msg.X, width, rowWidth) {
+		return mouseSelectionTarget{}, false
+	}
+	maxVisible := setupProviderMaxVisible(height, len(m.setup.providers))
+	if maxVisible == 0 {
+		return mouseSelectionTarget{}, false
+	}
+	content := m.setupProviderLines(width, height)
+	top := setupContentTop(height, len(content), m.setup.err != "")
+	row := msg.Y - top - 2
+	if row < 0 || row >= maxVisible {
+		return mouseSelectionTarget{}, false
+	}
+	start := selectableListStart(len(m.setup.providers), maxVisible, m.setup.selected)
+	index := start + row
+	if index < 0 || index >= len(m.setup.providers) {
+		return mouseSelectionTarget{}, false
+	}
+	m.setup.selected = index
+	m.setup.apiKey.SetValue("")
+	m.setup.modelGen++
+	m.resetSetupModels()
+	return mouseSelectionTarget{Scope: "first-run-provider", Value: m.setup.providers[index].ID, Index: index}, true
+}
+
+func (m *model) selectSetupModelAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if m.setup.modelLoad {
+		return mouseSelectionTarget{}, false
+	}
+	m.ensureSetupModels()
+	models := m.setupFilteredModels()
+	if len(models) == 0 {
+		return mouseSelectionTarget{}, false
+	}
+	width := chatWidth(m.width)
+	height := normalizedStartupHeight(m.height)
+	rowWidth := setupModelBlockWidth(width, m.setup.models)
+	if !setupBlockContainsMouseX(msg.X, width, rowWidth) {
+		return mouseSelectionTarget{}, false
+	}
+	maxVisible := setupModelMaxVisible(height, len(models))
+	if maxVisible == 0 {
+		return mouseSelectionTarget{}, false
+	}
+	m.setup.modelIndex = clampInt(m.setup.modelIndex, 0, len(models)-1)
+	content := m.setupModelLines(width, height)
+	top := setupContentTop(height, len(content), m.setup.err != "")
+	rowStart := 4
+	if m.setupModelStatus() != "" {
+		rowStart++
+	}
+	row := msg.Y - top - rowStart
+	if row < 0 || row >= maxVisible {
+		return mouseSelectionTarget{}, false
+	}
+	start := selectableListStart(len(models), maxVisible, m.setup.modelIndex)
+	index := start + row
+	if index < 0 || index >= len(models) {
+		return mouseSelectionTarget{}, false
+	}
+	m.setup.modelIndex = index
+	return mouseSelectionTarget{Scope: "first-run-model", Value: models[index].ID, Index: index}, true
+}
+
+func setupContentTop(height int, contentLines int, hasError bool) int {
+	if hasError {
+		contentLines += 2
+	}
+	return maxInt(0, (height-contentLines-3)/2)
+}
+
+func setupBlockContainsMouseX(x int, width int, blockWidth int) bool {
+	if blockWidth <= 0 {
+		return false
+	}
+	left := maxInt(0, (width-blockWidth)/2)
+	return x >= left && x < left+blockWidth
 }
 
 func (m model) advanceSetup() (tea.Model, tea.Cmd) {
@@ -604,12 +716,11 @@ func (m model) setupModelLines(width int, height int) []string {
 	for offset, model := range visibleModels {
 		lines = append(lines, m.setupModelRow(rowWidth, start+offset, model))
 	}
-	if detail := setupModelSelectedDetail(m.setupCurrentModel()); detail != "" {
-		lines = append(lines,
-			blankSetupBlockLine(rowWidth),
-			padSetupLine("  "+zeroTheme.faint.Render(detail), rowWidth),
-		)
-	}
+	detail := setupModelSelectedDetail(m.setupCurrentModel())
+	lines = append(lines,
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render(detail), rowWidth),
+	)
 	return lines
 }
 

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -652,7 +652,7 @@ func setupModelLoadingBlockWidth(terminalWidth int) int {
 func setupModelBlockWidth(terminalWidth int, models []providerWizardModel) int {
 	available := maxInt(34, minInt(terminalWidth-8, 72))
 	target := lipgloss.Width("  Choose a model")
-	target = maxInt(target, lipgloss.Width("  search > Search model"))
+	target = maxInt(target, lipgloss.Width("  search > model name..."))
 	for _, model := range models {
 		target = maxInt(target, 4+lipgloss.Width(model.displayLabel()))
 		if detail := setupModelSelectedDetail(model); detail != "" {

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -604,9 +604,6 @@ func (m model) setupModelLines(width int, height int) []string {
 	for offset, model := range visibleModels {
 		lines = append(lines, m.setupModelRow(rowWidth, start+offset, model))
 	}
-	if hidden := len(models) - maxVisible; hidden > 0 {
-		lines = append(lines, padSetupLine("  "+zeroTheme.faint.Render(fmt.Sprintf("%d more models", hidden)), rowWidth))
-	}
 	if detail := setupModelSelectedDetail(m.setupCurrentModel()); detail != "" {
 		lines = append(lines,
 			blankSetupBlockLine(rowWidth),

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	ProviderName           string
 	ModelName              string
 	ProviderProfile        config.ProviderProfile
+	FavoriteModels         []string
 	Provider               zeroruntime.Provider
 	NewProvider            func(config.ProviderProfile) (zeroruntime.Provider, error)
 	DiscoverProviderModels func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,8 +27,8 @@ const (
 
 // pickerItem is one selectable row: Label is shown, Value is passed to the
 // underlying command handler when chosen. Meta is the optional right-aligned
-// readout (ctx window · key env); the dot flags mark provider locality for
-// model rows (accent = remote, blue = local).
+// readout (ctx window · capabilities); the dot flags mark provider locality
+// for model rows (accent = remote, blue = local).
 type pickerItem struct {
 	Group    string
 	Label    string
@@ -139,7 +140,37 @@ func (m model) newModelPicker() *commandPicker {
 	if len(items) == 0 {
 		return nil
 	}
-	return &commandPicker{kind: pickerModel, title: "select model", items: items, allItems: append([]pickerItem{}, items...), selected: 0}
+	return &commandPicker{kind: pickerModel, title: "Choose a model", items: items, allItems: append([]pickerItem{}, items...), selected: 0}
+}
+
+func (m model) openModelPicker() (model, tea.Cmd) {
+	picker := m.newModelPicker()
+	if picker == nil {
+		return m, nil
+	}
+	m.picker = picker
+	m.clearModelPickerLoadState()
+	provider, ok := m.activeProviderDescriptor()
+	if !ok || (m.modelPickerLiveProviderID == provider.ID && len(m.modelPickerLiveModels) > 0) {
+		return m, nil
+	}
+	cmd := m.modelPickerDiscoveryCmd()
+	if cmd == nil {
+		return m, nil
+	}
+	m.modelPickerLoading = true
+	m.modelPickerLoadingProviderID = provider.ID
+	return m, cmd
+}
+
+func (m model) modelPickerIsLoading() bool {
+	return m.picker != nil && m.picker.kind == pickerModel && m.modelPickerLoading
+}
+
+func (m *model) clearModelPickerLoadState() {
+	m.modelPickerLoading = false
+	m.modelPickerLoadingProviderID = ""
+	m.modelPickerLoadError = ""
 }
 
 func (m model) assembleModelPickerItems(recent []pickerItem, catalog []pickerItem) []pickerItem {
@@ -228,9 +259,7 @@ func registryModelPickerItem(entry modelregistry.ModelEntry, group string) picke
 		Label: firstProviderDisplayValue(entry.DisplayName, entry.ID),
 		Value: entry.ID,
 	}
-	if window := entry.ContextLimits.ContextWindow; window > 0 {
-		item.Meta = formatContextWindow(window)
-	}
+	item.Meta = registryModelPickerMeta(entry)
 	if descriptor, ok := providercatalog.Get(string(entry.Provider)); ok {
 		applyProviderPickerMeta(&item, descriptor)
 	}
@@ -243,9 +272,7 @@ func providerModelPickerItem(provider providercatalog.Descriptor, model provider
 		Label: modelPickerDisplayName(model.ID, model.Description),
 		Value: model.ID,
 	}
-	if ctx := formatContextWindow(model.ContextWindow); ctx != "" {
-		item.Meta = ctx
-	}
+	item.Meta = providerWizardModelMeta(model.ContextWindow, model.ToolCall, model.Reasoning, model.InputCost, model.OutputCost, model.Tags)
 	applyProviderPickerMeta(&item, provider)
 	return item
 }
@@ -256,9 +283,7 @@ func discoveredModelPickerItem(provider providercatalog.Descriptor, model provid
 		Label: modelPickerDisplayName(model.ID, model.Description),
 		Value: model.ID,
 	}
-	if ctx := formatContextWindow(model.ContextWindow); ctx != "" {
-		item.Meta = ctx
-	}
+	item.Meta = providerWizardModelMeta(model.ContextWindow, model.ToolCall, model.Reasoning, model.InputCost, model.OutputCost, model.Tags)
 	applyProviderPickerMeta(&item, provider)
 	return item
 }
@@ -266,12 +291,23 @@ func discoveredModelPickerItem(provider providercatalog.Descriptor, model provid
 func applyProviderPickerMeta(item *pickerItem, provider providercatalog.Descriptor) {
 	item.Remote = !provider.Local
 	item.Local = provider.Local
-	if len(provider.AuthEnvVars) > 0 {
-		if item.Meta != "" {
-			item.Meta += " · "
-		}
-		item.Meta += provider.AuthEnvVars[0]
+}
+
+func registryModelPickerMeta(entry modelregistry.ModelEntry) string {
+	parts := []string{}
+	if ctx := formatContextWindow(entry.ContextLimits.ContextWindow); ctx != "" {
+		parts = append(parts, ctx+" ctx")
 	}
+	if entry.Supports(modelregistry.ModelCapabilityToolCalling) {
+		parts = append(parts, "tools")
+	}
+	if entry.Supports(modelregistry.ModelCapabilityReasoning) {
+		parts = append(parts, "reasoning")
+	}
+	if entry.Supports(modelregistry.ModelCapabilityVision) {
+		parts = append(parts, "vision")
+	}
+	return strings.Join(parts, " · ")
 }
 
 func modelPickerDisplayName(id string, description string) string {
@@ -424,21 +460,35 @@ func profileMatchesProviderBaseURL(profile config.ProviderProfile, provider prov
 
 func (m model) applyModelPickerModelsDiscovered(msg modelPickerModelsDiscoveredMsg) model {
 	provider, ok := m.activeProviderDescriptor()
-	if !ok || provider.ID != msg.providerID || msg.err != nil || len(msg.models) == 0 {
+	if !ok || provider.ID != msg.providerID {
 		return m
 	}
+	wasLoading := m.modelPickerLoadingProviderID == msg.providerID
+	if wasLoading {
+		m.modelPickerLoading = false
+		m.modelPickerLoadingProviderID = ""
+	}
+	if msg.err != nil || len(msg.models) == 0 {
+		if m.picker != nil && m.picker.kind == pickerModel && wasLoading {
+			m.modelPickerLoadError = "Using built-in model list"
+		}
+		return m
+	}
+	m.modelPickerLoadError = ""
 	m.modelPickerLiveProviderID = msg.providerID
 	m.modelPickerLiveModels = append([]providermodeldiscovery.Model{}, msg.models...)
-	if m.picker != nil && m.picker.kind == pickerModel {
+	if m.picker != nil && m.picker.kind == pickerModel && wasLoading {
 		selectedValue := ""
 		query := m.picker.query
 		if item, ok := m.picker.current(); ok {
 			selectedValue = item.Value
 		}
 		m.picker = m.newModelPicker()
-		m.picker.query = query
-		m.picker.applyQuery()
-		m.selectPickerValue(selectedValue)
+		if m.picker != nil {
+			m.picker.query = query
+			m.picker.applyQuery()
+			m.selectPickerValue(selectedValue)
+		}
 	}
 	return m
 }
@@ -459,6 +509,9 @@ func (m model) toggleModelFavorite() model {
 	} else {
 		m.favoriteModels[item.Value] = true
 	}
+	if err := m.persistFavoriteModels(); err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendError, text: "favorite save error: " + err.Error()})
+	}
 	selectedValue := item.Value
 	query := m.picker.query
 	m.picker = m.newModelPicker()
@@ -466,6 +519,45 @@ func (m model) toggleModelFavorite() model {
 	m.picker.applyQuery()
 	m.selectPickerValue(selectedValue)
 	return m
+}
+
+func (m model) persistFavoriteModels() error {
+	if strings.TrimSpace(m.userConfigPath) == "" {
+		return nil
+	}
+	_, err := config.SetFavoriteModels(m.userConfigPath, favoriteModelValues(m.favoriteModels))
+	return err
+}
+
+func favoriteModelSet(models []string) map[string]bool {
+	if len(models) == 0 {
+		return nil
+	}
+	favorites := map[string]bool{}
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		favorites[model] = true
+	}
+	if len(favorites) == 0 {
+		return nil
+	}
+	return favorites
+}
+
+func favoriteModelValues(favorites map[string]bool) []string {
+	values := make([]string, 0, len(favorites))
+	for model, favorite := range favorites {
+		model = strings.TrimSpace(model)
+		if !favorite || model == "" {
+			continue
+		}
+		values = append(values, model)
+	}
+	sort.Strings(values)
+	return values
 }
 
 func (m *model) selectPickerValue(value string) {

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -2,7 +2,11 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -85,6 +89,119 @@ func TestModelPickerRefreshesLiveModelsForActiveProvider(t *testing.T) {
 	if !contains(got, "live-cloud-a") || !contains(got, "live-cloud-b") {
 		t.Fatalf("picker values = %#v, want live cloud models", got)
 	}
+}
+
+func TestModelPickerShowsLoadingUntilDiscoveryCompletes(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "ollama-cloud",
+		ModelName:    "minimax-m3",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "ollama-cloud",
+			CatalogID:    "ollama-cloud",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://ollama.com/v1",
+			APIKey:       "ollama-key",
+			Model:        "minimax-m3",
+		},
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return []providermodeldiscovery.Model{
+				{ID: "live-cloud-a", Description: "Live Cloud A"},
+				{ID: "live-cloud-b", Description: "Live Cloud B"},
+			}, nil
+		},
+	})
+	m.input.SetValue("/model")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("expected opening the model picker to start discovery")
+	}
+	loading := plainRender(t, m.pickerOverlay(100))
+	assertContains(t, loading, "Checking available models...")
+	assertNotContains(t, loading, "Live Cloud A")
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.picker == nil {
+		t.Fatal("Enter while loading should not choose the fallback list")
+	}
+
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+	loaded := plainRender(t, m.pickerOverlay(100))
+	assertContains(t, loaded, "Live Cloud A")
+	assertNotContains(t, loaded, "Checking available models...")
+}
+
+func TestModelPickerMetadataOmitsCredentialEnv(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "ollama-cloud",
+		ModelName:    "minimax-m3",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "ollama-cloud",
+			CatalogID:    "ollama-cloud",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://ollama.com/v1",
+			APIKeyEnv:    "OLLAMA_API_KEY",
+			Model:        "minimax-m3",
+		},
+	})
+	m.modelPickerLiveProviderID = "ollama-cloud"
+	m.modelPickerLiveModels = []providermodeldiscovery.Model{
+		{
+			ID:            "cogito-2.1:671b",
+			ContextWindow: 163840,
+			ToolCall:      true,
+			Reasoning:     true,
+		},
+	}
+	m.picker = m.newModelPicker()
+	if m.picker == nil {
+		t.Fatal("expected model picker")
+	}
+	target := pickerIndex(m.picker.items, "cogito-2.1:671b")
+	if target < 0 {
+		t.Fatalf("expected cogito model in picker, got %#v", pickerValues(m.picker.items))
+	}
+	m.picker.selected = target
+
+	view := plainRender(t, m.pickerOverlay(100))
+	assertContains(t, view, "163K ctx")
+	assertContains(t, view, "tools")
+	assertContains(t, view, "reasoning")
+	assertNotContains(t, view, "OLLAMA_API_KEY")
+	for _, item := range m.picker.items {
+		assertNotContains(t, item.Meta, "API_KEY")
+	}
+}
+
+func TestModelPickerFallsBackWhenDiscoveryFails(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "ollama-cloud",
+		ModelName:    "minimax-m3",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "ollama-cloud",
+			CatalogID:    "ollama-cloud",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://ollama.com/v1",
+			APIKey:       "ollama-key",
+			Model:        "minimax-m3",
+		},
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
+	})
+	m.input.SetValue("/model")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("expected opening the model picker to start discovery")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
+	view := plainRender(t, m.pickerOverlay(100))
+	assertContains(t, view, "Using built-in model list")
+	assertNotContains(t, view, "Checking available models...")
 }
 
 func TestModelPickerAppliesLiveDiscoveredModelID(t *testing.T) {
@@ -188,9 +305,11 @@ func TestModelPickerSearchFiltersModels(t *testing.T) {
 }
 
 func TestModelPickerFavoriteShortcutTogglesSelectedModel(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	m := newModel(context.Background(), Options{
-		ProviderName: "ollama-cloud",
-		ModelName:    "minimax-m3",
+		UserConfigPath: configPath,
+		ProviderName:   "ollama-cloud",
+		ModelName:      "minimax-m3",
 		ProviderProfile: config.ProviderProfile{
 			Name:         "ollama-cloud",
 			CatalogID:    "ollama-cloud",
@@ -218,6 +337,10 @@ func TestModelPickerFavoriteShortcutTogglesSelectedModel(t *testing.T) {
 	if next.picker.items[0].Group != "Favorites" || next.picker.items[0].Value != "qwen3-coder:480b" {
 		t.Fatalf("first picker item = %#v, want favorite group row", next.picker.items[0])
 	}
+	persisted := readTUIConfigFixture(t, configPath)
+	if len(persisted.Preferences.FavoriteModels) != 1 || persisted.Preferences.FavoriteModels[0] != "qwen3-coder:480b" {
+		t.Fatalf("persisted FavoriteModels = %#v, want qwen3-coder:480b", persisted.Preferences.FavoriteModels)
+	}
 
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
 	next = updated.(model)
@@ -226,6 +349,26 @@ func TestModelPickerFavoriteShortcutTogglesSelectedModel(t *testing.T) {
 	}
 	if len(next.picker.items) > 0 && next.picker.items[0].Group == "Favorites" {
 		t.Fatalf("favorites group should be gone after unfavorite, got first item %#v", next.picker.items[0])
+	}
+	persisted = readTUIConfigFixture(t, configPath)
+	if len(persisted.Preferences.FavoriteModels) != 0 {
+		t.Fatalf("persisted FavoriteModels = %#v, want empty after unfavorite", persisted.Preferences.FavoriteModels)
+	}
+}
+
+func TestModelPickerLoadsFavoriteModelsFromOptions(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName:    "ollama-cloud",
+		ModelName:       "minimax-m3",
+		FavoriteModels:  []string{"qwen3-coder:480b"},
+		ProviderProfile: config.ProviderProfile{Name: "ollama-cloud", CatalogID: "ollama-cloud", Model: "minimax-m3"},
+	})
+	picker := m.newModelPicker()
+	if picker == nil {
+		t.Fatal("expected model picker")
+	}
+	if picker.items[0].Group != "Favorites" || picker.items[0].Value != "qwen3-coder:480b" {
+		t.Fatalf("first picker item = %#v, want persisted favorite first", picker.items[0])
 	}
 }
 
@@ -335,13 +478,23 @@ func TestModelPickerNavigatesAndChoosesAppliesHandler(t *testing.T) {
 		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
 			return next, nil
 		},
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return []providermodeldiscovery.Model{
+				{ID: "claude-haiku-4.5", Description: "Claude Haiku 4.5"},
+			}, nil
+		},
 	})
 	m.input.SetValue("/model")
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(model)
 	if m.picker == nil {
 		t.Fatal("expected model picker open")
 	}
+	if cmd == nil {
+		t.Fatal("expected opening the model picker to start discovery")
+	}
+	updated, _ = m.Update(cmd())
+	m = updated.(model)
 
 	// Point the picker at a concrete, different model in the same provider family
 	// and choose it (cross-provider switches require a matching profile).
@@ -452,7 +605,7 @@ func TestPickerRenders(t *testing.T) {
 	m.input.SetValue("/model")
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(model)
-	if !strings.Contains(m.View(), "select model") {
+	if !strings.Contains(m.View(), "Choose a model") {
 		t.Fatal("view should render the picker title")
 	}
 }
@@ -465,14 +618,14 @@ func TestPickerOverlayCapsVisibleRows(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.picker = &commandPicker{
 		kind:     pickerModel,
-		title:    "select model",
+		title:    "Choose a model",
 		items:    items,
 		allItems: append([]pickerItem{}, items...),
 		selected: 15,
 	}
 
 	got := plainRender(t, m.pickerOverlay(120))
-	if !strings.Contains(got, "select model") || !strings.Contains(got, "model-15") {
+	if !strings.Contains(got, "Choose a model") || !strings.Contains(got, "model-15") {
 		t.Fatalf("picker overlay should render selected window, got %q", got)
 	}
 	if strings.Contains(got, "model-00") || strings.Contains(got, "model-09") {
@@ -508,4 +661,18 @@ func pickerIndex(items []pickerItem, value string) int {
 		}
 	}
 	return -1
+}
+
+func readTUIConfigFixture(t *testing.T, path string) config.FileConfig {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg config.FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	return cfg
 }

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -453,6 +454,29 @@ func TestPickerRenders(t *testing.T) {
 	m = updated.(model)
 	if !strings.Contains(m.View(), "select model") {
 		t.Fatal("view should render the picker title")
+	}
+}
+
+func TestPickerOverlayCapsVisibleRows(t *testing.T) {
+	items := make([]pickerItem, 0, 20)
+	for i := range 20 {
+		items = append(items, pickerItem{Label: fmt.Sprintf("model-%02d", i), Value: fmt.Sprintf("model-%02d", i)})
+	}
+	m := newModel(context.Background(), Options{})
+	m.picker = &commandPicker{
+		kind:     pickerModel,
+		title:    "select model",
+		items:    items,
+		allItems: append([]pickerItem{}, items...),
+		selected: 15,
+	}
+
+	got := plainRender(t, m.pickerOverlay(120))
+	if !strings.Contains(got, "select model") || !strings.Contains(got, "model-15") {
+		t.Fatalf("picker overlay should render selected window, got %q", got)
+	}
+	if strings.Contains(got, "model-00") || strings.Contains(got, "model-09") {
+		t.Fatalf("picker overlay should cap visible rows around selection, got %q", got)
 	}
 }
 

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1,7 +1,6 @@
 package tui
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"unicode"
@@ -557,9 +556,6 @@ func (wizard *providerWizardState) renderModelStep(width int) []string {
 	start := selectableListStart(len(models), maxVisible, wizard.selectedModel)
 	for offset, model := range models[start : start+maxVisible] {
 		lines = append(lines, wizard.renderSelectableModel(width, start+offset, model))
-	}
-	if hidden := len(models) - maxVisible; hidden > 0 {
-		lines = append(lines, zeroTheme.faint.Render(fmt.Sprintf("  %d more models", hidden)))
 	}
 	if detail := providerWizardModelDetail(wizard.currentModel()); detail != "" {
 		lines = append(lines, fitStyledLine(zeroTheme.faint.Render("  "+detail), width))

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -14,8 +14,12 @@ import (
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
-const maxProviderWizardProvidersVisible = 10
+const maxProviderWizardProvidersVisible = 8
 const maxProviderWizardModelsVisible = 10
+const providerWizardMinWidth = 48
+const providerWizardProviderWidth = 64
+const providerWizardMediumWidth = 86
+const providerWizardModelWidth = 92
 
 type providerWizardStep int
 
@@ -48,22 +52,10 @@ type providerWizardState struct {
 
 func (m model) newProviderWizard() *providerWizardState {
 	providers := providerWizardProviders()
-	selected := 0
-	activeID := strings.TrimSpace(m.providerProfile.CatalogID)
-	if activeID == "" {
-		activeID = strings.TrimSpace(m.providerName)
-	}
-	for index, provider := range providers {
-		if provider.ID == activeID {
-			selected = index
-			break
-		}
-	}
-
 	wizard := &providerWizardState{
 		step:             providerWizardStepProvider,
 		providers:        providers,
-		selectedProvider: selected,
+		selectedProvider: 0,
 	}
 	wizard.refreshModels()
 	return wizard
@@ -147,6 +139,10 @@ func (wizard *providerWizardState) advance() {
 		wizard.step = providerWizardStepModel
 	case providerWizardStepModel:
 		wizard.err = ""
+		if wizard.modelLoading {
+			wizard.err = "Models are still loading."
+			return
+		}
 		wizard.refreshModels()
 		if len(wizard.filteredModels()) == 0 {
 			wizard.err = "choose a matching model before continuing"
@@ -155,6 +151,25 @@ func (wizard *providerWizardState) advance() {
 		wizard.step = providerWizardStepDone
 	case providerWizardStepDone:
 		wizard.step = providerWizardStepProvider
+	}
+}
+
+func (wizard *providerWizardState) retreat() {
+	if wizard == nil {
+		return
+	}
+	wizard.err = ""
+	switch wizard.step {
+	case providerWizardStepCredential:
+		wizard.step = providerWizardStepProvider
+	case providerWizardStepModel:
+		if providerWizardNeedsCredential(wizard.currentProvider()) {
+			wizard.step = providerWizardStepCredential
+		} else {
+			wizard.step = providerWizardStepProvider
+		}
+	case providerWizardStepDone:
+		wizard.step = providerWizardStepModel
 	}
 }
 
@@ -211,6 +226,14 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		case tea.KeyCtrlU:
 			m.providerWizard.apiKey = ""
 			return m, nil
+		case tea.KeyLeft:
+			m.providerWizard.retreat()
+			return m, nil
+		case tea.KeyRight:
+			if m.providerWizard.canAdvanceWithRight() {
+				return m.advanceProviderWizard()
+			}
+			return m, nil
 		case tea.KeyEnter:
 			return m.advanceProviderWizard()
 		}
@@ -237,6 +260,12 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		m.providerWizard.move(-1)
 	case tea.KeyDown, tea.KeyTab:
 		m.providerWizard.move(1)
+	case tea.KeyLeft:
+		m.providerWizard.retreat()
+	case tea.KeyRight:
+		if m.providerWizard.canAdvanceWithRight() {
+			return m.advanceProviderWizard()
+		}
 	case tea.KeyEnter:
 		if m.providerWizard.step == providerWizardStepDone {
 			return m.applyProviderWizard()
@@ -244,6 +273,42 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		return m.advanceProviderWizard()
 	}
 	return m, nil
+}
+
+func (wizard *providerWizardState) canAdvanceWithRight() bool {
+	if wizard == nil {
+		return false
+	}
+	switch wizard.step {
+	case providerWizardStepProvider:
+		return strings.TrimSpace(wizard.currentProvider().ID) != ""
+	case providerWizardStepCredential:
+		return wizard.credentialReadyForRight()
+	case providerWizardStepModel:
+		if wizard.modelLoading {
+			return false
+		}
+		wizard.refreshModels()
+		return len(wizard.filteredModels()) > 0
+	default:
+		return false
+	}
+}
+
+func (wizard *providerWizardState) credentialReadyForRight() bool {
+	if strings.TrimSpace(wizard.apiKey) != "" {
+		return true
+	}
+	provider := wizard.currentProvider()
+	if !providerWizardNeedsCredential(provider) {
+		return true
+	}
+	for _, env := range provider.AuthEnvVars {
+		if strings.TrimSpace(os.Getenv(strings.TrimSpace(env))) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (wizard *providerWizardState) appendAPIKey(runes []rune) {
@@ -333,13 +398,12 @@ func (wizard *providerWizardState) render(width int) string {
 	if wizard == nil {
 		return ""
 	}
-	overlayWidth := minInt(maxInt(56, width-10), minInt(width, 92))
+	overlayWidth := providerWizardOverlayWidth(width, wizard.step)
 	innerWidth := maxInt(20, overlayWidth-4)
 
 	lines := []string{
-		zeroTheme.badge.Render(" PROVIDER ") + " " + zeroTheme.ink.Bold(true).Render("Provider setup"),
 		zeroTheme.faint.Render(providerWizardStepLine(wizard.step)),
-		"",
+		zeroTheme.line.Render(strings.Repeat("─", innerWidth)),
 	}
 	if wizard.err != "" {
 		lines = append(lines, zeroTheme.red.Render("error: "+wizard.err), "")
@@ -354,13 +418,57 @@ func (wizard *providerWizardState) render(width int) string {
 	case providerWizardStepDone:
 		lines = append(lines, wizard.renderDoneStep(innerWidth)...)
 	}
-	lines = append(lines, "", zeroTheme.faint.Render("↑/↓ select  ·  Enter continue  ·  Esc close"))
+	lines = append(lines,
+		zeroTheme.line.Render(strings.Repeat("─", innerWidth)),
+		zeroTheme.faint.Render(wizard.footer()),
+	)
 
-	block := styledBlockFill(overlayWidth, lines, zeroTheme.line, zeroTheme.panel)
+	block := styledBlockFillTitle(overlayWidth, "Provider setup", lines, zeroTheme.lineStrong, lipgloss.NewStyle())
 	if width > overlayWidth {
 		return indentBlock(block, (width-overlayWidth)/2)
 	}
 	return block
+}
+
+func (wizard *providerWizardState) footer() string {
+	canRight := wizard.canAdvanceWithRight()
+	switch wizard.step {
+	case providerWizardStepProvider:
+		if canRight {
+			return "↑/↓ move   Enter/→ continue   Esc close"
+		}
+		return "↑/↓ move   Enter continue   Esc close"
+	case providerWizardStepModel:
+		if canRight {
+			return "↑/↓ move   Enter/→ continue   ← back   Esc close"
+		}
+		return "↑/↓ move   Enter continue   ← back   Esc close"
+	case providerWizardStepDone:
+		return "Enter save   ← back   Esc close"
+	default:
+		if canRight {
+			return "Enter/→ continue   ← back   Esc close"
+		}
+		return "Enter continue   ← back   Esc close"
+	}
+}
+
+func providerWizardOverlayWidth(width int, step providerWizardStep) int {
+	if width <= 0 {
+		return providerWizardProviderWidth
+	}
+	target := providerWizardMediumWidth
+	switch step {
+	case providerWizardStepProvider:
+		target = providerWizardProviderWidth
+	case providerWizardStepModel:
+		target = providerWizardModelWidth
+	}
+	target = minInt(target, width)
+	if target < providerWizardMinWidth {
+		return width
+	}
+	return target
 }
 
 func providerWizardStepLine(step providerWizardStep) string {
@@ -391,51 +499,49 @@ func (wizard *providerWizardState) renderProviderStep(width int) []string {
 	for offset, provider := range wizard.providers[start : start+maxVisible] {
 		lines = append(lines, wizard.renderSelectableProvider(width, start+offset, provider))
 	}
-	if hidden := len(wizard.providers) - maxVisible; hidden > 0 {
-		lines = append(lines, zeroTheme.faint.Render(fmt.Sprintf("  %d more providers in catalog", hidden)))
-	}
 	return lines
 }
 
 func (wizard *providerWizardState) renderSelectableProvider(width int, index int, provider providercatalog.Descriptor) string {
 	selected := index == wizard.selectedProvider
-	surface := zeroTheme.onPanel
+	surface := transparentSurface
 	marker := surface(zeroTheme.faintest).Render("  ")
 	if selected {
 		surface = zeroTheme.onSel
 		marker = surface(zeroTheme.accent).Render("❯ ")
 	}
-	auth := "local"
-	if provider.RequiresAuth {
-		auth = firstProviderDisplayValue(strings.Join(provider.AuthEnvVars, ","), "api key")
-	}
 	left := marker + surface(zeroTheme.ink).Render(provider.Name)
-	right := surface(zeroTheme.faint).Render(provider.ID + " · " + auth)
-	gap := width - lipglossWidth(left) - lipglossWidth(right)
-	return fitStyledLine(left+surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(1, gap)))+right, width)
+	return fitStyledLine(left, width)
 }
 
 func (wizard *providerWizardState) renderCredentialStep(width int) []string {
 	provider := wizard.currentProvider()
 	env := firstProviderDisplayValue(provider.AuthEnvVars...)
-	command := providerWizardAddCommand(provider, "")
-	value := zeroTheme.faint.Render("paste key here")
+	value := zeroTheme.accent.Render("▌") + zeroTheme.faint.Render("paste key here")
 	if wizard.apiKey != "" {
-		value = zeroTheme.ink.Render(maskedProviderWizardKey(wizard.apiKey)) + zeroTheme.faint.Render("  pasted key")
+		value = zeroTheme.ink.Render(maskedProviderWizardKey(wizard.apiKey)) + zeroTheme.accent.Render("▌")
 	}
-	input := zeroTheme.userPrompt.Render("api key > ") + value + zeroTheme.accent.Render("▌")
+	input := zeroTheme.userPrompt.Render("api key > ") + value
 	return []string{
 		zeroTheme.accent.Render("Paste API key"),
-		zeroTheme.ink.Render("Paste your key here, then press Enter."),
-		zeroTheme.faint.Render("Leave empty to use " + env + " from your environment."),
-		zeroTheme.onPanel2(zeroTheme.ink).Render(input),
-		zeroTheme.faint.Render("Pasted keys are hidden. Ready saves the profile to Zero config."),
-		zeroTheme.onPanel2(zeroTheme.ink).Render(command),
+		zeroTheme.ink.Render(providerWizardCredentialInstruction(env)),
+		input,
+		zeroTheme.faint.Render("Pasted keys are hidden and saved in your user config."),
 	}
 }
 
+func providerWizardCredentialInstruction(env string) string {
+	if env = strings.TrimSpace(env); env != "" {
+		return "Paste a key, or leave blank to use " + env + "."
+	}
+	return "Paste a key, or leave blank to use your shell env."
+}
+
 func (wizard *providerWizardState) renderModelStep(width int) []string {
-	lines := []string{zeroTheme.accent.Render("Choose model")}
+	if wizard.modelLoading {
+		return wizard.renderModelLoadingStep(width)
+	}
+	lines := []string{zeroTheme.accent.Render("Choose a model")}
 	if status := wizard.modelStatusText(); status != "" {
 		lines = append(lines, zeroTheme.faint.Render(status))
 	}
@@ -453,47 +559,61 @@ func (wizard *providerWizardState) renderModelStep(width int) []string {
 		lines = append(lines, wizard.renderSelectableModel(width, start+offset, model))
 	}
 	if hidden := len(models) - maxVisible; hidden > 0 {
-		lines = append(lines, zeroTheme.faint.Render(fmt.Sprintf("  %d more models - type to search", hidden)))
+		lines = append(lines, zeroTheme.faint.Render(fmt.Sprintf("  %d more models", hidden)))
+	}
+	if detail := providerWizardModelDetail(wizard.currentModel()); detail != "" {
+		lines = append(lines, fitStyledLine(zeroTheme.faint.Render("  "+detail), width))
 	}
 	return lines
 }
 
+func (wizard *providerWizardState) renderModelLoadingStep(width int) []string {
+	return []string{
+		zeroTheme.accent.Render("Choose a model"),
+		"",
+		fitStyledLine(zeroTheme.faint.Render("Checking available models..."), width),
+		fitStyledLine(zeroTheme.faint.Render("Built-in models will be used if discovery fails."), width),
+	}
+}
+
 func (wizard *providerWizardState) renderModelSearch(width int) string {
 	query := strings.TrimSpace(wizard.modelSearch)
-	value := zeroTheme.faint.Render("Search model")
-	if query != "" {
-		value = zeroTheme.ink.Render(query)
+	prompt := zeroTheme.userPrompt.Render("search > ")
+	cursor := zeroTheme.accent.Render("▌")
+	if query == "" {
+		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render("model name..."), width)
 	}
-	input := zeroTheme.userPrompt.Render("search > ") + value + zeroTheme.accent.Render("\u258c")
-	return fitStyledLine(zeroTheme.onPanel2(zeroTheme.ink).Render(input), width)
+	return fitStyledLine(prompt+zeroTheme.ink.Render(query)+cursor, width)
 }
 
 func (wizard *providerWizardState) modelStatusText() string {
-	if wizard.modelLoading {
-		return "models: refreshing catalog"
-	}
 	if wizard.modelLoadError != "" {
-		return "models: fallback - " + wizard.modelLoadError
-	}
-	if wizard.modelSource == "fallback" {
-		return "models: fallback"
+		return "Using built-in model list"
 	}
 	return ""
 }
 
 func (wizard *providerWizardState) renderSelectableModel(width int, index int, model providerWizardModel) string {
 	selected := index == wizard.selectedModel
-	surface := zeroTheme.onPanel
+	surface := transparentSurface
 	marker := surface(zeroTheme.faintest).Render("  ")
 	if selected {
 		surface = zeroTheme.onSel
 		marker = surface(zeroTheme.accent).Render("❯ ")
 	}
 	left := marker + surface(zeroTheme.ink).Render(model.displayLabel())
-	rightText := firstProviderDisplayValue(model.Meta, model.secondaryText())
-	right := surface(zeroTheme.faint).Render(rightText)
-	gap := width - lipglossWidth(left) - lipglossWidth(right)
-	return fitStyledLine(left+surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(1, gap)))+right, width)
+	return fitStyledLine(left, width)
+}
+
+func providerWizardModelDetail(model providerWizardModel) string {
+	parts := []string{}
+	if secondary := strings.TrimSpace(model.secondaryText()); secondary != "" && !providerWizardGenericModelDescription(secondary) {
+		parts = append(parts, secondary)
+	}
+	if meta := strings.TrimSpace(model.Meta); meta != "" {
+		parts = append(parts, meta)
+	}
+	return strings.Join(parts, " · ")
 }
 
 func (wizard *providerWizardState) filteredModels() []providerWizardModel {
@@ -548,15 +668,14 @@ func providerWizardGenericModelDescription(description string) bool {
 func (wizard *providerWizardState) renderDoneStep(width int) []string {
 	provider := wizard.currentProvider()
 	model := wizard.currentModel()
-	checkCommand := "zero providers check " + provider.ID + " --connectivity"
 	return []string{
 		zeroTheme.accent.Render("Ready to connect"),
-		zeroTheme.ink.Render("provider: " + provider.Name),
-		zeroTheme.ink.Render("model: " + model.ID),
-		zeroTheme.ink.Render("credential: " + providerWizardCredentialLabel(provider, wizard.apiKey)),
-		zeroTheme.faint.Render("Press Enter to save this provider and use it now."),
-		zeroTheme.faint.Render("Verify later with:"),
-		zeroTheme.onPanel2(zeroTheme.ink).Render(checkCommand),
+		"",
+		zeroTheme.ink.Render("Provider    " + provider.Name),
+		zeroTheme.ink.Render("Model       " + model.ID),
+		zeroTheme.ink.Render("Credential  " + providerWizardCredentialLabel(provider, wizard.apiKey)),
+		"",
+		zeroTheme.faint.Render("Press Enter to save and start using this provider."),
 	}
 }
 
@@ -623,20 +742,4 @@ func providerWizardAPIFormat(provider providercatalog.Descriptor) string {
 		return ""
 	}
 	return string(provider.SupportedAPIFormats[0])
-}
-
-func providerWizardAddCommand(provider providercatalog.Descriptor, model string) string {
-	parts := []string{"zero", "providers", "add", provider.ID}
-	if env := firstProviderDisplayValue(provider.AuthEnvVars...); provider.RequiresAuth && env != "" {
-		parts = append(parts, "--api-key-env", env)
-	}
-	if model = strings.TrimSpace(model); model != "" && model != provider.DefaultModel {
-		parts = append(parts, "--model", model)
-	}
-	parts = append(parts, "--set-active")
-	return strings.Join(parts, " ")
-}
-
-func lipglossWidth(value string) int {
-	return lipgloss.Width(value)
 }

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -47,6 +47,7 @@ type providerWizardState struct {
 	modelSource      string
 	modelLoading     bool
 	modelLoadError   string
+	discoveryToken   int
 }
 
 func (m model) newProviderWizard() *providerWizardState {

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -62,7 +62,7 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 
 func (m model) applyProviderModelsDiscovered(msg providerModelsDiscoveredMsg) model {
 	wizard := m.providerWizard
-	if wizard == nil || wizard.currentProvider().ID != msg.providerID {
+	if wizard == nil || wizard.step != providerWizardStepModel || wizard.currentProvider().ID != msg.providerID {
 		return m
 	}
 	wizard.modelLoading = false

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -16,6 +16,7 @@ import (
 
 type providerModelsDiscoveredMsg struct {
 	providerID string
+	token      int
 	models     []providermodeldiscovery.Model
 	err        error
 }
@@ -51,18 +52,20 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 
 	wizard.modelLoading = true
 	wizard.modelLoadError = ""
+	wizard.discoveryToken++
+	token := wizard.discoveryToken
 	providerID := provider.ID
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
 		defer cancel()
 		models, err := discover(ctx, profile)
-		return providerModelsDiscoveredMsg{providerID: providerID, models: models, err: err}
+		return providerModelsDiscoveredMsg{providerID: providerID, token: token, models: models, err: err}
 	}
 }
 
 func (m model) applyProviderModelsDiscovered(msg providerModelsDiscoveredMsg) model {
 	wizard := m.providerWizard
-	if wizard == nil || wizard.step != providerWizardStepModel || wizard.currentProvider().ID != msg.providerID {
+	if wizard == nil || wizard.step != providerWizardStepModel || wizard.currentProvider().ID != msg.providerID || msg.token != wizard.discoveryToken {
 		return m
 	}
 	wizard.modelLoading = false

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -52,6 +52,43 @@ func TestProviderCommandOpensOnboardingWizard(t *testing.T) {
 	}
 }
 
+func TestProviderWizardStartsAtFirstProvider(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "ollama-cloud",
+		ModelName:    "cogito-2.1:671b",
+	})
+	m.providerProfile = config.ProviderProfile{
+		Name:      "ollama-cloud",
+		CatalogID: "ollama-cloud",
+		Model:     "cogito-2.1:671b",
+	}
+
+	next := openProviderWizardForTest(t, m)
+	if next.providerWizard.selectedProvider != 0 {
+		t.Fatalf("selected provider = %d, want first provider", next.providerWizard.selectedProvider)
+	}
+	if got, want := next.providerWizard.currentProvider().ID, next.providerWizard.providers[0].ID; got != want {
+		t.Fatalf("current provider = %q, want first provider %q", got, want)
+	}
+}
+
+func TestProviderWizardReplacesEmptyStateWordmark(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width = 120
+	m.height = 34
+	m.input.SetValue("/provider")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	next.width = m.width
+	next.height = m.height
+
+	view := plainRender(t, next.View())
+	assertContains(t, view, "Provider setup")
+	assertNotContains(t, view, emptyStateTagline)
+	assertNotContains(t, view, "███████")
+}
+
 func TestProviderWizardUsesRuntimeProviderCatalog(t *testing.T) {
 	wizard := newModel(context.Background(), Options{}).newProviderWizard()
 	got := map[string]bool{}
@@ -144,19 +181,35 @@ func TestProviderWizardAdvancesProviderAPIKeyAndModelSteps(t *testing.T) {
 	for _, want := range []string{
 		"Paste API key",
 		"ANTHROPIC_API_KEY",
-		"zero providers add anthropic --api-key-env ANTHROPIC_API_KEY --set-active",
+		"Enter continue",
 	} {
 		assertContains(t, view, want)
 	}
+	assertNotContains(t, view, "zero providers add anthropic")
 
-	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
 	if next.providerWizard.step != providerWizardStepModel {
 		t.Fatalf("wizard step = %v, want model", next.providerWizard.step)
 	}
+	if cmd == nil {
+		t.Fatal("entering model step should start live model discovery")
+	}
+	view = plainRender(t, next.View())
+	assertContains(t, view, "Checking available models")
+	assertNotContains(t, view, "claude-sonnet-4.5")
+
+	updated, _ = next.Update(providerModelsDiscoveredMsg{
+		providerID: "anthropic",
+		models: []providermodeldiscovery.Model{{
+			ID:          "claude-sonnet-4.5",
+			Description: "claude-sonnet-4.5",
+		}},
+	})
+	next = updated.(model)
 	view = plainRender(t, next.View())
 	for _, want := range []string{
-		"Choose model",
+		"Choose a model",
 		"claude-sonnet-4.5",
 	} {
 		assertContains(t, view, want)
@@ -170,11 +223,96 @@ func TestProviderWizardAdvancesProviderAPIKeyAndModelSteps(t *testing.T) {
 	view = plainRender(t, next.View())
 	for _, want := range []string{
 		"Ready to connect",
-		"provider: Anthropic",
-		"model: claude-sonnet-4.5",
-		"zero providers check anthropic --connectivity",
+		"Provider    Anthropic",
+		"Model       claude-sonnet-4.5",
+		"Credential  ANTHROPIC_API_KEY env var",
+		"Press Enter to save and start using this provider.",
 	} {
 		assertContains(t, view, want)
+	}
+	assertNotContains(t, view, "zero providers check")
+}
+
+func TestProviderWizardSupportsLeftAndGuardedRightNavigation(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	next := updated.(model)
+	if next.providerWizard.step != providerWizardStepCredential {
+		t.Fatalf("right from provider step = %v, want credential", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepProvider {
+		t.Fatalf("left from credential step = %v, want provider", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRight})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepCredential {
+		t.Fatalf("right from empty credential step = %v, want credential", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("sk-test")})
+	next = updated.(model)
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRight})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("right from entered credential step = %v, want model", next.providerWizard.step)
+	}
+	if cmd == nil {
+		t.Fatal("right from entered credential should start live model discovery")
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRight})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("right while loading step = %v, want model", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(providerModelsDiscoveredMsg{
+		providerID: next.providerWizard.currentProvider().ID,
+		models: []providermodeldiscovery.Model{{
+			ID:          next.providerWizard.currentProvider().DefaultModel,
+			Description: next.providerWizard.currentProvider().DefaultModel,
+		}},
+	})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRight})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepDone {
+		t.Fatalf("right from model step = %v, want ready", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("left from ready step = %v, want model", next.providerWizard.step)
+	}
+}
+
+func TestProviderWizardRightAllowsExistingCredentialEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if next.providerWizard.step != providerWizardStepCredential {
+		t.Fatalf("enter from provider step = %v, want credential", next.providerWizard.step)
+	}
+
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRight})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("right with env credential step = %v, want model", next.providerWizard.step)
+	}
+	if cmd == nil {
+		t.Fatal("right with env credential should start live model discovery")
 	}
 }
 
@@ -195,7 +333,8 @@ func TestProviderWizardSkipsAPIKeyForLocalProvidersAndEscCloses(t *testing.T) {
 	if strings.Contains(view, "Paste API key") {
 		t.Fatalf("local provider should skip API key step, got view:\n%s", view)
 	}
-	assertContains(t, view, "llama3.1")
+	assertContains(t, view, "Checking available models")
+	assertNotContains(t, view, "llama3.1")
 
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	next = updated.(model)
@@ -222,7 +361,7 @@ func TestProviderWizardAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T) {
 		t.Fatalf("wizard api key was not captured from paste")
 	}
 	view := plainRender(t, next.View())
-	for _, want := range []string{"Paste API key", "api key >", "pasted key", "saves the profile"} {
+	for _, want := range []string{"Paste API key", "api key >", "saved in your user config"} {
 		assertContains(t, view, want)
 	}
 	assertNotContains(t, view, secret)
@@ -249,6 +388,7 @@ func TestProviderWizardAppliesPastedKeyToCurrentSession(t *testing.T) {
 	if next.providerWizard.step != providerWizardStepModel {
 		t.Fatalf("wizard step = %v, want model", next.providerWizard.step)
 	}
+	next = finishProviderWizardModelDiscoveryForTest(t, next)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
 	if next.providerWizard.step != providerWizardStepDone {
@@ -296,6 +436,9 @@ func TestProviderWizardPersistsPastedKeyToUserConfig(t *testing.T) {
 	next = updated.(model)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
+	next = finishProviderWizardModelDiscoveryForTest(t, next)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
 
@@ -340,6 +483,9 @@ func TestProviderWizardUsesAPIKeyEnvForCurrentSessionWithoutPersistingSecret(t *
 	next := updated.(model)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	next = finishProviderWizardModelDiscoveryForTest(t, next)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -389,6 +535,17 @@ func TestProviderWizardUsesLiveDiscoveredModels(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("entering model step should start live model discovery")
 	}
+	view := plainRender(t, next.View())
+	assertContains(t, view, "Checking available models")
+	assertNotContains(t, view, "llama3.1")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	waiting := updated.(model)
+	if waiting.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("enter while loading step = %v, want model", waiting.providerWizard.step)
+	}
+	assertContains(t, plainRender(t, waiting.View()), "Models are still loading.")
+
 	msg := cmd()
 	updated, _ = next.Update(msg)
 	next = updated.(model)
@@ -399,9 +556,9 @@ func TestProviderWizardUsesLiveDiscoveredModels(t *testing.T) {
 	if got := providerWizardModelIDs(next.providerWizard.models); strings.Join(got, ",") != "live-b,live-a" {
 		t.Fatalf("wizard models = %#v, want live discovered models", got)
 	}
-	view := plainRender(t, next.View())
+	view = plainRender(t, next.View())
 	assertNotContains(t, view, "models: live")
-	assertContains(t, view, "search > Search model")
+	assertContains(t, view, "search > \u258cmodel name...")
 	assertNotContains(t, view, "gpt-4.1")
 }
 
@@ -419,15 +576,19 @@ func TestProviderWizardKeepsFallbackModelsWhenLiveDiscoveryFails(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("entering model step should start live model discovery")
 	}
+	view := plainRender(t, next.View())
+	assertContains(t, view, "Checking available models")
+	assertNotContains(t, view, "llama3.1")
+
 	updated, _ = next.Update(cmd())
 	next = updated.(model)
 
 	if got := providerWizardModelIDs(next.providerWizard.models); !containsString(got, "llama3.1") {
 		t.Fatalf("wizard models = %#v, want fallback model llama3.1", got)
 	}
-	view := plainRender(t, next.View())
-	assertContains(t, view, "models: fallback")
-	assertContains(t, view, "offline")
+	view = plainRender(t, next.View())
+	assertContains(t, view, "Using built-in model list")
+	assertNotContains(t, view, "offline")
 }
 
 func TestProviderWizardRendersDiscoveredModelMetadata(t *testing.T) {
@@ -472,12 +633,13 @@ func TestProviderWizardModelStepUsesFriendlyNamesAndStaysCompact(t *testing.T) {
 	}
 
 	view := plainRender(t, strings.Join(wizard.renderModelStep(84), "\n"))
-	assertContains(t, view, "search > Search model")
+	assertContains(t, view, "search > \u258cmodel name...")
 	assertContains(t, view, "\u258c")
 	assertNotContains(t, view, "SearchÃ")
 	assertNotContains(t, view, "Searchâ")
 	assertContains(t, view, "Grok 4.3")
-	assertNotContains(t, view, "x-ai/grok-4.3")
+	assertContains(t, view, "x-ai/grok-4.3 · 1M ctx · tools · reasoning")
+	assertNotContains(t, view, "❯ x-ai/grok-4.3")
 	assertContains(t, view, "8 more models")
 	assertNotContains(t, view, "Model 17")
 }
@@ -567,6 +729,26 @@ func openProviderWizardForTest(t *testing.T, m model) model {
 		t.Fatal("expected provider wizard to be open")
 	}
 	return next
+}
+
+func finishProviderWizardModelDiscoveryForTest(t *testing.T, m model) model {
+	t.Helper()
+	if m.providerWizard == nil {
+		t.Fatal("expected provider wizard to be open")
+	}
+	if m.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("wizard step = %v, want model", m.providerWizard.step)
+	}
+	provider := m.providerWizard.currentProvider()
+	modelID := firstProviderDisplayValue(provider.DefaultModel, "test-model")
+	updated, _ := m.Update(providerModelsDiscoveredMsg{
+		providerID: provider.ID,
+		models: []providermodeldiscovery.Model{{
+			ID:          modelID,
+			Description: modelID,
+		}},
+	})
+	return updated.(model)
 }
 
 func providerWizardManyModelsForTest(count int) []providerWizardModel {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -251,6 +251,7 @@ func TestProviderWizardSupportsLeftAndGuardedRightNavigation(t *testing.T) {
 
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
+	clearProviderAuthEnvForTest(t, next.providerWizard.currentProvider())
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRight})
 	next = updated.(model)
 	if next.providerWizard.step != providerWizardStepCredential {
@@ -772,6 +773,16 @@ func providerWizardProviderIndex(t *testing.T, wizard *providerWizardState, id s
 	}
 	t.Fatalf("provider %q not found in wizard providers", id)
 	return 0
+}
+
+func clearProviderAuthEnvForTest(t *testing.T, provider providercatalog.Descriptor) {
+	t.Helper()
+	for _, env := range provider.AuthEnvVars {
+		env = strings.TrimSpace(env)
+		if env != "" {
+			t.Setenv(env, "")
+		}
+	}
 }
 
 func providerWizardModelIDs(models []providerWizardModel) []string {

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -640,7 +640,7 @@ func TestProviderWizardModelStepUsesFriendlyNamesAndStaysCompact(t *testing.T) {
 	assertContains(t, view, "Grok 4.3")
 	assertContains(t, view, "x-ai/grok-4.3 · 1M ctx · tools · reasoning")
 	assertNotContains(t, view, "❯ x-ai/grok-4.3")
-	assertContains(t, view, "8 more models")
+	assertNotContains(t, view, "more models")
 	assertNotContains(t, view, "Model 17")
 }
 

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -201,6 +201,7 @@ func TestProviderWizardAdvancesProviderAPIKeyAndModelSteps(t *testing.T) {
 
 	updated, _ = next.Update(providerModelsDiscoveredMsg{
 		providerID: "anthropic",
+		token:      next.providerWizard.discoveryToken,
 		models: []providermodeldiscovery.Model{{
 			ID:          "claude-sonnet-4.5",
 			Description: "claude-sonnet-4.5",
@@ -277,6 +278,7 @@ func TestProviderWizardSupportsLeftAndGuardedRightNavigation(t *testing.T) {
 
 	updated, _ = next.Update(providerModelsDiscoveredMsg{
 		providerID: next.providerWizard.currentProvider().ID,
+		token:      next.providerWizard.discoveryToken,
 		models: []providermodeldiscovery.Model{{
 			ID:          next.providerWizard.currentProvider().DefaultModel,
 			Description: next.providerWizard.currentProvider().DefaultModel,
@@ -563,6 +565,62 @@ func TestProviderWizardUsesLiveDiscoveredModels(t *testing.T) {
 	assertNotContains(t, view, "gpt-4.1")
 }
 
+func TestProviderWizardIgnoresStaleDiscoveryForSameProvider(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+	m.providerWizard.selectedProvider = providerWizardProviderIndex(t, m.providerWizard, "ollama")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("first model entry should start discovery")
+	}
+	staleToken := next.providerWizard.discoveryToken
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepProvider {
+		t.Fatalf("left from local model step = %v, want provider", next.providerWizard.step)
+	}
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd == nil {
+		t.Fatal("second model entry should start discovery")
+	}
+	currentToken := next.providerWizard.discoveryToken
+	if currentToken == staleToken {
+		t.Fatalf("discovery token did not advance: %d", currentToken)
+	}
+
+	updated, _ = next.Update(providerModelsDiscoveredMsg{
+		providerID: "ollama",
+		token:      staleToken,
+		models: []providermodeldiscovery.Model{{
+			ID: "stale-model",
+		}},
+	})
+	next = updated.(model)
+	if got := providerWizardModelIDs(next.providerWizard.models); containsString(got, "stale-model") {
+		t.Fatalf("stale discovery response applied: %#v", got)
+	}
+	if !next.providerWizard.modelLoading {
+		t.Fatal("stale discovery response should not clear the active loading state")
+	}
+
+	updated, _ = next.Update(providerModelsDiscoveredMsg{
+		providerID: "ollama",
+		token:      currentToken,
+		models: []providermodeldiscovery.Model{{
+			ID: "fresh-model",
+		}},
+	})
+	next = updated.(model)
+	if got := providerWizardModelIDs(next.providerWizard.models); !containsString(got, "fresh-model") {
+		t.Fatalf("fresh discovery response did not apply: %#v", got)
+	}
+}
+
 func TestProviderWizardKeepsFallbackModelsWhenLiveDiscoveryFails(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		DiscoverProviderModels: func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
@@ -744,6 +802,7 @@ func finishProviderWizardModelDiscoveryForTest(t *testing.T, m model) model {
 	modelID := firstProviderDisplayValue(provider.DefaultModel, "test-model")
 	updated, _ := m.Update(providerModelsDiscoveredMsg{
 		providerID: provider.ID,
+		token:      m.providerWizard.discoveryToken,
 		models: []providermodeldiscovery.Model{{
 			ID:          modelID,
 			Description: modelID,

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -272,8 +272,8 @@ func TestToolCardMarksAutoApprovedCalls(t *testing.T) {
 func TestComposerLineTracksRunState(t *testing.T) {
 	m := limeTestModel()
 	m.input.SetValue("add a flag")
-	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "run ↵") {
-		t.Fatalf("idle composer = %q, want run ↵ hint", got)
+	if got := plainRender(t, m.composerLine(96)); strings.Contains(got, "run ↵") {
+		t.Fatalf("idle composer = %q, should not show run hint", got)
 	}
 
 	m.pending = true
@@ -285,6 +285,22 @@ func TestComposerLineTracksRunState(t *testing.T) {
 	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, composerPlaceholderRunning) {
 		t.Fatalf("pending empty composer = %q, want running placeholder", got)
 	}
+}
+
+func TestComposerBoxFramesInputAndBottomModelModeLabel(t *testing.T) {
+	m := limeTestModel()
+	m.input.SetValue("add a flag")
+
+	got := plainRender(t, m.composerBox(96))
+	for _, want := range []string{"╭", "│", "❯ add a flag", "╰", "claude-sonnet-4.5", "auto-approve"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("composer box = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "run ↵") {
+		t.Fatalf("composer box = %q, should not show run hint", got)
+	}
+	assertRenderedLineWidths(t, got, 96)
 }
 
 func TestMalformedAskUserToolResultIsHiddenFromChatSurface(t *testing.T) {
@@ -320,9 +336,18 @@ func TestMalformedToolArgumentResultIsHiddenFromChatSurface(t *testing.T) {
 func TestStatusLineGroups(t *testing.T) {
 	m := limeTestModel()
 	got := plainRender(t, m.statusLine(110))
-	for _, want := range []string{"● anthropic", "claude-sonnet-4.5", "interactive", "⏵⏵ auto-approve"} {
+	for _, want := range []string{"● anthropic"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status line = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "interactive") || strings.Contains(got, "claude-sonnet-4.5") || strings.Contains(got, "auto-approve") {
+		t.Fatalf("status line = %q, should not include surface, model, or permission mode", got)
+	}
+	divider := plainRender(t, m.composerDividerLine(110))
+	for _, want := range []string{"claude-sonnet-4.5", "auto-approve"} {
+		if !strings.Contains(divider, want) {
+			t.Fatalf("composer divider = %q, missing %q", divider, want)
 		}
 	}
 }
@@ -437,8 +462,8 @@ func TestDiffPreambleLinesCarryNoGutterNumbers(t *testing.T) {
 
 func TestSuggestionDigitsTypeNormallyWhilePending(t *testing.T) {
 	m := limeTestModel()
-	// /clear mid-run leaves the transcript empty while pending; the chips are
-	// not on screen, so digits must type into the composer.
+	// /clear mid-run leaves the transcript empty while pending, so digits must
+	// keep typing into the composer.
 	m.pending = true
 	m = typeRunes(t, m, "1")
 	if got := m.input.Value(); got != "1" {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -287,6 +287,40 @@ func TestComposerLineTracksRunState(t *testing.T) {
 	}
 }
 
+func TestComposerLineShowsRequiredCommandArgumentHint(t *testing.T) {
+	m := limeTestModel()
+	m.input.Width = 40
+	m.input.SetValue("/spec")
+	m.input.CursorEnd()
+	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "/spec [task]") {
+		t.Fatalf("composer line = %q, want /spec argument hint", got)
+	}
+
+	m.input.SetValue("/spec ")
+	m.input.CursorEnd()
+	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "/spec [task]") || strings.Contains(got, "/spec  [task]") {
+		t.Fatalf("composer line = %q, want /spec argument hint", got)
+	}
+
+	m.input.SetValue("/find ")
+	m.input.CursorEnd()
+	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "/find") || !strings.Contains(got, "[query]") {
+		t.Fatalf("composer line = %q, want /find query hint", got)
+	}
+
+	m.input.SetValue("/spec fix this")
+	m.input.CursorEnd()
+	if got := plainRender(t, m.composerLine(96)); strings.Contains(got, "[task]") {
+		t.Fatalf("composer line = %q, should hide hint once an argument is present", got)
+	}
+
+	m.input.SetValue("/model ")
+	m.input.CursorEnd()
+	if got := plainRender(t, m.composerLine(96)); strings.Contains(got, "[list|id]") {
+		t.Fatalf("composer line = %q, should not hint optional arguments", got)
+	}
+}
+
 func TestComposerBoxFramesInputAndBottomModelModeLabel(t *testing.T) {
 	m := limeTestModel()
 	m.input.SetValue("add a flag")

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -581,16 +581,23 @@ func TestUnpromptedAllowRowsCollapseIntoAutoTag(t *testing.T) {
 	}
 }
 
-func TestModelPickerRowsCarryContextAndKeyEnvMeta(t *testing.T) {
+func TestModelPickerRowsCarryCapabilityMeta(t *testing.T) {
 	m := limeTestModel()
 	picker := m.newModelPicker()
 	if picker == nil {
 		t.Fatal("expected a model picker")
 	}
 	withMeta := 0
+	withCapability := 0
 	for _, item := range picker.items {
 		if strings.Contains(item.Meta, "K") || strings.Contains(item.Meta, "M") {
 			withMeta++
+		}
+		if strings.Contains(item.Meta, "tools") || strings.Contains(item.Meta, "reasoning") || strings.Contains(item.Meta, "vision") {
+			withCapability++
+		}
+		if strings.Contains(item.Meta, "API_KEY") {
+			t.Fatalf("picker item %q leaked credential env metadata: %q", item.Value, item.Meta)
 		}
 		if !item.Remote && !item.Local {
 			continue
@@ -599,13 +606,19 @@ func TestModelPickerRowsCarryContextAndKeyEnvMeta(t *testing.T) {
 	if withMeta == 0 {
 		t.Fatalf("expected catalog models to expose ctx metadata, got %#v", picker.items[:minInt(3, len(picker.items))])
 	}
+	if withCapability == 0 {
+		t.Fatalf("expected catalog models to expose capability metadata, got %#v", picker.items[:minInt(3, len(picker.items))])
+	}
 
 	m.picker = picker
 	got := plainRender(t, m.pickerOverlay(100))
-	for _, want := range []string{"select model", "↑/↓ · ⏎ · esc", "❯"} {
+	for _, want := range []string{"Choose a model", "Enter select", "Ctrl+F favorite", "❯"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("picker overlay = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "API_KEY") {
+		t.Fatalf("picker overlay leaked credential env metadata: %q", got)
 	}
 }
 

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -32,15 +32,18 @@ func Run(ctx context.Context, options Options) int {
 	}
 	if options.AltScreen {
 		programOpts = append(programOpts, tea.WithAltScreen())
-		programOpts = append(programOpts, tea.WithMouseCellMotion())
 	}
 	if notify.Enabled(notify.Mode(strings.TrimSpace(options.Notify.Mode))) {
 		programOpts = append(programOpts, tea.WithReportFocus())
 	}
-	// Mouse capture is scoped to the alt-screen app so wheel events scroll the
-	// managed transcript instead of being translated into ↑/↓ keypresses by the
-	// terminal, which would recall composer history.
-	program = tea.NewProgram(newModel(ctx, options), programOpts...)
+	initialModel := newModel(ctx, options)
+	if initialModel.wantsMouseCapture() {
+		programOpts = append(programOpts, tea.WithMouseCellMotion())
+		initialModel.mouseCapture = true
+	}
+	// Mouse capture starts enabled only when the initial surface needs it; later
+	// surfaces enable/disable it through syncMouseCapture after each update.
+	program = tea.NewProgram(initialModel, programOpts...)
 
 	if _, err := program.Run(); err != nil {
 		// Surface the failure: exiting 1 with zero diagnostics left users

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -12,6 +12,7 @@ func TestMouseWheelScrollsChatWithoutRecallingInputHistory(t *testing.T) {
 	m := newModel(context.Background(), Options{AltScreen: true})
 	m.width = 90
 	m.height = 14
+	m.mouseCapture = true
 	m.inputHistory = []string{"old prompt"}
 	m.historyIdx = len(m.inputHistory)
 	for index := 0; index < 12; index++ {

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -58,6 +58,19 @@ func TestAltScreenTranscriptScrollKeepsFooterFixed(t *testing.T) {
 	}
 }
 
+func TestAltScreenTranscriptClampsFooterToTerminalHeight(t *testing.T) {
+	m := newModel(context.Background(), Options{AltScreen: true, ProviderName: "openai", ModelName: "gpt-4.1"})
+	m.width = 80
+	m.height = 3
+	m.copyStatus = "Copied!"
+	m.transcript = appendRow(m.transcript, rowAssistant, "hello")
+
+	view := plainRender(t, m.View())
+	if got := len(viewLines(view)); got > m.height {
+		t.Fatalf("view rendered %d lines, want at most terminal height %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestPageKeysScrollAltScreenTranscript(t *testing.T) {
 	m := newModel(context.Background(), Options{AltScreen: true})
 	m.width = 90

--- a/internal/tui/selectable_list.go
+++ b/internal/tui/selectable_list.go
@@ -19,7 +19,7 @@ type selectableListOptions struct {
 	MaxVisible int
 }
 
-const selectableListAnchorRow = 2
+const selectableListAnchorRow = 3
 
 func renderSelectableList(options selectableListOptions) string {
 	if len(options.Items) == 0 {

--- a/internal/tui/selectable_list_test.go
+++ b/internal/tui/selectable_list_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func TestSelectableListAnchorsSelectionAroundThirdVisibleRow(t *testing.T) {
+func TestSelectableListAnchorsSelectionAroundFourthVisibleRow(t *testing.T) {
 	items := make([]selectableListItem, 10)
 	for i := range items {
 		items[i] = selectableListItem{Label: fmt.Sprintf("/cmd%d", i), Description: "command"}
@@ -25,18 +25,18 @@ func TestSelectableListAnchorsSelectionAroundThirdVisibleRow(t *testing.T) {
 	if len(lines) != 6 {
 		t.Fatalf("rendered %d lines, want 5 rows plus count line: %q", len(lines), lines)
 	}
-	for _, hidden := range []string{"/cmd0", "/cmd1", "/cmd2", "/cmd8", "/cmd9"} {
+	for _, hidden := range []string{"/cmd0", "/cmd1", "/cmd7", "/cmd8", "/cmd9"} {
 		if strings.Contains(rendered, hidden) {
 			t.Fatalf("visible window should hide %s, got %q", hidden, plainRender(t, rendered))
 		}
 	}
-	for _, visible := range []string{"/cmd3", "/cmd4", "/cmd5", "/cmd6", "/cmd7"} {
+	for _, visible := range []string{"/cmd2", "/cmd3", "/cmd4", "/cmd5", "/cmd6"} {
 		if !strings.Contains(rendered, visible) {
 			t.Fatalf("visible window should include %s, got %q", visible, plainRender(t, rendered))
 		}
 	}
-	if !strings.Contains(lines[2], "❯ /cmd5") {
-		t.Fatalf("selected item should be anchored on third visible row, got %q", lines[2])
+	if !strings.Contains(lines[3], "❯ /cmd5") {
+		t.Fatalf("selected item should be anchored on fourth visible row, got %q", lines[3])
 	}
 	if !strings.Contains(lines[5], "5 more") {
 		t.Fatalf("count line should summarize hidden rows, got %q", lines[5])

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -33,11 +33,10 @@ var zeroWordmarkOLines = []string{
 	` ╚═════╝ `,
 }
 
-const emptyStateTagline = "a std-lib-first coding agent · bring your own key · no lock-in"
+const emptyStateTagline = "Any model. Every tool. Zero limits."
 
 // emptyState renders the centered stream-area block shown while the
-// transcript has no real content: the brand glyph, tagline, active-model
-// hint, and the three starter-suggestion chips (inserted by keys 1–3).
+// transcript has no real content: the brand glyph and tagline.
 func (m model) emptyState(width int) string {
 	lines := []string{}
 	for _, glyph := range zeroWordmarkLines() {
@@ -45,11 +44,8 @@ func (m model) emptyState(width int) string {
 	}
 	lines = append(lines, "")
 	lines = append(lines, centerLine(zeroTheme.muted.Render(emptyStateTagline), width))
-	lines = append(lines, centerLine(m.emptyStateModelHint(), width))
-	lines = append(lines, "")
-	lines = append(lines, m.emptyStateChips(width)...)
-	// centerLine pads but never truncates; below ~62 cols the tagline (and on
-	// long model ids, the hint) would exceed the frame without this fit.
+	// centerLine pads but never truncates; below ~62 cols the tagline would
+	// exceed the frame without this fit.
 	for index := range lines {
 		lines[index] = fitStyledLine(lines[index], width)
 	}
@@ -67,37 +63,6 @@ func zeroWordmarkLines() []string {
 		lines = append(lines, zeroTheme.ink.Render(zeroWordmarkPrefixLines[index])+zeroTheme.accent.Render(zeroWordmarkOLines[index]))
 	}
 	return lines
-}
-
-func (m model) emptyStateModelHint() string {
-	provider := strings.TrimSpace(m.providerName)
-	model := strings.TrimSpace(m.modelName)
-	target := provider
-	if target != "" && model != "" {
-		target += "/"
-	}
-	target += model
-	if target == "" {
-		return zeroTheme.faint.Render("no provider configured · set one with /provider")
-	}
-	return zeroTheme.faint.Render("running zero against ") + zeroTheme.ink.Render(target)
-}
-
-func (m model) emptyStateChips(width int) []string {
-	rows := make([]string, 0, len(emptyStateSuggestions))
-	boxWidth := 0
-	for _, suggestion := range emptyStateSuggestions {
-		row := zeroTheme.userPrompt.Render("❯ ") + zeroTheme.ink.Render(suggestion)
-		rows = append(rows, row)
-		if w := lipgloss.Width(row) + 4; w > boxWidth {
-			boxWidth = w
-		}
-	}
-	if boxWidth > width {
-		boxWidth = width
-	}
-	block := borderedBlock(boxWidth, rows)
-	return strings.Split(indentBlock(block, maxInt(0, (width-boxWidth)/2)), "\n")
 }
 
 func borderedBlock(width int, lines []string) string {

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -187,6 +187,14 @@ func centerLine(line string, width int) string {
 	return strings.Repeat(" ", padding) + line
 }
 
+func rightAlignedLine(line string, width int) string {
+	padding := width - lipgloss.Width(line)
+	if padding < 0 {
+		padding = 0
+	}
+	return strings.Repeat(" ", padding) + line
+}
+
 func indentBlock(block string, spaces int) string {
 	if spaces <= 0 {
 		return block

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -38,6 +38,32 @@ const emptyStateTagline = "Any model. Every tool. Zero limits."
 // emptyState renders the centered stream-area block shown while the
 // transcript has no real content: the brand glyph and tagline.
 func (m model) emptyState(width int) string {
+	lines := emptyStateLines(width)
+
+	// Vertically center within the stream area: the frame around it (title bar,
+	// rules, composer, status line) occupies ~6 terminal rows.
+	height := normalizedStartupHeight(m.height)
+	gap := clamp((height-6-len(lines))/2, 0, 12)
+	return strings.Repeat("\n", gap) + strings.Join(lines, "\n") + strings.Repeat("\n", gap)
+}
+
+func (m model) emptyStateWithOverlay(width int, overlay string) string {
+	lines := viewLines(overlay)
+	for index := range lines {
+		lines[index] = fitStyledLine(lines[index], width)
+	}
+
+	// Center the palette in the visible chat area. While the command palette is
+	// open it replaces the empty-state wordmark instead of sitting below it.
+	available := normalizedStartupHeight(m.height) - 5
+	if !m.headerPrinted {
+		available -= 2
+	}
+	gap := maxInt(0, (available-len(lines))/2)
+	return strings.Repeat("\n", gap) + strings.Join(lines, "\n") + strings.Repeat("\n", gap)
+}
+
+func emptyStateLines(width int) []string {
 	lines := []string{}
 	for _, glyph := range zeroWordmarkLines() {
 		lines = append(lines, centerLine(glyph, width))
@@ -49,12 +75,7 @@ func (m model) emptyState(width int) string {
 	for index := range lines {
 		lines[index] = fitStyledLine(lines[index], width)
 	}
-
-	// Vertically center within the stream area: the frame around it (title bar,
-	// rules, composer, status line) occupies ~6 terminal rows.
-	height := normalizedStartupHeight(m.height)
-	gap := clamp((height-6-len(lines))/2, 0, 12)
-	return strings.Repeat("\n", gap) + strings.Join(lines, "\n") + strings.Repeat("\n", gap)
+	return lines
 }
 
 func zeroWordmarkLines() []string {

--- a/internal/tui/startup_test.go
+++ b/internal/tui/startup_test.go
@@ -8,18 +8,17 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func TestEmptyStateShowsBrandTaglineAndSuggestions(t *testing.T) {
+func TestEmptyStateShowsBrandAndTaglineOnly(t *testing.T) {
 	m := newModel(context.Background(), Options{ProviderName: "anthropic", ModelName: "claude-sonnet-4.5"})
 	m.width, m.height = 100, 30
 
 	view := plainRender(t, m.View())
 	assertContains(t, view, "███████╗███████╗██████╗  ██████╗")
 	assertContains(t, view, emptyStateTagline)
-	assertContains(t, view, "running zero against ")
-	assertContains(t, view, "anthropic/claude-sonnet-4.5")
-	for _, suggestion := range emptyStateSuggestions {
-		assertContains(t, view, suggestion)
-	}
+	assertNotContains(t, view, "running zero against ")
+	assertNotContains(t, view, "add a --version flag")
+	assertNotContains(t, view, "explain internal/agent/loop.go")
+	assertNotContains(t, view, "fix the failing test in internal/tools")
 }
 
 func TestEmptyStateDisappearsAfterFirstRow(t *testing.T) {
@@ -34,17 +33,19 @@ func TestEmptyStateDisappearsAfterFirstRow(t *testing.T) {
 	assertContains(t, view, "hello")
 }
 
-func TestSuggestionKeysInsertOnEmptySurface(t *testing.T) {
+func TestDigitsTypeNormallyOnEmptySurface(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.width, m.height = 100, 30
 
 	m = typeRunes(t, m, "2")
-	if got := m.input.Value(); got != emptyStateSuggestions[1] {
-		t.Fatalf("pressing 2 on the empty surface should insert suggestion 2, got %q", got)
+	if got := m.input.Value(); got != "2" {
+		t.Fatalf("digit should type normally on the empty surface, got %q", got)
 	}
 
-	// With text already in the composer the digit types normally.
+	// With text already in the composer the digit keeps typing normally.
+	m = newModel(context.Background(), Options{})
 	m.input.SetValue("count to ")
+	m.resetComposerFromInput()
 	m = typeRunes(t, m, "3")
 	if got := m.input.Value(); got != "count to 3" {
 		t.Fatalf("digit should append to a non-empty composer, got %q", got)

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -11,16 +11,17 @@ import "github.com/charmbracelet/lipgloss"
 // literal may appear outside this file.
 type tuiTheme struct {
 	// Base tokens.
-	ink      lipgloss.Style // primary text
-	muted    lipgloss.Style // secondary text, assistant interim prose
-	faint    lipgloss.Style // hints, metadata
-	faintest lipgloss.Style // line numbers, separators, tool args
-	accent   lipgloss.Style // brand lime: prompts, spinner, focus, final rail
-	green    lipgloss.Style // success, diff add sign, ✓
-	red      lipgloss.Style // errors, diff del sign, ✗, deny
-	amber    lipgloss.Style // permission surfaces, warnings, auto badge
-	blue     lipgloss.Style // grep file locations, local-model dot
-	line     lipgloss.Style // default borders, rules, status separators
+	ink        lipgloss.Style // primary text
+	muted      lipgloss.Style // secondary text, assistant interim prose
+	faint      lipgloss.Style // hints, metadata
+	faintest   lipgloss.Style // line numbers, separators, tool args
+	accent     lipgloss.Style // brand lime: prompts, spinner, focus, final rail
+	green      lipgloss.Style // success, diff add sign, ✓
+	red        lipgloss.Style // errors, diff del sign, ✗, deny
+	amber      lipgloss.Style // permission surfaces, warnings, auto badge
+	blue       lipgloss.Style // grep file locations, local-model dot
+	line       lipgloss.Style // default borders, rules, status separators
+	lineStrong lipgloss.Style // emphasized borders
 
 	// Title bar.
 	badge lipgloss.Style // ` 0 ` brand chip: onAccent on accent, bold
@@ -82,7 +83,7 @@ const (
 	colorPanel2   = "#121215" // card header rows, picker rows
 	colorPanel3   = "#17171b" // selected/hovered row bg
 	colorLine     = "#242429" // default borders, rules
-	colorLine2    = "#2e2e34" // emphasized borders
+	colorLine2    = "#414147" // emphasized borders
 	colorInk      = "#ececee" // primary text
 	colorMuted    = "#8b8b93" // secondary text
 	colorFaint    = "#5b5b63" // hints, metadata
@@ -105,16 +106,17 @@ const (
 )
 
 var zeroTheme = tuiTheme{
-	ink:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk)),
-	muted:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
-	faint:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaint)),
-	faintest: lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)),
-	accent:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true),
-	green:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)),
-	red:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)),
-	amber:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
-	blue:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlue)),
-	line:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine)),
+	ink:        lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk)),
+	muted:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
+	faint:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaint)),
+	faintest:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)),
+	accent:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true),
+	green:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)),
+	red:        lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)),
+	amber:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
+	blue:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlue)),
+	line:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine)),
+	lineStrong: lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine2)),
 
 	badge: lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorOnAccent)).Bold(true),
 

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -22,6 +22,7 @@ type tuiTheme struct {
 	blue       lipgloss.Style // grep file locations, local-model dot
 	line       lipgloss.Style // default borders, rules, status separators
 	lineStrong lipgloss.Style // emphasized borders
+	selection  lipgloss.Style // transcript selection highlight
 
 	// Title bar.
 	badge lipgloss.Style // ` 0 ` brand chip: onAccent on accent, bold
@@ -117,6 +118,7 @@ var zeroTheme = tuiTheme{
 	blue:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlue)),
 	line:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine)),
 	lineStrong: lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine2)),
+	selection:  lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorOnAccent)),
 
 	badge: lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorOnAccent)).Bold(true),
 

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -1,0 +1,331 @@
+package tui
+
+import (
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+type transcriptSelectionPoint struct {
+	bodyY int
+	x     int
+}
+
+type transcriptSelectionState struct {
+	active bool
+	anchor transcriptSelectionPoint
+	cursor transcriptSelectionPoint
+}
+
+type transcriptSelectableLine struct {
+	bodyY     int
+	rowIndex  int
+	textStart int
+	text      string
+}
+
+type transcriptCopiedMsg struct {
+	chars int
+}
+
+type transcriptCopyStatusExpiredMsg struct {
+	seq int
+}
+
+func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcriptSelectableLine) {
+	lines := []string{}
+	selectable := []transcriptSelectableLine{}
+	appendBlock := func(block string) int {
+		start := len(lines)
+		lines = append(lines, viewLines(block)...)
+		return start
+	}
+	appendBlank := func() {
+		lines = append(lines, "")
+	}
+
+	// The title bar prints once into scrollback on the first WindowSizeMsg;
+	// until then it renders managed so the surface never appears headless.
+	if !m.headerPrinted {
+		appendBlock(m.titleBar(width))
+	}
+
+	if m.transcriptEmpty() && !m.pending {
+		if emptyOverlay != "" {
+			appendBlock(m.emptyStateWithOverlay(width, emptyOverlay))
+		} else {
+			appendBlock(m.emptyState(width))
+		}
+	} else {
+		rc := buildRowContext(m.transcript)
+		shownAny := false
+		for index := m.flushed; index < len(m.transcript); index++ {
+			row := m.transcript[index]
+			// A welcome row carries no Lime visual (the empty state replaced it)
+			// and a resolved tool call collapses into its result's card.
+			if row.kind == rowWelcome || rc.skip(row) {
+				continue
+			}
+			// Blank-line separation before turns, including between flushed
+			// history and the first live row.
+			if (shownAny || m.flushedAny) && startsTurn(row.kind) {
+				appendBlank()
+			}
+			start := len(lines)
+			rendered, rowSelectable := m.renderTranscriptRow(index, row, width, rc, start)
+			appendBlock(rendered)
+			selectable = append(selectable, rowSelectable...)
+			shownAny = true
+		}
+	}
+
+	if m.pending {
+		appendBlank()
+		switch {
+		case m.pendingPermission != nil:
+			appendBlock(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
+		case m.pendingAskUser != nil:
+			appendBlock(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
+		default:
+			appendBlock(m.interimBlock(width))
+		}
+	}
+	if m.pendingSpecReview != nil {
+		appendBlank()
+		appendBlock(renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width))
+	}
+
+	return strings.Join(lines, "\n"), selectable
+}
+
+func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {
+	switch row.kind {
+	case rowUser:
+		return m.renderSelectableUserRow(rowIndex, row, width, startBodyY)
+	case rowAssistant:
+		return m.renderSelectableAssistantRow(rowIndex, row, width, startBodyY)
+	default:
+		return m.renderRow(row, width, rc), nil
+	}
+}
+
+func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
+	wrapped := wrapPlainText(row.text, sayMeasure(width))
+	lines := make([]string, 0, len(wrapped))
+	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
+	for index, line := range wrapped {
+		prefix := "  "
+		if index == 0 {
+			prefix = "❯ "
+		}
+		meta := transcriptSelectableLine{
+			bodyY:     startBodyY + index,
+			rowIndex:  rowIndex,
+			textStart: lipgloss.Width(prefix),
+			text:      line,
+		}
+		selectable = append(selectable, meta)
+		lines = append(lines, zeroTheme.userPrompt.Render(prefix)+m.renderTranscriptSelectableText(meta, zeroTheme.ink))
+	}
+	return strings.Join(lines, "\n"), selectable
+}
+
+func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
+	wrapped := wrapPlainText(row.text, sayMeasure(width))
+	lines := make([]string, 0, len(wrapped)+1)
+	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
+	prefix := ""
+	textStyle := zeroTheme.sayText
+	if row.final {
+		prefix = "│ "
+		textStyle = zeroTheme.ink
+	}
+	for index, line := range wrapped {
+		meta := transcriptSelectableLine{
+			bodyY:     startBodyY + index,
+			rowIndex:  rowIndex,
+			textStart: lipgloss.Width(prefix),
+			text:      line,
+		}
+		selectable = append(selectable, meta)
+		rendered := m.renderTranscriptSelectableText(meta, textStyle)
+		if row.final {
+			rendered = zeroTheme.finalRail.Render(prefix) + rendered
+		}
+		lines = append(lines, rendered)
+	}
+	if row.final {
+		lines = append(lines, doneLine(row, false))
+	}
+	return strings.Join(lines, "\n"), selectable
+}
+
+func (m model) renderTranscriptSelectableText(line transcriptSelectableLine, base lipgloss.Style) string {
+	start, end, ok := m.selectedColumnsForTranscriptLine(line)
+	if !ok {
+		return base.Render(line.text)
+	}
+	before, rest := splitPlainAtDisplayWidth(line.text, start)
+	middle, after := splitPlainAtDisplayWidth(rest, end-start)
+	return base.Render(before) + zeroTheme.selection.Render(middle) + base.Render(after)
+}
+
+func (m model) selectedColumnsForTranscriptLine(line transcriptSelectableLine) (int, int, bool) {
+	if !m.transcriptSelection.active {
+		return 0, 0, false
+	}
+	startPoint, endPoint := orderedTranscriptSelectionPoints(m.transcriptSelection.anchor, m.transcriptSelection.cursor)
+	if line.bodyY < startPoint.bodyY || line.bodyY > endPoint.bodyY {
+		return 0, 0, false
+	}
+	lineStart := line.textStart
+	lineEnd := line.textStart + lipgloss.Width(line.text)
+	start := lineStart
+	end := lineEnd
+	if line.bodyY == startPoint.bodyY {
+		start = clampInt(startPoint.x, lineStart, lineEnd)
+	}
+	if line.bodyY == endPoint.bodyY {
+		end = clampInt(endPoint.x, lineStart, lineEnd)
+	}
+	if end <= start {
+		return 0, 0, false
+	}
+	return start - line.textStart, end - line.textStart, true
+}
+
+func orderedTranscriptSelectionPoints(a transcriptSelectionPoint, b transcriptSelectionPoint) (transcriptSelectionPoint, transcriptSelectionPoint) {
+	if a.bodyY < b.bodyY || a.bodyY == b.bodyY && a.x <= b.x {
+		return a, b
+	}
+	return b, a
+}
+
+func splitPlainAtDisplayWidth(text string, width int) (string, string) {
+	if width <= 0 {
+		return "", text
+	}
+	used := 0
+	for index, glyph := range text {
+		glyphWidth := lipgloss.Width(string(glyph))
+		if used+glyphWidth > width {
+			return text[:index], text[index:]
+		}
+		used += glyphWidth
+	}
+	return text, ""
+}
+
+func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine, bool) {
+	if !m.altScreen || m.height <= 0 || m.setup.visible || m.providerWizard != nil || m.picker != nil || m.suggestionsActive() {
+		return transcriptSelectableLine{}, false
+	}
+	width := chatWidth(m.width)
+	body, selectable := m.transcriptBody(width, "")
+	start, available := m.transcriptViewportStart(body, width)
+	if msg.Y < 0 || msg.Y >= available {
+		return transcriptSelectableLine{}, false
+	}
+	bodyY := start + msg.Y
+	for _, line := range selectable {
+		if line.bodyY != bodyY {
+			continue
+		}
+		if msg.X < 0 {
+			return transcriptSelectableLine{}, false
+		}
+		return line, true
+	}
+	return transcriptSelectableLine{}, false
+}
+
+func (m model) transcriptViewportStart(body string, width int) (int, int) {
+	bodyLines := viewLines(body)
+	footerLines := viewLines(m.footerView(width))
+	available := m.height - len(footerLines)
+	if available < 1 {
+		available = 1
+	}
+	maxOffset := maxInt(0, len(bodyLines)-available)
+	offset := clamp(m.chatScrollOffset, 0, maxOffset)
+	start := maxInt(0, len(bodyLines)-available-offset)
+	return start, available
+}
+
+func transcriptSelectionPointForMouse(line transcriptSelectableLine, x int) transcriptSelectionPoint {
+	lineEnd := line.textStart + lipgloss.Width(line.text)
+	return transcriptSelectionPoint{
+		bodyY: line.bodyY,
+		x:     clampInt(x, line.textStart, lineEnd),
+	}
+}
+
+func (m model) handleTranscriptSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd, bool) {
+	switch {
+	case mouseLeftPress(msg):
+		line, ok := m.transcriptLineAtMouse(msg)
+		if !ok {
+			if m.transcriptSelection.active {
+				m.transcriptSelection = transcriptSelectionState{}
+				return m, nil, true
+			}
+			return m, nil, false
+		}
+		point := transcriptSelectionPointForMouse(line, msg.X)
+		m.copyStatus = ""
+		m.transcriptSelection = transcriptSelectionState{active: true, anchor: point, cursor: point}
+		return m, nil, true
+	case mouseMotion(msg):
+		if !m.transcriptSelection.active {
+			return m, nil, false
+		}
+		line, ok := m.transcriptLineAtMouse(msg)
+		if ok {
+			m.transcriptSelection.cursor = transcriptSelectionPointForMouse(line, msg.X)
+		}
+		return m, nil, true
+	case mouseRelease(msg):
+		if !m.transcriptSelection.active {
+			return m, nil, false
+		}
+		if line, ok := m.transcriptLineAtMouse(msg); ok {
+			m.transcriptSelection.cursor = transcriptSelectionPointForMouse(line, msg.X)
+		}
+		text := m.selectedTranscriptText()
+		if strings.TrimSpace(text) == "" {
+			m.transcriptSelection = transcriptSelectionState{}
+			return m, nil, true
+		}
+		return m, copyTranscriptSelectionCmd(text), true
+	default:
+		return m, nil, false
+	}
+}
+
+func (m model) selectedTranscriptText() string {
+	width := chatWidth(m.width)
+	_, selectable := m.transcriptBody(width, "")
+	parts := []string{}
+	for _, line := range selectable {
+		start, end, ok := m.selectedColumnsForTranscriptLine(line)
+		if !ok {
+			continue
+		}
+		before, rest := splitPlainAtDisplayWidth(line.text, start)
+		_ = before
+		selected, _ := splitPlainAtDisplayWidth(rest, end-start)
+		parts = append(parts, selected)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func copyTranscriptSelectionCmd(text string) tea.Cmd {
+	return func() tea.Msg {
+		_, _ = os.Stdout.WriteString(ansi.SetSystemClipboard(text))
+		return transcriptCopiedMsg{chars: utf8.RuneCountInString(text)}
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -14,6 +14,12 @@ import (
 	"github.com/Gitlawb/zero/internal/agent"
 )
 
+const (
+	suggestionPaletteMaxVisible = 7
+	suggestionPaletteMaxWidth   = 76
+	suggestionPaletteMinWidth   = 44
+)
+
 // layoutTier buckets the terminal width into the spec's adaptive tiers. It
 // is derived from the live width at every render, so a WindowSizeMsg
 // re-evaluates it implicitly.
@@ -285,20 +291,178 @@ func gitBranch(cwd string) string {
 	return ref
 }
 
-// suggestionOverlay renders the slash-command autocomplete list below the
-// composer: one row per match on the panel surface, the selected row on the
-// selection tint with an accent ❯ marker. Returns "" when no overlay should
-// show.
+// suggestionOverlay renders the slash-command/file autocomplete palette below
+// the composer: compact, bordered, and capped so short prefixes cannot flood
+// the chat surface. Returns "" when no overlay should show.
 func (m model) suggestionOverlay(width int) string {
 	if !m.suggestionsActive() {
 		return ""
 	}
-	return renderSelectableList(selectableListOptions{
-		Items:      selectableItems(m.suggestions, m.suggestionsAreFiles),
-		Selected:   m.suggestionIdx,
-		Width:      width - 2,
-		MaxVisible: maxCommandSuggestions,
-	})
+	title := "Commands"
+	query := commandSuggestionQuery(m.input.Value())
+	footer := "↑/↓ move   Enter run   Esc close"
+	if m.suggestionsAreFiles {
+		title = "Files"
+		query = fileSuggestionQuery(m.input.Value())
+		footer = "↑/↓ move   Enter insert   Esc close"
+	}
+	return centerRenderedBlock(renderSuggestionPalette(selectableItems(m.suggestions, m.suggestionsAreFiles), m.suggestionIdx, width, title, query, footer), width)
+}
+
+func commandSuggestionQuery(value string) string {
+	trimmed := strings.TrimLeft(value, " ")
+	if trimmed == "" {
+		return ""
+	}
+	if fields := strings.Fields(trimmed); len(fields) > 0 {
+		return strings.TrimPrefix(fields[0], "/")
+	}
+	return strings.TrimPrefix(strings.TrimSpace(trimmed), "/")
+}
+
+func fileSuggestionQuery(value string) string {
+	if token, ok := trailingAtToken(value); ok {
+		return token
+	}
+	return ""
+}
+
+func renderSuggestionPalette(items []selectableListItem, selected, width int, title, query, footer string) string {
+	if width <= 0 {
+		width = defaultStartupWidth
+	}
+	paletteWidth := minInt(width, suggestionPaletteMaxWidth)
+	if paletteWidth < suggestionPaletteMinWidth {
+		paletteWidth = width
+	}
+	innerWidth := maxInt(1, paletteWidth-4)
+	maxVisible := minInt(suggestionPaletteMaxVisible, len(items))
+	visible := []selectableListItem{}
+	start := 0
+	if len(items) > 0 {
+		selected = clampInt(selected, 0, len(items)-1)
+		start = selectableListStart(len(items), maxVisible, selected)
+		visible = items[start : start+maxVisible]
+	}
+
+	labelWidth := 0
+	for _, item := range visible {
+		if w := lipgloss.Width(item.Label); w > labelWidth {
+			labelWidth = w
+		}
+	}
+	labelWidth = minInt(labelWidth, maxInt(8, innerWidth/2))
+
+	lines := make([]string, 0, len(visible)+5)
+	searchInset := lipgloss.Width("❯ ")
+	lines = append(lines, fillPaletteLine(strings.Repeat(" ", searchInset)+renderSuggestionSearchLine(query, maxInt(1, innerWidth-searchInset)), innerWidth, transparentSurface))
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+
+	for index, item := range visible {
+		absoluteIndex := start + index
+		surface := transparentSurface
+		marker := surface(zeroTheme.faintest).Render("  ")
+		if absoluteIndex == selected {
+			surface = zeroTheme.onSel
+			marker = surface(zeroTheme.accent).Render("❯ ")
+		}
+
+		labelText := truncateRunes(item.Label, labelWidth)
+		label := surface(zeroTheme.ink).Render(labelText)
+		pad := surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(0, labelWidth-lipgloss.Width(labelText))))
+		line := marker + label + pad
+		if desc := strings.TrimSpace(item.Description); desc != "" {
+			descWidth := innerWidth - lipgloss.Width(marker) - labelWidth - 2
+			if truncated := truncateRunes(desc, maxInt(0, descWidth)); truncated != "" {
+				line += surface(zeroTheme.faint).Render("  " + truncated)
+			}
+		}
+		lines = append(lines, fillPaletteLine(line, innerWidth, surface))
+	}
+	if len(visible) == 0 {
+		message := "no matching commands"
+		if strings.EqualFold(strings.TrimSpace(title), "Files") {
+			message = "no matching files"
+		}
+		lines = append(lines, fillPaletteLine(strings.Repeat(" ", searchInset)+zeroTheme.faint.Render(message), innerWidth, transparentSurface))
+	}
+
+	if footer = strings.TrimSpace(footer); footer != "" {
+		lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+		line := zeroTheme.faint.Render(footer)
+		lines = append(lines, fillPaletteLine(line, innerWidth, transparentSurface))
+	}
+	return styledBlockFillTitle(paletteWidth, strings.TrimSpace(title), lines, zeroTheme.lineStrong, lipgloss.NewStyle())
+}
+
+func styledBlockFillTitle(width int, title string, lines []string, borderStyle lipgloss.Style, fill lipgloss.Style) string {
+	if width < 4 {
+		width = 4
+	}
+	if title = strings.TrimSpace(title); title == "" || widthTier(width) == tierTiny {
+		return styledBlockFill(width, lines, borderStyle, fill)
+	}
+	ruleWidth := width - 2
+	titleText := " " + title + " "
+	titleWidth := lipgloss.Width(titleText)
+	if titleWidth >= ruleWidth {
+		return styledBlockFill(width, lines, borderStyle, fill)
+	}
+
+	leftRule := "──"
+	rightRule := strings.Repeat("─", maxInt(0, ruleWidth-lipgloss.Width(leftRule)-titleWidth))
+	top := borderStyle.Render("╭"+leftRule) + zeroTheme.ink.Bold(true).Render(titleText) + borderStyle.Render(rightRule+"╮")
+	bottom := borderStyle.Render("╰" + strings.Repeat("─", width-2) + "╯")
+
+	body := make([]string, 0, len(lines)+2)
+	body = append(body, top)
+	for _, line := range lines {
+		available := width - 4
+		fitted := fitStyledLine(line, available)
+		pad := fill.Render(strings.Repeat(" ", maxInt(0, available-lipgloss.Width(fitted))))
+		body = append(body, borderStyle.Render("│ ")+fitted+pad+borderStyle.Render(" │"))
+	}
+	body = append(body, bottom)
+	return strings.Join(body, "\n")
+}
+
+func renderSuggestionSearchLine(query string, width int) string {
+	query = strings.TrimSpace(query)
+	label := zeroTheme.userPrompt.Render("search > ")
+	valueWidth := maxInt(1, width-lipgloss.Width(label))
+	value := zeroTheme.ink.Render(truncateRunes(query, valueWidth))
+	return fitStyledLine(label+value, width)
+}
+
+func transparentSurface(style lipgloss.Style) lipgloss.Style {
+	return style
+}
+
+func fillPaletteLine(line string, width int, surface func(lipgloss.Style) lipgloss.Style) string {
+	line = fitStyledLine(line, width)
+	pad := maxInt(0, width-lipgloss.Width(line))
+	if pad > 0 {
+		line += surface(zeroTheme.ink).Render(strings.Repeat(" ", pad))
+	}
+	return line
+}
+
+func centerRenderedBlock(block string, width int) string {
+	if block == "" || width <= 0 {
+		return block
+	}
+	lines := strings.Split(block, "\n")
+	blockWidth := 0
+	for _, line := range lines {
+		if w := lipgloss.Width(line); w > blockWidth {
+			blockWidth = w
+		}
+	}
+	pad := maxInt(0, (width-blockWidth)/2)
+	if pad == 0 {
+		return block
+	}
+	return indentBlock(block, pad)
 }
 
 func selectableItems(suggestions []commandSuggestion, files bool) []selectableListItem {
@@ -307,6 +471,8 @@ func selectableItems(suggestions []commandSuggestion, files bool) []selectableLi
 		item := selectableListItem{Label: suggestion.Name, Description: suggestion.Desc}
 		if files {
 			item = fileSelectableItem(suggestion.Name)
+		} else {
+			item.Label = strings.TrimPrefix(item.Label, "/")
 		}
 		items = append(items, item)
 	}
@@ -318,13 +484,13 @@ func fileSelectableItem(token string) selectableListItem {
 	rel = filepath.ToSlash(rel)
 	base := path.Base(rel)
 	if base == "." || base == "/" || base == "" {
-		return selectableListItem{Label: token, Description: "file"}
+		return selectableListItem{Label: strings.TrimPrefix(token, "@"), Description: "file"}
 	}
 	dir := path.Dir(rel)
 	if dir == "." || dir == "" {
-		return selectableListItem{Label: "@" + base, Description: "file"}
+		return selectableListItem{Label: base, Description: "file"}
 	}
-	return selectableListItem{Label: "@" + base, Description: dir}
+	return selectableListItem{Label: base, Description: dir}
 }
 
 // pickerOverlay renders an open interactive selector below the composer: a

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -21,6 +21,8 @@ const (
 	pickerOverlayMaxVisible     = 10
 	pickerOverlayMaxWidth       = 92
 	pickerOverlayMinWidth       = 56
+	modelPickerOverlayMaxWidth  = 76
+	modelPickerOverlayMinWidth  = 58
 )
 
 // layoutTier buckets the terminal width into the spec's adaptive tiers. It
@@ -117,7 +119,7 @@ func (m model) titleModelSegment() string {
 func (m model) composerDividerLine(width int) string {
 	model := displayValue(strings.TrimSpace(m.modelName), "no model")
 	label, style := m.modeLabel()
-	meta := zeroTheme.muted.Render(model) + zeroTheme.line.Render(" · ") + style.Render(label)
+	meta := zeroTheme.muted.Render(model) + zeroTheme.muted.Render(" · ") + style.Render(label)
 	metaWidth := lipgloss.Width(meta)
 	if width < 8 {
 		return zeroTheme.lineStrong.Render(strings.Repeat("─", width))
@@ -512,6 +514,9 @@ func (m model) pickerOverlay(width int) string {
 	if m.picker == nil {
 		return ""
 	}
+	if m.picker.kind == pickerModel {
+		return m.modelPickerOverlay(width)
+	}
 	overlayWidth := minInt(width, pickerOverlayMaxWidth)
 	if overlayWidth < pickerOverlayMinWidth {
 		overlayWidth = width
@@ -529,18 +534,7 @@ func (m model) pickerOverlay(width int) string {
 	lines := make([]string, 0, len(visible)+5)
 	title := strings.TrimSpace(m.picker.title)
 	hint := "↑/↓ · ⏎ · esc"
-	if m.picker.kind == pickerModel {
-		hint += " · ctrl+f favorite"
-	}
 	lines = append(lines, zeroTheme.faint.Render(hint))
-	if m.picker.kind == pickerModel {
-		query := strings.TrimSpace(m.picker.query)
-		value := zeroTheme.faint.Render("Search model")
-		if query != "" {
-			value = zeroTheme.ink.Render(query)
-		}
-		lines = append(lines, zeroTheme.userPrompt.Render("search > ")+value)
-	}
 	lastGroup := ""
 	for index, item := range visible {
 		absoluteIndex := start + index
@@ -579,6 +573,155 @@ func (m model) pickerOverlay(width int) string {
 		lines = append(lines, zeroTheme.faint.Render("  no matching items"))
 	}
 	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, title, lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
+}
+
+func (m model) modelPickerOverlay(width int) string {
+	if m.picker == nil {
+		return ""
+	}
+	if m.modelPickerLoading {
+		return m.modelPickerLoadingOverlay(width)
+	}
+	overlayWidth := modelPickerOverlayWidth(width, m.picker)
+	innerWidth := maxInt(1, overlayWidth-4)
+	maxVisible := minInt(pickerOverlayMaxVisible, len(m.picker.items))
+	start := 0
+	visible := []pickerItem{}
+	if len(m.picker.items) > 0 {
+		m.picker.selected = clampInt(m.picker.selected, 0, len(m.picker.items)-1)
+		start = selectableListStart(len(m.picker.items), maxVisible, m.picker.selected)
+		visible = m.picker.items[start : start+maxVisible]
+	}
+
+	lines := make([]string, 0, len(visible)+6)
+	searchInset := lipgloss.Width("❯ ")
+	searchPrefix := transparentSurface(zeroTheme.ink).Render(strings.Repeat(" ", searchInset))
+	lines = append(lines, fillPaletteLine(searchPrefix+renderModelPickerSearchLine(m.picker.query, maxInt(1, innerWidth-searchInset)), innerWidth, transparentSurface))
+	if status := strings.TrimSpace(m.modelPickerLoadError); status != "" {
+		lines = append(lines, fillPaletteLine(searchPrefix+zeroTheme.faint.Render(status), innerWidth, transparentSurface))
+	}
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+	for index, item := range visible {
+		lines = append(lines, renderModelPickerRow(innerWidth, start+index == m.picker.selected, item))
+	}
+	if len(visible) == 0 {
+		lines = append(lines, fillPaletteLine(searchPrefix+zeroTheme.faint.Render("no matching models"), innerWidth, transparentSurface))
+	}
+	if item, ok := m.picker.current(); ok {
+		if detail := modelPickerItemDetail(item); detail != "" {
+			lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+			lines = append(lines, fillPaletteLine(searchPrefix+zeroTheme.faint.Render(detail), innerWidth, transparentSurface))
+		}
+	}
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+	footer := "↑/↓ move   Enter select   Ctrl+F favorite   Esc close"
+	lines = append(lines, fillPaletteLine(zeroTheme.faint.Render(footer), innerWidth, transparentSurface))
+	title := strings.TrimSpace(m.picker.title)
+	if title == "" {
+		title = "Choose a model"
+	}
+	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, title, lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
+}
+
+func (m model) modelPickerLoadingOverlay(width int) string {
+	overlayWidth := modelPickerLoadingOverlayWidth(width)
+	innerWidth := maxInt(1, overlayWidth-4)
+	lines := []string{
+		fillPaletteLine(zeroTheme.faint.Render("Checking available models..."), innerWidth, transparentSurface),
+		fillPaletteLine(zeroTheme.faint.Render("Built-in models will be used if discovery fails."), innerWidth, transparentSurface),
+		zeroTheme.line.Render(strings.Repeat("─", innerWidth)),
+		fillPaletteLine(zeroTheme.faint.Render("Esc close"), innerWidth, transparentSurface),
+	}
+	title := strings.TrimSpace(m.picker.title)
+	if title == "" {
+		title = "Choose a model"
+	}
+	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, title, lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
+}
+
+func modelPickerLoadingOverlayWidth(terminalWidth int) int {
+	if terminalWidth <= 0 {
+		terminalWidth = defaultStartupWidth
+	}
+	available := minInt(terminalWidth, modelPickerOverlayMaxWidth)
+	if terminalWidth < modelPickerOverlayMinWidth {
+		available = terminalWidth
+	}
+	target := lipgloss.Width("Built-in models will be used if discovery fails.")
+	target = maxInt(target, lipgloss.Width("Choose a model"))
+	target = maxInt(target, lipgloss.Width("Esc close"))
+	overlayWidth := maxInt(modelPickerOverlayMinWidth, target+4)
+	return minInt(overlayWidth, maxInt(4, available))
+}
+
+func modelPickerOverlayWidth(terminalWidth int, picker *commandPicker) int {
+	if terminalWidth <= 0 {
+		terminalWidth = defaultStartupWidth
+	}
+	available := minInt(terminalWidth, modelPickerOverlayMaxWidth)
+	if terminalWidth < modelPickerOverlayMinWidth {
+		available = terminalWidth
+	}
+	target := lipgloss.Width("Choose a model")
+	target = maxInt(target, lipgloss.Width("  search > model name..."))
+	target = maxInt(target, lipgloss.Width("↑/↓ move   Enter select   Ctrl+F favorite   Esc close"))
+	target = maxInt(target, lipgloss.Width("  Using built-in model list"))
+	if picker != nil {
+		for _, item := range picker.items {
+			labelWidth := lipgloss.Width(item.Label)
+			if item.Favorite {
+				labelWidth += lipgloss.Width("* ")
+			}
+			target = maxInt(target, lipgloss.Width("❯ ")+labelWidth)
+			if detail := modelPickerItemDetail(item); detail != "" {
+				target = maxInt(target, lipgloss.Width("  "+detail))
+			}
+		}
+	}
+	overlayWidth := maxInt(modelPickerOverlayMinWidth, target+4)
+	return minInt(overlayWidth, maxInt(4, available))
+}
+
+func renderModelPickerSearchLine(query string, width int) string {
+	query = strings.TrimSpace(query)
+	prompt := zeroTheme.userPrompt.Render("search > ")
+	cursor := zeroTheme.accent.Render("▌")
+	if query == "" {
+		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render("model name..."), width)
+	}
+	return fitStyledLine(prompt+zeroTheme.ink.Render(query)+cursor, width)
+}
+
+func renderModelPickerRow(width int, selected bool, item pickerItem) string {
+	surface := transparentSurface
+	marker := surface(zeroTheme.faintest).Render("  ")
+	if selected {
+		surface = zeroTheme.onSel
+		marker = surface(zeroTheme.accent).Render("❯ ")
+	}
+	label := strings.TrimSpace(item.Label)
+	if label == "" {
+		label = strings.TrimSpace(item.Value)
+	}
+	prefix := ""
+	if item.Favorite {
+		prefix = "* "
+	}
+	line := marker + surface(zeroTheme.ink).Render(prefix+label)
+	return fillPaletteLine(line, width, surface)
+}
+
+func modelPickerItemDetail(item pickerItem) string {
+	parts := []string{}
+	value := strings.TrimSpace(item.Value)
+	label := strings.TrimSpace(item.Label)
+	if value != "" && value != label {
+		parts = append(parts, value)
+	}
+	if meta := strings.TrimSpace(item.Meta); meta != "" {
+		parts = append(parts, meta)
+	}
+	return strings.Join(parts, " · ")
 }
 
 // argHint extracts the most representative argument from a tool call's raw JSON

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -482,13 +482,18 @@ func selectableItems(suggestions []commandSuggestion, files bool) []selectableLi
 func fileSelectableItem(token string) selectableListItem {
 	rel := strings.TrimPrefix(token, "@")
 	rel = filepath.ToSlash(rel)
-	base := path.Base(rel)
+	isDir := strings.HasSuffix(rel, "/")
+	cleanRel := strings.TrimSuffix(rel, "/")
+	base := path.Base(cleanRel)
 	if base == "." || base == "/" || base == "" {
 		return selectableListItem{Label: strings.TrimPrefix(token, "@"), Description: "file"}
 	}
-	dir := path.Dir(rel)
+	if isDir {
+		base += "/"
+	}
+	dir := path.Dir(cleanRel)
 	if dir == "." || dir == "" {
-		return selectableListItem{Label: base, Description: "file"}
+		return selectableListItem{Label: base}
 	}
 	return selectableListItem{Label: base, Description: dir}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -300,6 +300,9 @@ func (m model) suggestionOverlay(width int) string {
 	title := "Commands"
 	query := commandSuggestionQuery(m.input.Value())
 	footer := "↑/↓ move   Enter run   Esc close"
+	if m.selectedCommandSuggestionRequiresInput() {
+		footer = "↑/↓ move   Enter insert   Esc close"
+	}
 	if m.suggestionsAreFiles {
 		title = "Files"
 		query = fileSuggestionQuery(m.input.Value())

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -22,7 +22,7 @@ type layoutTier int
 const (
 	tierTiny   layoutTier = iota // < 58: single-segment header, rail-less cards
 	tierNarrow                   // 58–79: no gutters, bare badge, lean status
-	tierMedium                   // 80–99: no tool-arg column, no ctx, no "interactive"
+	tierMedium                   // 80–99: no tool-arg column, no ctx
 	tierFull                     // ≥ 100: everything
 )
 
@@ -105,34 +105,41 @@ func (m model) titleModelSegment() string {
 	}
 }
 
+func (m model) composerDividerLine(width int) string {
+	model := displayValue(strings.TrimSpace(m.modelName), "no model")
+	label, style := m.modeLabel()
+	meta := zeroTheme.muted.Render(model) + zeroTheme.line.Render(" · ") + style.Render(label)
+	metaWidth := lipgloss.Width(meta)
+	if width < 8 {
+		return zeroTheme.lineStrong.Render(strings.Repeat("─", width))
+	}
+	if width <= metaWidth+4 {
+		return zeroTheme.lineStrong.Render("╰" + strings.Repeat("─", width-2) + "╯")
+	}
+	rule := strings.Repeat("─", width-metaWidth-4)
+	return zeroTheme.lineStrong.Render("╰"+rule+" ") + meta + zeroTheme.lineStrong.Render(" ╯")
+}
+
 // statusLine renders the bottom readout as ` │ `-separated groups: provider
-// and model on the left, then a flexible gap, then tokens/cost, the surface
-// name, and the permission mode. Groups drop with the width tier: medium
-// loses "interactive", narrow keeps provider+tokens+mode only, tiny shows
-// just the mode.
+// on the left, then a flexible gap, then tokens/cost and the surface name.
+// Groups drop with the width tier: narrow keeps provider+tokens only, tiny
+// shows the provider only.
 func (m model) statusLine(width int) string {
 	tier := widthTier(width)
 	separator := zeroTheme.line.Render(" │ ")
-	label, style := m.modeLabel()
-	mode := style.Render("⏵⏵ " + label)
+	prefix := "  "
 
 	if tier == tierTiny {
-		return fitStyledLine(mode, width)
+		provider := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(displayValue(strings.TrimSpace(m.providerName), "no provider"))
+		return fitStyledLine(provider, width)
 	}
 
-	left := zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(displayValue(strings.TrimSpace(m.providerName), "no provider"))
-	if model := strings.TrimSpace(m.modelName); model != "" && tier >= tierMedium {
-		left += separator + zeroTheme.muted.Render(model)
-	}
+	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(displayValue(strings.TrimSpace(m.providerName), "no provider"))
 
 	rightGroups := []string{}
 	if usage := m.usageStatusSegment(); usage != "" {
 		rightGroups = append(rightGroups, zeroTheme.muted.Render(usage))
 	}
-	if tier == tierFull {
-		rightGroups = append(rightGroups, zeroTheme.faint.Render("interactive"))
-	}
-	rightGroups = append(rightGroups, mode)
 	right := strings.Join(rightGroups, separator)
 
 	return fitStyledLine(joinHeaderLine(left, right, width), width)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -18,6 +18,9 @@ const (
 	suggestionPaletteMaxVisible = 7
 	suggestionPaletteMaxWidth   = 76
 	suggestionPaletteMinWidth   = 44
+	pickerOverlayMaxVisible     = 10
+	pickerOverlayMaxWidth       = 92
+	pickerOverlayMinWidth       = 56
 )
 
 // layoutTier buckets the terminal width into the spec's adaptive tiers. It
@@ -357,7 +360,8 @@ func renderSuggestionPalette(items []selectableListItem, selected, width int, ti
 
 	lines := make([]string, 0, len(visible)+5)
 	searchInset := lipgloss.Width("❯ ")
-	lines = append(lines, fillPaletteLine(strings.Repeat(" ", searchInset)+renderSuggestionSearchLine(query, maxInt(1, innerWidth-searchInset)), innerWidth, transparentSurface))
+	searchPrefix := transparentSurface(zeroTheme.ink).Render(strings.Repeat(" ", searchInset))
+	lines = append(lines, fillPaletteLine(searchPrefix+renderSuggestionSearchLine(query, maxInt(1, innerWidth-searchInset)), innerWidth, transparentSurface))
 	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
 
 	for index, item := range visible {
@@ -386,7 +390,7 @@ func renderSuggestionPalette(items []selectableListItem, selected, width int, ti
 		if strings.EqualFold(strings.TrimSpace(title), "Files") {
 			message = "no matching files"
 		}
-		lines = append(lines, fillPaletteLine(strings.Repeat(" ", searchInset)+zeroTheme.faint.Render(message), innerWidth, transparentSurface))
+		lines = append(lines, fillPaletteLine(searchPrefix+zeroTheme.faint.Render(message), innerWidth, transparentSurface))
 	}
 
 	if footer = strings.TrimSpace(footer); footer != "" {
@@ -500,7 +504,7 @@ func fileSelectableItem(token string) selectableListItem {
 	return selectableListItem{Label: base, Description: dir}
 }
 
-// pickerOverlay renders an open interactive selector below the composer: a
+// pickerOverlay renders an open interactive selector as a centered modal: a
 // bordered panel with a title-and-hints row, rows carrying a provider dot and
 // right metadata when the catalog exposes them, and the selected row on the
 // selection tint.
@@ -508,13 +512,27 @@ func (m model) pickerOverlay(width int) string {
 	if m.picker == nil {
 		return ""
 	}
-	innerWidth := width - 4
-	lines := make([]string, 0, len(m.picker.items)+1)
-	hint := "  ↑/↓ · ⏎ · esc"
+	overlayWidth := minInt(width, pickerOverlayMaxWidth)
+	if overlayWidth < pickerOverlayMinWidth {
+		overlayWidth = width
+	}
+	innerWidth := maxInt(1, overlayWidth-4)
+	maxVisible := minInt(pickerOverlayMaxVisible, len(m.picker.items))
+	start := 0
+	visible := []pickerItem{}
+	if len(m.picker.items) > 0 {
+		m.picker.selected = clampInt(m.picker.selected, 0, len(m.picker.items)-1)
+		start = selectableListStart(len(m.picker.items), maxVisible, m.picker.selected)
+		visible = m.picker.items[start : start+maxVisible]
+	}
+
+	lines := make([]string, 0, len(visible)+5)
+	title := strings.TrimSpace(m.picker.title)
+	hint := "↑/↓ · ⏎ · esc"
 	if m.picker.kind == pickerModel {
 		hint += " · ctrl+f favorite"
 	}
-	lines = append(lines, zeroTheme.ink.Render(m.picker.title)+zeroTheme.faint.Render(hint))
+	lines = append(lines, zeroTheme.faint.Render(hint))
 	if m.picker.kind == pickerModel {
 		query := strings.TrimSpace(m.picker.query)
 		value := zeroTheme.faint.Render("Search model")
@@ -524,14 +542,15 @@ func (m model) pickerOverlay(width int) string {
 		lines = append(lines, zeroTheme.userPrompt.Render("search > ")+value)
 	}
 	lastGroup := ""
-	for index, item := range m.picker.items {
+	for index, item := range visible {
+		absoluteIndex := start + index
 		if item.Group != "" && item.Group != lastGroup {
 			lines = append(lines, zeroTheme.accent.Render(item.Group))
 			lastGroup = item.Group
 		}
-		surface := zeroTheme.onPanel2
+		surface := transparentSurface
 		marker := surface(zeroTheme.faintest).Render("  ")
-		if index == m.picker.selected {
+		if absoluteIndex == m.picker.selected {
 			surface = zeroTheme.onSel
 			marker = surface(zeroTheme.accent).Render("❯ ")
 		}
@@ -556,7 +575,10 @@ func (m model) pickerOverlay(width int) string {
 		line := left + surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(1, gap))) + right
 		lines = append(lines, fitStyledLine(line, innerWidth))
 	}
-	return borderedBlock(width, lines)
+	if len(visible) == 0 {
+		lines = append(lines, zeroTheme.faint.Render("  no matching items"))
+	}
+	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, title, lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
 }
 
 // argHint extracts the most representative argument from a tool call's raw JSON

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -119,7 +119,7 @@ func (m model) composerDividerLine(width int) string {
 	if width < 8 {
 		return zeroTheme.lineStrong.Render(strings.Repeat("─", width))
 	}
-	if width <= metaWidth+4 {
+	if width < metaWidth+4 {
 		return zeroTheme.lineStrong.Render("╰" + strings.Repeat("─", width-2) + "╯")
 	}
 	rule := strings.Repeat("─", width-metaWidth-4)
@@ -127,9 +127,8 @@ func (m model) composerDividerLine(width int) string {
 }
 
 // statusLine renders the bottom readout as ` │ `-separated groups: provider
-// on the left, then a flexible gap, then tokens/cost and the surface name.
-// Groups drop with the width tier: narrow keeps provider+tokens only, tiny
-// shows the provider only.
+// on the left, then a flexible gap, then token/cost usage on the right. Groups
+// drop with the width tier: narrow keeps provider+usage, tiny shows provider.
 func (m model) statusLine(width int) string {
 	tier := widthTier(width)
 	separator := zeroTheme.line.Render(" │ ")

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -105,6 +105,21 @@ func TestTinyTierSingleSegmentAndRailLessCards(t *testing.T) {
 	}
 }
 
+func TestComposerDividerRendersMetaAtExactFit(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ModelName:      "m",
+		PermissionMode: agent.PermissionModeAsk,
+	})
+	label, style := m.modeLabel()
+	meta := zeroTheme.muted.Render("m") + zeroTheme.line.Render(" · ") + style.Render(label)
+	width := lipgloss.Width(meta) + 4
+
+	got := plainRender(t, m.composerDividerLine(width))
+	if !strings.Contains(got, "m") || !strings.Contains(got, label) {
+		t.Fatalf("exact-fit composer divider = %q, want metadata", got)
+	}
+}
+
 // The spec's hard rendering invariant: never emit a styled line wider than
 // the terminal, across the whole frame at every tier — including the empty
 // state, ask-user rows, permission details, and pending image chips, which

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -111,7 +111,7 @@ func TestComposerDividerRendersMetaAtExactFit(t *testing.T) {
 		PermissionMode: agent.PermissionModeAsk,
 	})
 	label, style := m.modeLabel()
-	meta := zeroTheme.muted.Render("m") + zeroTheme.line.Render(" · ") + style.Render(label)
+	meta := zeroTheme.muted.Render("m") + zeroTheme.muted.Render(" · ") + style.Render(label)
 	width := lipgloss.Width(meta) + 4
 
 	got := plainRender(t, m.composerDividerLine(width))

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -24,19 +24,17 @@ func TestWidthTierSegments(t *testing.T) {
 	}, "\n")
 
 	cases := []struct {
-		width        int
-		wantCtx      bool // header context window ("200K")
-		wantCwd      bool // header cwd segment
-		wantArg      bool // tool-card arg column
-		wantGutter   bool // diff line-number gutter
-		wantInteract bool // status "interactive" group
-		wantModelID  bool // status model id group
+		width      int
+		wantCtx    bool // header context window ("200K")
+		wantCwd    bool // header cwd segment
+		wantArg    bool // tool-card arg column
+		wantGutter bool // diff line-number gutter
 	}{
-		{width: 58, wantCtx: false, wantCwd: false, wantArg: false, wantGutter: false, wantInteract: false, wantModelID: false},
-		{width: 70, wantCtx: false, wantCwd: false, wantArg: false, wantGutter: false, wantInteract: false, wantModelID: false},
-		{width: 80, wantCtx: false, wantCwd: true, wantArg: false, wantGutter: true, wantInteract: false, wantModelID: true},
-		{width: 100, wantCtx: true, wantCwd: true, wantArg: true, wantGutter: true, wantInteract: true, wantModelID: true},
-		{width: 120, wantCtx: true, wantCwd: true, wantArg: true, wantGutter: true, wantInteract: true, wantModelID: true},
+		{width: 58, wantCtx: false, wantCwd: false, wantArg: false, wantGutter: false},
+		{width: 70, wantCtx: false, wantCwd: false, wantArg: false, wantGutter: false},
+		{width: 80, wantCtx: false, wantCwd: true, wantArg: false, wantGutter: true},
+		{width: 100, wantCtx: true, wantCwd: true, wantArg: true, wantGutter: true},
+		{width: 120, wantCtx: true, wantCwd: true, wantArg: true, wantGutter: true},
 	}
 
 	for _, tc := range cases {
@@ -72,14 +70,12 @@ func TestWidthTierSegments(t *testing.T) {
 		}
 
 		status := plainRender(t, m.statusLine(tc.width))
-		if got := strings.Contains(status, "interactive"); got != tc.wantInteract {
-			t.Errorf("width %d: status interactive = %v, want %v (%q)", tc.width, got, tc.wantInteract, status)
+		if strings.Contains(status, "interactive") || strings.Contains(status, "claude-sonnet-4.5") || strings.Contains(status, "auto-approve") {
+			t.Errorf("width %d: status should not include surface, model, or permission mode (%q)", tc.width, status)
 		}
-		if got := strings.Contains(status, "claude-sonnet-4.5"); got != tc.wantModelID {
-			t.Errorf("width %d: status model id = %v, want %v (%q)", tc.width, got, tc.wantModelID, status)
-		}
-		if !strings.Contains(status, "⏵⏵") {
-			t.Errorf("width %d: status must always keep the mode group (%q)", tc.width, status)
+		divider := plainRender(t, m.composerDividerLine(tc.width))
+		if !strings.Contains(divider, "claude-sonnet-4.5") || !strings.Contains(divider, "auto-approve") {
+			t.Errorf("width %d: composer divider must keep model and mode labels (%q)", tc.width, divider)
 		}
 	}
 }
@@ -89,11 +85,15 @@ func TestTinyTierSingleSegmentAndRailLessCards(t *testing.T) {
 	m.width, m.height = 40, 20
 
 	status := plainRender(t, m.statusLine(40))
-	if strings.Contains(status, "anthropic") {
-		t.Fatalf("tiny status = %q, want mode line only", status)
+	if !strings.Contains(status, "anthropic") {
+		t.Fatalf("tiny status = %q, want provider status", status)
 	}
-	if !strings.Contains(status, "⏵⏵") {
-		t.Fatalf("tiny status = %q, want the mode group", status)
+	if strings.Contains(status, "claude-sonnet-4.5") || strings.Contains(status, "auto-approve") {
+		t.Fatalf("tiny status = %q, want provider only", status)
+	}
+	divider := plainRender(t, m.composerDividerLine(40))
+	if !strings.Contains(divider, "claude-sonnet-4.5") || !strings.Contains(divider, "auto-approve") {
+		t.Fatalf("tiny composer divider = %q, want model and mode labels", divider)
 	}
 
 	row := transcriptRow{kind: rowToolResult, id: "c", tool: "grep", status: tools.StatusOK, detail: "a.go:1: x"}


### PR DESCRIPTION
Summary:
- Simplifies the empty chat surface by removing starter prompt chips and duplicate model text.
- Frames the composer with a stronger border and shows model + permission mode in the frame.
- Quiets the bottom status line and improves alignment.
- Adds terminal-style composer word editing for Alt/Ctrl word movement and deletion.
- Adds app-managed mouse selection/copy for chat transcript text; this intentionally captures mouse input while the TUI is active, so native terminal selection remains available through the terminal escape path such as Shift-drag where supported.

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

More UI polish can continue in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Word-wise cursor navigation, smarter word deletion, mention-aware backspace, transcript text selection & copy, mouse interactions for overlays.
* **UI/UX Changes**
  * Bordered composer with stronger divider showing model/mode, inline command-argument hints, simplified empty state, centered/capped suggestion & picker overlays, model-picker loading/status views, refined footer/status rendering and theme accents.
* **Bug Fixes**
  * More robust suggestion completion/dismissal, stale discovery guarding, cursor/selection edge-case fixes.
* **Tests**
  * Large expansion across autocomplete, mouse, picker, wizard, rendering, onboarding, and config tests.
* **Config**
  * Favorite models preference added with normalization and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->