### PR TITLE
wedge stage 10: distribution (skill/plugin install, tools make)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -45,6 +45,8 @@ type appDeps struct {
 	loadPlugins          func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks            func(hooks.LoadOptions) (hooks.LoadResult, error)
 	skillsDir            func() string
+	pluginsDir           func() string
+	toolsDir             func() string
 	newMCPStore          func() (*mcp.PermissionStore, error)
 	newMCPTokenStore     func() (*mcp.TokenStore, error)
 	newSandboxStore      func() (*sandbox.GrantStore, error)
@@ -111,6 +113,10 @@ func defaultAppDeps() appDeps {
 		skillsDir: func() string {
 			return skills.DefaultDir(nil)
 		},
+		pluginsDir: defaultUserPluginsDir,
+		// Scaffolded tools are plugins, so the toolbox dir is the user plugins root:
+		// after activation a `tools make` skeleton is discovered like any plugin.
+		toolsDir: defaultUserPluginsDir,
 		newMCPStore: func() (*mcp.PermissionStore, error) {
 			return mcp.NewPermissionStore(mcp.StoreOptions{})
 		},
@@ -140,6 +146,24 @@ func defaultAppDeps() appDeps {
 
 func userAgent() string {
 	return "zero/" + version
+}
+
+// defaultUserPluginsDir resolves the user-scoped plugins root
+// ($XDG_CONFIG_HOME/zero/plugins) used as the install target for `plugin add`
+// and the toolbox for `tools make`. It is the SourceUser root from
+// plugins.ResolveRoots; an empty string is returned only if it cannot be
+// resolved, which the command layer surfaces as an error.
+func defaultUserPluginsDir() string {
+	roots, err := plugins.ResolveRoots(plugins.ResolveRootOptions{})
+	if err != nil {
+		return ""
+	}
+	for _, root := range roots {
+		if root.Source == plugins.SourceUser {
+			return root.Path
+		}
+	}
+	return ""
 }
 
 func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) (exitCode int) {
@@ -241,6 +265,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runPlugins(args[1:], stdout, stderr, deps)
 	case "skills", "skill":
 		return runSkills(args[1:], stdout, stderr, deps)
+	case "tools", "tool":
+		return runTools(args[1:], stdout, stderr, deps)
 	case "hooks":
 		return runHooks(args[1:], stdout, stderr, deps)
 	case "mcp":
@@ -310,6 +336,12 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.skillsDir == nil {
 		deps.skillsDir = defaults.skillsDir
+	}
+	if deps.pluginsDir == nil {
+		deps.pluginsDir = defaults.pluginsDir
+	}
+	if deps.toolsDir == nil {
+		deps.toolsDir = defaults.toolsDir
 	}
 	if deps.newMCPStore == nil {
 		deps.newMCPStore = defaults.newMCPStore
@@ -566,8 +598,9 @@ Commands:
   sessions   Inspect local Zero session lineage
   spec       Review and approve saved spec-mode drafts
   specialist Manage local Zero specialist profiles
-  plugins    Inspect local Zero plugin manifests
-  skills     Inspect local Zero skills
+  plugins    Inspect, install, and remove local Zero plugins
+  skills     Inspect, install, and remove local Zero skills
+  tools      Scaffold and list local Zero plugin-tools
   hooks      Inspect Zero hook configuration
   mcp        Manage MCP backend settings
   sandbox    Inspect sandbox policy and persistent grants

--- a/internal/cli/distribution.go
+++ b/internal/cli/distribution.go
@@ -446,9 +446,7 @@ func formatToolboxList(items []toolboxItem, diagnostics []plugins.Diagnostic, di
 			lines = append(lines, fmt.Sprintf("    command: %s [%s]", item.Command, item.Permission))
 		}
 	}
-	for _, line := range formatToolboxDiagnostics(diagnostics) {
-		lines = append(lines, line)
-	}
+	lines = append(lines, formatToolboxDiagnostics(diagnostics)...)
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/cli/distribution.go
+++ b/internal/cli/distribution.go
@@ -146,7 +146,7 @@ func runSkillInfo(args []string, dir string, stdout io.Writer, stderr io.Writer)
 }
 
 func runSkillRemove(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
-	name, _, help, err := parseNameCommandArgs(args, "skill remove")
+	name, asJSON, help, err := parseNameCommandArgs(args, "skill remove")
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -155,6 +155,9 @@ func runSkillRemove(args []string, dir string, stdout io.Writer, stderr io.Write
 			return exitCrash
 		}
 		return exitSuccess
+	}
+	if asJSON {
+		return writeExecUsageError(stderr, "skill remove does not support --json")
 	}
 	if name == "" {
 		return writeExecUsageError(stderr, "usage: zero skill remove <name>")
@@ -223,7 +226,7 @@ func runPluginAdd(args []string, dir string, stdout io.Writer, stderr io.Writer)
 }
 
 func runPluginRemove(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
-	id, _, help, err := parseNameCommandArgs(args, "plugin remove")
+	id, asJSON, help, err := parseNameCommandArgs(args, "plugin remove")
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
 	}
@@ -232,6 +235,9 @@ func runPluginRemove(args []string, dir string, stdout io.Writer, stderr io.Writ
 			return exitCrash
 		}
 		return exitSuccess
+	}
+	if asJSON {
+		return writeExecUsageError(stderr, "plugin remove does not support --json")
 	}
 	if id == "" {
 		return writeExecUsageError(stderr, "usage: zero plugin remove <id>")
@@ -339,7 +345,7 @@ func runToolsMake(args []string, dir string, stdout io.Writer, stderr io.Writer)
 		"",
 		"Next steps:",
 		"  1. Implement the TODO in the entry script.",
-		"  2. Run `zero plugins list` to confirm it loads.",
+		"  2. Run `zero tools list` to confirm it loads.",
 		"  3. The tool activates through the normal permission flow.",
 	}
 	if _, err := fmt.Fprintln(stdout, redaction.RedactString(strings.Join(lines, "\n"), redaction.Options{})); err != nil {
@@ -376,14 +382,15 @@ func runToolsList(args []string, dir string, stdout io.Writer, stderr io.Writer)
 	items := toolboxItems(result.Plugins)
 	if asJSON {
 		payload := struct {
-			Tools []toolboxItem `json:"tools"`
-		}{Tools: items}
+			Tools       []toolboxItem        `json:"tools"`
+			Diagnostics []plugins.Diagnostic `json:"diagnostics"`
+		}{Tools: items, Diagnostics: result.Diagnostics}
 		if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
 			return exitCrash
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatToolboxList(items, dir), redaction.Options{})); err != nil {
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatToolboxList(items, result.Diagnostics, dir), redaction.Options{})); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -424,20 +431,40 @@ func toolboxItems(loaded []plugins.LoadedPlugin) []toolboxItem {
 	return items
 }
 
