### PR TITLE
tui: migrate off deprecated Bubble Tea mouse Type API (SA1019)

### DIFF
--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -170,28 +170,28 @@ func (m model) syncMouseCapture() (model, tea.Cmd) {
 	return m, tea.DisableMouse
 }
 
-// Bubble Tea's Type field is deprecated, but its parser still populates it for
-// compatibility cases such as left-button drag events. Keep these helpers
-// tolerant of both the current Button/Action pair and legacy Type values.
+// Mouse classification uses the current Button/Action pair only. Bubble Tea's
+// parser always populates Button+Action and merely derives the deprecated Type
+// field from them, so checking Type adds nothing — and a left-button drag is
+// Action==Motion (which mouseMotion already covers), not a press.
 func mouseLeftPress(msg tea.MouseMsg) bool {
-	return msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress ||
-		msg.Type == tea.MouseLeft && msg.Action == tea.MouseActionPress
+	return msg.Button == tea.MouseButtonLeft && msg.Action == tea.MouseActionPress
 }
 
 func mouseMotion(msg tea.MouseMsg) bool {
-	return msg.Action == tea.MouseActionMotion || msg.Type == tea.MouseMotion
+	return msg.Action == tea.MouseActionMotion
 }
 
 func mouseRelease(msg tea.MouseMsg) bool {
-	return msg.Action == tea.MouseActionRelease || msg.Type == tea.MouseRelease
+	return msg.Action == tea.MouseActionRelease
 }
 
 func mouseWheelUp(msg tea.MouseMsg) bool {
-	return msg.Button == tea.MouseButtonWheelUp || msg.Type == tea.MouseWheelUp
+	return msg.Button == tea.MouseButtonWheelUp
 }
 
 func mouseWheelDown(msg tea.MouseMsg) bool {
-	return msg.Button == tea.MouseButtonWheelDown || msg.Type == tea.MouseWheelDown
+	return msg.Button == tea.MouseButtonWheelDown
 }
 
 func (m model) mouseOverComposer(msg tea.MouseMsg) bool {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -348,12 +348,11 @@ func TestTranscriptSelectionLeftDragDoesNotResetAnchor(t *testing.T) {
 		Y:      1,
 	})
 	m = updated.(model)
-	// Bubble Tea marks left-button drag motion as Type MouseLeft for backward
-	// compatibility; this must update the cursor without resetting the anchor.
+	// A left-button drag is Action==Motion with Button==Left; this must update the
+	// cursor without resetting the selection anchor.
 	updated, _ = m.Update(tea.MouseMsg{
 		Button: tea.MouseButtonLeft,
 		Action: tea.MouseActionMotion,
-		Type:   tea.MouseLeft,
 		X:      8,
 		Y:      1,
 	})


### PR DESCRIPTION
## Summary

Clears the **11 `SA1019`** deprecation findings in `internal/tui` (surfaced by the v16 audit) by migrating the mouse helpers off the deprecated `msg.Type` / `tea.MouseLeft|MouseMotion|MouseRelease|MouseWheelUp|MouseWheelDown` API to the current `Button`/`Action` pair.

## Why it's safe (no behavior change)
Bubble Tea's mouse parser **always** sets `Button`+`Action` as the source of truth and merely *derives* the deprecated `Type` field from them (`parseMouseButton`'s "backward compatibility" switch). So the `|| msg.Type == …` fallbacks in the five helpers were pure redundancy. In particular a left-button **drag** is reported as `Action==Motion` (with `Type` derived to `MouseLeft`), which `mouseMotion` already matches via `Action==Motion` — so dropping `Type` changes nothing.

- 5 helpers (`mouseLeftPress`, `mouseMotion`, `mouseRelease`, `mouseWheelUp`, `mouseWheelDown`) now use `Button`/`Action` only.
- The left-drag test drops the deprecated `Type:` field and asserts the `Action==Motion` path directly (its 1 SA1019 too).

## Verification
`staticcheck ./internal/tui/` SA1019 count: **11 → 0**. Existing mouse + transcript-selection tests pass under `-race`. gofmt · vet · build (host + linux + **windows**) · full `go test ./...` · deadcode (no new vs main) all green.

First of the audit-hygiene / remaining-backlog items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated event classification fallback logic, streamlining to use only current event fields.
  * Updated corresponding tests to reflect the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->