### PR TITLE
Fix provider setup paste handling

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -561,12 +561,18 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case providerWizardDeviceCodeMsg:
 		return m.applyProviderWizardDeviceCode(msg)
 	case tea.PasteMsg:
-		if m.setup.visible || m.pendingAskUser != nil {
+		if m.setup.visible {
+			return m.handleSetupPaste(msg)
+		}
+		if m.pendingAskUser != nil {
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)
 			return m, cmd
 		}
-		if m.transcriptDetailed || m.pendingSpecReview != nil || m.pendingPermission != nil || m.providerWizard != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil {
+		if m.providerWizard != nil {
+			return m.handleProviderWizardPaste(msg.Content)
+		}
+		if m.transcriptDetailed || m.pendingSpecReview != nil || m.pendingPermission != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil {
 			return m, nil
 		}
 		state := m.currentComposerState()

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -260,6 +260,31 @@ func (m model) handleSetupKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) handleSetupPaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	if m.setup.oauthPending {
+		return m, nil
+	}
+	switch {
+	case m.setupEndpointInputActive():
+		m.appendSetupBaseURL([]rune(msg.Content))
+	case m.setupNameInputActive():
+		m.appendSetupName([]rune(msg.Content))
+	case m.setupCredentialInputActive():
+		previousAPIKey := m.setup.apiKey.Value()
+		var cmd tea.Cmd
+		m.setup.apiKey, cmd = m.setup.apiKey.Update(msg)
+		if m.setup.apiKey.Value() != previousAPIKey {
+			m.setup.modelGen++
+			m.resetSetupModels()
+		}
+		m.setup.err = ""
+		return m, cmd
+	case m.setup.stage == setupStageModel:
+		m.appendSetupModelQuery([]rune(msg.Content))
+	}
+	return m, nil
+}
+
 func (m model) handleSetupMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if m.setup.oauthPending {
 		return m, nil

--- a/internal/tui/onboarding_test.go
+++ b/internal/tui/onboarding_test.go
@@ -249,6 +249,36 @@ func TestSetupTakeoverCustomCompatibleCollectsEndpointNameAndModel(t *testing.T)
 	}
 }
 
+func TestSetupEndpointAcceptsPastedURL(t *testing.T) {
+	m := newModel(context.Background(), Options{
+		Setup: SetupOptions{
+			Visible: true,
+			Providers: []SetupProviderOption{
+				{ID: "custom-openai-compatible", Name: "Custom OpenAI-compatible", DefaultModel: "custom-model", EnvVar: "OPENAI_API_KEY", RequiresAuth: true},
+			},
+		},
+	})
+	m.width = 100
+	m.height = 30
+
+	m = pressSetupContinue(m)
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageEndpoint {
+		t.Fatalf("stage = %v, want endpoint", m.setup.stage)
+	}
+
+	updated, _ := m.Update(testPaste("https://api.minimax.io/v1\n"))
+	m = updated.(model)
+	if m.setup.baseURL != "https://api.minimax.io/v1" {
+		t.Fatalf("setup baseURL = %q, want pasted endpoint", m.setup.baseURL)
+	}
+
+	m = pressSetupContinue(m)
+	if m.setup.stage != setupStageName {
+		t.Fatalf("stage = %v, want name", m.setup.stage)
+	}
+}
+
 func TestSetupCompletionResetsChatSurfaceInsideAltScreen(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
@@ -600,7 +630,7 @@ func TestSetupCredentialsAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T)
 	m.height = 30
 	m.setup.stage = setupStageCredentials
 
