### PR TITLE
feat(sandbox): complete sandbox breadth — WSL fallback + opt-in MITM TLS inspection

### DIFF
--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -23,15 +23,26 @@ type Backend struct {
 	// under a seatbelt profile that restricts outbound to the proxy port);
 	// bubblewrap isolates the network namespace with no bridge to the host proxy,
 	// so scoped egress there collapses to deny until a real relay exists.
-	ScopedEgress bool   `json:"scopedEgress,omitempty"`
-	Executable   string `json:"executable,omitempty"`
-	Message      string `json:"message,omitempty"`
+	ScopedEgress bool `json:"scopedEgress,omitempty"`
+	// ProxyEgress reports a backend that routes scoped egress through the local
+	// filtering proxy on a BEST-EFFORT basis (the child must honor the proxy env)
+	// rather than via OS-level network isolation. The WSL policy-only fallback uses
+	// this: there is no netns/seatbelt to enforce egress, but the proxy still
+	// applies the allow/deny gate to well-behaved clients.
+	ProxyEgress bool   `json:"proxyEgress,omitempty"`
+	Executable  string `json:"executable,omitempty"`
+	Message     string `json:"message,omitempty"`
 }
 
 // EnforcesScopedEgress reports whether a populated NetworkScoped allowlist can be
-// enforced by this backend. When false, scoped egress must fail closed (collapse
-// to deny) rather than silently run with unrestricted networking.
+// routed through the filtering proxy by this backend. When false, scoped egress
+// must fail closed (collapse to deny) rather than silently run with unrestricted
+// networking. A native backend needs an executable; the WSL fallback uses
+// best-effort proxy egress (ProxyEgress) with no native isolation.
 func (backend Backend) EnforcesScopedEgress() bool {
+	if backend.ProxyEgress {
+		return true
+	}
 	return backend.Available && backend.Executable != "" && backend.ScopedEgress
 }
 
@@ -65,6 +76,12 @@ func SelectBackend(options BackendOptions) Backend {
 		if path, err := lookup("bwrap"); err == nil && path != "" {
 			return nativeBackend(goos, BackendBubblewrap, path, "bubblewrap sandbox available")
 		}
+		// Under WSL (no bubblewrap), do NOT silently degrade to a plain policy-only
+		// runner: select the WSL backend, which still routes egress through the
+		// filtering proxy and is gated on AllowPolicyOnlyRunner in the runner.
+		if info := detectWSL(); info.IsWSL {
+			return wslBackend(goos, info)
+		}
 		return policyOnlyBackend(goos, "policy-only fallback: bubblewrap is not installed")
 	case "darwin":
 		if path, err := lookup("sandbox-exec"); err == nil && path != "" {
@@ -91,6 +108,26 @@ func nativeBackend(goos string, name BackendName, executable string, message str
 		ScopedEgress: name == BackendSandboxExec,
 		Executable:   executable,
 		Message:      message,
+	}
+}
+
+// wslBackend is the policy-only WSL fallback: no native isolation, but scoped
+// egress is routed best-effort through the filtering proxy (ProxyEgress). The
+// runner gates it on Policy.AllowPolicyOnlyRunner and records a downgrade note.
+func wslBackend(goos string, info WSLInfo) Backend {
+	msg := "policy-only WSL fallback: bubblewrap unavailable under WSL; egress routed through the filtering proxy"
+	if info.IsWSL2 {
+		msg = "policy-only WSL2 fallback: bubblewrap unavailable/unreliable under WSL2; egress routed through the filtering proxy"
+	}
+	return Backend{
+		Name:            BackendWSL,
+		Available:       false,
+		Platform:        goos,
+		Fallback:        true,
+		CommandWrapping: false,
+		NativeIsolation: false,
+		ProxyEgress:     true,
+		Message:         msg,
 	}
 }
 

--- a/internal/sandbox/egress.go
+++ b/internal/sandbox/egress.go
@@ -139,11 +139,19 @@ func newEgressProxy(options egressOptions) (*egressProxy, error) {
 			return nil, err
 		}
 		proxy.mitm = ca
+		dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
 		proxy.mitmTransport = &http.Transport{
+			// Bound the TCP connect phase so a blackholed upstream cannot park a
+			// handler+goroutine for the OS default (minutes) — mirrors the
+			// net.DialTimeout the passthrough CONNECT path uses.
+			DialContext: dialer.DialContext,
 			// Upstream TLS is validated normally; upstreamRoots is nil in production
 			// (system roots) and set only by tests. NEVER InsecureSkipVerify.
-			TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: options.upstreamRoots},
-			ForceAttemptHTTP2:     true,
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: options.upstreamRoots},
+			// Keep upstream on HTTP/1.1: the decrypted client side is HTTP/1.1, so an
+			// HTTP/2 upstream response would serialize an invalid status line back to
+			// the client. (handleConnectMITM also normalizes the response proto.)
+			ForceAttemptHTTP2:     false,
 			TLSHandshakeTimeout:   30 * time.Second,
 			ResponseHeaderTimeout: 30 * time.Second,
 		}

