### PR TITLE
wedge stage 05: hooks upgrade (events, actions, async/rewake/continueOnBlock)

### DIFF
--- a/internal/agent/hook_wiring_test.go
+++ b/internal/agent/hook_wiring_test.go
@@ -92,4 +92,8 @@ func TestDispatchHelpersAreNoopWithoutDispatcher(t *testing.T) {
 	if feedback := dispatchAfterTool(context.Background(), options, ToolCall{Name: "bash"}, nil, tools.Result{}); feedback != "" {
 		t.Fatalf("a nil dispatcher must yield no feedback, got %q", feedback)
 	}
+	if injected := dispatchUserPromptSubmit(context.Background(), options, "do the thing"); injected != "" {
+		t.Fatalf("a nil dispatcher must inject no userPromptSubmit context, got %q", injected)
+	}
+	dispatchStop(context.Background(), options) // must not panic with a nil dispatcher
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -50,6 +50,10 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		return Result{}, errors.New("agent provider is required")
 	}
 
+	// stop hooks fire once as the run ends, on every exit path. A detached context
+	// lets end-of-run hooks still execute even if the run's own context is done.
+	defer dispatchStop(context.Background(), options)
+
 	maxTurns := options.MaxTurns
 	if maxTurns <= 0 {
 		maxTurns = 12
@@ -66,6 +70,15 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	}
 
 	messages := zeroruntime.SeedMessagesWithImages(buildSystemPrompt(options), prompt, options.Images)
+
+	// userPromptSubmit hooks may inject additional context for this run (e.g.
+	// repository conventions); their output is appended once before the turn loop.
+	if injected := dispatchUserPromptSubmit(ctx, options, prompt); injected != "" {
+		messages = append(messages, zeroruntime.Message{
+			Role:    zeroruntime.MessageRoleUser,
+			Content: injected,
+		})
+	}
 
 	guards := newGuardState()
 	compactor := newCompactionState(options)
@@ -691,6 +704,43 @@ func dispatchAfterTool(ctx context.Context, options Options, call ToolCall, args
 		},
 	})
 	return strings.TrimSpace(strings.Join(outcome.Messages, "\n"))
+}
+
+// dispatchUserPromptSubmit runs userPromptSubmit hooks before the run's turn loop
+// and returns any hook output to inject into the model context for this run (e.g.
+// a hook that prepends repository conventions). A nil dispatcher is a no-op.
+func dispatchUserPromptSubmit(ctx context.Context, options Options, prompt string) string {
+	if options.Hooks == nil {
+		return ""
+	}
+	outcome := options.Hooks.Dispatch(ctx, hooks.DispatchInput{
+		Event: hooks.EventUserPromptSubmit,
+		Payload: map[string]any{
+			"event":     string(hooks.EventUserPromptSubmit),
+			"sessionId": options.SessionID,
+			"cwd":       options.Cwd,
+			"prompt":    prompt,
+		},
+	})
+	return strings.TrimSpace(strings.Join(outcome.Messages, "\n"))
+}
+
+// dispatchStop runs stop hooks as the run ends. It is observational: output is
+// recorded to the audit store but does not change the result. A nil dispatcher is
+// a no-op. Callers should pass a non-cancelled context so end-of-run hooks still
+// execute after the run's own context is done.
+func dispatchStop(ctx context.Context, options Options) {
+	if options.Hooks == nil {
+		return
+	}
+	options.Hooks.Dispatch(ctx, hooks.DispatchInput{
+		Event: hooks.EventStop,
+		Payload: map[string]any{
+			"event":     string(hooks.EventStop),
+			"sessionId": options.SessionID,
+			"cwd":       options.Cwd,
+		},
+	})
 }
 
 // blockedByHookResult is the tool result for a call vetoed by a beforeTool hook.

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -722,7 +722,10 @@ func dispatchUserPromptSubmit(ctx context.Context, options Options, prompt strin
 			"prompt":    prompt,
 		},
 	})
-	return strings.TrimSpace(strings.Join(outcome.Messages, "\n"))
+	// Hook output is injected straight into the transcript, bypassing the registry
+	// redaction boundary, so scrub secrets exactly like the other hook-output paths.
+	injected := strings.TrimSpace(strings.Join(outcome.Messages, "\n"))
+	return redaction.RedactString(injected, redaction.Options{})
 }
 
 // dispatchStop runs stop hooks as the run ends. It is observational: output is

--- a/internal/hooks/actions.go
+++ b/internal/hooks/actions.go
@@ -87,14 +87,18 @@ func (dispatcher *Dispatcher) runHTTPAction(ctx context.Context, hook Definition
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return commandResult{ExitCode: -1, Err: err}
+		// No verdict from the policy endpoint (connect/transport failure). Fail
+		// closed: a non-zero exit blocks a beforeTool hook via classifyResult while
+		// staying advisory for non-blocking events. Returning Err would fail OPEN
+		// (classifyResult maps any Err to a non-blocking AuditError).
+		return commandResult{ExitCode: 1, Stderr: "http hook request failed: " + err.Error()}
 	}
 	defer func() { _ = resp.Body.Close() }()
 	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxHTTPHookResponseBytes))
 	if readErr != nil {
-		// A reset/truncated body means we never got the full verdict; treat it as
-		// an execution failure rather than silently reporting a clean (ExitCode 0) pass.
-		return commandResult{ExitCode: -1, Err: fmt.Errorf("read http hook response: %w", readErr)}
+		// A reset/truncated body means we never got the full verdict. Fail closed
+		// for the same reason: a non-zero exit blocks beforeTool; Err would not.
+		return commandResult{ExitCode: 1, Stderr: "read http hook response: " + readErr.Error()}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return commandResult{ExitCode: 1, Stderr: fmt.Sprintf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))}

--- a/internal/hooks/actions.go
+++ b/internal/hooks/actions.go
@@ -1,0 +1,88 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// PromptRunner evaluates a hook prompt against a model and returns the model's
+// text output. It is injected so the hooks package stays decoupled from the
+// provider/agent stack and can be exercised with a fake in tests. A nil runner
+// makes prompt hooks fail (as a non-blocking error), never block.
+type PromptRunner func(ctx context.Context, model string, prompt string, payload []byte) (string, error)
+
+// maxHTTPHookResponseBytes caps how much of an HTTP hook response is captured so
+// a chatty endpoint cannot bloat the audit log or model context.
+const maxHTTPHookResponseBytes = 64 * 1024
+
+// executeAction runs one hook through the executor selected by its Type, bounded
+// by the dispatcher timeout. The command path preserves the original behaviour;
+// prompt and http are the Stage 05 additions. A deadline/cancellation that fired
+// mid-run is reported via TimedOut so classifyResult can fail closed on blocking
+// events, exactly as the command path does.
+func (dispatcher *Dispatcher) executeAction(ctx context.Context, hook Definition, payload []byte) commandResult {
+	runCtx, cancel := context.WithTimeout(ctx, dispatcher.timeout)
+	defer cancel()
+
+	var result commandResult
+	switch hook.Type {
+	case ActionPrompt:
+		result = dispatcher.runPromptAction(runCtx, hook, payload)
+	case ActionHTTP:
+		result = dispatcher.runHTTPAction(runCtx, hook, payload)
+	default: // ActionCommand or "" (back-compat)
+		env := os.Environ()
+		if len(dispatcher.env) > 0 {
+			env = append(env, dispatcher.env...)
+		}
+		result = dispatcher.run(runCtx, hook.Command, hook.Args, payload, dispatcher.cwd, env)
+	}
+	if runCtx.Err() != nil {
+		result.TimedOut = true
+	}
+	return result
+}
+
+func (dispatcher *Dispatcher) runPromptAction(ctx context.Context, hook Definition, payload []byte) commandResult {
+	if dispatcher.promptRunner == nil {
+		return commandResult{ExitCode: -1, Err: errors.New("prompt hook requires a configured prompt runner")}
+	}
+	output, err := dispatcher.promptRunner(ctx, hook.Model, hook.Prompt, payload)
+	if err != nil {
+		return commandResult{ExitCode: -1, Err: err}
+	}
+	return commandResult{ExitCode: 0, Stdout: output}
+}
+
+func (dispatcher *Dispatcher) runHTTPAction(ctx context.Context, hook Definition, payload []byte) commandResult {
+	// Allowlist is enforced here, never at parse time: untrusted config must not be
+	// able to POST to an arbitrary URL just because it is syntactically valid.
+	if !dispatcher.allowedHTTPURLs[hook.URL] {
+		return commandResult{ExitCode: -1, Err: fmt.Errorf("http hook url is not on the allowlist: %s", hook.URL)}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hook.URL, bytes.NewReader(payload))
+	if err != nil {
+		return commandResult{ExitCode: -1, Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := dispatcher.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return commandResult{ExitCode: -1, Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxHTTPHookResponseBytes))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return commandResult{ExitCode: 1, Stderr: fmt.Sprintf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))}
+	}
+	return commandResult{ExitCode: 0, Stdout: strings.TrimSpace(string(body))}
+}

