### PR TITLE
Polish TUI transcript and reasoning display

### DIFF
--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1125,6 +1125,27 @@ func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
 	}
 }
 
+func TestResolveProviderProfileParseThinkTagsFalseAlias(t *testing.T) {
+	path := writeConfig(t, `{
+		"activeProvider": "custom",
+		"providers": [{
+			"name": "custom",
+			"provider_kind": "openai-compatible",
+			"base_url": "https://custom.example/v1",
+			"model_id": "custom-model",
+			"parse_think_tags": false
+		}]
+	}`)
+
+	resolved, err := Resolve(ResolveOptions{UserConfigPath: path, Env: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resolved.Provider.ParseThinkTags == nil || *resolved.Provider.ParseThinkTags {
+		t.Fatalf("ParseThinkTags = %#v, want explicit false", resolved.Provider.ParseThinkTags)
+	}
+}
+
 func TestResolveRejectsUnknownProviderCatalogID(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "bad",

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1094,7 +1094,8 @@ func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
 			"auth_scheme": "raw",
 			"auth_header_value": "header-secret",
 			"custom_headers": {"X-Zero": "1"},
-			"model_id": "custom-model"
+			"model_id": "custom-model",
+			"parse_think_tags": true
 		}]
 	}`)
 
@@ -1118,6 +1119,9 @@ func TestResolveProviderProfileExtendedJSONAliases(t *testing.T) {
 	}
 	if profile.CustomHeaders["X-Zero"] != "1" {
 		t.Fatalf("CustomHeaders = %#v, want X-Zero header", profile.CustomHeaders)
+	}
+	if profile.ParseThinkTags == nil || !*profile.ParseThinkTags {
+		t.Fatalf("ParseThinkTags = %#v, want true", profile.ParseThinkTags)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -34,6 +34,7 @@ type ProviderProfile struct {
 	AuthHeaderValue string            `json:"authHeaderValue,omitempty"`
 	CustomHeaders   map[string]string `json:"customHeaders,omitempty"`
 	Model           string            `json:"model,omitempty"`
+	ParseThinkTags  *bool             `json:"parseThinkTags,omitempty"`
 	Description     string            `json:"description,omitempty"`
 }
 
@@ -51,6 +52,7 @@ func HasProviderProfile(profile ProviderProfile) bool {
 		strings.TrimSpace(profile.AuthHeaderValue) != "" ||
 		profile.CustomHeaders != nil ||
 		strings.TrimSpace(profile.Model) != "" ||
+		profile.ParseThinkTags != nil ||
 		strings.TrimSpace(profile.Description) != ""
 }
 
@@ -304,6 +306,8 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 		CustomHeadersSnake   map[string]string `json:"custom_headers"`
 		Model                string            `json:"model"`
 		ModelID              string            `json:"model_id"`
+		ParseThinkTags       *bool             `json:"parseThinkTags"`
+		ParseThinkTagsSnake  *bool             `json:"parse_think_tags"`
 		Description          string            `json:"description"`
 	}
 
@@ -325,6 +329,7 @@ func (profile *ProviderProfile) UnmarshalJSON(data []byte) error {
 	profile.AuthHeaderValue = firstNonEmpty(raw.AuthHeaderValue, raw.AuthHeaderValueSnake)
 	profile.CustomHeaders = firstNonNilMap(raw.CustomHeaders, raw.CustomHeadersSnake)
 	profile.Model = strings.TrimSpace(firstNonEmpty(raw.Model, raw.ModelID))
+	profile.ParseThinkTags = firstNonNilBool(raw.ParseThinkTags, raw.ParseThinkTagsSnake)
 	profile.Description = strings.TrimSpace(raw.Description)
 	return nil
 }
@@ -343,6 +348,15 @@ func firstNonNilMap(values ...map[string]string) map[string]string {
 	for _, value := range values {
 		if value != nil {
 			return copyStringMap(value)
+		}
+	}
+	return nil
+}
+
+func firstNonNilBool(values ...*bool) *bool {
+	for _, value := range values {
+		if value != nil {
+			return value
 		}
 	}
 	return nil

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -40,6 +40,7 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 			MaxTokens:       resolved.maxOutputTokens,
 			HTTPClient:      options.HTTPClient,
 			UserAgent:       options.UserAgent,
+			ParseThinkTags:  parseThinkTagsForProfile(profile, resolved),
 		})
 	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
 		return anthropic.New(anthropic.Options{
@@ -70,6 +71,40 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 	default:
 		return nil, fmt.Errorf("unsupported provider kind %q", resolved.providerKind)
 	}
+}
+
+func parseThinkTagsForProfile(profile config.ProviderProfile, resolved resolvedProfile) bool {
+	if profile.ParseThinkTags != nil {
+		return *profile.ParseThinkTags
+	}
+	if resolved.providerKind != config.ProviderKindOpenAICompatible {
+		return false
+	}
+	return modelMayEmitThinkTags(resolved.apiModel)
+}
+
+func modelMayEmitThinkTags(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	for _, marker := range []string{
+		"deepseek-r1",
+		"deepseek-reasoner",
+		"gpt-oss",
+		"glm-z1",
+		"kimi-k2-thinking",
+		"magistral",
+		"minimax-m3",
+		"nemotron",
+		"qwen3",
+		"qwq",
+		"reasoner",
+		"reasoning",
+		"thinking",
+	} {
+		if strings.Contains(model, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 type resolvedProfile struct {

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -108,6 +108,33 @@ func TestNewSupportsOpenAIProviderKind(t *testing.T) {
 	}
 }
 
+func TestParseThinkTagsForProfileUsesConservativeDefaultsAndOverride(t *testing.T) {
+	openAICompatible := resolvedProfile{providerKind: config.ProviderKindOpenAICompatible, apiModel: "qwen3-coder:480b"}
+	if !parseThinkTagsForProfile(config.ProviderProfile{}, openAICompatible) {
+		t.Fatal("qwen3 OpenAI-compatible model should parse inline think tags by default")
+	}
+
+	generic := resolvedProfile{providerKind: config.ProviderKindOpenAICompatible, apiModel: "factory-model"}
+	if parseThinkTagsForProfile(config.ProviderProfile{}, generic) {
+		t.Fatal("generic OpenAI-compatible model should preserve literal think tags by default")
+	}
+
+	official := resolvedProfile{providerKind: config.ProviderKindOpenAI, apiModel: "gpt-4.1"}
+	if parseThinkTagsForProfile(config.ProviderProfile{}, official) {
+		t.Fatal("official OpenAI model should preserve literal think tags by default")
+	}
+
+	enabled := true
+	if !parseThinkTagsForProfile(config.ProviderProfile{ParseThinkTags: &enabled}, generic) {
+		t.Fatal("explicit parseThinkTags=true should enable inline think parsing")
+	}
+
+	disabled := false
+	if parseThinkTagsForProfile(config.ProviderProfile{ParseThinkTags: &disabled}, openAICompatible) {
+		t.Fatal("explicit parseThinkTags=false should disable inline think parsing")
+	}
+}
+
 func TestNewResolvesKnownModelToAPIModelAndProvider(t *testing.T) {
 	transport := &captureTransport{
 		responseBody: "data: {\"type\":\"message_stop\"}\n\n",

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -170,6 +170,7 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		return provider.emitPayload(ctx, data, state, events)
 	})
 	if errors.Is(err, providerio.ErrStreamIdle) {
+		state.flushContent(ctx, events)
 		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{
 			Type:  zeroruntime.StreamEventError,
@@ -178,16 +179,19 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		return
 	}
 	if err != nil {
+		state.flushContent(ctx, events)
 		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
+		state.flushContent(ctx, events)
 		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + ctxErr.Error())})
 		return
 	}
 	if !state.done {
+		state.flushContent(ctx, events)
 		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone, FinishReason: state.finishReason})
 	}
@@ -199,6 +203,7 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 func (provider *Provider) emitPayload(ctx context.Context, data string, state *toolState, events chan<- zeroruntime.StreamEvent) bool {
 	var chunk streamChunk
 	if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+		state.flushContent(ctx, events)
 		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{
 			Type:  zeroruntime.StreamEventError,
@@ -208,6 +213,7 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *t
 		return false
 	}
 	if chunk.Error != nil {
+		state.flushContent(ctx, events)
 		state.closeOpen(ctx, events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{
 			Type:  zeroruntime.StreamEventError,
@@ -234,15 +240,13 @@ func (provider *Provider) emitChunk(
 			})
 		}
 		if choice.Delta.Content != "" {
-			sendEvent(ctx, events, zeroruntime.StreamEvent{
-				Type:    zeroruntime.StreamEventText,
-				Content: choice.Delta.Content,
-			})
+			state.emitContent(ctx, events, choice.Delta.Content)
 		}
 		for _, toolCall := range choice.Delta.ToolCalls {
 			state.applyDelta(ctx, toolCall, events)
 		}
 		if choice.FinishReason == "tool_calls" {
+			state.flushContent(ctx, events)
 			state.closeOpen(ctx, events)
 		}
 		if reason := mapFinishReason(choice.FinishReason); reason != "" {

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -170,8 +170,8 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		return provider.emitPayload(ctx, data, state, events)
 	})
 	if errors.Is(err, providerio.ErrStreamIdle) {
-		state.flushContent(ctx, events)
-		state.closeOpen(ctx, events)
+		state.flushBufferedContent(events)
+		state.closeBufferedOpen(events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{
 			Type:  zeroruntime.StreamEventError,
 			Error: provider.redact(fmt.Sprintf("provider stream error: idle timeout after %s (upstream stopped sending data)", provider.streamIdleTimeout)),
@@ -179,14 +179,14 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		return
 	}
 	if err != nil {
-		state.flushContent(ctx, events)
-		state.closeOpen(ctx, events)
+		state.flushBufferedContent(events)
+		state.closeBufferedOpen(events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		state.flushContent(ctx, events)
-		state.closeOpen(ctx, events)
+		state.flushBufferedContent(events)
+		state.closeBufferedOpen(events)
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + ctxErr.Error())})
 		return
 	}
@@ -315,6 +315,13 @@ func sendEvent(ctx context.Context, events chan<- zeroruntime.StreamEvent, event
 			}
 		}
 	case events <- event:
+	}
+}
+
+func sendBufferedEvent(events chan<- zeroruntime.StreamEvent, event zeroruntime.StreamEvent) {
+	select {
+	case events <- event:
+	default:
 	}
 }
 

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -40,6 +40,9 @@ type Options struct {
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
 	// Zero uses defaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
+	// ParseThinkTags converts streamed <think>...</think> content into reasoning
+	// events for OpenAI-compatible models known to emit that legacy format.
+	ParseThinkTags bool
 }
 
 // Provider streams completions from an OpenAI-compatible chat completions API.
@@ -55,6 +58,7 @@ type Provider struct {
 	httpClient        *http.Client
 	userAgent         string
 	streamIdleTimeout time.Duration
+	parseThinkTags    bool
 }
 
 // New creates an OpenAI-compatible provider.
@@ -100,6 +104,7 @@ func New(options Options) (*Provider, error) {
 		httpClient:        httpClient,
 		userAgent:         options.UserAgent,
 		streamIdleTimeout: idleTimeout,
+		parseThinkTags:    options.ParseThinkTags,
 	}, nil
 }
 
@@ -162,7 +167,7 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 		return
 	}
 
-	state := newToolState()
+	state := newToolState(provider.parseThinkTags)
 	// Use the shared SSE reader (also used by the Anthropic/Gemini providers) so
 	// multi-line "data:" continuation fields are joined into one payload, and the
 	// idle watchdog / context cancellation are handled uniformly.

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -244,6 +244,40 @@ func TestStreamCompletionEmitsReasoningBeforeRegularContent(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionSplitsInlineThinkTagsFromContent(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"content":"<think>private reasoning</think>public answer"}}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	assertEvent(t, events[0], zeroruntime.StreamEventReasoning, "private reasoning")
+	assertEvent(t, events[1], zeroruntime.StreamEventText, "public answer")
+	if events[2].Type != zeroruntime.StreamEventDone {
+		t.Fatalf("third event = %#v, want done", events[2])
+	}
+}
+
+func TestStreamCompletionSplitsInlineThinkTagsAcrossChunks(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"content":"<thi"}}]}`)
+		writeSSE(w, `{"choices":[{"delta":{"content":"nk>reason"}}]}`)
+		writeSSE(w, `{"choices":[{"delta":{"content":"ing</"}}]}`)
+		writeSSE(w, `{"choices":[{"delta":{"content":"think> answer"}}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	reasoning := eventsOfType(events, zeroruntime.StreamEventReasoning)
+	if len(reasoning) != 2 || reasoning[0].Content != "reason" || reasoning[1].Content != "ing" {
+		t.Fatalf("reasoning events = %#v, want split reasoning content", reasoning)
+	}
+	text := eventsOfType(events, zeroruntime.StreamEventText)
+	if len(text) != 1 || text[0].Content != " answer" {
+		t.Fatalf("text events = %#v, want answer-only content", text)
+	}
+}
+
 func TestStreamCompletionBuffersToolArgsUntilIDAndNameArrive(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":"}}]}}]}`)

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -244,8 +244,21 @@ func TestStreamCompletionEmitsReasoningBeforeRegularContent(t *testing.T) {
 	}
 }
 
