### PR TITLE
Harden TUI layout and mouse routing

### DIFF
--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -1,0 +1,133 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestTranscriptFrameLayoutPinsMainRegions(t *testing.T) {
+	m := mouseTestModel()
+	m.width = 100
+	m.height = 24
+	m.providerName = "openai"
+	m.modelName = "gpt-4.1"
+
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+
+	if frame.headerRect != (tuiRect{width: width, height: len(frame.headerLines)}) {
+		t.Fatalf("header rect = %#v, want y=0 width=%d height=%d", frame.headerRect, width, len(frame.headerLines))
+	}
+	if frame.bodyRect.y != frame.headerRect.height {
+		t.Fatalf("body y = %d, want below header height %d", frame.bodyRect.y, frame.headerRect.height)
+	}
+	if frame.footerRect.y != frame.bodyRect.y+frame.bodyRect.height {
+		t.Fatalf("footer y = %d, want after body at %d", frame.footerRect.y, frame.bodyRect.y+frame.bodyRect.height)
+	}
+	if frame.footerRect.y+frame.footerRect.height != m.height {
+		t.Fatalf("footer bottom = %d, want terminal height %d", frame.footerRect.y+frame.footerRect.height, m.height)
+	}
+	if frame.composerRect.height <= 0 || !frame.footerRect.contains(frame.composerRect.x, frame.composerRect.y) {
+		t.Fatalf("composer rect should be visible inside footer, frame=%#v", frame)
+	}
+	if frame.statusRect.height != 1 || frame.statusRect.y != frame.footerRect.y+frame.footerRect.height-1 {
+		t.Fatalf("status rect = %#v, want final visible footer line", frame.statusRect)
+	}
+}
+
+func TestTranscriptFrameLayoutClipsFooterInTinyTerminal(t *testing.T) {
+	m := mouseTestModel()
+	m.width = 44
+	m.height = 3
+	m.copyStatus = "Copied!"
+	m.input.SetValue("Create a book library dashboard page with cards, filters, charts, and responsive behavior.")
+
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+
+	if frame.bodyRect.height != 1 {
+		t.Fatalf("body height = %d, want one protected viewport line", frame.bodyRect.height)
+	}
+	if frame.footerRect.height != m.height-1 {
+		t.Fatalf("footer height = %d, want clipped to %d", frame.footerRect.height, m.height-1)
+	}
+	if frame.headerRect.height != 0 {
+		t.Fatalf("header should clip out before body disappears, got %#v", frame.headerRect)
+	}
+	if frame.footerClip <= 0 {
+		t.Fatalf("footerClip = %d, want clipped full footer", frame.footerClip)
+	}
+	if len(frame.footerLines) >= len(frame.fullFooterLines) {
+		t.Fatalf("footer lines were not clipped: visible=%d full=%d", len(frame.footerLines), len(frame.fullFooterLines))
+	}
+}
+
+func TestFrameComposerRegionDrivesMouseHit(t *testing.T) {
+	m := mouseTestModel()
+	m.width = 44
+	m.height = 20
+	m.input.SetValue("Create a book library dashboard page with cards, filters, charts, and responsive behavior.")
+
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	if frame.composerRect.height <= 0 {
+		t.Fatalf("expected visible composer rect, frame=%#v", frame)
+	}
+	if !m.mouseOverComposer(testMouseWheel(tea.MouseWheelUp, 0, frame.composerRect.y)) {
+		t.Fatalf("mouse over composer y=%d should hit composer rect %#v", frame.composerRect.y, frame.composerRect)
+	}
+	if m.mouseOverComposer(testMouseWheel(tea.MouseWheelUp, 0, frame.statusRect.y)) {
+		t.Fatalf("mouse over status y=%d should not hit composer rect %#v", frame.statusRect.y, frame.composerRect)
+	}
+}
+
+func TestOverlayMouseRectCentersInsideTranscriptBody(t *testing.T) {
+	m := mouseTestModel()
+	m.width = 100
+	m.height = 30
+
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	rect := m.overlayMouseRect(5, width)
+
+	wantY := frame.bodyRect.y + (frame.bodyRect.height-5)/2
+	if rect.y != wantY || rect.height != 5 || rect.width != width {
+		t.Fatalf("overlay rect = %#v, want y=%d height=5 width=%d", rect, wantY, width)
+	}
+	if !frame.bodyRect.contains(rect.x, rect.y) || !frame.bodyRect.contains(rect.x, rect.y+rect.height-1) {
+		t.Fatalf("overlay rect %#v should be inside body rect %#v", rect, frame.bodyRect)
+	}
+}
+
+func TestTranscriptLineAtMouseUsesFrameBodyRegion(t *testing.T) {
+	m := mouseTestModel()
+	m.width = 90
+	m.height = 12
+	m.transcript = appendRow(m.transcript, rowUser, "target text")
+
+	width := chatWidth(m.width)
+	body, selectable := m.transcriptBody(width, "")
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	start, _, _ := transcriptViewportStartForFrame(body, frame, m.chatScrollOffset)
+
+	var target transcriptSelectableLine
+	for _, line := range selectable {
+		if strings.Contains(line.text, "target text") {
+			target = line
+			break
+		}
+	}
+	if target.text == "" {
+		t.Fatalf("target line missing from selectable lines: %#v", selectable)
+	}
+
+	hit, ok := m.transcriptLineAtMouse(testMouseClick(tea.MouseLeft, target.textStart, frame.bodyRect.y+target.bodyY-start))
+	if !ok || hit.text != target.text {
+		t.Fatalf("transcript line hit = %#v ok=%v, want %#v", hit, ok, target)
+	}
+	if _, ok := m.transcriptLineAtMouse(testMouseClick(tea.MouseLeft, target.textStart, frame.headerRect.y)); ok {
+		t.Fatal("header click should not map to transcript body")
+	}
+}

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -29,7 +29,9 @@ func TestTranscriptFrameLayoutPinsMainRegions(t *testing.T) {
 	if frame.footerRect.y+frame.footerRect.height != m.height {
 		t.Fatalf("footer bottom = %d, want terminal height %d", frame.footerRect.y+frame.footerRect.height, m.height)
 	}
-	if frame.composerRect.height <= 0 || !frame.footerRect.contains(frame.composerRect.x, frame.composerRect.y) {
+	if frame.composerRect.height <= 0 ||
+		!frame.footerRect.contains(frame.composerRect.x, frame.composerRect.y) ||
+		!frame.footerRect.contains(frame.composerRect.x+frame.composerRect.width-1, frame.composerRect.y+frame.composerRect.height-1) {
 		t.Fatalf("composer rect should be visible inside footer, frame=%#v", frame)
 	}
 	if frame.statusRect.height != 1 || frame.statusRect.y != frame.footerRect.y+frame.footerRect.height-1 {
@@ -61,6 +63,35 @@ func TestTranscriptFrameLayoutClipsFooterInTinyTerminal(t *testing.T) {
 	}
 	if len(frame.footerLines) >= len(frame.fullFooterLines) {
 		t.Fatalf("footer lines were not clipped: visible=%d full=%d", len(frame.footerLines), len(frame.fullFooterLines))
+	}
+}
+
+func TestTranscriptFrameLayoutHandlesDegenerateDimensions(t *testing.T) {
+	for _, size := range []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{name: "zero", width: 0, height: 0},
+		{name: "negative", width: -10, height: -4},
+	} {
+		t.Run(size.name, func(t *testing.T) {
+			m := mouseTestModel()
+			m.width = size.width
+			m.height = size.height
+
+			width := chatWidth(m.width)
+			frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+			if width <= 0 {
+				t.Fatalf("chatWidth(%d) = %d, want positive fallback", size.width, width)
+			}
+			if frame.bodyRect.height < 1 {
+				t.Fatalf("body rect = %#v, want protected body height", frame.bodyRect)
+			}
+			if frame.width != width {
+				t.Fatalf("frame width = %d, want chat width %d", frame.width, width)
+			}
+		})
 	}
 }
 
@@ -98,6 +129,27 @@ func TestOverlayMouseRectCentersInsideTranscriptBody(t *testing.T) {
 	}
 	if !frame.bodyRect.contains(rect.x, rect.y) || !frame.bodyRect.contains(rect.x, rect.y+rect.height-1) {
 		t.Fatalf("overlay rect %#v should be inside body rect %#v", rect, frame.bodyRect)
+	}
+}
+
+func TestOverlayMouseHitClampsToVisibleBody(t *testing.T) {
+	m := mouseTestModel()
+	m.width = 80
+	m.height = 8
+
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	overlay := strings.Join([]string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"}, "\n")
+	rect := m.overlayMouseRect(len(viewLines(overlay)), width)
+	if rect.height != frame.bodyRect.height {
+		t.Fatalf("overlay rect = %#v, want height clamped to body rect %#v", rect, frame.bodyRect)
+	}
+
+	if _, ok := m.overlayMouseHit(testMouseClick(tea.MouseLeft, 1, rect.y+rect.height-1), overlay, width); !ok {
+		t.Fatalf("click inside visible overlay rect %#v should hit", rect)
+	}
+	if _, ok := m.overlayMouseHit(testMouseClick(tea.MouseLeft, 1, rect.y+rect.height), overlay, width); ok {
+		t.Fatalf("click below visible overlay rect %#v should not hit invisible overlay rows", rect)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1316,15 +1316,43 @@ func (m model) footerView(width int) string {
 	return footer.String()
 }
 
+type tuiRect struct {
+	x      int
+	y      int
+	width  int
+	height int
+}
+
+func (r tuiRect) contains(x int, y int) bool {
+	return x >= r.x && y >= r.y && x < r.x+r.width && y < r.y+r.height
+}
+
+func (r tuiRect) local(x int, y int) (int, int, bool) {
+	if !r.contains(x, y) {
+		return 0, 0, false
+	}
+	return x - r.x, y - r.y, true
+}
+
 type transcriptFrameLayout struct {
-	headerLines []string
-	bodyHeight  int
-	footerLines []string
+	width           int
+	height          int
+	headerRect      tuiRect
+	bodyRect        tuiRect
+	footerRect      tuiRect
+	composerRect    tuiRect
+	statusRect      tuiRect
+	headerLines     []string
+	bodyHeight      int
+	footerLines     []string
+	fullFooterLines []string
+	footerClip      int
 }
 
 func (m model) scrollableTranscriptFrame(header string, footer string) transcriptFrameLayout {
 	headerLines := viewLines(header)
-	footerLines := viewLines(footer)
+	fullFooterLines := viewLines(footer)
+	footerLines := append([]string(nil), fullFooterLines...)
 
 	maxFooterLines := maxInt(0, m.height-1)
 	if len(footerLines) > maxFooterLines {
@@ -1347,7 +1375,56 @@ func (m model) scrollableTranscriptFrame(header string, footer string) transcrip
 	if bodyHeight < 1 {
 		bodyHeight = 1
 	}
-	return transcriptFrameLayout{headerLines: headerLines, bodyHeight: bodyHeight, footerLines: footerLines}
+	width := chatWidth(m.width)
+	footerTop := len(headerLines) + bodyHeight
+	frame := transcriptFrameLayout{
+		width:           width,
+		height:          m.height,
+		headerRect:      tuiRect{width: width, height: len(headerLines)},
+		bodyRect:        tuiRect{y: len(headerLines), width: width, height: bodyHeight},
+		footerRect:      tuiRect{y: footerTop, width: width, height: len(footerLines)},
+		headerLines:     headerLines,
+		bodyHeight:      bodyHeight,
+		footerLines:     footerLines,
+		fullFooterLines: fullFooterLines,
+		footerClip:      maxInt(0, len(fullFooterLines)-len(footerLines)),
+	}
+	frame.composerRect = frame.footerSubrect(viewLines(m.composerBox(width)))
+	if len(fullFooterLines) > 0 {
+		frame.statusRect = frame.footerLineRect(len(fullFooterLines) - 1)
+	}
+	return frame
+}
+
+func (f transcriptFrameLayout) footerSubrect(sequence []string) tuiRect {
+	if len(sequence) == 0 || len(f.footerLines) == 0 {
+		return tuiRect{}
+	}
+	top := lineSequenceIndex(f.fullFooterLines, sequence)
+	if top < 0 {
+		return tuiRect{}
+	}
+	visibleTop := maxInt(top, f.footerClip)
+	visibleBottom := minInt(top+len(sequence), f.footerClip+len(f.footerLines))
+	if visibleTop >= visibleBottom {
+		return tuiRect{}
+	}
+	return tuiRect{
+		y:      f.footerRect.y + visibleTop - f.footerClip,
+		width:  f.width,
+		height: visibleBottom - visibleTop,
+	}
+}
+
+func (f transcriptFrameLayout) footerLineRect(line int) tuiRect {
+	if line < f.footerClip || line >= f.footerClip+len(f.footerLines) {
+		return tuiRect{}
+	}
+	return tuiRect{
+		y:      f.footerRect.y + line - f.footerClip,
+		width:  f.width,
+		height: 1,
+	}
 }
 
 func (m model) scrollableTranscriptView(header string, body string, footer string, width int, overlay string) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1264,7 +1264,7 @@ func (m model) transcriptView() string {
 	if m.transcriptEmpty() && !m.pending && viewportOverlay != "" {
 		emptyOverlay = viewportOverlay
 	}
-	body, _ := m.transcriptBody(width, emptyOverlay)
+	bodyLayout := m.transcriptBodyLayout(width, emptyOverlay)
 
 	footer := m.footerView(width)
 
@@ -1274,9 +1274,10 @@ func (m model) transcriptView() string {
 	}
 
 	if m.altScreen && m.height > 0 {
-		return m.scrollableTranscriptView(m.pinnedTitleBar(width), body, footer, width, overlayForViewport)
+		return m.scrollableTranscriptLayoutView(m.pinnedTitleBar(width), bodyLayout, footer, width, overlayForViewport)
 	}
 
+	body := bodyLayout.String()
 	if overlayForViewport != "" {
 		body += "\n" + overlayForViewport + "\n"
 	}
@@ -1428,14 +1429,14 @@ func (f transcriptFrameLayout) footerLineRect(line int) tuiRect {
 }
 
 func (m model) scrollableTranscriptView(header string, body string, footer string, width int, overlay string) string {
-	bodyLines := viewLines(body)
-	frame := m.scrollableTranscriptFrame(header, footer)
-	window := newTranscriptViewport(len(bodyLines), frame.bodyRect.height, m.chatScrollOffset).window()
+	return m.scrollableTranscriptLayoutView(header, transcriptBodyLayout{lines: viewLines(body)}, footer, width, overlay)
+}
 
-	bodyWindow := make([]string, 0, window.height)
-	if window.start < window.end {
-		bodyWindow = append(bodyWindow, bodyLines[window.start:window.end]...)
-	}
+func (m model) scrollableTranscriptLayoutView(header string, body transcriptBodyLayout, footer string, width int, overlay string) string {
+	frame := m.scrollableTranscriptFrame(header, footer)
+	window := transcriptViewportForLayout(body, frame, m.chatScrollOffset).window()
+
+	bodyWindow := body.visibleLines(window)
 	for len(bodyWindow) < window.height {
 		bodyWindow = append(bodyWindow, "")
 	}
@@ -1577,9 +1578,9 @@ func (m model) chatTranscriptViewport() (transcriptViewport, bool) {
 		return transcriptViewport{}, false
 	}
 	width := chatWidth(m.width)
-	body, _ := m.transcriptBody(width, "")
+	body := m.transcriptBodyLayout(width, "")
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	return transcriptViewportForBody(body, frame, m.chatScrollOffset), true
+	return transcriptViewportForLayout(body, frame, m.chatScrollOffset), true
 }
 
 // syncChatScroll pins the viewport to what the user is reading. The scroll offset

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1430,17 +1430,13 @@ func (f transcriptFrameLayout) footerLineRect(line int) tuiRect {
 func (m model) scrollableTranscriptView(header string, body string, footer string, width int, overlay string) string {
 	bodyLines := viewLines(body)
 	frame := m.scrollableTranscriptFrame(header, footer)
-	available := frame.bodyHeight
-	maxOffset := maxInt(0, len(bodyLines)-available)
-	offset := clamp(m.chatScrollOffset, 0, maxOffset)
-	start := maxInt(0, len(bodyLines)-available-offset)
-	end := minInt(len(bodyLines), start+available)
+	window := newTranscriptViewport(len(bodyLines), frame.bodyRect.height, m.chatScrollOffset).window()
 
-	bodyWindow := make([]string, 0, available)
-	if start < end {
-		bodyWindow = append(bodyWindow, bodyLines[start:end]...)
+	bodyWindow := make([]string, 0, window.height)
+	if window.start < window.end {
+		bodyWindow = append(bodyWindow, bodyLines[window.start:window.end]...)
 	}
-	for len(bodyWindow) < available {
+	for len(bodyWindow) < window.height {
 		bodyWindow = append(bodyWindow, "")
 	}
 	bodyWindow = overlayViewportLines(bodyWindow, overlay, width)
@@ -1552,9 +1548,11 @@ func (m model) scrollChat(delta int) model {
 	if !m.altScreen || delta == 0 {
 		return m
 	}
-	maxOffset := m.chatMaxScrollOffset()
-	current := clampInt(m.chatScrollOffset, 0, maxOffset)
-	m.chatScrollOffset = clampInt(current+delta, 0, maxOffset)
+	viewport, ok := m.chatTranscriptViewport()
+	if !ok {
+		return m
+	}
+	m.chatScrollOffset = viewport.scroll(delta).offset
 	if m.chatScrollOffset == 0 {
 		m.chatBodyLines = 0
 	}
@@ -1567,15 +1565,21 @@ func (m model) chatMaxScrollOffset() int {
 }
 
 func (m model) chatScrollMetrics() (int, int) {
-	if !m.altScreen || m.height <= 0 {
+	viewport, ok := m.chatTranscriptViewport()
+	if !ok {
 		return 0, 0
+	}
+	return viewport.totalLines, viewport.maxOffset()
+}
+
+func (m model) chatTranscriptViewport() (transcriptViewport, bool) {
+	if !m.altScreen || m.height <= 0 {
+		return transcriptViewport{}, false
 	}
 	width := chatWidth(m.width)
 	body, _ := m.transcriptBody(width, "")
-	bodyLines := len(viewLines(body))
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	available := frame.bodyHeight
-	return bodyLines, maxInt(0, bodyLines-available)
+	return transcriptViewportForBody(body, frame, m.chatScrollOffset), true
 }
 
 // syncChatScroll pins the viewport to what the user is reading. The scroll offset

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -442,14 +442,14 @@ func (m model) overlayMouseHit(msg tea.MouseMsg, overlay string, width int) (mou
 	if overlayWidth <= 0 || len(lines) == 0 {
 		return mouseOverlayHit{}, false
 	}
-	top := m.overlayMouseTop(len(lines), width)
-	if mouseY(msg) < top || mouseY(msg) >= top+len(lines) {
+	rect := m.overlayMouseRect(len(lines), width)
+	if rect.height <= 0 || mouseY(msg) < rect.y || mouseY(msg) >= rect.y+rect.height {
 		return mouseOverlayHit{}, false
 	}
 	if mouseX(msg) < left || mouseX(msg) >= left+overlayWidth {
 		return mouseOverlayHit{}, false
 	}
-	return mouseOverlayHit{x: mouseX(msg) - left, y: mouseY(msg) - top}, true
+	return mouseOverlayHit{x: mouseX(msg) - left, y: mouseY(msg) - rect.y}, true
 }
 
 func (m model) overlayMouseTop(overlayHeight int, width int) int {
@@ -462,10 +462,14 @@ func (m model) overlayMouseRect(overlayHeight int, width int) tuiRect {
 	}
 	if m.altScreen && m.height > 0 {
 		frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+		visibleHeight := minInt(overlayHeight, frame.bodyRect.height)
+		if visibleHeight <= 0 {
+			return tuiRect{}
+		}
 		return tuiRect{
-			y:      frame.bodyRect.y + maxInt(0, (frame.bodyRect.height-overlayHeight)/2),
+			y:      frame.bodyRect.y + maxInt(0, (frame.bodyRect.height-visibleHeight)/2),
 			width:  width,
-			height: overlayHeight,
+			height: visibleHeight,
 		}
 	}
 	return tuiRect{

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -3,6 +3,7 @@ package tui
 import tea "charm.land/bubbletea/v2"
 
 type mouseOverlayHit struct {
+	x int
 	y int
 }
 
@@ -448,16 +449,28 @@ func (m model) overlayMouseHit(msg tea.MouseMsg, overlay string, width int) (mou
 	if mouseX(msg) < left || mouseX(msg) >= left+overlayWidth {
 		return mouseOverlayHit{}, false
 	}
-	return mouseOverlayHit{y: mouseY(msg) - top}, true
+	return mouseOverlayHit{x: mouseX(msg) - left, y: mouseY(msg) - top}, true
 }
 
 func (m model) overlayMouseTop(overlayHeight int, width int) int {
+	return m.overlayMouseRect(overlayHeight, width).y
+}
+
+func (m model) overlayMouseRect(overlayHeight int, width int) tuiRect {
 	if overlayHeight <= 0 {
-		return 0
+		return tuiRect{}
 	}
 	if m.altScreen && m.height > 0 {
 		frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-		return frame.bodyRect.y + maxInt(0, (frame.bodyRect.height-overlayHeight)/2)
+		return tuiRect{
+			y:      frame.bodyRect.y + maxInt(0, (frame.bodyRect.height-overlayHeight)/2),
+			width:  width,
+			height: overlayHeight,
+		}
 	}
-	return maxInt(0, (normalizedStartupHeight(m.height)-overlayHeight)/2)
+	return tuiRect{
+		y:      maxInt(0, (normalizedStartupHeight(m.height)-overlayHeight)/2),
+		width:  width,
+		height: overlayHeight,
+	}
 }

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -178,29 +178,8 @@ func (m model) mouseOverComposer(msg tea.MouseMsg) bool {
 		return false
 	}
 	width := chatWidth(m.width)
-	composerLines := viewLines(m.composerBox(width))
-	fullFooterLines := viewLines(m.footerView(width))
-	if len(composerLines) == 0 || len(fullFooterLines) == 0 {
-		return false
-	}
-	composerTop := lineSequenceIndex(fullFooterLines, composerLines)
-	if composerTop < 0 {
-		return false
-	}
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	footerLines := frame.footerLines
-	clippedPrefix := len(fullFooterLines) - len(footerLines)
-	if len(footerLines) == 0 {
-		return false
-	}
-	visibleTop := maxInt(composerTop, clippedPrefix)
-	visibleBottom := minInt(composerTop+len(composerLines), clippedPrefix+len(footerLines))
-	if visibleTop >= visibleBottom {
-		return false
-	}
-	footerTop := len(frame.headerLines) + frame.bodyHeight
-	top := footerTop + visibleTop - clippedPrefix
-	return mouseY(msg) >= top && mouseY(msg) < top+visibleBottom-visibleTop
+	return frame.composerRect.contains(mouseX(msg), mouseY(msg))
 }
 
 func lineSequenceIndex(lines []string, sequence []string) int {
@@ -478,7 +457,7 @@ func (m model) overlayMouseTop(overlayHeight int, width int) int {
 	}
 	if m.altScreen && m.height > 0 {
 		frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-		return len(frame.headerLines) + maxInt(0, (frame.bodyHeight-overlayHeight)/2)
+		return frame.bodyRect.y + maxInt(0, (frame.bodyRect.height-overlayHeight)/2)
 	}
 	return maxInt(0, (normalizedStartupHeight(m.height)-overlayHeight)/2)
 }

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -490,11 +490,11 @@ func TestMCPAddWizardBlocksTranscriptSelectionBehindOverlay(t *testing.T) {
 	m := mouseTestModel()
 	m.mouseCapture = true
 	m.transcript = appendRow(m.transcript, rowUser, "hidden behind wizard")
-	textY := firstTranscriptTextMouseY(t, m)
+	textX, textY := firstTranscriptTextMousePoint(t, m)
 	m.mcpAddWizard = newMCPAddWizard("http")
 	m.mcpAddWizard.step = mcpAddWizardStepType
 
-	updated, cmd := m.Update(testMouseClick(tea.MouseLeft, 0, textY))
+	updated, cmd := m.Update(testMouseClick(tea.MouseLeft, textX, textY))
 	next := updated.(model)
 	if cmd != nil {
 		t.Fatal("click behind MCP add wizard should not return a command")
@@ -557,16 +557,22 @@ func TestMouseCaptureOnlyDuringInteractiveSetupStages(t *testing.T) {
 
 func firstTranscriptTextMouseY(t *testing.T, m model) int {
 	t.Helper()
+	_, y := firstTranscriptTextMousePoint(t, m)
+	return y
+}
+
+func firstTranscriptTextMousePoint(t *testing.T, m model) (int, int) {
+	t.Helper()
 	width := chatWidth(m.width)
 	body, selectable := m.transcriptBody(width, "")
 	start, _, top := m.transcriptViewportStart(body, width)
 	for _, line := range selectable {
 		if line.text != "" && !line.toggle {
-			return top + line.bodyY - start
+			return line.textStart, top + line.bodyY - start
 		}
 	}
 	t.Fatalf("no selectable transcript text line found: %#v", selectable)
-	return 0
+	return 0, 0
 }
 
 func mouseTestModel() model {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -486,6 +486,24 @@ func TestMCPAddWizardMouseSelectsAndActivatesType(t *testing.T) {
 	}
 }
 
+func TestMCPAddWizardBlocksTranscriptSelectionBehindOverlay(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendRow(m.transcript, rowUser, "hidden behind wizard")
+	textY := firstTranscriptTextMouseY(t, m)
+	m.mcpAddWizard = newMCPAddWizard("http")
+	m.mcpAddWizard.step = mcpAddWizardStepType
+
+	updated, cmd := m.Update(testMouseClick(tea.MouseLeft, 0, textY))
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("click behind MCP add wizard should not return a command")
+	}
+	if next.transcriptSelection.active {
+		t.Fatal("MCP add wizard should block transcript selection behind the overlay")
+	}
+}
+
 func TestTranscriptCopyStatusUsesComposerSpacerWithoutFooterGrowth(t *testing.T) {
 	m := mouseTestModel()
 	m.providerName = "ollama-cloud"

--- a/internal/tui/render_cache_test.go
+++ b/internal/tui/render_cache_test.go
@@ -158,6 +158,26 @@ func TestRenderRowCacheSkipsPendingPermissionPromptRows(t *testing.T) {
 	}
 }
 
+func TestSelectableAssistantRowsUseRenderCacheWhenSelectionInactive(t *testing.T) {
+	cache := replaceDefaultRenderCache(t, newStaticRenderCache(8, 1000))
+	m := newModel(context.Background(), Options{})
+	row := transcriptRow{kind: rowAssistant, text: "Done with **markdown**.", final: true, turnTools: 1}
+
+	first, firstSelectable := m.renderSelectableAssistantRow(0, row, 80, 0)
+	second, secondSelectable := m.renderSelectableAssistantRow(0, row, 80, 0)
+
+	if first == "" || first != second {
+		t.Fatalf("rendered rows = %q and %q, want stable cached output", first, second)
+	}
+	if len(firstSelectable) == 0 || len(secondSelectable) != len(firstSelectable) {
+		t.Fatalf("selectable metadata = %#v then %#v, want stable selectable lines", firstSelectable, secondSelectable)
+	}
+	stats := cache.stats()
+	if stats.Misses != 1 || stats.Hits != 1 {
+		t.Fatalf("cache stats = %#v, want one miss and one hit", stats)
+	}
+}
+
 func replaceDefaultRenderCache(t *testing.T, cache *staticRenderCache) *staticRenderCache {
 	t.Helper()
 	previous := defaultRenderCache

--- a/internal/tui/transcript_body_test.go
+++ b/internal/tui/transcript_body_test.go
@@ -1,0 +1,72 @@
+package tui
+
+import "testing"
+
+func TestTranscriptBodyItemsRepresentEmptyState(t *testing.T) {
+	m := mouseTestModel()
+	width := chatWidth(m.width)
+
+	items := m.transcriptBodyItems(width, "")
+	layout := layoutTranscriptBodyItems(items)
+
+	if len(layout.spans) != 1 || layout.spans[0].kind != transcriptBodyItemEmpty {
+		t.Fatalf("spans = %#v, want one empty-state item", layout.spans)
+	}
+	if layout.spans[0].height != len(layout.lines) || layout.spans[0].height == 0 {
+		t.Fatalf("empty-state span = %#v lines=%d, want positive span covering all lines", layout.spans[0], len(layout.lines))
+	}
+	if len(layout.selectable) != 0 {
+		t.Fatalf("empty state should not expose selectable transcript text: %#v", layout.selectable)
+	}
+}
+
+func TestTranscriptBodyItemsShiftSelectableLinesByItemStart(t *testing.T) {
+	m := mouseTestModel()
+	m.transcript = appendRow(m.transcript, rowUser, "hello")
+	width := chatWidth(m.width)
+
+	layout := layoutTranscriptBodyItems(m.transcriptBodyItems(width, ""))
+
+	if len(layout.spans) != 1 || layout.spans[0].kind != transcriptBodyItemRow {
+		t.Fatalf("spans = %#v, want one transcript row item", layout.spans)
+	}
+	rowSpan := layout.spans[0]
+	if rowSpan.height != 3 {
+		t.Fatalf("user row height = %d, want padding/text/padding", rowSpan.height)
+	}
+	if len(layout.selectable) != 1 {
+		t.Fatalf("selectable lines = %#v, want one user text line", layout.selectable)
+	}
+	if got, want := layout.selectable[0].bodyY, rowSpan.startY+1; got != want {
+		t.Fatalf("selectable bodyY = %d, want item start + user padding = %d", got, want)
+	}
+	if layout.selectable[0].rowIndex != len(m.transcript)-1 || layout.selectable[0].text != "hello" {
+		t.Fatalf("selectable line = %#v, want user row text", layout.selectable[0])
+	}
+}
+
+func TestTranscriptBodyItemsKeepPendingInterimSelectableLocal(t *testing.T) {
+	m := mouseTestModel()
+	m.pending = true
+	m.streamingReasoning = "private thought"
+	width := chatWidth(m.width)
+
+	layout := layoutTranscriptBodyItems(m.transcriptBodyItems(width, ""))
+
+	if len(layout.spans) != 2 {
+		t.Fatalf("spans = %#v, want separator plus pending interim", layout.spans)
+	}
+	if layout.spans[0].kind != transcriptBodyItemSeparator || layout.spans[0].height != 1 {
+		t.Fatalf("first span = %#v, want one-line separator", layout.spans[0])
+	}
+	pendingSpan := layout.spans[1]
+	if pendingSpan.kind != transcriptBodyItemPendingInterim || pendingSpan.height == 0 {
+		t.Fatalf("pending span = %#v, want rendered interim item", pendingSpan)
+	}
+	if len(layout.selectable) != 1 || !layout.selectable[0].live || !layout.selectable[0].toggle {
+		t.Fatalf("selectable lines = %#v, want live streaming reasoning toggle", layout.selectable)
+	}
+	if layout.selectable[0].bodyY != pendingSpan.startY {
+		t.Fatalf("streaming selectable bodyY = %d, want pending item start %d", layout.selectable[0].bodyY, pendingSpan.startY)
+	}
+}

--- a/internal/tui/transcript_body_test.go
+++ b/internal/tui/transcript_body_test.go
@@ -70,3 +70,17 @@ func TestTranscriptBodyItemsKeepPendingInterimSelectableLocal(t *testing.T) {
 		t.Fatalf("streaming selectable bodyY = %d, want pending item start %d", layout.selectable[0].bodyY, pendingSpan.startY)
 	}
 }
+
+func TestTranscriptBodyLayoutVisibleLinesUsesViewportWindow(t *testing.T) {
+	layout := transcriptBodyLayout{lines: []string{"zero", "one", "two", "three"}}
+	window := newTranscriptViewport(layout.totalLines(), 2, 1).window()
+
+	got := layout.visibleLines(window)
+	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Fatalf("visible lines = %#v, want [one two]", got)
+	}
+	got[0] = "mutated"
+	if layout.lines[1] != "one" {
+		t.Fatalf("visibleLines should return a copy, layout lines = %#v", layout.lines)
+	}
+}

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -395,7 +395,7 @@ func splitPlainAtDisplayWidth(text string, width int) (string, string) {
 }
 
 func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine, bool) {
-	if !m.altScreen || m.height <= 0 || m.setup.visible || m.providerWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
+	if !m.altScreen || m.height <= 0 || m.setup.visible || m.providerWizard != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
 		return transcriptSelectableLine{}, false
 	}
 	width := chatWidth(m.width)

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -43,29 +43,61 @@ type transcriptCopyStatusExpiredMsg struct {
 	seq int
 }
 
+type transcriptBodyItemKind int
+
+const (
+	transcriptBodyItemTitle transcriptBodyItemKind = iota
+	transcriptBodyItemEmpty
+	transcriptBodyItemSeparator
+	transcriptBodyItemRow
+	transcriptBodyItemPendingPrompt
+	transcriptBodyItemPendingInterim
+	transcriptBodyItemSpecReview
+)
+
+type transcriptBodyItem struct {
+	kind     transcriptBodyItemKind
+	rowIndex int
+	render   func(startBodyY int) transcriptBodyRenderedItem
+}
+
+type transcriptBodyRenderedItem struct {
+	lines      []string
+	selectable []transcriptSelectableLine
+}
+
+type transcriptBodyItemSpan struct {
+	kind     transcriptBodyItemKind
+	rowIndex int
+	startY   int
+	height   int
+}
+
+type transcriptBodyLayout struct {
+	lines      []string
+	selectable []transcriptSelectableLine
+	spans      []transcriptBodyItemSpan
+}
+
 func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcriptSelectableLine) {
-	lines := []string{}
-	selectable := []transcriptSelectableLine{}
-	appendBlock := func(block string) int {
-		start := len(lines)
-		lines = append(lines, viewLines(block)...)
-		return start
-	}
-	appendBlank := func() {
-		lines = append(lines, "")
-	}
+	layout := layoutTranscriptBodyItems(m.transcriptBodyItems(width, emptyOverlay))
+	return strings.Join(layout.lines, "\n"), layout.selectable
+}
+
+func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptBodyItem {
+	items := []transcriptBodyItem{}
 
 	// The inline title bar prints once into scrollback on the first WindowSizeMsg;
 	// until then it renders managed so the surface never appears headless.
 	if m.titleBarInTranscriptBody() {
-		appendBlock(m.titleBar(width))
+		items = append(items, transcriptBlockBodyItem(transcriptBodyItemTitle, -1, m.titleBar(width)))
 	}
 
 	if m.transcriptEmpty() && !m.pending {
 		if emptyOverlay != "" {
-			appendBlock(m.emptyStateWithOverlay(width, emptyOverlay))
+			items = append(items, transcriptBlockBodyItem(transcriptBodyItemEmpty, -1, m.emptyStateWithOverlay(width, emptyOverlay)))
 		} else {
-			appendBlock(m.emptyState(width))
+			items = append(items, transcriptBlockBodyItem(transcriptBodyItemEmpty, -1, m.emptyState(width)))
 		}
 	} else {
 		rc := buildRowContext(m.transcript)
@@ -81,15 +113,20 @@ func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcr
 			// Blank-line separation before turns, including between flushed
 			// history and the first live row.
 			if (shownAny || m.flushedAny) && startsTurn(row.kind) {
-				appendBlank()
+				items = append(items, transcriptBlankBodyItem())
 			}
 			if (shownAny || (m.flushedAny && havePreviousKind)) && previousKind == rowUser && row.kind == rowReasoning {
-				appendBlank()
+				items = append(items, transcriptBlankBodyItem())
 			}
-			start := len(lines)
-			rendered, rowSelectable := m.renderTranscriptRow(index, row, width, rc, start)
-			appendBlock(rendered)
-			selectable = append(selectable, rowSelectable...)
+			rowIndex, transcriptRow := index, row
+			items = append(items, transcriptBodyItem{
+				kind:     transcriptBodyItemRow,
+				rowIndex: rowIndex,
+				render: func(startBodyY int) transcriptBodyRenderedItem {
+					rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, width, rc, startBodyY)
+					return transcriptBodyRenderedItem{lines: viewLines(rendered), selectable: selectable}
+				},
+			})
 			shownAny = true
 			previousKind = row.kind
 			havePreviousKind = true
@@ -97,23 +134,71 @@ func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcr
 	}
 
 	if m.pending {
-		appendBlank()
+		items = append(items, transcriptBlankBodyItem())
 		switch {
 		case m.pendingPermission != nil:
-			appendBlock(renderFocusedPermissionPrompt(m.pendingPermission.request, width))
+			items = append(items, transcriptBlockBodyItem(transcriptBodyItemPendingPrompt, -1, renderFocusedPermissionPrompt(m.pendingPermission.request, width)))
 		case m.pendingAskUser != nil:
-			appendBlock(renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width))
+			items = append(items, transcriptBlockBodyItem(transcriptBodyItemPendingPrompt, -1, renderFocusedAskUserPrompt(*m.pendingAskUser, m.input.Value(), width)))
 		default:
-			start := appendBlock(m.interimBlock(width))
-			selectable = append(selectable, m.renderSelectableStreamingReasoning(width, start)...)
+			items = append(items, transcriptBodyItem{
+				kind:     transcriptBodyItemPendingInterim,
+				rowIndex: -1,
+				render: func(startBodyY int) transcriptBodyRenderedItem {
+					return transcriptBodyRenderedItem{
+						lines:      viewLines(m.interimBlock(width)),
+						selectable: m.renderSelectableStreamingReasoning(width, startBodyY),
+					}
+				},
+			})
 		}
 	}
 	if m.pendingSpecReview != nil {
-		appendBlank()
-		appendBlock(renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width))
+		items = append(items, transcriptBlankBodyItem())
+		items = append(items, transcriptBlockBodyItem(transcriptBodyItemSpecReview, -1, renderFocusedSpecReviewPrompt(*m.pendingSpecReview, width)))
 	}
 
-	return strings.Join(lines, "\n"), selectable
+	return items
+}
+
+func transcriptBlockBodyItem(kind transcriptBodyItemKind, rowIndex int, block string) transcriptBodyItem {
+	return transcriptBodyItem{
+		kind:     kind,
+		rowIndex: rowIndex,
+		render: func(int) transcriptBodyRenderedItem {
+			return transcriptBodyRenderedItem{lines: viewLines(block)}
+		},
+	}
+}
+
+func transcriptBlankBodyItem() transcriptBodyItem {
+	return transcriptBodyItem{
+		kind:     transcriptBodyItemSeparator,
+		rowIndex: -1,
+		render: func(int) transcriptBodyRenderedItem {
+			return transcriptBodyRenderedItem{lines: []string{""}}
+		},
+	}
+}
+
+func layoutTranscriptBodyItems(items []transcriptBodyItem) transcriptBodyLayout {
+	layout := transcriptBodyLayout{}
+	for _, item := range items {
+		startY := len(layout.lines)
+		rendered := transcriptBodyRenderedItem{}
+		if item.render != nil {
+			rendered = item.render(startY)
+		}
+		layout.lines = append(layout.lines, rendered.lines...)
+		layout.selectable = append(layout.selectable, rendered.selectable...)
+		layout.spans = append(layout.spans, transcriptBodyItemSpan{
+			kind:     item.kind,
+			rowIndex: item.rowIndex,
+			startY:   startY,
+			height:   len(rendered.lines),
+		})
+	}
+	return layout
 }
 
 func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -247,9 +247,7 @@ func (m model) renderSelectableToolResultRow(rowIndex int, row transcriptRow, wi
 func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
 	contentWidth := userPromptContentWidth(width)
 	wrapped := wrapPlainText(row.text, maxInt(1, contentWidth))
-	lines := make([]string, 0, len(wrapped)+2)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
-	lines = append(lines, renderUserPromptPaddingLine(width))
 	for index, line := range wrapped {
 		meta := transcriptSelectableLine{
 			bodyY:     startBodyY + index + 1,
@@ -258,6 +256,13 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 			text:      line,
 		}
 		selectable = append(selectable, meta)
+	}
+	if !m.transcriptSelection.active {
+		return m.renderRow(row, width, rowContext{}), selectable
+	}
+	lines := make([]string, 0, len(wrapped)+2)
+	lines = append(lines, renderUserPromptPaddingLine(width))
+	for _, meta := range selectable {
 		lines = append(lines, renderUserPromptStyledLine(m.renderTranscriptSelectableText(meta, zeroTheme.onUserPrompt(zeroTheme.ink.Bold(true))), contentWidth))
 	}
 	lines = append(lines, renderUserPromptPaddingLine(width))
@@ -267,12 +272,7 @@ func (m model) renderSelectableUserRow(rowIndex int, row transcriptRow, width in
 func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, width int, startBodyY int) (string, []transcriptSelectableLine) {
 	tableMeasure := width
 	wrapped := renderAssistantMarkdownText(row.text, assistantMeasure(width), tableMeasure)
-	lines := make([]string, 0, len(wrapped)+1)
 	selectable := make([]transcriptSelectableLine, 0, len(wrapped))
-	textStyle := zeroTheme.sayText
-	if row.final {
-		textStyle = zeroTheme.ink
-	}
 	for index, line := range wrapped {
 		plainLine := stripMarkdownRenderControls(line)
 		meta := transcriptSelectableLine{
@@ -282,6 +282,17 @@ func (m model) renderSelectableAssistantRow(rowIndex int, row transcriptRow, wid
 			text:      plainLine,
 		}
 		selectable = append(selectable, meta)
+	}
+	if !m.transcriptSelection.active {
+		return m.renderRow(row, width, rowContext{}), selectable
+	}
+	lines := make([]string, 0, len(wrapped)+1)
+	textStyle := zeroTheme.sayText
+	if row.final {
+		textStyle = zeroTheme.ink
+	}
+	for index, line := range wrapped {
+		meta := selectable[index]
 		rendered := m.renderTranscriptSelectableMarkdownText(meta, line, textStyle)
 		lines = append(lines, rendered)
 	}

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -79,9 +79,27 @@ type transcriptBodyLayout struct {
 	spans      []transcriptBodyItemSpan
 }
 
+func (m model) transcriptBodyLayout(width int, emptyOverlay string) transcriptBodyLayout {
+	return layoutTranscriptBodyItems(m.transcriptBodyItems(width, emptyOverlay))
+}
+
 func (m model) transcriptBody(width int, emptyOverlay string) (string, []transcriptSelectableLine) {
-	layout := layoutTranscriptBodyItems(m.transcriptBodyItems(width, emptyOverlay))
-	return strings.Join(layout.lines, "\n"), layout.selectable
+	layout := m.transcriptBodyLayout(width, emptyOverlay)
+	return layout.String(), layout.selectable
+}
+
+func (l transcriptBodyLayout) String() string {
+	return strings.Join(l.lines, "\n")
+}
+
+func (l transcriptBodyLayout) totalLines() int {
+	return len(l.lines)
+}
+
+func (l transcriptBodyLayout) visibleLines(window transcriptViewportWindow) []string {
+	start := clampInt(window.start, 0, len(l.lines))
+	end := clampInt(window.end, start, len(l.lines))
+	return append([]string(nil), l.lines[start:end]...)
 }
 
 func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptBodyItem {
@@ -399,15 +417,15 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 		return transcriptSelectableLine{}, false
 	}
 	width := chatWidth(m.width)
-	body, selectable := m.transcriptBody(width, "")
+	layout := m.transcriptBodyLayout(width, "")
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	start, _, _ := transcriptViewportStartForFrame(body, frame, m.chatScrollOffset)
+	start, _, _ := transcriptViewportStartForLayout(layout, frame, m.chatScrollOffset)
 	_, localY, ok := frame.bodyRect.local(mouseX(msg), mouseY(msg))
 	if !ok {
 		return transcriptSelectableLine{}, false
 	}
 	bodyY := start + localY
-	for _, line := range selectable {
+	for _, line := range layout.selectable {
 		if line.bodyY != bodyY {
 			continue
 		}
@@ -422,6 +440,11 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 func (m model) transcriptViewportStart(body string, width int) (int, int, int) {
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	return transcriptViewportStartForFrame(body, frame, m.chatScrollOffset)
+}
+
+func transcriptViewportStartForLayout(layout transcriptBodyLayout, frame transcriptFrameLayout, scrollOffset int) (int, int, int) {
+	window := transcriptViewportForLayout(layout, frame, scrollOffset).window()
+	return window.start, window.height, frame.bodyRect.y
 }
 
 func transcriptViewportStartForFrame(body string, frame transcriptFrameLayout, scrollOffset int) (int, int, int) {
@@ -502,9 +525,9 @@ func (m model) toggleTranscriptRow(rowIndex int) model {
 
 func (m model) selectedTranscriptText() string {
 	width := chatWidth(m.width)
-	_, selectable := m.transcriptBody(width, "")
+	layout := m.transcriptBodyLayout(width, "")
 	parts := []string{}
-	for _, line := range selectable {
+	for _, line := range layout.selectable {
 		start, end, ok := m.selectedColumnsForTranscriptLine(line)
 		if !ok {
 			continue

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -340,12 +340,8 @@ func (m model) transcriptViewportStart(body string, width int) (int, int, int) {
 }
 
 func transcriptViewportStartForFrame(body string, frame transcriptFrameLayout, scrollOffset int) (int, int, int) {
-	bodyLines := viewLines(body)
-	available := frame.bodyRect.height
-	maxOffset := maxInt(0, len(bodyLines)-available)
-	offset := clamp(scrollOffset, 0, maxOffset)
-	start := maxInt(0, len(bodyLines)-available-offset)
-	return start, available, frame.bodyRect.y
+	window := transcriptViewportForBody(body, frame, scrollOffset).window()
+	return window.start, window.height, frame.bodyRect.y
 }
 
 func transcriptSelectionPointForMouse(line transcriptSelectableLine, x int) transcriptSelectionPoint {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -315,8 +315,9 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 	}
 	width := chatWidth(m.width)
 	body, selectable := m.transcriptBody(width, "")
-	start, _, _ := m.transcriptViewportStart(body, width)
-	_, localY, ok := m.transcriptViewportRect(width).local(mouseX(msg), mouseY(msg))
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	start, _, _ := transcriptViewportStartForFrame(body, frame, m.chatScrollOffset)
+	_, localY, ok := frame.bodyRect.local(mouseX(msg), mouseY(msg))
 	if !ok {
 		return transcriptSelectableLine{}, false
 	}
@@ -334,18 +335,17 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 }
 
 func (m model) transcriptViewportStart(body string, width int) (int, int, int) {
-	bodyLines := viewLines(body)
-	bodyRect := m.transcriptViewportRect(width)
-	available := bodyRect.height
-	maxOffset := maxInt(0, len(bodyLines)-available)
-	offset := clamp(m.chatScrollOffset, 0, maxOffset)
-	start := maxInt(0, len(bodyLines)-available-offset)
-	return start, available, bodyRect.y
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	return transcriptViewportStartForFrame(body, frame, m.chatScrollOffset)
 }
 
-func (m model) transcriptViewportRect(width int) tuiRect {
-	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	return frame.bodyRect
+func transcriptViewportStartForFrame(body string, frame transcriptFrameLayout, scrollOffset int) (int, int, int) {
+	bodyLines := viewLines(body)
+	available := frame.bodyRect.height
+	maxOffset := maxInt(0, len(bodyLines)-available)
+	offset := clamp(scrollOffset, 0, maxOffset)
+	start := maxInt(0, len(bodyLines)-available-offset)
+	return start, available, frame.bodyRect.y
 }
 
 func transcriptSelectionPointForMouse(line transcriptSelectableLine, x int) transcriptSelectionPoint {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -315,11 +315,12 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 	}
 	width := chatWidth(m.width)
 	body, selectable := m.transcriptBody(width, "")
-	start, available, top := m.transcriptViewportStart(body, width)
-	if mouseY(msg) < top || mouseY(msg) >= top+available {
+	start, _, _ := m.transcriptViewportStart(body, width)
+	_, localY, ok := m.transcriptViewportRect(width).local(mouseX(msg), mouseY(msg))
+	if !ok {
 		return transcriptSelectableLine{}, false
 	}
-	bodyY := start + mouseY(msg) - top
+	bodyY := start + localY
 	for _, line := range selectable {
 		if line.bodyY != bodyY {
 			continue
@@ -334,12 +335,17 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 
 func (m model) transcriptViewportStart(body string, width int) (int, int, int) {
 	bodyLines := viewLines(body)
-	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	available := frame.bodyHeight
+	bodyRect := m.transcriptViewportRect(width)
+	available := bodyRect.height
 	maxOffset := maxInt(0, len(bodyLines)-available)
 	offset := clamp(m.chatScrollOffset, 0, maxOffset)
 	start := maxInt(0, len(bodyLines)-available-offset)
-	return start, available, len(frame.headerLines)
+	return start, available, bodyRect.y
+}
+
+func (m model) transcriptViewportRect(width int) tuiRect {
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	return frame.bodyRect
 }
 
 func transcriptSelectionPointForMouse(line transcriptSelectableLine, x int) transcriptSelectionPoint {

--- a/internal/tui/transcript_viewport.go
+++ b/internal/tui/transcript_viewport.go
@@ -29,6 +29,10 @@ func transcriptViewportForBody(body string, frame transcriptFrameLayout, offset 
 	return newTranscriptViewport(len(viewLines(body)), frame.bodyRect.height, offset)
 }
 
+func transcriptViewportForLayout(layout transcriptBodyLayout, frame transcriptFrameLayout, offset int) transcriptViewport {
+	return newTranscriptViewport(layout.totalLines(), frame.bodyRect.height, offset)
+}
+
 func (v transcriptViewport) maxOffset() int {
 	return maxInt(0, v.totalLines-v.height)
 }

--- a/internal/tui/transcript_viewport.go
+++ b/internal/tui/transcript_viewport.go
@@ -1,0 +1,53 @@
+package tui
+
+type transcriptViewport struct {
+	totalLines int
+	height     int
+	offset     int
+}
+
+type transcriptViewportWindow struct {
+	start     int
+	end       int
+	height    int
+	maxOffset int
+	offset    int
+}
+
+func newTranscriptViewport(totalLines int, height int, offset int) transcriptViewport {
+	totalLines = maxInt(0, totalLines)
+	height = maxInt(1, height)
+	maxOffset := maxInt(0, totalLines-height)
+	return transcriptViewport{
+		totalLines: totalLines,
+		height:     height,
+		offset:     clampInt(offset, 0, maxOffset),
+	}
+}
+
+func transcriptViewportForBody(body string, frame transcriptFrameLayout, offset int) transcriptViewport {
+	return newTranscriptViewport(len(viewLines(body)), frame.bodyRect.height, offset)
+}
+
+func (v transcriptViewport) maxOffset() int {
+	return maxInt(0, v.totalLines-v.height)
+}
+
+func (v transcriptViewport) scroll(delta int) transcriptViewport {
+	v.offset = clampInt(v.offset+delta, 0, v.maxOffset())
+	return v
+}
+
+func (v transcriptViewport) window() transcriptViewportWindow {
+	maxOffset := v.maxOffset()
+	offset := clampInt(v.offset, 0, maxOffset)
+	start := maxInt(0, v.totalLines-v.height-offset)
+	end := minInt(v.totalLines, start+v.height)
+	return transcriptViewportWindow{
+		start:     start,
+		end:       end,
+		height:    v.height,
+		maxOffset: maxOffset,
+		offset:    offset,
+	}
+}

--- a/internal/tui/transcript_viewport_test.go
+++ b/internal/tui/transcript_viewport_test.go
@@ -1,0 +1,46 @@
+package tui
+
+import "testing"
+
+func TestTranscriptViewportWindowIsBottomAnchored(t *testing.T) {
+	viewport := newTranscriptViewport(20, 5, 0)
+	window := viewport.window()
+
+	if window.start != 15 || window.end != 20 || window.height != 5 || window.maxOffset != 15 {
+		t.Fatalf("window = %#v, want bottom five lines with max offset 15", window)
+	}
+}
+
+func TestTranscriptViewportScrollClamps(t *testing.T) {
+	viewport := newTranscriptViewport(20, 5, 0)
+
+	viewport = viewport.scroll(100)
+	if viewport.offset != 15 {
+		t.Fatalf("scroll past top offset = %d, want 15", viewport.offset)
+	}
+	viewport = viewport.scroll(-100)
+	if viewport.offset != 0 {
+		t.Fatalf("scroll past bottom offset = %d, want 0", viewport.offset)
+	}
+}
+
+func TestTranscriptViewportKeepsNonScrollableOffsetAtZero(t *testing.T) {
+	viewport := newTranscriptViewport(3, 10, 99)
+	window := viewport.window()
+
+	if viewport.offset != 0 || window.start != 0 || window.end != 3 || window.maxOffset != 0 {
+		t.Fatalf("viewport=%#v window=%#v, want non-scrollable viewport clamped to full body", viewport, window)
+	}
+}
+
+func TestTranscriptViewportClampsInflatedOffsetBeforeScrollingDown(t *testing.T) {
+	viewport := newTranscriptViewport(20, 5, 100)
+	if viewport.offset != 15 {
+		t.Fatalf("inflated offset should clamp to top, got %d", viewport.offset)
+	}
+
+	viewport = viewport.scroll(-5)
+	if viewport.offset != 10 {
+		t.Fatalf("scroll down from clamped top offset = %d, want 10", viewport.offset)
+	}
+}

--- a/internal/tui/transcript_viewport_test.go
+++ b/internal/tui/transcript_viewport_test.go
@@ -33,6 +33,45 @@ func TestTranscriptViewportKeepsNonScrollableOffsetAtZero(t *testing.T) {
 	}
 }
 
+func TestTranscriptViewportHandlesZeroAndNegativeInputs(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		totalLines int
+		height     int
+		offset     int
+		want       transcriptViewportWindow
+	}{
+		{
+			name:       "zero lines",
+			totalLines: 0,
+			height:     5,
+			offset:     10,
+			want:       transcriptViewportWindow{start: 0, end: 0, height: 5, maxOffset: 0, offset: 0},
+		},
+		{
+			name:       "zero height",
+			totalLines: 3,
+			height:     0,
+			offset:     2,
+			want:       transcriptViewportWindow{start: 0, end: 1, height: 1, maxOffset: 2, offset: 2},
+		},
+		{
+			name:       "negative values",
+			totalLines: -10,
+			height:     -4,
+			offset:     -20,
+			want:       transcriptViewportWindow{start: 0, end: 0, height: 1, maxOffset: 0, offset: 0},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			window := newTranscriptViewport(tt.totalLines, tt.height, tt.offset).window()
+			if window != tt.want {
+				t.Fatalf("window = %#v, want %#v", window, tt.want)
+			}
+		})
+	}
+}
+
 func TestTranscriptViewportClampsInflatedOffsetBeforeScrollingDown(t *testing.T) {
 	viewport := newTranscriptViewport(20, 5, 100)
 	if viewport.offset != 15 {


### PR DESCRIPTION
## Summary
- centralize chat frame geometry for header, transcript body, footer, composer, and status regions
- route composer, overlay, and transcript mouse hit testing through shared region geometry
- preserve current transcript rendering and bottom-anchored scroll behavior for the first slice of TUI hardening

## Notes
This is the single draft PR for the TUI backend hardening work. Follow-up commits for the transcript viewport/cache work should stack onto this branch instead of opening separate PRs.

## Tests
- env GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- /bin/bash -lc "GOCACHE=/tmp/zero-go-cache go test ./..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated alt-screen transcript UI to use geometry-aware framing and viewport-based scrolling for more accurate header/body/footer behavior.
  * Reworked transcript body rendering into structured line items to improve selection and overlay rendering consistency.
  * Centralized transcript scroll/visible-window calculations to clamp offsets reliably.
* **Bug Fixes**
  * Improved mouse hit detection for transcript lines and overlay interactions, including correct region mapping and tighter click clamping.
  * Adjusted composer/status hit targeting to match visible areas.
* **Tests**
  * Expanded unit and interaction tests, including tiny/degenerate terminal dimensions and overlay/selection mouse scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->