### PR TITLE
web_search: add domains allowlist + score field

### DIFF
--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -29,6 +29,9 @@ type searchResult struct {
 	Title   string
 	URL     string
 	Snippet string
+	// Score is an optional provider-supplied relevance signal in the [0, 1]
+	// range. Zero (the zero value) is treated as "absent" by the renderer.
+	Score float64
 }
 
 // searchBackend discovers URLs for a query. It is an interface so any hosted
@@ -66,6 +69,11 @@ func newWebSearchToolWithBackend(backend searchBackend) Tool {
 						Default:     defaultWebSearchLimit,
 						Minimum:     intPtr(1),
 						Maximum:     intPtr(maxWebSearchLimit),
+					},
+					"domains": {
+						Type:        "array",
+						Description: "Optional list of allowed hostnames; results outside these hosts are filtered out before they reach the model. Useful as a prompt-injection defense when you only want results from a known set of domains.",
+						Items:       &PropertySchema{Type: "string"},
 					},
 				},
 				Required:             []string{"query"},
@@ -123,6 +131,10 @@ func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
 	if limit > maxWebSearchLimit {
 		limit = maxWebSearchLimit
 	}
+	domains, err := stringListArgWebSearch(args, "domains")
+	if err != nil {
+		return errorResult("Error: Invalid arguments for web_search: " + err.Error())
+	}
 
 	if tool.backend == nil {
 		return errorResult("Error: no search backend configured. Set ZERO_WEBSEARCH_BASE_URL (and ZERO_WEBSEARCH_API_KEY) to enable web_search.")
@@ -135,6 +147,16 @@ func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
 	if err != nil {
 		return errorResult("Error performing web search: " + redactWebSearchText(err.Error()))
 	}
+	// Filter by domains BEFORE the empty-result short-circuit so a non-empty
+	// allowlist that ate every hit surfaces as a clear "no results matched
+	// domains" error rather than a misleading "no results" message.
+	if len(results) > 0 && len(domains) > 0 {
+		filtered, err := filterWebSearchByDomains(results, domains)
+		if err != nil {
+			return errorResult("Error: " + err.Error())
+		}
+		results = filtered
+	}
 	if len(results) == 0 {
 		return okResult("No results for query: " + redactWebSearchText(query))
 	}
@@ -146,6 +168,9 @@ func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
 
 // formatSearchResults renders results as a compact numbered list:
 // "1. Title — URL" with the snippet indented on the next line.
+// If a result carries a non-zero Score, it is shown as " — score 0.91" after
+// the title; absence (zero value) is rendered without the score to keep the
+// common case tidy.
 func formatSearchResults(results []searchResult) string {
 	lines := make([]string, 0, len(results)*2)
 	for index, result := range results {
@@ -153,7 +178,11 @@ func formatSearchResults(results []searchResult) string {
 		if title == "" {
 			title = "(untitled)"
 		}
-		lines = append(lines, fmt.Sprintf("%d. %s — %s", index+1, title, strings.TrimSpace(result.URL)))
+		header := fmt.Sprintf("%d. %s — %s", index+1, title, strings.TrimSpace(result.URL))
+		if result.Score > 0 {
+			header += fmt.Sprintf(" — score %.2f", result.Score)
+		}
+		lines = append(lines, header)
 		if snippet := strings.TrimSpace(result.Snippet); snippet != "" {
 			lines = append(lines, "   "+snippet)
 		}
@@ -260,13 +289,16 @@ func (backend *httpSearchBackend) Search(ctx context.Context, query string, limi
 	return parseSearchResults(body)
 }
 
-// parseSearchResults accepts either a bare array [{title,url,snippet}] or a
-// wrapped object {"results":[...]}, the two shapes common across providers.
+// parseSearchResults accepts either a bare array [{title,url,snippet,score}] or
+// a wrapped object {"results":[...]}, the two shapes common across providers.
+// The optional "score" field is forwarded when present; providers that omit
+// it leave searchResult.Score at the zero value and the renderer skips it.
 func parseSearchResults(body []byte) ([]searchResult, error) {
 	type rawResult struct {
-		Title   string `json:"title"`
-		URL     string `json:"url"`
-		Snippet string `json:"snippet"`
+		Title   string  `json:"title"`
+		URL     string  `json:"url"`
+		Snippet string  `json:"snippet"`
+		Score   float64 `json:"score,omitempty"`
 	}
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {
@@ -276,7 +308,12 @@ func parseSearchResults(body []byte) ([]searchResult, error) {
 	convert := func(raw []rawResult) []searchResult {
 		out := make([]searchResult, 0, len(raw))
 		for _, item := range raw {
-			out = append(out, searchResult{Title: item.Title, URL: item.URL, Snippet: item.Snippet})
+			out = append(out, searchResult{
+				Title:   item.Title,
+				URL:     item.URL,
+				Snippet: item.Snippet,
+				Score:   item.Score,
+			})
 		}
 		return out
 	}
@@ -299,4 +336,114 @@ func parseSearchResults(body []byte) ([]searchResult, error) {
 
 func redactWebSearchText(value string) string {
 	return redaction.RedactString(value, redaction.Options{})
+}
+
+// stringListArgWebSearch reads an optional []string argument. The conventional
+// `[]any` shape is preferred (matches the rest of the tools package) but some
+// providers' tool-calling shapes emit `[]string` directly; tolerate both.
+func stringListArgWebSearch(args map[string]any, key string) ([]string, error) {
+	value, ok := args[key]
+	if !ok || value == nil {
+		return nil, nil
+	}
+	raw, ok := value.([]any)
+	if !ok {
+		if asString, ok2 := value.([]string); ok2 {
+			return normalizeWebSearchDomainList(asString), nil
+		}
+		return nil, fmt.Errorf("%s must be a list of strings", key)
+	}
+	out := make([]string, 0, len(raw))
+	for index, item := range raw {
+		text, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s[%d] must be a string", key, index)
+		}
+		out = append(out, text)
+	}
+	return normalizeWebSearchDomainList(out), nil
+}
+
+// normalizeWebSearchDomainList lowercases, strips scheme/www/path fragments,
+// drops empty entries, and de-duplicates while preserving input order.
+func normalizeWebSearchDomainList(domains []string) []string {
+	seen := make(map[string]struct{}, len(domains))
+	out := make([]string, 0, len(domains))
+	for _, raw := range domains {
+		host := canonicalizeWebSearchHost(raw)
+		if host == "" {
+			continue
+		}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		out = append(out, host)
+	}
+	return out
+}
+
+// canonicalizeWebSearchHost extracts a bare lowercase hostname from a domain
+// string, accepting "react.dev", "https://react.dev/x", and "www.React.dev"
+// forms. Returns "" on empty/whitespace input. The "www." prefix is stripped
+// before lowercasing so case-insensitive matches like "WWW.react.dev" work.
+func canonicalizeWebSearchHost(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.Contains(trimmed, "://") {
+		parsed, err := url.Parse(trimmed)
+		if err != nil {
+			return ""
+		}
+		trimmed = parsed.Host
+	}
+	trimmed = strings.TrimSpace(trimmed)
+	if i := strings.IndexAny(trimmed, "/?#"); i >= 0 {
+		trimmed = trimmed[:i]
+	}
+	trimmed = strings.ToLower(trimmed)
+	trimmed = strings.TrimPrefix(trimmed, "www.")
+	if trimmed == "" || strings.ContainsAny(trimmed, " \t\n") {
+		return ""
+	}
+	return trimmed
+}
+
+// filterWebSearchByDomains drops results whose host is not in the allowlist.
+// A result whose URL fails to parse is dropped (fail-closed). When the filter
+// eats every result, the error names the failing allowlist so the caller knows
+// the constraint, not the provider, is the cause.
+func filterWebSearchByDomains(results []searchResult, allowed []string) ([]searchResult, error) {
+	allowSet := make(map[string]struct{}, len(allowed))
+	for _, d := range allowed {
+		allowSet[d] = struct{}{}
+	}
+	out := make([]searchResult, 0, len(results))
+	for _, row := range results {
+		host := hostFromWebSearchURL(row.URL)
+		if host == "" {
+			// Unparseable URL: never let it through when an allowlist is set.
+			continue
+		}
+		if _, ok := allowSet[host]; !ok {
+			continue
+		}
+		out = append(out, row)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no web_search results matched domains=%v; loosen the allowlist or remove the domains argument", allowed)
+	}
+	return out, nil
+}
+
+func hostFromWebSearchURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil {
+		return ""
+	}
+	host := strings.ToLower(parsed.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	return host
 }

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -131,9 +131,16 @@ func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
 	if limit > maxWebSearchLimit {
 		limit = maxWebSearchLimit
 	}
-	domains, err := stringListArgWebSearch(args, "domains")
+	domains, domainsProvided, err := stringListArgWebSearch(args, "domains")
 	if err != nil {
 		return errorResult("Error: Invalid arguments for web_search: " + err.Error())
+	}
+	// Fail closed: the caller asked for an allowlist, but every entry was
+	// invalid (or the list was empty). Silently dropping the filter would
+	// turn a constrained search into an unconstrained one, defeating the
+	// prompt-injection defense the parameter exists to provide.
+	if domainsProvided && len(domains) == 0 {
+		return errorResult("Error: web_search 'domains' argument was provided but contained no valid hostnames; remove the argument or pass valid hostnames")
 	}
 
 	if tool.backend == nil {
@@ -341,27 +348,33 @@ func redactWebSearchText(value string) string {
 // stringListArgWebSearch reads an optional []string argument. The conventional
 // `[]any` shape is preferred (matches the rest of the tools package) but some
 // providers' tool-calling shapes emit `[]string` directly; tolerate both.
-func stringListArgWebSearch(args map[string]any, key string) ([]string, error) {
+//
+// The returned provided bool is true when the caller passed a "domains" key at
+// all (even with an empty array or all-invalid entries). That lets Run
+// distinguish "no allowlist" from "allowlist that normalized to empty" — the
+// latter is a fail-closed error, not a silent permission to skip filtering.
+func stringListArgWebSearch(args map[string]any, key string) (domains []string, provided bool, err error) {
 	value, ok := args[key]
 	if !ok || value == nil {
-		return nil, nil
+		return nil, false, nil
 	}
+	provided = true
 	raw, ok := value.([]any)
 	if !ok {
 		if asString, ok2 := value.([]string); ok2 {
-			return normalizeWebSearchDomainList(asString), nil
+			return normalizeWebSearchDomainList(asString), true, nil
 		}
-		return nil, fmt.Errorf("%s must be a list of strings", key)
+		return nil, true, fmt.Errorf("%s must be a list of strings", key)
 	}
 	out := make([]string, 0, len(raw))
 	for index, item := range raw {
 		text, ok := item.(string)
 		if !ok {
-			return nil, fmt.Errorf("%s[%d] must be a string", key, index)
+			return nil, true, fmt.Errorf("%s[%d] must be a string", key, index)
 		}
 		out = append(out, text)
 	}
-	return normalizeWebSearchDomainList(out), nil
+	return normalizeWebSearchDomainList(out), true, nil
 }
 
 // normalizeWebSearchDomainList lowercases, strips scheme/www/path fragments,
@@ -397,7 +410,11 @@ func canonicalizeWebSearchHost(raw string) string {
 		if err != nil {
 			return ""
 		}
-		trimmed = parsed.Host
+		// Hostname() strips the port so allowlist entries like
+		// "https://react.dev:443/path" normalize the same as "react.dev".
+		// Using parsed.Host here would leave ":443" in the string and
+		// silently break every match against a result URL on port 443.
+		trimmed = parsed.Hostname()
 	}
 	trimmed = strings.TrimSpace(trimmed)
 	if i := strings.IndexAny(trimmed, "/?#"); i >= 0 {

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -256,3 +256,230 @@ func TestSameHostRedirectPolicy(t *testing.T) {
 		t.Fatal("redirect limit must be enforced")
 	}
 }
+
+// ---- new: domains allowlist + score field ----------------------------------
+
+func TestWebSearchDomainsFilterKeepsOnlyAllowedHosts(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "RSC", URL: "https://react.dev/rsc", Snippet: "Server components"},
+		{Title: "RFC", URL: "https://github.com/reactjs/rfcs", Snippet: "RFC 0188"},
+		{Title: "Other", URL: "https://stackoverflow.com/q/1", Snippet: "unrelated"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "react server components",
+		"domains": []any{"react.dev", "github.com"},
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v, output = %q", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "stackoverflow.com") {
+		t.Errorf("stackoverflow result must be filtered out, got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "react.dev/rsc") || !strings.Contains(res.Output, "github.com/reactjs/rfcs") {
+		t.Errorf("allowed-host results missing, got: %s", res.Output)
+	}
+}
+
+func TestWebSearchDomainsFilterEmptyResultIsError(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "x", URL: "https://stackoverflow.com/q/1"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": []any{"react.dev"},
+	})
+	if res.Status != StatusError {
+		t.Fatalf("expected error when allowlist eats every result, got %v: %s", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Output, "no web_search results matched domains") {
+		t.Errorf("expected clear allowlist error, got: %s", res.Output)
+	}
+}
+
+func TestWebSearchDomainsFilterToleratesStringSlice(t *testing.T) {
+	// Some providers send []string instead of []any. The tool must accept both.
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://react.dev/x"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": []string{"react.dev"},
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("expected ok for []string domains, got %v: %s", res.Status, res.Output)
+	}
+}
+
+func TestWebSearchDomainsFilterNormalizesSchemeAndCase(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://React.Dev/x"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": []any{"https://REACT.dev/path?ignored=1", "WWW.react.dev"},
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("expected ok after normalization, got %v: %s", res.Status, res.Output)
+	}
+}
+
+func TestWebSearchDomainsFilterStripsWWWFromResult(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://www.react.dev/x"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+	// Allowlist "react.dev" must still match a result that has www. in the URL.
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": []any{"react.dev"},
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("expected ok when result host has www., got %v: %s", res.Status, res.Output)
+	}
+}
+
+func TestWebSearchDomainsFilterRejectsMalformedURLs(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://react.dev/x"},
+		{Title: "bad", URL: "::::not a url::::"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": []any{"react.dev"},
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v, output = %s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "not a url") {
+		t.Errorf("malformed URL must be filtered out, got: %s", res.Output)
+	}
+}
+
+func TestWebSearchDomainsFilterRejectsBadArgType(t *testing.T) {
+	tool := newWebSearchToolWithBackend(&fakeSearchBackend{})
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": "react.dev", // string instead of array
+	})
+	if res.Status != StatusError {
+		t.Fatalf("expected error for non-array domains, got %v: %s", res.Status, res.Output)
+	}
+}
+
+func TestWebSearchRendersScoreWhenPresent(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "ranked", URL: "https://react.dev/rsc", Score: 0.91},
+		{Title: "unranked", URL: "https://react.dev/other"}, // zero score, must be omitted
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+	res := tool.Run(context.Background(), map[string]any{"query": "x"})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v, output = %s", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Output, "score 0.91") {
+		t.Errorf("expected 'score 0.91' in output, got: %s", res.Output)
+	}
+	// The zero-score row must NOT render "score 0.00" — that would be noisy.
+	if strings.Contains(res.Output, "score 0.00") {
+		t.Errorf("zero score must not be rendered, got: %s", res.Output)
+	}
+}
+
+func TestHTTPSearchBackendParsesScoreField(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"title":"A","url":"https://a.test","snippet":"sa","score":0.77},{"title":"B","url":"https://b.test","snippet":"sb"}]}`))
+	}))
+	defer server.Close()
+
+	backend := &httpSearchBackend{client: server.Client(), baseURL: server.URL}
+	results, err := backend.Search(context.Background(), "q", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Score != 0.77 {
+		t.Errorf("first result Score = %v, want 0.77", results[0].Score)
+	}
+	if results[1].Score != 0 {
+		t.Errorf("absent score must be zero, got %v", results[1].Score)
+	}
+}
+
+func TestCanonicalizeWebSearchHost(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"react.dev", "react.dev"},
+		{"  REACT.dev  ", "react.dev"},
+		{"https://react.dev/x", "react.dev"},
+		{"http://www.react.dev", "react.dev"},
+		{"WWW.react.dev", "react.dev"},
+		{"react.dev/path?x=1", "react.dev"},
+		{"", ""},
+		{"   ", ""},
+		{"https://", ""},
+		{"react .dev", ""}, // space inside
+	}
+	for _, c := range cases {
+		if got := canonicalizeWebSearchHost(c.in); got != c.want {
+			t.Errorf("canonicalizeWebSearchHost(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeWebSearchDomainList(t *testing.T) {
+	got := normalizeWebSearchDomainList([]string{"  REACT.dev  ", "https://github.com/x", "www.example.com", "react.dev", "", "   "})
+	want := []string{"react.dev", "github.com", "example.com"}
+	if len(got) != len(want) {
+		t.Fatalf("normalizeWebSearchDomainList = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFilterWebSearchByDomains(t *testing.T) {
+	rows := []searchResult{
+		{URL: "https://react.dev/x"},
+		{URL: "https://github.com/y"},
+		{URL: "https://stackoverflow.com/z"},
+	}
+	filtered, err := filterWebSearchByDomains(rows, []string{"react.dev", "github.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("filtered len = %d, want 2; got %v", len(filtered), filtered)
+	}
+	// Empty allowlist must be rejected when called directly with no rows that match.
+	_, err = filterWebSearchByDomains([]searchResult{{URL: "https://x.test"}}, []string{"nope.test"})
+	if err == nil {
+		t.Fatal("expected error when allowlist is non-empty and no rows match")
+	}
+}
+
+func TestWebSearchSchemaHasDomainsField(t *testing.T) {
+	tool := NewWebSearchTool()
+	domains := tool.Parameters().Properties["domains"]
+	if domains.Type != "array" {
+		t.Fatalf("domains.Type = %q, want array", domains.Type)
+	}
+	if domains.Items == nil || domains.Items.Type != "string" {
+		t.Fatalf("domains.Items = %#v, want array of string", domains.Items)
+	}
+	if domains.Description == "" {
+		t.Fatal("domains.Description should explain the prompt-injection defense")
+	}
+}

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -483,3 +483,106 @@ func TestWebSearchSchemaHasDomainsField(t *testing.T) {
 		t.Fatal("domains.Description should explain the prompt-injection defense")
 	}
 }
+
+// TestWebSearchDomainsFilterRejectsAllInvalidInputs covers the fail-closed
+// contract: when the caller passes a 'domains' argument but every entry is
+// invalid (e.g. all whitespace, all with embedded spaces), the tool must
+// error rather than silently return unfiltered results. The whole point of
+// the parameter is the prompt-injection defense; an unfiltered result set
+// would defeat it.
+func TestWebSearchDomainsFilterRejectsAllInvalidInputs(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "x", URL: "https://react.dev/x"},
+	}}
+	tool := newWebSearchToolWithBackend(backend)
+
+	cases := []struct {
+		name    string
+		domains []any
+	}{
+		{"all whitespace", []any{"   ", "\t", "\n"}},
+		{"empty strings", []any{"", ""}},
+		{"embedded spaces", []any{"react .dev", "github .com"}},
+		{"mixed invalid", []any{"", "   ", "react .dev"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := tool.Run(context.Background(), map[string]any{
+				"query":   "x",
+				"domains": c.domains,
+			})
+			if res.Status != StatusError {
+				t.Fatalf("expected error when all domains are invalid, got %v: %s", res.Status, res.Output)
+			}
+			if !strings.Contains(res.Output, "no valid hostnames") {
+				t.Errorf("expected 'no valid hostnames' in error, got: %s", res.Output)
+			}
+			if backend.gotQuery != "" {
+				t.Errorf("backend must not have been called when domains are invalid; got query %q", backend.gotQuery)
+			}
+		})
+	}
+}
+
+// TestWebSearchDomainsFilterAcceptsHostPort covers the canonicalization
+// contract: an allowlist entry that includes a port WITH a scheme (e.g. the
+// result of a model passing "https://react.dev:443/path") must still match
+// a result URL on the same hostname. The CodeRabbit-flagged bug was that
+// the canonicalizer was using parsed.Host (which includes ":443") rather
+// than parsed.Hostname() (which strips the port), so a "react.dev" allowlist
+// silently never matched results from "https://react.dev:443/...". The fix
+// uses Hostname(), so this test locks in the corrected contract.
+func TestWebSearchDomainsFilterAcceptsHostPort(t *testing.T) {
+	cases := []struct {
+		name        string
+		allowlist   []any
+		expectMatch bool
+	}{
+		{"with explicit https port", []any{"https://react.dev:443/path"}, true},
+		{"with explicit http port", []any{"http://react.dev:80/x"}, true},
+		{"scheme-less host:port is rejected", []any{"react.dev:9999"}, false}, // not a valid hostname
+		{"port on different host", []any{"github.com:443"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			backend := &fakeSearchBackend{results: []searchResult{
+				{Title: "ok", URL: "https://react.dev/x"},
+			}}
+			tool := newWebSearchToolWithBackend(backend)
+			res := tool.Run(context.Background(), map[string]any{
+				"query":   "x",
+				"domains": c.allowlist,
+			})
+			if c.expectMatch {
+				if res.Status != StatusOK {
+					t.Fatalf("expected match, got %v: %s", res.Status, res.Output)
+				}
+				if !strings.Contains(res.Output, "react.dev/x") {
+					t.Errorf("expected react.dev result, got: %s", res.Output)
+				}
+			} else {
+				if res.Status != StatusError {
+					t.Fatalf("expected no-match error, got %v: %s", res.Status, res.Output)
+				}
+			}
+		})
+	}
+}
+
+func TestCanonicalizeWebSearchHostStripsPort(t *testing.T) {
+	// Lock in the contract that parsed.Host (which includes ":443") is NOT
+	// used; parsed.Hostname() is. CodeRabbit flagged this inconsistency.
+	cases := []struct {
+		in, want string
+	}{
+		{"https://react.dev:443/x", "react.dev"},
+		{"http://react.dev:80", "react.dev"},
+		{"https://api.react.dev:8443/v1", "api.react.dev"},
+		{"https://react.dev", "react.dev"},
+	}
+	for _, c := range cases {
+		if got := canonicalizeWebSearchHost(c.in); got != c.want {
+			t.Errorf("canonicalizeWebSearchHost(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Enriches the existing web_search tool (merged in #175) with two model-facing additions: a domains allowlist (the zero-only prompt-injection defense) and provider score surfacing. See commit body for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web search now supports an optional domain allowlist to restrict results to specific hosts.
  * Search results can now include and display provider relevance scores when available.

* **Bug Fixes**
  * Improved robustness when normalizing and matching domain allowlist entries and handling malformed result URLs.
  * Added clearer error handling when the domain allowlist eliminates all results or is provided in an invalid format.

* **Tests**
  * Expanded automated coverage for domain allowlisting, score parsing/rendering, host normalization, and allowlist/port handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->