### PR TITLE
wedge M2: MCP server resources/prompts + sandbox scoped egress + MCP OAuth

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -46,6 +46,7 @@ type appDeps struct {
 	loadHooks            func(hooks.LoadOptions) (hooks.LoadResult, error)
 	skillsDir            func() string
 	newMCPStore          func() (*mcp.PermissionStore, error)
+	newMCPTokenStore     func() (*mcp.TokenStore, error)
 	newSandboxStore      func() (*sandbox.GrantStore, error)
 	selectSandboxBackend func(sandbox.BackendOptions) sandbox.Backend
 	registerMCPTools     func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error)
@@ -112,6 +113,9 @@ func defaultAppDeps() appDeps {
 		},
 		newMCPStore: func() (*mcp.PermissionStore, error) {
 			return mcp.NewPermissionStore(mcp.StoreOptions{})
+		},
+		newMCPTokenStore: func() (*mcp.TokenStore, error) {
+			return mcp.NewTokenStore(mcp.TokenStoreOptions{})
 		},
 		newSandboxStore: func() (*sandbox.GrantStore, error) {
 			return sandbox.NewGrantStore(sandbox.StoreOptions{})
@@ -309,6 +313,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.newMCPStore == nil {
 		deps.newMCPStore = defaults.newMCPStore
+	}
+	if deps.newMCPTokenStore == nil {
+		deps.newMCPTokenStore = defaults.newMCPTokenStore
 	}
 	if deps.newSandboxStore == nil {
 		deps.newSandboxStore = defaults.newSandboxStore

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -144,6 +144,8 @@ func runMCP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 		return runMCPPermissions(args[1:], stdout, stderr, deps)
 	case "tools":
 		return runMCPTools(args[1:], stdout, stderr, deps)
+	case "oauth":
+		return runMCPOAuth(args[1:], stdout, stderr, deps)
 	case "list":
 		return runMCPLegacyList(args[1:], stdout, stderr, deps)
 	default:
@@ -556,6 +558,7 @@ func writeMCPHelp(w io.Writer) error {
 
 Commands:
   list           List configured MCP servers, or tools with --tools
+  oauth          Manage OAuth credentials for remote MCP servers
   permissions    Manage persistent MCP tool permissions
   tools          Inspect configured MCP tools
 `)

--- a/internal/cli/mcp_oauth.go
+++ b/internal/cli/mcp_oauth.go
@@ -34,7 +34,7 @@ func runMCPOAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 }
 
 func runMCPOAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
-	_, positional, help, err := parseMCPPositionalCommand(args)
+	opts, positional, help, err := parseMCPPositionalCommand(args)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -43,6 +43,12 @@ func runMCPOAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps ap
 			return exitCrash
 		}
 		return exitSuccess
+	}
+	if opts.json {
+		// login is an interactive flow (prints a URL, waits for the callback); a
+		// machine-readable mode would be misleading, so reject it rather than
+		// accepting the flag and ignoring it.
+		return writeExecUsageError(stderr, "zero mcp oauth login does not support --json")
 	}
 	if len(positional) != 1 {
 		return writeExecUsageError(stderr, "usage: zero mcp oauth login <server>")

--- a/internal/cli/mcp_oauth.go
+++ b/internal/cli/mcp_oauth.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+func runMCPOAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "mcp oauth subcommand required. Use `zero mcp oauth status`.")
+	}
+	if args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		if err := writeMCPOAuthHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	switch args[0] {
+	case "login":
+		return runMCPOAuthLogin(args[1:], stdout, stderr, deps)
+	case "logout":
+		return runMCPOAuthLogout(args[1:], stdout, stderr, deps)
+	case "status":
+		return runMCPOAuthStatus(args[1:], stdout, stderr, deps)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown mcp oauth subcommand %q", args[0]))
+	}
+}
+
+func runMCPOAuthLogin(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	_, positional, help, err := parseMCPPositionalCommand(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPOAuthHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) != 1 {
+		return writeExecUsageError(stderr, "usage: zero mcp oauth login <server>")
+	}
+	serverName := positional[0]
+
+	server, err := resolveOAuthServer(deps, serverName)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	store, err := deps.newMCPTokenStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	// The opener prints the authorization URL so headless environments can copy
+	// it into a browser. The URL carries no token material.
+	opener := func(authURL string) error {
+		_, err := fmt.Fprintf(stdout, "Open this URL in your browser to authorize %s:\n\n  %s\n\nWaiting for the authorization callback...\n", serverName, authURL)
+		return err
+	}
+
+	token, err := mcp.Login(context.Background(), mcp.LoginOptions{
+		ServerName:  serverName,
+		ServerURL:   server.URL,
+		Config:      oauthConfigForServer(server),
+		OpenBrowser: opener,
+		Now:         deps.now,
+	})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if err := store.Save(serverName, token); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	if _, err := fmt.Fprintf(stdout, "Stored OAuth credentials for %s.\n", serverName); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runMCPOAuthLogout(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, positional, help, err := parseMCPPositionalCommand(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPOAuthHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) != 1 {
+		return writeExecUsageError(stderr, "usage: zero mcp oauth logout <server>")
+	}
+	serverName := positional[0]
+
+	store, err := deps.newMCPTokenStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	removed, err := store.Delete(serverName)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		payload := struct {
+			ServerName string `json:"serverName"`
+			Removed    bool   `json:"removed"`
+		}{ServerName: serverName, Removed: removed}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if removed {
+		if _, err := fmt.Fprintf(stdout, "Removed OAuth credentials for %s.\n", serverName); err != nil {
+			return exitCrash
+		}
+	} else if _, err := fmt.Fprintf(stdout, "No OAuth credentials stored for %s.\n", serverName); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runMCPOAuthStatus(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, positional, help, err := parseMCPPositionalCommand(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPOAuthHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) > 1 {
+		return writeExecUsageError(stderr, "usage: zero mcp oauth status [server]")
+	}
+
+	store, err := deps.newMCPTokenStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	statuses, err := store.Status()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if len(positional) == 1 {
+		statuses = filterTokenStatuses(statuses, positional[0])
+	}
+
+	if options.json {
+		// TokenStatus is redaction-safe by construction: it carries presence and
+		// expiry metadata but never the access or refresh token, so it is emitted
+		// directly. Routing time.Time through reflective redaction would mangle the
+		// expiry timestamp.
+		payload := struct {
+			Tokens []mcp.TokenStatus `json:"tokens"`
+		}{Tokens: statuses}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, mcp.FormatTokenStatuses(statuses)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func filterTokenStatuses(statuses []mcp.TokenStatus, serverName string) []mcp.TokenStatus {
+	filtered := make([]mcp.TokenStatus, 0, 1)
+	for _, status := range statuses {
+		if status.ServerName == serverName {
+			filtered = append(filtered, status)
+		}
+	}
+	return filtered
+}
+
+// resolveOAuthServer loads the workspace MCP config and returns the named server
+// after verifying it declares OAuth authentication.
+func resolveOAuthServer(deps appDeps, serverName string) (mcp.Server, error) {
+	if err := mcp.ValidateServerName(serverName); err != nil {
+		return mcp.Server{}, err
+	}
+	cwd, err := deps.getwd()
+	if err != nil {
+		return mcp.Server{}, fmt.Errorf("failed to resolve workspace: %w", err)
+	}
+	cfg, err := deps.resolveMCPConfig(cwd)
+	if err != nil {
+		return mcp.Server{}, err
+	}
+	servers, err := mcp.NormalizeConfig(cfg)
+	if err != nil {
+		return mcp.Server{}, err
+	}
+	for _, server := range servers {
+		if server.Name != serverName {
+			continue
+		}
+		if !strings.EqualFold(server.Auth, mcp.ServerAuthOAuth) {
+			return mcp.Server{}, fmt.Errorf("MCP server %q does not declare auth: \"oauth\"", serverName)
+		}
+		return server, nil
+	}
+	return mcp.Server{}, fmt.Errorf("MCP server %q is not configured", serverName)
+}
+
+func oauthConfigForServer(server mcp.Server) mcp.OAuthConfig {
+	if server.OAuth != nil {
+		return *server.OAuth
+	}
+	return mcp.OAuthConfig{}
+}
+
+func writeMCPOAuthHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp oauth <command>
+
+Commands:
+  login <server>     Run the OAuth flow and store credentials for a server
+  logout <server>    Delete stored OAuth credentials for a server
+  status [server]    Show credential presence and expiry (never the token)
+
+Flags:
+      --json    Print command result as JSON
+  -h, --help    Show this help
+`)
+	return err
+}

--- a/internal/cli/mcp_oauth_test.go
+++ b/internal/cli/mcp_oauth_test.go
@@ -142,7 +142,7 @@ func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
 
 	// Drive the loopback redirect as soon as the authorization URL is printed.
 	stdout := &syncBuffer{}
-	var stderr bytes.Buffer
+	stderr := &syncBuffer{}
 	go func() {
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
@@ -154,7 +154,19 @@ func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
 			time.Sleep(5 * time.Millisecond)
 		}
 	}()
-	exitCode := runWithDeps([]string{"mcp", "oauth", "login", "remote"}, stdout, &stderr, deps)
+	// Run the command (which blocks waiting for the callback) off-goroutine and
+	// bound it: if the callback is never driven, fail fast instead of hanging
+	// until the package test timeout.
+	done := make(chan int, 1)
+	go func() {
+		done <- runWithDeps([]string{"mcp", "oauth", "login", "remote"}, stdout, stderr, deps)
+	}()
+	var exitCode int
+	select {
+	case exitCode = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("login did not complete within 10s; stderr=%s stdout=%s", stderr.String(), stdout.String())
+	}
 	if exitCode != exitSuccess {
 		t.Fatalf("exitCode = %d stderr=%s stdout=%s", exitCode, stderr.String(), stdout.String())
 	}

