### PR TITLE
wedge stage 13: launch readiness (first-run + benchmark)

### DIFF
--- a/cmd/zero-perf-bench/main.go
+++ b/cmd/zero-perf-bench/main.go
@@ -33,6 +33,12 @@ func main() {
 }
 
 func run(args []string, getenv func(string) string, stdout io.Writer, stderr io.Writer) int {
+	// The `tasks` subcommand is the reproducible Terminal-Bench-style task harness;
+	// the default (no subcommand) path stays the cold-start/RSS perf benchmark so
+	// existing invocations are unchanged.
+	if len(args) > 0 && args[0] == "tasks" {
+		return runTasksCommand(args[1:], getenv, stdout, stderr)
+	}
 	options, err := parseArgs(args, getenv)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err.Error())
@@ -199,6 +205,7 @@ func parseArgs(args []string, getenv func(string) string) (cliOptions, error) {
 func helpText() string {
 	return strings.Join([]string{
 		"Usage: zero-perf-bench [options]",
+		"       zero-perf-bench tasks [options]   (Terminal-Bench-style task harness; see `tasks --help`)",
 		"",
 		"Options:",
 		"  --iterations <n>             Measured samples to collect (default: 5)",

--- a/cmd/zero-perf-bench/tasks.go
+++ b/cmd/zero-perf-bench/tasks.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/perfbench"
+)
+
+// taskOptions configures the `zero-perf-bench tasks` subcommand: the reproducible
+// Terminal-Bench-style harness that runs ZERO headlessly against a task set and
+// records a publishable result (model + commit + self-correct flag + date).
+type taskOptions struct {
+	SuitePath   string
+	Model       string
+	Mode        string
+	SelfCorrect bool
+	Binary      string
+	Version     string
+	Commit      string
+	Output      string
+	JSON        bool
+	DryRun      bool
+	Help        bool
+}
+
+func runTasksCommand(args []string, getenv func(string) string, stdout io.Writer, stderr io.Writer) int {
+	options, err := parseTaskArgs(args, getenv)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err.Error())
+		return 2
+	}
+	if options.Help {
+		_, _ = fmt.Fprint(stdout, taskHelpText())
+		return 0
+	}
+
+	set, err := perfbench.LoadTaskSet(options.SuitePath)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "[zero] Task benchmark failed: "+err.Error())
+		return 1
+	}
+
+	runner := perfbench.SkipRunner
+	if !options.DryRun {
+		binary := strings.TrimSpace(options.Binary)
+		if binary == "" {
+			_, _ = fmt.Fprintln(stderr, "[zero] Task benchmark failed: --binary is required unless --dry-run is set")
+			return 2
+		}
+		runner = perfbench.NewExecRunner(binary)
+	}
+
+	result, err := perfbench.RunTasks(context.Background(), set, perfbench.TaskConfig{
+		Model:       options.Model,
+		Mode:        options.Mode,
+		SelfCorrect: options.SelfCorrect,
+		Version:     options.Version,
+		Commit:      options.Commit,
+		Runner:      runner,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, "[zero] Task benchmark failed: "+err.Error())
+		return 1
+	}
+
+	if options.Output != "" {
+		if err := writeTaskReport(options.Output, result); err != nil {
+			_, _ = fmt.Fprintln(stderr, "[zero] Task benchmark failed: "+err.Error())
+			return 1
+		}
+	}
+	if options.JSON {
+		if err := perfbench.WriteTaskJSON(stdout, result); err != nil {
+			_, _ = fmt.Fprintln(stderr, "[zero] Task benchmark failed: "+err.Error())
+			return 1
+		}
+		return 0
+	}
+	_, _ = fmt.Fprintln(stdout, perfbench.FormatTaskSummary(result))
+	return 0
+}
+
+func parseTaskArgs(args []string, getenv func(string) string) (taskOptions, error) {
+	options := taskOptions{
+		Version: strings.TrimSpace(getenv("ZERO_BENCH_VERSION")),
+		Commit:  strings.TrimSpace(getenv("ZERO_BENCH_COMMIT")),
+	}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		flag, inlineValue := splitFlagValue(arg)
+		switch flag {
+		case "--suite":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.SuitePath = value
+			index = next
+		case "--model":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.Model = value
+			index = next
+		case "--mode":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.Mode = value
+			index = next
+		case "--binary":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.Binary = value
+			index = next
+		case "--version":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.Version = value
+			index = next
+		case "--commit":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.Commit = value
+			index = next
+		case "--output":
+			value, next, err := readOptionValue(args, inlineValue, index, flag)
+			if err != nil {
+				return options, err
+			}
+			options.Output = value
+			index = next
+		case "--self-correct":
+			if strings.Contains(arg, "=") {
+				return options, fmt.Errorf("%s does not accept a value", flag)
+			}
+			options.SelfCorrect = true
+		case "--json":
+			if strings.Contains(arg, "=") {
+				return options, fmt.Errorf("%s does not accept a value", flag)
+			}
+			options.JSON = true
+		case "--dry-run":
+			if strings.Contains(arg, "=") {
+				return options, fmt.Errorf("%s does not accept a value", flag)
+			}
+			options.DryRun = true
+		case "-h", "--help":
+			if strings.Contains(arg, "=") {
+				return options, fmt.Errorf("%s does not accept a value", flag)
+			}
+			options.Help = true
+		default:
+			return options, fmt.Errorf("unknown option: %s", arg)
+		}
+	}
+	if options.Help {
+		return options, nil
+	}
+	if strings.TrimSpace(options.SuitePath) == "" {
+		return options, fmt.Errorf("--suite is required")
+	}
+	if strings.TrimSpace(options.Model) == "" {
+		return options, fmt.Errorf("--model is required")
+	}
+	return options, nil
+}
+
+func writeTaskReport(path string, result perfbench.TaskRunResult) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	var buffer bytes.Buffer
+	if err := perfbench.WriteTaskJSON(&buffer, result); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buffer.Bytes(), 0o644)
+}
+
+func taskHelpText() string {
+	return strings.Join([]string{
+		"Usage: zero-perf-bench tasks [options]",
+		"",
+		"Runs ZERO headlessly against a Terminal-Bench-style task set and records a",
+		"reproducible, publishable result (model + commit + self-correct flag + date).",
+		"",
+		"Options:",
+		"  --suite <path>      Task set JSON file (required)",
+		"  --model <model>     Model to run (required); recorded with the result",
+		"  --mode <name>       Exec mode preset to apply",
+		"  --self-correct      Enable the post-edit verify-and-correct loop",
+		"  --binary <path>     Path to the `zero` binary (required unless --dry-run)",
+		"  --version <v>       Record the ZERO version (default: $ZERO_BENCH_VERSION)",
+		"  --commit <sha>      Record the ZERO commit (default: $ZERO_BENCH_COMMIT)",
+		"  --output <path>     Write the JSON result to path",
+		"  --json              Print only the JSON result",
+		"  --dry-run           Record every task as skipped without invoking the agent",
+		"  -h, --help          Show this help",
+		"",
+		"Run twice — with and without --self-correct — to publish the delta.",
+	}, "\n") + "\n"
+}

--- a/cmd/zero-perf-bench/tasks_test.go
+++ b/cmd/zero-perf-bench/tasks_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTaskSuite(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "suite.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write suite: %v", err)
+	}
+	return path
+}
+
+func TestParseTaskArgsRequiresSuiteAndModel(t *testing.T) {
+	if _, err := parseTaskArgs([]string{"--model", "m"}, emptyEnv); err == nil || !strings.Contains(err.Error(), "--suite") {
+		t.Fatalf("expected missing-suite error, got %v", err)
+	}
+	if _, err := parseTaskArgs([]string{"--suite", "/x.json"}, emptyEnv); err == nil || !strings.Contains(err.Error(), "--model") {
+		t.Fatalf("expected missing-model error, got %v", err)
+	}
+}
+
+func TestParseTaskArgsReadsFlagsAndEnv(t *testing.T) {
+	env := func(key string) string {
+		return map[string]string{
+			"ZERO_BENCH_COMMIT":  "deadbeef",
+			"ZERO_BENCH_VERSION": "9.9.9",
+		}[key]
+	}
+	options, err := parseTaskArgs([]string{
+		"--suite", "/tmp/suite.json",
+		"--model", "test-model",
+		"--mode", "build",
+		"--self-correct",
+		"--binary", "/usr/local/bin/zero",
+		"--output", "dist/bench.json",
+		"--json",
+	}, env)
+	if err != nil {
+		t.Fatalf("parseTaskArgs error: %v", err)
+	}
+	if options.SuitePath != "/tmp/suite.json" || options.Model != "test-model" || options.Mode != "build" {
+		t.Fatalf("options = %#v", options)
+	}
+	if !options.SelfCorrect || !options.JSON {
+		t.Fatalf("flags not parsed: %#v", options)
+	}
+	if options.Binary != "/usr/local/bin/zero" || options.Output != "dist/bench.json" {
+		t.Fatalf("binary/output = %q/%q", options.Binary, options.Output)
+	}
+	if options.Commit != "deadbeef" || options.Version != "9.9.9" {
+		t.Fatalf("commit/version from env = %q/%q", options.Commit, options.Version)
+	}
+}
+
+func TestParseTaskArgsFlagsOverrideEnv(t *testing.T) {
+	env := func(key string) string {
+		return map[string]string{"ZERO_BENCH_COMMIT": "fromenv"}[key]
+	}
+	options, err := parseTaskArgs([]string{"--suite", "/s.json", "--model", "m", "--commit", "fromflag"}, env)
+	if err != nil {
+		t.Fatalf("parseTaskArgs error: %v", err)
+	}
+	if options.Commit != "fromflag" {
+		t.Fatalf("commit = %q, want fromflag (flag overrides env)", options.Commit)
+	}
+}
+
+func TestRunTasksCommandWritesRecordWithoutBinary(t *testing.T) {
+	// With --dry-run no agent is invoked: every task is recorded as skipped. This
+	// exercises the full record path (model + commit + self-correct flag) without
+	// needing a real zero binary or model.
+	suite := writeTaskSuite(t, `{
+		"id": "terminal-bench-mini",
+		"name": "Terminal-Bench (mini)",
+		"tasks": [
+			{"id": "t1", "name": "fix", "prompt": "do the thing"},
+			{"id": "t2", "name": "flag", "prompt": "add a flag"}
+		]
+	}`)
+	outPath := filepath.Join(t.TempDir(), "bench.json")
+
+	var stdout, stderr bytes.Buffer
+	code := runTasksCommand([]string{
+		"--suite", suite,
+		"--model", "test-model",
+		"--self-correct",
+		"--commit", "abc1234",
+		"--version", "1.2.3",
+		"--dry-run",
+		"--output", outPath,
+	}, emptyEnv, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runTasksCommand code = %d, stderr = %q", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var record struct {
+		Model       string `json:"model"`
+		Commit      string `json:"commit"`
+		SelfCorrect bool   `json:"selfCorrect"`
+		Suite       string `json:"suite"`
+		Attempted   int    `json:"tasksAttempted"`
+	}
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("decode record: %v\n%s", err, data)
+	}
+	if record.Model != "test-model" || record.Commit != "abc1234" || !record.SelfCorrect {
+		t.Fatalf("record = %#v", record)
+	}
+	if record.Suite != "terminal-bench-mini" || record.Attempted != 2 {
+		t.Fatalf("record suite/attempted = %q/%d", record.Suite, record.Attempted)
+	}
+	if !strings.Contains(stdout.String(), "self-correct: on") {
+		t.Fatalf("summary missing self-correct line:\n%s", stdout.String())
+	}
+}
+
+func TestRunTasksCommandRejectsMissingSuiteFile(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runTasksCommand([]string{"--suite", "/no/such/suite.json", "--model", "m", "--dry-run"}, emptyEnv, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for missing suite file")
+	}
+	if stderr.Len() == 0 {
+		t.Fatalf("expected an error message on stderr")
+	}
+}
+
+func TestSampleTaskSuiteIsValidAndRunnableDry(t *testing.T) {
+	// The published example suite (referenced by docs/BENCHMARK.md) must load and
+	// dry-run cleanly so the documented command never bit-rots.
+	outPath := filepath.Join(t.TempDir(), "bench.json")
+	var stdout, stderr bytes.Buffer
+	code := runTasksCommand([]string{
+		"--suite", filepath.Join("testdata", "terminal-bench-sample.json"),
+		"--model", "example-model",
+		"--dry-run",
+		"--output", outPath,
+	}, emptyEnv, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("sample suite dry run code = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "terminal-bench-sample") {
+		t.Fatalf("summary should name the suite:\n%s", stdout.String())
+	}
+}
+
+func TestTasksSubcommandRoutedFromMain(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// "tasks --help" must route to the task harness help, not the perf-bench flags.
+	code := run([]string{"tasks", "--help"}, emptyEnv, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run tasks --help code = %d stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "zero-perf-bench tasks") {
+		t.Fatalf("tasks help missing usage:\n%s", stdout.String())
+	}
+}

--- a/cmd/zero-perf-bench/testdata/terminal-bench-sample.json
+++ b/cmd/zero-perf-bench/testdata/terminal-bench-sample.json
@@ -1,0 +1,20 @@
+{
+  "id": "terminal-bench-sample",
+  "name": "Terminal-Bench (sample)",
+  "tasks": [
+    {
+      "id": "hello-fix",
+      "name": "make the failing test pass",
+      "prompt": "The test in ./hello fails. Fix the implementation so `go test ./...` passes.",
+      "workspaceFixture": "./hello",
+      "verificationCommand": ["go", "test", "./..."]
+    },
+    {
+      "id": "add-json-flag",
+      "name": "add a --json flag",
+      "prompt": "Add a --json flag to the CLI that prints the result as JSON, and a test for it.",
+      "workspaceFixture": "./cli",
+      "verificationCommand": ["go", "test", "./..."]
+    }
+  ]
+}

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -1,0 +1,130 @@
+# Zero Task Benchmark
+
+This is the **task** benchmark: how often ZERO completes a real coding task
+end-to-end, headless, unattended. It is separate from
+[`docs/PERFORMANCE.md`](PERFORMANCE.md), which measures process startup and
+memory, not task success.
+
+The methodology is the point, not the digit. A task-success score is **largely
+model-bounded** — most of the number comes from whichever model you bring. So we
+record the model with every result and we publish the score **with and without
+the self-correct loop**, because the delta between those two runs is the part
+ZERO actually contributes: the agent noticing its own broken edit and fixing it
+before it hands the task back.
+
+## What is recorded
+
+Every run produces a self-describing JSON record so a published number is
+reproducible and auditable from the record alone:
+
+| Field            | Meaning                                                       |
+| ---------------- | ------------------------------------------------------------- |
+| `suite`          | Task set id (which tasks produced the number)                 |
+| `model`          | The model that ran — the score is model-bounded, so this is required |
+| `mode`           | Exec mode preset, if any                                      |
+| `selfCorrect`    | Whether the post-edit verify-and-correct loop was enabled     |
+| `version`        | ZERO version                                                  |
+| `commit`         | ZERO commit the run was built from                            |
+| `date`           | UTC timestamp of the run                                      |
+| `tasksAttempted` | Tasks attempted                                               |
+| `tasksPassed`    | Tasks whose verification passed                               |
+| `passRate`       | `tasksPassed / tasksAttempted`                                |
+| `tasks`          | Per-task pass/fail/error with detail                          |
+
+## Integration point: headless `zero exec`
+
+The harness drives ZERO through its headless surface — the same path CI uses:
+
+```bash
+zero exec --output-format stream-json --model <model> [--self-correct] "<task prompt>"
+```
+
+Per task, the harness reads the terminal `run_end` event's exit code from the
+stream-json output to decide pass/fail. When a task carries a
+`verificationCommand` (e.g. `go test ./...`), that command's exit status is
+authoritative — mirroring Terminal-Bench's external-verifier model: the task is
+"passed" only when the project's own checks pass after the agent finishes.
+
+## Task set format
+
+A task set is a JSON manifest. A runnable sample lives at
+[`cmd/zero-perf-bench/testdata/terminal-bench-sample.json`](../cmd/zero-perf-bench/testdata/terminal-bench-sample.json):
+
+```json
+{
+  "id": "terminal-bench-sample",
+  "name": "Terminal-Bench (sample)",
+  "tasks": [
+    {
+      "id": "hello-fix",
+      "name": "make the failing test pass",
+      "prompt": "The test in ./hello fails. Fix the implementation so `go test ./...` passes.",
+      "workspaceFixture": "./hello",
+      "verificationCommand": ["go", "test", "./..."]
+    }
+  ]
+}
+```
+
+## The exact command
+
+Build the binary, then run the task harness **twice** against the same task set
+and the same model — once without self-correct, once with — and stamp the version
+and commit so the records are reproducible:
+
+```bash
+# build the production binary
+go run ./cmd/zero-release build
+
+VERSION=$(git describe --tags --always)
+COMMIT=$(git rev-parse --short HEAD)
+SUITE=cmd/zero-perf-bench/testdata/terminal-bench-sample.json
+MODEL=<your-model>
+
+# baseline: self-correct OFF
+go run ./cmd/zero-perf-bench tasks \
+  --suite "$SUITE" --binary ./zero --model "$MODEL" \
+  --version "$VERSION" --commit "$COMMIT" \
+  --output dist/bench/tasks-baseline.json
+
+# self-correct ON (auto-fix needs --auto medium or high; see note below)
+go run ./cmd/zero-perf-bench tasks \
+  --suite "$SUITE" --binary ./zero --model "$MODEL" --self-correct \
+  --version "$VERSION" --commit "$COMMIT" \
+  --output dist/bench/tasks-selfcorrect.json
+```
+
+`--version`/`--commit` also read from `ZERO_BENCH_VERSION` / `ZERO_BENCH_COMMIT`
+when the flags are omitted, so CI can stamp them once in the environment.
+
+Use `--dry-run` to exercise the record path without invoking a model (every task
+is recorded as skipped) — useful for validating a task set before a real run.
+
+> **Self-correct and autonomy.** `--self-correct` runs the verify-and-correct
+> loop after each mutating edit. Whether a detected failure is **auto-fixed** or
+> only **reported** is gated by the run's autonomy: pass `--auto medium` (or
+> `high`) for the loop to drive corrective rounds. At the default low autonomy it
+> reports failures without auto-fixing, so the with/without delta is measured at
+> `--auto medium` or higher.
+
+## Published result
+
+Fill in after a clean run on a fixed machine. Keep both records; the delta is the
+headline.
+
+| Run                     | Model     | Self-correct | Pass rate | Commit |
+| ----------------------- | --------- | ------------ | --------- | ------ |
+| Baseline                | _TBD_     | off          | _TBD_     | _TBD_  |
+| With self-correct       | _TBD_     | on           | _TBD_     | _TBD_  |
+| **Self-correct delta**  |           |              | **_TBD_** |        |
+
+Report the model alongside the number every time. A score without its model is
+not a claim about ZERO — it is a claim about the model. The honest signal is the
+delta: how much the self-correct loop moved the same model on the same tasks.
+
+## Reproducing a published number
+
+1. Check out the `commit` from the record.
+2. `go run ./cmd/zero-release build`.
+3. Run the two commands above with the recorded `model` and `suite`.
+4. Compare `passRate` in the new records against the published ones.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -693,6 +693,7 @@ Flags:
       --init-session-id <id>         Create a new exec session with this id
       --skip-permissions-unsafe      Allow prompt-gated tools without approval
       --allow-escalation             Let the agent escalate to a stronger model mid-run via escalate_model