-func formatToolboxList(items []toolboxItem, dir string) string {
+func formatToolboxList(items []toolboxItem, diagnostics []plugins.Diagnostic, dir string) string {
+	lines := []string{}
 	if len(items) == 0 {
-		return fmt.Sprintf("No Zero plugin-tools found in %s.", dir)
-	}
-	lines := []string{"Zero Tools:"}
-	for _, item := range items {
-		line := "  " + item.Name + " (" + item.Plugin + ")"
-		if item.Description != "" {
-			line += " - " + item.Description
+		lines = append(lines, fmt.Sprintf("No Zero plugin-tools found in %s.", dir))
+	} else {
+		lines = append(lines, "Zero Tools:")
+		for _, item := range items {
+			line := "  " + item.Name + " (" + item.Plugin + ")"
+			if item.Description != "" {
+				line += " - " + item.Description
+			}
+			lines = append(lines, line)
+			lines = append(lines, fmt.Sprintf("    command: %s [%s]", item.Command, item.Permission))
 		}
+	}
+	for _, line := range formatToolboxDiagnostics(diagnostics) {
 		lines = append(lines, line)
-		lines = append(lines, fmt.Sprintf("    command: %s [%s]", item.Command, item.Permission))
 	}
 	return strings.Join(lines, "\n")
+}
+
+// formatToolboxDiagnostics renders loader diagnostics the same way the plugins
+// listing does, so a broken toolbox plugin surfaces a warning instead of
+// silently vanishing from the listing.
+func formatToolboxDiagnostics(diagnostics []plugins.Diagnostic) []string {
+	if len(diagnostics) == 0 {
+		return nil
+	}
+	lines := []string{"Tool diagnostics:"}
+	for _, diagnostic := range diagnostics {
+		line := fmt.Sprintf("  [%s] %s", diagnostic.Kind, diagnostic.Message)
+		lines = append(lines, line)
+	}
+	return lines
 }
 
 // parseNameCommandArgs parses a single positional name plus an optional --json

--- a/internal/cli/distribution.go
+++ b/internal/cli/distribution.go
@@ -1,0 +1,580 @@
+package cli
+
+// Distribution command handlers: `zero skill {add,info,remove}`,
+// `zero plugin {add,remove}`, and `zero tools {make,list}`. These wire the
+// install/scaffold logic in internal/skills, internal/plugins, and
+// internal/tools into the CLI. List for skills/plugins reuses the existing
+// listing handlers (runSkillsList / runPlugins list).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/skills"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// distributionAddOptions are the flags shared by `skill add` / `plugin add`.
+type distributionAddOptions struct {
+	force bool
+	json  bool
+}
+
+// parseDistributionAddArgs splits a positional source from the add flags.
+func parseDistributionAddArgs(args []string, label string) (string, distributionAddOptions, bool, error) {
+	options := distributionAddOptions{}
+	source := ""
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return "", options, true, nil
+		case "--force", "-f":
+			options.force = true
+		case "--json":
+			options.json = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return "", options, false, execUsageError{fmt.Sprintf("unknown %s add flag %q", label, arg)}
+			}
+			if source != "" {
+				return "", options, false, execUsageError{fmt.Sprintf("%s add takes a single source (git URL or path)", label)}
+			}
+			source = arg
+		}
+	}
+	return source, options, false, nil
+}
+
+// --- skill add / info / remove ---
+
+func runSkillAdd(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	source, options, help, err := parseDistributionAddArgs(args, "skill")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSkillAddHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if source == "" {
+		return writeExecUsageError(stderr, "usage: zero skill add <git-url|path> [--force] [--json]")
+	}
+	if dir == "" {
+		return writeAppError(stderr, "could not resolve the skills directory", exitCrash)
+	}
+
+	result, err := skills.Install(context.Background(), skills.InstallOptions{
+		Source: source,
+		Dir:    dir,
+		Force:  options.force,
+	})
+	if err != nil {
+		if errors.Is(err, skills.ErrNameClash) {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitUsage)
+		}
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(result, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	lines := []string{}
+	if result.Updated {
+		lines = append(lines, fmt.Sprintf("Updated skill %q.", result.Name))
+		lines = append(lines, fmt.Sprintf("  hash: %s -> %s", shortHash(result.PreviousHash), shortHash(result.Hash)))
+	} else {
+		lines = append(lines, fmt.Sprintf("Installed skill %q.", result.Name))
+		lines = append(lines, "  hash: "+result.Hash)
+	}
+	lines = append(lines, "  source: "+result.Source)
+	lines = append(lines, "  path: "+result.Path)
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(strings.Join(lines, "\n"), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSkillInfo(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	name, asJSON, help, err := parseNameCommandArgs(args, "skill info")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSkillInfoHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if name == "" {
+		return writeExecUsageError(stderr, "usage: zero skill info <name> [--json]")
+	}
+	info, ok := skills.Info(dir, name)
+	if !ok {
+		return writeAppError(stderr, fmt.Sprintf("skill %q not found", name), exitUsage)
+	}
+	if asJSON {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(info, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	lines := []string{info.Skill.Name}
+	if info.Skill.Description != "" {
+		lines = append(lines, "  "+info.Skill.Description)
+	}
+	if info.Source != "" {
+		lines = append(lines, "  source: "+info.Source)
+	}
+	if info.Hash != "" {
+		lines = append(lines, "  hash: "+info.Hash)
+	}
+	lines = append(lines, "  path: "+info.Skill.Path)
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(strings.Join(lines, "\n"), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runSkillRemove(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	name, _, help, err := parseNameCommandArgs(args, "skill remove")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSkillRemoveHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if name == "" {
+		return writeExecUsageError(stderr, "usage: zero skill remove <name>")
+	}
+	if err := skills.Remove(dir, name); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitUsage)
+	}
+	if _, err := fmt.Fprintf(stdout, "Removed skill %q.\n", name); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// --- plugin add / remove ---
+
+func runPluginAdd(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	source, options, help, err := parseDistributionAddArgs(args, "plugin")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writePluginAddHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if source == "" {
+		return writeExecUsageError(stderr, "usage: zero plugin add <git-url|path> [--force] [--json]")
+	}
+	if dir == "" {
+		return writeAppError(stderr, "could not resolve the plugins directory", exitCrash)
+	}
+
+	result, err := plugins.Install(context.Background(), plugins.InstallOptions{
+		Source: source,
+		Dir:    dir,
+		Force:  options.force,
+	})
+	if err != nil {
+		if errors.Is(err, plugins.ErrNameClash) {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitUsage)
+		}
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(result, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	lines := []string{}
+	if result.Updated {
+		lines = append(lines, fmt.Sprintf("Updated plugin %s@%s.", result.ID, result.Version))
+		lines = append(lines, fmt.Sprintf("  hash: %s -> %s", shortHash(result.PreviousHash), shortHash(result.Hash)))
+	} else {
+		lines = append(lines, fmt.Sprintf("Installed plugin %s@%s.", result.ID, result.Version))
+		lines = append(lines, "  hash: "+result.Hash)
+	}
+	lines = append(lines, "  source: "+result.Source)
+	lines = append(lines, "  path: "+result.ManifestPath)
+	lines = append(lines, "Activation gates each tool through the normal permission flow; no install script was run.")
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(strings.Join(lines, "\n"), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runPluginRemove(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	id, _, help, err := parseNameCommandArgs(args, "plugin remove")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writePluginRemoveHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if id == "" {
+		return writeExecUsageError(stderr, "usage: zero plugin remove <id>")
+	}
+	if err := plugins.Remove(dir, id); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitUsage)
+	}
+	if _, err := fmt.Fprintf(stdout, "Removed plugin %q.\n", id); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// --- tools make / list ---
+
+func runTools(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) == 0 {
+		return writeExecUsageError(stderr, "tools subcommand required. Use `zero tools make <name>` or `zero tools list`.")
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		if err := writeToolsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	case "make", "new", "scaffold":
+		return runToolsMake(args[1:], deps.toolsDir(), stdout, stderr)
+	case "list", "ls":
+		return runToolsList(args[1:], deps.toolsDir(), stdout, stderr)
+	default:
+		return writeExecUsageError(stderr, fmt.Sprintf("unknown tools subcommand %q", args[0]))
+	}
+}
+
+type toolsMakeOptions struct {
+	runtime     string
+	description string
+	json        bool
+}
+
+func runToolsMake(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	name := ""
+	options := toolsMakeOptions{}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			if err := writeToolsMakeHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		case arg == "--json":
+			options.json = true
+		case arg == "--runtime":
+			value, next, err := nextFlagValue(args, i, arg)
+			if err != nil {
+				return writeExecUsageError(stderr, err.Error())
+			}
+			options.runtime, i = value, next
+		case strings.HasPrefix(arg, "--runtime="):
+			options.runtime = strings.TrimSpace(strings.TrimPrefix(arg, "--runtime="))
+		case arg == "--description":
+			value, next, err := nextFlagValue(args, i, arg)
+			if err != nil {
+				return writeExecUsageError(stderr, err.Error())
+			}
+			options.description, i = value, next
+		case strings.HasPrefix(arg, "--description="):
+			options.description = strings.TrimSpace(strings.TrimPrefix(arg, "--description="))
+		case strings.HasPrefix(arg, "-"):
+			return writeExecUsageError(stderr, fmt.Sprintf("unknown tools make flag %q", arg))
+		default:
+			if name != "" {
+				return writeExecUsageError(stderr, "tools make takes a single tool name")
+			}
+			name = arg
+		}
+	}
+	if name == "" {
+		return writeExecUsageError(stderr, "usage: zero tools make <name> [--runtime shell|node|python] [--description text]")
+	}
+	if dir == "" {
+		return writeAppError(stderr, "could not resolve the toolbox directory", exitCrash)
+	}
+
+	result, err := tools.Scaffold(tools.ScaffoldOptions{
+		Name:        name,
+		Dir:         dir,
+		Description: options.description,
+		Runtime:     tools.ScaffoldRuntime(strings.TrimSpace(options.runtime)),
+	})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitUsage)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, redaction.RedactValue(result, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	lines := []string{
+		fmt.Sprintf("Scaffolded tool %q at %s.", result.Name, result.PluginDir),
+		"  manifest: " + result.ManifestPath,
+		"  entry:    " + result.EntryPath,
+		"",
+		"Next steps:",
+		"  1. Implement the TODO in the entry script.",
+		"  2. Run `zero plugins list` to confirm it loads.",
+		"  3. The tool activates through the normal permission flow.",
+	}
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(strings.Join(lines, "\n"), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runToolsList(args []string, dir string, stdout io.Writer, stderr io.Writer) int {
+	asJSON := false
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			if err := writeToolsListHelp(stdout); err != nil {
+				return exitCrash
+			}
+			return exitSuccess
+		case "--json":
+			asJSON = true
+		default:
+			return writeExecUsageError(stderr, fmt.Sprintf("unknown tools list flag %q", arg))
+		}
+	}
+	if dir == "" {
+		return writeAppError(stderr, "could not resolve the toolbox directory", exitCrash)
+	}
+
+	// Scaffolded tools are plugins, so list them through the plugin loader scoped
+	// to the toolbox dir, then surface their tool extensions.
+	result, err := plugins.Load(plugins.LoadOptions{Roots: []plugins.Root{{Source: plugins.SourceUser, Path: dir}}})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	items := toolboxItems(result.Plugins)
+	if asJSON {
+		payload := struct {
+			Tools []toolboxItem `json:"tools"`
+		}{Tools: items}
+		if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatToolboxList(items, dir), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// toolboxItem is a flattened view of a plugin tool for `tools list`.
+type toolboxItem struct {
+	Plugin      string `json:"plugin"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Command     string `json:"command"`
+	Permission  string `json:"permission"`
+}
+
+func toolboxItems(loaded []plugins.LoadedPlugin) []toolboxItem {
+	items := []toolboxItem{}
+	for _, plugin := range loaded {
+		for _, tool := range plugin.Tools {
+			command := tool.Command
+			if len(tool.Args) > 0 {
+				command = strings.TrimSpace(command + " " + strings.Join(tool.Args, " "))
+			}
+			items = append(items, toolboxItem{
+				Plugin:      plugin.ID,
+				Name:        tool.Name,
+				Description: tool.Description,
+				Command:     command,
+				Permission:  string(tool.Permission),
+			})
+		}
+	}
+	sort.Slice(items, func(left int, right int) bool {
+		if items[left].Plugin != items[right].Plugin {
+			return items[left].Plugin < items[right].Plugin
+		}
+		return items[left].Name < items[right].Name
+	})
+	return items
+}
+
+func formatToolboxList(items []toolboxItem, dir string) string {
+	if len(items) == 0 {
+		return fmt.Sprintf("No Zero plugin-tools found in %s.", dir)
+	}
+	lines := []string{"Zero Tools:"}
+	for _, item := range items {
+		line := "  " + item.Name + " (" + item.Plugin + ")"
+		if item.Description != "" {
+			line += " - " + item.Description
+		}
+		lines = append(lines, line)
+		lines = append(lines, fmt.Sprintf("    command: %s [%s]", item.Command, item.Permission))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// parseNameCommandArgs parses a single positional name plus an optional --json
+// flag for the info/remove style commands.
+func parseNameCommandArgs(args []string, label string) (string, bool, bool, error) {
+	name := ""
+	asJSON := false
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return "", false, true, nil
+		case "--json":
+			asJSON = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return "", false, false, execUsageError{fmt.Sprintf("unknown %s flag %q", label, arg)}
+			}
+			if name != "" {
+				return "", false, false, execUsageError{fmt.Sprintf("%s takes a single name", label)}
+			}
+			name = arg
+		}
+	}
+	return name, asJSON, false, nil
+}
+
+// shortHash trims a "sha256:<hex>" fingerprint to a readable prefix for status
+// lines while leaving the algorithm tag intact.
+func shortHash(hash string) string {
+	if hash == "" {
+		return "(none)"
+	}
+	algo, hex, found := strings.Cut(hash, ":")
+	if !found {
+		if len(hash) > 12 {
+			return hash[:12]
+		}
+		return hash
+	}
+	if len(hex) > 12 {
+		hex = hex[:12]
+	}
+	return algo + ":" + hex
+}
+
+func writeSkillAddHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero skill add <git-url|path> [flags]
+
+Installs a skill from a git URL or local path into the skills directory and
+records a content hash in skills.lock. Fetched content is never executed.
+
+Flags:
+  -f, --force    Overwrite a skill installed from a different source
+      --json     Print the install result as JSON
+  -h, --help     Show this help
+`)
+	return err
+}
+
+func writeSkillInfoHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero skill info <name> [--json]
+
+Shows a skill's frontmatter plus its recorded source and pinned hash.
+`)
+	return err
+}
+
+func writeSkillRemoveHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero skill remove <name>
+
+Removes an installed skill directory and its skills.lock entry.
+`)
+	return err
+}
+
+func writePluginAddHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero plugin add <git-url|path> [flags]
+
+Installs a plugin from a git URL or local path. The manifest is validated and a
+content hash is recorded in plugins.lock. No install script is run; the plugin
+still activates through the normal permission flow.
+
+Flags:
+  -f, --force    Overwrite a plugin installed from a different source
+      --json     Print the install result as JSON
+  -h, --help     Show this help
+`)
+	return err
+}
+
+func writePluginRemoveHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero plugin remove <id>
+
+Removes an installed plugin directory and its plugins.lock entry.
+`)
+	return err
+}
+
+func writeToolsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero tools <command>
+
+Commands:
+  make <name>    Scaffold a new plugin-tool skeleton in the toolbox dir
+  list           List plugin-tools in the toolbox dir
+`)
+	return err
+}
+
+func writeToolsMakeHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero tools make <name> [flags]
+
+Scaffolds a plugin-tool skeleton (a plugin manifest plus a runnable entry stub)
+in the toolbox directory. After plugin activation the tool is loadable.
+
+Flags:
+      --runtime <shell|node|python>   Entry stub language (default shell)
+      --description <text>            Tool description
+      --json                          Print the scaffold result as JSON
+  -h, --help                          Show this help
+`)
+	return err
+}
+
+func writeToolsListHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero tools list [flags]
+
+Flags:
+      --json    Print plugin-tools as JSON
+  -h, --help    Show this help
+`)
+	return err
+}

--- a/internal/cli/distribution_test.go
+++ b/internal/cli/distribution_test.go
@@ -242,6 +242,64 @@ func TestRunToolsMakeRequiresName(t *testing.T) {
 	}
 }
 
+// A broken plugin in the toolbox dir must not vanish silently: tools list surfaces
+// the loader diagnostic in both text and JSON output.
+func TestRunToolsListSurfacesDiagnostics(t *testing.T) {
+	toolsDir := t.TempDir()
+	// A plugin dir whose plugin.json is not valid JSON yields a load diagnostic.
+	broken := filepath.Join(toolsDir, "broken")
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "plugin.json"), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deps := appDeps{toolsDir: func() string { return toolsDir }}
+
+	var stdout, stderr bytes.Buffer
+	if exit := runWithDeps([]string{"tools", "list"}, &stdout, &stderr, deps); exit != exitSuccess {
+		t.Fatalf("tools list exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(strings.ToLower(stdout.String()), "diagnostic") {
+		t.Fatalf("text listing should surface loader diagnostics:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"tools", "list", "--json"}, &stdout, &stderr, deps); exit != exitSuccess {
+		t.Fatalf("tools list --json exit = %d, stderr = %s", exit, stderr.String())
+	}
+	var payload struct {
+		Tools       []map[string]any `json:"tools"`
+		Diagnostics []map[string]any `json:"diagnostics"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("tools list --json not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Diagnostics) == 0 {
+		t.Fatalf("JSON listing should include loader diagnostics:\n%s", stdout.String())
+	}
+}
+
+func TestRunRemoveRejectsJSONFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"skill", "remove", "demo", "--json"},
+		{"plugin", "remove", "zero.demo", "--json"},
+	} {
+		var stdout, stderr bytes.Buffer
+		exit := runWithDeps(args, &stdout, &stderr, appDeps{
+			skillsDir:  func() string { return t.TempDir() },
+			pluginsDir: func() string { return t.TempDir() },
+		})
+		if exit == exitSuccess {
+			t.Fatalf("%v should reject --json, got success", args)
+		}
+		if !strings.Contains(strings.ToLower(stderr.String()), "json") {
+			t.Fatalf("%v error should mention json:\n%s", args, stderr.String())
+		}
+	}
+}
+
 func TestRunToolsListEmpty(t *testing.T) {
 	toolsDir := filepath.Join(t.TempDir(), "missing")
 	var stdout, stderr bytes.Buffer

--- a/internal/cli/distribution_test.go
+++ b/internal/cli/distribution_test.go
@@ -41,6 +41,13 @@ func TestRunSkillAddInfoRemove(t *testing.T) {
 	skillsDir := t.TempDir()
 	src := writeSourceSkillDir(t, filepath.Join(t.TempDir(), "src"),
 		"---\nname: confirmation-policy\ndescription: Ask first.\n---\nbody\n")
+	// Install records the canonical (symlink-resolved) source, which "info" then
+	// shows. Normalize here too so the assertion matches on every platform — on
+	// Windows the temp dir is an 8.3 short path EvalSymlinks expands, and on macOS
+	// it resolves /var -> /private/var.
+	if resolved, err := filepath.EvalSymlinks(src); err == nil {
+		src = resolved
+	}
 
 	deps := appDeps{skillsDir: func() string { return skillsDir }}
 

--- a/internal/cli/distribution_test.go
+++ b/internal/cli/distribution_test.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSourceSkillDir(t *testing.T, dir string, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return dir
+}
+
+func writeSourcePluginDir(t *testing.T, dir string, manifest map[string]any) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), data, 0o644); err != nil {
+		t.Fatalf("write plugin.json: %v", err)
+	}
+	return dir
+}
+
+// --- skill add/info/remove ---
+
+func TestRunSkillAddInfoRemove(t *testing.T) {
+	skillsDir := t.TempDir()
+	src := writeSourceSkillDir(t, filepath.Join(t.TempDir(), "src"),
+		"---\nname: confirmation-policy\ndescription: Ask first.\n---\nbody\n")
+
+	deps := appDeps{skillsDir: func() string { return skillsDir }}
+
+	// add
+	var stdout, stderr bytes.Buffer
+	if exit := runWithDeps([]string{"skill", "add", src}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("skill add exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "confirmation-policy") {
+		t.Fatalf("add output missing name:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "sha256:") {
+		t.Fatalf("add output should show the recorded hash:\n%s", stdout.String())
+	}
+
+	// list reflects the install
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"skill", "list"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("skill list exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "confirmation-policy") {
+		t.Fatalf("list missing installed skill:\n%s", stdout.String())
+	}
+
+	// info shows source + hash
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"skill", "info", "confirmation-policy"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("skill info exit = %d, stderr = %s", exit, stderr.String())
+	}
+	info := stdout.String()
+	if !strings.Contains(info, src) || !strings.Contains(info, "sha256:") {
+		t.Fatalf("info missing source/hash:\n%s", info)
+	}
+
+	// remove deletes it
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"skill", "remove", "confirmation-policy"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("skill remove exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "confirmation-policy")); err == nil {
+		t.Fatalf("skill dir should be gone after remove")
+	}
+}
+
+func TestRunSkillAddRejectsInvalid(t *testing.T) {
+	skillsDir := t.TempDir()
+	bad := filepath.Join(t.TempDir(), "empty")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"skill", "add", bad}, &stdout, &stderr, appDeps{skillsDir: func() string { return skillsDir }})
+	if exit == 0 {
+		t.Fatalf("expected a non-zero exit for an invalid skill source")
+	}
+}
+
+func TestRunSkillAddClashIsNotSilentlyOverwritten(t *testing.T) {
+	skillsDir := t.TempDir()
+	deps := appDeps{skillsDir: func() string { return skillsDir }}
+	srcA := writeSourceSkillDir(t, filepath.Join(t.TempDir(), "a"), "---\nname: shared\ndescription: a\n---\noriginal\n")
+	srcB := writeSourceSkillDir(t, filepath.Join(t.TempDir(), "b"), "---\nname: shared\ndescription: b\n---\nreplacement\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := runWithDeps([]string{"skill", "add", srcA}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("seed add failed: %s", stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	exit := runWithDeps([]string{"skill", "add", srcB}, &stdout, &stderr, deps)
+	if exit == 0 {
+		t.Fatalf("expected clash to fail without --force")
+	}
+	if !strings.Contains(strings.ToLower(stderr.String()), "force") {
+		t.Fatalf("clash error should mention --force:\n%s", stderr.String())
+	}
+	// --force overwrites
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"skill", "add", srcB, "--force"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("forced add failed: %s", stderr.String())
+	}
+}
+
+func TestRunSkillAddReinstallShowsHashChange(t *testing.T) {
+	skillsDir := t.TempDir()
+	deps := appDeps{skillsDir: func() string { return skillsDir }}
+	src := filepath.Join(t.TempDir(), "src")
+	writeSourceSkillDir(t, src, "---\nname: demo\ndescription: v1\n---\nfirst\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := runWithDeps([]string{"skill", "add", src}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("first add: %s", stderr.String())
+	}
+	writeSourceSkillDir(t, src, "---\nname: demo\ndescription: v2\n---\nsecond\n")
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"skill", "add", src}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("reinstall: %s", stderr.String())
+	}
+	// The output should communicate that the hash changed (an update).
+	if !strings.Contains(strings.ToLower(stdout.String()), "updated") {
+		t.Fatalf("reinstall output should report an update:\n%s", stdout.String())
+	}
+}
+
+// --- plugin add/remove ---
+
+func TestRunPluginAddListRemove(t *testing.T) {
+	pluginsDir := t.TempDir()
+	src := writeSourcePluginDir(t, filepath.Join(t.TempDir(), "src"), map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.demo",
+		"name":          "Zero Demo",
+		"version":       "0.1.0",
+	})
+	deps := appDeps{pluginsDir: func() string { return pluginsDir }}
+
+	var stdout, stderr bytes.Buffer
+	if exit := runWithDeps([]string{"plugin", "add", src}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("plugin add exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "zero.demo") {
+		t.Fatalf("add output missing id:\n%s", stdout.String())
+	}
+
+	// remove
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"plugin", "remove", "zero.demo"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("plugin remove exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(pluginsDir, "zero.demo")); err == nil {
+		t.Fatalf("plugin dir should be gone after remove")
+	}
+}
+
+func TestRunPluginAddRejectsInvalidManifest(t *testing.T) {
+	pluginsDir := t.TempDir()
+	src := writeSourcePluginDir(t, filepath.Join(t.TempDir(), "bad"), map[string]any{"schemaVersion": float64(1)})
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"plugin", "add", src}, &stdout, &stderr, appDeps{pluginsDir: func() string { return pluginsDir }})
+	if exit == 0 {
+		t.Fatalf("expected a non-zero exit for an invalid manifest")
+	}
+}
+
+// --- tools make/list ---
+
+func TestRunToolsMakeAndList(t *testing.T) {
+	toolsDir := t.TempDir()
+	deps := appDeps{toolsDir: func() string { return toolsDir }}
+
+	var stdout, stderr bytes.Buffer
+	if exit := runWithDeps([]string{"tools", "make", "foo"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("tools make exit = %d, stderr = %s", exit, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "foo") {
+		t.Fatalf("make output missing name:\n%s", out)
+	}
+	// The path and next steps should be printed.
+	if !strings.Contains(out, filepath.Join(toolsDir, "foo")) {
+		t.Fatalf("make output should print the created path:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(toolsDir, "foo", "plugin.json")); err != nil {
+		t.Fatalf("manifest not created: %v", err)
+	}
+
+	// list reflects the scaffolded tool
+	stdout.Reset()
+	stderr.Reset()
+	if exit := runWithDeps([]string{"tools", "list"}, &stdout, &stderr, deps); exit != 0 {
+		t.Fatalf("tools list exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "foo") {
+		t.Fatalf("tools list missing scaffolded tool:\n%s", stdout.String())
+	}
+}
+
+func TestRunToolsMakeRejectsBadName(t *testing.T) {
+	toolsDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"tools", "make", "../escape"}, &stdout, &stderr, appDeps{toolsDir: func() string { return toolsDir }})
+	if exit == 0 {
+		t.Fatalf("expected a non-zero exit for an invalid tool name")
+	}
+}
+
+func TestRunToolsMakeRequiresName(t *testing.T) {
+	toolsDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"tools", "make"}, &stdout, &stderr, appDeps{toolsDir: func() string { return toolsDir }})
+	if exit == 0 {
+		t.Fatalf("expected a non-zero exit when no name is given")
+	}
+}
+
+func TestRunToolsListEmpty(t *testing.T) {
+	toolsDir := filepath.Join(t.TempDir(), "missing")
+	var stdout, stderr bytes.Buffer
+	exit := runWithDeps([]string{"tools", "list"}, &stdout, &stderr, appDeps{toolsDir: func() string { return toolsDir }})
+	if exit != 0 {
+		t.Fatalf("tools list on empty dir exit = %d, stderr = %s", exit, stderr.String())
+	}
+	if !strings.Contains(strings.ToLower(stdout.String()), "no") {
+		t.Fatalf("expected an empty-toolbox message:\n%s", stdout.String())
+	}
+}
+
+// Distribution must never launch the interactive TUI: each command resolves to
+// its own dispatch path and returns without invoking the TUI launcher (which is
+// left nil here, so a stray launch would panic).
+func TestRunDistributionCommandsDoNotLaunchTUI(t *testing.T) {
+	for _, args := range [][]string{
+		{"skill", "list"},
+		{"plugin", "list"},
+		{"tools", "list"},
+	} {
+		var stdout, stderr bytes.Buffer
+		exit := runWithDeps(args, &stdout, &stderr, appDeps{
+			skillsDir:  func() string { return t.TempDir() },
+			pluginsDir: func() string { return t.TempDir() },
+			toolsDir:   func() string { return t.TempDir() },
+			getwd:      func() (string, error) { return t.TempDir(), nil },
+		})
+		if exit != exitSuccess {
+			t.Fatalf("%v exit = %d, stderr = %s", args, exit, stderr.String())
+		}
+	}
+}

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -76,6 +76,10 @@ func runPlugins(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 			return exitCrash
 		}
 		return exitSuccess
