### PR TITLE
Edit safety: file read/write tracking, external-modification detection, post-apply hooks

### DIFF
--- a/internal/agent/hook_wiring_test.go
+++ b/internal/agent/hook_wiring_test.go
@@ -10,18 +10,33 @@ import (
 )
 
 func TestAppendHookFeedbackFormatsOutput(t *testing.T) {
-	// Blank feedback leaves the original output untouched.
-	if got := appendHookFeedback("tool output", "   "); got != "tool output" {
-		t.Fatalf("blank feedback should not change output, got %q", got)
+	// Blank feedback leaves the original output untouched and reports no redaction.
+	if got, redacted := appendHookFeedback("tool output", "   "); got != "tool output" || redacted {
+		t.Fatalf("blank feedback should not change output or redact, got %q redacted=%v", got, redacted)
 	}
 	// Feedback is appended under a header alongside the existing output.
-	got := appendHookFeedback("tool output", "gofmt reformatted main.go")
+	got, redacted := appendHookFeedback("tool output", "gofmt reformatted main.go")
 	if !strings.Contains(got, "tool output") || !strings.Contains(got, "Hook output:") || !strings.Contains(got, "gofmt reformatted main.go") {
 		t.Fatalf("expected combined tool + hook output, got %q", got)
 	}
+	if redacted {
+		t.Fatal("clean feedback should not be reported as redacted")
+	}
 	// With no original output the hook feedback stands alone under the header.
-	if got := appendHookFeedback("", "validation ran"); !strings.HasPrefix(got, "Hook output:") || !strings.Contains(got, "validation ran") {
+	if got, _ := appendHookFeedback("", "validation ran"); !strings.HasPrefix(got, "Hook output:") || !strings.Contains(got, "validation ran") {
 		t.Fatalf("expected standalone hook output, got %q", got)
+	}
+}
+
+func TestAppendHookFeedbackScrubsSecretsAndFlagsRedaction(t *testing.T) {
+	// A hook that echoes a secret must be scrubbed before it reaches the model,
+	// and the redaction must be reported so the caller can flag ToolResult.Redacted.
+	got, redacted := appendHookFeedback("tool output", "leaked token ghp_abcdefghijklmnopqrstuvwxyz0123456789")
+	if !redacted {
+		t.Fatal("expected redaction to be reported for secret-bearing feedback")
+	}
+	if strings.Contains(got, "ghp_abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Fatalf("secret leaked into hook feedback: %q", got)
 	}
 }
 
@@ -43,6 +58,22 @@ func TestBlockedByHookResultCarriesReasonAndDenial(t *testing.T) {
 		if !strings.Contains(out.Output, want) {
 			t.Fatalf("output %q missing %q", out.Output, want)
 		}
+	}
+	if out.Redacted {
+		t.Fatal("a clean hook reason must not flag Redacted")
+	}
+}
+
+func TestBlockedByHookResultScrubsSecretReason(t *testing.T) {
+	out := blockedByHookResult(
+		ToolCall{ID: "c3", Name: "bash"},
+		hooks.DispatchOutcome{Blocked: true, BlockedBy: "secret-scan", Reason: "denied: found ghp_abcdefghijklmnopqrstuvwxyz0123456789 in args"},
+	)
+	if !out.Redacted {
+		t.Fatal("a scrubbed hook reason must set ToolResult.Redacted")
+	}
+	if strings.Contains(out.Output, "ghp_abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Fatalf("secret leaked into blocked-hook output: %q", out.Output)
 	}
 }
 

--- a/internal/agent/hook_wiring_test.go
+++ b/internal/agent/hook_wiring_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestAppendHookFeedbackFormatsOutput(t *testing.T) {
+	// Blank feedback leaves the original output untouched.
+	if got := appendHookFeedback("tool output", "   "); got != "tool output" {
+		t.Fatalf("blank feedback should not change output, got %q", got)
+	}
+	// Feedback is appended under a header alongside the existing output.
+	got := appendHookFeedback("tool output", "gofmt reformatted main.go")
+	if !strings.Contains(got, "tool output") || !strings.Contains(got, "Hook output:") || !strings.Contains(got, "gofmt reformatted main.go") {
+		t.Fatalf("expected combined tool + hook output, got %q", got)
+	}
+	// With no original output the hook feedback stands alone under the header.
+	if got := appendHookFeedback("", "validation ran"); !strings.HasPrefix(got, "Hook output:") || !strings.Contains(got, "validation ran") {
+		t.Fatalf("expected standalone hook output, got %q", got)
+	}
+}
+
+func TestBlockedByHookResultCarriesReasonAndDenial(t *testing.T) {
+	out := blockedByHookResult(
+		ToolCall{ID: "c1", Name: "write_file"},
+		hooks.DispatchOutcome{Blocked: true, BlockedBy: "policy", Reason: "writes under /etc are denied"},
+	)
+	if out.Status != tools.StatusError {
+		t.Fatalf("status = %v, want error", out.Status)
+	}
+	if out.DenialReason != DenialHookBlocked {
+		t.Fatalf("denial = %q, want %q", out.DenialReason, DenialHookBlocked)
+	}
+	if out.ToolCallID != "c1" || out.Name != "write_file" {
+		t.Fatalf("call identity not propagated: %#v", out)
+	}
+	for _, want := range []string{"write_file", "policy", "writes under /etc are denied"} {
+		if !strings.Contains(out.Output, want) {
+			t.Fatalf("output %q missing %q", out.Output, want)
+		}
+	}
+}
+
+func TestBlockedByHookResultFallsBackWhenReasonEmpty(t *testing.T) {
+	out := blockedByHookResult(ToolCall{ID: "c2", Name: "bash"}, hooks.DispatchOutcome{Blocked: true, BlockedBy: "x"})
+	if !strings.Contains(out.Output, "blocked by a beforeTool hook") {
+		t.Fatalf("expected a default reason, got %q", out.Output)
+	}
+}
+
+func TestDispatchHelpersAreNoopWithoutDispatcher(t *testing.T) {
+	options := Options{} // Hooks is nil
+	if _, blocked := dispatchBeforeTool(context.Background(), options, ToolCall{Name: "bash"}, nil); blocked {
+		t.Fatal("a nil dispatcher must never block a tool")
+	}
+	if feedback := dispatchAfterTool(context.Background(), options, ToolCall{Name: "bash"}, nil, tools.Result{}); feedback != "" {
+		t.Fatalf("a nil dispatcher must yield no feedback, got %q", feedback)
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -589,7 +589,11 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	// formatter or vet result) is surfaced back to the model on the result.
 	if toolFound {
 		if feedback := dispatchAfterTool(ctx, options, call, args, result); feedback != "" {
-			result.Output = appendHookFeedback(result.Output, feedback)
+			var didRedact bool
+			result.Output, didRedact = appendHookFeedback(result.Output, feedback)
+			if didRedact {
+				result.Redacted = true
+			}
 		}
 	}
 	// Secret scrubbing happens at the registry boundary (the single point both
@@ -664,8 +668,11 @@ func dispatchAfterTool(ctx context.Context, options Options, call ToolCall, args
 func blockedByHookResult(call ToolCall, outcome hooks.DispatchOutcome) ToolResult {
 	// The hook reason (its stdout/stderr) is model-visible here, an intercepted
 	// path that bypasses the registry's output redaction boundary — so scrub it
-	// like every other string that crosses into the transcript.
-	reason := strings.TrimSpace(redaction.RedactString(outcome.Reason, redaction.Options{}))
+	// like every other string that crosses into the transcript, and flag Redacted
+	// when scrubbing changed it (matching the registry's contract).
+	scrubbed := redaction.RedactString(outcome.Reason, redaction.Options{})
+	redacted := scrubbed != outcome.Reason
+	reason := strings.TrimSpace(scrubbed)
 	if reason == "" {
 		reason = "blocked by a beforeTool hook"
 	}
@@ -675,21 +682,25 @@ func blockedByHookResult(call ToolCall, outcome hooks.DispatchOutcome) ToolResul
 		Name:         call.Name,
 		Status:       tools.StatusError,
 		Output:       message,
+		Redacted:     redacted,
 		DenialReason: DenialHookBlocked,
 	}
 }
 
 // appendHookFeedback appends afterTool hook output to a tool result's output,
-// scrubbed for secrets like every other string crossing the tool boundary.
-func appendHookFeedback(output string, feedback string) string {
-	feedback = redaction.RedactString(feedback, redaction.Options{})
-	if strings.TrimSpace(feedback) == "" {
-		return output
+// scrubbed for secrets like every other string crossing the tool boundary. The
+// returned bool reports whether scrubbing changed the feedback, so the caller can
+// set ToolResult.Redacted to match the registry's redaction contract.
+func appendHookFeedback(output string, feedback string) (string, bool) {
+	scrubbed := redaction.RedactString(feedback, redaction.Options{})
+	redacted := scrubbed != feedback
+	if strings.TrimSpace(scrubbed) == "" {
+		return output, redacted
 	}
 	if strings.TrimSpace(output) == "" {
-		return "Hook output:\n" + feedback
+		return "Hook output:\n" + scrubbed, redacted
 	}
-	return output + "\n\nHook output:\n" + feedback
+	return output + "\n\nHook output:\n" + scrubbed, redacted
 }
 
 // isRetriableToolError reports whether a failed tool result is one the model can

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -548,6 +550,13 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		}
 	}
 
+	// beforeTool hooks may veto the call before it runs (a non-zero exit blocks).
+	if toolFound {
+		if outcome, blocked := dispatchBeforeTool(ctx, options, call, args); blocked {
+			return blockedByHookResult(call, outcome), nil
+		}
+	}
+
 	result := registry.RunWithOptions(ctx, call.Name, args, tools.RunOptions{
 		PermissionGranted: permissionGranted,
 		PermissionMode:    string(permissionMode),
@@ -559,6 +568,9 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		ReasoningEffort:   options.ReasoningEffort,
 		Depth:             options.Depth,
 		Cwd:               options.Cwd,
+		// Per-session file version tracker so write_file/edit_file refuse to clobber
+		// a file that changed on disk outside Zero since it was last read.
+		FileTracker: options.FileTracker,
 		// Forward the run's operator tool filters so a filter-aware tool
 		// (tool_search) never discloses or loads an operator-hidden deferred tool.
 		EnabledTools:  options.EnabledTools,
@@ -571,6 +583,13 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		if event, ok := buildPermissionEvent(call, tool, args, permissionGranted, permissionMode, options, sandboxDecision); ok {
 			event.DecisionReason = decisionReason
 			options.OnPermission(event)
+		}
+	}
+	// afterTool hooks run once the tool has executed; their output (e.g. a
+	// formatter or vet result) is surfaced back to the model on the result.
+	if toolFound {
+		if feedback := dispatchAfterTool(ctx, options, call, args, result); feedback != "" {
+			result.Output = appendHookFeedback(result.Output, feedback)
 		}
 	}
 	// Secret scrubbing happens at the registry boundary (the single point both
@@ -592,6 +611,82 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		// ordinary tool result.
 		RequestedModel: result.Meta["escalate_to_model"],
 	}, nil
+}
+
+// dispatchBeforeTool runs configured beforeTool hooks for a tool call. A hook
+// that exits non-zero vetoes the call: the returned bool is true and the tool
+// must not run. A nil dispatcher (no hooks wired) is a no-op.
+func dispatchBeforeTool(ctx context.Context, options Options, call ToolCall, args map[string]any) (hooks.DispatchOutcome, bool) {
+	if options.Hooks == nil {
+		return hooks.DispatchOutcome{}, false
+	}
+	outcome := options.Hooks.Dispatch(ctx, hooks.DispatchInput{
+		Event:      hooks.EventBeforeTool,
+		ToolName:   call.Name,
+		ToolCallID: call.ID,
+		Payload: map[string]any{
+			"event":      string(hooks.EventBeforeTool),
+			"tool":       call.Name,
+			"toolCallId": call.ID,
+			"sessionId":  options.SessionID,
+			"cwd":        options.Cwd,
+			"args":       args,
+		},
+	})
+	return outcome, outcome.Blocked
+}
+
+// dispatchAfterTool runs configured afterTool hooks once a tool has executed and
+// returns any advisory output (e.g. a formatter or vet result) to surface back
+// to the model. afterTool hooks never block. A nil dispatcher is a no-op.
+func dispatchAfterTool(ctx context.Context, options Options, call ToolCall, args map[string]any, result tools.Result) string {
+	if options.Hooks == nil {
+		return ""
+	}
+	outcome := options.Hooks.Dispatch(ctx, hooks.DispatchInput{
+		Event:      hooks.EventAfterTool,
+		ToolName:   call.Name,
+		ToolCallID: call.ID,
+		Payload: map[string]any{
+			"event":        string(hooks.EventAfterTool),
+			"tool":         call.Name,
+			"toolCallId":   call.ID,
+			"sessionId":    options.SessionID,
+			"cwd":          options.Cwd,
+			"status":       string(result.Status),
+			"changedFiles": result.ChangedFiles,
+		},
+	})
+	return strings.TrimSpace(strings.Join(outcome.Messages, "\n"))
+}
+
+// blockedByHookResult is the tool result for a call vetoed by a beforeTool hook.
+func blockedByHookResult(call ToolCall, outcome hooks.DispatchOutcome) ToolResult {
+	reason := strings.TrimSpace(outcome.Reason)
+	if reason == "" {
+		reason = "blocked by a beforeTool hook"
+	}
+	message := fmt.Sprintf("Error: %q was blocked by hook %q: %s", call.Name, outcome.BlockedBy, reason)
+	return ToolResult{
+		ToolCallID:   call.ID,
+		Name:         call.Name,
+		Status:       tools.StatusError,
+		Output:       message,
+		DenialReason: DenialHookBlocked,
+	}
+}
+
+// appendHookFeedback appends afterTool hook output to a tool result's output,
+// scrubbed for secrets like every other string crossing the tool boundary.
+func appendHookFeedback(output string, feedback string) string {
+	feedback = redaction.RedactString(feedback, redaction.Options{})
+	if strings.TrimSpace(feedback) == "" {
+		return output
+	}
+	if strings.TrimSpace(output) == "" {
+		return "Hook output:\n" + feedback
+	}
+	return output + "\n\nHook output:\n" + feedback
 }
 
 // isRetriableToolError reports whether a failed tool result is one the model can

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -662,7 +662,10 @@ func dispatchAfterTool(ctx context.Context, options Options, call ToolCall, args
 
 // blockedByHookResult is the tool result for a call vetoed by a beforeTool hook.
 func blockedByHookResult(call ToolCall, outcome hooks.DispatchOutcome) ToolResult {
-	reason := strings.TrimSpace(outcome.Reason)
+	// The hook reason (its stdout/stderr) is model-visible here, an intercepted
+	// path that bypasses the registry's output redaction boundary — so scrub it
+	// like every other string that crosses into the transcript.
+	reason := strings.TrimSpace(redaction.RedactString(outcome.Reason, redaction.Options{}))
 	if reason == "" {
 		reason = "blocked by a beforeTool hook"
 	}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 
+	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -73,6 +74,7 @@ const (
 	DenialFiltered         DenialCategory = "filtered"          // tool not enabled for this run
 	DenialPermissionDenied DenialCategory = "permission_denied" // approval declined
 	DenialSandboxViolation DenialCategory = "sandbox_violation" // blocked by the sandbox
+	DenialHookBlocked      DenialCategory = "hook_blocked"      // vetoed by a beforeTool hook
 )
 
 type PermissionRequest struct {
@@ -169,15 +171,23 @@ type Options struct {
 	PermissionMode         PermissionMode
 	Autonomy               string
 	Sandbox                *sandbox.Engine
-	EnabledTools           []string
-	DisabledTools          []string
-	OnText                 func(string)
-	OnToolCall             func(ToolCall)
-	OnPermissionRequest    func(context.Context, PermissionRequest) (PermissionDecision, error)
-	OnPermission           func(PermissionEvent)
-	OnAskUser              func(context.Context, AskUserRequest) (AskUserResponse, error)
-	OnToolResult           func(ToolResult)
-	OnUsage                func(Usage)
+	// FileTracker records per-session file read/write versions so the write tools
+	// can detect a file changed on disk outside Zero since it was last read. nil
+	// disables the check. Created once per session and threaded into every tool run.
+	FileTracker *tools.FileTracker
+	// Hooks, when set, runs configured beforeTool (blocking) and afterTool
+	// (advisory) commands around each tool call. nil disables hooks entirely; a
+	// dispatcher built from an empty config is also a safe no-op.
+	Hooks               *hooks.Dispatcher
+	EnabledTools        []string
+	DisabledTools       []string
+	OnText              func(string)
+	OnToolCall          func(ToolCall)
+	OnPermissionRequest func(context.Context, PermissionRequest) (PermissionDecision, error)
+	OnPermission        func(PermissionEvent)
+	OnAskUser           func(context.Context, AskUserRequest) (AskUserResponse, error)
+	OnToolResult        func(ToolResult)
+	OnUsage             func(Usage)
 	// OnContext, when set, is called once per turn with the per-category context
 	// budget of the request about to be sent, so a surface (TUI/CLI) can show
 	// context utilization. Opt-in like the other callbacks; nil is a no-op.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -447,6 +447,8 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 			PermissionMode: permissionMode,
 			Autonomy:       string(sandbox.AutonomyLow),
 			Sandbox:        sandboxEngine,
+			FileTracker:    tools.NewFileTracker(),
+			Hooks:          newHookDispatcher(workspaceRoot),
 			DeferThreshold: resolved.Tools.DeferThreshold,
 		},
 		PermissionMode: permissionMode,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -461,6 +461,8 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		PermissionMode:   permissionMode,
 		Autonomy:         options.autonomy,
 		Sandbox:          sandboxEngine,
+		FileTracker:      tools.NewFileTracker(),
+		Hooks:            newHookDispatcher(workspaceRoot),
 		EnabledTools:     options.enabledTools,
 		DisabledTools:    options.disabledTools,
 		OnText:           writer.text,

--- a/internal/cli/exec_spec.go
+++ b/internal/cli/exec_spec.go
@@ -108,6 +108,8 @@ func runExecSpecDraft(run execSpecDraftRun) int {
 		PermissionMode:  agent.PermissionModeSpecDraft,
 		Autonomy:        "low",
 		Sandbox:         run.sandboxEngine,
+		FileTracker:     tools.NewFileTracker(),
+		Hooks:           newHookDispatcher(run.workspaceRoot),
 		EnabledTools:    run.options.enabledTools,
 		DisabledTools:   run.options.disabledTools,
 		OnText:          writer.text,

--- a/internal/cli/hook_dispatch.go
+++ b/internal/cli/hook_dispatch.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"github.com/Gitlawb/zero/internal/hooks"
+)
+
+// newHookDispatcher builds the per-session hooks dispatcher for a workspace,
+// merging user + project hooks.json and wiring the audit store. It fails OPEN:
+// any load or setup error yields a nil dispatcher, which Dispatch treats as a
+// no-op, so a malformed hooks config can never wedge tool execution. With no
+// hooks configured the dispatcher selects nothing and runs no commands, so the
+// hot path stays free of overhead until a user opts in via hooks.json.
+func newHookDispatcher(workspaceRoot string) *hooks.Dispatcher {
+	loaded, err := hooks.LoadConfig(hooks.LoadOptions{Cwd: workspaceRoot})
+	if err != nil {
+		return nil
+	}
+	var audit *hooks.AuditStore
+	if store, err := hooks.NewAuditStore(hooks.AuditStoreOptions{}); err == nil {
+		audit = store
+	}
+	return hooks.NewDispatcher(hooks.DispatcherOptions{
+		Config: loaded.Config,
+		Audit:  audit,
+		Cwd:    workspaceRoot,
+	})
+}

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -31,6 +31,10 @@ type DispatchOutcome struct {
 	Blocked   bool   // a blocking-event hook exited non-zero, vetoing the action
 	BlockedBy string // ID of the hook that blocked (empty unless Blocked)
 	Reason    string // the blocking hook's stderr/stdout, for surfacing to the model
+	// Messages collects the output (stdout, else stderr) of each hook that
+	// produced any, in run order. afterTool validators use this to feed results
+	// (e.g. a formatter diff or vet warning) back to the model on the tool result.
+	Messages []string
 }
 
 type commandResult struct {
@@ -132,6 +136,10 @@ func (dispatcher *Dispatcher) Dispatch(ctx context.Context, input DispatchInput)
 		status, blocked := classifyResult(input.Event, result)
 		dispatcher.recordCompleted(hook, input, status, result, durationMs)
 
+		if message := hookMessage(result); message != "" {
+			outcome.Messages = append(outcome.Messages, message)
+		}
+
 		if blocked {
 			outcome.Blocked = true
 			outcome.BlockedBy = hook.ID
@@ -186,6 +194,15 @@ func classifyResult(event Event, result commandResult) (AuditStatus, bool) {
 		return AuditError, false
 	}
 	return AuditCompleted, false
+}
+
+// hookMessage returns the output worth surfacing from a hook run: stdout when
+// present, else stderr. Empty when the hook produced no output.
+func hookMessage(result commandResult) string {
+	if trimmed := strings.TrimSpace(result.Stdout); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(result.Stderr)
 }
 
 func blockReason(result commandResult) string {

--- a/internal/hooks/dispatch_test.go
+++ b/internal/hooks/dispatch_test.go
@@ -103,6 +103,38 @@ func TestDispatchNonBlockingEventDoesNotVetoOnNonZero(t *testing.T) {
 	}
 }
 
+func TestDispatchCollectsHookOutputMessages(t *testing.T) {
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		switch command {
+		case "fmt":
+			return commandResult{ExitCode: 0, Stdout: "  reformatted main.go  "}
+		case "vet":
+			return commandResult{ExitCode: 1, Stderr: "vet: suspicious construct"} // stdout empty → stderr surfaces
+		case "quiet":
+			return commandResult{ExitCode: 0} // no output → omitted
+		}
+		return commandResult{}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "fmt", Event: EventAfterTool, Command: "fmt", Enabled: true},
+		{ID: "vet", Event: EventAfterTool, Command: "vet", Enabled: true},
+		{ID: "quiet", Event: EventAfterTool, Command: "quiet", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "write_file"})
+	if outcome.Blocked {
+		t.Fatalf("afterTool must not block: %#v", outcome)
+	}
+	if outcome.Ran != 3 {
+		t.Fatalf("Ran = %d, want 3", outcome.Ran)
+	}
+	want := []string{"reformatted main.go", "vet: suspicious construct"}
+	if strings.Join(outcome.Messages, "|") != strings.Join(want, "|") {
+		t.Fatalf("Messages = %#v, want trimmed stdout then stderr-fallback, quiet omitted: %#v", outcome.Messages, want)
+	}
+}
+
 func TestDispatchSkipsWhenDisabledOrUnmatched(t *testing.T) {
 	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
 		t.Fatal("runner must not be called")

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -42,6 +42,10 @@ func NewScopedApplyPatchTool(workspaceRoot string, scope PathScope) Tool {
 }
 
 func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.RunWithOptions(ctx, args, RunOptions{})
+}
+
+func (tool applyPatchTool) RunWithOptions(ctx context.Context, args map[string]any, options RunOptions) Result {
 	patch, err := aliasedStringArg(args, []string{"patch", "diff"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for apply_patch: " + err.Error())
@@ -97,6 +101,15 @@ func (tool applyPatchTool) Run(ctx context.Context, args map[string]any) Result 
 	result := okResult(summary)
 	result.ChangedFiles = changedFilesFromPatch(relativeRoot, patch)
 	result.Display = Display{Summary: summary, Kind: "diff"}
+	// git apply already rejects a patch whose context drifted, so it has its own
+	// staleness guard. Drop any tracked baseline for the files it rewrote so a
+	// subsequent edit_file/write_file re-reads instead of false-flagging the
+	// patch's own change as an external modification.
+	for _, changed := range result.ChangedFiles {
+		if absolute, _, rerr := resolveScopedPath(tool.workspaceRoot, tool.scope, changed); rerr == nil {
+			options.FileTracker.Forget(absolute)
+		}
+	}
 	return result
 }
 

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -40,7 +40,11 @@ func NewScopedEditFileTool(workspaceRoot string, scope PathScope) Tool {
 	}
 }
 
-func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
+func (tool editFileTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.RunWithOptions(ctx, args, RunOptions{})
+}
+
+func (tool editFileTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
 	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for edit_file: " + err.Error())
@@ -65,6 +69,12 @@ func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
 	contentBytes, err := os.ReadFile(absolutePath)
 	if err != nil {
 		return errorResult("Error reading " + relativePath + ": " + err.Error())
+	}
+	// Refuse to edit a file that changed on disk outside Zero since it was last
+	// read: the model's old_string was formed against a stale view, so applying it
+	// now could silently corrupt the newer content.
+	if cerr := options.FileTracker.CheckConflict(absolutePath, contentBytes); cerr != nil {
+		return errorResult(fileConflictMessage(relativePath))
 	}
 	content := string(contentBytes)
 	occurrences := strings.Count(content, oldString)
@@ -91,6 +101,10 @@ func (tool editFileTool) Run(_ context.Context, args map[string]any) Result {
 	if err := os.WriteFile(absolutePath, []byte(updated), 0o644); err != nil {
 		return errorResult("Error writing " + relativePath + ": " + err.Error())
 	}
+	// Re-baseline to the content we just wrote so subsequent edits in this session
+	// compare against the current on-disk state, not the pre-edit version.
+	newInfo, _ := os.Stat(absolutePath)
+	options.FileTracker.Record(absolutePath, []byte(updated), newInfo)
 
 	suffix := ""
 	if replacedCount != 1 {

--- a/internal/tools/file_safety_test.go
+++ b/internal/tools/file_safety_test.go
@@ -1,0 +1,147 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// safetyRegistry wires the read/write tools the conflict-detection feature spans,
+// so tests exercise the real RunWithOptions dispatch (including optionsAwareTool
+// routing) rather than calling tool methods directly.
+func safetyRegistry(t *testing.T, dir string) *Registry {
+	t.Helper()
+	registry := NewRegistry()
+	for _, tool := range []Tool{NewReadFileTool(dir), NewEditFileTool(dir), NewWriteFileTool(dir)} {
+		registry.Register(tool)
+	}
+	return registry
+}
+
+func grantedOpts(tracker *FileTracker) RunOptions {
+	return RunOptions{PermissionGranted: true, FileTracker: tracker}
+}
+
+func TestEditFileRefusesAfterFileChangedOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := safetyRegistry(t, dir)
+	tracker := NewFileTracker()
+
+	// Model reads the file → baseline recorded.
+	if res := registry.RunWithOptions(context.Background(), "read_file", map[string]any{"path": "f.txt"}, grantedOpts(tracker)); res.Status != StatusOK {
+		t.Fatalf("read_file failed: %s", res.Output)
+	}
+	// Something outside Zero rewrites the file.
+	if err := os.WriteFile(path, []byte("alpha changed externally\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The edit (anchored on the stale view) must be refused, not applied.
+	res := registry.RunWithOptions(context.Background(), "edit_file", map[string]any{
+		"path": "f.txt", "old_string": "alpha", "new_string": "beta",
+	}, grantedOpts(tracker))
+	if res.Status != StatusError || !strings.Contains(res.Output, "changed on disk") {
+		t.Fatalf("expected an on-disk-change refusal, got status=%s output=%q", res.Status, res.Output)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "alpha changed externally\n" {
+		t.Fatalf("file must be untouched after a refused edit, got %q", got)
+	}
+}
+
+func TestEditFileSucceedsWhenUnchangedAndRebaselines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := safetyRegistry(t, dir)
+	tracker := NewFileTracker()
+
+	registry.RunWithOptions(context.Background(), "read_file", map[string]any{"path": "f.txt"}, grantedOpts(tracker))
+	if res := registry.RunWithOptions(context.Background(), "edit_file", map[string]any{
+		"path": "f.txt", "old_string": "alpha", "new_string": "beta",
+	}, grantedOpts(tracker)); res.Status != StatusOK {
+		t.Fatalf("edit on unchanged file should succeed, got %q", res.Output)
+	}
+	// A second edit must not false-conflict: the write re-baselined the tracker.
+	if res := registry.RunWithOptions(context.Background(), "edit_file", map[string]any{
+		"path": "f.txt", "old_string": "beta", "new_string": "gamma",
+	}, grantedOpts(tracker)); res.Status != StatusOK {
+		t.Fatalf("second consecutive edit should succeed (re-baselined), got %q", res.Output)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "gamma\n" {
+		t.Fatalf("file = %q, want gamma", got)
+	}
+}
+
+func TestWriteFileOverwriteRefusedWhenChangedOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := safetyRegistry(t, dir)
+	tracker := NewFileTracker()
+
+	registry.RunWithOptions(context.Background(), "read_file", map[string]any{"path": "f.txt"}, grantedOpts(tracker))
+	if err := os.WriteFile(path, []byte("v2 external\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
+		"path": "f.txt", "content": "v3 stale\n", "overwrite": true,
+	}, grantedOpts(tracker))
+	if res.Status != StatusError || !strings.Contains(res.Output, "changed on disk") {
+		t.Fatalf("expected overwrite refusal, got status=%s output=%q", res.Status, res.Output)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "v2 external\n" {
+		t.Fatalf("file must be untouched after a refused overwrite, got %q", got)
+	}
+}
+
+func TestWriteFileOverwriteAllowedForUntrackedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := safetyRegistry(t, dir)
+	tracker := NewFileTracker()
+
+	// Never read through a tool → no baseline → overwrite is the model's call.
+	res := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
+		"path": "f.txt", "content": "v3\n", "overwrite": true,
+	}, grantedOpts(tracker))
+	if res.Status != StatusOK {
+		t.Fatalf("untracked overwrite should be allowed, got %q", res.Output)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "v3\n" {
+		t.Fatalf("file = %q, want v3", got)
+	}
+}
+
+func TestWriteAndEditUnaffectedWithoutTracker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("alpha\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	registry := safetyRegistry(t, dir)
+
+	// nil tracker (RunOptions without FileTracker) preserves the old behavior:
+	// read, external change, then edit all proceed with no conflict gate.
+	opts := RunOptions{PermissionGranted: true}
+	registry.RunWithOptions(context.Background(), "read_file", map[string]any{"path": "f.txt"}, opts)
+	if err := os.WriteFile(path, []byte("alpha changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if res := registry.RunWithOptions(context.Background(), "edit_file", map[string]any{
+		"path": "f.txt", "old_string": "alpha changed", "new_string": "beta",
+	}, opts); res.Status != StatusOK {
+		t.Fatalf("without a tracker, edit should proceed, got %q", res.Output)
+	}
+}

--- a/internal/tools/file_tracker.go
+++ b/internal/tools/file_tracker.go
@@ -1,0 +1,111 @@
+package tools
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"sync"
+	"time"
+)
+
+// ErrFileChangedOnDisk is returned by CheckConflict when a file's current
+// on-disk content no longer matches what a tool last read or wrote in this
+// session — i.e. it was modified outside Zero. The write tools surface it with
+// guidance to re-read before retrying, so a stale overwrite cannot silently
+// clobber an external edit.
+var ErrFileChangedOnDisk = errors.New("the file changed on disk since you last read it")
+
+// FileVersion is what a tool last observed for a file: an authoritative content
+// hash plus cheap stat metadata kept for diagnostics.
+type FileVersion struct {
+	Hash  string
+	Size  int64
+	MTime time.Time
+}
+
+// FileTracker records, per absolute path, the version of each file a tool read
+// or wrote within a single session. A later write compares the current on-disk
+// content against this baseline to detect a modification made outside Zero.
+//
+// Construct with NewFileTracker. A nil *FileTracker is a valid no-op — every
+// method tolerates it — so a caller that has not wired the feature (tests, MCP)
+// needs no nil guards.
+type FileTracker struct {
+	mu       sync.Mutex
+	versions map[string]FileVersion
+}
+
+func NewFileTracker() *FileTracker {
+	return &FileTracker{versions: make(map[string]FileVersion)}
+}
+
+// Record stores the version of absPath given its content and optional stat info.
+func (tracker *FileTracker) Record(absPath string, content []byte, info os.FileInfo) {
+	if tracker == nil {
+		return
+	}
+	version := FileVersion{Hash: HashContent(content)}
+	if info != nil {
+		version.Size = info.Size()
+		version.MTime = info.ModTime()
+	}
+	tracker.mu.Lock()
+	tracker.versions[absPath] = version
+	tracker.mu.Unlock()
+}
+
+// Version returns the recorded version for absPath and whether one exists.
+func (tracker *FileTracker) Version(absPath string) (FileVersion, bool) {
+	if tracker == nil {
+		return FileVersion{}, false
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	version, ok := tracker.versions[absPath]
+	return version, ok
+}
+
+// Forget drops any recorded version for absPath, so the next read re-establishes
+// the baseline. Used after a tool rewrites a file by a path other than its own
+// (e.g. apply_patch) where the new content is not cheaply available to Record.
+func (tracker *FileTracker) Forget(absPath string) {
+	if tracker == nil {
+		return
+	}
+	tracker.mu.Lock()
+	delete(tracker.versions, absPath)
+	tracker.mu.Unlock()
+}
+
+// CheckConflict reports ErrFileChangedOnDisk when absPath has a recorded baseline
+// and currentContent (the bytes the caller just read from disk) no longer matches
+// it. An untracked path returns nil: with no baseline there is nothing to
+// conflict against, so a first-touch write is always allowed.
+func (tracker *FileTracker) CheckConflict(absPath string, currentContent []byte) error {
+	if tracker == nil {
+		return nil
+	}
+	version, ok := tracker.Version(absPath)
+	if !ok {
+		return nil
+	}
+	if HashContent(currentContent) != version.Hash {
+		return ErrFileChangedOnDisk
+	}
+	return nil
+}
+
+// HashContent returns the hex-encoded SHA-256 of content. Exported so the write
+// tools and tests share one definition of a file's identity.
+func HashContent(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// fileConflictMessage is the actionable error a write tool returns when a target
+// changed on disk since it was last read, telling the model how to recover.
+func fileConflictMessage(relativePath string) string {
+	return "Error writing " + relativePath + ": " + ErrFileChangedOnDisk.Error() +
+		" (it may have been edited outside Zero). Re-read it with read_file, then re-apply your change so you do not overwrite the newer content."
+}

--- a/internal/tools/file_tracker_test.go
+++ b/internal/tools/file_tracker_test.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileTrackerRecordsAndReadsBackVersion(t *testing.T) {
+	tracker := NewFileTracker()
+	path := filepath.Join(t.TempDir(), "a.txt")
+	content := []byte("hello world")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tracker.Record(path, content, info)
+	version, ok := tracker.Version(path)
+	if !ok {
+		t.Fatal("expected a recorded version")
+	}
+	if version.Hash != HashContent(content) {
+		t.Fatalf("hash = %q, want %q", version.Hash, HashContent(content))
+	}
+	if version.Size != int64(len(content)) {
+		t.Fatalf("size = %d, want %d", version.Size, len(content))
+	}
+	if version.MTime.IsZero() {
+		t.Fatal("expected mtime to be recorded from stat info")
+	}
+}
+
+func TestCheckConflictAllowsUntrackedPath(t *testing.T) {
+	tracker := NewFileTracker()
+	// No Record call: a first-touch write has no baseline to conflict against.
+	if err := tracker.CheckConflict("/nowhere/x.txt", []byte("anything")); err != nil {
+		t.Fatalf("untracked path should not conflict, got %v", err)
+	}
+}
+
+func TestCheckConflictAllowsMatchingContent(t *testing.T) {
+	tracker := NewFileTracker()
+	content := []byte("stable content")
+	tracker.Record("/repo/x.txt", content, nil)
+	if err := tracker.CheckConflict("/repo/x.txt", content); err != nil {
+		t.Fatalf("unchanged content should not conflict, got %v", err)
+	}
+}
+
+func TestCheckConflictBlocksDriftedContent(t *testing.T) {
+	tracker := NewFileTracker()
+	tracker.Record("/repo/x.txt", []byte("version one"), nil)
+	if err := tracker.CheckConflict("/repo/x.txt", []byte("version two — changed underneath us")); err != ErrFileChangedOnDisk {
+		t.Fatalf("drifted content should report ErrFileChangedOnDisk, got %v", err)
+	}
+}
+
+func TestForgetClearsBaselineSoNextWriteIsAllowed(t *testing.T) {
+	tracker := NewFileTracker()
+	tracker.Record("/repo/x.txt", []byte("version one"), nil)
+	tracker.Forget("/repo/x.txt")
+	if _, ok := tracker.Version("/repo/x.txt"); ok {
+		t.Fatal("Forget should drop the recorded version")
+	}
+	if err := tracker.CheckConflict("/repo/x.txt", []byte("version two")); err != nil {
+		t.Fatalf("forgotten path should behave as untracked, got %v", err)
+	}
+}
+
+func TestRecordOverwritesBaselineWithNewContent(t *testing.T) {
+	tracker := NewFileTracker()
+	tracker.Record("/repo/x.txt", []byte("old"), nil)
+	tracker.Record("/repo/x.txt", []byte("new"), nil)
+	// After re-recording, the new content is the baseline and matches.
+	if err := tracker.CheckConflict("/repo/x.txt", []byte("new")); err != nil {
+		t.Fatalf("re-recorded content should be the new baseline, got %v", err)
+	}
+	if err := tracker.CheckConflict("/repo/x.txt", []byte("old")); err != ErrFileChangedOnDisk {
+		t.Fatal("the superseded content should now conflict")
+	}
+}
+
+func TestNilFileTrackerIsANoop(t *testing.T) {
+	var tracker *FileTracker
+	tracker.Record("/repo/x.txt", []byte("x"), nil) // must not panic
+	tracker.Forget("/repo/x.txt")
+	if _, ok := tracker.Version("/repo/x.txt"); ok {
+		t.Fatal("nil tracker should report no version")
+	}
+	if err := tracker.CheckConflict("/repo/x.txt", []byte("x")); err != nil {
+		t.Fatalf("nil tracker should never conflict, got %v", err)
+	}
+}
+
+func TestHashContentIsStableAndDistinguishing(t *testing.T) {
+	if HashContent([]byte("a")) != HashContent([]byte("a")) {
+		t.Fatal("hash must be stable for identical content")
+	}
+	if HashContent([]byte("a")) == HashContent([]byte("b")) {
+		t.Fatal("hash must differ for different content")
+	}
+}

--- a/internal/tools/file_tracker_test.go
+++ b/internal/tools/file_tracker_test.go
@@ -97,10 +97,14 @@ func TestNilFileTrackerIsANoop(t *testing.T) {
 }
 
 func TestHashContentIsStableAndDistinguishing(t *testing.T) {
-	if HashContent([]byte("a")) != HashContent([]byte("a")) {
+	// Store results of separate calls before comparing so the stability check is
+	// not a same-expression comparison (staticcheck SA4000).
+	first := HashContent([]byte("a"))
+	second := HashContent([]byte("a"))
+	if first != second {
 		t.Fatal("hash must be stable for identical content")
 	}
-	if HashContent([]byte("a")) == HashContent([]byte("b")) {
+	if first == HashContent([]byte("b")) {
 		t.Fatal("hash must differ for different content")
 	}
 }

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -41,7 +41,11 @@ func NewScopedReadFileTool(workspaceRoot string, scope PathScope) Tool {
 	}
 }
 
-func (tool readFileTool) Run(_ context.Context, args map[string]any) Result {
+func (tool readFileTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.RunWithOptions(ctx, args, RunOptions{})
+}
+
+func (tool readFileTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
 	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filepath", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
@@ -68,6 +72,12 @@ func (tool readFileTool) Run(_ context.Context, args map[string]any) Result {
 	if err != nil {
 		return errorResult("Error reading file " + relativePath + ": " + err.Error())
 	}
+	// Record the whole-file baseline (the raw bytes, matching what edit_file and
+	// write_file read) so a later write can detect an out-of-Zero modification.
+	// Stat is best-effort: a missing FileInfo only drops the diagnostic size/mtime,
+	// not the authoritative content hash.
+	info, _ := os.Stat(absolutePath)
+	options.FileTracker.Record(absolutePath, content, info)
 
 	normalizedContent := strings.ReplaceAll(string(content), "\r\n", "\n")
 	normalizedContent = strings.TrimSuffix(normalizedContent, "\n")

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -23,6 +23,11 @@ type RunOptions struct {
 	ReasoningEffort   string
 	Depth             int
 	Cwd               string
+	// FileTracker, when set, records the version of each file read or written this
+	// session so write_file/edit_file can refuse to clobber a file that changed on
+	// disk outside Zero since it was last read. nil disables the feature entirely
+	// (the read/write tools behave exactly as before).
+	FileTracker *FileTracker
 	// EnabledTools / DisabledTools carry the run's operator tool filters so a
 	// filter-aware tool (tool_search) never discloses or loads an operator-hidden
 	// tool. They use the same allow/deny semantics as the agent's filter gate:

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -78,10 +78,15 @@ func (tool writeFileTool) RunWithOptions(_ context.Context, args map[string]any,
 	// so a first-touch create/overwrite stays a single write with no extra read.
 	if existed {
 		if _, tracked := options.FileTracker.Version(absolutePath); tracked {
-			if current, rerr := os.ReadFile(absolutePath); rerr == nil {
-				if cerr := options.FileTracker.CheckConflict(absolutePath, current); cerr != nil {
-					return errorResult(fileConflictMessage(relativePath))
-				}
+			// Fail CLOSED: if the tracked file can't be re-read to verify it, refuse
+			// the overwrite rather than clobbering a file whose current state is
+			// unknown (it may have been replaced or removed out from under us).
+			current, rerr := os.ReadFile(absolutePath)
+			if rerr != nil {
+				return errorResult(fileConflictMessage(relativePath))
+			}
+			if cerr := options.FileTracker.CheckConflict(absolutePath, current); cerr != nil {
+				return errorResult(fileConflictMessage(relativePath))
 			}
 		}
 	}

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -39,7 +39,11 @@ func NewScopedWriteFileTool(workspaceRoot string, scope PathScope) Tool {
 	}
 }
 
-func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
+func (tool writeFileTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.RunWithOptions(ctx, args, RunOptions{})
+}
+
+func (tool writeFileTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
 	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filename"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for write_file: " + err.Error())
@@ -68,6 +72,20 @@ func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
 
+	// On overwrite, refuse to clobber a tracked file that changed on disk outside
+	// Zero since it was last read — the new content was likely composed against a
+	// stale view. Only read current bytes when there is a baseline to compare,
+	// so a first-touch create/overwrite stays a single write with no extra read.
+	if existed {
+		if _, tracked := options.FileTracker.Version(absolutePath); tracked {
+			if current, rerr := os.ReadFile(absolutePath); rerr == nil {
+				if cerr := options.FileTracker.CheckConflict(absolutePath, current); cerr != nil {
+					return errorResult(fileConflictMessage(relativePath))
+				}
+			}
+		}
+	}
+
 	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
@@ -77,6 +95,10 @@ func (tool writeFileTool) Run(_ context.Context, args map[string]any) Result {
 	if err := os.WriteFile(absolutePath, []byte(content), 0o644); err != nil {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
+	// Baseline the freshly written content so a later edit/overwrite in this
+	// session compares against what is now on disk.
+	newInfo, _ := os.Stat(absolutePath)
+	options.FileTracker.Record(absolutePath, []byte(content), newInfo)
 
 	verb := "Created"
 	if existed {


### PR DESCRIPTION
Closes the tool edit-safety gap vs. Factory's droid (file read/write tracking, external modification detection, post-apply validation), implemented Go-native in three phases.

## Phase 1 — file version tracker
`internal/tools/file_tracker.go`: a per-session `FileTracker` recording a sha256 content hash (plus stat metadata) per absolute path. `CheckConflict` only flags drift against a known baseline; an untracked first-touch write is always allowed. A nil `*FileTracker` is a no-op so callers without the feature need no guards.

## Phase 2 — external-modification detection
- `read_file` records the whole-file baseline (raw bytes) it shows the model.
- `edit_file` and `write_file --overwrite` refuse to clobber a file whose on-disk content drifted from that baseline (an edit made outside Zero), with an actionable "re-read first" error, then re-baseline to what they wrote.
- `apply_patch` forgets the files it rewrote (git apply has its own context guard) so a later edit does not false-conflict.
- Threaded via a new `RunOptions`/`agent.Options` `FileTracker`, constructed once per session in the exec, spec, and TUI launch paths. nil preserves prior behavior.

## Phase 3 — post-apply validation via hooks
The `hooks.Dispatcher` existed but was never called. Wired into `executeToolCall`:
- **beforeTool** hooks run before a tool; a non-zero exit vetoes the call (`DenialHookBlocked`).
- **afterTool** hooks run after; their output (formatter / vet / custom validator) is secret-scrubbed and surfaced back to the model on the result. `DispatchOutcome` now collects hook stdout/stderr for this.
- The per-session dispatcher is built from merged user+project `hooks.json` with an audit store, threaded via `agent.Options`. It **fails open** (nil dispatcher) and runs nothing until a user configures a hook, so the hot path is unaffected by default.

## Tests
- `file_tracker_test.go`, `file_safety_test.go` — tracker semantics + end-to-end conflict detection through the registry dispatch (edit/overwrite refused on drift; untracked allowed; nil tracker = old behavior).
- `hooks/dispatch_test.go` — afterTool output-message collection (trimmed stdout preferred, stderr fallback, quiet hook omitted).
- `agent/hook_wiring_test.go` — feedback formatting/scrubbing, blocked-result shape + denial category, nil-dispatcher no-op.

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l`, and the full `go test ./...` suite all pass (test suite run with an isolated `XDG_DATA_HOME`).

## Notes
- Default behavior is unchanged: no `hooks.json` → no commands run; nil `FileTracker` → no conflict checks.
- Security: afterTool hook output is scrubbed at the same boundary as tool output. beforeTool veto is non-retriable (`DenialHookBlocked`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool-execution hooks: beforeTool can block a tool with a denial reason; afterTool messages are collected and appended to tool output with secret redaction.
  * Per-session file tracker: records file versions, detects external on-disk changes, and re-baselines after successful writes/edits; CLI initializes tracker and hook dispatcher per run.

* **Bug Fixes**
  * Improved file-safety: read/write/edit tools now refuse overwrites when files changed externally since last read.

* **Tests**
  * Added tests for hook redaction/behavior, hook output collection, file-tracker functionality, and file-safety scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->