### PR TITLE
Polish TUI title bar

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -67,6 +67,8 @@ type model struct {
 	sessionEvents          []sessions.Event
 	usageTracker           *usage.Tracker
 	sessionCompactor       SessionCompactor
+	prService              *PrService
+	prState                PrState
 	runtimeMessageSink     func(tea.Msg)
 	agentOptions           agent.Options
 	notifier               *notify.Notifier
@@ -254,6 +256,10 @@ type doctorCommandResultMsg struct {
 	text string
 }
 
+type prStateMsg struct {
+	state PrState
+}
+
 type permissionDecision = agent.PermissionDecisionAction
 
 const (
@@ -335,6 +341,10 @@ func newModel(ctx context.Context, options Options) model {
 	if usageTracker == nil {
 		usageTracker = usage.NewTracker(usage.TrackerOptions{})
 	}
+	prService := options.PrService
+	if prService == nil {
+		prService = NewPrService(cwd)
+	}
 	doctorUserConfigPath := options.DoctorUserConfigPath
 	if doctorUserConfigPath == "" {
 		doctorUserConfigPath = options.UserConfigPath
@@ -398,6 +408,8 @@ func newModel(ctx context.Context, options Options) model {
 		userAgent:              options.UserAgent,
 		usageTracker:           usageTracker,
 		transcript:             initialTranscript(),
+		prService:              prService,
+		prState:                prService.GetState(),
 		input:                  input,
 		spinner:                runSpinner,
 		now:                    time.Now,
@@ -442,7 +454,22 @@ const (
 )
 
 func (m model) Init() tea.Cmd {
-	return textinput.Blink
+	cmds := []tea.Cmd{textinput.Blink}
+	if m.prService != nil && m.runtimeMessageSink != nil {
+		service := m.prService
+		sink := m.runtimeMessageSink
+		ctx := m.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		cmds = append(cmds, func() tea.Msg {
+			WatchPRStateContext(ctx, service, func(state PrState) {
+				sink(prStateMsg{state: state})
+			})
+			return nil
+		})
+	}
+	return tea.Batch(cmds...)
 }
 
 // Update routes every message through updateModel, then advances the flush
@@ -1041,6 +1068,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.doctorFrame = 0
 			m = m.setDoctorStatusRow(msg.text)
 		}
+		return m, nil
+	case prStateMsg:
+		m.prState = msg.state
 		return m, nil
 	case bashResultMsg:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -69,6 +69,7 @@ type model struct {
 	sessionCompactor       SessionCompactor
 	prService              *PrService
 	prState                PrState
+	prWatcherStop          func()
 	runtimeMessageSink     func(tea.Msg)
 	agentOptions           agent.Options
 	notifier               *notify.Notifier
@@ -258,6 +259,10 @@ type doctorCommandResultMsg struct {
 
 type prStateMsg struct {
 	state PrState
+}
+
+type prWatcherStartedMsg struct {
+	stop func()
 }
 
 type permissionDecision = agent.PermissionDecisionAction
@@ -463,13 +468,26 @@ func (m model) Init() tea.Cmd {
 			ctx = context.Background()
 		}
 		cmds = append(cmds, func() tea.Msg {
-			WatchPRStateContext(ctx, service, func(state PrState) {
+			stop := WatchPRStateContext(ctx, service, func(state PrState) {
 				sink(prStateMsg{state: state})
 			})
-			return nil
+			return prWatcherStartedMsg{stop: stop}
 		})
 	}
 	return tea.Batch(cmds...)
+}
+
+func (m *model) stopPRWatcher() {
+	if m.prWatcherStop == nil {
+		return
+	}
+	m.prWatcherStop()
+	m.prWatcherStop = nil
+}
+
+func (m model) quit() (tea.Model, tea.Cmd) {
+	m.stopPRWatcher()
+	return m, tea.Quit
 }
 
 // Update routes every message through updateModel, then advances the flush
@@ -551,7 +569,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.flushRunIDs) > 0 {
 				return m, nil
 			}
-			return m, tea.Quit
+			return m.quit()
 		case tea.KeyCtrlO:
 			return m.toggleDetailedTranscript(), nil
 		case tea.KeyEsc:
@@ -950,7 +968,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// checkpoint session events have been flushed (above). Now that the
 				// last pending flush is drained, fire the deferred quit.
 				if m.exiting && len(m.flushRunIDs) == 0 {
-					return m, tea.Quit
+					return m.quit()
 				}
 			}
 			return m, nil
@@ -1071,6 +1089,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case prStateMsg:
 		m.prState = msg.state
+		return m, nil
+	case prWatcherStartedMsg:
+		if msg.stop == nil {
+			return m, nil
+		}
+		if m.prWatcherStop != nil {
+			m.prWatcherStop()
+		}
+		m.prWatcherStop = msg.stop
 		return m, nil
 	case bashResultMsg:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: msg.output})
@@ -1877,7 +1904,7 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		if len(m.flushRunIDs) > 0 {
 			return m, nil
 		}
-		return m, tea.Quit
+		return m.quit()
 	case commandTools:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.toolsText()})
 		return m, nil

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -247,7 +247,7 @@ func TestTranscriptReducer(t *testing.T) {
 
 func TestInitialRenderShowsLimeChatSurface(t *testing.T) {
 	model := newModel(context.Background(), Options{
-		Cwd:          `D:\codings\Opensource\Zero`,
+		Cwd:          `/workspace/zero`,
 		ProviderName: "openai",
 		ModelName:    "gpt-4.1",
 	})
@@ -255,11 +255,11 @@ func TestInitialRenderShowsLimeChatSurface(t *testing.T) {
 	model.height = 34
 
 	view := model.View()
-	assertContains(t, view, " 0 ")
-	assertContains(t, view, "zero")
+	assertContains(t, view, `/workspace/zero`)
 	assertContains(t, view, "openai/gpt-4.1")
 	assertContains(t, view, emptyStateTagline)
 	assertNotContains(t, view, "running zero against ")
+	assertNotContains(t, view, " 0 ")
 	assertContains(t, view, composerPlaceholder)
 	assertNotContains(t, view, "interactive")
 	if strings.Contains(view, "Welcome to Zero") {

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -42,6 +42,7 @@ type Options struct {
 	MCPCommand             func(context.Context, []string) MCPCommandResult
 	UsageTracker           *usage.Tracker
 	SessionCompactor       SessionCompactor
+	PrService              *PrService
 
 	AgentOptions    agent.Options
 	PermissionMode  agent.PermissionMode

--- a/internal/tui/pr_status.go
+++ b/internal/tui/pr_status.go
@@ -1,0 +1,386 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+type PrStatus string
+
+const (
+	PrIdle     PrStatus = "idle"
+	PrLoading  PrStatus = "loading"
+	PrFound    PrStatus = "found"
+	PrNotFound PrStatus = "notfound"
+)
+
+type PrProvider string
+
+const (
+	ProviderGitHub PrProvider = "github"
+	ProviderGitLab PrProvider = "gitlab"
+)
+
+type PrState struct {
+	Status    PrStatus
+	PrURL     string
+	PrNumber  string
+	Provider  PrProvider
+	Additions int
+	Deletions int
+}
+
+type PrService struct {
+	mu        sync.RWMutex
+	state     PrState
+	listeners []func(PrState)
+	cwd       string
+	run       prCommandRunner
+}
+
+type prCommandRunner func(context.Context, string, string, ...string) (string, error)
+
+const prRefreshInterval = 60 * time.Second
+const prCommandTimeout = 8 * time.Second
+
+func NewPrService(cwdValues ...string) *PrService {
+	cwd := ""
+	if len(cwdValues) > 0 {
+		cwd = cwdValues[0]
+	}
+	if strings.TrimSpace(cwd) == "" {
+		if current, err := os.Getwd(); err == nil {
+			cwd = current
+		}
+	}
+	return &PrService{
+		state: PrState{Status: PrIdle},
+		cwd:   cwd,
+		run:   defaultPRCommandRunner,
+	}
+}
+
+func (s *PrService) GetState() PrState {
+	if s == nil {
+		return PrState{Status: PrIdle}
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+func (s *PrService) Subscribe(fn func(PrState)) func() {
+	if s == nil || fn == nil {
+		return func() {}
+	}
+	s.mu.Lock()
+	s.listeners = append(s.listeners, fn)
+	index := len(s.listeners) - 1
+	s.mu.Unlock()
+
+	return func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if index < 0 || index >= len(s.listeners) || s.listeners[index] == nil {
+			return
+		}
+		s.listeners[index] = nil
+	}
+}
+
+func (s *PrService) Refresh() {
+	if s == nil {
+		return
+	}
+	if s.GetState().Status == PrIdle {
+		s.setState(PrState{Status: PrLoading})
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), prCommandTimeout)
+		defer cancel()
+		s.setState(s.detect(ctx))
+	}()
+}
+
+func (s *PrService) setState(state PrState) {
+	s.mu.Lock()
+	s.state = state
+	listeners := append([]func(PrState){}, s.listeners...)
+	s.mu.Unlock()
+
+	for _, listener := range listeners {
+		if listener != nil {
+			listener(state)
+		}
+	}
+}
+
+func (s *PrService) detect(ctx context.Context) PrState {
+	if s == nil {
+		return PrState{Status: PrNotFound}
+	}
+	run := s.run
+	if run == nil {
+		run = defaultPRCommandRunner
+	}
+	cwd := s.cwd
+	if strings.TrimSpace(cwd) == "" {
+		if current, err := os.Getwd(); err == nil {
+			cwd = current
+		}
+	}
+
+	if state, ok := detectGitHubPR(ctx, cwd, run); ok {
+		return state
+	}
+	if state, ok := detectGitLabMR(ctx, cwd, run); ok {
+		return state
+	}
+	return PrState{Status: PrNotFound}
+}
+
+func WatchPRState(service *PrService, onChange func(PrState)) func() {
+	return WatchPRStateContext(context.Background(), service, onChange)
+}
+
+func WatchPRStateContext(ctx context.Context, service *PrService, onChange func(PrState)) func() {
+	if service == nil || onChange == nil {
+		return func() {}
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	onChange(service.GetState())
+	unsubscribe := service.Subscribe(onChange)
+	service.Refresh()
+
+	go func() {
+		ticker := time.NewTicker(prRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				service.Refresh()
+			}
+		}
+	}()
+
+	return func() {
+		cancel()
+		unsubscribe()
+	}
+}
+
+type githubPRView struct {
+	URL         string          `json:"url"`
+	Number      json.RawMessage `json:"number"`
+	BaseRefName string          `json:"baseRefName"`
+}
+
+type gitlabMRView struct {
+	WebURL       string          `json:"web_url"`
+	IID          json.RawMessage `json:"iid"`
+	TargetBranch string          `json:"target_branch"`
+}
+
+func detectGitHubPR(ctx context.Context, cwd string, run prCommandRunner) (PrState, bool) {
+	output, err := run(ctx, cwd, "gh", "pr", "view", "--json", "url,number,baseRefName")
+	if err != nil {
+		return PrState{}, false
+	}
+	var view githubPRView
+	if err := json.Unmarshal([]byte(output), &view); err != nil {
+		return PrState{}, false
+	}
+	state := PrState{
+		Status:   PrFound,
+		Provider: ProviderGitHub,
+		PrURL:    strings.TrimSpace(view.URL),
+		PrNumber: jsonScalarString(view.Number),
+	}
+	if state.PrNumber == "" {
+		return PrState{}, false
+	}
+	state.Additions, state.Deletions, _ = getLocalDiffStats(ctx, cwd, view.BaseRefName, run)
+	return state, true
+}
+
+func detectGitLabMR(ctx context.Context, cwd string, run prCommandRunner) (PrState, bool) {
+	output, err := run(ctx, cwd, "glab", "mr", "view", "--json", "web_url,iid,target_branch")
+	if err != nil {
+		return PrState{}, false
+	}
+	var view gitlabMRView
+	if err := json.Unmarshal([]byte(output), &view); err != nil {
+		return PrState{}, false
+	}
+	state := PrState{
+		Status:   PrFound,
+		Provider: ProviderGitLab,
+		PrURL:    strings.TrimSpace(view.WebURL),
+		PrNumber: jsonScalarString(view.IID),
+	}
+	if state.PrNumber == "" {
+		return PrState{}, false
+	}
+	state.Additions, state.Deletions, _ = getLocalDiffStats(ctx, cwd, view.TargetBranch, run)
+	return state, true
+}
+
+func GetLocalDiffStats(baseBranch string) (additions int, deletions int, err error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return 0, 0, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), prCommandTimeout)
+	defer cancel()
+	return getLocalDiffStats(ctx, cwd, baseBranch, defaultPRCommandRunner)
+}
+
+func getLocalDiffStats(ctx context.Context, cwd string, baseBranch string, run prCommandRunner) (int, int, error) {
+	baseBranch = strings.TrimSpace(baseBranch)
+	if baseBranch == "" {
+		return 0, 0, nil
+	}
+	originBase := "origin/" + baseBranch
+	mergeBase, err := run(ctx, cwd, "git", "merge-base", originBase, "HEAD")
+	if err != nil {
+		mergeBase = originBase
+	}
+	output, err := run(ctx, cwd, "git", "diff", "--shortstat", strings.TrimSpace(mergeBase))
+	if err != nil {
+		return 0, 0, err
+	}
+	additions, deletions := parseGitShortStat(output)
+	return additions, deletions, nil
+}
+
+var insertionShortStatPattern = regexp.MustCompile(`(\d+)\s+insertion`)
+var deletionShortStatPattern = regexp.MustCompile(`(\d+)\s+deletion`)
+
+func parseGitShortStat(output string) (int, int) {
+	return parseShortStatCount(insertionShortStatPattern, output), parseShortStatCount(deletionShortStatPattern, output)
+}
+
+func parseShortStatCount(pattern *regexp.Regexp, output string) int {
+	matches := pattern.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return 0
+	}
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func jsonScalarString(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+	var number int
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return strconv.Itoa(number)
+	}
+	return ""
+}
+
+func defaultPRCommandRunner(ctx context.Context, cwd string, name string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	if strings.TrimSpace(cwd) != "" {
+		command.Dir = cwd
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return "", fmt.Errorf("%s: %s", name, detail)
+	}
+	return stdout.String(), nil
+}
+
+type Color string
+
+const (
+	ColorDefault Color = "default"
+	ColorAccent  Color = "accent"
+	ColorGreen   Color = "green"
+	ColorRed     Color = "red"
+)
+
+type PrSegment struct {
+	Text  string
+	Color Color
+	Bold  bool
+	URL   string
+}
+
+func BuildPRSegments(state PrState, useNerdFont bool) []PrSegment {
+	if state.Status != PrFound || strings.TrimSpace(state.PrNumber) == "" {
+		return nil
+	}
+	url := strings.TrimSpace(state.PrURL)
+	segments := []PrSegment{}
+	if useNerdFont {
+		segments = append(segments, PrSegment{Text: " ", Color: ColorAccent, Bold: true, URL: url})
+	}
+	segments = append(segments,
+		PrSegment{Text: "+" + strconv.Itoa(maxInt(0, state.Additions)), Color: ColorGreen, Bold: true, URL: url},
+		PrSegment{Text: " ", Color: ColorDefault, URL: url},
+		PrSegment{Text: "-" + strconv.Itoa(maxInt(0, state.Deletions)), Color: ColorRed, Bold: true, URL: url},
+		PrSegment{Text: " ", Color: ColorDefault, URL: url},
+		PrSegment{Text: "#" + strings.TrimSpace(state.PrNumber), Color: ColorAccent, Bold: true, URL: url},
+	)
+	return segments
+}
+
+func renderPRSegments(segments []PrSegment) string {
+	var builder strings.Builder
+	for _, segment := range segments {
+		text := renderPRSegment(segment)
+		if segment.URL != "" {
+			text = hyperlink(segment.URL, text)
+		}
+		builder.WriteString(text)
+	}
+	return builder.String()
+}
+
+func renderPRSegment(segment PrSegment) string {
+	style := lipgloss.NewStyle()
+	switch segment.Color {
+	case ColorAccent:
+		style = zeroTheme.accent
+	case ColorGreen:
+		style = zeroTheme.gitAdd
+	case ColorRed:
+		style = zeroTheme.gitDel
+	case ColorDefault:
+		style = zeroTheme.muted
+	}
+	if segment.Bold {
+		style = style.Bold(true)
+	}
+	return style.Render(segment.Text)
+}

--- a/internal/tui/pr_status.go
+++ b/internal/tui/pr_status.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -258,31 +257,34 @@ func getLocalDiffStats(ctx context.Context, cwd string, baseBranch string, run p
 	if err != nil {
 		mergeBase = originBase
 	}
-	output, err := run(ctx, cwd, "git", "diff", "--shortstat", strings.TrimSpace(mergeBase))
+	output, err := run(ctx, cwd, "git", "diff", "--numstat", strings.TrimSpace(mergeBase))
 	if err != nil {
 		return 0, 0, err
 	}
-	additions, deletions := parseGitShortStat(output)
+	additions, deletions := parseGitNumStat(output)
 	return additions, deletions, nil
 }
 
-var insertionShortStatPattern = regexp.MustCompile(`(\d+)\s+insertion`)
-var deletionShortStatPattern = regexp.MustCompile(`(\d+)\s+deletion`)
-
-func parseGitShortStat(output string) (int, int) {
-	return parseShortStatCount(insertionShortStatPattern, output), parseShortStatCount(deletionShortStatPattern, output)
+func parseGitNumStat(output string) (int, int) {
+	additions := 0
+	deletions := 0
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		additions += parseNumStatValue(fields[0])
+		deletions += parseNumStatValue(fields[1])
+	}
+	return additions, deletions
 }
 
-func parseShortStatCount(pattern *regexp.Regexp, output string) int {
-	matches := pattern.FindStringSubmatch(output)
-	if len(matches) < 2 {
-		return 0
-	}
-	value, err := strconv.Atoi(matches[1])
+func parseNumStatValue(value string) int {
+	count, err := strconv.Atoi(value)
 	if err != nil {
 		return 0
 	}
-	return value
+	return count
 }
 
 func jsonScalarString(raw json.RawMessage) string {

--- a/internal/tui/pr_status_test.go
+++ b/internal/tui/pr_status_test.go
@@ -15,8 +15,8 @@ func TestPrServiceDetectsGitHubPRAndDiffStats(t *testing.T) {
 		"git merge-base origin/main HEAD": {
 			output: "abc123\n",
 		},
-		"git diff --shortstat abc123": {
-			output: " 1 file changed, 42 insertions(+), 7 deletions(-)\n",
+		"git diff --numstat abc123": {
+			output: "42\t7\tinternal/tui/view.go\n",
 		},
 	}}
 	service := NewPrService("/workspace/zero")
@@ -49,8 +49,8 @@ func TestPrServiceFallsBackToGitLabMR(t *testing.T) {
 		"git merge-base origin/develop HEAD": {
 			output: "def456\n",
 		},
-		"git diff --shortstat def456": {
-			output: " 2 files changed, 9 insertions(+), 11 deletions(-)\n",
+		"git diff --numstat def456": {
+			output: "4\t5\ta.go\n5\t6\tb.go\n",
 		},
 	}}
 	service := NewPrService("/workspace/zero")
@@ -71,8 +71,8 @@ func TestGetLocalDiffStatsFallsBackToOriginBase(t *testing.T) {
 		"git merge-base origin/main HEAD": {
 			err: errors.New("unknown revision"),
 		},
-		"git diff --shortstat origin/main": {
-			output: " 1 file changed, 3 insertions(+)\n",
+		"git diff --numstat origin/main": {
+			output: "3\t0\tREADME.md\n",
 		},
 	}}
 
@@ -82,6 +82,13 @@ func TestGetLocalDiffStatsFallsBackToOriginBase(t *testing.T) {
 	}
 	if additions != 3 || deletions != 0 {
 		t.Fatalf("diff stats = +%d -%d, want +3 -0", additions, deletions)
+	}
+}
+
+func TestParseGitNumStatSumsLocaleIndependentColumns(t *testing.T) {
+	additions, deletions := parseGitNumStat("10\t2\tfile one.go\n-\t-\tassets/logo.png\n3\t4\tdir/file.go\n")
+	if additions != 13 || deletions != 6 {
+		t.Fatalf("diff stats = +%d -%d, want +13 -6", additions, deletions)
 	}
 }
 

--- a/internal/tui/pr_status_test.go
+++ b/internal/tui/pr_status_test.go
@@ -1,0 +1,168 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPrServiceDetectsGitHubPRAndDiffStats(t *testing.T) {
+	runner := &fakePRRunner{results: map[string]fakePRResult{
+		"gh pr view --json url,number,baseRefName": {
+			output: `{"url":"https://github.com/org/repo/pull/1337","number":1337,"baseRefName":"main"}`,
+		},
+		"git merge-base origin/main HEAD": {
+			output: "abc123\n",
+		},
+		"git diff --shortstat abc123": {
+			output: " 1 file changed, 42 insertions(+), 7 deletions(-)\n",
+		},
+	}}
+	service := NewPrService("/workspace/zero")
+	service.run = runner.Run
+
+	state := service.detect(context.Background())
+
+	if state.Status != PrFound || state.Provider != ProviderGitHub || state.PrNumber != "1337" {
+		t.Fatalf("unexpected PR state: %#v", state)
+	}
+	if state.PrURL != "https://github.com/org/repo/pull/1337" {
+		t.Fatalf("PrURL = %q", state.PrURL)
+	}
+	if state.Additions != 42 || state.Deletions != 7 {
+		t.Fatalf("diff stats = +%d -%d, want +42 -7", state.Additions, state.Deletions)
+	}
+	if runner.called("glab mr view --json web_url,iid,target_branch") {
+		t.Fatal("GitLab fallback should not run when GitHub PR is found")
+	}
+}
+
+func TestPrServiceFallsBackToGitLabMR(t *testing.T) {
+	runner := &fakePRRunner{results: map[string]fakePRResult{
+		"gh pr view --json url,number,baseRefName": {
+			err: errors.New("no pull request found"),
+		},
+		"glab mr view --json web_url,iid,target_branch": {
+			output: `{"web_url":"https://gitlab.com/org/repo/-/merge_requests/55","iid":55,"target_branch":"develop"}`,
+		},
+		"git merge-base origin/develop HEAD": {
+			output: "def456\n",
+		},
+		"git diff --shortstat def456": {
+			output: " 2 files changed, 9 insertions(+), 11 deletions(-)\n",
+		},
+	}}
+	service := NewPrService("/workspace/zero")
+	service.run = runner.Run
+
+	state := service.detect(context.Background())
+
+	if state.Status != PrFound || state.Provider != ProviderGitLab || state.PrNumber != "55" {
+		t.Fatalf("unexpected MR state: %#v", state)
+	}
+	if state.Additions != 9 || state.Deletions != 11 {
+		t.Fatalf("diff stats = +%d -%d, want +9 -11", state.Additions, state.Deletions)
+	}
+}
+
+func TestGetLocalDiffStatsFallsBackToOriginBase(t *testing.T) {
+	runner := &fakePRRunner{results: map[string]fakePRResult{
+		"git merge-base origin/main HEAD": {
+			err: errors.New("unknown revision"),
+		},
+		"git diff --shortstat origin/main": {
+			output: " 1 file changed, 3 insertions(+)\n",
+		},
+	}}
+
+	additions, deletions, err := getLocalDiffStats(context.Background(), "/workspace/zero", "main", runner.Run)
+	if err != nil {
+		t.Fatalf("getLocalDiffStats returned error: %v", err)
+	}
+	if additions != 3 || deletions != 0 {
+		t.Fatalf("diff stats = +%d -%d, want +3 -0", additions, deletions)
+	}
+}
+
+func TestBuildPRSegments(t *testing.T) {
+	state := PrState{
+		Status:    PrFound,
+		PrURL:     "https://github.com/org/repo/pull/1337",
+		PrNumber:  "1337",
+		Additions: 42,
+		Deletions: 7,
+	}
+
+	segments := BuildPRSegments(state, false)
+	gotText := ""
+	for _, segment := range segments {
+		gotText += segment.Text
+		if segment.URL != state.PrURL {
+			t.Fatalf("segment %#v should carry PR hyperlink", segment)
+		}
+	}
+	if gotText != "+42 -7 #1337" {
+		t.Fatalf("segments text = %q", gotText)
+	}
+}
+
+func TestTitleBarShowsPRDiffStatsBesideBranch(t *testing.T) {
+	m := limeTestModel()
+	m.cwd = "/workspace/zero"
+	m.gitBranch = "feat/title-polish"
+	m.prState = PrState{
+		Status:    PrFound,
+		PrURL:     "https://github.com/org/repo/pull/219",
+		PrNumber:  "219",
+		Additions: 144,
+		Deletions: 32,
+	}
+
+	rendered := m.titleBar(120)
+	plain := plainRender(t, rendered)
+	for _, want := range []string{" feat/title-polish", "+144", "-32", "#219", "/workspace/zero"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("title bar = %q, missing %q", plain, want)
+		}
+	}
+	if !strings.Contains(rendered, "\x1b]8;;"+m.prState.PrURL+"\x1b\\") {
+		t.Fatalf("title bar should include OSC 8 PR hyperlink: %q", rendered)
+	}
+
+	footer := plainRender(t, m.footerView(120))
+	for _, notWant := range []string{"+144", "-32", "#219"} {
+		if strings.Contains(footer, notWant) {
+			t.Fatalf("footer = %q, should not contain title-bar PR stat %q", footer, notWant)
+		}
+	}
+}
+
+type fakePRResult struct {
+	output string
+	err    error
+}
+
+type fakePRRunner struct {
+	results map[string]fakePRResult
+	calls   []string
+}
+
+func (runner *fakePRRunner) Run(ctx context.Context, cwd string, name string, args ...string) (string, error) {
+	call := strings.TrimSpace(name + " " + strings.Join(args, " "))
+	runner.calls = append(runner.calls, call)
+	result, ok := runner.results[call]
+	if !ok {
+		return "", errors.New("unexpected command: " + call)
+	}
+	return result.output, result.err
+}
+
+func (runner *fakePRRunner) called(call string) bool {
+	for _, actual := range runner.calls {
+		if actual == call {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -384,11 +384,11 @@ func renderUserRow(row transcriptRow, width int) string {
 	contentWidth := userPromptContentWidth(width)
 	wrapped := wrapPlainText(row.text, maxInt(1, contentWidth))
 	lines := make([]string, 0, len(wrapped)+2)
-	lines = append(lines, renderUserPromptHalfLine(width, "▄"))
+	lines = append(lines, renderUserPromptPaddingLine(width))
 	for _, line := range wrapped {
 		lines = append(lines, renderUserPromptStyledLine(zeroTheme.onUserPrompt(zeroTheme.ink.Bold(true)).Render(line), contentWidth))
 	}
-	lines = append(lines, renderUserPromptHalfLine(width, "▀"))
+	lines = append(lines, renderUserPromptPaddingLine(width))
 	return strings.Join(lines, "\n")
 }
 
@@ -411,18 +411,11 @@ func renderUserPromptStyledLine(styledText string, contentWidth int) string {
 	return zeroTheme.userPrompt.Render("▌") + zeroTheme.userPromptPanel.Render("  ") + fitted + pad
 }
 
-func renderUserPromptHalfLine(width int, glyph string) string {
+func renderUserPromptPaddingLine(width int) string {
 	if width <= 0 {
 		return ""
 	}
-	capGlyph := glyph
-	switch glyph {
-	case "▄":
-		capGlyph = "▖"
-	case "▀":
-		capGlyph = "▘"
-	}
-	return zeroTheme.userPrompt.Render(capGlyph) + zeroTheme.userPromptHalf.Render(strings.Repeat(glyph, maxInt(0, width-1)))
+	return zeroTheme.userPrompt.Render("▌") + zeroTheme.userPromptPanel.Render(strings.Repeat(" ", maxInt(0, width-1)))
 }
 
 // renderAssistantRow draws final answers as plain response text plus completion

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
@@ -982,6 +983,30 @@ func TestTitleBarShowsWorkspaceAndModel(t *testing.T) {
 		if strings.Contains(got, notWant) {
 			t.Fatalf("title bar = %q, should not include old brand cluster %q", got, notWant)
 		}
+	}
+}
+
+func TestTitleBarHighlightsBranchOverWorkspace(t *testing.T) {
+	oldProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(oldProfile)
+	})
+
+	m := limeTestModel()
+	m.cwd = "/workspace/zero"
+	m.gitBranch = "main"
+	got := m.titleWorkspaceSegment()
+
+	highlightedBranch := zeroTheme.muted.Render("") + " " + zeroTheme.muted.Render("main")
+	recessedWorkspace := zeroTheme.faint.Render("/workspace/zero")
+	for _, want := range []string{highlightedBranch, recessedWorkspace} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("title workspace segment = %q, missing styled segment %q", got, want)
+		}
+	}
+	if faintBranch := zeroTheme.faint.Render("") + " " + zeroTheme.faint.Render("main"); strings.Contains(got, faintBranch) {
+		t.Fatalf("title workspace segment = %q, branch should use highlighted title colour", got)
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -967,13 +967,20 @@ func TestStatusLineGroups(t *testing.T) {
 	}
 }
 
-func TestTitleBarShowsBadgeAndModel(t *testing.T) {
+func TestTitleBarShowsWorkspaceAndModel(t *testing.T) {
 	m := limeTestModel()
 	m.width = 120
+	m.cwd = "/workspace/zero"
+	m.gitBranch = "main"
 	got := plainRender(t, m.titleBar(120))
-	for _, want := range []string{" 0 ", "zero", "test-provider/test-model"} {
+	for _, want := range []string{" main", "/workspace/zero", "test-provider/test-model"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("title bar = %q, missing %q", got, want)
+		}
+	}
+	for _, notWant := range []string{" 0 ", "zero /"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("title bar = %q, should not include old brand cluster %q", got, notWant)
 		}
 	}
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -68,7 +68,6 @@ type tuiTheme struct {
 	// Surfaces.
 	panel           lipgloss.Style // bare panel background (card padding, body fill)
 	userPromptPanel lipgloss.Style // submitted user prompt background
-	userPromptHalf  lipgloss.Style // submitted prompt half-block padding
 
 	// Permission modes.
 	modeAuto   lipgloss.Style
@@ -159,7 +158,6 @@ var zeroTheme = tuiTheme{
 
 	panel:           lipgloss.NewStyle().Background(lipgloss.Color(colorPanel)),
 	userPromptPanel: lipgloss.NewStyle().Background(lipgloss.Color(colorPromptBg)),
-	userPromptHalf:  lipgloss.NewStyle().Foreground(lipgloss.Color(colorPromptBg)),
 
 	modeAuto:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)).Bold(true),
 	modeAsk:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)).Bold(true),

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -20,6 +20,8 @@ type tuiTheme struct {
 	red        lipgloss.Style // errors, diff del sign, ✗, deny
 	amber      lipgloss.Style // permission surfaces, warnings, auto badge
 	blue       lipgloss.Style // grep file locations, local-model dot
+	gitAdd     lipgloss.Style // PR/local diff additions
+	gitDel     lipgloss.Style // PR/local diff deletions
 	line       lipgloss.Style // default borders, rules, status separators
 	lineStrong lipgloss.Style // emphasized borders
 	selection  lipgloss.Style // transcript selection highlight
@@ -96,6 +98,8 @@ const (
 	colorRed      = "#ff7a7a" // errors, diff del
 	colorAmber    = "#ffc25c" // permission, warnings
 	colorBlue     = "#7db4ff" // grep locations, local-model dot
+	colorGitAdd   = "#7db87a" // footer PR diff additions
+	colorGitDel   = "#b87a7a" // footer PR diff deletions
 	colorAddBg    = "#15201d" // diff added-line bg (green @9% over panel)
 	colorDelBg    = "#241819" // diff deleted-line bg (red @9%)
 	colorPermBg   = "#1c1915" // permission card bg (amber @6%)
@@ -118,6 +122,8 @@ var zeroTheme = tuiTheme{
 	red:        lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)),
 	amber:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
 	blue:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlue)),
