### PR TITLE
wedge stage 12: PDF ingestion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	golang.org/x/sys v0.38.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/imageinput/pdf.go
+++ b/internal/imageinput/pdf.go
@@ -1,0 +1,379 @@
+package imageinput
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+	"github.com/ledongthuc/pdf"
+)
+
+// Dependency posture (see stage 12): the DEFAULT build extracts a PDF's text
+// layer in pure Go via github.com/ledongthuc/pdf (BSD-licensed, no CGO, no
+// transitive deps), so ZERO stays a single static cross-compilable binary with
+// no runtime dependencies. Rasterizing pages to images for vision models needs
+// real font/graphics rendering, which no maintained pure-Go library does well;
+// that path is OPTIONAL and uses the poppler tools (pdftotext / pdftoppm) only
+// when they are already on PATH -- the same "external tool the user may have"
+// posture as the LSP language servers. When poppler is absent, extraction
+// silently degrades to the pure-Go text layer; absence is never an error.
+
+// MaxDocumentBytes is the per-document raw-file cap (32 MiB). PDFs are routinely
+// larger than the image cap, but we still bound the file before it is read into
+// memory or handed to a parser so an unbounded file never reaches a provider.
+const MaxDocumentBytes = 32 << 20
+
+// MaxDocumentTextBytes caps the EXTRACTED text we hand to a model (256 KiB).
+// Unlike the raw-file cap (which rejects), an over-cap text layer is truncated
+// with documentTruncatedMarker so a large-but-valid spec is still partially
+// usable instead of refused outright.
+const MaxDocumentTextBytes = 256 << 10
+
+// documentTruncatedMarker is appended to capped text so the agent (and the user)
+// can tell extraction was cut short rather than the document simply ending.
+const documentTruncatedMarker = "\n\n[... document text truncated at the size limit ...]"
+
+// defaultMaxRasterPages bounds how many pages the optional vision path renders,
+// so a long PDF cannot blow up the context window. Callers may override it via
+// DocumentOptions.MaxPages.
+const defaultMaxRasterPages = 10
+
+// popplerTimeout bounds each external poppler invocation so a wedged or
+// pathological binary cannot hang the CLI/TUI.
+const popplerTimeout = 30 * time.Second
+
+// pdfMagic is the leading signature of every PDF stream. Detection keys on these
+// bytes, never on the file extension alone.
+var pdfMagic = []byte("%PDF-")
+
+// Document is the result of ingesting a PDF: the extracted text layer (always
+// populated when a text layer exists) plus, on the optional vision path, one
+// ImageBlock per rendered page. Pages is the page count the parser reported;
+// Truncated is set when Text was capped at MaxDocumentTextBytes.
+type Document struct {
+	Text      string
+	Images    []zeroruntime.ImageBlock
+	Pages     int
+	Truncated bool
+}
+
+// DocumentOptions tunes how a PDF is ingested.
+type DocumentOptions struct {
+	// Vision asks for page rasterization (ImageBlocks) in addition to text, for a
+	// vision-capable model. It is best-effort: when no rasterizer is available the
+	// load degrades to the text layer rather than erroring.
+	Vision bool
+	// MaxPages bounds how many pages the vision path renders. Zero means
+	// defaultMaxRasterPages.
+	MaxPages int
+
+	// disableExternalTools forces the pure-Go path even if poppler is installed.
+	// It exists so tests are deterministic on any host; it is intentionally
+	// unexported and not part of the public surface.
+	disableExternalTools bool
+}
+
+// isPDF reports whether data begins with the PDF magic signature ("%PDF-"). It
+// is the authoritative check: the file extension is only a hint.
+func isPDF(data []byte) bool {
+	return bytes.HasPrefix(data, pdfMagic)
+}
+
+// IsProbablyDocumentPath reports whether a path looks like a document ZERO can
+// ingest (currently: a ".pdf" extension, case-insensitive). It is only a routing
+// hint for input surfaces deciding whether to call LoadDocument vs LoadFile;
+// LoadDocument re-verifies the real content via magic bytes.
+func IsProbablyDocumentPath(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".pdf")
+}
+
+// LoadDocument reads the PDF at path (resolved against workspaceRoot when
+// relative), enforces the per-document size cap, and extracts its text layer.
+// With opts.Vision and an available rasterizer it also renders the first N pages
+// to ImageBlocks. The file is identified by magic bytes, not its extension, so a
+// ".pdf"-named non-PDF is rejected with a clear error. A PDF with no text layer
+// and no rasterization/OCR available returns an explicit "no extractable text"
+// error rather than a silent empty success. Errors are plain (callers wrap them
+// into surface-specific notice text).
+func LoadDocument(path string, workspaceRoot string, opts DocumentOptions) (Document, error) {
+	data, err := readDocumentBytes(path, workspaceRoot)
+	if err != nil {
+		return Document{}, err
+	}
+	if !isPDF(data) {
+		return Document{}, fmt.Errorf("%s is not a PDF (expected a %%PDF- file)", path)
+	}
+
+	useExternal := !opts.disableExternalTools
+
+	// Vision path (optional): render pages to images via poppler when available.
+	// Failures here are non-fatal -- we still return the text layer below.
+	var images []zeroruntime.ImageBlock
+	if opts.Vision && useExternal {
+		if rendered, rerr := rasterizeWithPoppler(data, opts.maxPages()); rerr == nil {
+			images = rendered
+		}
+	}
+
+	// Text path. Prefer poppler's pdftotext when present (it handles more font
+	// encodings); otherwise use the pure-Go extractor. Either way, absence of the
+	// external tool is not an error.
+	text, pages := "", 0
+	if useExternal {
+		if t, ok := extractTextWithPoppler(data); ok {
+			text = t
+		}
+	}
+	if strings.TrimSpace(text) == "" {
+		t, p, terr := extractTextPureGo(data)
+		if terr != nil {
+			// Only surface the pure-Go error when we have nothing else (no poppler
+			// text and no rasterized pages) to offer.
+			if len(images) == 0 {
+				return Document{}, terr
+			}
+		} else {
+			text, pages = t, p
+		}
+	}
+
+	text, truncated := capDocumentText(text)
+
+	// Scanned-PDF guard: no text layer AND no rendered pages means we have nothing
+	// the model can use. Say so explicitly instead of returning empty success.
+	if strings.TrimSpace(text) == "" && len(images) == 0 {
+		return Document{}, fmt.Errorf("%s has no extractable text; OCR is not available (install poppler's pdftotext/pdftoppm for image-only PDFs)", path)
+	}
+
+	return Document{Text: text, Images: images, Pages: pages, Truncated: truncated}, nil
+}
+
+// readDocumentBytes resolves path against workspaceRoot, rejects missing,
+// non-regular, and oversized files (mirroring LoadFile), and returns the raw
+// bytes with a hard bound so an unbounded source can never allocate without
+// limit.
+func readDocumentBytes(path string, workspaceRoot string) ([]byte, error) {
+	resolved := path
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(workspaceRoot, resolved)
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("document file not found: %s", path)
+	}
+	// Reject non-regular files (directories, FIFOs, devices) before os.Open so a
+	// writerless FIFO can never block the read forever -- same guard as LoadFile.
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("document file must be a regular file: %s", path)
+	}
+	if info.Size() > MaxDocumentBytes {
+		return nil, fmt.Errorf("document %s is larger than the 32 MiB limit", path)
+	}
+
+	file, err := os.Open(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open document %s: %w", path, err)
+	}
+	defer file.Close()
+
+	// LimitReader of cap+1: at most one byte past the cap is buffered, so the cap
+	// is the real bound regardless of any stat/read race or a growing file.
+	data, err := io.ReadAll(io.LimitReader(file, MaxDocumentBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read document %s: %w", path, err)
+	}
+	if len(data) > MaxDocumentBytes {
+		return nil, fmt.Errorf("document %s is larger than the 32 MiB limit", path)
+	}
+	return data, nil
+}
+
+// extractTextPureGo extracts the full text layer with the pure-Go parser. The
+// ledongthuc/pdf parser panics (not errors) on some malformed structures, so the
+// whole call is wrapped in a recover: a bad PDF becomes a clean error, never a
+// crash that escapes the package. It returns the joined text and the page count.
+func extractTextPureGo(data []byte) (text string, pages int, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			text, pages = "", 0
+			err = fmt.Errorf("could not parse PDF (malformed or unsupported): %v", rec)
+		}
+	}()
+
+	reader, rerr := pdf.NewReader(bytes.NewReader(data), int64(len(data)))
+	if rerr != nil {
+		return "", 0, fmt.Errorf("could not parse PDF: %w", rerr)
+	}
+	pages = reader.NumPage()
+
+	var buf strings.Builder
+	plain, perr := reader.GetPlainText()
+	if perr != nil {
+		return "", pages, fmt.Errorf("could not extract PDF text: %w", perr)
+	}
+	if _, cerr := io.Copy(&buf, plain); cerr != nil {
+		return "", pages, fmt.Errorf("could not read PDF text: %w", cerr)
+	}
+	return strings.TrimSpace(buf.String()), pages, nil
+}
+
+// capDocumentText truncates text to MaxDocumentTextBytes on a UTF-8 rune
+// boundary and appends documentTruncatedMarker when it had to cut. The second
+// return reports whether truncation happened.
+func capDocumentText(text string) (string, bool) {
+	if len(text) <= MaxDocumentTextBytes {
+		return text, false
+	}
+	cut := MaxDocumentTextBytes
+	// Back up to a rune boundary so we never split a multi-byte character.
+	for cut > 0 && !utf8RuneStart(text[cut]) {
+		cut--
+	}
+	return text[:cut] + documentTruncatedMarker, true
+}
+
+// utf8RuneStart reports whether b can start a UTF-8 rune (i.e. it is not a
+// continuation byte 0b10xxxxxx). Kept local to avoid pulling in unicode/utf8
+// for a single bit test.
+func utf8RuneStart(b byte) bool {
+	return b&0xC0 != 0x80
+}
+
+func (o DocumentOptions) maxPages() int {
+	if o.MaxPages > 0 {
+		return o.MaxPages
+	}
+	return defaultMaxRasterPages
+}
+
+// --- Optional external poppler path -----------------------------------------
+
+// popplerAvailable reports whether a poppler binary is resolvable on PATH.
+func popplerAvailable(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+// extractTextWithPoppler runs `pdftotext - -` (read stdin, write stdout) when
+// pdftotext is on PATH. The bool is false when the tool is absent or failed, so
+// the caller can fall back to the pure-Go extractor. Absence is never an error.
+func extractTextWithPoppler(data []byte) (string, bool) {
+	if !popplerAvailable("pdftotext") {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), popplerTimeout)
+	defer cancel()
+
+	// "-layout" keeps the visual column layout; the trailing "- -" reads the PDF
+	// from stdin and writes UTF-8 text to stdout.
+	cmd := exec.CommandContext(ctx, "pdftotext", "-layout", "-enc", "UTF-8", "-", "-")
+	cmd.Stdin = bytes.NewReader(data)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(stdout.String()), true
+}
+
+// rasterizeWithPoppler renders the first maxPages pages to PNG via pdftoppm and
+// returns them as normalized ImageBlocks (reusing the image allow-list, sniff,
+// and per-image cap). It returns an error when pdftoppm is absent or rendering
+// produced nothing; the caller treats that as "no rasterization available" and
+// keeps the text layer.
+func rasterizeWithPoppler(data []byte, maxPages int) ([]zeroruntime.ImageBlock, error) {
+	if !popplerAvailable("pdftoppm") {
+		return nil, fmt.Errorf("pdftoppm not available")
+	}
+	if maxPages <= 0 {
+		maxPages = defaultMaxRasterPages
+	}
+
+	dir, err := os.MkdirTemp("", "zero-pdf-raster-")
+	if err != nil {
+		return nil, fmt.Errorf("cannot create temp dir for rasterization: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), popplerTimeout)
+	defer cancel()
+
+	prefix := filepath.Join(dir, "page")
+	// -png: PNG output; -r 150: 150 DPI (legible without huge files);
+	// -f 1 / -l N: render only the first N pages so context can't blow up.
+	cmd := exec.CommandContext(ctx, "pdftoppm", "-png", "-r", "150", "-f", "1", "-l", fmt.Sprintf("%d", maxPages), "-", prefix)
+	cmd.Stdin = bytes.NewReader(data)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("pdftoppm failed: %w", err)
+	}
+
+	entries, err := filepath.Glob(prefix + "*.png")
+	if err != nil {
+		return nil, fmt.Errorf("cannot list rendered pages: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("rasterization produced no pages")
+	}
+	// Glob order is lexical; pdftoppm zero-pads page numbers, so a numeric-aware
+	// sort keeps page 10 after page 9 rather than after page 1.
+	sort.Strings(entries)
+
+	images := make([]zeroruntime.ImageBlock, 0, len(entries))
+	for _, name := range entries {
+		if len(images) >= maxPages {
+			break
+		}
+		block, err := loadRenderedPage(name)
+		if err != nil {
+			// Skip a single unreadable page rather than failing the whole render.
+			continue
+		}
+		images = append(images, block)
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("no rendered pages could be loaded")
+	}
+	return images, nil
+}
+
+// loadRenderedPage reads one rendered PNG page, enforces the per-image cap, and
+// normalizes its media type through the same allow-list LoadFile uses, so
+// rasterized pages flow through the existing image pipeline unchanged.
+func loadRenderedPage(name string) (zeroruntime.ImageBlock, error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		return zeroruntime.ImageBlock{}, err
+	}
+	if info.Size() > MaxImageBytes {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("rendered page %s exceeds the per-image limit", filepath.Base(name))
+	}
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return zeroruntime.ImageBlock{}, err
+	}
+	if len(data) > MaxImageBytes {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("rendered page %s exceeds the per-image limit", filepath.Base(name))
+	}
+	sniffLen := len(data)
+	if sniffLen > 512 {
+		sniffLen = 512
+	}
+	mediaType := zeroruntime.NormalizeImageMediaType(http.DetectContentType(data[:sniffLen]))
+	if mediaType == "" {
+		return zeroruntime.ImageBlock{}, fmt.Errorf("rendered page %s has an unsupported image type", filepath.Base(name))
+	}
+	return zeroruntime.ImageBlock{MediaType: mediaType, Data: data}, nil
+}

