### PR TITLE
feat(daemon): zero daemon — worker pool + session supervisor over a local control socket

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -240,6 +240,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 	case "exec":
 		// Forward leading --add-dir occurrences so exec's own parser collects them.
 		return runExec(append(addDirFlagArgs(addDirs), args[1:]...), stdout, stderr, deps)
+	case "daemon":
+		return runDaemon(args[1:], stdout, stderr, deps)
 	case "config":
 		return runConfig(args[1:], stdout, stderr, deps)
 	case "models":

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -649,6 +649,7 @@ Usage:
 
 Commands:
   exec       Run a one-shot prompt through the Go agent runtime
+  daemon     Manage the local background worker daemon (start/stop/status/run/attach)
   setup      Guide first-run provider setup
   config     Inspect resolved Go configuration without leaking secrets
   models     List Zero model registry entries

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -161,6 +161,9 @@ func runDaemonStop(args []string, stdout io.Writer, stderr io.Writer) int {
 	if helpRequested(args) {
 		return writeDaemonUsage(stdout, exitSuccess)
 	}
+	if len(args) > 0 {
+		return writeExecUsageError(stderr, "daemon stop takes no arguments")
+	}
 	paths, err := daemon.DefaultPaths()
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
@@ -181,6 +184,9 @@ func runDaemonStop(args []string, stdout io.Writer, stderr io.Writer) int {
 func runDaemonStatus(args []string, stdout io.Writer, stderr io.Writer) int {
 	if helpRequested(args) {
 		return writeDaemonUsage(stdout, exitSuccess)
+	}
+	if len(args) > 0 {
+		return writeExecUsageError(stderr, "daemon status takes no arguments")
 	}
 	paths, err := daemon.DefaultPaths()
 	if err != nil {
@@ -272,16 +278,22 @@ func runDaemonRun(args []string, stdout io.Writer, stderr io.Writer) int {
 
 func runDaemonAttach(args []string, stdout io.Writer, stderr io.Writer) int {
 	session := ""
+	extra := 0
 	for _, a := range args {
 		if a == "-h" || a == "--help" {
 			return writeDaemonUsage(stdout, exitSuccess)
 		}
 		if session == "" {
 			session = a
+			continue
 		}
+		extra++
 	}
 	if strings.TrimSpace(session) == "" {
 		return writeExecUsageError(stderr, "daemon attach requires a <session> id")
+	}
+	if extra > 0 {
+		return writeExecUsageError(stderr, "daemon attach accepts exactly one <session> id")
 	}
 	paths, err := daemon.DefaultPaths()
 	if err != nil {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1,0 +1,319 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/daemon"
+)
+
+// runDaemon dispatches the `zero daemon ...` subcommands. The daemon supervises a
+// pool of headless `zero exec` workers and routes sessions to them over an
+// owner-only local control socket. It is an ADDITIVE surface — interactive and
+// one-shot exec are unchanged.
+func runDaemon(args []string, stdout io.Writer, stderr io.Writer, _ appDeps) int {
+	if len(args) == 0 {
+		return writeDaemonUsage(stderr, exitUsage)
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "start":
+		return runDaemonStart(rest, stdout, stderr)
+	case "stop":
+		return runDaemonStop(rest, stdout, stderr)
+	case "status":
+		return runDaemonStatus(rest, stdout, stderr)
+	case "run":
+		return runDaemonRun(rest, stdout, stderr)
+	case "attach":
+		return runDaemonAttach(rest, stdout, stderr)
+	case "-h", "--help", "help":
+		return writeDaemonUsage(stdout, exitSuccess)
+	default:
+		fmt.Fprintf(stderr, "unknown daemon subcommand %q\n", sub)
+		return writeDaemonUsage(stderr, exitUsage)
+	}
+}
+
+func writeDaemonUsage(w io.Writer, code int) int {
+	fmt.Fprint(w, `Usage: zero daemon <command>
+
+Commands:
+  start [--foreground]      Start the daemon (background by default).
+  stop                      Gracefully stop the running daemon.
+  status                    Show daemon / pool / session status.
+  run --session <id> [--cwd <dir>] [--prompt <text>] [exec flags...]
+                            Create/route a session and stream its output.
+  attach <session>          Attach to a running session's stream.
+`)
+	return code
+}
+
+// runDaemonStart starts the daemon. Without --foreground it spawns a detached
+// background process running the foreground daemon and returns once it is up.
+func runDaemonStart(args []string, stdout io.Writer, stderr io.Writer) int {
+	foreground := false
+	for _, a := range args {
+		switch a {
+		case "--foreground", "-f":
+			foreground = true
+		case "-h", "--help":
+			return writeDaemonUsage(stdout, exitSuccess)
+		default:
+			return writeExecUsageError(stderr, fmt.Sprintf("unknown flag %q for daemon start", a))
+		}
+	}
+	paths, err := daemon.DefaultPaths()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if foreground {
+		return runDaemonForeground(paths, stdout, stderr)
+	}
+	return runDaemonStartDetached(paths, stdout, stderr)
+}
+
+// runDaemonForeground runs the daemon in this process until SIGINT/SIGTERM. Each
+// worker is a headless `zero exec` child with the sandbox re-entrancy markers
+// scrubbed (NewExecLauncher) so it establishes its own sandbox.
+func runDaemonForeground(paths daemon.Paths, stdout io.Writer, stderr io.Writer) int {
+	launcher, err := daemon.NewExecLauncher(daemon.ExecLauncherConfig{})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	logf := func(line string) { fmt.Fprintln(stderr, "[daemon] "+line) }
+	pool, err := daemon.NewPool(daemon.PoolOptions{Launcher: launcher, Log: logf})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	mgr, err := daemon.NewSessionManager(daemon.SessionManagerOptions{Pool: pool})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	srv, err := daemon.NewServer(daemon.ServerOptions{Paths: paths, Manager: mgr, Pool: pool, Log: logf})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		srv.Shutdown()
+	}()
+
+	if err := srv.Serve(); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	return exitSuccess
+}
+
+// runDaemonStartDetached spawns the foreground daemon as a detached background
+// process (its own process group, output to a log file) and waits for it to bind.
+func runDaemonStartDetached(paths daemon.Paths, stdout io.Writer, stderr io.Writer) int {
+	if daemonReachable(paths) {
+		fmt.Fprintln(stdout, "zero daemon is already running")
+		return exitSuccess
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.Socket), 0o700); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	logPath := filepath.Join(filepath.Dir(paths.Socket), "daemon.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	defer logFile.Close()
+
+	cmd := exec.Command(exe, "daemon", "start", "--foreground")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	background.ConfigureChildProcessGroup(cmd) // own process group: outlives this shell
+	if err := cmd.Start(); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	_ = cmd.Process.Release()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if daemonReachable(paths) {
+			fmt.Fprintf(stdout, "zero daemon started (socket %s)\n", paths.Socket)
+			return exitSuccess
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return writeAppError(stderr, "daemon did not come up within timeout; see "+logPath, exitCrash)
+}
+
+func runDaemonStop(args []string, stdout io.Writer, stderr io.Writer) int {
+	if helpRequested(args) {
+		return writeDaemonUsage(stdout, exitSuccess)
+	}
+	paths, err := daemon.DefaultPaths()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	client, err := daemon.Dial(paths.Socket)
+	if err != nil {
+		fmt.Fprintln(stdout, "zero daemon is not running")
+		return exitSuccess
+	}
+	defer client.Close()
+	if err := client.Shutdown(); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	fmt.Fprintln(stdout, "zero daemon stopped")
+	return exitSuccess
+}
+
+func runDaemonStatus(args []string, stdout io.Writer, stderr io.Writer) int {
+	if helpRequested(args) {
+		return writeDaemonUsage(stdout, exitSuccess)
+	}
+	paths, err := daemon.DefaultPaths()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	client, err := daemon.Dial(paths.Socket)
+	if err != nil {
+		fmt.Fprintln(stdout, "zero daemon is not running")
+		return exitSuccess
+	}
+	defer client.Close()
+	report, err := client.Status()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	fmt.Fprintf(stdout, "daemon pid=%d version=%d socket=%s\n", report.PID, report.Version, report.Socket)
+	fmt.Fprintf(stdout, "pool size=%d busy=%d queue=%d\n", report.PoolSize, len(report.Workers), report.QueueDepth)
+	for _, s := range report.Sessions {
+		fmt.Fprintf(stdout, "  session %s state=%s lines=%d\n", s.ID, s.State, s.Lines)
+	}
+	return exitSuccess
+}
+
+func runDaemonRun(args []string, stdout io.Writer, stderr io.Writer) int {
+	session, cwd, prompt := "", "", ""
+	var forward []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		value := func() (string, bool) {
+			if i+1 >= len(args) {
+				return "", false
+			}
+			i++
+			return args[i], true
+		}
+		switch {
+		case a == "-h" || a == "--help":
+			return writeDaemonUsage(stdout, exitSuccess)
+		case a == "--session":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--session requires a value")
+			}
+			session = v
+		case strings.HasPrefix(a, "--session="):
+			session = strings.TrimPrefix(a, "--session=")
+		case a == "--cwd":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--cwd requires a value")
+			}
+			cwd = v
+		case strings.HasPrefix(a, "--cwd="):
+			cwd = strings.TrimPrefix(a, "--cwd=")
+		case a == "--prompt" || a == "-p":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--prompt requires a value")
+			}
+			prompt = v
+		case strings.HasPrefix(a, "--prompt="):
+			prompt = strings.TrimPrefix(a, "--prompt=")
+		default:
+			// Forwarded verbatim to the worker `zero exec` (reuses exec's own flag
+			// parsing for per-session run options).
+			forward = append(forward, a)
+		}
+	}
+	if strings.TrimSpace(session) == "" {
+		return writeExecUsageError(stderr, "daemon run requires --session <id>")
+	}
+	if prompt == "" && len(forward) == 0 {
+		return writeExecUsageError(stderr, "daemon run requires --prompt <text> or exec args")
+	}
+	paths, err := daemon.DefaultPaths()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	client, err := daemon.Dial(paths.Socket)
+	if err != nil {
+		return writeAppError(stderr, "zero daemon is not running (start it with `zero daemon start`)", exitCrash)
+	}
+	defer client.Close()
+	if err := client.Run(session, cwd, prompt, forward, func(line string) { fmt.Fprintln(stdout, line) }); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	return exitSuccess
+}
+
+func runDaemonAttach(args []string, stdout io.Writer, stderr io.Writer) int {
+	session := ""
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			return writeDaemonUsage(stdout, exitSuccess)
+		}
+		if session == "" {
+			session = a
+		}
+	}
+	if strings.TrimSpace(session) == "" {
+		return writeExecUsageError(stderr, "daemon attach requires a <session> id")
+	}
+	paths, err := daemon.DefaultPaths()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	client, err := daemon.Dial(paths.Socket)
+	if err != nil {
+		return writeAppError(stderr, "zero daemon is not running (start it with `zero daemon start`)", exitCrash)
+	}
+	defer client.Close()
+	if err := client.Attach(session, func(line string) { fmt.Fprintln(stdout, line) }); err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	return exitSuccess
+}
+
+// daemonReachable reports whether a daemon is accepting connections (a successful
+// handshake). Used for the single-instance check and start-up wait.
+func daemonReachable(paths daemon.Paths) bool {
+	client, err := daemon.Dial(paths.Socket)
+	if err != nil {
+		return false
+	}
+	_ = client.Close()
+	return true
+}
+
+func helpRequested(args []string) bool {
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -106,3 +106,18 @@ func TestDaemonRunWhenNotRunning(t *testing.T) {
 		t.Fatalf("stderr = %q, want 'not running'", errb)
 	}
 }