+      --self-correct                 Run the post-edit verify-and-correct loop (auto-fix needs --auto medium or high)
       --notify <off|bell|notify|both>
                                     Override notification mode for this run
       --no-notify                   Disable notifications for this run

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -89,6 +89,12 @@ type execOptions struct {
 	// default — a run without the flag is byte-identical to before (no tool, nil
 	// switcher).
 	allowEscalation bool
+	// selfCorrect opts the run into the post-edit verify-and-correct loop: after a
+	// mutating tool call ZERO runs the workspace verification plan and feeds
+	// failures back to the model to fix, bounded by an attempt ceiling and the
+	// autonomy gate. Off by default — a run without the flag wires a nil
+	// SelfCorrector, leaving the agent loop byte-identical to before.
+	selfCorrect bool
 	// notifyMode overrides config.Notify.Mode for this run. Mutually exclusive
 	// with noNotify.
 	notifyMode string
@@ -441,6 +447,12 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	// cleanly (the loop honors context cancellation) instead of being killed.
 	runCtx, stopSignals := signalContext()
 	defer stopSignals()
+	// --self-correct opts the run into the post-edit verify-and-correct loop. Off
+	// by default the corrector is nil, leaving the agent loop byte-identical. When
+	// on we verify with the workspace test plan (the LSP half stays nil here since
+	// headless exec does not run a language-server manager); the autonomy gate
+	// inside the corrector still decides whether failures auto-fix or just report.
+	selfCorrector := newExecSelfCorrector(options.selfCorrect, workspaceRoot, options.autonomy)
 	result, err := agent.Run(runCtx, agentPrompt, provider, agent.Options{
 		MaxTurns:         resolved.MaxTurns,
 		ContextWindow:    modelContextWindow(modelRegistry, resolved.Provider.Model),
@@ -460,6 +472,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		Registry:         registry,
 		PermissionMode:   permissionMode,
 		Autonomy:         options.autonomy,
+		SelfCorrect:      selfCorrector,
 		Sandbox:          sandboxEngine,
 		FileTracker:      tools.NewFileTracker(),
 		Hooks:            newHookDispatcher(workspaceRoot),
@@ -573,6 +586,26 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 // population here keeps registration and activation in agreement: tool_search is
 // registered iff the partition will actually go active. Built-ins never implement
 // the Deferred interface, so they never count.
+// newExecSelfCorrector builds the post-edit self-corrector for a headless run,
+// or nil when --self-correct is off. nil is deliberately the disabled state the
+// agent loop treats as a no-op, so a run without the flag stays byte-identical.
+//
+// The headless wiring verifies with the workspace test plan only (IncludeLSP is
+// false: exec does not spin up a language-server manager, and NewSelfCorrector
+// accepts a nil checker). Whether a failure auto-fixes or is merely reported is
+// decided by the corrector's autonomy gate from the run's --auto level.
+func newExecSelfCorrector(enabled bool, workspaceRoot string, autonomy string) *agent.SelfCorrector {
+	if !enabled {
+		return nil
+	}
+	return agent.NewSelfCorrector(workspaceRoot, nil, agent.NewProjectVerifier(workspaceRoot), agent.SelfCorrectConfig{
+		Enabled:      true,
+		IncludeTests: true,
+		IncludeLSP:   false,
+		Autonomy:     autonomy,
+	})
+}
+
 func deferredEligibleCount(registry *tools.Registry, permissionMode agent.PermissionMode, enabledTools []string, disabledTools []string) int {
 	count := 0
 	for _, tool := range registry.All() {

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -394,6 +394,12 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 	if options.useSpec && strings.EqualFold(strings.TrimSpace(options.tag), specialist.SessionTagSpecialist) {
 		return options, false, execUsageError{"--use-spec cannot be used inside a specialist child session."}
 	}
+	if options.useSpec && options.selfCorrect {
+		// The spec-draft (planning) path never wires the post-edit self-correct loop,
+		// so accepting the flag here would silently ignore it. Reject the combination
+		// rather than pretend it took effect.
+		return options, false, execUsageError{"--self-correct cannot be combined with --use-spec."}
+	}
 	if !options.useSpec && options.specModel != "" {
 		return options, false, execUsageError{"--spec-model requires --use-spec."}
 	}

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -26,6 +26,8 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			options.listTools = true
 		case arg == "--allow-escalation":
 			options.allowEscalation = true
+		case arg == "--self-correct":
+			options.selfCorrect = true
 		case arg == "--no-notify":
 			options.noNotify = true
 		case arg == "--notify":

--- a/internal/cli/exec_self_correct_test.go
+++ b/internal/cli/exec_self_correct_test.go
@@ -39,6 +39,19 @@ func TestParseExecSelfCorrectFlag(t *testing.T) {
 			t.Fatal("expected an error for --self-correct=yes, got nil")
 		}
 	})
+
+	t.Run("rejects combination with --use-spec", func(t *testing.T) {
+		// --use-spec routes through the spec-draft (planning) path, which never wires
+		// the post-edit self-correct loop. Accepting --self-correct there would
+		// silently ignore it, so the combination is rejected at parse time.
+		_, _, err := parseExecArgs([]string{"--use-spec", "--self-correct", "hello"})
+		if err == nil {
+			t.Fatal("expected an error for --use-spec with --self-correct, got nil")
+		}
+		if !strings.Contains(err.Error(), "--self-correct") || !strings.Contains(err.Error(), "--use-spec") {
+			t.Fatalf("error should name both flags, got %q", err.Error())
+		}
+	})
 }
 
 func TestRunExecHelpDocumentsSelfCorrect(t *testing.T) {

--- a/internal/cli/exec_self_correct_test.go
+++ b/internal/cli/exec_self_correct_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseExecSelfCorrectFlag(t *testing.T) {
+	t.Run("absent defaults to false", func(t *testing.T) {
+		options, help, err := parseExecArgs([]string{"hello"})
+		if err != nil {
+			t.Fatalf("parseExecArgs returned error: %v", err)
+		}
+		if help {
+			t.Fatal("help = true, want false")
+		}
+		if options.selfCorrect {
+			t.Fatal("selfCorrect = true, want false by default")
+		}
+	})
+
+	t.Run("flag sets true", func(t *testing.T) {
+		options, _, err := parseExecArgs([]string{"--self-correct", "hello"})
+		if err != nil {
+			t.Fatalf("parseExecArgs returned error: %v", err)
+		}
+		if !options.selfCorrect {
+			t.Fatal("selfCorrect = false, want true")
+		}
+		if strings.Join(options.promptParts, " ") != "hello" {
+			t.Fatalf("promptParts = %#v, want [hello]", options.promptParts)
+		}
+	})
+
+	t.Run("flag rejects an inline value", func(t *testing.T) {
+		_, _, err := parseExecArgs([]string{"--self-correct=yes", "hello"})
+		if err == nil {
+			t.Fatal("expected an error for --self-correct=yes, got nil")
+		}
+	})
+}
+
+func TestRunExecHelpDocumentsSelfCorrect(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	exitCode := Run([]string{"exec", "--help"}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "--self-correct") {
+		t.Fatalf("expected exec help to document --self-correct, got %q", stdout.String())
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -82,7 +82,7 @@ func runSetup(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 		return exitSuccess
 	}
 	output := formatSetupComplete(result)
-	if verification != nil && verification.OK {
+	if verification != nil && verification.Ran && verification.OK {
 		output += "\nverified: " + verification.Summary
 	}
 	if _, err := fmt.Fprintln(stdout, output); err != nil {
@@ -92,18 +92,22 @@ func runSetup(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 }
 
 // setupVerification is the outcome of the optional first-run connectivity probe.
+// Ran distinguishes "the probe ran and passed" (OK) from "no probe was wired so
+// nothing was verified", so a skipped probe is never reported as verified.
 type setupVerification struct {
+	Ran     bool
 	OK      bool
 	Summary string
 }
 
 // verifySetupProvider runs a live connectivity probe against the just-saved
-// provider and classifies any failure into a specific, fixable message. It is a
-// no-op (reports OK) when no probe is wired, so it never blocks setup in a
-// context that cannot probe.
+// provider and classifies any failure into a specific, fixable message. When no
+// probe is wired it reports a skipped (not-run) state rather than success, so it
+// never blocks setup in a context that cannot probe and never claims a provider
+// is verified when nothing was checked.
 func verifySetupProvider(deps appDeps, profile config.ProviderProfile) (setupVerification, error) {
 	if deps.probeProviderHealth == nil {
-		return setupVerification{OK: true, Summary: "probe unavailable; skipped"}, nil
+		return setupVerification{Ran: false, Summary: "probe unavailable; skipped"}, nil
 	}
 	ctx, stop := signalContext()
 	defer stop()
@@ -113,13 +117,13 @@ func verifySetupProvider(deps appDeps, profile config.ProviderProfile) (setupVer
 		UserAgent:    userAgent(),
 	})
 	if probeErr, failed := provideronboarding.ClassifySetupProbe(result); failed {
-		return setupVerification{OK: false, Summary: string(probeErr.Class)}, probeErr
+		return setupVerification{Ran: true, OK: false, Summary: string(probeErr.Class)}, probeErr
 	}
 	summary := "provider endpoint reachable"
 	if check := result.PrimaryCheck(); check != nil && strings.TrimSpace(check.Message) != "" {
 		summary = strings.TrimSpace(check.Message)
 	}
-	return setupVerification{OK: true, Summary: summary}, nil
+	return setupVerification{Ran: true, OK: true, Summary: summary}, nil
 }
 
 func setupJSONPayload(result tui.SetupResult, verification *setupVerification) map[string]any {
@@ -130,7 +134,11 @@ func setupJSONPayload(result tui.SetupResult, verification *setupVerification) m
 		"catalogID":  result.Provider.CatalogID,
 	}
 	if verification != nil {
-		payload["verified"] = verification.OK
+		// Only emit the machine-readable verified flag when a probe actually ran, so
+		// a skipped probe is never reported as a passing verification.
+		if verification.Ran {
+			payload["verified"] = verification.OK
+		}
 		if verification.Summary != "" {
 			payload["verifyStatus"] = verification.Summary
 		}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/providerhealth"
+	"github.com/Gitlawb/zero/internal/provideronboarding"
 	"github.com/Gitlawb/zero/internal/tui"
 )
 
@@ -19,6 +21,10 @@ type setupOptions struct {
 	baseURL   string
 	apiKeyEnv string
 	json      bool
+	// verify runs a live connectivity probe after saving the provider and reports
+	// a specific, fixable error on failure (wrong base URL, bad key, model not
+	// found) — the first-run "paste key -> working" confirmation.
+	verify bool
 }
 
 func runSetup(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
@@ -47,21 +53,89 @@ func runSetup(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
+
+	var verification *setupVerification
+	if options.verify {
+		verified, probeErr := verifySetupProvider(deps, result.Provider)
+		verification = &verified
+		if probeErr != nil {
+			// A failed probe is reported as a specific, fixable provider error — the
+			// profile is already saved, so the message tells the user the one thing to
+			// change and re-run, never a stack trace.
+			if options.json {
+				if err := writePrettyJSON(stdout, setupJSONPayload(result, verification)); err != nil {
+					return exitCrash
+				}
+			} else {
+				if _, err := fmt.Fprintln(stdout, formatSetupComplete(result)); err != nil {
+					return exitCrash
+				}
+			}
+			return writeAppError(stderr, "setup verification failed: "+probeErr.Error(), exitProvider)
+		}
+	}
+
 	if options.json {
-		if err := writePrettyJSON(stdout, map[string]any{
-			"configPath": result.ConfigPath,
-			"provider":   result.Provider.Name,
-			"model":      result.Provider.Model,
-			"catalogID":  result.Provider.CatalogID,
-		}); err != nil {
+		if err := writePrettyJSON(stdout, setupJSONPayload(result, verification)); err != nil {
 			return exitCrash
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, formatSetupComplete(result)); err != nil {
+	output := formatSetupComplete(result)
+	if verification != nil && verification.OK {
+		output += "\nverified: " + verification.Summary
+	}
+	if _, err := fmt.Fprintln(stdout, output); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
+}
+
+// setupVerification is the outcome of the optional first-run connectivity probe.
+type setupVerification struct {
+	OK      bool
+	Summary string
+}
+
+// verifySetupProvider runs a live connectivity probe against the just-saved
+// provider and classifies any failure into a specific, fixable message. It is a
+// no-op (reports OK) when no probe is wired, so it never blocks setup in a
+// context that cannot probe.
+func verifySetupProvider(deps appDeps, profile config.ProviderProfile) (setupVerification, error) {
+	if deps.probeProviderHealth == nil {
+		return setupVerification{OK: true, Summary: "probe unavailable; skipped"}, nil
+	}
+	ctx, stop := signalContext()
+	defer stop()
+	result := deps.probeProviderHealth(ctx, providerhealth.Options{
+		Profile:      profile,
+		Connectivity: true,
+		UserAgent:    userAgent(),
+	})
+	if probeErr, failed := provideronboarding.ClassifySetupProbe(result); failed {
+		return setupVerification{OK: false, Summary: string(probeErr.Class)}, probeErr
+	}
+	summary := "provider endpoint reachable"
+	if check := result.PrimaryCheck(); check != nil && strings.TrimSpace(check.Message) != "" {
+		summary = strings.TrimSpace(check.Message)
+	}
+	return setupVerification{OK: true, Summary: summary}, nil
+}
+
+func setupJSONPayload(result tui.SetupResult, verification *setupVerification) map[string]any {
+	payload := map[string]any{
+		"configPath": result.ConfigPath,
+		"provider":   result.Provider.Name,
+		"model":      result.Provider.Model,
+		"catalogID":  result.Provider.CatalogID,
+	}
+	if verification != nil {
+		payload["verified"] = verification.OK
+		if verification.Summary != "" {
+			payload["verifyStatus"] = verification.Summary
+		}
+	}
+	return payload
 }
 
 func parseSetupArgs(args []string) (setupOptions, bool, error) {
@@ -73,6 +147,8 @@ func parseSetupArgs(args []string) (setupOptions, bool, error) {
 			return options, true, nil
 		case arg == "--json":
 			options.json = true
+		case arg == "--verify":
+			options.verify = true
 		case arg == "--name":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
@@ -224,7 +300,19 @@ func formatSetupComplete(result tui.SetupResult) string {
 		}
 	}
 	lines = append(lines, "next: "+setupCheckCommand(result.Provider.Name), "next: zero")
+	lines = append(lines, "try this: "+setupTryThisExample(result.Provider))
 	return strings.Join(lines, "\n")
+}
+
+// setupTryThisExample returns a concrete one-line headless run the user can paste
+// to confirm a real completion, parameterized by the model just configured. This
+// is the "end the wizard in a working state" example from the first-run spec.
+func setupTryThisExample(profile config.ProviderProfile) string {
+	example := `zero exec "say hello in one short sentence"`
+	if model := strings.TrimSpace(profile.Model); model != "" {
+		example += " --model " + setupCommandArg(model)
+	}
+	return example
 }
 
 func setupMissingCredentialEnv(profile config.ProviderProfile) (string, bool) {
@@ -308,6 +396,7 @@ Flags:
       --model <model>           Override the default model
       --base-url <url>          Override provider base URL
       --api-key-env <name>      Store an API key environment variable name
+      --verify                  Probe the provider after saving and report a fixable error on failure
       --json                    Print machine-readable setup result
   -h, --help                    Show this help
 `)

--- a/internal/cli/setup_verify_test.go
+++ b/internal/cli/setup_verify_test.go
@@ -96,6 +96,35 @@ func TestRunSetupVerifySucceedsAndConfirmsWorking(t *testing.T) {
 	}
 }
 
+func TestVerifySetupProviderWithoutProbeIsNotVerified(t *testing.T) {
+	// When no probe is wired, the verification did not run. It must report Ran=false
+	// (and not OK=true), so the caller never claims the provider is verified.
+	verification, err := verifySetupProvider(appDeps{probeProviderHealth: nil}, config.ProviderProfile{Name: "openai"})
+	if err != nil {
+		t.Fatalf("verifySetupProvider returned error: %v", err)
+	}
+	if verification.Ran {
+		t.Fatalf("a skipped probe must report Ran=false, got Ran=true")
+	}
+	if verification.OK {
+		t.Fatalf("a skipped probe must not report OK=true, got OK=true")
+	}
+}
+
+func TestSetupJSONPayloadGatesVerifiedOnRan(t *testing.T) {
+	// A verification that did not run must not emit a "verified" flag at all, so a
+	// machine consumer never reads a skipped probe as a passing verification.
+	payload := setupJSONPayload(tui.SetupResult{Provider: config.ProviderProfile{Name: "openai", Model: "gpt-4.1"}}, &setupVerification{Ran: false, OK: false, Summary: "probe unavailable; skipped"})
+	if _, present := payload["verified"]; present {
+		t.Fatalf("a probe that did not run must not emit a verified flag, got %#v", payload["verified"])
+	}
+
+	ranPayload := setupJSONPayload(tui.SetupResult{Provider: config.ProviderProfile{Name: "openai"}}, &setupVerification{Ran: true, OK: true, Summary: "reachable"})
+	if got, present := ranPayload["verified"]; !present || got != true {
+		t.Fatalf("a probe that ran and passed must emit verified=true, got present=%v value=%#v", present, got)
+	}
+}
+
 func TestRunSetupWithoutVerifyDoesNotProbe(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	configPath := filepath.Join(t.TempDir(), "config.json")

--- a/internal/cli/setup_verify_test.go
+++ b/internal/cli/setup_verify_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providerhealth"
+	"github.com/Gitlawb/zero/internal/tui"
+)
+
+func TestFormatSetupCompleteIncludesTryThisExample(t *testing.T) {
+	out := formatSetupComplete(tui.SetupResult{
+		ConfigPath: "/home/u/.config/zero/config.json",
+		Provider: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			APIKey:       "sk-x",
+			Model:        "gpt-4.1",
+		},
+	})
+	if !strings.Contains(out, "Zero setup complete") {
+		t.Fatalf("missing completion header: %q", out)
+	}
+	// The working-state confirmation must include a concrete one-line "try this"
+	// example so the user can immediately verify a real run.
+	if !strings.Contains(out, `zero exec "`) || !strings.Contains(out, "--model gpt-4.1") {
+		t.Fatalf("missing try-this exec example: %q", out)
+	}
+}
+
+func TestRunSetupVerifyReportsClassifiedProbeFailure(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	probed := false
+	deps := appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		probeProviderHealth: func(_ context.Context, options providerhealth.Options) providerhealth.Result {
+			probed = true
+			if !options.Connectivity {
+				t.Fatalf("setup --verify must request a connectivity probe")
+			}
+			return providerhealth.Result{
+				Status: providerhealth.StatusFail,
+				Checks: []providerhealth.Check{
+					{ID: "provider.connectivity", Status: providerhealth.StatusFail, Category: providerhealth.CategoryAuth, Message: "Provider endpoint returned 401: invalid api key"},
+				},
+			}
+		},
+	}
+
+	exitCode := runWithDeps([]string{"setup", "openai", "--api-key-env", "OPENAI_API_KEY", "--verify"}, &stdout, &stderr, deps)
+
+	if !probed {
+		t.Fatalf("expected setup --verify to run a probe")
+	}
+	if exitCode != exitProvider {
+		t.Fatalf("exit code = %d, want %d (a failed probe is a provider error)", exitCode, exitProvider)
+	}
+	output := stderr.String()
+	// The failure must be specific and fixable, not a stack trace.
+	if !strings.Contains(strings.ToLower(output), "api key") {
+		t.Fatalf("expected a fixable auth remedy on stderr, got %q", output)
+	}
+}
+
+func TestRunSetupVerifySucceedsAndConfirmsWorking(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	deps := appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		probeProviderHealth: func(context.Context, providerhealth.Options) providerhealth.Result {
+			return providerhealth.Result{
+				Status: providerhealth.StatusPass,
+				Checks: []providerhealth.Check{
+					{ID: "provider.connectivity", Status: providerhealth.StatusPass, Message: "reachable"},
+				},
+			}
+		},
+	}
+
+	exitCode := runWithDeps([]string{"setup", "openai", "--api-key-env", "OPENAI_API_KEY", "--verify"}, &stdout, &stderr, deps)
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exit code = %d, want %d: %s", exitCode, exitSuccess, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Zero setup complete") {
+		t.Fatalf("missing completion header: %q", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "verified") && !strings.Contains(strings.ToLower(out), "reachable") {
+		t.Fatalf("a passing probe should confirm the provider is verified/reachable, got %q", out)
+	}
+}
+
+func TestRunSetupWithoutVerifyDoesNotProbe(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	deps := appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+		probeProviderHealth: func(context.Context, providerhealth.Options) providerhealth.Result {
+			t.Fatal("setup without --verify must not probe")
+			return providerhealth.Result{}
+		},
+	}
+
+	exitCode := runWithDeps([]string{"setup", "ollama"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exit code = %d, want %d: %s", exitCode, exitSuccess, stderr.String())
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -45,6 +45,13 @@ type Options struct {
 	Provider       config.ProviderProfile
 	Connectivity   bool
 	ProviderHealth *providerhealth.Result
+	// GOOS overrides the platform used to resolve the sandbox backend. Empty
+	// means runtime.GOOS. Tests set it to assert platform-specific remedies.
+	GOOS string
+	// LookupExecutable resolves a binary on PATH for the sandbox-backend and
+	// LSP-server checks. Nil means exec.LookPath; tests inject a stub so the
+	// checks are deterministic regardless of the host's installed tooling.
+	LookupExecutable func(string) (string, error)
 }
 
 func Run(options Options) Report {
@@ -62,6 +69,8 @@ func Run(options Options) Report {
 	modelCheck := providerModelCheck(options.Provider)
 	checks = append(checks, modelCheck)
 	checks = append(checks, connectivityCheck(options.Provider, options.Connectivity, modelCheck.Status, options.ProviderHealth))
+	checks = append(checks, sandboxBackendCheck(options.GOOS, options.LookupExecutable))
+	checks = append(checks, lspServersCheck(options.LookupExecutable))
 
 	report := Report{
 		GeneratedAt: now().UTC().Format(time.RFC3339),

--- a/internal/doctor/hardening.go
+++ b/internal/doctor/hardening.go
@@ -1,0 +1,98 @@
+package doctor
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/Gitlawb/zero/internal/lsp"
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+// sandboxBackendCheck reports whether a native sandbox backend (bubblewrap on
+// Linux, sandbox-exec on macOS) is available. A missing backend is a WARN, not a
+// FAIL: ZERO still evaluates its policy engine before every tool call, it just
+// loses native process isolation. The remedy line is the fix — the platform's
+// install/enable command — not a restatement of the diagnosis.
+func sandboxBackendCheck(goos string, lookup func(string) (string, error)) Check {
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	backend := sandbox.SelectBackend(sandbox.BackendOptions{GOOS: goos, LookupExecutable: lookup})
+	if backend.Available {
+		return check("sandbox.backend", "Sandbox backend", StatusPass, fmt.Sprintf("Native sandbox backend %s is available.", backend.Name), map[string]any{
+			"backend":  string(backend.Name),
+			"platform": goos,
+		})
+	}
+	remedy := sandboxRemedy(goos)
+	return check("sandbox.backend", "Sandbox backend", StatusWarn, fmt.Sprintf("No native sandbox backend on %s; ZERO falls back to policy-only preflight checks.", goos), map[string]any{
+		"backend":  string(backend.Name),
+		"platform": goos,
+		"remedy":   remedy,
+	})
+}
+
+// sandboxRemedy returns the platform-specific, actionable command to obtain a
+// native sandbox backend.
+func sandboxRemedy(goos string) string {
+	switch goos {
+	case "linux":
+		return "install bubblewrap (e.g. `apt-get install bubblewrap` or `dnf install bubblewrap`) so `bwrap` is on PATH"
+	case "darwin":
+		return "sandbox-exec ships with macOS; ensure /usr/bin is on PATH so `sandbox-exec` resolves"
+	case "windows":
+		return "native sandboxing is not yet available on Windows; run inside WSL2 or a Linux container for native isolation"
+	default:
+		return "no native sandbox adapter exists for " + goos + "; run inside Linux (bubblewrap) or macOS (sandbox-exec) for native isolation"
+	}
+}
+
+// lspServersCheck reports which language servers ZERO would use are present on
+// PATH. Missing servers are not a failure — ZERO degrades to text-only edits for
+// those languages — so the worst status is WARN, and each missing server gets an
+// actionable install command keyed by its binary name.
+func lspServersCheck(lookup func(string) (string, error)) Check {
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	present := map[string]any{}
+	missing := map[string]any{}
+	for _, binary := range lsp.ServerBinaries() {
+		if _, err := lookup(binary); err == nil {
+			present[binary] = "on PATH"
+			continue
+		}
+		missing[binary] = lspRemedy(binary)
+	}
+	if len(missing) == 0 {
+		return check("lsp.servers", "LSP servers", StatusPass, "All known language servers are available on PATH.", map[string]any{
+			"present": present,
+		})
+	}
+	return check("lsp.servers", "LSP servers", StatusWarn, fmt.Sprintf("%d language server(s) missing from PATH; affected files degrade to text-only edits.", len(missing)), map[string]any{
+		"present": present,
+		"missing": missing,
+	})
+}
+
+// lspRemedy returns an actionable install command for a missing language-server
+// binary. It is provider/tooling neutral and names the ecosystem's standard
+// installer.
+func lspRemedy(binary string) string {
+	switch binary {
+	case "gopls":
+		return "install with `go install golang.org/x/tools/gopls@latest` (ensure $GOBIN is on PATH)"
+	case "typescript-language-server":
+		return "install with `npm install -g typescript typescript-language-server`"
+	case "pyright-langserver":
+		return "install with `npm install -g pyright` (or `pipx install pyright`)"
+	case "rust-analyzer":
+		return "install with `rustup component add rust-analyzer`"
+	default:
+		return "install the " + binary + " language server and ensure it is on PATH"
+	}
+}

--- a/internal/doctor/hardening_test.go
+++ b/internal/doctor/hardening_test.go
@@ -1,0 +1,162 @@
+package doctor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+// validProvider is a fully-formed provider profile so the report's overall OK
+// status reflects only the check under test (not an unrelated provider failure).
+func validProvider() config.ProviderProfile {
+	return config.ProviderProfile{
+		Name:         "openai",
+		ProviderKind: config.ProviderKindOpenAI,
+		BaseURL:      config.OpenAIBaseURL,
+		APIKey:       "sk-test",
+		Model:        "gpt-4.1",
+	}
+}
+
+// stubLookup returns a lookup function that resolves only the named binaries.
+func stubLookup(present ...string) func(string) (string, error) {
+	set := map[string]bool{}
+	for _, name := range present {
+		set[name] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("executable file not found in $PATH")
+	}
+}
+
+func TestSandboxCheckPassesWhenBackendPresent(t *testing.T) {
+	report := Run(Options{
+		Now:              fixedDoctorClock("2026-06-12T10:00:00Z"),
+		Runtime:          "go",
+		GOOS:             "linux",
+		LookupExecutable: stubLookup("bwrap"),
+	})
+
+	check := report.Check("sandbox.backend")
+	if check == nil || check.Status != StatusPass {
+		t.Fatalf("expected sandbox.backend pass, got %#v", report.Checks)
+	}
+	if !strings.Contains(strings.ToLower(check.Message), "bubblewrap") {
+		t.Fatalf("expected bubblewrap named in message, got %q", check.Message)
+	}
+}
+
+func TestSandboxCheckWarnsWithRemedyWhenBackendMissing(t *testing.T) {
+	report := Run(Options{
+		Now:              fixedDoctorClock("2026-06-12T10:05:00Z"),
+		Runtime:          "go",
+		GOOS:             "linux",
+		Provider:         validProvider(),
+		LookupExecutable: stubLookup("gopls", "typescript-language-server", "pyright-langserver", "rust-analyzer"),
+	})
+
+	check := report.Check("sandbox.backend")
+	if check == nil || check.Status != StatusWarn {
+		t.Fatalf("expected sandbox.backend warn, got %#v", report.Checks)
+	}
+	remedy, _ := check.Details["remedy"].(string)
+	if !strings.Contains(remedy, "bwrap") && !strings.Contains(remedy, "bubblewrap") {
+		t.Fatalf("expected actionable bubblewrap remedy, got %q (details %#v)", remedy, check.Details)
+	}
+	// A missing native sandbox is a degradation, not a hard failure: the policy
+	// engine still runs, so the overall report must not fail on it alone.
+	if !report.OK {
+		t.Fatalf("missing sandbox backend should warn, not fail the report: %#v", report.Checks)
+	}
+}
+
+func TestSandboxCheckRemedyIsPlatformSpecific(t *testing.T) {
+	darwin := Run(Options{
+		Now:              fixedDoctorClock("2026-06-12T10:06:00Z"),
+		Runtime:          "go",
+		GOOS:             "darwin",
+		LookupExecutable: stubLookup(),
+	}).Check("sandbox.backend")
+	if darwin == nil || darwin.Status != StatusWarn {
+		t.Fatalf("expected darwin sandbox warn, got %#v", darwin)
+	}
+	remedy, _ := darwin.Details["remedy"].(string)
+	if !strings.Contains(remedy, "sandbox-exec") {
+		t.Fatalf("darwin remedy should mention sandbox-exec, got %q", remedy)
+	}
+
+	macPresent := Run(Options{
+		Now:              fixedDoctorClock("2026-06-12T10:07:00Z"),
+		Runtime:          "go",
+		GOOS:             "darwin",
+		LookupExecutable: stubLookup("sandbox-exec"),
+	}).Check("sandbox.backend")
+	if macPresent == nil || macPresent.Status != StatusPass {
+		t.Fatalf("expected darwin sandbox pass when sandbox-exec present, got %#v", macPresent)
+	}
+}
+
+func TestLSPCheckWarnsForMissingServersWithRemedy(t *testing.T) {
+	report := Run(Options{
+		Now:              fixedDoctorClock("2026-06-12T10:10:00Z"),
+		Runtime:          "go",
+		GOOS:             "linux",
+		Provider:         validProvider(),
+		LookupExecutable: stubLookup("gopls", "bwrap"), // gopls present, other servers missing
+	})
+
+	check := report.Check("lsp.servers")
+	if check == nil || check.Status != StatusWarn {
+		t.Fatalf("expected lsp.servers warn, got %#v", report.Checks)
+	}
+	// gopls present -> not in the missing list; a missing one (e.g. the TS
+	// server) must come with an actionable install command.
+	missing, ok := check.Details["missing"].(map[string]any)
+	if !ok || len(missing) == 0 {
+		t.Fatalf("expected a non-empty missing-server map, got %#v", check.Details)
+	}
+	if _, present := missing["gopls"]; present {
+		t.Fatalf("gopls is on PATH and must not be listed as missing: %#v", missing)
+	}
+	tsRemedy, _ := missing["typescript-language-server"].(string)
+	if !strings.Contains(tsRemedy, "install") && !strings.Contains(tsRemedy, "npm") {
+		t.Fatalf("expected an actionable install remedy for the TS server, got %q", tsRemedy)
+	}
+	if !report.OK {
+		t.Fatalf("missing optional LSP servers should warn, not fail: %#v", report.Checks)
+	}
+}
+
+func TestLSPCheckPassesWhenAllServersPresent(t *testing.T) {
+	report := Run(Options{
+		Now:              fixedDoctorClock("2026-06-12T10:15:00Z"),
+		Runtime:          "go",
+		LookupExecutable: stubLookup("gopls", "typescript-language-server", "pyright-langserver", "rust-analyzer"),
+	})
+
+	check := report.Check("lsp.servers")
+	if check == nil || check.Status != StatusPass {
+		t.Fatalf("expected lsp.servers pass, got %#v", report.Checks)
+	}
+}
+
+func TestHardeningChecksSkipWhenNoLookupProvided(t *testing.T) {
+	// Without an injected lookup the checks fall back to the real PATH. That is
+	// environment-dependent, so we only assert the checks are present and never
+	// fail the report (they degrade to warn/pass, never fail).
+	report := Run(Options{Now: fixedDoctorClock("2026-06-12T10:20:00Z"), Runtime: "go"})
+	for _, id := range []string{"sandbox.backend", "lsp.servers"} {
+		check := report.Check(id)
+		if check == nil {
+			t.Fatalf("expected %s check to be present, got %#v", id, report.Checks)
+		}
+		if check.Status == StatusFail {
+			t.Fatalf("%s must never hard-fail the report, got %#v", id, check)
+		}
+	}
+}

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -28,6 +29,27 @@ var languageIDs = map[string]string{
 	".jsx": "javascriptreact",
 	".py":  "python",
 	".rs":  "rust",
+}
+
+// ServerBinaries returns the unique set of language-server binaries ZERO may
+// spawn, sorted for stable output. It is the canonical list `zero doctor` checks
+// against PATH, so the configured commands stay the single source of truth.
+func ServerBinaries() []string {
+	seen := map[string]bool{}
+	binaries := make([]string, 0, len(serverCommands))
+	for _, command := range serverCommands {
+		if len(command) == 0 {
+			continue
+		}
+		binary := command[0]
+		if binary == "" || seen[binary] {
+			continue
+		}
+		seen[binary] = true
+		binaries = append(binaries, binary)
+	}
+	sort.Strings(binaries)
+	return binaries
 }
 
 // ServerFor returns the server command for a path's extension, and whether one is

--- a/internal/perfbench/taskbench.go
+++ b/internal/perfbench/taskbench.go
@@ -1,0 +1,387 @@
+package perfbench
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// TaskSchemaVersion is the schema version of a published task-benchmark result.
+// Bump it whenever the TaskRunResult shape changes so consumers (docs/BENCHMARK.md
+// tooling, dashboards) can detect format drift.
+const TaskSchemaVersion = 1
+
+// TaskSet is a reproducible benchmark task list. It mirrors the shape of a
+// Terminal-Bench task manifest: each task is an isolated workspace plus a prompt
+// ZERO must satisfy. The set is recorded by ID with every result so a published
+// number is traceable to the exact tasks that produced it.
+type TaskSet struct {
+	ID    string      `json:"id"`
+	Name  string      `json:"name,omitempty"`
+	Tasks []BenchTask `json:"tasks"`
+}
+
+// BenchTask is one benchmark task. WorkspaceFixture is the relative path of the
+// task's starting workspace; VerificationCommand (optional) is the command the
+// default runner executes to decide pass/fail after ZERO finishes.
+type BenchTask struct {
+	ID                  string   `json:"id"`
+	Name                string   `json:"name,omitempty"`
+	Prompt              string   `json:"prompt"`
+	WorkspaceFixture    string   `json:"workspaceFixture,omitempty"`
+	VerificationCommand []string `json:"verificationCommand,omitempty"`
+}
+
+// TaskConfig is the recorded configuration of a benchmark run. The honest
+// framing matters: the model, mode, and self-correct flag are captured because
+// the score is largely model-bounded — the point of the benchmark is to show the
+// self-correct loop's contribution (the with/without delta), not the raw digit.
+type TaskConfig struct {
+	Model       string
+	Mode        string
+	SelfCorrect bool
+	Version     string
+	Commit      string
+	// Now overrides the clock for the recorded date (tests inject a fixed time).
+	Now func() time.Time
+	// Runner executes one task and reports the outcome. Required. The default
+	// production runner (NewExecRunner) invokes headless `zero exec`.
+	Runner TaskRunner
+}
+
+// RunContext is the immutable per-run context handed to the runner for each
+// task, so a runner records the same model/mode/self-correct values the result
+// is stamped with.
+type RunContext struct {
+	Model       string
+	Mode        string
+	SelfCorrect bool
+}
+
+// TaskRunner runs a single benchmark task and returns its outcome.
+type TaskRunner func(ctx context.Context, task BenchTask, rc RunContext) TaskOutcome
+
+// TaskOutcome is what a runner reports for one task. Err is reserved for the run
+// failing to execute (e.g. the agent process crashed); Passed reports whether
+// the task's verification succeeded. A non-nil Err is always a non-pass.
+type TaskOutcome struct {
+	Passed bool
+	Detail string
+	Err    error
+}
+
+// TaskResult is the per-task entry in a TaskRunResult.
+type TaskResult struct {
+	ID      string `json:"id"`
+	Name    string `json:"name,omitempty"`
+	Passed  bool   `json:"passed"`
+	Errored bool   `json:"errored,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// TaskRunResult is the publishable benchmark record. It is intentionally
+// self-describing: model + version + commit + self-correct flag + date are all
+// embedded so a copy of this JSON is reproducible and auditable on its own.
+type TaskRunResult struct {
+	SchemaVersion  int          `json:"schemaVersion"`
+	Suite          string       `json:"suite"`
+	SuiteName      string       `json:"suiteName,omitempty"`
+	Model          string       `json:"model"`
+	Mode           string       `json:"mode,omitempty"`
+	SelfCorrect    bool         `json:"selfCorrect"`
+	Version        string       `json:"version,omitempty"`
+	Commit         string       `json:"commit,omitempty"`
+	Date           string       `json:"date"`
+	TasksAttempted int          `json:"tasksAttempted"`
+	TasksPassed    int          `json:"tasksPassed"`
+	Errors         int          `json:"errors"`
+	PassRate       float64      `json:"passRate"`
+	Tasks          []TaskResult `json:"tasks"`
+}
+
+// LoadTaskSet reads and validates a benchmark task set from a JSON file. Unknown
+// fields are rejected so a malformed manifest fails loudly rather than silently
+// dropping tasks.
+func LoadTaskSet(path string) (TaskSet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TaskSet{}, fmt.Errorf("load task set: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var set TaskSet
+	if err := decoder.Decode(&set); err != nil {
+		return TaskSet{}, fmt.Errorf("parse task set: %w", err)
+	}
+	if strings.TrimSpace(set.ID) == "" {
+		return TaskSet{}, errors.New("parse task set: id is required")
+	}
+	if len(set.Tasks) == 0 {
+		return TaskSet{}, errors.New("parse task set: tasks must not be empty")
+	}
+	for index, task := range set.Tasks {
+		if strings.TrimSpace(task.ID) == "" {
+			return TaskSet{}, fmt.Errorf("parse task set: tasks[%d] id is required", index)
+		}
+		if strings.TrimSpace(task.Prompt) == "" {
+			return TaskSet{}, fmt.Errorf("parse task set: tasks[%d] prompt is required", index)
+		}
+	}
+	return set, nil
+}
+
+// SkipRunner is a runner that performs no work and records every task as skipped
+// (not passed, no error). It backs the harness's --dry-run mode, which exercises
+// the full record path without invoking an agent or a model.
+func SkipRunner(context.Context, BenchTask, RunContext) TaskOutcome {
+	return TaskOutcome{Passed: false, Detail: "skipped (dry run)"}
+}
+
+// RunTasks executes every task in the set with the configured runner and returns
+// a self-describing result record. It never aborts on a single task failure or
+// runner error — every task is attempted and recorded — so one bad task can't
+// hide the rest of the run. The context cancels the whole run.
+func RunTasks(ctx context.Context, set TaskSet, config TaskConfig) (TaskRunResult, error) {
+	if len(set.Tasks) == 0 {
+		return TaskRunResult{}, errors.New("task set has no tasks")
+	}
+	if strings.TrimSpace(config.Model) == "" {
+		return TaskRunResult{}, errors.New("benchmark requires a model")
+	}
+	if config.Runner == nil {
+		return TaskRunResult{}, errors.New("benchmark requires a task runner")
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	rc := RunContext{Model: config.Model, Mode: config.Mode, SelfCorrect: config.SelfCorrect}
+
+	result := TaskRunResult{
+		SchemaVersion: TaskSchemaVersion,
+		Suite:         strings.TrimSpace(set.ID),
+		SuiteName:     strings.TrimSpace(set.Name),
+		Model:         strings.TrimSpace(config.Model),
+		Mode:          strings.TrimSpace(config.Mode),
+		SelfCorrect:   config.SelfCorrect,
+		Version:       strings.TrimSpace(config.Version),
+		Commit:        strings.TrimSpace(config.Commit),
+		Date:          now().UTC().Format(time.RFC3339),
+		Tasks:         make([]TaskResult, 0, len(set.Tasks)),
+	}
+
+	for _, task := range set.Tasks {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		outcome := config.Runner(ctx, task, rc)
+		entry := TaskResult{ID: task.ID, Name: task.Name}
+		result.TasksAttempted++
+		switch {
+		case outcome.Err != nil:
+			entry.Errored = true
+			entry.Detail = outcome.Err.Error()
+			result.Errors++
+		case outcome.Passed:
+			entry.Passed = true
+			entry.Detail = strings.TrimSpace(outcome.Detail)
+			result.TasksPassed++
+		default:
+			entry.Detail = strings.TrimSpace(outcome.Detail)
+		}
+		result.Tasks = append(result.Tasks, entry)
+	}
+	if result.TasksAttempted > 0 {
+		result.PassRate = RoundMetric(float64(result.TasksPassed) / float64(result.TasksAttempted))
+	}
+	return result, nil
+}
+
+// FormatTaskSummary renders a human-readable summary that foregrounds the honest
+// framing: the model and the self-correct setting are printed alongside the
+// score, because the number is model-bounded.
+func FormatTaskSummary(result TaskRunResult) string {
+	selfCorrect := "off"
+	if result.SelfCorrect {
+		selfCorrect = "on"
+	}
+	build := strings.TrimSpace(result.Version)
+	if commit := strings.TrimSpace(result.Commit); commit != "" {
+		if build != "" {
+			build += " (commit " + commit + ")"
+		} else {
+			build = "commit " + commit
+		}
+	}
+	lines := []string{
+		"Zero task benchmark: " + displayOrUnknown(result.Suite),
+		"model: " + displayOrUnknown(result.Model),
+	}
+	if mode := strings.TrimSpace(result.Mode); mode != "" {
+		lines = append(lines, "mode: "+mode)
+	}
+	lines = append(lines, "self-correct: "+selfCorrect)
+	if build != "" {
+		lines = append(lines, "build: "+build)
+	}
+	lines = append(lines, fmt.Sprintf("passed: %d/%d (%.0f%%)", result.TasksPassed, result.TasksAttempted, result.PassRate*100))
+	if result.Errors > 0 {
+		lines = append(lines, fmt.Sprintf("errors: %d", result.Errors))
+	}
+	for _, task := range result.Tasks {
+		lines = append(lines, "- "+formatTaskLine(task))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// WriteTaskJSON writes the indented JSON form of a benchmark result.
+func WriteTaskJSON(w io.Writer, result TaskRunResult) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}
+
+func formatTaskLine(task TaskResult) string {
+	status := "pass"
+	if task.Errored {
+		status = "error"
+	} else if !task.Passed {
+		status = "fail"
+	}
+	label := strings.TrimSpace(task.Name)
+	if label == "" {
+		label = task.ID
+	} else {
+		label = task.ID + " " + label
+	}
+	line := fmt.Sprintf("[%s] %s", status, label)
+	if detail := strings.TrimSpace(task.Detail); detail != "" {
+		line += ": " + detail
+	}
+	return line
+}
+
+func displayOrUnknown(value string) string {
+	if trimmed := strings.TrimSpace(value); trimmed != "" {
+		return trimmed
+	}
+	return "unknown"
+}
+
+// NewExecRunner builds the production runner: it invokes headless `zero exec`
+// with stream-json output for each task and decides pass/fail. binary is the path
+// to the `zero` binary; extraArgs are appended to every invocation (e.g. sandbox
+// flags). The self-correct flag from RunContext is translated into the exec
+// invocation so the recorded config matches what actually ran.
+//
+// Pass/fail is decided from the stream-json run_end event's exit code: a zero
+// exit means the agent completed the task without error. When a task carries a
+// VerificationCommand, that command is run after the agent and its exit status
+// is authoritative (this mirrors Terminal-Bench's external verifier model).
+func NewExecRunner(binary string, extraArgs ...string) TaskRunner {
+	return func(ctx context.Context, task BenchTask, rc RunContext) TaskOutcome {
+		args := buildExecArgs(task, rc, extraArgs)
+		cmd := exec.CommandContext(ctx, binary, args...)
+		cmd.Env = appendNoColor(os.Environ())
+		if dir := strings.TrimSpace(task.WorkspaceFixture); dir != "" {
+			cmd.Dir = dir
+		}
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		runErr := cmd.Run()
+
+		exitCode, haveExit := streamJSONExitCode(stdout.Bytes())
+		if runErr != nil {
+			detail := strings.TrimSpace(stderr.String())
+			if detail == "" {
+				detail = runErr.Error()
+			}
+			return TaskOutcome{Err: fmt.Errorf("zero exec failed: %s", detail)}
+		}
+		if haveExit && exitCode != 0 {
+			return TaskOutcome{Passed: false, Detail: fmt.Sprintf("agent run_end exit code %d", exitCode)}
+		}
+
+		if len(task.VerificationCommand) > 0 {
+			return runVerification(ctx, task)
+		}
+		return TaskOutcome{Passed: true}
+	}
+}
+
+func buildExecArgs(task BenchTask, rc RunContext, extraArgs []string) []string {
+	args := []string{"exec", "--output-format", "stream-json"}
+	if model := strings.TrimSpace(rc.Model); model != "" {
+		args = append(args, "--model", model)
+	}
+	if mode := strings.TrimSpace(rc.Mode); mode != "" {
+		args = append(args, "--mode", mode)
+	}
+	if rc.SelfCorrect {
+		args = append(args, "--self-correct")
+	}
+	args = append(args, extraArgs...)
+	args = append(args, task.Prompt)
+	return args
+}
+
+func runVerification(ctx context.Context, task BenchTask) TaskOutcome {
+	cmd := exec.CommandContext(ctx, task.VerificationCommand[0], task.VerificationCommand[1:]...)
+	cmd.Env = appendNoColor(nil)
+	if dir := strings.TrimSpace(task.WorkspaceFixture); dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return TaskOutcome{Passed: false, Detail: "verification failed: " + firstLine(detail)}
+	}
+	return TaskOutcome{Passed: true}
+}
+
+// streamJSONExitCode scans stream-json output for the terminal run_end event and
+// returns its exit code. ZERO emits one JSON object per line; the last run_end
+// (or final) event carries the exit code. Lines that don't parse are skipped.
+func streamJSONExitCode(output []byte) (int, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	exitCode := 0
+	found := false
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var event struct {
+			Type     string `json:"type"`
+			ExitCode *int   `json:"exitCode"`
+		}
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if event.Type == "run_end" && event.ExitCode != nil {
+			exitCode = *event.ExitCode
+			found = true
+		}
+	}
+	return exitCode, found
+}
+
+func firstLine(text string) string {
+	if index := strings.IndexByte(text, '\n'); index >= 0 {
+		return strings.TrimSpace(text[:index])
+	}
+	return text
+}

--- a/internal/perfbench/taskbench.go
+++ b/internal/perfbench/taskbench.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -121,18 +122,31 @@ func LoadTaskSet(path string) (TaskSet, error) {
 	if err := decoder.Decode(&set); err != nil {
 		return TaskSet{}, fmt.Errorf("parse task set: %w", err)
 	}
+	// DisallowUnknownFields only validates the first top-level value, so a file
+	// like `{...}\nnot-json` would still load. Reject any trailing content so a
+	// malformed manifest fails loudly rather than silently using only the prefix.
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return TaskSet{}, errors.New("parse task set: unexpected trailing content")
+	}
 	if strings.TrimSpace(set.ID) == "" {
 		return TaskSet{}, errors.New("parse task set: id is required")
 	}
 	if len(set.Tasks) == 0 {
 		return TaskSet{}, errors.New("parse task set: tasks must not be empty")
 	}
+	// Resolve relative workspace fixtures against the manifest's directory so the
+	// runner's cmd.Dir does not depend on the caller's cwd (the documented sample
+	// uses paths like ./hello relative to the manifest, not the repo root).
+	base := filepath.Dir(path)
 	for index, task := range set.Tasks {
 		if strings.TrimSpace(task.ID) == "" {
 			return TaskSet{}, fmt.Errorf("parse task set: tasks[%d] id is required", index)
 		}
 		if strings.TrimSpace(task.Prompt) == "" {
 			return TaskSet{}, fmt.Errorf("parse task set: tasks[%d] prompt is required", index)
+		}
+		if fixture := strings.TrimSpace(task.WorkspaceFixture); fixture != "" && !filepath.IsAbs(fixture) {
+			set.Tasks[index].WorkspaceFixture = filepath.Clean(filepath.Join(base, fixture))
 		}
 	}
 	return set, nil
@@ -299,16 +313,25 @@ func NewExecRunner(binary string, extraArgs ...string) TaskRunner {
 		cmd.Stderr = &stderr
 		runErr := cmd.Run()
 
+		// The terminal run_end exit code is authoritative for pass/fail: a non-zero
+		// agent exit is a normal task failure, not a harness error, even though
+		// cmd.Run() reports any non-zero process exit as an *exec.ExitError. Only when
+		// no terminal run_end event was parsed do we fall back to treating the run as
+		// a harness error — failing closed so a missing terminal event never reads as
+		// a pass.
 		exitCode, haveExit := streamJSONExitCode(stdout.Bytes())
-		if runErr != nil {
-			detail := strings.TrimSpace(stderr.String())
-			if detail == "" {
-				detail = runErr.Error()
-			}
-			return TaskOutcome{Err: fmt.Errorf("zero exec failed: %s", detail)}
-		}
 		if haveExit && exitCode != 0 {
 			return TaskOutcome{Passed: false, Detail: fmt.Sprintf("agent run_end exit code %d", exitCode)}
+		}
+		if !haveExit {
+			detail := strings.TrimSpace(stderr.String())
+			if detail == "" && runErr != nil {
+				detail = runErr.Error()
+			}
+			if detail == "" {
+				detail = "missing terminal run_end event"
+			}
+			return TaskOutcome{Err: fmt.Errorf("zero exec failed: %s", detail)}
 		}
 
 		if len(task.VerificationCommand) > 0 {

--- a/internal/perfbench/taskbench.go
+++ b/internal/perfbench/taskbench.go
@@ -359,7 +359,10 @@ func buildExecArgs(task BenchTask, rc RunContext, extraArgs []string) []string {
 
 func runVerification(ctx context.Context, task BenchTask) TaskOutcome {
 	cmd := exec.CommandContext(ctx, task.VerificationCommand[0], task.VerificationCommand[1:]...)
-	cmd.Env = appendNoColor(nil)
+	// Inherit the environment so the verifier sees PATH, HOME, language toolchain
+	// vars, etc. — the same surface a maintainer gets running the command by hand
+	// (matching the agent run above). NO_COLOR is appended for stable output.
+	cmd.Env = appendNoColor(os.Environ())
 	if dir := strings.TrimSpace(task.WorkspaceFixture); dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/perfbench/taskbench_test.go
+++ b/internal/perfbench/taskbench_test.go
@@ -3,6 +3,10 @@ package perfbench
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -197,4 +201,130 @@ func TestFormatTaskSummarySelfCorrectOff(t *testing.T) {
 
 func passingRunner(context.Context, BenchTask, RunContext) TaskOutcome {
 	return TaskOutcome{Passed: true}
+}
+
+func writeManifest(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "suite.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+func TestLoadTaskSetRejectsTrailingContent(t *testing.T) {
+	// A "fail loudly" manifest loader must reject extra JSON after the object, not
+	// silently load only the first value.
+	path := writeManifest(t, t.TempDir(), `{"id":"s","tasks":[{"id":"t1","prompt":"p"}]}
+not-json`)
+	if _, err := LoadTaskSet(path); err == nil {
+		t.Fatalf("LoadTaskSet should reject trailing content after the manifest object")
+	}
+}
+
+func TestLoadTaskSetResolvesFixturesRelativeToManifest(t *testing.T) {
+	// Relative workspaceFixture paths must be anchored at the manifest's directory,
+	// not the caller's cwd, so the documented repo-root command points at the right
+	// directories.
+	dir := t.TempDir()
+	path := writeManifest(t, dir, `{"id":"s","tasks":[
+		{"id":"t1","prompt":"p","workspaceFixture":"./hello"},
+		{"id":"t2","prompt":"p","workspaceFixture":"sub/cli"},
+		{"id":"t3","prompt":"p"}
+	]}`)
+	set, err := LoadTaskSet(path)
+	if err != nil {
+		t.Fatalf("LoadTaskSet returned error: %v", err)
+	}
+	wantT1 := filepath.Join(dir, "hello")
+	if set.Tasks[0].WorkspaceFixture != wantT1 {
+		t.Fatalf("t1 fixture = %q, want %q", set.Tasks[0].WorkspaceFixture, wantT1)
+	}
+	wantT2 := filepath.Join(dir, "sub", "cli")
+	if set.Tasks[1].WorkspaceFixture != wantT2 {
+		t.Fatalf("t2 fixture = %q, want %q", set.Tasks[1].WorkspaceFixture, wantT2)
+	}
+	if set.Tasks[2].WorkspaceFixture != "" {
+		t.Fatalf("t3 fixture = %q, want empty (no fixture)", set.Tasks[2].WorkspaceFixture)
+	}
+}
+
+func TestLoadTaskSetKeepsAbsoluteFixtures(t *testing.T) {
+	dir := t.TempDir()
+	abs := filepath.Join(dir, "elsewhere")
+	path := writeManifest(t, dir, `{"id":"s","tasks":[{"id":"t1","prompt":"p","workspaceFixture":`+strconv.Quote(abs)+`}]}`)
+	set, err := LoadTaskSet(path)
+	if err != nil {
+		t.Fatalf("LoadTaskSet returned error: %v", err)
+	}
+	if set.Tasks[0].WorkspaceFixture != abs {
+		t.Fatalf("absolute fixture = %q, want unchanged %q", set.Tasks[0].WorkspaceFixture, abs)
+	}
+}
+
+func writeExecStub(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("exec stub uses a POSIX shell script")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "zero-stub.sh")
+	script := "#!/bin/sh\n" + body
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write exec stub: %v", err)
+	}
+	return path
+}
+
+func TestNewExecRunnerNonZeroRunEndIsFailNotError(t *testing.T) {
+	// A non-zero run_end exit code is a normal task failure, not a harness error,
+	// even though the process itself exits non-zero.
+	stub := writeExecStub(t, `echo '{"type":"run_end","exitCode":1}'
+exit 1
+`)
+	runner := NewExecRunner(stub)
+	outcome := runner(context.Background(), BenchTask{ID: "t1", Prompt: "p"}, RunContext{Model: "m"})
+	if outcome.Err != nil {
+		t.Fatalf("non-zero run_end must not be a harness error, got Err=%v", outcome.Err)
+	}
+	if outcome.Passed {
+		t.Fatalf("non-zero run_end must be a failed task, got Passed=true")
+	}
+}
+
+func TestNewExecRunnerMissingRunEndFailsClosed(t *testing.T) {
+	// A clean exit with no terminal run_end event is a harness error: we cannot
+	// claim the task passed when the agent never reported a terminal event.
+	stub := writeExecStub(t, `echo '{"type":"text","text":"hi"}'
+exit 0
+`)
+	runner := NewExecRunner(stub)
+	outcome := runner(context.Background(), BenchTask{ID: "t1", Prompt: "p"}, RunContext{Model: "m"})
+	if outcome.Err == nil {
+		t.Fatalf("missing terminal run_end must be a harness error, got Passed=%v", outcome.Passed)
+	}
+}
+
+func TestNewExecRunnerZeroRunEndPasses(t *testing.T) {
+	stub := writeExecStub(t, `echo '{"type":"run_end","exitCode":0}'
+exit 0
+`)
+	runner := NewExecRunner(stub)
+	outcome := runner(context.Background(), BenchTask{ID: "t1", Prompt: "p"}, RunContext{Model: "m"})
+	if outcome.Err != nil {
+		t.Fatalf("zero run_end with no verification must pass, got Err=%v", outcome.Err)
+	}
+	if !outcome.Passed {
+		t.Fatalf("zero run_end with no verification must pass, got Passed=false")
+	}
+}
+
+func TestNewExecRunnerLaunchFailureIsHarnessError(t *testing.T) {
+	// A binary that cannot be launched (no terminal event, process error) is a
+	// genuine harness error.
+	runner := NewExecRunner(filepath.Join(t.TempDir(), "does-not-exist"))
+	outcome := runner(context.Background(), BenchTask{ID: "t1", Prompt: "p"}, RunContext{Model: "m"})
+	if outcome.Err == nil {
+		t.Fatalf("a launch failure must be a harness error")
+	}
 }

--- a/internal/perfbench/taskbench_test.go
+++ b/internal/perfbench/taskbench_test.go
@@ -328,3 +328,22 @@ func TestNewExecRunnerLaunchFailureIsHarnessError(t *testing.T) {
 		t.Fatalf("a launch failure must be a harness error")
 	}
 }
+
+func TestRunVerificationInheritsEnvironment(t *testing.T) {
+	// The verifier must see the inherited environment (PATH, HOME, toolchain
+	// vars, ...) the same way a maintainer running the command by hand would.
+	// A command that only succeeds when it can read an inherited var proves the
+	// environment is passed through rather than reset to NO_COLOR only.
+	if runtime.GOOS == "windows" {
+		t.Skip("verification probe uses a POSIX shell")
+	}
+	t.Setenv("PERFBENCH_VERIFY_PROBE", "present")
+	task := BenchTask{
+		ID:                  "t1",
+		VerificationCommand: []string{"sh", "-c", `[ "$PERFBENCH_VERIFY_PROBE" = present ]`},
+	}
+	outcome := runVerification(context.Background(), task)
+	if !outcome.Passed {
+		t.Fatalf("verifier should see the inherited env var, got Passed=false detail=%q", outcome.Detail)
+	}
+}

--- a/internal/perfbench/taskbench_test.go
+++ b/internal/perfbench/taskbench_test.go
@@ -1,0 +1,200 @@
+package perfbench
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func sampleTaskSet() TaskSet {
+	return TaskSet{
+		ID:   "terminal-bench-mini",
+		Name: "Terminal-Bench (mini)",
+		Tasks: []BenchTask{
+			{ID: "t1", Name: "fix failing test", Prompt: "make the test pass", WorkspaceFixture: "fixtures/t1"},
+			{ID: "t2", Name: "add flag", Prompt: "add a --json flag", WorkspaceFixture: "fixtures/t2"},
+		},
+	}
+}
+
+func TestRunTasksRecordsModelCommitAndSelfCorrect(t *testing.T) {
+	config := TaskConfig{
+		Model:       "test-model",
+		Mode:        "build",
+		SelfCorrect: true,
+		Version:     "1.2.3",
+		Commit:      "abc1234",
+		Runner: func(_ context.Context, task BenchTask, rc RunContext) TaskOutcome {
+			if !rc.SelfCorrect {
+				t.Fatalf("runner should see SelfCorrect=true from config")
+			}
+			if rc.Model != "test-model" {
+				t.Fatalf("runner model = %q, want test-model", rc.Model)
+			}
+			return TaskOutcome{Passed: true}
+		},
+	}
+
+	result, err := RunTasks(context.Background(), sampleTaskSet(), config)
+	if err != nil {
+		t.Fatalf("RunTasks returned error: %v", err)
+	}
+
+	if result.Model != "test-model" {
+		t.Fatalf("result.Model = %q, want test-model", result.Model)
+	}
+	if result.Commit != "abc1234" {
+		t.Fatalf("result.Commit = %q, want abc1234", result.Commit)
+	}
+	if result.Version != "1.2.3" {
+		t.Fatalf("result.Version = %q, want 1.2.3", result.Version)
+	}
+	if !result.SelfCorrect {
+		t.Fatalf("result.SelfCorrect = false, want true")
+	}
+	if result.Mode != "build" {
+		t.Fatalf("result.Mode = %q, want build", result.Mode)
+	}
+	if result.TasksAttempted != 2 || result.TasksPassed != 2 {
+		t.Fatalf("attempted/passed = %d/%d, want 2/2", result.TasksAttempted, result.TasksPassed)
+	}
+	if result.Suite != "terminal-bench-mini" {
+		t.Fatalf("result.Suite = %q, want terminal-bench-mini", result.Suite)
+	}
+	if strings.TrimSpace(result.Date) == "" {
+		t.Fatalf("result.Date must be recorded, got empty")
+	}
+	if result.SchemaVersion != TaskSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", result.SchemaVersion, TaskSchemaVersion)
+	}
+	if len(result.Tasks) != 2 {
+		t.Fatalf("per-task results = %d, want 2", len(result.Tasks))
+	}
+}
+
+func TestRunTasksCountsPassesAndFailures(t *testing.T) {
+	config := TaskConfig{
+		Model: "m",
+		Runner: func(_ context.Context, task BenchTask, _ RunContext) TaskOutcome {
+			if task.ID == "t1" {
+				return TaskOutcome{Passed: true}
+			}
+			return TaskOutcome{Passed: false, Detail: "verification failed"}
+		},
+	}
+
+	result, err := RunTasks(context.Background(), sampleTaskSet(), config)
+	if err != nil {
+		t.Fatalf("RunTasks returned error: %v", err)
+	}
+	if result.TasksAttempted != 2 || result.TasksPassed != 1 {
+		t.Fatalf("attempted/passed = %d/%d, want 2/1", result.TasksAttempted, result.TasksPassed)
+	}
+	if result.PassRate < 0.49 || result.PassRate > 0.51 {
+		t.Fatalf("pass rate = %v, want ~0.5", result.PassRate)
+	}
+	var t2 *TaskResult
+	for i := range result.Tasks {
+		if result.Tasks[i].ID == "t2" {
+			t2 = &result.Tasks[i]
+		}
+	}
+	if t2 == nil || t2.Passed || t2.Detail != "verification failed" {
+		t.Fatalf("t2 result = %#v, want failed with detail", t2)
+	}
+}
+
+func TestRunTasksRecordsRunnerError(t *testing.T) {
+	config := TaskConfig{
+		Model: "m",
+		Runner: func(_ context.Context, task BenchTask, _ RunContext) TaskOutcome {
+			return TaskOutcome{Err: errors.New("zero exec exited 1")}
+		},
+	}
+
+	result, err := RunTasks(context.Background(), sampleTaskSet(), config)
+	if err != nil {
+		t.Fatalf("RunTasks must not abort on a single task error: %v", err)
+	}
+	// A runner error counts as a non-pass (attempted but not passed) and is
+	// recorded as the task detail, never silently dropped.
+	if result.TasksPassed != 0 {
+		t.Fatalf("errored tasks must not count as passed: %#v", result)
+	}
+	if result.Errors != 2 {
+		t.Fatalf("errors = %d, want 2", result.Errors)
+	}
+	if !strings.Contains(result.Tasks[0].Detail, "zero exec exited 1") {
+		t.Fatalf("task detail should carry the runner error, got %q", result.Tasks[0].Detail)
+	}
+}
+
+func TestRunTasksRejectsEmptyTaskSet(t *testing.T) {
+	_, err := RunTasks(context.Background(), TaskSet{ID: "empty"}, TaskConfig{Model: "m", Runner: passingRunner})
+	if err == nil {
+		t.Fatalf("RunTasks should reject an empty task set")
+	}
+}
+
+func TestRunTasksRequiresModel(t *testing.T) {
+	_, err := RunTasks(context.Background(), sampleTaskSet(), TaskConfig{Runner: passingRunner})
+	if err == nil || !strings.Contains(err.Error(), "model") {
+		t.Fatalf("RunTasks should require a model, got err=%v", err)
+	}
+}
+
+func TestRunTasksRequiresRunner(t *testing.T) {
+	_, err := RunTasks(context.Background(), sampleTaskSet(), TaskConfig{Model: "m"})
+	if err == nil || !strings.Contains(err.Error(), "runner") {
+		t.Fatalf("RunTasks should require a runner, got err=%v", err)
+	}
+}
+
+func TestFormatTaskSummaryIsHonestAboutModelAndSelfCorrect(t *testing.T) {
+	result := TaskRunResult{
+		SchemaVersion:  TaskSchemaVersion,
+		Suite:          "terminal-bench-mini",
+		Model:          "test-model",
+		Mode:           "build",
+		SelfCorrect:    true,
+		Version:        "1.2.3",
+		Commit:         "abc1234",
+		Date:           "2026-06-12T00:00:00Z",
+		TasksAttempted: 2,
+		TasksPassed:    1,
+		PassRate:       0.5,
+		Tasks: []TaskResult{
+			{ID: "t1", Name: "fix", Passed: true},
+			{ID: "t2", Name: "flag", Passed: false, Detail: "nope"},
+		},
+	}
+
+	summary := FormatTaskSummary(result)
+	for _, want := range []string{
+		"terminal-bench-mini",
+		"model: test-model",
+		"self-correct: on",
+		"commit abc1234",
+		"1/2",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary missing %q:\n%s", want, summary)
+		}
+	}
+}
+
+func TestFormatTaskSummarySelfCorrectOff(t *testing.T) {
+	summary := FormatTaskSummary(TaskRunResult{
+		Suite: "s", Model: "m", SelfCorrect: false,
+		TasksAttempted: 1, TasksPassed: 0,
+		Tasks: []TaskResult{{ID: "t1", Passed: false}},
+	})
+	if !strings.Contains(summary, "self-correct: off") {
+		t.Fatalf("summary should report self-correct off:\n%s", summary)
+	}
+}
+
+func passingRunner(context.Context, BenchTask, RunContext) TaskOutcome {
+	return TaskOutcome{Passed: true}
+}

--- a/internal/provideronboarding/localruntime.go
+++ b/internal/provideronboarding/localruntime.go
@@ -1,0 +1,183 @@
+package provideronboarding
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/providercatalog"
+)
+
+// LocalRuntime describes a local, OpenAI-compatible model server that ZERO can
+// adopt with no API key. These are the runtimes the launch audience is most
+// likely to already be running (Ollama, LM Studio), so the first-run wizard
+// auto-detects them on their default ports and offers them with no key step.
+type LocalRuntime struct {
+	CatalogID    string
+	Name         string
+	BaseURL      string
+	DefaultModel string
+	RequiresKey  bool
+}
+
+// DetectedLocalRuntime is a LocalRuntime that has been probed. Reachable reports
+// whether its default endpoint answered the probe; Models is the list of model
+// ids the runtime advertised (best-effort, empty when the probe could not parse
+// a model list).
+type DetectedLocalRuntime struct {
+	LocalRuntime
+	Reachable bool
+	Models    []string
+}
+
+// LocalDetectOptions configures DetectLocalRuntimes. All fields are optional;
+// the zero value probes the built-in candidates with a short default timeout
+// using http.DefaultClient. Tests inject HTTPClient and Candidates.
+type LocalDetectOptions struct {
+	HTTPClient *http.Client
+	Timeout    time.Duration
+	Candidates []LocalRuntime
+}
+
+const defaultLocalProbeTimeout = 400 * time.Millisecond
+
+// LocalRuntimeCandidates returns the built-in local-runtime candidates derived
+// from the provider catalog. Only catalog entries flagged Local are returned, so
+// the default ports stay the single source of truth (catalog.go).
+func LocalRuntimeCandidates() []LocalRuntime {
+	candidates := make([]LocalRuntime, 0, 2)
+	for _, descriptor := range providercatalog.All() {
+		if !descriptor.Local {
+			continue
+		}
+		candidates = append(candidates, LocalRuntime{
+			CatalogID:    descriptor.ID,
+			Name:         descriptor.Name,
+			BaseURL:      descriptor.DefaultBaseURL,
+			DefaultModel: descriptor.DefaultModel,
+			RequiresKey:  descriptor.RequiresAuth,
+		})
+	}
+	return candidates
+}
+
+// DetectLocalRuntimes probes each candidate's default endpoint and returns only
+// the runtimes that answered successfully. A runtime is "reachable" when its
+// OpenAI-compatible models endpoint returns a 2xx; transport errors (closed
+// port), timeouts, and non-2xx responses are treated as "not running" and the
+// candidate is dropped. Detection never errors — a machine with nothing running
+// locally simply yields an empty slice.
+func DetectLocalRuntimes(ctx context.Context, options LocalDetectOptions) []DetectedLocalRuntime {
+	candidates := options.Candidates
+	if len(candidates) == 0 {
+		candidates = LocalRuntimeCandidates()
+	}
+	timeout := options.Timeout
+	if timeout <= 0 {
+		timeout = defaultLocalProbeTimeout
+	}
+	client := options.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+
+	detected := make([]DetectedLocalRuntime, 0, len(candidates))
+	for _, candidate := range candidates {
+		models, reachable := probeLocalRuntime(ctx, client, timeout, candidate)
+		if !reachable {
+			continue
+		}
+		detected = append(detected, DetectedLocalRuntime{
+			LocalRuntime: candidate,
+			Reachable:    true,
+			Models:       models,
+		})
+	}
+	return detected
+}
+
+// SetupAction returns the no-key onboarding action for a detected local runtime.
+func (runtime DetectedLocalRuntime) SetupAction() Action {
+	descriptor := providercatalog.Descriptor{ID: runtime.CatalogID, RequiresAuth: false}
+	command := SetupCommand(descriptor, runtime.Name, true)
+	name := strings.TrimSpace(runtime.Name)
+	if name == "" {
+		name = runtime.CatalogID
+	}
+	return Action{
+		Label:   "Use local runtime",
+		Command: command,
+		Detail:  "Detected " + name + " on " + runtime.BaseURL + " — no API key required.",
+	}
+}
+
+func probeLocalRuntime(ctx context.Context, client *http.Client, timeout time.Duration, candidate LocalRuntime) ([]string, bool) {
+	endpoint := localModelsEndpoint(candidate.BaseURL)
+	if endpoint == "" {
+		return nil, false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(probeCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, false
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, false
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, false
+	}
+	return decodeLocalModelIDs(response.Body), true
+}
+
+// decodeLocalModelIDs best-effort parses the OpenAI-compatible models list
+// ({"data":[{"id":"..."}]}). The body is bounded so a misbehaving local server
+// cannot stream unbounded data into the wizard. A parse failure is not fatal:
+// the runtime is still reachable, we just return no model ids.
+func decodeLocalModelIDs(body io.Reader) []string {
+	data, err := io.ReadAll(io.LimitReader(body, 256*1024))
+	if err != nil {
+		return nil
+	}
+	var parsed struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(parsed.Data))
+	seen := map[string]bool{}
+	for _, entry := range parsed.Data {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}
+
+// localModelsEndpoint resolves the OpenAI-compatible "list models" path for a
+// base URL. Local base URLs in the catalog already end in /v1, so the endpoint
+// is baseURL + "/models"; a trailing slash is trimmed so we never emit "//".
+func localModelsEndpoint(baseURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed + "/models"
+}

--- a/internal/provideronboarding/localruntime_test.go
+++ b/internal/provideronboarding/localruntime_test.go
@@ -1,0 +1,154 @@
+package provideronboarding
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalRuntimeCandidatesCoverOllamaAndLMStudio(t *testing.T) {
+	candidates := LocalRuntimeCandidates()
+	if len(candidates) == 0 {
+		t.Fatalf("LocalRuntimeCandidates() returned no candidates")
+	}
+	byCatalog := map[string]LocalRuntime{}
+	for _, candidate := range candidates {
+		byCatalog[candidate.CatalogID] = candidate
+	}
+	ollama, ok := byCatalog["ollama"]
+	if !ok {
+		t.Fatalf("expected an ollama candidate, got %#v", candidates)
+	}
+	if !strings.Contains(ollama.BaseURL, "11434") {
+		t.Fatalf("ollama candidate must probe default port 11434, got %q", ollama.BaseURL)
+	}
+	if ollama.RequiresKey {
+		t.Fatalf("ollama candidate must not require an API key: %#v", ollama)
+	}
+	lmstudio, ok := byCatalog["lmstudio"]
+	if !ok {
+		t.Fatalf("expected an lmstudio candidate, got %#v", candidates)
+	}
+	if !strings.Contains(lmstudio.BaseURL, "1234") {
+		t.Fatalf("lmstudio candidate must probe default port 1234, got %q", lmstudio.BaseURL)
+	}
+	if lmstudio.RequiresKey {
+		t.Fatalf("lmstudio candidate must not require an API key: %#v", lmstudio)
+	}
+}
+
+func TestDetectLocalRuntimesReportsReachableRuntime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[{"id":"llama3.1"}]}`))
+	}))
+	defer server.Close()
+
+	detected := DetectLocalRuntimes(context.Background(), LocalDetectOptions{
+		HTTPClient: server.Client(),
+		Candidates: []LocalRuntime{{
+			CatalogID: "ollama",
+			Name:      "Ollama Local",
+			BaseURL:   server.URL + "/v1",
+		}},
+	})
+	if len(detected) != 1 {
+		t.Fatalf("DetectLocalRuntimes() = %#v, want one reachable runtime", detected)
+	}
+	if !detected[0].Reachable {
+		t.Fatalf("runtime should be reachable: %#v", detected[0])
+	}
+	if detected[0].Models == nil || len(detected[0].Models) == 0 || detected[0].Models[0] != "llama3.1" {
+		t.Fatalf("expected discovered model list, got %#v", detected[0].Models)
+	}
+}
+
+func TestDetectLocalRuntimesSkipsUnreachableRuntime(t *testing.T) {
+	// A client whose transport always fails simulates a closed local port.
+	failing := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	})}
+
+	detected := DetectLocalRuntimes(context.Background(), LocalDetectOptions{
+		HTTPClient: failing,
+		Candidates: []LocalRuntime{{
+			CatalogID: "ollama",
+			Name:      "Ollama Local",
+			BaseURL:   "http://127.0.0.1:11434/v1",
+		}},
+	})
+	if len(detected) != 0 {
+		t.Fatalf("DetectLocalRuntimes() = %#v, want no reachable runtimes", detected)
+	}
+}
+
+func TestDetectLocalRuntimesIgnoresServerErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	detected := DetectLocalRuntimes(context.Background(), LocalDetectOptions{
+		HTTPClient: server.Client(),
+		Candidates: []LocalRuntime{{
+			CatalogID: "lmstudio",
+			Name:      "LM Studio",
+			BaseURL:   server.URL + "/v1",
+		}},
+	})
+	if len(detected) != 0 {
+		t.Fatalf("a 5xx local response must not count as a reachable runtime: %#v", detected)
+	}
+}
+
+func TestLocalRuntimeActionOffersNoKeySetup(t *testing.T) {
+	runtime := DetectedLocalRuntime{LocalRuntime: LocalRuntime{
+		CatalogID: "ollama",
+		Name:      "Ollama Local",
+		BaseURL:   "http://localhost:11434/v1",
+	}, Reachable: true}
+
+	action := runtime.SetupAction()
+	if !strings.Contains(action.Command, "zero providers add ollama") {
+		t.Fatalf("setup command should add the ollama provider, got %q", action.Command)
+	}
+	if strings.Contains(action.Command, "--api-key-env") {
+		t.Fatalf("local runtime setup must not require an API key env, got %q", action.Command)
+	}
+	if !strings.Contains(strings.ToLower(action.Detail), "no api key") {
+		t.Fatalf("setup detail should advertise the no-key path, got %q", action.Detail)
+	}
+}
+
+func TestDetectLocalRuntimesAppliesDefaultTimeout(t *testing.T) {
+	// A handler that blocks past the configured timeout must be treated as
+	// unreachable rather than hanging the wizard.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	detected := DetectLocalRuntimes(context.Background(), LocalDetectOptions{
+		HTTPClient: server.Client(),
+		Timeout:    20 * time.Millisecond,
+		Candidates: []LocalRuntime{{
+			CatalogID: "ollama",
+			Name:      "Ollama Local",
+			BaseURL:   server.URL + "/v1",
+		}},
+	})
+	if len(detected) != 0 {
+		t.Fatalf("a runtime slower than the timeout must be skipped: %#v", detected)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/provideronboarding/setupprobe.go
+++ b/internal/provideronboarding/setupprobe.go
@@ -1,0 +1,158 @@
+package provideronboarding
+
+import (
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/providerhealth"
+)
+
+// SetupProbeClass is the stable, machine-readable class of a first-run probe
+// failure. It exists so the wizard can render a specific, fixable remedy instead
+// of a raw stack trace: each class maps to one concrete thing the user changes.
+type SetupProbeClass string
+
+const (
+	SetupProbeAuth      SetupProbeClass = "auth"       // bad / missing API key
+	SetupProbeEndpoint  SetupProbeClass = "endpoint"   // wrong base URL, unreachable, timeout
+	SetupProbeModel     SetupProbeClass = "model"      // model not found at the provider
+	SetupProbeRateLimit SetupProbeClass = "rate_limit" // throttled; key works, retry later
+	SetupProbeConfig    SetupProbeClass = "config"     // local profile is incomplete
+	SetupProbeUnknown   SetupProbeClass = "unknown"    // unclassified provider error
+)
+
+// SetupProbeError is a classified, user-facing first-run probe failure. It is a
+// value type (not panicking) so a failing probe can be rendered as a single
+// fixable line. Message is the remedy; Detail is the underlying (already
+// secret-scrubbed) provider message for context.
+type SetupProbeError struct {
+	Class   SetupProbeClass
+	Message string
+	Detail  string
+}
+
+func (err SetupProbeError) Error() string {
+	if strings.TrimSpace(err.Detail) == "" {
+		return err.Message
+	}
+	return err.Message + " (" + err.Detail + ")"
+}
+
+// ClassifySetupProbe maps a provider health probe result to a specific, fixable
+// error. It returns ok=false when the probe passed (nothing to fix). It never
+// panics: an empty or degenerate result classifies to SetupProbeUnknown rather
+// than dereferencing a nil check.
+//
+// The whole point is that "paste key -> working" fails loudly with the one thing
+// to change — wrong base URL, bad key, or model not found — not a stack trace.
+func ClassifySetupProbe(result providerhealth.Result) (SetupProbeError, bool) {
+	if result.Status == providerhealth.StatusPass {
+		return SetupProbeError{}, false
+	}
+
+	check := failingProbeCheck(result)
+	category := providerhealth.Category("")
+	detail := ""
+	if check != nil {
+		category = check.Category
+		detail = strings.TrimSpace(check.Message)
+	}
+
+	switch category {
+	case providerhealth.CategoryAuth:
+		return SetupProbeError{
+			Class:   SetupProbeAuth,
+			Message: "The provider rejected the API key. Double-check the key value (and that it is for this provider), then re-run setup.",
+			Detail:  detail,
+		}, true
+	case providerhealth.CategoryNetwork, providerhealth.CategoryTimeout, providerhealth.CategoryConnectivity:
+		return SetupProbeError{
+			Class:   SetupProbeEndpoint,
+			Message: "Could not reach the provider endpoint. Check the base URL (including scheme and port) and that the server is running.",
+			Detail:  detail,
+		}, true
+	case providerhealth.CategoryRateLimit:
+		return SetupProbeError{
+			Class:   SetupProbeRateLimit,
+			Message: "The provider is rate-limiting requests. The key is reaching it; wait a moment and re-run setup.",
+			Detail:  detail,
+		}, true
+	case providerhealth.CategoryConfig, providerhealth.CategoryUnsupported:
+		return SetupProbeError{
+			Class:   SetupProbeConfig,
+			Message: "The provider profile is incomplete. Set the missing field (model, base URL, or provider kind) and re-run setup.",
+			Detail:  detail,
+		}, true
+	case providerhealth.CategoryProvider:
+		// A provider-side error: a 404 / "model not found" is the common, fixable
+		// case at first run, so classify those as a model problem; anything else is
+		// an unclassified provider error reported verbatim.
+		if isModelNotFound(check, result.Model) {
+			return SetupProbeError{
+				Class:   SetupProbeModel,
+				Message: "The configured model was not found at the provider. Pick a model the provider serves, then re-run setup.",
+				Detail:  detail,
+			}, true
+		}
+		return SetupProbeError{Class: SetupProbeUnknown, Message: "The provider returned an error.", Detail: detail}, true
+	default:
+		return SetupProbeError{Class: SetupProbeUnknown, Message: "The provider probe failed.", Detail: detail}, true
+	}
+}
+
+// failingProbeCheck returns the most relevant check for diagnosis: the first
+// failing check, else the first warning, else the connectivity check, else nil.
+func failingProbeCheck(result providerhealth.Result) *providerhealth.Check {
+	for index := range result.Checks {
+		if result.Checks[index].Status == providerhealth.StatusFail {
+			return &result.Checks[index]
+		}
+	}
+	for index := range result.Checks {
+		if result.Checks[index].Status == providerhealth.StatusWarn {
+			return &result.Checks[index]
+		}
+	}
+	if connectivity := result.Check("provider.connectivity"); connectivity != nil {
+		return connectivity
+	}
+	if len(result.Checks) == 0 {
+		return nil
+	}
+	return &result.Checks[0]
+}
+
+// isModelNotFound reports whether a provider-category check looks like a
+// model-not-found error: an explicit 404 status, or a message that names the
+// model alongside a "not found"/"does not exist"/"unknown model" phrase.
+func isModelNotFound(check *providerhealth.Check, model string) bool {
+	if check == nil {
+		return false
+	}
+	if code, ok := statusCode(check.Details); ok && code == 404 {
+		return true
+	}
+	message := strings.ToLower(check.Message)
+	if strings.Contains(message, "model") && (strings.Contains(message, "not found") || strings.Contains(message, "does not exist") || strings.Contains(message, "unknown")) {
+		return true
+	}
+	if model = strings.ToLower(strings.TrimSpace(model)); model != "" && strings.Contains(message, model) && strings.Contains(message, "not found") {
+		return true
+	}
+	return false
+}
+
+func statusCode(details map[string]any) (int, bool) {
+	if details == nil {
+		return 0, false
+	}
+	switch value := details["statusCode"].(type) {
+	case int:
+		return value, true
+	case int64:
+		return int(value), true
+	case float64:
+		return int(value), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/provideronboarding/setupprobe.go
+++ b/internal/provideronboarding/setupprobe.go
@@ -49,7 +49,7 @@ func ClassifySetupProbe(result providerhealth.Result) (SetupProbeError, bool) {
 		return SetupProbeError{}, false
 	}
 
-	check := failingProbeCheck(result)
+	check := result.PrimaryCheck()
 	category := providerhealth.Category("")
 	detail := ""
 	if check != nil {
@@ -99,43 +99,26 @@ func ClassifySetupProbe(result providerhealth.Result) (SetupProbeError, bool) {
 	}
 }
 
-// failingProbeCheck returns the most relevant check for diagnosis: the first
-// failing check, else the first warning, else the connectivity check, else nil.
-func failingProbeCheck(result providerhealth.Result) *providerhealth.Check {
-	for index := range result.Checks {
-		if result.Checks[index].Status == providerhealth.StatusFail {
-			return &result.Checks[index]
-		}
-	}
-	for index := range result.Checks {
-		if result.Checks[index].Status == providerhealth.StatusWarn {
-			return &result.Checks[index]
-		}
-	}
-	if connectivity := result.Check("provider.connectivity"); connectivity != nil {
-		return connectivity
-	}
-	if len(result.Checks) == 0 {
-		return nil
-	}
-	return &result.Checks[0]
-}
-
 // isModelNotFound reports whether a provider-category check looks like a
-// model-not-found error: an explicit 404 status, or a message that names the
-// model alongside a "not found"/"does not exist"/"unknown model" phrase.
+// model-not-found error: a message that names the model alongside a "not
+// found"/"does not exist"/"unknown" phrase, or a 404 whose message actually
+// references a model lookup. A bare 404 is intentionally NOT treated as a model
+// problem — a wrong base URL/path is an equally common first-run cause, and that
+// is reported as the endpoint, not the model.
 func isModelNotFound(check *providerhealth.Check, model string) bool {
 	if check == nil {
 		return false
 	}
-	if code, ok := statusCode(check.Details); ok && code == 404 {
+	message := strings.ToLower(check.Message)
+	model = strings.ToLower(strings.TrimSpace(model))
+	mentionsModel := strings.Contains(message, "model") || (model != "" && strings.Contains(message, model))
+	if code, ok := statusCode(check.Details); ok && code == 404 && mentionsModel {
 		return true
 	}
-	message := strings.ToLower(check.Message)
 	if strings.Contains(message, "model") && (strings.Contains(message, "not found") || strings.Contains(message, "does not exist") || strings.Contains(message, "unknown")) {
 		return true
 	}
-	if model = strings.ToLower(strings.TrimSpace(model)); model != "" && strings.Contains(message, model) && strings.Contains(message, "not found") {
+	if model != "" && strings.Contains(message, model) && strings.Contains(message, "not found") {
 		return true
 	}
 	return false

--- a/internal/provideronboarding/setupprobe_test.go
+++ b/internal/provideronboarding/setupprobe_test.go
@@ -1,0 +1,136 @@
+package provideronboarding
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/providerhealth"
+)
+
+func TestClassifySetupProbeSuccess(t *testing.T) {
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusPass,
+		Checks: []providerhealth.Check{
+			{ID: "provider.connectivity", Status: providerhealth.StatusPass, Message: "reachable"},
+		},
+	})
+	if ok {
+		t.Fatalf("a passing probe must not produce an error: %#v", probeErr)
+	}
+}
+
+func TestClassifySetupProbeAuthFailure(t *testing.T) {
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusFail,
+		Checks: []providerhealth.Check{
+			{ID: "provider.connectivity", Status: providerhealth.StatusFail, Category: providerhealth.CategoryAuth, Message: "Provider endpoint returned 401: invalid api key"},
+		},
+	})
+	if !ok {
+		t.Fatalf("a failing auth probe must produce an error")
+	}
+	if probeErr.Class != SetupProbeAuth {
+		t.Fatalf("class = %q, want %q", probeErr.Class, SetupProbeAuth)
+	}
+	if !strings.Contains(strings.ToLower(probeErr.Message), "api key") {
+		t.Fatalf("auth message should point at the API key, got %q", probeErr.Message)
+	}
+	if probeErr.Error() == "" {
+		t.Fatalf("error string must not be empty")
+	}
+}
+
+func TestClassifySetupProbeModelNotFound(t *testing.T) {
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusFail,
+		Model:  "missing-model",
+		Checks: []providerhealth.Check{
+			{ID: "provider.connectivity", Status: providerhealth.StatusFail, Category: providerhealth.CategoryProvider, Message: "Provider endpoint returned 404: model not found", Details: map[string]any{"statusCode": 404}},
+		},
+	})
+	if !ok {
+		t.Fatalf("a model-not-found probe must produce an error")
+	}
+	if probeErr.Class != SetupProbeModel {
+		t.Fatalf("class = %q, want %q (a 404 / model-not-found should classify as model)", probeErr.Class, SetupProbeModel)
+	}
+	if !strings.Contains(strings.ToLower(probeErr.Message), "model") {
+		t.Fatalf("model message should mention the model, got %q", probeErr.Message)
+	}
+}
+
+func TestClassifySetupProbeNetworkFailure(t *testing.T) {
+	cases := []struct {
+		name     string
+		category providerhealth.Category
+	}{
+		{"network", providerhealth.CategoryNetwork},
+		{"timeout", providerhealth.CategoryTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+				Status: providerhealth.StatusFail,
+				Checks: []providerhealth.Check{
+					{ID: "provider.connectivity", Status: providerhealth.StatusFail, Category: tc.category, Message: "could not connect"},
+				},
+			})
+			if !ok {
+				t.Fatalf("a %s probe must produce an error", tc.name)
+			}
+			if probeErr.Class != SetupProbeEndpoint {
+				t.Fatalf("class = %q, want %q", probeErr.Class, SetupProbeEndpoint)
+			}
+			if !strings.Contains(strings.ToLower(probeErr.Message), "base url") {
+				t.Fatalf("endpoint message should point at the base URL, got %q", probeErr.Message)
+			}
+		})
+	}
+}
+
+func TestClassifySetupProbeConfigFailure(t *testing.T) {
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusFail,
+		Checks: []providerhealth.Check{
+			{ID: "provider.config", Status: providerhealth.StatusFail, Category: providerhealth.CategoryConfig, Message: "Provider openai requires model."},
+		},
+	})
+	if !ok {
+		t.Fatalf("a config failure must produce an error")
+	}
+	if probeErr.Class != SetupProbeConfig {
+		t.Fatalf("class = %q, want %q", probeErr.Class, SetupProbeConfig)
+	}
+}
+
+func TestClassifySetupProbeRateLimit(t *testing.T) {
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusWarn,
+		Checks: []providerhealth.Check{
+			{ID: "provider.connectivity", Status: providerhealth.StatusWarn, Category: providerhealth.CategoryRateLimit, Message: "Provider endpoint returned 429"},
+		},
+	})
+	if !ok {
+		t.Fatalf("a rate-limit warning is a soft failure that must still surface a classified message")
+	}
+	if probeErr.Class != SetupProbeRateLimit {
+		t.Fatalf("class = %q, want %q", probeErr.Class, SetupProbeRateLimit)
+	}
+}
+
+func TestClassifySetupProbeNeverPanicsOnEmptyResult(t *testing.T) {
+	// The headline guarantee: a degenerate / empty probe result must classify to a
+	// stable error class, never panic and never dereference a nil check.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ClassifySetupProbe panicked on an empty result: %v", r)
+		}
+	}()
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{Status: providerhealth.StatusFail})
+	if !ok {
+		t.Fatalf("a failing-but-empty result must still produce an error")
+	}
+	if probeErr.Class != SetupProbeUnknown {
+		t.Fatalf("class = %q, want %q", probeErr.Class, SetupProbeUnknown)
+	}
+}