-func TestStreamCompletionSplitsInlineThinkTagsFromContent(t *testing.T) {
+func TestStreamCompletionPreservesLiteralThinkTagsByDefault(t *testing.T) {
 	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"content":"show <think>literal</think> markup"}}]}`)
+		writeSSE(w, `[DONE]`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	assertEvent(t, events[0], zeroruntime.StreamEventText, "show <think>literal</think> markup")
+	if reasoning := eventsOfType(events, zeroruntime.StreamEventReasoning); len(reasoning) != 0 {
+		t.Fatalf("literal think tags must not emit reasoning by default, got %#v", reasoning)
+	}
+}
+
+func TestStreamCompletionSplitsInlineThinkTagsFromContent(t *testing.T) {
+	provider := newTestProviderWithThinkTags(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"content":"<think>private reasoning</think>public answer"}}]}`)
 		writeSSE(w, `[DONE]`)
 	})
@@ -259,7 +272,7 @@ func TestStreamCompletionSplitsInlineThinkTagsFromContent(t *testing.T) {
 }
 
 func TestStreamCompletionSplitsInlineThinkTagsAcrossChunks(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+	provider := newTestProviderWithThinkTags(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"content":"<thi"}}]}`)
 		writeSSE(w, `{"choices":[{"delta":{"content":"nk>reason"}}]}`)
 		writeSSE(w, `{"choices":[{"delta":{"content":"ing</"}}]}`)
@@ -421,7 +434,7 @@ func TestStreamCompletionEmitsErrorWhenContextCancels(t *testing.T) {
 
 func TestStreamCompletionFlushesBufferedContentWhenContextCancels(t *testing.T) {
 	release := make(chan struct{})
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+	provider := newTestProviderWithThinkTags(t, func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"choices":[{"delta":{"content":"visible <thi"}}]}`)
 		select {
 		case <-r.Context().Done():
@@ -449,11 +462,14 @@ func TestStreamCompletionFlushesBufferedContentWhenContextCancels(t *testing.T) 
 	cancel()
 	events = append(events, readAll(stream)...)
 
-	if text := eventsOfType(events, zeroruntime.StreamEventText); len(text) != 2 || text[0].Content != "visible " || text[1].Content != "<thi" {
-		t.Fatalf("text events = %#v, want visible text plus buffered partial tag", text)
+	if len(events) != 3 ||
+		events[0].Type != zeroruntime.StreamEventText || events[0].Content != "visible " ||
+		events[1].Type != zeroruntime.StreamEventText || events[1].Content != "<thi" ||
+		events[2].Type != zeroruntime.StreamEventError {
+		t.Fatalf("events = %#v, want text, buffered text, then context error", events)
 	}
-	if len(eventsOfType(events, zeroruntime.StreamEventError)) != 1 {
-		t.Fatalf("events = %#v, want one context error after buffered content", events)
+	if done := eventsOfType(events, zeroruntime.StreamEventDone); len(done) != 0 {
+		t.Fatalf("events = %#v, want no done after context cancel", events)
 	}
 }
 
@@ -464,12 +480,35 @@ func newTestProvider(t *testing.T, handler http.HandlerFunc) *Provider {
 
 func newTestProviderWithKey(t *testing.T, apiKey string, handler http.HandlerFunc) *Provider {
 	t.Helper()
+	return newTestProviderWithOptions(t, Options{APIKey: apiKey}, handler)
+}
+
+func newTestProviderWithThinkTags(t *testing.T, handler http.HandlerFunc) *Provider {
+	t.Helper()
+	return newTestProviderWithOptions(t, Options{ParseThinkTags: true}, handler)
+}
+
+func newTestProviderWithOptions(t *testing.T, options Options, handler http.HandlerFunc) *Provider {
+	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
+	options.BaseURL = server.URL
+	if strings.TrimSpace(options.Model) == "" {
+		options.Model = "gpt-test"
+	}
 	provider, err := New(Options{
-		APIKey:  apiKey,
-		BaseURL: server.URL,
-		Model:   "gpt-test",
+		APIKey:            options.APIKey,
+		BaseURL:           options.BaseURL,
+		Model:             options.Model,
+		AuthHeader:        options.AuthHeader,
+		AuthScheme:        options.AuthScheme,
+		AuthHeaderValue:   options.AuthHeaderValue,
+		CustomHeaders:     options.CustomHeaders,
+		HTTPClient:        options.HTTPClient,
+		UserAgent:         options.UserAgent,
+		MaxTokens:         options.MaxTokens,
+		StreamIdleTimeout: options.StreamIdleTimeout,
+		ParseThinkTags:    options.ParseThinkTags,
 	})
 	if err != nil {
 		t.Fatalf("New returned error: %v", err)

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -419,6 +419,44 @@ func TestStreamCompletionEmitsErrorWhenContextCancels(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionFlushesBufferedContentWhenContextCancels(t *testing.T) {
+	release := make(chan struct{})
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"choices":[{"delta":{"content":"visible <thi"}}]}`)
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	})
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := provider.StreamCompletion(ctx, zeroruntime.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned setup error: %v", err)
+	}
+
+	events := []zeroruntime.StreamEvent{}
+	select {
+	case event, ok := <-stream:
+		if !ok {
+			t.Fatal("stream closed before first text event")
+		}
+		events = append(events, event)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first text event")
+	}
+	cancel()
+	events = append(events, readAll(stream)...)
+
+	if text := eventsOfType(events, zeroruntime.StreamEventText); len(text) != 2 || text[0].Content != "visible " || text[1].Content != "<thi" {
+		t.Fatalf("text events = %#v, want visible text plus buffered partial tag", text)
+	}
+	if len(eventsOfType(events, zeroruntime.StreamEventError)) != 1 {
+		t.Fatalf("events = %#v, want one context error after buffered content", events)
+	}
+}
+
 func newTestProvider(t *testing.T, handler http.HandlerFunc) *Provider {
 	t.Helper()
 	return newTestProviderWithKey(t, "", handler)

--- a/internal/providers/openai/tool_state.go
+++ b/internal/providers/openai/tool_state.go
@@ -37,20 +37,40 @@ func newToolState() *toolState {
 	return &toolState{calls: make(map[int]*pendingToolCall)}
 }
 
+type streamEventEmitter func(zeroruntime.StreamEvent)
+
 type thinkTagSplitter struct {
 	pending    string
 	inThinking bool
 }
 
 func (state *toolState) emitContent(ctx context.Context, events chan<- zeroruntime.StreamEvent, content string) {
-	state.think.push(content, func(eventType zeroruntime.StreamEventType, text string) {
-		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: eventType, Content: text})
+	state.emitContentWith(content, func(event zeroruntime.StreamEvent) {
+		sendEvent(ctx, events, event)
 	})
 }
 
 func (state *toolState) flushContent(ctx context.Context, events chan<- zeroruntime.StreamEvent) {
+	state.flushContentWith(func(event zeroruntime.StreamEvent) {
+		sendEvent(ctx, events, event)
+	})
+}
+
+func (state *toolState) flushBufferedContent(events chan<- zeroruntime.StreamEvent) {
+	state.flushContentWith(func(event zeroruntime.StreamEvent) {
+		sendBufferedEvent(events, event)
+	})
+}
+
+func (state *toolState) emitContentWith(content string, emit streamEventEmitter) {
+	state.think.push(content, func(eventType zeroruntime.StreamEventType, text string) {
+		emit(zeroruntime.StreamEvent{Type: eventType, Content: text})
+	})
+}
+
+func (state *toolState) flushContentWith(emit streamEventEmitter) {
 	state.think.flush(func(eventType zeroruntime.StreamEventType, text string) {
-		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: eventType, Content: text})
+		emit(zeroruntime.StreamEvent{Type: eventType, Content: text})
 	})
 }
 
@@ -178,6 +198,18 @@ func (state *toolState) applyDelta(
 }
 
 func (state *toolState) closeOpen(ctx context.Context, events chan<- zeroruntime.StreamEvent) {
+	state.closeOpenWith(func(event zeroruntime.StreamEvent) {
+		sendEvent(ctx, events, event)
+	})
+}
+
+func (state *toolState) closeBufferedOpen(events chan<- zeroruntime.StreamEvent) {
+	state.closeOpenWith(func(event zeroruntime.StreamEvent) {
+		sendBufferedEvent(events, event)
+	})
+}
+
+func (state *toolState) closeOpenWith(emit streamEventEmitter) {
 	indexes := make([]int, 0, len(state.calls))
 	for index := range state.calls {
 		indexes = append(indexes, index)
@@ -195,20 +227,20 @@ func (state *toolState) closeOpen(ctx context.Context, events chan<- zeroruntime
 		if call.id == "" || call.name == "" {
 			if call.id != "" || call.name != "" || call.arguments != "" {
 				call.ended = true
-				sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDropped})
+				emit(zeroruntime.StreamEvent{Type: zeroruntime.StreamEventToolCallDropped})
 			}
 			continue
 		}
 		if !call.started {
 			call.started = true
-			sendEvent(ctx, events, zeroruntime.StreamEvent{
+			emit(zeroruntime.StreamEvent{
 				Type:       zeroruntime.StreamEventToolCallStart,
 				ToolCallID: call.id,
 				ToolName:   call.name,
 			})
 		}
 		if call.arguments != "" {
-			sendEvent(ctx, events, zeroruntime.StreamEvent{
+			emit(zeroruntime.StreamEvent{
 				Type:              zeroruntime.StreamEventToolCallDelta,
 				ToolCallID:        call.id,
 				ArgumentsFragment: call.arguments,
@@ -216,7 +248,7 @@ func (state *toolState) closeOpen(ctx context.Context, events chan<- zeroruntime
 			call.arguments = ""
 		}
 		call.ended = true
-		sendEvent(ctx, events, zeroruntime.StreamEvent{
+		emit(zeroruntime.StreamEvent{
 			Type:       zeroruntime.StreamEventToolCallEnd,
 			ToolCallID: call.id,
 		})

--- a/internal/providers/openai/tool_state.go
+++ b/internal/providers/openai/tool_state.go
@@ -3,12 +3,19 @@ package openai
 import (
 	"context"
 	"sort"
+	"strings"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
+const (
+	thinkOpenTag  = "<think>"
+	thinkCloseTag = "</think>"
+)
+
 type toolState struct {
 	calls map[int]*pendingToolCall
+	think thinkTagSplitter
 	// finishReason holds the normalized terminal stop reason (zeroruntime
 	// FinishReason*) when the response ended abnormally (length/content_filter),
 	// so the provider can attach it to the done event. Empty for a normal finish.
@@ -28,6 +35,99 @@ type pendingToolCall struct {
 
 func newToolState() *toolState {
 	return &toolState{calls: make(map[int]*pendingToolCall)}
+}
+
+type thinkTagSplitter struct {
+	pending    string
+	inThinking bool
+}
+
+func (state *toolState) emitContent(ctx context.Context, events chan<- zeroruntime.StreamEvent, content string) {
+	state.think.push(content, func(eventType zeroruntime.StreamEventType, text string) {
+		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: eventType, Content: text})
+	})
+}
+
+func (state *toolState) flushContent(ctx context.Context, events chan<- zeroruntime.StreamEvent) {
+	state.think.flush(func(eventType zeroruntime.StreamEventType, text string) {
+		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: eventType, Content: text})
+	})
+}
+
+func (splitter *thinkTagSplitter) push(content string, emit func(zeroruntime.StreamEventType, string)) {
+	if content == "" {
+		return
+	}
+	splitter.pending += content
+	splitter.drain(false, emit)
+}
+
+func (splitter *thinkTagSplitter) flush(emit func(zeroruntime.StreamEventType, string)) {
+	splitter.drain(true, emit)
+}
+
+func (splitter *thinkTagSplitter) drain(final bool, emit func(zeroruntime.StreamEventType, string)) {
+	for {
+		tag := thinkOpenTag
+		if splitter.inThinking {
+			tag = thinkCloseTag
+		}
+		if index := indexFold(splitter.pending, tag); index >= 0 {
+			splitter.emitCurrent(emit, splitter.pending[:index])
+			splitter.pending = splitter.pending[index+len(tag):]
+			splitter.inThinking = !splitter.inThinking
+			continue
+		}
+		if final {
+			splitter.emitCurrent(emit, splitter.pending)
+			splitter.pending = ""
+			return
+		}
+		keep := trailingTagPrefixLen(splitter.pending, tag)
+		if keep == len(splitter.pending) {
+			return
+		}
+		emitText := splitter.pending[:len(splitter.pending)-keep]
+		splitter.emitCurrent(emit, emitText)
+		splitter.pending = splitter.pending[len(splitter.pending)-keep:]
+		return
+	}
+}
+
+func (splitter *thinkTagSplitter) emitCurrent(emit func(zeroruntime.StreamEventType, string), text string) {
+	if text == "" {
+		return
+	}
+	eventType := zeroruntime.StreamEventText
+	if splitter.inThinking {
+		eventType = zeroruntime.StreamEventReasoning
+	}
+	emit(eventType, text)
+}
+
+func trailingTagPrefixLen(text string, tag string) int {
+	maxLen := min(len(text), len(tag)-1)
+	for length := maxLen; length > 0; length-- {
+		if strings.EqualFold(text[len(text)-length:], tag[:length]) {
+			return length
+		}
+	}
+	return 0
+}
+
+func indexFold(text string, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	if len(text) < len(needle) {
+		return -1
+	}
+	for index := 0; index <= len(text)-len(needle); index++ {
+		if strings.EqualFold(text[index:index+len(needle)], needle) {
+			return index
+		}
+	}
+	return -1
 }
 
 func (state *toolState) applyDelta(

--- a/internal/providers/openai/tool_state.go
+++ b/internal/providers/openai/tool_state.go
@@ -14,8 +14,9 @@ const (
 )
 
 type toolState struct {
-	calls map[int]*pendingToolCall
-	think thinkTagSplitter
+	calls          map[int]*pendingToolCall
+	think          thinkTagSplitter
+	parseThinkTags bool
 	// finishReason holds the normalized terminal stop reason (zeroruntime
 	// FinishReason*) when the response ended abnormally (length/content_filter),
 	// so the provider can attach it to the done event. Empty for a normal finish.
@@ -33,8 +34,8 @@ type pendingToolCall struct {
 	ended     bool
 }
 
-func newToolState() *toolState {
-	return &toolState{calls: make(map[int]*pendingToolCall)}
+func newToolState(parseThinkTags bool) *toolState {
+	return &toolState{calls: make(map[int]*pendingToolCall), parseThinkTags: parseThinkTags}
 }
 
 type streamEventEmitter func(zeroruntime.StreamEvent)
@@ -63,12 +64,19 @@ func (state *toolState) flushBufferedContent(events chan<- zeroruntime.StreamEve
 }
 
 func (state *toolState) emitContentWith(content string, emit streamEventEmitter) {
+	if !state.parseThinkTags {
+		emit(zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: content})
+		return
+	}
 	state.think.push(content, func(eventType zeroruntime.StreamEventType, text string) {
 		emit(zeroruntime.StreamEvent{Type: eventType, Content: text})
 	})
 }
 
 func (state *toolState) flushContentWith(emit streamEventEmitter) {
+	if !state.parseThinkTags {
+		return
+	}
 	state.think.flush(func(eventType zeroruntime.StreamEventType, text string) {
 		emit(zeroruntime.StreamEvent{Type: eventType, Content: text})
 	})

--- a/internal/tui/flush.go
+++ b/internal/tui/flush.go
@@ -90,6 +90,7 @@ func (m model) settleTranscript() (model, tea.Cmd) {
 	rc := buildRowContext(m.transcript)
 	width := chatWidth(m.width)
 	batch := []string{}
+	previousKind, havePreviousKind := previousVisibleTranscriptKind(m.transcript, m.flushed, rc)
 	for m.flushed < len(m.transcript) {
 		row := m.transcript[m.flushed]
 		if !m.settledRow(row, rc) {
@@ -106,8 +107,13 @@ func (m model) settleTranscript() (model, tea.Cmd) {
 		if m.flushedAny && startsTurn(row.kind) {
 			rendered = "\n" + rendered
 		}
+		if (m.flushedAny || havePreviousKind) && previousKind == rowUser && row.kind == rowReasoning {
+			rendered = "\n" + rendered
+		}
 		m.flushedAny = true
 		batch = append(batch, rendered)
+		previousKind = row.kind
+		havePreviousKind = true
 	}
 	if len(batch) > 0 {
 		m.flushQueue = append(m.flushQueue, strings.Join(batch, "\n"))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -141,7 +141,9 @@ type model struct {
 	historyIdx   int
 	historyDraft string
 
-	streamingText string // live assistant text for the current segment
+	streamingText              string // live assistant text for the current segment
+	streamingReasoning         string // live provider reasoning for the current segment
+	streamingReasoningExpanded bool
 
 	// Slash-command autocomplete (purely additive UI state). suggestions is the
 	// live match list for the current "/token"; suggestionIdx is the highlighted
@@ -199,6 +201,11 @@ type agentTextMsg struct {
 	delta string
 }
 
+type agentReasoningMsg struct {
+	runID int
+	delta string
+}
+
 type agentResponseMsg struct {
 	runID         int
 	rows          []transcriptRow
@@ -207,8 +214,7 @@ type agentResponseMsg struct {
 	sessionEvents []pendingSessionEvent
 	specReview    *pendingSpecReviewPrompt
 	err           error
-	// Done-line metadata for the error path, where no final assistant row
-	// carries it (the success path marks the row itself).
+	// Turn metadata for settled rows that do not otherwise carry it.
 	turnTools   int
 	turnElapsed time.Duration
 }
@@ -799,6 +805,12 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.streamingText += msg.delta
 		return m, nil
+	case agentReasoningMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		m.streamingReasoning += msg.delta
+		return m, nil
 	case spinner.TickMsg:
 		// Not forwarding the tick while idle stops the spinner's self-scheduling,
 		// so no timer fires between runs.
@@ -934,12 +946,19 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.transcript = appendTranscriptRow(m.transcript, row)
 		}
 		for _, row := range msg.rows {
+			if row.kind == rowReasoning {
+				m.streamingReasoning = ""
+				m.streamingReasoningExpanded = false
+			}
 			m.transcript = appendTranscriptRow(m.transcript, row)
 		}
 		if msg.err != nil {
 			// A failed turn has no final answer row to supersede the streamed
 			// text the user already watched — keep the partial answer instead of
 			// letting it vanish from history.
+			if row, ok := reasoningTranscriptRow("", msg.runID, m.streamingReasoning); ok {
+				m.transcript = appendTranscriptRow(m.transcript, row)
+			}
 			if text := strings.TrimRight(m.streamingText, "\n"); strings.TrimSpace(text) != "" {
 				m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowAssistant, text: text})
 			}
@@ -954,6 +973,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		m.streamingText = ""
+		m.streamingReasoning = ""
+		m.streamingReasoningExpanded = false
 		if msg.specReview != nil {
 			m = m.activateSpecReview(*msg.specReview)
 		}
@@ -987,11 +1008,20 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.runID != m.activeRunID {
 			return m, nil
 		}
+		if msg.row.kind == rowReasoning {
+			m.streamingReasoning = ""
+			m.streamingReasoningExpanded = false
+		}
 		// A tool call ends the current streamed text segment. The segment is the
 		// assistant's working narration ("Let me check X…") — append it as a
 		// non-final assistant row so it stays in history instead of silently
 		// vanishing when the tool card replaces the interim block.
 		if msg.row.kind == rowToolCall {
+			if row, ok := reasoningTranscriptRow("", msg.runID, m.streamingReasoning); ok {
+				m.transcript = appendTranscriptRow(m.transcript, row)
+				m.streamingReasoning = ""
+				m.streamingReasoningExpanded = false
+			}
 			if text := strings.TrimRight(m.streamingText, "\n"); strings.TrimSpace(text) != "" {
 				m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowAssistant, text: text})
 			}
@@ -1259,15 +1289,24 @@ func (m model) chatPageScrollLines() int {
 // pending.
 func (m model) interimBlock(width int) string {
 	text := strings.TrimRight(m.streamingText, "\n")
+	reasoning := strings.TrimRight(m.streamingReasoning, "\n")
+	blocks := []string{}
+	if strings.TrimSpace(reasoning) != "" {
+		blocks = append(blocks, renderReasoningBlock(reasoning, m.streamingReasoningExpanded, width, true, 0))
+	}
 	if strings.TrimSpace(text) == "" {
+		if len(blocks) > 0 {
+			return strings.Join(blocks, "\n")
+		}
 		return m.spinner.View() + " " + zeroTheme.muted.Render("working…")
 	}
-	lines := renderAssistantMarkdownText(text, sayMeasure(width), width)
+	lines := renderAssistantMarkdownText(text, assistantMeasure(width), width)
 	for index, line := range lines {
-		lines[index] = styleAssistantMarkdownLine(line, zeroTheme.sayText)
+		lines[index] = styleAssistantMarkdownLine(line, zeroTheme.ink)
 	}
 	lines = appendStreamingCursor(lines, width)
-	return strings.Join(lines, "\n")
+	blocks = append(blocks, strings.Join(lines, "\n"))
+	return strings.Join(blocks, "\n")
 }
 
 func appendStreamingCursor(lines []string, width int) []string {
@@ -2124,6 +2163,9 @@ func (m *model) cancelRun() {
 		// A cancelled run must terminate visibly in the transcript: first the
 		// partial streamed answer (if any), then the cancellation marker — the
 		// session log gets the same marker below.
+		if row, ok := reasoningTranscriptRow("", m.activeRunID, m.streamingReasoning); ok {
+			m.transcript = appendTranscriptRow(m.transcript, row)
+		}
 		if text := strings.TrimRight(m.streamingText, "\n"); strings.TrimSpace(text) != "" {
 			m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowAssistant, text: text})
 		}
@@ -2144,6 +2186,8 @@ func (m *model) cancelRun() {
 	// The interim block renders streamingText live; a cancelled run's partial
 	// answer must not leak into (and concatenate with) the next turn's stream.
 	m.streamingText = ""
+	m.streamingReasoning = ""
+	m.streamingReasoningExpanded = false
 }
 
 func (m model) runAgent(runID int, runCtx context.Context, prompt string, images []zeroruntime.ImageBlock) tea.Cmd {
@@ -2222,21 +2266,48 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 			})
 		}
 
+		// Some providers synthesize tool-call ids that repeat within a run (e.g.
+		// Gemini restarts its gemini_tool_N numbering on every provider turn).
+		// Transcript rows need distinct ids for dedup and call→result collapse,
+		// so repeats get an ordinal suffix; session payloads keep the provider's
+		// original ids.
+		callSeq := map[string]int{}
+		reasoningText := ""
+		reasoningSeq := 0
+		var reasoningStarted time.Time
+		var reasoningLast time.Time
+		flushReasoning := func(closedAt time.Time) {
+			if row, ok := reasoningTranscriptRow(fmt.Sprintf("reasoning_%d", reasoningSeq+1), runID, reasoningText); ok {
+				if !reasoningStarted.IsZero() {
+					if closedAt.IsZero() {
+						closedAt = reasoningLast
+					}
+					if !reasoningLast.IsZero() && closedAt.Before(reasoningLast) {
+						closedAt = reasoningLast
+					}
+					if elapsed := closedAt.Sub(reasoningStarted); elapsed > 0 {
+						row.turnElapsed = elapsed
+					}
+				}
+				reasoningSeq++
+				rows = append(rows, row)
+				m.sendAgentRow(runID, row)
+			}
+			reasoningText = ""
+			reasoningStarted = time.Time{}
+			reasoningLast = time.Time{}
+		}
+
 		onText := options.OnText
 		options.OnText = func(delta string) {
+			if strings.TrimSpace(reasoningText) != "" {
+				flushReasoning(m.now())
+			}
 			m.sendAgentText(runID, delta)
 			if onText != nil {
 				onText(delta)
 			}
 		}
-		onReasoning := options.OnReasoning
-		options.OnReasoning = func(delta string) {
-			m.sendAgentText(runID, delta)
-			if onReasoning != nil {
-				onReasoning(delta)
-			}
-		}
-
 		onPermissionRequest := options.OnPermissionRequest
 		options.OnPermissionRequest = func(ctx context.Context, request agent.PermissionRequest) (agent.PermissionDecision, error) {
 			if onPermissionRequest != nil {
@@ -2313,15 +2384,25 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 			}
 		}
 
-		// Some providers synthesize tool-call ids that repeat within a run (e.g.
-		// Gemini restarts its gemini_tool_N numbering on every provider turn).
-		// Transcript rows need distinct ids for dedup and call→result collapse,
-		// so repeats get an ordinal suffix; session payloads keep the provider's
-		// original ids.
-		callSeq := map[string]int{}
+		onReasoning := options.OnReasoning
+		options.OnReasoning = func(delta string) {
+			now := m.now()
+			if strings.TrimSpace(reasoningText) == "" && strings.TrimSpace(delta) != "" {
+				reasoningStarted = now
+			}
+			if strings.TrimSpace(delta) != "" {
+				reasoningLast = now
+			}
+			reasoningText += delta
+			m.sendAgentReasoning(runID, delta)
+			if onReasoning != nil {
+				onReasoning(delta)
+			}
+		}
 
 		onToolCall := options.OnToolCall
 		options.OnToolCall = func(call agent.ToolCall) {
+			flushReasoning(m.now())
 			toolCalls++
 			callSeq[call.ID]++
 			row := transcriptRow{
@@ -2444,6 +2525,7 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 
 		result, err := agent.Run(runCtx, prompt, m.provider, options)
 		if err != nil {
+			flushReasoning(m.now())
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type:    sessions.EventError,
 				Payload: map[string]any{"message": err.Error()},
@@ -2453,20 +2535,24 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		if runOptions.specDraft {
 			if result.StopReason != agent.StopReasonSpecReviewRequired || specReview == nil || specReview.SpecID == "" || specReview.SpecFilePath == "" {
 				err := fmt.Errorf("spec draft ended without submit_spec")
+				flushReasoning(m.now())
 				sessionEvents = append(sessionEvents, pendingSessionEvent{
 					Type:    sessions.EventError,
 					Payload: map[string]any{"message": err.Error()},
 				})
 				return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, err: err, turnTools: toolCalls, turnElapsed: m.now().Sub(started)}
 			}
-			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, specReview: specReview}
+			flushReasoning(m.now())
+			return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, specReview: specReview, turnTools: toolCalls, turnElapsed: m.now().Sub(started)}
 		}
+		flushReasoning(m.now())
+		elapsed := m.now().Sub(started)
 		rows = append(rows, transcriptRow{
 			kind:        rowAssistant,
 			text:        result.FinalAnswer,
 			final:       true,
 			turnTools:   toolCalls,
-			turnElapsed: m.now().Sub(started),
+			turnElapsed: elapsed,
 		})
 		if notice := result.TruncationNotice(); notice != "" {
 			rows = append(rows, transcriptRow{kind: rowSystem, text: notice})
@@ -2478,7 +2564,7 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				"content": result.FinalAnswer,
 			},
 		})
-		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents}
+		return agentResponseMsg{runID: runID, rows: rows, usageEvents: usageEvents, usageModelID: usageModelID, sessionEvents: sessionEvents, turnTools: toolCalls, turnElapsed: elapsed}
 	}
 }
 
@@ -2518,6 +2604,13 @@ func (m model) sendAgentText(runID int, delta string) {
 		return
 	}
 	m.runtimeMessageSink(agentTextMsg{runID: runID, delta: delta})
+}
+
+func (m model) sendAgentReasoning(runID int, delta string) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(agentReasoningMsg{runID: runID, delta: delta})
 }
 
 func toolResultRowText(result agent.ToolResult) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -103,6 +103,67 @@ func TestPromptSubmitInjectsLiveSessionModelContext(t *testing.T) {
 	}
 }
 
+func TestPromptSubmitStoresReasoningSeparatelyFromAnswer(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventReasoning, Content: "private "},
+		{Type: zeroruntime.StreamEventReasoning, Content: "thought"},
+		{Type: zeroruntime.StreamEventText, Content: "public answer"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	m := newModel(context.Background(), Options{
+		Cwd:          t.TempDir(),
+		ProviderName: "tokenrouter",
+		ModelName:    "MiniMax-M3",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+	})
+	base := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+	times := []time.Time{
+		base,
+		base.Add(1 * time.Second),
+		base.Add(1800 * time.Millisecond),
+		base.Add(2500 * time.Millisecond),
+		base.Add(6 * time.Second),
+	}
+	m.now = func() time.Time {
+		if len(times) == 0 {
+			return base.Add(6 * time.Second)
+		}
+		next := times[0]
+		times = times[1:]
+		return next
+	}
+	m.input.SetValue("hello")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt submit to start an agent run")
+	}
+
+	updated, _ = next.Update(execCmd(cmd))
+	next = updated.(model)
+
+	reasoning, ok := findTranscriptRow(next.transcript, rowReasoning)
+	if !ok || reasoning.text != "private thought" {
+		t.Fatalf("reasoning row = %#v, ok=%v", reasoning, ok)
+	}
+	if reasoning.turnElapsed != 1500*time.Millisecond {
+		t.Fatalf("reasoning elapsed = %s, want 1.5s", reasoning.turnElapsed)
+	}
+	assistant, ok := findTranscriptRow(next.transcript, rowAssistant)
+	if !ok || assistant.text != "public answer" {
+		t.Fatalf("assistant row = %#v, ok=%v", assistant, ok)
+	}
+	if assistant.turnElapsed != 6*time.Second {
+		t.Fatalf("assistant elapsed = %s, want 6s", assistant.turnElapsed)
+	}
+	if strings.Contains(assistant.text, "private thought") {
+		t.Fatalf("assistant answer leaked reasoning: %#v", assistant)
+	}
+}
+
 func TestParseCommand(t *testing.T) {
 	cases := []struct {
 		input string

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -274,8 +274,8 @@ func TestTranscriptSelectionOnlyStartsOnTranscriptText(t *testing.T) {
 	updated, cmd = next.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
-		X:      0,
-		Y:      0,
+		X:      3,
+		Y:      1,
 	})
 	next = updated.(model)
 	if cmd != nil {
@@ -294,15 +294,15 @@ func TestTranscriptSelectionExtractsVisibleTextRange(t *testing.T) {
 	updated, _ := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
-		X:      0,
-		Y:      0,
+		X:      3,
+		Y:      1,
 	})
 	m = updated.(model)
 	updated, _ = m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionMotion,
-		X:      7,
-		Y:      0,
+		X:      8,
+		Y:      1,
 	})
 	m = updated.(model)
 
@@ -319,15 +319,15 @@ func TestTranscriptSelectionUpdatesOnGenericMotion(t *testing.T) {
 	updated, _ := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
-		X:      0,
-		Y:      0,
+		X:      3,
+		Y:      1,
 	})
 	m = updated.(model)
 	updated, _ = m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonNone,
 		Action: tea.MouseActionMotion,
-		X:      7,
-		Y:      0,
+		X:      8,
+		Y:      1,
 	})
 	m = updated.(model)
 
@@ -344,8 +344,8 @@ func TestTranscriptSelectionLeftDragDoesNotResetAnchor(t *testing.T) {
 	updated, _ := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
-		X:      0,
-		Y:      0,
+		X:      3,
+		Y:      1,
 	})
 	m = updated.(model)
 	// Bubble Tea marks left-button drag motion as Type MouseLeft for backward
@@ -354,8 +354,8 @@ func TestTranscriptSelectionLeftDragDoesNotResetAnchor(t *testing.T) {
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionMotion,
 		Type:   tea.MouseLeft,
-		X:      7,
-		Y:      0,
+		X:      8,
+		Y:      1,
 	})
 	m = updated.(model)
 
@@ -372,15 +372,15 @@ func TestTranscriptSelectionReleaseExtendsRangeWithoutMotion(t *testing.T) {
 	updated, _ := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionPress,
-		X:      0,
-		Y:      0,
+		X:      3,
+		Y:      1,
 	})
 	m = updated.(model)
 	updated, cmd := m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonNone,
 		Action: tea.MouseActionRelease,
-		X:      7,
-		Y:      0,
+		X:      8,
+		Y:      1,
 	})
 	m = updated.(model)
 	if cmd == nil {
@@ -405,6 +405,83 @@ func TestTranscriptSelectionClearsAfterCopy(t *testing.T) {
 	}
 	if next.copyStatus != "Copied!" {
 		t.Fatalf("copyStatus = %q, want Copied!", next.copyStatus)
+	}
+}
+
+func TestMouseClickTogglesReasoningRow(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowReasoning, text: "private thought"})
+
+	width := chatWidth(m.width)
+	body, selectable := m.transcriptBody(width, "")
+	start, _ := m.transcriptViewportStart(body, width)
+	var target transcriptSelectableLine
+	for _, line := range selectable {
+		if line.toggle {
+			target = line
+			break
+		}
+	}
+	if !target.toggle {
+		t.Fatalf("expected reasoning header to be clickable, selectable=%#v", selectable)
+	}
+
+	updated, cmd := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      target.textStart,
+		Y:      target.bodyY - start,
+	})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("reasoning toggle click should not return a command")
+	}
+	if !next.transcript[len(next.transcript)-1].expanded {
+		t.Fatalf("reasoning row should expand after click: %#v", next.transcript[len(next.transcript)-1])
+	}
+	if next.transcriptSelection.active {
+		t.Fatal("reasoning toggle should not start transcript selection")
+	}
+}
+
+func TestMouseClickTogglesStreamingReasoning(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.pending = true
+	m.activeRunID = 1
+	m.streamingReasoning = "private **thought**"
+
+	width := chatWidth(m.width)
+	body, selectable := m.transcriptBody(width, "")
+	start, _ := m.transcriptViewportStart(body, width)
+	var target transcriptSelectableLine
+	for _, line := range selectable {
+		if line.toggle && line.live {
+			target = line
+			break
+		}
+	}
+	if !target.toggle || !target.live {
+		t.Fatalf("expected live reasoning header to be clickable, selectable=%#v", selectable)
+	}
+
+	updated, cmd := m.Update(tea.MouseMsg{
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+		X:      target.textStart,
+		Y:      target.bodyY - start,
+	})
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("streaming reasoning toggle click should not return a command")
+	}
+	if !next.streamingReasoningExpanded {
+		t.Fatal("streaming reasoning should expand after click")
+	}
+	view := plainRender(t, next.interimBlock(width))
+	if !strings.Contains(view, "private thought") || strings.Contains(view, "**") {
+		t.Fatalf("expanded streaming reasoning should render markdown-clean text, got:\n%s", view)
 	}
 }
 

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -145,6 +145,7 @@ func (m model) renderRowCacheKey(row transcriptRow, width int, rc rowContext, op
 	appendRenderCacheField(&b, row.detail)
 	appendRenderCacheField(&b, row.arg)
 	appendRenderCacheField(&b, strconv.Itoa(row.runID))
+	appendRenderCacheField(&b, strconv.FormatBool(row.expanded))
 	appendRenderCacheField(&b, strconv.FormatBool(row.final))
 	appendRenderCacheField(&b, strconv.Itoa(row.turnTools))
 	appendRenderCacheField(&b, strconv.FormatInt(int64(row.turnElapsed), 10))

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
@@ -197,6 +198,8 @@ func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext
 		return renderUserRow(row, width)
 	case rowAssistant:
 		return renderAssistantRow(row, width)
+	case rowReasoning:
+		return renderReasoningRow(row, width)
 	case rowSystem:
 		if row.tool == "sessions" {
 			return renderSessionsCards(row.text, width)
@@ -275,12 +278,22 @@ func looksLikePath(value string) bool {
 	return strings.Contains(value, "/") || filepath.Ext(value) != ""
 }
 
-// sayMeasure is the prose wrap width for user/assistant text: min(width-4, 74).
+// sayMeasure is the narrow prose wrap width for compact secondary text.
 func sayMeasure(width int) int {
 	measure := width - 4
 	if measure > 74 {
 		measure = 74
 	}
+	if measure < 16 {
+		measure = 16
+	}
+	return measure
+}
+
+// assistantMeasure is the main answer wrap width. Assistant responses use the
+// available chat width so they visually balance full-width submitted prompts.
+func assistantMeasure(width int) int {
+	measure := width - 2
 	if measure < 16 {
 		measure = 16
 	}
@@ -359,15 +372,48 @@ func splitAtWidth(text string, measure int) (string, string) {
 }
 
 func renderUserRow(row transcriptRow, width int) string {
-	lines := wrapPlainText(row.text, sayMeasure(width))
-	for index, line := range lines {
-		if index == 0 {
-			lines[index] = zeroTheme.userPrompt.Render("❯ ") + zeroTheme.ink.Render(line)
-		} else {
-			lines[index] = "  " + zeroTheme.ink.Render(line)
-		}
+	contentWidth := userPromptContentWidth(width)
+	wrapped := wrapPlainText(row.text, maxInt(1, contentWidth))
+	lines := make([]string, 0, len(wrapped)+2)
+	lines = append(lines, renderUserPromptHalfLine(width, "▄"))
+	for _, line := range wrapped {
+		lines = append(lines, renderUserPromptStyledLine(zeroTheme.onUserPrompt(zeroTheme.ink.Bold(true)).Render(line), contentWidth))
 	}
+	lines = append(lines, renderUserPromptHalfLine(width, "▀"))
 	return strings.Join(lines, "\n")
+}
+
+const userPromptPrefix = "▌  "
+
+func userPromptContentWidth(width int) int {
+	if width <= 0 {
+		return 0
+	}
+	prefixWidth := lipgloss.Width(userPromptPrefix)
+	return maxInt(0, width-prefixWidth)
+}
+
+func renderUserPromptStyledLine(styledText string, contentWidth int) string {
+	if contentWidth <= 0 {
+		return zeroTheme.userPrompt.Render("▌")
+	}
+	fitted := fitStyledLine(styledText, contentWidth)
+	pad := zeroTheme.userPromptPanel.Render(strings.Repeat(" ", maxInt(0, contentWidth-lipgloss.Width(fitted))))
+	return zeroTheme.userPrompt.Render("▌") + zeroTheme.userPromptPanel.Render("  ") + fitted + pad
+}
+
+func renderUserPromptHalfLine(width int, glyph string) string {
+	if width <= 0 {
+		return ""
+	}
+	capGlyph := glyph
+	switch glyph {
+	case "▄":
+		capGlyph = "▖"
+	case "▀":
+		capGlyph = "▘"
+	}
+	return zeroTheme.userPrompt.Render(capGlyph) + zeroTheme.userPromptHalf.Render(strings.Repeat(glyph, maxInt(0, width-1)))
 }
 
 // renderAssistantRow draws the turn's final answer with the accent rail
@@ -378,7 +424,7 @@ func renderAssistantRow(row transcriptRow, width int) string {
 	if row.final {
 		tableMeasure = maxInt(16, width-2)
 	}
-	lines := renderAssistantMarkdownText(row.text, sayMeasure(width), tableMeasure)
+	lines := renderAssistantMarkdownText(row.text, assistantMeasure(width), tableMeasure)
 	if !row.final {
 		for index := range lines {
 			lines[index] = styleAssistantMarkdownLine(lines[index], zeroTheme.sayText)
@@ -392,16 +438,75 @@ func renderAssistantRow(row transcriptRow, width int) string {
 	return strings.Join(lines, "\n")
 }
 
+func renderReasoningRow(row transcriptRow, width int) string {
+	return renderReasoningBlock(row.text, row.expanded, width, false, row.turnElapsed)
+}
+
+func renderReasoningBlock(text string, expanded bool, width int, running bool, elapsed time.Duration) string {
+	text = strings.TrimSpace(text)
+	if strings.TrimSpace(text) == "" {
+		return ""
+	}
+	header := reasoningHeaderLine(text, expanded, running, elapsed)
+	if !expanded {
+		return fitStyledLine(header, width)
+	}
+	lines := []string{fitStyledLine(header, width)}
+	for _, line := range renderReasoningBodyLines(text, width) {
+		lines = append(lines, fitStyledLine("  "+styleAssistantMarkdownLine(line, zeroTheme.sayText), width))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderReasoningBodyLines(text string, width int) []string {
+	measure := maxInt(16, sayMeasure(width)-2)
+	return renderAssistantMarkdownText(strings.TrimSpace(text), measure, measure)
+}
+
+func reasoningHeaderLine(text string, expanded bool, running bool, elapsed time.Duration) string {
+	return zeroTheme.faint.Render(reasoningHeaderText(text, expanded, running, elapsed))
+}
+
+func reasoningHeaderText(text string, expanded bool, running bool, elapsed time.Duration) string {
+	icon, label := reasoningHeaderParts(text, expanded, running, elapsed)
+	if icon == "" {
+		return label
+	}
+	return icon + " " + label
+}
+
+func reasoningHeaderParts(_ string, expanded bool, running bool, elapsed time.Duration) (string, string) {
+	if running {
+		return "", "Thinking"
+	}
+	icon := "▸"
+	if expanded {
+		icon = "▾"
+	}
+	label := "Thought"
+	if elapsed > 0 {
+		label = fmt.Sprintf("Thought for %s", formatElapsedSeconds(elapsed))
+	}
+	return icon, label
+}
+
+func formatElapsedSeconds(elapsed time.Duration) string {
+	return fmt.Sprintf("%.1fs", elapsed.Seconds())
+}
+
 // doneLine renders the turn terminator: ● green (red on error) plus faint
 // counters. Segments the turn has no data for are omitted, never invented.
 func doneLine(row transcriptRow, failed bool) string {
 	glyph := zeroTheme.green.Render("●")
-	label := "done"
+	label := "completed"
 	if failed {
 		glyph = zeroTheme.red.Render("●")
 		label = "error"
 	}
 	segments := []string{zeroTheme.faint.Render(label)}
+	if !failed && row.turnElapsed > 0 {
+		segments[0] = zeroTheme.faint.Render(fmt.Sprintf("completed in %s", formatElapsedSeconds(row.turnElapsed)))
+	}
 	if row.turnTools > 0 {
 		noun := "tools"
 		if row.turnTools == 1 {
@@ -409,8 +514,8 @@ func doneLine(row transcriptRow, failed bool) string {
 		}
 		segments = append(segments, zeroTheme.faint.Render(fmt.Sprintf("%d %s", row.turnTools, noun)))
 	}
-	if row.turnElapsed > 0 {
-		segments = append(segments, zeroTheme.faint.Render(fmt.Sprintf("%.1fs", row.turnElapsed.Seconds())))
+	if failed && row.turnElapsed > 0 {
+		segments = append(segments, zeroTheme.faint.Render(formatElapsedSeconds(row.turnElapsed)))
 	}
 	return glyph + " " + strings.Join(segments, zeroTheme.faintest.Render(" · "))
 }

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -35,8 +35,22 @@ func TestUserRowRendersPromptGutter(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{kind: rowUser, text: "add a --version flag"}
 	got := plainRender(t, m.renderRow(row, 96, buildRowContext(nil)))
-	if !strings.HasPrefix(got, "❯ add a --version flag") {
-		t.Fatalf("user row = %q, want ❯-prefixed text", got)
+	if !strings.Contains(got, "\n▌  add a --version flag") {
+		t.Fatalf("user row = %q, want rail-prefixed text", got)
+	}
+}
+
+func TestTranscriptSeparatesUserPromptFromContinuation(t *testing.T) {
+	m := limeTestModel()
+	m.headerPrinted = true
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: "hey"})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowReasoning, text: "private thought"})
+
+	body, _ := m.transcriptBody(96, "")
+	got := plainRender(t, body)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 5 || !strings.HasPrefix(lines[1], "▌  hey") || lines[3] != "" || !strings.HasPrefix(lines[4], "▸ Thought") {
+		t.Fatalf("transcript body should keep a small gap before thought, got:\n%s", got)
 	}
 }
 
@@ -309,8 +323,54 @@ func TestFinalAnswerRendersRailAndDoneLine(t *testing.T) {
 	if !strings.Contains(got, "│ Done — the CLI now prints its version.") {
 		t.Fatalf("final row = %q, want accent-rail gutter", got)
 	}
-	if !strings.Contains(got, "● done · 2 tools · 8.4s") {
-		t.Fatalf("final row = %q, want done line with counters", got)
+	if !strings.Contains(got, "● completed in 8.4s · 2 tools") {
+		t.Fatalf("final row = %q, want completion line with counters", got)
+	}
+}
+
+func TestReasoningRowIsCollapsedByDefaultAndExpands(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{kind: rowReasoning, text: "\n\nprivate **chain**\nsecond line"}
+
+	collapsed := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if !strings.Contains(collapsed, "▸ Thought") {
+		t.Fatalf("collapsed reasoning row missing summary:\n%s", collapsed)
+	}
+	if strings.Contains(collapsed, "private chain") {
+		t.Fatalf("collapsed reasoning row leaked content:\n%s", collapsed)
+	}
+
+	row.expanded = true
+	expanded := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if !strings.Contains(expanded, "▾ Thought") || !strings.Contains(expanded, "private chain") {
+		t.Fatalf("expanded reasoning row missing content:\n%s", expanded)
+	}
+	if strings.Contains(expanded, "**") {
+		t.Fatalf("expanded reasoning row leaked markdown markers:\n%s", expanded)
+	}
+	lines := strings.Split(expanded, "\n")
+	if len(lines) < 2 || strings.TrimSpace(lines[1]) == "" {
+		t.Fatalf("expanded reasoning row should start content immediately after header:\n%s", expanded)
+	}
+}
+
+func TestReasoningRowShowsElapsedWhenKnown(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind:        rowReasoning,
+		text:        "private thought",
+		turnElapsed: 2300 * time.Millisecond,
+	}
+
+	collapsed := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if !strings.Contains(collapsed, "▸ Thought for 2.3s") {
+		t.Fatalf("collapsed reasoning row missing elapsed:\n%s", collapsed)
+	}
+
+	row.expanded = true
+	expanded := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if !strings.Contains(expanded, "▾ Thought for 2.3s") {
+		t.Fatalf("expanded reasoning row missing elapsed:\n%s", expanded)
 	}
 }
 
@@ -344,8 +404,8 @@ func TestFinalAnswerRendersMarkdownTableForTerminal(t *testing.T) {
 	if !strings.Contains(got, " │ ") || !strings.Contains(got, "─┼─") {
 		t.Fatalf("markdown table should render terminal table separators, got:\n%s", got)
 	}
-	if !strings.Contains(got, "● done") {
-		t.Fatalf("markdown final row = %q, want done line terminator", got)
+	if !strings.Contains(got, "● completed") {
+		t.Fatalf("markdown final row = %q, want completed line terminator", got)
 	}
 	for index, line := range strings.Split(rendered, "\n") {
 		if gotWidth := lipgloss.Width(line); gotWidth > 72 {
@@ -469,8 +529,8 @@ func TestFinalAnswerRendersCrowdedMarkdownTablesAsTables(t *testing.T) {
 
 func TestDoneLineOmitsMissingSegments(t *testing.T) {
 	got := plainRender(t, doneLine(transcriptRow{final: true}, false))
-	if got != "● done" {
-		t.Fatalf("done line without counters = %q, want plain ● done", got)
+	if got != "● completed" {
+		t.Fatalf("done line without counters = %q, want plain ● completed", got)
 	}
 	if got := plainRender(t, doneLine(transcriptRow{final: true, turnTools: 1}, false)); !strings.Contains(got, "1 tool") || strings.Contains(got, "1 tools") {
 		t.Fatalf("done line = %q, want singular tool noun", got)

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -374,6 +374,23 @@ func TestReasoningRowShowsElapsedWhenKnown(t *testing.T) {
 	}
 }
 
+func TestSelectableExpandedReasoningRowsAreClamped(t *testing.T) {
+	m := limeTestModel()
+	const width = 28
+	row := transcriptRow{
+		kind:     rowReasoning,
+		text:     strings.Repeat("unbroken", 10),
+		expanded: true,
+	}
+
+	rendered, _ := m.renderSelectableReasoningRow(0, row, width, 0)
+	for _, line := range strings.Split(rendered, "\n") {
+		if got := lipgloss.Width(plainRender(t, line)); got > width {
+			t.Fatalf("line width = %d, want <= %d:\n%s", got, width, rendered)
+		}
+	}
+}
+
 func TestFinalAnswerRendersMarkdownTableForTerminal(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -65,7 +65,9 @@ type tuiTheme struct {
 	permBorder lipgloss.Style // permission card border (amber-mixed line)
 
 	// Surfaces.
-	panel lipgloss.Style // bare panel background (card padding, body fill)
+	panel           lipgloss.Style // bare panel background (card padding, body fill)
+	userPromptPanel lipgloss.Style // submitted user prompt background
+	userPromptHalf  lipgloss.Style // submitted prompt half-block padding
 
 	// Permission modes.
 	modeAuto   lipgloss.Style
@@ -83,6 +85,7 @@ const (
 	colorPanel    = "#0e0e10" // card backgrounds
 	colorPanel2   = "#121215" // card header rows, picker rows
 	colorPanel3   = "#17171b" // selected/hovered row bg
+	colorPromptBg = "#262626" // submitted user prompt background
 	colorLine     = "#242429" // default borders, rules
 	colorLine2    = "#414147" // emphasized borders
 	colorInk      = "#ececee" // primary text
@@ -151,7 +154,9 @@ var zeroTheme = tuiTheme{
 	permBg:     lipgloss.NewStyle().Background(lipgloss.Color(colorPermBg)),
 	permBorder: lipgloss.NewStyle().Foreground(lipgloss.Color(colorCardPerm)),
 
-	panel: lipgloss.NewStyle().Background(lipgloss.Color(colorPanel)),
+	panel:           lipgloss.NewStyle().Background(lipgloss.Color(colorPanel)),
+	userPromptPanel: lipgloss.NewStyle().Background(lipgloss.Color(colorPromptBg)),
+	userPromptHalf:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorPromptBg)),
 
 	modeAuto:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)).Bold(true),
 	modeAsk:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)).Bold(true),
@@ -164,6 +169,11 @@ var zeroTheme = tuiTheme{
 // wrap their foreground styles through this instead of referencing hex.
 func (t tuiTheme) onPanel(style lipgloss.Style) lipgloss.Style {
 	return style.Background(lipgloss.Color(colorPanel))
+}
+
+// onUserPrompt paints on the submitted user-prompt surface.
+func (t tuiTheme) onUserPrompt(style lipgloss.Style) lipgloss.Style {
+	return style.Background(lipgloss.Color(colorPromptBg))
 }
 
 // onPanel2 paints on the header/picker-row surface.

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -16,6 +16,7 @@ const (
 	rowWelcome rowKind = iota
 	rowUser
 	rowAssistant
+	rowReasoning
 	rowToolCall
 	rowToolResult
 	rowPermission
@@ -35,6 +36,7 @@ type transcriptRow struct {
 	runID      int          // owning run, for tool call rows (0 = rehydrated/unknown)
 	permission *agent.PermissionEvent
 	askUser    *agent.AskUserRequest
+	expanded   bool // collapsible transcript rows, e.g. provider thoughts
 
 	// Final-answer metadata, set at append time. Interim assistant text streams
 	// through model.streamingText and never lands in the transcript, so a
@@ -124,6 +126,10 @@ func transcriptRowKey(row transcriptRow) string {
 		if row.id != "" {
 			return fmt.Sprintf("%d:%d:%s", row.kind, row.runID, row.id)
 		}
+	case rowReasoning:
+		if row.id != "" {
+			return fmt.Sprintf("%d:%d:%s", row.kind, row.runID, row.id)
+		}
 	case rowPermission:
 		if row.permission != nil && row.permission.ToolCallID != "" {
 			return fmt.Sprintf("%d:%d:%s:%s", row.kind, row.runID, row.permission.ToolCallID, row.permission.Action)
@@ -139,6 +145,28 @@ func transcriptRowKey(row transcriptRow) string {
 		}
 	}
 	return ""
+}
+
+func reasoningTranscriptRow(id string, runID int, text string) (transcriptRow, bool) {
+	text = strings.TrimRight(text, "\n")
+	if strings.TrimSpace(text) == "" {
+		return transcriptRow{}, false
+	}
+	return transcriptRow{kind: rowReasoning, id: id, runID: runID, text: text}, true
+}
+
+func previousVisibleTranscriptKind(rows []transcriptRow, before int, rc rowContext) (rowKind, bool) {
+	if before > len(rows) {
+		before = len(rows)
+	}
+	for index := before - 1; index >= 0; index-- {
+		row := rows[index]
+		if row.kind == rowWelcome || rc.skip(row) {
+			continue
+		}
+		return row.kind, true
+	}
+	return rowWelcome, false
 }
 
 // effectiveToolRowID disambiguates a provider tool-call id that repeats within

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -26,6 +27,8 @@ type transcriptSelectableLine struct {
 	rowIndex  int
 	textStart int
 	text      string
+	toggle    bool
+	live      bool
 }
 
 type transcriptCopiedMsg struct {
@@ -63,6 +66,7 @@ func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcr
 	} else {
 		rc := buildRowContext(m.transcript)
 		shownAny := false
+		previousKind, havePreviousKind := previousVisibleTranscriptKind(m.transcript, m.flushed, rc)
 		for index := m.flushed; index < len(m.transcript); index++ {
 			row := m.transcript[index]
 			// A welcome row carries no Lime visual (the empty state replaced it)
@@ -75,11 +79,16 @@ func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcr
 			if (shownAny || m.flushedAny) && startsTurn(row.kind) {
 				appendBlank()
 			}
+			if (shownAny || (m.flushedAny && havePreviousKind)) && previousKind == rowUser && row.kind == rowReasoning {
+				appendBlank()
+			}
 			start := len(lines)
 			rendered, rowSelectable := m.renderTranscriptRow(index, row, width, rc, start)
 			appendBlock(rendered)
 			selectable = append(selectable, rowSelectable...)
 			shownAny = true
+			previousKind = row.kind
+			havePreviousKind = true
 		}
 	}
 
@@ -91,7 +100,8 @@ func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcr
 		case m.pendingAskUser != nil:
 			appendBlock(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
 		default:
-			appendBlock(m.interimBlock(width))
+			start := appendBlock(m.interimBlock(width))
+			selectable = append(selectable, m.renderSelectableStreamingReasoning(width, start)...)
 		}
 	}
 	if m.pendingSpecReview != nil {
@@ -108,29 +118,30 @@ func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, r
 		return m.renderSelectableUserRow(rowIndex, row, width, startBodyY)
 	case rowAssistant:
 		return m.renderSelectableAssistantRow(rowIndex, row, width, startBodyY)
+	case rowReasoning:
+		return m.renderSelectableReasoningRow(rowIndex, row, width, startBodyY)
 	default:
 		return m.renderRow(row, width, rc), nil
 	}
 }
 
 func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
-	wrapped := wrapPlainText(row.text, sayMeasure(width))
-	lines := make([]string, 0, len(wrapped))
+	contentWidth := userPromptContentWidth(width)
+	wrapped := wrapPlainText(row.text, maxInt(1, contentWidth))
+	lines := make([]string, 0, len(wrapped)+2)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
+	lines = append(lines, renderUserPromptHalfLine(width, "▄"))
 	for index, line := range wrapped {
-		prefix := "  "
-		if index == 0 {
-			prefix = "❯ "
-		}
 		meta := transcriptSelectableLine{
-			bodyY:     startBodyY + index,
+			bodyY:     startBodyY + index + 1,
 			rowIndex:  rowIndex,
-			textStart: lipgloss.Width(prefix),
+			textStart: lipgloss.Width(userPromptPrefix),
 			text:      line,
 		}
 		selectable = append(selectable, meta)
-		lines = append(lines, zeroTheme.userPrompt.Render(prefix)+m.renderTranscriptSelectableText(meta, zeroTheme.ink))
+		lines = append(lines, renderUserPromptStyledLine(m.renderTranscriptSelectableText(meta, zeroTheme.onUserPrompt(zeroTheme.ink.Bold(true))), contentWidth))
 	}
+	lines = append(lines, renderUserPromptHalfLine(width, "▀"))
 	return strings.Join(lines, "\n"), selectable
 }
 
@@ -139,7 +150,7 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 	if row.final {
 		tableMeasure = maxInt(16, width-2)
 	}
-	wrapped := renderAssistantMarkdownText(row.text, sayMeasure(width), tableMeasure)
+	wrapped := renderAssistantMarkdownText(row.text, assistantMeasure(width), tableMeasure)
 	lines := make([]string, 0, len(wrapped)+1)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
 	prefix := ""
@@ -167,6 +178,64 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 		lines = append(lines, doneLine(row, false))
 	}
 	return strings.Join(lines, "\n"), selectable
+}
+
+func (m model) renderSelectableReasoningRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
+	lines, selectable := m.renderSelectableReasoningBlock(rowIndex, row.text, row.expanded, false, row.turnElapsed, width, startBodyY)
+	return strings.Join(lines, "\n"), selectable
+}
+
+func (m model) renderSelectableStreamingReasoning(width int, startBodyY int) []transcriptSelectableLine {
+	_, selectable := m.renderSelectableReasoningBlock(-1, m.streamingReasoning, m.streamingReasoningExpanded, true, 0, width, startBodyY)
+	for index := range selectable {
+		selectable[index].live = true
+	}
+	return selectable
+}
+
+func (m model) renderSelectableReasoningBlock(rowIndex int, text string, expanded bool, running bool, elapsed time.Duration, width int, startBodyY int) ([]string, []transcriptSelectableLine) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil, nil
+	}
+	headerPlain := reasoningHeaderText(text, expanded, running, elapsed)
+	header := reasoningHeaderLine(text, expanded, running, elapsed)
+	headerMeta := transcriptSelectableLine{
+		bodyY:     startBodyY,
+		rowIndex:  rowIndex,
+		textStart: 0,
+		text:      headerPlain,
+		toggle:    true,
+	}
+	headerRendered := header
+	if _, _, ok := m.selectedColumnsForTranscriptLine(headerMeta); ok {
+		headerRendered = m.renderTranscriptSelectableText(headerMeta, zeroTheme.faint)
+	}
+	lines := []string{headerRendered}
+	selectable := []transcriptSelectableLine{headerMeta}
+	if expanded {
+		renderedLines := renderReasoningBodyLines(text, width)
+		plainLines := renderAssistantMarkdownPlainText(text, maxInt(16, sayMeasure(width)-2), maxInt(16, sayMeasure(width)-2))
+		for index, line := range renderedLines {
+			plainLine := ""
+			if index < len(plainLines) {
+				plainLine = plainLines[index]
+			}
+			meta := transcriptSelectableLine{
+				bodyY:     startBodyY + index + 1,
+				rowIndex:  rowIndex,
+				textStart: 2,
+				text:      plainLine,
+			}
+			selectable = append(selectable, meta)
+			rendered := styleAssistantMarkdownLine(line, zeroTheme.sayText)
+			if _, _, ok := m.selectedColumnsForTranscriptLine(meta); ok {
+				rendered = m.renderTranscriptSelectableText(meta, zeroTheme.sayText)
+			}
+			lines = append(lines, "  "+rendered)
+		}
+	}
+	return lines, selectable
 }
 
 func (m model) renderTranscriptSelectableMarkdownText(line transcriptSelectableLine, styledText string, base lipgloss.Style) string {
@@ -287,6 +356,14 @@ func (m model) handleTranscriptSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd,
 			}
 			return m, nil, false
 		}
+		if line.toggle {
+			if line.live {
+				m.streamingReasoningExpanded = !m.streamingReasoningExpanded
+			} else {
+				m = m.toggleReasoningRow(line.rowIndex)
+			}
+			return m, nil, true
+		}
 		point := transcriptSelectionPointForMouse(line, msg.X)
 		m.copyStatus = ""
 		m.transcriptSelection = transcriptSelectionState{active: true, anchor: point, cursor: point}
@@ -316,6 +393,14 @@ func (m model) handleTranscriptSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd,
 	default:
 		return m, nil, false
 	}
+}
+
+func (m model) toggleReasoningRow(rowIndex int) model {
+	if rowIndex < 0 || rowIndex >= len(m.transcript) || m.transcript[rowIndex].kind != rowReasoning {
+		return m
+	}
+	m.transcript[rowIndex].expanded = !m.transcript[rowIndex].expanded
+	return m
 }
 
 func (m model) selectedTranscriptText() string {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -232,7 +232,7 @@ func (m model) renderSelectableReasoningBlock(rowIndex int, text string, expande
 			if _, _, ok := m.selectedColumnsForTranscriptLine(meta); ok {
 				rendered = m.renderTranscriptSelectableText(meta, zeroTheme.sayText)
 			}
-			lines = append(lines, "  "+rendered)
+			lines = append(lines, fitStyledLine("  "+rendered, width))
 		}
 	}
 	return lines, selectable

--- a/internal/tui/transcript_view.go
+++ b/internal/tui/transcript_view.go
@@ -23,6 +23,7 @@ func (m model) detailedTranscriptView() string {
 	builder.WriteString("\n")
 
 	shownAny := false
+	var previousKind rowKind
 	for _, row := range m.transcript {
 		if rc.skip(row) {
 			continue
@@ -39,9 +40,13 @@ func (m model) detailedTranscriptView() string {
 		if shownAny && startsTurn(row.kind) {
 			builder.WriteString("\n")
 		}
+		if shownAny && previousKind == rowUser && row.kind == rowReasoning {
+			builder.WriteString("\n")
+		}
 		builder.WriteString(rendered)
 		builder.WriteString("\n")
 		shownAny = true
+		previousKind = row.kind
 	}
 
 	if !shownAny {


### PR DESCRIPTION
Summary:
- improves TUI transcript rendering for submitted prompts, markdown tables, reasoning/thought blocks, and completion status text
- keeps OpenAI-compatible reasoning content out of normal answer text and shows it as expandable Thought/Thinking content
- tightens composer and selection behavior around transcript copy, command/file pickers, and prompt display

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui ./internal/providers/openai
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added separate, expandable “Reasoning” transcript blocks with clickable headers, selectable/live streaming support, and updated transcript spacing.
  * Added optional inline `<think>...</think>` parsing that can split streamed content into reasoning vs plain text based on provider profile/model defaults.

* **Bug Fixes**
  * Improved streaming buffering to flush partial output consistently on idle, errors, malformed payloads, and context cancellation.
  * Refined TUI rendering (elapsed time, “completed” wording) and cache behavior for expanded rows.

* **Tests**
  * Added streaming and parsing tests for OpenAI “think” handling and context-cancellation behavior; updated TUI rendering/mouse-selection expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->