### PR TITLE
feat: add MCP manager UX

### DIFF
--- a/internal/agenteval/benchmark_test.go
+++ b/internal/agenteval/benchmark_test.go
@@ -453,12 +453,13 @@ func TestHarnessTimeoutCancelsBlockedAgent(t *testing.T) {
 		}},
 	}
 
-	// The timeout is far longer than materialization of the small fixture, so
-	// the agent is always reached; it then blocks until the deadline fires.
+	// The timeout is longer than materialization of the small fixture even on
+	// slower Windows CI runners, so the agent is reached before it blocks until
+	// the deadline fires.
 	report := harness.Run(context.Background(), suitePath, suite, BenchmarkInput{
 		TaskID:   "document-stream-json-verify-events",
 		WorkRoot: t.TempDir(),
-		Timeout:  2 * time.Second,
+		Timeout:  10 * time.Second,
 	})
 
 	if !agentReached {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -449,7 +449,9 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	}
 	mcpTokenStore, err := deps.newMCPTokenStore()
 	if err != nil {
-		return writeAppError(stderr, "failed to initialize MCP OAuth tokens: "+err.Error(), 1)
+		_, _ = fmt.Fprintf(stderr, "[zero] warning: failed to initialize MCP OAuth tokens: %s\n", err)
+		mcpTokenStore = nil
+		err = nil
 	}
 	mcpRuntime := mcpToolRuntime(noopMCPRuntime{})
 	if len(mcpConfig.Servers) > 0 {
@@ -459,6 +461,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		})
 	}
 	if err != nil {
+		closeMCPRuntime(stderr, mcpRuntime)
 		return writeAppError(stderr, err.Error(), 1)
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -439,7 +439,25 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		return writeAppError(stderr, "failed to initialize specialist tools: "+err.Error(), 1)
 	}
 	defer closeSpecialistRuntime(stderr, specialistRuntime)
-	mcpRuntime, err := registerMCPToolsForWorkspace(context.Background(), workspaceRoot, registry, deps, mcp.AutonomyLow)
+	mcpConfig, err := deps.resolveMCPConfig(workspaceRoot)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), 1)
+	}
+	mcpPermissionStore, err := deps.newMCPStore()
+	if err != nil {
+		return writeAppError(stderr, "failed to initialize MCP permissions: "+err.Error(), 1)
+	}
+	mcpTokenStore, err := deps.newMCPTokenStore()
+	if err != nil {
+		return writeAppError(stderr, "failed to initialize MCP OAuth tokens: "+err.Error(), 1)
+	}
+	mcpRuntime := mcpToolRuntime(noopMCPRuntime{})
+	if len(mcpConfig.Servers) > 0 {
+		mcpRuntime, err = deps.registerMCPTools(context.Background(), registry, mcpConfig, mcp.RegisterOptions{
+			PermissionStore: mcpPermissionStore,
+			Autonomy:        mcp.AutonomyLow,
+		})
+	}
 	if err != nil {
 		return writeAppError(stderr, err.Error(), 1)
 	}
@@ -482,17 +500,20 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		Scope:         scope,
 	})
 	return deps.runTUI(context.Background(), tui.Options{
-		Cwd:             workspaceRoot,
-		UserConfigPath:  userConfigPath,
-		ProviderName:    resolved.Provider.Name,
-		ModelName:       resolved.Provider.Model,
-		ProviderProfile: resolved.Provider,
-		FavoriteModels:  resolved.Preferences.FavoriteModels,
-		Provider:        provider,
-		NewProvider:     deps.newProvider,
-		Registry:        registry,
-		SessionStore:    deps.newSessionStore(),
-		SandboxStore:    sandboxStore,
+		Cwd:                workspaceRoot,
+		UserConfigPath:     userConfigPath,
+		ProviderName:       resolved.Provider.Name,
+		ModelName:          resolved.Provider.Model,
+		ProviderProfile:    resolved.Provider,
+		FavoriteModels:     resolved.Preferences.FavoriteModels,
+		Provider:           provider,
+		NewProvider:        deps.newProvider,
+		Registry:           registry,
+		SessionStore:       deps.newSessionStore(),
+		SandboxStore:       sandboxStore,
+		MCPConfig:          mcpConfig,
+		MCPPermissionStore: mcpPermissionStore,
+		MCPTokenStore:      mcpTokenStore,
 		AgentOptions: agent.Options{
 			MaxTurns:       resolved.MaxTurns,
 			Registry:       registry,

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -519,9 +519,12 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		MCPConfig:          mcpConfig,
 		MCPPermissionStore: mcpPermissionStore,
 		MCPTokenStore:      mcpTokenStore,
-		MCPCommand: func(args []string) tui.MCPCommandResult {
+		MCPCommand: func(ctx context.Context, args []string) tui.MCPCommandResult {
+			if ctx == nil {
+				ctx = context.Background()
+			}
 			var stdout, stderr bytes.Buffer
-			exitCode := runMCP(args, &stdout, &stderr, deps)
+			exitCode := runMCPWithContext(ctx, args, &stdout, &stderr, deps)
 			nextConfig := lastKnownMCPConfig
 			if refreshed, err := deps.resolveMCPConfig(workspaceRoot); err == nil {
 				lastKnownMCPConfig = refreshed

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -503,6 +503,7 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		Backend:       deps.selectSandboxBackend(sandbox.BackendOptions{}),
 		Scope:         scope,
 	})
+	lastKnownMCPConfig := mcpConfig
 	return deps.runTUI(context.Background(), tui.Options{
 		Cwd:                workspaceRoot,
 		UserConfigPath:     userConfigPath,
@@ -521,8 +522,9 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		MCPCommand: func(args []string) tui.MCPCommandResult {
 			var stdout, stderr bytes.Buffer
 			exitCode := runMCP(args, &stdout, &stderr, deps)
-			nextConfig := mcpConfig
+			nextConfig := lastKnownMCPConfig
 			if refreshed, err := deps.resolveMCPConfig(workspaceRoot); err == nil {
+				lastKnownMCPConfig = refreshed
 				nextConfig = refreshed
 			}
 			return tui.MCPCommandResult{

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -517,6 +518,20 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		MCPConfig:          mcpConfig,
 		MCPPermissionStore: mcpPermissionStore,
 		MCPTokenStore:      mcpTokenStore,
+		MCPCommand: func(args []string) tui.MCPCommandResult {
+			var stdout, stderr bytes.Buffer
+			exitCode := runMCP(args, &stdout, &stderr, deps)
+			nextConfig := mcpConfig
+			if refreshed, err := deps.resolveMCPConfig(workspaceRoot); err == nil {
+				nextConfig = refreshed
+			}
+			return tui.MCPCommandResult{
+				Config:   nextConfig,
+				Output:   strings.TrimSpace(stdout.String()),
+				Error:    strings.TrimSpace(stderr.String()),
+				ExitCode: exitCode,
+			}
+		},
 		AgentOptions: agent.Options{
 			MaxTurns:       resolved.MaxTurns,
 			Registry:       registry,

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
@@ -117,6 +118,86 @@ func TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured(t *tes
 	}
 	assertCoreRegistry(t, launchedOptions.Registry)
 	assertAgentOptions(t, launchedOptions, 12, agent.PermissionModeAsk)
+}
+
+func TestRunNoArgsLaunchesTUIWithMCPState(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	mcpConfig := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}}
+	permissionStore, err := mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json")})
+	if err != nil {
+		t.Fatalf("NewPermissionStore() error = %v", err)
+	}
+	tokenStore, err := mcp.NewTokenStore(mcp.TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-oauth.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	var launchedOptions tui.Options
+	var registeredConfig config.MCPConfig
+	var registeredStore *mcp.PermissionStore
+	runtimeClosed := false
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		userConfigPath: func() (string, error) {
+			return userConfigPath, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return mcpConfig, nil
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return permissionStore, nil
+		},
+		newMCPTokenStore: func() (*mcp.TokenStore, error) {
+			return tokenStore, nil
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			registeredConfig = cfg
+			registeredStore = options.PermissionStore
+			return closeFunc(func() error {
+				runtimeClosed = true
+				return nil
+			}), nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if _, ok := registeredConfig.Servers["docs"]; !ok {
+		t.Fatalf("registered MCP config = %#v, want docs server", registeredConfig.Servers)
+	}
+	if registeredStore != permissionStore {
+		t.Fatalf("registered PermissionStore = %#v, want launched store %#v", registeredStore, permissionStore)
+	}
+	if _, ok := launchedOptions.MCPConfig.Servers["docs"]; !ok {
+		t.Fatalf("launched MCP config = %#v, want docs server", launchedOptions.MCPConfig.Servers)
+	}
+	if launchedOptions.MCPPermissionStore != permissionStore {
+		t.Fatalf("launched MCPPermissionStore = %#v, want %#v", launchedOptions.MCPPermissionStore, permissionStore)
+	}
+	if launchedOptions.MCPTokenStore != tokenStore {
+		t.Fatalf("launched MCPTokenStore = %#v, want %#v", launchedOptions.MCPTokenStore, tokenStore)
+	}
+	if !runtimeClosed {
+		t.Fatal("MCP runtime was not closed after TUI exits")
+	}
 }
 
 func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -247,13 +247,17 @@ func TestTUIMCPCommandUsesLastGoodConfigOnRefreshError(t *testing.T) {
 			return closeFunc(func() error { return nil }), nil
 		},
 		runTUI: func(ctx context.Context, options tui.Options) int {
-			first := options.MCPCommand([]string{"list"})
+			first := options.MCPCommand(ctx, []string{"list"})
 			if _, ok := first.Config.Servers["github"]; !ok {
 				t.Fatalf("first MCP result config = %#v, want refreshed github server", first.Config.Servers)
 			}
-			second := options.MCPCommand([]string{"list"})
+			second := options.MCPCommand(ctx, []string{"list"})
 			if _, ok := second.Config.Servers["github"]; !ok {
-				t.Fatalf("second MCP result config = %#v, want last known github server after refresh error", second.Config.Servers)
+				t.Fatalf("second MCP result config = %#v, want refreshed github server", second.Config.Servers)
+			}
+			third := options.MCPCommand(ctx, []string{"list"})
+			if _, ok := third.Config.Servers["github"]; !ok {
+				t.Fatalf("third MCP result config = %#v, want last known github server after refresh error", third.Config.Servers)
 			}
 			return 0
 		},

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -200,6 +200,112 @@ func TestRunNoArgsLaunchesTUIWithMCPState(t *testing.T) {
 	}
 }
 
+func TestRunNoArgsClosesPartialMCPRuntimeWhenRegistrationFails(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	permissionStore, err := mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json")})
+	if err != nil {
+		t.Fatalf("NewPermissionStore() error = %v", err)
+	}
+	tokenStore, err := mcp.NewTokenStore(mcp.TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-oauth.json")})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	runtimeClosed := false
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		userConfigPath: func() (string, error) {
+			return userConfigPath, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"docs": {Type: "stdio", Command: "docs-mcp"},
+			}}, nil
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return permissionStore, nil
+		},
+		newMCPTokenStore: func() (*mcp.TokenStore, error) {
+			return tokenStore, nil
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return closeFunc(func() error {
+				runtimeClosed = true
+				return nil
+			}), errors.New("register mcp tools failed")
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			t.Fatal("TUI should not launch after MCP registration fails")
+			return 0
+		},
+	})
+
+	if exitCode == 0 {
+		t.Fatalf("exitCode = %d, want failure", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "register mcp tools failed") {
+		t.Fatalf("stderr missing registration error: %s", stderr.String())
+	}
+	if !runtimeClosed {
+		t.Fatal("partial MCP runtime was not closed after registration error")
+	}
+}
+
+func TestRunNoArgsSoftFailsMCPTokenStoreInit(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	permissionStore, err := mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json")})
+	if err != nil {
+		t.Fatalf("NewPermissionStore() error = %v", err)
+	}
+	var launchedOptions tui.Options
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		userConfigPath: func() (string, error) {
+			return userConfigPath, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{}, nil
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return permissionStore, nil
+		},
+		newMCPTokenStore: func() (*mcp.TokenStore, error) {
+			return nil, errors.New("token store unreadable")
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			launchedOptions = options
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if launchedOptions.MCPTokenStore != nil {
+		t.Fatalf("MCPTokenStore = %#v, want nil after soft failure", launchedOptions.MCPTokenStore)
+	}
+	if !strings.Contains(stderr.String(), "warning: failed to initialize MCP OAuth tokens") {
+		t.Fatalf("stderr missing soft-failure warning: %s", stderr.String())
+	}
+}
+
 func TestRunNoArgsLaunchesTUIWithResolvedProviderMetadata(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -203,6 +203,67 @@ func TestRunNoArgsLaunchesTUIWithMCPState(t *testing.T) {
 	}
 }
 
+func TestTUIMCPCommandUsesLastGoodConfigOnRefreshError(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cwd := t.TempDir()
+	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	startupConfig := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {Type: "stdio", Command: "docs-mcp"},
+	}}
+	refreshedConfig := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"github": {Type: "http", URL: "https://mcp.github.example"},
+	}}
+	resolveCalls := 0
+
+	exitCode := runWithDeps([]string{}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) {
+			return cwd, nil
+		},
+		userConfigPath: func() (string, error) {
+			return userConfigPath, nil
+		},
+		resolveConfig: func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{MaxTurns: 8}, nil
+		},
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			resolveCalls++
+			switch resolveCalls {
+			case 1:
+				return startupConfig, nil
+			case 2, 3:
+				return refreshedConfig, nil
+			default:
+				return config.MCPConfig{}, errors.New("config temporarily unavailable")
+			}
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json")})
+		},
+		newMCPTokenStore: func() (*mcp.TokenStore, error) {
+			return mcp.NewTokenStore(mcp.TokenStoreOptions{FilePath: filepath.Join(t.TempDir(), "mcp-oauth.json")})
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return closeFunc(func() error { return nil }), nil
+		},
+		runTUI: func(ctx context.Context, options tui.Options) int {
+			first := options.MCPCommand([]string{"list"})
+			if _, ok := first.Config.Servers["github"]; !ok {
+				t.Fatalf("first MCP result config = %#v, want refreshed github server", first.Config.Servers)
+			}
+			second := options.MCPCommand([]string{"list"})
+			if _, ok := second.Config.Servers["github"]; !ok {
+				t.Fatalf("second MCP result config = %#v, want last known github server after refresh error", second.Config.Servers)
+			}
+			return 0
+		},
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+}
+
 func TestRunNoArgsClosesPartialMCPRuntimeWhenRegistrationFails(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -195,6 +195,9 @@ func TestRunNoArgsLaunchesTUIWithMCPState(t *testing.T) {
 	if launchedOptions.MCPTokenStore != tokenStore {
 		t.Fatalf("launched MCPTokenStore = %#v, want %#v", launchedOptions.MCPTokenStore, tokenStore)
 	}
+	if launchedOptions.MCPCommand == nil {
+		t.Fatal("launched MCPCommand runner is nil")
+	}
 	if !runtimeClosed {
 		t.Fatal("MCP runtime was not closed after TUI exits")
 	}

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -135,6 +135,13 @@ func runHooks(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) i
 }
 
 func runMCP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	return runMCPWithContext(context.Background(), args, stdout, stderr, deps)
+}
+
+func runMCPWithContext(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if len(args) == 0 {
 		return writeExecUsageError(stderr, "mcp subcommand required. Use `zero mcp permissions list`.")
 	}
@@ -153,11 +160,11 @@ func runMCP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 	case "disable":
 		return runMCPToggle(args[1:], stdout, stderr, deps, true)
 	case "check":
-		return runMCPCheck(args[1:], stdout, stderr, deps)
+		return runMCPCheck(ctx, args[1:], stdout, stderr, deps)
 	case "permissions":
 		return runMCPPermissions(args[1:], stdout, stderr, deps)
 	case "tools":
-		return runMCPTools(args[1:], stdout, stderr, deps)
+		return runMCPTools(ctx, args[1:], stdout, stderr, deps)
 	case "oauth":
 		return runMCPOAuth(args[1:], stdout, stderr, deps)
 	case "list":
@@ -183,7 +190,7 @@ func runMCPLegacyList(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		if options.json {
 			forwarded = append(forwarded, "--json")
 		}
-		return runMCPTools(forwarded, stdout, stderr, deps)
+		return runMCPTools(context.Background(), forwarded, stdout, stderr, deps)
 	}
 
 	cwd, err := deps.getwd()
@@ -210,7 +217,7 @@ func runMCPLegacyList(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		}
 		return exitSuccess
 	}
-	if _, err := fmt.Fprintln(stdout, formatMCPServerList(cfg.Servers)); err != nil {
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatMCPServerList(cfg.Servers), redaction.Options{})); err != nil {
 		return exitCrash
 	}
 	return exitSuccess
@@ -240,7 +247,10 @@ func redactMCPServerConfigs(servers map[string]config.MCPServerConfig) map[strin
 	return redacted
 }
 
-func runMCPTools(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+func runMCPTools(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if len(args) == 0 {
 		return writeExecUsageError(stderr, "mcp tools subcommand required. Use `zero mcp tools list`.")
 	}
@@ -268,7 +278,7 @@ func runMCPTools(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 			return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), exitCrash)
 		}
 		registry := tools.NewRegistry()
-		runtime, err := registerMCPToolsForWorkspace(context.Background(), cwd, registry, deps, mcp.AutonomyLow)
+		runtime, err := registerMCPToolsForWorkspace(ctx, cwd, registry, deps, mcp.AutonomyLow)
 		if err != nil {
 			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 		}

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -144,6 +144,16 @@ func runMCP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 			return exitCrash
 		}
 		return exitSuccess
+	case "add":
+		return runMCPAdd(args[1:], stdout, stderr, deps)
+	case "remove", "rm":
+		return runMCPRemove(args[1:], stdout, stderr, deps)
+	case "enable":
+		return runMCPToggle(args[1:], stdout, stderr, deps, false)
+	case "disable":
+		return runMCPToggle(args[1:], stdout, stderr, deps, true)
+	case "check":
+		return runMCPCheck(args[1:], stdout, stderr, deps)
 	case "permissions":
 		return runMCPPermissions(args[1:], stdout, stderr, deps)
 	case "tools":
@@ -563,10 +573,15 @@ func writeMCPHelp(w io.Writer) error {
   zero mcp <command>
 
 Commands:
-  list           List configured MCP servers, or tools with --tools
-  oauth          Manage OAuth credentials for remote MCP servers
-  permissions    Manage persistent MCP tool permissions
-  tools          Inspect configured MCP tools
+  add <server>      Add or update an MCP server in user config
+  remove <server>   Remove an MCP server from user config
+  enable <server>   Enable a user-configured MCP server
+  disable <server>  Disable a user-configured MCP server
+  check <server>    Connect to one MCP server and list its tools
+  list              List configured MCP servers, or tools with --tools
+  oauth             Manage OAuth credentials for remote MCP servers
+  permissions       Manage persistent MCP tool permissions
+  tools             Inspect configured MCP tools
 `)
 	return err
 }

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -278,11 +278,11 @@ func runMCPTools(ctx context.Context, args []string, stdout io.Writer, stderr io
 			return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), exitCrash)
 		}
 		registry := tools.NewRegistry()
-		runtime, err := registerMCPToolsForWorkspace(ctx, cwd, registry, deps, mcp.AutonomyLow)
+		mcpRuntime, err := registerMCPToolsForWorkspace(ctx, cwd, registry, deps, mcp.AutonomyLow)
 		if err != nil {
 			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 		}
-		defer closeMCPRuntime(stderr, runtime)
+		defer closeMCPRuntime(stderr, mcpRuntime)
 		items := mcpToolList(registry)
 		if options.json {
 			payload := struct {

--- a/internal/cli/extensions.go
+++ b/internal/cli/extensions.go
@@ -234,6 +234,7 @@ func redactMCPServerConfigs(servers map[string]config.MCPServerConfig) map[strin
 				clone.Headers[key] = "[REDACTED]"
 			}
 		}
+		clone.URL = redactMCPURL(clone.URL, "[REDACTED]")
 		redacted[name] = clone
 	}
 	return redacted

--- a/internal/cli/mcp_commands_test.go
+++ b/internal/cli/mcp_commands_test.go
@@ -100,6 +100,45 @@ func TestRunMCPAddHTTPPreservesConfigAndRedactsHeader(t *testing.T) {
 	}
 }
 
+func TestRunMCPAddHTTPAcceptsColonHeader(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "remote", "--url", "https://remote.example/mcp", "--header", "Authorization: Bearer secret-header"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	remote := cfg.MCP.Servers["remote"]
+	if got := remote.Headers["Authorization"]; got != "Bearer secret-header" {
+		t.Fatalf("Authorization header = %q, want persisted Bearer secret-header", got)
+	}
+}
+
+func TestRunMCPAddDisabledHTTPAllowsInvalidURL(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "draft", "--type", "http", "--url", "sxas", "--disabled"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	draft := cfg.MCP.Servers["draft"]
+	if !draft.Disabled {
+		t.Fatalf("draft server Disabled = false, want true: %#v", draft)
+	}
+	if draft.Type != "http" || draft.URL != "sxas" {
+		t.Fatalf("draft server = %#v, want disabled http with raw invalid URL", draft)
+	}
+}
+
 func TestRunMCPAddUpdatePreservesUnknownServerFields(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	writeMCPCommandRawConfig(t, configPath, `{

--- a/internal/cli/mcp_commands_test.go
+++ b/internal/cli/mcp_commands_test.go
@@ -147,6 +147,99 @@ func TestRunMCPAddUpdatePreservesUnknownServerFields(t *testing.T) {
 	}
 }
 
+func TestRunMCPAddUpdatePreservesExistingOAuth(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandRawConfig(t, configPath, `{
+  "mcp": {
+    "servers": {
+      "remote": {
+        "type": "http",
+        "url": "https://old.example/mcp",
+        "auth": "oauth",
+        "oauth": {
+          "clientID": "client-123",
+          "scopes": ["docs:read"]
+        },
+        "futureServer": {"keep": true}
+      }
+    }
+  }
+}
+`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "remote", "--url", "https://new.example/mcp", "--json"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	remote := cfg.MCP.Servers["remote"]
+	if remote.OAuth == nil || remote.OAuth.ClientID != "client-123" {
+		t.Fatalf("OAuth config was not preserved: %#v", remote.OAuth)
+	}
+	if remote.Auth != "oauth" {
+		t.Fatalf("Auth = %q, want preserved oauth", remote.Auth)
+	}
+	if got := remote.URL; got != "https://new.example/mcp" {
+		t.Fatalf("URL = %q, want updated URL", got)
+	}
+	raw := readMCPCommandRawConfig(t, configPath)
+	remoteRaw := rawMCPCommandObject(t, rawMCPCommandObject(t, rawMCPCommandObject(t, raw["mcp"])["servers"])["remote"])
+	if _, ok := remoteRaw["futureServer"]; !ok {
+		t.Fatalf("unknown server field was not preserved: %s", mustMarshalMCPCommandJSON(t, remoteRaw))
+	}
+	if _, ok := remoteRaw["oauth"]; !ok {
+		t.Fatalf("oauth raw field was not preserved: %s", mustMarshalMCPCommandJSON(t, remoteRaw))
+	}
+	if got := string(remoteRaw["auth"]); got != `"oauth"` {
+		t.Fatalf("auth raw = %s, want preserved oauth in %s", got, mustMarshalMCPCommandJSON(t, remoteRaw))
+	}
+}
+
+func TestRunMCPAddMigratesLegacyServerRawFields(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandRawConfig(t, configPath, `{
+  "mcpServers": {
+    "legacy": {
+      "type": "http",
+      "url": "https://old.example/mcp",
+      "auth": "oauth",
+      "oauth": {"clientID": "legacy-client"},
+      "futureLegacy": {"keep": true}
+    }
+  }
+}
+`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "legacy", "--url", "https://new.example/mcp", "--json"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	raw := readMCPCommandRawConfig(t, configPath)
+	if _, ok := raw["mcpServers"]; ok {
+		t.Fatalf("legacy mcpServers entry was not migrated: %s", mustMarshalMCPCommandJSON(t, raw))
+	}
+	legacyRaw := rawMCPCommandObject(t, rawMCPCommandObject(t, rawMCPCommandObject(t, raw["mcp"])["servers"])["legacy"])
+	for _, key := range []string{"oauth", "futureLegacy"} {
+		if _, ok := legacyRaw[key]; !ok {
+			t.Fatalf("legacy raw field %q was not preserved: %s", key, mustMarshalMCPCommandJSON(t, legacyRaw))
+		}
+	}
+	if got := string(legacyRaw["auth"]); got != `"oauth"` {
+		t.Fatalf("auth raw = %s, want preserved oauth in %s", got, mustMarshalMCPCommandJSON(t, legacyRaw))
+	}
+	if got := string(legacyRaw["url"]); got != `"https://new.example/mcp"` {
+		t.Fatalf("url raw = %s, want updated URL in %s", got, mustMarshalMCPCommandJSON(t, legacyRaw))
+	}
+}
+
 func TestRunMCPRemoveDeletesUserConfigServer(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	writeMCPCommandConfig(t, configPath, config.FileConfig{

--- a/internal/cli/mcp_commands_test.go
+++ b/internal/cli/mcp_commands_test.go
@@ -210,6 +210,81 @@ func TestRunMCPToggleEnableDisablePreservesConfig(t *testing.T) {
 	}
 }
 
+func TestRunMCPToggleMigratesLegacyServerAliases(t *testing.T) {
+	cases := []struct {
+		name      string
+		aliasName string
+	}{
+		{name: "camel legacy alias", aliasName: "mcpServers"},
+		{name: "snake legacy alias", aliasName: "mcp_servers"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+			writeMCPCommandRawConfig(t, configPath, `{
+  "activeProvider": "fast",
+  "`+tc.aliasName+`": {
+    "docs": {
+      "type": "stdio",
+      "command": "docs-mcp",
+      "futureServer": "keep"
+    }
+  }
+}
+`)
+
+			var disableOut, disableErr bytes.Buffer
+			disableCode := runWithDeps([]string{"mcp", "disable", "docs", "--json"}, &disableOut, &disableErr, appDeps{
+				userConfigPath: func() (string, error) { return configPath, nil },
+			})
+			if disableCode != exitSuccess {
+				t.Fatalf("disable exitCode = %d stdout=%s stderr=%s", disableCode, disableOut.String(), disableErr.String())
+			}
+			var disablePayload struct {
+				ServerName string `json:"serverName"`
+				Disabled   bool   `json:"disabled"`
+				Changed    bool   `json:"changed"`
+			}
+			if err := json.Unmarshal(disableOut.Bytes(), &disablePayload); err != nil {
+				t.Fatalf("decode disable JSON: %v\n%s", err, disableOut.String())
+			}
+			if disablePayload.ServerName != "docs" || !disablePayload.Disabled || !disablePayload.Changed {
+				t.Fatalf("disable payload = %#v, want docs disabled changed", disablePayload)
+			}
+
+			raw := readMCPCommandRawConfig(t, configPath)
+			if _, ok := raw[tc.aliasName]; ok {
+				t.Fatalf("legacy alias %s should be migrated away: %s", tc.aliasName, mustMarshalMCPCommandJSON(t, raw))
+			}
+			mcpRaw := rawMCPCommandObject(t, raw["mcp"])
+			serversRaw := rawMCPCommandObject(t, mcpRaw["servers"])
+			docsRaw := rawMCPCommandObject(t, serversRaw["docs"])
+			if got := string(docsRaw["disabled"]); got != "true" {
+				t.Fatalf("disabled raw = %s, want true in canonical mcp.servers: %s", got, mustMarshalMCPCommandJSON(t, docsRaw))
+			}
+			if _, ok := docsRaw["futureServer"]; !ok {
+				t.Fatalf("server unknown field was not preserved during migration: %s", mustMarshalMCPCommandJSON(t, docsRaw))
+			}
+
+			var enableOut, enableErr bytes.Buffer
+			enableCode := runWithDeps([]string{"mcp", "enable", "docs", "--json"}, &enableOut, &enableErr, appDeps{
+				userConfigPath: func() (string, error) { return configPath, nil },
+			})
+			if enableCode != exitSuccess {
+				t.Fatalf("enable exitCode = %d stdout=%s stderr=%s", enableCode, enableOut.String(), enableErr.String())
+			}
+			raw = readMCPCommandRawConfig(t, configPath)
+			mcpRaw = rawMCPCommandObject(t, raw["mcp"])
+			serversRaw = rawMCPCommandObject(t, mcpRaw["servers"])
+			docsRaw = rawMCPCommandObject(t, serversRaw["docs"])
+			if _, ok := docsRaw["disabled"]; ok {
+				t.Fatalf("enable should remove disabled=false noise after migration: %s", mustMarshalMCPCommandJSON(t, docsRaw))
+			}
+		})
+	}
+}
+
 func TestRunMCPRemovePreservesUnrelatedConfigFields(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	writeMCPCommandRawConfig(t, configPath, `{
@@ -256,6 +331,49 @@ func TestRunMCPRemovePreservesUnrelatedConfigFields(t *testing.T) {
 	otherRaw := rawMCPCommandObject(t, serversRaw["other"])
 	if _, ok := otherRaw["futureServer"]; !ok {
 		t.Fatalf("unrelated server unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, otherRaw))
+	}
+}
+
+func TestRunMCPListRedactsURLCredentialsAndSensitiveQueryParams(t *testing.T) {
+	cwd := t.TempDir()
+	serverURL := "https://user:password@remote.example/mcp?access_token=secret-token&api_key=secret-key&safe=value"
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"remote": {Type: "http", URL: serverURL},
+			}}, nil
+		},
+	}
+
+	for _, args := range [][]string{
+		{"mcp", "list"},
+		{"mcp", "list", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			exitCode := runWithDeps(args, &stdout, &stderr, deps)
+
+			if exitCode != exitSuccess {
+				t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+			}
+			output := stdout.String()
+			for _, leaked := range []string{"user:password", "secret-token", "secret-key", "access_token=secret-token", "api_key=secret-key"} {
+				if strings.Contains(output, leaked) {
+					t.Fatalf("mcp list leaked %q in output:\n%s", leaked, output)
+				}
+			}
+			if !strings.Contains(output, "remote.example") {
+				t.Fatalf("mcp list dropped non-sensitive URL context:\n%s", output)
+			}
+			if !strings.Contains(output, "[REDACTED]") {
+				t.Fatalf("mcp list did not mark redacted URL parts:\n%s", output)
+			}
+		})
 	}
 }
 

--- a/internal/cli/mcp_commands_test.go
+++ b/internal/cli/mcp_commands_test.go
@@ -516,6 +516,7 @@ func TestRunMCPRemovePreservesUnrelatedConfigFields(t *testing.T) {
 func TestRunMCPListRedactsURLCredentialsAndSensitiveQueryParams(t *testing.T) {
 	cwd := t.TempDir()
 	serverURL := "https://user:password@remote.example/mcp?access_token=secret-token&api_key=secret-key&safe=value#access_token=fragment-secret"
+	commandSecret := "sk-proj-" + strings.Repeat("a", 24)
 	deps := appDeps{
 		getwd: func() (string, error) { return cwd, nil },
 		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
@@ -524,6 +525,7 @@ func TestRunMCPListRedactsURLCredentialsAndSensitiveQueryParams(t *testing.T) {
 			}
 			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
 				"remote": {Type: "http", URL: serverURL},
+				"stdio":  {Type: "stdio", Command: commandSecret},
 			}}, nil
 		},
 	}
@@ -541,7 +543,7 @@ func TestRunMCPListRedactsURLCredentialsAndSensitiveQueryParams(t *testing.T) {
 				t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
 			}
 			output := stdout.String()
-			for _, leaked := range []string{"user:password", "secret-token", "secret-key", "fragment-secret", "access_token=secret-token", "api_key=secret-key", "access_token=fragment-secret"} {
+			for _, leaked := range []string{"user:password", "secret-token", "secret-key", "fragment-secret", "access_token=secret-token", "api_key=secret-key", "access_token=fragment-secret", commandSecret} {
 				if strings.Contains(output, leaked) {
 					t.Fatalf("mcp list leaked %q in output:\n%s", leaked, output)
 				}

--- a/internal/cli/mcp_commands_test.go
+++ b/internal/cli/mcp_commands_test.go
@@ -1,0 +1,462 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestRunMCPAddStdioPersistsUserConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "docs", "--env", "DOCS_TOKEN=secret", "--", "docs-mcp", "--port", "123"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	server, ok := cfg.MCP.Servers["docs"]
+	if !ok {
+		t.Fatalf("docs server was not persisted: %#v", cfg.MCP.Servers)
+	}
+	if server.Type != "stdio" || server.Command != "docs-mcp" {
+		t.Fatalf("server = %#v, want stdio docs-mcp", server)
+	}
+	if !reflect.DeepEqual(server.Args, []string{"--port", "123"}) {
+		t.Fatalf("Args = %#v, want --port 123", server.Args)
+	}
+	if got := server.Env["DOCS_TOKEN"]; got != "secret" {
+		t.Fatalf("Env[DOCS_TOKEN] = %q, want secret", got)
+	}
+	if strings.Contains(stdout.String(), "secret") {
+		t.Fatalf("stdout leaked env value: %s", stdout.String())
+	}
+}
+
+func TestRunMCPAddHTTPPreservesConfigAndRedactsHeader(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandRawConfig(t, configPath, `{
+  "activeProvider": "fast",
+  "futureTop": {"keep": true},
+  "mcp": {
+    "futureMCP": "keep",
+    "servers": {
+      "other": {
+        "type": "http",
+        "url": "https://other.example/mcp",
+        "futureServer": "keep"
+      }
+    }
+  }
+}
+`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "remote", "--url", "https://remote.example/mcp", "--header", "Authorization=Bearer secret-header", "--json"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "secret-header") {
+		t.Fatalf("stdout leaked header value: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "[REDACTED]") {
+		t.Fatalf("stdout did not redact header value: %s", stdout.String())
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	remote := cfg.MCP.Servers["remote"]
+	if remote.Type != "http" || remote.URL != "https://remote.example/mcp" {
+		t.Fatalf("remote server = %#v, want default http type with URL", remote)
+	}
+	if got := remote.Headers["Authorization"]; got != "Bearer secret-header" {
+		t.Fatalf("Authorization header = %q, want persisted secret", got)
+	}
+	raw := readMCPCommandRawConfig(t, configPath)
+	if _, ok := raw["futureTop"]; !ok {
+		t.Fatalf("top-level unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, raw))
+	}
+	mcpRaw := rawMCPCommandObject(t, raw["mcp"])
+	if _, ok := mcpRaw["futureMCP"]; !ok {
+		t.Fatalf("mcp unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, mcpRaw))
+	}
+	serversRaw := rawMCPCommandObject(t, mcpRaw["servers"])
+	otherRaw := rawMCPCommandObject(t, serversRaw["other"])
+	if _, ok := otherRaw["futureServer"]; !ok {
+		t.Fatalf("unrelated server unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, otherRaw))
+	}
+}
+
+func TestRunMCPRemoveDeletesUserConfigServer(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandConfig(t, configPath, config.FileConfig{
+		MCP: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"docs":  {Type: "stdio", Command: "docs-mcp"},
+			"other": {Type: "http", URL: "https://example.com/mcp"},
+		}},
+	})
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "remove", "docs", "--json"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	var payload struct {
+		ServerName string `json:"serverName"`
+		Removed    bool   `json:"removed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.ServerName != "docs" || !payload.Removed {
+		t.Fatalf("payload = %#v, want docs removed", payload)
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	if _, ok := cfg.MCP.Servers["docs"]; ok {
+		t.Fatalf("docs server still present: %#v", cfg.MCP.Servers)
+	}
+	if _, ok := cfg.MCP.Servers["other"]; !ok {
+		t.Fatalf("remove dropped unrelated server: %#v", cfg.MCP.Servers)
+	}
+}
+
+func TestRunMCPToggleEnableDisablePreservesConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandRawConfig(t, configPath, `{
+  "activeProvider": "fast",
+  "mcp": {
+    "futureMCP": "keep",
+    "servers": {
+      "docs": {
+        "type": "stdio",
+        "command": "docs-mcp",
+        "futureServer": "keep"
+      }
+    }
+  }
+}
+`)
+
+	var disableOut, disableErr bytes.Buffer
+	disableCode := runWithDeps([]string{"mcp", "disable", "docs", "--json"}, &disableOut, &disableErr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if disableCode != exitSuccess {
+		t.Fatalf("disable exitCode = %d stderr=%s", disableCode, disableErr.String())
+	}
+	var disablePayload struct {
+		ServerName string `json:"serverName"`
+		Disabled   bool   `json:"disabled"`
+		Changed    bool   `json:"changed"`
+	}
+	if err := json.Unmarshal(disableOut.Bytes(), &disablePayload); err != nil {
+		t.Fatalf("decode disable JSON: %v\n%s", err, disableOut.String())
+	}
+	if disablePayload.ServerName != "docs" || !disablePayload.Disabled || !disablePayload.Changed {
+		t.Fatalf("disable payload = %#v, want docs disabled changed", disablePayload)
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	if !cfg.MCP.Servers["docs"].Disabled {
+		t.Fatalf("server not disabled: %#v", cfg.MCP.Servers["docs"])
+	}
+
+	var enableOut, enableErr bytes.Buffer
+	enableCode := runWithDeps([]string{"mcp", "enable", "docs", "--json"}, &enableOut, &enableErr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if enableCode != exitSuccess {
+		t.Fatalf("enable exitCode = %d stderr=%s", enableCode, enableErr.String())
+	}
+	var enablePayload struct {
+		ServerName string `json:"serverName"`
+		Disabled   bool   `json:"disabled"`
+		Changed    bool   `json:"changed"`
+	}
+	if err := json.Unmarshal(enableOut.Bytes(), &enablePayload); err != nil {
+		t.Fatalf("decode enable JSON: %v\n%s", err, enableOut.String())
+	}
+	if enablePayload.ServerName != "docs" || enablePayload.Disabled || !enablePayload.Changed {
+		t.Fatalf("enable payload = %#v, want docs enabled changed", enablePayload)
+	}
+
+	raw := readMCPCommandRawConfig(t, configPath)
+	mcpRaw := rawMCPCommandObject(t, raw["mcp"])
+	if _, ok := mcpRaw["futureMCP"]; !ok {
+		t.Fatalf("mcp unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, mcpRaw))
+	}
+	serversRaw := rawMCPCommandObject(t, mcpRaw["servers"])
+	docsRaw := rawMCPCommandObject(t, serversRaw["docs"])
+	if _, ok := docsRaw["futureServer"]; !ok {
+		t.Fatalf("server unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, docsRaw))
+	}
+	if _, ok := docsRaw["disabled"]; ok {
+		t.Fatalf("enable should remove disabled=false noise: %s", mustMarshalMCPCommandJSON(t, docsRaw))
+	}
+}
+
+func TestRunMCPRemovePreservesUnrelatedConfigFields(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandRawConfig(t, configPath, `{
+  "activeProvider": "fast",
+  "futureTop": {"keep": true},
+  "mcp": {
+    "futureMCP": "keep",
+    "servers": {
+      "docs": {"type": "stdio", "command": "docs-mcp"},
+      "other": {
+        "type": "http",
+        "url": "https://other.example/mcp",
+        "futureServer": "keep"
+      }
+    }
+  }
+}
+`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "remove", "docs"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	cfg := readMCPCommandConfig(t, configPath)
+	if _, ok := cfg.MCP.Servers["docs"]; ok {
+		t.Fatalf("docs server still present: %#v", cfg.MCP.Servers)
+	}
+	raw := readMCPCommandRawConfig(t, configPath)
+	if _, ok := raw["futureTop"]; !ok {
+		t.Fatalf("top-level unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, raw))
+	}
+	mcpRaw := rawMCPCommandObject(t, raw["mcp"])
+	if _, ok := mcpRaw["futureMCP"]; !ok {
+		t.Fatalf("mcp unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, mcpRaw))
+	}
+	serversRaw := rawMCPCommandObject(t, mcpRaw["servers"])
+	if _, ok := serversRaw["docs"]; ok {
+		t.Fatalf("docs server raw JSON still present: %s", mustMarshalMCPCommandJSON(t, serversRaw))
+	}
+	otherRaw := rawMCPCommandObject(t, serversRaw["other"])
+	if _, ok := otherRaw["futureServer"]; !ok {
+		t.Fatalf("unrelated server unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, otherRaw))
+	}
+}
+
+func TestRunMCPCheckRegistersOnlyRequestedServer(t *testing.T) {
+	cwd := t.TempDir()
+	var registered config.MCPConfig
+	closed := false
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "check", "docs", "--json"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"docs":  {Type: "stdio", Command: "docs-mcp"},
+				"other": {Type: "stdio", Command: "other-mcp"},
+			}}, nil
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "permissions.json")})
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			registered = cfg
+			registry.Register(cliFakeMCPRegistryTool{})
+			return closeFunc(func() error {
+				closed = true
+				return nil
+			}), nil
+		},
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if _, ok := registered.Servers["docs"]; !ok || len(registered.Servers) != 1 {
+		t.Fatalf("registered cfg = %#v, want only docs", registered.Servers)
+	}
+	if !closed {
+		t.Fatal("MCP runtime was not closed")
+	}
+	var payload struct {
+		ServerName string            `json:"serverName"`
+		Status     string            `json:"status"`
+		ToolCount  int               `json:"toolCount"`
+		Tools      []mcpToolListItem `json:"tools"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.ServerName != "docs" || payload.Status != "ok" || payload.ToolCount != 1 || len(payload.Tools) != 1 {
+		t.Fatalf("payload = %#v, want docs ok with one tool", payload)
+	}
+}
+
+func TestRunMCPCheckClosesRuntimeReturnedWithError(t *testing.T) {
+	cwd := t.TempDir()
+	closed := false
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "check", "docs"}, &stdout, &stderr, appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"docs": {Type: "stdio", Command: "docs-mcp"},
+			}}, nil
+		},
+		newMCPStore: func() (*mcp.PermissionStore, error) {
+			return mcp.NewPermissionStore(mcp.StoreOptions{FilePath: filepath.Join(t.TempDir(), "permissions.json")})
+		},
+		registerMCPTools: func(ctx context.Context, registry *tools.Registry, cfg config.MCPConfig, options mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return closeFunc(func() error {
+				closed = true
+				return nil
+			}), os.ErrPermission
+		},
+	})
+
+	if exitCode != exitCrash {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if !closed {
+		t.Fatal("MCP runtime returned with error was not closed")
+	}
+}
+
+func TestRunMCPConfigCommandsReportCommandSpecificUnknownFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "remove", args: []string{"mcp", "remove", "docs", "--bogus"}, want: `unknown mcp remove flag "--bogus"`},
+		{name: "check", args: []string{"mcp", "check", "docs", "--bogus"}, want: `unknown mcp check flag "--bogus"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			exitCode := runWithDeps(tc.args, &stdout, &stderr, appDeps{})
+
+			if exitCode != exitUsage {
+				t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr missing %q:\n%s", tc.want, stderr.String())
+			}
+			if strings.Contains(stderr.String(), "permissions") {
+				t.Fatalf("stderr referenced permissions parser:\n%s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunMCPHelpMentionsConfigCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "--help"}, &stdout, &stderr, appDeps{})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"add <server>", "remove <server>", "enable <server>", "disable <server>", "check <server>", "list", "oauth", "permissions", "tools"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func writeMCPCommandRawConfig(t *testing.T, path string, data string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func writeMCPCommandConfig(t *testing.T, path string, cfg config.FileConfig) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("encode config: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func readMCPCommandConfig(t *testing.T, path string) config.FileConfig {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg config.FileConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config: %v\n%s", err, string(data))
+	}
+	return cfg
+}
+
+func readMCPCommandRawConfig(t *testing.T, path string) map[string]json.RawMessage {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read raw config: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode raw config: %v\n%s", err, string(data))
+	}
+	return raw
+}
+
+func rawMCPCommandObject(t *testing.T, data json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode raw object: %v\n%s", err, string(data))
+	}
+	return raw
+}
+
+func mustMarshalMCPCommandJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return string(data)
+}

--- a/internal/cli/mcp_commands_test.go
+++ b/internal/cli/mcp_commands_test.go
@@ -100,6 +100,53 @@ func TestRunMCPAddHTTPPreservesConfigAndRedactsHeader(t *testing.T) {
 	}
 }
 
+func TestRunMCPAddUpdatePreservesUnknownServerFields(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandRawConfig(t, configPath, `{
+  "mcp": {
+    "servers": {
+      "remote": {
+        "type": "http",
+        "url": "https://old.example/mcp",
+        "headers": {"Authorization": "Bearer old"},
+        "disabled": true,
+        "futureServer": {"keep": true}
+      }
+    }
+  }
+}
+`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{"mcp", "add", "remote", "--url", "https://new.example/mcp", "--header", "X-Api-Key=new-secret", "--json"}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+	}
+	raw := readMCPCommandRawConfig(t, configPath)
+	mcpRaw := rawMCPCommandObject(t, raw["mcp"])
+	serversRaw := rawMCPCommandObject(t, mcpRaw["servers"])
+	remoteRaw := rawMCPCommandObject(t, serversRaw["remote"])
+	if _, ok := remoteRaw["futureServer"]; !ok {
+		t.Fatalf("updated server unknown field was not preserved: %s", mustMarshalMCPCommandJSON(t, remoteRaw))
+	}
+	if got := string(remoteRaw["url"]); got != `"https://new.example/mcp"` {
+		t.Fatalf("url raw = %s, want new URL in %s", got, mustMarshalMCPCommandJSON(t, remoteRaw))
+	}
+	if _, ok := remoteRaw["disabled"]; ok {
+		t.Fatalf("disabled=false noise/stale disabled field should be removed: %s", mustMarshalMCPCommandJSON(t, remoteRaw))
+	}
+	headersRaw := rawMCPCommandObject(t, remoteRaw["headers"])
+	if _, ok := headersRaw["Authorization"]; ok {
+		t.Fatalf("stale Authorization header should not survive update: %s", mustMarshalMCPCommandJSON(t, headersRaw))
+	}
+	if got := string(headersRaw["X-Api-Key"]); got != `"new-secret"` {
+		t.Fatalf("X-Api-Key raw = %s, want persisted new secret in %s", got, mustMarshalMCPCommandJSON(t, headersRaw))
+	}
+}
+
 func TestRunMCPRemoveDeletesUserConfigServer(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	writeMCPCommandConfig(t, configPath, config.FileConfig{
@@ -336,7 +383,7 @@ func TestRunMCPRemovePreservesUnrelatedConfigFields(t *testing.T) {
 
 func TestRunMCPListRedactsURLCredentialsAndSensitiveQueryParams(t *testing.T) {
 	cwd := t.TempDir()
-	serverURL := "https://user:password@remote.example/mcp?access_token=secret-token&api_key=secret-key&safe=value"
+	serverURL := "https://user:password@remote.example/mcp?access_token=secret-token&api_key=secret-key&safe=value#access_token=fragment-secret"
 	deps := appDeps{
 		getwd: func() (string, error) { return cwd, nil },
 		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
@@ -362,7 +409,7 @@ func TestRunMCPListRedactsURLCredentialsAndSensitiveQueryParams(t *testing.T) {
 				t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
 			}
 			output := stdout.String()
-			for _, leaked := range []string{"user:password", "secret-token", "secret-key", "access_token=secret-token", "api_key=secret-key"} {
+			for _, leaked := range []string{"user:password", "secret-token", "secret-key", "fragment-secret", "access_token=secret-token", "api_key=secret-key", "access_token=fragment-secret"} {
 				if strings.Contains(output, leaked) {
 					t.Fatalf("mcp list leaked %q in output:\n%s", leaked, output)
 				}

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -573,7 +573,7 @@ func (cfg *mcpWritableConfig) upsertServer(name string, server config.MCPServerC
 	}
 	_, updated := cfg.file.MCP.Servers[name]
 	cfg.file.MCP.Servers[name] = server
-	data, err := json.Marshal(server)
+	data, err := mergeMCPServerRaw(cfg.serverRaw[name], server)
 	if err != nil {
 		return false, err
 	}
@@ -582,6 +582,34 @@ func (cfg *mcpWritableConfig) upsertServer(name string, server config.MCPServerC
 		return false, err
 	}
 	return updated, nil
+}
+
+func mergeMCPServerRaw(existing json.RawMessage, server config.MCPServerConfig) (json.RawMessage, error) {
+	typed, err := json.Marshal(server)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) == 0 || string(existing) == "null" {
+		return typed, nil
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(existing, &merged); err != nil {
+		return nil, err
+	}
+	if merged == nil {
+		merged = map[string]json.RawMessage{}
+	}
+	for _, key := range []string{"type", "command", "args", "env", "url", "headers", "auth", "oauth", "disabled"} {
+		delete(merged, key)
+	}
+	var typedRaw map[string]json.RawMessage
+	if err := json.Unmarshal(typed, &typedRaw); err != nil {
+		return nil, err
+	}
+	for key, value := range typedRaw {
+		merged[key] = value
+	}
+	return json.Marshal(merged)
 }
 
 func (cfg *mcpWritableConfig) removeServer(name string) (bool, error) {

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -571,9 +571,24 @@ func (cfg *mcpWritableConfig) upsertServer(name string, server config.MCPServerC
 	if cfg.file.MCP.Servers == nil {
 		cfg.file.MCP.Servers = map[string]config.MCPServerConfig{}
 	}
-	_, updated := cfg.file.MCP.Servers[name]
-	cfg.file.MCP.Servers[name] = server
-	data, err := mergeMCPServerRaw(cfg.serverRaw[name], server)
+	existingRaw, updated := cfg.serverRaw[name]
+	existingServer := cfg.file.MCP.Servers[name]
+	if !updated {
+		legacyRaw, legacyFound, err := cfg.legacyServerRaw(name)
+		if err != nil {
+			return false, err
+		}
+		if legacyFound {
+			existingRaw = legacyRaw
+			updated = true
+			if len(legacyRaw) > 0 && string(legacyRaw) != "null" {
+				_ = json.Unmarshal(legacyRaw, &existingServer)
+			}
+		}
+	}
+	mergedServer := overlayMCPServer(existingServer, server)
+	cfg.file.MCP.Servers[name] = mergedServer
+	data, err := mergeMCPServerRaw(existingRaw, mergedServer)
 	if err != nil {
 		return false, err
 	}
@@ -582,6 +597,31 @@ func (cfg *mcpWritableConfig) upsertServer(name string, server config.MCPServerC
 		return false, err
 	}
 	return updated, nil
+}
+
+func overlayMCPServer(existing config.MCPServerConfig, next config.MCPServerConfig) config.MCPServerConfig {
+	existing.Type = next.Type
+	existing.Command = next.Command
+	existing.Args = append([]string{}, next.Args...)
+	existing.Env = cloneStringMap(next.Env)
+	existing.URL = next.URL
+	existing.Headers = cloneStringMap(next.Headers)
+	if strings.TrimSpace(next.Auth) != "" {
+		existing.Auth = next.Auth
+	}
+	existing.Disabled = next.Disabled
+	return existing
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 func mergeMCPServerRaw(existing json.RawMessage, server config.MCPServerConfig) (json.RawMessage, error) {
@@ -599,14 +639,18 @@ func mergeMCPServerRaw(existing json.RawMessage, server config.MCPServerConfig) 
 	if merged == nil {
 		merged = map[string]json.RawMessage{}
 	}
-	for _, key := range []string{"type", "command", "args", "env", "url", "headers", "auth", "oauth", "disabled"} {
+	for _, key := range []string{"type", "command", "args", "env", "url", "headers", "auth", "disabled"} {
 		delete(merged, key)
 	}
 	var typedRaw map[string]json.RawMessage
 	if err := json.Unmarshal(typed, &typedRaw); err != nil {
 		return nil, err
 	}
+	_, preserveRawOAuth := merged["oauth"]
 	for key, value := range typedRaw {
+		if key == "oauth" && preserveRawOAuth {
+			continue
+		}
 		merged[key] = value
 	}
 	return json.Marshal(merged)
@@ -719,6 +763,25 @@ func (cfg *mcpWritableConfig) takeLegacyServer(name string) (json.RawMessage, bo
 			cfg.raw[key] = next
 		}
 		return raw, true, nil
+	}
+	return nil, false, nil
+}
+
+func (cfg *mcpWritableConfig) legacyServerRaw(name string) (json.RawMessage, bool, error) {
+	cfg.ensureRaw()
+	for _, key := range []string{"mcpServers", "mcp_servers"} {
+		data, ok := cfg.raw[key]
+		if !ok || len(data) == 0 || string(data) == "null" {
+			continue
+		}
+		var servers map[string]json.RawMessage
+		if err := json.Unmarshal(data, &servers); err != nil {
+			return nil, false, err
+		}
+		raw, ok := servers[name]
+		if ok {
+			return raw, true, nil
+		}
 	}
 	return nil, false, nil
 }

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -264,15 +264,15 @@ func runMCPCheck(ctx context.Context, args []string, stdout io.Writer, stderr io
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 	registry := tools.NewRegistry()
-	runtime, err := deps.registerMCPTools(ctx, registry, scoped, mcp.RegisterOptions{
+	mcpRuntime, err := deps.registerMCPTools(ctx, registry, scoped, mcp.RegisterOptions{
 		PermissionStore: store,
 		Autonomy:        mcp.AutonomyLow,
 	})
 	if err != nil {
-		closeMCPRuntime(stderr, runtime)
+		closeMCPRuntime(stderr, mcpRuntime)
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
-	defer closeMCPRuntime(stderr, runtime)
+	defer closeMCPRuntime(stderr, mcpRuntime)
 
 	items := mcpToolList(registry)
 	if options.json {
@@ -860,16 +860,19 @@ func replaceMCPWritableConfigFile(tmpPath string, path string) error {
 	if err := os.Rename(tmpPath, path); err == nil || runtime.GOOS != "windows" {
 		return err
 	}
-	existing, readErr := os.ReadFile(path)
-	if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
-		return removeErr
+	backupPath := tmpPath + ".bak"
+	if err := os.Rename(path, backupPath); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		if readErr == nil {
-			_ = os.WriteFile(path, existing, 0o600)
+		if _, statErr := os.Stat(backupPath); statErr == nil {
+			if restoreErr := os.Rename(backupPath, path); restoreErr != nil {
+				return fmt.Errorf("%w; failed to restore original config: %v", err, restoreErr)
+			}
 		}
 		return err
 	}
+	_ = os.Remove(backupPath)
 	return nil
 }
 

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -427,10 +427,13 @@ func parseMCPAddArgs(args []string) (mcpAddOptions, bool, error) {
 		return options, false, execUsageError{fmt.Sprintf("unsupported MCP server type %q", options.server.Type)}
 	}
 
-	validationServer := options.server
-	validationServer.Disabled = false
-	if _, err := mcp.NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{options.serverName: validationServer}}); err != nil {
-		return options, false, err
+	if options.server.Auth != "" && options.server.Auth != mcp.ServerAuthOAuth {
+		return options, false, execUsageError{fmt.Sprintf("MCP server %s has unsupported auth %q", options.serverName, options.server.Auth)}
+	}
+	if !options.server.Disabled {
+		if _, err := mcp.NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{options.serverName: options.server}}); err != nil {
+			return options, false, err
+		}
 	}
 	return options, false, nil
 }
@@ -449,8 +452,15 @@ func requiredNextMCPFlagValue(args []string, index *int, flag string) (string, e
 
 func addMCPStringMapValue(target *map[string]string, raw string, flag string) error {
 	key, value, ok := strings.Cut(raw, "=")
+	if !ok && flag == "--header" {
+		key, value, ok = strings.Cut(raw, ":")
+		value = strings.TrimLeft(value, " \t")
+	}
 	key = strings.TrimSpace(key)
 	if !ok || key == "" {
+		if flag == "--header" {
+			return execUsageError{fmt.Sprintf("%s expects KEY=VALUE or \"Key: Value\"", flag)}
+		}
 		return execUsageError{fmt.Sprintf("%s expects KEY=VALUE", flag)}
 	}
 	if *target == nil {

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -1,0 +1,770 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type mcpAddOptions struct {
+	json       bool
+	serverName string
+	server     config.MCPServerConfig
+}
+
+type mcpWritableConfig struct {
+	file      config.FileConfig
+	raw       map[string]json.RawMessage
+	mcpRaw    map[string]json.RawMessage
+	serverRaw map[string]json.RawMessage
+}
+
+func runMCPAdd(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseMCPAddArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPAddHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, "failed to resolve user config: "+err.Error(), exitCrash)
+	}
+	cfg, err := readMCPWritableConfig(configPath)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if cfg.file.MCP.Servers == nil {
+		cfg.file.MCP.Servers = map[string]config.MCPServerConfig{}
+	}
+	updated, err := cfg.upsertServer(options.serverName, options.server)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if err := writeMCPWritableConfig(configPath, cfg); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	if options.json {
+		payload := struct {
+			ServerName string                 `json:"serverName"`
+			Updated    bool                   `json:"updated"`
+			ConfigPath string                 `json:"configPath"`
+			Server     config.MCPServerConfig `json:"server"`
+		}{
+			ServerName: options.serverName,
+			Updated:    updated,
+			ConfigPath: configPath,
+			Server:     redactMCPServerConfigs(map[string]config.MCPServerConfig{options.serverName: options.server})[options.serverName],
+		}
+		if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	action := "Added"
+	if updated {
+		action = "Updated"
+	}
+	if _, err := fmt.Fprintf(stdout, "%s MCP server %s in %s.\n", action, options.serverName, configPath); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runMCPRemove(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, positional, help, err := parseMCPConfigPositionalCommand(args, "remove")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPRemoveHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) != 1 {
+		return writeExecUsageError(stderr, "usage: zero mcp remove <server> [--json]")
+	}
+	serverName := positional[0]
+	if err := mcp.ValidateServerName(serverName); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, "failed to resolve user config: "+err.Error(), exitCrash)
+	}
+	cfg, err := readMCPWritableConfig(configPath)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	removed, err := cfg.removeServer(serverName)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if removed {
+		if err := writeMCPWritableConfig(configPath, cfg); err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+	}
+
+	if options.json {
+		payload := struct {
+			ServerName string `json:"serverName"`
+			Removed    bool   `json:"removed"`
+			ConfigPath string `json:"configPath"`
+		}{ServerName: serverName, Removed: removed, ConfigPath: configPath}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if removed {
+		if _, err := fmt.Fprintf(stdout, "Removed MCP server %s from %s.\n", serverName, configPath); err != nil {
+			return exitCrash
+		}
+	} else if _, err := fmt.Fprintf(stdout, "No MCP server named %s is configured in %s.\n", serverName, configPath); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runMCPToggle(args []string, stdout io.Writer, stderr io.Writer, deps appDeps, disabled bool) int {
+	commandName := "enable"
+	if disabled {
+		commandName = "disable"
+	}
+	options, positional, help, err := parseMCPConfigPositionalCommand(args, commandName)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPToggleHelp(stdout, commandName); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) != 1 {
+		return writeExecUsageError(stderr, fmt.Sprintf("usage: zero mcp %s <server> [--json]", commandName))
+	}
+	serverName := positional[0]
+	if err := mcp.ValidateServerName(serverName); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+
+	configPath, err := deps.userConfigPath()
+	if err != nil {
+		return writeAppError(stderr, "failed to resolve user config: "+err.Error(), exitCrash)
+	}
+	cfg, err := readMCPWritableConfig(configPath)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	changed, found, err := cfg.setServerDisabled(serverName, disabled)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if !found {
+		return writeExecUsageError(stderr, fmt.Sprintf("MCP server %s is not configured in user config", serverName))
+	}
+	if changed {
+		if err := writeMCPWritableConfig(configPath, cfg); err != nil {
+			return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+		}
+	}
+
+	if options.json {
+		payload := struct {
+			ServerName string `json:"serverName"`
+			Disabled   bool   `json:"disabled"`
+			Changed    bool   `json:"changed"`
+			ConfigPath string `json:"configPath"`
+		}{ServerName: serverName, Disabled: disabled, Changed: changed, ConfigPath: configPath}
+		if err := writePrettyJSON(stdout, payload); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	state := "enabled"
+	if disabled {
+		state = "disabled"
+	}
+	if changed {
+		if _, err := fmt.Fprintf(stdout, "MCP server %s is now %s in %s.\n", serverName, state, configPath); err != nil {
+			return exitCrash
+		}
+	} else if _, err := fmt.Fprintf(stdout, "MCP server %s was already %s in %s.\n", serverName, state, configPath); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func runMCPCheck(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, positional, help, err := parseMCPConfigPositionalCommand(args, "check")
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeMCPCheckHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if len(positional) != 1 {
+		return writeExecUsageError(stderr, "usage: zero mcp check <server> [--json]")
+	}
+	serverName := positional[0]
+	if err := mcp.ValidateServerName(serverName); err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+
+	cwd, err := deps.getwd()
+	if err != nil {
+		return writeAppError(stderr, "failed to resolve workspace: "+err.Error(), exitCrash)
+	}
+	cfg, err := deps.resolveMCPConfig(cwd)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	raw, ok := cfg.Servers[serverName]
+	if !ok {
+		return writeAppError(stderr, fmt.Sprintf("MCP server %q is not configured", serverName), exitCrash)
+	}
+	if raw.Disabled {
+		return writeAppError(stderr, fmt.Sprintf("MCP server %q is disabled", serverName), exitCrash)
+	}
+	scoped := config.MCPConfig{Servers: map[string]config.MCPServerConfig{serverName: raw}}
+	if _, err := mcp.NormalizeConfig(scoped); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	store, err := deps.newMCPStore()
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	registry := tools.NewRegistry()
+	runtime, err := deps.registerMCPTools(context.Background(), registry, scoped, mcp.RegisterOptions{
+		PermissionStore: store,
+		Autonomy:        mcp.AutonomyLow,
+	})
+	if err != nil {
+		closeMCPRuntime(stderr, runtime)
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	defer closeMCPRuntime(stderr, runtime)
+
+	items := mcpToolList(registry)
+	if options.json {
+		payload := struct {
+			ServerName string            `json:"serverName"`
+			Status     string            `json:"status"`
+			ToolCount  int               `json:"toolCount"`
+			Tools      []mcpToolListItem `json:"tools"`
+		}{ServerName: serverName, Status: "ok", ToolCount: len(items), Tools: items}
+		if err := writePrettyJSON(stdout, redaction.RedactValue(payload, redaction.Options{})); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintf(stdout, "MCP server %s is reachable. %d tool(s) available.\n", serverName, len(items)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseMCPAddArgs(args []string) (mcpAddOptions, bool, error) {
+	options := mcpAddOptions{}
+	command := []string{}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case options.serverName == "":
+			if strings.HasPrefix(arg, "-") {
+				return options, false, execUsageError{"usage: zero mcp add <server> [flags] -- <command> [args...]"}
+			}
+			options.serverName = arg
+		case arg == "--":
+			command = append(command, args[i+1:]...)
+			i = len(args)
+		case arg == "--json":
+			options.json = true
+		case arg == "--disabled":
+			options.server.Disabled = true
+		case arg == "--type":
+			value, err := requiredNextMCPFlagValue(args, &i, "--type")
+			if err != nil {
+				return options, false, err
+			}
+			options.server.Type = value
+		case strings.HasPrefix(arg, "--type="):
+			value, err := requiredInlineFlagValue(arg, "--type")
+			if err != nil {
+				return options, false, err
+			}
+			options.server.Type = value
+		case arg == "--url":
+			value, err := requiredNextMCPFlagValue(args, &i, "--url")
+			if err != nil {
+				return options, false, err
+			}
+			options.server.URL = value
+		case strings.HasPrefix(arg, "--url="):
+			value, err := requiredInlineFlagValue(arg, "--url")
+			if err != nil {
+				return options, false, err
+			}
+			options.server.URL = value
+		case arg == "--env":
+			value, err := requiredNextMCPFlagValue(args, &i, "--env")
+			if err != nil {
+				return options, false, err
+			}
+			if err := addMCPStringMapValue(&options.server.Env, value, "--env"); err != nil {
+				return options, false, err
+			}
+		case strings.HasPrefix(arg, "--env="):
+			value, err := requiredInlineFlagValue(arg, "--env")
+			if err != nil {
+				return options, false, err
+			}
+			if err := addMCPStringMapValue(&options.server.Env, value, "--env"); err != nil {
+				return options, false, err
+			}
+		case arg == "--header":
+			value, err := requiredNextMCPFlagValue(args, &i, "--header")
+			if err != nil {
+				return options, false, err
+			}
+			if err := addMCPStringMapValue(&options.server.Headers, value, "--header"); err != nil {
+				return options, false, err
+			}
+		case strings.HasPrefix(arg, "--header="):
+			value, err := requiredInlineFlagValue(arg, "--header")
+			if err != nil {
+				return options, false, err
+			}
+			if err := addMCPStringMapValue(&options.server.Headers, value, "--header"); err != nil {
+				return options, false, err
+			}
+		case arg == "--auth":
+			value, err := requiredNextMCPFlagValue(args, &i, "--auth")
+			if err != nil {
+				return options, false, err
+			}
+			options.server.Auth = value
+		case strings.HasPrefix(arg, "--auth="):
+			value, err := requiredInlineFlagValue(arg, "--auth")
+			if err != nil {
+				return options, false, err
+			}
+			options.server.Auth = value
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown mcp add flag %q", arg)}
+		default:
+			command = append(command, args[i:]...)
+			i = len(args)
+		}
+	}
+
+	options.serverName = strings.TrimSpace(options.serverName)
+	if options.serverName == "" {
+		return options, false, execUsageError{"usage: zero mcp add <server> [flags] -- <command> [args...]"}
+	}
+	if err := mcp.ValidateServerName(options.serverName); err != nil {
+		return options, false, err
+	}
+
+	options.server.Type = strings.ToLower(strings.TrimSpace(options.server.Type))
+	options.server.Auth = strings.ToLower(strings.TrimSpace(options.server.Auth))
+	if options.server.Type == "" {
+		if strings.TrimSpace(options.server.URL) != "" {
+			options.server.Type = string(mcp.ServerTypeHTTP)
+		} else {
+			options.server.Type = string(mcp.ServerTypeStdio)
+		}
+	}
+	switch mcp.ServerType(options.server.Type) {
+	case mcp.ServerTypeStdio:
+		if len(command) == 0 {
+			return options, false, execUsageError{"usage: zero mcp add <server> [flags] -- <command> [args...]"}
+		}
+		options.server.Command = command[0]
+		options.server.Args = append([]string{}, command[1:]...)
+	case mcp.ServerTypeHTTP, mcp.ServerTypeSSE:
+		if strings.TrimSpace(options.server.URL) == "" {
+			return options, false, execUsageError{fmt.Sprintf("zero mcp add --type %s requires --url", options.server.Type)}
+		}
+		if len(command) > 0 {
+			return options, false, execUsageError{fmt.Sprintf("zero mcp add --type %s does not accept a command", options.server.Type)}
+		}
+	default:
+		return options, false, execUsageError{fmt.Sprintf("unsupported MCP server type %q", options.server.Type)}
+	}
+
+	validationServer := options.server
+	validationServer.Disabled = false
+	if _, err := mcp.NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{options.serverName: validationServer}}); err != nil {
+		return options, false, err
+	}
+	return options, false, nil
+}
+
+func requiredNextMCPFlagValue(args []string, index *int, flag string) (string, error) {
+	if *index+1 >= len(args) {
+		return "", execUsageError{fmt.Sprintf("%s requires a value", flag)}
+	}
+	*index = *index + 1
+	value := args[*index]
+	if strings.TrimSpace(value) == "" {
+		return "", execUsageError{fmt.Sprintf("%s requires a value", flag)}
+	}
+	return value, nil
+}
+
+func addMCPStringMapValue(target *map[string]string, raw string, flag string) error {
+	key, value, ok := strings.Cut(raw, "=")
+	key = strings.TrimSpace(key)
+	if !ok || key == "" {
+		return execUsageError{fmt.Sprintf("%s expects KEY=VALUE", flag)}
+	}
+	if *target == nil {
+		*target = map[string]string{}
+	}
+	(*target)[key] = value
+	return nil
+}
+
+func parseMCPConfigPositionalCommand(args []string, command string) (mcpCommandOptions, []string, bool, error) {
+	options := mcpCommandOptions{}
+	positional := []string{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, positional, true, nil
+		case "--json":
+			options.json = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return options, positional, false, execUsageError{fmt.Sprintf("unknown mcp %s flag %q", command, arg)}
+			}
+			positional = append(positional, arg)
+		}
+	}
+	return options, positional, false, nil
+}
+
+func readMCPWritableConfig(path string) (mcpWritableConfig, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return mcpWritableConfig{}, fmt.Errorf("config path is required")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			cfg := mcpWritableConfig{}
+			cfg.ensureRaw()
+			return cfg, nil
+		}
+		return mcpWritableConfig{}, fmt.Errorf("read config %s: %w", path, err)
+	}
+	cfg := mcpWritableConfig{}
+	if err := json.Unmarshal(data, &cfg.file); err != nil {
+		return mcpWritableConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, &cfg.raw); err != nil {
+		return mcpWritableConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+	}
+	cfg.ensureRaw()
+	if data, ok := cfg.raw["mcp"]; ok && len(data) > 0 && string(data) != "null" {
+		if err := json.Unmarshal(data, &cfg.mcpRaw); err != nil {
+			return mcpWritableConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	}
+	cfg.ensureRaw()
+	if data, ok := cfg.mcpRaw["servers"]; ok && len(data) > 0 && string(data) != "null" {
+		if err := json.Unmarshal(data, &cfg.serverRaw); err != nil {
+			return mcpWritableConfig{}, fmt.Errorf("invalid config JSON %s: %w", path, err)
+		}
+	}
+	cfg.ensureRaw()
+	return cfg, nil
+}
+
+func writeMCPWritableConfig(path string, cfg mcpWritableConfig) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("config path is required")
+	}
+	dir := filepath.Dir(path)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create config directory %s: %w", dir, err)
+		}
+	}
+	data, err := cfg.marshalJSON()
+	if err != nil {
+		return fmt.Errorf("encode config JSON: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".zero-config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("secure config permissions %s: %w", path, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	if err := replaceMCPWritableConfigFile(tmpPath, path); err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	return nil
+}
+
+func (cfg *mcpWritableConfig) ensureRaw() {
+	if cfg.raw == nil {
+		cfg.raw = map[string]json.RawMessage{}
+	}
+	if cfg.mcpRaw == nil {
+		cfg.mcpRaw = map[string]json.RawMessage{}
+	}
+	if cfg.serverRaw == nil {
+		cfg.serverRaw = map[string]json.RawMessage{}
+	}
+}
+
+func (cfg *mcpWritableConfig) upsertServer(name string, server config.MCPServerConfig) (bool, error) {
+	cfg.ensureRaw()
+	if cfg.file.MCP.Servers == nil {
+		cfg.file.MCP.Servers = map[string]config.MCPServerConfig{}
+	}
+	_, updated := cfg.file.MCP.Servers[name]
+	cfg.file.MCP.Servers[name] = server
+	data, err := json.Marshal(server)
+	if err != nil {
+		return false, err
+	}
+	cfg.serverRaw[name] = data
+	if _, err := cfg.removeLegacyServer(name); err != nil {
+		return false, err
+	}
+	return updated, nil
+}
+
+func (cfg *mcpWritableConfig) removeServer(name string) (bool, error) {
+	cfg.ensureRaw()
+	removed := false
+	if cfg.file.MCP.Servers != nil {
+		if _, ok := cfg.file.MCP.Servers[name]; ok {
+			delete(cfg.file.MCP.Servers, name)
+			removed = true
+		}
+	}
+	if _, ok := cfg.serverRaw[name]; ok {
+		delete(cfg.serverRaw, name)
+		removed = true
+	}
+	removedLegacy, err := cfg.removeLegacyServer(name)
+	if err != nil {
+		return false, err
+	}
+	return removed || removedLegacy, nil
+}
+
+func (cfg *mcpWritableConfig) setServerDisabled(name string, disabled bool) (bool, bool, error) {
+	cfg.ensureRaw()
+	raw, found := cfg.serverRaw[name]
+	if !found {
+		return false, false, nil
+	}
+	var server map[string]json.RawMessage
+	if len(raw) > 0 && string(raw) != "null" {
+		if err := json.Unmarshal(raw, &server); err != nil {
+			return false, false, err
+		}
+	}
+	if server == nil {
+		server = map[string]json.RawMessage{}
+	}
+
+	current := false
+	if rawDisabled, ok := server["disabled"]; ok && len(rawDisabled) > 0 && string(rawDisabled) != "null" {
+		if err := json.Unmarshal(rawDisabled, &current); err != nil {
+			return false, false, err
+		}
+	}
+	changed := current != disabled
+	if disabled {
+		data, err := json.Marshal(true)
+		if err != nil {
+			return false, false, err
+		}
+		server["disabled"] = data
+	} else {
+		delete(server, "disabled")
+	}
+	data, err := json.Marshal(server)
+	if err != nil {
+		return false, false, err
+	}
+	cfg.serverRaw[name] = data
+
+	if cfg.file.MCP.Servers != nil {
+		typed := cfg.file.MCP.Servers[name]
+		typed.Disabled = disabled
+		cfg.file.MCP.Servers[name] = typed
+	}
+	return changed, true, nil
+}
+
+func (cfg *mcpWritableConfig) removeLegacyServer(name string) (bool, error) {
+	cfg.ensureRaw()
+	removed := false
+	for _, key := range []string{"mcpServers", "mcp_servers"} {
+		data, ok := cfg.raw[key]
+		if !ok || len(data) == 0 || string(data) == "null" {
+			continue
+		}
+		var servers map[string]json.RawMessage
+		if err := json.Unmarshal(data, &servers); err != nil {
+			return false, err
+		}
+		if _, ok := servers[name]; !ok {
+			continue
+		}
+		delete(servers, name)
+		removed = true
+		if len(servers) == 0 {
+			delete(cfg.raw, key)
+			continue
+		}
+		next, err := json.Marshal(servers)
+		if err != nil {
+			return false, err
+		}
+		cfg.raw[key] = next
+	}
+	return removed, nil
+}
+
+func (cfg mcpWritableConfig) marshalJSON() ([]byte, error) {
+	cfg.ensureRaw()
+	if len(cfg.serverRaw) > 0 {
+		data, err := json.Marshal(cfg.serverRaw)
+		if err != nil {
+			return nil, err
+		}
+		cfg.mcpRaw["servers"] = data
+	} else {
+		delete(cfg.mcpRaw, "servers")
+	}
+	if len(cfg.mcpRaw) > 0 {
+		data, err := json.Marshal(cfg.mcpRaw)
+		if err != nil {
+			return nil, err
+		}
+		cfg.raw["mcp"] = data
+	} else {
+		delete(cfg.raw, "mcp")
+	}
+	data, err := json.MarshalIndent(cfg.raw, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func replaceMCPWritableConfigFile(tmpPath string, path string) error {
+	if err := os.Rename(tmpPath, path); err == nil || runtime.GOOS != "windows" {
+		return err
+	}
+	existing, readErr := os.ReadFile(path)
+	if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+		return removeErr
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		if readErr == nil {
+			_ = os.WriteFile(path, existing, 0o600)
+		}
+		return err
+	}
+	return nil
+}
+
+func writeMCPAddHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp add <server> [flags] -- <command> [args...]
+  zero mcp add <server> --url <url> [flags]
+
+Flags:
+      --auth <auth>        Authentication mode for remote servers (for example: oauth)
+      --disabled           Persist the server as disabled
+      --env KEY=VALUE      Add stdio environment variable (repeatable)
+      --header KEY=VALUE   Add HTTP/SSE header (repeatable)
+      --json               Print command result as JSON
+      --type <type>        MCP transport: stdio, http, or sse
+      --url <url>          Remote MCP endpoint URL
+  -h, --help               Show this help
+`)
+	return err
+}
+
+func writeMCPRemoveHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp remove <server> [flags]
+
+Flags:
+      --json    Print command result as JSON
+  -h, --help    Show this help
+`)
+	return err
+}
+
+func writeMCPToggleHelp(w io.Writer, commandName string) error {
+	_, err := fmt.Fprintf(w, `Usage:
+  zero mcp %s <server> [flags]
+
+Flags:
+      --json    Print command result as JSON
+  -h, --help    Show this help
+`, commandName)
+	return err
+}
+
+func writeMCPCheckHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero mcp check <server> [flags]
+
+Flags:
+      --json    Print command result as JSON
+  -h, --help    Show this help
+`)
+	return err
+}

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -405,12 +405,18 @@ func parseMCPAddArgs(args []string) (mcpAddOptions, bool, error) {
 	}
 	switch mcp.ServerType(options.server.Type) {
 	case mcp.ServerTypeStdio:
+		if len(options.server.Headers) > 0 {
+			return options, false, execUsageError{"headers are only supported for http or sse transports"}
+		}
 		if len(command) == 0 {
 			return options, false, execUsageError{"usage: zero mcp add <server> [flags] -- <command> [args...]"}
 		}
 		options.server.Command = command[0]
 		options.server.Args = append([]string{}, command[1:]...)
 	case mcp.ServerTypeHTTP, mcp.ServerTypeSSE:
+		if len(options.server.Env) > 0 {
+			return options, false, execUsageError{"env is only supported for stdio transport"}
+		}
 		if strings.TrimSpace(options.server.URL) == "" {
 			return options, false, execUsageError{fmt.Sprintf("zero mcp add --type %s requires --url", options.server.Type)}
 		}
@@ -602,7 +608,15 @@ func (cfg *mcpWritableConfig) setServerDisabled(name string, disabled bool) (boo
 	cfg.ensureRaw()
 	raw, found := cfg.serverRaw[name]
 	if !found {
-		return false, false, nil
+		legacyRaw, legacyFound, err := cfg.takeLegacyServer(name)
+		if err != nil {
+			return false, false, err
+		}
+		if !legacyFound {
+			return false, false, nil
+		}
+		raw = legacyRaw
+		found = true
 	}
 	var server map[string]json.RawMessage
 	if len(raw) > 0 && string(raw) != "null" {
@@ -636,12 +650,49 @@ func (cfg *mcpWritableConfig) setServerDisabled(name string, disabled bool) (boo
 	}
 	cfg.serverRaw[name] = data
 
-	if cfg.file.MCP.Servers != nil {
-		typed := cfg.file.MCP.Servers[name]
-		typed.Disabled = disabled
-		cfg.file.MCP.Servers[name] = typed
+	if cfg.file.MCP.Servers == nil {
+		cfg.file.MCP.Servers = map[string]config.MCPServerConfig{}
 	}
+	typed := cfg.file.MCP.Servers[name]
+	if len(raw) > 0 && string(raw) != "null" {
+		var decoded config.MCPServerConfig
+		if err := json.Unmarshal(raw, &decoded); err == nil {
+			typed = decoded
+		}
+	}
+	typed.Disabled = disabled
+	cfg.file.MCP.Servers[name] = typed
 	return changed, true, nil
+}
+
+func (cfg *mcpWritableConfig) takeLegacyServer(name string) (json.RawMessage, bool, error) {
+	cfg.ensureRaw()
+	for _, key := range []string{"mcpServers", "mcp_servers"} {
+		data, ok := cfg.raw[key]
+		if !ok || len(data) == 0 || string(data) == "null" {
+			continue
+		}
+		var servers map[string]json.RawMessage
+		if err := json.Unmarshal(data, &servers); err != nil {
+			return nil, false, err
+		}
+		raw, ok := servers[name]
+		if !ok {
+			continue
+		}
+		delete(servers, name)
+		if len(servers) == 0 {
+			delete(cfg.raw, key)
+		} else {
+			next, err := json.Marshal(servers)
+			if err != nil {
+				return nil, false, err
+			}
+			cfg.raw[key] = next
+		}
+		return raw, true, nil
+	}
+	return nil, false, nil
 }
 
 func (cfg *mcpWritableConfig) removeLegacyServer(name string) (bool, error) {
@@ -674,7 +725,7 @@ func (cfg *mcpWritableConfig) removeLegacyServer(name string) (bool, error) {
 	return removed, nil
 }
 
-func (cfg mcpWritableConfig) marshalJSON() ([]byte, error) {
+func (cfg *mcpWritableConfig) marshalJSON() ([]byte, error) {
 	cfg.ensureRaw()
 	if len(cfg.serverRaw) > 0 {
 		data, err := json.Marshal(cfg.serverRaw)

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -217,7 +217,10 @@ func runMCPToggle(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 	return exitSuccess
 }
 
-func runMCPCheck(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+func runMCPCheck(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	options, positional, help, err := parseMCPConfigPositionalCommand(args, "check")
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
@@ -261,7 +264,7 @@ func runMCPCheck(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
 	}
 	registry := tools.NewRegistry()
-	runtime, err := deps.registerMCPTools(context.Background(), registry, scoped, mcp.RegisterOptions{
+	runtime, err := deps.registerMCPTools(ctx, registry, scoped, mcp.RegisterOptions{
 		PermissionStore: store,
 		Autonomy:        mcp.AutonomyLow,
 	})

--- a/internal/cli/mcp_tools.go
+++ b/internal/cli/mcp_tools.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -96,9 +97,65 @@ func formatMCPServerList(servers map[string]config.MCPServerConfig) string {
 		}
 		identity := strings.TrimSpace(server.Command)
 		if identity == "" {
-			identity = strings.TrimSpace(server.URL)
+			identity = redactMCPURL(server.URL, "[REDACTED]")
 		}
 		lines = append(lines, fmt.Sprintf("  %s [%s] %s %s", name, server.Type, state, identity))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func redactMCPURL(raw string, marker string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if parsed.User != nil {
+		parsed.User = nil
+	}
+	if parsed.RawQuery != "" {
+		parsed.RawQuery = redactMCPRawQuery(parsed.RawQuery, marker)
+	}
+	out := parsed.String()
+	if strings.TrimSpace(out) == "" {
+		return raw
+	}
+	return out
+}
+
+func redactMCPRawQuery(rawQuery string, marker string) string {
+	parts := strings.Split(rawQuery, "&")
+	for index, part := range parts {
+		if part == "" {
+			continue
+		}
+		key, _, hasValue := strings.Cut(part, "=")
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			decodedKey = key
+		}
+		if !isSensitiveMCPDisplayKey(decodedKey) {
+			continue
+		}
+		if hasValue {
+			parts[index] = key + "=" + marker
+		} else {
+			parts[index] = key
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+func isSensitiveMCPDisplayKey(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.ReplaceAll(key, "-", "_")
+	for _, token := range []string{"token", "secret", "password", "passwd", "api_key", "apikey", "access_key", "auth", "credential"} {
+		if strings.Contains(key, token) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/mcp_tools.go
+++ b/internal/cli/mcp_tools.go
@@ -119,6 +119,9 @@ func redactMCPURL(raw string, marker string) string {
 	if parsed.RawQuery != "" {
 		parsed.RawQuery = redactMCPRawQuery(parsed.RawQuery, marker)
 	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = redactMCPRawQuery(parsed.Fragment, marker)
+	}
 	out := parsed.String()
 	if strings.TrimSpace(out) == "" {
 		return raw
@@ -152,6 +155,9 @@ func redactMCPRawQuery(rawQuery string, marker string) string {
 func isSensitiveMCPDisplayKey(key string) bool {
 	key = strings.ToLower(strings.TrimSpace(key))
 	key = strings.ReplaceAll(key, "-", "_")
+	if key == "key" {
+		return true
+	}
 	for _, token := range []string{"token", "secret", "password", "passwd", "api_key", "apikey", "access_key", "auth", "credential"} {
 		if strings.Contains(key, token) {
 			return true

--- a/internal/cli/mcp_validation_test.go
+++ b/internal/cli/mcp_validation_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestRunMCPAddJSONRedactsEnvAndPreservesConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	writeMCPCommandConfig(t, configPath, config.FileConfig{
+		ActiveProvider: "local",
+		MaxTurns:       42,
+		Providers: []config.ProviderProfile{{
+			Name:  "local",
+			Model: "qwen3-coder:480b",
+		}},
+		Preferences: config.PreferencesConfig{FavoriteModels: []string{"qwen3-coder:480b"}},
+		MCP: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"existing": {Type: "stdio", Command: "existing-mcp"},
+		}},
+	})
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{
+		"mcp", "add", "docs",
+		"--json",
+		"--env", "DOCS_TOKEN=stdio-secret",
+		"--", "docs-mcp", "--port", "123",
+	}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if output := stdout.String(); strings.Contains(output, "stdio-secret") {
+		t.Fatalf("JSON stdout leaked secret value: %s", output)
+	}
+	var payload struct {
+		Server config.MCPServerConfig `json:"server"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, stdout.String())
+	}
+	if got := payload.Server.Env["DOCS_TOKEN"]; got != "[REDACTED]" {
+		t.Fatalf("JSON env redaction = %q, want [REDACTED]", got)
+	}
+
+	cfg := readMCPCommandConfig(t, configPath)
+	if cfg.ActiveProvider != "local" || cfg.MaxTurns != 42 || len(cfg.Providers) != 1 {
+		t.Fatalf("non-MCP config was not preserved: %#v", cfg)
+	}
+	if got := cfg.Preferences.FavoriteModels; len(got) != 1 || got[0] != "qwen3-coder:480b" {
+		t.Fatalf("preferences were not preserved: %#v", got)
+	}
+	if _, ok := cfg.MCP.Servers["existing"]; !ok {
+		t.Fatalf("existing MCP server was not preserved: %#v", cfg.MCP.Servers)
+	}
+	added := cfg.MCP.Servers["docs"]
+	if got := added.Env["DOCS_TOKEN"]; got != "stdio-secret" {
+		t.Fatalf("persisted env secret = %q, want original value", got)
+	}
+}
+
+func TestRunMCPAddJSONRedactsHeaders(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runWithDeps([]string{
+		"mcp", "add", "docs",
+		"--json",
+		"--header", "Authorization=Bearer header-secret",
+		"--url", "https://example.com/mcp",
+	}, &stdout, &stderr, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if output := stdout.String(); strings.Contains(output, "header-secret") {
+		t.Fatalf("JSON stdout leaked header value: %s", output)
+	}
+	var payload struct {
+		Server config.MCPServerConfig `json:"server"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, stdout.String())
+	}
+	if got := payload.Server.Headers["Authorization"]; got != "[REDACTED]" {
+		t.Fatalf("JSON header redaction = %q, want [REDACTED]", got)
+	}
+
+	cfg := readMCPCommandConfig(t, configPath)
+	added := cfg.MCP.Servers["docs"]
+	if got := added.Headers["Authorization"]; got != "Bearer header-secret" {
+		t.Fatalf("persisted header secret = %q, want original value", got)
+	}
+}

--- a/internal/cli/mcp_validation_test.go
+++ b/internal/cli/mcp_validation_test.go
@@ -102,3 +102,54 @@ func TestRunMCPAddJSONRedactsHeaders(t *testing.T) {
 		t.Fatalf("persisted header secret = %q, want original value", got)
 	}
 }
+
+func TestRunMCPAddRejectsTransportSpecificSecrets(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "http rejects env",
+			args: []string{"mcp", "add", "remote", "--url", "https://example.com/mcp", "--env", "REMOTE_TOKEN=secret"},
+			want: "env is only supported for stdio transport",
+		},
+		{
+			name: "sse rejects env",
+			args: []string{"mcp", "add", "events", "--type", "sse", "--url", "https://example.com/sse", "--env", "SSE_TOKEN=secret"},
+			want: "env is only supported for stdio transport",
+		},
+		{
+			name: "stdio rejects header",
+			args: []string{"mcp", "add", "local", "--header", "Authorization=Bearer secret", "--", "local-mcp"},
+			want: "headers are only supported for http or sse transports",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			configPathCalled := false
+
+			exitCode := runWithDeps(tc.args, &stdout, &stderr, appDeps{
+				userConfigPath: func() (string, error) {
+					configPathCalled = true
+					return filepath.Join(t.TempDir(), "zero", "config.json"), nil
+				},
+			})
+
+			if exitCode != exitUsage {
+				t.Fatalf("exitCode = %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+			}
+			if configPathCalled {
+				t.Fatal("user config path was resolved after invalid MCP add arguments")
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr missing %q:\n%s", tc.want, stderr.String())
+			}
+			if strings.Contains(stdout.String()+stderr.String(), "secret") {
+				t.Fatalf("output leaked secret value:\nstdout=%s\nstderr=%s", stdout.String(), stderr.String())
+			}
+		})
+	}
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -93,8 +93,20 @@ func TestServeResourcesListExcludesOutOfScope(t *testing.T) {
 		Resources []Resource `json:"resources"`
 	}
 	decodeServerTestResult(t, readServerTestMessage(t, newMessageReader(&output)), &result)
+	outsideRoot, err := filepath.EvalSymlinks(outside)
+	if err != nil {
+		outsideRoot = filepath.Clean(outside)
+	}
 	for _, resource := range result.Resources {
-		if strings.Contains(resource.URI, "secret.txt") || strings.Contains(resource.URI, filepath.Base(outside)) {
+		resourcePath, err := pathFromURI(resource.URI)
+		if err != nil {
+			t.Fatalf("resource URI %q did not decode: %v", resource.URI, err)
+		}
+		resourcePath, err = filepath.EvalSymlinks(resourcePath)
+		if err != nil {
+			resourcePath = filepath.Clean(resourcePath)
+		}
+		if strings.Contains(resource.URI, "secret.txt") || containedInRoot(outsideRoot, resourcePath) {
 			t.Fatalf("resource %#v leaks out-of-scope path", resource)
 		}
 	}

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -53,7 +53,7 @@ var fileSuggestionIndexCache = struct {
 // handling. A slash-command palette stays active even with zero matches so the
 // query remains in the palette instead of leaking back into the composer.
 func (m model) suggestionsActive() bool {
-	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil || m.providerWizard != nil {
+	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil || m.providerWizard != nil || m.mcpManager != nil {
 		return false
 	}
 	if len(m.suggestions) > 0 {
@@ -75,7 +75,7 @@ func (m *model) clearSuggestions() {
 // disappear once the user starts typing arguments. Modals suppress matching
 // entirely. The selected index is preserved when still in range, otherwise reset.
 func (m *model) recomputeSuggestions() {
-	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil || m.providerWizard != nil {
+	if m.pendingPermission != nil || m.pendingAskUser != nil || m.pendingSpecReview != nil || m.providerWizard != nil || m.mcpManager != nil {
 		m.clearSuggestions()
 		return
 	}

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -1,9 +1,12 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
@@ -52,40 +55,110 @@ func (m model) mcpText() string {
 	return renderMCPView(m.mcpViewState(), width)
 }
 
-func (m model) mcpViewState() MCPViewState {
-	return BuildMCPViewState(MCPStateOptions{
+func (m *model) refreshMCPViewState() {
+	m.mcpViewStateCache = BuildMCPViewState(MCPStateOptions{
 		Config:          m.mcpConfig,
 		Registry:        m.registry,
 		PermissionStore: m.mcpPermissionStore,
 		PermissionMode:  string(m.permissionMode),
 		TokenStore:      m.mcpTokenStore,
 	})
+	m.mcpViewStateReady = true
 }
 
-func (m model) handleMCPCommand(args string) (model, string) {
+func (m model) mcpViewState() MCPViewState {
+	if m.mcpViewStateReady {
+		return m.mcpViewStateCache
+	}
+	// Older tests may construct a zero-value model; keep that path useful, while
+	// production refreshes the cache before any MCP view can render.
+	m.refreshMCPViewState()
+	return m.mcpViewStateCache
+}
+
+func (m model) startMCPTranscriptCommand(args string) (model, tea.Cmd) {
 	args = strings.TrimSpace(args)
 	if args == "" {
-		return m, m.mcpText()
-	}
-	if m.mcpCommand == nil {
-		return m, strings.Join([]string{
-			"MCP action unavailable",
-			"Run MCP management commands in your terminal for this build.",
-			"Example: zero mcp " + args,
-			"",
-			m.mcpText(),
-		}, "\n")
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: m.mcpText()})
+		return m, nil
 	}
 	parsedArgs, err := splitMCPCommandArgs(args)
 	if err != nil {
-		return m, strings.Join([]string{
+		text := strings.Join([]string{
 			"MCP action failed",
 			err.Error(),
 			"",
 			m.mcpText(),
 		}, "\n")
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
+		return m, nil
 	}
-	result := m.mcpCommand(parsedArgs)
+	return m.startMCPCommand(mcpCommandRequest{origin: mcpCommandOriginTranscript, raw: args, args: parsedArgs})
+}
+
+func (m model) startMCPCommand(request mcpCommandRequest) (model, tea.Cmd) {
+	if m.mcpCommand == nil {
+		result := MCPCommandResult{
+			ExitCode: 1,
+			Error:    "MCP action unavailable",
+			Config:   m.mcpConfig,
+		}
+		return m.applyMCPCommandResultMessage(mcpCommandResultMsg{request: request, result: result}), nil
+	}
+	m.cancelMCPCommand()
+	ctx := m.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	m.mcpCommandSeq++
+	request.id = m.mcpCommandSeq
+	request.args = append([]string{}, request.args...)
+	m.mcpCommandCancel = cancel
+	runner := m.mcpCommand
+	return m, func() tea.Msg {
+		return mcpCommandResultMsg{
+			request: request,
+			result:  runner(ctx, request.args),
+		}
+	}
+}
+
+func (m *model) cancelMCPCommand() {
+	if m.mcpCommandCancel != nil {
+		m.mcpCommandCancel()
+		m.mcpCommandCancel = nil
+		m.mcpCommandSeq++
+	}
+}
+
+func (m model) applyMCPCommandResultMessage(msg mcpCommandResultMsg) model {
+	if msg.request.id != 0 && msg.request.id != m.mcpCommandSeq {
+		return m
+	}
+	m.mcpCommandCancel = nil
+	switch msg.request.origin {
+	case mcpCommandOriginManager:
+		text := ""
+		m, text = m.applyMCPCommandResult(strings.Join(msg.request.args, " "), msg.result)
+		m.mcpManager = &mcpManagerState{selected: msg.request.managerSelected, query: msg.request.managerQuery}
+		if items := m.mcpManagerItems(); len(items) > 0 {
+			m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
+		}
+		if text != "" {
+			m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
+		}
+	case mcpCommandOriginWizard:
+		m = m.applyMCPAddWizardSaveResult(msg.result, msg.request.wizardDisabled)
+	default:
+		text := ""
+		m, text = m.applyMCPCommandResult(msg.request.raw, msg.result)
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
+	}
+	return m
+}
+
+func (m model) applyMCPCommandResult(args string, result MCPCommandResult) (model, string) {
 	if result.ExitCode != 0 || strings.TrimSpace(result.Error) != "" {
 		message := strings.TrimSpace(result.Error)
 		if message == "" {
@@ -103,6 +176,7 @@ func (m model) handleMCPCommand(args string) (model, string) {
 	}
 	if len(result.Config.Servers) > 0 || len(m.mcpConfig.Servers) > 0 {
 		m.mcpConfig = result.Config
+		m.refreshMCPViewState()
 	}
 	output := strings.TrimSpace(result.Output)
 	if output == "" {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -76,10 +76,16 @@ func (m model) handleMCPCommand(args string) (model, string) {
 			m.mcpText(),
 		}, "\n")
 	}
-	result := m.mcpCommand(strings.Fields(args))
-	if len(result.Config.Servers) > 0 || len(m.mcpConfig.Servers) > 0 {
-		m.mcpConfig = result.Config
+	parsedArgs, err := splitMCPCommandArgs(args)
+	if err != nil {
+		return m, strings.Join([]string{
+			"MCP action failed",
+			err.Error(),
+			"",
+			m.mcpText(),
+		}, "\n")
 	}
+	result := m.mcpCommand(parsedArgs)
 	if result.ExitCode != 0 || strings.TrimSpace(result.Error) != "" {
 		message := strings.TrimSpace(result.Error)
 		if message == "" {
@@ -95,6 +101,9 @@ func (m model) handleMCPCommand(args string) (model, string) {
 			m.mcpText(),
 		}, "\n")
 	}
+	if len(result.Config.Servers) > 0 || len(m.mcpConfig.Servers) > 0 {
+		m.mcpConfig = result.Config
+	}
 	output := strings.TrimSpace(result.Output)
 	if output == "" {
 		output = "zero mcp " + args
@@ -105,6 +114,62 @@ func (m model) handleMCPCommand(args string) (model, string) {
 		"",
 		m.mcpText(),
 	}, "\n")
+}
+
+func splitMCPCommandArgs(args string) ([]string, error) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return nil, nil
+	}
+	out := []string{}
+	var current strings.Builder
+	var quote rune
+	hasToken := false
+	runes := []rune(args)
+	for index := 0; index < len(runes); index++ {
+		r := runes[index]
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+				hasToken = true
+				continue
+			}
+			if r == '\\' && index+1 < len(runes) && runes[index+1] == quote {
+				index++
+				current.WriteRune(runes[index])
+				hasToken = true
+				continue
+			}
+			current.WriteRune(r)
+			hasToken = true
+			continue
+		}
+		switch {
+		case r == '\'' || r == '"':
+			quote = r
+			hasToken = true
+		case r == '\\' && index+1 < len(runes) && (runes[index+1] == '\'' || runes[index+1] == '"' || strings.TrimSpace(string(runes[index+1])) == ""):
+			index++
+			current.WriteRune(runes[index])
+			hasToken = true
+		case strings.TrimSpace(string(r)) == "":
+			if hasToken {
+				out = append(out, current.String())
+				current.Reset()
+				hasToken = false
+			}
+		default:
+			current.WriteRune(r)
+			hasToken = true
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote in MCP command")
+	}
+	if hasToken {
+		out = append(out, current.String())
+	}
+	return out, nil
 }
 
 func (m model) permissionsText() string {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -62,6 +62,51 @@ func (m model) mcpViewState() MCPViewState {
 	})
 }
 
+func (m model) handleMCPCommand(args string) (model, string) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return m, m.mcpText()
+	}
+	if m.mcpCommand == nil {
+		return m, strings.Join([]string{
+			"MCP action unavailable",
+			"Run MCP management commands in your terminal for this build.",
+			"Example: zero mcp " + args,
+			"",
+			m.mcpText(),
+		}, "\n")
+	}
+	result := m.mcpCommand(strings.Fields(args))
+	if len(result.Config.Servers) > 0 || len(m.mcpConfig.Servers) > 0 {
+		m.mcpConfig = result.Config
+	}
+	if result.ExitCode != 0 || strings.TrimSpace(result.Error) != "" {
+		message := strings.TrimSpace(result.Error)
+		if message == "" {
+			message = strings.TrimSpace(result.Output)
+		}
+		if message == "" {
+			message = "MCP command failed"
+		}
+		return m, strings.Join([]string{
+			"MCP action failed",
+			message,
+			"",
+			m.mcpText(),
+		}, "\n")
+	}
+	output := strings.TrimSpace(result.Output)
+	if output == "" {
+		output = "zero mcp " + args
+	}
+	return m, strings.Join([]string{
+		"MCP action complete",
+		output,
+		"",
+		m.mcpText(),
+	}, "\n")
+}
+
 func (m model) permissionsText() string {
 	stateLines := []string{
 		"Permission mode: " + string(m.permissionMode),

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -44,6 +44,24 @@ func (m model) toolsText() string {
 	})
 }
 
+func (m model) mcpText() string {
+	width := 0
+	if m.width > 0 {
+		width = chatWidth(m.width)
+	}
+	return renderMCPView(m.mcpViewState(), width)
+}
+
+func (m model) mcpViewState() MCPViewState {
+	return BuildMCPViewState(MCPStateOptions{
+		Config:          m.mcpConfig,
+		Registry:        m.registry,
+		PermissionStore: m.mcpPermissionStore,
+		PermissionMode:  string(m.permissionMode),
+		TokenStore:      m.mcpTokenStore,
+	})
+}
+
 func (m model) permissionsText() string {
 	stateLines := []string{
 		"Permission mode: " + string(m.permissionMode),

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -47,7 +47,7 @@ func (m model) toolsText() string {
 	})
 }
 
-func (m model) mcpText() string {
+func (m *model) mcpText() string {
 	width := 0
 	if m.width > 0 {
 		width = chatWidth(m.width)
@@ -66,7 +66,7 @@ func (m *model) refreshMCPViewState() {
 	m.mcpViewStateReady = true
 }
 
-func (m model) mcpViewState() MCPViewState {
+func (m *model) mcpViewState() MCPViewState {
 	if m.mcpViewStateReady {
 		return m.mcpViewStateCache
 	}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -13,6 +13,7 @@ const (
 	commandClear
 	commandExit
 	commandTools
+	commandMCP
 	commandPermissions
 	commandProvider
 	commandModel
@@ -141,6 +142,14 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupTools,
 		description: "Search local session events. Requires a query argument.",
 		kind:        commandSearch,
+	},
+	{
+		name:        "/mcp",
+		aliases:     []string{"/mcp-status"},
+		usage:       "/mcp",
+		group:       commandGroupTools,
+		description: "Show MCP server status.",
+		kind:        commandMCP,
 	},
 	{
 		name:        "/resume",

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -571,6 +571,87 @@ func TestChatMCPSetupStitchURLOpensPrefilledWizard(t *testing.T) {
 	}
 }
 
+func TestChatMCPSetupFalsePositiveSendsPrompt(t *testing.T) {
+	provider := &fakeProvider{}
+	m := newModel(context.Background(), Options{
+		Provider: provider,
+		Registry: tools.NewRegistry(),
+	})
+	m.width = 120
+	m.height = 36
+	prompt := "how do I add a fetch call to my mcp client?"
+	m.input.SetValue(prompt)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if next.mcpAddWizard != nil {
+		t.Fatal("ordinary MCP chat prompt should not open the add wizard")
+	}
+	if cmd == nil {
+		t.Fatal("ordinary MCP chat prompt should be sent to the agent")
+	}
+	if !transcriptContains(next.transcript, prompt) {
+		t.Fatalf("expected original prompt in transcript, got %#v", next.transcript)
+	}
+	_ = applyCommandResult(t, next, cmd)
+	foundPrompt := false
+	for _, request := range provider.requests {
+		for _, message := range request.Messages {
+			if strings.Contains(message.Content, prompt) {
+				foundPrompt = true
+				break
+			}
+		}
+	}
+	if !foundPrompt {
+		t.Fatalf("expected prompt to reach provider, got %#v", provider.requests)
+	}
+}
+
+func TestMCPAddWizardOpenCancelsStaleManagerResult(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		MCPCommand: func(_ context.Context, _ []string) MCPCommandResult {
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "checked",
+				Config:   config.MCPConfig{Servers: map[string]config.MCPServerConfig{}},
+			}
+		},
+	})
+	m.mcpManager = &mcpManagerState{selected: 1, query: "docs"}
+	var cmd tea.Cmd
+	m, cmd = m.startMCPCommand(mcpCommandRequest{
+		origin:          mcpCommandOriginManager,
+		args:            []string{"check", "docs"},
+		managerSelected: 1,
+		managerQuery:    "docs",
+	})
+	if cmd == nil {
+		t.Fatal("expected manager command")
+	}
+
+	m = m.openMCPAddWizard("http")
+	if m.mcpAddWizard == nil {
+		t.Fatal("expected add wizard to open")
+	}
+	if m.mcpManager != nil {
+		t.Fatal("expected manager to close when add wizard opens")
+	}
+	resultMsg := execCmd(cmd)
+	msg, ok := resultMsg.(mcpCommandResultMsg)
+	if !ok {
+		t.Fatalf("expected mcpCommandResultMsg, got %T", resultMsg)
+	}
+	m = m.applyMCPCommandResultMessage(msg)
+	if m.mcpManager != nil {
+		t.Fatal("stale manager result should not reopen manager over wizard")
+	}
+	if m.mcpAddWizard == nil {
+		t.Fatal("stale manager result should leave wizard open")
+	}
+}
+
 func TestMCPAddWizardConfirmRedactsSensitiveSourceAndEndpoint(t *testing.T) {
 	wizard := newMCPAddWizard("http")
 	wizard.step = mcpAddWizardStepConfirm

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -229,6 +229,12 @@ func TestMCPManagerNavigationPrefillsAddCommand(t *testing.T) {
 		t.Fatal("expected MCP manager to open")
 	}
 
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("custom remote")})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected MCP manager search to update synchronously")
+	}
+
 	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
 	if cmd != nil {
@@ -238,6 +244,57 @@ func TestMCPManagerNavigationPrefillsAddCommand(t *testing.T) {
 		t.Fatal("expected add command selection to close the MCP manager")
 	}
 	if got, want := next.input.Value(), "/mcp add <name> --url <url>"; got != want {
+		t.Fatalf("composer = %q, want %q", got, want)
+	}
+}
+
+func TestMCPManagerSearchFiltersMarketplace(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width = 120
+	m.height = 36
+	m.input.SetValue("/mcp")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("playwright")})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected search typing to be synchronous")
+	}
+
+	view := plainRender(t, next.View())
+	for _, want := range []string{
+		"search > playwright",
+		"Marketplace",
+		"Playwright",
+		"@playwright/mcp",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("MCP marketplace search missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Filesystem") {
+		t.Fatalf("MCP marketplace search should filter non-matching entries:\n%s", view)
+	}
+}
+
+func TestMCPManagerMarketplaceSelectionPrefillsInstallCommand(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/mcp")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("context7")})
+	next = updated.(model)
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected marketplace selection to prefill synchronously")
+	}
+	if next.mcpManager != nil {
+		t.Fatal("expected marketplace install selection to close manager")
+	}
+	if got, want := next.input.Value(), "/mcp add context7 --url https://mcp.context7.com/mcp"; got != want {
 		t.Fatalf("composer = %q, want %q", got, want)
 	}
 }
@@ -268,7 +325,7 @@ func TestMCPManagerRunsSelectedServerAction(t *testing.T) {
 		t.Fatal("expected MCP manager to open")
 	}
 
-	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d"), Alt: true})
 	next = updated.(model)
 	if cmd != nil {
 		t.Fatal("expected MCP action to run synchronously")

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -278,6 +278,25 @@ func TestMCPManagerSearchFiltersMarketplace(t *testing.T) {
 	}
 }
 
+func TestMCPManagerDeleteEditsSearchQuery(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/mcp")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("play")})
+	next = updated.(model)
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyDelete})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected Delete in MCP search to update synchronously")
+	}
+	if next.mcpManager == nil || next.mcpManager.query != "pla" {
+		t.Fatalf("query after Delete = %#v, want pla", next.mcpManager)
+	}
+}
+
 func TestMCPManagerMarketplaceSelectionPrefillsInstallCommand(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.input.SetValue("/mcp")

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -1,8 +1,18 @@
 package tui
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	internalmcp "github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 func TestFormatCommandHelpLinesGroupsCommandsByStableOrder(t *testing.T) {
@@ -33,6 +43,7 @@ func TestFormatCommandHelpLinesGroupsCommandsByStableOrder(t *testing.T) {
 		"  /permissions - Show the active permission mode and sandbox grants.",
 		"  /debug (/debug-mode) - Show debug mode status.",
 		"tools:",
+		"  /mcp (/mcp-status) - Show MCP server status.",
 		"  /search <query> (/find) - Search local session events. Requires a query argument.",
 		"meta:",
 		"  /exit (/quit) - Exit Zero.",
@@ -43,9 +54,192 @@ func TestFormatCommandHelpLinesGroupsCommandsByStableOrder(t *testing.T) {
 	}
 }
 
+func TestMCPCommandMetadataAndAutocomplete(t *testing.T) {
+	command, ok := resolveCommand("/mcp")
+	if !ok {
+		t.Fatal("expected /mcp to resolve")
+	}
+	if command.kind == commandUnknown || command.kind == commandPrompt || command.kind == commandEmpty {
+		t.Fatalf("expected /mcp to resolve to a concrete command kind, got %v", command.kind)
+	}
+	if command.group != commandGroupTools {
+		t.Fatalf("expected /mcp in tools group, got %q", command.group)
+	}
+	if commandSelectionRequiresInput("/mcp") {
+		t.Fatal("/mcp should run without required input")
+	}
+
+	alias, ok := resolveCommand("/mcp-status")
+	if !ok || alias.kind != command.kind {
+		t.Fatalf("expected /mcp-status to resolve to MCP command, got ok=%v command=%#v", ok, alias)
+	}
+
+	names := listCommandNames()
+	for _, want := range []string{"/mcp", "/mcp-status"} {
+		if !commandTestStringSliceContains(names, want) {
+			t.Fatalf("expected command names to contain %s, got %#v", want, names)
+		}
+	}
+
+	for _, token := range []string{"/mc", "/mcp-status"} {
+		if !commandSuggestionNamesContain(matchCommandSuggestions(token), "/mcp") {
+			t.Fatalf("expected autocomplete for %q to surface canonical /mcp", token)
+		}
+	}
+}
+
+func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
+	registry := tools.NewRegistry()
+	registry.Register(commandTestMCPTool{
+		name:        "mcp_docs_lookup",
+		serverName:  "docs",
+		description: "Look up docs",
+		safety: tools.Safety{
+			SideEffect: tools.SideEffectNetwork,
+			Permission: tools.PermissionPrompt,
+		},
+	})
+
+	permissionStore, err := internalmcp.NewPermissionStore(internalmcp.StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-permissions.json"),
+		Now:      func() time.Time { return time.Date(2026, 6, 13, 9, 30, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewPermissionStore returned error: %v", err)
+	}
+	if _, err := permissionStore.GrantServer(internalmcp.GrantServerInput{
+		ServerName:     "docs",
+		ServerIdentity: "docs-identity",
+		MaxAutonomy:    internalmcp.AutonomyLow,
+	}); err != nil {
+		t.Fatalf("GrantServer returned error: %v", err)
+	}
+	if _, err := permissionStore.GrantTool(internalmcp.GrantToolInput{
+		ServerName:     "github",
+		ServerIdentity: "github-identity",
+		ToolName:       "create_issue",
+		MaxAutonomy:    internalmcp.AutonomyMedium,
+	}); err != nil {
+		t.Fatalf("GrantTool returned error: %v", err)
+	}
+
+	tokenStore, err := internalmcp.NewTokenStore(internalmcp.TokenStoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "mcp-oauth.json"),
+		Now:      func() time.Time { return time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewTokenStore returned error: %v", err)
+	}
+	if err := tokenStore.Save("github", internalmcp.StoredToken{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		TokenType:    "Bearer",
+		Scopes:       []string{"issues:read", "issues:write"},
+		ExpiresAt:    time.Date(2026, 6, 13, 11, 45, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Save token returned error: %v", err)
+	}
+
+	m := newModel(context.Background(), Options{
+		Registry:       registry,
+		PermissionMode: agent.PermissionModeAsk,
+	})
+	m.mcpConfig = config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {
+			Type:    "stdio",
+			Command: "zero-docs-mcp",
+			Args:    []string{"--workspace", "."},
+		},
+		"github": {
+			Type: "http",
+			URL:  "https://mcp.github.example",
+			Auth: "oauth",
+			OAuth: &config.MCPOAuthConfig{
+				Scopes: []string{"issues:read", "issues:write"},
+			},
+		},
+	}}
+	m.mcpPermissionStore = permissionStore
+	m.mcpTokenStore = tokenStore
+	m.input.SetValue("/mcp")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /mcp to be handled without starting an agent run")
+	}
+	if next.pending || next.activeRunID != 0 || next.runID != 0 {
+		t.Fatalf("expected /mcp not to mutate agent run state, pending=%v activeRunID=%d runID=%d", next.pending, next.activeRunID, next.runID)
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{
+		"MCP",
+		"status: ok",
+		"Servers",
+		"docs [stdio] enabled 1 tool - zero-docs-mcp --workspace .",
+		"github [http] enabled oauth - https://mcp.github.example",
+		"Tools",
+		"mcp_docs_lookup [network/prompt] - docs/lookup - Look up docs",
+		"Permissions",
+		"mode: ask",
+		"persistent grants: 2",
+		"server grants: 1",
+		"tool grants: 1",
+		"docs/* [low] approved 2026-06-13T09:30:00Z",
+		"github/create_issue [medium] approved 2026-06-13T09:30:00Z",
+		"OAuth",
+		"github configured token refresh expires 2026-06-13T11:45:00Z Bearer scopes issues:read,issues:write",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected MCP status text to contain %q, got:\n%s", want, text)
+		}
+	}
+}
+
+type commandTestMCPTool struct {
+	name        string
+	serverName  string
+	description string
+	safety      tools.Safety
+}
+
+func (tool commandTestMCPTool) Name() string {
+	return tool.name
+}
+
+func (tool commandTestMCPTool) Description() string {
+	return tool.description
+}
+
+func (tool commandTestMCPTool) Parameters() tools.Schema {
+	return tools.Schema{Type: "object"}
+}
+
+func (tool commandTestMCPTool) Safety() tools.Safety {
+	return tool.safety
+}
+
+func (tool commandTestMCPTool) Run(context.Context, map[string]any) tools.Result {
+	return tools.Result{Status: tools.StatusOK}
+}
+
+func (tool commandTestMCPTool) MCPServerName() string {
+	return tool.serverName
+}
+
 func commandTestStringSliceContains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func commandSuggestionNamesContain(suggestions []commandSuggestion, want string) bool {
+	for _, suggestion := range suggestions {
+		if suggestion.Name == want {
 			return true
 		}
 	}

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -509,6 +509,91 @@ func TestMCPAddWizardSavesRemoteWithPastedHeader(t *testing.T) {
 	}
 }
 
+func TestChatMCPSetupStitchURLOpensPrefilledWizard(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width = 120
+	m.height = 36
+	m.input.SetValue("configure this MCP https://stitch.withgoogle.com/docs/mcp/setup")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected MCP setup intent to open synchronously")
+	}
+	if next.pending {
+		t.Fatal("MCP setup intent should not start an agent run before confirmation")
+	}
+	if next.mcpAddWizard == nil {
+		t.Fatal("expected MCP setup intent to open add wizard")
+	}
+	if next.mcpAddWizard.step != mcpAddWizardStepConfirm {
+		t.Fatalf("wizard step = %v, want confirm", next.mcpAddWizard.step)
+	}
+	view := plainRender(t, next.View())
+	for _, want := range []string{
+		"Add MCP Server",
+		"Review setup",
+		"stitch",
+		"STDIO",
+		"npx -y @_davideast/stitch-mcp@latest proxy",
+		"Google Cloud auth",
+		"stitch.withgoogle.com/docs/mcp/setup",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("Stitch setup wizard missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(transcriptText(next.transcript), "No provider configured") {
+		t.Fatalf("MCP setup intent should not fall through to provider error:\n%s", transcriptText(next.transcript))
+	}
+}
+
+func TestChatMCPSetupStitchConfirmSavesServer(t *testing.T) {
+	var called []string
+	m := newModel(context.Background(), Options{
+		MCPCommand: func(args []string) MCPCommandResult {
+			called = append([]string{}, args...)
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "Added MCP server stitch.",
+				Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+					"stitch": {Type: "stdio", Command: "npx", Args: []string{"-y", "@_davideast/stitch-mcp@latest", "proxy"}},
+				}},
+			}
+		},
+	})
+	m.width = 120
+	m.height = 36
+	m.input.SetValue("setup stitch mcp from https://stitch.withgoogle.com/docs/mcp/setup")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected MCP setup intent to open synchronously")
+	}
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected MCP setup save to run synchronously")
+	}
+
+	want := []string{"add", "stitch", "--type", "stdio", "--", "npx", "-y", "@_davideast/stitch-mcp@latest", "proxy"}
+	if !reflect.DeepEqual(called, want) {
+		t.Fatalf("MCPCommand args = %#v, want %#v", called, want)
+	}
+	if _, ok := next.mcpConfig.Servers["stitch"]; !ok {
+		t.Fatalf("stitch server was not applied to TUI state: %#v", next.mcpConfig.Servers)
+	}
+	view := plainRender(t, next.View())
+	for _, want := range []string{"MCP server ready", "stitch", "connected", "Use server"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("saved Stitch result missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestMCPManagerRunsSelectedServerAction(t *testing.T) {
 	var called []string
 	m := newModel(context.Background(), Options{

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -174,11 +174,13 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	}
 	text := transcriptText(next.transcript)
 	for _, want := range []string{
-		"MCP",
-		"status: ok",
-		"Servers",
-		"docs [stdio] enabled 1 tool - zero-docs-mcp --workspace .",
-		"github [http] enabled oauth - https://mcp.github.example",
+		"Manage MCP servers",
+		"2 servers",
+		"User MCPs",
+		"docs · enabled · 1 tool · stdio",
+		"zero mcp disable docs",
+		"github · enabled · oauth · http",
+		"zero mcp oauth login github",
 		"Tools",
 		"lookup [network/prompt] - mcp_docs_lookup - docs/lookup - Look up docs",
 		"Permissions",
@@ -190,6 +192,8 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 		"github/create_issue [medium] approved 2026-06-13T09:30:00Z",
 		"OAuth",
 		"github configured token refresh expires 2026-06-13T11:45:00Z Bearer scopes issues:read,issues:write",
+		"add: zero mcp add <name> --url <url>",
+		"disconnect: zero mcp disable <name>",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected MCP status text to contain %q, got:\n%s", want, text)

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -162,6 +162,8 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	}}
 	m.mcpPermissionStore = permissionStore
 	m.mcpTokenStore = tokenStore
+	m.width = 220
+	m.height = 42
 	m.input.SetValue("/mcp")
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -173,10 +175,13 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	if next.pending || next.activeRunID != 0 || next.runID != 0 {
 		t.Fatalf("expected /mcp not to mutate agent run state, pending=%v activeRunID=%d runID=%d", next.pending, next.activeRunID, next.runID)
 	}
-	if len(next.transcript) == 0 || next.transcript[len(next.transcript)-1].tool != "mcp" {
-		t.Fatalf("expected /mcp transcript row to use dedicated mcp renderer, got %#v", next.transcript)
+	if next.mcpManager == nil {
+		t.Fatal("expected /mcp to open the selectable MCP manager")
 	}
-	text := transcriptText(next.transcript)
+	if len(next.transcript) != len(m.transcript) {
+		t.Fatalf("/mcp should open a manager overlay without appending transcript rows; before=%d after=%d", len(m.transcript), len(next.transcript))
+	}
+	text := plainRender(t, next.View())
 	for _, want := range []string{
 		"Manage MCP servers",
 		"2 servers",
@@ -201,6 +206,83 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected MCP status text to contain %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestMCPManagerNavigationPrefillsAddCommand(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/mcp")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /mcp to open synchronously")
+	}
+	if next.mcpManager == nil {
+		t.Fatal("expected MCP manager to open")
+	}
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected MCP manager selection to prefill synchronously")
+	}
+	if next.mcpManager != nil {
+		t.Fatal("expected add command selection to close the MCP manager")
+	}
+	if got, want := next.input.Value(), "/mcp add <name> --url <url>"; got != want {
+		t.Fatalf("composer = %q, want %q", got, want)
+	}
+}
+
+func TestMCPManagerRunsSelectedServerAction(t *testing.T) {
+	var called []string
+	m := newModel(context.Background(), Options{
+		PermissionMode: agent.PermissionModeAsk,
+		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"docs": {Type: "stdio", Command: "zero-docs-mcp"},
+		}},
+		MCPCommand: func(args []string) MCPCommandResult {
+			called = append([]string{}, args...)
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "MCP server docs is now disabled.",
+				Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+					"docs": {Type: "stdio", Command: "zero-docs-mcp", Disabled: true},
+				}},
+			}
+		},
+	})
+	m.input.SetValue("/mcp")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if next.mcpManager == nil {
+		t.Fatal("expected MCP manager to open")
+	}
+
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("expected MCP action to run synchronously")
+	}
+	if !reflect.DeepEqual(called, []string{"disable", "docs"}) {
+		t.Fatalf("MCPCommand args = %#v, want disable docs", called)
+	}
+	if !next.mcpConfig.Servers["docs"].Disabled {
+		t.Fatalf("docs server was not disabled in TUI state: %#v", next.mcpConfig.Servers["docs"])
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{
+		"MCP action complete",
+		"MCP server docs is now disabled.",
+		"docs",
+		"disabled",
+		"stdio",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("MCP manager action output missing %q:\n%s", want, text)
 		}
 	}
 }

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -186,26 +186,32 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 		"Manage MCP servers",
 		"2 servers",
 		"User MCPs",
-		"docs · enabled · 1 tool · stdio",
-		"zero mcp disable docs",
-		"github · enabled · oauth · http",
-		"zero mcp oauth login github",
-		"Tools",
-		"lookup [network/prompt] - mcp_docs_lookup - docs/lookup - Look up docs",
-		"Permissions",
-		"mode: ask",
-		"persistent grants: 2",
-		"server grants: 1",
-		"tool grants: 1",
-		"docs/* [low] approved 2026-06-13T09:30:00Z",
-		"github/create_issue [medium] approved 2026-06-13T09:30:00Z",
-		"OAuth",
-		"github configured token refresh expires 2026-06-13T11:45:00Z Bearer scopes issues:read,issues:write",
-		"add: zero mcp add <name> --url <url>",
-		"disconnect: zero mcp disable <name>",
+		"docs",
+		"enabled",
+		"github",
+		"oauth",
+		"Add MCP server",
+		"Add local stdio MCP",
+		"List configured",
+		"d disable",
+		"r remove",
+		"Enter action",
+		"Esc close",
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("expected MCP status text to contain %q, got:\n%s", want, text)
+			t.Fatalf("expected clean MCP manager overlay to contain %q, got:\n%s", want, text)
+		}
+	}
+	for _, unwanted := range []string{
+		"lookup [network/prompt]",
+		"persistent grants:",
+		"server grants:",
+		"OAuth",
+		"add: zero mcp add",
+		"disconnect: zero mcp disable",
+	} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("MCP manager overlay should not include old status report text %q:\n%s", unwanted, text)
 		}
 	}
 }

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -393,6 +393,67 @@ func TestMCPCommandRunsManagerActionAndRefreshesState(t *testing.T) {
 	}
 }
 
+func TestMCPCommandPreservesQuotedArguments(t *testing.T) {
+	var called []string
+	m := newModel(context.Background(), Options{
+		MCPCommand: func(args []string) MCPCommandResult {
+			called = append([]string{}, args...)
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "Added MCP server docs.",
+				Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+					"docs": {Type: "stdio", Command: `C:\Program Files\docs mcp.exe`, Args: []string{"--label", "Zero Docs"}},
+				}},
+			}
+		},
+	})
+	m.input.SetValue(`/mcp add docs -- "C:\Program Files\docs mcp.exe" --label "Zero Docs"`)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /mcp add to run synchronously")
+	}
+	want := []string{"add", "docs", "--", `C:\Program Files\docs mcp.exe`, "--label", "Zero Docs"}
+	if !reflect.DeepEqual(called, want) {
+		t.Fatalf("MCPCommand args = %#v, want %#v", called, want)
+	}
+	if got := next.mcpConfig.Servers["docs"].Command; got != `C:\Program Files\docs mcp.exe` {
+		t.Fatalf("persisted command = %q", got)
+	}
+}
+
+func TestMCPCommandDoesNotApplyFailedConfig(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"docs": {Type: "stdio", Command: "zero-docs-mcp"},
+		}},
+		MCPCommand: func(args []string) MCPCommandResult {
+			return MCPCommandResult{
+				ExitCode: 1,
+				Error:    "permission denied",
+				Config:   config.MCPConfig{},
+			}
+		},
+	})
+	m.input.SetValue("/mcp disable docs")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected failed /mcp command to resolve synchronously")
+	}
+	if _, ok := next.mcpConfig.Servers["docs"]; !ok {
+		t.Fatalf("failed MCP command cleared existing config: %#v", next.mcpConfig.Servers)
+	}
+	text := transcriptText(next.transcript)
+	if !strings.Contains(text, "MCP action failed") || !strings.Contains(text, "permission denied") {
+		t.Fatalf("missing failure output:\n%s", text)
+	}
+}
+
 type commandTestMCPTool struct {
 	name        string
 	serverName  string

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -180,7 +180,7 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 		"docs [stdio] enabled 1 tool - zero-docs-mcp --workspace .",
 		"github [http] enabled oauth - https://mcp.github.example",
 		"Tools",
-		"mcp_docs_lookup [network/prompt] - docs/lookup - Look up docs",
+		"lookup [network/prompt] - mcp_docs_lookup - docs/lookup - Look up docs",
 		"Permissions",
 		"mode: ask",
 		"persistent grants: 2",

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,9 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	if next.pending || next.activeRunID != 0 || next.runID != 0 {
 		t.Fatalf("expected /mcp not to mutate agent run state, pending=%v activeRunID=%d runID=%d", next.pending, next.activeRunID, next.runID)
 	}
+	if len(next.transcript) == 0 || next.transcript[len(next.transcript)-1].tool != "mcp" {
+		t.Fatalf("expected /mcp transcript row to use dedicated mcp renderer, got %#v", next.transcript)
+	}
 	text := transcriptText(next.transcript)
 	for _, want := range []string{
 		"Manage MCP servers",
@@ -197,6 +201,49 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected MCP status text to contain %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestMCPCommandRunsManagerActionAndRefreshesState(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		PermissionMode: agent.PermissionModeAsk,
+		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"docs": {Type: "stdio", Command: "zero-docs-mcp"},
+		}},
+		MCPCommand: func(args []string) MCPCommandResult {
+			if !reflect.DeepEqual(args, []string{"disable", "docs"}) {
+				t.Fatalf("MCPCommand args = %#v, want disable docs", args)
+			}
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "MCP server docs is now disabled.",
+				Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+					"docs": {Type: "stdio", Command: "zero-docs-mcp", Disabled: true},
+				}},
+			}
+		},
+	})
+	m.input.SetValue("/mcp disable docs")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /mcp disable to run synchronously")
+	}
+	if !next.mcpConfig.Servers["docs"].Disabled {
+		t.Fatalf("docs server was not disabled in TUI state: %#v", next.mcpConfig.Servers["docs"])
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{
+		"MCP action complete",
+		"MCP server docs is now disabled.",
+		"docs · disabled · stdio",
+		"zero mcp enable docs",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("/mcp action text missing %q:\n%s", want, text)
 		}
 	}
 }

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
+func applyCommandResult(t *testing.T, m model, cmd tea.Cmd) model {
+	t.Helper()
+	msg := execCmd(cmd)
+	if msg == nil {
+		t.Fatal("expected command to return a result message")
+	}
+	updated, _ := m.Update(msg)
+	return updated.(model)
+}
+
 func TestFormatCommandHelpLinesGroupsCommandsByStableOrder(t *testing.T) {
 	lines := formatCommandHelpLines()
 	help := strings.Join(lines, "\n")
@@ -356,7 +366,7 @@ func TestMCPManagerAddRemoteOpensWizard(t *testing.T) {
 
 func TestMCPAddWizardInvalidURLShowsUnsavedResult(t *testing.T) {
 	m := newModel(context.Background(), Options{
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			t.Fatalf("MCPCommand should not run for invalid URL, got %#v", args)
 			return MCPCommandResult{}
 		},
@@ -405,7 +415,7 @@ func TestMCPAddWizardInvalidURLShowsUnsavedResult(t *testing.T) {
 func TestMCPAddWizardInvalidURLCanSaveDisabledDraft(t *testing.T) {
 	var called []string
 	m := newModel(context.Background(), Options{
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			called = append([]string{}, args...)
 			return MCPCommandResult{
 				ExitCode: 0,
@@ -420,7 +430,8 @@ func TestMCPAddWizardInvalidURLCanSaveDisabledDraft(t *testing.T) {
 	m.height = 36
 	m.mcpAddWizard = newMCPAddWizard("http")
 
-	for _, key := range []tea.KeyMsg{
+	var cmd tea.Cmd
+	for index, key := range []tea.KeyMsg{
 		{Type: tea.KeyRunes, Runes: []rune("draft")},
 		{Type: tea.KeyEnter},
 		{Type: tea.KeyEnter},
@@ -428,12 +439,17 @@ func TestMCPAddWizardInvalidURLCanSaveDisabledDraft(t *testing.T) {
 		{Type: tea.KeyEnter},
 		{Type: tea.KeyRunes, Runes: []rune("s")},
 	} {
-		updated, cmd := m.Update(key)
-		if cmd != nil {
+		updated, nextCmd := m.Update(key)
+		if nextCmd != nil && index != 5 {
 			t.Fatal("expected MCP add wizard input to update synchronously")
 		}
 		m = updated.(model)
+		cmd = nextCmd
 	}
+	if cmd == nil {
+		t.Fatal("expected save disabled action to run asynchronously")
+	}
+	m = applyCommandResult(t, m, cmd)
 
 	want := []string{"add", "draft", "--type", "http", "--disabled", "--url", "sxas"}
 	if !reflect.DeepEqual(called, want) {
@@ -453,7 +469,7 @@ func TestMCPAddWizardInvalidURLCanSaveDisabledDraft(t *testing.T) {
 func TestMCPAddWizardSavesRemoteWithPastedHeader(t *testing.T) {
 	var called []string
 	m := newModel(context.Background(), Options{
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			called = append([]string{}, args...)
 			return MCPCommandResult{
 				ExitCode: 0,
@@ -468,7 +484,8 @@ func TestMCPAddWizardSavesRemoteWithPastedHeader(t *testing.T) {
 	m.height = 36
 	m.mcpAddWizard = newMCPAddWizard("http")
 
-	for _, key := range []tea.KeyMsg{
+	var cmd tea.Cmd
+	for index, key := range []tea.KeyMsg{
 		{Type: tea.KeyRunes, Runes: []rune("docs")},
 		{Type: tea.KeyEnter},
 		{Type: tea.KeyEnter},
@@ -478,12 +495,17 @@ func TestMCPAddWizardSavesRemoteWithPastedHeader(t *testing.T) {
 		{Type: tea.KeyEnter},
 		{Type: tea.KeyEnter},
 	} {
-		updated, cmd := m.Update(key)
-		if cmd != nil {
+		updated, nextCmd := m.Update(key)
+		if nextCmd != nil && index != 7 {
 			t.Fatal("expected MCP add wizard input to update synchronously")
 		}
 		m = updated.(model)
+		cmd = nextCmd
 	}
+	if cmd == nil {
+		t.Fatal("expected MCP add wizard save to run asynchronously")
+	}
+	m = applyCommandResult(t, m, cmd)
 
 	want := []string{"add", "docs", "--type", "http", "--url", "https://docs.example/mcp", "--header", "Authorization=Bearer secret"}
 	if !reflect.DeepEqual(called, want) {
@@ -549,10 +571,33 @@ func TestChatMCPSetupStitchURLOpensPrefilledWizard(t *testing.T) {
 	}
 }
 
+func TestMCPAddWizardConfirmRedactsSensitiveSourceAndEndpoint(t *testing.T) {
+	wizard := newMCPAddWizard("http")
+	wizard.step = mcpAddWizardStepConfirm
+	wizard.serverName = "remote"
+	wizard.serverType = "http"
+	wizard.endpoint = "https://user:password@remote.example/mcp?access_token=endpoint-secret&safe=value#api_key=fragment-secret"
+	wizard.sourceLabel = "Remote Docs"
+	wizard.sourceURL = "https://docs.example/setup?api_key=docs-secret"
+	wizard.headerKey = "Authorization"
+
+	got := plainRender(t, wizard.render(120))
+	for _, leaked := range []string{"user:password", "endpoint-secret", "fragment-secret", "docs-secret"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("wizard confirm leaked %q in:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{"remote.example", "safe=value", "access_token=[REDACTED]", "api_key=[REDACTED]", "Authorization=[REDACTED]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("wizard confirm missing redacted context %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestChatMCPSetupStitchConfirmSavesServer(t *testing.T) {
 	var called []string
 	m := newModel(context.Background(), Options{
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			called = append([]string{}, args...)
 			return MCPCommandResult{
 				ExitCode: 0,
@@ -575,9 +620,10 @@ func TestChatMCPSetupStitchConfirmSavesServer(t *testing.T) {
 
 	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("expected MCP setup save to run synchronously")
+	if cmd == nil {
+		t.Fatal("expected MCP setup save to run asynchronously")
 	}
+	next = applyCommandResult(t, next, cmd)
 
 	want := []string{"add", "stitch", "--type", "stdio", "--", "npx", "-y", "@_davideast/stitch-mcp@latest", "proxy"}
 	if !reflect.DeepEqual(called, want) {
@@ -601,7 +647,7 @@ func TestMCPManagerRunsSelectedServerAction(t *testing.T) {
 		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
 			"docs": {Type: "stdio", Command: "zero-docs-mcp"},
 		}},
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			called = append([]string{}, args...)
 			return MCPCommandResult{
 				ExitCode: 0,
@@ -622,9 +668,13 @@ func TestMCPManagerRunsSelectedServerAction(t *testing.T) {
 
 	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d"), Alt: true})
 	next = updated.(model)
-	if cmd != nil {
-		t.Fatal("expected MCP action to run synchronously")
+	if cmd == nil {
+		t.Fatal("expected MCP action to run asynchronously")
 	}
+	if called != nil {
+		t.Fatalf("MCPCommand ran during Update; called=%#v", called)
+	}
+	next = applyCommandResult(t, next, cmd)
 	if !reflect.DeepEqual(called, []string{"disable", "docs"}) {
 		t.Fatalf("MCPCommand args = %#v, want disable docs", called)
 	}
@@ -651,7 +701,7 @@ func TestMCPCommandRunsManagerActionAndRefreshesState(t *testing.T) {
 		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
 			"docs": {Type: "stdio", Command: "zero-docs-mcp"},
 		}},
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			if !reflect.DeepEqual(args, []string{"disable", "docs"}) {
 				t.Fatalf("MCPCommand args = %#v, want disable docs", args)
 			}
@@ -669,9 +719,10 @@ func TestMCPCommandRunsManagerActionAndRefreshesState(t *testing.T) {
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
-	if cmd != nil {
-		t.Fatal("expected /mcp disable to run synchronously")
+	if cmd == nil {
+		t.Fatal("expected /mcp disable to run asynchronously")
 	}
+	next = applyCommandResult(t, next, cmd)
 	if !next.mcpConfig.Servers["docs"].Disabled {
 		t.Fatalf("docs server was not disabled in TUI state: %#v", next.mcpConfig.Servers["docs"])
 	}
@@ -691,7 +742,7 @@ func TestMCPCommandRunsManagerActionAndRefreshesState(t *testing.T) {
 func TestMCPCommandPreservesQuotedArguments(t *testing.T) {
 	var called []string
 	m := newModel(context.Background(), Options{
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			called = append([]string{}, args...)
 			return MCPCommandResult{
 				ExitCode: 0,
@@ -707,9 +758,10 @@ func TestMCPCommandPreservesQuotedArguments(t *testing.T) {
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
-	if cmd != nil {
-		t.Fatal("expected /mcp add to run synchronously")
+	if cmd == nil {
+		t.Fatal("expected /mcp add to run asynchronously")
 	}
+	next = applyCommandResult(t, next, cmd)
 	want := []string{"add", "docs", "--", `C:\Program Files\docs mcp.exe`, "--label", "Zero Docs"}
 	if !reflect.DeepEqual(called, want) {
 		t.Fatalf("MCPCommand args = %#v, want %#v", called, want)
@@ -724,7 +776,7 @@ func TestMCPCommandDoesNotApplyFailedConfig(t *testing.T) {
 		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
 			"docs": {Type: "stdio", Command: "zero-docs-mcp"},
 		}},
-		MCPCommand: func(args []string) MCPCommandResult {
+		MCPCommand: func(_ context.Context, args []string) MCPCommandResult {
 			return MCPCommandResult{
 				ExitCode: 1,
 				Error:    "permission denied",
@@ -737,9 +789,10 @@ func TestMCPCommandDoesNotApplyFailedConfig(t *testing.T) {
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next := updated.(model)
 
-	if cmd != nil {
-		t.Fatal("expected failed /mcp command to resolve synchronously")
+	if cmd == nil {
+		t.Fatal("expected failed /mcp command to run asynchronously")
 	}
+	next = applyCommandResult(t, next, cmd)
 	if _, ok := next.mcpConfig.Servers["docs"]; !ok {
 		t.Fatalf("failed MCP command cleared existing config: %#v", next.mcpConfig.Servers)
 	}

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -216,7 +216,7 @@ func TestMCPCommandRendersConfiguredStateWithoutAgentRun(t *testing.T) {
 	}
 }
 
-func TestMCPManagerNavigationPrefillsAddCommand(t *testing.T) {
+func TestMCPManagerNavigationOpensAddWizard(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m.input.SetValue("/mcp")
 
@@ -243,8 +243,11 @@ func TestMCPManagerNavigationPrefillsAddCommand(t *testing.T) {
 	if next.mcpManager != nil {
 		t.Fatal("expected add command selection to close the MCP manager")
 	}
-	if got, want := next.input.Value(), "/mcp add <name> --url <url>"; got != want {
-		t.Fatalf("composer = %q, want %q", got, want)
+	if next.mcpAddWizard == nil {
+		t.Fatal("expected add command selection to open the MCP wizard")
+	}
+	if got := next.input.Value(); got != "" {
+		t.Fatalf("composer = %q, want empty while wizard is active", got)
 	}
 }
 
@@ -315,6 +318,194 @@ func TestMCPManagerMarketplaceSelectionPrefillsInstallCommand(t *testing.T) {
 	}
 	if got, want := next.input.Value(), "/mcp add context7 --url https://mcp.context7.com/mcp"; got != want {
 		t.Fatalf("composer = %q, want %q", got, want)
+	}
+}
+
+func TestMCPManagerAddRemoteOpensWizard(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width = 120
+	m.height = 36
+	m.input.SetValue("/mcp")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a"), Alt: true})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected MCP add wizard to open synchronously")
+	}
+	if next.mcpManager != nil {
+		t.Fatal("expected MCP manager to close when add wizard opens")
+	}
+	if next.mcpAddWizard == nil {
+		t.Fatal("expected MCP add wizard to be active")
+	}
+	view := plainRender(t, next.View())
+	for _, want := range []string{
+		"Add MCP Server",
+		"Server Name",
+		"HTTP remote",
+		"Enter continue",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("MCP add wizard missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestMCPAddWizardInvalidURLShowsUnsavedResult(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		MCPCommand: func(args []string) MCPCommandResult {
+			t.Fatalf("MCPCommand should not run for invalid URL, got %#v", args)
+			return MCPCommandResult{}
+		},
+	})
+	m.width = 120
+	m.height = 36
+	m.mcpAddWizard = newMCPAddWizard("http")
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("adds")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("sxas")},
+		{Type: tea.KeyEnter},
+	} {
+		updated, cmd := m.Update(key)
+		if cmd != nil {
+			t.Fatal("expected MCP add wizard input to update synchronously")
+		}
+		m = updated.(model)
+	}
+
+	if m.mcpAddWizard == nil {
+		t.Fatal("expected wizard result to stay visible")
+	}
+	view := plainRender(t, m.View())
+	for _, want := range []string{
+		"MCP setup issue",
+		"adds",
+		"HTTP remote",
+		"URL could not be parsed",
+		"No config was saved yet.",
+		"Edit URL",
+		"Save disabled",
+		"Discard",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("invalid URL result missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Disable server") {
+		t.Fatalf("unsaved invalid result should not offer Disable server:\n%s", view)
+	}
+}
+
+func TestMCPAddWizardInvalidURLCanSaveDisabledDraft(t *testing.T) {
+	var called []string
+	m := newModel(context.Background(), Options{
+		MCPCommand: func(args []string) MCPCommandResult {
+			called = append([]string{}, args...)
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "Added MCP server draft.",
+				Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+					"draft": {Type: "http", URL: "sxas", Disabled: true},
+				}},
+			}
+		},
+	})
+	m.width = 120
+	m.height = 36
+	m.mcpAddWizard = newMCPAddWizard("http")
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("draft")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("sxas")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("s")},
+	} {
+		updated, cmd := m.Update(key)
+		if cmd != nil {
+			t.Fatal("expected MCP add wizard input to update synchronously")
+		}
+		m = updated.(model)
+	}
+
+	want := []string{"add", "draft", "--type", "http", "--disabled", "--url", "sxas"}
+	if !reflect.DeepEqual(called, want) {
+		t.Fatalf("MCPCommand args = %#v, want %#v", called, want)
+	}
+	if !m.mcpConfig.Servers["draft"].Disabled {
+		t.Fatalf("draft server was not saved disabled: %#v", m.mcpConfig.Servers["draft"])
+	}
+	view := plainRender(t, m.View())
+	for _, want := range []string{"MCP server saved", "disabled", "Edit config"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("disabled draft result missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestMCPAddWizardSavesRemoteWithPastedHeader(t *testing.T) {
+	var called []string
+	m := newModel(context.Background(), Options{
+		MCPCommand: func(args []string) MCPCommandResult {
+			called = append([]string{}, args...)
+			return MCPCommandResult{
+				ExitCode: 0,
+				Output:   "Added MCP server docs.",
+				Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+					"docs": {Type: "http", URL: "https://docs.example/mcp", Headers: map[string]string{"Authorization": "Bearer secret"}},
+				}},
+			}
+		},
+	})
+	m.width = 120
+	m.height = 36
+	m.mcpAddWizard = newMCPAddWizard("http")
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("docs")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("https://docs.example/mcp")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("Authorization: Bearer secret")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyEnter},
+	} {
+		updated, cmd := m.Update(key)
+		if cmd != nil {
+			t.Fatal("expected MCP add wizard input to update synchronously")
+		}
+		m = updated.(model)
+	}
+
+	want := []string{"add", "docs", "--type", "http", "--url", "https://docs.example/mcp", "--header", "Authorization=Bearer secret"}
+	if !reflect.DeepEqual(called, want) {
+		t.Fatalf("MCPCommand args = %#v, want %#v", called, want)
+	}
+	if m.mcpAddWizard == nil {
+		t.Fatal("expected saved result card to stay visible")
+	}
+	view := plainRender(t, m.View())
+	for _, want := range []string{
+		"MCP server ready",
+		"docs",
+		"connected",
+		"Use server",
+		"Manage tools",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("saved result missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Bearer secret") {
+		t.Fatalf("saved result leaked header secret:\n%s", view)
 	}
 }
 

--- a/internal/tui/mcp_add_wizard.go
+++ b/internal/tui/mcp_add_wizard.go
@@ -29,15 +29,18 @@ const (
 )
 
 type mcpAddWizardState struct {
-	step         mcpAddWizardStep
-	serverName   string
-	serverType   string
-	endpoint     string
-	headerInput  string
-	headerKey    string
-	selectedType int
-	err          string
-	result       mcpAddWizardResult
+	step          mcpAddWizardStep
+	serverName    string
+	serverType    string
+	endpoint      string
+	headerInput   string
+	headerKey     string
+	sourceLabel   string
+	sourceURL     string
+	prerequisites []string
+	selectedType  int
+	err           string
+	result        mcpAddWizardResult
 }
 
 type mcpAddWizardResult struct {
@@ -76,6 +79,27 @@ func newMCPAddWizard(defaultType string) *mcpAddWizardState {
 func (m model) openMCPAddWizard(defaultType string) model {
 	m.mcpManager = nil
 	m.mcpAddWizard = newMCPAddWizard(defaultType)
+	m.clearSuggestions()
+	return m
+}
+
+func (m model) openMCPAddWizardFromIntent(intent mcpSetupIntent) model {
+	m.mcpManager = nil
+	wizard := newMCPAddWizard(intent.ServerType)
+	wizard.serverName = strings.TrimSpace(intent.ServerName)
+	wizard.serverType = strings.TrimSpace(intent.ServerType)
+	wizard.endpoint = strings.TrimSpace(intent.Endpoint)
+	wizard.sourceLabel = strings.TrimSpace(intent.SourceLabel)
+	wizard.sourceURL = strings.TrimSpace(intent.SourceURL)
+	wizard.prerequisites = append([]string{}, intent.Prerequisites...)
+	for index, candidate := range mcpAddWizardTypes {
+		if candidate.ID == wizard.serverType {
+			wizard.selectedType = index
+			break
+		}
+	}
+	wizard.step = mcpAddWizardStepConfirm
+	m.mcpAddWizard = wizard
 	m.clearSuggestions()
 	return m
 }

--- a/internal/tui/mcp_add_wizard.go
+++ b/internal/tui/mcp_add_wizard.go
@@ -1,0 +1,412 @@
+package tui
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	internalmcp "github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+const (
+	mcpAddWizardMinWidth = 58
+	mcpAddWizardMaxWidth = 92
+)
+
+type mcpAddWizardStep int
+
+const (
+	mcpAddWizardStepName mcpAddWizardStep = iota
+	mcpAddWizardStepType
+	mcpAddWizardStepEndpoint
+	mcpAddWizardStepHeader
+	mcpAddWizardStepConfirm
+	mcpAddWizardStepResult
+)
+
+type mcpAddWizardState struct {
+	step         mcpAddWizardStep
+	serverName   string
+	serverType   string
+	endpoint     string
+	headerInput  string
+	headerKey    string
+	selectedType int
+	err          string
+	result       mcpAddWizardResult
+}
+
+type mcpAddWizardResult struct {
+	Title      string
+	State      string
+	Message    string
+	Saved      bool
+	Connected  bool
+	ToolCount  int
+	ActionHint string
+}
+
+var mcpAddWizardTypes = []struct {
+	ID    string
+	Label string
+	Meta  string
+}{
+	{ID: "http", Label: "HTTP remote", Meta: "streamable HTTP endpoint"},
+	{ID: "sse", Label: "SSE remote", Meta: "legacy server-sent events endpoint"},
+	{ID: "stdio", Label: "Local stdio", Meta: "local command process"},
+}
+
+func newMCPAddWizard(defaultType string) *mcpAddWizardState {
+	wizard := &mcpAddWizardState{step: mcpAddWizardStepName, serverType: "http"}
+	defaultType = strings.ToLower(strings.TrimSpace(defaultType))
+	for index, candidate := range mcpAddWizardTypes {
+		if candidate.ID == defaultType {
+			wizard.selectedType = index
+			wizard.serverType = candidate.ID
+			break
+		}
+	}
+	return wizard
+}
+
+func (m model) openMCPAddWizard(defaultType string) model {
+	m.mcpManager = nil
+	m.mcpAddWizard = newMCPAddWizard(defaultType)
+	m.clearSuggestions()
+	return m
+}
+
+func (m model) handleMCPAddWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
+	if m.mcpAddWizard == nil {
+		return m, nil
+	}
+	wizard := m.mcpAddWizard
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.mcpAddWizard = nil
+		return m, nil
+	case tea.KeyBackspace, tea.KeyCtrlH:
+		wizard.deleteRune()
+		return m, nil
+	case tea.KeyCtrlU:
+		wizard.clearCurrentInput()
+		return m, nil
+	case tea.KeyLeft:
+		wizard.back()
+		return m, nil
+	case tea.KeyUp:
+		if wizard.step == mcpAddWizardStepType || wizard.step == mcpAddWizardStepResult {
+			wizard.move(-1)
+		}
+		return m, nil
+	case tea.KeyDown, tea.KeyTab:
+		if wizard.step == mcpAddWizardStepType || wizard.step == mcpAddWizardStepResult {
+			wizard.move(1)
+		}
+		return m, nil
+	case tea.KeyRunes:
+		if wizard.step == mcpAddWizardStepResult {
+			return m.handleMCPAddWizardResultShortcut(msg)
+		}
+		wizard.appendRunes(msg.Runes)
+		return m, nil
+	case tea.KeyEnter, tea.KeyRight:
+		if wizard.step == mcpAddWizardStepResult {
+			return m.handleMCPAddWizardResultEnter()
+		}
+		return m.advanceMCPAddWizard()
+	}
+	return m, nil
+}
+
+func (m model) advanceMCPAddWizard() (model, tea.Cmd) {
+	wizard := m.mcpAddWizard
+	if wizard == nil {
+		return m, nil
+	}
+	wizard.err = ""
+	switch wizard.step {
+	case mcpAddWizardStepName:
+		name := strings.TrimSpace(wizard.serverName)
+		if err := internalmcp.ValidateServerName(name); err != nil {
+			wizard.err = err.Error()
+			return m, nil
+		}
+		wizard.serverName = name
+		wizard.step = mcpAddWizardStepType
+	case mcpAddWizardStepType:
+		wizard.serverType = mcpAddWizardTypes[clampInt(wizard.selectedType, 0, len(mcpAddWizardTypes)-1)].ID
+		wizard.step = mcpAddWizardStepEndpoint
+	case mcpAddWizardStepEndpoint:
+		if wizard.isRemote() {
+			if err := validateMCPAddWizardURL(wizard.endpoint); err != nil {
+				wizard.result = mcpAddWizardResult{
+					Title:      "MCP setup issue",
+					State:      "not saved",
+					Message:    "URL could not be parsed: " + strings.TrimSpace(wizard.endpoint),
+					ActionHint: "Edit URL",
+				}
+				wizard.step = mcpAddWizardStepResult
+				return m, nil
+			}
+			wizard.step = mcpAddWizardStepHeader
+			return m, nil
+		}
+		if strings.TrimSpace(wizard.endpoint) == "" {
+			wizard.err = "Command is required."
+			return m, nil
+		}
+		wizard.step = mcpAddWizardStepConfirm
+	case mcpAddWizardStepHeader:
+		if strings.TrimSpace(wizard.headerInput) == "" {
+			wizard.step = mcpAddWizardStepConfirm
+			return m, nil
+		}
+		key, value, err := parseMCPWizardHeader(wizard.headerInput)
+		if err != nil {
+			wizard.err = err.Error()
+			return m, nil
+		}
+		wizard.headerKey = key
+		wizard.headerInput = key + "=" + value
+		wizard.step = mcpAddWizardStepConfirm
+	case mcpAddWizardStepConfirm:
+		return m.saveMCPAddWizard(false)
+	}
+	return m, nil
+}
+
+func (m model) handleMCPAddWizardResultEnter() (model, tea.Cmd) {
+	wizard := m.mcpAddWizard
+	if wizard == nil {
+		return m, nil
+	}
+	if wizard.result.Connected {
+		m.mcpAddWizard = nil
+		return m.openMCPManager(), nil
+	}
+	wizard.step = mcpAddWizardStepEndpoint
+	wizard.err = ""
+	return m, nil
+}
+
+func (m model) handleMCPAddWizardResultShortcut(msg tea.KeyMsg) (model, tea.Cmd) {
+	if m.mcpAddWizard == nil {
+		return m, nil
+	}
+	switch strings.ToLower(string(msg.Runes)) {
+	case "e", "r":
+		m.mcpAddWizard.step = mcpAddWizardStepEndpoint
+		m.mcpAddWizard.err = ""
+	case "d":
+		m.mcpAddWizard = nil
+	case "s":
+		return m.saveMCPAddWizard(true)
+	}
+	return m, nil
+}
+
+func (m model) saveMCPAddWizard(disabled bool) (model, tea.Cmd) {
+	wizard := m.mcpAddWizard
+	if wizard == nil {
+		return m, nil
+	}
+	if m.mcpCommand == nil {
+		wizard.result = mcpAddWizardResult{Title: "MCP setup issue", State: "not saved", Message: "MCP action unavailable", ActionHint: "Discard"}
+		wizard.step = mcpAddWizardStepResult
+		return m, nil
+	}
+	args, err := wizard.commandArgs(disabled)
+	if err != nil {
+		wizard.err = err.Error()
+		return m, nil
+	}
+	result := m.mcpCommand(args)
+	if result.ExitCode != 0 || strings.TrimSpace(result.Error) != "" {
+		message := strings.TrimSpace(result.Error)
+		if message == "" {
+			message = strings.TrimSpace(result.Output)
+		}
+		if message == "" {
+			message = "MCP command failed"
+		}
+		wizard.result = mcpAddWizardResult{
+			Title:      "MCP setup issue",
+			State:      "not saved",
+			Message:    redaction.RedactString(message, redaction.Options{}),
+			ActionHint: "Edit config",
+		}
+		wizard.step = mcpAddWizardStepResult
+		return m, nil
+	}
+	if len(result.Config.Servers) > 0 || len(m.mcpConfig.Servers) > 0 {
+		m.mcpConfig = result.Config
+	}
+	server := result.Config.Servers[wizard.serverName]
+	wizard.result = mcpAddWizardResult{
+		Title:      "MCP server ready",
+		State:      "connected",
+		Saved:      true,
+		Connected:  true,
+		ToolCount:  0,
+		ActionHint: "Use server",
+	}
+	if disabled || server.Disabled {
+		wizard.result.Title = "MCP server saved"
+		wizard.result.State = "disabled"
+		wizard.result.Connected = false
+		wizard.result.ActionHint = "Edit config"
+	}
+	wizard.step = mcpAddWizardStepResult
+	return m, nil
+}
+
+func (wizard *mcpAddWizardState) commandArgs(disabled bool) ([]string, error) {
+	args := []string{"add", strings.TrimSpace(wizard.serverName), "--type", strings.TrimSpace(wizard.serverType)}
+	if disabled {
+		args = append(args, "--disabled")
+	}
+	if wizard.isRemote() {
+		args = append(args, "--url", strings.TrimSpace(wizard.endpoint))
+		if strings.TrimSpace(wizard.headerInput) != "" {
+			key, value, err := parseMCPWizardHeader(wizard.headerInput)
+			if err != nil {
+				return nil, err
+			}
+			args = append(args, "--header", key+"="+value)
+		}
+		return args, nil
+	}
+	command, err := splitMCPCommandArgs(wizard.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if len(command) == 0 {
+		return nil, fmt.Errorf("Command is required.")
+	}
+	args = append(args, "--")
+	args = append(args, command...)
+	return args, nil
+}
+
+func (wizard *mcpAddWizardState) appendRunes(runes []rune) {
+	if wizard == nil {
+		return
+	}
+	for _, r := range runes {
+		if r == '\n' || r == '\r' || r == '\t' || unicode.IsControl(r) {
+			continue
+		}
+		switch wizard.step {
+		case mcpAddWizardStepName:
+			wizard.serverName += string(r)
+		case mcpAddWizardStepEndpoint:
+			wizard.endpoint += string(r)
+		case mcpAddWizardStepHeader:
+			wizard.headerInput += string(r)
+		}
+	}
+	wizard.err = ""
+}
+
+func (wizard *mcpAddWizardState) deleteRune() {
+	if wizard == nil {
+		return
+	}
+	switch wizard.step {
+	case mcpAddWizardStepName:
+		wizard.serverName = trimLastRune(wizard.serverName)
+	case mcpAddWizardStepEndpoint:
+		wizard.endpoint = trimLastRune(wizard.endpoint)
+	case mcpAddWizardStepHeader:
+		wizard.headerInput = trimLastRune(wizard.headerInput)
+	}
+	wizard.err = ""
+}
+
+func (wizard *mcpAddWizardState) clearCurrentInput() {
+	if wizard == nil {
+		return
+	}
+	switch wizard.step {
+	case mcpAddWizardStepName:
+		wizard.serverName = ""
+	case mcpAddWizardStepEndpoint:
+		wizard.endpoint = ""
+	case mcpAddWizardStepHeader:
+		wizard.headerInput = ""
+		wizard.headerKey = ""
+	}
+	wizard.err = ""
+}
+
+func (wizard *mcpAddWizardState) back() {
+	if wizard == nil {
+		return
+	}
+	wizard.err = ""
+	switch wizard.step {
+	case mcpAddWizardStepType:
+		wizard.step = mcpAddWizardStepName
+	case mcpAddWizardStepEndpoint:
+		wizard.step = mcpAddWizardStepType
+	case mcpAddWizardStepHeader:
+		wizard.step = mcpAddWizardStepEndpoint
+	case mcpAddWizardStepConfirm:
+		if wizard.isRemote() {
+			wizard.step = mcpAddWizardStepHeader
+		} else {
+			wizard.step = mcpAddWizardStepEndpoint
+		}
+	case mcpAddWizardStepResult:
+		wizard.step = mcpAddWizardStepEndpoint
+	}
+}
+
+func (wizard *mcpAddWizardState) move(delta int) {
+	if wizard == nil {
+		return
+	}
+	if wizard.step == mcpAddWizardStepType {
+		wizard.selectedType = ((wizard.selectedType+delta)%len(mcpAddWizardTypes) + len(mcpAddWizardTypes)) % len(mcpAddWizardTypes)
+		wizard.serverType = mcpAddWizardTypes[wizard.selectedType].ID
+	}
+}
+
+func (wizard *mcpAddWizardState) isRemote() bool {
+	return wizard == nil || wizard.serverType == "http" || wizard.serverType == "sse" || wizard.serverType == ""
+}
+
+func validateMCPAddWizardURL(value string) error {
+	value = strings.TrimSpace(value)
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("URL could not be parsed")
+	}
+	return nil
+}
+
+func parseMCPWizardHeader(raw string) (string, string, error) {
+	key, value, ok := strings.Cut(raw, "=")
+	if !ok {
+		key, value, ok = strings.Cut(raw, ":")
+	}
+	key = strings.TrimSpace(key)
+	value = strings.TrimSpace(value)
+	if !ok || key == "" || value == "" {
+		return "", "", fmt.Errorf("Header must be in format Key: Value")
+	}
+	return key, value, nil
+}
+
+func trimLastRune(value string) string {
+	if value == "" {
+		return ""
+	}
+	runes := []rune(value)
+	return string(runes[:len(runes)-1])
+}

--- a/internal/tui/mcp_add_wizard.go
+++ b/internal/tui/mcp_add_wizard.go
@@ -78,6 +78,7 @@ func newMCPAddWizard(defaultType string) *mcpAddWizardState {
 }
 
 func (m model) openMCPAddWizard(defaultType string) model {
+	m.cancelMCPCommand()
 	m.mcpManager = nil
 	m.mcpAddWizard = newMCPAddWizard(defaultType)
 	m.clearSuggestions()
@@ -85,6 +86,7 @@ func (m model) openMCPAddWizard(defaultType string) model {
 }
 
 func (m model) openMCPAddWizardFromIntent(intent mcpSetupIntent) model {
+	m.cancelMCPCommand()
 	m.mcpManager = nil
 	wizard := newMCPAddWizard(intent.ServerType)
 	wizard.serverName = strings.TrimSpace(intent.ServerName)

--- a/internal/tui/mcp_add_wizard.go
+++ b/internal/tui/mcp_add_wizard.go
@@ -29,18 +29,19 @@ const (
 )
 
 type mcpAddWizardState struct {
-	step          mcpAddWizardStep
-	serverName    string
-	serverType    string
-	endpoint      string
-	headerInput   string
-	headerKey     string
-	sourceLabel   string
-	sourceURL     string
-	prerequisites []string
-	selectedType  int
-	err           string
-	result        mcpAddWizardResult
+	step           mcpAddWizardStep
+	serverName     string
+	serverType     string
+	endpoint       string
+	headerInput    string
+	headerKey      string
+	sourceLabel    string
+	sourceURL      string
+	prerequisites  []string
+	selectedType   int
+	resultSelected int
+	err            string
+	result         mcpAddWizardResult
 }
 
 type mcpAddWizardResult struct {
@@ -111,6 +112,7 @@ func (m model) handleMCPAddWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 	wizard := m.mcpAddWizard
 	switch msg.Type {
 	case tea.KeyEsc:
+		m.cancelMCPCommand()
 		m.mcpAddWizard = nil
 		return m, nil
 	case tea.KeyBackspace, tea.KeyCtrlH:
@@ -171,7 +173,7 @@ func (m model) advanceMCPAddWizard() (model, tea.Cmd) {
 				wizard.result = mcpAddWizardResult{
 					Title:      "MCP setup issue",
 					State:      "not saved",
-					Message:    "URL could not be parsed: " + strings.TrimSpace(wizard.endpoint),
+					Message:    "URL could not be parsed: " + redactMCPWizardDisplayValue(wizard.endpoint),
 					ActionHint: "Edit URL",
 				}
 				wizard.step = mcpAddWizardStepResult
@@ -181,7 +183,7 @@ func (m model) advanceMCPAddWizard() (model, tea.Cmd) {
 			return m, nil
 		}
 		if strings.TrimSpace(wizard.endpoint) == "" {
-			wizard.err = "Command is required."
+			wizard.err = "command is required"
 			return m, nil
 		}
 		wizard.step = mcpAddWizardStepConfirm
@@ -209,13 +211,22 @@ func (m model) handleMCPAddWizardResultEnter() (model, tea.Cmd) {
 	if wizard == nil {
 		return m, nil
 	}
-	if wizard.result.Connected {
+	switch wizard.currentResultAction() {
+	case "use", "manage":
 		m.mcpAddWizard = nil
 		return m.openMCPManager(), nil
+	case "retry":
+		return m.saveMCPAddWizard(false)
+	case "save-disabled", "disable":
+		return m.saveMCPAddWizard(true)
+	case "discard", "remove":
+		m.mcpAddWizard = nil
+		return m, nil
+	default:
+		wizard.step = mcpAddWizardStepEndpoint
+		wizard.err = ""
+		return m, nil
 	}
-	wizard.step = mcpAddWizardStepEndpoint
-	wizard.err = ""
-	return m, nil
 }
 
 func (m model) handleMCPAddWizardResultShortcut(msg tea.KeyMsg) (model, tea.Cmd) {
@@ -249,7 +260,17 @@ func (m model) saveMCPAddWizard(disabled bool) (model, tea.Cmd) {
 		wizard.err = err.Error()
 		return m, nil
 	}
-	result := m.mcpCommand(args)
+	wizard.result = mcpAddWizardResult{Title: "Testing MCP server", State: "running", Message: "Connecting and saving the MCP server...", ActionHint: "Esc cancels"}
+	wizard.resultSelected = 0
+	wizard.step = mcpAddWizardStepResult
+	return m.startMCPCommand(mcpCommandRequest{origin: mcpCommandOriginWizard, args: args, wizardDisabled: disabled})
+}
+
+func (m model) applyMCPAddWizardSaveResult(result MCPCommandResult, disabled bool) model {
+	wizard := m.mcpAddWizard
+	if wizard == nil {
+		return m
+	}
 	if result.ExitCode != 0 || strings.TrimSpace(result.Error) != "" {
 		message := strings.TrimSpace(result.Error)
 		if message == "" {
@@ -265,10 +286,12 @@ func (m model) saveMCPAddWizard(disabled bool) (model, tea.Cmd) {
 			ActionHint: "Edit config",
 		}
 		wizard.step = mcpAddWizardStepResult
-		return m, nil
+		wizard.resultSelected = 0
+		return m
 	}
 	if len(result.Config.Servers) > 0 || len(m.mcpConfig.Servers) > 0 {
 		m.mcpConfig = result.Config
+		m.refreshMCPViewState()
 	}
 	server := result.Config.Servers[wizard.serverName]
 	wizard.result = mcpAddWizardResult{
@@ -286,7 +309,8 @@ func (m model) saveMCPAddWizard(disabled bool) (model, tea.Cmd) {
 		wizard.result.ActionHint = "Edit config"
 	}
 	wizard.step = mcpAddWizardStepResult
-	return m, nil
+	wizard.resultSelected = 0
+	return m
 }
 
 func (wizard *mcpAddWizardState) commandArgs(disabled bool) ([]string, error) {
@@ -310,7 +334,7 @@ func (wizard *mcpAddWizardState) commandArgs(disabled bool) ([]string, error) {
 		return nil, err
 	}
 	if len(command) == 0 {
-		return nil, fmt.Errorf("Command is required.")
+		return nil, fmt.Errorf("command is required")
 	}
 	args = append(args, "--")
 	args = append(args, command...)
@@ -398,6 +422,13 @@ func (wizard *mcpAddWizardState) move(delta int) {
 	if wizard.step == mcpAddWizardStepType {
 		wizard.selectedType = ((wizard.selectedType+delta)%len(mcpAddWizardTypes) + len(mcpAddWizardTypes)) % len(mcpAddWizardTypes)
 		wizard.serverType = mcpAddWizardTypes[wizard.selectedType].ID
+		return
+	}
+	if wizard.step == mcpAddWizardStepResult {
+		count := len(wizard.resultActions())
+		if count > 0 {
+			wizard.resultSelected = ((wizard.resultSelected+delta)%count + count) % count
+		}
 	}
 }
 
@@ -409,7 +440,7 @@ func validateMCPAddWizardURL(value string) error {
 	value = strings.TrimSpace(value)
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return fmt.Errorf("URL could not be parsed")
+		return fmt.Errorf("url could not be parsed")
 	}
 	return nil
 }
@@ -422,9 +453,30 @@ func parseMCPWizardHeader(raw string) (string, string, error) {
 	key = strings.TrimSpace(key)
 	value = strings.TrimSpace(value)
 	if !ok || key == "" || value == "" {
-		return "", "", fmt.Errorf("Header must be in format Key: Value")
+		return "", "", fmt.Errorf("header must be in format key: value")
 	}
 	return key, value, nil
+}
+
+func (wizard *mcpAddWizardState) resultActions() []string {
+	if wizard == nil {
+		return nil
+	}
+	if wizard.result.Connected {
+		return []string{"use", "manage", "edit", "disable"}
+	}
+	if wizard.result.Saved {
+		return []string{"retry", "edit", "disable", "remove"}
+	}
+	return []string{"edit", "save-disabled", "discard"}
+}
+
+func (wizard *mcpAddWizardState) currentResultAction() string {
+	actions := wizard.resultActions()
+	if len(actions) == 0 {
+		return ""
+	}
+	return actions[clampInt(wizard.resultSelected, 0, len(actions)-1)]
 }
 
 func trimLastRune(value string) string {

--- a/internal/tui/mcp_add_wizard_view.go
+++ b/internal/tui/mcp_add_wizard_view.go
@@ -1,0 +1,208 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+func (m model) mcpAddWizardOverlay(width int) string {
+	if m.mcpAddWizard == nil {
+		return ""
+	}
+	return m.mcpAddWizard.render(width)
+}
+
+func (wizard *mcpAddWizardState) render(width int) string {
+	if wizard == nil {
+		return ""
+	}
+	overlayWidth := mcpAddWizardOverlayWidth(width)
+	innerWidth := maxInt(20, overlayWidth-4)
+	lines := []string{
+		zeroTheme.faint.Render(mcpAddWizardStepLine(wizard.step)),
+		zeroTheme.line.Render(strings.Repeat("-", innerWidth)),
+	}
+	if wizard.err != "" {
+		lines = append(lines, zeroTheme.red.Render("error: "+wizard.err), "")
+	}
+	switch wizard.step {
+	case mcpAddWizardStepName:
+		lines = append(lines, wizard.renderNameStep(innerWidth)...)
+	case mcpAddWizardStepType:
+		lines = append(lines, wizard.renderTypeStep(innerWidth)...)
+	case mcpAddWizardStepEndpoint:
+		lines = append(lines, wizard.renderEndpointStep(innerWidth)...)
+	case mcpAddWizardStepHeader:
+		lines = append(lines, wizard.renderHeaderStep(innerWidth)...)
+	case mcpAddWizardStepConfirm:
+		lines = append(lines, wizard.renderConfirmStep(innerWidth)...)
+	case mcpAddWizardStepResult:
+		lines = append(lines, wizard.renderResultStep(innerWidth)...)
+	}
+	lines = append(lines,
+		zeroTheme.line.Render(strings.Repeat("-", innerWidth)),
+		zeroTheme.faint.Render(wizard.footer()),
+	)
+	block := styledBlockFillTitle(overlayWidth, "Add MCP Server", lines, zeroTheme.lineStrong, lipgloss.NewStyle())
+	return centerRenderedBlock(block, width)
+}
+
+func (wizard *mcpAddWizardState) renderNameStep(width int) []string {
+	value := displayValue(strings.TrimSpace(wizard.serverName), "type a stable name")
+	return []string{
+		zeroTheme.accent.Render("Server Name"),
+		fitStyledLine(zeroTheme.ink.Render("> "+value), width),
+		zeroTheme.faint.Render("Default: " + mcpAddWizardTypes[clampInt(wizard.selectedType, 0, len(mcpAddWizardTypes)-1)].Label),
+		zeroTheme.faint.Render("Use lowercase letters, numbers, dashes, or underscores."),
+	}
+}
+
+func (wizard *mcpAddWizardState) renderTypeStep(width int) []string {
+	lines := []string{zeroTheme.accent.Render("Server Type")}
+	for index, item := range mcpAddWizardTypes {
+		marker := "  "
+		surface := transparentSurface
+		if index == wizard.selectedType {
+			marker = "> "
+			surface = zeroTheme.onSel
+		}
+		line := marker + item.Label
+		if item.Meta != "" {
+			line += "  " + item.Meta
+		}
+		lines = append(lines, fillPaletteLine(surface(zeroTheme.ink).Render(line), width, surface))
+	}
+	return lines
+}
+
+func (wizard *mcpAddWizardState) renderEndpointStep(width int) []string {
+	title := "Endpoint URL"
+	placeholder := "https://example.com/mcp"
+	if !wizard.isRemote() {
+		title = "Command"
+		placeholder = "npx -y @modelcontextprotocol/server-filesystem ."
+	}
+	value := displayValue(strings.TrimSpace(wizard.endpoint), placeholder)
+	return []string{
+		zeroTheme.accent.Render(title),
+		fitStyledLine(zeroTheme.ink.Render("> "+value), width),
+	}
+}
+
+func (wizard *mcpAddWizardState) renderHeaderStep(width int) []string {
+	value := displayValue(strings.TrimSpace(wizard.headerInput), "press Enter to skip")
+	return []string{
+		zeroTheme.accent.Render("Add header"),
+		fitStyledLine(zeroTheme.ink.Render("> "+redaction.RedactString(value, redaction.Options{})), width),
+		zeroTheme.faint.Render(`Paste "Key: Value" or "Key=Value".`),
+	}
+}
+
+func (wizard *mcpAddWizardState) renderConfirmStep(width int) []string {
+	lines := []string{
+		zeroTheme.accent.Render("Review setup"),
+		"server: " + zeroTheme.ink.Render(wizard.serverName),
+		"type: " + zeroTheme.ink.Render(strings.ToUpper(wizard.serverType)),
+	}
+	if wizard.isRemote() {
+		lines = append(lines, "url: "+zeroTheme.ink.Render(wizard.endpoint))
+		if wizard.headerKey != "" {
+			lines = append(lines, "header: "+zeroTheme.ink.Render(wizard.headerKey+"=[REDACTED]"))
+		}
+	} else {
+		lines = append(lines, "command: "+zeroTheme.ink.Render(wizard.endpoint))
+	}
+	lines = append(lines, "", zeroTheme.faint.Render("Enter saves and tests the server."))
+	for index, line := range lines {
+		lines[index] = fitStyledLine(line, width)
+	}
+	return lines
+}
+
+func (wizard *mcpAddWizardState) renderResultStep(width int) []string {
+	result := wizard.result
+	title := result.Title
+	if title == "" {
+		title = "MCP setup issue"
+	}
+	state := displayValue(result.State, "not saved")
+	transport := "HTTP remote"
+	if !wizard.isRemote() {
+		transport = "Local stdio"
+	} else if wizard.serverType == "sse" {
+		transport = "SSE remote"
+	}
+	lines := []string{
+		zeroTheme.accent.Render(title),
+		zeroTheme.ink.Bold(true).Render(displayValue(wizard.serverName, "unnamed")) + "  " + zeroTheme.faint.Render(state),
+		zeroTheme.faint.Render(transport),
+	}
+	if result.Message != "" {
+		lines = append(lines, fitStyledLine(zeroTheme.red.Render(result.Message), width))
+	}
+	if !result.Saved {
+		lines = append(lines, zeroTheme.faint.Render("No config was saved yet."))
+	} else {
+		lines = append(lines, fmt.Sprintf("Tools: %d discovered", maxInt(0, result.ToolCount)))
+	}
+	lines = append(lines, "")
+	if result.Connected {
+		lines = append(lines, "> Use server", "  Manage tools", "  Edit config", "  Disable server")
+	} else if result.Saved {
+		lines = append(lines, "> Retry connection", "  Edit config", "  Disable server", "  Remove server")
+	} else {
+		lines = append(lines, "> Edit URL", "  Save disabled", "  Discard")
+	}
+	for index, line := range lines {
+		lines[index] = fitStyledLine(line, width)
+	}
+	return lines
+}
+
+func (wizard *mcpAddWizardState) footer() string {
+	switch wizard.step {
+	case mcpAddWizardStepType:
+		return "up/down select   Enter continue   Esc close"
+	case mcpAddWizardStepResult:
+		return "Enter select   r retry   s save disabled   d discard"
+	default:
+		return "Enter continue   left back   Esc close"
+	}
+}
+
+func mcpAddWizardOverlayWidth(width int) int {
+	if width <= 0 {
+		return mcpAddWizardMaxWidth
+	}
+	target := minInt(width, mcpAddWizardMaxWidth)
+	if target < mcpAddWizardMinWidth {
+		return width
+	}
+	return target
+}
+
+func mcpAddWizardStepLine(step mcpAddWizardStep) string {
+	steps := []struct {
+		step  mcpAddWizardStep
+		label string
+	}{
+		{mcpAddWizardStepName, "1 name"},
+		{mcpAddWizardStepType, "2 type"},
+		{mcpAddWizardStepEndpoint, "3 endpoint"},
+		{mcpAddWizardStepHeader, "4 auth"},
+		{mcpAddWizardStepConfirm, "5 confirm"},
+	}
+	parts := make([]string, 0, len(steps))
+	for _, item := range steps {
+		if item.step == step {
+			parts = append(parts, "["+item.label+"]")
+		} else {
+			parts = append(parts, item.label)
+		}
+	}
+	return strings.Join(parts, "  ")
+}

--- a/internal/tui/mcp_add_wizard_view.go
+++ b/internal/tui/mcp_add_wizard_view.go
@@ -112,15 +112,15 @@ func (wizard *mcpAddWizardState) renderConfirmStep(width int) []string {
 		lines = append(lines, "source: "+zeroTheme.ink.Render(source))
 	}
 	if sourceURL := strings.TrimSpace(wizard.sourceURL); sourceURL != "" {
-		lines = append(lines, "docs: "+zeroTheme.ink.Render(sourceURL))
+		lines = append(lines, "docs: "+zeroTheme.ink.Render(redactMCPWizardDisplayValue(sourceURL)))
 	}
 	if wizard.isRemote() {
-		lines = append(lines, "url: "+zeroTheme.ink.Render(wizard.endpoint))
+		lines = append(lines, "url: "+zeroTheme.ink.Render(redactMCPWizardDisplayValue(wizard.endpoint)))
 		if wizard.headerKey != "" {
 			lines = append(lines, "header: "+zeroTheme.ink.Render(wizard.headerKey+"=[REDACTED]"))
 		}
 	} else {
-		lines = append(lines, "command: "+zeroTheme.ink.Render(wizard.endpoint))
+		lines = append(lines, "command: "+zeroTheme.ink.Render(redactMCPWizardCommand(wizard.endpoint)))
 	}
 	if len(wizard.prerequisites) > 0 {
 		lines = append(lines, "", zeroTheme.accent.Render("Needs"))
@@ -162,17 +162,58 @@ func (wizard *mcpAddWizardState) renderResultStep(width int) []string {
 		lines = append(lines, fmt.Sprintf("Tools: %d discovered", maxInt(0, result.ToolCount)))
 	}
 	lines = append(lines, "")
-	if result.Connected {
-		lines = append(lines, "> Use server", "  Manage tools", "  Edit config", "  Disable server")
-	} else if result.Saved {
-		lines = append(lines, "> Retry connection", "  Edit config", "  Disable server", "  Remove server")
-	} else {
-		lines = append(lines, "> Edit URL", "  Save disabled", "  Discard")
+	for index, action := range wizard.resultActionLabels() {
+		marker := "  "
+		if index == clampInt(wizard.resultSelected, 0, len(wizard.resultActionLabels())-1) {
+			marker = "> "
+		}
+		lines = append(lines, marker+action)
 	}
 	for index, line := range lines {
 		lines[index] = fitStyledLine(line, width)
 	}
 	return lines
+}
+
+func redactMCPWizardDisplayValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if looksLikeMCPDisplayURLValue(value) {
+		return redactMCPDisplayURL(value)
+	}
+	return redaction.RedactString(value, redaction.Options{})
+}
+
+func redactMCPWizardCommand(value string) string {
+	parts, err := splitMCPCommandArgs(value)
+	if err != nil || len(parts) == 0 {
+		return redactMCPWizardDisplayValue(value)
+	}
+	redacted := make([]string, 0, len(parts))
+	head := strings.TrimSpace(parts[0])
+	if looksLikeMCPDisplayURLValue(head) {
+		head = redactMCPDisplayURL(head)
+	} else {
+		head = redaction.RedactString(head, redaction.Options{})
+	}
+	redacted = append(redacted, head)
+	redacted = append(redacted, redactedCommandArgs(parts[1:])...)
+	return strings.Join(redacted, " ")
+}
+
+func (wizard *mcpAddWizardState) resultActionLabels() []string {
+	switch {
+	case wizard == nil:
+		return nil
+	case wizard.result.Connected:
+		return []string{"Use server", "Manage tools", "Edit config", "Disable server"}
+	case wizard.result.Saved:
+		return []string{"Retry connection", "Edit config", "Disable server", "Remove server"}
+	default:
+		return []string{"Edit URL", "Save disabled", "Discard"}
+	}
 }
 
 func (wizard *mcpAddWizardState) footer() string {

--- a/internal/tui/mcp_add_wizard_view.go
+++ b/internal/tui/mcp_add_wizard_view.go
@@ -108,6 +108,12 @@ func (wizard *mcpAddWizardState) renderConfirmStep(width int) []string {
 		"server: " + zeroTheme.ink.Render(wizard.serverName),
 		"type: " + zeroTheme.ink.Render(strings.ToUpper(wizard.serverType)),
 	}
+	if source := strings.TrimSpace(wizard.sourceLabel); source != "" {
+		lines = append(lines, "source: "+zeroTheme.ink.Render(source))
+	}
+	if sourceURL := strings.TrimSpace(wizard.sourceURL); sourceURL != "" {
+		lines = append(lines, "docs: "+zeroTheme.ink.Render(sourceURL))
+	}
 	if wizard.isRemote() {
 		lines = append(lines, "url: "+zeroTheme.ink.Render(wizard.endpoint))
 		if wizard.headerKey != "" {
@@ -115,6 +121,12 @@ func (wizard *mcpAddWizardState) renderConfirmStep(width int) []string {
 		}
 	} else {
 		lines = append(lines, "command: "+zeroTheme.ink.Render(wizard.endpoint))
+	}
+	if len(wizard.prerequisites) > 0 {
+		lines = append(lines, "", zeroTheme.accent.Render("Needs"))
+		for _, item := range wizard.prerequisites {
+			lines = append(lines, "  - "+zeroTheme.ink.Render(item))
+		}
 	}
 	lines = append(lines, "", zeroTheme.faint.Render("Enter saves and tests the server."))
 	for index, line := range lines {

--- a/internal/tui/mcp_manager.go
+++ b/internal/tui/mcp_manager.go
@@ -117,7 +117,7 @@ func (m model) handleMCPManagerKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		m.moveMCPManager(1)
 	case tea.KeyEnter:
 		return m.chooseMCPManagerItem()
-	case tea.KeyBackspace, tea.KeyCtrlH:
+	case tea.KeyBackspace, tea.KeyDelete, tea.KeyCtrlH:
 		m.deleteMCPManagerQueryRune()
 	case tea.KeyCtrlU:
 		m.mcpManager.query = ""

--- a/internal/tui/mcp_manager.go
+++ b/internal/tui/mcp_manager.go
@@ -129,9 +129,9 @@ func (m model) handleMCPManagerKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		}
 		switch strings.ToLower(string(msg.Runes)) {
 		case "a":
-			return m.prefillMCPManagerCommand("/mcp add <name> --url <url>"), nil
+			return m.openMCPAddWizard("http"), nil
 		case "s":
-			return m.prefillMCPManagerCommand("/mcp add <name> -- <command> [args...]"), nil
+			return m.openMCPAddWizard("stdio"), nil
 		case "l":
 			return m.runMCPManagerCommand([]string{"list"})
 		case "c":
@@ -200,9 +200,9 @@ func (m model) chooseMCPManagerItem() (model, tea.Cmd) {
 	case mcpManagerItemMarketplace:
 		return m.prefillMCPManagerCommand(item.InstallCommand), nil
 	case mcpManagerItemAddRemote:
-		return m.prefillMCPManagerCommand("/mcp add <name> --url <url>"), nil
+		return m.openMCPAddWizard("http"), nil
 	case mcpManagerItemAddStdio:
-		return m.prefillMCPManagerCommand("/mcp add <name> -- <command> [args...]"), nil
+		return m.openMCPAddWizard("stdio"), nil
 	case mcpManagerItemList:
 		return m.runMCPManagerCommand([]string{"list"})
 	default:

--- a/internal/tui/mcp_manager.go
+++ b/internal/tui/mcp_manager.go
@@ -181,7 +181,7 @@ func mcpManagerServerMeta(server MCPServerView) string {
 		parts = append(parts, pluralCount(server.ToolCount, "tool"))
 	}
 	parts = append(parts, displayValue(strings.TrimSpace(server.Transport), "unknown"))
-	return strings.Join(parts, " Â· ")
+	return strings.Join(parts, " · ")
 }
 
 func (m model) mcpManagerOverlay(width int) string {
@@ -201,32 +201,47 @@ func (m model) mcpManagerOverlay(width int) string {
 		m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
 	}
 
+	state := m.mcpViewState()
 	lines := []string{
-		fillPaletteLine(zeroTheme.faint.Render("â†‘/â†“ navigate   Enter action   a add remote   s add stdio   Esc close"), innerWidth, transparentSurface),
+		fillPaletteLine(zeroTheme.ink.Bold(true).Render(pluralCount(len(state.Servers), "server")), innerWidth, transparentSurface),
+		zeroTheme.accent.Bold(true).Render("User MCPs"),
 	}
-	lines = append(lines, m.renderMCPManagerItemLines(innerWidth, items)...)
-	lines = append(lines, zeroTheme.line.Render(strings.Repeat("â”€", innerWidth)))
-	for _, line := range strings.Split(renderMCPView(m.mcpViewState(), innerWidth), "\n") {
-		lines = append(lines, fitStyledLine(m.styleMCPManagerDetailLine(line), innerWidth))
+	if len(state.Servers) == 0 {
+		lines = append(lines, zeroTheme.faint.Render("  No MCP servers configured."))
 	}
+	itemLines, _ := m.renderMCPManagerItemLines(innerWidth, items)
+	lines = append(lines, itemLines...)
+	if detail := m.mcpManagerSelectionDetail(innerWidth); len(detail) > 0 {
+		lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+		lines = append(lines, detail...)
+	}
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
+	lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("up/down navigate   Enter action   a add remote   s add stdio   Esc close"), innerWidth, transparentSurface))
 	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, "Manage MCP servers", lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
 }
 
-func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) []string {
+func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) ([]string, []int) {
 	if len(items) == 0 {
-		return []string{fillPaletteLine(zeroTheme.faint.Render("  no MCP actions"), width, transparentSurface)}
+		return []string{fillPaletteLine(zeroTheme.faint.Render("  no MCP actions"), width, transparentSurface)}, []int{-1}
 	}
 	maxVisible := minInt(mcpManagerMaxVisible, len(items))
 	start := selectableListStart(len(items), maxVisible, m.mcpManager.selected)
 	visible := items[start : start+maxVisible]
 	lines := make([]string, 0, len(visible))
+	itemRows := make([]int, 0, len(visible))
+	lastKind := mcpManagerItemServer
 	for offset, item := range visible {
 		index := start + offset
+		if item.Kind != mcpManagerItemServer && (index == 0 || lastKind == mcpManagerItemServer) {
+			lines = append(lines, zeroTheme.accent.Bold(true).Render("Actions"))
+			itemRows = append(itemRows, -1)
+		}
+		lastKind = item.Kind
 		surface := transparentSurface
 		marker := surface(zeroTheme.faintest).Render("  ")
 		if index == m.mcpManager.selected {
 			surface = zeroTheme.onSel
-			marker = surface(zeroTheme.accent).Render("â¯ ")
+			marker = surface(zeroTheme.accent).Render("› ")
 		}
 		left := marker + surface(zeroTheme.ink).Render(item.Label)
 		right := ""
@@ -236,22 +251,50 @@ func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) []st
 		gap := width - lipgloss.Width(left) - lipgloss.Width(right)
 		line := left + surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(1, gap))) + right
 		lines = append(lines, fillPaletteLine(line, width, surface))
+		itemRows = append(itemRows, index)
 	}
-	return lines
+	return lines, itemRows
 }
 
-func (m model) styleMCPManagerDetailLine(line string) string {
-	trimmed := strings.TrimSpace(line)
-	switch {
-	case trimmed == "":
-		return ""
-	case trimmed == "Manage MCP servers", trimmed == "User MCPs", trimmed == "Tools", trimmed == "Permissions", trimmed == "OAuth", trimmed == "Actions":
-		return zeroTheme.accent.Bold(true).Render(line)
-	case strings.Contains(trimmed, "zero mcp "):
-		return zeroTheme.ink.Render(line)
-	case strings.HasPrefix(trimmed, "â€º") || strings.HasPrefix(trimmed, "- "):
-		return zeroTheme.ink.Render(line)
-	default:
-		return zeroTheme.muted.Render(line)
+func (m model) mcpManagerSelectionDetail(width int) []string {
+	item, ok := m.currentMCPManagerItem()
+	if !ok {
+		return nil
 	}
+	switch item.Kind {
+	case mcpManagerItemServer:
+		server, ok := m.mcpManagerServer(item.Name)
+		if !ok {
+			return nil
+		}
+		lines := []string{
+			fillPaletteLine(zeroTheme.ink.Bold(true).Render(server.Name)+" "+zeroTheme.faint.Render(server.Transport+" · "+server.State), width, transparentSurface),
+		}
+		if target := strings.TrimSpace(server.Target); target != "" {
+			lines = append(lines, fitStyledLine(zeroTheme.faint.Render(target), width))
+		}
+		action := "d disable"
+		if strings.EqualFold(strings.TrimSpace(server.State), "disabled") {
+			action = "e enable"
+		}
+		lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("Enter check   c check   "+action+"   r remove"), width, transparentSurface))
+		return lines
+	case mcpManagerItemAddRemote:
+		return []string{fillPaletteLine(zeroTheme.faint.Render("Enter fills composer: /mcp add <name> --url <url>"), width, transparentSurface)}
+	case mcpManagerItemAddStdio:
+		return []string{fillPaletteLine(zeroTheme.faint.Render("Enter fills composer: /mcp add <name> -- <command> [args...]"), width, transparentSurface)}
+	case mcpManagerItemList:
+		return []string{fillPaletteLine(zeroTheme.faint.Render("Enter runs zero mcp list and refreshes this manager."), width, transparentSurface)}
+	default:
+		return nil
+	}
+}
+
+func (m model) mcpManagerServer(name string) (MCPServerView, bool) {
+	for _, server := range m.mcpViewState().Servers {
+		if server.Name == name {
+			return server, true
+		}
+	}
+	return MCPServerView{}, false
 }

--- a/internal/tui/mcp_manager.go
+++ b/internal/tui/mcp_manager.go
@@ -1,0 +1,257 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	mcpManagerOverlayMaxWidth = 168
+	mcpManagerOverlayMinWidth = 58
+	mcpManagerMaxVisible      = 7
+)
+
+type mcpManagerState struct {
+	selected int
+}
+
+type mcpManagerItemKind int
+
+const (
+	mcpManagerItemServer mcpManagerItemKind = iota
+	mcpManagerItemAddRemote
+	mcpManagerItemAddStdio
+	mcpManagerItemList
+)
+
+type mcpManagerItem struct {
+	Kind  mcpManagerItemKind
+	Name  string
+	Label string
+	Meta  string
+}
+
+func (m model) openMCPManager() model {
+	m.mcpManager = &mcpManagerState{}
+	m.clearSuggestions()
+	return m
+}
+
+func (m model) handleMCPManagerKey(msg tea.KeyMsg) (model, tea.Cmd) {
+	if m.mcpManager == nil {
+		return m, nil
+	}
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.mcpManager = nil
+	case tea.KeyUp:
+		m.moveMCPManager(-1)
+	case tea.KeyDown, tea.KeyTab:
+		m.moveMCPManager(1)
+	case tea.KeyEnter:
+		return m.chooseMCPManagerItem()
+	case tea.KeyRunes:
+		switch strings.ToLower(string(msg.Runes)) {
+		case "a":
+			return m.prefillMCPManagerCommand("/mcp add <name> --url <url>"), nil
+		case "s":
+			return m.prefillMCPManagerCommand("/mcp add <name> -- <command> [args...]"), nil
+		case "l":
+			return m.runMCPManagerCommand([]string{"list"})
+		case "c":
+			if item, ok := m.currentMCPManagerItem(); ok && item.Kind == mcpManagerItemServer {
+				return m.runMCPManagerCommand([]string{"check", item.Name})
+			}
+		case "d":
+			if item, ok := m.currentMCPManagerItem(); ok && item.Kind == mcpManagerItemServer {
+				return m.runMCPManagerCommand([]string{"disable", item.Name})
+			}
+		case "e":
+			if item, ok := m.currentMCPManagerItem(); ok && item.Kind == mcpManagerItemServer {
+				return m.runMCPManagerCommand([]string{"enable", item.Name})
+			}
+		case "r":
+			if item, ok := m.currentMCPManagerItem(); ok && item.Kind == mcpManagerItemServer {
+				return m.runMCPManagerCommand([]string{"remove", item.Name})
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m *model) moveMCPManager(delta int) {
+	if m.mcpManager == nil {
+		return
+	}
+	count := len(m.mcpManagerItems())
+	if count == 0 {
+		m.mcpManager.selected = 0
+		return
+	}
+	m.mcpManager.selected = ((m.mcpManager.selected+delta)%count + count) % count
+}
+
+func (m model) chooseMCPManagerItem() (model, tea.Cmd) {
+	item, ok := m.currentMCPManagerItem()
+	if !ok {
+		return m, nil
+	}
+	switch item.Kind {
+	case mcpManagerItemServer:
+		return m.runMCPManagerCommand([]string{"check", item.Name})
+	case mcpManagerItemAddRemote:
+		return m.prefillMCPManagerCommand("/mcp add <name> --url <url>"), nil
+	case mcpManagerItemAddStdio:
+		return m.prefillMCPManagerCommand("/mcp add <name> -- <command> [args...]"), nil
+	case mcpManagerItemList:
+		return m.runMCPManagerCommand([]string{"list"})
+	default:
+		return m, nil
+	}
+}
+
+func (m model) prefillMCPManagerCommand(command string) model {
+	m.mcpManager = nil
+	m.input.SetValue(command)
+	m.input.SetCursor(len([]rune(command)))
+	m.resetComposerFromInput()
+	m.clearSuggestions()
+	return m
+}
+
+func (m model) runMCPManagerCommand(args []string) (model, tea.Cmd) {
+	selected := 0
+	if m.mcpManager != nil {
+		selected = m.mcpManager.selected
+	}
+	text := ""
+	m, text = m.handleMCPCommand(strings.Join(args, " "))
+	m.mcpManager = &mcpManagerState{selected: selected}
+	if items := m.mcpManagerItems(); len(items) > 0 {
+		m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
+	}
+	if text != "" {
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
+	}
+	return m, nil
+}
+
+func (m model) currentMCPManagerItem() (mcpManagerItem, bool) {
+	if m.mcpManager == nil {
+		return mcpManagerItem{}, false
+	}
+	items := m.mcpManagerItems()
+	if len(items) == 0 {
+		return mcpManagerItem{}, false
+	}
+	m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
+	return items[m.mcpManager.selected], true
+}
+
+func (m model) mcpManagerItems() []mcpManagerItem {
+	state := m.mcpViewState()
+	items := make([]mcpManagerItem, 0, len(state.Servers)+3)
+	for _, server := range state.Servers {
+		name := displayValue(strings.TrimSpace(server.Name), "unnamed")
+		items = append(items, mcpManagerItem{
+			Kind:  mcpManagerItemServer,
+			Name:  name,
+			Label: name,
+			Meta:  mcpManagerServerMeta(server),
+		})
+	}
+	items = append(items,
+		mcpManagerItem{Kind: mcpManagerItemAddRemote, Label: "Add MCP server", Meta: "zero mcp add <name> --url <url>"},
+		mcpManagerItem{Kind: mcpManagerItemAddStdio, Label: "Add local stdio MCP", Meta: "zero mcp add <name> -- <command> [args...]"},
+		mcpManagerItem{Kind: mcpManagerItemList, Label: "List configured", Meta: "zero mcp list"},
+	)
+	return items
+}
+
+func mcpManagerServerMeta(server MCPServerView) string {
+	parts := []string{
+		displayValue(strings.TrimSpace(server.State), "configured"),
+	}
+	if auth := strings.TrimSpace(server.Auth); auth != "" {
+		parts = append(parts, auth)
+	}
+	if server.ToolCount > 0 {
+		parts = append(parts, pluralCount(server.ToolCount, "tool"))
+	}
+	parts = append(parts, displayValue(strings.TrimSpace(server.Transport), "unknown"))
+	return strings.Join(parts, " Â· ")
+}
+
+func (m model) mcpManagerOverlay(width int) string {
+	if m.mcpManager == nil {
+		return ""
+	}
+	if width <= 0 {
+		width = defaultStartupWidth
+	}
+	overlayWidth := minInt(width, mcpManagerOverlayMaxWidth)
+	if overlayWidth < mcpManagerOverlayMinWidth {
+		overlayWidth = width
+	}
+	innerWidth := maxInt(1, overlayWidth-4)
+	items := m.mcpManagerItems()
+	if len(items) > 0 {
+		m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
+	}
+
+	lines := []string{
+		fillPaletteLine(zeroTheme.faint.Render("â†‘/â†“ navigate   Enter action   a add remote   s add stdio   Esc close"), innerWidth, transparentSurface),
+	}
+	lines = append(lines, m.renderMCPManagerItemLines(innerWidth, items)...)
+	lines = append(lines, zeroTheme.line.Render(strings.Repeat("â”€", innerWidth)))
+	for _, line := range strings.Split(renderMCPView(m.mcpViewState(), innerWidth), "\n") {
+		lines = append(lines, fitStyledLine(m.styleMCPManagerDetailLine(line), innerWidth))
+	}
+	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, "Manage MCP servers", lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
+}
+
+func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) []string {
+	if len(items) == 0 {
+		return []string{fillPaletteLine(zeroTheme.faint.Render("  no MCP actions"), width, transparentSurface)}
+	}
+	maxVisible := minInt(mcpManagerMaxVisible, len(items))
+	start := selectableListStart(len(items), maxVisible, m.mcpManager.selected)
+	visible := items[start : start+maxVisible]
+	lines := make([]string, 0, len(visible))
+	for offset, item := range visible {
+		index := start + offset
+		surface := transparentSurface
+		marker := surface(zeroTheme.faintest).Render("  ")
+		if index == m.mcpManager.selected {
+			surface = zeroTheme.onSel
+			marker = surface(zeroTheme.accent).Render("â¯ ")
+		}
+		left := marker + surface(zeroTheme.ink).Render(item.Label)
+		right := ""
+		if item.Meta != "" {
+			right = surface(zeroTheme.faint).Render(item.Meta)
+		}
+		gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+		line := left + surface(zeroTheme.ink).Render(strings.Repeat(" ", maxInt(1, gap))) + right
+		lines = append(lines, fillPaletteLine(line, width, surface))
+	}
+	return lines
+}
+
+func (m model) styleMCPManagerDetailLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	switch {
+	case trimmed == "":
+		return ""
+	case trimmed == "Manage MCP servers", trimmed == "User MCPs", trimmed == "Tools", trimmed == "Permissions", trimmed == "OAuth", trimmed == "Actions":
+		return zeroTheme.accent.Bold(true).Render(line)
+	case strings.Contains(trimmed, "zero mcp "):
+		return zeroTheme.ink.Render(line)
+	case strings.HasPrefix(trimmed, "â€º") || strings.HasPrefix(trimmed, "- "):
+		return zeroTheme.ink.Render(line)
+	default:
+		return zeroTheme.muted.Render(line)
+	}
+}

--- a/internal/tui/mcp_manager.go
+++ b/internal/tui/mcp_manager.go
@@ -99,6 +99,7 @@ var mcpMarketplaceCatalog = []mcpMarketplaceEntry{
 }
 
 func (m model) openMCPManager() model {
+	m.refreshMCPViewState()
 	m.mcpManager = &mcpManagerState{}
 	m.clearSuggestions()
 	return m
@@ -220,22 +221,12 @@ func (m model) prefillMCPManagerCommand(command string) model {
 }
 
 func (m model) runMCPManagerCommand(args []string) (model, tea.Cmd) {
-	selected := 0
-	query := ""
+	request := mcpCommandRequest{origin: mcpCommandOriginManager, args: append([]string{}, args...)}
 	if m.mcpManager != nil {
-		selected = m.mcpManager.selected
-		query = m.mcpManager.query
+		request.managerSelected = m.mcpManager.selected
+		request.managerQuery = m.mcpManager.query
 	}
-	text := ""
-	m, text = m.handleMCPCommand(strings.Join(args, " "))
-	m.mcpManager = &mcpManagerState{selected: selected, query: query}
-	if items := m.mcpManagerItems(); len(items) > 0 {
-		m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
-	}
-	if text != "" {
-		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
-	}
-	return m, nil
+	return m.startMCPCommand(request)
 }
 
 func (m model) currentMCPManagerItem() (mcpManagerItem, bool) {
@@ -291,6 +282,14 @@ func (m model) mcpManagerItems() []mcpManagerItem {
 		}
 	}
 	return items
+}
+
+func mcpManagerFirstItemRow(state MCPViewState) int {
+	baseRow := 4 // top border + server count + search + "User MCPs"
+	if len(state.Servers) == 0 {
+		baseRow++
+	}
+	return baseRow
 }
 
 func mcpMarketplaceItem(entry mcpMarketplaceEntry) mcpManagerItem {

--- a/internal/tui/mcp_manager.go
+++ b/internal/tui/mcp_manager.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"strings"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -10,27 +11,91 @@ import (
 const (
 	mcpManagerOverlayMaxWidth = 168
 	mcpManagerOverlayMinWidth = 58
-	mcpManagerMaxVisible      = 7
+	mcpManagerMaxVisible      = 12
 )
 
 type mcpManagerState struct {
 	selected int
+	query    string
 }
 
 type mcpManagerItemKind int
 
 const (
 	mcpManagerItemServer mcpManagerItemKind = iota
+	mcpManagerItemMarketplace
 	mcpManagerItemAddRemote
 	mcpManagerItemAddStdio
 	mcpManagerItemList
 )
 
 type mcpManagerItem struct {
-	Kind  mcpManagerItemKind
-	Name  string
-	Label string
-	Meta  string
+	Kind           mcpManagerItemKind
+	Name           string
+	Label          string
+	Meta           string
+	Detail         string
+	InstallCommand string
+}
+
+type mcpMarketplaceEntry struct {
+	ID             string
+	Name           string
+	Description    string
+	Meta           string
+	InstallCommand string
+	Tags           []string
+}
+
+var mcpMarketplaceCatalog = []mcpMarketplaceEntry{
+	{
+		ID:             "filesystem",
+		Name:           "Filesystem",
+		Description:    "Read and manage files under an explicit workspace path.",
+		Meta:           "stdio · official · files",
+		InstallCommand: "/mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem .",
+		Tags:           []string{"files", "local", "official", "workspace"},
+	},
+	{
+		ID:             "memory",
+		Name:           "Memory",
+		Description:    "Persistent knowledge graph memory for long-lived project facts.",
+		Meta:           "stdio · official · memory",
+		InstallCommand: "/mcp add memory -- npx -y @modelcontextprotocol/server-memory",
+		Tags:           []string{"memory", "knowledge", "official"},
+	},
+	{
+		ID:             "fetch",
+		Name:           "Fetch",
+		Description:    "Fetch and convert web content for model-readable context.",
+		Meta:           "stdio · official · web",
+		InstallCommand: "/mcp add fetch -- npx -y @modelcontextprotocol/server-fetch",
+		Tags:           []string{"web", "fetch", "official"},
+	},
+	{
+		ID:             "sequential-thinking",
+		Name:           "Sequential Thinking",
+		Description:    "Structured step-by-step reasoning as an MCP tool.",
+		Meta:           "stdio · official · reasoning",
+		InstallCommand: "/mcp add sequential-thinking -- npx -y @modelcontextprotocol/server-sequential-thinking",
+		Tags:           []string{"reasoning", "planning", "official"},
+	},
+	{
+		ID:             "context7",
+		Name:           "Context7",
+		Description:    "Fresh library documentation and examples over HTTP MCP.",
+		Meta:           "http · docs · remote",
+		InstallCommand: "/mcp add context7 --url https://mcp.context7.com/mcp",
+		Tags:           []string{"docs", "libraries", "context7", "remote"},
+	},
+	{
+		ID:             "playwright",
+		Name:           "Playwright",
+		Description:    "Browser automation and page inspection through Playwright MCP.",
+		Meta:           "stdio · browser · @playwright/mcp",
+		InstallCommand: "/mcp add playwright -- npx -y @playwright/mcp",
+		Tags:           []string{"browser", "automation", "testing", "playwright"},
+	},
 }
 
 func (m model) openMCPManager() model {
@@ -52,7 +117,16 @@ func (m model) handleMCPManagerKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		m.moveMCPManager(1)
 	case tea.KeyEnter:
 		return m.chooseMCPManagerItem()
+	case tea.KeyBackspace, tea.KeyCtrlH:
+		m.deleteMCPManagerQueryRune()
+	case tea.KeyCtrlU:
+		m.mcpManager.query = ""
+		m.mcpManager.selected = 0
 	case tea.KeyRunes:
+		if !msg.Alt {
+			m.appendMCPManagerQuery(msg.Runes)
+			return m, nil
+		}
 		switch strings.ToLower(string(msg.Runes)) {
 		case "a":
 			return m.prefillMCPManagerCommand("/mcp add <name> --url <url>"), nil
@@ -81,6 +155,28 @@ func (m model) handleMCPManagerKey(msg tea.KeyMsg) (model, tea.Cmd) {
 	return m, nil
 }
 
+func (m *model) appendMCPManagerQuery(runes []rune) {
+	if m.mcpManager == nil {
+		return
+	}
+	for _, r := range runes {
+		if r == '\t' || r == '\n' || r == '\r' || unicode.IsControl(r) {
+			continue
+		}
+		m.mcpManager.query += string(r)
+	}
+	m.mcpManager.selected = 0
+}
+
+func (m *model) deleteMCPManagerQueryRune() {
+	if m.mcpManager == nil || m.mcpManager.query == "" {
+		return
+	}
+	runes := []rune(m.mcpManager.query)
+	m.mcpManager.query = string(runes[:len(runes)-1])
+	m.mcpManager.selected = 0
+}
+
 func (m *model) moveMCPManager(delta int) {
 	if m.mcpManager == nil {
 		return
@@ -101,6 +197,8 @@ func (m model) chooseMCPManagerItem() (model, tea.Cmd) {
 	switch item.Kind {
 	case mcpManagerItemServer:
 		return m.runMCPManagerCommand([]string{"check", item.Name})
+	case mcpManagerItemMarketplace:
+		return m.prefillMCPManagerCommand(item.InstallCommand), nil
 	case mcpManagerItemAddRemote:
 		return m.prefillMCPManagerCommand("/mcp add <name> --url <url>"), nil
 	case mcpManagerItemAddStdio:
@@ -123,12 +221,14 @@ func (m model) prefillMCPManagerCommand(command string) model {
 
 func (m model) runMCPManagerCommand(args []string) (model, tea.Cmd) {
 	selected := 0
+	query := ""
 	if m.mcpManager != nil {
 		selected = m.mcpManager.selected
+		query = m.mcpManager.query
 	}
 	text := ""
 	m, text = m.handleMCPCommand(strings.Join(args, " "))
-	m.mcpManager = &mcpManagerState{selected: selected}
+	m.mcpManager = &mcpManagerState{selected: selected, query: query}
 	if items := m.mcpManagerItems(); len(items) > 0 {
 		m.mcpManager.selected = clampInt(m.mcpManager.selected, 0, len(items)-1)
 	}
@@ -152,22 +252,65 @@ func (m model) currentMCPManagerItem() (mcpManagerItem, bool) {
 
 func (m model) mcpManagerItems() []mcpManagerItem {
 	state := m.mcpViewState()
-	items := make([]mcpManagerItem, 0, len(state.Servers)+3)
+	query := ""
+	if m.mcpManager != nil {
+		query = strings.ToLower(strings.TrimSpace(m.mcpManager.query))
+	}
+	installed := make(map[string]bool, len(state.Servers))
+	items := make([]mcpManagerItem, 0, len(state.Servers)+len(mcpMarketplaceCatalog)+3)
 	for _, server := range state.Servers {
 		name := displayValue(strings.TrimSpace(server.Name), "unnamed")
-		items = append(items, mcpManagerItem{
-			Kind:  mcpManagerItemServer,
-			Name:  name,
-			Label: name,
-			Meta:  mcpManagerServerMeta(server),
-		})
+		installed[strings.ToLower(name)] = true
+		item := mcpManagerItem{
+			Kind:   mcpManagerItemServer,
+			Name:   name,
+			Label:  name,
+			Meta:   mcpManagerServerMeta(server),
+			Detail: strings.Join([]string{name, server.Transport, server.State, server.Auth, server.Target}, " "),
+		}
+		if mcpManagerItemMatches(item, query) {
+			items = append(items, item)
+		}
 	}
-	items = append(items,
-		mcpManagerItem{Kind: mcpManagerItemAddRemote, Label: "Add MCP server", Meta: "zero mcp add <name> --url <url>"},
-		mcpManagerItem{Kind: mcpManagerItemAddStdio, Label: "Add local stdio MCP", Meta: "zero mcp add <name> -- <command> [args...]"},
-		mcpManagerItem{Kind: mcpManagerItemList, Label: "List configured", Meta: "zero mcp list"},
-	)
+	for _, entry := range mcpMarketplaceCatalog {
+		if installed[strings.ToLower(entry.ID)] {
+			continue
+		}
+		item := mcpMarketplaceItem(entry)
+		if mcpManagerItemMatches(item, query) {
+			items = append(items, item)
+		}
+	}
+	for _, item := range []mcpManagerItem{
+		{Kind: mcpManagerItemAddRemote, Name: "custom-remote", Label: "Add MCP server", Meta: "zero mcp add <name> --url <url>", Detail: "custom remote http sse url"},
+		{Kind: mcpManagerItemAddStdio, Name: "custom-stdio", Label: "Add local stdio MCP", Meta: "zero mcp add <name> -- <command> [args...]", Detail: "custom local stdio command"},
+		{Kind: mcpManagerItemList, Name: "list", Label: "List configured", Meta: "zero mcp list", Detail: "configured installed servers"},
+	} {
+		if mcpManagerItemMatches(item, query) {
+			items = append(items, item)
+		}
+	}
 	return items
+}
+
+func mcpMarketplaceItem(entry mcpMarketplaceEntry) mcpManagerItem {
+	return mcpManagerItem{
+		Kind:           mcpManagerItemMarketplace,
+		Name:           entry.ID,
+		Label:          entry.Name,
+		Meta:           entry.Meta,
+		Detail:         strings.Join(append([]string{entry.Description, entry.InstallCommand}, entry.Tags...), " "),
+		InstallCommand: entry.InstallCommand,
+	}
+}
+
+func mcpManagerItemMatches(item mcpManagerItem, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	haystack := strings.ToLower(strings.Join([]string{item.Name, item.Label, item.Meta, item.Detail, item.InstallCommand}, " "))
+	return strings.Contains(haystack, query)
 }
 
 func mcpManagerServerMeta(server MCPServerView) string {
@@ -204,6 +347,7 @@ func (m model) mcpManagerOverlay(width int) string {
 	state := m.mcpViewState()
 	lines := []string{
 		fillPaletteLine(zeroTheme.ink.Bold(true).Render(pluralCount(len(state.Servers), "server")), innerWidth, transparentSurface),
+		fillPaletteLine(renderMCPManagerSearchLine(m.mcpManager.query, innerWidth), innerWidth, transparentSurface),
 		zeroTheme.accent.Bold(true).Render("User MCPs"),
 	}
 	if len(state.Servers) == 0 {
@@ -216,8 +360,17 @@ func (m model) mcpManagerOverlay(width int) string {
 		lines = append(lines, detail...)
 	}
 	lines = append(lines, zeroTheme.line.Render(strings.Repeat("─", innerWidth)))
-	lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("up/down navigate   Enter action   a add remote   s add stdio   Esc close"), innerWidth, transparentSurface))
+	lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("type search   up/down navigate   Enter action   Alt+d disable   Esc close"), innerWidth, transparentSurface))
 	return centerRenderedBlock(styledBlockFillTitle(overlayWidth, "Manage MCP servers", lines, zeroTheme.lineStrong, lipgloss.NewStyle()), width)
+}
+
+func renderMCPManagerSearchLine(query string, width int) string {
+	query = strings.TrimSpace(query)
+	prompt := zeroTheme.userPrompt.Render("search > ")
+	if query == "" {
+		return fitStyledLine(prompt+zeroTheme.faint.Render("MCP servers, tools, docs..."), width)
+	}
+	return fitStyledLine(prompt+zeroTheme.ink.Render(query), width)
 }
 
 func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) ([]string, []int) {
@@ -229,14 +382,14 @@ func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) ([]s
 	visible := items[start : start+maxVisible]
 	lines := make([]string, 0, len(visible))
 	itemRows := make([]int, 0, len(visible))
-	lastKind := mcpManagerItemServer
+	lastGroup := ""
 	for offset, item := range visible {
 		index := start + offset
-		if item.Kind != mcpManagerItemServer && (index == 0 || lastKind == mcpManagerItemServer) {
-			lines = append(lines, zeroTheme.accent.Bold(true).Render("Actions"))
+		if group := mcpManagerItemGroup(item.Kind); group != "" && group != lastGroup {
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(group))
 			itemRows = append(itemRows, -1)
+			lastGroup = group
 		}
-		lastKind = item.Kind
 		surface := transparentSurface
 		marker := surface(zeroTheme.faintest).Render("  ")
 		if index == m.mcpManager.selected {
@@ -256,6 +409,17 @@ func (m model) renderMCPManagerItemLines(width int, items []mcpManagerItem) ([]s
 	return lines, itemRows
 }
 
+func mcpManagerItemGroup(kind mcpManagerItemKind) string {
+	switch kind {
+	case mcpManagerItemMarketplace:
+		return "Marketplace"
+	case mcpManagerItemAddRemote, mcpManagerItemAddStdio, mcpManagerItemList:
+		return "Actions"
+	default:
+		return ""
+	}
+}
+
 func (m model) mcpManagerSelectionDetail(width int) []string {
 	item, ok := m.currentMCPManagerItem()
 	if !ok {
@@ -273,11 +437,20 @@ func (m model) mcpManagerSelectionDetail(width int) []string {
 		if target := strings.TrimSpace(server.Target); target != "" {
 			lines = append(lines, fitStyledLine(zeroTheme.faint.Render(target), width))
 		}
-		action := "d disable"
+		action := "Alt+d disable"
 		if strings.EqualFold(strings.TrimSpace(server.State), "disabled") {
-			action = "e enable"
+			action = "Alt+e enable"
 		}
-		lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("Enter check   c check   "+action+"   r remove"), width, transparentSurface))
+		lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("Enter check   Alt+c check   "+action+"   Alt+r remove"), width, transparentSurface))
+		return lines
+	case mcpManagerItemMarketplace:
+		lines := []string{
+			fillPaletteLine(zeroTheme.ink.Bold(true).Render(item.Label)+" "+zeroTheme.faint.Render(item.Meta), width, transparentSurface),
+		}
+		if detail := firstMCPMarketplaceDetailLine(item); detail != "" {
+			lines = append(lines, fitStyledLine(zeroTheme.faint.Render(detail), width))
+		}
+		lines = append(lines, fillPaletteLine(zeroTheme.faint.Render("Enter fills composer: "+item.InstallCommand), width, transparentSurface))
 		return lines
 	case mcpManagerItemAddRemote:
 		return []string{fillPaletteLine(zeroTheme.faint.Render("Enter fills composer: /mcp add <name> --url <url>"), width, transparentSurface)}
@@ -288,6 +461,17 @@ func (m model) mcpManagerSelectionDetail(width int) []string {
 	default:
 		return nil
 	}
+}
+
+func firstMCPMarketplaceDetailLine(item mcpManagerItem) string {
+	detail := strings.TrimSpace(item.Detail)
+	if detail == "" {
+		return ""
+	}
+	if before, _, ok := strings.Cut(detail, " /mcp add "); ok {
+		return strings.TrimSpace(before)
+	}
+	return detail
 }
 
 func (m model) mcpManagerServer(name string) (MCPServerView, bool) {

--- a/internal/tui/mcp_manager_test.go
+++ b/internal/tui/mcp_manager_test.go
@@ -85,7 +85,7 @@ func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
 			"docs": {
 				Type:    "stdio",
 				Command: "zero-docs-mcp",
-				Args:    []string{"--workspace", ".", "--token", "arg-secret", "--api-key=inline-secret"},
+				Args:    []string{"--workspace", ".", "--token", "arg-secret", "--api-key=inline-secret", "--endpoint", "https://remote.example/mcp?access_token=arg-url-secret#token=frag-secret"},
 				Env:     map[string]string{"ZERO_DOCS_TOKEN": "env-secret"},
 			},
 			"linear": {
@@ -97,11 +97,13 @@ func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
 			},
 		}},
 	})
-	got := plainRender(t, renderMCPView(state, 180))
+	got := plainRender(t, renderMCPView(state, 260))
 
 	for _, leaked := range []string{
 		"arg-secret",
 		"inline-secret",
+		"arg-url-secret",
+		"frag-secret",
 		"url-secret",
 		"env-secret",
 		"header-secret",
@@ -111,11 +113,12 @@ func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
 		}
 	}
 	for _, want := range []string{
-		"--token [redacted]",
+		"--token [REDACTED]",
 		"--api-key=[REDACTED]",
 		"access_token=[REDACTED]",
+		"token=[REDACTED]",
 		"workspace=public",
-		"ZERO_DOCS_TOKEN=[redacted]",
+		"ZERO_DOCS_TOKEN=[REDACTED]",
 		"Authorization=[REDACTED]",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/tui/mcp_manager_test.go
+++ b/internal/tui/mcp_manager_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestMCPManagerViewRendersServerActionHints(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{
+		Servers: []MCPServerView{
+			{Name: "docs", Transport: "stdio", State: "enabled", Target: "zero-docs-mcp --workspace .", ToolCount: 2},
+			{Name: "linear", Transport: "http", State: "disabled", Target: "https://mcp.linear.example", Auth: "oauth"},
+		},
+	}, 140))
+
+	for _, want := range []string{
+		"zero mcp check docs",
+		"zero mcp disable docs",
+		"zero mcp remove docs",
+		"zero mcp enable linear",
+		"zero mcp oauth login linear",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP manager server actions = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPManagerViewGroupsToolsUnderServers(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{
+		Servers: []MCPServerView{
+			{Name: "docs", Transport: "stdio", State: "enabled", ToolCount: 2},
+			{Name: "github", Transport: "http", State: "enabled", ToolCount: 1},
+		},
+		Tools: []MCPToolView{
+			{ServerName: "docs", Name: "lookup", RegistryName: "mcp_docs_lookup", SideEffect: "network", Permission: "prompt", Description: "Look up documentation"},
+			{ServerName: "docs", Name: "search", RegistryName: "mcp_docs_search", SideEffect: "network", Permission: "prompt", Description: "Search documentation"},
+			{ServerName: "github", Name: "create_issue", RegistryName: "mcp_github_create_issue", SideEffect: "network", Permission: "prompt", Description: "Create an issue"},
+		},
+	}, 160))
+
+	for _, want := range []string{
+		"docs tools (2)",
+		"lookup [network/prompt] - mcp_docs_lookup - docs/lookup - Look up documentation",
+		"search [network/prompt] - mcp_docs_search - docs/search - Search documentation",
+		"github tools (1)",
+		"create_issue [network/prompt] - mcp_github_create_issue - github/create_issue - Create an issue",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP manager grouped tools = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPManagerViewRendersOAuthActionHints(t *testing.T) {
+	expiry := time.Date(2026, 6, 13, 11, 45, 0, 0, time.UTC)
+	got := plainRender(t, renderMCPView(MCPViewState{
+		OAuth: MCPOAuthSummary{
+			Servers: []MCPOAuthServerView{
+				{ServerName: "linear", Configured: true, HasToken: true, HasRefreshToken: true, TokenType: "Bearer", ExpiresAt: expiry},
+				{ServerName: "notion", Configured: true},
+				{ServerName: "expired", Configured: true, HasToken: true, Expired: true},
+			},
+		},
+	}, 140))
+
+	for _, want := range []string{
+		"zero mcp oauth refresh linear",
+		"zero mcp oauth logout linear",
+		"zero mcp oauth login notion",
+		"zero mcp oauth refresh expired",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP manager OAuth actions = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
+	state := BuildMCPViewState(MCPStateOptions{
+		Config: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"docs": {
+				Type:    "stdio",
+				Command: "zero-docs-mcp",
+				Args:    []string{"--workspace", ".", "--token", "arg-secret", "--api-key=inline-secret"},
+				Env:     map[string]string{"ZERO_DOCS_TOKEN": "env-secret"},
+			},
+			"linear": {
+				Type: "http",
+				URL:  "https://mcp.linear.example/sse?access_token=url-secret&workspace=public",
+				Headers: map[string]string{
+					"Authorization": "Bearer header-secret",
+				},
+			},
+		}},
+	})
+	got := plainRender(t, renderMCPView(state, 180))
+
+	for _, leaked := range []string{
+		"arg-secret",
+		"inline-secret",
+		"url-secret",
+		"env-secret",
+		"header-secret",
+	} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("MCP manager target leaked %q in:\n%s", leaked, got)
+		}
+	}
+	for _, want := range []string{
+		"--token [redacted]",
+		"--api-key=[REDACTED]",
+		"access_token=[REDACTED]",
+		"workspace=public",
+		"ZERO_DOCS_TOKEN=[redacted]",
+		"Authorization=[REDACTED]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP manager redacted target = %q, missing %q", got, want)
+		}
+	}
+}

--- a/internal/tui/mcp_manager_test.go
+++ b/internal/tui/mcp_manager_test.go
@@ -85,7 +85,7 @@ func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
 			"docs": {
 				Type:    "stdio",
 				Command: "zero-docs-mcp",
-				Args:    []string{"--workspace", ".", "--token", "arg-secret", "--api-key=inline-secret", "--endpoint", "https://remote.example/mcp?access_token=arg-url-secret#token=frag-secret"},
+				Args:    []string{"--workspace", ".", "--token", "arg-secret", "--api-key=inline-secret", "--endpoint", "https://remote.example/mcp?access_token=arg-url-secret#token=frag-secret", "--inline-endpoint=https://remote.example/mcp?access_token=inline-url-secret#token=inline-frag-secret"},
 				Env:     map[string]string{"ZERO_DOCS_TOKEN": "env-secret"},
 			},
 			"linear": {
@@ -104,6 +104,8 @@ func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
 		"inline-secret",
 		"arg-url-secret",
 		"frag-secret",
+		"inline-url-secret",
+		"inline-frag-secret",
 		"url-secret",
 		"env-secret",
 		"header-secret",
@@ -117,6 +119,7 @@ func TestMCPManagerTargetsRedactSecretsFromURLsAndArgs(t *testing.T) {
 		"--api-key=[REDACTED]",
 		"access_token=[REDACTED]",
 		"token=[REDACTED]",
+		"--inline-endpoint=https://remote.example/mcp?access_token=[REDACTED]#token=[REDACTED]",
 		"workspace=public",
 		"ZERO_DOCS_TOKEN=[REDACTED]",
 		"Authorization=[REDACTED]",

--- a/internal/tui/mcp_setup_intent.go
+++ b/internal/tui/mcp_setup_intent.go
@@ -1,0 +1,104 @@
+package tui
+
+import (
+	"net/url"
+	"strings"
+)
+
+type mcpSetupIntent struct {
+	ServerName    string
+	ServerType    string
+	Endpoint      string
+	SourceLabel   string
+	SourceURL     string
+	Prerequisites []string
+}
+
+func detectMCPSetupIntent(prompt string) (mcpSetupIntent, bool) {
+	normalized := strings.ToLower(strings.TrimSpace(prompt))
+	if normalized == "" || !looksLikeMCPSetupRequest(normalized) {
+		return mcpSetupIntent{}, false
+	}
+	if strings.Contains(normalized, "stitch.withgoogle.com/docs/mcp/setup") ||
+		strings.Contains(normalized, "stitch mcp") ||
+		strings.Contains(normalized, "google stitch") {
+		return stitchMCPSetupIntent(prompt), true
+	}
+	for _, entry := range mcpMarketplaceCatalog {
+		if !strings.Contains(normalized, strings.ToLower(entry.ID)) &&
+			!strings.Contains(normalized, strings.ToLower(entry.Name)) {
+			continue
+		}
+		intent, ok := mcpSetupIntentFromInstallCommand(entry.Name, entry.InstallCommand)
+		if ok {
+			return intent, true
+		}
+	}
+	return mcpSetupIntent{}, false
+}
+
+func looksLikeMCPSetupRequest(normalized string) bool {
+	if !strings.Contains(normalized, "mcp") && !strings.Contains(normalized, "model context protocol") {
+		return false
+	}
+	for _, token := range []string{"add", "setup", "set up", "configure", "install", "connect", "enable"} {
+		if strings.Contains(normalized, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func stitchMCPSetupIntent(prompt string) mcpSetupIntent {
+	return mcpSetupIntent{
+		ServerName:  "stitch",
+		ServerType:  "stdio",
+		Endpoint:    "npx -y @_davideast/stitch-mcp@latest proxy",
+		SourceLabel: "Stitch MCP setup",
+		SourceURL:   firstURLWithHost(prompt, "stitch.withgoogle.com"),
+		Prerequisites: []string{
+			"Google Cloud auth configured",
+			"Stitch API enabled for the selected project",
+			"GOOGLE_CLOUD_PROJECT available when the proxy runs",
+		},
+	}
+}
+
+func mcpSetupIntentFromInstallCommand(label string, command string) (mcpSetupIntent, bool) {
+	command = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(command), "/mcp"))
+	args, err := splitMCPCommandArgs(command)
+	if err != nil || len(args) < 2 || args[0] != "add" {
+		return mcpSetupIntent{}, false
+	}
+	intent := mcpSetupIntent{ServerName: args[1], SourceLabel: label}
+	for index := 2; index < len(args); index++ {
+		switch {
+		case args[index] == "--url" && index+1 < len(args):
+			intent.ServerType = "http"
+			intent.Endpoint = args[index+1]
+			return intent, true
+		case strings.HasPrefix(args[index], "--url="):
+			intent.ServerType = "http"
+			intent.Endpoint = strings.TrimPrefix(args[index], "--url=")
+			return intent, true
+		case args[index] == "--":
+			if index+1 < len(args) {
+				intent.ServerType = "stdio"
+				intent.Endpoint = strings.Join(args[index+1:], " ")
+				return intent, true
+			}
+		}
+	}
+	return mcpSetupIntent{}, false
+}
+
+func firstURLWithHost(value string, host string) string {
+	for _, field := range strings.Fields(value) {
+		candidate := strings.Trim(field, `"'()[]<>.,;`)
+		parsed, err := url.Parse(candidate)
+		if err == nil && strings.EqualFold(parsed.Host, host) {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/internal/tui/mcp_setup_intent.go
+++ b/internal/tui/mcp_setup_intent.go
@@ -30,7 +30,7 @@ func detectMCPSetupIntent(prompt string) (mcpSetupIntent, bool) {
 			continue
 		}
 		intent, ok := mcpSetupIntentFromInstallCommand(entry.Name, entry.InstallCommand)
-		if ok {
+		if ok && promptContainsSetupEndpoint(prompt, intent.Endpoint) {
 			return intent, true
 		}
 	}
@@ -90,6 +90,25 @@ func mcpSetupIntentFromInstallCommand(label string, command string) (mcpSetupInt
 		}
 	}
 	return mcpSetupIntent{}, false
+}
+
+func promptContainsSetupEndpoint(prompt string, endpoint string) bool {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return false
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	normalized := strings.ToLower(prompt)
+	if !strings.Contains(normalized, strings.ToLower(parsed.Host)) {
+		return false
+	}
+	if parsed.Path == "" || parsed.Path == "/" {
+		return true
+	}
+	return strings.Contains(normalized, strings.ToLower(strings.TrimRight(parsed.Path, "/")))
 }
 
 func firstURLWithHost(value string, host string) string {

--- a/internal/tui/mcp_state.go
+++ b/internal/tui/mcp_state.go
@@ -1,0 +1,342 @@
+package tui
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type MCPStateOptions struct {
+	Config          config.MCPConfig
+	Registry        *tools.Registry
+	PermissionStore *mcp.PermissionStore
+	TokenStore      *mcp.TokenStore
+	PermissionMode  string
+	PromptCount     int
+	DeniedCount     int
+}
+
+type mcpServerNamedTool interface {
+	MCPServerName() string
+}
+
+const mcpRegistryToolPrefix = "mcp_"
+
+var mcpStateUnsafeToolNameChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+
+func BuildMCPViewState(options MCPStateOptions) MCPViewState {
+	toolViews := buildMCPToolViews(options.Config, options.Registry)
+	toolCounts := make(map[string]int, len(toolViews))
+	for _, tool := range toolViews {
+		toolCounts[tool.ServerName]++
+	}
+
+	return MCPViewState{
+		Servers:     buildMCPServerViews(options.Config, toolCounts),
+		Tools:       toolViews,
+		Permissions: buildMCPPermissionSummary(options),
+		OAuth:       buildMCPOAuthSummary(options.Config, options.TokenStore),
+	}
+}
+
+func buildMCPServerViews(cfg config.MCPConfig, toolCounts map[string]int) []MCPServerView {
+	names := sortedMCPServerNames(cfg)
+	servers := make([]MCPServerView, 0, len(names))
+	for _, name := range names {
+		raw := cfg.Servers[name]
+		state := "enabled"
+		if raw.Disabled {
+			state = "disabled"
+		}
+		servers = append(servers, MCPServerView{
+			Name:      name,
+			Transport: mcpServerTransport(raw),
+			State:     state,
+			Target:    mcpServerTarget(raw),
+			Auth:      strings.TrimSpace(raw.Auth),
+			ToolCount: toolCounts[name],
+		})
+	}
+	return servers
+}
+
+func buildMCPToolViews(cfg config.MCPConfig, registry *tools.Registry) []MCPToolView {
+	if registry == nil {
+		return nil
+	}
+
+	serverTokens := mcpServerTokenMap(cfg)
+	registered := registry.All()
+	views := make([]MCPToolView, 0, len(registered))
+	for _, tool := range registered {
+		registryName := strings.TrimSpace(tool.Name())
+		if !strings.HasPrefix(registryName, mcpRegistryToolPrefix) {
+			continue
+		}
+
+		serverName := mcpToolServerName(tool, registryName, serverTokens)
+		toolName := mcpToolName(registryName, serverName)
+		safety := tool.Safety()
+		views = append(views, MCPToolView{
+			ServerName:   serverName,
+			Name:         toolName,
+			RegistryName: registryName,
+			SideEffect:   string(safety.SideEffect),
+			Permission:   string(safety.Permission),
+			Description:  tool.Description(),
+		})
+	}
+
+	sort.SliceStable(views, func(left, right int) bool {
+		if views[left].ServerName != views[right].ServerName {
+			return views[left].ServerName < views[right].ServerName
+		}
+		if views[left].Name != views[right].Name {
+			return views[left].Name < views[right].Name
+		}
+		return views[left].RegistryName < views[right].RegistryName
+	})
+	return views
+}
+
+func buildMCPPermissionSummary(options MCPStateOptions) MCPPermissionSummary {
+	summary := MCPPermissionSummary{
+		Mode:        strings.TrimSpace(options.PermissionMode),
+		PromptCount: options.PromptCount,
+		DeniedCount: options.DeniedCount,
+	}
+	if options.PermissionStore == nil {
+		return summary
+	}
+
+	grants, err := options.PermissionStore.List()
+	if err != nil {
+		return summary
+	}
+	summary.GrantCount = len(grants)
+	summary.Grants = make([]MCPPermissionGrantView, 0, len(grants))
+	for _, grant := range grants {
+		switch grant.Scope {
+		case mcp.ScopeServer:
+			summary.ServerGrants++
+		case mcp.ScopeTool:
+			summary.ToolGrants++
+		}
+		summary.Grants = append(summary.Grants, MCPPermissionGrantView{
+			Target:     mcpPermissionTarget(grant),
+			Autonomy:   string(grant.MaxAutonomy),
+			ApprovedAt: grant.ApprovedAt,
+		})
+	}
+	return summary
+}
+
+func buildMCPOAuthSummary(cfg config.MCPConfig, tokenStore *mcp.TokenStore) MCPOAuthSummary {
+	configured := make(map[string]bool)
+	for name, server := range cfg.Servers {
+		if strings.EqualFold(strings.TrimSpace(server.Auth), mcp.ServerAuthOAuth) || server.OAuth != nil {
+			configured[name] = true
+		}
+	}
+
+	statuses := map[string]mcp.TokenStatus{}
+	if tokenStore != nil {
+		if stored, err := tokenStore.Status(); err == nil {
+			for _, status := range stored {
+				statuses[status.ServerName] = status
+			}
+		}
+	}
+
+	names := make([]string, 0, len(configured)+len(statuses))
+	seen := make(map[string]struct{}, len(configured)+len(statuses))
+	for name := range configured {
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for name := range statuses {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	servers := make([]MCPOAuthServerView, 0, len(names))
+	for _, name := range names {
+		status := statuses[name]
+		servers = append(servers, MCPOAuthServerView{
+			ServerName:      name,
+			Configured:      configured[name],
+			HasToken:        status.HasToken,
+			HasRefreshToken: status.HasRefreshToken,
+			TokenType:       status.TokenType,
+			Scopes:          append([]string{}, status.Scopes...),
+			ExpiresAt:       status.ExpiresAt,
+			Expired:         status.Expired,
+		})
+	}
+	return MCPOAuthSummary{Servers: servers}
+}
+
+func sortedMCPServerNames(cfg config.MCPConfig) []string {
+	names := make([]string, 0, len(cfg.Servers))
+	for name := range cfg.Servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func mcpServerTransport(server config.MCPServerConfig) string {
+	transport := strings.ToLower(strings.TrimSpace(server.Type))
+	if transport != "" {
+		return transport
+	}
+	if strings.TrimSpace(server.URL) != "" {
+		return string(mcp.ServerTypeHTTP)
+	}
+	return string(mcp.ServerTypeStdio)
+}
+
+func mcpServerTarget(server config.MCPServerConfig) string {
+	switch mcpServerTransport(server) {
+	case string(mcp.ServerTypeHTTP), string(mcp.ServerTypeSSE):
+		parts := []string{}
+		if url := strings.TrimSpace(server.URL); url != "" {
+			parts = append(parts, url)
+		}
+		if headers := redactedStringMap(server.Headers); headers != "" {
+			parts = append(parts, "headers", headers)
+		}
+		return strings.Join(parts, " ")
+	default:
+		parts := []string{}
+		if command := strings.TrimSpace(server.Command); command != "" {
+			parts = append(parts, command)
+		}
+		parts = append(parts, trimmedStrings(server.Args)...)
+		if env := redactedStringMap(server.Env); env != "" {
+			parts = append(parts, "env", env)
+		}
+		return strings.Join(parts, " ")
+	}
+}
+
+func redactedStringMap(values map[string]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if key = strings.TrimSpace(key); key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"=[redacted]")
+	}
+	return strings.Join(parts, " ")
+}
+
+func trimmedStrings(values []string) []string {
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			trimmed = append(trimmed, value)
+		}
+	}
+	return trimmed
+}
+
+func mcpServerTokenMap(cfg config.MCPConfig) map[string]string {
+	tokens := make(map[string]string, len(cfg.Servers))
+	for name := range cfg.Servers {
+		tokens[mcpStateSanitizeToolNamePart(name)] = name
+	}
+	return tokens
+}
+
+func mcpToolServerName(tool tools.Tool, registryName string, serverTokens map[string]string) string {
+	if named, ok := tool.(mcpServerNamedTool); ok {
+		if serverName := strings.TrimSpace(named.MCPServerName()); serverName != "" {
+			return serverName
+		}
+	}
+
+	rest, ok := strings.CutPrefix(registryName, mcpRegistryToolPrefix)
+	if !ok {
+		return ""
+	}
+	tokens := make([]string, 0, len(serverTokens))
+	for token := range serverTokens {
+		tokens = append(tokens, token)
+	}
+	sort.Slice(tokens, func(left, right int) bool {
+		if len(tokens[left]) != len(tokens[right]) {
+			return len(tokens[left]) > len(tokens[right])
+		}
+		return tokens[left] < tokens[right]
+	})
+	for _, token := range tokens {
+		if strings.HasPrefix(rest, token+"_") {
+			return serverTokens[token]
+		}
+	}
+	if server, _, ok := strings.Cut(rest, "_"); ok {
+		return server
+	}
+	return ""
+}
+
+func mcpToolName(registryName string, serverName string) string {
+	rest, ok := strings.CutPrefix(registryName, mcpRegistryToolPrefix)
+	if !ok {
+		return registryName
+	}
+	if serverName != "" {
+		prefix := mcpStateSanitizeToolNamePart(serverName) + "_"
+		if strings.HasPrefix(rest, prefix) {
+			return strings.TrimPrefix(rest, prefix)
+		}
+	}
+	if _, name, ok := strings.Cut(rest, "_"); ok {
+		return name
+	}
+	return rest
+}
+
+func mcpStateSanitizeToolNamePart(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	value = mcpStateUnsafeToolNameChars.ReplaceAllString(value, "_")
+	value = strings.Trim(value, "_")
+	if value == "" {
+		return "server"
+	}
+	return value
+}
+
+func mcpPermissionTarget(grant mcp.PermissionGrant) string {
+	serverName := strings.TrimSpace(grant.ServerName)
+	if grant.Scope == mcp.ScopeTool {
+		toolName := strings.TrimSpace(grant.ToolName)
+		if serverName == "" {
+			return toolName
+		}
+		if toolName == "" {
+			return serverName + "/*"
+		}
+		return serverName + "/" + toolName
+	}
+	if serverName == "" {
+		return "*"
+	}
+	return serverName + "/*"
+}

--- a/internal/tui/mcp_state.go
+++ b/internal/tui/mcp_state.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -208,7 +209,7 @@ func mcpServerTarget(server config.MCPServerConfig) string {
 	case string(mcp.ServerTypeHTTP), string(mcp.ServerTypeSSE):
 		parts := []string{}
 		if url := strings.TrimSpace(server.URL); url != "" {
-			parts = append(parts, url)
+			parts = append(parts, redactMCPDisplayURL(url))
 		}
 		if headers := redactedStringMap(server.Headers); headers != "" {
 			parts = append(parts, "headers", headers)
@@ -219,7 +220,7 @@ func mcpServerTarget(server config.MCPServerConfig) string {
 		if command := strings.TrimSpace(server.Command); command != "" {
 			parts = append(parts, command)
 		}
-		parts = append(parts, trimmedStrings(server.Args)...)
+		parts = append(parts, redactedCommandArgs(server.Args)...)
 		if env := redactedStringMap(server.Env); env != "" {
 			parts = append(parts, "env", env)
 		}
@@ -245,14 +246,90 @@ func redactedStringMap(values map[string]string) string {
 	return strings.Join(parts, " ")
 }
 
-func trimmedStrings(values []string) []string {
+func redactedCommandArgs(values []string) []string {
 	trimmed := make([]string, 0, len(values))
+	redactNext := false
 	for _, value := range values {
 		if value = strings.TrimSpace(value); value != "" {
+			if redactNext {
+				trimmed = append(trimmed, "[redacted]")
+				redactNext = false
+				continue
+			}
+			if key, _, ok := strings.Cut(value, "="); ok && isSensitiveMCPDisplayKey(key) {
+				trimmed = append(trimmed, key+"=[redacted]")
+				continue
+			}
+			if isSensitiveMCPDisplayFlag(value) {
+				trimmed = append(trimmed, value)
+				redactNext = true
+				continue
+			}
 			trimmed = append(trimmed, value)
 		}
 	}
 	return trimmed
+}
+
+func redactMCPDisplayURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if parsed.User != nil {
+		parsed.User = nil
+	}
+	if parsed.RawQuery != "" {
+		parsed.RawQuery = redactMCPDisplayRawQuery(parsed.RawQuery)
+	}
+	out := parsed.String()
+	if strings.TrimSpace(out) == "" {
+		return raw
+	}
+	return out
+}
+
+func redactMCPDisplayRawQuery(rawQuery string) string {
+	parts := strings.Split(rawQuery, "&")
+	for index, part := range parts {
+		if part == "" {
+			continue
+		}
+		key, _, hasValue := strings.Cut(part, "=")
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			decodedKey = key
+		}
+		if !isSensitiveMCPDisplayKey(decodedKey) {
+			continue
+		}
+		if hasValue {
+			parts[index] = key + "=[redacted]"
+		} else {
+			parts[index] = key
+		}
+	}
+	return strings.Join(parts, "&")
+}
+
+func isSensitiveMCPDisplayFlag(value string) bool {
+	value = strings.TrimLeft(strings.ToLower(strings.TrimSpace(value)), "-")
+	return isSensitiveMCPDisplayKey(value)
+}
+
+func isSensitiveMCPDisplayKey(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(strings.TrimLeft(key, "-")))
+	key = strings.ReplaceAll(key, "-", "_")
+	for _, token := range []string{"token", "secret", "password", "passwd", "api_key", "apikey", "access_key", "auth", "credential"} {
+		if strings.Contains(key, token) {
+			return true
+		}
+	}
+	return false
 }
 
 func mcpServerTokenMap(cfg config.MCPConfig) map[string]string {

--- a/internal/tui/mcp_state.go
+++ b/internal/tui/mcp_state.go
@@ -261,9 +261,15 @@ func redactedCommandArgs(values []string) []string {
 				redactNext = false
 				continue
 			}
-			if key, _, ok := strings.Cut(value, "="); ok && isSensitiveMCPDisplayKey(key) {
-				trimmed = append(trimmed, key+"="+mcpDisplayRedacted)
-				continue
+			if key, rest, ok := strings.Cut(value, "="); ok {
+				switch {
+				case isSensitiveMCPDisplayKey(key):
+					trimmed = append(trimmed, key+"="+mcpDisplayRedacted)
+					continue
+				case looksLikeMCPDisplayURLValue(rest):
+					trimmed = append(trimmed, key+"="+redactMCPDisplayURL(rest))
+					continue
+				}
 			}
 			if isSensitiveMCPDisplayFlag(value) {
 				trimmed = append(trimmed, value)
@@ -302,7 +308,7 @@ func redactMCPDisplayURL(raw string) string {
 	if strings.TrimSpace(out) == "" {
 		return fallbackRedactMCPDisplayURL(raw)
 	}
-	return out
+	return strings.ReplaceAll(out, "%5BREDACTED%5D", mcpDisplayRedacted)
 }
 
 func redactMCPDisplayRawQuery(rawQuery string) string {
@@ -368,6 +374,9 @@ func fallbackRedactMCPDisplayURL(raw string) string {
 
 func isSensitiveMCPDisplayFlag(value string) bool {
 	value = strings.TrimLeft(strings.ToLower(strings.TrimSpace(value)), "-")
+	if key, _, ok := strings.Cut(value, "="); ok {
+		value = key
+	}
 	return isSensitiveMCPDisplayKey(value)
 }
 

--- a/internal/tui/mcp_state.go
+++ b/internal/tui/mcp_state.go
@@ -26,6 +26,7 @@ type mcpServerNamedTool interface {
 }
 
 const mcpRegistryToolPrefix = "mcp_"
+const mcpDisplayRedacted = "[REDACTED]"
 
 var mcpStateUnsafeToolNameChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
 
@@ -241,7 +242,7 @@ func redactedStringMap(values map[string]string) string {
 	sort.Strings(keys)
 	parts := make([]string, 0, len(keys))
 	for _, key := range keys {
-		parts = append(parts, key+"=[redacted]")
+		parts = append(parts, key+"="+mcpDisplayRedacted)
 	}
 	return strings.Join(parts, " ")
 }
@@ -252,17 +253,25 @@ func redactedCommandArgs(values []string) []string {
 	for _, value := range values {
 		if value = strings.TrimSpace(value); value != "" {
 			if redactNext {
-				trimmed = append(trimmed, "[redacted]")
+				if looksLikeMCPDisplayURLValue(value) {
+					trimmed = append(trimmed, redactMCPDisplayURL(value))
+				} else {
+					trimmed = append(trimmed, mcpDisplayRedacted)
+				}
 				redactNext = false
 				continue
 			}
 			if key, _, ok := strings.Cut(value, "="); ok && isSensitiveMCPDisplayKey(key) {
-				trimmed = append(trimmed, key+"=[redacted]")
+				trimmed = append(trimmed, key+"="+mcpDisplayRedacted)
 				continue
 			}
 			if isSensitiveMCPDisplayFlag(value) {
 				trimmed = append(trimmed, value)
 				redactNext = true
+				continue
+			}
+			if looksLikeMCPDisplayURLValue(value) {
+				trimmed = append(trimmed, redactMCPDisplayURL(value))
 				continue
 			}
 			trimmed = append(trimmed, value)
@@ -278,7 +287,7 @@ func redactMCPDisplayURL(raw string) string {
 	}
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		return raw
+		return fallbackRedactMCPDisplayURL(raw)
 	}
 	if parsed.User != nil {
 		parsed.User = nil
@@ -286,9 +295,12 @@ func redactMCPDisplayURL(raw string) string {
 	if parsed.RawQuery != "" {
 		parsed.RawQuery = redactMCPDisplayRawQuery(parsed.RawQuery)
 	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = redactMCPDisplayRawQuery(parsed.Fragment)
+	}
 	out := parsed.String()
 	if strings.TrimSpace(out) == "" {
-		return raw
+		return fallbackRedactMCPDisplayURL(raw)
 	}
 	return out
 }
@@ -308,12 +320,50 @@ func redactMCPDisplayRawQuery(rawQuery string) string {
 			continue
 		}
 		if hasValue {
-			parts[index] = key + "=[redacted]"
+			parts[index] = key + "=" + mcpDisplayRedacted
 		} else {
 			parts[index] = key
 		}
 	}
 	return strings.Join(parts, "&")
+}
+
+func looksLikeMCPDisplayURLValue(value string) bool {
+	value = strings.TrimSpace(value)
+	lower := strings.ToLower(value)
+	return strings.Contains(value, "://") ||
+		strings.HasPrefix(lower, "http:") ||
+		strings.HasPrefix(lower, "https:") ||
+		strings.Contains(value, "?") ||
+		strings.Contains(value, "#")
+}
+
+func fallbackRedactMCPDisplayURL(raw string) string {
+	out := strings.TrimSpace(raw)
+	if out == "" {
+		return ""
+	}
+	if schemeIndex := strings.Index(out, "://"); schemeIndex >= 0 {
+		authorityStart := schemeIndex + len("://")
+		authorityEnd := len(out)
+		for _, marker := range []string{"/", "?", "#"} {
+			if index := strings.Index(out[authorityStart:], marker); index >= 0 && authorityStart+index < authorityEnd {
+				authorityEnd = authorityStart + index
+			}
+		}
+		if at := strings.LastIndex(out[authorityStart:authorityEnd], "@"); at >= 0 {
+			out = out[:authorityStart] + out[authorityStart+at+1:]
+		}
+	}
+	if head, fragment, ok := strings.Cut(out, "#"); ok {
+		fragment = redactMCPDisplayRawQuery(fragment)
+		out = head + "#" + fragment
+	}
+	if head, query, ok := strings.Cut(out, "?"); ok {
+		query = redactMCPDisplayRawQuery(query)
+		out = head + "?" + query
+	}
+	return out
 }
 
 func isSensitiveMCPDisplayFlag(value string) bool {
@@ -324,6 +374,9 @@ func isSensitiveMCPDisplayFlag(value string) bool {
 func isSensitiveMCPDisplayKey(key string) bool {
 	key = strings.ToLower(strings.TrimSpace(strings.TrimLeft(key, "-")))
 	key = strings.ReplaceAll(key, "-", "_")
+	if key == "key" {
+		return true
+	}
 	for _, token := range []string{"token", "secret", "password", "passwd", "api_key", "apikey", "access_key", "auth", "credential"} {
 		if strings.Contains(key, token) {
 			return true

--- a/internal/tui/mcp_state_test.go
+++ b/internal/tui/mcp_state_test.go
@@ -1,0 +1,286 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestBuildMCPViewStateSummarizesConfiguredServers(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs": {
+			Type:    "stdio",
+			Command: "docs-mcp",
+			Args:    []string{"--workspace", "."},
+			Env:     map[string]string{"ZERO_DOCS_TOKEN": "sk-secret"},
+		},
+		"linear": {
+			Type:     "http",
+			URL:      "https://linear.example/mcp",
+			Headers:  map[string]string{"Authorization": "Bearer secret"},
+			Auth:     "oauth",
+			Disabled: true,
+		},
+		"updates": {
+			Type:    "sse",
+			URL:     "https://events.example/sse",
+			Headers: map[string]string{"X-Api-Key": "secret"},
+		},
+	}}
+
+	state := BuildMCPViewState(MCPStateOptions{Config: cfg})
+
+	if len(state.Servers) != 3 {
+		t.Fatalf("servers = %#v, want 3 configured servers", state.Servers)
+	}
+	assertServerView(t, state.Servers[0], MCPServerView{
+		Name:      "docs",
+		Transport: "stdio",
+		State:     "enabled",
+		Target:    "docs-mcp --workspace . env ZERO_DOCS_TOKEN=[redacted]",
+	})
+	assertServerView(t, state.Servers[1], MCPServerView{
+		Name:      "linear",
+		Transport: "http",
+		State:     "disabled",
+		Target:    "https://linear.example/mcp headers Authorization=[redacted]",
+		Auth:      "oauth",
+	})
+	assertServerView(t, state.Servers[2], MCPServerView{
+		Name:      "updates",
+		Transport: "sse",
+		State:     "enabled",
+		Target:    "https://events.example/sse headers X-Api-Key=[redacted]",
+	})
+
+	rendered := renderMCPView(state, 160)
+	for _, leaked := range []string{"sk-secret", "Bearer secret"} {
+		if strings.Contains(rendered, leaked) {
+			t.Fatalf("rendered MCP state leaked %q: %s", leaked, rendered)
+		}
+	}
+}
+
+func TestBuildMCPViewStateGroupsRegisteredMCPToolsByServer(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs":   {Type: "stdio", Command: "docs-mcp"},
+		"github": {Type: "http", URL: "https://github.example/mcp"},
+	}}
+	registry := tools.NewRegistry()
+	_, err := mcp.RegisterTools(context.Background(), registry, cfg, mcp.RegisterOptions{
+		ClientFactory: func(_ context.Context, server mcp.Server) (mcp.ToolClient, error) {
+			switch server.Name {
+			case "docs":
+				return &tuiFakeMCPClient{listed: []mcp.RemoteTool{
+					{Name: "lookup", Description: "Look up documentation"},
+					{Name: "search", Description: "Search documentation"},
+				}}, nil
+			case "github":
+				return &tuiFakeMCPClient{listed: []mcp.RemoteTool{
+					{Name: "create_issue", Description: "Create a GitHub issue"},
+				}}, nil
+			default:
+				return &tuiFakeMCPClient{}, nil
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTools() error = %v", err)
+	}
+
+	state := BuildMCPViewState(MCPStateOptions{Config: cfg, Registry: registry})
+
+	if got := state.Servers[0].ToolCount; got != 2 {
+		t.Fatalf("docs tool count = %d, want 2", got)
+	}
+	if got := state.Servers[1].ToolCount; got != 1 {
+		t.Fatalf("github tool count = %d, want 1", got)
+	}
+	if len(state.Tools) != 3 {
+		t.Fatalf("tools = %#v, want 3 MCP tools", state.Tools)
+	}
+	assertToolView(t, state.Tools[0], MCPToolView{ServerName: "docs", Name: "lookup", RegistryName: "mcp_docs_lookup", SideEffect: "network", Permission: "prompt", Description: "Look up documentation"})
+	assertToolView(t, state.Tools[1], MCPToolView{ServerName: "docs", Name: "search", RegistryName: "mcp_docs_search", SideEffect: "network", Permission: "prompt", Description: "Search documentation"})
+	assertToolView(t, state.Tools[2], MCPToolView{ServerName: "github", Name: "create_issue", RegistryName: "mcp_github_create_issue", SideEffect: "network", Permission: "prompt", Description: "Create a GitHub issue"})
+}
+
+func TestBuildMCPViewStateSummarizesPermissions(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"docs":   {Type: "stdio", Command: "docs-mcp"},
+		"github": {Type: "http", URL: "https://github.example/mcp"},
+	}}
+	servers, err := mcp.NormalizeConfig(cfg)
+	if err != nil {
+		t.Fatalf("NormalizeConfig() error = %v", err)
+	}
+	identities := map[string]string{}
+	for _, server := range servers {
+		identities[server.Name] = server.Identity
+	}
+	store, err := mcp.NewPermissionStore(mcp.StoreOptions{
+		FilePath: t.TempDir() + "/permissions.json",
+		Now:      func() time.Time { return time.Date(2026, 6, 13, 9, 30, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewPermissionStore() error = %v", err)
+	}
+	if _, err := store.GrantServer(mcp.GrantServerInput{ServerName: "docs", ServerIdentity: identities["docs"], MaxAutonomy: mcp.AutonomyLow}); err != nil {
+		t.Fatalf("GrantServer() error = %v", err)
+	}
+	if _, err := store.GrantTool(mcp.GrantToolInput{ServerName: "github", ServerIdentity: identities["github"], ToolName: "create_issue", MaxAutonomy: mcp.AutonomyMedium}); err != nil {
+		t.Fatalf("GrantTool() error = %v", err)
+	}
+
+	state := BuildMCPViewState(MCPStateOptions{
+		Config:          cfg,
+		PermissionStore: store,
+		PermissionMode:  "ask",
+		PromptCount:     4,
+		DeniedCount:     1,
+	})
+
+	summary := state.Permissions
+	if summary.Mode != "ask" || summary.GrantCount != 2 || summary.ServerGrants != 1 || summary.ToolGrants != 1 || summary.PromptCount != 4 || summary.DeniedCount != 1 {
+		t.Fatalf("permission summary = %#v", summary)
+	}
+	if len(summary.Grants) != 2 {
+		t.Fatalf("permission grants = %#v, want 2", summary.Grants)
+	}
+	if summary.Grants[0].Target != "docs/*" || summary.Grants[0].Autonomy != "low" {
+		t.Fatalf("server grant = %#v", summary.Grants[0])
+	}
+	if summary.Grants[1].Target != "github/create_issue" || summary.Grants[1].Autonomy != "medium" {
+		t.Fatalf("tool grant = %#v", summary.Grants[1])
+	}
+}
+
+func TestBuildMCPViewStateSummarizesOAuthTokens(t *testing.T) {
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	expiry := now.Add(time.Hour)
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"linear": {Type: "http", URL: "https://linear.example/mcp", Auth: "oauth"},
+		"notion": {Type: "sse", URL: "https://notion.example/sse", Auth: "oauth"},
+	}}
+	store, err := mcp.NewTokenStore(mcp.TokenStoreOptions{
+		FilePath: t.TempDir() + "/tokens.json",
+		Now:      func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := store.Save("linear", mcp.StoredToken{
+		AccessToken:  "access-secret",
+		RefreshToken: "refresh-secret",
+		TokenType:    "Bearer",
+		Scopes:       []string{"issues:read", "issues:write"},
+		ExpiresAt:    expiry,
+	}); err != nil {
+		t.Fatalf("Save(linear) error = %v", err)
+	}
+	if err := store.Save("orphan", mcp.StoredToken{AccessToken: "orphan-secret", ExpiresAt: now.Add(-time.Minute)}); err != nil {
+		t.Fatalf("Save(orphan) error = %v", err)
+	}
+
+	state := BuildMCPViewState(MCPStateOptions{Config: cfg, TokenStore: store})
+
+	if len(state.OAuth.Servers) != 3 {
+		t.Fatalf("OAuth servers = %#v, want configured servers plus stored orphan", state.OAuth.Servers)
+	}
+	assertOAuthView(t, state.OAuth.Servers[0], MCPOAuthServerView{
+		ServerName:      "linear",
+		Configured:      true,
+		HasToken:        true,
+		HasRefreshToken: true,
+		TokenType:       "Bearer",
+		Scopes:          []string{"issues:read", "issues:write"},
+		ExpiresAt:       expiry,
+	})
+	assertOAuthView(t, state.OAuth.Servers[1], MCPOAuthServerView{ServerName: "notion", Configured: true})
+	assertOAuthView(t, state.OAuth.Servers[2], MCPOAuthServerView{ServerName: "orphan", HasToken: true, Expired: true, ExpiresAt: now.Add(-time.Minute)})
+}
+
+func TestBuildMCPViewStateToleratesUnreadableStores(t *testing.T) {
+	cfg := config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"linear": {Type: "http", URL: "https://linear.example/mcp", Auth: "oauth"},
+	}}
+	permissionStore, err := mcp.NewPermissionStore(mcp.StoreOptions{FilePath: t.TempDir() + "/permissions.json"})
+	if err != nil {
+		t.Fatalf("NewPermissionStore() error = %v", err)
+	}
+	tokenStore, err := mcp.NewTokenStore(mcp.TokenStoreOptions{FilePath: t.TempDir() + "/tokens.json"})
+	if err != nil {
+		t.Fatalf("NewTokenStore() error = %v", err)
+	}
+	if err := writeInvalidStoreFile(permissionStore.FilePath()); err != nil {
+		t.Fatalf("write invalid permission store: %v", err)
+	}
+	if err := writeInvalidStoreFile(tokenStore.FilePath()); err != nil {
+		t.Fatalf("write invalid token store: %v", err)
+	}
+
+	state := BuildMCPViewState(MCPStateOptions{Config: cfg, PermissionStore: permissionStore, TokenStore: tokenStore})
+
+	if len(state.Servers) != 1 || state.Servers[0].Name != "linear" {
+		t.Fatalf("servers = %#v, want configured server despite store errors", state.Servers)
+	}
+	if state.Permissions.GrantCount != 0 || len(state.Permissions.Grants) != 0 {
+		t.Fatalf("permissions = %#v, want empty summary after store error", state.Permissions)
+	}
+	if len(state.OAuth.Servers) != 1 || state.OAuth.Servers[0].ServerName != "linear" || !state.OAuth.Servers[0].Configured {
+		t.Fatalf("oauth = %#v, want configured OAuth server without token status", state.OAuth.Servers)
+	}
+}
+
+func assertServerView(t *testing.T, got MCPServerView, want MCPServerView) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("server view = %#v, want %#v", got, want)
+	}
+}
+
+func assertToolView(t *testing.T, got MCPToolView, want MCPToolView) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("tool view = %#v, want %#v", got, want)
+	}
+}
+
+func assertOAuthView(t *testing.T, got MCPOAuthServerView, want MCPOAuthServerView) {
+	t.Helper()
+	if got.ServerName != want.ServerName ||
+		got.Configured != want.Configured ||
+		got.HasToken != want.HasToken ||
+		got.HasRefreshToken != want.HasRefreshToken ||
+		got.TokenType != want.TokenType ||
+		got.ExpiresAt != want.ExpiresAt ||
+		got.Expired != want.Expired ||
+		strings.Join(got.Scopes, "\x00") != strings.Join(want.Scopes, "\x00") {
+		t.Fatalf("OAuth view = %#v, want %#v", got, want)
+	}
+}
+
+func writeInvalidStoreFile(path string) error {
+	return os.WriteFile(path, []byte(`{"schemaVersion":999}`+"\n"), 0o600)
+}
+
+type tuiFakeMCPClient struct {
+	listed []mcp.RemoteTool
+}
+
+func (client *tuiFakeMCPClient) ListTools(context.Context) ([]mcp.RemoteTool, error) {
+	return client.listed, nil
+}
+
+func (client *tuiFakeMCPClient) CallTool(context.Context, string, map[string]any) (mcp.CallToolResult, error) {
+	return mcp.CallToolResult{}, nil
+}
+
+func (client *tuiFakeMCPClient) Close() error {
+	return nil
+}

--- a/internal/tui/mcp_state_test.go
+++ b/internal/tui/mcp_state_test.go
@@ -183,6 +183,12 @@ func TestBuildMCPViewStateSummarizesOAuthTokens(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Save(linear) error = %v", err)
 	}
+	if err := store.Save("notion", mcp.StoredToken{
+		AccessToken: "expired-secret",
+		ExpiresAt:   now.Add(-2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("Save(notion) error = %v", err)
+	}
 	if err := store.Save("orphan", mcp.StoredToken{AccessToken: "orphan-secret", ExpiresAt: now.Add(-time.Minute)}); err != nil {
 		t.Fatalf("Save(orphan) error = %v", err)
 	}
@@ -201,8 +207,25 @@ func TestBuildMCPViewStateSummarizesOAuthTokens(t *testing.T) {
 		Scopes:          []string{"issues:read", "issues:write"},
 		ExpiresAt:       expiry,
 	})
-	assertOAuthView(t, state.OAuth.Servers[1], MCPOAuthServerView{ServerName: "notion", Configured: true})
+	assertOAuthView(t, state.OAuth.Servers[1], MCPOAuthServerView{
+		ServerName: "notion",
+		Configured: true,
+		HasToken:   true,
+		Expired:    true,
+		ExpiresAt:  now.Add(-2 * time.Minute),
+	})
 	assertOAuthView(t, state.OAuth.Servers[2], MCPOAuthServerView{ServerName: "orphan", HasToken: true, Expired: true, ExpiresAt: now.Add(-time.Minute)})
+
+	rendered := renderMCPView(state, 160)
+	for _, want := range []string{
+		"linear configured token refresh expires 2026-06-13T13:00:00Z Bearer scopes issues:read,issues:write",
+		"notion configured token expired",
+		"orphan not configured",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered OAuth state = %q, missing %q", rendered, want)
+		}
+	}
 }
 
 func TestBuildMCPViewStateToleratesUnreadableStores(t *testing.T) {

--- a/internal/tui/mcp_state_test.go
+++ b/internal/tui/mcp_state_test.go
@@ -43,20 +43,20 @@ func TestBuildMCPViewStateSummarizesConfiguredServers(t *testing.T) {
 		Name:      "docs",
 		Transport: "stdio",
 		State:     "enabled",
-		Target:    "docs-mcp --workspace . env ZERO_DOCS_TOKEN=[redacted]",
+		Target:    "docs-mcp --workspace . env ZERO_DOCS_TOKEN=[REDACTED]",
 	})
 	assertServerView(t, state.Servers[1], MCPServerView{
 		Name:      "linear",
 		Transport: "http",
 		State:     "disabled",
-		Target:    "https://linear.example/mcp headers Authorization=[redacted]",
+		Target:    "https://linear.example/mcp headers Authorization=[REDACTED]",
 		Auth:      "oauth",
 	})
 	assertServerView(t, state.Servers[2], MCPServerView{
 		Name:      "updates",
 		Transport: "sse",
 		State:     "enabled",
-		Target:    "https://events.example/sse headers X-Api-Key=[redacted]",
+		Target:    "https://events.example/sse headers X-Api-Key=[REDACTED]",
 	})
 
 	rendered := renderMCPView(state, 160)

--- a/internal/tui/mcp_view.go
+++ b/internal/tui/mcp_view.go
@@ -143,34 +143,58 @@ func mcpServerLines(servers []MCPServerView) []string {
 			line += " - " + target
 		}
 		lines = append(lines, commandBullet(line))
+		if actions := mcpServerActionLine(server); actions != "" {
+			lines = append(lines, actions)
+		}
 	}
 	return lines
 }
 
 func mcpToolLines(tools []MCPToolView) []string {
-	lines := make([]string, 0, len(tools))
+	grouped := map[string][]MCPToolView{}
+	order := []string{}
 	for _, tool := range tools {
-		name := strings.TrimSpace(tool.RegistryName)
-		if name == "" {
-			name = strings.Trim(strings.Join([]string{"mcp", tool.ServerName, tool.Name}, "_"), "_")
+		serverName := displayValue(strings.TrimSpace(tool.ServerName), "unknown")
+		if _, ok := grouped[serverName]; !ok {
+			order = append(order, serverName)
 		}
-		if name == "" {
-			name = "mcp_tool"
-		}
+		grouped[serverName] = append(grouped[serverName], tool)
+	}
 
-		sideEffect := displayValue(strings.TrimSpace(tool.SideEffect), "unknown")
-		permission := displayValue(strings.TrimSpace(tool.Permission), "prompt")
-		line := fmt.Sprintf("%s [%s/%s]", name, sideEffect, permission)
-
-		if target := mcpToolTarget(tool); target != "" {
-			line += " - " + target
+	lines := make([]string, 0, len(tools)+len(order))
+	for _, serverName := range order {
+		serverTools := grouped[serverName]
+		lines = append(lines, commandBullet(fmt.Sprintf("%s tools (%d)", serverName, len(serverTools))))
+		for _, tool := range serverTools {
+			lines = append(lines, "  "+commandBullet(mcpToolLine(tool)))
 		}
-		if description := strings.TrimSpace(tool.Description); description != "" {
-			line += " - " + description
-		}
-		lines = append(lines, commandBullet(line))
 	}
 	return lines
+}
+
+func mcpToolLine(tool MCPToolView) string {
+	name := strings.TrimSpace(tool.RegistryName)
+	if name == "" {
+		name = strings.Trim(strings.Join([]string{"mcp", tool.ServerName, tool.Name}, "_"), "_")
+	}
+	if name == "" {
+		name = "mcp_tool"
+	}
+
+	sideEffect := displayValue(strings.TrimSpace(tool.SideEffect), "unknown")
+	permission := displayValue(strings.TrimSpace(tool.Permission), "prompt")
+	displayName := displayValue(strings.TrimSpace(tool.Name), name)
+	line := fmt.Sprintf("%s [%s/%s]", displayName, sideEffect, permission)
+	if name != "" && name != displayName {
+		line += " - " + name
+	}
+	if target := mcpToolTarget(tool); target != "" && target != displayName {
+		line += " - " + target
+	}
+	if description := strings.TrimSpace(tool.Description); description != "" {
+		line += " - " + description
+	}
+	return line
 }
 
 func mcpToolTarget(tool MCPToolView) string {
@@ -250,8 +274,59 @@ func mcpOAuthLines(servers []MCPOAuthServerView) []string {
 			parts = append(parts, "not configured")
 		}
 		lines = append(lines, commandBullet(strings.Join(parts, " ")))
+		if actions := mcpOAuthActionLine(server); actions != "" {
+			lines = append(lines, actions)
+		}
 	}
 	return lines
+}
+
+func mcpServerActionLine(server MCPServerView) string {
+	name := strings.TrimSpace(server.Name)
+	if name == "" {
+		return ""
+	}
+	actions := []string{"zero mcp check " + name}
+	if strings.EqualFold(strings.TrimSpace(server.State), "disabled") {
+		actions = append(actions, "zero mcp enable "+name)
+	} else {
+		actions = append(actions, "zero mcp disable "+name)
+	}
+	actions = append(actions, "zero mcp remove "+name)
+	if strings.EqualFold(strings.TrimSpace(server.Auth), "oauth") {
+		actions = append(actions, "zero mcp oauth login "+name)
+	}
+	return "    actions: " + strings.Join(actions, " | ")
+}
+
+func mcpOAuthActionLine(server MCPOAuthServerView) string {
+	name := strings.TrimSpace(server.ServerName)
+	if name == "" || !server.Configured {
+		return ""
+	}
+	actions := []string{}
+	if server.HasToken {
+		actions = append(actions, "zero mcp oauth refresh "+name, "zero mcp oauth logout "+name)
+	} else {
+		actions = append(actions, "zero mcp oauth login "+name)
+	}
+	if server.Expired && !server.HasRefreshToken {
+		actions = append(actions, "zero mcp oauth refresh "+name)
+	}
+	return "    actions: " + strings.Join(dedupeStrings(actions), " | ")
+}
+
+func dedupeStrings(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
 }
 
 func fitCommandOutput(output commandOutput, width int) string {

--- a/internal/tui/mcp_view.go
+++ b/internal/tui/mcp_view.go
@@ -63,49 +63,54 @@ type MCPOAuthServerView struct {
 }
 
 func renderMCPView(state MCPViewState, width int) string {
-	output := commandOutput{
-		Title:  "MCP",
-		Status: mcpViewStatus(state),
+	lines := []string{
+		"Manage MCP servers",
+		pluralCount(len(state.Servers), "server"),
+		"",
 	}
 
 	if !hasMCPViewContent(state) {
-		output.Sections = []commandSection{{
-			Title: "State",
-			Lines: []string{
-				"No MCP servers configured.",
-				"Add one with zero mcp add, then reopen /mcp.",
-			},
-		}}
-		output.Hints = []string{"zero mcp add <name> --url <url>", "zero mcp list", "zero mcp check <name>"}
-		return fitCommandOutput(output, width)
+		lines = append(lines,
+			"User MCPs",
+			"  No MCP servers configured.",
+			"  › Add MCP server      zero mcp add <name> --url <url>",
+			"  › Add local stdio MCP zero mcp add <name> -- <command> [args...]",
+			"  › List configured     zero mcp list",
+			"",
+			"Actions",
+			"  add remote · add stdio · list configured · check health",
+		)
+		return fitMCPManagerLines(lines, width)
 	}
 
 	if len(state.Servers) > 0 {
-		output.Sections = append(output.Sections, commandSection{
-			Title: "Servers",
-			Lines: mcpServerLines(state.Servers),
-		})
+		lines = append(lines, "User MCPs")
+		lines = append(lines, mcpManagerServerLines(state.Servers)...)
 	}
 	if len(state.Tools) > 0 {
-		output.Sections = append(output.Sections, commandSection{
-			Title: "Tools",
-			Lines: mcpToolLines(state.Tools),
-		})
+		lines = append(lines, "", "Tools")
+		lines = append(lines, mcpToolLines(state.Tools)...)
 	}
 	if hasMCPPermissionSummary(state.Permissions) {
-		output.Sections = append(output.Sections, commandSection{
-			Title: "Permissions",
-			Lines: mcpPermissionLines(state.Permissions),
-		})
+		lines = append(lines, "", "Permissions")
+		for _, line := range mcpPermissionLines(state.Permissions) {
+			lines = append(lines, "  "+line)
+		}
 	}
 	if len(state.OAuth.Servers) > 0 {
-		output.Sections = append(output.Sections, commandSection{
-			Title: "OAuth",
-			Lines: mcpOAuthLines(state.OAuth.Servers),
-		})
+		lines = append(lines, "", "OAuth")
+		lines = append(lines, mcpOAuthLines(state.OAuth.Servers)...)
 	}
 
-	return fitCommandOutput(output, width)
+	lines = append(lines,
+		"",
+		"Actions",
+		"  add: zero mcp add <name> --url <url>",
+		"  disconnect: zero mcp disable <name>",
+		"  reconnect: zero mcp enable <name>",
+		"  remove: zero mcp remove <name>",
+	)
+	return fitMCPManagerLines(lines, width)
 }
 
 func mcpViewStatus(state MCPViewState) commandStatus {
@@ -161,6 +166,36 @@ func mcpServerLines(servers []MCPServerView) []string {
 		lines = append(lines, commandBullet(line))
 		if actions := mcpServerActionLine(server); actions != "" {
 			lines = append(lines, actions)
+		}
+	}
+	return lines
+}
+
+func mcpManagerServerLines(servers []MCPServerView) []string {
+	lines := make([]string, 0, len(servers)*3)
+	for index, server := range servers {
+		name := displayValue(strings.TrimSpace(server.Name), "unnamed")
+		transport := displayValue(strings.TrimSpace(server.Transport), "unknown")
+		state := displayValue(strings.TrimSpace(server.State), "configured")
+		prefix := "  "
+		if index == 0 {
+			prefix = "› "
+		}
+
+		parts := []string{name, state}
+		if auth := strings.TrimSpace(server.Auth); auth != "" {
+			parts = append(parts, auth)
+		}
+		if server.ToolCount > 0 {
+			parts = append(parts, pluralCount(server.ToolCount, "tool"))
+		}
+		parts = append(parts, transport)
+		lines = append(lines, prefix+strings.Join(parts, " · "))
+		if target := strings.TrimSpace(server.Target); target != "" {
+			lines = append(lines, "  "+target)
+		}
+		if actions := strings.TrimSpace(mcpServerActionLine(server)); actions != "" {
+			lines = append(lines, "  "+actions)
 		}
 	}
 	return lines
@@ -351,6 +386,16 @@ func fitCommandOutput(output commandOutput, width int) string {
 		return rendered
 	}
 	lines := strings.Split(rendered, "\n")
+	for index, line := range lines {
+		lines[index] = fitStyledLine(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func fitMCPManagerLines(lines []string, width int) string {
+	if width <= 0 {
+		return strings.Join(lines, "\n")
+	}
 	for index, line := range lines {
 		lines[index] = fitStyledLine(line, width)
 	}

--- a/internal/tui/mcp_view.go
+++ b/internal/tui/mcp_view.go
@@ -1,0 +1,274 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type MCPViewState struct {
+	Servers     []MCPServerView
+	Tools       []MCPToolView
+	Permissions MCPPermissionSummary
+	OAuth       MCPOAuthSummary
+}
+
+type MCPServerView struct {
+	Name      string
+	Transport string
+	State     string
+	Target    string
+	Auth      string
+	ToolCount int
+}
+
+type MCPToolView struct {
+	ServerName   string
+	Name         string
+	RegistryName string
+	SideEffect   string
+	Permission   string
+	Description  string
+}
+
+type MCPPermissionSummary struct {
+	Mode         string
+	GrantCount   int
+	ServerGrants int
+	ToolGrants   int
+	PromptCount  int
+	DeniedCount  int
+	Grants       []MCPPermissionGrantView
+}
+
+type MCPPermissionGrantView struct {
+	Target     string
+	Autonomy   string
+	ApprovedAt string
+}
+
+type MCPOAuthSummary struct {
+	Servers []MCPOAuthServerView
+}
+
+type MCPOAuthServerView struct {
+	ServerName      string
+	Configured      bool
+	HasToken        bool
+	HasRefreshToken bool
+	TokenType       string
+	Scopes          []string
+	ExpiresAt       time.Time
+	Expired         bool
+}
+
+func renderMCPView(state MCPViewState, width int) string {
+	output := commandOutput{
+		Title:  "MCP",
+		Status: mcpViewStatus(state),
+	}
+
+	if !hasMCPViewContent(state) {
+		output.Sections = []commandSection{{
+			Title: "State",
+			Lines: []string{"No MCP servers configured."},
+		}}
+		output.Hints = []string{"zero mcp list", "zero mcp tools list"}
+		return fitCommandOutput(output, width)
+	}
+
+	if len(state.Servers) > 0 {
+		output.Sections = append(output.Sections, commandSection{
+			Title: "Servers",
+			Lines: mcpServerLines(state.Servers),
+		})
+	}
+	if len(state.Tools) > 0 {
+		output.Sections = append(output.Sections, commandSection{
+			Title: "Tools",
+			Lines: mcpToolLines(state.Tools),
+		})
+	}
+	if hasMCPPermissionSummary(state.Permissions) {
+		output.Sections = append(output.Sections, commandSection{
+			Title: "Permissions",
+			Lines: mcpPermissionLines(state.Permissions),
+		})
+	}
+	if len(state.OAuth.Servers) > 0 {
+		output.Sections = append(output.Sections, commandSection{
+			Title: "OAuth",
+			Lines: mcpOAuthLines(state.OAuth.Servers),
+		})
+	}
+
+	return fitCommandOutput(output, width)
+}
+
+func mcpViewStatus(state MCPViewState) commandStatus {
+	if !hasMCPViewContent(state) {
+		return commandStatusWarning
+	}
+	for _, server := range state.Servers {
+		status := strings.ToLower(strings.TrimSpace(server.State))
+		if strings.Contains(status, "error") || strings.Contains(status, "failed") {
+			return commandStatusBlocked
+		}
+	}
+	return commandStatusOK
+}
+
+func hasMCPViewContent(state MCPViewState) bool {
+	return len(state.Servers) > 0 ||
+		len(state.Tools) > 0 ||
+		hasMCPPermissionSummary(state.Permissions) ||
+		len(state.OAuth.Servers) > 0
+}
+
+func mcpServerLines(servers []MCPServerView) []string {
+	lines := make([]string, 0, len(servers))
+	for _, server := range servers {
+		name := displayValue(strings.TrimSpace(server.Name), "unnamed")
+		transport := displayValue(strings.TrimSpace(server.Transport), "unknown")
+		state := displayValue(strings.TrimSpace(server.State), "configured")
+
+		line := fmt.Sprintf("%s [%s] %s", name, transport, state)
+		if auth := strings.TrimSpace(server.Auth); auth != "" {
+			line += " " + auth
+		}
+		if server.ToolCount > 0 {
+			line += " " + pluralCount(server.ToolCount, "tool")
+		}
+		if target := strings.TrimSpace(server.Target); target != "" {
+			line += " - " + target
+		}
+		lines = append(lines, commandBullet(line))
+	}
+	return lines
+}
+
+func mcpToolLines(tools []MCPToolView) []string {
+	lines := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.RegistryName)
+		if name == "" {
+			name = strings.Trim(strings.Join([]string{"mcp", tool.ServerName, tool.Name}, "_"), "_")
+		}
+		if name == "" {
+			name = "mcp_tool"
+		}
+
+		sideEffect := displayValue(strings.TrimSpace(tool.SideEffect), "unknown")
+		permission := displayValue(strings.TrimSpace(tool.Permission), "prompt")
+		line := fmt.Sprintf("%s [%s/%s]", name, sideEffect, permission)
+
+		if target := mcpToolTarget(tool); target != "" {
+			line += " - " + target
+		}
+		if description := strings.TrimSpace(tool.Description); description != "" {
+			line += " - " + description
+		}
+		lines = append(lines, commandBullet(line))
+	}
+	return lines
+}
+
+func mcpToolTarget(tool MCPToolView) string {
+	server := strings.TrimSpace(tool.ServerName)
+	name := strings.TrimSpace(tool.Name)
+	switch {
+	case server != "" && name != "":
+		return server + "/" + name
+	case server != "":
+		return server + "/*"
+	default:
+		return name
+	}
+}
+
+func hasMCPPermissionSummary(summary MCPPermissionSummary) bool {
+	return strings.TrimSpace(summary.Mode) != "" ||
+		summary.GrantCount > 0 ||
+		summary.ServerGrants > 0 ||
+		summary.ToolGrants > 0 ||
+		summary.PromptCount > 0 ||
+		summary.DeniedCount > 0 ||
+		len(summary.Grants) > 0
+}
+
+func mcpPermissionLines(summary MCPPermissionSummary) []string {
+	lines := []string{
+		"mode: " + displayValue(strings.TrimSpace(summary.Mode), "unknown"),
+		fmt.Sprintf("persistent grants: %d", summary.GrantCount),
+		fmt.Sprintf("server grants: %d", summary.ServerGrants),
+		fmt.Sprintf("tool grants: %d", summary.ToolGrants),
+		fmt.Sprintf("prompted this session: %d", summary.PromptCount),
+		fmt.Sprintf("denied this session: %d", summary.DeniedCount),
+	}
+	if len(summary.Grants) == 0 {
+		return lines
+	}
+	for _, grant := range summary.Grants {
+		target := displayValue(strings.TrimSpace(grant.Target), "unknown")
+		autonomy := displayValue(strings.TrimSpace(grant.Autonomy), "low")
+		line := fmt.Sprintf("%s [%s]", target, autonomy)
+		if approvedAt := strings.TrimSpace(grant.ApprovedAt); approvedAt != "" {
+			line += " approved " + approvedAt
+		}
+		lines = append(lines, commandBullet(line))
+	}
+	return lines
+}
+
+func mcpOAuthLines(servers []MCPOAuthServerView) []string {
+	lines := make([]string, 0, len(servers))
+	for _, server := range servers {
+		name := displayValue(strings.TrimSpace(server.ServerName), "unnamed")
+		parts := []string{name}
+		if server.Configured {
+			parts = append(parts, "configured")
+			if server.HasToken {
+				parts = append(parts, "token")
+			} else {
+				parts = append(parts, "no token")
+			}
+			if server.HasRefreshToken {
+				parts = append(parts, "refresh")
+			}
+			if server.Expired {
+				parts = append(parts, "expired")
+			} else if !server.ExpiresAt.IsZero() {
+				parts = append(parts, "expires", server.ExpiresAt.UTC().Format(time.RFC3339))
+			}
+			if tokenType := strings.TrimSpace(server.TokenType); tokenType != "" {
+				parts = append(parts, tokenType)
+			}
+			if len(server.Scopes) > 0 {
+				parts = append(parts, "scopes", strings.Join(server.Scopes, ","))
+			}
+		} else {
+			parts = append(parts, "not configured")
+		}
+		lines = append(lines, commandBullet(strings.Join(parts, " ")))
+	}
+	return lines
+}
+
+func fitCommandOutput(output commandOutput, width int) string {
+	rendered := renderCommandOutput(output)
+	if width <= 0 {
+		return rendered
+	}
+	lines := strings.Split(rendered, "\n")
+	for index, line := range lines {
+		lines[index] = fitStyledLine(line, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func pluralCount(count int, noun string) string {
+	if count == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", count, noun)
+}

--- a/internal/tui/mcp_view.go
+++ b/internal/tui/mcp_view.go
@@ -71,9 +71,12 @@ func renderMCPView(state MCPViewState, width int) string {
 	if !hasMCPViewContent(state) {
 		output.Sections = []commandSection{{
 			Title: "State",
-			Lines: []string{"No MCP servers configured."},
+			Lines: []string{
+				"No MCP servers configured.",
+				"Add one with zero mcp add, then reopen /mcp.",
+			},
 		}}
-		output.Hints = []string{"zero mcp list", "zero mcp tools list"}
+		output.Hints = []string{"zero mcp add <name> --url <url>", "zero mcp list", "zero mcp check <name>"}
 		return fitCommandOutput(output, width)
 	}
 
@@ -106,7 +109,7 @@ func renderMCPView(state MCPViewState, width int) string {
 }
 
 func mcpViewStatus(state MCPViewState) commandStatus {
-	if !hasMCPViewContent(state) {
+	if !hasMCPOperationalContent(state) {
 		return commandStatusWarning
 	}
 	for _, server := range state.Servers {
@@ -119,10 +122,23 @@ func mcpViewStatus(state MCPViewState) commandStatus {
 }
 
 func hasMCPViewContent(state MCPViewState) bool {
+	return hasMCPOperationalContent(state) ||
+		hasMCPPermissionActivity(state.Permissions)
+}
+
+func hasMCPOperationalContent(state MCPViewState) bool {
 	return len(state.Servers) > 0 ||
 		len(state.Tools) > 0 ||
-		hasMCPPermissionSummary(state.Permissions) ||
 		len(state.OAuth.Servers) > 0
+}
+
+func hasMCPPermissionActivity(summary MCPPermissionSummary) bool {
+	return summary.GrantCount > 0 ||
+		summary.ServerGrants > 0 ||
+		summary.ToolGrants > 0 ||
+		summary.PromptCount > 0 ||
+		summary.DeniedCount > 0 ||
+		len(summary.Grants) > 0
 }
 
 func mcpServerLines(servers []MCPServerView) []string {

--- a/internal/tui/mcp_view_test.go
+++ b/internal/tui/mcp_view_test.go
@@ -23,6 +23,26 @@ func TestMCPViewRendersEmptyState(t *testing.T) {
 	}
 }
 
+func TestMCPViewRendersEmptyStateWhenOnlyPermissionModeExists(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{
+		Permissions: MCPPermissionSummary{Mode: "ask"},
+	}, 96))
+
+	for _, want := range []string{
+		"MCP",
+		"status: warning",
+		"No MCP servers configured.",
+		"zero mcp add",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("empty MCP view with permission mode = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "status: ok") {
+		t.Fatalf("empty MCP view should not report ok:\n%s", got)
+	}
+}
+
 func TestMCPViewRendersServerRows(t *testing.T) {
 	got := plainRender(t, renderMCPView(MCPViewState{
 		Servers: []MCPServerView{

--- a/internal/tui/mcp_view_test.go
+++ b/internal/tui/mcp_view_test.go
@@ -54,9 +54,11 @@ func TestMCPViewRendersToolRows(t *testing.T) {
 
 	for _, want := range []string{
 		"Tools",
-		"mcp_filesystem_read_file [read/allow]",
+		"filesystem tools (1)",
+		"read_file [read/allow] - mcp_filesystem_read_file",
 		"filesystem/read_file",
-		"mcp_github_create_issue [network/prompt]",
+		"github tools (1)",
+		"create_issue [network/prompt] - mcp_github_create_issue",
 		"Create an issue in GitHub",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/tui/mcp_view_test.go
+++ b/internal/tui/mcp_view_test.go
@@ -1,0 +1,169 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestMCPViewRendersEmptyState(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{}, 72))
+
+	for _, want := range []string{
+		"MCP",
+		"status: warning",
+		"No MCP servers configured.",
+		"zero mcp list",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("empty MCP view = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPViewRendersServerRows(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{
+		Servers: []MCPServerView{
+			{Name: "filesystem", Transport: "stdio", State: "connected", Target: "npx @modelcontextprotocol/server-filesystem /repo", ToolCount: 3},
+			{Name: "linear", Transport: "http", State: "disabled", Target: "https://mcp.linear.app", Auth: "oauth"},
+		},
+	}, 96))
+
+	for _, want := range []string{
+		"Servers",
+		"filesystem [stdio] connected",
+		"3 tools",
+		"linear [http] disabled oauth",
+		"https://mcp.linear.app",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP server view = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPViewRendersToolRows(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{
+		Tools: []MCPToolView{
+			{ServerName: "filesystem", Name: "read_file", RegistryName: "mcp_filesystem_read_file", SideEffect: "read", Permission: "allow", Description: "Read a file from the workspace"},
+			{ServerName: "github", Name: "create_issue", RegistryName: "mcp_github_create_issue", SideEffect: "network", Permission: "prompt", Description: "Create an issue in GitHub"},
+		},
+	}, 140))
+
+	for _, want := range []string{
+		"Tools",
+		"mcp_filesystem_read_file [read/allow]",
+		"filesystem/read_file",
+		"mcp_github_create_issue [network/prompt]",
+		"Create an issue in GitHub",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP tools view = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPViewRendersPermissionStates(t *testing.T) {
+	got := plainRender(t, renderMCPView(MCPViewState{
+		Permissions: MCPPermissionSummary{
+			Mode:         "ask",
+			GrantCount:   2,
+			ServerGrants: 1,
+			ToolGrants:   1,
+			PromptCount:  4,
+			DeniedCount:  1,
+			Grants: []MCPPermissionGrantView{
+				{Target: "filesystem/*", Autonomy: "low", ApprovedAt: "2026-06-13T09:30:00Z"},
+				{Target: "github/create_issue", Autonomy: "medium", ApprovedAt: "2026-06-13T10:00:00Z"},
+			},
+		},
+	}, 92))
+
+	for _, want := range []string{
+		"Permissions",
+		"mode: ask",
+		"persistent grants: 2",
+		"server grants: 1",
+		"tool grants: 1",
+		"prompted this session: 4",
+		"denied this session: 1",
+		"filesystem/* [low] approved 2026-06-13T09:30:00Z",
+		"github/create_issue [medium] approved 2026-06-13T10:00:00Z",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP permission view = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPViewRendersOAuthSummary(t *testing.T) {
+	expiry := time.Date(2026, 6, 13, 11, 45, 0, 0, time.UTC)
+	got := plainRender(t, renderMCPView(MCPViewState{
+		OAuth: MCPOAuthSummary{
+			Servers: []MCPOAuthServerView{
+				{ServerName: "linear", Configured: true, HasToken: true, HasRefreshToken: true, TokenType: "Bearer", Scopes: []string{"issues:read", "issues:write"}, ExpiresAt: expiry},
+				{ServerName: "notion", Configured: true, HasToken: true, Expired: true},
+				{ServerName: "plain", Configured: false},
+			},
+		},
+	}, 160))
+
+	for _, want := range []string{
+		"OAuth",
+		"linear configured token refresh expires 2026-06-13T11:45:00Z Bearer scopes issues:read,issues:write",
+		"notion configured token expired",
+		"plain not configured",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("MCP OAuth view = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestMCPViewNeverExceedsWidth(t *testing.T) {
+	state := MCPViewState{
+		Servers: []MCPServerView{{
+			Name:      "very-long-server-name",
+			Transport: "stdio",
+			State:     "connected",
+			Target:    "C:/Users/example/workspaces/very/deep/path/with/a/long/command --and --many --arguments",
+			ToolCount: 12,
+		}},
+		Tools: []MCPToolView{{
+			ServerName:   "very-long-server-name",
+			Name:         "tool_with_an_extremely_long_name",
+			RegistryName: "mcp_very_long_server_name_tool_with_an_extremely_long_name",
+			SideEffect:   "network",
+			Permission:   "prompt",
+			Description:  "This description is intentionally long so the renderer has to trim it safely.",
+		}},
+		Permissions: MCPPermissionSummary{
+			Mode:       "ask",
+			GrantCount: 1,
+			Grants: []MCPPermissionGrantView{{
+				Target:     "very-long-server-name/tool_with_an_extremely_long_name",
+				Autonomy:   "medium",
+				ApprovedAt: "2026-06-13T10:00:00Z",
+			}},
+		},
+		OAuth: MCPOAuthSummary{Servers: []MCPOAuthServerView{{
+			ServerName:      "very-long-server-name",
+			Configured:      true,
+			HasToken:        true,
+			HasRefreshToken: true,
+			TokenType:       "Bearer",
+			Scopes:          []string{"workspace:read", "workspace:write", "offline_access"},
+			ExpiresAt:       time.Date(2026, 6, 13, 11, 45, 0, 0, time.UTC),
+		}}},
+	}
+
+	for _, width := range []int{24, 40, 58, 72, 96} {
+		for index, line := range strings.Split(renderMCPView(state, width), "\n") {
+			if got := lipgloss.Width(line); got > width {
+				t.Fatalf("width %d: line %d is %d cells wide: %q", width, index, got, line)
+			}
+		}
+	}
+}

--- a/internal/tui/mcp_view_test.go
+++ b/internal/tui/mcp_view_test.go
@@ -12,14 +12,22 @@ func TestMCPViewRendersEmptyState(t *testing.T) {
 	got := plainRender(t, renderMCPView(MCPViewState{}, 72))
 
 	for _, want := range []string{
-		"MCP",
-		"status: warning",
+		"Manage MCP servers",
+		"0 servers",
+		"User MCPs",
 		"No MCP servers configured.",
-		"zero mcp list",
+		"Add MCP server",
+		"zero mcp add <name> --url <url>",
+		"Actions",
+		"add remote",
+		"check health",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("empty MCP view = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "status:") {
+		t.Fatalf("empty MCP manager should not render generic status line:\n%s", got)
 	}
 }
 
@@ -29,8 +37,8 @@ func TestMCPViewRendersEmptyStateWhenOnlyPermissionModeExists(t *testing.T) {
 	}, 96))
 
 	for _, want := range []string{
-		"MCP",
-		"status: warning",
+		"Manage MCP servers",
+		"0 servers",
 		"No MCP servers configured.",
 		"zero mcp add",
 	} {
@@ -52,11 +60,16 @@ func TestMCPViewRendersServerRows(t *testing.T) {
 	}, 96))
 
 	for _, want := range []string{
-		"Servers",
-		"filesystem [stdio] connected",
-		"3 tools",
-		"linear [http] disabled oauth",
+		"Manage MCP servers",
+		"2 servers",
+		"User MCPs",
+		"filesystem · connected · 3 tools · stdio",
+		"linear · disabled · oauth · http",
+		"zero mcp disable filesystem",
+		"zero mcp enable linear",
 		"https://mcp.linear.app",
+		"disconnect: zero mcp disable <name>",
+		"remove: zero mcp remove <name>",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("MCP server view = %q, missing %q", got, want)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,6 +49,7 @@ type model struct {
 	mcpConfig              config.MCPConfig
 	mcpPermissionStore     *internalmcp.PermissionStore
 	mcpTokenStore          *internalmcp.TokenStore
+	mcpCommand             func([]string) MCPCommandResult
 	activeSession          sessions.Metadata
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
@@ -325,6 +326,7 @@ func newModel(ctx context.Context, options Options) model {
 		mcpConfig:              options.MCPConfig,
 		mcpPermissionStore:     options.MCPPermissionStore,
 		mcpTokenStore:          options.MCPTokenStore,
+		mcpCommand:             options.MCPCommand,
 		agentOptions:           options.AgentOptions,
 		sessionCompactor:       options.SessionCompactor,
 		runtimeMessageSink:     options.RuntimeMessageSink,
@@ -1416,7 +1418,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.toolsText()})
 		return m, nil
 	case commandMCP:
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.mcpText()})
+		text := ""
+		m, text = m.handleMCPCommand(command.text)
+		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
 		return m, nil
 	case commandPermissions:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.permissionsText()})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	internalmcp "github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/notify"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
@@ -45,6 +46,9 @@ type model struct {
 	registry               *tools.Registry
 	sessionStore           *sessions.Store
 	sandboxStore           *sandbox.GrantStore
+	mcpConfig              config.MCPConfig
+	mcpPermissionStore     *internalmcp.PermissionStore
+	mcpTokenStore          *internalmcp.TokenStore
 	activeSession          sessions.Metadata
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
@@ -318,6 +322,9 @@ func newModel(ctx context.Context, options Options) model {
 		registry:               registry,
 		sessionStore:           sessionStore,
 		sandboxStore:           sandboxStore,
+		mcpConfig:              options.MCPConfig,
+		mcpPermissionStore:     options.MCPPermissionStore,
+		mcpTokenStore:          options.MCPTokenStore,
 		agentOptions:           options.AgentOptions,
 		sessionCompactor:       options.SessionCompactor,
 		runtimeMessageSink:     options.RuntimeMessageSink,
@@ -1407,6 +1414,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case commandTools:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.toolsText()})
+		return m, nil
+	case commandMCP:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.mcpText()})
 		return m, nil
 	case commandPermissions:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.permissionsText()})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -154,6 +154,7 @@ type model struct {
 	picker                       *commandPicker
 	providerWizard               *providerWizardState
 	mcpManager                   *mcpManagerState
+	mcpAddWizard                 *mcpAddWizardState
 	favoriteModels               map[string]bool
 	modelPickerLoading           bool
 	modelPickerLoadingProviderID string
@@ -459,6 +460,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.providerWizard = nil
 				return m, nil
 			}
+			if m.mcpAddWizard != nil {
+				m.mcpAddWizard = nil
+				return m, nil
+			}
 			if m.mcpManager != nil {
 				m.mcpManager = nil
 				return m, nil
@@ -504,6 +509,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
+			if m.mcpAddWizard != nil {
+				return m.handleMCPAddWizardKey(msg)
+			}
 			if m.mcpManager != nil {
 				return m.handleMCPManagerKey(msg)
 			}
@@ -532,7 +540,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// nextPermissionMode), but only when nothing modal is up: a permission
 			// prompt, ask_user questionnaire, or open picker all take precedence
 			// and let the key fall through to their own handlers below.
-			if m.pendingPermission == nil && m.pendingAskUser == nil && m.pendingSpecReview == nil && m.providerWizard == nil && m.mcpManager == nil && m.picker == nil {
+			if m.pendingPermission == nil && m.pendingAskUser == nil && m.pendingSpecReview == nil && m.providerWizard == nil && m.mcpAddWizard == nil && m.mcpManager == nil && m.picker == nil {
 				m.permissionMode = nextPermissionMode(m.permissionMode)
 				return m, nil
 			}
@@ -558,6 +566,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
+			if m.mcpAddWizard != nil {
+				return m.handleMCPAddWizardKey(msg)
+			}
 			if m.mcpManager != nil {
 				return m.handleMCPManagerKey(msg)
 			}
@@ -582,6 +593,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
+			if m.mcpAddWizard != nil {
+				return m.handleMCPAddWizardKey(msg)
+			}
 			if m.mcpManager != nil {
 				return m.handleMCPManagerKey(msg)
 			}
@@ -605,6 +619,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
+			}
+			if m.mcpAddWizard != nil {
+				return m.handleMCPAddWizardKey(msg)
 			}
 			if m.mcpManager != nil {
 				return m.handleMCPManagerKey(msg)
@@ -642,6 +659,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.providerWizard != nil {
 			return m.handleProviderWizardKey(msg)
+		}
+		if m.mcpAddWizard != nil {
+			return m.handleMCPAddWizardKey(msg)
 		}
 		if m.mcpManager != nil {
 			return m.handleMCPManagerKey(msg)
@@ -932,12 +952,15 @@ func (m model) transcriptView() string {
 
 	suggestionOverlay := m.suggestionOverlay(width)
 	providerOverlay := m.providerWizardOverlay(width)
+	mcpAddOverlay := m.mcpAddWizardOverlay(width)
 	mcpOverlay := m.mcpManagerOverlay(width)
 	pickerOverlay := m.pickerOverlay(width)
 	viewportOverlay := ""
 	switch {
 	case providerOverlay != "":
 		viewportOverlay = providerOverlay
+	case mcpAddOverlay != "":
+		viewportOverlay = mcpAddOverlay
 	case mcpOverlay != "":
 		viewportOverlay = mcpOverlay
 	case pickerOverlay != "":

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,7 +49,11 @@ type model struct {
 	mcpConfig              config.MCPConfig
 	mcpPermissionStore     *internalmcp.PermissionStore
 	mcpTokenStore          *internalmcp.TokenStore
-	mcpCommand             func([]string) MCPCommandResult
+	mcpCommand             func(context.Context, []string) MCPCommandResult
+	mcpViewStateCache      MCPViewState
+	mcpViewStateReady      bool
+	mcpCommandSeq          int
+	mcpCommandCancel       context.CancelFunc
 	activeSession          sessions.Metadata
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
@@ -204,6 +208,29 @@ type agentRowMsg struct {
 	row   transcriptRow
 }
 
+type mcpCommandOrigin int
+
+const (
+	mcpCommandOriginTranscript mcpCommandOrigin = iota
+	mcpCommandOriginManager
+	mcpCommandOriginWizard
+)
+
+type mcpCommandRequest struct {
+	id              int
+	origin          mcpCommandOrigin
+	args            []string
+	raw             string
+	managerSelected int
+	managerQuery    string
+	wizardDisabled  bool
+}
+
+type mcpCommandResultMsg struct {
+	request mcpCommandRequest
+	result  MCPCommandResult
+}
+
 type permissionDecision = agent.PermissionDecisionAction
 
 const (
@@ -310,7 +337,7 @@ func newModel(ctx context.Context, options Options) model {
 	})
 	notifier.SetFocused(true)
 
-	return model{
+	m := model{
 		ctx:                    ctx,
 		cwd:                    cwd,
 		userConfigPath:         options.UserConfigPath,
@@ -345,6 +372,8 @@ func newModel(ctx context.Context, options Options) model {
 		setup:                  newSetupState(options.Setup),
 		setupSave:              options.Setup.Save,
 	}
+	m.refreshMCPViewState()
+	return m
 }
 
 const (
@@ -443,6 +472,16 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlO:
 			return m.toggleDetailedTranscript(), nil
 		case tea.KeyEsc:
+			if m.mcpCommandCancel != nil {
+				m.cancelMCPCommand()
+				if m.mcpAddWizard != nil {
+					m.mcpAddWizard.result = mcpAddWizardResult{Title: "MCP setup cancelled", State: "cancelled", Message: "MCP action was cancelled.", ActionHint: "Edit config"}
+					m.mcpAddWizard.step = mcpAddWizardStepResult
+					return m, nil
+				}
+				m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: "MCP action cancelled"})
+				return m, nil
+			}
 			if m.transcriptDetailed {
 				m.transcriptDetailed = false
 				return m, nil
@@ -915,6 +954,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applySetupModelsDiscovered(msg), nil
 	case modelPickerModelsDiscoveredMsg:
 		return m.applyModelPickerModelsDiscovered(msg), nil
+	case mcpCommandResultMsg:
+		return m.applyMCPCommandResultMessage(msg), nil
 	}
 
 	var cmd tea.Cmd
@@ -1467,10 +1508,7 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		if strings.TrimSpace(command.text) == "" {
 			return m.openMCPManager(), nil
 		}
-		text := ""
-		m, text = m.handleMCPCommand(command.text)
-		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})
-		return m, nil
+		return m.startMCPTranscriptCommand(command.text)
 	case commandPermissions:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.permissionsText()})
 		return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1634,6 +1634,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "$ " + cmdText})
 		return m, runBashEscape(m.cwd, cmdText)
 	case commandPrompt:
+		if intent, ok := detectMCPSetupIntent(command.text); ok {
+			return m.openMCPAddWizardFromIntent(intent), nil
+		}
 		return m.launchPrompt(command.text)
 	default:
 		return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -153,6 +153,7 @@ type model struct {
 	// the chosen value through the existing command handlers.
 	picker                       *commandPicker
 	providerWizard               *providerWizardState
+	mcpManager                   *mcpManagerState
 	favoriteModels               map[string]bool
 	modelPickerLoading           bool
 	modelPickerLoadingProviderID string
@@ -458,6 +459,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.providerWizard = nil
 				return m, nil
 			}
+			if m.mcpManager != nil {
+				m.mcpManager = nil
+				return m, nil
+			}
 			// An open picker cancels first; then an active suggestion overlay is
 			// dismissed. Neither cancels the run or clears the input.
 			if m.picker != nil {
@@ -499,6 +504,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
+			if m.mcpManager != nil {
+				return m.handleMCPManagerKey(msg)
+			}
 			if m.picker != nil {
 				return m.choosePicker()
 			}
@@ -524,7 +532,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// nextPermissionMode), but only when nothing modal is up: a permission
 			// prompt, ask_user questionnaire, or open picker all take precedence
 			// and let the key fall through to their own handlers below.
-			if m.pendingPermission == nil && m.pendingAskUser == nil && m.pendingSpecReview == nil && m.providerWizard == nil && m.picker == nil {
+			if m.pendingPermission == nil && m.pendingAskUser == nil && m.pendingSpecReview == nil && m.providerWizard == nil && m.mcpManager == nil && m.picker == nil {
 				m.permissionMode = nextPermissionMode(m.permissionMode)
 				return m, nil
 			}
@@ -550,6 +558,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
+			if m.mcpManager != nil {
+				return m.handleMCPManagerKey(msg)
+			}
 			if m.picker == nil && m.suggestionsActive() {
 				m.moveSuggestion(1)
 				return m, nil
@@ -571,6 +582,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
 			}
+			if m.mcpManager != nil {
+				return m.handleMCPManagerKey(msg)
+			}
 			if m.picker != nil {
 				if m.modelPickerIsLoading() {
 					return m, nil
@@ -591,6 +605,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.providerWizard != nil {
 				return m.handleProviderWizardKey(msg)
+			}
+			if m.mcpManager != nil {
+				return m.handleMCPManagerKey(msg)
 			}
 			if m.picker != nil {
 				if m.modelPickerIsLoading() {
@@ -625,6 +642,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.providerWizard != nil {
 			return m.handleProviderWizardKey(msg)
+		}
+		if m.mcpManager != nil {
+			return m.handleMCPManagerKey(msg)
 		}
 		// An open picker is modal over the input: swallow remaining keys so they
 		// don't type into the field. ↑/↓/Enter/Esc were already handled above.
@@ -912,11 +932,14 @@ func (m model) transcriptView() string {
 
 	suggestionOverlay := m.suggestionOverlay(width)
 	providerOverlay := m.providerWizardOverlay(width)
+	mcpOverlay := m.mcpManagerOverlay(width)
 	pickerOverlay := m.pickerOverlay(width)
 	viewportOverlay := ""
 	switch {
 	case providerOverlay != "":
 		viewportOverlay = providerOverlay
+	case mcpOverlay != "":
+		viewportOverlay = mcpOverlay
 	case pickerOverlay != "":
 		viewportOverlay = pickerOverlay
 	case suggestionOverlay != "":
@@ -1418,6 +1441,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.toolsText()})
 		return m, nil
 	case commandMCP:
+		if strings.TrimSpace(command.text) == "" {
+			return m.openMCPManager(), nil
+		}
 		text := ""
 		m, text = m.handleMCPCommand(command.text)
 		m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowSystem, tool: "mcp", text: text})

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -26,7 +26,14 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case m.mcpAddWizard != nil:
-			return m, nil
+			if target, ok := m.selectMCPAddWizardAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.handleMCPAddWizardMouseActivate()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
 		case m.mcpManager != nil:
 			if target, ok := m.selectMCPManagerAtMouse(msg); ok {
 				if m.repeatMouseSelection(target) {
@@ -225,10 +232,7 @@ func (m *model) selectMCPManagerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget,
 		return mouseSelectionTarget{}, false
 	}
 	_, itemRows := m.renderMCPManagerItemLines(maxInt(1, chatWidth(m.width)-4), items)
-	baseRow := 3
-	if len(m.mcpViewState().Servers) == 0 {
-		baseRow++
-	}
+	baseRow := mcpManagerFirstItemRow(m.mcpViewState())
 	row := hit.y - baseRow
 	if row < 0 || row >= len(itemRows) || itemRows[row] < 0 {
 		return mouseSelectionTarget{}, false
@@ -236,6 +240,70 @@ func (m *model) selectMCPManagerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget,
 	index := itemRows[row]
 	m.mcpManager.selected = index
 	return mouseSelectionTarget{Scope: "mcp-manager", Kind: int(items[index].Kind), Value: items[index].Name, Index: index}, true
+}
+
+func (m *model) selectMCPAddWizardAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if m.mcpAddWizard == nil {
+		return mouseSelectionTarget{}, false
+	}
+	width := chatWidth(m.width)
+	hit, ok := m.overlayMouseHit(msg, m.mcpAddWizardOverlay(width), width)
+	if !ok {
+		return mouseSelectionTarget{}, false
+	}
+	baseRow := 4
+	if m.mcpAddWizard.err != "" {
+		baseRow += 2
+	}
+	switch m.mcpAddWizard.step {
+	case mcpAddWizardStepType:
+		row := hit.y - baseRow
+		if row < 0 || row >= len(mcpAddWizardTypes) {
+			return mouseSelectionTarget{}, false
+		}
+		m.mcpAddWizard.selectedType = row
+		m.mcpAddWizard.serverType = mcpAddWizardTypes[row].ID
+		return mouseSelectionTarget{Scope: "mcp-add-wizard", Kind: int(m.mcpAddWizard.step), Value: m.mcpAddWizard.serverType, Index: row}, true
+	case mcpAddWizardStepResult:
+		actions := m.mcpAddWizard.resultActions()
+		if len(actions) == 0 {
+			return mouseSelectionTarget{}, false
+		}
+		rowStart := m.mcpAddWizard.mcpAddWizardResultActionStartRow()
+		row := hit.y - rowStart
+		if row < 0 || row >= len(actions) {
+			return mouseSelectionTarget{}, false
+		}
+		m.mcpAddWizard.resultSelected = row
+		return mouseSelectionTarget{Scope: "mcp-add-wizard", Kind: int(m.mcpAddWizard.step), Value: actions[row], Index: row}, true
+	default:
+		return mouseSelectionTarget{}, false
+	}
+}
+
+func (m model) handleMCPAddWizardMouseActivate() (tea.Model, tea.Cmd) {
+	if m.mcpAddWizard == nil {
+		return m, nil
+	}
+	if m.mcpAddWizard.step == mcpAddWizardStepResult {
+		return m.handleMCPAddWizardResultEnter()
+	}
+	return m.advanceMCPAddWizard()
+}
+
+func (wizard *mcpAddWizardState) mcpAddWizardResultActionStartRow() int {
+	if wizard == nil {
+		return 0
+	}
+	row := 7 // top border + step + separator + title + server + transport + saved/tools line
+	if wizard.err != "" {
+		row += 2
+	}
+	if wizard.result.Message != "" {
+		row++
+	}
+	row++ // blank line before actions
+	return row
 }
 
 func (m *model) selectModelPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -215,7 +215,7 @@ func (m *model) selectMCPManagerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget,
 		return mouseSelectionTarget{}, false
 	}
 	_, itemRows := m.renderMCPManagerItemLines(maxInt(1, chatWidth(m.width)-4), items)
-	baseRow := 2
+	baseRow := 3
 	if len(m.mcpViewState().Servers) == 0 {
 		baseRow++
 	}

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -25,6 +25,15 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				m.lastMouseSelection = target
 				return m, nil
 			}
+		case m.mcpManager != nil:
+			if target, ok := m.selectMCPManagerAtMouse(msg); ok {
+				if m.repeatMouseSelection(target) {
+					m.clearMouseSelection()
+					return m.chooseMCPManagerItem()
+				}
+				m.lastMouseSelection = target
+				return m, nil
+			}
 		case m.picker != nil:
 			if target, ok := m.selectPickerAtMouse(msg); ok {
 				if m.repeatMouseSelection(target) {
@@ -56,6 +65,10 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			m.providerWizard.move(-1)
 			return m, nil
 		}
+		if m.mcpManager != nil {
+			m.moveMCPManager(-1)
+			return m, nil
+		}
 		if m.picker != nil {
 			if m.modelPickerIsLoading() {
 				return m, nil
@@ -72,6 +85,10 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		m.clearMouseSelection()
 		if m.providerWizard != nil {
 			m.providerWizard.move(1)
+			return m, nil
+		}
+		if m.mcpManager != nil {
+			m.moveMCPManager(1)
 			return m, nil
 		}
 		if m.picker != nil {
@@ -100,7 +117,7 @@ func (m *model) clearMouseSelection() {
 }
 
 func (m model) wantsMouseCapture() bool {
-	return m.altScreen && (m.setupWantsMouseCapture() || m.chatWantsMouseCapture() || m.providerWizard != nil || m.picker != nil || m.suggestionsActive())
+	return m.altScreen && (m.setupWantsMouseCapture() || m.chatWantsMouseCapture() || m.providerWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive())
 }
 
 func (m model) setupWantsMouseCapture() bool {
@@ -182,6 +199,31 @@ func (m *model) selectPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, boo
 		return m.selectModelPickerAtMouse(msg)
 	}
 	return m.selectGenericPickerAtMouse(msg)
+}
+
+func (m *model) selectMCPManagerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
+	if m.mcpManager == nil {
+		return mouseSelectionTarget{}, false
+	}
+	items := m.mcpManagerItems()
+	if len(items) == 0 {
+		return mouseSelectionTarget{}, false
+	}
+	width := chatWidth(m.width)
+	hit, ok := m.overlayMouseHit(msg, m.mcpManagerOverlay(width), width)
+	if !ok {
+		return mouseSelectionTarget{}, false
+	}
+	maxVisible := minInt(mcpManagerMaxVisible, len(items))
+	selected := clampInt(m.mcpManager.selected, 0, len(items)-1)
+	start := selectableListStart(len(items), maxVisible, selected)
+	row := hit.y - 2
+	if row < 0 || row >= maxVisible {
+		return mouseSelectionTarget{}, false
+	}
+	index := start + row
+	m.mcpManager.selected = index
+	return mouseSelectionTarget{Scope: "mcp-manager", Kind: int(items[index].Kind), Value: items[index].Name, Index: index}, true
 }
 
 func (m *model) selectModelPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -25,6 +25,8 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				m.lastMouseSelection = target
 				return m, nil
 			}
+		case m.mcpAddWizard != nil:
+			return m, nil
 		case m.mcpManager != nil:
 			if target, ok := m.selectMCPManagerAtMouse(msg); ok {
 				if m.repeatMouseSelection(target) {
@@ -65,6 +67,10 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			m.providerWizard.move(-1)
 			return m, nil
 		}
+		if m.mcpAddWizard != nil {
+			m.mcpAddWizard.move(-1)
+			return m, nil
+		}
 		if m.mcpManager != nil {
 			m.moveMCPManager(-1)
 			return m, nil
@@ -85,6 +91,10 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		m.clearMouseSelection()
 		if m.providerWizard != nil {
 			m.providerWizard.move(1)
+			return m, nil
+		}
+		if m.mcpAddWizard != nil {
+			m.mcpAddWizard.move(1)
 			return m, nil
 		}
 		if m.mcpManager != nil {
@@ -117,7 +127,7 @@ func (m *model) clearMouseSelection() {
 }
 
 func (m model) wantsMouseCapture() bool {
-	return m.altScreen && (m.setupWantsMouseCapture() || m.chatWantsMouseCapture() || m.providerWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive())
+	return m.altScreen && (m.setupWantsMouseCapture() || m.chatWantsMouseCapture() || m.providerWizard != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive())
 }
 
 func (m model) setupWantsMouseCapture() bool {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -214,14 +214,16 @@ func (m *model) selectMCPManagerAtMouse(msg tea.MouseMsg) (mouseSelectionTarget,
 	if !ok {
 		return mouseSelectionTarget{}, false
 	}
-	maxVisible := minInt(mcpManagerMaxVisible, len(items))
-	selected := clampInt(m.mcpManager.selected, 0, len(items)-1)
-	start := selectableListStart(len(items), maxVisible, selected)
-	row := hit.y - 2
-	if row < 0 || row >= maxVisible {
+	_, itemRows := m.renderMCPManagerItemLines(maxInt(1, chatWidth(m.width)-4), items)
+	baseRow := 2
+	if len(m.mcpViewState().Servers) == 0 {
+		baseRow++
+	}
+	row := hit.y - baseRow
+	if row < 0 || row >= len(itemRows) || itemRows[row] < 0 {
 		return mouseSelectionTarget{}, false
 	}
-	index := start + row
+	index := itemRows[row]
 	m.mcpManager.selected = index
 	return mouseSelectionTarget{Scope: "mcp-manager", Kind: int(items[index].Kind), Value: items[index].Name, Index: index}, true
 }

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/config"
 )
 
 func TestMouseClickSelectsThenAppliesCommandSuggestionRow(t *testing.T) {
@@ -427,6 +429,62 @@ func TestTranscriptCopyStatusClearsOnlyForLatestCopy(t *testing.T) {
 	m = updated.(model)
 	if m.copyStatus != "" {
 		t.Fatalf("latest expiry left status = %q, want empty", m.copyStatus)
+	}
+}
+
+func TestMCPManagerMouseSelectsFirstItemRow(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		MCPConfig: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"docs": {Type: "stdio", Command: "docs-mcp"},
+		}},
+	})
+	m.width = 120
+	m.height = 36
+	m = m.openMCPManager()
+	width := chatWidth(m.width)
+	overlay := m.mcpManagerOverlay(width)
+	lines := viewLines(overlay)
+	left, _, _ := normalizeOverlayBlock(lines, width)
+	y := m.overlayMouseTop(len(lines), width) + mcpManagerFirstItemRow(m.mcpViewState())
+
+	target, ok := m.selectMCPManagerAtMouse(tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, X: left + 2, Y: y})
+	if !ok {
+		t.Fatal("expected click on first manager item row to select")
+	}
+	if target.Index != 0 || m.mcpManager.selected != 0 || target.Value != "docs" {
+		t.Fatalf("selected target = %#v manager=%#v, want first docs item", target, m.mcpManager)
+	}
+}
+
+func TestMCPAddWizardMouseSelectsAndActivatesType(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.width = 120
+	m.height = 36
+	m.mcpAddWizard = newMCPAddWizard("http")
+	m.mcpAddWizard.step = mcpAddWizardStepType
+	width := chatWidth(m.width)
+	overlay := m.mcpAddWizardOverlay(width)
+	lines := viewLines(overlay)
+	left, _, _ := normalizeOverlayBlock(lines, width)
+	y := m.overlayMouseTop(len(lines), width) + 5 // second type row: top border + step + rule + title + first row
+	msg := tea.MouseMsg{Button: tea.MouseButtonLeft, Action: tea.MouseActionPress, X: left + 2, Y: y}
+
+	updated, cmd := m.Update(msg)
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("single click should only select the type")
+	}
+	if next.mcpAddWizard.serverType != "sse" {
+		t.Fatalf("serverType after click = %q, want sse", next.mcpAddWizard.serverType)
+	}
+
+	updated, cmd = next.Update(msg)
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("double-click type activation should advance synchronously")
+	}
+	if next.mcpAddWizard.step != mcpAddWizardStepEndpoint {
+		t.Fatalf("wizard step after double-click = %v, want endpoint", next.mcpAddWizard.step)
 	}
 }
 

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -35,7 +35,7 @@ type Options struct {
 	MCPConfig              config.MCPConfig
 	MCPPermissionStore     *mcp.PermissionStore
 	MCPTokenStore          *mcp.TokenStore
-	MCPCommand             func([]string) MCPCommandResult
+	MCPCommand             func(context.Context, []string) MCPCommandResult
 	UsageTracker           *usage.Tracker
 	SessionCompactor       SessionCompactor
 

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 	"github.com/Gitlawb/zero/internal/sandbox"
@@ -31,6 +32,9 @@ type Options struct {
 	Registry               *tools.Registry
 	SessionStore           *sessions.Store
 	SandboxStore           *sandbox.GrantStore
+	MCPConfig              config.MCPConfig
+	MCPPermissionStore     *mcp.PermissionStore
+	MCPTokenStore          *mcp.TokenStore
 	UsageTracker           *usage.Tracker
 	SessionCompactor       SessionCompactor
 

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	MCPConfig              config.MCPConfig
 	MCPPermissionStore     *mcp.PermissionStore
 	MCPTokenStore          *mcp.TokenStore
+	MCPCommand             func([]string) MCPCommandResult
 	UsageTracker           *usage.Tracker
 	SessionCompactor       SessionCompactor
 
@@ -54,6 +55,13 @@ type Options struct {
 	// Setup configures the first-run/setup takeover. It is shown before the
 	// normal chat surface when Visible is true.
 	Setup SetupOptions
+}
+
+type MCPCommandResult struct {
+	Config   config.MCPConfig
+	Output   string
+	Error    string
+	ExitCode int
 }
 
 // SetupOptions configures the guided first-run provider setup takeover.

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -201,6 +201,9 @@ func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext
 		if row.tool == "sessions" {
 			return renderSessionsCards(row.text, width)
 		}
+		if row.tool == "mcp" {
+			return renderMCPManagerCard(row.text, width)
+		}
 		if row.id == compactStatusRowID && strings.HasPrefix(strings.TrimSpace(row.text), "Compressing session") {
 			return renderCompactRunningCard(row.text, width)
 		}
@@ -412,6 +415,40 @@ func doneLine(row transcriptRow, failed bool) string {
 // the panel surface inside a line border. Content is passed through unchanged.
 func renderSystemNote(text string, width int) string {
 	return noteBox(text, width, zeroTheme.line, zeroTheme.onPanel(zeroTheme.faint))
+}
+
+func renderMCPManagerCard(text string, width int) string {
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(text, "\r\n", "\n"), "\n"), "\n")
+	lines := make([]string, 0, len(raw))
+	for index, line := range raw {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			lines = append(lines, "")
+		case index == 0:
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
+		case index == 1:
+			lines = append(lines, zeroTheme.ink.Bold(true).Render(line))
+		case isMCPManagerHeading(trimmed):
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
+		case strings.Contains(trimmed, "zero mcp "):
+			lines = append(lines, zeroTheme.ink.Render(line))
+		case strings.HasPrefix(trimmed, "›") || strings.HasPrefix(trimmed, "- "):
+			lines = append(lines, zeroTheme.ink.Render(line))
+		default:
+			lines = append(lines, zeroTheme.muted.Render(line))
+		}
+	}
+	return styledBlock(width, lines, zeroTheme.accent)
+}
+
+func isMCPManagerHeading(value string) bool {
+	switch value {
+	case "User MCPs", "Built-in MCPs", "Tools", "Permissions", "OAuth", "Actions":
+		return true
+	default:
+		return false
+	}
 }
 
 func renderCompactRunningCard(text string, width int) string {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -221,7 +221,7 @@ func splitPlainAtDisplayWidth(text string, width int) (string, string) {
 }
 
 func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine, bool) {
-	if !m.altScreen || m.height <= 0 || m.setup.visible || m.providerWizard != nil || m.picker != nil || m.suggestionsActive() {
+	if !m.altScreen || m.height <= 0 || m.setup.visible || m.providerWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
 		return transcriptSelectableLine{}, false
 	}
 	width := chatWidth(m.width)


### PR DESCRIPTION
﻿## Summary
- adds MCP config management commands: `add`, `remove`, `enable`, `disable`, and `check`
- preserves unknown config JSON while updating MCP server config, and redacts env/header secrets in command output
- adds `/mcp` TUI status rendering backed by configured servers, registered MCP tools, permission grants, and OAuth token status
- threads MCP config/stores into the interactive TUI launch path

## Why
Zero already had MCP backend pieces, but users had no coherent product surface to manage and inspect MCP servers. This PR makes MCP feel like a real manager flow without adding marketplace/plugin scope.

## Validation
- `gofmt -l internal/cli internal/tui`
- `go test ./internal/cli ./internal/tui ./internal/mcp -count=1`
- `go test ./...`
- `go vet ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- isolated manual smoke with temp `%APPDATA%`: `zero mcp add`, `disable`, `enable`, `list`

## Notes
- This intentionally keeps live server checks explicit via `zero mcp check <server>` so opening `/mcp` does not unexpectedly connect to remote/local MCP servers.
- I briefly ran a manual smoke with the wrong temp config env var; it added a `docs` test server to the real user config, then I immediately removed it. A follow-up `zero mcp list` on the real config reports no MCP servers configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full MCP management: CLI subcommands (add/remove/enable/disable/check/list), TUI /mcp command, manager overlay, add wizard, marketplace install flows, and in-app MCP command execution with buffered results.

* **Bug Fixes / Privacy**
  * Stronger redaction of URLs, query/fragment params, headers, env and command args; safer MCP runtime/token-store initialization and cleanup; improved UI rendering and wrapping.

* **Tests**
  * Extensive CLI and TUI test coverage for MCP workflows, validation, migrations, permissions, OAuth/token handling, views, manager, mouse and autocomplete interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->