### PR TITLE
OAuth / account login for providers (OpenRouter, xAI) + subscription-proxy support

### DIFF
--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -41,26 +41,24 @@ Running `/provider` opens a **"How do you want to connect?"** chooser:
   Paste an API key / browse providers  Any of 20+ providers, local, or a proxy
 ```
 
-Pick **Sign in with OAuth** → a list of sign-in options → choose one:
+Pick **Sign in with OAuth** → the list of providers that do real OAuth → choose one:
 
 ```
 ❯ OpenRouter    browser sign-in · creates a key
   xAI (Grok)    browser or device code
-  ChatGPT       subscription · needs a local proxy
-  Claude        subscription · needs a local proxy
 ```
 
 - **OpenRouter / xAI** are real OAuth: your browser opens to approve → done (no
-  key to paste). OpenRouter mints a key; xAI stores a refreshable token.
+  key to paste). OpenRouter mints a key; xAI stores a refreshable token. The same
+  chooser appears in first-run onboarding.
 - **Device code (headless / SSH):** for a provider that supports it (xAI), press
   **d** on the list to get a code to enter on another device instead of opening a
   browser. On an SSH session or headless Linux box (no `DISPLAY`) device code is
   used automatically; set `ZERO_OAUTH_DEVICE=1` to force it anywhere. The CLI
   equivalent is `zero auth login xai --device`.
-- **ChatGPT / Claude** can't do in-app OAuth (see §2). Selecting them does **not**
-  fake a login — it drops you into the local-proxy setup (endpoint → model) with
-  the proxy defaults pre-filled, so you point Zero at a proxy you run. The same
-  first-run onboarding chooser offers the identical options.
+- **ChatGPT / Claude are intentionally not in this list** — they can't do in-app
+  OAuth (see §2). Use *Paste an API key / browse providers* + a local proxy
+  (`chatgpt-proxy` / `custom-anthropic-compatible`), as described below.
 
 ### Built-in OAuth providers (no env needed)
 

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -50,7 +50,8 @@ Pick **Sign in with OAuth** → the list of providers that do real OAuth → cho
 
 - **OpenRouter / xAI** are real OAuth: your browser opens to approve → done (no
   key to paste). OpenRouter mints a key; xAI stores a refreshable token. The same
-  chooser appears in first-run onboarding.
+  chooser appears in first-run onboarding. (xAI uses an opt-in preset — set
+  `ZERO_OAUTH_ALLOW_PRESETS=1` or your own `ZERO_OAUTH_XAI_*`; see below.)
 - **Device code (headless / SSH):** for a provider that supports it (xAI), press
   **d** on the list to get a code to enter on another device instead of opening a
   browser. On an SSH session or headless Linux box (no `DISPLAY`) device code is
@@ -60,20 +61,23 @@ Pick **Sign in with OAuth** → the list of providers that do real OAuth → cho
   OAuth (see §2). Use *Paste an API key / browse providers* + a local proxy
   (`chatgpt-proxy` / `custom-anthropic-compatible`), as described below.
 
-### Built-in OAuth providers (no env needed)
+### Built-in OAuth providers
 
-Two providers ship a working browser login out of the box:
-
-- **OpenRouter** — `zero auth openrouter` opens a browser, you approve, and it
-  **mints an OpenRouter API key** (public PKCE flow, no client_id). In the
-  interactive setup wizard, pick **OpenRouter** and press **ctrl+o** at the key
-  step to do the same inline ("Log in with OAuth"). The minted key is saved to the
-  provider profile and used normally.
-- **xAI (Grok)** — `zero auth login xai` (browser, or `--device` for headless).
-  The token is used directly on `api.x.ai/v1`; configure an `xai` provider profile
-  and it's picked up automatically. Requires a SuperGrok / X Premium+ subscription;
-  the client_id is an undocumented public Grok-CLI client (override via
-  `ZERO_OAUTH_XAI_*` if it changes).
+- **OpenRouter (no env needed)** — `zero auth openrouter` opens a browser, you
+  approve, and it **mints an OpenRouter API key** (public PKCE flow, no client_id).
+  In the interactive setup wizard, pick **OpenRouter** and press **ctrl+o** at the
+  key step to do the same inline ("Log in with OAuth"). The minted key is saved to
+  the provider profile and used normally.
+- **xAI (Grok) — opt-in preset** — xAI's flow needs an OAuth `client_id`. Zero
+  ships a built-in preset for the public Grok-CLI client, but to keep third-party
+  client identities out of the default credential path it is **off by default**.
+  Enable it with `export ZERO_OAUTH_ALLOW_PRESETS=1`, then `zero auth login xai`
+  (browser, or `--device` for headless) works one-click; the token is used directly
+  on `api.x.ai/v1`. Without the opt-in, set `ZERO_OAUTH_XAI_CLIENT_ID` (and
+  endpoints, or an issuer) yourself via `ZERO_OAUTH_XAI_*`. Either way the preset is
+  fully overridable by `ZERO_OAUTH_XAI_*` (env wins), and it requires a
+  SuperGrok / X Premium+ subscription; the client_id is an undocumented public
+  Grok-CLI client that may change without notice.
 
 Any field of a preset is overridable via `ZERO_OAUTH_<NAME>_*`. For a fully custom
 OAuth/OIDC provider, set those env vars (see `zero auth --help`) and

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -32,6 +32,25 @@ When a login exists for a provider, the **OpenAI and Anthropic** providers send
 before. Tokens are stored 0600 (or the OS keyring with
 `ZERO_OAUTH_STORAGE=keyring`) and never logged. See `zero auth --help`.
 
+### Built-in OAuth providers (no env needed)
+
+Two providers ship a working browser login out of the box:
+
+- **OpenRouter** — `zero auth openrouter` opens a browser, you approve, and it
+  **mints an OpenRouter API key** (public PKCE flow, no client_id). In the
+  interactive setup wizard, pick **OpenRouter** and press **ctrl+o** at the key
+  step to do the same inline ("Log in with OAuth"). The minted key is saved to the
+  provider profile and used normally.
+- **xAI (Grok)** — `zero auth login xai` (browser, or `--device` for headless).
+  The token is used directly on `api.x.ai/v1`; configure an `xai` provider profile
+  and it's picked up automatically. Requires a SuperGrok / X Premium+ subscription;
+  the client_id is an undocumented public Grok-CLI client (override via
+  `ZERO_OAUTH_XAI_*` if it changes).
+
+Any field of a preset is overridable via `ZERO_OAUTH_<NAME>_*`. For a fully custom
+OAuth/OIDC provider, set those env vars (see `zero auth --help`) and
+`zero auth login <name>`.
+
 ---
 
 ## 2. ChatGPT / Claude subscriptions — why a proxy is required

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -52,6 +52,11 @@ Pick **Sign in with OAuth** → a list of sign-in options → choose one:
 
 - **OpenRouter / xAI** are real OAuth: your browser opens to approve → done (no
   key to paste). OpenRouter mints a key; xAI stores a refreshable token.
+- **Device code (headless / SSH):** for a provider that supports it (xAI), press
+  **d** on the list to get a code to enter on another device instead of opening a
+  browser. On an SSH session or headless Linux box (no `DISPLAY`) device code is
+  used automatically; set `ZERO_OAUTH_DEVICE=1` to force it anywhere. The CLI
+  equivalent is `zero auth login xai --device`.
 - **ChatGPT / Claude** can't do in-app OAuth (see §2). Selecting them does **not**
   fake a login — it drops you into the local-proxy setup (endpoint → model) with
   the proxy defaults pre-filled, so you point Zero at a proxy you run. The same

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -100,13 +100,15 @@ We researched this carefully. As of mid-2026, a **subscription** OAuth token doe
   (`anthropic-beta: oauth-2025-04-20`, `claude-cli` UA, and a verbatim
   *"You are Claude Code…"* system prompt) — and **even then** tool-using requests
   on Max plans are routed to a disabled billing lane and `400`. Anthropic's policy
-  **explicitly prohibits** subscription-token use outside Claude Code / claude.ai:
-  a **Feb 19 2026** docs update clarified that Free/Pro/Max OAuth tokens may not be
-  used in third-party tools or the Agent SDK, and **since April 4 2026** Claude
-  subscriptions **no longer cover third-party-tool usage at all** (enforcement
-  began with OpenClaw in early 2026 and expanded to every third-party harness;
-  integrators must now use an API key with usage-based billing). The request to
-  allow it (claude-code #37205) was closed *"not planned."*
+  **prohibits** subscription-token use outside Claude Code / claude.ai, and the
+  timeline hardened through 2026: a **Feb 19 2026** docs update spelled out that
+  Free/Pro/Max OAuth tokens may not be used in third-party tools or the Agent SDK,
+  then on **April 4 2026** enforcement landed and subscription OAuth tokens
+  **stopped working in third-party harnesses** (starting with OpenClaw, then the
+  rest). As of mid-2026 the only supported ways to drive Claude from a third-party
+  tool are a standard **API key** or pay-as-you-go **"Extra Usage"** billing —
+  both per-token, not the flat subscription. The request to allow subscription use
+  (claude-code #37205) was closed *"not planned."*
 
 So Zero does **not** call those backends directly or spoof those clients — that
 would be fragile, account-risky, and (for Anthropic) against the vendor's terms.

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -32,6 +32,20 @@ When a login exists for a provider, the **OpenAI and Anthropic** providers send
 before. Tokens are stored 0600 (or the OS keyring with
 `ZERO_OAUTH_STORAGE=keyring`) and never logged. See `zero auth --help`.
 
+### In the setup wizard (`/provider`)
+
+Running `/provider` opens a **"How do you want to connect?"** chooser:
+
+```
+❯ Sign in with OAuth                 One-click browser login (OpenRouter, xAI)
+  Paste an API key / browse providers  Any of 20+ providers, local, or a proxy
+```
+
+Pick **Sign in with OAuth** → a list of OAuth-capable providers → choose one →
+your browser opens to approve → done (no key to paste). OpenRouter mints a key;
+xAI stores a refreshable token. ChatGPT/Claude aren't here (they can't do in-app
+OAuth) — use "browse" + the proxy setup below.
+
 ### Built-in OAuth providers (no env needed)
 
 Two providers ship a working browser login out of the box:

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -36,14 +36,14 @@ before. Tokens are stored 0600 (or the OS keyring with
 
 Running `/provider` opens a **"How do you want to connect?"** chooser:
 
-```
+```text
 ❯ Sign in with OAuth                 One-click browser login (OpenRouter, xAI)
   Paste an API key / browse providers  Any of 20+ providers, local, or a proxy
 ```
 
 Pick **Sign in with OAuth** → the list of providers that do real OAuth → choose one:
 
-```
+```text
 ❯ OpenRouter    browser sign-in · creates a key
   xAI (Grok)    browser or device code
 ```
@@ -95,10 +95,14 @@ We researched this carefully. As of mid-2026, a **subscription** OAuth token doe
   for third-party use unless the request spoofs the Claude Code identity
   (`anthropic-beta: oauth-2025-04-20`, `claude-cli` UA, and a verbatim
   *"You are Claude Code…"* system prompt) — and **even then** tool-using requests
-  on Max plans are routed to a disabled billing lane and `400`. Anthropic's Feb
-  2026 policy **explicitly prohibits** subscription-token use outside Claude
-  Code / claude.ai and has **actively enforced** it (account bans), and the
-  request to allow it (claude-code #37205) was closed *"not planned."*
+  on Max plans are routed to a disabled billing lane and `400`. Anthropic's policy
+  **explicitly prohibits** subscription-token use outside Claude Code / claude.ai:
+  a **Feb 19 2026** docs update clarified that Free/Pro/Max OAuth tokens may not be
+  used in third-party tools or the Agent SDK, and **since April 4 2026** Claude
+  subscriptions **no longer cover third-party-tool usage at all** (enforcement
+  began with OpenClaw in early 2026 and expanded to every third-party harness;
+  integrators must now use an API key with usage-based billing). The request to
+  allow it (claude-code #37205) was closed *"not planned."*
 
 So Zero does **not** call those backends directly or spoof those clients — that
 would be fragile, account-risky, and (for Anthropic) against the vendor's terms.

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -1,0 +1,127 @@
+# OAuth logins & using ChatGPT / Claude subscriptions
+
+Zero supports two distinct things people mean by "log in with OAuth":
+
+1. **OAuth login for a provider/gateway** that issues a *standard* bearer token —
+   fully built in (`zero auth login …`). Zero attaches the token to model calls
+   automatically.
+2. **Using a ChatGPT or Claude *subscription*** (Plus / Pro / Max) instead of a
+   pay-per-token API key — only possible through a **local proxy**, for the
+   reasons documented below. Zero ships a convenience preset and this recipe.
+
+---
+
+## 1. OAuth login for a provider or gateway (built in)
+
+For any OAuth 2.0 / OIDC provider that returns a normal access token usable as
+`Authorization: Bearer …` on its API, configure it with `ZERO_OAUTH_<NAME>_*`
+env vars and log in:
+
+```sh
+export ZERO_OAUTH_ACME_CLIENT_ID=…
+export ZERO_OAUTH_ACME_AUTHORIZE_URL=https://acme.example/oauth/authorize
+export ZERO_OAUTH_ACME_TOKEN_URL=https://acme.example/oauth/token
+export ZERO_OAUTH_ACME_SCOPES="openid profile"
+zero auth login acme            # browser (loopback); --device for headless
+zero auth status
+```
+
+When a login exists for a provider, the **OpenAI and Anthropic** providers send
+`Authorization: Bearer <fresh-token>` (auto-refreshed; one refresh-and-retry on a
+`401`) instead of the API key. With no login they use the API key exactly as
+before. Tokens are stored 0600 (or the OS keyring with
+`ZERO_OAUTH_STORAGE=keyring`) and never logged. See `zero auth --help`.
+
+---
+
+## 2. ChatGPT / Claude subscriptions — why a proxy is required
+
+We researched this carefully. As of mid-2026, a **subscription** OAuth token does
+**not** work as a drop-in bearer against the standard APIs:
+
+- **OpenAI (ChatGPT):** a "Sign in with ChatGPT" token only works against
+  ChatGPT's own backend (`chatgpt.com/backend-api/codex/responses`, the Responses
+  API), **not** `api.openai.com`. That backend is **Cloudflare bot-protected** —
+  non-browser / headless clients get `cf-mitigated: challenge` → `403`. It also
+  requires mimicking the official Codex client (originator + account-id header).
+- **Anthropic (Claude):** the Messages API **rejects** subscription OAuth tokens
+  for third-party use unless the request spoofs the Claude Code identity
+  (`anthropic-beta: oauth-2025-04-20`, `claude-cli` UA, and a verbatim
+  *"You are Claude Code…"* system prompt) — and **even then** tool-using requests
+  on Max plans are routed to a disabled billing lane and `400`. Anthropic's Feb
+  2026 policy **explicitly prohibits** subscription-token use outside Claude
+  Code / claude.ai and has **actively enforced** it (account bans), and the
+  request to allow it (claude-code #37205) was closed *"not planned."*
+
+So Zero does **not** call those backends directly or spoof those clients — that
+would be fragile, account-risky, and (for Anthropic) against the vendor's terms.
+The robust, supported pattern is a **local proxy** that holds your subscription
+session and exposes a clean OpenAI- or Anthropic-compatible endpoint on
+`127.0.0.1`. The proxy absorbs the Cloudflare / client-spoofing surface; Zero
+just points at it.
+
+### ChatGPT via a local proxy
+
+Run a local ChatGPT OAuth proxy that exposes an OpenAI-compatible endpoint (these
+typically listen on `127.0.0.1:10531/v1`). Then use the built-in **`chatgpt-proxy`**
+preset (no API key — the proxy authenticates):
+
+```jsonc
+// ~/.config/zero/config.json (or ./.zero/config.json)
+{
+  "activeProvider": "chatgpt",
+  "providers": [
+    {
+      "name": "chatgpt",
+      "catalogID": "chatgpt-proxy",     // OpenAI-compatible, local, no key
+      "baseURL": "http://localhost:10531/v1", // override for your proxy's port
+      "model": "gpt-5"                   // whatever model your proxy serves
+    }
+  ]
+}
+```
+
+```sh
+zero exec --prompt "say hi"   # routes through the proxy → your ChatGPT plan
+```
+
+### Claude via a local proxy
+
+There is no single canonical Claude OAuth-proxy port, so use the generic
+**`custom-anthropic-compatible`** entry pointed at your proxy's Anthropic-compatible
+endpoint:
+
+```jsonc
+{
+  "activeProvider": "claude",
+  "providers": [
+    {
+      "name": "claude",
+      "catalogID": "custom-anthropic-compatible",
+      "baseURL": "http://localhost:<port>",  // your Claude proxy
+      "apiKey": "unused-by-proxy",
+      "model": "claude-sonnet-4.5"
+    }
+  ]
+}
+```
+
+---
+
+## 3. Supported alternatives (no proxy)
+
+- **API key (recommended, simplest):** set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`
+  (or per-profile `apiKey`) and use the `openai` / `anthropic` catalog providers.
+  Bills as API usage.
+- **Anthropic subscription automation, sanctioned:** spawn the real `claude` CLI
+  (e.g. `claude -p …`) as a subprocess — the only path Anthropic recognizes as a
+  first-class subscription session.
+
+---
+
+## Notes
+
+- The `chatgpt-proxy` base URL / port and model are defaults you override for your
+  setup; they are not an endorsement of any specific proxy implementation.
+- Subscription-via-proxy depends on third-party tools and undocumented vendor
+  backends; it can break without notice. The API-key path is the stable one.

