### PR TITLE
fix(providers): clear error when a model host is unreachable

### DIFF
--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -163,6 +163,15 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 			}
 		}, 0)
 	if err != nil {
+		// A caller-driven cancel/deadline (parent ctx done) surfaces here as a
+		// transport error whose string can contain "context deadline exceeded" plus
+		// the request host — which UpstreamUnreachable would mislabel as an upstream
+		// outage. Check the parent context first and surface its error verbatim, so
+		// only genuine connect failures (ctx still live) get humanized.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + ctxErr.Error())})
+			return
+		}
 		// A direct connection that never completes (e.g. a hosted endpoint blocked
 		// by the local network) surfaces as a transport error; humanize it the same
 		// way as a proxy's gateway error so the user sees a clear connectivity cause.

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -163,6 +163,13 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 			}
 		}, 0)
 	if err != nil {
+		// A direct connection that never completes (e.g. a hosted endpoint blocked
+		// by the local network) surfaces as a transport error; humanize it the same
+		// way as a proxy's gateway error so the user sees a clear connectivity cause.
+		if humanized, ok := providerio.UpstreamUnreachable(err.Error()); ok {
+			sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact(humanized)})
+			return
+		}
 		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact("provider stream error: " + err.Error())})
 		return
 	}
@@ -303,6 +310,13 @@ func (provider *Provider) emitHTTPError(ctx context.Context, response *http.Resp
 	}
 	if message == "" {
 		message = response.Status
+	}
+	// A local proxy (e.g. an Ollama daemon serving a "-cloud" model) answers on
+	// localhost but returns a gateway error when it cannot reach its own backend.
+	// Surface that as a clear connectivity message instead of the raw proxied body.
+	if humanized, ok := providerio.UpstreamUnreachable(message); ok {
+		sendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventError, Error: provider.redact(humanized)})
+		return
 	}
 	sendEvent(ctx, events, zeroruntime.StreamEvent{
 		Type:  zeroruntime.StreamEventError,

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -375,6 +375,33 @@ func TestStreamCompletionClassifiesHTTPErrorsAndRedactsToken(t *testing.T) {
 	}
 }
 
+func TestStreamCompletionHumanizesUpstreamUnreachableGatewayError(t *testing.T) {
+	// A local Ollama daemon serving a "-cloud" model answers on localhost but
+	// returns HTTP 502 with an opaque proxied transport error when it cannot reach
+	// its cloud backend. The adapter must surface a clear connectivity message
+	// naming the host, not the raw proxied JSON body.
+	provider := newTestProviderWithKey(t, "sk-secret", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"Post \"https://ollama.com:443/v1/chat/completions?ts=1\": net/http: TLS handshake timeout"}`, http.StatusBadGateway)
+	})
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned setup error: %v", err)
+	}
+	events := readAll(stream)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
+		t.Fatalf("events = %#v, want one error", events)
+	}
+	got := events[0].Error
+	if !strings.HasPrefix(got, "upstream unreachable: ") {
+		t.Fatalf("error = %q, want upstream-unreachable prefix", got)
+	}
+	for _, want := range []string{"ollama.com:443", "TLS handshake timeout"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
 func TestStreamCompletionEmitsStreamErrorObject(t *testing.T) {
 	provider := newTestProviderWithKey(t, "sk-secret", func(w http.ResponseWriter, r *http.Request) {
 		writeSSE(w, `{"error":{"message":"stream failed sk-secret","type":"server_error"}}`)

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -459,6 +459,36 @@ func TestStreamCompletionEmitsErrorWhenContextCancels(t *testing.T) {
 	}
 }
 
+// A parent-context deadline surfaces as a transport error whose string contains
+// "context deadline exceeded" plus the request host. That must be reported as a
+// caller timeout, NOT humanized into an "upstream unreachable" outage (the host
+// is reachable; the caller's clock ran out).
+func TestStreamCompletionContextDeadlineNotHumanizedAsUpstream(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		<-release // hold the request open until the parent deadline fires
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	stream, err := provider.StreamCompletion(ctx, zeroruntime.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("StreamCompletion returned setup error: %v", err)
+	}
+	events := readAll(stream)
+	if len(events) != 1 || events[0].Type != zeroruntime.StreamEventError {
+		t.Fatalf("events = %#v, want one error", events)
+	}
+	got := events[0].Error
+	if strings.Contains(got, "upstream unreachable") {
+		t.Fatalf("parent-context deadline mislabeled as an upstream outage: %q", got)
+	}
+	if !strings.Contains(got, "context deadline exceeded") {
+		t.Fatalf("error = %q, want the context deadline surfaced verbatim", got)
+	}
+}
+
 func TestStreamCompletionFlushesBufferedContentWhenContextCancels(t *testing.T) {
 	release := make(chan struct{})
 	provider := newTestProviderWithThinkTags(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -248,6 +248,76 @@ func Redact(message string, secrets ...string) string {
 	return strings.Join(words, " ")
 }
 
+// upstreamFailureMarkers are transport-level failures that mean a request never
+// reached the model: the server the client connected to could not establish a
+// connection to its upstream. They distinguish a connectivity problem (outside
+// the agent's control) from the model rejecting the request.
+var upstreamFailureMarkers = []string{
+	"TLS handshake timeout",
+	"context deadline exceeded",
+	"connection refused",
+	"no such host",
+	"network is unreachable",
+	"i/o timeout",
+}
+
+// UpstreamUnreachable detects a provider error that is really a connectivity
+// failure to an upstream host rather than a model/request error, and rewrites it
+// into a clear, actionable message. The common case is a local Ollama daemon
+// serving a "-cloud" model: it answers on localhost but returns HTTP 502 because
+// it cannot reach its own cloud backend, surfacing an opaque proxied string like
+// `Post "https://ollama.com:443/...": net/http: TLS handshake timeout`. It
+// matches only when both a transport failure marker and a concrete host are
+// present, so the agent's own request-deadline cancellations are left untouched.
+// Non-matching messages are returned unchanged with false.
+func UpstreamUnreachable(message string) (string, bool) {
+	reason := ""
+	for _, marker := range upstreamFailureMarkers {
+		if strings.Contains(message, marker) {
+			reason = marker
+			break
+		}
+	}
+	host := upstreamHost(message)
+	if reason == "" || host == "" {
+		return message, false
+	}
+
+	return "upstream unreachable: the model server could not connect to " + host +
+		" (" + reason + "). The request never reached the model — this is a network failure " +
+		"between the model server and its upstream, not a model error. Verify the host is " +
+		"reachable from the machine running the model server (DNS/proxy/VPN/firewall); a local " +
+		"daemon proxying a cloud model — e.g. an Ollama daemon serving a \"-cloud\" model — must " +
+		"itself be able to reach the internet.", true
+}
+
+// upstreamHost extracts the unreachable host from a Go transport error. It
+// handles the two shapes these errors take: a quoted request URL
+// (`... "https://host:port/path": ...`) and a raw dial target
+// (`dial tcp host:port: ...`). The URL form is preferred when both are present.
+// It returns "" when neither yields a host.
+func upstreamHost(message string) string {
+	if index := strings.Index(message, "\"http"); index >= 0 {
+		rest := message[index+1:]
+		if end := strings.IndexByte(rest, '"'); end >= 0 {
+			if parsed, err := url.Parse(rest[:end]); err == nil && parsed.Host != "" {
+				return parsed.Host
+			}
+		}
+	}
+	const dialPrefix = "dial tcp "
+	if index := strings.Index(message, dialPrefix); index >= 0 {
+		rest := message[index+len(dialPrefix):]
+		if end := strings.Index(rest, ": "); end >= 0 {
+			rest = rest[:end]
+		}
+		if host := strings.TrimSpace(rest); host != "" && !strings.Contains(host, " ") {
+			return host
+		}
+	}
+	return ""
+}
+
 // PositiveOrDefault validates optional max token settings.
 func PositiveOrDefault(value int, fallback int, label string) (int, error) {
 	if value == 0 {

--- a/internal/providers/providerio/providerio_test.go
+++ b/internal/providers/providerio/providerio_test.go
@@ -119,3 +119,85 @@ func TestScanSSEDataWithContextDeliversThenEOF(t *testing.T) {
 		t.Fatalf("got %#v, want one accumulated payload", got)
 	}
 }
+
+// UpstreamUnreachable rewrites a transport/gateway connectivity failure into a
+// clear message naming the host, and leaves genuine model errors (and bare
+// markers with no host) untouched.
+func TestUpstreamUnreachable(t *testing.T) {
+	cases := []struct {
+		name       string
+		message    string
+		wantMatch  bool
+		wantHost   string
+		wantReason string
+	}{
+		{
+			name:       "ollama daemon 502 cloud proxy",
+			message:    `Post "https://ollama.com:443/v1/chat/completions?ts=1781690613": net/http: TLS handshake timeout`,
+			wantMatch:  true,
+			wantHost:   "ollama.com:443",
+			wantReason: "TLS handshake timeout",
+		},
+		{
+			name:       "direct connection tls timeout",
+			message:    `Post "https://ollama.com/v1/chat/completions": net/http: TLS handshake timeout`,
+			wantMatch:  true,
+			wantHost:   "ollama.com",
+			wantReason: "TLS handshake timeout",
+		},
+		{
+			name:       "url form preferred over dial target",
+			message:    `Get "https://api.example.com/v1/models": dial tcp 203.0.113.7:443: i/o timeout`,
+			wantMatch:  true,
+			wantHost:   "api.example.com",
+			wantReason: "i/o timeout",
+		},
+		{
+			name:       "dns lookup failure keeps url host",
+			message:    `Post "https://ollama.com/api/chat": dial tcp: lookup ollama.com on 8.8.8.8:53: no such host`,
+			wantMatch:  true,
+			wantHost:   "ollama.com",
+			wantReason: "no such host",
+		},
+		{
+			name:       "local daemon not running",
+			message:    `dial tcp 127.0.0.1:11434: connect: connection refused`,
+			wantMatch:  true,
+			wantHost:   "127.0.0.1:11434",
+			wantReason: "connection refused",
+		},
+		{
+			name:      "genuine model error untouched",
+			message:   `{"error":{"message":"model not found"}}`,
+			wantMatch: false,
+		},
+		{
+			name:      "marker without host untouched",
+			message:   `context deadline exceeded`,
+			wantMatch: false,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, ok := UpstreamUnreachable(testCase.message)
+			if ok != testCase.wantMatch {
+				t.Fatalf("match = %v, want %v (got %q)", ok, testCase.wantMatch, got)
+			}
+			if !testCase.wantMatch {
+				if got != testCase.message {
+					t.Fatalf("non-match must return input unchanged, got %q", got)
+				}
+				return
+			}
+			if !strings.HasPrefix(got, "upstream unreachable: ") {
+				t.Errorf("missing prefix in %q", got)
+			}
+			if !strings.Contains(got, testCase.wantHost) {
+				t.Errorf("missing host %q in %q", testCase.wantHost, got)
+			}
+			if !strings.Contains(got, testCase.wantReason) {
+				t.Errorf("missing reason %q in %q", testCase.wantReason, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When the server zero connects to can't reach the model, the surfaced error is an opaque, low-level transport string that reads like a zero bug and gives the user nothing to act on.

- A local **Ollama** daemon serving a `-cloud` model answers on `localhost` but returns **HTTP 502** carrying a proxied error when it cannot reach its own cloud backend:

  ```
  provider error: {"error":"Post \"https://ollama.com:443/v1/chat/completions?ts=…\": net/http: TLS handshake timeout"}
  ```

- A direct hosted endpoint blocked by the local network (DNS / proxy / VPN / firewall) fails the same way at the transport layer and surfaces as `provider stream error: … TLS handshake timeout`.

In both cases **the request never reached the model** — it's a connectivity problem upstream of the agent — but the message doesn't say so, so users assume zero is broken.

## Change

- Add `providerio.UpstreamUnreachable(message) (string, bool)` — detects a transport-level connectivity failure (`TLS handshake timeout`, `context deadline exceeded`, `connection refused`, `no such host`, `network is unreachable`, `i/o timeout`) **bound to a concrete host**, and rewrites it into an actionable message:

  > upstream unreachable: the model server could not connect to ollama.com:443 (TLS handshake timeout). The request never reached the model — this is a network failure between the model server and its upstream, not a model error. Verify the host is reachable from the machine running the model server (DNS/proxy/VPN/firewall); a local daemon proxying a cloud model — e.g. an Ollama daemon serving a "-cloud" model — must itself be able to reach the internet.

- Matches only when **both** a failure marker and a host are present, so the agent's own request-deadline cancellations (which carry no host) are left untouched.
- Wired into the OpenAI-compatible adapter's two error points — the gateway-error path (`emitHTTPError`) and the transport-error path — so it covers both the local daemon proxy and direct hosted providers. Secrets are still redacted on the way out.

## Why it isn't "just retry"

The existing 5xx/429/network retry already runs; this is for when the upstream is *persistently* unreachable from the host. No amount of retrying reaches a blocked host, so the right fix is a clear diagnosis rather than a silent failure or an opaque string.

## Tests

- `TestUpstreamUnreachable` — 7 cases over the real proxied / direct / DNS / connection-refused shapes, plus negative cases (genuine model error; bare marker with no host).
- `TestStreamCompletionHumanizesUpstreamUnreachableGatewayError` — end-to-end: a 502 carrying the proxied body yields a single, clear, host-named error event.

Gate: `gofmt`, `go vet`, build, `staticcheck`, and `go test -race` on the affected packages (`providerio`, `openai`, `anthropic`, `gemini`, `zeroruntime`) — all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed and non-2xx error messaging for upstream connectivity issues by humanizing “upstream unreachable” with the affected host and underlying reason, avoiding generic provider stream error text.
  * Ensured caller cancellations/deadlines are reported verbatim and are not misclassified as “upstream unreachable.”

* **Tests**
  * Added unit tests validating upstream-unreachable error humanization and confirming context deadline errors are not rewritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->