### PR TITLE
Polish model status and reasoning streams

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -144,8 +144,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		}
 
 		collected := zeroruntime.CollectStreamWithOptions(ctx, stream, zeroruntime.CollectOptions{
-			OnText:  options.OnText,
-			OnUsage: options.OnUsage,
+			OnText:      options.OnText,
+			OnReasoning: options.OnReasoning,
+			OnUsage:     options.OnUsage,
 		})
 		if collected.Error != "" {
 			// REACTIVE compaction: the streamed error may also be a context
@@ -445,8 +446,9 @@ func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages [
 		return "", messages, ""
 	}
 	collected := zeroruntime.CollectStreamWithOptions(ctx, stream, zeroruntime.CollectOptions{
-		OnText:  options.OnText,
-		OnUsage: options.OnUsage,
+		OnText:      options.OnText,
+		OnReasoning: options.OnReasoning,
+		OnUsage:     options.OnUsage,
 	})
 	if ctx.Err() != nil || collected.Error != "" || strings.TrimSpace(collected.Text) == "" {
 		return "", messages, ""

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -89,6 +89,39 @@ func TestRunReturnsProviderText(t *testing.T) {
 	assertMessage(t, provider.requests[0].Messages[1], zeroruntime.MessageRoleUser, "say hi")
 }
 
+func TestRunDoesNotPersistReasoningAsAssistantText(t *testing.T) {
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{{
+			{Type: zeroruntime.StreamEventReasoning, Content: "private reasoning"},
+			{Type: zeroruntime.StreamEventText, Content: "public answer"},
+			{Type: zeroruntime.StreamEventDone},
+		}},
+	}
+	var reasoning []string
+
+	result, err := Run(context.Background(), "say hi", provider, Options{
+		Registry:    tools.NewRegistry(),
+		OnReasoning: func(delta string) { reasoning = append(reasoning, delta) },
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "public answer" {
+		t.Fatalf("final answer = %q, want public answer", result.FinalAnswer)
+	}
+	if len(result.Messages) == 0 {
+		t.Fatal("expected persisted messages")
+	}
+	last := result.Messages[len(result.Messages)-1]
+	if last.Role != zeroruntime.MessageRoleAssistant || last.Content != "public answer" {
+		t.Fatalf("assistant message = %#v, want answer-only assistant content", last)
+	}
+	if len(reasoning) != 1 || reasoning[0] != "private reasoning" {
+		t.Fatalf("reasoning callbacks = %#v", reasoning)
+	}
+}
+
 func TestRunReportsTruncationFinishReason(t *testing.T) {
 	provider := &mockProvider{
 		turns: [][]zeroruntime.StreamEvent{{

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -184,6 +184,7 @@ type Options struct {
 	EnabledTools        []string
 	DisabledTools       []string
 	OnText              func(string)
+	OnReasoning         func(string)
 	OnToolCall          func(ToolCall)
 	OnPermissionRequest func(context.Context, PermissionRequest) (PermissionDecision, error)
 	OnPermission        func(PermissionEvent)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -230,9 +230,9 @@ type setupSaveOptions struct {
 func saveSetupProvider(deps appDeps, selection tui.SetupSelection, options setupSaveOptions) (tui.SetupResult, error) {
 	profile, err := providerProfileForAdd(providerAddOptions{
 		catalogID: selection.CatalogID,
-		name:      options.name,
+		name:      firstNonEmptyCLI(options.name, selection.Name),
 		model:     firstNonEmptyCLI(selection.Model),
-		baseURL:   options.baseURL,
+		baseURL:   firstNonEmptyCLI(options.baseURL, selection.BaseURL),
 		apiKeyEnv: options.apiKeyEnv,
 		setActive: true,
 	})

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -176,3 +176,46 @@ func TestSaveSetupProviderStoresCustomEndpointSelection(t *testing.T) {
 		t.Fatalf("stored provider endpoint/model = %#v", profile)
 	}
 }
+
+func TestSaveSetupProviderCLIOptionsOverrideCustomEndpointSelection(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	result, err := saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+	}, tui.SetupSelection{
+		CatalogID: "custom-openai-compatible",
+		Name:      "selection-name",
+		BaseURL:   "https://selection.example/v1",
+		Model:     "selection-model",
+	}, setupSaveOptions{
+		name:    "cli-name",
+		baseURL: "https://cli.example/v1",
+	})
+	if err != nil {
+		t.Fatalf("saveSetupProvider() error = %v", err)
+	}
+
+	if result.Provider.Name != "cli-name" {
+		t.Fatalf("Provider.Name = %q, want CLI name", result.Provider.Name)
+	}
+	if result.Provider.BaseURL != "https://cli.example/v1" {
+		t.Fatalf("Provider.BaseURL = %q, want CLI endpoint", result.Provider.BaseURL)
+	}
+	if result.Provider.Model != "selection-model" {
+		t.Fatalf("Provider.Model = %q, want selection model", result.Provider.Model)
+	}
+
+	cfg := readFileConfig(t, configPath)
+	if cfg.ActiveProvider != "cli-name" {
+		t.Fatalf("ActiveProvider = %q, want cli-name", cfg.ActiveProvider)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("Providers = %#v, want one provider", cfg.Providers)
+	}
+	profile := cfg.Providers[0]
+	if profile.Name != "cli-name" || profile.BaseURL != "https://cli.example/v1" || profile.Model != "selection-model" {
+		t.Fatalf("stored provider = %#v, want CLI name/baseURL and selection model", profile)
+	}
+}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -133,3 +133,46 @@ func TestSaveSetupProviderStoresPastedAPIKey(t *testing.T) {
 		t.Fatalf("stored provider credentials = APIKey %q APIKeyEnv %q, want pasted key only", cfg.Providers[0].APIKey, cfg.Providers[0].APIKeyEnv)
 	}
 }
+
+func TestSaveSetupProviderStoresCustomEndpointSelection(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+
+	result, err := saveSetupProvider(appDeps{
+		userConfigPath: func() (string, error) {
+			return configPath, nil
+		},
+	}, tui.SetupSelection{
+		CatalogID: "custom-openai-compatible",
+		Name:      "minimax",
+		BaseURL:   "https://api.minimax.io/v1",
+		Model:     "MiniMax-M3",
+	}, setupSaveOptions{})
+	if err != nil {
+		t.Fatalf("saveSetupProvider() error = %v", err)
+	}
+
+	if result.Provider.Name != "minimax" {
+		t.Fatalf("Provider.Name = %q, want minimax", result.Provider.Name)
+	}
+	if result.Provider.BaseURL != "https://api.minimax.io/v1" {
+		t.Fatalf("Provider.BaseURL = %q, want custom endpoint", result.Provider.BaseURL)
+	}
+	if result.Provider.Model != "MiniMax-M3" {
+		t.Fatalf("Provider.Model = %q, want typed model", result.Provider.Model)
+	}
+
+	cfg := readFileConfig(t, configPath)
+	if cfg.ActiveProvider != "minimax" {
+		t.Fatalf("ActiveProvider = %q, want minimax", cfg.ActiveProvider)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("Providers = %#v, want one provider", cfg.Providers)
+	}
+	profile := cfg.Providers[0]
+	if profile.Name != "minimax" || profile.CatalogID != "custom-openai-compatible" {
+		t.Fatalf("stored provider identity = %#v, want minimax custom-openai-compatible", profile)
+	}
+	if profile.BaseURL != "https://api.minimax.io/v1" || profile.Model != "MiniMax-M3" {
+		t.Fatalf("stored provider endpoint/model = %#v", profile)
+	}
+}

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -229,7 +229,7 @@ func (provider *Provider) emitChunk(
 	for _, choice := range chunk.Choices {
 		if choice.Delta.ReasoningContent != "" {
 			sendEvent(ctx, events, zeroruntime.StreamEvent{
-				Type:    zeroruntime.StreamEventText,
+				Type:    zeroruntime.StreamEventReasoning,
 				Content: choice.Delta.ReasoningContent,
 			})
 		}

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -227,6 +227,12 @@ func (provider *Provider) emitChunk(
 	events chan<- zeroruntime.StreamEvent,
 ) {
 	for _, choice := range chunk.Choices {
+		if choice.Delta.ReasoningContent != "" {
+			sendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:    zeroruntime.StreamEventText,
+				Content: choice.Delta.ReasoningContent,
+			})
+		}
 		if choice.Delta.Content != "" {
 			sendEvent(ctx, events, zeroruntime.StreamEvent{
 				Type:    zeroruntime.StreamEventText,
@@ -371,9 +377,8 @@ func mapMessage(message zeroruntime.Message) chatMessage {
 	// message that happens to carry Images keeps the plain string/nil content
 	// path (its images are simply not serialized).
 	if len(message.Images) == 0 || message.Role != zeroruntime.MessageRoleUser {
-		// Preserve today's behavior exactly: a string assigned only when
-		// non-empty, leaving Content nil otherwise so the `omitempty` tag still
-		// drops the key. An empty string boxed in `any` would NOT be omitted.
+		// Preserve the legacy behavior: only non-empty text is serialized, so
+		// empty content is omitted by the `omitempty` tag.
 		if message.Content != "" {
 			mapped.Content = message.Content
 		}

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -207,6 +207,25 @@ func TestStreamCompletionEmitsTextUsageAndDone(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionEmitsReasoningContentDeltas(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"reasoning_content":"Thinking. "}}]}`)
+		writeSSE(w, `{"choices":[{"delta":{"reasoning_content":"Answering now."}}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var text string
+	for _, event := range events {
+		if event.Type == zeroruntime.StreamEventText {
+			text += event.Content
+		}
+	}
+	if text != "Thinking. Answering now." {
+		t.Fatalf("collected text = %q, want reasoning content text", text)
+	}
+}
+
 func TestStreamCompletionBuffersToolArgsUntilIDAndNameArrive(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":"}}]}}]}`)

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -215,14 +215,32 @@ func TestStreamCompletionEmitsReasoningContentDeltas(t *testing.T) {
 	})
 
 	events := collectProviderEvents(t, provider)
-	var text string
-	for _, event := range events {
-		if event.Type == zeroruntime.StreamEventText {
-			text += event.Content
-		}
+	reasoning := eventsOfType(events, zeroruntime.StreamEventReasoning)
+	if len(reasoning) != 2 {
+		t.Fatalf("reasoning events = %#v, want two reasoning deltas", reasoning)
 	}
-	if text != "Thinking. Answering now." {
-		t.Fatalf("collected text = %q, want reasoning content text", text)
+	if reasoning[0].Content != "Thinking. " || reasoning[1].Content != "Answering now." {
+		t.Fatalf("unexpected reasoning events: %#v", reasoning)
+	}
+	if text := eventsOfType(events, zeroruntime.StreamEventText); len(text) != 0 {
+		t.Fatalf("reasoning_content must not emit text events, got %#v", text)
+	}
+}
+
+func TestStreamCompletionEmitsReasoningBeforeRegularContent(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"reasoning_content":"Thinking. ","content":"Answer."}}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	if len(events) < 3 {
+		t.Fatalf("events = %#v, want reasoning, text, done", events)
+	}
+	assertEvent(t, events[0], zeroruntime.StreamEventReasoning, "Thinking. ")
+	assertEvent(t, events[1], zeroruntime.StreamEventText, "Answer.")
+	if events[2].Type != zeroruntime.StreamEventDone {
+		t.Fatalf("third event = %#v, want done", events[2])
 	}
 }
 

--- a/internal/providers/openai/types.go
+++ b/internal/providers/openai/types.go
@@ -71,8 +71,9 @@ type streamChoice struct {
 }
 
 type streamDelta struct {
-	Content   string                `json:"content"`
-	ToolCalls []streamToolCallDelta `json:"tool_calls"`
+	Content          string                `json:"content"`
+	ReasoningContent string                `json:"reasoning_content"`
+	ToolCalls        []streamToolCallDelta `json:"tool_calls"`
 }
 
 type streamToolCallDelta struct {

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -225,11 +225,7 @@ func (m model) completeSuggestion() model {
 	chosen := m.suggestions[idx].Name
 	if m.suggestionsAreFiles {
 		isDir := fileSuggestionIsDirectory(m.suggestions[idx])
-		// Replace only the trailing "@token" with the chosen path so any preceding
-		// prompt text ("read @foo") is preserved.
-		nextValue, nextCursor := completePathQueryWithTrailingSpace(m.input.Value(), m.input.Position(), chosen, !isDir)
-		m.input.SetValue(nextValue)
-		m.input.SetCursor(nextCursor)
+		m = m.completeFileSuggestion(chosen, !isDir)
 	} else {
 		if commandSelectionRequiresInput(chosen) {
 			m.input.SetValue(chosen)
@@ -244,6 +240,32 @@ func (m model) completeSuggestion() model {
 	m.commandPaletteOpen = false
 	m.filePaletteOpen = false
 	return m
+}
+
+func (m model) completeFileSuggestion(chosen string, trailingSpace bool) model {
+	state := m.fileSuggestionComposerState()
+	query := extractPathQuery(state.text, state.cursor)
+	if query == nil {
+		nextValue, nextCursor := completePathQueryWithTrailingSpace(m.input.Value(), m.input.Position(), chosen, trailingSpace)
+		m.input.SetValue(nextValue)
+		m.input.SetCursor(nextCursor)
+		m.resetComposerFromInput()
+		return m
+	}
+	replacement := chosen
+	if trailingSpace {
+		replacement += " "
+	}
+	return m.replaceComposerRangeWithPastePreviews(state, query.StartIndex, query.EndIndex, replacement)
+}
+
+func (m model) fileSuggestionComposerState() composerState {
+	state := m.currentComposerState()
+	inputState := normalizeComposerState(composerState{text: m.input.Value(), cursor: m.input.Position()})
+	if m.composerActive && inputState.text == state.text && inputState.cursor != state.cursor {
+		return inputState
+	}
+	return state
 }
 
 func (m model) selectedSuggestionIsDirectory() bool {
@@ -523,15 +545,10 @@ func fuzzySubsequenceGap(value, query string) (int, bool) {
 // owns that search text while it is open.
 func (m model) dismissSuggestions() model {
 	if m.suggestionsAreFiles {
-		if query := extractPathQuery(m.input.Value(), m.input.Position()); query != nil {
-			runes := []rune(m.input.Value())
-			next := make([]rune, 0, len(runes)-(query.EndIndex-query.StartIndex))
-			next = append(next, runes[:query.StartIndex]...)
-			next = append(next, runes[query.EndIndex:]...)
-			m.input.SetValue(string(next))
-			m.input.SetCursor(query.StartIndex)
+		state := m.fileSuggestionComposerState()
+		if query := extractPathQuery(state.text, state.cursor); query != nil {
+			m = m.replaceComposerRangeWithPastePreviews(state, query.StartIndex, query.EndIndex, "")
 		}
-		m.resetComposerFromInput()
 	} else {
 		m.clearComposer()
 	}

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -630,6 +630,118 @@ func TestEnterOnFileSuggestionClosesFilePalette(t *testing.T) {
 	}
 }
 
+func TestFileSuggestionCompletionKeepsPastePreviewCollapsed(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "docs/guide.md")
+	paste := "Create a book library dashboard page with the Bootstrap theme. " + strings.Repeat("SECRET_TAIL ", 20)
+	m := newModel(context.Background(), Options{Cwd: root})
+	m.width = 44
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("@guide")})
+	m = updated.(model)
+
+	if !m.suggestionsActive() || !m.suggestionsAreFiles {
+		t.Fatalf("expected file suggestions after @guide, got suggestions=%v files=%v", m.suggestionsActive(), m.suggestionsAreFiles)
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("file completion should not submit a prompt")
+	}
+	if got := m.composerValue(); got != paste+" @docs/guide.md " {
+		t.Fatalf("composer value after file completion = %q", got)
+	}
+	view := plainRender(t, m.composerBox(96))
+	for _, want := range []string{"[Create a book library dashboard page", "lines", "@docs/guide.md"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("file completion view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "SECRET_TAIL") {
+		t.Fatalf("file completion should keep pasted content collapsed:\n%s", view)
+	}
+}
+
+func TestFileSuggestionDismissKeepsPastePreviewCollapsed(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "docs/guide.md")
+	paste := "Create a book library dashboard page with the Bootstrap theme. " + strings.Repeat("SECRET_TAIL ", 20)
+	m := newModel(context.Background(), Options{Cwd: root})
+	m.width = 44
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("@guide")})
+	m = updated.(model)
+
+	if !m.suggestionsActive() || !m.suggestionsAreFiles {
+		t.Fatalf("expected file suggestions after @guide, got suggestions=%v files=%v", m.suggestionsActive(), m.suggestionsAreFiles)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(model)
+
+	if got := m.composerValue(); got != paste+" " {
+		t.Fatalf("composer value after dismissing file suggestion = %q", got)
+	}
+	if m.suggestionsActive() {
+		t.Fatal("file suggestion dismiss should close the file palette")
+	}
+	view := plainRender(t, m.composerBox(96))
+	for _, want := range []string{"[Create a book library dashboard page", "lines"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("file dismiss view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "SECRET_TAIL") || strings.Contains(view, "@guide") {
+		t.Fatalf("file dismiss should remove the query and keep pasted content collapsed:\n%s", view)
+	}
+}
+
+func TestBackspaceAfterCompletedFileSuggestionKeepsPastePreviewCollapsed(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, root, "docs/guide.md")
+	paste := "Create a book library dashboard page with the Bootstrap theme. " + strings.Repeat("SECRET_TAIL ", 20)
+	m := newModel(context.Background(), Options{Cwd: root})
+	m.width = 44
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("@guide")})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+
+	if got := m.composerValue(); got != paste+" @docs/guide.md " {
+		t.Fatalf("composer value after file completion = %q", got)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = updated.(model)
+
+	if got := m.composerValue(); got != paste+" " {
+		t.Fatalf("composer value after deleting completed file mention = %q", got)
+	}
+	view := plainRender(t, m.composerBox(96))
+	for _, want := range []string{"[Create a book library dashboard page", "lines"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("backspace after file completion view missing %q:\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{"SECRET_TAIL", "@docs/guide.md"} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("backspace after file completion should keep pasted content collapsed and remove mention:\n%s", view)
+		}
+	}
+}
+
 func TestFileSuggestionsMatchesAndSkipsVCSDirs(t *testing.T) {
 	root := t.TempDir()
 	mustWrite := func(rel string) {

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -270,7 +270,7 @@ func (m model) handleModelCommand(args string) (model, string) {
 	lines = append(lines,
 		"Switched model for this TUI session.",
 		"model: "+target.modelID,
-		"provider: "+string(metadata.ProviderKind),
+		"provider: "+displayValue(nextProfile.Name, string(metadata.ProviderKind)),
 		"api model: "+metadata.APIModel,
 		effortLine,
 	)
@@ -400,7 +400,7 @@ func (m model) handleModeCommand(args string) (model, string) {
 		"Switched to mode "+mode.Name+" for this TUI session.",
 		mode.Description,
 		"model: "+entry.ID,
-		"provider: "+string(metadata.ProviderKind),
+		"provider: "+displayValue(nextProfile.Name, string(metadata.ProviderKind)),
 		effortLine,
 		turnsLine,
 	)

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 type composerState struct {
@@ -192,8 +193,10 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 	case msg.Type == tea.KeyCtrlJ:
 		m = m.insertComposerTextWithPastePreview(state, "\n", "")
 	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "d":
-		m.setComposerState(deleteComposerWordAfter(state))
-		m.composerPastePreviews = nil
+		end := deleteComposerWordAfter(state).cursor
+		nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, state.cursor, end)
+		m.setComposerState(nextState)
+		m.composerPastePreviews = nextPreviews
 	case (msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlLeft) && msg.Alt:
 		m.setComposerState(moveComposerWordBefore(state))
 	case (msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlRight) && msg.Alt:
@@ -213,7 +216,7 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		previewLabel := ""
 		if msg.Paste {
 			text = sanitizeComposerPaste(text)
-			previewLabel, _ = composerPastePreviewLabel(text)
+			previewLabel, _ = composerPastePreviewLabel(text, m.composerPastePreviewWrapWidth())
 		} else {
 			text = sanitizeComposerInput(text)
 		}
@@ -245,17 +248,23 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		state.cursor = composerLineEnd(state)
 		m.setComposerState(state)
 	case msg.Type == tea.KeyCtrlU:
-		m.setComposerState(deleteComposerLineBefore(state))
-		m.composerPastePreviews = nil
+		nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, composerLineStart(state), state.cursor)
+		m.setComposerState(nextState)
+		m.composerPastePreviews = nextPreviews
 	case msg.Type == tea.KeyCtrlK:
-		m.setComposerState(deleteComposerLineAfter(state))
-		m.composerPastePreviews = nil
+		nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, state.cursor, composerLineEnd(state))
+		m.setComposerState(nextState)
+		m.composerPastePreviews = nextPreviews
 	case msg.Type == tea.KeyCtrlW || (msg.Alt && (msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH)):
-		m.setComposerState(deleteComposerWordBefore(state))
-		m.composerPastePreviews = nil
+		start := deleteComposerWordBefore(state).cursor
+		nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, start, state.cursor)
+		m.setComposerState(nextState)
+		m.composerPastePreviews = nextPreviews
 	case msg.Alt && msg.Type == tea.KeyDelete:
-		m.setComposerState(deleteComposerWordAfter(state))
-		m.composerPastePreviews = nil
+		end := deleteComposerWordAfter(state).cursor
+		nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, state.cursor, end)
+		m.setComposerState(nextState)
+		m.composerPastePreviews = nextPreviews
 	case msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH:
 		if nextState, nextPreviews, ok := deleteComposerPastePreviewBefore(state, m.composerPastePreviews); ok && !m.suggestionsActive() {
 			m.setComposerState(nextState)
@@ -264,16 +273,18 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 			m.setComposerState(nextState)
 			m.composerPastePreviews = nil
 		} else {
-			m.setComposerState(deleteComposerRange(state, state.cursor-1, state.cursor))
-			m.composerPastePreviews = nil
+			nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, state.cursor-1, state.cursor)
+			m.setComposerState(nextState)
+			m.composerPastePreviews = nextPreviews
 		}
 	case msg.Type == tea.KeyDelete || msg.Type == tea.KeyCtrlD:
 		if nextState, nextPreviews, ok := deleteComposerPastePreviewAfter(state, m.composerPastePreviews); ok {
 			m.setComposerState(nextState)
 			m.composerPastePreviews = nextPreviews
 		} else {
-			m.setComposerState(deleteComposerRange(state, state.cursor, state.cursor+1))
-			m.composerPastePreviews = nil
+			nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, state.cursor, state.cursor+1)
+			m.setComposerState(nextState)
+			m.composerPastePreviews = nextPreviews
 		}
 	default:
 		return m, false
@@ -294,6 +305,7 @@ func (m model) insertComposerTextWithPastePreview(state composerState, text stri
 	nextPreviews := composerPastePreviewsAfterInsert(m.composerPastePreviews, insertStart, insertedRunes)
 	m.setComposerState(insertComposerText(state, text))
 	if previewLabel != "" && insertedRunes > 0 {
+		previewLabel = composerPastePreviewLabelWithIndex(previewLabel, len(nextPreviews))
 		nextPreviews = append(nextPreviews, composerPastePreview{
 			active: true,
 			start:  insertStart,
@@ -308,13 +320,21 @@ func (m model) insertComposerTextWithPastePreview(state composerState, text stri
 	return m
 }
 
-func composerPastePreviewLabel(text string) (string, bool) {
+func (m model) composerPastePreviewWrapWidth() int {
+	width := chatWidth(m.width)
+	if width < 8 {
+		width = defaultStartupWidth
+	}
+	return maxInt(1, width-4-lipgloss.Width(m.input.Prompt))
+}
+
+func composerPastePreviewLabel(text string, wrapWidth int) (string, bool) {
 	text = strings.TrimSpace(text)
 	if text == "" {
 		return "", false
 	}
-	lineCount := strings.Count(text, "\n") + 1
 	runeCount := len([]rune(text))
+	lineCount := composerPastePreviewVisualLineCount(text, wrapWidth)
 	if lineCount < 3 && runeCount < 220 {
 		return "", false
 	}
@@ -327,10 +347,28 @@ func composerPastePreviewLabel(text string) (string, bool) {
 		snippet = "pasted text"
 	}
 	snippet = truncateComposerPasteSnippet(snippet, 48)
-	if lineCount >= 3 {
-		return "[" + snippet + " · " + strconv.Itoa(lineCount) + " lines]", true
+	label := "lines"
+	if lineCount == 1 {
+		label = "line"
 	}
-	return "[" + snippet + " · " + strconv.Itoa(runeCount) + " chars]", true
+	return "[" + snippet + " · " + strconv.Itoa(lineCount) + " " + label + "]", true
+}
+
+func composerPastePreviewLabelWithIndex(label string, pasteIndex int) string {
+	if pasteIndex <= 0 || !strings.HasSuffix(label, "]") {
+		return label
+	}
+	return strings.TrimSuffix(label, "]") + ", paste " + strconv.Itoa(pasteIndex) + "]"
+}
+
+func composerPastePreviewVisualLineCount(text string, wrapWidth int) int {
+	wrapWidth = maxInt(1, wrapWidth)
+	total := 0
+	for _, line := range strings.Split(text, "\n") {
+		width := lipgloss.Width(line)
+		total += maxInt(1, (width+wrapWidth-1)/wrapWidth)
+	}
+	return total
 }
 
 func truncateComposerPasteSnippet(text string, limit int) string {
@@ -400,6 +438,61 @@ func deleteComposerPastePreviewAfter(state composerState, previews []composerPas
 		return deleteComposerRange(state, preview.start, preview.end), composerPastePreviewsAfterDelete(valid, index), true
 	}
 	return state, previews, false
+}
+
+func deleteComposerRangeWithPastePreviews(state composerState, previews []composerPastePreview, start int, end int) (composerState, []composerPastePreview) {
+	state = normalizeComposerState(state)
+	runeCount := len([]rune(state.text))
+	start = clamp(start, 0, runeCount)
+	end = clamp(end, 0, runeCount)
+	if end < start {
+		start, end = end, start
+	}
+	if start == end {
+		return state, validComposerPastePreviews(state, previews)
+	}
+
+	valid := validComposerPastePreviews(state, previews)
+	deleteStart, deleteEnd := start, end
+	for {
+		expanded := false
+		for _, preview := range valid {
+			if !composerRangesOverlap(deleteStart, deleteEnd, preview.start, preview.end) {
+				continue
+			}
+			if preview.start < deleteStart {
+				deleteStart = preview.start
+				expanded = true
+			}
+			if preview.end > deleteEnd {
+				deleteEnd = preview.end
+				expanded = true
+			}
+		}
+		if !expanded {
+			break
+		}
+	}
+
+	nextState := deleteComposerRange(state, deleteStart, deleteEnd)
+	delta := deleteEnd - deleteStart
+	nextPreviews := make([]composerPastePreview, 0, len(valid))
+	for _, preview := range valid {
+		switch {
+		case composerRangesOverlap(deleteStart, deleteEnd, preview.start, preview.end):
+			continue
+		case preview.start >= deleteEnd:
+			preview.start -= delta
+			preview.end -= delta
+		}
+		nextPreviews = append(nextPreviews, preview)
+	}
+	sortComposerPastePreviews(nextPreviews)
+	return nextState, nextPreviews
+}
+
+func composerRangesOverlap(leftStart int, leftEnd int, rightStart int, rightEnd int) bool {
+	return leftStart < rightEnd && rightStart < leftEnd
 }
 
 func validComposerPastePreviews(state composerState, previews []composerPastePreview) []composerPastePreview {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -269,9 +269,10 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		if nextState, nextPreviews, ok := deleteComposerPastePreviewBefore(state, m.composerPastePreviews); ok && !m.suggestionsActive() {
 			m.setComposerState(nextState)
 			m.composerPastePreviews = nextPreviews
-		} else if nextState, ok := deleteCompletedFileMentionBefore(state); ok && !m.suggestionsActive() {
+		} else if start, end, ok := completedFileMentionRangeBefore(state); ok && !m.suggestionsActive() {
+			nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, start, end)
 			m.setComposerState(nextState)
-			m.composerPastePreviews = nil
+			m.composerPastePreviews = nextPreviews
 		} else {
 			nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, state.cursor-1, state.cursor)
 			m.setComposerState(nextState)
@@ -318,6 +319,16 @@ func (m model) insertComposerTextWithPastePreview(state composerState, text stri
 	}
 	m.composerPastePreviews = nextPreviews
 	return m
+}
+
+func (m model) replaceComposerRangeWithPastePreviews(state composerState, start int, end int, replacement string) model {
+	nextState, nextPreviews := deleteComposerRangeWithPastePreviews(state, m.composerPastePreviews, start, end)
+	m.setComposerState(nextState)
+	m.composerPastePreviews = nextPreviews
+	if replacement == "" {
+		return m
+	}
+	return m.insertComposerTextWithPastePreview(m.currentComposerState(), replacement, "")
 }
 
 func (m model) composerPastePreviewWrapWidth() int {
@@ -570,10 +581,18 @@ func shouldInsertCommandArgumentSpace(state composerState, text string) bool {
 }
 
 func deleteCompletedFileMentionBefore(state composerState) (composerState, bool) {
+	start, end, ok := completedFileMentionRangeBefore(state)
+	if !ok {
+		return state, false
+	}
+	return deleteComposerRange(state, start, end), true
+}
+
+func completedFileMentionRangeBefore(state composerState) (int, int, bool) {
 	state = normalizeComposerState(state)
 	runes := []rune(state.text)
 	if state.cursor <= 0 || state.cursor > len(runes) || !isPathQueryBoundary(runes[state.cursor-1]) {
-		return state, false
+		return 0, 0, false
 	}
 	tokenEnd := state.cursor
 	for tokenEnd > 0 && isPathQueryBoundary(runes[tokenEnd-1]) {
@@ -584,9 +603,9 @@ func deleteCompletedFileMentionBefore(state composerState) (composerState, bool)
 		tokenStart--
 	}
 	if tokenStart >= tokenEnd || runes[tokenStart] != '@' || tokenEnd-tokenStart <= 1 {
-		return state, false
+		return 0, 0, false
 	}
-	return deleteComposerRange(state, tokenStart, state.cursor), true
+	return tokenStart, state.cursor, true
 }
 
 func deleteComposerRange(state composerState, start int, end int) composerState {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -327,11 +327,10 @@ func composerPastePreviewLabel(text string) (string, bool) {
 		snippet = "pasted text"
 	}
 	snippet = truncateComposerPasteSnippet(snippet, 48)
-	label := "lines"
-	if lineCount == 1 {
-		label = "line"
+	if lineCount >= 3 {
+		return "[" + snippet + " · " + strconv.Itoa(lineCount) + " lines]", true
 	}
-	return "[" + snippet + " · " + strconv.Itoa(lineCount) + " " + label + "]", true
+	return "[" + snippet + " · " + strconv.Itoa(runeCount) + " chars]", true
 }
 
 func truncateComposerPasteSnippet(text string, limit int) string {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -158,14 +159,14 @@ func (m *model) setComposerState(state composerState) {
 func (m *model) clearComposer() {
 	m.composer = composerState{}
 	m.composerActive = false
-	m.composerPastePreview = composerPastePreview{}
+	m.composerPastePreviews = nil
 	m.input.SetValue("")
 }
 
 func (m *model) resetComposerFromInput() {
 	m.composer = composerState{}
 	m.composerActive = false
-	m.composerPastePreview = composerPastePreview{}
+	m.composerPastePreviews = nil
 }
 
 func (m *model) syncInputFromComposer() {
@@ -192,7 +193,7 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		m = m.insertComposerTextWithPastePreview(state, "\n", "")
 	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "d":
 		m.setComposerState(deleteComposerWordAfter(state))
-		m.composerPastePreview = composerPastePreview{}
+		m.composerPastePreviews = nil
 	case (msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlLeft) && msg.Alt:
 		m.setComposerState(moveComposerWordBefore(state))
 	case (msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlRight) && msg.Alt:
@@ -224,14 +225,14 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		}
 		m = m.insertComposerTextWithPastePreview(state, text, previewLabel)
 	case msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlB:
-		if nextState, ok := moveComposerPastePreviewBoundary(state, m.composerPastePreview, -1); ok {
+		if nextState, ok := moveComposerPastePreviewBoundary(state, m.composerPastePreviews, -1); ok {
 			m.setComposerState(nextState)
 			break
 		}
 		state.cursor--
 		m.setComposerState(state)
 	case msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlF:
-		if nextState, ok := moveComposerPastePreviewBoundary(state, m.composerPastePreview, 1); ok {
+		if nextState, ok := moveComposerPastePreviewBoundary(state, m.composerPastePreviews, 1); ok {
 			m.setComposerState(nextState)
 			break
 		}
@@ -245,34 +246,34 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		m.setComposerState(state)
 	case msg.Type == tea.KeyCtrlU:
 		m.setComposerState(deleteComposerLineBefore(state))
-		m.composerPastePreview = composerPastePreview{}
+		m.composerPastePreviews = nil
 	case msg.Type == tea.KeyCtrlK:
 		m.setComposerState(deleteComposerLineAfter(state))
-		m.composerPastePreview = composerPastePreview{}
+		m.composerPastePreviews = nil
 	case msg.Type == tea.KeyCtrlW || (msg.Alt && (msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH)):
 		m.setComposerState(deleteComposerWordBefore(state))
-		m.composerPastePreview = composerPastePreview{}
+		m.composerPastePreviews = nil
 	case msg.Alt && msg.Type == tea.KeyDelete:
 		m.setComposerState(deleteComposerWordAfter(state))
-		m.composerPastePreview = composerPastePreview{}
+		m.composerPastePreviews = nil
 	case msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH:
-		if nextState, ok := deleteComposerPastePreviewBefore(state, m.composerPastePreview); ok && !m.suggestionsActive() {
+		if nextState, nextPreviews, ok := deleteComposerPastePreviewBefore(state, m.composerPastePreviews); ok && !m.suggestionsActive() {
 			m.setComposerState(nextState)
-			m.composerPastePreview = composerPastePreview{}
+			m.composerPastePreviews = nextPreviews
 		} else if nextState, ok := deleteCompletedFileMentionBefore(state); ok && !m.suggestionsActive() {
 			m.setComposerState(nextState)
-			m.composerPastePreview = composerPastePreview{}
+			m.composerPastePreviews = nil
 		} else {
 			m.setComposerState(deleteComposerRange(state, state.cursor-1, state.cursor))
-			m.composerPastePreview = composerPastePreview{}
+			m.composerPastePreviews = nil
 		}
 	case msg.Type == tea.KeyDelete || msg.Type == tea.KeyCtrlD:
-		if nextState, ok := deleteComposerPastePreviewAfter(state, m.composerPastePreview); ok {
+		if nextState, nextPreviews, ok := deleteComposerPastePreviewAfter(state, m.composerPastePreviews); ok {
 			m.setComposerState(nextState)
-			m.composerPastePreview = composerPastePreview{}
+			m.composerPastePreviews = nextPreviews
 		} else {
 			m.setComposerState(deleteComposerRange(state, state.cursor, state.cursor+1))
-			m.composerPastePreview = composerPastePreview{}
+			m.composerPastePreviews = nil
 		}
 	default:
 		return m, false
@@ -290,18 +291,20 @@ func (m model) insertComposerTextWithPastePreview(state composerState, text stri
 	state = normalizeComposerState(state)
 	insertStart := state.cursor
 	insertedRunes := len([]rune(text))
-	nextPreview := m.composerPastePreview.afterInsert(insertStart, insertedRunes)
+	nextPreviews := composerPastePreviewsAfterInsert(m.composerPastePreviews, insertStart, insertedRunes)
 	m.setComposerState(insertComposerText(state, text))
 	if previewLabel != "" && insertedRunes > 0 {
-		m.composerPastePreview = composerPastePreview{
+		nextPreviews = append(nextPreviews, composerPastePreview{
 			active: true,
 			start:  insertStart,
 			end:    insertStart + insertedRunes,
 			label:  previewLabel,
-		}
+		})
+		sortComposerPastePreviews(nextPreviews)
+		m.composerPastePreviews = nextPreviews
 		return m
 	}
-	m.composerPastePreview = nextPreview
+	m.composerPastePreviews = nextPreviews
 	return m
 }
 
@@ -338,65 +341,121 @@ func truncateComposerPasteSnippet(text string, limit int) string {
 	return string(runes[:limit-3]) + "..."
 }
 
-func (preview composerPastePreview) validFor(state composerState) bool {
-	state = normalizeComposerState(state)
-	if !preview.active || preview.label == "" {
-		return false
+func composerPastePreviewsAfterInsert(previews []composerPastePreview, pos int, length int) []composerPastePreview {
+	if length <= 0 || len(previews) == 0 {
+		return previews
 	}
-	return preview.start >= 0 && preview.start < preview.end && preview.end <= len([]rune(state.text))
+	next := make([]composerPastePreview, 0, len(previews))
+	for _, preview := range previews {
+		if !preview.active {
+			continue
+		}
+		switch {
+		case pos <= preview.start:
+			preview.start += length
+			preview.end += length
+		case pos < preview.end:
+			continue
+		}
+		next = append(next, preview)
+	}
+	sortComposerPastePreviews(next)
+	return next
 }
 
-func (preview composerPastePreview) afterInsert(pos int, length int) composerPastePreview {
-	if !preview.active || length <= 0 {
-		return preview
+func moveComposerPastePreviewBoundary(state composerState, previews []composerPastePreview, direction int) (composerState, bool) {
+	state = normalizeComposerState(state)
+	for _, preview := range validComposerPastePreviews(state, previews) {
+		switch {
+		case direction < 0 && state.cursor > preview.start && state.cursor <= preview.end:
+			state.cursor = preview.start
+			return state, true
+		case direction > 0 && state.cursor >= preview.start && state.cursor < preview.end:
+			state.cursor = preview.end
+			return state, true
+		}
 	}
-	switch {
-	case pos <= preview.start:
-		preview.start += length
-		preview.end += length
-	case pos < preview.end:
-		return composerPastePreview{}
-	}
-	return preview
+	return state, false
 }
 
-func moveComposerPastePreviewBoundary(state composerState, preview composerPastePreview, direction int) (composerState, bool) {
-	if !preview.validFor(state) {
-		return state, false
-	}
+func deleteComposerPastePreviewBefore(state composerState, previews []composerPastePreview) (composerState, []composerPastePreview, bool) {
 	state = normalizeComposerState(state)
-	switch {
-	case direction < 0 && state.cursor > preview.start && state.cursor <= preview.end:
-		state.cursor = preview.start
-		return state, true
-	case direction > 0 && state.cursor >= preview.start && state.cursor < preview.end:
-		state.cursor = preview.end
-		return state, true
-	default:
-		return state, false
+	valid := validComposerPastePreviews(state, previews)
+	for index, preview := range valid {
+		if state.cursor != preview.end {
+			continue
+		}
+		return deleteComposerRange(state, preview.start, preview.end), composerPastePreviewsAfterDelete(valid, index), true
 	}
+	return state, previews, false
 }
 
-func deleteComposerPastePreviewBefore(state composerState, preview composerPastePreview) (composerState, bool) {
-	if !preview.validFor(state) {
-		return state, false
-	}
+func deleteComposerPastePreviewAfter(state composerState, previews []composerPastePreview) (composerState, []composerPastePreview, bool) {
 	state = normalizeComposerState(state)
-	if state.cursor != preview.end {
-		return state, false
+	valid := validComposerPastePreviews(state, previews)
+	for index, preview := range valid {
+		if state.cursor != preview.start {
+			continue
+		}
+		return deleteComposerRange(state, preview.start, preview.end), composerPastePreviewsAfterDelete(valid, index), true
 	}
-	return deleteComposerRange(state, preview.start, preview.end), true
+	return state, previews, false
 }
 
-func deleteComposerPastePreviewAfter(state composerState, preview composerPastePreview) (composerState, bool) {
-	if !preview.validFor(state) {
-		return state, false
-	}
+func validComposerPastePreviews(state composerState, previews []composerPastePreview) []composerPastePreview {
 	state = normalizeComposerState(state)
-	if state.cursor != preview.start {
-		return state, false
+	if len(previews) == 0 {
+		return nil
 	}
-	return deleteComposerRange(state, preview.start, preview.end), true
+	runeCount := len([]rune(state.text))
+	valid := make([]composerPastePreview, 0, len(previews))
+	for _, preview := range previews {
+		if !preview.active || preview.label == "" || preview.start < 0 || preview.start >= preview.end || preview.end > runeCount {
+			continue
+		}
+		valid = append(valid, preview)
+	}
+	sortComposerPastePreviews(valid)
+	out := valid[:0]
+	lastEnd := -1
+	for _, preview := range valid {
+		if preview.start < lastEnd {
+			continue
+		}
+		out = append(out, preview)
+		lastEnd = preview.end
+	}
+	return out
+}
+
+func sortComposerPastePreviews(previews []composerPastePreview) {
+	sort.SliceStable(previews, func(i, j int) bool {
+		if previews[i].start == previews[j].start {
+			return previews[i].end < previews[j].end
+		}
+		return previews[i].start < previews[j].start
+	})
+}
+
+func composerPastePreviewsAfterDelete(previews []composerPastePreview, deleteIndex int) []composerPastePreview {
+	if deleteIndex < 0 || deleteIndex >= len(previews) {
+		return previews
+	}
+	deleted := previews[deleteIndex]
+	delta := deleted.end - deleted.start
+	next := make([]composerPastePreview, 0, len(previews)-1)
+	for index, preview := range previews {
+		if index == deleteIndex {
+			continue
+		}
+		if preview.start >= deleted.end {
+			preview.start -= delta
+			preview.end -= delta
+		}
+		next = append(next, preview)
+	}
+	sortComposerPastePreviews(next)
+	return next
 }
 
 func shouldInsertCommandArgumentSpace(state composerState, text string) bool {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -327,10 +327,11 @@ func composerPastePreviewLabel(text string) (string, bool) {
 		snippet = "pasted text"
 	}
 	snippet = truncateComposerPasteSnippet(snippet, 48)
-	if lineCount >= 3 {
-		return "[" + snippet + " · " + strconv.Itoa(lineCount) + " lines]", true
+	label := "lines"
+	if lineCount == 1 {
+		label = "line"
 	}
-	return "[" + snippet + " · " + strconv.Itoa(runeCount) + " chars]", true
+	return "[" + snippet + " · " + strconv.Itoa(lineCount) + " " + label + "]", true
 }
 
 func truncateComposerPasteSnippet(text string, limit int) string {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -306,7 +306,7 @@ func (m model) insertComposerTextWithPastePreview(state composerState, text stri
 	nextPreviews := composerPastePreviewsAfterInsert(m.composerPastePreviews, insertStart, insertedRunes)
 	m.setComposerState(insertComposerText(state, text))
 	if previewLabel != "" && insertedRunes > 0 {
-		previewLabel = composerPastePreviewLabelWithIndex(previewLabel, len(nextPreviews))
+		previewLabel = composerPastePreviewLabelWithIndex(previewLabel, len(nextPreviews)+1)
 		nextPreviews = append(nextPreviews, composerPastePreview{
 			active: true,
 			start:  insertStart,
@@ -365,11 +365,11 @@ func composerPastePreviewLabel(text string, wrapWidth int) (string, bool) {
 	return "[" + snippet + " · " + strconv.Itoa(lineCount) + " " + label + "]", true
 }
 
-func composerPastePreviewLabelWithIndex(label string, pasteIndex int) string {
-	if pasteIndex <= 0 || !strings.HasSuffix(label, "]") {
+func composerPastePreviewLabelWithIndex(label string, pasteNumber int) string {
+	if pasteNumber <= 1 || !strings.HasSuffix(label, "]") {
 		return label
 	}
-	return strings.TrimSuffix(label, "]") + ", paste " + strconv.Itoa(pasteIndex) + "]"
+	return strings.TrimSuffix(label, "]") + ", paste " + strconv.Itoa(pasteNumber) + "]"
 }
 
 func composerPastePreviewVisualLineCount(text string, wrapWidth int) int {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -11,6 +12,13 @@ import (
 type composerState struct {
 	text   string
 	cursor int
+}
+
+type composerPastePreview struct {
+	active bool
+	start  int
+	end    int
+	label  string
 }
 
 func insertComposerText(state composerState, text string) composerState {
@@ -150,12 +158,14 @@ func (m *model) setComposerState(state composerState) {
 func (m *model) clearComposer() {
 	m.composer = composerState{}
 	m.composerActive = false
+	m.composerPastePreview = composerPastePreview{}
 	m.input.SetValue("")
 }
 
 func (m *model) resetComposerFromInput() {
 	m.composer = composerState{}
 	m.composerActive = false
+	m.composerPastePreview = composerPastePreview{}
 }
 
 func (m *model) syncInputFromComposer() {
@@ -177,11 +187,12 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 	state := m.currentComposerState()
 	switch {
 	case msg.Type == tea.KeyEnter && msg.Alt:
-		m.setComposerState(insertComposerText(state, "\n"))
+		m = m.insertComposerTextWithPastePreview(state, "\n", "")
 	case msg.Type == tea.KeyCtrlJ:
-		m.setComposerState(insertComposerText(state, "\n"))
+		m = m.insertComposerTextWithPastePreview(state, "\n", "")
 	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "d":
 		m.setComposerState(deleteComposerWordAfter(state))
+		m.composerPastePreview = composerPastePreview{}
 	case (msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlLeft) && msg.Alt:
 		m.setComposerState(moveComposerWordBefore(state))
 	case (msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlRight) && msg.Alt:
@@ -195,22 +206,35 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 	case msg.Type == tea.KeyRunes && msg.Alt && string(msg.Runes) == "f":
 		m.setComposerState(moveComposerWordAfter(state))
 	case msg.Type == tea.KeySpace:
-		m.setComposerState(insertComposerText(state, " "))
+		m = m.insertComposerTextWithPastePreview(state, " ", "")
 	case msg.Type == tea.KeyRunes && !msg.Alt:
 		text := string(msg.Runes)
+		previewLabel := ""
 		if msg.Paste {
 			text = sanitizeComposerPaste(text)
+			previewLabel, _ = composerPastePreviewLabel(text)
 		} else {
 			text = sanitizeComposerInput(text)
 		}
 		if shouldInsertCommandArgumentSpace(state, text) {
 			text = " " + text
+			if previewLabel != "" {
+				previewLabel = " " + previewLabel
+			}
 		}
-		m.setComposerState(insertComposerText(state, text))
+		m = m.insertComposerTextWithPastePreview(state, text, previewLabel)
 	case msg.Type == tea.KeyLeft || msg.Type == tea.KeyCtrlB:
+		if nextState, ok := moveComposerPastePreviewBoundary(state, m.composerPastePreview, -1); ok {
+			m.setComposerState(nextState)
+			break
+		}
 		state.cursor--
 		m.setComposerState(state)
 	case msg.Type == tea.KeyRight || msg.Type == tea.KeyCtrlF:
+		if nextState, ok := moveComposerPastePreviewBoundary(state, m.composerPastePreview, 1); ok {
+			m.setComposerState(nextState)
+			break
+		}
 		state.cursor++
 		m.setComposerState(state)
 	case msg.Type == tea.KeyHome || msg.Type == tea.KeyCtrlA:
@@ -221,20 +245,35 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		m.setComposerState(state)
 	case msg.Type == tea.KeyCtrlU:
 		m.setComposerState(deleteComposerLineBefore(state))
+		m.composerPastePreview = composerPastePreview{}
 	case msg.Type == tea.KeyCtrlK:
 		m.setComposerState(deleteComposerLineAfter(state))
+		m.composerPastePreview = composerPastePreview{}
 	case msg.Type == tea.KeyCtrlW || (msg.Alt && (msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH)):
 		m.setComposerState(deleteComposerWordBefore(state))
+		m.composerPastePreview = composerPastePreview{}
 	case msg.Alt && msg.Type == tea.KeyDelete:
 		m.setComposerState(deleteComposerWordAfter(state))
+		m.composerPastePreview = composerPastePreview{}
 	case msg.Type == tea.KeyBackspace || msg.Type == tea.KeyCtrlH:
-		if nextState, ok := deleteCompletedFileMentionBefore(state); ok && !m.suggestionsActive() {
+		if nextState, ok := deleteComposerPastePreviewBefore(state, m.composerPastePreview); ok && !m.suggestionsActive() {
 			m.setComposerState(nextState)
+			m.composerPastePreview = composerPastePreview{}
+		} else if nextState, ok := deleteCompletedFileMentionBefore(state); ok && !m.suggestionsActive() {
+			m.setComposerState(nextState)
+			m.composerPastePreview = composerPastePreview{}
 		} else {
 			m.setComposerState(deleteComposerRange(state, state.cursor-1, state.cursor))
+			m.composerPastePreview = composerPastePreview{}
 		}
 	case msg.Type == tea.KeyDelete || msg.Type == tea.KeyCtrlD:
-		m.setComposerState(deleteComposerRange(state, state.cursor, state.cursor+1))
+		if nextState, ok := deleteComposerPastePreviewAfter(state, m.composerPastePreview); ok {
+			m.setComposerState(nextState)
+			m.composerPastePreview = composerPastePreview{}
+		} else {
+			m.setComposerState(deleteComposerRange(state, state.cursor, state.cursor+1))
+			m.composerPastePreview = composerPastePreview{}
+		}
 	default:
 		return m, false
 	}
@@ -245,6 +284,119 @@ func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {
 		m.recomputeSuggestions()
 	}
 	return m, true
+}
+
+func (m model) insertComposerTextWithPastePreview(state composerState, text string, previewLabel string) model {
+	state = normalizeComposerState(state)
+	insertStart := state.cursor
+	insertedRunes := len([]rune(text))
+	nextPreview := m.composerPastePreview.afterInsert(insertStart, insertedRunes)
+	m.setComposerState(insertComposerText(state, text))
+	if previewLabel != "" && insertedRunes > 0 {
+		m.composerPastePreview = composerPastePreview{
+			active: true,
+			start:  insertStart,
+			end:    insertStart + insertedRunes,
+			label:  previewLabel,
+		}
+		return m
+	}
+	m.composerPastePreview = nextPreview
+	return m
+}
+
+func composerPastePreviewLabel(text string) (string, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", false
+	}
+	lineCount := strings.Count(text, "\n") + 1
+	runeCount := len([]rune(text))
+	if lineCount < 3 && runeCount < 220 {
+		return "", false
+	}
+	snippet := text
+	if newline := strings.IndexRune(snippet, '\n'); newline >= 0 {
+		snippet = snippet[:newline]
+	}
+	snippet = strings.Join(strings.Fields(snippet), " ")
+	if snippet == "" {
+		snippet = "pasted text"
+	}
+	snippet = truncateComposerPasteSnippet(snippet, 48)
+	if lineCount >= 3 {
+		return "[" + snippet + " · " + strconv.Itoa(lineCount) + " lines]", true
+	}
+	return "[" + snippet + " · " + strconv.Itoa(runeCount) + " chars]", true
+}
+
+func truncateComposerPasteSnippet(text string, limit int) string {
+	runes := []rune(text)
+	if limit <= 3 || len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit-3]) + "..."
+}
+
+func (preview composerPastePreview) validFor(state composerState) bool {
+	state = normalizeComposerState(state)
+	if !preview.active || preview.label == "" {
+		return false
+	}
+	return preview.start >= 0 && preview.start < preview.end && preview.end <= len([]rune(state.text))
+}
+
+func (preview composerPastePreview) afterInsert(pos int, length int) composerPastePreview {
+	if !preview.active || length <= 0 {
+		return preview
+	}
+	switch {
+	case pos <= preview.start:
+		preview.start += length
+		preview.end += length
+	case pos < preview.end:
+		return composerPastePreview{}
+	}
+	return preview
+}
+
+func moveComposerPastePreviewBoundary(state composerState, preview composerPastePreview, direction int) (composerState, bool) {
+	if !preview.validFor(state) {
+		return state, false
+	}
+	state = normalizeComposerState(state)
+	switch {
+	case direction < 0 && state.cursor > preview.start && state.cursor <= preview.end:
+		state.cursor = preview.start
+		return state, true
+	case direction > 0 && state.cursor >= preview.start && state.cursor < preview.end:
+		state.cursor = preview.end
+		return state, true
+	default:
+		return state, false
+	}
+}
+
+func deleteComposerPastePreviewBefore(state composerState, preview composerPastePreview) (composerState, bool) {
+	if !preview.validFor(state) {
+		return state, false
+	}
+	state = normalizeComposerState(state)
+	if state.cursor != preview.end {
+		return state, false
+	}
+	return deleteComposerRange(state, preview.start, preview.end), true
+}
+
+func deleteComposerPastePreviewAfter(state composerState, preview composerPastePreview) (composerState, bool) {
+	if !preview.validFor(state) {
+		return state, false
+	}
+	state = normalizeComposerState(state)
+	if state.cursor != preview.start {
+		return state, false
+	}
+	return deleteComposerRange(state, preview.start, preview.end), true
 }
 
 func shouldInsertCommandArgumentSpace(state composerState, text string) bool {
@@ -263,19 +415,6 @@ func shouldInsertCommandArgumentSpace(state composerState, text string) bool {
 		return false
 	}
 	return commandArgumentHintForInput(state.text) != ""
-}
-
-func renderComposerState(state composerState, prompt string, width int) string {
-	state = normalizeComposerState(state)
-	lines := strings.Split(state.text, "\n")
-	for index, line := range lines {
-		prefix := "  "
-		if index == 0 {
-			prefix = prompt
-		}
-		lines[index] = fitStyledLine(prefix+line, width)
-	}
-	return strings.Join(lines, "\n")
 }
 
 func deleteCompletedFileMentionBefore(state composerState) (composerState, bool) {

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -166,8 +166,45 @@ func TestBackspaceAfterPastedPreviewDeletesWholePaste(t *testing.T) {
 	if got := next.composerValue(); got != "" {
 		t.Fatalf("composer value after deleting paste preview = %q, want empty", got)
 	}
-	if next.composerPastePreview.active {
+	if len(next.composerPastePreviews) != 0 {
 		t.Fatal("paste preview should clear after deleting pasted block")
+	}
+}
+
+func TestPastingTwiceKeepsBothComposerPreviews(t *testing.T) {
+	firstPaste := strings.Join([]string{
+		"Create a dashboard.",
+		"Use cards and filters.",
+		"Keep it responsive.",
+	}, "\n")
+	secondPaste := strings.Join([]string{
+		"Log line one",
+		"Log line two",
+		"Log line three",
+		"Log line four",
+	}, "\n")
+	m := newModel(context.Background(), Options{})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(firstPaste), Paste: true})
+	next := updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(secondPaste), Paste: true})
+	next = updated.(model)
+
+	if got := next.composerValue(); got != firstPaste+"\n"+secondPaste {
+		t.Fatalf("composer value should preserve both pastes = %q", got)
+	}
+	view := plainRender(t, next.composerBox(120))
+	for _, want := range []string{"[Create a dashboard.", "3 lines", "[Log line one", "4 lines"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("composer preview missing %q in:\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{"Use cards and filters", "Log line two"} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("composer preview should keep both pasted blocks compact, found %q in:\n%s", unwanted, view)
+		}
 	}
 }
 

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -129,6 +129,22 @@ func TestSanitizeComposerPastePreservesNewlines(t *testing.T) {
 	}
 }
 
+func TestCtrlVDoesNotPasteIntoComposer(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("hello")
+	m.input.CursorEnd()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlV})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("ctrl+v should not run the textinput clipboard paste command")
+	}
+	if got := next.composerValue(); got != "hello" {
+		t.Fatalf("composer value after ctrl+v = %q, want unchanged", got)
+	}
+}
+
 func TestPastedMultilineComposerContentRendersAsPreview(t *testing.T) {
 	paste := strings.Join([]string{
 		"Create a book library dashboard page with the Bootstrap theme.",

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -281,7 +281,7 @@ func TestPastingTwiceKeepsBothComposerPreviews(t *testing.T) {
 		t.Fatalf("composer value should preserve both pastes = %q", got)
 	}
 	view := plainRender(t, next.composerBox(120))
-	for _, want := range []string{"[Create a dashboard.", "3 lines", "[Log line one", "4 lines, paste 1"} {
+	for _, want := range []string{"[Create a dashboard.", "3 lines", "[Log line one", "4 lines, paste 2"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("composer preview missing %q in:\n%s", want, view)
 		}

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -155,25 +155,6 @@ func TestPastedMultilineComposerContentRendersAsPreview(t *testing.T) {
 	}
 }
 
-func TestPastedLongSingleLineComposerPreviewShowsLineCount(t *testing.T) {
-	paste := strings.Repeat("single line log entry ", 18)
-	m := newModel(context.Background(), Options{})
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
-	next := updated.(model)
-
-	if got := next.composerValue(); got != paste {
-		t.Fatalf("composer value should preserve full paste = %q, want %q", got, paste)
-	}
-	view := plainRender(t, next.composerBox(96))
-	if !strings.Contains(view, "1 line") {
-		t.Fatalf("composer preview should show line count instead of chars:\n%s", view)
-	}
-	if strings.Contains(view, "chars") {
-		t.Fatalf("composer preview should not show char count:\n%s", view)
-	}
-}
-
 func TestBackspaceAfterPastedPreviewDeletesWholePaste(t *testing.T) {
 	paste := "first line\nsecond line\nthird line"
 	m := newModel(context.Background(), Options{})

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -128,6 +129,48 @@ func TestSanitizeComposerPastePreservesNewlines(t *testing.T) {
 	}
 }
 
+func TestPastedMultilineComposerContentRendersAsPreview(t *testing.T) {
+	paste := strings.Join([]string{
+		"Create a book library dashboard page with the Bootstrap theme.",
+		"Include cards, search, filters, and progress bars.",
+		"Make the grid responsive across desktop and mobile.",
+		"Keep the sidebar readable.",
+	}, "\n")
+	m := newModel(context.Background(), Options{})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	next := updated.(model)
+
+	if got := next.composerValue(); got != paste {
+		t.Fatalf("composer value should preserve full paste = %q, want %q", got, paste)
+	}
+	view := plainRender(t, next.composerBox(96))
+	for _, want := range []string{"[Create a book library dashboard page", "4 lines"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("composer preview missing %q in:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Include cards") || strings.Contains(view, "Keep the sidebar") {
+		t.Fatalf("composer preview should not render full pasted content:\n%s", view)
+	}
+}
+
+func TestBackspaceAfterPastedPreviewDeletesWholePaste(t *testing.T) {
+	paste := "first line\nsecond line\nthird line"
+	m := newModel(context.Background(), Options{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	next := updated.(model)
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	next = updated.(model)
+	if got := next.composerValue(); got != "" {
+		t.Fatalf("composer value after deleting paste preview = %q, want empty", got)
+	}
+	if next.composerPastePreview.active {
+		t.Fatal("paste preview should clear after deleting pasted block")
+	}
+}
+
 func TestModifiedEnterInsertsNewlineWithoutSubmitting(t *testing.T) {
 	tests := []struct {
 		name string
@@ -194,6 +237,31 @@ func TestMultilineComposerAcceptsSpaceKey(t *testing.T) {
 	}
 	if !next.composerActive {
 		t.Fatal("space insertion should keep multiline composer state active")
+	}
+}
+
+func TestWrappedComposerArrowKeysMoveByVisualLine(t *testing.T) {
+	text := "Create a book library dashboard page with cards, filters, charts, and responsive behavior."
+	m := newModel(context.Background(), Options{})
+	m.width = 44
+	m.input.SetValue(text)
+	m.input.CursorEnd()
+	startCursor := len([]rune(text))
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	next := updated.(model)
+	if got := next.composerValue(); got != text {
+		t.Fatalf("composer value = %q, want unchanged text %q", got, text)
+	}
+	upCursor := next.currentComposerState().cursor
+	if upCursor >= startCursor {
+		t.Fatalf("up cursor = %d, want before end cursor %d", upCursor, startCursor)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyDown})
+	next = updated.(model)
+	if got := next.currentComposerState().cursor; got != startCursor {
+		t.Fatalf("down cursor = %d, want restored end cursor %d", got, startCursor)
 	}
 }
 

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -155,6 +155,30 @@ func TestPastedMultilineComposerContentRendersAsPreview(t *testing.T) {
 	}
 }
 
+func TestPastedLongSingleLineComposerContentRendersWrappedLineCount(t *testing.T) {
+	paste := strings.TrimSpace(strings.Repeat("word ", 37))
+	m := newModel(context.Background(), Options{})
+	m.width = 44
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	next := updated.(model)
+
+	if got := next.composerValue(); got != paste {
+		t.Fatalf("composer value should preserve full paste = %q, want %q", got, paste)
+	}
+	view := plainRender(t, next.composerBox(44))
+	for _, want := range []string{"[word word word", "5 lines"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("composer preview missing %q in:\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{"1 line", "chars"} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("composer preview should use wrapped line count, found %q in:\n%s", unwanted, view)
+		}
+	}
+}
+
 func TestBackspaceAfterPastedPreviewDeletesWholePaste(t *testing.T) {
 	paste := "first line\nsecond line\nthird line"
 	m := newModel(context.Background(), Options{})
@@ -168,6 +192,51 @@ func TestBackspaceAfterPastedPreviewDeletesWholePaste(t *testing.T) {
 	}
 	if len(next.composerPastePreviews) != 0 {
 		t.Fatal("paste preview should clear after deleting pasted block")
+	}
+}
+
+func TestAltBackspaceAfterPastedPreviewDoesNotLeakPaste(t *testing.T) {
+	paste := "first line\nsecond line\nthird line"
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("prefix ")
+	m.input.CursorEnd()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	next := updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyBackspace, Alt: true})
+	next = updated.(model)
+
+	if got := next.composerValue(); got != "prefix " {
+		t.Fatalf("composer value after alt+backspace = %q, want prefix only", got)
+	}
+	view := plainRender(t, next.composerBox(96))
+	if strings.Contains(view, "second line") || strings.Contains(view, "third line") {
+		t.Fatalf("alt+backspace should not leak hidden pasted content:\n%s", view)
+	}
+}
+
+func TestBackspaceAfterTypedTextKeepsPastedPreviewCollapsed(t *testing.T) {
+	paste := "first line\nsecond line\nthird line"
+	m := newModel(context.Background(), Options{})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	next := updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	next = updated.(model)
+
+	if got := next.composerValue(); got != paste {
+		t.Fatalf("composer value after deleting typed suffix = %q, want original paste", got)
+	}
+	view := plainRender(t, next.composerBox(96))
+	for _, want := range []string{"[first line", "3 lines"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("composer preview missing %q after deleting typed suffix:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "second line") || strings.Contains(view, "third line") {
+		t.Fatalf("backspace after typed suffix should keep paste collapsed:\n%s", view)
 	}
 }
 
@@ -196,7 +265,7 @@ func TestPastingTwiceKeepsBothComposerPreviews(t *testing.T) {
 		t.Fatalf("composer value should preserve both pastes = %q", got)
 	}
 	view := plainRender(t, next.composerBox(120))
-	for _, want := range []string{"[Create a dashboard.", "3 lines", "[Log line one", "4 lines"} {
+	for _, want := range []string{"[Create a dashboard.", "3 lines", "[Log line one", "4 lines, paste 1"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("composer preview missing %q in:\n%s", want, view)
 		}

--- a/internal/tui/composer_test.go
+++ b/internal/tui/composer_test.go
@@ -155,6 +155,25 @@ func TestPastedMultilineComposerContentRendersAsPreview(t *testing.T) {
 	}
 }
 
+func TestPastedLongSingleLineComposerPreviewShowsLineCount(t *testing.T) {
+	paste := strings.Repeat("single line log entry ", 18)
+	m := newModel(context.Background(), Options{})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(paste), Paste: true})
+	next := updated.(model)
+
+	if got := next.composerValue(); got != paste {
+		t.Fatalf("composer value should preserve full paste = %q, want %q", got, paste)
+	}
+	view := plainRender(t, next.composerBox(96))
+	if !strings.Contains(view, "1 line") {
+		t.Fatalf("composer preview should show line count instead of chars:\n%s", view)
+	}
+	if strings.Contains(view, "chars") {
+		t.Fatalf("composer preview should not show char count:\n%s", view)
+	}
+}
+
 func TestBackspaceAfterPastedPreviewDeletesWholePaste(t *testing.T) {
 	paste := "first line\nsecond line\nthird line"
 	m := newModel(context.Background(), Options{})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -67,7 +67,7 @@ type model struct {
 	input                  textinput.Model
 	composer               composerState
 	composerActive         bool
-	composerPastePreview   composerPastePreview
+	composerPastePreviews  []composerPastePreview
 	altScreen              bool
 	setup                  setupState
 	setupSave              func(SetupSelection) (SetupResult, error)
@@ -1147,25 +1147,17 @@ func (m model) composerLine(width int) string {
 	if hideInputForSuggestions {
 		state = composerState{}
 	}
-	hint := ""
 	argumentHint := commandArgumentHintForInput(input.Value())
 	if argumentHint != "" && input.Position() != len([]rune(input.Value())) {
 		argumentHint = ""
 	}
 	if argumentHint != "" {
 		input.Width = 0
-		line := commandArgumentHintComposerLine(input, argumentHint)
-		if hint == "" {
-			return fitStyledLine(line, width)
-		}
-		return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
+		return fitStyledLine(commandArgumentHintComposerLine(input, argumentHint), width)
 	}
-	displayState := composerDisplayStateForPastePreview(state, m.composerPastePreview)
-	line := renderComposerInput(input, displayState, width)
-	if hint == "" {
-		return line
-	}
-	return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
+	previews := validComposerPastePreviews(state, m.composerPastePreviews)
+	displayState := composerDisplayStateForPastePreviews(state, previews)
+	return renderComposerInput(input, displayState, width)
 }
 
 type composerVisualLine struct {
@@ -1291,28 +1283,43 @@ func composerVisualLinePrefix(input textinput.Model, first bool) string {
 	return "  "
 }
 
-func composerDisplayStateForPastePreview(state composerState, preview composerPastePreview) composerState {
+func composerDisplayStateForPastePreviews(state composerState, previews []composerPastePreview) composerState {
 	state = normalizeComposerState(state)
-	if !preview.validFor(state) {
+	valid := validComposerPastePreviews(state, previews)
+	if len(valid) == 0 {
 		return state
 	}
 	runes := []rune(state.text)
-	labelRunes := []rune(preview.label)
-	display := make([]rune, 0, len(runes)-(preview.end-preview.start)+len(labelRunes))
-	display = append(display, runes[:preview.start]...)
-	display = append(display, labelRunes...)
-	display = append(display, runes[preview.end:]...)
-
-	displayCursor := state.cursor
-	switch {
-	case state.cursor <= preview.start:
-		displayCursor = state.cursor
-	case state.cursor <= preview.end:
-		displayCursor = preview.start + len(labelRunes)
-	default:
-		displayCursor = state.cursor - (preview.end - preview.start) + len(labelRunes)
+	display := make([]rune, 0, len(runes))
+	last := 0
+	for _, preview := range valid {
+		display = append(display, runes[last:preview.start]...)
+		display = append(display, []rune(preview.label)...)
+		last = preview.end
 	}
-	return composerState{text: string(display), cursor: displayCursor}
+	display = append(display, runes[last:]...)
+	return composerState{
+		text:   string(display),
+		cursor: composerDisplayCursorForPastePreviews(state.cursor, valid),
+	}
+}
+
+func composerDisplayCursorForPastePreviews(cursor int, previews []composerPastePreview) int {
+	delta := 0
+	for _, preview := range previews {
+		labelLen := len([]rune(preview.label))
+		hiddenLen := preview.end - preview.start
+		displayStart := preview.start + delta
+		switch {
+		case cursor <= preview.start:
+			return cursor + delta
+		case cursor <= preview.end:
+			return displayStart + labelLen
+		default:
+			delta += labelLen - hiddenLen
+		}
+	}
+	return cursor + delta
 }
 
 func (m model) moveComposerVisualCursor(direction int) (model, bool) {
@@ -1329,7 +1336,8 @@ func (m model) moveComposerVisualCursor(direction int) (model, bool) {
 	if state.text == "" {
 		return m, false
 	}
-	displayState := composerDisplayStateForPastePreview(state, m.composerPastePreview)
+	previews := validComposerPastePreviews(state, m.composerPastePreviews)
+	displayState := composerDisplayStateForPastePreviews(state, previews)
 	segments := composerWrappedVisualLines(input, displayState, maxInt(1, width-4))
 	if len(segments) <= 1 {
 		return m, false
@@ -1341,25 +1349,31 @@ func (m model) moveComposerVisualCursor(direction int) (model, bool) {
 	}
 	column := composerVisualCursorColumn(displayState, segments[cursorLine])
 	displayState.cursor = composerCursorForVisualColumn(displayState, segments[targetLine], column)
-	state.cursor = composerOriginalCursorForPastePreview(displayState.cursor, m.composerPastePreview)
+	state.cursor = composerOriginalCursorForPastePreviews(displayState.cursor, previews)
 	m.setComposerState(state)
 	return m, true
 }
 
-func composerOriginalCursorForPastePreview(displayCursor int, preview composerPastePreview) int {
-	if !preview.active || preview.label == "" {
+func composerOriginalCursorForPastePreviews(displayCursor int, previews []composerPastePreview) int {
+	if len(previews) == 0 {
 		return displayCursor
 	}
-	labelWidth := len([]rune(preview.label))
-	displayEnd := preview.start + labelWidth
-	switch {
-	case displayCursor <= preview.start:
-		return displayCursor
-	case displayCursor <= displayEnd:
-		return preview.end
-	default:
-		return displayCursor - labelWidth + (preview.end - preview.start)
+	delta := 0
+	for _, preview := range previews {
+		labelLen := len([]rune(preview.label))
+		hiddenLen := preview.end - preview.start
+		displayStart := preview.start + delta
+		displayEnd := displayStart + labelLen
+		switch {
+		case displayCursor <= displayStart:
+			return displayCursor - delta
+		case displayCursor <= displayEnd:
+			return preview.end
+		default:
+			delta += labelLen - hiddenLen
+		}
 	}
+	return displayCursor - delta
 }
 
 func composerVisualCursorColumn(state composerState, segment composerVisualLine) int {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1582,7 +1582,9 @@ func (m model) chooseSuggestion() (tea.Model, tea.Cmd) {
 	wasDirectory := m.selectedSuggestionIsDirectory()
 	requiresInput := m.selectedCommandSuggestionRequiresInput()
 	next := m.completeSuggestion()
-	next.resetComposerFromInput()
+	if !wasFiles {
+		next.resetComposerFromInput()
+	}
 	if wasFiles && wasDirectory {
 		next.recomputeSuggestions()
 		return next, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -294,6 +294,7 @@ func newModel(ctx context.Context, options Options) model {
 	input.TextStyle = zeroTheme.ink
 	input.PlaceholderStyle = zeroTheme.faint
 	input.Placeholder = composerPlaceholder
+	input.KeyMap.Paste.SetEnabled(false)
 	input.Focus()
 
 	runSpinner := spinner.New(spinner.WithSpinner(spinner.MiniDot), spinner.WithStyle(zeroTheme.accent))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -67,6 +67,7 @@ type model struct {
 	input                  textinput.Model
 	composer               composerState
 	composerActive         bool
+	composerPastePreview   composerPastePreview
 	altScreen              bool
 	setup                  setupState
 	setupSave              func(SetupSelection) (SetupResult, error)
@@ -336,7 +337,10 @@ func newModel(ctx context.Context, options Options) model {
 	}
 }
 
-const composerPlaceholder = "describe a task for zero…"
+const (
+	composerPlaceholder     = "describe a task for zero…"
+	composerMaxVisibleLines = 4
+)
 
 func (m model) Init() tea.Cmd {
 	return textinput.Blink
@@ -566,6 +570,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.moveSuggestion(1)
 				return m, nil
 			}
+			if next, ok := m.moveComposerVisualCursor(1); ok {
+				return next, nil
+			}
 			if m.historyRecallActive() {
 				return m.recallHistory(1), nil
 			}
@@ -586,6 +593,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.suggestionsActive() {
 				m.moveSuggestion(-1)
 				return m, nil
+			}
+			if next, ok := m.moveComposerVisualCursor(-1); ok {
+				return next, nil
 			}
 			if m.historyRecallActive() {
 				return m.recallHistory(-1), nil
@@ -1124,21 +1134,20 @@ func appendStreamingCursor(lines []string, width int) []string {
 // composerLine renders the borderless composer.
 func (m model) composerLine(width int) string {
 	input := m.input
-	if m.suggestionsActive() && (!m.suggestionsAreFiles || fileSuggestionOnlyInput(m.input.Value())) {
+	hideInputForSuggestions := m.suggestionsActive() && (!m.suggestionsAreFiles || fileSuggestionOnlyInput(m.input.Value()))
+	if hideInputForSuggestions {
 		input.SetValue("")
 		input.Placeholder = ""
 		input.CursorEnd()
 	}
-	hint := ""
-	if m.composerActive && strings.Contains(m.composer.text, "\n") {
-		line := renderComposerState(m.composer, m.input.Prompt, width)
-		if hint == "" {
-			return line
-		}
-		lines := strings.Split(line, "\n")
-		lines[len(lines)-1] = joinHeaderLine(fitStyledLine(lines[len(lines)-1], width-lipgloss.Width(hint)-2), hint, width)
-		return strings.Join(lines, "\n")
+	state := composerState{text: input.Value(), cursor: input.Position()}
+	if m.composerActive {
+		state = m.composer
 	}
+	if hideInputForSuggestions {
+		state = composerState{}
+	}
+	hint := ""
 	argumentHint := commandArgumentHintForInput(input.Value())
 	if argumentHint != "" && input.Position() != len([]rune(input.Value())) {
 		argumentHint = ""
@@ -1151,11 +1160,231 @@ func (m model) composerLine(width int) string {
 		}
 		return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
 	}
-	line := input.View()
+	displayState := composerDisplayStateForPastePreview(state, m.composerPastePreview)
+	line := renderComposerInput(input, displayState, width)
 	if hint == "" {
-		return fitStyledLine(line, width)
+		return line
 	}
 	return joinHeaderLine(fitStyledLine(line, width-lipgloss.Width(hint)-2), hint, width)
+}
+
+type composerVisualLine struct {
+	first bool
+	start int
+	end   int
+}
+
+func renderComposerInput(input textinput.Model, state composerState, width int) string {
+	state = normalizeComposerState(state)
+	if width <= 0 {
+		return ""
+	}
+	if state.text == "" {
+		return fitStyledLine(input.View(), width)
+	}
+
+	segments := composerWrappedVisualLines(input, state, width)
+	cursorLine := composerCursorVisualLine(segments, state.cursor)
+	if len(segments) > composerMaxVisibleLines {
+		start := clamp(cursorLine-composerMaxVisibleLines+1, 0, len(segments)-composerMaxVisibleLines)
+		end := start + composerMaxVisibleLines
+		cursorLine -= start
+		segments = segments[start:end]
+		if len(segments) > 0 {
+			segments[0].first = true
+		}
+	}
+
+	lines := make([]string, 0, len(segments))
+	for index, segment := range segments {
+		lines = append(lines, fitStyledLine(renderComposerVisualLine(input, state, segment, index == cursorLine), width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func composerWrappedVisualLines(input textinput.Model, state composerState, width int) []composerVisualLine {
+	runes := []rune(state.text)
+	segments := []composerVisualLine{}
+	first := true
+	start := 0
+	for index, r := range runes {
+		if r != '\n' {
+			continue
+		}
+		segments = appendComposerWrappedVisualLines(segments, input, runes, start, index, width, &first)
+		start = index + 1
+	}
+	segments = appendComposerWrappedVisualLines(segments, input, runes, start, len(runes), width, &first)
+	return segments
+}
+
+func appendComposerWrappedVisualLines(segments []composerVisualLine, input textinput.Model, runes []rune, start int, end int, width int, first *bool) []composerVisualLine {
+	if start >= end {
+		segments = append(segments, composerVisualLine{first: *first, start: start, end: end})
+		*first = false
+		return segments
+	}
+	for start < end {
+		lineFirst := *first
+		measure := maxInt(1, width-lipgloss.Width(composerVisualLinePrefix(input, lineFirst)))
+		split := start
+		used := 0
+		for split < end {
+			nextWidth := lipgloss.Width(string(runes[split]))
+			if used+nextWidth > measure {
+				break
+			}
+			used += nextWidth
+			split++
+		}
+		if split == start {
+			split++
+		}
+		segments = append(segments, composerVisualLine{first: lineFirst, start: start, end: split})
+		*first = false
+		start = split
+	}
+	return segments
+}
+
+func composerCursorVisualLine(segments []composerVisualLine, cursor int) int {
+	if len(segments) == 0 {
+		return 0
+	}
+	for index, segment := range segments {
+		if cursor < segment.start || cursor > segment.end {
+			continue
+		}
+		if cursor == segment.end && index+1 < len(segments) && segments[index+1].start == cursor {
+			continue
+		}
+		return index
+	}
+	return len(segments) - 1
+}
+
+func renderComposerVisualLine(input textinput.Model, state composerState, segment composerVisualLine, hasCursor bool) string {
+	runes := []rune(state.text)
+	prefix := composerVisualLinePrefix(input, segment.first)
+	textStyle := input.TextStyle.Inline(true)
+	if !hasCursor {
+		return prefix + textStyle.Render(string(runes[segment.start:segment.end]))
+	}
+
+	offset := clamp(state.cursor-segment.start, 0, segment.end-segment.start)
+	cursorIndex := segment.start + offset
+	before := string(runes[segment.start:cursorIndex])
+	cursor := input.Cursor
+	if cursorIndex < segment.end {
+		cursor.SetChar(string(runes[cursorIndex]))
+		after := string(runes[cursorIndex+1 : segment.end])
+		return prefix + textStyle.Render(before) + cursor.View() + textStyle.Render(after)
+	}
+	cursor.SetChar(" ")
+	return prefix + textStyle.Render(before) + cursor.View()
+}
+
+func composerVisualLinePrefix(input textinput.Model, first bool) string {
+	if first {
+		return input.PromptStyle.Render(input.Prompt)
+	}
+	return "  "
+}
+
+func composerDisplayStateForPastePreview(state composerState, preview composerPastePreview) composerState {
+	state = normalizeComposerState(state)
+	if !preview.validFor(state) {
+		return state
+	}
+	runes := []rune(state.text)
+	labelRunes := []rune(preview.label)
+	display := make([]rune, 0, len(runes)-(preview.end-preview.start)+len(labelRunes))
+	display = append(display, runes[:preview.start]...)
+	display = append(display, labelRunes...)
+	display = append(display, runes[preview.end:]...)
+
+	displayCursor := state.cursor
+	switch {
+	case state.cursor <= preview.start:
+		displayCursor = state.cursor
+	case state.cursor <= preview.end:
+		displayCursor = preview.start + len(labelRunes)
+	default:
+		displayCursor = state.cursor - (preview.end - preview.start) + len(labelRunes)
+	}
+	return composerState{text: string(display), cursor: displayCursor}
+}
+
+func (m model) moveComposerVisualCursor(direction int) (model, bool) {
+	if direction == 0 {
+		return m, false
+	}
+	width := chatWidth(m.width)
+	if width < 8 {
+		return m, false
+	}
+	input := m.input
+	state := m.currentComposerState()
+	state = normalizeComposerState(state)
+	if state.text == "" {
+		return m, false
+	}
+	displayState := composerDisplayStateForPastePreview(state, m.composerPastePreview)
+	segments := composerWrappedVisualLines(input, displayState, maxInt(1, width-4))
+	if len(segments) <= 1 {
+		return m, false
+	}
+	cursorLine := composerCursorVisualLine(segments, displayState.cursor)
+	targetLine := clamp(cursorLine+direction, 0, len(segments)-1)
+	if targetLine == cursorLine {
+		return m, true
+	}
+	column := composerVisualCursorColumn(displayState, segments[cursorLine])
+	displayState.cursor = composerCursorForVisualColumn(displayState, segments[targetLine], column)
+	state.cursor = composerOriginalCursorForPastePreview(displayState.cursor, m.composerPastePreview)
+	m.setComposerState(state)
+	return m, true
+}
+
+func composerOriginalCursorForPastePreview(displayCursor int, preview composerPastePreview) int {
+	if !preview.active || preview.label == "" {
+		return displayCursor
+	}
+	labelWidth := len([]rune(preview.label))
+	displayEnd := preview.start + labelWidth
+	switch {
+	case displayCursor <= preview.start:
+		return displayCursor
+	case displayCursor <= displayEnd:
+		return preview.end
+	default:
+		return displayCursor - labelWidth + (preview.end - preview.start)
+	}
+}
+
+func composerVisualCursorColumn(state composerState, segment composerVisualLine) int {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	cursor := clamp(state.cursor, segment.start, segment.end)
+	column := 0
+	for index := segment.start; index < cursor && index < len(runes); index++ {
+		column += lipgloss.Width(string(runes[index]))
+	}
+	return column
+}
+
+func composerCursorForVisualColumn(state composerState, segment composerVisualLine, column int) int {
+	state = normalizeComposerState(state)
+	runes := []rune(state.text)
+	used := 0
+	for index := segment.start; index < segment.end && index < len(runes); index++ {
+		width := lipgloss.Width(string(runes[index]))
+		if used+width > column {
+			return index
+		}
+		used += width
+	}
+	return segment.end
 }
 
 func commandArgumentHintComposerLine(input textinput.Model, argumentHint string) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -294,6 +294,8 @@ func newModel(ctx context.Context, options Options) model {
 	input.TextStyle = zeroTheme.ink
 	input.PlaceholderStyle = zeroTheme.faint
 	input.Placeholder = composerPlaceholder
+	// Bubble's Ctrl+V binding reads the clipboard itself. Keep it disabled so
+	// terminal bracketed paste (Paste: true) is the single paste path.
 	input.KeyMap.Paste.SetEnabled(false)
 	input.Focus()
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2030,6 +2030,13 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				onText(delta)
 			}
 		}
+		onReasoning := options.OnReasoning
+		options.OnReasoning = func(delta string) {
+			m.sendAgentText(runID, delta)
+			if onReasoning != nil {
+				onReasoning(delta)
+			}
+		}
 
 		onPermissionRequest := options.OnPermissionRequest
 		options.OnPermissionRequest = func(ctx context.Context, request agent.PermissionRequest) (agent.PermissionDecision, error) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -292,7 +292,7 @@ func newModel(ctx context.Context, options Options) model {
 	input.PromptStyle = zeroTheme.userPrompt
 	input.TextStyle = zeroTheme.ink
 	input.PlaceholderStyle = zeroTheme.faint
-	input.Placeholder = composerPlaceholderIdle
+	input.Placeholder = composerPlaceholder
 	input.Focus()
 
 	runSpinner := spinner.New(spinner.WithSpinner(spinner.MiniDot), spinner.WithStyle(zeroTheme.accent))
@@ -336,14 +336,7 @@ func newModel(ctx context.Context, options Options) model {
 	}
 }
 
-const (
-	composerPlaceholderIdle = "describe a task for zero…"
-	// Esc is the run-interrupt key; Ctrl+C quits the whole app (after the
-	// cancelled run's checkpoint flush). The spec mock said "ctrl+c to
-	// interrupt", but advertising a quit keystroke as an interrupt would teach
-	// users to lose their session — the hint follows the actual binding.
-	composerPlaceholderRunning = "running… esc to interrupt"
-)
+const composerPlaceholder = "describe a task for zero…"
 
 func (m model) Init() tea.Cmd {
 	return textinput.Blink
@@ -1128,23 +1121,15 @@ func appendStreamingCursor(lines []string, width int) []string {
 	return lines
 }
 
-// composerLine renders the borderless composer: the styled textinput plus a
-// right-aligned faint key hint that tracks run state.
+// composerLine renders the borderless composer.
 func (m model) composerLine(width int) string {
 	input := m.input
-	if m.pending {
-		input.Placeholder = composerPlaceholderRunning
-	}
 	if m.suggestionsActive() && (!m.suggestionsAreFiles || fileSuggestionOnlyInput(m.input.Value())) {
 		input.SetValue("")
 		input.Placeholder = ""
 		input.CursorEnd()
 	}
 	hint := ""
-	switch {
-	case m.pending:
-		hint = zeroTheme.faint.Render("esc stop")
-	}
 	if m.composerActive && strings.Contains(m.composer.text, "\n") {
 		line := renderComposerState(m.composer, m.input.Prompt, width)
 		if hint == "" {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -199,7 +199,7 @@ func TestInitialRenderShowsLimeChatSurface(t *testing.T) {
 	assertContains(t, view, "openai/gpt-4.1")
 	assertContains(t, view, emptyStateTagline)
 	assertNotContains(t, view, "running zero against ")
-	assertContains(t, view, composerPlaceholderIdle)
+	assertContains(t, view, composerPlaceholder)
 	assertNotContains(t, view, "interactive")
 	if strings.Contains(view, "Welcome to Zero") {
 		t.Fatalf("empty chat surface should not show welcome transcript clutter, got %q", view)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -67,6 +67,11 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			m.moveSuggestion(-1)
 			return m, nil
 		}
+		if m.mouseOverComposer(msg) {
+			if next, ok := m.moveComposerVisualCursor(-1); ok {
+				return next, nil
+			}
+		}
 		return m.scrollChat(chatWheelScrollLines), nil
 	case mouseWheelDown(msg):
 		m.clearMouseSelection()
@@ -84,6 +89,11 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if m.suggestionsActive() {
 			m.moveSuggestion(1)
 			return m, nil
+		}
+		if m.mouseOverComposer(msg) {
+			if next, ok := m.moveComposerVisualCursor(1); ok {
+				return next, nil
+			}
 		}
 		return m.scrollChat(-chatWheelScrollLines), nil
 	default:
@@ -148,6 +158,31 @@ func mouseWheelUp(msg tea.MouseMsg) bool {
 
 func mouseWheelDown(msg tea.MouseMsg) bool {
 	return msg.Button == tea.MouseButtonWheelDown || msg.Type == tea.MouseWheelDown
+}
+
+func (m model) mouseOverComposer(msg tea.MouseMsg) bool {
+	if !m.altScreen || m.height <= 0 {
+		return false
+	}
+	width := chatWidth(m.width)
+	composerLines := viewLines(m.composerBox(width))
+	footerLines := viewLines(m.footerView(width))
+	if len(composerLines) == 0 || len(footerLines) == 0 {
+		return false
+	}
+	composerTop := -1
+	for index := 0; index+len(composerLines) <= len(footerLines); index++ {
+		if footerLines[index] == composerLines[0] {
+			composerTop = index
+			break
+		}
+	}
+	if composerTop < 0 {
+		return false
+	}
+	footerTop := maxInt(0, m.height-len(footerLines))
+	top := footerTop + composerTop
+	return msg.Y >= top && msg.Y < top+len(composerLines)
 }
 
 func (m *model) selectSuggestionAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -166,23 +166,51 @@ func (m model) mouseOverComposer(msg tea.MouseMsg) bool {
 	}
 	width := chatWidth(m.width)
 	composerLines := viewLines(m.composerBox(width))
-	footerLines := viewLines(m.footerView(width))
-	if len(composerLines) == 0 || len(footerLines) == 0 {
+	fullFooterLines := viewLines(m.footerView(width))
+	if len(composerLines) == 0 || len(fullFooterLines) == 0 {
 		return false
 	}
-	composerTop := -1
-	for index := 0; index+len(composerLines) <= len(footerLines); index++ {
-		if footerLines[index] == composerLines[0] {
-			composerTop = index
-			break
-		}
-	}
+	composerTop := lineSequenceIndex(fullFooterLines, composerLines)
 	if composerTop < 0 {
 		return false
 	}
+	footerLines := fullFooterLines
+	clippedPrefix := 0
+	maxFooterLines := maxInt(0, m.height-1)
+	if len(footerLines) > maxFooterLines {
+		clippedPrefix = len(footerLines) - maxFooterLines
+		footerLines = footerLines[clippedPrefix:]
+	}
+	if len(footerLines) == 0 {
+		return false
+	}
+	visibleTop := maxInt(composerTop, clippedPrefix)
+	visibleBottom := minInt(composerTop+len(composerLines), clippedPrefix+len(footerLines))
+	if visibleTop >= visibleBottom {
+		return false
+	}
 	footerTop := maxInt(0, m.height-len(footerLines))
-	top := footerTop + composerTop
-	return msg.Y >= top && msg.Y < top+len(composerLines)
+	top := footerTop + visibleTop - clippedPrefix
+	return msg.Y >= top && msg.Y < top+visibleBottom-visibleTop
+}
+
+func lineSequenceIndex(lines []string, sequence []string) int {
+	if len(sequence) == 0 || len(sequence) > len(lines) {
+		return -1
+	}
+	for index := 0; index+len(sequence) <= len(lines); index++ {
+		matched := true
+		for offset := range sequence {
+			if lines[index+offset] != sequence[offset] {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return index
+		}
+	}
+	return -1
 }
 
 func (m *model) selectSuggestionAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -78,6 +78,8 @@ func newSetupState(options SetupOptions) setupState {
 	apiKey.Placeholder = "paste key or leave blank"
 	apiKey.EchoMode = textinput.EchoPassword
 	apiKey.EchoCharacter = '*'
+	// Bubble's Ctrl+V binding reads the clipboard itself. Keep it disabled so
+	// terminal bracketed paste (Paste: true) is the single paste path.
 	apiKey.KeyMap.Paste.SetEnabled(false)
 	apiKey.Focus()
 	return setupState{

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -78,6 +78,7 @@ func newSetupState(options SetupOptions) setupState {
 	apiKey.Placeholder = "paste key or leave blank"
 	apiKey.EchoMode = textinput.EchoPassword
 	apiKey.EchoCharacter = '*'
+	apiKey.KeyMap.Paste.SetEnabled(false)
 	apiKey.Focus()
 	return setupState{
 		visible:    options.Visible,

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -21,13 +22,13 @@ type setupStage int
 const (
 	setupStageWelcome setupStage = iota
 	setupStageProvider
+	setupStageEndpoint
+	setupStageName
 	setupStageCredentials
 	setupStageModel
 	setupStageSafety
 	setupStageReady
 )
-
-const setupStageCount = int(setupStageReady) + 1
 
 type setupState struct {
 	visible    bool
@@ -37,6 +38,8 @@ type setupState struct {
 	selected   int
 	stage      setupStage
 	err        string
+	baseURL    string
+	name       string
 	apiKey     textinput.Model
 	models     []providerWizardModel
 	modelIndex int
@@ -87,6 +90,12 @@ func newSetupState(options SetupOptions) setupState {
 
 func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.clearMouseSelection()
+	if m.setupEndpointInputActive() {
+		return m.handleSetupEndpointKey(msg)
+	}
+	if m.setupNameInputActive() {
+		return m.handleSetupNameKey(msg)
+	}
 	if m.setupCredentialInputActive() {
 		return m.handleSetupCredentialKey(msg)
 	}
@@ -95,7 +104,7 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case tea.KeyEsc:
 		if m.setup.stage > setupStageWelcome {
-			m.setup.stage--
+			m.setup.stage = m.previousSetupStage()
 			m.setup.err = ""
 			return m, nil
 		}
@@ -105,7 +114,7 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.exitSetupToChat()
 	case tea.KeyLeft:
 		if m.setup.stage > setupStageWelcome {
-			m.setup.stage--
+			m.setup.stage = m.previousSetupStage()
 			m.setup.err = ""
 		}
 		return m, nil
@@ -257,6 +266,8 @@ func (m *model) selectSetupProviderAtMouse(msg tea.MouseMsg) (mouseSelectionTarg
 	}
 	m.setup.selected = index
 	m.setup.apiKey.SetValue("")
+	m.setup.baseURL = ""
+	m.setup.name = ""
 	m.setup.modelGen++
 	m.resetSetupModels()
 	return mouseSelectionTarget{Scope: "first-run-provider", Value: m.setup.providers[index].ID, Index: index}, true
@@ -308,6 +319,41 @@ func setupContentTop(height int, contentLines int, hasError bool) int {
 	return maxInt(0, (height-contentLines-3)/2)
 }
 
+func (m model) setupStages() []setupStage {
+	stages := []setupStage{setupStageWelcome, setupStageProvider}
+	if setupProviderNeedsEndpoint(m.setupProvider()) {
+		stages = append(stages, setupStageEndpoint, setupStageName)
+	}
+	stages = append(stages, setupStageCredentials, setupStageModel, setupStageSafety, setupStageReady)
+	return stages
+}
+
+func (m model) nextSetupStage() setupStage {
+	stages := m.setupStages()
+	for index, stage := range stages {
+		if stage == m.setup.stage {
+			if index+1 < len(stages) {
+				return stages[index+1]
+			}
+			return stage
+		}
+	}
+	return m.setup.stage
+}
+
+func (m model) previousSetupStage() setupStage {
+	stages := m.setupStages()
+	for index, stage := range stages {
+		if stage == m.setup.stage {
+			if index > 0 {
+				return stages[index-1]
+			}
+			return stage
+		}
+	}
+	return m.setup.stage
+}
+
 func setupBlockContainsMouseX(x int, width int, blockWidth int) bool {
 	if blockWidth <= 0 {
 		return false
@@ -320,16 +366,28 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 	if m.setup.stage < setupStageReady {
 		if m.setup.stage == setupStageProvider {
 			m.setup.apiKey.SetValue("")
+			m.setup.baseURL = ""
+			m.setup.name = ""
+		}
+		if m.setup.stage == setupStageEndpoint {
+			if err := providerWizardEndpointError(m.setup.baseURL); err != "" {
+				m.setup.err = err
+				return m, nil
+			}
 		}
 		if m.setup.stage == setupStageModel && m.setup.modelLoad {
 			m.setup.err = "Models are still loading."
+			return m, nil
+		}
+		if m.setup.stage == setupStageModel && setupProviderUsesTypedModel(m.setupProvider()) && strings.TrimSpace(m.setup.modelQuery) == "" {
+			m.setup.err = "Enter a model name before continuing."
 			return m, nil
 		}
 		if m.setup.stage == setupStageModel && m.setupCurrentModel().ID == "" {
 			m.setup.err = "Choose a matching model before continuing."
 			return m, nil
 		}
-		m.setup.stage++
+		m.setup.stage = m.nextSetupStage()
 		m.setup.err = ""
 		if m.setup.stage == setupStageModel {
 			m.resetSetupModels()
@@ -350,6 +408,8 @@ func (m *model) moveSetupProvider(delta int) {
 	}
 	m.setup.selected = ((m.setup.selected+delta)%len(m.setup.providers) + len(m.setup.providers)) % len(m.setup.providers)
 	m.setup.apiKey.SetValue("")
+	m.setup.baseURL = ""
+	m.setup.name = ""
 	m.setup.modelGen++
 	m.resetSetupModels()
 }
@@ -366,6 +426,8 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 
 	result, err := m.setupSave(SetupSelection{
 		CatalogID: option.ID,
+		Name:      m.setupProfileName(option),
+		BaseURL:   m.setupBaseURL(option),
 		Model:     m.setupCurrentModel().ID,
 		APIKey:    m.setupCredentialAPIKey(option),
 	})
@@ -394,6 +456,16 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 func (m *model) resetSetupModels() {
 	option := m.setupProvider()
 	provider := setupProviderDescriptor(option)
+	if setupProviderUsesTypedModel(option) {
+		m.setup.models = nil
+		m.setup.modelIndex = 0
+		m.setup.modelQuery = ""
+		m.setup.modelForID = provider.ID
+		m.setup.modelLoad = false
+		m.setup.modelErr = ""
+		m.setup.modelSrc = "manual"
+		return
+	}
 	models := providerWizardModelOptions(provider)
 	m.setup.models = models
 	m.setup.modelIndex = 0
@@ -408,6 +480,9 @@ func (m model) setupModelDiscoveryCmd(gen uint64) tea.Cmd {
 	option := m.setupProvider()
 	provider := setupProviderDescriptor(option)
 	if provider.ID == "" || !providercatalog.RuntimeSupported(provider) {
+		return nil
+	}
+	if setupProviderUsesTypedModel(option) {
 		return nil
 	}
 	profile := providerWizardDiscoveryProfile(provider, m.setupCredentialAPIKey(option))
@@ -496,6 +571,13 @@ func cleanSetupEnvVar(envVar string) []string {
 }
 
 func (m model) setupCurrentModel() providerWizardModel {
+	if setupProviderUsesTypedModel(m.setupProvider()) {
+		modelID := strings.TrimSpace(m.setup.modelQuery)
+		if modelID == "" {
+			return providerWizardModel{Description: "model name required"}
+		}
+		return providerWizardModel{ID: modelID, Description: "custom model"}
+	}
 	m.ensureSetupModels()
 	models := m.setupFilteredModels()
 	if len(models) == 0 {
@@ -579,12 +661,62 @@ func (m model) setupCredentialInputActive() bool {
 	return m.setup.stage == setupStageCredentials && setupProviderAcceptsAPIKey(m.setupProvider())
 }
 
+func (m model) setupEndpointInputActive() bool {
+	return m.setup.stage == setupStageEndpoint && setupProviderNeedsEndpoint(m.setupProvider())
+}
+
+func (m model) setupNameInputActive() bool {
+	return m.setup.stage == setupStageName && setupProviderNeedsProfileName(m.setupProvider())
+}
+
+func (m model) handleSetupEndpointKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc, tea.KeyLeft:
+		m.setup.stage = m.previousSetupStage()
+		m.setup.err = ""
+		return m, nil
+	case tea.KeyEnter:
+		return m.advanceSetup()
+	case tea.KeyRunes:
+		m.appendSetupBaseURL(msg.Runes)
+	case tea.KeyBackspace, tea.KeyCtrlH:
+		m.deleteSetupBaseURLRune()
+	case tea.KeyCtrlU:
+		m.setup.baseURL = ""
+		m.setup.err = ""
+	}
+	return m, nil
+}
+
+func (m model) handleSetupNameKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc, tea.KeyLeft:
+		m.setup.stage = m.previousSetupStage()
+		m.setup.err = ""
+		return m, nil
+	case tea.KeyEnter:
+		return m.advanceSetup()
+	case tea.KeyRunes:
+		m.appendSetupName(msg.Runes)
+	case tea.KeyBackspace, tea.KeyCtrlH:
+		m.deleteSetupNameRune()
+	case tea.KeyCtrlU:
+		m.setup.name = ""
+		m.setup.err = ""
+	}
+	return m, nil
+}
+
 func (m model) handleSetupCredentialKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		return m, tea.Quit
 	case tea.KeyEsc, tea.KeyLeft:
-		m.setup.stage--
+		m.setup.stage = m.previousSetupStage()
 		m.setup.err = ""
 		return m, nil
 	case tea.KeyEnter:
@@ -607,11 +739,75 @@ func setupProviderAcceptsAPIKey(option SetupProviderOption) bool {
 	return option.RequiresAuth && !option.Local
 }
 
+func setupProviderNeedsEndpoint(option SetupProviderOption) bool {
+	return providerWizardNeedsEndpoint(setupProviderDescriptor(option))
+}
+
+func setupProviderNeedsProfileName(option SetupProviderOption) bool {
+	return setupProviderNeedsEndpoint(option)
+}
+
+func setupProviderUsesTypedModel(option SetupProviderOption) bool {
+	return setupProviderNeedsEndpoint(option)
+}
+
 func (m model) setupCredentialAPIKey(option SetupProviderOption) string {
 	if !setupProviderAcceptsAPIKey(option) {
 		return ""
 	}
 	return strings.TrimSpace(m.setup.apiKey.Value())
+}
+
+func (m model) setupBaseURL(option SetupProviderOption) string {
+	if !setupProviderNeedsEndpoint(option) {
+		return ""
+	}
+	return strings.TrimSpace(m.setup.baseURL)
+}
+
+func (m model) setupProfileName(option SetupProviderOption) string {
+	if !setupProviderNeedsProfileName(option) {
+		return ""
+	}
+	return providerWizardDisplayName(setupProviderDescriptor(option), m.setup.baseURL, m.setup.name)
+}
+
+func (m *model) appendSetupBaseURL(runes []rune) {
+	for _, r := range runes {
+		if r < 32 || r == 127 || unicode.IsSpace(r) {
+			continue
+		}
+		m.setup.baseURL += string(r)
+	}
+	m.setup.err = ""
+}
+
+func (m *model) deleteSetupBaseURLRune() {
+	if m.setup.baseURL == "" {
+		return
+	}
+	runes := []rune(m.setup.baseURL)
+	m.setup.baseURL = string(runes[:len(runes)-1])
+	m.setup.err = ""
+}
+
+func (m *model) appendSetupName(runes []rune) {
+	for _, r := range runes {
+		if r < 32 || r == 127 || unicode.IsSpace(r) {
+			continue
+		}
+		m.setup.name += string(r)
+	}
+	m.setup.err = ""
+}
+
+func (m *model) deleteSetupNameRune() {
+	if m.setup.name == "" {
+		return
+	}
+	runes := []rune(m.setup.name)
+	m.setup.name = string(runes[:len(runes)-1])
+	m.setup.err = ""
 }
 
 func (m model) setupProvider() SetupProviderOption {
@@ -631,7 +827,7 @@ func (m model) setupView(width int) string {
 	if m.setup.err != "" {
 		content = append(content, "", zeroTheme.red.Render("error: "+m.setup.err))
 	}
-	progress := setupProgressText(m.setup.stage)
+	progress := m.setupProgressText()
 	footer := m.setupFooter()
 
 	topGap := maxInt(0, (height-len(content)-3)/2)
@@ -653,6 +849,10 @@ func (m model) setupStageLines(width int, height int) []string {
 	switch m.setup.stage {
 	case setupStageProvider:
 		return m.setupProviderLines(width, height)
+	case setupStageEndpoint:
+		return m.setupEndpointLines(width)
+	case setupStageName:
+		return m.setupNameLines(width)
 	case setupStageCredentials:
 		return m.setupCredentialLines(width)
 	case setupStageModel:
@@ -667,19 +867,7 @@ func (m model) setupStageLines(width int, height int) []string {
 			zeroTheme.faint.Render("Default: ask before risky work."),
 		}
 	case setupStageReady:
-		option := m.setupProvider()
-		model := m.setupCurrentModel()
-		return []string{
-			zeroTheme.ink.Bold(true).Render("Ready"),
-			"",
-			"Zero will save this setup and open chat.",
-			"provider: " + displayValue(option.Name, option.ID),
-			"model: " + displayValue(model.ID, option.DefaultModel),
-			"credentials: " + m.setupCredentialSummary(option),
-			"config: " + displayValue(m.setup.configPath, "user config"),
-			"",
-			zeroTheme.faint.Render("Later, use /provider, /doctor, or /help anytime."),
-		}
+		return m.setupReadyLines(width)
 	default:
 		return []string{
 			zeroTheme.accent.Render("Welcome to Zero"),
@@ -690,7 +878,67 @@ func (m model) setupStageLines(width int, height int) []string {
 	}
 }
 
+type setupReadyRow struct {
+	label string
+	value string
+}
+
+func (m model) setupReadyLines(width int) []string {
+	option := m.setupProvider()
+	model := m.setupCurrentModel()
+	providerName := displayValue(option.Name, option.ID)
+	if name := m.setupProfileName(option); name != "" {
+		providerName = name
+	}
+
+	rows := []setupReadyRow{{label: "provider", value: providerName}}
+	if endpoint := m.setupBaseURL(option); endpoint != "" {
+		rows = append(rows, setupReadyRow{label: "endpoint", value: endpoint})
+	}
+	rows = append(rows,
+		setupReadyRow{label: "model", value: displayValue(model.ID, option.DefaultModel)},
+		setupReadyRow{label: "credentials", value: m.setupCredentialSummary(option)},
+		setupReadyRow{label: "config", value: shortenPath(displayValue(m.setup.configPath, "user config"))},
+	)
+
+	lines := []string{
+		zeroTheme.ink.Bold(true).Render("Ready"),
+		"",
+		"Zero will save this setup and open chat.",
+		"",
+	}
+
+	labelWidth := 0
+	for _, row := range rows {
+		labelWidth = maxInt(labelWidth, lipgloss.Width(row.label)+1)
+	}
+	rowWidth := setupReadyRowsWidth(width, labelWidth, rows)
+	for _, row := range rows {
+		label := fmt.Sprintf("%*s", labelWidth, row.label+":")
+		line := "  " + zeroTheme.faint.Render(label) + "  " + zeroTheme.ink.Render(row.value)
+		lines = append(lines, padSetupLine(line, rowWidth))
+	}
+
+	lines = append(lines,
+		"",
+		zeroTheme.faint.Render("Later, use /provider, /doctor, or /help anytime."),
+	)
+	return lines
+}
+
+func setupReadyRowsWidth(terminalWidth int, labelWidth int, rows []setupReadyRow) int {
+	available := maxInt(28, minInt(terminalWidth-8, 86))
+	target := 0
+	for _, row := range rows {
+		target = maxInt(target, 4+labelWidth+lipgloss.Width(row.value))
+	}
+	return minInt(target, available)
+}
+
 func (m model) setupModelLines(width int, height int) []string {
+	if setupProviderUsesTypedModel(m.setupProvider()) {
+		return m.setupTypedModelLines(width)
+	}
 	m.ensureSetupModels()
 	if m.setup.modelLoad {
 		return m.setupModelLoadingLines(width)
@@ -724,6 +972,19 @@ func (m model) setupModelLines(width int, height int) []string {
 	return lines
 }
 
+func (m model) setupTypedModelLines(width int) []string {
+	option := m.setupProvider()
+	rowWidth := setupTextInputBlockWidth(width, option.DefaultModel)
+	return []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("Choose a model"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+zeroTheme.ink.Render("Enter the model ID this endpoint expects."), rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render("Examples: gpt-4.1, claude-sonnet-4-5, llama-3.3-70b"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+providerWizardInputLine("model > ", strings.TrimSpace(m.setup.modelQuery), option.DefaultModel, rowWidth-2), rowWidth),
+	}
+}
+
 func (m model) setupModelLoadingLines(width int) []string {
 	rowWidth := setupModelLoadingBlockWidth(width)
 	return []string{
@@ -732,6 +993,17 @@ func (m model) setupModelLoadingLines(width int) []string {
 		padSetupLine("  "+zeroTheme.faint.Render("Checking available models..."), rowWidth),
 		padSetupLine("  "+zeroTheme.faint.Render("Built-in models will be used if discovery fails."), rowWidth),
 	}
+}
+
+func setupTextInputBlockWidth(terminalWidth int, values ...string) int {
+	available := maxInt(34, minInt(terminalWidth-8, 72))
+	target := 42
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			target = maxInt(target, lipgloss.Width("  "+value)+8)
+		}
+	}
+	return minInt(target, available)
 }
 
 func setupModelMaxVisible(height int, total int) int {
@@ -837,6 +1109,35 @@ func (m model) setupProviderLines(width int, height int) []string {
 	return lines
 }
 
+func (m model) setupEndpointLines(width int) []string {
+	option := m.setupProvider()
+	provider := setupProviderDescriptor(option)
+	rowWidth := setupTextInputBlockWidth(width, providerWizardEndpointPlaceholder(provider), m.setup.baseURL)
+	return []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("Endpoint URL"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+zeroTheme.ink.Render("Enter the API base URL for "+displayValue(option.Name, option.ID)+"."), rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render(providerWizardEndpointHint(provider)), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+providerWizardInputLine("url > ", strings.TrimSpace(m.setup.baseURL), providerWizardEndpointPlaceholder(provider), rowWidth-2), rowWidth),
+	}
+}
+
+func (m model) setupNameLines(width int) []string {
+	option := m.setupProvider()
+	provider := setupProviderDescriptor(option)
+	name := providerWizardDisplayName(provider, m.setup.baseURL, m.setup.name)
+	rowWidth := setupTextInputBlockWidth(width, name, m.setup.name)
+	return []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("Provider name"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+zeroTheme.ink.Render("Choose the short label shown in Zero."), rowWidth),
+		padSetupLine("  "+zeroTheme.faint.Render("Leave blank to use "+name+"."), rowWidth),
+		blankSetupBlockLine(rowWidth),
+		padSetupLine("  "+providerWizardInputLine("name > ", strings.TrimSpace(m.setup.name), name, rowWidth-2), rowWidth),
+	}
+}
+
 func setupProviderMaxVisible(height int, total int) int {
 	if total <= 0 {
 		return 0
@@ -921,6 +1222,10 @@ func (m model) setupFooter() string {
 	switch m.setup.stage {
 	case setupStageReady:
 		return zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" to save and start chat")
+	case setupStageEndpoint:
+		return zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   left back")
+	case setupStageName:
+		return zeroTheme.faint.Render("name optional   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   left back")
 	case setupStageCredentials:
 		if m.setupCredentialInputActive() {
 			return zeroTheme.faint.Render("paste key optional   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   left back")
@@ -948,8 +1253,16 @@ func centerSetupLines(lines []string, width int) []string {
 	return fitted
 }
 
-func setupProgressText(stage setupStage) string {
-	return zeroTheme.faint.Render(fmt.Sprintf("%d/%d", int(stage)+1, setupStageCount))
+func (m model) setupProgressText() string {
+	stages := m.setupStages()
+	position := 0
+	for index, stage := range stages {
+		if stage == m.setup.stage {
+			position = index
+			break
+		}
+	}
+	return zeroTheme.faint.Render(fmt.Sprintf("%d/%d", position+1, len(stages)))
 }
 
 func padSetupLine(line string, width int) string {

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -85,6 +85,115 @@ func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 	}
 }
 
+func TestSetupTakeoverCustomCompatibleCollectsEndpointNameAndModel(t *testing.T) {
+	var saved SetupSelection
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "custom-openai-compatible", Name: "Custom OpenAI-compatible", DefaultModel: "custom-model", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+			Save: func(selection SetupSelection) (SetupResult, error) {
+				saved = selection
+				return SetupResult{
+					ConfigPath: "/tmp/zero/config.json",
+					Provider: config.ProviderProfile{
+						Name:      selection.Name,
+						CatalogID: selection.CatalogID,
+						BaseURL:   selection.BaseURL,
+						Model:     selection.Model,
+					},
+				}, nil
+			},
+		},
+	})
+	m.width = 100
+	m.height = 30
+
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageProvider {
+		t.Fatalf("stage = %v, want provider", m.setup.stage)
+	}
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageEndpoint {
+		t.Fatalf("stage = %v, want endpoint", m.setup.stage)
+	}
+	view := plainRender(t, m.View())
+	assertContains(t, view, "Endpoint URL")
+	assertContains(t, view, "url >")
+	assertContains(t, view, "https://api.example.com/v1")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.setup.stage != setupStageEndpoint {
+		t.Fatalf("blank endpoint advanced to %v, want endpoint", m.setup.stage)
+	}
+	assertContains(t, plainRender(t, m.View()), "enter an endpoint URL")
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("https://api.minimax.io/v1")})
+	m = updated.(model)
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageName {
+		t.Fatalf("stage = %v, want name", m.setup.stage)
+	}
+	view = plainRender(t, m.View())
+	assertContains(t, view, "Provider name")
+	assertContains(t, view, "name >")
+	assertContains(t, view, "minimax")
+
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageCredentials {
+		t.Fatalf("stage = %v, want credentials", m.setup.stage)
+	}
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageModel {
+		t.Fatalf("stage = %v, want model", m.setup.stage)
+	}
+	view = plainRender(t, m.View())
+	assertContains(t, view, "Choose a model")
+	assertContains(t, view, "model >")
+	assertContains(t, view, "custom-model")
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.setup.stage != setupStageModel {
+		t.Fatalf("blank model advanced to %v, want model", m.setup.stage)
+	}
+	assertContains(t, plainRender(t, m.View()), "Enter a model name")
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("MiniMax-M3")})
+	m = updated.(model)
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageSafety {
+		t.Fatalf("stage = %v, want safety", m.setup.stage)
+	}
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageReady {
+		t.Fatalf("stage = %v, want ready", m.setup.stage)
+	}
+	view = plainRender(t, m.View())
+	assertContains(t, view, "provider:  minimax")
+	assertContains(t, view, "endpoint:  https://api.minimax.io/v1")
+	assertContains(t, view, "model:  MiniMax-M3")
+
+	m = pressSetupContinue(m)
+	if m.setup.visible {
+		t.Fatal("setup should hide after saving custom provider")
+	}
+	if saved.CatalogID != "custom-openai-compatible" {
+		t.Fatalf("saved CatalogID = %q, want custom-openai-compatible", saved.CatalogID)
+	}
+	if saved.Name != "minimax" {
+		t.Fatalf("saved Name = %q, want minimax", saved.Name)
+	}
+	if saved.BaseURL != "https://api.minimax.io/v1" {
+		t.Fatalf("saved BaseURL = %q, want endpoint", saved.BaseURL)
+	}
+	if saved.Model != "MiniMax-M3" {
+		t.Fatalf("saved Model = %q, want typed model", saved.Model)
+	}
+}
+
 func TestSetupCompletionResetsChatSurfaceInsideAltScreen(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
@@ -1113,7 +1222,7 @@ func TestSetupReadyFooterUsesEnter(t *testing.T) {
 func pressSetupContinue(m model) model {
 	var updated tea.Model
 	var cmd tea.Cmd
-	if m.setup.stage == setupStageProvider || m.setupCredentialInputActive() || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
+	if m.setup.stage == setupStageProvider || m.setupEndpointInputActive() || m.setupNameInputActive() || m.setupCredentialInputActive() || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
 		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	} else {
 		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -569,6 +569,30 @@ func TestSetupCredentialsAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T)
 	}
 }
 
+func TestSetupCredentialsCtrlVDoesNotRunClipboardPaste(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "ollama-cloud", Name: "Ollama Cloud", DefaultModel: "qwen3-coder:480b", EnvVar: "OLLAMA_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.setup.stage = setupStageCredentials
+	m.setup.apiKey.SetValue("existing")
+	m.setup.apiKey.CursorEnd()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlV})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("ctrl+v should not run the setup input clipboard paste command")
+	}
+	if got := next.setup.apiKey.Value(); got != "existing" {
+		t.Fatalf("setup API key after ctrl+v = %q, want unchanged", got)
+	}
+}
+
 func TestSetupModelStepSavesCatalogModelChoice(t *testing.T) {
 	var saved SetupSelection
 	m := newModel(context.Background(), Options{

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -74,6 +74,8 @@ type SetupProviderOption struct {
 // SetupSelection is the user's setup choice.
 type SetupSelection struct {
 	CatalogID string
+	Name      string
+	BaseURL   string
 	Model     string
 	APIKey    string
 }

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"net/url"
 	"os"
 	"strings"
 	"unicode"
@@ -24,6 +25,8 @@ type providerWizardStep int
 
 const (
 	providerWizardStepProvider providerWizardStep = iota
+	providerWizardStepEndpoint
+	providerWizardStepName
 	providerWizardStepCredential
 	providerWizardStepModel
 	providerWizardStepDone
@@ -42,6 +45,8 @@ type providerWizardState struct {
 	models           []providerWizardModel
 	selectedModel    int
 	modelSearch      string
+	baseURL          string
+	profileName      string
 	apiKey           string
 	err              string
 	modelSource      string
@@ -84,6 +89,13 @@ func (wizard *providerWizardState) currentModel() providerWizardModel {
 	if wizard == nil {
 		return providerWizardModel{}
 	}
+	if providerWizardUsesTypedModel(wizard.currentProvider()) {
+		modelID := strings.TrimSpace(wizard.modelSearch)
+		if modelID == "" {
+			return providerWizardModel{Description: "model name required"}
+		}
+		return providerWizardModel{ID: modelID, Description: "custom model"}
+	}
 	wizard.refreshModels()
 	models := wizard.filteredModels()
 	if len(models) == 0 {
@@ -105,6 +117,8 @@ func (wizard *providerWizardState) move(delta int) {
 		wizard.selectedProvider = ((wizard.selectedProvider+delta)%len(wizard.providers) + len(wizard.providers)) % len(wizard.providers)
 		wizard.selectedModel = 0
 		wizard.modelSearch = ""
+		wizard.baseURL = ""
+		wizard.profileName = ""
 		wizard.apiKey = ""
 		wizard.err = ""
 		wizard.modelSource = ""
@@ -129,6 +143,22 @@ func (wizard *providerWizardState) advance() {
 	case providerWizardStepProvider:
 		wizard.refreshModels()
 		wizard.err = ""
+		if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+			wizard.step = providerWizardStepEndpoint
+		} else if providerWizardNeedsCredential(wizard.currentProvider()) {
+			wizard.step = providerWizardStepCredential
+		} else {
+			wizard.step = providerWizardStepModel
+		}
+	case providerWizardStepEndpoint:
+		wizard.err = ""
+		if err := providerWizardEndpointError(wizard.baseURL); err != "" {
+			wizard.err = err
+			return
+		}
+		wizard.step = providerWizardStepName
+	case providerWizardStepName:
+		wizard.err = ""
 		if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
 		} else {
@@ -139,6 +169,14 @@ func (wizard *providerWizardState) advance() {
 		wizard.step = providerWizardStepModel
 	case providerWizardStepModel:
 		wizard.err = ""
+		if providerWizardUsesTypedModel(wizard.currentProvider()) {
+			if strings.TrimSpace(wizard.modelSearch) == "" {
+				wizard.err = "enter a model name before continuing"
+				return
+			}
+			wizard.step = providerWizardStepDone
+			return
+		}
 		if wizard.modelLoading {
 			wizard.err = "Models are still loading."
 			return
@@ -160,11 +198,23 @@ func (wizard *providerWizardState) retreat() {
 	}
 	wizard.err = ""
 	switch wizard.step {
-	case providerWizardStepCredential:
+	case providerWizardStepEndpoint:
 		wizard.step = providerWizardStepProvider
+	case providerWizardStepName:
+		wizard.step = providerWizardStepEndpoint
+	case providerWizardStepCredential:
+		if providerWizardNeedsProfileName(wizard.currentProvider()) {
+			wizard.step = providerWizardStepName
+		} else if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+			wizard.step = providerWizardStepEndpoint
+		} else {
+			wizard.step = providerWizardStepProvider
+		}
 	case providerWizardStepModel:
 		if providerWizardNeedsCredential(wizard.currentProvider()) {
 			wizard.step = providerWizardStepCredential
+		} else if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+			wizard.step = providerWizardStepEndpoint
 		} else {
 			wizard.step = providerWizardStepProvider
 		}
@@ -178,6 +228,9 @@ func (wizard *providerWizardState) refreshModels() {
 		return
 	}
 	provider := wizard.currentProvider()
+	if providerWizardUsesTypedModel(provider) {
+		return
+	}
 	if wizard.modelSource != "" && wizard.modelSource != "fallback" {
 		wizard.selectedModel = clampInt(wizard.selectedModel, 0, maxInt(0, len(wizard.models)-1))
 		return
@@ -208,9 +261,69 @@ func providerWizardNeedsCredential(provider providercatalog.Descriptor) bool {
 	return provider.RequiresAuth && !provider.Local && len(provider.AuthEnvVars) > 0
 }
 
+func providerWizardNeedsEndpoint(provider providercatalog.Descriptor) bool {
+	switch provider.ID {
+	case "custom-openai-compatible", "custom-anthropic-compatible":
+		return true
+	default:
+		return false
+	}
+}
+
+func providerWizardUsesTypedModel(provider providercatalog.Descriptor) bool {
+	return providerWizardNeedsEndpoint(provider)
+}
+
+func providerWizardNeedsProfileName(provider providercatalog.Descriptor) bool {
+	return providerWizardNeedsEndpoint(provider)
+}
+
 func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 	if m.providerWizard == nil {
 		return m, nil
+	}
+	if m.providerWizard.step == providerWizardStepEndpoint {
+		switch msg.Type {
+		case tea.KeyRunes:
+			m.providerWizard.appendBaseURL(msg.Runes)
+			return m, nil
+		case tea.KeyBackspace, tea.KeyCtrlH:
+			m.providerWizard.deleteBaseURLRune()
+			return m, nil
+		case tea.KeyCtrlU:
+			m.providerWizard.baseURL = ""
+			m.providerWizard.err = ""
+			return m, nil
+		case tea.KeyLeft:
+			m.providerWizard.retreat()
+			return m, nil
+		case tea.KeyRight:
+			if m.providerWizard.canAdvanceWithRight() {
+				return m.advanceProviderWizard()
+			}
+			return m, nil
+		case tea.KeyEnter:
+			return m.advanceProviderWizard()
+		}
+	}
+	if m.providerWizard.step == providerWizardStepName {
+		switch msg.Type {
+		case tea.KeyRunes:
+			m.providerWizard.appendProfileName(msg.Runes)
+			return m, nil
+		case tea.KeyBackspace, tea.KeyCtrlH:
+			m.providerWizard.deleteProfileNameRune()
+			return m, nil
+		case tea.KeyCtrlU:
+			m.providerWizard.profileName = ""
+			m.providerWizard.err = ""
+			return m, nil
+		case tea.KeyLeft:
+			m.providerWizard.retreat()
+			return m, nil
+		case tea.KeyRight, tea.KeyEnter:
+			return m.advanceProviderWizard()
+		}
 	}
 	if m.providerWizard.step == providerWizardStepCredential {
 		switch msg.Type {
@@ -282,9 +395,16 @@ func (wizard *providerWizardState) canAdvanceWithRight() bool {
 	switch wizard.step {
 	case providerWizardStepProvider:
 		return strings.TrimSpace(wizard.currentProvider().ID) != ""
+	case providerWizardStepEndpoint:
+		return providerWizardEndpointError(wizard.baseURL) == ""
+	case providerWizardStepName:
+		return true
 	case providerWizardStepCredential:
 		return wizard.credentialReadyForRight()
 	case providerWizardStepModel:
+		if providerWizardUsesTypedModel(wizard.currentProvider()) {
+			return strings.TrimSpace(wizard.modelSearch) != ""
+		}
 		if wizard.modelLoading {
 			return false
 		}
@@ -330,6 +450,44 @@ func (wizard *providerWizardState) deleteAPIKeyRune() {
 	wizard.err = ""
 }
 
+func (wizard *providerWizardState) appendBaseURL(runes []rune) {
+	for _, r := range runes {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			continue
+		}
+		wizard.baseURL += string(r)
+	}
+	wizard.err = ""
+}
+
+func (wizard *providerWizardState) deleteBaseURLRune() {
+	if wizard.baseURL == "" {
+		return
+	}
+	runes := []rune(wizard.baseURL)
+	wizard.baseURL = string(runes[:len(runes)-1])
+	wizard.err = ""
+}
+
+func (wizard *providerWizardState) appendProfileName(runes []rune) {
+	for _, r := range runes {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			continue
+		}
+		wizard.profileName += string(r)
+	}
+	wizard.err = ""
+}
+
+func (wizard *providerWizardState) deleteProfileNameRune() {
+	if wizard.profileName == "" {
+		return
+	}
+	runes := []rune(wizard.profileName)
+	wizard.profileName = string(runes[:len(runes)-1])
+	wizard.err = ""
+}
+
 func (wizard *providerWizardState) appendModelSearch(runes []rune) {
 	for _, r := range runes {
 		if unicode.IsControl(r) {
@@ -356,7 +514,7 @@ func (m model) applyProviderWizard() (model, tea.Cmd) {
 	}
 	provider := wizard.currentProvider()
 	modelChoice := wizard.currentModel()
-	profile := providerWizardProfile(provider, modelChoice.ID, wizard.apiKey)
+	profile := providerWizardProfile(provider, modelChoice.ID, wizard.apiKey, wizard.baseURL, wizard.profileName)
 	runtimeProfile := providerWizardRuntimeProfile(profile)
 	if m.newProvider != nil {
 		nextProvider, err := m.newProvider(runtimeProfile)
@@ -402,7 +560,7 @@ func (wizard *providerWizardState) render(width int) string {
 	innerWidth := maxInt(20, overlayWidth-4)
 
 	lines := []string{
-		zeroTheme.faint.Render(providerWizardStepLine(wizard.step)),
+		zeroTheme.faint.Render(providerWizardStepLine(wizard)),
 		zeroTheme.line.Render(strings.Repeat("─", innerWidth)),
 	}
 	if wizard.err != "" {
@@ -411,6 +569,10 @@ func (wizard *providerWizardState) render(width int) string {
 	switch wizard.step {
 	case providerWizardStepProvider:
 		lines = append(lines, wizard.renderProviderStep(innerWidth)...)
+	case providerWizardStepEndpoint:
+		lines = append(lines, wizard.renderEndpointStep(innerWidth)...)
+	case providerWizardStepName:
+		lines = append(lines, wizard.renderNameStep(innerWidth)...)
 	case providerWizardStepCredential:
 		lines = append(lines, wizard.renderCredentialStep(innerWidth)...)
 	case providerWizardStepModel:
@@ -438,6 +600,13 @@ func (wizard *providerWizardState) footer() string {
 			return "↑/↓ move   Enter/→ continue   Esc close"
 		}
 		return "↑/↓ move   Enter continue   Esc close"
+	case providerWizardStepEndpoint:
+		if canRight {
+			return "Enter/→ continue   ← back   Esc close"
+		}
+		return "Enter continue   ← back   Esc close"
+	case providerWizardStepName:
+		return "Enter/→ continue   ← back   Esc close"
 	case providerWizardStepModel:
 		if canRight {
 			return "↑/↓ move   Enter/→ continue   ← back   Esc close"
@@ -471,15 +640,55 @@ func providerWizardOverlayWidth(width int, step providerWizardStep) int {
 	return target
 }
 
-func providerWizardStepLine(step providerWizardStep) string {
+func providerWizardStepLine(wizard *providerWizardState) string {
+	if wizard == nil {
+		return ""
+	}
+	step := wizard.step
 	steps := []struct {
 		step  providerWizardStep
 		label string
 	}{
 		{providerWizardStepProvider, "1 provider"},
-		{providerWizardStepCredential, "2 key"},
-		{providerWizardStepModel, "3 model"},
-		{providerWizardStepDone, "4 ready"},
+	}
+	if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+		steps = append(steps,
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepEndpoint, "2 endpoint"},
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepName, "3 name"},
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepCredential, "4 key"},
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepModel, "5 model"},
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepDone, "6 ready"},
+		)
+	} else {
+		steps = append(steps,
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepCredential, "2 key"},
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepModel, "3 model"},
+			struct {
+				step  providerWizardStep
+				label string
+			}{providerWizardStepDone, "4 ready"},
+		)
 	}
 	parts := make([]string, 0, len(steps))
 	for _, item := range steps {
@@ -514,6 +723,41 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 	return fitStyledLine(left, width)
 }
 
+func (wizard *providerWizardState) renderEndpointStep(width int) []string {
+	provider := wizard.currentProvider()
+	input := providerWizardInputLine("url > ", wizard.baseURL, providerWizardEndpointPlaceholder(provider), width)
+	return []string{
+		zeroTheme.accent.Render("Endpoint URL"),
+		zeroTheme.ink.Render("Enter the API base URL for " + provider.Name + "."),
+		zeroTheme.faint.Render(providerWizardEndpointHint(provider)),
+		input,
+	}
+}
+
+func providerWizardEndpointPlaceholder(provider providercatalog.Descriptor) string {
+	if provider.Transport == providercatalog.TransportAnthropicCompatible {
+		return "https://api.example.com/anthropic"
+	}
+	return "https://api.example.com/v1"
+}
+
+func providerWizardEndpointHint(provider providercatalog.Descriptor) string {
+	if provider.Transport == providercatalog.TransportAnthropicCompatible {
+		return "Use the base URL before /v1/messages."
+	}
+	return "Use the base URL before /chat/completions."
+}
+
+func (wizard *providerWizardState) renderNameStep(width int) []string {
+	name := providerWizardDisplayName(wizard.currentProvider(), wizard.baseURL, wizard.profileName)
+	return []string{
+		zeroTheme.accent.Render("Provider name"),
+		zeroTheme.ink.Render("Choose the short label shown in the status bar."),
+		zeroTheme.faint.Render("Leave blank to use " + name + "."),
+		providerWizardInputLine("name > ", strings.TrimSpace(wizard.profileName), name, width),
+	}
+}
+
 func (wizard *providerWizardState) renderCredentialStep(width int) []string {
 	provider := wizard.currentProvider()
 	env := firstProviderDisplayValue(provider.AuthEnvVars...)
@@ -538,6 +782,9 @@ func providerWizardCredentialInstruction(env string) string {
 }
 
 func (wizard *providerWizardState) renderModelStep(width int) []string {
+	if providerWizardUsesTypedModel(wizard.currentProvider()) {
+		return wizard.renderTypedModelStep(width)
+	}
 	if wizard.modelLoading {
 		return wizard.renderModelLoadingStep(width)
 	}
@@ -575,12 +822,29 @@ func (wizard *providerWizardState) renderModelLoadingStep(width int) []string {
 
 func (wizard *providerWizardState) renderModelSearch(width int) string {
 	query := strings.TrimSpace(wizard.modelSearch)
+	return providerWizardInputLine("search > ", query, "model name...", width)
+}
+
+func providerWizardInputLine(promptText string, value string, placeholder string, width int) string {
 	prompt := zeroTheme.userPrompt.Render("search > ")
 	cursor := zeroTheme.accent.Render("▌")
-	if query == "" {
-		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render("model name..."), width)
+	if promptText != "" {
+		prompt = zeroTheme.userPrompt.Render(promptText)
 	}
-	return fitStyledLine(prompt+zeroTheme.ink.Render(query)+cursor, width)
+	if value == "" {
+		return fitStyledLine(prompt+cursor+zeroTheme.faint.Render(placeholder), width)
+	}
+	return fitStyledLine(prompt+zeroTheme.ink.Render(value)+cursor, width)
+}
+
+func (wizard *providerWizardState) renderTypedModelStep(width int) []string {
+	provider := wizard.currentProvider()
+	return []string{
+		zeroTheme.accent.Render("Model name"),
+		zeroTheme.ink.Render("Enter the model ID this endpoint expects."),
+		zeroTheme.faint.Render("Examples: gpt-4.1, claude-sonnet-4-5, llama-3.3-70b"),
+		providerWizardInputLine("model > ", strings.TrimSpace(wizard.modelSearch), provider.DefaultModel, width),
+	}
 }
 
 func (wizard *providerWizardState) modelStatusText() string {
@@ -665,15 +929,22 @@ func providerWizardGenericModelDescription(description string) bool {
 func (wizard *providerWizardState) renderDoneStep(width int) []string {
 	provider := wizard.currentProvider()
 	model := wizard.currentModel()
-	return []string{
+	lines := []string{
 		zeroTheme.accent.Render("Ready to connect"),
 		"",
 		zeroTheme.ink.Render("Provider    " + provider.Name),
-		zeroTheme.ink.Render("Model       " + model.ID),
-		zeroTheme.ink.Render("Credential  " + providerWizardCredentialLabel(provider, wizard.apiKey)),
+	}
+	if providerWizardNeedsEndpoint(provider) {
+		lines = append(lines, zeroTheme.ink.Render("Endpoint    "+strings.TrimSpace(wizard.baseURL)))
+	}
+	lines = append(lines,
+		zeroTheme.ink.Render("Name        "+providerWizardDisplayName(provider, wizard.baseURL, wizard.profileName)),
+		zeroTheme.ink.Render("Model       "+model.ID),
+		zeroTheme.ink.Render("Credential  "+providerWizardCredentialLabel(provider, wizard.apiKey)),
 		"",
 		zeroTheme.faint.Render("Press Enter to save and start using this provider."),
-	}
+	)
+	return lines
 }
 
 func providerWizardCredentialLabel(provider providercatalog.Descriptor, apiKey string) string {
@@ -697,12 +968,12 @@ func maskedProviderWizardKey(value string) string {
 	return strings.Repeat("*", count)
 }
 
-func providerWizardProfile(provider providercatalog.Descriptor, model string, apiKey string) config.ProviderProfile {
+func providerWizardProfile(provider providercatalog.Descriptor, model string, apiKey string, baseURL string, profileName string) config.ProviderProfile {
 	profile := config.ProviderProfile{
-		Name:         provider.ID,
+		Name:         providerWizardDisplayName(provider, baseURL, profileName),
 		ProviderKind: providerWizardProviderKind(provider),
 		CatalogID:    provider.ID,
-		BaseURL:      provider.DefaultBaseURL,
+		BaseURL:      firstProviderDisplayValue(strings.TrimSpace(baseURL), provider.DefaultBaseURL),
 		APIFormat:    providerWizardAPIFormat(provider),
 		Model:        firstProviderDisplayValue(model, provider.DefaultModel),
 	}
@@ -712,6 +983,49 @@ func providerWizardProfile(provider providercatalog.Descriptor, model string, ap
 		profile.APIKeyEnv = env
 	}
 	return profile
+}
+
+func providerWizardEndpointError(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "enter an endpoint URL before continuing"
+	}
+	parsed, err := url.ParseRequestURI(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "enter a valid endpoint URL including https://"
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return "endpoint URL must start with http:// or https://"
+	}
+	return ""
+}
+
+func providerWizardDisplayName(provider providercatalog.Descriptor, baseURL string, profileName string) string {
+	if name := strings.TrimSpace(profileName); name != "" {
+		return name
+	}
+	if providerWizardNeedsProfileName(provider) {
+		return providerWizardNameFromBaseURL(baseURL)
+	}
+	return provider.ID
+}
+
+func providerWizardNameFromBaseURL(baseURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed.Host == "" {
+		return "custom"
+	}
+	host := strings.ToLower(parsed.Hostname())
+	host = strings.TrimPrefix(host, "api.")
+	host = strings.TrimPrefix(host, "gateway.")
+	parts := strings.Split(host, ".")
+	if len(parts) >= 2 {
+		return parts[len(parts)-2]
+	}
+	if host != "" {
+		return strings.ReplaceAll(host, ":", "-")
+	}
+	return "custom"
 }
 
 func providerWizardProviderKind(provider providercatalog.Descriptor) config.ProviderKind {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -997,7 +998,19 @@ func providerWizardEndpointError(value string) string {
 	if parsed.Scheme != "https" && parsed.Scheme != "http" {
 		return "endpoint URL must start with http:// or https://"
 	}
+	if parsed.Scheme == "http" && !providerWizardIsLoopbackHost(parsed.Hostname()) {
+		return "endpoint URL must use https:// unless it is local loopback"
+	}
 	return ""
+}
+
+func providerWizardIsLoopbackHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func providerWizardDisplayName(provider providercatalog.Descriptor, baseURL string, profileName string) string {
@@ -1016,6 +1029,9 @@ func providerWizardNameFromBaseURL(baseURL string) string {
 		return "custom"
 	}
 	host := strings.ToLower(parsed.Hostname())
+	if ip := net.ParseIP(host); ip != nil {
+		return providerWizardSanitizedName("ip-" + ip.String())
+	}
 	host = strings.TrimPrefix(host, "api.")
 	host = strings.TrimPrefix(host, "gateway.")
 	parts := strings.Split(host, ".")
@@ -1026,6 +1042,24 @@ func providerWizardNameFromBaseURL(baseURL string) string {
 		return strings.ReplaceAll(host, ":", "-")
 	}
 	return "custom"
+}
+
+func providerWizardSanitizedName(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash && builder.Len() > 0 {
+			builder.WriteRune('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
 }
 
 func providerWizardProviderKind(provider providercatalog.Descriptor) config.ProviderKind {

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -42,6 +42,9 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 	if !providerWizardCatalogDiscoveryAllowed(provider) {
 		return nil
 	}
+	if providerWizardUsesTypedModel(provider) {
+		return nil
+	}
 	profile := providerWizardDiscoveryProfile(provider, wizard.apiKey)
 	discover := m.discoverProviderModels
 	if discover == nil {
@@ -118,7 +121,7 @@ func providerWizardModelsSource(models []providermodeldiscovery.Model) string {
 }
 
 func providerWizardDiscoveryProfile(provider providercatalog.Descriptor, apiKey string) config.ProviderProfile {
-	profile := providerWizardProfile(provider, provider.DefaultModel, apiKey)
+	profile := providerWizardProfile(provider, provider.DefaultModel, apiKey, "", "")
 	if strings.TrimSpace(profile.APIKey) == "" && strings.TrimSpace(profile.APIKeyEnv) != "" {
 		profile.APIKey = strings.TrimSpace(os.Getenv(profile.APIKeyEnv))
 	}

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -319,6 +319,128 @@ func TestProviderWizardRightAllowsExistingCredentialEnv(t *testing.T) {
 	}
 }
 
+func TestProviderWizardCustomCompatibleProviderCollectsEndpointAndModel(t *testing.T) {
+	var captured config.ProviderProfile
+	m := newModel(context.Background(), Options{
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			captured = profile
+			return &fakeProvider{}, nil
+		},
+	})
+	m = openProviderWizardForTest(t, m)
+	m.providerWizard.selectedProvider = providerWizardProviderIndex(t, m.providerWizard, "custom-openai-compatible")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("custom endpoint step should not start model discovery")
+	}
+	if next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("custom provider first step = %v, want endpoint", next.providerWizard.step)
+	}
+	view := plainRender(t, next.View())
+	for _, want := range []string{
+		"Endpoint URL",
+		"url >",
+		"https://api.example.com/v1",
+		"2 endpoint",
+	} {
+		assertContains(t, view, want)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("blank endpoint advanced to %v, want endpoint", next.providerWizard.step)
+	}
+	assertContains(t, plainRender(t, next.View()), "enter an endpoint URL")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("https://proxy.example/v1")})
+	next = updated.(model)
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("endpoint step should not start model discovery")
+	}
+	if next.providerWizard.step != providerWizardStepName {
+		t.Fatalf("endpoint step advanced to %v, want name", next.providerWizard.step)
+	}
+	view = plainRender(t, next.View())
+	for _, want := range []string{
+		"Provider name",
+		"name >",
+		"proxy",
+	} {
+		assertContains(t, view, want)
+	}
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("name step should not start model discovery")
+	}
+	if next.providerWizard.step != providerWizardStepCredential {
+		t.Fatalf("name step advanced to %v, want credential", next.providerWizard.step)
+	}
+
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("custom model step should not discover against the placeholder endpoint")
+	}
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("credential step advanced to %v, want model", next.providerWizard.step)
+	}
+	view = plainRender(t, next.View())
+	for _, want := range []string{
+		"Model name",
+		"model >",
+		"custom-model",
+	} {
+		assertContains(t, view, want)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("blank model advanced to %v, want model", next.providerWizard.step)
+	}
+	assertContains(t, plainRender(t, next.View()), "enter a model name")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("my-custom-model")})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepDone {
+		t.Fatalf("model step advanced to %v, want ready", next.providerWizard.step)
+	}
+	view = plainRender(t, next.View())
+	assertContains(t, view, "Endpoint    https://proxy.example/v1")
+	assertContains(t, view, "Name        proxy")
+	assertContains(t, view, "Model       my-custom-model")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard != nil {
+		t.Fatal("saving custom provider should close the wizard")
+	}
+	if captured.CatalogID != "custom-openai-compatible" || captured.ProviderKind != config.ProviderKindOpenAICompatible {
+		t.Fatalf("captured provider identity = %#v", captured)
+	}
+	if captured.Name != "proxy" {
+		t.Fatalf("captured Name = %q, want derived endpoint name", captured.Name)
+	}
+	if captured.BaseURL != "https://proxy.example/v1" {
+		t.Fatalf("captured BaseURL = %q, want custom endpoint", captured.BaseURL)
+	}
+	if captured.Model != "my-custom-model" {
+		t.Fatalf("captured Model = %q, want typed model", captured.Model)
+	}
+	if captured.APIKeyEnv != "OPENAI_API_KEY" {
+		t.Fatalf("captured APIKeyEnv = %q, want OPENAI_API_KEY fallback", captured.APIKeyEnv)
+	}
+}
+
 func TestProviderWizardSkipsAPIKeyForLocalProvidersAndEscCloses(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = openProviderWizardForTest(t, m)

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -441,6 +441,76 @@ func TestProviderWizardCustomCompatibleProviderCollectsEndpointAndModel(t *testi
 	}
 }
 
+func TestProviderWizardCustomCompatibleProviderRejectsRemoteHTTP(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+	m.providerWizard.selectedProvider = providerWizardProviderIndex(t, m.providerWizard, "custom-openai-compatible")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("custom provider first step = %v, want endpoint", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("http://api.example.com/v1")})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("remote http endpoint advanced to %v, want endpoint", next.providerWizard.step)
+	}
+	assertContains(t, plainRender(t, next.View()), "endpoint URL must use https:// unless it is local loopback")
+}
+
+func TestProviderWizardCustomCompatibleProviderDerivesIPName(t *testing.T) {
+	var captured config.ProviderProfile
+	m := newModel(context.Background(), Options{
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			captured = profile
+			return &fakeProvider{}, nil
+		},
+	})
+	m = openProviderWizardForTest(t, m)
+	m.providerWizard.selectedProvider = providerWizardProviderIndex(t, m.providerWizard, "custom-openai-compatible")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("https://127.0.0.1:1234/v1")})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepName {
+		t.Fatalf("endpoint step advanced to %v, want name", next.providerWizard.step)
+	}
+	assertContains(t, plainRender(t, next.View()), "ip-127-0-0-1")
+
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("local-test-model")})
+	next = updated.(model)
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepDone {
+		t.Fatalf("model step advanced to %v, want ready", next.providerWizard.step)
+	}
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	if next.providerWizard != nil {
+		t.Fatal("saving custom provider should close the wizard")
+	}
+	if captured.Name != "ip-127-0-0-1" {
+		t.Fatalf("captured Name = %q, want sanitized IP name", captured.Name)
+	}
+	if captured.BaseURL != "https://127.0.0.1:1234/v1" {
+		t.Fatalf("captured BaseURL = %q, want IP endpoint", captured.BaseURL)
+	}
+	if captured.Model != "local-test-model" {
+		t.Fatalf("captured Model = %q, want typed model", captured.Model)
+	}
+}
+
 func TestProviderWizardSkipsAPIKeyForLocalProvidersAndEscCloses(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = openProviderWizardForTest(t, m)

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 )
@@ -789,6 +790,32 @@ func TestTitleBarShowsBadgeAndModel(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("title bar = %q, missing %q", got, want)
 		}
+	}
+}
+
+func TestGenericCustomProviderDisplayUsesEndpointName(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderName: "custom-openai-compatible",
+		ModelName:    "MiniMax-M3",
+		ProviderProfile: config.ProviderProfile{
+			Name:      "custom-openai-compatible",
+			CatalogID: "custom-openai-compatible",
+			BaseURL:   "https://api.minimax.io/v1",
+			Model:     "MiniMax-M3",
+		},
+	})
+
+	title := plainRender(t, m.titleBar(120))
+	if !strings.Contains(title, "minimax/MiniMax-M3") {
+		t.Fatalf("title bar = %q, want derived custom provider label", title)
+	}
+	if strings.Contains(title, "custom-openai-compatible/MiniMax-M3") {
+		t.Fatalf("title bar = %q, should not show generic custom catalog id", title)
+	}
+
+	status := plainRender(t, m.statusLine(100))
+	if !strings.Contains(status, "● minimax") {
+		t.Fatalf("status line = %q, want derived custom provider label", status)
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -673,13 +673,13 @@ func TestComposerLineTracksRunState(t *testing.T) {
 	}
 
 	m.pending = true
-	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, "esc stop") {
-		t.Fatalf("pending composer = %q, want esc stop hint", got)
+	if got := plainRender(t, m.composerLine(96)); strings.Contains(got, "esc stop") || strings.Contains(got, "esc to interrupt") {
+		t.Fatalf("pending composer = %q, should not show stop hint", got)
 	}
 
 	m.input.SetValue("")
-	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, composerPlaceholderRunning) {
-		t.Fatalf("pending empty composer = %q, want running placeholder", got)
+	if got := plainRender(t, m.composerLine(96)); !strings.Contains(got, composerPlaceholder) || strings.Contains(got, "running") || strings.Contains(got, "stop") || strings.Contains(got, "interrupt") {
+		t.Fatalf("pending empty composer = %q, should show normal placeholder without run status text", got)
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -733,6 +733,39 @@ func TestComposerBoxFramesInputAndBottomModelModeLabel(t *testing.T) {
 	assertRenderedLineWidths(t, got, 96)
 }
 
+func TestComposerBoxWrapsLongPrompt(t *testing.T) {
+	m := limeTestModel()
+	m.input.SetValue("Create a book library dashboard page with the Bootstrap 5.3 theme displaying a grid of book cards showing cover images, titles, authors, and reading progress bars.")
+	m.input.CursorEnd()
+
+	got := plainRender(t, m.composerBox(72))
+	if !strings.Contains(got, "Bootstrap 5.3") || !strings.Contains(got, "reading progress bars") {
+		t.Fatalf("composer box should show wrapped long prompt, got:\n%s", got)
+	}
+	if lineCount := len(strings.Split(got, "\n")); lineCount < 5 {
+		t.Fatalf("composer box line count = %d, want wrapped multi-line box:\n%s", lineCount, got)
+	}
+	assertRenderedLineWidths(t, got, 72)
+}
+
+func TestComposerBoxCapsLongPromptHeightAroundCursor(t *testing.T) {
+	m := limeTestModel()
+	m.input.SetValue(strings.Repeat("alpha beta gamma delta ", 12) + "final words")
+	m.input.CursorEnd()
+
+	got := plainRender(t, m.composerBox(44))
+	if lineCount := len(strings.Split(got, "\n")); lineCount != composerMaxVisibleLines+2 {
+		t.Fatalf("composer box line count = %d, want %d:\n%s", lineCount, composerMaxVisibleLines+2, got)
+	}
+	if !strings.Contains(got, "final words") {
+		t.Fatalf("composer box should keep cursor-adjacent tail visible, got:\n%s", got)
+	}
+	if !strings.Contains(got, "❯") {
+		t.Fatalf("composer box should keep the prompt marker visible when capped, got:\n%s", got)
+	}
+	assertRenderedLineWidths(t, got, 44)
+}
+
 func TestMalformedAskUserToolResultIsHiddenFromChatSurface(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -32,6 +32,29 @@ func TestMouseWheelScrollsChatWithoutRecallingInputHistory(t *testing.T) {
 	}
 }
 
+func TestMouseWheelOverWrappedComposerMovesComposerCursor(t *testing.T) {
+	text := "Create a book library dashboard page with cards, filters, charts, and responsive behavior."
+	m := newModel(context.Background(), Options{AltScreen: true})
+	m.width = 44
+	m.height = 20
+	m.mouseCapture = true
+	m.input.SetValue(text)
+	m.input.CursorEnd()
+	startCursor := len([]rune(text))
+
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp, Y: 14})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("mouse wheel over composer should not return a command")
+	}
+	if next.chatScrollOffset != 0 {
+		t.Fatalf("chatScrollOffset = %d, want unchanged", next.chatScrollOffset)
+	}
+	if got := next.currentComposerState().cursor; got >= startCursor {
+		t.Fatalf("composer cursor = %d, want moved before end cursor %d", got, startCursor)
+	}
+}
+
 func TestAltScreenTranscriptScrollKeepsFooterFixed(t *testing.T) {
 	m := newModel(context.Background(), Options{AltScreen: true, ProviderName: "openai", ModelName: "gpt-4.1"})
 	m.width = 90

--- a/internal/tui/scroll_test.go
+++ b/internal/tui/scroll_test.go
@@ -55,6 +55,26 @@ func TestMouseWheelOverWrappedComposerMovesComposerCursor(t *testing.T) {
 	}
 }
 
+func TestMouseWheelOnClippedFooterStatusDoesNotMoveComposerCursor(t *testing.T) {
+	text := "Create a book library dashboard page with cards, filters, charts, and responsive behavior."
+	m := newModel(context.Background(), Options{AltScreen: true})
+	m.width = 44
+	m.height = 3
+	m.mouseCapture = true
+	m.input.SetValue(text)
+	m.input.CursorEnd()
+	startCursor := len([]rune(text))
+
+	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp, Y: m.height - 1})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("mouse wheel on clipped footer should not return a command")
+	}
+	if got := next.currentComposerState().cursor; got != startCursor {
+		t.Fatalf("composer cursor = %d, want unchanged end cursor %d", got, startCursor)
+	}
+}
+
 func TestAltScreenTranscriptScrollKeepsFooterFixed(t *testing.T) {
 	m := newModel(context.Background(), Options{AltScreen: true, ProviderName: "openai", ModelName: "gpt-4.1"})
 	m.width = 90

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -102,7 +102,7 @@ func (m model) titleBar(width int) string {
 }
 
 func (m model) titleModelSegment() string {
-	provider := strings.TrimSpace(m.providerName)
+	provider := strings.TrimSpace(m.providerDisplayName())
 	model := strings.TrimSpace(m.modelName)
 	switch {
 	case provider == "" && model == "":
@@ -138,13 +138,14 @@ func (m model) statusLine(width int) string {
 	tier := widthTier(width)
 	separator := zeroTheme.line.Render(" │ ")
 	prefix := "  "
+	providerName := displayValue(strings.TrimSpace(m.providerDisplayName()), "no provider")
 
 	if tier == tierTiny {
-		provider := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(displayValue(strings.TrimSpace(m.providerName), "no provider"))
+		provider := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
 		return fitStyledLine(provider, width)
 	}
 
-	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(displayValue(strings.TrimSpace(m.providerName), "no provider"))
+	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
 
 	rightGroups := []string{}
 	if usage := m.usageStatusSegment(); usage != "" {
@@ -153,6 +154,34 @@ func (m model) statusLine(width int) string {
 	right := strings.Join(rightGroups, separator)
 
 	return fitStyledLine(joinHeaderLine(left, right, width), width)
+}
+
+func (m model) providerDisplayName() string {
+	provider := strings.TrimSpace(m.providerName)
+	if provider == "" {
+		provider = strings.TrimSpace(m.providerProfile.Name)
+	}
+	if !providerDisplayNameIsGenericCustom(provider) {
+		return provider
+	}
+	baseURL := strings.TrimSpace(m.providerProfile.BaseURL)
+	if baseURL == "" || strings.Contains(strings.ToLower(baseURL), "example.invalid") {
+		return provider
+	}
+	derived := providerWizardNameFromBaseURL(baseURL)
+	if derived == "" || derived == "custom" {
+		return provider
+	}
+	return derived
+}
+
+func providerDisplayNameIsGenericCustom(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "custom-openai-compatible", "custom-anthropic-compatible":
+		return true
+	default:
+		return false
+	}
 }
 
 // nextPermissionMode toggles between the two prompt-respecting modes:

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -31,8 +31,9 @@ func (collected CollectedStream) Truncated() bool {
 
 // CollectOptions provides callbacks for consumers that need live stream updates.
 type CollectOptions struct {
-	OnText  func(string)
-	OnUsage func(Usage)
+	OnText      func(string)
+	OnReasoning func(string)
+	OnUsage     func(Usage)
 }
 
 // SeedMessages creates the initial system and user turns for a request. It is a
@@ -113,6 +114,10 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 				collected.Text += event.Content
 				if options.OnText != nil {
 					options.OnText(event.Content)
+				}
+			case StreamEventReasoning:
+				if options.OnReasoning != nil {
+					options.OnReasoning(event.Content)
 				}
 			case StreamEventToolCallStart:
 				collector.start(event.ToolCallID, event.ToolName, event.ToolCallSignature)

--- a/internal/zeroruntime/provider_test.go
+++ b/internal/zeroruntime/provider_test.go
@@ -45,6 +45,7 @@ func TestSeedMessagesProducesSystemAndUserTurns(t *testing.T) {
 func TestStreamEventNamesMatchProviderContract(t *testing.T) {
 	cases := map[StreamEventType]string{
 		StreamEventText:          "text",
+		StreamEventReasoning:     "reasoning",
 		StreamEventToolCallStart: "tool-call-start",
 		StreamEventToolCallDelta: "tool-call-delta",
 		StreamEventToolCallEnd:   "tool-call-end",
@@ -238,21 +239,24 @@ func TestCollectStreamAccumulatesMixedUsageShapes(t *testing.T) {
 	}
 }
 
-func TestCollectStreamWithOptionsEmitsTextAndUsageCallbacks(t *testing.T) {
+func TestCollectStreamWithOptionsEmitsTextReasoningAndUsageCallbacks(t *testing.T) {
 	events := make(chan StreamEvent)
 	go func() {
 		defer close(events)
 		events <- StreamEvent{Type: StreamEventText, Content: "Hello "}
+		events <- StreamEvent{Type: StreamEventReasoning, Content: "Thinking. "}
 		events <- StreamEvent{Type: StreamEventUsage, Usage: Usage{PromptTokens: 12, CompletionTokens: 5, CachedInputTokens: 2}}
 		events <- StreamEvent{Type: StreamEventText, Content: "zero"}
 		events <- StreamEvent{Type: StreamEventDone}
 	}()
 
 	var textDeltas []string
+	var reasoningDeltas []string
 	var usageEvents []Usage
 	collected := CollectStreamWithOptions(context.Background(), events, CollectOptions{
-		OnText:  func(delta string) { textDeltas = append(textDeltas, delta) },
-		OnUsage: func(usage Usage) { usageEvents = append(usageEvents, usage) },
+		OnText:      func(delta string) { textDeltas = append(textDeltas, delta) },
+		OnReasoning: func(delta string) { reasoningDeltas = append(reasoningDeltas, delta) },
+		OnUsage:     func(usage Usage) { usageEvents = append(usageEvents, usage) },
 	})
 
 	if collected.Text != "Hello zero" {
@@ -260,6 +264,9 @@ func TestCollectStreamWithOptionsEmitsTextAndUsageCallbacks(t *testing.T) {
 	}
 	if len(textDeltas) != 2 || textDeltas[0] != "Hello " || textDeltas[1] != "zero" {
 		t.Fatalf("unexpected text callbacks: %#v", textDeltas)
+	}
+	if len(reasoningDeltas) != 1 || reasoningDeltas[0] != "Thinking. " {
+		t.Fatalf("unexpected reasoning callbacks: %#v", reasoningDeltas)
 	}
 	if len(usageEvents) != 1 {
 		t.Fatalf("expected one usage callback, got %#v", usageEvents)

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -34,7 +34,10 @@ const (
 )
 
 const (
-	StreamEventText          StreamEventType = "text"
+	StreamEventText StreamEventType = "text"
+	// StreamEventReasoning carries live reasoning deltas that must never be
+	// folded into answer text or persisted as assistant content.
+	StreamEventReasoning     StreamEventType = "reasoning"
 	StreamEventToolCallStart StreamEventType = "tool-call-start"
 	StreamEventToolCallDelta StreamEventType = "tool-call-delta"
 	StreamEventToolCallEnd   StreamEventType = "tool-call-end"


### PR DESCRIPTION
Summary:
- show the configured provider profile name in /model and /mode status output
- parse OpenAI-compatible reasoning_content stream deltas as visible text
- add a focused provider test for reasoning_content chunks

Notes:
- empty OpenAI-compatible message content behavior is unchanged from main
- .config/ and examples/ are local untracked files and are not included

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/providers/openai ./internal/tui
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamed "reasoning" content is emitted as separate text events.
  * Onboarding/setup accepts custom endpoint and profile name; supports typed-model entry and endpoint validation.

* **UI**
  * Provider display uses endpoint-derived labels in title/status and confirmations.
  * Composer: visual-line cursor movement, paste-preview summaries, updated placeholders, and mouse-wheel cursor scrolling over composer.

* **Behavior**
  * CLI options can override saved provider name/base URL.
  * File-suggestion completion/dismissal preserves collapsed paste previews.

* **Tests**
  * Expanded coverage for streaming, setup/onboarding, composer, rendering, autocomplete, mouse and wizard flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->