+
+func TestDaemonSubcommandsRejectExtraArgs(t *testing.T) {
+	isolateDaemonPaths(t)
+	cases := [][]string{
+		{"stop", "oops"},
+		{"status", "oops"},
+		{"attach", "s1", "extra"},
+	}
+	for _, args := range cases {
+		code, _, errb := runDaemonCLI(t, args...)
+		if code != exitUsage {
+			t.Fatalf("%v exit = %d, want exitUsage (reject extra args); stderr=%q", args, code, errb)
+		}
+	}
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// isolateDaemonPaths points DefaultPaths at a temp dir so the test never touches
+// a real daemon on the dev machine.
+func isolateDaemonPaths(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+}
+
+func runDaemonCLI(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	code := runDaemon(args, &out, &errb, appDeps{})
+	return code, out.String(), errb.String()
+}
+
+func TestDaemonUsage(t *testing.T) {
+	code, _, _ := runDaemonCLI(t)
+	if code != exitUsage {
+		t.Fatalf("no-args exit = %d, want exitUsage", code)
+	}
+	code, out, _ := runDaemonCLI(t, "--help")
+	if code != exitSuccess || !strings.Contains(out, "Usage: zero daemon") {
+		t.Fatalf("--help exit=%d out=%q", code, out)
+	}
+}
+
+func TestDaemonUnknownSubcommand(t *testing.T) {
+	code, _, errb := runDaemonCLI(t, "frobnicate")
+	if code != exitUsage {
+		t.Fatalf("unknown subcommand exit = %d, want exitUsage", code)
+	}
+	if !strings.Contains(errb, "unknown daemon subcommand") {
+		t.Fatalf("stderr = %q, want unknown-subcommand message", errb)
+	}
+}
+
+func TestDaemonRunRequiresSession(t *testing.T) {
+	isolateDaemonPaths(t)
+	code, _, errb := runDaemonCLI(t, "run", "--prompt", "hi")
+	if code != exitUsage {
+		t.Fatalf("run without --session exit = %d, want exitUsage", code)
+	}
+	if !strings.Contains(errb, "--session") {
+		t.Fatalf("stderr = %q, want a --session hint", errb)
+	}
+}
+
+func TestDaemonRunRequiresPromptOrArgs(t *testing.T) {
+	isolateDaemonPaths(t)
+	code, _, errb := runDaemonCLI(t, "run", "--session", "s1")
+	if code != exitUsage {
+		t.Fatalf("run without prompt/args exit = %d, want exitUsage", code)
+	}
+	if !strings.Contains(errb, "--prompt") {
+		t.Fatalf("stderr = %q, want a --prompt hint", errb)
+	}
+}
+
+func TestDaemonStopWhenNotRunning(t *testing.T) {
+	isolateDaemonPaths(t)
+	code, out, _ := runDaemonCLI(t, "stop")
+	if code != exitSuccess {
+		t.Fatalf("stop (not running) exit = %d, want exitSuccess", code)
+	}
+	if !strings.Contains(out, "not running") {
+		t.Fatalf("stop output = %q, want 'not running'", out)
+	}
+}
+
+func TestDaemonStatusWhenNotRunning(t *testing.T) {
+	isolateDaemonPaths(t)
+	code, out, _ := runDaemonCLI(t, "status")
+	if code != exitSuccess {
+		t.Fatalf("status (not running) exit = %d, want exitSuccess", code)
+	}
+	if !strings.Contains(out, "not running") {
+		t.Fatalf("status output = %q, want 'not running'", out)
+	}
+}
+
+func TestDaemonAttachRequiresSession(t *testing.T) {
+	isolateDaemonPaths(t)
+	code, _, errb := runDaemonCLI(t, "attach")
+	if code != exitUsage {
+		t.Fatalf("attach without session exit = %d, want exitUsage", code)
+	}
+	if !strings.Contains(errb, "session") {
+		t.Fatalf("stderr = %q, want a session hint", errb)
+	}
+}
+
+func TestDaemonRunWhenNotRunning(t *testing.T) {
+	isolateDaemonPaths(t)
+	code, _, errb := runDaemonCLI(t, "run", "--session", "s1", "--prompt", "hello")
+	if code != exitCrash {
+		t.Fatalf("run (no daemon) exit = %d, want exitCrash", code)
+	}
+	if !strings.Contains(errb, "not running") {
+		t.Fatalf("stderr = %q, want 'not running'", errb)
+	}
+}

--- a/internal/daemon/backoff.go
+++ b/internal/daemon/backoff.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Backoff bounds. Mirrors reference-daemon-code-agent-js/worker-manager.js:
+// backoffMs(consecutive) = jitter(min(1000 * 2**consecutive, 300000)).
+const (
+	backoffUnit = time.Second
+	backoffCap  = 5 * time.Minute
+)
+
+// backoffBase returns the un-jittered exponential delay for a 1-based restart
+// count: min(1s * 2^attempt, 5m). attempt<=0 yields the unit delay.
+func backoffBase(attempt int) time.Duration {
+	if attempt <= 0 {
+		return backoffUnit
+	}
+	// Shift carefully: cap before overflow. 2^attempt * 1s exceeds the cap well
+	// before any int64 overflow (cap is 5m), so clamp once it would exceed it.
+	d := backoffUnit
+	for i := 0; i < attempt; i++ {
+		d *= 2
+		if d >= backoffCap {
+			return backoffCap
+		}
+	}
+	return d
+}
+
+// BackoffWithJitter returns backoffBase(attempt) scaled by a uniform random
+// factor in [0.5, 1.5), matching worker-manager.js jitter(base) =
+// base*(0.5 + random()). The jitter de-synchronizes simultaneous restarts so a
+// fleet of workers does not thunder back at the same instant.
+func BackoffWithJitter(attempt int) time.Duration {
+	base := backoffBase(attempt)
+	factor := 0.5 + rand.Float64() //nolint:gosec // jitter, not security-sensitive
+	return time.Duration(float64(base) * factor)
+}

--- a/internal/daemon/backoff_test.go
+++ b/internal/daemon/backoff_test.go
@@ -1,0 +1,38 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoffBaseExponentialAndCap(t *testing.T) {
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 8 * time.Second},
+		{20, backoffCap}, // far past the cap
+	}
+	for _, tc := range cases {
+		if got := backoffBase(tc.attempt); got != tc.want {
+			t.Fatalf("backoffBase(%d) = %s, want %s", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestBackoffWithJitterBounds(t *testing.T) {
+	for attempt := 1; attempt <= 6; attempt++ {
+		base := backoffBase(attempt)
+		lo := time.Duration(float64(base) * 0.5)
+		hi := time.Duration(float64(base) * 1.5)
+		for i := 0; i < 200; i++ {
+			got := BackoffWithJitter(attempt)
+			if got < lo || got >= hi {
+				t.Fatalf("BackoffWithJitter(%d) = %s, want in [%s,%s)", attempt, got, lo, hi)
+			}
+		}
+	}
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// Client is a control-socket client used by the `zero daemon run|attach|status|
+// stop` subcommands. It performs the version handshake on Dial.
+type Client struct {
+	conn net.Conn
+}
+
+// Dial connects to the daemon control socket and completes the handshake.
+func Dial(socketPath string) (*Client, error) {
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	c := &Client{conn: conn}
+	if err := c.handshake(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Client) handshake() error {
+	if err := WriteControl(c.conn, Ctrl{Type: CtrlHello, Version: ProtoVersion}); err != nil {
+		return err
+	}
+	reply, err := ReadControl(c.conn)
+	if err != nil {
+		return err
+	}
+	if reply.Type != CtrlHelloOK {
+		return fmt.Errorf("daemon: handshake rejected: %s", reply.Message)
+	}
+	return nil
+}
+
+// Close closes the connection.
+func (c *Client) Close() error { return c.conn.Close() }
+
+// Run starts/routes a session and streams its stream-json output lines to onLine
+// until the session ends. It returns the session's terminal error, if any.
+func (c *Client) Run(session, cwd, prompt string, args []string, onLine func(string)) error {
+	if err := WriteControl(c.conn, Ctrl{Type: CtrlRun, Session: session, Cwd: cwd, Prompt: prompt, Args: args}); err != nil {
+		return err
+	}
+	return c.streamLoop(onLine)
+}
+
+// Attach streams a running session's output (buffered history + live) to onLine.
+func (c *Client) Attach(session string, onLine func(string)) error {
+	if err := WriteControl(c.conn, Ctrl{Type: CtrlAttach, Session: session}); err != nil {
+		return err
+	}
+	return c.streamLoop(onLine)
+}
+
+func (c *Client) streamLoop(onLine func(string)) error {
+	for {
+		msg, err := ReadControl(c.conn)
+		if err != nil {
+			return err
+		}
+		switch msg.Type {
+		case CtrlAck:
+			// dispatch acknowledged; keep reading
+		case CtrlData:
+			if onLine != nil {
+				onLine(msg.Line)
+			}
+		case CtrlEnd:
+			return nil
+		case CtrlError:
+			return fmt.Errorf("daemon: %s", msg.Message)
+		default:
+			return fmt.Errorf("daemon: unexpected message %q", msg.Type)
+		}
+	}
+}
+
+// Status requests the daemon/worker/session status report.
+func (c *Client) Status() (*StatusReport, error) {
+	if err := WriteControl(c.conn, Ctrl{Type: CtrlStatus}); err != nil {
+		return nil, err
+	}
+	msg, err := ReadControl(c.conn)
+	if err != nil {
+		return nil, err
+	}
+	if msg.Type == CtrlError {
+		return nil, fmt.Errorf("daemon: %s", msg.Message)
+	}
+	if msg.Type != CtrlStatusResult || msg.Status == nil {
+		return nil, fmt.Errorf("daemon: unexpected status reply %q", msg.Type)
+	}
+	return msg.Status, nil
+}
+
+// Shutdown asks the daemon to drain and stop.
+func (c *Client) Shutdown() error {
+	if err := WriteControl(c.conn, Ctrl{Type: CtrlShutdown}); err != nil {
+		return err
+	}
+	msg, err := ReadControl(c.conn)
+	if err != nil {
+		return err
+	}
+	if msg.Type == CtrlError {
+		return fmt.Errorf("daemon: %s", msg.Message)
+	}
+	return nil
+}

--- a/internal/daemon/launcher.go
+++ b/internal/daemon/launcher.go
@@ -1,0 +1,165 @@
+package daemon
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/background"
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+// reentrancyMarkers are the env vars zero sets on a command it has ALREADY
+// wrapped in a sandbox. The daemon MUST strip them from every worker's
+// environment: a worker that inherited them would trip zero's re-entrancy guard
+// (sandbox.IsAlreadySandboxed needs BOTH) and run with a pass-through plan —
+// i.e. UNSANDBOXED — silently defeating the sandbox. Stripping them forces each
+// worker to (re)establish its own sandbox. This is the daemon's #1 security
+// invariant: it must NOT bypass the sandbox.
+var reentrancyMarkers = []string{sandbox.EnvSandboxed, sandbox.EnvSandboxBackend}
+
+// scrubWorkerEnv returns env with the sandbox re-entrancy markers removed. Every
+// other variable is preserved — including the ZERO_SANDBOX_* policy config the
+// worker reads to rebuild its own policy — so the sandbox policy is PROPAGATED,
+// not bypassed. The caller's slice is never mutated.
+func scrubWorkerEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		drop := false
+		for _, marker := range reentrancyMarkers {
+			if strings.HasPrefix(kv, marker+"=") {
+				drop = true
+				break
+			}
+		}
+		if !drop {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// execWorker is a WorkerHandle backed by a `zero exec` child process speaking
+// stream-json on stdout.
+type execWorker struct {
+	cmd    *exec.Cmd
+	stdout io.ReadCloser
+	lines  *scannerLines
+	pid    int
+}
+
+func (w *execWorker) Stdout() Lines { return w.lines }
+func (w *execWorker) Pid() int      { return w.pid }
+
+func (w *execWorker) Wait() (int, error) {
+	err := w.cmd.Wait()
+	if err == nil {
+		return 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return -1, err
+}
+
+func (w *execWorker) Kill() error {
+	if w.cmd.Process == nil {
+		return nil
+	}
+	// background.TerminateProcess is the cross-platform terminate (kills the
+	// process group on POSIX, taskkill /T on Windows).
+	return background.TerminateProcess(w.cmd.Process.Pid)
+}
+
+// scannerLines adapts a bufio.Scanner to the Lines interface.
+type scannerLines struct {
+	sc *bufio.Scanner
+}
+
+func (s *scannerLines) Next() (string, bool, error) {
+	if s.sc.Scan() {
+		return s.sc.Text(), true, nil
+	}
+	if err := s.sc.Err(); err != nil {
+		return "", false, err
+	}
+	return "", false, nil
+}
+
+// ExecLauncherConfig configures the production worker launcher.
+type ExecLauncherConfig struct {
+	// Executable is the zero binary to spawn (defaults to os.Executable()).
+	Executable string
+	// BaseArgs are prepended before the per-session args (defaults to the headless
+	// stream-json exec invocation `exec --output-format stream-json`).
+	BaseArgs []string
+	// Env is the base environment for workers (defaults to os.Environ()). The
+	// re-entrancy markers are always scrubbed from it.
+	Env []string
+}
+
+// NewExecLauncher builds a Launcher that spawns `zero exec` workers which speak
+// stream-json on stdout. Each worker:
+//   - runs with the re-entrancy markers SCRUBBED from its env (so it establishes
+//     its own sandbox; the daemon never bypasses the sandbox), while the rest of
+//     the policy config/env is propagated;
+//   - is placed in its own process group (background.ConfigureChildProcessGroup)
+//     so Kill / drain can terminate it and any children cleanly;
+//   - has its per-session working directory (spec.Cwd) and flags (spec.Args)
+//     applied. The pool does the os/exec itself and uses internal/background only
+//     for process-group setup + cross-platform terminate.
+func NewExecLauncher(cfg ExecLauncherConfig) (Launcher, error) {
+	exe := cfg.Executable
+	if exe == "" {
+		resolved, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("daemon: locate zero executable: %w", err)
+		}
+		exe = resolved
+	}
+	baseArgs := cfg.BaseArgs
+	if baseArgs == nil {
+		baseArgs = []string{"exec", "--output-format", "stream-json"}
+	}
+	baseEnv := cfg.Env
+	if baseEnv == nil {
+		baseEnv = os.Environ()
+	}
+	env := scrubWorkerEnv(baseEnv)
+
+	return func(ctx context.Context, spec WorkerSpec) (WorkerHandle, error) {
+		args := make([]string, 0, len(baseArgs)+len(spec.Args))
+		args = append(args, baseArgs...)
+		args = append(args, spec.Args...)
+
+		cmd := exec.CommandContext(ctx, exe, args...)
+		cmd.Dir = spec.Cwd
+		cmd.Env = env
+		cmd.Stdin = nil // the prompt is passed via flags; no streamed stdin input
+		background.ConfigureChildProcessGroup(cmd)
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("daemon: worker stdout pipe: %w", err)
+		}
+		if err := cmd.Start(); err != nil {
+			return nil, fmt.Errorf("daemon: start worker: %w", err)
+		}
+
+		scanner := bufio.NewScanner(stdout)
+		// Allow long stream-json lines up to the control-frame cap.
+		scanner.Buffer(make([]byte, 0, 64*1024), MaxFrameSize)
+		return &execWorker{
+			cmd:    cmd,
+			stdout: stdout,
+			lines:  &scannerLines{sc: scanner},
+			pid:    cmd.Process.Pid,
+		}, nil
+	}, nil
+}

--- a/internal/daemon/launcher_test.go
+++ b/internal/daemon/launcher_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+func TestScrubWorkerEnvRemovesReentrancyMarkers(t *testing.T) {
+	in := []string{
+		"PATH=/bin",
+		sandbox.EnvSandboxed + "=1",
+		"ZERO_SANDBOX_AUTO_ALLOW_BASH=1", // policy config — must be PRESERVED
+		sandbox.EnvSandboxBackend + "=bubblewrap",
+		"HOME=/home/u",
+	}
+	out := scrubWorkerEnv(in)
+
+	for _, kv := range out {
+		if strings.HasPrefix(kv, sandbox.EnvSandboxed+"=") || strings.HasPrefix(kv, sandbox.EnvSandboxBackend+"=") {
+			t.Fatalf("re-entrancy marker not scrubbed: %q", kv)
+		}
+	}
+	want := map[string]bool{"PATH=/bin": true, "ZERO_SANDBOX_AUTO_ALLOW_BASH=1": true, "HOME=/home/u": true}
+	got := map[string]bool{}
+	for _, kv := range out {
+		got[kv] = true
+	}
+	for w := range want {
+		if !got[w] {
+			t.Fatalf("scrub dropped a non-marker var: %q", w)
+		}
+	}
+	if len(out) != len(want) {
+		t.Fatalf("scrub result = %v, want exactly %d preserved vars", out, len(want))
+	}
+	if len(in) != 5 {
+		t.Fatal("scrubWorkerEnv must not mutate the caller's slice")
+	}
+}
+
+// TestExecLauncherScrubsEnvEndToEnd proves the spawned WORKER PROCESS actually
+// receives an environment without the re-entrancy markers — the security
+// invariant. It uses /bin/sh to dump the worker env, so it is POSIX-only.
+func TestExecLauncherScrubsEnvEndToEnd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses the POSIX env dumper /bin/sh -c env")
+	}
+	launcher, err := NewExecLauncher(ExecLauncherConfig{
+		Executable: "/bin/sh",
+		BaseArgs:   []string{"-c", "env"},
+		Env: append([]string{"KEEP=yes"},
+			sandbox.EnvSandboxed+"=1",
+			sandbox.EnvSandboxBackend+"=bubblewrap"),
+	})
+	if err != nil {
+		t.Fatalf("NewExecLauncher: %v", err)
+	}
+	h, err := launcher(context.Background(), WorkerSpec{})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	lines := h.Stdout()
+	var got []string
+	for {
+		line, ok, lerr := lines.Next()
+		if lerr != nil {
+			t.Fatalf("read worker stdout: %v", lerr)
+		}
+		if !ok {
+			break
+		}
+		got = append(got, line)
+	}
+	if _, err := h.Wait(); err != nil {
+		t.Fatalf("worker wait: %v", err)
+	}
+
+	keepSeen := false
+	for _, l := range got {
+		if strings.HasPrefix(l, sandbox.EnvSandboxed+"=") || strings.HasPrefix(l, sandbox.EnvSandboxBackend+"=") {
+			t.Fatalf("worker process still has a re-entrancy marker in its env: %q", l)
+		}
+		if l == "KEEP=yes" {
+			keepSeen = true
+		}
+	}
+	if !keepSeen {
+		t.Fatalf("worker env lost a non-marker var (KEEP=yes); got %v", got)
+	}
+}
+
+func TestNewExecLauncherDefaults(t *testing.T) {
+	// With no Executable it resolves the test binary's own path (os.Executable),
+	// and constructs without error.
+	if _, err := NewExecLauncher(ExecLauncherConfig{}); err != nil {
+		t.Fatalf("NewExecLauncher with defaults: %v", err)
+	}
+}

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -37,7 +37,14 @@ func acquireLock(path string, isAlive func(pid int) bool) (*fileLock, error) {
 	for attempt := 0; attempt < 2; attempt++ {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
-			_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
+			// A failed PID write would leave a malformed lock file that another
+			// process reads as stale (unparsable PID) and wrongly reclaims, breaking
+			// the single-instance guarantee — so on write failure, remove it and fail.
+			if _, werr := fmt.Fprintf(f, "%d\n", os.Getpid()); werr != nil {
+				_ = f.Close()
+				_ = os.Remove(path)
+				return nil, werr
+			}
 			if cerr := f.Close(); cerr != nil {
 				_ = os.Remove(path)
 				return nil, cerr

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Single-instance lock. Mirrors reference-daemon-code-agent-js/supervisor.js's
+// lock file: a PID file created with O_EXCL. A second start fails; a STALE lock
+// left by a dead daemon (the recorded PID is no longer alive) is reclaimed so the
+// daemon recovers from an unclean shutdown without manual cleanup.
+
+// ErrAlreadyRunning is returned when a live daemon already holds the lock.
+var ErrAlreadyRunning = errors.New("daemon: another instance is already running")
+
+// fileLock is an acquired single-instance lock.
+type fileLock struct {
+	path string
+}
+
+// processAlive reports whether pid is a live process. Implemented per-platform
+// (lock_posix.go / lock_windows.go). It is a package var so tests can stub it.
+var processAlive = osProcessAlive
+
+// acquireLock takes the single-instance lock at path, reclaiming a stale lock
+// whose recorded PID is dead. isAlive overrides the liveness check (tests pass a
+// stub); nil uses the real processAlive.
+func acquireLock(path string, isAlive func(pid int) bool) (*fileLock, error) {
+	if isAlive == nil {
+		isAlive = processAlive
+	}
+	// At most two passes: create, or detect-stale-then-retry once.
+	for attempt := 0; attempt < 2; attempt++ {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_, _ = fmt.Fprintf(f, "%d\n", os.Getpid())
+			if cerr := f.Close(); cerr != nil {
+				_ = os.Remove(path)
+				return nil, cerr
+			}
+			return &fileLock{path: path}, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return nil, err
+		}
+		pid, perr := readPidFile(path)
+		if perr == nil && pid > 0 && isAlive(pid) {
+			return nil, fmt.Errorf("%w (pid %d)", ErrAlreadyRunning, pid)
+		}
+		// Stale lock (dead PID or unreadable) — remove and retry once.
+		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+			return nil, rmErr
+		}
+	}
+	return nil, ErrAlreadyRunning
+}
+
+// release removes the lock file. Safe to call once.
+func (l *fileLock) release() error {
+	if l == nil || l.path == "" {
+		return nil
+	}
+	if err := os.Remove(l.path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// readPidFile reads and parses the PID recorded in a lock file.
+func readPidFile(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(strings.TrimSpace(string(data)))
+}

--- a/internal/daemon/lock_posix.go
+++ b/internal/daemon/lock_posix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"syscall"
+)
+
+// osProcessAlive reports whether pid is a live process on POSIX. Signal 0 does
+// not deliver a signal; it only checks existence/permission. ESRCH means no such
+// process (dead); EPERM means it exists but we may not signal it (alive).
+func osProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestLockSingleInstance(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.lock")
+	alive := func(int) bool { return true }
+
+	l1, err := acquireLock(path, alive)
+	if err != nil {
+		t.Fatalf("first acquireLock: %v", err)
+	}
+	// Second acquire while the holder is "alive" must be refused.
+	if _, err := acquireLock(path, alive); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("second acquireLock err = %v, want ErrAlreadyRunning", err)
+	}
+	// After release, a new acquire succeeds.
+	if err := l1.release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	l2, err := acquireLock(path, alive)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	_ = l2.release()
+}
+
+func TestLockStaleRecovery(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.lock")
+	// Simulate a stale lock from a crashed daemon: a PID file whose process is
+	// dead.
+	if err := os.WriteFile(path, []byte("4242\n"), 0o600); err != nil {
+		t.Fatalf("write stale lock: %v", err)
+	}
+	dead := func(int) bool { return false }
+	l, err := acquireLock(path, dead)
+	if err != nil {
+		t.Fatalf("stale-lock recovery failed: %v", err)
+	}
+	// The lock now records OUR pid, not the stale one.
+	data, _ := os.ReadFile(path)
+	if strings.TrimSpace(string(data)) != strconv.Itoa(os.Getpid()) {
+		t.Fatalf("reclaimed lock pid = %q, want %d", strings.TrimSpace(string(data)), os.Getpid())
+	}
+	_ = l.release()
+}
+
+func TestLockReleaseRemovesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.lock")
+	l, err := acquireLock(path, func(int) bool { return true })
+	if err != nil {
+		t.Fatalf("acquireLock: %v", err)
+	}
+	if err := l.release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lock file still present after release: %v", err)
+	}
+}
+
+func TestProcessAliveSelfAndDead(t *testing.T) {
+	if !osProcessAlive(os.Getpid()) {
+		t.Fatal("osProcessAlive(self) = false, want true")
+	}
+	// PID 0 / negative are never live.
+	if osProcessAlive(0) || osProcessAlive(-1) {
+		t.Fatal("osProcessAlive must reject non-positive pids")
+	}
+}

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package daemon
+
+import "golang.org/x/sys/windows"
+
+// osProcessAlive reports whether pid is a live process on Windows. It opens the
+// process for limited query access; a successful open with a non-exited status
+// means the PID is live. x/sys is already a module dependency.
+func osProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+	var code uint32
+	if err := windows.GetExitCodeProcess(handle, &code); err != nil {
+		// Could not query; treat the open as proof of life (conservative: do not
+		// reclaim a lock we are unsure about).
+		return true
+	}
+	const stillActive = 259 // STILL_ACTIVE
+	return code == stillActive
+}

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultDir returns the per-user directory for the daemon's runtime files:
+// $XDG_RUNTIME_DIR/zero when set (a tmpfs owned by the user on Linux), otherwise
+// ~/.zero. Mirrors supervisor.js / config.js choosing a per-user runtime dir.
+func DefaultDir() (string, error) {
+	if rt := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); rt != "" {
+		return filepath.Join(rt, "zero"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".zero"), nil
+}
+
+// Paths bundles the daemon's socket, lock, and status file paths.
+type Paths struct {
+	Socket string
+	Lock   string
+	Status string
+}
+
+// DefaultPaths returns the daemon control-socket, lock, and status file paths
+// under DefaultDir.
+func DefaultPaths() (Paths, error) {
+	dir, err := DefaultDir()
+	if err != nil {
+		return Paths{}, err
+	}
+	return Paths{
+		Socket: filepath.Join(dir, "daemon.sock"),
+		Lock:   filepath.Join(dir, "daemon.lock"),
+		Status: filepath.Join(dir, "daemon.status"),
+	}, nil
+}

--- a/internal/daemon/pool.go
+++ b/internal/daemon/pool.go
@@ -1,0 +1,355 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Exit codes a worker may use to signal restart policy. Mirrors
+// reference-daemon-code-agent-js/worker-manager.js EXIT_TEMPFAIL/EXIT_PERMANENT.
+const (
+	// ExitTempfail asks for a retry after a fixed cool-off (transient failure).
+	ExitTempfail = 75
+	// ExitPermanent asks the daemon to STOP retrying this work (fatal).
+	ExitPermanent = 76
+)
+
+// defaultPoolSize, defaultMaxAttempts and defaultKillTimeout are used when a
+// PoolOptions field is left zero.
+const (
+	defaultPoolSize    = 4
+	defaultMaxAttempts = 5
+	defaultKillTimeout = 5 * time.Second
+)
+
+// ErrPoolDraining is returned by Run once the pool is shutting down.
+var ErrPoolDraining = errors.New("daemon: pool is draining")
+
+// ErrPermanent is returned when a worker exits ExitPermanent or the attempt cap
+// is exhausted; the request must not be retried.
+var ErrPermanent = errors.New("daemon: worker failed permanently")
+
+// WorkerSpec describes the worker to launch for one session attempt.
+type WorkerSpec struct {
+	Session string
+	Cwd     string
+	// Args are the per-session exec flags (e.g. --prompt ...), parsed by the CLI
+	// and appended after `exec` by the production launcher.
+	Args []string
+}
+
+// WorkerHandle is a launched worker process the pool supervises. The production
+// launcher wraps an exec.Cmd running `zero exec -i/-o stream-json`; tests inject
+// a fake. Stdout yields the worker's stream-json event lines.
+type WorkerHandle interface {
+	Stdout() Lines
+	// Wait blocks until the worker exits and returns its process exit code.
+	Wait() (int, error)
+	// Kill force-terminates the worker (used on drain timeout).
+	Kill() error
+	Pid() int
+}
+
+// Lines is a stream of stream-json output lines from a worker. Next returns the
+// next line and io-EOF-style ok=false when the stream ends.
+type Lines interface {
+	Next() (line string, ok bool, err error)
+}
+
+// Launcher spawns a worker for a single attempt. It must apply the sandbox/env
+// policy (the production launcher scrubs the re-entrancy markers so the worker
+// re-establishes its own sandbox — see newExecLauncher).
+type Launcher func(ctx context.Context, spec WorkerSpec) (WorkerHandle, error)
+
+// PoolOptions configures a Pool. Zero fields take documented defaults.
+type PoolOptions struct {
+	// Size is the max number of concurrent workers (lease slots). Sessions beyond
+	// this queue until a slot frees.
+	Size int
+	// Launcher spawns a worker. Required.
+	Launcher Launcher
+	// MaxAttempts caps the total attempts per request (first + retries). When
+	// exhausted, Run returns ErrPermanent (mirrors capping consecutive restarts).
+	MaxAttempts int
+	// KillTimeout bounds graceful termination before SIGKILL-equivalent on drain.
+	KillTimeout time.Duration
+	// Backoff returns the delay before retry attempt n (1-based crash count).
+	// Defaults to BackoffWithJitter; tests inject a deterministic function.
+	Backoff func(attempt int) time.Duration
+	// TempfailDelay is the cool-off after an ExitTempfail exit. Defaults to 30s.
+	TempfailDelay time.Duration
+	// Log, when set, receives one line per lifecycle event.
+	Log func(string)
+}
+
+// Pool is a bounded, self-healing worker pool. A crashed worker never takes down
+// the pool: Run retries on a fresh worker with backoff up to MaxAttempts, and an
+// ExitPermanent worker stops retries. Drain stops new work and kills stragglers.
+type Pool struct {
+	opts  PoolOptions
+	slots chan struct{}
+
+	mu       sync.Mutex
+	draining bool
+	active   map[int]WorkerHandle // pid -> handle, for drain/kill + status
+	nextID   int
+
+	drainOnce sync.Once
+	drained   chan struct{}
+}
+
+// workerStat tracks one in-flight request's restart count (local to Run).
+type workerStat struct {
+	id       int
+	restarts int
+}
+
+// NewPool builds a pool from opts, filling defaults.
+func NewPool(opts PoolOptions) (*Pool, error) {
+	if opts.Launcher == nil {
+		return nil, errors.New("daemon: pool requires a Launcher")
+	}
+	if opts.Size <= 0 {
+		opts.Size = defaultPoolSize
+	}
+	if opts.MaxAttempts <= 0 {
+		opts.MaxAttempts = defaultMaxAttempts
+	}
+	if opts.KillTimeout <= 0 {
+		opts.KillTimeout = defaultKillTimeout
+	}
+	if opts.TempfailDelay <= 0 {
+		opts.TempfailDelay = 30 * time.Second
+	}
+	if opts.Backoff == nil {
+		opts.Backoff = BackoffWithJitter
+	}
+	return &Pool{
+		opts:    opts,
+		slots:   make(chan struct{}, opts.Size),
+		active:  map[int]WorkerHandle{},
+		drained: make(chan struct{}),
+	}, nil
+}
+
+// Size returns the configured max concurrency.
+func (p *Pool) Size() int { return p.opts.Size }
+
+func (p *Pool) logf(format string, args ...any) {
+	if p.opts.Log != nil {
+		p.opts.Log(fmt.Sprintf(format, args...))
+	}
+}
+
+// acquire takes a lease slot, queuing until one frees or ctx is cancelled / the
+// pool drains.
+func (p *Pool) acquire(ctx context.Context) error {
+	p.mu.Lock()
+	draining := p.draining
+	p.mu.Unlock()
+	if draining {
+		return ErrPoolDraining
+	}
+	select {
+	case p.slots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.drained:
+		return ErrPoolDraining
+	}
+}
+
+func (p *Pool) release() { <-p.slots }
+
+// QueueDepth reports how many lease slots are currently in use.
+func (p *Pool) QueueDepth() int { return len(p.slots) }
+
+// Sink receives a worker's stream-json output lines for one request.
+type Sink interface {
+	Line(line string)
+}
+
+// Run leases a worker slot and dispatches spec to a worker, streaming its
+// stream-json lines to sink. It is at-least-once with bounded retries: a worker
+// that crashes (non-zero, non-permanent) is retried on a fresh worker after a
+// backoff; ExitPermanent or exhausting MaxAttempts returns ErrPermanent. Run
+// queues when all slots are busy. The returned int is the final worker exit code.
+func (p *Pool) Run(ctx context.Context, spec WorkerSpec, sink Sink) (int, error) {
+	if err := p.acquire(ctx); err != nil {
+		return 0, err
+	}
+	defer p.release()
+
+	// Lease hook: a sink that tracks queue->running state is notified the instant
+	// a worker slot is leased (mirrors lease.js acquiring a worker for a session).
+	if s, ok := sink.(interface{ Started() }); ok {
+		s.Started()
+	}
+
+	stat := p.newStat()
+	var lastErr error
+	for attempt := 1; attempt <= p.opts.MaxAttempts; attempt++ {
+		if p.isDraining() {
+			return 0, ErrPoolDraining
+		}
+		code, err := p.runOnce(ctx, stat.id, spec, sink)
+		switch {
+		case err != nil:
+			lastErr = err
+			if ctx.Err() != nil {
+				return 0, ctx.Err()
+			}
+			p.logf("worker %d launch/run error: %v", stat.id, err)
+		case code == 0:
+			return 0, nil // clean success
+		case code == ExitPermanent:
+			p.logf("worker %d exited permanently (code=%d) — not retrying", stat.id, code)
+			return code, ErrPermanent
+		case code == ExitTempfail:
+			lastErr = fmt.Errorf("worker %d tempfail (code=%d)", stat.id, code)
+			p.logf("worker %d tempfail — retry after %s", stat.id, p.opts.TempfailDelay)
+			if !p.sleep(ctx, p.opts.TempfailDelay) {
+				return 0, ctx.Err()
+			}
+			continue // tempfail retries do not count against the crash backoff
+		default:
+			lastErr = fmt.Errorf("worker %d exited code=%d", stat.id, code)
+		}
+
+		if attempt == p.opts.MaxAttempts {
+			break
+		}
+		stat.restarts++
+		delay := p.opts.Backoff(stat.restarts)
+		p.logf("worker %d restart %d after backoff %s", stat.id, stat.restarts, delay)
+		if !p.sleep(ctx, delay) {
+			return 0, ctx.Err()
+		}
+	}
+	if lastErr == nil {
+		lastErr = ErrPermanent
+	}
+	return ExitPermanent, fmt.Errorf("%w: %v", ErrPermanent, lastErr)
+}
+
+// runOnce launches a single worker, pumps its output to sink, and returns its
+// exit code. The worker handle is tracked so Drain can kill it.
+func (p *Pool) runOnce(ctx context.Context, id int, spec WorkerSpec, sink Sink) (int, error) {
+	handle, err := p.opts.Launcher(ctx, spec)
+	if err != nil {
+		return 0, err
+	}
+	p.track(handle)
+	defer p.untrack(handle)
+
+	// Pump stdout lines until the stream ends.
+	lines := handle.Stdout()
+	for {
+		line, ok, lerr := lines.Next()
+		if lerr != nil {
+			break
+		}
+		if !ok {
+			break
+		}
+		if sink != nil {
+			sink.Line(line)
+		}
+	}
+	return handle.Wait()
+}
+
+func (p *Pool) newStat() *workerStat {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.nextID++
+	return &workerStat{id: p.nextID}
+}
+
+func (p *Pool) track(h WorkerHandle) {
+	p.mu.Lock()
+	p.active[h.Pid()] = h
+	p.mu.Unlock()
+}
+
+func (p *Pool) untrack(h WorkerHandle) {
+	p.mu.Lock()
+	delete(p.active, h.Pid())
+	p.mu.Unlock()
+}
+
+func (p *Pool) isDraining() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.draining
+}
+
+// sleep waits d, returning false if ctx is cancelled first. A non-positive d
+// returns immediately.
+func (p *Pool) sleep(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// Drain stops accepting new work, gives in-flight workers a grace window
+// (KillTimeout) to finish on their own, then force-kills any straggler. It
+// returns as soon as the pool is idle (graceful) or the window elapses. Safe to
+// call once; subsequent calls are no-ops.
+func (p *Pool) Drain() {
+	p.drainOnce.Do(func() {
+		p.mu.Lock()
+		p.draining = true
+		p.mu.Unlock()
+		close(p.drained)
+
+		// Grace window: poll until idle or the deadline.
+		deadline := time.Now().Add(p.opts.KillTimeout)
+		for time.Now().Before(deadline) {
+			p.mu.Lock()
+			n := len(p.active)
+			p.mu.Unlock()
+			if n == 0 {
+				return // all workers drained gracefully
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+
+		// Timed out: force-kill remaining workers.
+		p.mu.Lock()
+		handles := make([]WorkerHandle, 0, len(p.active))
+		for _, h := range p.active {
+			handles = append(handles, h)
+		}
+		p.mu.Unlock()
+		for _, h := range handles {
+			p.logf("drain: killing straggler worker pid=%d", h.Pid())
+			_ = h.Kill()
+		}
+	})
+}
+
+// WorkerStats returns a snapshot of the currently-active (busy) workers, bounded
+// by the pool size. The on-demand pool keeps no idle workers, so an empty result
+// means the pool is idle.
+func (p *Pool) WorkerStats() []WorkerStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]WorkerStatus, 0, len(p.active))
+	for pid := range p.active {
+		out = append(out, WorkerStatus{PID: pid, State: "busy"})
+	}
+	return out
+}

