### PR TITLE
feat: add doctor fix flow

### DIFF
--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -16,6 +16,8 @@ import (
 	zsearch "github.com/Gitlawb/zero/internal/search"
 )
 
+const doctorStatusRowID = "doctor/status"
+
 func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
 	connectivity, fix, help, err := parseDoctorCommandArgs(args)
 	if err != nil {
@@ -37,10 +39,12 @@ func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
 	m.doctorCommandSeq++
 	id := m.doctorCommandSeq
 	snapshot := m
-	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorConnectivityRunningText()})
-	return m, func() tea.Msg {
+	m.doctorInFlight = true
+	m.doctorFrame = 0
+	m = m.setDoctorStatusRow(m.doctorConnectivityRunningText())
+	return m, tea.Batch(func() tea.Msg {
 		return doctorCommandResultMsg{id: id, text: snapshot.doctorText(true)}
-	}
+	}, m.spinner.Tick)
 }
 
 func (m model) startDoctorFixCommand() (model, tea.Cmd) {
@@ -173,16 +177,31 @@ func doctorFixLines(report doctor.Report) []string {
 	return lines
 }
 
-func doctorConnectivityRunningText() string {
-	return renderCommandOutput(commandOutput{
-		Title:  "Diagnostics",
-		Status: commandStatusInfo,
-		Sections: []commandSection{{
-			Title: "Provider",
-			Lines: []string{"checking provider connectivity..."},
-		}},
-		Hints: []string{"keep typing; Zero will append the result when the probe finishes"},
-	})
+func (m model) doctorConnectivityRunningText() string {
+	return strings.Join([]string{
+		"Checking provider",
+		"Zero is probing the active endpoint. Keep typing; messages will queue until the check finishes.",
+		m.doctorAnimationLine(),
+		"provider: " + displayValue(m.providerName, displayValue(m.providerProfile.Name, "unknown")),
+		"model: " + displayValue(m.modelName, displayValue(m.providerProfile.Model, "unknown")),
+	}, "\n")
+}
+
+func (m model) doctorAnimationLine() string {
+	frame := compactFrames[m.doctorFrame%len(compactFrames)]
+	return frame + " checking provider connectivity..."
+}
+
+func (m model) setDoctorStatusRow(text string) model {
+	row := transcriptRow{kind: rowSystem, id: doctorStatusRowID, tool: "doctor", text: text}
+	for i := len(m.transcript) - 1; i >= 0; i-- {
+		if m.transcript[i].id == doctorStatusRowID {
+			m.transcript[i] = row
+			return m
+		}
+	}
+	m.transcript = appendTranscriptRow(m.transcript, row)
+	return m
 }
 
 func (m model) searchText(query string) string {

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -84,6 +84,9 @@ func parseDoctorCommandArgs(args string) (connectivity bool, fix bool, help bool
 			return false, false, false, fmt.Errorf("unknown doctor flag %q", field)
 		}
 	}
+	if connectivity && fix {
+		return false, false, false, fmt.Errorf("choose either %q or %q, not both", "fix", "--connectivity")
+	}
 	return connectivity, fix, help, nil
 }
 
@@ -156,10 +159,12 @@ func doctorFixPlanText(report doctor.Report) string {
 
 func doctorFixLines(report doctor.Report) []string {
 	lines := []string{}
+	hasIssue := false
 	for _, check := range report.Checks {
 		if check.Status == doctor.StatusPass {
 			continue
 		}
+		hasIssue = true
 		switch check.ID {
 		case "sandbox.backend":
 			lines = append(lines, "native sandbox: use WSL2 or a Linux container on Windows")
@@ -172,6 +177,9 @@ func doctorFixLines(report doctor.Report) []string {
 		}
 	}
 	if len(lines) == 0 {
+		if hasIssue {
+			return []string{"No automatic fixes are available for the detected diagnostics."}
+		}
 		return []string{"No automatic fixes are available because diagnostics are already clean."}
 	}
 	return lines

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -32,7 +32,7 @@ func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
 		return m.startDoctorFixCommand()
 	}
 	if !connectivity {
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.doctorText(false)})
+		m = m.setDoctorStatusRow(m.doctorText(false))
 		return m, nil
 	}
 

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
-	connectivity, help, err := parseDoctorCommandArgs(args)
+	connectivity, fix, help, err := parseDoctorCommandArgs(args)
 	if err != nil {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorUsageText(commandStatusBlocked, err.Error())})
 		return m, nil
@@ -25,6 +25,9 @@ func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
 	if help {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorUsageText(commandStatusInfo, "Show local diagnostics for provider, model, sandbox, LSP, and backend setup.")})
 		return m, nil
+	}
+	if fix {
+		return m.startDoctorFixCommand()
 	}
 	if !connectivity {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.doctorText(false)})
@@ -40,23 +43,58 @@ func (m model) startDoctorCommand(args string) (model, tea.Cmd) {
 	}
 }
 
