### PR TITLE
Add command dashboard cards

### DIFF
--- a/internal/tui/command_output.go
+++ b/internal/tui/command_output.go
@@ -53,6 +53,19 @@ type commandCardSection struct {
 	Rows   []commandRow
 }
 
+const commandCardTranscriptPrefix = "\x00command-card\x00"
+
+func renderCommandCardTranscript(card commandCard) string {
+	return commandCardTranscriptPrefix + renderCommandCard(card)
+}
+
+func commandCardTranscriptPayload(text string) (string, bool) {
+	if !strings.HasPrefix(text, commandCardTranscriptPrefix) {
+		return text, false
+	}
+	return strings.TrimPrefix(text, commandCardTranscriptPrefix), true
+}
+
 func renderCommandCard(card commandCard) string {
 	lines := []string{}
 

--- a/internal/tui/command_output.go
+++ b/internal/tui/command_output.go
@@ -39,6 +39,92 @@ type commandRow struct {
 	Text string
 }
 
+type commandCard struct {
+	Title    string
+	Summary  []string
+	Sections []commandCardSection
+	Actions  []string
+}
+
+type commandCardSection struct {
+	Title  string
+	Fields []commandField
+	Lines  []string
+	Rows   []commandRow
+}
+
+func renderCommandCard(card commandCard) string {
+	lines := []string{}
+
+	title := compactCommandOutputText(card.Title)
+	if title == "" {
+		title = "Zero"
+	}
+	lines = append(lines, title)
+
+	if summary := compactCommandCardList(card.Summary); len(summary) > 0 {
+		lines = append(lines, strings.Join(summary, " | "))
+	}
+
+	for _, section := range card.Sections {
+		lines = append(lines, formatCommandCardSection(section)...)
+	}
+
+	if actions := compactCommandCardList(card.Actions); len(actions) > 0 {
+		lines = append(lines, "actions: "+strings.Join(actions, " | "))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func formatCommandCardSection(section commandCardSection) []string {
+	lines := []string{}
+
+	if title := compactCommandOutputText(section.Title); title != "" {
+		lines = append(lines, title)
+	}
+
+	keyWidth := 0
+	fields := make([]commandField, 0, len(section.Fields))
+	for _, field := range section.Fields {
+		key := compactCommandOutputText(field.Key)
+		value := compactCommandOutputText(field.Value)
+		if key == "" || value == "" {
+			continue
+		}
+		if len(key) > keyWidth {
+			keyWidth = len(key)
+		}
+		fields = append(fields, commandField{Key: key, Value: value})
+	}
+	for _, field := range fields {
+		lines = append(lines, "  "+field.Key+strings.Repeat(" ", keyWidth-len(field.Key)+2)+field.Value)
+	}
+
+	for _, line := range section.Lines {
+		if text := compactCommandOutputText(line); text != "" {
+			lines = append(lines, "  "+text)
+		}
+	}
+	for _, row := range section.Rows {
+		if text := compactCommandOutputText(row.Text); text != "" {
+			lines = append(lines, "  - "+text)
+		}
+	}
+
+	return lines
+}
+
+func compactCommandCardList(values []string) []string {
+	compacted := make([]string, 0, len(values))
+	for _, value := range values {
+		if text := compactCommandOutputText(value); text != "" {
+			compacted = append(compacted, text)
+		}
+	}
+	return compacted
+}
+
 func formatCommandOutput(output commandOutput) string {
 	lines := []string{}
 

--- a/internal/tui/command_output_test.go
+++ b/internal/tui/command_output_test.go
@@ -87,6 +87,43 @@ func TestFormatCommandCardRendersBoundedDashboard(t *testing.T) {
 	}
 }
 
+func TestFormatCommandCardRedactsTokenLikeText(t *testing.T) {
+	got := renderCommandCard(commandCard{
+		Title:   "Context",
+		Summary: []string{"provider sk-proj-summary-secret-value"},
+		Sections: []commandCardSection{
+			{
+				Title: "Runtime",
+				Fields: []commandField{
+					{Key: "api key", Value: "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"},
+				},
+				Lines: []string{
+					"google token AIza1234567890abcdef",
+				},
+				Rows: []commandRow{
+					{Text: "shell used sk-proj-row-secret-value"},
+				},
+			},
+		},
+		Actions: []string{"retry with sk-proj-action-secret-value"},
+	})
+
+	for _, secret := range []string{
+		"sk-proj-summary-secret-value",
+		"sk-ant-api03-abcdefghijklmnopqrstuvwxyz",
+		"AIza1234567890abcdef",
+		"sk-proj-row-secret-value",
+		"sk-proj-action-secret-value",
+	} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("expected token-like text to be redacted, got:\n%s", got)
+		}
+	}
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("expected redacted marker in command card, got:\n%s", got)
+	}
+}
+
 func TestFormatCommandOutputSupportsAllStatuses(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/tui/command_output_test.go
+++ b/internal/tui/command_output_test.go
@@ -49,6 +49,44 @@ func TestFormatCommandOutputRendersSectionsFieldsRowsAndHints(t *testing.T) {
 	}
 }
 
