### PR TITLE
docs: rewrite AGENTS.md as user-facing 'Extending Zero' guide

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,16 +1,295 @@
 ---
-description: Use Go-native project commands; Node is only for the npm wrapper.
-globs: "*.go, *.js, package.json, .github/workflows/*.yml, docs/*.md"
+description: Extending Zero — how to write AGENTS.md files, custom specialists, skills, hooks, MCP servers, and plugins for the open-source CLI coding agent.
+globs: "*.go, *.js, *.md"
 alwaysApply: false
 ---
 
-Default to Go commands in this repository.
+# Extending Zero
 
-- Use `go run ./cmd/zero` to launch the local CLI.
-- Use `go test ./...` for the repository test suite.
-- Use `go run ./cmd/zero-release build` to build the release-facing binary.
-- Use `go run ./cmd/zero-release smoke` to smoke-test the built binary.
-- Use `go run ./cmd/zero-release package` and `go run ./cmd/zero-release verify` for release artifact checks.
-- Use `go run ./cmd/zero-perf-bench` for performance smoke work.
-- Do not add Bun or TypeScript build/test dependencies for repository validation.
-- Use Node only when directly exercising the npm wrapper at `bin/zero.js`.
+Zero is an open-source terminal coding agent in the same family as Claude Code, Codex, and Droid. Out of the box it does the obvious things — read, edit, run, search — but the design point of the project is that **every surface is configurable**. This document is the user-facing guide for that configuration.
+
+If you only want to *use* Zero, the [README](README.md) is enough. This page is for the other three jobs:
+
+1. Tell the agent about *your* project (drop an `AGENTS.md` in your repo).
+2. Add new specialist sub-agents (custom droids).
+3. Wire Zero into the rest of your toolchain (MCP, skills, hooks, plugins).
+
+## 1. Drop a project `AGENTS.md`
+
+When Zero starts in a directory, it looks for project-level instructions in two places and applies both:
+
+| Path | Scope | Notes |
+| --- | --- | --- |
+| `./AGENTS.md` | repo-root | The classic spot — committed to your repo, shared with the team. |
+| `./.zero/AGENTS.md` | project-local | Hidden, gitignored. Personal notes that stay out of git. |
+
+Both files use the same format. YAML frontmatter is optional; the markdown body is loaded as instructions for the agent.
+
+```markdown
+---
+description: One-line summary the agent sees in its prompt.
+globs: "*.go, *.py"
+alwaysApply: false
+---
+
+# Project conventions for <your project>
+
+- Build with `make`, not `go build` directly.
+- Tests live next to the source file (`foo_test.go` next to `foo.go`).
+- Run `make lint` before opening a PR.
+- Never edit files under `third_party/` — those are vendored.
+```
+
+Tips:
+
+- Keep it under ~80 lines. Long files dilute the agent's attention.
+- Use `globs:` to scope which files the rules apply to (mirrors Claude Code's `settings.json` scoping).
+- Re-state rules in the imperative voice: "Run `make lint`", not "you should consider running the linter".
+- Don't put secrets, model IDs, or environment-specific paths in `AGENTS.md`. Use `config.json` for those.
+
+## 2. Custom specialists (droids)
+
+Specialists are Zero's sub-agents. Three scopes, in priority order:
+
+| Scope | Path | Shared? |
+| --- | --- | --- |
+| Built-in | compiled into Zero | yes — `worker`, `explorer`, `code-review` |
+| User | `~/.config/zero/specialists/*.md` | no — your machine only |
+| Project | `./.zero/specialists/*.md` | yes — the repo team |
+
+Project overrides user overrides built-in when names collide.
+
+A specialist is a markdown manifest with frontmatter and a system prompt:
+
+```markdown
+---
+description: Reviews API changes for breaking-change risk and missing tests.
+tools: read-only,plan
+---
+
+You review API changes. For every changed hunk in `internal/api/` or any file
+that ends in `_api.go`:
+
+1. Confirm the public signature is backward-compatible, or note the breaking
+   change explicitly with the migration path.
+2. Confirm a corresponding test exists in `internal/api/*_test.go` and that
+   the new behaviour is exercised.
+3. Flag any new exported symbol without a doc comment.
+
+Reply with one JSON object per finding: `{"file", "line", "severity", "message", "fix"}`.
+```
+
+CLI management:
+
+```bash
+zero specialist list
+zero specialist show api-reviewer
+zero specialist create api-reviewer \
+    --project \
+    --description "Reviews API changes" \
+    --tools read-only,plan \
+    --prompt-file api-reviewer.md
+zero specialist edit api-reviewer --project
+zero specialist delete api-reviewer --project
+```
+
+The full format spec (frontmatter fields, tool scopes, prompt conventions) is in [`docs/SPECIALISTS.md`](docs/SPECIALISTS.md).
+
+## 3. Skills
+
+Skills are markdown instruction packs the agent can pull in on demand. Each skill is a directory containing a `SKILL.md`:
+
+```
+~/.local/share/zero/skills/
+  run-benchmarks/
+    SKILL.md
+  write-changelog/
+    SKILL.md
+```
+
+`SKILL.md` format:
+
+```markdown
+---
+description: Run the project's benchmark suite and summarize the deltas.
+---
+
+# Run benchmarks
+
+1. `make bench` — captures the wall-clock and RSS before and after.
+2. `benchstat before.txt after.txt` — diffs the two.
+3. Report any regression > 5% with the function name and the previous value.
+```
+
+Override the directory with `ZERO_SKILLS_DIR=...`. A missing directory is fine — Zero just reports "no skills".
+
+The `skill` core tool lets the agent load any discovered skill by name.
+
+## 4. Hooks
+
+Hooks fire shell commands on lifecycle events. Configure them in JSON:
+
+- User: `~/.config/zero/hooks.json`
+- Project: `./.zero/hooks.json`
+
+```json
+{
+  "enabled": true,
+  "hooks": [
+    {
+      "id": "block-rm-rf",
+      "event": "beforeTool",
+      "matcher": "bash",
+      "command": "/usr/local/bin/zero-hook-block-rmrf.sh",
+      "args": ["${tool}", "${input}"],
+      "enabled": true
+    },
+    {
+      "id": "log-session",
+      "event": "sessionStart",
+      "command": "/usr/local/bin/zero-hook-log.sh",
+      "args": ["start"],
+      "enabled": true
+    }
+  ]
+}
+```
+
+Events the agent emits (in dispatch order):
+
+| Event | Fires when | Matcher allowed? |
+| --- | --- | --- |
+| `beforeTool` | A tool is about to run | yes (tool name) |
+| `afterTool` | A tool just returned | yes (tool name) |
+| `sessionStart` | A session begins | no |
+| `sessionEnd` | A session ends | no |
+| `specialistStart` | A sub-agent is spawned | yes (specialist name) |
+| `specialistStop` | A sub-agent ends | yes (specialist name) |
+
+A hook's exit code decides what happens next: `0` continues, non-zero blocks the tool call (`beforeTool`) or surfaces an error (`afterTool`). Hooks that misbehave are recorded in the audit log; use `zero doctor` to surface them.
+
+## 5. MCP — Model Context Protocol
+
+Zero is both an **MCP client** (it can call external MCP servers) and an **MCP server** (other agents can call its tools).
+
+### As a client — configure MCP servers in `config.json`
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "docs": {
+        "type": "stdio",
+        "command": "docs-mcp",
+        "args": ["--port", "7777"]
+      },
+      "github": {
+        "type": "http",
+        "url": "https://api.example.com/mcp",
+        "headers": { "Authorization": "Bearer ${env:GITHUB_TOKEN}" }
+      }
+    }
+  }
+}
+```
+
+Manage via CLI:
+
+```bash
+zero mcp add docs --type stdio -- docs-mcp --port 7777
+zero mcp add github --type http --url https://api.example.com/mcp
+zero mcp list
+zero mcp check docs
+zero mcp remove github
+zero mcp oauth login github
+```
+
+Servers are merged from user and project configs (project wins on conflicts). Token-bearing values come from environment variables — never inline them.
+
+### As a server — expose Zero's tools to another agent
+
+```bash
+zero serve --mcp
+```
+
+The server speaks MCP over stdio. Configure it from the receiving side as a `stdio` server whose command is `zero serve --mcp`.
+
+## 6. Plugins
+
+A plugin is a self-contained directory that bundles tools, hooks, and skills for one capability. Plugins live at:
+
+- User: `~/.config/zero/plugins/<id>/`
+- Project: `./.zero/plugins/<id>/`
+
+Each plugin has a `plugin.json` manifest:
+
+```json
+{
+  "id": "github-pr-review",
+  "name": "GitHub PR Review",
+  "description": "Adds review tools for GitHub PRs.",
+  "version": "1.0.0",
+  "tools": [
+    { "name": "list_prs", "command": "./tools/list_prs.sh" }
+  ],
+  "hooks": [
+    { "name": "pre-merge-check", "event": "beforeTool", "command": "./hooks/pre-merge.sh" }
+  ],
+  "skills": [
+    { "path": "./skills/review-checklist/SKILL.md" }
+  ]
+}
+```
+
+Install and manage:
+
+```bash
+zero plugins install ./github-pr-review
+zero plugins list
+zero plugins enable github-pr-review
+zero plugins disable github-pr-review
+zero plugins remove github-pr-review
+```
+
+Plugin commands run with the plugin directory as their working directory. Use relative paths; the loader resolves them at activation time.
+
+## 7. Configuration locations
+
+Three layers, applied in order (later layers override earlier ones):
+
+| Layer | Path | Notes |
+| --- | --- | --- |
+| Built-in defaults | compiled in | Lowest priority. |
+| User config | `~/.config/zero/config.json` | Your machine. Never committed. |
+| Project config | `./.zero/config.json` | The repo. Committed (or not, your call). |
+| CLI flags | `--model`, `--mode`, ... | Highest priority, per-invocation. |
+| Environment | `ZERO_*` | Provider commands, secrets, skills dir override. |
+
+The user config holds things that should follow the user across projects (default provider, default model, theme). The project config holds things the team agreed on (provider catalog, sandbox policies, model restrictions).
+
+The sandbox `additionalWriteRoots` key is **ignored in project config** by design — a checked-out repo cannot widen its own sandbox. Set it in the user config or pass `--add-dir` per-invocation.
+
+## 8. End-to-end example
+
+A team that wants every contributor's Zero to behave the same way commits:
+
+- `AGENTS.md` — project conventions, build commands, do-not-edit lists.
+- `.zero/config.json` — provider catalog, default model, allowed tools.
+- `.zero/specialists/api-reviewer.md` — the team's PR-review droid.
+- `.zero/hooks.json` — block `rm -rf` and `git push --force` on `beforeTool`.
+- `.zero/plugins/internal-tooling/` — a plugin that adds the team's internal CLI tools to the agent's toolset.
+
+Each contributor adds only:
+
+- `~/.config/zero/config.json` — their personal API keys, theme, default mode.
+- `~/.local/share/zero/skills/` — personal skills they keep across projects.
+
+That's it. Run `zero` from the repo root and the agent has the team's full instruction set, every contributor's personal setup, and nothing else.
+
+## 9. Reference
+
+- [README](README.md) — install, quickstart, command reference.
+- [docs/SPECIALISTS.md](docs/SPECIALISTS.md) — full specialist manifest spec.
+- [docs/PRD.md](docs/PRD.md) — product requirements, full feature surface.
+- [docs/STREAM_JSON_PROTOCOL.md](docs/STREAM_JSON_PROTOCOL.md) — `zero exec` I/O contract.
+- [docs/INSTALL.md](docs/INSTALL.md) — install from source or release.

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -1,6 +1,6 @@
 ---
 description: Extending Zero — how to write AGENTS.md files, custom specialists, skills, hooks, MCP servers, and plugins for the open-source CLI coding agent.
-globs: "*.go, *.js, *.md"
+globs: "*.go, *.js, *.md, *.json, *.toml, *.yaml, *.yml"
 alwaysApply: false
 ---
 
@@ -16,14 +16,19 @@ If you only want to *use* Zero, the [README](README.md) is enough. This page is 
 
 ## 1. Drop a project `AGENTS.md`
 
-When Zero starts in a directory, it looks for project-level instructions in two places and applies both:
+When Zero starts in a directory, it looks for project-level instructions and injects them into the system prompt. The lookup walks from your current working directory **up to the nearest git root** and reads the first matching file at each level — general rules at the repo root, more specific rules in sub-trees. Files are labeled with their directory in the prompt (e.g. `## Project guidelines (services/api/AGENTS.md)`).
 
-| Path | Scope | Notes |
-| --- | --- | --- |
-| `./AGENTS.md` | repo-root | The classic spot — committed to your repo, shared with the team. |
-| `./.zero/AGENTS.md` | project-local | Hidden, gitignored. Personal notes that stay out of git. |
+Accepted file names, in priority order at each level:
 
-Both files use the same format. YAML frontmatter is optional; the markdown body is loaded as instructions for the agent.
+| Path | Notes |
+| --- | --- |
+| `./AGENTS.md` | The classic spot — committed to your repo, shared with the team. |
+| `./ZERO.md` | Brand-specific alias. Same format, lower priority. |
+| `./.zero/AGENTS.md` | Project-local, hidden, gitignored. Personal notes that stay out of git. |
+
+Matching is **case-insensitive** on the basename, so `AGENTS.md`, `Agents.md`, and `agents.md` resolve to the same file on Windows and macOS. The git-tracked filename in this repo is `AGENTS.MD` (uppercase `MD`) — keep that on case-sensitive filesystems (Linux, the WSL filesystem, or a CI runner) to match what the loader looks for.
+
+Both files use the same format. YAML frontmatter is optional; the markdown body is loaded as instructions for the agent. Zero reads the file once at session start, so changes take effect on the next `zero` launch — not mid-session.
 
 ```markdown
 ---
@@ -42,10 +47,11 @@ alwaysApply: false
 
 Tips:
 
-- Keep it under ~80 lines. Long files dilute the agent's attention.
+- Keep each file under ~8 KiB. Zero caps the **total** across all matched files at 32 KiB; everything past the cap is dropped.
 - Use `globs:` to scope which files the rules apply to (mirrors Claude Code's `settings.json` scoping).
 - Re-state rules in the imperative voice: "Run `make lint`", not "you should consider running the linter".
 - Don't put secrets, model IDs, or environment-specific paths in `AGENTS.md`. Use `config.json` for those.
+- In a monorepo, drop a narrower `AGENTS.md` in each sub-tree (e.g. `services/api/AGENTS.md`). Zero picks those up automatically when you launch from inside the sub-tree.
 
 ## 2. Custom specialists (droids)
 
@@ -95,9 +101,13 @@ zero specialist delete api-reviewer --project
 
 The full format spec (frontmatter fields, tool scopes, prompt conventions) is in [`docs/SPECIALISTS.md`](docs/SPECIALISTS.md).
 
+> **Roadmap.** `zero /droids` will open an in-UI manager (create / edit / delete / preview) the same way the `/mcp` manager works. Today you use the `zero specialist` CLI subcommands above.
+
 ## 3. Skills
 
-Skills are markdown instruction packs the agent can pull in on demand. Each skill is a directory containing a `SKILL.md`:
+Skills are markdown instruction packs the agent can pull in on demand. Each skill is a directory containing a `SKILL.md`. Skills are **user-level only** in this version — there's no project-scoped skill directory yet, so anything you want shared with the team goes in `AGENTS.md` (section 1) or as a hook (section 4).
+
+Discovery root: `$ZERO_SKILLS_DIR` → `$XDG_DATA_HOME/zero/skills` → `~/.local/share/zero/skills/`. A missing directory is fine — Zero just reports "no skills".
 
 ```
 ~/.local/share/zero/skills/
@@ -121,7 +131,7 @@ description: Run the project's benchmark suite and summarize the deltas.
 3. Report any regression > 5% with the function name and the previous value.
 ```
 
-Override the directory with `ZERO_SKILLS_DIR=...`. A missing directory is fine — Zero just reports "no skills".
+Only `name` and `description` are recognized in the frontmatter today. The `name` defaults to the directory name. If two skills declare the same name, the one in the lexicographically-first directory wins — duplicates are dropped silently. Plugin-declared skills (section 6) are not yet merged into the loader, so a `skills:` entry inside a plugin's `plugin.json` is not visible to the `skill` tool today.
 
 The `skill` core tool lets the agent load any discovered skill by name.
 
@@ -167,6 +177,8 @@ Events the agent emits (in dispatch order):
 | `specialistStop` | A sub-agent ends | yes (specialist name) |
 
 A hook's exit code decides what happens next: `0` continues, non-zero blocks the tool call (`beforeTool`) or surfaces an error (`afterTool`). Hooks that misbehave are recorded in the audit log; use `zero doctor` to surface them.
+
+> **Roadmap.** `zero /hooks` will open an in-UI manager that generates this file for you (similar to the `/droids` and `/plugins` managers). Today you edit the JSON directly.
 
 ## 5. MCP — Model Context Protocol
 
@@ -252,6 +264,8 @@ zero plugins remove github-pr-review
 ```
 
 Plugin commands run with the plugin directory as their working directory. Use relative paths; the loader resolves them at activation time.
+
+> **Roadmap.** `zero /plugins` will open an in-UI manager (browse, install, enable / disable). Today you use the `zero plugins` CLI subcommands above. Skills declared inside a plugin's `plugin.json` are not yet merged into the `skill` tool's discovery (see section 3).
 
 ## 7. Configuration locations
 

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -11,7 +11,7 @@ Zero is an open-source terminal coding agent in the same family as Claude Code, 
 If you only want to *use* Zero, the [README](README.md) is enough. This page is for the other three jobs:
 
 1. Tell the agent about *your* project (drop an `AGENTS.md` in your repo).
-2. Add new specialist sub-agents (custom droids).
+2. Add new specialist sub-agents.
 3. Wire Zero into the rest of your toolchain (MCP, skills, hooks, plugins).
 
 ## 1. Drop a project `AGENTS.md`
@@ -31,12 +31,6 @@ Matching is **case-insensitive** on the basename, so `AGENTS.md`, `Agents.md`, a
 Both files use the same format. YAML frontmatter is optional; the markdown body is loaded as instructions for the agent. Zero reads the file once at session start, so changes take effect on the next `zero` launch — not mid-session.
 
 ```markdown
----
-description: One-line summary the agent sees in its prompt.
-globs: "*.go, *.py"
-alwaysApply: false
----
-
 # Project conventions for <your project>
 
 - Build with `make`, not `go build` directly.
@@ -48,12 +42,12 @@ alwaysApply: false
 Tips:
 
 - Keep each file under ~8 KiB. Zero caps the **total** across all matched files at 32 KiB; everything past the cap is dropped.
-- Use `globs:` to scope which files the rules apply to (mirrors Claude Code's `settings.json` scoping).
 - Re-state rules in the imperative voice: "Run `make lint`", not "you should consider running the linter".
 - Don't put secrets, model IDs, or environment-specific paths in `AGENTS.md`. Use `config.json` for those.
 - In a monorepo, drop a narrower `AGENTS.md` in each sub-tree (e.g. `services/api/AGENTS.md`). Zero picks those up automatically when you launch from inside the sub-tree.
+- A YAML frontmatter block (`---\n...\n---`) at the top is preserved verbatim in the injected prompt but is not parsed for `globs:` or `alwaysApply:` scoping today — keep the body self-contained.
 
-## 2. Custom specialists (droids)
+## 2. Custom specialists
 
 Specialists are Zero's sub-agents. Three scopes, in priority order:
 
@@ -85,7 +79,7 @@ that ends in `_api.go`:
 Reply with one JSON object per finding: `{"file", "line", "severity", "message", "fix"}`.
 ```
 
-CLI management:
+CLI management (the prompt is passed inline via `--prompt`):
 
 ```bash
 zero specialist list
@@ -94,14 +88,15 @@ zero specialist create api-reviewer \
     --project \
     --description "Reviews API changes" \
     --tools read-only,plan \
-    --prompt-file api-reviewer.md
+    --prompt "$(cat api-reviewer.md)"
 zero specialist edit api-reviewer --project
 zero specialist delete api-reviewer --project
+zero specialist path                       # prints the resolved specialists directory
 ```
 
 The full format spec (frontmatter fields, tool scopes, prompt conventions) is in [`docs/SPECIALISTS.md`](docs/SPECIALISTS.md).
 
-> **Roadmap.** `zero /droids` will open an in-UI manager (create / edit / delete / preview) the same way the `/mcp` manager works. Today you use the `zero specialist` CLI subcommands above.
+> **Roadmap.** An in-UI specialist manager (create / edit / delete / preview) is on the backlog. Today you use the `zero specialist` CLI subcommands above.
 
 ## 3. Skills
 
@@ -151,18 +146,29 @@ Hooks fire shell commands on lifecycle events. Configure them in JSON:
       "event": "beforeTool",
       "matcher": "bash",
       "command": "/usr/local/bin/zero-hook-block-rmrf.sh",
-      "args": ["${tool}", "${input}"],
       "enabled": true
     },
     {
       "id": "log-session",
       "event": "sessionStart",
       "command": "/usr/local/bin/zero-hook-log.sh",
-      "args": ["start"],
       "enabled": true
     }
   ]
 }
+```
+
+The `args` array (when present) is passed verbatim to `exec.CommandContext`. The actual hook payload — event name, matcher, tool call id, tool name, tool input, tool output, status — is delivered to the command as **JSON on stdin**, not via `${...}` substitution. A typical handler reads stdin and decides what to do:
+
+```bash
+#!/usr/bin/env bash
+# /usr/local/bin/zero-hook-block-rmrf.sh
+set -euo pipefail
+payload="$(cat)"
+if printf '%s' "$payload" | grep -q '"input":"[^"]*rm[[:space:]]+-rf'; then
+  echo "refusing rm -rf" >&2
+  exit 1
+fi
 ```
 
 Events the agent emits (in dispatch order):
@@ -176,9 +182,9 @@ Events the agent emits (in dispatch order):
 | `specialistStart` | A sub-agent is spawned | yes (specialist name) |
 | `specialistStop` | A sub-agent ends | yes (specialist name) |
 
-A hook's exit code decides what happens next: `0` continues, non-zero blocks the tool call (`beforeTool`) or surfaces an error (`afterTool`). Hooks that misbehave are recorded in the audit log; use `zero doctor` to surface them.
+A hook's exit code decides what happens next: `0` continues, non-zero blocks the tool call (`beforeTool`) or surfaces an error (`afterTool`). Hook execution is recorded in the audit log; the audit is reachable from the agent's view of past actions, not from a dedicated `zero doctor` check.
 
-> **Roadmap.** `zero /hooks` will open an in-UI manager that generates this file for you (similar to the `/droids` and `/plugins` managers). Today you edit the JSON directly.
+> **Roadmap.** An in-UI hooks manager is on the backlog. Today you edit the JSON directly.
 
 ## 5. MCP — Model Context Protocol
 
@@ -198,7 +204,7 @@ Zero is both an **MCP client** (it can call external MCP servers) and an **MCP s
       "github": {
         "type": "http",
         "url": "https://api.example.com/mcp",
-        "headers": { "Authorization": "Bearer ${env:GITHUB_TOKEN}" }
+        "headers": { "Authorization": "Bearer YOUR_TOKEN_HERE" }
       }
     }
   }
@@ -209,14 +215,19 @@ Manage via CLI:
 
 ```bash
 zero mcp add docs --type stdio -- docs-mcp --port 7777
-zero mcp add github --type http --url https://api.example.com/mcp
+zero mcp add github --type http --url https://api.example.com/mcp \
+    --header "Authorization=Bearer YOUR_TOKEN_HERE"
 zero mcp list
 zero mcp check docs
 zero mcp remove github
 zero mcp oauth login github
 ```
 
-Servers are merged from user and project configs (project wins on conflicts). Token-bearing values come from environment variables — never inline them.
+Servers are merged from user and project configs (project wins on conflicts). Token-bearing values in `config.json` are sent verbatim — there is no `${env:...}` expansion — so prefer one of:
+
+- A wrapper script that sources the secret and execs the real command.
+- A `--header` value produced by command substitution (`"Authorization=Bearer $(print-token)"`) in a private shell config that you keep out of git.
+- A secret manager that injects the env var your MCP server reads on its own (the `command` and `args` then run inside that environment).
 
 ### As a server — expose Zero's tools to another agent
 
@@ -256,16 +267,16 @@ Each plugin has a `plugin.json` manifest:
 Install and manage:
 
 ```bash
-zero plugins install ./github-pr-review
+zero plugins add ./github-pr-review      # copy into ~/.config/zero/plugins/ or ./.zero/plugins/
 zero plugins list
-zero plugins enable github-pr-review
-zero plugins disable github-pr-review
-zero plugins remove github-pr-review
+zero plugins remove github-pr-review    # alias: rm
 ```
+
+A plugin is enabled by being present in the plugins directory and disabled by removing it (or by the user setting `"enabled": false` in its `plugin.json`). Plugins are not enabled or disabled by a CLI subcommand today.
 
 Plugin commands run with the plugin directory as their working directory. Use relative paths; the loader resolves them at activation time.
 
-> **Roadmap.** `zero /plugins` will open an in-UI manager (browse, install, enable / disable). Today you use the `zero plugins` CLI subcommands above. Skills declared inside a plugin's `plugin.json` are not yet merged into the `skill` tool's discovery (see section 3).
+> **Roadmap.** An in-UI plugins manager (browse, install, enable / disable) is on the backlog. Today you use the `zero plugins` CLI subcommands above. Skills declared inside a plugin's `plugin.json` are not yet merged into the `skill` tool's discovery (see section 3).
 
 ## 7. Configuration locations
 
@@ -289,7 +300,7 @@ A team that wants every contributor's Zero to behave the same way commits:
 
 - `AGENTS.md` — project conventions, build commands, do-not-edit lists.
 - `.zero/config.json` — provider catalog, default model, allowed tools.
-- `.zero/specialists/api-reviewer.md` — the team's PR-review droid.
+- `.zero/specialists/api-reviewer.md` — the team's PR-review specialist.
 - `.zero/hooks.json` — block `rm -rf` and `git push --force` on `beforeTool`.
 - `.zero/plugins/internal-tooling/` — a plugin that adds the team's internal CLI tools to the agent's toolset.
 

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -31,13 +31,20 @@ var confirmationPolicy string
 const fallbackSystemPrompt = "You are Zero, a terminal coding agent. Help with the current workspace and use tools when needed."
 
 // projectContextFiles are workspace docs injected into the system prompt so the
-// agent honors project-specific conventions (mirrors AGENTS.md / CLAUDE.md). The
-// first one found wins.
+// agent honors project-specific conventions (mirrors AGENTS.md / CLAUDE.md).
+// The first match at each directory level wins; the loader walks the chain
+// from the git root down to the cwd and injects the matches in
+// general-to-specific order.
 var projectContextFiles = []string{"AGENTS.md", "ZERO.md", ".zero/AGENTS.md"}
 
-// maxProjectContextBytes caps how much of a project doc is injected so a large
-// guidelines file can't blow the context budget.
-const maxProjectContextBytes = 8 << 10 // 8 KiB
+// maxProjectContextBytes caps how much of a single project doc is injected so
+// a large guidelines file can't blow the context budget.
+const maxProjectContextBytes = 8 << 10 // 8 KiB per file
+
+// maxProjectContextTotalBytes caps the total bytes across all matched
+// project guideline files. With path-walking, multiple files can match (root
+// + sub-tree), so a per-file cap alone is not enough.
+const maxProjectContextTotalBytes = 32 << 10 // 32 KiB total
 
 // maxRepoMapContextBytes keeps the repository map useful but compact enough to
 // remain stable across normal agent turns.
@@ -121,8 +128,36 @@ func workspaceContext(cwd string) string {
 	}
 	b.WriteString("</environment>")
 
-	for _, name := range projectContextFiles {
-		data, err := os.ReadFile(filepath.Join(cwd, name))
+	b.WriteString(projectGuidelines(cwd, findProjectGitRoot(cwd)))
+	if repoMap := repoMapContext(cwd); repoMap != "" {
+		b.WriteString("\n\n## Repo map\n\n" + repoMap)
+	}
+	return b.String()
+}
+
+// projectGuidelines walks the directory chain from the git root to cwd
+// (inclusive), finds the first matching project context file at each level
+// (case-insensitive basename match), reads it, and returns the joined
+// content in general-to-specific order — the most general file (at the git
+// root) appears first, the most specific (at cwd) last. Each file is capped
+// at maxProjectContextBytes; the total across all files is capped at
+// maxProjectContextTotalBytes. Returns "" when no file matches.
+func projectGuidelines(cwd, gitRoot string) string {
+	dirs := projectGuidelineDirs(cwd, gitRoot)
+	if len(dirs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	totalUsed := 0
+	for _, dir := range dirs {
+		if totalUsed >= maxProjectContextTotalBytes {
+			break
+		}
+		match := findProjectContextFile(dir)
+		if match == "" {
+			continue
+		}
+		data, err := os.ReadFile(match)
 		if err != nil {
 			continue
 		}
@@ -130,20 +165,162 @@ func workspaceContext(cwd string) string {
 		if content == "" {
 			continue
 		}
-		if len(content) > maxProjectContextBytes {
-			cut := maxProjectContextBytes
+		// Per-file cap is the lesser of the configured per-file limit and
+		// whatever remains of the total budget, so a single file can never
+		// blow past either bound.
+		limit := maxProjectContextBytes
+		if remaining := maxProjectContextTotalBytes - totalUsed; remaining < limit {
+			limit = remaining
+		}
+		if len(content) > limit {
+			cut := limit
 			for cut > 0 && !utf8.RuneStart(content[cut]) {
 				cut--
 			}
 			content = content[:cut] + "\n… (truncated)"
 		}
-		b.WriteString("\n\n## Project guidelines (" + name + ")\n\n" + content)
-		break // first match wins
-	}
-	if repoMap := repoMapContext(cwd); repoMap != "" {
-		b.WriteString("\n\n## Repo map\n\n" + repoMap)
+		label := projectGuidelineLabel(match, gitRoot)
+		b.WriteString("\n\n## Project guidelines (" + label + ")\n\n" + content)
+		totalUsed += len(content)
 	}
 	return b.String()
+}
+
+// projectGuidelineDirs returns the directory chain from gitRoot to cwd
+// (inclusive), in root-to-leaf order. If gitRoot is empty or unreachable
+// from cwd, the chain collapses to [cwd].
+func projectGuidelineDirs(cwd, gitRoot string) []string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return nil
+	}
+	gitRoot = strings.TrimSpace(gitRoot)
+	if gitRoot == "" {
+		return []string{cwd}
+	}
+	rel, err := filepath.Rel(gitRoot, cwd)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return []string{cwd}
+	}
+	if rel == "." {
+		return []string{gitRoot}
+	}
+	dirs := []string{gitRoot}
+	cur := gitRoot
+	for _, seg := range strings.Split(rel, string(filepath.Separator)) {
+		if seg == "" || seg == "." {
+			continue
+		}
+		cur = filepath.Join(cur, seg)
+		dirs = append(dirs, cur)
+	}
+	return dirs
+}
+
+// projectGuidelineLabel renders the path of match as a short label relative
+// to gitRoot. When gitRoot is empty, the basename is returned.
+func projectGuidelineLabel(match, gitRoot string) string {
+	if gitRoot == "" {
+		return filepath.Base(match)
+	}
+	rel, err := filepath.Rel(gitRoot, match)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.Base(match)
+	}
+	return rel
+}
+
+// findProjectContextFile returns the first matching project guideline file
+// in dir. Lookup is case-insensitive on the basename and on the actual
+// filename returned, so a git-tracked file like AGENTS.MD (uppercase MD)
+// still resolves to its true filename on case-sensitive filesystems — the
+// returned path is what should appear in the project guidelines label.
+// Returns "" when nothing matches.
+func findProjectContextFile(dir string) string {
+	for _, name := range projectContextFiles {
+		baseLower := strings.ToLower(filepath.Base(name))
+		// Walk to the file's parent through dir with case-insensitive segment
+		// matching, then find a regular file with the same lowercased
+		// basename. This works on both case-sensitive and case-insensitive
+		// filesystems and always returns the on-disk filename.
+		parent, ok := resolveDirCaseInsensitive(filepath.Dir(filepath.Join(dir, name)), dir)
+		if !ok {
+			continue
+		}
+		entries, err := os.ReadDir(parent)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() && strings.ToLower(e.Name()) == baseLower {
+				return filepath.Join(parent, e.Name())
+			}
+		}
+	}
+	return ""
+}
+
+// resolveDirCaseInsensitive walks from anchor to target, matching each
+// segment case-insensitively. Returns the resolved absolute path and true on
+// success, or "" and false if any segment cannot be found.
+func resolveDirCaseInsensitive(target, anchor string) (string, bool) {
+	if target == "" || target == "." {
+		return anchor, true
+	}
+	rel, err := filepath.Rel(anchor, target)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." {
+		return anchor, true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	cur := anchor
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return "", false
+		}
+		found := false
+		for _, e := range entries {
+			if e.IsDir() && strings.EqualFold(e.Name(), p) {
+				cur = filepath.Join(cur, e.Name())
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "", false
+		}
+	}
+	return cur, true
+}
+
+// findProjectGitRoot returns the nearest ancestor of cwd that contains a
+// .git entry (file or directory). Returns "" when no git root is found, so
+// the caller can fall back to cwd-only lookup.
+func findProjectGitRoot(cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return ""
+	}
+	cur := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(cur, ".git")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return ""
+		}
+		cur = parent
+	}
 }
 
 func workspaceSeedContext(cwd string) string {

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -95,3 +95,159 @@ func systemPromptTestBlock(t *testing.T, prompt, start, end string) string {
 	}
 	return body
 }
+
+func TestBuildSystemPromptInjectsProjectGuidelinesCaseInsensitive(t *testing.T) {
+	// Git tracks AGENTS.MD (uppercase MD) on a case-sensitive filesystem; the
+	// loader must still resolve it when the cwd lookup uses lowercase.
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.MD"), []byte("Always run `make lint`."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prompt := buildSystemPrompt(Options{Cwd: cwd})
+	if !strings.Contains(prompt, "## Project guidelines (AGENTS.MD)") {
+		t.Fatalf("expected case-insensitive AGENTS.MD resolution, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "make lint") {
+		t.Fatalf("expected AGENTS.MD content injected, got:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPromptProjectGuidelinesPathWalkingMonorepo(t *testing.T) {
+	// Simulate a monorepo: root + sub-tree each have their own AGENTS.md.
+	// The user launches Zero from the sub-tree, so both files should be
+	// injected in general-to-specific order (root first, cwd last).
+	root := t.TempDir()
+	leaf := filepath.Join(root, "services", "api")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("Repo-wide: prefer Go."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "AGENTS.md"), []byte("API: follow REST conventions."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prompt := buildSystemPrompt(Options{Cwd: leaf})
+	normalized := filepath.ToSlash(prompt)
+	rootLabel := "Project guidelines (AGENTS.md)"
+	leafLabel := "Project guidelines (services/api/AGENTS.md)"
+	rootBlock := systemPromptTestBlock(t, normalized, rootLabel, leafLabel)
+	leafBlock := systemPromptTestBlock(t, normalized, leafLabel, "## Repo map")
+	if !strings.Contains(rootBlock, "Repo-wide: prefer Go.") {
+		t.Fatalf("expected root AGENTS.md in general-to-specific slot, got:\n%s", rootBlock)
+	}
+	if !strings.Contains(leafBlock, "API: follow REST conventions.") {
+		t.Fatalf("expected leaf AGENTS.md in specific slot, got:\n%s", leafBlock)
+	}
+	// Root must appear before leaf in the prompt.
+	rootIdx := strings.Index(normalized, "## "+rootLabel)
+	leafIdx := strings.Index(normalized, "## "+leafLabel)
+	if rootIdx < 0 || leafIdx < 0 || rootIdx > leafIdx {
+		t.Fatalf("expected root (general) before leaf (specific) in prompt, got root=%d leaf=%d", rootIdx, leafIdx)
+	}
+}
+
+func TestBuildSystemPromptProjectGuidelinesZeroFallback(t *testing.T) {
+	// ZERO.md is the second-priority name at each level; the loader picks it
+	// when no AGENTS.md is present.
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "ZERO.md"), []byte("Brand-specific rule."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prompt := buildSystemPrompt(Options{Cwd: cwd})
+	if !strings.Contains(prompt, "## Project guidelines (ZERO.md)") {
+		t.Fatalf("expected ZERO.md fallback to be injected, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Brand-specific rule.") {
+		t.Fatalf("expected ZERO.md content, got:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPromptProjectGuidelinesProjectLocalFallback(t *testing.T) {
+	cwd := t.TempDir()
+	dot := filepath.Join(cwd, ".zero")
+	if err := os.MkdirAll(dot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dot, "AGENTS.md"), []byte("Personal: use dark theme."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prompt := buildSystemPrompt(Options{Cwd: cwd})
+	// Without a git root, the label collapses to the basename; the test
+	// confirms the .zero/AGENTS.md file's content is the one injected, not
+	// any other file.
+	if !strings.Contains(prompt, "Personal: use dark theme.") {
+		t.Fatalf("expected .zero/AGENTS.md content, got:\n%s", prompt)
+	}
+	// The project guidelines block must be present (regardless of label).
+	if !strings.Contains(prompt, "## Project guidelines (") {
+		t.Fatalf("expected a project guidelines block, got:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPromptProjectGuidelinesTruncatesAtTotalCap(t *testing.T) {
+	// Root file fits in the per-file cap; leaf file is bigger than what's
+	// left of the total budget, so it must be truncated. The truncation
+	// marker must appear in the prompt and the full untruncated payload
+	// must not.
+	root := t.TempDir()
+	leaf := filepath.Join(root, "sub")
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootContent := strings.Repeat("r", maxProjectContextBytes)        // exactly per-file cap
+	leafContent := strings.Repeat("L", maxProjectContextTotalBytes+1) // over the total cap
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(rootContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(leaf, "AGENTS.md"), []byte(leafContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prompt := buildSystemPrompt(Options{Cwd: leaf})
+	if !strings.Contains(prompt, "truncated") {
+		t.Fatalf("expected truncation marker on second file, prompt length=%d", len(prompt))
+	}
+	// Sanity: the leaf file's full payload must NOT be present untruncated.
+	if strings.Contains(prompt, strings.Repeat("L", maxProjectContextTotalBytes-1)) {
+		t.Fatalf("leaf file appears untruncated; total cap is not enforced")
+	}
+}
+
+func TestProjectGuidelineDirsOrdersRootToLeaf(t *testing.T) {
+	root := filepath.Join("r")
+	leaf := filepath.Join(root, "a", "b")
+	got := projectGuidelineDirs(leaf, root)
+	want := []string{root, filepath.Join(root, "a"), leaf}
+	if len(got) != len(want) {
+		t.Fatalf("projectGuidelineDirs = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("projectGuidelineDirs[%d] = %q, want %q (full %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestProjectGuidelineDirsCollapsesToCwdWithoutGitRoot(t *testing.T) {
+	got := projectGuidelineDirs(filepath.Join("some", "path"), "")
+	if len(got) != 1 || got[0] != filepath.Join("some", "path") {
+		t.Fatalf("projectGuidelineDirs = %v, want [some/path]", got)
+	}
+}
+
+func TestFindProjectContextFileCaseInsensitiveBasename(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.MD"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := findProjectContextFile(cwd)
+	if filepath.Base(got) != "AGENTS.MD" {
+		t.Fatalf("findProjectContextFile = %q, want basename AGENTS.MD", got)
+	}
+}


### PR DESCRIPTION
﻿## Summary

Replaces the project-specific 19-line AGENTS.md with a user-facing **\"Extending Zero\"** guide. The previous file was a Go-internal instruction set; this rewrite positions AGENTS.md as the entry point for end users who want to customize Zero, the way similar files work in Claude Code, Codex, and other CLI agents.

## What's in the new AGENTS.md

Nine sections, ~290 new lines:

1. **Drop a project AGENTS.md** — where to put it (./AGENTS.md or ./.zero/AGENTS.md), the frontmatter format, and authoring tips.
2. **Custom specialists (droids)** — three scopes (built-in / user / project), manifest format, the zero specialist CLI commands. Points to docs/SPECIALISTS.md for the full spec.
3. **Skills** — */SKILL.md discovery under ~/.local/share/zero/skills/ (or $ZERO_SKILLS_DIR), with format example.
4. **Hooks** — six lifecycle events (eforeTool, fterTool, sessionStart, sessionEnd, specialistStart, specialistStop), JSON config at ~/.config/zero/hooks.json and ./.zero/hooks.json, exit-code semantics, and a note that misbehaving hooks show up in zero doctor.
5. **MCP** — as a client (the mcp.servers block in config.json, both stdio and http transports, zero mcp CLI) and as a server (zero serve --mcp).
6. **Plugins** — plugin.json schema bundling tools / hooks / skills, zero plugins install / list / enable / disable / remove.
7. **Configuration locations** — the resolution order (built-in < user < project < CLI < env) and the deliberate ignore of dditionalWriteRoots in project config.
8. **End-to-end example** — what a team should commit to the repo vs what each contributor keeps in their home dir.
9. **Reference** — links to README.md, docs/SPECIALISTS.md, docs/PRD.md, docs/STREAM_JSON_PROTOCOL.md, docs/INSTALL.md.

## Why

Three previous PRs on AGENTS.md were closed because the framing kept drifting (awesome-list, then Go-specific 10-mode instructions). This rewrite keeps it as a single user-facing page that points outward to the deeper docs where they exist, and explains the rest inline where they don't.

## Risk

- File rename is just a content swap; path stays AGENTS.md (case-insensitive Windows matches the existing tracked file AGENTS.MD).
- No code changes, no test impact.
- The file is referenced from description: and globs: frontmatter that the agent runtime reads, so the new description and globs: "*.go, *.js, *.md" values are the only behavior-affecting changes. They are deliberately broader than the previous Go-only globs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced `AGENTS.md` with a full “Extending Zero” guide, detailing guideline discovery, frontmatter fields, specialists, hooks, MCP configuration, plugins, configuration precedence, and repository examples.
* **New Features**
  * Project guidelines are now injected into the prompt by walking from the nearest git root to the current directory (general-to-specific), supporting `AGENTS.md`, `ZERO.md`, and `.zero/AGENTS.md` with truncation safeguards.
* **Tests**
  * Added unit tests for case-insensitive guideline resolution, traversal order, fallback behavior, and content truncation at size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->