+	gitAdd:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorGitAdd)),
+	gitDel:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorGitDel)),
 	line:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine)),
 	lineStrong: lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine2)),
 	selection:  lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorOnAccent)),

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -130,7 +130,7 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 	wrapped := wrapPlainText(row.text, maxInt(1, contentWidth))
 	lines := make([]string, 0, len(wrapped)+2)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
-	lines = append(lines, renderUserPromptHalfLine(width, "▄"))
+	lines = append(lines, renderUserPromptPaddingLine(width))
 	for index, line := range wrapped {
 		meta := transcriptSelectableLine{
 			bodyY:     startBodyY + index + 1,
@@ -141,7 +141,7 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 		selectable = append(selectable, meta)
 		lines = append(lines, renderUserPromptStyledLine(m.renderTranscriptSelectableText(meta, zeroTheme.onUserPrompt(zeroTheme.ink.Bold(true))), contentWidth))
 	}
-	lines = append(lines, renderUserPromptHalfLine(width, "▀"))
+	lines = append(lines, renderUserPromptPaddingLine(width))
 	return strings.Join(lines, "\n"), selectable
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -60,7 +60,7 @@ func (m model) titleBar(width int) string {
 	workspace := m.titleWorkspaceSegment()
 	workspaceShort := m.titleWorkspaceSegmentShort()
 	branchOnly := m.titleBranchSegment()
-	cwdOnly := zeroTheme.muted.Render(shortenPath(m.cwd))
+	cwdOnly := zeroTheme.faint.Render(shortenPath(m.cwd))
 	compactLeft := cwdOnly
 	if branchOnly != "" {
 		compactLeft = branchOnly
@@ -107,21 +107,35 @@ func (m model) titleBar(width int) string {
 }
 
 func (m model) titleWorkspaceSegment() string {
-	cwd := zeroTheme.muted.Render(shortenPath(m.cwd))
+	cwd := zeroTheme.faint.Render(shortenPath(m.cwd))
+	parts := []string{}
 	if branch := m.titleBranchSegment(); branch != "" {
-		return branch + "  " + cwd
+		parts = append(parts, branch)
+	}
+	if pr := m.titlePRSegment(); pr != "" {
+		parts = append(parts, pr)
+	}
+	if len(parts) > 0 {
+		return strings.Join(append(parts, cwd), "  ")
 	}
 	return cwd
 }
 
 func (m model) titleWorkspaceSegmentShort() string {
-	cwd := zeroTheme.muted.Render(shortenPath(m.cwd))
+	cwd := zeroTheme.faint.Render(shortenPath(m.cwd))
+	parts := []string{}
 	branch := strings.TrimSpace(m.gitBranch)
-	if branch == "" {
-		return cwd
+	if branch != "" {
+		icon := zeroTheme.muted.Render("")
+		parts = append(parts, icon+" "+zeroTheme.muted.Render(middleTruncate(branch, 22)))
 	}
-	icon := zeroTheme.faint.Render("")
-	return icon + " " + zeroTheme.faint.Render(middleTruncate(branch, 22)) + "  " + cwd
+	if pr := m.titlePRSegment(); pr != "" {
+		parts = append(parts, pr)
+	}
+	if len(parts) > 0 {
+		return strings.Join(append(parts, cwd), "  ")
+	}
+	return cwd
 }
 
 func (m model) titleBranchSegment() string {
@@ -129,7 +143,11 @@ func (m model) titleBranchSegment() string {
 	if branch == "" {
 		return ""
 	}
-	return zeroTheme.faint.Render("") + " " + zeroTheme.faint.Render(branch)
+	return zeroTheme.muted.Render("") + " " + zeroTheme.muted.Render(branch)
+}
+
+func (m model) titlePRSegment() string {
+	return renderPRSegments(BuildPRSegments(m.prState, false))
 }
 
 func (m model) titleModelSegment() string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -50,23 +50,20 @@ func widthTier(width int) layoutTier {
 	}
 }
 
-// titleBar renders the top zone of the chat surface: the brand badge, cwd and
-// branch on the left, provider/model and context window on the right, then a
-// rule. Segments drop with the width tier (full → no ctx → no cwd → bare
-// badge + model only), reusing the startupHeaderLine candidate fallback.
+// titleBar renders the top zone of the chat surface: git branch and cwd on the
+// left, provider/model and context window on the right, then a rule. Segments
+// drop with the width tier (full → no ctx → no cwd → branch/path only), reusing
+// the startupHeaderLine candidate fallback.
 func (m model) titleBar(width int) string {
 	tier := widthTier(width)
 
-	badge := zeroTheme.badge.Render(" 0 ") + " " + zeroTheme.ink.Bold(true).Render("zero")
-	if tier <= tierNarrow {
-		badge = zeroTheme.accent.Render("0") + " " + zeroTheme.ink.Bold(true).Render("zero")
-	}
-	cwd := zeroTheme.faintest.Render(" / ") + zeroTheme.muted.Render(shortenPath(m.cwd))
-	branch := ""
-	branchShort := ""
-	if b := strings.TrimSpace(m.gitBranch); b != "" {
-		branch = " " + zeroTheme.faint.Render(b)
-		branchShort = " " + zeroTheme.faint.Render(middleTruncate(b, 22))
+	workspace := m.titleWorkspaceSegment()
+	workspaceShort := m.titleWorkspaceSegmentShort()
+	branchOnly := m.titleBranchSegment()
+	cwdOnly := zeroTheme.muted.Render(shortenPath(m.cwd))
+	compactLeft := cwdOnly
+	if branchOnly != "" {
+		compactLeft = branchOnly
 	}
 	model := m.titleModelSegment()
 	ctx := ""
@@ -78,33 +75,61 @@ func (m model) titleBar(width int) string {
 	switch tier {
 	case tierFull:
 		candidates = []headerCandidate{
-			{left: badge + cwd + branch, right: model + ctx},
-			{left: badge + cwd + branch, right: model},
-			{left: badge + cwd + branchShort, right: model},
-			{left: badge + cwd, right: model},
-			{left: badge, right: model},
+			{left: workspace, right: model + ctx},
+			{left: workspace, right: model},
+			{left: workspaceShort, right: model},
+			{left: cwdOnly, right: model},
+			{left: compactLeft, right: model},
 		}
 	case tierMedium:
 		candidates = []headerCandidate{
-			{left: badge + cwd + branch, right: model},
-			{left: badge + cwd + branchShort, right: model},
-			{left: badge + cwd, right: model},
-			{left: badge, right: model},
+			{left: workspace, right: model},
+			{left: workspaceShort, right: model},
+			{left: cwdOnly, right: model},
+			{left: compactLeft, right: model},
 		}
 	case tierNarrow:
 		candidates = []headerCandidate{
-			{left: badge, right: model},
+			{left: branchOnly, right: model},
+			{left: "", right: model},
 		}
 	default:
 		// Tiny: one segment, no right column.
 		candidates = []headerCandidate{
-			{left: badge, right: ""},
+			{left: compactLeft, right: ""},
+			{left: cwdOnly, right: ""},
 		}
 	}
 
 	line := startupHeaderLine(width, candidates)
 	rule := zeroTheme.line.Render(strings.Repeat("─", width))
 	return line + "\n" + rule
+}
+
+func (m model) titleWorkspaceSegment() string {
+	cwd := zeroTheme.muted.Render(shortenPath(m.cwd))
+	if branch := m.titleBranchSegment(); branch != "" {
+		return branch + "  " + cwd
+	}
+	return cwd
+}
+
+func (m model) titleWorkspaceSegmentShort() string {
+	cwd := zeroTheme.muted.Render(shortenPath(m.cwd))
+	branch := strings.TrimSpace(m.gitBranch)
+	if branch == "" {
+		return cwd
+	}
+	icon := zeroTheme.faint.Render("")
+	return icon + " " + zeroTheme.faint.Render(middleTruncate(branch, 22)) + "  " + cwd
+}
+
+func (m model) titleBranchSegment() string {
+	branch := strings.TrimSpace(m.gitBranch)
+	if branch == "" {
+		return ""
+	}
+	return zeroTheme.faint.Render("") + " " + zeroTheme.faint.Render(branch)
 }
 
 func (m model) titleModelSegment() string {

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -114,10 +114,13 @@ func TestTitleBarKeepsWorkspaceWithLongBranchAndModel(t *testing.T) {
 	m.gitBranch = "feat/tui-assistant-response-cleanup"
 
 	got := plainRender(t, m.titleBar(108))
-	for _, want := range []string{"zero", "/workspace/zero", "feat/", "…", "ollama-cloud/cogito-2.1:671b-extra-long-model-name"} {
+	for _, want := range []string{"", "/workspace/zero", "feat/tui-assistant-response-cleanup", "ollama-cloud/cogito-2.1:671b-extra-long-model-name"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("title bar = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, " 0 ") {
+		t.Fatalf("title bar = %q, should not include old badge", got)
 	}
 	for index, line := range strings.Split(got, "\n") {
 		if width := lipgloss.Width(line); width > 108 {


### PR DESCRIPTION
Summary:
- replace the old lime 0/zero header cluster with a quieter branch + workspace title bar
- keep provider/model on the right and preserve responsive fallbacks
- update title-bar tests with generic workspace paths

Tests:
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Title bar now prominently shows workspace path, git branch indicator, and model/provider info with adaptive layout across terminal widths.
  * Added pull/merge request status display in the TUI when detected, including a PR link and local diff statistics.
* **Tests**
  * Updated title bar regression coverage for the new workspace/branch/model behavior.
  * Added unit tests for PR/MR detection, diff-stat computation, and PR segment/title/footer rendering.
* **Chores / Style**
  * Refined user prompt framing and theme styling for git diff markers and footer visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->