### PR TITLE
Fix /resume flooding with sub-run sessions

### DIFF
--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -345,6 +345,47 @@ func (store *Store) Latest() (*Metadata, error) {
 	return &sessions[0], nil
 }
 
+// IsResumableKind reports whether a session kind represents a standalone,
+// user-resumable conversation rather than an agent sub-run. Regular ("") and
+// user fork sessions are resumable; child (specialist/sub-agent) and spec
+// draft/impl sessions are not — each agent task and /spec run creates one, so
+// listing them in the resume picker floods it with non-conversation entries.
+func IsResumableKind(kind SessionKind) bool {
+	switch kind {
+	case "", SessionKindFork:
+		return true
+	default:
+		return false
+	}
+}
+
+// ListResumable returns only the sessions a user can resume as standalone
+// conversations (see IsResumableKind), newest-first like List.
+func (store *Store) ListResumable() ([]Metadata, error) {
+	all, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	resumable := make([]Metadata, 0, len(all))
+	for _, session := range all {
+		if IsResumableKind(session.SessionKind) {
+			resumable = append(resumable, session)
+		}
+	}
+	return resumable, nil
+}
+
+// LatestResumable returns the most-recently-updated resumable session, or nil
+// when none exist. Used by `/resume latest` so it lands on a real conversation
+// instead of the newest child/spec sub-run.
+func (store *Store) LatestResumable() (*Metadata, error) {
+	resumable, err := store.ListResumable()
+	if err != nil || len(resumable) == 0 {
+		return nil, err
+	}
+	return &resumable[0], nil
+}
+
 func (store *Store) Fork(parentSessionID string, input ForkInput) (Metadata, error) {
 	if !ValidSessionID(parentSessionID) {
 		return Metadata{}, fmt.Errorf("invalid zero session id %q", parentSessionID)

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -316,6 +316,60 @@ func TestStoreListsChildrenLineageAndTree(t *testing.T) {
 	}
 }
 
+func TestListAndLatestResumableExcludeSubRuns(t *testing.T) {
+	at, err := time.Parse(time.RFC3339, "2026-06-04T10:00:00Z")
+	if err != nil {
+		t.Fatalf("parse start time: %v", err)
+	}
+	// Advancing clock: each created session is strictly newer than the last, so
+	// LatestResumable is deterministic regardless of how often Create reads Now.
+	clock := func() time.Time {
+		at = at.Add(time.Second)
+		return at
+	}
+	store := NewStore(StoreOptions{RootDir: t.TempDir(), Now: clock})
+
+	mk := func(kind SessionKind, title string) Metadata {
+		s, err := store.Create(CreateInput{Title: title, Cwd: "/repo", ModelID: "m", Provider: "p", SessionKind: kind})
+		if err != nil {
+			t.Fatalf("Create(%q): %v", kind, err)
+		}
+		return s
+	}
+	mk("", "conversation-1")
+	mk(SessionKindFork, "fork-1")
+	mk(SessionKindChild, "child-1")
+	mk(SessionKindSpecDraft, "spec-draft-1")
+	mk(SessionKindSpecImpl, "spec-impl-1")
+	newestResumable := mk("", "conversation-2") // newest standalone conversation
+	mk(SessionKindChild, "child-2")             // newer overall, but a sub-run
+
+	resumable, err := store.ListResumable()
+	if err != nil {
+		t.Fatalf("ListResumable: %v", err)
+	}
+	if len(resumable) != 3 {
+		t.Fatalf("ListResumable returned %d sessions, want 3 (two regular + one fork)", len(resumable))
+	}
+	for _, session := range resumable {
+		if !IsResumableKind(session.SessionKind) {
+			t.Fatalf("ListResumable leaked sub-run kind %q (%s)", session.SessionKind, session.SessionID)
+		}
+	}
+
+	latest, err := store.LatestResumable()
+	if err != nil {
+		t.Fatalf("LatestResumable: %v", err)
+	}
+	if latest == nil || latest.SessionID != newestResumable.SessionID {
+		got := "nil"
+		if latest != nil {
+			got = latest.SessionID
+		}
+		t.Fatalf("LatestResumable = %s, want newest resumable %s (must skip the newer child)", got, newestResumable.SessionID)
+	}
+}
+
 func TestDefaultRootHonorsXDGDataHome(t *testing.T) {
 	got := DefaultRoot(map[string]string{
 		"XDG_DATA_HOME": "/tmp/zero-data",

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -53,7 +53,9 @@ func (m model) resumeText(args string) string {
 			Hints: []string{"use /resume " + args + " to hydrate this TUI session"},
 		})
 	}
-	sessions, err := m.sessionStore.List()
+	// Only standalone conversations — not child/spec sub-runs, which an agent
+	// spawns by the dozen and would otherwise flood the picker (the "… N more").
+	sessions, err := m.sessionStore.ListResumable()
 	if err != nil {
 		return renderCommandOutput(commandOutput{
 			Title:  "Sessions",

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -166,7 +166,9 @@ func (m model) sessionPrompt(prompt string) string {
 
 func (m model) resolveResumeSession(args string) (*sessions.Metadata, error) {
 	if strings.EqualFold(args, "latest") {
-		latest, err := m.sessionStore.Latest()
+		// Latest *resumable* conversation, so "latest" never lands on a child or
+		// spec sub-run. An explicit `/resume <id>` below still resolves any session.
+		latest, err := m.sessionStore.LatestResumable()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -682,6 +682,30 @@ func TestResumeCommandIsBlockedWhileRunPending(t *testing.T) {
 	}
 }
 
+func TestResumePickerExcludesSubRunSessions(t *testing.T) {
+	store := testSessionStore(t)
+	if _, err := store.Create(sessions.CreateInput{Title: "Real Conversation"}); err != nil {
+		t.Fatalf("Create conversation: %v", err)
+	}
+	// A specialist/sub-agent run and a spec draft both create sessions; neither is
+	// a standalone conversation and must not flood the /resume picker.
+	if _, err := store.Create(sessions.CreateInput{Title: "Specialist Run", SessionKind: sessions.SessionKindChild}); err != nil {
+		t.Fatalf("Create child: %v", err)
+	}
+	if _, err := store.Create(sessions.CreateInput{Title: "Spec Draft", SessionKind: sessions.SessionKindSpecDraft}); err != nil {
+		t.Fatalf("Create spec draft: %v", err)
+	}
+
+	out := newModel(context.Background(), Options{SessionStore: store}).resumeText("")
+
+	if !strings.Contains(out, "Real Conversation") {
+		t.Fatalf("resume picker should list the real conversation:\n%s", out)
+	}
+	if strings.Contains(out, "Specialist Run") || strings.Contains(out, "Spec Draft") {
+		t.Fatalf("resume picker must exclude child/spec sub-runs:\n%s", out)
+	}
+}
+
 func TestResumeLatestHydratesNewestSession(t *testing.T) {
 	store := testSessionStore(t)
 	older, err := store.Create(sessions.CreateInput{Title: "Older"})


### PR DESCRIPTION
## Problem

`/resume` showed a session list ending in "… 779 more · /resume <id>" — far more sessions than real conversations. Root cause: the picker called `sessions.Store.List()` **unfiltered**, so it listed every session directory, including the **child** (specialist/sub-agent) and **spec-draft/spec-impl** sessions an agent spawns by the dozen. The TUI itself creates exactly one session per conversation (`ensureActiveSession` guards on the active id and appends events), so the flood was entirely the unfiltered listing.

## Fix

- Add `sessions.IsResumableKind`, `Store.ListResumable()`, and `Store.LatestResumable()` — they keep only standalone conversations (regular + user forks) and drop `child` / `spec-draft` / `spec-impl` sub-runs.
- `/resume` picker uses `ListResumable()`; the "N more" count is now honest.
- `/resume latest` uses `LatestResumable()` so it never lands on a newer child/spec sub-run.
- `/resume <id>` is unchanged — an explicit id still resolves any session.

## Tests

- `TestListAndLatestResumableExcludeSubRuns` — store-level: only regular+fork listed; latest skips a newer child.
- `TestResumePickerExcludesSubRunSessions` — TUI picker lists the real conversation, excludes child/spec.

`go build`, full `go test ./...`, `go vet`, `gofmt` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the resume session picker to display only standalone conversations and exclude sub-runs (child sessions and spec drafts), providing a cleaner selection experience.
  * Fixed the latest resume feature to correctly identify and select the most recent resumable conversation instead of sub-runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->