### PR TITLE
Align permission session approvals

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -558,23 +558,36 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	}
 
 	decisionReason := ""
+	var decisionAction PermissionDecisionAction
 	if toolFound && options.OnPermissionRequest != nil && shouldRequestPermission(tool, permissionGranted, preflightDecision) {
 		requestEvent, ok := buildPermissionEvent(call, tool, args, permissionGranted, permissionMode, options, preflightDecision)
 		if !ok {
 			requestEvent = fallbackPermissionEvent(call, tool, args, permissionMode, options)
 		}
-		request := permissionRequestFromEvent(requestEvent, args)
+		request := permissionRequestFromEvent(requestEvent, args, options)
 		decision, err := requestPermission(ctx, request, options)
 		if err != nil {
 			decision = PermissionDecision{Action: PermissionDecisionDeny, Reason: err.Error()}
 		}
 		decision.Action = normalizePermissionDecisionAction(decision.Action)
 		decisionReason = strings.TrimSpace(decision.Reason)
+		decisionAction = decision.Action
 		switch decision.Action {
 		case PermissionDecisionAllow:
 			permissionGranted = true
+			requestEvent.DecisionAction = decision.Action
+		case PermissionDecisionAllowForSession:
+			permissionGranted = true
+			requestEvent.DecisionAction = decision.Action
+			if options.Sandbox != nil {
+				if grant, err := persistSessionPermissionGrant(call.Name, args, decisionReason, options); err == nil {
+					requestEvent.GrantMatched = true
+					requestEvent.Grant = &grant
+				}
+			}
 		case PermissionDecisionAlwaysAllow:
 			permissionGranted = true
+			requestEvent.DecisionAction = decision.Action
 			// "Always allow" also persists a grant so FUTURE calls skip the prompt.
 			// With no sandbox engine there is nowhere to persist it, and persistence
 			// can also fail — neither must deny what the user explicitly allowed, so
@@ -584,7 +597,10 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 			// (buildPermissionEvent reads decision.GrantMatched/Grant), so the
 			// persisted grant does not need to be recorded on requestEvent here.
 			if options.Sandbox != nil {
-				_, _ = persistPermissionGrant(call.Name, args, decisionReason, options)
+				if grant, err := persistPermissionGrant(call.Name, args, decisionReason, options); err == nil {
+					requestEvent.GrantMatched = true
+					requestEvent.Grant = &grant
+				}
 			}
 		default:
 			emitDeniedPermission(options, call, requestEvent, decisionReason)
@@ -624,6 +640,9 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	if toolFound && options.OnPermission != nil {
 		if event, ok := buildPermissionEvent(call, tool, args, permissionGranted, permissionMode, options, sandboxDecision); ok {
 			event.DecisionReason = decisionReason
+			if decisionAction != "" {
+				event.DecisionAction = decisionAction
+			}
 			options.OnPermission(event)
 		}
 	}
@@ -931,7 +950,7 @@ func requestPermission(ctx context.Context, request PermissionRequest, options O
 
 func normalizePermissionDecisionAction(action PermissionDecisionAction) PermissionDecisionAction {
 	switch action {
-	case PermissionDecisionAllow, PermissionDecisionAlwaysAllow:
+	case PermissionDecisionAllow, PermissionDecisionAllowForSession, PermissionDecisionAlwaysAllow:
 		return action
 	default:
 		return PermissionDecisionDeny
@@ -963,6 +982,28 @@ func persistPermissionGrant(toolName string, args map[string]any, reason string,
 	})
 }
 
+func persistSessionPermissionGrant(toolName string, args map[string]any, reason string, options Options) (sandbox.Grant, error) {
+	if options.Sandbox == nil {
+		return sandbox.Grant{}, errors.New("sandbox engine is not configured")
+	}
+	maxAutonomy := sandbox.Autonomy(options.Autonomy)
+	if maxAutonomy == "" {
+		maxAutonomy = sandbox.AutonomyMedium
+	}
+	if normalized, err := sandbox.NormalizeAutonomy(maxAutonomy); err == nil {
+		maxAutonomy = normalized
+	}
+	scope, kind := sandbox.DeriveScope(toolName, args)
+	return options.Sandbox.GrantForSession(sandbox.GrantInput{
+		ToolName:    toolName,
+		Decision:    sandbox.GrantAllow,
+		MaxAutonomy: maxAutonomy,
+		Reason:      reason,
+		Scope:       scope,
+		ScopeKind:   kind,
+	})
+}
+
 func emitDeniedPermission(options Options, call ToolCall, requestEvent PermissionEvent, reason string) {
 	if options.OnPermission == nil {
 		return
@@ -975,6 +1016,7 @@ func emitDeniedPermission(options Options, call ToolCall, requestEvent Permissio
 	event.ToolCallID = call.ID
 	event.ToolName = call.Name
 	event.Action = PermissionActionDeny
+	event.DecisionAction = PermissionDecisionDeny
 	event.PermissionGranted = false
 	event.DecisionReason = reason
 	options.OnPermission(event)
@@ -990,6 +1032,7 @@ func deniedPermissionResult(call ToolCall, reason string, requestEvent Permissio
 	}
 	event := requestEvent
 	event.Action = PermissionActionDeny
+	event.DecisionAction = PermissionDecisionDeny
 	event.PermissionGranted = false
 	event.DecisionReason = reason
 	if event.Risk.Level == "" {
@@ -1098,6 +1141,7 @@ func buildPermissionEvent(call ToolCall, tool tools.Tool, args map[string]any, p
 		ToolCallID:        call.ID,
 		ToolName:          call.Name,
 		Action:            action,
+		DecisionAction:    grantDecisionAction(grant),
 		Permission:        string(safety.Permission),
 		PermissionGranted: permissionGranted,
 		PermissionMode:    permissionMode,
@@ -1112,28 +1156,57 @@ func buildPermissionEvent(call ToolCall, tool tools.Tool, args map[string]any, p
 	}, true
 }
 
+func grantDecisionAction(grant *sandbox.Grant) PermissionDecisionAction {
+	if grant == nil {
+		return ""
+	}
+	if grant.Session {
+		return PermissionDecisionAllowForSession
+	}
+	if grant.Decision == sandbox.GrantAllow {
+		return PermissionDecisionAlwaysAllow
+	}
+	return ""
+}
+
 func fallbackPermissionEvent(call ToolCall, tool tools.Tool, args map[string]any, permissionMode PermissionMode, options Options) PermissionEvent {
 	event, _ := buildPermissionEvent(call, tool, args, false, permissionMode, options, nil)
 	return event
 }
 
-func permissionRequestFromEvent(event PermissionEvent, args map[string]any) PermissionRequest {
+func permissionRequestFromEvent(event PermissionEvent, args map[string]any, options Options) PermissionRequest {
 	return PermissionRequest{
-		ToolCallID:     event.ToolCallID,
-		ToolName:       event.ToolName,
-		Action:         event.Action,
-		Permission:     event.Permission,
-		PermissionMode: event.PermissionMode,
-		Autonomy:       event.Autonomy,
-		SideEffect:     event.SideEffect,
-		Reason:         event.Reason,
-		Scope:          event.Scope,
-		Risk:           event.Risk,
-		Args:           cloneArgs(args),
-		Violation:      event.Violation,
-		GrantMatched:   event.GrantMatched,
-		Grant:          event.Grant,
+		ToolCallID:         event.ToolCallID,
+		ToolName:           event.ToolName,
+		Action:             event.Action,
+		Permission:         event.Permission,
+		PermissionMode:     event.PermissionMode,
+		Autonomy:           event.Autonomy,
+		SideEffect:         event.SideEffect,
+		Reason:             event.Reason,
+		Scope:              event.Scope,
+		Risk:               event.Risk,
+		Args:               cloneArgs(args),
+		Violation:          event.Violation,
+		GrantMatched:       event.GrantMatched,
+		Grant:              event.Grant,
+		AvailableDecisions: availablePermissionDecisions(event, options),
 	}
+}
+
+func availablePermissionDecisions(event PermissionEvent, options Options) []PermissionDecisionAction {
+	if event.Action != PermissionActionPrompt {
+		return nil
+	}
+	decisions := []PermissionDecisionAction{PermissionDecisionAllow}
+	if options.Sandbox != nil {
+		decisions = append(decisions, PermissionDecisionAllowForSession)
+		if options.Sandbox.CanPersistGrants() {
+			decisions = append(decisions, PermissionDecisionAlwaysAllow)
+		}
+	}
+	decisions = append(decisions, PermissionDecisionDeny)
+	return decisions
 }
 
 func cloneArgs(args map[string]any) map[string]any {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -792,6 +792,55 @@ func TestRunRequestsPromptToolPermissionBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestRunAllowsWorkspaceWriteWithoutPromptWhenSandboxPolicyPermits(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write done")
+	var permissionEvents []PermissionEvent
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        sandbox.DefaultPolicy(),
+		}),
+		OnPermissionRequest: func(context.Context, PermissionRequest) (PermissionDecision, error) {
+			t.Fatal("workspace write should not request permission")
+			return PermissionDecision{}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "write done" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("expected workspace write content, got %q", content)
+	}
+	if len(permissionEvents) != 1 {
+		t.Fatalf("expected one auto permission event, got %#v", permissionEvents)
+	}
+	event := permissionEvents[0]
+	if event.Action != PermissionActionAllow || event.PermissionGranted || event.GrantMatched {
+		t.Fatalf("expected sandbox policy allow without user grant, got %#v", event)
+	}
+	if event.Reason != "workspace write permitted by sandbox policy" {
+		t.Fatalf("expected workspace-write reason, got %#v", event)
+	}
+}
+
 func TestRunDeniesPromptToolWhenPermissionRequestDenied(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()
@@ -850,6 +899,8 @@ func TestRunPersistsAlwaysAllowPermissionDecision(t *testing.T) {
 	registry.Register(tools.NewWriteFileTool(root))
 	provider := providerCallingWriteFileThenAnswer("write approved")
 	var permissionEvents []PermissionEvent
+	policy := sandbox.DefaultPolicy()
+	policy.EnforceWorkspace = false
 
 	result, err := Run(context.Background(), "write notes", provider, Options{
 		Registry:       registry,
@@ -857,7 +908,7 @@ func TestRunPersistsAlwaysAllowPermissionDecision(t *testing.T) {
 		Autonomy:       string(sandbox.AutonomyMedium),
 		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
 			WorkspaceRoot: root,
-			Policy:        sandbox.DefaultPolicy(),
+			Policy:        policy,
 			Store:         store,
 		}),
 		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
@@ -907,6 +958,91 @@ func TestRunPersistsAlwaysAllowPermissionDecision(t *testing.T) {
 	}
 	if event.Grant.Decision != sandbox.GrantAllow || event.Grant.ToolName != "write_file" {
 		t.Fatalf("unexpected persisted grant in event: %#v", event)
+	}
+}
+
+func TestRunSessionAllowSkipsMatchingPromptWithoutPersistentGrant(t *testing.T) {
+	root := t.TempDir()
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "write_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"path":"notes.txt","content":"first","overwrite":true}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-2", ToolName: "write_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-2", ArgumentsFragment: `{"path":"notes.txt","content":"second","overwrite":true}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-2"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var requests []PermissionRequest
+	var permissionEvents []PermissionEvent
+	policy := sandbox.DefaultPolicy()
+	policy.EnforceWorkspace = false
+
+	result, err := Run(context.Background(), "write notes twice", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        policy,
+			Store:         store,
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			requests = append(requests, request)
+			return PermissionDecision{Action: PermissionDecisionAllowForSession, Reason: "trust this file for the session"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "notes.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "second" {
+		t.Fatalf("expected second write content, got %q", content)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected one permission request, got %#v", requests)
+	}
+	if len(permissionEvents) != 2 {
+		t.Fatalf("expected two permission events, got %#v", permissionEvents)
+	}
+	if permissionEvents[0].DecisionAction != PermissionDecisionAllowForSession || permissionEvents[0].Grant == nil || !permissionEvents[0].Grant.Session {
+		t.Fatalf("expected first event to carry session grant, got %#v", permissionEvents[0])
+	}
+	if !permissionEvents[1].GrantMatched || permissionEvents[1].Grant == nil || !permissionEvents[1].Grant.Session {
+		t.Fatalf("expected second event to be session-grant matched, got %#v", permissionEvents[1])
+	}
+	lookup, err := store.Lookup("write_file", filepath.Join(root, "notes.txt"), sandbox.AutonomyMedium)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lookup.Matched {
+		t.Fatalf("session approval must not persist a grant, got %#v", lookup)
 	}
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -38,9 +38,10 @@ const (
 )
 
 const (
-	PermissionDecisionAllow       PermissionDecisionAction = "allow"
-	PermissionDecisionDeny        PermissionDecisionAction = "deny"
-	PermissionDecisionAlwaysAllow PermissionDecisionAction = "always_allow"
+	PermissionDecisionAllow           PermissionDecisionAction = "allow"
+	PermissionDecisionAllowForSession PermissionDecisionAction = "allow_for_session"
+	PermissionDecisionDeny            PermissionDecisionAction = "deny"
+	PermissionDecisionAlwaysAllow     PermissionDecisionAction = "always_allow"
 )
 
 type ToolResult struct {
@@ -78,20 +79,21 @@ const (
 )
 
 type PermissionRequest struct {
-	ToolCallID     string             `json:"toolCallId"`
-	ToolName       string             `json:"name"`
-	Action         PermissionAction   `json:"action"`
-	Permission     string             `json:"permission"`
-	PermissionMode PermissionMode     `json:"permissionMode"`
-	Autonomy       string             `json:"autonomy,omitempty"`
-	SideEffect     string             `json:"sideEffect"`
-	Reason         string             `json:"reason,omitempty"`
-	Scope          string             `json:"scope,omitempty"`
-	Risk           sandbox.Risk       `json:"risk"`
-	Args           map[string]any     `json:"args,omitempty"`
-	Violation      *sandbox.Violation `json:"violation,omitempty"`
-	GrantMatched   bool               `json:"grantMatched,omitempty"`
-	Grant          *sandbox.Grant     `json:"grant,omitempty"`
+	ToolCallID         string                     `json:"toolCallId"`
+	ToolName           string                     `json:"name"`
+	Action             PermissionAction           `json:"action"`
+	Permission         string                     `json:"permission"`
+	PermissionMode     PermissionMode             `json:"permissionMode"`
+	Autonomy           string                     `json:"autonomy,omitempty"`
+	SideEffect         string                     `json:"sideEffect"`
+	Reason             string                     `json:"reason,omitempty"`
+	Scope              string                     `json:"scope,omitempty"`
+	Risk               sandbox.Risk               `json:"risk"`
+	Args               map[string]any             `json:"args,omitempty"`
+	Violation          *sandbox.Violation         `json:"violation,omitempty"`
+	GrantMatched       bool                       `json:"grantMatched,omitempty"`
+	Grant              *sandbox.Grant             `json:"grant,omitempty"`
+	AvailableDecisions []PermissionDecisionAction `json:"availableDecisions,omitempty"`
 }
 
 type PermissionDecision struct {
@@ -100,21 +102,22 @@ type PermissionDecision struct {
 }
 
 type PermissionEvent struct {
-	ToolCallID        string             `json:"toolCallId"`
-	ToolName          string             `json:"name"`
-	Action            PermissionAction   `json:"action"`
-	Permission        string             `json:"permission"`
-	PermissionGranted bool               `json:"permissionGranted,omitempty"`
-	PermissionMode    PermissionMode     `json:"permissionMode"`
-	Autonomy          string             `json:"autonomy,omitempty"`
-	SideEffect        string             `json:"sideEffect"`
-	Reason            string             `json:"reason,omitempty"`
-	Scope             string             `json:"scope,omitempty"`
-	DecisionReason    string             `json:"decisionReason,omitempty"`
-	Risk              sandbox.Risk       `json:"risk"`
-	Violation         *sandbox.Violation `json:"violation,omitempty"`
-	GrantMatched      bool               `json:"grantMatched,omitempty"`
-	Grant             *sandbox.Grant     `json:"grant,omitempty"`
+	ToolCallID        string                   `json:"toolCallId"`
+	ToolName          string                   `json:"name"`
+	Action            PermissionAction         `json:"action"`
+	DecisionAction    PermissionDecisionAction `json:"decisionAction,omitempty"`
+	Permission        string                   `json:"permission"`
+	PermissionGranted bool                     `json:"permissionGranted,omitempty"`
+	PermissionMode    PermissionMode           `json:"permissionMode"`
+	Autonomy          string                   `json:"autonomy,omitempty"`
+	SideEffect        string                   `json:"sideEffect"`
+	Reason            string                   `json:"reason,omitempty"`
+	Scope             string                   `json:"scope,omitempty"`
+	DecisionReason    string                   `json:"decisionReason,omitempty"`
+	Risk              sandbox.Risk             `json:"risk"`
+	Violation         *sandbox.Violation       `json:"violation,omitempty"`
+	GrantMatched      bool                     `json:"grantMatched,omitempty"`
+	Grant             *sandbox.Grant           `json:"grant,omitempty"`
 }
 
 // AskUserQuestion is one clarifying question the agent wants answered.

--- a/internal/cli/exec_protocol_test.go
+++ b/internal/cli/exec_protocol_test.go
@@ -357,7 +357,7 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 				toolCallID: "call_write",
 				toolName:   "write_file",
 				arguments:  `{"path":"notes.txt","content":"hello"}`,
-				answer:     "write denied",
+				answer:     "write allowed",
 			}, nil
 		},
 		newSandboxStore: func() (*sandbox.GrantStore, error) {
@@ -374,15 +374,21 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 
 	events := decodeJSONLines(t, stdout.String())
 	eventTypes := jsonEventTypes(events)
-	if !slices.Contains(eventTypes, "permission_request") {
-		t.Fatalf("expected permission_request event in %v; output %q", eventTypes, stdout.String())
+	if slices.Contains(eventTypes, "permission_request") {
+		t.Fatalf("workspace write should not request permission in %v; output %q", eventTypes, stdout.String())
 	}
-	permissionEvent := findJSONEvent(t, events, "permission_request")
-	if permissionEvent["id"] != "call_write" || permissionEvent["name"] != "write_file" || permissionEvent["action"] != "prompt" {
+	permissionEvent := findJSONEvent(t, events, "permission_decision")
+	if permissionEvent["id"] != "call_write" || permissionEvent["name"] != "write_file" || permissionEvent["action"] != "allow" {
 		t.Fatalf("unexpected permission event: %#v", permissionEvent)
 	}
 	if permissionEvent["permission"] != "prompt" || permissionEvent["permissionMode"] != "auto" || permissionEvent["sideEffect"] != "write" {
 		t.Fatalf("unexpected permission metadata: %#v", permissionEvent)
+	}
+	if permissionEvent["permissionGranted"] == true {
+		t.Fatalf("workspace policy allow should not be recorded as user-granted permission: %#v", permissionEvent)
+	}
+	if permissionEvent["reason"] != "workspace write permitted by sandbox policy" {
+		t.Fatalf("unexpected workspace permission reason: %#v", permissionEvent)
 	}
 	risk, ok := permissionEvent["risk"].(map[string]any)
 	if !ok || risk["level"] == "" {
@@ -400,12 +406,12 @@ func TestRunExecStreamJSONEmitsAndRecordsPermissionEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadEvents returned error: %v", err)
 	}
-	permissionRecord := findSessionEvent(t, recorded, sessions.EventPermissionRequest)
+	permissionRecord := findSessionEvent(t, recorded, sessions.EventPermissionDecision)
 	var payload map[string]any
 	if err := json.Unmarshal(permissionRecord.Payload, &payload); err != nil {
 		t.Fatalf("decode permission payload: %v", err)
 	}
-	if payload["toolCallId"] != "call_write" || payload["name"] != "write_file" || payload["action"] != "prompt" {
+	if payload["toolCallId"] != "call_write" || payload["name"] != "write_file" || payload["action"] != "allow" {
 		t.Fatalf("unexpected recorded permission payload: %#v", payload)
 	}
 

--- a/internal/sandbox/auto_allow_bash_test.go
+++ b/internal/sandbox/auto_allow_bash_test.go
@@ -72,9 +72,11 @@ func TestAutoAllowBashOffStillPrompts(t *testing.T) {
 // must not error.
 func TestAutoAllowBashDoesNotAffectNonShell(t *testing.T) {
 	engine := autoAllowBashEngine(t, true, nativeWrappingBackend)
-	// A non-shell prompt tool must still prompt; auto-allow is shell-only.
+	// A non-shell prompt tool must still prompt; auto-allow is shell-only. Use a
+	// generic write tool name so the workspace file-tool auto-allow does not
+	// apply.
 	decision := engine.Evaluate(context.Background(), Request{
-		ToolName:       "write_file",
+		ToolName:       "custom_writer",
 		SideEffect:     SideEffectWrite,
 		Permission:     PermissionPrompt,
 		PermissionMode: PermissionModeAsk,

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
+	"time"
 )
 
 // reasonAboveCeiling is the Decision.Reason emitted when a grant-allow or unsafe
@@ -24,6 +26,8 @@ type Engine struct {
 	store         *GrantStore
 	backend       Backend
 	scope         *Scope
+	sessionMu     sync.Mutex
+	sessionGrants map[string][]Grant
 }
 
 func NewEngine(options EngineOptions) *Engine {
@@ -63,6 +67,10 @@ func (engine *Engine) Scope() *Scope {
 		return nil
 	}
 	return engine.scope
+}
+
+func (engine *Engine) CanPersistGrants() bool {
+	return engine != nil && engine.store != nil
 }
 
 // ReadExclusions returns the resolved DenyRead/AllowRead exclusion matcher for
@@ -300,9 +308,9 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	if policy.DenyDestructiveShell && HasRiskCategory(risk, "destructive") {
 		return deny(request, risk, ViolationDestructiveCommand, "", "destructive shell command is blocked by sandbox policy", false)
 	}
+	reqRaw, reqKind := DeriveScope(request.ToolName, request.Args)
+	reqScope := resolveScopeForKind(reqRaw, reqKind, request.WorkspaceRoot)
 	if engine.store != nil {
-		reqRaw, reqKind := DeriveScope(request.ToolName, request.Args)
-		reqScope := resolveScopeForKind(reqRaw, reqKind, request.WorkspaceRoot)
 		match, err := engine.store.Lookup(request.ToolName, reqScope, request.Autonomy)
 		if err == nil && match.Matched {
 			grant := match.Grant
@@ -330,8 +338,33 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 			}
 		}
 	}
+	if match := engine.lookupSessionGrant(request.ToolName, reqScope, request.Autonomy); match.Matched {
+		grant := match.Grant
+		if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {
+			return Decision{
+				Action:       ActionPrompt,
+				Reason:       reasonAboveCeiling,
+				Risk:         risk,
+				GrantMatched: true,
+				Grant:        &grant,
+			}
+		}
+		return Decision{
+			Action:       ActionAllow,
+			Reason:       "session sandbox allow grant matched",
+			Risk:         risk,
+			GrantMatched: true,
+			Grant:        &grant,
+		}
+	}
 	if request.Permission == PermissionAllow {
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
+	}
+	if workspaceWriteAutoAllowed(policy, request) {
+		if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {
+			return Decision{Action: ActionPrompt, Risk: risk, Reason: reasonAboveCeiling}
+		}
+		return Decision{Action: ActionAllow, Risk: risk, Reason: "workspace write permitted by sandbox policy", AutoAllowed: true}
 	}
 	// Auto-allow a sandboxed shell command when the operator opted in: the active
 	// native sandbox is the safety boundary, so the bash prompt is skipped. This
@@ -358,9 +391,47 @@ func (engine *Engine) Grant(input GrantInput) (Grant, error) {
 	if engine == nil || engine.store == nil {
 		return Grant{}, errors.New("sandbox grant store is not configured")
 	}
-	kind, err := normalizeScopeKind(input.ScopeKind)
+	input, err := engine.normalizeGrantInput(input)
 	if err != nil {
 		return Grant{}, err
+	}
+	return engine.store.Grant(input)
+}
+
+func (engine *Engine) GrantForSession(input GrantInput) (Grant, error) {
+	if engine == nil {
+		return Grant{}, errors.New("sandbox engine is not configured")
+	}
+	input, err := engine.normalizeGrantInput(input)
+	if err != nil {
+		return Grant{}, err
+	}
+	grant, err := createGrant(input, time.Now)
+	if err != nil {
+		return Grant{}, err
+	}
+	grant.Session = true
+	engine.sessionMu.Lock()
+	defer engine.sessionMu.Unlock()
+	if engine.sessionGrants == nil {
+		engine.sessionGrants = map[string][]Grant{}
+	}
+	bucket := engine.sessionGrants[grant.ToolName]
+	for index := range bucket {
+		if bucket[index].Scope == grant.Scope && bucket[index].ScopeKind == grant.ScopeKind {
+			bucket[index] = grant
+			engine.sessionGrants[grant.ToolName] = bucket
+			return grant, nil
+		}
+	}
+	engine.sessionGrants[grant.ToolName] = append(bucket, grant)
+	return grant, nil
+}
+
+func (engine *Engine) normalizeGrantInput(input GrantInput) (GrantInput, error) {
+	kind, err := normalizeScopeKind(input.ScopeKind)
+	if err != nil {
+		return GrantInput{}, err
 	}
 	scope, kind := reconcileScope(strings.TrimSpace(input.Scope), kind)
 	if kind != ScopeToolWide {
@@ -370,7 +441,34 @@ func (engine *Engine) Grant(input GrantInput) (Grant, error) {
 	}
 	input.Scope = scope
 	input.ScopeKind = kind
-	return engine.store.Grant(input)
+	return input, nil
+}
+
+func (engine *Engine) lookupSessionGrant(toolName string, reqScope string, requestedAutonomy Autonomy) GrantLookup {
+	if engine == nil {
+		return GrantLookup{}
+	}
+	requested, err := NormalizeAutonomy(requestedAutonomy)
+	if err != nil {
+		return GrantLookup{}
+	}
+	engine.sessionMu.Lock()
+	defer engine.sessionMu.Unlock()
+	return lookupGrantBucket(engine.sessionGrants[strings.TrimSpace(toolName)], reqScope, requested)
+}
+
+func workspaceWriteAutoAllowed(policy Policy, request Request) bool {
+	if !policy.EnforceWorkspace || request.WorkspaceRoot == "" || request.SideEffect != SideEffectWrite {
+		return false
+	}
+	switch request.ToolName {
+	case "write_file", "edit_file":
+		return len(requestPaths(request)) > 0
+	case "apply_patch":
+		return true
+	default:
+		return false
+	}
 }
 
 func deny(request Request, risk Risk, code ViolationCode, path string, reason string, recoverable bool) Decision {

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -290,6 +291,9 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	// workspace boundary itself needs a root, so it is gated on having one. Mode is
 	// already known to be enforcing here (ModeDisabled returned above).
 	enforceWorkspace := policy.EnforceWorkspace && request.WorkspaceRoot != ""
+	if violation := applyPatchPathViolation(request); violation != nil {
+		return deny(request, risk, violation.Code, violation.Path, violation.Reason, false)
+	}
 	for _, requested := range requestPaths(request) {
 		if violation := validatePathWithPolicy(scope, policy, request.SideEffect, enforceWorkspace, request.WorkspaceRoot, requested); violation != nil {
 			return deny(request, risk, violation.Code, violation.Path, violation.Reason, false)
@@ -360,7 +364,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	if request.Permission == PermissionAllow {
 		return Decision{Action: ActionAllow, Risk: risk, Reason: permissionReason(request)}
 	}
-	if workspaceWriteAutoAllowed(policy, request) {
+	if workspaceWriteAutoAllowed(policy, request, scope) {
 		if !autonomyAllowed(rawAutonomy, policy.MaxAutonomy) {
 			return Decision{Action: ActionPrompt, Risk: risk, Reason: reasonAboveCeiling}
 		}
@@ -457,18 +461,80 @@ func (engine *Engine) lookupSessionGrant(toolName string, reqScope string, reque
 	return lookupGrantBucket(engine.sessionGrants[strings.TrimSpace(toolName)], reqScope, requested)
 }
 
-func workspaceWriteAutoAllowed(policy Policy, request Request) bool {
+func workspaceWriteAutoAllowed(policy Policy, request Request, scope *Scope) bool {
 	if !policy.EnforceWorkspace || request.WorkspaceRoot == "" || request.SideEffect != SideEffectWrite {
 		return false
 	}
+	paths := requestPaths(request)
+	if len(paths) == 0 || requestPathsTouchProtectedMetadata(scope, request.WorkspaceRoot, paths) {
+		return false
+	}
 	switch request.ToolName {
-	case "write_file", "edit_file":
-		return len(requestPaths(request)) > 0
-	case "apply_patch":
+	case "write_file", "edit_file", "apply_patch":
 		return true
 	default:
 		return false
 	}
+}
+
+func requestPathsTouchProtectedMetadata(scope *Scope, workspaceRoot string, paths []string) bool {
+	if len(paths) == 0 {
+		return false
+	}
+	for _, path := range paths {
+		if pathTouchesProtectedMetadata(scope, workspaceRoot, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathTouchesProtectedMetadata(scope *Scope, workspaceRoot string, path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	if !filepath.IsAbs(path) {
+		return relativePathTouchesProtectedMetadata(path)
+	}
+	roots := []string{}
+	if scope != nil {
+		roots = scope.Roots()
+	} else if workspaceRoot != "" {
+		roots = []string{workspaceRoot}
+	}
+	for _, root := range roots {
+		root = normalizeWorkspaceRootBestEffort(root)
+		if root == "" {
+			continue
+		}
+		normalized := NormalizePrefixForRoot(filepath.Clean(path), root)
+		relative, err := filepath.Rel(root, normalized)
+		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+			continue
+		}
+		if relativePathTouchesProtectedMetadata(relative) {
+			return true
+		}
+	}
+	return false
+}
+
+func relativePathTouchesProtectedMetadata(path string) bool {
+	cleaned := filepath.Clean(filepath.FromSlash(strings.TrimSpace(path)))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
+		return false
+	}
+	first := cleaned
+	if index := strings.Index(first, string(filepath.Separator)); index >= 0 {
+		first = first[:index]
+	}
+	for _, protected := range protectedMetadataNames {
+		if first == protected {
+			return true
+		}
+	}
+	return false
 }
 
 func deny(request Request, risk Risk, code ViolationCode, path string, reason string, recoverable bool) Decision {

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -67,7 +67,7 @@ func TestEngineEvaluatesReadPromptAndPersistentDecisions(t *testing.T) {
 	}
 	engine := NewEngine(EngineOptions{
 		WorkspaceRoot: root,
-		Policy:        DefaultPolicy(),
+		Policy:        promptWorkspaceWritePolicy(),
 		Store:         store,
 	})
 
@@ -145,7 +145,7 @@ func TestEngineGrantScopesToFileAndDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewGrantStore returned error: %v", err)
 	}
-	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy(), Store: store})
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: promptWorkspaceWritePolicy(), Store: store})
 
 	writeReq := func(path string) Request {
 		return Request{
@@ -182,6 +182,46 @@ func TestEngineGrantScopesToFileAndDirectory(t *testing.T) {
 	denied.Autonomy = AutonomyHigh
 	if d := engine.Evaluate(context.Background(), denied); d.Action != ActionDeny || !d.GrantMatched || d.Violation == nil || d.Violation.Code != ViolationPersistentDeny {
 		t.Fatalf("path under deny subtree should be denied, got %#v", d)
+	}
+}
+
+func TestEngineAutoAllowsWorkspaceFileMutationTools(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "write_file", args: map[string]any{"path": "notes.txt"}},
+		{name: "edit_file", args: map[string]any{"path": "notes.txt"}},
+		{name: "apply_patch", args: map[string]any{"patch": "diff --git a/notes.txt b/notes.txt\n"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := engine.Evaluate(context.Background(), Request{
+				ToolName:       tc.name,
+				SideEffect:     SideEffectWrite,
+				Permission:     PermissionPrompt,
+				PermissionMode: PermissionModeAsk,
+				Autonomy:       AutonomyMedium,
+				Args:           tc.args,
+			})
+			if decision.Action != ActionAllow || !decision.AutoAllowed || decision.GrantMatched {
+				t.Fatalf("workspace mutation decision = %#v, want auto allow without grant", decision)
+			}
+		})
+	}
+
+	outside := engine.Evaluate(context.Background(), Request{
+		ToolName:       "write_file",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       AutonomyMedium,
+		Args:           map[string]any{"path": filepath.Join(t.TempDir(), "escape.txt")},
+	})
+	if outside.Action != ActionDeny || outside.Violation == nil || outside.Violation.Code != ViolationOutsideWorkspace {
+		t.Fatalf("outside workspace mutation decision = %#v, want deny", outside)
 	}
 }
 
@@ -716,6 +756,12 @@ func fixedSandboxTime(value string) func() time.Time {
 		panic(err)
 	}
 	return func() time.Time { return parsed }
+}
+
+func promptWorkspaceWritePolicy() Policy {
+	policy := DefaultPolicy()
+	policy.EnforceWorkspace = false
+	return policy
 }
 
 func TestEvaluateAllowsWritesInsideExtraScopeRoot(t *testing.T) {

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -225,6 +225,111 @@ func TestEngineAutoAllowsWorkspaceFileMutationTools(t *testing.T) {
 	}
 }
 
+func TestEngineDoesNotAutoAllowProtectedMetadataWrites(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
+
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+	}{
+		{name: "write_file git hook", args: map[string]any{"path": ".git/hooks/pre-commit"}},
+		{name: "edit_file zero config", args: map[string]any{"path": ".zero/config.json"}},
+		{name: "apply_patch agents metadata", args: map[string]any{"patch": "--- /dev/null\n+++ b/.agents/config.json\n@@ -0,0 +1 @@\n+{}\n"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := engine.Evaluate(context.Background(), Request{
+				ToolName:       strings.Fields(tc.name)[0],
+				SideEffect:     SideEffectWrite,
+				Permission:     PermissionPrompt,
+				PermissionMode: PermissionModeAsk,
+				Autonomy:       AutonomyMedium,
+				Args:           tc.args,
+			})
+			if decision.Action != ActionPrompt || decision.AutoAllowed {
+				t.Fatalf("protected metadata decision = %#v, want prompt without auto-allow", decision)
+			}
+		})
+	}
+}
+
+func TestEngineDeniesApplyPatchEscapesFromPatchBody(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "apply_patch",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       AutonomyMedium,
+		Args: map[string]any{
+			"patch": "--- a/notes.txt\n+++ b/../escape.txt\n@@ -0,0 +1 @@\n+escape\n",
+		},
+	})
+
+	if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationOutsideWorkspace {
+		t.Fatalf("escaping apply_patch decision = %#v, want outside-workspace deny", decision)
+	}
+}
+
+func TestEngineSessionGrantDoesNotMatchSiblingFile(t *testing.T) {
+	root := t.TempDir()
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: promptWorkspaceWritePolicy()})
+
+	if _, err := engine.GrantForSession(GrantInput{
+		ToolName:    "write_file",
+		Decision:    GrantAllow,
+		MaxAutonomy: AutonomyMedium,
+		Scope:       "src/a.txt",
+		ScopeKind:   ScopeFile,
+	}); err != nil {
+		t.Fatalf("GrantForSession file: %v", err)
+	}
+
+	request := func(path string) Request {
+		return Request{
+			ToolName:       "write_file",
+			SideEffect:     SideEffectWrite,
+			Permission:     PermissionPrompt,
+			PermissionMode: PermissionModeAsk,
+			Autonomy:       AutonomyMedium,
+			Args:           map[string]any{"path": path},
+		}
+	}
+
+	if decision := engine.Evaluate(context.Background(), request("src/a.txt")); decision.Action != ActionAllow || !decision.GrantMatched || decision.Grant == nil || !decision.Grant.Session {
+		t.Fatalf("same file session grant decision = %#v, want matched session allow", decision)
+	}
+	if decision := engine.Evaluate(context.Background(), request("src/b.txt")); decision.Action != ActionPrompt || decision.GrantMatched {
+		t.Fatalf("sibling file session grant decision = %#v, want prompt without grant match", decision)
+	}
+}
+
+func TestEngineDeniesAutoAllowedSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:       "apply_patch",
+		SideEffect:     SideEffectWrite,
+		Permission:     PermissionPrompt,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       AutonomyMedium,
+		Args: map[string]any{
+			"patch": "--- /dev/null\n+++ b/linked/escape.txt\n@@ -0,0 +1 @@\n+escape\n",
+		},
+	})
+
+	if decision.Action != ActionDeny || decision.Violation == nil || decision.Violation.Code != ViolationSymlinkTraversal {
+		t.Fatalf("symlink apply_patch decision = %#v, want symlink traversal deny", decision)
+	}
+}
+
 func TestEngineGrantScopesWebFetchToHost(t *testing.T) {
 	store, err := NewGrantStore(StoreOptions{
 		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),

--- a/internal/sandbox/grants.go
+++ b/internal/sandbox/grants.go
@@ -25,6 +25,7 @@ type Grant struct {
 	MaxAutonomy Autonomy      `json:"maxAutonomy"`
 	ApprovedAt  string        `json:"approvedAt"`
 	Reason      string        `json:"reason,omitempty"`
+	Session     bool          `json:"session,omitempty"`
 }
 
 type StoreOptions struct {
@@ -170,6 +171,10 @@ func (store *GrantStore) Lookup(toolName string, reqScope string, requestedAuton
 		return GrantLookup{}, err
 	}
 	bucket := state.Grants[strings.TrimSpace(toolName)]
+	return lookupGrantBucket(bucket, reqScope, requested), nil
+}
+
+func lookupGrantBucket(bucket []Grant, reqScope string, requested Autonomy) GrantLookup {
 	var bestAllow *Grant
 	for i := range bucket {
 		grant := bucket[i]
@@ -178,7 +183,7 @@ func (store *GrantStore) Lookup(toolName string, reqScope string, requestedAuton
 		}
 		if grant.Decision == GrantDeny {
 			covering := grant
-			return GrantLookup{Matched: true, Grant: covering}, nil
+			return GrantLookup{Matched: true, Grant: covering}
 		}
 		if !autonomyAllowed(requested, grant.MaxAutonomy) {
 			continue
@@ -189,9 +194,9 @@ func (store *GrantStore) Lookup(toolName string, reqScope string, requestedAuton
 		}
 	}
 	if bestAllow != nil {
-		return GrantLookup{Matched: true, Grant: *bestAllow}, nil
+		return GrantLookup{Matched: true, Grant: *bestAllow}
 	}
-	return GrantLookup{}, nil
+	return GrantLookup{}
 }
 
 func (store *GrantStore) List() ([]Grant, error) {

--- a/internal/sandbox/risk.go
+++ b/internal/sandbox/risk.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -232,5 +233,127 @@ func requestPaths(request Request) []string {
 			paths = append(paths, value)
 		}
 	}
+	if request.ToolName == "apply_patch" {
+		paths = append(paths, applyPatchRequestPaths(request.Args)...)
+	}
 	return paths
+}
+
+func applyPatchRequestPaths(args map[string]any) []string {
+	patch := firstArgString(args, "patch", "diff")
+	if patch == "" {
+		return nil
+	}
+	cwd := firstArgString(args, "cwd")
+	var paths []string
+	for _, path := range patchHeaderPaths(patch) {
+		if path == "" || path == "/dev/null" {
+			continue
+		}
+		if cwd != "" && filepath.Clean(cwd) != "." && !filepath.IsAbs(path) {
+			path = filepath.Join(cwd, path)
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func applyPatchPathViolation(request Request) *pathViolation {
+	if request.ToolName != "apply_patch" {
+		return nil
+	}
+	patch := firstArgString(request.Args, "patch", "diff")
+	if patch == "" {
+		return nil
+	}
+	for _, path := range patchHeaderPaths(patch) {
+		if path == "" || path == "/dev/null" {
+			continue
+		}
+		if filepath.IsAbs(path) || path == ".." || strings.HasPrefix(path, "../") {
+			return &pathViolation{
+				Code:   ViolationOutsideWorkspace,
+				Path:   path,
+				Reason: fmt.Sprintf("patch path %q must stay inside the workspace", path),
+			}
+		}
+	}
+	return nil
+}
+
+func patchHeaderPaths(patch string) []string {
+	var paths []string
+	oldRemaining, newRemaining := 0, 0
+	inHunk := false
+	for _, line := range strings.Split(strings.ReplaceAll(patch, "\r\n", "\n"), "\n") {
+		if inHunk && (oldRemaining > 0 || newRemaining > 0) {
+			switch {
+			case strings.HasPrefix(line, "-"):
+				oldRemaining--
+			case strings.HasPrefix(line, "+"):
+				newRemaining--
+			case strings.HasPrefix(line, "\\"):
+			default:
+				oldRemaining--
+				newRemaining--
+			}
+			continue
+		}
+		inHunk = false
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			fields := strings.Fields(line)
+			if len(fields) >= 4 {
+				paths = append(paths, stripPatchPrefix(fields[2]), stripPatchPrefix(fields[3]))
+			}
+		case strings.HasPrefix(line, "@@"):
+			oldRemaining, newRemaining = parsePatchHunkCounts(line)
+			inHunk = oldRemaining > 0 || newRemaining > 0
+		case strings.HasPrefix(line, "--- "), strings.HasPrefix(line, "+++ "):
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				paths = append(paths, stripPatchPrefix(fields[1]))
+			}
+		}
+	}
+	return paths
+}
+
+func parsePatchHunkCounts(line string) (int, int) {
+	_, rest, ok := strings.Cut(line, "@@")
+	if !ok {
+		return 0, 0
+	}
+	rangeSection := rest
+	if before, _, ok := strings.Cut(rest, "@@"); ok {
+		rangeSection = before
+	}
+	old, next := 0, 0
+	for _, field := range strings.Fields(rangeSection) {
+		switch {
+		case strings.HasPrefix(field, "-"):
+			old = patchHunkCount(field[1:])
+		case strings.HasPrefix(field, "+"):
+			next = patchHunkCount(field[1:])
+		}
+	}
+	return old, next
+}
+
+func patchHunkCount(spec string) int {
+	if _, count, ok := strings.Cut(spec, ","); ok {
+		if n, err := strconv.Atoi(count); err == nil {
+			return n
+		}
+		return 0
+	}
+	return 1
+}
+
+func stripPatchPrefix(path string) string {
+	path = strings.TrimSpace(path)
+	if strings.HasPrefix(path, "a/") || strings.HasPrefix(path, "b/") {
+		path = path[2:]
+	}
+	return filepath.ToSlash(path)
 }

--- a/internal/sandbox/types.go
+++ b/internal/sandbox/types.go
@@ -255,9 +255,10 @@ type Decision struct {
 	Grant        *Grant     `json:"grant,omitempty"`
 	Violation    *Violation `json:"violation,omitempty"`
 	// AutoAllowed marks an allow that the sandbox itself authorized without a user
-	// prompt or persistent grant — currently only AutoAllowBashWhenSandboxed for a
-	// sandboxed shell command. Enforcement points treat it like a grant-authorized
-	// allow so a prompt tool runs without a separately-recorded PermissionGranted.
+	// prompt or persistent grant, such as a workspace-write file mutation or an
+	// opted-in sandboxed shell command. Enforcement points treat it like a
+	// grant-authorized allow so a prompt tool runs without a separately-recorded
+	// PermissionGranted.
 	AutoAllowed bool `json:"autoAllowed,omitempty"`
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -119,9 +119,9 @@ func (registry *Registry) RunWithOptions(ctx context.Context, name string, args 
 			res.SandboxDecision = sandboxDecision
 			return res
 		}
-		// A persistent grant OR a sandbox auto-allow (AutoAllowBashWhenSandboxed for
-		// a sandboxed shell command) authorizes a prompt tool to run without a
-		// separately-recorded PermissionGranted; the sandbox is the safety boundary.
+		// A persistent grant OR a sandbox auto-allow authorizes a prompt tool to run
+		// without a separately-recorded PermissionGranted; the sandbox is the safety
+		// boundary.
 		sandboxGrantAuthorized = d.Action == sandbox.ActionAllow && (d.GrantMatched || d.AutoAllowed)
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -314,9 +314,10 @@ type prWatcherStartedMsg struct {
 type permissionDecision = agent.PermissionDecisionAction
 
 const (
-	permissionDecisionAllow       permissionDecision = agent.PermissionDecisionAllow
-	permissionDecisionDeny        permissionDecision = agent.PermissionDecisionDeny
-	permissionDecisionAlwaysAllow permissionDecision = agent.PermissionDecisionAlwaysAllow
+	permissionDecisionAllow           permissionDecision = agent.PermissionDecisionAllow
+	permissionDecisionAllowForSession permissionDecision = agent.PermissionDecisionAllowForSession
+	permissionDecisionDeny            permissionDecision = agent.PermissionDecisionDeny
+	permissionDecisionAlwaysAllow     permissionDecision = agent.PermissionDecisionAlwaysAllow
 )
 
 type permissionRequestMsg struct {
@@ -328,9 +329,9 @@ type permissionRequestMsg struct {
 type pendingPermissionPrompt struct {
 	request agent.PermissionRequest
 	decide  func(agent.PermissionDecision)
-	// cursor is the highlighted option index (into permissionOptions): 0=allow
-	// once (the resting default), 1=always, 2=deny. Moved by ↑/↓/Tab; confirmed
-	// by Enter or a click. The a/y/d hotkeys resolve directly and ignore it.
+	// cursor is the highlighted option index (into permissionOptions): 0 is the
+	// resting approval choice. Moved by ↑/↓/Tab; confirmed by Enter or a click.
+	// Hotkeys resolve the matching request-provided option directly.
 	cursor int
 }
 
@@ -2137,16 +2138,16 @@ func startsTurn(kind rowKind) bool {
 }
 
 func (m model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch strings.ToLower(msg.String()) {
-	case "a":
-		return m.resolvePermission(permissionDecisionAllow)
-	case "d":
-		return m.resolvePermission(permissionDecisionDeny)
-	case "y":
-		return m.resolvePermission(permissionDecisionAlwaysAllow)
-	default:
+	if m.pendingPermission == nil {
 		return m, nil
 	}
+	key := strings.ToLower(msg.String())
+	for _, option := range permissionOptions(m.pendingPermission.request) {
+		if option.hotkey == key {
+			return m.resolvePermission(option.choice)
+		}
+	}
+	return m, nil
 }
 
 func (m model) resolvePermission(decision permissionDecision) (tea.Model, tea.Cmd) {
@@ -2209,6 +2210,8 @@ func permissionDecisionReason(decision permissionDecision) string {
 	switch decision {
 	case permissionDecisionAllow:
 		return "approved in TUI"
+	case permissionDecisionAllowForSession:
+		return "approved for this session in TUI"
 	case permissionDecisionAlwaysAllow:
 		return "persistently approved in TUI"
 	case permissionDecisionDeny:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1241,7 +1241,7 @@ func TestPermissionRequestShowsFocusedPrompt(t *testing.T) {
 		t.Fatalf("expected permission row to preserve scope %q, got %#v", request.Scope, row)
 	}
 	view := next.View()
-	for _, want := range []string{"write_file", "allow once", "[a]", "deny", "[d]", "always for this scope", "[y]", "scope: src/main.go", "risk:high", "Creates or overwrites files."} {
+	for _, want := range []string{"write_file", "Yes, proceed", "[a]", "these files in this session", "[s]", "don't ask again for this scope", "[y]", "tell Zero", "[d]", "scope: src/main.go", "risk:high", "Creates or overwrites files."} {
 		assertContains(t, view, want)
 	}
 }
@@ -1254,6 +1254,7 @@ func TestPermissionPromptChoicesResolveDecision(t *testing.T) {
 	}{
 		{name: "allow", key: "a", want: permissionDecisionAllow},
 		{name: "deny", key: "d", want: permissionDecisionDeny},
+		{name: "session", key: "s", want: permissionDecisionAllowForSession},
 		{name: "always", key: "y", want: permissionDecisionAlwaysAllow},
 	}
 
@@ -1309,10 +1310,10 @@ func TestPermissionPromptBlocksNormalSubmit(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected permission confirm to resolve synchronously (no cmd)")
 	}
-	// Enter confirms the highlighted option (default: allow once) — it must NOT
+	// Enter confirms the highlighted option (default: approve) -- it must NOT
 	// submit the composer's pending text as a new prompt.
 	if len(decisions) != 1 || decisions[0] != permissionDecisionAllow {
-		t.Fatalf("expected Enter to confirm the default option (allow once), got %#v", decisions)
+		t.Fatalf("expected Enter to confirm the default approval option, got %#v", decisions)
 	}
 	if transcriptContains(next.transcript, "second prompt") {
 		t.Fatalf("permission prompt should block normal prompt submit, got %#v", next.transcript)

--- a/internal/tui/permission_prompt.go
+++ b/internal/tui/permission_prompt.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/agent"
 )
 
 // permissionOption is one selectable choice in the permission popup. The slice
@@ -13,20 +15,46 @@ type permissionOption struct {
 	choice permissionDecision
 }
 
-// permissionOptions returns the ordered choices the popup offers. "Allow once"
-// is first so it is the resting highlight (the common response a user attends
-// to a prompt to give); "deny" is last. The hotkeys mirror handlePermissionKey.
-func permissionOptions() []permissionOption {
-	return []permissionOption{
-		{label: "allow once", hotkey: "a", choice: permissionDecisionAllow},
-		{label: "always", hotkey: "y", choice: permissionDecisionAlwaysAllow},
-		{label: "deny", hotkey: "d", choice: permissionDecisionDeny},
+// permissionOptions returns the ordered choices the popup offers. The backend
+// supplies the decision set because network, file, and generic command prompts
+// can validly expose different scopes.
+func permissionOptions(request agent.PermissionRequest) []permissionOption {
+	decisions := request.AvailableDecisions
+	if len(decisions) == 0 {
+		decisions = []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionAlwaysAllow,
+			agent.PermissionDecisionDeny,
+		}
 	}
+	options := make([]permissionOption, 0, len(decisions))
+	seen := map[agent.PermissionDecisionAction]bool{}
+	for _, decision := range decisions {
+		if seen[decision] {
+			continue
+		}
+		seen[decision] = true
+		switch decision {
+		case agent.PermissionDecisionAllow:
+			options = append(options, permissionOption{label: "allow once", hotkey: "a", choice: permissionDecisionAllow})
+		case agent.PermissionDecisionAllowForSession:
+			options = append(options, permissionOption{label: "allow for session", hotkey: "s", choice: permissionDecisionAllowForSession})
+		case agent.PermissionDecisionAlwaysAllow:
+			options = append(options, permissionOption{label: "always", hotkey: "y", choice: permissionDecisionAlwaysAllow})
+		case agent.PermissionDecisionDeny:
+			options = append(options, permissionOption{label: "deny", hotkey: "d", choice: permissionDecisionDeny})
+		}
+	}
+	if len(options) == 0 {
+		return []permissionOption{{label: "deny", hotkey: "d", choice: permissionDecisionDeny}}
+	}
+	return options
 }
 
 // clampPermissionCursor keeps a cursor index within the option range.
-func clampPermissionCursor(cursor int) int {
-	n := len(permissionOptions())
+func clampPermissionCursor(cursor int, request agent.PermissionRequest) int {
+	n := len(permissionOptions(request))
 	if cursor < 0 {
 		return 0
 	}
@@ -43,8 +71,8 @@ func (m model) movePermissionCursor(delta int) model {
 	if m.pendingPermission == nil {
 		return m
 	}
-	n := len(permissionOptions())
-	cursor := (clampPermissionCursor(m.pendingPermission.cursor) + delta) % n
+	n := len(permissionOptions(m.pendingPermission.request))
+	cursor := (clampPermissionCursor(m.pendingPermission.cursor, m.pendingPermission.request) + delta) % n
 	if cursor < 0 {
 		cursor += n
 	}
@@ -58,6 +86,6 @@ func (m model) confirmPermissionCursor() (tea.Model, tea.Cmd) {
 	if m.pendingPermission == nil {
 		return m, nil
 	}
-	option := permissionOptions()[clampPermissionCursor(m.pendingPermission.cursor)]
+	option := permissionOptions(m.pendingPermission.request)[clampPermissionCursor(m.pendingPermission.cursor, m.pendingPermission.request)]
 	return m.resolvePermission(option.choice)
 }

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -30,7 +30,7 @@ func pendingPermissionModel(t *testing.T, decide func(agent.PermissionDecision))
 func TestPermissionCursorDefaultsToAllowOnce(t *testing.T) {
 	m := pendingPermissionModel(t, func(agent.PermissionDecision) {})
 	if m.pendingPermission.cursor != 0 {
-		t.Fatalf("default cursor = %d, want 0 (allow once)", m.pendingPermission.cursor)
+		t.Fatalf("default cursor = %d, want 0 (approve)", m.pendingPermission.cursor)
 	}
 }
 
@@ -39,18 +39,18 @@ func TestPermissionCursorMovesAndEnterConfirms(t *testing.T) {
 	m := pendingPermissionModel(t, func(d agent.PermissionDecision) {
 		decisions = append(decisions, permissionDecision(d.Action))
 	})
-	// 0 →down 1 →down 2 →up 1 (always).
+	// 0 -> down 1 -> down 2 -> up 1 (session).
 	for _, key := range []rune{tea.KeyDown, tea.KeyDown, tea.KeyUp} {
 		updated, _ := m.Update(testKey(key))
 		m = updated.(model)
 	}
 	if m.pendingPermission == nil || m.pendingPermission.cursor != 1 {
-		t.Fatalf("cursor after down,down,up = %v, want 1 (always)", m.pendingPermission)
+		t.Fatalf("cursor after down,down,up = %v, want 1 (session)", m.pendingPermission)
 	}
 	updated, _ := m.Update(testKey(tea.KeyEnter))
 	m = updated.(model)
-	if len(decisions) != 1 || decisions[0] != permissionDecisionAlwaysAllow {
-		t.Fatalf("enter on cursor 1 should resolve 'always', got %#v", decisions)
+	if len(decisions) != 1 || decisions[0] != permissionDecisionAllowForSession {
+		t.Fatalf("enter on cursor 1 should resolve session allow, got %#v", decisions)
 	}
 	if m.pendingPermission != nil {
 		t.Fatal("prompt should clear after confirm")
@@ -61,7 +61,7 @@ func TestPermissionCursorWrapsWithUp(t *testing.T) {
 	m := pendingPermissionModel(t, func(agent.PermissionDecision) {})
 	updated, _ := m.Update(testKey(tea.KeyUp)) // 0 wraps to last (deny)
 	m = updated.(model)
-	if want := len(permissionOptions()) - 1; m.pendingPermission.cursor != want {
+	if want := len(permissionOptions(m.pendingPermission.request)) - 1; m.pendingPermission.cursor != want {
 		t.Fatalf("Up from 0 should wrap to %d, got %d", want, m.pendingPermission.cursor)
 	}
 }
@@ -81,17 +81,17 @@ func TestPermissionHotkeysStillResolveDirectly(t *testing.T) {
 
 func TestPermissionRenderEmitsHighlightedClickableOffsets(t *testing.T) {
 	request := agent.PermissionRequest{ToolName: "bash"}
-	card, offsets := renderFocusedPermissionPrompt(request, 2, 60) // cursor on deny
-	if len(offsets) != len(permissionOptions()) {
-		t.Fatalf("offsets = %d, want %d", len(offsets), len(permissionOptions()))
+	card, offsets := renderFocusedPermissionPrompt(request, 2, 60) // cursor on future approval
+	if len(offsets) != len(permissionOptions(request)) {
+		t.Fatalf("offsets = %d, want %d", len(offsets), len(permissionOptions(request)))
 	}
 	lines := strings.Split(plainRender(t, card), "\n")
-	deny := offsets[2]
-	if deny < 0 || deny >= len(lines) || !strings.Contains(lines[deny], "deny") {
-		t.Fatalf("offset[2] (%d) should point at the deny line; lines=%#v", deny, lines)
+	future := offsets[2]
+	if future < 0 || future >= len(lines) || !strings.Contains(lines[future], "always") {
+		t.Fatalf("offset[2] (%d) should point at the future line; lines=%#v", future, lines)
 	}
-	if !strings.Contains(lines[deny], "▸") {
-		t.Fatalf("the highlighted (cursor) option line should carry ▸, got %q", lines[deny])
+	if !strings.Contains(lines[future], "▸") {
+		t.Fatalf("the highlighted (cursor) option line should carry ▸, got %q", lines[future])
 	}
 }
 
@@ -103,7 +103,7 @@ func TestPermissionRenderShowsNetworkTargetAndHostScopedAlways(t *testing.T) {
 	}
 	card, _ := renderFocusedPermissionPrompt(request, 1, 72)
 	got := plainRender(t, card)
-	for _, want := range []string{"target: example.com", "always for this host", "[y]"} {
+	for _, want := range []string{"target: example.com", "allow this host for this conversation", "[s]", "allow this host in the future", "[y]"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("permission card = %q, missing %q", got, want)
 		}

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -174,6 +174,7 @@ func permissionCacheFingerprint(event *agent.PermissionEvent) string {
 		event.ToolCallID,
 		event.ToolName,
 		string(event.Action),
+		string(event.DecisionAction),
 		event.Permission,
 		string(event.PermissionMode),
 		event.Autonomy,
@@ -183,6 +184,7 @@ func permissionCacheFingerprint(event *agent.PermissionEvent) string {
 		string(event.Risk.Level),
 		strconv.FormatBool(event.GrantMatched),
 		strconv.FormatBool(event.Grant != nil),
+		strconv.FormatBool(event.Grant != nil && event.Grant.Session),
 	}
 	if event.Violation != nil {
 		fields = append(fields,

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -763,9 +763,11 @@ func renderPermissionRow(row transcriptRow, width int) string {
 	switch event.Action {
 	case agent.PermissionActionAllow:
 		label := "allowed once"
-		// Rehydrated events lose the grant object but keep GrantMatched, which
-		// for a prompted allow is set exactly by the always path.
-		if event.Grant != nil || event.GrantMatched {
+		if event.DecisionAction == agent.PermissionDecisionAllowForSession ||
+			(event.Grant != nil && event.Grant.Session) {
+			label = "allowed for session"
+		} else if event.DecisionAction == agent.PermissionDecisionAlwaysAllow ||
+			event.Grant != nil || event.GrantMatched {
 			label = "always"
 		}
 		line := zeroTheme.green.Render(label) + dot + zeroTheme.green.Render(name)
@@ -817,8 +819,7 @@ func wrapDetailBlock(detail string, width int) string {
 
 // renderFocusedPermissionPrompt draws the modal permission card and reports the
 // card-relative Y offset of each option line (in permissionOptions order) so the
-// caller can register those lines as clickable. cursor is the highlighted option
-// (default 0 = allow once); the a/y/d hotkeys still resolve directly.
+// caller can register those lines as clickable.
 func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, width int) (string, []int) {
 	name := strings.TrimSpace(request.ToolName)
 	if name == "" {
@@ -852,8 +853,8 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	// label; the rest stay quiet. styledBlockFill prepends exactly one top-border
 	// line, so an option at content index i renders at card line i+1 — the offset
 	// returned for click registration.
-	options := permissionOptions()
-	cursor = clampPermissionCursor(cursor)
+	options := permissionOptions(request)
+	cursor = clampPermissionCursor(cursor, request)
 	offsets := make([]int, len(options))
 	for index, option := range options {
 		offsets[index] = 1 + len(lines)
@@ -883,13 +884,33 @@ func permissionScopeLine(request agent.PermissionRequest, scope string) string {
 }
 
 func permissionOptionLabel(option permissionOption, request agent.PermissionRequest) string {
-	if option.choice != permissionDecisionAlwaysAllow || strings.TrimSpace(request.Scope) == "" {
+	switch option.choice {
+	case permissionDecisionAllow:
+		if request.SideEffect == string(tools.SideEffectNetwork) {
+			return "Yes, just this once"
+		}
+		return "Yes, proceed"
+	case permissionDecisionAllowForSession:
+		if request.SideEffect == string(tools.SideEffectNetwork) {
+			return "Yes, and allow this host for this conversation"
+		}
+		if request.SideEffect == string(tools.SideEffectWrite) && strings.TrimSpace(request.Scope) != "" {
+			return "Yes, and don't ask again for these files in this session"
+		}
+		return "Yes, and don't ask again for this command in this session"
+	case permissionDecisionAlwaysAllow:
+		if request.SideEffect == string(tools.SideEffectNetwork) {
+			return "Yes, and allow this host in the future"
+		}
+		if strings.TrimSpace(request.Scope) != "" {
+			return "Yes, and don't ask again for this scope"
+		}
+		return option.label
+	case permissionDecisionDeny:
+		return "No, and tell Zero what to do differently"
+	default:
 		return option.label
 	}
-	if request.SideEffect == string(tools.SideEffectNetwork) {
-		return "always for this host"
-	}
-	return "always for this scope"
 }
 
 func permissionEventScopeLabel(event *agent.PermissionEvent) string {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -1249,13 +1249,13 @@ func TestFocusedPermissionCardShowsBadgeRiskAndKeys(t *testing.T) {
 	}
 	card, offsets := renderFocusedPermissionPrompt(request, 0, 80)
 	got := plainRender(t, card)
-	for _, want := range []string{"PERMISSION", "risk: medium", "edit_file", "writes internal/agent/exec.go", "allow once", "[a]", "always", "[y]", "deny", "[d]", "[esc]"} {
+	for _, want := range []string{"PERMISSION", "risk: medium", "edit_file", "writes internal/agent/exec.go", "Yes, proceed", "[a]", "this session", "[s]", "don't ask again", "[y]", "tell Zero", "[d]", "[esc]"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("permission card = %q, missing %q", got, want)
 		}
 	}
-	if len(offsets) != len(permissionOptions()) {
-		t.Fatalf("offsets = %d, want one per option (%d)", len(offsets), len(permissionOptions()))
+	if len(offsets) != len(permissionOptions(request)) {
+		t.Fatalf("offsets = %d, want one per option (%d)", len(offsets), len(permissionOptions(request)))
 	}
 }
 
@@ -1274,6 +1274,17 @@ func TestPermissionPromptCollapsesAfterDecision(t *testing.T) {
 	}
 	if got := plainRender(t, m.renderRow(allowed, 80, rc)); !strings.Contains(got, "allowed once · bash") {
 		t.Fatalf("manual allow = %q, want allowed once · bash", got)
+	}
+
+	session := transcriptRow{kind: rowPermission, id: "call_session", permission: &agent.PermissionEvent{
+		ToolCallID: "call_session", ToolName: "bash", Action: agent.PermissionActionAllow, DecisionAction: agent.PermissionDecisionAllowForSession,
+	}}
+	rcSession := buildRowContext([]transcriptRow{
+		{kind: rowPermission, id: "call_session", permission: &agent.PermissionEvent{ToolCallID: "call_session", ToolName: "bash", Action: agent.PermissionActionPrompt}},
+		session,
+	})
+	if got := plainRender(t, m.renderRow(session, 80, rcSession)); !strings.Contains(got, "allowed for session · bash") {
+		t.Fatalf("session allow = %q, want allowed for session · bash", got)
 	}
 
 	grant := &agent.PermissionEvent{ToolCallID: "call_2", ToolName: "bash", Action: agent.PermissionActionAllow}

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -454,6 +454,7 @@ func permissionEventFromPayload(payload map[string]any) agent.PermissionEvent {
 		ToolCallID:        firstNonEmptyString(payloadString(payload, "toolCallId"), payloadString(payload, "id")),
 		ToolName:          name,
 		Action:            agent.PermissionAction(payloadString(payload, "action")),
+		DecisionAction:    agent.PermissionDecisionAction(payloadString(payload, "decisionAction")),
 		Permission:        payloadString(payload, "permission"),
 		PermissionGranted: payloadBool(payload, "permissionGranted"),
 		PermissionMode:    agent.PermissionMode(payloadString(payload, "permissionMode")),

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -230,7 +230,7 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 			Autonomy: string(sandbox.AutonomyMedium),
 			Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
 				WorkspaceRoot: root,
-				Policy:        sandbox.DefaultPolicy(),
+				Policy:        promptWritePolicy(),
 			}),
 		},
 	})
@@ -473,7 +473,7 @@ func submitAndDrivePermissionRun(t *testing.T, m model, prompt string, key strin
 func newPermissionTestModel(root string, provider zeroruntime.Provider, registry *tools.Registry, store *sessions.Store, grantStore *sandbox.GrantStore, runtimeMessages chan<- tea.Msg) model {
 	engineOptions := sandbox.EngineOptions{
 		WorkspaceRoot: root,
-		Policy:        sandbox.DefaultPolicy(),
+		Policy:        promptWritePolicy(),
 	}
 	if grantStore != nil {
 		engineOptions.Store = grantStore
@@ -495,6 +495,12 @@ func newPermissionTestModel(root string, provider zeroruntime.Provider, registry
 			Sandbox:  sandbox.NewEngine(engineOptions),
 		},
 	})
+}
+
+func promptWritePolicy() sandbox.Policy {
+	policy := sandbox.DefaultPolicy()
+	policy.EnforceWorkspace = false
+	return policy
 }
 
 func writeFileToolScript(callID string, path string, content string) []zeroruntime.StreamEvent {

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -286,6 +286,9 @@ func permissionDetailText(event agent.PermissionEvent) string {
 	if event.Permission != "" {
 		parts = append(parts, "permission="+event.Permission)
 	}
+	if event.DecisionAction != "" {
+		parts = append(parts, "decision="+string(event.DecisionAction))
+	}
 	if event.PermissionMode != "" {
 		parts = append(parts, "mode="+string(event.PermissionMode))
 	}

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -177,7 +177,7 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				heightCacheStable: false, // the highlight changes with the cursor
 				render: func(startBodyY int) transcriptBodyRenderedItem {
 					block, offsets := renderFocusedPermissionPrompt(perm.request, perm.cursor, width)
-					options := permissionOptions()
+					options := permissionOptions(perm.request)
 					selectable := make([]transcriptSelectableLine, 0, len(offsets))
 					for index, offset := range offsets {
 						if index >= len(options) {


### PR DESCRIPTION
## Summary
- Add in-memory session approvals alongside persistent sandbox grants.
- Auto-allow built-in workspace file mutations when sandbox policy permits the target, while keeping outside-workspace writes denied.
- Send dynamic permission choices to the TUI for once, session, future, and deny decisions, with matching stream/session events.

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session-scoped permission grants: approve permissions for the current session only without storing persistent grants.
  * Permission prompts now dynamically display available decision options based on your sandbox configuration.

* **Improvements**
  * Workspace file mutations automatically allow in sandbox-protected environments.
  * Enhanced permission decision tracking and display in session history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->