### PR TITLE
feat: add TUI diagnostics center

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -415,6 +415,12 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	if err != nil {
 		return writeAppError(stderr, "failed to resolve user config path: "+err.Error(), 1)
 	}
+	doctorUserConfigPath := ""
+	projectConfigPath := ""
+	if resolveOptions, optErr := config.DefaultResolveOptions(workspaceRoot); optErr == nil {
+		doctorUserConfigPath = resolveOptions.UserConfigPath
+		projectConfigPath = resolveOptions.ProjectConfigPath
+	}
 
 	needsSetup := setupRequired(resolved)
 	setupVisible := forceSetup || needsSetup
@@ -507,20 +513,24 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	})
 	lastKnownMCPConfig := mcpConfig
 	return deps.runTUI(context.Background(), tui.Options{
-		Cwd:                workspaceRoot,
-		UserConfigPath:     userConfigPath,
-		ProviderName:       resolved.Provider.Name,
-		ModelName:          resolved.Provider.Model,
-		ProviderProfile:    resolved.Provider,
-		FavoriteModels:     resolved.Preferences.FavoriteModels,
-		Provider:           provider,
-		NewProvider:        deps.newProvider,
-		Registry:           registry,
-		SessionStore:       deps.newSessionStore(),
-		SandboxStore:       sandboxStore,
-		MCPConfig:          mcpConfig,
-		MCPPermissionStore: mcpPermissionStore,
-		MCPTokenStore:      mcpTokenStore,
+		Cwd:                  workspaceRoot,
+		UserConfigPath:       userConfigPath,
+		DoctorUserConfigPath: doctorUserConfigPath,
+		ProjectConfigPath:    projectConfigPath,
+		ProviderName:         resolved.Provider.Name,
+		ModelName:            resolved.Provider.Model,
+		ProviderProfile:      resolved.Provider,
+		FavoriteModels:       resolved.Preferences.FavoriteModels,
+		Provider:             provider,
+		NewProvider:          deps.newProvider,
+		ProbeProviderHealth:  deps.probeProviderHealth,
+		UserAgent:            userAgent(),
+		Registry:             registry,
+		SessionStore:         deps.newSessionStore(),
+		SandboxStore:         sandboxStore,
+		MCPConfig:            mcpConfig,
+		MCPPermissionStore:   mcpPermissionStore,
+		MCPTokenStore:        mcpTokenStore,
 		MCPCommand: func(ctx context.Context, args []string) tui.MCPCommandResult {
 			if ctx == nil {
 				ctx = context.Background()

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -59,10 +60,38 @@ func TestRunPrintsHelp(t *testing.T) {
 	}
 }
 
+func setCLIUserConfigRoot(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("APPDATA", root)
+	case "darwin":
+		t.Setenv("HOME", root)
+	default:
+		t.Setenv("XDG_CONFIG_HOME", root)
+	}
+
+	configRoot, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error = %v", err)
+	}
+	return configRoot
+}
+
 func TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cwd := t.TempDir()
+	setCLIUserConfigRoot(t)
+	projectConfigPath := filepath.Join(cwd, ".zero", "config.json")
+	if err := os.MkdirAll(filepath.Dir(projectConfigPath), 0o700); err != nil {
+		t.Fatalf("create project config parent: %v", err)
+	}
+	if err := os.WriteFile(projectConfigPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
 	userConfigPath := filepath.Join(t.TempDir(), "zero", "config.json")
 	var launchedOptions tui.Options
 
@@ -103,6 +132,12 @@ func TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured(t *tes
 	}
 	if launchedOptions.UserConfigPath != userConfigPath {
 		t.Fatalf("UserConfigPath = %q, want %q", launchedOptions.UserConfigPath, userConfigPath)
+	}
+	if launchedOptions.DoctorUserConfigPath != "" {
+		t.Fatalf("DoctorUserConfigPath = %q, want empty for missing user config", launchedOptions.DoctorUserConfigPath)
+	}
+	if launchedOptions.ProjectConfigPath != projectConfigPath {
+		t.Fatalf("ProjectConfigPath = %q, want %q", launchedOptions.ProjectConfigPath, projectConfigPath)
 	}
 	if launchedOptions.Provider != nil {
 		t.Fatalf("Provider = %#v, want nil", launchedOptions.Provider)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -158,6 +158,9 @@ func providerModelCheck(profile config.ProviderProfile) Check {
 	if emptyProviderProfile(profile) {
 		return check("provider.model", "Provider model", StatusWarn, "Model validity was skipped because provider config is unavailable.", nil)
 	}
+	if strings.TrimSpace(profile.Model) == "" {
+		return check("provider.model", "Provider model", StatusFail, "Provider model is required.", map[string]any{"provider": providerName(profile)})
+	}
 	registry, err := modelregistry.DefaultRegistry()
 	if err != nil {
 		return check("provider.model", "Provider model", StatusFail, "Model registry could not be loaded: "+err.Error(), nil)
@@ -165,7 +168,7 @@ func providerModelCheck(profile config.ProviderProfile) Check {
 	model, err := registry.Require(profile.Model)
 	if err != nil {
 		if profile.ProviderKind == config.ProviderKindOpenAICompatible || profile.ProviderKind == config.ProviderKindAnthropicCompat {
-			return check("provider.model", "Provider model", StatusWarn, fmt.Sprintf("Custom %s model was not found in the Zero registry; runtime will pass it through to the configured provider.", profile.ProviderKind), map[string]any{"model": profile.Model, "provider": providerName(profile)})
+			return check("provider.model", "Provider model", StatusWarn, fmt.Sprintf("Custom %s model was not found in the Zero registry; runtime will pass it through to the configured provider. Run `zero doctor --connectivity` to validate the endpoint and auth.", profile.ProviderKind), map[string]any{"model": profile.Model, "provider": providerName(profile)})
 		}
 		return check("provider.model", "Provider model", StatusFail, "Provider model is invalid: "+err.Error(), map[string]any{"model": profile.Model})
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -86,6 +86,96 @@ func TestRunReportWarnsForUnknownOpenAICompatibleModel(t *testing.T) {
 	}
 }
 
+func TestProviderModelUnknownOpenAICompatibleModelWarnsPassThrough(t *testing.T) {
+	report := Run(Options{
+		Now:     fixedDoctorClock("2026-06-04T15:45:00Z"),
+		Runtime: "go",
+		Provider: config.ProviderProfile{
+			Name:         "openrouter",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://openrouter.ai/api/v1",
+			Model:        "vendor/new-dynamic-model",
+		},
+	})
+
+	if !report.OK {
+		t.Fatalf("unknown openai-compatible model should warn, not fail: %#v", report)
+	}
+	check := report.Check("provider.model")
+	if check == nil {
+		t.Fatalf("expected provider.model check: %#v", report.Checks)
+	}
+	if check.Status != StatusWarn {
+		t.Fatalf("provider.model status = %s, want warn: %#v", check.Status, check)
+	}
+	if !strings.Contains(check.Message, "runtime will pass it through") || !strings.Contains(check.Message, "doctor --connectivity") {
+		t.Fatalf("provider.model message should explain pass-through connectivity validation, got %q", check.Message)
+	}
+}
+
+func TestProviderModelMissingModelFails(t *testing.T) {
+	report := Run(Options{
+		Now:     fixedDoctorClock("2026-06-04T15:45:00Z"),
+		Runtime: "go",
+		Provider: config.ProviderProfile{
+			Name:         "ollama-cloud",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://ollama.com/v1",
+			Model:        "   ",
+		},
+	})
+
+	if report.OK {
+		t.Fatalf("missing model should fail: %#v", report)
+	}
+	check := report.Check("provider.model")
+	if check == nil || check.Status != StatusFail || !strings.Contains(check.Message, "required") {
+		t.Fatalf("expected missing model failure: %#v", report.Checks)
+	}
+}
+
+func TestProviderModelBuiltInUnknownModelFails(t *testing.T) {
+	report := Run(Options{
+		Now:     fixedDoctorClock("2026-06-04T15:45:00Z"),
+		Runtime: "go",
+		Provider: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      config.OpenAIBaseURL,
+			Model:        "vendor/new-dynamic-model",
+		},
+	})
+
+	if report.OK {
+		t.Fatalf("built-in provider unknown model should fail: %#v", report)
+	}
+	check := report.Check("provider.model")
+	if check == nil || check.Status != StatusFail || !strings.Contains(check.Message, "unknown Zero model") {
+		t.Fatalf("expected built-in unknown model failure: %#v", report.Checks)
+	}
+}
+
+func TestProviderModelRegisteredProviderMismatchFails(t *testing.T) {
+	report := Run(Options{
+		Now:     fixedDoctorClock("2026-06-04T15:45:00Z"),
+		Runtime: "go",
+		Provider: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			BaseURL:      config.OpenAIBaseURL,
+			Model:        "gemini-2.5-pro",
+		},
+	})
+
+	if report.OK {
+		t.Fatalf("registered provider mismatch should fail: %#v", report)
+	}
+	check := report.Check("provider.model")
+	if check == nil || check.Status != StatusFail || !strings.Contains(check.Message, "not available for provider") {
+		t.Fatalf("expected registered provider mismatch failure: %#v", report.Checks)
+	}
+}
+
 func writeDoctorConfig(t *testing.T, body string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/doctor"
 	"github.com/Gitlawb/zero/internal/modelregistry"
@@ -14,13 +16,75 @@ import (
 	zsearch "github.com/Gitlawb/zero/internal/search"
 )
 
-func (m model) doctorText() string {
-	report := doctor.Run(doctor.Options{
-		Now:      m.now,
-		Runtime:  "go",
-		Provider: m.providerProfile,
+func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
+	connectivity, help, err := parseDoctorCommandArgs(args)
+	if err != nil {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorUsageText(commandStatusBlocked, err.Error())})
+		return m, nil
+	}
+	if help {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorUsageText(commandStatusInfo, "Show local diagnostics for provider, model, sandbox, LSP, and backend setup.")})
+		return m, nil
+	}
+	if !connectivity {
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.doctorText(false)})
+		return m, nil
+	}
+
+	m.doctorCommandSeq++
+	id := m.doctorCommandSeq
+	snapshot := m
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorConnectivityRunningText()})
+	return m, func() tea.Msg {
+		return doctorCommandResultMsg{id: id, text: snapshot.doctorText(true)}
+	}
+}
+
+func (m model) doctorText(connectivity bool) string {
+	report := doctor.Run(m.doctorOptions(connectivity))
+	return renderCommandOutput(doctorCommandOutput(report, nil))
+}
+
+func parseDoctorCommandArgs(args string) (connectivity bool, help bool, err error) {
+	for _, field := range strings.Fields(args) {
+		switch strings.ToLower(field) {
+		case "--connectivity", "connectivity":
+			connectivity = true
+		case "-h", "--help", "help":
+			help = true
+		default:
+			return false, false, fmt.Errorf("unknown doctor flag %q", field)
+		}
+	}
+	return connectivity, help, nil
+}
+
+func doctorUsageText(status commandStatus, message string) string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Diagnostics",
+		Status: status,
+		Sections: []commandSection{{
+			Title: "Usage",
+			Lines: []string{
+				message,
+				"/doctor",
+				"/doctor --connectivity",
+				"/health",
+			},
+		}},
 	})
