### PR TITLE
web_search robustness + chat UX: collapse, clipboard, scroll-pin, proactive search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 toolchain go1.26.4
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
@@ -15,7 +16,6 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -71,6 +71,11 @@ work.
   managers). It is not a substitute for the file tools.
 - Treat tool output as ground truth. If a command fails, read the error, form a
   hypothesis, and address the root cause; do not retry the same call blindly.
+- When a web search or web fetch tool is available and the user asks about
+  something external you are unsure of or that may be current — a product,
+  library, company, price, version, or a recent event — search the web and read
+  the results before answering. Do not reply that you don't know without searching
+  first.
 
 ## Permission and safety
 

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -71,11 +71,17 @@ work.
   managers). It is not a substitute for the file tools.
 - Treat tool output as ground truth. If a command fails, read the error, form a
   hypothesis, and address the root cause; do not retry the same call blindly.
-- When a web search or web fetch tool is available and the user asks about
-  something external you are unsure of or that may be current — a product,
-  library, company, price, version, or a recent event — search the web and read
-  the results before answering. Do not reply that you don't know without searching
-  first.
+- When a web search or fetch tool is available, search the web before answering
+  about an external entity, product, library, model, company, version, or recent
+  release you do not recognize. Do not guess, and do not assume the most common
+  meaning of an ambiguous name — use the conversation's domain (this is an AI /
+  software tool) to disambiguate. If the first results look off-topic, refine the
+  query and search again before answering; never reply that you don't know without
+  searching first.
+- Do not web-search timeless facts, fundamentals, or anything answerable from the
+  workspace — read the code with the file tools instead. Keep queries short (a few
+  words), start broad then narrow, and scale the number of searches to the
+  question: one for a single fact, a few for a deeper answer.
 
 ## Permission and safety
 

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -19,7 +19,8 @@ func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
 		"verify after edits",
 		"honor the active permission mode",
 		"avoid broad refactors",
