### PR TITLE
wedge build: web_search + LSP client/diagnostics (stages 01-03)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -326,6 +326,19 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			if outcome.InjectHint && failureHint == "" {
 				failureHint = toolFailureHint(call.Name, toolSchemaJSON(registry, call.Name), toolResult.Output)
 			}
+
+			// Post-edit self-correction: after a successful mutating tool call,
+			// verify the changed files and feed any failure back so the model can
+			// fix it next turn. nil SelfCorrect (the default) is a no-op, and a
+			// read-only tool (no ChangedFiles) never triggers verification.
+			if options.SelfCorrect != nil && toolResult.Status == tools.StatusOK && len(toolResult.ChangedFiles) > 0 {
+				if feedback, _ := options.SelfCorrect.AfterEdit(ctx, toolResult.ChangedFiles); feedback != "" {
+					messages = append(messages, zeroruntime.Message{
+						Role:    zeroruntime.MessageRoleUser,
+						Content: feedback,
+					})
+				}
+			}
 		}
 
 		// Mid-run model escalation: if a tool asked to switch models this turn and

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -260,12 +260,15 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		// after the batch, so every tool_result is recorded first and at most one
 		// switch occurs per turn.
 		turnRequestedModel := ""
-		// selfCorrectFeedback accumulates post-edit verification feedback during
-		// the batch; it is appended ONCE after the loop so every advertised tool
-		// call keeps its tool_result contiguous (a user message interleaved between
-		// tool_results breaks strict provider replay) — same after-batch rationale
-		// as turnRequestedModel above.
-		var selfCorrectFeedback []string
+		// changedFilesThisBatch aggregates every file the turn's mutating tools
+		// touched, so post-edit self-correction runs ONCE over the union after the
+		// batch — one AfterEdit call keeps the per-run attempt budget accurate and
+		// avoids verifying an intermediate edit a later call in the same turn already
+		// superseded. Its feedback is appended after the loop so every advertised
+		// tool call keeps its tool_result contiguous (a user message interleaved
+		// between tool_results breaks strict provider replay) — same after-batch
+		// rationale as turnRequestedModel above.
+		var changedFilesThisBatch []string
 		for index, call := range collected.ToolCalls {
 			if options.OnToolCall != nil {
 				options.OnToolCall(call)
@@ -333,25 +336,25 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 				failureHint = toolFailureHint(call.Name, toolSchemaJSON(registry, call.Name), toolResult.Output)
 			}
 
-			// Post-edit self-correction: after a successful mutating tool call,
-			// verify the changed files and feed any failure back so the model can
-			// fix it next turn. nil SelfCorrect (the default) is a no-op, and a
-			// read-only tool (no ChangedFiles) never triggers verification.
+			// Post-edit self-correction: collect the files this successful mutating
+			// tool changed; verification runs once over the union after the batch.
+			// A read-only tool (no ChangedFiles) never contributes.
 			if options.SelfCorrect != nil && toolResult.Status == tools.StatusOK && len(toolResult.ChangedFiles) > 0 {
-				if feedback, _ := options.SelfCorrect.AfterEdit(ctx, toolResult.ChangedFiles); feedback != "" {
-					selfCorrectFeedback = append(selfCorrectFeedback, feedback)
-				}
+				changedFilesThisBatch = append(changedFilesThisBatch, toolResult.ChangedFiles...)
 			}
 		}
 
-		// Append accumulated self-correct feedback now that every tool_result for
-		// this batch is recorded, so the assistant's tool_results stay contiguous
-		// (a user message between tool_results breaks strict provider replay).
-		if len(selfCorrectFeedback) > 0 {
-			messages = append(messages, zeroruntime.Message{
-				Role:    zeroruntime.MessageRoleUser,
-				Content: strings.Join(selfCorrectFeedback, "\n\n"),
-			})
+		// Run post-edit self-correction once over the union of files this turn
+		// changed, then append any feedback after every tool_result is recorded so
+		// the assistant's tool_results stay contiguous (a user message between
+		// tool_results breaks strict provider replay). nil SelfCorrect is a no-op.
+		if options.SelfCorrect != nil && len(changedFilesThisBatch) > 0 {
+			if feedback, _ := options.SelfCorrect.AfterEdit(ctx, dedupeStrings(changedFilesThisBatch)); feedback != "" {
+				messages = append(messages, zeroruntime.Message{
+					Role:    zeroruntime.MessageRoleUser,
+					Content: feedback,
+				})
+			}
 		}
 
 		// Mid-run model escalation: if a tool asked to switch models this turn and
@@ -1389,6 +1392,21 @@ func appendAbortedToolResults(messages []Message, remaining []ToolCall) []Messag
 		})
 	}
 	return messages
+}
+
+// dedupeStrings returns values with duplicates removed, preserving first-seen
+// order so the deduped list (e.g. a turn's changed files) stays deterministic.
+func dedupeStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
 }
 
 func copyMessages(messages []Message) []Message {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -260,6 +260,12 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		// after the batch, so every tool_result is recorded first and at most one
 		// switch occurs per turn.
 		turnRequestedModel := ""
+		// selfCorrectFeedback accumulates post-edit verification feedback during
+		// the batch; it is appended ONCE after the loop so every advertised tool
+		// call keeps its tool_result contiguous (a user message interleaved between
+		// tool_results breaks strict provider replay) — same after-batch rationale
+		// as turnRequestedModel above.
+		var selfCorrectFeedback []string
 		for index, call := range collected.ToolCalls {
 			if options.OnToolCall != nil {
 				options.OnToolCall(call)
@@ -333,12 +339,19 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			// read-only tool (no ChangedFiles) never triggers verification.
 			if options.SelfCorrect != nil && toolResult.Status == tools.StatusOK && len(toolResult.ChangedFiles) > 0 {
 				if feedback, _ := options.SelfCorrect.AfterEdit(ctx, toolResult.ChangedFiles); feedback != "" {
-					messages = append(messages, zeroruntime.Message{
-						Role:    zeroruntime.MessageRoleUser,
-						Content: feedback,
-					})
+					selfCorrectFeedback = append(selfCorrectFeedback, feedback)
 				}
 			}
+		}
+
+		// Append accumulated self-correct feedback now that every tool_result for
+		// this batch is recorded, so the assistant's tool_results stay contiguous
+		// (a user message between tool_results breaks strict provider replay).
+		if len(selfCorrectFeedback) > 0 {
+			messages = append(messages, zeroruntime.Message{
+				Role:    zeroruntime.MessageRoleUser,
+				Content: strings.Join(selfCorrectFeedback, "\n\n"),
+			})
 		}
 
 		// Mid-run model escalation: if a tool asked to switch models this turn and

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -485,6 +486,85 @@ func TestRunSanitizesMalformedToolCallArgumentsBeforeRetry(t *testing.T) {
 	}
 	if toolParseError == "" {
 		t.Fatalf("expected model-visible tool result to keep the parse error, messages: %#v", provider.requests[1].Messages)
+	}
+}
+
+func TestRunDefersSelfCorrectFeedbackUntilAfterToolBatch(t *testing.T) {
+	// A single assistant turn with two tool calls where the first mutates and
+	// self-correct fails must keep both tool_results contiguous, with the feedback
+	// appended only after the whole batch — otherwise a user message interleaves
+	// between tool_results and breaks strict provider replay.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "existing.txt"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	registry.Register(tools.NewReadFileTool(root))
+
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "write_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"path":"notes.txt","content":"hello"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-2", ToolName: "read_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-2", ArgumentsFragment: `{"path":"existing.txt"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-2"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+
+	corrector := NewSelfCorrector(root, erroringChecker{err: errors.New("lsp boom")}, nil, SelfCorrectConfig{
+		Enabled:    true,
+		IncludeLSP: true,
+		Autonomy:   "high",
+	})
+
+	if _, err := Run(context.Background(), "go", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		SelfCorrect:    corrector,
+		OnPermissionRequest: func(_ context.Context, _ PermissionRequest) (PermissionDecision, error) {
+			return PermissionDecision{Action: PermissionDecisionAllow, Reason: "test"}, nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.requests) < 2 {
+		t.Fatalf("expected a second completion request, got %d", len(provider.requests))
+	}
+
+	msgs := provider.requests[1].Messages
+	var toolIdx []int
+	feedbackIdx := -1
+	for i, m := range msgs {
+		switch m.Role {
+		case zeroruntime.MessageRoleTool:
+			toolIdx = append(toolIdx, i)
+		case zeroruntime.MessageRoleUser:
+			if strings.Contains(m.Content, "Verification failed after your edit") {
+				feedbackIdx = i
+			}
+		}
+	}
+	if len(toolIdx) != 2 {
+		t.Fatalf("expected 2 tool_result messages, got %d: %#v", len(toolIdx), msgs)
+	}
+	if feedbackIdx == -1 {
+		t.Fatalf("expected a self-correct feedback message, messages: %#v", msgs)
+	}
+	if toolIdx[1] != toolIdx[0]+1 {
+		t.Fatalf("tool_results must be contiguous, got indices %v: %#v", toolIdx, msgs)
+	}
+	if feedbackIdx < toolIdx[1] {
+		t.Fatalf("self-correct feedback (idx %d) must come after both tool_results %v", feedbackIdx, toolIdx)
 	}
 }
 

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -568,6 +568,67 @@ func TestRunDefersSelfCorrectFeedbackUntilAfterToolBatch(t *testing.T) {
 	}
 }
 
+func TestRunBatchesSelfCorrectOncePerTurn(t *testing.T) {
+	// Two mutating tool calls in one assistant turn must trigger a single
+	// AfterEdit over the union of changed files — not one per call — so the per-run
+	// attempt budget isn't consumed twice and an intermediate edit isn't verified
+	// after a later call in the same turn supersedes it.
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "write_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"path":"a.txt","content":"hello"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-2", ToolName: "write_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-2", ArgumentsFragment: `{"path":"b.txt","content":"hello"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-2"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+
+	corrector := NewSelfCorrector(root, erroringChecker{err: errors.New("boom")}, nil, SelfCorrectConfig{
+		Enabled:    true,
+		IncludeLSP: true,
+		Autonomy:   "high",
+	})
+
+	if _, err := Run(context.Background(), "go", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		SelfCorrect:    corrector,
+		OnPermissionRequest: func(_ context.Context, _ PermissionRequest) (PermissionDecision, error) {
+			return PermissionDecision{Action: PermissionDecisionAllow, Reason: "test"}, nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// One AfterEdit for the whole turn -> exactly one corrective attempt consumed
+	// (the old per-call path would have consumed two).
+	if corrector.attempts != 1 {
+		t.Fatalf("AfterEdit should run once per turn (attempts=1), got %d", corrector.attempts)
+	}
+	feedbackCount := 0
+	for _, m := range provider.requests[1].Messages {
+		if m.Role == zeroruntime.MessageRoleUser && strings.Contains(m.Content, "Verification failed after your edit") {
+			feedbackCount++
+		}
+	}
+	if feedbackCount != 1 {
+		t.Fatalf("expected exactly one self-correct feedback message, got %d", feedbackCount)
+	}
+}
+
 func TestRunDeniesPromptToolWithoutUnsafePermission(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()

--- a/internal/agent/selfcorrect.go
+++ b/internal/agent/selfcorrect.go
@@ -1,0 +1,239 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/lsp"
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/verify"
+)
+
+// defaultSelfCorrectMaxAttempts bounds how many corrective rounds a single run
+// will drive before giving up, so an unattended run can never loop forever.
+const defaultSelfCorrectMaxAttempts = 3
+
+// diagnosticsChecker returns the diagnostics for a single (absolute) file path.
+// *lsp.Manager is adapted to this via lspDiagnosticsChecker; tests inject a fake.
+type diagnosticsChecker interface {
+	Check(ctx context.Context, path string) ([]lsp.Diagnostic, error)
+}
+
+// projectVerifier runs the workspace's verification plan once and reports it.
+// The default implementation is DetectPlan + verify.Run; tests inject a fake.
+type projectVerifier interface {
+	Verify(ctx context.Context) (verify.Report, error)
+}
+
+// SelfCorrectConfig controls the post-edit verify-and-correct cycle.
+type SelfCorrectConfig struct {
+	Enabled      bool
+	MaxAttempts  int
+	IncludeTests bool
+	IncludeLSP   bool
+	Autonomy     string // low | medium | high
+}
+
+// Outcome reports what a self-correct round decided, for observability/tests.
+type Outcome string
+
+const (
+	OutcomeDisabled   Outcome = "disabled"   // self-correct off, or nothing to check
+	OutcomePassed     Outcome = "passed"     // verification passed; nothing to do
+	OutcomeCorrecting Outcome = "correcting" // failed; feedback issued for the model to fix
+	OutcomeReported   Outcome = "reported"   // failed; low autonomy, reported but no auto-fix
+	OutcomeAborted    Outcome = "aborted"    // failed but the correction budget is exhausted
+)
+
+// CorrectionReport is the unified result of a post-edit verification pass.
+type CorrectionReport struct {
+	LSPDiagnostics map[string][]lsp.Diagnostic // path -> error diagnostics
+	VerifyReport   verify.Report
+	Failed         bool
+}
+
+// SelfCorrector runs verification after a mutating edit and, when it fails,
+// synthesizes corrective feedback for the model — bounded by a per-run attempt
+// budget and gated by the autonomy ceiling. One instance per run (it holds the
+// attempt counter). A nil *SelfCorrector is a no-op.
+type SelfCorrector struct {
+	workspaceRoot string
+	checker       diagnosticsChecker
+	verifier      projectVerifier
+	cfg           SelfCorrectConfig
+	attempts      int
+}
+
+// NewSelfCorrector builds a self-corrector. checker/verifier may be nil to
+// disable that half of verification (e.g. no LSP server, or tests off).
+func NewSelfCorrector(workspaceRoot string, checker diagnosticsChecker, verifier projectVerifier, cfg SelfCorrectConfig) *SelfCorrector {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = defaultSelfCorrectMaxAttempts
+	}
+	return &SelfCorrector{workspaceRoot: workspaceRoot, checker: checker, verifier: verifier, cfg: cfg}
+}
+
+// AfterEdit runs a verification pass over the files a mutating tool changed and
+// returns corrective feedback (empty when nothing actionable) plus the outcome.
+// The loop appends any non-empty feedback to the conversation so the model can
+// fix the problem on its next turn.
+func (sc *SelfCorrector) AfterEdit(ctx context.Context, changedFiles []string) (string, Outcome) {
+	if sc == nil || !sc.cfg.Enabled || len(changedFiles) == 0 {
+		return "", OutcomeDisabled
+	}
+
+	report := sc.inspect(ctx, changedFiles)
+	if !report.Failed {
+		return "", OutcomePassed
+	}
+
+	// Low autonomy reports the failure but never starts an auto-fix round.
+	if !autonomyAllowsAutoCorrect(sc.cfg.Autonomy) {
+		return sc.feedback(report, false), OutcomeReported
+	}
+
+	if sc.attempts >= sc.cfg.MaxAttempts {
+		return abortedSelfCorrectNotice(sc.cfg.MaxAttempts), OutcomeAborted
+	}
+	sc.attempts++
+	return sc.feedback(report, true), OutcomeCorrecting
+}
+
+// inspect collects LSP error diagnostics for the changed files and runs the
+// project verification plan, marking Failed on any LSP error or verify failure.
+func (sc *SelfCorrector) inspect(ctx context.Context, changedFiles []string) CorrectionReport {
+	report := CorrectionReport{LSPDiagnostics: map[string][]lsp.Diagnostic{}}
+
+	if sc.cfg.IncludeLSP && sc.checker != nil {
+		for _, file := range changedFiles {
+			abs := sc.absPath(file)
+			diags, err := sc.checker.Check(ctx, abs)
+			if err != nil {
+				continue
+			}
+			if errs := lsp.FilterBySeverity(diags, lsp.SeverityError); len(errs) > 0 {
+				report.LSPDiagnostics[file] = errs
+				report.Failed = true
+			}
+		}
+	}
+
+	if sc.cfg.IncludeTests && sc.verifier != nil {
+		if vr, err := sc.verifier.Verify(ctx); err == nil {
+			report.VerifyReport = vr
+			if !vr.OK {
+				report.Failed = true
+			}
+		}
+	}
+	return report
+}
+
+// feedback synthesizes the model-facing message. corrective=false is the
+// low-autonomy reporting variant.
+func (sc *SelfCorrector) feedback(report CorrectionReport, corrective bool) string {
+	var b strings.Builder
+	if corrective {
+		b.WriteString("Verification failed after your edit. Fix these and continue:\n")
+	} else {
+		b.WriteString("Verification failed after your edit (auto-correction is off at low autonomy; reporting only):\n")
+	}
+
+	for file, diags := range report.LSPDiagnostics {
+		b.WriteString(lsp.FormatDiagnostics(file, diags))
+		b.WriteString("\n")
+	}
+	for _, result := range report.VerifyReport.Results {
+		if result.Status == verify.StatusPass {
+			continue
+		}
+		fmt.Fprintf(&b, "%s (%s): %s\n", result.Name, strings.Join(result.Command, " "), result.Status)
+		for _, line := range verifyResultLines(result) {
+			b.WriteString("  " + line + "\n")
+		}
+	}
+
+	// Secret-scrub the whole message: verify/LSP output can echo args, paths, env.
+	return strings.TrimRight(redaction.RedactString(b.String(), redaction.Options{}), "\n")
+}
+
+// verifyResultLines returns the most useful, already-trimmed output for a failing
+// check: the captured summary lines if present, else a trimmed stderr/stdout/err.
+func verifyResultLines(result verify.Result) []string {
+	if result.OutputSummary != nil && len(result.OutputSummary.Lines) > 0 {
+		return result.OutputSummary.Lines
+	}
+	for _, candidate := range []string{result.Stderr, result.Stdout, result.Error} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return strings.Split(trimmed, "\n")
+		}
+	}
+	return nil
+}
+
+func (sc *SelfCorrector) absPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(sc.workspaceRoot, path)
+}
+
+func autonomyAllowsAutoCorrect(autonomy string) bool {
+	switch strings.ToLower(strings.TrimSpace(autonomy)) {
+	case "medium", "high":
+		return true
+	default:
+		// low / unset: conservative — report, don't auto-attempt.
+		return false
+	}
+}
+
+func abortedSelfCorrectNotice(maxAttempts int) string {
+	return fmt.Sprintf("Verification is still failing after %d self-correction attempts; stopping auto-correction. Review the remaining failures and decide how to proceed.", maxAttempts)
+}
+
+// lspDiagnosticsChecker adapts *lsp.Manager to diagnosticsChecker by reading the
+// file's current contents before asking the manager to check it.
+type lspDiagnosticsChecker struct {
+	manager *lsp.Manager
+}
+
+// NewLSPDiagnosticsChecker wraps an *lsp.Manager for use as a SelfCorrector
+// checker. Returns nil when manager is nil so self-correct cleanly skips LSP.
+func NewLSPDiagnosticsChecker(manager *lsp.Manager) diagnosticsChecker {
+	if manager == nil {
+		return nil
+	}
+	return lspDiagnosticsChecker{manager: manager}
+}
+
+func (c lspDiagnosticsChecker) Check(ctx context.Context, path string) ([]lsp.Diagnostic, error) {
+	text, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err // unreadable (e.g. deleted) -> let the caller decide
+	}
+	return c.manager.Check(ctx, path, string(text))
+}
+
+// detectPlanVerifier is the default projectVerifier: detect the plan once per
+// run and execute it with verify.Run.
+type detectPlanVerifier struct {
+	root    string
+	options verify.RunOptions
+}
+
+// NewProjectVerifier builds the default verifier rooted at workspaceRoot.
+func NewProjectVerifier(workspaceRoot string) projectVerifier {
+	return detectPlanVerifier{root: workspaceRoot}
+}
+
+func (v detectPlanVerifier) Verify(ctx context.Context) (verify.Report, error) {
+	plan, err := verify.DetectPlan(v.root)
+	if err != nil {
+		return verify.Report{}, err
+	}
+	return verify.Run(ctx, plan, v.options), nil
+}

