### PR TITLE
feat: add backend doctor diagnostics

### DIFF
--- a/internal/cli/backends.go
+++ b/internal/cli/backends.go
@@ -17,6 +17,13 @@ type backendStatusOptions struct {
 }
 
 func runBackends(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if len(args) > 0 {
+		switch args[0] {
+		case "doctor":
+			return runBackendsDoctor(args[1:], stdout, stderr, deps)
+		}
+	}
+
 	options, help, err := parseBackendsArgs(args)
 	if err != nil {
 		return writeExecUsageError(stderr, err.Error())
@@ -44,6 +51,44 @@ func runBackends(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 	return exitSuccess
 }
 
+type backendDoctorOptions struct {
+	json bool
+}
+
+func runBackendsDoctor(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseBackendsDoctorArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeBackendsDoctorHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	report, err := backendDoctorReport(deps)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+		if !report.OK {
+			return exitProvider
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, redaction.RedactString(formatBackendDoctorReport(report), redaction.Options{})); err != nil {
+		return exitCrash
+	}
+	if !report.OK {
+		return exitProvider
+	}
+	return exitSuccess
+}
+
 func parseBackendsArgs(args []string) (backendStatusOptions, bool, error) {
 	options := backendStatusOptions{}
 	for _, arg := range args {
@@ -54,6 +99,21 @@ func parseBackendsArgs(args []string) (backendStatusOptions, bool, error) {
 			options.json = true
 		default:
 			return options, false, execUsageError{fmt.Sprintf("unknown backends flag %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func parseBackendsDoctorArgs(args []string) (backendDoctorOptions, bool, error) {
+	options := backendDoctorOptions{}
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			return options, true, nil
+		case "--json":
+			options.json = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unknown backends doctor flag %q", arg)}
 		}
 	}
 	return options, false, nil
@@ -84,6 +144,32 @@ func backendLifecycleSnapshot(deps appDeps) (zerocommands.BackendLifecycleSnapsh
 	}
 
 	return zerocommands.NewBackendLifecycleSnapshot(servers, hookResult.Config.Hooks, pluginResult.Plugins), nil
+}
+
+func backendDoctorReport(deps appDeps) (zerocommands.BackendDoctorReport, error) {
+	cwd, err := deps.getwd()
+	if err != nil {
+		return zerocommands.BackendDoctorReport{}, fmt.Errorf("failed to resolve workspace: %w", err)
+	}
+
+	cfg, err := deps.resolveMCPConfig(cwd)
+	if err != nil {
+		return zerocommands.BackendDoctorReport{}, err
+	}
+	hookResult, err := deps.loadHooks(hooks.LoadOptions{Cwd: cwd})
+	if err != nil {
+		return zerocommands.BackendDoctorReport{}, err
+	}
+	pluginResult, err := deps.loadPlugins(plugins.LoadOptions{Cwd: cwd})
+	if err != nil {
+		return zerocommands.BackendDoctorReport{}, err
+	}
+
+	return zerocommands.NewBackendDoctorReport(zerocommands.BackendDoctorInput{
+		MCP:     cfg,
+		Hooks:   hookResult,
+		Plugins: pluginResult,
+	}), nil
 }
 
 func formatBackendLifecycleSnapshot(snapshot zerocommands.BackendLifecycleSnapshot) string {
@@ -135,15 +221,51 @@ func formatBackendLifecycleSnapshot(snapshot zerocommands.BackendLifecycleSnapsh
 	return strings.Join(lines, "\n")
 }
 
+func formatBackendDoctorReport(report zerocommands.BackendDoctorReport) string {
+	lines := []string{
+		"Zero backend doctor",
+		"Overall: " + string(report.Status),
+	}
+	for _, check := range report.Checks {
+		target := ""
+		if check.Target != "" {
+			target = " " + check.Target
+		}
+		lines = append(lines, fmt.Sprintf("[%s] %s%s - %s", check.Status, check.ID, target, check.Message))
+		if check.Action != "" {
+			lines = append(lines, "  action: "+check.Action)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 func writeBackendsHelp(w io.Writer) error {
 	_, err := fmt.Fprint(w, `Usage:
   zero backends [flags]
+  zero backends doctor [flags]
 
 Inspect MCP, hook, and plugin backend lifecycle state without connecting to
 external MCP servers.
 
+Commands:
+  doctor    Diagnose MCP, hook, and plugin backend setup
+
 Flags:
       --json    Print backend lifecycle data as JSON
+  -h, --help    Show this help
+`)
+	return err
+}
+
+func writeBackendsDoctorHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero backends doctor [flags]
+
+Diagnose MCP, hook, and plugin backend setup without connecting to external MCP
+servers or executing hooks/plugins.
+
+Flags:
+      --json    Print backend diagnostics as JSON
   -h, --help    Show this help
 `)
 	return err

--- a/internal/cli/backends_test.go
+++ b/internal/cli/backends_test.go
@@ -5,7 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
@@ -151,5 +156,222 @@ func TestRunBackendsTextAndHelp(t *testing.T) {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("backend help missing %q:\n%s", want, stdout.String())
 		}
+	}
+}
+
+func TestRunBackendsDoctorJSONAndTextWithoutConnectingMCP(t *testing.T) {
+	cwd := t.TempDir()
+	secret := "sk-proj-" + strings.Repeat("b", 24)
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(workspaceRoot string) (config.MCPConfig, error) {
+			if workspaceRoot != cwd {
+				t.Fatalf("workspaceRoot = %q, want %q", workspaceRoot, cwd)
+			}
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"remote": {
+					Type: "http",
+					URL:  "https://api.example.com/mcp?token=" + secret,
+				},
+				"broken": {
+					Type: "http",
+				},
+			}}, nil
+		},
+		loadHooks: func(options hooks.LoadOptions) (hooks.LoadResult, error) {
+			if options.Cwd != cwd {
+				t.Fatalf("hook Cwd = %q, want %q", options.Cwd, cwd)
+			}
+			return hooks.LoadResult{Diagnostics: []hooks.Diagnostic{{
+				Kind:    hooks.DiagnosticSchema,
+				Message: "schema failed " + secret,
+				HookID:  "zero.bad",
+			}}}, nil
+		},
+		loadPlugins: func(options plugins.LoadOptions) (plugins.LoadResult, error) {
+			if options.Cwd != cwd {
+				t.Fatalf("plugin Cwd = %q, want %q", options.Cwd, cwd)
+			}
+			return plugins.LoadResult{Plugins: []plugins.LoadedPlugin{{
+				ID:      "zero.docs",
+				Name:    "Docs",
+				Enabled: true,
+				Source:  plugins.SourceProject,
+			}}}, nil
+		},
+		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return nil, errors.New("zero backends doctor must not connect to MCP servers")
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"backends", "doctor", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitProvider {
+		t.Fatalf("exitCode = %d, want %d stderr=%s stdout=%s", exitCode, exitProvider, stderr.String(), stdout.String())
+	}
+	if strings.Contains(stdout.String(), secret) || strings.Contains(stdout.String(), "sk-proj-") {
+		t.Fatalf("backend doctor JSON leaked secret material:\n%s", stdout.String())
+	}
+	var payload zerocommands.BackendDoctorReport
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("backend doctor JSON failed to decode: %v\n%s", err, stdout.String())
+	}
+	if payload.OK {
+		t.Fatalf("payload.OK = true, want false for invalid MCP/hook diagnostic: %#v", payload.Checks)
+	}
+	if payload.Status != zerocommands.BackendDoctorStatusFail {
+		t.Fatalf("payload.Status = %q, want %q", payload.Status, zerocommands.BackendDoctorStatusFail)
+	}
+	assertBackendDoctorPayloadCheck(t, payload, "backend.mcp.invalid", "broken")
+	assertBackendDoctorPayloadCheck(t, payload, "backend.hooks.diagnostic", "zero.bad")
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"backends", "doctor"}, &stdout, &stderr, deps)
+	if exitCode != exitProvider {
+		t.Fatalf("text exitCode = %d, want %d stderr=%s", exitCode, exitProvider, stderr.String())
+	}
+	for _, want := range []string{"Zero backend doctor", "[fail] backend.mcp.invalid", "zero mcp add broken", "[fail] backend.hooks.diagnostic"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("backend doctor text missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRunBackendsDoctorHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"backends", "doctor", "--help"}, &stdout, &stderr, appDeps{})
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s", exitCode, stderr.String())
+	}
+	for _, want := range []string{"Usage:", "zero backends doctor", "--json"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("backend doctor help missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRunBackendsDoctorDoesNotConnectOrExecuteConfiguredBackends(t *testing.T) {
+	cwd := t.TempDir()
+	hookSentinel := filepath.Join(cwd, "hook-ran")
+	pluginToolSentinel := filepath.Join(cwd, "plugin-tool-ran")
+	pluginHookSentinel := filepath.Join(cwd, "plugin-hook-ran")
+	helperCommand := os.Args[0]
+	helperArgs := func(path string) []string {
+		return []string{"-test.run=TestBackendDoctorHelperProcess", "--", "--zero-backend-doctor-sentinel", path}
+	}
+
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	hookConfigPath := filepath.Join(cwd, ".zero", "hooks.json")
+	writeBackendDoctorJSON(t, hookConfigPath, map[string]any{
+		"enabled": true,
+		"hooks": []any{map[string]any{
+			"id":      "zero.sentinel",
+			"event":   "sessionStart",
+			"command": helperCommand,
+			"args":    helperArgs(hookSentinel),
+		}},
+	})
+	pluginDir := filepath.Join(cwd, ".zero", "plugins", "sentinel")
+	writeBackendDoctorJSON(t, filepath.Join(pluginDir, "plugin.json"), map[string]any{
+		"schemaVersion": 1,
+		"id":            "zero.sentinel",
+		"name":          "Sentinel",
+		"version":       "1.0.0",
+		"tools": []any{map[string]any{
+			"name":    "sentinel_tool",
+			"command": helperCommand,
+			"args":    helperArgs(pluginToolSentinel),
+		}},
+		"hooks": []any{map[string]any{
+			"name":    "sentinel_hook",
+			"event":   "sessionStart",
+			"command": helperCommand,
+			"args":    helperArgs(pluginHookSentinel),
+		}},
+	})
+
+	deps := appDeps{
+		getwd: func() (string, error) { return cwd, nil },
+		resolveMCPConfig: func(string) (config.MCPConfig, error) {
+			return config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+				"remote": {Type: "http", URL: server.URL + "/mcp"},
+			}}, nil
+		},
+		loadHooks: func(options hooks.LoadOptions) (hooks.LoadResult, error) {
+			return hooks.LoadConfig(hooks.LoadOptions{
+				Cwd:               options.Cwd,
+				UserConfigPath:    filepath.Join(cwd, "missing-user-hooks.json"),
+				ProjectConfigPath: hookConfigPath,
+			})
+		},
+		loadPlugins: func(options plugins.LoadOptions) (plugins.LoadResult, error) {
+			return plugins.Load(plugins.LoadOptions{
+				Roots: []plugins.Root{{Source: plugins.SourceProject, Path: filepath.Join(cwd, ".zero", "plugins")}},
+				Cwd:   options.Cwd,
+			})
+		},
+		registerMCPTools: func(context.Context, *tools.Registry, config.MCPConfig, mcp.RegisterOptions) (mcpToolRuntime, error) {
+			return nil, errors.New("zero backends doctor must not register MCP tools")
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"backends", "doctor", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exitCode = %d stderr=%s stdout=%s", exitCode, stderr.String(), stdout.String())
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("backend doctor connected to MCP HTTP server %d time(s)", got)
+	}
+	for _, sentinel := range []string{hookSentinel, pluginToolSentinel, pluginHookSentinel} {
+		if _, err := os.Stat(sentinel); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("backend doctor executed configured backend command, sentinel=%s err=%v", sentinel, err)
+		}
+	}
+}
+
+func assertBackendDoctorPayloadCheck(t *testing.T, report zerocommands.BackendDoctorReport, id string, target string) {
+	t.Helper()
+	for _, check := range report.Checks {
+		if check.ID == id && check.Target == target {
+			return
+		}
+	}
+	t.Fatalf("check %s/%s not found in %#v", id, target, report.Checks)
+}
+
+func writeBackendDoctorJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("create dir for %s: %v", path, err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestBackendDoctorHelperProcess(t *testing.T) {
+	for index, arg := range os.Args {
+		if arg != "--zero-backend-doctor-sentinel" || index+1 >= len(os.Args) {
+			continue
+		}
+		if err := os.WriteFile(os.Args[index+1], []byte("executed"), 0o600); err != nil {
+			os.Exit(2)
+		}
+		os.Exit(0)
 	}
 }

--- a/internal/zerocommands/backend_doctor.go
+++ b/internal/zerocommands/backend_doctor.go
@@ -1,0 +1,276 @@
+package zerocommands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/mcp"
+	"github.com/Gitlawb/zero/internal/plugins"
+	"github.com/Gitlawb/zero/internal/redaction"
+)
+
+type BackendDoctorStatus string
+
+const (
+	BackendDoctorStatusPass BackendDoctorStatus = "pass"
+	BackendDoctorStatusWarn BackendDoctorStatus = "warn"
+	BackendDoctorStatusFail BackendDoctorStatus = "fail"
+)
+
+type BackendDoctorInput struct {
+	MCP     config.MCPConfig
+	Hooks   hooks.LoadResult
+	Plugins plugins.LoadResult
+}
+
+type BackendDoctorReport struct {
+	OK     bool                 `json:"ok"`
+	Status BackendDoctorStatus  `json:"status"`
+	Checks []BackendDoctorCheck `json:"checks"`
+}
+
+type BackendDoctorCheck struct {
+	ID      string              `json:"id"`
+	Surface string              `json:"surface"`
+	Target  string              `json:"target"`
+	Status  BackendDoctorStatus `json:"status"`
+	Message string              `json:"message"`
+	Action  string              `json:"action,omitempty"`
+	Details map[string]string   `json:"details,omitempty"`
+}
+
+func NewBackendDoctorReport(input BackendDoctorInput) BackendDoctorReport {
+	checks := []BackendDoctorCheck{}
+	checks = append(checks, mcpDoctorChecks(input.MCP)...)
+	checks = append(checks, hookDoctorChecks(input.Hooks)...)
+	checks = append(checks, pluginDoctorChecks(input.Plugins)...)
+
+	report := BackendDoctorReport{OK: true, Status: BackendDoctorStatusPass, Checks: checks}
+	for _, check := range checks {
+		if check.Status == BackendDoctorStatusFail {
+			report.OK = false
+			report.Status = BackendDoctorStatusFail
+			break
+		}
+		if check.Status == BackendDoctorStatusWarn && report.Status == BackendDoctorStatusPass {
+			report.Status = BackendDoctorStatusWarn
+		}
+	}
+	return report
+}
+
+func mcpDoctorChecks(cfg config.MCPConfig) []BackendDoctorCheck {
+	if len(cfg.Servers) == 0 {
+		return []BackendDoctorCheck{{
+			ID:      "backend.mcp.configured",
+			Surface: "mcp",
+			Target:  "mcp",
+			Status:  BackendDoctorStatusPass,
+			Message: "No MCP servers configured.",
+			Action:  "zero mcp add <name> --url <url>",
+		}}
+	}
+
+	names := make([]string, 0, len(cfg.Servers))
+	for name := range cfg.Servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	checks := make([]BackendDoctorCheck, 0, len(names))
+	for _, name := range names {
+		raw := cfg.Servers[name]
+		target := redactSnapshotString(name)
+		if raw.Disabled {
+			checks = append(checks, BackendDoctorCheck{
+				ID:      "backend.mcp.disabled",
+				Surface: "mcp",
+				Target:  target,
+				Status:  BackendDoctorStatusWarn,
+				Message: fmt.Sprintf("MCP server %s is disabled.", target),
+				Action:  "zero mcp enable " + target,
+			})
+			continue
+		}
+
+		servers, err := mcp.NormalizeConfig(config.MCPConfig{Servers: map[string]config.MCPServerConfig{name: raw}})
+		if err != nil {
+			checks = append(checks, BackendDoctorCheck{
+				ID:      "backend.mcp.invalid",
+				Surface: "mcp",
+				Target:  target,
+				Status:  BackendDoctorStatusFail,
+				Message: redaction.RedactString(err.Error(), redaction.Options{}),
+				Action:  "zero mcp add " + target,
+			})
+			continue
+		}
+		detail := ""
+		if len(servers) == 1 {
+			detail = string(servers[0].Type)
+		}
+		check := BackendDoctorCheck{
+			ID:      "backend.mcp.server",
+			Surface: "mcp",
+			Target:  target,
+			Status:  BackendDoctorStatusPass,
+			Message: fmt.Sprintf("MCP server %s is configured.", target),
+			Action:  "zero mcp check " + target,
+		}
+		if detail != "" {
+			check.Details = map[string]string{"type": detail}
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}
+
+func hookDoctorChecks(result hooks.LoadResult) []BackendDoctorCheck {
+	checks := []BackendDoctorCheck{}
+	if len(result.Config.Hooks) == 0 && len(result.Diagnostics) == 0 {
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.hooks.configured",
+			Surface: "hooks",
+			Target:  "hooks",
+			Status:  BackendDoctorStatusPass,
+			Message: "No hooks configured.",
+			Action:  "zero hooks list",
+		})
+	}
+	if len(result.Config.Hooks) > 0 && !result.Config.Enabled {
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.hooks.disabled",
+			Surface: "hooks",
+			Target:  "hooks",
+			Status:  BackendDoctorStatusWarn,
+			Message: "Hooks are configured but globally disabled.",
+			Action:  "zero hooks list",
+		})
+	}
+	for _, diagnostic := range result.Diagnostics {
+		target := firstNonEmpty(diagnostic.HookID, diagnostic.FieldPath, string(diagnostic.Source), "hooks")
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.hooks.diagnostic",
+			Surface: "hooks",
+			Target:  redactSnapshotString(target),
+			Status:  hookDiagnosticStatus(diagnostic.Kind),
+			Message: redactSnapshotString(diagnostic.Message),
+			Action:  "zero hooks list",
+			Details: compactDetails(map[string]string{
+				"kind":      string(diagnostic.Kind),
+				"source":    string(diagnostic.Source),
+				"path":      diagnostic.Path,
+				"fieldPath": diagnostic.FieldPath,
+			}),
+		})
+	}
+	if len(checks) == 0 {
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.hooks.configured",
+			Surface: "hooks",
+			Target:  "hooks",
+			Status:  BackendDoctorStatusPass,
+			Message: fmt.Sprintf("%d hooks configured.", len(result.Config.Hooks)),
+			Action:  "zero hooks list",
+		})
+	}
+	return checks
+}
+
+func pluginDoctorChecks(result plugins.LoadResult) []BackendDoctorCheck {
+	checks := []BackendDoctorCheck{}
+	if len(result.Plugins) == 0 && len(result.Diagnostics) == 0 {
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.plugins.configured",
+			Surface: "plugins",
+			Target:  "plugins",
+			Status:  BackendDoctorStatusPass,
+			Message: "No plugins loaded.",
+			Action:  "zero plugins list",
+		})
+	}
+	for _, plugin := range result.Plugins {
+		if plugin.Enabled {
+			continue
+		}
+		target := redactSnapshotString(plugin.ID)
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.plugins.disabled",
+			Surface: "plugins",
+			Target:  target,
+			Status:  BackendDoctorStatusWarn,
+			Message: fmt.Sprintf("Plugin %s is disabled.", target),
+			Action:  "zero plugins list",
+		})
+	}
+	for _, diagnostic := range result.Diagnostics {
+		target := firstNonEmpty(diagnostic.PluginID, diagnostic.FieldPath, string(diagnostic.Source), "plugins")
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.plugins.diagnostic",
+			Surface: "plugins",
+			Target:  redactSnapshotString(target),
+			Status:  pluginDiagnosticStatus(diagnostic.Kind),
+			Message: redactSnapshotString(diagnostic.Message),
+			Action:  "zero plugins list",
+			Details: compactDetails(map[string]string{
+				"kind":         string(diagnostic.Kind),
+				"source":       string(diagnostic.Source),
+				"root":         diagnostic.Root,
+				"pluginPath":   diagnostic.PluginPath,
+				"manifestPath": diagnostic.ManifestPath,
+				"fieldPath":    diagnostic.FieldPath,
+			}),
+		})
+	}
+	if len(checks) == 0 {
+		checks = append(checks, BackendDoctorCheck{
+			ID:      "backend.plugins.configured",
+			Surface: "plugins",
+			Target:  "plugins",
+			Status:  BackendDoctorStatusPass,
+			Message: fmt.Sprintf("%d plugins loaded.", len(result.Plugins)),
+			Action:  "zero plugins list",
+		})
+	}
+	return checks
+}
+
+func hookDiagnosticStatus(kind hooks.DiagnosticKind) BackendDoctorStatus {
+	if kind == hooks.DiagnosticDuplicate {
+		return BackendDoctorStatusWarn
+	}
+	return BackendDoctorStatusFail
+}
+
+func pluginDiagnosticStatus(kind plugins.DiagnosticKind) BackendDoctorStatus {
+	if kind == plugins.DiagnosticDuplicate {
+		return BackendDoctorStatusWarn
+	}
+	return BackendDoctorStatusFail
+}
+
+func compactDetails(values map[string]string) map[string]string {
+	out := map[string]string{}
+	for key, value := range values {
+		value = redactSnapshotString(value)
+		if value != "" {
+			out[key] = value
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/zerocommands/backend_doctor_test.go
+++ b/internal/zerocommands/backend_doctor_test.go
@@ -1,0 +1,128 @@
+package zerocommands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/hooks"
+	"github.com/Gitlawb/zero/internal/plugins"
+)
+
+func TestNewBackendDoctorReportSurfacesDiagnosticsAndActions(t *testing.T) {
+	secret := "sk-proj-" + strings.Repeat("a", 24)
+	report := NewBackendDoctorReport(BackendDoctorInput{
+		MCP: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"remote": {
+				Type: "http",
+				URL:  "https://api.example.com/mcp?token=" + secret,
+			},
+			"broken": {
+				Type: "http",
+			},
+			"disabled": {
+				Type:     "stdio",
+				Command:  "docs-mcp",
+				Disabled: true,
+			},
+		}},
+		Hooks: hooks.LoadResult{
+			Config: hooks.Config{Enabled: false, Hooks: []hooks.Definition{{
+				ID:      "zero.preflight",
+				Event:   hooks.EventBeforeTool,
+				Command: "sh",
+				Enabled: true,
+			}}},
+			Diagnostics: []hooks.Diagnostic{{
+				Kind:      hooks.DiagnosticSchema,
+				Message:   "bad arg " + secret,
+				Path:      "/tmp/" + secret + "/hooks.json",
+				HookID:    "zero.preflight-" + secret,
+				FieldPath: "hooks.0.command." + secret,
+			}},
+		},
+		Plugins: plugins.LoadResult{
+			Plugins: []plugins.LoadedPlugin{{
+				ID:      "zero.docs",
+				Name:    "Docs",
+				Enabled: false,
+				Source:  plugins.SourceProject,
+			}},
+			Diagnostics: []plugins.Diagnostic{{
+				Kind:         plugins.DiagnosticDuplicate,
+				Message:      "duplicate " + secret,
+				Root:         "/tmp/" + secret + "/plugins",
+				PluginPath:   "/tmp/" + secret + "/plugins/docs",
+				ManifestPath: "/tmp/plugin.json?token=" + secret,
+				FieldPath:    "tools.0.command." + secret,
+				PluginID:     "zero.docs-" + secret,
+			}},
+		},
+	})
+
+	if report.OK {
+		t.Fatalf("report.OK = true, want false because broken MCP and hook schema diagnostics exist: %#v", report.Checks)
+	}
+	if report.Status != BackendDoctorStatusFail {
+		t.Fatalf("report.Status = %q, want %q", report.Status, BackendDoctorStatusFail)
+	}
+	assertBackendDoctorCheck(t, report, "backend.mcp.server", "remote", BackendDoctorStatusPass, "zero mcp check remote")
+	assertBackendDoctorCheck(t, report, "backend.mcp.invalid", "broken", BackendDoctorStatusFail, "zero mcp add broken")
+	assertBackendDoctorCheck(t, report, "backend.mcp.disabled", "disabled", BackendDoctorStatusWarn, "zero mcp enable disabled")
+	assertBackendDoctorCheck(t, report, "backend.hooks.disabled", "hooks", BackendDoctorStatusWarn, "zero hooks list")
+	assertBackendDoctorCheck(t, report, "backend.hooks.diagnostic", "zero.preflight-[REDACTED]", BackendDoctorStatusFail, "zero hooks list")
+	assertBackendDoctorCheck(t, report, "backend.plugins.disabled", "zero.docs", BackendDoctorStatusWarn, "zero plugins list")
+	assertBackendDoctorCheck(t, report, "backend.plugins.diagnostic", "zero.docs-[REDACTED]", BackendDoctorStatusWarn, "zero plugins list")
+
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(encoded), secret) || strings.Contains(string(encoded), "sk-proj-") {
+		t.Fatalf("backend doctor report leaked secret material: %s", string(encoded))
+	}
+}
+
+func TestNewBackendDoctorReportPassesEmptySetup(t *testing.T) {
+	report := NewBackendDoctorReport(BackendDoctorInput{})
+	if !report.OK {
+		t.Fatalf("empty setup should be a passing report, got %#v", report.Checks)
+	}
+	if report.Status != BackendDoctorStatusPass {
+		t.Fatalf("report.Status = %q, want %q", report.Status, BackendDoctorStatusPass)
+	}
+	assertBackendDoctorCheck(t, report, "backend.mcp.configured", "mcp", BackendDoctorStatusPass, "zero mcp add")
+	assertBackendDoctorCheck(t, report, "backend.hooks.configured", "hooks", BackendDoctorStatusPass, "zero hooks list")
+	assertBackendDoctorCheck(t, report, "backend.plugins.configured", "plugins", BackendDoctorStatusPass, "zero plugins list")
+}
+
+func TestNewBackendDoctorReportWarnsWithoutFailing(t *testing.T) {
+	report := NewBackendDoctorReport(BackendDoctorInput{
+		MCP: config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+			"disabled": {Type: "stdio", Command: "docs-mcp", Disabled: true},
+		}},
+	})
+	if !report.OK {
+		t.Fatalf("warning-only report should keep OK=true, got %#v", report.Checks)
+	}
+	if report.Status != BackendDoctorStatusWarn {
+		t.Fatalf("report.Status = %q, want %q", report.Status, BackendDoctorStatusWarn)
+	}
+}
+
+func assertBackendDoctorCheck(t *testing.T, report BackendDoctorReport, id string, target string, status BackendDoctorStatus, actionContains string) {
+	t.Helper()
+	for _, check := range report.Checks {
+		if check.ID == id && check.Target == target {
+			if check.Status != status {
+				t.Fatalf("%s/%s status = %q, want %q (check %#v)", id, target, check.Status, status, check)
+			}
+			if actionContains != "" && !strings.Contains(check.Action, actionContains) {
+				t.Fatalf("%s/%s action = %q, want to contain %q", id, target, check.Action, actionContains)
+			}
+			return
+		}
+	}
+	t.Fatalf("check %s/%s not found in %#v", id, target, report.Checks)
+}

--- a/internal/zerocommands/backend_snapshots.go
+++ b/internal/zerocommands/backend_snapshots.go
@@ -100,7 +100,6 @@ func MCPServerSnapshotFromServer(server mcp.Server) MCPServerSnapshot {
 	return MCPServerSnapshot{
 		Name:        strings.TrimSpace(server.Name),
 		Type:        string(server.Type),
-		Identity:    strings.TrimSpace(server.Identity),
 		URL:         stripURLCredentialsFromURL(server.URL),
 		Command:     redactSnapshotString(server.Command),
 		ArgCount:    len(server.Args),
@@ -297,10 +296,10 @@ func stripURLCredentialsFromURL(value string) string {
 	}
 	parsed, err := url.Parse(trimmed)
 	if err != nil || parsed == nil {
-		return trimmed
+		return redactSnapshotString(trimmed)
 	}
 	if parsed.Scheme == "" && parsed.Host == "" {
-		return trimmed
+		return redactSnapshotString(trimmed)
 	}
 	if parsed.User == nil {
 		return redactSensitiveURLQuery(parsed, trimmed)

--- a/internal/zerocommands/backend_snapshots_test.go
+++ b/internal/zerocommands/backend_snapshots_test.go
@@ -31,8 +31,8 @@ func TestMCPServerSnapshotFromServerStripsSecretsAndCountsMaps(t *testing.T) {
 	if snapshot.Name != "work" {
 		t.Fatalf("Name not trimmed: %q", snapshot.Name)
 	}
-	if snapshot.Identity != "work-fs" {
-		t.Fatalf("Identity not trimmed: %q", snapshot.Identity)
+	if snapshot.Identity != "" {
+		t.Fatalf("Identity should not be exposed in operator snapshots, got %q", snapshot.Identity)
 	}
 	if snapshot.Command != "npx" {
 		t.Fatalf("Command not trimmed: %q", snapshot.Command)
@@ -281,6 +281,43 @@ func TestMCPServerSnapshotKeepsUnparseableURLInsteadOfEmpty(t *testing.T) {
 	}
 	if snapshot.URL != "not a url but still useful" {
 		t.Fatalf("expected trimmed raw URL, got %q", snapshot.URL)
+	}
+}
+
+func TestMCPServerSnapshotRedactsMalformedURLSecretText(t *testing.T) {
+	server := mcp.Server{
+		Name: "broken-secret",
+		Type: mcp.ServerTypeHTTP,
+		URL:  "  not a url token=plain-backend-secret  ",
+	}
+	snapshot := MCPServerSnapshotFromServer(server)
+	encoded, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(encoded), "plain-backend-secret") {
+		t.Fatalf("malformed URL secret should be redacted, got %s", string(encoded))
+	}
+}
+
+func TestMCPServerSnapshotOmitsSecretDerivedIdentity(t *testing.T) {
+	first := MCPServerSnapshotFromServer(mcp.Server{
+		Name:     "same",
+		Type:     mcp.ServerTypeStdio,
+		Command:  "npx",
+		Identity: "identity-derived-from-secret-one",
+	})
+	second := MCPServerSnapshotFromServer(mcp.Server{
+		Name:     "same",
+		Type:     mcp.ServerTypeStdio,
+		Command:  "npx",
+		Identity: "identity-derived-from-secret-two",
+	})
+	if first.Identity != "" || second.Identity != "" {
+		t.Fatalf("operator snapshots must omit secret-derived identities, got %q and %q", first.Identity, second.Identity)
+	}
+	if first != second {
+		t.Fatalf("snapshots should not differ only because secret-derived identity differs: %#v %#v", first, second)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `zero backends doctor` with text and JSON diagnostics for MCP, hooks, and plugins.
- Keep the doctor path offline-safe: reads local config/manifests only and never registers/connects MCP tools or executes hooks/plugins.
- Add actionable next commands for each check, plus pass/warn/fail status and proper exit behavior.
- Harden backend snapshots by omitting secret-derived MCP identity and redacting malformed URL text.

## Stacking
This PR is stacked on `feat/backend-status-contract` / #192. After #192 merges, this can be retargeted to `main` or rebased.

## Validation
- `gofmt -l internal\cli internal\zerocommands`
- `go vet ./...`
- `go build ./...`
- `go test ./... -timeout 300s`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`
- `go run ./cmd/zero backends doctor`
- `go run ./cmd/zero backends doctor --json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `zero backends doctor` to check backend health across MCP servers, hooks, and plugins
  * Produces pass/warn/fail summaries with optional remediation actions
  * Supports both `--json` output and human-readable text, including updated command help
* **Bug Fixes**
  * Strengthened sanitization for backend diagnostic snapshots by omitting identity fields and redacting secret-like URL contents, even for malformed URLs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->