### PR TITLE
feat(daemon): TLS remote bridge — authenticated network access to the daemon

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/background"
 	"github.com/Gitlawb/zero/internal/daemon"
+	"github.com/Gitlawb/zero/internal/daemon/remote"
 )
 
 // runDaemon dispatches the `zero daemon ...` subcommands. The daemon supervises a
@@ -35,6 +36,8 @@ func runDaemon(args []string, stdout io.Writer, stderr io.Writer, _ appDeps) int
 		return runDaemonRun(rest, stdout, stderr)
 	case "attach":
 		return runDaemonAttach(rest, stdout, stderr)
+	case "serve-remote":
+		return runDaemonServeRemote(rest, stdout, stderr)
 	case "-h", "--help", "help":
 		return writeDaemonUsage(stdout, exitSuccess)
 	default:
@@ -53,6 +56,14 @@ Commands:
   run --session <id> [--cwd <dir>] [--prompt <text>] [exec flags...]
                             Create/route a session and stream its output.
   attach <session>          Attach to a running session's stream.
+  serve-remote --addr <host:port> --tls-cert <f> --tls-key <f>
+                            Serve an opt-in, TLS-only network bridge to this
+                            daemon. Requires a bearer token in $ZERO_DAEMON_REMOTE_TOKEN
+                            (or $ZERO_DAEMON_REMOTE_TOKEN_FILE).
+
+run and attach accept --remote <host:port> [--token <t>] [--ca-cert <f>]
+[--server-name <name>] to drive a remote daemon over the bridge instead of the
+local socket.
 `)
 	return code
 }
@@ -212,6 +223,7 @@ func runDaemonStatus(args []string, stdout io.Writer, stderr io.Writer) int {
 
 func runDaemonRun(args []string, stdout io.Writer, stderr io.Writer) int {
 	session, cwd, prompt := "", "", ""
+	var remoteFlags remoteDialFlags
 	var forward []string
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -225,6 +237,38 @@ func runDaemonRun(args []string, stdout io.Writer, stderr io.Writer) int {
 		switch {
 		case a == "-h" || a == "--help":
 			return writeDaemonUsage(stdout, exitSuccess)
+		case a == "--remote":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--remote requires a value")
+			}
+			remoteFlags.Addr = v
+		case strings.HasPrefix(a, "--remote="):
+			remoteFlags.Addr = strings.TrimPrefix(a, "--remote=")
+		case a == "--token":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--token requires a value")
+			}
+			remoteFlags.Token = v
+		case strings.HasPrefix(a, "--token="):
+			remoteFlags.Token = strings.TrimPrefix(a, "--token=")
+		case a == "--ca-cert":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--ca-cert requires a value")
+			}
+			remoteFlags.CACert = v
+		case strings.HasPrefix(a, "--ca-cert="):
+			remoteFlags.CACert = strings.TrimPrefix(a, "--ca-cert=")
+		case a == "--server-name":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--server-name requires a value")
+			}
+			remoteFlags.ServerName = v
+		case strings.HasPrefix(a, "--server-name="):
+			remoteFlags.ServerName = strings.TrimPrefix(a, "--server-name=")
 		case a == "--session":
 			v, ok := value()
 			if !ok {
@@ -261,13 +305,9 @@ func runDaemonRun(args []string, stdout io.Writer, stderr io.Writer) int {
 	if prompt == "" && len(forward) == 0 {
 		return writeExecUsageError(stderr, "daemon run requires --prompt <text> or exec args")
 	}
-	paths, err := daemon.DefaultPaths()
+	client, err := dialForCLI(remoteFlags)
 	if err != nil {
-		return writeAppError(stderr, err.Error(), exitCrash)
-	}
-	client, err := daemon.Dial(paths.Socket)
-	if err != nil {
-		return writeAppError(stderr, "zero daemon is not running (start it with `zero daemon start`)", exitCrash)
+		return writeAppError(stderr, daemonDialError(remoteFlags, err), exitCrash)
 	}
 	defer client.Close()
 	if err := client.Run(session, cwd, prompt, forward, func(line string) { fmt.Fprintln(stdout, line) }); err != nil {
@@ -278,16 +318,57 @@ func runDaemonRun(args []string, stdout io.Writer, stderr io.Writer) int {
 
 func runDaemonAttach(args []string, stdout io.Writer, stderr io.Writer) int {
 	session := ""
+	var remoteFlags remoteDialFlags
 	extra := 0
-	for _, a := range args {
-		if a == "-h" || a == "--help" {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		value := func() (string, bool) {
+			if i+1 >= len(args) {
+				return "", false
+			}
+			i++
+			return args[i], true
+		}
+		switch {
+		case a == "-h" || a == "--help":
 			return writeDaemonUsage(stdout, exitSuccess)
-		}
-		if session == "" {
+		case a == "--remote":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--remote requires a value")
+			}
+			remoteFlags.Addr = v
+		case strings.HasPrefix(a, "--remote="):
+			remoteFlags.Addr = strings.TrimPrefix(a, "--remote=")
+		case a == "--token":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--token requires a value")
+			}
+			remoteFlags.Token = v
+		case strings.HasPrefix(a, "--token="):
+			remoteFlags.Token = strings.TrimPrefix(a, "--token=")
+		case a == "--ca-cert":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--ca-cert requires a value")
+			}
+			remoteFlags.CACert = v
+		case strings.HasPrefix(a, "--ca-cert="):
+			remoteFlags.CACert = strings.TrimPrefix(a, "--ca-cert=")
+		case a == "--server-name":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--server-name requires a value")
+			}
+			remoteFlags.ServerName = v
+		case strings.HasPrefix(a, "--server-name="):
+			remoteFlags.ServerName = strings.TrimPrefix(a, "--server-name=")
+		case session == "":
 			session = a
-			continue
+		default:
+			extra++
 		}
-		extra++
 	}
 	if strings.TrimSpace(session) == "" {
 		return writeExecUsageError(stderr, "daemon attach requires a <session> id")
@@ -295,19 +376,194 @@ func runDaemonAttach(args []string, stdout io.Writer, stderr io.Writer) int {
 	if extra > 0 {
 		return writeExecUsageError(stderr, "daemon attach accepts exactly one <session> id")
 	}
-	paths, err := daemon.DefaultPaths()
+	client, err := dialForCLI(remoteFlags)
 	if err != nil {
-		return writeAppError(stderr, err.Error(), exitCrash)
-	}
-	client, err := daemon.Dial(paths.Socket)
-	if err != nil {
-		return writeAppError(stderr, "zero daemon is not running (start it with `zero daemon start`)", exitCrash)
+		return writeAppError(stderr, daemonDialError(remoteFlags, err), exitCrash)
 	}
 	defer client.Close()
 	if err := client.Attach(session, func(line string) { fmt.Fprintln(stdout, line) }); err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
 	return exitSuccess
+}
+
+// daemonDialError tailors the connect-failure message for local vs remote.
+func daemonDialError(flags remoteDialFlags, err error) string {
+	if strings.TrimSpace(flags.Addr) != "" {
+		return "failed to reach remote daemon at " + flags.Addr + ": " + err.Error()
+	}
+	return "zero daemon is not running (start it with `zero daemon start`)"
+}
+
+// runDaemonServeRemote starts the local daemon plus an opt-in, TLS-only network
+// bridge. TLS and a bearer token are mandatory (fail closed): it refuses to
+// start without a cert/key pair and a token from the environment.
+func runDaemonServeRemote(args []string, stdout io.Writer, stderr io.Writer) int {
+	addr, certFile, keyFile := "", "", ""
+	minVersion, maxConns := 0, 0
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		value := func() (string, bool) {
+			if i+1 >= len(args) {
+				return "", false
+			}
+			i++
+			return args[i], true
+		}
+		switch {
+		case a == "-h" || a == "--help":
+			return writeDaemonUsage(stdout, exitSuccess)
+		case a == "--addr":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--addr requires a value")
+			}
+			addr = v
+		case strings.HasPrefix(a, "--addr="):
+			addr = strings.TrimPrefix(a, "--addr=")
+		case a == "--tls-cert":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--tls-cert requires a value")
+			}
+			certFile = v
+		case strings.HasPrefix(a, "--tls-cert="):
+			certFile = strings.TrimPrefix(a, "--tls-cert=")
+		case a == "--tls-key":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--tls-key requires a value")
+			}
+			keyFile = v
+		case strings.HasPrefix(a, "--tls-key="):
+			keyFile = strings.TrimPrefix(a, "--tls-key=")
+		case a == "--min-version":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--min-version requires a value")
+			}
+			minVersion = atoiOrZero(v)
+		case a == "--max-conns":
+			v, ok := value()
+			if !ok {
+				return writeExecUsageError(stderr, "--max-conns requires a value")
+			}
+			maxConns = atoiOrZero(v)
+		default:
+			return writeExecUsageError(stderr, fmt.Sprintf("unknown flag %q for daemon serve-remote", a))
+		}
+	}
+	if strings.TrimSpace(addr) == "" {
+		return writeExecUsageError(stderr, "daemon serve-remote requires --addr <host:port>")
+	}
+	// Fail closed: TLS cert/key + a bearer token are mandatory.
+	tlsConfig, err := remote.ServerTLSConfig(certFile, keyFile)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	token, err := remote.TokenFromEnv()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	auth, err := remote.NewTokenAuthenticator(token)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	paths, err := daemon.DefaultPaths()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	launcher, err := daemon.NewExecLauncher(daemon.ExecLauncherConfig{})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	logf := func(line string) { fmt.Fprintln(stderr, "[daemon] "+line) }
+	pool, err := daemon.NewPool(daemon.PoolOptions{Launcher: launcher, Log: logf})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	mgr, err := daemon.NewSessionManager(daemon.SessionManagerOptions{Pool: pool})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	srv, err := daemon.NewServer(daemon.ServerOptions{Paths: paths, Manager: mgr, Pool: pool, Log: logf})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	bridge, err := remote.NewBridge(remote.BridgeOptions{
+		Server: srv, Authenticator: auth, MinVersion: minVersion, MaxConnections: maxConns, Log: logf,
+	})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	// Serve the local control socket too, so local clients keep working.
+	go func() {
+		if serveErr := srv.Serve(); serveErr != nil {
+			logf("local serve error: " + serveErr.Error())
+		}
+	}()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- bridge.ListenAndServeTLS(addr, tlsConfig) }()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	fmt.Fprintf(stdout, "zero daemon remote bridge listening on %s (TLS)\n", addr)
+	select {
+	case <-sigCh:
+		srv.Shutdown()
+		_ = bridge.Close()
+		<-serveErr // wait for the accept loop to unwind
+		return exitSuccess
+	case err := <-serveErr:
+		// Bind/serve failed before any signal (e.g. address in use).
+		srv.Shutdown()
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+}
+
+// remoteDialFlags holds the optional flags that redirect run/attach to a remote
+// daemon. When Addr is empty the local control socket is used.
+type remoteDialFlags struct {
+	Addr       string
+	Token      string
+	CACert     string
+	ServerName string
+}
+
+// dialForCLI returns a daemon.Client for either the local socket (Addr empty) or
+// a remote bridge (Addr set). For remote, the token falls back to the env.
+func dialForCLI(flags remoteDialFlags) (*daemon.Client, error) {
+	if strings.TrimSpace(flags.Addr) == "" {
+		paths, err := daemon.DefaultPaths()
+		if err != nil {
+			return nil, err
+		}
+		return daemon.Dial(paths.Socket)
+	}
+	token := strings.TrimSpace(flags.Token)
+	if token == "" {
+		token, _ = remote.TokenFromEnv() // best effort; DialRemote rejects an empty token
+	}
+	return remote.DialRemote(remote.RemoteConfig{
+		Address:    flags.Addr,
+		Token:      token,
+		CACertFile: flags.CACert,
+		ServerName: flags.ServerName,
+	})
+}
+
+func atoiOrZero(s string) int {
+	n := 0
+	for _, r := range strings.TrimSpace(s) {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
 }
 
 // daemonReachable reports whether a daemon is accepting connections (a successful

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -26,6 +26,19 @@ func Dial(socketPath string) (*Client, error) {
 	return c, nil
 }
 
+// NewClientConn completes the control handshake on an already-connected
+// transport (e.g. a TLS connection the remote bridge has authenticated) and
+// returns a Client ready for Run/Attach/Status. It takes ownership of conn and
+// closes it on handshake failure.
+func NewClientConn(conn net.Conn) (*Client, error) {
+	c := &Client{conn: conn}
+	if err := c.handshake(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
 func (c *Client) handshake() error {
 	if err := WriteControl(c.conn, Ctrl{Type: CtrlHello, Version: ProtoVersion}); err != nil {
 		return err

--- a/internal/daemon/remote/auth.go
+++ b/internal/daemon/remote/auth.go
@@ -1,0 +1,158 @@
+// Package remote adds an OPT-IN, TLS-only network bridge on top of zero's local
+// daemon (internal/daemon). It lets a remote client drive the SAME daemon
+// SessionManager/Pool over the network, behind bearer-token authentication and a
+// protocol-version floor. The local Unix-socket daemon is unchanged and remains
+// the default; nothing here activates unless `zero daemon serve-remote` is run.
+//
+// Security (fail closed):
+//   - TLS is mandatory; the bridge refuses to serve without a cert/key.
+//   - A connection is authenticated BEFORE any control frame is dispatched; a
+//     failed/absent token closes the connection (after a small backoff) and no
+//     session frame is ever processed.
+//   - Tokens are compared in constant time and are never logged.
+//   - The control-frame size cap and version negotiation from internal/daemon are
+//     reused unchanged; oversize/old-version handshakes are rejected.
+//   - A remote-driven session runs through the same daemon dispatch, so it stays
+//     under the same sandbox + risk model — remote never bypasses local controls.
+package remote
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/daemon"
+)
+
+// Env vars the bridge reads for its bearer token.
+const (
+	EnvToken     = "ZERO_DAEMON_REMOTE_TOKEN"
+	EnvTokenFile = "ZERO_DAEMON_REMOTE_TOKEN_FILE"
+)
+
+// ErrUnauthorized is returned when a token does not match.
+var ErrUnauthorized = errors.New("remote: unauthorized")
+
+// Authenticator verifies a bearer token presented by a remote client.
+type Authenticator interface {
+	Authenticate(token string) error
+}
+
+// TokenAuthenticator compares a presented token against a fixed secret in
+// constant time.
+type TokenAuthenticator struct {
+	token string
+}
+
+// NewTokenAuthenticator builds a token authenticator, refusing an empty secret
+// (fail closed — a bridge must never accept everyone).
+func NewTokenAuthenticator(token string) (*TokenAuthenticator, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, errors.New("remote: a non-empty auth token is required")
+	}
+	return &TokenAuthenticator{token: token}, nil
+}
+
+// Authenticate reports nil when token matches the configured secret.
+func (a *TokenAuthenticator) Authenticate(token string) error {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(a.token)) == 1 {
+		return nil
+	}
+	return ErrUnauthorized
+}
+
+// TokenFromEnv resolves the bridge token from EnvToken, or a file named by
+// EnvTokenFile. It never logs the token.
+func TokenFromEnv() (string, error) {
+	if t := strings.TrimSpace(os.Getenv(EnvToken)); t != "" {
+		return t, nil
+	}
+	if file := strings.TrimSpace(os.Getenv(EnvTokenFile)); file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("remote: read token file: %w", err)
+		}
+		t := strings.TrimSpace(string(data))
+		if t == "" {
+			return "", errors.New("remote: token file is empty")
+		}
+		return t, nil
+	}
+	return "", fmt.Errorf("remote: set %s or %s", EnvToken, EnvTokenFile)
+}
+
+// Attestation is an optional post-token hook (e.g. workload attestation). The
+// default is a no-op; a deployment can supply a stricter implementation.
+type Attestation interface {
+	Verify(meta map[string]string) error
+}
+
+type noopAttestation struct{}
+
+func (noopAttestation) Verify(map[string]string) error { return nil }
+
+// authRequest is the first frame a remote client sends (before the daemon
+// hello). Token is never logged.
+type authRequest struct {
+	Token   string            `json:"token"`
+	Version int               `json:"version"`
+	Meta    map[string]string `json:"meta,omitempty"`
+}
+
+// authResponse is the bridge's reply to the auth handshake.
+type authResponse struct {
+	OK      bool   `json:"ok"`
+	Version int    `json:"version,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func writeAuthRequest(w io.Writer, req authRequest) error {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	return daemon.WriteFrame(w, daemon.KindCtrl, payload)
+}
+
+func readAuthRequest(r io.Reader) (authRequest, error) {
+	kind, payload, err := daemon.ReadFrame(r)
+	if err != nil {
+		return authRequest{}, err
+	}
+	if kind != daemon.KindCtrl {
+		return authRequest{}, errors.New("remote: expected auth frame")
+	}
+	var req authRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return authRequest{}, fmt.Errorf("remote: decode auth request: %w", err)
+	}
+	return req, nil
+}
+
+func writeAuthResponse(w io.Writer, resp authResponse) error {
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	return daemon.WriteFrame(w, daemon.KindCtrl, payload)
+}
+
+func readAuthResponse(r io.Reader) (authResponse, error) {
+	kind, payload, err := daemon.ReadFrame(r)
+	if err != nil {
+		return authResponse{}, err
+	}
+	if kind != daemon.KindCtrl {
+		return authResponse{}, errors.New("remote: expected auth response frame")
+	}
+	var resp authResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return authResponse{}, fmt.Errorf("remote: decode auth response: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/daemon/remote/auth_test.go
+++ b/internal/daemon/remote/auth_test.go
@@ -1,0 +1,67 @@
+package remote
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTokenAuthenticator(t *testing.T) {
+	if _, err := NewTokenAuthenticator("  "); err == nil {
+		t.Fatal("empty token must be rejected (fail closed)")
+	}
+	a, err := NewTokenAuthenticator("s3cret")
+	if err != nil {
+		t.Fatalf("NewTokenAuthenticator: %v", err)
+	}
+	if err := a.Authenticate("s3cret"); err != nil {
+		t.Fatalf("matching token should authenticate: %v", err)
+	}
+	if err := a.Authenticate("wrong"); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("mismatch err = %v, want ErrUnauthorized", err)
+	}
+	if err := a.Authenticate(""); !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("empty presented token err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestTokenFromEnv(t *testing.T) {
+	// Clear both so the no-config path errors.
+	t.Setenv(EnvToken, "")
+	t.Setenv(EnvTokenFile, "")
+	if _, err := TokenFromEnv(); err == nil {
+		t.Fatal("TokenFromEnv with neither var set must error")
+	}
+	// Direct env.
+	t.Setenv(EnvToken, "from-env")
+	if tok, err := TokenFromEnv(); err != nil || tok != "from-env" {
+		t.Fatalf("TokenFromEnv(env) = %q, %v", tok, err)
+	}
+	// File (env takes precedence, so clear env first).
+	t.Setenv(EnvToken, "")
+	file := filepath.Join(t.TempDir(), "tok")
+	if err := os.WriteFile(file, []byte("  from-file\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	t.Setenv(EnvTokenFile, file)
+	if tok, err := TokenFromEnv(); err != nil || tok != "from-file" {
+		t.Fatalf("TokenFromEnv(file) = %q, %v", tok, err)
+	}
+	// Empty file fails closed.
+	if err := os.WriteFile(file, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("rewrite token file: %v", err)
+	}
+	if _, err := TokenFromEnv(); err == nil {
+		t.Fatal("empty token file must error")
+	}
+}
+
+func TestServerTLSConfigRequiresCertKey(t *testing.T) {
+	if _, err := ServerTLSConfig("", ""); err == nil {
+		t.Fatal("ServerTLSConfig must require a cert and key (TLS mandatory)")
+	}
+	if _, err := ServerTLSConfig("/nope/cert.pem", "/nope/key.pem"); err == nil {
+		t.Fatal("ServerTLSConfig must error on unreadable cert/key")
+	}
+}

--- a/internal/daemon/remote/bridge.go
+++ b/internal/daemon/remote/bridge.go
@@ -125,6 +125,7 @@ func (b *Bridge) ListenAndServeTLS(addr string, tlsConfig *tls.Config) error {
 func (b *Bridge) Close() error {
 	b.mu.Lock()
 	listener := b.listener
+	b.listener = nil // clear so a repeat Close is a no-op, not a closed-listener error
 	b.mu.Unlock()
 	if listener != nil {
 		return listener.Close()

--- a/internal/daemon/remote/bridge.go
+++ b/internal/daemon/remote/bridge.go
@@ -1,0 +1,213 @@
+package remote
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/daemon"
+)
+
+const (
+	defaultMaxConnections   = 32
+	defaultHandshakeTimeout = 10 * time.Second
+	defaultAuthFailDelay    = 250 * time.Millisecond
+)
+
+// Bridge serves authenticated remote connections and drives the local daemon's
+// control dispatch for each one.
+type Bridge struct {
+	server           *daemon.Server
+	auth             Authenticator
+	attest           Attestation
+	minVersion       int
+	handshakeTimeout time.Duration
+	authFailDelay    time.Duration
+	log              func(string)
+	sem              chan struct{}
+
+	mu       sync.Mutex
+	listener net.Listener
+}
+
+// BridgeOptions configures a Bridge.
+type BridgeOptions struct {
+	// Server is the local daemon to drive (required).
+	Server *daemon.Server
+	// Authenticator verifies bearer tokens (required).
+	Authenticator Authenticator
+	// Attestation is an optional post-token hook; nil => no-op.
+	Attestation Attestation
+	// MinVersion is the lowest control-protocol version accepted; 0 =>
+	// daemon.ProtoVersion.
+	MinVersion int
+	// MaxConnections bounds concurrent remote connections; 0 => default.
+	MaxConnections int
+	// HandshakeTimeout bounds the auth handshake; 0 => default.
+	HandshakeTimeout time.Duration
+	// AuthFailDelay slows brute-force attempts; <0 => none, 0 => default.
+	AuthFailDelay time.Duration
+	Log           func(string)
+}
+
+// NewBridge validates options and builds a Bridge.
+func NewBridge(opts BridgeOptions) (*Bridge, error) {
+	if opts.Server == nil {
+		return nil, errors.New("remote: bridge requires a daemon server")
+	}
+	if opts.Authenticator == nil {
+		return nil, errors.New("remote: bridge requires an authenticator")
+	}
+	minVersion := opts.MinVersion
+	if minVersion <= 0 {
+		minVersion = daemon.ProtoVersion
+	}
+	maxConns := opts.MaxConnections
+	if maxConns <= 0 {
+		maxConns = defaultMaxConnections
+	}
+	handshakeTimeout := opts.HandshakeTimeout
+	if handshakeTimeout <= 0 {
+		handshakeTimeout = defaultHandshakeTimeout
+	}
+	authFailDelay := opts.AuthFailDelay
+	switch {
+	case authFailDelay < 0:
+		authFailDelay = 0
+	case authFailDelay == 0:
+		authFailDelay = defaultAuthFailDelay
+	}
+	attest := opts.Attestation
+	if attest == nil {
+		attest = noopAttestation{}
+	}
+	return &Bridge{
+		server:           opts.Server,
+		auth:             opts.Authenticator,
+		attest:           attest,
+		minVersion:       minVersion,
+		handshakeTimeout: handshakeTimeout,
+		authFailDelay:    authFailDelay,
+		log:              opts.Log,
+		sem:              make(chan struct{}, maxConns),
+	}, nil
+}
+
+func (b *Bridge) logf(format string, args ...any) {
+	if b.log != nil {
+		b.log(fmt.Sprintf(format, args...))
+	}
+}
+
+// ListenAndServeTLS binds a TLS listener on addr and serves until the listener
+// is closed (via Close). It refuses to serve without a TLS config (no plaintext
+// remote bridge).
+func (b *Bridge) ListenAndServeTLS(addr string, tlsConfig *tls.Config) error {
+	if tlsConfig == nil {
+		return errors.New("remote: TLS config is required; refusing to serve a plaintext remote bridge")
+	}
+	listener, err := tls.Listen("tcp", addr, tlsConfig)
+	if err != nil {
+		return fmt.Errorf("remote: listen %s: %w", addr, err)
+	}
+	b.mu.Lock()
+	b.listener = listener
+	b.mu.Unlock()
+	return b.Serve(listener)
+}
+
+// Close stops the listener started by ListenAndServeTLS, causing Serve to
+// return. Safe to call before serving or more than once.
+func (b *Bridge) Close() error {
+	b.mu.Lock()
+	listener := b.listener
+	b.mu.Unlock()
+	if listener != nil {
+		return listener.Close()
+	}
+	return nil
+}
+
+// Serve accepts connections from listener until it returns an error (e.g. it is
+// closed). Each connection is authenticated, then handed to the daemon's control
+// dispatch. Connections beyond MaxConnections are refused immediately.
+func (b *Bridge) Serve(listener net.Listener) error {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return err
+		}
+		select {
+		case b.sem <- struct{}{}:
+		default:
+			// At capacity: refuse fast (fail closed) rather than queueing.
+			b.logf("remote: refused connection (at capacity)")
+			_ = conn.Close()
+			continue
+		}
+		go func() {
+			defer func() { <-b.sem }()
+			b.handle(conn)
+		}()
+	}
+}
+
+// handle authenticates conn then drives the daemon dispatch. It always closes
+// conn (directly on a failed handshake, or via ServeConn on success).
+func (b *Bridge) handle(conn net.Conn) {
+	// Bound the auth handshake so a stalled peer cannot hold a connection slot.
+	_ = conn.SetDeadline(time.Now().Add(b.handshakeTimeout))
+	req, err := readAuthRequest(conn)
+	if err != nil {
+		_ = conn.Close()
+		return
+	}
+	if req.Version < b.minVersion {
+		b.deny(conn, "unsupported protocol version")
+		return
+	}
+	if err := b.auth.Authenticate(req.Token); err != nil {
+		b.deny(conn, "unauthorized")
+		return
+	}
+	if err := b.attest.Verify(req.Meta); err != nil {
+		b.deny(conn, "attestation failed")
+		return
+	}
+	if err := writeAuthResponse(conn, authResponse{OK: true, Version: daemon.ProtoVersion}); err != nil {
+		_ = conn.Close()
+		return
+	}
+	// Clear the handshake deadline: a session may stream for a long time.
+	_ = conn.SetDeadline(time.Time{})
+	b.server.ServeConn(conn) // performs the daemon handshake + one command, then closes conn
+}
+
+// deny rejects an unauthenticated connection after a small backoff (to slow
+// brute force). The reason is generic and never includes any token material.
+func (b *Bridge) deny(conn net.Conn, message string) {
+	if b.authFailDelay > 0 {
+		time.Sleep(b.authFailDelay)
+	}
+	_ = writeAuthResponse(conn, authResponse{OK: false, Message: message})
+	_ = conn.Close()
+}
+
+// ServerTLSConfig builds a server TLS config from a cert/key pair, refusing if
+// either is missing (TLS is mandatory for the remote bridge).
+func ServerTLSConfig(certFile, keyFile string) (*tls.Config, error) {
+	certFile = strings.TrimSpace(certFile)
+	keyFile = strings.TrimSpace(keyFile)
+	if certFile == "" || keyFile == "" {
+		return nil, errors.New("remote: a TLS cert and key are required for serve-remote")
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("remote: load TLS keypair: %w", err)
+	}
+	return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}, nil
+}

--- a/internal/daemon/remote/bridge_test.go
+++ b/internal/daemon/remote/bridge_test.go
@@ -1,0 +1,339 @@
+package remote
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/daemon"
+)
+
+// ---- fake daemon worker (the daemon's test fakes are unexported) -------------
+
+type fakeLines struct{ ch <-chan string }
+
+func (l fakeLines) Next() (string, bool, error) {
+	line, ok := <-l.ch
+	return line, ok, nil
+}
+
+type fakeWorker struct {
+	ch  chan string
+	pid int
+}
+
+func (w *fakeWorker) Stdout() daemon.Lines { return fakeLines{ch: w.ch} }
+func (w *fakeWorker) Wait() (int, error)   { return 0, nil }
+func (w *fakeWorker) Kill() error          { return nil }
+func (w *fakeWorker) Pid() int             { return w.pid }
+
+// staticLauncher emits the given lines then ends the stream.
+func staticLauncher(lines ...string) daemon.Launcher {
+	return func(_ context.Context, _ daemon.WorkerSpec) (daemon.WorkerHandle, error) {
+		ch := make(chan string, len(lines))
+		for _, l := range lines {
+			ch <- l
+		}
+		close(ch)
+		return &fakeWorker{ch: ch, pid: 1}, nil
+	}
+}
+
+// blockingLauncher returns a worker whose stream stays open until release is
+// closed, so a session (and its bridge connection slot) is held open.
+func blockingLauncher(release <-chan struct{}) daemon.Launcher {
+	return func(_ context.Context, _ daemon.WorkerSpec) (daemon.WorkerHandle, error) {
+		ch := make(chan string)
+		go func() {
+			<-release
+			close(ch)
+		}()
+		return &fakeWorker{ch: ch, pid: 1}, nil
+	}
+}
+
+func newBridgeServer(t *testing.T, launcher daemon.Launcher) *daemon.Server {
+	t.Helper()
+	dir := t.TempDir()
+	pool, err := daemon.NewPool(daemon.PoolOptions{Size: 4, Launcher: launcher, KillTimeout: 200 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	mgr, err := daemon.NewSessionManager(daemon.SessionManagerOptions{Pool: pool})
+	if err != nil {
+		t.Fatalf("NewSessionManager: %v", err)
+	}
+	srv, err := daemon.NewServer(daemon.ServerOptions{
+		Paths:   daemon.Paths{Socket: filepath.Join(dir, "s.sock"), Lock: filepath.Join(dir, "s.lock"), Status: filepath.Join(dir, "s.status")},
+		Manager: mgr,
+		Pool:    pool,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(srv.Shutdown)
+	return srv
+}
+
+// genTestCert writes a self-signed cert/key (valid for 127.0.0.1) to temp files.
+func genTestCert(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "zero-remote-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:         true,
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	certOut, _ := os.Create(certFile)
+	_ = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	_ = certOut.Close()
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyOut, _ := os.Create(keyFile)
+	_ = pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	_ = keyOut.Close()
+	return certFile, keyFile
+}
+
+// startBridge starts a TLS bridge on 127.0.0.1:0 and returns its address + cert.
+func startBridge(t *testing.T, srv *daemon.Server, opts BridgeOptions) (addr, caCert string) {
+	t.Helper()
+	certFile, keyFile := genTestCert(t)
+	tlsConfig, err := ServerTLSConfig(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("ServerTLSConfig: %v", err)
+	}
+	opts.Server = srv
+	bridge, err := NewBridge(opts)
+	if err != nil {
+		t.Fatalf("NewBridge: %v", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tlsLn := tls.NewListener(ln, tlsConfig)
+	go func() { _ = bridge.Serve(tlsLn) }()
+	t.Cleanup(func() { _ = tlsLn.Close() })
+	return ln.Addr().String(), certFile
+}
+
+func TestBridgeRunStatusRoundTrip(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher(`{"type":"event","seq":1}`, `{"type":"event","seq":2}`))
+	auth, _ := NewTokenAuthenticator("tok")
+	addr, ca := startBridge(t, srv, BridgeOptions{Authenticator: auth})
+
+	client, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca})
+	if err != nil {
+		t.Fatalf("DialRemote: %v", err)
+	}
+	var got []string
+	if err := client.Run("sess-1", "", "hello", nil, func(l string) { got = append(got, l) }); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	_ = client.Close()
+	if len(got) != 2 || got[0] != `{"type":"event","seq":1}` {
+		t.Fatalf("run output = %v", got)
+	}
+
+	// Status over a fresh remote connection (same protocol as local).
+	statusClient, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca})
+	if err != nil {
+		t.Fatalf("DialRemote(status): %v", err)
+	}
+	report, err := statusClient.Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	_ = statusClient.Close()
+	if report == nil || report.PID == 0 {
+		t.Fatalf("status report = %+v", report)
+	}
+}
+
+func TestBridgeRejectsBadToken(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher())
+	auth, _ := NewTokenAuthenticator("correct")
+	addr, ca := startBridge(t, srv, BridgeOptions{Authenticator: auth, AuthFailDelay: -1})
+
+	_, err := DialRemote(RemoteConfig{Address: addr, Token: "wrong", CACertFile: ca})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("DialRemote(bad token) err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestBridgeRejectsLowVersion(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher())
+	auth, _ := NewTokenAuthenticator("tok")
+	// Require a version higher than the client speaks (daemon.ProtoVersion).
+	addr, ca := startBridge(t, srv, BridgeOptions{Authenticator: auth, MinVersion: daemon.ProtoVersion + 1, AuthFailDelay: -1})
+
+	_, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca})
+	if err == nil {
+		t.Fatal("DialRemote with a below-min version must be rejected")
+	}
+}
+
+func TestBridgeRequiresVerifiableCert(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher())
+	auth, _ := NewTokenAuthenticator("tok")
+	addr, _ := startBridge(t, srv, BridgeOptions{Authenticator: auth})
+	// No CA configured + a self-signed server cert => verification must fail
+	// (NEVER InsecureSkipVerify).
+	if _, err := DialRemote(RemoteConfig{Address: addr, Token: "tok"}); err == nil {
+		t.Fatal("DialRemote must reject an untrusted self-signed cert")
+	}
+}
+
+func TestListenAndServeTLSRequiresConfig(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher())
+	auth, _ := NewTokenAuthenticator("tok")
+	bridge, _ := NewBridge(BridgeOptions{Server: srv, Authenticator: auth})
+	if err := bridge.ListenAndServeTLS("127.0.0.1:0", nil); err == nil {
+		t.Fatal("ListenAndServeTLS(nil) must refuse to serve plaintext")
+	}
+}
+
+func TestListenAndServeTLSServesAndCloses(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher(`{"type":"event","seq":1}`))
+	auth, _ := NewTokenAuthenticator("tok")
+	certFile, keyFile := genTestCert(t)
+	tlsConfig, err := ServerTLSConfig(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("ServerTLSConfig: %v", err)
+	}
+	bridge, err := NewBridge(BridgeOptions{Server: srv, Authenticator: auth})
+	if err != nil {
+		t.Fatalf("NewBridge: %v", err)
+	}
+	// Bind an ephemeral port, discover it, then serve via ListenAndServeTLS by
+	// passing the same addr (it rebinds) — instead we bind here to learn the port
+	// and serve through the public entry on that exact address.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	addr := probe.Addr().String()
+	_ = probe.Close()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- bridge.ListenAndServeTLS(addr, tlsConfig) }()
+
+	// Wait until it accepts a connection, then drive one run.
+	var client *daemon.Client
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		client, err = DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: certFile, Timeout: 300 * time.Millisecond})
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bridge never came up: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	var got []string
+	if err := client.Run("s", "", "hi", nil, func(l string) { got = append(got, l) }); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	_ = client.Close()
+	if len(got) != 1 {
+		t.Fatalf("got %d lines, want 1", len(got))
+	}
+	// Close stops the accept loop.
+	if err := bridge.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	select {
+	case <-serveErr: // ListenAndServeTLS returned after Close
+	case <-time.After(2 * time.Second):
+		t.Fatal("ListenAndServeTLS did not return after Close")
+	}
+}
+
+func TestBridgeResumeAfterReconnect(t *testing.T) {
+	srv := newBridgeServer(t, staticLauncher(`{"type":"event","seq":1}`, `{"type":"event","seq":2}`))
+	auth, _ := NewTokenAuthenticator("tok")
+	addr, ca := startBridge(t, srv, BridgeOptions{Authenticator: auth})
+
+	// First connection runs the session to completion.
+	c1, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca})
+	if err != nil {
+		t.Fatalf("DialRemote 1: %v", err)
+	}
+	if err := c1.Run("sess-resume", "", "hi", nil, func(string) {}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	_ = c1.Close()
+
+	// A new connection re-attaches and replays the buffered session output —
+	// the dropped first connection did not lose the session.
+	c2, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca})
+	if err != nil {
+		t.Fatalf("DialRemote 2: %v", err)
+	}
+	defer c2.Close()
+	var replayed []string
+	if err := c2.Attach("sess-resume", func(l string) { replayed = append(replayed, l) }); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if len(replayed) != 2 {
+		t.Fatalf("re-attach replayed %d lines, want 2", len(replayed))
+	}
+}
+
+func TestBridgeConnectionCap(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	srv := newBridgeServer(t, blockingLauncher(release))
+	auth, _ := NewTokenAuthenticator("tok")
+	addr, ca := startBridge(t, srv, BridgeOptions{Authenticator: auth, MaxConnections: 1})
+
+	// First connection holds the only slot with a blocking run.
+	c1, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca})
+	if err != nil {
+		t.Fatalf("DialRemote 1: %v", err)
+	}
+	defer c1.Close()
+	runErr := make(chan error, 1)
+	go func() { runErr <- c1.Run("sess-block", "", "hi", nil, func(string) {}) }()
+
+	// Wait until the slot is in use, then a second dial must be refused.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c2, err := DialRemote(RemoteConfig{Address: addr, Token: "tok", CACertFile: ca, Timeout: 500 * time.Millisecond})
+		if err != nil {
+			return // refused as expected
+		}
+		_ = c2.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("second connection was not refused at the connection cap")
+}