--- a/internal/hooks/actions.go
+++ b/internal/hooks/actions.go
@@ -21,6 +21,16 @@ type PromptRunner func(ctx context.Context, model string, prompt string, payload
 // a chatty endpoint cannot bloat the audit log or model context.
 const maxHTTPHookResponseBytes = 64 * 1024
 
+// noRedirectHTTPClient refuses to follow redirects. Following a 3xx would let an
+// allowlisted endpoint bounce the request (and its event payload) to a host that
+// is not on the allowlist — an allowlist bypass / SSRF vector. ErrUseLastResponse
+// returns the 3xx response unfollowed, which runHTTPAction reports as a failure.
+var noRedirectHTTPClient = &http.Client{
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
 // executeAction runs one hook through the executor selected by its Type, bounded
 // by the dispatcher timeout. The command path preserves the original behaviour;
 // prompt and http are the Stage 05 additions. A deadline/cancellation that fired
@@ -73,7 +83,7 @@ func (dispatcher *Dispatcher) runHTTPAction(ctx context.Context, hook Definition
 	req.Header.Set("Content-Type", "application/json")
 	client := dispatcher.httpClient
 	if client == nil {
-		client = http.DefaultClient
+		client = noRedirectHTTPClient
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/hooks/actions.go
+++ b/internal/hooks/actions.go
@@ -90,7 +90,12 @@ func (dispatcher *Dispatcher) runHTTPAction(ctx context.Context, hook Definition
 		return commandResult{ExitCode: -1, Err: err}
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxHTTPHookResponseBytes))
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxHTTPHookResponseBytes))
+	if readErr != nil {
+		// A reset/truncated body means we never got the full verdict; treat it as
+		// an execution failure rather than silently reporting a clean (ExitCode 0) pass.
+		return commandResult{ExitCode: -1, Err: fmt.Errorf("read http hook response: %w", readErr)}
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return commandResult{ExitCode: 1, Stderr: fmt.Sprintf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))}
 	}

--- a/internal/hooks/actions_test.go
+++ b/internal/hooks/actions_test.go
@@ -89,6 +89,34 @@ func TestDispatchHTTPActionPostsToAllowlistedURL(t *testing.T) {
 	}
 }
 
+func TestDispatchHTTPActionDoesNotFollowRedirectToNonAllowlistedHost(t *testing.T) {
+	var evilCalled bool
+	evil := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		evilCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer evil.Close()
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, evil.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "h", Event: EventNotification, Type: ActionHTTP, URL: redirector.URL, Enabled: true},
+	}}
+	// Only the redirector is allowlisted; the redirect target is not.
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, AllowedHTTPURLs: []string{redirector.URL}})
+
+	dispatcher.Dispatch(context.Background(), DispatchInput{
+		Event:   EventNotification,
+		Payload: map[string]any{"secret": "payload"},
+	})
+
+	if evilCalled {
+		t.Fatal("http hook followed a redirect to a non-allowlisted host (allowlist bypass / SSRF)")
+	}
+}
+
 func TestDispatchHTTPActionRejectsNonAllowlistedURL(t *testing.T) {
 	var called bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/hooks/actions_test.go
+++ b/internal/hooks/actions_test.go
@@ -2,12 +2,22 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("connection reset mid-body") }
 
 func TestDispatchPromptActionReturnsModelOutput(t *testing.T) {
 	var gotModel, gotPrompt string
@@ -114,6 +124,38 @@ func TestDispatchHTTPActionDoesNotFollowRedirectToNonAllowlistedHost(t *testing.
 
 	if evilCalled {
 		t.Fatal("http hook followed a redirect to a non-allowlisted host (allowlist bypass / SSRF)")
+	}
+}
+
+func TestDispatchHTTPActionTreatsTruncatedResponseAsFailure(t *testing.T) {
+	const url = "https://allowed.example/hook"
+	badClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		// 200 headers, but the body errors mid-read (server reset).
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(errReader{}), Header: make(http.Header)}, nil
+	})}
+	audit, err := NewAuditStore(AuditStoreOptions{AuditPath: filepath.Join(t.TempDir(), "audit.jsonl")})
+	if err != nil {
+		t.Fatalf("NewAuditStore: %v", err)
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "h", Event: EventNotification, Type: ActionHTTP, URL: url, Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, Audit: audit, AllowedHTTPURLs: []string{url}, HTTPClient: badClient})
+
+	dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventNotification})
+
+	events, err := audit.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	var status AuditStatus
+	for _, e := range events {
+		if e.Type == "hook_execution_completed" && e.HookID == "h" {
+			status = e.Status
+		}
+	}
+	if status != AuditError {
+		t.Fatalf("a truncated/erroring http response must be recorded as an error, got status %q", status)
 	}
 }
 

--- a/internal/hooks/actions_test.go
+++ b/internal/hooks/actions_test.go
@@ -1,0 +1,117 @@
+package hooks
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDispatchPromptActionReturnsModelOutput(t *testing.T) {
+	var gotModel, gotPrompt string
+	var gotPayload []byte
+	promptRunner := func(_ context.Context, model string, prompt string, payload []byte) (string, error) {
+		gotModel, gotPrompt, gotPayload = model, prompt, payload
+		return "looks good", nil
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "p", Event: EventAfterTool, Type: ActionPrompt, Prompt: "Follows conventions?", Model: "sonnet", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, PromptRunner: promptRunner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{
+		Event:    EventAfterTool,
+		ToolName: "edit_file",
+		Payload:  map[string]any{"k": "v"},
+	})
+
+	if outcome.Ran != 1 {
+		t.Fatalf("Ran = %d, want 1", outcome.Ran)
+	}
+	if len(outcome.Messages) != 1 || outcome.Messages[0] != "looks good" {
+		t.Fatalf("Messages = %#v, want [looks good]", outcome.Messages)
+	}
+	if gotModel != "sonnet" || gotPrompt != "Follows conventions?" {
+		t.Fatalf("prompt runner got model=%q prompt=%q", gotModel, gotPrompt)
+	}
+	if !strings.Contains(string(gotPayload), `"k":"v"`) {
+		t.Fatalf("payload not forwarded to prompt runner: %s", gotPayload)
+	}
+}
+
+func TestDispatchPromptActionWithoutRunnerErrorsWithoutBlocking(t *testing.T) {
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "p", Event: EventAfterTool, Type: ActionPrompt, Prompt: "x", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+
+	if outcome.Blocked {
+		t.Fatalf("prompt action without a runner must not block: %#v", outcome)
+	}
+	if outcome.Ran != 1 {
+		t.Fatalf("Ran = %d, want 1", outcome.Ran)
+	}
+}
+
+func TestDispatchHTTPActionPostsToAllowlistedURL(t *testing.T) {
+	var gotBody string
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "h", Event: EventNotification, Type: ActionHTTP, URL: server.URL, Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, AllowedHTTPURLs: []string{server.URL}})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{
+		Event:   EventNotification,
+		Payload: map[string]any{"event": "notification", "msg": "hi"},
+	})
+
+	if outcome.Ran != 1 {
+		t.Fatalf("Ran = %d, want 1", outcome.Ran)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("method = %q, want POST", gotMethod)
+	}
+	if !strings.Contains(gotBody, `"msg":"hi"`) {
+		t.Fatalf("posted body = %q", gotBody)
+	}
+}
+
+func TestDispatchHTTPActionRejectsNonAllowlistedURL(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "h", Event: EventNotification, Type: ActionHTTP, URL: server.URL, Enabled: true},
+	}}
+	// Allowlist is empty: the request must never be made.
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventNotification})
+
+	if called {
+		t.Fatal("non-allowlisted URL must not be requested")
+	}
+	if outcome.Ran != 1 {
+		t.Fatalf("Ran = %d, want 1", outcome.Ran)
+	}
+	if outcome.Blocked {
+		t.Fatalf("a rejected http hook on an advisory event must not block: %#v", outcome)
+	}
+}

