### PR TITLE
feat: add `providers detect` and `sandbox check` (wire audit-found unwired features) + coverage

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Gitlawb/zero/internal/observability"
 	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/providerhealth"
+	"github.com/Gitlawb/zero/internal/provideronboarding"
 	"github.com/Gitlawb/zero/internal/providers"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/selfverify"
@@ -44,6 +45,7 @@ type appDeps struct {
 	resolveMCPConfig     func(workspaceRoot string) (config.MCPConfig, error)
 	newProvider          func(config.ProviderProfile) (zeroruntime.Provider, error)
 	probeProviderHealth  func(context.Context, providerhealth.Options) providerhealth.Result
+	detectLocalRuntimes  func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime
 	newSessionStore      func() *sessions.Store
 	loadPlugins          func(plugins.LoadOptions) (plugins.LoadResult, error)
 	loadHooks            func(hooks.LoadOptions) (hooks.LoadResult, error)
@@ -111,6 +113,7 @@ func defaultAppDeps() appDeps {
 			})
 		},
 		probeProviderHealth: providerhealth.Probe,
+		detectLocalRuntimes: provideronboarding.DetectLocalRuntimes,
 		newSessionStore: func() *sessions.Store {
 			return sessions.NewStore(sessions.StoreOptions{})
 		},
