### PR TITLE
feat: add backend lifecycle status command

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -264,6 +264,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runSpecialists(args[1:], stdout, stderr, deps)
 	case "plugins", "plugin":
 		return runPlugins(args[1:], stdout, stderr, deps)
+	case "backends", "backend":
+		return runBackends(args[1:], stdout, stderr, deps)
 	case "skills", "skill":
 		return runSkills(args[1:], stdout, stderr, deps)
 	case "tools", "tool":
@@ -648,6 +650,7 @@ Commands:
   spec       Review and approve saved spec-mode drafts
   specialist Manage local Zero specialist profiles
   plugins    Inspect, install, and remove local Zero plugins
+  backends   Inspect MCP, hook, and plugin backend lifecycle state
   skills     Inspect, install, and remove local Zero skills
   tools      Scaffold and list local Zero plugin-tools
   hooks      Inspect Zero hook configuration

--- a/internal/cli/backends.go
+++ b/internal/cli/backends.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/redaction"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+type backendStatusOptions struct {
+	json bool
+}
+
+func runBackends(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseBackendsArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeBackendsHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	snapshot, err := backendLifecycleSnapshot(deps)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, snapshot); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatBackendLifecycleSnapshot(snapshot), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseBackendsArgs(args []string) (backendStatusOptions, bool, error) {
+	options := backendStatusOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown backends flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func backendLifecycleSnapshot(deps appDeps) (zerocommands.BackendLifecycleSnapshot, error) {
+	cwd, err := deps.getwd()
+	if err != nil {
+		return zerocommands.BackendLifecycleSnapshot{}, fmt.Errorf("failed to resolve workspace: %w", err)
+	}
+
+	cfg, err := deps.resolveMCPConfig(cwd)
+	if err != nil {
+		return zerocommands.BackendLifecycleSnapshot{}, err
+	}
+	servers, err := mcp.NormalizeConfig(cfg)
+	if err != nil {
+		return zerocommands.BackendLifecycleSnapshot{}, err
+	}
+
+	hookResult, err := deps.loadHooks(hooks.LoadOptions{Cwd: cwd})
+	if err != nil {
+		return zerocommands.BackendLifecycleSnapshot{}, err
+	}
+	pluginResult, err := deps.loadPlugins(plugins.LoadOptions{Cwd: cwd})
+	if err != nil {
+		return zerocommands.BackendLifecycleSnapshot{}, err
+	}
+
+	return zerocommands.NewBackendLifecycleSnapshot(servers, hookResult.Config.Hooks, pluginResult.Plugins), nil
+}
+
+func formatBackendLifecycleSnapshot(snapshot zerocommands.BackendLifecycleSnapshot) string {
+	lines := []string{"Zero Backends:"}
+	lines = append(lines, fmt.Sprintf("  MCP servers: %d", len(snapshot.MCPServers)))
+	for _, server := range snapshot.MCPServers {
+		detail := server.Command
+		if detail == "" {
+			detail = server.URL
+		}
+		counts := []string{}
+		if server.ArgCount > 0 {
+			counts = append(counts, fmt.Sprintf("%d args", server.ArgCount))
+		}
+		if server.EnvKeyCount > 0 {
+			counts = append(counts, fmt.Sprintf("%d env", server.EnvKeyCount))
+		}
+		if server.HeaderCount > 0 {
+			counts = append(counts, fmt.Sprintf("%d headers", server.HeaderCount))
+		}
+		suffix := ""
+		if len(counts) > 0 {
+			suffix = " (" + strings.Join(counts, ", ") + ")"
+		}
+		lines = append(lines, fmt.Sprintf("    - %s [%s] %s%s", server.Name, server.Type, detail, suffix))
+	}
+
+	lines = append(lines, fmt.Sprintf("  Hooks: %d", len(snapshot.Hooks)))
+	for _, hook := range snapshot.Hooks {
+		label := hook.Name
+		if label == "" {
+			label = hook.ID
+		}
+		state := "disabled"
+		if hook.Enabled {
+			state = "enabled"
+		}
+		lines = append(lines, fmt.Sprintf("    - %s [%s] %s %s", label, hook.Event, state, hook.Command))
+	}
+
+	lines = append(lines, fmt.Sprintf("  Plugins: %d", len(snapshot.Plugins)))
+	for _, plugin := range snapshot.Plugins {
+		state := "disabled"
+		if plugin.Enabled {
+			state = "enabled"
+		}
+		lines = append(lines, fmt.Sprintf("    - %s [%s] %s tools=%d prompts=%d skills=%d hooks=%d", plugin.ID, plugin.Source, state, plugin.ToolCount, plugin.PromptCount, plugin.SkillCount, plugin.HookCount))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func writeBackendsHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero backends [flags]
+
+Inspect MCP, hook, and plugin backend lifecycle state without connecting to
+external MCP servers.
+
+Flags:
+      --json    Print backend lifecycle data as JSON
+  -h, --help    Show this help
+`)
+	return err
+}

--- a/internal/cli/backends_test.go
+++ b/internal/cli/backends_test.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+func TestRunBackendsJSONUsesLifecycleSnapshotWithoutConnectingMCP(t *testing.T) {
+	cwd := t.TempDir()
+	secret := "sk-proj-" + strings.Repeat("a", 24)
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"zulu": {
+					Type: "http",
+					URL:  "https://admin:secret@example.com/mcp?token=" + secret + "&mode=readonly",
+					Headers: map[string]string{
+						"Authorization": "Bearer " + secret,
+					},
+				},
+				"alpha": {
+					Type:    "stdio",
+					Command: "alpha-mcp",
+					Args:    []string{"--project", cwd},
+					Env: map[string]string{
+						"ALPHA_TOKEN": secret,
+					},
+				},
+				"disabled": {
+					Type:     "stdio",
+					Command:  "disabled-mcp",
+					Disabled: true,
+				},
+			}}, nil
+		},
+		loadHooks: func(options hooks.LoadOptions) (hooks.LoadResult, error) {
+			if options.Cwd != cwd {
+				t.Fatalf("hook Cwd = %q, want %q", options.Cwd, cwd)
+			}
+			return hooks.LoadResult{Config: hooks.Config{Hooks: []hooks.Definition{{
+				ID:      "zero.preflight",
+				Event:   hooks.EventBeforeTool,
+				Matcher: "bash",
+				Command: "sh",
+				Args:    []string{"-c", "echo " + secret},
+				Enabled: true,
+			}}}}, nil
+		},
+		loadPlugins: func(options plugins.LoadOptions) (plugins.LoadResult, error) {
+			if options.Cwd != cwd {
+				t.Fatalf("plugin Cwd = %q, want %q", options.Cwd, cwd)
+			}
+			return plugins.LoadResult{Plugins: []plugins.LoadedPlugin{{
+				ID:           "zero.docs",
+				Name:         "Docs",
+				Description:  "uses " + secret,
+				Enabled:      true,
+				Source:       plugins.SourceProject,
+				Root:         "C:/tmp/" + secret,
+				PluginDir:    "C:/tmp/plugin",
+				ManifestPath: "C:/tmp/plugin/plugin.json?token=" + secret,
+				Tools:        []plugins.ToolExtension{{Name: "lookup"}},
+				Prompts:      []plugins.PathExtension{{Name: "review"}},
+				Hooks:        []plugins.HookExtension{{Name: "audit"}},
+			}}}, nil
+		},
+		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return nil, errors.New("zero backends must not connect to MCP servers")
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"backends", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), secret) || strings.Contains(stdout.String(), "admin:secret") || strings.Contains(stdout.String(), "Authorization") || strings.Contains(stdout.String(), "ALPHA_TOKEN") {
+		t.Fatalf("backend JSON leaked secret material:\n%s", stdout.String())
+	}
+
+	var snapshot zerocommands.BackendLifecycleSnapshot
+	if err := json.Unmarshal(stdout.Bytes(), &snapshot); err != nil {
+		t.Fatalf("backend JSON failed to decode: %v\n%s", err, stdout.String())
+	}
+	if len(snapshot.MCPServers) != 2 || snapshot.MCPServers[0].Name != "alpha" || snapshot.MCPServers[1].Name != "zulu" {
+		t.Fatalf("unexpected MCP snapshots: %#v", snapshot.MCPServers)
+	}
+	if snapshot.MCPServers[0].ArgCount != 2 || snapshot.MCPServers[0].EnvKeyCount != 1 {
+		t.Fatalf("stdio MCP counts wrong: %#v", snapshot.MCPServers[0])
+	}
+	if snapshot.MCPServers[1].HeaderCount != 1 || !strings.Contains(snapshot.MCPServers[1].URL, "mode=readonly") {
+		t.Fatalf("http MCP snapshot missing safe status data: %#v", snapshot.MCPServers[1])
+	}
+	if len(snapshot.Hooks) != 1 || snapshot.Hooks[0].ID != "zero.preflight" || strings.Contains(strings.Join(snapshot.Hooks[0].Args, " "), secret) {
+		t.Fatalf("unexpected hook snapshots: %#v", snapshot.Hooks)
+	}
+	if len(snapshot.Plugins) != 1 || snapshot.Plugins[0].ID != "zero.docs" || snapshot.Plugins[0].ToolCount != 1 || snapshot.Plugins[0].PromptCount != 1 || snapshot.Plugins[0].HookCount != 1 {
+		t.Fatalf("unexpected plugin snapshots: %#v", snapshot.Plugins)
+	}
+}
+
+func TestRunBackendsTextAndHelp(t *testing.T) {
+	deps := appDeps{
+		getwd: func() (string, error) { return t.TempDir(), nil },
+		resolveMCPConfig: func(string) (config.MCPConfig, error) {
+			return config.MCPConfig{}, nil
+		},
+		loadHooks: func(hooks.LoadOptions) (hooks.LoadResult, error) {
+			return hooks.LoadResult{}, nil
+		},
+		loadPlugins: func(plugins.LoadOptions) (plugins.LoadResult, error) {
+			return plugins.LoadResult{}, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"backends"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"Zero Backends:", "MCP servers: 0", "Hooks: 0", "Plugins: 0"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("backend text missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"backends", "--help"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitSuccess {
+		t.Fatalf("help exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"Usage:", "zero backends", "--json"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("backend help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}

--- a/internal/zerocommands/backend_snapshots.go
+++ b/internal/zerocommands/backend_snapshots.go
@@ -91,18 +91,18 @@ type BackendLifecycleSnapshot struct {
 // MCPServerSnapshotFromServer converts a single mcp.Server into its
 // typed snapshot. Secret material in `Env` and `Headers` is never
 // copied; only the key counts are recorded. The URL field is run
-// through stripURLCredentialsFromURL so any userinfo embedded in
-// the URL (https://user:token@host) is removed before the snapshot
-// leaves the runtime. A URL that fails to parse is returned
-// trimmed, not empty, so the operator still sees the configured
-// endpoint when triaging a malformed MCP configuration.
+// through stripURLCredentialsFromURL so userinfo and sensitive
+// query values are removed before the snapshot leaves the runtime.
+// A URL that fails to parse is returned trimmed, not empty, so the
+// operator still sees the configured endpoint when triaging a
+// malformed MCP configuration.
 func MCPServerSnapshotFromServer(server mcp.Server) MCPServerSnapshot {
 	return MCPServerSnapshot{
 		Name:        strings.TrimSpace(server.Name),
 		Type:        string(server.Type),
 		Identity:    strings.TrimSpace(server.Identity),
 		URL:         stripURLCredentialsFromURL(server.URL),
-		Command:     strings.TrimSpace(server.Command),
+		Command:     redactSnapshotString(server.Command),
 		ArgCount:    len(server.Args),
 		EnvKeyCount: len(server.Env),
 		HeaderCount: len(server.Headers),
@@ -159,11 +159,11 @@ type MCPServerCounts struct {
 // snapshot.
 func HookSnapshotFromDefinition(def hooks.Definition, source hooks.ConfigSource) HookSnapshot {
 	return HookSnapshot{
-		ID:      strings.TrimSpace(def.ID),
-		Name:    strings.TrimSpace(def.Name),
+		ID:      redactSnapshotString(def.ID),
+		Name:    redactSnapshotString(def.Name),
 		Event:   string(def.Event),
-		Matcher: strings.TrimSpace(def.Matcher),
-		Command: redaction.RedactString(strings.TrimSpace(def.Command), redaction.Options{}),
+		Matcher: redactSnapshotString(def.Matcher),
+		Command: redactSnapshotString(def.Command),
 		Args:    redactStringSlice(def.Args),
 		Enabled: def.Enabled,
 		Source:  string(source),
@@ -204,19 +204,20 @@ func hookSnapshotsWithSource(definitions []hooks.Definition, source hooks.Config
 // PluginSnapshotFromPlugin converts a plugins.LoadedPlugin into its
 // typed snapshot. The full slice of tools, hooks, prompts, and
 // skills is collapsed to counts so the headless JSON output stays
-// small. The Path fields are preserved verbatim because the
-// operator needs them to triage a load failure.
+// small. Operator-facing path and metadata fields are preserved
+// after trimming and redaction because they help triage a load
+// failure but may include copied token-like strings.
 func PluginSnapshotFromPlugin(plugin plugins.LoadedPlugin) PluginSnapshot {
 	return PluginSnapshot{
-		ID:           strings.TrimSpace(plugin.ID),
-		Name:         strings.TrimSpace(plugin.Name),
-		Version:      strings.TrimSpace(plugin.Version),
-		Description:  strings.TrimSpace(plugin.Description),
+		ID:           redactSnapshotString(plugin.ID),
+		Name:         redactSnapshotString(plugin.Name),
+		Version:      redactSnapshotString(plugin.Version),
+		Description:  redactSnapshotString(plugin.Description),
 		Enabled:      plugin.Enabled,
 		Source:       string(plugin.Source),
-		Root:         strings.TrimSpace(plugin.Root),
-		PluginDir:    strings.TrimSpace(plugin.PluginDir),
-		ManifestPath: strings.TrimSpace(plugin.ManifestPath),
+		Root:         redactSnapshotString(plugin.Root),
+		PluginDir:    redactSnapshotString(plugin.PluginDir),
+		ManifestPath: redactSnapshotString(plugin.ManifestPath),
 		ToolCount:    len(plugin.Tools),
 		PromptCount:  len(plugin.Prompts),
 		SkillCount:   len(plugin.Skills),
@@ -273,13 +274,18 @@ func redactStringSlice(values []string) []string {
 			out[index] = ""
 			continue
 		}
-		out[index] = redaction.RedactString(trimmed, redaction.Options{})
+		out[index] = redactSnapshotString(trimmed)
 	}
 	return out
 }
 
+func redactSnapshotString(value string) string {
+	return redaction.RedactString(strings.TrimSpace(value), redaction.Options{})
+}
+
 // stripURLCredentialsFromURL returns value with any embedded
-// userinfo (https://user:token@host) removed. The helper is
+// userinfo (https://user:token@host) and sensitive query or
+// fragment values removed. The helper is
 // tolerant of malformed input: a URL that fails to parse is
 // returned trimmed, not empty, so the operator still sees the
 // configured endpoint when triaging an MCP configuration that
@@ -293,9 +299,59 @@ func stripURLCredentialsFromURL(value string) string {
 	if err != nil || parsed == nil {
 		return trimmed
 	}
-	if parsed.User == nil {
+	if parsed.Scheme == "" && parsed.Host == "" {
 		return trimmed
 	}
+	if parsed.User == nil {
+		return redactSensitiveURLQuery(parsed, trimmed)
+	}
 	parsed.User = nil
-	return parsed.String()
+	return redactSensitiveURLQuery(parsed, trimmed)
+}
+
+func redactSensitiveURLQuery(parsed *url.URL, fallback string) string {
+	if parsed.RawQuery != "" {
+		parsed.RawQuery = redactSensitiveRawQuery(parsed.RawQuery)
+	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = redactSensitiveRawQuery(parsed.Fragment)
+	}
+	out := parsed.String()
+	if strings.TrimSpace(out) == "" {
+		return fallback
+	}
+	return out
+}
+
+func redactSensitiveRawQuery(rawQuery string) string {
+	parts := strings.Split(rawQuery, "&")
+	for index, part := range parts {
+		if part == "" {
+			continue
+		}
+		key, _, hasValue := strings.Cut(part, "=")
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			decodedKey = key
+		}
+		if !isSensitiveURLKey(decodedKey) || !hasValue {
+			continue
+		}
+		parts[index] = key + "=[REDACTED]"
+	}
+	return strings.Join(parts, "&")
+}
+
+func isSensitiveURLKey(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.ReplaceAll(key, "-", "_")
+	if key == "key" {
+		return true
+	}
+	for _, token := range []string{"token", "secret", "password", "passwd", "api_key", "apikey", "access_key", "auth", "credential"} {
+		if strings.Contains(key, token) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/zerocommands/backend_snapshots_test.go
+++ b/internal/zerocommands/backend_snapshots_test.go
@@ -88,6 +88,23 @@ func TestMCPServerSnapshotWithCountsMergesRuntimeCounts(t *testing.T) {
 	}
 }
 
+func TestMCPServerSnapshotRedactsSecretCommand(t *testing.T) {
+	secret := "sk-proj-" + strings.Repeat("d", 24)
+	server := mcp.Server{
+		Name:    "leaky",
+		Type:    mcp.ServerTypeStdio,
+		Command: "mcp-wrapper --token " + secret,
+	}
+
+	snapshot := MCPServerSnapshotFromServer(server)
+	if strings.Contains(snapshot.Command, secret) || strings.Contains(snapshot.Command, "sk-proj-") {
+		t.Fatalf("MCP command should be redacted, got %q", snapshot.Command)
+	}
+	if !strings.Contains(snapshot.Command, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in MCP command, got %q", snapshot.Command)
+	}
+}
+
 func TestMCPServerSnapshotsSortsAndReturnsEmptySliceForEmptyInput(t *testing.T) {
 	servers := []mcp.Server{
 		{Name: "zulu", Type: mcp.ServerTypeHTTP, URL: "https://zulu.test"},
@@ -183,6 +200,24 @@ func TestHookSnapshotFromDefinitionPreservesPositionForRedactedArgs(t *testing.T
 	}
 }
 
+func TestHookSnapshotFromDefinitionRedactsSecretCommand(t *testing.T) {
+	secret := "sk-proj-" + strings.Repeat("c", 24)
+	def := hooks.Definition{
+		ID:      "hook-secret-command",
+		Event:   hooks.EventAfterTool,
+		Command: "curl -H Authorization:Bearer " + secret,
+		Enabled: true,
+	}
+
+	snapshot := HookSnapshotFromDefinition(def, hooks.SourceUser)
+	if strings.Contains(snapshot.Command, secret) || strings.Contains(snapshot.Command, "sk-proj-") {
+		t.Fatalf("hook command should be redacted, got %q", snapshot.Command)
+	}
+	if !strings.Contains(snapshot.Command, "[REDACTED]") {
+		t.Fatalf("expected redaction marker in hook command, got %q", snapshot.Command)
+	}
+}
+
 func TestMCPServerSnapshotStripsURLCredentials(t *testing.T) {
 	server := mcp.Server{
 		Name: "creds",
@@ -201,6 +236,24 @@ func TestMCPServerSnapshotStripsURLCredentials(t *testing.T) {
 	}
 	if snapshot.URL != "https://api.example.com/v1" {
 		t.Fatalf("expected sanitized URL, got %q", snapshot.URL)
+	}
+}
+
+func TestMCPServerSnapshotRedactsSensitiveURLQueryValues(t *testing.T) {
+	server := mcp.Server{
+		Name: "query",
+		Type: mcp.ServerTypeHTTP,
+		URL:  "https://api.example.com/v1?token=secret-token&mode=readonly&api_key=sk-proj-" + strings.Repeat("b", 24),
+	}
+	snapshot := MCPServerSnapshotFromServer(server)
+	if strings.Contains(snapshot.URL, "secret-token") || strings.Contains(snapshot.URL, "sk-proj-") {
+		t.Fatalf("URL query must not contain secret values, got %q", snapshot.URL)
+	}
+	if !strings.Contains(snapshot.URL, "token=[REDACTED]") || !strings.Contains(snapshot.URL, "api_key=[REDACTED]") {
+		t.Fatalf("expected sensitive query values to be redacted, got %q", snapshot.URL)
+	}
+	if !strings.Contains(snapshot.URL, "mode=readonly") {
+		t.Fatalf("expected safe query value to be preserved, got %q", snapshot.URL)
 	}
 }
 
@@ -306,6 +359,33 @@ func TestPluginSnapshotFromPluginCollapsesSlicesToCounts(t *testing.T) {
 	}
 	if snapshot.ToolCount != 2 || snapshot.PromptCount != 1 || snapshot.SkillCount != 1 || snapshot.HookCount != 1 {
 		t.Fatalf("counts wrong: %#v", snapshot)
+	}
+}
+
+func TestPluginSnapshotRedactsOperatorFacingStrings(t *testing.T) {
+	secret := "sk-proj-" + strings.Repeat("e", 24)
+	plugin := plugins.LoadedPlugin{
+		ID:           "plugin-" + secret,
+		Name:         "Docs " + secret,
+		Version:      "1.0.0",
+		Description:  "requires " + secret,
+		Enabled:      true,
+		Source:       plugins.SourceUser,
+		Root:         "/tmp/" + secret,
+		PluginDir:    "/tmp/plugin?api_key=" + secret,
+		ManifestPath: "/tmp/plugin/plugin.json?token=" + secret,
+	}
+
+	snapshot := PluginSnapshotFromPlugin(plugin)
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(encoded), secret) || strings.Contains(string(encoded), "sk-proj-") {
+		t.Fatalf("plugin snapshot should redact operator-facing strings, got %s", string(encoded))
+	}
+	if !strings.Contains(string(encoded), "[REDACTED]") {
+		t.Fatalf("expected redaction marker in plugin snapshot, got %s", string(encoded))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `zero backends` / `zero backend` to inspect MCP, hook, and plugin lifecycle status from one command.
- Return the existing `zerocommands.BackendLifecycleSnapshot` as stable JSON, plus a compact text view.
- Keep the command offline-safe: it reads config/manifests only and does not register or connect MCP tools.
- Harden backend snapshots so MCP commands, URL query/fragment secrets, hook fields, and plugin metadata/path strings are redacted before JSON output.

## Validation
- `gofmt -l internal\cli internal\zerocommands`
- `go vet ./...`
- `go build ./...`
- `go test ./... -timeout 300s`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `go run ./cmd/zero backends`
- `go run ./cmd/zero backends --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `zero backends` CLI subcommand to display backend lifecycle information including hooks, plugins, and MCP servers
  * Supports `--json` output format for programmatic access and `--help` for usage information
  * Automatically redacts sensitive credentials, tokens, and secrets from output

* **Tests**
  * Added CLI regression tests for the backends command
  * Added comprehensive redaction validation tests for sensitive data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->