--- a/internal/hooks/actions_test.go
+++ b/internal/hooks/actions_test.go
@@ -159,6 +159,27 @@ func TestDispatchHTTPActionTreatsTruncatedResponseAsFailure(t *testing.T) {
 	}
 }
 
+func TestDispatchHTTPActionBeforeToolReadFailureBlocks(t *testing.T) {
+	const url = "https://allowed.example/hook"
+	badClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		// Headers arrive, but the body resets mid-read: no verdict from the gate.
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(errReader{}), Header: make(http.Header)}, nil
+	})}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "policy", Event: EventBeforeTool, Type: ActionHTTP, URL: url, Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, AllowedHTTPURLs: []string{url}, HTTPClient: badClient})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventBeforeTool, ToolName: "bash"})
+
+	if !outcome.Blocked {
+		t.Fatalf("a beforeTool HTTP policy hook whose response read fails must fail closed (block): %#v", outcome)
+	}
+	if outcome.BlockedBy != "policy" {
+		t.Fatalf("BlockedBy = %q, want policy", outcome.BlockedBy)
+	}
+}
+
 func TestDispatchHTTPActionRejectsNonAllowlistedURL(t *testing.T) {
 	var called bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -121,6 +121,8 @@ func (dispatcher *Dispatcher) Rewakes() <-chan RewakeSignal {
 
 // WaitAsync blocks until every background hook launched so far has finished. The
 // loop drains async hooks at session end; tests use it to observe their results.
+// It must be called after the final Dispatch, not concurrently with one: like any
+// sync.WaitGroup, a Dispatch that adds from a zero counter must not race a Wait.
 func (dispatcher *Dispatcher) WaitAsync() {
 	if dispatcher == nil {
 		return
@@ -242,16 +244,23 @@ func (dispatcher *Dispatcher) Dispatch(ctx context.Context, input DispatchInput)
 // for asyncRewake hooks that exit with the blocking code, emits a RewakeSignal.
 func (dispatcher *Dispatcher) runAsync(ctx context.Context, hook Definition, input DispatchInput, payload []byte) {
 	dispatcher.recordStarted(hook, input, Command{Command: hook.Command, Args: hook.Args})
+	// Detach from the request context so a background hook outlives the turn that
+	// launched it (the whole point of async); it remains bounded by the per-hook
+	// timeout applied inside executeAction. WithoutCancel preserves ctx values.
+	asyncCtx := context.WithoutCancel(ctx)
 	dispatcher.wg.Add(1)
 	go func() {
 		defer dispatcher.wg.Done()
 		started := dispatcher.now()
-		result := dispatcher.executeAction(ctx, hook, payload)
+		result := dispatcher.executeAction(asyncCtx, hook, payload)
 		durationMs := int(dispatcher.now().Sub(started) / time.Millisecond)
 		status, _ := classifyResult(input.Event, result)
 		dispatcher.recordCompleted(hook, input, status, result, durationMs)
 
-		if hook.AsyncRewake && result.Err == nil && result.ExitCode == blockingExitCode {
+		// A timed-out/killed hook never produced a real verdict, so it must not wake
+		// the model — matching the synchronous afterTool block decision's fail-closed
+		// TimedOut check.
+		if hook.AsyncRewake && result.Err == nil && !result.TimedOut && result.ExitCode == blockingExitCode {
 			signal := RewakeSignal{
 				HookID:  hook.ID,
 				Summary: firstNonEmpty(hook.RewakeSummary, "a background hook requested attention"),

--- a/internal/hooks/dispatch.go
+++ b/internal/hooks/dispatch.go
@@ -5,15 +5,31 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
+	"net/http"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
 // defaultHookTimeout bounds a single hook command so a hung or slow hook cannot
 // stall the agent indefinitely.
 const defaultHookTimeout = 30 * time.Second
+
+// blockingExitCode is the conventional "blocking error" exit code. A beforeTool
+// hook already vetoes on any non-zero exit; afterTool hooks use exactly this code
+// to signal a block decision (continue-on-block or end-turn), and an asyncRewake
+// hook uses it to wake the model.
+const blockingExitCode = 2
+
+// RewakeSignal is emitted when a background (asyncRewake) hook exits with the
+// blocking code. The loop selects on Dispatcher.Rewakes() and, on receipt, wakes
+// the model with a system-reminder built from Message and shows Summary to the user.
+type RewakeSignal struct {
+	HookID  string
+	Summary string
+	Message string
+}
 
 // DispatchInput describes one lifecycle point at which hooks may run.
 type DispatchInput struct {
@@ -35,6 +51,14 @@ type DispatchOutcome struct {
 	// produced any, in run order. afterTool validators use this to feed results
 	// (e.g. a formatter diff or vet warning) back to the model on the tool result.
 	Messages []string
+	// AsyncLaunched counts hooks started in the background (not awaited).
+	AsyncLaunched int
+	// ContinueReason is set when an afterTool hook signalled a block with
+	// ContinueOnBlock=true: its reason is fed back to the model and the turn continues.
+	ContinueReason string
+	// EndTurn is set when an afterTool hook signalled a block without
+	// ContinueOnBlock: the turn should end (Reason carries why).
+	EndTurn bool
 }
 
 type commandResult struct {
@@ -56,8 +80,15 @@ type DispatcherOptions struct {
 	Cwd     string        // working directory for hook commands
 	Env     []string      // extra environment entries appended to the process env
 	Timeout time.Duration // per-command timeout (defaults to defaultHookTimeout)
-	now     func() time.Time
-	run     commandRunner
+	// PromptRunner evaluates "prompt" action hooks; nil makes them a non-blocking
+	// error. AllowedHTTPURLs is the exact-match allowlist for "http" action hooks;
+	// a URL not on it is rejected before any request is made. HTTPClient is
+	// injectable for tests (defaults to http.DefaultClient).
+	PromptRunner    PromptRunner
+	AllowedHTTPURLs []string
+	HTTPClient      *http.Client
+	now             func() time.Time
+	run             commandRunner
 }
 
 // Dispatcher selects and runs the hooks configured for a lifecycle event,
@@ -65,13 +96,36 @@ type DispatcherOptions struct {
 // blocks the tool; hooks for other events are advisory (failures are recorded
 // but do not interrupt the run).
 type Dispatcher struct {
-	config  Config
-	audit   *AuditStore
-	cwd     string
-	env     []string
-	timeout time.Duration
-	now     func() time.Time
-	run     commandRunner
+	config          Config
+	audit           *AuditStore
+	cwd             string
+	env             []string
+	timeout         time.Duration
+	promptRunner    PromptRunner
+	allowedHTTPURLs map[string]bool
+	httpClient      *http.Client
+	now             func() time.Time
+	run             commandRunner
+	rewakes         chan RewakeSignal
+	wg              sync.WaitGroup
+}
+
+// Rewakes returns the channel on which background asyncRewake hooks deliver
+// wake-the-model signals. The loop should select on it between turns.
+func (dispatcher *Dispatcher) Rewakes() <-chan RewakeSignal {
+	if dispatcher == nil {
+		return nil
+	}
+	return dispatcher.rewakes
+}
+
+// WaitAsync blocks until every background hook launched so far has finished. The
+// loop drains async hooks at session end; tests use it to observe their results.
+func (dispatcher *Dispatcher) WaitAsync() {
+	if dispatcher == nil {
+		return
+	}
+	dispatcher.wg.Wait()
 }
 
 // NewDispatcher builds a Dispatcher. A zero/empty config yields a dispatcher that
@@ -89,14 +143,24 @@ func NewDispatcher(options DispatcherOptions) *Dispatcher {
 	if run == nil {
 		run = execCommandRunner
 	}
+	allowed := map[string]bool{}
+	for _, raw := range options.AllowedHTTPURLs {
+		if trimmed := strings.TrimSpace(raw); trimmed != "" {
+			allowed[trimmed] = true
+		}
+	}
 	return &Dispatcher{
-		config:  options.Config,
-		audit:   options.Audit,
-		cwd:     options.Cwd,
-		env:     options.Env,
-		timeout: timeout,
-		now:     now,
-		run:     run,
+		config:          options.Config,
+		audit:           options.Audit,
+		cwd:             options.Cwd,
+		env:             options.Env,
+		timeout:         timeout,
+		promptRunner:    options.PromptRunner,
+		allowedHTTPURLs: allowed,
+		httpClient:      options.HTTPClient,
+		now:             now,
+		run:             run,
+		rewakes:         make(chan RewakeSignal, 16),
 	}
 }
 
@@ -125,11 +189,20 @@ func (dispatcher *Dispatcher) Dispatch(ctx context.Context, input DispatchInput)
 	}
 
 	for _, hook := range selected {
+		// Async hooks run in the background and never block the turn; their result
+		// is collected out-of-band (audit + asyncRewake channel). AsyncRewake
+		// implies async even if config normalization did not set it.
+		if hook.Async || hook.AsyncRewake {
+			dispatcher.runAsync(ctx, hook, input, payload)
+			outcome.AsyncLaunched++
+			continue
+		}
+
 		command := Command{Command: hook.Command, Args: hook.Args}
 		dispatcher.recordStarted(hook, input, command)
 
 		started := dispatcher.now()
-		result := dispatcher.runWithTimeout(ctx, hook, payload)
+		result := dispatcher.executeAction(ctx, hook, payload)
 		durationMs := int(dispatcher.now().Sub(started) / time.Millisecond)
 		outcome.Ran++
 
@@ -147,26 +220,77 @@ func (dispatcher *Dispatcher) Dispatch(ctx context.Context, input DispatchInput)
 			// Stop on the first veto: the action is already denied.
 			return outcome
 		}
+
+		// afterTool (and other non-veto events) signal a block decision with the
+		// conventional blocking exit code. ContinueOnBlock feeds the reason back and
+		// keeps going; otherwise the turn ends.
+		if !blocksOn(input.Event) && result.Err == nil && !result.TimedOut && result.ExitCode == blockingExitCode {
+			reason := blockReason(result)
+			if hook.ContinueOnBlock {
+				outcome.ContinueReason = appendReason(outcome.ContinueReason, reason)
+				continue
+			}
+			outcome.EndTurn = true
+			outcome.Reason = reason
+			return outcome
+		}
 	}
 	return outcome
 }
 
-func (dispatcher *Dispatcher) runWithTimeout(ctx context.Context, hook Definition, stdin []byte) commandResult {
-	runCtx, cancel := context.WithTimeout(ctx, dispatcher.timeout)
-	defer cancel()
-	env := os.Environ()
-	if len(dispatcher.env) > 0 {
-		env = append(env, dispatcher.env...)
+// runAsync launches a background hook. It records the run to the audit store and,
+// for asyncRewake hooks that exit with the blocking code, emits a RewakeSignal.
+func (dispatcher *Dispatcher) runAsync(ctx context.Context, hook Definition, input DispatchInput, payload []byte) {
+	dispatcher.recordStarted(hook, input, Command{Command: hook.Command, Args: hook.Args})
+	dispatcher.wg.Add(1)
+	go func() {
+		defer dispatcher.wg.Done()
+		started := dispatcher.now()
+		result := dispatcher.executeAction(ctx, hook, payload)
+		durationMs := int(dispatcher.now().Sub(started) / time.Millisecond)
+		status, _ := classifyResult(input.Event, result)
+		dispatcher.recordCompleted(hook, input, status, result, durationMs)
+
+		if hook.AsyncRewake && result.Err == nil && result.ExitCode == blockingExitCode {
+			signal := RewakeSignal{
+				HookID:  hook.ID,
+				Summary: firstNonEmpty(hook.RewakeSummary, "a background hook requested attention"),
+				Message: buildRewakeMessage(hook.RewakeMessage, result),
+			}
+			// Never block the goroutine if nobody is draining the channel.
+			select {
+			case dispatcher.rewakes <- signal:
+			default:
+			}
+		}
+	}()
+}
+
+// buildRewakeMessage joins the configured prefix with the hook's output into the
+// system-reminder body fed to the model.
+func buildRewakeMessage(prefix string, result commandResult) string {
+	parts := make([]string, 0, 2)
+	if trimmed := strings.TrimSpace(prefix); trimmed != "" {
+		parts = append(parts, trimmed)
 	}
-	result := dispatcher.run(runCtx, hook.Command, hook.Args, stdin, dispatcher.cwd, env)
-	// A deadline or cancellation that fired while the hook was running is distinct
-	// from a launch failure: the hook DID start, we just never got its verdict.
-	// classifyResult must fail CLOSED on this for a blocking event — a hung policy
-	// hook cannot be allowed to wave the tool through.
-	if runCtx.Err() != nil {
-		result.TimedOut = true
+	if message := hookMessage(result); message != "" {
+		parts = append(parts, message)
 	}
-	return result
+	if len(parts) == 0 {
+		return "a background hook exited with the blocking code"
+	}
+	return strings.Join(parts, "\n")
+}
+
+func appendReason(existing string, reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return existing
+	}
+	if existing == "" {
+		return reason
+	}
+	return existing + "\n" + reason
 }
 
 // classifyResult maps a command result to an audit status and whether it vetoes

--- a/internal/hooks/dispatch_async_test.go
+++ b/internal/hooks/dispatch_async_test.go
@@ -105,14 +105,18 @@ func TestDispatchAsyncRewakeNoSignalOnSuccess(t *testing.T) {
 
 func TestDispatchAsyncRewakeNoSignalWhenTimedOut(t *testing.T) {
 	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
-		// Exits with the blocking code, but the run is killed (no real verdict).
+		// Wait for the per-hook deadline to fire, then return the blocking code:
+		// the result is both ExitCode 2 and TimedOut, with no real verdict. Waiting
+		// on ctx.Done() makes TimedOut deterministic on every platform (no reliance
+		// on a sub-tick timer firing within a synchronous window).
+		<-ctx.Done()
 		return commandResult{ExitCode: 2, Stderr: "exited 2 while being killed"}
 	}
 	config := Config{Enabled: true, Hooks: []Definition{
 		{ID: "verifier", Event: EventAfterTool, Command: "verify", AsyncRewake: true, RewakeMessage: "broke:", Enabled: true},
 	}}
-	// A 1ns timeout forces executeAction to mark the result TimedOut.
-	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner, Timeout: time.Nanosecond})
+	// A short timeout the runner waits for, forcing executeAction to mark TimedOut.
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner, Timeout: 10 * time.Millisecond})
 
 	dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
 	dispatcher.WaitAsync()

--- a/internal/hooks/dispatch_async_test.go
+++ b/internal/hooks/dispatch_async_test.go
@@ -103,6 +103,51 @@ func TestDispatchAsyncRewakeNoSignalOnSuccess(t *testing.T) {
 	}
 }
 
+func TestDispatchAsyncRewakeNoSignalWhenTimedOut(t *testing.T) {
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		// Exits with the blocking code, but the run is killed (no real verdict).
+		return commandResult{ExitCode: 2, Stderr: "exited 2 while being killed"}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "verifier", Event: EventAfterTool, Command: "verify", AsyncRewake: true, RewakeMessage: "broke:", Enabled: true},
+	}}
+	// A 1ns timeout forces executeAction to mark the result TimedOut.
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner, Timeout: time.Nanosecond})
+
+	dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+	dispatcher.WaitAsync()
+
+	select {
+	case sig := <-dispatcher.Rewakes():
+		t.Fatalf("a timed-out hook produced no verdict and must not wake the model: %#v", sig)
+	default:
+	}
+}
+
+func TestRunAsyncDetachesFromRequestContext(t *testing.T) {
+	release := make(chan struct{})
+	sawCancelled := make(chan bool, 1)
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		<-release
+		sawCancelled <- (ctx.Err() != nil)
+		return commandResult{ExitCode: 0}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "bg", Event: EventAfterTool, Command: "bg", Async: true, Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dispatcher.Dispatch(ctx, DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+	cancel() // cancel the request context while the background hook is mid-run
+	close(release)
+	dispatcher.WaitAsync()
+
+	if <-sawCancelled {
+		t.Fatal("background async hook saw a cancelled context; it must be detached from the request context to outlive the turn")
+	}
+}
+
 func TestDispatchAfterToolContinueOnBlockFeedsReasonAndContinues(t *testing.T) {
 	var ran []string
 	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {

--- a/internal/hooks/dispatch_async_test.go
+++ b/internal/hooks/dispatch_async_test.go
@@ -1,0 +1,160 @@
+package hooks
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDispatchAsyncHookDoesNotBlockAndIsCollected(t *testing.T) {
+	release := make(chan struct{})
+	var ran int32
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		<-release
+		atomic.AddInt32(&ran, 1)
+		return commandResult{ExitCode: 0, Stdout: "done"}
+	}
+	audit, err := NewAuditStore(AuditStoreOptions{AuditPath: filepath.Join(t.TempDir(), "audit.jsonl")})
+	if err != nil {
+		t.Fatalf("NewAuditStore: %v", err)
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "bg", Event: EventAfterTool, Command: "bg", Async: true, Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, Audit: audit, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+
+	if atomic.LoadInt32(&ran) != 0 {
+		t.Fatal("async hook ran before Dispatch returned; it must not block the turn")
+	}
+	if outcome.Ran != 0 || outcome.AsyncLaunched != 1 {
+		t.Fatalf("outcome = %#v; want Ran=0, AsyncLaunched=1", outcome)
+	}
+
+	close(release)
+	dispatcher.WaitAsync()
+
+	if atomic.LoadInt32(&ran) != 1 {
+		t.Fatal("async hook did not run after release")
+	}
+	events, err := audit.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	completed := 0
+	for _, event := range events {
+		if event.Type == "hook_execution_completed" && event.HookID == "bg" {
+			completed++
+		}
+	}
+	if completed != 1 {
+		t.Fatalf("async result not collected to audit: %#v", events)
+	}
+}
+
+func TestDispatchAsyncRewakeSignalsOnBlockingExit(t *testing.T) {
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		return commandResult{ExitCode: 2, Stderr: "tests failing"}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "verifier", Event: EventAfterTool, Command: "verify", AsyncRewake: true, RewakeMessage: "You broke it:", RewakeSummary: "build broken", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+
+	select {
+	case sig := <-dispatcher.Rewakes():
+		if sig.HookID != "verifier" {
+			t.Fatalf("HookID = %q", sig.HookID)
+		}
+		if sig.Summary != "build broken" {
+			t.Fatalf("Summary = %q", sig.Summary)
+		}
+		if !strings.Contains(sig.Message, "You broke it:") || !strings.Contains(sig.Message, "tests failing") {
+			t.Fatalf("Message = %q; want prefix + hook output", sig.Message)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no rewake signal delivered for asyncRewake exit code 2")
+	}
+	dispatcher.WaitAsync()
+}
+
+func TestDispatchAsyncRewakeNoSignalOnSuccess(t *testing.T) {
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		return commandResult{ExitCode: 0, Stdout: "all good"}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "verifier", Event: EventAfterTool, Command: "verify", AsyncRewake: true, RewakeMessage: "broke:", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+	dispatcher.WaitAsync()
+
+	select {
+	case sig := <-dispatcher.Rewakes():
+		t.Fatalf("unexpected rewake on success: %#v", sig)
+	default:
+	}
+}
+
+func TestDispatchAfterToolContinueOnBlockFeedsReasonAndContinues(t *testing.T) {
+	var ran []string
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		ran = append(ran, command)
+		if command == "gate" {
+			return commandResult{ExitCode: 2, Stderr: "convention violated"}
+		}
+		return commandResult{ExitCode: 0}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "gate", Event: EventAfterTool, Command: "gate", ContinueOnBlock: true, Enabled: true},
+		{ID: "after", Event: EventAfterTool, Command: "after", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+
+	if outcome.EndTurn {
+		t.Fatalf("continueOnBlock=true must not end the turn: %#v", outcome)
+	}
+	if !strings.Contains(outcome.ContinueReason, "convention violated") {
+		t.Fatalf("ContinueReason = %q; want the gate's reason fed back", outcome.ContinueReason)
+	}
+	if strings.Join(ran, ",") != "gate,after" {
+		t.Fatalf("ran = %v; want both hooks (turn continues past the block)", ran)
+	}
+}
+
+func TestDispatchAfterToolBlockWithoutContinueEndsTurn(t *testing.T) {
+	var ran []string
+	runner := func(ctx context.Context, command string, args []string, stdin []byte, cwd string, env []string) commandResult {
+		ran = append(ran, command)
+		if command == "gate" {
+			return commandResult{ExitCode: 2, Stderr: "stop now"}
+		}
+		return commandResult{ExitCode: 0}
+	}
+	config := Config{Enabled: true, Hooks: []Definition{
+		{ID: "gate", Event: EventAfterTool, Command: "gate", Enabled: true},
+		{ID: "after", Event: EventAfterTool, Command: "after", Enabled: true},
+	}}
+	dispatcher := NewDispatcher(DispatcherOptions{Config: config, run: runner})
+
+	outcome := dispatcher.Dispatch(context.Background(), DispatchInput{Event: EventAfterTool, ToolName: "edit_file"})
+
+	if !outcome.EndTurn {
+		t.Fatalf("a block without continueOnBlock must end the turn: %#v", outcome)
+	}
+	if !strings.Contains(outcome.Reason, "stop now") {
+		t.Fatalf("Reason = %q", outcome.Reason)
+	}
+	if strings.Join(ran, ",") != "gate" {
+		t.Fatalf("ran = %v; want only gate (stop after end-turn block)", ran)
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -73,7 +73,7 @@ type Definition struct {
 	Event       Event    `json:"event"`
 	Matcher     string   `json:"matcher,omitempty"`
 	Command     string   `json:"command,omitempty"`
-	Args        []string `json:"args,omitempty"`
+	Args        []string `json:"args"`
 	Enabled     bool     `json:"enabled"`
 
 	// Type selects the action executor; empty/"command" preserves legacy behaviour.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -846,21 +847,41 @@ func optionalBool(obj map[string]any, field string) (bool, error) {
 	return parsed, nil
 }
 
-// validateHookURL returns an empty string when raw is an acceptable http(s) URL,
-// otherwise a human-readable reason. The per-run allowlist is enforced at
-// dispatch time; this only rejects structurally invalid URLs at parse time.
+// validateHookURL returns an empty string when raw is an acceptable hook URL,
+// otherwise a human-readable reason. Hook payloads and block decisions can be
+// sensitive, so cleartext http is allowed only to loopback hosts; everything else
+// must be https. The per-run allowlist is enforced at dispatch time; this only
+// rejects structurally invalid or insecure URLs at parse time.
 func validateHookURL(raw string) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return "Expected a valid URL."
 	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "Expected an http or https URL."
-	}
 	if parsed.Host == "" {
 		return "Expected a URL with a host."
 	}
-	return ""
+	switch parsed.Scheme {
+	case "https":
+		return ""
+	case "http":
+		if isLoopbackHost(parsed.Hostname()) {
+			return ""
+		}
+		return "Expected an https URL (cleartext http is only allowed for loopback hosts)."
+	default:
+		return "Expected an http or https URL."
+	}
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // eventAllowsHTTP blocks http actions for setup-type events, which run before the

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +15,7 @@ import (
 )
 
 type Event string
+type ActionType string
 type DiagnosticKind string
 type ConfigSource string
 type AuditStatus string
@@ -25,6 +27,20 @@ const (
 	EventSessionEnd      Event = "sessionEnd"
 	EventSpecialistStart Event = "specialistStart"
 	EventSpecialistStop  Event = "specialistStop"
+	// Stage 05 lifecycle events.
+	EventUserPromptSubmit Event = "userPromptSubmit"
+	EventPreCompact       Event = "preCompact"
+	EventNotification     Event = "notification"
+	EventStop             Event = "stop"
+)
+
+const (
+	// ActionCommand is the default action: execute Command/Args as a process.
+	ActionCommand ActionType = "command"
+	// ActionPrompt evaluates Prompt against a model; its text becomes the output.
+	ActionPrompt ActionType = "prompt"
+	// ActionHTTP POSTs the event payload to URL (allowlisted at dispatch time).
+	ActionHTTP ActionType = "http"
 )
 
 const (
@@ -56,9 +72,27 @@ type Definition struct {
 	Description string   `json:"description,omitempty"`
 	Event       Event    `json:"event"`
 	Matcher     string   `json:"matcher,omitempty"`
-	Command     string   `json:"command"`
-	Args        []string `json:"args"`
+	Command     string   `json:"command,omitempty"`
+	Args        []string `json:"args,omitempty"`
 	Enabled     bool     `json:"enabled"`
+
+	// Type selects the action executor; empty/"command" preserves legacy behaviour.
+	Type ActionType `json:"type,omitempty"`
+	// Async runs the hook without blocking the turn; its result is collected
+	// out-of-band. AsyncRewake implies Async.
+	Async       bool `json:"async,omitempty"`
+	AsyncRewake bool `json:"asyncRewake,omitempty"`
+	// RewakeMessage prefixes the system-reminder injected when an asyncRewake hook
+	// exits with the blocking code; RewakeSummary is the one-line user notice.
+	RewakeMessage string `json:"rewakeMessage,omitempty"`
+	RewakeSummary string `json:"rewakeSummary,omitempty"`
+	// ContinueOnBlock feeds a blocking afterTool hook's reason back to the model
+	// and continues the turn instead of ending it.
+	ContinueOnBlock bool `json:"continueOnBlock,omitempty"`
+	// Prompt/Model drive the "prompt" action; URL drives the "http" action.
+	Prompt string `json:"prompt,omitempty"`
+	Model  string `json:"model,omitempty"`
+	URL    string `json:"url,omitempty"`
 }
 
 type Config struct {
@@ -694,13 +728,74 @@ func normalizeDefinition(raw any, field string) (Definition, error) {
 	if matcher != "" && !eventSupportsMatcher(event) {
 		return Definition{}, manifestError{fieldPath: field + ".matcher", message: "matcher is only supported for beforeTool and afterTool hooks."}
 	}
-	command, err := requiredString(obj, field+".command")
+	actionType, err := parseActionType(obj["type"], field+".type")
+	if err != nil {
+		return Definition{}, err
+	}
+	command, err := optionalString(obj, field+".command")
 	if err != nil {
 		return Definition{}, err
 	}
 	args, err := optionalStringArray(obj["args"], field+".args")
 	if err != nil {
 		return Definition{}, err
+	}
+	prompt, err := optionalString(obj, field+".prompt")
+	if err != nil {
+		return Definition{}, err
+	}
+	model, err := optionalString(obj, field+".model")
+	if err != nil {
+		return Definition{}, err
+	}
+	hookURL, err := optionalString(obj, field+".url")
+	if err != nil {
+		return Definition{}, err
+	}
+	rewakeMessage, err := optionalString(obj, field+".rewakeMessage")
+	if err != nil {
+		return Definition{}, err
+	}
+	rewakeSummary, err := optionalString(obj, field+".rewakeSummary")
+	if err != nil {
+		return Definition{}, err
+	}
+	async, err := optionalBool(obj, field+".async")
+	if err != nil {
+		return Definition{}, err
+	}
+	asyncRewake, err := optionalBool(obj, field+".asyncRewake")
+	if err != nil {
+		return Definition{}, err
+	}
+	continueOnBlock, err := optionalBool(obj, field+".continueOnBlock")
+	if err != nil {
+		return Definition{}, err
+	}
+	// Per-action required fields. New bools default false; back-compat command
+	// hooks (no "type") still require a command.
+	switch actionType {
+	case ActionCommand:
+		if command == "" {
+			return Definition{}, manifestError{fieldPath: field + ".command", message: "Expected a non-empty string."}
+		}
+	case ActionPrompt:
+		if prompt == "" {
+			return Definition{}, manifestError{fieldPath: field + ".prompt", message: "prompt action requires a prompt."}
+		}
+	case ActionHTTP:
+		if hookURL == "" {
+			return Definition{}, manifestError{fieldPath: field + ".url", message: "http action requires a url."}
+		}
+		if message := validateHookURL(hookURL); message != "" {
+			return Definition{}, manifestError{fieldPath: field + ".url", message: message}
+		}
+		if !eventAllowsHTTP(event) {
+			return Definition{}, manifestError{fieldPath: field + ".type", message: "http action is not allowed for setup events (sessionStart/sessionEnd)."}
+		}
+	}
+	if asyncRewake {
+		async = true
 	}
 	enabled := true
 	if rawEnabled, ok := obj["enabled"]; ok {
@@ -710,7 +805,68 @@ func normalizeDefinition(raw any, field string) (Definition, error) {
 		}
 		enabled = parsed
 	}
-	return Definition{ID: id, Name: name, Description: description, Event: event, Matcher: matcher, Command: command, Args: args, Enabled: enabled}, nil
+	return Definition{
+		ID: id, Name: name, Description: description, Event: event, Matcher: matcher,
+		Command: command, Args: args, Enabled: enabled,
+		Type: actionType, Async: async, AsyncRewake: asyncRewake,
+		RewakeMessage: rewakeMessage, RewakeSummary: rewakeSummary, ContinueOnBlock: continueOnBlock,
+		Prompt: prompt, Model: model, URL: hookURL,
+	}, nil
+}
+
+func parseActionType(raw any, field string) (ActionType, error) {
+	if raw == nil {
+		return ActionCommand, nil
+	}
+	text, ok := raw.(string)
+	if !ok {
+		return "", manifestError{fieldPath: field, message: "Expected a string."}
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ActionCommand, nil
+	}
+	switch ActionType(text) {
+	case ActionCommand, ActionPrompt, ActionHTTP:
+		return ActionType(text), nil
+	default:
+		return "", manifestError{fieldPath: field, message: "Expected command, prompt, or http."}
+	}
+}
+
+func optionalBool(obj map[string]any, field string) (bool, error) {
+	value, ok := obj[lastPathSegment(field)]
+	if !ok || value == nil {
+		return false, nil
+	}
+	parsed, ok := value.(bool)
+	if !ok {
+		return false, manifestError{fieldPath: field, message: "Expected a boolean."}
+	}
+	return parsed, nil
+}
+
+// validateHookURL returns an empty string when raw is an acceptable http(s) URL,
+// otherwise a human-readable reason. The per-run allowlist is enforced at
+// dispatch time; this only rejects structurally invalid URLs at parse time.
+func validateHookURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "Expected a valid URL."
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "Expected an http or https URL."
+	}
+	if parsed.Host == "" {
+		return "Expected a URL with a host."
+	}
+	return ""
+}
+
+// eventAllowsHTTP blocks http actions for setup-type events, which run before the
+// session is fully trusted and should not reach the network from config alone.
+func eventAllowsHTTP(event Event) bool {
+	return event != EventSessionStart && event != EventSessionEnd
 }
 
 func matchesHookMatcher(matcher string, toolName string) bool {
@@ -809,10 +965,11 @@ func parseEvent(raw any, field string) (Event, error) {
 	}
 	event := Event(strings.TrimSpace(text))
 	switch event {
-	case EventBeforeTool, EventAfterTool, EventSessionStart, EventSessionEnd, EventSpecialistStart, EventSpecialistStop:
+	case EventBeforeTool, EventAfterTool, EventSessionStart, EventSessionEnd, EventSpecialistStart, EventSpecialistStop,
+		EventUserPromptSubmit, EventPreCompact, EventNotification, EventStop:
 		return event, nil
 	default:
-		return "", manifestError{fieldPath: field, message: "Expected beforeTool, afterTool, sessionStart, sessionEnd, specialistStart, or specialistStop."}
+		return "", manifestError{fieldPath: field, message: "Expected beforeTool, afterTool, sessionStart, sessionEnd, specialistStart, specialistStop, userPromptSubmit, preCompact, notification, or stop."}
 	}
 }
 
@@ -861,9 +1018,13 @@ func definitionToRaw(definition Definition) map[string]any {
 	value := map[string]any{
 		"id":      definition.ID,
 		"event":   string(definition.Event),
-		"command": definition.Command,
-		"args":    definition.Args,
 		"enabled": definition.Enabled,
+	}
+	if definition.Command != "" {
+		value["command"] = definition.Command
+	}
+	if len(definition.Args) > 0 {
+		value["args"] = definition.Args
 	}
 	if definition.Name != "" {
 		value["name"] = definition.Name
@@ -873,6 +1034,33 @@ func definitionToRaw(definition Definition) map[string]any {
 	}
 	if definition.Matcher != "" {
 		value["matcher"] = definition.Matcher
+	}
+	if definition.Type != "" && definition.Type != ActionCommand {
+		value["type"] = string(definition.Type)
+	}
+	if definition.Async {
+		value["async"] = true
+	}
+	if definition.AsyncRewake {
+		value["asyncRewake"] = true
+	}
+	if definition.RewakeMessage != "" {
+		value["rewakeMessage"] = definition.RewakeMessage
+	}
+	if definition.RewakeSummary != "" {
+		value["rewakeSummary"] = definition.RewakeSummary
+	}
+	if definition.ContinueOnBlock {
+		value["continueOnBlock"] = true
+	}
+	if definition.Prompt != "" {
+		value["prompt"] = definition.Prompt
+	}
+	if definition.Model != "" {
+		value["model"] = definition.Model
+	}
+	if definition.URL != "" {
+		value["url"] = definition.URL
 	}
 	return value
 }

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -307,6 +307,141 @@ func TestSpecialistHookEventsLoadAndSelect(t *testing.T) {
 	}
 }
 
+func TestNewLifecycleEventsLoadAndSelect(t *testing.T) {
+	dir := t.TempDir()
+	projectConfigPath := filepath.Join(dir, "hooks.json")
+	writeHookJSON(t, projectConfigPath, map[string]any{
+		"hooks": []any{
+			map[string]any{"id": "zero.user-prompt", "event": "userPromptSubmit", "command": "node"},
+			map[string]any{"id": "zero.pre-compact", "event": "preCompact", "command": "node"},
+			map[string]any{"id": "zero.notification", "event": "notification", "command": "node"},
+			map[string]any{"id": "zero.stop", "event": "stop", "command": "node"},
+		},
+	})
+
+	result, err := LoadConfig(LoadOptions{
+		UserConfigPath:    filepath.Join(dir, "missing-user-hooks.json"),
+		ProjectConfigPath: projectConfigPath,
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics)
+	}
+	for event, wantID := range map[Event]string{
+		EventUserPromptSubmit: "zero.user-prompt",
+		EventPreCompact:       "zero.pre-compact",
+		EventNotification:     "zero.notification",
+		EventStop:             "zero.stop",
+	} {
+		if got := hookIDs(Select(result.Config, SelectInput{Event: event})); !reflect.DeepEqual(got, []string{wantID}) {
+			t.Fatalf("%s selection = %#v, want [%q]", event, got, wantID)
+		}
+	}
+}
+
+func TestActionTypeHooksLoadFieldsAndDefaults(t *testing.T) {
+	dir := t.TempDir()
+	projectConfigPath := filepath.Join(dir, "hooks.json")
+	writeHookJSON(t, projectConfigPath, map[string]any{
+		"hooks": []any{
+			map[string]any{"id": "a.command", "event": "afterTool", "command": "gofmt"},
+			map[string]any{"id": "b.prompt", "event": "afterTool", "type": "prompt", "prompt": "Follows conventions?", "model": "sonnet"},
+			map[string]any{"id": "c.http", "event": "notification", "type": "http", "url": "https://hooks.example/zero"},
+			map[string]any{"id": "d.rewake", "event": "afterTool", "command": "verify", "asyncRewake": true, "rewakeMessage": "You broke the build:", "rewakeSummary": "build broken", "continueOnBlock": true},
+		},
+	})
+
+	result, err := LoadConfig(LoadOptions{
+		UserConfigPath:    filepath.Join(dir, "missing-user-hooks.json"),
+		ProjectConfigPath: projectConfigPath,
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics)
+	}
+	byID := map[string]Definition{}
+	for _, hook := range result.Config.Hooks {
+		byID[hook.ID] = hook
+	}
+
+	if got := byID["a.command"]; got.Type != ActionCommand || got.Command != "gofmt" {
+		t.Fatalf("a.command = %#v; want command type, gofmt command", got)
+	}
+	if got := byID["b.prompt"]; got.Type != ActionPrompt || got.Prompt != "Follows conventions?" || got.Model != "sonnet" || got.Command != "" {
+		t.Fatalf("b.prompt = %#v", got)
+	}
+	if got := byID["c.http"]; got.Type != ActionHTTP || got.URL != "https://hooks.example/zero" {
+		t.Fatalf("c.http = %#v", got)
+	}
+	if got := byID["d.rewake"]; !got.Async || !got.AsyncRewake || got.RewakeMessage != "You broke the build:" || got.RewakeSummary != "build broken" || !got.ContinueOnBlock {
+		t.Fatalf("d.rewake = %#v; want asyncRewake forcing async, messages set, continueOnBlock", got)
+	}
+}
+
+func TestActionTypeHooksValidation(t *testing.T) {
+	cases := []struct {
+		name      string
+		hook      map[string]any
+		fieldPath string
+	}{
+		{
+			name:      "prompt requires prompt",
+			hook:      map[string]any{"id": "p", "event": "afterTool", "type": "prompt"},
+			fieldPath: "hooks.0.prompt",
+		},
+		{
+			name:      "http requires url",
+			hook:      map[string]any{"id": "h", "event": "notification", "type": "http"},
+			fieldPath: "hooks.0.url",
+		},
+		{
+			name:      "http rejects non-http url",
+			hook:      map[string]any{"id": "h", "event": "notification", "type": "http", "url": "ftp://x/y"},
+			fieldPath: "hooks.0.url",
+		},
+		{
+			name:      "http disallowed for sessionStart",
+			hook:      map[string]any{"id": "h", "event": "sessionStart", "type": "http", "url": "https://x/y"},
+			fieldPath: "hooks.0.type",
+		},
+		{
+			name:      "unknown type rejected",
+			hook:      map[string]any{"id": "x", "event": "afterTool", "type": "webhook", "command": "node"},
+			fieldPath: "hooks.0.type",
+		},
+		{
+			name:      "command still required for command type",
+			hook:      map[string]any{"id": "c", "event": "afterTool"},
+			fieldPath: "hooks.0.command",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			projectConfigPath := filepath.Join(dir, "hooks.json")
+			writeHookJSON(t, projectConfigPath, map[string]any{"hooks": []any{tt.hook}})
+
+			result, err := LoadConfig(LoadOptions{
+				UserConfigPath:    filepath.Join(dir, "missing-user-hooks.json"),
+				ProjectConfigPath: projectConfigPath,
+			})
+			if err != nil {
+				t.Fatalf("LoadConfig returned error: %v", err)
+			}
+			if len(result.Config.Hooks) != 0 {
+				t.Fatalf("expected invalid hook to be skipped: %#v", result.Config.Hooks)
+			}
+			if !hasHookDiagnostic(result.Diagnostics, DiagnosticSchema, "", tt.fieldPath) {
+				t.Fatalf("missing diagnostic for %s: %#v", tt.fieldPath, result.Diagnostics)
+			}
+		})
+	}
+}
+
 func TestAuditStoreAppendsAndSkipsMalformedLines(t *testing.T) {
 	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
 	if err := os.WriteFile(auditPath, []byte(strings.Join([]string{

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -404,6 +404,11 @@ func TestActionTypeHooksValidation(t *testing.T) {
 			fieldPath: "hooks.0.url",
 		},
 		{
+			name:      "http rejects cleartext to non-loopback host",
+			hook:      map[string]any{"id": "h", "event": "notification", "type": "http", "url": "http://hooks.example/zero"},
+			fieldPath: "hooks.0.url",
+		},
+		{
 			name:      "http disallowed for sessionStart",
 			hook:      map[string]any{"id": "h", "event": "sessionStart", "type": "http", "url": "https://x/y"},
 			fieldPath: "hooks.0.type",
@@ -439,6 +444,32 @@ func TestActionTypeHooksValidation(t *testing.T) {
 				t.Fatalf("missing diagnostic for %s: %#v", tt.fieldPath, result.Diagnostics)
 			}
 		})
+	}
+}
+
+func TestActionTypeHTTPAllowsHTTPSAndLoopbackHTTP(t *testing.T) {
+	dir := t.TempDir()
+	projectConfigPath := filepath.Join(dir, "hooks.json")
+	writeHookJSON(t, projectConfigPath, map[string]any{
+		"hooks": []any{
+			map[string]any{"id": "secure", "event": "notification", "type": "http", "url": "https://hooks.example/zero"},
+			map[string]any{"id": "loopback-name", "event": "notification", "type": "http", "url": "http://localhost:8080/zero"},
+			map[string]any{"id": "loopback-ip", "event": "notification", "type": "http", "url": "http://127.0.0.1:9000/zero"},
+		},
+	})
+
+	result, err := LoadConfig(LoadOptions{
+		UserConfigPath:    filepath.Join(dir, "missing-user-hooks.json"),
+		ProjectConfigPath: projectConfigPath,
+	})
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if len(result.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %#v", result.Diagnostics)
+	}
+	if got := hookIDs(result.Config.Hooks); !reflect.DeepEqual(got, []string{"loopback-ip", "loopback-name", "secure"}) {
+		t.Fatalf("hook ids = %#v", got)
 	}
 }
 


### PR DESCRIPTION
Stage 05 of the wedge build — extends the hook system from "6 events, command-only" toward the mature shape that powers unattended self-correction and external triggers. Built clean-room in Go (semantics only; no competitor source). TDD throughout.

## Done — hooks package (fully unit-tested)
- **New lifecycle events:** `userPromptSubmit`, `preCompact`, `notification`, `stop` (parse + select; matcher still restricted to before/afterTool).
- **Action types** on `Definition` (`type`: `command` default, `prompt`, `http`) plus `async`, `asyncRewake`, `rewakeMessage`, `rewakeSummary`, `continueOnBlock`, `prompt`, `model`, `url`.
- **Action executors** (`actions.go`): `command` (unchanged), `prompt` (injectable `PromptRunner`), `http` (allowlisted POST, capped response body).
- **async / rewake / continueOnBlock** (`dispatch.go`): background execution that doesn't block the turn; an `asyncRewake` hook exiting code 2 emits a `RewakeSignal` on `Dispatcher.Rewakes()`; afterTool block decisions (`continueOnBlock` feeds the reason back and continues, otherwise end-turn).

### Schema / back-compat
New bool fields default false; `type` defaults `command`; `asyncRewake` implies `async`. Existing command-only hook configs parse unchanged (covered by tests). Validation: `prompt` requires `prompt`; `http` requires an allowlisted http(s) `url` and is rejected for setup events (`sessionStart`/`sessionEnd`); unknown `type` rejected.

### Security
`http` actions are gated by an exact-match allowlist enforced at dispatch time (never from config alone); a non-allowlisted URL is rejected before any request is made.

## Done — agent loop wiring
- `userPromptSubmit` fires before the turn loop; hook output is injected once into the run context.
- `stop` fires on every run-exit path (deferred, detached context).

## Remaining (follow-up, intentionally not rushed into the core loop)
- Consume `continueOnBlock`/end-turn and `Rewakes()` in the turn loop's control flow (the dispatch-layer mechanism + tests are in place; wiring the turn-loop control flow is the risky part).
- Fire `preCompact` from the compaction entry point and `notification` from the notify path (the latter ties into Stage 11).

## Validation
`gofmt -l` clean · `go vet ./...` clean · `go build ./...` · `go test ./...` all green.

Stacked on `feat/wedge-build` (stages 01–04); retarget to `main` after that lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle events (userPromptSubmit, preCompact, notification, stop), prompt and HTTP hook actions, HTTP allowlisting and response-size limits, async background hooks with rewake signaling, and reliable stop-hook execution; userPromptSubmit output can be appended to runs.

* **Bug Fixes**
  * Hook dispatch helpers are safe no-ops when no dispatcher is configured (no panics or injected context).

* **Tests**
  * Expanded coverage for prompt/HTTP actions, allowlisting, redirects, truncated responses, async/rewake behavior, and block-vs-continue rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->