--- a/internal/daemon/remote/bridge_test.go
+++ b/internal/daemon/remote/bridge_test.go
@@ -267,9 +267,12 @@ func TestListenAndServeTLSServesAndCloses(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("got %d lines, want 1", len(got))
 	}
-	// Close stops the accept loop.
+	// Close stops the accept loop; a second Close is a no-op (not an error).
 	if err := bridge.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
+	}
+	if err := bridge.Close(); err != nil {
+		t.Fatalf("second Close should be a no-op, got: %v", err)
 	}
 	select {
 	case <-serveErr: // ListenAndServeTLS returned after Close

--- a/internal/daemon/remote/client.go
+++ b/internal/daemon/remote/client.go
@@ -1,0 +1,101 @@
+package remote
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/daemon"
+)
+
+const defaultDialTimeout = 15 * time.Second
+
+// RemoteConfig configures a remote dial.
+type RemoteConfig struct {
+	// Address is host:port of the remote bridge (required).
+	Address string
+	// Token is the bearer token (required).
+	Token string
+	// CACertFile, when set, is the only CA trusted for the server cert (use for a
+	// self-signed bridge). Empty => system roots. InsecureSkipVerify is never used.
+	CACertFile string
+	// ServerName overrides the TLS/SNI verification name; empty => host of Address.
+	ServerName string
+	// Timeout bounds the dial + auth handshake; 0 => default.
+	Timeout time.Duration
+}
+
+// DialRemote establishes a verified TLS connection to a remote bridge,
+// authenticates with the bearer token, and returns a daemon.Client ready for
+// Run/Attach/Status — the same client the local socket uses, so remote and local
+// share one protocol. The server certificate is always verified (never
+// InsecureSkipVerify).
+func DialRemote(cfg RemoteConfig) (*daemon.Client, error) {
+	address := strings.TrimSpace(cfg.Address)
+	if address == "" {
+		return nil, errors.New("remote: address is required")
+	}
+	token := strings.TrimSpace(cfg.Token)
+	if token == "" {
+		return nil, errors.New("remote: a non-empty token is required")
+	}
+	tlsConfig, err := clientTLSConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultDialTimeout
+	}
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: timeout}, "tcp", address, tlsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("remote: dial %s: %w", address, err)
+	}
+	// Bound the auth handshake; the daemon handshake + stream run without a deadline.
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	if err := writeAuthRequest(conn, authRequest{Token: token, Version: daemon.ProtoVersion}); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("remote: send auth: %w", err)
+	}
+	resp, err := readAuthResponse(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("remote: auth handshake: %w", err)
+	}
+	if !resp.OK {
+		_ = conn.Close()
+		return nil, fmt.Errorf("%w: %s", ErrUnauthorized, resp.Message)
+	}
+	_ = conn.SetDeadline(time.Time{})
+	return daemon.NewClientConn(conn)
+}
+
+// clientTLSConfig builds a verifying client TLS config. It never disables
+// verification; for a self-signed bridge, set CACertFile to the bridge's cert.
+func clientTLSConfig(cfg RemoteConfig) (*tls.Config, error) {
+	tc := &tls.Config{MinVersion: tls.VersionTLS12}
+	serverName := strings.TrimSpace(cfg.ServerName)
+	if serverName == "" {
+		if host, _, err := net.SplitHostPort(cfg.Address); err == nil {
+			serverName = host
+		}
+	}
+	tc.ServerName = serverName
+	if ca := strings.TrimSpace(cfg.CACertFile); ca != "" {
+		pem, err := os.ReadFile(ca)
+		if err != nil {
+			return nil, fmt.Errorf("remote: read CA cert: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, errors.New("remote: CA cert file contained no certificates")
+		}
+		tc.RootCAs = pool
+	}
+	return tc, nil
+}

--- a/internal/daemon/remote/client.go
+++ b/internal/daemon/remote/client.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -52,7 +53,13 @@ func DialRemote(cfg RemoteConfig) (*daemon.Client, error) {
 	if timeout <= 0 {
 		timeout = defaultDialTimeout
 	}
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: timeout}, "tcp", address, tlsConfig)
+	// Context-aware TLS dial (tls.DialWithDialer is deprecated and not
+	// cancellation-aware). The context bounds the dial + TLS handshake only; the
+	// returned conn is independent of it for the subsequent auth/stream I/O.
+	dialCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	dialer := &tls.Dialer{NetDialer: &net.Dialer{}, Config: tlsConfig}
+	conn, err := dialer.DialContext(dialCtx, "tcp", address)
 	if err != nil {
 		return nil, fmt.Errorf("remote: dial %s: %w", address, err)
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -167,6 +167,13 @@ func (s *Server) writeStatusFile() error {
 	return nil
 }
 
+// ServeConn runs the control protocol (handshake + one command) on an
+// already-established connection, reusing the exact local dispatch path. The
+// remote bridge calls it AFTER authenticating a TLS connection, so a remote
+// session is handled identically to a local one (same SessionManager/Pool, same
+// sandbox/risk model) — remote never bypasses the local controls. It closes conn.
+func (s *Server) ServeConn(conn net.Conn) { s.handleConn(conn) }
+
 // handleConn performs the handshake then dispatches a single control command.
 func (s *Server) handleConn(conn net.Conn) {
 	defer conn.Close()

--- a/internal/swarm/mailbox.go
+++ b/internal/swarm/mailbox.go
@@ -378,6 +378,8 @@ func acquireLock(lockPath string, timeout time.Duration) (func(), error) {
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("swarm: timed out acquiring lock %s", filepath.Base(lockPath))
 		}
-		time.Sleep(20 * time.Millisecond)
+		// Short retry so a freed lock is re-acquired promptly under heavy
+		// contention (Windows file ops are slow; a coarse sleep starves waiters).
+		time.Sleep(2 * time.Millisecond)
 	}
 }