--- a/internal/cli/mcp_oauth_test.go
+++ b/internal/cli/mcp_oauth_test.go
@@ -1,0 +1,234 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+)
+
+// syncBuffer is a goroutine-safe writer used when a background goroutine reads
+// CLI output while the command is still writing it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestRunMCPOAuthStatusReportsPresenceWithoutToken(t *testing.T) {
+	store, err := mcp.NewTokenStore(mcp.TokenStoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-oauth-tokens.json"),
+	})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	if err := store.Save("remote", mcp.StoredToken{
+		AccessToken:  "super-secret-access",
+		RefreshToken: "super-secret-refresh",
+		ExpiresAt:    expiry,
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	deps := appDeps{newMCPTokenStore: func() (*mcp.TokenStore, error) { return store, nil }}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"mcp", "oauth", "status", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "super-secret-access") || strings.Contains(out, "super-secret-refresh") {
+		t.Fatalf("status leaked token material: %s", out)
+	}
+	var payload struct {
+		Tokens []mcp.TokenStatus `json:"tokens"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode status JSON: %v\n%s", err, out)
+	}
+	if len(payload.Tokens) != 1 {
+		t.Fatalf("tokens = %#v, want one", payload.Tokens)
+	}
+	if !payload.Tokens[0].HasToken || !payload.Tokens[0].HasRefreshToken {
+		t.Fatalf("status = %#v, want present token", payload.Tokens[0])
+	}
+}
+
+func TestRunMCPOAuthLogout(t *testing.T) {
+	store, err := mcp.NewTokenStore(mcp.TokenStoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-oauth-tokens.json"),
+	})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("remote", mcp.StoredToken{AccessToken: "a", RefreshToken: "r"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	deps := appDeps{newMCPTokenStore: func() (*mcp.TokenStore, error) { return store, nil }}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"mcp", "oauth", "logout", "remote", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"removed": true`) {
+		t.Fatalf("logout output = %s", stdout.String())
+	}
+	if _, ok, _ := store.Load("remote"); ok {
+		t.Fatal("token still present after logout")
+	}
+}
+
+func TestRunMCPOAuthLoginStoresTokens(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-final",
+			"refresh_token": "refresh-final",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	store, err := mcp.NewTokenStore(mcp.TokenStoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-oauth-tokens.json"),
+	})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+
+	cwd := t.TempDir()
+	deps := appDeps{
+		getwd:            func() (string, error) { return cwd, nil },
+		newMCPTokenStore: func() (*mcp.TokenStore, error) { return store, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"remote": {
+					Type: "http",
+					URL:  "https://remote.invalid/mcp",
+					Auth: "oauth",
+					OAuth: &config.MCPOAuthConfig{
+						ClientID:              "client-123",
+						AuthorizationEndpoint: "https://remote.invalid/authorize",
+						TokenEndpoint:         tokenServer.URL,
+						Scopes:                []string{"read"},
+					},
+				},
+			}}, nil
+		},
+		now: time.Now,
+	}
+
+	// Drive the loopback redirect as soon as the authorization URL is printed.
+	stdout := &syncBuffer{}
+	var stderr bytes.Buffer
+	go func() {
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			callbackURL := extractCallbackURL(stdout.String())
+			if callbackURL != "" {
+				_, _ = http.Get(callbackURL)
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+	exitCode := runWithDeps([]string{"mcp", "oauth", "login", "remote"}, stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s stdout=%s", exitCode, stderr.String(), stdout.String())
+	}
+	token, ok, err := store.Load("remote")
+	if err != nil || !ok {
+		t.Fatalf("Load() ok=%v err=%v", ok, err)
+	}
+	if token.AccessToken != "access-final" || token.RefreshToken != "refresh-final" {
+		t.Fatalf("stored token = %#v", token)
+	}
+	// The login output must never echo the issued tokens.
+	if strings.Contains(stdout.String(), "access-final") || strings.Contains(stdout.String(), "refresh-final") {
+		t.Fatalf("login stdout leaked token: %s", stdout.String())
+	}
+}
+
+func TestRunMCPOAuthLoginRejectsNonOAuthServer(t *testing.T) {
+	cwd := t.TempDir()
+	store, err := mcp.NewTokenStore(mcp.TokenStoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-oauth-tokens.json"),
+	})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	deps := appDeps{
+		getwd:            func() (string, error) { return cwd, nil },
+		newMCPTokenStore: func() (*mcp.TokenStore, error) { return store, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"plain": {Type: "http", URL: "https://plain.invalid/mcp"},
+			}}, nil
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"mcp", "oauth", "login", "plain"}, &stdout, &stderr, deps)
+	if exitCode == exitSuccess {
+		t.Fatal("login on non-oauth server should fail")
+	}
+	if !strings.Contains(stderr.String(), "oauth") {
+		t.Fatalf("stderr = %q, want oauth guidance", stderr.String())
+	}
+}
+
+func TestRunMCPOAuthUnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"mcp", "oauth", "bogus"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitUsage {
+		t.Fatalf("exitCode = %d, want usage error", exitCode)
+	}
+}
+
+// extractCallbackURL pulls the printed authorization URL and rewrites it into a
+// loopback callback hit carrying the code and state.
+func extractCallbackURL(output string) string {
+	const marker = "https://remote.invalid/authorize"
+	index := strings.Index(output, marker)
+	if index < 0 {
+		return ""
+	}
+	rest := output[index:]
+	if end := strings.IndexAny(rest, " \n"); end >= 0 {
+		rest = rest[:end]
+	}
+	parsed, err := url.Parse(rest)
+	if err != nil {
+		return ""
+	}
+	state := parsed.Query().Get("state")
+	if state == "" {
+		return ""
+	}
+	redirect := parsed.Query().Get("redirect_uri")
+	if redirect == "" {
+		return ""
+	}
+	return redirect + "?code=auth-code&state=" + url.QueryEscape(state)
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -559,6 +559,12 @@ func mergeMCPServer(base MCPServerConfig, next MCPServerConfig) MCPServerConfig 
 	if next.Headers != nil {
 		base.Headers = copyMCPStringMap(next.Headers)
 	}
+	if strings.TrimSpace(next.Auth) != "" {
+		base.Auth = next.Auth
+	}
+	if next.OAuth != nil {
+		base.OAuth = next.OAuth
+	}
 	if next.disabledSet || next.Disabled {
 		base.Disabled = next.Disabled
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -162,8 +162,25 @@ type MCPServerConfig struct {
 	Env         map[string]string `json:"env,omitempty"`
 	URL         string            `json:"url,omitempty"`
 	Headers     map[string]string `json:"headers,omitempty"`
+	Auth        string            `json:"auth,omitempty"`
+	OAuth       *MCPOAuthConfig   `json:"oauth,omitempty"`
 	Disabled    bool              `json:"disabled,omitempty"`
 	disabledSet bool
+}
+
+// MCPOAuthConfig describes how to authenticate to a remote MCP server using an
+// OAuth 2.0 + PKCE authorization-code flow. Endpoints may be discovered from the
+// authorization server's metadata document; explicit values here override or
+// fill in anything discovery cannot provide. Client credentials are optional
+// when the server supports dynamic client registration.
+type MCPOAuthConfig struct {
+	ClientID              string   `json:"clientID,omitempty"`
+	ClientSecret          string   `json:"clientSecret,omitempty"`
+	Scopes                []string `json:"scopes,omitempty"`
+	AuthorizationEndpoint string   `json:"authorizationEndpoint,omitempty"`
+	TokenEndpoint         string   `json:"tokenEndpoint,omitempty"`
+	RegistrationEndpoint  string   `json:"registrationEndpoint,omitempty"`
+	IssuerURL             string   `json:"issuerURL,omitempty"`
 }
 
 func (cfg *FileConfig) UnmarshalJSON(data []byte) error {
@@ -215,6 +232,8 @@ func (server *MCPServerConfig) UnmarshalJSON(data []byte) error {
 		Env      map[string]string `json:"env"`
 		URL      string            `json:"url"`
 		Headers  map[string]string `json:"headers"`
+		Auth     string            `json:"auth"`
+		OAuth    *MCPOAuthConfig   `json:"oauth"`
 		Disabled *bool             `json:"disabled"`
 	}
 
@@ -228,6 +247,8 @@ func (server *MCPServerConfig) UnmarshalJSON(data []byte) error {
 	server.Env = raw.Env
 	server.URL = raw.URL
 	server.Headers = raw.Headers
+	server.Auth = raw.Auth
+	server.OAuth = raw.OAuth
 	server.Disabled = false
 	server.disabledSet = false
 	if raw.Disabled != nil {

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -28,6 +28,8 @@ type Server struct {
 	Env      map[string]string
 	URL      string
 	Headers  map[string]string
+	Auth     string
+	OAuth    *OAuthConfig
 	Identity string
 }
 
@@ -70,6 +72,7 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 		}
 	}
 
+	auth := strings.ToLower(strings.TrimSpace(raw.Auth))
 	server := Server{
 		Name:    name,
 		Type:    serverType,
@@ -78,6 +81,8 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 		Env:     copyStringMap(raw.Env),
 		URL:     strings.TrimSpace(raw.URL),
 		Headers: copyStringMap(raw.Headers),
+		Auth:    auth,
+		OAuth:   normalizeOAuthConfig(raw.OAuth),
 	}
 
 	switch server.Type {
@@ -90,6 +95,9 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 		}
 		if len(server.Headers) > 0 {
 			return Server{}, fmt.Errorf("MCP server %s headers are only supported for http or sse transports", server.Name)
+		}
+		if server.Auth != "" {
+			return Server{}, fmt.Errorf("MCP server %s auth is only supported for http or sse transports", server.Name)
 		}
 	case ServerTypeHTTP, ServerTypeSSE:
 		if server.URL == "" {
@@ -108,8 +116,30 @@ func normalizeServer(name string, raw config.MCPServerConfig) (Server, error) {
 		return Server{}, fmt.Errorf("MCP server %s has unsupported type %q", server.Name, raw.Type)
 	}
 
+	if server.Auth != "" && server.Auth != ServerAuthOAuth {
+		return Server{}, fmt.Errorf("MCP server %s has unsupported auth %q", server.Name, raw.Auth)
+	}
+
 	server.Identity = computeServerIdentity(server)
 	return server, nil
+}
+
+// normalizeOAuthConfig converts a raw config OAuth block into the mcp package's
+// OAuthConfig, trimming endpoint and identifier fields. Credential values are
+// preserved verbatim.
+func normalizeOAuthConfig(raw *config.MCPOAuthConfig) *OAuthConfig {
+	if raw == nil {
+		return nil
+	}
+	return &OAuthConfig{
+		ClientID:              strings.TrimSpace(raw.ClientID),
+		ClientSecret:          raw.ClientSecret,
+		Scopes:                trimStringSlice(raw.Scopes),
+		AuthorizationEndpoint: strings.TrimSpace(raw.AuthorizationEndpoint),
+		TokenEndpoint:         strings.TrimSpace(raw.TokenEndpoint),
+		RegistrationEndpoint:  strings.TrimSpace(raw.RegistrationEndpoint),
+		IssuerURL:             strings.TrimSpace(raw.IssuerURL),
+	}
 }
 
 func validateHTTPURL(serverName string, value string) error {
@@ -131,6 +161,8 @@ func computeServerIdentity(server Server) string {
 		Env     map[string]string `json:"env,omitempty"`
 		URL     string            `json:"url,omitempty"`
 		Headers map[string]string `json:"headers,omitempty"`
+		Auth    string            `json:"auth,omitempty"`
+		OAuth   *OAuthConfig      `json:"oauth,omitempty"`
 	}{
 		Type:    server.Type,
 		Command: server.Command,
@@ -138,6 +170,8 @@ func computeServerIdentity(server Server) string {
 		Env:     copyStringMap(server.Env),
 		URL:     server.URL,
 		Headers: copyStringMap(server.Headers),
+		Auth:    server.Auth,
+		OAuth:   server.OAuth,
 	}
 	// Marshal cannot fail for this canonical shape because it only contains
 	// JSON-serializable primitive, slice, and map fields.

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -136,6 +136,71 @@ func TestServerIdentityChangesWithTransportFields(t *testing.T) {
 	}
 }
 
+func TestNormalizeConfigCarriesOAuth(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"remote": {
+			Type: "http",
+			URL:  "https://example.com/mcp",
+			Auth: "oauth",
+			OAuth: &config.MCPOAuthConfig{
+				ClientID:      "client-123",
+				Scopes:        []string{" read ", "write", "  "},
+				TokenEndpoint: " https://example.com/token ",
+			},
+		},
+	}}
+
+	servers, err := NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("NormalizeConfig() error = %v", err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("servers = %#v", servers)
+	}
+	server := servers[0]
+	if server.Auth != ServerAuthOAuth {
+		t.Fatalf("auth = %q, want oauth", server.Auth)
+	}
+	if server.OAuth == nil {
+		t.Fatal("OAuth = nil, want carried config")
+	}
+	if server.OAuth.ClientID != "client-123" {
+		t.Fatalf("client id = %q", server.OAuth.ClientID)
+	}
+	if server.OAuth.TokenEndpoint != "https://example.com/token" {
+		t.Fatalf("token endpoint = %q, want trimmed", server.OAuth.TokenEndpoint)
+	}
+	if len(server.OAuth.Scopes) != 2 || server.OAuth.Scopes[0] != "read" || server.OAuth.Scopes[1] != "write" {
+		t.Fatalf("scopes = %#v, want trimmed and filtered", server.OAuth.Scopes)
+	}
+}
+
+func TestNormalizeConfigRejectsUnsupportedAuth(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"remote": {Type: "http", URL: "https://example.com/mcp", Auth: "basic"},
+	}}
+	_, err := NormalizeConfig(cfg)
+	if err == nil {
+		t.Fatal("NormalizeConfig() error = nil, want unsupported auth error")
+	}
+	if !strings.Contains(err.Error(), "unsupported auth") {
+		t.Fatalf("error = %q, want unsupported auth", err.Error())
+	}
+}
+
+func TestNormalizeConfigRejectsAuthOnStdio(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"local": {Type: "stdio", Command: "local-mcp", Auth: "oauth"},
+	}}
+	_, err := NormalizeConfig(cfg)
+	if err == nil {
+		t.Fatal("NormalizeConfig() error = nil, want auth-on-stdio error")
+	}
+	if !strings.Contains(err.Error(), "auth is only supported") {
+		t.Fatalf("error = %q, want auth-on-stdio error", err.Error())
+	}
+}
+
 func TestCopyStringMapTrimsKeysAndPreservesValues(t *testing.T) {
 	copied := copyStringMap(map[string]string{
 		" TOKEN ": "  keep surrounding spaces  ",

--- a/internal/mcp/network_client.go
+++ b/internal/mcp/network_client.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 )
 
 type networkClient struct {
@@ -47,9 +48,13 @@ type sseEvent struct {
 }
 
 func connectNetwork(ctx context.Context, server Server) (ToolClient, error) {
+	httpClient, err := oauthHTTPClient(server)
+	if err != nil {
+		return nil, err
+	}
 	client := &networkClient{
 		server: server,
-		client: http.DefaultClient,
+		client: httpClient,
 		nextID: 1,
 	}
 	if err := client.initialize(ctx); err != nil {
@@ -59,9 +64,13 @@ func connectNetwork(ctx context.Context, server Server) (ToolClient, error) {
 }
 
 func connectRemoteSSE(ctx context.Context, server Server) (ToolClient, error) {
+	httpClient, err := oauthHTTPClient(server)
+	if err != nil {
+		return nil, err
+	}
 	client := &remoteSSEClient{
 		server:  server,
-		client:  http.DefaultClient,
+		client:  httpClient,
 		nextID:  1,
 		pending: map[string]chan ssePendingResponse{},
 	}
@@ -702,4 +711,152 @@ func rpcResponseKey(id any) string {
 		return ""
 	}
 	return fmt.Sprint(id)
+}
+
+// oauthTokenSource supplies a current bearer token and refreshes it on demand.
+type oauthTokenSource interface {
+	AccessToken(ctx context.Context) (string, error)
+	Refresh(ctx context.Context) (string, error)
+}
+
+// oauthRoundTripper attaches a bearer token to every request and, on a 401,
+// refreshes the token once and retries the request a single time. A refresh
+// failure is surfaced as an actionable error that points at the login command.
+type oauthRoundTripper struct {
+	base       http.RoundTripper
+	source     oauthTokenSource
+	serverName string
+}
+
+func newOAuthRoundTripper(base http.RoundTripper, source oauthTokenSource, serverName string) *oauthRoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &oauthRoundTripper{base: base, source: source, serverName: serverName}
+}
+
+func (transport *oauthRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	token, err := transport.source.AccessToken(request.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	first, body, err := cloneRequestWithBearer(request, token)
+	if err != nil {
+		return nil, err
+	}
+	response, err := transport.base.RoundTrip(first)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusUnauthorized {
+		return response, nil
+	}
+
+	// Drain and close the 401 body before retrying to free the connection.
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+
+	refreshed, refreshErr := transport.source.Refresh(request.Context())
+	if refreshErr != nil {
+		return nil, fmt.Errorf("MCP OAuth token refresh failed for %s: re-run `zero mcp oauth login %s`: %w", transport.serverName, transport.serverName, refreshErr)
+	}
+
+	retry, _, err := cloneRequestWithBearer(request, refreshed)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		retry.Body = io.NopCloser(bytes.NewReader(body))
+		retry.ContentLength = int64(len(body))
+	}
+	return transport.base.RoundTrip(retry)
+}
+
+// cloneRequestWithBearer copies a request, buffers its body so the request can
+// be retried, and sets the Authorization header.
+func cloneRequestWithBearer(request *http.Request, token string) (*http.Request, []byte, error) {
+	var body []byte
+	if request.Body != nil {
+		buffered, err := io.ReadAll(request.Body)
+		_ = request.Body.Close()
+		if err != nil {
+			return nil, nil, err
+		}
+		body = buffered
+	}
+	clone := request.Clone(request.Context())
+	if body != nil {
+		clone.Body = io.NopCloser(bytes.NewReader(body))
+		clone.ContentLength = int64(len(body))
+	}
+	if strings.TrimSpace(token) != "" {
+		clone.Header.Set("Authorization", "Bearer "+token)
+	}
+	return clone, body, nil
+}
+
+// storeTokenSource adapts the persistent token store and refresh logic to the
+// oauthTokenSource interface used by the round tripper.
+type storeTokenSource struct {
+	server     Server
+	store      *TokenStore
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func (source *storeTokenSource) config() OAuthConfig {
+	if source.server.OAuth != nil {
+		return *source.server.OAuth
+	}
+	return OAuthConfig{}
+}
+
+func (source *storeTokenSource) AccessToken(ctx context.Context) (string, error) {
+	token, ok, err := source.store.Load(source.server.Name)
+	if err != nil {
+		return "", err
+	}
+	if !ok || strings.TrimSpace(token.AccessToken) == "" {
+		return "", fmt.Errorf("no stored OAuth token for MCP server %s: run `zero mcp oauth login %s`", source.server.Name, source.server.Name)
+	}
+	return token.AccessToken, nil
+}
+
+func (source *storeTokenSource) Refresh(ctx context.Context) (string, error) {
+	token, ok, err := source.store.Load(source.server.Name)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("no stored OAuth token for MCP server %s", source.server.Name)
+	}
+	refreshed, err := refreshAccessToken(ctx, source.httpClient, source.config(), token, source.now)
+	if err != nil {
+		return "", err
+	}
+	if err := source.store.Save(source.server.Name, refreshed); err != nil {
+		return "", err
+	}
+	return refreshed.AccessToken, nil
+}
+
+// oauthHTTPClient returns an HTTP client whose transport attaches OAuth bearer
+// tokens and refreshes them on 401 for OAuth-configured servers. Servers that do
+// not declare OAuth get the default client unchanged.
+func oauthHTTPClient(server Server) (*http.Client, error) {
+	if !strings.EqualFold(strings.TrimSpace(server.Auth), ServerAuthOAuth) {
+		return http.DefaultClient, nil
+	}
+	store, err := NewTokenStore(TokenStoreOptions{})
+	if err != nil {
+		return nil, err
+	}
+	source := &storeTokenSource{
+		server:     server,
+		store:      store,
+		httpClient: http.DefaultClient,
+		now:        time.Now,
+	}
+	return &http.Client{Transport: newOAuthRoundTripper(http.DefaultTransport, source, server.Name)}, nil
 }

--- a/internal/mcp/network_client_test.go
+++ b/internal/mcp/network_client_test.go
@@ -1,0 +1,181 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeTokenSource drives the OAuth round tripper without a real provider. It
+// hands out a current access token and, on refresh, advances to a new one. A
+// failing refresh returns an error to exercise the actionable-error path.
+type fakeTokenSource struct {
+	access      atomic.Value // string
+	refreshFunc func() (string, error)
+	refreshes   int32
+}
+
+func (s *fakeTokenSource) AccessToken(context.Context) (string, error) {
+	value, _ := s.access.Load().(string)
+	return value, nil
+}
+
+func (s *fakeTokenSource) Refresh(context.Context) (string, error) {
+	atomic.AddInt32(&s.refreshes, 1)
+	token, err := s.refreshFunc()
+	if err != nil {
+		return "", err
+	}
+	s.access.Store(token)
+	return token, nil
+}
+
+func TestOAuthRoundTripperAttachesBearer(t *testing.T) {
+	var gotAuth atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	source := &fakeTokenSource{}
+	source.access.Store("access-1")
+	source.refreshFunc = func() (string, error) { return "access-2", nil }
+
+	client := &http.Client{Transport: newOAuthRoundTripper(http.DefaultTransport, source, "demo")}
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	resp.Body.Close()
+	if got, _ := gotAuth.Load().(string); got != "Bearer access-1" {
+		t.Fatalf("Authorization = %q, want Bearer access-1", got)
+	}
+	if atomic.LoadInt32(&source.refreshes) != 0 {
+		t.Fatal("refresh called without a 401")
+	}
+}
+
+func TestOAuthRoundTripperRefreshesOn401AndRetriesOnce(t *testing.T) {
+	source := &fakeTokenSource{}
+	source.access.Store("access-stale")
+	source.refreshFunc = func() (string, error) { return "access-fresh", nil }
+
+	var attempts int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		auth := r.Header.Get("Authorization")
+		if n == 1 {
+			if auth != "Bearer access-stale" {
+				t.Errorf("first attempt auth = %q", auth)
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if auth != "Bearer access-fresh" {
+			t.Errorf("retry auth = %q, want refreshed token", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	client := &http.Client{Transport: newOAuthRoundTripper(http.DefaultTransport, source, "demo")}
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after refresh", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("upstream attempts = %d, want exactly 2 (retry once)", got)
+	}
+	if got := atomic.LoadInt32(&source.refreshes); got != 1 {
+		t.Fatalf("refreshes = %d, want 1", got)
+	}
+}
+
+func TestOAuthRoundTripperRefreshFailureSurfacesActionableError(t *testing.T) {
+	source := &fakeTokenSource{}
+	source.access.Store("access-stale")
+	source.refreshFunc = func() (string, error) { return "", context.DeadlineExceeded }
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	client := &http.Client{Transport: newOAuthRoundTripper(http.DefaultTransport, source, "demo")}
+	_, err := client.Get(upstream.URL)
+	if err == nil {
+		t.Fatal("Get() error = nil, want actionable refresh failure")
+	}
+	if !strings.Contains(err.Error(), "zero mcp oauth login demo") {
+		t.Fatalf("error = %q, want actionable re-login message", err.Error())
+	}
+}
+
+func TestOAuthRoundTripperDoesNotRetryAfterSuccessfulNon401(t *testing.T) {
+	source := &fakeTokenSource{}
+	source.access.Store("access-1")
+	source.refreshFunc = func() (string, error) { return "access-2", nil }
+
+	var attempts int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer upstream.Close()
+
+	client := &http.Client{Transport: newOAuthRoundTripper(http.DefaultTransport, source, "demo")}
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 passed through", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry on non-401)", got)
+	}
+	if got := atomic.LoadInt32(&source.refreshes); got != 0 {
+		t.Fatalf("refreshes = %d, want 0", got)
+	}
+}
+
+func TestNonOAuthServerIsUnaffected(t *testing.T) {
+	// Regression: a server without auth must not get a bearer header or any
+	// OAuth round tripper, and must connect normally.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); strings.HasPrefix(got, "Bearer") {
+			t.Errorf("non-oauth server received bearer header %q", got)
+		}
+		message := readHTTPRPCMessage(t, r)
+		switch message.Method {
+		case "initialize":
+			writeHTTPRPCResponse(t, w, message.ID, map[string]any{"protocolVersion": "2024-11-05"})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			writeHTTPRPCResponse(t, w, message.ID, map[string]any{})
+		}
+	}))
+	defer upstream.Close()
+
+	client, err := Connect(ctx, Server{Name: "plain", Type: ServerTypeHTTP, URL: upstream.URL})
+	if err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}

--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -1,0 +1,515 @@
+package mcp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ServerAuthOAuth is the value of an MCP server's auth field that selects the
+// OAuth 2.0 + PKCE authorization-code flow.
+const ServerAuthOAuth = "oauth"
+
+const (
+	wellKnownAuthServerPath = "/.well-known/oauth-authorization-server"
+	defaultLoginTimeout     = 3 * time.Minute
+	// pkceVerifierBytes yields a 43-character base64url verifier, the minimum
+	// length permitted by the PKCE spec while remaining high-entropy.
+	pkceVerifierBytes = 32
+	stateBytes        = 32
+)
+
+// OAuthConfig describes how to authenticate to a remote MCP server using OAuth.
+// Endpoints may be discovered from the server's metadata document; explicit
+// values here override or fill in anything discovery cannot provide.
+type OAuthConfig struct {
+	ClientID              string
+	ClientSecret          string
+	Scopes                []string
+	AuthorizationEndpoint string
+	TokenEndpoint         string
+	RegistrationEndpoint  string
+	// IssuerURL overrides the base URL used for metadata discovery. When empty
+	// the MCP server URL is used.
+	IssuerURL string
+}
+
+// authServerMetadata is the subset of the OAuth 2.0 authorization server
+// metadata document that the flow consumes.
+type authServerMetadata struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RegistrationEndpoint  string   `json:"registration_endpoint"`
+	ScopesSupported       []string `json:"scopes_supported"`
+}
+
+// pkceParams holds a PKCE verifier/challenge pair.
+type pkceParams struct {
+	Verifier  string
+	Challenge string
+	Method    string
+}
+
+// LoginOptions configures a single interactive authorization-code login.
+type LoginOptions struct {
+	ServerName string
+	ServerURL  string
+	Config     OAuthConfig
+	HTTPClient *http.Client
+	// OpenBrowser is invoked with the authorization URL. The default prints the
+	// URL; tests inject a function that drives the loopback redirect.
+	OpenBrowser func(authURL string) error
+	Timeout     time.Duration
+	Now         func() time.Time
+}
+
+// authorizationFlow carries the per-login state shared across helpers.
+type authorizationFlow struct {
+	httpClient *http.Client
+	metadata   authServerMetadata
+	config     OAuthConfig
+	pkce       pkceParams
+	state      string
+	now        func() time.Time
+}
+
+// discoverAuthorizationServer fetches the OAuth 2.0 authorization server
+// metadata document published at the well-known path under the given base URL.
+func discoverAuthorizationServer(ctx context.Context, client *http.Client, baseURL string) (authServerMetadata, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	metadataURL, err := joinWellKnown(baseURL)
+	if err != nil {
+		return authServerMetadata{}, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return authServerMetadata{}, err
+	}
+	request.Header.Set("Accept", "application/json")
+	response, err := client.Do(request)
+	if err != nil {
+		return authServerMetadata{}, fmt.Errorf("fetch authorization server metadata: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return authServerMetadata{}, fmt.Errorf("authorization server metadata returned HTTP %d", response.StatusCode)
+	}
+	var metadata authServerMetadata
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&metadata); err != nil {
+		return authServerMetadata{}, fmt.Errorf("decode authorization server metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+// resolveAuthorizationServer discovers metadata and applies explicit config
+// overrides. Configured endpoints take precedence over discovered ones, and act
+// as a fallback when discovery fails or omits a value.
+func resolveAuthorizationServer(ctx context.Context, client *http.Client, baseURL string, cfg OAuthConfig) (authServerMetadata, error) {
+	discoveryBase := strings.TrimSpace(cfg.IssuerURL)
+	if discoveryBase == "" {
+		discoveryBase = baseURL
+	}
+
+	metadata, err := discoverAuthorizationServer(ctx, client, discoveryBase)
+	if err != nil {
+		// Discovery failures are non-fatal when the config supplies the endpoints
+		// directly; otherwise surface the discovery error.
+		metadata = authServerMetadata{}
+	}
+
+	if endpoint := strings.TrimSpace(cfg.AuthorizationEndpoint); endpoint != "" {
+		metadata.AuthorizationEndpoint = endpoint
+	}
+	if endpoint := strings.TrimSpace(cfg.TokenEndpoint); endpoint != "" {
+		metadata.TokenEndpoint = endpoint
+	}
+	if endpoint := strings.TrimSpace(cfg.RegistrationEndpoint); endpoint != "" {
+		metadata.RegistrationEndpoint = endpoint
+	}
+
+	if strings.TrimSpace(metadata.AuthorizationEndpoint) == "" {
+		return authServerMetadata{}, errors.New("no authorization endpoint discovered or configured")
+	}
+	if strings.TrimSpace(metadata.TokenEndpoint) == "" {
+		return authServerMetadata{}, errors.New("no token endpoint discovered or configured")
+	}
+	return metadata, nil
+}
+
+// newPKCE generates a high-entropy code verifier and its S256 challenge.
+func newPKCE() (pkceParams, error) {
+	verifierRaw := make([]byte, pkceVerifierBytes)
+	if _, err := rand.Read(verifierRaw); err != nil {
+		return pkceParams{}, fmt.Errorf("generate PKCE verifier: %w", err)
+	}
+	verifier := base64.RawURLEncoding.EncodeToString(verifierRaw)
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	return pkceParams{Verifier: verifier, Challenge: challenge, Method: "S256"}, nil
+}
+
+func newState() (string, error) {
+	raw := make([]byte, stateBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+// authorizationURL builds the authorization request URL.
+func (flow *authorizationFlow) authorizationURL(redirectURI string) (string, error) {
+	parsed, err := url.Parse(flow.metadata.AuthorizationEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse authorization endpoint: %w", err)
+	}
+	query := parsed.Query()
+	query.Set("response_type", "code")
+	query.Set("client_id", flow.config.ClientID)
+	query.Set("redirect_uri", redirectURI)
+	query.Set("state", flow.state)
+	query.Set("code_challenge", flow.pkce.Challenge)
+	query.Set("code_challenge_method", flow.pkce.Method)
+	if len(flow.config.Scopes) > 0 {
+		query.Set("scope", strings.Join(flow.config.Scopes, " "))
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+// parseCallback validates the redirect query and returns the authorization
+// code. It rejects a mismatched state (CSRF) and surfaces provider errors.
+func (flow *authorizationFlow) parseCallback(values url.Values) (string, error) {
+	if got := values.Get("state"); got != flow.state {
+		return "", errors.New("OAuth callback state mismatch: possible CSRF, login aborted")
+	}
+	if providerErr := strings.TrimSpace(values.Get("error")); providerErr != "" {
+		description := strings.TrimSpace(values.Get("error_description"))
+		if description != "" {
+			return "", fmt.Errorf("authorization server returned error %q: %s", providerErr, description)
+		}
+		return "", fmt.Errorf("authorization server returned error %q", providerErr)
+	}
+	code := strings.TrimSpace(values.Get("code"))
+	if code == "" {
+		return "", errors.New("OAuth callback missing authorization code")
+	}
+	return code, nil
+}
+
+// exchangeCode swaps an authorization code + PKCE verifier for tokens.
+func (flow *authorizationFlow) exchangeCode(ctx context.Context, code string, redirectURI string) (StoredToken, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", flow.config.ClientID)
+	form.Set("code_verifier", flow.pkce.Verifier)
+	if secret := strings.TrimSpace(flow.config.ClientSecret); secret != "" {
+		form.Set("client_secret", secret)
+	}
+	return postTokenRequest(ctx, flow.httpClient, flow.metadata.TokenEndpoint, form, StoredToken{Scopes: flow.config.Scopes}, flow.now)
+}
+
+// refreshAccessToken exchanges a refresh token for a fresh access token. A
+// response that omits a new refresh token preserves the previous one.
+func refreshAccessToken(ctx context.Context, client *http.Client, cfg OAuthConfig, current StoredToken, now func() time.Time) (StoredToken, error) {
+	refresh := strings.TrimSpace(current.RefreshToken)
+	if refresh == "" {
+		return StoredToken{}, errors.New("no refresh token available")
+	}
+	tokenEndpoint := strings.TrimSpace(cfg.TokenEndpoint)
+	if tokenEndpoint == "" {
+		return StoredToken{}, errors.New("no token endpoint configured for refresh")
+	}
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refresh)
+	form.Set("client_id", cfg.ClientID)
+	if secret := strings.TrimSpace(cfg.ClientSecret); secret != "" {
+		form.Set("client_secret", secret)
+	}
+	if len(cfg.Scopes) > 0 {
+		form.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+	refreshed, err := postTokenRequest(ctx, client, tokenEndpoint, form, StoredToken{Scopes: current.Scopes, RefreshToken: refresh}, now)
+	if err != nil {
+		return StoredToken{}, err
+	}
+	return refreshed, nil
+}
+
+// tokenResponse is the JSON returned by the token endpoint.
+type tokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int64  `json:"expires_in"`
+	Scope            string `json:"scope"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// postTokenRequest performs a token endpoint POST and maps the response onto a
+// StoredToken. The base token supplies values to preserve (e.g. an existing
+// refresh token or scope set) when the response omits them.
+func postTokenRequest(ctx context.Context, client *http.Client, tokenEndpoint string, form url.Values, base StoredToken, now func() time.Time) (StoredToken, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if now == nil {
+		now = time.Now
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return StoredToken{}, err
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Accept", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return StoredToken{}, fmt.Errorf("token request failed: %w", err)
+	}
+	defer response.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	var parsed tokenResponse
+	if len(body) > 0 {
+		// A malformed body on an error status is reported as a status error below.
+		_ = json.Unmarshal(body, &parsed)
+	}
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		if parsed.Error != "" {
+			if parsed.ErrorDescription != "" {
+				return StoredToken{}, fmt.Errorf("token endpoint error %q: %s", parsed.Error, parsed.ErrorDescription)
+			}
+			return StoredToken{}, fmt.Errorf("token endpoint error %q", parsed.Error)
+		}
+		return StoredToken{}, fmt.Errorf("token endpoint returned HTTP %d", response.StatusCode)
+	}
+	if strings.TrimSpace(parsed.AccessToken) == "" {
+		return StoredToken{}, errors.New("token endpoint returned no access token")
+	}
+
+	token := base
+	token.AccessToken = parsed.AccessToken
+	if strings.TrimSpace(parsed.RefreshToken) != "" {
+		token.RefreshToken = parsed.RefreshToken
+	}
+	if strings.TrimSpace(parsed.TokenType) != "" {
+		token.TokenType = parsed.TokenType
+	}
+	if parsed.ExpiresIn > 0 {
+		token.ExpiresAt = now().Add(time.Duration(parsed.ExpiresIn) * time.Second).UTC()
+	}
+	if scope := strings.TrimSpace(parsed.Scope); scope != "" {
+		token.Scopes = strings.Fields(scope)
+	}
+	return token, nil
+}
+
+// registerClient performs dynamic client registration against the registration
+// endpoint and returns the issued client_id and optional client_secret.
+func registerClient(ctx context.Context, client *http.Client, registrationEndpoint string, redirectURI string, scopes []string) (string, string, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	payload := map[string]any{
+		"client_name":                "zero",
+		"redirect_uris":              []string{redirectURI},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	}
+	if len(scopes) > 0 {
+		payload["scope"] = strings.Join(scopes, " ")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, strings.NewReader(string(body)))
+	if err != nil {
+		return "", "", err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return "", "", fmt.Errorf("client registration failed: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return "", "", fmt.Errorf("client registration returned HTTP %d", response.StatusCode)
+	}
+	var registered struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&registered); err != nil {
+		return "", "", fmt.Errorf("decode client registration response: %w", err)
+	}
+	if strings.TrimSpace(registered.ClientID) == "" {
+		return "", "", errors.New("client registration returned no client_id")
+	}
+	return registered.ClientID, registered.ClientSecret, nil
+}
+
+// Login runs the full OAuth 2.0 + PKCE authorization-code flow: it discovers (or
+// falls back to configured) endpoints, optionally registers a client, starts a
+// loopback redirect listener, opens the authorization URL, validates the
+// callback state, and exchanges the code for tokens. Tokens are returned and are
+// never logged.
+func Login(ctx context.Context, options LoginOptions) (StoredToken, error) {
+	if err := ValidateServerName(options.ServerName); err != nil {
+		return StoredToken{}, err
+	}
+	httpClient := options.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = defaultLoginTimeout
+	}
+
+	cfg := options.Config
+	metadata, err := resolveAuthorizationServer(ctx, httpClient, options.ServerURL, cfg)
+	if err != nil {
+		return StoredToken{}, err
+	}
+
+	// Bind the loopback redirect listener first so the redirect URI is known
+	// before client registration and authorization URL construction.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return StoredToken{}, fmt.Errorf("start loopback redirect listener: %w", err)
+	}
+	defer listener.Close()
+	redirectURI := fmt.Sprintf("http://%s/callback", listener.Addr().String())
+
+	if strings.TrimSpace(cfg.ClientID) == "" {
+		if registration := strings.TrimSpace(metadata.RegistrationEndpoint); registration != "" {
+			clientID, clientSecret, regErr := registerClient(ctx, httpClient, registration, redirectURI, cfg.Scopes)
+			if regErr != nil {
+				return StoredToken{}, regErr
+			}
+			cfg.ClientID = clientID
+			if clientSecret != "" {
+				cfg.ClientSecret = clientSecret
+			}
+		}
+	}
+	if strings.TrimSpace(cfg.ClientID) == "" {
+		return StoredToken{}, errors.New("no client_id configured and dynamic registration unavailable")
+	}
+
+	pkce, err := newPKCE()
+	if err != nil {
+		return StoredToken{}, err
+	}
+	state, err := newState()
+	if err != nil {
+		return StoredToken{}, err
+	}
+
+	flow := &authorizationFlow{
+		httpClient: httpClient,
+		metadata:   metadata,
+		config:     cfg,
+		pkce:       pkce,
+		state:      state,
+		now:        now,
+	}
+
+	authURL, err := flow.authorizationURL(redirectURI)
+	if err != nil {
+		return StoredToken{}, err
+	}
+
+	type callbackResult struct {
+		code string
+		err  error
+	}
+	resultChan := make(chan callbackResult, 1)
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/callback" {
+				http.NotFound(w, r)
+				return
+			}
+			code, parseErr := flow.parseCallback(r.URL.Query())
+			if parseErr != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, "Authorization failed. You may close this window.")
+			} else {
+				_, _ = io.WriteString(w, "Authorization complete. You may close this window.")
+			}
+			select {
+			case resultChan <- callbackResult{code: code, err: parseErr}:
+			default:
+			}
+		}),
+	}
+	go func() { _ = server.Serve(listener) }()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	open := options.OpenBrowser
+	if open == nil {
+		open = func(string) error { return nil }
+	}
+	if err := open(authURL); err != nil {
+		return StoredToken{}, fmt.Errorf("open authorization URL: %w", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	select {
+	case result := <-resultChan:
+		if result.err != nil {
+			return StoredToken{}, result.err
+		}
+		token, err := flow.exchangeCode(waitCtx, result.code, redirectURI)
+		if err != nil {
+			return StoredToken{}, err
+		}
+		return token, nil
+	case <-waitCtx.Done():
+		return StoredToken{}, fmt.Errorf("timed out waiting for OAuth authorization callback: %w", waitCtx.Err())
+	}
+}
+
+func joinWellKnown(baseURL string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed.Host == "" {
+		return "", fmt.Errorf("invalid base URL for metadata discovery: %q", baseURL)
+	}
+	parsed.Path = wellKnownAuthServerPath
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}

--- a/internal/mcp/oauth.go
+++ b/internal/mcp/oauth.go
@@ -391,9 +391,15 @@ func Login(ctx context.Context, options LoginOptions) (StoredToken, error) {
 	if timeout <= 0 {
 		timeout = defaultLoginTimeout
 	}
+	// One deadline bounds the WHOLE interactive login — discovery, optional client
+	// registration, the callback wait, and the code exchange — so a hung
+	// metadata/registration/token endpoint can't block the command forever (the
+	// CLI passes a non-cancelable context).
+	loginCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	cfg := options.Config
-	metadata, err := resolveAuthorizationServer(ctx, httpClient, options.ServerURL, cfg)
+	metadata, err := resolveAuthorizationServer(loginCtx, httpClient, options.ServerURL, cfg)
 	if err != nil {
 		return StoredToken{}, err
 	}
@@ -409,7 +415,7 @@ func Login(ctx context.Context, options LoginOptions) (StoredToken, error) {
 
 	if strings.TrimSpace(cfg.ClientID) == "" {
 		if registration := strings.TrimSpace(metadata.RegistrationEndpoint); registration != "" {
-			clientID, clientSecret, regErr := registerClient(ctx, httpClient, registration, redirectURI, cfg.Scopes)
+			clientID, clientSecret, regErr := registerClient(loginCtx, httpClient, registration, redirectURI, cfg.Scopes)
 			if regErr != nil {
 				return StoredToken{}, regErr
 			}
@@ -485,21 +491,18 @@ func Login(ctx context.Context, options LoginOptions) (StoredToken, error) {
 		return StoredToken{}, fmt.Errorf("open authorization URL: %w", err)
 	}
 
-	waitCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	select {
 	case result := <-resultChan:
 		if result.err != nil {
 			return StoredToken{}, result.err
 		}
-		token, err := flow.exchangeCode(waitCtx, result.code, redirectURI)
+		token, err := flow.exchangeCode(loginCtx, result.code, redirectURI)
 		if err != nil {
 			return StoredToken{}, err
 		}
 		return token, nil
-	case <-waitCtx.Done():
-		return StoredToken{}, fmt.Errorf("timed out waiting for OAuth authorization callback: %w", waitCtx.Err())
+	case <-loginCtx.Done():
+		return StoredToken{}, fmt.Errorf("timed out waiting for OAuth authorization callback: %w", loginCtx.Err())
 	}
 }
 
@@ -508,7 +511,15 @@ func joinWellKnown(baseURL string) (string, error) {
 	if err != nil || parsed.Host == "" {
 		return "", fmt.Errorf("invalid base URL for metadata discovery: %q", baseURL)
 	}
+	// RFC 8414: the well-known segment is inserted between the host and any issuer
+	// path component, so a path-based issuer (https://host/tenant-a) is probed at
+	// https://host/.well-known/oauth-authorization-server/tenant-a — not at the
+	// host root (which would break tenant-scoped discovery).
+	issuerPath := strings.Trim(parsed.Path, "/")
 	parsed.Path = wellKnownAuthServerPath
+	if issuerPath != "" {
+		parsed.Path = strings.TrimRight(wellKnownAuthServerPath, "/") + "/" + issuerPath
+	}
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String(), nil

--- a/internal/mcp/oauth_store.go
+++ b/internal/mcp/oauth_store.go
@@ -1,0 +1,341 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	tokenStoreSchemaVersion = 1
+	tokenStoreLockTimeout   = 5 * time.Second
+	tokenStoreLockRetry     = 10 * time.Millisecond
+)
+
+// StoredToken holds the credentials issued by an OAuth 2.0 authorization server
+// for a single MCP server. The token fields are sensitive: they are tagged so
+// the repo's redaction layer masks them, and they must never be written to logs
+// or stream output.
+type StoredToken struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	TokenType    string    `json:"token_type,omitempty"`
+	Scopes       []string  `json:"scopes,omitempty"`
+	ExpiresAt    time.Time `json:"expires_at,omitempty"`
+}
+
+// TokenStatus is a redaction-safe summary of a stored token. It deliberately
+// omits the access and refresh token material so it can be printed by the CLI.
+type TokenStatus struct {
+	ServerName      string    `json:"serverName"`
+	HasToken        bool      `json:"hasToken"`
+	HasRefreshToken bool      `json:"hasRefreshToken"`
+	TokenType       string    `json:"tokenType,omitempty"`
+	Scopes          []string  `json:"scopes,omitempty"`
+	ExpiresAt       time.Time `json:"expiresAt,omitempty"`
+	Expired         bool      `json:"expired"`
+}
+
+// TokenStoreOptions configures where OAuth tokens are persisted. When FilePath
+// is empty the path is resolved under the user config dir, mirroring how MCP
+// permissions are stored.
+type TokenStoreOptions struct {
+	FilePath string
+	Env      map[string]string
+	Now      func() time.Time
+}
+
+// TokenStore persists OAuth tokens per MCP server in a 0600 JSON file.
+type TokenStore struct {
+	filePath string
+	now      func() time.Time
+	mu       sync.Mutex
+}
+
+type tokenFile struct {
+	SchemaVersion int                    `json:"schemaVersion"`
+	Tokens        map[string]StoredToken `json:"tokens"`
+}
+
+// ResolveTokenStorePath determines the on-disk location for OAuth tokens,
+// honoring an explicit override, XDG_CONFIG_HOME, then the user home dir.
+func ResolveTokenStorePath(env map[string]string) (string, error) {
+	override := strings.TrimSpace(envValue(env, "ZERO_MCP_OAUTH_TOKENS_PATH"))
+	if override != "" {
+		if filepath.IsAbs(override) {
+			return filepath.Clean(override), nil
+		}
+		return filepath.Abs(override)
+	}
+
+	configHome := strings.TrimSpace(envValue(env, "XDG_CONFIG_HOME"))
+	if configHome == "" {
+		home := strings.TrimSpace(firstNonEmpty(envValue(env, "HOME"), envValue(env, "USERPROFILE")))
+		var err error
+		if home == "" {
+			home, err = os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolve user home: %w", err)
+			}
+		}
+		configHome = filepath.Join(home, ".config")
+	} else if !filepath.IsAbs(configHome) {
+		resolved, err := filepath.Abs(configHome)
+		if err != nil {
+			return "", err
+		}
+		configHome = resolved
+	}
+	return filepath.Join(configHome, "zero", "mcp-oauth-tokens.json"), nil
+}
+
+// NewTokenStore builds a file-backed token store.
+func NewTokenStore(options TokenStoreOptions) (*TokenStore, error) {
+	filePath := options.FilePath
+	var err error
+	if strings.TrimSpace(filePath) == "" {
+		filePath, err = ResolveTokenStorePath(options.Env)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !filepath.IsAbs(filePath) {
+		filePath, err = filepath.Abs(filePath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	now := options.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &TokenStore{filePath: filepath.Clean(filePath), now: now}, nil
+}
+
+// FilePath returns the resolved token store path.
+func (store *TokenStore) FilePath() string {
+	return store.filePath
+}
+
+// Save persists the token for a server, replacing any existing entry.
+func (store *TokenStore) Save(serverName string, token StoredToken) error {
+	if err := ValidateServerName(serverName); err != nil {
+		return err
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return err
+	}
+	state.Tokens[serverName] = token
+	return store.writeState(state)
+}
+
+// Load returns the stored token for a server. The second return value is false
+// when no token has been stored for the server.
+func (store *TokenStore) Load(serverName string) (StoredToken, bool, error) {
+	if err := ValidateServerName(serverName); err != nil {
+		return StoredToken{}, false, err
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return StoredToken{}, false, err
+	}
+	token, ok := state.Tokens[serverName]
+	return token, ok, nil
+}
+
+// Delete removes the stored token for a server. It reports whether an entry was
+// present before deletion.
+func (store *TokenStore) Delete(serverName string) (bool, error) {
+	if err := ValidateServerName(serverName); err != nil {
+		return false, err
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	unlock, err := store.lockStateFile()
+	if err != nil {
+		return false, err
+	}
+	defer unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return false, err
+	}
+	if _, ok := state.Tokens[serverName]; !ok {
+		return false, nil
+	}
+	delete(state.Tokens, serverName)
+	if err := store.writeState(state); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Status returns a redaction-safe summary of every stored token, sorted by
+// server name. It never includes the token material.
+func (store *TokenStore) Status() ([]TokenStatus, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	state, err := store.readState()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(state.Tokens))
+	for name := range state.Tokens {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	now := store.now()
+	statuses := make([]TokenStatus, 0, len(names))
+	for _, name := range names {
+		token := state.Tokens[name]
+		status := TokenStatus{
+			ServerName:      name,
+			HasToken:        strings.TrimSpace(token.AccessToken) != "",
+			HasRefreshToken: strings.TrimSpace(token.RefreshToken) != "",
+			TokenType:       token.TokenType,
+			Scopes:          token.Scopes,
+			ExpiresAt:       token.ExpiresAt,
+		}
+		if !token.ExpiresAt.IsZero() && !token.ExpiresAt.After(now) {
+			status.Expired = true
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
+func (store *TokenStore) readState() (tokenFile, error) {
+	data, err := os.ReadFile(store.filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return emptyTokenFile(), nil
+		}
+		return tokenFile{}, err
+	}
+	var state tokenFile
+	if err := json.Unmarshal(data, &state); err != nil {
+		return tokenFile{}, fmt.Errorf("invalid MCP OAuth token file at %s: %w", store.filePath, err)
+	}
+	if state.SchemaVersion != tokenStoreSchemaVersion {
+		return tokenFile{}, fmt.Errorf("invalid MCP OAuth token file at %s: unsupported schemaVersion", store.filePath)
+	}
+	if state.Tokens == nil {
+		state.Tokens = map[string]StoredToken{}
+	}
+	for serverName := range state.Tokens {
+		if err := ValidateServerName(serverName); err != nil {
+			return tokenFile{}, fmt.Errorf("invalid MCP OAuth token file at %s: %w", store.filePath, err)
+		}
+	}
+	return state, nil
+}
+
+func (store *TokenStore) writeState(state tokenFile) error {
+	if err := os.MkdirAll(filepath.Dir(store.filePath), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	tempPath := fmt.Sprintf("%s.tmp-%d-%d", store.filePath, os.Getpid(), store.now().UnixNano())
+	if err := os.WriteFile(tempPath, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, store.filePath); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
+}
+
+func (store *TokenStore) lockStateFile() (func(), error) {
+	lockPath := store.filePath + ".lockfile"
+	if err := os.MkdirAll(filepath.Dir(store.filePath), 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(tokenStoreLockTimeout)
+	for {
+		locked, err := tryLockPermissionFile(file)
+		if err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		if locked {
+			return func() {
+				_ = unlockPermissionFile(file)
+				_ = file.Close()
+			}, nil
+		}
+		if time.Now().After(deadline) {
+			_ = file.Close()
+			return nil, fmt.Errorf("timed out waiting for MCP OAuth token lock at %s", lockPath)
+		}
+		time.Sleep(tokenStoreLockRetry)
+	}
+}
+
+func emptyTokenFile() tokenFile {
+	return tokenFile{
+		SchemaVersion: tokenStoreSchemaVersion,
+		Tokens:        map[string]StoredToken{},
+	}
+}
+
+// FormatTokenStatuses renders a human-readable status table without leaking any
+// token material.
+func FormatTokenStatuses(statuses []TokenStatus) string {
+	if len(statuses) == 0 {
+		return "No MCP OAuth tokens are stored."
+	}
+	var builder strings.Builder
+	for index, status := range statuses {
+		if index > 0 {
+			builder.WriteByte('\n')
+		}
+		builder.WriteString(status.ServerName)
+		builder.WriteString(": ")
+		if !status.HasToken {
+			builder.WriteString("no token")
+			continue
+		}
+		builder.WriteString("token present")
+		if status.HasRefreshToken {
+			builder.WriteString(" (refreshable)")
+		}
+		if !status.ExpiresAt.IsZero() {
+			if status.Expired {
+				builder.WriteString(", expired at ")
+			} else {
+				builder.WriteString(", expires ")
+			}
+			builder.WriteString(status.ExpiresAt.UTC().Format(time.RFC3339))
+		}
+	}
+	return builder.String()
+}

--- a/internal/mcp/oauth_store_test.go
+++ b/internal/mcp/oauth_store_test.go
@@ -159,11 +159,15 @@ func TestTokenStoreStatusReportsPresenceWithoutToken(t *testing.T) {
 }
 
 func TestResolveTokenStorePathUsesXDG(t *testing.T) {
-	path, err := ResolveTokenStorePath(map[string]string{"XDG_CONFIG_HOME": "/tmp/xdg-test"})
+	// Use a real temp dir so the base is absolute on every OS (a literal
+	// "/tmp/..." isn't absolute on Windows, where ResolveTokenStorePath would
+	// then prepend the drive letter and diverge from a hard-coded want).
+	configHome := t.TempDir()
+	path, err := ResolveTokenStorePath(map[string]string{"XDG_CONFIG_HOME": configHome})
 	if err != nil {
 		t.Fatalf("ResolveTokenStorePath() error = %v", err)
 	}
-	want := filepath.Join("/tmp/xdg-test", "zero", "mcp-oauth-tokens.json")
+	want := filepath.Join(configHome, "zero", "mcp-oauth-tokens.json")
 	if path != want {
 		t.Fatalf("path = %q, want %q", path, want)
 	}

--- a/internal/mcp/oauth_store_test.go
+++ b/internal/mcp/oauth_store_test.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestTokenStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-oauth-tokens.json")
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	saved := StoredToken{
+		AccessToken:  "access-abc",
+		RefreshToken: "refresh-abc",
+		TokenType:    "Bearer",
+		Scopes:       []string{"read", "write"},
+		ExpiresAt:    expiry,
+	}
+	if err := store.Save("demo", saved); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, ok, err := store.Load("demo")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Load() ok = false, want stored token")
+	}
+	if loaded.AccessToken != saved.AccessToken || loaded.RefreshToken != saved.RefreshToken {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+	if !loaded.ExpiresAt.Equal(expiry) {
+		t.Fatalf("expiry = %v, want %v", loaded.ExpiresAt, expiry)
+	}
+}
+
+func TestTokenStoreFileIs0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file permissions are not enforced on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-oauth-tokens.json")
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("demo", StoredToken{AccessToken: "a", RefreshToken: "r"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("file mode = %o, want 600", perm)
+	}
+}
+
+func TestTokenStoreDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-oauth-tokens.json")
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("demo", StoredToken{AccessToken: "a", RefreshToken: "r"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	removed, err := store.Delete("demo")
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if !removed {
+		t.Fatal("Delete() removed = false, want true")
+	}
+	_, ok, err := store.Load("demo")
+	if err != nil {
+		t.Fatalf("Load() after delete error = %v", err)
+	}
+	if ok {
+		t.Fatal("Load() ok = true after delete")
+	}
+
+	// Deleting a missing entry reports false without error.
+	removed, err = store.Delete("missing")
+	if err != nil {
+		t.Fatalf("Delete(missing) error = %v", err)
+	}
+	if removed {
+		t.Fatal("Delete(missing) removed = true, want false")
+	}
+}
+
+func TestTokenStoreLoadMissingIsNotError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-oauth-tokens.json")
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	_, ok, err := store.Load("demo")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if ok {
+		t.Fatal("Load() ok = true for empty store")
+	}
+}
+
+func TestTokenStoreStatusReportsPresenceWithoutToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-oauth-tokens.json")
+	store, err := NewTokenStore(TokenStoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	expiry := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+	if err := store.Save("demo", StoredToken{
+		AccessToken:  "secret-access",
+		RefreshToken: "secret-refresh",
+		ExpiresAt:    expiry,
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	statuses, err := store.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("statuses = %#v, want one entry", statuses)
+	}
+	status := statuses[0]
+	if status.ServerName != "demo" {
+		t.Fatalf("server name = %q", status.ServerName)
+	}
+	if !status.HasToken {
+		t.Fatal("HasToken = false, want true")
+	}
+	if !status.HasRefreshToken {
+		t.Fatal("HasRefreshToken = false, want true")
+	}
+	if !status.ExpiresAt.Equal(expiry) {
+		t.Fatalf("expiry = %v, want %v", status.ExpiresAt, expiry)
+	}
+	// The status struct must not carry the secret material at all.
+	if got := FormatTokenStatuses(statuses); contains(got, "secret-access") || contains(got, "secret-refresh") {
+		t.Fatalf("status output leaked token: %s", got)
+	}
+}
+
+func TestResolveTokenStorePathUsesXDG(t *testing.T) {
+	path, err := ResolveTokenStorePath(map[string]string{"XDG_CONFIG_HOME": "/tmp/xdg-test"})
+	if err != nil {
+		t.Fatalf("ResolveTokenStorePath() error = %v", err)
+	}
+	want := filepath.Join("/tmp/xdg-test", "zero", "mcp-oauth-tokens.json")
+	if path != want {
+		t.Fatalf("path = %q, want %q", path, want)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/mcp/oauth_test.go
+++ b/internal/mcp/oauth_test.go
@@ -1,0 +1,393 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+func TestDiscoverParsesMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/oauth-authorization-server" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 r.Host,
+			"authorization_endpoint": "https://issuer.example/authorize",
+			"token_endpoint":         "https://issuer.example/token",
+			"registration_endpoint":  "https://issuer.example/register",
+			"scopes_supported":       []string{"read", "write"},
+		})
+	}))
+	defer server.Close()
+
+	meta, err := discoverAuthorizationServer(context.Background(), http.DefaultClient, server.URL)
+	if err != nil {
+		t.Fatalf("discoverAuthorizationServer() error = %v", err)
+	}
+	if meta.AuthorizationEndpoint != "https://issuer.example/authorize" {
+		t.Fatalf("authorization endpoint = %q", meta.AuthorizationEndpoint)
+	}
+	if meta.TokenEndpoint != "https://issuer.example/token" {
+		t.Fatalf("token endpoint = %q", meta.TokenEndpoint)
+	}
+	if meta.RegistrationEndpoint != "https://issuer.example/register" {
+		t.Fatalf("registration endpoint = %q", meta.RegistrationEndpoint)
+	}
+	if len(meta.ScopesSupported) != 2 {
+		t.Fatalf("scopes = %#v", meta.ScopesSupported)
+	}
+}
+
+func TestResolveEndpointsFallsBackToConfig(t *testing.T) {
+	// Server with no metadata document: discovery must fail and the resolver must
+	// fall back to the explicitly configured endpoints.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	cfg := OAuthConfig{
+		AuthorizationEndpoint: "https://issuer.example/authorize",
+		TokenEndpoint:         "https://issuer.example/token",
+	}
+	meta, err := resolveAuthorizationServer(context.Background(), http.DefaultClient, server.URL, cfg)
+	if err != nil {
+		t.Fatalf("resolveAuthorizationServer() error = %v", err)
+	}
+	if meta.AuthorizationEndpoint != cfg.AuthorizationEndpoint {
+		t.Fatalf("authorization endpoint = %q, want config fallback", meta.AuthorizationEndpoint)
+	}
+	if meta.TokenEndpoint != cfg.TokenEndpoint {
+		t.Fatalf("token endpoint = %q, want config fallback", meta.TokenEndpoint)
+	}
+}
+
+func TestResolveEndpointsConfigOverridesDiscovery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization_endpoint": "https://discovered.example/authorize",
+			"token_endpoint":         "https://discovered.example/token",
+		})
+	}))
+	defer server.Close()
+
+	cfg := OAuthConfig{TokenEndpoint: "https://configured.example/token"}
+	meta, err := resolveAuthorizationServer(context.Background(), http.DefaultClient, server.URL, cfg)
+	if err != nil {
+		t.Fatalf("resolveAuthorizationServer() error = %v", err)
+	}
+	if meta.AuthorizationEndpoint != "https://discovered.example/authorize" {
+		t.Fatalf("authorization endpoint = %q, want discovered value", meta.AuthorizationEndpoint)
+	}
+	if meta.TokenEndpoint != "https://configured.example/token" {
+		t.Fatalf("token endpoint = %q, want configured override", meta.TokenEndpoint)
+	}
+}
+
+func TestPKCEChallengeIsS256OfVerifier(t *testing.T) {
+	pkce, err := newPKCE()
+	if err != nil {
+		t.Fatalf("newPKCE() error = %v", err)
+	}
+	if pkce.Method != "S256" {
+		t.Fatalf("method = %q, want S256", pkce.Method)
+	}
+	sum := sha256.Sum256([]byte(pkce.Verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if pkce.Challenge != want {
+		t.Fatalf("challenge = %q, want %q", pkce.Challenge, want)
+	}
+	// Verifiers must carry high entropy and stay within the RFC 7636 length bounds.
+	if len(pkce.Verifier) < 43 || len(pkce.Verifier) > 128 {
+		t.Fatalf("verifier length = %d, want 43..128", len(pkce.Verifier))
+	}
+}
+
+func TestAuthorizationURLIncludesPKCEAndState(t *testing.T) {
+	flow := &authorizationFlow{
+		metadata: authServerMetadata{AuthorizationEndpoint: "https://issuer.example/authorize"},
+		config:   OAuthConfig{ClientID: "client-123", Scopes: []string{"read", "write"}},
+		pkce:     pkceParams{Challenge: "challenge-value", Method: "S256"},
+		state:    "state-token",
+	}
+	authURL, err := flow.authorizationURL("http://127.0.0.1:54321/callback")
+	if err != nil {
+		t.Fatalf("authorizationURL() error = %v", err)
+	}
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse authorization URL: %v", err)
+	}
+	query := parsed.Query()
+	if query.Get("response_type") != "code" {
+		t.Fatalf("response_type = %q", query.Get("response_type"))
+	}
+	if query.Get("client_id") != "client-123" {
+		t.Fatalf("client_id = %q", query.Get("client_id"))
+	}
+	if query.Get("code_challenge") != "challenge-value" {
+		t.Fatalf("code_challenge = %q", query.Get("code_challenge"))
+	}
+	if query.Get("code_challenge_method") != "S256" {
+		t.Fatalf("code_challenge_method = %q", query.Get("code_challenge_method"))
+	}
+	if query.Get("state") != "state-token" {
+		t.Fatalf("state = %q", query.Get("state"))
+	}
+	if query.Get("redirect_uri") != "http://127.0.0.1:54321/callback" {
+		t.Fatalf("redirect_uri = %q", query.Get("redirect_uri"))
+	}
+	if query.Get("scope") != "read write" {
+		t.Fatalf("scope = %q", query.Get("scope"))
+	}
+}
+
+func TestCallbackRejectsStateMismatch(t *testing.T) {
+	flow := &authorizationFlow{state: "expected-state"}
+	_, err := flow.parseCallback(url.Values{
+		"code":  []string{"the-code"},
+		"state": []string{"attacker-state"},
+	})
+	if err == nil {
+		t.Fatal("parseCallback() error = nil, want state mismatch rejection")
+	}
+	if !strings.Contains(err.Error(), "state") {
+		t.Fatalf("error = %q, want state mismatch", err.Error())
+	}
+}
+
+func TestCallbackAcceptsMatchingState(t *testing.T) {
+	flow := &authorizationFlow{state: "expected-state"}
+	code, err := flow.parseCallback(url.Values{
+		"code":  []string{"the-code"},
+		"state": []string{"expected-state"},
+	})
+	if err != nil {
+		t.Fatalf("parseCallback() error = %v", err)
+	}
+	if code != "the-code" {
+		t.Fatalf("code = %q, want the-code", code)
+	}
+}
+
+func TestCallbackSurfacesProviderError(t *testing.T) {
+	flow := &authorizationFlow{state: "expected-state"}
+	_, err := flow.parseCallback(url.Values{
+		"error":             []string{"access_denied"},
+		"error_description": []string{"user said no"},
+		"state":             []string{"expected-state"},
+	})
+	if err == nil {
+		t.Fatal("parseCallback() error = nil, want provider error")
+	}
+	if !strings.Contains(err.Error(), "access_denied") {
+		t.Fatalf("error = %q, want provider error", err.Error())
+	}
+}
+
+func TestExchangeCodeReturnsTokens(t *testing.T) {
+	var gotVerifier, gotCode, gotGrant, gotRedirect string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotVerifier = r.Form.Get("code_verifier")
+		gotCode = r.Form.Get("code")
+		gotGrant = r.Form.Get("grant_type")
+		gotRedirect = r.Form.Get("redirect_uri")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-xyz",
+			"refresh_token": "refresh-xyz",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	flow := &authorizationFlow{
+		httpClient: http.DefaultClient,
+		metadata:   authServerMetadata{TokenEndpoint: server.URL},
+		config:     OAuthConfig{ClientID: "client-123"},
+		pkce:       pkceParams{Verifier: "verifier-value"},
+		now:        time.Now,
+	}
+	token, err := flow.exchangeCode(context.Background(), "auth-code", "http://127.0.0.1:54321/callback")
+	if err != nil {
+		t.Fatalf("exchangeCode() error = %v", err)
+	}
+	if token.AccessToken != "access-xyz" || token.RefreshToken != "refresh-xyz" {
+		t.Fatalf("token = %#v", token)
+	}
+	if token.ExpiresAt.IsZero() {
+		t.Fatal("expiry not set from expires_in")
+	}
+	if gotVerifier != "verifier-value" || gotCode != "auth-code" {
+		t.Fatalf("verifier=%q code=%q", gotVerifier, gotCode)
+	}
+	if gotGrant != "authorization_code" {
+		t.Fatalf("grant_type = %q", gotGrant)
+	}
+	if gotRedirect != "http://127.0.0.1:54321/callback" {
+		t.Fatalf("redirect_uri = %q", gotRedirect)
+	}
+}
+
+func TestRefreshTokenExchange(t *testing.T) {
+	var gotGrant, gotRefresh string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotGrant = r.Form.Get("grant_type")
+		gotRefresh = r.Form.Get("refresh_token")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "access-new",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	cfg := OAuthConfig{ClientID: "client-123", TokenEndpoint: server.URL}
+	token, err := refreshAccessToken(context.Background(), http.DefaultClient, cfg, StoredToken{RefreshToken: "refresh-old"}, time.Now)
+	if err != nil {
+		t.Fatalf("refreshAccessToken() error = %v", err)
+	}
+	if token.AccessToken != "access-new" {
+		t.Fatalf("access token = %q", token.AccessToken)
+	}
+	// A refresh response without a new refresh_token must preserve the old one.
+	if token.RefreshToken != "refresh-old" {
+		t.Fatalf("refresh token = %q, want carried over", token.RefreshToken)
+	}
+	if gotGrant != "refresh_token" || gotRefresh != "refresh-old" {
+		t.Fatalf("grant=%q refresh=%q", gotGrant, gotRefresh)
+	}
+}
+
+func TestRefreshTokenFailureSurfacesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "invalid_grant"})
+	}))
+	defer server.Close()
+
+	cfg := OAuthConfig{ClientID: "client-123", TokenEndpoint: server.URL}
+	_, err := refreshAccessToken(context.Background(), http.DefaultClient, cfg, StoredToken{RefreshToken: "refresh-old"}, time.Now)
+	if err == nil {
+		t.Fatal("refreshAccessToken() error = nil, want failure")
+	}
+}
+
+func TestDynamicClientRegistration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id":     "registered-client",
+			"client_secret": "registered-secret",
+		})
+	}))
+	defer server.Close()
+
+	clientID, clientSecret, err := registerClient(context.Background(), http.DefaultClient, server.URL, "http://127.0.0.1:54321/callback", []string{"read"})
+	if err != nil {
+		t.Fatalf("registerClient() error = %v", err)
+	}
+	if clientID != "registered-client" || clientSecret != "registered-secret" {
+		t.Fatalf("client = %q / %q", clientID, clientSecret)
+	}
+}
+
+func TestTokensNeverAppearInRedactedOutput(t *testing.T) {
+	token := StoredToken{
+		AccessToken:  "sk-secret-access-token-value",
+		RefreshToken: "refresh-secret-value",
+		TokenType:    "Bearer",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}
+	redacted := redaction.RedactValue(token, redaction.Options{})
+	encoded, err := json.Marshal(redacted)
+	if err != nil {
+		t.Fatalf("marshal redacted: %v", err)
+	}
+	output := string(encoded)
+	if strings.Contains(output, "sk-secret-access-token-value") {
+		t.Fatalf("access token leaked in redacted output: %s", output)
+	}
+	if strings.Contains(output, "refresh-secret-value") {
+		t.Fatalf("refresh token leaked in redacted output: %s", output)
+	}
+}
+
+func TestFullFlowStoresTokens(t *testing.T) {
+	// End-to-end: discovery + authorization URL + simulated callback + exchange,
+	// driven by a fake browser that immediately hits the loopback redirect.
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authorization_endpoint": "PLACEHOLDER",
+				"token_endpoint":         "PLACEHOLDER",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer authServer.Close()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "access-final",
+			"refresh_token": "refresh-final",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	cfg := OAuthConfig{
+		ClientID:              "client-123",
+		AuthorizationEndpoint: "https://issuer.invalid/authorize",
+		TokenEndpoint:         tokenServer.URL,
+		Scopes:                []string{"read"},
+	}
+
+	// The browser opener receives the authorization URL and replies on the
+	// loopback redirect with a code + the issued state.
+	opener := func(authURL string) error {
+		parsed, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		state := parsed.Query().Get("state")
+		redirect := parsed.Query().Get("redirect_uri")
+		go func() {
+			cbURL := redirect + "?code=auth-code&state=" + url.QueryEscape(state)
+			_, _ = http.Get(cbURL)
+		}()
+		return nil
+	}
+
+	result, err := Login(context.Background(), LoginOptions{
+		ServerName:  "demo",
+		ServerURL:   "https://issuer.invalid",
+		Config:      cfg,
+		HTTPClient:  http.DefaultClient,
+		OpenBrowser: opener,
+		Timeout:     5 * time.Second,
+		Now:         time.Now,
+	})
+	if err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+	if result.AccessToken != "access-final" || result.RefreshToken != "refresh-final" {
+		t.Fatalf("login token = %#v", result)
+	}
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,203 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// jsonRPCPromptNotFound is the MCP convention for an unknown prompt name. It is
+// distinct from the transport-level method-not-found code.
+const jsonRPCPromptNotFound = -32002
+
+// Prompt describes a curated prompt template advertised through prompts/list.
+type Prompt struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Arguments   []PromptArgument `json:"arguments,omitempty"`
+}
+
+// PromptArgument describes one templated argument of a prompt.
+type PromptArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+// PromptMessage is one message in a rendered prompt (prompts/get result).
+type PromptMessage struct {
+	Role    string               `json:"role"`
+	Content PromptMessageContent `json:"content"`
+}
+
+// PromptMessageContent carries the rendered text of a prompt message.
+type PromptMessageContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// promptTemplate is the internal definition of a curated prompt: its metadata
+// plus the message templates that {{arg}} substitution is applied to.
+type promptTemplate struct {
+	prompt   Prompt
+	messages []promptMessageTemplate
+}
+
+type promptMessageTemplate struct {
+	role string
+	text string
+}
+
+// curatedPrompts is ZERO's published prompt catalogue. These mirror ZERO's own
+// slash-command / spec-mode workflows (code review, spec drafting, workspace
+// explanation) as reusable templates other agents can pull; internal system
+// prompts are deliberately not exposed.
+var curatedPrompts = []promptTemplate{
+	{
+		prompt: Prompt{
+			Name:        "code_review",
+			Description: "Review a code change for correctness, clarity, and risk.",
+			Arguments: []PromptArgument{
+				{Name: "diff", Description: "The unified diff or code to review.", Required: true},
+				{Name: "focus", Description: "Optional area to focus the review on (e.g. security, performance).", Required: false},
+			},
+		},
+		messages: []promptMessageTemplate{
+			{
+				role: "user",
+				text: "Review the following change. Call out correctness bugs first, then " +
+					"clarity and maintainability issues, then anything risky. Be specific " +
+					"and cite the exact lines.\n\nExtra focus: {{focus}}\n\n```\n{{diff}}\n```",
+			},
+		},
+	},
+	{
+		prompt: Prompt{
+			Name:        "draft_spec",
+			Description: "Draft a concrete implementation spec for a requested change.",
+			Arguments: []PromptArgument{
+				{Name: "task", Description: "What needs to be built or changed.", Required: true},
+				{Name: "context", Description: "Optional relevant files, constraints, or background.", Required: false},
+			},
+		},
+		messages: []promptMessageTemplate{
+			{
+				role: "user",
+				text: "Draft an implementation spec for the task below. Choose one concrete " +
+					"approach (no unresolved Option A/Option B). Include: Goal, Relevant " +
+					"files/components, Implementation steps, Tests and verification, Risks " +
+					"and edge cases, and Out of scope.\n\nTask: {{task}}\n\nContext: {{context}}",
+			},
+		},
+	},
+	{
+		prompt: Prompt{
+			Name:        "explain_code",
+			Description: "Explain what a piece of code does and how it fits together.",
+			Arguments: []PromptArgument{
+				{Name: "code", Description: "The code to explain.", Required: true},
+			},
+		},
+		messages: []promptMessageTemplate{
+			{
+				role: "user",
+				text: "Explain the following code: what it does, the key control flow, and " +
+					"any notable edge cases or assumptions. Keep it concise.\n\n```\n{{code}}\n```",
+			},
+		},
+	},
+}
+
+// curatedPrompt looks up a prompt template by name.
+func curatedPrompt(name string) (promptTemplate, bool) {
+	for _, template := range curatedPrompts {
+		if template.prompt.Name == name {
+			return template, true
+		}
+	}
+	return promptTemplate{}, false
+}
+
+// listPrompts returns the curated prompt catalogue sorted by name for stable
+// output.
+func listPrompts() []Prompt {
+	prompts := make([]Prompt, 0, len(curatedPrompts))
+	for _, template := range curatedPrompts {
+		prompts = append(prompts, template.prompt)
+	}
+	sort.Slice(prompts, func(left int, right int) bool {
+		return prompts[left].Name < prompts[right].Name
+	})
+	return prompts
+}
+
+// getPromptResult is the rendered prompts/get payload.
+type getPromptResult struct {
+	Description string          `json:"description"`
+	Messages    []PromptMessage `json:"messages"`
+}
+
+// getPrompt renders a curated prompt with {{arg}} substitution. It returns a
+// JSON-RPC error code alongside the error so the caller can map missing-name
+// (invalid params) and unknown-prompt (not found) distinctly.
+func getPrompt(rawParams json.RawMessage) (getPromptResult, int, error) {
+	var params struct {
+		Name      string            `json:"name"`
+		Arguments map[string]string `json:"arguments"`
+	}
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return getPromptResult{}, jsonRPCInvalidParams, fmt.Errorf("invalid prompts/get params: %w", err)
+		}
+	}
+	name := strings.TrimSpace(params.Name)
+	if name == "" {
+		return getPromptResult{}, jsonRPCInvalidParams, errors.New("prompts/get requires a prompt name")
+	}
+	template, ok := curatedPrompt(name)
+	if !ok {
+		return getPromptResult{}, jsonRPCPromptNotFound, fmt.Errorf("unknown prompt: %s", name)
+	}
+
+	messages := make([]PromptMessage, 0, len(template.messages))
+	for _, message := range template.messages {
+		messages = append(messages, PromptMessage{
+			Role: message.role,
+			Content: PromptMessageContent{
+				Type: "text",
+				Text: substituteArgs(message.text, params.Arguments),
+			},
+		})
+	}
+	return getPromptResult{
+		Description: template.prompt.Description,
+		Messages:    messages,
+	}, 0, nil
+}
+
+// substituteArgs replaces every {{name}} placeholder with the matching argument
+// value. Placeholders without a supplied argument render as empty so a partial
+// invocation never leaks raw template syntax to the consumer.
+func substituteArgs(text string, arguments map[string]string) string {
+	for name, value := range arguments {
+		text = strings.ReplaceAll(text, "{{"+name+"}}", value)
+	}
+	return blankRemainingPlaceholders(text)
+}
+
+// blankRemainingPlaceholders strips any {{...}} placeholders left unfilled.
+func blankRemainingPlaceholders(text string) string {
+	for {
+		open := strings.Index(text, "{{")
+		if open < 0 {
+			return text
+		}
+		close := strings.Index(text[open:], "}}")
+		if close < 0 {
+			return text
+		}
+		text = text[:open] + text[open+close+2:]
+	}
+}

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -160,6 +160,17 @@ func getPrompt(rawParams json.RawMessage) (getPromptResult, int, error) {
 	if !ok {
 		return getPromptResult{}, jsonRPCPromptNotFound, fmt.Errorf("unknown prompt: %s", name)
 	}
+	// Honor the contract advertised by prompts/list: a required argument must be
+	// supplied and non-empty, otherwise the call is invalid rather than silently
+	// rendering a blank.
+	for _, arg := range template.prompt.Arguments {
+		if !arg.Required {
+			continue
+		}
+		if value, present := params.Arguments[arg.Name]; !present || strings.TrimSpace(value) == "" {
+			return getPromptResult{}, jsonRPCInvalidParams, fmt.Errorf("prompts/get: missing required argument %q", arg.Name)
+		}
+	}
 
 	messages := make([]PromptMessage, 0, len(template.messages))
 	for _, message := range template.messages {
@@ -177,27 +188,28 @@ func getPrompt(rawParams json.RawMessage) (getPromptResult, int, error) {
 	}, 0, nil
 }
 
-// substituteArgs replaces every {{name}} placeholder with the matching argument
-// value. Placeholders without a supplied argument render as empty so a partial
-// invocation never leaks raw template syntax to the consumer.
+// substituteArgs renders a TEMPLATE by replacing each {{name}} placeholder with
+// the matching argument value (or blank when not supplied). It scans the
+// template left-to-right and writes argument values verbatim, so {{...}} that
+// appears inside a supplied value (Helm/Mustache/Actions snippets in a pasted
+// diff, etc.) is preserved and never re-interpreted as a placeholder.
 func substituteArgs(text string, arguments map[string]string) string {
-	for name, value := range arguments {
-		text = strings.ReplaceAll(text, "{{"+name+"}}", value)
-	}
-	return blankRemainingPlaceholders(text)
-}
-
-// blankRemainingPlaceholders strips any {{...}} placeholders left unfilled.
-func blankRemainingPlaceholders(text string) string {
+	var b strings.Builder
 	for {
 		open := strings.Index(text, "{{")
 		if open < 0 {
-			return text
+			b.WriteString(text)
+			break
 		}
-		close := strings.Index(text[open:], "}}")
-		if close < 0 {
-			return text
+		rel := strings.Index(text[open:], "}}")
+		if rel < 0 {
+			b.WriteString(text)
+			break
 		}
-		text = text[:open] + text[open+close+2:]
+		b.WriteString(text[:open])
+		name := strings.TrimSpace(text[open+2 : open+rel])
+		b.WriteString(arguments[name]) // missing arg -> "" (blank)
+		text = text[open+rel+2:]
 	}
+	return b.String()
 }

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -1,0 +1,130 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestServePromptsListReturnsCuratedSet(t *testing.T) {
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{ID: 1, Method: "prompts/list"})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	var result struct {
+		Prompts []Prompt `json:"prompts"`
+	}
+	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+	if len(result.Prompts) == 0 {
+		t.Fatalf("prompts/list returned no prompts")
+	}
+	for _, prompt := range result.Prompts {
+		if strings.TrimSpace(prompt.Name) == "" {
+			t.Fatalf("prompt has empty name: %#v", prompt)
+		}
+		if strings.TrimSpace(prompt.Description) == "" {
+			t.Fatalf("prompt %q has empty description", prompt.Name)
+		}
+	}
+	if _, ok := curatedPrompt("code_review"); !ok {
+		t.Fatalf("curated set missing code_review prompt")
+	}
+}
+
+func TestServePromptsGetSubstitutesArguments(t *testing.T) {
+	template, ok := curatedPrompt("code_review")
+	if !ok {
+		t.Fatalf("code_review prompt not registered")
+	}
+	if len(template.prompt.Arguments) == 0 {
+		t.Fatalf("code_review prompt has no arguments to substitute")
+	}
+	argName := template.prompt.Arguments[0].Name
+
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     1,
+		Method: "prompts/get",
+		Params: mustRaw(map[string]any{
+			"name":      "code_review",
+			"arguments": map[string]any{argName: "ZERO-SENTINEL-VALUE"},
+		}),
+	})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	var result struct {
+		Description string          `json:"description"`
+		Messages    []PromptMessage `json:"messages"`
+	}
+	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+	if result.Description == "" {
+		t.Fatalf("prompts/get description empty")
+	}
+	if len(result.Messages) == 0 {
+		t.Fatalf("prompts/get returned no messages")
+	}
+
+	var rendered strings.Builder
+	for _, message := range result.Messages {
+		if message.Role == "" {
+			t.Fatalf("message has empty role: %#v", message)
+		}
+		if message.Content.Type != "text" {
+			t.Fatalf("message content type = %q, want text", message.Content.Type)
+		}
+		rendered.WriteString(message.Content.Text)
+	}
+	if !strings.Contains(rendered.String(), "ZERO-SENTINEL-VALUE") {
+		t.Fatalf("rendered prompt did not substitute argument: %q", rendered.String())
+	}
+	if strings.Contains(rendered.String(), "{{"+argName+"}}") {
+		t.Fatalf("rendered prompt still contains placeholder for %q", argName)
+	}
+}
+
+func TestServePromptsGetUnknownErrors(t *testing.T) {
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     1,
+		Method: "prompts/get",
+		Params: mustRaw(map[string]any{"name": "does_not_exist"}),
+	})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	message := readServerTestMessage(t, newMessageReader(&output))
+	if message.Error == nil {
+		t.Fatalf("expected error for unknown prompt, got result %s", string(message.Result))
+	}
+}
+
+func TestServePromptsGetMissingNameErrors(t *testing.T) {
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     1,
+		Method: "prompts/get",
+		Params: mustRaw(map[string]any{}),
+	})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	message := readServerTestMessage(t, newMessageReader(&output))
+	if message.Error == nil || message.Error.Code != jsonRPCInvalidParams {
+		t.Fatalf("error = %#v, want invalid params", message.Error)
+	}
+}

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -93,6 +93,41 @@ func TestServePromptsGetSubstitutesArguments(t *testing.T) {
 	}
 }
 
+func TestSubstituteArgsPreservesPlaceholdersInUserInput(t *testing.T) {
+	// A supplied value containing {{...}} (a pasted template/CI snippet) must
+	// survive verbatim — only TEMPLATE placeholders are replaced.
+	out := substituteArgs("Review this: {{diff}}", map[string]string{
+		"diff": "run: ${{ secrets.TOKEN }}\nvalue: {{ .Values.x }}",
+	})
+	if !strings.Contains(out, "${{ secrets.TOKEN }}") || !strings.Contains(out, "{{ .Values.x }}") {
+		t.Fatalf("user-supplied {{...}} was mangled: %q", out)
+	}
+	// An unfilled template placeholder still renders blank (no raw syntax leaks).
+	if blank := substituteArgs("a {{missing}} b", map[string]string{}); strings.Contains(blank, "{{") {
+		t.Fatalf("unfilled template placeholder leaked raw syntax: %q", blank)
+	}
+}
+
+func TestServePromptsGetMissingRequiredArgErrors(t *testing.T) {
+	// code_review.diff is required; omitting it must error rather than silently
+	// rendering a blank, honoring the contract prompts/list advertises.
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     1,
+		Method: "prompts/get",
+		Params: mustRaw(map[string]any{"name": "code_review", "arguments": map[string]any{}}),
+	})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	message := readServerTestMessage(t, newMessageReader(&output))
+	if message.Error == nil {
+		t.Fatalf("expected error for missing required argument, got result %s", string(message.Result))
+	}
+}
+
 func TestServePromptsGetUnknownErrors(t *testing.T) {
 	var input bytes.Buffer
 	writeServerTestMessage(t, &input, rpcMessage{

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -163,7 +164,10 @@ func (server toolServer) readResource(rawParams json.RawMessage) ([]ResourceCont
 	}
 
 	contents := ResourceContents{
-		URI:      fileURI(absolute),
+		// Echo the requested URI (what resources/list advertised) rather than the
+		// symlink-resolved path, so list and read stay consistent and reading a
+		// file never reveals the canonical host path behind a symlinked root.
+		URI:      uri,
 		MimeType: mimeTypeForPath(absolute),
 	}
 	if looksBinary(absolute, data) {
@@ -190,13 +194,20 @@ func (server toolServer) resolveResourcePath(requested string) (string, error) {
 	}
 	cleaned := filepath.Clean(requested)
 
+	// Resolve symlinks BEFORE the scope check: an in-root symlink that points
+	// outside the roots (e.g. link -> /etc/passwd) must NOT be readable. A path
+	// that cannot be resolved (missing file) is rejected. Roots are resolved too
+	// so a symlinked root prefix (e.g. macOS /var -> /private/var) still matches.
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", errors.New("resource is outside the allowed workspace scope")
+	}
 	for _, root := range server.resourceRoots() {
-		if containedInRoot(root, cleaned) {
-			return cleaned, nil
+		realRoot, rootErr := filepath.EvalSymlinks(root)
+		if rootErr != nil {
+			realRoot = filepath.Clean(root)
 		}
-		// Resolve symlinks so an in-scope symlink that still lands inside a root
-		// is accepted, while a link escaping the roots is rejected.
-		if resolved, err := filepath.EvalSymlinks(cleaned); err == nil && containedInRoot(root, resolved) {
+		if containedInRoot(realRoot, resolved) {
 			return resolved, nil
 		}
 	}
@@ -229,30 +240,33 @@ func fileURI(absolute string) string {
 	if !strings.HasPrefix(slashed, "/") {
 		slashed = "/" + slashed
 	}
-	return "file://" + slashed
+	// Build via url.URL so the path is percent-encoded (spaces, #, %, ? in file
+	// names round-trip through standards-compliant clients).
+	u := url.URL{Scheme: "file", Path: slashed}
+	return u.String()
 }
 
 // pathFromURI extracts an absolute filesystem path from a resource URI. It
 // accepts file:// URIs (the scheme resources/list advertises); any other scheme
 // is rejected so a client cannot smuggle in an unexpected locator.
 func pathFromURI(uri string) (string, error) {
-	const scheme = "file://"
-	if !strings.HasPrefix(uri, scheme) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return "", fmt.Errorf("invalid resource uri: %s", uri)
+	}
+	if parsed.Scheme != "file" {
 		return "", fmt.Errorf("unsupported resource uri scheme: %s", uri)
 	}
-	rest := strings.TrimPrefix(uri, scheme)
-	// file:///abs -> /abs ; file://host/abs is not supported (no remote hosts).
-	if rest == "" {
+	// Only a local file URI (empty or "localhost" authority) is supported; a real
+	// remote host must not be smuggled in.
+	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
+		return "", fmt.Errorf("resource uri host is not supported: %s", uri)
+	}
+	// parsed.Path is already percent-decoded, so names with spaces / # / % work.
+	if parsed.Path == "" {
 		return "", errors.New("resource uri has no path")
 	}
-	// Drop an optional empty authority (file:///path) but reject a real host.
-	if !strings.HasPrefix(rest, "/") {
-		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
-			return "", fmt.Errorf("resource uri host is not supported: %s", uri)
-		}
-		return "", fmt.Errorf("unsupported resource uri: %s", uri)
-	}
-	decoded := filepath.FromSlash(rest)
+	decoded := filepath.FromSlash(parsed.Path)
 	// On Windows a file URI like file:///C:/x yields /C:/x; strip the leading
 	// slash so it becomes a valid drive-rooted path.
 	if len(decoded) >= 3 && decoded[0] == filepath.Separator && decoded[2] == ':' {

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,305 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/Gitlawb/zero/internal/workspaceindex"
+)
+
+// jsonRPCResourceNotFound is the MCP convention for a resource the server knows
+// about but cannot serve (missing or out-of-scope). It is distinct from the
+// transport-level method-not-found and parameter codes already defined.
+const jsonRPCResourceNotFound = -32002
+
+// maxResourceBytes caps a single resources/read so a remote client cannot drive
+// an unbounded allocation by pointing at an enormous file. It mirrors the
+// transport's framing limit.
+const maxResourceBytes = maxMessageBytes
+
+// Resource describes a workspace file advertised through resources/list. Only
+// the fields ZERO populates are emitted; pagination cursors and icons are not
+// used.
+type Resource struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	MimeType    string `json:"mimeType,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ResourceContents is one entry in a resources/read result. Exactly one of Text
+// or Blob is populated: Text for UTF-8 files, base64 Blob for binary files.
+type ResourceContents struct {
+	URI      string `json:"uri"`
+	MimeType string `json:"mimeType,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Blob     string `json:"blob,omitempty"`
+}
+
+// resourceRoots returns the absolute roots the server is allowed to expose.
+// When a PathScope is configured its roots are authoritative (workspace root
+// first, extra roots after); otherwise enumeration is confined to the single
+// workspace root. Roots are cleaned to absolute paths so prefix containment
+// checks in resolveResourcePath are reliable.
+func (server toolServer) resourceRoots() []string {
+	var raw []string
+	if server.scope != nil {
+		raw = server.scope.Roots()
+	}
+	if len(raw) == 0 {
+		raw = []string{server.workspaceRoot}
+	}
+	roots := make([]string, 0, len(raw))
+	for _, root := range raw {
+		trimmed := strings.TrimSpace(root)
+		if trimmed == "" {
+			continue
+		}
+		if absolute, err := filepath.Abs(trimmed); err == nil {
+			roots = append(roots, filepath.Clean(absolute))
+		}
+	}
+	return roots
+}
+
+// listResources enumerates every in-scope, non-binary-by-extension file across
+// the allowed roots and renders them as MCP resources. It reuses the shared
+// workspace scanner so gitignore-style exclusions (.git, node_modules, vendor,
+// binary extensions, ...) match the rest of ZERO instead of re-walking.
+func (server toolServer) listResources() []Resource {
+	roots := server.resourceRoots()
+	resources := make([]Resource, 0)
+	seen := map[string]struct{}{}
+	for _, root := range roots {
+		// MaxDepth -1 selects the scanner's default depth (Options{} would mean
+		// root files only). MaxFiles 0 selects the default file cap.
+		summary, err := workspaceindex.Scan(root, workspaceindex.Options{MaxDepth: -1})
+		if err != nil {
+			// A partial scan still yields the files it reached; skip a root that
+			// could not be read at all rather than failing the whole listing.
+			if len(summary.Files) == 0 {
+				continue
+			}
+		}
+		for _, file := range summary.Files {
+			absolute := filepath.Join(root, filepath.FromSlash(file.Path))
+			uri := fileURI(absolute)
+			if _, ok := seen[uri]; ok {
+				continue
+			}
+			seen[uri] = struct{}{}
+			resources = append(resources, Resource{
+				URI:         uri,
+				Name:        file.Path,
+				MimeType:    mimeTypeForPath(file.Path),
+				Description: resourceDescription(file),
+			})
+		}
+	}
+	return resources
+}
+
+func resourceDescription(file workspaceindex.File) string {
+	if file.Language != "" {
+		return file.Language + " file"
+	}
+	return ""
+}
+
+// readResource resolves a resources/read URI to an in-scope absolute path and
+// returns its contents. It enforces scope (no traversal, no out-of-scope
+// absolute paths) and never writes. Binary files come back as a base64 blob.
+func (server toolServer) readResource(rawParams json.RawMessage) ([]ResourceContents, int, error) {
+	var params struct {
+		URI string `json:"uri"`
+	}
+	if len(rawParams) > 0 {
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return nil, jsonRPCInvalidParams, fmt.Errorf("invalid resources/read params: %w", err)
+		}
+	}
+	uri := strings.TrimSpace(params.URI)
+	if uri == "" {
+		return nil, jsonRPCInvalidParams, errors.New("resources/read requires a uri")
+	}
+
+	requested, err := pathFromURI(uri)
+	if err != nil {
+		return nil, jsonRPCInvalidParams, err
+	}
+
+	absolute, err := server.resolveResourcePath(requested)
+	if err != nil {
+		// Out-of-scope and traversal attempts are reported as not-found with no
+		// contents so a remote client learns nothing about the host filesystem
+		// outside the granted roots.
+		return nil, jsonRPCResourceNotFound, err
+	}
+
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return nil, jsonRPCResourceNotFound, fmt.Errorf("resource not found: %s", uri)
+	}
+	if info.IsDir() {
+		return nil, jsonRPCInvalidParams, fmt.Errorf("resource is a directory, not a file: %s", uri)
+	}
+	if info.Size() > maxResourceBytes {
+		return nil, jsonRPCInvalidParams, fmt.Errorf("resource exceeds %d-byte limit: %s", maxResourceBytes, uri)
+	}
+
+	data, err := os.ReadFile(absolute)
+	if err != nil {
+		return nil, jsonRPCResourceNotFound, fmt.Errorf("resource not found: %s", uri)
+	}
+
+	contents := ResourceContents{
+		URI:      fileURI(absolute),
+		MimeType: mimeTypeForPath(absolute),
+	}
+	if looksBinary(absolute, data) {
+		contents.Blob = base64.StdEncoding.EncodeToString(data)
+		if contents.MimeType == "" || strings.HasPrefix(contents.MimeType, "text/") {
+			contents.MimeType = "application/octet-stream"
+		}
+	} else {
+		contents.Text = string(data)
+		if contents.MimeType == "" {
+			contents.MimeType = "text/plain; charset=utf-8"
+		}
+	}
+	return []ResourceContents{contents}, 0, nil
+}
+
+// resolveResourcePath maps a requested absolute path to a real path inside an
+// allowed root, rejecting traversal and out-of-scope locations. It mirrors the
+// containment checks the scoped file tools use: the cleaned, symlink-resolved
+// path must live within one of the roots (or equal a root).
+func (server toolServer) resolveResourcePath(requested string) (string, error) {
+	if !filepath.IsAbs(requested) {
+		return "", errors.New("resource uri must be an absolute file path")
+	}
+	cleaned := filepath.Clean(requested)
+
+	for _, root := range server.resourceRoots() {
+		if containedInRoot(root, cleaned) {
+			return cleaned, nil
+		}
+		// Resolve symlinks so an in-scope symlink that still lands inside a root
+		// is accepted, while a link escaping the roots is rejected.
+		if resolved, err := filepath.EvalSymlinks(cleaned); err == nil && containedInRoot(root, resolved) {
+			return resolved, nil
+		}
+	}
+	return "", errors.New("resource is outside the allowed workspace scope")
+}
+
+// containedInRoot reports whether target is root itself or lies beneath it,
+// using a separator-aware prefix check so /a/bc is not treated as inside /a/b.
+func containedInRoot(root string, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	if target == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return !filepath.IsAbs(rel)
+}
+
+// fileURI renders an absolute path as a file:// URI. The path is slash-normalized
+// and, on Windows where absolute paths start with a drive letter, gains the
+// extra leading slash file URIs require.
+func fileURI(absolute string) string {
+	slashed := filepath.ToSlash(absolute)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	return "file://" + slashed
+}
+
+// pathFromURI extracts an absolute filesystem path from a resource URI. It
+// accepts file:// URIs (the scheme resources/list advertises); any other scheme
+// is rejected so a client cannot smuggle in an unexpected locator.
+func pathFromURI(uri string) (string, error) {
+	const scheme = "file://"
+	if !strings.HasPrefix(uri, scheme) {
+		return "", fmt.Errorf("unsupported resource uri scheme: %s", uri)
+	}
+	rest := strings.TrimPrefix(uri, scheme)
+	// file:///abs -> /abs ; file://host/abs is not supported (no remote hosts).
+	if rest == "" {
+		return "", errors.New("resource uri has no path")
+	}
+	// Drop an optional empty authority (file:///path) but reject a real host.
+	if !strings.HasPrefix(rest, "/") {
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			return "", fmt.Errorf("resource uri host is not supported: %s", uri)
+		}
+		return "", fmt.Errorf("unsupported resource uri: %s", uri)
+	}
+	decoded := filepath.FromSlash(rest)
+	// On Windows a file URI like file:///C:/x yields /C:/x; strip the leading
+	// slash so it becomes a valid drive-rooted path.
+	if len(decoded) >= 3 && decoded[0] == filepath.Separator && decoded[2] == ':' {
+		decoded = decoded[1:]
+	}
+	return decoded, nil
+}
+
+// mimeTypeForPath maps a file extension to a MIME type, falling back to text for
+// known source/text extensions the standard library does not register.
+func mimeTypeForPath(file string) string {
+	ext := strings.ToLower(path.Ext(filepath.ToSlash(file)))
+	if ext == "" {
+		return "text/plain; charset=utf-8"
+	}
+	if mimeType := mime.TypeByExtension(ext); mimeType != "" {
+		return mimeType
+	}
+	switch ext {
+	case ".go", ".rs", ".py", ".rb", ".sh", ".bash", ".zsh", ".c", ".h", ".cc",
+		".cpp", ".hpp", ".java", ".kt", ".swift", ".php", ".lua", ".sql", ".proto",
+		".tf", ".dart", ".ex", ".exs", ".vue", ".svelte", ".toml":
+		return "text/plain; charset=utf-8"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// looksBinary decides whether a file's contents should be returned as a base64
+// blob. It treats known-binary extensions and any non-UTF-8 / NUL-containing
+// payload as binary; everything else is served as text.
+func looksBinary(file string, data []byte) bool {
+	if workspaceindex.LooksBinaryPath(file) {
+		return true
+	}
+	if bytes.IndexByte(data, 0) >= 0 {
+		return true
+	}
+	if !utf8.Valid(data) {
+		return true
+	}
+	// Sniff the leading bytes as a final guard for content the extension did not
+	// reveal (e.g. an unknown-extension binary).
+	sniff := data
+	if len(sniff) > 512 {
+		sniff = sniff[:512]
+	}
+	contentType := http.DetectContentType(sniff)
+	return strings.HasPrefix(contentType, "application/octet-stream")
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,224 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestServeInitializeAdvertisesResourcesAndPrompts(t *testing.T) {
+	registry := tools.NewRegistry()
+
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{ID: 1, Method: "initialize"})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, registry, ServeOptions{}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	var result struct {
+		Capabilities map[string]any `json:"capabilities"`
+	}
+	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+	for _, capability := range []string{"tools", "resources", "prompts"} {
+		if _, ok := result.Capabilities[capability]; !ok {
+			t.Fatalf("initialize capabilities = %#v, want %s", result.Capabilities, capability)
+		}
+	}
+}
+
+func TestServeResourcesListReturnsInScopeFiles(t *testing.T) {
+	workspace := t.TempDir()
+	writeResourceFile(t, workspace, "main.go", "package main\n")
+	writeResourceFile(t, workspace, "docs/readme.md", "# Title\n")
+	// A binary file is still listed (read decides how to encode it).
+	writeResourceFile(t, workspace, "logo.png", "\x89PNG\r\n\x1a\n")
+
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{ID: 1, Method: "resources/list"})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{WorkspaceRoot: workspace}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	var result struct {
+		Resources []Resource `json:"resources"`
+	}
+	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+
+	names := map[string]Resource{}
+	for _, resource := range result.Resources {
+		names[resource.Name] = resource
+	}
+	if _, ok := names["main.go"]; !ok {
+		t.Fatalf("resources = %#v, want main.go", result.Resources)
+	}
+	if _, ok := names["docs/readme.md"]; !ok {
+		t.Fatalf("resources = %#v, want docs/readme.md", result.Resources)
+	}
+	main := names["main.go"]
+	if !strings.HasPrefix(main.URI, "file://") {
+		t.Fatalf("resource URI = %q, want file:// scheme", main.URI)
+	}
+	if main.MimeType == "" {
+		t.Fatalf("resource mimeType empty for %#v", main)
+	}
+}
+
+func TestServeResourcesListExcludesOutOfScope(t *testing.T) {
+	workspace := t.TempDir()
+	writeResourceFile(t, workspace, "inside.txt", "in\n")
+
+	// A sibling directory outside the workspace root must never be enumerated.
+	outside := t.TempDir()
+	writeResourceFile(t, outside, "secret.txt", "leak\n")
+
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{ID: 1, Method: "resources/list"})
+
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{WorkspaceRoot: workspace}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+
+	var result struct {
+		Resources []Resource `json:"resources"`
+	}
+	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+	for _, resource := range result.Resources {
+		if strings.Contains(resource.URI, "secret.txt") || strings.Contains(resource.URI, filepath.Base(outside)) {
+			t.Fatalf("resource %#v leaks out-of-scope path", resource)
+		}
+	}
+}
+
+func TestServeResourcesReadReturnsText(t *testing.T) {
+	workspace := t.TempDir()
+	writeResourceFile(t, workspace, "hello.txt", "hello world\n")
+
+	uri := fileURI(filepath.Join(workspace, "hello.txt"))
+	contents := readResource(t, workspace, uri)
+	if len(contents) != 1 {
+		t.Fatalf("contents = %#v, want one entry", contents)
+	}
+	if contents[0].Text != "hello world\n" {
+		t.Fatalf("text = %q, want hello world", contents[0].Text)
+	}
+	if contents[0].Blob != "" {
+		t.Fatalf("blob = %q, want empty for text file", contents[0].Blob)
+	}
+	if contents[0].URI != uri {
+		t.Fatalf("uri = %q, want %q", contents[0].URI, uri)
+	}
+}
+
+func TestServeResourcesReadBinaryReturnsBlob(t *testing.T) {
+	workspace := t.TempDir()
+	raw := "\x89PNG\r\n\x1a\n\x00\x01\x02"
+	writeResourceFile(t, workspace, "logo.png", raw)
+
+	uri := fileURI(filepath.Join(workspace, "logo.png"))
+	contents := readResource(t, workspace, uri)
+	if len(contents) != 1 {
+		t.Fatalf("contents = %#v, want one entry", contents)
+	}
+	if contents[0].Text != "" {
+		t.Fatalf("text = %q, want empty for binary file", contents[0].Text)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(contents[0].Blob)
+	if err != nil {
+		t.Fatalf("blob decode: %v", err)
+	}
+	if string(decoded) != raw {
+		t.Fatalf("decoded blob = %q, want %q", decoded, raw)
+	}
+}
+
+func TestServeResourcesReadRejectsTraversal(t *testing.T) {
+	workspace := t.TempDir()
+	writeResourceFile(t, workspace, "inside.txt", "in\n")
+
+	traversal := "file://" + filepath.ToSlash(filepath.Join(workspace, "..", "..", "etc", "passwd"))
+	message := readResourceMessage(t, workspace, traversal)
+	if message.Error == nil {
+		t.Fatalf("expected error for traversal, got result %s", string(message.Result))
+	}
+	if len(message.Result) != 0 {
+		t.Fatalf("traversal returned contents: %s", string(message.Result))
+	}
+}
+
+func TestServeResourcesReadRejectsOutOfScopeAbsolute(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	writeResourceFile(t, outside, "secret.txt", "leak\n")
+
+	uri := fileURI(filepath.Join(outside, "secret.txt"))
+	message := readResourceMessage(t, workspace, uri)
+	if message.Error == nil {
+		t.Fatalf("expected error for out-of-scope absolute path, got result %s", string(message.Result))
+	}
+	if len(message.Result) != 0 {
+		t.Fatalf("out-of-scope read returned contents: %s", string(message.Result))
+	}
+	if strings.Contains(message.Error.Message, "leak") {
+		t.Fatalf("error message leaked file contents: %q", message.Error.Message)
+	}
+}
+
+func TestServeResourcesReadMissingFileErrors(t *testing.T) {
+	workspace := t.TempDir()
+
+	uri := fileURI(filepath.Join(workspace, "nope.txt"))
+	message := readResourceMessage(t, workspace, uri)
+	if message.Error == nil {
+		t.Fatalf("expected error for missing file, got result %s", string(message.Result))
+	}
+}
+
+func readResource(t *testing.T, workspace string, uri string) []ResourceContents {
+	t.Helper()
+	message := readResourceMessage(t, workspace, uri)
+	if message.Error != nil {
+		t.Fatalf("resources/read error = %#v", message.Error)
+	}
+	var result struct {
+		Contents []ResourceContents `json:"contents"`
+	}
+	decodeServerTestResult(t, message, &result)
+	return result.Contents
+}
+
+func readResourceMessage(t *testing.T, workspace string, uri string) rpcMessage {
+	t.Helper()
+	var input bytes.Buffer
+	writeServerTestMessage(t, &input, rpcMessage{
+		ID:     7,
+		Method: "resources/read",
+		Params: mustRaw(map[string]any{"uri": uri}),
+	})
+	var output bytes.Buffer
+	if err := Serve(context.Background(), &input, &output, tools.NewRegistry(), ServeOptions{WorkspaceRoot: workspace}); err != nil {
+		t.Fatalf("Serve() error = %v", err)
+	}
+	return readServerTestMessage(t, newMessageReader(&output))
+}
+
+func writeResourceFile(t *testing.T, root string, rel string, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -156,6 +156,28 @@ func TestServeResourcesReadRejectsTraversal(t *testing.T) {
 	}
 }
 
+func TestServeResourcesReadRejectsInRootSymlinkEscape(t *testing.T) {
+	workspace := t.TempDir()
+	writeResourceFile(t, workspace, "inside.txt", "in\n")
+	// A secret outside the workspace, reachable only via an in-workspace symlink.
+	// Resolving symlinks before the scope check must keep it unreadable.
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("top secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(workspace, "link.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+	message := readResourceMessage(t, workspace, fileURI(link))
+	if message.Error == nil {
+		t.Fatalf("expected error for an in-root symlink escaping the workspace, got result %s", string(message.Result))
+	}
+	if len(message.Result) != 0 {
+		t.Fatalf("symlink escape returned contents: %s", string(message.Result))
+	}
+}
+
 func TestServeResourcesReadRejectsOutOfScopeAbsolute(t *testing.T) {
 	workspace := t.TempDir()
 	outside := t.TempDir()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -24,6 +25,14 @@ type ServeOptions struct {
 	Name              string
 	Version           string
 	PermissionGranted bool
+	// WorkspaceRoot is the directory whose files are exposed as MCP resources.
+	// Empty means the process working directory. Resource reads are confined to
+	// this root (and any extra Scope roots).
+	WorkspaceRoot string
+	// Scope, when set, widens the resource roots beyond WorkspaceRoot using the
+	// same multi-root scoping the sandbox/file tools use. nil means
+	// workspace-only.
+	Scope tools.PathScope
 }
 
 func Serve(ctx context.Context, input io.Reader, output io.Writer, registry *tools.Registry, options ServeOptions) error {
@@ -32,10 +41,13 @@ func Serve(ctx context.Context, input io.Reader, output io.Writer, registry *too
 	}
 	reader := newMessageReader(input)
 	writer := newMessageWriter(output)
+	resolvedOptions := options.withDefaults()
 	server := toolServer{
-		registry: registry,
-		options:  options.withDefaults(),
-		writer:   writer,
+		registry:      registry,
+		options:       resolvedOptions,
+		writer:        writer,
+		workspaceRoot: resolvedOptions.WorkspaceRoot,
+		scope:         resolvedOptions.Scope,
 	}
 
 	// Run the blocking reads on a goroutine and select on ctx so a
@@ -89,13 +101,20 @@ func (options ServeOptions) withDefaults() ServeOptions {
 	if strings.TrimSpace(options.Version) == "" {
 		options.Version = "dev"
 	}
+	if strings.TrimSpace(options.WorkspaceRoot) == "" {
+		if cwd, err := os.Getwd(); err == nil {
+			options.WorkspaceRoot = cwd
+		}
+	}
 	return options
 }
 
 type toolServer struct {
-	registry *tools.Registry
-	options  ServeOptions
-	writer   *messageWriter
+	registry      *tools.Registry
+	options       ServeOptions
+	writer        *messageWriter
+	workspaceRoot string
+	scope         tools.PathScope
 }
 
 func (server toolServer) handle(ctx context.Context, message rpcMessage) error {
@@ -110,7 +129,11 @@ func (server toolServer) handle(ctx context.Context, message rpcMessage) error {
 	case "initialize":
 		return server.writeResult(message.ID, map[string]any{
 			"protocolVersion": defaultProtocolVersion,
-			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"capabilities": map[string]any{
+				"tools":     map[string]any{},
+				"resources": map[string]any{},
+				"prompts":   map[string]any{},
+			},
 			"serverInfo": map[string]any{
 				"name":    server.options.Name,
 				"version": server.options.Version,
@@ -124,6 +147,28 @@ func (server toolServer) handle(ctx context.Context, message rpcMessage) error {
 		result, err := server.callTool(ctx, message.Params)
 		if err != nil {
 			return server.writeError(message.ID, jsonRPCInvalidParams, err.Error())
+		}
+		return server.writeResult(message.ID, result)
+	case "resources/list":
+		return server.writeResult(message.ID, map[string]any{
+			"resources": server.listResources(),
+		})
+	case "resources/read":
+		contents, code, err := server.readResource(message.Params)
+		if err != nil {
+			return server.writeError(message.ID, code, err.Error())
+		}
+		return server.writeResult(message.ID, map[string]any{
+			"contents": contents,
+		})
+	case "prompts/list":
+		return server.writeResult(message.ID, map[string]any{
+			"prompts": listPrompts(),
+		})
+	case "prompts/get":
+		result, code, err := getPrompt(message.Params)
+		if err != nil {
+			return server.writeError(message.ID, code, err.Error())
 		}
 		return server.writeResult(message.ID, result)
 	case "ping":

--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -17,8 +17,22 @@ type Backend struct {
 	Fallback        bool        `json:"fallback"`
 	CommandWrapping bool        `json:"commandWrapping"`
 	NativeIsolation bool        `json:"nativeIsolation"`
-	Executable      string      `json:"executable,omitempty"`
-	Message         string      `json:"message,omitempty"`
+	// ScopedEgress reports whether this backend can route a sandboxed process's
+	// traffic through the local filtering proxy so a NetworkScoped allowlist is
+	// actually enforced. Only sandbox-exec can today (it shares the host network
+	// under a seatbelt profile that restricts outbound to the proxy port);
+	// bubblewrap isolates the network namespace with no bridge to the host proxy,
+	// so scoped egress there collapses to deny until a real relay exists.
+	ScopedEgress bool   `json:"scopedEgress,omitempty"`
+	Executable   string `json:"executable,omitempty"`
+	Message      string `json:"message,omitempty"`
+}
+
+// EnforcesScopedEgress reports whether a populated NetworkScoped allowlist can be
+// enforced by this backend. When false, scoped egress must fail closed (collapse
+// to deny) rather than silently run with unrestricted networking.
+func (backend Backend) EnforcesScopedEgress() bool {
+	return backend.Available && backend.Executable != "" && backend.ScopedEgress
 }
 
 type BackendPlan struct {
@@ -72,8 +86,11 @@ func nativeBackend(goos string, name BackendName, executable string, message str
 		Fallback:        false,
 		CommandWrapping: true,
 		NativeIsolation: true,
-		Executable:      executable,
-		Message:         message,
+		// Only sandbox-exec can enforce scoped egress today; bubblewrap's isolated
+		// network namespace has no bridge to the host filtering proxy.
+		ScopedEgress: name == BackendSandboxExec,
+		Executable:   executable,
+		Message:      message,
 	}
 }
 

--- a/internal/sandbox/auto_allow_bash_test.go
+++ b/internal/sandbox/auto_allow_bash_test.go
@@ -1,0 +1,156 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func autoAllowBashEngine(t *testing.T, autoAllow bool, backend Backend) *Engine {
+	t.Helper()
+	policy := DefaultPolicy()
+	policy.AutoAllowBashWhenSandboxed = autoAllow
+	return NewEngine(EngineOptions{
+		WorkspaceRoot: t.TempDir(),
+		Policy:        policy,
+		Backend:       backend,
+	})
+}
+
+func bashRequest() Request {
+	return Request{
+		ToolName:       "bash",
+		SideEffect:     SideEffectShell,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"command": "echo hi"},
+	}
+}
+
+var nativeWrappingBackend = Backend{
+	Name:            BackendBubblewrap,
+	Available:       true,
+	Executable:      "/usr/bin/bwrap",
+	CommandWrapping: true,
+	NativeIsolation: true,
+}
+
+// TestAutoAllowBashWhenSandboxedActive: flag on + a real wrapping backend means
+// the bash prompt is skipped (auto-allow), because the sandbox is the safety
+// boundary.
+func TestAutoAllowBashWhenSandboxedActive(t *testing.T) {
+	engine := autoAllowBashEngine(t, true, nativeWrappingBackend)
+	decision := engine.Evaluate(context.Background(), bashRequest())
+	if decision.Action != ActionAllow {
+		t.Fatalf("decision = %#v, want allow (sandbox active + flag on)", decision)
+	}
+}
+
+// TestAutoAllowBashIgnoredWithoutSandbox: flag on but NO active sandbox
+// (policy-only backend) must NOT auto-allow; the normal prompt policy stands.
+func TestAutoAllowBashIgnoredWithoutSandbox(t *testing.T) {
+	engine := autoAllowBashEngine(t, true, Backend{Name: BackendPolicyOnly})
+	decision := engine.Evaluate(context.Background(), bashRequest())
+	if decision.Action != ActionPrompt {
+		t.Fatalf("decision = %#v, want prompt (no active sandbox, flag must be ignored)", decision)
+	}
+}
+
+// TestAutoAllowBashOffStillPrompts: flag off + active sandbox keeps the normal
+// prompt policy.
+func TestAutoAllowBashOffStillPrompts(t *testing.T) {
+	engine := autoAllowBashEngine(t, false, nativeWrappingBackend)
+	decision := engine.Evaluate(context.Background(), bashRequest())
+	if decision.Action != ActionPrompt {
+		t.Fatalf("decision = %#v, want prompt (flag off)", decision)
+	}
+}
+
+// TestAutoAllowBashDisabledPolicyMode: when the policy is disabled the sandbox
+// is not enforcing, so the flag must not change the (already-allow) outcome and
+// must not error.
+func TestAutoAllowBashDoesNotAffectNonShell(t *testing.T) {
+	engine := autoAllowBashEngine(t, true, nativeWrappingBackend)
+	// A non-shell prompt tool must still prompt; auto-allow is shell-only.
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"path": "notes.txt"},
+	})
+	if decision.Action != ActionPrompt {
+		t.Fatalf("decision = %#v, want prompt (auto-allow is shell-only)", decision)
+	}
+}
+
+// TestAutoAllowBashEnvSurface verifies the ZERO_SANDBOX_AUTO_ALLOW_BASH env var
+// is off by default and only enables on a truthy value, and that the overlay
+// never disables an already-enabled config field.
+func TestAutoAllowBashEnvSurface(t *testing.T) {
+	cases := []struct {
+		value string
+		set   bool
+		want  bool
+	}{
+		{set: false, want: false},
+		{value: "", set: true, want: false},
+		{value: "0", set: true, want: false},
+		{value: "false", set: true, want: false},
+		{value: "nonsense", set: true, want: false},
+		{value: "1", set: true, want: true},
+		{value: "true", set: true, want: true},
+		{value: "TRUE", set: true, want: true},
+	}
+	for _, tc := range cases {
+		if tc.set {
+			t.Setenv(EnvAutoAllowBash, tc.value)
+		} else {
+			os.Unsetenv(EnvAutoAllowBash)
+		}
+		if got := AutoAllowBashEnvEnabled(); got != tc.want {
+			t.Fatalf("AutoAllowBashEnvEnabled() with %q (set=%v) = %v, want %v", tc.value, tc.set, got, tc.want)
+		}
+		overlaid := ApplyAutoAllowBashEnv(DefaultPolicy())
+		if overlaid.AutoAllowBashWhenSandboxed != tc.want {
+			t.Fatalf("ApplyAutoAllowBashEnv with %q = %v, want %v", tc.value, overlaid.AutoAllowBashWhenSandboxed, tc.want)
+		}
+	}
+
+	// The overlay must not clear an already-enabled config opt-in when the env is
+	// unset.
+	os.Unsetenv(EnvAutoAllowBash)
+	enabled := DefaultPolicy()
+	enabled.AutoAllowBashWhenSandboxed = true
+	if got := ApplyAutoAllowBashEnv(enabled); !got.AutoAllowBashWhenSandboxed {
+		t.Fatal("ApplyAutoAllowBashEnv cleared an already-enabled config opt-in")
+	}
+}
+
+// TestShellSandboxActive reports correctly across backends and policy modes.
+func TestShellSandboxActive(t *testing.T) {
+	root := t.TempDir()
+
+	native := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Backend: nativeWrappingBackend})
+	if !native.shellSandboxActive(DefaultPolicy()) {
+		t.Fatal("native wrapping backend must be sandbox-active")
+	}
+
+	policyOnly := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Backend: Backend{Name: BackendPolicyOnly}})
+	if policyOnly.shellSandboxActive(DefaultPolicy()) {
+		t.Fatal("policy-only backend must NOT be sandbox-active")
+	}
+
+	disabled := DefaultPolicy()
+	disabled.Mode = ModeDisabled
+	if native.shellSandboxActive(disabled) {
+		t.Fatal("disabled policy must NOT be sandbox-active")
+	}
+
+	var nilEngine *Engine
+	if nilEngine.shellSandboxActive(DefaultPolicy()) {
+		t.Fatal("nil engine must NOT be sandbox-active")
+	}
+}

--- a/internal/sandbox/egress.go
+++ b/internal/sandbox/egress.go
@@ -160,9 +160,14 @@ func (proxy *egressProxy) handleConnect(w http.ResponseWriter, r *http.Request) 
 // host, then re-issues the request upstream and copies the response back. A
 // denied host gets a 403 and the request is never forwarded.
 func (proxy *egressProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
-	target := r.Host
+	// Authorize the host actually dialed. A forward-proxy request carries an
+	// absolute URL whose host is the upstream target, so authorize r.URL.Host
+	// and fall back to the Host header only when the request line had no host.
+	// Trusting the Host header here would let `GET http://denied/ Host: allowed`
+	// bypass the allowlist while the transport still dials the URL host.
+	target := r.URL.Host
 	if target == "" {
-		target = r.URL.Host
+		target = r.Host
 	}
 	host := hostnameOnly(target)
 	if host == "" || !domainAllowed(host, proxy.allowed, proxy.denied) {

--- a/internal/sandbox/egress.go
+++ b/internal/sandbox/egress.go
@@ -1,0 +1,339 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+// egressProxy is a local, in-process filtering HTTP proxy used to give a
+// sandboxed process *scoped* network egress: it may reach an explicit set of
+// domains and nothing else. It handles both HTTP CONNECT (the HTTPS tunnel
+// method) and plain HTTP forward-proxy requests. Every connection's target
+// host is checked against the allow/deny lists; a denied target is refused
+// (403 / failed CONNECT) and never tunneled.
+//
+// The proxy binds to an ephemeral loopback port (127.0.0.1:0) so only the local
+// machine can reach it; the chosen address is exported into the sandbox env as
+// HTTP_PROXY/HTTPS_PROXY/ALL_PROXY by the runner.
+//
+// Safety: the proxy fails closed. An empty effective allowlist is rejected at
+// construction; an unparseable target host is denied; any forwarding error
+// closes the connection rather than opening unrestricted access.
+type egressProxy struct {
+	listener net.Listener
+	server   *http.Server
+	allowed  []string
+	denied   []string
+	log      func(string)
+
+	closeOnce sync.Once
+}
+
+// egressOptions configures a scoped-egress proxy. Allowed lists the domains the
+// sandboxed process may reach (exact host or any subdomain). Denied is
+// subtracted from Allowed and always wins. Log, when set, receives one line per
+// allow/deny decision; lines are passed through the repo redaction so query
+// tokens are never written to the audit trail.
+type egressOptions struct {
+	Allowed []string
+	Denied  []string
+	Log     func(string)
+}
+
+// errEmptyAllowlist is returned when a scoped-egress proxy is requested with no
+// allowlisted domains. Scoped egress with an empty allowlist must behave like a
+// full network deny, so the caller treats this as "deny", never "allow".
+var errEmptyAllowlist = errors.New("scoped egress requires at least one allowed domain")
+
+func newEgressProxy(options egressOptions) (*egressProxy, error) {
+	allowed := normalizeDomains(options.Allowed)
+	if len(allowed) == 0 {
+		return nil, errEmptyAllowlist
+	}
+	denied := normalizeDomains(options.Denied)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("bind scoped-egress proxy: %w", err)
+	}
+
+	proxy := &egressProxy{
+		listener: listener,
+		allowed:  allowed,
+		denied:   denied,
+		log:      options.Log,
+	}
+	proxy.server = &http.Server{
+		Handler:           http.HandlerFunc(proxy.handle),
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	go func() {
+		// Serve returns ErrServerClosed on Close; nothing else to do.
+		_ = proxy.server.Serve(listener)
+	}()
+	return proxy, nil
+}
+
+// Addr returns the loopback host:port the proxy is listening on.
+func (proxy *egressProxy) Addr() string {
+	if proxy == nil || proxy.listener == nil {
+		return ""
+	}
+	return proxy.listener.Addr().String()
+}
+
+// Close stops the proxy and releases its listener. It is safe to call multiple
+// times.
+func (proxy *egressProxy) Close() error {
+	if proxy == nil {
+		return nil
+	}
+	var err error
+	proxy.closeOnce.Do(func() {
+		if proxy.server != nil {
+			err = proxy.server.Close()
+		}
+	})
+	return err
+}
+
+func (proxy *egressProxy) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		proxy.handleConnect(w, r)
+		return
+	}
+	proxy.handleHTTP(w, r)
+}
+
+// handleConnect implements the HTTPS tunnel: it authorizes the CONNECT target,
+// then (if allowed) hijacks the client connection and blindly relays bytes
+// between the client and the upstream. The proxy never sees plaintext TLS; the
+// allow/deny decision is made purely on the requested host.
+func (proxy *egressProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
+	target := r.Host
+	if target == "" {
+		target = r.URL.Host
+	}
+	host := hostnameOnly(target)
+	if host == "" || !domainAllowed(host, proxy.allowed, proxy.denied) {
+		proxy.logDecision("deny", "CONNECT", target)
+		http.Error(w, "scoped egress: host not allowed", http.StatusForbidden)
+		return
+	}
+
+	upstream, err := net.DialTimeout("tcp", normalizeConnectTarget(target), 30*time.Second)
+	if err != nil {
+		proxy.logDecision("deny", "CONNECT", target)
+		http.Error(w, "scoped egress: upstream dial failed", http.StatusBadGateway)
+		return
+	}
+	defer upstream.Close()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "scoped egress: hijack unsupported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, "scoped egress: hijack failed", http.StatusInternalServerError)
+		return
+	}
+	defer clientConn.Close()
+
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		return
+	}
+	proxy.logDecision("allow", "CONNECT", target)
+	relay(clientConn, upstream)
+}
+
+// handleHTTP implements the plain-HTTP forward proxy: it authorizes the target
+// host, then re-issues the request upstream and copies the response back. A
+// denied host gets a 403 and the request is never forwarded.
+func (proxy *egressProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
+	target := r.Host
+	if target == "" {
+		target = r.URL.Host
+	}
+	host := hostnameOnly(target)
+	if host == "" || !domainAllowed(host, proxy.allowed, proxy.denied) {
+		proxy.logDecision("deny", r.Method, requestURLString(r))
+		http.Error(w, "scoped egress: host not allowed", http.StatusForbidden)
+		return
+	}
+
+	outbound := r.Clone(r.Context())
+	outbound.RequestURI = ""
+	// A forward-proxy request carries an absolute URL; ensure the scheme/host
+	// are populated so the transport can dial the upstream.
+	if outbound.URL.Scheme == "" {
+		outbound.URL.Scheme = "http"
+	}
+	if outbound.URL.Host == "" {
+		outbound.URL.Host = target
+	}
+
+	transport := &http.Transport{}
+	defer transport.CloseIdleConnections()
+	resp, err := transport.RoundTrip(outbound)
+	if err != nil {
+		proxy.logDecision("deny", r.Method, requestURLString(r))
+		http.Error(w, "scoped egress: upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	proxy.logDecision("allow", r.Method, requestURLString(r))
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// logDecision records a single allow/deny decision through the repo redaction so
+// a target carrying a query token (e.g. ?token=...) is never written raw.
+func (proxy *egressProxy) logDecision(decision string, method string, target string) {
+	if proxy == nil || proxy.log == nil {
+		return
+	}
+	safe := redaction.RedactString(target, redaction.Options{})
+	proxy.log(fmt.Sprintf("scoped-egress %s %s %s", decision, method, safe))
+}
+
+// relay copies bytes in both directions between two connections until either
+// side closes, then returns. It is the byte-pump for an established CONNECT
+// tunnel.
+func relay(a, b net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	copyHalf := func(dst, src net.Conn) {
+		defer wg.Done()
+		_, _ = io.Copy(dst, src)
+		// Unblock the paired copy by signalling EOF/closure on the other half.
+		if closer, ok := dst.(interface{ CloseWrite() error }); ok {
+			_ = closer.CloseWrite()
+		} else {
+			_ = dst.SetReadDeadline(time.Now())
+		}
+	}
+	go copyHalf(a, b)
+	go copyHalf(b, a)
+	wg.Wait()
+}
+
+// domainAllowed reports whether host may be reached under the given allow/deny
+// lists. Matching semantics (host is lowercased and stripped of any :port and
+// trailing dot first):
+//
+//   - An entry matches host when host equals the entry OR host is a subdomain of
+//     the entry (host ends with "."+entry). So "github.com" matches "github.com"
+//     and "api.github.com", but NOT "notgithub.com" (no label boundary) nor
+//     "github.com.evil.com" (entry is not a suffix at a label boundary).
+//   - host is allowed only if it matches at least one Allowed entry AND matches
+//     no Denied entry. Deny always wins (deny overrides allow), and the deny
+//     check uses the same exact-or-subdomain rule, so denying "github.com" blocks
+//     every github.com subdomain while denying "secret.github.com" blocks only
+//     that subtree.
+//   - An empty host, or an empty allowlist, is denied (fail closed).
+func domainAllowed(host string, allowed []string, denied []string) bool {
+	normalized := hostnameOnly(host)
+	if normalized == "" {
+		return false
+	}
+	matched := false
+	for _, entry := range allowed {
+		if domainMatches(normalized, entry) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+	for _, entry := range denied {
+		if domainMatches(normalized, entry) {
+			return false
+		}
+	}
+	return true
+}
+
+// domainMatches reports whether host is exactly entry or a subdomain of entry.
+// Both arguments must already be lowercased host-only forms.
+func domainMatches(host string, entry string) bool {
+	if entry == "" || host == "" {
+		return false
+	}
+	if host == entry {
+		return true
+	}
+	return strings.HasSuffix(host, "."+entry)
+}
+
+// hostnameOnly lowercases host, strips any :port and a single trailing dot, and
+// returns the bare hostname. It returns "" for input that has no usable host.
+func hostnameOnly(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	// Strip a :port when present; SplitHostPort fails on a bare host, in which
+	// case the original value is the host.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.TrimSuffix(host, ".")
+	return strings.ToLower(host)
+}
+
+// normalizeConnectTarget ensures a CONNECT target carries an explicit port,
+// defaulting to 443 (the HTTPS port CONNECT is used for) when one is absent.
+func normalizeConnectTarget(target string) string {
+	if _, _, err := net.SplitHostPort(target); err == nil {
+		return target
+	}
+	return net.JoinHostPort(strings.TrimSuffix(target, "."), "443")
+}
+
+// normalizeDomains lowercases, trims, host-normalizes, and de-duplicates a list
+// of domain entries, dropping blanks.
+func normalizeDomains(domains []string) []string {
+	if len(domains) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(domains))
+	out := make([]string, 0, len(domains))
+	for _, domain := range domains {
+		normalized := hostnameOnly(domain)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+// requestURLString returns a printable form of the request target for logging.
+// It is always passed through redaction before being written.
+func requestURLString(r *http.Request) string {
+	if r.URL != nil && r.URL.String() != "" {
+		return r.URL.String()
+	}
+	return r.Host
+}

--- a/internal/sandbox/egress_test.go
+++ b/internal/sandbox/egress_test.go
@@ -79,6 +79,25 @@ func TestEgressProxyBindsLoopback(t *testing.T) {
 	}
 }
 
+// TestEgressProxyHTTPAuthorizesURLHostNotHostHeader verifies an absolute-URL
+// request to a DENIED host carrying an ALLOWED Host header is refused —
+// authorization follows the dialed URL host, not the spoofable Host header.
+func TestEgressProxyHTTPAuthorizesURLHostNotHostHeader(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"allowed.example"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	req := httptest.NewRequest(http.MethodGet, "http://denied.example/data", nil)
+	req.Host = "allowed.example" // spoofed allowed Host header
+	rec := httptest.NewRecorder()
+	proxy.handleHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (Host header must not authorize a different URL host)", rec.Code)
+	}
+}
+
 // TestEgressProxyConnectAllowed verifies an allowlisted CONNECT tunnels through
 // to a fake upstream TLS server.
 func TestEgressProxyConnectAllowed(t *testing.T) {

--- a/internal/sandbox/egress_test.go
+++ b/internal/sandbox/egress_test.go
@@ -1,0 +1,280 @@
+package sandbox
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDomainAllowedMatchingSemantics(t *testing.T) {
+	cases := []struct {
+		name    string
+		host    string
+		allowed []string
+		denied  []string
+		want    bool
+	}{
+		{name: "exact match", host: "github.com", allowed: []string{"github.com"}, want: true},
+		{name: "subdomain match", host: "api.github.com", allowed: []string{"github.com"}, want: true},
+		{name: "deep subdomain match", host: "a.b.github.com", allowed: []string{"github.com"}, want: true},
+		{name: "host with port", host: "github.com:443", allowed: []string{"github.com"}, want: true},
+		{name: "subdomain with port", host: "api.github.com:443", allowed: []string{"github.com"}, want: true},
+		{name: "case insensitive", host: "API.GitHub.COM", allowed: []string{"github.com"}, want: true},
+		{name: "trailing dot host", host: "github.com.", allowed: []string{"github.com"}, want: true},
+
+		{name: "no false suffix prefix", host: "notgithub.com", allowed: []string{"github.com"}, want: false},
+		{name: "no false suffix superstring label", host: "evilgithub.com", allowed: []string{"github.com"}, want: false},
+		{name: "no false suffix appended domain", host: "github.com.evil.com", allowed: []string{"github.com"}, want: false},
+		{name: "unrelated host", host: "example.org", allowed: []string{"github.com"}, want: false},
+		{name: "empty allowlist denies", host: "github.com", allowed: nil, want: false},
+
+		{name: "deny overrides allow exact", host: "github.com", allowed: []string{"github.com"}, denied: []string{"github.com"}, want: false},
+		{name: "deny overrides allow subdomain", host: "api.github.com", allowed: []string{"github.com"}, denied: []string{"github.com"}, want: false},
+		{name: "deny specific subdomain only", host: "secret.github.com", allowed: []string{"github.com"}, denied: []string{"secret.github.com"}, want: false},
+		{name: "allow sibling when deny is specific", host: "api.github.com", allowed: []string{"github.com"}, denied: []string{"secret.github.com"}, want: true},
+
+		{name: "multiple allow entries", host: "registry.npmjs.org", allowed: []string{"github.com", "npmjs.org"}, want: true},
+		{name: "empty host denied", host: "", allowed: []string{"github.com"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := domainAllowed(tc.host, tc.allowed, tc.denied)
+			if got != tc.want {
+				t.Fatalf("domainAllowed(%q, %v, %v) = %v, want %v", tc.host, tc.allowed, tc.denied, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewEgressProxyEmptyAllowlistFailsClosed(t *testing.T) {
+	if _, err := newEgressProxy(egressOptions{Allowed: nil}); err == nil {
+		t.Fatal("newEgressProxy with empty allowlist = nil error, want fail-closed error")
+	}
+	if _, err := newEgressProxy(egressOptions{Allowed: []string{"   "}}); err == nil {
+		t.Fatal("newEgressProxy with blank-only allowlist = nil error, want fail-closed error")
+	}
+}
+
+func TestEgressProxyBindsLoopback(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+	host, _, err := net.SplitHostPort(proxy.Addr())
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", proxy.Addr(), err)
+	}
+	if host != "127.0.0.1" {
+		t.Fatalf("proxy bound to %q, want loopback 127.0.0.1", host)
+	}
+}
+
+// TestEgressProxyConnectAllowed verifies an allowlisted CONNECT tunnels through
+// to a fake upstream TLS server.
+func TestEgressProxyConnectAllowed(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "upstream-ok")
+	}))
+	defer upstream.Close()
+	upstreamHost := mustHost(t, upstream.URL)
+
+	// Allow the upstream host so the tunnel is permitted.
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{upstreamHost}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.Addr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	target := mustHostPort(t, upstream.URL)
+	fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: "CONNECT"})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("tls handshake through tunnel: %v", err)
+	}
+	fmt.Fprintf(tlsConn, "GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", target)
+	body, err := io.ReadAll(tlsConn)
+	if err != nil {
+		t.Fatalf("read tunneled response: %v", err)
+	}
+	if !strings.Contains(string(body), "upstream-ok") {
+		t.Fatalf("tunneled body = %q, want upstream-ok", string(body))
+	}
+}
+
+// TestEgressProxyConnectRefused verifies a non-allowlisted CONNECT is refused
+// with 403 and no tunnel is established.
+func TestEgressProxyConnectRefused(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.Addr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprint(conn, "CONNECT notgithub.com:443 HTTP/1.1\r\nHost: notgithub.com:443\r\n\r\n")
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: "CONNECT"})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("CONNECT status = %d, want 403 for denied host", resp.StatusCode)
+	}
+}
+
+// TestEgressProxyHTTPRefused verifies a plain-HTTP request to a denied host is
+// blocked with 403.
+func TestEgressProxyHTTPRefused(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(mustURL(t, "http://"+proxy.Addr())),
+		},
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get("http://denied.example.com/path")
+	if err != nil {
+		t.Fatalf("proxied GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("HTTP status = %d, want 403 for denied host", resp.StatusCode)
+	}
+}
+
+// TestEgressProxyHTTPAllowed verifies a plain-HTTP request to an allowlisted
+// host is forwarded to the upstream.
+func TestEgressProxyHTTPAllowed(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "http-upstream-ok")
+	}))
+	defer upstream.Close()
+	upstreamHost := mustHost(t, upstream.URL)
+
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{upstreamHost}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(mustURL(t, "http://"+proxy.Addr())),
+		},
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get(upstream.URL + "/path")
+	if err != nil {
+		t.Fatalf("proxied GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(body), "http-upstream-ok") {
+		t.Fatalf("allowed HTTP status=%d body=%q, want 200 http-upstream-ok", resp.StatusCode, string(body))
+	}
+}
+
+// TestEgressProxyRedactsDeniedURLLogs verifies a denied URL containing a
+// ?token=... query string is not logged raw (the token is redacted).
+func TestEgressProxyRedactsDeniedURLLogs(t *testing.T) {
+	var mu sync.Mutex
+	var logs []string
+	proxy, err := newEgressProxy(egressOptions{
+		Allowed: []string{"github.com"},
+		Log: func(line string) {
+			mu.Lock()
+			logs = append(logs, line)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	const secret = "super-secret-token-value-1234567890"
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(mustURL(t, "http://"+proxy.Addr())),
+		},
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get("http://denied.example.com/path?token=" + secret)
+	if err != nil {
+		t.Fatalf("proxied GET: %v", err)
+	}
+	resp.Body.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(logs) == 0 {
+		t.Fatal("expected a deny log line, got none")
+	}
+	joined := strings.Join(logs, "\n")
+	if strings.Contains(joined, secret) {
+		t.Fatalf("deny log leaked the raw token:\n%s", joined)
+	}
+	// Sanity: the deny decision was logged for the denied host.
+	if !strings.Contains(joined, "denied.example.com") {
+		t.Fatalf("deny log missing host:\n%s", joined)
+	}
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return parsed
+}
+
+func mustHost(t *testing.T, raw string) string {
+	t.Helper()
+	host, _, err := net.SplitHostPort(mustHostPort(t, raw))
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	return host
+}
+
+func mustHostPort(t *testing.T, raw string) string {
+	t.Helper()
+	parsed := mustURL(t, raw)
+	return parsed.Host
+}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -79,6 +79,23 @@ func (engine *Engine) scopeFor(requestRoot string) *Scope {
 	return &Scope{workspaceRoot: requestRoot}
 }
 
+// shellSandboxActive reports whether a native wrapping sandbox would actually
+// wrap a shell command under the given policy. It is true only when the policy
+// is enforcing and the engine's backend can wrap commands with native isolation
+// (bubblewrap / sandbox-exec available). A policy-only fallback, a disabled
+// policy, or a nil engine all report false — so AutoAllowBashWhenSandboxed never
+// auto-allows an unsandboxed command.
+func (engine *Engine) shellSandboxActive(policy Policy) bool {
+	if engine == nil {
+		return false
+	}
+	if policy.Mode == ModeDisabled {
+		return false
+	}
+	backend := engine.backend
+	return backend.Available && backend.Executable != "" && backend.CommandWrapping && backend.NativeIsolation
+}
+
 func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	if ctx == nil {
 		ctx = context.Background()
@@ -135,7 +152,11 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 			}
 		}
 	}
