### PR TITLE
chore: clear staticcheck nits surfaced by the v16 audit

### DIFF
--- a/internal/agenteval/score.go
+++ b/internal/agenteval/score.go
@@ -125,9 +125,7 @@ func Score(suite Suite, input ScoreInput) Report {
 	if len(task.RequiredTraceEvents) > 0 {
 		report.Results = append(report.Results, scoreTraceEvents(task.RequiredTraceEvents, input))
 	}
-	for _, result := range unknownCommandResults(input.CommandResults, seenCommands, input) {
-		report.Results = append(report.Results, result)
-	}
+	report.Results = append(report.Results, unknownCommandResults(input.CommandResults, seenCommands, input)...)
 	report.finishSummary()
 	return report
 }

--- a/internal/cli/agent_eval.go
+++ b/internal/cli/agent_eval.go
@@ -515,9 +515,7 @@ func agentEvalReportFromBenchmark(suite agenteval.Suite, report agenteval.Benchm
 		if task.Agent.Truncated {
 			converted.Truncated = true
 		}
-		for _, failure := range agentEvalFailuresFromTaskReport(task) {
-			converted.Failures = append(converted.Failures, failure)
-		}
+		converted.Failures = append(converted.Failures, agentEvalFailuresFromTaskReport(task)...)
 	}
 	return converted
 }

--- a/internal/provideronboarding/localruntime_test.go
+++ b/internal/provideronboarding/localruntime_test.go
@@ -62,7 +62,7 @@ func TestDetectLocalRuntimesReportsReachableRuntime(t *testing.T) {
 	if !detected[0].Reachable {
 		t.Fatalf("runtime should be reachable: %#v", detected[0])
 	}
-	if detected[0].Models == nil || len(detected[0].Models) == 0 || detected[0].Models[0] != "llama3.1" {
+	if len(detected[0].Models) == 0 || detected[0].Models[0] != "llama3.1" {
 		t.Fatalf("expected discovered model list, got %#v", detected[0].Models)
 	}
 }

--- a/internal/tools/web_fetch.go
+++ b/internal/tools/web_fetch.go
@@ -302,7 +302,7 @@ func webFetchRedirectPolicy(previous func(*http.Request, []*http.Request) error,
 			return fmt.Errorf("too many redirects: maximum is %d", webFetchRedirectLimit)
 		}
 		if err := validateParsedWebFetchURL(request.Context(), request.URL, resolver, gate); err != nil {
-			return fmt.Errorf("Unsafe redirect URL: %w", err)
+			return fmt.Errorf("unsafe redirect URL: %w", err)
 		}
 		if previous != nil {
 			return previous(request, via)

--- a/internal/tools/web_fetch_test.go
+++ b/internal/tools/web_fetch_test.go
@@ -285,7 +285,7 @@ func TestWebFetchToolRejectsUnsafeRedirects(t *testing.T) {
 			if result.Status != StatusError {
 				t.Fatalf("expected redirect safety error, got %s: %s", result.Status, result.Output)
 			}
-			if !strings.Contains(result.Output, "Unsafe redirect URL") {
+			if !strings.Contains(result.Output, "unsafe redirect URL") {
 				t.Fatalf("expected unsafe redirect message, got %q", result.Output)
 			}
 		})

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -276,7 +276,7 @@ func parseSearchResults(body []byte) ([]searchResult, error) {
 	convert := func(raw []rawResult) []searchResult {
 		out := make([]searchResult, 0, len(raw))
 		for _, item := range raw {
-			out = append(out, searchResult{Title: item.Title, URL: item.URL, Snippet: item.Snippet})
+			out = append(out, searchResult(item))
 		}
 		return out
 	}

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -635,7 +635,7 @@ func TestProviderWizardPersistsPastedKeyToUserConfig(t *testing.T) {
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(model)
 	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	next = updated.(model)
+	_ = updated.(model)
 
 	if captured.APIKey != secret {
 		t.Fatalf("captured APIKey = %q, want pasted secret", captured.APIKey)


### PR DESCRIPTION
## Summary

Clears the six minor `staticcheck` findings the v16 audit surfaced (§5.1 / §7 #4). All are cosmetic — **no behavior change** — and each is independently verified by `staticcheck`.

| Code | File | Fix |
|---|---|---|
| S1011 ×2 | `agenteval/score.go`, `cli/agent_eval.go` | `for … { append(x, e) }` → `append(x, src...)` |
| S1016 | `tools/web_search.go` | `searchResult{Title:…, URL:…, Snippet:…}` → `searchResult(item)` (identical fields) |
| ST1005 | `tools/web_fetch.go` | lowercase the `"unsafe redirect URL"` error string (+ test assertion) |
| SA4006 | `tui/provider_wizard_test.go` | drop the dead final `next =` assignment (keep the type assertion) |
| S1009 | `provideronboarding/localruntime_test.go` | remove redundant `== nil` before `len()` |

## Verification

- `staticcheck ./...`: **32 → 26** (the remaining 26 are the two separate audit buckets: 15 `U1000` unused + 11 `SA1019` deprecated Bubble Tea mouse API — each its own follow-up).
- `gofmt -l` clean · `go vet` clean · `go build ./...` · **`go test ./...` (full) pass**.
- `deadcode` unchanged (100) · `govulncheck` 0.

Scoped deliberately to the cosmetic nits; the dead-code prune, the deprecated mouse-API migration, the unwired Slack sink, and the scoped-network wiring are tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error message formatting for consistency across the application.

* **Refactor**
  * Streamlined internal code patterns and structures for improved maintainability.

* **Tests**
  * Updated test assertions to reflect formatting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->