### PR TITLE
fix(sandbox): web_search/web_fetch hard-denied under default network policy

### DIFF
--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -149,6 +149,19 @@ func (engine *Engine) NetworkHostAllowed(host string) (bool, NetworkMode) {
 	}
 }
 
+// toolNetworkExempt reports whether a request is exempt from the engine-level
+// network deny because it is a first-party, in-process network TOOL — one that
+// declares SideEffectNetwork (web_search / web_fetch) — and the operator has not
+// opted into EnforceToolNetwork. Such tools do not use the sandboxed shell's
+// egress; they keep their own SSRF/host safeguards, and NetworkHostAllowed (also
+// gated by EnforceToolNetwork) governs them at run time. A SHELL command merely
+// classified as network (SideEffectShell) is NOT exempt, so shell egress stays
+// blocked under deny. Mirrors the NetworkHostAllowed exemption so the Evaluate
+// gate and the per-tool gate never diverge.
+func (engine *Engine) toolNetworkExempt(policy Policy, request Request) bool {
+	return !policy.EnforceToolNetwork && request.SideEffect == SideEffectNetwork
+}
+
 // scopeFor returns the scope to validate request paths against. The engine's
 // shared scope applies only when the request targets the engine's own
 // workspace root; a per-request override root gets an ad-hoc single-root scope
@@ -281,7 +294,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	// than running with unrestricted networking. Shared with NetworkHostAllowed so
 	// the per-tool gate can't diverge from this decision. Allow is unchanged.
 	netMode := engine.effectiveNetworkMode(policy)