--- a/internal/imageinput/pdf.go
+++ b/internal/imageinput/pdf.go
@@ -96,6 +96,36 @@ func IsProbablyDocumentPath(path string) bool {
 	return strings.EqualFold(filepath.Ext(path), ".pdf")
 }
 
+// LooksLikeDocumentFile reports whether the file at path is a PDF by content,
+// reading only its leading magic bytes. It lets input surfaces route a real PDF
+// to LoadDocument even when its name lacks a ".pdf" extension, so detection is
+// content-based rather than extension-only. It opens nothing it cannot stat as a
+// regular file and never reads more than the magic prefix; any I/O error (missing
+// file, permission, non-regular) simply reports false and lets the normal path
+// surface a precise error. Relative paths resolve against workspaceRoot.
+func LooksLikeDocumentFile(path string, workspaceRoot string) bool {
+	resolved := path
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(workspaceRoot, resolved)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	file, err := os.Open(resolved)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	header := make([]byte, len(pdfMagic))
+	n, err := io.ReadFull(file, header)
+	if err != nil && n < len(pdfMagic) {
+		return false
+	}
+	return isPDF(header)
+}
+
 // LoadDocument reads the PDF at path (resolved against workspaceRoot when
 // relative), enforces the per-document size cap, and extracts its text layer.
 // With opts.Vision and an available rasterizer it also renders the first N pages