+	case "add":
+		return runPluginAdd(args[1:], deps.pluginsDir(), stdout, stderr)
+	case "remove", "rm":
+		return runPluginRemove(args[1:], deps.pluginsDir(), stdout, stderr)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown plugins subcommand %q", args[0]))
 	}
@@ -515,7 +519,9 @@ func writePluginsHelp(w io.Writer) error {
   zero plugins <command>
 
 Commands:
-  list    List local Zero plugins
+  list                 List local Zero plugins
+  add <git-url|path>   Install a plugin (manifest-validated, pinned in plugins.lock)
+  remove <id>          Remove an installed plugin and its lockfile entry
 `)
 	return err
 }

--- a/internal/cli/skills.go
+++ b/internal/cli/skills.go
@@ -23,8 +23,8 @@ func runSkills(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 				return exitCrash
 			}
 			return exitSuccess
-		case "list":
-			command, rest = "list", args[1:]
+		case "list", "add", "info", "remove", "rm":
+			command, rest = args[0], args[1:]
 		default:
 			// Treat a leading flag (e.g. --json) as belonging to the implicit
 			// `list` command so `zero skills --json` works like `zero plugins`.
@@ -47,6 +47,12 @@ func runSkills(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) 
 			return exitSuccess
 		}
 		return runSkillsList(deps.skillsDir(), options, stdout, stderr)
+	case "add":
+		return runSkillAdd(rest, deps.skillsDir(), stdout, stderr)
+	case "info":
+		return runSkillInfo(rest, deps.skillsDir(), stdout, stderr)
+	case "remove", "rm":
+		return runSkillRemove(rest, deps.skillsDir(), stdout, stderr)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown skills subcommand %q", command))
 	}
@@ -109,7 +115,10 @@ func writeSkillsHelp(w io.Writer) error {
   zero skills <command>
 
 Commands:
-  list    List discovered Zero skills
+  list                 List discovered Zero skills
+  add <git-url|path>   Install a skill (checksum-pinned in skills.lock)
+  info <name>          Show a skill's frontmatter, source, and pinned hash
+  remove <name>        Remove an installed skill and its lockfile entry
 `)
 	return err
 }

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -82,6 +82,9 @@ func Install(ctx context.Context, options InstallOptions) (InstallResult, error)
 	if dir == "" {
 		return InstallResult{}, errors.New("a plugins directory is required")
 	}
+	// Canonicalize a local source so clash detection keys off the resolved path,
+	// not the spelling the user typed (relative vs absolute, symlinked vs not).
+	source = canonicalSource(source)
 
 	fetchDir, cleanup, err := fetchSource(ctx, source, options.GitRunner)
 	if err != nil {
@@ -117,7 +120,13 @@ func Install(ctx context.Context, options InstallOptions) (InstallResult, error)
 	}
 	id := parsed.ID
 