--- a/internal/swarm/mailbox_test.go
+++ b/internal/swarm/mailbox_test.go
@@ -246,10 +246,11 @@ func TestMailboxLockReleaseIsOwnershipAware(t *testing.T) {
 
 func TestMailboxConcurrentSends(t *testing.T) {
 	mb := newTestMailbox(t)
-	// High fan-out + a generous lock timeout so heavy contention is exercised
-	// (and a lock regression — e.g. a Windows sharing-violation treated as fatal —
-	// would surface as lost/failed messages here rather than flaking).
-	mb.LockTimeout = 10 * time.Second
+	// High fan-out exercises heavy contention (a lock regression — e.g. a Windows
+	// sharing-violation treated as fatal — surfaces as lost/failed messages here).
+	// The lock timeout is generous so a slow CI (Windows file ops are slow under
+	// 200-way contention) never times a legitimate send out and flakes.
+	mb.LockTimeout = 60 * time.Second
 	const n = 200
 	var wg sync.WaitGroup
 	var failures atomic.Int32


### PR DESCRIPTION
## Summary

Adds **`internal/daemon/remote`** — an **opt-in, TLS-only network bridge** on top of the local daemon (#203). A remote client drives the **same** `SessionManager`/`Pool` over the network behind bearer-token auth, reusing the daemon's framing + dispatch unchanged. The local Unix-socket daemon stays the default and is unchanged; nothing here activates unless `zero daemon serve-remote` is run.

This is the final completion-kit feature (sandbox → daemon → sandbox-completion → swarm → **daemon-remote**).

## What's included

- **Bridge** — per accepted TLS connection: authenticate, *then* hand to the daemon's control dispatch via a new `Server.ServeConn` seam. A remote session runs under the **same sandbox/risk model** as a local one — remote never bypasses local controls.
- **Authenticator + TokenAuthenticator** — constant-time bearer-token check; token from `$ZERO_DAEMON_REMOTE_TOKEN` or `$ZERO_DAEMON_REMOTE_TOKEN_FILE`; optional attestation hook (no-op default). Auth happens **before any control frame**; failure closes the connection after a small backoff; tokens are never logged.
- **RemoteClient (`DialRemote`)** — verified TLS dial (**never `InsecureSkipVerify`**) + auth handshake, then the existing `daemon.Client` via a new `NewClientConn` seam, so remote and local share one protocol.
- **CLI** — `zero daemon serve-remote --addr --tls-cert --tls-key`; `run`/`attach` gain `--remote <addr> [--token --ca-cert --server-name]`.

## Security (fail closed)

TLS mandatory (refuses to start without a cert/key) · auth-before-frames · constant-time token compare, never logged · configurable **min-protocol-version** floor · the daemon's **1 MiB frame cap** reused · **bounded concurrent connections** (overflow refused) · auth-fail backoff · server cert always verified.

## Daemon seams (additive, behavior unchanged)

`Server.ServeConn(conn)` and `NewClientConn(conn)` — tiny exported wrappers reused by the bridge/client. The local daemon path is otherwise untouched.

## Deferred (documented follow-ups)

`SessionLink` (POST session events to a configured endpoint with bounded retry) and git-bundle repo transfer — both optional per the kit; not needed for the core bridge.

## Verification

**Unit/integration tests** cover: auth accept/reject (env + file token), TLS-required, **cert verification** (untrusted self-signed rejected), version floor, run/status/attach round-trip, **re-attach resumption**, **connection cap**, `ListenAndServeTLS`/`Close`.

Gates: gofmt · vet · build (host + linux + **windows**) · `go test ./...` incl. `-race` · staticcheck (no new) · govulncheck (0) · deadcode (no new).

**Local run check (built binary):**
- `daemon serve-remote` binds TLS + the local socket;
- fail-closed paths verified live: no token / no cert / no `--addr` all rejected;
- over **real TLS-over-TCP**: wrong token → `unauthorized`; untrusted self-signed (no `--ca-cert`) → `failed to verify certificate`; **right token + `--ca-cert` → authenticated, dispatched, and a worker streamed `stream-json` back over the bridge** (only the expected "no provider configured" surfaced — downstream of this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `serve-remote` subcommand to start an opt-in secure remote control bridge for the daemon.
  * Added remote connectivity flags (`--remote`, `--token`, `--ca-cert`, `--server-name`) to `daemon run` and `daemon attach`, using TLS (TLS 1.2+) plus bearer-token authentication.
* **Bug Fixes**
  * Improved and standardized error messaging for remote vs local connection failures.
* **Tests**
  * Added coverage for remote auth, TLS/config validation, protocol version gating, and remote connection/session limits.
* **Chores**
  * Reduced daemon mailbox lock contention backoff interval; adjusted concurrent send test timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->