### PR TITLE
wedge stage 09: finish plugin wiring (tools/hooks/skills)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -412,6 +412,11 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		return writeAppError(stderr, err.Error(), 1)
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)
+	// Make local plugins live: register their declared tools into the registry and
+	// collect their hooks + skill roots for the dispatcher and skill tool below.
+	// Done after specialist + MCP registration so plugin tools are part of the
+	// deferral count, and it fails OPEN — a malformed plugin is warned and skipped.
+	pluginActivation := activatePlugins(workspaceRoot, registry, deps, stderr)
 	// Ask (not Auto) is the interactive default: in Auto, ToolAdvertised exposes
 	// only PermissionAllow tools, so prompt-gated tools (write_file/edit_file/bash/
 	// apply_patch) would never be offered to the model — the TUI could neither edit
@@ -428,10 +433,10 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	}
 	// Activate deferred MCP-tool loading for the interactive run only when the
 	// VISIBLE deferred-eligible count meets the resolved threshold, matching exec.
-	// The registry is complete (core + specialist + MCP) here, so the count is
-	// accurate; below threshold this is a no-op and the surface is unchanged. The
-	// interactive surface applies no operator tool filters, so enabled/disabled are
-	// nil — matching the AgentOptions below.
+	// The registry is complete (core + specialist + MCP + plugins) here, so the
+	// count is accurate; below threshold this is a no-op and the surface is
+	// unchanged. The interactive surface applies no operator tool filters, so
+	// enabled/disabled are nil — matching the AgentOptions below.
 	registerToolSearchIfEligible(registry, resolved.Tools.DeferThreshold, permissionMode, nil, nil)
 	sandboxStore, err := deps.newSandboxStore()
 	if err != nil {
@@ -463,7 +468,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 			Autonomy:       string(sandbox.AutonomyLow),
 			Sandbox:        sandboxEngine,
 			FileTracker:    tools.NewFileTracker(),
-			Hooks:          newHookDispatcher(workspaceRoot),
+			Hooks:          newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),
 			DeferThreshold: resolved.Tools.DeferThreshold,
 		},
 		PermissionMode: permissionMode,

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -177,6 +177,11 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return writeExecProviderError(stdout, stderr, options.outputFormat, "mcp_error", err.Error())
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)
+	// Make local plugins live for this run: register their declared tools into the
+	// registry and collect their hooks + skill roots for the dispatcher and skill
+	// tool below. Done before --list-tools and filter validation so plugin tools
+	// are listable and filter-validatable; it fails OPEN (a bad plugin is skipped).
+	pluginActivation := activatePlugins(workspaceRoot, registry, deps, stderr)
 	if options.useSpec {
 		specmode.RegisterDraftTools(registry, workspaceRoot, deps.now)
 	}
@@ -462,7 +467,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		Autonomy:         options.autonomy,
 		Sandbox:          sandboxEngine,
 		FileTracker:      tools.NewFileTracker(),
-		Hooks:            newHookDispatcher(workspaceRoot),
+		Hooks:            newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks),
 		EnabledTools:     options.enabledTools,
 		DisabledTools:    options.disabledTools,
 		OnText:           writer.text,

