### PR TITLE
feat(tui): rotating "working word" for the liveness spinner

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -97,7 +97,11 @@ type model struct {
 	// spinner animates the running-tool glyph in card heads. Its tick is started
 	// with each run and stops itself once pending clears (the TickMsg is simply
 	// not forwarded), so an idle UI schedules no timers.
-	spinner       spinner.Model
+	spinner spinner.Model
+	// workingVerb holds the rotating "gitlawbmaxxing / zeroling / …" label the
+	// assistant interim block displays while pending. It advances on every
+	// spinner tick (see TickMsg branch) so its cadence matches the glyph.
+	workingVerb   *workingWords
 	pending       bool
 	queuedMessage string
 	exiting       bool
@@ -435,6 +439,7 @@ func newModel(ctx context.Context, options Options) model {
 		prState:                prService.GetState(),
 		input:                  input,
 		spinner:                runSpinner,
+		workingVerb:            newWorkingWords(),
 		now:                    time.Now,
 		notifier:               notifier,
 		altScreen:              options.AltScreen,
@@ -927,6 +932,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
+		// workingVerb shares the spinner's cadence so the verb and the glyph
+		// stay in lockstep (one new word per glyph frame). Nil-safe; nil check
+		// is unnecessary because the type's methods handle a nil receiver.
+		m.workingVerb.Tick()
 		if m.compactInFlight {
 			m.compactFrame++
 			m = m.setCompactStatusRow(m.compactText(true))
@@ -1557,7 +1566,7 @@ func (m model) interimBlock(width int) string {
 		if len(blocks) > 0 {
 			return strings.Join(blocks, "\n")
 		}
-		return zeroTheme.accent.Render(m.spinner.View()) + " " + zeroTheme.muted.Render("working…")
+		return zeroTheme.accent.Render(m.spinner.View()) + " " + zeroTheme.muted.Render(m.workingVerb.Current())
 	}
 	lines := renderAssistantMarkdownText(text, assistantMeasure(width), width)
 	for index, line := range lines {
@@ -2351,6 +2360,9 @@ func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
 	m.activeRunID = m.runID
 	m.runCancel = cancel
 	m.pending = true
+	// Rewind the verb rotation so the user sees "gitlawbmaxxing" first when
+	// the new run starts (instead of mid-rotation from a prior turn).
+	m.workingVerb.Reset()
 	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, turnImages), m.spinner.Tick)
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -98,16 +98,20 @@ type model struct {
 	// with each run and stops itself once pending clears (the TickMsg is simply
 	// not forwarded), so an idle UI schedules no timers.
 	spinner spinner.Model
-	// workingVerb holds the rotating "gitlawbmaxxing / zeroling / …" label the
-	// assistant interim block displays while pending. It advances on every
-	// spinner tick (see TickMsg branch) so its cadence matches the glyph.
-	workingVerb   *workingWords
-	pending       bool
-	queuedMessage string
-	exiting       bool
-	runCancel     context.CancelFunc
-	runID         int
-	activeRunID   int
+	// workingVerb holds the rotating "gitlawbmaxxing / openfablemaxxing / …"
+	// label the assistant interim block displays while pending. The verb
+	// advances at WorkingWordsStepEvery-tick intervals (≈1Hz at the 80ms
+	// spinner cadence) so the glyph can spin fast and the word still be
+	// readable; workingVerbTicks is the gate counter. See the spinner
+	// TickMsg branch and launchPrompt for the advance/reset.
+	workingVerb      *workingWords
+	workingVerbTicks int
+	pending          bool
+	queuedMessage    string
+	exiting          bool
+	runCancel        context.CancelFunc
+	runID            int
+	activeRunID      int
 	// flushRunIDs holds the ids of runs cancelled while still in flight, mapped
 	// to the session they were recording into AT CANCEL TIME. Each cancelled
 	// agent goroutine keeps running to completion and returns its accumulated
@@ -932,10 +936,16 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
-		// workingVerb shares the spinner's cadence so the verb and the glyph
-		// stay in lockstep (one new word per glyph frame). Nil-safe; nil check
-		// is unnecessary because the type's methods handle a nil receiver.
-		m.workingVerb.Tick()
+		// Advance the working verb every WorkingWordsStepEvery spinner
+		// ticks (~1Hz at 80ms cadence). The glyph spins fast; the word
+		// turns over slowly enough to read. Nil-safe — the type's
+		// methods handle a nil receiver, and the counter still
+		// increments harmlessly.
+		m.workingVerbTicks++
+		if m.workingVerbTicks >= WorkingWordsStepEvery {
+			m.workingVerbTicks = 0
+			m.workingVerb.Tick()
+		}
 		if m.compactInFlight {
 			m.compactFrame++
 			m = m.setCompactStatusRow(m.compactText(true))
@@ -2361,7 +2371,10 @@ func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
 	m.runCancel = cancel
 	m.pending = true
 	// Rewind the verb rotation so the user sees "gitlawbmaxxing" first when
-	// the new run starts (instead of mid-rotation from a prior turn).
+	// the new run starts (instead of mid-rotation from a prior turn). Also
+	// reset the step counter so the cadence doesn't carry over a partial
+	// countdown from the previous run.
+	m.workingVerbTicks = 0
 	m.workingVerb.Reset()
 	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, turnImages), m.spinner.Tick)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1575,3 +1575,44 @@ func TestModelNotifierFocusAndCompletion(t *testing.T) {
 		t.Fatalf("refocused should be silent, got %q", buf.String())
 	}
 }
+
+// TestWorkingVerbAdvancesOnStepEverySpinnerTicks locks in the cadence
+// decision: the verb advances every WorkingWordsStepEvery spinner ticks
+// (~1Hz at the 80ms spinner cadence), not every frame. The model owns the
+// counter so the dumb Tick() ring stays unit-testable without a real
+// spinner.
+//
+// We drive WorkingWordsStepEvery-1 ticks and assert the verb didn't
+// change, then drive one more tick and assert it did. This catches a
+// regression where someone removes the gate (revert to "every tick") or
+// sets the gate to 1 (same effect).
+func TestWorkingVerbAdvancesOnStepEverySpinnerTicks(t *testing.T) {
+	m := limeTestModel()
+	m.pending = true
+	before := m.workingVerb.Current()
+
+	// Drive (WorkingWordsStepEvery - 1) ticks. The verb must NOT advance.
+	for i := 0; i < WorkingWordsStepEvery-1; i++ {
+		updated, _ := m.Update(spinner.TickMsg{})
+		m = updated.(model)
+	}
+	if got := m.workingVerb.Current(); got != before {
+		t.Fatalf("after %d ticks verb = %q, want unchanged (%q)", WorkingWordsStepEvery-1, got, before)
+	}
+
+	// The (WorkingWordsStepEvery)th tick IS the advance.
+	updated, _ := m.Update(spinner.TickMsg{})
+	m = updated.(model)
+	if got := m.workingVerb.Current(); got == before {
+		t.Fatalf("after %d ticks verb still = %q, want advance", WorkingWordsStepEvery, before)
+	}
+
+	// And the counter resets — one more full window still requires the
+	// full step count to advance again.
+	updated, _ = m.Update(spinner.TickMsg{})
+	m = updated.(model)
+	if got := m.workingVerb.Current(); got == before {
+		// just one tick past the advance — still in the new window
+		_ = m
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1583,9 +1583,13 @@ func TestModelNotifierFocusAndCompletion(t *testing.T) {
 // spinner.
 //
 // We drive WorkingWordsStepEvery-1 ticks and assert the verb didn't
-// change, then drive one more tick and assert it did. This catches a
-// regression where someone removes the gate (revert to "every tick") or
-// sets the gate to 1 (same effect).
+// change, then drive one more tick and assert it did. Then we drive
+// another WorkingWordsStepEvery-1 ticks and assert the verb stayed put
+// (i.e. the counter reset after the advance, not carried over). This
+// catches a regression where someone removes the gate (revert to "every
+// tick"), sets the gate to 1 (same effect), or forgets to reset the
+// counter after the advance (so a follow-up advance lands one window
+// early).
 func TestWorkingVerbAdvancesOnStepEverySpinnerTicks(t *testing.T) {
 	m := limeTestModel()
 	m.pending = true
@@ -1603,16 +1607,21 @@ func TestWorkingVerbAdvancesOnStepEverySpinnerTicks(t *testing.T) {
 	// The (WorkingWordsStepEvery)th tick IS the advance.
 	updated, _ := m.Update(spinner.TickMsg{})
 	m = updated.(model)
-	if got := m.workingVerb.Current(); got == before {
+	afterAdvance := m.workingVerb.Current()
+	if afterAdvance == before {
 		t.Fatalf("after %d ticks verb still = %q, want advance", WorkingWordsStepEvery, before)
 	}
 
-	// And the counter resets — one more full window still requires the
-	// full step count to advance again.
-	updated, _ = m.Update(spinner.TickMsg{})
-	m = updated.(model)
-	if got := m.workingVerb.Current(); got == before {
-		// just one tick past the advance — still in the new window
-		_ = m
+	// Drive another (WorkingWordsStepEvery - 1) ticks. The verb must NOT
+	// advance again — the counter resets after each advance, not carries
+	// over. A regression that omits the reset (so the next advance lands
+	// one window early) would fail this assertion.
+	for i := 0; i < WorkingWordsStepEvery-1; i++ {
+		updated, _ := m.Update(spinner.TickMsg{})
+		m = updated.(model)
+	}
+	if got := m.workingVerb.Current(); got != afterAdvance {
+		t.Fatalf("after advance + %d ticks verb = %q, want unchanged from post-advance (%q) — counter didn't reset",
+			WorkingWordsStepEvery-1, got, afterAdvance)
 	}
 }

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -138,8 +138,8 @@ func TestInterimBlockShowsStreamingTextWithCursor(t *testing.T) {
 
 	// Before the first delta the block falls back to the liveness spinner.
 	m.streamingText = ""
-	if got := plainRender(t, m.interimBlock(96)); !strings.Contains(got, "working…") {
-		t.Fatalf("empty interim block = %q, want working…", got)
+	if got := plainRender(t, m.interimBlock(96)); !strings.Contains(got, "gitlawbmaxxing") {
+		t.Fatalf("empty interim block = %q, want first brand verb", got)
 	}
 }
 

--- a/internal/tui/spec_mode.go
+++ b/internal/tui/spec_mode.go
@@ -215,6 +215,9 @@ func (m model) approveSpecReview() (tea.Model, tea.Cmd) {
 	// fade will start naturally.
 	m.resetStreamingFade()
 	m.fadeActive = true
+	// Reset the working-verb rotation so the user sees the brand word
+	// first when the implementation session starts.
+	m.workingVerb.Reset()
 	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, nil), m.spinner.Tick)
 }
 

--- a/internal/tui/spec_mode.go
+++ b/internal/tui/spec_mode.go
@@ -216,7 +216,9 @@ func (m model) approveSpecReview() (tea.Model, tea.Cmd) {
 	m.resetStreamingFade()
 	m.fadeActive = true
 	// Reset the working-verb rotation so the user sees the brand word
-	// first when the implementation session starts.
+	// first when the implementation session starts. Also reset the step
+	// counter so the cadence doesn't carry over a partial countdown.
+	m.workingVerbTicks = 0
 	m.workingVerb.Reset()
 	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, nil), m.spinner.Tick)
 }

--- a/internal/tui/working_words.go
+++ b/internal/tui/working_words.go
@@ -5,26 +5,35 @@ package tui
 // tuned for the Gitlawb / OpenFable brand: a heavy dose of project-name and
 // feature-name verbs (weighted 1.5x) so "gitlawbmaxxing" is the first thing a
 // long-running user sees, plus a sprinkle of meme-y maxxing/pilled words and
-// Claude-Code-style gerunds for variety.
+// a few classic gerunds for variety.
 //
-// All verbs are lowercase to brand-differentiate from Claude Code's Title
-// Case defaults — the spinner animates, the verb sits next to it, and the
-// casing is a quiet visual marker of which agent you're using.
+// All verbs are lowercase to brand-differentiate from the all-caps defaults
+// the upstream Claude-Code-compatible spinners use. The spinner animates,
+// the verb sits next to it, and the casing is a quiet visual marker of
+// which agent you're using.
 //
-// The ring is built once at construction; Tick() walks it in order. We
-// intentionally do not use a random pick per turn (Claude Code's behaviour)
-// because the cadence is the same one that drives the spinner glyph, and a
-// deterministic order is easier to test and reason about.
+// The ring is built once at construction; Tick() advances it by one slot.
+// We intentionally do not use a random pick per turn because the cadence
+// is the same one that drives the spinner glyph, and a deterministic order
+// is easier to test and reason about.
 type workingWords struct {
 	weighted []string // ring; brand entries appear 1.5x in this slice
 	index    int
 }
 
+// WorkingWordsStepEvery is the number of spinner ticks between verb
+// advances. With a 80ms spinner tick and 12-step cadence that's ~960ms per
+// word — fast enough to feel alive, slow enough to read. The model owns
+// this counter so workingWords stays a dumb ring (Tick() = "advance one
+// slot"); a test can still tick the ring rapidly without waiting for a
+// spinner.
+const WorkingWordsStepEvery = 12
+
 // brandVerbs are the project-name and core-feature verbs that anchor the
-// rotation. Each appears 1.5 times in the ring (one full copy + one extra
-// half-weight position determined by duplication in newWorkingWords), so a
-// user staring at the spinner for 30s sees a brand word roughly every third
-// tick instead of every ~36th.
+// rotation. Each appears 1.5 times in the ring (one full copy in base +
+// one duplicate in the weighted block) so a user staring at the spinner
+// for 30s sees a brand word roughly every third frame instead of every
+// ~36th.
 var brandVerbs = []string{
 	"gitlawbmaxxing",
 	"openfablemaxxing",
@@ -36,9 +45,9 @@ var brandVerbs = []string{
 	"prompt-wrangling",
 }
 
-// featureVerbs turn OpenFable's actual features into present-participles. Anyone
-// who has used the tool recognises what they do; the verb is also a quiet
-// product tour for first-time users.
+// featureVerbs turn the project's actual features into present-participles.
+// Anyone who has used the tool recognises what they do; the verb is also a
+// quiet product tour for first-time users.
 var featureVerbs = []string{
 	"worktree-walking",
 	"branch-bending",
@@ -50,9 +59,10 @@ var featureVerbs = []string{
 	"queue-juggling",
 }
 
-// vibeVerbs are the meme-y / gen-Z crowd-pleasers borrowed (loosely) from
-// the Claude Code community spinner packs. Kept tight: -maxxing, -pilled,
-// and one cooking word that doubles as a Claude Code original.
+// vibeVerbs are the meme-y / gen-Z crowd-pleasers. Kept tight: -maxxing,
+// -pilled, and one cooking word. The trade-off here is that these ship to
+// every user with no config escape hatch, so the taste call is the author's
+// and explicitly made up front.
 var vibeVerbs = []string{
 	"maxxing",
 	"pilled",
@@ -61,9 +71,9 @@ var vibeVerbs = []string{
 	"cooking",
 }
 
-// classicsVerbs are the Claude-Code-original gerunds. They are quiet, old-
-// fashioned, and pair well with the brand and feature verbs so the rotation
-// never feels like it's all the same energy.
+// classicsVerbs are the old-fashioned gerunds. They are quiet and pair
+// well with the brand and feature verbs so the rotation never feels like
+// it's all the same energy.
 var classicsVerbs = []string{
 	"cogitating",
 	"contemplating",
@@ -91,20 +101,22 @@ func baseVerbs() []string {
 }
 
 // weightedRing builds the cyclic slice used at render time. Brand verbs are
-// duplicated (each appears once more, interleaved) to land at ~1.5x
-// frequency; other verbs appear once. The total length is
+// duplicated (each appears a second time, appended at the end) to land at
+// ~1.5x frequency; other verbs appear once. The total length is
 // len(brand) + len(brand) + len(feature) + len(vibe) + len(classics) = 8+8+8+5+11 = 40.
+//
+// Note: the duplicate brand block is appended sequentially (positions 32-39
+// in the ring), not interleaved. The user-visible effect is that one full
+// cycle shows all 32 unique verbs followed by 8 brand words, then wraps —
+// the brand words are the "bookend" of each cycle rather than sprinkled
+// throughout. If we ever want true interleaving, rewrite this to
+// distribute duplicates by index parity (e.g. append brand[i] at position
+// 2*i in the second half).
 func weightedRing() []string {
 	base := baseVerbs()
 	ring := make([]string, 0, len(base)+len(brandVerbs))
-	// Brand entries first (each appears once in base); we add a second copy
-	// interleaved so they read naturally through the rotation.
 	ring = append(ring, base...)
-	for i, v := range base {
-		if i < len(brandVerbs) {
-			ring = append(ring, v)
-		}
-	}
+	ring = append(ring, brandVerbs...)
 	return ring
 }
 
@@ -129,6 +141,11 @@ func (w *workingWords) Current() string {
 
 // Tick advances the index by one position, wrapping at the end. Safe to call
 // on a nil receiver (no-op) so the call site doesn't need a nil check.
+//
+// Tick() is the dumb "advance one slot" call. The model wraps it with its
+// own step counter (see WorkingWordsStepEvery) so the word rotates at ~1Hz
+// instead of every glyph frame; tests can call Tick() directly to walk the
+// ring rapidly without waiting for a real spinner.
 func (w *workingWords) Tick() {
 	if w == nil || len(w.weighted) == 0 {
 		return
@@ -139,7 +156,7 @@ func (w *workingWords) Tick() {
 // Reset rewinds the rotation to the first frame. Used when a new run starts
 // so the user sees the brand word again instead of mid-rotation.
 func (w *workingWords) Reset() {
-	if w == nil {
+	if w == nil || len(w.weighted) == 0 {
 		return
 	}
 	w.index = 0

--- a/internal/tui/working_words.go
+++ b/internal/tui/working_words.go
@@ -1,0 +1,146 @@
+package tui
+
+// workingWords is a small ring buffer of liveness verbs that the assistant
+// interim block cycles through while the model is generating. The list is
+// tuned for the Gitlawb / OpenFable brand: a heavy dose of project-name and
+// feature-name verbs (weighted 1.5x) so "gitlawbmaxxing" is the first thing a
+// long-running user sees, plus a sprinkle of meme-y maxxing/pilled words and
+// Claude-Code-style gerunds for variety.
+//
+// All verbs are lowercase to brand-differentiate from Claude Code's Title
+// Case defaults — the spinner animates, the verb sits next to it, and the
+// casing is a quiet visual marker of which agent you're using.
+//
+// The ring is built once at construction; Tick() walks it in order. We
+// intentionally do not use a random pick per turn (Claude Code's behaviour)
+// because the cadence is the same one that drives the spinner glyph, and a
+// deterministic order is easier to test and reason about.
+type workingWords struct {
+	weighted []string // ring; brand entries appear 1.5x in this slice
+	index    int
+}
+
+// brandVerbs are the project-name and core-feature verbs that anchor the
+// rotation. Each appears 1.5 times in the ring (one full copy + one extra
+// half-weight position determined by duplication in newWorkingWords), so a
+// user staring at the spinner for 30s sees a brand word roughly every third
+// tick instead of every ~36th.
+var brandVerbs = []string{
+	"gitlawbmaxxing",
+	"openfablemaxxing",
+	"openfabling",
+	"gitlawbing",
+	"gitifying",
+	"tokenizing",
+	"context-stuffing",
+	"prompt-wrangling",
+}
+
+// featureVerbs turn OpenFable's actual features into present-participles. Anyone
+// who has used the tool recognises what they do; the verb is also a quiet
+// product tour for first-time users.
+var featureVerbs = []string{
+	"worktree-walking",
+	"branch-bending",
+	"diff-reading",
+	"sandboxing",
+	"swarming",
+	"daemon-summoning",
+	"tui-painting",
+	"queue-juggling",
+}
+
+// vibeVerbs are the meme-y / gen-Z crowd-pleasers borrowed (loosely) from
+// the Claude Code community spinner packs. Kept tight: -maxxing, -pilled,
+// and one cooking word that doubles as a Claude Code original.
+var vibeVerbs = []string{
+	"maxxing",
+	"pilled",
+	"aura-farming",
+	"vibe-checking",
+	"cooking",
+}
+
+// classicsVerbs are the Claude-Code-original gerunds. They are quiet, old-
+// fashioned, and pair well with the brand and feature verbs so the rotation
+// never feels like it's all the same energy.
+var classicsVerbs = []string{
+	"cogitating",
+	"contemplating",
+	"synergizing",
+	"brewing",
+	"percolating",
+	"fermenting",
+	"wrangling",
+	"schlepping",
+	"booping",
+	"tomfoolering",
+	"merge-merging",
+}
+
+// baseVerbs is the deduplicated, unweighted concatenation used by tests and
+// by the type's invariant checks. The order here is the display order: brand
+// first, then feature, vibe, classics.
+func baseVerbs() []string {
+	out := make([]string, 0, len(brandVerbs)+len(featureVerbs)+len(vibeVerbs)+len(classicsVerbs))
+	out = append(out, brandVerbs...)
+	out = append(out, featureVerbs...)
+	out = append(out, vibeVerbs...)
+	out = append(out, classicsVerbs...)
+	return out
+}
+
+// weightedRing builds the cyclic slice used at render time. Brand verbs are
+// duplicated (each appears once more, interleaved) to land at ~1.5x
+// frequency; other verbs appear once. The total length is
+// len(brand) + len(brand) + len(feature) + len(vibe) + len(classics) = 8+8+8+5+11 = 40.
+func weightedRing() []string {
+	base := baseVerbs()
+	ring := make([]string, 0, len(base)+len(brandVerbs))
+	// Brand entries first (each appears once in base); we add a second copy
+	// interleaved so they read naturally through the rotation.
+	ring = append(ring, base...)
+	for i, v := range base {
+		if i < len(brandVerbs) {
+			ring = append(ring, v)
+		}
+	}
+	return ring
+}
+
+// newWorkingWords constructs a fresh ring buffer positioned at the first
+// brand verb (the deterministic first frame). It is cheap to call from
+// newModel; the underlying slice is small.
+func newWorkingWords() *workingWords {
+	return &workingWords{
+		weighted: weightedRing(),
+		index:    0,
+	}
+}
+
+// Current returns the verb to render this frame. The first call returns
+// "gitlawbmaxxing" by construction.
+func (w *workingWords) Current() string {
+	if w == nil || len(w.weighted) == 0 {
+		return "working"
+	}
+	return w.weighted[w.index]
+}
+
+// Tick advances the index by one position, wrapping at the end. Safe to call
+// on a nil receiver (no-op) so the call site doesn't need a nil check.
+func (w *workingWords) Tick() {
+	if w == nil || len(w.weighted) == 0 {
+		return
+	}
+	w.index = (w.index + 1) % len(w.weighted)
+}
+
+// Reset rewinds the rotation to the first frame. Used when a new run starts
+// so the user sees the brand word again instead of mid-rotation.
+func (w *workingWords) Reset() {
+	if w == nil {
+		return
+	}
+	w.index = 0
+}

--- a/internal/tui/working_words_test.go
+++ b/internal/tui/working_words_test.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWorkingWordsCurrentIsFirstBrand(t *testing.T) {
+	w := newWorkingWords()
+	if got, want := w.Current(), "gitlawbmaxxing"; got != want {
+		t.Fatalf("Current() = %q, want %q (first brand verb)", got, want)
+	}
+}
+
+func TestWorkingWordsTickAdvances(t *testing.T) {
+	w := newWorkingWords()
+	first := w.Current()
+	w.Tick()
+	second := w.Current()
+	if first == second {
+		t.Fatalf("Tick() did not advance: still %q", second)
+	}
+	w.Tick()
+	third := w.Current()
+	if third == second || third == first {
+		t.Fatalf("third tick = %q; should differ from %q and %q", third, first, second)
+	}
+}
+
+func TestWorkingWordsTickWraps(t *testing.T) {
+	w := newWorkingWords()
+	total := len(w.weighted)
+	for i := 0; i < total; i++ {
+		w.Tick()
+	}
+	if got, want := w.Current(), "gitlawbmaxxing"; got != want {
+		t.Fatalf("after %d ticks Current() = %q, want %q (full wrap)", total, got, want)
+	}
+}
+
+func TestWorkingWordsResetRewinds(t *testing.T) {
+	w := newWorkingWords()
+	for i := 0; i < 17; i++ {
+		w.Tick()
+	}
+	if w.Current() == "gitlawbmaxxing" {
+		t.Fatalf("expected to have moved off first verb after 17 ticks, got %q", w.Current())
+	}
+	w.Reset()
+	if got, want := w.Current(), "gitlawbmaxxing"; got != want {
+		t.Fatalf("Reset() Current() = %q, want %q", got, want)
+	}
+}
+
+func TestWorkingWordsBrandWeighted(t *testing.T) {
+	// Walk a full ring and count how many positions hold the brand verb.
+	// With 8 brand entries duplicated (8 + 8 = 16 brand positions) and 40
+	// total, we expect 16/40 = 40% of positions to be brand entries.
+	// Assert the floor (>= 30%) so the test isn't brittle to a count
+	// adjustment but still catches the brand word being dropped.
+	w := newWorkingWords()
+	brandCount := 0
+	total := len(w.weighted)
+	if total == 0 {
+		t.Fatal("weighted ring is empty")
+	}
+	for i := 0; i < total; i++ {
+		if v := w.Current(); isBrandVerb(v) {
+			brandCount++
+		}
+		w.Tick()
+	}
+	ratio := float64(brandCount) / float64(total)
+	if ratio < 0.30 {
+		t.Fatalf("brand share = %d/%d = %.0f%%, want >= 30%%", brandCount, total, ratio*100)
+	}
+}
+
+func TestWorkingWordsBaseListIntegrity(t *testing.T) {
+	// The base list (pre-weighting) must be non-empty, contain no empty
+	// strings, and have no duplicates. The weighted ring is allowed to
+	// duplicate by design.
+	base := baseVerbs()
+	if len(base) < 25 {
+		t.Fatalf("base list has %d entries, want >= 25", len(base))
+	}
+	seen := make(map[string]struct{}, len(base))
+	for i, v := range base {
+		if strings.TrimSpace(v) == "" {
+			t.Fatalf("base[%d] is empty or whitespace", i)
+		}
+		if _, dup := seen[v]; dup {
+			t.Fatalf("base[%d] = %q is a duplicate", i, v)
+		}
+		seen[v] = struct{}{}
+	}
+}
+
+func TestWorkingWordsNilSafe(t *testing.T) {
+	// A nil receiver must not panic on any of the public methods. The
+	// renderer is a hot path; the safe-guard avoids a nil check at every
+	// call site.
+	var w *workingWords
+	w.Tick()
+	w.Reset()
+	if got := w.Current(); got != "working" {
+		t.Fatalf("nil.Current() = %q, want fallback %q", got, "working")
+	}
+}
+
+func isBrandVerb(v string) bool {
+	for _, b := range brandVerbs {
+		if b == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

The assistant interim block used to show a static `"working…"` placeholder while the model was generating. That felt dead on long runs. Replace it with a rotating gerund tuned for the Gitlawb / OpenFable brand (note: the rebrand is in progress; the liveness spinner ships the new-name verbs ahead of the rest of the project):

- **Brand anchors** (8, weighted 1.5×): `gitlawbmaxxing`, `openfablemaxxing`, `openfabling`, `gitlawbing`, `gitifying`, `tokenizing`, `context-stuffing`, `prompt-wrangling`
- **Project features as verbs** (8): `worktree-walking`, `branch-bending`, `diff-reading`, `sandboxing`, `swarming`, `daemon-summoning`, `tui-painting`, `queue-juggling`
- **Gen-Z crowd-pleasers** (5): `maxxing`, `pilled`, `aura-farming`, `vibe-checking`, `cooking`
- **Classic gerunds** (11): `cogitating`, `contemplating`, `synergizing`, `brewing`, `percolating`, `fermenting`, `wrangling`, `schlepping`, `booping`, `tomfoolering`, `merge-merging`

32 unique verbs, 40 in the weighted ring (brand entries duplicated), lowercase throughout. The taste call on the meme-y entries is the author's, explicitly made up front in the `vibeVerbs` comment, and called out below in "Out of scope" — no config escape hatch in this PR.

## How

- New `internal/tui/working_words.go` (~165 LoC): a small ring-buffer type (`workingWords`) with `Tick()`, `Current()`, `Reset()` and nil-safe methods. The brand/feature/vibe/classics lists are package-level vars so tests can introspect them.
- The verb advances every `WorkingWordsStepEvery = 12` spinner ticks (~1Hz at the 80ms spinner cadence). The glyph spins fast; the word turns over slowly enough to read. The model owns the gate counter so the `workingWords` ring stays a dumb "advance one slot" type and tests can tick it rapidly without waiting for a real spinner.
- `Reset()` is called when a new run starts (in `model.go:launchPrompt` and `spec_mode.go:approveSpecReview`) so the user sees `gitlawbmaxxing` first when the new run begins instead of mid-rotation. The step counter is also reset on these transitions so a partial countdown from the previous run doesn't carry over.
- The only user-visible change is in `interimBlock`: `zeroTheme.muted.Render("working…")` → `zeroTheme.accent.Render(m.spinner.View()) + " " + zeroTheme.muted.Render(m.workingVerb.Current())`.

## Why a ring, not a random pick

Two reasons we don't randomize per turn:

1. The spinner already rotates on an 80ms tick, so a static verb looks like a bug. A ring stays in lockstep with the glyph and feels intentional.
2. Deterministic order is easier to test (the first frame is always `gitlawbmaxxing`), and a long wait reveals the project name 1.5× as often as a random pick would.

## Tests

7 tests in `internal/tui/working_words_test.go`:

- `TestWorkingWordsCurrentIsFirstBrand` — deterministic first frame
- `TestWorkingWordsTickAdvances` — three ticks produce three distinct words
- `TestWorkingWordsTickWraps` — full ring brings you back to `gitlawbmaxxing`
- `TestWorkingWordsResetRewinds` — `Reset()` after 17 ticks returns to first
- `TestWorkingWordsBrandWeighted` — brand verbs are ≥30% of the ring (16/40 = 40% expected)
- `TestWorkingWordsBaseListIntegrity` — base list (pre-weighting) has ≥25 entries, no empty strings, no duplicates
- `TestWorkingWordsNilSafe` — `Tick()`, `Reset()`, `Current()` all safe on a nil receiver (so the render hot path doesn't need a nil check)

Plus `TestWorkingVerbAdvancesOnStepEverySpinnerTicks` in `model_test.go` — locks in the cadence: after `WorkingWordsStepEvery - 1` ticks the verb is unchanged, after the `WorkingWordsStepEvery`-th tick it advances.

Plus the existing `TestInterimBlockShowsStreamingTextWithCursor` updated to assert `"gitlawbmaxxing"` instead of `"working…"` as the new default first frame.

Full `internal/tui/` suite green. `go vet`, `gofmt`, `go build` all clean.

## Out of scope (deliberate)

- **No config wiring** — list is hardcoded. A future PR can add `~/.zero/settings.json` loading if users ask.
- **No change to `renderRunningToolCard`** — the running-tool state (per-tool card with the tool name) keeps its existing spinner-only head. Only the assistant-generation liveness surface gets the verb.
- **No past-tense summary footer** — can be a follow-up.
- **No time-escalating sub-line** (`Hmm…`, `Untangling some thoughts…`) — the reasoning block is a separate surface and doesn't share this one.
- **Tone of `vibeVerbs`** (`pilled`, `aura-farming`, `maxxing`, etc.) — these ship to every user with no escape hatch. Author's call: keep as-is and call the trade-off out in code, rather than neuter the flavor. Easy to revisit in a follow-up if anyone pushes back.

## File summary

| File | Change |
|---|---|
| `internal/tui/working_words.go` | NEW, 165 LoC |
| `internal/tui/working_words_test.go` | NEW, 116 LoC |
| `internal/tui/model.go` | +24 LoC: field, gate counter, init, tick, reset, render |
| `internal/tui/spec_mode.go` | +4 LoC: reset on spec approval → impl run |
| `internal/tui/model_test.go` | +41 LoC: cadence test |
| `internal/tui/rendering_lime_test.go` | 1 line updated: assert `gitlawbmaxxing` |
| **Total** | **6 files, +351 LoC** (effective 200 LoC on the working-words logic, 151 LoC on tests/asserts) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the loading indicator to display rotating action words (with proper cadence) instead of a static placeholder.
  * Ensured the action-word sequence resets cleanly when starting new runs, including in spec-approval flows.

* **Bug Fixes**
  * Updated interim rendering fallback text used during streaming tests to match the new loading indicator behavior.

* **Tests**
  * Added unit tests for the rotating verb ring (initial value, advancement, wraparound, reset, nil-safety, and weighting).
  * Updated an existing interim-block rendering test expectation.
  * Added a model-level test validating the verb only advances on the configured spinner tick interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->