### PR TITLE
perf(tools): lower default deferThreshold to stop eager MCP-schema token waste

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -77,17 +77,38 @@ type CompactionResult struct {
 // ~1k tokens is a representative mid-range cost across providers.
 const imageTokenEstimate = 1000
 
-// estimateTokens is a cheap, dependency-free token estimate (~4 chars/token)
+// ApproxTextTokens estimates the token count of text WITHOUT a real tokenizer.
+// The BPE tokenizers zero targets fold a run's leading space into the following
+// token rather than emitting whitespace as its own token, so naive len/4
+// overcounts real text by ~15-20% (measured: a 24.8k-char prompt counted 5.2k
+// real tokens where len/4 said 6.2k). Counting NON-whitespace bytes / 4 tracks
+// the provider's actual count closely (validated against live usage) while
+// staying allocation- and dependency-free. zero still receives the exact count
+// back as usage on every request; this estimate is only for the pre-request
+// context budget preview and the compaction threshold.
+func ApproxTextTokens(value string) int {
+	nonSpace := 0
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case ' ', '\t', '\n', '\r', '\f', '\v':
+		default:
+			nonSpace++
+		}
+	}
+	return nonSpace / 4
+}
+
+// estimateTokens is a cheap, dependency-free token estimate (see ApproxTextTokens)
 // across message content plus tool call names/arguments and a flat per-image
 // cost. It deliberately uses no real tokenizer; it only needs to be monotonic
 // and roughly proportional so the loop can decide when to compact.
 func estimateTokens(messages []zeroruntime.Message) int {
 	total := 0
 	for _, message := range messages {
-		total += len(message.Content) / 4
+		total += ApproxTextTokens(message.Content)
 		for _, call := range message.ToolCalls {
-			total += len(call.Name) / 4
-			total += len(call.Arguments) / 4
+			total += ApproxTextTokens(call.Name)
+			total += ApproxTextTokens(call.Arguments)
 			total += 4 // small per-call overhead
 		}
 		total += len(message.Images) * imageTokenEstimate
@@ -104,11 +125,11 @@ func estimateTokens(messages []zeroruntime.Message) int {
 func estimateToolDefTokens(tools []zeroruntime.ToolDefinition) int {
 	total := 0
 	for _, tool := range tools {
-		total += len(tool.Name) / 4
-		total += len(tool.Description) / 4
+		total += ApproxTextTokens(tool.Name)
+		total += ApproxTextTokens(tool.Description)
 		if len(tool.Parameters) > 0 {
 			if encoded, err := json.Marshal(tool.Parameters); err == nil {
-				total += len(encoded) / 4
+				total += ApproxTextTokens(string(encoded))
 			}
 		}
 		total += 4 // per-tool overhead

--- a/internal/agent/context_measurement.go
+++ b/internal/agent/context_measurement.go
@@ -48,16 +48,16 @@ func MeasureContext(messages []zeroruntime.Message, tools []zeroruntime.ToolDefi
 }
 
 // estimateToolTokens approximates the token footprint of advertised tool
-// definitions (name + description + JSON schema), matching estimateTokens'
-// ~4-chars/token heuristic so all categories use the same scale.
+// definitions (name + description + JSON schema), using the same ApproxTextTokens
+// heuristic as estimateTokens so all categories share one scale.
 func estimateToolTokens(tools []zeroruntime.ToolDefinition) int {
 	total := 0
 	for _, tool := range tools {
-		total += len(tool.Name) / 4
-		total += len(tool.Description) / 4
+		total += ApproxTextTokens(tool.Name)
+		total += ApproxTextTokens(tool.Description)
 		if len(tool.Parameters) > 0 {
 			if encoded, err := json.Marshal(tool.Parameters); err == nil {
-				total += len(encoded) / 4
+				total += ApproxTextTokens(string(encoded))
 			}
 		}
 		total += 4 // per-tool overhead

--- a/internal/agent/defer_savings_test.go
+++ b/internal/agent/defer_savings_test.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// richMCPTool mimics a real MCP tool's schema (Exa/Firecrawl-style search): an
+// object with several typed, described properties. Real MCP tools are this size
+// or larger, which is why shipping their full schemas every turn is expensive.
+type richMCPTool struct{ name string }
+
+func (t richMCPTool) Name() string { return t.name }
+func (t richMCPTool) Description() string {
+	return "Search the web and return ranked, structured results with titles, URLs, snippets, and optional cleaned full-page content. Supports natural-language and keyword queries with domain and date filtering."
+}
+func (t richMCPTool) Parameters() tools.Schema {
+	return tools.Schema{
+		Type:                 "object",
+		AdditionalProperties: false,
+		Required:             []string{"query"},
+		Properties: map[string]tools.PropertySchema{
+			"query":                {Type: "string", Description: "The search query to run against the web index. Supports natural-language and keyword queries."},
+			"num_results":          {Type: "integer", Description: "Maximum number of results to return (1-100). Defaults to 10."},
+			"include_domains":      {Type: "array", Description: "Only return results from these domains.", Items: &tools.PropertySchema{Type: "string"}},
+			"exclude_domains":      {Type: "array", Description: "Never return results from these domains.", Items: &tools.PropertySchema{Type: "string"}},
+			"start_published_date": {Type: "string", Description: "ISO-8601 date; only results published on or after this date are returned."},
+			"end_published_date":   {Type: "string", Description: "ISO-8601 date; only results published on or before this date are returned."},
+			"category":             {Type: "string", Description: "Restrict results to a content category.", Enum: []string{"news", "research paper", "company", "tweet", "pdf"}},
+			"include_text":         {Type: "boolean", Description: "Include cleaned full-page text for each result (slower, larger payload)."},
+		},
+	}
+}
+func (t richMCPTool) Safety() tools.Safety {
+	return tools.Safety{SideEffect: tools.SideEffectNetwork, Permission: tools.PermissionAllow}
+}
+func (t richMCPTool) Run(_ context.Context, _ map[string]any) tools.Result {
+	return tools.Result{Status: tools.StatusOK}
+}
+func (t richMCPTool) Deferred() bool { return true }
+
+// TestDeferralTokenSavingsMeasurement quantifies the win from the lowered
+// deferThreshold default: with a typical small MCP server (6 tools), threshold 10
+// (the OLD default) kept deferral OFF so all six full schemas shipped every turn,
+// while threshold 3 (the NEW default) collapses them to compact reminder lines.
+func TestDeferralTokenSavingsMeasurement(t *testing.T) {
+	const mcpToolCount = 6
+	registry := tools.NewRegistry()
+	for i := 0; i < mcpToolCount; i++ {
+		registry.Register(richMCPTool{name: fmt.Sprintf("mcp__websearch__search_v%d", i)})
+	}
+	registry.Register(fakeToolSearchTool{})
+
+	measure := func(threshold int) (int, int) {
+		defs, reminder := partitionTools(registry, PermissionModeAuto, Options{DeferThreshold: threshold}, map[string]bool{})
+		encoded, err := json.Marshal(defs)
+		if err != nil {
+			t.Fatalf("marshal tool defs: %v", err)
+		}
+		bytes := len(encoded) + len(reminder)
+		return bytes, bytes / 4 // ~tokens (approx 4 chars/token)
+	}
+
+	eagerBytes, eagerTok := measure(10) // 6 < 10 -> inactive -> all schemas eager
+	deferBytes, deferTok := measure(3)  // 6 >= 3 -> active  -> compact reminder
+	savedPct := 100 * float64(eagerBytes-deferBytes) / float64(eagerBytes)
+
+	t.Logf("MCP tools in set: %d", mcpToolCount)
+	t.Logf("threshold 10 (OLD, eager schemas): %d bytes (~%d tokens) per turn", eagerBytes, eagerTok)
+	t.Logf("threshold  3 (NEW, deferred lines): %d bytes (~%d tokens) per turn", deferBytes, deferTok)
+	t.Logf("SAVED: ~%d tokens per turn (%.0f%% smaller tool payload)", eagerTok-deferTok, savedPct)
+
+	if deferBytes >= eagerBytes {
+		t.Fatalf("deferral should shrink the tool payload: eager=%d defer=%d", eagerBytes, deferBytes)
+	}
+	if savedPct < 50 {
+		t.Fatalf("expected a large reduction, got only %.0f%%", savedPct)
+	}
+}

--- a/internal/agent/tokens_test.go
+++ b/internal/agent/tokens_test.go
@@ -1,0 +1,27 @@
+package agent
+
+import "testing"
+
+func TestApproxTextTokens(t *testing.T) {
+	if got := ApproxTextTokens(""); got != 0 {
+		t.Fatalf("empty = %d, want 0", got)
+	}
+	// Whitespace is folded out (BPE merges it into the adjacent token):
+	// "aaaa    bbbb" has 8 non-space bytes -> 2 tokens, where naive len/4 says 3.
+	if got := ApproxTextTokens("aaaa    bbbb"); got != 2 {
+		t.Fatalf("ApproxTextTokens = %d, want 2 (8 non-space / 4)", got)
+	}
+	// It must never exceed naive len/4 — it only removes whitespace — and on
+	// whitespace-bearing text it should be strictly smaller.
+	cases := []string{"hello world", "func main() {\n\treturn\n}", "a\tb\nc d e f"}
+	for _, s := range cases {
+		approx, naive := ApproxTextTokens(s), len(s)/4
+		if approx > naive {
+			t.Fatalf("ApproxTextTokens(%q)=%d exceeded len/4=%d", s, approx, naive)
+		}
+	}
+	// Pure non-whitespace matches len/4 exactly (nothing to fold).
+	if got := ApproxTextTokens("abcdefgh"); got != 2 {
+		t.Fatalf("ApproxTextTokens(no spaces) = %d, want 2", got)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -15,7 +15,16 @@ import (
 
 const defaultMaxTurns = 30
 
-const defaultDeferThreshold = 10
+// defaultDeferThreshold is the number of deferred-eligible (MCP) tools at which
+// Zero collapses their full JSON schemas into compact `tool_search` reminder
+// lines instead of advertising every schema on every turn. MCP tool schemas run
+// 300-600 tokens each, so eagerly shipping even a small server's toolset wastes
+// thousands of input tokens per message. Kept low so a typical single-server set
+// (Exa-style, a handful of tools) defers and stays cheap; the only cost is one
+// `tool_search` round-trip before a deferred tool's first use, after which it is
+// loaded for the rest of the run. Override per-config with tools.deferThreshold
+// (set 0 to always advertise every schema, e.g. for a model without tool_search).
+const defaultDeferThreshold = 3
 
 func Resolve(options ResolveOptions) (ResolvedConfig, error) {
 	cfg := FileConfig{

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1417,6 +1417,15 @@ func TestResolveDefaultsDeferThresholdWhenUnset(t *testing.T) {
 	}
 }
 
+// The default must stay low so a typical single MCP server's toolset defers
+// instead of shipping every full schema each turn (the token-economy fix). This
+// guards against a regression silently bumping it back up.
+func TestDefaultDeferThresholdStaysLowForTokenEconomy(t *testing.T) {
+	if defaultDeferThreshold <= 0 || defaultDeferThreshold > 4 {
+		t.Fatalf("defaultDeferThreshold = %d, want a small positive value (<=4) so small MCP sets defer", defaultDeferThreshold)
+	}
+}
+
 func TestResolveDeferThresholdFromFile(t *testing.T) {
 	path := writeConfig(t, `{
 		"activeProvider": "p",

--- a/internal/contextreport/contextreport.go
+++ b/internal/contextreport/contextreport.go
@@ -261,7 +261,10 @@ func estimateTextTokens(value string) int {
 	if value == "" {
 		return 0
 	}
-	tokens := len(value) / 4
+	// Share the agent's heuristic (non-whitespace bytes / 4) so the context
+	// preview matches the scale the compaction loop uses and tracks the real
+	// tokenizer far better than naive len/4. Non-empty text reports at least 1.
+	tokens := agent.ApproxTextTokens(value)
 	if tokens == 0 {
 		return 1
 	}

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -8,6 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/usage"
@@ -604,7 +605,7 @@ func estimateTranscriptTokens(rows []transcriptRow) int {
 		if text == "" {
 			continue
 		}
-		total += len(text)/4 + 4
+		total += agent.ApproxTextTokens(text) + 4
 	}
 	return total
 }


### PR DESCRIPTION
## Problem

A short message (even "hi") was costing ~20k input tokens for users with MCP servers. Root cause traced through the request-assembly path:

MCP tool schemas are only collapsed into compact `tool_search` reminder lines once the deferred-eligible tool count reaches `tools.deferThreshold`. The default was **10**, so a typical single MCP server (Exa-style, a handful of tools) sat **below** the threshold — and every full MCP schema (**300–600 tokens each**) was re-sent on **every turn**, regardless of message length. A small MCP set therefore added several thousand input tokens per message, paid again on every turn.

The non-MCP floor is modest by comparison (measured via `zero context` on a large repo): system prompt ~2.8k + 12 core tool schemas ~1.9k + capped workspace map ~1k + guidelines. The eager MCP schemas were the runaway component.

## Fix

Lower `defaultDeferThreshold` from **10 → 3**, so a normal MCP server's toolset defers and stays cheap (~30-token reminder line per tool instead of a full schema).

**Capability is unchanged.** Every tool is still reachable — the model loads a deferred tool's schema via `tool_search` before its first use, after which it's loaded for the rest of the run. The only cost is one `tool_search` round-trip per deferred tool's first use, versus paying its full schema on *every* turn.

Fully overridable per config: `tools.deferThreshold` (set `0` to keep the old always-eager behavior, e.g. for a model without `tool_search`).

## Example saving
A 5-tool MCP server: ~2k tokens of eager schemas every turn → ~150 tokens of reminder lines. ~1.8k saved per message, compounding across a conversation.

## Tests
- `TestDefaultDeferThresholdStaysLowForTokenEconomy` — regression guard so the default can't silently drift back up.
- Existing deferral/partition tests unchanged and green (they set explicit thresholds).

Gate: gofmt, vet, build, staticcheck, `-race` on `config` + `agent`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Lowered the default deferred-eligible tool deferral threshold (now **3** instead of **10**) and expanded configuration guidance for deferred tool schema compaction.

* **Refactor**
  * Improved token-count estimation used for proactive compaction and transcript/context sizing for more consistent behavior.

* **Tests**
  * Added a regression test to keep the default defer threshold low.
  * Added a measurement-based test verifying reduced tool payload size with the lower threshold.
  * Added unit coverage for the updated token estimation heuristic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->