--- a/internal/agent/selfcorrect.go
+++ b/internal/agent/selfcorrect.go
@@ -52,7 +52,12 @@ const (
 type CorrectionReport struct {
 	LSPDiagnostics map[string][]lsp.Diagnostic // path -> error diagnostics
 	VerifyReport   verify.Report
-	Failed         bool
+	// InspectErrors holds non-degradable verification failures (an LSP
+	// startup/sync error, an unreadable changed file, or plan detection failing).
+	// These are distinct from diagnostics and must fail the pass rather than be
+	// silently swallowed into a false "passed".
+	InspectErrors []string
+	Failed        bool
 }
 
 // SelfCorrector runs verification after a mutating edit and, when it fails,
@@ -112,6 +117,12 @@ func (sc *SelfCorrector) inspect(ctx context.Context, changedFiles []string) Cor
 			abs := sc.absPath(file)
 			diags, err := sc.checker.Check(ctx, abs)
 			if err != nil {
+				// Manager.Check degrades missing servers / unsupported files to
+				// (nil, nil), so a non-nil error here is a real failure (LSP
+				// startup/sync, or an unreadable changed file). Surface it instead
+				// of silently passing.
+				report.InspectErrors = append(report.InspectErrors, fmt.Sprintf("%s: %v", file, err))
+				report.Failed = true
 				continue
 			}
 			if errs := lsp.FilterBySeverity(diags, lsp.SeverityError); len(errs) > 0 {
@@ -122,7 +133,14 @@ func (sc *SelfCorrector) inspect(ctx context.Context, changedFiles []string) Cor
 	}
 
 	if sc.cfg.IncludeTests && sc.verifier != nil {
-		if vr, err := sc.verifier.Verify(ctx); err == nil {
+		vr, err := sc.verifier.Verify(ctx)
+		if err != nil {
+			// "No plan / no tests" is not an error (DetectPlan returns an empty
+			// plan), so a non-nil error means verification could not run at all —
+			// don't let that masquerade as a pass.
+			report.InspectErrors = append(report.InspectErrors, fmt.Sprintf("verification could not run: %v", err))
+			report.Failed = true
+		} else {
 			report.VerifyReport = vr
 			if !vr.OK {
 				report.Failed = true
@@ -142,6 +160,9 @@ func (sc *SelfCorrector) feedback(report CorrectionReport, corrective bool) stri
 		b.WriteString("Verification failed after your edit (auto-correction is off at low autonomy; reporting only):\n")
 	}
 
+	for _, msg := range report.InspectErrors {
+		fmt.Fprintf(&b, "could not verify after edit: %s\n", msg)
+	}
 	for file, diags := range report.LSPDiagnostics {
 		b.WriteString(lsp.FormatDiagnostics(file, diags))
 		b.WriteString("\n")

--- a/internal/agent/selfcorrect_test.go
+++ b/internal/agent/selfcorrect_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -32,6 +33,53 @@ type fakeChecker struct {
 
 func (f fakeChecker) Check(_ context.Context, path string) ([]lsp.Diagnostic, error) {
 	return f.byPath[path], nil
+}
+
+type erroringChecker struct{ err error }
+
+func (e erroringChecker) Check(context.Context, string) ([]lsp.Diagnostic, error) {
+	return nil, e.err
+}
+
+type erroringVerifier struct{ err error }
+
+func (e erroringVerifier) Verify(context.Context) (verify.Report, error) {
+	return verify.Report{}, e.err
+}
+
+func TestSelfCorrectSurfacesCheckerErrorInsteadOfPassing(t *testing.T) {
+	// Manager.Check degrades missing servers to (nil, nil); a real error (LSP
+	// startup/sync failure or unreadable file) must fail the pass, not be swallowed
+	// into OutcomePassed.
+	sc := NewSelfCorrector("/root", erroringChecker{err: errors.New("lsp server crashed")}, nil, SelfCorrectConfig{
+		Enabled:    true,
+		IncludeLSP: true,
+		Autonomy:   "high",
+	})
+	feedback, outcome := sc.AfterEdit(context.Background(), []string{"a.go"})
+	if outcome != OutcomeCorrecting {
+		t.Fatalf("outcome = %q, want %q (a checker error must not pass)", outcome, OutcomeCorrecting)
+	}
+	if !strings.Contains(feedback, "lsp server crashed") {
+		t.Fatalf("feedback should surface the checker error, got: %q", feedback)
+	}
+}
+
+func TestSelfCorrectSurfacesVerifierErrorInsteadOfPassing(t *testing.T) {
+	// DetectPlan returns an empty plan (not an error) when no tests exist, so a
+	// non-nil Verify error means verification could not run — it must fail the pass.
+	sc := NewSelfCorrector("/root", nil, erroringVerifier{err: errors.New("plan detection failed")}, SelfCorrectConfig{
+		Enabled:      true,
+		IncludeTests: true,
+		Autonomy:     "high",
+	})
+	feedback, outcome := sc.AfterEdit(context.Background(), []string{"a.go"})
+	if outcome != OutcomeCorrecting {
+		t.Fatalf("outcome = %q, want %q (a verifier error must not pass)", outcome, OutcomeCorrecting)
+	}
+	if !strings.Contains(feedback, "plan detection failed") {
+		t.Fatalf("feedback should surface the verifier error, got: %q", feedback)
+	}
 }
 
 func TestLSPDiagnosticsCheckerPropagatesReadError(t *testing.T) {

--- a/internal/agent/selfcorrect_test.go
+++ b/internal/agent/selfcorrect_test.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/lsp"
+	"github.com/Gitlawb/zero/internal/verify"
+)
+
+type fakeVerifier struct {
+	reports []verify.Report
+	calls   int
+}
+
+func (f *fakeVerifier) Verify(context.Context) (verify.Report, error) {
+	report := verify.Report{OK: true}
+	switch {
+	case f.calls < len(f.reports):
+		report = f.reports[f.calls]
+	case len(f.reports) > 0:
+		report = f.reports[len(f.reports)-1]
+	}
+	f.calls++
+	return report, nil
+}
+
+type fakeChecker struct {
+	byPath map[string][]lsp.Diagnostic
+}
+
+func (f fakeChecker) Check(_ context.Context, path string) ([]lsp.Diagnostic, error) {
+	return f.byPath[path], nil
+}
+
+func TestLSPDiagnosticsCheckerPropagatesReadError(t *testing.T) {
+	// A read failure (e.g. the edit deleted the file) must propagate so callers
+	// can decide how to handle it, rather than being swallowed as "no diagnostics".
+	// manager is never reached on a read error, so a nil manager is fine here.
+	c := lspDiagnosticsChecker{}
+	if _, err := c.Check(context.Background(), "/nonexistent/zero-selfcorrect/missing.go"); err == nil {
+		t.Fatal("expected Check to propagate the file-read error, got nil")
+	}
+}
+
+func failingReport(stderr string) verify.Report {
+	return verify.Report{
+		OK: false,
+		Results: []verify.Result{{
+			Name:    "go test",
+			Command: []string{"go", "test", "./..."},
+			Status:  verify.StatusFail,
+			Stderr:  stderr,
+		}},
+	}
+}
+
+func newTestCorrector(checker diagnosticsChecker, verifier projectVerifier, autonomy string, maxAttempts int) *SelfCorrector {
+	return NewSelfCorrector("", checker, verifier, SelfCorrectConfig{
+		Enabled:      true,
+		IncludeLSP:   checker != nil,
+		IncludeTests: verifier != nil,
+		Autonomy:     autonomy,
+		MaxAttempts:  maxAttempts,
+	})
+}
+
+func TestSelfCorrectPassesWithNoFailures(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{{OK: true}}}
+	sc := newTestCorrector(nil, v, "high", 3)
+	if fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); fb != "" || oc != OutcomePassed {
+		t.Fatalf("expected passed/no-feedback, got %q / %s", fb, oc)
+	}
+}
+
+func TestSelfCorrectFailsThenPasses(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("--- FAIL: TestX"), {OK: true}}}
+	sc := newTestCorrector(nil, v, "high", 3)
+
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeCorrecting || !strings.Contains(fb, "Fix these and continue") || !strings.Contains(fb, "go test") {
+		t.Fatalf("round 1 = %q / %s", fb, oc)
+	}
+	fb2, oc2 := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc2 != OutcomePassed || fb2 != "" {
+		t.Fatalf("round 2 should pass cleanly, got %q / %s", fb2, oc2)
+	}
+}
+
+func TestSelfCorrectAbortsAtMaxAttempts(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("boom")}} // always fails
+	sc := newTestCorrector(nil, v, "high", 2)
+
+	for i := 1; i <= 2; i++ {
+		if _, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); oc != OutcomeCorrecting {
+			t.Fatalf("attempt %d outcome = %s, want correcting", i, oc)
+		}
+	}
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeAborted {
+		t.Fatalf("third round outcome = %s, want aborted", oc)
+	}
+	if !strings.Contains(fb, "stopping auto-correction") {
+		t.Fatalf("abort notice = %q", fb)
+	}
+	if sc.attempts != 2 {
+		t.Fatalf("correction attempts exceeded the ceiling: %d", sc.attempts)
+	}
+}
+
+func TestSelfCorrectSkipsWhenNoChangedFiles(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("x")}}
+	sc := newTestCorrector(nil, v, "high", 3)
+	if fb, oc := sc.AfterEdit(context.Background(), nil); fb != "" || oc != OutcomeDisabled {
+		t.Fatalf("read-only (no changes) should skip, got %q / %s", fb, oc)
+	}
+	if v.calls != 0 {
+		t.Fatal("verification must not run when nothing changed")
+	}
+}
+
+func TestSelfCorrectLowAutonomyReportsButDoesNotAttempt(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("FAIL")}}
+	sc := newTestCorrector(nil, v, "low", 3)
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeReported {
+		t.Fatalf("low autonomy outcome = %s, want reported", oc)
+	}
+	if !strings.Contains(fb, "reporting only") {
+		t.Fatalf("expected a reporting-only message, got %q", fb)
+	}
+	if sc.attempts != 0 {
+		t.Fatalf("low autonomy must not consume a correction attempt, got %d", sc.attempts)
+	}
+}
+
+func TestSelfCorrectLSPOnlyFailureFeedsDiagnostics(t *testing.T) {
+	checker := fakeChecker{byPath: map[string][]lsp.Diagnostic{
+		"main.go": {{
+			Severity: lsp.SeverityError,
+			Message:  "undefined: foo",
+			Range:    lsp.Range{Start: lsp.Position{Line: 4, Character: 1}},
+		}},
+	}}
+	v := &fakeVerifier{reports: []verify.Report{{OK: true}}} // tests pass; only LSP fails
+	sc := newTestCorrector(checker, v, "high", 3)
+
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeCorrecting {
+		t.Fatalf("LSP error should drive a correction, got %s", oc)
+	}
+	if !strings.Contains(fb, "main.go:5:2: error: undefined: foo") {
+		t.Fatalf("feedback missing formatted diagnostic: %q", fb)
+	}
+}
+
+func TestSelfCorrectRedactsSecretsInFeedback(t *testing.T) {
+	secret := "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+	v := &fakeVerifier{reports: []verify.Report{failingReport("auth failed with " + secret)}}
+	sc := newTestCorrector(nil, v, "high", 3)
+	fb, _ := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if strings.Contains(fb, secret) {
+		t.Fatalf("secret leaked into self-correct feedback: %q", fb)
+	}
+}
+
+func TestSelfCorrectDisabledIsNoop(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("x")}}
+	sc := NewSelfCorrector("", nil, v, SelfCorrectConfig{Enabled: false, IncludeTests: true, Autonomy: "high"})
+	if fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); fb != "" || oc != OutcomeDisabled {
+		t.Fatalf("disabled corrector should no-op, got %q / %s", fb, oc)
+	}
+	if v.calls != 0 {
+		t.Fatal("disabled corrector must not verify")
+	}
+}
+
+func TestNilSelfCorrectorIsSafe(t *testing.T) {
+	var sc *SelfCorrector
+	if fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); fb != "" || oc != OutcomeDisabled {
+		t.Fatalf("nil corrector should no-op, got %q / %s", fb, oc)
+	}
+}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -201,6 +201,12 @@ type Options struct {
 	// request), so every existing caller is unaffected. A returned error is
 	// non-fatal: the run continues on the current model.
 	ModelSwitcher func(ctx context.Context, modelID string) (Provider, error)
+	// SelfCorrect, when set, runs a post-edit verify-and-correct cycle after a
+	// mutating tool call: it verifies the changed files (LSP diagnostics + project
+	// tests) and feeds failures back to the model to fix, bounded by an attempt
+	// ceiling and the autonomy gate. nil disables it entirely (the loop is
+	// byte-identical to before). One instance per run — it holds attempt state.
+	SelfCorrect *SelfCorrector
 }
 
 type Result struct {

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -99,6 +99,14 @@ func (c *Client) SetNotificationHandler(handler NotificationHandler) {
 // Call sends a request and blocks until the matching response arrives, the
 // context is cancelled, or the connection closes.
 func (c *Client) Call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	// A closed client is unusable: don't register a pending entry that nothing
+	// will ever resolve.
+	select {
+	case <-c.closed:
+		return nil, c.readError()
+	default:
+	}
+
 	c.mu.Lock()
 	c.nextID++
 	id := c.nextID
@@ -209,6 +217,13 @@ func (c *Client) readError() error {
 }
 
 func (c *Client) write(payload any) error {
+	// Reject writes once the client is closed so Notify (and Call's request write)
+	// can't keep pushing frames onto a dead connection.
+	select {
+	case <-c.closed:
+		return c.readError()
+	default:
+	}
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	return writeMessage(c.writer, payload)

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -1,0 +1,263 @@
+package lsp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// NotificationHandler receives server->client notifications (e.g.
+// textDocument/publishDiagnostics). params is the raw JSON payload.
+type NotificationHandler func(method string, params json.RawMessage)
+
+// Client speaks JSON-RPC 2.0 with LSP framing (Content-Length headers) over a
+// reader/writer pair. It is transport-agnostic: server.go wires it to a process's
+// stdout/stdin, and tests wire it to in-memory pipes. Safe for concurrent Call /
+// Notify from multiple goroutines.
+type Client struct {
+	writeMu sync.Mutex // serializes outgoing frames
+	writer  io.Writer
+
+	mu      sync.Mutex // guards nextID + pending + handler
+	nextID  int64
+	pending map[int64]chan rpcResponse
+	handler NotificationHandler
+
+	closeOnce sync.Once
+	closed    chan struct{}
+	readErr   error
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *rpcError) Error() string {
+	return fmt.Sprintf("lsp error %d: %s", e.Code, e.Message)
+}
+
+type rpcResponse struct {
+	Result json.RawMessage
+	Err    *rpcError
+}
+
+type outgoingRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type outgoingNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type outgoingReply struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result"`
+}
+
+type incomingMessage struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+	Params json.RawMessage `json:"params"`
+}
+
+// NewClient starts a client reading framed messages from r and writing to w. It
+// spawns a read-loop goroutine that lives until r returns an error (e.g. the
+// server process exits); call Close to stop using the client.
+func NewClient(r io.Reader, w io.Writer) *Client {
+	client := &Client{
+		writer:  w,
+		pending: make(map[int64]chan rpcResponse),
+		closed:  make(chan struct{}),
+	}
+	go client.readLoop(bufio.NewReader(r))
+	return client
+}
+
+// SetNotificationHandler installs the handler for server->client notifications.
+func (c *Client) SetNotificationHandler(handler NotificationHandler) {
+	c.mu.Lock()
+	c.handler = handler
+	c.mu.Unlock()
+}
+
+// Call sends a request and blocks until the matching response arrives, the
+// context is cancelled, or the connection closes.
+func (c *Client) Call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	c.mu.Lock()
+	c.nextID++
+	id := c.nextID
+	ch := make(chan rpcResponse, 1)
+	c.pending[id] = ch
+	c.mu.Unlock()
+
+	if err := c.write(outgoingRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case <-ctx.Done():
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	case <-c.closed:
+		return nil, c.readError()
+	case resp := <-ch:
+		if resp.Err != nil {
+			return nil, resp.Err
+		}
+		return resp.Result, nil
+	}
+}
+
+// Notify sends a notification (no response expected).
+func (c *Client) Notify(_ context.Context, method string, params any) error {
+	return c.write(outgoingNotification{JSONRPC: "2.0", Method: method, Params: params})
+}
+
+// Close stops the client and fails any in-flight calls.
+func (c *Client) Close() error {
+	c.failPending(errors.New("lsp client closed"))
+	return nil
+}
+
+func (c *Client) readLoop(reader *bufio.Reader) {
+	for {
+		body, err := readMessage(reader)
+		if err != nil {
+			c.failPending(err)
+			return
+		}
+		var msg incomingMessage
+		if err := json.Unmarshal(body, &msg); err != nil {
+			continue // skip a malformed frame rather than tearing down the session
+		}
+		hasID := len(msg.ID) > 0 && string(msg.ID) != "null"
+		switch {
+		case msg.Method != "" && hasID:
+			// Server->client request. We don't implement these yet, but a reply is
+			// required or the server can block waiting on it (e.g. registerCapability).
+			_ = c.write(outgoingReply{JSONRPC: "2.0", ID: msg.ID, Result: nil})
+		case msg.Method != "":
+			c.mu.Lock()
+			handler := c.handler
+			c.mu.Unlock()
+			if handler != nil {
+				handler(msg.Method, msg.Params)
+			}
+		case hasID:
+			var id int64
+			if err := json.Unmarshal(msg.ID, &id); err == nil {
+				c.deliver(id, rpcResponse{Result: msg.Result, Err: msg.Error})
+			}
+		}
+	}
+}
+
+func (c *Client) deliver(id int64, resp rpcResponse) {
+	c.mu.Lock()
+	ch, ok := c.pending[id]
+	if ok {
+		delete(c.pending, id)
+	}
+	c.mu.Unlock()
+	if ok {
+		ch <- resp
+	}
+}
+
+func (c *Client) failPending(err error) {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		c.readErr = err
+		pending := c.pending
+		c.pending = make(map[int64]chan rpcResponse)
+		c.mu.Unlock()
+		for _, ch := range pending {
+			ch <- rpcResponse{Err: &rpcError{Code: -1, Message: err.Error()}}
+		}
+		close(c.closed)
+	})
+}
+
+func (c *Client) readError() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.readErr != nil {
+		return c.readErr
+	}
+	return errors.New("lsp client closed")
+}
+
+func (c *Client) write(payload any) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return writeMessage(c.writer, payload)
+}
+
+// writeMessage frames a JSON-RPC payload with the LSP Content-Length header.
+func writeMessage(w io.Writer, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Content-Length: %d\r\n\r\n", len(data)); err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// readMessage reads one LSP-framed message: headers terminated by a blank line,
+// then exactly Content-Length bytes of JSON body. Extra headers are ignored.
+func readMessage(reader *bufio.Reader) ([]byte, error) {
+	contentLength := -1
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			break
+		}
+		name, value, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(name), "Content-Length") {
+			n, err := strconv.Atoi(strings.TrimSpace(value))
+			if err != nil || n < 0 {
+				return nil, fmt.Errorf("invalid Content-Length %q", value)
+			}
+			contentLength = n
+		}
+	}
+	if contentLength < 0 {
+		return nil, errors.New("message missing Content-Length header")
+	}
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(reader, body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -226,3 +226,20 @@ func TestClientNotificationHandler(t *testing.T) {
 		t.Fatal("notification handler was not called")
 	}
 }