+func (m model) startDoctorFixCommand() (model, tea.Cmd) {
+	report := doctor.Run(m.doctorOptions(false))
+	if doctorReportNeedsProviderSetup(report) {
+		if m.pending {
+			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorFixBusyText()})
+			return m, nil
+		}
+		m.providerWizard = m.newProviderWizard()
+		m.clearSuggestions()
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorFixProviderSetupText()})
+		return m, nil
+	}
+	if doctorReportCanProbeConnectivity(report) {
+		return m.startDoctorCommand("--connectivity")
+	}
+	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: doctorFixPlanText(report)})
+	return m, nil
+}
+
 func (m model) doctorText(connectivity bool) string {
 	report := doctor.Run(m.doctorOptions(connectivity))
 	return renderCommandOutput(doctorCommandOutput(report, nil))
 }
 
-func parseDoctorCommandArgs(args string) (connectivity bool, help bool, err error) {
+func parseDoctorCommandArgs(args string) (connectivity bool, fix bool, help bool, err error) {
 	for _, field := range strings.Fields(args) {
 		switch strings.ToLower(field) {
 		case "--connectivity", "connectivity":
 			connectivity = true
+		case "--fix", "fix":
+			fix = true
 		case "-h", "--help", "help":
 			help = true
 		default:
-			return false, false, fmt.Errorf("unknown doctor flag %q", field)
+			return false, false, false, fmt.Errorf("unknown doctor flag %q", field)
 		}
 	}
-	return connectivity, help, nil
+	return connectivity, fix, help, nil
+}
+
+func doctorReportNeedsProviderSetup(report doctor.Report) bool {
+	for _, id := range []string{"provider.config", "provider.model"} {
+		if check := report.Check(id); check != nil && check.Status == doctor.StatusFail {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorReportCanProbeConnectivity(report doctor.Report) bool {
+	check := report.Check("provider.connectivity")
+	return check != nil && check.Status != doctor.StatusPass
 }
 
 func doctorUsageText(status commandStatus, message string) string {
@@ -68,11 +106,71 @@ func doctorUsageText(status commandStatus, message string) string {
 			Lines: []string{
 				message,
 				"/doctor",
+				"/doctor fix",
 				"/doctor --connectivity",
 				"/health",
 			},
 		}},
 	})
+}
+
+func doctorFixProviderSetupText() string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Diagnostics fix",
+		Status: commandStatusInfo,
+		Sections: []commandSection{{
+			Title: "Provider",
+			Lines: []string{"Opening provider setup. Choose a provider, add credentials, then select a model."},
+		}},
+		Hints: []string{"Esc closes setup"},
+	})
+}
+
+func doctorFixBusyText() string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Diagnostics fix",
+		Status: commandStatusWarning,
+		Sections: []commandSection{{
+			Title: "Provider",
+			Lines: []string{"Cannot open provider setup while a run is active."},
+		}},
+		Hints: []string{"stop the current run, then retry /doctor fix"},
+	})
+}
+
+func doctorFixPlanText(report doctor.Report) string {
+	return renderCommandOutput(commandOutput{
+		Title:  "Diagnostics fix",
+		Status: doctorCommandStatus(report),
+		Sections: []commandSection{{
+			Title: "Next actions",
+			Lines: doctorFixLines(report),
+		}},
+		Hints: []string{"run /doctor --connectivity to recheck provider health"},
+	})
+}
+
+func doctorFixLines(report doctor.Report) []string {
+	lines := []string{}
+	for _, check := range report.Checks {
+		if check.Status == doctor.StatusPass {
+			continue
+		}
+		switch check.ID {
+		case "sandbox.backend":
+			lines = append(lines, "native sandbox: use WSL2 or a Linux container on Windows")
+		case "lsp.servers":
+			lines = append(lines, "language servers: install missing LSP binaries on PATH")
+		case "provider.connectivity":
+			lines = append(lines, "provider connectivity: run /doctor --connectivity")
+		case "config.files", "config.validation":
+			lines = append(lines, "config: run /provider to create or repair provider config")
+		}
+	}
+	if len(lines) == 0 {
+		return []string{"No automatic fixes are available because diagnostics are already clean."}
+	}
+	return lines
 }
 
 func doctorConnectivityRunningText() string {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -220,9 +220,9 @@ var commandDefinitions = []commandDefinition{
 	{
 		name:        "/doctor",
 		aliases:     []string{"/health"},
-		usage:       "/doctor [--connectivity]",
+		usage:       "/doctor [fix|--connectivity]",
 		group:       commandGroupRuntime,
-		description: "Show local diagnostics, including optional connectivity checks.",
+		description: "Show diagnostics, open safe fixes, or run provider connectivity checks.",
 		kind:        commandDoctor,
 	},
 	{

--- a/internal/tui/doctor_command_test.go
+++ b/internal/tui/doctor_command_test.go
@@ -136,6 +136,42 @@ func TestDoctorConnectivityCommandRunsProbeAsynchronously(t *testing.T) {
 	}
 }
 
+func TestDoctorCommandUsesDiagnosticCenterRow(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		ProviderProfile: config.ProviderProfile{
+			Name:         "custom",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			Model:        "custom-model",
+		},
+	})
+	m.input.SetValue("/doctor")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected plain /doctor to render synchronously")
+	}
+	row := newestDoctorStatusRow(next.transcript)
+	if row == nil {
+		t.Fatalf("expected /doctor to render a doctor status row, got %#v", next.transcript)
+	}
+	if row.id != doctorStatusRowID {
+		t.Fatalf("expected /doctor row id %q, got %q", doctorStatusRowID, row.id)
+	}
+	text := row.text
+	for _, want := range []string{"Diagnostics", "checks need attention", "Actions"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("doctor row missing %q:\n%s", want, text)
+		}
+	}
+	for _, unwanted := range []string{"Generated", "Checks", "[pass]"} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("doctor row should hide %q:\n%s", unwanted, text)
+		}
+	}
+}
+
 func TestDoctorConnectivityCommandAnimatesAndReplacesStatusRow(t *testing.T) {
 	profile := config.ProviderProfile{
 		Name:         "custom",
@@ -210,18 +246,28 @@ func TestDoctorFixOpensProviderWizardWhenProviderMissing(t *testing.T) {
 }
 
 func newestDoctorStatusText(rows []transcriptRow) string {
+	if row := newestDoctorStatusRow(rows); row != nil {
+		return row.text
+	}
+	return ""
+}
+
+func newestDoctorStatusRow(rows []transcriptRow) *transcriptRow {
 	for i := len(rows) - 1; i >= 0; i-- {
 		row := rows[i]
 		if row.kind != rowSystem {
 			continue
 		}
+		if row.id == doctorStatusRowID {
+			return &rows[i]
+		}
 		if strings.Contains(row.text, "Checking provider") ||
 			strings.Contains(row.text, "provider.connectivity") ||
 			strings.Contains(row.text, "Diagnostics") {
-			return row.text
+			return &rows[i]
 		}
 	}
-	return ""
+	return nil
 }
 
 func countDoctorDiagnosticRows(rows []transcriptRow) int {

--- a/internal/tui/doctor_command_test.go
+++ b/internal/tui/doctor_command_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/Gitlawb/zero/internal/providerhealth"
 )
 
+func TestParseDoctorCommandArgsRejectsFixWithConnectivity(t *testing.T) {
+	_, _, _, err := parseDoctorCommandArgs("fix --connectivity")
+	if err == nil {
+		t.Fatal("parseDoctorCommandArgs accepted both fix and --connectivity")
+	}
+	if !strings.Contains(err.Error(), "choose either") {
+		t.Fatalf("error = %q, want mutually exclusive flag guidance", err)
+	}
+}
+
 func TestDoctorOptionsIncludeConfigPaths(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		UserConfigPath:    "C:/zero/user.json",
@@ -245,6 +255,22 @@ func TestDoctorFixOpensProviderWizardWhenProviderMissing(t *testing.T) {
 	}
 }
 
+func TestDoctorFixLinesShowNoAutomaticFixForUnmappedFailure(t *testing.T) {
+	lines := doctorFixLines(doctor.Report{Checks: []doctor.Check{{
+		ID:      "provider.auth",
+		Status:  doctor.StatusFail,
+		Message: "API key rejected.",
+	}}})
+
+	text := strings.Join(lines, "\n")
+	if strings.Contains(text, "already clean") {
+		t.Fatalf("doctorFixLines reported clean diagnostics for an unmapped failure:\n%s", text)
+	}
+	if !strings.Contains(text, "No automatic fixes are available") {
+		t.Fatalf("doctorFixLines = %q, want no automatic fix guidance", text)
+	}
+}
+
 func newestDoctorStatusText(rows []transcriptRow) string {
 	if row := newestDoctorStatusRow(rows); row != nil {
 		return row.text
@@ -255,15 +281,7 @@ func newestDoctorStatusText(rows []transcriptRow) string {
 func newestDoctorStatusRow(rows []transcriptRow) *transcriptRow {
 	for i := len(rows) - 1; i >= 0; i-- {
 		row := rows[i]
-		if row.kind != rowSystem {
-			continue
-		}
-		if row.id == doctorStatusRowID {
-			return &rows[i]
-		}
-		if strings.Contains(row.text, "Checking provider") ||
-			strings.Contains(row.text, "provider.connectivity") ||
-			strings.Contains(row.text, "Diagnostics") {
+		if row.kind == rowSystem && row.id == doctorStatusRowID {
 			return &rows[i]
 		}
 	}
@@ -273,7 +291,7 @@ func newestDoctorStatusRow(rows []transcriptRow) *transcriptRow {
 func countDoctorDiagnosticRows(rows []transcriptRow) int {
 	count := 0
 	for _, row := range rows {
-		if row.kind == rowSystem && strings.Contains(row.text, "Diagnostics") {
+		if row.kind == rowSystem && row.id == doctorStatusRowID {
 			count++
 		}
 	}

--- a/internal/tui/doctor_command_test.go
+++ b/internal/tui/doctor_command_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -122,7 +123,7 @@ func TestDoctorConnectivityCommandRunsProbeAsynchronously(t *testing.T) {
 		t.Fatalf("expected running doctor status, got %#v", next.transcript)
 	}
 
-	msg := cmd()
+	msg := execCmd(cmd)
 	if !called {
 		t.Fatal("provider probe did not run when the async command executed")
 	}
@@ -132,6 +133,62 @@ func TestDoctorConnectivityCommandRunsProbeAsynchronously(t *testing.T) {
 		if !transcriptContains(final.transcript, want) {
 			t.Fatalf("expected final doctor transcript to contain %q, got %#v", want, final.transcript)
 		}
+	}
+}
+
+func TestDoctorConnectivityCommandAnimatesAndReplacesStatusRow(t *testing.T) {
+	profile := config.ProviderProfile{
+		Name:         "custom",
+		ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL:      "https://api.example.com/v1",
+		Model:        "custom-model",
+	}
+	m := newModel(context.Background(), Options{
+		ProviderProfile: profile,
+		ProbeProviderHealth: func(context.Context, providerhealth.Options) providerhealth.Result {
+			return providerhealth.Result{
+				Status: providerhealth.StatusPass,
+				Checks: []providerhealth.Check{{
+					ID:      "provider.connectivity",
+					Status:  providerhealth.StatusPass,
+					Message: "reachable",
+				}},
+			}
+		},
+	})
+	m.input.SetValue("/doctor --connectivity")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected /doctor --connectivity to start an async command")
+	}
+	beforeRows := len(next.transcript)
+	before := newestDoctorStatusText(next.transcript)
+
+	updated, _ = next.Update(next.spinner.Tick())
+	ticked := updated.(model)
+	after := newestDoctorStatusText(ticked.transcript)
+	if before == "" || after == "" {
+		t.Fatalf("expected doctor status row before=%q after=%q", before, after)
+	}
+	if before == after {
+		t.Fatalf("expected doctor status to animate on tick, still %q", after)
+	}
+
+	updated, _ = ticked.Update(execCmd(cmd))
+	final := updated.(model)
+	if len(final.transcript) != beforeRows {
+		t.Fatalf("expected final doctor report to replace the running row, rows before=%d after=%d: %#v", beforeRows, len(final.transcript), final.transcript)
+	}
+	if got := countDoctorDiagnosticRows(final.transcript); got != 1 {
+		t.Fatalf("expected one doctor diagnostic row after completion, got %d: %#v", got, final.transcript)
+	}
+	if transcriptContains(final.transcript, "checking provider connectivity") {
+		t.Fatalf("expected stale running copy to be replaced, got %#v", final.transcript)
+	}
+	if !transcriptContains(final.transcript, "[pass] provider.connectivity") {
+		t.Fatalf("expected completed diagnostics result, got %#v", final.transcript)
 	}
 }
 
@@ -150,6 +207,31 @@ func TestDoctorFixOpensProviderWizardWhenProviderMissing(t *testing.T) {
 	if !transcriptContains(next.transcript, "Opening provider setup") {
 		t.Fatalf("expected doctor fix transcript to explain provider setup, got %#v", next.transcript)
 	}
+}
+
+func newestDoctorStatusText(rows []transcriptRow) string {
+	for i := len(rows) - 1; i >= 0; i-- {
+		row := rows[i]
+		if row.kind != rowSystem {
+			continue
+		}
+		if strings.Contains(row.text, "Checking provider") ||
+			strings.Contains(row.text, "provider.connectivity") ||
+			strings.Contains(row.text, "Diagnostics") {
+			return row.text
+		}
+	}
+	return ""
+}
+
+func countDoctorDiagnosticRows(rows []transcriptRow) int {
+	count := 0
+	for _, row := range rows {
+		if row.kind == rowSystem && strings.Contains(row.text, "Diagnostics") {
+			count++
+		}
+	}
+	return count
 }
 
 func TestDoctorFixRunsConnectivityWhenProviderConfigured(t *testing.T) {
@@ -188,7 +270,7 @@ func TestDoctorFixRunsConnectivityWhenProviderConfigured(t *testing.T) {
 		t.Fatalf("expected running doctor status, got %#v", next.transcript)
 	}
 
-	updated, _ = next.Update(cmd())
+	updated, _ = next.Update(execCmd(cmd))
 	final := updated.(model)
 	if !called {
 		t.Fatal("provider probe did not run when /doctor fix command executed")

--- a/internal/tui/doctor_command_test.go
+++ b/internal/tui/doctor_command_test.go
@@ -134,3 +134,66 @@ func TestDoctorConnectivityCommandRunsProbeAsynchronously(t *testing.T) {
 		}
 	}
 }
+
+func TestDoctorFixOpensProviderWizardWhenProviderMissing(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m.input.SetValue("/doctor fix")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /doctor fix provider setup path to be handled synchronously")
+	}
+	if next.providerWizard == nil {
+		t.Fatalf("expected /doctor fix to open provider setup wizard, transcript %#v", next.transcript)
+	}
+	if !transcriptContains(next.transcript, "Opening provider setup") {
+		t.Fatalf("expected doctor fix transcript to explain provider setup, got %#v", next.transcript)
+	}
+}
+
+func TestDoctorFixRunsConnectivityWhenProviderConfigured(t *testing.T) {
+	profile := config.ProviderProfile{
+		Name:         "custom",
+		ProviderKind: config.ProviderKindOpenAICompatible,
+		BaseURL:      "https://api.example.com/v1",
+		Model:        "custom-model",
+	}
+	called := false
+	m := newModel(context.Background(), Options{
+		ProviderProfile: profile,
+		ProbeProviderHealth: func(context.Context, providerhealth.Options) providerhealth.Result {
+			called = true
+			return providerhealth.Result{
+				Status: providerhealth.StatusPass,
+				Checks: []providerhealth.Check{{
+					ID:      "provider.connectivity",
+					Status:  providerhealth.StatusPass,
+					Message: "reachable",
+				}},
+			}
+		},
+	})
+	m.input.SetValue("/doctor fix")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected /doctor fix to run provider connectivity asynchronously")
+	}
+	if called {
+		t.Fatal("provider probe ran synchronously before the returned command executed")
+	}
+	if !transcriptContains(next.transcript, "checking provider connectivity") {
+		t.Fatalf("expected running doctor status, got %#v", next.transcript)
+	}
+
+	updated, _ = next.Update(cmd())
+	final := updated.(model)
+	if !called {
+		t.Fatal("provider probe did not run when /doctor fix command executed")
+	}
+	if !transcriptContains(final.transcript, "[pass] provider.connectivity") {
+		t.Fatalf("expected connectivity result in transcript, got %#v", final.transcript)
+	}
+}

--- a/internal/tui/doctor_view.go
+++ b/internal/tui/doctor_view.go
@@ -9,16 +9,10 @@ import (
 )
 
 func doctorCommandOutput(report doctor.Report, backend *zerocommands.BackendLifecycleSnapshot) commandOutput {
-	sections := []commandSection{}
-	if report.GeneratedAt != "" {
-		sections = append(sections, commandSection{
-			Title: "Summary",
-			Fields: []commandField{
-				{Key: "Generated", Value: report.GeneratedAt},
-				{Key: "Checks", Value: fmt.Sprintf("%d", len(report.Checks))},
-			},
-		})
-	}
+	sections := []commandSection{{
+		Title: "Summary",
+		Lines: doctorSummaryLines(report.Checks),
+	}}
 
 	provider, platform, other := doctorCheckSections(report.Checks)
 	sections = appendNonEmptyDoctorSection(sections, "Provider", provider)
@@ -27,12 +21,17 @@ func doctorCommandOutput(report doctor.Report, backend *zerocommands.BackendLife
 	if backend != nil {
 		sections = append(sections, doctorBackendSection(*backend))
 	}
+	if actions := doctorActions(report.Checks, backend); len(actions) > 0 {
+		sections = append(sections, commandSection{
+			Title: "Actions",
+			Lines: actions,
+		})
+	}
 
 	return commandOutput{
 		Title:    "Diagnostics",
 		Status:   doctorCommandStatus(report),
 		Sections: sections,
-		Hints:    doctorHints(report.Checks, backend),
 	}
 }
 
@@ -54,6 +53,9 @@ func doctorCommandStatus(report doctor.Report) commandStatus {
 
 func doctorCheckSections(checks []doctor.Check) (provider []commandRow, platform []commandRow, other []commandRow) {
 	for _, check := range checks {
+		if check.Status == doctor.StatusPass && check.ID != "provider.connectivity" {
+			continue
+		}
 		row := commandRow{Text: doctorCheckRow(check)}
 		switch doctorCheckGroup(check.ID) {
 		case "provider":
@@ -76,6 +78,35 @@ func doctorCheckGroup(id string) string {
 	default:
 		return ""
 	}
+}
+
+func doctorSummaryLines(checks []doctor.Check) []string {
+	pass, warn, fail := doctorStatusCounts(checks)
+	attention := warn + fail
+	if attention == 0 {
+		return []string{
+			fmt.Sprintf("%d checks healthy", pass),
+			"All core systems are ready.",
+		}
+	}
+	return []string{
+		fmt.Sprintf("%d checks need attention", attention),
+		fmt.Sprintf("%d checks healthy", pass),
+	}
+}
+
+func doctorStatusCounts(checks []doctor.Check) (pass int, warn int, fail int) {
+	for _, check := range checks {
+		switch check.Status {
+		case doctor.StatusPass:
+			pass++
+		case doctor.StatusWarn:
+			warn++
+		case doctor.StatusFail:
+			fail++
+		}
+	}
+	return pass, warn, fail
 }
 
 func doctorCheckRow(check doctor.Check) string {
@@ -110,16 +141,16 @@ func doctorBackendSection(backend zerocommands.BackendLifecycleSnapshot) command
 	}
 }
 
-func doctorHints(checks []doctor.Check, backend *zerocommands.BackendLifecycleSnapshot) []string {
+func doctorActions(checks []doctor.Check, backend *zerocommands.BackendLifecycleSnapshot) []string {
 	seen := map[string]bool{}
-	hints := []string{}
-	add := func(hint string) {
-		hint = strings.TrimSpace(hint)
-		if hint == "" || seen[hint] {
+	actions := []string{}
+	add := func(action string) {
+		action = strings.TrimSpace(action)
+		if action == "" || seen[action] {
 			return
 		}
-		seen[hint] = true
-		hints = append(hints, hint)
+		seen[action] = true
+		actions = append(actions, action)
 	}
 
 	for _, check := range checks {
@@ -129,24 +160,25 @@ func doctorHints(checks []doctor.Check, backend *zerocommands.BackendLifecycleSn
 		message := strings.ToLower(check.Message)
 		switch check.ID {
 		case "provider.config", "provider.model":
-			add("use /provider to configure the active provider and model")
+			add("/provider - configure the active provider and model")
+			add("/doctor fix - open guided diagnostics repair")
 		case "provider.connectivity":
-			add("use /doctor --connectivity to retry provider connectivity checks")
+			add("/doctor --connectivity - probe the provider endpoint")
 		case "sandbox.backend":
 			if strings.Contains(message, "windows") || strings.Contains(message, "policy-only") {
-				add("run Zero inside WSL2 or a Linux container for native sandbox isolation on Windows")
+				add("WSL2 or Linux container - enable native sandbox isolation on Windows")
 			}
 		case "lsp.servers":
 			if strings.Contains(message, "missing") {
-				add("install missing language servers so code intelligence is available on PATH")
+				add("install missing language servers - restore code intelligence on PATH")
 			}
 		}
 	}
 
 	if backend != nil {
-		add("use /mcp to inspect MCP servers")
-		add("use /hooks to inspect hooks")
-		add("use /plugins to inspect plugins")
+		add("/mcp - inspect MCP servers")
+		add("/hooks - inspect hooks")
+		add("/plugins - inspect plugins")
 	}
-	return hints
+	return actions
 }

--- a/internal/tui/doctor_view.go
+++ b/internal/tui/doctor_view.go
@@ -85,14 +85,28 @@ func doctorSummaryLines(checks []doctor.Check) []string {
 	attention := warn + fail
 	if attention == 0 {
 		return []string{
-			fmt.Sprintf("%d checks healthy", pass),
+			fmt.Sprintf("%s healthy", doctorCheckCountLabel(pass)),
 			"All core systems are ready.",
 		}
 	}
 	return []string{
-		fmt.Sprintf("%d checks need attention", attention),
-		fmt.Sprintf("%d checks healthy", pass),
+		fmt.Sprintf("%s %s attention", doctorCheckCountLabel(attention), doctorAttentionVerb(attention)),
+		fmt.Sprintf("%s healthy", doctorCheckCountLabel(pass)),
 	}
+}
+
+func doctorCheckCountLabel(count int) string {
+	if count == 1 {
+		return "1 check"
+	}
+	return fmt.Sprintf("%d checks", count)
+}
+
+func doctorAttentionVerb(count int) string {
+	if count == 1 {
+		return "needs"
+	}
+	return "need"
 }
 
 func doctorStatusCounts(checks []doctor.Check) (pass int, warn int, fail int) {

--- a/internal/tui/doctor_view_test.go
+++ b/internal/tui/doctor_view_test.go
@@ -64,13 +64,52 @@ func TestDoctorCommandOutputGroupsProviderAndPlatformChecks(t *testing.T) {
 	if provider == nil {
 		t.Fatalf("missing Provider section: %#v", output.Sections)
 	}
-	assertRowsContain(t, provider.Rows, "provider.config", "provider.model", "provider.connectivity")
+	assertRowsContain(t, provider.Rows, "provider.model", "provider.connectivity")
+	assertRowsDoNotContain(t, provider.Rows, "provider.config")
 
 	platform := doctorSection(output, "Platform")
 	if platform == nil {
 		t.Fatalf("missing Platform section: %#v", output.Sections)
 	}
-	assertRowsContain(t, platform.Rows, "sandbox.backend", "runtime.go", "config.files")
+	assertRowsContain(t, platform.Rows, "sandbox.backend")
+	assertRowsDoNotContain(t, platform.Rows, "runtime.go", "config.files")
+}
+
+func TestDoctorCommandOutputIsProblemFirstDiagnosticCenter(t *testing.T) {
+	output := doctorCommandOutput(doctor.Report{GeneratedAt: "2026-06-14T00:00:00Z", Checks: []doctor.Check{
+		doctorCheck("provider.config", doctor.StatusPass, "Provider config loaded."),
+		doctorCheck("provider.model", doctor.StatusWarn, "Provider model is not configured."),
+		doctorCheck("provider.connectivity", doctor.StatusWarn, "Connectivity probe skipped."),
+		doctorCheck("runtime.go", doctor.StatusPass, "Zero Go runtime is available."),
+		doctorCheck("config.files", doctor.StatusPass, "Zero config files are available."),
+		doctorCheck("lsp.servers", doctor.StatusWarn, "2 language server(s) missing from PATH."),
+	}}, nil)
+
+	text := formatCommandOutput(output)
+	for _, want := range []string{
+		"3 checks need attention",
+		"3 checks healthy",
+		"provider.model",
+		"provider.connectivity",
+		"lsp.servers",
+		"Actions",
+		"/doctor fix",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formatted output missing %q:\n%s", want, text)
+		}
+	}
+	for _, unwanted := range []string{
+		"Generated",
+		"Checks",
+		"provider.config",
+		"runtime.go",
+		"config.files",
+	} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("formatted output should hide %q:\n%s", unwanted, text)
+		}
+	}
 }
 
 func TestDoctorCommandOutputAddsActionableHints(t *testing.T) {
@@ -160,6 +199,19 @@ func assertRowsContain(t *testing.T, rows []commandRow, wants ...string) {
 	for _, want := range wants {
 		if !strings.Contains(text, want) {
 			t.Fatalf("rows missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func assertRowsDoNotContain(t *testing.T, rows []commandRow, wants ...string) {
+	t.Helper()
+	text := ""
+	for _, row := range rows {
+		text += row.Text + "\n"
+	}
+	for _, want := range wants {
+		if strings.Contains(text, want) {
+			t.Fatalf("rows unexpectedly contain %q:\n%s", want, text)
 		}
 	}
 }

--- a/internal/tui/doctor_view_test.go
+++ b/internal/tui/doctor_view_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -47,6 +48,39 @@ func TestDoctorCommandOutputMapsOverallStatus(t *testing.T) {
 				t.Fatalf("Status = %q, want %q", output.Status, test.want)
 			}
 		})
+	}
+}
+
+func TestDoctorSummaryLinesUseSingularGrammar(t *testing.T) {
+	healthy := doctorSummaryLines([]doctor.Check{
+		doctorCheck("runtime.go", doctor.StatusPass, "Go runtime is available."),
+	})
+	if got, want := healthy[0], "1 check healthy"; got != want {
+		t.Fatalf("healthy summary = %q, want %q", got, want)
+	}
+
+	attention := doctorSummaryLines([]doctor.Check{
+		doctorCheck("provider.model", doctor.StatusWarn, "Provider model is not configured."),
+	})
+	if got, want := attention[0], "1 check needs attention"; got != want {
+		t.Fatalf("attention summary = %q, want %q", got, want)
+	}
+}
+
+func TestDoctorResultBorderStyleUsesSummaryStatusLine(t *testing.T) {
+	text := strings.Join([]string{
+		"Diagnostics",
+		"",
+		"status: blocked",
+		"",
+		"Summary",
+		"- status: ok appears in detail text only",
+	}, "\n")
+
+	got := fmt.Sprint(doctorResultBorderStyle(text).GetForeground())
+	want := fmt.Sprint(zeroTheme.red.GetForeground())
+	if got != want {
+		t.Fatalf("border foreground = %s, want blocked red %s", got, want)
 	}
 }
 

--- a/internal/tui/health_command_test.go
+++ b/internal/tui/health_command_test.go
@@ -29,7 +29,8 @@ func TestDoctorHelpListsHealthAliasAndConnectivity(t *testing.T) {
 	help := strings.Join(formatCommandHelpLines(), "\n")
 
 	for _, want := range []string{
-		"/doctor [--connectivity] (/health)",
+		"/doctor [fix|--connectivity] (/health)",
+		"fix",
 		"connectivity",
 	} {
 		if !strings.Contains(help, want) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -61,6 +61,8 @@ type model struct {
 	mcpCommandSeq          int
 	mcpCommandCancel       context.CancelFunc
 	doctorCommandSeq       int
+	doctorInFlight         bool
+	doctorFrame            int
 	activeSession          sessions.Metadata
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
@@ -802,7 +804,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinner.TickMsg:
 		// Not forwarding the tick while idle stops the spinner's self-scheduling,
 		// so no timer fires between runs.
-		if !m.pending && !m.compactInFlight {
+		if !m.pending && !m.compactInFlight && !m.doctorInFlight {
 			return m, nil
 		}
 		var cmd tea.Cmd
@@ -810,6 +812,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.compactInFlight {
 			m.compactFrame++
 			m = m.setCompactStatusRow(m.compactText(true))
+		}
+		if m.doctorInFlight {
+			m.doctorFrame++
+			m = m.setDoctorStatusRow(m.doctorConnectivityRunningText())
 		}
 		return m, cmd
 	case tea.WindowSizeMsg:
@@ -1001,7 +1007,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case doctorCommandResultMsg:
 		if msg.id == 0 || msg.id == m.doctorCommandSeq {
-			m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.text})
+			m.doctorInFlight = false
+			m.doctorFrame = 0
+			m = m.setDoctorStatusRow(msg.text)
 		}
 		return m, nil
 	case bashResultMsg:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -679,9 +679,14 @@ func TestDoctorCommandUsesCurrentProviderProfile(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /doctor to be handled without starting an agent run")
 	}
-	for _, want := range []string{"Diagnostics", "Provider", "provider.config", "provider.model"} {
+	for _, want := range []string{"Diagnostics", "Provider", "provider.connectivity", "Actions"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected doctor transcript to contain %q, got %#v", want, next.transcript)
+		}
+	}
+	for _, unwanted := range []string{"provider.config", "provider.model", "Generated", "Checks"} {
+		if transcriptContains(next.transcript, unwanted) {
+			t.Fatalf("expected doctor transcript to hide %q, got %#v", unwanted, next.transcript)
 		}
 	}
 }

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -558,16 +558,17 @@ func renderDoctorResultCard(text string, width int) string {
 }
 
 func doctorResultBorderStyle(text string) lipgloss.Style {
-	switch {
-	case strings.Contains(text, "status: ok"):
-		return zeroTheme.green
-	case strings.Contains(text, "status: blocked"):
-		return zeroTheme.red
-	case strings.Contains(text, "status: warning"):
-		return zeroTheme.amber
-	default:
-		return zeroTheme.accent
+	for _, line := range strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n") {
+		switch strings.TrimSpace(line) {
+		case "status: ok":
+			return zeroTheme.green
+		case "status: blocked":
+			return zeroTheme.red
+		case "status: warning":
+			return zeroTheme.amber
+		}
 	}
+	return zeroTheme.accent
 }
 
 func isDoctorResultHeading(value string) bool {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -210,6 +210,12 @@ func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext
 		if row.id == compactStatusRowID && strings.HasPrefix(strings.TrimSpace(row.text), "Compression complete") {
 			return renderCompactCompleteCard(row.text, width)
 		}
+		if row.id == doctorStatusRowID && strings.HasPrefix(strings.TrimSpace(row.text), "Checking provider") {
+			return renderDoctorRunningCard(row.text, width)
+		}
+		if row.id == doctorStatusRowID {
+			return renderDoctorResultCard(row.text, width)
+		}
 		return renderSystemNote(row.text, width)
 	case rowError:
 		return renderErrorRow(row, width)
@@ -493,6 +499,80 @@ func renderCompactCompleteCard(text string, width int) string {
 		}
 	}
 	return styledBlock(width, lines, zeroTheme.green)
+}
+
+func renderDoctorRunningCard(text string, width int) string {
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(text, "\r\n", "\n"), "\n"), "\n")
+	lines := make([]string, 0, len(raw)+1)
+	for index, line := range raw {
+		switch index {
+		case 0:
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
+		case 1:
+			lines = append(lines, zeroTheme.muted.Render(line))
+		case 2:
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
+		default:
+			lines = append(lines, zeroTheme.faint.Render(line))
+		}
+		if index == 0 {
+			lines = append(lines, "")
+		}
+	}
+	return styledBlock(width, lines, zeroTheme.accent)
+}
+
+func renderDoctorResultCard(text string, width int) string {
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(text, "\r\n", "\n"), "\n"), "\n")
+	border := doctorResultBorderStyle(text)
+	lines := make([]string, 0, len(raw))
+	for index, line := range raw {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case index == 0:
+			lines = append(lines, border.Bold(true).Render(line))
+		case strings.HasPrefix(trimmed, "status:"):
+			lines = append(lines, border.Render(line))
+		case isDoctorResultHeading(trimmed):
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
+		case strings.HasPrefix(trimmed, "- [pass]"):
+			lines = append(lines, zeroTheme.green.Render(line))
+		case strings.HasPrefix(trimmed, "- [warn]"):
+			lines = append(lines, zeroTheme.amber.Render(line))
+		case strings.HasPrefix(trimmed, "- [fail]"):
+			lines = append(lines, zeroTheme.red.Render(line))
+		case strings.HasPrefix(trimmed, "hint:"):
+			lines = append(lines, zeroTheme.faint.Render(line))
+		default:
+			lines = append(lines, zeroTheme.muted.Render(line))
+		}
+		if index == 0 {
+			lines = append(lines, "")
+		}
+	}
+	return styledBlock(width, lines, border)
+}
+
+func doctorResultBorderStyle(text string) lipgloss.Style {
+	switch {
+	case strings.Contains(text, "status: ok"):
+		return zeroTheme.green
+	case strings.Contains(text, "status: blocked"):
+		return zeroTheme.red
+	case strings.Contains(text, "status: warning"):
+		return zeroTheme.amber
+	default:
+		return zeroTheme.accent
+	}
+}
+
+func isDoctorResultHeading(value string) bool {
+	switch value {
+	case "Summary", "Provider", "Platform", "LSP", "Backend", "Config":
+		return true
+	default:
+		return false
+	}
 }
 
 func renderErrorRow(row transcriptRow, width int) string {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -543,6 +543,10 @@ func renderDoctorResultCard(text string, width int) string {
 			lines = append(lines, zeroTheme.red.Render(line))
 		case strings.HasPrefix(trimmed, "hint:"):
 			lines = append(lines, zeroTheme.faint.Render(line))
+		case strings.HasPrefix(trimmed, "/") ||
+			strings.HasPrefix(trimmed, "WSL2") ||
+			strings.HasPrefix(trimmed, "install "):
+			lines = append(lines, zeroTheme.ink.Render(line))
 		default:
 			lines = append(lines, zeroTheme.muted.Render(line))
 		}
@@ -568,7 +572,7 @@ func doctorResultBorderStyle(text string) lipgloss.Style {
 
 func isDoctorResultHeading(value string) bool {
 	switch value {
-	case "Summary", "Provider", "Platform", "LSP", "Backend", "Config":
+	case "Summary", "Provider", "Platform", "Other", "Backend", "Actions":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

- add `/doctor fix` / `/health fix` as a real action flow instead of another static diagnostics view
- opens provider setup automatically when provider/model config is missing
- runs provider connectivity asynchronously when a provider is configured
- keeps external platform fixes as actionable guidance for sandbox/LSP/config cases
- updates command help to advertise `/doctor [fix|--connectivity]`

## Tests

- `go test ./internal/tui -run DoctorFix|DoctorConnectivity|DoctorHelp|Health -count=1`
- `go test ./internal/tui -count=1`
- `go test ./internal/cli ./internal/doctor -count=1`
- `go test ./... -timeout 300s`
- `go vet ./...`
- `go build ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/doctor fix`, which runs diagnostics and provides next-action guidance, including provider setup and connectivity follow-ups.
* **User Experience**
  * Enhanced `/doctor` TUI with dedicated “running” vs. result cards, clearer “Summary” and “Actions”, and improved check grouping (showing relevant issues first).
* **Bug Fixes**
  * Improved `/doctor --connectivity` behavior so the view transitions cleanly to a single completed Diagnostics result with animation.
* **Documentation & Tests**
  * Updated `/doctor` help text and expanded doctor-related TUI tests and transcript assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->