### PR TITLE
wedge stage 04: self-correct loop

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -326,6 +326,19 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			if outcome.InjectHint && failureHint == "" {
 				failureHint = toolFailureHint(call.Name, toolSchemaJSON(registry, call.Name), toolResult.Output)
 			}
+
+			// Post-edit self-correction: after a successful mutating tool call,
+			// verify the changed files and feed any failure back so the model can
+			// fix it next turn. nil SelfCorrect (the default) is a no-op, and a
+			// read-only tool (no ChangedFiles) never triggers verification.
+			if options.SelfCorrect != nil && toolResult.Status == tools.StatusOK && len(toolResult.ChangedFiles) > 0 {
+				if feedback, _ := options.SelfCorrect.AfterEdit(ctx, toolResult.ChangedFiles); feedback != "" {
+					messages = append(messages, zeroruntime.Message{
+						Role:    zeroruntime.MessageRoleUser,
+						Content: feedback,
+					})
+				}
+			}
 		}
 
 		// Mid-run model escalation: if a tool asked to switch models this turn and

--- a/internal/agent/selfcorrect.go
+++ b/internal/agent/selfcorrect.go
@@ -213,7 +213,7 @@ func NewLSPDiagnosticsChecker(manager *lsp.Manager) diagnosticsChecker {
 func (c lspDiagnosticsChecker) Check(ctx context.Context, path string) ([]lsp.Diagnostic, error) {
 	text, err := os.ReadFile(path)
 	if err != nil {
-		return nil, nil // unreadable (e.g. deleted) -> no diagnostics, degrade quietly
+		return nil, err // unreadable (e.g. deleted) -> let the caller decide
 	}
 	return c.manager.Check(ctx, path, string(text))
 }

--- a/internal/agent/selfcorrect.go
+++ b/internal/agent/selfcorrect.go
@@ -1,0 +1,239 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/lsp"
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/verify"
+)
+
+// defaultSelfCorrectMaxAttempts bounds how many corrective rounds a single run
+// will drive before giving up, so an unattended run can never loop forever.
+const defaultSelfCorrectMaxAttempts = 3
+
+// diagnosticsChecker returns the diagnostics for a single (absolute) file path.
+// *lsp.Manager is adapted to this via lspDiagnosticsChecker; tests inject a fake.
+type diagnosticsChecker interface {
+	Check(ctx context.Context, path string) ([]lsp.Diagnostic, error)
+}
+
+// projectVerifier runs the workspace's verification plan once and reports it.
+// The default implementation is DetectPlan + verify.Run; tests inject a fake.
+type projectVerifier interface {
+	Verify(ctx context.Context) (verify.Report, error)
+}
+
+// SelfCorrectConfig controls the post-edit verify-and-correct cycle.
+type SelfCorrectConfig struct {
+	Enabled      bool
+	MaxAttempts  int
+	IncludeTests bool
+	IncludeLSP   bool
+	Autonomy     string // low | medium | high
+}
+
+// Outcome reports what a self-correct round decided, for observability/tests.
+type Outcome string
+
+const (
+	OutcomeDisabled   Outcome = "disabled"   // self-correct off, or nothing to check
+	OutcomePassed     Outcome = "passed"     // verification passed; nothing to do
+	OutcomeCorrecting Outcome = "correcting" // failed; feedback issued for the model to fix
+	OutcomeReported   Outcome = "reported"   // failed; low autonomy, reported but no auto-fix
+	OutcomeAborted    Outcome = "aborted"    // failed but the correction budget is exhausted
+)
+
+// CorrectionReport is the unified result of a post-edit verification pass.
+type CorrectionReport struct {
+	LSPDiagnostics map[string][]lsp.Diagnostic // path -> error diagnostics
+	VerifyReport   verify.Report
+	Failed         bool
+}
+
+// SelfCorrector runs verification after a mutating edit and, when it fails,
+// synthesizes corrective feedback for the model — bounded by a per-run attempt
+// budget and gated by the autonomy ceiling. One instance per run (it holds the
+// attempt counter). A nil *SelfCorrector is a no-op.
+type SelfCorrector struct {
+	workspaceRoot string
+	checker       diagnosticsChecker
+	verifier      projectVerifier
+	cfg           SelfCorrectConfig
+	attempts      int
+}
+
+// NewSelfCorrector builds a self-corrector. checker/verifier may be nil to
+// disable that half of verification (e.g. no LSP server, or tests off).
+func NewSelfCorrector(workspaceRoot string, checker diagnosticsChecker, verifier projectVerifier, cfg SelfCorrectConfig) *SelfCorrector {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = defaultSelfCorrectMaxAttempts
+	}
+	return &SelfCorrector{workspaceRoot: workspaceRoot, checker: checker, verifier: verifier, cfg: cfg}
+}
+
+// AfterEdit runs a verification pass over the files a mutating tool changed and
+// returns corrective feedback (empty when nothing actionable) plus the outcome.
+// The loop appends any non-empty feedback to the conversation so the model can
+// fix the problem on its next turn.
+func (sc *SelfCorrector) AfterEdit(ctx context.Context, changedFiles []string) (string, Outcome) {
+	if sc == nil || !sc.cfg.Enabled || len(changedFiles) == 0 {
+		return "", OutcomeDisabled
+	}
+
+	report := sc.inspect(ctx, changedFiles)
+	if !report.Failed {
+		return "", OutcomePassed
+	}
+
+	// Low autonomy reports the failure but never starts an auto-fix round.
+	if !autonomyAllowsAutoCorrect(sc.cfg.Autonomy) {
+		return sc.feedback(report, false), OutcomeReported
+	}
+
+	if sc.attempts >= sc.cfg.MaxAttempts {
+		return abortedSelfCorrectNotice(sc.cfg.MaxAttempts), OutcomeAborted
+	}
+	sc.attempts++
+	return sc.feedback(report, true), OutcomeCorrecting
+}
+
+// inspect collects LSP error diagnostics for the changed files and runs the
+// project verification plan, marking Failed on any LSP error or verify failure.
+func (sc *SelfCorrector) inspect(ctx context.Context, changedFiles []string) CorrectionReport {
+	report := CorrectionReport{LSPDiagnostics: map[string][]lsp.Diagnostic{}}
+
+	if sc.cfg.IncludeLSP && sc.checker != nil {
+		for _, file := range changedFiles {
+			abs := sc.absPath(file)
+			diags, err := sc.checker.Check(ctx, abs)
+			if err != nil {
+				continue
+			}
+			if errs := lsp.FilterBySeverity(diags, lsp.SeverityError); len(errs) > 0 {
+				report.LSPDiagnostics[file] = errs
+				report.Failed = true
+			}
+		}
+	}
+
+	if sc.cfg.IncludeTests && sc.verifier != nil {
+		if vr, err := sc.verifier.Verify(ctx); err == nil {
+			report.VerifyReport = vr
+			if !vr.OK {
+				report.Failed = true
+			}
+		}
+	}
+	return report
+}
+
+// feedback synthesizes the model-facing message. corrective=false is the
+// low-autonomy reporting variant.
+func (sc *SelfCorrector) feedback(report CorrectionReport, corrective bool) string {
+	var b strings.Builder
+	if corrective {
+		b.WriteString("Verification failed after your edit. Fix these and continue:\n")
+	} else {
+		b.WriteString("Verification failed after your edit (auto-correction is off at low autonomy; reporting only):\n")
+	}
+
+	for file, diags := range report.LSPDiagnostics {
+		b.WriteString(lsp.FormatDiagnostics(file, diags))
+		b.WriteString("\n")
+	}
+	for _, result := range report.VerifyReport.Results {
+		if result.Status == verify.StatusPass {
+			continue
+		}
+		fmt.Fprintf(&b, "%s (%s): %s\n", result.Name, strings.Join(result.Command, " "), result.Status)
+		for _, line := range verifyResultLines(result) {
+			b.WriteString("  " + line + "\n")
+		}
+	}
+
+	// Secret-scrub the whole message: verify/LSP output can echo args, paths, env.
+	return strings.TrimRight(redaction.RedactString(b.String(), redaction.Options{}), "\n")
+}
+
+// verifyResultLines returns the most useful, already-trimmed output for a failing
+// check: the captured summary lines if present, else a trimmed stderr/stdout/err.
+func verifyResultLines(result verify.Result) []string {
+	if result.OutputSummary != nil && len(result.OutputSummary.Lines) > 0 {
+		return result.OutputSummary.Lines
+	}
+	for _, candidate := range []string{result.Stderr, result.Stdout, result.Error} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return strings.Split(trimmed, "\n")
+		}
+	}
+	return nil
+}
+
+func (sc *SelfCorrector) absPath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(sc.workspaceRoot, path)
+}
+
+func autonomyAllowsAutoCorrect(autonomy string) bool {
+	switch strings.ToLower(strings.TrimSpace(autonomy)) {
+	case "medium", "high":
+		return true
+	default:
+		// low / unset: conservative — report, don't auto-attempt.
+		return false
+	}
+}
+
+func abortedSelfCorrectNotice(maxAttempts int) string {
+	return fmt.Sprintf("Verification is still failing after %d self-correction attempts; stopping auto-correction. Review the remaining failures and decide how to proceed.", maxAttempts)
+}
+
+// lspDiagnosticsChecker adapts *lsp.Manager to diagnosticsChecker by reading the
+// file's current contents before asking the manager to check it.
+type lspDiagnosticsChecker struct {
+	manager *lsp.Manager
+}
+
+// NewLSPDiagnosticsChecker wraps an *lsp.Manager for use as a SelfCorrector
+// checker. Returns nil when manager is nil so self-correct cleanly skips LSP.
+func NewLSPDiagnosticsChecker(manager *lsp.Manager) diagnosticsChecker {
+	if manager == nil {
+		return nil
+	}
+	return lspDiagnosticsChecker{manager: manager}
+}
+
+func (c lspDiagnosticsChecker) Check(ctx context.Context, path string) ([]lsp.Diagnostic, error) {
+	text, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil // unreadable (e.g. deleted) -> no diagnostics, degrade quietly
+	}
+	return c.manager.Check(ctx, path, string(text))
+}
+
+// detectPlanVerifier is the default projectVerifier: detect the plan once per
+// run and execute it with verify.Run.
+type detectPlanVerifier struct {
+	root    string
+	options verify.RunOptions
+}
+
+// NewProjectVerifier builds the default verifier rooted at workspaceRoot.
+func NewProjectVerifier(workspaceRoot string) projectVerifier {
+	return detectPlanVerifier{root: workspaceRoot}
+}
+
+func (v detectPlanVerifier) Verify(ctx context.Context) (verify.Report, error) {
+	plan, err := verify.DetectPlan(v.root)
+	if err != nil {
+		return verify.Report{}, err
+	}
+	return verify.Run(ctx, plan, v.options), nil
+}