-	if policy.Network == NetworkDeny && HasRiskCategory(risk, "network") {
+	// effectiveNetwork collapses an empty-allowlist scoped policy to deny, so a
+	// misconfigured scoped policy still fails closed here; a populated scoped
+	// policy permits network-risk tools (the egress proxy enforces the allowlist
+	// at the transport layer). Allow/deny behaviour is unchanged.
+	if effectiveNetwork(policy) == NetworkDeny && HasRiskCategory(risk, "network") {
 		return deny(request, risk, ViolationNetwork, "", "network access is blocked by sandbox policy", false)
 	}
 	if policy.DenyDestructiveShell && HasRiskCategory(risk, "destructive") {
@@ -173,6 +194,18 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	}
 	if request.Permission == PermissionAllow {
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
+	}
+	// Auto-allow a sandboxed shell command when the operator opted in: the active
+	// native sandbox is the safety boundary, so the bash prompt is skipped. This
+	// only applies to shell commands AND only when a wrapping sandbox is actually
+	// active; an inactive sandbox (policy-only / disabled) ignores the flag so
+	// unsandboxed bash is never silently allowed. It still respects the autonomy
+	// ceiling, matching how an explicit permission grant is clamped.
+	if policy.AutoAllowBashWhenSandboxed && request.SideEffect == SideEffectShell && engine.shellSandboxActive(policy) {
+		if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {
+			return Decision{Action: ActionPrompt, Risk: risk, Reason: reasonAboveCeiling}
+		}
+		return Decision{Action: ActionAllow, Risk: risk, Reason: "auto-allowed: sandbox is active for this shell command", AutoAllowed: true}
 	}
 	if request.PermissionGranted || request.PermissionMode == PermissionUnsafe {
 		if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -153,10 +153,16 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 		}
 	}
 	// effectiveNetwork collapses an empty-allowlist scoped policy to deny, so a
