### PR TITLE
feat(sandbox): harden internal/sandbox — re-entrancy guard, SOCKS5 egress, sandbox-aware search, fine-grained path lists

### DIFF
--- a/internal/sandbox/egress.go
+++ b/internal/sandbox/egress.go
@@ -32,9 +32,14 @@ import (
 type egressProxy struct {
 	listener net.Listener
 	server   *http.Server
-	allowed  []string
-	denied   []string
-	log      func(string)
+	// socksListener serves the SOCKS5 CONNECT front-end on a SEPARATE loopback
+	// port. It runs the same authorize()/domainAllowed() gate as the HTTP proxy, so
+	// a client configured with ALL_PROXY=socks5://<socksAddr> is filtered
+	// identically. Bound to 127.0.0.1:0 like the HTTP listener.
+	socksListener net.Listener
+	allowed       []string
+	denied        []string
+	log           func(string)
 
 	// domainPrompt, when set, is asked to authorize an UNKNOWN host (one neither
 	// allowed nor explicitly denied) instead of failing closed. It must return
@@ -89,9 +94,18 @@ func newEgressProxy(options egressOptions) (*egressProxy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bind scoped-egress proxy: %w", err)
 	}
+	// Bind the SOCKS5 front-end on its own loopback port. Fail closed: if it
+	// cannot bind, tear down the HTTP listener and return an error so the caller
+	// treats scoped egress as a full deny rather than starting a partial proxy.
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = listener.Close()
+		return nil, fmt.Errorf("bind scoped-egress socks proxy: %w", err)
+	}
 
 	proxy := &egressProxy{
 		listener:      listener,
+		socksListener: socksListener,
 		allowed:       allowed,
 		denied:        denied,
 		log:           options.Log,
@@ -108,15 +122,25 @@ func newEgressProxy(options egressOptions) (*egressProxy, error) {
 		// Serve returns ErrServerClosed on Close; nothing else to do.
 		_ = proxy.server.Serve(listener)
 	}()
+	go proxy.serveSocks(socksListener)
 	return proxy, nil
 }
 
-// Addr returns the loopback host:port the proxy is listening on.
+// Addr returns the loopback host:port the HTTP proxy is listening on.
 func (proxy *egressProxy) Addr() string {
 	if proxy == nil || proxy.listener == nil {
 		return ""
 	}
 	return proxy.listener.Addr().String()
+}
+
+// SocksAddr returns the loopback host:port the SOCKS5 front-end is listening on,
+// or "" when no SOCKS listener is active.
+func (proxy *egressProxy) SocksAddr() string {
+	if proxy == nil || proxy.socksListener == nil {
+		return ""
+	}
+	return proxy.socksListener.Addr().String()
 }
 
 // Close stops the proxy and releases its listener. It is safe to call multiple
@@ -129,6 +153,13 @@ func (proxy *egressProxy) Close() error {
 	proxy.closeOnce.Do(func() {
 		if proxy.server != nil {
 			err = proxy.server.Close()
+		}
+		// Closing the SOCKS listener unblocks serveSocks's Accept loop so the
+		// goroutine returns. Report its error only if the HTTP close succeeded.
+		if proxy.socksListener != nil {
+			if cerr := proxy.socksListener.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
 		}
 	})
 	return err

--- a/internal/sandbox/egress_socks.go
+++ b/internal/sandbox/egress_socks.go
@@ -14,6 +14,7 @@ import (
 const (
 	socksVersion5          = 0x05
 	socksNoAuth            = 0x00
+	socksNoAcceptable      = 0xFF
 	socksCmdConnect        = 0x01
 	socksAtypIPv4          = 0x01
 	socksAtypDomain        = 0x03
@@ -83,10 +84,24 @@ func socksNegotiate(conn net.Conn) (host string, port int, ok bool) {
 	if _, err := io.ReadFull(conn, greeting); err != nil || greeting[0] != socksVersion5 {
 		return "", 0, false
 	}
-	if _, err := io.ReadFull(conn, make([]byte, int(greeting[1]))); err != nil {
+	methods := make([]byte, int(greeting[1]))
+	if _, err := io.ReadFull(conn, methods); err != nil {
 		return "", 0, false
 	}
-	// Select the no-auth method.
+	// RFC 1928: select a method the client actually offered. We only support
+	// no-auth; if the client did not offer it, reply "no acceptable methods"
+	// (0xFF) and abort rather than forcing a method it never advertised.
+	supportsNoAuth := false
+	for _, method := range methods {
+		if method == socksNoAuth {
+			supportsNoAuth = true
+			break
+		}
+	}
+	if !supportsNoAuth {
+		_, _ = conn.Write([]byte{socksVersion5, socksNoAcceptable})
+		return "", 0, false
+	}
 	if _, err := conn.Write([]byte{socksVersion5, socksNoAuth}); err != nil {
 		return "", 0, false
 	}

--- a/internal/sandbox/egress_socks.go
+++ b/internal/sandbox/egress_socks.go
@@ -1,0 +1,141 @@
+package sandbox
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+// SOCKS5 wire constants (RFC 1928). The proxy speaks only the no-auth CONNECT
+// subset: enough for a sandboxed process configured with ALL_PROXY=socks5://...
+// to tunnel TCP through the same allow/deny gate the HTTP proxy enforces.
+const (
+	socksVersion5          = 0x05
+	socksNoAuth            = 0x00
+	socksCmdConnect        = 0x01
+	socksAtypIPv4          = 0x01
+	socksAtypDomain        = 0x03
+	socksAtypIPv6          = 0x04
+	socksRepSuccess        = 0x00
+	socksRepGeneralFailure = 0x01
+	socksRepNotAllowed     = 0x02
+	socksRepCmdUnsupported = 0x07
+)
+
+// socksHandshakeTimeout bounds the greeting+request exchange so a stalled or
+// malformed client cannot pin a goroutine; it is cleared before the relay so an
+// established tunnel is not torn down.
+const socksHandshakeTimeout = 30 * time.Second
+
+// serveSocks accepts SOCKS5 connections until the listener is closed.
+func (proxy *egressProxy) serveSocks(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		go proxy.handleSocksConn(conn)
+	}
+}
+
+// handleSocksConn runs one SOCKS5 CONNECT through the SAME authorize() gate as
+// the HTTP proxy: an allowed (host, port) is dialed and relayed; a denied target
+// gets a SOCKS "connection not allowed" reply and is never dialed. Fail-closed:
+// any protocol/read error just closes the connection.
+func (proxy *egressProxy) handleSocksConn(conn net.Conn) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(socksHandshakeTimeout))
+
+	host, port, ok := socksNegotiate(conn)
+	if !ok {
+		return
+	}
+	targetLabel := net.JoinHostPort(host, strconv.Itoa(port))
+	if !proxy.authorize(host, port) {
+		proxy.logDecision("deny", "SOCKS", targetLabel)
+		_ = socksReply(conn, socksRepNotAllowed)
+		return
+	}
+	upstream, err := net.DialTimeout("tcp", targetLabel, 30*time.Second)
+	if err != nil {
+		proxy.logDecision("deny", "SOCKS", targetLabel)
+		_ = socksReply(conn, socksRepGeneralFailure)
+		return
+	}
+	defer upstream.Close()
+	if err := socksReply(conn, socksRepSuccess); err != nil {
+		return
+	}
+	// Clear the handshake deadline; the tunnel is long-lived.
+	_ = conn.SetDeadline(time.Time{})
+	proxy.logDecision("allow", "SOCKS", targetLabel)
+	relay(conn, upstream)
+}
+
+// socksNegotiate performs the no-auth greeting and a CONNECT request, returning
+// the requested host and port. ok=false means negotiation failed (an error reply
+// has already been written where the protocol calls for one) and the caller
+// should close the connection.
+func socksNegotiate(conn net.Conn) (host string, port int, ok bool) {
+	greeting := make([]byte, 2) // VER, NMETHODS
+	if _, err := io.ReadFull(conn, greeting); err != nil || greeting[0] != socksVersion5 {
+		return "", 0, false
+	}
+	if _, err := io.ReadFull(conn, make([]byte, int(greeting[1]))); err != nil {
+		return "", 0, false
+	}
+	// Select the no-auth method.
+	if _, err := conn.Write([]byte{socksVersion5, socksNoAuth}); err != nil {
+		return "", 0, false
+	}
+
+	header := make([]byte, 4) // VER, CMD, RSV, ATYP
+	if _, err := io.ReadFull(conn, header); err != nil || header[0] != socksVersion5 {
+		return "", 0, false
+	}
+	if header[1] != socksCmdConnect {
+		_ = socksReply(conn, socksRepCmdUnsupported)
+		return "", 0, false
+	}
+	switch header[3] {
+	case socksAtypIPv4:
+		addr := make([]byte, net.IPv4len)
+		if _, err := io.ReadFull(conn, addr); err != nil {
+			return "", 0, false
+		}
+		host = net.IP(addr).String()
+	case socksAtypIPv6:
+		addr := make([]byte, net.IPv6len)
+		if _, err := io.ReadFull(conn, addr); err != nil {
+			return "", 0, false
+		}
+		host = net.IP(addr).String()
+	case socksAtypDomain:
+		length := make([]byte, 1)
+		if _, err := io.ReadFull(conn, length); err != nil {
+			return "", 0, false
+		}
+		name := make([]byte, int(length[0]))
+		if _, err := io.ReadFull(conn, name); err != nil {
+			return "", 0, false
+		}
+		host = string(name)
+	default:
+		_ = socksReply(conn, socksRepGeneralFailure)
+		return "", 0, false
+	}
+	portBytes := make([]byte, 2)
+	if _, err := io.ReadFull(conn, portBytes); err != nil {
+		return "", 0, false
+	}
+	return host, int(binary.BigEndian.Uint16(portBytes)), true
+}
+
+// socksReply writes a minimal SOCKS5 reply with the given status and a zero IPv4
+// bound address (clients ignore BND.ADDR/BND.PORT for CONNECT).
+func socksReply(conn net.Conn, status byte) error {
+	_, err := conn.Write([]byte{socksVersion5, status, 0x00, socksAtypIPv4, 0, 0, 0, 0, 0, 0})
+	return err
+}

--- a/internal/sandbox/egress_socks_test.go
+++ b/internal/sandbox/egress_socks_test.go
@@ -1,0 +1,156 @@
+package sandbox
+
+import (
+	"io"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// socks5Connect performs a SOCKS5 no-auth greeting and a CONNECT request for the
+// given ATYP/address/port through proxyAddr, returning the open connection and
+// the server's REP byte. The caller closes the connection.
+func socks5Connect(t *testing.T, proxyAddr string, atyp byte, addr []byte, port int) (net.Conn, byte) {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", proxyAddr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial socks proxy: %v", err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Greeting: VER=5, NMETHODS=1, METHOD=0 (no auth).
+	if _, err := conn.Write([]byte{socksVersion5, 0x01, socksNoAuth}); err != nil {
+		t.Fatalf("write greeting: %v", err)
+	}
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatalf("read method selection: %v", err)
+	}
+	if method[0] != socksVersion5 || method[1] != socksNoAuth {
+		t.Fatalf("method selection = %v, want [5 0]", method)
+	}
+
+	// Request: VER=5, CMD=CONNECT, RSV=0, ATYP, ADDR, PORT(2, big-endian).
+	request := append([]byte{socksVersion5, socksCmdConnect, 0x00, atyp}, addr...)
+	request = append(request, byte(port>>8), byte(port&0xff))
+	if _, err := conn.Write(request); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	reply := make([]byte, 10) // VER, REP, RSV, ATYP(IPv4), BND.ADDR(4), BND.PORT(2)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	return conn, reply[1]
+}
+
+func TestEgressProxySocksAddrBindsLoopback(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	if proxy.SocksAddr() == "" {
+		t.Fatal("SocksAddr must be non-empty while the proxy is running")
+	}
+	if proxy.SocksAddr() == proxy.Addr() {
+		t.Fatalf("SOCKS and HTTP listeners must be distinct ports, both %q", proxy.Addr())
+	}
+	host, _, err := net.SplitHostPort(proxy.SocksAddr())
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", proxy.SocksAddr(), err)
+	}
+	if host != "127.0.0.1" {
+		t.Fatalf("SOCKS bound to %q, want loopback 127.0.0.1", host)
+	}
+}
+
+// TestEgressProxySocksConnectAllowed verifies an allowlisted SOCKS5 CONNECT is
+// authorized through the SAME gate, dialed, and relayed to a fake upstream.
+func TestEgressProxySocksConnectAllowed(t *testing.T) {
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+	defer upstream.Close()
+	go func() {
+		c, aerr := upstream.Accept()
+		if aerr != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 4)
+		if _, rerr := io.ReadFull(c, buf); rerr != nil {
+			return
+		}
+		_, _ = c.Write([]byte("pong"))
+	}()
+
+	_, portStr, _ := net.SplitHostPort(upstream.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	// Allow the loopback IP so the IPv4 CONNECT is authorized.
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"127.0.0.1"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	conn, rep := socks5Connect(t, proxy.SocksAddr(), socksAtypIPv4, net.IPv4(127, 0, 0, 1).To4(), port)
+	defer conn.Close()
+	if rep != socksRepSuccess {
+		t.Fatalf("SOCKS CONNECT to allowed host REP = %#x, want success (0)", rep)
+	}
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write through tunnel: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read through tunnel: %v", err)
+	}
+	if string(got) != "pong" {
+		t.Fatalf("tunneled response = %q, want pong", string(got))
+	}
+}
+
+// TestEgressProxySocksConnectDenied verifies a non-allowlisted SOCKS5 CONNECT
+// (domain form) is refused with the "connection not allowed" reply.
+func TestEgressProxySocksConnectDenied(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"allowed.example"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	domain := "denied.example"
+	addr := append([]byte{byte(len(domain))}, []byte(domain)...)
+	conn, rep := socks5Connect(t, proxy.SocksAddr(), socksAtypDomain, addr, 443)
+	conn.Close()
+	if rep != socksRepNotAllowed {
+		t.Fatalf("SOCKS CONNECT to denied host REP = %#x, want not-allowed (2)", rep)
+	}
+}
+
+// TestEgressProxySocksDenyWinsOverAllow verifies the SOCKS gate honors
+// deny-wins: a denied subdomain of an allowed domain is refused (REP 2), proving
+// the SOCKS path runs the same authorize()/domainAllowed() logic as the HTTP
+// proxy rather than a parallel, weaker check.
+func TestEgressProxySocksDenyWinsOverAllow(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{
+		Allowed: []string{"allowed.example"},
+		Denied:  []string{"blocked.allowed.example"},
+	})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	denied := "blocked.allowed.example"
+	addr := append([]byte{byte(len(denied))}, []byte(denied)...)
+	conn, rep := socks5Connect(t, proxy.SocksAddr(), socksAtypDomain, addr, 443)
+	conn.Close()
+	if rep != socksRepNotAllowed {
+		t.Fatalf("denied subdomain REP = %#x, want not-allowed (2) (deny must win)", rep)
+	}
+}