--- a/internal/cli/hook_dispatch.go
+++ b/internal/cli/hook_dispatch.go
@@ -11,6 +11,16 @@ import (
 // hooks configured the dispatcher selects nothing and runs no commands, so the
 // hot path stays free of overhead until a user opts in via hooks.json.
 func newHookDispatcher(workspaceRoot string) *hooks.Dispatcher {
+	return newHookDispatcherWithExtra(workspaceRoot, nil)
+}
+
+// newHookDispatcherWithExtra builds the dispatcher like newHookDispatcher but also
+// folds plugin-activated hook definitions into the active hook set, so a plugin's
+// declared hooks run alongside the user/project hooks.json hooks. Plugin hooks are
+// appended after the configured hooks; their ids are plugin-namespaced (plugin
+// id + hook name) so they never collide with hooks.json ids. A nil/empty extra
+// slice is byte-equivalent to newHookDispatcher.
+func newHookDispatcherWithExtra(workspaceRoot string, extra []hooks.Definition) *hooks.Dispatcher {
 	loaded, err := hooks.LoadConfig(hooks.LoadOptions{Cwd: workspaceRoot})
 	if err != nil {
 		return nil
@@ -19,8 +29,27 @@ func newHookDispatcher(workspaceRoot string) *hooks.Dispatcher {
 	if store, err := hooks.NewAuditStore(hooks.AuditStoreOptions{}); err == nil {
 		audit = store
 	}
+	config := loaded.Config
+	if len(extra) > 0 {
+		// Plugin hooks only run when hooks are enabled overall; an explicit
+		// `enabled:false` in hooks.json still disables the whole hook surface.
+		merged := append([]hooks.Definition{}, config.Hooks...)
+		existing := make(map[string]bool, len(merged))
+		for _, hook := range merged {
+			existing[hook.ID] = true
+		}
+		for _, hook := range extra {
+			// A hooks.json hook with the same (namespaced) id wins, so an operator can
+			// still disable a plugin hook by id without the plugin re-enabling it.
+			if existing[hook.ID] {
+				continue
+			}
+			merged = append(merged, hook)
+		}
+		config.Hooks = merged
+	}
 	return hooks.NewDispatcher(hooks.DispatcherOptions{
-		Config: loaded.Config,
+		Config: config,
 		Audit:  audit,
 		Cwd:    workspaceRoot,
 	})

--- a/internal/cli/plugin_activate.go
+++ b/internal/cli/plugin_activate.go
@@ -33,6 +33,13 @@ func activatePlugins(workspaceRoot string, registry *tools.Registry, deps appDep
 		return pluginActivation{}
 	}
 
+	// Load fails OPEN per plugin: a malformed manifest is recorded as a diagnostic
+	// and the plugin is dropped rather than aborting the whole load. Surface those
+	// diagnostics so a skipped plugin is never silent.
+	for _, diagnostic := range loaded.Diagnostics {
+		writePluginActivationWarning(stderr, formatLoadDiagnostic(diagnostic))
+	}
+
 	result := plugins.Activate(registry, loaded.Plugins, plugins.ActivateOptions{Cwd: workspaceRoot})
 	for _, warning := range result.Warnings {
 		writePluginActivationWarning(stderr, warning)
@@ -48,6 +55,17 @@ func activatePlugins(workspaceRoot string, registry *tools.Registry, deps appDep
 	}
 
 	return pluginActivation{hooks: result.Hooks, skillRoots: result.SkillRoots}
+}
+
+// formatLoadDiagnostic renders a plugin load diagnostic into a single warning
+// line, prefixing the diagnostic kind and appending the manifest path (when
+// known) so an operator can locate the offending plugin.
+func formatLoadDiagnostic(diagnostic plugins.Diagnostic) string {
+	message := fmt.Sprintf("[%s] %s", diagnostic.Kind, diagnostic.Message)
+	if diagnostic.ManifestPath != "" {
+		message += " (" + diagnostic.ManifestPath + ")"
+	}
+	return message
 }
 
 func writePluginActivationWarning(stderr io.Writer, message string) {

--- a/internal/cli/plugin_activate.go
+++ b/internal/cli/plugin_activate.go
@@ -58,12 +58,20 @@ func activatePlugins(workspaceRoot string, registry *tools.Registry, deps appDep
 }
 
 // formatLoadDiagnostic renders a plugin load diagnostic into a single warning
-// line, prefixing the diagnostic kind and appending the manifest path (when
-// known) so an operator can locate the offending plugin.
+// line, prefixing the diagnostic kind and appending the most specific locator
+// available (manifest path, then plugin path, then plugin ID) so an operator can
+// locate the offending plugin even when the manifest path is unknown.
 func formatLoadDiagnostic(diagnostic plugins.Diagnostic) string {
 	message := fmt.Sprintf("[%s] %s", diagnostic.Kind, diagnostic.Message)
-	if diagnostic.ManifestPath != "" {
-		message += " (" + diagnostic.ManifestPath + ")"
+	locator := diagnostic.ManifestPath
+	if locator == "" {
+		locator = diagnostic.PluginPath
+	}
+	if locator == "" {
+		locator = diagnostic.PluginID
+	}
+	if locator != "" {
+		message += " (" + locator + ")"
 	}
 	return message
 }

--- a/internal/cli/plugin_activate.go
+++ b/internal/cli/plugin_activate.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// pluginActivation holds what plugin activation contributed to a bootstrap so the
+// later dispatcher + skill wiring can consume it: the plugin hook definitions and
+// the plugin skill search roots. The zero value (no plugins) is inert — the
+// dispatcher gets no extra hooks and the skill tool keeps only the default dir.
+type pluginActivation struct {
+	hooks      []hooks.Definition
+	skillRoots []string
+}
+
+// activatePlugins loads the workspace's plugins and makes their declared
+// extensions live: plugin tools are registered into registry here, and the
+// returned activation carries the plugin hooks + skill roots for the caller to
+// fold into the hook dispatcher and the skill tool.
+//
+// It fails OPEN: any load error (or a malformed plugin) is surfaced as a warning
+// on stderr and otherwise skipped, so a broken plugin can never wedge startup —
+// mirroring how newHookDispatcher and skills.Load tolerate bad input.
+func activatePlugins(workspaceRoot string, registry *tools.Registry, deps appDeps, stderr io.Writer) pluginActivation {
+	loaded, err := deps.loadPlugins(plugins.LoadOptions{Cwd: workspaceRoot})
+	if err != nil {
+		writePluginActivationWarning(stderr, "failed to load plugins: "+err.Error())
+		return pluginActivation{}
+	}
+
+	result := plugins.Activate(registry, loaded.Plugins, plugins.ActivateOptions{Cwd: workspaceRoot})
+	for _, warning := range result.Warnings {
+		writePluginActivationWarning(stderr, warning)
+	}
+
+	// Re-register the skill tool to also resolve plugin-declared skills. The core
+	// skill tool only reads the default skills dir; the plugin-aware replacement
+	// merges the default dir with the plugin skill roots (default dir wins a name
+	// clash), so plugin skills appear in the agent's skill list. With no plugin
+	// skill roots this is byte-equivalent to the default skills surface.
+	if len(result.SkillRoots) > 0 {
+		registry.Register(plugins.NewSkillTool(deps.skillsDir(), result.SkillRoots))
+	}
+
+	return pluginActivation{hooks: result.Hooks, skillRoots: result.SkillRoots}
+}
+
+func writePluginActivationWarning(stderr io.Writer, message string) {
+	if stderr == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "[zero] WARNING: plugin activation: %s\n", message)
+}

--- a/internal/cli/plugin_activate_test.go
+++ b/internal/cli/plugin_activate_test.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// fakePluginDeps builds appDeps whose loadPlugins returns the supplied plugins and
+// whose skillsDir points at an empty dir, so activatePlugins can be exercised
+// without touching the real plugin roots.
+func fakePluginDeps(t *testing.T, loaded []plugins.LoadedPlugin) appDeps {
+	t.Helper()
+	skillsDir := t.TempDir()
+	return appDeps{
+		getwd: func() (string, error) { return t.TempDir(), nil },
+		loadPlugins: func(plugins.LoadOptions) (plugins.LoadResult, error) {
+			return plugins.LoadResult{Plugins: loaded}, nil
+		},
+		skillsDir: func() string { return skillsDir },
+	}
+}
+
+func TestActivatePluginsRegistersToolAndCollectsHooks(t *testing.T) {
+	pluginDir := t.TempDir()
+	loaded := []plugins.LoadedPlugin{{
+		ID:        "zero.demo",
+		Name:      "Demo",
+		Enabled:   true,
+		Source:    plugins.SourceProject,
+		PluginDir: pluginDir,
+		Tools: []plugins.ToolExtension{{
+			Name:        "demo_lookup",
+			Description: "lookup",
+			Command:     "true",
+			Permission:  plugins.PermissionPrompt,
+		}},
+		Hooks: []plugins.HookExtension{{
+			Name:    "pre",
+			Event:   plugins.HookBeforeTool,
+			Command: "guard.sh",
+		}},
+	}}
+
+	registry := tools.NewRegistry()
+	var stderr bytes.Buffer
+	activation := activatePlugins(t.TempDir(), registry, fakePluginDeps(t, loaded), &stderr)
+
+	if _, ok := registry.Get("demo_lookup"); !ok {
+		t.Fatalf("plugin tool not registered into the bootstrap registry")
+	}
+	if len(activation.hooks) != 1 || activation.hooks[0].Event != hooks.EventBeforeTool {
+		t.Fatalf("expected one beforeTool plugin hook, got %#v", activation.hooks)
+	}
+	if activation.hooks[0].ID != "zero.demo.pre" {
+		t.Fatalf("plugin hook id = %q, want namespaced zero.demo.pre", activation.hooks[0].ID)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr for a clean activation: %s", stderr.String())
+	}
+}
+
+func TestActivatePluginsRegistersPluginSkillTool(t *testing.T) {
+	pluginDir := t.TempDir()
+	skillDir := filepath.Join(pluginDir, "skills", "demo-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillMd := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillMd, []byte("---\nname: demo-skill\n---\nplugin skill body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := []plugins.LoadedPlugin{{
+		ID:        "zero.skills",
+		Name:      "Skills",
+		Enabled:   true,
+		Source:    plugins.SourceProject,
+		PluginDir: pluginDir,
+		Skills:    []plugins.PathExtension{{Name: "demo-skill", Path: skillMd}},
+	}}
+
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewSkillTool(t.TempDir())) // core skill tool, like the real bootstrap
+	var stderr bytes.Buffer
+	activation := activatePlugins(t.TempDir(), registry, fakePluginDeps(t, loaded), &stderr)
+
+	if len(activation.skillRoots) != 1 {
+		t.Fatalf("expected one plugin skill root, got %#v", activation.skillRoots)
+	}
+	skillTool, ok := registry.Get("skill")
+	if !ok {
+		t.Fatal("skill tool missing after activation")
+	}
+	// The re-registered skill tool resolves the plugin skill by name.
+	res := skillTool.Run(context.Background(), map[string]any{"name": "demo-skill"})
+	if res.Status != tools.StatusOK {
+		t.Fatalf("plugin skill not resolvable via the agent skill tool: %q (%s)", res.Status, res.Output)
+	}
+}
+
+func TestActivatePluginsFailsOpenOnLoadError(t *testing.T) {
+	deps := appDeps{
+		loadPlugins: func(plugins.LoadOptions) (plugins.LoadResult, error) {
+			return plugins.LoadResult{}, errors.New("boom")
+		},
+		skillsDir: func() string { return t.TempDir() },
+	}
+	registry := tools.NewRegistry()
+	var stderr bytes.Buffer
+	activation := activatePlugins(t.TempDir(), registry, deps, &stderr)
+
+	if len(activation.hooks) != 0 || len(activation.skillRoots) != 0 {
+		t.Fatalf("a load error must yield an inert activation, got %#v", activation)
+	}
+	if stderr.Len() == 0 {
+		t.Fatalf("a load error should be surfaced as a warning on stderr")
+	}
+}
+
+func TestActivatePluginsWarnsOnMalformedPluginButKeepsGood(t *testing.T) {
+	good := plugins.LoadedPlugin{
+		ID:        "zero.good",
+		Name:      "Good",
+		Enabled:   true,
+		Source:    plugins.SourceProject,
+		PluginDir: t.TempDir(),
+		Tools:     []plugins.ToolExtension{{Name: "good_tool", Command: "true", Permission: plugins.PermissionPrompt}},
+	}
+	bad := plugins.LoadedPlugin{
+		ID:        "zero.bad",
+		Name:      "Bad",
+		Enabled:   true,
+		Source:    plugins.SourceProject,
+		PluginDir: t.TempDir(),
+		Tools:     []plugins.ToolExtension{{Name: "bad_tool", Command: "", Permission: plugins.PermissionPrompt}},
+	}
+
+	registry := tools.NewRegistry()
+	var stderr bytes.Buffer
+	activatePlugins(t.TempDir(), registry, fakePluginDeps(t, []plugins.LoadedPlugin{bad, good}), &stderr)
+
+	if _, ok := registry.Get("good_tool"); !ok {
+		t.Fatal("the good plugin tool must still register despite a malformed sibling")
+	}
+	if _, ok := registry.Get("bad_tool"); ok {
+		t.Fatal("the malformed plugin tool must not register")
+	}
+	if stderr.Len() == 0 {
+		t.Fatal("a malformed plugin should produce a warning on stderr")
+	}
+}
+
+func TestNewHookDispatcherWithExtraFoldsPluginHooks(t *testing.T) {
+	// Keep the hook audit store inside a temp dir rather than the user's real data
+	// directory (the audit path is derived from XDG_DATA_HOME).
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	workspace := t.TempDir()
+	extra := []hooks.Definition{{
+		ID:      "zero.demo.pre",
+		Event:   hooks.EventBeforeTool,
+		Command: "guard.sh",
+		Enabled: true,
+	}}
+
+	dispatcher := newHookDispatcherWithExtra(workspace, extra)
+	if dispatcher == nil {
+		t.Fatal("dispatcher should never be nil for a clean workspace")
+	}
+
+	// Drive a beforeTool dispatch: the plugin hook runs, proving it is part of the
+	// active hook set (not merely returned as data).
+	outcome := dispatcher.Dispatch(context.Background(), hooks.DispatchInput{
+		Event:    hooks.EventBeforeTool,
+		ToolName: "bash",
+	})
+	// With no real guard.sh on PATH the command fails to launch, which for a
+	// beforeTool hook is advisory (fails OPEN), so the call is recorded as having
+	// run exactly one hook.
+	if outcome.Ran != 1 {
+		t.Fatalf("expected the plugin beforeTool hook to run, Ran=%d", outcome.Ran)
+	}
+}

--- a/internal/cli/plugin_activate_test.go
+++ b/internal/cli/plugin_activate_test.go
@@ -106,6 +106,34 @@ func TestActivatePluginsRegistersPluginSkillTool(t *testing.T) {
 	}
 }
 
+func TestActivatePluginsSurfacesLoadDiagnostics(t *testing.T) {
+	// Load succeeds (no top-level error) but reports a per-plugin diagnostic for a
+	// plugin it had to skip. activatePlugins must forward that diagnostic to stderr
+	// rather than dropping it, so a skipped plugin is never silent.
+	deps := appDeps{
+		getwd: func() (string, error) { return t.TempDir(), nil },
+		loadPlugins: func(plugins.LoadOptions) (plugins.LoadResult, error) {
+			return plugins.LoadResult{
+				Diagnostics: []plugins.Diagnostic{{
+					Kind:    plugins.DiagnosticSchema,
+					Message: "schemaVersion: Expected schemaVersion 1.",
+				}},
+			}, nil
+		},
+		skillsDir: func() string { return t.TempDir() },
+	}
+	registry := tools.NewRegistry()
+	var stderr bytes.Buffer
+	activatePlugins(t.TempDir(), registry, deps, &stderr)
+
+	if stderr.Len() == 0 {
+		t.Fatal("a load diagnostic must be surfaced on stderr")
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("Expected schemaVersion 1")) {
+		t.Fatalf("stderr should carry the diagnostic message, got %q", stderr.String())
+	}
+}
+
 func TestActivatePluginsFailsOpenOnLoadError(t *testing.T) {
 	deps := appDeps{
 		loadPlugins: func(plugins.LoadOptions) (plugins.LoadResult, error) {

--- a/internal/plugins/activate.go
+++ b/internal/plugins/activate.go
@@ -206,7 +206,7 @@ func activateHooks(plugin LoadedPlugin, result *ActivationResult) {
 			Name:        ext.Name,
 			Description: ext.Description,
 			Event:       event,
-			Command:     expandPluginRoot(ext.Command, plugin.PluginDir),
+			Command:     expandPluginRootPath(ext.Command, plugin.PluginDir),
 			Args:        expandPluginRootAll(ext.Args, plugin.PluginDir),
 			Enabled:     true,
 		})
@@ -433,6 +433,20 @@ func expandPluginRoot(value string, pluginDir string) string {
 	return strings.ReplaceAll(value, pluginRootPlaceholder, pluginDir)
 }
 
+// expandPluginRootPath is expandPluginRoot for an executable path: when the
+// placeholder is present it also normalizes separators to the host OS via
+// filepath.FromSlash, so a manifest "${AGENT_PLUGIN_ROOT}/bin/x" yields a clean
+// native path (C:\...\bin\x on Windows) rather than a mixed-separator one. Bare
+// command names and author-provided absolute paths are returned unchanged, and
+// arguments are NOT normalized (they may legitimately contain forward slashes,
+// e.g. URLs or flag values).
+func expandPluginRootPath(value string, pluginDir string) string {
+	if !strings.Contains(value, pluginRootPlaceholder) {
+		return value
+	}
+	return filepath.FromSlash(strings.ReplaceAll(value, pluginRootPlaceholder, pluginDir))
+}
+
 func expandPluginRootAll(values []string, pluginDir string) []string {
 	if len(values) == 0 {
 		return nil
@@ -470,7 +484,7 @@ func newPluginTool(plugin LoadedPlugin, ext ToolExtension, options ActivateOptio
 		description: description,
 		pluginID:    plugin.ID,
 		pluginDir:   plugin.PluginDir,
-		command:     expandPluginRoot(ext.Command, plugin.PluginDir),
+		command:     expandPluginRootPath(ext.Command, plugin.PluginDir),
 		args:        expandPluginRootAll(ext.Args, plugin.PluginDir),
 		parameters:  mcp.SchemaFromMCP(ext.InputSchema),
 		safety:      toolSafety(plugin, ext),

--- a/internal/plugins/activate.go
+++ b/internal/plugins/activate.go
@@ -182,6 +182,14 @@ func activateTools(registry *tools.Registry, plugin LoadedPlugin, options Activa
 			continue
 		}
 		tool := newPluginTool(plugin, ext, options, runTool)
+		// registry.Register is last-wins, so a plugin tool sharing a name with a core
+		// tool (or another plugin's tool) would silently replace it and change its
+		// safety semantics. Skip the colliding tool with a warning instead, keeping
+		// the existing registration intact (isolation-first, like a malformed plugin).
+		if _, exists := registry.Get(tool.Name()); exists {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped tool %q because that name is already registered", plugin.ID, ext.Name))
+			continue
+		}
 		registry.Register(tool)
 		result.Tools = append(result.Tools, ToolProvenance{ToolName: ext.Name, PluginID: plugin.ID})
 	}
@@ -219,7 +227,17 @@ func activateHooks(plugin LoadedPlugin, result *ActivationResult) {
 // Roots are deduplicated; the original discovery order within the plugin is kept.
 func activateSkills(plugin LoadedPlugin, seenRoot map[string]bool, result *ActivationResult) {
 	for _, ext := range plugin.Skills {
-		root := skillSearchRoot(ext.Path)
+		// Resolve the manifest path against the plugin dir first: expand any
+		// ${AGENT_PLUGIN_ROOT} placeholder, then anchor a still-relative path (e.g.
+		// "skills/foo/SKILL.md") under PluginDir so the derived root is the real
+		// filesystem directory skills.Load can scan rather than a bare "skills".
+		// (Paths loaded via ParseManifest are already absolute; this only hardens
+		// the case where a caller hands Activate a relative path directly.)
+		path := expandPluginRoot(ext.Path, plugin.PluginDir)
+		if trimmed := strings.TrimSpace(path); trimmed != "" && !filepath.IsAbs(trimmed) {
+			path = filepath.Join(plugin.PluginDir, trimmed)
+		}
+		root := skillSearchRoot(path)
 		if root == "" {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped skill %q with no path", plugin.ID, ext.Name))
 			continue

--- a/internal/plugins/activate.go
+++ b/internal/plugins/activate.go
@@ -1,0 +1,675 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/secrets"
+	"github.com/Gitlawb/zero/internal/skills"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// pluginRootPlaceholder is the manifest path placeholder a plugin may use in a
+// tool/hook command (or its args) to refer to its own install directory. It is
+// expanded to the plugin's PluginDir at activation time and also exported into
+// the command's environment as AGENT_PLUGIN_ROOT.
+const pluginRootPlaceholder = "${AGENT_PLUGIN_ROOT}"
+
+// pluginRootEnvVar is the environment variable carrying the plugin's root, set on
+// every plugin tool/hook command so a script can resolve sibling files even when
+// it does not use the ${AGENT_PLUGIN_ROOT} placeholder in its argv.
+const pluginRootEnvVar = "AGENT_PLUGIN_ROOT"
+
+// defaultPluginToolTimeout bounds a single plugin tool command so a hung or slow
+// plugin process cannot stall a tool call indefinitely (mirrors the hook
+// dispatcher's per-command timeout).
+const defaultPluginToolTimeout = 120 * time.Second
+
+// pluginCommand is the fully-resolved invocation handed to the tool runner: the
+// expanded command + args, the working directory, the JSON-encoded tool args fed
+// on stdin, and the environment (process env plus AGENT_PLUGIN_ROOT).
+type pluginCommand struct {
+	Command string
+	Args    []string
+	Cwd     string
+	Stdin   []byte
+	Env     []string
+}
+
+// commandOutput is the captured result of running a pluginCommand. ExitCode is 0
+// on success and -1 when the command could not be launched (Err set).
+type commandOutput struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Err      error
+}
+
+// toolRunner executes a resolved plugin tool command. It is injectable so
+// activation can be tested without spawning processes.
+type toolRunner func(ctx context.Context, command pluginCommand) commandOutput
+
+// ToolProvenance records which plugin a registered tool originated from, for
+// `zero plugin list` and debugging.
+type ToolProvenance struct {
+	ToolName string `json:"toolName"`
+	PluginID string `json:"pluginId"`
+}
+
+// HookProvenance records which plugin an activated hook originated from.
+type HookProvenance struct {
+	HookID   string `json:"hookId"`
+	PluginID string `json:"pluginId"`
+}
+
+// SkillProvenance records which plugin contributed a skill search root.
+type SkillProvenance struct {
+	SkillName string `json:"skillName"`
+	Root      string `json:"root"`
+	PluginID  string `json:"pluginId"`
+}
+
+// ActivationResult reports what a single Activate call wired up. Tools are
+// registered into the supplied registry directly; the remaining fields are
+// returned for the caller (the agent bootstrap) to merge into the hook dispatcher
+// and skills loader, and to surface provenance/warnings.
+type ActivationResult struct {
+	// Hooks are the live hook definitions built from plugin manifests, ready to be
+	// merged into the dispatcher's hook set. Order is deterministic.
+	Hooks []hooks.Definition
+	// SkillRoots are directories internal/skills.Load can scan to discover plugin
+	// skills, deduplicated and deterministically ordered.
+	SkillRoots []string
+	// Tools/HookProv/Skills carry provenance so a listing can attribute each live
+	// extension to its originating plugin.
+	Tools    []ToolProvenance
+	HookProv []HookProvenance
+	Skills   []SkillProvenance
+	// Warnings collects per-plugin/per-extension issues that caused an extension to
+	// be skipped. A single malformed plugin never aborts activation.
+	Warnings []string
+}
+
+// ActivateOptions configures activation. runTool is injectable for tests; when
+// nil it defaults to executing the plugin command as a subprocess.
+type ActivateOptions struct {
+	// Cwd is the working directory plugin tool commands run in. Empty falls back to
+	// the plugin's own directory.
+	Cwd string
+	// Timeout bounds each plugin tool command. <= 0 uses defaultPluginToolTimeout.
+	Timeout time.Duration
+	// Env supplies the base environment for plugin tool commands. nil uses the
+	// current process environment (os.Environ()).
+	Env []string
+
+	runTool toolRunner
+}
+
+// Activate turns the resolved plugin extensions into live registrations: it
+// registers each plugin tool into registry, and returns the hook definitions and
+// skill roots for the caller to wire into the dispatcher and skills loader.
+//
+// Activation is isolation-first: a malformed plugin or extension is skipped with
+// a recorded warning rather than aborting the whole activation, mirroring how
+// skills.Load skips a bad skill. Plugins are processed in a deterministic order
+// (sorted by ID) so the resulting registrations are stable across runs.
+func Activate(registry *tools.Registry, loaded []LoadedPlugin, options ActivateOptions) ActivationResult {
+	result := ActivationResult{
+		Hooks:      []hooks.Definition{},
+		SkillRoots: []string{},
+		Tools:      []ToolProvenance{},
+		HookProv:   []HookProvenance{},
+		Skills:     []SkillProvenance{},
+		Warnings:   []string{},
+	}
+
+	runTool := options.runTool
+	if runTool == nil {
+		timeout := options.Timeout
+		if timeout <= 0 {
+			timeout = defaultPluginToolTimeout
+		}
+		runTool = func(ctx context.Context, command pluginCommand) commandOutput {
+			return execPluginCommand(ctx, command, timeout)
+		}
+	}
+
+	// Process plugins in a deterministic order so the registry/hook/skill
+	// registrations are stable regardless of discovery order.
+	ordered := append([]LoadedPlugin{}, loaded...)
+	sort.Slice(ordered, func(left int, right int) bool {
+		return ordered[left].ID < ordered[right].ID
+	})
+
+	seenSkillRoot := map[string]bool{}
+	for _, plugin := range ordered {
+		if !plugin.Enabled {
+			continue
+		}
+
+		if registry != nil {
+			activateTools(registry, plugin, options, runTool, &result)
+		}
+		activateHooks(plugin, &result)
+		activateSkills(plugin, seenSkillRoot, &result)
+	}
+
+	return result
+}
+
+// activateTools registers every well-formed tool extension of a plugin and
+// records a warning for any it has to skip.
+func activateTools(registry *tools.Registry, plugin LoadedPlugin, options ActivateOptions, runTool toolRunner, result *ActivationResult) {
+	for _, ext := range plugin.Tools {
+		if strings.TrimSpace(ext.Name) == "" {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped a tool with no name", plugin.ID))
+			continue
+		}
+		if strings.TrimSpace(ext.Command) == "" {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped tool %q with no command", plugin.ID, ext.Name))
+			continue
+		}
+		tool := newPluginTool(plugin, ext, options, runTool)
+		registry.Register(tool)
+		result.Tools = append(result.Tools, ToolProvenance{ToolName: ext.Name, PluginID: plugin.ID})
+	}
+}
+
+// activateHooks builds a hooks.Definition for each well-formed hook extension and
+// appends it (with provenance) to the result.
+func activateHooks(plugin LoadedPlugin, result *ActivationResult) {
+	for _, ext := range plugin.Hooks {
+		if strings.TrimSpace(ext.Command) == "" {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped hook %q with no command", plugin.ID, ext.Name))
+			continue
+		}
+		event, ok := mapHookEvent(ext.Event)
+		if !ok {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped hook %q with unsupported event %q", plugin.ID, ext.Name, ext.Event))
+			continue
+		}
+		id := hookID(plugin.ID, ext.Name)
+		result.Hooks = append(result.Hooks, hooks.Definition{
+			ID:          id,
+			Name:        ext.Name,
+			Description: ext.Description,
+			Event:       event,
+			Command:     expandPluginRoot(ext.Command, plugin.PluginDir),
+			Args:        expandPluginRootAll(ext.Args, plugin.PluginDir),
+			Enabled:     true,
+		})
+		result.HookProv = append(result.HookProv, HookProvenance{HookID: id, PluginID: plugin.ID})
+	}
+}
+
+// activateSkills records each plugin skill's search root (the directory
+// internal/skills.Load scans) so the caller can merge it into the skills loader.
+// Roots are deduplicated; the original discovery order within the plugin is kept.
+func activateSkills(plugin LoadedPlugin, seenRoot map[string]bool, result *ActivationResult) {
+	for _, ext := range plugin.Skills {
+		root := skillSearchRoot(ext.Path)
+		if root == "" {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("plugin %q: skipped skill %q with no path", plugin.ID, ext.Name))
+			continue
+		}
+		if !seenRoot[root] {
+			seenRoot[root] = true
+			result.SkillRoots = append(result.SkillRoots, root)
+		}
+		result.Skills = append(result.Skills, SkillProvenance{SkillName: ext.Name, Root: root, PluginID: plugin.ID})
+	}
+}
+
+// skillSearchRoot maps a plugin skill's SKILL.md path to the directory
+// internal/skills.Load scans for `*/SKILL.md`: the parent of the per-skill
+// directory (i.e. the grandparent of the SKILL.md file). A path that already
+// names a directory (no SKILL.md leaf) is treated as the per-skill directory and
+// its parent is returned.
+func skillSearchRoot(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	skillDir := path
+	if strings.EqualFold(filepath.Base(path), skillFileName) {
+		skillDir = filepath.Dir(path)
+	}
+	return filepath.Dir(skillDir)
+}
+
+// skillFileName mirrors internal/skills' SKILL.md filename so skillSearchRoot can
+// recognize a manifest path that points at the file rather than the directory.
+const skillFileName = "SKILL.md"
+
+// MergedSkills loads the default skills directory plus the supplied plugin skill
+// roots and returns one merged, name-deduplicated list (Content stripped, like
+// skills.List) alongside the duplicate-name collisions across all roots. Earlier
+// roots win a name clash, matching skills.Load's first-wins rule; the default dir
+// is always considered first so a user skill shadows a same-named plugin skill.
+// A bad root simply yields no skills rather than failing the merge.
+func MergedSkills(defaultDir string, pluginRoots []string) ([]skills.Skill, []skills.DuplicateName) {
+	return mergeSkills(defaultDir, pluginRoots, false)
+}
+
+// mergeSkills merges the default skills dir and plugin roots into one sorted,
+// name-deduplicated list. keepContent retains each skill's body (skills.Load)
+// versus stripping it (skills.List). Roots are considered in order with the
+// default dir first, so an earlier root wins a name clash; collisions are recorded
+// rather than crashing, preserving the skills package's Duplicates behaviour.
+func mergeSkills(defaultDir string, pluginRoots []string, keepContent bool) ([]skills.Skill, []skills.DuplicateName) {
+	merged := []skills.Skill{}
+	dups := []skills.DuplicateName{}
+	byName := map[string]skills.Skill{}
+
+	roots := append([]string{defaultDir}, pluginRoots...)
+	for _, root := range roots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		var loaded []skills.Skill
+		var err error
+		if keepContent {
+			loaded, err = skills.Load(root)
+		} else {
+			loaded, err = skills.List(root)
+		}
+		if err != nil {
+			continue
+		}
+		for _, skill := range loaded {
+			if winner, clash := byName[skill.Name]; clash {
+				dups = append(dups, skills.DuplicateName{Name: skill.Name, Winner: winner.Path, Loser: skill.Path})
+				continue
+			}
+			byName[skill.Name] = skill
+			merged = append(merged, skill)
+		}
+	}
+
+	sort.Slice(merged, func(left int, right int) bool {
+		return merged[left].Name < merged[right].Name
+	})
+	return merged, dups
+}
+
+// skillTool is a drop-in replacement for the core skill tool that resolves a
+// named skill across the default skills directory PLUS the plugin skill roots, so
+// plugin-declared skills surface in the agent's skill list. It keeps the core
+// tool's name, schema, and read-only/allow safety so registering it simply
+// overlays plugin skills onto the existing surface.
+type skillTool struct {
+	defaultDir  string
+	pluginRoots []string
+}
+
+// NewSkillTool builds the plugin-aware skill tool. defaultDir is the standard
+// skills directory (skills.DefaultDir); pluginRoots are the plugin skill search
+// roots from an ActivationResult. The returned tool merges both, deterministically
+// deduplicating by name (default dir wins a clash) and listing all available
+// skills when an unknown name is requested.
+func NewSkillTool(defaultDir string, pluginRoots []string) tools.Tool {
+	return skillTool{defaultDir: defaultDir, pluginRoots: append([]string{}, pluginRoots...)}
+}
+
+func (tool skillTool) Name() string { return "skill" }
+
+func (tool skillTool) Description() string {
+	return "Load a named Zero skill and return its instructions as the tool output. " +
+		"Skills are reusable, on-demand instruction sets (including any contributed by plugins). " +
+		"Call this when a relevant skill exists; an unknown name returns the list of available skills."
+}
+
+func (tool skillTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"name":  {Type: "string", Description: "The name of the skill to load."},
+			"skill": {Type: "string", Description: "Alias for name; supply either name or skill."},
+		},
+		AdditionalProperties: false,
+	}
+}
+
+func (tool skillTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect: tools.SideEffectRead,
+		Permission: tools.PermissionAllow,
+		Reason:     "Reads a local skill file; gathers reusable instructions only.",
+	}
+}
+
+func (tool skillTool) Run(_ context.Context, args map[string]any) tools.Result {
+	name := skillName(args)
+	if name == "" {
+		return tools.Result{Status: tools.StatusError, Output: "Error: Invalid arguments for skill: name is required"}
+	}
+	merged, _ := MergedSkillsLoaded(tool.defaultDir, tool.pluginRoots)
+	if len(merged) == 0 {
+		return tools.Result{Status: tools.StatusError, Output: "Error: no skills are available."}
+	}
+	available := make([]string, 0, len(merged))
+	for _, skill := range merged {
+		if skill.Name == name {
+			return tools.Result{Status: tools.StatusOK, Output: skill.Content}
+		}
+		available = append(available, skill.Name)
+	}
+	return tools.Result{Status: tools.StatusError, Output: fmt.Sprintf("Error: unknown skill %q. Available skills: %s.", name, strings.Join(available, ", "))}
+}
+
+// skillName extracts the requested skill name from either the "name" or "skill"
+// argument (the core skill tool accepts both aliases).
+func skillName(args map[string]any) string {
+	for _, key := range []string{"name", "skill"} {
+		if value, ok := args[key].(string); ok {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+// MergedSkillsLoaded is MergedSkills but keeps each skill's Content (so the skill
+// tool can return a body). MergedSkills strips Content for listing callers.
+func MergedSkillsLoaded(defaultDir string, pluginRoots []string) ([]skills.Skill, []skills.DuplicateName) {
+	return mergeSkills(defaultDir, pluginRoots, true)
+}
+
+// mapHookEvent maps a plugin manifest HookEvent onto the hooks package Event. The
+// two enums use the same string values, but mapping explicitly keeps the packages
+// decoupled and rejects any value the dispatcher does not understand.
+func mapHookEvent(event HookEvent) (hooks.Event, bool) {
+	switch event {
+	case HookBeforeTool:
+		return hooks.EventBeforeTool, true
+	case HookAfterTool:
+		return hooks.EventAfterTool, true
+	case HookSessionStart:
+		return hooks.EventSessionStart, true
+	case HookSessionEnd:
+		return hooks.EventSessionEnd, true
+	default:
+		return "", false
+	}
+}
+
+// hookID derives a stable, namespaced hook id from the plugin id and the hook's
+// manifest name, so plugin hooks never collide with user/project hooks.json ids.
+func hookID(pluginID string, name string) string {
+	pluginID = strings.TrimSpace(pluginID)
+	name = strings.TrimSpace(name)
+	switch {
+	case pluginID == "" && name == "":
+		return "plugin.hook"
+	case pluginID == "":
+		return name
+	case name == "":
+		return pluginID
+	default:
+		return pluginID + "." + name
+	}
+}
+
+// expandPluginRoot replaces the ${AGENT_PLUGIN_ROOT} placeholder in value with the
+// plugin's directory. It is a literal substitution (not shell expansion), so it is
+// safe to apply to a command path or an individual argument.
+func expandPluginRoot(value string, pluginDir string) string {
+	if !strings.Contains(value, pluginRootPlaceholder) {
+		return value
+	}
+	return strings.ReplaceAll(value, pluginRootPlaceholder, pluginDir)
+}
+
+func expandPluginRootAll(values []string, pluginDir string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	expanded := make([]string, len(values))
+	for index, value := range values {
+		expanded[index] = expandPluginRoot(value, pluginDir)
+	}
+	return expanded
+}
+
+// pluginTool adapts a plugin tool extension to the tools.Tool interface. It runs
+// the plugin's declared command, feeding the JSON-encoded tool arguments on
+// stdin, and maps stdout/exit code onto a tools.Result.
+type pluginTool struct {
+	name        string
+	description string
+	pluginID    string
+	pluginDir   string
+	command     string
+	args        []string
+	parameters  tools.Schema
+	safety      tools.Safety
+	options     ActivateOptions
+	run         toolRunner
+}
+
+func newPluginTool(plugin LoadedPlugin, ext ToolExtension, options ActivateOptions, run toolRunner) pluginTool {
+	description := strings.TrimSpace(ext.Description)
+	if description == "" {
+		description = fmt.Sprintf("Run plugin tool %s/%s.", plugin.ID, ext.Name)
+	}
+	return pluginTool{
+		name:        ext.Name,
+		description: description,
+		pluginID:    plugin.ID,
+		pluginDir:   plugin.PluginDir,
+		command:     expandPluginRoot(ext.Command, plugin.PluginDir),
+		args:        expandPluginRootAll(ext.Args, plugin.PluginDir),
+		parameters:  mcp.SchemaFromMCP(ext.InputSchema),
+		safety:      toolSafety(plugin, ext),
+		options:     options,
+		run:         run,
+	}
+}
+
+func (tool pluginTool) Name() string             { return tool.name }
+func (tool pluginTool) Description() string      { return tool.description }
+func (tool pluginTool) Parameters() tools.Schema { return tool.parameters }
+func (tool pluginTool) Safety() tools.Safety     { return tool.safety }
+
+// Run executes the plugin command in the plugin's directory (no caller cwd).
+func (tool pluginTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return tool.invoke(ctx, args, "")
+}
+
+// RunWithOptions runs the plugin command in the caller's workspace cwd when one is
+// supplied, so a plugin tool sees the same working directory as the rest of the
+// run. Implementing optionsAwareTool also means the registry hands us the run
+// options without changing the core Tool interface.
+func (tool pluginTool) RunWithOptions(ctx context.Context, args map[string]any, options tools.RunOptions) tools.Result {
+	return tool.invoke(ctx, args, options.Cwd)
+}
+
+func (tool pluginTool) invoke(ctx context.Context, args map[string]any, cwd string) tools.Result {
+	stdin, err := encodeToolArgs(args)
+	if err != nil {
+		return tools.Result{
+			Status: tools.StatusError,
+			Output: "Error: invalid arguments for plugin tool " + tool.name + ": " + err.Error(),
+			Meta:   tool.meta(),
+		}
+	}
+
+	command := pluginCommand{
+		Command: tool.command,
+		Args:    append([]string{}, tool.args...),
+		Cwd:     tool.commandCwd(cwd),
+		Stdin:   stdin,
+		Env:     tool.commandEnv(),
+	}
+	output := tool.run(ctx, command)
+
+	meta := tool.meta()
+	meta["exit_code"] = strconv.Itoa(output.ExitCode)
+
+	if output.Err != nil {
+		return tools.Result{
+			Status: tools.StatusError,
+			Output: "Error executing plugin tool " + tool.name + ": " + output.Err.Error(),
+			Meta:   meta,
+		}
+	}
+	formatted := formatPluginToolOutput(output)
+	if output.ExitCode != 0 {
+		return tools.Result{
+			Status:  tools.StatusError,
+			Output:  formatted,
+			Meta:    meta,
+			Display: tools.Display{Summary: tool.name + " failed", Kind: "plugin"},
+		}
+	}
+	return tools.Result{
+		Status:  tools.StatusOK,
+		Output:  formatted,
+		Meta:    meta,
+		Display: tools.Display{Summary: tool.name, Kind: "plugin"},
+	}
+}
+
+// commandCwd prefers the caller's workspace cwd and falls back to the plugin's
+// own directory so a command launched with a relative argv still has a stable
+// working directory.
+func (tool pluginTool) commandCwd(cwd string) string {
+	if trimmed := strings.TrimSpace(cwd); trimmed != "" {
+		return trimmed
+	}
+	if trimmed := strings.TrimSpace(tool.options.Cwd); trimmed != "" {
+		return trimmed
+	}
+	return tool.pluginDir
+}
+
+// commandEnv returns the base environment plus AGENT_PLUGIN_ROOT so the plugin
+// command can resolve files relative to its install dir even without the
+// ${AGENT_PLUGIN_ROOT} placeholder in its argv.
+func (tool pluginTool) commandEnv() []string {
+	base := tool.options.Env
+	if base == nil {
+		base = os.Environ()
+	}
+	env := append([]string{}, base...)
+	if strings.TrimSpace(tool.pluginDir) != "" {
+		env = append(env, pluginRootEnvVar+"="+tool.pluginDir)
+	}
+	return env
+}
+
+func (tool pluginTool) meta() map[string]string {
+	return map[string]string{
+		"plugin.id":   tool.pluginID,
+		"plugin.tool": tool.name,
+	}
+}
+
+// toolSafety maps the plugin ToolPermission onto a tools.Safety. A plugin tool
+// runs an external command, so it always carries a shell side effect; the
+// permission is carried through directly. An allow permission here is only
+// reachable when the operator opted into manifest auto-approval at load time
+// (parsePermission clamps allow→prompt otherwise), so honoring it does not
+// silently auto-approve a mutating plugin tool.
+func toolSafety(plugin LoadedPlugin, ext ToolExtension) tools.Safety {
+	permission := tools.PermissionPrompt
+	switch ext.Permission {
+	case PermissionAllow:
+		permission = tools.PermissionAllow
+	case PermissionDeny:
+		permission = tools.PermissionDeny
+	case PermissionPrompt:
+		permission = tools.PermissionPrompt
+	default:
+		permission = tools.PermissionPrompt
+	}
+	return tools.Safety{
+		SideEffect: tools.SideEffectShell,
+		Permission: permission,
+		Reason:     fmt.Sprintf("Plugin tool %s/%s runs the plugin's declared command.", plugin.ID, ext.Name),
+	}
+}
+
+// encodeToolArgs serializes the tool arguments to JSON for the plugin command's
+// stdin. A nil/empty map encodes as "{}" so the command always receives a valid
+// JSON object.
+func encodeToolArgs(args map[string]any) ([]byte, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	return json.Marshal(args)
+}
+
+// formatPluginToolOutput renders the command's stdout/stderr/exit into the tool
+// Result Output, redacting any high-confidence secrets the command may have
+// printed (additive to the registry-boundary scrub), mirroring the bash tool.
+func formatPluginToolOutput(output commandOutput) string {
+	stdout := strings.TrimRight(output.Stdout, "\r\n")
+	stderr := strings.TrimRight(output.Stderr, "\r\n")
+	stdout, outFindings := secrets.Redact(stdout)
+	stderr, errFindings := secrets.Redact(stderr)
+
+	parts := []string{}
+	if stdout != "" {
+		parts = append(parts, "stdout:\n"+stdout)
+	}
+	if stderr != "" {
+		parts = append(parts, "stderr:\n"+stderr)
+	}
+	if output.ExitCode != 0 {
+		parts = append(parts, fmt.Sprintf("exit_code: %d", output.ExitCode))
+	}
+	if n := len(outFindings) + len(errFindings); n > 0 {
+		parts = append(parts, fmt.Sprintf("[zero] redacted %d likely secret(s) from this plugin tool output before showing it.", n))
+	}
+	if len(parts) == 0 {
+		return "Plugin tool completed with no output."
+	}
+	return strings.Join(parts, "\n")
+}
+
+// execPluginCommand runs a resolved plugin command as a subprocess, feeding the
+// JSON args on stdin and capturing stdout/stderr. A non-zero exit is reported via
+// ExitCode; Err is reserved for commands that could not be launched (so a missing
+// binary surfaces as an error, not a misleading exit code).
+func execPluginCommand(ctx context.Context, command pluginCommand, timeout time.Duration) commandOutput {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, command.Command, command.Args...)
+	cmd.Dir = command.Cwd
+	cmd.Env = command.Env
+	if len(command.Stdin) > 0 {
+		cmd.Stdin = bytes.NewReader(command.Stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := commandOutput{Stdout: stdout.String(), Stderr: stderr.String()}
+	if err == nil {
+		return output
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		output.ExitCode = exitErr.ExitCode()
+		return output
+	}
+	output.ExitCode = -1
+	output.Err = err
+	return output
+}

--- a/internal/plugins/activate_test.go
+++ b/internal/plugins/activate_test.go
@@ -24,6 +24,20 @@ func (runner *fakeToolRunner) run(_ context.Context, command pluginCommand) comm
 	return runner.out
 }
 
+// fakeRegisteredTool is a minimal tools.Tool used to pre-occupy a name in the
+// registry so activation's collision handling can be exercised.
+type fakeRegisteredTool struct {
+	name string
+}
+
+func (tool *fakeRegisteredTool) Name() string             { return tool.name }
+func (tool *fakeRegisteredTool) Description() string      { return "pre-registered" }
+func (tool *fakeRegisteredTool) Parameters() tools.Schema { return tools.Schema{Type: "object"} }
+func (tool *fakeRegisteredTool) Safety() tools.Safety     { return tools.Safety{} }
+func (tool *fakeRegisteredTool) Run(context.Context, map[string]any) tools.Result {
+	return tools.Result{Status: tools.StatusOK}
+}
+
 func toolPlugin(pluginDir string, tool ToolExtension) LoadedPlugin {
 	return LoadedPlugin{
 		SchemaVersion: 1,
@@ -180,6 +194,33 @@ func TestActivateDenyPermissionRegistersDenySafety(t *testing.T) {
 	}
 }
 
+func TestActivateSkipsToolWhoseNameCollidesWithRegisteredTool(t *testing.T) {
+	registry := tools.NewRegistry()
+	// A tool already occupies the "bash" name (mimicking a core tool). The plugin
+	// tool must not silently overwrite it; the existing registration must survive.
+	existing := &fakeRegisteredTool{name: "bash"}
+	registry.Register(existing)
+
+	runner := &fakeToolRunner{out: commandOutput{Stdout: "should not replace bash"}}
+	plugin := toolPlugin(t.TempDir(), ToolExtension{Name: "bash", Command: "evil", Permission: PermissionPrompt})
+
+	result := Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: runner.run})
+
+	got, ok := registry.Get("bash")
+	if !ok {
+		t.Fatal("the pre-existing bash tool must remain registered")
+	}
+	if got != tools.Tool(existing) {
+		t.Fatalf("plugin tool overwrote the existing %q registration", "bash")
+	}
+	if len(result.Tools) != 0 {
+		t.Fatalf("a skipped colliding tool must not be recorded as provenance: %#v", result.Tools)
+	}
+	if !containsSubstring(result.Warnings, "bash") {
+		t.Fatalf("expected a warning naming the skipped colliding tool, got %#v", result.Warnings)
+	}
+}
+
 func TestActivateBuildsHookDefinitionsForMappedEvent(t *testing.T) {
 	registry := tools.NewRegistry()
 	plugin := LoadedPlugin{
@@ -271,6 +312,40 @@ func TestActivateExposesSkillDirInLoaderRoots(t *testing.T) {
 	}
 	if len(loaded) != 1 || loaded[0].Name != "ts-review" {
 		t.Fatalf("plugin skill not discoverable via loader: %#v", loaded)
+	}
+}
+
+func TestActivateResolvesManifestRelativeSkillRoot(t *testing.T) {
+	// A LoadedPlugin handed to Activate directly may carry a manifest-relative skill
+	// path (e.g. "skills/ts-review/SKILL.md") or one using the ${AGENT_PLUGIN_ROOT}
+	// placeholder. Either must resolve against the plugin dir so SkillRoots is the
+	// real <pluginDir>/skills directory, not a bare "skills".
+	cases := map[string]string{
+		"relative":    filepath.Join("skills", "ts-review", "SKILL.md"),
+		"placeholder": pluginRootPlaceholder + "/skills/ts-review/SKILL.md",
+	}
+	for name, skillPath := range cases {
+		t.Run(name, func(t *testing.T) {
+			pluginDir := t.TempDir()
+			plugin := LoadedPlugin{
+				ID:        "zero.review",
+				Name:      "Review",
+				Enabled:   true,
+				Source:    SourceProject,
+				PluginDir: pluginDir,
+				Skills:    []PathExtension{{Name: "ts-review", Path: skillPath}},
+			}
+
+			result := Activate(tools.NewRegistry(), []LoadedPlugin{plugin}, ActivateOptions{})
+
+			if len(result.SkillRoots) != 1 {
+				t.Fatalf("expected 1 skill root, got %#v", result.SkillRoots)
+			}
+			wantRoot := filepath.Join(pluginDir, "skills")
+			if result.SkillRoots[0] != wantRoot {
+				t.Fatalf("skill root = %q, want %q (resolved against plugin dir)", result.SkillRoots[0], wantRoot)
+			}
+		})
 	}
 }
 

--- a/internal/plugins/activate_test.go
+++ b/internal/plugins/activate_test.go
@@ -1,0 +1,463 @@
+package plugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/skills"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// fakeToolRunner records the invocation and returns a canned result so tool
+// activation can be exercised without spawning a real process.
+type fakeToolRunner struct {
+	calls []pluginCommand
+	out   commandOutput
+}
+
+func (runner *fakeToolRunner) run(_ context.Context, command pluginCommand) commandOutput {
+	runner.calls = append(runner.calls, command)
+	return runner.out
+}
+
+func toolPlugin(pluginDir string, tool ToolExtension) LoadedPlugin {
+	return LoadedPlugin{
+		SchemaVersion: 1,
+		ID:            "zero.demo",
+		Name:          "Zero Demo",
+		Version:       "0.1.0",
+		Enabled:       true,
+		Source:        SourceProject,
+		PluginDir:     pluginDir,
+		Tools:         []ToolExtension{tool},
+	}
+}
+
+func TestActivateRegistersToolThatInvokesCommand(t *testing.T) {
+	pluginDir := t.TempDir()
+	registry := tools.NewRegistry()
+	runner := &fakeToolRunner{out: commandOutput{Stdout: "lookup result", ExitCode: 0}}
+
+	plugin := toolPlugin(pluginDir, ToolExtension{
+		Name:        "lookup",
+		Description: "Lookup docs",
+		Command:     "${AGENT_PLUGIN_ROOT}/bin/lookup",
+		Args:        []string{"--root", "${AGENT_PLUGIN_ROOT}", "docs"},
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string"}}},
+		Permission:  PermissionPrompt,
+	})
+
+	result := Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: runner.run})
+
+	tool, ok := registry.Get("lookup")
+	if !ok {
+		t.Fatalf("expected tool %q registered, registry has %d tools", "lookup", len(registry.All()))
+	}
+	if tool.Description() != "Lookup docs" {
+		t.Fatalf("description = %q", tool.Description())
+	}
+	if tool.Parameters().Type != "object" {
+		t.Fatalf("schema type = %q, want object", tool.Parameters().Type)
+	}
+	if _, ok := tool.Parameters().Properties["query"]; !ok {
+		t.Fatalf("schema properties missing query: %#v", tool.Parameters().Properties)
+	}
+
+	// Running through the registry with permission granted invokes the plugin
+	// command and maps stdout/exit onto the tool Result.
+	runResult := registry.RunWithOptions(context.Background(), "lookup", map[string]any{"query": "hello"}, tools.RunOptions{PermissionGranted: true})
+	if runResult.Status != tools.StatusOK {
+		t.Fatalf("status = %q (%s)", runResult.Status, runResult.Output)
+	}
+	if !strings.Contains(runResult.Output, "lookup result") {
+		t.Fatalf("output = %q, want plugin stdout", runResult.Output)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected exactly one command invocation, got %d", len(runner.calls))
+	}
+	call := runner.calls[0]
+	// ${AGENT_PLUGIN_ROOT} is expanded in both command and args.
+	if call.Command != filepath.Join(pluginDir, "bin", "lookup") {
+		t.Fatalf("command = %q, want expanded plugin root", call.Command)
+	}
+	if len(call.Args) != 3 || call.Args[1] != pluginDir {
+		t.Fatalf("args = %#v, want ${AGENT_PLUGIN_ROOT} expanded", call.Args)
+	}
+	// The plugin dir is also exported as an env var the command can read.
+	if !envContains(call.Env, "AGENT_PLUGIN_ROOT="+pluginDir) {
+		t.Fatalf("env missing AGENT_PLUGIN_ROOT=%s: %#v", pluginDir, call.Env)
+	}
+	if result.Tools[0].ToolName != "lookup" || result.Tools[0].PluginID != "zero.demo" {
+		t.Fatalf("provenance = %#v", result.Tools)
+	}
+}
+
+func TestActivateToolMapsNonZeroExitToError(t *testing.T) {
+	registry := tools.NewRegistry()
+	runner := &fakeToolRunner{out: commandOutput{Stderr: "boom", ExitCode: 2}}
+	plugin := toolPlugin(t.TempDir(), ToolExtension{Name: "lookup", Command: "lookup", Permission: PermissionPrompt})
+
+	Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: runner.run})
+
+	res := registry.RunWithOptions(context.Background(), "lookup", map[string]any{}, tools.RunOptions{PermissionGranted: true})
+	if res.Status != tools.StatusError {
+		t.Fatalf("status = %q, want error on non-zero exit", res.Status)
+	}
+	if !strings.Contains(res.Output, "boom") {
+		t.Fatalf("output = %q, want stderr surfaced", res.Output)
+	}
+	if res.Meta["exit_code"] != "2" {
+		t.Fatalf("meta exit_code = %q, want 2", res.Meta["exit_code"])
+	}
+}
+
+func TestActivatePromptPermissionMapsToPromptSafety(t *testing.T) {
+	registry := tools.NewRegistry()
+	plugin := toolPlugin(t.TempDir(), ToolExtension{Name: "edit", Command: "edit", Permission: PermissionPrompt})
+
+	Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: (&fakeToolRunner{}).run})
+
+	tool, ok := registry.Get("edit")
+	if !ok {
+		t.Fatal("tool edit not registered")
+	}
+	safety := tool.Safety()
+	if safety.Permission != tools.PermissionPrompt {
+		t.Fatalf("permission = %q, want prompt", safety.Permission)
+	}
+	// A prompt-gated plugin tool is not auto-runnable: without granted permission
+	// the registry refuses to execute it.
+	res := registry.Run(context.Background(), "edit", map[string]any{})
+	if res.Status != tools.StatusError || !strings.Contains(res.Output, "Permission required") {
+		t.Fatalf("expected permission-required error, got %q (%s)", res.Status, res.Output)
+	}
+}
+
+func TestActivateAllowPermissionMapsToAllowSafety(t *testing.T) {
+	registry := tools.NewRegistry()
+	runner := &fakeToolRunner{out: commandOutput{Stdout: "ok"}}
+	// permission=allow only survives parsing when AllowManifestToolAutoApproval is
+	// set, so an allow-permission tool here represents an explicitly auto-approved
+	// plugin tool and must map to allow-level Safety (runnable without a prompt).
+	plugin := toolPlugin(t.TempDir(), ToolExtension{Name: "report", Command: "report", Permission: PermissionAllow})
+
+	Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: runner.run})
+
+	tool, _ := registry.Get("report")
+	if tool.Safety().Permission != tools.PermissionAllow {
+		t.Fatalf("permission = %q, want allow", tool.Safety().Permission)
+	}
+	res := registry.Run(context.Background(), "report", map[string]any{})
+	if res.Status != tools.StatusOK {
+		t.Fatalf("allow tool should run without granted permission, got %q (%s)", res.Status, res.Output)
+	}
+}
+
+func TestActivateDenyPermissionRegistersDenySafety(t *testing.T) {
+	registry := tools.NewRegistry()
+	runner := &fakeToolRunner{out: commandOutput{Stdout: "should not run"}}
+	plugin := toolPlugin(t.TempDir(), ToolExtension{Name: "danger", Command: "danger", Permission: PermissionDeny})
+
+	Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: runner.run})
+
+	tool, ok := registry.Get("danger")
+	if !ok {
+		t.Fatal("deny tool not registered")
+	}
+	if tool.Safety().Permission != tools.PermissionDeny {
+		t.Fatalf("permission = %q, want deny", tool.Safety().Permission)
+	}
+	res := registry.RunWithOptions(context.Background(), "danger", map[string]any{}, tools.RunOptions{PermissionGranted: true})
+	if res.Status != tools.StatusError {
+		t.Fatalf("deny tool must never execute, got %q (%s)", res.Status, res.Output)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("deny tool command must not be invoked, got %d calls", len(runner.calls))
+	}
+}
+
+func TestActivateBuildsHookDefinitionsForMappedEvent(t *testing.T) {
+	registry := tools.NewRegistry()
+	plugin := LoadedPlugin{
+		ID:        "zero.guard",
+		Name:      "Guard",
+		Enabled:   true,
+		Source:    SourceProject,
+		PluginDir: t.TempDir(),
+		Hooks: []HookExtension{
+			{Name: "pre", Event: HookBeforeTool, Command: "${AGENT_PLUGIN_ROOT}/guard.sh", Args: []string{"--strict"}},
+			{Name: "post", Event: HookAfterTool, Command: "log.sh"},
+		},
+	}
+
+	result := Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{})
+
+	if len(result.Hooks) != 2 {
+		t.Fatalf("expected 2 hook definitions, got %d: %#v", len(result.Hooks), result.Hooks)
+	}
+	// Plugin HookEvent maps onto the hooks package Event, and the command's
+	// ${AGENT_PLUGIN_ROOT} is expanded against the plugin dir.
+	var before hooks.Definition
+	found := false
+	for _, def := range result.Hooks {
+		if def.Event == hooks.EventBeforeTool {
+			before = def
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no beforeTool hook in %#v", result.Hooks)
+	}
+	if before.Command != filepath.Join(plugin.PluginDir, "guard.sh") {
+		t.Fatalf("hook command = %q, want expanded plugin root", before.Command)
+	}
+	if len(before.Args) != 1 || before.Args[0] != "--strict" {
+		t.Fatalf("hook args = %#v", before.Args)
+	}
+	if !before.Enabled {
+		t.Fatalf("plugin hook should be enabled")
+	}
+
+	// The dispatcher built from these definitions selects the plugin hook for the
+	// mapped event, proving the hook is live (not merely parsed).
+	cfg := hooks.Config{Enabled: true, Hooks: result.Hooks}
+	selected := hooks.Select(cfg, hooks.SelectInput{Event: hooks.EventBeforeTool, ToolName: "bash"})
+	if len(selected) != 1 {
+		t.Fatalf("expected the plugin beforeTool hook selected, got %d", len(selected))
+	}
+}
+
+func TestActivateExposesSkillDirInLoaderRoots(t *testing.T) {
+	pluginDir := t.TempDir()
+	// A plugin skill is a directory containing SKILL.md, nested under the plugin's
+	// skills/ directory: skills/ts-review/SKILL.md.
+	skillDir := filepath.Join(pluginDir, "skills", "ts-review")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillMd := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillMd, []byte("---\nname: ts-review\ndescription: review TS\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := tools.NewRegistry()
+	plugin := LoadedPlugin{
+		ID:        "zero.review",
+		Name:      "Review",
+		Enabled:   true,
+		Source:    SourceProject,
+		PluginDir: pluginDir,
+		Skills:    []PathExtension{{Name: "ts-review", Path: skillMd}},
+	}
+
+	result := Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{})
+
+	if len(result.SkillRoots) != 1 {
+		t.Fatalf("expected 1 skill root, got %#v", result.SkillRoots)
+	}
+	// The root is the directory that internal/skills.Load scans (parent of the
+	// per-skill directory), so the skill becomes discoverable through the loader.
+	wantRoot := filepath.Join(pluginDir, "skills")
+	if result.SkillRoots[0] != wantRoot {
+		t.Fatalf("skill root = %q, want %q", result.SkillRoots[0], wantRoot)
+	}
+	loaded, err := skills.Load(result.SkillRoots[0])
+	if err != nil {
+		t.Fatalf("skills.Load: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].Name != "ts-review" {
+		t.Fatalf("plugin skill not discoverable via loader: %#v", loaded)
+	}
+}
+
+func TestNewSkillToolSurfacesPluginSkillInList(t *testing.T) {
+	defaultDir := t.TempDir()
+	writeTestSkill(t, defaultDir, "core-skill", "core body")
+	pluginRoot := t.TempDir()
+	writeTestSkill(t, pluginRoot, "plugin-skill", "plugin body")
+
+	tool := NewSkillTool(defaultDir, []string{pluginRoot})
+	if tool.Name() != "skill" {
+		t.Fatalf("plugin skill tool must reuse the skill tool name, got %q", tool.Name())
+	}
+	if tool.Safety().Permission != tools.PermissionAllow || tool.Safety().SideEffect != tools.SideEffectRead {
+		t.Fatalf("skill tool must stay read-only/allow, got %#v", tool.Safety())
+	}
+
+	// Loading the plugin skill by name returns its body.
+	got := tool.Run(context.Background(), map[string]any{"name": "plugin-skill"})
+	if got.Status != tools.StatusOK || !strings.Contains(got.Output, "plugin body") {
+		t.Fatalf("expected plugin skill body, got %q (%s)", got.Status, got.Output)
+	}
+	// A core skill is still reachable through the same tool.
+	core := tool.Run(context.Background(), map[string]any{"name": "core-skill"})
+	if core.Status != tools.StatusOK || !strings.Contains(core.Output, "core body") {
+		t.Fatalf("expected core skill body, got %q (%s)", core.Status, core.Output)
+	}
+	// An unknown name lists the available skills (both core and plugin).
+	unknown := tool.Run(context.Background(), map[string]any{"name": "nope"})
+	if unknown.Status != tools.StatusError {
+		t.Fatalf("unknown skill must error, got %q", unknown.Status)
+	}
+	if !strings.Contains(unknown.Output, "core-skill") || !strings.Contains(unknown.Output, "plugin-skill") {
+		t.Fatalf("unknown-skill error should list both skills, got %q", unknown.Output)
+	}
+}
+
+func TestMergeSkillRootsListsPluginSkillInAgentList(t *testing.T) {
+	defaultDir := t.TempDir()
+	writeTestSkill(t, defaultDir, "core-skill", "core")
+
+	pluginRoot := t.TempDir()
+	writeTestSkill(t, pluginRoot, "plugin-skill", "from plugin")
+
+	listed, dups := MergedSkills(defaultDir, []string{pluginRoot})
+	if len(dups) != 0 {
+		t.Fatalf("unexpected duplicates: %#v", dups)
+	}
+	names := map[string]bool{}
+	for _, skill := range listed {
+		names[skill.Name] = true
+	}
+	if !names["core-skill"] || !names["plugin-skill"] {
+		t.Fatalf("agent skill list missing entries: %#v", listed)
+	}
+}
+
+func TestMergedSkillsRecordsDuplicatesWithoutCrashing(t *testing.T) {
+	defaultDir := t.TempDir()
+	writeTestSkill(t, defaultDir, "shared", "default copy")
+
+	pluginRoot := t.TempDir()
+	writeTestSkill(t, pluginRoot, "shared", "plugin copy")
+
+	listed, dups := MergedSkills(defaultDir, []string{pluginRoot})
+	// Name clash must be recorded, not crash; exactly one survivor named "shared".
+	count := 0
+	for _, skill := range listed {
+		if skill.Name == "shared" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected one surviving 'shared' skill, got %d", count)
+	}
+	if len(dups) != 1 || dups[0].Name != "shared" {
+		t.Fatalf("expected one recorded duplicate for 'shared', got %#v", dups)
+	}
+}
+
+func TestActivateSkipsMalformedPluginAndContinues(t *testing.T) {
+	registry := tools.NewRegistry()
+	good := toolPlugin(t.TempDir(), ToolExtension{Name: "good", Command: "good", Permission: PermissionPrompt})
+	// A tool extension with an empty command is malformed: it can never be invoked,
+	// so activation must skip it with a warning rather than register a broken tool.
+	bad := toolPlugin(t.TempDir(), ToolExtension{Name: "bad", Command: "   ", Permission: PermissionPrompt})
+	bad.ID = "zero.bad"
+
+	result := Activate(registry, []LoadedPlugin{bad, good}, ActivateOptions{runTool: (&fakeToolRunner{}).run})
+
+	if _, ok := registry.Get("good"); !ok {
+		t.Fatal("good plugin tool must still activate after a malformed plugin")
+	}
+	if _, ok := registry.Get("bad"); ok {
+		t.Fatal("malformed plugin tool must not be registered")
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected a warning for the malformed plugin")
+	}
+	if !containsSubstring(result.Warnings, "bad") && !containsSubstring(result.Warnings, "zero.bad") {
+		t.Fatalf("warning should identify the offending plugin/tool: %#v", result.Warnings)
+	}
+}
+
+func TestActivateSkipsDisabledPlugin(t *testing.T) {
+	registry := tools.NewRegistry()
+	plugin := toolPlugin(t.TempDir(), ToolExtension{Name: "lookup", Command: "lookup", Permission: PermissionPrompt})
+	plugin.Enabled = false
+
+	result := Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{runTool: (&fakeToolRunner{}).run})
+
+	if _, ok := registry.Get("lookup"); ok {
+		t.Fatal("a disabled plugin's tools must not be registered")
+	}
+	if len(result.Tools) != 0 || len(result.Hooks) != 0 {
+		t.Fatalf("disabled plugin should contribute nothing, got %#v", result)
+	}
+}
+
+func TestActivateIsDeterministic(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	plugins := []LoadedPlugin{
+		{ID: "zero.b", Name: "B", Enabled: true, PluginDir: dirB, Hooks: []HookExtension{{Name: "hb", Event: HookSessionStart, Command: "b.sh"}}},
+		{ID: "zero.a", Name: "A", Enabled: true, PluginDir: dirA, Hooks: []HookExtension{{Name: "ha", Event: HookSessionStart, Command: "a.sh"}}},
+	}
+
+	first := Activate(tools.NewRegistry(), plugins, ActivateOptions{})
+	second := Activate(tools.NewRegistry(), plugins, ActivateOptions{})
+	if len(first.Hooks) != 2 || len(second.Hooks) != 2 {
+		t.Fatalf("expected 2 hooks each, got %d/%d", len(first.Hooks), len(second.Hooks))
+	}
+	for i := range first.Hooks {
+		if first.Hooks[i].ID != second.Hooks[i].ID {
+			t.Fatalf("hook order not deterministic at %d: %q vs %q", i, first.Hooks[i].ID, second.Hooks[i].ID)
+		}
+	}
+	// Deterministic order is by plugin ID then extension name: zero.a before zero.b.
+	if first.Hooks[0].ID != "zero.a.ha" {
+		t.Fatalf("first hook id = %q, want zero.a.ha (deterministic by plugin then name)", first.Hooks[0].ID)
+	}
+}
+
+func TestActivateHookEventMappingCoversAllEvents(t *testing.T) {
+	cases := map[HookEvent]hooks.Event{
+		HookBeforeTool:   hooks.EventBeforeTool,
+		HookAfterTool:    hooks.EventAfterTool,
+		HookSessionStart: hooks.EventSessionStart,
+		HookSessionEnd:   hooks.EventSessionEnd,
+	}
+	for pluginEvent, want := range cases {
+		got, ok := mapHookEvent(pluginEvent)
+		if !ok || got != want {
+			t.Fatalf("mapHookEvent(%q) = %q,%v want %q", pluginEvent, got, ok, want)
+		}
+	}
+	if _, ok := mapHookEvent(HookEvent("bogus")); ok {
+		t.Fatal("unknown hook event must not map")
+	}
+}
+
+func writeTestSkill(t *testing.T, dir string, name string, body string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\nname: " + name + "\n---\n" + body
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/activate_unix_test.go
+++ b/internal/plugins/activate_unix_test.go
@@ -1,0 +1,91 @@
+//go:build unix
+
+package plugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// TestActivateToolRunsRealCommandEndToEnd exercises the default (non-mocked) tool
+// runner: a real shell script is invoked through the registry, receives the JSON
+// arguments on stdin, can read its install dir from $AGENT_PLUGIN_ROOT, and its
+// stdout/exit map onto the tool Result. This proves execPluginCommand is wired
+// correctly, complementing the runner-stubbed unit tests.
+func TestActivateToolRunsRealCommandEndToEnd(t *testing.T) {
+	pluginDir := t.TempDir()
+	script := filepath.Join(pluginDir, "tool.sh")
+	// The script echoes a marker, the plugin root it received via env, and the JSON
+	// args it read from stdin — so the test can assert all three round-trip.
+	body := "#!/bin/sh\n" +
+		"printf 'ran in %s\\n' \"$AGENT_PLUGIN_ROOT\"\n" +
+		"cat\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := tools.NewRegistry()
+	plugin := LoadedPlugin{
+		ID:        "zero.demo",
+		Name:      "Demo",
+		Enabled:   true,
+		Source:    SourceProject,
+		PluginDir: pluginDir,
+		Tools: []ToolExtension{{
+			Name:       "demo",
+			Command:    "${AGENT_PLUGIN_ROOT}/tool.sh",
+			Permission: PermissionPrompt,
+		}},
+	}
+
+	// No runTool override: this uses the real execPluginCommand subprocess runner.
+	Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{})
+
+	res := registry.RunWithOptions(context.Background(), "demo", map[string]any{"q": "hello"}, tools.RunOptions{PermissionGranted: true})
+	if res.Status != tools.StatusOK {
+		t.Fatalf("status = %q (%s)", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Output, "ran in "+pluginDir) {
+		t.Fatalf("output missing AGENT_PLUGIN_ROOT round-trip: %q", res.Output)
+	}
+	if !strings.Contains(res.Output, `"q":"hello"`) {
+		t.Fatalf("output missing JSON args on stdin: %q", res.Output)
+	}
+	if res.Meta["exit_code"] != "0" {
+		t.Fatalf("exit_code meta = %q, want 0", res.Meta["exit_code"])
+	}
+}
+
+// TestActivateToolRealCommandMissingBinaryErrors confirms a plugin tool whose
+// command cannot be launched surfaces as a tool error (not a misleading exit
+// code), via the real subprocess runner.
+func TestActivateToolRealCommandMissingBinaryErrors(t *testing.T) {
+	registry := tools.NewRegistry()
+	plugin := LoadedPlugin{
+		ID:        "zero.demo",
+		Name:      "Demo",
+		Enabled:   true,
+		Source:    SourceProject,
+		PluginDir: t.TempDir(),
+		Tools: []ToolExtension{{
+			Name:       "demo",
+			Command:    filepath.Join(t.TempDir(), "does-not-exist"),
+			Permission: PermissionPrompt,
+		}},
+	}
+
+	Activate(registry, []LoadedPlugin{plugin}, ActivateOptions{})
+
+	res := registry.RunWithOptions(context.Background(), "demo", map[string]any{}, tools.RunOptions{PermissionGranted: true})
+	if res.Status != tools.StatusError {
+		t.Fatalf("status = %q, want error for unlaunchable command", res.Status)
+	}
+	if !strings.Contains(res.Output, "Error executing plugin tool demo") {
+		t.Fatalf("output = %q, want launch error", res.Output)
+	}
+}

--- a/internal/plugins/plugins.go
+++ b/internal/plugins/plugins.go
@@ -326,11 +326,12 @@ func ParseManifest(raw any, options ParseManifestOptions) (LoadedPlugin, error) 
 		return LoadedPlugin{}, err
 	}
 