--- a/internal/sandbox/egress.go
+++ b/internal/sandbox/egress.go
@@ -2,6 +2,8 @@ package sandbox
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -41,6 +43,13 @@ type egressProxy struct {
 	denied        []string
 	log           func(string)
 
+	// mitm, when non-nil (Policy.InspectTLS), makes handleConnect TERMINATE TLS
+	// using a locally generated CA so the decrypted Host can be re-checked against
+	// the allow/deny gate. mitmTransport dials upstreams with full validation
+	// (system roots unless upstreamRoots is set for tests) — never InsecureSkipVerify.
+	mitm          *mitmCA
+	mitmTransport *http.Transport
+
 	// domainPrompt, when set, is asked to authorize an UNKNOWN host (one neither
 	// allowed nor explicitly denied) instead of failing closed. It must return
 	// within promptTimeout — the passed context is cancelled on timeout so a
@@ -76,6 +85,14 @@ type egressOptions struct {
 	// fail-closed behavior.
 	DomainPrompt  func(ctx context.Context, host string, port int) (bool, error)
 	PromptTimeout time.Duration
+	// InspectTLS enables TLS termination (MITM) so the proxy can enforce the
+	// allow/deny gate on the decrypted request Host. Off => pure CONNECT
+	// passthrough (the default, byte-for-byte unchanged).
+	InspectTLS bool
+	// upstreamRoots overrides the root CAs used to validate UPSTREAM TLS. nil =
+	// system roots (production). Tests set it to an httptest server's pool so
+	// validation is exercised WITHOUT InsecureSkipVerify.
+	upstreamRoots *x509.CertPool
 }
 
 // errEmptyAllowlist is returned when a scoped-egress proxy is requested with no
@@ -114,6 +131,23 @@ func newEgressProxy(options egressOptions) (*egressProxy, error) {
 		decisionCache: map[string]bool{},
 		inflight:      map[string]chan struct{}{},
 	}
+	if options.InspectTLS {
+		ca, err := newMITMCA()
+		if err != nil {
+			_ = listener.Close()
+			_ = socksListener.Close()
+			return nil, err
+		}
+		proxy.mitm = ca
+		proxy.mitmTransport = &http.Transport{
+			// Upstream TLS is validated normally; upstreamRoots is nil in production
+			// (system roots) and set only by tests. NEVER InsecureSkipVerify.
+			TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: options.upstreamRoots},
+			ForceAttemptHTTP2:     true,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+		}
+	}
 	proxy.server = &http.Server{
 		Handler:           http.HandlerFunc(proxy.handle),
 		ReadHeaderTimeout: 30 * time.Second,
@@ -143,6 +177,16 @@ func (proxy *egressProxy) SocksAddr() string {
 	return proxy.socksListener.Addr().String()
 }
 
+// CACertPEM returns the MITM CA's public certificate (PEM) when TLS inspection
+// is active, or nil for a plain passthrough proxy. The runner writes this to a
+// file and surfaces it via ZERO_SANDBOX_CA_CERT.
+func (proxy *egressProxy) CACertPEM() []byte {
+	if proxy == nil || proxy.mitm == nil {
+		return nil
+	}
+	return proxy.mitm.caPEM()
+}
+
 // Close stops the proxy and releases its listener. It is safe to call multiple
 // times.
 func (proxy *egressProxy) Close() error {
@@ -161,12 +205,19 @@ func (proxy *egressProxy) Close() error {
 				err = cerr
 			}
 		}
+		if proxy.mitmTransport != nil {
+			proxy.mitmTransport.CloseIdleConnections()
+		}
 	})
 	return err
 }
 
 func (proxy *egressProxy) handle(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodConnect {
+		if proxy.mitm != nil {
+			proxy.handleConnectMITM(w, r)
+			return
+		}
 		proxy.handleConnect(w, r)
 		return
 	}

--- a/internal/sandbox/mitm.go
+++ b/internal/sandbox/mitm.go
@@ -1,0 +1,248 @@
+package sandbox
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MITM TLS interception (opt-in via Policy.InspectTLS). Mirrors
+// reference-sandbox-wsl-mitm-code-agent-js/sandbox-manager.js mitmCA/getMitmCA
+// and network/proxy.js. The proxy terminates TLS toward the SANDBOXED CLIENT
+// using an ephemeral, locally generated CA so it can read the decrypted request
+// and apply the SAME allow/deny gate on the real Host — visibility, not new
+// authority. The UPSTREAM connection is always validated against real roots
+// (never InsecureSkipVerify).
+
+// mitmCA is an ephemeral certificate authority that mints per-host leaf certs.
+// It lives only for the proxy's lifetime; only its PUBLIC cert is ever exposed
+// (so the sandboxed client can trust the minted leaves).
+type mitmCA struct {
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+	certDER []byte
+
+	mu     sync.Mutex
+	leaves map[string]*tls.Certificate
+}
+
+func randomSerial() (*big.Int, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, fmt.Errorf("mitm: serial: %w", err)
+	}
+	return serial, nil
+}
+
+// newMITMCA generates a fresh ECDSA CA. The key never leaves the process.
+func newMITMCA() (*mitmCA, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: generate CA key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "zero sandbox MITM CA", Organization: []string{"zero-sandbox"}},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: create CA cert: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: parse CA cert: %w", err)
+	}
+	return &mitmCA{cert: cert, key: key, certDER: der, leaves: map[string]*tls.Certificate{}}, nil
+}
+
+// caPEM returns the CA's PUBLIC certificate in PEM (safe to write/expose).
+func (ca *mitmCA) caPEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.certDER})
+}
+
+// leafFor mints (and caches) a leaf certificate for host, signed by the CA, with
+// the CA appended so the chain verifies against the CA alone.
+func (ca *mitmCA) leafFor(host string) (*tls.Certificate, error) {
+	host = hostnameOnly(host)
+	if host == "" {
+		return nil, fmt.Errorf("mitm: empty host for leaf cert")
+	}
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+	if leaf, ok := ca.leaves[host]; ok {
+		return leaf, nil
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		tmpl.IPAddresses = []net.IP{ip}
+	} else {
+		tmpl.DNSNames = []string{host}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &leafKey.PublicKey, ca.key)
+	if err != nil {
+		return nil, fmt.Errorf("mitm: mint leaf for %s: %w", host, err)
+	}
+	leaf := &tls.Certificate{Certificate: [][]byte{der, ca.certDER}, PrivateKey: leafKey}
+	ca.leaves[host] = leaf
+	return leaf, nil
+}
+
+// writeMITMCAFile writes the CA's PUBLIC cert PEM to an owner-only temp file and
+// returns its path, so the runner can surface it via ZERO_SANDBOX_CA_CERT.
+func writeMITMCAFile(pemBytes []byte) (string, error) {
+	f, err := os.CreateTemp("", "zero-sandbox-ca-*.pem")
+	if err != nil {
+		return "", fmt.Errorf("mitm: create CA file: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if _, err := f.Write(pemBytes); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// handleConnectMITM terminates TLS toward the client (minting a leaf for the
+// requested host), then for each decrypted request re-checks the real Host
+// through the SAME authorize gate and forwards it upstream with full system-root
+// validation. A denied host gets a 403 over the decrypted channel and is never
+// forwarded.
+func (proxy *egressProxy) handleConnectMITM(w http.ResponseWriter, r *http.Request) {
+	target := r.Host
+	if target == "" {
+		target = r.URL.Host
+	}
+	if !proxy.authorizeTarget(target, 443) {
+		proxy.logDecision("deny", "CONNECT", target)
+		http.Error(w, "scoped egress: host not allowed", http.StatusForbidden)
+		return
+	}
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "scoped egress: hijack unsupported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer clientConn.Close()
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		return
+	}
+
+	host := hostnameOnly(target)
+	tlsConn := tls.Server(clientConn, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			name := hello.ServerName
+			if name == "" {
+				name = host
+			}
+			return proxy.mitm.leafFor(name)
+		},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		return
+	}
+	defer tlsConn.Close()
+
+	reader := bufio.NewReader(tlsConn)
+	for {
+		req, err := http.ReadRequest(reader)
+		if err != nil {
+			return // client closed or EOF
+		}
+		reqHost := req.Host
+		if reqHost == "" {
+			reqHost = host
+		}
+		// MITM widens VISIBILITY, never authority: the decrypted Host passes the
+		// SAME authorize()/domainAllowed() gate (deny-wins, empty allowlist => deny).
+		if !domainAllowed(hostnameOnly(reqHost), proxy.allowed, proxy.denied) {
+			proxy.logDecision("deny", req.Method, reqHost)
+			writeMITMResponse(tlsConn, http.StatusForbidden, "scoped egress: host not allowed")
+			return
+		}
+		req.URL.Scheme = "https"
+		req.URL.Host = normalizeConnectTarget(target)
+		req.RequestURI = ""
+		resp, err := proxy.mitmTransport.RoundTrip(req)
+		if err != nil {
+			proxy.logDecision("deny", req.Method, reqHost)
+			writeMITMResponse(tlsConn, http.StatusBadGateway, "scoped egress: upstream request failed")
+			return
+		}
+		proxy.logDecision("allow", req.Method, reqHost)
+		writeErr := resp.Write(tlsConn)
+		_ = resp.Body.Close()
+		if writeErr != nil || req.Close || resp.Close {
+			return
+		}
+	}
+}
+
+// writeMITMResponse writes a minimal plaintext HTTP/1.1 response over the
+// decrypted client connection.
+func writeMITMResponse(conn net.Conn, code int, msg string) {
+	body := msg + "\n"
+	resp := &http.Response{
+		StatusCode:    code,
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	_ = resp.Write(conn)
+}

--- a/internal/sandbox/mitm.go
+++ b/internal/sandbox/mitm.go
@@ -40,6 +40,11 @@ type mitmCA struct {
 	leaves map[string]*tls.Certificate
 }
 
+// maxMITMLeafCacheEntries caps the per-host leaf cache so an attacker cannot grow
+// it without bound. Combined with minting for the AUTHORIZED host (not arbitrary
+// client SNI), this keeps the cache size to roughly the allowlist size.
+const maxMITMLeafCacheEntries = 512
+
 func randomSerial() (*big.Int, error) {
 	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
@@ -97,6 +102,9 @@ func (ca *mitmCA) leafFor(host string) (*tls.Certificate, error) {
 	if leaf, ok := ca.leaves[host]; ok {
 		return leaf, nil
 	}
+	// Bound the cache: past the cap, mint without caching so memory stays bounded
+	// (a small per-request cost rather than unbounded growth).
+	cacheable := len(ca.leaves) < maxMITMLeafCacheEntries
 	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
@@ -124,7 +132,9 @@ func (ca *mitmCA) leafFor(host string) (*tls.Certificate, error) {
 		return nil, fmt.Errorf("mitm: mint leaf for %s: %w", host, err)
 	}
 	leaf := &tls.Certificate{Certificate: [][]byte{der, ca.certDER}, PrivateKey: leafKey}
-	ca.leaves[host] = leaf
+	if cacheable {
+		ca.leaves[host] = leaf
+	}
 	return leaf, nil
 }
 
@@ -184,12 +194,11 @@ func (proxy *egressProxy) handleConnectMITM(w http.ResponseWriter, r *http.Reque
 	host := hostnameOnly(target)
 	tlsConn := tls.Server(clientConn, &tls.Config{
 		MinVersion: tls.VersionTLS12,
-		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			name := hello.ServerName
-			if name == "" {
-				name = host
-			}
-			return proxy.mitm.leafFor(name)
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			// Mint for the AUTHORIZED CONNECT host, never the arbitrary client SNI:
+			// honoring SNI would let an attacker churn distinct names to force
+			// unbounded key generation and cache growth.
+			return proxy.mitm.leafFor(host)
 		},
 	})
 	if err := tlsConn.Handshake(); err != nil {
@@ -208,8 +217,9 @@ func (proxy *egressProxy) handleConnectMITM(w http.ResponseWriter, r *http.Reque
 			reqHost = host
 		}
 		// MITM widens VISIBILITY, never authority: the decrypted Host passes the
-		// SAME authorize()/domainAllowed() gate (deny-wins, empty allowlist => deny).
-		if !domainAllowed(hostnameOnly(reqHost), proxy.allowed, proxy.denied) {
+		// SAME full authorize() gate as the CONNECT check (deny-wins, empty allowlist
+		// => deny, and an interactive DomainPrompt is honored consistently).
+		if !proxy.authorizeTarget(reqHost, 443) {
 			proxy.logDecision("deny", req.Method, reqHost)
 			writeMITMResponse(tlsConn, http.StatusForbidden, "scoped egress: host not allowed")
 			return
@@ -224,6 +234,9 @@ func (proxy *egressProxy) handleConnectMITM(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		proxy.logDecision("allow", req.Method, reqHost)
+		// Re-frame the response as HTTP/1.1 for the decrypted (HTTP/1.1) client
+		// connection, regardless of how the upstream replied.
+		resp.Proto, resp.ProtoMajor, resp.ProtoMinor = "HTTP/1.1", 1, 1
 		writeErr := resp.Write(tlsConn)
 		_ = resp.Body.Close()
 		if writeErr != nil || req.Close || resp.Close {

--- a/internal/sandbox/mitm_test.go
+++ b/internal/sandbox/mitm_test.go
@@ -66,6 +66,11 @@ func mitmConnect(t *testing.T, proxyAddr, target string, caPEM []byte, serverNam
 	if err != nil {
 		t.Fatalf("dial proxy: %v", err)
 	}
+	// Bound the whole exchange (CONNECT read + TLS handshake + request/response) so
+	// a regression cannot hang the test indefinitely.
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
 	fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, &http.Request{Method: "CONNECT"})
@@ -114,9 +119,17 @@ func TestEgressProxyMITMForwardsAllowlistedHost(t *testing.T) {
 	tlsConn := mitmConnect(t, proxy.Addr(), target, proxy.CACertPEM(), host)
 	defer tlsConn.Close()
 	fmt.Fprintf(tlsConn, "GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", host)
-	body, err := io.ReadAll(tlsConn)
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), &http.Request{Method: http.MethodGet})
 	if err != nil {
 		t.Fatalf("read decrypted response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("allowlisted forwarded request status = %d, want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read decrypted body: %v", err)
 	}
 	if !strings.Contains(string(body), "upstream-ok") {
 		t.Fatalf("MITM did not forward the allowlisted request, got %q", string(body))

--- a/internal/sandbox/mitm_test.go
+++ b/internal/sandbox/mitm_test.go
@@ -1,0 +1,145 @@
+package sandbox
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEgressProxyPassthroughNoCAByDefault(t *testing.T) {
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"github.com"}})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+	if proxy.mitm != nil {
+		t.Fatal("InspectTLS off must not create a MITM CA (pure passthrough)")
+	}
+	if proxy.CACertPEM() != nil {
+		t.Fatal("passthrough proxy must expose no CA cert")
+	}
+}
+
+func TestMITMCAMintsChainingLeaf(t *testing.T) {
+	ca, err := newMITMCA()
+	if err != nil {
+		t.Fatalf("newMITMCA: %v", err)
+	}
+	leaf, err := ca.leafFor("api.example.com")
+	if err != nil {
+		t.Fatalf("leafFor: %v", err)
+	}
+	leafCert, err := x509.ParseCertificate(leaf.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(ca.caPEM()) {
+		t.Fatal("append CA PEM")
+	}
+	if _, err := leafCert.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		DNSName:   "api.example.com",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Fatalf("minted leaf must chain to the CA: %v", err)
+	}
+	// Per-host caching.
+	if leaf2, _ := ca.leafFor("api.example.com"); leaf2 != leaf {
+		t.Fatal("leafFor must cache one leaf per host")
+	}
+}
+
+// mitmConnect performs a CONNECT through the proxy then opens a TLS client that
+// trusts ONLY the MITM CA, returning the decrypted client connection.
+func mitmConnect(t *testing.T, proxyAddr, target string, caPEM []byte, serverName string) *tls.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", proxyAddr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target)
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: "CONNECT"})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	if br.Buffered() != 0 {
+		t.Fatalf("proxy over-sent %d bytes after CONNECT 200", br.Buffered())
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatal("append MITM CA PEM")
+	}
+	tlsConn := tls.Client(conn, &tls.Config{RootCAs: pool, ServerName: serverName})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("client TLS handshake trusting the MITM CA: %v", err)
+	}
+	return tlsConn
+}
+
+func TestEgressProxyMITMForwardsAllowlistedHost(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "upstream-ok")
+	}))
+	defer upstream.Close()
+	host := mustHost(t, upstream.URL)
+	target := mustHostPort(t, upstream.URL)
+
+	// Trust the upstream's real cert explicitly (NOT InsecureSkipVerify): proves
+	// the MITM still validates the upstream chain.
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{host}, InspectTLS: true, upstreamRoots: upstreamRoots})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+	if proxy.CACertPEM() == nil {
+		t.Fatal("InspectTLS must generate a CA")
+	}
+
+	tlsConn := mitmConnect(t, proxy.Addr(), target, proxy.CACertPEM(), host)
+	defer tlsConn.Close()
+	fmt.Fprintf(tlsConn, "GET / HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n", host)
+	body, err := io.ReadAll(tlsConn)
+	if err != nil {
+		t.Fatalf("read decrypted response: %v", err)
+	}
+	if !strings.Contains(string(body), "upstream-ok") {
+		t.Fatalf("MITM did not forward the allowlisted request, got %q", string(body))
+	}
+}
+
+func TestEgressProxyMITMBlocksDeniedDecryptedHost(t *testing.T) {
+	// CONNECT to an allowed host, but send a Host header that is NOT allowlisted —
+	// the MITM re-checks the DECRYPTED Host and blocks it before forwarding.
+	proxy, err := newEgressProxy(egressOptions{Allowed: []string{"127.0.0.1"}, InspectTLS: true})
+	if err != nil {
+		t.Fatalf("newEgressProxy: %v", err)
+	}
+	defer proxy.Close()
+
+	tlsConn := mitmConnect(t, proxy.Addr(), "127.0.0.1:443", proxy.CACertPEM(), "127.0.0.1")
+	defer tlsConn.Close()
+	fmt.Fprint(tlsConn, "GET / HTTP/1.1\r\nHost: blocked.example\r\nConnection: close\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), nil)
+	if err != nil {
+		t.Fatalf("read decrypted response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("denied decrypted Host status = %d, want 403", resp.StatusCode)
+	}
+}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -17,6 +17,13 @@ const bubblewrapWorkspace = "/workspace"
 
 var errPolicyOnlyRunnerDisabled = errors.New("policy-only sandbox runner is disabled")
 
+// errWSLPolicyOnlyDisabled is returned when running under WSL without bubblewrap
+// and the policy has NOT opted into the policy-only runner — fail closed rather
+// than run with no native isolation.
+var errWSLPolicyOnlyDisabled = errors.New("bubblewrap is unavailable under WSL and Policy.AllowPolicyOnlyRunner is disabled: " +
+	"enable AllowPolicyOnlyRunner to run under the policy-only WSL fallback (engine policy + proxy egress, no native isolation), " +
+	"or install/enable bubblewrap")
+
 type CommandSpec struct {
 	Name string
 	Args []string
@@ -39,6 +46,10 @@ type CommandPlan struct {
 	// StartDenialMonitor to capture what the sandbox blocked. Empty unless
 	// Policy.MonitorDenials is set on a macOS sandbox-exec plan.
 	MonitorTag string `json:"monitorTag,omitempty"`
+	// Notes records auditable least-privilege downgrade notes — e.g. the WSL
+	// policy-only fallback noting that native isolation was unavailable. Surfaced to
+	// the operator; never affects enforcement.
+	Notes []string `json:"notes,omitempty"`
 	// cleanup releases resources tied to the plan's lifetime — currently the
 	// scoped-egress proxy, which must outlive the command run and be shut down
 	// afterwards. It is never serialized; callers invoke it via Cleanup() once the
@@ -208,11 +219,54 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 			}
 			return sandboxExecCommandPlan(spec, workspaceRoot, engine.writeRoots(workspaceRoot), policy, backend, egress), nil
 		}
+	case BackendWSL:
+		// WSL fallback: no native isolation available. Fail closed unless the policy
+		// opted into the policy-only runner; otherwise run policy-only with the
+		// command's egress routed through the filtering proxy and an auditable note.
+		if !policy.AllowPolicyOnlyRunner {
+			return CommandPlan{}, errWSLPolicyOnlyDisabled
+		}
+		egress, err := startScopedEgress(policy, backend)
+		if err != nil {
+			return CommandPlan{}, err
+		}
+		return wslCommandPlan(spec, workspaceRoot, policy, backend, egress), nil
 	}
 	if !policy.AllowPolicyOnlyRunner {
 		return CommandPlan{}, errPolicyOnlyRunnerDisabled
 	}
 	return directCommandPlan(spec, backend, policy, workspaceRoot), nil
+}
+
+// wslCommandPlan builds the WSL policy-only fallback plan: the command runs
+// DIRECTLY (no native wrap, since bubblewrap is unavailable under WSL) but with
+// the sandbox env markers (ZERO_SANDBOXED=1, ZERO_SANDBOX_BACKEND=wsl) and, when
+// a scoped-egress proxy was started, the proxy env so well-behaved clients route
+// through the allow/deny gate. It carries a least-privilege downgrade note.
+func wslCommandPlan(spec CommandSpec, workspaceRoot string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {
+	env := sandboxEnvironment(policy, BackendWSL, workspaceRoot)
+	if egress != nil {
+		env = append(env, ProxyEnvWithSocks(egress.addr, egress.socksAddr)...)
+		env = appendCACertEnv(env, egress)
+	}
+	plan := CommandPlan{
+		Backend:       backend,
+		WorkspaceRoot: workspaceRoot,
+		Policy:        policy,
+		Wrapped:       false,
+		Name:          spec.Name,
+		Args:          cloneStrings(spec.Args),
+		Dir:           spec.Dir,
+		Env:           env,
+		Notes: []string{
+			"WSL: native process isolation (bubblewrap) is unavailable; downgraded to the policy-only runner " +
+				"with proxy egress (least privilege). The engine still enforces the full policy.",
+		},
+	}
+	if egress != nil {
+		plan.cleanup = egress.cleanup
+	}
+	return plan
 }
 
 // scopedEgress holds the address of a started scoped-egress proxy and the
@@ -224,7 +278,25 @@ type scopedEgress struct {
 	// set ALL_PROXY=socks5://<socksAddr>. Empty when the proxy exposes no SOCKS
 	// listener, in which case ALL_PROXY falls back to the HTTP proxy.
 	socksAddr string
-	cleanup   func()
+	// caCertPath is the path to the MITM CA's public cert (PEM), set only when
+	// Policy.InspectTLS started a TLS-terminating proxy. Surfaced to the sandboxed
+	// client via ZERO_SANDBOX_CA_CERT so it can trust the minted leaves.
+	caCertPath string
+	cleanup    func()
+}
+
+// EnvCACert is the env var pointing the sandboxed client at the MITM CA's public
+// cert so it can trust the proxy's minted leaf certificates (only set when
+// Policy.InspectTLS is on).
+const EnvCACert = "ZERO_SANDBOX_CA_CERT"
+
+// appendCACertEnv adds ZERO_SANDBOX_CA_CERT when the egress proxy is terminating
+// TLS (InspectTLS). It is a no-op for a plain passthrough proxy.
+func appendCACertEnv(env []string, egress *scopedEgress) []string {
+	if egress == nil || egress.caCertPath == "" {
+		return env
+	}
+	return append(env, EnvCACert+"="+egress.caCertPath)
 }
 
 // startScopedEgress starts the local filtering proxy when the policy's effective
@@ -242,13 +314,32 @@ func startScopedEgress(policy Policy, backend Backend) (*scopedEgress, error) {
 		return nil, nil
 	}
 	proxy, err := startEgressProxy(egressOptions{
-		Allowed: policy.AllowedDomains,
-		Denied:  policy.DeniedDomains,
+		Allowed:    policy.AllowedDomains,
+		Denied:     policy.DeniedDomains,
+		InspectTLS: policy.InspectTLS,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("scoped egress unavailable, denying network: %w", err)
 	}
-	return &scopedEgress{addr: proxy.Addr(), socksAddr: proxy.SocksAddr(), cleanup: func() { _ = proxy.Close() }}, nil
+	se := &scopedEgress{addr: proxy.Addr(), socksAddr: proxy.SocksAddr(), cleanup: func() { _ = proxy.Close() }}
+	if policy.InspectTLS {
+		// Write the MITM CA's PUBLIC cert so the sandboxed client can trust the
+		// minted leaves; surface it via ZERO_SANDBOX_CA_CERT and clean it up with
+		// the proxy. Reuses no new bind path: sandbox-exec already allows file-read,
+		// and the WSL policy-only runner shares the host filesystem.
+		caPath, werr := writeMITMCAFile(proxy.CACertPEM())
+		if werr != nil {
+			_ = proxy.Close()
+			return nil, werr
+		}
+		se.caCertPath = caPath
+		base := se.cleanup
+		se.cleanup = func() {
+			base()
+			_ = os.Remove(caPath)
+		}
+	}
+	return se, nil
 }
 
 func directCommandPlan(spec CommandSpec, backend Backend, policy Policy, workspaceRoot string) CommandPlan {
@@ -438,6 +529,7 @@ func sandboxExecCommandPlan(spec CommandSpec, workspaceRoot string, writeRoots [
 	env := sandboxEnvironment(policy, BackendSandboxExec, workspaceRoot)
 	if egress != nil {
 		env = append(env, ProxyEnvWithSocks(egress.addr, egress.socksAddr)...)
+		env = appendCACertEnv(env, egress)
 	}
 	plan := CommandPlan{
 		Backend:       backend,

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -244,10 +244,27 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 // a scoped-egress proxy was started, the proxy env so well-behaved clients route
 // through the allow/deny gate. It carries a least-privilege downgrade note.
 func wslCommandPlan(spec CommandSpec, workspaceRoot string, policy Policy, backend Backend, egress *scopedEgress) CommandPlan {
-	env := sandboxEnvironment(policy, BackendWSL, workspaceRoot)
+	// The WSL fallback runs the command DIRECTLY (no native wrap), so it inherits
+	// the caller's environment like the generic policy-only runner; the sandbox
+	// markers are appended last so they cannot be shadowed by the caller's env.
+	var env []string
+	if spec.Env != nil {
+		env = cloneStrings(spec.Env)
+	} else {
+		env = append(env, os.Environ()...)
+	}
+	env = append(env,
+		EnvSandboxBackend+"="+string(BackendWSL),
+		"ZERO_SANDBOX_NETWORK="+string(policy.Network),
+		EnvSandboxed+"=1",
+	)
+	note := "WSL: native process isolation (bubblewrap) is unavailable; downgraded to the policy-only runner " +
+		"(least privilege). The engine still enforces the full policy."
 	if egress != nil {
 		env = append(env, ProxyEnvWithSocks(egress.addr, egress.socksAddr)...)
 		env = appendCACertEnv(env, egress)
+		note = "WSL: native process isolation (bubblewrap) is unavailable; downgraded to the policy-only runner " +
+			"with proxy egress (least privilege). The engine still enforces the full policy."
 	}
 	plan := CommandPlan{
 		Backend:       backend,
@@ -258,10 +275,7 @@ func wslCommandPlan(spec CommandSpec, workspaceRoot string, policy Policy, backe
 		Args:          cloneStrings(spec.Args),
 		Dir:           spec.Dir,
 		Env:           env,
-		Notes: []string{
-			"WSL: native process isolation (bubblewrap) is unavailable; downgraded to the policy-only runner " +
-				"with proxy egress (least privilege). The engine still enforces the full policy.",
-		},
+		Notes:         []string{note},
 	}
 	if egress != nil {
 		plan.cleanup = egress.cleanup

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -131,6 +131,11 @@ const (
 	BackendBubblewrap  BackendName = "bubblewrap"
 	BackendSandboxExec BackendName = "sandbox-exec"
 	BackendPolicyOnly  BackendName = "policy-only"
+	// BackendWSL is the policy-only fallback used under WSL when bubblewrap is
+	// unavailable/unreliable: there is no native OS isolation, but network egress
+	// is still routed through the local filtering proxy and the command runs under
+	// the full policy engine. It is surfaced via ZERO_SANDBOX_BACKEND=wsl.
+	BackendWSL BackendName = "wsl"
 )
 
 const (
@@ -207,6 +212,19 @@ type Policy struct {
 	DenyRead   []string `json:"denyRead,omitempty"`
 	AllowWrite []string `json:"allowWrite,omitempty"`
 	DenyWrite  []string `json:"denyWrite,omitempty"`
+	// InspectTLS, when true, lets the in-process scoped-egress proxy TERMINATE TLS
+	// (using a locally generated, ephemeral CA) so it can enforce the per-host
+	// allow/deny rules on the DECRYPTED request Host — today a CONNECT tunnel only
+	// reveals the host once. OFF by default: the proxy stays a pure CONNECT
+	// passthrough, byte-for-byte unchanged. SECURITY/TRUST: enabling this means the
+	// sandbox can read the plaintext of the sandboxed process's TLS traffic. The
+	// MITM only re-signs toward the sandboxed client; the upstream connection is
+	// ALWAYS validated against the system roots (never InsecureSkipVerify), and the
+	// decrypted Host still passes the SAME authorize()/domainAllowed() gate — MITM
+	// widens visibility, never authority. The generated CA's public cert is written
+	// to the sandbox runtime dir and surfaced via ZERO_SANDBOX_CA_CERT so the
+	// sandboxed client can trust it.
+	InspectTLS bool `json:"inspectTLS,omitempty"`
 }
 
 type Request struct {

--- a/internal/sandbox/wsl.go
+++ b/internal/sandbox/wsl.go
@@ -1,0 +1,26 @@
+package sandbox
+
+import "strings"
+
+// WSLInfo describes the Windows Subsystem for Linux environment, if any. It is
+// derived from /proc/version. Mirrors reference wsl/index.js isWSL/isWSL2 and
+// sandbox-manager.js isWsl (reads /proc/version, matches "microsoft").
+type WSLInfo struct {
+	IsWSL  bool
+	IsWSL2 bool
+	Kernel string
+}
+
+// parseWSL classifies a /proc/version string. IsWSL is set when it contains
+// "microsoft" or "wsl"; IsWSL2 additionally requires "microsoft" and the absence
+// of the legacy "wsl1" marker. Factored out (pure) so it is table-testable
+// without a real /proc on any GOOS.
+func parseWSL(procVersion string) WSLInfo {
+	lower := strings.ToLower(procVersion)
+	isWSL := strings.Contains(lower, "microsoft") || strings.Contains(lower, "wsl")
+	info := WSLInfo{IsWSL: isWSL, Kernel: strings.TrimSpace(procVersion)}
+	if isWSL {
+		info.IsWSL2 = strings.Contains(lower, "microsoft") && !strings.Contains(lower, "wsl1")
+	}
+	return info
+}

--- a/internal/sandbox/wsl_linux.go
+++ b/internal/sandbox/wsl_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package sandbox
+
+import "os"
+
+// detectWSL reads /proc/version once and classifies the WSL environment. A read
+// error (no /proc) yields the zero WSLInfo (not WSL).
+func detectWSL() WSLInfo {
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return WSLInfo{}
+	}
+	return parseWSL(string(data))
+}

--- a/internal/sandbox/wsl_other.go
+++ b/internal/sandbox/wsl_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package sandbox
+
+// detectWSL is a no-op on non-Linux platforms: WSL is a Linux-under-Windows
+// environment, so the host GOOS is never WSL. Keeps the package building on all
+// platforms.
+func detectWSL() WSLInfo { return WSLInfo{} }

--- a/internal/sandbox/wsl_test.go
+++ b/internal/sandbox/wsl_test.go
@@ -67,7 +67,7 @@ func TestWSLPolicyOnlyPlanCarriesProxyAndMarkers(t *testing.T) {
 	// so the WSL fallback starts the filtering proxy and runs policy-only.
 	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil), Backend: wslBackendForTest()})
 
-	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root, Env: []string{}})
 	if err != nil {
 		t.Fatalf("BuildCommandPlan: %v", err)
 	}
@@ -92,12 +92,36 @@ func TestWSLPolicyOnlyPlanCarriesProxyAndMarkers(t *testing.T) {
 	}
 }
 
+func TestWSLPlanPreservesCallerEnv(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Backend: wslBackendForTest()})
+	plan, err := engine.BuildCommandPlan(CommandSpec{
+		Name: "/bin/sh", Args: []string{"-c", "true"}, Dir: root,
+		Env: []string{"FOO=bar", "PATH=/custom/bin"},
+	})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	defer plan.Cleanup()
+	env := strings.Join(plan.Env, "\n")
+	// The WSL direct-run inherits the caller's env (it is not OS-wrapped)...
+	if !strings.Contains(env, "FOO=bar") || !strings.Contains(env, "PATH=/custom/bin") {
+		t.Fatalf("WSL plan must preserve caller env, got:\n%s", env)
+	}
+	// ...with the sandbox markers appended (so they win over caller env).
+	if !strings.Contains(env, EnvSandboxed+"=1") || !strings.Contains(env, EnvSandboxBackend+"=wsl") {
+		t.Fatalf("WSL plan must append sandbox markers:\n%s", env)
+	}
+}
+
 func TestWSLPolicyOnlyDenyPlanHasMarkersNoProxy(t *testing.T) {
 	root := t.TempDir()
 	// Default policy (NetworkDeny) → no proxy started, but the WSL markers + note
 	// still apply and the plan still runs (AllowPolicyOnlyRunner default true).
 	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Backend: wslBackendForTest()})
-	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	// Explicit empty env so the assertion below is not confused by a dev/CI
+	// HTTP_PROXY inherited via os.Environ().
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root, Env: []string{}})
 	if err != nil {
 		t.Fatalf("BuildCommandPlan: %v", err)
 	}
