### PR TITLE
feat(swarm): multi-agent swarm over the specialist sub-agent

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/skills"
 	"github.com/Gitlawb/zero/internal/specialist"
+	"github.com/Gitlawb/zero/internal/swarm"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/tui"
 	"github.com/Gitlawb/zero/internal/update"
@@ -594,12 +596,37 @@ func newCoreRegistryScoped(workspaceRoot string, scope tools.PathScope) *tools.R
 	return registry
 }
 
-func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) (*specialist.Runtime, error) {
+// agentToolRuntime bundles the specialist runtime with the swarm it backs so
+// their lifetimes (and shutdown) stay paired: registerSpecialistTools brings up
+// both, closeSpecialistRuntime tears down both.
+type agentToolRuntime struct {
+	specialist *specialist.Runtime
+	swarm      *swarm.Swarm
+}
+
+func registerSpecialistTools(registry *tools.Registry, workspaceRoot string) (*agentToolRuntime, error) {
 	paths, err := specialist.DefaultPaths(workspaceRoot)
 	if err != nil {
 		return nil, err
 	}
-	return specialist.RegisterTools(registry, specialist.Executor{Paths: paths})
+	executor := specialist.Executor{Paths: paths}
+	runtime, err := specialist.RegisterTools(registry, executor)
+	if err != nil {
+		return nil, err
+	}
+	// The swarm reuses the same specialist executor to launch each member, so
+	// every member runs under the orchestrator's sandbox + policy. Mailbox state
+	// lives under the workspace so its files fall within the sandbox write rules.
+	sw, err := swarm.New(swarm.Options{
+		BaseDir:  filepath.Join(workspaceRoot, ".zero", "swarm"),
+		Launcher: swarm.NewSpecialistLauncher(executor),
+	})
+	if err != nil {
+		runtime.Close()
+		return nil, err
+	}
+	swarm.RegisterTools(registry, sw)
+	return &agentToolRuntime{specialist: runtime, swarm: sw}, nil
 }
 
 func shouldRegisterExecSpecialistTools(options execOptions) bool {
@@ -621,12 +648,17 @@ func closeMCPRuntime(stderr io.Writer, runtime mcpToolRuntime) {
 	}
 }
 
-func closeSpecialistRuntime(stderr io.Writer, runtime *specialist.Runtime) {
+func closeSpecialistRuntime(stderr io.Writer, runtime *agentToolRuntime) {
 	if runtime == nil {
 		return
 	}
-	if err := runtime.Close(); err != nil {
-		_, _ = fmt.Fprintf(stderr, "[zero] specialist_cleanup_error: %s\n", err)
+	if runtime.swarm != nil {
+		runtime.swarm.Close()
+	}
+	if runtime.specialist != nil {
+		if err := runtime.specialist.Close(); err != nil {
+			_, _ = fmt.Fprintf(stderr, "[zero] specialist_cleanup_error: %s\n", err)
+		}
 	}
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
-	"github.com/Gitlawb/zero/internal/specialist"
 	"github.com/Gitlawb/zero/internal/specmode"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
@@ -163,7 +162,7 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 	if options.allowEscalation {
 		registry.Register(tools.NewEscalateModelTool())
 	}
-	var specialistRuntime *specialist.Runtime
+	var specialistRuntime *agentToolRuntime
 	if shouldRegisterExecSpecialistTools(options) {
 		var err error
 		specialistRuntime, err = registerSpecialistTools(registry, workspaceRoot)

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -58,14 +58,20 @@ type BuildArgsInput struct {
 	CurrentDepth          int
 	Description           string
 	Cwd                   string
+	// PermissionMode is the parent's resolved permission mode. Empty preserves
+	// the historical "--auto high" (the Task tool omits it); a caller that
+	// passes a non-unsafe mode (e.g. the swarm propagating a non-unsafe
+	// orchestrator) gets a non-unsafe child so authority is never widened.
+	PermissionMode string
 }
 
 type BuildResumeArgsInput struct {
-	SessionID    string
-	Prompt       string
-	CurrentDepth int
-	Manifest     Manifest
-	Cwd          string
+	SessionID      string
+	Prompt         string
+	CurrentDepth   int
+	Manifest       Manifest
+	Cwd            string
+	PermissionMode string
 }
 
 type BuildArgsResult struct {
@@ -90,7 +96,31 @@ type TaskRunOptions struct {
 	ParentReasoningEffort string
 	CurrentDepth          int
 	Cwd                   string
+	// PermissionMode propagates the parent's resolved permission mode to the
+	// child. Empty keeps the historical "--auto high"; a non-unsafe value runs
+	// the child non-unsafe so it never gains more authority than the parent.
+	PermissionMode string
 }
+
+// specialistAutonomy maps a parent permission mode to the child's "--auto"
+// level. A headless specialist child cannot answer interactive prompts, so it
+// runs autonomously — but only at "high" (unsafe) when the parent is itself
+// unsafe (or when no mode is provided, preserving the Task tool's behavior).
+// Any other parent mode yields the non-unsafe "low" level, so the child's
+// authority never exceeds the parent's.
+func specialistAutonomy(permissionMode string) string {
+	switch strings.TrimSpace(permissionMode) {
+	case "", string(permissionModeUnsafe):
+		return "high"
+	default:
+		return "low"
+	}
+}
+
+// permissionModeUnsafe mirrors agent.PermissionModeUnsafe without importing the
+// agent package (which would create an import cycle): exec resolves "--auto high"
+// to this mode.
+const permissionModeUnsafe = "unsafe"
 
 type ExecResult struct {
 	Result    tools.Result
@@ -147,7 +177,7 @@ func (executor Executor) BuildArgs(input BuildArgsInput) (BuildArgsResult, error
 	args := []string{"exec", "--init-session-id", sessionID}
 	args = append(args, promptArgs...)
 	args = appendModelArgs(args, input.Manifest, input.ParentModel, input.ParentReasoningEffort)
-	args = append(args, "--auto", "high", "--output-format", "stream-json")
+	args = append(args, "--auto", specialistAutonomy(input.PermissionMode), "--output-format", "stream-json")
 	toolAllowlist, err := resolvedToolAllowlist(input.Manifest)
 	if err != nil {
 		return BuildArgsResult{}, err
@@ -199,7 +229,7 @@ func (executor Executor) BuildResumeArgs(input BuildResumeArgsInput) (BuildArgsR
 	}
 	args := []string{"exec", "--resume", sessionID}
 	args = append(args, promptArgs...)
-	args = append(args, "--auto", "high", "--output-format", "stream-json")
+	args = append(args, "--auto", specialistAutonomy(input.PermissionMode), "--output-format", "stream-json")
 	toolAllowlist, err := resolvedToolAllowlist(input.Manifest)
 	if err != nil {
 		return BuildArgsResult{}, err
@@ -230,6 +260,7 @@ func (executor Executor) runFresh(ctx context.Context, params TaskParameters, op
 		CurrentDepth:          options.CurrentDepth,
 		Description:           params.Description,
 		Cwd:                   options.Cwd,
+		PermissionMode:        options.PermissionMode,
 	})
 	if err != nil {
 		return ExecResult{}, err
@@ -257,11 +288,12 @@ func (executor Executor) runResume(ctx context.Context, params TaskParameters, o
 		return ExecResult{}, err
 	}
 	built, err := executor.BuildResumeArgs(BuildResumeArgsInput{
-		SessionID:    params.Resume,
-		Prompt:       params.Prompt,
-		CurrentDepth: options.CurrentDepth,
-		Manifest:     manifest,
-		Cwd:          options.Cwd,
+		SessionID:      params.Resume,
+		Prompt:         params.Prompt,
+		CurrentDepth:   options.CurrentDepth,
+		Manifest:       manifest,
+		Cwd:            options.Cwd,
+		PermissionMode: options.PermissionMode,
 	})
 	if err != nil {
 		return ExecResult{}, err

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -64,6 +64,65 @@ func TestBuildArgsCreatesFreshSpecialistExecInvocation(t *testing.T) {
 	}
 }
 
+func TestSpecialistAutonomyByPermissionMode(t *testing.T) {
+	cases := map[string]string{
+		"":           "high", // back-compat: the Task tool omits the mode
+		"unsafe":     "high",
+		"auto":       "low",
+		"ask":        "low",
+		"spec-draft": "low",
+		"whatever":   "low",
+	}
+	for mode, want := range cases {
+		if got := specialistAutonomy(mode); got != want {
+			t.Errorf("specialistAutonomy(%q) = %q, want %q", mode, got, want)
+		}
+	}
+}
+
+func TestBuildArgsAutonomyHonorsPermissionMode(t *testing.T) {
+	executor := Executor{NewSessionID: func() (string, error) { return "child", nil }}
+	manifest := Manifest{Metadata: Metadata{Name: "reviewer"}, SystemPrompt: "x", ResolvedTools: []string{"read_file"}}
+
+	// A non-unsafe parent mode yields a non-unsafe child (--auto low), so a
+	// swarm member never gains more authority than a non-unsafe orchestrator.
+	res, err := executor.BuildArgs(BuildArgsInput{Manifest: manifest, Prompt: "p", PermissionMode: "auto"})
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	if !containsSequence(res.Args, []string{"--auto", "low"}) {
+		t.Fatalf("non-unsafe parent must yield --auto low, got %v", res.Args)
+	}
+	if containsSequence(res.Args, []string{"--auto", "high"}) {
+		t.Fatalf("non-unsafe parent must NOT yield --auto high: %v", res.Args)
+	}
+
+	// An unsafe parent (and the empty back-compat case) keep --auto high.
+	for _, mode := range []string{"unsafe", ""} {
+		out, err := executor.BuildArgs(BuildArgsInput{Manifest: manifest, Prompt: "p", PermissionMode: mode})
+		if err != nil {
+			t.Fatalf("BuildArgs(%q): %v", mode, err)
+		}
+		if !containsSequence(out.Args, []string{"--auto", "high"}) {
+			t.Fatalf("mode %q must yield --auto high, got %v", mode, out.Args)
+		}
+	}
+}
+
+func TestBuildResumeArgsAutonomyHonorsPermissionMode(t *testing.T) {
+	executor := Executor{}
+	manifest := Manifest{Metadata: Metadata{Name: "reviewer"}, ResolvedTools: []string{"read_file"}}
+	res, err := executor.BuildResumeArgs(BuildResumeArgsInput{
+		SessionID: "child_session", Prompt: "p", Manifest: manifest, PermissionMode: "auto",
+	})
+	if err != nil {
+		t.Fatalf("BuildResumeArgs: %v", err)
+	}
+	if !containsSequence(res.Args, []string{"--auto", "low"}) || containsSequence(res.Args, []string{"--auto", "high"}) {
+		t.Fatalf("resume non-unsafe parent must yield --auto low, got %v", res.Args)
+	}
+}
+
 func TestBuildArgsSessionTitleFallsBackToNameWithoutDescription(t *testing.T) {
 	executor := Executor{NewSessionID: func() (string, error) { return "child", nil }}
 	manifest := Manifest{

--- a/internal/swarm/coordinator.go
+++ b/internal/swarm/coordinator.go
@@ -1,0 +1,245 @@
+package swarm
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// TaskStatus is the lifecycle state of a swarm task.
+type TaskStatus string
+
+const (
+	// StatusPending: registered but the member has not started.
+	StatusPending TaskStatus = "pending"
+	// StatusRunning: the member is executing.
+	StatusRunning TaskStatus = "running"
+	// StatusDone: the member finished successfully.
+	StatusDone TaskStatus = "done"
+	// StatusFailed: the member exited with an error.
+	StatusFailed TaskStatus = "failed"
+	// StatusHandedOff: ownership was transferred to another agent.
+	StatusHandedOff TaskStatus = "handed-off"
+)
+
+// terminal reports whether a status is final (no further transitions expected).
+func (s TaskStatus) terminal() bool {
+	return s == StatusDone || s == StatusFailed || s == StatusHandedOff
+}
+
+// Task is one unit of work tracked by the coordinator. It is returned by value
+// from snapshots so callers cannot mutate coordinator state without the lock.
+type Task struct {
+	ID          string
+	AgentID     string
+	Team        string
+	Description string
+	Status      TaskStatus
+	Result      string
+	Err         string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// agentColors palette for stable per-agent coloring in the TUI/status. Provider
+// -neutral ANSI-ish names; the renderer maps them to styles.
+var agentColors = []string{"cyan", "magenta", "green", "yellow", "blue", "red"}
+
+// Coordinator is the in-memory task registry + team color assigner shared by an
+// orchestrator and its members. Mirrors swarm/coordinator.js (tasks map +
+// createColorAssigner) and is safe for concurrent use.
+type Coordinator struct {
+	mu         sync.RWMutex
+	tasks      map[string]*Task
+	colors     map[string]string // agentID -> color
+	colorIndex int
+	now        func() time.Time // injectable clock for tests
+}
+
+// NewCoordinator returns an empty coordinator using the wall clock.
+func NewCoordinator() *Coordinator {
+	return &Coordinator{
+		tasks:  map[string]*Task{},
+		colors: map[string]string{},
+		now:    time.Now,
+	}
+}
+
+// ErrTaskExists is returned when registering a duplicate task ID.
+var ErrTaskExists = errors.New("swarm: task already registered")
+
+// ErrUnknownTask is returned when updating/removing a missing task ID.
+var ErrUnknownTask = errors.New("swarm: unknown task")
+
+// Register adds a new pending task. The ID must be unique and non-empty.
+func (c *Coordinator) Register(id, agentID, team, description string) (Task, error) {
+	if id == "" {
+		return Task{}, errors.New("swarm: task id is required")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.tasks[id]; ok {
+		return Task{}, fmt.Errorf("%w: %s", ErrTaskExists, id)
+	}
+	now := c.now()
+	t := &Task{
+		ID:          id,
+		AgentID:     agentID,
+		Team:        team,
+		Description: description,
+		Status:      StatusPending,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	c.tasks[id] = t
+	c.assignColorLocked(agentID)
+	return *t, nil
+}
+
+// SetStatus transitions a task. Transitions out of a terminal state are
+// rejected (fail closed) so a late member update cannot resurrect a finished
+// task.
+func (c *Coordinator) SetStatus(id string, status TaskStatus) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.tasks[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownTask, id)
+	}
+	if t.Status.terminal() && t.Status != status {
+		return fmt.Errorf("swarm: task %s is %s (terminal); cannot move to %s", id, t.Status, status)
+	}
+	t.Status = status
+	t.UpdatedAt = c.now()
+	return nil
+}
+
+// Complete marks a task done with its result.
+func (c *Coordinator) Complete(id, result string) error {
+	return c.finish(id, StatusDone, result, "")
+}
+
+// Fail marks a task failed with an error message.
+func (c *Coordinator) Fail(id, errMsg string) error {
+	return c.finish(id, StatusFailed, "", errMsg)
+}
+
+func (c *Coordinator) finish(id string, status TaskStatus, result, errMsg string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.tasks[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownTask, id)
+	}
+	if t.Status.terminal() {
+		return fmt.Errorf("swarm: task %s already %s", id, t.Status)
+	}
+	t.Status = status
+	t.Result = result
+	t.Err = errMsg
+	t.UpdatedAt = c.now()
+	return nil
+}
+
+// Reassign transfers a task to a new agent (handoff/orphan-adoption). The task
+// returns to pending under the new owner unless it is already terminal.
+func (c *Coordinator) Reassign(id, newAgentID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.tasks[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownTask, id)
+	}
+	if t.Status.terminal() {
+		return fmt.Errorf("swarm: task %s already %s; cannot reassign", id, t.Status)
+	}
+	t.AgentID = newAgentID
+	t.Status = StatusPending
+	t.UpdatedAt = c.now()
+	c.assignColorLocked(newAgentID)
+	return nil
+}
+
+// Get returns a snapshot of one task.
+func (c *Coordinator) Get(id string) (Task, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	t, ok := c.tasks[id]
+	if !ok {
+		return Task{}, false
+	}
+	return *t, true
+}
+
+// List returns snapshots of all tasks, ordered by creation time then ID for
+// stable output.
+func (c *Coordinator) List() []Task {
+	c.mu.RLock()
+	out := make([]Task, 0, len(c.tasks))
+	for _, t := range c.tasks {
+		out = append(out, *t)
+	}
+	c.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out
+}
+
+// Color returns the stable color assigned to an agent (assigning one on first
+// use), so status output colors each member consistently.
+func (c *Coordinator) Color(agentID string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.assignColorLocked(agentID)
+}
+
+func (c *Coordinator) assignColorLocked(agentID string) string {
+	if agentID == "" {
+		return ""
+	}
+	if color, ok := c.colors[agentID]; ok {
+		return color
+	}
+	color := agentColors[c.colorIndex%len(agentColors)]
+	c.colors[agentID] = color
+	c.colorIndex++
+	return color
+}
+
+// Summary is an aggregate count of tasks by status for the status tool.
+type Summary struct {
+	Total     int
+	Pending   int
+	Running   int
+	Done      int
+	Failed    int
+	HandedOff int
+}
+
+// Summarize aggregates current task counts.
+func (c *Coordinator) Summarize() Summary {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	s := Summary{Total: len(c.tasks)}
+	for _, t := range c.tasks {
+		switch t.Status {
+		case StatusPending:
+			s.Pending++
+		case StatusRunning:
+			s.Running++
+		case StatusDone:
+			s.Done++
+		case StatusFailed:
+			s.Failed++
+		case StatusHandedOff:
+			s.HandedOff++
+		}
+	}
+	return s
+}

--- a/internal/swarm/coordinator.go
+++ b/internal/swarm/coordinator.go
@@ -29,6 +29,18 @@ func (s TaskStatus) terminal() bool {
 	return s == StatusDone || s == StatusFailed || s == StatusHandedOff
 }
 
+// valid reports whether a status is one of the known lifecycle states. Unknown
+// statuses are rejected (fail closed) so a task can never enter an undefined
+// state that Summarize and the lifecycle logic cannot reason about.
+func (s TaskStatus) valid() bool {
+	switch s {
+	case StatusPending, StatusRunning, StatusDone, StatusFailed, StatusHandedOff:
+		return true
+	default:
+		return false
+	}
+}
+
 // Task is one unit of work tracked by the coordinator. It is returned by value
 // from snapshots so callers cannot mutate coordinator state without the lock.
 type Task struct {
@@ -102,6 +114,9 @@ func (c *Coordinator) Register(id, agentID, team, description string) (Task, err
 // rejected (fail closed) so a late member update cannot resurrect a finished
 // task.
 func (c *Coordinator) SetStatus(id string, status TaskStatus) error {
+	if !status.valid() {
+		return fmt.Errorf("swarm: invalid task status %q", status)
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	t, ok := c.tasks[id]

--- a/internal/swarm/coordinator.go
+++ b/internal/swarm/coordinator.go
@@ -60,8 +60,7 @@ type Task struct {
 var agentColors = []string{"cyan", "magenta", "green", "yellow", "blue", "red"}
 
 // Coordinator is the in-memory task registry + team color assigner shared by an
-// orchestrator and its members. Mirrors swarm/coordinator.js (tasks map +
-// createColorAssigner) and is safe for concurrent use.
+// orchestrator and its members. It is safe for concurrent use.
 type Coordinator struct {
 	mu         sync.RWMutex
 	tasks      map[string]*Task

--- a/internal/swarm/coordinator_test.go
+++ b/internal/swarm/coordinator_test.go
@@ -48,6 +48,18 @@ func TestCoordinatorLifecycleTransitions(t *testing.T) {
 	}
 }
 
+func TestCoordinatorRejectsInvalidStatus(t *testing.T) {
+	c := NewCoordinator()
+	_, _ = c.Register("t1", "a1", "team", "desc")
+	if err := c.SetStatus("t1", TaskStatus("bogus")); err == nil {
+		t.Fatal("SetStatus must reject an unknown status")
+	}
+	// The task stays in its prior (valid) state.
+	if task, _ := c.Get("t1"); task.Status != StatusPending {
+		t.Fatalf("rejected status must not mutate the task, got %v", task.Status)
+	}
+}
+
 func TestCoordinatorUnknownTask(t *testing.T) {
 	c := NewCoordinator()
 	if err := c.SetStatus("missing", StatusRunning); !errors.Is(err, ErrUnknownTask) {

--- a/internal/swarm/coordinator_test.go
+++ b/internal/swarm/coordinator_test.go
@@ -1,0 +1,139 @@
+package swarm
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestCoordinatorRegisterAndDuplicate(t *testing.T) {
+	c := NewCoordinator()
+	if _, err := c.Register("t1", "a1", "team", "desc"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	task, ok := c.Get("t1")
+	if !ok || task.Status != StatusPending {
+		t.Fatalf("Get after register: ok=%v status=%v", ok, task.Status)
+	}
+	if _, err := c.Register("t1", "a1", "team", "desc"); !errors.Is(err, ErrTaskExists) {
+		t.Fatalf("duplicate Register err = %v, want ErrTaskExists", err)
+	}
+	if _, err := c.Register("", "a", "team", "d"); err == nil {
+		t.Fatal("empty id must error")
+	}
+}
+
+func TestCoordinatorLifecycleTransitions(t *testing.T) {
+	c := NewCoordinator()
+	_, _ = c.Register("t1", "a1", "team", "desc")
+	if err := c.SetStatus("t1", StatusRunning); err != nil {
+		t.Fatalf("SetStatus running: %v", err)
+	}
+	if err := c.Complete("t1", "result-data"); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	task, _ := c.Get("t1")
+	if task.Status != StatusDone || task.Result != "result-data" {
+		t.Fatalf("after Complete: status=%v result=%q", task.Status, task.Result)
+	}
+	// Terminal guard: cannot move done -> running, nor complete twice.
+	if err := c.SetStatus("t1", StatusRunning); err == nil {
+		t.Fatal("moving a done task to running must fail")
+	}
+	if err := c.Complete("t1", "x"); err == nil {
+		t.Fatal("completing a done task must fail")
+	}
+	if err := c.Fail("t1", "boom"); err == nil {
+		t.Fatal("failing a done task must fail")
+	}
+}
+
+func TestCoordinatorUnknownTask(t *testing.T) {
+	c := NewCoordinator()
+	if err := c.SetStatus("missing", StatusRunning); !errors.Is(err, ErrUnknownTask) {
+		t.Fatalf("SetStatus(missing) = %v, want ErrUnknownTask", err)
+	}
+	if err := c.Complete("missing", "x"); !errors.Is(err, ErrUnknownTask) {
+		t.Fatalf("Complete(missing) = %v, want ErrUnknownTask", err)
+	}
+}
+
+func TestCoordinatorReassign(t *testing.T) {
+	c := NewCoordinator()
+	_, _ = c.Register("t1", "a1", "team", "desc")
+	_ = c.SetStatus("t1", StatusRunning)
+	if err := c.Reassign("t1", "a2"); err != nil {
+		t.Fatalf("Reassign: %v", err)
+	}
+	task, _ := c.Get("t1")
+	if task.AgentID != "a2" || task.Status != StatusPending {
+		t.Fatalf("after Reassign: agent=%q status=%v", task.AgentID, task.Status)
+	}
+	// Cannot reassign a terminal task.
+	_ = c.Complete("t1", "done")
+	if err := c.Reassign("t1", "a3"); err == nil {
+		t.Fatal("reassigning a terminal task must fail")
+	}
+}
+
+func TestCoordinatorColorStability(t *testing.T) {
+	c := NewCoordinator()
+	first := c.Color("a1")
+	if first == "" {
+		t.Fatal("Color should assign a non-empty color")
+	}
+	if again := c.Color("a1"); again != first {
+		t.Fatalf("Color not stable: %q vs %q", first, again)
+	}
+	if other := c.Color("a2"); other == "" {
+		t.Fatal("second agent should also get a color")
+	}
+	if c.Color("") != "" {
+		t.Fatal("empty agent id should get no color")
+	}
+}
+
+func TestCoordinatorSummarize(t *testing.T) {
+	c := NewCoordinator()
+	_, _ = c.Register("p", "a", "team", "")
+	_, _ = c.Register("r", "b", "team", "")
+	_ = c.SetStatus("r", StatusRunning)
+	_, _ = c.Register("d", "c", "team", "")
+	_ = c.Complete("d", "ok")
+	s := c.Summarize()
+	if s.Total != 3 || s.Pending != 1 || s.Running != 1 || s.Done != 1 {
+		t.Fatalf("Summarize = %+v", s)
+	}
+}
+
+func TestCoordinatorConcurrentRegister(t *testing.T) {
+	c := NewCoordinator()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := "task-" + string(rune('a'+n%26)) + "-" + itoa(n)
+			_, _ = c.Register(id, id, "team", "desc")
+			_ = c.SetStatus(id, StatusRunning)
+			_ = c.Complete(id, "done")
+		}(i)
+	}
+	wg.Wait()
+	if got := len(c.List()); got != 50 {
+		t.Fatalf("List len = %d, want 50", got)
+	}
+}
+
+// itoa avoids importing strconv just for the concurrency test id.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/swarm/definition.go
+++ b/internal/swarm/definition.go
@@ -108,20 +108,19 @@ func (r *Registry) AgentTypes() []string {
 func builtinDefinitions() []Definition {
 	return []Definition{
 		{
-			AgentType:      "teammate",
-			WhenToUse:      "In-process teammate for parallel task execution; delegate work to run alongside the orchestrator.",
-			Model:          modelInherit,
-			PermissionMode: "default",
+			AgentType: "teammate",
+			WhenToUse: "In-process teammate for parallel task execution; delegate work to run alongside the orchestrator.",
+			Model:     modelInherit,
+			// Empty PermissionMode => inherit the orchestrator's mode (never widened).
 			SystemPrompt: func(ctx PromptContext) string {
 				return "You are a teammate agent collaborating with an orchestrator on team " +
 					displayTeam(ctx.Team) + ". Complete your assigned task and report results.\n\nTask: " + ctx.Task
 			},
 		},
 		{
-			AgentType:      "subagent",
-			WhenToUse:      "General-purpose subagent for an isolated, delegated task; starts with zero prior context.",
-			Model:          modelInherit,
-			PermissionMode: "default",
+			AgentType: "subagent",
+			WhenToUse: "General-purpose subagent for an isolated, delegated task; starts with zero prior context.",
+			Model:     modelInherit,
 			SystemPrompt: func(ctx PromptContext) string {
 				return "You are a subagent spawned to complete a specific task. You start with zero context — " +
 					"the briefing below is all you know.\n\nTask: " + ctx.Task

--- a/internal/swarm/definition.go
+++ b/internal/swarm/definition.go
@@ -21,14 +21,12 @@ import (
 var ErrUnknownAgentType = errors.New("swarm: unknown agent type")
 
 // modelInherit is the sentinel meaning "use the orchestrator's model" — members
-// never silently pick a different (e.g. more capable) model. Mirrors the
-// reference roster's model:"inherit".
+// never silently pick a different (e.g. more capable) model.
 const modelInherit = "inherit"
 
 // Definition is one entry in the agent roster: how a member of a given type
-// behaves. Mirrors reference-swarm-code-agent-js/definitions/swarm.js
-// (TEAMMATE_AGENT/SUBAGENT_AGENT: agentType, whenToUse, model:"inherit",
-// permissionMode, getSystemPrompt).
+// behaves (agent type, when to use it, model — "inherit" by default —,
+// permission mode, and a system-prompt builder).
 type Definition struct {
 	AgentType      string
 	WhenToUse      string
@@ -46,8 +44,7 @@ type PromptContext struct {
 }
 
 // Registry is the agent roster: definitions looked up by agent type. Built-ins
-// are seeded at construction; user-defined definitions (loaded from disk) extend
-// or override them. Mirrors definitions/index.js (lookup) + storage.js.
+// are seeded at construction; user-defined definitions extend or override them.
 type Registry struct {
 	mu   sync.RWMutex
 	defs map[string]Definition
@@ -102,9 +99,8 @@ func (r *Registry) AgentTypes() []string {
 	return types
 }
 
-// builtinDefinitions returns the seeded roster. Mirrors definitions/swarm.js
-// (teammate, subagent) — kept minimal and provider-neutral; user-defined agents
-// extend it via Register.
+// builtinDefinitions returns the seeded roster (teammate, subagent) — kept
+// minimal; user-defined agents extend it via Register.
 func builtinDefinitions() []Definition {
 	return []Definition{
 		{

--- a/internal/swarm/definition.go
+++ b/internal/swarm/definition.go
@@ -1,0 +1,138 @@
+// Package swarm adds a multi-agent SWARM on top of zero's single sub-agent
+// mechanism (internal/specialist): an orchestrator can spawn and coordinate
+// MULTIPLE specialist members that run concurrently, communicate via per-agent
+// mailboxes, and hand work off. It composes internal/specialist (to launch each
+// member), internal/daemon (pooled workers when a daemon is running) and
+// internal/background. Everything is additive and opt-in — the existing single
+// "task" tool is unchanged; swarm tools are only active when invoked.
+//
+// Every member runs under the SAME sandbox + risk/autonomy policy as the
+// orchestrator: the swarm never grants a member more authority than its parent.
+package swarm
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// ErrUnknownAgentType is returned when a definition lookup misses.
+var ErrUnknownAgentType = errors.New("swarm: unknown agent type")
+
+// modelInherit is the sentinel meaning "use the orchestrator's model" — members
+// never silently pick a different (e.g. more capable) model. Mirrors the
+// reference roster's model:"inherit".
+const modelInherit = "inherit"
+
+// Definition is one entry in the agent roster: how a member of a given type
+// behaves. Mirrors reference-swarm-code-agent-js/definitions/swarm.js
+// (TEAMMATE_AGENT/SUBAGENT_AGENT: agentType, whenToUse, model:"inherit",
+// permissionMode, getSystemPrompt).
+type Definition struct {
+	AgentType      string
+	WhenToUse      string
+	Model          string // "inherit" => use the orchestrator's model
+	PermissionMode string
+	// SystemPrompt returns the member's system prompt for the given task context.
+	// It is a func so a definition can fold the task briefing in.
+	SystemPrompt func(ctx PromptContext) string
+}
+
+// PromptContext is the minimal context handed to a definition's SystemPrompt.
+type PromptContext struct {
+	Team string
+	Task string
+}
+
+// Registry is the agent roster: definitions looked up by agent type. Built-ins
+// are seeded at construction; user-defined definitions (loaded from disk) extend
+// or override them. Mirrors definitions/index.js (lookup) + storage.js.
+type Registry struct {
+	mu   sync.RWMutex
+	defs map[string]Definition
+}
+
+// NewRegistry builds a registry seeded with the built-in roster.
+func NewRegistry() *Registry {
+	r := &Registry{defs: map[string]Definition{}}
+	for _, def := range builtinDefinitions() {
+		r.defs[def.AgentType] = def
+	}
+	return r
+}
+
+// Register adds or overrides a definition (user-defined agents extend the
+// built-ins). An empty AgentType is rejected.
+func (r *Registry) Register(def Definition) error {
+	agentType := strings.TrimSpace(def.AgentType)
+	if agentType == "" {
+		return errors.New("swarm: definition requires an agentType")
+	}
+	if def.Model == "" {
+		def.Model = modelInherit
+	}
+	def.AgentType = agentType
+	r.mu.Lock()
+	r.defs[agentType] = def
+	r.mu.Unlock()
+	return nil
+}
+
+// Lookup returns the definition for agentType, or ErrUnknownAgentType.
+func (r *Registry) Lookup(agentType string) (Definition, error) {
+	r.mu.RLock()
+	def, ok := r.defs[strings.TrimSpace(agentType)]
+	r.mu.RUnlock()
+	if !ok {
+		return Definition{}, ErrUnknownAgentType
+	}
+	return def, nil
+}
+
+// AgentTypes returns the registered agent types, sorted, for status/help.
+func (r *Registry) AgentTypes() []string {
+	r.mu.RLock()
+	types := make([]string, 0, len(r.defs))
+	for t := range r.defs {
+		types = append(types, t)
+	}
+	r.mu.RUnlock()
+	sort.Strings(types)
+	return types
+}
+
+// builtinDefinitions returns the seeded roster. Mirrors definitions/swarm.js
+// (teammate, subagent) — kept minimal and provider-neutral; user-defined agents
+// extend it via Register.
+func builtinDefinitions() []Definition {
+	return []Definition{
+		{
+			AgentType:      "teammate",
+			WhenToUse:      "In-process teammate for parallel task execution; delegate work to run alongside the orchestrator.",
+			Model:          modelInherit,
+			PermissionMode: "default",
+			SystemPrompt: func(ctx PromptContext) string {
+				return "You are a teammate agent collaborating with an orchestrator on team " +
+					displayTeam(ctx.Team) + ". Complete your assigned task and report results.\n\nTask: " + ctx.Task
+			},
+		},
+		{
+			AgentType:      "subagent",
+			WhenToUse:      "General-purpose subagent for an isolated, delegated task; starts with zero prior context.",
+			Model:          modelInherit,
+			PermissionMode: "default",
+			SystemPrompt: func(ctx PromptContext) string {
+				return "You are a subagent spawned to complete a specific task. You start with zero context — " +
+					"the briefing below is all you know.\n\nTask: " + ctx.Task
+			},
+		},
+	}
+}
+
+func displayTeam(team string) string {
+	if strings.TrimSpace(team) == "" {
+		return "default"
+	}
+	return team
+}

--- a/internal/swarm/definition_test.go
+++ b/internal/swarm/definition_test.go
@@ -1,0 +1,74 @@
+package swarm
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRegistryBuiltins(t *testing.T) {
+	r := NewRegistry()
+	for _, want := range []string{"teammate", "subagent"} {
+		def, err := r.Lookup(want)
+		if err != nil {
+			t.Fatalf("builtin %q missing: %v", want, err)
+		}
+		if def.Model != modelInherit {
+			t.Fatalf("builtin %q model = %q, want inherit", want, def.Model)
+		}
+		if def.SystemPrompt == nil {
+			t.Fatalf("builtin %q must have a SystemPrompt", want)
+		}
+		if got := def.SystemPrompt(PromptContext{Team: "t", Task: "do x"}); got == "" {
+			t.Fatalf("builtin %q SystemPrompt returned empty", want)
+		}
+	}
+}
+
+func TestRegistryLookupUnknown(t *testing.T) {
+	r := NewRegistry()
+	if _, err := r.Lookup("nope"); !errors.Is(err, ErrUnknownAgentType) {
+		t.Fatalf("Lookup(nope) err = %v, want ErrUnknownAgentType", err)
+	}
+}
+
+func TestRegistryRegisterOverrideAndDefaultModel(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(Definition{AgentType: "  custom  "}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	def, err := r.Lookup("custom")
+	if err != nil {
+		t.Fatalf("Lookup(custom): %v", err)
+	}
+	if def.AgentType != "custom" {
+		t.Fatalf("agentType not trimmed: %q", def.AgentType)
+	}
+	if def.Model != modelInherit {
+		t.Fatalf("default model = %q, want inherit", def.Model)
+	}
+	// Override a builtin.
+	if err := r.Register(Definition{AgentType: "teammate", Model: "fixed-model"}); err != nil {
+		t.Fatalf("override Register: %v", err)
+	}
+	if got, _ := r.Lookup("teammate"); got.Model != "fixed-model" {
+		t.Fatalf("override model = %q, want fixed-model", got.Model)
+	}
+}
+
+func TestRegistryRegisterRejectsEmpty(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(Definition{AgentType: "   "}); err == nil {
+		t.Fatal("Register with blank agentType must error")
+	}
+}
+
+func TestRegistryAgentTypesSorted(t *testing.T) {
+	r := NewRegistry()
+	_ = r.Register(Definition{AgentType: "alpha"})
+	types := r.AgentTypes()
+	for i := 1; i < len(types); i++ {
+		if types[i-1] > types[i] {
+			t.Fatalf("AgentTypes not sorted: %v", types)
+		}
+	}
+}

--- a/internal/swarm/launcher_specialist.go
+++ b/internal/swarm/launcher_specialist.go
@@ -17,15 +17,27 @@ import (
 // for that name governs the member's system prompt and tools. RunInBackground is
 // deliberately left false: the swarm provides concurrency itself (one goroutine
 // per member), so each Run executes to completion inside its goroutine.
+//
+// spec.PermissionMode (resolved + clamped by buildSpec, never above the
+// orchestrator's) is propagated so the child only runs unsafe/high autonomy when
+// the orchestrator is itself unsafe; otherwise it runs non-unsafe. An empty mode
+// is substituted with the non-unsafe "auto" default so a swarm member can never
+// fall into the historical empty-means-high path — that is the Task tool's
+// behavior, not the swarm's.
 func NewSpecialistLauncher(executor specialist.Executor) MemberLauncher {
 	return FuncLauncher{Run: func(ctx context.Context, spec MemberSpec) (MemberResult, error) {
+		permissionMode := spec.PermissionMode
+		if permissionMode == "" {
+			permissionMode = permissionModeAuto
+		}
 		res, err := executor.Run(ctx, specialist.TaskParameters{
 			Name:        spec.AgentType,
 			Prompt:      spec.Task,
 			Description: spec.AgentType + " · team " + spec.Team,
 		}, specialist.TaskRunOptions{
-			ParentModel: spec.Model,
-			Cwd:         spec.Cwd,
+			ParentModel:    spec.Model,
+			Cwd:            spec.Cwd,
+			PermissionMode: permissionMode,
 		})
 		if err != nil {
 			return MemberResult{}, err

--- a/internal/swarm/launcher_specialist.go
+++ b/internal/swarm/launcher_specialist.go
@@ -1,0 +1,35 @@
+package swarm
+
+import (
+	"context"
+
+	"github.com/Gitlawb/zero/internal/specialist"
+)
+
+// NewSpecialistLauncher adapts internal/specialist.Executor into a
+// MemberLauncher: each swarm member runs as a specialist sub-agent. This is the
+// production "direct" launch path (used when no daemon pool is wired). The
+// member inherits the orchestrator's model via spec.Model and runs in spec.Cwd,
+// so it stays under the same sandbox + policy as its parent — the swarm never
+// grants a member more authority.
+//
+// agentType maps to the specialist agent name; the specialist's own definition
+// for that name governs the member's system prompt and tools. RunInBackground is
+// deliberately left false: the swarm provides concurrency itself (one goroutine
+// per member), so each Run executes to completion inside its goroutine.
+func NewSpecialistLauncher(executor specialist.Executor) MemberLauncher {
+	return FuncLauncher{Run: func(ctx context.Context, spec MemberSpec) (MemberResult, error) {
+		res, err := executor.Run(ctx, specialist.TaskParameters{
+			Name:        spec.AgentType,
+			Prompt:      spec.Task,
+			Description: spec.AgentType + " · team " + spec.Team,
+		}, specialist.TaskRunOptions{
+			ParentModel: spec.Model,
+			Cwd:         spec.Cwd,
+		})
+		if err != nil {
+			return MemberResult{}, err
+		}
+		return MemberResult{Result: res.Result.Output, SessionID: res.SessionID}, nil
+	}}
+}

--- a/internal/swarm/lifecycle.go
+++ b/internal/swarm/lifecycle.go
@@ -1,0 +1,171 @@
+package swarm
+
+import (
+	"fmt"
+)
+
+// Spawn registers a task and launches a member of agentType to run it under the
+// given team, inheriting the orchestrator's policy. It returns the task id
+// immediately; the member runs concurrently (under the Swarm's base context, so
+// it outlives this call) and reports its result through the coordinator. If the
+// team is at its slot cap the member is queued and launches when a slot frees
+// (it stays pending in the coordinator until then).
+func (s *Swarm) Spawn(pol Policy, teamName, agentType, task, cwd string) (string, error) {
+	def, err := s.registry.Lookup(agentType)
+	if err != nil {
+		return "", err
+	}
+	team := sanitizeName(teamName)
+	id := s.nextID(agentType)
+	if _, err := s.coord.Register(id, id, team, task); err != nil {
+		return "", err
+	}
+	s.rememberCwd(id, cwd)
+	spec := s.buildSpec(pol, id, id, team, def, task, cwd)
+	s.dispatch(spec)
+	return id, nil
+}
+
+// dispatch admits a spec to its team (launching now or queuing for a slot).
+func (s *Swarm) dispatch(spec MemberSpec) {
+	t := s.team(spec.Team)
+	if t.admit(spec) {
+		s.launch(t, spec)
+	}
+	// Otherwise the spec is queued; the coordinator task stays pending until a
+	// slot frees and afterExit launches it.
+}
+
+// launch starts a member for spec and supervises it. A synchronous launch
+// failure fails the task and frees the slot.
+func (s *Swarm) launch(t *Team, spec MemberSpec) {
+	handle, err := s.launcher.Launch(s.baseCtx, spec)
+	if err != nil {
+		_ = s.coord.Fail(spec.TaskID, "launch: "+err.Error())
+		s.afterExit(t)
+		return
+	}
+	m := &Member{ID: spec.ID, AgentType: spec.AgentType, TaskID: spec.TaskID, handle: handle}
+	t.addMember(m)
+	_ = s.coord.SetStatus(spec.TaskID, StatusRunning)
+	go s.watch(t, m, spec)
+}
+
+// watch awaits a member, applies bounded relaunch on temporary failures, records
+// the terminal outcome, then frees the slot and drains the queue.
+func (s *Swarm) watch(t *Team, m *Member, spec MemberSpec) {
+	res, err := m.handle.Wait()
+	if err != nil {
+		if isRetryable(err) && m.restarts < maxMemberRestarts {
+			if nh, relErr := s.launcher.Launch(s.baseCtx, spec); relErr == nil {
+				m.restarts++
+				m.handle = nh
+				go s.watch(t, m, spec)
+				return
+			}
+			// fall through to record the original error if relaunch fails
+		}
+		_ = s.coord.Fail(m.TaskID, memberError(err))
+	} else {
+		_ = s.coord.Complete(m.TaskID, res.Result)
+	}
+	t.removeMember(m.ID)
+	s.afterExit(t)
+}
+
+// afterExit releases the just-vacated slot and launches the next queued spec, if
+// any. Each exit drains at most one queued member; that member's own exit drains
+// the next, so the queue empties one-per-slot without unbounded recursion.
+func (s *Swarm) afterExit(t *Team) {
+	next, ok := t.onExit()
+	if !ok {
+		return
+	}
+	s.launch(t, next)
+}
+
+// Handoff transfers a task to a fresh member of toAgentType, delivering a note to
+// the new member's inbox and marking the original task handed-off. It returns the
+// new task id. A handoff of an already-terminal task is rejected (fail closed).
+func (s *Swarm) Handoff(pol Policy, teamName, taskID, toAgentType, note string) (string, error) {
+	task, ok := s.coord.Get(taskID)
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrUnknownTask, taskID)
+	}
+	if task.Status.terminal() {
+		return "", fmt.Errorf("swarm: task %s already %s; cannot hand off", taskID, task.Status)
+	}
+	def, err := s.registry.Lookup(toAgentType)
+	if err != nil {
+		return "", err
+	}
+	team := sanitizeName(teamName)
+	newID := s.nextID(toAgentType)
+	handoffTask := task.Description
+	if note != "" {
+		handoffTask += "\n\nHandoff note: " + note
+	}
+	if _, err := s.coord.Register(newID, newID, team, handoffTask); err != nil {
+		return "", err
+	}
+	cwd := s.cwdFor(taskID)
+	s.rememberCwd(newID, cwd)
+	// Deliver the handoff note to the new member's inbox. A mailbox failure must
+	// not silently strand the handoff, so it is surfaced to the caller.
+	if note != "" {
+		if mbErr := s.mailbox.Send(team, newID, Message{
+			From: task.AgentID, Subject: "handoff", Body: note, Type: "handoff", Time: nowRFC3339(),
+		}); mbErr != nil {
+			return "", fmt.Errorf("swarm: deliver handoff note: %w", mbErr)
+		}
+	}
+	// Retire the original task (it has been re-delegated).
+	_ = s.coord.SetStatus(taskID, StatusHandedOff)
+	spec := s.buildSpec(pol, newID, newID, team, def, handoffTask, cwd)
+	s.dispatch(spec)
+	return newID, nil
+}
+
+// AdoptOrphans re-parents tasks in a team whose owning member is no longer live
+// (e.g. a crashed worker) onto fresh members of toAgentType, returning the
+// adopted task ids. Terminal tasks and tasks with a live owner are left alone.
+func (s *Swarm) AdoptOrphans(pol Policy, teamName, toAgentType string) ([]string, error) {
+	def, err := s.registry.Lookup(toAgentType)
+	if err != nil {
+		return nil, err
+	}
+	team := sanitizeName(teamName)
+	t := s.team(team)
+	live := t.liveAgents()
+	var adopted []string
+	for _, task := range s.coord.List() {
+		if task.Team != team || task.Status.terminal() {
+			continue
+		}
+		if _, ok := live[task.AgentID]; ok {
+			continue // still has a live member
+		}
+		newAgent := s.nextID(toAgentType)
+		if err := s.coord.Reassign(task.ID, newAgent); err != nil {
+			continue // raced to terminal; skip
+		}
+		cwd := s.cwdFor(task.ID)
+		s.rememberCwd(task.ID, cwd)
+		spec := s.buildSpec(pol, newAgent, task.ID, team, def, task.Description, cwd)
+		s.dispatch(spec)
+		adopted = append(adopted, task.ID)
+	}
+	return adopted, nil
+}
+
+// Collect returns snapshots of every task in a team, for swarm_collect/status.
+func (s *Swarm) Collect(teamName string) []Task {
+	team := sanitizeName(teamName)
+	var out []Task
+	for _, task := range s.coord.List() {
+		if task.Team == team {
+			out = append(out, task)
+		}
+	}
+	return out
+}

--- a/internal/swarm/lifecycle.go
+++ b/internal/swarm/lifecycle.go
@@ -53,6 +53,11 @@ func (s *Swarm) launch(t *Team, spec MemberSpec) {
 
 // watch awaits a member, applies bounded relaunch on temporary failures, records
 // the terminal outcome, then frees the slot and drains the queue.
+//
+// The relaunch counter is per-member (m.restarts) and the same spec is reused on
+// retry. This is sound because a Member is bound 1:1 to its spec for its whole
+// life (Member.ID == MemberSpec.ID); a retry never reuses the struct for a
+// different spec.
 func (s *Swarm) watch(t *Team, m *Member, spec MemberSpec) {
 	res, err := m.handle.Wait()
 	if err != nil {

--- a/internal/swarm/lifecycle_test.go
+++ b/internal/swarm/lifecycle_test.go
@@ -1,0 +1,328 @@
+package swarm
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// controllableLauncher records every launched spec and lets a test control each
+// member's outcome and (optionally) gate completion until a channel is closed.
+type controllableLauncher struct {
+	mu        sync.Mutex
+	specs     []MemberSpec
+	attempts  map[string]int
+	gate      chan struct{} // nil => members return immediately
+	result    func(spec MemberSpec, attempt int) (MemberResult, error)
+	launchErr error
+}
+
+func newLauncher(result func(MemberSpec, int) (MemberResult, error)) *controllableLauncher {
+	return &controllableLauncher{attempts: map[string]int{}, result: result}
+}
+
+func (l *controllableLauncher) Launch(ctx context.Context, spec MemberSpec) (MemberHandle, error) {
+	l.mu.Lock()
+	if l.launchErr != nil {
+		err := l.launchErr
+		l.mu.Unlock()
+		return nil, err
+	}
+	l.specs = append(l.specs, spec)
+	l.attempts[spec.ID]++
+	attempt := l.attempts[spec.ID]
+	gate := l.gate
+	result := l.result
+	l.mu.Unlock()
+
+	h := &funcHandle{id: spec.ID, done: make(chan struct{})}
+	go func() {
+		defer close(h.done)
+		if gate != nil {
+			select {
+			case <-gate:
+			case <-ctx.Done():
+				h.err = ctx.Err()
+				return
+			}
+		}
+		if result != nil {
+			h.res, h.err = result(spec, attempt)
+		}
+	}()
+	return h, nil
+}
+
+func (l *controllableLauncher) recorded() []MemberSpec {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]MemberSpec, len(l.specs))
+	copy(out, l.specs)
+	return out
+}
+
+func (l *controllableLauncher) attemptCount(id string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.attempts[id]
+}
+
+func newSwarmFor(t *testing.T, l MemberLauncher) *Swarm {
+	t.Helper()
+	sw, err := New(Options{BaseDir: t.TempDir(), Launcher: l, MaxTeamSize: 2})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(sw.Close)
+	return sw
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func okFor(spec MemberSpec, _ int) (MemberResult, error) {
+	return MemberResult{Result: "ok:" + spec.Task, SessionID: "sess-" + spec.ID}, nil
+}
+
+func TestSpawnCompletes(t *testing.T) {
+	l := newLauncher(okFor)
+	sw := newSwarmFor(t, l)
+	id, err := sw.Spawn(Policy{Model: "m"}, "team", "teammate", "build widget", "/work")
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	waitFor(t, "task done", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusDone
+	})
+	task, _ := sw.Coordinator().Get(id)
+	if task.Result != "ok:build widget" {
+		t.Fatalf("result = %q", task.Result)
+	}
+}
+
+func TestSpawnInheritsPolicy(t *testing.T) {
+	l := newLauncher(okFor)
+	sw := newSwarmFor(t, l)
+	_, err := sw.Spawn(Policy{Model: "orch-model", PermissionMode: "default"}, "team", "teammate", "task", "/cwd")
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	waitFor(t, "spec recorded", func() bool { return len(l.recorded()) == 1 })
+	spec := l.recorded()[0]
+	if spec.Model != "orch-model" {
+		t.Fatalf("member model = %q, want inherited orch-model", spec.Model)
+	}
+	if spec.PermissionMode != "default" {
+		t.Fatalf("member permission mode = %q, want inherited default", spec.PermissionMode)
+	}
+	if spec.Cwd != "/cwd" {
+		t.Fatalf("member cwd = %q, want /cwd", spec.Cwd)
+	}
+	if spec.SystemPrompt == "" {
+		t.Fatal("member should carry a resolved system prompt")
+	}
+}
+
+func TestConcurrencyCapAndQueueDrains(t *testing.T) {
+	gate := make(chan struct{})
+	l := newLauncher(okFor)
+	l.gate = gate
+	sw := newSwarmFor(t, l) // MaxTeamSize 2
+	pol := Policy{Model: "m"}
+	for i := 0; i < 5; i++ {
+		if _, err := sw.Spawn(pol, "team", "teammate", "task", ""); err != nil {
+			t.Fatalf("Spawn %d: %v", i, err)
+		}
+	}
+	team := sw.team("team")
+	if team.Running() != 2 || team.QueueDepth() != 3 {
+		t.Fatalf("cap not enforced: running=%d queue=%d, want 2/3", team.Running(), team.QueueDepth())
+	}
+	// Release everyone; the queue should drain one-per-slot until all are done.
+	close(gate)
+	waitFor(t, "all tasks done", func() bool { return sw.Coordinator().Summarize().Done == 5 })
+	if team.Running() != 0 || team.QueueDepth() != 0 {
+		t.Fatalf("after drain running=%d queue=%d, want 0/0", team.Running(), team.QueueDepth())
+	}
+	if got := len(l.recorded()); got != 5 {
+		t.Fatalf("launched %d members, want 5", got)
+	}
+}
+
+func TestRetryOnTemporaryError(t *testing.T) {
+	l := newLauncher(func(spec MemberSpec, attempt int) (MemberResult, error) {
+		if attempt < 3 {
+			return MemberResult{}, ErrMemberTemporary
+		}
+		return MemberResult{Result: "recovered"}, nil
+	})
+	sw := newSwarmFor(t, l)
+	id, _ := sw.Spawn(Policy{}, "team", "teammate", "task", "")
+	waitFor(t, "task recovered", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusDone
+	})
+	if got := l.attemptCount(id); got != 3 {
+		t.Fatalf("attempts = %d, want 3 (initial + 2 retries)", got)
+	}
+	task, _ := sw.Coordinator().Get(id)
+	if task.Result != "recovered" {
+		t.Fatalf("result = %q, want recovered", task.Result)
+	}
+}
+
+func TestRetryExhaustionFails(t *testing.T) {
+	l := newLauncher(func(MemberSpec, int) (MemberResult, error) {
+		return MemberResult{}, ErrMemberTemporary
+	})
+	sw := newSwarmFor(t, l)
+	id, _ := sw.Spawn(Policy{}, "team", "teammate", "task", "")
+	waitFor(t, "task failed", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusFailed
+	})
+	if got := l.attemptCount(id); got != maxMemberRestarts+1 {
+		t.Fatalf("attempts = %d, want %d", got, maxMemberRestarts+1)
+	}
+}
+
+func TestPermanentErrorNoRetry(t *testing.T) {
+	l := newLauncher(func(MemberSpec, int) (MemberResult, error) {
+		return MemberResult{}, errPlain("hard failure")
+	})
+	sw := newSwarmFor(t, l)
+	id, _ := sw.Spawn(Policy{}, "team", "teammate", "task", "")
+	waitFor(t, "task failed", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusFailed
+	})
+	if got := l.attemptCount(id); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry on permanent error)", got)
+	}
+	task, _ := sw.Coordinator().Get(id)
+	if task.Err == "" {
+		t.Fatal("failed task should record an error message")
+	}
+}
+
+func TestHandoffDeliversNoteAndRetiresOriginal(t *testing.T) {
+	gate := make(chan struct{})
+	l := newLauncher(okFor)
+	l.gate = gate // keep the original member running so it is non-terminal
+	sw := newSwarmFor(t, l)
+	pol := Policy{Model: "m"}
+	origID, _ := sw.Spawn(pol, "team", "teammate", "original task", "/w")
+	waitFor(t, "original running", func() bool {
+		task, ok := sw.Coordinator().Get(origID)
+		return ok && task.Status == StatusRunning
+	})
+
+	newID, err := sw.Handoff(pol, "team", origID, "subagent", "please continue")
+	if err != nil {
+		t.Fatalf("Handoff: %v", err)
+	}
+	// Original retired.
+	orig, _ := sw.Coordinator().Get(origID)
+	if orig.Status != StatusHandedOff {
+		t.Fatalf("original status = %v, want handed-off", orig.Status)
+	}
+	// Note delivered to the new member's inbox.
+	msgs, err := sw.Mailbox().ReadAndConsume("team", newID)
+	if err != nil {
+		t.Fatalf("read new inbox: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Body != "please continue" || msgs[0].Type != "handoff" {
+		t.Fatalf("handoff note not delivered: %+v", msgs)
+	}
+	// The new member carries the handoff note in its task and preserves cwd.
+	close(gate)
+	waitFor(t, "spec for new member", func() bool {
+		for _, s := range l.recorded() {
+			if s.ID == newID {
+				return true
+			}
+		}
+		return false
+	})
+	for _, s := range l.recorded() {
+		if s.ID == newID {
+			if s.Cwd != "/w" {
+				t.Fatalf("handoff lost cwd: %q", s.Cwd)
+			}
+		}
+	}
+	// A handoff of an already-terminal task is rejected.
+	waitFor(t, "new task done", func() bool {
+		task, ok := sw.Coordinator().Get(newID)
+		return ok && task.Status == StatusDone
+	})
+	if _, err := sw.Handoff(pol, "team", newID, "teammate", "again"); err == nil {
+		t.Fatal("handoff of a terminal task must fail")
+	}
+}
+
+func TestAdoptOrphans(t *testing.T) {
+	l := newLauncher(okFor)
+	sw := newSwarmFor(t, l)
+	// Simulate a crashed member: a running task in the coordinator whose owning
+	// agent has no live member in the team.
+	if _, err := sw.Coordinator().Register("orphan-1", "ghost", "team", "stranded work"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	_ = sw.Coordinator().SetStatus("orphan-1", StatusRunning)
+
+	adopted, err := sw.AdoptOrphans(Policy{Model: "m"}, "team", "subagent")
+	if err != nil {
+		t.Fatalf("AdoptOrphans: %v", err)
+	}
+	if len(adopted) != 1 || adopted[0] != "orphan-1" {
+		t.Fatalf("adopted = %v, want [orphan-1]", adopted)
+	}
+	// The orphan is relaunched under a fresh agent and completes.
+	waitFor(t, "orphan completed", func() bool {
+		task, ok := sw.Coordinator().Get("orphan-1")
+		return ok && task.Status == StatusDone
+	})
+	task, _ := sw.Coordinator().Get("orphan-1")
+	if task.AgentID == "ghost" {
+		t.Fatal("orphan should be reassigned to a new agent")
+	}
+	// A second adoption finds nothing (the task now has a live/owned outcome).
+	again, _ := sw.AdoptOrphans(Policy{}, "team", "subagent")
+	if len(again) != 0 {
+		t.Fatalf("second adoption = %v, want none", again)
+	}
+}
+
+func TestCollectScopesToTeam(t *testing.T) {
+	l := newLauncher(okFor)
+	sw := newSwarmFor(t, l)
+	a, _ := sw.Spawn(Policy{}, "alpha", "teammate", "ta", "")
+	_, _ = sw.Spawn(Policy{}, "beta", "teammate", "tb", "")
+	waitFor(t, "alpha done", func() bool {
+		task, ok := sw.Coordinator().Get(a)
+		return ok && task.Status == StatusDone
+	})
+	collected := sw.Collect("alpha")
+	if len(collected) != 1 || collected[0].Team != "alpha" {
+		t.Fatalf("Collect(alpha) = %+v, want one alpha task", collected)
+	}
+}
+
+func TestSpawnUnknownAgentType(t *testing.T) {
+	sw := newSwarmFor(t, newLauncher(okFor))
+	if _, err := sw.Spawn(Policy{}, "team", "does-not-exist", "task", ""); err == nil {
+		t.Fatal("Spawn with unknown agent type must error")
+	}
+}

--- a/internal/swarm/lifecycle_test.go
+++ b/internal/swarm/lifecycle_test.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -114,7 +115,7 @@ func TestSpawnCompletes(t *testing.T) {
 func TestSpawnInheritsPolicy(t *testing.T) {
 	l := newLauncher(okFor)
 	sw := newSwarmFor(t, l)
-	_, err := sw.Spawn(Policy{Model: "orch-model", PermissionMode: "default"}, "team", "teammate", "task", "/cwd")
+	_, err := sw.Spawn(Policy{Model: "orch-model", PermissionMode: permissionModeAuto}, "team", "teammate", "task", "/cwd")
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
@@ -123,8 +124,8 @@ func TestSpawnInheritsPolicy(t *testing.T) {
 	if spec.Model != "orch-model" {
 		t.Fatalf("member model = %q, want inherited orch-model", spec.Model)
 	}
-	if spec.PermissionMode != "default" {
-		t.Fatalf("member permission mode = %q, want inherited default", spec.PermissionMode)
+	if spec.PermissionMode != permissionModeAuto {
+		t.Fatalf("member permission mode = %q, want inherited auto", spec.PermissionMode)
 	}
 	if spec.Cwd != "/cwd" {
 		t.Fatalf("member cwd = %q, want /cwd", spec.Cwd)
@@ -317,6 +318,22 @@ func TestCollectScopesToTeam(t *testing.T) {
 	collected := sw.Collect("alpha")
 	if len(collected) != 1 || collected[0].Team != "alpha" {
 		t.Fatalf("Collect(alpha) = %+v, want one alpha task", collected)
+	}
+}
+
+func TestFuncLauncherRecoversPanic(t *testing.T) {
+	// A panic inside a member's Run must surface as that member's error, never
+	// escape the goroutine and crash the orchestrator.
+	l := FuncLauncher{Run: func(context.Context, MemberSpec) (MemberResult, error) {
+		panic("boom in member")
+	}}
+	h, err := l.Launch(context.Background(), MemberSpec{ID: "m1"})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	_, err = h.Wait()
+	if err == nil || !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("panic must surface as a member error, got %v", err)
 	}
 }
 

--- a/internal/swarm/lock_other.go
+++ b/internal/swarm/lock_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package swarm
+
+import (
+	"errors"
+	"os"
+)
+
+// isLockContended reports whether an O_EXCL lock-create error means the lock is
+// currently held (so the caller should retry/wait) rather than a hard failure.
+// On POSIX an existing lock surfaces only as os.ErrExist.
+func isLockContended(err error) bool {
+	return errors.Is(err, os.ErrExist)
+}

--- a/internal/swarm/lock_windows.go
+++ b/internal/swarm/lock_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package swarm
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// Windows error codes that an O_EXCL create (or a racing delete) can surface
+// when another writer holds the lock file open, instead of ERROR_FILE_EXISTS.
+// Treating them as "contended" makes the lock retry/wait rather than fail the
+// whole send/read spuriously under contention.
+const (
+	errorAccessDenied     = syscall.Errno(5)  // ERROR_ACCESS_DENIED
+	errorSharingViolation = syscall.Errno(32) // ERROR_SHARING_VIOLATION
+)
+
+// isLockContended reports whether an O_EXCL lock-create error means the lock is
+// currently held (so the caller should retry/wait) rather than a hard failure.
+// On Windows a held lock can appear as ERROR_FILE_EXISTS (mapped to os.ErrExist)
+// but also as ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION when the file is
+// concurrently open or pending deletion.
+func isLockContended(err error) bool {
+	if errors.Is(err, os.ErrExist) {
+		return true
+	}
+	return errors.Is(err, errorAccessDenied) || errors.Is(err, errorSharingViolation)
+}

--- a/internal/swarm/mailbox.go
+++ b/internal/swarm/mailbox.go
@@ -1,0 +1,320 @@
+package swarm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Mailbox is a per-agent, per-team message inbox persisted as a JSON array on
+// disk. It mirrors reference-swarm-code-agent-js/communication/mailbox.js
+// (inbox path <baseDir>/<team>/inboxes/<agent>.json, lock file, atomic write,
+// {from,type,read} message shape) and hardens it for untrusted input:
+//
+//   - inbox files and their parent dirs are owner-only (0600/0700);
+//   - every write takes an exclusive lock file (bounded retry, stale-break);
+//   - message bodies and whole inboxes are size-capped (fail closed on oversize);
+//   - team/agent names are sanitized so a name can never escape the base dir;
+//   - malformed inbox JSON is rejected rather than silently reset (fail closed).
+type Mailbox struct {
+	// BaseDir is the root under which <team>/inboxes/<agent>.json live. It must
+	// be set (NewMailbox enforces this).
+	BaseDir string
+	// MaxMessageBytes caps a single serialized message. 0 => defaultMaxMessageBytes.
+	MaxMessageBytes int
+	// MaxMessages caps the number of messages retained in one inbox. 0 =>
+	// defaultMaxMessages. Sends past the cap fail closed.
+	MaxMessages int
+	// LockTimeout bounds how long Send/MarkRead wait for the inbox lock.
+	LockTimeout time.Duration
+}
+
+const (
+	defaultMaxMessageBytes = 64 * 1024 // 64 KiB per message
+	defaultMaxMessages     = 1000      // per inbox
+	defaultLockTimeout     = 5 * time.Second
+	lockStaleAfter         = 30 * time.Second
+	inboxFileMode          = 0o600
+	inboxDirMode           = 0o700
+)
+
+// ErrMailboxFull is returned when an inbox is at MaxMessages.
+var ErrMailboxFull = errors.New("swarm: mailbox is full")
+
+// ErrMessageTooLarge is returned when a single message exceeds MaxMessageBytes.
+var ErrMessageTooLarge = errors.New("swarm: message exceeds size cap")
+
+// Message is one inbox entry. Mirrors the reference message shape
+// ({from, type, read, ...}); Time is RFC3339 and set on Send if empty.
+type Message struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Subject string `json:"subject,omitempty"`
+	Body    string `json:"body"`
+	Type    string `json:"type"`
+	Read    bool   `json:"read"`
+	Time    string `json:"time,omitempty"`
+}
+
+// NewMailbox validates baseDir and returns a Mailbox with defaults applied.
+func NewMailbox(baseDir string) (*Mailbox, error) {
+	if strings.TrimSpace(baseDir) == "" {
+		return nil, errors.New("swarm: mailbox base dir is required")
+	}
+	abs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("swarm: resolve mailbox base dir: %w", err)
+	}
+	return &Mailbox{
+		BaseDir:         abs,
+		MaxMessageBytes: defaultMaxMessageBytes,
+		MaxMessages:     defaultMaxMessages,
+		LockTimeout:     defaultLockTimeout,
+	}, nil
+}
+
+var nameUnsafe = regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
+
+// sanitizeName mirrors mailbox.js sanitizeTeamName: replace any char outside
+// [A-Za-z0-9-_] with '-', defaulting empty input to "default" and an all-unsafe
+// result to "unknown". This guarantees the name is a single safe path segment
+// (no '/', '\\', '.', '..').
+func sanitizeName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		trimmed = "default"
+	}
+	cleaned := nameUnsafe.ReplaceAllString(trimmed, "-")
+	if cleaned == "" {
+		return "unknown"
+	}
+	return cleaned
+}
+
+func (m *Mailbox) maxMessageBytes() int {
+	if m.MaxMessageBytes > 0 {
+		return m.MaxMessageBytes
+	}
+	return defaultMaxMessageBytes
+}
+
+func (m *Mailbox) maxMessages() int {
+	if m.MaxMessages > 0 {
+		return m.MaxMessages
+	}
+	return defaultMaxMessages
+}
+
+func (m *Mailbox) lockTimeout() time.Duration {
+	if m.LockTimeout > 0 {
+		return m.LockTimeout
+	}
+	return defaultLockTimeout
+}
+
+// inboxPath returns the sanitized, base-confined inbox path for (team, agent)
+// and verifies it cannot escape BaseDir (defense in depth on top of sanitize).
+func (m *Mailbox) inboxPath(team, agent string) (string, error) {
+	dir := filepath.Join(m.BaseDir, sanitizeName(team), "inboxes")
+	path := filepath.Join(dir, sanitizeName(agent)+".json")
+	// Confinement check: the resolved path must stay under BaseDir.
+	rel, err := filepath.Rel(m.BaseDir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("swarm: inbox path escapes base dir (team=%q agent=%q)", team, agent)
+	}
+	return path, nil
+}
+
+// Send appends msg to the recipient's inbox under the team, taking the inbox
+// lock. It fails closed on oversize messages or a full inbox.
+func (m *Mailbox) Send(team, recipient string, msg Message) error {
+	path, err := m.inboxPath(team, recipient)
+	if err != nil {
+		return err
+	}
+	if msg.Type == "" {
+		msg.Type = "message"
+	}
+	if msg.To == "" {
+		msg.To = sanitizeName(recipient)
+	}
+	if msg.Time == "" {
+		msg.Time = time.Now().UTC().Format(time.RFC3339)
+	}
+	encoded, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("swarm: encode message: %w", err)
+	}
+	if len(encoded) > m.maxMessageBytes() {
+		return fmt.Errorf("%w: %d > %d bytes", ErrMessageTooLarge, len(encoded), m.maxMessageBytes())
+	}
+	if err := os.MkdirAll(filepath.Dir(path), inboxDirMode); err != nil {
+		return fmt.Errorf("swarm: create inbox dir: %w", err)
+	}
+	release, err := acquireLock(path+".lock", m.lockTimeout())
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	messages, err := m.readLocked(path)
+	if err != nil {
+		return err
+	}
+	if len(messages) >= m.maxMessages() {
+		return fmt.Errorf("%w: %d messages", ErrMailboxFull, len(messages))
+	}
+	messages = append(messages, msg)
+	return atomicWriteJSON(path, messages)
+}
+
+// ReadAndConsume reads the recipient's inbox and marks every previously-unread
+// message read under one lock, returning the messages with their read flags as
+// they were BEFORE this read (so the caller can tell which were new). The inbox
+// is empty (no error) if it does not yet exist; malformed inbox JSON is reported
+// as an error (fail closed) and nothing is written.
+func (m *Mailbox) ReadAndConsume(team, recipient string) ([]Message, error) {
+	path, err := m.inboxPath(team, recipient)
+	if err != nil {
+		return nil, err
+	}
+	// The lock file lives beside the inbox; create the dir so it can be taken
+	// even on first read of a not-yet-existing inbox.
+	if err := os.MkdirAll(filepath.Dir(path), inboxDirMode); err != nil {
+		return nil, fmt.Errorf("swarm: create inbox dir: %w", err)
+	}
+	release, err := acquireLock(path+".lock", m.lockTimeout())
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	messages, err := m.readLocked(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
+		return messages, nil
+	}
+	// Snapshot pre-consume state to return, then flip unread -> read on disk.
+	snapshot := make([]Message, len(messages))
+	copy(snapshot, messages)
+	changed := false
+	for i := range messages {
+		if !messages[i].Read {
+			messages[i].Read = true
+			changed = true
+		}
+	}
+	if changed {
+		if err := atomicWriteJSON(path, messages); err != nil {
+			return nil, err
+		}
+	}
+	return snapshot, nil
+}
+
+// readLocked reads and decodes an inbox file. Callers that mutate must hold the
+// lock; pure readers may call it directly (a torn read surfaces as a decode
+// error and is retried by the caller, never silently treated as empty).
+func (m *Mailbox) readLocked(path string) ([]Message, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("swarm: read inbox: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	// Reject an oversized inbox file outright rather than decoding untrusted,
+	// unbounded JSON into memory.
+	if maxFile := m.maxMessages() * m.maxMessageBytes() * 2; len(raw) > maxFile {
+		return nil, fmt.Errorf("swarm: inbox file too large (%d bytes)", len(raw))
+	}
+	var messages []Message
+	if err := json.Unmarshal(raw, &messages); err != nil {
+		return nil, fmt.Errorf("swarm: malformed inbox %s: %w", filepath.Base(path), err)
+	}
+	for i := range messages {
+		if messages[i].Type == "" {
+			messages[i].Type = "message"
+		}
+	}
+	return messages, nil
+}
+
+// atomicWriteJSON writes data as pretty JSON to a sibling temp file (0600) then
+// renames it over path, so a reader never observes a partial write.
+func atomicWriteJSON(path string, data any) error {
+	encoded, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("swarm: encode inbox: %w", err)
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".inbox-*.tmp")
+	if err != nil {
+		return fmt.Errorf("swarm: create temp inbox: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if err := tmp.Chmod(inboxFileMode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("swarm: chmod temp inbox: %w", err)
+	}
+	if _, err := tmp.Write(encoded); err != nil {
+		tmp.Close()
+		return fmt.Errorf("swarm: write temp inbox: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("swarm: close temp inbox: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("swarm: commit inbox: %w", err)
+	}
+	return nil
+}
+
+// acquireLock takes an exclusive lock by creating lockPath with O_EXCL. It
+// retries with a short backoff until timeout, breaking a lock whose file is
+// older than lockStaleAfter (so a crashed holder cannot deadlock the swarm).
+func acquireLock(lockPath string, timeout time.Duration) (func(), error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, inboxFileMode)
+		if err == nil {
+			// Record the holder for diagnostics; ignore write errors (the lock
+			// itself is held by virtue of the exclusive create).
+			fmt.Fprintf(f, "%d %s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
+			f.Close()
+			var released bool
+			return func() {
+				if released {
+					return
+				}
+				released = true
+				os.Remove(lockPath)
+			}, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("swarm: acquire lock: %w", err)
+		}
+		// Lock held: break it if stale, otherwise wait.
+		if info, statErr := os.Stat(lockPath); statErr == nil {
+			if time.Since(info.ModTime()) > lockStaleAfter {
+				os.Remove(lockPath)
+				continue
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("swarm: timed out acquiring lock %s", filepath.Base(lockPath))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/swarm/mailbox.go
+++ b/internal/swarm/mailbox.go
@@ -13,9 +13,8 @@ import (
 )
 
 // Mailbox is a per-agent, per-team message inbox persisted as a JSON array on
-// disk. It mirrors reference-swarm-code-agent-js/communication/mailbox.js
-// (inbox path <baseDir>/<team>/inboxes/<agent>.json, lock file, atomic write,
-// {from,type,read} message shape) and hardens it for untrusted input:
+// disk at <baseDir>/<team>/inboxes/<agent>.json, written atomically under a
+// lock file. It is hardened for untrusted input:
 //
 //   - inbox files and their parent dirs are owner-only (0600/0700);
 //   - every write takes an exclusive lock file (bounded retry, stale-break);
@@ -50,8 +49,7 @@ var ErrMailboxFull = errors.New("swarm: mailbox is full")
 // ErrMessageTooLarge is returned when a single message exceeds MaxMessageBytes.
 var ErrMessageTooLarge = errors.New("swarm: message exceeds size cap")
 
-// Message is one inbox entry. Mirrors the reference message shape
-// ({from, type, read, ...}); Time is RFC3339 and set on Send if empty.
+// Message is one inbox entry. Time is RFC3339 and set on Send if empty.
 type Message struct {
 	From    string `json:"from"`
 	To      string `json:"to"`
@@ -81,10 +79,9 @@ func NewMailbox(baseDir string) (*Mailbox, error) {
 
 var nameUnsafe = regexp.MustCompile(`[^a-zA-Z0-9\-_]`)
 
-// sanitizeName mirrors mailbox.js sanitizeTeamName: replace any char outside
-// [A-Za-z0-9-_] with '-', defaulting empty input to "default" and an all-unsafe
-// result to "unknown". This guarantees the name is a single safe path segment
-// (no '/', '\\', '.', '..').
+// sanitizeName replaces any char outside [A-Za-z0-9-_] with '-', defaulting
+// empty input to "default" and an all-unsafe result to "unknown". This
+// guarantees the name is a single safe path segment (no '/', '\\', '.', '..').
 func sanitizeName(name string) string {
 	trimmed := strings.TrimSpace(name)
 	if trimmed == "" {
@@ -174,6 +171,11 @@ func (m *Mailbox) ensureInboxDir(inboxPath string) error {
 
 // Send appends msg to the recipient's inbox under the team, taking the inbox
 // lock. It fails closed on oversize messages or a full inbox.
+//
+// Each send rewrites the whole inbox (read all → append one → write all), so it
+// is O(N) in the inbox size. That is intentional given the small bounds
+// (MaxMessages × MaxMessageBytes); if those caps are raised substantially,
+// switch to an append-only log with periodic compaction.
 func (m *Mailbox) Send(team, recipient string, msg Message) error {
 	path, err := m.inboxPath(team, recipient)
 	if err != nil {
@@ -276,7 +278,10 @@ func (m *Mailbox) readLocked(path string) ([]Message, error) {
 		return nil, nil
 	}
 	// Reject an oversized inbox file outright rather than decoding untrusted,
-	// unbounded JSON into memory.
+	// unbounded JSON into memory. The bound is the cap on total message bytes
+	// (maxMessages × maxMessageBytes) doubled to allow for pretty-printed JSON
+	// (indentation, field names, brackets) overhead versus the compact bytes the
+	// per-message cap measures.
 	if maxFile := m.maxMessages() * m.maxMessageBytes() * 2; len(raw) > maxFile {
 		return nil, fmt.Errorf("swarm: inbox file too large (%d bytes)", len(raw))
 	}
@@ -357,7 +362,7 @@ func acquireLock(lockPath string, timeout time.Duration) (func(), error) {
 				}
 			}, nil
 		}
-		if !errors.Is(err, os.ErrExist) {
+		if !isLockContended(err) {
 			return nil, fmt.Errorf("swarm: acquire lock: %w", err)
 		}
 		// Lock held: break it if stale, otherwise wait. The break is conditional

--- a/internal/swarm/mailbox.go
+++ b/internal/swarm/mailbox.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -118,16 +119,57 @@ func (m *Mailbox) lockTimeout() time.Duration {
 }
 
 // inboxPath returns the sanitized, base-confined inbox path for (team, agent)
-// and verifies it cannot escape BaseDir (defense in depth on top of sanitize).
+// and verifies it cannot escape BaseDir lexically (defense in depth on top of
+// sanitize). Symlink-aware confinement happens in ensureInboxDir.
 func (m *Mailbox) inboxPath(team, agent string) (string, error) {
 	dir := filepath.Join(m.BaseDir, sanitizeName(team), "inboxes")
 	path := filepath.Join(dir, sanitizeName(agent)+".json")
-	// Confinement check: the resolved path must stay under BaseDir.
-	rel, err := filepath.Rel(m.BaseDir, path)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+	if within, err := pathWithin(m.BaseDir, path); err != nil || !within {
 		return "", fmt.Errorf("swarm: inbox path escapes base dir (team=%q agent=%q)", team, agent)
 	}
 	return path, nil
+}
+
+// pathWithin reports whether target is base or lives under it (lexically).
+func pathWithin(base, target string) (bool, error) {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false, err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// ensureInboxDir creates the inbox's parent directories owner-only, then
+// verifies — after resolving symlinks — that the real directory stays within the
+// real base dir. This defends against a symlink planted under BaseDir (e.g. a
+// pre-existing "inboxes" -> /etc) that the lexical inboxPath check cannot catch.
+// Only after confinement is confirmed are the directories tightened to 0700, so
+// a chmod can never land outside the base via a symlink.
+func (m *Mailbox) ensureInboxDir(inboxPath string) error {
+	dir := filepath.Dir(inboxPath) // <base>/<team>/inboxes
+	if err := os.MkdirAll(dir, inboxDirMode); err != nil {
+		return fmt.Errorf("swarm: create inbox dir: %w", err)
+	}
+	realBase, err := filepath.EvalSymlinks(m.BaseDir)
+	if err != nil {
+		return fmt.Errorf("swarm: resolve base dir: %w", err)
+	}
+	realDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return fmt.Errorf("swarm: resolve inbox dir: %w", err)
+	}
+	if within, err := pathWithin(realBase, realDir); err != nil || !within {
+		return fmt.Errorf("swarm: inbox dir escapes base dir via symlink")
+	}
+	// MkdirAll leaves an existing dir's permissions untouched; tighten the team
+	// and inboxes dirs to owner-only so mailbox contents are never group/world
+	// readable even if a dir pre-existed with broad perms.
+	_ = os.Chmod(dir, inboxDirMode)
+	_ = os.Chmod(filepath.Dir(dir), inboxDirMode) // <base>/<team>
+	return nil
 }
 
 // Send appends msg to the recipient's inbox under the team, taking the inbox
@@ -153,8 +195,8 @@ func (m *Mailbox) Send(team, recipient string, msg Message) error {
 	if len(encoded) > m.maxMessageBytes() {
 		return fmt.Errorf("%w: %d > %d bytes", ErrMessageTooLarge, len(encoded), m.maxMessageBytes())
 	}
-	if err := os.MkdirAll(filepath.Dir(path), inboxDirMode); err != nil {
-		return fmt.Errorf("swarm: create inbox dir: %w", err)
+	if err := m.ensureInboxDir(path); err != nil {
+		return err
 	}
 	release, err := acquireLock(path+".lock", m.lockTimeout())
 	if err != nil {
@@ -185,8 +227,8 @@ func (m *Mailbox) ReadAndConsume(team, recipient string) ([]Message, error) {
 	}
 	// The lock file lives beside the inbox; create the dir so it can be taken
 	// even on first read of a not-yet-existing inbox.
-	if err := os.MkdirAll(filepath.Dir(path), inboxDirMode); err != nil {
-		return nil, fmt.Errorf("swarm: create inbox dir: %w", err)
+	if err := m.ensureInboxDir(path); err != nil {
+		return nil, err
 	}
 	release, err := acquireLock(path+".lock", m.lockTimeout())
 	if err != nil {
@@ -281,17 +323,28 @@ func atomicWriteJSON(path string, data any) error {
 	return nil
 }
 
+// lockSeq makes each lock token unique within the process even when two
+// goroutines acquire in the same nanosecond.
+var lockSeq atomic.Uint64
+
 // acquireLock takes an exclusive lock by creating lockPath with O_EXCL. It
 // retries with a short backoff until timeout, breaking a lock whose file is
 // older than lockStaleAfter (so a crashed holder cannot deadlock the swarm).
+//
+// Each holder writes a unique token into the lock file and release is
+// OWNERSHIP-AWARE: it removes the lock only if it still holds our token. After a
+// stale-break another writer may legitimately own the lock; unconditionally
+// removing it would let a third writer in and create split-brain writers that
+// can corrupt or drop mailbox updates.
 func acquireLock(lockPath string, timeout time.Duration) (func(), error) {
+	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), time.Now().UnixNano(), lockSeq.Add(1))
 	deadline := time.Now().Add(timeout)
 	for {
 		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, inboxFileMode)
 		if err == nil {
-			// Record the holder for diagnostics; ignore write errors (the lock
-			// itself is held by virtue of the exclusive create).
-			fmt.Fprintf(f, "%d %s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
+			// Record our ownership token; the exclusive create already holds the
+			// lock, so a write error only weakens diagnostics, not safety.
+			_, _ = f.WriteString(token)
 			f.Close()
 			var released bool
 			return func() {
@@ -299,18 +352,23 @@ func acquireLock(lockPath string, timeout time.Duration) (func(), error) {
 					return
 				}
 				released = true
-				os.Remove(lockPath)
+				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
+					os.Remove(lockPath)
+				}
 			}, nil
 		}
 		if !errors.Is(err, os.ErrExist) {
 			return nil, fmt.Errorf("swarm: acquire lock: %w", err)
 		}
-		// Lock held: break it if stale, otherwise wait.
-		if info, statErr := os.Stat(lockPath); statErr == nil {
-			if time.Since(info.ModTime()) > lockStaleAfter {
+		// Lock held: break it if stale, otherwise wait. The break is conditional
+		// on the file's content being unchanged since we observed it, so we do not
+		// delete a lock another writer rotated in between.
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > lockStaleAfter {
+			stale, _ := os.ReadFile(lockPath)
+			if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == string(stale) {
 				os.Remove(lockPath)
-				continue
 			}
+			continue
 		}
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("swarm: timed out acquiring lock %s", filepath.Base(lockPath))

--- a/internal/swarm/mailbox_test.go
+++ b/internal/swarm/mailbox_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -245,16 +246,26 @@ func TestMailboxLockReleaseIsOwnershipAware(t *testing.T) {
 
 func TestMailboxConcurrentSends(t *testing.T) {
 	mb := newTestMailbox(t)
-	const n = 30
+	// High fan-out + a generous lock timeout so heavy contention is exercised
+	// (and a lock regression — e.g. a Windows sharing-violation treated as fatal —
+	// would surface as lost/failed messages here rather than flaking).
+	mb.LockTimeout = 10 * time.Second
+	const n = 200
 	var wg sync.WaitGroup
+	var failures atomic.Int32
 	for i := 0; i < n; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = mb.Send("team", "bob", Message{From: "a", Body: "concurrent"})
+			if err := mb.Send("team", "bob", Message{From: "a", Body: "concurrent"}); err != nil {
+				failures.Add(1)
+			}
 		}()
 	}
 	wg.Wait()
+	if f := failures.Load(); f != 0 {
+		t.Fatalf("%d concurrent Sends failed (lock contention not handled)", f)
+	}
 	msgs, err := mb.ReadAndConsume("team", "bob")
 	if err != nil {
 		t.Fatalf("ReadAndConsume: %v", err)

--- a/internal/swarm/mailbox_test.go
+++ b/internal/swarm/mailbox_test.go
@@ -1,0 +1,182 @@
+package swarm
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newTestMailbox(t *testing.T) *Mailbox {
+	t.Helper()
+	mb, err := NewMailbox(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewMailbox: %v", err)
+	}
+	return mb
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"":           "default",
+		"   ":        "default",
+		"team-1_ok":  "team-1_ok",
+		"../../etc":  "------etc",
+		"a/b\\c":     "a-b-c",
+		"team name!": "team-name-",
+		"!!!":        "---",
+		"plain":      "plain",
+	}
+	for in, want := range cases {
+		if got := sanitizeName(in); got != want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMailboxSendAndConsume(t *testing.T) {
+	mb := newTestMailbox(t)
+	if err := mb.Send("team", "bob", Message{From: "alice", Body: "hello"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := mb.Send("team", "bob", Message{From: "alice", Body: "again"}); err != nil {
+		t.Fatalf("Send 2: %v", err)
+	}
+	msgs, err := mb.ReadAndConsume("team", "bob")
+	if err != nil {
+		t.Fatalf("ReadAndConsume: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2", len(msgs))
+	}
+	// First read returns them as unread (pre-consume snapshot), with defaults set.
+	if msgs[0].Read || msgs[0].Type != "message" || msgs[0].To != "bob" || msgs[0].Time == "" {
+		t.Fatalf("message defaults wrong: %+v", msgs[0])
+	}
+	// Second read shows them already consumed (read).
+	msgs2, err := mb.ReadAndConsume("team", "bob")
+	if err != nil {
+		t.Fatalf("ReadAndConsume 2: %v", err)
+	}
+	for _, m := range msgs2 {
+		if !m.Read {
+			t.Fatalf("message should be read after consume: %+v", m)
+		}
+	}
+}
+
+func TestMailboxReadMissingIsEmpty(t *testing.T) {
+	mb := newTestMailbox(t)
+	msgs, err := mb.ReadAndConsume("team", "nobody")
+	if err != nil {
+		t.Fatalf("ReadAndConsume missing: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("missing inbox should be empty, got %d", len(msgs))
+	}
+}
+
+func TestMailboxOversizeMessageRejected(t *testing.T) {
+	mb := newTestMailbox(t)
+	mb.MaxMessageBytes = 64
+	err := mb.Send("team", "bob", Message{From: "a", Body: strings.Repeat("x", 1000)})
+	if !errors.Is(err, ErrMessageTooLarge) {
+		t.Fatalf("oversize Send err = %v, want ErrMessageTooLarge", err)
+	}
+	// Nothing should have been written.
+	msgs, _ := mb.ReadAndConsume("team", "bob")
+	if len(msgs) != 0 {
+		t.Fatalf("oversize Send must not persist, got %d messages", len(msgs))
+	}
+}
+
+func TestMailboxFullRejected(t *testing.T) {
+	mb := newTestMailbox(t)
+	mb.MaxMessages = 2
+	for i := 0; i < 2; i++ {
+		if err := mb.Send("team", "bob", Message{From: "a", Body: "ok"}); err != nil {
+			t.Fatalf("Send %d: %v", i, err)
+		}
+	}
+	if err := mb.Send("team", "bob", Message{From: "a", Body: "overflow"}); !errors.Is(err, ErrMailboxFull) {
+		t.Fatalf("full Send err = %v, want ErrMailboxFull", err)
+	}
+}
+
+func TestMailboxMalformedFailsClosed(t *testing.T) {
+	mb := newTestMailbox(t)
+	// Write a valid message so the inbox path exists, then corrupt the file.
+	if err := mb.Send("team", "bob", Message{From: "a", Body: "ok"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	path, err := mb.inboxPath("team", "bob")
+	if err != nil {
+		t.Fatalf("inboxPath: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("corrupt inbox: %v", err)
+	}
+	if _, err := mb.ReadAndConsume("team", "bob"); err == nil {
+		t.Fatal("malformed inbox must fail closed (error), not be treated as empty")
+	}
+	// A subsequent Send also fails closed rather than clobbering unknown data.
+	if err := mb.Send("team", "bob", Message{From: "a", Body: "x"}); err == nil {
+		t.Fatal("Send into a malformed inbox must fail closed")
+	}
+}
+
+func TestMailboxPathConfinement(t *testing.T) {
+	mb := newTestMailbox(t)
+	// A traversal-style name is sanitized into a single safe segment; the inbox
+	// stays under BaseDir.
+	path, err := mb.inboxPath("../../evil", "../escape")
+	if err != nil {
+		t.Fatalf("inboxPath: %v", err)
+	}
+	rel, err := filepath.Rel(mb.BaseDir, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Fatalf("inbox path escaped base dir: base=%q path=%q rel=%q", mb.BaseDir, path, rel)
+	}
+}
+
+func TestMailboxFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes")
+	}
+	mb := newTestMailbox(t)
+	if err := mb.Send("team", "bob", Message{From: "a", Body: "ok"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	path, _ := mb.inboxPath("team", "bob")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("inbox file mode = %o, want 600", perm)
+	}
+}
+
+func TestMailboxConcurrentSends(t *testing.T) {
+	mb := newTestMailbox(t)
+	const n = 30
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = mb.Send("team", "bob", Message{From: "a", Body: "concurrent"})
+		}()
+	}
+	wg.Wait()
+	msgs, err := mb.ReadAndConsume("team", "bob")
+	if err != nil {
+		t.Fatalf("ReadAndConsume: %v", err)
+	}
+	if len(msgs) != n {
+		t.Fatalf("concurrent sends lost messages: got %d, want %d", len(msgs), n)
+	}
+}

--- a/internal/swarm/mailbox_test.go
+++ b/internal/swarm/mailbox_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func newTestMailbox(t *testing.T) *Mailbox {
@@ -158,6 +159,88 @@ func TestMailboxFileMode(t *testing.T) {
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Fatalf("inbox file mode = %o, want 600", perm)
 	}
+}
+
+func TestMailboxTightensDirPerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes")
+	}
+	base := t.TempDir()
+	// Pre-create the team + inboxes dirs with broad perms; ensureInboxDir must
+	// tighten them to 0700 despite MkdirAll leaving existing dirs untouched.
+	broad := filepath.Join(base, "team", "inboxes")
+	if err := os.MkdirAll(broad, 0o755); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+	mb, err := NewMailbox(base)
+	if err != nil {
+		t.Fatalf("NewMailbox: %v", err)
+	}
+	if err := mb.Send("team", "bob", Message{From: "a", Body: "ok"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	for _, dir := range []string{broad, filepath.Join(base, "team")} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s: %v", dir, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o700 {
+			t.Fatalf("dir %s mode = %o, want 700", dir, perm)
+		}
+	}
+}
+
+func TestMailboxRejectsSymlinkedInboxDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ")
+	}
+	base := t.TempDir()
+	outside := t.TempDir() // a dir OUTSIDE base
+	// Plant a symlink: <base>/team/inboxes -> <outside>. A lexical check passes,
+	// but the symlink-aware confinement must reject the write.
+	if err := os.MkdirAll(filepath.Join(base, "team"), 0o700); err != nil {
+		t.Fatalf("mkdir team: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(base, "team", "inboxes")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	mb, err := NewMailbox(base)
+	if err != nil {
+		t.Fatalf("NewMailbox: %v", err)
+	}
+	if err := mb.Send("team", "bob", Message{From: "a", Body: "escape"}); err == nil {
+		t.Fatal("Send into a symlinked-out inbox dir must fail closed")
+	}
+	// And nothing was written outside the base.
+	if entries, _ := os.ReadDir(outside); len(entries) != 0 {
+		t.Fatalf("write escaped base via symlink: %d entries in %s", len(entries), outside)
+	}
+}
+
+func TestMailboxLockReleaseIsOwnershipAware(t *testing.T) {
+	mb := newTestMailbox(t)
+	path, _ := mb.inboxPath("team", "bob")
+	if err := mb.ensureInboxDir(path); err != nil {
+		t.Fatalf("ensureInboxDir: %v", err)
+	}
+	lockPath := path + ".lock"
+	// Writer A acquires the lock.
+	releaseA, err := acquireLock(lockPath, time.Second)
+	if err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	// Simulate a stale-break + takeover by writer B: overwrite the lock content
+	// with B's token (as a fresh acquire after a break would).
+	if err := os.WriteFile(lockPath, []byte("writer-B-token"), 0o600); err != nil {
+		t.Fatalf("simulate B takeover: %v", err)
+	}
+	// A's release must NOT delete B's lock (ownership-aware).
+	releaseA()
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("A's release deleted B's lock (split-brain): %v", err)
+	}
+	// B's own release removes it.
+	os.Remove(lockPath)
 }
 
 func TestMailboxConcurrentSends(t *testing.T) {

--- a/internal/swarm/member.go
+++ b/internal/swarm/member.go
@@ -1,0 +1,88 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+)
+
+// MemberSpec is the fully-resolved instruction to launch one member. The swarm
+// builds it from a Definition + task; a MemberLauncher turns it into a running
+// agent. PermissionMode/Model carry the orchestrator's policy so the launcher
+// can never grant a member more authority than its parent.
+type MemberSpec struct {
+	// ID identifies the running member (its agent id). For a freshly spawned
+	// member this equals TaskID; after an orphan adoption a new agent (new ID)
+	// takes over the original TaskID.
+	ID             string
+	TaskID         string
+	AgentType      string
+	Team           string
+	Task           string
+	Cwd            string
+	Model          string // resolved (never the "inherit" sentinel)
+	PermissionMode string
+	SystemPrompt   string
+}
+
+// MemberResult is what a finished member returns.
+type MemberResult struct {
+	Result    string
+	SessionID string
+}
+
+// MemberHandle is a running member. Wait blocks until the member exits and
+// returns its result or error; ID identifies the member.
+type MemberHandle interface {
+	ID() string
+	Wait() (MemberResult, error)
+}
+
+// MemberLauncher turns a MemberSpec into a running member. Production wires two
+// implementations behind this seam — one over internal/specialist.Executor
+// (direct) and one over internal/daemon.Pool (when a daemon is running) — while
+// tests inject a fake. Keeping the seam here means the swarm core has no
+// compile-time dependency on either heavy subsystem.
+type MemberLauncher interface {
+	Launch(ctx context.Context, spec MemberSpec) (MemberHandle, error)
+}
+
+// RunFunc executes a member to completion. Both production launchers and tests
+// supply one; FuncLauncher adapts it to the MemberLauncher interface by running
+// it in a goroutine.
+type RunFunc func(ctx context.Context, spec MemberSpec) (MemberResult, error)
+
+// FuncLauncher is the single MemberLauncher implementation: it runs a RunFunc in
+// a goroutine and exposes a handle. Production builds one whose RunFunc calls
+// specialist.Executor.Run (or submits to daemon.Pool); tests build one whose
+// RunFunc is a stub.
+type FuncLauncher struct {
+	Run RunFunc
+}
+
+// Launch starts the RunFunc for spec and returns a handle to await it.
+func (l FuncLauncher) Launch(ctx context.Context, spec MemberSpec) (MemberHandle, error) {
+	if l.Run == nil {
+		return nil, errors.New("swarm: FuncLauncher requires a Run func")
+	}
+	h := &funcHandle{id: spec.ID, done: make(chan struct{})}
+	go func() {
+		defer close(h.done)
+		h.res, h.err = l.Run(ctx, spec)
+	}()
+	return h, nil
+}
+
+type funcHandle struct {
+	id   string
+	done chan struct{}
+	res  MemberResult
+	err  error
+}
+
+func (h *funcHandle) ID() string { return h.id }
+
+// Wait blocks until the member exits and returns its result/error.
+func (h *funcHandle) Wait() (MemberResult, error) {
+	<-h.done
+	return h.res, h.err
+}

--- a/internal/swarm/member.go
+++ b/internal/swarm/member.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 // MemberSpec is the fully-resolved instruction to launch one member. The swarm
@@ -67,6 +68,14 @@ func (l FuncLauncher) Launch(ctx context.Context, spec MemberSpec) (MemberHandle
 	h := &funcHandle{id: spec.ID, done: make(chan struct{})}
 	go func() {
 		defer close(h.done)
+		// A panic in a member's Run must fail only that member, never crash the
+		// orchestrator process. Recover and surface it as the member's error.
+		defer func() {
+			if r := recover(); r != nil {
+				h.res = MemberResult{}
+				h.err = fmt.Errorf("swarm: member %s panicked: %v", spec.ID, r)
+			}
+		}()
 		h.res, h.err = l.Run(ctx, spec)
 	}()
 	return h, nil

--- a/internal/swarm/team.go
+++ b/internal/swarm/team.go
@@ -220,12 +220,15 @@ const (
 
 // permissionRank orders permission modes from least to most permissive so the
 // swarm can clamp a member to no more than its parent. Unknown/empty modes rank
-// as the strictest (0) so they never accidentally widen access.
+// as the strictest (0) so they never accidentally widen access. spec-draft
+// (which scopes a child to spec tooling) ranks below ask: it never grants more
+// authority than prompting-for-everything, so a spec-draft parent clamps members
+// hardest among the known modes.
 func permissionRank(mode string) int {
 	switch strings.TrimSpace(mode) {
-	case permissionModeAsk:
-		return 1
 	case permissionModeSpecDraft:
+		return 1
+	case permissionModeAsk:
 		return 2
 	case permissionModeAuto:
 		return 3

--- a/internal/swarm/team.go
+++ b/internal/swarm/team.go
@@ -208,18 +208,28 @@ func resolvePermissionMode(pol Policy, def Definition) string {
 	return def.PermissionMode
 }
 
+// Runtime permission modes (mirror internal/agent.PermissionMode without
+// importing it, to avoid an import cycle). These are the actual values that flow
+// through tools.RunOptions.PermissionMode — NOT the TUI display names.
+const (
+	permissionModeAsk       = "ask"        // prompts for every tool (most restrictive)
+	permissionModeSpecDraft = "spec-draft" // spec-drafting only
+	permissionModeAuto      = "auto"       // auto-approve low-risk
+	permissionModeUnsafe    = "unsafe"     // approve everything (most permissive)
+)
+
 // permissionRank orders permission modes from least to most permissive so the
-// swarm can clamp a member to no more than its parent. Unknown modes rank as the
-// strictest (0) so they never accidentally widen access.
+// swarm can clamp a member to no more than its parent. Unknown/empty modes rank
+// as the strictest (0) so they never accidentally widen access.
 func permissionRank(mode string) int {
 	switch strings.TrimSpace(mode) {
-	case "plan":
+	case permissionModeAsk:
 		return 1
-	case "default":
+	case permissionModeSpecDraft:
 		return 2
-	case "acceptEdits":
+	case permissionModeAuto:
 		return 3
-	case "bypassPermissions":
+	case permissionModeUnsafe:
 		return 4
 	default:
 		return 0

--- a/internal/swarm/team.go
+++ b/internal/swarm/team.go
@@ -1,0 +1,347 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// defaultMaxTeamSize bounds concurrently-running members per team. Spawns past
+// the cap queue and launch as slots free up (mirrors daemon.Pool's bounded,
+// on-demand worker model).
+const defaultMaxTeamSize = 8
+
+// maxMemberRestarts bounds automatic relaunches of a member that exits with a
+// temporary error, mirroring daemon.Pool's bounded backoff retries.
+const maxMemberRestarts = 2
+
+// Options configures a Swarm.
+type Options struct {
+	// BaseDir is the mailbox root (required).
+	BaseDir string
+	// Launcher turns specs into running members (required).
+	Launcher MemberLauncher
+	// Registry is the agent roster; nil => a fresh built-in registry.
+	Registry *Registry
+	// Coordinator tracks tasks; nil => a fresh coordinator.
+	Coordinator *Coordinator
+	// MaxTeamSize caps concurrent members per team; 0 => defaultMaxTeamSize.
+	MaxTeamSize int
+	// Definitions are user-defined agents to add to the roster (extending or
+	// overriding the built-ins). Empty agent types are rejected.
+	Definitions []Definition
+	// Context is the parent context for all members; members outlive the
+	// per-call tool context (a spawn returns immediately). nil => Background.
+	// Close cancels the derived context, stopping every member.
+	Context context.Context
+}
+
+// Policy is the orchestrator's live model + permission mode at spawn time. Every
+// member inherits it: a member never runs on a different model than requested,
+// nor with a more permissive mode than its parent. It is passed per call (not
+// stored on the Swarm) because the orchestrator's model/mode can change
+// mid-session (e.g. an escalate-model).
+type Policy struct {
+	Model          string
+	PermissionMode string
+}
+
+// Swarm is the façade the swarm tools call. It owns the agent roster, the task
+// coordinator, the mailbox, and the live teams, and enforces that every member
+// inherits the orchestrator's model + permission mode.
+type Swarm struct {
+	registry    *Registry
+	coord       *Coordinator
+	mailbox     *Mailbox
+	launcher    MemberLauncher
+	maxTeamSize int
+
+	baseCtx context.Context
+	cancel  context.CancelFunc
+
+	mu      sync.Mutex
+	teams   map[string]*Team
+	taskCwd map[string]string // taskID -> cwd, for handoff/adoption relaunch
+	idSeq   atomic.Uint64
+}
+
+// Team is a named set of concurrently-running members with a bounded slot count
+// and a FIFO queue for overflow spawns.
+type Team struct {
+	Name string
+
+	mu      sync.Mutex
+	members map[string]*Member
+	queue   []MemberSpec
+	running int
+	maxSize int
+}
+
+// Member is one running agent within a team.
+type Member struct {
+	ID        string
+	AgentType string
+	TaskID    string
+	handle    MemberHandle
+	restarts  int
+}
+
+// New validates options and returns a Swarm.
+func New(opts Options) (*Swarm, error) {
+	if opts.Launcher == nil {
+		return nil, errors.New("swarm: a MemberLauncher is required")
+	}
+	mb, err := NewMailbox(opts.BaseDir)
+	if err != nil {
+		return nil, err
+	}
+	registry := opts.Registry
+	if registry == nil {
+		registry = NewRegistry()
+	}
+	for _, def := range opts.Definitions {
+		if err := registry.Register(def); err != nil {
+			return nil, err
+		}
+	}
+	coord := opts.Coordinator
+	if coord == nil {
+		coord = NewCoordinator()
+	}
+	maxTeam := opts.MaxTeamSize
+	if maxTeam <= 0 {
+		maxTeam = defaultMaxTeamSize
+	}
+	parent := opts.Context
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &Swarm{
+		registry:    registry,
+		coord:       coord,
+		mailbox:     mb,
+		launcher:    opts.Launcher,
+		maxTeamSize: maxTeam,
+		baseCtx:     ctx,
+		cancel:      cancel,
+		teams:       map[string]*Team{},
+		taskCwd:     map[string]string{},
+	}, nil
+}
+
+// Close cancels every running member's context and releases resources. It is
+// safe to call more than once.
+func (s *Swarm) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+// rememberCwd records a task's working dir so a handoff/adoption relaunch keeps it.
+func (s *Swarm) rememberCwd(taskID, cwd string) {
+	s.mu.Lock()
+	s.taskCwd[taskID] = cwd
+	s.mu.Unlock()
+}
+
+// cwdFor returns a task's recorded working dir ("" if none).
+func (s *Swarm) cwdFor(taskID string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.taskCwd[taskID]
+}
+
+// Registry exposes the roster (for tool listing / user-defined registration).
+func (s *Swarm) Registry() *Registry { return s.registry }
+
+// Coordinator exposes the task registry (for status/collect).
+func (s *Swarm) Coordinator() *Coordinator { return s.coord }
+
+// Mailbox exposes the message store (for send/inbox tools).
+func (s *Swarm) Mailbox() *Mailbox { return s.mailbox }
+
+// team returns the named team, creating it on first use.
+func (s *Swarm) team(name string) *Team {
+	key := sanitizeName(name)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.teams[key]
+	if !ok {
+		t = &Team{Name: key, members: map[string]*Member{}, maxSize: s.maxTeamSize}
+		s.teams[key] = t
+	}
+	return t
+}
+
+// nextID mints a stable, unique member/task id within the process.
+func (s *Swarm) nextID(agentType string) string {
+	n := s.idSeq.Add(1)
+	return sanitizeName(agentType) + "-" + strconv.FormatUint(n, 10)
+}
+
+// resolveModel folds the "inherit" sentinel into the orchestrator's model so a
+// launched member never silently runs on a different model.
+func resolveModel(pol Policy, def Definition) string {
+	if def.Model == "" || def.Model == modelInherit {
+		return pol.Model
+	}
+	return def.Model
+}
+
+// resolvePermissionMode never widens authority: a member uses its definition's
+// mode only if it is not more permissive than the orchestrator's. Unknown modes
+// fall back to the orchestrator's mode (fail closed).
+func resolvePermissionMode(pol Policy, def Definition) string {
+	if def.PermissionMode == "" {
+		return pol.PermissionMode
+	}
+	if permissionRank(def.PermissionMode) > permissionRank(pol.PermissionMode) {
+		// Definition asks for more than the parent has — clamp to the parent.
+		return pol.PermissionMode
+	}
+	return def.PermissionMode
+}
+
+// permissionRank orders permission modes from least to most permissive so the
+// swarm can clamp a member to no more than its parent. Unknown modes rank as the
+// strictest (0) so they never accidentally widen access.
+func permissionRank(mode string) int {
+	switch strings.TrimSpace(mode) {
+	case "plan":
+		return 1
+	case "default":
+		return 2
+	case "acceptEdits":
+		return 3
+	case "bypassPermissions":
+		return 4
+	default:
+		return 0
+	}
+}
+
+// admit reserves a running slot for a spec, or queues it. It reports whether the
+// caller should launch immediately.
+func (t *Team) admit(spec MemberSpec) (launchNow bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.running < t.maxSize {
+		t.running++
+		return true
+	}
+	t.queue = append(t.queue, spec)
+	return false
+}
+
+// onExit releases a slot after a member exits and returns the next queued spec
+// (already re-reserving its slot) if one is waiting.
+func (t *Team) onExit() (MemberSpec, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.running > 0 {
+		t.running--
+	}
+	if len(t.queue) > 0 && t.running < t.maxSize {
+		next := t.queue[0]
+		t.queue = t.queue[1:]
+		t.running++
+		return next, true
+	}
+	return MemberSpec{}, false
+}
+
+func (t *Team) addMember(m *Member) {
+	t.mu.Lock()
+	t.members[m.ID] = m
+	t.mu.Unlock()
+}
+
+func (t *Team) removeMember(id string) {
+	t.mu.Lock()
+	delete(t.members, id)
+	t.mu.Unlock()
+}
+
+// liveAgents returns the set of agent ids that currently have a live member, so
+// orphan detection can tell which tasks have lost their owner.
+func (t *Team) liveAgents() map[string]struct{} {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	live := make(map[string]struct{}, len(t.members))
+	for _, m := range t.members {
+		live[m.ID] = struct{}{}
+	}
+	return live
+}
+
+// QueueDepth reports how many specs are waiting for a slot (status/tests).
+func (t *Team) QueueDepth() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.queue)
+}
+
+// Running reports how many members are currently occupying a slot.
+func (t *Team) Running() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.running
+}
+
+// ErrMemberTemporary marks a member failure as transient (worker died, transient
+// I/O) so the swarm relaunches it within maxMemberRestarts, mirroring daemon
+// EXIT_TEMPFAIL semantics. Permanent failures are not retried.
+var ErrMemberTemporary = errors.New("swarm: temporary member failure")
+
+// isRetryable reports whether a member error should trigger a bounded relaunch.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrMemberTemporary) {
+		return true
+	}
+	var t interface{ Temporary() bool }
+	if errors.As(err, &t) {
+		return t.Temporary()
+	}
+	return false
+}
+
+// buildSpec resolves a definition + task into a launchable spec under the
+// orchestrator's policy. memberID identifies the running agent; taskID is the
+// coordinator task it serves (equal for a fresh spawn, distinct after adoption).
+func (s *Swarm) buildSpec(pol Policy, memberID, taskID, team string, def Definition, task, cwd string) MemberSpec {
+	prompt := ""
+	if def.SystemPrompt != nil {
+		prompt = def.SystemPrompt(PromptContext{Team: team, Task: task})
+	}
+	return MemberSpec{
+		ID:             memberID,
+		TaskID:         taskID,
+		AgentType:      def.AgentType,
+		Team:           team,
+		Task:           task,
+		Cwd:            cwd,
+		Model:          resolveModel(pol, def),
+		PermissionMode: resolvePermissionMode(pol, def),
+		SystemPrompt:   prompt,
+	}
+}
+
+// memberError wraps a member's failure for coordinator recording.
+func memberError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", err)
+}
+
+// nowRFC3339 is a tiny helper for mailbox handoff notes.
+func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/internal/swarm/team_test.go
+++ b/internal/swarm/team_test.go
@@ -16,25 +16,22 @@ func TestResolveModelInherit(t *testing.T) {
 }
 
 func TestResolvePermissionModeNeverWidens(t *testing.T) {
-	parent := Policy{PermissionMode: "default"}
-	// A definition asking for MORE than the parent is clamped down.
-	if got := resolvePermissionMode(parent, Definition{PermissionMode: "bypassPermissions"}); got != "default" {
-		t.Fatalf("clamp = %q, want default (never widen)", got)
+	parent := Policy{PermissionMode: permissionModeAuto} // "auto"
+	// A definition asking for MORE than the parent (unsafe > auto) is clamped down.
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: permissionModeUnsafe}); got != permissionModeAuto {
+		t.Fatalf("clamp = %q, want auto (never widen)", got)
 	}
-	// A definition asking for LESS keeps its stricter mode.
-	if got := resolvePermissionMode(parent, Definition{PermissionMode: "plan"}); got != "plan" {
-		t.Fatalf("stricter = %q, want plan", got)
+	// A definition asking for LESS keeps its stricter mode (ask < auto).
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: permissionModeAsk}); got != permissionModeAsk {
+		t.Fatalf("stricter = %q, want ask", got)
 	}
 	// Empty inherits the parent.
-	if got := resolvePermissionMode(parent, Definition{PermissionMode: ""}); got != "default" {
-		t.Fatalf("empty = %q, want default", got)
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: ""}); got != permissionModeAuto {
+		t.Fatalf("empty = %q, want auto", got)
 	}
-	// Unknown mode ranks strictest, so it can never widen.
-	if got := resolvePermissionMode(parent, Definition{PermissionMode: "weird"}); got != "weird" {
-		t.Fatalf("unknown = %q, want weird (treated strictest, not widened)", got)
-	}
-	if got := resolvePermissionMode(Policy{PermissionMode: "weird"}, Definition{PermissionMode: "default"}); got != "weird" {
-		t.Fatalf("default vs unknown-parent = %q, want clamp to weird", got)
+	// An unsafe parent still honors a stricter definition (auto < unsafe).
+	if got := resolvePermissionMode(Policy{PermissionMode: permissionModeUnsafe}, Definition{PermissionMode: permissionModeAuto}); got != permissionModeAuto {
+		t.Fatalf("unsafe parent + auto def = %q, want auto (stricter honored)", got)
 	}
 }
 

--- a/internal/swarm/team_test.go
+++ b/internal/swarm/team_test.go
@@ -1,0 +1,94 @@
+package swarm
+
+import "testing"
+
+func TestResolveModelInherit(t *testing.T) {
+	pol := Policy{Model: "orchestrator-model"}
+	if got := resolveModel(pol, Definition{Model: modelInherit}); got != "orchestrator-model" {
+		t.Fatalf("inherit model = %q, want orchestrator-model", got)
+	}
+	if got := resolveModel(pol, Definition{Model: ""}); got != "orchestrator-model" {
+		t.Fatalf("empty model = %q, want orchestrator-model", got)
+	}
+	if got := resolveModel(pol, Definition{Model: "explicit"}); got != "explicit" {
+		t.Fatalf("explicit model = %q, want explicit", got)
+	}
+}
+
+func TestResolvePermissionModeNeverWidens(t *testing.T) {
+	parent := Policy{PermissionMode: "default"}
+	// A definition asking for MORE than the parent is clamped down.
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: "bypassPermissions"}); got != "default" {
+		t.Fatalf("clamp = %q, want default (never widen)", got)
+	}
+	// A definition asking for LESS keeps its stricter mode.
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: "plan"}); got != "plan" {
+		t.Fatalf("stricter = %q, want plan", got)
+	}
+	// Empty inherits the parent.
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: ""}); got != "default" {
+		t.Fatalf("empty = %q, want default", got)
+	}
+	// Unknown mode ranks strictest, so it can never widen.
+	if got := resolvePermissionMode(parent, Definition{PermissionMode: "weird"}); got != "weird" {
+		t.Fatalf("unknown = %q, want weird (treated strictest, not widened)", got)
+	}
+	if got := resolvePermissionMode(Policy{PermissionMode: "weird"}, Definition{PermissionMode: "default"}); got != "weird" {
+		t.Fatalf("default vs unknown-parent = %q, want clamp to weird", got)
+	}
+}
+
+func TestTeamAdmitAndQueue(t *testing.T) {
+	tm := &Team{Name: "t", members: map[string]*Member{}, maxSize: 2}
+	if !tm.admit(MemberSpec{ID: "a"}) || !tm.admit(MemberSpec{ID: "b"}) {
+		t.Fatal("first two admits should launch now")
+	}
+	if tm.admit(MemberSpec{ID: "c"}) {
+		t.Fatal("third admit should queue, not launch")
+	}
+	if tm.Running() != 2 || tm.QueueDepth() != 1 {
+		t.Fatalf("running=%d queue=%d, want 2/1", tm.Running(), tm.QueueDepth())
+	}
+	// One exit drains the single queued spec (re-reserving its slot).
+	next, ok := tm.onExit()
+	if !ok || next.ID != "c" {
+		t.Fatalf("onExit = %+v ok=%v, want spec c", next, ok)
+	}
+	if tm.Running() != 2 || tm.QueueDepth() != 0 {
+		t.Fatalf("after drain running=%d queue=%d, want 2/0", tm.Running(), tm.QueueDepth())
+	}
+	// Two more exits empty the team (no queue left).
+	if _, ok := tm.onExit(); ok {
+		t.Fatal("onExit with empty queue should not return a spec")
+	}
+	if _, ok := tm.onExit(); ok {
+		t.Fatal("onExit with empty queue should not return a spec")
+	}
+	if tm.Running() != 0 {
+		t.Fatalf("running = %d, want 0", tm.Running())
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	if isRetryable(nil) {
+		t.Fatal("nil is not retryable")
+	}
+	if !isRetryable(ErrMemberTemporary) {
+		t.Fatal("ErrMemberTemporary must be retryable")
+	}
+	if isRetryable(errPlain("permanent")) {
+		t.Fatal("a plain error is not retryable")
+	}
+	if !isRetryable(tempErr{}) {
+		t.Fatal("an error with Temporary()==true must be retryable")
+	}
+}
+
+type errPlain string
+
+func (e errPlain) Error() string { return string(e) }
+
+type tempErr struct{}
+
+func (tempErr) Error() string   { return "temp" }
+func (tempErr) Temporary() bool { return true }

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -295,7 +295,7 @@ func (t *handoffTool) Safety() tools.Safety {
 	return tools.Safety{
 		SideEffect:      tools.SideEffectShell,
 		Permission:      tools.PermissionPrompt,
-		Reason:          "Spawns a replacement swarm member to take over a task.",
+		Reason:          "Spawns a replacement swarm member to take over a task, and writes the handoff note to the new member's inbox.",
 		AdvertiseInAuto: true,
 	}
 }

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -393,9 +393,10 @@ func renderTasks(coord *Coordinator, tasks []Task, team string) string {
 func collapse(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.Join(strings.Fields(s), " ")
-	const max = 200
-	if len(s) > max {
-		return s[:max] + "…"
+	const max = 200 // runes, not bytes — never slice mid-character
+	runes := []rune(s)
+	if len(runes) > max {
+		return string(runes[:max]) + "…"
 	}
 	return s
 }

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -1,0 +1,401 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// Tool names. All swarm tools are additive and only act when invoked; the
+// existing single "Task" tool is unchanged.
+const (
+	SpawnToolName   = "swarm_spawn"
+	SendToolName    = "swarm_send"
+	InboxToolName   = "swarm_inbox"
+	StatusToolName  = "swarm_status"
+	HandoffToolName = "swarm_handoff"
+	CollectToolName = "swarm_collect"
+)
+
+// RegisterTools registers the six swarm tools backed by one shared Swarm. The
+// caller owns the Swarm's lifetime (call Swarm.Close on shutdown).
+func RegisterTools(registry *tools.Registry, sw *Swarm) {
+	registry.Register(&spawnTool{sw: sw})
+	registry.Register(&sendTool{sw: sw})
+	registry.Register(&inboxTool{sw: sw})
+	registry.Register(&statusTool{sw: sw})
+	registry.Register(&handoffTool{sw: sw})
+	registry.Register(&collectTool{sw: sw})
+}
+
+// policyFrom derives the member-inheritance policy from the live tool options so
+// each spawned member runs on the orchestrator's current model + permission mode.
+func policyFrom(options tools.RunOptions) Policy {
+	return Policy{Model: options.Model, PermissionMode: options.PermissionMode}
+}
+
+func swarmStr(args map[string]any, key string) string {
+	if args == nil {
+		return ""
+	}
+	if v, ok := args[key]; ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+func okResult(output, kind, summary string) tools.Result {
+	return tools.Result{Status: tools.StatusOK, Output: output, Display: tools.Display{Kind: kind, Summary: summary}}
+}
+
+func errResult(format string, a ...any) tools.Result {
+	return tools.Result{Status: tools.StatusError, Output: "Error: " + fmt.Sprintf(format, a...)}
+}
+
+// ---- swarm_spawn -----------------------------------------------------------
+
+type spawnTool struct{ sw *Swarm }
+
+func (t *spawnTool) Name() string { return SpawnToolName }
+func (t *spawnTool) Description() string {
+	return "Spawn a swarm member of the given agent type to run a task concurrently under a team. Returns a task id immediately; results are reported through swarm_status/swarm_collect."
+}
+func (t *spawnTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"agent_type": {Type: "string", Description: "Roster agent type to spawn (e.g. teammate, subagent)."},
+			"task":       {Type: "string", Description: "The focused task/briefing for the member."},
+			"team":       {Type: "string", Description: "Team to spawn into. Defaults to \"default\"."},
+		},
+		Required:             []string{"agent_type", "task"},
+		AdditionalProperties: false,
+	}
+}
+func (t *spawnTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectShell,
+		Permission:      tools.PermissionPrompt,
+		Reason:          "Spawns a swarm member sub-agent under the orchestrator's sandbox and policy.",
+		AdvertiseInAuto: true,
+	}
+}
+func (t *spawnTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return t.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+func (t *spawnTool) RunWithOptions(_ context.Context, args map[string]any, options tools.RunOptions) tools.Result {
+	agentType := swarmStr(args, "agent_type")
+	task := swarmStr(args, "task")
+	team := swarmStr(args, "team")
+	if agentType == "" {
+		return errResult("swarm_spawn requires agent_type")
+	}
+	if task == "" {
+		return errResult("swarm_spawn requires task")
+	}
+	id, err := t.sw.Spawn(policyFrom(options), team, agentType, task, options.Cwd)
+	if err != nil {
+		if errors.Is(err, ErrUnknownAgentType) {
+			return errResult("%v; available agent types: %s", err, strings.Join(t.sw.Registry().AgentTypes(), ", "))
+		}
+		return errResult("%v", err)
+	}
+	out := fmt.Sprintf("Spawned %s as task %s on team %s.", agentType, id, displayTeam(team))
+	res := okResult(out, "swarm", out)
+	res.Meta = map[string]string{"task_id": id, "team": sanitizeName(team), "agent_type": agentType}
+	return res
+}
+
+// ---- swarm_send ------------------------------------------------------------
+
+type sendTool struct{ sw *Swarm }
+
+func (t *sendTool) Name() string { return SendToolName }
+func (t *sendTool) Description() string {
+	return "Send a message to another swarm member's inbox on a team."
+}
+func (t *sendTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"to":      {Type: "string", Description: "Recipient member/agent id."},
+			"body":    {Type: "string", Description: "Message body."},
+			"subject": {Type: "string", Description: "Optional subject."},
+			"from":    {Type: "string", Description: "Optional sender id (the orchestrator by default)."},
+			"team":    {Type: "string", Description: "Team to send within. Defaults to \"default\"."},
+		},
+		Required:             []string{"to", "body"},
+		AdditionalProperties: false,
+	}
+}
+func (t *sendTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectWrite,
+		Permission:      tools.PermissionAllow,
+		Reason:          "Writes a message to an owner-only swarm inbox file.",
+		AdvertiseInAuto: true,
+	}
+}
+func (t *sendTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return t.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+func (t *sendTool) RunWithOptions(_ context.Context, args map[string]any, _ tools.RunOptions) tools.Result {
+	to := swarmStr(args, "to")
+	body := swarmStr(args, "body")
+	if to == "" {
+		return errResult("swarm_send requires to")
+	}
+	if body == "" {
+		return errResult("swarm_send requires body")
+	}
+	team := swarmStr(args, "team")
+	from := swarmStr(args, "from")
+	if from == "" {
+		from = "orchestrator"
+	}
+	msg := Message{From: from, Subject: swarmStr(args, "subject"), Body: body}
+	if err := t.sw.Mailbox().Send(team, to, msg); err != nil {
+		return errResult("%v", err)
+	}
+	out := fmt.Sprintf("Delivered message to %s on team %s.", sanitizeName(to), displayTeam(team))
+	return okResult(out, "swarm", out)
+}
+
+// ---- swarm_inbox -----------------------------------------------------------
+
+type inboxTool struct{ sw *Swarm }
+
+func (t *inboxTool) Name() string { return InboxToolName }
+func (t *inboxTool) Description() string {
+	return "Read a member's inbox on a team. Returns all messages and marks previously-unread ones as read."
+}
+func (t *inboxTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"agent": {Type: "string", Description: "Member/agent id whose inbox to read."},
+			"team":  {Type: "string", Description: "Team the inbox belongs to. Defaults to \"default\"."},
+		},
+		Required:             []string{"agent"},
+		AdditionalProperties: false,
+	}
+}
+func (t *inboxTool) Safety() tools.Safety {
+	return tools.Safety{
+		// Reading an inbox marks messages read (a benign metadata flip in an
+		// owner-only file), so it is classified as a write but auto-allowed.
+		SideEffect:      tools.SideEffectWrite,
+		Permission:      tools.PermissionAllow,
+		Reason:          "Reads and marks-read an owner-only swarm inbox file.",
+		AdvertiseInAuto: true,
+	}
+}
+func (t *inboxTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return t.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+func (t *inboxTool) RunWithOptions(_ context.Context, args map[string]any, _ tools.RunOptions) tools.Result {
+	agent := swarmStr(args, "agent")
+	if agent == "" {
+		return errResult("swarm_inbox requires agent")
+	}
+	team := swarmStr(args, "team")
+	messages, err := t.sw.Mailbox().ReadAndConsume(team, agent)
+	if err != nil {
+		return errResult("%v", err)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Inbox for %s on team %s: %d message(s)\n", sanitizeName(agent), displayTeam(team), len(messages))
+	for i, msg := range messages {
+		state := "read"
+		if !msg.Read {
+			state = "unread"
+		}
+		subject := msg.Subject
+		if subject != "" {
+			subject = " [" + subject + "]"
+		}
+		fmt.Fprintf(&b, "  [%d] (%s) from %s%s: %s\n", i, state, msg.From, subject, msg.Body)
+	}
+	out := strings.TrimRight(b.String(), "\n")
+	return okResult(out, "swarm", fmt.Sprintf("%d message(s)", len(messages)))
+}
+
+// ---- swarm_status ----------------------------------------------------------
+
+type statusTool struct{ sw *Swarm }
+
+func (t *statusTool) Name() string { return StatusToolName }
+func (t *statusTool) Description() string {
+	return "Report swarm task status: counts by state and per-task lines. Optionally scoped to one team."
+}
+func (t *statusTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"team": {Type: "string", Description: "Optional team to scope to."},
+		},
+		AdditionalProperties: false,
+	}
+}
+func (t *statusTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectRead,
+		Permission:      tools.PermissionAllow,
+		Reason:          "Reports in-memory swarm task status.",
+		AdvertiseInAuto: true,
+	}
+}
+func (t *statusTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return t.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+func (t *statusTool) RunWithOptions(_ context.Context, args map[string]any, _ tools.RunOptions) tools.Result {
+	team := swarmStr(args, "team")
+	tasks := t.sw.Coordinator().List()
+	if team != "" {
+		want := sanitizeName(team)
+		filtered := tasks[:0:0]
+		for _, task := range tasks {
+			if task.Team == want {
+				filtered = append(filtered, task)
+			}
+		}
+		tasks = filtered
+	}
+	return okResult(renderTasks(t.sw.Coordinator(), tasks, team), "swarm", fmt.Sprintf("%d task(s)", len(tasks)))
+}
+
+// ---- swarm_handoff ---------------------------------------------------------
+
+type handoffTool struct{ sw *Swarm }
+
+func (t *handoffTool) Name() string { return HandoffToolName }
+func (t *handoffTool) Description() string {
+	return "Hand a task off to a fresh member of another agent type, delivering an optional note to the new member's inbox."
+}
+func (t *handoffTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"task_id":       {Type: "string", Description: "Task id to hand off."},
+			"to_agent_type": {Type: "string", Description: "Roster agent type to take over."},
+			"note":          {Type: "string", Description: "Optional handoff note delivered to the new member's inbox."},
+			"team":          {Type: "string", Description: "Team the task belongs to. Defaults to \"default\"."},
+		},
+		Required:             []string{"task_id", "to_agent_type"},
+		AdditionalProperties: false,
+	}
+}
+func (t *handoffTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectShell,
+		Permission:      tools.PermissionPrompt,
+		Reason:          "Spawns a replacement swarm member to take over a task.",
+		AdvertiseInAuto: true,
+	}
+}
+func (t *handoffTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return t.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+func (t *handoffTool) RunWithOptions(_ context.Context, args map[string]any, options tools.RunOptions) tools.Result {
+	taskID := swarmStr(args, "task_id")
+	to := swarmStr(args, "to_agent_type")
+	if taskID == "" {
+		return errResult("swarm_handoff requires task_id")
+	}
+	if to == "" {
+		return errResult("swarm_handoff requires to_agent_type")
+	}
+	team := swarmStr(args, "team")
+	newID, err := t.sw.Handoff(policyFrom(options), team, taskID, to, swarmStr(args, "note"))
+	if err != nil {
+		return errResult("%v", err)
+	}
+	out := fmt.Sprintf("Handed off task %s to %s as task %s on team %s.", taskID, to, newID, displayTeam(team))
+	res := okResult(out, "swarm", out)
+	res.Meta = map[string]string{"task_id": newID, "previous_task_id": taskID}
+	return res
+}
+
+// ---- swarm_collect ---------------------------------------------------------
+
+type collectTool struct{ sw *Swarm }
+
+func (t *collectTool) Name() string { return CollectToolName }
+func (t *collectTool) Description() string {
+	return "Collect the results of a team's tasks (status, result, and any error per task)."
+}
+func (t *collectTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type: "object",
+		Properties: map[string]tools.PropertySchema{
+			"team": {Type: "string", Description: "Team to collect from. Defaults to \"default\"."},
+		},
+		AdditionalProperties: false,
+	}
+}
+func (t *collectTool) Safety() tools.Safety {
+	return tools.Safety{
+		SideEffect:      tools.SideEffectRead,
+		Permission:      tools.PermissionAllow,
+		Reason:          "Reports in-memory swarm task results.",
+		AdvertiseInAuto: true,
+	}
+}
+func (t *collectTool) Run(ctx context.Context, args map[string]any) tools.Result {
+	return t.RunWithOptions(ctx, args, tools.RunOptions{})
+}
+func (t *collectTool) RunWithOptions(_ context.Context, args map[string]any, _ tools.RunOptions) tools.Result {
+	team := swarmStr(args, "team")
+	tasks := t.sw.Collect(team)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Results for team %s: %d task(s)\n", displayTeam(team), len(tasks))
+	for _, task := range tasks {
+		line := fmt.Sprintf("  - %s [%s] %s", task.ID, task.Status, task.Description)
+		if task.Result != "" {
+			line += "\n      result: " + collapse(task.Result)
+		}
+		if task.Err != "" {
+			line += "\n      error: " + collapse(task.Err)
+		}
+		b.WriteString(line + "\n")
+	}
+	out := strings.TrimRight(b.String(), "\n")
+	return okResult(out, "swarm", fmt.Sprintf("%d task(s)", len(tasks)))
+}
+
+// renderTasks formats a status summary + per-task lines, colored per agent.
+func renderTasks(coord *Coordinator, tasks []Task, team string) string {
+	s := coord.Summarize()
+	var b strings.Builder
+	scope := "all teams"
+	if strings.TrimSpace(team) != "" {
+		scope = "team " + sanitizeName(team)
+	}
+	fmt.Fprintf(&b, "Swarm status (%s): %d task(s) — %d running, %d pending, %d done, %d failed, %d handed-off\n",
+		scope, len(tasks), s.Running, s.Pending, s.Done, s.Failed, s.HandedOff)
+	sorted := make([]Task, len(tasks))
+	copy(sorted, tasks)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+	for _, task := range sorted {
+		fmt.Fprintf(&b, "  - %s [%s] (%s) %s\n", task.ID, task.Status, coord.Color(task.AgentID), collapse(task.Description))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// collapse trims a possibly-multiline string to a single compact line for
+// status/collect output.
+func collapse(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.Join(strings.Fields(s), " ")
+	const max = 200
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -1,0 +1,190 @@
+package swarm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func newToolSwarm(t *testing.T, l MemberLauncher) (*tools.Registry, *Swarm) {
+	t.Helper()
+	sw := newSwarmFor(t, l)
+	reg := tools.NewRegistry()
+	RegisterTools(reg, sw)
+	return reg, sw
+}
+
+func TestRegisterToolsRegistersAll(t *testing.T) {
+	reg, _ := newToolSwarm(t, newLauncher(okFor))
+	for _, name := range []string{SpawnToolName, SendToolName, InboxToolName, StatusToolName, HandoffToolName, CollectToolName} {
+		if _, ok := reg.Get(name); !ok {
+			t.Fatalf("tool %q not registered", name)
+		}
+	}
+}
+
+func TestSpawnToolThroughRegistry(t *testing.T) {
+	l := newLauncher(okFor)
+	reg, sw := newToolSwarm(t, l)
+	res := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate",
+		"task":       "do the thing",
+		"team":       "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m1", Cwd: "/work"})
+	if res.Status != tools.StatusOK {
+		t.Fatalf("spawn result status = %v, output=%q", res.Status, res.Output)
+	}
+	id := res.Meta["task_id"]
+	if id == "" {
+		t.Fatal("spawn must return a task_id in Meta")
+	}
+	waitFor(t, "spec recorded", func() bool { return len(l.recorded()) == 1 })
+	spec := l.recorded()[0]
+	if spec.Model != "m1" || spec.Cwd != "/work" {
+		t.Fatalf("policy/cwd not threaded into member: model=%q cwd=%q", spec.Model, spec.Cwd)
+	}
+	if _, ok := sw.Coordinator().Get(id); !ok {
+		t.Fatalf("task %q not tracked by coordinator", id)
+	}
+}
+
+func TestSpawnToolRequiresPermission(t *testing.T) {
+	reg, _ := newToolSwarm(t, newLauncher(okFor))
+	// swarm_spawn is a prompt tool: without a grant the registry refuses it.
+	res := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate", "task": "x",
+	}, tools.RunOptions{})
+	if res.Status != tools.StatusError || !strings.Contains(res.Output, "Permission required") {
+		t.Fatalf("ungranted spawn should be refused, got status=%v output=%q", res.Status, res.Output)
+	}
+}
+
+func TestSpawnToolValidation(t *testing.T) {
+	_, sw := newToolSwarm(t, newLauncher(okFor))
+	tool := &spawnTool{sw: sw}
+	if res := tool.Run(context.Background(), map[string]any{"task": "x"}); res.Status != tools.StatusError {
+		t.Fatal("missing agent_type must error")
+	}
+	if res := tool.Run(context.Background(), map[string]any{"agent_type": "teammate"}); res.Status != tools.StatusError {
+		t.Fatal("missing task must error")
+	}
+}
+
+func TestSendAndInboxTools(t *testing.T) {
+	reg, _ := newToolSwarm(t, newLauncher(okFor))
+	send := reg.RunWithOptions(context.Background(), SendToolName, map[string]any{
+		"to": "bob", "body": "ping", "team": "alpha", "subject": "hi",
+	}, tools.RunOptions{})
+	if send.Status != tools.StatusOK {
+		t.Fatalf("send status = %v output=%q", send.Status, send.Output)
+	}
+	inbox := reg.RunWithOptions(context.Background(), InboxToolName, map[string]any{
+		"agent": "bob", "team": "alpha",
+	}, tools.RunOptions{})
+	if inbox.Status != tools.StatusOK {
+		t.Fatalf("inbox status = %v", inbox.Status)
+	}
+	if !strings.Contains(inbox.Output, "ping") || !strings.Contains(inbox.Output, "[hi]") {
+		t.Fatalf("inbox output missing message: %q", inbox.Output)
+	}
+	if !strings.Contains(inbox.Output, "unread") {
+		t.Fatalf("first inbox read should show unread: %q", inbox.Output)
+	}
+}
+
+func TestSendToolValidation(t *testing.T) {
+	_, sw := newToolSwarm(t, newLauncher(okFor))
+	tool := &sendTool{sw: sw}
+	if res := tool.Run(context.Background(), map[string]any{"body": "x"}); res.Status != tools.StatusError {
+		t.Fatal("missing to must error")
+	}
+	if res := tool.Run(context.Background(), map[string]any{"to": "bob"}); res.Status != tools.StatusError {
+		t.Fatal("missing body must error")
+	}
+}
+
+func TestStatusAndCollectTools(t *testing.T) {
+	reg, sw := newToolSwarm(t, newLauncher(okFor))
+	spawn := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate", "task": "compute", "team": "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m"})
+	id := spawn.Meta["task_id"]
+	waitFor(t, "task done", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusDone
+	})
+	status := reg.RunWithOptions(context.Background(), StatusToolName, map[string]any{"team": "alpha"}, tools.RunOptions{})
+	if status.Status != tools.StatusOK || !strings.Contains(status.Output, id) {
+		t.Fatalf("status output missing task: %q", status.Output)
+	}
+	collect := reg.RunWithOptions(context.Background(), CollectToolName, map[string]any{"team": "alpha"}, tools.RunOptions{})
+	if collect.Status != tools.StatusOK || !strings.Contains(collect.Output, "ok:compute") {
+		t.Fatalf("collect output missing result: %q", collect.Output)
+	}
+}
+
+func TestSpawnToolUnknownTypeListsAvailable(t *testing.T) {
+	_, sw := newToolSwarm(t, newLauncher(okFor))
+	tool := &spawnTool{sw: sw}
+	res := tool.RunWithOptions(context.Background(), map[string]any{
+		"agent_type": "ghost", "task": "x",
+	}, tools.RunOptions{})
+	if res.Status != tools.StatusError || !strings.Contains(res.Output, "available agent types") {
+		t.Fatalf("unknown type should list available agents, got %q", res.Output)
+	}
+	if !strings.Contains(res.Output, "teammate") {
+		t.Fatalf("available agents should include builtins, got %q", res.Output)
+	}
+}
+
+func TestNewWithUserDefinitions(t *testing.T) {
+	used := false
+	sw, err := New(Options{
+		BaseDir:  t.TempDir(),
+		Launcher: newLauncher(okFor),
+		Definitions: []Definition{{
+			AgentType:    "researcher",
+			SystemPrompt: func(PromptContext) string { used = true; return "research" },
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New with definitions: %v", err)
+	}
+	t.Cleanup(sw.Close)
+	if _, err := sw.Spawn(Policy{Model: "m"}, "team", "researcher", "find things", ""); err != nil {
+		t.Fatalf("Spawn user-defined agent: %v", err)
+	}
+	waitFor(t, "researcher used", func() bool { return used })
+
+	// A bad definition makes New fail closed.
+	if _, err := New(Options{BaseDir: t.TempDir(), Launcher: newLauncher(okFor), Definitions: []Definition{{AgentType: "  "}}}); err == nil {
+		t.Fatal("New with a blank-agentType definition must error")
+	}
+}
+
+func TestHandoffToolThroughRegistry(t *testing.T) {
+	gate := make(chan struct{})
+	l := newLauncher(okFor)
+	l.gate = gate
+	reg, sw := newToolSwarm(t, l)
+	spawn := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate", "task": "long", "team": "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m"})
+	origID := spawn.Meta["task_id"]
+	waitFor(t, "running", func() bool {
+		task, ok := sw.Coordinator().Get(origID)
+		return ok && task.Status == StatusRunning
+	})
+	res := reg.RunWithOptions(context.Background(), HandoffToolName, map[string]any{
+		"task_id": origID, "to_agent_type": "subagent", "note": "carry on", "team": "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m"})
+	if res.Status != tools.StatusOK {
+		t.Fatalf("handoff status = %v output=%q", res.Status, res.Output)
+	}
+	if res.Meta["previous_task_id"] != origID || res.Meta["task_id"] == "" {
+		t.Fatalf("handoff meta wrong: %+v", res.Meta)
+	}
+	close(gate)
+}

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -4,9 +4,21 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/tools"
 )
+
+func TestCollapseRuneSafeTruncation(t *testing.T) {
+	// 300 multi-byte runes: truncation must not split a rune (no invalid UTF-8).
+	got := collapse(strings.Repeat("🚀", 300))
+	if !utf8.ValidString(got) {
+		t.Fatalf("collapse produced invalid UTF-8: %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n != 201 { // 200 runes + ellipsis
+		t.Fatalf("collapse rune count = %d, want 201", n)
+	}
+}
 
 func newToolSwarm(t *testing.T, l MemberLauncher) (*tools.Registry, *Swarm) {
 	t.Helper()


### PR DESCRIPTION
## Summary

Adds **`internal/swarm`** — a multi-agent SWARM layered on top of zero's single sub-agent (`internal/specialist`). An orchestrator can spawn and coordinate **multiple** specialist members concurrently under a named team, have them communicate via per-agent mailboxes, hand work off, and adopt orphaned tasks.

Everything is **additive and opt-in**: the existing single `Task` tool is unchanged; the swarm tools only act when invoked.

## What's included

| Piece | File | Notes |
|---|---|---|
| Agent roster | `definition.go` | `Registry` + `Definition`; built-in `teammate`/`subagent`, plus user-defined agents via `Options.Definitions` |
| Mailbox | `mailbox.go` | per-team/per-agent JSON inbox, owner-only **0600**, file-locked (stale-break), **size-capped**, **path-confined**, malformed **fails closed** |
| Coordinator | `coordinator.go` | in-memory task registry with terminal-state guards + stable per-agent colors |
| Team roster | `team.go` | **bounded** concurrent members per team with a FIFO overflow **queue** (drains one-per-slot) |
| Lifecycle | `lifecycle.go` | spawn / handoff / orphan-adoption; **bounded relaunch** on temporary failures |
| Launcher seam | `member.go`, `launcher_specialist.go` | `MemberLauncher` interface (+`FuncLauncher`); production adapter over `specialist.Executor` |
| Tools | `tools.go` | `swarm_spawn`, `swarm_send`, `swarm_inbox`, `swarm_status`, `swarm_handoff`, `swarm_collect` |
| Wiring | `internal/cli/app.go`, `exec.go` | registers swarm tools alongside specialist tools; swarm lifetime paired with the specialist runtime |

## Security / fail-closed

- **Policy inheritance, never widened.** Each member is launched through `specialist.Executor` and inherits the orchestrator's **model + permission mode**; a definition that asks for a *more* permissive mode is clamped down to the parent's, and unknown modes rank strictest. Members run under the same sandbox/policy as the parent — the swarm never grants a member more authority.
- **Mailboxes are owner-only (0600)**, written atomically under an exclusive lock; names are sanitized to a single safe path segment and the resolved path is verified to stay under the base dir.
- **Caps + fail-closed**: per-message and per-inbox size caps reject oversize input; a full inbox is rejected; malformed inbox JSON surfaces an error rather than being silently reset; the team slot cap queues overflow rather than over-spawning.
- Mailbox state lives under the workspace (`.zero/swarm`) so its writes fall within the sandbox write rules.
- Members run under the Swarm's **base context** (not the per-call tool context) so a background member is not cancelled the instant `swarm_spawn` returns; `Swarm.Close` cancels them all on shutdown.

## Tests

Per-layer coverage incl. `-race`: roster lookup/override, mailbox (sanitize, oversize, full, malformed-fails-closed, path confinement, 0600 mode, concurrent sends), coordinator (terminal guards, reassign, color stability, concurrent registers), team (admit/queue, permission clamp, model resolve), lifecycle (completion, **concurrency cap + queue drain**, **retry/exhaustion**, permanent-error no-retry, **handoff**, **orphan-adoption**), and all six tools through the registry dispatch (registration, policy/cwd threading, validation, permission gating).

## Gates

`gofmt` clean · `go vet` clean · host + `GOOS=linux` build clean · full `go test ./...` pass · `staticcheck` no new findings · `govulncheck` 0 (code affected by 0) · `deadcode` no new entries vs `main`.

## Deferred (follow-ups)

- **Scheduling** (cron/wakeup/kairos) — out of scope for this PR.
- **Daemon-pool-backed members** — the launcher seam supports it; bridging the daemon worker protocol to specialist result capture is its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory multi-agent swarm with task coordination, status tracking, reassignment, handoff, orphan adoption, and team-scoped collection.
  * Introduced a persistent mailbox with safe path confinement, size/cap limits, and locked JSON inbox delivery/consumption.
  * Added swarm CLI tools to spawn tasks, send/read inbox messages, check status, hand off work, and collect results.
* **Bug Fixes**
  * Specialist execution autonomy now follows the parent permission mode.
  * Member panics are recovered and returned as task errors.
* **Tests**
  * Added unit and integration coverage for coordinator, lifecycle, tools, mailbox, and concurrency/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->