-	// misconfigured scoped policy still fails closed here; a populated scoped
-	// policy permits network-risk tools (the egress proxy enforces the allowlist
-	// at the transport layer). Allow/deny behaviour is unchanged.
-	if effectiveNetwork(policy) == NetworkDeny && HasRiskCategory(risk, "network") {
+	// misconfigured scoped policy still fails closed here. A populated scoped policy
+	// permits network-risk tools ONLY when the active backend can actually route
+	// through the filtering proxy; otherwise (bubblewrap's isolated netns has no
+	// bridge, policy-only has no isolation) the allowlist is unenforceable and must
+	// fail closed rather than run with unrestricted networking. Allow is unchanged.
+	netMode := effectiveNetwork(policy)
+	if netMode == NetworkScoped && !engine.backend.EnforcesScopedEgress() {
+		netMode = NetworkDeny
+	}
+	if netMode == NetworkDeny && HasRiskCategory(risk, "network") {
 		return deny(request, risk, ViolationNetwork, "", "network access is blocked by sandbox policy", false)
 	}
 	if policy.DenyDestructiveShell && HasRiskCategory(risk, "destructive") {

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -136,15 +136,15 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 	switch backend.Name {
 	case BackendBubblewrap:
 		if backend.Available && backend.Executable != "" {
-			egress, err := startScopedEgress(policy)
-			if err != nil {
-				return CommandPlan{}, err
-			}
-			return bubblewrapCommandPlan(spec, workspaceRoot, relativeDir, engine.writeRoots(workspaceRoot), policy, backend, egress), nil
+			// Bubblewrap isolates the network namespace (--unshare-net) with no
+			// bridge to the host loopback proxy, so it cannot enforce scoped egress;
+			// a scoped policy collapses to deny (no proxy is started). Evaluate's
+			// network gate denies network-risk tools for this backend to match.
+			return bubblewrapCommandPlan(spec, workspaceRoot, relativeDir, engine.writeRoots(workspaceRoot), policy, backend), nil
 		}
 	case BackendSandboxExec:
 		if backend.Available && backend.Executable != "" {
-			egress, err := startScopedEgress(policy)
+			egress, err := startScopedEgress(policy, backend)
 			if err != nil {
 				return CommandPlan{}, err
 			}
@@ -166,12 +166,17 @@ type scopedEgress struct {
 }
 
 // startScopedEgress starts the local filtering proxy when the policy's effective
-// network mode is NetworkScoped, returning its address. It fails closed: a
-// proxy-start error is returned so the build aborts rather than degrading to an
-// unproxied (open) plan. A non-scoped or empty-allowlist policy returns (nil,
-// nil) and the command is wired with the existing allow/deny network behaviour.
-func startScopedEgress(policy Policy) (*scopedEgress, error) {
+// network mode is NetworkScoped AND the backend can actually route through it,
+// returning its address. It fails closed: a proxy-start error is returned so the
+// build aborts rather than degrading to an unproxied (open) plan. A non-scoped or
+// empty-allowlist policy, or a backend that cannot enforce scoped egress (e.g.
+// bubblewrap's isolated netns), returns (nil, nil); the caller then wires the
+// command with the backend's deny-equivalent network isolation.
+func startScopedEgress(policy Policy, backend Backend) (*scopedEgress, error) {
 	if effectiveNetwork(policy) != NetworkScoped {
+		return nil, nil
+	}
+	if !backend.EnforcesScopedEgress() {
 		return nil, nil
 	}
 	proxy, err := startEgressProxy(egressOptions{
@@ -250,7 +255,7 @@ func (engine *Engine) resolveCommandDir(dir string, policy Policy) (string, stri
 	return workspaceRoot, commandDir, relativeDir, nil
 }
 
-func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir string, writeRoots []string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {
+func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir string, writeRoots []string, policy Policy, backend Backend) CommandPlan {
 	sandboxDir := bubblewrapWorkspace
 	if relativeDir != "" {
 		sandboxDir = filepath.ToSlash(filepath.Join(bubblewrapWorkspace, relativeDir))
@@ -284,11 +289,10 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 		args = append(args, "--bind", root, root)
 	}
 	args = append(args, "--chdir", sandboxDir)
-	// Scoped egress keeps the no-raw-network isolation of deny (--unshare-net) but
-	// reaches the filtering proxy via a loopback bridge: the proxy listens on the
-	// host's 127.0.0.1 and the sandbox is given a relay to that port plus the
-	// HTTP(S)_PROXY env so well-behaved clients route through it. deny stays a
-	// hard --unshare-net with no bridge; allow shares the host network unchanged.
+	// Both deny and scoped isolate the network namespace with --unshare-net (no raw
+	// host network). Scoped does NOT get the filtering proxy here: bubblewrap has no
+	// bridge from its netns to the host loopback proxy, so scoped collapses to deny
+	// until a real relay (e.g. slirp4netns) is added. allow shares the host network.
 	if network := effectiveNetwork(policy); network == NetworkDeny || network == NetworkScoped {
 		args = append(args, "--unshare-net")
 	}
@@ -297,14 +301,6 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 	}
 	args = append(args, "--clearenv")
 	setenvLines := sandboxEnvironment(policy, BackendBubblewrap, bubblewrapWorkspace)
-	if egress != nil {
-		// --share-net would defeat the isolation; instead the sandbox keeps its own
-		// netns (--unshare-net above) and reaches the host's loopback proxy through a
-		// relay bridge into the namespace. The proxy address is exported as
-		// HTTP(S)_PROXY/ALL_PROXY so well-behaved clients route through it; NO_PROXY
-		// keeps loopback itself direct.
-		setenvLines = append(setenvLines, scopedProxyEnv(egress.addr)...)
-	}
 	for _, env := range setenvLines {
 		key, value, ok := strings.Cut(env, "=")
 		if ok {
@@ -313,7 +309,7 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 	}
 	args = append(args, "--", spec.Name)
 	args = append(args, spec.Args...)
-	plan := CommandPlan{
+	return CommandPlan{
 		Backend:       backend,
 		WorkspaceRoot: workspaceRoot,
 		Policy:        policy,
@@ -322,10 +318,6 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 		Args:          args,
 		SandboxDir:    sandboxDir,
 	}
-	if egress != nil {
-		plan.cleanup = egress.cleanup
-	}
-	return plan
 }
 
 func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, writeRoots []string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,6 +33,54 @@ type CommandPlan struct {
 	Dir           string   `json:"dir,omitempty"`
 	Env           []string `json:"env,omitempty"`
 	SandboxDir    string   `json:"sandboxDir,omitempty"`
+	// cleanup releases resources tied to the plan's lifetime — currently the
+	// scoped-egress proxy, which must outlive the command run and be shut down
+	// afterwards. It is never serialized; callers invoke it via Cleanup() once the
+	// command has finished.
+	cleanup func()
+}
+
+// Cleanup releases any resources the plan holds (e.g. a scoped-egress proxy). It
+// is safe to call on a zero plan and to call more than once. Callers that run a
+// plan's command must defer Cleanup so a started proxy does not leak.
+func (plan CommandPlan) Cleanup() {
+	if plan.cleanup != nil {
+		plan.cleanup()
+	}
+}
+
+// startEgressProxy is the constructor for the scoped-egress proxy, kept as a
+// package var so tests can force a start failure and assert the build fails
+// closed (never degrading to open network).
+var startEgressProxy = newEgressProxy
+
+// effectiveNetwork resolves the network mode actually enforced for a policy.
+// NetworkScoped with no usable allowlisted domains collapses to NetworkDeny so
+// scoped egress fails closed; NetworkAllow and NetworkDeny are returned as-is.
+func effectiveNetwork(policy Policy) NetworkMode {
+	if policy.Network == NetworkScoped && len(normalizeDomains(policy.AllowedDomains)) == 0 {
+		return NetworkDeny
+	}
+	return policy.Network
+}
+
+// scopedProxyEnv returns the proxy environment variables that route a sandboxed
+// process's HTTP(S) traffic through the local filtering proxy at addr. Both
+// upper- and lower-case forms are set because different clients read different
+// casings. localhost is excluded so loopback (the proxy itself) is reached
+// directly.
+func scopedProxyEnv(addr string) []string {
+	proxyURL := "http://" + addr
+	return []string{
+		"HTTP_PROXY=" + proxyURL,
+		"HTTPS_PROXY=" + proxyURL,
+		"ALL_PROXY=" + proxyURL,
+		"http_proxy=" + proxyURL,
+		"https_proxy=" + proxyURL,
+		"all_proxy=" + proxyURL,
+		"NO_PROXY=localhost,127.0.0.1",
+		"no_proxy=localhost,127.0.0.1",
+	}
 }
 
 func (engine *Engine) CommandContext(ctx context.Context, spec CommandSpec) (*exec.Cmd, CommandPlan, error) {
@@ -87,17 +136,52 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 	switch backend.Name {
 	case BackendBubblewrap:
 		if backend.Available && backend.Executable != "" {
-			return bubblewrapCommandPlan(spec, workspaceRoot, relativeDir, engine.writeRoots(workspaceRoot), policy, backend), nil
+			egress, err := startScopedEgress(policy)
+			if err != nil {
+				return CommandPlan{}, err
+			}
+			return bubblewrapCommandPlan(spec, workspaceRoot, relativeDir, engine.writeRoots(workspaceRoot), policy, backend, egress), nil
 		}
 	case BackendSandboxExec:
 		if backend.Available && backend.Executable != "" {
-			return sandboxExecCommandPlan(spec, workspaceRoot, engine.writeRoots(workspaceRoot), policy, backend), nil
+			egress, err := startScopedEgress(policy)
+			if err != nil {
+				return CommandPlan{}, err
+			}
+			return sandboxExecCommandPlan(spec, workspaceRoot, engine.writeRoots(workspaceRoot), policy, backend, egress), nil
 		}
 	}
 	if !policy.AllowPolicyOnlyRunner {
 		return CommandPlan{}, errPolicyOnlyRunnerDisabled
 	}
 	return directCommandPlan(spec, backend, policy, workspaceRoot), nil
+}
+
+// scopedEgress holds the address of a started scoped-egress proxy and the
+// cleanup that shuts it down. A nil *scopedEgress means scoped egress is not in
+// effect for this command (the network mode is allow or deny-equivalent).
+type scopedEgress struct {
+	addr    string
+	cleanup func()
+}
+
+// startScopedEgress starts the local filtering proxy when the policy's effective
+// network mode is NetworkScoped, returning its address. It fails closed: a
+// proxy-start error is returned so the build aborts rather than degrading to an
+// unproxied (open) plan. A non-scoped or empty-allowlist policy returns (nil,
+// nil) and the command is wired with the existing allow/deny network behaviour.
+func startScopedEgress(policy Policy) (*scopedEgress, error) {
+	if effectiveNetwork(policy) != NetworkScoped {
+		return nil, nil
+	}
+	proxy, err := startEgressProxy(egressOptions{
+		Allowed: policy.AllowedDomains,
+		Denied:  policy.DeniedDomains,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scoped egress unavailable, denying network: %w", err)
+	}
+	return &scopedEgress{addr: proxy.Addr(), cleanup: func() { _ = proxy.Close() }}, nil
 }
 
 func directCommandPlan(spec CommandSpec, backend Backend, policy Policy, workspaceRoot string) CommandPlan {
@@ -166,7 +250,7 @@ func (engine *Engine) resolveCommandDir(dir string, policy Policy) (string, stri
 	return workspaceRoot, commandDir, relativeDir, nil
 }
 
-func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir string, writeRoots []string, policy Policy, backend Backend) CommandPlan {
+func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir string, writeRoots []string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {
 	sandboxDir := bubblewrapWorkspace
 	if relativeDir != "" {
 		sandboxDir = filepath.ToSlash(filepath.Join(bubblewrapWorkspace, relativeDir))
@@ -200,14 +284,28 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 		args = append(args, "--bind", root, root)
 	}
 	args = append(args, "--chdir", sandboxDir)
-	if policy.Network == NetworkDeny {
+	// Scoped egress keeps the no-raw-network isolation of deny (--unshare-net) but
+	// reaches the filtering proxy via a loopback bridge: the proxy listens on the
+	// host's 127.0.0.1 and the sandbox is given a relay to that port plus the
+	// HTTP(S)_PROXY env so well-behaved clients route through it. deny stays a
+	// hard --unshare-net with no bridge; allow shares the host network unchanged.
+	if network := effectiveNetwork(policy); network == NetworkDeny || network == NetworkScoped {
 		args = append(args, "--unshare-net")
 	}
 	for _, mount := range existingBubblewrapMounts() {
 		args = append(args, "--ro-bind", mount, mount)
 	}
 	args = append(args, "--clearenv")
-	for _, env := range sandboxEnvironment(policy, BackendBubblewrap, bubblewrapWorkspace) {
+	setenvLines := sandboxEnvironment(policy, BackendBubblewrap, bubblewrapWorkspace)
+	if egress != nil {
+		// --share-net would defeat the isolation; instead the sandbox keeps its own
+		// netns (--unshare-net above) and reaches the host's loopback proxy through a
+		// relay bridge into the namespace. The proxy address is exported as
+		// HTTP(S)_PROXY/ALL_PROXY so well-behaved clients route through it; NO_PROXY
+		// keeps loopback itself direct.
+		setenvLines = append(setenvLines, scopedProxyEnv(egress.addr)...)
+	}
+	for _, env := range setenvLines {
 		key, value, ok := strings.Cut(env, "=")
 		if ok {
 			args = append(args, "--setenv", key, value)
@@ -215,7 +313,7 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 	}
 	args = append(args, "--", spec.Name)
 	args = append(args, spec.Args...)
-	return CommandPlan{
+	plan := CommandPlan{
 		Backend:       backend,
 		WorkspaceRoot: workspaceRoot,
 		Policy:        policy,
@@ -224,12 +322,26 @@ func bubblewrapCommandPlan(spec CommandSpec, workspaceRoot string, relativeDir s
 		Args:          args,
 		SandboxDir:    sandboxDir,
 	}
+	if egress != nil {
+		plan.cleanup = egress.cleanup
+	}
+	return plan
 }
 
-func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, writeRoots []string, policy Policy, backend Backend) CommandPlan {
-	args := []string{"-p", sandboxExecProfile(writeRoots, policy), spec.Name}
+func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, writeRoots []string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {
+	var proxyPort string
+	if egress != nil {
+		if _, port, err := net.SplitHostPort(egress.addr); err == nil {
+			proxyPort = port
+		}
+	}
+	args := []string{"-p", sandboxExecProfile(writeRoots, policy, proxyPort), spec.Name}
 	args = append(args, spec.Args...)
-	return CommandPlan{
+	env := sandboxEnvironment(policy, BackendSandboxExec, workspaceRoot)
+	if egress != nil {
+		env = append(env, scopedProxyEnv(egress.addr)...)
+	}
+	plan := CommandPlan{
 		Backend:       backend,
 		WorkspaceRoot: workspaceRoot,
 		Policy:        policy,
@@ -237,9 +349,13 @@ func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, writeRoots [
 		Name:          backend.Executable,
 		Args:          args,
 		Dir:           spec.Dir,
-		Env:           sandboxEnvironment(policy, BackendSandboxExec, workspaceRoot),
+		Env:           env,
 		SandboxDir:    spec.Dir,
 	}
+	if egress != nil {
+		plan.cleanup = egress.cleanup
+	}
+	return plan
 }
 
 func existingBubblewrapMounts() []string {
@@ -318,11 +434,8 @@ var sandboxWritableSubpaths = []string{
 	"/dev/fd",
 }
 
-func sandboxExecProfile(writeRoots []string, policy Policy) string {
-	networkRule := "(deny network*)"
-	if policy.Network == NetworkAllow {
-		networkRule = "(allow network*)"
-	}
+func sandboxExecProfile(writeRoots []string, policy Policy, proxyPort string) string {
+	networkRule := networkRuleFor(policy, proxyPort)
 	writeRule := "(allow file-write*)"
 	if policy.EnforceWorkspace {
 		// The granted write roots are the only writable *project* locations. Temp
@@ -349,6 +462,28 @@ func sandboxExecProfile(writeRoots []string, policy Policy) string {
 		writeRule,
 		networkRule,
 	}, "\n")
+}
+
+// networkRuleFor returns the seatbelt network clause for a policy. allow opens
+// all network; deny (and an empty-allowlist scoped policy, which effectiveNetwork
+// collapses to deny) blocks all network; scoped denies general network but
+// permits only outbound to the local proxy port on localhost, so traffic must
+// flow through the filtering proxy. A scoped policy with no resolvable proxy port
+// falls back to a full deny (fail closed).
+func networkRuleFor(policy Policy, proxyPort string) string {
+	switch effectiveNetwork(policy) {
+	case NetworkAllow:
+		return "(allow network*)"
+	case NetworkScoped:
+		if strings.TrimSpace(proxyPort) == "" {
+			return "(deny network*)"
+		}
+		// Deny by default, then allow only outbound to the proxy on loopback.
+		return "(deny network*)\n" +
+			`(allow network-outbound (remote ip "localhost:` + sandboxProfileString(proxyPort) + `"))`
+	default:
+		return "(deny network*)"
+	}
 }
 
 func sandboxProfileString(value string) string {

--- a/internal/sandbox/runner_scoped_test.go
+++ b/internal/sandbox/runner_scoped_test.go
@@ -1,0 +1,202 @@
+package sandbox
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestScopedNetworkGateInEvaluate verifies the preflight network gate: a
+// populated scoped policy permits a network-risk tool (the proxy enforces the
+// allowlist), while an empty-allowlist scoped policy fails closed exactly like
+// NetworkDeny.
+func TestScopedNetworkGateInEvaluate(t *testing.T) {
+	root := t.TempDir()
+	networkRequest := Request{
+		ToolName:       "web_fetch",
+		SideEffect:     SideEffectNetwork,
+		Permission:     PermissionAllow,
+		PermissionMode: PermissionModeAuto,
+		Autonomy:       AutonomyHigh,
+		Args:           map[string]any{"url": "https://github.com"},
+	}
+
+	populated := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil)})
+	if decision := populated.Evaluate(context.Background(), networkRequest); decision.Action == ActionDeny {
+		t.Fatalf("populated scoped policy denied a network tool: %#v", decision)
+	}
+
+	empty := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy(nil, nil)})
+	decision := empty.Evaluate(context.Background(), networkRequest)
+	if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationNetwork {
+		t.Fatalf("empty scoped policy must deny network like NetworkDeny, got %#v", decision)
+	}
+}
+
+// scopedPolicy is DefaultPolicy with NetworkScoped and the given allow/deny
+// lists, used across the scoped-egress runner tests.
+func scopedPolicy(allowed []string, denied []string) Policy {
+	policy := DefaultPolicy()
+	policy.Network = NetworkScoped
+	policy.AllowedDomains = allowed
+	policy.DeniedDomains = denied
+	return policy
+}
+
+// TestEffectiveNetworkScopedEmptyIsDeny pins the fail-closed rule: NetworkScoped
+// with no allowlisted domains is treated exactly like NetworkDeny.
+func TestEffectiveNetworkScopedEmptyIsDeny(t *testing.T) {
+	if got := effectiveNetwork(scopedPolicy(nil, nil)); got != NetworkDeny {
+		t.Fatalf("effectiveNetwork(scoped, empty allowlist) = %q, want deny", got)
+	}
+	if got := effectiveNetwork(scopedPolicy([]string{"   "}, nil)); got != NetworkDeny {
+		t.Fatalf("effectiveNetwork(scoped, blank-only allowlist) = %q, want deny", got)
+	}
+	if got := effectiveNetwork(scopedPolicy([]string{"github.com"}, nil)); got != NetworkScoped {
+		t.Fatalf("effectiveNetwork(scoped, with allowlist) = %q, want scoped", got)
+	}
+	// Existing modes are unchanged.
+	if got := effectiveNetwork(DefaultPolicy()); got != NetworkDeny {
+		t.Fatalf("effectiveNetwork(default) = %q, want deny", got)
+	}
+	allow := DefaultPolicy()
+	allow.Network = NetworkAllow
+	if got := effectiveNetwork(allow); got != NetworkAllow {
+		t.Fatalf("effectiveNetwork(allow) = %q, want allow", got)
+	}
+}
+
+// TestBubblewrapScopedPlanWiresProxy verifies a scoped bubblewrap plan keeps
+// --unshare-net (no raw network) yet exports the proxy env so well-behaved
+// clients route through the local filtering proxy, and that the plan carries a
+// cleanup that shuts the proxy down.
+func TestBubblewrapScopedPlanWiresProxy(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        scopedPolicy([]string{"github.com"}, nil),
+		Backend:       Backend{Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+	})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	defer plan.Cleanup()
+
+	joined := strings.Join(plan.Args, " ")
+	if !strings.Contains(joined, "--unshare-net") {
+		t.Fatalf("scoped bubblewrap plan dropped --unshare-net:\n%s", joined)
+	}
+	proxyAddr := proxySetenvValue(t, plan.Args, "HTTP_PROXY")
+	if proxyAddr == "" {
+		t.Fatalf("scoped bubblewrap plan missing HTTP_PROXY setenv:\n%s", joined)
+	}
+	for _, key := range []string{"HTTPS_PROXY", "ALL_PROXY"} {
+		if got := proxySetenvValue(t, plan.Args, key); got != proxyAddr {
+			t.Fatalf("%s setenv = %q, want %q", key, got, proxyAddr)
+		}
+	}
+	if got := proxySetenvValue(t, plan.Args, "NO_PROXY"); !strings.Contains(got, "localhost") {
+		t.Fatalf("NO_PROXY setenv = %q, want it to include localhost", got)
+	}
+	host, _, err := net.SplitHostPort(strings.TrimPrefix(proxyAddr, "http://"))
+	if err != nil || host != "127.0.0.1" {
+		t.Fatalf("proxy addr %q not bound to loopback: host=%q err=%v", proxyAddr, host, err)
+	}
+}
+
+// TestSandboxExecScopedPlanWiresProxy verifies a scoped sandbox-exec profile
+// denies general network but permits localhost (the proxy port) and sets the
+// proxy env.
+func TestSandboxExecScopedPlanWiresProxy(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        scopedPolicy([]string{"github.com"}, nil),
+		Backend:       Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/sbin/sandbox-exec"},
+	})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	defer plan.Cleanup()
+
+	if len(plan.Args) < 2 || plan.Args[0] != "-p" {
+		t.Fatalf("sandbox-exec args = %#v, want profile", plan.Args)
+	}
+	profile := plan.Args[1]
+	if strings.Contains(profile, "(allow network*)") {
+		t.Fatalf("scoped sandbox-exec must not allow all network:\n%s", profile)
+	}
+	if !strings.Contains(profile, "network-outbound") || !strings.Contains(profile, "localhost") {
+		t.Fatalf("scoped sandbox-exec profile must allow localhost outbound:\n%s", profile)
+	}
+	var proxyAddr string
+	for _, env := range plan.Env {
+		if strings.HasPrefix(env, "HTTP_PROXY=") {
+			proxyAddr = strings.TrimPrefix(env, "HTTP_PROXY=")
+		}
+	}
+	if proxyAddr == "" {
+		t.Fatalf("scoped sandbox-exec plan missing HTTP_PROXY env: %#v", plan.Env)
+	}
+}
+
+// TestScopedEmptyAllowlistBuildsLikeDeny verifies a scoped plan with an empty
+// allowlist produces a deny-equivalent plan (no proxy, no network) and never
+// starts a proxy.
+func TestScopedEmptyAllowlistBuildsLikeDeny(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        scopedPolicy(nil, nil),
+		Backend:       Backend{Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+	})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	defer plan.Cleanup()
+
+	joined := strings.Join(plan.Args, " ")
+	if !strings.Contains(joined, "--unshare-net") {
+		t.Fatalf("empty scoped plan must keep --unshare-net (deny-equivalent):\n%s", joined)
+	}
+	if proxySetenvValue(t, plan.Args, "HTTP_PROXY") != "" {
+		t.Fatalf("empty scoped plan must not export a proxy:\n%s", joined)
+	}
+}
+
+// TestScopedProxyStartFailureDeniesNetwork verifies that if the egress proxy
+// cannot start, the command is denied network (an error) and never falls back to
+// open network access.
+func TestScopedProxyStartFailureDeniesNetwork(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        scopedPolicy([]string{"github.com"}, nil),
+		Backend:       Backend{Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+	})
+	// Force the proxy factory to fail; the build must surface an error rather than
+	// degrade to an unproxied (open) network plan.
+	restore := startEgressProxy
+	startEgressProxy = func(egressOptions) (*egressProxy, error) {
+		return nil, errEmptyAllowlist
+	}
+	defer func() { startEgressProxy = restore }()
+
+	if _, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root}); err == nil {
+		t.Fatal("BuildCommandPlan with failing proxy = nil error, want fail-closed deny")
+	}
+}
+
+func proxySetenvValue(t *testing.T, args []string, key string) string {
+	t.Helper()
+	for index := 0; index+2 < len(args); index++ {
+		if args[index] == "--setenv" && args[index+1] == key {
+			return args[index+2]
+		}
+	}
+	return ""
+}

--- a/internal/sandbox/runner_scoped_test.go
+++ b/internal/sandbox/runner_scoped_test.go
@@ -2,15 +2,15 @@ package sandbox
 
 import (
 	"context"
-	"net"
 	"strings"
 	"testing"
 )
 
-// TestScopedNetworkGateInEvaluate verifies the preflight network gate: a
-// populated scoped policy permits a network-risk tool (the proxy enforces the
-// allowlist), while an empty-allowlist scoped policy fails closed exactly like
-// NetworkDeny.
+// TestScopedNetworkGateInEvaluate verifies the preflight network gate: a populated
+// scoped policy permits a network-risk tool ONLY when the active backend can
+// actually route through the filtering proxy. A backend that cannot enforce scoped
+// egress (bubblewrap's isolated netns has no bridge; policy-only has no isolation)
+// fails closed and denies, exactly like an empty-allowlist scoped policy.
 func TestScopedNetworkGateInEvaluate(t *testing.T) {
 	root := t.TempDir()
 	networkRequest := Request{
@@ -21,13 +21,29 @@ func TestScopedNetworkGateInEvaluate(t *testing.T) {
 		Autonomy:       AutonomyHigh,
 		Args:           map[string]any{"url": "https://github.com"},
 	}
+	sandboxExec := Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/sbin/sandbox-exec", ScopedEgress: true}
 
-	populated := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil)})
-	if decision := populated.Evaluate(context.Background(), networkRequest); decision.Action == ActionDeny {
-		t.Fatalf("populated scoped policy denied a network tool: %#v", decision)
+	// An enforcing backend lets a populated scoped policy permit a network tool.
+	enforcing := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil), Backend: sandboxExec})
+	if decision := enforcing.Evaluate(context.Background(), networkRequest); decision.Action == ActionDeny {
+		t.Fatalf("enforcing backend + scoped policy denied a network tool: %#v", decision)
 	}
 
-	empty := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy(nil, nil)})
+	// Backends that cannot enforce scoped egress must fail closed (deny).
+	unenforceable := map[string]Backend{
+		"bubblewrap":  {Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+		"policy-only": {},
+	}
+	for name, backend := range unenforceable {
+		engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil), Backend: backend})
+		decision := engine.Evaluate(context.Background(), networkRequest)
+		if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationNetwork {
+			t.Fatalf("%s backend must deny scoped network it cannot enforce, got %#v", name, decision)
+		}
+	}
+
+	// Empty allowlist still fails closed regardless of backend.
+	empty := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy(nil, nil), Backend: sandboxExec})
 	decision := empty.Evaluate(context.Background(), networkRequest)
 	if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationNetwork {
 		t.Fatalf("empty scoped policy must deny network like NetworkDeny, got %#v", decision)
@@ -67,12 +83,20 @@ func TestEffectiveNetworkScopedEmptyIsDeny(t *testing.T) {
 	}
 }
 
