### PR TITLE
feat: free out-of-the-box web (keyless Firecrawl default) + resilient MCP startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,40 @@ The model registry tracks each model's capabilities, context window, and cost �
 
 Every mutating tool routes through the permission policy **before** any side effect.
 
+### Web search & scraping (free, no API key)
+
+`web_fetch` is built in and always available: it pulls a single URL into clean
+markdown locally, with no third party. For **search**, JS-rendered scraping,
+whole-site crawls, PDF→markdown, and structured extraction, Zero ships the
+[Firecrawl](https://firecrawl.dev) **keyless** MCP server **enabled by default**, so
+web search and scraping work out of the box with **no setup and no API key** (1,000
+free credits/month). It is a normal MCP server, so you stay in control:
+
+```bash
+zero mcp tools list           # see the firecrawl_* tools it exposes
+zero mcp disable firecrawl    # turn it off — web_fetch stays as the local floor
+```
+
+- **Privacy / disclosure:** keyless requests route through `firecrawl.dev`. If you
+  prefer nothing leaves your machine, `zero mcp disable firecrawl` and rely on
+  `web_fetch`, or self-host below.
+- **Self-host (unlimited, private):** Firecrawl is open source (AGPL-3.0). Run your
+  own instance and override the default URL — Zero only *calls* it over the network,
+  so the AGPL never reaches into Zero's own code:
+  ```jsonc
+  // config.json
+  { "mcp": { "servers": { "firecrawl": { "type": "http", "url": "http://localhost:3002/v2/mcp" } } } }
+  ```
+- **Bring your own key (higher limits):** add an auth header over the default:
+  ```bash
+  zero mcp add firecrawl --type http --url https://mcp.firecrawl.dev/v2/mcp \
+    --header "Authorization: Bearer fc-your-key"
+  ```
+
+An MCP server that can't be reached at startup (e.g. Firecrawl on an offline
+machine) is **skipped with a warning, not fatal** — Zero still launches and the
+rest of its tools, including `web_fetch`, keep working.
+
 ### Extra write directories (`--add-dir`)
 
 Zero confines writes to the workspace by default. To let the agent write somewhere

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Gitlawb/zero/internal/plugins"
 	"github.com/Gitlawb/zero/internal/providerhealth"
 	"github.com/Gitlawb/zero/internal/providers"
+	"github.com/Gitlawb/zero/internal/redaction"
 	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/selfverify"
 	"github.com/Gitlawb/zero/internal/sessions"