-	updated, _ := m.Update(testKeyText(secret))
+	updated, _ := m.Update(testPaste(secret))
 	m = updated.(model)
 	view := plainRender(t, m.View())
 	if strings.Contains(view, secret) {

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -666,6 +666,23 @@ func (m model) handleProviderWizardKey(msg tea.KeyMsg) (model, tea.Cmd) {
 	return m, nil
 }
 
+func (m model) handleProviderWizardPaste(content string) (model, tea.Cmd) {
+	if m.providerWizard == nil || m.providerWizard.oauthPending {
+		return m, nil
+	}
+	switch m.providerWizard.step {
+	case providerWizardStepEndpoint:
+		m.providerWizard.appendBaseURL([]rune(content))
+	case providerWizardStepName:
+		m.providerWizard.appendProfileName([]rune(content))
+	case providerWizardStepCredential:
+		m.providerWizard.appendAPIKey([]rune(content))
+	case providerWizardStepModel:
+		m.providerWizard.appendModelSearch([]rune(content))
+	}
+	return m, nil
+}
+
 func (wizard *providerWizardState) canAdvanceWithRight() bool {
 	if wizard == nil {
 		return false

--- a/internal/tui/provider_wizard_test.go
+++ b/internal/tui/provider_wizard_test.go
@@ -447,6 +447,30 @@ func TestProviderWizardCustomCompatibleProviderCollectsEndpointAndModel(t *testi
 	}
 }
 
+func TestProviderWizardAcceptsPastedEndpointURL(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	m = openProviderWizardForTest(t, m)
+	m.providerWizard.selectedProvider = providerWizardProviderIndex(t, m.providerWizard, "custom-openai-compatible")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if next.providerWizard.step != providerWizardStepEndpoint {
+		t.Fatalf("custom provider first step = %v, want endpoint", next.providerWizard.step)
+	}
+
+	updated, _ = next.Update(testPaste("https://proxy.example/v1\n"))
+	next = updated.(model)
+	if next.providerWizard.baseURL != "https://proxy.example/v1" {
+		t.Fatalf("wizard baseURL = %q, want pasted endpoint", next.providerWizard.baseURL)
+	}
+
+	updated, _ = next.Update(testKey(tea.KeyEnter))
+	next = updated.(model)
+	if next.providerWizard.step != providerWizardStepName {
+		t.Fatalf("endpoint step advanced to %v, want name", next.providerWizard.step)
+	}
+}
+
 func TestProviderWizardCustomCompatibleProviderRejectsRemoteHTTP(t *testing.T) {
 	m := newModel(context.Background(), Options{})
 	m = openProviderWizardForTest(t, m)
@@ -556,7 +580,7 @@ func TestProviderWizardAcceptsPastedAPIKeyWithoutRenderingSecret(t *testing.T) {
 		t.Fatalf("wizard step = %v, want credential", next.providerWizard.step)
 	}
 
-	updated, _ = next.Update(testKeyText(secret))
+	updated, _ = next.Update(testPaste(secret))
 	next = updated.(model)
 	if next.providerWizard.apiKey != secret {
 		t.Fatalf("wizard api key was not captured from paste")
@@ -582,7 +606,7 @@ func TestProviderWizardAppliesPastedKeyToCurrentSession(t *testing.T) {
 
 	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
-	updated, _ = next.Update(testKeyText(secret))
+	updated, _ = next.Update(testPaste(secret))
 	next = updated.(model)
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)
@@ -631,7 +655,7 @@ func TestProviderWizardPersistsPastedKeyToUserConfig(t *testing.T) {
 
 	updated, _ := m.Update(testKey(tea.KeyEnter))
 	next := updated.(model)
-	updated, _ = next.Update(testKeyText(secret))
+	updated, _ = next.Update(testPaste(secret))
 	next = updated.(model)
 	updated, _ = next.Update(testKey(tea.KeyEnter))
 	next = updated.(model)


### PR DESCRIPTION
## Summary
- route terminal paste events to the active provider setup field
- support pasted endpoint URLs in first-run setup and /provider wizard
- add regression coverage using PasteMsg for endpoint URLs and API keys

## Tests
- GOCACHE=/tmp/zero-go-cache GOMODCACHE=/tmp/zero-go-mod-cache go test ./internal/tui
- GOCACHE=/tmp/zero-go-cache GOMODCACHE=/tmp/zero-go-mod-cache go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced paste input handling during onboarding and provider setup to correctly route pasted content to appropriate input fields based on UI context.

* **Tests**
  * Added tests verifying paste functionality for URLs and API keys in onboarding and provider configuration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->