@@ -131,6 +161,10 @@ func LoadDocument(path string, workspaceRoot string, opts DocumentOptions) (Docu
 	if useExternal {
 		if t, ok := extractTextWithPoppler(data); ok {
 			text = t
+			// pdftotext does not report a page count, so derive it from the pure-Go
+			// reader (cheap structural read, no text extraction) to keep
+			// Document.Pages correct regardless of which text path wins.
+			pages = pdfPageCount(data)
 		}
 	}
 	if strings.TrimSpace(text) == "" {
@@ -227,14 +261,39 @@ func extractTextPureGo(data []byte) (text string, pages int, err error) {
 	return strings.TrimSpace(buf.String()), pages, nil
 }
 
+// pdfPageCount returns the page count via the pure-Go reader without extracting
+// any text. It backs Document.Pages on the poppler text path (pdftotext does not
+// report a count). Like extractTextPureGo it recovers from the parser's panics on
+// malformed input and reports 0 rather than crashing -- the page count is
+// informational, so an unreadable structure simply yields 0.
+func pdfPageCount(data []byte) (pages int) {
+	defer func() {
+		if recover() != nil {
+			pages = 0
+		}
+	}()
+	reader, err := pdf.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return 0
+	}
+	return reader.NumPage()
+}
+
 // capDocumentText truncates text to MaxDocumentTextBytes on a UTF-8 rune
 // boundary and appends documentTruncatedMarker when it had to cut. The second
-// return reports whether truncation happened.
+// return reports whether truncation happened. The marker is counted against the
+// cap so the returned string never exceeds MaxDocumentTextBytes.
 func capDocumentText(text string) (string, bool) {
 	if len(text) <= MaxDocumentTextBytes {
 		return text, false
 	}
-	cut := MaxDocumentTextBytes
+	// Reserve room for the marker so the final payload (text + marker) stays at or
+	// under the advertised cap. If the marker alone would not fit, cut to nothing
+	// and return just the marker.
+	cut := MaxDocumentTextBytes - len(documentTruncatedMarker)
+	if cut < 0 {
+		cut = 0
+	}
 	// Back up to a rune boundary so we never split a multi-byte character.
 	for cut > 0 && !utf8RuneStart(text[cut]) {
 		cut--

--- a/internal/imageinput/pdf_test.go
+++ b/internal/imageinput/pdf_test.go
@@ -169,8 +169,8 @@ func TestLoadDocumentTruncatesLongText(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadDocument: %v", err)
 	}
-	if len(doc.Text) > MaxDocumentTextBytes+len(documentTruncatedMarker) {
-		t.Fatalf("text length %d exceeds cap %d", len(doc.Text), MaxDocumentTextBytes)
+	if len(doc.Text) > MaxDocumentTextBytes {
+		t.Fatalf("capped text length %d exceeds cap %d (marker must be counted against the cap)", len(doc.Text), MaxDocumentTextBytes)
 	}
 	if !doc.Truncated {
 		t.Fatal("Truncated should be set when extracted text is capped")
@@ -279,6 +279,77 @@ func TestLoadDocumentVisionWithoutRasterizerUsesText(t *testing.T) {
 	}
 	if !strings.Contains(doc.Text, want) {
 		t.Fatalf("vision-without-raster should keep text, got %q", doc.Text)
+	}
+}
+
+// capDocumentText must keep the final payload (text + marker) at or under the
+// advertised cap: the marker is counted against MaxDocumentTextBytes, not added
+// on top of it.
+func TestCapDocumentTextRespectsCap(t *testing.T) {
+	// Text comfortably over the cap so truncation triggers.
+	over := strings.Repeat("a", MaxDocumentTextBytes+1024)
+	got, truncated := capDocumentText(over)
+	if !truncated {
+		t.Fatal("expected truncation for over-cap text")
+	}
+	if len(got) > MaxDocumentTextBytes {
+		t.Fatalf("capped text length %d exceeds cap %d", len(got), MaxDocumentTextBytes)
+	}
+	if !strings.HasSuffix(got, documentTruncatedMarker) {
+		t.Fatal("capped text should end with the truncation marker")
+	}
+
+	// At-or-under the cap is returned unchanged with no marker.
+	under := strings.Repeat("b", MaxDocumentTextBytes)
+	got, truncated = capDocumentText(under)
+	if truncated {
+		t.Fatal("text exactly at the cap must not be truncated")
+	}
+	if got != under {
+		t.Fatal("at-cap text must be returned unchanged")
+	}
+}
+
+// pdfPageCount must report the real page count from PDF bytes (this is what
+// backs Document.Pages on the poppler text path, where pdftotext gives no count)
+// and must return 0 -- not panic -- on garbage.
+func TestPDFPageCount(t *testing.T) {
+	if got := pdfPageCount(buildMinimalPDF("one page")); got != 1 {
+		t.Fatalf("pdfPageCount = %d, want 1", got)
+	}
+	if got := pdfPageCount([]byte("not a pdf at all")); got != 0 {
+		t.Fatalf("pdfPageCount on garbage = %d, want 0", got)
+	}
+}
+
+// LooksLikeDocumentFile sniffs PDF content by magic bytes, so a real PDF with no
+// ".pdf" extension is still recognized while a non-PDF (even named .pdf) is not.
+func TestLooksLikeDocumentFile(t *testing.T) {
+	root := t.TempDir()
+	// A real PDF named without a .pdf extension.
+	if err := os.WriteFile(filepath.Join(root, "spec"), buildMinimalPDF("hi"), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	// A non-PDF named with a .pdf extension.
+	if err := os.WriteFile(filepath.Join(root, "fake.pdf"), []byte("not a pdf"), 0o644); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	// A directory must not be treated as a document.
+	if err := os.Mkdir(filepath.Join(root, "adir"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if !LooksLikeDocumentFile("spec", root) {
+		t.Fatal("a real PDF without a .pdf extension should be recognized by content")
+	}
+	if LooksLikeDocumentFile("fake.pdf", root) {
+		t.Fatal("a .pdf-named non-PDF must not be recognized as a document")
+	}
+	if LooksLikeDocumentFile("nope", root) {
+		t.Fatal("a missing file must not be recognized as a document")
+	}
+	if LooksLikeDocumentFile("adir", root) {
+		t.Fatal("a directory must not be recognized as a document")
 	}
 }
 

--- a/internal/imageinput/pdf_test.go
+++ b/internal/imageinput/pdf_test.go
@@ -1,0 +1,300 @@
+package imageinput
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// buildMinimalPDF assembles a tiny, single-page PDF whose content stream draws
+// the given text. It computes a real cross-reference table and trailer so a
+// pure-Go PDF parser (ledongthuc/pdf) accepts it. Generating the fixture in-test
+// keeps the repo free of opaque binary blobs while still exercising the real
+// text-extraction path on real PDF bytes.
+func buildMinimalPDF(text string) []byte {
+	var buf bytes.Buffer
+	offsets := make([]int, 0, 8)
+	startObj := func() { offsets = append(offsets, buf.Len()) }
+
+	buf.WriteString("%PDF-1.4\n")
+
+	startObj() // object 1: catalog
+	buf.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+
+	startObj() // object 2: page tree
+	buf.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+
+	startObj() // object 3: page
+	buf.WriteString("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>\nendobj\n")
+
+	content := "BT /F1 24 Tf 72 700 Td (" + text + ") Tj ET"
+	startObj() // object 4: content stream
+	buf.WriteString("4 0 obj\n<< /Length " + strconv.Itoa(len(content)) + " >>\nstream\n")
+	buf.WriteString(content)
+	buf.WriteString("\nendstream\nendobj\n")
+
+	startObj() // object 5: font
+	buf.WriteString("5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+
+	xrefStart := buf.Len()
+	buf.WriteString("xref\n")
+	buf.WriteString("0 " + strconv.Itoa(len(offsets)+1) + "\n")
+	buf.WriteString("0000000000 65535 f \n")
+	for _, off := range offsets {
+		buf.WriteString(fmt.Sprintf("%010d 00000 n \n", off))
+	}
+	buf.WriteString("trailer\n<< /Size " + strconv.Itoa(len(offsets)+1) + " /Root 1 0 R >>\n")
+	buf.WriteString("startxref\n" + strconv.Itoa(xrefStart) + "\n%%EOF\n")
+	return buf.Bytes()
+}
+
+func TestIsPDF(t *testing.T) {
+	if !isPDF(buildMinimalPDF("hi")) {
+		t.Fatal("isPDF should accept real %PDF- bytes")
+	}
+	if !isPDF([]byte("%PDF-1.7\n...")) {
+		t.Fatal("isPDF should accept a bare %PDF- magic prefix")
+	}
+	if isPDF([]byte("not a pdf at all")) {
+		t.Fatal("isPDF should reject non-PDF bytes")
+	}
+	if isPDF(nil) {
+		t.Fatal("isPDF should reject empty input")
+	}
+	if isPDF([]byte("%PDF")) {
+		t.Fatal("isPDF should require the trailing dash of %PDF-")
+	}
+}
+
+func TestLoadDocumentTextExtraction(t *testing.T) {
+	root := t.TempDir()
+	want := "Hello ZERO PDF"
+	if err := os.WriteFile(filepath.Join(root, "doc.pdf"), buildMinimalPDF(want), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+
+	doc, err := LoadDocument("doc.pdf", root, DocumentOptions{})
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+	if !strings.Contains(doc.Text, want) {
+		t.Fatalf("extracted text %q should contain %q", doc.Text, want)
+	}
+	if len(doc.Images) != 0 {
+		t.Fatalf("text-only extraction should not return images, got %d", len(doc.Images))
+	}
+	if doc.Pages != 1 {
+		t.Fatalf("Pages = %d, want 1", doc.Pages)
+	}
+}
+
+// A .pdf-named file that is not actually a PDF must be rejected with a clear
+// error rather than silently treated as a document (extension is never trusted
+// over magic bytes).
+func TestLoadDocumentRejectsFakePDF(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fake.pdf"), []byte("this is plainly not a PDF document"), 0o644); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	_, err := LoadDocument("fake.pdf", root, DocumentOptions{})
+	if err == nil {
+		t.Fatal("expected error for a .pdf-named non-PDF file")
+	}
+	if !strings.Contains(err.Error(), "not a PDF") {
+		t.Fatalf("error %q should explain the file is not a PDF", err.Error())
+	}
+}
+
+func TestLoadDocumentMissing(t *testing.T) {
+	root := t.TempDir()
+	_, err := LoadDocument("nope.pdf", root, DocumentOptions{})
+	if err == nil {
+		t.Fatal("expected error for a missing file")
+	}
+	if !strings.Contains(err.Error(), "nope.pdf") {
+		t.Fatalf("error %q should name the path", err.Error())
+	}
+}
+
+func TestLoadDocumentRejectsNonRegular(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "adir.pdf"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	_, err := LoadDocument("adir.pdf", root, DocumentOptions{})
+	if err == nil {
+		t.Fatal("expected error for a non-regular file")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("error %q should mention regular file", err.Error())
+	}
+}
+
+// The per-document byte cap is enforced before parsing, mirroring the image cap,
+// so an unbounded file never reaches the parser or a provider.
+func TestLoadDocumentOversizeRejected(t *testing.T) {
+	root := t.TempDir()
+	big := make([]byte, MaxDocumentBytes+1)
+	copy(big, []byte("%PDF-1.4\n"))
+	if err := os.WriteFile(filepath.Join(root, "big.pdf"), big, 0o644); err != nil {
+		t.Fatalf("write big: %v", err)
+	}
+	_, err := LoadDocument("big.pdf", root, DocumentOptions{})
+	if err == nil {
+		t.Fatal("expected error for an oversize document")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("error %q should mention the size limit", err.Error())
+	}
+}
+
+// Extracted text longer than the cap is truncated (with a marker) rather than
+// rejected: a large but valid spec/doc should still be partially usable.
+func TestLoadDocumentTruncatesLongText(t *testing.T) {
+	root := t.TempDir()
+	// Many short lines so the *extracted text* (not the file) exceeds the cap.
+	var body strings.Builder
+	line := "The quick brown fox jumps over the lazy dog. "
+	for body.Len() < MaxDocumentTextBytes+4096 {
+		body.WriteString(line)
+	}
+	if err := os.WriteFile(filepath.Join(root, "long.pdf"), buildMinimalPDF(body.String()), 0o644); err != nil {
+		t.Fatalf("write long: %v", err)
+	}
+	doc, err := LoadDocument("long.pdf", root, DocumentOptions{})
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+	if len(doc.Text) > MaxDocumentTextBytes+len(documentTruncatedMarker) {
+		t.Fatalf("text length %d exceeds cap %d", len(doc.Text), MaxDocumentTextBytes)
+	}
+	if !doc.Truncated {
+		t.Fatal("Truncated should be set when extracted text is capped")
+	}
+	if !strings.Contains(doc.Text, documentTruncatedMarker) {
+		t.Fatal("truncated text should carry the truncation marker")
+	}
+}
+
+// A PDF with no extractable text layer and no rasterization/OCR available must
+// surface the explicit "no extractable text" message, never a silent empty
+// success.
+func TestLoadDocumentNoTextNoRaster(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scan.pdf"), buildEmptyTextPDF(), 0o644); err != nil {
+		t.Fatalf("write scan: %v", err)
+	}
+	// Force the pure-Go path with no external rasterizer so the no-text branch is
+	// deterministic regardless of what is installed on the test host.
+	_, err := LoadDocument("scan.pdf", root, DocumentOptions{disableExternalTools: true})
+	if err == nil {
+		t.Fatal("expected an error for a PDF with no extractable text and no raster")
+	}
+	if !strings.Contains(err.Error(), "no extractable text") {
+		t.Fatalf("error %q should explain there is no extractable text", err.Error())
+	}
+	if !strings.Contains(err.Error(), "OCR") {
+		t.Fatalf("error %q should mention OCR is unavailable", err.Error())
+	}
+}
+
+// buildEmptyTextPDF is a valid single-page PDF with an empty content stream:
+// structurally a PDF, but with no text layer to extract.
+func buildEmptyTextPDF() []byte {
+	var buf bytes.Buffer
+	offsets := make([]int, 0, 8)
+	startObj := func() { offsets = append(offsets, buf.Len()) }
+
+	buf.WriteString("%PDF-1.4\n")
+	startObj()
+	buf.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+	startObj()
+	buf.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+	startObj()
+	buf.WriteString("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> /Contents 4 0 R >>\nendobj\n")
+	startObj()
+	buf.WriteString("4 0 obj\n<< /Length 0 >>\nstream\n\nendstream\nendobj\n")
+
+	xrefStart := buf.Len()
+	buf.WriteString("xref\n")
+	buf.WriteString("0 " + strconv.Itoa(len(offsets)+1) + "\n")
+	buf.WriteString("0000000000 65535 f \n")
+	for _, off := range offsets {
+		buf.WriteString(fmt.Sprintf("%010d 00000 n \n", off))
+	}
+	buf.WriteString("trailer\n<< /Size " + strconv.Itoa(len(offsets)+1) + " /Root 1 0 R >>\n")
+	buf.WriteString("startxref\n" + strconv.Itoa(xrefStart) + "\n%%EOF\n")
+	return buf.Bytes()
+}
+
+// Malformed PDF bytes that pass the header check but break the parser must be
+// turned into a clean error, never a panic that escapes the package.
+func TestLoadDocumentMalformedDoesNotPanic(t *testing.T) {
+	root := t.TempDir()
+	bad := []byte("%PDF-1.4\nthis header is valid but the body and xref are garbage\nstartxref\n9\n%%EOF\n")
+	if err := os.WriteFile(filepath.Join(root, "bad.pdf"), bad, 0o644); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+	_, err := LoadDocument("bad.pdf", root, DocumentOptions{disableExternalTools: true})
+	if err == nil {
+		t.Fatal("expected an error for malformed PDF bytes")
+	}
+}
+
+// When the external poppler tools are absent (or disabled), extraction falls
+// back to the pure-Go text path and still succeeds; absence is never an error.
+func TestLoadDocumentFallsBackToPureGo(t *testing.T) {
+	root := t.TempDir()
+	want := "Pure Go fallback text"
+	if err := os.WriteFile(filepath.Join(root, "doc.pdf"), buildMinimalPDF(want), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	doc, err := LoadDocument("doc.pdf", root, DocumentOptions{disableExternalTools: true})
+	if err != nil {
+		t.Fatalf("LoadDocument (pure-Go): %v", err)
+	}
+	if !strings.Contains(doc.Text, want) {
+		t.Fatalf("pure-Go text %q should contain %q", doc.Text, want)
+	}
+}
+
+// Vision-mode extraction without an available rasterizer must not error: it
+// degrades to the text layer (a vision model can still read the text block).
+func TestLoadDocumentVisionWithoutRasterizerUsesText(t *testing.T) {
+	root := t.TempDir()
+	want := "Vision degrade to text"
+	if err := os.WriteFile(filepath.Join(root, "doc.pdf"), buildMinimalPDF(want), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	doc, err := LoadDocument("doc.pdf", root, DocumentOptions{Vision: true, disableExternalTools: true})
+	if err != nil {
+		t.Fatalf("LoadDocument (vision, no raster): %v", err)
+	}
+	if len(doc.Images) != 0 {
+		t.Fatalf("no rasterizer available, expected 0 images, got %d", len(doc.Images))
+	}
+	if !strings.Contains(doc.Text, want) {
+		t.Fatalf("vision-without-raster should keep text, got %q", doc.Text)
+	}
+}
+
+func TestIsProbablyDocumentPath(t *testing.T) {
+	cases := map[string]bool{
+		"report.pdf":      true,
+		"REPORT.PDF":      true,
+		"a/b/spec.Pdf":    true,
+		"image.png":       false,
+		"notes.txt":       false,
+		"noext":           false,
+		"archive.pdf.zip": false,
+	}
+	for path, want := range cases {
+		if got := IsProbablyDocumentPath(path); got != want {
+			t.Fatalf("IsProbablyDocumentPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -117,7 +117,7 @@ var commandDefinitions = []commandDefinition{
 		name:        "/image",
 		usage:       "/image <path> | clear",
 		group:       commandGroupSession,
-		description: "Attach a local image to the next message (vision models). /image clear removes pending attachments.",
+		description: "Attach a local image (vision models) or PDF (text layer for any model) to the next message. /image clear removes pending attachments.",
 		kind:        commandImage,
 	},
 	{

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -43,8 +43,11 @@ func (m model) handleImageCommand(arg string) model {
 	}
 
 	// A PDF carries a text layer every model can read, so it is not gated on
-	// vision the way a raw image is; the optional rasterized pages are.
-	if imageinput.IsProbablyDocumentPath(trimmed) {
+	// vision the way a raw image is; the optional rasterized pages are. Route by
+	// the ".pdf" hint OR a content sniff so a real PDF whose name lacks the
+	// extension still reaches the document path rather than the vision-only image
+	// path. The cheap header sniff runs before the vision gate.
+	if imageinput.IsProbablyDocumentPath(trimmed) || imageinput.LooksLikeDocumentFile(trimmed, m.cwd) {
 		return m.handleDocumentAttach(trimmed)
 	}
 

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -25,18 +26,26 @@ func modelSupportsVisionTUI(modelName string) bool {
 }
 
 // handleImageCommand processes "/image <path>" and "/image clear". A bare
-// "/image" prints usage. Attaching to a non-vision model is refused inline (the
-// active model can be checked synchronously). Attachment failures (missing file,
+// "/image" prints usage. PDFs are routed to the document path (text layer always
+// attaches; pages rasterize to images only for vision models with a rasterizer).
+// Image files attach only to vision models. Attachment failures (missing file,
 // unsupported type, oversize) surface as an inline notice and attach nothing.
 func (m model) handleImageCommand(arg string) model {
 	trimmed := strings.TrimSpace(arg)
 	switch {
 	case trimmed == "":
-		return m.appendImageNotice("Usage: /image <path>  (or /image clear)")
+		return m.appendImageNotice("Usage: /image <path>  (image or PDF; or /image clear)")
 	case strings.EqualFold(trimmed, "clear"):
 		m.pendingImages = nil
 		m.pendingImageLabels = nil
-		return m.appendImageNotice("Cleared pending image attachments.")
+		m.pendingDocuments = nil
+		return m.appendImageNotice("Cleared pending attachments.")
+	}
+
+	// A PDF carries a text layer every model can read, so it is not gated on
+	// vision the way a raw image is; the optional rasterized pages are.
+	if imageinput.IsProbablyDocumentPath(trimmed) {
+		return m.handleDocumentAttach(trimmed)
 	}
 
 	if !modelSupportsVisionTUI(m.modelName) {
@@ -57,6 +66,67 @@ func (m model) handleImageCommand(arg string) model {
 	return m.appendImageNotice("Attached " + filepath.Base(trimmed) + " (" + block.MediaType + ").")
 }
 
+// pendingDocument is a PDF staged by /image for the next user turn: its extracted
+// text layer (prepended to the prompt at submit time) and a display label.
+type pendingDocument struct {
+	label string
+	text  string
+}
+
+// handleDocumentAttach loads a PDF through imageinput.LoadDocument. The text
+// layer is staged for every model; when the active model supports vision and a
+// rasterizer is available, the rendered pages are staged through the existing
+// pending-image pipeline too. A scanned PDF with no text (and no rasterizer)
+// surfaces LoadDocument's explicit "no extractable text" notice and attaches
+// nothing.
+func (m model) handleDocumentAttach(path string) model {
+	doc, err := imageinput.LoadDocument(path, m.cwd, imageinput.DocumentOptions{
+		Vision: modelSupportsVisionTUI(m.modelName),
+	})
+	if err != nil {
+		return m.appendImageNotice(err.Error())
+	}
+
+	label := filepath.Base(path)
+	parts := make([]string, 0, 2)
+	if strings.TrimSpace(doc.Text) != "" {
+		m.pendingDocuments = append(m.pendingDocuments, pendingDocument{label: label, text: doc.Text})
+		summary := "text"
+		if doc.Truncated {
+			summary = "text, truncated at the size limit"
+		}
+		parts = append(parts, summary)
+	}
+	for _, block := range doc.Images {
+		m.pendingImages = append(m.pendingImages, block)
+		m.pendingImageLabels = append(m.pendingImageLabels, label)
+	}
+	if len(doc.Images) > 0 {
+		parts = append(parts, fmt.Sprintf("%d page image(s)", len(doc.Images)))
+	}
+
+	return m.appendImageNotice("Attached " + label + " (" + strings.Join(parts, ", ") + ").")
+}
+
+// consumePendingDocuments returns the staged document text formatted as a prompt
+// preamble and clears the pending documents. The preamble names each document so
+// the model can attribute the text; an empty result means nothing was staged.
+func (m *model) consumePendingDocuments() string {
+	if len(m.pendingDocuments) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, doc := range m.pendingDocuments {
+		b.WriteString("Attached document: ")
+		b.WriteString(doc.label)
+		b.WriteString("\n")
+		b.WriteString(doc.text)
+		b.WriteString("\n\n")
+	}
+	m.pendingDocuments = nil
+	return b.String()
+}
+
 func (m model) appendImageNotice(text string) model {
 	return m.appendSystemNotice(text)
 }
@@ -71,6 +141,22 @@ func renderImageChips(labels []string) string {
 	chips := make([]string, 0, len(labels))
 	for _, label := range labels {
 		chips = append(chips, "[img: "+label+"]")
+	}
+	return strings.Join(chips, " ")
+}
+
+// renderAttachmentChips builds the pending-attachment row from both staged
+// images and staged documents, e.g. "[img: a.png] [doc: spec.pdf]". Returns ""
+// when nothing is staged. Document chips are de-duplicated by label so a PDF
+// that produced both a text block and several page images shows one "[doc: …]"
+// rather than one per page (its page images already show as "[img: …]").
+func renderAttachmentChips(imageLabels []string, docs []pendingDocument) string {
+	chips := make([]string, 0, len(imageLabels)+len(docs))
+	for _, label := range imageLabels {
+		chips = append(chips, "[img: "+label+"]")
+	}
+	for _, doc := range docs {
+		chips = append(chips, "[doc: "+doc.label+"]")
 	}
 	return strings.Join(chips, " ")
 }

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -1,9 +1,12 @@
 package tui
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -256,5 +259,200 @@ func TestSubmitDropsImagesWhenModelSwitchedToNonVision(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected captureRunImages to be invoked (with no images)")
+	}
+}
+
+// writeTestPDF writes a tiny single-page PDF whose text layer is the given
+// string and returns its path. It mirrors the in-package fixture builder so the
+// TUI test exercises the real LoadDocument path on real PDF bytes.
+func writeTestPDF(t *testing.T, dir, name, text string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	offsets := make([]int, 0, 8)
+	startObj := func() { offsets = append(offsets, buf.Len()) }
+
+	buf.WriteString("%PDF-1.4\n")
+	startObj()
+	buf.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+	startObj()
+	buf.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+	startObj()
+	buf.WriteString("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>\nendobj\n")
+	content := "BT /F1 24 Tf 72 700 Td (" + text + ") Tj ET"
+	startObj()
+	buf.WriteString("4 0 obj\n<< /Length " + strconv.Itoa(len(content)) + " >>\nstream\n")
+	buf.WriteString(content)
+	buf.WriteString("\nendstream\nendobj\n")
+	startObj()
+	buf.WriteString("5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n")
+
+	xrefStart := buf.Len()
+	buf.WriteString("xref\n0 " + strconv.Itoa(len(offsets)+1) + "\n0000000000 65535 f \n")
+	for _, off := range offsets {
+		buf.WriteString(fmt.Sprintf("%010d 00000 n \n", off))
+	}
+	buf.WriteString("trailer\n<< /Size " + strconv.Itoa(len(offsets)+1) + " /Root 1 0 R >>\nstartxref\n" + strconv.Itoa(xrefStart) + "\n%%EOF\n")
+
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write pdf: %v", err)
+	}
+	return path
+}
+
+// A PDF carries a text layer every model can read, so /image <file.pdf> stages a
+// pending document even on a non-vision model -- unlike a raw image, which is
+// refused. No page images are staged without a rasterizer.
+func TestImageCommandAttachesPDFTextOnNonVisionModel(t *testing.T) {
+	root := t.TempDir()
+	writeTestPDF(t, root, "spec.pdf", "Design spec body text")
+
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "totally-unknown-custom"})
+	m.input.SetValue("/image spec.pdf")
+	updated, _ := m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingDocuments) != 1 {
+		t.Fatalf("expected 1 pending document, got %d", len(next.pendingDocuments))
+	}
+	if next.pendingDocuments[0].label != "spec.pdf" {
+		t.Fatalf("document label = %q, want spec.pdf", next.pendingDocuments[0].label)
+	}
+	if !strings.Contains(next.pendingDocuments[0].text, "Design spec body text") {
+		t.Fatalf("document text %q should contain the body", next.pendingDocuments[0].text)
+	}
+	if len(next.pendingImages) != 0 {
+		t.Fatalf("no rasterizer: expected 0 page images, got %d", len(next.pendingImages))
+	}
+	if notice := lastTranscriptText(next); !strings.Contains(notice, "spec.pdf") {
+		t.Fatalf("expected an attach notice naming the PDF, got %q", notice)
+	}
+}
+
+// A .pdf-named file that is not a real PDF is rejected with the explicit
+// not-a-PDF notice and stages nothing.
+func TestImageCommandRejectsFakePDF(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "fake.pdf"), []byte("definitely not a pdf"), 0o644); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "gpt-4.1"})
+	m.input.SetValue("/image fake.pdf")
+	updated, _ := m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingDocuments) != 0 || len(next.pendingImages) != 0 {
+		t.Fatal("a fake PDF must stage nothing")
+	}
+	if notice := lastTranscriptText(next); !strings.Contains(notice, "not a PDF") {
+		t.Fatalf("expected a not-a-PDF notice, got %q", notice)
+	}
+}
+
+// /image clear removes staged documents as well as images.
+func TestImageCommandClearAlsoClearsDocuments(t *testing.T) {
+	root := t.TempDir()
+	writeTestPDF(t, root, "spec.pdf", "some text")
+
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "gpt-4.1"})
+	m.input.SetValue("/image spec.pdf")
+	updated, _ := m.handleSubmit()
+	m = updated.(model)
+	if len(m.pendingDocuments) != 1 {
+		t.Fatalf("setup: expected 1 staged document, got %d", len(m.pendingDocuments))
+	}
+
+	m.input.SetValue("/image clear")
+	updated, _ = m.handleSubmit()
+	next := updated.(model)
+	if len(next.pendingDocuments) != 0 {
+		t.Fatalf("clear must drop staged documents, got %d", len(next.pendingDocuments))
+	}
+}
+
+// The chip row shows a "[doc: …]" entry for staged documents.
+func TestTranscriptViewShowsDocumentChips(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4.1"})
+	m.width = 100
+	m.height = 30
+	m.pendingDocuments = []pendingDocument{{label: "spec.pdf", text: "body"}}
+
+	view := m.transcriptView()
+	if !strings.Contains(view, "spec.pdf") {
+		t.Fatalf("transcript view should show the document chip, got:\n%s", view)
+	}
+}
+
+// On submit, the staged document text is prepended to the prompt the agent
+// receives (so the model can read it), and the pending documents are cleared.
+func TestSubmitPrependsDocumentTextThenClears(t *testing.T) {
+	root := t.TempDir()
+	writeTestPDF(t, root, "spec.pdf", "Top secret design notes")
+
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventText, Content: "ok"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		Cwd:          root,
+		ProviderName: "openai",
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
+	})
+	m.agentOptions.OnText = func(string) {}
+
+	m.input.SetValue("/image spec.pdf")
+	updated, _ := m.handleSubmit()
+	m = updated.(model)
+	if len(m.pendingDocuments) != 1 {
+		t.Fatalf("setup: expected 1 staged document, got %d", len(m.pendingDocuments))
+	}
+
+	m.input.SetValue("summarize the attached doc")
+	updated, cmd := m.handleSubmit()
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected a prompt submit to start a run")
+	}
+	if len(next.pendingDocuments) != 0 {
+		t.Fatalf("submit must clear staged documents, got %d", len(next.pendingDocuments))
+	}
+
+	updated, _ = next.Update(execCmd(cmd))
+	_ = updated.(model)
+
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one provider request, got %d", len(provider.requests))
+	}
+	// The last message is the user turn; it must carry both the document text and
+	// the user's question.
+	msgs := provider.requests[0].Messages
+	last := msgs[len(msgs)-1]
+	if last.Role != zeroruntime.MessageRoleUser {
+		t.Fatalf("last message role = %v, want user", last.Role)
+	}
+	if !strings.Contains(last.Content, "Top secret design notes") {
+		t.Fatalf("agent prompt should contain the document text, got:\n%s", last.Content)
+	}
+	if !strings.Contains(last.Content, "summarize the attached doc") {
+		t.Fatalf("agent prompt should contain the user question, got:\n%s", last.Content)
+	}
+	if !strings.Contains(last.Content, "spec.pdf") {
+		t.Fatalf("agent prompt should name the attached document, got:\n%s", last.Content)
+	}
+}
+
+func TestRenderAttachmentChips(t *testing.T) {
+	if got := renderAttachmentChips(nil, nil); got != "" {
+		t.Fatalf("empty attachments should render no chips, got %q", got)
+	}
+	got := renderAttachmentChips([]string{"a.png"}, []pendingDocument{{label: "spec.pdf"}})
+	if !strings.Contains(got, "[img: a.png]") {
+		t.Fatalf("chip row %q should include the image", got)
+	}
+	if !strings.Contains(got, "[doc: spec.pdf]") {
+		t.Fatalf("chip row %q should include the document", got)
 	}
 }

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -329,6 +329,29 @@ func TestImageCommandAttachesPDFTextOnNonVisionModel(t *testing.T) {
 	}
 }
 
