### PR TITLE
Polish /permissions command output into a bounded card

### DIFF
--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -299,10 +299,51 @@ func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
 		t.Fatal("expected /permissions to be handled without starting an agent run")
 	}
 	permissionText := transcriptText(next.transcript)
-	for _, want := range []string{"Permissions", "status: ok", "Permission mode: ask", "persistent grants: 1", "bash [allow/high]", "[REDACTED]"} {
+	for _, want := range []string{
+		"Permissions",
+		"ask permissions",
+		"1 persistent grant",
+		"State",
+		"mode  ask",
+		"Grants",
+		"bash [allow/high]",
+		"[REDACTED]",
+	} {
 		assertContains(t, permissionText, want)
 	}
 	assertNotContains(t, permissionText, "sk-proj-sensitive")
+	assertNotContains(t, permissionText, "status: ok")
+	assertNotContains(t, permissionText, "Permission mode:")
+}
+
+func TestPermissionsCommandCardHandlesNilStoreAndEmptyGrants(t *testing.T) {
+	nilStore := model{permissionMode: agent.PermissionModeAuto}.permissionsText()
+	for _, want := range []string{
+		"Permissions",
+		"auto permissions",
+		"grants unavailable",
+		"mode  auto",
+		"persistent grants: unavailable",
+	} {
+		assertContains(t, nilStore, want)
+	}
+	assertNotContains(t, nilStore, "status: warning")
+
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "empty-grants.json")})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	emptyText := model{permissionMode: agent.PermissionModeAsk, sandboxStore: store}.permissionsText()
+	for _, want := range []string{
+		"Permissions",
+		"ask permissions",
+		"no persistent grants",
+		"mode  ask",
+		"none",
+	} {
+		assertContains(t, emptyText, want)
+	}
+	assertNotContains(t, emptyText, "status: info")
 }
 
 func TestContextCommandCardHandlesNilRegistryAndStableStyle(t *testing.T) {

--- a/internal/tui/command_polish_test.go
+++ b/internal/tui/command_polish_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -316,6 +317,17 @@ func TestContextAndPermissionsCommandsRenderProductState(t *testing.T) {
 	assertNotContains(t, permissionText, "Permission mode:")
 }
 
+// stubGrantStore is a minimal test double for sandbox.GrantStore. It only
+// implements List, which is enough to exercise the error path of
+// permissionsText().
+type stubGrantStore struct {
+	listErr error
+}
+
+func (store *stubGrantStore) List() ([]sandbox.Grant, error) {
+	return nil, store.listErr
+}
+
 func TestPermissionsCommandCardHandlesNilStoreAndEmptyGrants(t *testing.T) {
 	nilStore := model{permissionMode: agent.PermissionModeAuto}.permissionsText()
 	for _, want := range []string{
@@ -344,6 +356,19 @@ func TestPermissionsCommandCardHandlesNilStoreAndEmptyGrants(t *testing.T) {
 		assertContains(t, emptyText, want)
 	}
 	assertNotContains(t, emptyText, "status: info")
+
+	errStore := &stubGrantStore{listErr: errors.New("storage failure")}
+	errText := model{permissionMode: agent.PermissionModeAsk}.permissionsTextWithStore(errStore)
+	for _, want := range []string{
+		"Permissions",
+		"ask permissions",
+		"grants error",
+		"mode  ask",
+		"error: storage failure",
+	} {
+		assertContains(t, errText, want)
+	}
+	assertNotContains(t, errText, "status: blocked")
 }
 
 func TestContextCommandCardHandlesNilRegistryAndStableStyle(t *testing.T) {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -260,35 +260,50 @@ func splitMCPCommandArgs(args string) ([]string, error) {
 }
 
 func (m model) permissionsText() string {
-	stateLines := []string{
-		"Permission mode: " + string(m.permissionMode),
-	}
+	mode := string(m.permissionMode)
 	if m.sandboxStore == nil {
-		return renderCommandOutput(commandOutput{
-			Title:  "Permissions",
-			Status: commandStatusWarning,
-			Sections: []commandSection{
-				{Title: "State", Lines: stateLines},
-				{Title: "Sandbox grants:", Lines: []string{"persistent grants: unavailable"}},
+		return renderCommandCardTranscript(commandCard{
+			Title:   "Permissions",
+			Summary: []string{mode + " permissions", "grants unavailable"},
+			Sections: []commandCardSection{
+				{
+					Title: "State",
+					Fields: []commandField{
+						{Key: "mode", Value: mode},
+					},
+				},
+				{
+					Title:  "Grants",
+					Lines:  []string{"persistent grants: unavailable"},
+				},
 			},
 		})
 	}
 
 	grants, err := m.sandboxStore.List()
 	if err != nil {
-		return renderCommandOutput(commandOutput{
-			Title:  "Permissions",
-			Status: commandStatusBlocked,
-			Sections: []commandSection{
-				{Title: "State", Lines: stateLines},
-				{Title: "Sandbox grants:", Lines: []string{"error: " + err.Error()}},
+		return renderCommandCardTranscript(commandCard{
+			Title:   "Permissions",
+			Summary: []string{mode + " permissions", "grants error"},
+			Sections: []commandCardSection{
+				{
+					Title: "State",
+					Fields: []commandField{
+						{Key: "mode", Value: mode},
+					},
+				},
+				{
+					Title: "Grants",
+					Lines: []string{"error: " + err.Error()},
+				},
 			},
 		})
 	}
+
 	snapshots := zerocommands.SandboxGrantSnapshots(grants)
-	grantLines := []string{fmt.Sprintf("persistent grants: %d", len(snapshots))}
+	grantRows := []commandRow{}
 	if len(snapshots) == 0 {
-		grantLines = append(grantLines, "none")
+		grantRows = append(grantRows, commandRow{Text: "none"})
 	} else {
 		for _, grant := range snapshots {
 			line := fmt.Sprintf("%s [%s/%s]", grant.ToolName, grant.Decision, grant.MaxAutonomy)
@@ -298,17 +313,36 @@ func (m model) permissionsText() string {
 			if grant.Reason != "" {
 				line += " - " + grant.Reason
 			}
-			grantLines = append(grantLines, commandBullet(line))
+			grantRows = append(grantRows, commandRow{Text: line})
 		}
 	}
-	return renderCommandOutput(commandOutput{
-		Title:  "Permissions",
-		Status: commandStatusOK,
-		Sections: []commandSection{
-			{Title: "State", Lines: stateLines},
-			{Title: "Sandbox grants:", Lines: grantLines},
+
+	return renderCommandCardTranscript(commandCard{
+		Title:   "Permissions",
+		Summary: []string{mode + " permissions", formatGrantCount(len(snapshots))},
+		Sections: []commandCardSection{
+			{
+				Title: "State",
+				Fields: []commandField{
+					{Key: "mode", Value: mode},
+				},
+			},
+			{
+				Title: "Grants",
+				Rows:  grantRows,
+			},
 		},
 	})
+}
+
+func formatGrantCount(count int) string {
+	if count == 0 {
+		return "no persistent grants"
+	}
+	if count == 1 {
+		return "1 persistent grant"
+	}
+	return fmt.Sprintf("%d persistent grants", count)
 }
 
 func (m model) providerText() string {

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -281,8 +281,8 @@ func (m model) permissionsTextWithStore(store grantLister) string {
 					},
 				},
 				{
-					Title:  "Grants",
-					Lines:  []string{"persistent grants: unavailable"},
+					Title: "Grants",
+					Lines: []string{"persistent grants: unavailable"},
 				},
 			},
 		})

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zerocommands"
 )
@@ -260,8 +261,15 @@ func splitMCPCommandArgs(args string) ([]string, error) {
 }
 
 func (m model) permissionsText() string {
-	mode := string(m.permissionMode)
 	if m.sandboxStore == nil {
+		return m.permissionsTextWithStore(nil)
+	}
+	return m.permissionsTextWithStore(m.sandboxStore)
+}
+
+func (m model) permissionsTextWithStore(store grantLister) string {
+	mode := string(m.permissionMode)
+	if store == nil {
 		return renderCommandCardTranscript(commandCard{
 			Title:   "Permissions",
 			Summary: []string{mode + " permissions", "grants unavailable"},
@@ -280,7 +288,7 @@ func (m model) permissionsText() string {
 		})
 	}
 
-	grants, err := m.sandboxStore.List()
+	grants, err := store.List()
 	if err != nil {
 		return renderCommandCardTranscript(commandCard{
 			Title:   "Permissions",
@@ -333,6 +341,13 @@ func (m model) permissionsText() string {
 			},
 		},
 	})
+}
+
+// grantLister is the subset of sandbox.GrantStore used by permissionsText().
+// It exists to let tests inject error-stub stores without reaching for a real
+// filesystem path.
+type grantLister interface {
+	List() ([]sandbox.Grant, error)
 }
 
 func formatGrantCount(count int) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -388,8 +388,10 @@ func TestPermissionsCommandListsPersistentSandboxGrants(t *testing.T) {
 	}
 	text := transcriptText(next.transcript)
 	for _, want := range []string{
-		"Permission mode: ask",
-		"Sandbox grants:",
+		"Permissions",
+		"ask permissions",
+		"mode  ask",
+		"Grants",
 		"bash [allow/high]",
 		"write_file [deny/low]",
 		"[REDACTED]",
@@ -397,6 +399,8 @@ func TestPermissionsCommandListsPersistentSandboxGrants(t *testing.T) {
 		assertContains(t, text, want)
 	}
 	assertNotContains(t, text, "sk-proj-sensitive")
+	assertNotContains(t, text, "status: ok")
+	assertNotContains(t, text, "Permission mode:")
 }
 
 func TestPlanCommandShowsCurrentPlan(t *testing.T) {


### PR DESCRIPTION
## What

Converts `/permissions` from the old `status: ok` plain-text dump into the bounded `commandCard` format already used by `/tools` and `/context`.

## Before

```
Permissions
status: ok
State
  Permission mode: ask
Sandbox grants:
  persistent grants: 1
  - bash [allow/high] - ...
```

## After

```
Permissions
ask permissions · 1 persistent grant
State
  mode  ask
Grants
  - bash [allow/high] - ...
```

## Changes
- `internal/tui/command_views.go` — `permissionsText()` now renders a `commandCard` with a bold summary line, aligned `mode` field, and bullet rows for each persistent sandbox grant.
- Nil-store and error cases are rendered as cards instead of `status: warning` / `status: blocked`.
- Updated `internal/tui/command_polish_test.go` and `internal/tui/model_test.go` assertions.
- Added `TestPermissionsCommandCardHandlesNilStoreAndEmptyGrants`.

## Validation
- `go test ./internal/tui -count=1` :white_check_mark:
- `go vet ./internal/tui` :white_check_mark:
- `go run ./cmd/zero-release build` :white_check_mark:
- `go run ./cmd/zero-release smoke` :white_check_mark:

Pre-existing unrelated failure: `TestRunExecUsesProjectConfigAndOpenAICompatibleProvider` in `internal/cli` fails on clean `main` with `anthropic provider anthropic requires official baseURL https://api.anthropic.com`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced `/permissions` output with structured, card-based sections for clearer **State** and **Grants** details, including **mode** and persistent grant counts.
  * Improved messaging when grant data is unavailable, empty, or fails—showing appropriate “unavailable/none/error” content and propagating error details when relevant.
* **Tests**
  * Expanded `/permissions` rendering tests to cover nil, empty, and failure cases, and to ensure outdated flat status markers are no longer shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->