@@ -106,7 +130,10 @@ func TestWSLPolicyOnlyDenyPlanHasMarkersNoProxy(t *testing.T) {
 	if !strings.Contains(env, EnvSandboxBackend+"=wsl") || !strings.Contains(env, EnvSandboxed+"=1") {
 		t.Fatalf("WSL deny plan must still carry sandbox markers:\n%s", env)
 	}
-	if strings.Contains(env, "HTTP_PROXY=") {
-		t.Fatalf("WSL deny plan must NOT export a proxy (network denied):\n%s", env)
+	if len(plan.Notes) == 0 || !strings.Contains(strings.Join(plan.Notes, " "), "policy-only") {
+		t.Fatalf("WSL deny plan must record a least-privilege downgrade note, got %v", plan.Notes)
+	}
+	if strings.Contains(env, "HTTP_PROXY=") || strings.Contains(env, "HTTPS_PROXY=") || strings.Contains(env, "ALL_PROXY=") {
+		t.Fatalf("WSL deny plan must NOT export any proxy env vars (network denied):\n%s", env)
 	}
 }

--- a/internal/sandbox/wsl_test.go
+++ b/internal/sandbox/wsl_test.go
@@ -1,0 +1,112 @@
+package sandbox
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseWSL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantWSL  bool
+		wantWSL2 bool
+	}{
+		{
+			name:     "wsl2 microsoft kernel",
+			input:    "Linux version 5.15.90.1-microsoft-standard-WSL2 (...)",
+			wantWSL:  true,
+			wantWSL2: true,
+		},
+		{
+			name:     "wsl1 legacy marker",
+			input:    "Linux version 4.4.0-19041-Microsoft (wsl1 build) ...",
+			wantWSL:  true,
+			wantWSL2: false,
+		},
+		{
+			name:     "plain linux",
+			input:    "Linux version 6.8.0-generic (gcc ...) #1 SMP",
+			wantWSL:  false,
+			wantWSL2: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseWSL(tc.input)
+			if got.IsWSL != tc.wantWSL || got.IsWSL2 != tc.wantWSL2 {
+				t.Fatalf("parseWSL(%q) = {IsWSL:%v IsWSL2:%v}, want {%v %v}", tc.input, got.IsWSL, got.IsWSL2, tc.wantWSL, tc.wantWSL2)
+			}
+			if got.IsWSL && got.Kernel == "" {
+				t.Fatalf("parseWSL should record the kernel string")
+			}
+		})
+	}
+}
+
+func wslBackendForTest() Backend {
+	return Backend{Name: BackendWSL, Platform: "linux", Fallback: true, ProxyEgress: true}
+}
+
+func TestWSLPlanFailsClosedWithoutPolicyOnly(t *testing.T) {
+	root := t.TempDir()
+	policy := scopedPolicy([]string{"github.com"}, nil)
+	policy.AllowPolicyOnlyRunner = false // explicitly refuse the degraded runner
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: policy, Backend: wslBackendForTest()})
+
+	_, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if !errors.Is(err, errWSLPolicyOnlyDisabled) {
+		t.Fatalf("WSL without AllowPolicyOnlyRunner err = %v, want errWSLPolicyOnlyDisabled", err)
+	}
+}
+
+func TestWSLPolicyOnlyPlanCarriesProxyAndMarkers(t *testing.T) {
+	root := t.TempDir()
+	// scopedPolicy uses DefaultPolicy (AllowPolicyOnlyRunner=true) + an allowlist,
+	// so the WSL fallback starts the filtering proxy and runs policy-only.
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: scopedPolicy([]string{"github.com"}, nil), Backend: wslBackendForTest()})
+
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	defer plan.Cleanup()
+
+	// Policy-only: the command runs directly, not OS-wrapped.
+	if plan.Wrapped || plan.Name != "/bin/sh" {
+		t.Fatalf("WSL plan must run the command directly, got wrapped=%v name=%q", plan.Wrapped, plan.Name)
+	}
+	env := strings.Join(plan.Env, "\n")
+	if !strings.Contains(env, EnvSandboxed+"=1") {
+		t.Fatalf("WSL plan env missing %s=1:\n%s", EnvSandboxed, env)
+	}
+	if !strings.Contains(env, EnvSandboxBackend+"=wsl") {
+		t.Fatalf("WSL plan env missing %s=wsl:\n%s", EnvSandboxBackend, env)
+	}
+	if !strings.Contains(env, "HTTP_PROXY=") || !strings.Contains(env, "ALL_PROXY=") {
+		t.Fatalf("WSL plan env missing proxy env (ProxyEnvWithSocks):\n%s", env)
+	}
+	if len(plan.Notes) == 0 || !strings.Contains(strings.Join(plan.Notes, " "), "policy-only") {
+		t.Fatalf("WSL plan must record a least-privilege downgrade note, got %v", plan.Notes)
+	}
+}
+
+func TestWSLPolicyOnlyDenyPlanHasMarkersNoProxy(t *testing.T) {
+	root := t.TempDir()
+	// Default policy (NetworkDeny) → no proxy started, but the WSL markers + note
+	// still apply and the plan still runs (AllowPolicyOnlyRunner default true).
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Backend: wslBackendForTest()})
+	plan, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Args: []string{"-c", "pwd"}, Dir: root})
+	if err != nil {
+		t.Fatalf("BuildCommandPlan: %v", err)
+	}
+	defer plan.Cleanup()
+	env := strings.Join(plan.Env, "\n")
+	if !strings.Contains(env, EnvSandboxBackend+"=wsl") || !strings.Contains(env, EnvSandboxed+"=1") {
+		t.Fatalf("WSL deny plan must still carry sandbox markers:\n%s", env)
+	}
+	if strings.Contains(env, "HTTP_PROXY=") {
+		t.Fatalf("WSL deny plan must NOT export a proxy (network denied):\n%s", env)
+	}
+}