-	if netMode == NetworkDeny && HasRiskCategory(risk, "network") {
+	if netMode == NetworkDeny && HasRiskCategory(risk, "network") && !engine.toolNetworkExempt(policy, request) {
 		return deny(request, risk, ViolationNetwork, "", "network access is blocked by sandbox policy", false)
 	}
 	if policy.DenyDestructiveShell && HasRiskCategory(risk, "destructive") {

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -9,6 +9,53 @@ import (
 	"time"
 )
 
+// TestEvaluateExemptsNetworkToolsFromDenyByDefault reproduces the web_search
+// hard-deny: under NetworkDeny, the engine-level network gate must NOT deny a
+// first-party network TOOL (SideEffect=network) by default, so it follows the
+// normal permission flow instead of being blocked outright. EnforceToolNetwork
+// restores the strict deny, and a network SHELL command stays denied either way.
+func TestEvaluateExemptsNetworkToolsFromDenyByDefault(t *testing.T) {
+	base := Policy{Mode: ModeEnforce, Network: NetworkDeny, MaxAutonomy: AutonomyHigh}
+
+	// Default (EnforceToolNetwork off): web_search is NOT network-denied.
+	engine := NewEngine(EngineOptions{Policy: base})
+	d := engine.Evaluate(context.Background(), Request{
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt,
+	})
+	if d.Action == ActionDeny {
+		t.Fatalf("web_search must not be network-denied by default, got deny: %s", d.ErrorString())
+	}
+
+	// Granted permission → it actually runs (ActionAllow), not blocked.
+	allowed := engine.Evaluate(context.Background(), Request{
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt, PermissionGranted: true,
+	})
+	if allowed.Action != ActionAllow {
+		t.Fatalf("granted web_search must be allowed under deny by default, got %q (%s)", allowed.Action, allowed.ErrorString())
+	}
+
+	// EnforceToolNetwork on → strict: the network tool is denied at the gate.
+	strict := base
+	strict.EnforceToolNetwork = true
+	strictEngine := NewEngine(EngineOptions{Policy: strict})
+	ds := strictEngine.Evaluate(context.Background(), Request{
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt, PermissionGranted: true,
+	})
+	if ds.Action != ActionDeny || ds.Violation == nil || ds.Violation.Code != ViolationNetwork {
+		t.Fatalf("with EnforceToolNetwork, web_search must be network-denied, got %q (%+v)", ds.Action, ds.Violation)
+	}
+
+	// A network SHELL command (SideEffect=shell) stays denied under deny — shell
+	// egress is never exempt, even with EnforceToolNetwork off.
+	shell := engine.Evaluate(context.Background(), Request{
+		ToolName: "bash", SideEffect: SideEffectShell, PermissionGranted: true,
+		Args: map[string]any{"command": "curl https://evil.test"},
+	})
+	if shell.Action != ActionDeny || shell.Violation == nil || shell.Violation.Code != ViolationNetwork {
+		t.Fatalf("a network shell command must stay denied under deny, got %q (%+v)", shell.Action, shell.Violation)
+	}
+}
+
 func TestEngineEvaluatesReadPromptAndPersistentDecisions(t *testing.T) {
 	root := t.TempDir()
 	store, err := NewGrantStore(StoreOptions{
@@ -295,7 +342,11 @@ func TestEngineClassifiesNetworkAndDestructiveShellCommands(t *testing.T) {
 }
 
 func TestEngineDeniesNetworkSideEffectWhenPolicyBlocksNetwork(t *testing.T) {
-	engine := NewEngine(EngineOptions{WorkspaceRoot: t.TempDir(), Policy: DefaultPolicy()})
+	// EnforceToolNetwork opts the in-process network tools into the policy; by
+	// default they are exempt (see TestEvaluateExemptsNetworkToolsFromDenyByDefault).
+	policy := DefaultPolicy()
+	policy.EnforceToolNetwork = true
+	engine := NewEngine(EngineOptions{WorkspaceRoot: t.TempDir(), Policy: policy})
 
 	decision := engine.Evaluate(context.Background(), Request{
 		ToolName:       "web_fetch",

--- a/internal/sandbox/runner_scoped_test.go
+++ b/internal/sandbox/runner_scoped_test.go
@@ -23,8 +23,17 @@ func TestScopedNetworkGateInEvaluate(t *testing.T) {
 	}
 	sandboxExec := Backend{Name: BackendSandboxExec, Available: true, Executable: "/usr/sbin/sandbox-exec", ScopedEgress: true}
 
+	// This test exercises the network GATE for a network tool, so it opts the
+	// in-process tools into the network policy (EnforceToolNetwork); by default
+	// those tools are exempt and would not be gated here.
+	enforcedScoped := func(allowed, denied []string) Policy {
+		p := scopedPolicy(allowed, denied)
+		p.EnforceToolNetwork = true
+		return p
+	}
+
 	// An enforcing backend lets a populated scoped policy permit a network tool.
-	enforcing := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil), Backend: sandboxExec})
+	enforcing := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: enforcedScoped([]string{"github.com"}, nil), Backend: sandboxExec})
 	if decision := enforcing.Evaluate(context.Background(), networkRequest); decision.Action == ActionDeny {
 		t.Fatalf("enforcing backend + scoped policy denied a network tool: %#v", decision)
 	}
@@ -35,7 +44,7 @@ func TestScopedNetworkGateInEvaluate(t *testing.T) {
 		"policy-only": {},
 	}
 	for name, backend := range unenforceable {
-		engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil), Backend: backend})
+		engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: enforcedScoped([]string{"github.com"}, nil), Backend: backend})
 		decision := engine.Evaluate(context.Background(), networkRequest)
 		if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationNetwork {
 			t.Fatalf("%s backend must deny scoped network it cannot enforce, got %#v", name, decision)
@@ -43,7 +52,7 @@ func TestScopedNetworkGateInEvaluate(t *testing.T) {
 	}
 
 	// Empty allowlist still fails closed regardless of backend.
-	empty := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy(nil, nil), Backend: sandboxExec})
+	empty := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: enforcedScoped(nil, nil), Backend: sandboxExec})
 	decision := empty.Evaluate(context.Background(), networkRequest)
 	if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationNetwork {
 		t.Fatalf("empty scoped policy must deny network like NetworkDeny, got %#v", decision)


### PR DESCRIPTION
## Problem
With the default sandbox policy (`network: deny`), `web_search` (and `web_fetch`) are **hard-denied** before they run:

```
denied · web_search · risk:high — network access is blocked by sandbox policy
Sandbox violation [network] for web_search: network access is blocked by sandbox policy
```

#199 added `EnforceToolNetwork` (off by default) to exempt the first-party in-process network tools, but it only relaxed `NetworkHostAllowed` — the per-host check *inside* the tool's `RunWithSandbox`. The actual deny happens **earlier**, at the engine-level gate in `Evaluate` (run by the tool registry): a request whose risk includes `network` under `NetworkDeny` is rejected *before* the tool executes. So the tool never reached the relaxed check. (#199 merged at the commit just before this follow-up, so the gap shipped to `main`.)

## Fix
`Evaluate` now skips the network-deny for a request that declares `SideEffectNetwork` (the first-party in-process tools `web_search`/`web_fetch`) when `EnforceToolNetwork` is off — mirroring the `NetworkHostAllowed` exemption so the engine-level gate and the per-tool gate agree. A **shell** command merely classified as network (`SideEffect=shell`, e.g. `curl`) is **not** exempt, so sandboxed-shell egress stays blocked under deny. Setting `EnforceToolNetwork: true` restores the strict deny for the tools.

Net effect: `web_search`/`web_fetch` are no longer hard-blocked by the sandbox; they follow the normal permission flow (prompt in ask mode → run on allow; run in auto mode).

## Tests
- `TestEvaluateExemptsNetworkToolsFromDenyByDefault` — full path: default → not denied; granted → `allow`; `EnforceToolNetwork=true` → denied; network **shell** command → stays denied.
- `TestEngineDeniesNetworkSideEffectWhenPolicyBlocksNetwork` and `TestScopedNetworkGateInEvaluate` updated to opt into `EnforceToolNetwork` (they test the strict gate).

## Gates (local)
`gofmt -l .` empty · `go vet` · `go build` · `go test ./...` (incl. `-race` on sandbox+tools) · `staticcheck` no new findings · `govulncheck` 0 · `deadcode -test=false` no new unreachable funcs.

Scoped to the sandbox fix only — 3 files (`engine.go`, `engine_test.go`, `runner_scoped_test.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network tools are now exempt from network-deny policies by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->