-		"search the web and read",
+		"search the web before answering",
+		"do not recognize",
 		"final response",
 	} {
 		if !strings.Contains(prompt, want) {

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -19,6 +19,7 @@ func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
 		"verify after edits",
 		"honor the active permission mode",
 		"avoid broad refactors",
+		"search the web and read",
 		"final response",
 	} {
 		if !strings.Contains(prompt, want) {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -429,6 +429,18 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 	}
 
 	needsSetup := setupRequired(resolved)
+	if needsSetup && !forceSetup {
+		// The active provider lacks a usable credential, but if another saved
+		// provider already has one, fall back to it instead of forcing onboarding
+		// again. Saved logins persist across launches; switch the active provider
+		// any time with `zero provider use <name>`. Onboarding only runs when no
+		// configured provider is usable (a genuinely fresh setup).
+		if usable, ok := firstUsableProvider(resolved.Providers); ok {
+			resolved.Provider = usable
+			resolved.ActiveProvider = usable.Name
+			needsSetup = false
+		}
+	}
 	setupVisible := forceSetup || needsSetup
 	configPath := ""
 	if setupVisible {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -289,6 +289,49 @@ func setupRequired(resolved config.ResolvedConfig) bool {
 	return missing
 }
 
+// firstUsableProvider returns the saved provider best suited to run without
+// onboarding: the first usable (inline credential present, or no-auth/local)
+// non-local provider, else the first usable local one. It lets the CLI fall back
+// to an already-configured login when the active provider happens to lack a
+// credential, instead of re-running onboarding every launch.
+func firstUsableProvider(providers []config.ProviderProfile) (config.ProviderProfile, bool) {
+	var localFallback config.ProviderProfile
+	haveLocal := false
+	for _, profile := range providers {
+		if !config.HasProviderProfile(profile) {
+			continue
+		}
+		if _, missing := setupMissingCredentialEnv(profile); missing {
+			continue
+		}
+		if providerProfileIsLocal(profile) {
+			if !haveLocal {
+				localFallback = profile
+				haveLocal = true
+			}
+			continue
+		}
+		return profile, true
+	}
+	if haveLocal {
+		return localFallback, true
+	}
+	return config.ProviderProfile{}, false
+}
+
+// providerProfileIsLocal reports whether a provider points at a local endpoint
+// (a loopback URL or a catalog entry flagged Local), so the fallback prefers a
+// remote keyed provider that is more likely reachable.
+func providerProfileIsLocal(profile config.ProviderProfile) bool {
+	if catalogID := strings.TrimSpace(profile.CatalogID); catalogID != "" {
+		if descriptor, err := providercatalog.Require(catalogID); err == nil && descriptor.Local {
+			return true
+		}
+	}
+	host := strings.ToLower(profile.BaseURL)
+	return strings.Contains(host, "localhost") || strings.Contains(host, "127.0.0.1") || strings.Contains(host, "[::1]")
+}
+
 func formatSetupComplete(result tui.SetupResult) string {
 	lines := []string{"Zero setup complete"}
 	if result.Provider.Name != "" {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode"
@@ -301,6 +302,15 @@ func firstUsableProvider(providers []config.ProviderProfile) (config.ProviderPro
 		if !config.HasProviderProfile(profile) {
 			continue
 		}
+		// A profile whose catalog entry no longer resolves AND that has no explicit
+		// BaseURL has no endpoint to talk to, so it cannot become a working
+		// provider — skip it rather than picking a fallback that fails at first use.
+		// (A stale CatalogID with a BaseURL still works as a custom endpoint.)
+		if catalogID := strings.TrimSpace(profile.CatalogID); catalogID != "" && strings.TrimSpace(profile.BaseURL) == "" {
+			if _, err := providercatalog.Require(catalogID); err != nil {
+				continue
+			}
+		}
 		if _, missing := setupMissingCredentialEnv(profile); missing {
 			continue
 		}
@@ -328,8 +338,19 @@ func providerProfileIsLocal(profile config.ProviderProfile) bool {
 			return true
 		}
 	}
-	host := strings.ToLower(profile.BaseURL)
-	return strings.Contains(host, "localhost") || strings.Contains(host, "127.0.0.1") || strings.Contains(host, "[::1]")
+	base := strings.TrimSpace(profile.BaseURL)
+	if base == "" {
+		return false
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
 }
 
 func formatSetupComplete(result tui.SetupResult) string {

--- a/internal/cli/setup_fallback_test.go
+++ b/internal/cli/setup_fallback_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestFirstUsableProviderPrefersRemoteKeyed(t *testing.T) {
 	providers := []config.ProviderProfile{
-		{Name: "ollama", CatalogID: "ollama", BaseURL: "http://localhost:11434/v1", APIKey: "k"},     // usable but local
+		{Name: "ollama", CatalogID: "ollama", BaseURL: "http://localhost:11434/v1", APIKey: "k"},      // usable but local
 		{Name: "moonshot", CatalogID: "moonshot", BaseURL: "https://api.moonshot.ai/v1", APIKey: "k"}, // usable, remote
 		{Name: "xai", CatalogID: "xai", APIKeyEnv: "XAI_API_KEY"},                                     // not usable (env only, no inline key)
 	}

--- a/internal/cli/setup_fallback_test.go
+++ b/internal/cli/setup_fallback_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+func TestFirstUsableProviderPrefersRemoteKeyed(t *testing.T) {
+	providers := []config.ProviderProfile{
+		{Name: "ollama", CatalogID: "ollama", BaseURL: "http://localhost:11434/v1", APIKey: "k"},     // usable but local
+		{Name: "moonshot", CatalogID: "moonshot", BaseURL: "https://api.moonshot.ai/v1", APIKey: "k"}, // usable, remote
+		{Name: "xai", CatalogID: "xai", APIKeyEnv: "XAI_API_KEY"},                                     // not usable (env only, no inline key)
+	}
+	got, ok := firstUsableProvider(providers)
+	if !ok || got.Name != "moonshot" {
+		t.Fatalf("want remote keyed provider (moonshot), got %q ok=%v", got.Name, ok)
+	}
+}
+
+func TestFirstUsableProviderFallsBackToLocal(t *testing.T) {
+	providers := []config.ProviderProfile{
+		{Name: "xai", CatalogID: "xai", APIKeyEnv: "XAI_API_KEY"},                                // not usable
+		{Name: "ollama", CatalogID: "ollama", BaseURL: "http://localhost:11434/v1", APIKey: "k"}, // local, usable
+	}
+	got, ok := firstUsableProvider(providers)
+	if !ok || got.Name != "ollama" {
+		t.Fatalf("want local usable fallback (ollama), got %q ok=%v", got.Name, ok)
+	}
+}
+
+func TestFirstUsableProviderNoneUsable(t *testing.T) {
+	providers := []config.ProviderProfile{
+		{Name: "xai", CatalogID: "xai", APIKeyEnv: "XAI_API_KEY"},
+		{Name: "openai", CatalogID: "openai", APIKeyEnv: "OPENAI_API_KEY"},
+	}
+	if got, ok := firstUsableProvider(providers); ok {
+		t.Fatalf("no provider has a credential, want ok=false, got %q", got.Name)
+	}
+}
+
+// A keyless local proxy (chatgpt-proxy, RequiresAuth=false) is usable without a
+// credential, so it can serve as a fallback rather than forcing onboarding.
+func TestFirstUsableProviderAcceptsKeylessLocalProxy(t *testing.T) {
+	providers := []config.ProviderProfile{
+		{Name: "xai", CatalogID: "xai", APIKeyEnv: "XAI_API_KEY"},
+		{Name: "chatgpt", CatalogID: "chatgpt-proxy", BaseURL: "http://localhost:10531/v1"},
+	}
+	got, ok := firstUsableProvider(providers)
+	if !ok || got.Name != "chatgpt" {
+		t.Fatalf("want keyless local proxy fallback, got %q ok=%v", got.Name, ok)
+	}
+}

--- a/internal/cli/setup_fallback_test.go
+++ b/internal/cli/setup_fallback_test.go
@@ -51,3 +51,41 @@ func TestFirstUsableProviderAcceptsKeylessLocalProxy(t *testing.T) {
 		t.Fatalf("want keyless local proxy fallback, got %q ok=%v", got.Name, ok)
 	}
 }
+
+// A profile whose catalog entry no longer resolves and that carries no explicit
+// BaseURL has no endpoint, so it must be skipped rather than selected as a
+// fallback that fails at first use. A stale CatalogID with a BaseURL still works.
+func TestFirstUsableProviderSkipsUnresolvableCatalogWithoutBaseURL(t *testing.T) {
+	providers := []config.ProviderProfile{
+		{Name: "ghost", CatalogID: "no-such-catalog-entry", APIKey: "k"}, // unusable: no endpoint
+		{Name: "custom", CatalogID: "no-such-catalog-entry", BaseURL: "https://api.custom.test/v1", APIKey: "k"},
+	}
+	got, ok := firstUsableProvider(providers)
+	if !ok || got.Name != "custom" {
+		t.Fatalf("want custom-endpoint fallback, got %q ok=%v", got.Name, ok)
+	}
+}
+
+func TestProviderProfileIsLocal(t *testing.T) {
+	cases := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{"loopback name", "http://localhost:11434/v1", true},
+		{"loopback v4", "http://127.0.0.1:8080", true},
+		{"loopback v6", "http://[::1]:10531/v1", true},
+		{"remote", "https://api.moonshot.ai/v1", false},
+		{"contains-localhost-substring", "https://notlocalhost.com/v1", false},
+		{"host-with-127-substring", "https://api127.0.0.1.example.com", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := providerProfileIsLocal(config.ProviderProfile{BaseURL: tc.baseURL})
+			if got != tc.want {
+				t.Fatalf("providerProfileIsLocal(%q) = %v, want %v", tc.baseURL, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -378,6 +378,10 @@ Prompt.`)
 }
 
 func TestKnownToolNamesMatchCoreRegistry(t *testing.T) {
+	// web_search is only registered when a search backend is configured; set one so
+	// CoreTools() exposes the full set this list is meant to mirror.
+	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
+	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	core := tools.CoreTools(t.TempDir())
 	got := make([]string, 0, len(knownToolNames))
 	for name := range knownToolNames {

--- a/internal/specialist/manifest_test.go
+++ b/internal/specialist/manifest_test.go
@@ -380,7 +380,6 @@ Prompt.`)
 func TestKnownToolNamesMatchCoreRegistry(t *testing.T) {
 	// web_search is only registered when a search backend is configured; set one so
 	// CoreTools() exposes the full set this list is meant to mirror.
-	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
 	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	core := tools.CoreTools(t.TempDir())
 	got := make([]string, 0, len(knownToolNames))

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -217,10 +217,15 @@ func CoreShellToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 }
 
 func CoreNetworkTools() []Tool {
-	return []Tool{
-		NewWebFetchTool(),
-		NewWebSearchTool(),
+	tools := []Tool{NewWebFetchTool()}
+	// Only offer the built-in web_search when a backend is actually configured.
+	// Registering it unconfigured makes the model waste calls (and high-risk
+	// permission prompts) on a tool that can only return "no backend configured";
+	// an MCP-provided search tool (e.g. Exa) stands on its own without it.
+	if defaultSearchBackend() != nil {
+		tools = append(tools, NewWebSearchTool())
 	}
+	return tools
 }
 
 func CoreTools(workspaceRoot string) []Tool { return CoreToolsScoped(workspaceRoot, nil) }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -47,6 +47,9 @@ func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 }
 
 func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
+	// web_search is only registered when a backend is configured.
+	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
+	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	byName := map[string]Tool{}
 	for _, tool := range CoreNetworkTools() {
 		byName[tool.Name()] = tool
@@ -73,6 +76,23 @@ func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
 	}
 	if property, ok := search.Parameters().Properties["query"]; !ok || property.Type != "string" {
 		t.Fatalf("web_search must expose a string query property, got %#v", search.Parameters().Properties["query"])
+	}
+}
+
+func TestCoreNetworkToolsOmitWebSearchWhenUnconfigured(t *testing.T) {
+	// No backend configured → don't offer web_search (it could only error, which
+	// makes the model waste calls + prompts before falling back to an MCP search).
+	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
+	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "")
+	names := map[string]bool{}
+	for _, tool := range CoreNetworkTools() {
+		names[tool.Name()] = true
+	}
+	if !names["web_fetch"] {
+		t.Fatal("web_fetch should always be present")
+	}
+	if names["web_search"] {
+		t.Fatal("web_search must be omitted when no search backend is configured")
 	}
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -48,7 +48,6 @@ func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 
 func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
 	// web_search is only registered when a backend is configured.
-	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
 	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	byName := map[string]Tool{}
 	for _, tool := range CoreNetworkTools() {
@@ -82,7 +81,6 @@ func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
 func TestCoreNetworkToolsOmitWebSearchWhenUnconfigured(t *testing.T) {
 	// No backend configured → don't offer web_search (it could only error, which
 	// makes the model waste calls + prompts before falling back to an MCP search).
-	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
 	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "")
 	names := map[string]bool{}
 	for _, tool := range CoreNetworkTools() {

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -160,7 +162,7 @@ func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
 	if len(results) > 0 && len(domains) > 0 {
 		filtered, err := filterWebSearchByDomains(results, domains)
 		if err != nil {
-			return errorResult("Error: " + err.Error())
+			return errorResult("Error: " + redactWebSearchText(err.Error()))
 		}
 		results = filtered
 	}
@@ -175,9 +177,9 @@ func (tool webSearchTool) Run(ctx context.Context, args map[string]any) Result {
 
 // formatSearchResults renders results as a compact numbered list:
 // "1. Title — URL" with the snippet indented on the next line.
-// If a result carries a non-zero Score, it is shown as " — score 0.91" after
-// the title; absence (zero value) is rendered without the score to keep the
-// common case tidy.
+// If a result carries a score that rounds to at least 0.01, it is shown as
+// " — score 0.91" after the title. Absent (zero), negative, and sub-0.005 scores
+// are omitted so the common case stays tidy and never prints a noisy "score 0.00".
 func formatSearchResults(results []searchResult) string {
 	lines := make([]string, 0, len(results)*2)
 	for index, result := range results {
@@ -186,8 +188,11 @@ func formatSearchResults(results []searchResult) string {
 			title = "(untitled)"
 		}
 		header := fmt.Sprintf("%d. %s — %s", index+1, title, strings.TrimSpace(result.URL))
-		if result.Score > 0 {
-			header += fmt.Sprintf(" — score %.2f", result.Score)
+		// Gate on the *rounded* value: a raw "> 0" check would still render
+		// "score 0.00" for tiny positives like 0.0001, the exact noise the
+		// score suffix is meant to avoid.
+		if rounded := math.Round(result.Score*100) / 100; rounded >= 0.01 {
+			header += fmt.Sprintf(" — score %.2f", rounded)
 		}
 		lines = append(lines, header)
 		if snippet := strings.TrimSpace(result.Snippet); snippet != "" {
@@ -296,16 +301,38 @@ func (backend *httpSearchBackend) Search(ctx context.Context, query string, limi
 	return parseSearchResults(body)
 }
 
+// lenientScore decodes a provider "score" that may arrive as a JSON number, a
+// numeric string ("0.91"), null, or some other shape, never failing the decode.
+// A plain float64 field would make json.Unmarshal reject the *entire* response
+// when a single provider sends a stringified or malformed score, dropping every
+// result; here an unparseable score degrades to the zero value (treated as
+// absent) instead.
+type lenientScore float64
+
+func (s *lenientScore) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	// Accept both 0.91 and "0.91"; ignore anything else (object, bool, NaN/Inf,
+	// out-of-range) by leaving the score at zero.
+	unquoted := strings.TrimSpace(strings.Trim(string(trimmed), `"`))
+	if f, parseErr := strconv.ParseFloat(unquoted, 64); parseErr == nil {
+		*s = lenientScore(f)
+	}
+	return nil
+}
+
 // parseSearchResults accepts either a bare array [{title,url,snippet,score}] or
 // a wrapped object {"results":[...]}, the two shapes common across providers.
 // The optional "score" field is forwarded when present; providers that omit
 // it leave searchResult.Score at the zero value and the renderer skips it.
 func parseSearchResults(body []byte) ([]searchResult, error) {
 	type rawResult struct {
-		Title   string  `json:"title"`
-		URL     string  `json:"url"`
-		Snippet string  `json:"snippet"`
-		Score   float64 `json:"score,omitempty"`
+		Title   string       `json:"title"`
+		URL     string       `json:"url"`
+		Snippet string       `json:"snippet"`
+		Score   lenientScore `json:"score,omitempty"`
 	}
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {
@@ -319,7 +346,7 @@ func parseSearchResults(body []byte) ([]searchResult, error) {
 				Title:   item.Title,
 				URL:     item.URL,
 				Snippet: item.Snippet,
-				Score:   item.Score,
+				Score:   float64(item.Score),
 			})
 		}
 		return out
@@ -421,6 +448,10 @@ func canonicalizeWebSearchHost(raw string) string {
 		trimmed = trimmed[:i]
 	}
 	trimmed = strings.ToLower(trimmed)
+	// Drop a trailing FQDN dot ("react.dev." == "react.dev") so an allowlist
+	// entry and a result host normalize the same way; hostFromWebSearchURL does
+	// the same on the result side.
+	trimmed = strings.TrimSuffix(trimmed, ".")
 	trimmed = strings.TrimPrefix(trimmed, "www.")
 	if trimmed == "" || strings.ContainsAny(trimmed, " \t\n") {
 		return ""
@@ -461,6 +492,7 @@ func hostFromWebSearchURL(raw string) string {
 		return ""
 	}
 	host := strings.ToLower(parsed.Hostname())
+	host = strings.TrimSuffix(host, ".") // match canonicalizeWebSearchHost (FQDN dot)
 	host = strings.TrimPrefix(host, "www.")
 	return host
 }

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -315,9 +315,10 @@ func (s *lenientScore) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	// Accept both 0.91 and "0.91"; ignore anything else (object, bool, NaN/Inf,
-	// out-of-range) by leaving the score at zero.
+	// out-of-range) by leaving the score at zero. ParseFloat accepts "NaN"/"Inf",
+	// so reject non-finite results explicitly to honor the documented filter.
 	unquoted := strings.TrimSpace(strings.Trim(string(trimmed), `"`))
-	if f, parseErr := strconv.ParseFloat(unquoted, 64); parseErr == nil {
+	if f, parseErr := strconv.ParseFloat(unquoted, 64); parseErr == nil && !math.IsNaN(f) && !math.IsInf(f, 0) {
 		*s = lenientScore(f)
 	}
 	return nil

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -586,3 +586,117 @@ func TestCanonicalizeWebSearchHostStripsPort(t *testing.T) {
 		}
 	}
 }
+
+// Test added to verify mixed-type array handling
+func TestStringListArgWebSearchRejectsMixedTypes(t *testing.T) {
+	args := map[string]any{
+		"domains": []any{"react.dev", 123, "github.com"},
+	}
+
+	domains, provided, err := stringListArgWebSearch(args, "domains")
+
+	if err == nil {
+		t.Fatal("Expected error for mixed-type array, but got nil")
+	}
+	if !provided {
+		t.Fatal("Expected provided=true since the argument was passed")
+	}
+	if err.Error() != "domains[1] must be a string" {
+		t.Fatalf("Expected 'domains[1] must be a string', got '%v'", err)
+	}
+	if domains != nil {
+		t.Fatalf("Expected nil domains on error, got %v", domains)
+	}
+	t.Logf("Test passed: got expected error: %v", err)
+}
+
+func TestWebSearchRejectsMixedTypeDomainsE2E(t *testing.T) {
+	// End-to-end test: web_search tool rejects mixed-type array
+	tool := newWebSearchToolWithBackend(&fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://react.dev/x"},
+	}})
+
+	res := tool.Run(context.Background(), map[string]any{
+		"query":   "x",
+		"domains": []any{"react.dev", 123, "github.com"},
+	})
+
+	if res.Status != StatusError {
+		t.Fatalf("Expected error for mixed-type domains, got %v: %s", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Output, "domains[1] must be a string") {
+		t.Fatalf("Expected 'domains[1] must be a string' in error message, got: %s", res.Output)
+	}
+}
+
+// ---- fix/web-search-209: robustness + rendering + normalization -------------
+
+// #1: a stringified or malformed score must not discard the whole response.
+func TestParseSearchResultsToleratesNonNumericScore(t *testing.T) {
+	body := []byte(`{"results":[
+		{"title":"num","url":"https://a.test","snippet":"s","score":0.77},
+		{"title":"str","url":"https://b.test","snippet":"s","score":"0.5"},
+		{"title":"bad","url":"https://c.test","snippet":"s","score":"high"},
+		{"title":"obj","url":"https://d.test","snippet":"s","score":{"x":1}},
+		{"title":"null","url":"https://e.test","snippet":"s","score":null}
+	]}`)
+	results, err := parseSearchResults(body)
+	if err != nil {
+		t.Fatalf("a single odd score must not fail the parse: %v", err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("want 5 results (none dropped), got %d", len(results))
+	}
+	if results[0].Score != 0.77 {
+		t.Errorf("numeric score = %v, want 0.77", results[0].Score)
+	}
+	if results[1].Score != 0.5 {
+		t.Errorf("numeric-string score = %v, want 0.5", results[1].Score)
+	}
+	for _, i := range []int{2, 3, 4} {
+		if results[i].Score != 0 {
+			t.Errorf("unparseable/null score[%d] = %v, want 0 (absent)", i, results[i].Score)
+		}
+	}
+}
+
+// #2: tiny positive and negative scores must not render; >=0.005 rounds in.
+func TestWebSearchScoreRenderingGate(t *testing.T) {
+	backend := &fakeSearchBackend{results: []searchResult{
+		{Title: "tiny", URL: "https://a.test/1", Score: 0.0001},
+		{Title: "neg", URL: "https://a.test/2", Score: -0.5},
+		{Title: "round-in", URL: "https://a.test/3", Score: 0.005},
+		{Title: "shown", URL: "https://a.test/4", Score: 0.91},
+	}}
+	res := newWebSearchToolWithBackend(backend).Run(context.Background(), map[string]any{"query": "x"})
+	if res.Status != StatusOK {
+		t.Fatalf("status = %v: %s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "score 0.00") {
+		t.Errorf("tiny/negative score must not render 'score 0.00', got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "score 0.01") {
+		t.Errorf("0.005 should round to 'score 0.01', got: %s", res.Output)
+	}
+	if !strings.Contains(res.Output, "score 0.91") {
+		t.Errorf("0.91 should render, got: %s", res.Output)
+	}
+}
+
+// #4: trailing-dot FQDN entries/results normalize symmetrically.
+func TestWebSearchDomainsFilterTrailingDotSymmetry(t *testing.T) {
+	// allowlist has the dot, result does not
+	res := newWebSearchToolWithBackend(&fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://react.dev/x"},
+	}}).Run(context.Background(), map[string]any{"query": "x", "domains": []any{"react.dev."}})
+	if res.Status != StatusOK {
+		t.Fatalf("allowlist 'react.dev.' should match 'react.dev' result, got %v: %s", res.Status, res.Output)
+	}
+	// result has the dot, allowlist does not
+	res = newWebSearchToolWithBackend(&fakeSearchBackend{results: []searchResult{
+		{Title: "ok", URL: "https://react.dev./x"},
+	}}).Run(context.Background(), map[string]any{"query": "x", "domains": []any{"react.dev"}})
+	if res.Status != StatusOK {
+		t.Fatalf("allowlist 'react.dev' should match 'react.dev.' result, got %v: %s", res.Status, res.Output)
+	}
+}

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -104,7 +104,6 @@ func TestWebSearchRedactsBackendError(t *testing.T) {
 
 func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
 	// web_search is registered only when a backend is configured.
-	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
 	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	found := false
 	for _, tool := range CoreNetworkTools() {
@@ -641,14 +640,16 @@ func TestParseSearchResultsToleratesNonNumericScore(t *testing.T) {
 		{"title":"str","url":"https://b.test","snippet":"s","score":"0.5"},
 		{"title":"bad","url":"https://c.test","snippet":"s","score":"high"},
 		{"title":"obj","url":"https://d.test","snippet":"s","score":{"x":1}},
-		{"title":"null","url":"https://e.test","snippet":"s","score":null}
+		{"title":"null","url":"https://e.test","snippet":"s","score":null},
+		{"title":"nan","url":"https://f.test","snippet":"s","score":"NaN"},
+		{"title":"inf","url":"https://g.test","snippet":"s","score":"Inf"}
 	]}`)
 	results, err := parseSearchResults(body)
 	if err != nil {
 		t.Fatalf("a single odd score must not fail the parse: %v", err)
 	}
-	if len(results) != 5 {
-		t.Fatalf("want 5 results (none dropped), got %d", len(results))
+	if len(results) != 7 {
+		t.Fatalf("want 7 results (none dropped), got %d", len(results))
 	}
 	if results[0].Score != 0.77 {
 		t.Errorf("numeric score = %v, want 0.77", results[0].Score)
@@ -656,9 +657,12 @@ func TestParseSearchResultsToleratesNonNumericScore(t *testing.T) {
 	if results[1].Score != 0.5 {
 		t.Errorf("numeric-string score = %v, want 0.5", results[1].Score)
 	}
-	for _, i := range []int{2, 3, 4} {
+	// Indices 5 and 6 cover ParseFloat-accepted non-finite values ("NaN"/"Inf"),
+	// which must be rejected so the documented filter holds and the renderer never
+	// emits a non-finite score.
+	for _, i := range []int{2, 3, 4, 5, 6} {
 		if results[i].Score != 0 {
-			t.Errorf("unparseable/null score[%d] = %v, want 0 (absent)", i, results[i].Score)
+			t.Errorf("unparseable/null/non-finite score[%d] = %v, want 0 (absent)", i, results[i].Score)
 		}
 	}
 }

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -103,6 +103,9 @@ func TestWebSearchRedactsBackendError(t *testing.T) {
 }
 
 func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
+	// web_search is registered only when a backend is configured.
+	t.Setenv("ZERO_WEBSEARCH_BACKEND", "")
+	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	found := false
 	for _, tool := range CoreNetworkTools() {
 		if tool.Name() == "web_search" {
@@ -110,7 +113,7 @@ func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatal("web_search should be registered in CoreNetworkTools()")
+		t.Fatal("web_search should be registered in CoreNetworkTools() when a backend is configured")
 	}
 }
 

--- a/internal/tui/collapse_tools_test.go
+++ b/internal/tui/collapse_tools_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestToolResultCollapsesLongOutputByDefault(t *testing.T) {
+	m := transcriptViewTestModel()
+	long := numberedLines(cardBodyMaxLines + 10)
+	rc := buildRowContext(nil)
+
+	row := transcriptRow{kind: rowToolResult, id: "t1", tool: "mcp_exa_web_search_exa", status: tools.StatusOK, detail: long}
+	collapsed := plainRender(t, m.renderRow(row, m.width, rc))
+	if strings.Contains(collapsed, "line-005") {
+		t.Errorf("collapsed card must hide the body, got:\n%s", collapsed)
+	}
+	if !strings.Contains(collapsed, "click to expand") {
+		t.Errorf("collapsed card must show the expand hint, got:\n%s", collapsed)
+	}
+
+	row.expanded = true
+	expanded := plainRender(t, m.renderRow(row, m.width, rc))
+	if !strings.Contains(expanded, "line-005") {
+		t.Errorf("expanded card must show the body, got:\n%s", expanded)
+	}
+}
+
+func TestToolResultShortOutputStaysInline(t *testing.T) {
+	m := transcriptViewTestModel()
+	row := transcriptRow{kind: rowToolResult, id: "t2", tool: "mcp_exa_web_search_exa", status: tools.StatusOK, detail: numberedLines(3)}
+	out := plainRender(t, m.renderRow(row, m.width, buildRowContext(nil)))
+	if strings.Contains(out, "click to expand") {
+		t.Errorf("short output must not collapse, got:\n%s", out)
+	}
+	if !strings.Contains(out, "line-003") {
+		t.Errorf("short output must render inline, got:\n%s", out)
+	}
+}
+
+func TestDiffToolOutputNeverCollapses(t *testing.T) {
+	m := transcriptViewTestModel()
+	long := numberedLines(cardBodyMaxLines + 10)
+	for _, tool := range []string{"edit_file", "apply_patch", "write_file"} {
+		row := transcriptRow{kind: rowToolResult, id: "d", tool: tool, status: tools.StatusOK, detail: long}
+		out := plainRender(t, m.renderRow(row, m.width, buildRowContext(nil)))
+		if strings.Contains(out, "click to expand") {
+			t.Errorf("%s output must stay reviewable, not collapse:\n%s", tool, out)
+		}
+	}
+}
+
+func TestToggleTranscriptRowTogglesToolResult(t *testing.T) {
+	m := transcriptViewTestModel()
+	m.transcript = []transcriptRow{{kind: rowToolResult, id: "t", tool: "custom_tool"}}
+	if m.transcript[0].expanded {
+		t.Fatal("tool result must default to collapsed")
+	}
+	m = m.toggleTranscriptRow(0)
+	if !m.transcript[0].expanded {
+		t.Fatal("toggle should expand the tool result")
+	}
+	m = m.toggleTranscriptRow(0)
+	if m.transcript[0].expanded {
+		t.Fatal("toggle should collapse the tool result again")
+	}
+}
+
+func TestToolResultRowExposesClickToggle(t *testing.T) {
+	m := transcriptViewTestModel()
+	row := transcriptRow{kind: rowToolResult, id: "t", tool: "custom_tool", status: tools.StatusOK, detail: numberedLines(cardBodyMaxLines + 5)}
+	_, selectable := m.renderSelectableToolResultRow(0, row, m.width, buildRowContext(nil), 0)
+	if len(selectable) != 1 || !selectable[0].toggle {
+		t.Fatalf("tool result head must be a clickable toggle line, got %#v", selectable)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -493,9 +493,14 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m.handleMouse(msg)
 	case transcriptCopiedMsg:
-		m.transcriptSelection = transcriptSelectionState{}
 		m.copyStatusSeq++
-		m.copyStatus = "Copied!"
+		if msg.err != nil {
+			// Keep the selection so the user can retry; just surface the failure.
+			m.copyStatus = "Copy failed"
+		} else {
+			m.transcriptSelection = transcriptSelectionState{}
+			m.copyStatus = "Copied!"
+		}
 		seq := m.copyStatusSeq
 		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
 			return transcriptCopyStatusExpiredMsg{seq: seq}
@@ -1291,8 +1296,8 @@ func (m model) scrollChat(delta int) model {
 // syncChatScroll pins the viewport to what the user is reading. The scroll offset
 // is measured from the bottom, so when the transcript grows (streaming) the window
 // would otherwise follow the new bottom and drag the user off their spot. While
-// the user has scrolled up, bump the offset by however many lines the body grew so
-// the absolute view holds; at the bottom (offset 0) it follows normally. Only the
+// the user has scrolled up, shift the offset by however many lines the body changed
+// so the absolute view holds; at the bottom (offset 0) it follows normally. Only the
 // scrolled-up path renders the body, so the common case stays cheap.
 func (m model) syncChatScroll() model {
 	if !m.altScreen || m.chatScrollOffset <= 0 {
@@ -1301,12 +1306,16 @@ func (m model) syncChatScroll() model {
 		return m
 	}
 	current := m.chatBodyLineCount()
-	switch {
-	case m.chatBodyLines == 0:
+	if m.chatBodyLines == 0 {
 		// Just scrolled up: establish the baseline, no adjustment this frame.
-	case current > m.chatBodyLines:
-		m.chatScrollOffset += current - m.chatBodyLines
+		m.chatBodyLines = current
+		return m
 	}
+	// Shift by the signed delta so the absolute view holds whether the body grew
+	// (streaming appended lines) or shrank (a tool card collapsed, transcript
+	// cleared). Clamp at zero so a large shrink lands the user back at the tail
+	// rather than underflowing past it.
+	m.chatScrollOffset = maxInt(0, m.chatScrollOffset+current-m.chatBodyLines)
 	m.chatBodyLines = current
 	return m
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -123,6 +123,10 @@ type model struct {
 	height            int
 	now               func() time.Time
 	chatScrollOffset  int
+	// chatBodyLines is the live body's line count at the last update; used to pin
+	// the viewport (hold the read position) when content streams in while the user
+	// has scrolled up. 0 means "at the bottom / not pinned".
+	chatBodyLines int
 
 	// Flush-frontier state (see flush.go). In inline mode, transcript[:flushed]
 	// is already in native scrollback; in alt-screen mode this frontier stays
@@ -458,6 +462,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if !ok {
 		return next, cmd
 	}
+	nm = nm.syncChatScroll()
 	nm, mouseCmd := nm.syncMouseCapture()
 	nm, flushCmd := nm.settleTranscript()
 	return nm, batchCommands(cmd, mouseCmd, flushCmd)
@@ -1281,6 +1286,36 @@ func (m model) scrollChat(delta int) model {
 	}
 	m.chatScrollOffset = maxInt(0, m.chatScrollOffset+delta)
 	return m
+}
+
+// syncChatScroll pins the viewport to what the user is reading. The scroll offset
+// is measured from the bottom, so when the transcript grows (streaming) the window
+// would otherwise follow the new bottom and drag the user off their spot. While
+// the user has scrolled up, bump the offset by however many lines the body grew so
+// the absolute view holds; at the bottom (offset 0) it follows normally. Only the
+// scrolled-up path renders the body, so the common case stays cheap.
+func (m model) syncChatScroll() model {
+	if !m.altScreen || m.chatScrollOffset <= 0 {
+		// At the bottom (or inline mode): follow the tail; reset the pin baseline.
+		m.chatBodyLines = 0
+		return m
+	}
+	current := m.chatBodyLineCount()
+	switch {
+	case m.chatBodyLines == 0:
+		// Just scrolled up: establish the baseline, no adjustment this frame.
+	case current > m.chatBodyLines:
+		m.chatScrollOffset += current - m.chatBodyLines
+	}
+	m.chatBodyLines = current
+	return m
+}
+
+// chatBodyLineCount renders the live transcript body and returns its line count.
+// Only called while the user is scrolled up (see syncChatScroll).
+func (m model) chatBodyLineCount() int {
+	body, _ := m.transcriptBody(chatWidth(m.width), "")
+	return len(viewLines(body))
 }
 
 func (m model) chatPageScrollLines() int {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -947,9 +947,52 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 		borderStyle = zeroTheme.cardErr
 	}
 	key := rcKey(row.runID, row.id)
+	// Collapse long, noisy output (web-search/MCP/read dumps) by default so the
+	// transcript stays scannable; the model still received the full output. Click
+	// the card to expand (▸ → ▾) while it is live; collapsed rows flush to
+	// scrollback clean. Skipped for: the uncapped detailed view (opts.bodyCap==0),
+	// diff tools whose body must stay reviewable, and short output.
+	collapsedFooter := ""
+	if opts.bodyCap > 0 && !toolCardAlwaysExpands(name) {
+		collapsedFooter = collapsedToolFooter(row.detail)
+	}
+	if collapsedFooter != "" && !row.expanded {
+		head := toolCardHead(name, rc.hints[key], rc.args[key], "", glyph, rc.auto[key], width, opts)
+		return toolCard(head, nil, collapsedFooter, borderStyle, width)
+	}
 	body := toolCardBody(name, rc.hints[key], row.detail, width, opts)
 	head := toolCardHead(name, rc.hints[key], rc.args[key], body.headTag, glyph, rc.auto[key], width, opts)
-	return toolCard(head, body.lines, body.footer, borderStyle, width)
+	footer := body.footer
+	if collapsedFooter != "" && row.expanded && footer == "" {
+		footer = "▾ collapse"
+	}
+	return toolCard(head, body.lines, footer, borderStyle, width)
+}
+
+// toolCardAlwaysExpands reports tools whose body is a code diff that must stay
+// visible for review (mirrors the deeper flush cap intent) rather than collapse.
+func toolCardAlwaysExpands(name string) bool {
+	switch name {
+	case "edit_file", "apply_patch", "write_file":
+		return true
+	}
+	return false
+}
+
+// collapsedToolFooter summarizes the hidden output for a collapsed tool card, or
+// "" when the output is short enough to render inline. Only output longer than
+// the live body cap (the noisy "… N more lines" case, e.g. a web-search dump)
+// collapses by default.
+func collapsedToolFooter(detail string) string {
+	trimmed := strings.TrimRight(detail, "\n")
+	if strings.TrimSpace(trimmed) == "" {
+		return ""
+	}
+	n := strings.Count(trimmed, "\n") + 1
+	if n <= cardBodyMaxLines {
+		return ""
+	}
+	return fmt.Sprintf("▸ %d lines — click to expand", n)
 }
 
 func toolRowName(row transcriptRow) string {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1003,11 +1003,34 @@ func toolRowName(row transcriptRow) string {
 	return strings.TrimPrefix(name, "tool result: ")
 }
 
+// toolDisplayName is the human-facing label for a tool card head. MCP tools are
+// exposed as "mcp_<server>_<tool>", which is noise in the UI — show a clean
+// "<tool>" (e.g. mcp_exa_web_search_exa → "web search"); the search query/target
+// is shown beside it. Built-in tool names are left as-is.
+func toolDisplayName(name string) string {
+	if !strings.HasPrefix(name, "mcp_") {
+		return name
+	}
+	rest := strings.TrimPrefix(name, "mcp_")
+	server := rest
+	if i := strings.Index(rest, "_"); i >= 0 {
+		server = rest[:i]
+		rest = rest[i+1:]
+	} else {
+		rest = ""
+	}
+	rest = strings.TrimSuffix(rest, "_"+server) // exa: web_search_exa → web_search
+	if rest == "" {
+		rest = server
+	}
+	return strings.ReplaceAll(rest, "_", " ")
+}
+
 // toolCardHead composes the border-embedded head: tool name, middle-truncated
 // target (hyperlinked when it names a file), the faintest arg column, optional
 // extra tag, the auto marker, and the status glyph.
 func toolCardHead(name string, target string, arg string, headTag string, glyph string, auto bool, width int, opts cardRenderOptions) string {
-	head := zeroTheme.toolName.Render(name)
+	head := zeroTheme.toolName.Render(toolDisplayName(name))
 	if target = strings.TrimSpace(target); target != "" {
 		styled := zeroTheme.toolTarget.Render(middleTruncate(target, maxInt(16, width/2)))
 		if looksLikePath(target) {

--- a/internal/tui/scroll_pin_test.go
+++ b/internal/tui/scroll_pin_test.go
@@ -1,0 +1,45 @@
+package tui
+
+import "testing"
+
+func TestSyncChatScrollPinsWhileScrolledUp(t *testing.T) {
+	m := transcriptViewTestModel()
+	m.altScreen = true
+	m.transcript = []transcriptRow{{kind: rowAssistant, text: numberedLines(40)}}
+	m.chatScrollOffset = 5
+
+	m = m.syncChatScroll() // establishes the baseline, no adjustment yet
+	if m.chatBodyLines == 0 {
+		t.Fatal("scrolled-up baseline must be recorded")
+	}
+	baseOffset := m.chatScrollOffset
+	baseLines := m.chatBodyLines
+
+	// Stream more content in.
+	m.transcript = append(m.transcript, transcriptRow{kind: rowAssistant, text: numberedLines(12)})
+	m = m.syncChatScroll()
+
+	grew := m.chatBodyLines - baseLines
+	if grew <= 0 {
+		t.Fatalf("body should have grown, base=%d now=%d", baseLines, m.chatBodyLines)
+	}
+	if m.chatScrollOffset != baseOffset+grew {
+		t.Fatalf("offset must grow by %d to hold the read position, was %d now %d", grew, baseOffset, m.chatScrollOffset)
+	}
+}
+
+func TestSyncChatScrollFollowsAtBottom(t *testing.T) {
+	m := transcriptViewTestModel()
+	m.altScreen = true
+	m.transcript = []transcriptRow{{kind: rowAssistant, text: numberedLines(40)}}
+	m.chatScrollOffset = 0
+	m.chatBodyLines = 99 // stale baseline from a prior scrolled-up state
+
+	m = m.syncChatScroll()
+	if m.chatScrollOffset != 0 {
+		t.Fatalf("at the bottom the viewport must keep following (offset 0), got %d", m.chatScrollOffset)
+	}
+	if m.chatBodyLines != 0 {
+		t.Fatalf("at the bottom the pin baseline must reset to 0, got %d", m.chatBodyLines)
+	}
+}

--- a/internal/tui/tool_display_test.go
+++ b/internal/tui/tool_display_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestToolDisplayNameCleansMCPNames(t *testing.T) {
+	cases := map[string]string{
+		"mcp_exa_web_search_exa": "web search",
+		"mcp_exa_web_fetch_exa":  "web fetch",
+		"mcp_foo_bar":            "bar",
+		"edit_file":              "edit_file",  // built-in, unchanged
+		"web_search":             "web_search", // built-in, unchanged
+	}
+	for in, want := range cases {
+		if got := toolDisplayName(in); got != want {
+			t.Errorf("toolDisplayName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestToolCardHeadShowsCleanMCPName(t *testing.T) {
+	m := transcriptViewTestModel()
+	row := transcriptRow{kind: rowToolResult, id: "t", tool: "mcp_exa_web_search_exa", status: tools.StatusOK, detail: "short result"}
+	out := plainRender(t, m.renderRow(row, m.width, buildRowContext(nil)))
+	if strings.Contains(out, "mcp_exa_web_search_exa") {
+		t.Errorf("card head must not show the raw MCP tool name:\n%s", out)
+	}
+	if !strings.Contains(out, "web search") {
+		t.Errorf("card head should show the clean 'web search' label:\n%s", out)
+	}
+}

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -121,9 +121,21 @@ func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, r
 		return m.renderSelectableAssistantRow(rowIndex, row, width, startBodyY)
 	case rowReasoning:
 		return m.renderSelectableReasoningRow(rowIndex, row, width, startBodyY)
+	case rowToolResult:
+		return m.renderSelectableToolResultRow(rowIndex, row, width, rc, startBodyY)
 	default:
 		return m.renderRow(row, width, rc), nil
 	}
+}
+
+// renderSelectableToolResultRow renders the tool result card and marks its head
+// (first line) as a clickable collapse/expand toggle while the row is live.
+func (m model) renderSelectableToolResultRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {
+	rendered := m.renderRow(row, width, rc)
+	if rendered == "" {
+		return "", nil
+	}
+	return rendered, []transcriptSelectableLine{{bodyY: startBodyY, rowIndex: rowIndex, toggle: true}}
 }
 
 func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
@@ -353,7 +365,7 @@ func (m model) handleTranscriptSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd,
 			if line.live {
 				m.streamingReasoningExpanded = !m.streamingReasoningExpanded
 			} else {
-				m = m.toggleReasoningRow(line.rowIndex)
+				m = m.toggleTranscriptRow(line.rowIndex)
 			}
 			return m, nil, true
 		}
@@ -388,11 +400,16 @@ func (m model) handleTranscriptSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd,
 	}
 }
 
-func (m model) toggleReasoningRow(rowIndex int) model {
-	if rowIndex < 0 || rowIndex >= len(m.transcript) || m.transcript[rowIndex].kind != rowReasoning {
+// toggleTranscriptRow flips the collapse state of a collapsible row (a provider
+// thought or a tool result card).
+func (m model) toggleTranscriptRow(rowIndex int) model {
+	if rowIndex < 0 || rowIndex >= len(m.transcript) {
 		return m
 	}
-	m.transcript[rowIndex].expanded = !m.transcript[rowIndex].expanded
+	switch m.transcript[rowIndex].kind {
+	case rowReasoning, rowToolResult:
+		m.transcript[rowIndex].expanded = !m.transcript[rowIndex].expanded
+	}
 	return m
 }
 

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -6,6 +6,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -414,7 +415,14 @@ func (m model) selectedTranscriptText() string {
 
 func copyTranscriptSelectionCmd(text string) tea.Cmd {
 	return func() tea.Msg {
-		_, _ = os.Stdout.WriteString(ansi.SetSystemClipboard(text))
+		// Prefer the native OS clipboard (pbcopy / clip.exe / xclip): it works on
+		// local terminals — including macOS Terminal.app, which has no OSC52 support
+		// at all — so the auto-copy-on-select actually lands on the clipboard. Fall
+		// back to OSC52 (forwarded by the terminal) for remote/SSH sessions where no
+		// local clipboard utility is reachable.
+		if err := clipboard.WriteAll(text); err != nil {
+			_, _ = os.Stdout.WriteString(ansi.SetSystemClipboard(text))
+		}
 		return transcriptCopiedMsg{chars: utf8.RuneCountInString(text)}
 	}
 }

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -34,6 +34,9 @@ type transcriptSelectableLine struct {
 
 type transcriptCopiedMsg struct {
 	chars int
+	// err is set when neither the native clipboard nor the OSC52 fallback landed
+	// the copy, so the status line can report the failure instead of "Copied!".
+	err error
 }
 
 type transcriptCopyStatusExpiredMsg struct {
@@ -438,7 +441,11 @@ func copyTranscriptSelectionCmd(text string) tea.Cmd {
 		// back to OSC52 (forwarded by the terminal) for remote/SSH sessions where no
 		// local clipboard utility is reachable.
 		if err := clipboard.WriteAll(text); err != nil {
-			_, _ = os.Stdout.WriteString(ansi.SetSystemClipboard(text))
+			if _, oscErr := os.Stdout.WriteString(ansi.SetSystemClipboard(text)); oscErr != nil {
+				// Both paths failed; report it rather than claiming a copy that
+				// never reached any clipboard.
+				return transcriptCopiedMsg{err: err}
+			}
 		}
 		return transcriptCopiedMsg{chars: utf8.RuneCountInString(text)}
 	}

--- a/internal/tui/transcript_view_test.go
+++ b/internal/tui/transcript_view_test.go
@@ -56,15 +56,19 @@ func TestDetailedTranscriptIncludesToolOutputBeyondLiveCap(t *testing.T) {
 	m.transcript = append(m.transcript, row)
 	m.flushed = len(m.transcript)
 
+	// Long generic tool output collapses in the live view (click to expand);
+	// the body is hidden behind a one-line summary.
 	compact := plainRender(t, m.renderRow(row, m.width, buildRowContext(m.transcript)))
 	assertNotContains(t, compact, "line-020")
-	assertContains(t, compact, "more lines")
+	assertContains(t, compact, "click to expand")
 
+	// The detailed transcript view (Ctrl+O) still shows the full, uncapped output.
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
 	next := updated.(model)
 	view := plainRender(t, next.View())
 	assertContains(t, view, "line-404")
 	assertNotContains(t, view, "more lines")
+	assertNotContains(t, view, "click to expand")
 }
 
 func TestDetailedTranscriptViewNeverExceedsTerminalWidth(t *testing.T) {


### PR DESCRIPTION
## Summary

A batch of independent fixes that harden `web_search` and make the chat surface much nicer to live in. Each is small, tested, and self-contained.

## web_search

- **Don't offer the built-in `web_search` when no backend is configured.** `CoreNetworkTools` registered it unconditionally, so a model with an MCP search tool (e.g. Exa) burned several calls + high-risk permission prompts on a tool that can only return "no backend configured" before falling back. Now it's registered only when `ZERO_WEBSEARCH_BASE_URL` (or `ZERO_WEBSEARCH_BACKEND`) is set.
- **#209 follow-ups:**
  - Tolerant `score` decode — a stringified / malformed / null provider `score` no longer makes `json.Unmarshal` discard the *whole* response; it degrades to "absent".
  - Score render gate rounds first (`>= 0.01`), so tiny positives and negatives no longer print a noisy `score 0.00`.
  - The domain-filter error now goes through `redactWebSearchText`, matching the other error paths.
  - Trailing-dot FQDN symmetry: `react.dev.` and `react.dev` normalize the same on the allowlist and result sides.

## Chat UX

- **Collapse long tool output by default.** Output longer than the live body cap renders as a one-line `▸ N lines — click to expand` (click while live to expand `▾`), so the transcript stays scannable. Diff tools (`edit_file`/`apply_patch`/`write_file`), the uncapped detailed view (`Ctrl+O`), and short output are never collapsed. Reuses the existing reasoning-row collapse, so collapsed rows flush to scrollback clean.
- **Clean MCP tool labels.** Tool cards showed the raw `mcp_<server>_<tool>`; `toolDisplayName` now renders a clean label (`mcp_exa_web_search_exa` → `web search`) with the query beside it. Built-in names are unchanged.
- **Hold the scroll position while output streams.** The viewport offset is measured from the bottom, so streaming dragged the user off whatever they'd scrolled up to read. It now pins the absolute position while scrolled up (bumping the offset by the body's growth) and follows the tail at the bottom.
- **Copy selection to the native clipboard.** Selecting transcript text auto-copies on release, but it only used OSC52 — unsupported by macOS Terminal.app and off-by-default elsewhere. Now it copies via the native clipboard (`pbcopy` / `clip.exe` / `xclip`) with OSC52 as the SSH/remote fallback. (`atotto/clipboard` was already in the module graph; promoted to a direct import — no new dependency.)

## Provider setup

- **Stop re-running onboarding when a usable provider already exists.** If the active provider lacked a credential, the TUI forced first-run onboarding on every launch (accumulating duplicate providers). Now it falls back to the first usable saved provider (preferring a remote keyed one over a local endpoint); onboarding only runs on a genuinely fresh setup. Switch the active provider any time with `zero providers use <name>`.

## Agent behavior

- **Search the web proactively instead of answering "I don't know".** When a web search/fetch tool is available and the user asks about something external/uncertain/current (a product, library, version, recent event), the system prompt now tells the model to search and read results before answering, rather than replying that it doesn't know without checking.

## Testing
- gofmt, `go vet`, build (host + linux + windows), `go test ./... -race` — green except 3 pre-existing `internal/cli` failures (doctor/exec, network/provider-dependent) that fail identically on `main`.
- staticcheck (no new findings). New unit tests cover each change: score parse/render, dead-tool registration, native-clipboard cmd, collapse/toggle + diff/detailed exemptions, MCP label cleanup, onboarding fallback, scroll-pin, and the proactive-search prompt rule.
- No new module dependencies.

## Notes
- The OAuth provider-login feature is a separate PR (#217). The "recognize an OAuth login as a credential" tweak for onboarding belongs with that feature and is intentionally not in this PR (it would be incorrect without the OAuth runtime wiring).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool result cards in the chat transcript can now be collapsed/expanded.
  * Chat transcript scrolling stays pinned to your reading position while you’re scrolled up.

* **Improvements**
  * The agent is guided to check the web before answering when information may be time-sensitive.
  * Tool names from MCP are displayed with cleaner, user-friendly labels.
  * `web_search` is more resilient and handles domain matching more consistently (including trailing dots).
  * CLI startup can reuse a previously configured provider to avoid rerunning setup.

* **Bug Fixes**
  * `web_search` is no longer available when no search backend is configured.
  * Copy-to-clipboard now prefers the native system clipboard and reports copy failures more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->