@@ -336,6 +339,9 @@ func fillAppDeps(deps appDeps) appDeps {
 	}
 	if deps.probeProviderHealth == nil {
 		deps.probeProviderHealth = defaults.probeProviderHealth
+	}
+	if deps.detectLocalRuntimes == nil {
+		deps.detectLocalRuntimes = defaults.detectLocalRuntimes
 	}
 	if deps.newSessionStore == nil {
 		deps.newSessionStore = defaults.newSessionStore

--- a/internal/cli/command_center.go
+++ b/internal/cli/command_center.go
@@ -78,6 +78,9 @@ func runProviders(args []string, stdout io.Writer, stderr io.Writer, deps appDep
 	if command == "setup" {
 		return runProvidersSetup(args, stdout, stderr, deps)
 	}
+	if command == "detect" {
+		return runProvidersDetect(args, stdout, stderr, deps)
+	}
 	if command != "list" && command != "current" && command != "catalog" {
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown providers command %q", command))
 	}
@@ -451,8 +454,10 @@ func writeProvidersHelp(w io.Writer) error {
   zero providers check [name] [flags]
   zero providers use <name> [flags]
   zero providers setup <catalog-id> [flags]
+  zero providers detect [flags]
 
 Inspects resolved provider profiles and provider catalog descriptors without printing secrets.
+Detect probes for running local runtimes (Ollama, LM Studio) and prints adopt commands plus per-provider next steps.
 
 Flags:
       --json                    Print JSON summary

--- a/internal/cli/provider_detect.go
+++ b/internal/cli/provider_detect.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/provideronboarding"
+)
+
+type providerDetectOptions struct {
+	json bool
+}
+
+// providerDetectAction is the JSON/text shape of a single suggested next step.
+type providerDetectAction struct {
+	Label   string `json:"label"`
+	Command string `json:"command"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+type providerDetectRuntime struct {
+	CatalogID string               `json:"catalogID"`
+	Name      string               `json:"name"`
+	BaseURL   string               `json:"baseURL"`
+	Models    []string             `json:"models,omitempty"`
+	Action    providerDetectAction `json:"action"`
+}
+
+type providerDetectProvider struct {
+	Name    string                 `json:"name"`
+	Active  bool                   `json:"active"`
+	Actions []providerDetectAction `json:"actions,omitempty"`
+}
+
+type providerDetectReport struct {
+	DetectedRuntimes []providerDetectRuntime  `json:"detectedRuntimes"`
+	Providers        []providerDetectProvider `json:"providers"`
+}
+
+// runProvidersDetect probes the machine for running local, OpenAI-compatible
+// model runtimes (Ollama, LM Studio) and prints a no-key adopt command for each
+// one it finds, followed by the next-step actions for every already-configured
+// provider. It is the onboarding-advice surface — "what can I do right now?" —
+// and never errors on a machine with nothing running locally (it just reports an
+// empty detected list).
+func runProvidersDetect(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseProviderDetectArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeProvidersHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+
+	resolved, exitCode := resolveCommandCenterConfig(stderr, deps)
+	if exitCode != exitSuccess {
+		return exitCode
+	}
+
+	ctx, stop := signalContext()
+	defer stop()
+	detected := deps.detectLocalRuntimes(ctx, provideronboarding.LocalDetectOptions{})
+
+	report := buildProviderDetectReport(resolved, detected)
+
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatProviderDetectReport(report)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseProviderDetectArgs(args []string) (providerDetectOptions, bool, error) {
+	options := providerDetectOptions{}
+	for _, arg := range args {
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		default:
+			return options, false, execUsageError{fmt.Sprintf("unexpected argument %q", arg)}
+		}
+	}
+	return options, false, nil
+}
+
+func buildProviderDetectReport(resolved config.ResolvedConfig, detected []provideronboarding.DetectedLocalRuntime) providerDetectReport {
+	report := providerDetectReport{
+		DetectedRuntimes: make([]providerDetectRuntime, 0, len(detected)),
+		Providers:        make([]providerDetectProvider, 0, len(resolved.Providers)),
+	}
+	for _, runtime := range detected {
+		report.DetectedRuntimes = append(report.DetectedRuntimes, providerDetectRuntime{
+			CatalogID: runtime.CatalogID,
+			Name:      runtime.Name,
+			BaseURL:   runtime.BaseURL,
+			Models:    runtime.Models,
+			Action:    providerDetectActionFrom(runtime.SetupAction()),
+		})
+	}
+	for _, profile := range resolved.Providers {
+		active := strings.TrimSpace(profile.Name) != "" && profile.Name == resolved.ActiveProvider
+		state := provideronboarding.ProviderState{Profile: profile, Active: active}
+		actions := state.Actions()
+		entry := providerDetectProvider{
+			Name:    profile.Name,
+			Active:  active,
+			Actions: make([]providerDetectAction, 0, len(actions)),
+		}
+		for _, action := range actions {
+			entry.Actions = append(entry.Actions, providerDetectActionFrom(action))
+		}
+		report.Providers = append(report.Providers, entry)
+	}
+	return report
+}
+
+func providerDetectActionFrom(action provideronboarding.Action) providerDetectAction {
+	return providerDetectAction{Label: action.Label, Command: action.Command, Detail: action.Detail}
+}
+
+func formatProviderDetectReport(report providerDetectReport) string {
+	lines := []string{"Detected local runtimes:"}
+	if len(report.DetectedRuntimes) == 0 {
+		lines = append(lines, "  (none running on default ports)")
+	}
+	for _, runtime := range report.DetectedRuntimes {
+		name := strings.TrimSpace(runtime.Name)
+		if name == "" {
+			name = runtime.CatalogID
+		}
+		lines = append(lines, "  "+name+" — "+runtime.BaseURL)
+		if len(runtime.Models) > 0 {
+			lines = append(lines, "    models: "+strings.Join(runtime.Models, ", "))
+		}
+		if command := strings.TrimSpace(runtime.Action.Command); command != "" {
+			lines = append(lines, "    "+runtime.Action.Label+": "+command)
+		}
+	}
+
+	lines = append(lines, "", "Configured providers:")
+	if len(report.Providers) == 0 {
+		lines = append(lines, "  (none configured — run `zero setup`)")
+	}
+	for _, provider := range report.Providers {
+		name := strings.TrimSpace(provider.Name)
+		if name == "" {
+			name = "(unnamed)"
+		}
+		marker := ""
+		if provider.Active {
+			marker = " (active)"
+		}
+		lines = append(lines, "  "+name+marker)
+		if len(provider.Actions) == 0 {
+			lines = append(lines, "    (ready)")
+		}
+		for _, action := range provider.Actions {
+			line := "    " + action.Label
+			if command := strings.TrimSpace(action.Command); command != "" {
+				line += ": " + command
+			}
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/cli/provider_detect_test.go
+++ b/internal/cli/provider_detect_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/provideronboarding"
+)
+
+func TestRunProvidersDetectSurfacesLocalRuntimeAndProviderActions(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.detectLocalRuntimes = func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime {
+		return []provideronboarding.DetectedLocalRuntime{{
+			LocalRuntime: provideronboarding.LocalRuntime{CatalogID: "ollama", Name: "Ollama Local", BaseURL: "http://localhost:11434/v1"},
+			Reachable:    true,
+			Models:       []string{"llama3.1"},
+		}}
+	}
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		// Configured-but-inactive provider with no credential: should yield the full
+		// "Use provider" / "Check provider" / "Set API key" action set.
+		profile := config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAI,
+			Model:        "gpt-4o",
+			APIKeyEnv:    "OPENAI_API_KEY",
+		}
+		return config.ResolvedConfig{ActiveProvider: "other", Providers: []config.ProviderProfile{profile}}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "detect"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exit=%d stderr=%s", exitCode, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Detected local runtimes:",
+		"Ollama Local — http://localhost:11434/v1",
+		"models: llama3.1",
+		"zero providers add ollama", // SetupAction's no-key adopt command
+		"Configured providers:",
+		"openai",
+		"Use provider",
+		"Check provider",
+		"Set API key",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("detect output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunProvidersDetectJSONNoRuntimesActiveProvider(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	deps := commandCenterDeps(t)
+	deps.detectLocalRuntimes = func(context.Context, provideronboarding.LocalDetectOptions) []provideronboarding.DetectedLocalRuntime {
+		return nil // nothing running locally
+	}
+	deps.resolveConfig = func(string, config.Overrides) (config.ResolvedConfig, error) {
+		// Active provider with an inline key: only "Check provider" remains.
+		profile := config.ProviderProfile{
+			Name:         "local",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://api.example.com/v1",
+			APIKey:       "sk-secret",
+			Model:        "custom",
+		}
+		return config.ResolvedConfig{ActiveProvider: "local", Provider: profile, Providers: []config.ProviderProfile{profile}}, nil
+	}
+
+	exitCode := runWithDeps([]string{"providers", "detect", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("exit=%d stderr=%s", exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "sk-secret") {
+		t.Fatalf("detect JSON leaked the API key: %s", stdout.String())
+	}
+	var payload struct {
+		DetectedRuntimes []struct {
+			CatalogID string `json:"catalogID"`
+		} `json:"detectedRuntimes"`
+		Providers []struct {
+			Name    string `json:"name"`
+			Active  bool   `json:"active"`
+			Actions []struct {
+				Label string `json:"label"`
+			} `json:"actions"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("detect JSON did not decode: %v\n%s", err, stdout.String())
+	}
+	if len(payload.DetectedRuntimes) != 0 {
+		t.Fatalf("expected no detected runtimes, got %#v", payload.DetectedRuntimes)
+	}
+	if len(payload.Providers) != 1 || payload.Providers[0].Name != "local" || !payload.Providers[0].Active {
+		t.Fatalf("expected one active provider 'local', got %#v", payload.Providers)
+	}
+	if len(payload.Providers[0].Actions) != 1 || payload.Providers[0].Actions[0].Label != "Check provider" {
+		t.Fatalf("expected only a Check action for an active keyed provider, got %#v", payload.Providers[0].Actions)
+	}
+}

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -31,6 +31,8 @@ func runSandbox(args []string, stdout io.Writer, stderr io.Writer, deps appDeps)
 		return exitSuccess
 	case "policy":
 		return runSandboxPolicy(args[1:], stdout, stderr, deps)
+	case "check":
+		return runSandboxCheck(args[1:], stdout, stderr, deps)
 	case "grants":
 		return runSandboxGrants(args[1:], stdout, stderr, deps)
 	default:
@@ -526,6 +528,7 @@ func writeSandboxHelp(w io.Writer) error {
 
 Commands:
   policy      Inspect active sandbox policy and platform backend
+  check       Evaluate the sandbox decision for a hypothetical tool action
   grants      Manage persistent sandbox grants
 
 `)

--- a/internal/cli/sandbox_check.go
+++ b/internal/cli/sandbox_check.go
@@ -1,0 +1,251 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/config"
+	zeroSandbox "github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/zerocommands"
+)
+
+type sandboxCheckOptions struct {
+	tool       string
+	sideEffect string
+	path       string
+	autonomy   string
+	reason     string
+	json       bool
+}
+
+// sandboxCheckReport is the combined snapshot `zero sandbox check` emits: the
+// active plan (policy + backend + restrictions), the decision the engine would
+// make for the described tool action, and any persistent grant that matches the
+// tool. It is the production consumer of the zerocommands sandbox-snapshot
+// contract, giving operators and CI a stable, redacted JSON view of "what would
+// the sandbox do for this action?".
+type sandboxCheckReport struct {
+	Tool     string                                 `json:"tool"`
+	Plan     zerocommands.SandboxPlanSnapshot       `json:"plan"`
+	Decision zerocommands.SandboxDecisionSnapshot   `json:"decision"`
+	Grant    zerocommands.SandboxGrantMatchSnapshot `json:"grant"`
+}
+
+func runSandboxCheck(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	options, help, err := parseSandboxCheckArgs(args)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	if help {
+		if err := writeSandboxCheckHelp(stdout); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if strings.TrimSpace(options.tool) == "" {
+		return writeExecUsageError(stderr, "tool name is required: zero sandbox check <tool> [flags]")
+	}
+
+	workspaceRoot, err := resolveWorkspaceRoot("", deps)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
+	}
+	store, err := deps.newSandboxStore()
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+	resolved, err := deps.resolveConfig(workspaceRoot, config.Overrides{})
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
+	}
+	policy := applyConfiguredSandboxPolicy(zeroSandbox.DefaultPolicy(), resolved.Sandbox)
+	backend := deps.selectSandboxBackend(zeroSandbox.BackendOptions{})
+	plan := backend.BuildPlan(workspaceRoot, policy)
+
+	sideEffect := zeroSandbox.SideEffect(strings.ToLower(strings.TrimSpace(options.sideEffect)))
+	if sideEffect == "" {
+		sideEffect = zeroSandbox.SideEffectRead
+	}
+	autonomy := zeroSandbox.Autonomy(strings.ToLower(strings.TrimSpace(options.autonomy)))
+	if autonomy == "" {
+		autonomy = zeroSandbox.AutonomyHigh
+	}
+
+	requestArgs := map[string]any{}
+	scopeAbs := workspaceRoot
+	if path := strings.TrimSpace(options.path); path != "" {
+		requestArgs["path"] = path
+		if filepath.IsAbs(path) {
+			scopeAbs = filepath.Clean(path)
+		} else {
+			scopeAbs = filepath.Join(workspaceRoot, path)
+		}
+	}
+
+	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
+		WorkspaceRoot: workspaceRoot,
+		Policy:        policy,
+		Store:         store,
+		Backend:       backend,
+	})
+	ctx, stop := signalContext()
+	defer stop()
+	decision := engine.Evaluate(ctx, zeroSandbox.Request{
+		WorkspaceRoot:  workspaceRoot,
+		ToolName:       options.tool,
+		SideEffect:     sideEffect,
+		PermissionMode: zeroSandbox.PermissionModeAsk,
+		Autonomy:       autonomy,
+		Args:           requestArgs,
+		Reason:         strings.TrimSpace(options.reason),
+	})
+
+	lookup, err := store.Lookup(options.tool, scopeAbs, autonomy)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitCrash)
+	}
+
+	report := sandboxCheckReport{
+		Tool:     strings.TrimSpace(options.tool),
+		Plan:     zerocommands.SandboxPlanSnapshotFromPlan(plan),
+		Decision: zerocommands.SandboxDecisionSnapshotFromDecision(decision),
+		Grant:    zerocommands.SandboxGrantMatchSnapshotFromLookup(options.tool, lookup),
+	}
+
+	if options.json {
+		if err := writePrettyJSON(stdout, report); err != nil {
+			return exitCrash
+		}
+		return exitSuccess
+	}
+	if _, err := fmt.Fprintln(stdout, formatSandboxCheckReport(report)); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+func parseSandboxCheckArgs(args []string) (sandboxCheckOptions, bool, error) {
+	options := sandboxCheckOptions{}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case arg == "-h" || arg == "--help" || arg == "help":
+			return options, true, nil
+		case arg == "--json":
+			options.json = true
+		case arg == "--side-effect" || arg == "--path" || arg == "--autonomy" || arg == "--reason":
+			value, next, err := nextFlagValue(args, index, arg)
+			if err != nil {
+				return options, false, err
+			}
+			assignSandboxCheckFlag(&options, arg, value)
+			index = next
+		case strings.HasPrefix(arg, "--side-effect="):
+			value, err := requiredInlineFlagValue(arg, "--side-effect")
+			if err != nil {
+				return options, false, err
+			}
+			options.sideEffect = value
+		case strings.HasPrefix(arg, "--path="):
+			value, err := requiredInlineFlagValue(arg, "--path")
+			if err != nil {
+				return options, false, err
+			}
+			options.path = value
+		case strings.HasPrefix(arg, "--autonomy="):
+			value, err := requiredInlineFlagValue(arg, "--autonomy")
+			if err != nil {
+				return options, false, err
+			}
+			options.autonomy = value
+		case strings.HasPrefix(arg, "--reason="):
+			value, err := requiredInlineFlagValue(arg, "--reason")
+			if err != nil {
+				return options, false, err
+			}
+			options.reason = value
+		case strings.HasPrefix(arg, "-"):
+			return options, false, execUsageError{fmt.Sprintf("unknown flag %q", arg)}
+		default:
+			if options.tool != "" {
+				return options, false, execUsageError{fmt.Sprintf("unexpected argument %q", arg)}
+			}
+			options.tool = arg
+		}
+	}
+	return options, false, nil
+}
+
+func assignSandboxCheckFlag(options *sandboxCheckOptions, flag string, value string) {
+	switch flag {
+	case "--side-effect":
+		options.sideEffect = value
+	case "--path":
+		options.path = value
+	case "--autonomy":
+		options.autonomy = value
+	case "--reason":
+		options.reason = value
+	}
+}
+
+func formatSandboxCheckReport(report sandboxCheckReport) string {
+	lines := []string{
+		"Sandbox check: " + report.Tool,
+		"decision: " + report.Decision.Action,
+	}
+	if reason := strings.TrimSpace(report.Decision.Reason); reason != "" {
+		lines = append(lines, "reason: "+reason)
+	}
+	risk := report.Decision.Risk
+	riskLine := "risk: " + risk.Level
+	if len(risk.Categories) > 0 {
+		riskLine += " [" + strings.Join(risk.Categories, ", ") + "]"
+	}
+	lines = append(lines, riskLine)
+	if violation := report.Decision.Violation; violation != nil {
+		line := "violation: [" + violation.Code + "] " + violation.Reason
+		if violation.Path != "" {
+			line += " (path: " + violation.Path + ")"
+		}
+		lines = append(lines, line)
+	}
+	if report.Grant.Matched && report.Grant.Grant != nil {
+		lines = append(lines, "grant: matched "+report.Grant.Grant.Decision+" (maxAutonomy "+report.Grant.Grant.MaxAutonomy+")")
+	} else {
+		lines = append(lines, "grant: none recorded for this tool")
+	}
+	lines = append(lines,
+		"policy: mode="+report.Plan.Policy.EffectiveMode+" network="+report.Plan.Policy.Network+fmt.Sprintf(" enforceWorkspace=%t", report.Plan.Policy.EnforceWorkspace),
+		"backend: "+report.Plan.Backend.Name+fmt.Sprintf(" (available=%t)", report.Plan.Backend.Available),
+	)
+	if len(report.Plan.Restrictions) > 0 {
+		lines = append(lines, "restrictions:")
+		for _, restriction := range report.Plan.Restrictions {
+			lines = append(lines, "  - "+restriction)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func writeSandboxCheckHelp(w io.Writer) error {
+	_, err := fmt.Fprint(w, `Usage:
+  zero sandbox check <tool> [flags]
+
+Evaluates the sandbox decision for a hypothetical tool action against the
+resolved policy, and prints the plan, the decision (allow/prompt/deny with risk
+and any violation), and any persistent grant that matches the tool. Secrets in
+grant reasons are redacted.
+
+Flags:
+      --side-effect <kind>   read | write | shell | network | none (default read)
+      --path <path>          Target path for the action (read/write checks)
+      --autonomy <level>     low | medium | high (default high)
+      --reason <text>        Reason recorded with the request
+      --json                 Print the machine-readable snapshot
+  -h, --help                 Show this help
+`)
+	return err
+}

--- a/internal/cli/sandbox_check.go
+++ b/internal/cli/sandbox_check.go
@@ -64,13 +64,13 @@ func runSandboxCheck(args []string, stdout io.Writer, stderr io.Writer, deps app
 	backend := deps.selectSandboxBackend(zeroSandbox.BackendOptions{})
 	plan := backend.BuildPlan(workspaceRoot, policy)
 
-	sideEffect := zeroSandbox.SideEffect(strings.ToLower(strings.TrimSpace(options.sideEffect)))
-	if sideEffect == "" {
-		sideEffect = zeroSandbox.SideEffectRead
+	sideEffect, err := parseSandboxCheckSideEffect(options.sideEffect)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
 	}
-	autonomy := zeroSandbox.Autonomy(strings.ToLower(strings.TrimSpace(options.autonomy)))
-	if autonomy == "" {
-		autonomy = zeroSandbox.AutonomyHigh
+	autonomy, err := parseSandboxCheckAutonomy(options.autonomy)
+	if err != nil {
+		return writeExecUsageError(stderr, err.Error())
 	}
 
 	requestArgs := map[string]any{}
@@ -84,11 +84,20 @@ func runSandboxCheck(args []string, stdout io.Writer, stderr io.Writer, deps app
 		}
 	}
 
+	// Build the engine with the SAME write scope the real entrypoints use
+	// (workspace root + configured additional write roots) so the check's
+	// decision matches actual enforcement and a stale extra-root config surfaces
+	// here too, instead of silently falling back to a workspace-only scope.
+	scope, err := zeroSandbox.NewScope(workspaceRoot, resolved.Sandbox.AdditionalWriteRoots)
+	if err != nil {
+		return writeAppError(stderr, err.Error(), exitProvider)
+	}
 	engine := zeroSandbox.NewEngine(zeroSandbox.EngineOptions{
 		WorkspaceRoot: workspaceRoot,
 		Policy:        policy,
 		Store:         store,
 		Backend:       backend,
+		Scope:         scope,
 	})
 	ctx, stop := signalContext()
 	defer stop()
@@ -191,6 +200,44 @@ func assignSandboxCheckFlag(options *sandboxCheckOptions, flag string, value str
 	}
 }
 
+// parseSandboxCheckSideEffect validates --side-effect against the closed set the
+// help advertises (empty defaults to read), so a typo returns a usage error
+// instead of being passed to the engine as an unknown side effect.
+func parseSandboxCheckSideEffect(value string) (zeroSandbox.SideEffect, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "read":
+		return zeroSandbox.SideEffectRead, nil
+	case "write":
+		return zeroSandbox.SideEffectWrite, nil
+	case "shell":
+		return zeroSandbox.SideEffectShell, nil
+	case "network":
+		return zeroSandbox.SideEffectNetwork, nil
+	case "none":
+		return zeroSandbox.SideEffectNone, nil
+	default:
+		return "", execUsageError{fmt.Sprintf("invalid --side-effect %q: expected read, write, shell, network, or none", value)}
+	}
+}
+
+// parseSandboxCheckAutonomy validates --autonomy against the closed set the help
+// advertises (empty defaults to high), so a typo returns a usage error instead
+// of the engine silently clamping an unknown tier.
+func parseSandboxCheckAutonomy(value string) (zeroSandbox.Autonomy, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return zeroSandbox.AutonomyHigh, nil
+	case string(zeroSandbox.AutonomyLow):
+		return zeroSandbox.AutonomyLow, nil
+	case string(zeroSandbox.AutonomyMedium):
+		return zeroSandbox.AutonomyMedium, nil
+	case string(zeroSandbox.AutonomyHigh):
+		return zeroSandbox.AutonomyHigh, nil
+	default:
+		return "", execUsageError{fmt.Sprintf("invalid --autonomy %q: expected low, medium, or high", value)}
+	}
+}
+
 func formatSandboxCheckReport(report sandboxCheckReport) string {
 	lines := []string{
 		"Sandbox check: " + report.Tool,
@@ -215,7 +262,7 @@ func formatSandboxCheckReport(report sandboxCheckReport) string {
 	if report.Grant.Matched && report.Grant.Grant != nil {
 		lines = append(lines, "grant: matched "+report.Grant.Grant.Decision+" (maxAutonomy "+report.Grant.Grant.MaxAutonomy+")")
 	} else {
-		lines = append(lines, "grant: none recorded for this tool")
+		lines = append(lines, "grant: no grant matched this action")
 	}
 	lines = append(lines,
 		"policy: mode="+report.Plan.Policy.EffectiveMode+" network="+report.Plan.Policy.Network+fmt.Sprintf(" enforceWorkspace=%t", report.Plan.Policy.EnforceWorkspace),

--- a/internal/cli/sandbox_check_test.go
+++ b/internal/cli/sandbox_check_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -28,8 +29,12 @@ func sandboxCheckDeps(t *testing.T) (appDeps, string) {
 
 func TestRunSandboxCheckJSONDeniesOutOfWorkspaceWrite(t *testing.T) {
 	deps, _ := sandboxCheckDeps(t)
+	// An absolute path outside the workspace, portable across OSes: a Unix literal
+	// like /etc/passwd is not absolute on Windows (it would be joined into the
+	// workspace and allowed), so build one under a separate temp dir instead.
+	outside := filepath.Join(t.TempDir(), "outside.txt")
 	var stdout, stderr bytes.Buffer
-	exitCode := runWithDeps([]string{"sandbox", "check", "write_file", "--side-effect", "write", "--path", "/etc/passwd", "--json"}, &stdout, &stderr, deps)
+	exitCode := runWithDeps([]string{"sandbox", "check", "write_file", "--side-effect", "write", "--path", outside, "--json"}, &stdout, &stderr, deps)
 	if exitCode != exitSuccess {
 		t.Fatalf("check exit=%d stderr=%s", exitCode, stderr.String())
 	}

--- a/internal/cli/sandbox_check_test.go
+++ b/internal/cli/sandbox_check_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sandbox"
+)
+
+func sandboxCheckDeps(t *testing.T) (appDeps, string) {
+	t.Helper()
+	store := newSandboxTestStore(t)
+	root := t.TempDir()
+	return appDeps{
+		getwd:           func() (string, error) { return root, nil },
+		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
+		selectSandboxBackend: func(sandbox.BackendOptions) sandbox.Backend {
+			return sandbox.Backend{Name: sandbox.BackendPolicyOnly, Platform: "windows", Fallback: true}
+		},
+	}, root
+}
+
+func TestRunSandboxCheckJSONDeniesOutOfWorkspaceWrite(t *testing.T) {
+	deps, _ := sandboxCheckDeps(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "check", "write_file", "--side-effect", "write", "--path", "/etc/passwd", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("check exit=%d stderr=%s", exitCode, stderr.String())
+	}
+	var payload struct {
+		Tool string `json:"tool"`
+		Plan struct {
+			Policy struct {
+				EffectiveMode string `json:"effectiveMode"`
+			} `json:"policy"`
+			Backend struct {
+				Name string `json:"name"`
+			} `json:"backend"`
+		} `json:"plan"`
+		Decision struct {
+			Action string `json:"action"`
+			Risk   struct {
+				Level string `json:"level"`
+			} `json:"risk"`
+			Violation *struct {
+				Code string `json:"code"`
+			} `json:"violation"`
+		} `json:"decision"`
+		Grant struct {
+			ToolName string `json:"toolName"`
+			Matched  bool   `json:"matched"`
+		} `json:"grant"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode check JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.Tool != "write_file" {
+		t.Fatalf("tool = %q", payload.Tool)
+	}
+	if payload.Plan.Policy.EffectiveMode != string(sandbox.ModeEnforce) {
+		t.Fatalf("effectiveMode = %q, want enforce", payload.Plan.Policy.EffectiveMode)
+	}
+	if payload.Plan.Backend.Name != string(sandbox.BackendPolicyOnly) {
+		t.Fatalf("backend = %q", payload.Plan.Backend.Name)
+	}
+	if payload.Decision.Action != string(sandbox.ActionDeny) {
+		t.Fatalf("expected deny for out-of-workspace write, got %q\n%s", payload.Decision.Action, stdout.String())
+	}
+	if payload.Decision.Violation == nil {
+		t.Fatalf("expected a violation for the out-of-workspace write")
+	}
+	if payload.Grant.ToolName != "write_file" || payload.Grant.Matched {
+		t.Fatalf("expected an unmatched grant for write_file, got %#v", payload.Grant)
+	}
+}
+
+func TestRunSandboxCheckTextRendersDecisionAndPlan(t *testing.T) {
+	deps, _ := sandboxCheckDeps(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "check", "read_file", "--side-effect", "read", "--path", "notes.txt"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("check exit=%d stderr=%s", exitCode, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Sandbox check: read_file",
+		"decision: ",
+		"risk: ",
+		"policy: mode=enforce",
+		"backend: policy-only",
+		"grant: none recorded for this tool",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("check text missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSandboxCheckRequiresTool(t *testing.T) {
+	deps, _ := sandboxCheckDeps(t)
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "check"}, &stdout, &stderr, deps)
+	if exitCode == exitSuccess {
+		t.Fatalf("expected a usage error when no tool is given, got success: %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "tool name is required") {
+		t.Fatalf("expected 'tool name is required', got %q", stderr.String())
+	}
+}

--- a/internal/cli/sandbox_check_test.go
+++ b/internal/cli/sandbox_check_test.go
@@ -94,7 +94,7 @@ func TestRunSandboxCheckTextRendersDecisionAndPlan(t *testing.T) {
 		"risk: ",
 		"policy: mode=enforce",
 		"backend: policy-only",
-		"grant: none recorded for this tool",
+		"grant: no grant matched this action",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("check text missing %q:\n%s", want, out)
@@ -111,5 +111,72 @@ func TestRunSandboxCheckRequiresTool(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "tool name is required") {
 		t.Fatalf("expected 'tool name is required', got %q", stderr.String())
+	}
+}
+
+func TestRunSandboxCheckRejectsInvalidFlags(t *testing.T) {
+	deps, _ := sandboxCheckDeps(t)
+	for _, args := range [][]string{
+		{"sandbox", "check", "read_file", "--side-effect", "wrtie"},
+		{"sandbox", "check", "read_file", "--autonomy", "supreme"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code := runWithDeps(args, &stdout, &stderr, deps); code == exitSuccess {
+			t.Fatalf("args %v: expected a usage error, got success: %s", args, stdout.String())
+		}
+		if !strings.Contains(stderr.String(), "invalid --") {
+			t.Fatalf("args %v: expected an 'invalid --…' usage error, got %q", args, stderr.String())
+		}
+	}
+}
+
+func TestRunSandboxCheckMatchedGrantRedactsReason(t *testing.T) {
+	store := newSandboxTestStore(t)
+	root := t.TempDir()
+	deps := appDeps{
+		getwd:           func() (string, error) { return root, nil },
+		newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil },
+		resolveConfig: func(string, config.Overrides) (config.ResolvedConfig, error) {
+			return config.ResolvedConfig{}, nil
+		},
+		selectSandboxBackend: func(sandbox.BackendOptions) sandbox.Backend {
+			return sandbox.Backend{Name: sandbox.BackendPolicyOnly}
+		},
+	}
+	// Seed a tool-wide allow grant whose reason embeds a secret; the matched-grant
+	// snapshot must redact it.
+	if _, err := store.Grant(sandbox.GrantInput{
+		ToolName:    "read_file",
+		Decision:    sandbox.GrantAllow,
+		MaxAutonomy: sandbox.AutonomyHigh,
+		Reason:      "approved with sk-test-secret1234567890",
+	}); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "check", "read_file", "--autonomy", "high", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("check exit=%d stderr=%s", exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "sk-test-secret1234567890") {
+		t.Fatalf("grant reason leaked a secret into the snapshot:\n%s", stdout.String())
+	}
+	var payload struct {
+		Grant struct {
+			Matched bool `json:"matched"`
+			Grant   *struct {
+				Reason string `json:"reason"`
+			} `json:"grant"`
+		} `json:"grant"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode check JSON: %v\n%s", err, stdout.String())
+	}
+	if !payload.Grant.Matched || payload.Grant.Grant == nil {
+		t.Fatalf("expected a matched grant, got %#v", payload.Grant)
+	}
+	if !strings.Contains(payload.Grant.Grant.Reason, "REDACTED") {
+		t.Fatalf("expected the reason to be redacted, got %q", payload.Grant.Grant.Reason)
 	}
 }

--- a/internal/providermodelcatalog/logic_test.go
+++ b/internal/providermodelcatalog/logic_test.go
@@ -1,0 +1,144 @@
+package providermodelcatalog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+)
+
+func TestLooksLikeCodingModelID(t *testing.T) {
+	coding := []string{"gpt-4o", "claude-sonnet-4.5", "o1", "o3-mini", "o4-mini", "qwen2.5-coder", "deepseek-chat", "kimi-k2", "codestral-latest", "grok-code"}
+	for _, id := range coding {
+		if !LooksLikeCodingModelID(id) {
+			t.Errorf("LooksLikeCodingModelID(%q) = false, want true", id)
+		}
+	}
+	nonCoding := []string{"", "   ", "whisper-1", "dall-e-3", "tts-1", "text-embedding-3-large", "omni-moderation-latest", "sora", "random-widget-7"}
+	for _, id := range nonCoding {
+		if LooksLikeCodingModelID(id) {
+			t.Errorf("LooksLikeCodingModelID(%q) = true, want false", id)
+		}
+	}
+}
+
+func TestModelMatchesProvider(t *testing.T) {
+	cases := []struct {
+		transport providercatalog.Transport
+		provider  modelregistry.ProviderKind
+		want      bool
+	}{
+		{providercatalog.TransportOpenAI, modelregistry.ProviderOpenAI, true},
+		{providercatalog.TransportOpenAI, modelregistry.ProviderAnthropic, false},
+		{providercatalog.TransportAnthropic, modelregistry.ProviderAnthropic, true},
+		{providercatalog.TransportAnthropicCompatible, modelregistry.ProviderAnthropic, true},
+		{providercatalog.TransportGoogle, modelregistry.ProviderGoogle, true},
+		{providercatalog.TransportGoogle, modelregistry.ProviderOpenAI, false},
+		{providercatalog.TransportOpenAICompatible, modelregistry.ProviderOpenAI, false}, // default branch: no match
+	}
+	for _, tc := range cases {
+		got := modelMatchesProvider(modelregistry.ModelEntry{Provider: tc.provider}, providercatalog.Descriptor{Transport: tc.transport})
+		if got != tc.want {
+			t.Errorf("modelMatchesProvider(provider=%q, transport=%q) = %v, want %v", tc.provider, tc.transport, got, tc.want)
+		}
+	}
+}
+
+func TestDefaultedOpenGatewayURL(t *testing.T) {
+	if got := defaultedOpenGatewayURL(providercatalog.Descriptor{}, " https://x/models.json "); got != "https://x/models.json" {
+		t.Fatalf("explicit override = %q, want trimmed override", got)
+	}
+	if got := defaultedOpenGatewayURL(providercatalog.Descriptor{DefaultBaseURL: "https://gw.example.com/v1"}, ""); got != "https://gw.example.com/zero/models.json" {
+		t.Fatalf("derived = %q", got)
+	}
+	if got := defaultedOpenGatewayURL(providercatalog.Descriptor{DefaultBaseURL: "::not a url"}, ""); got != "https://gateway.gitlawb.com/zero/models.json" {
+		t.Fatalf("fallback = %q", got)
+	}
+}
+
+func TestModelSortLabelAndSortModels(t *testing.T) {
+	if got := modelSortLabel(Model{Description: "  GPT-4o  "}); got != "gpt-4o" {
+		t.Fatalf("label from description = %q", got)
+	}
+	if got := modelSortLabel(Model{ID: "Llama-3"}); got != "llama-3" {
+		t.Fatalf("label from id = %q", got)
+	}
+	models := []Model{{ID: "b", Description: "Zeta"}, {ID: "a", Description: "Alpha"}}
+	sortModels(models)
+	if models[0].Description != "Alpha" {
+		t.Fatalf("sortModels did not order by label: %#v", models)
+	}
+}
+
+func TestFetchJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("Accept header = %q, want application/json", r.Header.Get("Accept"))
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	body, err := fetchJSON(context.Background(), srv.URL, srv.Client())
+	if err != nil || string(body) != `{"ok":true}` {
+		t.Fatalf("fetchJSON = %q, %v", string(body), err)
+	}
+	if _, err := fetchJSON(context.Background(), "   ", srv.Client()); err == nil {
+		t.Fatal("expected an error for an empty endpoint")
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	if _, err := fetchJSON(context.Background(), bad.URL, bad.Client()); err == nil {
+		t.Fatal("expected an error for a 500 response")
+	}
+}
+
+func TestFetchModelsDevAndOpenGatewayOverHTTP(t *testing.T) {
+	modelsDev := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"openai":{"models":{"gpt-4o":{"id":"gpt-4o"}}}}`))
+	}))
+	defer modelsDev.Close()
+	models, err := FetchModelsDev(context.Background(), "openai", FetchOptions{HTTPClient: modelsDev.Client(), ModelsDevURL: modelsDev.URL})
+	if err != nil {
+		t.Fatalf("FetchModelsDev error: %v", err)
+	}
+	if !containsModelID(models, "gpt-4o") {
+		t.Fatalf("FetchModelsDev models = %#v, want gpt-4o", models)
+	}
+
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"models":[{"id":"claude-coder"}]}`))
+	}))
+	defer gateway.Close()
+	models, err = FetchOpenGateway(context.Background(), gateway.URL, FetchOptions{HTTPClient: gateway.Client()})
+	if err != nil {
+		t.Fatalf("FetchOpenGateway error: %v", err)
+	}
+	if !containsModelID(models, "claude-coder") {
+		t.Fatalf("FetchOpenGateway models = %#v, want claude-coder", models)
+	}
+
+	// FetchRemote routes the opengateway provider to FetchOpenGateway via the override URL.
+	routed, err := FetchRemote(context.Background(), providercatalog.Descriptor{ID: "gitlawb-opengateway"}, FetchOptions{HTTPClient: gateway.Client(), OpenGatewayURL: gateway.URL})
+	if err != nil {
+		t.Fatalf("FetchRemote error: %v", err)
+	}
+	if !containsModelID(routed, "claude-coder") {
+		t.Fatalf("FetchRemote models = %#v, want claude-coder", routed)
+	}
+}
+
+func containsModelID(models []Model, id string) bool {
+	for _, model := range models {
+		if model.ID == id {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Finishes two fully-built-but-unwired feature surfaces and closes a coverage gap — all three identified by a whole-program reachability audit (`deadcode` + `staticcheck`). Each was tested code with **no production caller**; this PR connects them to the CLI rather than deleting them.

## 1. `zero providers detect` — local-runtime onboarding

The `provideronboarding` detect/advice builders (`DetectLocalRuntimes`, `LocalRuntimeCandidates`, `DetectedLocalRuntime.SetupAction`, `ProviderActions`, `MissingCredentialAction`, `SetupCommand`, `ProviderState.Actions`) existed and were tested but had no caller. The new command probes for running local OpenAI-compatible runtimes (Ollama, LM Studio) on their default ports and prints a no-key adopt command for each, plus the next-step actions for every configured provider.

```
Detected local runtimes:
  Ollama Local — http://localhost:11434/v1
    Use local runtime: zero providers add ollama --name "Ollama Local" --set-active