### PR DESCRIPTION
## Summary
The **last two** sandbox breadth features (the other four — SOCKS5 egress, re-entrancy guard, fine-grained path lists, sandbox-aware ripgrep — already shipped and are untouched here). Both new features are **opt-in** and the **DEFAULT policy is unchanged**: `Mode=enforce`, `Network=deny`, `InspectTLS` off.

## 1) WSL detection + safe fail-closed fallback
- `parseWSL`/`detectWSL` (`wsl.go` + `wsl_linux.go` reading `/proc/version`; `wsl_other.go` stub) classify WSL/WSL2 — mirrors the reference `isWSL`/`isWSL2` + `isWsl` (`/proc/version` contains `microsoft`).
- `SelectBackend`: on Linux **without** bubblewrap, when running under WSL it selects a new `BackendWSL` instead of silently degrading to a plain policy-only runner.
- `BuildCommandPlan(BackendWSL)`: **fails closed** unless `Policy.AllowPolicyOnlyRunner` is set (clear error on how to opt in). When allowed, it runs the policy-only fallback that **still routes egress through the filtering proxy** (`Backend.ProxyEgress` ⇒ `EnforcesScopedEgress`, best-effort HTTP+SOCKS), sets `ZERO_SANDBOXED=1` / `ZERO_SANDBOX_BACKEND=wsl`, and records an auditable least-privilege downgrade note (`CommandPlan.Notes`). **Never runs unsandboxed silently.**