--- a/internal/sandbox/egress_socks_test.go
+++ b/internal/sandbox/egress_socks_test.go
@@ -66,6 +66,37 @@ func TestEgressProxySocksAddrBindsLoopback(t *testing.T) {
 	}
 }
 
+// TestEgressProxySocksRejectsUnsupportedAuth verifies the proxy honors SOCKS5
+// method negotiation: a client offering only methods the proxy does not support
+// (here user/pass 0x02, no no-auth) gets the "no acceptable methods" reply (0xFF)
+// rather than the proxy forcing a method the client never advertised.
+func TestEgressProxySocksRejectsUnsupportedAuth(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.SocksAddr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial socks proxy: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+	// Greeting: VER=5, NMETHODS=1, METHOD=0x02 (user/pass) — no-auth NOT offered.
+	if _, err := conn.Write([]byte{socksVersion5, 0x01, 0x02}); err != nil {
+		t.Fatalf("write greeting: %v", err)
+	}
+	resp := make([]byte, 2)
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		t.Fatalf("read method selection: %v", err)
+	}
+	if resp[0] != socksVersion5 || resp[1] != socksNoAcceptable {
+		t.Fatalf("method selection = %v, want [5 0xFF] (no acceptable methods)", resp)
+	}
+}
+
 // TestEgressProxySocksConnectAllowed verifies an allowlisted SOCKS5 CONNECT is
 // authorized through the SAME gate, dialed, and relayed to a fake upstream.
 func TestEgressProxySocksConnectAllowed(t *testing.T) {

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"context"
 	"errors"
-	"path/filepath"
 	"strings"
 )
 
@@ -66,34 +65,20 @@ func (engine *Engine) Scope() *Scope {
 	return engine.scope
 }
 