+// A real PDF whose path lacks a ".pdf" extension is still routed to the document
+// path by a content sniff (not the extension), so its text layer attaches even on
+// a non-vision model instead of being refused as a non-image.
+func TestImageCommandAttachesExtensionlessPDFByContent(t *testing.T) {
+	root := t.TempDir()
+	writeTestPDF(t, root, "spec", "Extensionless PDF body text")
+
+	m := newModel(context.Background(), Options{Cwd: root, ModelName: "totally-unknown-custom"})
+	m.input.SetValue("/image spec")
+	updated, _ := m.handleSubmit()
+	next := updated.(model)
+
+	if len(next.pendingDocuments) != 1 {
+		t.Fatalf("expected 1 pending document from a content-sniffed PDF, got %d", len(next.pendingDocuments))
+	}
+	if !strings.Contains(next.pendingDocuments[0].text, "Extensionless PDF body text") {
+		t.Fatalf("document text %q should contain the body", next.pendingDocuments[0].text)
+	}
+	if notice := lastTranscriptText(next); strings.Contains(notice, "does not support image input") {
+		t.Fatalf("a real PDF must not be refused at the vision gate, got %q", notice)
+	}
+}
+
 // A .pdf-named file that is not a real PDF is rejected with the explicit
 // not-a-PDF notice and stages nothing.
 func TestImageCommandRejectsFakePDF(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -162,6 +162,11 @@ type model struct {
 	pendingImages      []zeroruntime.ImageBlock
 	pendingImageLabels []string
 
+	// pendingDocuments holds PDF text layers staged by /image for the next user
+	// turn; the text is prepended to the prompt as a preamble at submit time and
+	// the slice is cleared (or by /image clear). nil = no documents staged.
+	pendingDocuments []pendingDocument
+
 	// captureRunImages, when set, is invoked with the images a run is launched
 	// with. Nil in production; used by tests to assert image threading without a
 	// real provider round-trip.
@@ -934,7 +939,7 @@ func (m model) transcriptView() string {
 func (m model) footerView(width int) string {
 	var footer strings.Builder
 	footer.WriteString("\n")
-	if chips := renderImageChips(m.pendingImageLabels); chips != "" {
+	if chips := renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments); chips != "" {
 		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
 		footer.WriteString("\n")
 	}
@@ -1583,6 +1588,12 @@ func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
 			text: "No provider configured.",
 		})
 		return m, nil
+	}
+	// Prepend any staged PDF document text as a model-facing preamble. The
+	// visible transcript above keeps the user's clean prompt; the agent (and the
+	// recorded session, for resume fidelity) sees the document text first.
+	if preamble := m.consumePendingDocuments(); preamble != "" {
+		prompt = preamble + prompt
 	}
 	var err error
 	m, err = m.ensureActiveSession(prompt)


### PR DESCRIPTION
## What this builds

Stage 12 of the wedge: PDF ingestion in `internal/imageinput`. ZERO already accepts image input; specs, design docs, and tickets routinely arrive as PDF, so this adds the ability to attach a PDF the same way an image is attached. It extracts the text layer and, for vision models, optionally rasterizes pages to images.

## Dependency posture (the important decision)

ZERO's promise is a single static Go binary with no runtime deps and clean cross-compilation, so:

- **Default = pure-Go text extraction** via `github.com/ledongthuc/pdf` (BSD-licensed, no CGO, no transitive deps). Text-only, but keeps the static binary intact.
- **Optional external tools** — poppler's `pdftotext` / `pdftoppm` are used for richer extraction and page rasterization **only when present on PATH**, the same "external tool the user may have" posture as the LSP language servers. When absent, extraction silently degrades to the pure-Go text path; absence is never an error.
- **No CGO anywhere.** Confirmed `CGO_ENABLED=0` cross-compiles for linux/amd64, windows/arm64, and darwin/arm64.

## Behavior

- **Detection by magic bytes** (`%PDF-`), never by extension alone — a `.pdf`-named non-PDF is rejected with a clear error.
- **Caps:** a 32 MiB raw-file cap (rejects, bounded read so an unbounded source can't allocate without limit) and a 256 KiB extracted-text cap (truncates with a marker on a UTF-8 boundary, so a large-but-valid doc stays partially usable).
- **Malformed-input safety:** the pure-Go parser can panic on broken structures, so extraction is wrapped in a `recover` that turns a bad PDF into a clean error rather than a crash.
- **Scanned PDFs:** no text layer and no rasterizer returns an explicit `"no extractable text; OCR is not available"` error rather than silent empty success.
- **Vision path:** with a vision model and `pdftoppm` available, the first N pages (default 10, bounded so context can't blow up) render to PNG and flow through the existing image pipeline (`NormalizeImageMediaType`, the per-image cap, the allow-list). Without a rasterizer it degrades to the text layer.

## Integration point

`/image <file.pdf>` is routed to the document path (following the existing `/image` slash-command wiring). The text layer attaches for **any** model (it is just text) and is prepended to the next prompt as a labeled preamble; rendered pages attach as images for vision models via the existing pending-image pipeline. The pending-attachment chip row shows `[doc: …]` entries and `/image clear` clears staged documents too.

## Files

- `internal/imageinput/pdf.go` (new) — `LoadDocument`, `isPDF`, `IsProbablyDocumentPath`, pure-Go + optional-poppler extraction and rasterization.
- `internal/imageinput/pdf_test.go` (new) — magic-byte detection, text extraction on a generated fixture, both size caps, the no-text/no-raster message, malformed-input safety, and pure-Go fallback.
- `internal/tui/image_attach.go`, `internal/tui/commands.go`, `internal/tui/model.go` — the `/image` document-attach integration (staging, prompt preamble, chips, clear).
- `internal/tui/image_attach_test.go` — attach on non-vision model, fake-PDF rejection, clear, chip rendering, and a submit test asserting the document text reaches the agent prompt alongside the user question.
- `go.mod` / `go.sum` — the single pure-Go dependency (no transitive deps).

`internal/imageinput/imageinput.go` was intentionally **not** modified: `LoadDocument` is a sibling entrypoint and routing happens at the `/image` layer, which is cleaner than overloading `LoadFile`.

## How it was tested

- `go build ./...`, `go test ./...`, and `gofmt -l` over the changed dirs are all clean; `go vet` and `go test -race ./internal/imageinput/` pass.
- `CGO_ENABLED=0` cross-compile verified for three OS/arch targets.
- Fixtures are generated in-test (a minimal valid PDF with a real xref table) rather than committed as opaque binaries.

## Deferred (out of scope)

- OCR for image-only/scanned PDFs (the explicit no-text message points at poppler).
- Wiring PDFs into the CLI `--image` flag (named for images; a separate document flag + exec prompt-prepending would be a broader change than the `/image` slash-command scope this stage targets).
- A known limitation of the pure-Go library: on certain malformed dictionaries it writes a stray `DEBUG:` line to stdout before the (recovered) panic; this is inherent to the upstream library and only fires on malformed input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `/image` now accepts PDFs (by content or extension); extracted text is staged and prepended to prompts.
  * Vision-enabled flows may render and attach PDF page images when available; `/image clear` clears both images and documents.
  * Large PDFs are truncated with a marker when needed; invalid or non-PDF uploads are rejected with notice.

* **Tests**
  * Added extensive tests for PDF detection, extraction, truncation, attachment rendering, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->