-	hash := hashContent(data)
+	// Hash the SAME filtered tree that copyTree installs (not just the manifest),
+	// so a change to any installed file — a tool script, prompt, or bundled skill —
+	// is reflected in the lock hash and reported as an update.
+	hash, err := hashTree(pluginDir)
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("hash plugin: %w", err)
+	}
 
 	lock, err := ReadLock(dir)
 	if err != nil {
@@ -379,6 +388,25 @@ func fileExists(path string) bool {
 	return err == nil && info.Mode().IsRegular()
 }
 
+// canonicalSource normalizes a local filesystem source to an absolute,
+// symlink-evaluated path so a re-install via a different spelling of the same
+// directory is recognized as the same source. Remote sources (git URLs) are
+// returned unchanged. On any resolution error the input is returned as-is so a
+// non-existent local path still surfaces its real error later in fetchSource.
+func canonicalSource(source string) string {
+	if !isLocalPath(source) {
+		return source
+	}
+	abs, err := filepath.Abs(source)
+	if err != nil {
+		return source
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
+}
+
 // isLocalPath reports whether source is a local filesystem path rather than a
 // remote URL. URLs (scheme://… or scp-style host:path) and git shorthand are
 // remote.
@@ -428,7 +456,75 @@ func validInstallID(id string) bool {
 	return id == filepath.Base(id) && !strings.ContainsAny(id, `/\`) && !strings.Contains(id, "..")
 }
 
-func hashContent(data []byte) string {
-	sum := sha256.Sum256(data)
-	return "sha256:" + hex.EncodeToString(sum[:])
+// hashTree computes a content hash over the same filtered tree that copyTree
+// installs: regular files only, .git and symlinks skipped, walked in a stable
+// sorted order. Each file contributes its plugin-relative path, executable bit,
+// and bytes, so renames, mode flips, and content edits all change the hash.
+func hashTree(root string) (string, error) {
+	hasher := sha256.New()
+	if err := hashTreeInto(hasher, root, root); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func hashTreeInto(hasher io.Writer, root string, dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if name == ".git" {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			// Skipped by copyTree, so excluded from the hash too.
+			continue
+		case info.IsDir():
+			if err := hashTreeInto(hasher, root, path); err != nil {
+				return err
+			}
+		case info.Mode().IsRegular():
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			executable := 0
+			if info.Mode().Perm()&0o111 != 0 {
+				executable = 1
+			}
+			// Length-prefixed header keeps file boundaries unambiguous so two trees
+			// cannot collide by shifting bytes across the path/content split.
+			header := fmt.Sprintf("%s\x00%d\x00", filepath.ToSlash(rel), executable)
+			if _, err := io.WriteString(hasher, header); err != nil {
+				return err
+			}
+			file, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(hasher, file); err != nil {
+				_ = file.Close()
+				return err
+			}
+			if err := file.Close(); err != nil {
+				return err
+			}
+		default:
+			// FIFOs, sockets, devices: skipped by copyTree, excluded here.
+			continue
+		}
+	}
+	return nil
 }

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -504,8 +504,8 @@ func hashTreeInto(hasher io.Writer, root string, dir string) error {
 			if info.Mode().Perm()&0o111 != 0 {
 				executable = 1
 			}
-			// Length-prefixed header keeps file boundaries unambiguous so two trees
-			// cannot collide by shifting bytes across the path/content split.
+			// Null-delimited header keeps file boundaries unambiguous (paths cannot
+			// contain null bytes) so two trees cannot collide by shifting bytes.
 			header := fmt.Sprintf("%s\x00%d\x00", filepath.ToSlash(rel), executable)
 			if _, err := io.WriteString(hasher, header); err != nil {
 				return err

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -1,0 +1,434 @@
+package plugins
+
+// Distribution: install a plugin from a git URL or a local path into a plugins
+// directory, with the manifest validated and a content hash recorded in a
+// lockfile (plugins.lock). Install copies the plugin tree verbatim but NEVER
+// executes any of it — installed plugins still go through normal Stage 09
+// activation with permission gating before any tool can run.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// manifestFileName is the plugin manifest filename, matching the loader.
+const manifestFileName = "plugin.json"
+
+// LockFileName maps an installed plugin id to its source and content hash.
+const LockFileName = "plugins.lock"
+
+// ErrNameClash is returned when an install would overwrite a plugin already
+// installed from a DIFFERENT source, unless InstallOptions.Force is set.
+var ErrNameClash = errors.New("a different plugin with that id is already installed")
+
+// GitRunner fetches the plugin at source into destination. The default runner
+// shallow-clones with the system git (inheriting the process environment, so
+// proxy/egress settings are honored). It is injectable so tests never hit the
+// network. A runner must only fetch — it must never execute fetched content.
+type GitRunner func(ctx context.Context, destination string, source string) error
+
+// InstallOptions configures a single plugin install.
+type InstallOptions struct {
+	// Source is a git URL or a local filesystem path to a plugin directory (one
+	// that contains a plugin.json, or whose tree contains exactly one).
+	Source string
+	// Dir is the plugins directory to install into (typically the user plugins
+	// root from ResolveRoots).
+	Dir string
+	// Force allows overwriting a plugin installed from a different source.
+	Force bool
+	// GitRunner overrides the fetch implementation. When nil, a git source is
+	// shallow-cloned with the system git.
+	GitRunner GitRunner
+}
+
+// InstallResult reports what an install did.
+type InstallResult struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	ManifestPath string `json:"manifestPath"`
+	Hash         string `json:"hash"`
+	Source       string `json:"source"`
+	Updated      bool   `json:"updated"`
+	PreviousHash string `json:"previousHash,omitempty"`
+}
+
+// LockEntry records the source and content hash for one installed plugin.
+type LockEntry struct {
+	Source string `json:"source"`
+	Hash   string `json:"hash"`
+}
+
+// Install fetches the plugin at options.Source, validates its manifest, copies
+// the plugin tree into options.Dir/<id>/, and records a content hash (over the
+// manifest bytes) in the lockfile. Fetched content is never executed.
+func Install(ctx context.Context, options InstallOptions) (InstallResult, error) {
+	source := strings.TrimSpace(options.Source)
+	if source == "" {
+		return InstallResult{}, errors.New("a plugin source (git URL or path) is required")
+	}
+	dir := strings.TrimSpace(options.Dir)
+	if dir == "" {
+		return InstallResult{}, errors.New("a plugins directory is required")
+	}
+
+	fetchDir, cleanup, err := fetchSource(ctx, source, options.GitRunner)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	defer cleanup()
+
+	pluginDir, err := locatePluginDir(fetchDir)
+	if err != nil {
+		return InstallResult{}, err
+	}
+
+	manifestPath := filepath.Join(pluginDir, manifestFileName)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("read %s: %w", manifestFileName, err)
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return InstallResult{}, fmt.Errorf("parse %s: %w", manifestFileName, err)
+	}
+
+	// Validate against the same schema the loader uses. The install target id is
+	// derived from the (validated) manifest id, so it is safe as a directory name.
+	parsed, err := ParseManifest(raw, ParseManifestOptions{
+		Source:       SourceUser,
+		Root:         dir,
+		PluginDir:    filepath.Join(dir, "pending"),
+		ManifestPath: manifestPath,
+	})
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("invalid plugin manifest: %w", err)
+	}
+	id := parsed.ID
+
+	hash := hashContent(data)
+
+	lock, err := ReadLock(dir)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	previous, existed := lock[id]
+	if existed && previous.Source != source && !options.Force {
+		return InstallResult{}, fmt.Errorf("%w: %q is installed from %s (use --force to overwrite)", ErrNameClash, id, previous.Source)
+	}
+
+	target := filepath.Join(dir, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("create plugins dir: %w", err)
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return InstallResult{}, fmt.Errorf("clear previous plugin: %w", err)
+	}
+	// Copy the whole plugin tree (entry scripts, prompts, skills) so the installed
+	// plugin is runnable through activation. Copy DATA only — never execute it.
+	if err := copyTree(pluginDir, target); err != nil {
+		return InstallResult{}, fmt.Errorf("copy plugin: %w", err)
+	}
+
+	lock[id] = LockEntry{Source: source, Hash: hash}
+	if err := writeLock(dir, lock); err != nil {
+		return InstallResult{}, err
+	}
+
+	result := InstallResult{
+		ID:           id,
+		Name:         parsed.Name,
+		Version:      parsed.Version,
+		ManifestPath: filepath.Join(target, manifestFileName),
+		Hash:         hash,
+		Source:       source,
+	}
+	if existed {
+		result.Updated = previous.Hash != hash
+		result.PreviousHash = previous.Hash
+	}
+	return result, nil
+}
+
+// Remove deletes an installed plugin directory and its lockfile entry. It errors
+// if the named plugin is not present in either the dir or the lockfile.
+func Remove(dir string, id string) error {
+	dir = strings.TrimSpace(dir)
+	id = strings.TrimSpace(id)
+	if dir == "" || id == "" {
+		return errors.New("a plugins directory and plugin id are required")
+	}
+	if !validInstallID(id) {
+		return fmt.Errorf("invalid plugin id %q", id)
+	}
+
+	lock, err := ReadLock(dir)
+	if err != nil {
+		return err
+	}
+	_, locked := lock[id]
+	target := filepath.Join(dir, id)
+	_, statErr := os.Stat(target)
+	present := statErr == nil
+	if !locked && !present {
+		return fmt.Errorf("plugin %q is not installed", id)
+	}
+	if present {
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("remove plugin dir: %w", err)
+		}
+	}
+	if locked {
+		delete(lock, id)
+		if err := writeLock(dir, lock); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadLock loads the plugins lockfile from dir. A missing lockfile yields an
+// empty map with no error.
+func ReadLock(dir string) (map[string]LockEntry, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return map[string]LockEntry{}, nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, LockFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]LockEntry{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", LockFileName, err)
+	}
+	entries := map[string]LockEntry{}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return entries, nil
+	}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", LockFileName, err)
+	}
+	return entries, nil
+}
+
+func writeLock(dir string, entries map[string]LockEntry) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create plugins dir: %w", err)
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", LockFileName, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LockFileName), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", LockFileName, err)
+	}
+	return nil
+}
+
+// fetchSource resolves a source into a local directory. A local path is used in
+// place; a git URL is shallow-cloned into a temp dir via the runner.
+func fetchSource(ctx context.Context, source string, runner GitRunner) (string, func(), error) {
+	if isLocalPath(source) {
+		info, err := os.Stat(source)
+		if err != nil {
+			return "", func() {}, fmt.Errorf("read source: %w", err)
+		}
+		if !info.IsDir() {
+			return "", func() {}, fmt.Errorf("source must be a directory: %s", source)
+		}
+		abs, err := filepath.Abs(source)
+		if err != nil {
+			return "", func() {}, err
+		}
+		return abs, func() {}, nil
+	}
+
+	if runner == nil {
+		runner = defaultGitRunner
+	}
+	temp, err := os.MkdirTemp("", "zero-plugin-fetch-")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create temp dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(temp) }
+	if err := runner(ctx, temp, source); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("fetch %s: %w", source, err)
+	}
+	return temp, cleanup, nil
+}
+
+// defaultGitRunner shallow-clones source into destination. exec.CommandContext
+// inherits the process environment, so proxy/egress settings are honored;
+// GIT_TERMINAL_PROMPT=0 prevents a credential prompt from blocking. Cloning only
+// fetches; it never executes repository content.
+func defaultGitRunner(ctx context.Context, destination string, source string) error {
+	command := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--", source, destination)
+	command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone failed: %v: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// locatePluginDir finds the directory holding plugin.json within root: the root
+// itself, or exactly one immediate subdirectory.
+func locatePluginDir(root string) (string, error) {
+	if fileExists(filepath.Join(root, manifestFileName)) {
+		return root, nil
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", fmt.Errorf("scan source: %w", err)
+	}
+	matches := []string{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(root, entry.Name())
+		if fileExists(filepath.Join(candidate, manifestFileName)) {
+			matches = append(matches, candidate)
+		}
+	}
+	sort.Strings(matches)
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no %s found in source", manifestFileName)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("source contains multiple plugins (%d); install one at a time", len(matches))
+	}
+}
+
+// copyTree recursively copies regular files and directories from src to dst. It
+// skips the .git directory (clone metadata) and refuses symlinks so a malicious
+// source cannot smuggle a link that escapes the install dir. Copying is pure
+// I/O — it never executes anything it copies.
+func copyTree(src string, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == ".git" {
+			continue
+		}
+		srcPath := filepath.Join(src, name)
+		dstPath := filepath.Join(dst, name)
+		info, err := os.Lstat(srcPath)
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			// Never recreate a symlink: it could point outside the install dir and
+			// turn a copy into a write/read primitive elsewhere.
+			continue
+		case info.IsDir():
+			if err := copyTree(srcPath, dstPath); err != nil {
+				return err
+			}
+		case info.Mode().IsRegular():
+			if err := copyFile(srcPath, dstPath, info.Mode().Perm()); err != nil {
+				return err
+			}
+		default:
+			// Skip FIFOs, sockets, devices.
+			continue
+		}
+	}
+	return nil
+}
+
+func copyFile(src string, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// isLocalPath reports whether source is a local filesystem path rather than a
+// remote URL. URLs (scheme://… or scp-style host:path) and git shorthand are
+// remote.
+func isLocalPath(source string) bool {
+	if source == "" {
+		return false
+	}
+	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") || strings.HasPrefix(source, "~") {
+		return true
+	}
+	if filepath.IsAbs(source) {
+		return true
+	}
+	if hasURLScheme(source) {
+		return false
+	}
+	if idx := strings.Index(source, ":"); idx > 0 {
+		host := source[:idx]
+		if strings.Contains(host, "@") {
+			return false
+		}
+		if len(host) == 1 {
+			return true // drive letter
+		}
+		if strings.Contains(host, ".") {
+			return false // hostname
+		}
+	}
+	return true
+}
+
+func hasURLScheme(source string) bool {
+	for _, scheme := range []string{"http://", "https://", "git://", "ssh://", "git+ssh://", "ftp://", "ftps://", "file://"} {
+		if strings.HasPrefix(strings.ToLower(source), scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+// validInstallID guards a plugin id used as a directory component. Manifest ids
+// already match pluginIDPattern, but Remove takes an id directly from the user.
+func validInstallID(id string) bool {
+	if !pluginIDPattern.MatchString(id) {
+		return false
+	}
+	return id == filepath.Base(id) && !strings.ContainsAny(id, `/\`) && !strings.Contains(id, "..")
+}
+
+func hashContent(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/plugins/install_test.go
+++ b/internal/plugins/install_test.go
@@ -269,16 +269,13 @@ func TestInstallSameLocalSourceDifferentSpellingIsNotAClash(t *testing.T) {
 		t.Fatalf("first install: %v", err)
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	rel, err := filepath.Rel(wd, abs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := Install(context.Background(), InstallOptions{Source: rel, Dir: destDir}); err != nil {
-		t.Fatalf("reinstall with relative spelling should not clash: %v", err)
+	// A different textual spelling of the same directory (a redundant "/./"
+	// segment) canonicalizes to the same absolute path, so it must not clash. (A
+	// cwd-relative spelling can't be expressed across drives on Windows, where the
+	// temp dir and the repo are on different volumes, so use a same-dir alternate.)
+	messy := filepath.Dir(abs) + string(filepath.Separator) + "." + string(filepath.Separator) + filepath.Base(abs)
+	if _, err := Install(context.Background(), InstallOptions{Source: messy, Dir: destDir}); err != nil {
+		t.Fatalf("reinstall with an equivalent spelling should not clash: %v", err)
 	}
 
 	entries, err := ReadLock(destDir)

--- a/internal/plugins/install_test.go
+++ b/internal/plugins/install_test.go
@@ -111,7 +111,7 @@ func TestInstallCopiesLocalPluginAndRecordsHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadLock: %v", err)
 	}
-	if entries["zero.demo"].Hash != result.Hash || entries["zero.demo"].Source != src {
+	if entries["zero.demo"].Hash != result.Hash || entries["zero.demo"].Source != canonicalSource(src) {
 		t.Fatalf("lockfile entry unexpected: %#v", entries["zero.demo"])
 	}
 }
@@ -187,6 +187,54 @@ func TestInstallReinstallShowsHashChange(t *testing.T) {
 	}
 }
 
+// TestInstallReinstallDetectsNestedFileChange guards that the recorded hash
+// covers the whole installed tree, not just plugin.json. A change to a tool
+// script (with the manifest unchanged) must still be reported as an update so
+// checksum pinning catches modified executable content.
+func TestInstallReinstallDetectsNestedFileChange(t *testing.T) {
+	destDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "src")
+	writeSourcePlugin(t, src, map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.tool",
+		"name":          "Tool",
+		"version":       "0.1.0",
+		"tools": []any{map[string]any{
+			"name":    "lookup",
+			"command": "node",
+			"args":    []any{"tools/lookup.mjs"},
+		}},
+	})
+	entryDir := filepath.Join(src, "tools")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := filepath.Join(entryDir, "lookup.mjs")
+	if err := os.WriteFile(entry, []byte("console.log('v1')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Change ONLY the nested tool script; the manifest is untouched.
+	if err := os.WriteFile(entry, []byte("console.log('v2')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	if !second.Updated {
+		t.Fatalf("changing a nested file should be flagged as an update")
+	}
+	if second.PreviousHash != first.Hash || second.Hash == first.Hash {
+		t.Fatalf("expected the hash to change: prev=%q first=%q new=%q", second.PreviousHash, first.Hash, second.Hash)
+	}
+}
+
 func TestInstallNameClashWarnsAndDoesNotOverwriteWithoutForce(t *testing.T) {
 	destDir := t.TempDir()
 	srcA := writeSourcePlugin(t, filepath.Join(t.TempDir(), "a"), validManifest())
@@ -204,8 +252,41 @@ func TestInstallNameClashWarnsAndDoesNotOverwriteWithoutForce(t *testing.T) {
 		t.Fatalf("forced reinstall: %v", err)
 	}
 	entries, _ := ReadLock(destDir)
-	if entries["zero.demo"].Source != srcB {
+	if entries["zero.demo"].Source != canonicalSource(srcB) {
 		t.Fatalf("forced overwrite did not update source: %#v", entries["zero.demo"])
+	}
+}
+
+// TestInstallSameLocalSourceDifferentSpellingIsNotAClash verifies that a local
+// source installed via an absolute path and re-installed via an equivalent
+// relative spelling is treated as the same source, not a clash, because the
+// recorded source is canonicalized.
+func TestInstallSameLocalSourceDifferentSpellingIsNotAClash(t *testing.T) {
+	destDir := t.TempDir()
+	abs := writeSourcePlugin(t, filepath.Join(t.TempDir(), "src"), validManifest())
+
+	if _, err := Install(context.Background(), InstallOptions{Source: abs, Dir: destDir}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(wd, abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install(context.Background(), InstallOptions{Source: rel, Dir: destDir}); err != nil {
+		t.Fatalf("reinstall with relative spelling should not clash: %v", err)
+	}
+
+	entries, err := ReadLock(destDir)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if entries["zero.demo"].Source != canonicalSource(abs) {
+		t.Fatalf("lockfile should record the canonical source %q, got %q", canonicalSource(abs), entries["zero.demo"].Source)
 	}
 }
 

--- a/internal/plugins/install_test.go
+++ b/internal/plugins/install_test.go
@@ -1,0 +1,294 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initGitPluginRepo creates a real local git repo holding a plugin and returns a
+// file:// URL, exercising the DEFAULT git runner end to end. Skipped when git is
+// unavailable.
+func initGitPluginRepo(t *testing.T, manifest map[string]any) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	writeSourcePlugin(t, repo, manifest)
+	run("add", "-A")
+	run("commit", "-qm", "init")
+	return "file://" + repo
+}
+
+func TestInstallFromRealLocalGitRepo(t *testing.T) {
+	destDir := t.TempDir()
+	url := initGitPluginRepo(t, validManifest())
+
+	result, err := Install(context.Background(), InstallOptions{Source: url, Dir: destDir})
+	if err != nil {
+		t.Fatalf("Install from git: %v", err)
+	}
+	if result.ID != "zero.demo" {
+		t.Fatalf("ID = %q, want zero.demo", result.ID)
+	}
+	loaded, err := Load(LoadOptions{Roots: []Root{{Source: SourceUser, Path: destDir}}})
+	if err != nil || len(loaded.Plugins) != 1 {
+		t.Fatalf("installed git plugin not discoverable: err=%v plugins=%#v", err, loaded.Plugins)
+	}
+	// copyTree must skip .git so clone metadata never lands in the plugins dir.
+	if _, err := os.Stat(filepath.Join(destDir, "zero.demo", ".git")); err == nil {
+		t.Fatalf(".git metadata must not be copied into the plugins dir")
+	}
+}
+
+func writeSourcePlugin(t *testing.T, dir string, manifest map[string]any) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestFileName), data, 0o644); err != nil {
+		t.Fatalf("write plugin.json: %v", err)
+	}
+	return dir
+}
+
+func validManifest() map[string]any {
+	return map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.demo",
+		"name":          "Zero Demo",
+		"version":       "0.1.0",
+		"description":   "Demo plugin",
+	}
+}
+
+func TestInstallCopiesLocalPluginAndRecordsHash(t *testing.T) {
+	destDir := t.TempDir()
+	src := writeSourcePlugin(t, filepath.Join(t.TempDir(), "src"), validManifest())
+
+	result, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if result.ID != "zero.demo" {
+		t.Fatalf("ID = %q, want zero.demo", result.ID)
+	}
+	if result.Hash == "" {
+		t.Fatalf("expected a recorded content hash")
+	}
+
+	// The installed manifest is discoverable through the loader.
+	loaded, err := Load(LoadOptions{Roots: []Root{{Source: SourceUser, Path: destDir}}})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Plugins) != 1 || loaded.Plugins[0].ID != "zero.demo" {
+		t.Fatalf("installed plugin not discoverable: %#v", loaded.Plugins)
+	}
+
+	// Lockfile records id -> source + hash.
+	entries, err := ReadLock(destDir)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if entries["zero.demo"].Hash != result.Hash || entries["zero.demo"].Source != src {
+		t.Fatalf("lockfile entry unexpected: %#v", entries["zero.demo"])
+	}
+}
+
+func TestInstallRejectsInvalidManifest(t *testing.T) {
+	destDir := t.TempDir()
+	// Missing required fields (id/name/version) -> ParseManifest rejects it.
+	src := writeSourcePlugin(t, filepath.Join(t.TempDir(), "bad"), map[string]any{
+		"schemaVersion": float64(1),
+	})
+
+	_, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err == nil {
+		t.Fatalf("expected an error for an invalid manifest")
+	}
+	if entries, _ := os.ReadDir(destDir); len(entries) != 0 {
+		t.Fatalf("invalid manifest must not write into dest, found: %#v", entries)
+	}
+}
+
+func TestInstallRejectsMissingManifest(t *testing.T) {
+	destDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "empty")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err == nil {
+		t.Fatalf("expected an error for a source without plugin.json")
+	}
+}
+
+func TestInstallNeverExecutesInstallScript(t *testing.T) {
+	destDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "PWNED")
+	src := writeSourcePlugin(t, filepath.Join(t.TempDir(), "src"), validManifest())
+	// Drop a hostile install script alongside the manifest. Install must copy the
+	// plugin tree verbatim but NEVER run anything.
+	script := filepath.Join(src, "install.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntouch "+marker+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatalf("install must never execute an install script")
+	}
+}
+
+func TestInstallReinstallShowsHashChange(t *testing.T) {
+	destDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "src")
+	writeSourcePlugin(t, src, validManifest())
+
+	first, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	bumped := validManifest()
+	bumped["version"] = "0.2.0"
+	writeSourcePlugin(t, src, bumped)
+	second, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	if !second.Updated {
+		t.Fatalf("reinstall with changed content should be flagged as an update")
+	}
+	if second.PreviousHash != first.Hash || second.Hash == first.Hash {
+		t.Fatalf("expected a hash change: prev=%q first=%q new=%q", second.PreviousHash, first.Hash, second.Hash)
+	}
+}
+
+func TestInstallNameClashWarnsAndDoesNotOverwriteWithoutForce(t *testing.T) {
+	destDir := t.TempDir()
+	srcA := writeSourcePlugin(t, filepath.Join(t.TempDir(), "a"), validManifest())
+	if _, err := Install(context.Background(), InstallOptions{Source: srcA, Dir: destDir}); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	srcB := writeSourcePlugin(t, filepath.Join(t.TempDir(), "b"), validManifest())
+	_, err := Install(context.Background(), InstallOptions{Source: srcB, Dir: destDir})
+	if !errors.Is(err, ErrNameClash) {
+		t.Fatalf("expected ErrNameClash from a different source, got %v", err)
+	}
+
+	if _, err := Install(context.Background(), InstallOptions{Source: srcB, Dir: destDir, Force: true}); err != nil {
+		t.Fatalf("forced reinstall: %v", err)
+	}
+	entries, _ := ReadLock(destDir)
+	if entries["zero.demo"].Source != srcB {
+		t.Fatalf("forced overwrite did not update source: %#v", entries["zero.demo"])
+	}
+}
+
+func TestInstallGitSourceUsesRunner(t *testing.T) {
+	destDir := t.TempDir()
+	used := false
+	runner := func(ctx context.Context, destination string, source string) error {
+		used = true
+		writeSourcePlugin(t, destination, validManifest())
+		return nil
+	}
+	result, err := Install(context.Background(), InstallOptions{
+		Source:    "https://example.com/plugin.git",
+		Dir:       destDir,
+		GitRunner: runner,
+	})
+	if err != nil {
+		t.Fatalf("install via runner: %v", err)
+	}
+	if !used {
+		t.Fatalf("git runner not invoked for URL source")
+	}
+	if result.ID != "zero.demo" {
+		t.Fatalf("ID = %q", result.ID)
+	}
+}
+
+func TestRemoveDeletesPluginAndLockEntry(t *testing.T) {
+	destDir := t.TempDir()
+	src := writeSourcePlugin(t, filepath.Join(t.TempDir(), "src"), validManifest())
+	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	if err := Remove(destDir, "zero.demo"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	loaded, _ := Load(LoadOptions{Roots: []Root{{Source: SourceUser, Path: destDir}}})
+	if len(loaded.Plugins) != 0 {
+		t.Fatalf("plugin still present after Remove: %#v", loaded.Plugins)
+	}
+	entries, _ := ReadLock(destDir)
+	if _, ok := entries["zero.demo"]; ok {
+		t.Fatalf("lockfile entry survived Remove")
+	}
+}
+
+func TestRemoveUnknownPluginErrors(t *testing.T) {
+	if err := Remove(t.TempDir(), "missing.plugin"); err == nil {
+		t.Fatalf("expected an error removing an unknown plugin")
+	}
+}
+
+// TestInstallCopiesEntireTree confirms install copies the whole plugin directory
+// (entry scripts, prompt/skill files) so an installed plugin is actually runnable
+// through Stage 09 activation — it just never executes any of it during install.
+func TestInstallCopiesEntireTree(t *testing.T) {
+	destDir := t.TempDir()
+	src := writeSourcePlugin(t, filepath.Join(t.TempDir(), "src"), map[string]any{
+		"schemaVersion": float64(1),
+		"id":            "zero.tool",
+		"name":          "Tool",
+		"version":       "0.1.0",
+		"tools": []any{map[string]any{
+			"name":    "lookup",
+			"command": "node",
+			"args":    []any{"tools/lookup.mjs"},
+		}},
+	})
+	entryDir := filepath.Join(src, "tools")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "lookup.mjs"), []byte("console.log('hi')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	copied := filepath.Join(filepath.Dir(result.ManifestPath), "tools", "lookup.mjs")
+	if _, err := os.Stat(copied); err != nil {
+		t.Fatalf("entry script not copied into install dir: %v", err)
+	}
+}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -1,0 +1,404 @@
+package skills
+
+// Distribution: install a skill from a git URL or a local path into the skills
+// directory, with a content hash recorded in a lockfile (skills.lock) so every
+// install/update is verifiable. Skills are markdown, so install NEVER executes
+// fetched content — it copies and validates the SKILL.md and nothing else.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LockFileName is the name of the per-directory lockfile that maps an installed
+// skill name to the source it was installed from and the content hash recorded
+// at install time.
+const LockFileName = "skills.lock"
+
+// ErrNameClash is returned when an install would overwrite a skill that was
+// installed from a DIFFERENT source, unless InstallOptions.Force is set. It is a
+// safety guard so a remote source can never silently shadow a skill the user
+// already trusts.
+var ErrNameClash = errors.New("a different skill with that name is already installed")
+
+// GitRunner fetches the skill at source into destination. The default runner
+// shallow-clones with the system git, which inherits the process environment
+// (and therefore any proxy/egress settings). It is injectable so tests never hit
+// the network. A runner must only fetch — it must never execute fetched content.
+type GitRunner func(ctx context.Context, destination string, source string) error
+
+// InstallOptions configures a single skill install.
+type InstallOptions struct {
+	// Source is a git URL or a local filesystem path to a skill directory (one
+	// that contains a SKILL.md, or whose tree contains exactly one).
+	Source string
+	// Dir is the skills directory to install into (typically DefaultDir(env)).
+	Dir string
+	// Force allows overwriting a skill that was installed from a different source.
+	Force bool
+	// GitRunner overrides the fetch implementation (tests/proxy control). When
+	// nil, a git source is shallow-cloned with the system git.
+	GitRunner GitRunner
+}
+
+// InstallResult reports what an install did.
+type InstallResult struct {
+	Name string `json:"name"`
+	// Path is the absolute path to the installed SKILL.md.
+	Path string `json:"path"`
+	// Hash is the content hash recorded for the installed skill.
+	Hash string `json:"hash"`
+	// Source echoes the source the skill was installed from.
+	Source string `json:"source"`
+	// Updated is true when an existing install was replaced; PreviousHash then
+	// carries the prior recorded hash so a caller can show the change.
+	Updated      bool   `json:"updated"`
+	PreviousHash string `json:"previousHash,omitempty"`
+}
+
+// LockEntry records the source and content hash for one installed skill.
+type LockEntry struct {
+	Source string `json:"source"`
+	Hash   string `json:"hash"`
+}
+
+// SkillInfo bundles a discovered skill with its recorded source and hash, for
+// `skill info`.
+type SkillInfo struct {
+	Skill  Skill  `json:"skill"`
+	Source string `json:"source,omitempty"`
+	Hash   string `json:"hash,omitempty"`
+}
+
+// Install fetches the skill at options.Source and copies its SKILL.md into
+// options.Dir/<name>/, validating the frontmatter and recording a content hash
+// in the lockfile. A git URL is fetched via the (injectable) GitRunner into a
+// temp dir; a local path is read in place. Fetched content is never executed.
+func Install(ctx context.Context, options InstallOptions) (InstallResult, error) {
+	source := strings.TrimSpace(options.Source)
+	if source == "" {
+		return InstallResult{}, errors.New("a skill source (git URL or path) is required")
+	}
+	dir := strings.TrimSpace(options.Dir)
+	if dir == "" {
+		return InstallResult{}, errors.New("a skills directory is required")
+	}
+
+	fetchDir, cleanup, err := fetchSource(ctx, source, options.GitRunner)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	defer cleanup()
+
+	skillDir, err := locateSkillDir(fetchDir)
+	if err != nil {
+		return InstallResult{}, err
+	}
+
+	// Validate by parsing the SKILL.md through the same loader the runtime uses;
+	// reject anything without a usable frontmatter/dir name.
+	manifestPath := filepath.Join(skillDir, skillFileName)
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("read SKILL.md: %w", err)
+	}
+	parsed := parseSkill(filepath.Base(skillDir), manifestPath, string(data))
+	name := strings.TrimSpace(parsed.Name)
+	if name == "" || !validSkillName(name) {
+		return InstallResult{}, fmt.Errorf("skill has no usable name (set a frontmatter `name:` or use a directory name of letters, numbers, dots, dashes, or underscores)")
+	}
+
+	hash := hashContent(data)
+
+	lock, err := ReadLock(dir)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	previous, existed := lock[name]
+	// A different source under the same name is a clash unless Force is set.
+	if existed && previous.Source != source && !options.Force {
+		return InstallResult{}, fmt.Errorf("%w: %q is installed from %s (use --force to overwrite)", ErrNameClash, name, previous.Source)
+	}
+
+	target := filepath.Join(dir, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("create skills dir: %w", err)
+	}
+	// Replace any existing install atomically-enough: write the new SKILL.md after
+	// clearing a prior directory so a re-install never mixes old and new files.
+	if err := os.RemoveAll(target); err != nil {
+		return InstallResult{}, fmt.Errorf("clear previous skill: %w", err)
+	}
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("create skill dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, skillFileName), data, 0o644); err != nil {
+		return InstallResult{}, fmt.Errorf("write SKILL.md: %w", err)
+	}
+
+	lock[name] = LockEntry{Source: source, Hash: hash}
+	if err := writeLock(dir, lock); err != nil {
+		return InstallResult{}, err
+	}
+
+	result := InstallResult{
+		Name:   name,
+		Path:   filepath.Join(target, skillFileName),
+		Hash:   hash,
+		Source: source,
+	}
+	if existed {
+		result.Updated = previous.Hash != hash
+		result.PreviousHash = previous.Hash
+	}
+	return result, nil
+}
+
+// Remove deletes an installed skill directory and its lockfile entry. It errors
+// if the named skill is not present in either the dir or the lockfile.
+func Remove(dir string, name string) error {
+	dir = strings.TrimSpace(dir)
+	name = strings.TrimSpace(name)
+	if dir == "" || name == "" {
+		return errors.New("a skills directory and skill name are required")
+	}
+	if !validSkillName(name) {
+		return fmt.Errorf("invalid skill name %q", name)
+	}
+
+	lock, err := ReadLock(dir)
+	if err != nil {
+		return err
+	}
+	_, locked := lock[name]
+	target := filepath.Join(dir, name)
+	_, statErr := os.Stat(target)
+	present := statErr == nil
+	if !locked && !present {
+		return fmt.Errorf("skill %q is not installed", name)
+	}
+
+	if present {
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("remove skill dir: %w", err)
+		}
+	}
+	if locked {
+		delete(lock, name)
+		if err := writeLock(dir, lock); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Info returns the named skill plus its recorded source and hash, or ok=false if
+// it is not discoverable in dir.
+func Info(dir string, name string) (SkillInfo, bool) {
+	skill, ok := Get(dir, name)
+	if !ok {
+		return SkillInfo{}, false
+	}
+	info := SkillInfo{Skill: skill}
+	if lock, err := ReadLock(dir); err == nil {
+		if entry, found := lock[skill.Name]; found {
+			info.Source = entry.Source
+			info.Hash = entry.Hash
+		}
+	}
+	return info, true
+}
+
+// ReadLock loads the lockfile from dir. A missing lockfile yields an empty map
+// with no error so callers can treat "no lockfile" as "nothing installed".
+func ReadLock(dir string) (map[string]LockEntry, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return map[string]LockEntry{}, nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, LockFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]LockEntry{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", LockFileName, err)
+	}
+	entries := map[string]LockEntry{}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return entries, nil
+	}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", LockFileName, err)
+	}
+	return entries, nil
+}
+
+// writeLock persists the lockfile deterministically (json.Marshal sorts map keys),
+// creating the skills dir if necessary.
+func writeLock(dir string, entries map[string]LockEntry) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create skills dir: %w", err)
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", LockFileName, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LockFileName), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", LockFileName, err)
+	}
+	return nil
+}
+
+// fetchSource resolves a source into a local directory to read from. A local
+// path is used in place (no copy, no cleanup); a git URL is shallow-cloned into a
+// temp dir via the runner. The returned cleanup is always safe to call.
+func fetchSource(ctx context.Context, source string, runner GitRunner) (string, func(), error) {
+	if isLocalPath(source) {
+		info, err := os.Stat(source)
+		if err != nil {
+			return "", func() {}, fmt.Errorf("read source: %w", err)
+		}
+		if !info.IsDir() {
+			return "", func() {}, fmt.Errorf("source must be a directory: %s", source)
+		}
+		abs, err := filepath.Abs(source)
+		if err != nil {
+			return "", func() {}, err
+		}
+		return abs, func() {}, nil
+	}
+
+	if runner == nil {
+		runner = defaultGitRunner
+	}
+	temp, err := os.MkdirTemp("", "zero-skill-fetch-")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create temp dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(temp) }
+	if err := runner(ctx, temp, source); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("fetch %s: %w", source, err)
+	}
+	return temp, cleanup, nil
+}
+
+// defaultGitRunner shallow-clones source into destination. exec.CommandContext
+// inherits the process environment, so proxy/egress settings are honored, and
+// GIT_TERMINAL_PROMPT=0 keeps a missing-credential clone from blocking on a
+// terminal prompt. Cloning only fetches; it never executes repository content.
+func defaultGitRunner(ctx context.Context, destination string, source string) error {
+	command := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--", source, destination)
+	command.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if output, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone failed: %v: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// locateSkillDir finds the directory holding the SKILL.md within root. The common
+// case is a SKILL.md at the root; otherwise it searches one level deeper (a repo
+// whose skill lives in a subdirectory) and requires exactly one match so the
+// install target is unambiguous.
+func locateSkillDir(root string) (string, error) {
+	if fileExists(filepath.Join(root, skillFileName)) {
+		return root, nil
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", fmt.Errorf("scan source: %w", err)
+	}
+	matches := []string{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(root, entry.Name())
+		if fileExists(filepath.Join(candidate, skillFileName)) {
+			matches = append(matches, candidate)
+		}
+	}
+	sort.Strings(matches)
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no %s found in source", skillFileName)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("source contains multiple skills (%d); install one at a time", len(matches))
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// isLocalPath reports whether source should be treated as a local filesystem
+// path rather than a remote URL. URLs (scheme://… or scp-style host:path) and
+// the common git shorthand are treated as remote.
+func isLocalPath(source string) bool {
+	if source == "" {
+		return false
+	}
+	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") || strings.HasPrefix(source, "~") {
+		return true
+	}
+	if filepath.IsAbs(source) {
+		return true
+	}
+	if hasURLScheme(source) {
+		return false
+	}
+	// scp-style git remote: user@host:path or host:path (no scheme). A Windows
+	// drive path (C:\…) is local, so only treat host:path as remote when the
+	// segment before ':' is not a single drive letter.
+	if idx := strings.Index(source, ":"); idx > 0 {
+		host := source[:idx]
+		if strings.Contains(host, "@") {
+			return false
+		}
+		if len(host) == 1 {
+			return true // drive letter
+		}
+		if strings.Contains(host, ".") {
+			return false // looks like a hostname
+		}
+	}
+	return true
+}
+
+func hasURLScheme(source string) bool {
+	for _, scheme := range []string{"http://", "https://", "git://", "ssh://", "git+ssh://", "ftp://", "ftps://", "file://"} {
+		if strings.HasPrefix(strings.ToLower(source), scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+// validSkillName mirrors the install target safety rule: a skill name becomes a
+// single directory component, so it must not contain path separators or traversal.
+func validSkillName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return false
+	}
+	return name == filepath.Base(name)
+}
+
+func hashContent(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -92,6 +92,9 @@ func Install(ctx context.Context, options InstallOptions) (InstallResult, error)
 	if dir == "" {
 		return InstallResult{}, errors.New("a skills directory is required")
 	}
+	// Canonicalize a local source so clash detection keys off the resolved path,
+	// not the spelling the user typed (relative vs absolute, symlinked vs not).
+	source = canonicalSource(source)
 
 	fetchDir, cleanup, err := fetchSource(ctx, source, options.GitRunner)
 	if err != nil {
@@ -341,6 +344,25 @@ func locateSkillDir(root string) (string, error) {
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.Mode().IsRegular()
+}
+
+// canonicalSource normalizes a local filesystem source to an absolute,
+// symlink-evaluated path so a re-install via a different spelling of the same
+// directory is recognized as the same source. Remote sources (git URLs) are
+// returned unchanged. On any resolution error the input is returned as-is so a
+// non-existent local path still surfaces its real error later in fetchSource.
+func canonicalSource(source string) string {
+	if !isLocalPath(source) {
+		return source
+	}
+	abs, err := filepath.Abs(source)
+	if err != nil {
+		return source
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
 }
 
 // isLocalPath reports whether source should be treated as a local filesystem

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -1,0 +1,341 @@
+package skills
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initGitSkillRepo creates a real local git repo holding a skill and returns a
+// file:// URL for it, so the DEFAULT git runner (system git) is exercised end to
+// end rather than only the injected runner. The test is skipped when git is
+// unavailable.
+func initGitSkillRepo(t *testing.T, content string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	writeSourceSkill(t, repo, content)
+	run("add", "-A")
+	run("commit", "-qm", "init")
+	return "file://" + repo
+}
+
+func TestInstallFromRealLocalGitRepo(t *testing.T) {
+	destDir := t.TempDir()
+	url := initGitSkillRepo(t, "---\nname: from-git\ndescription: cloned\n---\nbody from git\n")
+
+	result, err := Install(context.Background(), InstallOptions{Source: url, Dir: destDir})
+	if err != nil {
+		t.Fatalf("Install from git: %v", err)
+	}
+	if result.Name != "from-git" {
+		t.Fatalf("Name = %q, want from-git", result.Name)
+	}
+	got, ok := Get(destDir, "from-git")
+	if !ok || !strings.Contains(got.Content, "body from git") {
+		t.Fatalf("installed git skill not discoverable: ok=%v skill=%+v", ok, got)
+	}
+	// The .git clone metadata must not leak into the skills dir.
+	if _, err := os.Stat(filepath.Join(destDir, "from-git", ".git")); err == nil {
+		t.Fatalf(".git metadata must not be installed into the skills dir")
+	}
+}
+
+// writeSourceSkill lays out a candidate skill directory containing a SKILL.md so
+// it can be used as a local install source.
+func writeSourceSkill(t *testing.T, dir string, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, skillFileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	return dir
+}
+
+func TestInstallCopiesLocalSkillAndRecordsHash(t *testing.T) {
+	destDir := t.TempDir()
+	source := writeSourceSkill(t, filepath.Join(t.TempDir(), "src"),
+		"---\nname: confirmation-policy\ndescription: Ask first.\n---\nAsk before risky actions.\n")
+
+	result, err := Install(context.Background(), InstallOptions{Source: source, Dir: destDir})
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if result.Name != "confirmation-policy" {
+		t.Fatalf("Name = %q, want confirmation-policy", result.Name)
+	}
+	if result.Hash == "" {
+		t.Fatalf("expected a recorded content hash")
+	}
+	if result.Updated {
+		t.Fatalf("first install should not be flagged as an update")
+	}
+
+	// The skill is discoverable through the normal loader.
+	got, ok := Get(destDir, "confirmation-policy")
+	if !ok {
+		t.Fatalf("installed skill not discoverable via Get")
+	}
+	if !strings.Contains(got.Content, "Ask before risky actions.") {
+		t.Fatalf("installed content unexpected: %q", got.Content)
+	}
+
+	// The lockfile records name -> source + hash.
+	entries, err := ReadLock(destDir)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	entry, ok := entries["confirmation-policy"]
+	if !ok {
+		t.Fatalf("lockfile missing entry for confirmation-policy: %#v", entries)
+	}
+	if entry.Hash != result.Hash {
+		t.Fatalf("lockfile hash %q != install hash %q", entry.Hash, result.Hash)
+	}
+	if entry.Source != source {
+		t.Fatalf("lockfile source = %q, want %q", entry.Source, source)
+	}
+}
+
+func TestInstallRejectsInvalidSkill(t *testing.T) {
+	destDir := t.TempDir()
+	// A source directory with no SKILL.md is not a valid skill.
+	src := filepath.Join(t.TempDir(), "empty")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err == nil {
+		t.Fatalf("expected an error for a source without SKILL.md")
+	}
+	// Nothing should have been written into the destination dir.
+	if entries, _ := os.ReadDir(destDir); len(entries) != 0 {
+		t.Fatalf("invalid source must not write into dest, found: %#v", entries)
+	}
+}
+
+func TestInstallRejectsSkillWithBlankFrontmatterName(t *testing.T) {
+	destDir := t.TempDir()
+	// Frontmatter present but the name resolves to empty after trimming; the dir
+	// name is also blank-ish so there is nothing valid to install under.
+	src := writeSourceSkill(t, filepath.Join(t.TempDir(), " "),
+		"---\nname:    \n---\nbody\n")
+
+	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err == nil {
+		t.Fatalf("expected rejection of a skill with no usable name")
+	}
+}
+
+func TestInstallReinstallShowsHashChange(t *testing.T) {
+	destDir := t.TempDir()
+	srcRoot := t.TempDir()
+	src := writeSourceSkill(t, filepath.Join(srcRoot, "src"),
+		"---\nname: demo\ndescription: v1\n---\nfirst body\n")
+
+	first, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+
+	// Change the source content and reinstall.
+	writeSourceSkill(t, src, "---\nname: demo\ndescription: v2\n---\nsecond body\n")
+	second, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	if !second.Updated {
+		t.Fatalf("reinstall with changed content should be flagged as an update")
+	}
+	if second.PreviousHash != first.Hash {
+		t.Fatalf("PreviousHash = %q, want %q", second.PreviousHash, first.Hash)
+	}
+	if second.Hash == first.Hash {
+		t.Fatalf("hash should change when content changes")
+	}
+
+	// The lockfile reflects the new hash.
+	entries, err := ReadLock(destDir)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if entries["demo"].Hash != second.Hash {
+		t.Fatalf("lockfile not updated: %q != %q", entries["demo"].Hash, second.Hash)
+	}
+
+	// The installed content is the new version.
+	got, _ := Get(destDir, "demo")
+	if !strings.Contains(got.Content, "second body") {
+		t.Fatalf("reinstall did not overwrite content: %q", got.Content)
+	}
+}
+
+func TestInstallNameClashWarnsAndDoesNotOverwriteWithoutForce(t *testing.T) {
+	destDir := t.TempDir()
+	// Pre-existing skill installed from source A.
+	srcA := writeSourceSkill(t, filepath.Join(t.TempDir(), "a"),
+		"---\nname: shared\ndescription: original\n---\noriginal body\n")
+	if _, err := Install(context.Background(), InstallOptions{Source: srcA, Dir: destDir}); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+
+	// A different source declaring the same name must not silently overwrite.
+	srcB := writeSourceSkill(t, filepath.Join(t.TempDir(), "b"),
+		"---\nname: shared\ndescription: replacement\n---\nreplacement body\n")
+	_, err := Install(context.Background(), InstallOptions{Source: srcB, Dir: destDir})
+	if !errors.Is(err, ErrNameClash) {
+		t.Fatalf("expected ErrNameClash without Force, got %v", err)
+	}
+
+	// The original content survives.
+	got, _ := Get(destDir, "shared")
+	if !strings.Contains(got.Content, "original body") {
+		t.Fatalf("clash should not overwrite: %q", got.Content)
+	}
+
+	// With Force the install proceeds and overwrites.
+	result, err := Install(context.Background(), InstallOptions{Source: srcB, Dir: destDir, Force: true})
+	if err != nil {
+		t.Fatalf("forced reinstall: %v", err)
+	}
+	if !result.Updated {
+		t.Fatalf("forced overwrite should be flagged as an update")
+	}
+	got, _ = Get(destDir, "shared")
+	if !strings.Contains(got.Content, "replacement body") {
+		t.Fatalf("forced overwrite did not replace content: %q", got.Content)
+	}
+}
+
+// TestInstallReinstallSameSourceUnchangedIsNotAClash verifies that re-running an
+// install from the SAME recorded source is treated as an idempotent update, not a
+// name clash (the clash guard only protects against a DIFFERENT source).
+func TestInstallReinstallSameSourceUnchangedIsNotAClash(t *testing.T) {
+	destDir := t.TempDir()
+	src := writeSourceSkill(t, filepath.Join(t.TempDir(), "src"),
+		"---\nname: demo\ndescription: v1\n---\nbody\n")
+	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	result, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("idempotent reinstall from same source should succeed, got %v", err)
+	}
+	if result.Updated {
+		t.Fatalf("reinstall of identical content from same source is not an update")
+	}
+}
+
+func TestInstallGitSourceUsesRunnerAndDoesNotExecuteContent(t *testing.T) {
+	destDir := t.TempDir()
+	cloneRoot := t.TempDir()
+
+	executed := false
+	runner := func(ctx context.Context, destination string, source string) error {
+		// Emulate a clone by laying down a skill plus a hostile executable that
+		// must NEVER be run during install.
+		writeSourceSkill(t, destination, "---\nname: remote\ndescription: fetched\n---\nremote body\n")
+		script := filepath.Join(destination, "install.sh")
+		if err := os.WriteFile(script, []byte("#!/bin/sh\ntouch "+filepath.Join(cloneRoot, "PWNED")+"\n"), 0o755); err != nil {
+			return err
+		}
+		executed = true
+		return nil
+	}
+
+	result, err := Install(context.Background(), InstallOptions{
+		Source:    "https://example.com/remote-skill.git",
+		Dir:       destDir,
+		GitRunner: runner,
+	})
+	if err != nil {
+		t.Fatalf("Install via git runner: %v", err)
+	}
+	if !executed {
+		t.Fatalf("git runner was not invoked for a URL source")
+	}
+	if result.Name != "remote" {
+		t.Fatalf("Name = %q, want remote", result.Name)
+	}
+	// The hostile install script must not have run.
+	if _, err := os.Stat(filepath.Join(cloneRoot, "PWNED")); err == nil {
+		t.Fatalf("install must never execute fetched content")
+	}
+	// The fetched executable must not be copied into the skills dir either (skills
+	// are markdown — only SKILL.md is installed, not arbitrary fetched files).
+	if _, err := os.Stat(filepath.Join(destDir, "remote", "install.sh")); err == nil {
+		t.Fatalf("install must not copy fetched executable into the skills dir")
+	}
+}
+
+func TestRemoveDeletesSkillAndLockEntry(t *testing.T) {
+	destDir := t.TempDir()
+	src := writeSourceSkill(t, filepath.Join(t.TempDir(), "src"),
+		"---\nname: demo\ndescription: d\n---\nbody\n")
+	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	if err := Remove(destDir, "demo"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, ok := Get(destDir, "demo"); ok {
+		t.Fatalf("skill still present after Remove")
+	}
+	entries, err := ReadLock(destDir)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if _, ok := entries["demo"]; ok {
+		t.Fatalf("lockfile entry survived Remove: %#v", entries)
+	}
+}
+
+func TestRemoveUnknownSkillErrors(t *testing.T) {
+	if err := Remove(t.TempDir(), "nope"); err == nil {
+		t.Fatalf("expected an error removing an unknown skill")
+	}
+}
+
+func TestInfoReturnsFrontmatterSourceAndHash(t *testing.T) {
+	destDir := t.TempDir()
+	src := writeSourceSkill(t, filepath.Join(t.TempDir(), "src"),
+		"---\nname: demo\ndescription: described\n---\nbody text\n")
+	installed, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	info, ok := Info(destDir, "demo")
+	if !ok {
+		t.Fatalf("Info(demo) not found")
+	}
+	if info.Skill.Description != "described" {
+		t.Fatalf("Info description = %q", info.Skill.Description)
+	}
+	if info.Source != src {
+		t.Fatalf("Info source = %q, want %q", info.Source, src)
+	}
+	if info.Hash != installed.Hash {
+		t.Fatalf("Info hash = %q, want %q", info.Hash, installed.Hash)
+	}
+}

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -206,17 +206,14 @@ func TestInstallSameLocalSourceDifferentSpellingIsNotAClash(t *testing.T) {
 		t.Fatalf("first install: %v", err)
 	}
 
-	// Reinstall using a relative spelling of the same directory.
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	rel, err := filepath.Rel(wd, abs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := Install(context.Background(), InstallOptions{Source: rel, Dir: destDir}); err != nil {
-		t.Fatalf("reinstall with relative spelling should not clash: %v", err)
+	// Reinstall using a different textual spelling of the same directory (a
+	// redundant "/./" segment). canonicalSource normalizes both spellings to the
+	// same absolute path, so this must not be treated as a clash. (A cwd-relative
+	// spelling can't be expressed across drives on Windows, where the temp dir and
+	// the repo live on different volumes, so use a same-directory alternate.)
+	messy := filepath.Dir(abs) + string(filepath.Separator) + "." + string(filepath.Separator) + filepath.Base(abs)
+	if _, err := Install(context.Background(), InstallOptions{Source: messy, Dir: destDir}); err != nil {
+		t.Fatalf("reinstall with an equivalent spelling should not clash: %v", err)
 	}
 
 	want := canonicalSource(abs)

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -111,8 +111,9 @@ func TestInstallCopiesLocalSkillAndRecordsHash(t *testing.T) {
 	if entry.Hash != result.Hash {
 		t.Fatalf("lockfile hash %q != install hash %q", entry.Hash, result.Hash)
 	}
-	if entry.Source != source {
-		t.Fatalf("lockfile source = %q, want %q", entry.Source, source)
+	// The recorded source is the canonical (absolute, symlink-resolved) local path.
+	if entry.Source != canonicalSource(source) {
+		t.Fatalf("lockfile source = %q, want %q", entry.Source, canonicalSource(source))
 	}
 }
 
@@ -188,6 +189,43 @@ func TestInstallReinstallShowsHashChange(t *testing.T) {
 	got, _ := Get(destDir, "demo")
 	if !strings.Contains(got.Content, "second body") {
 		t.Fatalf("reinstall did not overwrite content: %q", got.Content)
+	}
+}
+
+// TestInstallSameLocalSourceDifferentSpellingIsNotAClash verifies that a local
+// source installed via one spelling (e.g. a relative path) and re-installed via
+// an equivalent spelling (the absolute path) is treated as the same source, not
+// a clash, because the recorded source is canonicalized.
+func TestInstallSameLocalSourceDifferentSpellingIsNotAClash(t *testing.T) {
+	destDir := t.TempDir()
+	srcRoot := t.TempDir()
+	abs := writeSourceSkill(t, filepath.Join(srcRoot, "src"),
+		"---\nname: demo\ndescription: v1\n---\nbody\n")
+
+	if _, err := Install(context.Background(), InstallOptions{Source: abs, Dir: destDir}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Reinstall using a relative spelling of the same directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rel, err := filepath.Rel(wd, abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install(context.Background(), InstallOptions{Source: rel, Dir: destDir}); err != nil {
+		t.Fatalf("reinstall with relative spelling should not clash: %v", err)
+	}
+
+	want := canonicalSource(abs)
+	entries, err := ReadLock(destDir)
+	if err != nil {
+		t.Fatalf("ReadLock: %v", err)
+	}
+	if entries["demo"].Source != want {
+		t.Fatalf("lockfile should record the canonical source %q, got %q", want, entries["demo"].Source)
 	}
 }
 
@@ -334,8 +372,8 @@ func TestInfoReturnsFrontmatterSourceAndHash(t *testing.T) {
 	if info.Skill.Description != "described" {
 		t.Fatalf("Info description = %q", info.Skill.Description)
 	}
-	if info.Source != src {
-		t.Fatalf("Info source = %q, want %q", info.Source, src)
+	if info.Source != installed.Source {
+		t.Fatalf("Info source = %q, want %q", info.Source, installed.Source)
 	}
 	if info.Hash != installed.Hash {
 		t.Fatalf("Info hash = %q, want %q", info.Hash, installed.Hash)

--- a/internal/skills/install_test.go
+++ b/internal/skills/install_test.go
@@ -136,9 +136,11 @@ func TestInstallRejectsInvalidSkill(t *testing.T) {
 
 func TestInstallRejectsSkillWithBlankFrontmatterName(t *testing.T) {
 	destDir := t.TempDir()
-	// Frontmatter present but the name resolves to empty after trimming; the dir
-	// name is also blank-ish so there is nothing valid to install under.
-	src := writeSourceSkill(t, filepath.Join(t.TempDir(), " "),
+	// Frontmatter name is blank, so the name falls back to the source dir's base —
+	// which is itself not a usable skill name (validSkillName rejects "..") — so
+	// there is nothing valid to install under. (A whitespace-only dir name would be
+	// the other no-usable-name case, but that is not creatable on Windows.)
+	src := writeSourceSkill(t, filepath.Join(t.TempDir(), "no..usable..name"),
 		"---\nname:    \n---\nbody\n")
 
 	if _, err := Install(context.Background(), InstallOptions{Source: src, Dir: destDir}); err == nil {

--- a/internal/tools/scaffold.go
+++ b/internal/tools/scaffold.go
@@ -1,0 +1,246 @@
+package tools
+
+// Distribution: scaffold a new plugin-tool skeleton in the user's toolbox dir.
+// It writes a plugin manifest (schemaVersion 1, one prompt-gated tool with an
+// empty parameter schema and a command pointing at the entry stub) plus a
+// runnable stub carrying a clear TODO. After plugin activation the scaffolded
+// tool is loadable like any other local plugin. Generated content is data only —
+// scaffolding never executes anything.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ScaffoldRuntime selects the entry-stub language. The default is a POSIX shell
+// stub, which has no interpreter install dependency; node/python are offered for
+// authors who prefer them. Runtimes are deliberately model-provider-agnostic.
+type ScaffoldRuntime string
+
+const (
+	RuntimeShell  ScaffoldRuntime = "shell"
+	RuntimeNode   ScaffoldRuntime = "node"
+	RuntimePython ScaffoldRuntime = "python"
+)
+
+// scaffoldNamePattern matches a safe single-segment tool name (also a valid
+// plugin id and directory component).
+var scaffoldNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// ScaffoldOptions configures a single tool scaffold.
+type ScaffoldOptions struct {
+	// Name is the tool/plugin id (a single path segment).
+	Name string
+	// Dir is the toolbox directory to create the plugin under (typically the user
+	// plugins root).
+	Dir string
+	// Description is an optional human description; a default is used when empty.
+	Description string
+	// Runtime selects the entry-stub language; defaults to RuntimeShell.
+	Runtime ScaffoldRuntime
+}
+
+// ScaffoldResult reports the generated layout.
+type ScaffoldResult struct {
+	Name         string `json:"name"`
+	PluginDir    string `json:"pluginDir"`
+	ManifestPath string `json:"manifestPath"`
+	EntryPath    string `json:"entryPath"`
+}
+
+// runtimeSpec describes how to invoke a stub of a given runtime and what stub
+// body/filename to emit.
+type runtimeSpec struct {
+	entryFile string
+	command   string
+	// argsBefore are command args that precede the entry path (e.g. interpreter
+	// scripts pass the script path as an arg; an executable shell script is the
+	// command itself and needs no preceding args).
+	usesScriptArg bool
+	mode          os.FileMode
+	body          func(name string, description string) string
+}
+
+func runtimeSpecFor(runtime ScaffoldRuntime) (runtimeSpec, error) {
+	switch runtime {
+	case "", RuntimeShell:
+		return runtimeSpec{
+			entryFile:     "run.sh",
+			command:       "sh",
+			usesScriptArg: true,
+			mode:          0o755,
+			body:          shellStub,
+		}, nil
+	case RuntimeNode:
+		return runtimeSpec{
+			entryFile:     "run.mjs",
+			command:       "node",
+			usesScriptArg: true,
+			mode:          0o644,
+			body:          nodeStub,
+		}, nil
+	case RuntimePython:
+		return runtimeSpec{
+			entryFile:     "run.py",
+			command:       "python3",
+			usesScriptArg: true,
+			mode:          0o644,
+			body:          pythonStub,
+		}, nil
+	default:
+		return runtimeSpec{}, fmt.Errorf("unknown runtime %q (use shell, node, or python)", runtime)
+	}
+}
+
+// Scaffold generates a plugin-tool skeleton under options.Dir/<name>/ and returns
+// the created paths. It refuses an invalid name, a missing dir, or an existing
+// target so it never clobbers prior work.
+func Scaffold(options ScaffoldOptions) (ScaffoldResult, error) {
+	name := strings.TrimSpace(options.Name)
+	if name == "" {
+		return ScaffoldResult{}, fmt.Errorf("a tool name is required")
+	}
+	if name != filepath.Base(name) || !scaffoldNamePattern.MatchString(name) || strings.Contains(name, "..") {
+		return ScaffoldResult{}, fmt.Errorf("invalid tool name %q (use letters, numbers, dots, dashes, or underscores)", name)
+	}
+	dir := strings.TrimSpace(options.Dir)
+	if dir == "" {
+		return ScaffoldResult{}, fmt.Errorf("a toolbox directory is required")
+	}
+
+	spec, err := runtimeSpecFor(options.Runtime)
+	if err != nil {
+		return ScaffoldResult{}, err
+	}
+
+	pluginDir := filepath.Join(dir, name)
+	if _, err := os.Stat(pluginDir); err == nil {
+		return ScaffoldResult{}, fmt.Errorf("a tool already exists at %s", pluginDir)
+	} else if !os.IsNotExist(err) {
+		return ScaffoldResult{}, fmt.Errorf("stat %s: %w", pluginDir, err)
+	}
+
+	description := strings.TrimSpace(options.Description)
+	if description == "" {
+		description = "TODO: describe what the " + name + " tool does."
+	}
+
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		return ScaffoldResult{}, fmt.Errorf("create tool dir: %w", err)
+	}
+
+	entryPath := filepath.Join(pluginDir, spec.entryFile)
+	if err := os.WriteFile(entryPath, []byte(spec.body(name, description)), spec.mode); err != nil {
+		return ScaffoldResult{}, fmt.Errorf("write entry stub: %w", err)
+	}
+
+	// The command points at the stub. Args reference the entry by its path
+	// RELATIVE to the plugin dir, matching how the loader resolves plugin tool
+	// args (plugin paths stay inside the plugin directory).
+	args := []string{}
+	if spec.usesScriptArg {
+		args = append(args, spec.entryFile)
+	}
+	manifest := map[string]any{
+		"schemaVersion": 1,
+		"id":            name,
+		"name":          name,
+		"version":       "0.1.0",
+		"description":   description,
+		"tools": []map[string]any{{
+			"name":        name,
+			"description": description,
+			"command":     spec.command,
+			"args":        args,
+			"inputSchema": map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"additionalProperties": false,
+			},
+			// Prompt-gated by default: a freshly scaffolded tool must never be
+			// auto-approved. Activation applies the normal permission flow.
+			"permission": "prompt",
+		}},
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return ScaffoldResult{}, fmt.Errorf("encode manifest: %w", err)
+	}
+	manifestPath := filepath.Join(pluginDir, "plugin.json")
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o644); err != nil {
+		return ScaffoldResult{}, fmt.Errorf("write manifest: %w", err)
+	}
+
+	return ScaffoldResult{
+		Name:         name,
+		PluginDir:    pluginDir,
+		ManifestPath: manifestPath,
+		EntryPath:    entryPath,
+	}, nil
+}
+
+func shellStub(name string, description string) string {
+	return `#!/bin/sh
+# ` + name + ` — Zero plugin tool entry point.
+# ` + description + `
+#
+# Zero invokes this script with the tool-call arguments as a single JSON object
+# on stdin and expects the tool result on stdout.
+#
+# TODO: read the JSON arguments from stdin, do the work, and print a result.
+set -eu
+
+input="$(cat)"
+echo "TODO: implement ${0##*/}. Received arguments: ${input}"
+`
+}
+
+func nodeStub(name string, description string) string {
+	return `// ` + name + ` — Zero plugin tool entry point.
+// ` + description + `
+//
+// Zero invokes this script with the tool-call arguments as a single JSON object
+// on stdin and expects the tool result on stdout.
+
+import process from "node:process";
+
+let raw = "";
+process.stdin.on("data", (chunk) => {
+  raw += chunk;
+});
+process.stdin.on("end", () => {
+  // TODO: parse the JSON arguments and do the work.
+  const args = raw.trim() ? JSON.parse(raw) : {};
+  process.stdout.write("TODO: implement ` + name + `. Received: " + JSON.stringify(args) + "\n");
+});
+`
+}
+
+func pythonStub(name string, description string) string {
+	return `#!/usr/bin/env python3
+"""` + name + ` — Zero plugin tool entry point.
+
+` + description + `
+
+Zero invokes this script with the tool-call arguments as a single JSON object on
+stdin and expects the tool result on stdout.
+"""
+import json
+import sys
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    # TODO: parse the JSON arguments and do the work.
+    args = json.loads(raw) if raw.strip() else {}
+    print("TODO: implement ` + name + `. Received:", json.dumps(args))
+
+
+if __name__ == "__main__":
+    main()
+`
+}

--- a/internal/tools/scaffold_test.go
+++ b/internal/tools/scaffold_test.go
@@ -86,6 +86,69 @@ func commandReferencesEntry(tool plugins.ToolExtension, entryPath string, plugin
 	return false
 }
 
+// TestScaffoldCoversAllRuntimes exercises every runtimeSpecFor branch (shell,
+// node, python) so template/manifest drift in the non-default runtimes is caught:
+// each must produce an entry stub inside the plugin dir, a manifest that parses
+// against the real plugin schema, and a tool command that references the entry.
+func TestScaffoldCoversAllRuntimes(t *testing.T) {
+	for _, runtime := range []tools.ScaffoldRuntime{tools.RuntimeShell, tools.RuntimeNode, tools.RuntimePython} {
+		runtime := runtime
+		t.Run(string(runtime), func(t *testing.T) {
+			dir := t.TempDir()
+			name := "tool-" + string(runtime)
+			pluginDir := filepath.Join(dir, name)
+
+			result, err := tools.Scaffold(tools.ScaffoldOptions{Name: name, Dir: dir, Runtime: runtime})
+			if err != nil {
+				t.Fatalf("Scaffold(%s) returned error: %v", runtime, err)
+			}
+			if result.ManifestPath != filepath.Join(pluginDir, "plugin.json") {
+				t.Fatalf("ManifestPath = %q, want under %q", result.ManifestPath, pluginDir)
+			}
+			if _, err := os.Stat(result.ManifestPath); err != nil {
+				t.Fatalf("manifest not created: %v", err)
+			}
+			if _, err := os.Stat(result.EntryPath); err != nil {
+				t.Fatalf("entry stub not created: %v", err)
+			}
+			if !strings.HasPrefix(result.EntryPath, pluginDir) {
+				t.Fatalf("entry stub should live inside the plugin dir, got %q", result.EntryPath)
+			}
+
+			data, err := os.ReadFile(result.ManifestPath)
+			if err != nil {
+				t.Fatalf("read manifest: %v", err)
+			}
+			var raw any
+			if err := json.Unmarshal(data, &raw); err != nil {
+				t.Fatalf("manifest is not valid JSON: %v\n%s", err, data)
+			}
+			plugin, err := plugins.ParseManifest(raw, plugins.ParseManifestOptions{
+				Source:       plugins.SourceUser,
+				Root:         dir,
+				PluginDir:    pluginDir,
+				ManifestPath: result.ManifestPath,
+			})
+			if err != nil {
+				t.Fatalf("generated manifest does not parse: %v", err)
+			}
+			if len(plugin.Tools) != 1 {
+				t.Fatalf("expected exactly one tool, got %d", len(plugin.Tools))
+			}
+			tool := plugin.Tools[0]
+			if tool.Command == "" {
+				t.Fatalf("tool command should not be empty")
+			}
+			if !commandReferencesEntry(tool, result.EntryPath, pluginDir) {
+				t.Fatalf("manifest command/args do not reference the entry script: cmd=%q args=%v entry=%q", tool.Command, tool.Args, result.EntryPath)
+			}
+			if tool.Permission != plugins.PermissionPrompt {
+				t.Fatalf("scaffolded tool permission = %q, want prompt", tool.Permission)
+			}
+		})
+	}
+}
+
 func TestScaffoldStubIsRunnableShape(t *testing.T) {
 	dir := t.TempDir()
 	result, err := tools.Scaffold(tools.ScaffoldOptions{Name: "greeter", Dir: dir})

--- a/internal/tools/scaffold_test.go
+++ b/internal/tools/scaffold_test.go
@@ -1,0 +1,147 @@
+package tools_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestScaffoldCreatesManifestAndStub(t *testing.T) {
+	dir := t.TempDir()
+
+	result, err := tools.Scaffold(tools.ScaffoldOptions{Name: "foo", Dir: dir})
+	if err != nil {
+		t.Fatalf("Scaffold returned error: %v", err)
+	}
+
+	// The plugin lives under dir/<name>/ with a manifest and an entry stub.
+	manifestPath := filepath.Join(dir, "foo", "plugin.json")
+	if result.ManifestPath != manifestPath {
+		t.Fatalf("ManifestPath = %q, want %q", result.ManifestPath, manifestPath)
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("manifest not created: %v", err)
+	}
+	if _, err := os.Stat(result.EntryPath); err != nil {
+		t.Fatalf("entry stub not created: %v", err)
+	}
+	if filepath.Dir(result.EntryPath) == "" || !strings.HasPrefix(result.EntryPath, filepath.Join(dir, "foo")) {
+		t.Fatalf("entry stub should live inside the plugin dir, got %q", result.EntryPath)
+	}
+
+	// The generated manifest parses against the real plugin schema.
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v\n%s", err, data)
+	}
+	plugin, err := plugins.ParseManifest(raw, plugins.ParseManifestOptions{
+		Source:       plugins.SourceUser,
+		Root:         dir,
+		PluginDir:    filepath.Join(dir, "foo"),
+		ManifestPath: manifestPath,
+	})
+	if err != nil {
+		t.Fatalf("generated manifest does not parse: %v", err)
+	}
+	if len(plugin.Tools) != 1 {
+		t.Fatalf("expected exactly one tool, got %d", len(plugin.Tools))
+	}
+	tool := plugin.Tools[0]
+	if tool.Name != "foo" {
+		t.Fatalf("tool name = %q, want foo", tool.Name)
+	}
+	if tool.Command == "" {
+		t.Fatalf("tool command should not be empty")
+	}
+	// The command + args should point at the generated entry script (inside the
+	// plugin dir).
+	if !commandReferencesEntry(tool, result.EntryPath, filepath.Join(dir, "foo")) {
+		t.Fatalf("manifest command/args do not reference the entry script: cmd=%q args=%v entry=%q", tool.Command, tool.Args, result.EntryPath)
+	}
+	// A scaffolded tool defaults to prompt gating (never auto-allow) and an empty
+	// parameter schema.
+	if tool.Permission != plugins.PermissionPrompt {
+		t.Fatalf("scaffolded tool permission = %q, want prompt", tool.Permission)
+	}
+}
+
+func commandReferencesEntry(tool plugins.ToolExtension, entryPath string, pluginDir string) bool {
+	entryBase := filepath.Base(entryPath)
+	rel, _ := filepath.Rel(pluginDir, entryPath)
+	for _, candidate := range append([]string{tool.Command}, tool.Args...) {
+		if candidate == entryPath || candidate == entryBase || candidate == rel ||
+			strings.HasSuffix(candidate, entryBase) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScaffoldStubIsRunnableShape(t *testing.T) {
+	dir := t.TempDir()
+	result, err := tools.Scaffold(tools.ScaffoldOptions{Name: "greeter", Dir: dir})
+	if err != nil {
+		t.Fatalf("Scaffold: %v", err)
+	}
+	data, err := os.ReadFile(result.EntryPath)
+	if err != nil {
+		t.Fatalf("read entry: %v", err)
+	}
+	body := string(data)
+	// The stub should carry a clear TODO so the author knows what to fill in.
+	if !strings.Contains(strings.ToUpper(body), "TODO") {
+		t.Fatalf("entry stub should contain a TODO marker:\n%s", body)
+	}
+}
+
+func TestScaffoldRejectsInvalidName(t *testing.T) {
+	dir := t.TempDir()
+	for _, bad := range []string{"", "  ", "../escape", "with/slash", "."} {
+		if _, err := tools.Scaffold(tools.ScaffoldOptions{Name: bad, Dir: dir}); err == nil {
+			t.Fatalf("expected an error for invalid name %q", bad)
+		}
+	}
+}
+
+func TestScaffoldRefusesToClobberExisting(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := tools.Scaffold(tools.ScaffoldOptions{Name: "dup", Dir: dir}); err != nil {
+		t.Fatalf("first scaffold: %v", err)
+	}
+	if _, err := tools.Scaffold(tools.ScaffoldOptions{Name: "dup", Dir: dir}); err == nil {
+		t.Fatalf("expected an error scaffolding over an existing tool dir")
+	}
+}
+
+func TestScaffoldRequiresDir(t *testing.T) {
+	if _, err := tools.Scaffold(tools.ScaffoldOptions{Name: "foo"}); err == nil {
+		t.Fatalf("expected an error when Dir is empty")
+	}
+}
+
+func TestScaffoldRuntimeDefaultsAreLanguageAgnostic(t *testing.T) {
+	dir := t.TempDir()
+	// Default runtime: the test only asserts a stub is produced and the manifest
+	// parses; the specific interpreter is an implementation detail, but it must
+	// not name a model provider or hardcode anything provider-specific.
+	result, err := tools.Scaffold(tools.ScaffoldOptions{Name: "agnostic", Dir: dir})
+	if err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	data, _ := os.ReadFile(result.ManifestPath)
+	lower := strings.ToLower(string(data))
+	for _, banned := range []string{"openai", "anthropic", "claude", "gemini", "gpt-"} {
+		if strings.Contains(lower, banned) {
+			t.Fatalf("scaffolded manifest must stay provider-neutral, found %q", banned)
+		}
+	}
+}


### PR DESCRIPTION
## Stage 10 — Distribution

ZERO had skills/plugins but no way to install them (skills were discovery-only from a local dir) and no tool scaffolder. This adds a **file-backed, local** distribution surface so extensibility compounds into an ecosystem. There is no central registry: a "source" is just a git URL or a local path, and every install is checksum-pinned in a lockfile.

### What was built

**`internal/skills/install.go`** — `Install`, `Remove`, `Info`, lockfile (`skills.lock`).
- Fetches a skill from a git URL (shallow clone via an injectable runner) or a local path, locates the `SKILL.md` (root or a single subdir), and validates its frontmatter through the existing skills parser. Invalid/nameless skills are rejected and nothing is written.
- Copies the `SKILL.md` into `skills.DefaultDir(env)/<name>/`, records a `sha256` content hash mapped to its source in `skills.lock`. Reinstalling surfaces the old→new hash change.
- A name clash with a **different** source is refused unless `--force`; reinstalling from the same source is idempotent.

**`internal/plugins/install.go`** — `Install`, `Remove`, lockfile (`plugins.lock`).
- Same fetch + pin flow, validated against the existing plugin manifest schema (`ParseManifest`). The whole plugin tree is copied (entry scripts, prompts, skills) so the plugin is runnable through activation — `.git` and symlinks are skipped so clone metadata and link-escapes never land in the plugins dir.
- Installed plugins still go through normal activation with permission gating; no install script is run.

**`internal/tools/scaffold.go`** — `Scaffold`.
- Generates a minimal, prompt-gated plugin-tool skeleton in the toolbox dir: a `plugin.json` (schemaVersion 1, one tool, empty parameter schema, command pointing at the entry stub) plus a runnable entry stub carrying a clear TODO. Default runtime is a POSIX shell stub (no interpreter dependency); `node`/`python` are also available. After plugin activation the scaffolded tool is loadable like any plugin.

**CLI wiring**
- `zero skill {add,info,remove}` — extended `internal/cli/skills.go`.
- `zero plugin {add,remove}` — extended `internal/cli/extensions.go`.
- `zero tools {make,list}` — new command registered in `internal/cli/app.go` (dispatch + help), handlers in the new `internal/cli/distribution.go`.
- New `appDeps` resolvers `pluginsDir`/`toolsDir` (the user plugins root) added in `app.go`.

### Safety properties
- **No opaque remote code without a fingerprint:** every install records a content hash in a lockfile; updates show the hash change.
- **Never executes fetched content:** skills are markdown (validated, never run); plugin install scripts are never executed; the scaffolder only writes files. Tests assert a hostile `install.sh` in a fetched source does not run and is not copied into the skills dir.
- **Network:** git fetch inherits the process environment (so proxy/egress settings are honored) and sets `GIT_TERMINAL_PROMPT=0` so a missing-credential clone fails fast instead of blocking.

### Files
- `internal/skills/install.go` + `internal/skills/install_test.go`
- `internal/plugins/install.go` + `internal/plugins/install_test.go`
- `internal/tools/scaffold.go` + `internal/tools/scaffold_test.go`
- `internal/cli/distribution.go` + `internal/cli/distribution_test.go`
- `internal/cli/app.go`, `internal/cli/extensions.go`, `internal/cli/skills.go` (subcommand wiring + help)

### How it was tested
TDD (RED→GREEN). Per-package unit tests cover the spec's list: local install + hash recording, invalid-source rejection, reinstall hash change + lockfile update, name-clash guard (+`--force`), manifest validation, scaffold manifest parses against the real schema, list/info/remove reflect installed state, and "install never executes fetched content". Added real-git integration tests (a local `file://` repo exercising the default runner end to end, asserting `.git` does not leak) and a provider-neutrality assertion on the scaffolded manifest. End-to-end smoke through the built binary confirms the full add/list/info/update/remove and make/list lifecycle.

Gate: `gofmt -l .` clean, `go build ./...` succeeds, `go test ./...` passes.

### Deferred / out of scope
- Release-tarball fetch (the spec listed it as an alternative to shallow clone; clone is implemented and the runner is injectable).
- Merging plugin-declared skill paths into the skills loader and runtime registration of installed plugin tools remain the separately-tracked Stage 09 / multi-root work, unchanged here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New top-level CLI commands: tools (make, list), skill (add, info, remove), and plugin (add, remove); help updated.
  * Tool scaffolding creates runnable stubs (shell/Node/Python) and a plugin manifest.
  * CLI now respects user-scoped plugins/tools directory defaults.

* **Behavior**
  * Installs/removals record deterministic content hashes and lockfiles; force/overwrite rules enforced; list output supports human and --json modes and surfaces loader diagnostics.

* **Tests**
  * Extensive end-to-end and unit tests for CLI, install, scaffold flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->