--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -41,10 +41,21 @@ Running `/provider` opens a **"How do you want to connect?"** chooser:
   Paste an API key / browse providers  Any of 20+ providers, local, or a proxy
 ```
 
-Pick **Sign in with OAuth** → a list of OAuth-capable providers → choose one →
-your browser opens to approve → done (no key to paste). OpenRouter mints a key;
-xAI stores a refreshable token. ChatGPT/Claude aren't here (they can't do in-app
-OAuth) — use "browse" + the proxy setup below.
+Pick **Sign in with OAuth** → a list of sign-in options → choose one:
+
+```
+❯ OpenRouter    browser sign-in · creates a key
+  xAI (Grok)    browser or device code
+  ChatGPT       subscription · needs a local proxy
+  Claude        subscription · needs a local proxy
+```
+
+- **OpenRouter / xAI** are real OAuth: your browser opens to approve → done (no
+  key to paste). OpenRouter mints a key; xAI stores a refreshable token.
+- **ChatGPT / Claude** can't do in-app OAuth (see §2). Selecting them does **not**
+  fake a login — it drops you into the local-proxy setup (endpoint → model) with
+  the proxy defaults pre-filled, so you point Zero at a proxy you run. The same
+  first-run onboarding chooser offers the identical options.
 
 ### Built-in OAuth providers (no env needed)
 

--- a/internal/browser/open.go
+++ b/internal/browser/open.go
@@ -1,0 +1,38 @@
+// Package browser opens a URL in the user's default web browser. It is used by
+// interactive flows (e.g. the provider setup wizard's OAuth login) that need to
+// hand the user off to a browser for authorization.
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// OpenURL launches url in the default browser. It returns once the launcher
+// process has started (it does not wait for the browser to close). A failure to
+// start the launcher is returned so callers can fall back to printing the URL.
+func OpenURL(url string) error {
+	name, args := openCommand(runtime.GOOS, url)
+	cmd := exec.Command(name, args...)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("browser: open url: %w", err)
+	}
+	// Reap the short-lived launcher (open/xdg-open/rundll32 exit promptly) so it
+	// does not linger as a zombie; the browser window itself is independent.
+	go func() { _ = cmd.Wait() }()
+	return nil
+}
+
+// openCommand returns the launcher command + args for a platform. Split out as a
+// pure function so the per-OS choice is unit-testable without spawning anything.
+func openCommand(goos, url string) (string, []string) {
+	switch goos {
+	case "darwin":
+		return "open", []string{url}
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default: // linux and other unixes
+		return "xdg-open", []string{url}
+	}
+}

--- a/internal/browser/open_test.go
+++ b/internal/browser/open_test.go
@@ -1,0 +1,27 @@
+package browser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOpenCommand(t *testing.T) {
+	cases := []struct {
+		goos string
+		name string
+		args []string
+	}{
+		{"darwin", "open", []string{"https://x.test"}},
+		{"linux", "xdg-open", []string{"https://x.test"}},
+		{"freebsd", "xdg-open", []string{"https://x.test"}},
+		{"windows", "rundll32", []string{"url.dll,FileProtocolHandler", "https://x.test"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			name, args := openCommand(tc.goos, "https://x.test")
+			if name != tc.name || !reflect.DeepEqual(args, tc.args) {
+				t.Fatalf("openCommand(%s) = %q %v, want %q %v", tc.goos, name, args, tc.name, tc.args)
+			}
+		})
+	}
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -105,7 +105,10 @@ func defaultAppDeps() appDeps {
 			return config.ResolveMCP(options)
 		},
 		newProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
-			return providers.New(profile, providers.Options{UserAgent: userAgent()})
+			return providers.New(profile, providers.Options{
+				UserAgent:     userAgent(),
+				OAuthResolver: oauthResolverForProfile(profile),
+			})
 		},
 		probeProviderHealth: providerhealth.Probe,
 		newSessionStore: func() *sessions.Store {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -355,8 +355,10 @@ Commands:
   refresh <provider> [--watch]                    Force a token refresh (--watch keeps it fresh)
   openrouter                                      Log in to OpenRouter in the browser; mints an API key
 
-A provider is any OAuth 2.0 / OIDC server you configure via env (no providers are
-built in). For a provider named <name>, set:
+A provider is any OAuth 2.0 / OIDC server. A few ship built-in presets you can use
+directly (e.g. "xai" via 'zero auth login xai'; "openrouter" via 'zero auth
+openrouter'); any preset field is overridable via the env vars below. For a custom
+provider named <name>, set:
   ZERO_OAUTH_<NAME>_CLIENT_ID       (required)
   ZERO_OAUTH_<NAME>_CLIENT_SECRET   (optional)
   ZERO_OAUTH_<NAME>_AUTHORIZE_URL   ZERO_OAUTH_<NAME>_TOKEN_URL

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -49,10 +49,15 @@ func runAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 // provider profile, while this command prints it for manual configuration.
 func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, _ appDeps) int {
 	for _, a := range args {
-		if a == "-h" || a == "--help" {
+		if a == "-h" || a == "--help" || a == "help" {
 			_ = writeAuthHelp(stdout)
 			return exitSuccess
 		}
+	}
+	// openrouter takes no positional args or flags; reject the unexpected so a
+	// typo/unsupported flag fails fast instead of silently running the login.
+	if len(args) > 0 {
+		return writeExecUsageError(stderr, fmt.Sprintf("zero auth openrouter takes no arguments (got %q)", args[0]))
 	}
 	key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 		Out:        stdout,
@@ -355,10 +360,11 @@ Commands:
   refresh <provider> [--watch]                    Force a token refresh (--watch keeps it fresh)
   openrouter                                      Log in to OpenRouter in the browser; mints an API key
 
-A provider is any OAuth 2.0 / OIDC server. A few ship built-in presets you can use
-directly (e.g. "xai" via 'zero auth login xai'; "openrouter" via 'zero auth
-openrouter'); any preset field is overridable via the env vars below. For a custom
-provider named <name>, set:
+A provider is any OAuth 2.0 / OIDC server. "openrouter" ('zero auth openrouter')
+works out of the box. "xai" ('zero auth login xai') uses a built-in preset that is
+off by default — enable it with ZERO_OAUTH_ALLOW_PRESETS=1, or set the
+ZERO_OAUTH_XAI_* vars yourself. Any preset field is overridable via the env vars
+below. For a custom provider named <name>, set:
   ZERO_OAUTH_<NAME>_CLIENT_ID       (required)
   ZERO_OAUTH_<NAME>_CLIENT_SECRET   (optional)
   ZERO_OAUTH_<NAME>_AUTHORIZE_URL   ZERO_OAUTH_<NAME>_TOKEN_URL

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/provideroauth"
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
@@ -34,9 +36,37 @@ func runAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return runAuthStatus(args[1:], stdout, stderr, deps)
 	case "refresh":
 		return runAuthRefresh(args[1:], stdout, stderr, deps)
+	case "openrouter":
+		return runAuthOpenRouter(args[1:], stdout, stderr, deps)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown auth subcommand %q", args[0]))
 	}
+}
+
+// runAuthOpenRouter runs OpenRouter's browser PKCE login and prints the freshly
+// minted API key. Unlike `auth login` (which stores an OAuth bearer token),
+// OpenRouter's flow mints a normal API key; the setup wizard saves it to a
+// provider profile, while this command prints it for manual configuration.
+func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, _ appDeps) int {
+	for _, a := range args {
+		if a == "-h" || a == "--help" {
+			_ = writeAuthHelp(stdout)
+			return exitSuccess
+		}
+	}
+	key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
+		Out:        stdout,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		// ZERO_OPENROUTER_BASE_URL overrides the endpoint (self-hosted gateway or tests).
+		BaseURL: strings.TrimSpace(os.Getenv("ZERO_OPENROUTER_BASE_URL")),
+	})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if _, err := fmt.Fprintf(stdout, "\nOpenRouter login complete — new API key minted.\nUse it with zero, e.g.:\n  export OPENROUTER_API_KEY=%s\n(or add it to a provider profile with catalogID \"openrouter\").\n", key); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
 }
 
 // authArgs is the parsed form of an auth subcommand's arguments.
@@ -323,6 +353,7 @@ Commands:
   logout <provider>                               Delete a provider's stored login
   status [provider]                               Show login presence/expiry (never the token)
   refresh <provider> [--watch]                    Force a token refresh (--watch keeps it fresh)
+  openrouter                                      Log in to OpenRouter in the browser; mints an API key
 
 A provider is any OAuth 2.0 / OIDC server you configure via env (no providers are
 built in). For a provider named <name>, set:

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -116,6 +116,21 @@ func TestRunAuthRejectsWrongFlags(t *testing.T) {
 	}
 }
 
+func TestRunAuthOpenRouterRejectsArgs(t *testing.T) {
+	withAuthStore(t)
+	var stdout, stderr bytes.Buffer
+	// An unexpected arg/flag must fail fast, not silently run the login.
+	if code := runWithDeps([]string{"auth", "openrouter", "--json"}, &stdout, &stderr, appDeps{}); code == exitSuccess {
+		t.Fatalf("openrouter with an unexpected flag should fail; stdout=%q", stdout.String())
+	}
+	// --help still works.
+	stdout.Reset()
+	stderr.Reset()
+	if code := runWithDeps([]string{"auth", "openrouter", "--help"}, &stdout, &stderr, appDeps{}); code != exitSuccess {
+		t.Fatalf("openrouter --help should succeed, stderr=%q", stderr.String())
+	}
+}
+
 func TestRunAuthHelp(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := runWithDeps([]string{"auth", "--help"}, &stdout, &stderr, appDeps{}); code != exitSuccess {

--- a/internal/cli/oauth_credential_test.go
+++ b/internal/cli/oauth_credential_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
+)
+
+func TestProviderHasOAuthLogin(t *testing.T) {
+	xai := config.ProviderProfile{Name: "xai", CatalogID: "xai"}
+	if providerHasOAuthLogin(xai, nil) {
+		t.Fatal("no stored login must be false")
+	}
+	if !providerHasOAuthLogin(xai, map[string]bool{"xai": true}) {
+		t.Fatal("a stored login keyed by name must be true")
+	}
+	if !providerHasOAuthLogin(config.ProviderProfile{Name: "grok", CatalogID: "xai"}, map[string]bool{"xai": true}) {
+		t.Fatal("a stored login keyed by catalog id must be true")
+	}
+}
+
+func TestSetupRequiredRecognizesOAuthLogin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tok.json")
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", path)
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(oauth.ProviderKey("xai"), oauth.Token{AccessToken: "tok", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	// xai has no inline key (env-only) but IS logged in via OAuth → no setup.
+	loggedIn := config.ResolvedConfig{Provider: config.ProviderProfile{Name: "xai", CatalogID: "xai", APIKeyEnv: "XAI_API_KEY"}}
+	if setupRequired(loggedIn) {
+		t.Fatal("a provider with a stored OAuth login must not require onboarding")
+	}
+
+	// A keyless provider with no OAuth login still requires setup.
+	noLogin := config.ResolvedConfig{Provider: config.ProviderProfile{Name: "openai", CatalogID: "openai", APIKeyEnv: "OPENAI_API_KEY"}}
+	if !setupRequired(noLogin) {
+		t.Fatal("a keyless provider with no OAuth login must require onboarding")
+	}
+}

--- a/internal/cli/oauth_provider.go
+++ b/internal/cli/oauth_provider.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+)
+
+// providerOAuthName resolves the OAuth login name for a provider profile. It is
+// the name a user logs in under (`zero auth login <name>`) whose token then
+// authenticates this provider's model calls. For now it is the profile name;
+// the provider presets map well-known kinds (openai/anthropic) to canonical
+// names on top of this.
+func providerOAuthName(profile config.ProviderProfile) string {
+	return strings.TrimSpace(profile.Name)
+}
+
+// oauthResolverForProfile returns a TokenResolver that authenticates a provider's
+// model calls with the user's OAuth login, or nil when no login exists for this
+// provider. Returning nil for the no-login case keeps API-key users free of any
+// per-request store lookups: the resolver is only attached once a login is
+// present at construction time.
+func oauthResolverForProfile(profile config.ProviderProfile) providerio.TokenResolver {
+	name := providerOAuthName(profile)
+	if name == "" {
+		return nil
+	}
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return nil
+	}
+	key := oauth.ProviderKey(name)
+	if _, ok, loadErr := store.Load(key); loadErr != nil || !ok {
+		// No login (or an unreadable/invalid key) → API-key auth, no resolver.
+		return nil
+	}
+	manager, err := oauth.NewManager(oauth.ManagerOptions{
+		Store:      store,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	})
+	if err != nil {
+		return nil
+	}
+	return func(ctx context.Context, forceRefresh bool) (string, string, bool, error) {
+		var token string
+		var rerr error
+		if forceRefresh {
+			token, rerr = manager.Handle401(ctx, key)
+		} else {
+			token, rerr = manager.GetFresh(ctx, key)
+		}
+		if errors.Is(rerr, oauth.ErrNoToken) {
+			// The login was removed since construction → fall back to the API key.
+			return "", "", false, nil
+		}
+		if rerr != nil {
+			return "", "", false, rerr
+		}
+		return "Authorization", "Bearer " + token, true, nil
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/provideronboarding"
@@ -285,8 +286,45 @@ func setupRequired(resolved config.ResolvedConfig) bool {
 	if !config.HasProviderProfile(resolved.Provider) {
 		return true
 	}
-	_, missing := setupMissingCredentialEnv(resolved.Provider)
-	return missing
+	if _, missing := setupMissingCredentialEnv(resolved.Provider); !missing {
+		return false
+	}
+	// A stored OAuth login (e.g. `zero auth login xai`) is a credential too, even
+	// though the profile has no inline key / env var — so a logged-in provider
+	// must not trigger onboarding.
+	return !providerHasOAuthLogin(resolved.Provider, oauthLoggedInProviders())
+}
+
+// providerHasOAuthLogin reports whether a stored OAuth login exists for the
+// provider, keyed by its profile name or catalog id.
+func providerHasOAuthLogin(profile config.ProviderProfile, oauthLogins map[string]bool) bool {
+	for _, name := range []string{strings.TrimSpace(profile.Name), strings.TrimSpace(profile.CatalogID)} {
+		if name != "" && oauthLogins[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// oauthLoggedInProviders returns the set of provider names that have a stored
+// OAuth token, so credential checks recognize an OAuth login (not just inline
+// keys / env vars). Errors degrade to an empty set (no logins).
+func oauthLoggedInProviders() map[string]bool {
+	out := map[string]bool{}
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return out
+	}
+	statuses, err := store.Status(oauth.KeyPrefixProvider)
+	if err != nil {
+		return out
+	}
+	for _, status := range statuses {
+		if status.HasToken {
+			out[strings.TrimPrefix(status.Key, oauth.KeyPrefixProvider)] = true
+		}
+	}
+	return out
 }
 
 func formatSetupComplete(result tui.SetupResult) string {

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -2,12 +2,18 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 )
+
+// ErrNoToken reports that no token is stored for a key. Callers (e.g. a request
+// path that prefers OAuth but can fall back to an API key) match it with
+// errors.Is to distinguish "not logged in" from a real refresh failure.
+var ErrNoToken = errors.New("oauth: no stored token")
 
 // defaultRefreshBuffer refreshes a token this long before its hard expiry.
 const defaultRefreshBuffer = 60 * time.Second
@@ -255,7 +261,7 @@ func (m *Manager) loadForKey(key string) (Token, Config, error) {
 		return Token{}, Config{}, err
 	}
 	if !ok {
-		return Token{}, Config{}, fmt.Errorf("oauth: no stored token for %q", key)
+		return Token{}, Config{}, fmt.Errorf("%w for %q", ErrNoToken, key)
 	}
 	name := strings.TrimPrefix(key, KeyPrefixProvider)
 	if name == key {

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -145,11 +145,20 @@ func (m *Manager) PrepareDeviceLogin(ctx context.Context, opts LoginOptions) (De
 	if len(opts.ExtraScopes) > 0 {
 		cfg.Scopes = append(append([]string{}, cfg.Scopes...), opts.ExtraScopes...)
 	}
-	cfg, err = m.resolveEndpoints(ctx, cfg)
+	// Self-bound the network prepare (endpoint discovery + device-code request) the
+	// same way Login does, so a caller that hands in an unbounded context still gets
+	// the timeout guarantee instead of a hang.
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	prepCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	cfg, err = m.resolveEndpoints(prepCtx, cfg)
 	if err != nil {
 		return DeviceAuth{}, Config{}, err
 	}
-	auth, err := RequestDeviceCode(ctx, m.client, cfg, m.now)
+	auth, err := RequestDeviceCode(prepCtx, m.client, cfg, m.now)
 	if err != nil {
 		return DeviceAuth{}, Config{}, err
 	}
@@ -160,6 +169,14 @@ func (m *Manager) PrepareDeviceLogin(ctx context.Context, opts LoginOptions) (De
 // stores it under "provider:<name>", returning a redaction-safe status. Pass the
 // cfg and auth returned by PrepareDeviceLogin.
 func (m *Manager) CompleteDeviceLogin(ctx context.Context, provider string, cfg Config, auth DeviceAuth) (Status, error) {
+	// Bound the poll by the device code's own expiry so an unbounded caller context
+	// cannot leave an in-flight request hanging past the code's lifetime. PollDeviceToken
+	// re-checks ExpiresAt between polls; the deadline also caps each individual request.
+	if !auth.ExpiresAt.IsZero() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, auth.ExpiresAt)
+		defer cancel()
+	}
 	token, err := PollDeviceToken(ctx, m.client, cfg, auth, m.now)
 	if err != nil {
 		return Status{}, err

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -132,6 +132,45 @@ func (m *Manager) Login(ctx context.Context, opts LoginOptions) (Status, error) 
 	return m.statusFor(key)
 }
 
+// PrepareDeviceLogin resolves the provider config and requests an RFC 8628
+// device code, returning the user-facing DeviceAuth (verification URI + user
+// code) and the resolved config. It is split from the token poll
+// (CompleteDeviceLogin) so a UI can display the code to the user while waiting
+// for authorization. The CLI's monolithic Login(Device:true) is unaffected.
+func (m *Manager) PrepareDeviceLogin(ctx context.Context, opts LoginOptions) (DeviceAuth, Config, error) {
+	cfg, _, err := m.registry.ResolveConfig(opts.Provider, m.env)
+	if err != nil {
+		return DeviceAuth{}, Config{}, err
+	}
+	if len(opts.ExtraScopes) > 0 {
+		cfg.Scopes = append(append([]string{}, cfg.Scopes...), opts.ExtraScopes...)
+	}
+	cfg, err = m.resolveEndpoints(ctx, cfg)
+	if err != nil {
+		return DeviceAuth{}, Config{}, err
+	}
+	auth, err := RequestDeviceCode(ctx, m.client, cfg, m.now)
+	if err != nil {
+		return DeviceAuth{}, Config{}, err
+	}
+	return auth, cfg, nil
+}
+
+// CompleteDeviceLogin polls for the token authorized via PrepareDeviceLogin and
+// stores it under "provider:<name>", returning a redaction-safe status. Pass the
+// cfg and auth returned by PrepareDeviceLogin.
+func (m *Manager) CompleteDeviceLogin(ctx context.Context, provider string, cfg Config, auth DeviceAuth) (Status, error) {
+	token, err := PollDeviceToken(ctx, m.client, cfg, auth, m.now)
+	if err != nil {
+		return Status{}, err
+	}
+	key := ProviderKey(provider)
+	if err := m.store.Save(key, token); err != nil {
+		return Status{}, err
+	}
+	return m.statusFor(key)
+}
+
 // resolveEndpoints fills missing authorize/token/device endpoints from issuer
 // discovery (RFC 8414 then OIDC), leaving any explicitly-pinned endpoint intact.
 func (m *Manager) resolveEndpoints(ctx context.Context, cfg Config) (Config, error) {

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -286,7 +286,7 @@ func (m *Manager) GetFresh(ctx context.Context, key string) (string, error) {
 	if !token.NeedsRefresh(m.now(), m.buffer) {
 		return token.AccessToken, nil
 	}
-	cfg, err := m.resolveConfigForKey(key)
+	cfg, err := m.resolveConfigForKey(ctx, key)
 	if err != nil {
 		return "", err
 	}
@@ -300,7 +300,7 @@ func (m *Manager) Handle401(ctx context.Context, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cfg, err := m.resolveConfigForKey(key)
+	cfg, err := m.resolveConfigForKey(ctx, key)
 	if err != nil {
 		return "", err
 	}
@@ -337,12 +337,19 @@ func (m *Manager) loadToken(key string) (Token, error) {
 // resolveConfigForKey resolves the provider OAuth config for a provider-token key.
 // It is only needed to refresh a token (the endpoints + client identity), not to
 // read one.
-func (m *Manager) resolveConfigForKey(key string) (Config, error) {
+func (m *Manager) resolveConfigForKey(ctx context.Context, key string) (Config, error) {
 	name := strings.TrimPrefix(key, KeyPrefixProvider)
 	if name == key {
 		return Config{}, fmt.Errorf("oauth: refresh is only supported for provider tokens (got %q)", key)
 	}
 	cfg, _, err := m.registry.ResolveConfig(name, m.env)
+	if err != nil {
+		return Config{}, err
+	}
+	// Fill any missing token/authorize/device endpoints from issuer discovery so a
+	// provider configured with only ZERO_OAUTH_<NAME>_ISSUER_URL can still refresh
+	// (refreshAndSave requires the token endpoint).
+	cfg, err = m.resolveEndpoints(ctx, cfg)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/oauth/manager.go
+++ b/internal/oauth/manager.go
@@ -276,12 +276,19 @@ func (m *Manager) loginDevice(ctx context.Context, cfg Config) (Token, error) {
 // stored token is expired or within the refresh buffer. Mirrors
 // checkAndRefreshOAuthTokenIfNeeded.
 func (m *Manager) GetFresh(ctx context.Context, key string) (string, error) {
-	token, cfg, err := m.loadForKey(key)
+	token, err := m.loadToken(key)
 	if err != nil {
 		return "", err
 	}
+	// A still-valid token is returned without resolving the provider config, so a
+	// readable login never depends on config that is only needed to refresh (e.g.
+	// an opt-in preset client_id). Only an actual refresh resolves endpoints.
 	if !token.NeedsRefresh(m.now(), m.buffer) {
 		return token.AccessToken, nil
+	}
+	cfg, err := m.resolveConfigForKey(key)
+	if err != nil {
+		return "", err
 	}
 	return m.refreshAndSave(ctx, key, cfg, token)
 }
@@ -289,7 +296,11 @@ func (m *Manager) GetFresh(ctx context.Context, key string) (string, error) {
 // Handle401 forces a refresh after an upstream 401, returning the new access
 // token. Mirrors handleOAuth401Error.
 func (m *Manager) Handle401(ctx context.Context, key string) (string, error) {
-	token, cfg, err := m.loadForKey(key)
+	token, err := m.loadToken(key)
+	if err != nil {
+		return "", err
+	}
+	cfg, err := m.resolveConfigForKey(key)
 	if err != nil {
 		return "", err
 	}
@@ -307,27 +318,35 @@ func (m *Manager) refreshAndSave(ctx context.Context, key string, cfg Config, cu
 	return refreshed.AccessToken, nil
 }
 
-// loadForKey loads a stored token and resolves the provider config for its key.
-func (m *Manager) loadForKey(key string) (Token, Config, error) {
+// loadToken loads a stored token for key without resolving any provider config,
+// so reading a still-valid login never depends on refresh-only configuration.
+func (m *Manager) loadToken(key string) (Token, error) {
 	if err := ValidateKey(key); err != nil {
-		return Token{}, Config{}, err
+		return Token{}, err
 	}
 	token, ok, err := m.store.Load(key)
 	if err != nil {
-		return Token{}, Config{}, err
+		return Token{}, err
 	}
 	if !ok {
-		return Token{}, Config{}, fmt.Errorf("%w for %q", ErrNoToken, key)
+		return Token{}, fmt.Errorf("%w for %q", ErrNoToken, key)
 	}
+	return token, nil
+}
+
+// resolveConfigForKey resolves the provider OAuth config for a provider-token key.
+// It is only needed to refresh a token (the endpoints + client identity), not to
+// read one.
+func (m *Manager) resolveConfigForKey(key string) (Config, error) {
 	name := strings.TrimPrefix(key, KeyPrefixProvider)
 	if name == key {
-		return Token{}, Config{}, fmt.Errorf("oauth: refresh is only supported for provider tokens (got %q)", key)
+		return Config{}, fmt.Errorf("oauth: refresh is only supported for provider tokens (got %q)", key)
 	}
 	cfg, _, err := m.registry.ResolveConfig(name, m.env)
 	if err != nil {
-		return Token{}, Config{}, err
+		return Config{}, err
 	}
-	return token, cfg, nil
+	return cfg, nil
 }
 
 // Logout removes a provider's stored token, reporting whether one was present.

--- a/internal/oauth/manager_test.go
+++ b/internal/oauth/manager_test.go
@@ -141,6 +141,41 @@ func TestManagerPrepareAndCompleteDeviceLogin(t *testing.T) {
 	}
 }
 
+// A provider configured with only an issuer URL (no TOKEN_URL) must still be
+// refreshable: GetFresh resolves the token endpoint via discovery before
+// refreshing. Guards resolveConfigForKey calling resolveEndpoints.
+func TestManagerGetFreshDiscoversIssuerEndpoints(t *testing.T) {
+	var tokenHits int32
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"issuer":"`+server.URL+`","token_endpoint":"`+server.URL+`/token","authorization_endpoint":"`+server.URL+`/authorize"}`)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&tokenHits, 1)
+		_, _ = io.WriteString(w, `{"access_token":"refreshed-at","token_type":"Bearer","expires_in":3600}`)
+	})
+	env := map[string]string{
+		"ZERO_OAUTH_ISSUERONLY_CLIENT_ID":  "client",
+		"ZERO_OAUTH_ISSUERONLY_ISSUER_URL": server.URL, // no TOKEN_URL → discovered
+	}
+	m := managerFor(t, env, nil)
+	if err := m.store.Save(ProviderKey("issueronly"), Token{AccessToken: "stale", RefreshToken: "rt", ExpiresAt: time.Now().Add(-time.Hour)}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got, err := m.GetFresh(context.Background(), ProviderKey("issueronly"))
+	if err != nil {
+		t.Fatalf("GetFresh (issuer-only) must discover the token endpoint and refresh: %v", err)
+	}
+	if got != "refreshed-at" {
+		t.Fatalf("access = %q, want refreshed-at", got)
+	}
+	if atomic.LoadInt32(&tokenHits) == 0 {
+		t.Fatal("token endpoint never hit — discovery/refresh did not run")
+	}
+}
+
 func TestManagerGetFreshRefreshesExpired(t *testing.T) {
 	fp := newFakeProvider(t, `{"access_token":"fresh-at","expires_in":3600}`)
 	env := map[string]string{

--- a/internal/oauth/manager_test.go
+++ b/internal/oauth/manager_test.go
@@ -106,6 +106,41 @@ func TestManagerLoginDevice(t *testing.T) {
 	}
 }
 
+func TestManagerPrepareAndCompleteDeviceLogin(t *testing.T) {
+	fp := newFakeProvider(t, `{"access_token":"two-phase-at","token_type":"Bearer","expires_in":3600}`)
+	env := map[string]string{
+		"ZERO_OAUTH_DEMO2_CLIENT_ID":  "client",
+		"ZERO_OAUTH_DEMO2_TOKEN_URL":  fp.server.URL + "/token",
+		"ZERO_OAUTH_DEMO2_DEVICE_URL": fp.server.URL + "/device",
+	}
+	m := managerFor(t, env, nil)
+
+	// Phase 1: request the device code (what the UI displays to the user).
+	auth, cfg, err := m.PrepareDeviceLogin(context.Background(), LoginOptions{Provider: "demo2"})
+	if err != nil {
+		t.Fatalf("PrepareDeviceLogin: %v", err)
+	}
+	if auth.UserCode != "U-1" || auth.VerificationURI == "" {
+		t.Fatalf("device auth missing user code/uri: %+v", auth)
+	}
+
+	// Phase 2: poll for the token and persist it.
+	status, err := m.CompleteDeviceLogin(context.Background(), "demo2", cfg, auth)
+	if err != nil {
+		t.Fatalf("CompleteDeviceLogin: %v", err)
+	}
+	if !status.HasToken || status.Key != ProviderKey("demo2") {
+		t.Fatalf("status = %+v", status)
+	}
+	access, err := m.GetFresh(context.Background(), ProviderKey("demo2"))
+	if err != nil {
+		t.Fatalf("GetFresh: %v", err)
+	}
+	if access != "two-phase-at" {
+		t.Fatalf("access = %q, want two-phase-at", access)
+	}
+}
+
 func TestManagerGetFreshRefreshesExpired(t *testing.T) {
 	fp := newFakeProvider(t, `{"access_token":"fresh-at","expires_in":3600}`)
 	env := map[string]string{

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -14,9 +14,11 @@
 //   - Tokens, codes, and verifiers are never logged; error bodies are redacted.
 //   - Token files are 0600, base-confined, and file-locked.
 //
-// This package holds NO vendor secrets: provider client IDs and any overridable
-// endpoints come from config/env, so no third-party OAuth client identity is
-// baked into the binary.
+// This package holds NO vendor secrets: provider client IDs and endpoints come
+// from config/env by default, so no third-party OAuth client identity is used
+// unless the operator opts in. A small set of built-in presets (e.g. xAI's public
+// client) exists for convenience but is OFF by default and only consulted when
+// ZERO_OAUTH_ALLOW_PRESETS is set; env always overrides a preset.
 package oauth
 
 import (

--- a/internal/oauth/presets.go
+++ b/internal/oauth/presets.go
@@ -19,6 +19,13 @@ type providerPreset struct {
 
 // builtinOAuthPresets maps a provider name to its default OAuth config.
 //
+// These presets are OFF by default and only consulted when the operator opts in
+// with ZERO_OAUTH_ALLOW_PRESETS (see presetsAllowed). A preset carries a
+// third-party OAuth client identity, and the engine keeps such identities out of
+// the default credential path (see the package doc) — opting in is an explicit
+// acknowledgement that the binary's preset client_id will be used when no
+// ZERO_OAUTH_<NAME>_* override is set.
+//
 // xAI (Grok): the client_id is a PUBLIC client (no secret) used by several Grok
 // CLIs; its access token is accepted directly as a bearer on api.x.ai/v1 (an
 // OpenAI-compatible endpoint), so no header/identity spoofing is involved.
@@ -42,6 +49,18 @@ var builtinOAuthPresets = map[string]providerPreset{
 func lookupOAuthPreset(name string) (providerPreset, bool) {
 	preset, ok := builtinOAuthPresets[strings.ToLower(strings.TrimSpace(name))]
 	return preset, ok
+}
+
+// presetsAllowed reports whether baked-in OAuth presets may supply defaults. They
+// are OFF unless the operator opts in with ZERO_OAUTH_ALLOW_PRESETS set to a
+// truthy value, keeping any third-party OAuth client identity out of the default
+// credential path (a preset client_id is only ever used after explicit opt-in).
+func presetsAllowed(env map[string]string) bool {
+	switch strings.ToLower(strings.TrimSpace(envValue(env, "ZERO_OAUTH_ALLOW_PRESETS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // scopesOrPreset returns the env scopes (space-separated) when set, else the

--- a/internal/oauth/presets.go
+++ b/internal/oauth/presets.go
@@ -69,5 +69,6 @@ func scopesOrPreset(envScopes string, preset []string) []string {
 	if fields := strings.Fields(envScopes); len(fields) > 0 {
 		return fields
 	}
-	return preset
+	// Copy so a caller appending to cfg.Scopes can't mutate the shared preset slice.
+	return append([]string(nil), preset...)
 }

--- a/internal/oauth/presets.go
+++ b/internal/oauth/presets.go
@@ -1,0 +1,54 @@
+package oauth
+
+import "strings"
+
+// providerPreset is a baked-in default OAuth configuration for a well-known
+// provider. Every field is overridable per provider via ZERO_OAUTH_<NAME>_*
+// env vars (env wins). Only providers whose OAuth flow is verified to yield a
+// credential usable for model calls are listed here.
+type providerPreset struct {
+	ClientID                    string
+	ClientSecret                string
+	AuthorizationEndpoint       string
+	TokenEndpoint               string
+	DeviceAuthorizationEndpoint string
+	IssuerURL                   string
+	Scopes                      []string
+	Flow                        Flow
+}
+
+// builtinOAuthPresets maps a provider name to its default OAuth config.
+//
+// xAI (Grok): the client_id is a PUBLIC client (no secret) used by several Grok
+// CLIs; its access token is accepted directly as a bearer on api.x.ai/v1 (an
+// OpenAI-compatible endpoint), so no header/identity spoofing is involved.
+// CAVEATS: it is NOT formally documented by xAI as a public developer API and may
+// change without notice (override via ZERO_OAUTH_XAI_*), and using it requires a
+// SuperGrok / X Premium+ subscription. Pay-as-you-go users should use a console
+// API key instead.
+var builtinOAuthPresets = map[string]providerPreset{
+	"xai": {
+		ClientID:                    "b1a00492-073a-47ea-816f-4c329264a828",
+		AuthorizationEndpoint:       "https://auth.x.ai/oauth2/authorize",
+		TokenEndpoint:               "https://auth.x.ai/oauth2/token",
+		DeviceAuthorizationEndpoint: "https://auth.x.ai/oauth2/device/code",
+		IssuerURL:                   "https://auth.x.ai",
+		Scopes:                      []string{"openid", "profile", "email", "offline_access", "grok-cli:access", "api:access"},
+		Flow:                        FlowLoopback,
+	},
+}
+
+// lookupOAuthPreset returns the baked-in preset for a provider name (if any).
+func lookupOAuthPreset(name string) (providerPreset, bool) {
+	preset, ok := builtinOAuthPresets[strings.ToLower(strings.TrimSpace(name))]
+	return preset, ok
+}
+
+// scopesOrPreset returns the env scopes (space-separated) when set, else the
+// preset's scopes.
+func scopesOrPreset(envScopes string, preset []string) []string {
+	if fields := strings.Fields(envScopes); len(fields) > 0 {
+		return fields
+	}
+	return preset
+}

--- a/internal/oauth/presets_test.go
+++ b/internal/oauth/presets_test.go
@@ -1,0 +1,64 @@
+package oauth
+
+import "testing"
+
+func TestResolveConfigUsesXAIPreset(t *testing.T) {
+	r := NewRegistry()
+	// Non-nil empty env => no env vars (and no os.Getenv fallback), so the preset
+	// supplies everything.
+	cfg, flow, err := r.ResolveConfig("xai", map[string]string{})
+	if err != nil {
+		t.Fatalf("ResolveConfig(xai): %v", err)
+	}
+	if cfg.ClientID != "b1a00492-073a-47ea-816f-4c329264a828" {
+		t.Fatalf("client_id = %q", cfg.ClientID)
+	}
+	if cfg.AuthorizationEndpoint != "https://auth.x.ai/oauth2/authorize" {
+		t.Fatalf("authorize = %q", cfg.AuthorizationEndpoint)
+	}
+	if cfg.TokenEndpoint != "https://auth.x.ai/oauth2/token" {
+		t.Fatalf("token = %q", cfg.TokenEndpoint)
+	}
+	if cfg.DeviceAuthorizationEndpoint != "https://auth.x.ai/oauth2/device/code" {
+		t.Fatalf("device = %q", cfg.DeviceAuthorizationEndpoint)
+	}
+	if flow != FlowLoopback {
+		t.Fatalf("flow = %q, want loopback", flow)
+	}
+	if len(cfg.Scopes) == 0 {
+		t.Fatal("preset scopes should be populated")
+	}
+}
+
+func TestResolveConfigEnvOverridesPreset(t *testing.T) {
+	r := NewRegistry()
+	env := map[string]string{
+		"ZERO_OAUTH_XAI_CLIENT_ID": "custom-id",
+		"ZERO_OAUTH_XAI_SCOPES":    "alpha beta",
+		"ZERO_OAUTH_XAI_FLOW":      "device",
+	}
+	cfg, flow, err := r.ResolveConfig("xai", env)
+	if err != nil {
+		t.Fatalf("ResolveConfig(xai, env): %v", err)
+	}
+	if cfg.ClientID != "custom-id" {
+		t.Fatalf("env should override client_id, got %q", cfg.ClientID)
+	}
+	if len(cfg.Scopes) != 2 || cfg.Scopes[0] != "alpha" {
+		t.Fatalf("env should override scopes, got %v", cfg.Scopes)
+	}
+	if flow != FlowDevice {
+		t.Fatalf("env should override flow, got %q", flow)
+	}
+	// A field not overridden still comes from the preset.
+	if cfg.TokenEndpoint != "https://auth.x.ai/oauth2/token" {
+		t.Fatalf("non-overridden token endpoint = %q", cfg.TokenEndpoint)
+	}
+}
+
+func TestResolveConfigNoPresetStillRequiresEnv(t *testing.T) {
+	r := NewRegistry()
+	if _, _, err := r.ResolveConfig("acme-no-preset", map[string]string{}); err == nil {
+		t.Fatal("a provider with neither preset nor env config should error")
+	}
+}

--- a/internal/oauth/presets_test.go
+++ b/internal/oauth/presets_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+func TestScopesOrPresetReturnsACopy(t *testing.T) {
+	preset := []string{"openid", "profile"}
+	got := scopesOrPreset("", preset)
+	if len(got) != 2 || got[0] != "openid" {
+		t.Fatalf("got %v, want the preset scopes", got)
+	}
+	// Mutating the result must not bleed into the shared preset slice.
+	got[0] = "MUTATED"
+	if preset[0] != "openid" {
+		t.Fatalf("scopesOrPreset aliased the shared preset slice: %v", preset)
+	}
+}
+
 func TestResolveConfigUsesXAIPreset(t *testing.T) {
 	r := NewRegistry()
 	// Presets are opt-in; with ZERO_OAUTH_ALLOW_PRESETS set and no other env vars

--- a/internal/oauth/presets_test.go
+++ b/internal/oauth/presets_test.go
@@ -1,12 +1,15 @@
 package oauth
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestResolveConfigUsesXAIPreset(t *testing.T) {
 	r := NewRegistry()
-	// Non-nil empty env => no env vars (and no os.Getenv fallback), so the preset
-	// supplies everything.
-	cfg, flow, err := r.ResolveConfig("xai", map[string]string{})
+	// Presets are opt-in; with ZERO_OAUTH_ALLOW_PRESETS set and no other env vars
+	// the preset supplies everything.
+	cfg, flow, err := r.ResolveConfig("xai", map[string]string{"ZERO_OAUTH_ALLOW_PRESETS": "1"})
 	if err != nil {
 		t.Fatalf("ResolveConfig(xai): %v", err)
 	}
@@ -33,6 +36,7 @@ func TestResolveConfigUsesXAIPreset(t *testing.T) {
 func TestResolveConfigEnvOverridesPreset(t *testing.T) {
 	r := NewRegistry()
 	env := map[string]string{
+		"ZERO_OAUTH_ALLOW_PRESETS": "1",
 		"ZERO_OAUTH_XAI_CLIENT_ID": "custom-id",
 		"ZERO_OAUTH_XAI_SCOPES":    "alpha beta",
 		"ZERO_OAUTH_XAI_FLOW":      "device",
@@ -60,5 +64,19 @@ func TestResolveConfigNoPresetStillRequiresEnv(t *testing.T) {
 	r := NewRegistry()
 	if _, _, err := r.ResolveConfig("acme-no-preset", map[string]string{}); err == nil {
 		t.Fatal("a provider with neither preset nor env config should error")
+	}
+}
+
+// Without the opt-in flag the xAI preset must stay inert: no third-party client
+// identity is baked into the default credential path, and the error points the
+// user at the opt-in.
+func TestResolveConfigPresetInertWithoutOptIn(t *testing.T) {
+	r := NewRegistry()
+	_, _, err := r.ResolveConfig("xai", map[string]string{})
+	if err == nil {
+		t.Fatal("xai must not resolve from the preset unless ZERO_OAUTH_ALLOW_PRESETS is set")
+	}
+	if !strings.Contains(err.Error(), "ZERO_OAUTH_ALLOW_PRESETS") {
+		t.Fatalf("error should point at the opt-in, got: %v", err)
 	}
 }

--- a/internal/oauth/providers.go
+++ b/internal/oauth/providers.go
@@ -61,21 +61,29 @@ func (r *Registry) ResolveConfig(name string, env map[string]string) (Config, Fl
 	if err := ValidateProviderName(name); err != nil {
 		return Config{}, "", err
 	}
+	// A baked-in preset (if any) supplies defaults; each field is overridable by
+	// the matching ZERO_OAUTH_<NAME>_* env var (env wins).
+	preset, _ := lookupOAuthPreset(name)
 	cfg := Config{
-		ClientID:                    strings.TrimSpace(envValue(env, envKey(name, "CLIENT_ID"))),
-		ClientSecret:                strings.TrimSpace(envValue(env, envKey(name, "CLIENT_SECRET"))),
-		AuthorizationEndpoint:       strings.TrimSpace(envValue(env, envKey(name, "AUTHORIZE_URL"))),
-		TokenEndpoint:               strings.TrimSpace(envValue(env, envKey(name, "TOKEN_URL"))),
-		DeviceAuthorizationEndpoint: strings.TrimSpace(envValue(env, envKey(name, "DEVICE_URL"))),
-		IssuerURL:                   strings.TrimSpace(envValue(env, envKey(name, "ISSUER_URL"))),
-		Scopes:                      strings.Fields(envValue(env, envKey(name, "SCOPES"))),
+		ClientID:                    firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "CLIENT_ID"))), preset.ClientID),
+		ClientSecret:                firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "CLIENT_SECRET"))), preset.ClientSecret),
+		AuthorizationEndpoint:       firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "AUTHORIZE_URL"))), preset.AuthorizationEndpoint),
+		TokenEndpoint:               firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "TOKEN_URL"))), preset.TokenEndpoint),
+		DeviceAuthorizationEndpoint: firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "DEVICE_URL"))), preset.DeviceAuthorizationEndpoint),
+		IssuerURL:                   firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "ISSUER_URL"))), preset.IssuerURL),
+		Scopes:                      scopesOrPreset(envValue(env, envKey(name, "SCOPES")), preset.Scopes),
 	}
 	if cfg.ClientID == "" {
 		return Config{}, "", fmt.Errorf("oauth: provider %q is not configured; set %s (and its endpoints or an issuer)", name, envKey(name, "CLIENT_ID"))
 	}
 	var flow Flow
 	switch strings.ToLower(strings.TrimSpace(envValue(env, envKey(name, "FLOW")))) {
-	case "", string(FlowLoopback):
+	case "":
+		flow = preset.Flow
+		if flow == "" {
+			flow = FlowLoopback
+		}
+	case string(FlowLoopback):
 		flow = FlowLoopback
 	case string(FlowDevice):
 		flow = FlowDevice

--- a/internal/oauth/providers.go
+++ b/internal/oauth/providers.go
@@ -28,10 +28,11 @@ func ValidateProviderName(name string) error {
 	return nil
 }
 
-// Registry resolves a provider's Config from env/config. It ships NO built-in
-// providers, endpoints, or client identities: every provider is defined entirely
-// by the operator via ZERO_OAUTH_<NAME>_* variables, so no third-party brand or
-// OAuth client identity is baked into the binary.
+// Registry resolves a provider's Config from env/config. By default every provider
+// is defined entirely by the operator via ZERO_OAUTH_<NAME>_* variables, so no
+// third-party OAuth client identity is used. A small set of built-in presets
+// exists for convenience but stays inert unless the operator opts in with
+// ZERO_OAUTH_ALLOW_PRESETS (see presetsAllowed); env always overrides a preset.
 type Registry struct{}
 
 // NewRegistry returns the (stateless) env-driven registry.
@@ -61,9 +62,13 @@ func (r *Registry) ResolveConfig(name string, env map[string]string) (Config, Fl
 	if err := ValidateProviderName(name); err != nil {
 		return Config{}, "", err
 	}
-	// A baked-in preset (if any) supplies defaults; each field is overridable by
-	// the matching ZERO_OAUTH_<NAME>_* env var (env wins).
-	preset, _ := lookupOAuthPreset(name)
+	// A baked-in preset (if any) supplies defaults, but ONLY when the operator opts
+	// in with ZERO_OAUTH_ALLOW_PRESETS — otherwise no third-party client identity is
+	// used and every field must come from a ZERO_OAUTH_<NAME>_* env var (env wins).
+	var preset providerPreset
+	if presetsAllowed(env) {
+		preset, _ = lookupOAuthPreset(name)
+	}
 	cfg := Config{
 		ClientID:                    firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "CLIENT_ID"))), preset.ClientID),
 		ClientSecret:                firstNonEmpty(strings.TrimSpace(envValue(env, envKey(name, "CLIENT_SECRET"))), preset.ClientSecret),