+func TestFormatCommandCardRendersBoundedDashboard(t *testing.T) {
+	got := renderCommandCard(commandCard{
+		Title:   "Context",
+		Summary: []string{"go runtime", "ask permissions", "1 tool"},
+		Sections: []commandCardSection{
+			{
+				Title: "Runtime",
+				Fields: []commandField{
+					{Key: "cwd", Value: `D:\repo`},
+					{Key: "provider", Value: "openai"},
+				},
+			},
+			{
+				Title: "Tools",
+				Fields: []commandField{
+					{Key: "registered", Value: "1"},
+				},
+			},
+		},
+		Actions: []string{"/permissions manage access", "/tools inspect catalog"},
+	})
+
+	want := strings.Join([]string{
+		"Context",
+		"go runtime | ask permissions | 1 tool",
+		"Runtime",
+		"  cwd       D:\\repo",
+		"  provider  openai",
+		"Tools",
+		"  registered  1",
+		"actions: /permissions manage access | /tools inspect catalog",
+	}, "\n")
+
+	if got != want {
+		t.Fatalf("unexpected command card:\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
 func TestFormatCommandOutputSupportsAllStatuses(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -161,6 +161,18 @@ func TestToolsCommandRendersCommandCard(t *testing.T) {
 	assertNotContains(t, toolsText, "registered tools:")
 }
 
+func TestToolsCommandCardHandlesNilRegistry(t *testing.T) {
+	text := model{}.toolsText()
+
+	for _, want := range []string{
+		"Tools",
+		"0 registered | no tools available",
+		"registered  0",
+	} {
+		assertContains(t, text, want)
+	}
+}
+
 func TestToolsCommandShowsFullSortedCatalog(t *testing.T) {
 	registry := tools.NewRegistry()
 	for _, name := range []string{
@@ -291,6 +303,19 @@ func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
 		assertContains(t, permissionText, want)
 	}
 	assertNotContains(t, permissionText, "sk-proj-sensitive")
+}
+
+func TestContextCommandCardHandlesNilRegistryAndStableStyle(t *testing.T) {
+	text := model{}.contextText()
+
+	for _, want := range []string{
+		"Context",
+		"0 tools",
+		"style      balanced",
+		"root        unknown",
+	} {
+		assertContains(t, text, want)
+	}
 }
 
 func TestCompactCommandAvoidsShellOnlyPlaceholder(t *testing.T) {

--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -140,9 +140,24 @@ func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
 		t.Fatal("expected /context to be handled without starting an agent run")
 	}
 	contextText := transcriptText(next.transcript)
-	for _, want := range []string{"Context", "status: ok", "Runtime", "Session", "Tools", "cwd: D:\\codings\\Opensource\\Zero", "registered tools: 1"} {
+	for _, want := range []string{
+		"Context",
+		"go runtime | ask permissions | 1 tool",
+		"Runtime",
+		"cwd        D:\\codings\\Opensource\\Zero",
+		"provider   openai",
+		"model      gpt-4.1",
+		"Session",
+		"active      none",
+		"compaction  idle",
+		"Tools",
+		"registered  1",
+		"actions: /permissions manage access | /tools inspect catalog",
+	} {
 		assertContains(t, contextText, want)
 	}
+	assertNotContains(t, contextText, "status: ok")
+	assertNotContains(t, contextText, "permission mode:")
 
 	next.input.SetValue("/permissions")
 	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})

--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -107,6 +107,127 @@ func TestProviderCommandRedactsCredentialBearingBaseURL(t *testing.T) {
 	assertContains(t, text, "base url: https://proxy.local/v1?api_key=[REDACTED]")
 }
 
+func TestToolsCommandRendersCommandCard(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Registry: tools.NewRegistry(),
+	})
+	m.input.SetValue("/tools")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /tools to be handled without starting an agent run")
+	}
+	emptyText := transcriptText(next.transcript)
+	for _, want := range []string{
+		"Tools",
+		"0 registered | no tools available",
+		"Registry",
+		"registered  0",
+		"actions: /mcp manage servers | /permissions manage access",
+	} {
+		assertContains(t, emptyText, want)
+	}
+	assertNotContains(t, emptyText, "status: warning")
+	assertNotContains(t, emptyText, "registered tools:")
+
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewReadFileTool("."))
+	m = newModel(context.Background(), Options{
+		Registry: registry,
+	})
+	m.input.SetValue("/tools")
+
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /tools to be handled without starting an agent run")
+	}
+	toolsText := transcriptText(next.transcript)
+	for _, want := range []string{
+		"Tools",
+		"1 registered | registered catalog",
+		"Registry",
+		"registered  1",
+		"Available",
+		"- read_file",
+		"actions: /mcp manage servers | /permissions manage access",
+	} {
+		assertContains(t, toolsText, want)
+	}
+	assertNotContains(t, toolsText, "status: ok")
+	assertNotContains(t, toolsText, "registered tools:")
+}
+
+func TestToolsCommandShowsFullSortedCatalog(t *testing.T) {
+	registry := tools.NewRegistry()
+	for _, name := range []string{
+		"write_file",
+		"read_file",
+		"grep",
+		"glob",
+		"edit_file",
+		"apply_patch",
+		"bash",
+		"web_search",
+		"web_fetch",
+	} {
+		registry.Register(commandTestMCPTool{name: name, description: name + " tool"})
+	}
+
+	m := newModel(context.Background(), Options{
+		Registry: registry,
+	})
+	m.input.SetValue("/tools")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("expected /tools to be handled without starting an agent run")
+	}
+	text := transcriptText(next.transcript)
+	for _, want := range []string{
+		"9 registered | registered catalog",
+		"- apply_patch",
+		"- bash",
+		"- edit_file",
+		"- glob",
+		"- grep",
+		"- read_file",
+		"- web_fetch",
+		"- web_search",
+		"- write_file",
+	} {
+		assertContains(t, text, want)
+	}
+	assertNotContains(t, text, "... 1 more")
+
+	previous := -1
+	for _, want := range []string{
+		"- apply_patch",
+		"- bash",
+		"- edit_file",
+		"- glob",
+		"- grep",
+		"- read_file",
+		"- web_fetch",
+		"- web_search",
+		"- write_file",
+	} {
+		current := strings.Index(text, want)
+		if current < 0 {
+			t.Fatalf("expected tools output to contain %q, got:\n%s", want, text)
+		}
+		if current <= previous {
+			t.Fatalf("expected tools output to keep sorted order at %q, got:\n%s", want, text)
+		}
+		previous = current
+	}
+}
+
 func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewReadFileTool("."))

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -462,39 +462,58 @@ func (m model) modelText(args string) string {
 
 func (m model) contextText() string {
 	toolCount := len(m.registry.All())
-	return renderCommandOutput(commandOutput{
-		Title:  "Context",
-		Status: commandStatusOK,
-		Sections: []commandSection{
+	return renderCommandCard(commandCard{
+		Title: "Context",
+		Summary: []string{
+			"go runtime",
+			string(m.permissionMode) + " permissions",
+			pluralizeCount(toolCount, "tool", "tools"),
+		},
+		Sections: []commandCardSection{
 			{
 				Title: "Runtime",
-				Lines: []string{
-					"cwd: " + displayValue(m.cwd, "unknown"),
-					"provider: " + displayValue(m.providerName, "none"),
-					"model: " + displayValue(m.modelName, "none"),
-					"permission mode: " + string(m.permissionMode),
-					"effort: " + m.effortDisplay(),
-					"style: " + m.responseStyle,
-					"usage: " + m.usageSummaryText(),
-					fmt.Sprintf("max turns: %d", m.agentOptions.MaxTurns),
+				Fields: []commandField{
+					{Key: "cwd", Value: displayValue(m.cwd, "unknown")},
+					{Key: "provider", Value: displayValue(m.providerName, "none")},
+					{Key: "model", Value: displayValue(m.modelName, "none")},
+					{Key: "effort", Value: m.effortDisplay()},
+					{Key: "style", Value: m.responseStyle},
+					{Key: "usage", Value: m.usageSummaryText()},
+					{Key: "max turns", Value: fmt.Sprint(m.agentOptions.MaxTurns)},
 				},
 			},
 			{
 				Title: "Session",
-				Lines: []string{
-					"active session: " + displayValue(m.activeSession.SessionID, "none"),
-					"session root: " + displayValue(m.sessionStore.RootDir, "unknown"),
-					"compaction: " + m.compactionStatus(),
+				Fields: []commandField{
+					{Key: "active", Value: displayValue(m.activeSession.SessionID, "none")},
+					{Key: "root", Value: displayValue(m.sessionStore.RootDir, "unknown")},
+					{Key: "compaction", Value: contextCompactionStatus(m.compactionStatus())},
 				},
 			},
 			{
 				Title: "Tools",
-				Lines: []string{
-					fmt.Sprintf("registered tools: %d", toolCount),
+				Fields: []commandField{
+					{Key: "registered", Value: fmt.Sprint(toolCount)},
 				},
 			},
 		},
+		Actions: []string{"/permissions manage access", "/tools inspect catalog"},
 	})
+}
+
+func pluralizeCount(count int, singular string, plural string) string {
+	label := plural
+	if count == 1 {
+		label = singular
+	}
+	return fmt.Sprintf("%d %s", count, label)
+}
+
+func contextCompactionStatus(status string) string {
+	if status == "not compacted" {
+		return "idle"
+	}
+	return status
 }
 
 func (m model) configText() string {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zerocommands"
 )
 
 func (m model) toolsText() string {
-	registered := m.registry.All()
+	registered := m.registeredTools()
 	count := len(registered)
 	if len(registered) == 0 {
 		return renderCommandCardTranscript(commandCard{
@@ -473,7 +474,7 @@ func (m model) modelText(args string) string {
 }
 
 func (m model) contextText() string {
-	toolCount := len(m.registry.All())
+	toolCount := len(m.registeredTools())
 	return renderCommandCardTranscript(commandCard{
 		Title: "Context",
 		Summary: []string{
@@ -489,7 +490,7 @@ func (m model) contextText() string {
 					{Key: "provider", Value: displayValue(m.providerName, "none")},
 					{Key: "model", Value: displayValue(m.modelName, "none")},
 					{Key: "effort", Value: m.effortDisplay()},
-					{Key: "style", Value: m.responseStyle},
+					{Key: "style", Value: displayValue(m.responseStyle, defaultResponseStyle)},
 					{Key: "usage", Value: m.usageSummaryText()},
 					{Key: "max turns", Value: fmt.Sprint(m.agentOptions.MaxTurns)},
 				},
@@ -498,7 +499,7 @@ func (m model) contextText() string {
 				Title: "Session",
 				Fields: []commandField{
 					{Key: "active", Value: displayValue(m.activeSession.SessionID, "none")},
-					{Key: "root", Value: displayValue(m.sessionStore.RootDir, "unknown")},
+					{Key: "root", Value: displayValue(m.sessionRootDir(), "unknown")},
 					{Key: "compaction", Value: contextCompactionStatus(m.compactionStatus())},
 				},
 			},
@@ -511,6 +512,20 @@ func (m model) contextText() string {
 		},
 		Actions: []string{"/permissions manage access", "/tools inspect catalog"},
 	})
+}
+
+func (m model) registeredTools() []tools.Tool {
+	if m.registry == nil {
+		return nil
+	}
+	return m.registry.All()
+}
+
+func (m model) sessionRootDir() string {
+	if m.sessionStore == nil {
+		return ""
+	}
+	return m.sessionStore.RootDir
 }
 
 func pluralizeCount(count int, singular string, plural string) string {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -17,7 +17,7 @@ func (m model) toolsText() string {
 	registered := m.registry.All()
 	count := len(registered)
 	if len(registered) == 0 {
-		return renderCommandCard(commandCard{
+		return renderCommandCardTranscript(commandCard{
 			Title:   "Tools",
 			Summary: []string{"0 registered", "no tools available"},
 			Sections: []commandCardSection{{
@@ -40,7 +40,7 @@ func (m model) toolsText() string {
 		available = append(available, commandBullet(name))
 	}
 
-	return renderCommandCard(commandCard{
+	return renderCommandCardTranscript(commandCard{
 		Title:   "Tools",
 		Summary: []string{fmt.Sprintf("%d registered", count), "registered catalog"},
 		Sections: []commandCardSection{
@@ -474,7 +474,7 @@ func (m model) modelText(args string) string {
 
 func (m model) contextText() string {
 	toolCount := len(m.registry.All())
-	return renderCommandCard(commandCard{
+	return renderCommandCardTranscript(commandCard{
 		Title: "Context",
 		Summary: []string{
 			"go runtime",

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -15,35 +15,47 @@ import (
 
 func (m model) toolsText() string {
 	registered := m.registry.All()
+	count := len(registered)
 	if len(registered) == 0 {
-		return renderCommandOutput(commandOutput{
-			Title:  "Tools",
-			Status: commandStatusWarning,
-			Sections: []commandSection{{
+		return renderCommandCard(commandCard{
+			Title:   "Tools",
+			Summary: []string{"0 registered", "no tools available"},
+			Sections: []commandCardSection{{
 				Title: "Registry",
-				Lines: []string{"registered tools: 0"},
+				Fields: []commandField{
+					{Key: "registered", Value: "0"},
+				},
 			}},
+			Actions: []string{"/mcp manage servers", "/permissions manage access"},
 		})
 	}
 
-	names := make([]string, 0, len(registered))
+	names := make([]string, 0, count)
 	for _, tool := range registered {
-		names = append(names, commandBullet(tool.Name()))
+		names = append(names, tool.Name())
 	}
 	sort.Strings(names)
-	return renderCommandOutput(commandOutput{
-		Title:  "Tools",
-		Status: commandStatusOK,
-		Sections: []commandSection{
+	available := make([]string, 0, len(names))
+	for _, name := range names {
+		available = append(available, commandBullet(name))
+	}
+
+	return renderCommandCard(commandCard{
+		Title:   "Tools",
+		Summary: []string{fmt.Sprintf("%d registered", count), "registered catalog"},
+		Sections: []commandCardSection{
 			{
 				Title: "Registry",
-				Lines: []string{fmt.Sprintf("registered tools: %d", len(names))},
+				Fields: []commandField{
+					{Key: "registered", Value: fmt.Sprint(count)},
+				},
 			},
 			{
 				Title: "Available",
-				Lines: names,
+				Lines: available,
 			},
 		},
+		Actions: []string{"/mcp manage servers", "/permissions manage access"},
 	})
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -408,12 +408,12 @@ func TestContextCommandShowsSessionState(t *testing.T) {
 	}
 	for _, want := range []string{
 		`D:\codings\Opensource\Zero`,
-		"provider: openai",
-		"model: gpt-4.1",
-		"permission mode: ask",
-		"max turns:",
-		"session root:",
-		"registered tools: 1",
+		"go runtime | ask permissions | 1 tool",
+		"provider   openai",
+		"model      gpt-4.1",
+		"max turns  ",
+		"root        ",
+		"registered  1",
 	} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected context transcript to contain %q, got %#v", want, next.transcript)

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -442,7 +442,7 @@ func renderCommandCardRow(text string, width int) string {
 		case isCommandCardHeading(trimmed):
 			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
 		case strings.HasPrefix(trimmed, "actions:"):
-			lines = append(lines, zeroTheme.accent.Render("actions:")+zeroTheme.ink.Render(strings.TrimPrefix(line, "actions:")))
+			lines = append(lines, zeroTheme.accent.Render("actions:")+zeroTheme.ink.Render(strings.TrimPrefix(trimmed, "actions:")))
 		case strings.HasPrefix(trimmed, "- "):
 			lines = append(lines, zeroTheme.ink.Render(line))
 		default:

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -198,6 +198,9 @@ func (m model) renderRowModeUncached(row transcriptRow, width int, rc rowContext
 	case rowAssistant:
 		return renderAssistantRow(row, width)
 	case rowSystem:
+		if payload, ok := commandCardTranscriptPayload(row.text); ok {
+			return renderCommandCardRow(payload, width)
+		}
 		if row.tool == "sessions" {
 			return renderSessionsCards(row.text, width)
 		}
@@ -419,6 +422,44 @@ func doneLine(row transcriptRow, failed bool) string {
 // the panel surface inside a line border. Content is passed through unchanged.
 func renderSystemNote(text string, width int) string {
 	return noteBox(text, width, zeroTheme.line, zeroTheme.onPanel(zeroTheme.faint))
+}
+
+func renderCommandCardRow(text string, width int) string {
+	raw := strings.Split(strings.TrimRight(strings.ReplaceAll(text, "\r\n", "\n"), "\n"), "\n")
+	if len(raw) == 0 {
+		return renderSystemNote(text, width)
+	}
+
+	title := strings.TrimSpace(raw[0])
+	lines := make([]string, 0, len(raw)-1)
+	for index, line := range raw[1:] {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "":
+			lines = append(lines, "")
+		case index == 0:
+			lines = append(lines, zeroTheme.ink.Bold(true).Render(line))
+		case isCommandCardHeading(trimmed):
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
+		case strings.HasPrefix(trimmed, "actions:"):
+			lines = append(lines, zeroTheme.accent.Render("actions:")+zeroTheme.ink.Render(strings.TrimPrefix(line, "actions:")))
+		case strings.HasPrefix(trimmed, "- "):
+			lines = append(lines, zeroTheme.ink.Render(line))
+		default:
+			lines = append(lines, zeroTheme.muted.Render(line))
+		}
+	}
+	return styledBlockFillTitle(width, title, lines, zeroTheme.accent, lipgloss.NewStyle())
+}
+
+func isCommandCardHeading(value string) bool {
+	if value == "" {
+		return false
+	}
+	if strings.HasPrefix(value, "- ") || strings.HasPrefix(value, "actions:") {
+		return false
+	}
+	return !strings.Contains(value, " | ") && !strings.Contains(value, "  ")
 }
 
 func renderMCPManagerCard(text string, width int) string {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -92,6 +92,26 @@ func TestCommandCardRowRendersAsTitledCard(t *testing.T) {
 	}
 }
 
+func TestCommandCardRowTrimsIndentedActionsLabel(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowSystem,
+		text: commandCardTranscriptPrefix + strings.Join([]string{
+			"Tools",
+			"2 registered | registered catalog",
+			"  actions: /mcp manage servers | /permissions manage access",
+		}, "\n"),
+	}
+
+	got := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if strings.Contains(got, "actions:  actions:") {
+		t.Fatalf("command card duplicated indented actions label:\n%s", got)
+	}
+	if !strings.Contains(got, "actions: /mcp manage servers | /permissions manage access") {
+		t.Fatalf("command card missing actions line:\n%s", got)
+	}
+}
+
 func TestInterimBlockShowsStreamingTextWithCursor(t *testing.T) {
 	m := limeTestModel()
 	m.pending = true

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -40,6 +40,58 @@ func TestUserRowRendersPromptGutter(t *testing.T) {
 	}
 }
 
+func TestCommandCardRowRendersAsTitledCard(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind: rowSystem,
+		text: renderCommandCardTranscript(commandCard{
+			Title:   "Tools",
+			Summary: []string{"2 registered", "registered catalog"},
+			Sections: []commandCardSection{
+				{
+					Title: "Registry",
+					Fields: []commandField{
+						{Key: "registered", Value: "2"},
+					},
+				},
+				{
+					Title: "Available",
+					Lines: []string{
+						commandBullet("bash"),
+						commandBullet("read_file"),
+					},
+				},
+			},
+			Actions: []string{"/mcp manage servers", "/permissions manage access"},
+		}),
+	}
+
+	got := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	lines := strings.Split(got, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("command card rendered too few lines:\n%s", got)
+	}
+	if !strings.Contains(lines[0], "Tools") {
+		t.Fatalf("command card title should render in the border, got:\n%s", got)
+	}
+	if strings.Contains(got, "│ Tools") {
+		t.Fatalf("command card should not render the title as muted body text, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"2 registered | registered catalog",
+		"Registry",
+		"registered  2",
+		"Available",
+		"- bash",
+		"- read_file",
+		"actions: /mcp manage servers | /permissions manage access",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("command card missing %q in:\n%s", want, got)
+		}
+	}
+}
+
 func TestInterimBlockShowsStreamingTextWithCursor(t *testing.T) {
 	m := limeTestModel()
 	m.pending = true

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -541,7 +541,7 @@ func TestUsageEventsUpdateFooterAndContext(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected /context to be handled without starting an agent run")
 	}
-	for _, want := range []string{"usage: 1 request, 120 tokens", "style: balanced", "effort: auto", "compaction: not compacted"} {
+	for _, want := range []string{"usage      1 request, 120 tokens", "style      balanced", "effort     auto", "compaction  idle"} {
 		if !transcriptContains(next.transcript, want) {
 			t.Fatalf("expected context transcript to contain %q, got %#v", want, next.transcript)
 		}


### PR DESCRIPTION
## Summary

- add a reusable command-card renderer for bounded command dashboards
- migrate `/context` and `/tools` away from raw `status: ...` command dumps
- render command-card transcript rows as styled titled cards instead of muted system notes
- add regression coverage for card redaction, sorted `/tools` output, and action-line rendering

## Why

Several slash commands looked unchanged because they still flowed through the generic grey `rowSystem` note renderer. This PR makes the first command-card surfaces visibly product-like: titled card border, summary line, section headings, aligned fields, bullets, and actions.

The scope stays intentionally small so it does not collide with active doctor, sandbox/permissions, or transcript polish PRs.

## Validation

- `go test ./internal/tui -run 'TestCommandCardRowTrimsIndentedActionsLabel|TestCommandCardRowRendersAsTitledCard' -count=1`
- `go test ./internal/tui -run Tools -count=1`
- `go test ./internal/tui -count=1`
- `go test ./...`
- `go vet ./...`
- `go run ./cmd/zero-release build`
- `go run ./cmd/zero-release smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned `/tools` command display with organized card layout showing registry status and tool counts.
  * Redesigned `/context` command with improved information organization across Runtime, Session, and Tools sections.
  * Added aligned field formatting and action buttons to command displays.
  * Enhanced visual presentation with better structured command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->