### PR TITLE
test: isolate session store so `go test` stops writing to $HOME

### DIFF
--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -464,6 +464,7 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 }
 
 func TestRunExecStreamJSONRunStartUsesResolvedAPIModel(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -618,6 +619,7 @@ func TestRunExecStreamJSONProviderErrorEmitsErrorAndRunEnd(t *testing.T) {
 }
 
 func TestRunExecReadsStreamJSONPromptFromStdin(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	cwd := t.TempDir()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -62,6 +62,7 @@ func (provider *fakeProvider) StreamCompletion(
 }
 
 func TestPromptSubmitInjectsLiveSessionModelContext(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
 		{Type: zeroruntime.StreamEventText, Content: "I am using the active session model."},
 		{Type: zeroruntime.StreamEventDone},


### PR DESCRIPTION
## Problem

Three tests run a real exec session but only isolate the working directory (`t.TempDir()` + a `getwd` override), **not** the session store. With no `XDG_DATA_HOME` set, the store falls back to `sessions.DefaultRoot()` off the real `$HOME`, so every `go test` run persists a session into `~/.local/share/zero/sessions`:

- `internal/cli` — `TestRunExecStreamJSONRunStartUsesResolvedAPIModel`, `TestRunExecReadsStreamJSONPromptFromStdin`
- `internal/tui` — `TestPromptSubmitInjectsLiveSessionModelContext`

This silently pollutes the developer's (and CI's) home dir on every run — locally this had accumulated **1204** stray session directories, all with a `cwd` pointing at a `go test` tempdir (`/var/folders/…/T/Test…/001`).

## Fix

Add `t.Setenv("XDG_DATA_HOME", t.TempDir())` to the three tests — the same isolation convention already used by sibling tests in `exec_test.go` / `exec_scope_test.go`. `DefaultRoot` honors `XDG_DATA_HOME`, so each run now writes to a throwaway temp dir that the test framework cleans up.

## Verification

- All three tests pass.
- Full `internal/cli` + `internal/tui` suites pass.
- Before/after session-count check on a real store confirms a complete suite run now leaks **0** sessions (was leaking on every run).
- `gofmt` clean.

Test-only change; no production behavior is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test environment configuration to ensure proper isolation during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->