-	return doctor.Format(report)
+}
+
+func doctorConnectivityRunningText() string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Diagnostics",
+		Status: commandStatusInfo,
+		Sections: []commandSection{{
+			Title: "Provider",
+			Lines: []string{"checking provider connectivity..."},
+		}},
+		Hints: []string{"keep typing; Zero will append the result when the probe finishes"},
+	})
 }
 
 func (m model) searchText(query string) string {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -211,10 +211,18 @@ var commandDefinitions = []commandDefinition{
 		kind:        commandSelfCorrect,
 	},
 	{
+		name:        "/help",
+		usage:       "/help",
+		group:       commandGroupMeta,
+		description: "Show available commands.",
+		kind:        commandHelp,
+	},
+	{
 		name:        "/doctor",
-		usage:       "/doctor",
+		aliases:     []string{"/health"},
+		usage:       "/doctor [--connectivity]",
 		group:       commandGroupRuntime,
-		description: "Show local diagnostics.",
+		description: "Show local diagnostics, including optional connectivity checks.",
 		kind:        commandDoctor,
 	},
 	{
@@ -245,13 +253,6 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Show input style state.",
 		kind:        commandInputStyle,
-	},
-	{
-		name:        "/help",
-		usage:       "/help",
-		group:       commandGroupMeta,
-		description: "Show available commands.",
-		kind:        commandHelp,
 	},
 	{
 		name:        "/exit",

--- a/internal/tui/doctor_command_test.go
+++ b/internal/tui/doctor_command_test.go
@@ -1,0 +1,136 @@
+package tui
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/doctor"
+	"github.com/Gitlawb/zero/internal/providerhealth"
+)
+
+func TestDoctorOptionsIncludeConfigPaths(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		UserConfigPath:    "C:/zero/user.json",
+		ProjectConfigPath: "C:/repo/.zero/config.json",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			Model:        "gpt-4.1",
+		},
+	})
+
+	options := m.doctorOptions(false)
+
+	if options.UserConfig != "C:/zero/user.json" {
+		t.Fatalf("UserConfig = %q, want %q", options.UserConfig, "C:/zero/user.json")
+	}
+	if options.ProjectConfig != "C:/repo/.zero/config.json" {
+		t.Fatalf("ProjectConfig = %q, want %q", options.ProjectConfig, "C:/repo/.zero/config.json")
+	}
+	if options.Connectivity {
+		t.Fatal("Connectivity = true, want false")
+	}
+	if options.ProviderHealth != nil {
+		t.Fatalf("ProviderHealth = %#v, want nil without connectivity", options.ProviderHealth)
+	}
+}
+
+func TestDoctorOptionsConnectivityInvokesConfiguredProviderHealthProbe(t *testing.T) {
+	profile := config.ProviderProfile{
+		Name:         "custom",
+		ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL:      "https://api.example.com/v1",
+		Model:        "custom-model",
+	}
+	var called int
+	var gotOptions providerhealth.Options
+	m := newModel(context.Background(), Options{
+		ProviderProfile: profile,
+		UserAgent:       "zero-test",
+		ProbeProviderHealth: func(_ context.Context, options providerhealth.Options) providerhealth.Result {
+			called++
+			gotOptions = options
+			return providerhealth.Result{
+				Status: providerhealth.StatusPass,
+				Checks: []providerhealth.Check{{
+					ID:      "provider.connectivity",
+					Status:  providerhealth.StatusPass,
+					Message: "reachable",
+				}},
+			}
+		},
+	})
+
+	options := m.doctorOptions(true)
+	report := doctor.Run(options)
+
+	if called != 1 {
+		t.Fatalf("probe called %d time(s), want 1", called)
+	}
+	if !gotOptions.Connectivity {
+		t.Fatal("probe Connectivity = false, want true")
+	}
+	if gotOptions.UserAgent != "zero-test" {
+		t.Fatalf("probe UserAgent = %q, want %q", gotOptions.UserAgent, "zero-test")
+	}
+	if !reflect.DeepEqual(gotOptions.Profile, profile) {
+		t.Fatalf("probe Profile = %#v, want %#v", gotOptions.Profile, profile)
+	}
+	check := report.Check("provider.connectivity")
+	if options.ProviderHealth == nil || check == nil || check.Status != doctor.StatusPass {
+		t.Fatalf("connectivity check = %#v, ProviderHealth = %#v; want passing injected health", check, options.ProviderHealth)
+	}
+}
+
+func TestDoctorConnectivityCommandRunsProbeAsynchronously(t *testing.T) {
+	profile := config.ProviderProfile{
+		Name:         "custom",
+		ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL:      "https://api.example.com/v1",
+		Model:        "custom-model",
+	}
+	called := false
+	m := newModel(context.Background(), Options{
+		ProviderProfile: profile,
+		ProbeProviderHealth: func(context.Context, providerhealth.Options) providerhealth.Result {
+			called = true
+			return providerhealth.Result{
+				Status: providerhealth.StatusPass,
+				Checks: []providerhealth.Check{{
+					ID:      "provider.connectivity",
+					Status:  providerhealth.StatusPass,
+					Message: "reachable",
+				}},
+			}
+		},
+	})
+	m.input.SetValue("/doctor --connectivity")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected /doctor --connectivity to return an async command")
+	}
+	if called {
+		t.Fatal("provider probe ran synchronously before the returned command executed")
+	}
+	if !transcriptContains(next.transcript, "checking provider connectivity") {
+		t.Fatalf("expected running doctor status, got %#v", next.transcript)
+	}
+
+	msg := cmd()
+	if !called {
+		t.Fatal("provider probe did not run when the async command executed")
+	}
+	updated, _ = next.Update(msg)
+	final := updated.(model)
+	for _, want := range []string{"Diagnostics", "[pass] provider.connectivity", "reachable"} {
+		if !transcriptContains(final.transcript, want) {
+			t.Fatalf("expected final doctor transcript to contain %q, got %#v", want, final.transcript)
+		}
+	}
+}