--- a/internal/agent/selfcorrect_test.go
+++ b/internal/agent/selfcorrect_test.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/lsp"
+	"github.com/Gitlawb/zero/internal/verify"
+)
+
+type fakeVerifier struct {
+	reports []verify.Report
+	calls   int
+}
+
+func (f *fakeVerifier) Verify(context.Context) (verify.Report, error) {
+	report := verify.Report{OK: true}
+	switch {
+	case f.calls < len(f.reports):
+		report = f.reports[f.calls]
+	case len(f.reports) > 0:
+		report = f.reports[len(f.reports)-1]
+	}
+	f.calls++
+	return report, nil
+}
+
+type fakeChecker struct {
+	byPath map[string][]lsp.Diagnostic
+}
+
+func (f fakeChecker) Check(_ context.Context, path string) ([]lsp.Diagnostic, error) {
+	return f.byPath[path], nil
+}
+
+func failingReport(stderr string) verify.Report {
+	return verify.Report{
+		OK: false,
+		Results: []verify.Result{{
+			Name:    "go test",
+			Command: []string{"go", "test", "./..."},
+			Status:  verify.StatusFail,
+			Stderr:  stderr,
+		}},
+	}
+}
+
+func newTestCorrector(checker diagnosticsChecker, verifier projectVerifier, autonomy string, maxAttempts int) *SelfCorrector {
+	return NewSelfCorrector("", checker, verifier, SelfCorrectConfig{
+		Enabled:      true,
+		IncludeLSP:   checker != nil,
+		IncludeTests: verifier != nil,
+		Autonomy:     autonomy,
+		MaxAttempts:  maxAttempts,
+	})
+}
+
+func TestSelfCorrectPassesWithNoFailures(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{{OK: true}}}
+	sc := newTestCorrector(nil, v, "high", 3)
+	if fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); fb != "" || oc != OutcomePassed {
+		t.Fatalf("expected passed/no-feedback, got %q / %s", fb, oc)
+	}
+}
+
+func TestSelfCorrectFailsThenPasses(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("--- FAIL: TestX"), {OK: true}}}
+	sc := newTestCorrector(nil, v, "high", 3)
+
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeCorrecting || !strings.Contains(fb, "Fix these and continue") || !strings.Contains(fb, "go test") {
+		t.Fatalf("round 1 = %q / %s", fb, oc)
+	}
+	fb2, oc2 := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc2 != OutcomePassed || fb2 != "" {
+		t.Fatalf("round 2 should pass cleanly, got %q / %s", fb2, oc2)
+	}
+}
+
+func TestSelfCorrectAbortsAtMaxAttempts(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("boom")}} // always fails
+	sc := newTestCorrector(nil, v, "high", 2)
+
+	for i := 1; i <= 2; i++ {
+		if _, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); oc != OutcomeCorrecting {
+			t.Fatalf("attempt %d outcome = %s, want correcting", i, oc)
+		}
+	}
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeAborted {
+		t.Fatalf("third round outcome = %s, want aborted", oc)
+	}
+	if !strings.Contains(fb, "stopping auto-correction") {
+		t.Fatalf("abort notice = %q", fb)
+	}
+	if sc.attempts != 2 {
+		t.Fatalf("correction attempts exceeded the ceiling: %d", sc.attempts)
+	}
+}
+
+func TestSelfCorrectSkipsWhenNoChangedFiles(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("x")}}
+	sc := newTestCorrector(nil, v, "high", 3)
+	if fb, oc := sc.AfterEdit(context.Background(), nil); fb != "" || oc != OutcomeDisabled {
+		t.Fatalf("read-only (no changes) should skip, got %q / %s", fb, oc)
+	}
+	if v.calls != 0 {
+		t.Fatal("verification must not run when nothing changed")
+	}
+}
+
+func TestSelfCorrectLowAutonomyReportsButDoesNotAttempt(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("FAIL")}}
+	sc := newTestCorrector(nil, v, "low", 3)
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeReported {
+		t.Fatalf("low autonomy outcome = %s, want reported", oc)
+	}
+	if !strings.Contains(fb, "reporting only") {
+		t.Fatalf("expected a reporting-only message, got %q", fb)
+	}
+	if sc.attempts != 0 {
+		t.Fatalf("low autonomy must not consume a correction attempt, got %d", sc.attempts)
+	}
+}
+
+func TestSelfCorrectLSPOnlyFailureFeedsDiagnostics(t *testing.T) {
+	checker := fakeChecker{byPath: map[string][]lsp.Diagnostic{
+		"main.go": {{
+			Severity: lsp.SeverityError,
+			Message:  "undefined: foo",
+			Range:    lsp.Range{Start: lsp.Position{Line: 4, Character: 1}},
+		}},
+	}}
+	v := &fakeVerifier{reports: []verify.Report{{OK: true}}} // tests pass; only LSP fails
+	sc := newTestCorrector(checker, v, "high", 3)
+
+	fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if oc != OutcomeCorrecting {
+		t.Fatalf("LSP error should drive a correction, got %s", oc)
+	}
+	if !strings.Contains(fb, "main.go:5:2: error: undefined: foo") {
+		t.Fatalf("feedback missing formatted diagnostic: %q", fb)
+	}
+}
+
+func TestSelfCorrectRedactsSecretsInFeedback(t *testing.T) {
+	secret := "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+	v := &fakeVerifier{reports: []verify.Report{failingReport("auth failed with " + secret)}}
+	sc := newTestCorrector(nil, v, "high", 3)
+	fb, _ := sc.AfterEdit(context.Background(), []string{"main.go"})
+	if strings.Contains(fb, secret) {
+		t.Fatalf("secret leaked into self-correct feedback: %q", fb)
+	}
+}
+
+func TestSelfCorrectDisabledIsNoop(t *testing.T) {
+	v := &fakeVerifier{reports: []verify.Report{failingReport("x")}}
+	sc := NewSelfCorrector("", nil, v, SelfCorrectConfig{Enabled: false, IncludeTests: true, Autonomy: "high"})
+	if fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); fb != "" || oc != OutcomeDisabled {
+		t.Fatalf("disabled corrector should no-op, got %q / %s", fb, oc)
+	}
+	if v.calls != 0 {
+		t.Fatal("disabled corrector must not verify")
+	}
+}
+
+func TestNilSelfCorrectorIsSafe(t *testing.T) {
+	var sc *SelfCorrector
+	if fb, oc := sc.AfterEdit(context.Background(), []string{"main.go"}); fb != "" || oc != OutcomeDisabled {
+		t.Fatalf("nil corrector should no-op, got %q / %s", fb, oc)
+	}
+}