--- a/internal/daemon/pool_test.go
+++ b/internal/daemon/pool_test.go
@@ -1,0 +1,248 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// --- test doubles ---------------------------------------------------------
+
+type fakeLines struct {
+	lines []string
+	i     int
+}
+
+func (f *fakeLines) Next() (string, bool, error) {
+	if f.i >= len(f.lines) {
+		return "", false, nil
+	}
+	l := f.lines[f.i]
+	f.i++
+	return l, true, nil
+}
+
+type fakeWorker struct {
+	pid      int
+	out      []string
+	exitCode int
+	killed   int32
+	waitCh   chan struct{} // when non-nil, Wait blocks until closed (drain tests)
+}
+
+func (w *fakeWorker) Stdout() Lines { return &fakeLines{lines: w.out} }
+func (w *fakeWorker) Wait() (int, error) {
+	if w.waitCh != nil {
+		<-w.waitCh
+	}
+	return w.exitCode, nil
+}
+func (w *fakeWorker) Kill() error {
+	atomic.StoreInt32(&w.killed, 1)
+	if w.waitCh != nil {
+		select {
+		case <-w.waitCh:
+		default:
+			close(w.waitCh)
+		}
+	}
+	return nil
+}
+func (w *fakeWorker) Pid() int { return w.pid }
+
+// seqLauncher hands out the given workers in order, then errors.
+func seqLauncher(workers ...*fakeWorker) (Launcher, *int32) {
+	var calls int32
+	l := func(_ context.Context, _ WorkerSpec) (WorkerHandle, error) {
+		n := atomic.AddInt32(&calls, 1)
+		idx := int(n) - 1
+		if idx >= len(workers) {
+			return nil, errors.New("no more fake workers")
+		}
+		return workers[idx], nil
+	}
+	return l, &calls
+}
+
+type collectSink struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *collectSink) Line(line string) {
+	c.mu.Lock()
+	c.lines = append(c.lines, line)
+	c.mu.Unlock()
+}
+
+// --- tests ----------------------------------------------------------------
+
+func TestPoolRunStreamsAndSucceeds(t *testing.T) {
+	launcher, calls := seqLauncher(&fakeWorker{pid: 1, out: []string{"a", "b"}, exitCode: 0})
+	pool, err := NewPool(PoolOptions{Size: 2, Launcher: launcher})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	sink := &collectSink{}
+	code, err := pool.Run(context.Background(), WorkerSpec{Session: "s"}, sink)
+	if err != nil || code != 0 {
+		t.Fatalf("Run = (%d,%v), want (0,nil)", code, err)
+	}
+	if len(sink.lines) != 2 || sink.lines[0] != "a" || sink.lines[1] != "b" {
+		t.Fatalf("sink lines = %v, want [a b]", sink.lines)
+	}
+	if *calls != 1 {
+		t.Fatalf("launcher calls = %d, want 1", *calls)
+	}
+}
+
+func TestPoolRunRetriesWithBackoff(t *testing.T) {
+	launcher, calls := seqLauncher(
+		&fakeWorker{pid: 1, exitCode: 1},                      // crash
+		&fakeWorker{pid: 2, exitCode: 1},                      // crash
+		&fakeWorker{pid: 3, exitCode: 0, out: []string{"ok"}}, // success
+	)
+	var backoffArgs []int
+	pool, _ := NewPool(PoolOptions{
+		Size: 1, Launcher: launcher, MaxAttempts: 5,
+		Backoff: func(attempt int) time.Duration { backoffArgs = append(backoffArgs, attempt); return 0 },
+	})
+	sink := &collectSink{}
+	code, err := pool.Run(context.Background(), WorkerSpec{Session: "s"}, sink)
+	if err != nil || code != 0 {
+		t.Fatalf("Run = (%d,%v), want (0,nil)", code, err)
+	}
+	if *calls != 3 {
+		t.Fatalf("launcher calls = %d, want 3 (2 crashes + success)", *calls)
+	}
+	// Backoff invoked between attempts with an increasing 1-based restart count.
+	if len(backoffArgs) != 2 || backoffArgs[0] != 1 || backoffArgs[1] != 2 {
+		t.Fatalf("backoff attempts = %v, want [1 2]", backoffArgs)
+	}
+}
+
+func TestPoolRunPermanentStopsImmediately(t *testing.T) {
+	launcher, calls := seqLauncher(&fakeWorker{pid: 1, exitCode: ExitPermanent})
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher, Backoff: func(int) time.Duration { return 0 }})
+	code, err := pool.Run(context.Background(), WorkerSpec{Session: "s"}, &collectSink{})
+	if !errors.Is(err, ErrPermanent) {
+		t.Fatalf("Run err = %v, want ErrPermanent", err)
+	}
+	if code != ExitPermanent {
+		t.Fatalf("Run code = %d, want %d", code, ExitPermanent)
+	}
+	if *calls != 1 {
+		t.Fatalf("permanent exit must not retry; launcher calls = %d, want 1", *calls)
+	}
+}
+
+func TestPoolRunCapExhausted(t *testing.T) {
+	launcher, calls := seqLauncher(
+		&fakeWorker{pid: 1, exitCode: 1},
+		&fakeWorker{pid: 2, exitCode: 1},
+		&fakeWorker{pid: 3, exitCode: 1},
+	)
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher, MaxAttempts: 3, Backoff: func(int) time.Duration { return 0 }})
+	_, err := pool.Run(context.Background(), WorkerSpec{Session: "s"}, &collectSink{})
+	if !errors.Is(err, ErrPermanent) {
+		t.Fatalf("Run err = %v, want ErrPermanent after cap", err)
+	}
+	if *calls != 3 {
+		t.Fatalf("launcher calls = %d, want 3 (== MaxAttempts)", *calls)
+	}
+}
+
+func TestPoolRunTempfailRetries(t *testing.T) {
+	launcher, calls := seqLauncher(
+		&fakeWorker{pid: 1, exitCode: ExitTempfail},
+		&fakeWorker{pid: 2, exitCode: 0, out: []string{"ok"}},
+	)
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher, TempfailDelay: time.Millisecond})
+	code, err := pool.Run(context.Background(), WorkerSpec{Session: "s"}, &collectSink{})
+	if err != nil || code != 0 {
+		t.Fatalf("Run = (%d,%v), want (0,nil)", code, err)
+	}
+	if *calls != 2 {
+		t.Fatalf("launcher calls = %d, want 2 (tempfail + success)", *calls)
+	}
+}
+
+func TestPoolQueuesWhenFull(t *testing.T) {
+	block := make(chan struct{})
+	first := &fakeWorker{pid: 1, waitCh: block}
+	second := &fakeWorker{pid: 2, exitCode: 0}
+	launcher, _ := seqLauncher(first, second)
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher})
+
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		_, _ = pool.Run(context.Background(), WorkerSpec{Session: "a"}, &collectSink{})
+	}()
+	<-started
+	// Wait until the first run holds the only slot.
+	waitFor(t, func() bool { return pool.QueueDepth() == 1 })
+
+	secondDone := make(chan struct{})
+	go func() {
+		_, _ = pool.Run(context.Background(), WorkerSpec{Session: "b"}, &collectSink{})
+		close(secondDone)
+	}()
+	// The second run must NOT complete while the slot is held.
+	select {
+	case <-secondDone:
+		t.Fatal("second run completed while the only slot was busy (no queueing)")
+	case <-time.After(50 * time.Millisecond):
+	}
+	// Free the slot; the queued run now proceeds.
+	close(block)
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued run did not proceed after slot freed")
+	}
+}
+
+func TestPoolDrainKillsStraggler(t *testing.T) {
+	block := make(chan struct{})
+	straggler := &fakeWorker{pid: 1, waitCh: block}
+	launcher, _ := seqLauncher(straggler)
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher, MaxAttempts: 1, KillTimeout: 10 * time.Millisecond})
+
+	runDone := make(chan struct{})
+	go func() {
+		_, _ = pool.Run(context.Background(), WorkerSpec{Session: "a"}, &collectSink{})
+		close(runDone)
+	}()
+	waitFor(t, func() bool { return pool.QueueDepth() == 1 })
+
+	pool.Drain() // KillTimeout elapses, straggler is force-killed
+	if atomic.LoadInt32(&straggler.killed) != 1 {
+		t.Fatal("Drain must kill a straggler still running after KillTimeout")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not finish after drain kill")
+	}
+
+	// A new Run after drain is refused.
+	if _, err := pool.Run(context.Background(), WorkerSpec{Session: "b"}, &collectSink{}); !errors.Is(err, ErrPoolDraining) {
+		t.Fatalf("Run after drain err = %v, want ErrPoolDraining", err)
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -1,0 +1,184 @@
+// Package daemon implements zero's long-running daemon/server mode: a local
+// control server that supervises a pool of headless `zero exec` worker processes
+// and routes multiple agent sessions to them over an owner-only local socket.
+//
+// It reuses zero's existing building blocks rather than inventing new ones:
+//   - internal/background : child-process group setup + cross-platform terminate.
+//   - internal/streamjson : the line-based agent event protocol on worker stdio.
+//   - internal/cli (exec) : a worker is a `zero exec -i/-o stream-json` process.
+//
+// The control plane (this file) is a small framed codec mirrored from the
+// reference daemon's protocol.js: a 4-byte big-endian length prefix, a 1-byte
+// frame kind, then a JSON control payload, with a 1 MiB frame cap and a
+// version-negotiation handshake. The agent event stream itself stays stream-json.
+package daemon
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Wire constants. Mirrors reference-daemon-code-agent-js/protocol.js
+// (FRAME_DATA/FRAME_CTRL, HEADER_SIZE, MAX_FRAME_SIZE, PROTO_VERSION).
+const (
+	// ProtoVersion is the control-protocol version advertised in the handshake.
+	ProtoVersion = 1
+	// MaxFrameSize caps a single control frame payload at 1 MiB. A larger
+	// advertised length is rejected before any allocation (fail closed).
+	MaxFrameSize = 1 << 20
+	// frameHeaderSize is 4 bytes big-endian length + 1 byte kind.
+	frameHeaderSize = 5
+)
+
+// FrameKind tags a frame's payload. Mirrors protocol.js FRAME_DATA/FRAME_CTRL.
+type FrameKind uint8
+
+const (
+	// KindData carries an opaque payload (e.g. a stream-json line). Reserved for
+	// future use; the control plane uses KindCtrl.
+	KindData FrameKind = 0
+	// KindCtrl carries a JSON-encoded control message (see Ctrl).
+	KindCtrl FrameKind = 1
+)
+
+// ErrFrameTooLarge is returned when a frame's advertised payload length exceeds
+// MaxFrameSize. The reader rejects it without allocating the buffer.
+var ErrFrameTooLarge = errors.New("daemon: control frame exceeds size cap")
+
+// ErrUnknownFrameKind is returned for a frame whose kind byte is not recognized.
+var ErrUnknownFrameKind = errors.New("daemon: unknown control frame kind")
+
+// WriteFrame writes a single framed message: [uint32BE len][uint8 kind][payload].
+// It rejects an over-cap payload before writing anything so a buggy/hostile caller
+// cannot emit a frame a conforming reader would refuse.
+func WriteFrame(w io.Writer, kind FrameKind, payload []byte) error {
+	if len(payload) > MaxFrameSize {
+		return fmt.Errorf("%w (%d > %d)", ErrFrameTooLarge, len(payload), MaxFrameSize)
+	}
+	header := make([]byte, frameHeaderSize)
+	binary.BigEndian.PutUint32(header[:4], uint32(len(payload)))
+	header[4] = byte(kind)
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		return nil
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+// ReadFrame reads a single framed message. It validates the advertised length
+// against MaxFrameSize BEFORE allocating, so an oversize or hostile frame is
+// rejected (ErrFrameTooLarge) rather than triggering a huge allocation. An
+// unrecognized kind byte yields ErrUnknownFrameKind after the payload is drained
+// so the stream stays in sync.
+func ReadFrame(r io.Reader) (FrameKind, []byte, error) {
+	header := make([]byte, frameHeaderSize)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return 0, nil, err
+	}
+	length := binary.BigEndian.Uint32(header[:4])
+	if length > MaxFrameSize {
+		return 0, nil, fmt.Errorf("%w (%d > %d)", ErrFrameTooLarge, length, MaxFrameSize)
+	}
+	kind := FrameKind(header[4])
+	payload := make([]byte, length)
+	if length > 0 {
+		if _, err := io.ReadFull(r, payload); err != nil {
+			return 0, nil, err
+		}
+	}
+	if kind != KindData && kind != KindCtrl {
+		return kind, nil, ErrUnknownFrameKind
+	}
+	return kind, payload, nil
+}
+
+// CtrlType is the discriminator for a control message.
+type CtrlType string
+
+const (
+	// CtrlHello is the client's opening handshake; Version is the highest control
+	// version it speaks.
+	CtrlHello CtrlType = "hello"
+	// CtrlHelloOK is the daemon's handshake reply with the negotiated Version.
+	CtrlHelloOK CtrlType = "hello_ok"
+	// CtrlRun asks the daemon to create/route a session and stream its output.
+	CtrlRun CtrlType = "run"
+	// CtrlAttach asks the daemon to attach the client to a running session's stream.
+	CtrlAttach CtrlType = "attach"
+	// CtrlStatus requests daemon/worker/session status.
+	CtrlStatus CtrlType = "status"
+	// CtrlStatusResult carries the status payload (see StatusReport in Status).
+	CtrlStatusResult CtrlType = "status_result"
+	// CtrlData carries one stream-json line of agent output back to the client.
+	CtrlData CtrlType = "data"
+	// CtrlAck acknowledges receipt/dispatch of a request (at-least-once dispatch).
+	CtrlAck CtrlType = "ack"
+	// CtrlEnd marks the end of a session's stream.
+	CtrlEnd CtrlType = "end"
+	// CtrlShutdown asks the daemon to drain and stop.
+	CtrlShutdown CtrlType = "shutdown"
+	// CtrlError carries a human-readable error for the client.
+	CtrlError CtrlType = "error"
+)
+
+// Ctrl is a control message carried in a KindCtrl frame as JSON. Unused fields
+// are omitted so frames stay small.
+type Ctrl struct {
+	Type    CtrlType `json:"type"`
+	Version int      `json:"version,omitempty"`
+	Session string   `json:"session,omitempty"`
+	Cwd     string   `json:"cwd,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	Prompt  string   `json:"prompt,omitempty"`
+	// Line is one stream-json event line (for CtrlData).
+	Line string `json:"line,omitempty"`
+	// Message is a human-readable detail (for CtrlError / CtrlAck).
+	Message string `json:"message,omitempty"`
+	// Status is populated on CtrlStatusResult.
+	Status *StatusReport `json:"status,omitempty"`
+}
+
+// WriteControl marshals a control message into a KindCtrl frame.
+func WriteControl(w io.Writer, msg Ctrl) error {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return WriteFrame(w, KindCtrl, payload)
+}
+
+// ReadControl reads the next frame and decodes it as a control message. A
+// non-control frame yields ErrUnknownFrameKind so the caller fails closed.
+func ReadControl(r io.Reader) (Ctrl, error) {
+	kind, payload, err := ReadFrame(r)
+	if err != nil {
+		return Ctrl{}, err
+	}
+	if kind != KindCtrl {
+		return Ctrl{}, ErrUnknownFrameKind
+	}
+	var msg Ctrl
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		return Ctrl{}, fmt.Errorf("daemon: decode control message: %w", err)
+	}
+	return msg, nil
+}
+
+// NegotiateVersion picks the protocol version both ends can speak: the lower of
+// the client's advertised version and ProtoVersion. A non-positive client
+// version is invalid and yields ok=false so the daemon can reject the connection.
+func NegotiateVersion(clientVersion int) (int, bool) {
+	if clientVersion <= 0 {
+		return 0, false
+	}
+	if clientVersion < ProtoVersion {
+		return clientVersion, true
+	}
+	return ProtoVersion, true
+}

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	payloads := [][]byte{[]byte("hello"), {}, []byte(strings.Repeat("x", 4096))}
+	for _, p := range payloads {
+		if err := WriteFrame(&buf, KindCtrl, p); err != nil {
+			t.Fatalf("WriteFrame: %v", err)
+		}
+	}
+	for i, want := range payloads {
+		kind, got, err := ReadFrame(&buf)
+		if err != nil {
+			t.Fatalf("ReadFrame[%d]: %v", i, err)
+		}
+		if kind != KindCtrl {
+			t.Fatalf("frame[%d] kind = %d, want KindCtrl", i, kind)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("frame[%d] payload = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestControlRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	msg := Ctrl{Type: CtrlRun, Session: "s1", Cwd: "/tmp", Args: []string{"--prompt", "hi"}}
+	if err := WriteControl(&buf, msg); err != nil {
+		t.Fatalf("WriteControl: %v", err)
+	}
+	got, err := ReadControl(&buf)
+	if err != nil {
+		t.Fatalf("ReadControl: %v", err)
+	}
+	if got.Type != CtrlRun || got.Session != "s1" || got.Cwd != "/tmp" || len(got.Args) != 2 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestWriteFrameRejectsOversize(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteFrame(&buf, KindCtrl, make([]byte, MaxFrameSize+1))
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("WriteFrame oversize err = %v, want ErrFrameTooLarge", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("oversize WriteFrame must not emit any bytes, wrote %d", buf.Len())
+	}
+}
+
+func TestReadFrameRejectsOversizeBeforeAlloc(t *testing.T) {
+	// A header advertising a 4 GiB payload must be rejected without reading or
+	// allocating that payload.
+	header := make([]byte, frameHeaderSize)
+	binary.BigEndian.PutUint32(header[:4], MaxFrameSize+1)
+	header[4] = byte(KindCtrl)
+	_, _, err := ReadFrame(bytes.NewReader(header))
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("ReadFrame oversize err = %v, want ErrFrameTooLarge", err)
+	}
+}
+
+func TestReadFrameUnknownKind(t *testing.T) {
+	var buf bytes.Buffer
+	// Hand-write a frame with an unknown kind byte (7) and a small payload.
+	header := make([]byte, frameHeaderSize)
+	binary.BigEndian.PutUint32(header[:4], 2)
+	header[4] = 7
+	buf.Write(header)
+	buf.Write([]byte("ab"))
+	_, _, err := ReadFrame(&buf)
+	if !errors.Is(err, ErrUnknownFrameKind) {
+		t.Fatalf("unknown kind err = %v, want ErrUnknownFrameKind", err)
+	}
+}
+
+func TestReadFrameTruncated(t *testing.T) {
+	// Header promises 10 bytes but only 3 follow → unexpected EOF.
+	var buf bytes.Buffer
+	header := make([]byte, frameHeaderSize)
+	binary.BigEndian.PutUint32(header[:4], 10)
+	header[4] = byte(KindCtrl)
+	buf.Write(header)
+	buf.Write([]byte("abc"))
+	_, _, err := ReadFrame(&buf)
+	if err == nil || errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("truncated frame err = %v, want a read error", err)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("truncated frame err = %v, want io.ErrUnexpectedEOF", err)
+	}
+}
+
+func TestNegotiateVersion(t *testing.T) {
+	cases := []struct {
+		client int
+		want   int
+		wantOK bool
+	}{
+		{client: 1, want: 1, wantOK: true},
+		{client: 99, want: ProtoVersion, wantOK: true}, // clamp down to ours
+		{client: 0, want: 0, wantOK: false},
+		{client: -3, want: 0, wantOK: false},
+	}
+	for _, tc := range cases {
+		got, ok := NegotiateVersion(tc.client)
+		if got != tc.want || ok != tc.wantOK {
+			t.Fatalf("NegotiateVersion(%d) = (%d,%v), want (%d,%v)", tc.client, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,0 +1,294 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// Server is the daemon control plane. Mirrors reference-daemon-code-agent-js/
+// supervisor.js (single-instance lock, status file, lifecycle) + the accept loop
+// that routes framed control requests to the SessionManager/Pool. It listens on
+// an owner-only local Unix socket and NEVER binds a TCP port.
+type Server struct {
+	opts      ServerOptions
+	startedAt time.Time
+
+	listener net.Listener
+	lock     *fileLock
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	wg           sync.WaitGroup
+	shutdownOnce sync.Once
+	done         chan struct{}
+}
+
+// ServerOptions configures a Server.
+type ServerOptions struct {
+	Paths   Paths
+	Manager *SessionManager
+	Pool    *Pool
+	Version int
+	Now     func() time.Time
+	Log     func(string)
+	isAlive func(int) bool // test hook for the single-instance lock
+}
+
+// NewServer validates options and builds a Server.
+func NewServer(opts ServerOptions) (*Server, error) {
+	if opts.Manager == nil || opts.Pool == nil {
+		return nil, errors.New("daemon: server requires a Pool and SessionManager")
+	}
+	if opts.Paths.Socket == "" || opts.Paths.Lock == "" || opts.Paths.Status == "" {
+		return nil, errors.New("daemon: server requires socket, lock, and status paths")
+	}
+	if opts.Version <= 0 {
+		opts.Version = ProtoVersion
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Server{
+		opts:   opts,
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}, nil
+}
+
+func (s *Server) logf(format string, args ...any) {
+	if s.opts.Log != nil {
+		s.opts.Log(fmt.Sprintf(format, args...))
+	}
+}
+
+// Serve acquires the single-instance lock, binds the owner-only control socket,
+// writes the status file, and serves connections until Shutdown. It blocks. On
+// return it has released the lock and removed the socket/status files.
+func (s *Server) Serve() error {
+	if err := checkSocketPathLength(s.opts.Paths.Socket); err != nil {
+		return err
+	}
+	if err := secureSocketParent(s.opts.Paths.Socket); err != nil {
+		return err
+	}
+	lock, err := acquireLock(s.opts.Paths.Lock, s.opts.isAlive)
+	if err != nil {
+		return err
+	}
+	s.lock = lock
+	defer s.cleanup()
+
+	// A leftover socket file from an unclean exit would make Listen fail with
+	// "address already in use"; we hold the lock, so any socket here is stale.
+	_ = os.Remove(s.opts.Paths.Socket)
+
+	listener, err := net.Listen("unix", s.opts.Paths.Socket)
+	if err != nil {
+		return fmt.Errorf("daemon: bind control socket: %w", err)
+	}
+	s.listener = listener
+	if err := hardenSocketFile(s.opts.Paths.Socket); err != nil {
+		return fmt.Errorf("daemon: harden control socket: %w", err)
+	}
+	s.startedAt = s.opts.Now()
+	if err := s.writeStatusFile(); err != nil {
+		return err
+	}
+	s.logf("daemon listening on %s (pid %d)", s.opts.Paths.Socket, os.Getpid())
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			select {
+			case <-s.done:
+				s.wg.Wait()
+				return nil // clean shutdown
+			default:
+				// Transient accept error during normal operation.
+				s.logf("accept error: %v", err)
+				return fmt.Errorf("daemon: accept: %w", err)
+			}
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handleConn(conn)
+		}()
+	}
+}
+
+// Shutdown stops accepting connections, cancels in-flight runs, drains the pool,
+// and removes the socket/lock/status files. Safe to call multiple times.
+func (s *Server) Shutdown() {
+	s.shutdownOnce.Do(func() {
+		close(s.done)
+		s.cancel() // stop in-flight pool runs
+		if s.listener != nil {
+			_ = s.listener.Close()
+		}
+		s.opts.Pool.Drain()
+	})
+}
+
+func (s *Server) cleanup() {
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+	_ = os.Remove(s.opts.Paths.Socket)
+	_ = os.Remove(s.opts.Paths.Status)
+	if s.lock != nil {
+		_ = s.lock.release()
+	}
+}
+
+func (s *Server) writeStatusFile() error {
+	status := StatusFile{
+		PID:       os.Getpid(),
+		Socket:    s.opts.Paths.Socket,
+		Version:   s.opts.Version,
+		StartedAt: s.startedAt,
+	}
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(s.opts.Paths.Status, data, 0o600); err != nil {
+		return fmt.Errorf("daemon: write status file: %w", err)
+	}
+	return nil
+}
+
+// handleConn performs the handshake then dispatches a single control command.
+func (s *Server) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	hello, err := ReadControl(conn)
+	if err != nil {
+		return
+	}
+	if hello.Type != CtrlHello {
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: "expected hello"})
+		return
+	}
+	version, ok := NegotiateVersion(hello.Version)
+	if !ok {
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: "unsupported protocol version"})
+		return
+	}
+	if err := WriteControl(conn, Ctrl{Type: CtrlHelloOK, Version: version}); err != nil {
+		return
+	}
+
+	cmd, err := ReadControl(conn)
+	if err != nil {
+		return
+	}
+	switch cmd.Type {
+	case CtrlRun:
+		s.handleRun(conn, cmd)
+	case CtrlAttach:
+		s.handleAttach(conn, cmd)
+	case CtrlStatus:
+		s.handleStatus(conn)
+	case CtrlShutdown:
+		_ = WriteControl(conn, Ctrl{Type: CtrlAck, Message: "shutting down"})
+		s.Shutdown()
+	default:
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: fmt.Sprintf("unknown command %q", cmd.Type)})
+	}
+}
+
+func (s *Server) handleRun(conn net.Conn, cmd Ctrl) {
+	if cmd.Session == "" {
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: "run requires a session id"})
+		return
+	}
+	args := cmd.Args
+	if cmd.Prompt != "" {
+		args = append(args, "--prompt", cmd.Prompt)
+	}
+	sess, err := s.opts.Manager.Start(s.ctx, WorkerSpec{Session: cmd.Session, Cwd: cmd.Cwd, Args: args})
+	if err != nil {
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: err.Error()})
+		return
+	}
+	_ = WriteControl(conn, Ctrl{Type: CtrlAck, Session: sess.ID()})
+	buffered, live, cancel := sess.Subscribe()
+	defer cancel()
+	s.streamToClient(conn, sess, buffered, live)
+}
+
+func (s *Server) handleAttach(conn net.Conn, cmd Ctrl) {
+	if cmd.Session == "" {
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: "attach requires a session id"})
+		return
+	}
+	buffered, live, cancel, err := s.opts.Manager.Attach(cmd.Session)
+	if err != nil {
+		_ = WriteControl(conn, Ctrl{Type: CtrlError, Message: err.Error()})
+		return
+	}
+	defer cancel()
+	sess, _ := s.opts.Manager.Get(cmd.Session)
+	_ = WriteControl(conn, Ctrl{Type: CtrlAck, Session: cmd.Session})
+	s.streamToClient(conn, sess, buffered, live)
+}
+
+// streamToClient writes the buffered history then live lines as CtrlData frames,
+// finishing with CtrlEnd (or CtrlError if the session failed). A write error
+// (client disconnected) ends the stream without affecting the session.
+func (s *Server) streamToClient(conn net.Conn, sess *Session, buffered []string, live <-chan string) {
+	for _, line := range buffered {
+		if err := WriteControl(conn, Ctrl{Type: CtrlData, Line: line}); err != nil {
+			return
+		}
+	}
+	for {
+		select {
+		case line, ok := <-live:
+			if !ok {
+				s.finishStream(conn, sess)
+				return
+			}
+			if err := WriteControl(conn, Ctrl{Type: CtrlData, Line: line}); err != nil {
+				return
+			}
+		case <-s.done:
+			_ = WriteControl(conn, Ctrl{Type: CtrlEnd, Message: "daemon shutting down"})
+			return
+		}
+	}
+}
+
+func (s *Server) finishStream(conn net.Conn, sess *Session) {
+	if sess != nil {
+		if err := sess.Err(); err != nil {
+			_ = WriteControl(conn, Ctrl{Type: CtrlError, Session: sess.ID(), Message: err.Error()})
+			return
+		}
+	}
+	_ = WriteControl(conn, Ctrl{Type: CtrlEnd})
+}
+
+func (s *Server) handleStatus(conn net.Conn) {
+	report := StatusReport{
+		PID:        os.Getpid(),
+		Version:    s.opts.Version,
+		Socket:     s.opts.Paths.Socket,
+		StartedAt:  s.startedAt,
+		PoolSize:   s.opts.Pool.Size(),
+		Workers:    s.opts.Pool.WorkerStats(),
+		Sessions:   s.opts.Manager.Statuses(),
+		QueueDepth: s.opts.Pool.QueueDepth(),
+	}
+	_ = WriteControl(conn, Ctrl{Type: CtrlStatusResult, Status: &report})
+}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestServer(t *testing.T, launcher Launcher) (*Server, Paths) {
+	t.Helper()
+	dir := t.TempDir()
+	paths := Paths{
+		Socket: filepath.Join(dir, "d.sock"),
+		Lock:   filepath.Join(dir, "d.lock"),
+		Status: filepath.Join(dir, "d.status"),
+	}
+	pool, err := NewPool(PoolOptions{Size: 2, Launcher: launcher, KillTimeout: 200 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	mgr, err := NewSessionManager(SessionManagerOptions{Pool: pool})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	srv, err := NewServer(ServerOptions{Paths: paths, Manager: mgr, Pool: pool})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, paths
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("file %s did not appear within timeout", path)
+}
+
+func TestServerEndToEnd(t *testing.T) {
+	out := []string{`{"type":"event","seq":1}`, `{"type":"event","seq":2}`}
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, out: out, exitCode: 0})
+	srv, paths := newTestServer(t, launcher)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve() }()
+	waitForFile(t, paths.Status)
+
+	// --- run a session and collect its stream-json output ---
+	runClient, err := Dial(paths.Socket)
+	if err != nil {
+		t.Fatalf("Dial(run): %v", err)
+	}
+	var got []string
+	if err := runClient.Run("s1", "", "hello", nil, func(line string) { got = append(got, line) }); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	runClient.Close()
+	if len(got) != 2 || got[0] != out[0] || got[1] != out[1] {
+		t.Fatalf("streamed lines = %v, want %v", got, out)
+	}
+
+	// --- status reflects the session ---
+	statusClient, err := Dial(paths.Socket)
+	if err != nil {
+		t.Fatalf("Dial(status): %v", err)
+	}
+	report, err := statusClient.Status()
+	statusClient.Close()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if report.PoolSize != 2 {
+		t.Fatalf("status PoolSize = %d, want 2", report.PoolSize)
+	}
+	foundSession := false
+	for _, s := range report.Sessions {
+		if s.ID == "s1" {
+			foundSession = true
+			if s.State != string(SessionDone) {
+				t.Fatalf("session s1 state = %s, want done", s.State)
+			}
+		}
+	}
+	if !foundSession {
+		t.Fatalf("status missing session s1: %+v", report.Sessions)
+	}
+
+	// --- attach to the finished session sees the buffered history ---
+	attachClient, err := Dial(paths.Socket)
+	if err != nil {
+		t.Fatalf("Dial(attach): %v", err)
+	}
+	var attached []string
+	if err := attachClient.Attach("s1", func(line string) { attached = append(attached, line) }); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	attachClient.Close()
+	if len(attached) != 2 {
+		t.Fatalf("attach lines = %v, want 2 buffered", attached)
+	}
+
+	// --- graceful stop, daemon cleans up ---
+	stopClient, err := Dial(paths.Socket)
+	if err != nil {
+		t.Fatalf("Dial(stop): %v", err)
+	}
+	if err := stopClient.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	stopClient.Close()
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return after shutdown")
+	}
+	// Socket, status, and lock files are removed on exit.
+	for _, p := range []string{paths.Socket, paths.Status, paths.Lock} {
+		if _, err := os.Stat(p); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("file %s not cleaned up after shutdown: %v", p, err)
+		}
+	}
+}
+
+func TestServerSecondInstanceFails(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, waitCh: block})
+	srv1, paths := newTestServer(t, launcher)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv1.Serve() }()
+	waitForFile(t, paths.Status)
+
+	// A second server on the same paths must refuse to start (single instance).
+	pool2, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher})
+	mgr2, _ := NewSessionManager(SessionManagerOptions{Pool: pool2})
+	srv2, _ := NewServer(ServerOptions{Paths: paths, Manager: mgr2, Pool: pool2})
+	if err := srv2.Serve(); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("second Serve err = %v, want ErrAlreadyRunning", err)
+	}
+
+	srv1.Shutdown()
+	<-serveErr
+}
+
+func TestServerRejectsUnknownCommand(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, waitCh: block})
+	srv, paths := newTestServer(t, launcher)
+	go func() { _ = srv.Serve() }()
+	defer srv.Shutdown()
+	waitForFile(t, paths.Status)
+
+	client, err := Dial(paths.Socket)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer client.Close()
+	// Run with an empty session id is rejected with an error frame.
+	err = client.Run("", "", "hi", nil, nil)
+	if err == nil {
+		t.Fatal("run with empty session id must return an error")
+	}
+}

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -1,0 +1,259 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+)
+
+// Session/lease/roster model. Mirrors reference-daemon-code-agent-js/
+// session-manager.js (sessionID -> worker + metrics), lease.js (one active
+// request per worker) and roster.js (the live session registry). Because zero's
+// `exec` worker is one-shot, each session is served by exactly one worker via
+// Pool.Run, so "one active request per worker" holds inherently and the pool's
+// bounded slots provide the queue-when-full behavior.
+
+// SessionState is a session's lifecycle phase.
+type SessionState string
+
+const (
+	// SessionQueued: created, waiting for a free pool slot.
+	SessionQueued SessionState = "queued"
+	// SessionRunning: a worker is leased and producing output.
+	SessionRunning SessionState = "running"
+	// SessionDone: the worker finished cleanly.
+	SessionDone SessionState = "done"
+	// SessionFailed: the worker failed permanently / the run errored.
+	SessionFailed SessionState = "failed"
+)
+
+// ErrSessionExists is returned when starting a session ID already in use.
+var ErrSessionExists = errors.New("daemon: session already exists")
+
+// ErrSessionNotFound is returned by Get/Attach for an unknown session ID.
+var ErrSessionNotFound = errors.New("daemon: session not found")
+
+const defaultSessionBuffer = 1024
+
+// Session is one routed agent run. It buffers recent output (so a late `attach`
+// sees history) and fans live lines out to subscribers. It implements the pool's
+// Sink (Line) and the lease "started" hook (Started).
+type Session struct {
+	id  string
+	cwd string
+
+	mu          sync.Mutex
+	state       SessionState
+	buffer      []string
+	maxBuffer   int
+	lines       int
+	finished    bool
+	err         error
+	exitCode    int
+	subscribers map[int]chan string
+	nextSub     int
+	done        chan struct{}
+}
+
+func newSession(id, cwd string, maxBuffer int) *Session {
+	if maxBuffer <= 0 {
+		maxBuffer = defaultSessionBuffer
+	}
+	return &Session{
+		id:          id,
+		cwd:         cwd,
+		state:       SessionQueued,
+		maxBuffer:   maxBuffer,
+		subscribers: map[int]chan string{},
+		done:        make(chan struct{}),
+	}
+}
+
+// ID returns the session ID.
+func (s *Session) ID() string { return s.id }
+
+// Done is closed when the session finishes (success or failure).
+func (s *Session) Done() <-chan struct{} { return s.done }
+
+// Err returns the terminal error (nil on clean completion); valid after Done.
+func (s *Session) Err() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+// State returns the current lifecycle phase.
+func (s *Session) State() SessionState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.state
+}
+
+// Started marks the session running once the pool leases a worker (lease hook).
+func (s *Session) Started() {
+	s.mu.Lock()
+	if s.state == SessionQueued {
+		s.state = SessionRunning
+	}
+	s.mu.Unlock()
+}
+
+// Line records and broadcasts one stream-json output line.
+func (s *Session) Line(line string) {
+	s.mu.Lock()
+	s.lines++
+	s.buffer = append(s.buffer, line)
+	if len(s.buffer) > s.maxBuffer {
+		// Drop the oldest line; the ring keeps only the most recent maxBuffer.
+		s.buffer = s.buffer[len(s.buffer)-s.maxBuffer:]
+	}
+	subs := make([]chan string, 0, len(s.subscribers))
+	for _, ch := range s.subscribers {
+		subs = append(subs, ch)
+	}
+	s.mu.Unlock()
+	for _, ch := range subs {
+		// Non-blocking: a slow/stalled subscriber must not stall the worker pump.
+		// Dropped live lines remain available via the buffer for a fresh attach.
+		select {
+		case ch <- line:
+		default:
+		}
+	}
+}
+
+func (s *Session) finish(exitCode int, err error) {
+	s.mu.Lock()
+	s.finished = true
+	s.exitCode = exitCode
+	s.err = err
+	if err != nil {
+		s.state = SessionFailed
+	} else {
+		s.state = SessionDone
+	}
+	subs := s.subscribers
+	s.subscribers = map[int]chan string{}
+	s.mu.Unlock()
+	for _, ch := range subs {
+		close(ch)
+	}
+	close(s.done)
+}
+
+// Subscribe returns the buffered history plus a channel of subsequent live lines
+// and a cancel func. If the session has already finished, the live channel is
+// returned already closed. Mirrors attach.js.
+func (s *Session) Subscribe() (buffered []string, live <-chan string, cancel func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	buffered = append([]string(nil), s.buffer...)
+	if s.finished {
+		ch := make(chan string)
+		close(ch)
+		return buffered, ch, func() {}
+	}
+	id := s.nextSub
+	s.nextSub++
+	ch := make(chan string, 256)
+	s.subscribers[id] = ch
+	cancel = func() {
+		s.mu.Lock()
+		if c, ok := s.subscribers[id]; ok {
+			delete(s.subscribers, id)
+			close(c)
+		}
+		s.mu.Unlock()
+	}
+	return buffered, ch, cancel
+}
+
+func (s *Session) status() SessionStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SessionStatus{ID: s.id, State: string(s.state), Lines: s.lines}
+}
+
+// SessionManager owns the live session registry and routes each session to a
+// pool worker. Mirrors session-manager.js + roster.js.
+type SessionManager struct {
+	pool      *Pool
+	maxBuffer int
+
+	mu       sync.Mutex
+	sessions map[string]*Session
+}
+
+// SessionManagerOptions configures a SessionManager.
+type SessionManagerOptions struct {
+	Pool      *Pool
+	MaxBuffer int // per-session output ring size; 0 => default
+}
+
+// NewSessionManager builds a manager over pool.
+func NewSessionManager(opts SessionManagerOptions) (*SessionManager, error) {
+	if opts.Pool == nil {
+		return nil, errors.New("daemon: session manager requires a Pool")
+	}
+	return &SessionManager{
+		pool:      opts.Pool,
+		maxBuffer: opts.MaxBuffer,
+		sessions:  map[string]*Session{},
+	}, nil
+}
+
+// Start creates a session for spec and dispatches it to the pool. It returns the
+// Session immediately (non-blocking); the run proceeds in the background and the
+// session transitions queued -> running -> done/failed. A duplicate ID is
+// rejected with ErrSessionExists.
+func (m *SessionManager) Start(ctx context.Context, spec WorkerSpec) (*Session, error) {
+	m.mu.Lock()
+	if _, exists := m.sessions[spec.Session]; exists {
+		m.mu.Unlock()
+		return nil, ErrSessionExists
+	}
+	sess := newSession(spec.Session, spec.Cwd, m.maxBuffer)
+	m.sessions[spec.Session] = sess
+	m.mu.Unlock()
+
+	go func() {
+		code, err := m.pool.Run(ctx, spec, sess)
+		sess.finish(code, err)
+	}()
+	return sess, nil
+}
+
+// Get returns a session by ID.
+func (m *SessionManager) Get(id string) (*Session, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[id]
+	return s, ok
+}
+
+// Attach returns the buffered history + live stream for an existing session.
+func (m *SessionManager) Attach(id string) (buffered []string, live <-chan string, cancel func(), err error) {
+	s, ok := m.Get(id)
+	if !ok {
+		return nil, nil, nil, ErrSessionNotFound
+	}
+	b, l, c := s.Subscribe()
+	return b, l, c, nil
+}
+
+// Statuses returns a snapshot of all sessions, sorted by ID for stable output.
+func (m *SessionManager) Statuses() []SessionStatus {
+	m.mu.Lock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		sessions = append(sessions, s)
+	}
+	m.mu.Unlock()
+	out := make([]SessionStatus, 0, len(sessions))
+	for _, s := range sessions {
+		out = append(out, s.status())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -175,20 +175,37 @@ func (s *Session) status() SessionStatus {
 	return SessionStatus{ID: s.id, State: string(s.state), Lines: s.lines}
 }
 
+func (s *Session) isFinished() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.finished
+}
+
+// defaultMaxSessions bounds the retained session registry so a long-running
+// daemon does not accumulate finished sessions without limit.
+const defaultMaxSessions = 256
+
 // SessionManager owns the live session registry and routes each session to a
-// pool worker. Mirrors session-manager.js + roster.js.
+// pool worker. Mirrors session-manager.js + roster.js. Finished sessions are
+// retained (so a late `attach` sees history) up to MaxSessions, past which the
+// oldest FINISHED ones are evicted; running/queued sessions are never evicted.
 type SessionManager struct {
-	pool      *Pool
-	maxBuffer int
+	pool        *Pool
+	maxBuffer   int
+	maxSessions int
 
 	mu       sync.Mutex
 	sessions map[string]*Session
+	order    []string // creation order, for FIFO eviction of finished sessions
 }
 
 // SessionManagerOptions configures a SessionManager.
 type SessionManagerOptions struct {
 	Pool      *Pool
 	MaxBuffer int // per-session output ring size; 0 => default
+	// MaxSessions caps the retained session registry; 0 => default. The oldest
+	// FINISHED sessions are evicted once the cap is exceeded.
+	MaxSessions int
 }
 
 // NewSessionManager builds a manager over pool.
@@ -196,10 +213,15 @@ func NewSessionManager(opts SessionManagerOptions) (*SessionManager, error) {
 	if opts.Pool == nil {
 		return nil, errors.New("daemon: session manager requires a Pool")
 	}
+	maxSessions := opts.MaxSessions
+	if maxSessions <= 0 {
+		maxSessions = defaultMaxSessions
+	}
 	return &SessionManager{
-		pool:      opts.Pool,
-		maxBuffer: opts.MaxBuffer,
-		sessions:  map[string]*Session{},
+		pool:        opts.Pool,
+		maxBuffer:   opts.MaxBuffer,
+		maxSessions: maxSessions,
+		sessions:    map[string]*Session{},
 	}, nil
 }
 
@@ -215,6 +237,8 @@ func (m *SessionManager) Start(ctx context.Context, spec WorkerSpec) (*Session, 
 	}
 	sess := newSession(spec.Session, spec.Cwd, m.maxBuffer)
 	m.sessions[spec.Session] = sess
+	m.order = append(m.order, spec.Session)
+	m.pruneLocked()
 	m.mu.Unlock()
 
 	go func() {
@@ -222,6 +246,29 @@ func (m *SessionManager) Start(ctx context.Context, spec WorkerSpec) (*Session, 
 		sess.finish(code, err)
 	}()
 	return sess, nil
+}
+
+// pruneLocked evicts the oldest FINISHED sessions while the registry exceeds
+// maxSessions, so a long-running daemon does not retain finished sessions without
+// bound. Running/queued sessions are never evicted (a transient burst can exceed
+// the cap until those finish). Caller must hold m.mu.
+func (m *SessionManager) pruneLocked() {
+	if len(m.sessions) <= m.maxSessions {
+		return
+	}
+	kept := m.order[:0]
+	for _, id := range m.order {
+		s, ok := m.sessions[id]
+		if !ok {
+			continue // already removed
+		}
+		if len(m.sessions) > m.maxSessions && s.isFinished() {
+			delete(m.sessions, id)
+			continue
+		}
+		kept = append(kept, id)
+	}
+	m.order = kept
 }
 
 // Get returns a session by ID.

--- a/internal/daemon/session_test.go
+++ b/internal/daemon/session_test.go
@@ -114,6 +114,58 @@ func TestSessionAttachAfterFinishSeesBuffer(t *testing.T) {
 	}
 }
 
+func TestSessionManagerEvictsFinishedOverCap(t *testing.T) {
+	launcher, _ := seqLauncher(
+		&fakeWorker{pid: 1, out: []string{"a"}, exitCode: 0},
+		&fakeWorker{pid: 2, out: []string{"b"}, exitCode: 0},
+		&fakeWorker{pid: 3, out: []string{"c"}, exitCode: 0},
+	)
+	pool, _ := NewPool(PoolOptions{Size: 2, Launcher: launcher})
+	mgr, _ := NewSessionManager(SessionManagerOptions{Pool: pool, MaxSessions: 2})
+
+	for _, id := range []string{"s1", "s2", "s3"} {
+		s, err := mgr.Start(context.Background(), WorkerSpec{Session: id})
+		if err != nil {
+			t.Fatalf("Start(%s): %v", id, err)
+		}
+		<-s.Done() // finish before starting the next so prune can evict it
+	}
+
+	// Past the cap of 2, the oldest FINISHED session (s1) is evicted; the two
+	// newest are retained.
+	if _, ok := mgr.Get("s1"); ok {
+		t.Fatal("oldest finished session must be evicted past the cap")
+	}
+	if _, ok := mgr.Get("s2"); !ok {
+		t.Fatal("s2 must be retained")
+	}
+	if _, ok := mgr.Get("s3"); !ok {
+		t.Fatal("s3 (newest) must be retained")
+	}
+}
+
+func TestSessionManagerKeepsRunningOverCap(t *testing.T) {
+	// All sessions are running (workers block), so none are evicted even past cap.
+	block := make(chan struct{})
+	defer close(block)
+	launcher, _ := seqLauncher(
+		&fakeWorker{pid: 1, waitCh: block},
+		&fakeWorker{pid: 2, waitCh: block},
+	)
+	pool, _ := NewPool(PoolOptions{Size: 2, Launcher: launcher})
+	mgr, _ := NewSessionManager(SessionManagerOptions{Pool: pool, MaxSessions: 1})
+
+	s1, _ := mgr.Start(context.Background(), WorkerSpec{Session: "r1"})
+	s2, _ := mgr.Start(context.Background(), WorkerSpec{Session: "r2"})
+	waitFor(t, func() bool { return s1.State() == SessionRunning && s2.State() == SessionRunning })
+	if _, ok := mgr.Get("r1"); !ok {
+		t.Fatal("a running session must never be evicted, even past the cap")
+	}
+	if _, ok := mgr.Get("r2"); !ok {
+		t.Fatal("a running session must never be evicted, even past the cap")
+	}
+}
+
 func TestSessionStatuses(t *testing.T) {
 	launcher, _ := seqLauncher(&fakeWorker{pid: 1, out: []string{"l"}, exitCode: 0})
 	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher})

--- a/internal/daemon/session_test.go
+++ b/internal/daemon/session_test.go
@@ -1,0 +1,127 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func drain(t *testing.T, buffered []string, live <-chan string) []string {
+	t.Helper()
+	got := append([]string(nil), buffered...)
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case line, ok := <-live:
+			if !ok {
+				return got
+			}
+			got = append(got, line)
+		case <-timeout:
+			t.Fatal("timed out draining session stream")
+		}
+	}
+}
+
+func TestSessionStartRoutesAndStreams(t *testing.T) {
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, out: []string{"e1", "e2", "e3"}, exitCode: 0})
+	pool, _ := NewPool(PoolOptions{Size: 2, Launcher: launcher})
+	mgr, err := NewSessionManager(SessionManagerOptions{Pool: pool})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	sess, err := mgr.Start(context.Background(), WorkerSpec{Session: "s1"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	buffered, live, cancel := sess.Subscribe()
+	defer cancel()
+	got := drain(t, buffered, live)
+	if len(got) != 3 || got[0] != "e1" || got[2] != "e3" {
+		t.Fatalf("streamed lines = %v, want [e1 e2 e3]", got)
+	}
+	<-sess.Done()
+	if sess.State() != SessionDone {
+		t.Fatalf("state = %s, want done", sess.State())
+	}
+}
+
+func TestSessionDuplicateIDRejected(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, waitCh: block})
+	pool, _ := NewPool(PoolOptions{Size: 2, Launcher: launcher})
+	mgr, _ := NewSessionManager(SessionManagerOptions{Pool: pool})
+	if _, err := mgr.Start(context.Background(), WorkerSpec{Session: "dup"}); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if _, err := mgr.Start(context.Background(), WorkerSpec{Session: "dup"}); !errors.Is(err, ErrSessionExists) {
+		t.Fatalf("second Start err = %v, want ErrSessionExists", err)
+	}
+}
+
+func TestSessionLeaseQueuesWhenPoolFull(t *testing.T) {
+	block := make(chan struct{})
+	a := &fakeWorker{pid: 1, waitCh: block}
+	b := &fakeWorker{pid: 2, out: []string{"b1"}, exitCode: 0}
+	launcher, calls := seqLauncher(a, b)
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher})
+	mgr, _ := NewSessionManager(SessionManagerOptions{Pool: pool})
+
+	sa, _ := mgr.Start(context.Background(), WorkerSpec{Session: "a"})
+	waitFor(t, func() bool { return sa.State() == SessionRunning })
+
+	sb, _ := mgr.Start(context.Background(), WorkerSpec{Session: "b"})
+	// b must stay queued (its worker not yet launched) while a holds the slot.
+	time.Sleep(50 * time.Millisecond)
+	if sb.State() != SessionQueued {
+		t.Fatalf("session b state = %s, want queued while pool full", sb.State())
+	}
+	if n := atomic.LoadInt32(calls); n != 1 {
+		t.Fatalf("launcher calls = %d, want 1 (b not launched yet)", n)
+	}
+
+	close(block) // a finishes, slot frees, b proceeds
+	<-sb.Done()
+	if sb.State() != SessionDone {
+		t.Fatalf("session b state = %s, want done", sb.State())
+	}
+	if n := atomic.LoadInt32(calls); n != 2 {
+		t.Fatalf("launcher calls = %d, want 2 after slot freed", n)
+	}
+}
+
+func TestSessionAttachAfterFinishSeesBuffer(t *testing.T) {
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, out: []string{"x", "y"}, exitCode: 0})
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher})
+	mgr, _ := NewSessionManager(SessionManagerOptions{Pool: pool})
+	sess, _ := mgr.Start(context.Background(), WorkerSpec{Session: "s"})
+	<-sess.Done()
+
+	buffered, live, cancel, err := mgr.Attach("s")
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	defer cancel()
+	got := drain(t, buffered, live)
+	if len(got) != 2 || got[0] != "x" || got[1] != "y" {
+		t.Fatalf("attach buffered = %v, want [x y]", got)
+	}
+	if _, _, _, err := mgr.Attach("missing"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("Attach(missing) err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestSessionStatuses(t *testing.T) {
+	launcher, _ := seqLauncher(&fakeWorker{pid: 1, out: []string{"l"}, exitCode: 0})
+	pool, _ := NewPool(PoolOptions{Size: 1, Launcher: launcher})
+	mgr, _ := NewSessionManager(SessionManagerOptions{Pool: pool})
+	sess, _ := mgr.Start(context.Background(), WorkerSpec{Session: "only"})
+	<-sess.Done()
+	st := mgr.Statuses()
+	if len(st) != 1 || st[0].ID != "only" || st[0].State != string(SessionDone) || st[0].Lines != 1 {
+		t.Fatalf("statuses = %+v, want one done session with 1 line", st)
+	}
+}

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// maxUnixSocketPath bounds the socket path to the smallest platform sun_path
+// limit so we surface a clear error instead of a cryptic bind failure. macOS
+// allows 104 bytes incl. the NUL (so 103 chars); Linux allows 108. 103 is the
+// safe cross-platform ceiling.
+const maxUnixSocketPath = 103
+
+// secureSocketParent creates the socket's parent directory owner-only (0700 on
+// POSIX; on Windows the per-user profile directory is already ACL-restricted).
+func secureSocketParent(socketPath string) error {
+	return os.MkdirAll(filepath.Dir(socketPath), 0o700)
+}
+
+// checkSocketPathLength rejects an over-long unix socket path before bind.
+func checkSocketPathLength(socketPath string) error {
+	if len(socketPath) > maxUnixSocketPath {
+		return fmt.Errorf("daemon: socket path too long (%d > %d): %s", len(socketPath), maxUnixSocketPath, socketPath)
+	}
+	return nil
+}

--- a/internal/daemon/socket_posix.go
+++ b/internal/daemon/socket_posix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package daemon
+
+import "os"
+
+// hardenSocketFile restricts the control socket to its owner (0600) so no other
+// local user can connect. Combined with the 0700 parent directory this makes the
+// control plane owner-only, as required by the security model.
+func hardenSocketFile(path string) error {
+	return os.Chmod(path, 0o600)
+}

--- a/internal/daemon/socket_windows.go
+++ b/internal/daemon/socket_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package daemon
+
+// hardenSocketFile is a no-op on Windows: AF_UNIX socket files do not honor POSIX
+// mode bits, and the daemon places the socket under the per-user profile
+// directory, which is already ACL-restricted to the owner. A dedicated restricted
+// ACL (or a named pipe with an explicit DACL) is a documented follow-up.
+func hardenSocketFile(string) error { return nil }

--- a/internal/daemon/status.go
+++ b/internal/daemon/status.go
@@ -1,0 +1,43 @@
+package daemon
+
+import "time"
+
+// StatusReport is the daemon/worker/session snapshot returned by `zero daemon
+// status` (CtrlStatusResult). Mirrors reference-daemon-code-agent-js/status.js.
+type StatusReport struct {
+	PID        int             `json:"pid"`
+	Version    int             `json:"version"`
+	Socket     string          `json:"socket"`
+	StartedAt  time.Time       `json:"startedAt"`
+	PoolSize   int             `json:"poolSize"`
+	Workers    []WorkerStatus  `json:"workers"`
+	Sessions   []SessionStatus `json:"sessions"`
+	QueueDepth int             `json:"queueDepth"`
+}
+
+// WorkerStatus is one worker's lifecycle snapshot.
+type WorkerStatus struct {
+	ID                 int    `json:"id"`
+	PID                int    `json:"pid"`
+	State              string `json:"state"`
+	ConsecutiveCrashes int    `json:"consecutiveCrashes"`
+	Restarts           int    `json:"restarts"`
+	Session            string `json:"session,omitempty"`
+}
+
+// SessionStatus is one session's routing/metrics snapshot.
+type SessionStatus struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+	Lines int    `json:"lines"`
+}
+
+// StatusFile is the on-disk daemon status document (pid, socket, version,
+// started-at), written next to the lock so `status`/`stop` work without a live
+// connection. Mirrors supervisor.js's status file.
+type StatusFile struct {
+	PID       int       `json:"pid"`
+	Socket    string    `json:"socket"`
+	Version   int       `json:"version"`
+	StartedAt time.Time `json:"startedAt"`
+}


### PR DESCRIPTION
## Summary
Adds `internal/daemon` + the `zero daemon start|stop|status|run|attach` subcommands: a long-running local service that supervises a pool of headless `zero exec` workers and routes multiple agent sessions to them over an **owner-only local Unix-domain control socket**. Fully **additive** — interactive and one-shot exec are unchanged.

## Reuses zero's building blocks
| zero code | how |
|---|---|
| `internal/background` | `ConfigureChildProcessGroup` (process-group setup) + `TerminateProcess` (cross-platform terminate) for worker kill/drain. The pool does its own `os/exec` and uses `background` only for these helpers. |
| `internal/streamjson` | workers speak stream-json on stdout; the daemon forwards those lines to clients. |
| `internal/cli` exec | a worker is `zero exec --output-format stream-json`. |

## Pieces (reimplemented in Go from a reference daemon)
| File | Mirrors | Behavior |
|---|---|---|
| `protocol.go` | `protocol.js` | framed control codec: 4-byte BE len + 1 kind byte, **1 MiB cap**, JSON control messages, version negotiation |
| `pool.go` + `backoff.go` | `worker-manager.js` | bounded pool; at-least-once dispatch with **exp backoff+jitter** retry capped by `MaxAttempts`; `EXIT_TEMPFAIL(75)`/`EXIT_PERMANENT(76)`; graceful **drain + kill-timeout** |
| `session.go` | `session-manager.js` / `lease.js` / `roster.js` | sessionID→worker routing, **lease** (one active request/worker), **queue** when full, per-session attach buffer + metrics |
| `server.go` + `lock.go` + `socket.go` + `paths.go` | `supervisor.js` / `status.js` | single-instance **PID-file lock + stale-lock (dead-PID) recovery**, status file, owner-only socket, accept loop, cleanup on exit |
| `launcher.go` / `client.go` | `spawner.js` / `attach.js` | production worker launcher; control-socket client |

**Design note:** zero's `exec` is one-shot (one prompt → run → exit), so workers are **on-demand** (one session per worker — the lease is inherent), not warm long-lived slots. Warm/pre-spawned persistent workers would need a persistent worker mode in `exec` → follow-up.

## Security model
- **Local-only**: AF_UNIX socket file on the per-user runtime dir — **never a TCP port**.
- **Owner-only**: socket `0600` + parent dir `0700` on POSIX (verified live: `srw-------` / `drwx------`). On Windows the per-user profile dir ACL applies; a dedicated pipe ACL is a follow-up.
- **Workers stay sandboxed**: the launcher **scrubs the sandbox re-entrancy markers** (`ZERO_SANDBOXED` / `ZERO_SANDBOX_BACKEND`) from each worker's env so the worker re-establishes its **own** sandbox instead of inheriting a pass-through plan, while propagating the rest of the policy config/env. **The daemon never bypasses the sandbox.**
- Control frames over the 1 MiB cap are rejected **before allocation**.

## Robustness
A crashed worker never takes down the daemon (backoff+jitter retry, `MaxAttempts` cap, `EXIT_PERMANENT` stops retry). Drain gives a grace window then force-kills stragglers. A stale lock from an unclean exit is reclaimed (dead-PID check, `x/sys` on Windows).

## Out of scope (follow-up)
remote session-linking; warm pre-spawned persistent workers; Windows named-pipe + DACL.

## Tests
protocol round-trip + oversize/unknown-kind rejection; backoff bounds; pool spawn/retry-backoff/permanent/cap/queue/drain; session lease/route/queue/attach; lock single-instance + stale recovery; **launcher env-scrub end-to-end** (asserts the spawned worker process actually receives scrubbed env); server **e2e** start→run→stream-json→status→attach→stop with a fake worker; CLI usage/validation/not-running. Live-verified start/status/stop.

## Gates
`gofmt -l .` empty · `go vet` · `go build` · `go test ./...` (incl. `-race` on `internal/daemon`) · `staticcheck` no new findings · `govulncheck` 0 · `deadcode -test=false` no new unreachable funcs · platform files behind explicit `//go:build` tags · cross-compiled `GOOS=linux` **and** `GOOS=windows`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `daemon` mode to the CLI with `start`, `stop`, `status`, `run`, and `attach` subcommands.
  * Supports foreground and detached daemon operation, including background logging.
  * Session-based execution with streamed output and the ability to attach to existing sessions.
  * Daemon status reporting for process/socket info plus worker and session metrics.
  * Enforces single-instance daemon behavior and improves control-socket hardening.

* **Tests**
  * Added comprehensive unit and end-to-end test coverage for the daemon CLI, server, protocol, sessions, and worker pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->