@@ -74,7 +79,11 @@ func (r *Registry) ResolveConfig(name string, env map[string]string) (Config, Fl
 		Scopes:                      scopesOrPreset(envValue(env, envKey(name, "SCOPES")), preset.Scopes),
 	}
 	if cfg.ClientID == "" {
-		return Config{}, "", fmt.Errorf("oauth: provider %q is not configured; set %s (and its endpoints or an issuer)", name, envKey(name, "CLIENT_ID"))
+		hint := ""
+		if _, ok := lookupOAuthPreset(name); ok {
+			hint = " (or set ZERO_OAUTH_ALLOW_PRESETS=1 to use the built-in preset)"
+		}
+		return Config{}, "", fmt.Errorf("oauth: provider %q is not configured; set %s (and its endpoints or an issuer)%s", name, envKey(name, "CLIENT_ID"), hint)
 	}
 	var flow Flow
 	switch strings.ToLower(strings.TrimSpace(envValue(env, envKey(name, "FLOW")))) {

--- a/internal/oauth/scheduler.go
+++ b/internal/oauth/scheduler.go
@@ -50,7 +50,7 @@ func (s *RefreshScheduler) loop(ctx context.Context, m *Manager, key string, don
 	defer close(done)
 	loadErrors := 0
 	for {
-		token, _, err := m.loadForKey(key)
+		token, err := m.loadToken(key)
 		if err != nil {
 			// A load error may be transient (a concurrent store write, a brief I/O
 			// hiccup): back off and retry rather than permanently stopping proactive

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -263,7 +263,7 @@ func OAuthProviders() []Descriptor {
 	out := []Descriptor{}
 	for _, descriptor := range descriptors {
 		if descriptor.OAuth {
-			out = append(out, descriptor)
+			out = append(out, cloneDescriptor(descriptor))
 		}
 	}
 	return out

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -96,6 +96,13 @@ var descriptors = []Descriptor{
 	openAICompat("zai", "Z.ai", "https://open.bigmodel.cn/api/paas/v4", "glm-4.5", []string{"ZAI_API_KEY", "ZHIPU_API_KEY"}),
 	openAICompat("gitlawb-opengateway", "GitLawb OpenGateway", "https://gateway.gitlawb.com/v1", "gpt-4.1", []string{"GITLAWB_OPENGATEWAY_API_KEY"}, "gitlawb opengateway"),
 	openAICompat("atomic-chat", "Atomic Chat", "https://api.atomic.chat/v1", "gpt-4.1", []string{"ATOMIC_CHAT_API_KEY"}),
+	// ChatGPT subscription via a local OAuth proxy. A ChatGPT (Plus/Pro) OAuth
+	// token only works against ChatGPT's own backend (which is Cloudflare-gated to
+	// the official client), so zero does not call it directly; instead point this
+	// at a local proxy that holds the OAuth session and exposes an OpenAI-compatible
+	// endpoint. Local (no API key — the proxy authenticates); override the base URL
+	// for your proxy's port. See docs/oauth-subscriptions.md.
+	localOpenAI("chatgpt-proxy", "ChatGPT (local OAuth proxy)", "http://localhost:10531/v1", "gpt-5", "chatgpt"),
 	openAICompat("custom-openai-compatible", "Custom OpenAI-compatible", "https://example.invalid/v1", "custom-model", []string{"OPENAI_API_KEY"}, "custom openai compatible"),
 	anthropicCompat("custom-anthropic-compatible", "Custom Anthropic-compatible", "https://example.invalid/anthropic", "custom-model", []string{"ANTHROPIC_API_KEY"}, "custom anthropic compatible"),
 }

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -58,6 +58,12 @@ type Descriptor struct {
 	// OAuthDeviceFlow reports that RFC 8628 device-code login is supported (for
 	// headless / SSH use) in addition to the browser flow.
 	OAuthDeviceFlow bool
+	// OAuthProxy reports that this is a subscription-via-local-proxy provider
+	// (ChatGPT / Claude). It appears in the "Sign in with OAuth" chooser as a
+	// proxy entry that routes to local-proxy setup rather than a real OAuth login,
+	// because the vendor's subscription token is not usable as a standard bearer
+	// (Cloudflare-gated / ToS-restricted). See docs/oauth-subscriptions.md.
+	OAuthProxy bool
 }
 
 func RuntimeSupported(descriptor Descriptor) bool {
@@ -113,7 +119,13 @@ var descriptors = []Descriptor{
 	// at a local proxy that holds the OAuth session and exposes an OpenAI-compatible
 	// endpoint. Local (no API key — the proxy authenticates); override the base URL
 	// for your proxy's port. See docs/oauth-subscriptions.md.
-	localOpenAI("chatgpt-proxy", "ChatGPT (local OAuth proxy)", "http://localhost:10531/v1", "gpt-5", "chatgpt"),
+	oauthProxyProvider(localOpenAI("chatgpt-proxy", "ChatGPT (local OAuth proxy)", "http://localhost:10531/v1", "gpt-5", "chatgpt")),
+	// Claude (Pro/Max) subscription via a local Anthropic-compatible proxy. The
+	// same reasoning as chatgpt-proxy applies: a Claude subscription OAuth token is
+	// rejected/ToS-restricted for direct third-party use, so point this at a local
+	// proxy that holds the session. No API key (the proxy authenticates); override
+	// the base URL for your proxy's port. See docs/oauth-subscriptions.md.
+	oauthProxyProvider(localAnthropic("claude-proxy", "Claude (local OAuth proxy)", "http://localhost:8082", "claude-sonnet-4.5", "claude")),
 	openAICompat("custom-openai-compatible", "Custom OpenAI-compatible", "https://example.invalid/v1", "custom-model", []string{"OPENAI_API_KEY"}, "custom openai compatible"),
 	anthropicCompat("custom-anthropic-compatible", "Custom Anthropic-compatible", "https://example.invalid/anthropic", "custom-model", []string{"ANTHROPIC_API_KEY"}, "custom anthropic compatible"),
 }
@@ -256,6 +268,13 @@ func oauthProvider(descriptor Descriptor, mintsKey bool, deviceFlow bool) Descri
 	return descriptor
 }
 
+// oauthProxyProvider marks a descriptor as a subscription-via-local-proxy entry
+// (ChatGPT / Claude) shown in the OAuth chooser; see Descriptor.OAuthProxy.
+func oauthProxyProvider(descriptor Descriptor) Descriptor {
+	descriptor.OAuthProxy = true
+	return descriptor
+}
+
 // OAuthProviders returns the catalog descriptors that support an in-app OAuth
 // login, in catalog order. It is the single source of truth for the wizard's
 // dedicated "Sign in with OAuth" provider list.
@@ -269,8 +288,28 @@ func OAuthProviders() []Descriptor {
 	return out
 }
 
+// OAuthProxyProviders returns the subscription-via-local-proxy descriptors
+// (ChatGPT / Claude) in catalog order. They are listed in the OAuth chooser after
+// the real OAuth providers, routing to local-proxy setup instead of a login.
+func OAuthProxyProviders() []Descriptor {
+	out := []Descriptor{}
+	for _, descriptor := range descriptors {
+		if descriptor.OAuthProxy {
+			out = append(out, descriptor)
+		}
+	}
+	return out
+}
+
 func localOpenAI(id string, name string, baseURL string, model string, aliases ...string) Descriptor {
 	descriptor := openAICompat(id, name, baseURL, model, nil, aliases...)
+	descriptor.RequiresAuth = false
+	descriptor.Local = true
+	return descriptor
+}
+
+func localAnthropic(id string, name string, baseURL string, model string, aliases ...string) Descriptor {
+	descriptor := anthropicCompat(id, name, baseURL, model, nil, aliases...)
 	descriptor.RequiresAuth = false
 	descriptor.Local = true
 	return descriptor

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -47,6 +47,17 @@ type Descriptor struct {
 	Local               bool
 	SupportedAPIFormats []APIFormat
 	Aliases             []string
+
+	// OAuth reports that this provider offers an in-app OAuth login that yields a
+	// credential usable for model calls (browser PKCE and/or device code). Only
+	// set for providers where this actually works (not subscription-via-proxy).
+	OAuth bool
+	// OAuthMintsKey reports that the OAuth flow returns/mints a normal API key
+	// (e.g. OpenRouter) rather than a bearer token used directly.
+	OAuthMintsKey bool
+	// OAuthDeviceFlow reports that RFC 8628 device-code login is supported (for
+	// headless / SSH use) in addition to the browser flow.
+	OAuthDeviceFlow bool
 }
 
 func RuntimeSupported(descriptor Descriptor) bool {
@@ -77,7 +88,7 @@ var descriptors = []Descriptor{
 	openAICompat("ollama-cloud", "Ollama Cloud", "https://ollama.com/v1", "qwen3-coder:480b", []string{"OLLAMA_API_KEY"}, "ollama.com", "ollama cloud"),
 	localOpenAI("ollama", "Ollama Local", "http://localhost:11434/v1", "llama3.1", "ollama local"),
 	localOpenAI("lmstudio", "LM Studio", "http://localhost:1234/v1", "local-model", "lm-studio", "lm studio"),
-	openAICompat("openrouter", "OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-4.1", []string{"OPENROUTER_API_KEY"}),
+	oauthProvider(openAICompat("openrouter", "OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-4.1", []string{"OPENROUTER_API_KEY"}), true, false),
 	openAICompat("groq", "Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile", []string{"GROQ_API_KEY"}),
 	openAICompat("deepseek", "DeepSeek", "https://api.deepseek.com/v1", "deepseek-chat", []string{"DEEPSEEK_API_KEY"}),
 	openAICompat("together", "Together AI", "https://api.together.xyz/v1", "meta-llama/Llama-3.3-70B-Instruct-Turbo", []string{"TOGETHER_API_KEY"}),
@@ -89,7 +100,7 @@ var descriptors = []Descriptor{
 	openAICompat("github", "GitHub Models", "https://models.inference.ai.azure.com", "openai/gpt-4.1", []string{"GITHUB_TOKEN"}, "github-models"),
 	transportDescriptor("bedrock", "Amazon Bedrock", TransportBedrock, "https://bedrock-runtime.${AWS_REGION}.amazonaws.com", "anthropic.claude-3-5-sonnet-20241022-v2:0", []string{"AWS_ACCESS_KEY_ID", "AWS_PROFILE"}, []APIFormat{APIFormatBedrockConverse}, true),
 	transportDescriptor("vertex", "Vertex AI", TransportVertex, "https://aiplatform.googleapis.com", "gemini-2.5-pro", []string{"GOOGLE_APPLICATION_CREDENTIALS"}, []APIFormat{APIFormatVertexGenerateContent}, true),
-	openAICompat("xai", "xAI", "https://api.x.ai/v1", "grok-4", []string{"XAI_API_KEY"}),
+	oauthProvider(openAICompat("xai", "xAI", "https://api.x.ai/v1", "grok-4", []string{"XAI_API_KEY"}), false, true),
 	openAICompat("venice", "Venice AI", "https://api.venice.ai/api/v1", "qwen-2.5-qwq-32b", []string{"VENICE_API_KEY"}),
 	openAICompat("xiaomi-mimo", "Xiaomi MiMo", "https://api.mimo.xiaomi.com/openai/v1", "mimo-vl", []string{"MIMO_API_KEY", "XIAOMI_API_KEY"}, "xiaomi mimo"),
 	openAICompat("bankr", "Bankr", "https://api.bankr.bot/v1", "bankr-large", []string{"BANKR_API_KEY"}),
@@ -234,6 +245,28 @@ func google(id string, name string, baseURL string, model string, env []string, 
 		SupportedAPIFormats: []APIFormat{APIFormatGoogleGenerateContent},
 		Aliases:             aliases,
 	}
+}
+
+// oauthProvider marks a descriptor as OAuth-capable. mintsKey => the flow returns
+// an API key (OpenRouter); deviceFlow => RFC 8628 device code is also supported.
+func oauthProvider(descriptor Descriptor, mintsKey bool, deviceFlow bool) Descriptor {
+	descriptor.OAuth = true
+	descriptor.OAuthMintsKey = mintsKey
+	descriptor.OAuthDeviceFlow = deviceFlow
+	return descriptor
+}
+
+// OAuthProviders returns the catalog descriptors that support an in-app OAuth
+// login, in catalog order. It is the single source of truth for the wizard's
+// dedicated "Sign in with OAuth" provider list.
+func OAuthProviders() []Descriptor {
+	out := []Descriptor{}
+	for _, descriptor := range descriptors {
+		if descriptor.OAuth {
+			out = append(out, descriptor)
+		}
+	}
+	return out
 }
 
 func localOpenAI(id string, name string, baseURL string, model string, aliases ...string) Descriptor {

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -58,12 +58,6 @@ type Descriptor struct {
 	// OAuthDeviceFlow reports that RFC 8628 device-code login is supported (for
 	// headless / SSH use) in addition to the browser flow.
 	OAuthDeviceFlow bool
-	// OAuthProxy reports that this is a subscription-via-local-proxy provider
-	// (ChatGPT / Claude). It appears in the "Sign in with OAuth" chooser as a
-	// proxy entry that routes to local-proxy setup rather than a real OAuth login,
-	// because the vendor's subscription token is not usable as a standard bearer
-	// (Cloudflare-gated / ToS-restricted). See docs/oauth-subscriptions.md.
-	OAuthProxy bool
 }
 
 func RuntimeSupported(descriptor Descriptor) bool {
@@ -119,13 +113,7 @@ var descriptors = []Descriptor{
 	// at a local proxy that holds the OAuth session and exposes an OpenAI-compatible
 	// endpoint. Local (no API key — the proxy authenticates); override the base URL
 	// for your proxy's port. See docs/oauth-subscriptions.md.
-	oauthProxyProvider(localOpenAI("chatgpt-proxy", "ChatGPT (local OAuth proxy)", "http://localhost:10531/v1", "gpt-5", "chatgpt")),
-	// Claude (Pro/Max) subscription via a local Anthropic-compatible proxy. The
-	// same reasoning as chatgpt-proxy applies: a Claude subscription OAuth token is
-	// rejected/ToS-restricted for direct third-party use, so point this at a local
-	// proxy that holds the session. No API key (the proxy authenticates); override
-	// the base URL for your proxy's port. See docs/oauth-subscriptions.md.
-	oauthProxyProvider(localAnthropic("claude-proxy", "Claude (local OAuth proxy)", "http://localhost:8082", "claude-sonnet-4.5", "claude")),
+	localOpenAI("chatgpt-proxy", "ChatGPT (local OAuth proxy)", "http://localhost:10531/v1", "gpt-5", "chatgpt"),
 	openAICompat("custom-openai-compatible", "Custom OpenAI-compatible", "https://example.invalid/v1", "custom-model", []string{"OPENAI_API_KEY"}, "custom openai compatible"),
 	anthropicCompat("custom-anthropic-compatible", "Custom Anthropic-compatible", "https://example.invalid/anthropic", "custom-model", []string{"ANTHROPIC_API_KEY"}, "custom anthropic compatible"),
 }
@@ -268,13 +256,6 @@ func oauthProvider(descriptor Descriptor, mintsKey bool, deviceFlow bool) Descri
 	return descriptor
 }
 
-// oauthProxyProvider marks a descriptor as a subscription-via-local-proxy entry
-// (ChatGPT / Claude) shown in the OAuth chooser; see Descriptor.OAuthProxy.
-func oauthProxyProvider(descriptor Descriptor) Descriptor {
-	descriptor.OAuthProxy = true
-	return descriptor
-}
-
 // OAuthProviders returns the catalog descriptors that support an in-app OAuth
 // login, in catalog order. It is the single source of truth for the wizard's
 // dedicated "Sign in with OAuth" provider list.
@@ -288,28 +269,8 @@ func OAuthProviders() []Descriptor {
 	return out
 }
 
-// OAuthProxyProviders returns the subscription-via-local-proxy descriptors
-// (ChatGPT / Claude) in catalog order. They are listed in the OAuth chooser after
-// the real OAuth providers, routing to local-proxy setup instead of a login.
-func OAuthProxyProviders() []Descriptor {
-	out := []Descriptor{}
-	for _, descriptor := range descriptors {
-		if descriptor.OAuthProxy {
-			out = append(out, descriptor)
-		}
-	}
-	return out
-}
-
 func localOpenAI(id string, name string, baseURL string, model string, aliases ...string) Descriptor {
 	descriptor := openAICompat(id, name, baseURL, model, nil, aliases...)
-	descriptor.RequiresAuth = false
-	descriptor.Local = true
-	return descriptor
-}
-
-func localAnthropic(id string, name string, baseURL string, model string, aliases ...string) Descriptor {
-	descriptor := anthropicCompat(id, name, baseURL, model, nil, aliases...)
 	descriptor.RequiresAuth = false
 	descriptor.Local = true
 	return descriptor

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -33,6 +33,7 @@ var expectedCatalogIDs = []string{
 	"zai",
 	"gitlawb-opengateway",
 	"atomic-chat",
+	"chatgpt-proxy",
 	"custom-openai-compatible",
 	"custom-anthropic-compatible",
 }
@@ -220,7 +221,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -34,6 +34,7 @@ var expectedCatalogIDs = []string{
 	"gitlawb-opengateway",
 	"atomic-chat",
 	"chatgpt-proxy",
+	"claude-proxy",
 	"custom-openai-compatible",
 	"custom-anthropic-compatible",
 }
@@ -220,7 +221,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportGoogle:          {"google"},
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
-		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
+		TransportAnthropicCompat: {"minimax", "claude-proxy", "custom-anthropic-compatible"},
 		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
@@ -275,6 +276,40 @@ func TestReturnedDescriptorsAreCopies(t *testing.T) {
 	}
 	if next.AuthEnvVars[0] != "OPENAI_API_KEY" {
 		t.Fatalf("descriptor slices are shared, got %q", next.AuthEnvVars[0])
+	}
+}
+
+func TestOAuthProviderClassification(t *testing.T) {
+	oauthIDs := descriptorIDs(OAuthProviders())
+	if want := []string{"openrouter", "xai"}; !reflect.DeepEqual(oauthIDs, want) {
+		t.Fatalf("OAuthProviders() = %#v, want %#v", oauthIDs, want)
+	}
+	proxyIDs := descriptorIDs(OAuthProxyProviders())
+	if want := []string{"chatgpt-proxy", "claude-proxy"}; !reflect.DeepEqual(proxyIDs, want) {
+		t.Fatalf("OAuthProxyProviders() = %#v, want %#v", proxyIDs, want)
+	}
+
+	// Proxy entries must not claim real OAuth (no fake login), and real OAuth
+	// providers must not be flagged as proxies.
+	for _, id := range proxyIDs {
+		d, _ := Get(id)
+		if d.OAuth {
+			t.Fatalf("%q is a proxy entry but has OAuth=true", id)
+		}
+		if !d.Local || d.RequiresAuth {
+			t.Fatalf("%q proxy entry should be local and keyless, got Local=%v RequiresAuth=%v", id, d.Local, d.RequiresAuth)
+		}
+	}
+	for _, id := range oauthIDs {
+		if d, _ := Get(id); d.OAuthProxy {
+			t.Fatalf("%q is a real OAuth provider but flagged OAuthProxy", id)
+		}
+	}
+	if d, _ := Get("openrouter"); !d.OAuthMintsKey {
+		t.Fatal("openrouter should mint a key")
+	}
+	if d, _ := Get("xai"); !d.OAuthDeviceFlow {
+		t.Fatal("xai should advertise device-code flow")
 	}
 }
 

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -34,7 +34,6 @@ var expectedCatalogIDs = []string{
 	"gitlawb-opengateway",
 	"atomic-chat",
 	"chatgpt-proxy",
-	"claude-proxy",
 	"custom-openai-compatible",
 	"custom-anthropic-compatible",
 }
@@ -221,7 +220,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportGoogle:          {"google"},
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
-		TransportAnthropicCompat: {"minimax", "claude-proxy", "custom-anthropic-compatible"},
+		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
 		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
@@ -283,27 +282,6 @@ func TestOAuthProviderClassification(t *testing.T) {
 	oauthIDs := descriptorIDs(OAuthProviders())
 	if want := []string{"openrouter", "xai"}; !reflect.DeepEqual(oauthIDs, want) {
 		t.Fatalf("OAuthProviders() = %#v, want %#v", oauthIDs, want)
-	}
-	proxyIDs := descriptorIDs(OAuthProxyProviders())
-	if want := []string{"chatgpt-proxy", "claude-proxy"}; !reflect.DeepEqual(proxyIDs, want) {
-		t.Fatalf("OAuthProxyProviders() = %#v, want %#v", proxyIDs, want)
-	}
-
-	// Proxy entries must not claim real OAuth (no fake login), and real OAuth
-	// providers must not be flagged as proxies.
-	for _, id := range proxyIDs {
-		d, _ := Get(id)
-		if d.OAuth {
-			t.Fatalf("%q is a proxy entry but has OAuth=true", id)
-		}
-		if !d.Local || d.RequiresAuth {
-			t.Fatalf("%q proxy entry should be local and keyless, got Local=%v RequiresAuth=%v", id, d.Local, d.RequiresAuth)
-		}
-	}
-	for _, id := range oauthIDs {
-		if d, _ := Get(id); d.OAuthProxy {
-			t.Fatalf("%q is a real OAuth provider but flagged OAuthProxy", id)
-		}
 	}
 	if d, _ := Get("openrouter"); !d.OAuthMintsKey {
 		t.Fatal("openrouter should mint a key")

--- a/internal/providercatalog/oauth_test.go
+++ b/internal/providercatalog/oauth_test.go
@@ -24,6 +24,29 @@ func TestOAuthProviders(t *testing.T) {
 	}
 }
 
+func TestOAuthProvidersReturnsIndependentClones(t *testing.T) {
+	first := OAuthProviders()
+	mutated := 0
+	for i := range first {
+		for j := range first[i].AuthEnvVars {
+			first[i].AuthEnvVars[j] = "MUTATED"
+			mutated++
+		}
+	}
+	if mutated == 0 {
+		t.Fatal("expected at least one OAuth descriptor with AuthEnvVars to mutate")
+	}
+	// A fresh call must not observe the in-place mutation: like the other catalog
+	// accessors, OAuthProviders must hand back clones, not shared backing slices.
+	for _, d := range OAuthProviders() {
+		for _, env := range d.AuthEnvVars {
+			if env == "MUTATED" {
+				t.Fatalf("OAuthProviders() leaked a shared AuthEnvVars slice for %q", d.ID)
+			}
+		}
+	}
+}
+
 func TestNonOAuthProvidersNotFlagged(t *testing.T) {
 	for _, d := range All() {
 		switch d.ID {

--- a/internal/providercatalog/oauth_test.go
+++ b/internal/providercatalog/oauth_test.go
@@ -1,0 +1,37 @@
+package providercatalog
+
+import "testing"
+
+func TestOAuthProviders(t *testing.T) {
+	providers := OAuthProviders()
+	if len(providers) != 2 {
+		t.Fatalf("OAuthProviders() = %d, want 2 (openrouter, xai)", len(providers))
+	}
+	byID := map[string]Descriptor{}
+	for _, d := range providers {
+		if !d.OAuth {
+			t.Fatalf("OAuthProviders() returned a non-OAuth descriptor %q", d.ID)
+		}
+		byID[d.ID] = d
+	}
+	or, ok := byID["openrouter"]
+	if !ok || !or.OAuthMintsKey || or.OAuthDeviceFlow {
+		t.Fatalf("openrouter oauth flags wrong: %+v", or)
+	}
+	xai, ok := byID["xai"]
+	if !ok || xai.OAuthMintsKey || !xai.OAuthDeviceFlow {
+		t.Fatalf("xai oauth flags wrong: %+v", xai)
+	}
+}
+
+func TestNonOAuthProvidersNotFlagged(t *testing.T) {
+	for _, d := range All() {
+		switch d.ID {
+		case "openrouter", "xai":
+			continue
+		}
+		if d.OAuth {
+			t.Fatalf("provider %q should not be flagged OAuth-capable", d.ID)
+		}
+	}
+}

--- a/internal/provideroauth/openrouter.go
+++ b/internal/provideroauth/openrouter.go
@@ -6,6 +6,7 @@
 package provideroauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -141,7 +142,7 @@ func openRouterExchange(ctx context.Context, client *http.Client, base, code, ve
 	if err != nil {
 		return "", err
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, base+openRouterKeyExchangePath, strings.NewReader(string(payload)))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, base+openRouterKeyExchangePath, bytes.NewReader(payload))
 	if err != nil {
 		return "", err
 	}

--- a/internal/provideroauth/openrouter.go
+++ b/internal/provideroauth/openrouter.go
@@ -1,0 +1,171 @@
+// Package provideroauth implements provider-specific OAuth login flows that don't
+// fit the generic env-driven engine in internal/oauth — notably OpenRouter's
+// bespoke PKCE flow, which mints a normal API key rather than returning an OAuth
+// bearer token. These flows are launched from the setup wizard / CLI so a user
+// can "log in with the browser" instead of pasting a key.
+package provideroauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/oauth"
+)
+
+const (
+	openRouterDefaultBaseURL  = "https://openrouter.ai"
+	openRouterAuthPath        = "/auth"
+	openRouterKeyExchangePath = "/api/v1/auth/keys"
+	openRouterMaxBody         = 1 << 20
+)
+
+// OpenRouterOptions configures the OpenRouter login flow.
+type OpenRouterOptions struct {
+	// BaseURL overrides https://openrouter.ai (for tests).
+	BaseURL string
+	// HTTPClient performs the key exchange; nil => a client with a sane timeout.
+	HTTPClient *http.Client
+	// OpenBrowser is invoked with the authorize URL. When nil the URL is only
+	// printed (to Out) for the user to open manually.
+	OpenBrowser func(authURL string) error
+	// Out receives the "open this URL" line; nil => the URL is not printed.
+	Out io.Writer
+	// Timeout bounds the whole interactive login; 0 => 5 minutes.
+	Timeout time.Duration
+}
+
+// OpenRouterLogin runs OpenRouter's loopback PKCE flow and returns a freshly
+// minted OpenRouter API key. The flow needs no client_id: a local callback
+// captures the authorization code, which is exchanged (with the PKCE verifier)
+// at /api/v1/auth/keys for a key. PKCE (S256) binds the code to this client, so
+// no separate CSRF state is required. The returned key is a normal credential
+// the caller stores as the provider's API key.
+func OpenRouterLogin(ctx context.Context, opts OpenRouterOptions) (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(opts.BaseURL), "/")
+	if base == "" {
+		base = openRouterDefaultBaseURL
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	pkce, err := oauth.NewPKCE()
+	if err != nil {
+		return "", err
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("provideroauth: start loopback listener: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+	callbackURL := fmt.Sprintf("http://%s/callback", listener.Addr().String())
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/callback" {
+			http.NotFound(w, r)
+			return
+		}
+		if code := strings.TrimSpace(r.URL.Query().Get("code")); code != "" {
+			_, _ = io.WriteString(w, "OpenRouter authorization complete. You may close this window.")
+			select {
+			case codeCh <- code:
+			default:
+			}
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "Authorization failed. You may close this window.")
+		select {
+		case errCh <- errors.New("provideroauth: callback missing authorization code"):
+		default:
+		}
+	})}
+	go func() { _ = server.Serve(listener) }()
+	defer func() {
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), time.Second)
+		defer cancelShutdown()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	authURL := base + openRouterAuthPath + "?" + url.Values{
+		"callback_url":          {callbackURL},
+		"code_challenge":        {pkce.Challenge},
+		"code_challenge_method": {oauth.MethodS256},
+	}.Encode()
+	if opts.Out != nil {
+		fmt.Fprintf(opts.Out, "Open this URL to authorize OpenRouter:\n  %s\n", authURL)
+	}
+	if opts.OpenBrowser != nil {
+		if err := opts.OpenBrowser(authURL); err != nil {
+			return "", fmt.Errorf("provideroauth: open authorization URL: %w", err)
+		}
+	}
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		return "", err
+	case <-ctx.Done():
+		return "", fmt.Errorf("provideroauth: timed out waiting for OpenRouter authorization: %w", ctx.Err())
+	}
+
+	return openRouterExchange(ctx, client, base, code, pkce.Verifier)
+}
+
+// openRouterExchange swaps the authorization code + PKCE verifier for an API key.
+func openRouterExchange(ctx context.Context, client *http.Client, base, code, verifier string) (string, error) {
+	payload, err := json.Marshal(map[string]string{
+		"code":                  code,
+		"code_verifier":         verifier,
+		"code_challenge_method": oauth.MethodS256,
+	})
+	if err != nil {
+		return "", err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, base+openRouterKeyExchangePath, strings.NewReader(string(payload)))
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("provideroauth: openrouter key exchange: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(response.Body, openRouterMaxBody))
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("provideroauth: openrouter key exchange returned HTTP %d", response.StatusCode)
+	}
+	var parsed struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("provideroauth: decode openrouter key response: %w", err)
+	}
+	key := strings.TrimSpace(parsed.Key)
+	if key == "" {
+		return "", errors.New("provideroauth: openrouter returned an empty key")
+	}
+	return key, nil
+}

--- a/internal/provideroauth/openrouter_test.go
+++ b/internal/provideroauth/openrouter_test.go
@@ -1,0 +1,131 @@
+package provideroauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// simulateBrowser returns an OpenBrowser func that authorizes by GETting the
+// callback_url with the given code (or no code), mimicking OpenRouter's redirect.
+// It also asserts the PKCE params are present on the authorize URL.
+func simulateBrowser(t *testing.T, code string) func(string) error {
+	t.Helper()
+	return func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		if q.Get("code_challenge") == "" || q.Get("code_challenge_method") != "S256" {
+			t.Fatalf("authorize URL missing PKCE: %s", authURL)
+		}
+		cb := q.Get("callback_url")
+		if cb == "" {
+			t.Fatalf("authorize URL missing callback_url: %s", authURL)
+		}
+		target := cb
+		if code != "" {
+			target = cb + "?code=" + url.QueryEscape(code)
+		}
+		resp, err := http.Get(target) //nolint:noctx // test loopback
+		if err != nil {
+			return err
+		}
+		_ = resp.Body.Close()
+		return nil
+	}
+}
+
+func TestOpenRouterLoginMintsKey(t *testing.T) {
+	var gotCode, gotVerifier, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/keys" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var body map[string]string
+		_ = json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&body)
+		gotCode, gotVerifier, gotMethod = body["code"], body["code_verifier"], body["code_challenge_method"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"key": "sk-or-mock-123"})
+	}))
+	defer srv.Close()
+
+	key, err := OpenRouterLogin(context.Background(), OpenRouterOptions{
+		BaseURL:     srv.URL,
+		HTTPClient:  srv.Client(),
+		OpenBrowser: simulateBrowser(t, "TESTCODE"),
+	})
+	if err != nil {
+		t.Fatalf("OpenRouterLogin: %v", err)
+	}
+	if key != "sk-or-mock-123" {
+		t.Fatalf("key = %q, want sk-or-mock-123", key)
+	}
+	if gotCode != "TESTCODE" || gotVerifier == "" || gotMethod != "S256" {
+		t.Fatalf("exchange body: code=%q verifier=%q method=%q", gotCode, gotVerifier, gotMethod)
+	}
+}
+
+func TestOpenRouterLoginMissingCodeErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	_, err := OpenRouterLogin(context.Background(), OpenRouterOptions{
+		BaseURL:     srv.URL,
+		HTTPClient:  srv.Client(),
+		OpenBrowser: simulateBrowser(t, ""), // callback with no code
+	})
+	if err == nil {
+		t.Fatal("a callback without a code should error")
+	}
+}
+
+func TestOpenRouterLoginExchangeFailureErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // exchange rejected
+	}))
+	defer srv.Close()
+	_, err := OpenRouterLogin(context.Background(), OpenRouterOptions{
+		BaseURL:     srv.URL,
+		HTTPClient:  srv.Client(),
+		OpenBrowser: simulateBrowser(t, "C"),
+	})
+	if err == nil {
+		t.Fatal("a non-2xx exchange should error")
+	}
+}
+
+func TestOpenRouterLoginEmptyKeyErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"key":""}`)
+	}))
+	defer srv.Close()
+	_, err := OpenRouterLogin(context.Background(), OpenRouterOptions{
+		BaseURL:     srv.URL,
+		HTTPClient:  srv.Client(),
+		OpenBrowser: simulateBrowser(t, "C"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "empty key") {
+		t.Fatalf("empty key should error, got %v", err)
+	}
+}
+
+func TestOpenRouterLoginBrowserErrorPropagates(t *testing.T) {
+	_, err := OpenRouterLogin(context.Background(), OpenRouterOptions{
+		BaseURL:     "http://127.0.0.1:1",
+		OpenBrowser: func(string) error { return errors.New("no browser") },
+	})
+	if err == nil {
+		t.Fatal("a browser-open failure should propagate")
+	}
+}

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -87,6 +87,10 @@ type Options struct {
 	CustomHeaders   map[string]string
 	HTTPClient      *http.Client
 	UserAgent       string
+	// OAuthResolver, when set, supplies an OAuth bearer credential per request and
+	// is preferred over APIKey; a nil resolver (or one that yields ok=false) uses
+	// the API key. See providerio.SendWithAuthRetry.
+	OAuthResolver providerio.TokenResolver
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
 	// Zero uses defaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
@@ -104,6 +108,7 @@ type Provider struct {
 	authScheme        string
 	authHeaderValue   string
 	customHeaders     map[string]string
+	oauthResolver     providerio.TokenResolver
 	httpClient        *http.Client
 	userAgent         string
 	streamIdleTimeout time.Duration
@@ -142,6 +147,7 @@ func New(options Options) (*Provider, error) {
 		authScheme:        strings.TrimSpace(options.AuthScheme),
 		authHeaderValue:   strings.TrimSpace(options.AuthHeaderValue),
 		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
+		oauthResolver:     options.OAuthResolver,
 		httpClient:        providerio.HTTPClient(options.HTTPClient),
 		userAgent:         options.UserAgent,
 		streamIdleTimeout: idleTimeout,
@@ -176,24 +182,26 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, provider.baseURL+"/v1/messages", body, func(request *http.Request) {
-		request.Header.Set("Content-Type", "application/json")
-		request.Header.Set("anthropic-version", provider.version)
-		if provider.beta != "" {
-			request.Header.Set("anthropic-beta", provider.beta)
-		}
-		if provider.userAgent != "" {
-			request.Header.Set("User-Agent", provider.userAgent)
-		}
-		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+	response, err := providerio.SendWithAuthRetry(streamCtx, provider.httpClient, http.MethodPost, provider.baseURL+"/v1/messages", body,
+		providerio.AuthHeaders{
 			APIKey:            provider.apiKey,
 			DefaultAuthHeader: "x-api-key",
 			AuthHeader:        provider.authHeader,
 			AuthScheme:        provider.authScheme,
 			AuthHeaderValue:   provider.authHeaderValue,
 			CustomHeaders:     provider.customHeaders,
-		})
-	}, 0)
+		},
+		provider.oauthResolver,
+		func(request *http.Request) {
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("anthropic-version", provider.version)
+			if provider.beta != "" {
+				request.Header.Set("anthropic-beta", provider.beta)
+			}
+			if provider.userAgent != "" {
+				request.Header.Set("User-Agent", provider.userAgent)
+			}
+		}, 0)
 	if err != nil {
 		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Gitlawb/zero/internal/providers/anthropic"
 	"github.com/Gitlawb/zero/internal/providers/gemini"
 	"github.com/Gitlawb/zero/internal/providers/openai"
+	"github.com/Gitlawb/zero/internal/providers/providerio"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -18,6 +19,10 @@ type Options struct {
 	UserAgent     string
 	HTTPClient    *http.Client
 	ModelRegistry *modelregistry.Registry
+	// OAuthResolver, when set, lets the provider authenticate model calls with an
+	// OAuth bearer token (preferred over the API key). nil => API-key auth only.
+	// Applied to the OpenAI and Anthropic providers.
+	OAuthResolver providerio.TokenResolver
 }
 
 // New creates a runtime provider for a resolved provider profile.
@@ -37,6 +42,7 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 			AuthScheme:      profile.AuthScheme,
 			AuthHeaderValue: profile.AuthHeaderValue,
 			CustomHeaders:   profile.CustomHeaders,
+			OAuthResolver:   options.OAuthResolver,
 			MaxTokens:       resolved.maxOutputTokens,
 			HTTPClient:      options.HTTPClient,
 			UserAgent:       options.UserAgent,
@@ -51,6 +57,7 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 			AuthScheme:      profile.AuthScheme,
 			AuthHeaderValue: profile.AuthHeaderValue,
 			CustomHeaders:   profile.CustomHeaders,
+			OAuthResolver:   options.OAuthResolver,
 			MaxTokens:       resolved.maxOutputTokens,
 			HTTPClient:      options.HTTPClient,
 			UserAgent:       options.UserAgent,

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -34,6 +34,10 @@ type Options struct {
 	CustomHeaders   map[string]string
 	HTTPClient      *http.Client
 	UserAgent       string
+	// OAuthResolver, when set, supplies an OAuth bearer credential per request and
+	// is preferred over APIKey; a nil resolver (or one that yields ok=false) uses
+	// the API key. See providerio.SendWithAuthRetry.
+	OAuthResolver providerio.TokenResolver
 	// MaxTokens caps the model's output tokens. Zero omits the cap (the model's
 	// own default applies). Resolved from the model registry by the factory.
 	MaxTokens int
@@ -54,6 +58,7 @@ type Provider struct {
 	authScheme        string
 	authHeaderValue   string
 	customHeaders     map[string]string
+	oauthResolver     providerio.TokenResolver
 	maxTokens         int
 	httpClient        *http.Client
 	userAgent         string
@@ -100,6 +105,7 @@ func New(options Options) (*Provider, error) {
 		authScheme:        strings.TrimSpace(options.AuthScheme),
 		authHeaderValue:   strings.TrimSpace(options.AuthHeaderValue),
 		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
+		oauthResolver:     options.OAuthResolver,
 		maxTokens:         maxTokens,
 		httpClient:        httpClient,
 		userAgent:         options.UserAgent,
@@ -139,12 +145,8 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 	// Retry transient failures (network errors, 429, and 5xx) before surfacing
 	// them — hosted gateways return intermittent 500s and rate limits that
 	// succeed on a quick retry. Shared with the Anthropic/Gemini providers.
-	response, err := providerio.SendWithRetry(streamCtx, provider.httpClient, http.MethodPost, endpoint, body, func(request *http.Request) {
-		request.Header.Set("Content-Type", "application/json")
-		if provider.userAgent != "" {
-			request.Header.Set("User-Agent", provider.userAgent)
-		}
-		providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+	response, err := providerio.SendWithAuthRetry(streamCtx, provider.httpClient, http.MethodPost, endpoint, body,
+		providerio.AuthHeaders{
 			APIKey:            provider.apiKey,
 			DefaultAuthHeader: "Authorization",
 			DefaultAuthScheme: "Bearer",
@@ -152,8 +154,14 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 			AuthScheme:        provider.authScheme,
 			AuthHeaderValue:   provider.authHeaderValue,
 			CustomHeaders:     provider.customHeaders,
-		})
-	}, 0)
+		},
+		provider.oauthResolver,
+		func(request *http.Request) {
+			request.Header.Set("Content-Type", "application/json")
+			if provider.userAgent != "" {
+				request.Header.Set("User-Agent", provider.userAgent)
+			}
+		}, 0)
 	if err != nil {
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return

--- a/internal/providers/providerio/auth.go
+++ b/internal/providers/providerio/auth.go
@@ -1,0 +1,90 @@
+package providerio
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+// TokenResolver yields a fresh OAuth credential for one request, or ok=false to
+// fall back to the API key (e.g. there is no OAuth login for this provider).
+// header is the header name to set ("" => Authorization); value is the full
+// header value (for example "Bearer abc"). forceRefresh asks the resolver to
+// bypass any cached token; it is set only on the single retry after a 401.
+type TokenResolver func(ctx context.Context, forceRefresh bool) (header string, value string, ok bool, err error)
+
+// SendWithAuthRetry issues a request authenticated with an OAuth bearer (when the
+// resolver yields one) or the API key, retrying ONCE with a force-refreshed token
+// after an upstream 401. A 401 means the server rejected the request (auth
+// failed) WITHOUT processing a completion, so replaying it after a refresh is
+// safe — the same "no duplicate billable work" guarantee SendWithRetry relies on
+// for 429/503. With a nil resolver (or one that yields ok=false) this behaves
+// exactly like SendWithRetry with API-key auth.
+//
+// base carries the API-key auth config (key + default header/scheme). setExtra
+// (optional) sets the provider's non-auth headers on every attempt. Transient
+// retries (429/503/529) are handled by the inner SendWithRetry.
+func SendWithAuthRetry(
+	ctx context.Context,
+	client *http.Client,
+	method string,
+	url string,
+	body []byte,
+	base AuthHeaders,
+	resolver TokenResolver,
+	setExtra func(*http.Request),
+	maxAttempts int,
+) (*http.Response, error) {
+	forceRefresh := false
+	for authTry := 0; ; authTry++ {
+		var resolveErr error
+		response, err := SendWithRetry(ctx, client, method, url, body, func(request *http.Request) {
+			if setExtra != nil {
+				setExtra(request)
+			}
+			headers := base
+			if resolver != nil {
+				header, value, ok, rerr := resolver(request.Context(), forceRefresh)
+				if rerr != nil {
+					resolveErr = rerr
+					return
+				}
+				if ok {
+					headers = withBearer(base, header, value)
+				}
+			}
+			ApplyAuthHeaders(request, headers)
+		}, maxAttempts)
+
+		if resolveErr != nil {
+			if response != nil {
+				_ = response.Body.Close()
+			}
+			return nil, resolveErr
+		}
+		if err != nil {
+			return response, err
+		}
+		// One retry on 401 with a forced token refresh (rejected request → safe).
+		if resolver != nil && response.StatusCode == http.StatusUnauthorized && authTry == 0 {
+			_ = response.Body.Close()
+			forceRefresh = true
+			continue
+		}
+		return response, nil
+	}
+}
+
+// withBearer overrides base to use the OAuth credential: the given header
+// (default Authorization) carries value verbatim, and the API key is cleared so
+// the two auth methods can never both be sent.
+func withBearer(base AuthHeaders, header, value string) AuthHeaders {
+	if strings.TrimSpace(header) == "" {
+		header = "Authorization"
+	}
+	base.APIKey = ""
+	base.AuthHeader = header
+	base.AuthScheme = ""
+	base.AuthHeaderValue = value
+	return base
+}

--- a/internal/providers/providerio/auth.go
+++ b/internal/providers/providerio/auth.go
@@ -37,31 +37,25 @@ func SendWithAuthRetry(
 ) (*http.Response, error) {
 	forceRefresh := false
 	for authTry := 0; ; authTry++ {
-		var resolveErr error
+		// Resolve auth BEFORE dispatching: a resolver error inside the request
+		// callback would otherwise let SendWithRetry send an unauthenticated
+		// request (leaking the path/body) before we return the error.
+		headers := base
+		if resolver != nil {
+			header, value, ok, rerr := resolver(ctx, forceRefresh)
+			if rerr != nil {
+				return nil, rerr
+			}
+			if ok {
+				headers = withBearer(base, header, value)
+			}
+		}
 		response, err := SendWithRetry(ctx, client, method, url, body, func(request *http.Request) {
 			if setExtra != nil {
 				setExtra(request)
 			}
-			headers := base
-			if resolver != nil {
-				header, value, ok, rerr := resolver(request.Context(), forceRefresh)
-				if rerr != nil {
-					resolveErr = rerr
-					return
-				}
-				if ok {
-					headers = withBearer(base, header, value)
-				}
-			}
 			ApplyAuthHeaders(request, headers)
 		}, maxAttempts)
-
-		if resolveErr != nil {
-			if response != nil {
-				_ = response.Body.Close()
-			}
-			return nil, resolveErr
-		}
 		if err != nil {
 			return response, err
 		}

--- a/internal/providers/providerio/auth_test.go
+++ b/internal/providers/providerio/auth_test.go
@@ -38,6 +38,32 @@ func TestSendWithAuthRetryAPIKeyFallbackWhenNilResolver(t *testing.T) {
 	}
 }
 
+func TestSendWithAuthRetryResolverErrorDoesNotDispatch(t *testing.T) {
+	var hit int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hit, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resolver := func(context.Context, bool) (string, string, bool, error) {
+		return "", "", false, errors.New("resolve failed")
+	}
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{APIKey: "KEY", DefaultAuthHeader: "X-Api-Key"}, resolver, nil, 1)
+	drain(resp)
+	if err == nil {
+		t.Fatal("expected the resolver error to surface")
+	}
+	if resp != nil {
+		t.Fatalf("no response should be returned on resolver error, got status %d", resp.StatusCode)
+	}
+	// The request must never reach the server when auth resolution failed.
+	if n := atomic.LoadInt32(&hit); n != 0 {
+		t.Fatalf("request dispatched %d times despite resolver error, want 0", n)
+	}
+}
+
 func TestSendWithAuthRetryBearerWinsAndNeverBoth(t *testing.T) {
 	var gotKey, gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/providerio/auth_test.go
+++ b/internal/providers/providerio/auth_test.go
@@ -1,0 +1,171 @@
+package providerio
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func drain(resp *http.Response) {
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+}
+
+func TestSendWithAuthRetryAPIKeyFallbackWhenNilResolver(t *testing.T) {
+	var gotKey, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{APIKey: "KEY", DefaultAuthHeader: "X-Api-Key"}, nil, nil, 1)
+	defer drain(resp)
+	if err != nil {
+		t.Fatalf("SendWithAuthRetry: %v", err)
+	}
+	if gotKey != "KEY" {
+		t.Fatalf("X-Api-Key = %q, want KEY", gotKey)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization should be unset for API-key auth, got %q", gotAuth)
+	}
+}
+
+func TestSendWithAuthRetryBearerWinsAndNeverBoth(t *testing.T) {
+	var gotKey, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resolver := func(context.Context, bool) (string, string, bool, error) {
+		return "Authorization", "Bearer TOK", true, nil
+	}
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{APIKey: "KEY", DefaultAuthHeader: "X-Api-Key"}, resolver, nil, 1)
+	defer drain(resp)
+	if err != nil {
+		t.Fatalf("SendWithAuthRetry: %v", err)
+	}
+	if gotAuth != "Bearer TOK" {
+		t.Fatalf("Authorization = %q, want Bearer TOK", gotAuth)
+	}
+	if gotKey != "" {
+		t.Fatalf("API key must NOT be sent alongside a bearer token, got X-Api-Key=%q", gotKey)
+	}
+}
+
+func TestSendWithAuthRetryOkFalseFallsBackToAPIKey(t *testing.T) {
+	var gotKey, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// resolver yields ok=false (no login) → API key path.
+	resolver := func(context.Context, bool) (string, string, bool, error) { return "", "", false, nil }
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{APIKey: "KEY", DefaultAuthHeader: "X-Api-Key"}, resolver, nil, 1)
+	defer drain(resp)
+	if err != nil {
+		t.Fatalf("SendWithAuthRetry: %v", err)
+	}
+	if gotKey != "KEY" || gotAuth != "" {
+		t.Fatalf("ok=false should use API key: X-Api-Key=%q Authorization=%q", gotKey, gotAuth)
+	}
+}
+
+func TestSendWithAuthRetryRefreshesOn401(t *testing.T) {
+	var count int32
+	var first, second string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&count, 1)
+		if n == 1 {
+			first = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		second = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var forced int32
+	resolver := func(_ context.Context, forceRefresh bool) (string, string, bool, error) {
+		if forceRefresh {
+			atomic.AddInt32(&forced, 1)
+			return "Authorization", "Bearer NEW", true, nil
+		}
+		return "Authorization", "Bearer OLD", true, nil
+	}
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{}, resolver, nil, 1)
+	defer drain(resp)
+	if err != nil {
+		t.Fatalf("SendWithAuthRetry: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("final status = %d, want 200", resp.StatusCode)
+	}
+	if first != "Bearer OLD" || second != "Bearer NEW" {
+		t.Fatalf("expected old→new bearer, got first=%q second=%q", first, second)
+	}
+	if atomic.LoadInt32(&forced) != 1 {
+		t.Fatalf("force-refresh called %d times, want 1", forced)
+	}
+	if atomic.LoadInt32(&count) != 2 {
+		t.Fatalf("server hit %d times, want 2", count)
+	}
+}
+
+func TestSendWithAuthRetryStopsAfterOne401Retry(t *testing.T) {
+	var count int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&count, 1)
+		w.WriteHeader(http.StatusUnauthorized) // always 401
+	}))
+	defer srv.Close()
+
+	resolver := func(context.Context, bool) (string, string, bool, error) {
+		return "Authorization", "Bearer T", true, nil
+	}
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{}, resolver, nil, 1)
+	defer drain(resp)
+	if err != nil {
+		t.Fatalf("SendWithAuthRetry: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("final status = %d, want 401", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&count); got != 2 {
+		t.Fatalf("server hit %d times, want exactly 2 (initial + one refresh retry)", got)
+	}
+}
+
+func TestSendWithAuthRetrySurfacesResolverError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wantErr := errors.New("refresh failed")
+	resolver := func(context.Context, bool) (string, string, bool, error) { return "", "", false, wantErr }
+	resp, err := SendWithAuthRetry(context.Background(), srv.Client(), http.MethodPost, srv.URL, nil,
+		AuthHeaders{}, resolver, nil, 1)
+	defer drain(resp)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -502,6 +502,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case providerWizardOAuthMsg:
 		return m.applyProviderWizardOAuth(msg)
+	case providerWizardDeviceCodeMsg:
+		return m.applyProviderWizardDeviceCode(msg)
 	case tea.KeyMsg:
 		if m.setup.visible {
 			return m.handleSetupKey(msg)
@@ -1053,6 +1055,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applySetupModelsDiscovered(msg), nil
 	case setupOAuthMsg:
 		return m.applySetupOAuth(msg)
+	case setupOAuthDeviceMsg:
+		return m.applySetupOAuthDeviceCode(msg)
 	case modelPickerModelsDiscoveredMsg:
 		return m.applyModelPickerModelsDiscovered(msg), nil
 	case mcpCommandResultMsg:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1051,6 +1051,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyProviderModelsDiscovered(msg), nil
 	case setupModelsDiscoveredMsg:
 		return m.applySetupModelsDiscovered(msg), nil
+	case setupOAuthMsg:
+		return m.applySetupOAuth(msg)
 	case modelPickerModelsDiscoveredMsg:
 		return m.applyModelPickerModelsDiscovered(msg), nil
 	case mcpCommandResultMsg:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -500,6 +500,8 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.copyStatus = ""
 		}
 		return m, nil
+	case providerWizardOAuthMsg:
+		return m.applyProviderWizardOAuth(msg)
 	case tea.KeyMsg:
 		if m.setup.visible {
 			return m.handleSetupKey(msg)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -421,7 +421,7 @@ func (m *model) selectGenericPickerAtMouse(msg tea.MouseMsg) (mouseSelectionTarg
 }
 
 func (m *model) selectProviderWizardAtMouse(msg tea.MouseMsg) (mouseSelectionTarget, bool) {
-	if m.providerWizard == nil {
+	if m.providerWizard == nil || m.providerWizard.oauthPending {
 		return mouseSelectionTarget{}, false
 	}
 	width := chatWidth(m.width)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -14,6 +14,12 @@ type mouseSelectionTarget struct {
 }
 
 func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// While a provider-wizard OAuth login is in flight, ignore all mouse input
+	// (clicks and wheel) so a stray scroll can't change the selected provider
+	// mid-login — mirroring the keyboard handler's pending guard.
+	if m.providerWizard != nil && m.providerWizard.oauthPending {
+		return m, nil
+	}
 	if mouseLeftPress(msg) {
 		switch {
 		case m.providerWizard != nil:

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -97,6 +97,7 @@ func TestMouseClickSelectsThenAppliesPickerRow(t *testing.T) {
 func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.step = providerWizardStepProvider // skip the new method chooser
 	if m.providerWizard == nil || len(m.providerWizard.providers) < 2 {
 		t.Fatalf("expected multiple providers, got %#v", m.providerWizard)
 	}
@@ -133,6 +134,7 @@ func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
 func TestMouseWheelMovesProviderWizardRows(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.step = providerWizardStepProvider // skip the new method chooser
 	m.mouseCapture = true
 
 	updated, cmd := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown})

--- a/internal/tui/oauth_device.go
+++ b/internal/tui/oauth_device.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/browser"
+	"github.com/Gitlawb/zero/internal/oauth"
+)
+
+// oauthPreferDeviceFlow reports whether the device-code flow should be the
+// default for a device-capable provider because no usable browser is likely
+// present (SSH session or a headless Linux box). On a desktop the browser flow
+// stays the default; users can still force device code with the "d" shortcut.
+// ZERO_OAUTH_DEVICE forces it on for any environment.
+func oauthPreferDeviceFlow() bool {
+	if strings.TrimSpace(os.Getenv("ZERO_OAUTH_DEVICE")) != "" {
+		return true
+	}
+	if strings.TrimSpace(os.Getenv("SSH_CONNECTION")) != "" || strings.TrimSpace(os.Getenv("SSH_TTY")) != "" {
+		return true
+	}
+	if runtime.GOOS == "linux" &&
+		strings.TrimSpace(os.Getenv("DISPLAY")) == "" &&
+		strings.TrimSpace(os.Getenv("WAYLAND_DISPLAY")) == "" {
+		return true
+	}
+	return false
+}
+
+// oauthDevicePrepare requests an RFC 8628 device code for the provider (phase 1).
+// The returned DeviceAuth carries the verification URI + user code to display;
+// pass cfg/auth to oauthDeviceComplete to poll for the token.
+func oauthDevicePrepare(name string) (oauth.DeviceAuth, oauth.Config, error) {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return oauth.DeviceAuth{}, oauth.Config{}, err
+	}
+	manager, err := oauth.NewManager(oauth.ManagerOptions{
+		Store:       store,
+		HTTPClient:  &http.Client{Timeout: 60 * time.Second},
+		OpenBrowser: browser.OpenURL,
+	})
+	if err != nil {
+		return oauth.DeviceAuth{}, oauth.Config{}, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return manager.PrepareDeviceLogin(ctx, oauth.LoginOptions{Provider: name})
+}
+
+// oauthDeviceComplete polls for the token authorized via oauthDevicePrepare and
+// stores it under provider:<name> (phase 2). The runtime resolver then attaches
+// the refreshable token to model calls.
+func oauthDeviceComplete(name string, cfg oauth.Config, auth oauth.DeviceAuth) error {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return err
+	}
+	manager, err := oauth.NewManager(oauth.ManagerOptions{
+		Store:      store,
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+	})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	_, err = manager.CompleteDeviceLogin(ctx, name, cfg, auth)
+	return err
+}
+
+// oauthDeviceVerifyTarget picks the best URL to show the user: the complete URI
+// (code pre-filled) when present, else the bare verification URI.
+func oauthDeviceVerifyTarget(auth oauth.DeviceAuth) string {
+	if target := strings.TrimSpace(auth.VerificationURIComplete); target != "" {
+		return target
+	}
+	return strings.TrimSpace(auth.VerificationURI)
+}

--- a/internal/tui/oauth_device.go
+++ b/internal/tui/oauth_device.go
@@ -74,6 +74,29 @@ func oauthDeviceComplete(name string, cfg oauth.Config, auth oauth.DeviceAuth) e
 	return err
 }
 
+// oauthStoredToken returns a fresh access token for a provider that was logged in
+// via OAuth (token stored under provider:<id>), refreshing on demand. Empty when
+// there is no stored login or the refresh fails. Used to authenticate the model
+// discovery /models call so the wizard can show the live model list after login.
+func oauthStoredToken(ctx context.Context, providerID string) string {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return ""
+	}
+	manager, err := oauth.NewManager(oauth.ManagerOptions{
+		Store:      store,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	})
+	if err != nil {
+		return ""
+	}
+	token, err := manager.GetFresh(ctx, oauth.ProviderKey(providerID))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(token)
+}
+
 // oauthDeviceVerifyTarget picks the best URL to show the user: the complete URI
 // (code pre-filled) when present, else the bare verification URI.
 func oauthDeviceVerifyTarget(auth oauth.DeviceAuth) string {

--- a/internal/tui/oauth_device_test.go
+++ b/internal/tui/oauth_device_test.go
@@ -1,0 +1,75 @@
+package tui
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
+)
+
+func seedOAuthToken(t *testing.T, providerID, access string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tok.json")
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", path)
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(oauth.ProviderKey(providerID), oauth.Token{AccessToken: access, ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+}
+
+func TestOAuthStoredTokenReadsStoredLogin(t *testing.T) {
+	seedOAuthToken(t, "xai", "live-grok-token")
+
+	if got := oauthStoredToken(context.Background(), "xai"); got != "live-grok-token" {
+		t.Fatalf("oauthStoredToken(xai) = %q, want live-grok-token", got)
+	}
+	// No login for another provider → empty (no error, no panic).
+	if got := oauthStoredToken(context.Background(), "openrouter"); got != "" {
+		t.Fatalf("oauthStoredToken(openrouter) = %q, want empty", got)
+	}
+}
+
+// After an xAI OAuth login the bearer lives in the token store, not as a pasted
+// key — discovery must resolve it so /models is authenticated and the live list
+// shows (matching how the user picks a model after sign-in).
+func TestProviderWizardDiscoveryUsesOAuthToken(t *testing.T) {
+	seedOAuthToken(t, "xai", "live-grok-token")
+
+	var gotKey string
+	m := mouseTestModel()
+	m.discoverProviderModels = func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+		gotKey = profile.APIKey
+		return []providermodeldiscovery.Model{{ID: "grok-4"}}, nil
+	}
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.oauthMode = true
+	m.providerWizard.providers = providerWizardOAuthDescriptors()
+	for i, d := range m.providerWizard.providers {
+		if d.ID == "xai" {
+			m.providerWizard.selectedProvider = i
+		}
+	}
+	m.providerWizard.step = providerWizardStepModel
+
+	cmd := m.providerModelDiscoveryCmd()
+	if cmd == nil {
+		t.Fatal("expected a discovery command for xai")
+	}
+	msg, ok := cmd().(providerModelsDiscoveredMsg)
+	if !ok {
+		t.Fatal("unexpected discovery message type")
+	}
+	if msg.err != nil {
+		t.Fatalf("discovery error: %v", msg.err)
+	}
+	if gotKey != "live-grok-token" {
+		t.Fatalf("discovery profile APIKey = %q, want the resolved OAuth token", gotKey)
+	}
+}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -766,8 +766,12 @@ func (m model) setupModelDiscoveryCmd(gen uint64) tea.Cmd {
 	if setupProviderUsesTypedModel(option) {
 		return nil
 	}
-	profile := providerWizardDiscoveryProfile(provider, m.setupCredentialAPIKey(option))
-	redactionSecrets := []string{m.setup.apiKey.Value(), profile.APIKey}
+	pastedKey := m.setupCredentialAPIKey(option)
+	// A token-login provider (e.g. xAI) keeps its bearer in the OAuth store, not as
+	// a pasted key; resolve it so /models is authenticated and the live list shows
+	// after sign-in. (OpenRouter mints a key into the credential already.)
+	needOAuthToken := strings.TrimSpace(pastedKey) == "" && provider.OAuth && !provider.OAuthMintsKey
+	baseSecrets := []string{m.setup.apiKey.Value()}
 	discover := m.discoverProviderModels
 	if discover == nil {
 		discover = func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
@@ -776,10 +780,18 @@ func (m model) setupModelDiscoveryCmd(gen uint64) tea.Cmd {
 	}
 	providerID := provider.ID
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
+		ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
 		defer cancel()
+		apiKey := pastedKey
+		if needOAuthToken {
+			if resolved := oauthStoredToken(ctx, providerID); resolved != "" {
+				apiKey = resolved
+			}
+		}
+		profile := providerWizardDiscoveryProfile(provider, apiKey)
+		secrets := append(append([]string{}, baseSecrets...), apiKey, profile.APIKey)
 		models, err := discover(ctx, profile)
-		return setupModelsDiscoveredMsg{providerID: providerID, gen: gen, redactionSecrets: redactionSecrets, models: models, err: err}
+		return setupModelsDiscoveredMsg{providerID: providerID, gen: gen, redactionSecrets: secrets, models: models, err: err}
 	}
 }
 

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -67,12 +67,13 @@ type setupOAuthMsg struct {
 	err        error
 }
 
-// setupOAuthProviderOptions filters the full provider list to the OAuth-capable
-// ones (using the catalog OAuth flag) for the OAuth method path.
+// setupOAuthProviderOptions filters the full provider list to the entries shown
+// in the OAuth method path: real OAuth providers plus the subscription proxy
+// entries (ChatGPT / Claude). Catalog order puts the real OAuth providers first.
 func setupOAuthProviderOptions(all []SetupProviderOption) []SetupProviderOption {
 	out := []SetupProviderOption{}
 	for _, option := range all {
-		if descriptor, ok := providercatalog.Get(option.ID); ok && descriptor.OAuth {
+		if descriptor, ok := providercatalog.Get(option.ID); ok && (descriptor.OAuth || descriptor.OAuthProxy) {
 			out = append(out, option)
 		}
 	}
@@ -410,6 +411,31 @@ func (m *model) moveSetupMethod(delta int) {
 	m.setup.selectedMethod = ((m.setup.selectedMethod+delta)%len(options) + len(options)) % len(options)
 }
 
+// setupSelectBrowseProvider leaves the OAuth path and switches to the full
+// provider list with the given id selected, pre-filling the catalog defaults.
+// Used to route a subscription proxy entry (ChatGPT / Claude) into the normal
+// endpoint/model setup instead of a real OAuth login.
+func (m model) setupSelectBrowseProvider(id string) model {
+	m.setup.oauthMode = false
+	m.setup.oauthPending = false
+	m.setup.oauthErr = ""
+	m.setup.providers = m.setup.allProviders
+	m.setup.selected = 0
+	for index, option := range m.setup.providers {
+		if option.ID == id {
+			m.setup.selected = index
+			break
+		}
+	}
+	descriptor := m.setupProviderDescriptor()
+	m.resetSetupModels()
+	m.setup.baseURL = descriptor.DefaultBaseURL
+	m.setup.modelQuery = descriptor.DefaultModel
+	m.setup.apiKey.SetValue("")
+	m.setup.name = ""
+	return m
+}
+
 // setupOAuthCmd runs the chosen provider's browser OAuth login off the UI
 // goroutine for first-run setup. Mirrors the /provider wizard's flow.
 func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
@@ -513,6 +539,14 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 				m.setup.oauthPending = true
 				m.setup.oauthErr = ""
 				return m, setupOAuthCmd(descriptor)
+			}
+			// Subscription proxy entry (ChatGPT / Claude): no real OAuth login —
+			// route into the normal browse setup for the local proxy URL.
+			if descriptor.OAuthProxy {
+				m = m.setupSelectBrowseProvider(descriptor.ID)
+				m.setup.stage = m.nextSetupStage()
+				m.setup.err = ""
+				return m, nil
 			}
 		}
 		if m.setup.stage == setupStageProvider {

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -1574,6 +1574,14 @@ func (m model) setupAPIKeyInputLine(width int) string {
 }
 
 func (m model) setupCredentialSummary(option SetupProviderOption) string {
+	// An OAuth token-login provider (e.g. xAI) is authenticated by a stored,
+	// refreshable token, not an API key — don't advertise an env var for it on the
+	// Ready screen. (Key-minting OAuth like OpenRouter still ends up as a saved key.)
+	if m.setup.oauthMode {
+		if d, ok := providercatalog.Get(option.ID); ok && d.OAuth && !d.OAuthMintsKey {
+			return "OAuth token"
+		}
+	}
 	if !setupProviderAcceptsAPIKey(option) {
 		return "not required"
 	}

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 	"github.com/Gitlawb/zero/internal/provideroauth"
@@ -44,19 +45,23 @@ type setupState struct {
 	oauthMode      bool
 	oauthPending   bool
 	oauthErr       string
-	stage          setupStage
-	err            string
-	baseURL        string
-	name           string
-	apiKey         textinput.Model
-	models         []providerWizardModel
-	modelIndex     int
-	modelQuery     string
-	modelForID     string
-	modelLoad      bool
-	modelErr       string
-	modelSrc       string
-	modelGen       uint64
+	// Device-code login (RFC 8628) state while an OAuth login is in flight.
+	oauthDevice           bool
+	deviceUserCode        string
+	deviceVerificationURI string
+	stage                 setupStage
+	err                   string
+	baseURL               string
+	name                  string
+	apiKey                textinput.Model
+	models                []providerWizardModel
+	modelIndex            int
+	modelQuery            string
+	modelForID            string
+	modelLoad             bool
+	modelErr              string
+	modelSrc              string
+	modelGen              uint64
 }
 
 // setupOAuthMsg carries the result of a first-run browser OAuth login.
@@ -131,6 +136,7 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case tea.KeyEsc:
 			m.setup.oauthPending = false
+			m.setup.oauthDevice = false
 		}
 		return m, nil
 	}
@@ -213,6 +219,11 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "j":
 			if m.setup.stage == setupStageProvider {
 				m.moveSetupProvider(1)
+			}
+		case "d", "D":
+			// Force device-code login for a device-capable OAuth provider.
+			if m.setup.stage == setupStageProvider && m.setup.oauthMode && m.setupProviderDescriptor().OAuthDeviceFlow {
+				return m.startSetupDeviceLogin(m.setupProviderDescriptor())
 			}
 		}
 		return m, nil
@@ -397,6 +408,9 @@ func (m model) setupStages() []setupStage {
 func (m model) setupReturnToMethod() model {
 	m.setup.oauthMode = false
 	m.setup.oauthErr = ""
+	m.setup.oauthDevice = false
+	m.setup.deviceUserCode = ""
+	m.setup.deviceVerificationURI = ""
 	m.setup.providers = m.setup.allProviders
 	m.setup.selected = 0
 	m.resetSetupModels()
@@ -454,6 +468,70 @@ func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
 	}
 }
 
+// setupOAuthDeviceMsg carries phase 1 of device-code login (RequestDeviceCode)
+// for first-run setup: the user_code + verification URI to display.
+type setupOAuthDeviceMsg struct {
+	providerID string
+	userCode   string
+	verifyURL  string
+	cfg        oauth.Config
+	auth       oauth.DeviceAuth
+	err        error
+}
+
+func setupDevicePrepareCmd(name string) tea.Cmd {
+	return func() tea.Msg {
+		auth, cfg, err := oauthDevicePrepare(name)
+		if err != nil {
+			return setupOAuthDeviceMsg{providerID: name, err: err}
+		}
+		return setupOAuthDeviceMsg{
+			providerID: name,
+			userCode:   auth.UserCode,
+			verifyURL:  oauthDeviceVerifyTarget(auth),
+			cfg:        cfg,
+			auth:       auth,
+		}
+	}
+}
+
+func setupDevicePollCmd(name string, cfg oauth.Config, auth oauth.DeviceAuth) tea.Cmd {
+	return func() tea.Msg {
+		return setupOAuthMsg{tokenLogin: true, providerID: name, err: oauthDeviceComplete(name, cfg, auth)}
+	}
+}
+
+// startSetupDeviceLogin begins the device-code flow for the selected OAuth
+// provider during first-run setup (phase 1).
+func (m model) startSetupDeviceLogin(descriptor providercatalog.Descriptor) (tea.Model, tea.Cmd) {
+	if !descriptor.OAuth || !descriptor.OAuthDeviceFlow {
+		return m, nil
+	}
+	m.setup.oauthPending = true
+	m.setup.oauthDevice = true
+	m.setup.oauthErr = ""
+	m.setup.deviceUserCode = ""
+	m.setup.deviceVerificationURI = ""
+	return m, setupDevicePrepareCmd(descriptor.ID)
+}
+
+// applySetupOAuthDeviceCode handles phase 1 of device-code login: show the code,
+// then start phase 2 (the token poll). On error the redacted message is shown.
+func (m model) applySetupOAuthDeviceCode(msg setupOAuthDeviceMsg) (tea.Model, tea.Cmd) {
+	if !m.setup.visible || !m.setup.oauthPending {
+		return m, nil
+	}
+	if msg.err != nil {
+		m.setup.oauthPending = false
+		m.setup.oauthDevice = false
+		m.setup.oauthErr = redaction.RedactString(msg.err.Error(), redaction.Options{})
+		return m, nil
+	}
+	m.setup.deviceUserCode = msg.userCode
+	m.setup.deviceVerificationURI = msg.verifyURL
+	return m, setupDevicePollCmd(msg.providerID, msg.cfg, msg.auth)
+}
+
 // applySetupOAuth folds an OAuth login result into the first-run setup: on success
 // the credential is captured (minted key) or relied upon (stored token) and setup
 // jumps to model selection; on failure the redacted error is shown.
@@ -471,6 +549,9 @@ func (m model) applySetupOAuth(msg setupOAuthMsg) (tea.Model, tea.Cmd) {
 	}
 	m.setup.oauthErr = ""
 	m.setup.err = ""
+	m.setup.oauthDevice = false
+	m.setup.deviceUserCode = ""
+	m.setup.deviceVerificationURI = ""
 	m.setup.stage = setupStageModel
 	m.resetSetupModels()
 	m.setup.modelErr = ""
@@ -536,7 +617,13 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 		if m.setup.stage == setupStageProvider && m.setup.oauthMode {
 			descriptor := m.setupProviderDescriptor()
 			if descriptor.OAuth {
+				// Headless/SSH boxes can't open a browser — use device code there
+				// by default (the user can also force it with "d" from the list).
+				if descriptor.OAuthDeviceFlow && oauthPreferDeviceFlow() {
+					return m.startSetupDeviceLogin(descriptor)
+				}
 				m.setup.oauthPending = true
+				m.setup.oauthDevice = false
 				m.setup.oauthErr = ""
 				return m, setupOAuthCmd(descriptor)
 			}
@@ -1319,13 +1406,28 @@ func setupMethodBlockWidth(terminalWidth int, options []providerWizardMethodOpti
 func (m model) setupOAuthWaitingLines(width int) []string {
 	provider := m.setupProviderDescriptor()
 	name := displayValue(provider.Name, provider.ID)
-	lines := []string{
-		zeroTheme.ink.Bold(true).Render("Signing in with " + name),
-		"",
-		"Opening your browser — approve there, then return here.",
-		zeroTheme.faint.Render("Waiting for authorization..."),
-		"",
-		zeroTheme.faint.Render("If your browser didn't open, run:  " + providerWizardOAuthCLIHint(provider)),
+	var lines []string
+	if m.setup.oauthDevice {
+		lines = []string{zeroTheme.ink.Bold(true).Render("Device-code sign-in for " + name), ""}
+		if m.setup.deviceUserCode == "" {
+			lines = append(lines, zeroTheme.faint.Render("Requesting a device code..."))
+		} else {
+			lines = append(lines,
+				"1. On any device, visit:  "+zeroTheme.accent.Render(m.setup.deviceVerificationURI),
+				"2. Enter the code:  "+zeroTheme.accent.Bold(true).Render(m.setup.deviceUserCode),
+				"",
+				zeroTheme.faint.Render("Waiting for authorization..."),
+			)
+		}
+	} else {
+		lines = []string{
+			zeroTheme.ink.Bold(true).Render("Signing in with " + name),
+			"",
+			"Opening your browser — approve there, then return here.",
+			zeroTheme.faint.Render("Waiting for authorization..."),
+			"",
+			zeroTheme.faint.Render("If your browser didn't open, run:  " + providerWizardOAuthCLIHint(provider)),
+		}
 	}
 	if m.setup.oauthErr != "" {
 		lines = append(lines, "", zeroTheme.red.Render("Sign-in failed: "+m.setup.oauthErr))
@@ -1484,6 +1586,9 @@ func (m model) setupFooter() string {
 		}
 		return zeroTheme.accent.Render("Space") + zeroTheme.faint.Render(" to continue")
 	case setupStageProvider:
+		if m.setup.oauthMode && m.setupProviderDescriptor().OAuthDeviceFlow {
+			return zeroTheme.faint.Render("↑/↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" sign in   ") + zeroTheme.accent.Render("d") + zeroTheme.faint.Render(" device code   q quit")
+		}
 		return zeroTheme.faint.Render("↑/↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   q quit")
 	case setupStageModel:
 		if m.setup.modelLoad {

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -72,13 +72,13 @@ type setupOAuthMsg struct {
 	err        error
 }
 
-// setupOAuthProviderOptions filters the full provider list to the entries shown
-// in the OAuth method path: real OAuth providers plus the subscription proxy
-// entries (ChatGPT / Claude). Catalog order puts the real OAuth providers first.
+// setupOAuthProviderOptions filters the full provider list to the OAuth-capable
+// ones for the OAuth method path. ChatGPT/Claude are not here — they can't do
+// real in-app OAuth (use "browse" + a local proxy); see docs/oauth-subscriptions.md.
 func setupOAuthProviderOptions(all []SetupProviderOption) []SetupProviderOption {
 	out := []SetupProviderOption{}
 	for _, option := range all {
-		if descriptor, ok := providercatalog.Get(option.ID); ok && (descriptor.OAuth || descriptor.OAuthProxy) {
+		if descriptor, ok := providercatalog.Get(option.ID); ok && descriptor.OAuth {
 			out = append(out, option)
 		}
 	}
@@ -425,31 +425,6 @@ func (m *model) moveSetupMethod(delta int) {
 	m.setup.selectedMethod = ((m.setup.selectedMethod+delta)%len(options) + len(options)) % len(options)
 }
 
-// setupSelectBrowseProvider leaves the OAuth path and switches to the full
-// provider list with the given id selected, pre-filling the catalog defaults.
-// Used to route a subscription proxy entry (ChatGPT / Claude) into the normal
-// endpoint/model setup instead of a real OAuth login.
-func (m model) setupSelectBrowseProvider(id string) model {
-	m.setup.oauthMode = false
-	m.setup.oauthPending = false
-	m.setup.oauthErr = ""
-	m.setup.providers = m.setup.allProviders
-	m.setup.selected = 0
-	for index, option := range m.setup.providers {
-		if option.ID == id {
-			m.setup.selected = index
-			break
-		}
-	}
-	descriptor := m.setupProviderDescriptor()
-	m.resetSetupModels()
-	m.setup.baseURL = descriptor.DefaultBaseURL
-	m.setup.modelQuery = descriptor.DefaultModel
-	m.setup.apiKey.SetValue("")
-	m.setup.name = ""
-	return m
-}
-
 // setupOAuthCmd runs the chosen provider's browser OAuth login off the UI
 // goroutine for first-run setup. Mirrors the /provider wizard's flow.
 func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
@@ -626,14 +601,6 @@ func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 				m.setup.oauthDevice = false
 				m.setup.oauthErr = ""
 				return m, setupOAuthCmd(descriptor)
-			}
-			// Subscription proxy entry (ChatGPT / Claude): no real OAuth login —
-			// route into the normal browse setup for the local proxy URL.
-			if descriptor.OAuthProxy {
-				m = m.setupSelectBrowseProvider(descriptor.ID)
-				m.setup.stage = m.nextSetupStage()
-				m.setup.err = ""
-				return m, nil
 			}
 		}
 		if m.setup.stage == setupStageProvider {

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -417,8 +417,26 @@ func (m model) setupReturnToMethod() model {
 	return m
 }
 
-func (m *model) moveSetupMethod(delta int) {
+// setupMethodOptions returns the connect-method choices for this run, dropping the
+// OAuth option when this setup's own provider list has no OAuth-capable entry — so
+// the user can't pick OAuth and land on an empty provider list.
+func (m model) setupMethodOptions() []providerWizardMethodOption {
 	options := providerWizardMethodOptions()
+	if len(setupOAuthProviderOptions(m.setup.allProviders)) > 0 {
+		return options
+	}
+	filtered := make([]providerWizardMethodOption, 0, len(options))
+	for _, option := range options {
+		if option.oauth {
+			continue
+		}
+		filtered = append(filtered, option)
+	}
+	return filtered
+}
+
+func (m *model) moveSetupMethod(delta int) {
+	options := m.setupMethodOptions()
 	if len(options) == 0 {
 		return
 	}
@@ -496,6 +514,11 @@ func (m model) applySetupOAuthDeviceCode(msg setupOAuthDeviceMsg) (tea.Model, te
 	if !m.setup.visible || !m.setup.oauthPending {
 		return m, nil
 	}
+	// Ignore a stale result from a login the user has since replaced with a
+	// different provider (an in-flight prepare landing after the switch).
+	if msg.providerID != "" && msg.providerID != m.setupProviderDescriptor().ID {
+		return m, nil
+	}
 	if msg.err != nil {
 		m.setup.oauthPending = false
 		m.setup.oauthDevice = false
@@ -512,6 +535,11 @@ func (m model) applySetupOAuthDeviceCode(msg setupOAuthDeviceMsg) (tea.Model, te
 // jumps to model selection; on failure the redacted error is shown.
 func (m model) applySetupOAuth(msg setupOAuthMsg) (tea.Model, tea.Cmd) {
 	if !m.setup.visible || !m.setup.oauthPending {
+		return m, nil
+	}
+	// Ignore a stale result for a provider the user has since switched away from,
+	// so a late login can't capture a credential against the wrong provider.
+	if msg.providerID != "" && msg.providerID != m.setupProviderDescriptor().ID {
 		return m, nil
 	}
 	m.setup.oauthPending = false
@@ -573,7 +601,7 @@ func setupBlockContainsMouseX(x int, width int, blockWidth int) bool {
 func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 	if m.setup.stage < setupStageReady {
 		if m.setup.stage == setupStageMethod {
-			options := providerWizardMethodOptions()
+			options := m.setupMethodOptions()
 			m.setup.selectedMethod = clamp(m.setup.selectedMethod, 0, maxInt(0, len(options)-1))
 			if len(options) > 0 && options[m.setup.selectedMethod].oauth {
 				m.setup.oauthMode = true
@@ -1352,7 +1380,7 @@ func setupModelSelectedDetail(model providerWizardModel) string {
 }
 
 func (m model) setupMethodLines(width int) []string {
-	options := providerWizardMethodOptions()
+	options := m.setupMethodOptions()
 	rowWidth := setupMethodBlockWidth(width, options)
 	idx := clamp(m.setup.selectedMethod, 0, maxInt(0, len(options)-1))
 	lines := []string{
@@ -1433,6 +1461,15 @@ func (m model) setupProviderLines(width int, height int) []string {
 		}
 		line := marker + style.Render(displayValue(option.Name, option.ID))
 		lines = append(lines, padSetupLine(line, rowWidth))
+	}
+	// A failed OAuth login drops back here with oauthPending cleared, so the
+	// waiting screen (which owns the error) is gone — surface it on the list the
+	// user lands on so the failure isn't silent and they can retry.
+	if m.setup.oauthMode && m.setup.oauthErr != "" {
+		lines = append(lines,
+			blankSetupBlockLine(rowWidth),
+			padSetupLine("  "+zeroTheme.red.Render("Sign-in failed: "+m.setup.oauthErr), rowWidth),
+		)
 	}
 	return lines
 }

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -11,9 +11,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
+	"github.com/Gitlawb/zero/internal/provideroauth"
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
@@ -21,6 +23,7 @@ type setupStage int
 
 const (
 	setupStageWelcome setupStage = iota
+	setupStageMethod
 	setupStageProvider
 	setupStageEndpoint
 	setupStageName
@@ -31,24 +34,49 @@ const (
 )
 
 type setupState struct {
-	visible    bool
-	required   bool
-	configPath string
-	providers  []SetupProviderOption
-	selected   int
-	stage      setupStage
-	err        string
-	baseURL    string
-	name       string
-	apiKey     textinput.Model
-	models     []providerWizardModel
-	modelIndex int
-	modelQuery string
-	modelForID string
-	modelLoad  bool
-	modelErr   string
-	modelSrc   string
-	modelGen   uint64
+	visible        bool
+	required       bool
+	configPath     string
+	providers      []SetupProviderOption // active list (full, or OAuth-only after the chooser)
+	allProviders   []SetupProviderOption // full catalog (restored when leaving the OAuth path)
+	selected       int
+	selectedMethod int
+	oauthMode      bool
+	oauthPending   bool
+	oauthErr       string
+	stage          setupStage
+	err            string
+	baseURL        string
+	name           string
+	apiKey         textinput.Model
+	models         []providerWizardModel
+	modelIndex     int
+	modelQuery     string
+	modelForID     string
+	modelLoad      bool
+	modelErr       string
+	modelSrc       string
+	modelGen       uint64
+}
+
+// setupOAuthMsg carries the result of a first-run browser OAuth login.
+type setupOAuthMsg struct {
+	apiKey     string
+	tokenLogin bool
+	providerID string
+	err        error
+}
+
+// setupOAuthProviderOptions filters the full provider list to the OAuth-capable
+// ones (using the catalog OAuth flag) for the OAuth method path.
+func setupOAuthProviderOptions(all []SetupProviderOption) []SetupProviderOption {
+	out := []SetupProviderOption{}
+	for _, option := range all {
+		if descriptor, ok := providercatalog.Get(option.ID); ok && descriptor.OAuth {
+			out = append(out, option)
+		}
+	}
+	return out
 }
 
 type setupModelsDiscoveredMsg struct {
@@ -83,16 +111,28 @@ func newSetupState(options SetupOptions) setupState {
 	apiKey.KeyMap.Paste.SetEnabled(false)
 	apiKey.Focus()
 	return setupState{
-		visible:    options.Visible,
-		required:   options.Required,
-		configPath: strings.TrimSpace(options.ConfigPath),
-		providers:  providers,
-		apiKey:     apiKey,
+		visible:      options.Visible,
+		required:     options.Required,
+		configPath:   strings.TrimSpace(options.ConfigPath),
+		providers:    providers,
+		allProviders: providers,
+		apiKey:       apiKey,
 	}
 }
 
 func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.clearMouseSelection()
+	// While a browser OAuth login is in flight, ignore input except Ctrl+C (quit)
+	// and Esc (cancel back to the OAuth provider list).
+	if m.setup.oauthPending {
+		switch msg.Type {
+		case tea.KeyCtrlC:
+			return m, tea.Quit
+		case tea.KeyEsc:
+			m.setup.oauthPending = false
+		}
+		return m, nil
+	}
 	if m.setupEndpointInputActive() {
 		return m.handleSetupEndpointKey(msg)
 	}
@@ -107,7 +147,11 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case tea.KeyEsc:
 		if m.setup.stage > setupStageWelcome {
-			m.setup.stage = m.previousSetupStage()
+			prev := m.previousSetupStage()
+			if prev == setupStageMethod {
+				m = m.setupReturnToMethod()
+			}
+			m.setup.stage = prev
 			m.setup.err = ""
 			return m, nil
 		}
@@ -117,12 +161,16 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.exitSetupToChat()
 	case tea.KeyLeft:
 		if m.setup.stage > setupStageWelcome {
-			m.setup.stage = m.previousSetupStage()
+			prev := m.previousSetupStage()
+			if prev == setupStageMethod {
+				m = m.setupReturnToMethod()
+			}
+			m.setup.stage = prev
 			m.setup.err = ""
 		}
 		return m, nil
 	case tea.KeyEnter:
-		if m.setup.stage == setupStageProvider || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
+		if m.setup.stage == setupStageMethod || m.setup.stage == setupStageProvider || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
 			return m.advanceSetup()
 		}
 		return m, nil
@@ -132,14 +180,18 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case tea.KeyUp:
-		if m.setup.stage == setupStageProvider {
+		if m.setup.stage == setupStageMethod {
+			m.moveSetupMethod(-1)
+		} else if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(-1)
 		} else if m.setup.stage == setupStageModel {
 			m.moveSetupModel(-1)
 		}
 		return m, nil
 	case tea.KeyDown:
-		if m.setup.stage == setupStageProvider {
+		if m.setup.stage == setupStageMethod {
+			m.moveSetupMethod(1)
+		} else if m.setup.stage == setupStageProvider {
 			m.moveSetupProvider(1)
 		} else if m.setup.stage == setupStageModel {
 			m.moveSetupModel(1)
@@ -200,6 +252,9 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleSetupMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if m.setup.oauthPending {
+		return m, nil
+	}
 	if mouseLeftPress(msg) {
 		switch m.setup.stage {
 		case setupStageProvider:
@@ -323,12 +378,80 @@ func setupContentTop(height int, contentLines int, hasError bool) int {
 }
 
 func (m model) setupStages() []setupStage {
-	stages := []setupStage{setupStageWelcome, setupStageProvider}
+	stages := []setupStage{setupStageWelcome, setupStageMethod}
+	if m.setup.oauthMode {
+		// OAuth path skips endpoint/name/credentials (the login provides the credential).
+		return append(stages, setupStageProvider, setupStageModel, setupStageSafety, setupStageReady)
+	}
+	stages = append(stages, setupStageProvider)
 	if setupProviderNeedsEndpoint(m.setupProvider()) {
 		stages = append(stages, setupStageEndpoint, setupStageName)
 	}
 	stages = append(stages, setupStageCredentials, setupStageModel, setupStageSafety, setupStageReady)
 	return stages
+}
+
+// setupReturnToMethod resets the OAuth selection when navigating back to the
+// connect-method chooser.
+func (m model) setupReturnToMethod() model {
+	m.setup.oauthMode = false
+	m.setup.oauthErr = ""
+	m.setup.providers = m.setup.allProviders
+	m.setup.selected = 0
+	m.resetSetupModels()
+	return m
+}
+
+func (m *model) moveSetupMethod(delta int) {
+	options := providerWizardMethodOptions()
+	if len(options) == 0 {
+		return
+	}
+	m.setup.selectedMethod = ((m.setup.selectedMethod+delta)%len(options) + len(options)) % len(options)
+}
+
+// setupOAuthCmd runs the chosen provider's browser OAuth login off the UI
+// goroutine for first-run setup. Mirrors the /provider wizard's flow.
+func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
+	if provider.OAuthMintsKey {
+		return func() tea.Msg {
+			key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
+				OpenBrowser: browser.OpenURL,
+				Timeout:     3 * time.Minute,
+			})
+			return setupOAuthMsg{apiKey: key, providerID: provider.ID, err: err}
+		}
+	}
+	name := provider.ID
+	return func() tea.Msg {
+		return setupOAuthMsg{tokenLogin: true, providerID: name, err: runProviderTokenLogin(name)}
+	}
+}
+
+// applySetupOAuth folds an OAuth login result into the first-run setup: on success
+// the credential is captured (minted key) or relied upon (stored token) and setup
+// jumps to model selection; on failure the redacted error is shown.
+func (m model) applySetupOAuth(msg setupOAuthMsg) (tea.Model, tea.Cmd) {
+	if !m.setup.visible || !m.setup.oauthPending {
+		return m, nil
+	}
+	m.setup.oauthPending = false
+	if msg.err != nil {
+		m.setup.oauthErr = redaction.RedactString(msg.err.Error(), redaction.Options{})
+		return m, nil
+	}
+	if msg.apiKey != "" {
+		m.setup.apiKey.SetValue(msg.apiKey)
+	}
+	m.setup.oauthErr = ""
+	m.setup.err = ""
+	m.setup.stage = setupStageModel
+	m.resetSetupModels()
+	m.setup.modelErr = ""
+	m.setup.modelGen++
+	cmd := m.setupModelDiscoveryCmd(m.setup.modelGen)
+	m.setup.modelLoad = cmd != nil
+	return m, cmd
 }
 
 func (m model) nextSetupStage() setupStage {
@@ -367,6 +490,31 @@ func setupBlockContainsMouseX(x int, width int, blockWidth int) bool {
 
 func (m model) advanceSetup() (tea.Model, tea.Cmd) {
 	if m.setup.stage < setupStageReady {
+		if m.setup.stage == setupStageMethod {
+			options := providerWizardMethodOptions()
+			m.setup.selectedMethod = clamp(m.setup.selectedMethod, 0, maxInt(0, len(options)-1))
+			if len(options) > 0 && options[m.setup.selectedMethod].oauth {
+				m.setup.oauthMode = true
+				m.setup.providers = setupOAuthProviderOptions(m.setup.allProviders)
+			} else {
+				m.setup.oauthMode = false
+				m.setup.providers = m.setup.allProviders
+			}
+			m.setup.selected = 0
+			m.resetSetupModels()
+			m.setup.stage = setupStageProvider
+			m.setup.err = ""
+			return m, nil
+		}
+		// OAuth path: advancing from the OAuth provider list starts the browser login.
+		if m.setup.stage == setupStageProvider && m.setup.oauthMode {
+			descriptor := m.setupProviderDescriptor()
+			if descriptor.OAuth {
+				m.setup.oauthPending = true
+				m.setup.oauthErr = ""
+				return m, setupOAuthCmd(descriptor)
+			}
+		}
 		if m.setup.stage == setupStageProvider {
 			m.setup.apiKey.SetValue("")
 			m.setup.baseURL = ""
@@ -427,12 +575,21 @@ func (m model) completeSetup() (tea.Model, tea.Cmd) {
 		return m.exitSetupToChat()
 	}
 
+	name := m.setupProfileName(option)
+	apiKey := m.setupCredentialAPIKey(option)
+	// OAuth token login (e.g. xAI): the credential is the OAuth token stored under
+	// provider:<id>; name the profile after the provider id so the runtime resolver
+	// attaches the bearer, and store no API key.
+	if m.setup.oauthMode && !m.setupProviderDescriptor().OAuthMintsKey {
+		name = option.ID
+		apiKey = ""
+	}
 	result, err := m.setupSave(SetupSelection{
 		CatalogID: option.ID,
-		Name:      m.setupProfileName(option),
+		Name:      name,
 		BaseURL:   m.setupBaseURL(option),
 		Model:     m.setupCurrentModel().ID,
-		APIKey:    m.setupCredentialAPIKey(option),
+		APIKey:    apiKey,
 	})
 	if err != nil {
 		m.setup.err = err.Error()
@@ -849,7 +1006,12 @@ func (m model) setupView(width int) string {
 }
 
 func (m model) setupStageLines(width int, height int) []string {
+	if m.setup.oauthPending {
+		return m.setupOAuthWaitingLines(width)
+	}
 	switch m.setup.stage {
+	case setupStageMethod:
+		return m.setupMethodLines(width)
 	case setupStageProvider:
 		return m.setupProviderLines(width, height)
 	case setupStageEndpoint:
@@ -1089,6 +1251,54 @@ func setupModelSelectedDetail(model providerWizardModel) string {
 	return strings.Join(parts, " · ")
 }
 
+func (m model) setupMethodLines(width int) []string {
+	options := providerWizardMethodOptions()
+	rowWidth := setupMethodBlockWidth(width, options)
+	idx := clamp(m.setup.selectedMethod, 0, maxInt(0, len(options)-1))
+	lines := []string{
+		padSetupLine("  "+zeroTheme.ink.Bold(true).Render("How do you want to connect?"), rowWidth),
+		blankSetupBlockLine(rowWidth),
+	}
+	for index, option := range options {
+		marker := "  "
+		style := zeroTheme.ink
+		if index == idx {
+			marker = "❯ "
+			style = zeroTheme.accent.Bold(true)
+		}
+		lines = append(lines, padSetupLine(marker+style.Render(option.label), rowWidth))
+		lines = append(lines, padSetupLine("    "+zeroTheme.faint.Render(option.subtitle), rowWidth))
+	}
+	return lines
+}
+
+func setupMethodBlockWidth(terminalWidth int, options []providerWizardMethodOption) int {
+	available := maxInt(34, minInt(terminalWidth-8, 86))
+	target := lipgloss.Width("  How do you want to connect?")
+	for _, option := range options {
+		target = maxInt(target, 2+lipgloss.Width(option.label))
+		target = maxInt(target, 4+lipgloss.Width(option.subtitle))
+	}
+	return minInt(maxInt(target, 42), available)
+}
+
+func (m model) setupOAuthWaitingLines(width int) []string {
+	provider := m.setupProviderDescriptor()
+	name := displayValue(provider.Name, provider.ID)
+	lines := []string{
+		zeroTheme.ink.Bold(true).Render("Signing in with " + name),
+		"",
+		"Opening your browser — approve there, then return here.",
+		zeroTheme.faint.Render("Waiting for authorization..."),
+		"",
+		zeroTheme.faint.Render("If your browser didn't open, run:  " + providerWizardOAuthCLIHint(provider)),
+	}
+	if m.setup.oauthErr != "" {
+		lines = append(lines, "", zeroTheme.red.Render("Sign-in failed: "+m.setup.oauthErr))
+	}
+	return lines
+}
+
 func (m model) setupProviderLines(width int, height int) []string {
 	rowWidth := setupProviderBlockWidth(width, m.setup.providers)
 	maxVisible := setupProviderMaxVisible(height, len(m.setup.providers))
@@ -1222,7 +1432,12 @@ func (m model) setupCredentialSummary(option SetupProviderOption) string {
 }
 
 func (m model) setupFooter() string {
+	if m.setup.oauthPending {
+		return zeroTheme.faint.Render("Esc cancel")
+	}
 	switch m.setup.stage {
+	case setupStageMethod:
+		return zeroTheme.faint.Render("↑/↓ choose   ") + zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" continue   q quit")
 	case setupStageReady:
 		return zeroTheme.accent.Render("Enter") + zeroTheme.faint.Render(" to save and start chat")
 	case setupStageEndpoint:

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -1349,51 +1349,6 @@ func TestApplySetupOAuthDeviceCodeShowsCodeAndPolls(t *testing.T) {
 	}
 }
 
-func TestSetupProxyEntryRoutesToBrowse(t *testing.T) {
-	m := newModel(context.Background(), Options{Setup: SetupOptions{
-		Visible: true,
-		Providers: []SetupProviderOption{
-			{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true, EnvVar: "OPENROUTER_API_KEY"},
-			{ID: "chatgpt-proxy", Name: "ChatGPT (local OAuth proxy)", DefaultModel: "gpt-5", Local: true},
-			{ID: "openai", Name: "OpenAI", RequiresAuth: true, EnvVar: "OPENAI_API_KEY"},
-		},
-	}})
-	m.width = 100
-	m.height = 30
-
-	m = pressSetupContinueOnce(m) // Welcome → Method
-	m.setup.selectedMethod = 0    // Sign in with OAuth
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = updated.(model) // OAuth provider list (incl. proxy entries)
-	for i, p := range m.setup.providers {
-		if p.ID == "chatgpt-proxy" {
-			m.setup.selected = i
-			break
-		}
-	}
-	if m.setupProvider().ID != "chatgpt-proxy" {
-		t.Fatalf("chatgpt-proxy not selectable in the OAuth list (got %q)", m.setupProvider().ID)
-	}
-
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = updated.(model)
-	if m.setup.oauthMode {
-		t.Fatal("selecting a proxy entry should leave OAuth mode")
-	}
-	if m.setup.oauthPending || cmd != nil {
-		t.Fatalf("proxy entry must not start an OAuth login (pending=%v cmd!=nil=%v)", m.setup.oauthPending, cmd != nil)
-	}
-	if m.setup.stage != setupStageEndpoint {
-		t.Fatalf("proxy entry should route to the endpoint stage, got %v", m.setup.stage)
-	}
-	if m.setupProvider().ID != "chatgpt-proxy" {
-		t.Fatalf("selected provider after routing = %q, want chatgpt-proxy", m.setupProvider().ID)
-	}
-	if strings.TrimSpace(m.setup.baseURL) == "" {
-		t.Fatal("proxy entry should pre-fill the default proxy URL")
-	}
-}
-
 func TestApplySetupOAuthSuccessAdvancesToModel(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -48,6 +48,20 @@ func TestSetupMethodOptionsDropsOAuthWithoutOAuthProviders(t *testing.T) {
 	}
 }
 
+func TestSetupCredentialSummaryOAuthToken(t *testing.T) {
+	m := newModel(context.Background(), Options{Setup: SetupOptions{Visible: true}})
+	m.setup.oauthMode = true
+	// xAI logs in with a stored, refreshable OAuth token (not key-minting), so the
+	// Ready screen must say "OAuth token", not advertise an env var.
+	if got := m.setupCredentialSummary(SetupProviderOption{ID: "xai", EnvVar: "XAI_API_KEY", RequiresAuth: true}); got != "OAuth token" {
+		t.Fatalf("xai OAuth summary = %q, want \"OAuth token\"", got)
+	}
+	// OpenRouter mints a normal API key via OAuth, so it must NOT be labeled a token.
+	if got := m.setupCredentialSummary(SetupProviderOption{ID: "openrouter", EnvVar: "OPENROUTER_API_KEY", RequiresAuth: true}); got == "OAuth token" {
+		t.Fatalf("openrouter (key-minting) should not show as OAuth token, got %q", got)
+	}
+}
+
 func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 	var saved SetupSelection
 	m := newModel(context.Background(), Options{

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -1287,6 +1287,51 @@ func TestSetupMethodChooserOAuthPath(t *testing.T) {
 	}
 }
 
+func TestSetupProxyEntryRoutesToBrowse(t *testing.T) {
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{
+			{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true, EnvVar: "OPENROUTER_API_KEY"},
+			{ID: "chatgpt-proxy", Name: "ChatGPT (local OAuth proxy)", DefaultModel: "gpt-5", Local: true},
+			{ID: "openai", Name: "OpenAI", RequiresAuth: true, EnvVar: "OPENAI_API_KEY"},
+		},
+	}})
+	m.width = 100
+	m.height = 30
+
+	m = pressSetupContinueOnce(m) // Welcome → Method
+	m.setup.selectedMethod = 0    // Sign in with OAuth
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model) // OAuth provider list (incl. proxy entries)
+	for i, p := range m.setup.providers {
+		if p.ID == "chatgpt-proxy" {
+			m.setup.selected = i
+			break
+		}
+	}
+	if m.setupProvider().ID != "chatgpt-proxy" {
+		t.Fatalf("chatgpt-proxy not selectable in the OAuth list (got %q)", m.setupProvider().ID)
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.setup.oauthMode {
+		t.Fatal("selecting a proxy entry should leave OAuth mode")
+	}
+	if m.setup.oauthPending || cmd != nil {
+		t.Fatalf("proxy entry must not start an OAuth login (pending=%v cmd!=nil=%v)", m.setup.oauthPending, cmd != nil)
+	}
+	if m.setup.stage != setupStageEndpoint {
+		t.Fatalf("proxy entry should route to the endpoint stage, got %v", m.setup.stage)
+	}
+	if m.setupProvider().ID != "chatgpt-proxy" {
+		t.Fatalf("selected provider after routing = %q, want chatgpt-proxy", m.setupProvider().ID)
+	}
+	if strings.TrimSpace(m.setup.baseURL) == "" {
+		t.Fatal("proxy entry should pre-fill the default proxy URL")
+	}
+}
+
 func TestApplySetupOAuthSuccessAdvancesToModel(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -13,6 +13,41 @@ import (
 	"github.com/Gitlawb/zero/internal/providermodeldiscovery"
 )
 
+func TestSetupMethodOptionsDropsOAuthWithoutOAuthProviders(t *testing.T) {
+	build := func(providers []SetupProviderOption) model {
+		return newModel(context.Background(), Options{
+			Setup: SetupOptions{Visible: true, Providers: providers},
+		})
+	}
+
+	// This setup offers only non-OAuth providers, so the OAuth method must be
+	// hidden — otherwise selecting it lands the user on an empty provider list.
+	noOAuth := build([]SetupProviderOption{
+		{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+		{ID: "ollama", Name: "Ollama Local", Local: true},
+	})
+	for _, option := range noOAuth.setupMethodOptions() {
+		if option.oauth {
+			t.Fatal("OAuth method must be hidden when the setup has no OAuth providers")
+		}
+	}
+
+	// Add an OAuth-capable provider (xai) and the OAuth method returns.
+	withOAuth := build([]SetupProviderOption{
+		{ID: "xai", Name: "xAI"},
+		{ID: "openai", Name: "OpenAI", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+	})
+	hasOAuth := false
+	for _, option := range withOAuth.setupMethodOptions() {
+		if option.oauth {
+			hasOAuth = true
+		}
+	}
+	if !hasOAuth {
+		t.Fatal("OAuth method must be offered when the setup has an OAuth provider")
+	}
+}
+
 func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 	var saved SetupSelection
 	m := newModel(context.Background(), Options{

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -52,6 +52,12 @@ func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 		t.Fatal("setup navigation should not launch a command")
 	}
 	m = updated.(model)
+	if m.setup.stage != setupStageMethod {
+		t.Fatalf("stage = %v, want method chooser", m.setup.stage)
+	}
+	m.setup.selectedMethod = len(providerWizardMethodOptions()) - 1 // API-key / browse path
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
 	if m.setup.stage != setupStageProvider {
 		t.Fatalf("stage = %v, want provider", m.setup.stage)
 	}
@@ -1203,13 +1209,13 @@ func TestSetupProgressRendersAboveFooter(t *testing.T) {
 	stepIndex := -1
 	footerIndex := -1
 	for index, line := range lines {
-		if strings.Contains(line, "2/6") {
+		if strings.Contains(line, "3/7") {
 			stepIndex = index
 		}
 		if strings.Contains(line, "Enter continue") {
 			footerIndex = index
 		}
-		if strings.Contains(line, "Choose a provider") && strings.Contains(line, "2/6") {
+		if strings.Contains(line, "Choose a provider") && strings.Contains(line, "3/7") {
 			t.Fatalf("progress should not render in setup body: %q", line)
 		}
 	}
@@ -1243,10 +1249,89 @@ func TestSetupReadyFooterUsesEnter(t *testing.T) {
 	}
 }
 
+func TestSetupMethodChooserOAuthPath(t *testing.T) {
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{
+			{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true, EnvVar: "OPENROUTER_API_KEY"},
+			{ID: "xai", Name: "xAI", RequiresAuth: true, EnvVar: "XAI_API_KEY"},
+			{ID: "openai", Name: "OpenAI", RequiresAuth: true, EnvVar: "OPENAI_API_KEY"},
+		},
+	}})
+	m.width = 100
+	m.height = 30
+
+	m = pressSetupContinueOnce(m) // Welcome → Method
+	if m.setup.stage != setupStageMethod {
+		t.Fatalf("stage = %v, want method chooser", m.setup.stage)
+	}
+	m.setup.selectedMethod = 0 // "Sign in with OAuth"
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if m.setup.stage != setupStageProvider || !m.setup.oauthMode {
+		t.Fatalf("OAuth method should enter the OAuth provider list, got stage=%v oauth=%v", m.setup.stage, m.setup.oauthMode)
+	}
+	ids := map[string]bool{}
+	for _, p := range m.setup.providers {
+		ids[p.ID] = true
+	}
+	if len(m.setup.providers) != 2 || !ids["openrouter"] || !ids["xai"] {
+		t.Fatalf("OAuth provider list = %#v, want only openrouter+xai", m.setup.providers)
+	}
+
+	// Left returns to the method chooser and clears the OAuth selection.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(model)
+	if m.setup.stage != setupStageMethod || m.setup.oauthMode {
+		t.Fatalf("retreat should return to method without oauthMode, got stage=%v oauth=%v", m.setup.stage, m.setup.oauthMode)
+	}
+}
+
+func TestApplySetupOAuthSuccessAdvancesToModel(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			return nil, errors.New("offline")
+		},
+		Setup: SetupOptions{Visible: true, Providers: []SetupProviderOption{
+			{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true, EnvVar: "OPENROUTER_API_KEY"},
+		}},
+	})
+	m.width = 100
+	m.height = 30
+	m = pressSetupContinueOnce(m) // Welcome → Method
+	m.setup.selectedMethod = 0
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model) // OAuth provider stage
+	m.setup.oauthPending = true
+
+	res, _ := m.applySetupOAuth(setupOAuthMsg{apiKey: "sk-or-minted", providerID: "openrouter"})
+	m = res.(model)
+	if m.setup.oauthPending {
+		t.Fatal("pending should clear after success")
+	}
+	if m.setup.stage != setupStageModel {
+		t.Fatalf("stage = %v, want model after OAuth", m.setup.stage)
+	}
+	if m.setup.apiKey.Value() != "sk-or-minted" {
+		t.Fatalf("minted key not captured: %q", m.setup.apiKey.Value())
+	}
+}
+
 func pressSetupContinue(m model) model {
+	m = pressSetupContinueOnce(m)
+	// Transparently skip the connect-method chooser via the API-key/browse path so
+	// existing tests keep their Welcome→Provider→… expectations.
+	if m.setup.stage == setupStageMethod {
+		m.setup.selectedMethod = len(providerWizardMethodOptions()) - 1
+		m = pressSetupContinueOnce(m)
+	}
+	return m
+}
+
+func pressSetupContinueOnce(m model) model {
 	var updated tea.Model
 	var cmd tea.Cmd
-	if m.setup.stage == setupStageProvider || m.setupEndpointInputActive() || m.setupNameInputActive() || m.setupCredentialInputActive() || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
+	if m.setup.stage == setupStageMethod || m.setup.stage == setupStageProvider || m.setupEndpointInputActive() || m.setupNameInputActive() || m.setupCredentialInputActive() || m.setup.stage == setupStageModel || m.setup.stage == setupStageReady {
 		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	} else {
 		updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeySpace, Runes: []rune(" ")})

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -90,7 +90,7 @@ func TestSetupTakeoverRendersAndCompletes(t *testing.T) {
 	if m.setup.stage != setupStageMethod {
 		t.Fatalf("stage = %v, want method chooser", m.setup.stage)
 	}
-	m.setup.selectedMethod = len(providerWizardMethodOptions()) - 1 // API-key / browse path
+	m.setup.selectedMethod = len(m.setupMethodOptions()) - 1 // API-key / browse path
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(model)
 	if m.setup.stage != setupStageProvider {
@@ -1419,7 +1419,7 @@ func pressSetupContinue(m model) model {
 	// Transparently skip the connect-method chooser via the API-key/browse path so
 	// existing tests keep their Welcome→Provider→… expectations.
 	if m.setup.stage == setupStageMethod {
-		m.setup.selectedMethod = len(providerWizardMethodOptions()) - 1
+		m.setup.selectedMethod = len(m.setupMethodOptions()) - 1
 		m = pressSetupContinueOnce(m)
 	}
 	return m

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -1287,6 +1287,68 @@ func TestSetupMethodChooserOAuthPath(t *testing.T) {
 	}
 }
 
+func setupAtOAuthList(t *testing.T) model {
+	t.Helper()
+	m := newModel(context.Background(), Options{Setup: SetupOptions{
+		Visible: true,
+		Providers: []SetupProviderOption{
+			{ID: "openrouter", Name: "OpenRouter", RequiresAuth: true, EnvVar: "OPENROUTER_API_KEY"},
+			{ID: "xai", Name: "xAI", DefaultModel: "grok-4", RequiresAuth: true, EnvVar: "XAI_API_KEY"},
+		},
+	}})
+	m.width = 100
+	m.height = 30
+	m = pressSetupContinueOnce(m) // Welcome → Method
+	m.setup.selectedMethod = 0    // Sign in with OAuth
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return updated.(model)
+}
+
+func TestSetupDeviceShortcutStartsDeviceFlow(t *testing.T) {
+	m := setupAtOAuthList(t)
+	for i, p := range m.setup.providers {
+		if p.ID == "xai" {
+			m.setup.selected = i
+			break
+		}
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	m = updated.(model)
+	if !m.setup.oauthPending || !m.setup.oauthDevice {
+		t.Fatalf("'d' should start device login (pending=%v device=%v)", m.setup.oauthPending, m.setup.oauthDevice)
+	}
+	if cmd == nil {
+		t.Fatal("'d' should return the device-prepare command")
+	}
+}
+
+func TestApplySetupOAuthDeviceCodeShowsCodeAndPolls(t *testing.T) {
+	m := setupAtOAuthList(t)
+	for i, p := range m.setup.providers {
+		if p.ID == "xai" {
+			m.setup.selected = i
+			break
+		}
+	}
+	m.setup.oauthPending = true
+	m.setup.oauthDevice = true
+
+	res, cmd := m.applySetupOAuthDeviceCode(setupOAuthDeviceMsg{
+		providerID: "xai", userCode: "WXYZ-9", verifyURL: "https://x.ai/device",
+	})
+	m = res.(model)
+	if m.setup.deviceUserCode != "WXYZ-9" || m.setup.deviceVerificationURI != "https://x.ai/device" {
+		t.Fatalf("device code not stored: %+v", m.setup)
+	}
+	if cmd == nil {
+		t.Fatal("device-code msg should start the poll command")
+	}
+	view := strings.Join(m.setupOAuthWaitingLines(72), "\n")
+	if !strings.Contains(view, "WXYZ-9") || !strings.Contains(view, "x.ai/device") {
+		t.Fatalf("waiting render missing device code/uri:\n%s", view)
+	}
+}
+
 func TestSetupProxyEntryRoutesToBrowse(t *testing.T) {
 	m := newModel(context.Background(), Options{Setup: SetupOptions{
 		Visible: true,

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -51,8 +51,29 @@ func (m model) applyProviderWizardOAuth(msg providerWizardOAuthMsg) (model, tea.
 	// selection.
 	m.providerWizard.err = ""
 	m.providerWizard.oauthErr = ""
+	m.providerWizard.oauthDevice = false
+	m.providerWizard.deviceUserCode = ""
+	m.providerWizard.deviceVerificationURI = ""
 	m.providerWizard.step = providerWizardStepModel
 	return m, m.providerModelDiscoveryCmd()
+}
+
+// applyProviderWizardDeviceCode handles phase 1 of device-code login: show the
+// user_code + verification URI, then kick off phase 2 (the token poll). On error
+// the redacted message is surfaced and the login is abandoned.
+func (m model) applyProviderWizardDeviceCode(msg providerWizardDeviceCodeMsg) (model, tea.Cmd) {
+	if m.providerWizard == nil || !m.providerWizard.oauthPending {
+		return m, nil
+	}
+	if msg.err != nil {
+		m.providerWizard.oauthPending = false
+		m.providerWizard.oauthDevice = false
+		m.providerWizard.oauthErr = redaction.ErrorMessage(msg.err, redaction.Options{})
+		return m, nil
+	}
+	m.providerWizard.deviceUserCode = msg.userCode
+	m.providerWizard.deviceVerificationURI = msg.verifyURL
+	return m, providerWizardDevicePollCmd(msg.providerID, msg.cfg, msg.auth)
 }
 
 // providerWizardSupportsOAuth reports whether the credential step should offer a
@@ -103,6 +124,58 @@ func runProviderTokenLogin(name string) error {
 	defer cancel()
 	_, err = manager.Login(ctx, oauth.LoginOptions{Provider: name})
 	return err
+}
+
+// providerWizardDeviceCodeMsg carries the result of phase 1 (RequestDeviceCode):
+// the user_code + verification URI to display, plus the cfg/auth to poll with.
+type providerWizardDeviceCodeMsg struct {
+	providerID string
+	userCode   string
+	verifyURL  string
+	cfg        oauth.Config
+	auth       oauth.DeviceAuth
+	err        error
+}
+
+// providerWizardDevicePrepareCmd runs phase 1 of the device-code login off the UI
+// goroutine and reports the code to display (or an error).
+func providerWizardDevicePrepareCmd(name string) tea.Cmd {
+	return func() tea.Msg {
+		auth, cfg, err := oauthDevicePrepare(name)
+		if err != nil {
+			return providerWizardDeviceCodeMsg{providerID: name, err: err}
+		}
+		return providerWizardDeviceCodeMsg{
+			providerID: name,
+			userCode:   auth.UserCode,
+			verifyURL:  oauthDeviceVerifyTarget(auth),
+			cfg:        cfg,
+			auth:       auth,
+		}
+	}
+}
+
+// providerWizardDevicePollCmd runs phase 2 (poll for the token + store) off the
+// UI goroutine and reports completion as a regular OAuth result.
+func providerWizardDevicePollCmd(name string, cfg oauth.Config, auth oauth.DeviceAuth) tea.Cmd {
+	return func() tea.Msg {
+		return providerWizardOAuthMsg{tokenLogin: true, err: oauthDeviceComplete(name, cfg, auth)}
+	}
+}
+
+// startProviderDeviceLogin begins the device-code flow for the selected OAuth
+// provider (phase 1). Used by the headless default and the "d" shortcut.
+func (m model) startProviderDeviceLogin() (model, tea.Cmd) {
+	provider := m.providerWizard.currentProvider()
+	if !provider.OAuth || !provider.OAuthDeviceFlow {
+		return m, nil
+	}
+	m.providerWizard.oauthPending = true
+	m.providerWizard.oauthDevice = true
+	m.providerWizard.oauthErr = ""
+	m.providerWizard.deviceUserCode = ""
+	m.providerWizard.deviceVerificationURI = ""
+	return m, providerWizardDevicePrepareCmd(provider.ID)
 }
 
 const maxProviderWizardProvidersVisible = 8
@@ -182,6 +255,10 @@ type providerWizardState struct {
 	oauthMode        bool
 	oauthPending     bool
 	oauthErr         string
+	// Device-code login (RFC 8628) state while an OAuth login is in flight.
+	oauthDevice           bool
+	deviceUserCode        string
+	deviceVerificationURI string
 }
 
 func (m model) newProviderWizard() *providerWizardState {
@@ -483,6 +560,13 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 			m.providerWizard = nil
 		}
 		return m, nil
+	}
+	// On the OAuth provider list, "d" forces device-code login for a device-capable
+	// provider (xAI) — useful on a desktop when the browser flow won't work.
+	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode &&
+		msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && (msg.Runes[0] == 'd' || msg.Runes[0] == 'D') &&
+		m.providerWizard.currentProvider().OAuthDeviceFlow {
+		return m.startProviderDeviceLogin()
 	}
 	if m.providerWizard.step == providerWizardStepEndpoint {
 		switch msg.Type {
@@ -823,6 +907,9 @@ func (wizard *providerWizardState) footer() string {
 	case providerWizardStepMethod:
 		return "↑/↓ move   Enter/→ continue   Esc close"
 	case providerWizardStepProvider:
+		if wizard.oauthMode && wizard.currentProvider().OAuthDeviceFlow {
+			return "↑/↓ move   Enter sign in   d device code   ← back   Esc close"
+		}
 		if canRight {
 			return "↑/↓ move   Enter/→ continue   ← back   Esc close"
 		}
@@ -937,6 +1024,21 @@ func (wizard *providerWizardState) renderOAuthWaiting(width int) []string {
 	name := provider.Name
 	if name == "" {
 		name = "the provider"
+	}
+	if wizard.oauthDevice {
+		lines := []string{
+			zeroTheme.accent.Render("Device-code sign-in for " + name),
+			"",
+		}
+		if wizard.deviceUserCode == "" {
+			return append(lines, fitStyledLine(zeroTheme.faint.Render("Requesting a device code..."), width))
+		}
+		return append(lines,
+			fitStyledLine(zeroTheme.ink.Render("1. On any device, visit:  ")+zeroTheme.accent.Render(wizard.deviceVerificationURI), width),
+			fitStyledLine(zeroTheme.ink.Render("2. Enter the code:  ")+zeroTheme.accent.Bold(true).Render(wizard.deviceUserCode), width),
+			"",
+			fitStyledLine(zeroTheme.faint.Render("Waiting for authorization..."), width),
+		)
 	}
 	return []string{
 		zeroTheme.accent.Render("Signing in with " + name),

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -1,19 +1,67 @@
 package tui
 
 import (
+	"context"
 	"net"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/providercatalog"
+	"github.com/Gitlawb/zero/internal/provideroauth"
 	"github.com/Gitlawb/zero/internal/redaction"
 )
+
+// providerWizardOAuthMsg carries the result of an in-wizard browser OAuth login.
+type providerWizardOAuthMsg struct {
+	apiKey string
+	err    error
+}
+
+// applyProviderWizardOAuth folds an OAuth login result into the wizard: on
+// success the minted key fills the credential and the wizard advances; on failure
+// the (redacted) error is shown and the user can retry or paste a key.
+func (m model) applyProviderWizardOAuth(msg providerWizardOAuthMsg) (model, tea.Cmd) {
+	if m.providerWizard == nil {
+		return m, nil
+	}
+	m.providerWizard.oauthPending = false
+	if msg.err != nil {
+		m.providerWizard.oauthErr = redaction.ErrorMessage(msg.err, redaction.Options{})
+		return m, nil
+	}
+	m.providerWizard.apiKey = msg.apiKey
+	return m.advanceProviderWizard()
+}
+
+// providerWizardSupportsOAuth reports whether the credential step should offer a
+// browser "Log in with OAuth" option for this provider. Only providers whose
+// OAuth flow yields a credential usable directly (OpenRouter mints an API key)
+// are offered — subscription providers (ChatGPT/Claude) use the proxy preset, and
+// API-key-only providers just paste a key.
+func providerWizardSupportsOAuth(provider providercatalog.Descriptor) bool {
+	return provider.ID == "openrouter"
+}
+
+// providerWizardOAuthCmd runs the provider's browser OAuth login off the UI
+// goroutine and reports the outcome as a providerWizardOAuthMsg. Currently only
+// OpenRouter (PKCE → minted API key) is supported.
+func providerWizardOAuthCmd() tea.Cmd {
+	return func() tea.Msg {
+		key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
+			OpenBrowser: browser.OpenURL,
+			Timeout:     3 * time.Minute,
+		})
+		return providerWizardOAuthMsg{apiKey: key, err: err}
+	}
+}
 
 const maxProviderWizardProvidersVisible = 8
 const maxProviderWizardModelsVisible = 10
@@ -54,6 +102,8 @@ type providerWizardState struct {
 	modelLoading     bool
 	modelLoadError   string
 	discoveryToken   int
+	oauthPending     bool
+	oauthErr         string
 }
 
 func (m model) newProviderWizard() *providerWizardState {
@@ -125,6 +175,8 @@ func (wizard *providerWizardState) move(delta int) {
 		wizard.modelSource = ""
 		wizard.modelLoading = false
 		wizard.modelLoadError = ""
+		wizard.oauthPending = false
+		wizard.oauthErr = ""
 		wizard.refreshModels()
 	case providerWizardStepModel:
 		wizard.refreshModels()
@@ -327,9 +379,24 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		}
 	}
 	if m.providerWizard.step == providerWizardStepCredential {
+		// While a browser OAuth login is in flight, ignore input except Esc (which
+		// abandons the wizard; the background flow simply times out and is dropped).
+		if m.providerWizard.oauthPending {
+			if msg.Type == tea.KeyEsc {
+				m.providerWizard = nil
+			}
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeyEsc:
 			m.providerWizard = nil
+			return m, nil
+		case tea.KeyCtrlO:
+			if providerWizardSupportsOAuth(m.providerWizard.currentProvider()) {
+				m.providerWizard.oauthPending = true
+				m.providerWizard.oauthErr = ""
+				return m, providerWizardOAuthCmd()
+			}
 			return m, nil
 		case tea.KeyRunes:
 			m.providerWizard.appendAPIKey(msg.Runes)
@@ -761,18 +828,37 @@ func (wizard *providerWizardState) renderNameStep(width int) []string {
 
 func (wizard *providerWizardState) renderCredentialStep(width int) []string {
 	provider := wizard.currentProvider()
+	oauth := providerWizardSupportsOAuth(provider)
+
+	// In-flight browser OAuth: show a waiting state instead of the key prompt.
+	if wizard.oauthPending {
+		return []string{
+			zeroTheme.accent.Render("Logging in with OAuth"),
+			zeroTheme.ink.Render("Opening your browser to authorize — approve there, then return here."),
+			zeroTheme.faint.Render("If the browser didn't open, run:  zero auth openrouter"),
+			zeroTheme.faint.Render("Esc to cancel."),
+		}
+	}
+
 	env := firstProviderDisplayValue(provider.AuthEnvVars...)
 	value := zeroTheme.accent.Render("▌") + zeroTheme.faint.Render("paste key here")
 	if wizard.apiKey != "" {
 		value = zeroTheme.ink.Render(maskedProviderWizardKey(wizard.apiKey)) + zeroTheme.accent.Render("▌")
 	}
 	input := zeroTheme.userPrompt.Render("api key > ") + value
-	return []string{
+	lines := []string{
 		zeroTheme.accent.Render("Paste API key"),
 		zeroTheme.ink.Render(providerWizardCredentialInstruction(env)),
 		input,
 		zeroTheme.faint.Render("Pasted keys are hidden and saved in your user config."),
 	}
+	if oauth {
+		lines = append(lines, zeroTheme.accent.Render("or  ctrl+o  to log in with OAuth in the browser (no key needed)"))
+	}
+	if wizard.oauthErr != "" {
+		lines = append(lines, zeroTheme.red.Render("OAuth login failed: "+wizard.oauthErr))
+	}
+	return lines
 }
 
 func providerWizardCredentialInstruction(env string) string {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -150,10 +150,11 @@ func providerWizardMethodOptions() []providerWizardMethodOption {
 	return options
 }
 
-// providerWizardOAuthDescriptors returns the OAuth-capable providers as the
-// wizard's provider list (used after the OAuth method is chosen).
+// providerWizardOAuthDescriptors returns the provider list shown after the OAuth
+// method is chosen: the real OAuth providers first, then the subscription
+// proxy entries (ChatGPT / Claude) which route to local-proxy setup.
 func providerWizardOAuthDescriptors() []providercatalog.Descriptor {
-	return providercatalog.OAuthProviders()
+	return append(providercatalog.OAuthProviders(), providercatalog.OAuthProxyProviders()...)
 }
 
 type providerWizardModel struct {
@@ -203,6 +204,35 @@ func providerWizardProviders() []providercatalog.Descriptor {
 		providers = append(providers, descriptor)
 	}
 	return providers
+}
+
+// selectBrowseProvider leaves OAuth mode and switches to the full browse catalog
+// with the given provider id selected, pre-filling the catalog defaults so the
+// user can accept them. Used to route a subscription proxy entry (ChatGPT /
+// Claude) into the normal endpoint/model setup instead of a real OAuth login.
+func (wizard *providerWizardState) selectBrowseProvider(id string) {
+	if wizard == nil {
+		return
+	}
+	wizard.oauthMode = false
+	wizard.oauthPending = false
+	wizard.oauthErr = ""
+	wizard.providers = providerWizardProviders()
+	wizard.selectedProvider = 0
+	for index, provider := range wizard.providers {
+		if provider.ID == id {
+			wizard.selectedProvider = index
+			break
+		}
+	}
+	provider := wizard.currentProvider()
+	wizard.selectedModel = 0
+	wizard.modelSearch = provider.DefaultModel
+	wizard.baseURL = provider.DefaultBaseURL
+	wizard.profileName = ""
+	wizard.apiKey = ""
+	wizard.err = ""
+	wizard.refreshModels()
 }
 
 func (wizard *providerWizardState) currentProvider() providercatalog.Descriptor {
@@ -421,6 +451,11 @@ func providerWizardNeedsCredential(provider providercatalog.Descriptor) bool {
 }
 
 func providerWizardNeedsEndpoint(provider providercatalog.Descriptor) bool {
+	// Subscription proxy entries always need a user-supplied URL (the local
+	// proxy's port varies), as do the fully custom compatible providers.
+	if provider.OAuthProxy {
+		return true
+	}
 	switch provider.ID {
 	case "custom-openai-compatible", "custom-anthropic-compatible":
 		return true
@@ -953,6 +988,9 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 
 // providerWizardOAuthBadge is the faint mode hint shown next to OAuth providers.
 func providerWizardOAuthBadge(provider providercatalog.Descriptor) string {
+	if provider.OAuthProxy {
+		return "subscription · needs a local proxy"
+	}
 	if !provider.OAuth {
 		return ""
 	}

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -223,11 +223,12 @@ func providerWizardMethodOptions() []providerWizardMethodOption {
 	return options
 }
 
-// providerWizardOAuthDescriptors returns the provider list shown after the OAuth
-// method is chosen: the real OAuth providers first, then the subscription
-// proxy entries (ChatGPT / Claude) which route to local-proxy setup.
+// providerWizardOAuthDescriptors returns the OAuth-capable providers as the
+// wizard's provider list (used after the OAuth method is chosen). ChatGPT/Claude
+// are deliberately not here — they can't do real in-app OAuth (see
+// docs/oauth-subscriptions.md); use "browse" + a local proxy for those.
 func providerWizardOAuthDescriptors() []providercatalog.Descriptor {
-	return append(providercatalog.OAuthProviders(), providercatalog.OAuthProxyProviders()...)
+	return providercatalog.OAuthProviders()
 }
 
 type providerWizardModel struct {
@@ -281,35 +282,6 @@ func providerWizardProviders() []providercatalog.Descriptor {
 		providers = append(providers, descriptor)
 	}
 	return providers
-}
-
-// selectBrowseProvider leaves OAuth mode and switches to the full browse catalog
-// with the given provider id selected, pre-filling the catalog defaults so the
-// user can accept them. Used to route a subscription proxy entry (ChatGPT /
-// Claude) into the normal endpoint/model setup instead of a real OAuth login.
-func (wizard *providerWizardState) selectBrowseProvider(id string) {
-	if wizard == nil {
-		return
-	}
-	wizard.oauthMode = false
-	wizard.oauthPending = false
-	wizard.oauthErr = ""
-	wizard.providers = providerWizardProviders()
-	wizard.selectedProvider = 0
-	for index, provider := range wizard.providers {
-		if provider.ID == id {
-			wizard.selectedProvider = index
-			break
-		}
-	}
-	provider := wizard.currentProvider()
-	wizard.selectedModel = 0
-	wizard.modelSearch = provider.DefaultModel
-	wizard.baseURL = provider.DefaultBaseURL
-	wizard.profileName = ""
-	wizard.apiKey = ""
-	wizard.err = ""
-	wizard.refreshModels()
 }
 
 func (wizard *providerWizardState) currentProvider() providercatalog.Descriptor {
@@ -528,11 +500,6 @@ func providerWizardNeedsCredential(provider providercatalog.Descriptor) bool {
 }
 
 func providerWizardNeedsEndpoint(provider providercatalog.Descriptor) bool {
-	// Subscription proxy entries always need a user-supplied URL (the local
-	// proxy's port varies), as do the fully custom compatible providers.
-	if provider.OAuthProxy {
-		return true
-	}
 	switch provider.ID {
 	case "custom-openai-compatible", "custom-anthropic-compatible":
 		return true
@@ -1090,9 +1057,6 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 
 // providerWizardOAuthBadge is the faint mode hint shown next to OAuth providers.
 func providerWizardOAuthBadge(provider providercatalog.Descriptor) string {
-	if provider.OAuthProxy {
-		return "subscription · needs a local proxy"
-	}
 	if !provider.OAuth {
 		return ""
 	}

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -14,15 +15,20 @@ import (
 
 	"github.com/Gitlawb/zero/internal/browser"
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/provideroauth"
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
 // providerWizardOAuthMsg carries the result of an in-wizard browser OAuth login.
+// apiKey is set when the flow mints a key (OpenRouter); tokenLogin is set when the
+// flow stored an OAuth token in the oauth store (xAI) that the runtime resolver
+// will attach — in that case no key is needed on the profile.
 type providerWizardOAuthMsg struct {
-	apiKey string
-	err    error
+	apiKey     string
+	tokenLogin bool
+	err        error
 }
 
 // applyProviderWizardOAuth folds an OAuth login result into the wizard: on
@@ -37,8 +43,16 @@ func (m model) applyProviderWizardOAuth(msg providerWizardOAuthMsg) (model, tea.
 		m.providerWizard.oauthErr = redaction.ErrorMessage(msg.err, redaction.Options{})
 		return m, nil
 	}
-	m.providerWizard.apiKey = msg.apiKey
-	return m.advanceProviderWizard()
+	if msg.apiKey != "" {
+		m.providerWizard.apiKey = msg.apiKey
+	}
+	// OAuth succeeded (key minted, or a refreshable token stored for the runtime
+	// resolver). Skip the endpoint/credential steps and go straight to model
+	// selection.
+	m.providerWizard.err = ""
+	m.providerWizard.oauthErr = ""
+	m.providerWizard.step = providerWizardStepModel
+	return m, m.providerModelDiscoveryCmd()
 }
 
 // providerWizardSupportsOAuth reports whether the credential step should offer a
@@ -47,20 +61,48 @@ func (m model) applyProviderWizardOAuth(msg providerWizardOAuthMsg) (model, tea.
 // are offered — subscription providers (ChatGPT/Claude) use the proxy preset, and
 // API-key-only providers just paste a key.
 func providerWizardSupportsOAuth(provider providercatalog.Descriptor) bool {
-	return provider.ID == "openrouter"
+	return provider.OAuth
 }
 
-// providerWizardOAuthCmd runs the provider's browser OAuth login off the UI
-// goroutine and reports the outcome as a providerWizardOAuthMsg. Currently only
-// OpenRouter (PKCE → minted API key) is supported.
-func providerWizardOAuthCmd() tea.Cmd {
-	return func() tea.Msg {
-		key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
-			OpenBrowser: browser.OpenURL,
-			Timeout:     3 * time.Minute,
-		})
-		return providerWizardOAuthMsg{apiKey: key, err: err}
+// providerWizardOAuthCmdFor runs the chosen provider's browser OAuth login off the
+// UI goroutine and reports the outcome. OpenRouter mints an API key; other OAuth
+// providers (xAI) run the generic engine login which stores a refreshable token.
+func providerWizardOAuthCmdFor(provider providercatalog.Descriptor) tea.Cmd {
+	if provider.OAuthMintsKey {
+		return func() tea.Msg {
+			key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
+				OpenBrowser: browser.OpenURL,
+				Timeout:     3 * time.Minute,
+			})
+			return providerWizardOAuthMsg{apiKey: key, err: err}
+		}
 	}
+	name := provider.ID
+	return func() tea.Msg {
+		return providerWizardOAuthMsg{tokenLogin: true, err: runProviderTokenLogin(name)}
+	}
+}
+
+// runProviderTokenLogin runs the generic OAuth engine login for a provider that
+// has a built-in preset (e.g. xAI), storing a refreshable token under
+// provider:<name>. The runtime resolver then attaches it to model calls.
+func runProviderTokenLogin(name string) error {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return err
+	}
+	manager, err := oauth.NewManager(oauth.ManagerOptions{
+		Store:       store,
+		HTTPClient:  &http.Client{Timeout: 60 * time.Second},
+		OpenBrowser: browser.OpenURL,
+	})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	_, err = manager.Login(ctx, oauth.LoginOptions{Provider: name})
+	return err
 }
 
 const maxProviderWizardProvidersVisible = 8
@@ -73,13 +115,46 @@ const providerWizardModelWidth = 92
 type providerWizardStep int
 
 const (
-	providerWizardStepProvider providerWizardStep = iota
+	providerWizardStepMethod providerWizardStep = iota
+	providerWizardStepProvider
 	providerWizardStepEndpoint
 	providerWizardStepName
 	providerWizardStepCredential
 	providerWizardStepModel
 	providerWizardStepDone
 )
+
+// providerWizardMethodOption is a row in the "How do you want to connect?" step.
+type providerWizardMethodOption struct {
+	oauth    bool
+	label    string
+	subtitle string
+}
+
+// providerWizardMethodOptions returns the connect-method rows. OAuth is listed
+// first (and is the default) when any OAuth-capable provider exists.
+func providerWizardMethodOptions() []providerWizardMethodOption {
+	options := []providerWizardMethodOption{}
+	if len(providercatalog.OAuthProviders()) > 0 {
+		options = append(options, providerWizardMethodOption{
+			oauth:    true,
+			label:    "Sign in with OAuth",
+			subtitle: "One-click browser login, no API key to copy (OpenRouter, xAI).",
+		})
+	}
+	options = append(options, providerWizardMethodOption{
+		oauth:    false,
+		label:    "Paste an API key / browse providers",
+		subtitle: "Any of 20+ providers, a local model, or a subscription via proxy.",
+	})
+	return options
+}
+
+// providerWizardOAuthDescriptors returns the OAuth-capable providers as the
+// wizard's provider list (used after the OAuth method is chosen).
+func providerWizardOAuthDescriptors() []providercatalog.Descriptor {
+	return providercatalog.OAuthProviders()
+}
 
 type providerWizardModel struct {
 	ID          string
@@ -102,6 +177,8 @@ type providerWizardState struct {
 	modelLoading     bool
 	modelLoadError   string
 	discoveryToken   int
+	selectedMethod   int
+	oauthMode        bool
 	oauthPending     bool
 	oauthErr         string
 }
@@ -109,7 +186,7 @@ type providerWizardState struct {
 func (m model) newProviderWizard() *providerWizardState {
 	providers := providerWizardProviders()
 	wizard := &providerWizardState{
-		step:             providerWizardStepProvider,
+		step:             providerWizardStepMethod,
 		providers:        providers,
 		selectedProvider: 0,
 	}
@@ -161,6 +238,12 @@ func (wizard *providerWizardState) move(delta int) {
 		return
 	}
 	switch wizard.step {
+	case providerWizardStepMethod:
+		options := providerWizardMethodOptions()
+		if len(options) == 0 {
+			return
+		}
+		wizard.selectedMethod = ((wizard.selectedMethod+delta)%len(options) + len(options)) % len(options)
 	case providerWizardStepProvider:
 		if len(wizard.providers) == 0 {
 			return
@@ -193,7 +276,26 @@ func (wizard *providerWizardState) advance() {
 		return
 	}
 	switch wizard.step {
+	case providerWizardStepMethod:
+		options := providerWizardMethodOptions()
+		wizard.selectedMethod = clampInt(wizard.selectedMethod, 0, maxInt(0, len(options)-1))
+		wizard.err = ""
+		if len(options) > 0 && options[wizard.selectedMethod].oauth {
+			wizard.oauthMode = true
+			wizard.providers = providerWizardOAuthDescriptors()
+		} else {
+			wizard.oauthMode = false
+			wizard.providers = providerWizardProviders()
+		}
+		wizard.selectedProvider = 0
+		wizard.refreshModels()
+		wizard.step = providerWizardStepProvider
 	case providerWizardStepProvider:
+		// In OAuth mode, advancing starts the browser/device login (dispatched by
+		// advanceProviderWizard at the model level), not the key/endpoint flow.
+		if wizard.oauthMode {
+			return
+		}
 		wizard.refreshModels()
 		wizard.err = ""
 		if providerWizardNeedsEndpoint(wizard.currentProvider()) {
@@ -251,6 +353,10 @@ func (wizard *providerWizardState) retreat() {
 	}
 	wizard.err = ""
 	switch wizard.step {
+	case providerWizardStepProvider:
+		wizard.oauthMode = false
+		wizard.oauthErr = ""
+		wizard.step = providerWizardStepMethod
 	case providerWizardStepEndpoint:
 		wizard.step = providerWizardStepProvider
 	case providerWizardStepName:
@@ -335,6 +441,14 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 	if m.providerWizard == nil {
 		return m, nil
 	}
+	// While a browser/device OAuth login is in flight, ignore input except Esc,
+	// which abandons the wizard (the background flow times out and is dropped).
+	if m.providerWizard.oauthPending {
+		if msg.Type == tea.KeyEsc {
+			m.providerWizard = nil
+		}
+		return m, nil
+	}
 	if m.providerWizard.step == providerWizardStepEndpoint {
 		switch msg.Type {
 		case tea.KeyRunes:
@@ -379,14 +493,6 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 		}
 	}
 	if m.providerWizard.step == providerWizardStepCredential {
-		// While a browser OAuth login is in flight, ignore input except Esc (which
-		// abandons the wizard; the background flow simply times out and is dropped).
-		if m.providerWizard.oauthPending {
-			if msg.Type == tea.KeyEsc {
-				m.providerWizard = nil
-			}
-			return m, nil
-		}
 		switch msg.Type {
 		case tea.KeyEsc:
 			m.providerWizard = nil
@@ -395,7 +501,7 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 			if providerWizardSupportsOAuth(m.providerWizard.currentProvider()) {
 				m.providerWizard.oauthPending = true
 				m.providerWizard.oauthErr = ""
-				return m, providerWizardOAuthCmd()
+				return m, providerWizardOAuthCmdFor(m.providerWizard.currentProvider())
 			}
 			return m, nil
 		case tea.KeyRunes:
@@ -461,6 +567,8 @@ func (wizard *providerWizardState) canAdvanceWithRight() bool {
 		return false
 	}
 	switch wizard.step {
+	case providerWizardStepMethod:
+		return len(providerWizardMethodOptions()) > 0
 	case providerWizardStepProvider:
 		return strings.TrimSpace(wizard.currentProvider().ID) != ""
 	case providerWizardStepEndpoint:
@@ -634,7 +742,21 @@ func (wizard *providerWizardState) render(width int) string {
 	if wizard.err != "" {
 		lines = append(lines, zeroTheme.red.Render("error: "+wizard.err), "")
 	}
+	if wizard.oauthPending {
+		lines = append(lines, wizard.renderOAuthWaiting(innerWidth)...)
+		lines = append(lines,
+			zeroTheme.line.Render(strings.Repeat("─", innerWidth)),
+			zeroTheme.faint.Render("Esc cancel"),
+		)
+		block := styledBlockFillTitle(overlayWidth, "Provider setup", lines, zeroTheme.lineStrong, lipgloss.NewStyle())
+		if width > overlayWidth {
+			return indentBlock(block, (width-overlayWidth)/2)
+		}
+		return block
+	}
 	switch wizard.step {
+	case providerWizardStepMethod:
+		lines = append(lines, wizard.renderMethodStep(innerWidth)...)
 	case providerWizardStepProvider:
 		lines = append(lines, wizard.renderProviderStep(innerWidth)...)
 	case providerWizardStepEndpoint:
@@ -663,11 +785,13 @@ func (wizard *providerWizardState) render(width int) string {
 func (wizard *providerWizardState) footer() string {
 	canRight := wizard.canAdvanceWithRight()
 	switch wizard.step {
+	case providerWizardStepMethod:
+		return "↑/↓ move   Enter/→ continue   Esc close"
 	case providerWizardStepProvider:
 		if canRight {
-			return "↑/↓ move   Enter/→ continue   Esc close"
+			return "↑/↓ move   Enter/→ continue   ← back   Esc close"
 		}
-		return "↑/↓ move   Enter continue   Esc close"
+		return "↑/↓ move   Enter continue   ← back   Esc close"
 	case providerWizardStepEndpoint:
 		if canRight {
 			return "Enter/→ continue   ← back   Esc close"
@@ -713,49 +837,34 @@ func providerWizardStepLine(wizard *providerWizardState) string {
 		return ""
 	}
 	step := wizard.step
-	steps := []struct {
+	type stepLabel struct {
 		step  providerWizardStep
 		label string
-	}{
-		{providerWizardStepProvider, "1 provider"},
 	}
-	if providerWizardNeedsEndpoint(wizard.currentProvider()) {
+	steps := []stepLabel{
+		{providerWizardStepMethod, "1 method"},
+		{providerWizardStepProvider, "2 provider"},
+	}
+	switch {
+	case wizard.oauthMode:
+		// OAuth path skips endpoint/name/key entirely.
 		steps = append(steps,
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepEndpoint, "2 endpoint"},
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepName, "3 name"},
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepCredential, "4 key"},
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepModel, "5 model"},
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepDone, "6 ready"},
+			stepLabel{providerWizardStepModel, "3 model"},
+			stepLabel{providerWizardStepDone, "4 ready"},
 		)
-	} else {
+	case providerWizardNeedsEndpoint(wizard.currentProvider()):
 		steps = append(steps,
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepCredential, "2 key"},
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepModel, "3 model"},
-			struct {
-				step  providerWizardStep
-				label string
-			}{providerWizardStepDone, "4 ready"},
+			stepLabel{providerWizardStepEndpoint, "3 endpoint"},
+			stepLabel{providerWizardStepName, "4 name"},
+			stepLabel{providerWizardStepCredential, "5 key"},
+			stepLabel{providerWizardStepModel, "6 model"},
+			stepLabel{providerWizardStepDone, "7 ready"},
+		)
+	default:
+		steps = append(steps,
+			stepLabel{providerWizardStepCredential, "3 key"},
+			stepLabel{providerWizardStepModel, "4 model"},
+			stepLabel{providerWizardStepDone, "5 ready"},
 		)
 	}
 	parts := make([]string, 0, len(steps))
@@ -769,8 +878,56 @@ func providerWizardStepLine(wizard *providerWizardState) string {
 	return strings.Join(parts, "  ")
 }
 
+// renderMethodStep renders the "How do you want to connect?" chooser.
+func (wizard *providerWizardState) renderMethodStep(width int) []string {
+	options := providerWizardMethodOptions()
+	wizard.selectedMethod = clampInt(wizard.selectedMethod, 0, maxInt(0, len(options)-1))
+	lines := []string{zeroTheme.accent.Render("How do you want to connect?")}
+	for index, option := range options {
+		surface := transparentSurface
+		marker := surface(zeroTheme.faintest).Render("  ")
+		if index == wizard.selectedMethod {
+			surface = zeroTheme.onSel
+			marker = surface(zeroTheme.accent).Render("❯ ")
+		}
+		lines = append(lines, fitStyledLine(marker+surface(zeroTheme.ink).Render(option.label), width))
+		lines = append(lines, fitStyledLine("    "+zeroTheme.faint.Render(option.subtitle), width))
+	}
+	return lines
+}
+
+// renderOAuthWaiting renders the in-flight browser/device login screen.
+func (wizard *providerWizardState) renderOAuthWaiting(width int) []string {
+	provider := wizard.currentProvider()
+	name := provider.Name
+	if name == "" {
+		name = "the provider"
+	}
+	return []string{
+		zeroTheme.accent.Render("Signing in with " + name),
+		"",
+		fitStyledLine(zeroTheme.ink.Render("Opening your browser — approve there, then return here."), width),
+		fitStyledLine(zeroTheme.faint.Render("Waiting for authorization..."), width),
+		"",
+		fitStyledLine(zeroTheme.faint.Render("If your browser didn't open, run:  "+providerWizardOAuthCLIHint(provider)), width),
+	}
+}
+
+// providerWizardOAuthCLIHint gives the equivalent CLI command for a provider's
+// OAuth login (fallback when the browser doesn't open).
+func providerWizardOAuthCLIHint(provider providercatalog.Descriptor) string {
+	if provider.OAuthMintsKey {
+		return "zero auth openrouter"
+	}
+	return "zero auth login " + provider.ID
+}
+
 func (wizard *providerWizardState) renderProviderStep(width int) []string {
-	lines := []string{zeroTheme.accent.Render("Choose provider")}
+	header := "Choose provider"
+	if wizard.oauthMode {
+		header = "Choose an OAuth provider"
+	}
+	lines := []string{zeroTheme.accent.Render(header)}
 	maxVisible := minInt(maxProviderWizardProvidersVisible, len(wizard.providers))
 	start := selectableListStart(len(wizard.providers), maxVisible, wizard.selectedProvider)
 	for offset, provider := range wizard.providers[start : start+maxVisible] {
@@ -788,7 +945,24 @@ func (wizard *providerWizardState) renderSelectableProvider(width int, index int
 		marker = surface(zeroTheme.accent).Render("❯ ")
 	}
 	left := marker + surface(zeroTheme.ink).Render(provider.Name)
+	if badge := providerWizardOAuthBadge(provider); badge != "" {
+		left += surface(zeroTheme.faint).Render("   " + badge)
+	}
 	return fitStyledLine(left, width)
+}
+
+// providerWizardOAuthBadge is the faint mode hint shown next to OAuth providers.
+func providerWizardOAuthBadge(provider providercatalog.Descriptor) string {
+	if !provider.OAuth {
+		return ""
+	}
+	if provider.OAuthMintsKey {
+		return "browser sign-in · creates a key"
+	}
+	if provider.OAuthDeviceFlow {
+		return "browser or device code"
+	}
+	return "browser sign-in"
 }
 
 func (wizard *providerWizardState) renderEndpointStep(width int) []string {
@@ -829,16 +1003,6 @@ func (wizard *providerWizardState) renderNameStep(width int) []string {
 func (wizard *providerWizardState) renderCredentialStep(width int) []string {
 	provider := wizard.currentProvider()
 	oauth := providerWizardSupportsOAuth(provider)
-
-	// In-flight browser OAuth: show a waiting state instead of the key prompt.
-	if wizard.oauthPending {
-		return []string{
-			zeroTheme.accent.Render("Logging in with OAuth"),
-			zeroTheme.ink.Render("Opening your browser to authorize — approve there, then return here."),
-			zeroTheme.faint.Render("If the browser didn't open, run:  zero auth openrouter"),
-			zeroTheme.faint.Render("Esc to cancel."),
-		}
-	}
 
 	env := firstProviderDisplayValue(provider.AuthEnvVars...)
 	value := zeroTheme.accent.Render("▌") + zeroTheme.faint.Render("paste key here")

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -27,10 +27,19 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 	}
 	// OAuth path: advancing from the OAuth provider list starts the browser/device
 	// login instead of the key/endpoint flow.
-	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode && m.providerWizard.currentProvider().OAuth {
-		m.providerWizard.oauthPending = true
-		m.providerWizard.oauthErr = ""
-		return m, providerWizardOAuthCmdFor(m.providerWizard.currentProvider())
+	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode {
+		provider := m.providerWizard.currentProvider()
+		if provider.OAuth {
+			m.providerWizard.oauthPending = true
+			m.providerWizard.oauthErr = ""
+			return m, providerWizardOAuthCmdFor(provider)
+		}
+		// Subscription proxy entry (ChatGPT / Claude): no real OAuth login —
+		// route into the normal browse setup so the user points at their local
+		// proxy URL, then fall through to the standard advance below.
+		if provider.OAuthProxy {
+			m.providerWizard.selectBrowseProvider(provider.ID)
+		}
 	}
 	previous := m.providerWizard.step
 	m.providerWizard.advance()

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -25,6 +25,13 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 	if m.providerWizard == nil {
 		return m, nil
 	}
+	// OAuth path: advancing from the OAuth provider list starts the browser/device
+	// login instead of the key/endpoint flow.
+	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode && m.providerWizard.currentProvider().OAuth {
+		m.providerWizard.oauthPending = true
+		m.providerWizard.oauthErr = ""
+		return m, providerWizardOAuthCmdFor(m.providerWizard.currentProvider())
+	}
 	previous := m.providerWizard.step
 	m.providerWizard.advance()
 	if m.providerWizard.step == providerWizardStepModel && previous != providerWizardStepModel {

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -19,6 +19,9 @@ type providerModelsDiscoveredMsg struct {
 	token      int
 	models     []providermodeldiscovery.Model
 	err        error
+	// secrets are redacted from any surfaced error (e.g. a resolved OAuth token
+	// used to authenticate discovery, which must never be logged or shown).
+	secrets []string
 }
 
 func (m model) advanceProviderWizard() (model, tea.Cmd) {
@@ -67,7 +70,11 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 	if providerWizardUsesTypedModel(provider) {
 		return nil
 	}
-	profile := providerWizardDiscoveryProfile(provider, wizard.apiKey)
+	pastedKey := wizard.apiKey
+	// A token-login provider (e.g. xAI) stores its bearer in the OAuth store, not
+	// as a pasted key; resolve it so /models is authenticated and the live list
+	// shows after sign-in. (OpenRouter mints a key into wizard.apiKey already.)
+	needOAuthToken := strings.TrimSpace(pastedKey) == "" && provider.OAuth && !provider.OAuthMintsKey
 	discover := m.discoverProviderModels
 	if discover == nil {
 		discover = func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
@@ -81,10 +88,17 @@ func (m model) providerModelDiscoveryCmd() tea.Cmd {
 	token := wizard.discoveryToken
 	providerID := provider.ID
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(m.ctx, 8*time.Second)
+		ctx, cancel := context.WithTimeout(m.ctx, 12*time.Second)
 		defer cancel()
+		apiKey := pastedKey
+		if needOAuthToken {
+			if resolved := oauthStoredToken(ctx, providerID); resolved != "" {
+				apiKey = resolved
+			}
+		}
+		profile := providerWizardDiscoveryProfile(provider, apiKey)
 		models, err := discover(ctx, profile)
-		return providerModelsDiscoveredMsg{providerID: providerID, token: token, models: models, err: err}
+		return providerModelsDiscoveredMsg{providerID: providerID, token: token, models: models, err: err, secrets: []string{apiKey, profile.APIKey}}
 	}
 }
 
@@ -95,7 +109,7 @@ func (m model) applyProviderModelsDiscovered(msg providerModelsDiscoveredMsg) mo
 	}
 	wizard.modelLoading = false
 	if msg.err != nil {
-		wizard.modelLoadError = redaction.RedactString(msg.err.Error(), redaction.Options{ExtraSecretValues: []string{wizard.apiKey}})
+		wizard.modelLoadError = redaction.RedactString(msg.err.Error(), redaction.Options{ExtraSecretValues: append([]string{wizard.apiKey}, msg.secrets...)})
 		wizard.modelSource = "fallback"
 		wizard.refreshModels()
 		return m

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -30,7 +30,13 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode {
 		provider := m.providerWizard.currentProvider()
 		if provider.OAuth {
+			// Headless/SSH boxes can't open a browser — use device code there by
+			// default (the user can also force it with "d" from the list).
+			if provider.OAuthDeviceFlow && oauthPreferDeviceFlow() {
+				return m.startProviderDeviceLogin()
+			}
 			m.providerWizard.oauthPending = true
+			m.providerWizard.oauthDevice = false
 			m.providerWizard.oauthErr = ""
 			return m, providerWizardOAuthCmdFor(provider)
 		}

--- a/internal/tui/provider_wizard_discovery.go
+++ b/internal/tui/provider_wizard_discovery.go
@@ -30,25 +30,17 @@ func (m model) advanceProviderWizard() (model, tea.Cmd) {
 	}
 	// OAuth path: advancing from the OAuth provider list starts the browser/device
 	// login instead of the key/endpoint flow.
-	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode {
+	if m.providerWizard.step == providerWizardStepProvider && m.providerWizard.oauthMode && m.providerWizard.currentProvider().OAuth {
 		provider := m.providerWizard.currentProvider()
-		if provider.OAuth {
-			// Headless/SSH boxes can't open a browser — use device code there by
-			// default (the user can also force it with "d" from the list).
-			if provider.OAuthDeviceFlow && oauthPreferDeviceFlow() {
-				return m.startProviderDeviceLogin()
-			}
-			m.providerWizard.oauthPending = true
-			m.providerWizard.oauthDevice = false
-			m.providerWizard.oauthErr = ""
-			return m, providerWizardOAuthCmdFor(provider)
+		// Headless/SSH boxes can't open a browser — use device code there by
+		// default (the user can also force it with "d" from the list).
+		if provider.OAuthDeviceFlow && oauthPreferDeviceFlow() {
+			return m.startProviderDeviceLogin()
 		}
-		// Subscription proxy entry (ChatGPT / Claude): no real OAuth login —
-		// route into the normal browse setup so the user points at their local
-		// proxy URL, then fall through to the standard advance below.
-		if provider.OAuthProxy {
-			m.providerWizard.selectBrowseProvider(provider.ID)
-		}
+		m.providerWizard.oauthPending = true
+		m.providerWizard.oauthDevice = false
+		m.providerWizard.oauthErr = ""
+		return m, providerWizardOAuthCmdFor(provider)
 	}
 	previous := m.providerWizard.step
 	m.providerWizard.advance()

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -32,6 +32,76 @@ func wizardModelAt(t *testing.T, providerID string, step providerWizardStep) mod
 	return m
 }
 
+func TestProviderWizardMethodChooserOAuthPath(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	if m.providerWizard.step != providerWizardStepMethod {
+		t.Fatalf("wizard should open on the method chooser, got %v", m.providerWizard.step)
+	}
+	m.providerWizard.selectedMethod = 0 // "Sign in with OAuth" (default, first)
+	next, _ := m.advanceProviderWizard()
+	w := next.providerWizard
+	if w.step != providerWizardStepProvider || !w.oauthMode {
+		t.Fatalf("OAuth method should enter the provider step in oauthMode, got step=%v oauth=%v", w.step, w.oauthMode)
+	}
+	if len(w.providers) != len(providercatalog.OAuthProviders()) {
+		t.Fatalf("OAuth path should list only OAuth providers, got %d", len(w.providers))
+	}
+	for _, d := range w.providers {
+		if !d.OAuth {
+			t.Fatalf("non-OAuth provider %q in the OAuth list", d.ID)
+		}
+	}
+}
+
+func TestProviderWizardMethodChooserBrowsePath(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedMethod = len(providerWizardMethodOptions()) - 1 // "browse / API key"
+	next, _ := m.advanceProviderWizard()
+	w := next.providerWizard
+	if w.step != providerWizardStepProvider || w.oauthMode {
+		t.Fatalf("browse method should enter the provider step (not oauthMode), got step=%v oauth=%v", w.step, w.oauthMode)
+	}
+	if len(w.providers) <= len(providercatalog.OAuthProviders()) {
+		t.Fatalf("browse path should list the full catalog, got %d", len(w.providers))
+	}
+}
+
+func TestProviderWizardOAuthDispatchFromList(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedMethod = 0
+	next, _ := m.advanceProviderWizard() // → OAuth provider list
+	// select openrouter
+	for i, d := range next.providerWizard.providers {
+		if d.ID == "openrouter" {
+			next.providerWizard.selectedProvider = i
+		}
+	}
+	next, cmd := next.advanceProviderWizard()
+	if !next.providerWizard.oauthPending {
+		t.Fatal("advancing from the OAuth list should start the login (oauthPending)")
+	}
+	if cmd == nil {
+		t.Fatal("advancing from the OAuth list should return the OAuth command")
+	}
+}
+
+func TestProviderWizardRetreatFromProviderToMethod(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedMethod = 0
+	next, _ := m.advanceProviderWizard() // → OAuth provider list (oauthMode)
+	next.providerWizard.retreat()
+	if next.providerWizard.step != providerWizardStepMethod {
+		t.Fatalf("retreat from provider should return to method, got %v", next.providerWizard.step)
+	}
+	if next.providerWizard.oauthMode {
+		t.Fatal("retreat to method should clear oauthMode")
+	}
+}
+
 func TestProviderWizardSupportsOAuth(t *testing.T) {
 	or, _ := providercatalog.Get("openrouter")
 	if !providerWizardSupportsOAuth(or) {
@@ -105,7 +175,7 @@ func TestRenderCredentialStepShowsOAuthHintAndPending(t *testing.T) {
 		t.Fatal("credential step should show the ctrl+o OAuth hint for openrouter")
 	}
 	w.oauthPending = true
-	if !strings.Contains(strings.Join(w.renderCredentialStep(80), "\n"), "Opening your browser") {
+	if !strings.Contains(strings.Join(w.renderOAuthWaiting(80), "\n"), "Waiting for authorization") {
 		t.Fatal("pending state should show the browser-waiting message")
 	}
 }

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -44,49 +44,13 @@ func TestProviderWizardMethodChooserOAuthPath(t *testing.T) {
 	if w.step != providerWizardStepProvider || !w.oauthMode {
 		t.Fatalf("OAuth method should enter the provider step in oauthMode, got step=%v oauth=%v", w.step, w.oauthMode)
 	}
-	want := len(providercatalog.OAuthProviders()) + len(providercatalog.OAuthProxyProviders())
-	if len(w.providers) != want {
-		t.Fatalf("OAuth path should list OAuth + proxy providers, got %d want %d", len(w.providers), want)
+	if len(w.providers) != len(providercatalog.OAuthProviders()) {
+		t.Fatalf("OAuth path should list only OAuth providers, got %d", len(w.providers))
 	}
 	for _, d := range w.providers {
-		if !d.OAuth && !d.OAuthProxy {
-			t.Fatalf("provider %q in the OAuth list is neither OAuth nor a proxy entry", d.ID)
+		if !d.OAuth {
+			t.Fatalf("non-OAuth provider %q in the OAuth list", d.ID)
 		}
-	}
-}
-
-func TestProviderWizardProxyEntryRoutesToBrowse(t *testing.T) {
-	m := mouseTestModel()
-	m.providerWizard = m.newProviderWizard()
-	m.providerWizard.selectedMethod = 0
-	next, _ := m.advanceProviderWizard() // → OAuth provider list
-	found := false
-	for i, d := range next.providerWizard.providers {
-		if d.ID == "chatgpt-proxy" {
-			next.providerWizard.selectedProvider = i
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("chatgpt-proxy proxy entry not offered in the OAuth list")
-	}
-	next, cmd := next.advanceProviderWizard()
-	w := next.providerWizard
-	if w.oauthMode {
-		t.Fatal("selecting a proxy entry should leave OAuth mode")
-	}
-	if w.oauthPending || cmd != nil {
-		t.Fatalf("proxy entry must not start an OAuth login (pending=%v cmd!=nil=%v)", w.oauthPending, cmd != nil)
-	}
-	if w.step != providerWizardStepEndpoint {
-		t.Fatalf("proxy entry should route to the endpoint step, got %v", w.step)
-	}
-	if w.currentProvider().ID != "chatgpt-proxy" {
-		t.Fatalf("selected provider = %q, want chatgpt-proxy", w.currentProvider().ID)
-	}
-	if strings.TrimSpace(w.baseURL) == "" {
-		t.Fatal("proxy entry should pre-fill the default proxy URL")
 	}
 }
 

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -163,10 +163,16 @@ func TestProviderWizardOAuthDispatchFromList(t *testing.T) {
 	m.providerWizard.selectedMethod = 0
 	next, _ := m.advanceProviderWizard() // → OAuth provider list
 	// select openrouter
+	found := false
 	for i, d := range next.providerWizard.providers {
 		if d.ID == "openrouter" {
 			next.providerWizard.selectedProvider = i
+			found = true
+			break
 		}
+	}
+	if !found {
+		t.Fatal("openrouter not present in the OAuth provider list")
 	}
 	next, cmd := next.advanceProviderWizard()
 	if !next.providerWizard.oauthPending {

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -44,13 +44,49 @@ func TestProviderWizardMethodChooserOAuthPath(t *testing.T) {
 	if w.step != providerWizardStepProvider || !w.oauthMode {
 		t.Fatalf("OAuth method should enter the provider step in oauthMode, got step=%v oauth=%v", w.step, w.oauthMode)
 	}
-	if len(w.providers) != len(providercatalog.OAuthProviders()) {
-		t.Fatalf("OAuth path should list only OAuth providers, got %d", len(w.providers))
+	want := len(providercatalog.OAuthProviders()) + len(providercatalog.OAuthProxyProviders())
+	if len(w.providers) != want {
+		t.Fatalf("OAuth path should list OAuth + proxy providers, got %d want %d", len(w.providers), want)
 	}
 	for _, d := range w.providers {
-		if !d.OAuth {
-			t.Fatalf("non-OAuth provider %q in the OAuth list", d.ID)
+		if !d.OAuth && !d.OAuthProxy {
+			t.Fatalf("provider %q in the OAuth list is neither OAuth nor a proxy entry", d.ID)
 		}
+	}
+}
+
+func TestProviderWizardProxyEntryRoutesToBrowse(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedMethod = 0
+	next, _ := m.advanceProviderWizard() // → OAuth provider list
+	found := false
+	for i, d := range next.providerWizard.providers {
+		if d.ID == "chatgpt-proxy" {
+			next.providerWizard.selectedProvider = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("chatgpt-proxy proxy entry not offered in the OAuth list")
+	}
+	next, cmd := next.advanceProviderWizard()
+	w := next.providerWizard
+	if w.oauthMode {
+		t.Fatal("selecting a proxy entry should leave OAuth mode")
+	}
+	if w.oauthPending || cmd != nil {
+		t.Fatalf("proxy entry must not start an OAuth login (pending=%v cmd!=nil=%v)", w.oauthPending, cmd != nil)
+	}
+	if w.step != providerWizardStepEndpoint {
+		t.Fatalf("proxy entry should route to the endpoint step, got %v", w.step)
+	}
+	if w.currentProvider().ID != "chatgpt-proxy" {
+		t.Fatalf("selected provider = %q, want chatgpt-proxy", w.currentProvider().ID)
+	}
+	if strings.TrimSpace(w.baseURL) == "" {
+		t.Fatal("proxy entry should pre-fill the default proxy URL")
 	}
 }
 

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gitlawb/zero/internal/providercatalog"
+)
+
+// wizardModelAt builds a model whose provider wizard is at step with providerID
+// selected.
+func wizardModelAt(t *testing.T, providerID string, step providerWizardStep) model {
+	t.Helper()
+	m := mouseTestModel()
+	w := m.newProviderWizard()
+	idx := -1
+	for i, d := range w.providers {
+		if d.ID == providerID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("provider %q not offered by the wizard", providerID)
+	}
+	w.selectedProvider = idx
+	w.step = step
+	m.providerWizard = w
+	return m
+}
+
+func TestProviderWizardSupportsOAuth(t *testing.T) {
+	or, _ := providercatalog.Get("openrouter")
+	if !providerWizardSupportsOAuth(or) {
+		t.Fatal("openrouter should offer in-wizard OAuth")
+	}
+	oa, _ := providercatalog.Get("openai")
+	if providerWizardSupportsOAuth(oa) {
+		t.Fatal("openai should NOT offer in-wizard OAuth (no usable direct OAuth)")
+	}
+}
+
+func TestProviderWizardCtrlOStartsOAuthForOpenRouter(t *testing.T) {
+	m := wizardModelAt(t, "openrouter", providerWizardStepCredential)
+	next, cmd := m.handleProviderWizardKey(tea.KeyMsg{Type: tea.KeyCtrlO})
+	if next.providerWizard == nil || !next.providerWizard.oauthPending {
+		t.Fatal("ctrl+o should mark the wizard oauthPending")
+	}
+	if cmd == nil {
+		t.Fatal("ctrl+o should return a command to run the OAuth flow")
+	}
+}
+
+func TestProviderWizardCtrlONoopForNonOAuthProvider(t *testing.T) {
+	m := wizardModelAt(t, "openai", providerWizardStepCredential)
+	next, _ := m.handleProviderWizardKey(tea.KeyMsg{Type: tea.KeyCtrlO})
+	if next.providerWizard != nil && next.providerWizard.oauthPending {
+		t.Fatal("ctrl+o must not start OAuth for a provider that doesn't support it")
+	}
+}
+
+func TestApplyProviderWizardOAuthSuccessAdvances(t *testing.T) {
+	m := wizardModelAt(t, "openrouter", providerWizardStepCredential)
+	m.providerWizard.oauthPending = true
+	next, _ := m.applyProviderWizardOAuth(providerWizardOAuthMsg{apiKey: "sk-or-minted"})
+	if next.providerWizard == nil {
+		t.Fatal("wizard should remain open")
+	}
+	if next.providerWizard.oauthPending {
+		t.Fatal("pending should clear on success")
+	}
+	if next.providerWizard.apiKey != "sk-or-minted" {
+		t.Fatalf("minted key not applied: %q", next.providerWizard.apiKey)
+	}
+	if next.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("should advance to the model step, got %v", next.providerWizard.step)
+	}
+}
+
+func TestApplyProviderWizardOAuthErrorStays(t *testing.T) {
+	m := wizardModelAt(t, "openrouter", providerWizardStepCredential)
+	m.providerWizard.oauthPending = true
+	next, _ := m.applyProviderWizardOAuth(providerWizardOAuthMsg{err: errors.New("nope")})
+	if next.providerWizard == nil {
+		t.Fatal("wizard should remain open on error")
+	}
+	if next.providerWizard.oauthPending {
+		t.Fatal("pending should clear on error")
+	}
+	if next.providerWizard.step != providerWizardStepCredential {
+		t.Fatalf("should stay at credential step, got %v", next.providerWizard.step)
+	}
+	if next.providerWizard.oauthErr == "" {
+		t.Fatal("oauthErr should be set")
+	}
+}
+
+func TestRenderCredentialStepShowsOAuthHintAndPending(t *testing.T) {
+	m := wizardModelAt(t, "openrouter", providerWizardStepCredential)
+	w := m.providerWizard
+	if !strings.Contains(strings.Join(w.renderCredentialStep(80), "\n"), "ctrl+o") {
+		t.Fatal("credential step should show the ctrl+o OAuth hint for openrouter")
+	}
+	w.oauthPending = true
+	if !strings.Contains(strings.Join(w.renderCredentialStep(80), "\n"), "Opening your browser") {
+		t.Fatal("pending state should show the browser-waiting message")
+	}
+}

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -104,6 +104,95 @@ func TestProviderWizardMethodChooserBrowsePath(t *testing.T) {
 	}
 }
 
+func selectWizardOAuthProvider(t *testing.T, m model, id string) model {
+	t.Helper()
+	for i, d := range m.providerWizard.providers {
+		if d.ID == id {
+			m.providerWizard.selectedProvider = i
+			return m
+		}
+	}
+	t.Fatalf("provider %q not in the OAuth list", id)
+	return m
+}
+
+func TestProviderWizardDeviceShortcutStartsDeviceFlow(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedMethod = 0
+	next, _ := m.advanceProviderWizard() // → OAuth list
+	m = selectWizardOAuthProvider(t, next, "xai")
+
+	out, cmd := m.handleProviderWizardKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	if !out.providerWizard.oauthPending || !out.providerWizard.oauthDevice {
+		t.Fatalf("'d' should start device login (pending=%v device=%v)", out.providerWizard.oauthPending, out.providerWizard.oauthDevice)
+	}
+	if cmd == nil {
+		t.Fatal("'d' should return the device-prepare command")
+	}
+}
+
+func TestProviderWizardDeviceCodeMsgShowsCodeAndPolls(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.selectedMethod = 0
+	next, _ := m.advanceProviderWizard()
+	m = selectWizardOAuthProvider(t, next, "xai")
+	m.providerWizard.oauthPending = true
+	m.providerWizard.oauthDevice = true
+
+	out, cmd := m.applyProviderWizardDeviceCode(providerWizardDeviceCodeMsg{
+		providerID: "xai", userCode: "ABCD-1234", verifyURL: "https://x.ai/device",
+	})
+	if out.providerWizard.deviceUserCode != "ABCD-1234" || out.providerWizard.deviceVerificationURI != "https://x.ai/device" {
+		t.Fatalf("device code not stored: %+v", out.providerWizard)
+	}
+	if cmd == nil {
+		t.Fatal("device-code msg should start the poll command")
+	}
+	view := strings.Join(out.providerWizard.renderOAuthWaiting(72), "\n")
+	if !strings.Contains(view, "ABCD-1234") || !strings.Contains(view, "x.ai/device") {
+		t.Fatalf("waiting render missing device code/uri:\n%s", view)
+	}
+}
+
+func TestProviderWizardDeviceErrorSurfaced(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.oauthPending = true
+	m.providerWizard.oauthDevice = true
+
+	out, cmd := m.applyProviderWizardDeviceCode(providerWizardDeviceCodeMsg{
+		providerID: "xai", err: errors.New("device endpoint unreachable"),
+	})
+	if out.providerWizard.oauthPending || out.providerWizard.oauthDevice {
+		t.Fatal("device error should clear pending/device state")
+	}
+	if out.providerWizard.oauthErr == "" {
+		t.Fatal("device error should surface a message")
+	}
+	if cmd != nil {
+		t.Fatal("device error should not start a poll")
+	}
+}
+
+func TestProviderWizardOAuthSuccessClearsDeviceState(t *testing.T) {
+	m := mouseTestModel()
+	m.providerWizard = m.newProviderWizard()
+	m.providerWizard.oauthPending = true
+	m.providerWizard.oauthDevice = true
+	m.providerWizard.deviceUserCode = "X-1"
+	m.providerWizard.deviceVerificationURI = "https://x.ai/device"
+
+	out, _ := m.applyProviderWizardOAuth(providerWizardOAuthMsg{tokenLogin: true})
+	if out.providerWizard.oauthDevice || out.providerWizard.deviceUserCode != "" || out.providerWizard.deviceVerificationURI != "" {
+		t.Fatalf("success should clear device state: %+v", out.providerWizard)
+	}
+	if out.providerWizard.step != providerWizardStepModel {
+		t.Fatalf("success should advance to the model step, got %v", out.providerWizard.step)
+	}
+}
+
 func TestProviderWizardOAuthDispatchFromList(t *testing.T) {
 	m := mouseTestModel()
 	m.providerWizard = m.newProviderWizard()

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -31,24 +31,30 @@ func TestProviderCommandOpensOnboardingWizard(t *testing.T) {
 	if next.providerWizard == nil {
 		t.Fatal("expected provider wizard to be open")
 	}
-	if next.providerWizard.step != providerWizardStepProvider {
-		t.Fatalf("wizard step = %v, want provider catalog", next.providerWizard.step)
+	if next.providerWizard.step != providerWizardStepMethod {
+		t.Fatalf("wizard step = %v, want connect-method chooser", next.providerWizard.step)
 	}
 	if len(next.transcript) != len(m.transcript) {
 		t.Fatalf("/provider should not append transcript output when opening wizard")
 	}
+	// The wizard opens on the connect-method chooser, with OAuth listed first.
 	view := plainRender(t, next.View())
 	for _, want := range []string{
 		"Provider setup",
-		"Choose provider",
-		"OpenAI",
-		"Anthropic",
-		"Google",
-		"Groq",
-		"OpenRouter",
-		"Ollama",
+		"How do you want to connect?",
+		"Sign in with OAuth",
+		"Paste an API key",
 	} {
 		assertContains(t, view, want)
+	}
+
+	// Choosing the API-key method reveals the full provider catalog.
+	next.providerWizard.selectedMethod = len(providerWizardMethodOptions()) - 1
+	updated, _ = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(model)
+	listView := plainRender(t, next.View())
+	for _, want := range []string{"Choose provider", "OpenAI", "Anthropic", "Google", "Groq", "OpenRouter", "Ollama"} {
+		assertContains(t, listView, want)
 	}
 }
 
@@ -343,7 +349,7 @@ func TestProviderWizardCustomCompatibleProviderCollectsEndpointAndModel(t *testi
 		"Endpoint URL",
 		"url >",
 		"https://api.example.com/v1",
-		"2 endpoint",
+		"3 endpoint",
 	} {
 		assertContains(t, view, want)
 	}
@@ -978,6 +984,18 @@ func openProviderWizardForTest(t *testing.T, m model) model {
 	next := updated.(model)
 	if next.providerWizard == nil {
 		t.Fatal("expected provider wizard to be open")
+	}
+	// The wizard now opens on the connect-method chooser. These tests exercise the
+	// API-key / browse path, so select that method and advance into the provider
+	// list (the OAuth path is covered by the OAuth-specific tests).
+	if next.providerWizard.step == providerWizardStepMethod {
+		options := providerWizardMethodOptions()
+		next.providerWizard.selectedMethod = len(options) - 1 // last = "browse / API key"
+		u2, _ := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		next = u2.(model)
+		if next.providerWizard == nil || next.providerWizard.step != providerWizardStepProvider {
+			t.Fatalf("expected provider step after choosing API-key method, got %#v", next.providerWizard)
+		}
 	}
 	return next
 }


### PR DESCRIPTION
## Summary

Adds real OAuth / account login for the providers that support it, surfaced as a first-class **"Sign in with OAuth"** option in both the `/provider` wizard and first-run onboarding — no API key to paste. Two providers qualify today:

- **OpenRouter** — public PKCE flow that **mints an API key** (no client_id needed).
- **xAI (Grok)** — public OAuth client; the token is used directly as a bearer on `api.x.ai/v1`. Supports **browser** and **device-code** login.

For OpenAI/Anthropic *subscriptions* (ChatGPT/Claude), which can't be used as a standard bearer by a third-party tool, this ships a documented **local-proxy** path instead of an unreliable/ToS-risky direct login.

## What's included

**Runtime auth wiring**
- `providerio.SendWithAuthRetry` + `TokenResolver`: the OpenAI/Anthropic providers send `Authorization: Bearer <oauth>` when a login exists for the profile (auto-refreshed; one refresh-and-retry on `401`), else fall back to the API key. Never both. Zero per-request overhead for API-key users (resolver attached only when a login exists).

**OAuth engine & logins**
- `internal/oauth`: PKCE (S256), loopback browser flow, RFC 8628 device-code flow, token store (0600 / optional OS keyring), env-configurable providers (`ZERO_OAUTH_<NAME>_*`) + a built-in preset layer (xAI).
- `internal/provideroauth.OpenRouterLogin` (mints a key) and `zero auth openrouter`; `zero auth login xai [--device]`.

**In-app UX**
- A **"How do you want to connect?"** chooser (wizard + onboarding): *Sign in with OAuth* lists the OAuth-capable providers → browser/device login → straight to model selection. Browse/API-key path unchanged.
- **Device code** for headless/SSH: press `d` (or automatic on SSH / headless Linux / `ZERO_OAUTH_DEVICE=1`) — shows a URL + code to enter on another device.
- After login, model discovery is authenticated with the OAuth token, so the user picks from the **live** model list (curated fallback if offline).

**Subscription proxies (ChatGPT / Claude)**
- `chatgpt-proxy` preset + `docs/oauth-subscriptions.md`: full recipe for pointing Zero at a local proxy that holds the subscription session. ChatGPT/Claude are intentionally **not** in the OAuth chooser (they can't do clean in-app OAuth); they live under the browse path + proxy docs.

## Deliberately not included
Direct ChatGPT/Claude subscription login. Verified: the ChatGPT token only works against a Cloudflare-gated backend (403 for non-official clients), and Anthropic's terms prohibit third-party use of a Claude subscription token (enforced with account bans). Spoofing those official clients is fragile and account-risky, so it's not built — the proxy path is the supported alternative.

## Testing
- gofmt, `go vet`, build (host + linux + windows), `go test ./... -race` — all green.
- staticcheck (no new findings), govulncheck (0), deadcode (no new) — clean.
- Unit tests cover the bearer/retry logic, OAuth engine (loopback + two-phase device), the wizard/onboarding chooser + device shortcut, token-authenticated discovery, and catalog classification. OAuth/proxy flows verified against mock servers.
- No new module dependencies.

## Notes
The interactive browser/device approval and the live xAI `/models` response require a real account to confirm end-to-end; all surrounding logic is unit-tested and the OpenRouter mint flow was run-checked against a mock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added OAuth login across CLI and TUI, including `auth openrouter` (browser-based PKCE that prints an API key) and RFC 8628 device-code login where supported.
  * Introduced a new “connect method” step in onboarding/provider setup (including device-code shortcuts, OAuth badges, and device-code/browser waiting states).
  * Added per-request OAuth bearer auth for OpenAI- and Anthropic-compatible providers with automatic refresh-on-401 retry, plus optional built-in OAuth presets (opt-in for xAI).

* **Documentation**
  * Expanded the OAuth subscriptions guide with local proxy configuration examples.

* **Bug Fixes**
  * Improved OAuth-pending interaction handling (mouse input disabled) and avoided unnecessary onboarding by recognizing stored OAuth logins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->