### PR TITLE
tui: right-click pastes the clipboard directly (no menu)

### DIFF
--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/atotto/clipboard"
+)
+
+// clipboardReadMsg carries the result of an async OS-clipboard read back to
+// Update. It drives the right-click "paste" path.
+type clipboardReadMsg struct {
+	content string
+	err     error
+}
+
+// pasteFromClipboardCmd reads the OS clipboard off the Update goroutine (it
+// shells out to pbpaste/xclip/etc.) and delivers the text as a clipboardReadMsg.
+// A right-click pastes straight from here — no menu.
+func pasteFromClipboardCmd() tea.Cmd {
+	return func() tea.Msg {
+		content, err := clipboard.ReadAll()
+		return clipboardReadMsg{content: content, err: err}
+	}
+}
+
+// routePaste inserts pasted text into whichever input surface is focused. It is
+// shared by the terminal bracketed-paste handler (tea.PasteMsg) and the
+// right-click paste (clipboardReadMsg) so a bracketed paste and a right-click
+// paste behave identically. Surfaces with no editable text field (a permission/
+// spec prompt, the MCP manager, an open picker, the detailed transcript) swallow
+// the paste; empty content is a no-op.
+func (m model) routePaste(content string) (tea.Model, tea.Cmd) {
+	if content == "" {
+		return m, nil
+	}
+	// Setup and the ask_user questionnaire share the main text input.
+	if m.setup.visible {
+		return m.handleSetupPaste(tea.PasteMsg{Content: content})
+	}
+	if m.pendingAskUser != nil {
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(tea.PasteMsg{Content: content})
+		return m, cmd
+	}
+	if m.providerWizard != nil {
+		return m.handleProviderWizardPaste(content)
+	}
+	if m.transcriptDetailed || m.pendingSpecReview != nil || m.pendingPermission != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil {
+		return m, nil
+	}
+	state := m.currentComposerState()
+	m = m.applyComposerText(state, content, true)
+	m.recomputeSuggestions()
+	return m, nil
+}

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -19,18 +19,28 @@ func TestMouseRightPressDetectsRightClick(t *testing.T) {
 }
 
 func TestRightClickReturnsClipboardReadCmd(t *testing.T) {
-	// A right-click in the chat pastes the clipboard directly (no menu): it
-	// returns the async clipboard-read command.
+	// A right-click pastes the clipboard directly (no menu): it returns the async
+	// clipboard-read command. Assert at the handleMouse/handleSetupMouse scope
+	// where the contract actually lives — not via Update, which batches unrelated
+	// commands (ticks, etc.) so a nil-check there passes even if the right-click
+	// branch regresses.
 	m := mouseTestModel()
-	if _, cmd := m.Update(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
-		t.Fatal("a right-click should return the clipboard-read command")
+	if _, cmd := m.handleMouse(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
+		t.Fatal("a right-click in the chat should return the clipboard-read command")
 	}
 
-	// Same in the provider wizard.
+	// Provider wizard — also routed through handleMouse.
 	w := mouseTestModel()
 	w.providerWizard = &providerWizardState{step: providerWizardStepCredential}
-	if _, cmd := w.Update(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
+	if _, cmd := w.handleMouse(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
 		t.Fatal("a right-click in the wizard should return the clipboard-read command")
+	}
+
+	// Setup mode is routed to handleSetupMouse, which has its own right-click
+	// branch; without it setup would swallow the paste.
+	s := mouseTestModel()
+	if _, cmd := s.handleSetupMouse(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
+		t.Fatal("a right-click in setup should return the clipboard-read command")
 	}
 }
 

--- a/internal/tui/clipboard_test.go
+++ b/internal/tui/clipboard_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestMouseRightPressDetectsRightClick(t *testing.T) {
+	if !mouseRightPress(testMouseClick(tea.MouseRight, 10, 5)) {
+		t.Fatal("a right-click should be detected as a right press")
+	}
+	if mouseRightPress(testMouseClick(tea.MouseLeft, 10, 5)) {
+		t.Fatal("a left-click must not register as a right press")
+	}
+}
+
+func TestRightClickReturnsClipboardReadCmd(t *testing.T) {
+	// A right-click in the chat pastes the clipboard directly (no menu): it
+	// returns the async clipboard-read command.
+	m := mouseTestModel()
+	if _, cmd := m.Update(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
+		t.Fatal("a right-click should return the clipboard-read command")
+	}
+
+	// Same in the provider wizard.
+	w := mouseTestModel()
+	w.providerWizard = &providerWizardState{step: providerWizardStepCredential}
+	if _, cmd := w.Update(testMouseClick(tea.MouseRight, 40, 10)); cmd == nil {
+		t.Fatal("a right-click in the wizard should return the clipboard-read command")
+	}
+}
+
+func TestClipboardReadRoutesToFocusedField(t *testing.T) {
+	// Provider wizard API-key field.
+	m := newModel(context.Background(), Options{})
+	m.providerWizard = &providerWizardState{step: providerWizardStepCredential}
+	updated, _ := m.Update(clipboardReadMsg{content: "sk-from-clipboard"})
+	if next := updated.(model); next.providerWizard.apiKey != "sk-from-clipboard" {
+		t.Fatalf("clipboard paste should fill the API-key field, got %q", next.providerWizard.apiKey)
+	}
+
+	// Composer when no modal field is focused.
+	m2 := newModel(context.Background(), Options{})
+	updated2, _ := m2.Update(clipboardReadMsg{content: "hello world"})
+	if next := updated2.(model); !strings.Contains(next.input.Value(), "hello world") {
+		t.Fatalf("clipboard paste should fill the composer, got %q", next.input.Value())
+	}
+}
+
+func TestClipboardReadErrorShowsStatus(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	updated, _ := m.Update(clipboardReadMsg{err: errors.New("no clipboard utility")})
+	if next := updated.(model); next.copyStatus != "Paste failed" {
+		t.Fatalf("a clipboard-read error should surface a status, got %q", next.copyStatus)
+	}
+}
+
+func TestClipboardReadEmptyIsNoop(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	updated, _ := m.Update(clipboardReadMsg{content: ""})
+	if next := updated.(model); next.input.Value() != "" {
+		t.Fatalf("an empty clipboard should be a silent no-op, got %q", next.input.Value())
+	}
+}

--- a/internal/tui/input_compat.go
+++ b/internal/tui/input_compat.go
@@ -63,6 +63,11 @@ func mouseLeftPress(msg tea.MouseMsg) bool {
 	return event.Button == tea.MouseLeft && isMouseClick(msg)
 }
 
+func mouseRightPress(msg tea.MouseMsg) bool {
+	event := mouseEvent(msg)
+	return event.Button == tea.MouseRight && isMouseClick(msg)
+}
+
 func mouseMotion(msg tea.MouseMsg) bool {
 	_, ok := msg.(tea.MouseMotionMsg)
 	return ok

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -584,25 +584,21 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.applyProviderWizardOAuth(msg)
 	case providerWizardDeviceCodeMsg:
 		return m.applyProviderWizardDeviceCode(msg)
+	case clipboardReadMsg:
+		// Result of a right-click paste. Insert on success; surface a brief
+		// status if the clipboard couldn't be read (e.g. no clipboard utility on
+		// a remote session). An empty clipboard is a silent no-op.
+		if msg.err != nil {
+			m.copyStatusSeq++
+			m.copyStatus = "Paste failed"
+			seq := m.copyStatusSeq
+			return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
+				return transcriptCopyStatusExpiredMsg{seq: seq}
+			})
+		}
+		return m.routePaste(msg.content)
 	case tea.PasteMsg:
-		if m.setup.visible {
-			return m.handleSetupPaste(msg)
-		}
-		if m.pendingAskUser != nil {
-			var cmd tea.Cmd
-			m.input, cmd = m.input.Update(msg)
-			return m, cmd
-		}
-		if m.providerWizard != nil {
-			return m.handleProviderWizardPaste(msg.Content)
-		}
-		if m.transcriptDetailed || m.pendingSpecReview != nil || m.pendingPermission != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil {
-			return m, nil
-		}
-		state := m.currentComposerState()
-		m = m.applyComposerText(state, msg.Content, true)
-		m.recomputeSuggestions()
-		return m, nil
+		return m.routePaste(msg.Content)
 	case tea.KeyPressMsg:
 		if m.setup.visible {
 			return m.handleSetupKey(msg)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -21,6 +21,14 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if m.providerWizard != nil && m.providerWizard.oauthPending {
 		return m, nil
 	}
+	// A right-click pastes the clipboard straight into the focused field — no
+	// menu. pasteFromClipboardCmd reads the clipboard off the Update goroutine; the
+	// clipboardReadMsg result is routed by routePaste to wherever input is focused
+	// (composer, wizard, setup) or swallowed on a surface with no text field.
+	// Keyboard/selection copy-paste keep working unchanged.
+	if mouseRightPress(msg) {
+		return m, pasteFromClipboardCmd()
+	}
 	if mouseLeftPress(msg) {
 		switch {
 		case m.providerWizard != nil:

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -289,6 +289,13 @@ func (m model) handleSetupMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	if m.setup.oauthPending {
 		return m, nil
 	}
+	// A right-click pastes the clipboard into the focused setup field, mirroring
+	// handleMouse (mouse.go) so paste behaves identically in setup mode — routePaste
+	// targets the active setup input. Without this branch, setup swallows the
+	// right-click and paste never fires.
+	if mouseRightPress(msg) {
+		return m, pasteFromClipboardCmd()
+	}
 	if mouseLeftPress(msg) {
 		switch m.setup.stage {
 		case setupStageProvider:


### PR DESCRIPTION
## Summary
A right-click now pastes the OS clipboard **straight into the focused input** — composer, provider/MCP wizard, or first-run setup — with **no context menu**, mirroring the existing bracketed-paste behavior. Keyboard and selection copy/paste are unchanged.

This re-ports a local feature onto current `main`: the paste-into-wizard half already landed on `main` (`handleProviderWizardPaste`), so this routes the clipboard read through main's own paste path rather than re-introducing a parallel one.

## How it works
- `clipboard.go` — `pasteFromClipboardCmd` reads the OS clipboard off the Update goroutine (via `atotto/clipboard`, already a dep); `routePaste` is a shared router used by **both** the bracketed-paste handler (`tea.PasteMsg`) and the right-click paste (`clipboardReadMsg`), so they behave identically and route to whichever surface is focused (or swallow on a surface with no text field).
- `mouse.go` — a right-click returns `pasteFromClipboardCmd`; `input_compat.go` adds the `mouseRightPress` helper (mirrors `mouseLeftPress`).
- `model.go` — `tea.PasteMsg` now delegates to `routePaste`; `clipboardReadMsg` inserts on success or shows a brief `Paste failed` status when the clipboard can't be read (e.g. no clipboard utility on a remote session). Empty clipboard is a silent no-op.

## Tests
- `mouseRightPress` detection; right-click returns the read command (chat + wizard); clipboard content routes to the focused field; read error surfaces a status; empty is a no-op.
- Gate: `gofmt`, `go vet`, `go build` (host/linux/windows), `go test ./internal/tui -race`, staticcheck — all green.

## Note
Mouse behavior is covered by logic tests (the command is returned and the result routes correctly); the end-to-end right-click→OS-clipboard paste is best confirmed interactively in a real terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-click paste support across the app, inserting clipboard text into the currently focused field (including the composer and credential/setup flows).
  * Paste behavior is consistent across chat, wizards, and first-run setup screens.
  * Paste failures now show clear, temporary on-screen status feedback.
* **Tests**
  * Added unit tests covering right-click detection, clipboard routing to the focused input, error handling, and empty-clipboard no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->