--- a/internal/tui/doctor_view.go
+++ b/internal/tui/doctor_view.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/doctor"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+func doctorCommandOutput(report doctor.Report, backend *zerocommands.BackendLifecycleSnapshot) commandOutput {
+	sections := []commandSection{}
+	if report.GeneratedAt != "" {
+		sections = append(sections, commandSection{
+			Title: "Summary",
+			Fields: []commandField{
+				{Key: "Generated", Value: report.GeneratedAt},
+				{Key: "Checks", Value: fmt.Sprintf("%d", len(report.Checks))},
+			},
+		})
+	}
+
+	provider, platform, other := doctorCheckSections(report.Checks)
+	sections = appendNonEmptyDoctorSection(sections, "Provider", provider)
+	sections = appendNonEmptyDoctorSection(sections, "Platform", platform)
+	sections = appendNonEmptyDoctorSection(sections, "Other", other)
+	if backend != nil {
+		sections = append(sections, doctorBackendSection(*backend))
+	}
+
+	return commandOutput{
+		Title:    "Diagnostics",
+		Status:   doctorCommandStatus(report),
+		Sections: sections,
+		Hints:    doctorHints(report.Checks, backend),
+	}
+}
+
+func doctorCommandStatus(report doctor.Report) commandStatus {
+	hasWarning := false
+	for _, check := range report.Checks {
+		switch check.Status {
+		case doctor.StatusFail:
+			return commandStatusBlocked
+		case doctor.StatusWarn:
+			hasWarning = true
+		}
+	}
+	if hasWarning {
+		return commandStatusWarning
+	}
+	return commandStatusOK
+}
+
+func doctorCheckSections(checks []doctor.Check) (provider []commandRow, platform []commandRow, other []commandRow) {
+	for _, check := range checks {
+		row := commandRow{Text: doctorCheckRow(check)}
+		switch doctorCheckGroup(check.ID) {
+		case "provider":
+			provider = append(provider, row)
+		case "platform":
+			platform = append(platform, row)
+		default:
+			other = append(other, row)
+		}
+	}
+	return provider, platform, other
+}
+
+func doctorCheckGroup(id string) string {
+	switch id {
+	case "provider.config", "provider.model", "provider.connectivity", "provider.auth", "provider.runtime":
+		return "provider"
+	case "sandbox.backend", "lsp.servers", "runtime.go", "config.files", "config.validation":
+		return "platform"
+	default:
+		return ""
+	}
+}
+
+func doctorCheckRow(check doctor.Check) string {
+	parts := []string{fmt.Sprintf("[%s]", check.Status)}
+	if check.ID != "" {
+		parts = append(parts, check.ID)
+	}
+	if check.Message != "" {
+		parts = append(parts, "-", check.Message)
+	}
+	return strings.Join(parts, " ")
+}
+
+func appendNonEmptyDoctorSection(sections []commandSection, title string, rows []commandRow) []commandSection {
+	if len(rows) == 0 {
+		return sections
+	}
+	return append(sections, commandSection{
+		Title: title,
+		Rows:  rows,
+	})
+}
+
+func doctorBackendSection(backend zerocommands.BackendLifecycleSnapshot) commandSection {
+	return commandSection{
+		Title: "Backend",
+		Fields: []commandField{
+			{Key: "MCP servers", Value: fmt.Sprintf("%d", len(backend.MCPServers))},
+			{Key: "Hooks", Value: fmt.Sprintf("%d", len(backend.Hooks))},
+			{Key: "Plugins", Value: fmt.Sprintf("%d", len(backend.Plugins))},
+		},
+	}
+}
+
+func doctorHints(checks []doctor.Check, backend *zerocommands.BackendLifecycleSnapshot) []string {
+	seen := map[string]bool{}
+	hints := []string{}
+	add := func(hint string) {
+		hint = strings.TrimSpace(hint)
+		if hint == "" || seen[hint] {
+			return
+		}
+		seen[hint] = true
+		hints = append(hints, hint)
+	}
+
+	for _, check := range checks {
+		if check.Status == doctor.StatusPass {
+			continue
+		}
+		message := strings.ToLower(check.Message)
+		switch check.ID {
+		case "provider.config", "provider.model":
+			add("use /provider to configure the active provider and model")
+		case "provider.connectivity":
+			add("use /doctor --connectivity to retry provider connectivity checks")
+		case "sandbox.backend":
+			if strings.Contains(message, "windows") || strings.Contains(message, "policy-only") {
+				add("run Zero inside WSL2 or a Linux container for native sandbox isolation on Windows")
+			}
+		case "lsp.servers":
+			if strings.Contains(message, "missing") {
+				add("install missing language servers so code intelligence is available on PATH")
+			}
+		}
+	}
+
+	if backend != nil {
+		add("use /mcp to inspect MCP servers")
+		add("use /hooks to inspect hooks")
+		add("use /plugins to inspect plugins")
+	}
+	return hints
+}

