### PR TITLE
Render TUI transcript viewport from measured items

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -87,6 +87,7 @@ type model struct {
 	unpricedTokens         int
 	transcript             []transcriptRow
 	transcriptDetailed     bool
+	transcriptBodyHeights  *transcriptBodyHeightCache
 	input                  textinput.Model
 	composer               composerState
 	composerActive         bool
@@ -439,6 +440,7 @@ func newModel(ctx context.Context, options Options) model {
 		userAgent:              options.UserAgent,
 		usageTracker:           usageTracker,
 		transcript:             initialTranscript(),
+		transcriptBodyHeights:  newTranscriptBodyHeightCache(defaultTranscriptBodyHeightCacheMaxEntries),
 		prService:              prService,
 		prState:                prService.GetState(),
 		input:                  input,
@@ -1283,7 +1285,7 @@ func (m model) transcriptView() string {
 	if m.transcriptEmpty() && !m.pending && viewportOverlay != "" {
 		emptyOverlay = viewportOverlay
 	}
-	bodyLayout := m.transcriptBodyLayout(width, emptyOverlay)
+	bodyItems := m.transcriptBodyItems(width, emptyOverlay)
 
 	footer := m.footerView(width)
 
@@ -1293,9 +1295,10 @@ func (m model) transcriptView() string {
 	}
 
 	if m.altScreen && m.height > 0 {
-		return m.scrollableTranscriptLayoutView(m.pinnedTitleBar(width), bodyLayout, footer, width, overlayForViewport)
+		return m.scrollableTranscriptItemsView(m.pinnedTitleBar(width), bodyItems, footer, width, overlayForViewport)
 	}
 
+	bodyLayout := layoutTranscriptBodyItems(bodyItems)
 	body := bodyLayout.String()
 	if overlayForViewport != "" {
 		body += "\n" + overlayForViewport + "\n"
@@ -1456,6 +1459,19 @@ func (m model) scrollableTranscriptLayoutView(header string, body transcriptBody
 	window := transcriptViewportForLayout(body, frame, m.chatScrollOffset).window()
 
 	bodyWindow := body.visibleLines(window)
+	return m.renderScrollableTranscriptWindow(frame, bodyWindow, window, width, overlay)
+}
+
+func (m model) scrollableTranscriptItemsView(header string, items []transcriptBodyItem, footer string, width int, overlay string) string {
+	frame := m.scrollableTranscriptFrame(header, footer)
+	metrics := measureTranscriptBodyItems(items, m.transcriptBodyHeights)
+	window := transcriptViewportForLayout(metrics, frame, m.chatScrollOffset).window()
+	body := layoutVisibleTranscriptBodyItems(items, metrics, window)
+
+	return m.renderScrollableTranscriptWindow(frame, body.lines, window, width, overlay)
+}
+
+func (m model) renderScrollableTranscriptWindow(frame transcriptFrameLayout, bodyWindow []string, window transcriptViewportWindow, width int, overlay string) string {
 	for len(bodyWindow) < window.height {
 		bodyWindow = append(bodyWindow, "")
 	}
@@ -1597,7 +1613,8 @@ func (m model) chatTranscriptViewport() (transcriptViewport, bool) {
 		return transcriptViewport{}, false
 	}
 	width := chatWidth(m.width)
-	body := m.transcriptBodyLayout(width, "")
+	items := m.transcriptBodyItems(width, "")
+	body := measureTranscriptBodyItems(items, m.transcriptBodyHeights)
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	return transcriptViewportForLayout(body, frame, m.chatScrollOffset), true
 }

--- a/internal/tui/transcript_body_cache.go
+++ b/internal/tui/transcript_body_cache.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"container/list"
+	"sync"
+)
+
+const defaultTranscriptBodyHeightCacheMaxEntries = 512
+
+type transcriptBodyHeightCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	items      map[string]*list.Element
+	lru        *list.List
+}
+
+type transcriptBodyHeightCacheEntry struct {
+	key    string
+	height int
+}
+
+func newTranscriptBodyHeightCache(maxEntries int) *transcriptBodyHeightCache {
+	return &transcriptBodyHeightCache{
+		maxEntries: maxEntries,
+		items:      map[string]*list.Element{},
+		lru:        list.New(),
+	}
+}
+
+func (c *transcriptBodyHeightCache) get(key string) (int, bool) {
+	if c == nil || key == "" {
+		return 0, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	element, ok := c.items[key]
+	if !ok {
+		return 0, false
+	}
+	c.lru.MoveToFront(element)
+	return element.Value.(*transcriptBodyHeightCacheEntry).height, true
+}
+
+func (c *transcriptBodyHeightCache) set(key string, height int) {
+	if c == nil || key == "" || c.maxEntries <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if element, ok := c.items[key]; ok {
+		element.Value.(*transcriptBodyHeightCacheEntry).height = height
+		c.lru.MoveToFront(element)
+		return
+	}
+	c.items[key] = c.lru.PushFront(&transcriptBodyHeightCacheEntry{key: key, height: height})
+	for len(c.items) > c.maxEntries {
+		element := c.lru.Back()
+		if element == nil {
+			return
+		}
+		entry := element.Value.(*transcriptBodyHeightCacheEntry)
+		delete(c.items, entry.key)
+		c.lru.Remove(element)
+	}
+}

--- a/internal/tui/transcript_body_test.go
+++ b/internal/tui/transcript_body_test.go
@@ -84,3 +84,122 @@ func TestTranscriptBodyLayoutVisibleLinesUsesViewportWindow(t *testing.T) {
 		t.Fatalf("visibleLines should return a copy, layout lines = %#v", layout.lines)
 	}
 }
+
+func TestMeasureTranscriptBodyItemsUsesHeightCache(t *testing.T) {
+	cache := newTranscriptBodyHeightCache(8)
+	renders := 0
+	item := transcriptBodyItem{
+		kind:              transcriptBodyItemRow,
+		rowIndex:          7,
+		heightCacheKey:    "stable-row",
+		heightCacheStable: true,
+		render: func(int) transcriptBodyRenderedItem {
+			renders++
+			return transcriptBodyRenderedItem{lines: []string{"one", "two"}}
+		},
+	}
+
+	first := measureTranscriptBodyItems([]transcriptBodyItem{item}, cache)
+	second := measureTranscriptBodyItems([]transcriptBodyItem{item}, cache)
+
+	if renders != 1 {
+		t.Fatalf("renders = %d, want first measure only", renders)
+	}
+	if first.totalLines() != 2 || second.totalLines() != 2 {
+		t.Fatalf("total lines = %d/%d, want cached height 2", first.totalLines(), second.totalLines())
+	}
+}
+
+func TestVisibleTranscriptBodyLayoutRendersOnlyIntersectingItems(t *testing.T) {
+	cache := newTranscriptBodyHeightCache(8)
+	renders := [3]int{}
+	items := []transcriptBodyItem{
+		countingTranscriptBodyItem("a", []string{"a0", "a1"}, &renders[0]),
+		countingTranscriptBodyItem("b", []string{"b0", "b1"}, &renders[1]),
+		countingTranscriptBodyItem("c", []string{"c0", "c1"}, &renders[2]),
+	}
+
+	metrics := measureTranscriptBodyItems(items, cache)
+	window := transcriptViewportWindow{start: 2, end: 4, height: 2}
+	layout := layoutVisibleTranscriptBodyItems(items, metrics, window)
+
+	if got, want := renders, [3]int{1, 2, 1}; got != want {
+		t.Fatalf("renders after first visible layout = %#v, want %#v", got, want)
+	}
+	if len(layout.lines) != 2 || layout.lines[0] != "b0" || layout.lines[1] != "b1" {
+		t.Fatalf("visible lines = %#v, want b item only", layout.lines)
+	}
+
+	metrics = measureTranscriptBodyItems(items, cache)
+	_ = layoutVisibleTranscriptBodyItems(items, metrics, window)
+
+	if got, want := renders, [3]int{1, 3, 1}; got != want {
+		t.Fatalf("renders after cached measure = %#v, want only visible item rerendered %#v", got, want)
+	}
+}
+
+func TestVisibleTranscriptBodyLayoutKeepsSelectableBodyYAbsolute(t *testing.T) {
+	items := []transcriptBodyItem{
+		transcriptBlankBodyItem(),
+		{
+			kind:              transcriptBodyItemRow,
+			rowIndex:          3,
+			heightCacheKey:    "selectable-row",
+			heightCacheStable: true,
+			render: func(startBodyY int) transcriptBodyRenderedItem {
+				return transcriptBodyRenderedItem{
+					lines: []string{"top", "hit", "bottom"},
+					selectable: []transcriptSelectableLine{{
+						bodyY:    startBodyY + 1,
+						rowIndex: 3,
+						text:     "hit",
+					}},
+				}
+			},
+		},
+	}
+	metrics := measureTranscriptBodyItems(items, newTranscriptBodyHeightCache(8))
+	window := transcriptViewportWindow{start: 2, end: 3, height: 1}
+
+	layout := layoutVisibleTranscriptBodyItems(items, metrics, window)
+
+	if len(layout.lines) != 1 || layout.lines[0] != "hit" {
+		t.Fatalf("visible lines = %#v, want selected item line", layout.lines)
+	}
+	if len(layout.selectable) != 1 || layout.selectable[0].bodyY != 2 {
+		t.Fatalf("selectable = %#v, want absolute bodyY 2", layout.selectable)
+	}
+}
+
+func TestScrollableTranscriptItemsViewMatchesFullLayout(t *testing.T) {
+	m := mouseTestModel()
+	m.height = 14
+	m.chatScrollOffset = 2
+	m.transcript = appendRow(m.transcript, rowUser, "please inspect this request")
+	m.transcript = appendRow(m.transcript, rowAssistant, "first response line\nsecond response line\nthird response line")
+	m.transcript = appendRow(m.transcript, rowUser, "follow up")
+	width := chatWidth(m.width)
+	header := m.pinnedTitleBar(width)
+	footer := m.footerView(width)
+	items := m.transcriptBodyItems(width, "")
+	full := layoutTranscriptBodyItems(items)
+
+	got := m.scrollableTranscriptItemsView(header, items, footer, width, "")
+	want := m.scrollableTranscriptLayoutView(header, full, footer, width, "")
+
+	if got != want {
+		t.Fatalf("visible item view changed output\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}
+
+func countingTranscriptBodyItem(key string, lines []string, renders *int) transcriptBodyItem {
+	return transcriptBodyItem{
+		kind:              transcriptBodyItemRow,
+		heightCacheKey:    key,
+		heightCacheStable: true,
+		render: func(int) transcriptBodyRenderedItem {
+			(*renders)++
+			return transcriptBodyRenderedItem{lines: append([]string(nil), lines...)}
+		},
+	}
+}

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -56,9 +57,11 @@ const (
 )
 
 type transcriptBodyItem struct {
-	kind     transcriptBodyItemKind
-	rowIndex int
-	render   func(startBodyY int) transcriptBodyRenderedItem
+	kind              transcriptBodyItemKind
+	rowIndex          int
+	heightCacheKey    string
+	heightCacheStable bool
+	render            func(startBodyY int) transcriptBodyRenderedItem
 }
 
 type transcriptBodyRenderedItem struct {
@@ -93,6 +96,10 @@ func (l transcriptBodyLayout) String() string {
 }
 
 func (l transcriptBodyLayout) totalLines() int {
+	if len(l.spans) > 0 {
+		last := l.spans[len(l.spans)-1]
+		return last.startY + last.height
+	}
 	return len(l.lines)
 }
 
@@ -137,9 +144,12 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				items = append(items, transcriptBlankBodyItem())
 			}
 			rowIndex, transcriptRow := index, row
+			heightCacheKey, heightCacheStable := m.transcriptRowBodyHeightCacheKey(transcriptRow, width, rc)
 			items = append(items, transcriptBodyItem{
-				kind:     transcriptBodyItemRow,
-				rowIndex: rowIndex,
+				kind:              transcriptBodyItemRow,
+				rowIndex:          rowIndex,
+				heightCacheKey:    heightCacheKey,
+				heightCacheStable: heightCacheStable,
 				render: func(startBodyY int) transcriptBodyRenderedItem {
 					rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, width, rc, startBodyY)
 					return transcriptBodyRenderedItem{lines: viewLines(rendered), selectable: selectable}
@@ -181,8 +191,10 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 
 func transcriptBlockBodyItem(kind transcriptBodyItemKind, rowIndex int, block string) transcriptBodyItem {
 	return transcriptBodyItem{
-		kind:     kind,
-		rowIndex: rowIndex,
+		kind:              kind,
+		rowIndex:          rowIndex,
+		heightCacheKey:    transcriptBlockBodyHeightCacheKey(kind, block),
+		heightCacheStable: true,
 		render: func(int) transcriptBodyRenderedItem {
 			return transcriptBodyRenderedItem{lines: viewLines(block)}
 		},
@@ -191,8 +203,10 @@ func transcriptBlockBodyItem(kind transcriptBodyItemKind, rowIndex int, block st
 
 func transcriptBlankBodyItem() transcriptBodyItem {
 	return transcriptBodyItem{
-		kind:     transcriptBodyItemSeparator,
-		rowIndex: -1,
+		kind:              transcriptBodyItemSeparator,
+		rowIndex:          -1,
+		heightCacheKey:    "transcript-body-height:v1:separator",
+		heightCacheStable: true,
 		render: func(int) transcriptBodyRenderedItem {
 			return transcriptBodyRenderedItem{lines: []string{""}}
 		},
@@ -203,10 +217,7 @@ func layoutTranscriptBodyItems(items []transcriptBodyItem) transcriptBodyLayout 
 	layout := transcriptBodyLayout{}
 	for _, item := range items {
 		startY := len(layout.lines)
-		rendered := transcriptBodyRenderedItem{}
-		if item.render != nil {
-			rendered = item.render(startY)
-		}
+		rendered := renderTranscriptBodyItem(item, startY)
 		layout.lines = append(layout.lines, rendered.lines...)
 		layout.selectable = append(layout.selectable, rendered.selectable...)
 		layout.spans = append(layout.spans, transcriptBodyItemSpan{
@@ -217,6 +228,90 @@ func layoutTranscriptBodyItems(items []transcriptBodyItem) transcriptBodyLayout 
 		})
 	}
 	return layout
+}
+
+func measureTranscriptBodyItems(items []transcriptBodyItem, cache *transcriptBodyHeightCache) transcriptBodyLayout {
+	layout := transcriptBodyLayout{}
+	startY := 0
+	for _, item := range items {
+		height := transcriptBodyItemHeight(item, cache)
+		layout.spans = append(layout.spans, transcriptBodyItemSpan{
+			kind:     item.kind,
+			rowIndex: item.rowIndex,
+			startY:   startY,
+			height:   height,
+		})
+		startY += height
+	}
+	return layout
+}
+
+func layoutVisibleTranscriptBodyItems(items []transcriptBodyItem, metrics transcriptBodyLayout, window transcriptViewportWindow) transcriptBodyLayout {
+	layout := transcriptBodyLayout{spans: append([]transcriptBodyItemSpan(nil), metrics.spans...)}
+	if window.end <= window.start {
+		return layout
+	}
+	for index, item := range items {
+		if index >= len(metrics.spans) {
+			break
+		}
+		span := metrics.spans[index]
+		spanEnd := span.startY + span.height
+		if spanEnd <= window.start || span.startY >= window.end {
+			continue
+		}
+		rendered := renderTranscriptBodyItem(item, span.startY)
+		localStart := clampInt(window.start-span.startY, 0, len(rendered.lines))
+		localEnd := clampInt(window.end-span.startY, localStart, len(rendered.lines))
+		layout.lines = append(layout.lines, rendered.lines[localStart:localEnd]...)
+		for _, line := range rendered.selectable {
+			if line.bodyY >= window.start && line.bodyY < window.end {
+				layout.selectable = append(layout.selectable, line)
+			}
+		}
+	}
+	return layout
+}
+
+func transcriptBodyItemHeight(item transcriptBodyItem, cache *transcriptBodyHeightCache) int {
+	if item.heightCacheStable {
+		if height, ok := cache.get(item.heightCacheKey); ok {
+			return height
+		}
+	}
+	rendered := renderTranscriptBodyItem(item, 0)
+	height := len(rendered.lines)
+	if item.heightCacheStable {
+		cache.set(item.heightCacheKey, height)
+	}
+	return height
+}
+
+func renderTranscriptBodyItem(item transcriptBodyItem, startBodyY int) transcriptBodyRenderedItem {
+	if item.render == nil {
+		return transcriptBodyRenderedItem{}
+	}
+	return item.render(startBodyY)
+}
+
+func transcriptBlockBodyHeightCacheKey(kind transcriptBodyItemKind, block string) string {
+	var b strings.Builder
+	appendRenderCacheField(&b, "transcript-body-block-height-v1")
+	appendRenderCacheField(&b, strconv.Itoa(int(kind)))
+	appendRenderCacheField(&b, block)
+	return b.String()
+}
+
+func (m model) transcriptRowBodyHeightCacheKey(row transcriptRow, width int, rc rowContext) (string, bool) {
+	opts := cardRenderOptions{bodyCap: cardBodyMaxLines, cwd: m.cwd}
+	rowKey, stable := m.renderRowCacheKey(row, width, rc, opts, false)
+	if rowKey == "" {
+		return "", false
+	}
+	var b strings.Builder
+	appendRenderCacheField(&b, "transcript-body-row-height-v1")
+	appendRenderCacheField(&b, rowKey)
+	return b.String(), stable
 }
 
 func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {
@@ -428,14 +523,16 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 		return transcriptSelectableLine{}, false
 	}
 	width := chatWidth(m.width)
-	layout := m.transcriptBodyLayout(width, "")
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
-	start, _, _ := transcriptViewportStartForLayout(layout, frame, m.chatScrollOffset)
+	items := m.transcriptBodyItems(width, "")
+	metrics := measureTranscriptBodyItems(items, m.transcriptBodyHeights)
+	window := transcriptViewportForLayout(metrics, frame, m.chatScrollOffset).window()
+	layout := layoutVisibleTranscriptBodyItems(items, metrics, window)
 	_, localY, ok := frame.bodyRect.local(mouseX(msg), mouseY(msg))
 	if !ok {
 		return transcriptSelectableLine{}, false
 	}
-	bodyY := start + localY
+	bodyY := window.start + localY
 	for _, line := range layout.selectable {
 		if line.bodyY != bodyY {
 			continue


### PR DESCRIPTION
## Summary
- add a bounded transcript body height cache keyed by existing row render fingerprints
- render alt-screen transcript windows from measured item spans instead of building the whole body every frame
- route transcript mouse hit testing through the same visible item layout
- cover cache reuse, visible-only rendering, absolute selectable coordinates, and full-layout parity

## Tests
- env GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- git diff --check
- /bin/bash -lc "GOCACHE=/tmp/zero-go-cache go test ./..."

## Notes
This is the follow-up to #226 for the remaining useful backend hardening in the transcript viewport/rendering path. It avoids UI/design changes and keeps the existing full-layout path where it is still needed for inline rendering and selection copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized transcript rendering performance through improved caching and measurement strategies for better responsiveness when displaying conversation history.

* **Tests**
  * Added comprehensive test coverage for transcript body rendering, viewport calculations, and selection behavior to ensure rendering accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->