### PR TITLE
Render assistant Markdown in TUI

### DIFF
--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -727,13 +727,19 @@ func wrapMarkdownInlineWithPrefixes(firstPrefix string, continuationPrefix strin
 		}
 		wordWidth := lipgloss.Width(word.text)
 		rendered := renderMarkdownInlineSegment(word)
+		separator := " "
+		separatorWidth := 1
+		if joinsPreviousMarkdownWord(word.text) {
+			separator = ""
+			separatorWidth = 0
+		}
 		switch {
 		case line == "":
 			line = rendered
 			lineWidth = wordWidth
-		case lineWidth+1+wordWidth <= available:
-			line += " " + rendered
-			lineWidth += 1 + wordWidth
+		case lineWidth+separatorWidth+wordWidth <= available:
+			line += separator + rendered
+			lineWidth += separatorWidth + wordWidth
 		default:
 			flush()
 			line = rendered
@@ -754,6 +760,10 @@ func markdownInlineWords(segments []markdownInlineSegment) []markdownInlineSegme
 		}
 	}
 	return words
+}
+
+func joinsPreviousMarkdownWord(text string) bool {
+	return text != "" && strings.Trim(text, ".,!?;:%)]}") == ""
 }
 
 func renderMarkdownInline(text string) string {
@@ -805,14 +815,14 @@ func parseMarkdownInline(text string) []markdownInlineSegment {
 	for index := 0; index < len(text); {
 		switch {
 		case strings.HasPrefix(text[index:], "**"):
-			if bold || strings.Contains(text[index+2:], "**") {
+			if !code && (bold || strings.Contains(text[index+2:], "**")) {
 				flush()
 				bold = !bold
 				index += 2
 				continue
 			}
 		case strings.HasPrefix(text[index:], "__"):
-			if bold || strings.Contains(text[index+2:], "__") {
+			if !code && (bold || strings.Contains(text[index+2:], "__")) {
 				flush()
 				bold = !bold
 				index += 2
@@ -820,12 +830,14 @@ func parseMarkdownInline(text string) []markdownInlineSegment {
 			}
 		case text[index] == '`':
 			if code || strings.Contains(text[index+1:], "`") {
+				flush()
 				code = !code
 				index++
 				continue
 			}
 		case text[index] == '*':
-			if emphasis || strings.Contains(text[index+1:], "*") {
+			if !code && !strings.HasPrefix(text[index:], "**") && (emphasis || hasClosingMarkdownSingleStar(text[index+1:])) {
+				flush()
 				emphasis = !emphasis
 				index++
 				continue
@@ -841,6 +853,20 @@ func parseMarkdownInline(text string) []markdownInlineSegment {
 	}
 	flush()
 	return segments
+}
+
+func hasClosingMarkdownSingleStar(text string) bool {
+	for index := 0; index < len(text); index++ {
+		if text[index] != '*' {
+			continue
+		}
+		if index+1 < len(text) && text[index+1] == '*' {
+			index++
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func longestMarkdownWordWidth(text string) int {

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
@@ -815,14 +816,14 @@ func parseMarkdownInline(text string) []markdownInlineSegment {
 	for index := 0; index < len(text); {
 		switch {
 		case strings.HasPrefix(text[index:], "**"):
-			if !code && (bold || strings.Contains(text[index+2:], "**")) {
+			if !code && ((bold && canCloseMarkdownDelimiter(text, index, "**")) || (!bold && canOpenMarkdownDelimiter(text, index, "**") && hasClosingMarkdownDelimiter(text, index+2, "**"))) {
 				flush()
 				bold = !bold
 				index += 2
 				continue
 			}
 		case strings.HasPrefix(text[index:], "__"):
-			if !code && (bold || strings.Contains(text[index+2:], "__")) {
+			if !code && ((bold && canCloseMarkdownDelimiter(text, index, "__")) || (!bold && canOpenMarkdownDelimiter(text, index, "__") && hasClosingMarkdownDelimiter(text, index+2, "__"))) {
 				flush()
 				bold = !bold
 				index += 2
@@ -836,7 +837,7 @@ func parseMarkdownInline(text string) []markdownInlineSegment {
 				continue
 			}
 		case text[index] == '*':
-			if !code && !strings.HasPrefix(text[index:], "**") && (emphasis || hasClosingMarkdownSingleStar(text[index+1:])) {
+			if !code && !strings.HasPrefix(text[index:], "**") && ((emphasis && canCloseMarkdownDelimiter(text, index, "*")) || (!emphasis && canOpenMarkdownDelimiter(text, index, "*") && hasClosingMarkdownDelimiter(text, index+1, "*"))) {
 				flush()
 				emphasis = !emphasis
 				index++
@@ -855,18 +856,85 @@ func parseMarkdownInline(text string) []markdownInlineSegment {
 	return segments
 }
 
-func hasClosingMarkdownSingleStar(text string) bool {
-	for index := 0; index < len(text); index++ {
-		if text[index] != '*' {
+func hasClosingMarkdownDelimiter(text string, start int, marker string) bool {
+	for index := start; index < len(text); index++ {
+		if !strings.HasPrefix(text[index:], marker) {
 			continue
 		}
-		if index+1 < len(text) && text[index+1] == '*' {
+		if marker == "*" && index+1 < len(text) && text[index+1] == '*' {
 			index++
 			continue
 		}
-		return true
+		if canCloseMarkdownDelimiter(text, index, marker) {
+			return true
+		}
+		index += len(marker) - 1
 	}
 	return false
+}
+
+func canOpenMarkdownDelimiter(text string, index int, marker string) bool {
+	before, hasBefore := markdownRuneBefore(text, index)
+	after, hasAfter := markdownRuneAfter(text, index+len(marker))
+	if !hasAfter || unicode.IsSpace(after) {
+		return false
+	}
+	if hasBefore && markdownIsWordRune(before) {
+		return false
+	}
+	if marker == "__" && isMarkdownDunderIdentifier(text, index) {
+		return false
+	}
+	return true
+}
+
+func canCloseMarkdownDelimiter(text string, index int, marker string) bool {
+	before, hasBefore := markdownRuneBefore(text, index)
+	after, hasAfter := markdownRuneAfter(text, index+len(marker))
+	if !hasBefore || unicode.IsSpace(before) {
+		return false
+	}
+	if hasAfter && markdownIsWordRune(after) {
+		return false
+	}
+	return true
+}
+
+func isMarkdownDunderIdentifier(text string, index int) bool {
+	end := strings.Index(text[index+2:], "__")
+	if end < 0 {
+		return false
+	}
+	body := text[index+2 : index+2+end]
+	if body == "" {
+		return false
+	}
+	for _, r := range body {
+		if !markdownIsWordRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func markdownRuneBefore(text string, index int) (rune, bool) {
+	if index <= 0 {
+		return 0, false
+	}
+	r, _ := utf8.DecodeLastRuneInString(text[:index])
+	return r, r != utf8.RuneError
+}
+
+func markdownRuneAfter(text string, index int) (rune, bool) {
+	if index >= len(text) {
+		return 0, false
+	}
+	r, _ := utf8.DecodeRuneInString(text[index:])
+	return r, r != utf8.RuneError
+}
+
+func markdownIsWordRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
 func longestMarkdownWordWidth(text string) int {

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -9,9 +9,9 @@ import (
 
 const (
 	markdownTableColumnSeparator = " │ "
-	markdownTableRuleSeparator   = "─┼─"
 	markdownTableMinColumnWidth  = 4
 	markdownTableHeaderMaxWidth  = 18
+	markdownTableRuleBodyRows    = 4
 	markdownBoldStart            = "\x1b[1m"
 	markdownBoldEnd              = "\x1b[22m"
 )
@@ -177,7 +177,7 @@ func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
 
 func markdownDisplayStyleForRune(r rune, current markdownDisplayStyle) markdownDisplayStyle {
 	switch r {
-	case '│', '─', '┼':
+	case '│', '─', '┼', '╭', '╮', '╰', '╯', '├', '┤', '┬', '┴':
 		return markdownDisplayRule
 	default:
 		if current == markdownDisplayRule {
@@ -262,9 +262,21 @@ func parseMarkdownTableRow(line string) []string {
 	parts := strings.Split(trimmed, "|")
 	cells := make([]string, 0, len(parts))
 	for _, part := range parts {
-		cells = append(cells, strings.TrimSpace(part))
+		cells = append(cells, normalizeMarkdownTableCell(part))
 	}
 	return cells
+}
+
+func normalizeMarkdownTableCell(cell string) string {
+	replacer := strings.NewReplacer(
+		"<br />", "\n",
+		"<br/>", "\n",
+		"<br>", "\n",
+		"<BR />", "\n",
+		"<BR/>", "\n",
+		"<BR>", "\n",
+	)
+	return strings.TrimSpace(replacer.Replace(cell))
 }
 
 func isMarkdownTableSeparatorCell(cell string) bool {
@@ -312,7 +324,7 @@ func renderMarkdownTable(rows [][]string, alignments []markdownTableAlignment, m
 		renderedRows[rowIndex] = renderMarkdownTableRow(row, widths, alignments, rowIndex == 0)
 	}
 	separateBodyRows := markdownTableNeedsBodyRules(renderedRows)
-	out := []string{}
+	out := []string{markdownTableTopRule(widths)}
 	for rowIndex, rowLines := range renderedRows {
 		if separateBodyRows && rowIndex > 1 {
 			out = append(out, markdownTableRule(widths))
@@ -322,10 +334,14 @@ func renderMarkdownTable(rows [][]string, alignments []markdownTableAlignment, m
 			out = append(out, markdownTableRule(widths))
 		}
 	}
+	out = append(out, markdownTableBottomRule(widths))
 	return out
 }
 
 func markdownTableNeedsBodyRules(renderedRows [][]string) bool {
+	if len(renderedRows) > markdownTableRuleBodyRows {
+		return true
+	}
 	for _, row := range renderedRows[1:] {
 		if len(row) > 1 {
 			return true
@@ -335,7 +351,19 @@ func markdownTableNeedsBodyRules(renderedRows [][]string) bool {
 }
 
 func wrapMarkdownTableCellPart(prefix string, text string, measure int) []string {
-	return wrapMarkdownInlineWithPrefixes(prefix, strings.Repeat(" ", lipgloss.Width(prefix)), text, measure)
+	continuationPrefix := strings.Repeat(" ", lipgloss.Width(prefix))
+	lines := []string{}
+	for index, segment := range strings.Split(text, "\n") {
+		firstPrefix := prefix
+		if index > 0 {
+			firstPrefix = continuationPrefix
+		}
+		lines = append(lines, wrapMarkdownInlineWithPrefixes(firstPrefix, continuationPrefix, segment, measure)...)
+	}
+	if len(lines) == 0 {
+		return []string{prefix}
+	}
+	return lines
 }
 
 type markdownTableCellPart struct {
@@ -429,7 +457,7 @@ func normalizeMarkdownTableAlignments(alignments []markdownTableAlignment, colum
 }
 
 func markdownTableWidths(rows [][]string, columns int, measure int) []int {
-	separatorWidth := lipgloss.Width(markdownTableColumnSeparator) * maxInt(0, columns-1)
+	separatorWidth := lipgloss.Width(markdownTableColumnSeparator)*maxInt(0, columns-1) + 4
 	contentWidth := maxInt(columns*markdownTableMinColumnWidth, measure-separatorWidth)
 	widths := make([]int, columns)
 	minWidths := make([]int, columns)
@@ -522,7 +550,7 @@ func renderMarkdownTableRow(row []string, widths []int, alignments []markdownTab
 			}
 			parts[column] = alignMarkdownTableCell(cell, width, alignments[column])
 		}
-		lines = append(lines, strings.TrimRight(strings.Join(parts, markdownTableColumnSeparator), " "))
+		lines = append(lines, "│ "+strings.Join(parts, markdownTableColumnSeparator)+" │")
 	}
 	return lines
 }
@@ -535,8 +563,10 @@ func markdownTableCellWidthParts(cell string) []string {
 		if part.bullet {
 			line = "- " + line
 		}
-		if line != "" {
-			lines = append(lines, line)
+		for _, segment := range strings.Split(line, "\n") {
+			if segment != "" {
+				lines = append(lines, segment)
+			}
 		}
 	}
 	if len(lines) == 0 {
@@ -579,11 +609,23 @@ func alignMarkdownTableCell(text string, width int, alignment markdownTableAlign
 }
 
 func markdownTableRule(widths []int) string {
+	return markdownTableBorderRule(widths, "├", "┼", "┤")
+}
+
+func markdownTableTopRule(widths []int) string {
+	return markdownTableBorderRule(widths, "╭", "┬", "╮")
+}
+
+func markdownTableBottomRule(widths []int) string {
+	return markdownTableBorderRule(widths, "╰", "┴", "╯")
+}
+
+func markdownTableBorderRule(widths []int, left string, separator string, right string) string {
 	parts := make([]string, len(widths))
 	for index, width := range widths {
-		parts[index] = strings.Repeat("─", maxInt(1, width))
+		parts[index] = strings.Repeat("─", maxInt(1, width+2))
 	}
-	return strings.Join(parts, markdownTableRuleSeparator)
+	return left + strings.Join(parts, separator) + right
 }
 
 func markdownHeadingText(trimmed string) string {

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -1,0 +1,833 @@
+package tui
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	markdownTableColumnSeparator = " │ "
+	markdownTableRuleSeparator   = "─┼─"
+	markdownTableMinColumnWidth  = 4
+	markdownTableHeaderMaxWidth  = 18
+	markdownBoldStart            = "\x1b[1m"
+	markdownBoldEnd              = "\x1b[22m"
+)
+
+type markdownDisplayStyle int
+
+const (
+	markdownDisplayNormal markdownDisplayStyle = iota
+	markdownDisplayBold
+	markdownDisplayRule
+)
+
+type markdownTableAlignment int
+
+const (
+	markdownTableAlignLeft markdownTableAlignment = iota
+	markdownTableAlignCenter
+	markdownTableAlignRight
+)
+
+func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int) []string {
+	if proseMeasure < 16 {
+		proseMeasure = 16
+	}
+	if tableMeasure < proseMeasure {
+		tableMeasure = proseMeasure
+	}
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", "\n"), "\r", "\n"), "\n"), "\n")
+	if len(raw) == 0 {
+		return []string{""}
+	}
+
+	lines := []string{}
+	for index := 0; index < len(raw); {
+		line := raw[index]
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
+			lines = append(lines, "")
+			index++
+			continue
+		}
+
+		if fence, ok := markdownFenceMarker(trimmed); ok {
+			code := []string{}
+			index++
+			for index < len(raw) {
+				if closing, ok := markdownFenceMarker(strings.TrimSpace(raw[index])); ok && closing == fence {
+					index++
+					break
+				}
+				code = append(code, strings.ReplaceAll(raw[index], "\t", "    "))
+				index++
+			}
+			lines = append(lines, renderMarkdownCodeBlock(code, tableMeasure)...)
+			continue
+		}
+
+		if index+1 < len(raw) && isMarkdownTableHeader(line, raw[index+1]) {
+			tableRows := [][]string{parseMarkdownTableRow(line)}
+			alignments := parseMarkdownTableAlignments(raw[index+1])
+			index += 2
+			for index < len(raw) && isMarkdownTableRow(raw[index]) {
+				tableRows = append(tableRows, parseMarkdownTableRow(raw[index]))
+				index++
+			}
+			lines = append(lines, renderMarkdownTable(tableRows, alignments, tableMeasure)...)
+			continue
+		}
+
+		if heading := markdownHeadingText(trimmed); heading != "" {
+			lines = append(lines, wrapMarkdownInline(heading, proseMeasure)...)
+			index++
+			continue
+		}
+
+		if isMarkdownListLine(trimmed) || strings.HasPrefix(trimmed, ">") {
+			lines = append(lines, wrapMarkdownInline(renderMarkdownStandaloneLine(line), proseMeasure)...)
+			index++
+			continue
+		}
+
+		paragraph := []string{strings.TrimSpace(line)}
+		index++
+		for index < len(raw) {
+			next := raw[index]
+			nextTrimmed := strings.TrimSpace(next)
+			if nextTrimmed == "" || markdownStartsBlock(raw, index) {
+				break
+			}
+			paragraph = append(paragraph, nextTrimmed)
+			index++
+		}
+		lines = append(lines, wrapMarkdownInline(strings.Join(paragraph, " "), proseMeasure)...)
+	}
+
+	return trimMarkdownDisplayBlankEdges(lines)
+}
+
+func renderAssistantMarkdownPlainText(text string, proseMeasure int, tableMeasure int) []string {
+	lines := renderAssistantMarkdownText(text, proseMeasure, tableMeasure)
+	for index := range lines {
+		lines[index] = stripMarkdownRenderControls(lines[index])
+	}
+	return lines
+}
+
+func stripMarkdownRenderControls(text string) string {
+	text = strings.ReplaceAll(text, markdownBoldStart, "")
+	return strings.ReplaceAll(text, markdownBoldEnd, "")
+}
+
+func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
+	var builder strings.Builder
+	style := markdownDisplayNormal
+	var run strings.Builder
+
+	flush := func() {
+		if run.Len() == 0 {
+			return
+		}
+		text := run.String()
+		switch style {
+		case markdownDisplayBold:
+			builder.WriteString(zeroTheme.ink.Bold(true).Render(text))
+		case markdownDisplayRule:
+			builder.WriteString(zeroTheme.lineStrong.Render(text))
+		default:
+			builder.WriteString(base.Render(text))
+		}
+		run.Reset()
+	}
+
+	for index := 0; index < len(line); {
+		switch {
+		case strings.HasPrefix(line[index:], markdownBoldStart):
+			flush()
+			style = markdownDisplayBold
+			index += len(markdownBoldStart)
+			continue
+		case strings.HasPrefix(line[index:], markdownBoldEnd):
+			flush()
+			style = markdownDisplayNormal
+			index += len(markdownBoldEnd)
+			continue
+		}
+
+		r, size := utf8.DecodeRuneInString(line[index:])
+		if r == utf8.RuneError && size == 0 {
+			break
+		}
+		nextStyle := markdownDisplayStyleForRune(r, style)
+		if nextStyle != style {
+			flush()
+			style = nextStyle
+		}
+		run.WriteRune(r)
+		index += size
+	}
+	flush()
+	return builder.String()
+}
+
+func markdownDisplayStyleForRune(r rune, current markdownDisplayStyle) markdownDisplayStyle {
+	switch r {
+	case '│', '─', '┼':
+		return markdownDisplayRule
+	default:
+		if current == markdownDisplayRule {
+			return markdownDisplayNormal
+		}
+		return current
+	}
+}
+
+func markdownStartsBlock(lines []string, index int) bool {
+	if index >= len(lines) {
+		return false
+	}
+	trimmed := strings.TrimSpace(lines[index])
+	if trimmed == "" {
+		return true
+	}
+	if _, ok := markdownFenceMarker(trimmed); ok {
+		return true
+	}
+	if markdownHeadingText(trimmed) != "" || isMarkdownListLine(trimmed) || strings.HasPrefix(trimmed, ">") {
+		return true
+	}
+	return index+1 < len(lines) && isMarkdownTableHeader(lines[index], lines[index+1])
+}
+
+func markdownFenceMarker(trimmed string) (string, bool) {
+	for _, marker := range []string{"```", "~~~"} {
+		if strings.HasPrefix(trimmed, marker) {
+			return marker, true
+		}
+	}
+	return "", false
+}
+
+func renderMarkdownCodeBlock(code []string, measure int) []string {
+	if len(code) == 0 {
+		return []string{""}
+	}
+	lines := []string{}
+	for _, line := range code {
+		if line == "" {
+			lines = append(lines, "")
+			continue
+		}
+		for lipgloss.Width(line) > measure {
+			head, tail := splitAtWidth(line, measure)
+			lines = append(lines, head)
+			line = tail
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func isMarkdownTableHeader(header string, separator string) bool {
+	headerCells := parseMarkdownTableRow(header)
+	separatorCells := parseMarkdownTableRow(separator)
+	if len(headerCells) < 2 || len(headerCells) != len(separatorCells) {
+		return false
+	}
+	for _, cell := range separatorCells {
+		if !isMarkdownTableSeparatorCell(cell) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMarkdownTableRow(line string) bool {
+	cells := parseMarkdownTableRow(line)
+	return len(cells) >= 2
+}
+
+func parseMarkdownTableRow(line string) []string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || !strings.Contains(trimmed, "|") {
+		return nil
+	}
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	parts := strings.Split(trimmed, "|")
+	cells := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cells = append(cells, strings.TrimSpace(part))
+	}
+	return cells
+}
+
+func isMarkdownTableSeparatorCell(cell string) bool {
+	cell = strings.TrimSpace(cell)
+	cell = strings.Trim(cell, ":")
+	if len(cell) < 3 {
+		return false
+	}
+	for _, r := range cell {
+		if r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func parseMarkdownTableAlignments(separator string) []markdownTableAlignment {
+	cells := parseMarkdownTableRow(separator)
+	alignments := make([]markdownTableAlignment, len(cells))
+	for index, cell := range cells {
+		cell = strings.TrimSpace(cell)
+		left := strings.HasPrefix(cell, ":")
+		right := strings.HasSuffix(cell, ":")
+		switch {
+		case left && right:
+			alignments[index] = markdownTableAlignCenter
+		case right:
+			alignments[index] = markdownTableAlignRight
+		default:
+			alignments[index] = markdownTableAlignLeft
+		}
+	}
+	return alignments
+}
+
+func renderMarkdownTable(rows [][]string, alignments []markdownTableAlignment, measure int) []string {
+	rows, columns := normalizeMarkdownTableRows(rows)
+	if columns == 0 {
+		return nil
+	}
+	alignments = normalizeMarkdownTableAlignments(alignments, columns)
+	widths := markdownTableWidths(rows, columns, measure)
+	renderedRows := make([][]string, len(rows))
+	for rowIndex, row := range rows {
+		renderedRows[rowIndex] = renderMarkdownTableRow(row, widths, alignments, rowIndex == 0)
+	}
+	separateBodyRows := markdownTableNeedsBodyRules(renderedRows)
+	out := []string{}
+	for rowIndex, rowLines := range renderedRows {
+		if separateBodyRows && rowIndex > 1 {
+			out = append(out, markdownTableRule(widths))
+		}
+		out = append(out, rowLines...)
+		if rowIndex == 0 && len(rows) > 1 {
+			out = append(out, markdownTableRule(widths))
+		}
+	}
+	return out
+}
+
+func markdownTableNeedsBodyRules(renderedRows [][]string) bool {
+	for _, row := range renderedRows[1:] {
+		if len(row) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func wrapMarkdownTableCellPart(prefix string, text string, measure int) []string {
+	return wrapMarkdownInlineWithPrefixes(prefix, strings.Repeat(" ", lipgloss.Width(prefix)), text, measure)
+}
+
+type markdownTableCellPart struct {
+	text   string
+	bullet bool
+}
+
+func markdownTableCellParts(value string) []markdownTableCellPart {
+	value = strings.TrimSpace(value)
+	starts := markdownInlineBulletStarts(value)
+	if len(starts) == 0 {
+		return []markdownTableCellPart{{text: value}}
+	}
+
+	parts := []markdownTableCellPart{}
+	if starts[0] > 0 {
+		if text := strings.TrimSpace(value[:starts[0]]); text != "" {
+			parts = append(parts, markdownTableCellPart{text: text})
+		}
+	}
+	for index, start := range starts {
+		end := len(value)
+		if index+1 < len(starts) {
+			end = starts[index+1]
+		}
+		text := strings.TrimSpace(value[start:end])
+		text = strings.TrimSpace(strings.TrimPrefix(text, "-"))
+		if text != "" {
+			parts = append(parts, markdownTableCellPart{text: text, bullet: true})
+		}
+	}
+	if len(parts) == 0 {
+		return []markdownTableCellPart{{text: value}}
+	}
+	return parts
+}
+
+func markdownInlineBulletStarts(value string) []int {
+	starts := []int{}
+	if strings.HasPrefix(value, "- ") {
+		starts = append(starts, 0)
+	}
+	offset := 0
+	for {
+		index := strings.Index(value[offset:], " - ")
+		if index < 0 {
+			break
+		}
+		hyphen := offset + index + 1
+		candidate := hyphen + 2
+		if isProbableInlineBulletLabel(value[candidate:]) {
+			starts = append(starts, hyphen)
+		}
+		offset = candidate
+	}
+	return starts
+}
+
+func isProbableInlineBulletLabel(text string) bool {
+	colon := strings.IndexByte(text, ':')
+	if colon <= 0 || colon > 48 {
+		return false
+	}
+	label := text[:colon]
+	return !strings.ContainsAny(label, ".!?;")
+}
+
+func normalizeMarkdownTableRows(rows [][]string) ([][]string, int) {
+	columns := 0
+	for _, row := range rows {
+		if len(row) > columns {
+			columns = len(row)
+		}
+	}
+	if columns == 0 {
+		return nil, 0
+	}
+	normalized := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		next := make([]string, columns)
+		copy(next, row)
+		normalized = append(normalized, next)
+	}
+	return normalized, columns
+}
+
+func normalizeMarkdownTableAlignments(alignments []markdownTableAlignment, columns int) []markdownTableAlignment {
+	normalized := make([]markdownTableAlignment, columns)
+	copy(normalized, alignments)
+	return normalized
+}
+
+func markdownTableWidths(rows [][]string, columns int, measure int) []int {
+	separatorWidth := lipgloss.Width(markdownTableColumnSeparator) * maxInt(0, columns-1)
+	contentWidth := maxInt(columns*markdownTableMinColumnWidth, measure-separatorWidth)
+	widths := make([]int, columns)
+	minWidths := make([]int, columns)
+	for column := range widths {
+		headerWidth := 0
+		if len(rows) > 0 && column < len(rows[0]) {
+			headerWidth = lipgloss.Width(markdownInlinePlain(rows[0][column]))
+		}
+		minWidths[column] = clampInt(headerWidth, markdownTableMinColumnWidth, markdownTableHeaderMaxWidth)
+		widths[column] = minWidths[column]
+	}
+	for _, row := range rows {
+		for column, cell := range row {
+			if column >= len(widths) {
+				continue
+			}
+			for _, line := range markdownTableCellWidthParts(cell) {
+				plainLine := markdownInlinePlain(line)
+				lineWidth := lipgloss.Width(plainLine)
+				if wordWidth := longestMarkdownWordWidth(plainLine); wordWidth > lineWidth {
+					lineWidth = wordWidth
+				}
+				if lineWidth > widths[column] {
+					widths[column] = minInt(lineWidth, contentWidth)
+				}
+			}
+		}
+	}
+	for sumInts(widths) > contentWidth && shrinkMarkdownTableWidth(widths, minWidths) {
+	}
+	for sumInts(widths) > contentWidth {
+		largest := 0
+		for index, width := range widths {
+			if width > widths[largest] {
+				largest = index
+			}
+		}
+		if widths[largest] <= markdownTableMinColumnWidth {
+			break
+		}
+		widths[largest]--
+	}
+	return widths
+}
+
+func shrinkMarkdownTableWidth(widths []int, minWidths []int) bool {
+	largest := -1
+	for index, width := range widths {
+		if width <= minWidths[index] {
+			continue
+		}
+		if largest < 0 || width > widths[largest] {
+			largest = index
+		}
+	}
+	if largest < 0 {
+		return false
+	}
+	widths[largest]--
+	return true
+}
+
+func renderMarkdownTableRow(row []string, widths []int, alignments []markdownTableAlignment, header bool) []string {
+	wrapped := make([][]string, len(widths))
+	height := 1
+	for column, width := range widths {
+		cell := ""
+		if column < len(row) {
+			cell = row[column]
+		}
+		wrapped[column] = markdownTableCellLines(cell, width)
+		if len(wrapped[column]) == 0 {
+			wrapped[column] = []string{""}
+		}
+		if len(wrapped[column]) > height {
+			height = len(wrapped[column])
+		}
+	}
+
+	lines := make([]string, 0, height)
+	for lineIndex := 0; lineIndex < height; lineIndex++ {
+		parts := make([]string, len(widths))
+		for column, width := range widths {
+			cell := ""
+			if lineIndex < len(wrapped[column]) {
+				cell = wrapped[column][lineIndex]
+			}
+			if header && cell != "" {
+				cell = renderMarkdownBoldText(cell)
+			}
+			parts[column] = alignMarkdownTableCell(cell, width, alignments[column])
+		}
+		lines = append(lines, strings.TrimRight(strings.Join(parts, markdownTableColumnSeparator), " "))
+	}
+	return lines
+}
+
+func markdownTableCellWidthParts(cell string) []string {
+	parts := markdownTableCellParts(cell)
+	lines := []string{}
+	for _, part := range parts {
+		line := part.text
+		if part.bullet {
+			line = "- " + line
+		}
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}
+
+func markdownTableCellLines(cell string, width int) []string {
+	parts := markdownTableCellParts(cell)
+	if len(parts) == 1 && !parts[0].bullet {
+		return wrapMarkdownInline(cell, width)
+	}
+	lines := []string{}
+	for _, part := range parts {
+		prefix := ""
+		if part.bullet {
+			prefix = "- "
+		}
+		lines = append(lines, wrapMarkdownTableCellPart(prefix, part.text, width)...)
+	}
+	return lines
+}
+
+func alignMarkdownTableCell(text string, width int, alignment markdownTableAlignment) string {
+	padding := width - lipgloss.Width(text)
+	if padding <= 0 {
+		return text
+	}
+	switch alignment {
+	case markdownTableAlignRight:
+		return strings.Repeat(" ", padding) + text
+	case markdownTableAlignCenter:
+		left := padding / 2
+		right := padding - left
+		return strings.Repeat(" ", left) + text + strings.Repeat(" ", right)
+	default:
+		return text + strings.Repeat(" ", padding)
+	}
+}
+
+func markdownTableRule(widths []int) string {
+	parts := make([]string, len(widths))
+	for index, width := range widths {
+		parts[index] = strings.Repeat("─", maxInt(1, width))
+	}
+	return strings.Join(parts, markdownTableRuleSeparator)
+}
+
+func markdownHeadingText(trimmed string) string {
+	level := 0
+	for level < len(trimmed) && trimmed[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 || level >= len(trimmed) || trimmed[level] != ' ' {
+		return ""
+	}
+	return strings.TrimSpace(trimmed[level:])
+}
+
+func isMarkdownListLine(trimmed string) bool {
+	if len(trimmed) >= 2 {
+		if strings.Contains("-*+", string(trimmed[0])) && trimmed[1] == ' ' {
+			return true
+		}
+	}
+	dot := strings.IndexByte(trimmed, '.')
+	if dot <= 0 || dot+1 >= len(trimmed) || trimmed[dot+1] != ' ' {
+		return false
+	}
+	for _, r := range trimmed[:dot] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func renderMarkdownStandaloneLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, ">") {
+		return "│ " + strings.TrimSpace(strings.TrimPrefix(trimmed, ">"))
+	}
+	return strings.TrimRight(line, " ")
+}
+
+func stripMarkdownInline(text string) string {
+	return markdownInlinePlain(text)
+}
+
+type markdownInlineSegment struct {
+	text string
+	bold bool
+}
+
+func wrapMarkdownInline(text string, measure int) []string {
+	if measure < 1 {
+		measure = 1
+	}
+	out := []string{}
+	for _, paragraph := range strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n") {
+		if strings.TrimSpace(paragraph) == "" {
+			out = append(out, "")
+			continue
+		}
+		body := strings.TrimLeft(paragraph, " \t")
+		indent := strings.ReplaceAll(paragraph[:len(paragraph)-len(body)], "\t", "    ")
+		if len(indent) >= measure {
+			indent = strings.Repeat(" ", measure/2)
+		}
+		out = append(out, wrapMarkdownInlineWithPrefixes(indent, indent, body, measure)...)
+	}
+	return out
+}
+
+func wrapMarkdownInlineWithPrefixes(firstPrefix string, continuationPrefix string, text string, measure int) []string {
+	words := markdownInlineWords(parseMarkdownInline(text))
+	if len(words) == 0 {
+		return []string{firstPrefix}
+	}
+
+	lines := []string{}
+	line := ""
+	lineWidth := 0
+	prefix := firstPrefix
+	available := maxInt(1, measure-lipgloss.Width(prefix))
+
+	flush := func() {
+		lines = append(lines, prefix+line)
+		line = ""
+		lineWidth = 0
+		prefix = continuationPrefix
+		available = maxInt(1, measure-lipgloss.Width(prefix))
+	}
+
+	for _, word := range words {
+		for lipgloss.Width(word.text) > available {
+			if line != "" {
+				flush()
+			}
+			head, tail := splitAtWidth(word.text, available)
+			lines = append(lines, prefix+renderMarkdownInlineSegment(markdownInlineSegment{text: head, bold: word.bold}))
+			word.text = tail
+			prefix = continuationPrefix
+			available = maxInt(1, measure-lipgloss.Width(prefix))
+		}
+		wordWidth := lipgloss.Width(word.text)
+		rendered := renderMarkdownInlineSegment(word)
+		switch {
+		case line == "":
+			line = rendered
+			lineWidth = wordWidth
+		case lineWidth+1+wordWidth <= available:
+			line += " " + rendered
+			lineWidth += 1 + wordWidth
+		default:
+			flush()
+			line = rendered
+			lineWidth = wordWidth
+		}
+	}
+	if line != "" {
+		lines = append(lines, prefix+line)
+	}
+	return lines
+}
+
+func markdownInlineWords(segments []markdownInlineSegment) []markdownInlineSegment {
+	words := []markdownInlineSegment{}
+	for _, segment := range segments {
+		for _, word := range strings.Fields(segment.text) {
+			words = append(words, markdownInlineSegment{text: word, bold: segment.bold})
+		}
+	}
+	return words
+}
+
+func renderMarkdownInline(text string) string {
+	segments := parseMarkdownInline(text)
+	var builder strings.Builder
+	for _, segment := range segments {
+		builder.WriteString(renderMarkdownInlineSegment(segment))
+	}
+	return builder.String()
+}
+
+func renderMarkdownInlineSegment(segment markdownInlineSegment) string {
+	if segment.text == "" {
+		return ""
+	}
+	if segment.bold {
+		return renderMarkdownBoldText(segment.text)
+	}
+	return segment.text
+}
+
+func renderMarkdownBoldText(text string) string {
+	return markdownBoldStart + text + markdownBoldEnd
+}
+
+func markdownInlinePlain(text string) string {
+	segments := parseMarkdownInline(text)
+	var builder strings.Builder
+	for _, segment := range segments {
+		builder.WriteString(segment.text)
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func parseMarkdownInline(text string) []markdownInlineSegment {
+	segments := []markdownInlineSegment{}
+	var builder strings.Builder
+	bold := false
+	emphasis := false
+	code := false
+	flush := func() {
+		if builder.Len() == 0 {
+			return
+		}
+		segments = append(segments, markdownInlineSegment{text: builder.String(), bold: bold && !code})
+		builder.Reset()
+	}
+
+	for index := 0; index < len(text); {
+		switch {
+		case strings.HasPrefix(text[index:], "**"):
+			if bold || strings.Contains(text[index+2:], "**") {
+				flush()
+				bold = !bold
+				index += 2
+				continue
+			}
+		case strings.HasPrefix(text[index:], "__"):
+			if bold || strings.Contains(text[index+2:], "__") {
+				flush()
+				bold = !bold
+				index += 2
+				continue
+			}
+		case text[index] == '`':
+			if code || strings.Contains(text[index+1:], "`") {
+				code = !code
+				index++
+				continue
+			}
+		case text[index] == '*':
+			if emphasis || strings.Contains(text[index+1:], "*") {
+				emphasis = !emphasis
+				index++
+				continue
+			}
+		}
+
+		r, size := utf8.DecodeRuneInString(text[index:])
+		if r == utf8.RuneError && size == 0 {
+			break
+		}
+		builder.WriteRune(r)
+		index += size
+	}
+	flush()
+	return segments
+}
+
+func longestMarkdownWordWidth(text string) int {
+	longest := 0
+	for _, word := range strings.Fields(text) {
+		if width := lipgloss.Width(word); width > longest {
+			longest = width
+		}
+	}
+	return longest
+}
+
+func sumInts(values []int) int {
+	sum := 0
+	for _, value := range values {
+		sum += value
+	}
+	return sum
+}
+
+func trimMarkdownDisplayBlankEdges(lines []string) []string {
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1091,23 +1091,36 @@ func (m model) chatPageScrollLines() int {
 	return maxInt(3, m.height-8)
 }
 
-// interimBlock renders the live assistant text while a turn streams: muted
-// prose wrapped to the say measure with a trailing accent cursor. Before the
-// first delta arrives it falls back to the spinner so the surface still shows
-// liveness. The cursor needs no ticker — it appears exactly while pending.
+// interimBlock renders the live assistant text while a turn streams. It uses
+// the same lightweight markdown renderer as completed assistant rows, so
+// tables and simple formatting stabilize as soon as enough tokens arrive.
+// Before the first delta arrives it falls back to the spinner so the surface
+// still shows liveness. The cursor needs no ticker — it appears exactly while
+// pending.
 func (m model) interimBlock(width int) string {
 	text := strings.TrimRight(m.streamingText, "\n")
 	if strings.TrimSpace(text) == "" {
 		return m.spinner.View() + " " + zeroTheme.muted.Render("working…")
 	}
-	lines := wrapPlainText(text, sayMeasure(width))
+	lines := renderAssistantMarkdownText(text, sayMeasure(width), width)
 	for index, line := range lines {
-		lines[index] = zeroTheme.sayText.Render(line)
+		lines[index] = styleAssistantMarkdownLine(line, zeroTheme.sayText)
 	}
-	if len(lines) > 0 {
-		lines[len(lines)-1] += zeroTheme.accent.Render("▌")
-	}
+	lines = appendStreamingCursor(lines, width)
 	return strings.Join(lines, "\n")
+}
+
+func appendStreamingCursor(lines []string, width int) []string {
+	cursor := zeroTheme.accent.Render("▌")
+	if len(lines) == 0 {
+		return []string{cursor}
+	}
+	last := len(lines) - 1
+	if width > 0 && lipgloss.Width(lines[last])+1 > width {
+		return append(lines, cursor)
+	}
+	lines[last] += cursor
+	return lines
 }
 
 // composerLine renders the borderless composer: the styled textinput plus a

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -371,15 +371,19 @@ func renderUserRow(row transcriptRow, width int) string {
 // gutter plus its done line; a non-final assistant row (e.g. a rehydrated
 // inline notice) renders as plain interim-style prose.
 func renderAssistantRow(row transcriptRow, width int) string {
-	lines := wrapPlainText(row.text, sayMeasure(width))
+	tableMeasure := width
+	if row.final {
+		tableMeasure = maxInt(16, width-2)
+	}
+	lines := renderAssistantMarkdownText(row.text, sayMeasure(width), tableMeasure)
 	if !row.final {
 		for index := range lines {
-			lines[index] = zeroTheme.sayText.Render(lines[index])
+			lines[index] = styleAssistantMarkdownLine(lines[index], zeroTheme.sayText)
 		}
 		return strings.Join(lines, "\n")
 	}
 	for index := range lines {
-		lines[index] = zeroTheme.finalRail.Render("│ ") + zeroTheme.ink.Render(lines[index])
+		lines[index] = zeroTheme.finalRail.Render("│ ") + styleAssistantMarkdownLine(lines[index], zeroTheme.ink)
 	}
 	lines = append(lines, doneLine(row, false))
 	return strings.Join(lines, "\n")

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -98,6 +98,26 @@ func TestMarkdownInlineRendersBoldControlCodes(t *testing.T) {
 	}
 }
 
+func TestMarkdownInlinePreservesLiteralStarsAndCodeBoundaries(t *testing.T) {
+	got := renderMarkdownInline("literal * stays and **bold `not bold` bold**")
+	plain := ansiPattern.ReplaceAllString(got, "")
+	if plain != "literal * stays and bold not bold bold" {
+		t.Fatalf("inline markdown plain text = %q, want literal star and stripped markers", plain)
+	}
+	if strings.Contains(got, markdownBoldStart+"not bold"+markdownBoldEnd) {
+		t.Fatalf("inline code span inherited bold styling in %q", got)
+	}
+	for _, want := range []string{
+		markdownBoldStart + "bold " + markdownBoldEnd,
+		"not bold",
+		markdownBoldStart + " bold" + markdownBoldEnd,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("inline markdown render missing %q in %q", want, got)
+		}
+	}
+}
+
 func TestMarkdownTableHeaderRendersBold(t *testing.T) {
 	lines := renderAssistantMarkdownText(strings.Join([]string{
 		"| Feature | System A | System B |",
@@ -215,6 +235,9 @@ func TestMarkdownPlainTextStripsRenderControls(t *testing.T) {
 			t.Fatalf("plain markdown render leaked %q in:\n%s", unwanted, got)
 		}
 	}
+	if ansiPattern.MatchString(got) {
+		t.Fatalf("plain markdown render leaked ANSI escapes in:\n%s", got)
+	}
 	for _, want := range []string{"Feature", "Mode", "│", "─┼─"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("plain markdown render missing %q in:\n%s", want, got)
@@ -246,6 +269,9 @@ func TestSelectableAssistantRowKeepsMarkdownSemanticsPlain(t *testing.T) {
 			if strings.Contains(line.text, unwanted) {
 				t.Fatalf("selectable metadata leaked %q in %#v", unwanted, line)
 			}
+		}
+		if ansiPattern.MatchString(line.text) {
+			t.Fatalf("selectable metadata leaked ANSI escapes in %#v", line)
 		}
 	}
 }
@@ -297,6 +323,9 @@ func TestFinalAnswerRendersMarkdownTableForTerminal(t *testing.T) {
 	}
 	if !strings.Contains(got, " │ ") || !strings.Contains(got, "─┼─") {
 		t.Fatalf("markdown table should render terminal table separators, got:\n%s", got)
+	}
+	if !strings.Contains(got, "● done") {
+		t.Fatalf("markdown final row = %q, want done line terminator", got)
 	}
 	for index, line := range strings.Split(rendered, "\n") {
 		if gotWidth := lipgloss.Width(line); gotWidth > 72 {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -25,7 +27,7 @@ func plainRender(t *testing.T, rendered string) string {
 }
 
 func limeTestModel() model {
-	return newModel(context.Background(), Options{ProviderName: "anthropic", ModelName: "claude-sonnet-4.5"})
+	return newModel(context.Background(), Options{ProviderName: "test-provider", ModelName: "test-model"})
 }
 
 func TestUserRowRendersPromptGutter(t *testing.T) {
@@ -53,6 +55,152 @@ func TestInterimBlockShowsStreamingTextWithCursor(t *testing.T) {
 	}
 }
 
+func TestInterimBlockRendersStreamingMarkdownTable(t *testing.T) {
+	m := limeTestModel()
+	m.pending = true
+	m.streamingText = strings.Join([]string{
+		"Here's the comparison:",
+		"",
+		"| Category | System A | System B |",
+		"|---|---|---|",
+		"| **Label** | Alpha | Beta |",
+	}, "\n")
+
+	rendered := m.interimBlock(72)
+	got := plainRender(t, rendered)
+	for _, unwanted := range []string{"|---", "**Label**"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("streaming markdown table leaked source syntax %q in:\n%s", unwanted, got)
+		}
+	}
+	for _, want := range []string{"Category", "Label", " │ ", "─┼─", "▌"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("streaming markdown table missing %q in:\n%s", want, got)
+		}
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if gotWidth := lipgloss.Width(line); gotWidth > 72 {
+			t.Fatalf("line %d width = %d, want <= 72: %q", index, gotWidth, line)
+		}
+	}
+}
+
+func TestMarkdownInlineRendersBoldControlCodes(t *testing.T) {
+	got := renderMarkdownInline("plain **h** __there__ `code` *em*")
+	for _, want := range []string{markdownBoldStart + "h" + markdownBoldEnd, markdownBoldStart + "there" + markdownBoldEnd} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("inline markdown render missing bold segment %q in %q", want, got)
+		}
+	}
+	plain := ansiPattern.ReplaceAllString(got, "")
+	if plain != "plain h there code em" {
+		t.Fatalf("inline markdown plain text = %q, want markers stripped", plain)
+	}
+}
+
+func TestMarkdownTableHeaderRendersBold(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"| Feature | System A | System B |",
+		"|---|---|---|",
+		"| Mode | Alpha | Beta |",
+	}, "\n"), 72, 72)
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{
+		markdownBoldStart + "Feature" + markdownBoldEnd,
+		markdownBoldStart + "System A" + markdownBoldEnd,
+		markdownBoldStart + "System B" + markdownBoldEnd,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown table header missing bold segment %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestMarkdownTableAddsBodyRulesForWrappedRows(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"| Feature | System A | System B |",
+		"|---|---|---|",
+		"| Long Description | This cell contains enough neutral words to wrap across multiple lines. | This other cell also wraps across multiple lines for layout testing. |",
+		"| Short Row | Alpha | Beta |",
+	}, "\n"), 72, 72)
+	got := strings.Join(lines, "\n")
+	ruleCount := countMarkdownRuleLines(got)
+	if ruleCount < 2 {
+		t.Fatalf("wrapped markdown table should add body rules, got %d in:\n%s", ruleCount, got)
+	}
+}
+
+func TestMarkdownTableKeepsCompactRowsClean(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"| Feature | System A | System B |",
+		"|---|---|---|",
+		"| Count | one | two |",
+		"| Mode | Alpha | Beta |",
+	}, "\n"), 96, 96)
+	got := strings.Join(lines, "\n")
+	ruleCount := countMarkdownRuleLines(got)
+	if ruleCount != 1 {
+		t.Fatalf("compact markdown table should only have header rule, got %d in:\n%s", ruleCount, got)
+	}
+}
+
+func countMarkdownRuleLines(rendered string) int {
+	count := 0
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "─┼─") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestMarkdownPlainTextStripsRenderControls(t *testing.T) {
+	lines := renderAssistantMarkdownPlainText(strings.Join([]string{
+		"| **Feature** | System A |",
+		"|---|---|",
+		"| **Mode** | Alpha |",
+	}, "\n"), 72, 72)
+	got := strings.Join(lines, "\n")
+	for _, unwanted := range []string{markdownBoldStart, markdownBoldEnd, "**"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("plain markdown render leaked %q in:\n%s", unwanted, got)
+		}
+	}
+	for _, want := range []string{"Feature", "Mode", "│", "─┼─"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("plain markdown render missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestSelectableAssistantRowKeepsMarkdownSemanticsPlain(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowAssistant,
+		text: strings.Join([]string{
+			"| Feature | System A | System B |",
+			"|---|---|---|",
+			"| **Mode** | Alpha | Beta |",
+		}, "\n"),
+		final: true,
+	}
+
+	rendered, selectable := m.renderSelectableAssistantRow(0, row, 72, 0)
+	got := plainRender(t, rendered)
+	for _, want := range []string{"Feature", "System A", "System B", "Mode", "│", "─┼─"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("selectable assistant markdown row missing %q in:\n%s", want, got)
+		}
+	}
+	for _, line := range selectable {
+		for _, unwanted := range []string{markdownBoldStart, markdownBoldEnd, "**"} {
+			if strings.Contains(line.text, unwanted) {
+				t.Fatalf("selectable metadata leaked %q in %#v", unwanted, line)
+			}
+		}
+	}
+}
+
 func TestFinalAnswerRendersRailAndDoneLine(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{
@@ -68,6 +216,156 @@ func TestFinalAnswerRendersRailAndDoneLine(t *testing.T) {
 	}
 	if !strings.Contains(got, "● done · 2 tools · 8.4s") {
 		t.Fatalf("final row = %q, want done line with counters", got)
+	}
+}
+
+func TestFinalAnswerRendersMarkdownTableForTerminal(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowAssistant,
+		text: strings.Join([]string{
+			"Here's the comparison:",
+			"",
+			"| Category | System A | System B |",
+			"|---|---|---|",
+			"| **Label** | Alpha | Beta |",
+			"| **Status** | ready | ready |",
+		}, "\n"),
+		final: true,
+	}
+
+	rendered := m.renderRow(row, 72, buildRowContext(nil))
+	got := plainRender(t, rendered)
+	for _, unwanted := range []string{"|---", "**Label**", "| **Status**"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("markdown table leaked source syntax %q in:\n%s", unwanted, got)
+		}
+	}
+	for _, want := range []string{"Category", "Label", "System A", "System B"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown table render missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, " │ ") || !strings.Contains(got, "─┼─") {
+		t.Fatalf("markdown table should render terminal table separators, got:\n%s", got)
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if gotWidth := lipgloss.Width(line); gotWidth > 72 {
+			t.Fatalf("line %d width = %d, want <= 72: %q", index, gotWidth, line)
+		}
+	}
+}
+
+func TestFinalAnswerRendersLongThreeColumnMarkdownTables(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowAssistant,
+		text: strings.Join([]string{
+			"| Aspect | System A | System B |",
+			"|---|---|---|",
+			"| **Long Row** | This cell contains detailed neutral text that should wrap cleanly inside the column. | This cell contains another neutral description that should wrap cleanly too. |",
+		}, "\n"),
+		final: true,
+	}
+
+	rendered := m.renderRow(row, 92, buildRowContext(nil))
+	got := plainRender(t, rendered)
+	for _, want := range []string{
+		"Aspect",
+		"Long Row",
+		"System A",
+		"System B",
+		"detailed neutral",
+		"another neutral",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("long three-column table missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "─┼─") || strings.Contains(got, "  System A:") {
+		t.Fatalf("long three-column table should render as a table, got:\n%s", got)
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if gotWidth := lipgloss.Width(line); gotWidth > 92 {
+			t.Fatalf("line %d width = %d, want <= 92: %q", index, gotWidth, line)
+		}
+	}
+}
+
+func TestFinalAnswerCleansTableEmphasisAndInlineBullets(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowAssistant,
+		text: strings.Join([]string{
+			"| Aspect | System A | System B |",
+			"|---|---|---|",
+			"| **Core Detail** | This neutral phrase emphasizes clarity *by design*. | This neutral phrase stays broadly compatible. |",
+			"| **Capabilities** | - First capability: Generally reliable. - Second capability: Supports larger examples. | - Third capability: Broad task coverage. - Fourth capability: Strong integrations. |",
+		}, "\n"),
+		final: true,
+	}
+
+	rendered := m.renderRow(row, 92, buildRowContext(nil))
+	got := plainRender(t, rendered)
+	for _, unwanted := range []string{"*by design*", "Generally reliable. - Second capability:"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("markdown table leaked %q in:\n%s", unwanted, got)
+		}
+	}
+	for _, want := range []string{
+		"neutral phrase emphasizes",
+		"clarity by design.",
+		"- First capability:",
+		"- Second capability:",
+		"- Third capability:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown table missing %q in:\n%s", want, got)
+		}
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if gotWidth := lipgloss.Width(line); gotWidth > 92 {
+			t.Fatalf("line %d width = %d, want <= 92: %q", index, gotWidth, line)
+		}
+	}
+}
+
+func TestFinalAnswerRendersCrowdedMarkdownTablesAsTables(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowAssistant,
+		text: strings.Join([]string{
+			"| Feature | System A | System B | Notes |",
+			"|---|---|---|---|",
+			"| **Long Description** | This neutral cell is intentionally long enough to wrap across lines. | This other neutral cell is also long enough to wrap across lines. | Notes should remain attached to the correct row. |",
+			"| **Short Description** | Alpha | Beta | Both columns stay aligned. |",
+		}, "\n"),
+		final: true,
+	}
+
+	rendered := m.renderRow(row, 92, buildRowContext(nil))
+	got := plainRender(t, rendered)
+	for _, want := range []string{
+		"Feature",
+		"System A",
+		"System B",
+		"Notes",
+		"Long Description",
+		"intentionally long",
+		"other neutral",
+		"correct row",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("crowded markdown table missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "─┼─") || strings.Contains(got, "  Notes:") {
+		t.Fatalf("crowded table should render as a table, got:\n%s", got)
+	}
+	for index, line := range strings.Split(rendered, "\n") {
+		if gotWidth := lipgloss.Width(line); gotWidth > 92 {
+			t.Fatalf("line %d width = %d, want <= 92: %q", index, gotWidth, line)
+		}
 	}
 }
 
@@ -326,7 +624,7 @@ func TestComposerBoxFramesInputAndBottomModelModeLabel(t *testing.T) {
 	m.input.SetValue("add a flag")
 
 	got := plainRender(t, m.composerBox(96))
-	for _, want := range []string{"╭", "│", "❯ add a flag", "╰", "claude-sonnet-4.5", "auto-approve"} {
+	for _, want := range []string{"╭", "│", "❯ add a flag", "╰", "test-model", "auto-approve"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("composer box = %q, missing %q", got, want)
 		}
@@ -370,27 +668,27 @@ func TestMalformedToolArgumentResultIsHiddenFromChatSurface(t *testing.T) {
 func TestStatusLineGroups(t *testing.T) {
 	m := limeTestModel()
 	got := plainRender(t, m.statusLine(110))
-	for _, want := range []string{"● anthropic"} {
+	for _, want := range []string{"● test-provider"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("status line = %q, missing %q", got, want)
 		}
 	}
-	if strings.Contains(got, "interactive") || strings.Contains(got, "claude-sonnet-4.5") || strings.Contains(got, "auto-approve") {
+	if strings.Contains(got, "interactive") || strings.Contains(got, "test-model") || strings.Contains(got, "auto-approve") {
 		t.Fatalf("status line = %q, should not include surface, model, or permission mode", got)
 	}
 	divider := plainRender(t, m.composerDividerLine(110))
-	for _, want := range []string{"claude-sonnet-4.5", "auto-approve"} {
+	for _, want := range []string{"test-model", "auto-approve"} {
 		if !strings.Contains(divider, want) {
 			t.Fatalf("composer divider = %q, missing %q", divider, want)
 		}
 	}
 }
 
-func TestTitleBarShowsBadgeModelAndContextWindow(t *testing.T) {
+func TestTitleBarShowsBadgeAndModel(t *testing.T) {
 	m := limeTestModel()
 	m.width = 120
 	got := plainRender(t, m.titleBar(120))
-	for _, want := range []string{" 0 ", "zero", "anthropic/claude-sonnet-4.5", "200K"} {
+	for _, want := range []string{" 0 ", "zero", "test-provider/test-model"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("title bar = %q, missing %q", got, want)
 		}
@@ -635,14 +933,14 @@ func TestSpecReviewCardShowsBadgePathAndKeys(t *testing.T) {
 }
 
 func TestPermissionCollapseIsRunScoped(t *testing.T) {
-	// Providers like Gemini synthesize repeating ToolCallIDs (gemini_tool_1 in
+	// Some providers synthesize repeating ToolCallIDs (provider_tool_1 in
 	// every turn). A decision from run 2 must not collapse run 1's undecided
 	// prompt or steal its [auto]/hint attribution.
-	runOnePrompt := transcriptRow{kind: rowPermission, id: "gemini_tool_1", runID: 1, permission: &agent.PermissionEvent{
-		ToolCallID: "gemini_tool_1", ToolName: "bash", Action: agent.PermissionActionPrompt,
+	runOnePrompt := transcriptRow{kind: rowPermission, id: "provider_tool_1", runID: 1, permission: &agent.PermissionEvent{
+		ToolCallID: "provider_tool_1", ToolName: "bash", Action: agent.PermissionActionPrompt,
 	}}
-	runTwoDecision := transcriptRow{kind: rowPermission, id: "gemini_tool_1", runID: 2, permission: &agent.PermissionEvent{
-		ToolCallID: "gemini_tool_1", ToolName: "bash", Action: agent.PermissionActionAllow,
+	runTwoDecision := transcriptRow{kind: rowPermission, id: "provider_tool_1", runID: 2, permission: &agent.PermissionEvent{
+		ToolCallID: "provider_tool_1", ToolName: "bash", Action: agent.PermissionActionAllow,
 	}}
 	rc := buildRowContext([]transcriptRow{runOnePrompt, runTwoDecision})
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -116,6 +116,20 @@ func TestMarkdownTableHeaderRendersBold(t *testing.T) {
 	}
 }
 
+func TestMarkdownTableRendersOuterBorder(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"| Feature | System A |",
+		"|---|---|",
+		"| Mode | Alpha |",
+	}, "\n"), 80, 80)
+	got := strings.Join(lines, "\n")
+	for _, want := range []string{"╭", "┬", "╮", "├", "┼", "┤", "╰", "┴", "╯"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown table border missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestMarkdownTableAddsBodyRulesForWrappedRows(t *testing.T) {
 	lines := renderAssistantMarkdownText(strings.Join([]string{
 		"| Feature | System A | System B |",
@@ -141,6 +155,41 @@ func TestMarkdownTableKeepsCompactRowsClean(t *testing.T) {
 	ruleCount := countMarkdownRuleLines(got)
 	if ruleCount != 1 {
 		t.Fatalf("compact markdown table should only have header rule, got %d in:\n%s", ruleCount, got)
+	}
+}
+
+func TestMarkdownTableAddsBodyRulesForManyRows(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"| Feature | System A | System B |",
+		"|---|---|---|",
+		"| Count | one | two |",
+		"| Mode | Alpha | Beta |",
+		"| Scope | local | remote |",
+		"| State | ready | done |",
+	}, "\n"), 160, 160)
+	got := strings.Join(lines, "\n")
+	ruleCount := countMarkdownRuleLines(got)
+	if ruleCount < 2 {
+		t.Fatalf("multi-row markdown table should add body rules even when wide, got %d in:\n%s", ruleCount, got)
+	}
+}
+
+func TestMarkdownTableConvertsHtmlBreaks(t *testing.T) {
+	lines := renderAssistantMarkdownText(strings.Join([]string{
+		"| Field | Value |",
+		"|---|---|",
+		"| Price | first<br>second<BR />third<br/>fourth |",
+	}, "\n"), 96, 96)
+	got := strings.Join(lines, "\n")
+	for _, unwanted := range []string{"<br>", "<BR />", "<br/>"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("markdown table leaked html break %q in:\n%s", unwanted, got)
+		}
+	}
+	for _, want := range []string{"first", "second", "third", "fourth"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown table missing break segment %q in:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -86,14 +86,14 @@ func TestInterimBlockRendersStreamingMarkdownTable(t *testing.T) {
 }
 
 func TestMarkdownInlineRendersBoldControlCodes(t *testing.T) {
-	got := renderMarkdownInline("plain **h** __there__ `code` *em*")
-	for _, want := range []string{markdownBoldStart + "h" + markdownBoldEnd, markdownBoldStart + "there" + markdownBoldEnd} {
+	got := renderMarkdownInline("plain **h** __bold text__ `code` *em*")
+	for _, want := range []string{markdownBoldStart + "h" + markdownBoldEnd, markdownBoldStart + "bold text" + markdownBoldEnd} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("inline markdown render missing bold segment %q in %q", want, got)
 		}
 	}
 	plain := ansiPattern.ReplaceAllString(got, "")
-	if plain != "plain h there code em" {
+	if plain != "plain h bold text code em" {
 		t.Fatalf("inline markdown plain text = %q, want markers stripped", plain)
 	}
 }
@@ -114,6 +114,25 @@ func TestMarkdownInlinePreservesLiteralStarsAndCodeBoundaries(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("inline markdown render missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestMarkdownInlineKeepsCodingLiterals(t *testing.T) {
+	tests := map[string]string{
+		"`a.*b.*c`":                  "a.*b.*c",
+		"`*.go` and `*.py`":          "*.go and *.py",
+		"`x__y__z`":                  "x__y__z",
+		"the __init__ method":        "the __init__ method",
+		"run as __main__":            "run as __main__",
+		"compute 2 * 3 * 4":          "compute 2 * 3 * 4",
+		"keep a*b*c literal":         "keep a*b*c literal",
+		"glob *.go outside code too": "glob *.go outside code too",
+	}
+	for input, want := range tests {
+		got := ansiPattern.ReplaceAllString(renderMarkdownInline(input), "")
+		if got != want {
+			t.Fatalf("inline markdown for %q = %q, want %q", input, got, want)
 		}
 	}
 }

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -135,7 +135,11 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 }
 
 func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
-	wrapped := wrapPlainText(row.text, sayMeasure(width))
+	tableMeasure := width
+	if row.final {
+		tableMeasure = maxInt(16, width-2)
+	}
+	wrapped := renderAssistantMarkdownText(row.text, sayMeasure(width), tableMeasure)
 	lines := make([]string, 0, len(wrapped)+1)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
 	prefix := ""
@@ -145,14 +149,15 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 		textStyle = zeroTheme.ink
 	}
 	for index, line := range wrapped {
+		plainLine := stripMarkdownRenderControls(line)
 		meta := transcriptSelectableLine{
 			bodyY:     startBodyY + index,
 			rowIndex:  rowIndex,
 			textStart: lipgloss.Width(prefix),
-			text:      line,
+			text:      plainLine,
 		}
 		selectable = append(selectable, meta)
-		rendered := m.renderTranscriptSelectableText(meta, textStyle)
+		rendered := m.renderTranscriptSelectableMarkdownText(meta, line, textStyle)
 		if row.final {
 			rendered = zeroTheme.finalRail.Render(prefix) + rendered
 		}
@@ -162,6 +167,13 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 		lines = append(lines, doneLine(row, false))
 	}
 	return strings.Join(lines, "\n"), selectable
+}
+
+func (m model) renderTranscriptSelectableMarkdownText(line transcriptSelectableLine, styledText string, base lipgloss.Style) string {
+	if _, _, ok := m.selectedColumnsForTranscriptLine(line); ok {
+		return m.renderTranscriptSelectableText(line, base)
+	}
+	return styleAssistantMarkdownLine(styledText, base)
 }
 
 func (m model) renderTranscriptSelectableText(line transcriptSelectableLine, base lipgloss.Style) string {


### PR DESCRIPTION
Summary:
- adds a lightweight in-house assistant Markdown renderer for TUI transcript text
- renders Markdown during streaming and after completion, including inline bold, code/emphasis marker cleanup, and pipe tables
- improves table readability with styled headers/separators and adaptive body row rules for wrapped tables
- keeps transcript selection/copy metadata plain so ANSI styling does not leak into copied text

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant responses now render full Markdown in-terminal (tables, headings, lists, blockquotes, bold, code) for final, streaming/interim and selectable rows; plain-text variants strip control markers for selection and plain views.
* **Bug Fixes**
  * Streaming cursor placement adjusted to fit available width without corrupting interim display.
* **Tests**
  * Extensive markdown and streaming tests added; one obsolete final-answer rail test removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->