--- a/internal/agent/selfcorrect_test.go
+++ b/internal/agent/selfcorrect_test.go
@@ -34,6 +34,16 @@ func (f fakeChecker) Check(_ context.Context, path string) ([]lsp.Diagnostic, er
 	return f.byPath[path], nil
 }
 
+func TestLSPDiagnosticsCheckerPropagatesReadError(t *testing.T) {
+	// A read failure (e.g. the edit deleted the file) must propagate so callers
+	// can decide how to handle it, rather than being swallowed as "no diagnostics".
+	// manager is never reached on a read error, so a nil manager is fine here.
+	c := lspDiagnosticsChecker{}
+	if _, err := c.Check(context.Background(), "/nonexistent/zero-selfcorrect/missing.go"); err == nil {
+		t.Fatal("expected Check to propagate the file-read error, got nil")
+	}
+}
+
 func failingReport(stderr string) verify.Report {
 	return verify.Report{
 		OK: false,

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -201,6 +201,12 @@ type Options struct {
 	// request), so every existing caller is unaffected. A returned error is
 	// non-fatal: the run continues on the current model.
 	ModelSwitcher func(ctx context.Context, modelID string) (Provider, error)
+	// SelfCorrect, when set, runs a post-edit verify-and-correct cycle after a
+	// mutating tool call: it verifies the changed files (LSP diagnostics + project
+	// tests) and feeds failures back to the model to fix, bounded by an attempt
+	// ceiling and the autonomy gate. nil disables it entirely (the loop is
+	// byte-identical to before). One instance per run — it holds attempt state.
+	SelfCorrect *SelfCorrector
 }
 
 type Result struct {


### PR DESCRIPTION
**Stacked on #175** (base `feat/wedge-build`) — review/merge #175 first; this diff shows only stage 04.

The headline wedge: after a mutating edit, ZERO verifies the changed files and fixes its own mistakes, unattended and bounded.

## What it does
After a successful mutating tool call, `loop.go` runs `SelfCorrector.AfterEdit(changedFiles)`:
- **Verify** — LSP error diagnostics for each changed file (stage 03 `lsp.Manager`) + the project's `verify` plan (`DetectPlan`+`Run`).
- **Correct** — on failure, append a concise, secret-redacted, model-facing message ("Verification failed after your edit. Fix these and continue:" + diagnostics + failing check output) so the model fixes it next turn.
- **Bound** — a per-run attempt ceiling (default 3); once exhausted it emits a stop notice instead of looping.
- **Gate** — autonomy ceiling: `low` reports only (no auto-attempt); `medium`/`high` auto-correct. Read-only tools (no `ChangedFiles`) never trigger it. `nil` SelfCorrect (the default) is a complete no-op.

## Scope (per the stage spec's file list)
- `internal/agent/selfcorrect.go` (engine, injectable `diagnosticsChecker`/`projectVerifier`)
- `internal/agent/loop.go` (gated invocation after a mutating tool result)
- `internal/agent/types.go` (**explicit options change:** `Options.SelfCorrect *SelfCorrector`)
- `internal/agent/selfcorrect_test.go`

## Design notes
- Single-pass `verify.Run` per call; the multi-attempt cycle comes from the agent loop + the model editing between turns (not `selfverify`'s same-command re-runs). The per-run counter provides the hard bound.
- **CLI activation deliberately deferred:** a `--self-correct` / `ZERO_SELF_CORRECT` flag that constructs the `SelfCorrector` in `exec.go` would touch files outside this stage's scope. The engine + adapters (`NewSelfCorrector`, `NewLSPDiagnosticsChecker`, `NewProjectVerifier`) are exported and ready; wiring is a small follow-up.

## Verification
TDD: fail-then-pass, max-attempts abort, read-only skip, low-autonomy report-only, LSP-only failure, secret redaction, disabled/nil no-op. `go build ./...`, full `go test ./...`, `-race` on `internal/agent`, `gofmt` all clean; 0 session leak. Loop change is nil-gated → existing loop tests byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post-edit self-correction: after file-changing operations, the system verifies edits (diagnostics and tests), returns scrubbed feedback, and can auto-attempt fixes up to configurable limits with autonomy gating.

* **Tests**
  * Added extensive tests covering pass/fail flows, retry limits and aborts, LSP diagnostics handling, redaction of sensitive output, disabled behavior, and safety of nil config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->