Configured providers:
  openai
    Use provider: zero providers use openai
    Set API key: set OPENAI_API_KEY in your shell
```

`--json` supported; detection is injected through an `appDep` so tests stay hermetic (no real localhost probe).

## 2. `zero sandbox check` — decision evaluation as JSON

The `zerocommands` sandbox-snapshot contract (`SandboxPlanSnapshotFromPlan`, `SandboxDecisionSnapshotFromDecision`, and the policy/backend/risk/violation/grant-match builders) was documented as the stable sandbox JSON shape but nothing constructed it. The new **additive** command evaluates what the sandbox engine would decide for a hypothetical tool action and emits the active plan + decision + any matching grant.

```
decision: deny
risk: critical [absolute_path, out_of_workspace, write]
violation: [outside_workspace] /etc/hosts is outside the workspace …
policy: mode=enforce network=deny enforceWorkspace=true
backend: sandbox-exec (available=true)
```

`--json` emits the redacted snapshot contract. **The existing `sandbox policy` output is unchanged** — this is purely additive.

## 3. Coverage — `internal/providermodelcatalog` 48.9% → 79.5%

Targeted tests for the model predicates (`LooksLikeCodingModelID`, `modelMatchesProvider`), URL/label helpers (`defaultedOpenGatewayURL`, `modelSortLabel`), and the HTTP fetch layer (`fetchJSON`, `FetchModelsDev`, `FetchOpenGateway`, `FetchRemote` routing) via `httptest`. `cmd/zero` (a `main()` shim) and `browser.OpenURL` (an exec wrapper) are intentionally left to CI Smoke — their only logic seam (`openCommand`) is already covered.

## Verification

- `deadcode -test ./...`: truly-dead **15 → 14** (`ProviderState.Actions` wired); all detect/advice + sandbox snapshot builders are now production-reachable.
- Full gate green: `gofmt`, `go vet`, build, `staticcheck`, `go test ./... -race`.
- Both new commands smoke-tested in a built binary (the `providers detect` run found a real local Ollama).

No behavior changes to existing commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `zero providers detect` to report locally running model runtimes and provider onboarding “next step” actions, with `--json` output and updated help text.
  * Added `zero sandbox check` to evaluate sandbox policy decisions for a hypothetical request, with `--json` output and detailed text rendering.

* **Tests**
  * Added provider-detection tests (text + `--json`, including no API key leakage).
  * Added sandbox-check tests (output rendering, required tool flag, invalid flag handling, and grant-reason redaction).
  * Added model catalog/unit tests for selection, labeling, and remote fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->