### PR TITLE
Remove superseded and dead utility functions

### DIFF
--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -199,7 +199,6 @@ func CoreReadOnlyToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 	}
 }
 
-func CoreWriteTools(workspaceRoot string) []Tool { return CoreWriteToolsScoped(workspaceRoot, nil) }
 func CoreWriteToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 	return []Tool{
 		NewScopedWriteFileTool(workspaceRoot, scope),
@@ -209,7 +208,6 @@ func CoreWriteToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 	}
 }
 
-func CoreShellTools(workspaceRoot string) []Tool { return CoreShellToolsScoped(workspaceRoot, nil) }
 func CoreShellToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 	return []Tool{
 		NewScopedBashTool(workspaceRoot, scope),

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -81,7 +81,6 @@ type tuiTheme struct {
 // ink so every pairing survives 256-color downsampling.
 const (
 	colorPanel    = "#0e0e10" // card backgrounds
-	colorPanel2   = "#121215" // card header rows, picker rows
 	colorPanel3   = "#17171b" // selected/hovered row bg
 	colorLine     = "#242429" // default borders, rules
 	colorLine2    = "#414147" // emphasized borders
@@ -164,11 +163,6 @@ var zeroTheme = tuiTheme{
 // wrap their foreground styles through this instead of referencing hex.
 func (t tuiTheme) onPanel(style lipgloss.Style) lipgloss.Style {
 	return style.Background(lipgloss.Color(colorPanel))
-}
-
-// onPanel2 paints on the header/picker-row surface.
-func (t tuiTheme) onPanel2(style lipgloss.Style) lipgloss.Style {
-	return style.Background(lipgloss.Color(colorPanel2))
 }
 
 // onSel paints on the selected-row tint.

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -790,15 +790,6 @@ func firstArgValue(raw string, keys []string) string {
 	return ""
 }
 
-func indentText(text string, spaces int) string {
-	prefix := strings.Repeat(" ", spaces)
-	lines := strings.Split(text, "\n")
-	for index, line := range lines {
-		lines[index] = prefix + line
-	}
-	return strings.Join(lines, "\n")
-}
-
 // looksLikeDiff reports whether output should be rendered as a diff card: a
 // real hunk header, or both old/new file headers. A single line starting with
 // "---" (a Markdown rule, YAML document marker, log separator…) must NOT

--- a/internal/workspaceindex/workspaceindex.go
+++ b/internal/workspaceindex/workspaceindex.go
@@ -316,16 +316,6 @@ func normalizeSeparators(rel string) string {
 	return strings.ReplaceAll(filepath.ToSlash(rel), "\\", "/")
 }
 
-func MaxFileDepth(files []File) int {
-	maxDepth := 0
-	for _, file := range files {
-		if file.Depth > maxDepth {
-			maxDepth = file.Depth
-		}
-	}
-	return maxDepth
-}
-
 func SortFiles(files []File) {
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].Path < files[j].Path


### PR DESCRIPTION
## Summary

Behavior-preserving removal of dead utility code — functions unreachable from `cmd/*` **and** from the test suite (`deadcode -test ./...`), so deleting them changes no behavior.

Removed:
- `tools.CoreWriteTools` / `CoreShellTools` — superseded by the `…Scoped` variants (the live registration path).
- `workspaceindex.MaxFileDepth` — unused helper.
- `tui.indentText` — unused string utility.
- `tuiTheme.onPanel2` + the now-orphaned `colorPanel2` const — unused style helper.

## Scope (deliberately narrow)

This is the **safe-cleanup** slice only — genuine cruft with no feature intent. The other ~18 truly-dead funcs are **dormant/intended-but-unwired features** (e.g. `tui/composer.go` line-editing, `tui/mcp_view.go` helpers, `sessions.ReplayEvents`, `agenteval` scoring). Those are wire-vs-delete decisions for their owners, not blind deletes, so they're intentionally left out.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean; full `go test ./...` green.
- `deadcode -test=false ./...`: **114 → 109**; truly-dead: **23 → 18**.
- `sandbox/seccomp_other.go: ApplyUnixSocketBlock` intentionally kept (non-Linux no-op stub).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code consolidation and cleanup to improve maintainability and reduce redundant utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->