### PR TITLE
Align web tool permission prompts

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1017,11 +1017,11 @@ func deniedPermissionResult(call ToolCall, reason string, requestEvent Permissio
 }
 
 // permissionScope returns a concise, human-readable description of what a tool
-// call will actually touch — the file path, directory, or working dir lifted
-// from its arguments — so the permission card and the persisted decision can
-// show the user exactly what "allow" covers. It is empty when the tool exposes
-// no path-like argument (the grant is then plainly tool-wide). The first
-// matching key wins, ordered most-specific (a concrete file) first.
+// call will actually touch -- a file path, directory, working dir, or network
+// host lifted from its arguments -- so the permission card and persisted
+// decision can show the user exactly what "allow" covers. It is empty when the
+// tool exposes no scoped argument (the grant is then plainly tool-wide). The
+// first matching key wins, ordered most-specific (a concrete file) first.
 func permissionScope(toolName string, args map[string]any) string {
 	// sandbox.DeriveScope is the single source of truth for which arguments carry
 	// a scope, shared with grant persistence and matching so the card display can

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -315,6 +315,37 @@ func TestRunAdvertisesWebFetchInAutoMode(t *testing.T) {
 	}
 }
 
+func TestRunAdvertisesAllowedWebSearchInAutoMode(t *testing.T) {
+	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
+	registry := tools.NewRegistry()
+	for _, tool := range tools.CoreNetworkTools() {
+		if tool.Name() == "web_search" {
+			registry.Register(tool)
+		}
+	}
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{{
+			{Type: zeroruntime.StreamEventText, Content: "done"},
+			{Type: zeroruntime.StreamEventDone},
+		}},
+	}
+
+	_, err := Run(context.Background(), "what tools exist?", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAuto,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("expected one request, got %d", len(provider.requests))
+	}
+	if len(provider.requests[0].Tools) != 1 || provider.requests[0].Tools[0].Name != "web_search" {
+		t.Fatalf("expected web_search to be advertised in auto mode, got %#v", provider.requests[0].Tools)
+	}
+}
+
 func TestRunFiltersAdvertisedTools(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()

--- a/internal/agent/permission_scope_test.go
+++ b/internal/agent/permission_scope_test.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 func TestPermissionScope(t *testing.T) {
@@ -21,6 +24,7 @@ func TestPermissionScope(t *testing.T) {
 		{name: "non-string path ignored", tool: "write_file", args: map[string]any{"path": 42}, want: ""},
 		{name: "path wins over cwd", tool: "x", args: map[string]any{"cwd": "a", "path": "b"}, want: "b"},
 		{name: "whitespace path is no scope", tool: "write_file", args: map[string]any{"path": "  "}, want: ""},
+		{name: "web fetch host", tool: "web_fetch", args: map[string]any{"url": "https://Example.COM:443/a"}, want: "example.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -39,5 +43,34 @@ func TestPermissionScopeTruncatesLongPaths(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, "…") {
 		t.Fatalf("truncated scope should end with an ellipsis: %q", got)
+	}
+}
+
+func TestPersistPermissionGrantScopesWebFetchToHost(t *testing.T) {
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: t.TempDir(),
+		Policy:        sandbox.DefaultPolicy(),
+		Store:         store,
+	})
+
+	grant, err := persistPermissionGrant("web_fetch", map[string]any{"url": "https://Example.COM:443/docs"}, "trust this host", Options{
+		Sandbox:  engine,
+		Autonomy: string(sandbox.AutonomyMedium),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.ScopeKind != sandbox.ScopeHost || grant.Scope != "example.com" {
+		t.Fatalf("grant = %#v, want host-scoped example.com", grant)
+	}
+	if lookup, err := store.Lookup("web_fetch", "example.com", sandbox.AutonomyMedium); err != nil || !lookup.Matched {
+		t.Fatalf("expected exact host lookup to match: lookup=%#v err=%v", lookup, err)
+	}
+	if lookup, err := store.Lookup("web_fetch", "api.example.com", sandbox.AutonomyMedium); err != nil || lookup.Matched {
+		t.Fatalf("expected subdomain lookup to re-prompt: lookup=%#v err=%v", lookup, err)
 	}
 }

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -301,9 +301,9 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 		return deny(request, risk, ViolationDestructiveCommand, "", "destructive shell command is blocked by sandbox policy", false)
 	}
 	if engine.store != nil {
-		reqRaw, _ := DeriveScope(request.ToolName, request.Args)
-		reqScopeAbs := resolveScopeAbs(reqRaw, request.WorkspaceRoot)
-		match, err := engine.store.Lookup(request.ToolName, reqScopeAbs, request.Autonomy)
+		reqRaw, reqKind := DeriveScope(request.ToolName, request.Args)
+		reqScope := resolveScopeForKind(reqRaw, reqKind, request.WorkspaceRoot)
+		match, err := engine.store.Lookup(request.ToolName, reqScope, request.Autonomy)
 		if err == nil && match.Matched {
 			grant := match.Grant
 			if grant.Decision == GrantDeny {
@@ -364,9 +364,9 @@ func (engine *Engine) Grant(input GrantInput) (Grant, error) {
 	}
 	scope, kind := reconcileScope(strings.TrimSpace(input.Scope), kind)
 	if kind != ScopeToolWide {
-		// Anchor a relative scope to this workspace so the grant cannot match a
-		// same-named path in another project.
-		scope = resolveScopeAbs(scope, engine.workspaceRoot)
+		// Anchor relative path scopes to this workspace so the grant cannot match
+		// a same-named path in another project. Host scopes remain network hosts.
+		scope = resolveScopeForKind(scope, kind, engine.workspaceRoot)
 	}
 	input.Scope = scope
 	input.ScopeKind = kind

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -11,8 +11,8 @@ import (
 
 // TestEvaluateExemptsNetworkToolsFromDenyByDefault reproduces the web_search
 // hard-deny: under NetworkDeny, the engine-level network gate must NOT deny a
-// first-party network TOOL (SideEffect=network) by default, so it follows the
-// normal permission flow instead of being blocked outright. EnforceToolNetwork
+// first-party network TOOL (SideEffect=network) by default, so it follows its
+// normal tool permission metadata instead of being blocked outright. EnforceToolNetwork
 // restores the strict deny, and a network SHELL command stays denied either way.
 func TestEvaluateExemptsNetworkToolsFromDenyByDefault(t *testing.T) {
 	base := Policy{Mode: ModeEnforce, Network: NetworkDeny, MaxAutonomy: AutonomyHigh}
@@ -20,15 +20,15 @@ func TestEvaluateExemptsNetworkToolsFromDenyByDefault(t *testing.T) {
 	// Default (EnforceToolNetwork off): web_search is NOT network-denied.
 	engine := NewEngine(EngineOptions{Policy: base})
 	d := engine.Evaluate(context.Background(), Request{
-		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt,
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionAllow,
 	})
-	if d.Action == ActionDeny {
-		t.Fatalf("web_search must not be network-denied by default, got deny: %s", d.ErrorString())
+	if d.Action != ActionAllow {
+		t.Fatalf("web_search must be allowed by default, got %q: %s", d.Action, d.ErrorString())
 	}
 
-	// Granted permission → it actually runs (ActionAllow), not blocked.
+	// Granted permission also runs, not blocked.
 	allowed := engine.Evaluate(context.Background(), Request{
-		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt, PermissionGranted: true,
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionAllow, PermissionGranted: true,
 	})
 	if allowed.Action != ActionAllow {
 		t.Fatalf("granted web_search must be allowed under deny by default, got %q (%s)", allowed.Action, allowed.ErrorString())
@@ -39,7 +39,7 @@ func TestEvaluateExemptsNetworkToolsFromDenyByDefault(t *testing.T) {
 	strict.EnforceToolNetwork = true
 	strictEngine := NewEngine(EngineOptions{Policy: strict})
 	ds := strictEngine.Evaluate(context.Background(), Request{
-		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionPrompt, PermissionGranted: true,
+		ToolName: "web_search", SideEffect: SideEffectNetwork, Permission: PermissionAllow, PermissionGranted: true,
 	})
 	if ds.Action != ActionDeny || ds.Violation == nil || ds.Violation.Code != ViolationNetwork {
 		t.Fatalf("with EnforceToolNetwork, web_search must be network-denied, got %q (%+v)", ds.Action, ds.Violation)
@@ -182,6 +182,44 @@ func TestEngineGrantScopesToFileAndDirectory(t *testing.T) {
 	denied.Autonomy = AutonomyHigh
 	if d := engine.Evaluate(context.Background(), denied); d.Action != ActionDeny || !d.GrantMatched || d.Violation == nil || d.Violation.Code != ViolationPersistentDeny {
 		t.Fatalf("path under deny subtree should be denied, got %#v", d)
+	}
+}
+
+func TestEngineGrantScopesWebFetchToHost(t *testing.T) {
+	store, err := NewGrantStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),
+		Now:      fixedSandboxTime("2026-06-05T14:00:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	engine := NewEngine(EngineOptions{WorkspaceRoot: t.TempDir(), Policy: DefaultPolicy(), Store: store})
+	if _, err := engine.Grant(GrantInput{
+		ToolName:    "web_fetch",
+		Decision:    GrantAllow,
+		MaxAutonomy: AutonomyMedium,
+		Scope:       "Example.COM:443",
+		ScopeKind:   ScopeHost,
+	}); err != nil {
+		t.Fatalf("engine.Grant host: %v", err)
+	}
+
+	request := func(rawURL string) Request {
+		return Request{
+			ToolName:       "web_fetch",
+			SideEffect:     SideEffectNetwork,
+			Permission:     PermissionPrompt,
+			PermissionMode: PermissionModeAsk,
+			Autonomy:       AutonomyMedium,
+			Args:           map[string]any{"url": rawURL},
+		}
+	}
+
+	if d := engine.Evaluate(context.Background(), request("https://example.com/docs")); d.Action != ActionAllow || !d.GrantMatched {
+		t.Fatalf("same host should auto-allow, got %#v", d)
+	}
+	if d := engine.Evaluate(context.Background(), request("https://api.example.com/docs")); d.Action != ActionPrompt || d.GrantMatched {
+		t.Fatalf("different host should re-prompt, got %#v", d)
 	}
 }
 

--- a/internal/sandbox/grant_scope.go
+++ b/internal/sandbox/grant_scope.go
@@ -1,19 +1,23 @@
 package sandbox
 
 import (
+	"net"
+	"net/url"
 	"path/filepath"
 	"strings"
 )
 
-// ScopeKind classifies what a grant's scope covers. An empty kind is a tool-wide
-// grant (it authorizes the whole tool, the pre-scoping behavior); a file scope
-// matches one exact path; a dir scope matches the directory and any descendant.
+// ScopeKind classifies what a grant's scope covers. An empty kind is a
+// tool-wide grant (it authorizes the whole tool, the pre-scoping behavior); a
+// file scope matches one exact path; a dir scope matches the directory and any
+// descendant; a host scope matches one normalized network host.
 type ScopeKind string
 
 const (
 	ScopeToolWide ScopeKind = ""
 	ScopeFile     ScopeKind = "file"
 	ScopeDir      ScopeKind = "dir"
+	ScopeHost     ScopeKind = "host"
 )
 
 // scopeArgKeys lists the path-like argument keys in priority order (most specific
@@ -31,11 +35,16 @@ var scopeArgKeys = []struct {
 	{"cwd", ScopeDir},
 }
 
-// DeriveScope inspects a tool call's arguments and returns the raw (un-resolved)
-// scope string and its kind. It returns ("", ScopeToolWide) when no path-like
-// argument is present, the value is not a string, or the value points at the
-// workspace root (".") — in those cases the grant is plainly tool-wide.
+// DeriveScope inspects a tool call's arguments and returns the raw
+// (un-resolved) scope string and its kind. It returns ("", ScopeToolWide) when
+// no scoped argument is present, the value is not a string, or the value points
+// at the workspace root (".") -- in those cases the grant is plainly tool-wide.
 func DeriveScope(toolName string, args map[string]any) (string, ScopeKind) {
+	if toolName == "web_fetch" {
+		if host, ok := deriveHostScope(args["url"]); ok {
+			return host, ScopeHost
+		}
+	}
 	for _, candidate := range scopeArgKeys {
 		value, ok := args[candidate.key].(string)
 		if !ok {
@@ -53,6 +62,19 @@ func DeriveScope(toolName string, args map[string]any) (string, ScopeKind) {
 		return trimmed, candidate.kind
 	}
 	return "", ScopeToolWide
+}
+
+func deriveHostScope(value any) (string, bool) {
+	raw, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Host == "" {
+		return "", false
+	}
+	host := normalizeHostScope(parsed.Hostname())
+	return host, host != ""
 }
 
 // resolveScopeAbs converts a raw scope to an absolute, cleaned path. A relative
@@ -75,35 +97,65 @@ func resolveScopeAbs(raw string, workspaceRoot string) string {
 	return filepath.Clean(trimmed)
 }
 
+func resolveScopeForKind(raw string, kind ScopeKind, workspaceRoot string) string {
+	scope, kind := reconcileScope(strings.TrimSpace(raw), kind)
+	switch kind {
+	case ScopeFile, ScopeDir:
+		return resolveScopeAbs(scope, workspaceRoot)
+	case ScopeHost:
+		return normalizeHostScope(scope)
+	default:
+		return ""
+	}
+}
+
+func normalizeHostScope(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Host != "" {
+		trimmed = parsed.Hostname()
+	} else if host, _, err := net.SplitHostPort(trimmed); err == nil {
+		trimmed = host
+	}
+	trimmed = strings.Trim(trimmed, "[]")
+	trimmed = strings.TrimSuffix(trimmed, ".")
+	return strings.ToLower(strings.TrimSpace(trimmed))
+}
+
 // grantCovers reports whether a stored grant covers a request whose absolute
-// scope is reqAbs. A tool-wide grant covers everything (including a tool-wide
+// scope is reqScope. A tool-wide grant covers everything (including a tool-wide
 // request); a file grant matches its exact path; a dir grant matches the
-// directory itself or any descendant. A narrower grant never covers a tool-wide
-// request (reqAbs == ""), so such a request re-prompts (fail-safe).
-func grantCovers(grant Grant, reqAbs string) bool {
+// directory itself or any descendant; a host grant matches its exact normalized
+// host. A narrower grant never covers a tool-wide request (reqScope == ""), so
+// such a request re-prompts (fail-safe).
+func grantCovers(grant Grant, reqScope string) bool {
 	switch grant.ScopeKind {
 	case ScopeToolWide:
 		return true
 	case ScopeFile:
-		return reqAbs != "" && reqAbs == grant.Scope
+		return reqScope != "" && reqScope == grant.Scope
 	case ScopeDir:
-		if reqAbs == "" || grant.Scope == "" {
+		if reqScope == "" || grant.Scope == "" {
 			return false
 		}
-		if reqAbs == grant.Scope {
+		if reqScope == grant.Scope {
 			return true
 		}
-		return strings.HasPrefix(reqAbs, grant.Scope+string(filepath.Separator))
+		return strings.HasPrefix(reqScope, grant.Scope+string(filepath.Separator))
+	case ScopeHost:
+		return reqScope != "" && normalizeHostScope(reqScope) == normalizeHostScope(grant.Scope)
 	default:
 		return false
 	}
 }
 
 // scopeSpecificity ranks scope kinds so the most precise covering allow wins when
-// several grants match the same request (file > dir > tool-wide).
+// several grants match the same request.
 func scopeSpecificity(kind ScopeKind) int {
 	switch kind {
-	case ScopeFile:
+	case ScopeFile, ScopeHost:
 		return 2
 	case ScopeDir:
 		return 1

--- a/internal/sandbox/grant_scope_test.go
+++ b/internal/sandbox/grant_scope_test.go
@@ -165,6 +165,8 @@ func TestDeriveScope(t *testing.T) {
 		{name: "path wins over cwd", tool: "x", args: map[string]any{"cwd": "a", "path": "b"}, wantRaw: "b", wantKind: ScopeFile},
 		{name: "non-string path ignored", tool: "write_file", args: map[string]any{"path": 42}, wantRaw: "", wantKind: ScopeToolWide},
 		{name: "whitespace path is tool-wide", tool: "write_file", args: map[string]any{"path": "  "}, wantRaw: "", wantKind: ScopeToolWide},
+		{name: "web fetch url host", tool: "web_fetch", args: map[string]any{"url": "https://Example.COM:443/path?q=1"}, wantRaw: "example.com", wantKind: ScopeHost},
+		{name: "web fetch invalid url is tool-wide", tool: "web_fetch", args: map[string]any{"url": "://bad"}, wantRaw: "", wantKind: ScopeToolWide},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -224,6 +226,7 @@ func TestGrantCovers(t *testing.T) {
 	toolWide := Grant{ScopeKind: ScopeToolWide}
 	fileGrant := Grant{Scope: file, ScopeKind: ScopeFile}
 	dirGrant := Grant{Scope: dir, ScopeKind: ScopeDir}
+	hostGrant := Grant{Scope: "example.com", ScopeKind: ScopeHost}
 
 	cases := []struct {
 		name  string
@@ -241,6 +244,9 @@ func TestGrantCovers(t *testing.T) {
 		{"dir does not cover a sibling dir prefix", dirGrant, siblingDir, false},
 		{"dir does not cover its parent", dirGrant, parent, false},
 		{"dir does not cover an empty request", dirGrant, "", false},
+		{"host covers exact host case-insensitively", hostGrant, "EXAMPLE.com", true},
+		{"host does not cover subdomain", hostGrant, "api.example.com", false},
+		{"host does not cover empty request", hostGrant, "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/sandbox/grants.go
+++ b/internal/sandbox/grants.go
@@ -19,8 +19,8 @@ const grantSchemaVersion = 2
 
 type Grant struct {
 	ToolName    string        `json:"toolName"`
-	Scope       string        `json:"scope,omitempty"`     // absolute, cleaned path; "" = tool-wide
-	ScopeKind   ScopeKind     `json:"scopeKind,omitempty"` // file | dir | "" (tool-wide)
+	Scope       string        `json:"scope,omitempty"`     // absolute path, host, or "" for tool-wide
+	ScopeKind   ScopeKind     `json:"scopeKind,omitempty"` // file | dir | host | "" (tool-wide)
 	Decision    GrantDecision `json:"decision"`
 	MaxAutonomy Autonomy      `json:"maxAutonomy"`
 	ApprovedAt  string        `json:"approvedAt"`
@@ -38,9 +38,9 @@ type GrantInput struct {
 	Decision    GrantDecision
 	MaxAutonomy Autonomy
 	Reason      string
-	// Scope is the raw (possibly relative) path the grant covers; ScopeKind
-	// classifies it. engine.Grant resolves Scope to an absolute path before
-	// persisting. Both empty means a tool-wide grant.
+	// Scope is the raw path or host the grant covers; ScopeKind classifies it.
+	// engine.Grant resolves path scopes to absolute paths and normalizes host
+	// scopes before persisting. Both empty means a tool-wide grant.
 	Scope     string
 	ScopeKind ScopeKind
 }
@@ -150,12 +150,12 @@ func (store *GrantStore) Grant(input GrantInput) (Grant, error) {
 	return grant, nil
 }
 
-// Lookup returns the grant that governs a tool call whose absolute scope is
-// reqScopeAbs (empty for a tool-wide request, e.g. a shell command with no cwd).
+// Lookup returns the grant that governs a tool call whose normalized scope is
+// reqScope (empty for a tool-wide request, e.g. a shell command with no cwd).
 // Among the tool's grants that cover the request, a covering deny wins outright
 // (regardless of autonomy); otherwise the most-specific covering allow whose
 // recorded MaxAutonomy admits the requested autonomy is returned.
-func (store *GrantStore) Lookup(toolName string, reqScopeAbs string, requestedAutonomy Autonomy) (GrantLookup, error) {
+func (store *GrantStore) Lookup(toolName string, reqScope string, requestedAutonomy Autonomy) (GrantLookup, error) {
 	if err := ValidateToolName(toolName); err != nil {
 		return GrantLookup{}, err
 	}
@@ -173,7 +173,7 @@ func (store *GrantStore) Lookup(toolName string, reqScopeAbs string, requestedAu
 	var bestAllow *Grant
 	for i := range bucket {
 		grant := bucket[i]
-		if !grantCovers(grant, reqScopeAbs) {
+		if !grantCovers(grant, reqScope) {
 			continue
 		}
 		if grant.Decision == GrantDeny {
@@ -378,8 +378,10 @@ func normalizeScopeKind(kind ScopeKind) (ScopeKind, error) {
 		return ScopeFile, nil
 	case ScopeDir:
 		return ScopeDir, nil
+	case ScopeHost:
+		return ScopeHost, nil
 	default:
-		return "", fmt.Errorf("invalid sandbox scope kind %q. Expected file, dir, or empty", kind)
+		return "", fmt.Errorf("invalid sandbox scope kind %q. Expected file, dir, host, or empty", kind)
 	}
 }
 
@@ -389,6 +391,13 @@ func normalizeScopeKind(kind ScopeKind) (ScopeKind, error) {
 func reconcileScope(scope string, kind ScopeKind) (string, ScopeKind) {
 	if kind == ScopeToolWide || scope == "" {
 		return "", ScopeToolWide
+	}
+	if kind == ScopeHost {
+		host := normalizeHostScope(scope)
+		if host == "" {
+			return "", ScopeToolWide
+		}
+		return host, ScopeHost
 	}
 	return scope, kind
 }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -46,15 +46,14 @@ func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	}
 }
 
-func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
+func TestCoreNetworkToolsExposeSafetyMetadata(t *testing.T) {
 	// web_search is only registered when a backend is configured.
 	t.Setenv("ZERO_WEBSEARCH_BASE_URL", "https://search.example/api")
 	byName := map[string]Tool{}
 	for _, tool := range CoreNetworkTools() {
 		byName[tool.Name()] = tool
-		// Every core network tool shares the same prompt-gated egress posture.
 		safety := tool.Safety()
-		if safety.SideEffect != SideEffectNetwork || safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
+		if safety.SideEffect != SideEffectNetwork {
 			t.Fatalf("network tool %q has unexpected safety metadata: %#v", tool.Name(), safety)
 		}
 	}
@@ -67,6 +66,9 @@ func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
 	if property, ok := fetch.Parameters().Properties["url"]; !ok || property.Type != "string" {
 		t.Fatalf("web_fetch must expose a string url property, got %#v", fetch.Parameters().Properties["url"])
 	}
+	if safety := fetch.Safety(); safety.Permission != PermissionPrompt || !safety.AdvertiseInAuto {
+		t.Fatalf("web_fetch safety = %#v, want prompt and advertised in auto", safety)
+	}
 
 	// web_search discovers URLs; its key parameter is "query".
 	search, ok := byName["web_search"]
@@ -75,6 +77,9 @@ func TestCoreNetworkToolsExposePromptMetadata(t *testing.T) {
 	}
 	if property, ok := search.Parameters().Properties["query"]; !ok || property.Type != "string" {
 		t.Fatalf("web_search must expose a string query property, got %#v", search.Parameters().Properties["query"])
+	}
+	if safety := search.Safety(); safety.Permission != PermissionAllow || safety.AdvertiseInAuto {
+		t.Fatalf("web_search safety = %#v, want allow without prompt-advertise override", safety)
 	}
 }
 

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -38,8 +38,8 @@ type Safety struct {
 	SideEffect SideEffect
 	Permission Permission
 	Reason     string
-	// AdvertiseInAuto allows selected prompt-gated tools to be visible while
-	// still requiring the normal permission flow before execution.
+	// AdvertiseInAuto allows selected non-allow tools to be visible in auto mode
+	// while still requiring the normal permission flow before execution.
 	AdvertiseInAuto bool
 }
 

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -81,15 +81,14 @@ func newWebSearchToolWithBackend(backend searchBackend) Tool {
 				Required:             []string{"query"},
 				AdditionalProperties: false,
 			},
-			// Network egress, so it carries the same prompt-gated posture as web_fetch
-			// (the codebase enforces this for every CoreNetworkTools entry). It only
-			// discovers public URLs and mutates nothing, but the query still leaves
-			// the machine for an operator-configured endpoint, which warrants a prompt.
+			// Hosted search is a read-only discovery action. It remains marked as
+			// network for sandbox policy accounting, but it does not interrupt every
+			// search with a permission prompt. Operators that want search held to the
+			// sandbox network allowlist can enable EnforceToolNetwork.
 			safety: Safety{
-				SideEffect:      SideEffectNetwork,
-				Permission:      PermissionPrompt,
-				Reason:          "Performs a web search over the network.",
-				AdvertiseInAuto: true,
+				SideEffect: SideEffectNetwork,
+				Permission: PermissionAllow,
+				Reason:     "Performs a web search over the network.",
 			},
 		},
 		backend: backend,

--- a/internal/tools/web_search_test.go
+++ b/internal/tools/web_search_test.go
@@ -116,6 +116,20 @@ func TestWebSearchRegisteredInCoreNetworkTools(t *testing.T) {
 	}
 }
 
+func TestWebSearchSafetyAllowsHostedSearchWithoutPrompt(t *testing.T) {
+	tool := newWebSearchToolWithBackend(&fakeSearchBackend{})
+	safety := tool.Safety()
+	if safety.SideEffect != SideEffectNetwork {
+		t.Fatalf("side effect = %s, want network", safety.SideEffect)
+	}
+	if safety.Permission != PermissionAllow {
+		t.Fatalf("permission = %s, want allow", safety.Permission)
+	}
+	if safety.AdvertiseInAuto {
+		t.Fatal("web_search should not need the prompt-tool auto advertisement override")
+	}
+}
+
 func TestHTTPSearchBackendSendsProviderAndParsesResults(t *testing.T) {
 	var gotBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1215,6 +1215,7 @@ func TestAgentResponsePreservesPermissionMetadata(t *testing.T) {
 
 func TestPermissionRequestShowsFocusedPrompt(t *testing.T) {
 	request := testPromptPermissionRequest()
+	request.Scope = "src/main.go"
 	m := newModel(context.Background(), Options{})
 	m.pending = true
 	m.activeRunID = 7
@@ -1235,8 +1236,12 @@ func TestPermissionRequestShowsFocusedPrompt(t *testing.T) {
 	if countTranscriptRows(next.transcript, rowPermission) != 1 {
 		t.Fatalf("expected permission request to append one permission row, got %#v", next.transcript)
 	}
+	row, ok := findTranscriptRow(next.transcript, rowPermission)
+	if !ok || row.permission == nil || row.permission.Scope != request.Scope {
+		t.Fatalf("expected permission row to preserve scope %q, got %#v", request.Scope, row)
+	}
 	view := next.View()
-	for _, want := range []string{"write_file", "allow once", "[a]", "deny", "[d]", "always", "[y]", "risk:high", "Creates or overwrites files."} {
+	for _, want := range []string{"write_file", "allow once", "[a]", "deny", "[d]", "always for this scope", "[y]", "scope: src/main.go", "risk:high", "Creates or overwrites files."} {
 		assertContains(t, view, want)
 	}
 }

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -94,3 +94,21 @@ func TestPermissionRenderEmitsHighlightedClickableOffsets(t *testing.T) {
 		t.Fatalf("the highlighted (cursor) option line should carry ▸, got %q", lines[deny])
 	}
 }
+
+func TestPermissionRenderShowsNetworkTargetAndHostScopedAlways(t *testing.T) {
+	request := agent.PermissionRequest{
+		ToolName:   "web_fetch",
+		SideEffect: "network",
+		Scope:      "example.com",
+	}
+	card, _ := renderFocusedPermissionPrompt(request, 1, 72)
+	got := plainRender(t, card)
+	for _, want := range []string{"target: example.com", "always for this host", "[y]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("permission card = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "scope: example.com") {
+		t.Fatalf("network prompt should render target label, got %q", got)
+	}
+}

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -179,6 +179,7 @@ func permissionCacheFingerprint(event *agent.PermissionEvent) string {
 		event.Autonomy,
 		event.SideEffect,
 		event.Reason,
+		event.Scope,
 		string(event.Risk.Level),
 		strconv.FormatBool(event.GrantMatched),
 		strconv.FormatBool(event.Grant != nil),

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -770,13 +770,13 @@ func renderPermissionRow(row transcriptRow, width int) string {
 		}
 		line := zeroTheme.green.Render(label) + dot + zeroTheme.green.Render(name)
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
-			line += dot + zeroTheme.muted.Render("scope:"+scope)
+			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
 		return fitStyledLine(line, width)
 	case agent.PermissionActionDeny:
 		line := zeroTheme.red.Render("denied") + dot + zeroTheme.red.Render(name)
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
-			line += dot + zeroTheme.muted.Render("scope:"+scope)
+			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
 		if event.Risk.Level != "" {
 			line += dot + zeroTheme.muted.Render("risk:"+string(event.Risk.Level))
@@ -792,7 +792,7 @@ func renderPermissionRow(row transcriptRow, width int) string {
 	default:
 		line := zeroTheme.amber.Render("permission") + "  " + zeroTheme.ink.Render(name) + "  " + zeroTheme.amber.Render("prompt")
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
-			line += "  " + zeroTheme.muted.Render("scope:"+scope)
+			line += "  " + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
 		if event.Risk.Level != "" {
 			line += "  " + zeroTheme.muted.Render("risk:"+string(event.Risk.Level))
@@ -839,10 +839,10 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	if reason := strings.TrimSpace(request.Reason); reason != "" {
 		lines = append(lines, fill(zeroTheme.muted).Render(reason))
 	}
-	// Surface exactly what the grant covers (the file/dir the call touches) so
-	// "always" is a clear, bounded choice rather than a blind tool-wide yes.
+	// Surface exactly what the grant covers (file/dir/host) so "always" is a
+	// clear, bounded choice rather than a blind tool-wide yes.
 	if scope := strings.TrimSpace(request.Scope); scope != "" {
-		lines = append(lines, fill(zeroTheme.muted).Render("scope: "+scope))
+		lines = append(lines, fill(zeroTheme.muted).Render(permissionScopeLine(request, scope)))
 	}
 
 	lines = append(lines, "")
@@ -858,12 +858,13 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	for index, option := range options {
 		offsets[index] = 1 + len(lines)
 		hotkey := fill(zeroTheme.faint).Render(" [" + option.hotkey + "]")
+		optionLabel := permissionOptionLabel(option, request)
 		if index == cursor {
 			marker := fill(zeroTheme.accent).Render("▸ ")
-			label := zeroTheme.badge.Render(" " + option.label + " ")
+			label := zeroTheme.badge.Render(" " + optionLabel + " ")
 			lines = append(lines, marker+label+hotkey)
 		} else {
-			label := fill(zeroTheme.ink).Render(option.label)
+			label := fill(zeroTheme.ink).Render(optionLabel)
 			lines = append(lines, "  "+label+hotkey)
 		}
 	}
@@ -872,6 +873,30 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter or click to confirm · [esc] cancel run"))
 
 	return styledBlockFill(width, lines, zeroTheme.permBorder, zeroTheme.permBg), offsets
+}
+
+func permissionScopeLine(request agent.PermissionRequest, scope string) string {
+	if request.SideEffect == string(tools.SideEffectNetwork) {
+		return "target: " + scope
+	}
+	return "scope: " + scope
+}
+
+func permissionOptionLabel(option permissionOption, request agent.PermissionRequest) string {
+	if option.choice != permissionDecisionAlwaysAllow || strings.TrimSpace(request.Scope) == "" {
+		return option.label
+	}
+	if request.SideEffect == string(tools.SideEffectNetwork) {
+		return "always for this host"
+	}
+	return "always for this scope"
+}
+
+func permissionEventScopeLabel(event *agent.PermissionEvent) string {
+	if event != nil && event.SideEffect == string(tools.SideEffectNetwork) {
+		return "target"
+	}
+	return "scope"
 }
 
 // renderFocusedAskUserPrompt draws the ask-user questionnaire in the same

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -460,6 +460,7 @@ func permissionEventFromPayload(payload map[string]any) agent.PermissionEvent {
 		Autonomy:          payloadString(payload, "autonomy"),
 		SideEffect:        payloadString(payload, "sideEffect"),
 		Reason:            payloadString(payload, "reason"),
+		Scope:             payloadString(payload, "scope"),
 		DecisionReason:    payloadString(payload, "decisionReason"),
 		GrantMatched:      payloadBool(payload, "grantMatched"),
 	}

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -575,6 +575,7 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 		"permission":     "allow",
 		"permissionMode": "auto",
 		"sideEffect":     "read",
+		"scope":          "src",
 		"risk":           map[string]any{"level": "low"},
 	})
 	appendTestEvent(t, store, session.SessionID, sessions.EventToolResult, map[string]any{"toolCallId": "call_1", "name": "grep", "status": "error", "output": "matches"})
@@ -602,6 +603,9 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	permissionRow, ok := findTranscriptRow(next.transcript, rowPermission)
 	if !ok || permissionRow.tool != "grep" || permissionRow.permission == nil || permissionRow.permission.Action != agent.PermissionActionAllow {
 		t.Fatalf("expected hydrated permission metadata, got ok=%v row=%#v", ok, permissionRow)
+	}
+	if permissionRow.permission.Scope != "src" {
+		t.Fatalf("expected hydrated permission scope, got %#v", permissionRow.permission)
 	}
 	toolResult, ok := findTranscriptRow(next.transcript, rowToolResult)
 	if !ok || toolResult.tool != "grep" || toolResult.status != tools.StatusError || toolResult.detail != "matches" {

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -256,6 +256,7 @@ func permissionEventFromRequest(request agent.PermissionRequest) agent.Permissio
 		Autonomy:       request.Autonomy,
 		SideEffect:     request.SideEffect,
 		Reason:         request.Reason,
+		Scope:          request.Scope,
 		Risk:           request.Risk,
 		Violation:      request.Violation,
 		GrantMatched:   request.GrantMatched,


### PR DESCRIPTION
## Summary
- treat hosted web_search as an allowed read-only network discovery tool so normal searches do not stop for approval
- add host-scoped persistent grants for web_fetch URLs so always-allow is bounded to the requested host
- update permission prompt/transcript rendering to show network targets and preserve scope metadata through caching and session hydration

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Host-scoped permissions for network operations enable granular per-host access control
  - Enhanced permission prompts now display specific targets and offer "always for this host" options
  - Permission scope information is now preserved across transcripts and session resumption

* **Bug Fixes**
  - Improved permission scope handling and matching for network tools

* **Documentation**
  - Clarified permission metadata and scope behavior descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->