## 2) Optional gated MITM TLS inspection (`Policy.InspectTLS`, default OFF)
- **Off** ⇒ the egress proxy stays a pure CONNECT passthrough, byte-for-byte unchanged (no CA generated).
- **On** ⇒ the proxy terminates TLS toward the sandboxed client with an **ephemeral, locally generated ECDSA CA** (`mitm.go`), minting per-host leaves on the fly, so it can re-check the **decrypted** request Host through the **same** `authorize()`/`domainAllowed()` gate (deny-wins, empty allowlist ⇒ deny) — **MITM widens visibility, never authority**.
- The **upstream** dial is **always validated against the system roots** (never `InsecureSkipVerify`; tests inject a known root pool to exercise real validation).
- The CA's **public** cert is written owner-only and surfaced via `ZERO_SANDBOX_CA_CERT`. MITM only runs on backends that already permit reading it (sandbox-exec allows `file-read`; the WSL policy-only runner shares the host fs), so no new bind path is introduced.
- Trust implications documented loudly on the field. There is no "raw passthrough only" flag in zero, so the mutual-exclusion case is N/A.

## Tests
`parseWSL` table; WSL fail-closed-without-opt-in, policy-only-with-proxy (markers + `ProxyEnvWithSocks`), deny-mode markers-without-proxy; MITM passthrough-by-default (no CA), CA mints a chaining leaf, **full TLS-terminate-and-forward** of an allowlisted host to a real `httptest` TLS upstream (validated via an explicit root pool — proves no `InsecureSkipVerify`), and **decrypted-Host deny** (CONNECT host allowed, Host header denied ⇒ 403 before forwarding).

## Gates
`gofmt -l .` empty · `go vet` (host **and** `GOOS=linux`) · `go build` (host/linux/windows) · `go test ./...` (incl. `-race`) · `staticcheck` no new (host + linux) · `govulncheck` 0 · `deadcode -test=false` under **`GOOS=linux`** no new unreachable funcs.

Part of the completion kit; swarm and daemon-remote follow as separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows Subsystem for Linux (WSL) detection and a WSL-specific fallback backend when native sandboxing isn’t reliable.
  * Introduced optional TLS inspection (MITM) for the scoped egress proxy, including issuing short-lived per-host certificates and enforcing allow/deny rules on decrypted traffic.
  * Added a CA-certificate bootstrap mechanism for inspected traffic and improved WSL runner behavior (including fail-closed handling and added downgrade/audit notes).
* **Tests**
  * Added coverage for TLS inspection passthrough/allow/block flows and expanded WSL detection and plan-selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->