-// ReadPathExcluded reports whether reading path is excluded by the policy's
-// DenyRead list (honoring more-specific AllowRead re-inclusion). It is the
-// per-file predicate the search tools use to skip read-denied files mid-walk.
-// False when DenyRead is unset (the default) or the engine is nil.
-func (engine *Engine) ReadPathExcluded(path string) bool {
+// ReadExclusions returns the resolved DenyRead/AllowRead exclusion matcher for
+// this engine's policy, resolving each policy entry ONCE. The search tools build
+// it a single time per run and reuse it across the whole walk so the predicates
+// don't re-run Abs/EvalSymlinks per visited path. Returns nil for a nil engine
+// (the matcher's methods treat nil as "exclude nothing").
+func (engine *Engine) ReadExclusions() *ReadExclusions {
 	if engine == nil {
-		return false
+		return nil
 	}
-	return readDenied(engine.policy, engine.workspaceRoot, path)
-}
-
-// ReadDirExcluded reports whether a directory subtree can be skipped wholesale
-// during a read-walk: it is read-denied AND contains no nested AllowRead root
-// (descending is required to reach a re-included subtree). When it returns false
-// on a denied dir because of a nested allow, the per-file ReadPathExcluded still
-// filters the denied siblings.
-func (engine *Engine) ReadDirExcluded(path string) bool {
-	if engine == nil {
-		return false
+	return &ReadExclusions{
+		workspaceRoot: engine.workspaceRoot,
+		denyRoots:     resolvePolicyPaths(engine.policy.DenyRead),
+		allowRoots:    resolvePolicyPaths(engine.policy.AllowRead),
 	}
-	if !readDenied(engine.policy, engine.workspaceRoot, path) {
-		return false
-	}
-	abs := path
-	if !filepath.IsAbs(abs) && engine.workspaceRoot != "" {
-		abs = filepath.Join(engine.workspaceRoot, path)
-	}
-	return !hasNestedAllowRead(engine.policy, abs)
 }
 
 // ReadExclusionGlobs returns the ripgrep-style --glob exclusion args for this

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -71,7 +71,9 @@ func (engine *Engine) Scope() *Scope {
 // don't re-run Abs/EvalSymlinks per visited path. Returns nil for a nil engine
 // (the matcher's methods treat nil as "exclude nothing").
 func (engine *Engine) ReadExclusions() *ReadExclusions {
-	if engine == nil {
+	// A disabled policy enforces nothing, so it must not filter search results
+	// either (Evaluate already allows every request under ModeDisabled).
+	if engine == nil || engine.policy.Mode == ModeDisabled {
 		return nil
 	}
 	return &ReadExclusions{
@@ -85,7 +87,8 @@ func (engine *Engine) ReadExclusions() *ReadExclusions {
 // engine's policy + scope (see the package-level ReadExclusionGlobs). Empty when
 // DenyRead is unset or the engine has no scope.
 func (engine *Engine) ReadExclusionGlobs() []string {
-	if engine == nil {
+	// A disabled policy filters nothing (parity with ReadExclusions / Evaluate).
+	if engine == nil || engine.policy.Mode == ModeDisabled {
 		return nil
 	}
 	return ReadExclusionGlobs(engine.policy, engine.scope)
@@ -258,9 +261,15 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	if request.Permission == PermissionDeny {
 		return deny(request, risk, ViolationDeniedPermission, "", permissionReason(request), false)
 	}
-	if policy.EnforceWorkspace && request.WorkspaceRoot != "" {
+	// The fine-grained path lists (DenyRead/DenyWrite/AllowRead/AllowWrite) apply
+	// whenever the sandbox is enforcing, independent of EnforceWorkspace, so a
+	// DenyWrite/DenyRead entry is honored even with workspace confinement off (and
+	// consistent with the grep/glob exclusion path). The workspace boundary itself
+	// is still gated by EnforceWorkspace inside validatePathWithPolicy. Mode is
+	// already known to be enforcing here (ModeDisabled returned above).
+	if request.WorkspaceRoot != "" {
 		for _, requested := range requestPaths(request) {
-			if violation := validatePathWithPolicy(scope, policy, request.SideEffect, request.WorkspaceRoot, requested); violation != nil {
+			if violation := validatePathWithPolicy(scope, policy, request.SideEffect, policy.EnforceWorkspace, request.WorkspaceRoot, requested); violation != nil {
 				return deny(request, risk, violation.Code, violation.Path, violation.Reason, false)
 			}
 		}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -116,12 +116,23 @@ func (engine *Engine) effectiveNetworkMode(policy Policy) NetworkMode {
 // their pre-sandbox behaviour); deny blocks everything; scoped allows only hosts
 // in AllowedDomains minus DeniedDomains (an empty allowlist, or a backend that
 // can't enforce scoped egress, collapses to deny).
+//
+// By default the first-party, in-process tools that consult this gate are NOT
+// subject to the network policy (EnforceToolNetwork is off): that policy exists
+// to confine the sandboxed SHELL's egress, which these tools don't use, and they
+// retain their own SSRF/port/redirect safeguards. Set EnforceToolNetwork to also
+// hold them to the allow/scoped/deny policy. The sandboxed-shell egress decision
+// lives in Evaluate via effectiveNetworkMode and is unaffected by this flag.
 func (engine *Engine) NetworkHostAllowed(host string) (bool, NetworkMode) {
 	if engine == nil {
 		return true, NetworkAllow
 	}
 	policy := engine.policy
 	if policy.Mode == ModeDisabled {
+		return true, NetworkAllow
+	}
+	if !policy.EnforceToolNetwork {
+		// First-party in-process tools are exempt unless the operator opts in.
 		return true, NetworkAllow
 	}
 	switch mode := engine.effectiveNetworkMode(policy); mode {

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -262,16 +262,16 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 		return deny(request, risk, ViolationDeniedPermission, "", permissionReason(request), false)
 	}
 	// The fine-grained path lists (DenyRead/DenyWrite/AllowRead/AllowWrite) apply
-	// whenever the sandbox is enforcing, independent of EnforceWorkspace, so a
-	// DenyWrite/DenyRead entry is honored even with workspace confinement off (and
-	// consistent with the grep/glob exclusion path). The workspace boundary itself
-	// is still gated by EnforceWorkspace inside validatePathWithPolicy. Mode is
+	// whenever the sandbox is enforcing, independent of EnforceWorkspace and even
+	// when there is no workspace root (absolute paths are still resolved and
+	// matched), so they are honored consistently with the grep/glob exclusion path
+	// and can't be bypassed by an engine built without a workspace root. The
+	// workspace boundary itself needs a root, so it is gated on having one. Mode is
 	// already known to be enforcing here (ModeDisabled returned above).
-	if request.WorkspaceRoot != "" {
-		for _, requested := range requestPaths(request) {
-			if violation := validatePathWithPolicy(scope, policy, request.SideEffect, policy.EnforceWorkspace, request.WorkspaceRoot, requested); violation != nil {
-				return deny(request, risk, violation.Code, violation.Path, violation.Reason, false)
-			}
+	enforceWorkspace := policy.EnforceWorkspace && request.WorkspaceRoot != ""
+	for _, requested := range requestPaths(request) {
+		if violation := validatePathWithPolicy(scope, policy, request.SideEffect, enforceWorkspace, request.WorkspaceRoot, requested); violation != nil {
+			return deny(request, risk, violation.Code, violation.Path, violation.Reason, false)
 		}
 	}
 	// effectiveNetworkMode collapses an empty-allowlist scoped policy to deny, and

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 )
 
@@ -63,6 +64,46 @@ func (engine *Engine) Scope() *Scope {
 		return nil
 	}
 	return engine.scope
+}
+
+// ReadPathExcluded reports whether reading path is excluded by the policy's
+// DenyRead list (honoring more-specific AllowRead re-inclusion). It is the
+// per-file predicate the search tools use to skip read-denied files mid-walk.
+// False when DenyRead is unset (the default) or the engine is nil.
+func (engine *Engine) ReadPathExcluded(path string) bool {
+	if engine == nil {
+		return false
+	}
+	return readDenied(engine.policy, engine.workspaceRoot, path)
+}
+
+// ReadDirExcluded reports whether a directory subtree can be skipped wholesale
+// during a read-walk: it is read-denied AND contains no nested AllowRead root
+// (descending is required to reach a re-included subtree). When it returns false
+// on a denied dir because of a nested allow, the per-file ReadPathExcluded still
+// filters the denied siblings.
+func (engine *Engine) ReadDirExcluded(path string) bool {
+	if engine == nil {
+		return false
+	}
+	if !readDenied(engine.policy, engine.workspaceRoot, path) {
+		return false
+	}
+	abs := path
+	if !filepath.IsAbs(abs) && engine.workspaceRoot != "" {
+		abs = filepath.Join(engine.workspaceRoot, path)
+	}
+	return !hasNestedAllowRead(engine.policy, abs)
+}
+
+// ReadExclusionGlobs returns the ripgrep-style --glob exclusion args for this
+// engine's policy + scope (see the package-level ReadExclusionGlobs). Empty when
+// DenyRead is unset or the engine has no scope.
+func (engine *Engine) ReadExclusionGlobs() []string {
+	if engine == nil {
+		return nil
+	}
+	return ReadExclusionGlobs(engine.policy, engine.scope)
 }
 
 // effectiveNetworkMode is the single source of truth for the engine's active
@@ -223,7 +264,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	}
 	if policy.EnforceWorkspace && request.WorkspaceRoot != "" {
 		for _, requested := range requestPaths(request) {
-			if violation := scope.validate(requested); violation != nil {
+			if violation := validatePathWithPolicy(scope, policy, request.SideEffect, request.WorkspaceRoot, requested); violation != nil {
 				return deny(request, risk, violation.Code, violation.Path, violation.Reason, false)
 			}
 		}

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -736,7 +736,11 @@ func TestEngineNetworkHostAllowed(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			engine := NewEngine(EngineOptions{Policy: tc.policy, Backend: tc.backend})
+			// This table exercises the ENFORCED tool-network gate; the default
+			// (exempt) posture is covered by TestEngineNetworkHostAllowedToolNetworkDefaultExempt.
+			policy := tc.policy
+			policy.EnforceToolNetwork = true
+			engine := NewEngine(EngineOptions{Policy: policy, Backend: tc.backend})
 			allowed, mode := engine.NetworkHostAllowed(tc.host)
 			if allowed != tc.allowed || mode != tc.mode {
 				t.Fatalf("NetworkHostAllowed(%q) = (%v, %q), want (%v, %q)", tc.host, allowed, mode, tc.allowed, tc.mode)
@@ -747,5 +751,23 @@ func TestEngineNetworkHostAllowed(t *testing.T) {
 	var nilEngine *Engine
 	if allowed, mode := nilEngine.NetworkHostAllowed("example.com"); !allowed || mode != NetworkAllow {
 		t.Fatalf("nil engine NetworkHostAllowed = (%v, %q), want (true, allow)", allowed, mode)
+	}
+}
+
+// TestEngineNetworkHostAllowedToolNetworkDefaultExempt verifies the default
+// posture: with EnforceToolNetwork off, the in-process tool gate is exempt from
+// the network policy, so even a deny / scoped-unlisted host is allowed (the
+// sandboxed-shell egress decision is separate and unaffected).
+func TestEngineNetworkHostAllowedToolNetworkDefaultExempt(t *testing.T) {
+	egressBackend := Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/bin/sandbox-exec", ScopedEgress: true}
+	policies := []Policy{
+		{Mode: ModeEnforce, Network: NetworkDeny},
+		{Mode: ModeEnforce, Network: NetworkScoped, AllowedDomains: []string{"allowed.test"}},
+	}
+	for _, policy := range policies {
+		engine := NewEngine(EngineOptions{Policy: policy, Backend: egressBackend})
+		if allowed, _ := engine.NetworkHostAllowed("evil.test"); !allowed {
+			t.Fatalf("default (EnforceToolNetwork off) must allow the tool host under network=%q", policy.Network)
+		}
 	}
 }

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -1,0 +1,274 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file implements the fine-grained AllowRead/DenyRead/AllowWrite/DenyWrite
+// path lists (Policy fields). They layer ON TOP of the workspace + Scope guards
+// and never bypass them: AllowRead only re-includes inside a DenyRead carve-out,
+// AllowWrite is consulted only after the workspace/Scope guard already denied a
+// write, and every match is symlink-resolved so a symlink prefix cannot evade a
+// deny or sneak past an allow. All lists default empty, so an unconfigured policy
+// behaves exactly as before.
+
+// resolvePolicyPath home-expands, makes absolute, and symlink-resolves a single
+// policy path entry. ok is false for a blank entry or one that does not exist
+// (EvalSymlinks requires existence) so a bogus entry is dropped — a non-existent
+// deny protects nothing and a non-existent allow grants nothing.
+func resolvePolicyPath(entry string) (string, bool) {
+	trimmed := strings.TrimSpace(entry)
+	if trimmed == "" {
+		return "", false
+	}
+	if trimmed == "~" || strings.HasPrefix(trimmed, "~/") || strings.HasPrefix(trimmed, "~"+string(filepath.Separator)) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		trimmed = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(trimmed[1:], "/"), string(filepath.Separator)))
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", false
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", false
+	}
+	return resolved, true
+}
+
+// resolvePolicyPaths resolves and de-duplicates a list of policy path entries,
+// dropping blanks and non-existent entries. Files and directories are both kept
+// (a DenyRead/DenyWrite entry may target a single sensitive file).
+func resolvePolicyPaths(entries []string) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(entries))
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		resolved, ok := resolvePolicyPath(entry)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[resolved]; dup {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		out = append(out, resolved)
+	}
+	return out
+}
+
+// resolveWriteRootPaths is resolvePolicyPaths restricted to existing directories
+// that are not the filesystem root — the only valid targets for an OS write bind
+// and for an AllowWrite grant root.
+func resolveWriteRootPaths(entries []string) []string {
+	resolved := resolvePolicyPaths(entries)
+	if len(resolved) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(resolved))
+	for _, path := range resolved {
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if filepath.Dir(path) == path {
+			continue // refuse the filesystem root as a write root
+		}
+		out = append(out, path)
+	}
+	return out
+}
+
+// pathUnderPolicyRoot reports whether requestedPath lies within root. A relative
+// requestedPath is resolved against workspaceRoot; the portion of an absolute
+// path outside root is symlink-resolved (via NormalizePrefixForRoot) so a
+// symlink prefix cannot evade the match. root must be an already-resolved
+// absolute path.
+func pathUnderPolicyRoot(requestedPath, root, workspaceRoot string) bool {
+	if root == "" {
+		return false
+	}
+	abs := requestedPath
+	if !filepath.IsAbs(abs) {
+		if workspaceRoot == "" {
+			return false
+		}
+		abs = filepath.Join(workspaceRoot, abs)
+	}
+	normalized := NormalizePrefixForRoot(abs, root)
+	return pathWithinRoot(root, normalized)
+}
+
+// readDenied reports whether path is excluded by the DenyRead list with no
+// more-specific AllowRead re-inclusion. "More specific" means an AllowRead entry
+// nested inside the matched DenyRead entry — that subtree is read back in while
+// the rest of the denied tree stays blocked.
+func readDenied(policy Policy, workspaceRoot, path string) bool {
+	denyRoots := resolvePolicyPaths(policy.DenyRead)
+	if len(denyRoots) == 0 {
+		return false
+	}
+	allowRoots := resolvePolicyPaths(policy.AllowRead)
+	for _, deny := range denyRoots {
+		if !pathUnderPolicyRoot(path, deny, workspaceRoot) {
+			continue
+		}
+		reincluded := false
+		for _, allow := range allowRoots {
+			// The allow entry must sit inside the deny entry to be "more specific",
+			// and the path must fall under that allow entry.
+			if pathWithinRoot(deny, allow) && pathUnderPolicyRoot(path, allow, workspaceRoot) {
+				reincluded = true
+				break
+			}
+		}
+		if !reincluded {
+			return true
+		}
+	}
+	return false
+}
+
+// allowWriteScope builds an ad-hoc Scope from the resolved AllowWrite roots so a
+// write to an AllowWrite path is validated with the SAME symlink-traversal logic
+// the workspace Scope uses. Returns nil when there are no usable AllowWrite roots.
+func allowWriteScope(policy Policy) *Scope {
+	roots := resolveWriteRootPaths(policy.AllowWrite)
+	if len(roots) == 0 {
+		return nil
+	}
+	return &Scope{workspaceRoot: roots[0], extraRoots: roots[1:]}
+}
+
+// validateWritePath enforces the write precedence: DenyWrite wins, then a
+// workspace/Scope-writable path is allowed, then an absolute path under an
+// AllowWrite root is allowed, otherwise the base workspace/Scope violation
+// stands. It never bypasses the symlink/out-of-workspace guards.
+func validateWritePath(scope *Scope, policy Policy, workspaceRoot, path string) *pathViolation {
+	for _, deny := range resolvePolicyPaths(policy.DenyWrite) {
+		if pathUnderPolicyRoot(path, deny, workspaceRoot) {
+			return &pathViolation{
+				Code:   ViolationPolicyDenied,
+				Path:   path,
+				Reason: path + " is excluded by the sandbox DenyWrite policy",
+			}
+		}
+	}
+	base := scope.validate(path)
+	if base == nil {
+		return nil // writable under the workspace / Scope guard
+	}
+	// AllowWrite only extends ABSOLUTE paths: a relative path is inherently
+	// workspace-relative and already resolved by the base guard above.
+	if filepath.IsAbs(path) {
+		if allow := allowWriteScope(policy); allow != nil && allow.validate(path) == nil {
+			return nil
+		}
+	}
+	return base
+}
+
+// validatePathWithPolicy is the single entry point the engine uses to validate a
+// request path: it applies the fine-grained read/write lists for read and write
+// side effects and falls back to the plain workspace/Scope guard for everything
+// else, so behavior is unchanged when the lists are empty.
+func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, workspaceRoot, path string) *pathViolation {
+	switch sideEffect {
+	case SideEffectRead:
+		if readDenied(policy, workspaceRoot, path) {
+			return &pathViolation{
+				Code:   ViolationPolicyDenied,
+				Path:   path,
+				Reason: path + " is excluded by the sandbox DenyRead policy",
+			}
+		}
+		return scope.validate(path)
+	case SideEffectWrite, SideEffectOutOfWorkspace:
+		return validateWritePath(scope, policy, workspaceRoot, path)
+	default:
+		return scope.validate(path)
+	}
+}
+
+// hasNestedAllowRead reports whether any AllowRead root sits strictly inside dir
+// (an already-resolved absolute path). When true, a read-denied dir must still be
+// descended during a walk so the re-included subtree is reachable.
+func hasNestedAllowRead(policy Policy, dir string) bool {
+	for _, allow := range resolvePolicyPaths(policy.AllowRead) {
+		if allow != dir && pathWithinRoot(dir, allow) {
+			return true
+		}
+	}
+	return false
+}
+
+// workspaceRelGlob returns target as a clean, slash-separated path relative to
+// workspaceRoot, or ok=false when target is the root itself or lies outside it
+// (a workspace-rooted search never reaches such a path, so no glob is needed).
+func workspaceRelGlob(workspaceRoot, target string) (string, bool) {
+	rel, err := filepath.Rel(workspaceRoot, target)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
+// ReadExclusionGlobs returns ripgrep-style --glob exclusion args for the policy's
+// DenyRead subtrees that fall inside the scope's workspace root, so a
+// ripgrep-based search never descends into a read-denied subtree. For each such
+// entry it emits `--glob`, `!<rel>` and `--glob`, `!<rel>/**`. Mirrors the
+// read-subtree exclusion globs used by comparable executor sandboxes.
+//
+// The projection is exclusions-only: a positive ripgrep glob would switch the
+// search into whitelist mode and restrict it to only matching files, so AllowRead
+// re-inclusion is NOT expressed here. The Go-native grep/glob tools honor
+// AllowRead precisely via the per-path predicate (Engine.ReadPathExcluded /
+// ReadDirExcluded); this function is the coarser ripgrep-format export for an
+// external rg-based consumer. Empty when DenyRead is unset (the default), so
+// search behavior is unchanged.
+func ReadExclusionGlobs(policy Policy, scope *Scope) []string {
+	denyRoots := resolvePolicyPaths(policy.DenyRead)
+	if len(denyRoots) == 0 || scope == nil {
+		return nil
+	}
+	workspaceRoot := scope.WorkspaceRoot()
+	if workspaceRoot == "" {
+		return nil
+	}
+	var globs []string
+	for _, deny := range denyRoots {
+		rel, ok := workspaceRelGlob(workspaceRoot, deny)
+		if !ok {
+			continue
+		}
+		globs = append(globs, "--glob", "!"+rel, "--glob", "!"+rel+"/**")
+	}
+	return globs
+}
+
+// dedupeStrings returns xs with duplicates removed, preserving first-seen order.
+func dedupeStrings(xs []string) []string {
+	if len(xs) <= 1 {
+		return xs
+	}
+	seen := make(map[string]struct{}, len(xs))
+	out := make([]string, 0, len(xs))
+	for _, x := range xs {
+		if _, dup := seen[x]; dup {
+			continue
+		}
+		seen[x] = struct{}{}
+		out = append(out, x)
+	}
+	return out
+}

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -205,11 +205,14 @@ func allowWriteScope(policy Policy) *Scope {
 	return &Scope{workspaceRoot: roots[0], extraRoots: roots[1:]}
 }
 
-// validateWritePath enforces the write precedence: DenyWrite wins, then a
-// workspace/Scope-writable path is allowed, then an absolute path under an
-// AllowWrite root is allowed, otherwise the base workspace/Scope violation
-// stands. It never bypasses the symlink/out-of-workspace guards.
-func validateWritePath(scope *Scope, policy Policy, workspaceRoot, path string) *pathViolation {
+// validateWritePath enforces the write precedence: DenyWrite wins, then (when
+// workspace enforcement is on) a workspace/Scope-writable path is allowed, then
+// an absolute path under an AllowWrite root is allowed, otherwise the base
+// workspace/Scope violation stands. The DenyWrite list applies regardless of
+// enforceWorkspace; the workspace boundary itself applies only when
+// enforceWorkspace. It never bypasses the symlink/out-of-workspace guards.
+func validateWritePath(scope *Scope, policy Policy, enforceWorkspace bool, workspaceRoot, path string) *pathViolation {
+	// DenyWrite wins regardless of workspace enforcement.
 	for _, deny := range resolvePolicyPaths(policy.DenyWrite) {
 		if pathUnderPolicyRoot(path, deny, workspaceRoot) {
 			return &pathViolation{
@@ -218,6 +221,10 @@ func validateWritePath(scope *Scope, policy Policy, workspaceRoot, path string) 
 				Reason: path + " is excluded by the sandbox DenyWrite policy",
 			}
 		}
+	}
+	if !enforceWorkspace {
+		// Workspace confinement is off: only the explicit DenyWrite list restricts.
+		return nil
 	}
 	base := scope.validate(path)
 	if base == nil {
@@ -234,10 +241,12 @@ func validateWritePath(scope *Scope, policy Policy, workspaceRoot, path string) 
 }
 
 // validatePathWithPolicy is the single entry point the engine uses to validate a
-// request path: it applies the fine-grained read/write lists for read and write
-// side effects and falls back to the plain workspace/Scope guard for everything
-// else, so behavior is unchanged when the lists are empty.
-func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, workspaceRoot, path string) *pathViolation {
+// request path. The fine-grained read/write lists (DenyRead/DenyWrite, with
+// AllowRead/AllowWrite) apply whenever the sandbox is enforcing, INDEPENDENT of
+// enforceWorkspace, so they match the grep/glob path that also honors DenyRead
+// directly. The workspace boundary (scope.validate) applies only when
+// enforceWorkspace. Behavior is unchanged when the lists are empty.
+func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, enforceWorkspace bool, workspaceRoot, path string) *pathViolation {
 	switch sideEffect {
 	case SideEffectRead:
 		if readDenied(policy, workspaceRoot, path) {
@@ -247,11 +256,17 @@ func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, 
 				Reason: path + " is excluded by the sandbox DenyRead policy",
 			}
 		}
-		return scope.validate(path)
+		if enforceWorkspace {
+			return scope.validate(path)
+		}
+		return nil
 	case SideEffectWrite, SideEffectOutOfWorkspace:
-		return validateWritePath(scope, policy, workspaceRoot, path)
+		return validateWritePath(scope, policy, enforceWorkspace, workspaceRoot, path)
 	default:
-		return scope.validate(path)
+		if enforceWorkspace {
+			return scope.validate(path)
+		}
+		return nil
 	}
 }
 

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -247,6 +247,20 @@ func validateWritePath(scope *Scope, policy Policy, enforceWorkspace bool, works
 // directly. The workspace boundary (scope.validate) applies only when
 // enforceWorkspace. Behavior is unchanged when the lists are empty.
 func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, enforceWorkspace bool, workspaceRoot, path string) *pathViolation {
+	// A relative path cannot be anchored without a workspace root, so it cannot be
+	// checked against the (absolute) path lists or workspace boundary. Fail closed
+	// when there is anything to enforce; otherwise it is a no-op (unchanged from the
+	// pre-path-list behavior, where an empty workspace root skipped validation).
+	if workspaceRoot == "" && !filepath.IsAbs(path) {
+		if enforceWorkspace || policyHasPathLists(policy) {
+			return &pathViolation{
+				Code:   ViolationOutsideWorkspace,
+				Path:   path,
+				Reason: path + " cannot be validated without a workspace root",
+			}
+		}
+		return nil
+	}
 	switch sideEffect {
 	case SideEffectRead:
 		if readDenied(policy, workspaceRoot, path) {
@@ -328,6 +342,12 @@ func ReadExclusionGlobs(policy Policy, scope *Scope) []string {
 		globs = append(globs, "--glob", "!"+rel, "--glob", "!"+rel+"/**")
 	}
 	return globs
+}
+
+// policyHasPathLists reports whether any fine-grained path list is configured.
+func policyHasPathLists(policy Policy) bool {
+	return len(policy.DenyRead) > 0 || len(policy.AllowRead) > 0 ||
+		len(policy.DenyWrite) > 0 || len(policy.AllowWrite) > 0
 }
 
 // dedupeStrings returns xs with duplicates removed, preserving first-seen order.

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -109,13 +109,20 @@ func pathUnderPolicyRoot(requestedPath, root, workspaceRoot string) bool {
 // readDenied reports whether path is excluded by the DenyRead list with no
 // more-specific AllowRead re-inclusion. "More specific" means an AllowRead entry
 // nested inside the matched DenyRead entry — that subtree is read back in while
-// the rest of the denied tree stays blocked.
+// the rest of the denied tree stays blocked. It resolves the policy entries on
+// each call, so it suits a one-shot check (the Evaluate gate). A search walk that
+// checks many paths should use ReadExclusions, which resolves the entries once.
 func readDenied(policy Policy, workspaceRoot, path string) bool {
-	denyRoots := resolvePolicyPaths(policy.DenyRead)
+	return readDeniedResolved(workspaceRoot, resolvePolicyPaths(policy.DenyRead), resolvePolicyPaths(policy.AllowRead), path)
+}
+
+// readDeniedResolved is readDenied operating on ALREADY-resolved deny/allow roots,
+// so a caller that resolved the policy entries once can reuse them across many
+// path checks instead of re-running Abs/EvalSymlinks per path.
+func readDeniedResolved(workspaceRoot string, denyRoots, allowRoots []string, path string) bool {
 	if len(denyRoots) == 0 {
 		return false
 	}
-	allowRoots := resolvePolicyPaths(policy.AllowRead)
 	for _, deny := range denyRoots {
 		if !pathUnderPolicyRoot(path, deny, workspaceRoot) {
 			continue
@@ -134,6 +141,49 @@ func readDenied(policy Policy, workspaceRoot, path string) bool {
 		}
 	}
 	return false
+}
+
+// ReadExclusions holds the resolved DenyRead/AllowRead roots for a policy so a
+// search walk resolves each policy entry ONCE (Abs/EvalSymlinks) and reuses the
+// result across every visited path, rather than re-resolving per path. Build it
+// with Engine.ReadExclusions and reuse it for the whole grep/glob walk.
+type ReadExclusions struct {
+	workspaceRoot string
+	denyRoots     []string
+	allowRoots    []string
+}
+
+// Active reports whether any DenyRead root is configured. When false the
+// exclusions are a no-op and the search behaves exactly as before.
+func (rx *ReadExclusions) Active() bool {
+	return rx != nil && len(rx.denyRoots) > 0
+}
+
+// PathExcluded reports whether reading path is excluded by DenyRead, honoring a
+// more-specific AllowRead re-inclusion. It is the per-file predicate for a walk.
+func (rx *ReadExclusions) PathExcluded(path string) bool {
+	if !rx.Active() {
+		return false
+	}
+	return readDeniedResolved(rx.workspaceRoot, rx.denyRoots, rx.allowRoots, path)
+}
+
+// DirExcluded reports whether a directory subtree can be skipped wholesale during
+// a walk: it is read-denied AND contains no nested AllowRead root (descending is
+// required to reach a re-included subtree). When it returns false on a denied dir
+// because of a nested allow, PathExcluded still filters the denied siblings.
+func (rx *ReadExclusions) DirExcluded(path string) bool {
+	if !rx.Active() {
+		return false
+	}
+	if !readDeniedResolved(rx.workspaceRoot, rx.denyRoots, rx.allowRoots, path) {
+		return false
+	}
+	abs := path
+	if !filepath.IsAbs(abs) && rx.workspaceRoot != "" {
+		abs = filepath.Join(rx.workspaceRoot, path)
+	}
+	return !hasNestedAllowReadResolved(rx.allowRoots, abs)
 }
 
 // allowWriteScope builds an ad-hoc Scope from the resolved AllowWrite roots so a
@@ -197,11 +247,12 @@ func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, 
 	}
 }
 
-// hasNestedAllowRead reports whether any AllowRead root sits strictly inside dir
-// (an already-resolved absolute path). When true, a read-denied dir must still be
-// descended during a walk so the re-included subtree is reachable.
-func hasNestedAllowRead(policy Policy, dir string) bool {
-	for _, allow := range resolvePolicyPaths(policy.AllowRead) {
+// hasNestedAllowReadResolved reports whether any already-resolved AllowRead root
+// sits strictly inside dir (an already-resolved absolute path). When true, a
+// read-denied dir must still be descended during a walk so the re-included
+// subtree is reachable.
+func hasNestedAllowReadResolved(allowRoots []string, dir string) bool {
+	for _, allow := range allowRoots {
 		if allow != dir && pathWithinRoot(dir, allow) {
 			return true
 		}
@@ -232,10 +283,10 @@ func workspaceRelGlob(workspaceRoot, target string) (string, bool) {
 // The projection is exclusions-only: a positive ripgrep glob would switch the
 // search into whitelist mode and restrict it to only matching files, so AllowRead
 // re-inclusion is NOT expressed here. The Go-native grep/glob tools honor
-// AllowRead precisely via the per-path predicate (Engine.ReadPathExcluded /
-// ReadDirExcluded); this function is the coarser ripgrep-format export for an
-// external rg-based consumer. Empty when DenyRead is unset (the default), so
-// search behavior is unchanged.
+// AllowRead precisely via the cached predicate (Engine.ReadExclusions); this
+// function is the coarser ripgrep-format export for an external rg-based
+// consumer. Empty when DenyRead is unset (the default), so search behavior is
+// unchanged.
 func ReadExclusionGlobs(policy Policy, scope *Scope) []string {
 	denyRoots := resolvePolicyPaths(policy.DenyRead)
 	if len(denyRoots) == 0 || scope == nil {

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -344,10 +344,16 @@ func ReadExclusionGlobs(policy Policy, scope *Scope) []string {
 	return globs
 }
 
-// policyHasPathLists reports whether any fine-grained path list is configured.
+// policyHasPathLists reports whether any fine-grained path list has an
+// ENFORCEABLE entry. It resolves the lists (matching how the rest of this file
+// normalizes them) rather than counting raw config, so a typo or non-existent
+// entry — which resolution drops — doesn't spuriously fail-close relative
+// requests when there is no workspace root.
 func policyHasPathLists(policy Policy) bool {
-	return len(policy.DenyRead) > 0 || len(policy.AllowRead) > 0 ||
-		len(policy.DenyWrite) > 0 || len(policy.AllowWrite) > 0
+	return len(resolvePolicyPaths(policy.DenyRead)) > 0 ||
+		len(resolvePolicyPaths(policy.AllowRead)) > 0 ||
+		len(resolvePolicyPaths(policy.DenyWrite)) > 0 ||
+		len(resolveWriteRootPaths(policy.AllowWrite)) > 0
 }
 
 // dedupeStrings returns xs with duplicates removed, preserving first-seen order.

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -183,6 +183,14 @@ func (rx *ReadExclusions) DirExcluded(path string) bool {
 	if !filepath.IsAbs(abs) && rx.workspaceRoot != "" {
 		abs = filepath.Join(rx.workspaceRoot, path)
 	}
+	// allowRoots are symlink-resolved (resolvePolicyPaths), so resolve abs the
+	// same way before the prefix comparison — otherwise a dir reached THROUGH a
+	// symlink would fail to match a nested AllowRead root and be wrongly skipped,
+	// dropping a re-included subtree. Best-effort: keep abs if it can't resolve
+	// (e.g. a non-existent path), matching the deny check's tolerant behavior.
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
 	return !hasNestedAllowReadResolved(rx.allowRoots, abs)
 }
 

--- a/internal/sandbox/pathlists_test.go
+++ b/internal/sandbox/pathlists_test.go
@@ -256,6 +256,41 @@ func TestPathListsApplyWithoutWorkspaceEnforcement(t *testing.T) {
 	}
 }
 
+// TestEvaluatePathListsWithoutWorkspaceRoot verifies the path lists are enforced
+// even on an engine built WITHOUT a workspace root: absolute paths are matched
+// against DenyWrite, and an unanchorable relative path fails closed.
+func TestEvaluatePathListsWithoutWorkspaceRoot(t *testing.T) {
+	secret := resolvedTempDir(t)
+	other := resolvedTempDir(t)
+	engine := NewEngine(EngineOptions{
+		Policy: Policy{Mode: ModeEnforce, MaxAutonomy: AutonomyHigh, DenyWrite: []string{secret}},
+	})
+
+	denied := engine.Evaluate(context.Background(), Request{
+		ToolName: "write_file", SideEffect: SideEffectWrite,
+		Args: map[string]any{"path": filepath.Join(secret, "x")},
+	})
+	if denied.Action != ActionDeny {
+		t.Fatalf("absolute DenyWrite path must be denied without a workspace root, got %q", denied.Action)
+	}
+
+	ok := engine.Evaluate(context.Background(), Request{
+		ToolName: "write_file", SideEffect: SideEffectWrite,
+		Args: map[string]any{"path": filepath.Join(other, "x")},
+	})
+	if ok.Action == ActionDeny {
+		t.Fatalf("a non-denied absolute path must not be denied without a workspace root, got deny: %s", ok.ErrorString())
+	}
+
+	rel := engine.Evaluate(context.Background(), Request{
+		ToolName: "write_file", SideEffect: SideEffectWrite,
+		Args: map[string]any{"path": "x"},
+	})
+	if rel.Action != ActionDeny {
+		t.Fatalf("an unanchorable relative path must fail closed when path lists exist, got %q", rel.Action)
+	}
+}
+
 // TestReadExclusionsInactiveWhenDisabled verifies a disabled policy filters
 // nothing — ReadExclusions/ReadExclusionGlobs are inert under ModeDisabled even
 // when DenyRead is configured.

--- a/internal/sandbox/pathlists_test.go
+++ b/internal/sandbox/pathlists_test.go
@@ -1,0 +1,315 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolvedTempDir returns a symlink-resolved temp dir so paths built under it
+// compare equal to the EvalSymlinks-normalized forms the path lists produce
+// (macOS /var -> /private/var would otherwise diverge).
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(tempdir): %v", err)
+	}
+	return resolved
+}
+
+func mkdir(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", path, err)
+	}
+	return path
+}
+
+func TestReadDenyAllowPrecedence(t *testing.T) {
+	ws := resolvedTempDir(t)
+	mkdir(t, filepath.Join(ws, "src"))
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+	public := mkdir(t, filepath.Join(ws, "secret", "public"))
+
+	cases := []struct {
+		name       string
+		policy     Policy
+		path       string
+		wantDenied bool
+	}{
+		{
+			name:       "no lists: nothing denied",
+			policy:     Policy{},
+			path:       filepath.Join(secret, "data"),
+			wantDenied: false,
+		},
+		{
+			name:       "denyread blocks subtree",
+			policy:     Policy{DenyRead: []string{secret}},
+			path:       filepath.Join(secret, "data"),
+			wantDenied: true,
+		},
+		{
+			name:       "denyread does not touch siblings",
+			policy:     Policy{DenyRead: []string{secret}},
+			path:       filepath.Join(ws, "src", "main.go"),
+			wantDenied: false,
+		},
+		{
+			name:       "more-specific allowread re-includes",
+			policy:     Policy{DenyRead: []string{secret}, AllowRead: []string{public}},
+			path:       filepath.Join(public, "ok.txt"),
+			wantDenied: false,
+		},
+		{
+			name:       "allowread only re-includes its own subtree",
+			policy:     Policy{DenyRead: []string{secret}, AllowRead: []string{public}},
+			path:       filepath.Join(secret, "other.txt"),
+			wantDenied: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := readDenied(tc.policy, ws, tc.path); got != tc.wantDenied {
+				t.Fatalf("readDenied(%q) = %v, want %v", tc.path, got, tc.wantDenied)
+			}
+		})
+	}
+}
+
+func TestWritePrecedenceMatrix(t *testing.T) {
+	ws := resolvedTempDir(t)
+	mkdir(t, filepath.Join(ws, "src"))
+	wsSecret := mkdir(t, filepath.Join(ws, "secret"))
+	ext := resolvedTempDir(t)
+	mkdir(t, filepath.Join(ext, "build"))
+	extProtected := mkdir(t, filepath.Join(ext, "build", "protected"))
+	outside := resolvedTempDir(t) // never allowed
+
+	scope, err := NewScope(ws, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		policy    Policy
+		path      string
+		wantAllow bool
+	}{
+		{
+			name:      "workspace path writable by default",
+			policy:    Policy{},
+			path:      filepath.Join(ws, "src", "main.go"),
+			wantAllow: true,
+		},
+		{
+			name:      "outside path denied by default",
+			policy:    Policy{},
+			path:      filepath.Join(outside, "x"),
+			wantAllow: false,
+		},
+		{
+			name:      "allowwrite extends to external root",
+			policy:    Policy{AllowWrite: []string{filepath.Join(ext, "build")}},
+			path:      filepath.Join(ext, "build", "out.o"),
+			wantAllow: true,
+		},
+		{
+			name:      "denywrite wins over workspace",
+			policy:    Policy{DenyWrite: []string{wsSecret}},
+			path:      filepath.Join(wsSecret, "creds"),
+			wantAllow: false,
+		},
+		{
+			name:      "denywrite wins over allowwrite",
+			policy:    Policy{AllowWrite: []string{filepath.Join(ext, "build")}, DenyWrite: []string{extProtected}},
+			path:      filepath.Join(extProtected, "x"),
+			wantAllow: false,
+		},
+		{
+			name:      "allowwrite does not allow unlisted external path",
+			policy:    Policy{AllowWrite: []string{filepath.Join(ext, "build")}},
+			path:      filepath.Join(outside, "x"),
+			wantAllow: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			violation := validateWritePath(scope, tc.policy, ws, tc.path)
+			gotAllow := violation == nil
+			if gotAllow != tc.wantAllow {
+				t.Fatalf("validateWritePath(%q) allow=%v (violation=%v), want allow=%v", tc.path, gotAllow, violation, tc.wantAllow)
+			}
+		})
+	}
+}
+
+func TestReadExclusionGlobs(t *testing.T) {
+	ws := resolvedTempDir(t)
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+	scope, err := NewScope(ws, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+
+	// Empty DenyRead → no globs (default behavior unchanged).
+	if globs := ReadExclusionGlobs(Policy{}, scope); globs != nil {
+		t.Fatalf("empty DenyRead must yield no globs, got %v", globs)
+	}
+
+	// DenyRead inside the workspace → ripgrep exclusion globs for the rel path.
+	got := strings.Join(ReadExclusionGlobs(Policy{DenyRead: []string{secret}}, scope), " ")
+	want := "--glob !secret --glob !secret/**"
+	if got != want {
+		t.Fatalf("ReadExclusionGlobs = %q, want %q", got, want)
+	}
+
+	// DenyRead OUTSIDE the workspace → skipped (a rooted search never reaches it).
+	outside := resolvedTempDir(t)
+	if globs := ReadExclusionGlobs(Policy{DenyRead: []string{outside}}, scope); globs != nil {
+		t.Fatalf("out-of-workspace DenyRead must yield no globs, got %v", globs)
+	}
+}
+
+// TestReadDirExcludedDescendsForNestedAllow verifies a read-denied dir is NOT
+// skipped wholesale when it contains a nested AllowRead root, so the walk can
+// still reach the re-included subtree.
+func TestReadDirExcludedDescendsForNestedAllow(t *testing.T) {
+	ws := resolvedTempDir(t)
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+	public := mkdir(t, filepath.Join(ws, "secret", "public"))
+
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: ws,
+		Policy:        Policy{Mode: ModeEnforce, EnforceWorkspace: true, DenyRead: []string{secret}, AllowRead: []string{public}},
+	})
+	// The denied dir must be descended (nested allow), but the denied dir's own
+	// files are still excluded per-file.
+	if engine.ReadDirExcluded(secret) {
+		t.Fatalf("a denied dir with a nested AllowRead must not be skipped wholesale")
+	}
+	if !engine.ReadPathExcluded(filepath.Join(secret, "creds")) {
+		t.Fatalf("a denied file outside the re-included subtree must be excluded")
+	}
+	if engine.ReadPathExcluded(filepath.Join(public, "ok")) {
+		t.Fatalf("a re-included AllowRead file must not be excluded")
+	}
+}
+
+// TestEvaluateAppliesReadDeny verifies the lists are wired into Evaluate: a read
+// under DenyRead is denied, while a sibling read is not.
+func TestEvaluateAppliesReadDeny(t *testing.T) {
+	ws := resolvedTempDir(t)
+	mkdir(t, filepath.Join(ws, "src"))
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: ws,
+		Policy: Policy{
+			Mode:             ModeEnforce,
+			EnforceWorkspace: true,
+			MaxAutonomy:      AutonomyHigh,
+			DenyRead:         []string{secret},
+		},
+	})
+
+	denied := engine.Evaluate(context.Background(), Request{
+		ToolName:   "read_file",
+		SideEffect: SideEffectRead,
+		Args:       map[string]any{"path": filepath.Join(secret, "creds.txt")},
+	})
+	if denied.Action != ActionDeny {
+		t.Fatalf("read under DenyRead = %q, want deny", denied.Action)
+	}
+
+	ok := engine.Evaluate(context.Background(), Request{
+		ToolName:   "read_file",
+		SideEffect: SideEffectRead,
+		Args:       map[string]any{"path": filepath.Join(ws, "src", "main.go")},
+	})
+	if ok.Action == ActionDeny {
+		t.Fatalf("read of a non-denied sibling must not be denied, got %q (%s)", ok.Action, ok.ErrorString())
+	}
+}
+
+// TestEvaluateAppliesWriteAllow verifies an external write is denied by default
+// but permitted once the path is on AllowWrite.
+func TestEvaluateAppliesWriteAllow(t *testing.T) {
+	ws := resolvedTempDir(t)
+	ext := resolvedTempDir(t)
+	build := mkdir(t, filepath.Join(ext, "build"))
+
+	base := Policy{Mode: ModeEnforce, EnforceWorkspace: true, MaxAutonomy: AutonomyHigh}
+	target := filepath.Join(build, "out.o")
+
+	denyEngine := NewEngine(EngineOptions{WorkspaceRoot: ws, Policy: base})
+	denied := denyEngine.Evaluate(context.Background(), Request{
+		ToolName:   "write_file",
+		SideEffect: SideEffectWrite,
+		Args:       map[string]any{"path": target},
+	})
+	if denied.Action != ActionDeny {
+		t.Fatalf("external write without AllowWrite = %q, want deny", denied.Action)
+	}
+
+	allowPolicy := base
+	allowPolicy.AllowWrite = []string{build}
+	allowEngine := NewEngine(EngineOptions{WorkspaceRoot: ws, Policy: allowPolicy})
+	allowed := allowEngine.Evaluate(context.Background(), Request{
+		ToolName:   "write_file",
+		SideEffect: SideEffectWrite,
+		Args:       map[string]any{"path": target},
+	})
+	if allowed.Action == ActionDeny {
+		t.Fatalf("external write under AllowWrite must not be denied, got deny: %s", allowed.ErrorString())
+	}
+}
+
+// TestWriteRootsReflectAllowWrite verifies AllowWrite roots flow into the OS
+// backend write binds (so a sandboxed shell can write there).
+func TestWriteRootsReflectAllowWrite(t *testing.T) {
+	ws := resolvedTempDir(t)
+	ext := resolvedTempDir(t)
+	build := mkdir(t, filepath.Join(ext, "build"))
+
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: ws,
+		Policy:        Policy{Mode: ModeEnforce, EnforceWorkspace: true, AllowWrite: []string{build}},
+	})
+	roots := engine.writeRoots(ws)
+	found := false
+	for _, r := range roots {
+		if r == build {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("writeRoots must include AllowWrite root %q, got %v", build, roots)
+	}
+}
+
+// TestSandboxExecProfileEmitsDenyWriteRule verifies a DenyWrite directory becomes
+// an explicit seatbelt deny clause AFTER the write-allow (last-match-wins).
+func TestSandboxExecProfileEmitsDenyWriteRule(t *testing.T) {
+	ws := resolvedTempDir(t)
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+
+	policy := Policy{Mode: ModeEnforce, EnforceWorkspace: true, DenyWrite: []string{secret}}
+	profile := sandboxExecProfile([]string{ws}, policy, "", "", "")
+
+	wantDeny := `(deny file-write* (subpath "` + secret + `"))`
+	if !strings.Contains(profile, wantDeny) {
+		t.Fatalf("profile missing DenyWrite rule %q:\n%s", wantDeny, profile)
+	}
+	// The deny clause must appear AFTER the write-allow so seatbelt's
+	// last-match-wins lets it override the bind.
+	allowIdx := strings.Index(profile, "(allow file-write*")
+	denyIdx := strings.Index(profile, wantDeny)
+	if allowIdx < 0 || denyIdx < 0 || denyIdx < allowIdx {
+		t.Fatalf("DenyWrite rule must follow the write-allow (allow@%d deny@%d):\n%s", allowIdx, denyIdx, profile)
+	}
+}

--- a/internal/sandbox/pathlists_test.go
+++ b/internal/sandbox/pathlists_test.go
@@ -139,7 +139,8 @@ func TestWritePrecedenceMatrix(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			violation := validateWritePath(scope, tc.policy, ws, tc.path)
+			// This matrix exercises the workspace-enforced write precedence.
+			violation := validateWritePath(scope, tc.policy, true, ws, tc.path)
 			gotAllow := violation == nil
 			if gotAllow != tc.wantAllow {
 				t.Fatalf("validateWritePath(%q) allow=%v (violation=%v), want allow=%v", tc.path, gotAllow, violation, tc.wantAllow)
@@ -224,6 +225,52 @@ func TestDirExcludedResolvesSymlinkPrefix(t *testing.T) {
 	// subtree once the prefix is resolved, so it must not be skipped wholesale.
 	if rx.DirExcluded(filepath.Join(link, "secret")) {
 		t.Fatalf("DirExcluded must resolve the symlink prefix and detect the nested AllowRead (must not skip)")
+	}
+}
+
+// TestPathListsApplyWithoutWorkspaceEnforcement verifies the explicit path lists
+// (DenyWrite/DenyRead) are honored even when EnforceWorkspace is off, while the
+// workspace boundary itself is not enforced in that mode.
+func TestPathListsApplyWithoutWorkspaceEnforcement(t *testing.T) {
+	ws := resolvedTempDir(t)
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+	outside := resolvedTempDir(t)
+	scope, err := NewScope(ws, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+
+	// DenyWrite still blocks even with workspace enforcement off.
+	denyPolicy := Policy{DenyWrite: []string{secret}}
+	if v := validateWritePath(scope, denyPolicy, false, ws, filepath.Join(secret, "creds")); v == nil {
+		t.Fatal("DenyWrite must block even when EnforceWorkspace is off")
+	}
+	// With enforcement off and no DenyWrite match, an out-of-workspace write is
+	// NOT blocked (the workspace boundary is intentionally not applied).
+	if v := validateWritePath(scope, denyPolicy, false, ws, filepath.Join(outside, "x")); v != nil {
+		t.Fatalf("with EnforceWorkspace off, a non-denied path must be allowed, got %v", v)
+	}
+	// DenyRead still blocks reads even with workspace enforcement off.
+	if v := validatePathWithPolicy(scope, Policy{DenyRead: []string{secret}}, SideEffectRead, false, ws, filepath.Join(secret, "x")); v == nil {
+		t.Fatal("DenyRead must block reads even when EnforceWorkspace is off")
+	}
+}
+
+// TestReadExclusionsInactiveWhenDisabled verifies a disabled policy filters
+// nothing — ReadExclusions/ReadExclusionGlobs are inert under ModeDisabled even
+// when DenyRead is configured.
+func TestReadExclusionsInactiveWhenDisabled(t *testing.T) {
+	ws := resolvedTempDir(t)
+	secret := mkdir(t, filepath.Join(ws, "secret"))
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: ws,
+		Policy:        Policy{Mode: ModeDisabled, DenyRead: []string{secret}},
+	})
+	if rx := engine.ReadExclusions(); rx.Active() {
+		t.Fatal("ReadExclusions must be inactive under a disabled policy")
+	}
+	if globs := engine.ReadExclusionGlobs(); globs != nil {
+		t.Fatalf("ReadExclusionGlobs must be empty under a disabled policy, got %v", globs)
 	}
 }
 

--- a/internal/sandbox/pathlists_test.go
+++ b/internal/sandbox/pathlists_test.go
@@ -189,13 +189,14 @@ func TestReadDirExcludedDescendsForNestedAllow(t *testing.T) {
 	})
 	// The denied dir must be descended (nested allow), but the denied dir's own
 	// files are still excluded per-file.
-	if engine.ReadDirExcluded(secret) {
+	rx := engine.ReadExclusions()
+	if rx.DirExcluded(secret) {
 		t.Fatalf("a denied dir with a nested AllowRead must not be skipped wholesale")
 	}
-	if !engine.ReadPathExcluded(filepath.Join(secret, "creds")) {
+	if !rx.PathExcluded(filepath.Join(secret, "creds")) {
 		t.Fatalf("a denied file outside the re-included subtree must be excluded")
 	}
-	if engine.ReadPathExcluded(filepath.Join(public, "ok")) {
+	if rx.PathExcluded(filepath.Join(public, "ok")) {
 		t.Fatalf("a re-included AllowRead file must not be excluded")
 	}
 }

--- a/internal/sandbox/pathlists_test.go
+++ b/internal/sandbox/pathlists_test.go
@@ -201,6 +201,32 @@ func TestReadDirExcludedDescendsForNestedAllow(t *testing.T) {
 	}
 }
 
+// TestDirExcludedResolvesSymlinkPrefix verifies DirExcluded resolves a symlink
+// in the path prefix before checking for a nested AllowRead root, so a denied dir
+// reached through a symlink is NOT skipped wholesale when it contains a
+// re-included subtree (the resolved allowRoots would otherwise never match).
+func TestDirExcludedResolvesSymlinkPrefix(t *testing.T) {
+	ws := resolvedTempDir(t)
+	real := mkdir(t, filepath.Join(ws, "real"))
+	secret := mkdir(t, filepath.Join(real, "secret"))
+	public := mkdir(t, filepath.Join(secret, "public"))
+	link := filepath.Join(ws, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: ws,
+		Policy:        Policy{Mode: ModeEnforce, EnforceWorkspace: true, DenyRead: []string{secret}, AllowRead: []string{public}},
+	})
+	rx := engine.ReadExclusions()
+	// secret reached THROUGH the symlink still contains the re-included AllowRead
+	// subtree once the prefix is resolved, so it must not be skipped wholesale.
+	if rx.DirExcluded(filepath.Join(link, "secret")) {
+		t.Fatalf("DirExcluded must resolve the symlink prefix and detect the nested AllowRead (must not skip)")
+	}
+}
+
 // TestEvaluateAppliesReadDeny verifies the lists are wired into Evaluate: a read
 // under DenyRead is denied, while a sibling read is not.
 func TestEvaluateAppliesReadDeny(t *testing.T) {
@@ -302,7 +328,9 @@ func TestSandboxExecProfileEmitsDenyWriteRule(t *testing.T) {
 	policy := Policy{Mode: ModeEnforce, EnforceWorkspace: true, DenyWrite: []string{secret}}
 	profile := sandboxExecProfile([]string{ws}, policy, "", "", "")
 
-	wantDeny := `(deny file-write* (subpath "` + secret + `"))`
+	// The path is escaped the same way the profile escapes it (e.g. Windows
+	// backslashes are doubled), so the assertion holds on every platform.
+	wantDeny := `(deny file-write* (subpath "` + sandboxProfileString(secret) + `"))`
 	if !strings.Contains(profile, wantDeny) {
 		t.Fatalf("profile missing DenyWrite rule %q:\n%s", wantDeny, profile)
 	}

--- a/internal/sandbox/reentrancy_test.go
+++ b/internal/sandbox/reentrancy_test.go
@@ -1,0 +1,66 @@
+package sandbox
+
+import "testing"
+
+func TestIsAlreadySandboxed(t *testing.T) {
+	t.Setenv(EnvSandboxed, "")
+	if IsAlreadySandboxed() {
+		t.Fatalf("IsAlreadySandboxed must be false when %s is unset", EnvSandboxed)
+	}
+	t.Setenv(EnvSandboxed, "1")
+	if !IsAlreadySandboxed() {
+		t.Fatalf("IsAlreadySandboxed must be true when %s=1", EnvSandboxed)
+	}
+	t.Setenv(EnvSandboxed, "0")
+	if IsAlreadySandboxed() {
+		t.Fatalf("IsAlreadySandboxed must be false when %s=0", EnvSandboxed)
+	}
+}
+
+func TestSandboxEnvironmentMarksSandboxed(t *testing.T) {
+	env := sandboxEnvironment(DefaultPolicy(), BackendBubblewrap, "/home/agent")
+	want := EnvSandboxed + "=1"
+	for _, entry := range env {
+		if entry == want {
+			return
+		}
+	}
+	t.Fatalf("sandboxEnvironment must set %s so a wrapped command is detectable; got %#v", want, env)
+}
+
+func TestBuildCommandPlanWrapsWhenNotAlreadySandboxed(t *testing.T) {
+	t.Setenv(EnvSandboxed, "") // ensure we are NOT already inside a sandbox
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        DefaultPolicy(),
+		Backend:       Backend{Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+	})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	if !plan.Wrapped || plan.Name != "/usr/bin/bwrap" {
+		t.Fatalf("expected a wrapped bubblewrap plan, got wrapped=%v name=%q", plan.Wrapped, plan.Name)
+	}
+}
+
+func TestBuildCommandPlanReEntrancyGuardReturnsPassThrough(t *testing.T) {
+	t.Setenv(EnvSandboxed, "1") // simulate running inside an already-sandboxed process
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: root,
+		Policy:        DefaultPolicy(),
+		Backend:       Backend{Name: BackendBubblewrap, Available: true, Executable: "/usr/bin/bwrap"},
+	})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	if plan.Wrapped {
+		t.Fatalf("re-entrancy guard must return an unwrapped pass-through plan, got wrapped=%v name=%q args=%v", plan.Wrapped, plan.Name, plan.Args)
+	}
+	if plan.Name != "/bin/sh" {
+		t.Fatalf("pass-through plan must run the command directly, got name=%q", plan.Name)
+	}
+}

--- a/internal/sandbox/reentrancy_test.go
+++ b/internal/sandbox/reentrancy_test.go
@@ -29,13 +29,22 @@ func TestIsAlreadySandboxed(t *testing.T) {
 
 func TestSandboxEnvironmentMarksSandboxed(t *testing.T) {
 	env := sandboxEnvironment(DefaultPolicy(), BackendBubblewrap, "/home/agent")
-	want := EnvSandboxed + "=1"
+	// Both correlated markers must be set: IsAlreadySandboxed requires BOTH, so a
+	// regression that drops either one would silently break re-entrancy detection.
+	wantSandboxed := EnvSandboxed + "=1"
+	wantBackend := EnvSandboxBackend + "=" + string(BackendBubblewrap)
+	var gotSandboxed, gotBackend bool
 	for _, entry := range env {
-		if entry == want {
-			return
+		switch entry {
+		case wantSandboxed:
+			gotSandboxed = true
+		case wantBackend:
+			gotBackend = true
 		}
 	}
-	t.Fatalf("sandboxEnvironment must set %s so a wrapped command is detectable; got %#v", want, env)
+	if !gotSandboxed || !gotBackend {
+		t.Fatalf("sandboxEnvironment must set %q and %q so a wrapped command is detectable; got %#v", wantSandboxed, wantBackend, env)
+	}
 }
 
 func TestBuildCommandPlanWrapsWhenNotAlreadySandboxed(t *testing.T) {

--- a/internal/sandbox/reentrancy_test.go
+++ b/internal/sandbox/reentrancy_test.go
@@ -3,13 +3,23 @@ package sandbox
 import "testing"
 
 func TestIsAlreadySandboxed(t *testing.T) {
+	// A lone ZERO_SANDBOXED=1 (no corroborating backend marker) must NOT count as
+	// sandboxed — stronger provenance than a single ambient flag.
+	t.Setenv(EnvSandboxBackend, "")
+	t.Setenv(EnvSandboxed, "1")
+	if IsAlreadySandboxed() {
+		t.Fatalf("IsAlreadySandboxed must be false when only %s=1 is set without %s", EnvSandboxed, EnvSandboxBackend)
+	}
+	// The backend marker alone (no ZERO_SANDBOXED=1) must not count either.
+	t.Setenv(EnvSandboxBackend, string(BackendBubblewrap))
 	t.Setenv(EnvSandboxed, "")
 	if IsAlreadySandboxed() {
-		t.Fatalf("IsAlreadySandboxed must be false when %s is unset", EnvSandboxed)
+		t.Fatalf("IsAlreadySandboxed must be false when only %s is set", EnvSandboxBackend)
 	}
+	// Both correlated markers present (as sandboxEnvironment sets them) → sandboxed.
 	t.Setenv(EnvSandboxed, "1")
 	if !IsAlreadySandboxed() {
-		t.Fatalf("IsAlreadySandboxed must be true when %s=1", EnvSandboxed)
+		t.Fatalf("IsAlreadySandboxed must be true when both %s=1 and %s are set", EnvSandboxed, EnvSandboxBackend)
 	}
 	t.Setenv(EnvSandboxed, "0")
 	if IsAlreadySandboxed() {
@@ -29,7 +39,9 @@ func TestSandboxEnvironmentMarksSandboxed(t *testing.T) {
 }
 
 func TestBuildCommandPlanWrapsWhenNotAlreadySandboxed(t *testing.T) {
-	t.Setenv(EnvSandboxed, "") // ensure we are NOT already inside a sandbox
+	// Ensure neither re-entrancy marker is set so we are NOT seen as sandboxed.
+	t.Setenv(EnvSandboxed, "")
+	t.Setenv(EnvSandboxBackend, "")
 	root := t.TempDir()
 	engine := NewEngine(EngineOptions{
 		WorkspaceRoot: root,
@@ -46,7 +58,10 @@ func TestBuildCommandPlanWrapsWhenNotAlreadySandboxed(t *testing.T) {
 }
 
 func TestBuildCommandPlanReEntrancyGuardReturnsPassThrough(t *testing.T) {
-	t.Setenv(EnvSandboxed, "1") // simulate running inside an already-sandboxed process
+	// Simulate running inside an already-wrapped process: BOTH correlated markers
+	// that sandboxEnvironment sets together must be present for the guard to fire.
+	t.Setenv(EnvSandboxed, "1")
+	t.Setenv(EnvSandboxBackend, string(BackendBubblewrap))
 	root := t.TempDir()
 	engine := NewEngine(EngineOptions{
 		WorkspaceRoot: root,

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -99,6 +99,29 @@ func ProxyEnv(addr string) []string {
 	}
 }
 
+// ProxyEnvWithSocks is the SOCKS-aware form of ProxyEnv built ON TOP of it:
+// HTTP_PROXY/HTTPS_PROXY stay on the HTTP listener (httpAddr) for HTTP(S)-aware
+// clients, while ALL_PROXY/all_proxy are re-pointed at the SOCKS5 front-end
+// (socksAddr) so a client that honors ALL_PROXY tunnels arbitrary TCP through the
+// same allow/deny gate. When socksAddr is empty it returns exactly ProxyEnv's
+// output, so the SOCKS upgrade is purely additive and never weakens the default.
+func ProxyEnvWithSocks(httpAddr, socksAddr string) []string {
+	env := ProxyEnv(httpAddr)
+	if socksAddr == "" {
+		return env
+	}
+	socksURL := "socks5://" + socksAddr
+	for i, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "ALL_PROXY="):
+			env[i] = "ALL_PROXY=" + socksURL
+		case strings.HasPrefix(kv, "all_proxy="):
+			env[i] = "all_proxy=" + socksURL
+		}
+	}
+	return env
+}
+
 func (engine *Engine) CommandContext(ctx context.Context, spec CommandSpec) (*exec.Cmd, CommandPlan, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -118,10 +141,20 @@ func (engine *Engine) CommandContext(ctx context.Context, spec CommandSpec) (*ex
 // only applies to engines built without a workspace root (NewEngine always
 // builds a scope otherwise); it is kept as defense in depth.
 func (engine *Engine) writeRoots(workspaceRoot string) []string {
+	var roots []string
 	if engine.scope != nil {
-		return engine.scope.Roots()
+		roots = engine.scope.Roots()
+	} else {
+		roots = []string{workspaceRoot}
 	}
-	return []string{workspaceRoot}
+	// Reflect the policy's AllowWrite roots in the OS backend write binds so a
+	// sandboxed shell command may write where the policy grants writes. DenyWrite
+	// is enforced at the policy gate, and on sandbox-exec additionally as an
+	// explicit deny rule (see sandboxExecProfile).
+	if extra := resolveWriteRootPaths(engine.policy.AllowWrite); len(extra) > 0 {
+		roots = dedupeStrings(append(roots, extra...))
+	}
+	return roots
 }
 
 func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
@@ -145,6 +178,14 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 	backend := engine.backend
 	if backend.Name == "" {
 		backend = Backend{Name: BackendPolicyOnly, Message: "policy-only fallback: sandbox backend was not selected"}
+	}
+	// Re-entrancy guard: a command spawned by a process we already wrapped
+	// (ZERO_SANDBOXED=1 in its env) must not be wrapped again — nested bwrap /
+	// sandbox-exec fails and a second egress proxy would be redundant. Return a
+	// pass-through plan. Mirrors the already-sandboxed guard used by comparable
+	// executor sandboxes.
+	if IsAlreadySandboxed() {
+		return directCommandPlan(spec, backend, policy, workspaceRoot), nil
 	}
 	if policy.Mode == ModeDisabled {
 		return directCommandPlan(spec, backend, policy, workspaceRoot), nil
@@ -177,8 +218,12 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 // cleanup that shuts it down. A nil *scopedEgress means scoped egress is not in
 // effect for this command (the network mode is allow or deny-equivalent).
 type scopedEgress struct {
-	addr    string
-	cleanup func()
+	addr string
+	// socksAddr is the loopback address of the proxy's SOCKS5 front-end, used to
+	// set ALL_PROXY=socks5://<socksAddr>. Empty when the proxy exposes no SOCKS
+	// listener, in which case ALL_PROXY falls back to the HTTP proxy.
+	socksAddr string
+	cleanup   func()
 }
 
 // startScopedEgress starts the local filtering proxy when the policy's effective
@@ -202,7 +247,7 @@ func startScopedEgress(policy Policy, backend Backend) (*scopedEgress, error) {
 	if err != nil {
 		return nil, fmt.Errorf("scoped egress unavailable, denying network: %w", err)
 	}
-	return &scopedEgress{addr: proxy.Addr(), cleanup: func() { _ = proxy.Close() }}, nil
+	return &scopedEgress{addr: proxy.Addr(), socksAddr: proxy.SocksAddr(), cleanup: func() { _ = proxy.Close() }}, nil
 }
 
 func directCommandPlan(spec CommandSpec, backend Backend, policy Policy, workspaceRoot string) CommandPlan {
@@ -374,21 +419,24 @@ func findSeccompHelper() string {
 }
 
 func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, writeRoots []string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {
-	var proxyPort string
+	var proxyPort, socksPort string
 	if egress != nil {
 		if _, port, err := net.SplitHostPort(egress.addr); err == nil {
 			proxyPort = port
+		}
+		if _, port, err := net.SplitHostPort(egress.socksAddr); err == nil {
+			socksPort = port
 		}
 	}
 	denialTag := ""
 	if policy.MonitorDenials {
 		denialTag = nextSandboxDenialTag()
 	}
-	args := []string{"-p", sandboxExecProfile(writeRoots, policy, proxyPort, denialTag), spec.Name}
+	args := []string{"-p", sandboxExecProfile(writeRoots, policy, proxyPort, socksPort, denialTag), spec.Name}
 	args = append(args, spec.Args...)
 	env := sandboxEnvironment(policy, BackendSandboxExec, workspaceRoot)
 	if egress != nil {
-		env = append(env, ProxyEnv(egress.addr)...)
+		env = append(env, ProxyEnvWithSocks(egress.addr, egress.socksAddr)...)
 	}
 	plan := CommandPlan{
 		Backend:       backend,
@@ -428,6 +476,7 @@ func sandboxEnvironment(policy Policy, backend BackendName, home string) []strin
 		"TERM=" + firstEnv("TERM", "dumb"),
 		"ZERO_SANDBOX_BACKEND=" + string(backend),
 		"ZERO_SANDBOX_NETWORK=" + string(policy.Network),
+		EnvSandboxed + "=1",
 	}
 	if runtime.GOOS == "windows" {
 		env = append(env, "COMSPEC="+firstEnv("COMSPEC", "cmd.exe"))
@@ -540,8 +589,8 @@ func sandboxMachLookupRule() string {
 	return "(allow mach-lookup\n  " + strings.Join(filters, "\n  ") + ")"
 }
 
-func sandboxExecProfile(writeRoots []string, policy Policy, proxyPort string, denialTag string) string {
-	networkRule := networkRuleFor(policy, proxyPort)
+func sandboxExecProfile(writeRoots []string, policy Policy, proxyPort string, socksPort string, denialTag string) string {
+	networkRule := networkRuleFor(policy, proxyPort, socksPort)
 	writeRule := "(allow file-write*)"
 	if policy.EnforceWorkspace {
 		// The granted write roots are the only writable *project* locations. Temp
@@ -566,7 +615,7 @@ func sandboxExecProfile(writeRoots []string, policy Policy, proxyPort string, de
 		// filters `log stream` for this exact (per-plan) tag.
 		denyDefault = `(deny default (with message "` + sandboxProfileString(denialTag) + `"))`
 	}
-	return strings.Join([]string{
+	rules := []string{
 		"(version 1)",
 		denyDefault,
 		"(allow process*)",
@@ -579,27 +628,67 @@ func sandboxExecProfile(writeRoots []string, policy Policy, proxyPort string, de
 		sandboxMachLookupRule(),
 		"(allow file-read*)",
 		writeRule,
-		networkRule,
-	}, "\n")
+	}
+	// DenyWrite entries are emitted AFTER the write allow so seatbelt's
+	// last-match-wins makes them override the workspace/AllowWrite binds — so
+	// "DenyWrite wins" holds for shell commands too, not just the policy gate.
+	rules = append(rules, denyWriteRules(policy)...)
+	rules = append(rules, networkRule)
+	return strings.Join(rules, "\n")
+}
+
+// denyWriteRules returns seatbelt deny clauses for the policy's resolved
+// DenyWrite paths: a (subpath ...) clause for a directory, a (literal ...) clause
+// for a single file. Empty when DenyWrite is unset.
+func denyWriteRules(policy Policy) []string {
+	resolved := resolvePolicyPaths(policy.DenyWrite)
+	if len(resolved) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(resolved))
+	for _, path := range resolved {
+		filter := `(subpath "` + sandboxProfileString(path) + `")`
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			filter = `(literal "` + sandboxProfileString(path) + `")`
+		}
+		out = append(out, "(deny file-write* "+filter+")")
+	}
+	return out
 }
 
 // networkRuleFor returns the seatbelt network clause for a policy. allow opens
 // all network; deny (and an empty-allowlist scoped policy, which effectiveNetwork
 // collapses to deny) blocks all network; scoped denies general network but
-// permits only outbound to the local proxy port on localhost, so traffic must
-// flow through the filtering proxy. A scoped policy with no resolvable proxy port
-// falls back to a full deny (fail closed).
-func networkRuleFor(policy Policy, proxyPort string) string {
+// permits only outbound to the local proxy ports on localhost, so traffic must
+// flow through the filtering proxy. Both the HTTP proxy port and the SOCKS5
+// front-end port are allowed (a sandboxed process configured with
+// ALL_PROXY=socks5://... must reach the SOCKS listener). A scoped policy with no
+// resolvable proxy port falls back to a full deny (fail closed).
+func networkRuleFor(policy Policy, proxyPort string, socksPort string) string {
 	switch effectiveNetwork(policy) {
 	case NetworkAllow:
 		return "(allow network*)"
 	case NetworkScoped:
-		if strings.TrimSpace(proxyPort) == "" {
+		rules := []string{"(deny network*)"}
+		seen := map[string]struct{}{}
+		// Deny by default, then allow only outbound to each distinct proxy port on
+		// loopback. Duplicate/empty ports are skipped so the clause stays minimal.
+		for _, port := range []string{proxyPort, socksPort} {
+			port = strings.TrimSpace(port)
+			if port == "" {
+				continue
+			}
+			if _, ok := seen[port]; ok {
+				continue
+			}
+			seen[port] = struct{}{}
+			rules = append(rules, `(allow network-outbound (remote ip "localhost:`+sandboxProfileString(port)+`"))`)
+		}
+		if len(rules) == 1 {
+			// No resolvable proxy port: fail closed.
 			return "(deny network*)"
 		}
-		// Deny by default, then allow only outbound to the proxy on loopback.
-		return "(deny network*)\n" +
-			`(allow network-outbound (remote ip "localhost:` + sandboxProfileString(proxyPort) + `"))`
+		return strings.Join(rules, "\n")
 	default:
 		return "(deny network*)"
 	}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -179,11 +179,12 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 	if backend.Name == "" {
 		backend = Backend{Name: BackendPolicyOnly, Message: "policy-only fallback: sandbox backend was not selected"}
 	}
-	// Re-entrancy guard: a command spawned by a process we already wrapped
-	// (ZERO_SANDBOXED=1 in its env) must not be wrapped again — nested bwrap /
-	// sandbox-exec fails and a second egress proxy would be redundant. Return a
-	// pass-through plan. Mirrors the already-sandboxed guard used by comparable
-	// executor sandboxes.
+	// Re-entrancy guard: a command spawned by a process we already wrapped (both
+	// ZERO_SANDBOXED=1 and ZERO_SANDBOX_BACKEND set in its env — see
+	// IsAlreadySandboxed) must not be wrapped again — nested bwrap / sandbox-exec
+	// fails and a second egress proxy would be redundant. Return a pass-through
+	// plan. Mirrors the already-sandboxed guard used by comparable executor
+	// sandboxes.
 	if IsAlreadySandboxed() {
 		return directCommandPlan(spec, backend, policy, workspaceRoot), nil
 	}
@@ -474,7 +475,7 @@ func sandboxEnvironment(policy Policy, backend BackendName, home string) []strin
 		"HOME=" + home,
 		"PATH=" + firstEnv("PATH", defaultPath()),
 		"TERM=" + firstEnv("TERM", "dumb"),
-		"ZERO_SANDBOX_BACKEND=" + string(backend),
+		EnvSandboxBackend + "=" + string(backend),
 		"ZERO_SANDBOX_NETWORK=" + string(policy.Network),
 		EnvSandboxed + "=1",
 	}

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -233,7 +233,7 @@ func resolvedTestPath(t *testing.T, path string) string {
 }
 
 func TestSandboxExecProfileIncludesExtraWriteRoots(t *testing.T) {
-	profile := sandboxExecProfile([]string{"/ws", "/extra root"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "", "")
+	profile := sandboxExecProfile([]string{"/ws", "/extra root"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "", "", "")
 	if !strings.Contains(profile, "(allow file-write*") {
 		t.Fatalf("profile missing file-write rule:\n%s", profile)
 	}
@@ -251,7 +251,7 @@ func TestSandboxExecProfileIncludesExtraWriteRoots(t *testing.T) {
 }
 
 func TestSandboxExecProfileTagsDenialsWhenMonitoring(t *testing.T) {
-	off := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "", "")
+	off := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "", "", "")
 	if strings.Contains(off, "with message") {
 		t.Fatalf("denials must not be tagged when monitoring is off:\n%s", off)
 	}
@@ -259,7 +259,7 @@ func TestSandboxExecProfileTagsDenialsWhenMonitoring(t *testing.T) {
 		t.Fatalf("profile missing the plain default-deny:\n%s", off)
 	}
 
-	on := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true, MonitorDenials: true}, "", "run-tag-123")
+	on := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true, MonitorDenials: true}, "", "", "run-tag-123")
 	if !strings.Contains(on, `(deny default (with message "run-tag-123"))`) {
 		t.Fatalf("denials must be tagged when monitoring is on:\n%s", on)
 	}
@@ -291,7 +291,7 @@ func TestSandboxExecCommandPlanUsesUniquePerPlanDenialTag(t *testing.T) {
 }
 
 func TestSandboxExecProfileGrantsSignalAndMachLookup(t *testing.T) {
-	profile := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "", "")
+	profile := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "", "", "")
 
 	// Signalling own process group lets a sandboxed script kill the children it
 	// spawns; without it seatbelt denies kill() with "Operation not permitted".
@@ -463,5 +463,49 @@ func TestProxyEnv(t *testing.T) {
 	// Loopback must bypass the proxy so the proxy itself is reachable directly.
 	if !strings.Contains(env["NO_PROXY"], "127.0.0.1") || !strings.Contains(env["no_proxy"], "127.0.0.1") {
 		t.Fatalf("ProxyEnv NO_PROXY must exclude loopback, got %q/%q", env["NO_PROXY"], env["no_proxy"])
+	}
+}
+
+func TestProxyEnvWithSocks(t *testing.T) {
+	env := map[string]string{}
+	for _, kv := range ProxyEnvWithSocks("127.0.0.1:8899", "127.0.0.1:1080") {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			env[kv[:i]] = kv[i+1:]
+		}
+	}
+	// HTTP_PROXY/HTTPS_PROXY stay on the HTTP listener...
+	const httpURL = "http://127.0.0.1:8899"
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		if env[key] != httpURL {
+			t.Fatalf("ProxyEnvWithSocks[%s] = %q, want %q", key, env[key], httpURL)
+		}
+	}
+	// ...while ALL_PROXY/all_proxy point at the SOCKS5 front-end.
+	const socksURL = "socks5://127.0.0.1:1080"
+	for _, key := range []string{"ALL_PROXY", "all_proxy"} {
+		if env[key] != socksURL {
+			t.Fatalf("ProxyEnvWithSocks[%s] = %q, want %q", key, env[key], socksURL)
+		}
+	}
+	if !strings.Contains(env["NO_PROXY"], "127.0.0.1") {
+		t.Fatalf("ProxyEnvWithSocks NO_PROXY must exclude loopback, got %q", env["NO_PROXY"])
+	}
+}
+
+// TestProxyEnvWithSocksEmptyFallsBackToHTTP verifies the SOCKS upgrade is purely
+// additive: with no SOCKS address, ALL_PROXY falls back to the HTTP proxy exactly
+// as the legacy ProxyEnv produced, never weakening the default.
+func TestProxyEnvWithSocksEmptyFallsBackToHTTP(t *testing.T) {
+	env := map[string]string{}
+	for _, kv := range ProxyEnvWithSocks("127.0.0.1:8899", "") {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			env[kv[:i]] = kv[i+1:]
+		}
+	}
+	const httpURL = "http://127.0.0.1:8899"
+	for _, key := range []string{"ALL_PROXY", "all_proxy"} {
+		if env[key] != httpURL {
+			t.Fatalf("ProxyEnvWithSocks(empty socks)[%s] = %q, want HTTP fallback %q", key, env[key], httpURL)
+		}
 	}
 }

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -12,6 +12,20 @@ import (
 // only an explicit truthy value enables it.
 const EnvAutoAllowBash = "ZERO_SANDBOX_AUTO_ALLOW_BASH"
 
+// EnvSandboxed marks a process that zero has already wrapped in a sandbox: every
+// wrapped command carries ZERO_SANDBOXED=1 in its environment. When such a
+// process spawns another command through the engine, the re-entrancy guard
+// returns a pass-through plan instead of double-wrapping it — nested bwrap /
+// sandbox-exec fails, and a second egress proxy would be redundant. Mirrors the
+// already-sandboxed guard used by comparable executor sandboxes. Unset by default.
+const EnvSandboxed = "ZERO_SANDBOXED"
+
+// IsAlreadySandboxed reports whether the current process is already running
+// inside a zero-created sandbox (EnvSandboxed == "1").
+func IsAlreadySandboxed() bool {
+	return os.Getenv(EnvSandboxed) == "1"
+}
+
 type SideEffect string
 type Permission string
 type PermissionMode string
@@ -153,6 +167,27 @@ type Policy struct {
 	// (runs without the filter) when the helper binary is not found. Ignored on
 	// non-bubblewrap backends.
 	BlockUnixSockets bool `json:"blockUnixSockets,omitempty"`
+	// AllowRead/DenyRead/AllowWrite/DenyWrite are fine-grained path lists layered
+	// ON TOP of the workspace + Scope guards; they never bypass the symlink /
+	// out-of-workspace protections. Each entry is home-expanded, made absolute, and
+	// symlink-resolved (an entry that does not exist is dropped). All default empty,
+	// so an unconfigured policy behaves exactly as before. Semantics:
+	//
+	//   - Read: a path readable under the base workspace/Scope guard is denied if it
+	//     falls under a DenyRead entry, UNLESS a more-specific AllowRead entry (one
+	//     nested inside that DenyRead entry) re-includes it. AllowRead only
+	//     re-includes within a DenyRead carve-out; it never extends reads beyond the
+	//     workspace.
+	//   - Write: DenyWrite wins over everything; otherwise a path writable under the
+	//     workspace/Scope guard is allowed; otherwise an absolute path under an
+	//     AllowWrite root is allowed; otherwise it is denied. AllowWrite roots are
+	//     also reflected in the OS backend write binds, and on sandbox-exec DenyWrite
+	//     entries are emitted as explicit deny rules so the precedence holds for
+	//     shell commands too.
+	AllowRead  []string `json:"allowRead,omitempty"`
+	DenyRead   []string `json:"denyRead,omitempty"`
+	AllowWrite []string `json:"allowWrite,omitempty"`
+	DenyWrite  []string `json:"denyWrite,omitempty"`
 }
 
 type Request struct {

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -20,10 +20,21 @@ const EnvAutoAllowBash = "ZERO_SANDBOX_AUTO_ALLOW_BASH"
 // already-sandboxed guard used by comparable executor sandboxes. Unset by default.
 const EnvSandboxed = "ZERO_SANDBOXED"
 
+// EnvSandboxBackend records which backend wrapped the command. sandboxEnvironment
+// always sets it alongside EnvSandboxed, so it serves as a corroborating marker:
+// the re-entrancy guard requires BOTH, raising the provenance bar above a single
+// ambient flag (a stray or hand-exported ZERO_SANDBOXED=1 with no backend marker
+// no longer forces an unsandboxed pass-through).
+const EnvSandboxBackend = "ZERO_SANDBOX_BACKEND"
+
 // IsAlreadySandboxed reports whether the current process is already running
-// inside a zero-created sandbox (EnvSandboxed == "1").
+// inside a zero-created sandbox. It requires BOTH correlated markers that
+// sandboxEnvironment sets together — EnvSandboxed == "1" AND a non-empty
+// EnvSandboxBackend — so a single user-set/inherited ZERO_SANDBOXED=1 cannot by
+// itself disable wrapping. zero sets both only on genuinely wrapped commands;
+// pass-through (direct) plans set neither.
 func IsAlreadySandboxed() bool {
-	return os.Getenv(EnvSandboxed) == "1"
+	return os.Getenv(EnvSandboxed) == "1" && strings.TrimSpace(os.Getenv(EnvSandboxBackend)) != ""
 }
 
 type SideEffect string

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -158,6 +158,14 @@ type Policy struct {
 	// NetworkDeny so existing policies keep their exact behaviour.
 	AllowedDomains []string `json:"allowedDomains,omitempty"`
 	DeniedDomains  []string `json:"deniedDomains,omitempty"`
+	// EnforceToolNetwork, when true, subjects the first-party in-process network
+	// tools (web_search / web_fetch) to the sandbox network policy via
+	// NetworkHostAllowed. It is OFF by default: that policy exists to confine the
+	// sandboxed SHELL's egress, which these tools do not use, so by default they
+	// are allowed to run (keeping their own SSRF/port/redirect/redaction
+	// safeguards). The sandboxed-shell egress decision is independent of this flag.
+	// Turn it on to also hold web_search/web_fetch to the allow/scoped/deny policy.
+	EnforceToolNetwork bool `json:"enforceToolNetwork,omitempty"`
 	// AutoAllowBashWhenSandboxed, when true, auto-allows the bash tool WITHOUT a
 	// permission prompt — but only when the sandbox is actually active (a
 	// native-isolation backend wraps the command). The sandbox is then the safety

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 type globTool struct {
@@ -44,6 +46,17 @@ func NewScopedGlobTool(workspaceRoot string, scope PathScope) Tool {
 }
 
 func (tool globTool) Run(_ context.Context, args map[string]any) Result {
+	return tool.runWith(args, readExcluder{})
+}
+
+// RunWithSandbox runs glob while skipping subtrees the sandbox policy denies
+// reads to (DenyRead). With no DenyRead configured the excluder is a no-op and
+// behavior is unchanged.
+func (tool globTool) RunWithSandbox(_ context.Context, args map[string]any, engine *sandbox.Engine) Result {
+	return tool.runWith(args, sandboxReadExcluder(engine))
+}
+
+func (tool globTool) runWith(args map[string]any, exclude readExcluder) Result {
 	pattern, err := aliasedStringArg(args, []string{"pattern", "glob", "match", "query", "expression"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for glob: " + err.Error())
@@ -75,7 +88,7 @@ func (tool globTool) Run(_ context.Context, args map[string]any) Result {
 		return errorResult("Error running glob " + fmt.Sprintf("%q", pattern) + ": " + err.Error())
 	}
 
-	matches, err := scanGlob(root, displayRoot, matcher, includeDirs)
+	matches, err := scanGlob(root, displayRoot, matcher, includeDirs, exclude)
 	if err != nil {
 		return errorResult("Error running glob " + fmt.Sprintf("%q", pattern) + ": " + err.Error())
 	}
@@ -99,7 +112,7 @@ func (tool globTool) Run(_ context.Context, args map[string]any) Result {
 	}
 }
 
-func scanGlob(root string, displayRoot string, matcher *regexp.Regexp, includeDirs bool) ([]string, error) {
+func scanGlob(root string, displayRoot string, matcher *regexp.Regexp, includeDirs bool, exclude readExcluder) ([]string, error) {
 	matches := []string{}
 	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -117,6 +130,10 @@ func scanGlob(root string, displayRoot string, matcher *regexp.Regexp, includeDi
 		if entry.IsDir() && shouldSkipDirectory(entry.Name()) {
 			return filepath.SkipDir
 		}
+		if entry.IsDir() && exclude.dirExcluded(path) {
+			// Skip a read-denied subtree (sandbox DenyRead) wholesale.
+			return filepath.SkipDir
+		}
 		if entry.IsDir() && !includeDirs {
 			return nil
 		}
@@ -127,6 +144,11 @@ func scanGlob(root string, displayRoot string, matcher *regexp.Regexp, includeDi
 		}
 		normalized := filepath.ToSlash(relative)
 		if !entry.IsDir() && shouldSkipWorkspaceFile(normalized) {
+			return nil
+		}
+		// A read-denied path (even an includeDirs directory with a nested allow we
+		// still descended into) must not appear in results.
+		if exclude.fileExcluded(path) {
 			return nil
 		}
 		if matcher.MatchString(normalized) {

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 type grepTool struct {
@@ -54,6 +56,18 @@ func NewScopedGrepTool(workspaceRoot string, scope PathScope) Tool {
 }
 
 func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
+	return tool.runWith(args, readExcluder{})
+}
+
+// RunWithSandbox runs the search while skipping subtrees the sandbox policy
+// denies reads to (DenyRead), so grep never surfaces content from a read-denied
+// path. With no DenyRead configured the excluder is a no-op and behavior is
+// unchanged.
+func (tool grepTool) RunWithSandbox(_ context.Context, args map[string]any, engine *sandbox.Engine) Result {
+	return tool.runWith(args, sandboxReadExcluder(engine))
+}
+
+func (tool grepTool) runWith(args map[string]any, exclude readExcluder) Result {
 	pattern, err := aliasedStringArg(args, []string{"pattern", "query", "regex", "search", "expression"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for grep: " + err.Error())
@@ -124,7 +138,7 @@ func (tool grepTool) Run(_ context.Context, args map[string]any) Result {
 		}
 	}
 
-	files, err := grepFiles(resolvedRoot, target, globMatcher)
+	files, err := grepFiles(resolvedRoot, target, globMatcher, exclude)
 	if err != nil {
 		return errorResult("Error running grep: " + err.Error())
 	}
@@ -225,7 +239,7 @@ func confineGrepFile(resolvedRoot string, path string) (string, string, bool) {
 	return filepath.ToSlash(relative), resolved, true
 }
 
-func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) ([]string, error) {
+func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp, exclude readExcluder) ([]string, error) {
 	info, err := os.Stat(target)
 	if err != nil {
 		return nil, err
@@ -237,6 +251,9 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 			return []string{}, nil
 		}
 		if shouldSkipWorkspaceFile(relative) {
+			return []string{}, nil
+		}
+		if exclude.fileExcluded(target) {
 			return []string{}, nil
 		}
 		// A single explicit file is matched by its base name so a pattern like
@@ -265,6 +282,13 @@ func grepFiles(resolvedRoot string, target string, globMatcher *regexp.Regexp) (
 			return filepath.SkipDir
 		}
 		if entry.IsDir() {
+			// Skip a read-denied subtree (sandbox DenyRead) wholesale.
+			if exclude.dirExcluded(path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if exclude.fileExcluded(path) {
 			return nil
 		}
 		// Confine each candidate through symlinks: a symlink inside the workspace

--- a/internal/tools/read_exclusions.go
+++ b/internal/tools/read_exclusions.go
@@ -1,0 +1,25 @@
+package tools
+
+import "github.com/Gitlawb/zero/internal/sandbox"
+
+// readExcluder skips read-denied paths (the sandbox DenyRead policy) during a
+// search walk. The zero value (both funcs nil) excludes nothing, so a
+// non-sandboxed search behaves exactly as before — the exclusions are opt-in and
+// only ever REMOVE results, never add them.
+type readExcluder struct {
+	file func(string) bool
+	dir  func(string) bool
+}
+
+func (e readExcluder) fileExcluded(path string) bool { return e.file != nil && e.file(path) }
+func (e readExcluder) dirExcluded(path string) bool  { return e.dir != nil && e.dir(path) }
+
+// sandboxReadExcluder builds a readExcluder from a sandbox engine's DenyRead
+// policy. A nil engine yields the no-op excluder, so the search tools keep their
+// pre-sandbox behavior when no sandbox is active.
+func sandboxReadExcluder(engine *sandbox.Engine) readExcluder {
+	if engine == nil {
+		return readExcluder{}
+	}
+	return readExcluder{file: engine.ReadPathExcluded, dir: engine.ReadDirExcluded}
+}

--- a/internal/tools/read_exclusions.go
+++ b/internal/tools/read_exclusions.go
@@ -15,11 +15,17 @@ func (e readExcluder) fileExcluded(path string) bool { return e.file != nil && e
 func (e readExcluder) dirExcluded(path string) bool  { return e.dir != nil && e.dir(path) }
 
 // sandboxReadExcluder builds a readExcluder from a sandbox engine's DenyRead
-// policy. A nil engine yields the no-op excluder, so the search tools keep their
-// pre-sandbox behavior when no sandbox is active.
+// policy. The engine's read-exclusion matcher resolves the policy paths ONCE here
+// (not per visited path), and the closures reuse it for the whole walk. A nil
+// engine or an inactive (no DenyRead) policy yields the no-op excluder, so the
+// search tools keep their pre-sandbox behavior.
 func sandboxReadExcluder(engine *sandbox.Engine) readExcluder {
 	if engine == nil {
 		return readExcluder{}
 	}
-	return readExcluder{file: engine.ReadPathExcluded, dir: engine.ReadDirExcluded}
+	rx := engine.ReadExclusions()
+	if !rx.Active() {
+		return readExcluder{}
+	}
+	return readExcluder{file: rx.PathExcluded, dir: rx.DirExcluded}
 }

--- a/internal/tools/read_exclusions_test.go
+++ b/internal/tools/read_exclusions_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+// denyReadFixture builds a workspace with an ordinary file and a secret subtree,
+// returning the resolved workspace root and a sandbox engine whose DenyRead
+// covers the secret dir.
+func denyReadFixture(t *testing.T) (string, *sandbox.Engine) {
+	t.Helper()
+	ws, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+	secret := filepath.Join(ws, "secret")
+	if err := os.MkdirAll(secret, 0o755); err != nil {
+		t.Fatalf("mkdir secret: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(secret, "creds.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatalf("write creds.go: %v", err)
+	}
+
+	scope, err := sandbox.NewScope(ws, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: ws,
+		Policy: sandbox.Policy{
+			Mode:             sandbox.ModeEnforce,
+			EnforceWorkspace: true,
+			DenyRead:         []string{secret},
+		},
+		Scope: scope,
+	})
+	return ws, engine
+}
+
+func TestGrepSkipsDenyReadSubtree(t *testing.T) {
+	ws, engine := denyReadFixture(t)
+	tool, ok := NewGrepTool(ws).(sandboxAwareTool)
+	if !ok {
+		t.Fatal("grep tool must be sandbox-aware")
+	}
+	args := map[string]any{"pattern": "package main", "output_mode": "files_with_matches"}
+
+	// Sandboxed: the DenyRead subtree must be excluded from results.
+	sandboxed := tool.RunWithSandbox(context.Background(), args, engine)
+	if sandboxed.Status != StatusOK {
+		t.Fatalf("grep failed: %s", sandboxed.Output)
+	}
+	if !strings.Contains(sandboxed.Output, "main.go") {
+		t.Fatalf("grep must still match the non-denied file, got:\n%s", sandboxed.Output)
+	}
+	if strings.Contains(sandboxed.Output, "creds.go") {
+		t.Fatalf("grep must NOT surface a DenyRead file, got:\n%s", sandboxed.Output)
+	}
+
+	// Without a sandbox, the same search includes the secret file (default behavior).
+	plain := NewGrepTool(ws).Run(context.Background(), args)
+	if !strings.Contains(plain.Output, "creds.go") {
+		t.Fatalf("non-sandboxed grep should include the secret file, got:\n%s", plain.Output)
+	}
+}
+
+func TestGlobSkipsDenyReadSubtree(t *testing.T) {
+	ws, engine := denyReadFixture(t)
+	tool, ok := NewGlobTool(ws).(sandboxAwareTool)
+	if !ok {
+		t.Fatal("glob tool must be sandbox-aware")
+	}
+	args := map[string]any{"pattern": "**/*.go"}
+
+	sandboxed := tool.RunWithSandbox(context.Background(), args, engine)
+	if sandboxed.Status != StatusOK {
+		t.Fatalf("glob failed: %s", sandboxed.Output)
+	}
+	if !strings.Contains(sandboxed.Output, "main.go") {
+		t.Fatalf("glob must still match the non-denied file, got:\n%s", sandboxed.Output)
+	}
+	if strings.Contains(sandboxed.Output, "creds.go") {
+		t.Fatalf("glob must NOT surface a DenyRead file, got:\n%s", sandboxed.Output)
+	}
+
+	plain := NewGlobTool(ws).Run(context.Background(), args)
+	if !strings.Contains(plain.Output, "creds.go") {
+		t.Fatalf("non-sandboxed glob should include the secret file, got:\n%s", plain.Output)
+	}
+}

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -386,7 +386,9 @@ func TestWebFetchRunWithSandboxBlocksDeniedHost(t *testing.T) {
 	}
 
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
-		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkDeny},
+		// EnforceToolNetwork opts the in-process tool into the network policy; off
+		// (the default) would let web_fetch run despite deny.
+		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkDeny, EnforceToolNetwork: true},
 	})
 	result := tool.RunWithSandbox(context.Background(), map[string]any{"url": "https://example.com"}, engine)
 	if result.Status != StatusError {
@@ -405,7 +407,7 @@ func TestWebFetchRunWithSandboxScopedBlocksUnlistedHost(t *testing.T) {
 	tool := newWebFetchToolWithClient(failingClient).(webFetchTool)
 
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
-		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"allowed.test"}},
+		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"allowed.test"}, EnforceToolNetwork: true},
 		Backend: zeroSandbox.Backend{
 			Name: zeroSandbox.BackendSandboxExec, Available: true,
 			Executable: "/usr/bin/sandbox-exec", ScopedEgress: true,
@@ -433,7 +435,7 @@ func TestRegistryRoutesWebFetchThroughSandboxScopedPolicy(t *testing.T) {
 	registry.Register(newWebFetchToolWithClient(failingClient))
 
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
-		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"allowed.test"}},
+		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"allowed.test"}, EnforceToolNetwork: true},
 		Backend: zeroSandbox.Backend{
 			Name: zeroSandbox.BackendSandboxExec, Available: true,
 			Executable: "/usr/bin/sandbox-exec", ScopedEgress: true,

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -160,18 +160,36 @@ func TestHTTPSearchBackendEndpointHost(t *testing.T) {
 	}
 }
 
-func TestWebSearchRunWithSandboxBlocksUnderDeny(t *testing.T) {
-	backend := &fakeHostedBackend{host: "search.example"}
+// TestWebSearchRunWithSandboxAllowsByDefaultUnderDeny verifies the default
+// posture: a first-party in-process tool is NOT subject to the sandbox network
+// policy unless EnforceToolNetwork is set, so web_search runs even under deny.
+func TestWebSearchRunWithSandboxAllowsByDefaultUnderDeny(t *testing.T) {
+	backend := &fakeHostedBackend{host: "search.example", results: []searchResult{{Title: "T", URL: "https://x.test"}}}
 	tool := newWebSearchToolWithBackend(backend).(webSearchTool)
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
 		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkDeny},
+	})
+	res := tool.RunWithSandbox(context.Background(), map[string]any{"query": "hi"}, engine)
+	if res.Status != StatusOK {
+		t.Fatalf("web_search must run by default even under deny, got %q: %s", res.Status, res.Output)
+	}
+	if !backend.called {
+		t.Fatal("search backend must be called when tool-network enforcement is off (default)")
+	}
+}
+
+func TestWebSearchRunWithSandboxBlocksUnderDenyWhenEnforced(t *testing.T) {
+	backend := &fakeHostedBackend{host: "search.example"}
+	tool := newWebSearchToolWithBackend(backend).(webSearchTool)
+	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
+		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkDeny, EnforceToolNetwork: true},
 	})
 	res := tool.RunWithSandbox(context.Background(), map[string]any{"query": "hi"}, engine)
 	if res.Status != StatusError || !strings.Contains(res.Output, "disabled") {
 		t.Fatalf("expected deny block, got %q: %s", res.Status, res.Output)
 	}
 	if backend.called {
-		t.Fatal("search backend must not be called under network deny")
+		t.Fatal("search backend must not be called under network deny when enforced")
 	}
 }
 
@@ -179,7 +197,7 @@ func TestWebSearchRunWithSandboxScopedBlocksUnlistedHost(t *testing.T) {
 	backend := &fakeHostedBackend{host: "search.example"}
 	tool := newWebSearchToolWithBackend(backend).(webSearchTool)
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
-		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"allowed.test"}},
+		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"allowed.test"}, EnforceToolNetwork: true},
 		Backend: zeroSandbox.Backend{
 			Name: zeroSandbox.BackendSandboxExec, Available: true,
 			Executable: "/usr/bin/sandbox-exec", ScopedEgress: true,
@@ -198,7 +216,7 @@ func TestWebSearchRunWithSandboxScopedAllowsListedHost(t *testing.T) {
 	backend := &fakeHostedBackend{host: "search.example", results: []searchResult{{Title: "T", URL: "https://x.test"}}}
 	tool := newWebSearchToolWithBackend(backend).(webSearchTool)
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
-		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"search.example"}},
+		Policy: zeroSandbox.Policy{Mode: zeroSandbox.ModeEnforce, Network: zeroSandbox.NetworkScoped, AllowedDomains: []string{"search.example"}, EnforceToolNetwork: true},
 		Backend: zeroSandbox.Backend{
 			Name: zeroSandbox.BackendSandboxExec, Available: true,
 			Executable: "/usr/bin/sandbox-exec", ScopedEgress: true,


### PR DESCRIPTION
## Summary

Four **opt-in, fail-closed** capabilities added to `internal/sandbox` (Go only — no new deps, `bin/zero.js` untouched). Every addition is gated by a `Policy` field with a safe default, so an unconfigured policy behaves exactly as before.

### 1. Re-entrancy guard
- `EnvSandboxed = "ZERO_SANDBOXED"` is set on every wrapped command's env.
- A nested `BuildCommandPlan` while `ZERO_SANDBOXED=1` returns a **pass-through** plan — no double `bwrap`/`sandbox-exec` wrap, no second egress proxy.
- New: `IsAlreadySandboxed() bool`.

### 2. SOCKS5 egress
- The scoped-egress proxy now also serves **SOCKS5 CONNECT** on a separate `127.0.0.1:0` listener, routed through the **same** `authorize()` / `domainAllowed()` gate (deny-wins, empty-allowlist → deny, fail-closed).
- `ProxyEnvWithSocks(httpAddr, socksAddr)` points `ALL_PROXY`/`all_proxy` at `socks5://<addr>` while `HTTP_PROXY`/`HTTPS_PROXY` stay on the HTTP listener; `NO_PROXY=localhost,127.0.0.1` preserved. Empty SOCKS addr falls back to the legacy `ProxyEnv` output.
- The `sandbox-exec` profile allows outbound to **both** proxy ports. Bubblewrap (isolated netns) scoped policy still collapses to **deny** — backend-awareness preserved.

### 3. Sandbox-aware search
- `ReadExclusionGlobs(policy, scope) []string` returns ripgrep `--glob '!<pat>'` exclusions for `DenyRead` subtrees inside the workspace.
- The Go-native `grep`/`glob` tools become sandbox-aware (`RunWithSandbox`) and **skip read-denied subtrees** during their walk via `Engine.ReadPathExcluded` / `ReadDirExcluded` (the predicate honors more-specific `AllowRead` re-inclusion). No sandbox / no `DenyRead` → unchanged.

### 4. Fine-grained allow/deny path lists
- New `Policy` fields: `AllowRead`, `DenyRead`, `AllowWrite`, `DenyWrite []string`.
- **Read** = deny-then-allow: a `DenyRead` subtree is blocked unless a more-specific `AllowRead` re-includes it.
- **Write** precedence: `DenyWrite` wins > workspace/scope-writable > `AllowWrite` > deny.
- `AllowWrite` roots are reflected in the OS write binds; `DenyWrite` is also emitted as explicit `sandbox-exec` deny rules (last-match-wins) so the precedence holds for shell commands.
- Layered **on top** of the workspace + Scope guards; never bypasses the symlink / out-of-workspace protections. Each entry is home-expanded, made absolute, and `EvalSymlinks`-resolved (non-existent entries dropped).

## Defaults / safety
No default weakened: all lists default empty, `ZERO_SANDBOXED` defaults unset, SOCKS reuses the same allowlist, every gate fails closed.

## Tests
`internal/sandbox/{reentrancy,egress_socks,pathlists}_test.go`, `internal/sandbox/runner_test.go` (ProxyEnv variants), and `internal/tools/read_exclusions_test.go` — covering the re-entrancy plan, SOCKS allow/deny + deny-wins, the read/write precedence matrix, glob generation, and grep/glob subtree exclusion.

## Gate results (local)
- `gofmt -l .` → empty
- `go vet ./...` → clean
- `go build ./...` → clean
- `go test ./...` → all pass (incl. `-race` on `internal/sandbox` + `internal/tools`)
- `staticcheck ./...` → no new findings (none in changed files)
- `govulncheck ./...` → 0 vulnerabilities
- `deadcode -test=false ./...` → no new unreachable funcs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SOCKS5 egress front-end alongside existing HTTP proxying; sandboxed proxy networking now routes `ALL_PROXY/all_proxy` to SOCKS when available and restricts outbound proxy traffic to local loopback proxy ports.
  * Introduced fine-grained sandbox file policies: `AllowRead/DenyRead` and `AllowWrite/DenyWrite`, with deny precedence and nested allow re-inclusion.
  * Sandboxed grep/glob execution now respects `DenyRead` during traversal (skipping denied subtrees).
  * Added `EnforceToolNetwork` to apply sandbox network rules to first-party tools.
* **Tests**
  * Expanded SOCKS5 integration, proxy environment behavior, path-policy precedence/exclusion (including symlink-aware directory pruning), and sandboxed grep/glob coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->