### PR TITLE
Polish assistant response transcript

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1131,13 +1131,14 @@ func (m model) transcriptView() string {
 
 func (m model) footerView(width int) string {
 	var footer strings.Builder
-	footer.WriteString("\n")
-	if chips := renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments); chips != "" {
-		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
-		footer.WriteString("\n")
-	}
 	if copyStatus := strings.TrimSpace(m.copyStatus); copyStatus != "" {
 		footer.WriteString(rightAlignedLine(zeroTheme.ink.Render(copyStatus), width))
+		footer.WriteString("\n")
+	} else {
+		footer.WriteString("\n")
+	}
+	if chips := renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments); chips != "" {
+		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
 		footer.WriteString("\n")
 	}
 	footer.WriteString(m.composerBox(width))

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -565,16 +565,29 @@ func TestMCPAddWizardMouseSelectsAndActivatesType(t *testing.T) {
 	}
 }
 
-func TestTranscriptCopyStatusRendersAboveComposer(t *testing.T) {
+func TestTranscriptCopyStatusUsesComposerSpacerWithoutFooterGrowth(t *testing.T) {
 	m := mouseTestModel()
 	m.providerName = "ollama-cloud"
 	m.modelName = "qwen3-coder:480b"
+
+	normalFooterLines := len(viewLines(plainRender(t, m.footerView(80))))
+	normalViewLines := len(viewLines(plainRender(t, m.View())))
 	m.copyStatus = "Copied!"
 
 	footer := plainRender(t, m.footerView(80))
-	lines := strings.Split(footer, "\n")
-	if len(lines) < 2 || !strings.Contains(lines[1], "Copied!") {
-		t.Fatalf("footer should show copy status above composer, got:\n%s", footer)
+	if got := len(viewLines(footer)); got != normalFooterLines {
+		t.Fatalf("copy status changed footer height from %d to %d:\n%s", normalFooterLines, got, footer)
+	}
+	view := plainRender(t, m.View())
+	if got := len(viewLines(view)); got != normalViewLines {
+		t.Fatalf("copy status changed view height from %d to %d:\n%s", normalViewLines, got, view)
+	}
+	if !strings.Contains(view, "Copied!") {
+		t.Fatalf("view should show copy status, got:\n%s", view)
+	}
+	footerLines := viewLines(footer)
+	if len(footerLines) < 2 || !strings.Contains(footerLines[0], "Copied!") || !strings.HasPrefix(footerLines[1], "╭") {
+		t.Fatalf("copy status should replace the spacer directly above composer, got:\n%s", footer)
 	}
 	if strings.Contains(plainRender(t, m.statusLine(80)), "Copied!") {
 		t.Fatalf("status line should not contain copy feedback: %q", plainRender(t, m.statusLine(80)))

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -302,7 +302,7 @@ func sayMeasure(width int) int {
 // assistantMeasure is the main answer wrap width. Assistant responses use the
 // available chat width so they visually balance full-width submitted prompts.
 func assistantMeasure(width int) int {
-	measure := width - 2
+	measure := width
 	if measure < 16 {
 		measure = 16
 	}
@@ -425,14 +425,11 @@ func renderUserPromptHalfLine(width int, glyph string) string {
 	return zeroTheme.userPrompt.Render(capGlyph) + zeroTheme.userPromptHalf.Render(strings.Repeat(glyph, maxInt(0, width-1)))
 }
 
-// renderAssistantRow draws the turn's final answer with the accent rail
-// gutter plus its done line; a non-final assistant row (e.g. a rehydrated
-// inline notice) renders as plain interim-style prose.
+// renderAssistantRow draws final answers as plain response text plus completion
+// metadata; a non-final assistant row (e.g. a rehydrated inline notice) renders
+// as interim-style prose.
 func renderAssistantRow(row transcriptRow, width int) string {
 	tableMeasure := width
-	if row.final {
-		tableMeasure = maxInt(16, width-2)
-	}
 	lines := renderAssistantMarkdownText(row.text, assistantMeasure(width), tableMeasure)
 	if !row.final {
 		for index := range lines {
@@ -441,7 +438,7 @@ func renderAssistantRow(row transcriptRow, width int) string {
 		return strings.Join(lines, "\n")
 	}
 	for index := range lines {
-		lines[index] = zeroTheme.finalRail.Render("│ ") + styleAssistantMarkdownLine(lines[index], zeroTheme.ink)
+		lines[index] = styleAssistantMarkdownLine(lines[index], zeroTheme.ink)
 	}
 	lines = append(lines, doneLine(row, false))
 	return strings.Join(lines, "\n")
@@ -503,13 +500,11 @@ func formatElapsedSeconds(elapsed time.Duration) string {
 	return fmt.Sprintf("%.1fs", elapsed.Seconds())
 }
 
-// doneLine renders the turn terminator: ● green (red on error) plus faint
-// counters. Segments the turn has no data for are omitted, never invented.
+// doneLine renders the turn terminator and faint counters. Normal completions
+// stay text-only; errors keep a red marker so failures remain easy to scan.
 func doneLine(row transcriptRow, failed bool) string {
-	glyph := zeroTheme.green.Render("●")
 	label := "completed"
 	if failed {
-		glyph = zeroTheme.red.Render("●")
 		label = "error"
 	}
 	segments := []string{zeroTheme.faint.Render(label)}
@@ -526,7 +521,11 @@ func doneLine(row transcriptRow, failed bool) string {
 	if failed && row.turnElapsed > 0 {
 		segments = append(segments, zeroTheme.faint.Render(formatElapsedSeconds(row.turnElapsed)))
 	}
-	return glyph + " " + strings.Join(segments, zeroTheme.faintest.Render(" · "))
+	line := strings.Join(segments, zeroTheme.faintest.Render(" · "))
+	if failed {
+		return zeroTheme.red.Render("●") + " " + line
+	}
+	return line
 }
 
 // renderSystemNote draws a system notice as a bordered note: faint text on

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -382,7 +382,7 @@ func TestSelectableAssistantRowKeepsMarkdownSemanticsPlain(t *testing.T) {
 	}
 }
 
-func TestFinalAnswerRendersRailAndDoneLine(t *testing.T) {
+func TestFinalAnswerRendersPlainTextAndCompletionLine(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{
 		kind:        rowAssistant,
@@ -392,10 +392,13 @@ func TestFinalAnswerRendersRailAndDoneLine(t *testing.T) {
 		turnElapsed: 8400 * time.Millisecond,
 	}
 	got := plainRender(t, m.renderRow(row, 96, buildRowContext(nil)))
-	if !strings.Contains(got, "│ Done — the CLI now prints its version.") {
-		t.Fatalf("final row = %q, want accent-rail gutter", got)
+	if strings.Contains(got, "│") || strings.Contains(got, "●") {
+		t.Fatalf("final row = %q, must not carry assistant rail or done glyph", got)
 	}
-	if !strings.Contains(got, "● completed in 8.4s · 2 tools") {
+	if !strings.Contains(got, "Done — the CLI now prints its version.") {
+		t.Fatalf("final row = %q, want final answer text", got)
+	}
+	if !strings.Contains(got, "completed in 8.4s · 2 tools") {
 		t.Fatalf("final row = %q, want completion line with counters", got)
 	}
 }
@@ -493,7 +496,7 @@ func TestFinalAnswerRendersMarkdownTableForTerminal(t *testing.T) {
 	if !strings.Contains(got, " │ ") || !strings.Contains(got, "─┼─") {
 		t.Fatalf("markdown table should render terminal table separators, got:\n%s", got)
 	}
-	if !strings.Contains(got, "● completed") {
+	if !strings.Contains(got, "completed") {
 		t.Fatalf("markdown final row = %q, want completed line terminator", got)
 	}
 	for index, line := range strings.Split(rendered, "\n") {
@@ -618,8 +621,8 @@ func TestFinalAnswerRendersCrowdedMarkdownTablesAsTables(t *testing.T) {
 
 func TestDoneLineOmitsMissingSegments(t *testing.T) {
 	got := plainRender(t, doneLine(transcriptRow{final: true}, false))
-	if got != "● completed" {
-		t.Fatalf("done line without counters = %q, want plain ● completed", got)
+	if got != "completed" {
+		t.Fatalf("done line without counters = %q, want plain completed", got)
 	}
 	if got := plainRender(t, doneLine(transcriptRow{final: true, turnTools: 1}, false)); !strings.Contains(got, "1 tool") || strings.Contains(got, "1 tools") {
 		t.Fatalf("done line = %q, want singular tool noun", got)

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -235,9 +235,8 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			case "user":
 				rows = append(rows, transcriptRow{kind: rowUser, text: content})
 			case "assistant":
-				// A persisted assistant message was a turn's final answer, so it keeps
-				// the final-answer rail on rehydration. Tool/timing counters were not
-				// recorded; the done line omits those segments.
+				// A persisted assistant message was a turn's final answer. Tool/timing
+				// counters were not recorded; the completion line omits those segments.
 				rows = append(rows, transcriptRow{kind: rowAssistant, text: content, final: true})
 			default:
 				rows = append(rows, transcriptRow{kind: rowSystem, text: content})

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -15,7 +15,7 @@ type tuiTheme struct {
 	muted      lipgloss.Style // secondary text, assistant interim prose
 	faint      lipgloss.Style // hints, metadata
 	faintest   lipgloss.Style // line numbers, separators, tool args
-	accent     lipgloss.Style // brand lime: prompts, spinner, focus, final rail
+	accent     lipgloss.Style // brand lime: prompts, spinner, focus
 	green      lipgloss.Style // success, diff add sign, ✓
 	red        lipgloss.Style // errors, diff del sign, ✗, deny
 	amber      lipgloss.Style // permission surfaces, warnings, auto badge
@@ -30,7 +30,6 @@ type tuiTheme struct {
 	// Stream roles.
 	userPrompt lipgloss.Style // ❯ user gutter, accent bold
 	sayText    lipgloss.Style // assistant interim prose, muted
-	finalRail  lipgloss.Style // │ gutter rail on the final answer, accent
 
 	// Tool cards.
 	toolName   lipgloss.Style // head-row tool name, ink bold
@@ -127,8 +126,6 @@ var zeroTheme = tuiTheme{
 
 	userPrompt: lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true),
 	sayText:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
-	finalRail:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)),
-
 	toolName:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk)).Bold(true),
 	toolTarget: lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
 	toolArg:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)),

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -147,16 +147,11 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 
 func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
 	tableMeasure := width
-	if row.final {
-		tableMeasure = maxInt(16, width-2)
-	}
 	wrapped := renderAssistantMarkdownText(row.text, assistantMeasure(width), tableMeasure)
 	lines := make([]string, 0, len(wrapped)+1)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
-	prefix := ""
 	textStyle := zeroTheme.sayText
 	if row.final {
-		prefix = "│ "
 		textStyle = zeroTheme.ink
 	}
 	for index, line := range wrapped {
@@ -164,14 +159,11 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 		meta := transcriptSelectableLine{
 			bodyY:     startBodyY + index,
 			rowIndex:  rowIndex,
-			textStart: lipgloss.Width(prefix),
+			textStart: 0,
 			text:      plainLine,
 		}
 		selectable = append(selectable, meta)
 		rendered := m.renderTranscriptSelectableMarkdownText(meta, line, textStyle)
-		if row.final {
-			rendered = zeroTheme.finalRail.Render(prefix) + rendered
-		}
 		lines = append(lines, rendered)
 	}
 	if row.final {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -63,8 +63,10 @@ func (m model) titleBar(width int) string {
 	}
 	cwd := zeroTheme.faintest.Render(" / ") + zeroTheme.muted.Render(shortenPath(m.cwd))
 	branch := ""
+	branchShort := ""
 	if b := strings.TrimSpace(m.gitBranch); b != "" {
 		branch = " " + zeroTheme.faint.Render(b)
+		branchShort = " " + zeroTheme.faint.Render(middleTruncate(b, 22))
 	}
 	model := m.titleModelSegment()
 	ctx := ""
@@ -78,11 +80,15 @@ func (m model) titleBar(width int) string {
 		candidates = []headerCandidate{
 			{left: badge + cwd + branch, right: model + ctx},
 			{left: badge + cwd + branch, right: model},
+			{left: badge + cwd + branchShort, right: model},
+			{left: badge + cwd, right: model},
 			{left: badge, right: model},
 		}
 	case tierMedium:
 		candidates = []headerCandidate{
 			{left: badge + cwd + branch, right: model},
+			{left: badge + cwd + branchShort, right: model},
+			{left: badge + cwd, right: model},
 			{left: badge, right: model},
 		}
 	case tierNarrow:

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -105,6 +105,27 @@ func TestTinyTierSingleSegmentAndRailLessCards(t *testing.T) {
 	}
 }
 
+func TestTitleBarKeepsWorkspaceWithLongBranchAndModel(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Cwd:          "/workspace/zero",
+		ProviderName: "ollama-cloud",
+		ModelName:    "cogito-2.1:671b-extra-long-model-name",
+	})
+	m.gitBranch = "feat/tui-assistant-response-cleanup"
+
+	got := plainRender(t, m.titleBar(108))
+	for _, want := range []string{"zero", "/workspace/zero", "feat/", "…", "ollama-cloud/cogito-2.1:671b-extra-long-model-name"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("title bar = %q, missing %q", got, want)
+		}
+	}
+	for index, line := range strings.Split(got, "\n") {
+		if width := lipgloss.Width(line); width > 108 {
+			t.Fatalf("title line %d width = %d, want <= 108: %q", index, width, line)
+		}
+	}
+}
+
 func TestComposerDividerRendersMetaAtExactFit(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		ModelName:      "m",


### PR DESCRIPTION
Summary:
- remove the final assistant response rail and green completion dot
- keep completion metadata as plain faint text, while preserving red failure markers
- keep the title bar workspace/branch visible by falling back to a shortened branch before dropping context
- update selectable transcript math and regression tests

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/Visual Changes**
  * Final assistant answers now render as plain text (removes decorative rail/dot styling).
  * Completion “done” lines now show timing/tool counter information as plain text.
  * Title bar improves layout for long branch names via truncation while keeping workspace/cwd and model details readable.
  * Footer rendering order is adjusted so copy status appears before attachment chips.

* **Tests**
  * Updated TUI rendering assertions for final answer and completion line formatting.
  * Added title bar width/long-branch test and updated copy-status/height regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->