--- a/internal/tui/doctor_view_test.go
+++ b/internal/tui/doctor_view_test.go
@@ -1,0 +1,175 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/doctor"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+func TestDoctorCommandOutputMapsOverallStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []doctor.Check
+		want   commandStatus
+	}{
+		{
+			name: "all pass is ok",
+			checks: []doctor.Check{
+				doctorCheck("provider.config", doctor.StatusPass, "Provider config loaded."),
+				doctorCheck("runtime.go", doctor.StatusPass, "Go runtime is available."),
+			},
+			want: commandStatusOK,
+		},
+		{
+			name: "warnings only is warning",
+			checks: []doctor.Check{
+				doctorCheck("provider.config", doctor.StatusPass, "Provider config loaded."),
+				doctorCheck("lsp.servers", doctor.StatusWarn, "1 language server missing from PATH."),
+			},
+			want: commandStatusWarning,
+		},
+		{
+			name: "any failure is blocked",
+			checks: []doctor.Check{
+				doctorCheck("provider.config", doctor.StatusFail, "No LLM provider is configured."),
+				doctorCheck("runtime.go", doctor.StatusPass, "Go runtime is available."),
+			},
+			want: commandStatusBlocked,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output := doctorCommandOutput(doctor.Report{GeneratedAt: "2026-06-14T00:00:00Z", Checks: test.checks}, nil)
+			if output.Status != test.want {
+				t.Fatalf("Status = %q, want %q", output.Status, test.want)
+			}
+		})
+	}
+}
+
+func TestDoctorCommandOutputGroupsProviderAndPlatformChecks(t *testing.T) {
+	output := doctorCommandOutput(doctor.Report{Checks: []doctor.Check{
+		doctorCheck("provider.config", doctor.StatusPass, "Provider config loaded."),
+		doctorCheck("provider.model", doctor.StatusWarn, "Provider model is not configured."),
+		doctorCheck("provider.connectivity", doctor.StatusFail, "Provider connectivity failed."),
+		doctorCheck("sandbox.backend", doctor.StatusWarn, "No native sandbox backend on windows; ZERO falls back to policy-only preflight checks."),
+		doctorCheck("runtime.go", doctor.StatusPass, "Zero Go runtime is available."),
+		doctorCheck("config.files", doctor.StatusPass, "Zero config file inputs are available."),
+	}}, nil)
+
+	provider := doctorSection(output, "Provider")
+	if provider == nil {
+		t.Fatalf("missing Provider section: %#v", output.Sections)
+	}
+	assertRowsContain(t, provider.Rows, "provider.config", "provider.model", "provider.connectivity")
+
+	platform := doctorSection(output, "Platform")
+	if platform == nil {
+		t.Fatalf("missing Platform section: %#v", output.Sections)
+	}
+	assertRowsContain(t, platform.Rows, "sandbox.backend", "runtime.go", "config.files")
+}
+
+func TestDoctorCommandOutputAddsActionableHints(t *testing.T) {
+	output := doctorCommandOutput(doctor.Report{Checks: []doctor.Check{
+		doctorCheck("provider.config", doctor.StatusFail, "No LLM provider is configured."),
+		doctorCheck("provider.model", doctor.StatusWarn, "Provider model is not configured."),
+		doctorCheck("provider.connectivity", doctor.StatusWarn, "Provider connectivity was skipped."),
+		doctorCheck("sandbox.backend", doctor.StatusWarn, "No native sandbox backend on windows; ZERO falls back to policy-only preflight checks."),
+		doctorCheck("lsp.servers", doctor.StatusWarn, "2 language server(s) missing from PATH; affected files degrade to text-only edits."),
+	}}, nil)
+
+	text := formatCommandOutput(output)
+	for _, want := range []string{
+		"/provider",
+		"/doctor --connectivity",
+		"WSL2",
+		"Linux container",
+		"install missing language servers",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestDoctorCommandOutputIsNilBackendSafe(t *testing.T) {
+	output := doctorCommandOutput(doctor.Report{Checks: []doctor.Check{
+		doctorCheck("runtime.go", doctor.StatusPass, "Go runtime is available."),
+	}}, nil)
+
+	if section := doctorSection(output, "Backend"); section != nil {
+		t.Fatalf("unexpected Backend section for nil backend: %#v", section)
+	}
+}
+
+func TestDoctorCommandOutputIncludesBackendCountsAndHints(t *testing.T) {
+	backend := zerocommands.BackendLifecycleSnapshot{
+		MCPServers: []zerocommands.MCPServerSnapshot{{Name: "filesystem"}, {Name: "github"}},
+		Hooks:      []zerocommands.HookSnapshot{{ID: "lint", Enabled: true}},
+		Plugins:    []zerocommands.PluginSnapshot{{ID: "browser"}, {ID: "github"}, {ID: "linear"}},
+	}
+
+	output := doctorCommandOutput(doctor.Report{Checks: []doctor.Check{
+		doctorCheck("runtime.go", doctor.StatusPass, "Go runtime is available."),
+	}}, &backend)
+
+	section := doctorSection(output, "Backend")
+	if section == nil {
+		t.Fatalf("missing Backend section: %#v", output.Sections)
+	}
+	assertField(t, section.Fields, "MCP servers", "2")
+	assertField(t, section.Fields, "Hooks", "1")
+	assertField(t, section.Fields, "Plugins", "3")
+
+	text := formatCommandOutput(output)
+	for _, want := range []string{"/mcp", "/hooks", "/plugins"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func doctorCheck(id string, status doctor.Status, message string) doctor.Check {
+	return doctor.Check{
+		ID:      id,
+		Label:   id,
+		Status:  status,
+		Message: message,
+	}
+}
+
+func doctorSection(output commandOutput, title string) *commandSection {
+	for index := range output.Sections {
+		if output.Sections[index].Title == title {
+			return &output.Sections[index]
+		}
+	}
+	return nil
+}
+
+func assertRowsContain(t *testing.T, rows []commandRow, wants ...string) {
+	t.Helper()
+	text := ""
+	for _, row := range rows {
+		text += row.Text + "\n"
+	}
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			t.Fatalf("rows missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func assertField(t *testing.T, fields []commandField, key string, value string) {
+	t.Helper()
+	for _, field := range fields {
+		if field.Key == key && field.Value == value {
+			return
+		}
+	}
+	t.Fatalf("missing field %s=%s in %#v", key, value, fields)
+}

--- a/internal/tui/health_command_test.go
+++ b/internal/tui/health_command_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHealthCommandAliasResolvesToDoctor(t *testing.T) {
+	got := parseCommand("/health")
+	if got.kind != commandDoctor {
+		t.Fatalf("/health kind = %v, want %v", got.kind, commandDoctor)
+	}
+	if got.name != "/doctor" {
+		t.Fatalf("/health canonical name = %q, want /doctor", got.name)
+	}
+}
+
+func TestDoctorCommandPreservesConnectivityArgs(t *testing.T) {
+	got := parseCommand("/doctor --connectivity")
+	if got.kind != commandDoctor {
+		t.Fatalf("/doctor --connectivity kind = %v, want %v", got.kind, commandDoctor)
+	}
+	if got.text != "--connectivity" {
+		t.Fatalf("/doctor --connectivity text = %q, want --connectivity", got.text)
+	}
+}
+
+func TestDoctorHelpListsHealthAliasAndConnectivity(t *testing.T) {
+	help := strings.Join(formatCommandHelpLines(), "\n")
+
+	for _, want := range []string{
+		"/doctor [--connectivity] (/health)",
+		"connectivity",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("expected command help to contain %q, got:\n%s", want, help)
+		}
+	}
+}
+
+func TestHealthAliasIsDiscoverableByNamesAndAutocomplete(t *testing.T) {
+	if !healthCommandStringSliceContains(listCommandNames(), "/health") {
+		t.Fatalf("expected command names to contain /health, got %#v", listCommandNames())
+	}
+	if !healthCommandSuggestionNamesContain(matchCommandSuggestions("/hea"), "/doctor") {
+		t.Fatalf("expected autocomplete for /hea to surface canonical /doctor")
+	}
+}
+
+func healthCommandStringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func healthCommandSuggestionNamesContain(suggestions []commandSuggestion, want string) bool {
+	for _, suggestion := range suggestions {
+		if suggestion.Name == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,10 +17,12 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/doctor"
 	"github.com/Gitlawb/zero/internal/lsp"
 	internalmcp "github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/notify"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -37,12 +39,15 @@ type model struct {
 	ctx                    context.Context
 	cwd                    string
 	userConfigPath         string
+	doctorUserConfigPath   string
+	projectConfigPath      string
 	gitBranch              string
 	providerName           string
 	modelName              string
 	providerProfile        config.ProviderProfile
 	provider               zeroruntime.Provider
 	newProvider            func(config.ProviderProfile) (zeroruntime.Provider, error)
+	probeProviderHealth    func(context.Context, providerhealth.Options) providerhealth.Result
 	discoverProviderModels func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	registry               *tools.Registry
 	sessionStore           *sessions.Store
@@ -55,6 +60,7 @@ type model struct {
 	mcpViewStateReady      bool
 	mcpCommandSeq          int
 	mcpCommandCancel       context.CancelFunc
+	doctorCommandSeq       int
 	activeSession          sessions.Metadata
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
@@ -66,6 +72,7 @@ type model struct {
 	selfCorrectTests       bool
 	reasoningEffort        modelregistry.ReasoningEffort
 	responseStyle          string
+	userAgent              string
 	compactRequests        int
 	compactInFlight        bool
 	compactFrame           int
@@ -234,6 +241,11 @@ type mcpCommandResultMsg struct {
 	result  MCPCommandResult
 }
 
+type doctorCommandResultMsg struct {
+	id   int
+	text string
+}
+
 type permissionDecision = agent.PermissionDecisionAction
 
 const (
@@ -315,6 +327,10 @@ func newModel(ctx context.Context, options Options) model {
 	if usageTracker == nil {
 		usageTracker = usage.NewTracker(usage.TrackerOptions{})
 	}
+	doctorUserConfigPath := options.DoctorUserConfigPath
+	if doctorUserConfigPath == "" {
+		doctorUserConfigPath = options.UserConfigPath
+	}
 
 	permissionMode := options.PermissionMode
 	if permissionMode == "" {
@@ -347,6 +363,8 @@ func newModel(ctx context.Context, options Options) model {
 		ctx:                    ctx,
 		cwd:                    cwd,
 		userConfigPath:         options.UserConfigPath,
+		doctorUserConfigPath:   doctorUserConfigPath,
+		projectConfigPath:      options.ProjectConfigPath,
 		gitBranch:              gitBranch(cwd),
 		providerName:           options.ProviderName,
 		modelName:              options.ModelName,
@@ -354,6 +372,7 @@ func newModel(ctx context.Context, options Options) model {
 		favoriteModels:         favoriteModelSet(options.FavoriteModels),
 		provider:               options.Provider,
 		newProvider:            options.NewProvider,
+		probeProviderHealth:    options.ProbeProviderHealth,
 		discoverProviderModels: options.DiscoverProviderModels,
 		registry:               registry,
 		sessionStore:           sessionStore,
@@ -368,6 +387,7 @@ func newModel(ctx context.Context, options Options) model {
 		permissionMode:         permissionMode,
 		reasoningEffort:        options.ReasoningEffort,
 		responseStyle:          defaultedResponseStyle(options.ResponseStyle),
+		userAgent:              options.UserAgent,
 		usageTracker:           usageTracker,
 		transcript:             initialTranscript(),
 		input:                  input,
@@ -380,6 +400,32 @@ func newModel(ctx context.Context, options Options) model {
 	}
 	m.refreshMCPViewState()
 	return m
+}
+
+func (m model) doctorOptions(connectivity bool) doctor.Options {
+	var health *providerhealth.Result
+	if connectivity && m.probeProviderHealth != nil && config.HasProviderProfile(m.providerProfile) {
+		ctx := m.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		result := m.probeProviderHealth(ctx, providerhealth.Options{
+			Profile:      m.providerProfile,
+			Connectivity: true,
+			UserAgent:    m.userAgent,
+		})
+		health = &result
+	}
+
+	return doctor.Options{
+		Now:            m.now,
+		Runtime:        "go",
+		UserConfig:     m.doctorUserConfigPath,
+		ProjectConfig:  m.projectConfigPath,
+		Provider:       m.providerProfile,
+		Connectivity:   connectivity,
+		ProviderHealth: health,
+	}
 }
 
 const (
@@ -952,6 +998,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.streamingText = ""
 		}
 		m.transcript = appendTranscriptRow(m.transcript, msg.row)
+		return m, nil
+	case doctorCommandResultMsg:
+		if msg.id == 0 || msg.id == m.doctorCommandSeq {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.text})
+		}
 		return m, nil
 	case bashResultMsg:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})
@@ -1815,8 +1866,7 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.planText()})
 		return m, nil
 	case commandDoctor:
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.doctorText()})
-		return m, nil
+		return m.startDoctorCommand(command.text)
 	case commandSearch:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.searchText(command.text)})
 		return m, nil

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -679,7 +679,7 @@ func TestDoctorCommandUsesCurrentProviderProfile(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /doctor to be handled without starting an agent run")
 	}
-	for _, want := range []string{"Zero doctor report", "provider.config", "provider.model"} {
+	for _, want := range []string{"Diagnostics", "Provider", "provider.config", "provider.model"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected doctor transcript to contain %q, got %#v", want, next.transcript)
 		}

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/mcp"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -21,12 +22,15 @@ import (
 type Options struct {
 	Cwd                    string
 	UserConfigPath         string
+	DoctorUserConfigPath   string
+	ProjectConfigPath      string
 	ProviderName           string
 	ModelName              string
 	ProviderProfile        config.ProviderProfile
 	FavoriteModels         []string
 	Provider               zeroruntime.Provider
 	NewProvider            func(config.ProviderProfile) (zeroruntime.Provider, error)
+	ProbeProviderHealth    func(context.Context, providerhealth.Options) providerhealth.Result
 	DiscoverProviderModels func(context.Context, config.ProviderProfile) ([]providermodeldiscovery.Model, error)
 	RuntimeMessageSink     func(tea.Msg)
 	Registry               *tools.Registry
@@ -43,6 +47,7 @@ type Options struct {
 	PermissionMode  agent.PermissionMode
 	ReasoningEffort modelregistry.ReasoningEffort
 	ResponseStyle   string
+	UserAgent       string
 
 	// Notify configures completion / awaiting-input notifications.
 	Notify config.NotifyConfig


### PR DESCRIPTION
## Summary

- add a TUI diagnostics renderer for `/doctor` with grouped provider/platform checks and actionable hints
- add `/health` as a discoverable alias for `/doctor`
- support async `/doctor --connectivity` in the TUI using the configured provider health probe
- wire existing config paths and provider-health/user-agent context from CLI launch into TUI doctor
- make doctor model health friendlier for dynamic OpenAI-compatible providers by warning/pass-through instead of failing unknown custom models

## Tests

- `go test ./internal/tui -run Doctor|Health|Command -count=1`
- `go test ./internal/doctor -run ProviderModel -count=1`
- `go test ./internal/cli -run TestRunNoArgsLaunchesSetupTUIWithNilProviderWhenNoProviderConfigured|TestRunNoArgsLaunchesTUI -count=1`
- `go test ./... -timeout 300s`
- `go vet ./...`
- `go build ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `/doctor` command with `--connectivity` flag to check provider connectivity and health.
  * Added `/health` as an alias for the `/doctor` command.
  * Improved diagnostic output with structured sections for Provider, Platform, and Backend information.

* **Bug Fixes**
  * Provider model validation now properly fails when a required model is missing or empty.

* **Tests**
  * Comprehensive test coverage added for doctor command functionality and provider validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->