@@ -70,11 +71,16 @@ type appDeps struct {
 
 type mcpToolRuntime interface {
 	Close() error
+	Skipped() []mcp.SkippedServer
 }
 
 type noopMCPRuntime struct{}
 
 func (noopMCPRuntime) Close() error {
+	return nil
+}
+
+func (noopMCPRuntime) Skipped() []mcp.SkippedServer {
 	return nil
 }
 
@@ -495,6 +501,12 @@ func runInteractiveTUIWithSetup(stderr io.Writer, deps appDeps, permissionMode a
 		return writeAppError(stderr, err.Error(), 1)
 	}
 	defer closeMCPRuntime(stderr, mcpRuntime)
+	// A server that could not be reached or validated is skipped, not fatal (one
+	// bad MCP server must not abort startup) — surface each so a missing tool set is
+	// explained rather than silently absent.
+	for _, skipped := range mcpRuntime.Skipped() {
+		fmt.Fprintf(stderr, "warning: MCP server %s unavailable, skipped: %s\n", skipped.Name, redaction.ErrorMessage(skipped.Err, redaction.Options{}))
+	}
 	// Make local plugins live: register their declared tools into the registry and
 	// collect their hooks + skill roots for the dispatcher and skill tool below.
 	// Done after specialist + MCP registration so plugin tools are part of the

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -715,6 +715,10 @@ func (fn closeFunc) Close() error {
 	return fn()
 }
 
+func (fn closeFunc) Skipped() []mcp.SkippedServer {
+	return nil
+}
+
 type toolCallingExecProvider struct {
 	toolCallID string
 	toolName   string

--- a/internal/cli/mcp_config.go
+++ b/internal/cli/mcp_config.go
@@ -697,11 +697,20 @@ func (cfg *mcpWritableConfig) setServerDisabled(name string, disabled bool) (boo
 		if err != nil {
 			return false, false, err
 		}
-		if !legacyFound {
+		switch {
+		case legacyFound:
+			raw = legacyRaw
+			found = true
+		case config.IsDefaultMCPServer(name):
+			// A built-in default server isn't written to the file until the user
+			// overrides it. Treat it as present with an empty base so disabling it
+			// writes a minimal {"disabled":true} entry that merges over the default —
+			// letting `zero mcp disable <default>` work even though it lives in code.
+			raw = nil
+			found = true
+		default:
 			return false, false, nil
 		}
-		raw = legacyRaw
-		found = true
 	}
 	var server map[string]json.RawMessage
 	if len(raw) > 0 && string(raw) != "null" {

--- a/internal/cli/mcp_default_test.go
+++ b/internal/cli/mcp_default_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+)
+
+// `zero mcp disable firecrawl` must work even though firecrawl is a built-in
+// default that is not written to the user's config file until overridden.
+func TestRunMCPDisableSeededFirecrawlDefault(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "zero", "config.json")
+	// A config with no firecrawl entry — the default lives in code, not the file.
+	writeMCPCommandRawConfig(t, configPath, `{"activeProvider":"fast"}`)
+
+	var out, errBuf bytes.Buffer
+	code := runWithDeps([]string{"mcp", "disable", "firecrawl", "--json"}, &out, &errBuf, appDeps{
+		userConfigPath: func() (string, error) { return configPath, nil },
+	})
+	if code != exitSuccess {
+		t.Fatalf("disable exit=%d stderr=%s", code, errBuf.String())
+	}
+	var payload struct {
+		ServerName string `json:"serverName"`
+		Disabled   bool   `json:"disabled"`
+		Changed    bool   `json:"changed"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode disable JSON: %v\n%s", err, out.String())
+	}
+	if payload.ServerName != "firecrawl" || !payload.Disabled || !payload.Changed {
+		t.Fatalf("disable payload = %#v, want firecrawl disabled+changed", payload)
+	}
+
+	// End-to-end: resolving that config now turns the default off.
+	cfg, err := config.ResolveMCP(config.ResolveOptions{UserConfigPath: configPath})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if !cfg.Servers["firecrawl"].Disabled {
+		t.Fatal("expected `mcp disable firecrawl` to turn the seeded default off in the resolved config")
+	}
+}

--- a/internal/config/mcp_defaults.go
+++ b/internal/config/mcp_defaults.go
@@ -1,0 +1,31 @@
+package config
+
+import "strings"
+
+// DefaultMCPServers returns the MCP servers Zero ships ENABLED by default so web
+// search and scraping work out of the box with no setup and no API key. They are
+// seeded before user/project config is merged (see ResolveMCP), so a user can
+// override any field — for example point firecrawl at a self-hosted instance, or
+// add an API-key header to lift the free-tier limit — or disable it entirely with
+// `zero mcp disable <name>` (which writes `"disabled": true`).
+//
+// Keyless Firecrawl routes requests through firecrawl.dev (1,000 free credits per
+// month, no account). Self-host Firecrawl (AGPL-3.0) for unlimited and private
+// use. Zero only calls it over the network, so Firecrawl's license never reaches
+// into Zero's own code.
+func DefaultMCPServers() map[string]MCPServerConfig {
+	return map[string]MCPServerConfig{
+		"firecrawl": {
+			Type: "http",
+			URL:  "https://mcp.firecrawl.dev/v2/mcp",
+		},
+	}
+}
+
+// IsDefaultMCPServer reports whether name is one of Zero's built-in default MCP
+// servers. The config commands use it so a default can be disabled/enabled even
+// though it is not written to the user's config file until overridden.
+func IsDefaultMCPServer(name string) bool {
+	_, ok := DefaultMCPServers()[strings.TrimSpace(name)]
+	return ok
+}

--- a/internal/config/mcp_defaults_test.go
+++ b/internal/config/mcp_defaults_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsDefaultMCPServer(t *testing.T) {
+	if !IsDefaultMCPServer("firecrawl") {
+		t.Fatal("firecrawl should be a built-in default")
+	}
+	if IsDefaultMCPServer("  firecrawl  ") == false {
+		t.Fatal("IsDefaultMCPServer should trim whitespace")
+	}
+	if IsDefaultMCPServer("not-a-default") {
+		t.Fatal("unknown server should not be a default")
+	}
+}
+
+func TestResolveMCPSeedsEnabledFirecrawlDefault(t *testing.T) {
+	cfg, err := ResolveMCP(ResolveOptions{})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl, ok := cfg.Servers["firecrawl"]
+	if !ok {
+		t.Fatal("expected the firecrawl default to be seeded with no user config")
+	}
+	if firecrawl.Type != "http" || firecrawl.URL != "https://mcp.firecrawl.dev/v2/mcp" {
+		t.Fatalf("unexpected firecrawl default: %#v", firecrawl)
+	}
+	if firecrawl.Disabled {
+		t.Fatal("the firecrawl default must be enabled out of the box")
+	}
+}
+
+func TestResolveMCPUserCanDisableDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"disabled":true}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if !cfg.Servers["firecrawl"].Disabled {
+		t.Fatal("a user must be able to disable the default by writing over it")
+	}
+}
+
+func TestResolveMCPUserCanOverrideDefaultURLKeepingOtherFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	// Point firecrawl at a self-hosted instance; the default's Type must survive.
+	if err := os.WriteFile(path, []byte(`{"mcp":{"servers":{"firecrawl":{"url":"http://localhost:3002/mcp"}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveMCP(ResolveOptions{UserConfigPath: path})
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	firecrawl := cfg.Servers["firecrawl"]
+	if firecrawl.URL != "http://localhost:3002/mcp" {
+		t.Fatalf("user override of the default URL did not apply: %#v", firecrawl)
+	}
+	if firecrawl.Type != "http" {
+		t.Fatalf("override should keep the default's other fields (type), got %#v", firecrawl)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -108,7 +108,10 @@ func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 }
 
 func ResolveMCP(options ResolveOptions) (MCPConfig, error) {
-	cfg := FileConfig{}
+	// Seed Zero's built-in default MCP servers (e.g. keyless Firecrawl for free,
+	// no-setup web search/scrape) BEFORE merging user/project config, so the user
+	// can override any field or disable a default by writing over it.
+	cfg := FileConfig{MCP: MCPConfig{Servers: DefaultMCPServers()}}
 
 	for _, path := range []string{options.UserConfigPath, options.ProjectConfigPath} {
 		if path == "" {

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -17,10 +17,29 @@ type RegisterOptions struct {
 	ClientFactory   func(context.Context, Server) (ToolClient, error)
 }
 
+// SkippedServer records an MCP server that was not registered because it could
+// not be reached or its tools could not be validated. Registration is
+// best-effort per server: one unreachable server is skipped (and reported here)
+// rather than aborting startup or disabling the others.
+type SkippedServer struct {
+	Name string
+	Err  error
+}
+
 type Runtime struct {
 	clients []ToolClient
+	skipped []SkippedServer
 	once    sync.Once
 	err     error
+}
+
+// Skipped returns the servers that were skipped during registration (unreachable
+// or invalid), so the caller can warn the user without failing the launch.
+func (runtime *Runtime) Skipped() []SkippedServer {
+	if runtime == nil {
+		return nil
+	}
+	return runtime.skipped
 }
 
 var unsafeToolNameChars = regexp.MustCompile(`[^A-Za-z0-9_]+`)
@@ -45,52 +64,82 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 		}
 	}
 
-	// Registration is atomic per call: validate and stage every server's tools
-	// first, then commit to the caller's registry only once they all succeed. If a
-	// LATER server fails mid-registration, nothing was committed, so the registry
-	// never ends up holding dead tools that point at a (now-closed) client for an
-	// earlier server.
+	// Registration is best-effort across servers but atomic within a server: each
+	// server is connected and ALL of its tools validated before any are committed,
+	// so a server never contributes a partial tool set (no tools pointing at a
+	// now-closed client). A server that cannot be reached, lists no valid tools, or
+	// conflicts with an already-committed tool is SKIPPED — recorded in
+	// runtime.skipped, not fatal — so one unreachable MCP server can't abort startup
+	// or disable the others. The conflict check still spans the registry plus every
+	// tool committed by an earlier server in this call.
 	staged := make([]registryTool, 0)
 	stagedNames := make(map[string]struct{})
 	for _, server := range servers {
-		client, err := factory(ctx, server)
-		if err != nil {
-			_ = runtime.Close()
-			return nil, err
+		client, serverTools, stageErr := stageServer(ctx, registry, factory, server, options, stagedNames)
+		if stageErr != nil {
+			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: stageErr})
+			continue
 		}
 		runtime.clients = append(runtime.clients, client)
-
-		remoteTools, err := client.ListTools(ctx)
-		if err != nil {
-			_ = runtime.Close()
-			return nil, fmt.Errorf("list MCP tools for %s: %w", server.Name, err)
-		}
-		for _, remote := range remoteTools {
-			if strings.TrimSpace(remote.Name) == "" {
-				_ = runtime.Close()
-				return nil, fmt.Errorf("MCP server %s returned a tool without a name", server.Name)
-			}
-			tool := newRegistryTool(server, remote, client, options)
-			// Conflict detection spans both the existing registry and tools staged so
-			// far in this call (two MCP tools whose names collapse to the same
-			// sanitized name conflict even though neither is in the registry yet).
-			if existing, ok := registry.Get(tool.Name()); ok {
-				_ = runtime.Close()
-				return nil, fmt.Errorf("MCP tool %s from %s conflicts with existing tool %s", remote.Name, server.Name, existing.Name())
-			}
-			if _, ok := stagedNames[tool.Name()]; ok {
-				_ = runtime.Close()
-				return nil, fmt.Errorf("MCP tool %s from %s conflicts with another MCP tool named %s", remote.Name, server.Name, tool.Name())
-			}
+		for _, tool := range serverTools {
 			stagedNames[tool.Name()] = struct{}{}
 			staged = append(staged, tool)
 		}
 	}
-	// Every server succeeded — commit the staged tools to the registry.
+	// Commit the tools of every server that fully validated.
 	for _, tool := range staged {
 		registry.Register(tool)
 	}
 	return runtime, nil
+}
+
+// stageServer connects to one server and validates ALL of its tools against the
+// registry and the names already committed by earlier servers. It returns the
+// client and the server's tools only when every tool is named and conflict-free;
+// on any failure it closes the client and returns an error, so the caller skips
+// the whole server (per-server atomicity — never a partial tool set, never a
+// dangling tool on a closed client).
+func stageServer(
+	ctx context.Context,
+	registry *tools.Registry,
+	factory func(context.Context, Server) (ToolClient, error),
+	server Server,
+	options RegisterOptions,
+	stagedNames map[string]struct{},
+) (ToolClient, []registryTool, error) {
+	client, err := factory(ctx, server)
+	if err != nil {
+		return nil, nil, err
+	}
+	remoteTools, err := client.ListTools(ctx)
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, fmt.Errorf("list MCP tools for %s: %w", server.Name, err)
+	}
+	serverTools := make([]registryTool, 0, len(remoteTools))
+	localNames := make(map[string]struct{})
+	for _, remote := range remoteTools {
+		if strings.TrimSpace(remote.Name) == "" {
+			_ = client.Close()
+			return nil, nil, fmt.Errorf("MCP server %s returned a tool without a name", server.Name)
+		}
+		tool := newRegistryTool(server, remote, client, options)
+		if existing, ok := registry.Get(tool.Name()); ok {
+			_ = client.Close()
+			return nil, nil, fmt.Errorf("MCP tool %s from %s conflicts with existing tool %s", remote.Name, server.Name, existing.Name())
+		}
+		if _, ok := stagedNames[tool.Name()]; ok {
+			_ = client.Close()
+			return nil, nil, fmt.Errorf("MCP tool %s from %s conflicts with another MCP tool named %s", remote.Name, server.Name, tool.Name())
+		}
+		if _, ok := localNames[tool.Name()]; ok {
+			_ = client.Close()
+			return nil, nil, fmt.Errorf("MCP tool %s from %s conflicts with another tool from the same server", remote.Name, server.Name)
+		}
+		localNames[tool.Name()] = struct{}{}
+		serverTools = append(serverTools, tool)
+	}
+	return client, serverTools, nil
 }
 
 func (runtime *Runtime) Close() error {

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -6,15 +6,26 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
+// defaultConnectTimeout bounds how long startup waits for ONE MCP server to
+// connect and list its tools. A server that exceeds it is abandoned and skipped
+// so a slow or unreachable server (e.g. a hosted endpoint blocked by the local
+// network) cannot delay the first model response. Servers connect concurrently,
+// so total startup cost is the slowest reachable server, not the sum.
+const defaultConnectTimeout = 8 * time.Second
+
 type RegisterOptions struct {
 	PermissionStore *PermissionStore
 	Autonomy        PermissionAutonomy
 	ClientFactory   func(context.Context, Server) (ToolClient, error)
+	// ConnectTimeout bounds the per-server connect+list at startup. Zero uses
+	// defaultConnectTimeout.
+	ConnectTimeout time.Duration
 }
 
 // SkippedServer records an MCP server that was not registered because it could
@@ -28,6 +39,11 @@ type SkippedServer struct {
 
 type Runtime struct {
 	clients []ToolClient
+	// cancels releases the per-server connect contexts of the clients we KEPT.
+	// A stdio server's subprocess is tied to its context, so the context must
+	// stay live for the session and be cancelled only at Close (after the client
+	// is closed). Same length/order as clients is not required.
+	cancels []context.CancelFunc
 	skipped []SkippedServer
 	once    sync.Once
 	err     error
@@ -64,49 +80,105 @@ func RegisterTools(ctx context.Context, registry *tools.Registry, cfg config.MCP
 		}
 	}
 
-	// Registration is best-effort across servers but atomic within a server: each
-	// server is connected and ALL of its tools validated before any are committed,
-	// so a server never contributes a partial tool set (no tools pointing at a
-	// now-closed client). A server that cannot be reached, lists no valid tools, or
-	// conflicts with an already-committed tool is SKIPPED — recorded in
-	// runtime.skipped, not fatal — so one unreachable MCP server can't abort startup
-	// or disable the others. The conflict check still spans the registry plus every
-	// tool committed by an earlier server in this call.
+	timeout := options.ConnectTimeout
+	if timeout <= 0 {
+		timeout = defaultConnectTimeout
+	}
+
+	// Connect every server CONCURRENTLY: connect + list-tools is network/process
+	// I/O, so connecting serially makes startup wait for the SUM of all servers —
+	// one slow or unreachable server would block every other server AND the first
+	// model response. Each server gets its own cancelable context bounded by the
+	// startup timeout; a server that does not connect + list in time is abandoned
+	// (its context cancelled to tear down the half-open connection/subprocess) and
+	// recorded as skipped. The concurrent phase does ONLY I/O and touches no shared
+	// state; all validation, conflict detection, and registration happen in the
+	// deterministic serial phase below, so the result is identical regardless of
+	// completion order.
+	type connectResult struct {
+		client ToolClient
+		remote []RemoteTool
+		cancel context.CancelFunc
+		err    error
+	}
+	results := make([]connectResult, len(servers))
+	var wg sync.WaitGroup
+	for index := range servers {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			server := servers[index]
+			serverCtx, cancel := context.WithCancel(ctx)
+			done := make(chan connectResult, 1)
+			go func() {
+				client, remote, err := connectAndList(serverCtx, factory, server)
+				done <- connectResult{client: client, remote: remote, err: err}
+			}()
+			select {
+			case res := <-done:
+				if res.err != nil {
+					cancel() // failed: nothing to keep
+				} else {
+					res.cancel = cancel // keep the context alive; released at Close
+				}
+				results[index] = res
+			case <-time.After(timeout):
+				cancel() // abandon the slow connect: tears down the conn/subprocess
+				// Reap the goroutine + any partial client in the background so a
+				// slow server never blocks startup.
+				go func() {
+					if res := <-done; res.client != nil {
+						_ = res.client.Close()
+					}
+				}()
+				results[index] = connectResult{err: fmt.Errorf("connect timed out after %s", timeout)}
+			}
+		}(index)
+	}
+	wg.Wait()
+
+	// Serial, deterministic commit in server order. Building tools reads the
+	// permission store and the registry, so it stays single-goroutine. A server is
+	// best-effort: one that failed to connect, timed out, returned a nameless tool,
+	// or conflicts with an already-committed tool is SKIPPED (recorded, not fatal),
+	// and still contributes its tools all-or-none. The conflict check spans the
+	// registry plus every tool committed by an earlier server.
 	staged := make([]registryTool, 0)
 	stagedNames := make(map[string]struct{})
-	for _, server := range servers {
-		client, serverTools, stageErr := stageServer(ctx, registry, factory, server, options, stagedNames)
-		if stageErr != nil {
-			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: stageErr})
+	for index, server := range servers {
+		res := results[index]
+		if res.err != nil {
+			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: res.err})
 			continue
 		}
-		runtime.clients = append(runtime.clients, client)
+		serverTools, validateErr := buildServerTools(registry, server, res.remote, res.client, options, stagedNames)
+		if validateErr != nil {
+			if res.cancel != nil {
+				res.cancel()
+			}
+			_ = res.client.Close()
+			runtime.skipped = append(runtime.skipped, SkippedServer{Name: server.Name, Err: validateErr})
+			continue
+		}
+		runtime.clients = append(runtime.clients, res.client)
+		if res.cancel != nil {
+			runtime.cancels = append(runtime.cancels, res.cancel)
+		}
 		for _, tool := range serverTools {
 			stagedNames[tool.Name()] = struct{}{}
 			staged = append(staged, tool)
 		}
 	}
-	// Commit the tools of every server that fully validated.
 	for _, tool := range staged {
 		registry.Register(tool)
 	}
 	return runtime, nil
 }
 
-// stageServer connects to one server and validates ALL of its tools against the
-// registry and the names already committed by earlier servers. It returns the
-// client and the server's tools only when every tool is named and conflict-free;
-// on any failure it closes the client and returns an error, so the caller skips
-// the whole server (per-server atomicity — never a partial tool set, never a
-// dangling tool on a closed client).
-func stageServer(
-	ctx context.Context,
-	registry *tools.Registry,
-	factory func(context.Context, Server) (ToolClient, error),
-	server Server,
-	options RegisterOptions,
-	stagedNames map[string]struct{},
-) (ToolClient, []registryTool, error) {
+// connectAndList connects to one server and lists its tools. It does ONLY I/O
+// (no registry, permission-store, or other shared state), so it is safe to run
+// concurrently for every server. On a list error it closes the client.
+func connectAndList(ctx context.Context, factory func(context.Context, Server) (ToolClient, error), server Server) (ToolClient, []RemoteTool, error) {
 	client, err := factory(ctx, server)
 	if err != nil {
 		return nil, nil, err
@@ -116,30 +188,35 @@ func stageServer(
 		_ = client.Close()
 		return nil, nil, fmt.Errorf("list MCP tools for %s: %w", server.Name, err)
 	}
+	return client, remoteTools, nil
+}
+
+// buildServerTools validates a server's remote tools against the registry and the
+// names already committed by earlier servers, returning the server's tools only
+// when every one is named and conflict-free. It runs in the serial commit phase
+// (single goroutine), so its registry and permission-store reads are race-free.
+// On error the caller closes the client (it owns the result), so this never does.
+func buildServerTools(registry *tools.Registry, server Server, remoteTools []RemoteTool, client ToolClient, options RegisterOptions, stagedNames map[string]struct{}) ([]registryTool, error) {
 	serverTools := make([]registryTool, 0, len(remoteTools))
 	localNames := make(map[string]struct{})
 	for _, remote := range remoteTools {
 		if strings.TrimSpace(remote.Name) == "" {
-			_ = client.Close()
-			return nil, nil, fmt.Errorf("MCP server %s returned a tool without a name", server.Name)
+			return nil, fmt.Errorf("MCP server %s returned a tool without a name", server.Name)
 		}
 		tool := newRegistryTool(server, remote, client, options)
 		if existing, ok := registry.Get(tool.Name()); ok {
-			_ = client.Close()
-			return nil, nil, fmt.Errorf("MCP tool %s from %s conflicts with existing tool %s", remote.Name, server.Name, existing.Name())
+			return nil, fmt.Errorf("MCP tool %s from %s conflicts with existing tool %s", remote.Name, server.Name, existing.Name())
 		}
 		if _, ok := stagedNames[tool.Name()]; ok {
-			_ = client.Close()
-			return nil, nil, fmt.Errorf("MCP tool %s from %s conflicts with another MCP tool named %s", remote.Name, server.Name, tool.Name())
+			return nil, fmt.Errorf("MCP tool %s from %s conflicts with another MCP tool named %s", remote.Name, server.Name, tool.Name())
 		}
 		if _, ok := localNames[tool.Name()]; ok {
-			_ = client.Close()
-			return nil, nil, fmt.Errorf("MCP tool %s from %s conflicts with another tool from the same server", remote.Name, server.Name)
+			return nil, fmt.Errorf("MCP tool %s from %s conflicts with another tool from the same server", remote.Name, server.Name)
 		}
 		localNames[tool.Name()] = struct{}{}
 		serverTools = append(serverTools, tool)
 	}
-	return client, serverTools, nil
+	return serverTools, nil
 }
 
 func (runtime *Runtime) Close() error {
@@ -151,6 +228,12 @@ func (runtime *Runtime) Close() error {
 			if err := client.Close(); err != nil && runtime.err == nil {
 				runtime.err = err
 			}
+		}
+		// Release the kept servers' connect contexts AFTER closing the clients: a
+		// stdio subprocess is already terminated by Close, so cancelling is then a
+		// no-op; it frees the context (and any tied subprocess) either way.
+		for _, cancel := range runtime.cancels {
+			cancel()
 		}
 	})
 	return runtime.err

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -118,14 +118,15 @@ func TestRegisterToolsMarksPersistentlyApprovedToolsAllow(t *testing.T) {
 	}
 }
 
-func TestRegisterToolsRollsBackEarlierServerToolsWhenLaterServerFails(t *testing.T) {
+func TestRegisterToolsSkipsUnreachableServerAndKeepsOthers(t *testing.T) {
 	// NormalizeConfig sorts server names, so "alpha" registers before "zebra".
-	// "zebra" fails mid-registration; registration must be atomic, so "alpha"'s
-	// tools must NOT be left dangling in the caller's registry.
+	// "zebra" is unreachable; it must be SKIPPED (recorded in Skipped()), not fatal,
+	// and "alpha"'s tools must still register — one bad server can't disable the rest
+	// or abort startup. A server still contributes its tools all-or-none.
 	registry := tools.NewRegistry()
 	alphaClient := &fakeToolClient{listed: []RemoteTool{{Name: "lookup", Description: "Lookup documentation"}}}
 
-	_, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
 		"alpha": {Type: "stdio", Command: "alpha-mcp"},
 		"zebra": {Type: "stdio", Command: "zebra-mcp"},
 	}}, RegisterOptions{
@@ -136,21 +137,29 @@ func TestRegisterToolsRollsBackEarlierServerToolsWhenLaterServerFails(t *testing
 			return alphaClient, nil
 		},
 	})
-	if err == nil {
-		t.Fatal("expected RegisterTools to fail when a later server fails")
+	if err != nil {
+		t.Fatalf("RegisterTools returned error, want a skip: %v", err)
 	}
-	if _, ok := registry.Get("mcp_alpha_lookup"); ok {
-		t.Fatal("expected earlier server's tools to be rolled back when a later server fails")
+	defer runtime.Close()
+	if _, ok := registry.Get("mcp_alpha_lookup"); !ok {
+		t.Fatal("expected the reachable server's tools to register when another is skipped")
+	}
+	skipped := runtime.Skipped()
+	if len(skipped) != 1 || skipped[0].Name != "zebra" {
+		t.Fatalf("Skipped() = %#v, want exactly one entry for zebra", skipped)
+	}
+	if skipped[0].Err == nil {
+		t.Fatal("expected the skipped server to record why it was skipped")
 	}
 }
 
-func TestRegisterToolsPreservesPriorRegistryStateOnFailure(t *testing.T) {
-	// A tool that predates the MCP registration must survive a failed RegisterTools
-	// call: rollback removes only what this call added.
+func TestRegisterToolsKeepsPriorStateAndReachableServersWhenOneIsSkipped(t *testing.T) {
+	// A tool that predates registration must survive, the reachable server's tools
+	// must register, and the unreachable server is skipped (recorded), not fatal.
 	registry := tools.NewRegistry()
 	registry.Register(&fakePreexistingTool{name: "preexisting"})
 
-	_, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
 		"alpha": {Type: "stdio", Command: "alpha-mcp"},
 		"zebra": {Type: "stdio", Command: "zebra-mcp"},
 	}}, RegisterOptions{
@@ -161,14 +170,18 @@ func TestRegisterToolsPreservesPriorRegistryStateOnFailure(t *testing.T) {
 			return &fakeToolClient{listed: []RemoteTool{{Name: "lookup"}}}, nil
 		},
 	})
-	if err == nil {
-		t.Fatal("expected RegisterTools to fail when a later server fails")
+	if err != nil {
+		t.Fatalf("RegisterTools returned error, want a skip: %v", err)
 	}
+	defer runtime.Close()
 	if _, ok := registry.Get("preexisting"); !ok {
-		t.Fatal("expected pre-existing tool to survive a failed MCP registration")
+		t.Fatal("expected the pre-existing tool to survive registration")
 	}
-	if _, ok := registry.Get("mcp_alpha_lookup"); ok {
-		t.Fatal("expected the failed call to add no MCP tools")
+	if _, ok := registry.Get("mcp_alpha_lookup"); !ok {
+		t.Fatal("expected the reachable server's tools to register")
+	}
+	if skipped := runtime.Skipped(); len(skipped) != 1 || skipped[0].Name != "zebra" {
+		t.Fatalf("Skipped() = %#v, want exactly one entry for zebra", skipped)
 	}
 }
 

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -185,6 +185,41 @@ func TestRegisterToolsKeepsPriorStateAndReachableServersWhenOneIsSkipped(t *test
 	}
 }
 
+func TestRegisterToolsSkipsServerThatExceedsConnectTimeout(t *testing.T) {
+	// A slow server must not block startup: it is abandoned after ConnectTimeout
+	// and skipped, while a fast server registers normally. This is the latency fix
+	// — one unreachable server can't hold up the first response.
+	registry := tools.NewRegistry()
+	fastClient := &fakeToolClient{listed: []RemoteTool{{Name: "lookup", Description: "fast"}}}
+
+	runtime, err := RegisterTools(context.Background(), registry, config.MCPConfig{Servers: map[string]config.MCPServerConfig{
+		"fast": {Type: "stdio", Command: "fast-mcp"},
+		"slow": {Type: "stdio", Command: "slow-mcp"},
+	}}, RegisterOptions{
+		ConnectTimeout: 50 * time.Millisecond,
+		ClientFactory: func(ctx context.Context, server Server) (ToolClient, error) {
+			if server.Name == "slow" {
+				// Block past the timeout, honoring ctx cancellation so the abandoned
+				// connect tears down cleanly instead of leaking.
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}
+			return fastClient, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RegisterTools error: %v", err)
+	}
+	defer runtime.Close()
+	if _, ok := registry.Get("mcp_fast_lookup"); !ok {
+		t.Fatal("expected the fast server's tools to register despite the slow one timing out")
+	}
+	skipped := runtime.Skipped()
+	if len(skipped) != 1 || skipped[0].Name != "slow" {
+		t.Fatalf("Skipped() = %#v, want exactly one entry for slow", skipped)
+	}
+}
+
 func TestRegistryToolIsDeferredEligible(t *testing.T) {
 	client := &fakeToolClient{}
 	tool := newRegistryTool(


### PR DESCRIPTION
## Summary

Free, out-of-the-box **web search + scraping** for open-source users — no API key, no setup — plus a robustness fix that the default depends on.

Verified live: `mcp check` against the keyless endpoint returns **25 tools, no key**, and a built binary shows `firecrawl [http] enabled` on first run.

## 1. `fix(mcp)`: skip an unreachable MCP server instead of aborting startup

`RegisterTools` connected to every server eagerly and failed the **whole batch** if any one couldn't be reached or list its tools — and the caller **aborts startup with exit 1** on that error. So a single unreachable MCP server prevented `zero` from launching at all and disabled every other working server.

Now registration is **best-effort across servers but atomic within a server**: each server's tools are validated as a unit before anything commits, and a server that can't be connected, returns a nameless tool, or conflicts is **skipped** (recorded on `Runtime.Skipped()`), not fatal. The caller surfaces each skip as a warning and keeps launching. The "no dead tools" / no-partial-tool-set guarantees are preserved.

This is a real robustness fix on its own — one flaky MCP server should never break `zero`'s startup.

## 2. `feat(mcp)`: keyless Firecrawl as a default web server

[Firecrawl just launched **Keyless**](https://www.firecrawl.dev/blog/firecrawl-keyless-launch): a hosted MCP at `https://mcp.firecrawl.dev/v2/mcp` with 1,000 free credits/month and no account. This seeds it **enabled by default** in `ResolveMCP` (before user/project config merges), so web search, JS-rendered scraping, crawl, PDF→markdown, and structured extraction work with zero setup.

You stay in control:

```bash
zero mcp tools list           # the firecrawl_* tools
zero mcp disable firecrawl    # off-switch — works even though the default lives in code
```

- The built-in `web_fetch` tool remains the **always-local floor** (no third party).
- Any field is overridable: point at a **self-hosted** Firecrawl, or add a **BYO-key** header for higher limits.
- **License:** Firecrawl is AGPL-3.0, but `zero` only *calls* it over the network — that's not linking/embedding, so the AGPL never reaches `zero`'s code. (SDKs are MIT regardless.)
- **Privacy:** keyless routes through `firecrawl.dev`; the README discloses this and documents disable/self-host.

### Why default-on is now safe
On an offline/blocked network the default would otherwise hang or break startup. Part 1 makes it **degrade gracefully**: the server is skipped with a warning and `web_fetch` keeps working. (`zero mcp disable firecrawl` writes an override even though the default isn't in the config file — the disable path now recognizes built-in defaults.)

## Tests
- `internal/mcp`: skip-and-keep-others + prior-state-preserved (the two old fail-hard tests rewritten to the new skip semantics).
- `internal/config`: default seeded enabled; user can disable; user can override the URL keeping other fields; `IsDefaultMCPServer`.
- `internal/cli`: `zero mcp disable firecrawl` turns the seeded default off end-to-end.

Full gate green: gofmt, `go vet`, build, `staticcheck`, `go test ./... -race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added built-in Firecrawl web search & scraping (keyless, no setup needed).
  * Introduced `zero mcp` commands to list and disable MCP servers.

* **Bug Fixes**
  * Unreachable/invalid MCP servers are now skipped at startup (non-fatal), with warnings so other tools keep working.
  * Disabling the built-in Firecrawl default now works correctly even if no prior config entry exists.

* **Documentation**
  * Updated the guide with keyless privacy disclosures, self-hosting/auth options, and how to manage Firecrawl.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->