-	// NOTE: the tools/prompts/skills/hooks extensions parsed below are validated
-	// for DISCOVERY only (the `zero plugins` listing + backend snapshots). They
-	// are not yet registered into the tool registry / hook dispatcher / skills
-	// loader at runtime — that wiring is tracked as a separate feature, so these
-	// parsed-but-unconsumed fields are intentional, not dead code.
+	// The tools/prompts/skills/hooks extensions parsed below feed two consumers:
+	// DISCOVERY (the `zero plugins` listing + backend snapshots) and ACTIVATION
+	// (activate.go), which turns the resolved tools/hooks/skills into live
+	// registrations — tools into the tools.Registry, hooks into the hooks
+	// dispatcher, and skills into the skills loader's search roots. Prompts remain
+	// discovery-only for now.
 	tools, err := parseTools(obj["tools"], options.AllowManifestToolAutoApproval)
 	if err != nil {
 		return LoadedPlugin{}, err


### PR DESCRIPTION
## Summary

Finishes the previously-stubbed `internal/plugins` so loaded plugin manifests actually take effect at runtime. Before this change, plugin tools/hooks/skills were parsed for discovery only (the `zero plugins` listing) and never registered — plugins loaded but did nothing. This stage turns each plugin's declared **tools**, **hooks**, and **skills** into live registrations.

## What was built

**`internal/plugins/activate.go` (new)** — `Activate(registry, plugins, options)`:
- **Tools → registry:** a `pluginTool` adapter implements the `tools.Tool` interface by invoking the plugin's declared command. Tool arguments are passed as JSON on stdin; stdout/exit map onto a `tools.Result`; `${AGENT_PLUGIN_ROOT}` placeholders in the command/args are expanded to the plugin dir, which is also exported as the `AGENT_PLUGIN_ROOT` env var. The runner is injectable for tests and defaults to a bounded subprocess. Each tool is registered via `registry.Register`.
- **Permission mapping:** `ToolPermission` (allow/prompt/deny) maps onto `tools.Safety` (always `shell` side-effect + the carried permission). `allow` only survives manifest parsing when `AllowManifestToolAutoApproval` was set, so mutating plugin tools are **not** auto-approved by default; `deny` tools register but are never advertised or executed.
- **Hooks → dispatcher:** builds an `internal/hooks.Definition` per hook extension (mapping the plugin `HookEvent` to the hooks `Event`, carrying command/args, `${AGENT_PLUGIN_ROOT}`-expanded), with plugin-namespaced ids.
- **Skills → loader:** exposes each plugin skill's search root (the directory `internal/skills.Load` scans) and provides a plugin-aware `skill` tool that merges the default skills dir with plugin roots, deduplicating by name and recording collisions (preserving `skills.Duplicates` behaviour, never crashing).
- **Isolation:** a malformed plugin/extension is skipped with a recorded warning; a single bad plugin never aborts activation. Activation order is deterministic (plugins sorted by id). Provenance (originating plugin id) is recorded for tools/hooks/skills and tagged in tool-result `Meta`.

**`internal/cli/plugin_activate.go` (new) + bootstrap wiring** — `activatePlugins(...)` loads the workspace's plugins and runs activation. It is invoked in **both** bootstrap paths:
- interactive TUI: `internal/cli/app.go` in `runInteractiveTUIWithSetup`, right after specialist + MCP tool registration (so plugin tools are part of the deferral count).
- one-shot exec: `internal/cli/exec.go` in `runExec`, after MCP registration and before `--list-tools`/filter validation (so plugin tools are listable and filter-validatable).

`newHookDispatcherWithExtra` (in `internal/cli/hook_dispatch.go`) folds the plugin hook definitions into the dispatcher's active hook set; the plugin-aware skill tool is registered when a plugin declares skills. Activation **fails open**: a load error or malformed plugin is surfaced as a `[zero] WARNING` on stderr and skipped, never wedging startup.

**`internal/plugins/plugins.go`** — comment-only update replacing the stale "not yet registered" note (no behavioural change).

## Where activation is invoked
- `internal/cli/app.go`: `activatePlugins(workspaceRoot, registry, deps, stderr)` in `runInteractiveTUIWithSetup`, and `newHookDispatcherWithExtra(workspaceRoot, pluginActivation.hooks)` in the TUI `agent.Options`.
- `internal/cli/exec.go`: `activatePlugins(...)` in `runExec`, and `newHookDispatcherWithExtra(...)` in the exec `agent.Options`.

## Testing
- `internal/plugins/activate_test.go`: tool registration + command invocation + stdout→Result mapping (stubbed runner); non-zero exit → error; permission mapping (prompt requires grant, allow runs, deny never executes); hook `Definition` build + event mapping + dispatcher `Select`; skill search-root derivation + loader discovery; merged skill list + duplicate recording; malformed-plugin skip-with-warning; disabled-plugin skip; deterministic ordering.
- `internal/plugins/activate_unix_test.go`: real-subprocess end-to-end (JSON args on stdin and `$AGENT_PLUGIN_ROOT` round-trip; missing binary → tool error).
- `internal/cli/plugin_activate_test.go`: bootstrap helper registers the plugin tool, collects namespaced hooks, re-registers the plugin-aware skill tool, fails open on load error, warns on malformed plugin; `newHookDispatcherWithExtra` runs a folded plugin hook.
- Gate: `gofmt -l` clean on changed dirs, `go build ./...` and `go test ./...` both green.

## Deferred / out of scope
- Plugin **prompts** remain discovery-only (the spec scoped this stage to tools/hooks/skills).
- No new config surface for manifest tool auto-approval was added; `AllowManifestToolAutoApproval` stays off by default at the bootstrap, so plugin `allow` tools are clamped to prompt unless a caller opts in.
- Plugin tools are advertised eagerly (they do not opt into the deferred-tool/`tool_search` mechanism).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins now activate automatically during CLI interactive and execution runs; plugin-provided hooks are merged into the CLI hook dispatcher while preserving workspace hook config.
  * Plugin tools and skills are dynamically registered and made available at runtime; activation emits warnings for load/activation issues without blocking runs.

* **Tests**
  * Comprehensive unit and end-to-end tests added to validate plugin activation, tool execution, hook wiring, skill merging, and subprocess behavior.

* **Documentation**
  * Clarified manifest parsing docs to distinguish discovery vs activation consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->