+
+func TestClientRejectsCallsAfterClose(t *testing.T) {
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+	client := NewClient(clientReader, clientWriter)
+	defer serverWriter.Close()
+	defer clientWriter.Close()
+	_ = serverReader
+
+	client.Close()
+	if _, err := client.Call(context.Background(), "initialize", nil); err == nil {
+		t.Fatal("Call after Close must return an error")
+	}
+	if err := client.Notify(context.Background(), "initialized", nil); err == nil {
+		t.Fatal("Notify after Close must return an error")
+	}
+}

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -1,0 +1,228 @@
+package lsp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMessageFramingRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	payload := outgoingRequest{JSONRPC: "2.0", ID: 7, Method: "initialize", Params: map[string]any{"rootUri": "file:///r"}}
+	if err := writeMessage(&buf, payload); err != nil {
+		t.Fatalf("writeMessage: %v", err)
+	}
+	body, err := readMessage(bufio.NewReader(&buf))
+	if err != nil {
+		t.Fatalf("readMessage: %v", err)
+	}
+	var got incomingMessage
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Method != "initialize" || string(got.ID) != "7" {
+		t.Fatalf("round-trip mismatch: %s", body)
+	}
+}
+
+func TestReadMessageIgnoresExtraHeaders(t *testing.T) {
+	raw := "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: 17\r\n\r\n{\"jsonrpc\":\"2.0\"}"
+	body, err := readMessage(bufio.NewReader(strings.NewReader(raw)))
+	if err != nil {
+		t.Fatalf("readMessage: %v", err)
+	}
+	if string(body) != `{"jsonrpc":"2.0"}` {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestReadMessageRejectsMissingContentLength(t *testing.T) {
+	if _, err := readMessage(bufio.NewReader(strings.NewReader("X: y\r\n\r\n{}"))); err == nil {
+		t.Fatal("expected error for missing Content-Length")
+	}
+}
+
+func TestClientMatchesConcurrentResponsesByID(t *testing.T) {
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+	client := NewClient(clientReader, clientWriter)
+	defer client.Close()
+	defer serverWriter.Close()
+	defer clientWriter.Close()
+
+	// Stub server: read BOTH requests, then reply in REVERSE order so a broken
+	// id router would deliver a response to the wrong caller.
+	go func() {
+		reader := bufio.NewReader(serverReader)
+		type req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		var reqs []req
+		for len(reqs) < 2 {
+			body, err := readMessage(reader)
+			if err != nil {
+				return
+			}
+			var r req
+			_ = json.Unmarshal(body, &r)
+			reqs = append(reqs, r)
+		}
+		for i := len(reqs) - 1; i >= 0; i-- {
+			_ = writeMessage(serverWriter, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      reqs[i].ID,
+				"result":  map[string]string{"method": reqs[i].Method},
+			})
+		}
+	}()
+
+	type outcome struct{ err error }
+	results := make(chan outcome, 2)
+	call := func(method string) {
+		raw, err := client.Call(context.Background(), method, nil)
+		if err != nil {
+			results <- outcome{err: err}
+			return
+		}
+		var got struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal(raw, &got); err != nil {
+			results <- outcome{err: err}
+			return
+		}
+		if got.Method != method {
+			results <- outcome{err: fmt.Errorf("id mismatch: sent %q, got response for %q", method, got.Method)}
+			return
+		}
+		results <- outcome{}
+	}
+	go call("alpha")
+	go call("beta")
+
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-results:
+			if r.err != nil {
+				t.Fatal(r.err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for responses")
+		}
+	}
+}
+
+func TestClientCallContextCancel(t *testing.T) {
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+	client := NewClient(clientReader, clientWriter)
+	defer client.Close()
+	defer serverWriter.Close()
+	defer clientWriter.Close()
+	// Drain requests but never reply, so the call must unblock via context.
+	go func() {
+		reader := bufio.NewReader(serverReader)
+		for {
+			if _, err := readMessage(reader); err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := client.Call(ctx, "initialize", nil); err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+func TestPerformInitializeHandshake(t *testing.T) {
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+	client := NewClient(clientReader, clientWriter)
+	defer client.Close()
+	defer serverWriter.Close()
+	defer clientWriter.Close()
+
+	initialized := make(chan struct{}, 1)
+	gotRootURI := make(chan string, 1)
+	go func() {
+		reader := bufio.NewReader(serverReader)
+		for {
+			body, err := readMessage(reader)
+			if err != nil {
+				return
+			}
+			var msg struct {
+				ID     json.RawMessage  `json:"id"`
+				Method string           `json:"method"`
+				Params InitializeParams `json:"params"`
+			}
+			_ = json.Unmarshal(body, &msg)
+			switch msg.Method {
+			case "initialize":
+				gotRootURI <- msg.Params.RootURI
+				_ = writeMessage(serverWriter, map[string]any{
+					"jsonrpc": "2.0",
+					"id":      msg.ID,
+					"result":  map[string]any{"capabilities": map[string]any{}},
+				})
+			case "initialized":
+				initialized <- struct{}{}
+			}
+		}
+	}()
+
+	if err := performInitialize(context.Background(), client, "/repo/project"); err != nil {
+		t.Fatalf("performInitialize: %v", err)
+	}
+	select {
+	case uri := <-gotRootURI:
+		if uri != PathToURI("/repo/project") {
+			t.Fatalf("rootUri = %q, want %q", uri, PathToURI("/repo/project"))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received initialize params")
+	}
+	select {
+	case <-initialized:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never received the initialized notification")
+	}
+}
+
+func TestClientNotificationHandler(t *testing.T) {
+	clientReader, serverWriter := io.Pipe()
+	serverReader, clientWriter := io.Pipe()
+	client := NewClient(clientReader, clientWriter)
+	defer client.Close()
+	defer serverWriter.Close()
+	defer clientWriter.Close()
+	_ = serverReader
+
+	received := make(chan string, 1)
+	client.SetNotificationHandler(func(method string, _ json.RawMessage) {
+		received <- method
+	})
+	_ = writeMessage(serverWriter, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "textDocument/publishDiagnostics",
+		"params":  map[string]any{"uri": "file:///x", "diagnostics": []any{}},
+	})
+
+	select {
+	case method := <-received:
+		if method != "textDocument/publishDiagnostics" {
+			t.Fatalf("notification method = %q", method)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification handler was not called")
+	}
+}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -21,6 +21,13 @@ func severityLabel(severity DiagnosticSeverity) string {
 	}
 }
 
+// collapseWhitespace flattens a (possibly multi-line) diagnostic message to a
+// single line so each formatted record stays "path:line:col: severity: message"
+// and downstream line-based parsing isn't broken by embedded \n / \t.
+func collapseWhitespace(message string) string {
+	return strings.Join(strings.Fields(message), " ")
+}
+
 // hasErrors reports whether any diagnostic is error severity.
 func hasErrors(diags []Diagnostic) bool {
 	for _, diag := range diags {
@@ -62,7 +69,7 @@ func FormatDiagnostics(path string, diags []Diagnostic) string {
 			diag.Range.Start.Line+1,
 			diag.Range.Start.Character+1,
 			severityLabel(diag.Severity),
-			strings.TrimSpace(diag.Message),
+			collapseWhitespace(diag.Message),
 		))
 	}
 	return strings.Join(lines, "\n")

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -1,0 +1,69 @@
+package lsp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// severityLabel maps the LSP severity enum to a short human label. An unset
+// severity (0) is treated as an error — the conservative choice for a tool whose
+// job is to stop broken edits.
+func severityLabel(severity DiagnosticSeverity) string {
+	switch severity {
+	case SeverityWarning:
+		return "warning"
+	case SeverityInformation:
+		return "info"
+	case SeverityHint:
+		return "hint"
+	default:
+		return "error"
+	}
+}
+
+// hasErrors reports whether any diagnostic is error severity.
+func hasErrors(diags []Diagnostic) bool {
+	for _, diag := range diags {
+		if diag.Severity == SeverityError || diag.Severity == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterBySeverity returns only diagnostics at or above (numerically at or below,
+// since Error=1 is most severe) the given severity.
+func FilterBySeverity(diags []Diagnostic, minimum DiagnosticSeverity) []Diagnostic {
+	out := make([]Diagnostic, 0, len(diags))
+	for _, diag := range diags {
+		sev := diag.Severity
+		if sev == 0 {
+			sev = SeverityError
+		}
+		if sev <= minimum {
+			out = append(out, diag)
+		}
+	}
+	return out
+}
+
+// FormatDiagnostics renders diagnostics as compact, model-readable lines:
+//
+//	path:line:col: severity: message
+//
+// Lines/columns are converted from LSP's zero-based positions to the one-based
+// form editors and compilers print. The path is passed in because a Diagnostic
+// carries only a range, not its document.
+func FormatDiagnostics(path string, diags []Diagnostic) string {
+	lines := make([]string, 0, len(diags))
+	for _, diag := range diags {
+		lines = append(lines, fmt.Sprintf("%s:%d:%d: %s: %s",
+			path,
+			diag.Range.Start.Line+1,
+			diag.Range.Start.Character+1,
+			severityLabel(diag.Severity),
+			strings.TrimSpace(diag.Message),
+		))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -1,0 +1,44 @@
+package lsp
+
+import "testing"
+
+func TestFormatDiagnosticsShape(t *testing.T) {
+	diags := []Diagnostic{
+		{Range: Range{Start: Position{Line: 9, Character: 4}}, Severity: SeverityError, Message: "undefined: foo"},
+		{Range: Range{Start: Position{Line: 0, Character: 0}}, Severity: SeverityWarning, Message: "unused import"},
+	}
+	got := FormatDiagnostics("internal/x/a.go", diags)
+	want := "internal/x/a.go:10:5: error: undefined: foo\ninternal/x/a.go:1:1: warning: unused import"
+	if got != want {
+		t.Fatalf("FormatDiagnostics =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestHasErrors(t *testing.T) {
+	if hasErrors([]Diagnostic{{Severity: SeverityWarning}}) {
+		t.Fatal("warnings are not errors")
+	}
+	if !hasErrors([]Diagnostic{{Severity: SeverityWarning}, {Severity: SeverityError}}) {
+		t.Fatal("an error diagnostic should be detected")
+	}
+	// Unset severity is treated as an error (conservative).
+	if !hasErrors([]Diagnostic{{Message: "no severity"}}) {
+		t.Fatal("unset severity should count as an error")
+	}
+}
+
+func TestFilterBySeverity(t *testing.T) {
+	diags := []Diagnostic{
+		{Severity: SeverityError, Message: "e"},
+		{Severity: SeverityWarning, Message: "w"},
+		{Severity: SeverityHint, Message: "h"},
+	}
+	errorsOnly := FilterBySeverity(diags, SeverityError)
+	if len(errorsOnly) != 1 || errorsOnly[0].Message != "e" {
+		t.Fatalf("error filter = %#v", errorsOnly)
+	}
+	upToWarning := FilterBySeverity(diags, SeverityWarning)
+	if len(upToWarning) != 2 {
+		t.Fatalf("warning filter should include error+warning, got %#v", upToWarning)
+	}
+}

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -42,3 +42,15 @@ func TestFilterBySeverity(t *testing.T) {
 		t.Fatalf("warning filter should include error+warning, got %#v", upToWarning)
 	}
 }
+
+func TestFormatDiagnosticsCollapsesMultilineMessage(t *testing.T) {
+	diags := []Diagnostic{{
+		Range:    Range{Start: Position{Line: 0, Character: 0}},
+		Severity: SeverityError,
+		Message:  "first line\n\tsecond   line",
+	}}
+	got := FormatDiagnostics("a.go", diags)
+	if want := "a.go:1:1: error: first line second line"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -23,11 +23,12 @@ type session struct {
 
 	mu           sync.Mutex
 	open         map[string]bool            // uri -> didOpen sent
-	versions     map[string]int             // uri -> current version
+	versions     map[string]int             // uri -> current (committed) version
 	diagnostics  map[string][]Diagnostic    // uri -> latest published diagnostics
 	lastPublish  map[string]time.Time       // uri -> time of last publish
 	publishCount map[string]int             // uri -> monotonic publish count
 	waiters      map[string][]chan struct{} // uri -> goroutines awaiting the next publish
+	fileLocks    map[string]*sync.Mutex     // uri -> per-document sync serializer
 }
 
 func newSession(server lspServer) *session {
@@ -40,6 +41,7 @@ func newSession(server lspServer) *session {
 		lastPublish:  map[string]time.Time{},
 		publishCount: map[string]int{},
 		waiters:      map[string][]chan struct{}{},
+		fileLocks:    map[string]*sync.Mutex{},
 	}
 	s.client.SetNotificationHandler(s.handleNotification)
 	return s
@@ -54,6 +56,14 @@ func (s *session) handleNotification(method string, params json.RawMessage) {
 		return
 	}
 	s.mu.Lock()
+	// Drop a delayed publish for a superseded version: if we've already synced a
+	// newer document version, an older version's diagnostics are stale and must
+	// not move the cache backward. Many servers omit the version (0) — only skip
+	// when the payload carries a strictly-older positive version.
+	if payload.Version > 0 && s.versions[payload.URI] > payload.Version {
+		s.mu.Unlock()
+		return
+	}
 	s.diagnostics[payload.URI] = payload.Diagnostics
 	s.lastPublish[payload.URI] = time.Now()
 	s.publishCount[payload.URI]++
@@ -66,28 +76,55 @@ func (s *session) handleNotification(method string, params json.RawMessage) {
 }
 
 // sync opens the document on first sight, otherwise sends a full-text change.
+// It holds a per-URI lock across the whole compute+notify so two concurrent
+// syncs of the same document can't race their didOpen/didChange writes onto the
+// wire out of order, and only commits the new version/open state after the
+// notification succeeds (a failed Notify leaves tracking unchanged).
 func (s *session) sync(ctx context.Context, absPath, languageID, text string) error {
 	uri := PathToURI(absPath)
+	lock := s.fileLock(uri)
+	lock.Lock()
+	defer lock.Unlock()
+
 	s.mu.Lock()
 	first := !s.open[uri]
-	if first {
-		s.open[uri] = true
-		s.versions[uri] = 1
-	} else {
-		s.versions[uri]++
+	nextVersion := 1
+	if !first {
+		nextVersion = s.versions[uri] + 1
 	}
-	version := s.versions[uri]
 	s.mu.Unlock()
 
+	var err error
 	if first {
-		return s.client.Notify(ctx, "textDocument/didOpen", map[string]any{
-			"textDocument": TextDocumentItem{URI: uri, LanguageID: languageID, Version: version, Text: text},
+		err = s.client.Notify(ctx, "textDocument/didOpen", map[string]any{
+			"textDocument": TextDocumentItem{URI: uri, LanguageID: languageID, Version: nextVersion, Text: text},
+		})
+	} else {
+		err = s.client.Notify(ctx, "textDocument/didChange", map[string]any{
+			"textDocument":   map[string]any{"uri": uri, "version": nextVersion},
+			"contentChanges": []any{map[string]any{"text": text}}, // full-document sync
 		})
 	}
-	return s.client.Notify(ctx, "textDocument/didChange", map[string]any{
-		"textDocument":   map[string]any{"uri": uri, "version": version},
-		"contentChanges": []any{map[string]any{"text": text}}, // full-document sync
-	})
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.open[uri] = true
+	s.versions[uri] = nextVersion
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *session) fileLock(uri string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lock, ok := s.fileLocks[uri]
+	if !ok {
+		lock = &sync.Mutex{}
+		s.fileLocks[uri] = lock
+	}
+	return lock
 }
 
 func (s *session) didClose(ctx context.Context, absPath string) error {
@@ -117,10 +154,12 @@ func (s *session) publishBaseline(uri string) int {
 
 // waitForDiagnostics blocks until a publish newer than baseline arrives for the
 // URI and the server then goes quiet for the debounce window, or until ctx is
-// done. Servers don't signal "analysis complete", so the debounce approximates
-// it: once a fresh publish lands, wait debounce for a follow-up, resetting on
-// each new publish.
-func (s *session) waitForDiagnostics(ctx context.Context, uri string, debounce time.Duration, baseline int) {
+// done. It returns true when a fresh publish was observed and false when ctx
+// expired before any did — so a caller can avoid returning a stale prior result
+// for newer text. Servers don't signal "analysis complete", so the debounce
+// approximates it: once a fresh publish lands, wait debounce for a follow-up,
+// resetting on each new publish.
+func (s *session) waitForDiagnostics(ctx context.Context, uri string, debounce time.Duration, baseline int) bool {
 	for {
 		s.mu.Lock()
 		ch := make(chan struct{})
@@ -133,7 +172,7 @@ func (s *session) waitForDiagnostics(ctx context.Context, uri string, debounce t
 			select {
 			case <-ctx.Done():
 				s.cancelWaiter(uri, ch)
-				return
+				return false // no fresh publish for this sync arrived in time
 			case <-ch:
 				continue // a fresh publish arrived; loop into the debounce check
 			}
@@ -142,20 +181,20 @@ func (s *session) waitForDiagnostics(ctx context.Context, uri string, debounce t
 		remaining := debounce - time.Since(last)
 		if remaining <= 0 {
 			s.cancelWaiter(uri, ch)
-			return
+			return true
 		}
 		timer := time.NewTimer(remaining)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			s.cancelWaiter(uri, ch)
-			return
+			return true // a fresh publish did arrive; ctx merely cut the debounce short
 		case <-ch:
 			timer.Stop()
 			continue // a newer publish arrived; re-arm the debounce
 		case <-timer.C:
 			s.cancelWaiter(uri, ch)
-			return // quiet for the full window
+			return true // quiet for the full window
 		}
 	}
 }

--- a/internal/lsp/documents.go
+++ b/internal/lsp/documents.go
@@ -1,0 +1,175 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// lspServer is the subset of *Server the session needs, so a session can be
+// driven by a stub over an in-memory pipe in tests.
+type lspServer interface {
+	Client() *Client
+	Shutdown(ctx context.Context) error
+}
+
+// session wraps one language-server connection with per-document version
+// tracking and a diagnostics store fed by textDocument/publishDiagnostics
+// notifications. Safe for concurrent use.
+type session struct {
+	server lspServer
+	client *Client
+
+	mu           sync.Mutex
+	open         map[string]bool            // uri -> didOpen sent
+	versions     map[string]int             // uri -> current version
+	diagnostics  map[string][]Diagnostic    // uri -> latest published diagnostics
+	lastPublish  map[string]time.Time       // uri -> time of last publish
+	publishCount map[string]int             // uri -> monotonic publish count
+	waiters      map[string][]chan struct{} // uri -> goroutines awaiting the next publish
+}
+
+func newSession(server lspServer) *session {
+	s := &session{
+		server:       server,
+		client:       server.Client(),
+		open:         map[string]bool{},
+		versions:     map[string]int{},
+		diagnostics:  map[string][]Diagnostic{},
+		lastPublish:  map[string]time.Time{},
+		publishCount: map[string]int{},
+		waiters:      map[string][]chan struct{}{},
+	}
+	s.client.SetNotificationHandler(s.handleNotification)
+	return s
+}
+
+func (s *session) handleNotification(method string, params json.RawMessage) {
+	if method != "textDocument/publishDiagnostics" {
+		return
+	}
+	var payload PublishDiagnosticsParams
+	if err := json.Unmarshal(params, &payload); err != nil {
+		return
+	}
+	s.mu.Lock()
+	s.diagnostics[payload.URI] = payload.Diagnostics
+	s.lastPublish[payload.URI] = time.Now()
+	s.publishCount[payload.URI]++
+	waiters := s.waiters[payload.URI]
+	delete(s.waiters, payload.URI)
+	s.mu.Unlock()
+	for _, ch := range waiters {
+		close(ch)
+	}
+}
+
+// sync opens the document on first sight, otherwise sends a full-text change.
+func (s *session) sync(ctx context.Context, absPath, languageID, text string) error {
+	uri := PathToURI(absPath)
+	s.mu.Lock()
+	first := !s.open[uri]
+	if first {
+		s.open[uri] = true
+		s.versions[uri] = 1
+	} else {
+		s.versions[uri]++
+	}
+	version := s.versions[uri]
+	s.mu.Unlock()
+
+	if first {
+		return s.client.Notify(ctx, "textDocument/didOpen", map[string]any{
+			"textDocument": TextDocumentItem{URI: uri, LanguageID: languageID, Version: version, Text: text},
+		})
+	}
+	return s.client.Notify(ctx, "textDocument/didChange", map[string]any{
+		"textDocument":   map[string]any{"uri": uri, "version": version},
+		"contentChanges": []any{map[string]any{"text": text}}, // full-document sync
+	})
+}
+
+func (s *session) didClose(ctx context.Context, absPath string) error {
+	uri := PathToURI(absPath)
+	s.mu.Lock()
+	delete(s.open, uri)
+	s.mu.Unlock()
+	return s.client.Notify(ctx, "textDocument/didClose", map[string]any{
+		"textDocument": map[string]any{"uri": uri},
+	})
+}
+
+func (s *session) diagnosticsFor(uri string) []Diagnostic {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Diagnostic(nil), s.diagnostics[uri]...)
+}
+
+// publishBaseline snapshots the current publish count for a URI, captured before
+// a sync so waitForDiagnostics can wait specifically for the publish that sync
+// triggers (not be satisfied by a stale earlier publish).
+func (s *session) publishBaseline(uri string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.publishCount[uri]
+}
+
+// waitForDiagnostics blocks until a publish newer than baseline arrives for the
+// URI and the server then goes quiet for the debounce window, or until ctx is
+// done. Servers don't signal "analysis complete", so the debounce approximates
+// it: once a fresh publish lands, wait debounce for a follow-up, resetting on
+// each new publish.
+func (s *session) waitForDiagnostics(ctx context.Context, uri string, debounce time.Duration, baseline int) {
+	for {
+		s.mu.Lock()
+		ch := make(chan struct{})
+		s.waiters[uri] = append(s.waiters[uri], ch)
+		count := s.publishCount[uri]
+		last := s.lastPublish[uri]
+		s.mu.Unlock()
+
+		if count <= baseline {
+			select {
+			case <-ctx.Done():
+				s.cancelWaiter(uri, ch)
+				return
+			case <-ch:
+				continue // a fresh publish arrived; loop into the debounce check
+			}
+		}
+
+		remaining := debounce - time.Since(last)
+		if remaining <= 0 {
+			s.cancelWaiter(uri, ch)
+			return
+		}
+		timer := time.NewTimer(remaining)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			s.cancelWaiter(uri, ch)
+			return
+		case <-ch:
+			timer.Stop()
+			continue // a newer publish arrived; re-arm the debounce
+		case <-timer.C:
+			s.cancelWaiter(uri, ch)
+			return // quiet for the full window
+		}
+	}
+}
+
+// cancelWaiter removes a still-open waiter (one a publish has not already closed
+// and cleared) so it can't leak or be closed twice.
+func (s *session) cancelWaiter(uri string, target chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := s.waiters[uri]
+	for i, ch := range list {
+		if ch == target {
+			s.waiters[uri] = append(list[:i], list[i+1:]...)
+			return
+		}
+	}
+}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -1,0 +1,142 @@
+package lsp
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// diagnosticsDebounce is how long to wait for a quiet period after the last
+// publish before treating a document's diagnostics as settled.
+const diagnosticsDebounce = 300 * time.Millisecond
+
+// serverStarter starts (and initializes) a language server. It is injectable so
+// tests can substitute a stub over an in-memory pipe instead of spawning a real
+// server.
+type serverStarter func(ctx context.Context, command []string, root string) (lspServer, error)
+
+func defaultStarter(ctx context.Context, command []string, root string) (lspServer, error) {
+	return StartServer(ctx, command, root)
+}
+
+// Manager is the single entry point the rest of ZERO uses for LSP. It owns one
+// long-lived server per language (lazily started, reused across calls — starting
+// gopls per edit would be far too slow), routes a file to the right server, and
+// degrades to "no diagnostics" when no server is available. Safe for concurrent
+// use.
+type Manager struct {
+	workspaceRoot string
+	debounce      time.Duration
+	starter       serverStarter
+
+	mu       sync.Mutex
+	sessions map[string]*session // keyed by server binary
+}
+
+// NewManager creates a Manager rooted at workspaceRoot.
+func NewManager(workspaceRoot string) *Manager {
+	return newManagerWithStarter(workspaceRoot, defaultStarter)
+}
+
+func newManagerWithStarter(workspaceRoot string, starter serverStarter) *Manager {
+	return &Manager{
+		workspaceRoot: workspaceRoot,
+		debounce:      diagnosticsDebounce,
+		starter:       starter,
+		sessions:      map[string]*session{},
+	}
+}
+
+// Check syncs the file's text to the right language server and returns the
+// settled diagnostics. A file whose extension has no configured/available server
+// returns (nil, nil): missing diagnostics are a graceful degrade, not an error.
+func (m *Manager) Check(ctx context.Context, path, text string) ([]Diagnostic, error) {
+	command, ok := ServerFor(path)
+	if !ok {
+		return nil, nil
+	}
+	languageID, _ := LanguageID(path)
+	abs := m.absPath(path)
+	uri := PathToURI(abs)
+
+	sess, err := m.sessionFor(ctx, command)
+	if err != nil {
+		return nil, err
+	}
+	baseline := sess.publishBaseline(uri)
+	if err := sess.sync(ctx, abs, languageID, text); err != nil {
+		return nil, err
+	}
+	sess.waitForDiagnostics(ctx, uri, m.debounce, baseline)
+	return sess.diagnosticsFor(uri), nil
+}
+
+// DiagnosticsFor returns the most recently published diagnostics for a file
+// without re-syncing. Empty when no server is running for it.
+func (m *Manager) DiagnosticsFor(path string) []Diagnostic {
+	command, ok := ServerFor(path)
+	if !ok {
+		return nil
+	}
+	m.mu.Lock()
+	sess := m.sessions[command[0]]
+	m.mu.Unlock()
+	if sess == nil {
+		return nil
+	}
+	return sess.diagnosticsFor(PathToURI(m.absPath(path)))
+}
+
+// HasErrors reports whether the file currently has any error-severity diagnostic.
+func (m *Manager) HasErrors(path string) bool {
+	return hasErrors(m.DiagnosticsFor(path))
+}
+
+// Shutdown stops every running server.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	sessions := m.sessions
+	m.sessions = map[string]*session{}
+	m.mu.Unlock()
+	for _, sess := range sessions {
+		_ = sess.server.Shutdown(ctx)
+	}
+	return nil
+}
+
+// sessionFor returns the running session for a server command, starting one if
+// needed. Concurrent first-callers double-check under the lock so only one server
+// is kept; a loser shuts its extra server down.
+func (m *Manager) sessionFor(ctx context.Context, command []string) (*session, error) {
+	key := command[0]
+	m.mu.Lock()
+	if sess, ok := m.sessions[key]; ok {
+		m.mu.Unlock()
+		return sess, nil
+	}
+	m.mu.Unlock()
+
+	server, err := m.starter(ctx, command, m.workspaceRoot)
+	if err != nil {
+		return nil, err
+	}
+	sess := newSession(server)
+
+	m.mu.Lock()
+	if existing, ok := m.sessions[key]; ok {
+		m.mu.Unlock()
+		_ = server.Shutdown(context.Background()) // lost the start race; discard ours
+		return existing, nil
+	}
+	m.sessions[key] = sess
+	m.mu.Unlock()
+	return sess, nil
+}
+
+func (m *Manager) absPath(path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(m.workspaceRoot, path)
+}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"errors"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"time"
@@ -63,6 +64,13 @@ func (m *Manager) Check(ctx context.Context, path, text string) ([]Diagnostic, e
 
 	sess, err := m.sessionFor(ctx, command)
 	if err != nil {
+		// A configured extension whose language-server binary isn't installed must
+		// degrade exactly like an unsupported extension — LSP is an opportunistic
+		// layer, not a hard dependency. Only a missing binary degrades; any other
+		// start failure still surfaces.
+		if isServerUnavailable(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	baseline := sess.publishBaseline(uri)
@@ -142,6 +150,13 @@ func (m *Manager) sessionFor(ctx context.Context, command []string) (*session, e
 	m.sessions[key] = sess
 	m.mu.Unlock()
 	return sess, nil
+}
+
+// isServerUnavailable reports whether a start error is just a missing binary
+// (exec could not find the language server on PATH), which should degrade to
+// "no diagnostics" rather than fail the run.
+func isServerUnavailable(err error) bool {
+	return errors.Is(err, exec.ErrNotFound)
 }
 
 func (m *Manager) absPath(path string) string {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"sync"
 	"time"
@@ -68,7 +69,12 @@ func (m *Manager) Check(ctx context.Context, path, text string) ([]Diagnostic, e
 	if err := sess.sync(ctx, abs, languageID, text); err != nil {
 		return nil, err
 	}
-	sess.waitForDiagnostics(ctx, uri, m.debounce, baseline)
+	// If no publish newer than baseline arrived (server too slow / ctx expired),
+	// return no diagnostics rather than a stale prior result for the new text —
+	// a missing signal degrades like a missing server, not a false "compiles".
+	if !sess.waitForDiagnostics(ctx, uri, m.debounce, baseline) {
+		return nil, nil
+	}
 	return sess.diagnosticsFor(uri), nil
 }
 
@@ -93,16 +99,20 @@ func (m *Manager) HasErrors(path string) bool {
 	return hasErrors(m.DiagnosticsFor(path))
 }
 
-// Shutdown stops every running server.
+// Shutdown stops every running server, returning the joined errors of any that
+// failed to exit cleanly (a leaked language-server process is worth surfacing).
 func (m *Manager) Shutdown(ctx context.Context) error {
 	m.mu.Lock()
 	sessions := m.sessions
 	m.sessions = map[string]*session{}
 	m.mu.Unlock()
+	var errs []error
 	for _, sess := range sessions {
-		_ = sess.server.Shutdown(ctx)
+		if err := sess.server.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // sessionFor returns the running session for a server command, starting one if

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -236,5 +237,17 @@ func TestSessionDropsStaleVersionPublish(t *testing.T) {
 	sess.handleNotification("textDocument/publishDiagnostics", fresh)
 	if d := sess.diagnosticsFor(uri); len(d) != 1 || d[0].Message != "fresh" {
 		t.Fatalf("a current-version publish must apply, got %#v", d)
+	}
+}
+
+func TestManagerCheckDegradesWhenServerBinaryMissing(t *testing.T) {
+	// A configured extension whose binary isn't on PATH (exec.ErrNotFound) must
+	// degrade to no diagnostics, exactly like an unsupported extension.
+	m := fastManager(func(context.Context, []string, string) (lspServer, error) {
+		return nil, &exec.Error{Name: "gopls", Err: exec.ErrNotFound}
+	})
+	diags, err := m.Check(context.Background(), "main.go", "package main")
+	if err != nil || diags != nil {
+		t.Fatalf("missing server binary should degrade to (nil,nil), got (%#v, %v)", diags, err)
 	}
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -195,5 +197,44 @@ func TestManagerCheckConcurrentReusesOneServer(t *testing.T) {
 	m.mu.Unlock()
 	if sessions != 1 {
 		t.Fatalf("expected a single reused session, got %d", sessions)
+	}
+}
+
+type errShutdownServer struct{}
+
+func (errShutdownServer) Client() *Client { return NewClient(strings.NewReader(""), io.Discard) }
+func (errShutdownServer) Shutdown(context.Context) error {
+	return errors.New("server refused to exit")
+}
+
+func TestManagerShutdownPropagatesErrors(t *testing.T) {
+	m := newManagerWithStarter("/repo", func(context.Context, []string, string) (lspServer, error) {
+		return errShutdownServer{}, nil
+	})
+	if _, err := m.sessionFor(context.Background(), []string{"gopls"}); err != nil {
+		t.Fatalf("sessionFor: %v", err)
+	}
+	if err := m.Shutdown(context.Background()); err == nil {
+		t.Fatal("Shutdown must surface a server that refused to exit")
+	}
+}
+
+func TestSessionDropsStaleVersionPublish(t *testing.T) {
+	sess := newSession(errShutdownServer{})
+	uri := PathToURI("/repo/main.go")
+	sess.mu.Lock()
+	sess.versions[uri] = 3
+	sess.mu.Unlock()
+
+	stale, _ := json.Marshal(PublishDiagnosticsParams{URI: uri, Version: 2, Diagnostics: []Diagnostic{{Message: "stale"}}})
+	sess.handleNotification("textDocument/publishDiagnostics", stale)
+	if len(sess.diagnosticsFor(uri)) != 0 {
+		t.Fatal("a publish for an older version must be ignored")
+	}
+
+	fresh, _ := json.Marshal(PublishDiagnosticsParams{URI: uri, Version: 3, Diagnostics: []Diagnostic{{Message: "fresh"}}})
+	sess.handleNotification("textDocument/publishDiagnostics", fresh)
+	if d := sess.diagnosticsFor(uri); len(d) != 1 || d[0].Message != "fresh" {
+		t.Fatalf("a current-version publish must apply, got %#v", d)
 	}
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -1,0 +1,199 @@
+package lsp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stubLSPServer is an lspServer backed by in-memory pipes. On each didOpen/
+// didChange it publishes the next entry of a configured diagnostics sequence
+// (repeating the last entry), or nothing when neverPublish is set.
+type stubLSPServer struct {
+	client       *Client
+	serverWriter *io.PipeWriter
+	clientWriter *io.PipeWriter
+	closeOnce    sync.Once
+}
+
+func (s *stubLSPServer) Client() *Client { return s.client }
+
+func (s *stubLSPServer) Shutdown(_ context.Context) error {
+	s.closeOnce.Do(func() {
+		_ = s.client.Close()
+		_ = s.serverWriter.Close()
+		_ = s.clientWriter.Close()
+	})
+	return nil
+}
+
+func (s *stubLSPServer) run(serverReader io.Reader, sequence [][]Diagnostic, neverPublish bool) {
+	reader := bufio.NewReader(serverReader)
+	count := 0
+	for {
+		body, err := readMessage(reader)
+		if err != nil {
+			return
+		}
+		var msg struct {
+			Method string `json:"method"`
+			Params struct {
+				TextDocument struct {
+					URI string `json:"uri"`
+				} `json:"textDocument"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &msg)
+		if msg.Method != "textDocument/didOpen" && msg.Method != "textDocument/didChange" {
+			continue
+		}
+		if neverPublish {
+			continue
+		}
+		diags := []Diagnostic{}
+		if count < len(sequence) {
+			diags = sequence[count]
+		} else if len(sequence) > 0 {
+			diags = sequence[len(sequence)-1]
+		}
+		count++
+		_ = writeMessage(s.serverWriter, map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "textDocument/publishDiagnostics",
+			"params":  PublishDiagnosticsParams{URI: msg.Params.TextDocument.URI, Diagnostics: diags},
+		})
+	}
+}
+
+func stubStarter(sequence [][]Diagnostic, neverPublish bool) serverStarter {
+	return func(_ context.Context, _ []string, _ string) (lspServer, error) {
+		clientReader, serverWriter := io.Pipe()
+		serverReader, clientWriter := io.Pipe()
+		stub := &stubLSPServer{
+			client:       NewClient(clientReader, clientWriter),
+			serverWriter: serverWriter,
+			clientWriter: clientWriter,
+		}
+		go stub.run(serverReader, sequence, neverPublish)
+		return stub, nil
+	}
+}
+
+func fastManager(starter serverStarter) *Manager {
+	m := newManagerWithStarter("/repo", starter)
+	m.debounce = 15 * time.Millisecond // keep tests quick
+	return m
+}
+
+func TestManagerCheckReturnsDiagnostics(t *testing.T) {
+	errDiag := Diagnostic{
+		Range:    Range{Start: Position{Line: 2, Character: 0}},
+		Severity: SeverityError,
+		Message:  "undefined: foo",
+	}
+	m := fastManager(stubStarter([][]Diagnostic{{errDiag}}, false))
+	defer m.Shutdown(context.Background())
+
+	diags, err := m.Check(context.Background(), "main.go", "package main")
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if len(diags) != 1 || diags[0].Message != "undefined: foo" {
+		t.Fatalf("diagnostics = %#v", diags)
+	}
+	if !m.HasErrors("main.go") {
+		t.Fatal("HasErrors should be true after an error diagnostic")
+	}
+}
+
+func TestManagerCheckClearsDiagnosticsOnChange(t *testing.T) {
+	errDiag := Diagnostic{Severity: SeverityError, Message: "boom"}
+	// First sync publishes an error; second publishes an empty list (fixed).
+	m := fastManager(stubStarter([][]Diagnostic{{errDiag}, {}}, false))
+	defer m.Shutdown(context.Background())
+
+	if _, err := m.Check(context.Background(), "main.go", "broken"); err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasErrors("main.go") {
+		t.Fatal("expected errors after first check")
+	}
+	diags, err := m.Check(context.Background(), "main.go", "fixed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diags) != 0 || m.HasErrors("main.go") {
+		t.Fatalf("expected diagnostics cleared, got %#v", diags)
+	}
+}
+
+func TestManagerCheckTimesOutWithoutPublish(t *testing.T) {
+	m := fastManager(stubStarter(nil, true)) // server never publishes
+	defer m.Shutdown(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	diags, err := m.Check(ctx, "main.go", "package main")
+	if err != nil {
+		t.Fatalf("Check should not error on timeout, got %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diags)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("Check hung well past the context timeout")
+	}
+}
+
+func TestManagerNoServerForExtension(t *testing.T) {
+	calls := 0
+	m := fastManager(func(_ context.Context, _ []string, _ string) (lspServer, error) {
+		calls++
+		return nil, nil
+	})
+	diags, err := m.Check(context.Background(), "notes.md", "hello")
+	if err != nil || diags != nil {
+		t.Fatalf("unconfigured extension should return (nil,nil), got (%#v,%v)", diags, err)
+	}
+	if calls != 0 {
+		t.Fatal("no server should be started for an unconfigured extension")
+	}
+}
+
+func TestManagerCheckConcurrentReusesOneServer(t *testing.T) {
+	var mu sync.Mutex
+	started := 0
+	base := stubStarter([][]Diagnostic{{{Severity: SeverityWarning, Message: "w"}}}, false)
+	m := fastManager(func(ctx context.Context, command []string, root string) (lspServer, error) {
+		mu.Lock()
+		started++
+		mu.Unlock()
+		return base(ctx, command, root)
+	})
+	defer m.Shutdown(context.Background())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := m.Check(context.Background(), "main.go", "package main"); err != nil {
+				t.Errorf("concurrent Check: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All four calls target the same .go server; only one session is retained.
+	m.mu.Lock()
+	sessions := len(m.sessions)
+	m.mu.Unlock()
+	if sessions != 1 {
+		t.Fatalf("expected a single reused session, got %d", sessions)
+	}
+}

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -1,0 +1,61 @@
+package lsp
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// serverCommands maps a file extension to the language-server command (argv) ZERO
+// will spawn. The first element is the binary looked up on PATH; missing binaries
+// are not an error, the agent just degrades to text-only for that file.
+var serverCommands = map[string][]string{
+	".go":  {"gopls", "serve"},
+	".ts":  {"typescript-language-server", "--stdio"},
+	".tsx": {"typescript-language-server", "--stdio"},
+	".js":  {"typescript-language-server", "--stdio"},
+	".jsx": {"typescript-language-server", "--stdio"},
+	".py":  {"pyright-langserver", "--stdio"},
+	".rs":  {"rust-analyzer"},
+}
+
+// languageIDs maps a file extension to the LSP languageId used in didOpen.
+var languageIDs = map[string]string{
+	".go":  "go",
+	".ts":  "typescript",
+	".tsx": "typescriptreact",
+	".js":  "javascript",
+	".jsx": "javascriptreact",
+	".py":  "python",
+	".rs":  "rust",
+}
+
+// ServerFor returns the server command for a path's extension, and whether one is
+// configured. It does not check PATH (use Available for that).
+func ServerFor(path string) ([]string, bool) {
+	cmd, ok := serverCommands[extKey(path)]
+	if !ok {
+		return nil, false
+	}
+	return append([]string(nil), cmd...), true
+}
+
+// LanguageID returns the LSP languageId for a path's extension.
+func LanguageID(path string) (string, bool) {
+	id, ok := languageIDs[extKey(path)]
+	return id, ok
+}
+
+// Available reports whether a configured server for the path exists on PATH.
+func Available(path string) bool {
+	cmd, ok := ServerFor(path)
+	if !ok {
+		return false
+	}
+	_, err := exec.LookPath(cmd[0])
+	return err == nil
+}
+
+func extKey(path string) string {
+	return strings.ToLower(filepath.Ext(path))
+}

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -1,0 +1,69 @@
+package lsp
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestServerForMapsExtensions(t *testing.T) {
+	cases := []struct {
+		path string
+		bin  string
+		ok   bool
+	}{
+		{"/x/main.go", "gopls", true},
+		{"/x/app.tsx", "typescript-language-server", true},
+		{"/x/app.ts", "typescript-language-server", true},
+		{"/x/script.py", "pyright-langserver", true},
+		{"/x/lib.rs", "rust-analyzer", true},
+		{"/x/README.md", "", false},
+		{"/x/noext", "", false},
+	}
+	for _, tc := range cases {
+		cmd, ok := ServerFor(tc.path)
+		if ok != tc.ok {
+			t.Fatalf("ServerFor(%q) ok = %v, want %v", tc.path, ok, tc.ok)
+		}
+		if ok && cmd[0] != tc.bin {
+			t.Fatalf("ServerFor(%q) binary = %q, want %q", tc.path, cmd[0], tc.bin)
+		}
+	}
+}
+
+func TestServerForIsCaseInsensitive(t *testing.T) {
+	if cmd, ok := ServerFor("/x/MAIN.GO"); !ok || cmd[0] != "gopls" {
+		t.Fatalf("uppercase extension should still map: %v %v", cmd, ok)
+	}
+}
+
+func TestServerForReturnsACopy(t *testing.T) {
+	cmd, _ := ServerFor("/x/main.go")
+	cmd[0] = "tampered"
+	again, _ := ServerFor("/x/main.go")
+	if again[0] != "gopls" {
+		t.Fatal("ServerFor must not expose the shared command slice")
+	}
+}
+
+func TestAvailableReflectsPATH(t *testing.T) {
+	// An unconfigured extension is never available.
+	if Available("/x/README.md") {
+		t.Fatal("unconfigured extension must report unavailable")
+	}
+	// For a configured extension, Available agrees with exec.LookPath — robust
+	// whether or not the server binary is installed in this environment.
+	cmd, _ := ServerFor("/x/main.go")
+	_, lookErr := exec.LookPath(cmd[0])
+	if Available("/x/main.go") != (lookErr == nil) {
+		t.Fatal("Available must reflect exec.LookPath for the configured binary")
+	}
+}
+
+func TestLanguageIDMapping(t *testing.T) {
+	if id, ok := LanguageID("/x/main.go"); !ok || id != "go" {
+		t.Fatalf("go languageId = %q ok=%v", id, ok)
+	}
+	if _, ok := LanguageID("/x/readme.md"); ok {
+		t.Fatal("unconfigured extension should have no languageId")
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1,0 +1,116 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// shutdownGrace bounds how long Shutdown waits for the server to exit cleanly
+// before killing the process.
+const shutdownGrace = 2 * time.Second
+
+// Server is a spawned language-server process plus the JSON-RPC client speaking
+// to it over stdio, with the LSP initialize handshake already completed.
+type Server struct {
+	cmd    *exec.Cmd
+	client *Client
+	stdin  io.WriteCloser
+}
+
+// StartServer spawns the given command, wires a Client to its stdio, and performs
+// the LSP initialize/initialized handshake rooted at rootPath. On any failure the
+// process is torn down before returning.
+func StartServer(ctx context.Context, command []string, rootPath string) (*Server, error) {
+	if len(command) == 0 {
+		return nil, errors.New("empty language-server command")
+	}
+	cmd := exec.Command(command[0], command[1:]...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	// The server's stderr is diagnostic noise for our purposes; discard it so it
+	// can't block on a full pipe.
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	server := &Server{cmd: cmd, client: NewClient(stdout, stdin), stdin: stdin}
+	if err := performInitialize(ctx, server.client, rootPath); err != nil {
+		_ = server.Shutdown(context.Background())
+		return nil, err
+	}
+	return server, nil
+}
+
+// Client exposes the JSON-RPC client for document sync / diagnostics (stage 03).
+func (s *Server) Client() *Client {
+	return s.client
+}
+
+// Shutdown sends the LSP shutdown request + exit notification, then waits briefly
+// for the process to exit and kills it otherwise. Best-effort: it never returns
+// an error for a server that simply ignored the handshake.
+func (s *Server) Shutdown(ctx context.Context) error {
+	_, _ = s.client.Call(ctx, "shutdown", nil)
+	_ = s.client.Notify(ctx, "exit", nil)
+	_ = s.client.Close()
+	_ = s.stdin.Close()
+
+	if s.cmd == nil || s.cmd.Process == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = s.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(shutdownGrace):
+		_ = s.cmd.Process.Kill()
+		<-done
+	}
+	return nil
+}
+
+// performInitialize runs the LSP handshake on an already-connected client. It is
+// separate from StartServer so it can be tested against a stub server over an
+// in-memory pipe without spawning a real process.
+func performInitialize(ctx context.Context, client *Client, rootPath string) error {
+	params := InitializeParams{
+		ProcessID:    os.Getpid(),
+		RootURI:      PathToURI(rootPath),
+		Capabilities: clientCapabilities(),
+	}
+	if _, err := client.Call(ctx, "initialize", params); err != nil {
+		return err
+	}
+	return client.Notify(ctx, "initialized", map[string]any{})
+}
+
+// clientCapabilities advertises the minimal capabilities ZERO needs: full-text
+// document sync and diagnostics via publishDiagnostics.
+func clientCapabilities() map[string]any {
+	return map[string]any{
+		"textDocument": map[string]any{
+			"synchronization": map[string]any{
+				"didSave":             true,
+				"willSave":            false,
+				"dynamicRegistration": false,
+			},
+			"publishDiagnostics": map[string]any{
+				"relatedInformation": true,
+			},
+		},
+	}
+}

--- a/internal/lsp/types.go
+++ b/internal/lsp/types.go
@@ -1,0 +1,116 @@
+// Package lsp is a direct Language Server Protocol client: ZERO spawns the
+// language server itself and speaks LSP JSON-RPC over stdio, so an unattended
+// run (cron/CI, no open editor) can still see real compiler diagnostics. This
+// file holds the minimal LSP data model and file<->URI helpers; client.go is the
+// transport and server.go the process lifecycle.
+package lsp
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// Position is a zero-based line/character offset in a document.
+type Position struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+// Range is an inclusive-start, exclusive-end span.
+type Range struct {
+	Start Position `json:"start"`
+	End   Position `json:"end"`
+}
+
+// Location is a range within a specific document URI.
+type Location struct {
+	URI   string `json:"uri"`
+	Range Range  `json:"range"`
+}
+
+// DiagnosticSeverity mirrors the LSP severity enum.
+type DiagnosticSeverity int
+
+const (
+	SeverityError       DiagnosticSeverity = 1
+	SeverityWarning     DiagnosticSeverity = 2
+	SeverityInformation DiagnosticSeverity = 3
+	SeverityHint        DiagnosticSeverity = 4
+)
+
+// Diagnostic is one compiler/linter finding for a document.
+type Diagnostic struct {
+	Range    Range              `json:"range"`
+	Severity DiagnosticSeverity `json:"severity,omitempty"`
+	Code     any                `json:"code,omitempty"`
+	Source   string             `json:"source,omitempty"`
+	Message  string             `json:"message"`
+}
+
+// TextDocumentItem is the payload for textDocument/didOpen.
+type TextDocumentItem struct {
+	URI        string `json:"uri"`
+	LanguageID string `json:"languageId"`
+	Version    int    `json:"version"`
+	Text       string `json:"text"`
+}
+
+// InitializeParams is the (trimmed) payload for the LSP initialize request.
+type InitializeParams struct {
+	ProcessID    int            `json:"processId"`
+	RootURI      string         `json:"rootUri"`
+	Capabilities map[string]any `json:"capabilities"`
+}
+
+// InitializeResult is the (trimmed) initialize response; we only need the
+// server's reported capabilities.
+type InitializeResult struct {
+	Capabilities map[string]any `json:"capabilities"`
+}
+
+// PublishDiagnosticsParams is the payload of the textDocument/publishDiagnostics
+// notification (consumed in stage 03).
+type PublishDiagnosticsParams struct {
+	URI         string       `json:"uri"`
+	Version     int          `json:"version,omitempty"`
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+// PathToURI converts an absolute filesystem path to a file:// URI, handling the
+// Windows drive-letter form (C:\x -> file:///C:/x). It is the inverse of
+// URIToPath; the pair round-trips for any absolute path.
+func PathToURI(path string) string {
+	if path == "" {
+		return ""
+	}
+	slashed := filepath.ToSlash(path)
+	// Windows absolute paths ("C:/x") need a leading slash so the drive becomes
+	// part of the URI path: /C:/x.
+	if len(slashed) >= 2 && slashed[1] == ':' {
+		slashed = "/" + slashed
+	}
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	u := url.URL{Scheme: "file", Path: slashed}
+	return u.String()
+}
+
+// URIToPath converts a file:// URI back to an OS-native absolute path. A
+// non-file URI (or unparseable input) is returned unchanged.
+func URIToPath(uri string) string {
+	if uri == "" {
+		return ""
+	}
+	parsed, err := url.Parse(uri)
+	if err != nil || parsed.Scheme != "file" {
+		return uri
+	}
+	path := parsed.Path
+	// Strip the synthetic leading slash from a Windows drive path: /C:/x -> C:/x.
+	if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return filepath.FromSlash(path)
+}

--- a/internal/lsp/types_test.go
+++ b/internal/lsp/types_test.go
@@ -1,0 +1,39 @@
+package lsp
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestURIRoundTrip(t *testing.T) {
+	// Use an OS-appropriate absolute path so the round-trip is platform-correct,
+	// including a space to exercise percent-encoding.
+	path := "/home/dev/a b.go"
+	if runtime.GOOS == "windows" {
+		path = `C:\Users\dev\a b.go`
+	}
+
+	uri := PathToURI(path)
+	if !strings.HasPrefix(uri, "file://") {
+		t.Fatalf("PathToURI(%q) = %q, want file:// scheme", path, uri)
+	}
+	if strings.Contains(uri, " ") {
+		t.Fatalf("URI should percent-encode spaces, got %q", uri)
+	}
+	if got := URIToPath(uri); got != path {
+		t.Fatalf("round-trip failed: %q -> %q -> %q", path, uri, got)
+	}
+}
+
+func TestURIToPathPassesThroughNonFileURI(t *testing.T) {
+	if got := URIToPath("https://example.com/x"); got != "https://example.com/x" {
+		t.Fatalf("non-file URI should pass through, got %q", got)
+	}
+}
+
+func TestPathToURIEmpty(t *testing.T) {
+	if PathToURI("") != "" {
+		t.Fatal("empty path should yield empty URI")
+	}
+}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -111,6 +111,7 @@ var knownToolNames = map[string]bool{
 	"update_plan":    true,
 	"bash":           true,
 	"web_fetch":      true,
+	"web_search":     true,
 }
 
 func DefaultPaths(workspaceRoot string) (Paths, error) {

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -133,7 +133,7 @@ Prompt.`,
 			content: `---
 name: explorer
 description: Explores code
-tools: [web_search]
+tools: [web_crawl]
 ---
 Prompt.`,
 			want: "unknown tool or category",

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -228,6 +228,7 @@ func CoreShellToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 func CoreNetworkTools() []Tool {
 	return []Tool{
 		NewWebFetchTool(),
+		NewWebSearchTool(),
 	}
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -47,29 +47,32 @@ func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 }
 
 func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
-	toolset := CoreNetworkTools()
-	if len(toolset) != 1 {
-		t.Fatalf("expected 1 core network tool, got %d", len(toolset))
+	byName := map[string]Tool{}
+	for _, tool := range CoreNetworkTools() {
+		byName[tool.Name()] = tool
+		// Every core network tool shares the same prompt-gated egress posture.
+		safety := tool.Safety()
+		if safety.SideEffect != SideEffectNetwork || safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
+			t.Fatalf("network tool %q has unexpected safety metadata: %#v", tool.Name(), safety)
+		}
 	}
 
-	tool := toolset[0]
-	if tool.Name() != "web_fetch" {
-		t.Fatalf("expected web_fetch network tool, got %q", tool.Name())
-	}
-	safety := tool.Safety()
-	if safety.SideEffect != SideEffectNetwork || safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
-		t.Fatalf("unexpected web_fetch safety metadata: %#v", safety)
-	}
-	schema := tool.Parameters()
-	if schema.Properties == nil {
-		t.Fatal("web_fetch schema properties are nil")
-	}
-	urlProperty, ok := schema.Properties["url"]
+	// web_fetch retrieves a known URL; its key parameter is "url".
+	fetch, ok := byName["web_fetch"]
 	if !ok {
-		t.Fatal("web_fetch schema missing url property")
+		t.Fatal("expected web_fetch in core network tools")
 	}
-	if urlProperty.Type != "string" {
-		t.Fatalf("web_fetch url type = %s, want string", urlProperty.Type)
+	if property, ok := fetch.Parameters().Properties["url"]; !ok || property.Type != "string" {
+		t.Fatalf("web_fetch must expose a string url property, got %#v", fetch.Parameters().Properties["url"])
+	}
+
+	// web_search discovers URLs; its key parameter is "query".
+	search, ok := byName["web_search"]
+	if !ok {
+		t.Fatal("expected web_search in core network tools")
+	}
+	if property, ok := search.Parameters().Properties["query"]; !ok || property.Type != "string" {
+		t.Fatalf("web_search must expose a string query property, got %#v", search.Parameters().Properties["query"])
 	}
 }
 

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -162,7 +162,13 @@ type httpSearchBackend struct {
 }
 
 func (backend *httpSearchBackend) Search(ctx context.Context, query string, limit int) ([]searchResult, error) {
-	payload, err := json.Marshal(map[string]any{"query": query, "limit": limit})
+	requestBody := map[string]any{"query": query, "limit": limit}
+	// Forward the configured provider so an aggregating endpoint can route the
+	// query; without this the ZERO_WEBSEARCH_PROVIDER knob would be inert.
+	if backend.provider != "" {
+		requestBody["provider"] = backend.provider
+	}
+	payload, err := json.Marshal(requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("encode search request: %w", err)
 	}

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -28,9 +28,9 @@ type searchResult struct {
 	Snippet string
 }
 
-// searchBackend discovers URLs for a query. It is an interface so Brave / Tavily
-// / Exa / You.com (or a fake, in tests) can be dropped in without touching the
-// tool. nil means no backend is configured.
+// searchBackend discovers URLs for a query. It is an interface so any hosted
+// search API (or a fake, in tests) can be dropped in without touching the tool.
+// nil means no backend is configured.
 type searchBackend interface {
 	Search(ctx context.Context, query string, limit int) ([]searchResult, error)
 }
@@ -152,8 +152,8 @@ func defaultSearchBackend() searchBackend {
 
 // httpSearchBackend is the generic JSON backend: POST {query,limit} to a
 // configured endpoint and parse an array of {title,url,snippet}. Its shape
-// matches common providers (Exa / You / Tavily / Brave) without copying any of
-// their code; swap in a provider-specific backend by implementing searchBackend.
+// matches common hosted search APIs without copying any of their code; swap in a
+// backend-specific implementation by implementing searchBackend.
 type httpSearchBackend struct {
 	client   *http.Client
 	baseURL  string

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -1,0 +1,236 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+const (
+	defaultWebSearchLimit = 5
+	maxWebSearchLimit     = 10
+	webSearchTimeout      = 10 * time.Second
+	webSearchBodyLimit    = 256 * 1024
+)
+
+// searchResult is one hit returned by a search backend.
+type searchResult struct {
+	Title   string
+	URL     string
+	Snippet string
+}
+
+// searchBackend discovers URLs for a query. It is an interface so Brave / Tavily
+// / Exa / You.com (or a fake, in tests) can be dropped in without touching the
+// tool. nil means no backend is configured.
+type searchBackend interface {
+	Search(ctx context.Context, query string, limit int) ([]searchResult, error)
+}
+
+type webSearchTool struct {
+	baseTool
+	backend searchBackend
+}
+
+// NewWebSearchTool builds the web_search tool with the env-configured backend.
+func NewWebSearchTool() Tool {
+	return newWebSearchToolWithBackend(defaultSearchBackend())
+}
+
+func newWebSearchToolWithBackend(backend searchBackend) Tool {
+	return webSearchTool{
+		baseTool: baseTool{
+			name:        "web_search",
+			description: "Search the web for a query and return ranked results (title, URL, snippet). Complements web_fetch, which retrieves a single known URL.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"query": {
+						Type:        "string",
+						Description: "Search query.",
+					},
+					"limit": {
+						Type:        "integer",
+						Description: "Maximum number of results to return.",
+						Default:     defaultWebSearchLimit,
+						Minimum:     intPtr(1),
+						Maximum:     intPtr(maxWebSearchLimit),
+					},
+				},
+				Required:             []string{"query"},
+				AdditionalProperties: false,
+			},
+			// Network egress, so it carries the same prompt-gated posture as web_fetch
+			// (the codebase enforces this for every CoreNetworkTools entry). It only
+			// discovers public URLs and mutates nothing, but the query still leaves
+			// the machine for an operator-configured endpoint, which warrants a prompt.
+			safety: Safety{
+				SideEffect:      SideEffectNetwork,
+				Permission:      PermissionPrompt,
+				Reason:          "Performs a web search over the network.",
+				AdvertiseInAuto: true,
+			},
+		},
+		backend: backend,
+	}
+}
+
+func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
+	query, err := stringArg(args, "query", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for web_search: " + err.Error())
+	}
+	// max=0 disables intArg's upper bound so an over-cap limit clamps here rather
+	// than erroring; min=1 still rejects non-positive limits.
+	limit, err := intArg(args, "limit", defaultWebSearchLimit, 1, 0)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for web_search: " + err.Error())
+	}
+	if limit > maxWebSearchLimit {
+		limit = maxWebSearchLimit
+	}
+
+	if tool.backend == nil {
+		return errorResult("Error: no search backend configured. Set ZERO_WEBSEARCH_BASE_URL (and ZERO_WEBSEARCH_API_KEY) to enable web_search.")
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, webSearchTimeout)
+	defer cancel()
+
+	results, err := tool.backend.Search(runCtx, query, limit)
+	if err != nil {
+		return errorResult("Error performing web search: " + redactWebSearchText(err.Error()))
+	}
+	if len(results) == 0 {
+		return okResult("No results for query: " + redactWebSearchText(query))
+	}
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return okResult(redactWebSearchText(formatSearchResults(results)))
+}
+
+// formatSearchResults renders results as a compact numbered list:
+// "1. Title — URL" with the snippet indented on the next line.
+func formatSearchResults(results []searchResult) string {
+	lines := make([]string, 0, len(results)*2)
+	for index, result := range results {
+		title := strings.TrimSpace(result.Title)
+		if title == "" {
+			title = "(untitled)"
+		}
+		lines = append(lines, fmt.Sprintf("%d. %s — %s", index+1, title, strings.TrimSpace(result.URL)))
+		if snippet := strings.TrimSpace(result.Snippet); snippet != "" {
+			lines = append(lines, "   "+snippet)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// defaultSearchBackend returns the env-configured generic backend, or nil when
+// ZERO_WEBSEARCH_BASE_URL is unset (the tool then reports it as unconfigured).
+func defaultSearchBackend() searchBackend {
+	baseURL := strings.TrimSpace(os.Getenv("ZERO_WEBSEARCH_BASE_URL"))
+	if baseURL == "" {
+		return nil
+	}
+	return &httpSearchBackend{
+		client:   &http.Client{Timeout: webSearchTimeout},
+		baseURL:  baseURL,
+		apiKey:   strings.TrimSpace(os.Getenv("ZERO_WEBSEARCH_API_KEY")),
+		provider: strings.TrimSpace(os.Getenv("ZERO_WEBSEARCH_PROVIDER")),
+	}
+}
+
+// httpSearchBackend is the generic JSON backend: POST {query,limit} to a
+// configured endpoint and parse an array of {title,url,snippet}. Its shape
+// matches common providers (Exa / You / Tavily / Brave) without copying any of
+// their code; swap in a provider-specific backend by implementing searchBackend.
+type httpSearchBackend struct {
+	client   *http.Client
+	baseURL  string
+	apiKey   string
+	provider string
+}
+
+func (backend *httpSearchBackend) Search(ctx context.Context, query string, limit int) ([]searchResult, error) {
+	payload, err := json.Marshal(map[string]any{"query": query, "limit": limit})
+	if err != nil {
+		return nil, fmt.Errorf("encode search request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, backend.baseURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build search request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("User-Agent", "zero-web-search/0.1")
+	if backend.apiKey != "" {
+		request.Header.Set("Authorization", "Bearer "+backend.apiKey)
+	}
+
+	response, err := backend.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, webSearchBodyLimit))
+	if err != nil {
+		return nil, fmt.Errorf("read search response: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		// Status only; the body may echo the request (incl. auth) so it is not surfaced.
+		return nil, fmt.Errorf("search backend returned HTTP %d", response.StatusCode)
+	}
+	return parseSearchResults(body)
+}
+
+// parseSearchResults accepts either a bare array [{title,url,snippet}] or a
+// wrapped object {"results":[...]}, the two shapes common across providers.
+func parseSearchResults(body []byte) ([]searchResult, error) {
+	type rawResult struct {
+		Title   string `json:"title"`
+		URL     string `json:"url"`
+		Snippet string `json:"snippet"`
+	}
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("empty search backend response")
+	}
+
+	convert := func(raw []rawResult) []searchResult {
+		out := make([]searchResult, 0, len(raw))
+		for _, item := range raw {
+			out = append(out, searchResult{Title: item.Title, URL: item.URL, Snippet: item.Snippet})
+		}
+		return out
+	}
+
+	if trimmed[0] == '[' {
+		var bare []rawResult
+		if err := json.Unmarshal(trimmed, &bare); err != nil {
+			return nil, fmt.Errorf("parse search results: %w", err)
+		}
+		return convert(bare), nil
+	}
+	var wrapped struct {
+		Results []rawResult `json:"results"`
+	}
+	if err := json.Unmarshal(trimmed, &wrapped); err != nil {
+		return nil, fmt.Errorf("parse search results: %w", err)
+	}
+	return convert(wrapped.Results), nil
+}
+
+func redactWebSearchText(value string) string {
+	return redaction.RedactString(value, redaction.Options{})
+}

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -2,7 +2,10 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -106,5 +109,31 @@ func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("web_search should be registered in CoreNetworkTools()")
+	}
+}
+
+func TestHTTPSearchBackendSendsProviderAndParsesResults(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"title":"Title","url":"https://x.dev","snippet":"snip"}]}`))
+	}))
+	defer server.Close()
+
+	backend := &httpSearchBackend{client: server.Client(), baseURL: server.URL, apiKey: "k", provider: "exa"}
+	results, err := backend.Search(context.Background(), "q", 3)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 || results[0].Title != "Title" || results[0].URL != "https://x.dev" {
+		t.Fatalf("results = %#v", results)
+	}
+	// The configured provider and query must reach the backend.
+	if gotBody["provider"] != "exa" {
+		t.Fatalf("ZERO_WEBSEARCH_PROVIDER not forwarded: %#v", gotBody)
+	}
+	if gotBody["query"] != "q" {
+		t.Fatalf("query not forwarded: %#v", gotBody)
 	}
 }

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -1,0 +1,110 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type fakeSearchBackend struct {
+	results  []searchResult
+	err      error
+	gotQuery string
+	gotLimit int
+}
+
+func (f *fakeSearchBackend) Search(_ context.Context, query string, limit int) ([]searchResult, error) {
+	f.gotQuery = query
+	f.gotLimit = limit
+	return f.results, f.err
+}
+
+func TestWebSearchFormatsResults(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "Go errors", URL: "https://go.dev/blog/errors", Snippet: "Working with errors in Go."},
+		{Title: "Wrapping", URL: "https://go.dev/blog/wrap", Snippet: "Error wrapping."},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+
+	res := tool.Run(context.Background(), map[string]any{"query": "go errors"})
+
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v, output = %q", res.Status, res.Output)
+	}
+	for _, want := range []string{
+		"1. Go errors — https://go.dev/blog/errors",
+		"   Working with errors in Go.",
+		"2. Wrapping — https://go.dev/blog/wrap",
+		"   Error wrapping.",
+	} {
+		if !strings.Contains(res.Output, want) {
+			t.Fatalf("output missing %q:\n%s", want, res.Output)
+		}
+	}
+	if backend.gotQuery != "go errors" {
+		t.Fatalf("backend query = %q, want %q", backend.gotQuery, "go errors")
+	}
+}
+
+func TestWebSearchClampsAndDefaultsLimit(t *testing.T) {
+	backend := &fakeSearchBackend{}
+	tool := newWebSearchToolWithBackend(backend)
+
+	// Above the cap clamps to 10 rather than erroring.
+	tool.Run(context.Background(), map[string]any{"query": "q", "limit": 50})
+	if backend.gotLimit != maxWebSearchLimit {
+		t.Fatalf("limit = %d, want clamp to %d", backend.gotLimit, maxWebSearchLimit)
+	}
+	// Missing limit falls back to the default.
+	tool.Run(context.Background(), map[string]any{"query": "q"})
+	if backend.gotLimit != defaultWebSearchLimit {
+		t.Fatalf("default limit = %d, want %d", backend.gotLimit, defaultWebSearchLimit)
+	}
+}
+
+func TestWebSearchRequiresQuery(t *testing.T) {
+	tool := newWebSearchToolWithBackend(&fakeSearchBackend{})
+	res := tool.Run(context.Background(), map[string]any{})
+	if res.Status != StatusError {
+		t.Fatalf("expected StatusError for missing query, got %v", res.Status)
+	}
+}
+
+func TestWebSearchUnconfiguredBackend(t *testing.T) {
+	tool := newWebSearchToolWithBackend(nil)
+	res := tool.Run(context.Background(), map[string]any{"query": "q"})
+	if res.Status != StatusError {
+		t.Fatalf("expected StatusError, got %v", res.Status)
+	}
+	if !strings.Contains(res.Output, "no search backend configured") {
+		t.Fatalf("output should explain the missing backend, got %q", res.Output)
+	}
+}
+
+func TestWebSearchRedactsBackendError(t *testing.T) {
+	secret := "sk-livesecret0123456789abcdef"
+	backend := &fakeSearchBackend{err: fmt.Errorf("backend rejected key %s", secret)}
+	tool := newWebSearchToolWithBackend(backend)
+
+	res := tool.Run(context.Background(), map[string]any{"query": "q"})
+
+	if res.Status != StatusError {
+		t.Fatalf("expected StatusError, got %v", res.Status)
+	}
+	if strings.Contains(res.Output, secret) {
+		t.Fatalf("backend error leaked the API key into output: %q", res.Output)
+	}
+}
+
+func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
+	found := false
+	for _, tool := range CoreNetworkTools() {
+		if tool.Name() == "web_search" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("web_search should be registered in CoreNetworkTools()")
+	}
+}


### PR DESCRIPTION
First three stages of the ZERO wedge build pack — *the model-agnostic agent that runs unattended and fixes its own mistakes*. Each stage is TDD-gated and tagged (`zero-wedge-01..03`). Stdlib-only; clean-room (Go implemented fresh from behavioural reference, no reproduced source). Verified the built binary runs and registers the new tool.

## Stage 01 — `web_search` tool (`zero-wedge-01`)
Complements `web_fetch` (fetch a known URL) by *discovering* URLs — what an unattended agent needs when it hits unknown errors or new library versions.
- `internal/tools/web_search.go`: `webSearchTool` over a pluggable `searchBackend`; env-configured generic JSON backend (`ZERO_WEBSEARCH_BASE_URL`/`_API_KEY`/`_PROVIDER`), swappable for Exa/You/Tavily/Brave. `query` + clamped `limit` (default 5, cap 10); numbered-list output; output redaction; clear "no search backend configured" error.
- Registered in `CoreNetworkTools()`.

**Intentional deviation from the stage prompt:** the prompt said `readOnlySafety`, but the repo's own `TestCoreNetworkToolsExposePromptMetadata` enforces that every core network tool is prompt-gated egress. Shipping an auto-allowed network tool (and weakening that test) would be a security regression, so `web_search` matches `web_fetch`'s `network/prompt` posture — confirmed in the built binary (`web_search [network/prompt]`).

## Stage 02 — LSP client foundation (`internal/lsp`) (`zero-wedge-02`)
A **direct** (self-spawned, stdio) Language Server Protocol client so an unattended run sees real compiler diagnostics with no open editor.
- `client.go`: JSON-RPC 2.0 + LSP `Content-Length` framing; concurrent id-matched `Call`/`Notify`, server→client request auto-reply, notification handler, context cancellation.
- `server.go`: lifecycle (spawn, `initialize`/`initialized` handshake, graceful shutdown+exit with kill fallback).
- `registry.go`: extension → server command (.go/.ts/.tsx/.js/.jsx/.py/.rs), languageId, PATH availability.
- `types.go`: minimal LSP types + `PathToURI`/`URIToPath` (Windows-drive aware).

## Stage 03 — LSP document sync + diagnostics (`zero-wedge-03`)
Turns the client into actionable signal: "did my edit compile?", headless.
- `documents.go`: per-server session — document lifecycle (didOpen / full-sync didChange / didClose), URI→diagnostics store fed by `publishDiagnostics`, `WaitForDiagnostics` with a publish-baseline + 300ms quiet debounce.
- `diagnostics.go`: `FormatDiagnostics` (`path:line:col: severity: message`, 1-based), `HasErrors`, `FilterBySeverity`.
- `manager.go`: `Manager` — one lazily-started, reused server per language; `Check(ctx,path,text) → settled diagnostics`; unknown extension → `(nil,nil)`.

A TDD-caught bug worth noting: `WaitForDiagnostics` initially returned the *previous* check's diagnostics (keyed off global last-publish time); fixed with a per-URI publish counter so each check waits for its own publish.

## Verification
Per-stage gate, all green: `go build ./...`, full `go test ./...`, `gofmt -l` clean. LSP concurrency tested with `-race` over in-memory pipes (stub server, no real `gopls`). Built the binary locally: runs, lists `web_search` as prompt-gated, `internal/lsp` compiled in.

## Notes / sequencing
- `internal/lsp` has no CLI surface yet — it's foundation consumed by stage 04 (the self-correct loop), which will wire testrunner/verify/selfverify/LSP into `internal/agent/loop.go`. That stage touches the core agent loop (conflict-prone vs in-flight TUI/loop PRs) and is intentionally **not** in this PR — it should land deliberately after sequencing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LSP support: language-server integration with document sync, diagnostics delivery, and graceful startup/shutdown.
  * Web search tool: network-backed searches returning ranked title/URL/snippet results with query/limit.
  * Post-edit self-correction: optional verify-and-correct feedback appended once after edits.

* **Utilities**
  * Path↔URI helpers, compact diagnostic formatting/filtering, and registry for server/language mappings.

* **Tests**
  * Expanded unit/integration tests covering LSP, diagnostics, registry, web search, and self-correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->