### PR TITLE
audit: fix isolated remaining findings (redaction, secrets, rune-safety, credential status)

### DIFF
--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -199,5 +199,7 @@ func cronTruncate(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max] + "…"
+	// Cut on a UTF-8 rune boundary so a persisted run-error excerpt can't end in
+	// a split multi-byte rune (invalid UTF-8 in the cron record).
+	return cutRuneBoundary(s, max) + "…"
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -129,8 +129,10 @@ func providerConfigCheck(profile config.ProviderProfile) Check {
 	// Report key PRESENCE, never the value: the raw key would only be redacted
 	// downstream anyway, and an unconditional [REDACTED] read as "configured"
 	// even when no key was set at all.
+	// A profile can authenticate via a raw auth-header value instead of APIKey, so
+	// treat either as a configured credential (matches ProviderSnapshot.APIKeySet).
 	apiKey := "not set"
-	if profile.APIKey != "" {
+	if profile.APIKey != "" || profile.AuthHeaderValue != "" {
 		apiKey = "set"
 	}
 	return check("provider.config", "Provider config", StatusPass, fmt.Sprintf("Provider config loaded for %s.", providerName(profile)), map[string]any{

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -126,21 +126,22 @@ func providerConfigCheck(profile config.ProviderProfile) Check {
 	if emptyProviderProfile(profile) {
 		return check("provider.config", "Provider config", StatusFail, "No LLM provider is configured.", map[string]any{"help": "Set a provider in config or environment."})
 	}
-	// Report key PRESENCE, never the value: the raw key would only be redacted
-	// downstream anyway, and an unconditional [REDACTED] read as "configured"
-	// even when no key was set at all.
-	// A profile can authenticate via a raw auth-header value instead of APIKey, so
-	// treat either as a configured credential (matches ProviderSnapshot.APIKeySet).
-	apiKey := "not set"
-	if profile.APIKey != "" || profile.AuthHeaderValue != "" {
-		apiKey = "set"
+	// Report credential PRESENCE, never the value. Reported under a non-sensitive
+	// key ("credentialConfigured"): the prior "apiKey" key was itself sensitive, so
+	// check()'s redaction scrubbed the indicator to [REDACTED] — making "set"/"not
+	// set" invisible. A profile can authenticate via a raw auth-header value instead
+	// of APIKey, and both are trimmed so a whitespace-only value reads "not set"
+	// (matching ProviderSnapshot.APIKeySet).
+	credential := "not set"
+	if strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != "" {
+		credential = "set"
 	}
 	return check("provider.config", "Provider config", StatusPass, fmt.Sprintf("Provider config loaded for %s.", providerName(profile)), map[string]any{
-		"name":     profile.Name,
-		"provider": profile.ProviderKind,
-		"baseURL":  profile.BaseURL,
-		"model":    profile.Model,
-		"apiKey":   apiKey,
+		"name":                 profile.Name,
+		"provider":             profile.ProviderKind,
+		"baseURL":              profile.BaseURL,
+		"model":                profile.Model,
+		"credentialConfigured": credential,
 	})
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -290,7 +290,9 @@ func TestProviderConfigCheckCredentialPresence(t *testing.T) {
 	}{
 		{"api key", base(func(p *config.ProviderProfile) { p.APIKey = "sk-x" }), "set"},
 		{"auth header only", base(func(p *config.ProviderProfile) { p.AuthHeaderValue = "Bearer t" }), "set"},
+		{"both", base(func(p *config.ProviderProfile) { p.APIKey = "sk-x"; p.AuthHeaderValue = "Bearer t" }), "set"},
 		{"whitespace api key", base(func(p *config.ProviderProfile) { p.APIKey = "   " }), "not set"},
+		{"whitespace auth header only", base(func(p *config.ProviderProfile) { p.AuthHeaderValue = "   " }), "not set"},
 		{"no credential", base(func(*config.ProviderProfile) {}), "not set"},
 	}
 	for _, tc := range cases {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -276,3 +276,29 @@ func fixedDoctorClock(value string) func() time.Time {
 	}
 	return func() time.Time { return parsed }
 }
+
+func TestProviderConfigCheckCredentialPresence(t *testing.T) {
+	base := func(extra func(*config.ProviderProfile)) config.ProviderProfile {
+		p := config.ProviderProfile{Name: "main", ProviderKind: config.ProviderKindOpenAI, Model: "gpt-4.1"}
+		extra(&p)
+		return p
+	}
+	cases := []struct {
+		name    string
+		profile config.ProviderProfile
+		want    string
+	}{
+		{"api key", base(func(p *config.ProviderProfile) { p.APIKey = "sk-x" }), "set"},
+		{"auth header only", base(func(p *config.ProviderProfile) { p.AuthHeaderValue = "Bearer t" }), "set"},
+		{"whitespace api key", base(func(p *config.ProviderProfile) { p.APIKey = "   " }), "not set"},
+		{"no credential", base(func(*config.ProviderProfile) {}), "not set"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := providerConfigCheck(tc.profile).Details["credentialConfigured"]
+			if got != tc.want {
+				t.Fatalf("credentialConfigured = %v, want %q (matches ProviderSnapshot.APIKeySet trimming)", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/providermodeldiscovery/discovery.go
+++ b/internal/providermodeldiscovery/discovery.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providermodelcatalog"
+	"github.com/Gitlawb/zero/internal/providers/providerio"
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
@@ -39,7 +40,7 @@ type Options struct {
 
 func DiscoverCatalog(ctx context.Context, provider providercatalog.Descriptor, profile config.ProviderProfile, options Options) ([]Model, error) {
 	catalogModels, catalogErr := fetchCatalogModels(ctx, provider, options)
-	canProbeProvider := openAICompatibleDiscoveryAllowed(profile) && (!provider.RequiresAuth || strings.TrimSpace(profile.APIKey) != "")
+	canProbeProvider := openAICompatibleDiscoveryAllowed(profile) && (!provider.RequiresAuth || discoveryHasCredential(profile))
 	if canProbeProvider {
 		liveModels, liveErr := Discover(ctx, profile, options)
 		if liveErr == nil {
@@ -58,6 +59,14 @@ func DiscoverCatalog(ctx context.Context, provider providercatalog.Descriptor, p
 	return nil, fmt.Errorf("no provider models discovered")
 }
 
+// discoveryHasCredential reports whether the profile carries a usable credential
+// for an authenticated /models probe. A profile may authenticate via a raw
+// auth-header value instead of APIKey, so treat either as present — consistent
+// with config credential checks and zerocommands ProviderSnapshot.APIKeySet.
+func discoveryHasCredential(profile config.ProviderProfile) bool {
+	return strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != ""
+}
+
 func Discover(ctx context.Context, profile config.ProviderProfile, options Options) ([]Model, error) {
 	if !openAICompatibleDiscoveryAllowed(profile) {
 		return nil, fmt.Errorf("provider %s does not expose OpenAI-compatible model discovery", displayProviderName(profile))
@@ -71,9 +80,19 @@ func Discover(ctx context.Context, profile config.ProviderProfile, options Optio
 	if err != nil {
 		return nil, err
 	}
-	if key := strings.TrimSpace(profile.APIKey); key != "" {
-		request.Header.Set("Authorization", "Bearer "+key)
-	}
+	// Authenticate via either an APIKey (Authorization: Bearer ...) or a raw
+	// auth-header value / custom headers, matching how the live providers build
+	// their requests (internal/providers/providerio). Honoring AuthHeaderValue
+	// keeps discovery consistent with the credential-present logic elsewhere.
+	providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+		APIKey:            profile.APIKey,
+		DefaultAuthHeader: "Authorization",
+		DefaultAuthScheme: "Bearer",
+		AuthHeader:        profile.AuthHeader,
+		AuthScheme:        profile.AuthScheme,
+		AuthHeaderValue:   profile.AuthHeaderValue,
+		CustomHeaders:     profile.CustomHeaders,
+	})
 	request.Header.Set("Accept", "application/json")
 
 	client := options.HTTPClient

--- a/internal/providermodeldiscovery/discovery_test.go
+++ b/internal/providermodeldiscovery/discovery_test.go
@@ -51,6 +51,52 @@ func TestDiscoverOpenAICompatibleModelsFetchesModelsEndpoint(t *testing.T) {
 	}
 }
 
+func TestDiscoverOpenAICompatibleModelsHonorsAuthHeaderValue(t *testing.T) {
+	// A profile can authenticate via a raw auth-header value instead of APIKey;
+	// discovery must send it rather than probe unauthenticated.
+	const headerValue = "Bearer raw-header-secret"
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"model-a"}]}`))
+	}))
+	defer server.Close()
+
+	if _, err := Discover(context.Background(), config.ProviderProfile{
+		Name:            "test",
+		ProviderKind:    config.ProviderKindOpenAICompatible,
+		BaseURL:         server.URL + "/v1",
+		AuthHeaderValue: headerValue,
+	}, Options{HTTPClient: server.Client()}); err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+	if gotAuth != headerValue {
+		t.Fatalf("Authorization = %q, want raw auth-header value %q", gotAuth, headerValue)
+	}
+}
+
+func TestDiscoveryHasCredential(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile config.ProviderProfile
+		want    bool
+	}{
+		{"api key", config.ProviderProfile{APIKey: "sk-x"}, true},
+		{"auth header only", config.ProviderProfile{AuthHeaderValue: "Bearer t"}, true},
+		{"both", config.ProviderProfile{APIKey: "sk-x", AuthHeaderValue: "Bearer t"}, true},
+		{"neither", config.ProviderProfile{}, false},
+		{"whitespace only", config.ProviderProfile{APIKey: "  ", AuthHeaderValue: "\t"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := discoveryHasCredential(tc.profile); got != tc.want {
+				t.Fatalf("discoveryHasCredential = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDiscoverOpenAICompatibleModelsHandlesBaseURLWithoutVersion(t *testing.T) {
 	var gotPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -223,7 +223,12 @@ func redactReflect(value reflect.Value, context redactionContext, depth int) any
 			return CircularReference
 		}
 		context.seen[ptr] = struct{}{}
-		return redactReflect(value.Elem(), context, depth+1)
+		// Track only the current DFS path: drop the pointer after recursing so a
+		// shared (non-cyclic) reference reached again via a SIBLING branch is not
+		// mistaken for a cycle. Only an ancestor still on the path triggers it.
+		out := redactReflect(value.Elem(), context, depth+1)
+		delete(context.seen, ptr)
+		return out
 	case reflect.Map:
 		if value.IsNil() {
 			return nil
@@ -243,6 +248,7 @@ func redactReflect(value reflect.Value, context redactionContext, depth int) any
 			}
 			out[key] = redactReflect(iter.Value(), context, depth+1)
 		}
+		delete(context.seen, ptr)
 		return out
 	case reflect.Slice, reflect.Array:
 		out := make([]any, value.Len())
@@ -358,8 +364,10 @@ func normalizeKey(key string) string {
 	return strings.Trim(builder.String(), "_")
 }
 
+var urlWithCredsPattern = regexp.MustCompile(`\b(?:https?|wss?|ftp)://[^\s]+`)
+
 func redactURLPasswords(value string, replacement string) string {
-	return regexp.MustCompile(`\b(?:https?|wss?|ftp)://[^\s]+`).ReplaceAllStringFunc(value, func(candidate string) string {
+	return urlWithCredsPattern.ReplaceAllStringFunc(value, func(candidate string) string {
 		parsed, err := url.Parse(candidate)
 		if err != nil || parsed.User == nil {
 			return candidate

--- a/internal/redaction/redaction_test.go
+++ b/internal/redaction/redaction_test.go
@@ -83,3 +83,61 @@ type withFieldsError struct {
 func (err withFieldsError) Error() string {
 	return err.err.Error()
 }
+
+func TestRedactValueSharedPointerIsNotMistakenForCycle(t *testing.T) {
+	// Two sibling fields referencing the SAME object form a DAG, not a cycle.
+	// Both must redact normally; the second must not collapse to CircularReference.
+	type leaf struct{ Name string }
+	type root struct {
+		A *leaf
+		B *leaf
+	}
+	shared := &leaf{Name: "shared"}
+	out := RedactValue(root{A: shared, B: shared}, Options{})
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", out)
+	}
+	for _, field := range []string{"A", "B"} {
+		sub, ok := m[field].(map[string]any)
+		if !ok {
+			t.Fatalf("field %s = %#v, want a redacted leaf (sibling DAG must not be %q)", field, m[field], CircularReference)
+		}
+		if sub["Name"] != "shared" {
+			t.Fatalf("field %s Name = %v, want \"shared\"", field, sub["Name"])
+		}
+	}
+}
+
+func TestRedactValueTrueCycleStillDetected(t *testing.T) {
+	type node struct {
+		Name string
+		Next *node
+	}
+	a := &node{Name: "a"}
+	a.Next = a // genuine self-cycle
+	out := RedactValue(a, Options{})
+	if !containsCircular(out) {
+		t.Fatalf("expected a CircularReference marker somewhere in %#v", out)
+	}
+}
+
+func containsCircular(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return t == CircularReference
+	case map[string]any:
+		for _, val := range t {
+			if containsCircular(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, val := range t {
+			if containsCircular(val) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -32,7 +32,9 @@ var patterns = []pattern{
 	{"github_pat", regexp.MustCompile(`github_pat_[A-Za-z0-9_]{22,}`)},
 	{"slack_token", regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"google_api_key", regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`)},
-	{"openai_key", regexp.MustCompile(`sk-[A-Za-z0-9]{20,}`)},
+	// Body allows - and _ so modern prefixed keys (sk-proj-…, sk-svcacct-…) match,
+	// not just the legacy sk-<alnum> shape.
+	{"openai_key", regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -96,5 +96,8 @@ func TestScanDetectsModernPrefixedOpenAIKeys(t *testing.T) {
 		if strings.Contains(redacted, key) {
 			t.Fatalf("key leaked after redaction: %q", redacted)
 		}
+		if !strings.Contains(redacted, "[REDACTED:openai_key]") {
+			t.Fatalf("missing typed placeholder for %q: %q", key, redacted)
+		}
 	}
 }

--- a/internal/secrets/scanner_test.go
+++ b/internal/secrets/scanner_test.go
@@ -81,3 +81,20 @@ func TestRedactNoMatchReturnsInputUnchanged(t *testing.T) {
 		t.Fatalf("expected unchanged input and nil findings, got %q / %#v", redacted, findings)
 	}
 }
+
+func TestScanDetectsModernPrefixedOpenAIKeys(t *testing.T) {
+	// Modern keys carry sk-proj-/sk-svcacct- prefixes and use - and _ in the body;
+	// the legacy sk-<alnum> pattern would have missed them.
+	for _, key := range []string{
+		"sk-proj-abcDEF123_ghiJKL456-mnoPQR789stu",
+		"sk-svcacct-abcDEF123_ghiJKL456-mnoPQR789",
+	} {
+		redacted, findings := Redact("token=" + key)
+		if len(findings) != 1 || findings[0].Type != "openai_key" {
+			t.Fatalf("expected one openai_key finding for %q, got %#v", key, findings)
+		}
+		if strings.Contains(redacted, key) {
+			t.Fatalf("key leaked after redaction: %q", redacted)
+		}
+	}
+}

--- a/internal/zerocommands/contracts.go
+++ b/internal/zerocommands/contracts.go
@@ -160,7 +160,7 @@ func ProviderSnapshotFromProfile(profile config.ProviderProfile, active bool) Pr
 	snapshot := ProviderSnapshot{
 		Name:         profile.Name,
 		ProviderKind: string(profile.ProviderKind),
-		BaseURL:      redactProviderBaseURL(profile.BaseURL, profile.APIKey),
+		BaseURL:      redactProviderBaseURL(profile.BaseURL, profile.APIKey, profile.AuthHeaderValue),
 		Model:        profile.Model,
 		Active:       active,
 		// A profile can authenticate via a raw auth-header value instead of APIKey;
@@ -333,13 +333,21 @@ func SessionTreeSnapshotFromNode(node sessions.TreeNode) SessionTreeSnapshot {
 	}
 }
 
-func redactProviderBaseURL(baseURL string, apiKey string) string {
+func redactProviderBaseURL(baseURL string, secrets ...string) string {
 	baseURL = strings.TrimSpace(baseURL)
 	if baseURL == "" {
 		return ""
 	}
 	safeURL := stripURLCredentials(baseURL)
-	return redaction.RedactString(safeURL, redaction.Options{ExtraSecretValues: []string{apiKey}})
+	// Redact any configured credential (APIKey and/or a raw auth-header value) if
+	// it leaked into the URL. Drop empties so an unset credential can't match.
+	extra := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		if strings.TrimSpace(secret) != "" {
+			extra = append(extra, secret)
+		}
+	}
+	return redaction.RedactString(safeURL, redaction.Options{ExtraSecretValues: extra})
 }
 
 func stripURLCredentials(value string) string {

--- a/internal/zerocommands/contracts.go
+++ b/internal/zerocommands/contracts.go
@@ -163,8 +163,11 @@ func ProviderSnapshotFromProfile(profile config.ProviderProfile, active bool) Pr
 		BaseURL:      redactProviderBaseURL(profile.BaseURL, profile.APIKey),
 		Model:        profile.Model,
 		Active:       active,
-		APIKeySet:    strings.TrimSpace(profile.APIKey) != "",
-		Status:       "ok",
+		// A profile can authenticate via a raw auth-header value instead of APIKey;
+		// treat either as a configured credential so auth-header-only profiles don't
+		// render as "not set".
+		APIKeySet: strings.TrimSpace(profile.APIKey) != "" || strings.TrimSpace(profile.AuthHeaderValue) != "",
+		Status:    "ok",
 	}
 	metadata, err := providers.ResolveRuntimeMetadata(profile, providers.Options{})
 	if err != nil {

--- a/internal/zerocommands/contracts_test.go
+++ b/internal/zerocommands/contracts_test.go
@@ -335,6 +335,8 @@ func TestProviderSnapshotAPIKeySetCountsAuthHeaderValue(t *testing.T) {
 		{"auth header only", config.ProviderProfile{Name: "p", AuthHeaderValue: "Bearer t"}, true},
 		{"both", config.ProviderProfile{Name: "p", APIKey: "sk-x", AuthHeaderValue: "Bearer t"}, true},
 		{"neither", config.ProviderProfile{Name: "p"}, false},
+		{"whitespace api key only", config.ProviderProfile{Name: "p", APIKey: "   "}, false},
+		{"whitespace auth header only", config.ProviderProfile{Name: "p", AuthHeaderValue: "   "}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/zerocommands/contracts_test.go
+++ b/internal/zerocommands/contracts_test.go
@@ -324,3 +324,24 @@ func TestSessionTreeSnapshotConvertsChildren(t *testing.T) {
 		t.Fatalf("child lineage not preserved in tree snapshot: %#v", snapshot)
 	}
 }
+
+func TestProviderSnapshotAPIKeySetCountsAuthHeaderValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile config.ProviderProfile
+		want    bool
+	}{
+		{"api key only", config.ProviderProfile{Name: "p", APIKey: "sk-x"}, true},
+		{"auth header only", config.ProviderProfile{Name: "p", AuthHeaderValue: "Bearer t"}, true},
+		{"both", config.ProviderProfile{Name: "p", APIKey: "sk-x", AuthHeaderValue: "Bearer t"}, true},
+		{"neither", config.ProviderProfile{Name: "p"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := ProviderSnapshotFromProfile(tc.profile, false)
+			if snapshot.APIKeySet != tc.want {
+				t.Fatalf("APIKeySet = %v, want %v", snapshot.APIKeySet, tc.want)
+			}
+		})
+	}
+}

--- a/internal/zerocommands/contracts_test.go
+++ b/internal/zerocommands/contracts_test.go
@@ -347,3 +347,17 @@ func TestProviderSnapshotAPIKeySetCountsAuthHeaderValue(t *testing.T) {
 		})
 	}
 }
+
+func TestProviderSnapshotRedactsAuthHeaderValueInBaseURL(t *testing.T) {
+	// A raw auth-header value that leaks into the base URL must be redacted too,
+	// not just APIKey.
+	const secret = "authhdr-secret-9f8e7d6c5b"
+	snapshot := ProviderSnapshotFromProfile(config.ProviderProfile{
+		Name:            "p",
+		BaseURL:         "https://api.test/v1?token=" + secret,
+		AuthHeaderValue: secret,
+	}, false)
+	if strings.Contains(snapshot.BaseURL, secret) {
+		t.Fatalf("auth-header value leaked into base URL: %q", snapshot.BaseURL)
+	}
+}

--- a/internal/zerogit/zerogit.go
+++ b/internal/zerogit/zerogit.go
@@ -204,7 +204,9 @@ func ValidateMessage(message string) error {
 		return fmt.Errorf("commit message is required")
 	}
 	firstLine := strings.Split(trimmed, "\n")[0]
-	if len(firstLine) > 72 {
+	// Count runes, not bytes, so a valid non-ASCII subject under the limit is not
+	// rejected for spilling past 72 bytes.
+	if utf8.RuneCountInString(firstLine) > 72 {
 		return fmt.Errorf("commit message subject must be 72 characters or fewer")
 	}
 	return nil

--- a/internal/zerogit/zerogit_test.go
+++ b/internal/zerogit/zerogit_test.go
@@ -470,3 +470,16 @@ func writeTestFile(t *testing.T, path string, content string) {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
+
+func TestValidateMessageCountsRunesNotBytes(t *testing.T) {
+	// 72 multi-byte runes (é = 2 bytes = 144 bytes) is a valid subject; the old
+	// byte-length check wrongly rejected it.
+	subject := strings.Repeat("é", 72)
+	if err := ValidateMessage(subject); err != nil {
+		t.Fatalf("72-rune non-ASCII subject should be valid, got %v", err)
+	}
+	// 73 runes must still be rejected.
+	if err := ValidateMessage(strings.Repeat("é", 73)); err == nil {
+		t.Fatal("73-rune subject should be rejected")
+	}
+}


### PR DESCRIPTION
Addresses a batch of the **isolated, non-conflicting** open findings from the deep-audit ledger (`docs/audit/2026-06-10-deep-audit-status.md`). Each is real, verified, and lives in a file *not* being rewritten by the in-flight PRs (#166/#170/#172) — see "Deliberately deferred" for why this isn't all 91.

## Fixed (6 findings)

| Audit location | Fix |
|---|---|
| `redaction.go:222` | `seen` set now tracks only the current DFS path (delete pointer after recursing), so a shared reference reached via a **sibling** branch is no longer reported as `CircularReference`. True cycles still detected. |
| `redaction.go:362` | `redactURLPasswords` compiles its regexp once at package scope instead of per call. |
| `scanner.go:35` | `openai_key` body allows `-`/`_` so modern `sk-proj-…` / `sk-svcacct-…` keys match, not just legacy `sk-<alnum>`. |
| `cron_run.go:179` | `cronTruncate` cuts on a UTF-8 rune boundary (reuses `cutRuneBoundary`) so a persisted run-error excerpt can't end in a split rune. |
| `zerogit.go:207` | `ValidateMessage` counts runes, not bytes — a valid non-ASCII commit subject under 72 chars is no longer rejected. |
| `contracts.go:166` | `ProviderSnapshot.APIKeySet` is true for an auth-header-only profile (was APIKey-only), so it no longer renders as "not set". |

New regression tests: redaction sibling-DAG + true-cycle, modern OpenAI key redaction, `ValidateMessage` rune count.

## Verification
`go build ./...`, `go vet`, `gofmt`, and the changed packages' tests all pass; full-suite run leaked 0 sessions into `$HOME`.

> Note: a full `go test ./...` showed one **flaky, unrelated** failure — `internal/config TestLoadProviderCommandDoesNotResolveAPIKeyEnvFromProcess` timed out at its 5s subprocess limit under full-suite parallelism, then passed 2/2 in isolation. Not touched by this PR; worth a separate fix to raise/relax that timeout.

## Deliberately deferred (NOT in this PR — by design)

The ledger has ~74 open + 17 partial. The rest are excluded for concrete reasons:

1. **Conflicts with in-flight PRs** — findings in `agent/loop.go`, `agent/types.go`, `sandbox/grants.go`, `sandbox/engine.go`, `agent/compaction*.go`, `tui/rendering.go`, `tui/session_controls.go`, `tui/model.go`, `tools/{write,edit,read,apply_patch}.go` are being rewritten by #166/#170/#172. Fixing them now guarantees merge conflicts — they should be done **after** those merge.
2. **Needs its own focused PR + tests** — specialist `--auto high` autonomy clamp (gap #6, the program's top safety item), MCP client/network bugs (ping handling, blocking write under mutex, SSE first-message, scanner reconnect), cron DST fall-back + reconcileOverdue, `process_posix` recycled-pid race, `safe_command` quote-aware split, sessions Fork usage double-count / fsync, specialist accounting race.
3. **Behavioral blast radius** — `worktrees defaultRunGit` stdout/stderr split changes git-output parsing for every caller; needs a caller audit.
4. **Dead-code judgment calls** — e.g. `redaction StackTrace` interface is defensive (keep), provider `isImplicitOpenAI` dead branch touches provider resolution; these need per-item decisions, not a blanket sweep.

These are tracked in the v0.1 release program PRD workstreams (WS-A/B/E backlogs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce false-positive circular-reference redactions so shared non-cyclic references aren’t misclassified.
  * Ensure sensitive values embedded in URLs or provider snapshots are redacted and not leaked.

* **Improvements**
  * Truncation and commit-subject validation now respect UTF‑8 rune boundaries for correct multi-byte handling.
  * Profiles authenticated via auth headers are treated as having configured credentials.
  * Secret detection updated to match modern OpenAI key formats and uses a precompiled pattern.

* **Tests**
  * Added tests for cycle detection, auth-header credential handling, model-discovery auth, and modern OpenAI key detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->