--- a/internal/provideronboarding/setupprobe_test.go
+++ b/internal/provideronboarding/setupprobe_test.go
@@ -59,6 +59,44 @@ func TestClassifySetupProbeModelNotFound(t *testing.T) {
 	}
 }
 
+func TestClassifySetupProbeBadBaseURL404IsNotModel(t *testing.T) {
+	// A 404 from a wrong base URL/path is a common first-run mistake. It must not be
+	// classified as a missing model — that would send the user to change the model
+	// when the real fix is the endpoint. With no model-lookup context in the
+	// message, a provider-category 404 stays an unclassified provider error.
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusFail,
+		Model:  "gpt-4.1",
+		Checks: []providerhealth.Check{
+			{ID: "provider.connectivity", Status: providerhealth.StatusFail, Category: providerhealth.CategoryProvider, Message: "Provider endpoint returned 404: 404 page not found", Details: map[string]any{"statusCode": 404}},
+		},
+	})
+	if !ok {
+		t.Fatalf("a failing provider probe must produce an error")
+	}
+	if probeErr.Class == SetupProbeModel {
+		t.Fatalf("a bad-base-URL 404 must not classify as a missing model, got %q", probeErr.Class)
+	}
+}
+
+func TestClassifySetupProbeModelNotFound404WithModelContext(t *testing.T) {
+	// A 404 whose message names a model lookup failure stays classified as a model
+	// problem.
+	probeErr, ok := ClassifySetupProbe(providerhealth.Result{
+		Status: providerhealth.StatusFail,
+		Model:  "gpt-4.1",
+		Checks: []providerhealth.Check{
+			{ID: "provider.connectivity", Status: providerhealth.StatusFail, Category: providerhealth.CategoryProvider, Message: "Provider endpoint returned 404: The model `gpt-4.1` does not exist", Details: map[string]any{"statusCode": 404}},
+		},
+	})
+	if !ok {
+		t.Fatalf("a failing provider probe must produce an error")
+	}
+	if probeErr.Class != SetupProbeModel {
+		t.Fatalf("a model-context 404 must classify as model, got %q", probeErr.Class)
+	}
+}
+
 func TestClassifySetupProbeNetworkFailure(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Stage 13 hardens the two things a launch is won or lost on: the first 60 seconds (install/first-run) and a reproducible, published benchmark. Scoped to the areas the stage spec lists (plus their tests).

## First run, model-agnostic-first
- **Local runtime detection** (`internal/provideronboarding/localruntime.go`): `LocalRuntimeCandidates()` derives the local, OpenAI-compatible candidates from the provider catalog (Ollama on :11434, LM Studio on :1234); `DetectLocalRuntimes()` probes their default endpoints and returns only the ones answering, with **no key required**. Transport errors, timeouts, and non-2xx responses are treated as "not running" and dropped — detection never errors.
- **Classified setup probe** (`internal/provideronboarding/setupprobe.go`): `ClassifySetupProbe()` maps a live connectivity probe result to a specific, fixable error class — `auth` (bad/missing key), `endpoint` (wrong base URL / unreachable / timeout), `model` (model not found, incl. 404), `rate_limit`, `config` — instead of a stack trace. Never panics, including on a degenerate/empty result.
- **`zero setup --verify`** (`internal/cli/setup.go`): after saving the provider, runs a live connectivity probe (guarded — no-op when no prober is wired), reports the classified fixable error on failure (exit `provider`), and on success confirms the endpoint is reachable. `setup` now also prints a concrete one-line `try this: zero exec "..." --model <model>` so the wizard ends in a working state.

## `zero doctor` hardening (`internal/doctor`)
- New **`sandbox.backend`** check: resolves the native backend (bubblewrap on Linux, sandbox-exec on macOS) and, when absent, **warns** (the policy engine still runs) with a platform-specific install remedy.
- New **`lsp.servers`** check: lists which language servers are missing from PATH with a per-binary install command. Source of truth is `lsp.ServerBinaries()` (small accessor over the existing server map).
- `doctor.Options` gains `GOOS` + `LookupExecutable` so both checks are deterministic in tests; production uses `runtime.GOOS` + `exec.LookPath`. Neither check can hard-fail the report.

## Self-correct surface + benchmark
- **`zero exec --self-correct`** (`internal/cli/exec.go`, `exec_parse.go`): wires the existing post-edit verify-and-correct loop (`agent.SelfCorrector`) via the project verifier. Off by default the corrector is nil, leaving the agent loop byte-identical; auto-fix vs. report-only is decided by the run's `--auto` autonomy gate.
- **Task benchmark harness** (`internal/perfbench/taskbench.go`): `RunTasks()` runs a `TaskSet` and produces a self-describing record capturing **model + commit + version + self-correct flag + date** plus per-task pass/fail/error and pass rate. `NewExecRunner()` is the production runner — it drives headless `zero exec --output-format stream-json` and decides pass/fail from the `run_end` exit code (or a task's external `verificationCommand`, Terminal-Bench style). The runner is injectable so the suite tests run against a mocked task set with no binary or model.
- **`zero-perf-bench tasks`** subcommand (`cmd/zero-perf-bench/tasks.go`): one command to run a suite reproducibly, with `--self-correct`, `--commit`/`--version` (or `ZERO_BENCH_*` env), `--output`, and `--dry-run`. A runnable sample suite ships at `cmd/zero-perf-bench/testdata/`. The existing perf-bench (cold-start/RSS) path is unchanged.
- **`docs/BENCHMARK.md`**: publishes the methodology — the exact two commands (with and without `--self-correct`), the recorded fields, why the score is model-bounded, and a results table for the self-correct delta. Provider-neutral throughout (`<model>` placeholders).

## Testing
- TDD per area. `go build ./...` and `gofmt -l .` clean (whole repo); `go vet` clean on touched packages.
- `go test ./...` passes. Note: under heavy parallel load one pre-existing test in the untouched `internal/config` package (`TestLoadProviderCommandFailureIncludesExitAndRedactsOutput`, a 5s external-command timeout) can flake; it passes deterministically in isolation and with bounded `-p`.

## Deferred (intentionally out of scope)
- The published benchmark numbers in `docs/BENCHMARK.md` are left as `TBD` — they must be produced on a fixed machine with a real model, which can't run in CI.
- The headless self-correct wiring verifies with the workspace test plan only (LSP half nil): `zero exec` does not spin up a language-server manager, and `NewSelfCorrector` accepts a nil checker. Wiring the LSP half into headless exec is left to a focused follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New task benchmark harness and `zero-perf-bench tasks` subcommand with dry-run, JSON/file output, and human summaries.
  * `exec` gains `--self-correct` to enable self-correcting execution.
  * `setup` gains `--verify` to probe and report provider connectivity.
  * Local runtime discovery/onboarding for no‑API‑key runtimes.
  * Doctor now checks sandbox backend and language-server availability.

* **Documentation**
  * Added benchmark methodology and reproducibility guide.

* **Tests**
  * Extensive new test coverage for tasks, exec self-correct, setup verification, doctor hardening, perfbench harness, and onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->