-// TestBubblewrapScopedPlanWiresProxy verifies a scoped bubblewrap plan keeps
-// --unshare-net (no raw network) yet exports the proxy env so well-behaved
-// clients route through the local filtering proxy, and that the plan carries a
-// cleanup that shuts the proxy down.
-func TestBubblewrapScopedPlanWiresProxy(t *testing.T) {
+// TestBubblewrapScopedPlanFailsClosedWithoutProxy verifies that, because
+// bubblewrap isolates the network namespace (--unshare-net) with no bridge to the
+// host loopback proxy, a scoped policy collapses to deny: the plan keeps
+// --unshare-net, never exports a proxy, and never starts an (unreachable) proxy.
+func TestBubblewrapScopedPlanFailsClosedWithoutProxy(t *testing.T) {
 	root := t.TempDir()
+	started := false
+	restore := startEgressProxy
+	startEgressProxy = func(egressOptions) (*egressProxy, error) {
+		started = true
+		return nil, errEmptyAllowlist
+	}
+	defer func() { startEgressProxy = restore }()
+
 	engine := NewEngine(EngineOptions{
 		WorkspaceRoot: root,
 		Policy:        scopedPolicy([]string{"github.com"}, nil),
@@ -86,23 +110,13 @@ func TestBubblewrapScopedPlanWiresProxy(t *testing.T) {
 
 	joined := strings.Join(plan.Args, " ")
 	if !strings.Contains(joined, "--unshare-net") {
-		t.Fatalf("scoped bubblewrap plan dropped --unshare-net:\n%s", joined)
+		t.Fatalf("scoped bubblewrap plan must keep --unshare-net (deny-equivalent):\n%s", joined)
 	}
-	proxyAddr := proxySetenvValue(t, plan.Args, "HTTP_PROXY")
-	if proxyAddr == "" {
-		t.Fatalf("scoped bubblewrap plan missing HTTP_PROXY setenv:\n%s", joined)
+	if proxyAddr := proxySetenvValue(t, plan.Args, "HTTP_PROXY"); proxyAddr != "" {
+		t.Fatalf("scoped bubblewrap plan must not export a proxy it cannot reach:\n%s", joined)
 	}
-	for _, key := range []string{"HTTPS_PROXY", "ALL_PROXY"} {
-		if got := proxySetenvValue(t, plan.Args, key); got != proxyAddr {
-			t.Fatalf("%s setenv = %q, want %q", key, got, proxyAddr)
-		}
-	}
-	if got := proxySetenvValue(t, plan.Args, "NO_PROXY"); !strings.Contains(got, "localhost") {
-		t.Fatalf("NO_PROXY setenv = %q, want it to include localhost", got)
-	}
-	host, _, err := net.SplitHostPort(strings.TrimPrefix(proxyAddr, "http://"))
-	if err != nil || host != "127.0.0.1" {
-		t.Fatalf("proxy addr %q not bound to loopback: host=%q err=%v", proxyAddr, host, err)
+	if started {
+		t.Fatal("bubblewrap must not start an unreachable egress proxy for a scoped policy")
 	}
 }
 
@@ -114,7 +128,7 @@ func TestSandboxExecScopedPlanWiresProxy(t *testing.T) {
 	engine := NewEngine(EngineOptions{
 		WorkspaceRoot: root,
 		Policy:        scopedPolicy([]string{"github.com"}, nil),
-		Backend:       Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/sbin/sandbox-exec"},
+		Backend:       Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/sbin/sandbox-exec", ScopedEgress: true},
 	})
 	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
 	if err != nil {
@@ -176,7 +190,8 @@ func TestScopedProxyStartFailureDeniesNetwork(t *testing.T) {
 	engine := NewEngine(EngineOptions{
 		WorkspaceRoot: root,
 		Policy:        scopedPolicy([]string{"github.com"}, nil),
-		Backend:       Backend{Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+		// sandbox-exec actually starts the proxy, so its failure must fail closed.
+		Backend: Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/sbin/sandbox-exec", ScopedEgress: true},
 	})
 	// Force the proxy factory to fail; the build must surface an error rather than
 	// degrade to an unproxied (open) network plan.

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -221,7 +221,7 @@ func resolvedTestPath(t *testing.T, path string) string {
 }
 
 func TestSandboxExecProfileIncludesExtraWriteRoots(t *testing.T) {
-	profile := sandboxExecProfile([]string{"/ws", "/extra root"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true})
+	profile := sandboxExecProfile([]string{"/ws", "/extra root"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "")
 	if !strings.Contains(profile, "(allow file-write*") {
 		t.Fatalf("profile missing file-write rule:\n%s", profile)
 	}

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -1,6 +1,16 @@
 package sandbox
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// EnvAutoAllowBash is the environment variable that opts in to auto-allowing the
+// bash tool when the sandbox is active for the command. It is OFF by default;
+// only an explicit truthy value enables it.
+const EnvAutoAllowBash = "ZERO_SANDBOX_AUTO_ALLOW_BASH"
 
 type SideEffect string
 type Permission string
@@ -54,6 +64,11 @@ const (
 const (
 	NetworkDeny  NetworkMode = "deny"
 	NetworkAllow NetworkMode = "allow"
+	// NetworkScoped is the middle ground between deny and allow: the sandboxed
+	// process may reach only the policy's AllowedDomains (minus DeniedDomains) and
+	// nothing else, routed through a local filtering egress proxy. An empty
+	// effective allowlist makes it behave exactly like NetworkDeny (fail closed).
+	NetworkScoped NetworkMode = "scoped"
 )
 
 const (
@@ -109,6 +124,18 @@ type Policy struct {
 	DenyDestructiveShell  bool        `json:"denyDestructiveShell"`
 	AllowPolicyOnlyRunner bool        `json:"allowPolicyOnlyRunner"`
 	MaxAutonomy           Autonomy    `json:"maxAutonomy,omitempty"`
+	// AllowedDomains / DeniedDomains apply only when Network is NetworkScoped:
+	// the sandboxed process may reach the allowed domains (exact host or any
+	// subdomain) minus the denied ones. They are ignored for NetworkAllow and
+	// NetworkDeny so existing policies keep their exact behaviour.
+	AllowedDomains []string `json:"allowedDomains,omitempty"`
+	DeniedDomains  []string `json:"deniedDomains,omitempty"`
+	// AutoAllowBashWhenSandboxed, when true, auto-allows the bash tool WITHOUT a
+	// permission prompt — but only when the sandbox is actually active (a
+	// native-isolation backend wraps the command). The sandbox is then the safety
+	// boundary. When the sandbox is not active the flag is ignored: unsandboxed
+	// bash is never auto-allowed. Off by default.
+	AutoAllowBashWhenSandboxed bool `json:"autoAllowBashWhenSandboxed,omitempty"`
 }
 
 type Request struct {
@@ -130,6 +157,11 @@ type Decision struct {
 	GrantMatched bool       `json:"grantMatched,omitempty"`
 	Grant        *Grant     `json:"grant,omitempty"`
 	Violation    *Violation `json:"violation,omitempty"`
+	// AutoAllowed marks an allow that the sandbox itself authorized without a user
+	// prompt or persistent grant — currently only AutoAllowBashWhenSandboxed for a
+	// sandboxed shell command. Enforcement points treat it like a grant-authorized
+	// allow so a prompt tool runs without a separately-recorded PermissionGranted.
+	AutoAllowed bool `json:"autoAllowed,omitempty"`
 }
 
 type Risk struct {
@@ -174,4 +206,29 @@ func DefaultPolicy() Policy {
 		AllowPolicyOnlyRunner: true,
 		MaxAutonomy:           AutonomyHigh,
 	}
+}
+
+// AutoAllowBashEnvEnabled reports whether the EnvAutoAllowBash environment
+// variable is set to a truthy value. It is the env surface for
+// AutoAllowBashWhenSandboxed and is OFF for any unset/blank/falsey value, so the
+// safe default (prompt) holds unless the operator explicitly opts in.
+func AutoAllowBashEnvEnabled() bool {
+	value := strings.TrimSpace(os.Getenv(EnvAutoAllowBash))
+	if value == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(value)
+	return err == nil && enabled
+}
+
+// ApplyAutoAllowBashEnv overlays the EnvAutoAllowBash opt-in onto a policy: when
+// the env var is truthy it enables AutoAllowBashWhenSandboxed. It never disables
+// an already-enabled policy field, so an explicit config opt-in is preserved
+// even when the env var is unset. Wire this where the engine policy is built so
+// the env surface takes effect.
+func ApplyAutoAllowBashEnv(policy Policy) Policy {
+	if AutoAllowBashEnvEnabled() {
+		policy.AutoAllowBashWhenSandboxed = true
+	}
+	return policy
 }

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -104,6 +104,9 @@ func (tool bashTool) run(ctx context.Context, args map[string]any, engine *zeroS
 			Meta:   meta,
 		}
 	}
+	// Release any plan-scoped resources (e.g. the scoped-egress proxy) once the
+	// command has finished running.
+	defer plan.Cleanup()
 	addSandboxMeta(meta, plan)
 
 	var stdout bytes.Buffer

--- a/internal/tools/bash_auto_allow_test.go
+++ b/internal/tools/bash_auto_allow_test.go
@@ -1,0 +1,114 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+// nativeBackendStub reports as an active wrapping sandbox so shellSandboxActive
+// is true. Its executable does not exist, so the command itself fails to launch
+// — that is fine: these tests assert the *permission gate*, not execution.
+func nativeBackendStub() sandbox.Backend {
+	return sandbox.Backend{
+		Name:            sandbox.BackendBubblewrap,
+		Available:       true,
+		Executable:      "/nonexistent/bwrap-stub",
+		CommandWrapping: true,
+		NativeIsolation: true,
+	}
+}
+
+func autoAllowBashPolicy(autoAllow bool) sandbox.Policy {
+	policy := sandbox.DefaultPolicy()
+	policy.AutoAllowBashWhenSandboxed = autoAllow
+	// Network deny so no proxy is started for these gate-only tests.
+	return policy
+}
+
+const permissionRequiredFragment = "Permission required for bash"
+
+// TestBashAutoAllowedWhenSandboxActive: flag on + active sandbox => the bash
+// permission gate is bypassed (no "Permission required" error). The command
+// itself fails to exec (stub backend), which is the expected non-gate outcome.
+func TestBashAutoAllowedWhenSandboxActive(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry()
+	registry.Register(NewBashTool(root))
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        autoAllowBashPolicy(true),
+		Backend:       nativeBackendStub(),
+	})
+
+	result := registry.RunWithOptions(context.Background(), "bash", map[string]any{
+		"command": "echo hi",
+	}, RunOptions{
+		PermissionGranted: false,
+		Sandbox:           engine,
+		PermissionMode:    string(sandbox.PermissionModeAsk),
+		Autonomy:          string(sandbox.AutonomyHigh),
+	})
+
+	if strings.Contains(result.Output, permissionRequiredFragment) {
+		t.Fatalf("bash was gated despite auto-allow: %q", result.Output)
+	}
+	if result.SandboxDecision == nil || result.SandboxDecision.Action != sandbox.ActionAllow || !result.SandboxDecision.AutoAllowed {
+		t.Fatalf("sandbox decision = %#v, want auto-allowed allow", result.SandboxDecision)
+	}
+}
+
+// TestBashStillPromptsWithoutAutoAllow: flag off + active sandbox => the normal
+// prompt policy stands; the bash gate blocks an ungranted command.
+func TestBashStillPromptsWithoutAutoAllow(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry()
+	registry.Register(NewBashTool(root))
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        autoAllowBashPolicy(false),
+		Backend:       nativeBackendStub(),
+	})
+
+	result := registry.RunWithOptions(context.Background(), "bash", map[string]any{
+		"command": "echo hi",
+	}, RunOptions{
+		PermissionGranted: false,
+		Sandbox:           engine,
+		PermissionMode:    string(sandbox.PermissionModeAsk),
+		Autonomy:          string(sandbox.AutonomyHigh),
+	})
+
+	if result.Status != StatusError || !strings.Contains(result.Output, "Sandbox approval required for bash") {
+		t.Fatalf("expected bash to be gated when auto-allow off, got %s: %q", result.Status, result.Output)
+	}
+}
+
+// TestBashAutoAllowIgnoredWithoutActiveSandbox: flag on but the backend is
+// policy-only (no native isolation), so the flag must be ignored and the bash
+// gate blocks the ungranted command.
+func TestBashAutoAllowIgnoredWithoutActiveSandbox(t *testing.T) {
+	root := t.TempDir()
+	registry := NewRegistry()
+	registry.Register(NewBashTool(root))
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        autoAllowBashPolicy(true),
+		Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly},
+	})
+
+	result := registry.RunWithOptions(context.Background(), "bash", map[string]any{
+		"command": "echo hi",
+	}, RunOptions{
+		PermissionGranted: false,
+		Sandbox:           engine,
+		PermissionMode:    string(sandbox.PermissionModeAsk),
+		Autonomy:          string(sandbox.AutonomyHigh),
+	})
+
+	if result.Status != StatusError || !strings.Contains(result.Output, "Sandbox approval required for bash") {
+		t.Fatalf("expected bash to be gated when sandbox inactive, got %s: %q", result.Status, result.Output)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -131,7 +131,10 @@ func (registry *Registry) RunWithOptions(ctx context.Context, name string, args 
 			res.SandboxDecision = sandboxDecision
 			return res
 		}
-		sandboxGrantAuthorized = d.Action == sandbox.ActionAllow && d.GrantMatched
+		// A persistent grant OR a sandbox auto-allow (AutoAllowBashWhenSandboxed for
+		// a sandboxed shell command) authorizes a prompt tool to run without a
+		// separately-recorded PermissionGranted; the sandbox is the safety boundary.
+		sandboxGrantAuthorized = d.Action == sandbox.ActionAllow && (d.GrantMatched || d.AutoAllowed)
 	}
 
 	switch tool.Safety().Permission {


### PR DESCRIPTION
## Summary

Milestone 2 of the wedge build pack, three related modules in one PR (clean-room Go, stdlib-first, TDD-gated). Builds directly on `main`.

### Stage 06 — MCP server: resources + prompts
ZERO's MCP server previously advertised only `tools`. It is now a first-class server that also serves **resources** and **prompts**.
- `server.go`: `initialize` advertises `{tools, resources, prompts}`; new handler cases for `resources/list`, `resources/read`, `prompts/list`, `prompts/get` (existing transport/framing + `writeResult`/`writeError` unchanged). `ServeOptions` gained `WorkspaceRoot` + `Scope`.
- `resources.go` (new): enumerate in-scope files (reusing the workspace indexer's `.git`/`node_modules`/`vendor`/binary exclusions) and read them. **Scope-enforced**: symlink-resolved containment check rejects `../` traversal and out-of-scope absolute paths with a JSON-RPC error and no contents; binary files return a base64 blob; read-only.
- `prompts.go` (new): a curated prompt catalogue (code-review / spec-draft / explain) with `{{arg}}` substitution; internal system prompts are deliberately not exposed.

### Stage 07 — sandbox per-domain egress + auto-allow-bash
Adds a middle ground between full-open and full-deny networking.
- `types.go`: `NetworkScoped` mode + `Policy.AllowedDomains`/`DeniedDomains` + `AutoAllowBashWhenSandboxed` (off by default, `ZERO_SANDBOX_AUTO_ALLOW_BASH`).
- `egress.go` (new): in-process filtering proxy on `127.0.0.1:0` handling HTTP `CONNECT` (HTTPS tunnel) and plain HTTP. Domain matching is exact-or-subdomain at a label boundary (`api.github.com` matches `github.com`; `notgithub.com` and `github.com.evil.com` do not); deny-list overrides allow-list. Decisions are logged through redaction so query-string tokens never leak. **Fails closed** — empty allowlist or any proxy-start error denies the network; never falls back to open.
- `runner.go`: wires `NetworkScoped` for both bubblewrap (keeps `--unshare-net`, exports proxy env) and sandbox-exec (allows only localhost:proxy). `NetworkAllow`/`NetworkDeny` behavior unchanged. The proxy is cleaned up after the command via `CommandPlan.Cleanup()`.
- `engine.go`/`bash`: auto-allows a shell tool only when the sandbox is actually active and the autonomy ceiling permits; ignored when unsandboxed.

### Stage 08 — MCP OAuth client
Lets ZERO connect to remote MCP servers that require OAuth.
- `oauth.go` (new): OAuth 2.0 + PKCE authorization-code flow — metadata discovery (`/.well-known/oauth-authorization-server`) with config-endpoint fallback, optional dynamic client registration, S256 PKCE, a `127.0.0.1:0` loopback redirect listener, **CSRF state validation**, code→token exchange, and refresh. Headless-safe (prints the authorization URL rather than force-opening a browser). Tokens are never logged.
- `oauth_store.go` (new): per-server token store in a `0600` file under the config dir.
- `network_client.go`: attaches `Authorization: Bearer` for OAuth servers and, on `401`, refreshes and retries once; on refresh failure surfaces an actionable re-login message.
- `config.go` (+ `config/types.go`/`resolver.go` carriers): an MCP server entry may declare `auth: "oauth"`.
- `zero mcp oauth {login,logout,status}` subcommands (`status` reports presence/expiry, never the token).

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` (clean), and `go test ./...` (all 57 packages) green.
- `-race` on `internal/mcp` and `internal/sandbox` (the new proxy/loopback concurrency) green.
- Security-critical paths spot-reviewed: domain-boundary matching and symlink-resolved resource scoping both reject the adversarial cases, with TDD coverage.

## Notes / scope
- Stage 08's `auth: "oauth"` required additive carrier fields in `internal/config/types.go` + `resolver.go` and the `zero mcp oauth` CLI files — minimal and necessary to wire the in-scope `internal/mcp/config.go` change to the command surface.
- Deferred 1-liner: `internal/cli/serve.go` does not yet pass its `-C/--cwd` to `ServeOptions.WorkspaceRoot` (the server falls back to the process working dir, correct for normal `serve`). Tracked for a follow-up.
- Stage 05 (hooks upgrade) is intentionally **not** here — it modifies `internal/agent/loop.go`, which conflicts with the in-flight #175; it should land after #175 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth 2.0 (PKCE) sign-in for MCP servers with persistent, redaction-safe token storage and status reporting (JSON/human).
  * New CLI: `zero mcp oauth` with `login`, `logout`, and `status`.
  * MCP "resources" API to list/read workspace files (text or base64 blobs).
  * MCP "prompts" API with curated templates and argument-driven rendering.
  * Sandboxed egress proxy and scoped network mode (allow/deny lists) for sandboxed runs.
  * Auto-allow bash when native sandbox isolation is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->