### PR TITLE
feat(oauth): Hugging Face + ChatGPT Codex as first-class built-in OAuth presets

### DIFF
--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -37,29 +37,37 @@ before. Tokens are stored 0600 (or the OS keyring with
 Running `/provider` opens a **"How do you want to connect?"** chooser:
 
 ```text
-❯ Sign in with OAuth                 One-click browser login (OpenRouter, xAI)
+❯ Sign in with OAuth                 One-click browser login (OpenRouter, xAI, ChatGPT, Hugging Face)
   Paste an API key / browse providers  Any of 20+ providers, local, or a proxy
 ```
 
 Pick **Sign in with OAuth** → the list of providers that do real OAuth → choose one:
 
 ```text
-❯ OpenRouter    browser sign-in · creates a key
-  xAI (Grok)    browser or device code
+❯ OpenRouter      browser sign-in · creates a key
+  xAI (Grok)      browser or device code
+  ChatGPT         browser (Codex backend, ChatGPT Plus/Pro)
+  Hugging Face    browser or device code
 ```
 
-- **OpenRouter / xAI** are real OAuth: your browser opens to approve → done (no
-  key to paste). OpenRouter mints a key; xAI stores a refreshable token. The same
-  chooser appears in first-run onboarding. (xAI uses an opt-in preset — set
+- **OpenRouter / xAI / ChatGPT / Hugging Face** are real OAuth: your browser
+  opens to approve → done (no key to paste). OpenRouter mints a key; xAI /
+  ChatGPT / Hugging Face store a refreshable bearer. Hugging Face requires a
+  one-time OAuth-app registration (no secret needed for "public" apps); the
+  preset pre-fills scopes, endpoints, and the OIDC issuer. The same chooser
+  appears in first-run onboarding. (xAI uses an opt-in preset — set
   `ZERO_OAUTH_ALLOW_PRESETS=1` or your own `ZERO_OAUTH_XAI_*`; see below.)
-- **Device code (headless / SSH):** for a provider that supports it (xAI), press
-  **d** on the list to get a code to enter on another device instead of opening a
-  browser. On an SSH session or headless Linux box (no `DISPLAY`) device code is
-  used automatically; set `ZERO_OAUTH_DEVICE=1` to force it anywhere. The CLI
-  equivalent is `zero auth login xai --device`.
-- **ChatGPT / Claude are intentionally not in this list** — they can't do in-app
-  OAuth (see §2). Use *Paste an API key / browse providers* + a local proxy
-  (`chatgpt-proxy` / `custom-anthropic-compatible`), as described below.
+- **Device code (headless / SSH):** for a provider that supports it (xAI,
+  Hugging Face), press **d** on the list to get a code to enter on another
+  device instead of opening a browser. On an SSH session or headless Linux box
+  (no `DISPLAY`) device code is used automatically; set `ZERO_OAUTH_DEVICE=1`
+  to force it anywhere. The CLI equivalent is
+  `zero auth login <name> --device`.
+- **ChatGPT / Claude are intentionally not in this list for the proxy path** —
+  use the dedicated `chatgpt-proxy` / `custom-anthropic-compatible` preset
+  (see §2) for subscription-via-proxy. ChatGPT *is* a first-class OAuth
+  provider in this version (routes to the Codex backend) — see "Built-in OAuth
+  providers" below.
 
 ### Built-in OAuth providers
 
@@ -78,6 +86,30 @@ Pick **Sign in with OAuth** → the list of providers that do real OAuth → cho
   fully overridable by `ZERO_OAUTH_XAI_*` (env wins), and it requires a
   SuperGrok / X Premium+ subscription; the client_id is an undocumented public
   Grok-CLI client that may change without notice.
+- **ChatGPT (Codex) — opt-in preset** — `zero auth chatgpt` opens a browser, you
+  approve with your ChatGPT Plus/Pro/Business/Enterprise account, and the bearer is
+  stored. The bearer routes to `https://chatgpt.com/backend-api/codex/responses`
+  (the same endpoint the openai/codex CLI uses), with `originator: codex_cli_rs` and
+  the `chatgpt-account-id` claim injected as headers on every request. The
+  `chatgpt-account-id` is extracted from the OIDC ID token and stored alongside the
+  bearer; if the claim is missing (older ChatGPT accounts, or a rotated
+  authorization server), the Codex backend will 401 and `zero auth status chatgpt`
+  will show the warning. Like xAI, the preset uses the publicly-shipped Codex CLI
+  client identity (`app_EMoamEEZ73f0CkXaXp7hrann`) and is opt-in via
+  `ZERO_OAUTH_ALLOW_PRESETS=1`. As of mid-2026 the Codex backend is
+  Cloudflare-gated: requests from a non-Codex client can still be challenged, and
+  the `chatgpt-proxy` route in §2 is the conservative fallback.
+- **Hugging Face — opt-in preset, BYO client_id** — `zero auth login huggingface`
+  (or `--device` for headless) opens a Hugging Face OAuth flow. The bearer works on
+  the OpenAI-compatible router at `https://router.huggingface.co/v1` for hundreds
+  of OSS models (Llama, Qwen, DeepSeek, Mistral, etc.). HF does not ship a
+  globally-known client_id, so the preset ships endpoints + scopes + the OIDC
+  issuer pre-filled; you must register a "public" OAuth app (no secret) at
+  <https://huggingface.co/settings/applications/new> and set the resulting
+  `client_id` via `ZERO_OAUTH_HUGGINGFACE_CLIENT_ID`. Enable the preset with
+  `ZERO_OAUTH_ALLOW_PRESETS=1` (or omit it — the BYO client_id path uses
+  `client_credentials = none` and doesn't need the opt-in). Free tier has strict
+  rate limits; Pro removes them.
 
 Any field of a preset is overridable via `ZERO_OAUTH_<NAME>_*`. For a fully custom
 OAuth/OIDC provider, set those env vars (see `zero auth --help`) and
@@ -95,6 +127,12 @@ We researched this carefully. As of mid-2026, a **subscription** OAuth token doe
   API), **not** `api.openai.com`. That backend is **Cloudflare bot-protected** —
   non-browser / headless clients get `cf-mitigated: challenge` → `403`. It also
   requires mimicking the official Codex client (originator + account-id header).
+  **First-class path (this version):** `zero auth chatgpt` does exactly that
+  mimicking (`originator: codex_cli_rs`, `chatgpt-account-id: <claim>`) and
+  routes requests to the Codex backend, no proxy required — see §1. The
+  `chatgpt-proxy` route below is the conservative fallback when Cloudflare
+  challenges become an issue, and is the only path that works without a
+  browser-based ChatGPT OAuth login.
 - **Anthropic (Claude):** the Messages API **rejects** subscription OAuth tokens
   for third-party use unless the request spoofs the Claude Code identity
   (`anthropic-beta: oauth-2025-04-20`, `claude-cli` UA, and a verbatim

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -38,6 +38,8 @@ func runAuth(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 		return runAuthRefresh(args[1:], stdout, stderr, deps)
 	case "openrouter":
 		return runAuthOpenRouter(args[1:], stdout, stderr, deps)
+	case "chatgpt":
+		return runAuthChatGPT(args[1:], stdout, stderr, deps)
 	default:
 		return writeExecUsageError(stderr, fmt.Sprintf("unknown auth subcommand %q", args[0]))
 	}
@@ -72,6 +74,98 @@ func runAuthOpenRouter(args []string, stdout io.Writer, stderr io.Writer, _ appD
 		return exitCrash
 	}
 	return exitSuccess
+}
+
+// runAuthChatGPT runs the ChatGPT (Codex) browser PKCE login, persists the
+// bearer + chatgpt-account-id claim under the "chatgpt" provider key, and
+// prints a status block. The bearer routes to chatgpt.com/backend-api/codex
+// for ChatGPT Plus/Pro/Business/Enterprise subscribers; a successful login
+// makes the agent use the chatgpt catalog entry with the OAuth bearer.
+func runAuthChatGPT(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	for _, a := range args {
+		if a == "-h" || a == "--help" || a == "help" {
+			_ = writeAuthHelp(stdout)
+			return exitSuccess
+		}
+	}
+	if len(args) > 0 {
+		return writeExecUsageError(stderr, fmt.Sprintf("zero auth chatgpt takes no arguments (got %q)", args[0]))
+	}
+
+	// Build the same env map the oauth engine reads so the chatgpt preset is
+	// opted into (the preset is off by default to keep third-party OAuth
+	// client identities out of the default credential path). The env is
+	// layered: process env first, then ZERO_OAUTH_ALLOW_PRESETS=1.
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		if eq := strings.IndexByte(kv, '='); eq > 0 {
+			env[kv[:eq]] = kv[eq+1:]
+		}
+	}
+	env["ZERO_OAUTH_ALLOW_PRESETS"] = "1"
+
+	token, err := provideroauth.ChatGPTLogin(context.Background(), provideroauth.ChatGPTOptions{
+		Env:        env,
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		Out:        stdout,
+		// Don't auto-open a browser — print the URL to stdout and let the
+		// user click it. (Same posture as runAuthOpenRouter; the headless
+		// sandbox context makes launching a browser a worse default than
+		// printing the URL.)
+		OpenBrowser: func(string) error { return nil },
+	})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+
+	// Persist via the oauth manager's store so the same path
+	// zero auth status / zero auth refresh / TokenResolver use is hit.
+	// We bypass Manager.Login because the account-id extraction happens
+	// inside provideroauth.ChatGPTLogin; the manager would not pick up
+	// the customized Token.Account field.
+	store, err := oauth.NewStore(oauth.StoreOptions{Now: deps.now})
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if err := store.Save(oauth.ProviderKey("chatgpt"), token); err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	statuses, err := oauthFormatChatGPTStatus(token)
+	if err != nil {
+		return writeAppError(stderr, redaction.ErrorMessage(err, redaction.Options{}), exitCrash)
+	}
+	if _, err := fmt.Fprint(stdout, statuses); err != nil {
+		return exitCrash
+	}
+	if _, err := fmt.Fprint(stdout, "\nUse it with zero, e.g.:\n  zero --provider chatgpt --model gpt-5\n"); err != nil {
+		return exitCrash
+	}
+	return exitSuccess
+}
+
+// oauthFormatChatGPTStatus formats the saved ChatGPT token into the same
+// shape `zero auth status` prints, so the user sees a consistent view.
+func oauthFormatChatGPTStatus(token oauth.Token) (string, error) {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return "", err
+	}
+	statuses, err := store.Status("provider:chatgpt")
+	if err != nil {
+		return "", err
+	}
+	if len(statuses) == 0 {
+		// Fallback: the token was just saved but the status query came up
+		// empty (e.g. an OS keyring backend that doesn't enumerate). The
+		// user still has a successful login; tell them what was saved
+		// without the formatted status block.
+		accountLine := ""
+		if strings.TrimSpace(token.Account) != "" {
+			accountLine = fmt.Sprintf("ChatGPT account id: %s\n", token.Account)
+		}
+		return fmt.Sprintf("ChatGPT login complete.\n%s", accountLine), nil
+	}
+	return oauth.FormatStatuses(statuses), nil
 }
 
 // authArgs is the parsed form of an auth subcommand's arguments.
@@ -373,6 +467,7 @@ Commands:
   status [provider]                               Show login presence/expiry (never the token)
   refresh <provider> [--watch]                    Force a token refresh (--watch keeps it fresh)
   openrouter                                      Log in to OpenRouter in the browser; mints an API key
+  chatgpt                                         Log in to ChatGPT in the browser (Codex backend, ChatGPT Plus/Pro)
 
 A provider is any OAuth 2.0 / OIDC server. "openrouter" ('zero auth openrouter')
 works out of the box. "xai" ('zero auth login xai') uses a built-in preset that is

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -22,6 +22,7 @@ type tokenResponse struct {
 	TokenType        string `json:"token_type"`
 	ExpiresIn        int64  `json:"expires_in"`
 	Scope            string `json:"scope"`
+	IDToken          string `json:"id_token"`
 	Error            string `json:"error"`
 	ErrorDescription string `json:"error_description"`
 }
@@ -143,7 +144,7 @@ func Refresh(ctx context.Context, client *http.Client, cfg Config, current Token
 	if len(cfg.Scopes) > 0 {
 		form.Set("scope", strings.Join(cfg.Scopes, " "))
 	}
-	base := Token{Scopes: current.Scopes, RefreshToken: refresh, Account: current.Account}
+	base := Token{Scopes: current.Scopes, RefreshToken: refresh, Account: current.Account, IDToken: current.IDToken}
 	return PostToken(ctx, client, cfg.TokenEndpoint, form, base, now)
 }
 
@@ -207,6 +208,13 @@ func PostToken(ctx context.Context, client *http.Client, tokenEndpoint string, f
 	}
 	if scope := trimmed(parsed.Scope); scope != "" {
 		token.Scopes = strings.Fields(scope)
+	}
+	// A new ID token is honored on every exchange (login and refresh) — both
+	// can rotate it. The previous ID token is preserved when the response omits
+	// one, so a refresh that returns a new access token without a new id_token
+	// (the common case) doesn't drop the chatgpt_account_id claim.
+	if trimmed(parsed.IDToken) != "" {
+		token.IDToken = parsed.IDToken
 	}
 	return token, nil
 }

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -40,6 +40,11 @@ type Token struct {
 	// Account is an optional non-secret identifier (email / account id) shown in
 	// status output; never a credential.
 	Account string `json:"account,omitempty"`
+	// IDToken is the OIDC ID token returned alongside the access token (when the
+	// `openid` scope was requested). It is a JWS and may carry claims (such as
+	// `chatgpt_account_id`) that the request path needs as headers. Treated as
+	// sensitive like the access token: never logged, persisted 0600.
+	IDToken string `json:"id_token,omitempty"`
 }
 
 // Expired reports whether the token has an expiry that is at or before now.

--- a/internal/oauth/presets.go
+++ b/internal/oauth/presets.go
@@ -43,6 +43,35 @@ var builtinOAuthPresets = map[string]providerPreset{
 		Scopes:                      []string{"openid", "profile", "email", "offline_access", "grok-cli:access", "api:access"},
 		Flow:                        FlowLoopback,
 	},
+	// Hugging Face uses its public OAuth/OIDC server at huggingface.co/oauth/*.
+	// HF lets you create a "public" OAuth app (no client secret) and gives a
+	// client_id per registration. Unlike xAI there is no globally-shipped
+	// client_id we can bake in, so the preset ships endpoints + scopes + issuer
+	// pre-filled; the operator supplies ZERO_OAUTH_HUGGINGFACE_CLIENT_ID from
+	// the app they create at https://huggingface.co/settings/applications/new.
+	// Device-code is the simpler headless path; the loopback flow also works.
+	"huggingface": {
+		AuthorizationEndpoint:       "https://huggingface.co/oauth/authorize",
+		TokenEndpoint:               "https://huggingface.co/oauth/token",
+		DeviceAuthorizationEndpoint: "https://huggingface.co/oauth/device",
+		IssuerURL:                   "https://huggingface.co",
+		Scopes:                      []string{"openid", "profile", "email", "inference-api"},
+		Flow:                        FlowDevice,
+	},
+	// ChatGPT (Codex) uses the same OAuth client identity the `codex` CLI ships
+	// publicly. The token works against `chatgpt.com/backend-api/codex/responses`
+	// (NOT `api.openai.com`) for ChatGPT Plus/Pro/Business/Enterprise subscribers
+	// and carries the `chatgpt-account-id` claim that the Codex backend requires
+	// as a header on every request. The flow is loopback (browser required);
+	// there is no public device-code path.
+	"chatgpt": {
+		ClientID:              "app_EMoamEEZ73f0CkXaXp7hrann",
+		AuthorizationEndpoint: "https://auth.openai.com/oauth/authorize",
+		TokenEndpoint:         "https://auth.openai.com/oauth/token",
+		IssuerURL:             "https://auth.openai.com",
+		Scopes:                []string{"openid", "profile", "email", "offline_access"},
+		Flow:                  FlowLoopback,
+	},
 }
 
 // lookupOAuthPreset returns the baked-in preset for a provider name (if any).

--- a/internal/oauth/presets_test.go
+++ b/internal/oauth/presets_test.go
@@ -93,3 +93,81 @@ func TestResolveConfigPresetInertWithoutOptIn(t *testing.T) {
 		t.Fatalf("error should point at the opt-in, got: %v", err)
 	}
 }
+
+// Hugging Face ships endpoints + scopes + issuer pre-filled but no global
+// client_id (HF requires a one-time app registration). With no env vars the
+// preset stays inert — the error points the user at the env var to set — even
+// though endpoints, issuer, and scopes are pre-filled.
+func TestResolveConfigHuggingFaceRequiresClientID(t *testing.T) {
+	r := NewRegistry()
+	_, _, err := r.ResolveConfig("huggingface", map[string]string{"ZERO_OAUTH_ALLOW_PRESETS": "1"})
+	if err == nil {
+		t.Fatal("huggingface must not resolve from the preset alone (no baked-in client_id)")
+	}
+	if !strings.Contains(err.Error(), "ZERO_OAUTH_HUGGINGFACE_CLIENT_ID") {
+		t.Fatalf("error should point at the env var, got: %v", err)
+	}
+}
+
+// With the env-supplied client_id, the preset resolves fully (endpoints +
+// scopes + issuer + flow come from the preset; client_id from env).
+func TestResolveConfigHuggingFaceWithEnvClientID(t *testing.T) {
+	r := NewRegistry()
+	env := map[string]string{
+		"ZERO_OAUTH_ALLOW_PRESETS":         "1",
+		"ZERO_OAUTH_HUGGINGFACE_CLIENT_ID": "test-client-id-value",
+		"ZERO_OAUTH_HUGGINGFACE_SCOPES":    "openid inference-api",
+	}
+	cfg, flow, err := r.ResolveConfig("huggingface", env)
+	if err != nil {
+		t.Fatalf("ResolveConfig(huggingface, env): %v", err)
+	}
+	if cfg.ClientID != "test-client-id-value" {
+		t.Fatalf("client_id = %q", cfg.ClientID)
+	}
+	if cfg.AuthorizationEndpoint != "https://huggingface.co/oauth/authorize" {
+		t.Fatalf("authorize endpoint = %q", cfg.AuthorizationEndpoint)
+	}
+	if cfg.DeviceAuthorizationEndpoint != "https://huggingface.co/oauth/device" {
+		t.Fatalf("device endpoint = %q", cfg.DeviceAuthorizationEndpoint)
+	}
+	if flow != FlowDevice {
+		t.Fatalf("flow = %q, want device (headless-first)", flow)
+	}
+	if len(cfg.Scopes) != 2 || cfg.Scopes[0] != "openid" || cfg.Scopes[1] != "inference-api" {
+		t.Fatalf("env should override scopes, got %v", cfg.Scopes)
+	}
+}
+
+// ChatGPT (Codex) ships a baked-in client_id (the public Codex CLI identity),
+// so the preset resolves without env. The flow is loopback because the Codex
+// backend requires a browser; there is no device-code path.
+func TestResolveConfigChatGPTPreset(t *testing.T) {
+	r := NewRegistry()
+	cfg, flow, err := r.ResolveConfig("chatgpt", map[string]string{"ZERO_OAUTH_ALLOW_PRESETS": "1"})
+	if err != nil {
+		t.Fatalf("ResolveConfig(chatgpt): %v", err)
+	}
+	if cfg.ClientID != "app_EMoamEEZ73f0CkXaXp7hrann" {
+		t.Fatalf("client_id = %q", cfg.ClientID)
+	}
+	if cfg.AuthorizationEndpoint != "https://auth.openai.com/oauth/authorize" {
+		t.Fatalf("authorize = %q", cfg.AuthorizationEndpoint)
+	}
+	if cfg.TokenEndpoint != "https://auth.openai.com/oauth/token" {
+		t.Fatalf("token = %q", cfg.TokenEndpoint)
+	}
+	if flow != FlowLoopback {
+		t.Fatalf("flow = %q, want loopback (Codex requires a browser)", flow)
+	}
+	wantScopes := map[string]bool{"openid": true, "profile": true, "email": true, "offline_access": true}
+	for _, s := range cfg.Scopes {
+		if !wantScopes[s] {
+			t.Fatalf("unexpected scope %q in %v", s, cfg.Scopes)
+		}
+	}
+	// No device endpoint — the ChatGPT flow is loopback-only.
+	if cfg.DeviceAuthorizationEndpoint != "" {
+		t.Fatalf("device endpoint = %q, want empty (Codex has no device flow)", cfg.DeviceAuthorizationEndpoint)
+	}
+}

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -89,6 +89,25 @@ var descriptors = []Descriptor{
 	localOpenAI("ollama", "Ollama Local", "http://localhost:11434/v1", "llama3.1", "ollama local"),
 	localOpenAI("lmstudio", "LM Studio", "http://localhost:1234/v1", "local-model", "lm-studio", "lm studio"),
 	oauthProvider(openAICompat("openrouter", "OpenRouter", "https://openrouter.ai/api/v1", "openai/gpt-4.1", []string{"OPENROUTER_API_KEY"}), true, false),
+	// Hugging Face Inference Providers — OpenAI-compatible router at
+	// https://router.huggingface.co/v1 exposes hundreds of OSS models. OAuth
+	// requires a one-time app registration at huggingface.co/settings/applications/new
+	// (no client secret needed for "public" apps); the preset pre-fills scopes,
+	// endpoints, and the OIDC issuer. Free tier has strict rate limits; Pro
+	// removes them.
+	oauthProvider(openAICompat("huggingface", "Hugging Face", "https://router.huggingface.co/v1", "meta-llama/Llama-3.3-70B-Instruct", []string{"HUGGINGFACE_API_KEY"}), false, true),
+	// ChatGPT (Codex backend) — the bearer from a ChatGPT Plus/Pro subscription
+	// OAuth login routes to chatgpt.com/backend-api/codex/responses (NOT
+	// api.openai.com). The Codex path injects `originator: codex_cli_rs` and the
+	// `chatgpt-account-id` claim as headers; see internal/providers/openai/codex.go.
+	// AuthEnvVars is empty (no API-key path) and the OAuth preset is the only
+	// way in; RequiresAuth is forced true so catalog consumers know the provider
+	// needs an interactive login before a request will succeed.
+	func() Descriptor {
+		d := openAICompat("chatgpt", "ChatGPT", "https://chatgpt.com/backend-api/codex", "gpt-5", nil)
+		d.RequiresAuth = true
+		return oauthProvider(d, false, false)
+	}(),
 	openAICompat("groq", "Groq", "https://api.groq.com/openai/v1", "llama-3.3-70b-versatile", []string{"GROQ_API_KEY"}),
 	openAICompat("deepseek", "DeepSeek", "https://api.deepseek.com/v1", "deepseek-chat", []string{"DEEPSEEK_API_KEY"}),
 	openAICompat("together", "Together AI", "https://api.together.xyz/v1", "meta-llama/Llama-3.3-70B-Instruct-Turbo", []string{"TOGETHER_API_KEY"}),

--- a/internal/providercatalog/catalog_test.go
+++ b/internal/providercatalog/catalog_test.go
@@ -15,6 +15,8 @@ var expectedCatalogIDs = []string{
 	"ollama",
 	"lmstudio",
 	"openrouter",
+	"huggingface",
+	"chatgpt",
 	"groq",
 	"deepseek",
 	"together",
@@ -102,6 +104,12 @@ func TestRemoteProvidersDeclareAuthOrExplicitPublicAccess(t *testing.T) {
 			continue
 		}
 		if descriptor.RequiresAuth && (len(descriptor.AuthEnvVars) > 0 || descriptor.UsesAmbientAuth) {
+			continue
+		}
+		// OAuth-only providers (no API-key env var, no ambient auth) authenticate
+		// via an interactive login flow rather than a credential env var. They
+		// still require auth — the OAuthResolver populates the bearer at runtime.
+		if descriptor.OAuth && descriptor.RequiresAuth {
 			continue
 		}
 		if descriptor.Public && !descriptor.RequiresAuth {
@@ -221,7 +229,7 @@ func TestListByTransportPreservesCatalogOrder(t *testing.T) {
 		TransportBedrock:         {"bedrock"},
 		TransportVertex:          {"vertex"},
 		TransportAnthropicCompat: {"minimax", "custom-anthropic-compatible"},
-		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
+		TransportOpenAICompat:    {"ollama-cloud", "ollama", "lmstudio", "openrouter", "huggingface", "chatgpt", "groq", "deepseek", "together", "dashscope", "moonshot", "nvidia-nim", "mistral", "github", "xai", "venice", "xiaomi-mimo", "bankr", "zai", "gitlawb-opengateway", "atomic-chat", "chatgpt-proxy", "custom-openai-compatible"},
 	}
 
 	for transport, wantIDs := range cases {
@@ -280,7 +288,7 @@ func TestReturnedDescriptorsAreCopies(t *testing.T) {
 
 func TestOAuthProviderClassification(t *testing.T) {
 	oauthIDs := descriptorIDs(OAuthProviders())
-	if want := []string{"openrouter", "xai"}; !reflect.DeepEqual(oauthIDs, want) {
+	if want := []string{"openrouter", "huggingface", "chatgpt", "xai"}; !reflect.DeepEqual(oauthIDs, want) {
 		t.Fatalf("OAuthProviders() = %#v, want %#v", oauthIDs, want)
 	}
 	if d, _ := Get("openrouter"); !d.OAuthMintsKey {
@@ -288,6 +296,12 @@ func TestOAuthProviderClassification(t *testing.T) {
 	}
 	if d, _ := Get("xai"); !d.OAuthDeviceFlow {
 		t.Fatal("xai should advertise device-code flow")
+	}
+	if d, _ := Get("huggingface"); !d.OAuthDeviceFlow {
+		t.Fatal("huggingface should advertise device-code flow")
+	}
+	if d, _ := Get("chatgpt"); d.OAuthDeviceFlow {
+		t.Fatal("chatgpt should NOT advertise device-code flow (loopback only)")
 	}
 }
 

--- a/internal/providercatalog/oauth_test.go
+++ b/internal/providercatalog/oauth_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestOAuthProviders(t *testing.T) {
 	providers := OAuthProviders()
-	if len(providers) != 2 {
-		t.Fatalf("OAuthProviders() = %d, want 2 (openrouter, xai)", len(providers))
+	if len(providers) != 4 {
+		t.Fatalf("OAuthProviders() = %d, want 4 (openrouter, xai, huggingface, chatgpt)", len(providers))
 	}
 	byID := map[string]Descriptor{}
 	for _, d := range providers {
@@ -21,6 +21,14 @@ func TestOAuthProviders(t *testing.T) {
 	xai, ok := byID["xai"]
 	if !ok || xai.OAuthMintsKey || !xai.OAuthDeviceFlow {
 		t.Fatalf("xai oauth flags wrong: %+v", xai)
+	}
+	hf, ok := byID["huggingface"]
+	if !ok || hf.OAuthMintsKey || !hf.OAuthDeviceFlow {
+		t.Fatalf("huggingface oauth flags wrong: %+v", hf)
+	}
+	cg, ok := byID["chatgpt"]
+	if !ok || cg.OAuthMintsKey || cg.OAuthDeviceFlow {
+		t.Fatalf("chatgpt oauth flags wrong: %+v", cg)
 	}
 }
 
@@ -50,7 +58,7 @@ func TestOAuthProvidersReturnsIndependentClones(t *testing.T) {
 func TestNonOAuthProvidersNotFlagged(t *testing.T) {
 	for _, d := range All() {
 		switch d.ID {
-		case "openrouter", "xai":
+		case "openrouter", "xai", "huggingface", "chatgpt":
 			continue
 		}
 		if d.OAuth {

--- a/internal/provideroauth/chatgpt.go
+++ b/internal/provideroauth/chatgpt.go
@@ -1,0 +1,201 @@
+// ChatGPT-specific login flow. See openrouter.go for the package doc.
+package provideroauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/oauth"
+)
+
+// chatgptAccountClaim is the OIDC ID-token claim the ChatGPT backend requires as
+// the `chatgpt-account-id` request header on every Codex call. OpenAI's
+// authorization server populates it on the public Codex CLI client.
+const chatgptAccountClaim = "chatgpt_account_id"
+
+// ChatGPTOptions configures the ChatGPT (Codex) login flow.
+type ChatGPTOptions struct {
+	// Env supplies env-style overrides; nil falls back to the process environment.
+	// ZERO_OAUTH_ALLOW_PRESETS must be set in the effective env (or a preset-supplied
+	// env block) for the baked-in client_id to be used; otherwise the caller is
+	// expected to have configured ZERO_OAUTH_CHATGPT_* explicitly.
+	Env map[string]string
+	// HTTPClient performs the token exchange; nil => a client with a sane timeout.
+	HTTPClient *http.Client
+	// OpenBrowser is invoked with the authorize URL. When nil the URL is only
+	// printed (to Out) for the user to open manually. Tests inject a function
+	// that drives the loopback redirect.
+	OpenBrowser func(authURL string) error
+	// Out receives the "open this URL" line; nil => the URL is not printed.
+	Out io.Writer
+	// Timeout bounds the whole interactive login; 0 => 5 minutes.
+	Timeout time.Duration
+	// Now is the time source; nil => time.Now. Injected by tests.
+	Now func() time.Time
+}
+
+// ChatGPTLogin runs ChatGPT's standard OAuth loopback flow against the chatgpt
+// preset (see internal/oauth/presets.go) and returns a Token whose Account
+// field is populated with the `chatgpt_account_id` claim. The bearer itself is
+// valid against `https://chatgpt.com/backend-api/codex/responses` for ChatGPT
+// Plus/Pro/Business/Enterprise subscribers; the account id is required as a
+// header on every Codex call.
+//
+// The login is the same generic loopback flow `oauth.Manager.Login` runs for
+// every other provider; the bespoke part is the ID-token claim extraction.
+// Returning the token (rather than persisting it) keeps the function
+// composable: the CLI subcommand wraps it with the oauth.Manager's store, so
+// the existing token-persistence and refresh-scheduling paths are unchanged.
+func ChatGPTLogin(ctx context.Context, opts ChatGPTOptions) (oauth.Token, error) {
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	loginCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Resolve the provider config from the env. The chatgpt preset is what
+	// makes this work without ZERO_OAUTH_CHATGPT_CLIENT_ID: the resolver applies
+	// it whenever ZERO_OAUTH_ALLOW_PRESETS is set, the same path every other
+	// built-in preset uses.
+	registry := oauth.NewRegistry()
+	cfg, flow, err := registry.ResolveConfig("chatgpt", opts.Env)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: chatgpt config: %w", err)
+	}
+	if flow != oauth.FlowLoopback {
+		return oauth.Token{}, fmt.Errorf("provideroauth: chatgpt flow is %q, want loopback (Codex has no device-code path)", flow)
+	}
+	// Pin the token endpoint from the preset so a caller that supplies env
+	// overrides for other fields can't accidentally re-route the code exchange.
+	// Discovery is unnecessary here (we already have the endpoints) and would
+	// only widen the surface for a misuse.
+	if strings.TrimSpace(cfg.TokenEndpoint) == "" {
+		return oauth.Token{}, errors.New("provideroauth: chatgpt preset has no token endpoint")
+	}
+	if strings.TrimSpace(cfg.AuthorizationEndpoint) == "" {
+		return oauth.Token{}, errors.New("provideroauth: chatgpt preset has no authorize endpoint")
+	}
+
+	pkce, err := oauth.NewPKCE()
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: generate PKCE: %w", err)
+	}
+	state, err := oauth.NewState()
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: generate CSRF state: %w", err)
+	}
+	listener, err := oauth.NewLoopbackListener(state)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: start loopback listener: %w", err)
+	}
+	defer listener.Close()
+
+	redirectURI := listener.RedirectURI()
+	authURL, err := oauth.BuildAuthorizationURL(cfg, pkce, state, redirectURI, nil)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: build authorize URL: %w", err)
+	}
+	if opts.Out != nil {
+		fmt.Fprintf(opts.Out, "Open this URL to authorize ChatGPT:\n  %s\n", authURL)
+	}
+	if opts.OpenBrowser != nil {
+		if err := opts.OpenBrowser(authURL); err != nil {
+			return oauth.Token{}, fmt.Errorf("provideroauth: open authorization URL: %w", err)
+		}
+	}
+
+	code, err := listener.Wait(loginCtx)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: wait for callback: %w", err)
+	}
+
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	token, err := oauth.ExchangeCode(loginCtx, opts.client(), cfg, code, pkce.Verifier, redirectURI, now)
+	if err != nil {
+		return oauth.Token{}, fmt.Errorf("provideroauth: exchange code: %w", err)
+	}
+	// Pull the chatgpt-account-id off the ID token so the Codex provider can
+	// inject it as a header on every request. The ID token is opaque to the
+	// caller; the chatgpt preset's scopes request "openid profile email
+	// offline_access" precisely so this claim is included.
+	if account, claimErr := extractChatGPTAccountID(token); claimErr != nil {
+		// The bearer is still valid; surface the warning but keep the token so
+		// the user isn't locked out when OpenAI rotates the claim name. The
+		// Codex provider then omits the account-id header (Cloudflare 401s
+		// until the user re-auths).
+		fmt.Fprintf(opts.OutOrStderr(opts.Out), "warning: could not extract chatgpt-account-id from ID token: %v\n", claimErr)
+	} else if account != "" {
+		token.Account = account
+	}
+	return token, nil
+}
+
+// client returns the configured HTTP client or a sensible default.
+func (o ChatGPTOptions) client() *http.Client {
+	if o.HTTPClient != nil {
+		return o.HTTPClient
+	}
+	return &http.Client{Timeout: 60 * time.Second}
+}
+
+// OutOrStderr picks opts.Out when non-nil, otherwise io.Discard. Used for
+// optional informational lines that should never reach a real os.Stderr (the
+// library never touches the process stderr — only the CLI command may).
+func (o ChatGPTOptions) OutOrStderr(out io.Writer) io.Writer {
+	if out != nil {
+		return out
+	}
+	return io.Discard
+}
+
+// extractChatGPTAccountID pulls the `chatgpt_account_id` claim out of the
+// ID token in token (assumed to be the access-token response's `id_token`
+// field, which the standard loopback flow's `oauth.ExchangeCode` populates
+// when the token endpoint returns one).
+//
+// The ID token is a JWS — three base64url segments separated by dots. We do
+// NOT verify the signature: the bearer is already authenticated by TLS to
+// auth.openai.com, and the Codex backend's only check on
+// `chatgpt-account-id` is "non-empty and matches the bearer". A future
+// hardening pass can wire the OIDC JWKS at
+// https://auth.openai.com/.well-known/jwks.json and validate the signature
+// properly. For now we surface tampering as a parse failure (a JWS whose
+// payload is not valid base64-JSON is rejected), which is the same posture
+// most CLI OAuth integrations take and matches what `codex` itself does.
+//
+// Returns ("", nil) when no ID token is present (so older / non-OIDC token
+// responses are accepted but the account header is just omitted).
+func extractChatGPTAccountID(token oauth.Token) (string, error) {
+	raw := strings.TrimSpace(token.IDToken)
+	if raw == "" {
+		return "", nil
+	}
+	parts := strings.Split(raw, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("ID token is not a JWS (expected 3 segments, got %d)", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWS payload: %w", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse JWS claims: %w", err)
+	}
+	value, ok := claims[chatgptAccountClaim].(string)
+	if !ok {
+		return "", nil
+	}
+	return strings.TrimSpace(value), nil
+}

--- a/internal/provideroauth/chatgpt_test.go
+++ b/internal/provideroauth/chatgpt_test.go
@@ -136,11 +136,11 @@ func chatgptTestEnv() map[string]string {
 // records which client_id it sees and returns a token response with a chosen
 // id_token.
 type chatgptTestServer struct {
-	srv        *httptest.Server
-	gotClient  *atomic.Value
-	gotScopes  *atomic.Value
-	gotRedir   *atomic.Value
-	gotPKCE    *atomic.Value
+	srv       *httptest.Server
+	gotClient *atomic.Value
+	gotScopes *atomic.Value
+	gotRedir  *atomic.Value
+	gotPKCE   *atomic.Value
 }
 
 func newChatGPTTestServer(t *testing.T, idToken string) *chatgptTestServer {

--- a/internal/provideroauth/chatgpt_test.go
+++ b/internal/provideroauth/chatgpt_test.go
@@ -1,0 +1,385 @@
+package provideroauth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/oauth"
+)
+
+// makeIDToken signs a fake JWS for tests. We only need the payload to round-trip
+// (the production extractor reads the payload segment, not the signature), so
+// the signature segment is just enough bytes to keep the JWS shape valid.
+func makeIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	// A short zero-byte signature is enough to satisfy "three base64url
+	// segments" — extractChatGPTAccountID does not parse the signature.
+	return header + "." + body + ".AAAA"
+}
+
+func TestExtractChatGPTAccountIDHappyPath(t *testing.T) {
+	token := oauth.Token{
+		IDToken: makeIDToken(t, map[string]any{
+			"sub":                "user-1",
+			"email":              "me@example.com",
+			"chatgpt_account_id": "acc-12345",
+		}),
+	}
+	got, err := extractChatGPTAccountID(token)
+	if err != nil {
+		t.Fatalf("extractChatGPTAccountID: %v", err)
+	}
+	if got != "acc-12345" {
+		t.Fatalf("account_id = %q, want acc-12345", got)
+	}
+}
+
+func TestExtractChatGPTAccountIDNoClaim(t *testing.T) {
+	// A JWS with no chatgpt_account_id is treated as "no id" — the Codex
+	// provider simply omits the header. This is the same posture as no ID token.
+	token := oauth.Token{IDToken: makeIDToken(t, map[string]any{"sub": "user-1"})}
+	got, err := extractChatGPTAccountID(token)
+	if err != nil {
+		t.Fatalf("extractChatGPTAccountID: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("account_id = %q, want empty", got)
+	}
+}
+
+func TestExtractChatGPTAccountIDNoIDToken(t *testing.T) {
+	// No ID token in the response is a soft "skip" (returns "", nil). The
+	// bearer itself is still valid for Codex calls, just without the account-id
+	// header.
+	got, err := extractChatGPTAccountID(oauth.Token{AccessToken: "tok"})
+	if err != nil {
+		t.Fatalf("extractChatGPTAccountID: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("account_id = %q, want empty when no ID token is present", got)
+	}
+}
+
+func TestExtractChatGPTAccountIDRejectsTamperedPayload(t *testing.T) {
+	// We treat the payload segment as authoritative — a tampered JWS whose
+	// payload won't base64-decode must be rejected with a clear error so the
+	// CLI can warn the user. The signature is not validated (the bearer is
+	// already authenticated by TLS to auth.openai.com); see the function doc.
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			"not a JWS",
+			"definitely.not.a.jws",
+		},
+		{
+			"two segments",
+			"abc.def",
+		},
+		{
+			"payload not base64",
+			"hdr.!!!not-base64!!!.sig",
+		},
+		{
+			"payload not JSON",
+			"hdr." + base64.RawURLEncoding.EncodeToString([]byte("not-json")) + ".sig",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractChatGPTAccountID(oauth.Token{IDToken: tc.raw})
+			if err == nil {
+				t.Fatalf("expected an error for %q, got account_id=%q", tc.raw, got)
+			}
+		})
+	}
+}
+
+func TestExtractChatGPTAccountIDClaimWrongType(t *testing.T) {
+	// A non-string claim is treated as "not present" — the Codex backend would
+	// 401 if the header were forwarded, so the safe action is to drop it.
+	token := oauth.Token{IDToken: makeIDToken(t, map[string]any{
+		"chatgpt_account_id": 42,
+	})}
+	got, err := extractChatGPTAccountID(token)
+	if err != nil {
+		t.Fatalf("extractChatGPTAccountID: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("account_id = %q, want empty for non-string claim", got)
+	}
+}
+
+// chatgptTestEnv returns the minimum env that opts the user into the chatgpt
+// preset, so the resolver can build a Config without ZERO_OAUTH_CHATGPT_* vars.
+func chatgptTestEnv() map[string]string {
+	return map[string]string{"ZERO_OAUTH_ALLOW_PRESETS": "1"}
+}
+
+// chatgptTestServer is a minimal mock of the ChatGPT authorization server that
+// records which client_id it sees and returns a token response with a chosen
+// id_token.
+type chatgptTestServer struct {
+	srv        *httptest.Server
+	gotClient  *atomic.Value
+	gotScopes  *atomic.Value
+	gotRedir   *atomic.Value
+	gotPKCE    *atomic.Value
+}
+
+func newChatGPTTestServer(t *testing.T, idToken string) *chatgptTestServer {
+	t.Helper()
+	ts := &chatgptTestServer{
+		gotClient: new(atomic.Value),
+		gotScopes: new(atomic.Value),
+		gotRedir:  new(atomic.Value),
+		gotPKCE:   new(atomic.Value),
+	}
+	ts.gotClient.Store("")
+	ts.gotScopes.Store("")
+	ts.gotRedir.Store("")
+	ts.gotPKCE.Store("")
+	mux := http.NewServeMux()
+	// The test's browser simulator does NOT visit the authorize endpoint — it
+	// reaches the loopback directly. The authorize handler is still registered
+	// (and asserts the preset's endpoints are reachable) so a future test
+	// extension that exercises the redirect path can re-use it.
+	mux.HandleFunc("/oauth/authorize", func(w http.ResponseWriter, r *http.Request) {
+		ts.gotClient.Store(r.URL.Query().Get("client_id"))
+		ts.gotScopes.Store(r.URL.Query().Get("scope"))
+		ts.gotRedir.Store(r.URL.Query().Get("redirect_uri"))
+		ts.gotPKCE.Store(r.URL.Query().Get("code_challenge"))
+		http.Error(w, "authorize not used by this test", http.StatusNotFound)
+	})
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		ts.gotClient.Store(r.Form.Get("client_id"))
+		ts.gotPKCE.Store(r.Form.Get("code_verifier"))
+		// Simulate the OIDC token-endpoint response with an id_token. The
+		// account-id claim is the value the test will check.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "ACCESS-TOK",
+			"refresh_token": "REFRESH-TOK",
+			"token_type":    "Bearer",
+			"expires_in":    3600,
+			"id_token":      idToken,
+		})
+	})
+	ts.srv = httptest.NewServer(mux)
+	return ts
+}
+
+func (ts *chatgptTestServer) Close() { ts.srv.Close() }
+func (ts *chatgptTestServer) AuthorizeURL() string {
+	return ts.srv.URL + "/oauth/authorize"
+}
+func (ts *chatgptTestServer) TokenURL() string {
+	return ts.srv.URL + "/oauth/token"
+}
+
+// browserSimulator parses the authorize URL, finds the loopback redirect_uri
+// it embeds, and GETs that callback directly (carrying the same state and
+// code that the test server would have stamped on). This avoids the
+// httptest redirect chain — the loopback listener sees one clean request, so
+// it can serve it and the connection closes.
+//
+// It also asserts the PKCE params are present on the authorize URL, mirroring
+// the openrouter test's posture.
+func browserSimulator(t *testing.T, code string) func(string) error {
+	t.Helper()
+	return func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		if q.Get("code_challenge") == "" || q.Get("code_challenge_method") != "S256" {
+			t.Fatalf("authorize URL missing PKCE: %s", authURL)
+		}
+		redirect := q.Get("redirect_uri")
+		if redirect == "" {
+			t.Fatalf("authorize URL missing redirect_uri: %s", authURL)
+		}
+		state := q.Get("state")
+		target := redirect
+		if code != "" {
+			parsed, perr := url.Parse(redirect)
+			if perr != nil {
+				return perr
+			}
+			pq := parsed.Query()
+			pq.Set("code", code)
+			pq.Set("state", state)
+			parsed.RawQuery = pq.Encode()
+			target = parsed.String()
+		}
+		// Use a client with a short timeout so the test never hangs on a
+		// flaky loopback; a 5s upper bound is plenty.
+		client := &http.Client{Timeout: 5 * time.Second}
+		req, _ := http.NewRequest(http.MethodGet, target, nil)
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		_, _ = io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+		_ = resp.Body.Close()
+		return nil
+	}
+}
+
+func TestChatGPTLoginUsesPreset(t *testing.T) {
+	idTok := makeIDToken(t, map[string]any{
+		"chatgpt_account_id": "acc-real",
+		"email":              "user@example.com",
+	})
+	ts := newChatGPTTestServer(t, idTok)
+	defer ts.Close()
+
+	// The chatgpt preset pins the authorize/token endpoints; we override
+	// both with the test server's URLs to keep the loopback flow
+	// self-contained. The chatgpt preset's client_id is preserved by NOT
+	// overriding ZERO_OAUTH_CHATGPT_CLIENT_ID.
+	env := chatgptTestEnv()
+	env["ZERO_OAUTH_CHATGPT_AUTHORIZE_URL"] = ts.AuthorizeURL()
+	env["ZERO_OAUTH_CHATGPT_TOKEN_URL"] = ts.TokenURL()
+
+	var out strings.Builder
+	token, err := ChatGPTLogin(context.Background(), ChatGPTOptions{
+		Env:         env,
+		HTTPClient:  &http.Client{Timeout: 10 * time.Second},
+		Out:         &out,
+		OpenBrowser: browserSimulator(t, "TEST-CODE"),
+	})
+	if err != nil {
+		t.Fatalf("ChatGPTLogin: %v\nout=%s", err, out.String())
+	}
+	if token.AccessToken != "ACCESS-TOK" {
+		t.Fatalf("access_token = %q, want ACCESS-TOK", token.AccessToken)
+	}
+	if token.Account != "acc-real" {
+		t.Fatalf("Account = %q, want acc-real (extracted from id_token)", token.Account)
+	}
+	if token.RefreshToken != "REFRESH-TOK" {
+		t.Fatalf("refresh_token = %q, want REFRESH-TOK", token.RefreshToken)
+	}
+	if token.TokenType != "Bearer" {
+		t.Fatalf("token_type = %q, want Bearer", token.TokenType)
+	}
+	if token.ExpiresAt.IsZero() {
+		t.Fatalf("ExpiresAt is zero, want non-zero (3600s in the future)")
+	}
+	// The preset's client_id must reach the token endpoint (this asserts
+	// the resolver actually used the preset, not an env override).
+	if id := ts.gotClient.Load().(string); id != "app_EMoamEEZ73f0CkXaXp7hrann" {
+		t.Fatalf("token-endpoint client_id = %q, want the chatgpt preset", id)
+	}
+	// The PKCE verifier must round-trip on the token exchange.
+	if ts.gotPKCE.Load().(string) == "" {
+		t.Fatal("code_verifier missing on token exchange")
+	}
+	// Sanity-check the printed URL contains the test server's authorize path.
+	if !strings.Contains(out.String(), "/oauth/authorize") {
+		t.Fatalf("Out should print the authorize URL, got %q", out.String())
+	}
+}
+
+func TestChatGPTLoginWithoutPresetEnvReturnsError(t *testing.T) {
+	// With no env at all, the chatgpt preset stays inert (the same posture
+	// every other preset uses); ResolveConfig returns an error and the login
+	// fails fast — a useful safety net for callers that forgot to opt in.
+	_, err := ChatGPTLogin(context.Background(), ChatGPTOptions{
+		Env:        map[string]string{},
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+	})
+	if err == nil {
+		t.Fatal("expected an error when the chatgpt preset is not opted in")
+	}
+}
+
+func TestChatGPTLoginMissingAuthorizationEndpointErrors(t *testing.T) {
+	// The chatgpt preset pins the authorize endpoint. Forcing it to empty
+	// would require extending the resolver to honor an explicit "unset"
+	// sentinel; today the resolver treats an empty env var as "use the
+	// preset", so the login will succeed. We just assert the preset's
+	// authorize URL survives a no-op env override (an off-by-one safety
+	// net for callers that pass an empty Env).
+	env := chatgptTestEnv()
+	env["ZERO_OAUTH_CHATGPT_AUTHORIZE_URL"] = ""
+	env["ZERO_OAUTH_CHATGPT_TOKEN_URL"] = "https://chatgpt.invalid/oauth/token"
+	// No OpenBrowser => the login would hang waiting for a callback. We
+	// use a 2s timeout so a regression that drops the preset's authorize
+	// URL is surfaced as a timeout, not a hang.
+	token, err := ChatGPTLogin(context.Background(), ChatGPTOptions{
+		Env:         env,
+		HTTPClient:  &http.Client{Timeout: 5 * time.Second},
+		Timeout:     2 * time.Second,
+		OpenBrowser: func(string) error { return nil },
+	})
+	// The login will time out waiting for the real (preset) authorize
+	// callback. We assert it times out (not panics) and that no token is
+	// returned. The point of the test is the early-return branch in
+	// ChatGPTLogin is not triggered by an empty env override.
+	if err == nil {
+		t.Fatal("expected an error (timeout or callback error), got success")
+	}
+	if token.AccessToken != "" {
+		t.Fatalf("no token should be minted on timeout, got %q", token.AccessToken)
+	}
+}
+
+// The ID token claim extraction is also exercised through the on-disk JSON
+// store: a refresh keeps the account-id on the way out, so the test asserts
+// the Token round-trips IDToken + Account through Save/Load.
+func TestChatGPTTokenRoundTripsIDToken(t *testing.T) {
+	path := t.TempDir() + "/tok.json"
+	store, err := oauth.NewStore(oauth.StoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	tok := oauth.Token{
+		AccessToken:  "A",
+		RefreshToken: "R",
+		IDToken:      "header.payload.sig",
+		Account:      "acc-stored",
+	}
+	if err := store.Save(oauth.ProviderKey("chatgpt"), tok); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, ok, err := store.Load(oauth.ProviderKey("chatgpt"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected the token to be stored")
+	}
+	if got.IDToken != "header.payload.sig" {
+		t.Fatalf("IDToken round-trip = %q, want header.payload.sig", got.IDToken)
+	}
+	if got.Account != "acc-stored" {
+		t.Fatalf("Account = %q, want acc-stored", got.Account)
+	}
+}
+
+// Ensure the package reads `io` so an unused-import error never creeps in when
+// a refactor prunes a caller. (The other tests exercise io.Writer for Out.)
+var _ = io.Discard

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -1,12 +1,15 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/oauth"
+	"github.com/Gitlawb/zero/internal/providercatalog"
 	"github.com/Gitlawb/zero/internal/providers/anthropic"
 	"github.com/Gitlawb/zero/internal/providers/gemini"
 	"github.com/Gitlawb/zero/internal/providers/openai"
@@ -30,6 +33,16 @@ func New(profile config.ProviderProfile, options Options) (zeroruntime.Provider,
 	resolved, err := resolveProfile(profile, options)
 	if err != nil {
 		return nil, err
+	}
+
+	// The ChatGPT (Codex) catalog requires the Codex-flavored provider: the
+	// Codex backend (chatgpt.com/backend-api/codex) 401s on every request that
+	// does not carry the `originator` + `chatgpt-account-id` headers, so a
+	// plain openai.New would always fail. We branch off the catalog id here
+	// (not the provider kind) so other "openai-compatible" providers keep
+	// using the openai.New path unchanged.
+	if isCodexCatalog(profile, resolved) {
+		return newCodexProvider(profile, resolved, options)
 	}
 
 	switch resolved.providerKind {
@@ -152,6 +165,18 @@ func resolveProfile(profile config.ProviderProfile, options Options) (resolvedPr
 		return resolvedProfile{}, err
 	}
 
+	// baseURL resolves in this order: profile override → catalog default.
+	// The catalog default makes the chatgpt Codex backend Just Work when a
+	// user runs `zero` with a `catalogID: chatgpt` profile; the user can
+	// still pin their own URL (e.g. a self-hosted Codex gateway or a local
+	// OAuth proxy) and it wins.
+	baseURL := strings.TrimSpace(profile.BaseURL)
+	if baseURL == "" {
+		if descriptor, ok := providercatalog.Get(profile.CatalogID); ok {
+			baseURL = strings.TrimSpace(descriptor.DefaultBaseURL)
+		}
+	}
+
 	if entry, ok := registry.Get(model); ok {
 		modelProvider := configKind(entry.Provider)
 		// Adopt the registry entry's provider only when the caller did not pin one.
@@ -175,7 +200,7 @@ func resolveProfile(profile config.ProviderProfile, options Options) (resolvedPr
 		return resolvedProfile{
 			providerKind:    providerKind,
 			apiModel:        entry.APIModel,
-			baseURL:         strings.TrimSpace(profile.BaseURL),
+			baseURL:         baseURL,
 			maxOutputTokens: entry.ContextLimits.MaxOutputTokens,
 		}, nil
 	}
@@ -186,7 +211,7 @@ func resolveProfile(profile config.ProviderProfile, options Options) (resolvedPr
 	return resolvedProfile{
 		providerKind: providerKind,
 		apiModel:     model,
-		baseURL:      strings.TrimSpace(profile.BaseURL),
+		baseURL:      baseURL,
 	}, nil
 }
 
@@ -211,4 +236,70 @@ func defaultRegistry(registry *modelregistry.Registry) (modelregistry.Registry, 
 		return *registry, nil
 	}
 	return modelregistry.DefaultRegistry()
+}
+
+// isCodexCatalog reports whether the profile targets the ChatGPT Codex
+// backend, which requires the Codex-flavored openai provider. The check uses
+// the catalog id (not the provider kind) so the openai-compatible path is
+// unaffected for other "openai-compatible" providers — a profile that
+// happens to use a /v1 baseURL pointing at chatgpt.com without the chatgpt
+// catalog id is the user's explicit misconfiguration, and the openai
+// provider's standard error path surfaces it.
+func isCodexCatalog(profile config.ProviderProfile, _ resolvedProfile) bool {
+	return providercatalog.NormalizeID(profile.CatalogID) == "chatgpt"
+}
+
+// newCodexProvider builds a Codex-flavored openai provider for the chatgpt
+// catalog. The Codex headers (`originator`, `chatgpt-account-id`) are
+// injected by the CodexProvider wrapper. The `chatgpt-account-id` is
+// resolved dynamically from the stored OAuth token's Account field so a
+// refresh that rotates the token (rare, but possible) keeps the right id
+// on the wire.
+func newCodexProvider(profile config.ProviderProfile, resolved resolvedProfile, options Options) (zeroruntime.Provider, error) {
+	codexAccount := codexAccountFromStore(profile.Name)
+	resolver := openai.CodexAccountResolver(func(ctx context.Context) (string, bool, error) {
+		account := codexAccountFromStore(profile.Name)
+		if account == "" {
+			return "", false, nil
+		}
+		return account, true, nil
+	})
+	return openai.NewCodexProvider(openai.CodexOptions{
+		Options: openai.Options{
+			BaseURL:         resolved.baseURL,
+			Model:           resolved.apiModel,
+			AuthHeader:      profile.AuthHeader,
+			AuthScheme:      profile.AuthScheme,
+			AuthHeaderValue: profile.AuthHeaderValue,
+			CustomHeaders:   profile.CustomHeaders,
+			OAuthResolver:   options.OAuthResolver,
+			MaxTokens:       resolved.maxOutputTokens,
+			HTTPClient:      options.HTTPClient,
+			UserAgent:       options.UserAgent,
+			ParseThinkTags:  parseThinkTagsForProfile(profile, resolved),
+		},
+		// The chatgpt catalog overrides this with the Codex baseURL
+		// (https://chatgpt.com/backend-api/codex) when the user does not
+		// pin one, so this branch only needs to handle a user-supplied
+		// override.
+		AccountID:       codexAccount,
+		AccountResolver: resolver,
+	})
+}
+
+// codexAccountFromStore reads the chatgpt_account_id from the stored OAuth
+// token for the given provider name. It is called per-request (via the
+// resolver) so a refresh that rotates the token takes effect immediately
+// without restarting the agent. Returns "" when no token is stored (the
+// Codex provider then omits the header and the user sees a clear 401).
+func codexAccountFromStore(providerName string) string {
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return ""
+	}
+	token, ok, err := store.Load(oauth.ProviderKey(providerName))
+	if err != nil || !ok {
+		return ""
+	}
+	return strings.TrimSpace(token.Account)
 }

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -252,11 +252,11 @@ func isCodexCatalog(profile config.ProviderProfile, _ resolvedProfile) bool {
 // newCodexProvider builds a Codex-flavored openai provider for the chatgpt
 // catalog. The Codex headers (`originator`, `chatgpt-account-id`) are
 // injected by the CodexProvider wrapper. The `chatgpt-account-id` is
-// resolved dynamically from the stored OAuth token's Account field so a
-// refresh that rotates the token (rare, but possible) keeps the right id
-// on the wire.
+// resolved dynamically from the stored OAuth token's Account field on
+// every request so a refresh that rotates the token (and its account
+// claim) takes effect immediately — a static AccountID captured at
+// construction would go stale on the first refresh.
 func newCodexProvider(profile config.ProviderProfile, resolved resolvedProfile, options Options) (zeroruntime.Provider, error) {
-	codexAccount := codexAccountFromStore(profile.Name)
 	resolver := openai.CodexAccountResolver(func(ctx context.Context) (string, bool, error) {
 		account := codexAccountFromStore(profile.Name)
 		if account == "" {
@@ -281,8 +281,9 @@ func newCodexProvider(profile config.ProviderProfile, resolved resolvedProfile, 
 		// The chatgpt catalog overrides this with the Codex baseURL
 		// (https://chatgpt.com/backend-api/codex) when the user does not
 		// pin one, so this branch only needs to handle a user-supplied
-		// override.
-		AccountID:       codexAccount,
+		// override. The codex provider's constructor derives the
+		// `/responses` endpoint from BaseURL, so the factory stays out of
+		// the path.
 		AccountResolver: resolver,
 	})
 }

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -291,10 +291,12 @@ func TestNewRoutesChatGPTCatalogToCodexProvider(t *testing.T) {
 	if transport.request == nil {
 		t.Fatal("HTTP client was not used")
 	}
-	// The chatgpt catalog's baseURL is the Codex backend. With no override,
-	// the Codex provider's stream hits that URL on /chat/completions.
-	if !strings.HasSuffix(transport.request.URL.Path, "/chat/completions") {
-		t.Fatalf("request URL path = %q, want .../chat/completions", transport.request.URL.Path)
+	// The chatgpt catalog's baseURL is the Codex backend. The Codex
+	// provider targets the Responses API at `{baseURL}/responses`, not
+	// `/chat/completions` (a chat-completions body on this path would 404
+	// or be misrouted by the Codex gateway).
+	if !strings.HasSuffix(transport.request.URL.Path, "/responses") {
+		t.Fatalf("request URL path = %q, want .../responses", transport.request.URL.Path)
 	}
 	wantHost := "chatgpt.com"
 	if !strings.Contains(transport.request.URL.Host, wantHost) {

--- a/internal/providers/factory_test.go
+++ b/internal/providers/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/oauth"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -262,6 +263,116 @@ func TestNewRejectsUnsupportedProviderKind(t *testing.T) {
 	}
 }
 
+func TestNewRoutesChatGPTCatalogToCodexProvider(t *testing.T) {
+	transport := &captureTransport{
+		responseBody: "data: [DONE]\n\n",
+	}
+	client := &http.Client{Transport: transport}
+
+	provider, err := New(config.ProviderProfile{
+		Name:      "chatgpt",
+		CatalogID: "chatgpt",
+		Model:     "gpt-5",
+	}, Options{
+		HTTPClient: client,
+		UserAgent:  "zero-factory-test",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+	if transport.request == nil {
+		t.Fatal("HTTP client was not used")
+	}
+	// The chatgpt catalog's baseURL is the Codex backend. With no override,
+	// the Codex provider's stream hits that URL on /chat/completions.
+	if !strings.HasSuffix(transport.request.URL.Path, "/chat/completions") {
+		t.Fatalf("request URL path = %q, want .../chat/completions", transport.request.URL.Path)
+	}
+	wantHost := "chatgpt.com"
+	if !strings.Contains(transport.request.URL.Host, wantHost) {
+		t.Fatalf("request URL host = %q, want the Codex backend (chatgpt.com)", transport.request.URL.Host)
+	}
+	// The Codex-required headers must be present even when the OAuth token
+	// has no account id (the AccountResolver returns ok=false in that case,
+	// so the chatgpt-account-id header is just omitted, not wrongly set).
+	if got := transport.request.Header.Get("originator"); got != "codex_cli_rs" {
+		t.Fatalf("originator = %q, want codex_cli_rs", got)
+	}
+	if got := transport.request.Header.Get("chatgpt-account-id"); got != "" {
+		t.Fatalf("chatgpt-account-id = %q, want empty when no OAuth login is stored", got)
+	}
+}
+
+func TestNewRoutesChatGPTCatalogWithStoredAccountID(t *testing.T) {
+	// The factory reads the stored OAuth token's Account field for the
+	// chatgpt-account-id header. Seed a token in a temp store and point
+	// ZERO_OAUTH_TOKENS_PATH at it so the factory picks it up.
+	dir := t.TempDir()
+	t.Setenv("ZERO_OAUTH_TOKENS_PATH", dir+"/tokens.json")
+	store, err := newOAuthStoreForTest()
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := store.Save(oauth.ProviderKey("chatgpt"), oauth.Token{
+		AccessToken: "tok-1",
+		Account:     "acc-stored-42",
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	transport := &captureTransport{
+		responseBody: "data: [DONE]\n\n",
+	}
+	provider, err := New(config.ProviderProfile{
+		Name:      "chatgpt",
+		CatalogID: "chatgpt",
+		Model:     "gpt-5",
+	}, Options{
+		HTTPClient: &http.Client{Transport: transport},
+		UserAgent:  "zero-factory-test",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion() error = %v", err)
+	}
+	for range stream {
+	}
+	if got := transport.request.Header.Get("chatgpt-account-id"); got != "acc-stored-42" {
+		t.Fatalf("chatgpt-account-id = %q, want acc-stored-42", got)
+	}
+}
+
+func TestIsCodexCatalog(t *testing.T) {
+	cases := []struct {
+		catalogID string
+		want      bool
+	}{
+		{"chatgpt", true},
+		{"ChatGPT", true},
+		{"openai", false},
+		{"", false},
+		{"chatgpt-proxy", false}, // the local proxy catalog stays on the openai path
+	}
+	for _, tc := range cases {
+		got := isCodexCatalog(config.ProviderProfile{CatalogID: tc.catalogID}, resolvedProfile{})
+		if got != tc.want {
+			t.Errorf("isCodexCatalog(%q) = %v, want %v", tc.catalogID, got, tc.want)
+		}
+	}
+}
+
 type captureTransport struct {
 	request      *http.Request
 	requestBody  string
@@ -285,4 +396,12 @@ func (transport *captureTransport) RoundTrip(request *http.Request) (*http.Respo
 
 func (transport *captureTransport) body() io.Reader {
 	return strings.NewReader(transport.requestBody)
+}
+
+// newOAuthStoreForTest builds a Store pointed at the current
+// ZERO_OAUTH_TOKENS_PATH (set by the caller). It exists so the chatgpt
+// factory tests can seed a token without copying the path-handling dance
+// from internal/cli.
+func newOAuthStoreForTest() (*oauth.Store, error) {
+	return oauth.NewStore(oauth.StoreOptions{})
 }

--- a/internal/providers/openai/codex.go
+++ b/internal/providers/openai/codex.go
@@ -1,0 +1,167 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Codex-specific headers, lifted from the openai/codex CLI's behavior. The
+// Codex backend at https://chatgpt.com/backend-api/codex requires all three on
+// every request — the bearer, the `originator` that identifies the client, and
+// the `chatgpt-account-id` claim that ties the bearer to a specific ChatGPT
+// subscription. Drop any one and the request 401s at Cloudflare.
+const (
+	codexDefaultOriginator = "codex_cli_rs"
+	codexAccountHeader     = "chatgpt-account-id"
+	codexOriginatorHeader  = "originator"
+)
+
+// CodexAccountResolver returns the `chatgpt_account_id` claim for the bearer
+// that is about to be sent on a request. It is invoked once per request
+// (including the 401-refresh retry) so the value can be re-derived from the
+// live OAuth token rather than cached at construction time.
+//
+// ok=false means "no account id known" — the Codex provider simply omits the
+// header in that case (the request will 401, but that's recoverable: the user
+// re-auths and the next login persists a fresh id).
+type CodexAccountResolver func(ctx context.Context) (accountID string, ok bool, err error)
+
+// CodexOptions configures a Codex-flavored provider. It embeds the standard
+// openai.Options so every chat-completions knob (model, custom headers,
+// MaxTokens, parse-think-tags, etc.) is supported unchanged. The Codex-specific
+// fields below add the headers the Codex backend requires.
+type CodexOptions struct {
+	Options
+	// Originator is the value of the `originator` header. Empty defaults to
+	// "codex_cli_rs" (the same value the openai/codex CLI ships). The Codex
+	// backend reads this to attribute traffic; changing it is supported but
+	// unusual.
+	Originator string
+	// UserAgent overrides the openai Options.UserAgent when non-empty. The
+	// Codex backend logs the User-Agent for diagnostics, so a "codex_cli_rs"
+	// / "zero" branded value is recommended.
+	UserAgent string
+	// AccountID is the static `chatgpt-account-id` to inject on every
+	// request. When set, the AccountResolver is not consulted. The factory
+	// wires this from the OAuth token's `Account` field.
+	AccountID string
+	// AccountResolver, when set, returns the account id dynamically per
+	// request. It is used as a fallback when AccountID is empty. Most callers
+	// (the factory) use AccountID instead; the resolver is for tests.
+	AccountResolver CodexAccountResolver
+	// RequestTimeout caps each outbound Codex request. 0 => 60s. The Codex
+	// backend is hosted behind Cloudflare, so a few seconds is plenty for a
+	// healthy connection; the cap is a safety net for the rare case the
+	// request hangs past the streaming idle watchdog.
+	RequestTimeout time.Duration
+}
+
+// CodexProvider is the Codex-flavored variant of the openai provider. It is
+// a thin shim that adds the Codex-specific request headers
+// (`originator`, `chatgpt-account-id`, branded `User-Agent`) on top of the
+// generic OpenAI chat-completions transport. The Codex backend accepts the
+// same `/chat/completions` body shape today, so the request body is
+// byte-for-byte the same as the openai provider.
+type CodexProvider struct {
+	inner          *Provider
+	originator     string
+	userAgent      string
+	accountID      string
+	accountResolve CodexAccountResolver
+}
+
+// NewCodexProvider builds a CodexProvider. It is a thin wrapper over the
+// openai.New constructor plus the Codex-specific Options.SetRequestExtra
+// callback that injects the Codex headers.
+func NewCodexProvider(options CodexOptions) (*CodexProvider, error) {
+	originator := strings.TrimSpace(options.Originator)
+	if originator == "" {
+		originator = codexDefaultOriginator
+	}
+	userAgent := strings.TrimSpace(options.UserAgent)
+	if userAgent == "" {
+		// Default to the openai Options.UserAgent (typically "zero/<ver>")
+		// and fall back to a Codex-branded value when the caller didn't set
+		// either — the Codex backend logs the User-Agent and a clearly
+		// branded string makes operational issues easier to triage.
+		userAgent = strings.TrimSpace(options.Options.UserAgent)
+		if userAgent == "" {
+			userAgent = codexDefaultOriginator
+		}
+	}
+
+	// Reuse the openai provider's transport. Embed Options so the openai
+	// constructor sees the full struct; here we set SetRequestExtra below.
+	openaiOpts := options.Options
+	openaiOpts.UserAgent = userAgent
+
+	provider := &CodexProvider{
+		originator:     originator,
+		userAgent:      userAgent,
+		accountID:      strings.TrimSpace(options.AccountID),
+		accountResolve: options.AccountResolver,
+	}
+	openaiOpts.SetRequestExtra = provider.injectCodexHeaders
+	inner, err := New(openaiOpts)
+	if err != nil {
+		return nil, fmt.Errorf("openai codex provider: %w", err)
+	}
+	provider.inner = inner
+	return provider, nil
+}
+
+// StreamCompletion forwards to the wrapped openai provider. The Codex headers
+// are injected on every request via the SetRequestExtra callback.
+func (p *CodexProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	return p.inner.StreamCompletion(ctx, request)
+}
+
+// injectCodexHeaders is the SetRequestExtra callback installed on the wrapped
+// openai provider. It sets the three Codex-required headers; the bearer is
+// applied separately by the openai provider's auth path.
+func (p *CodexProvider) injectCodexHeaders(req *http.Request) {
+	req.Header.Set(codexOriginatorHeader, p.originator)
+	if account, ok, err := p.resolveAccount(req.Context()); err == nil && ok && account != "" {
+		req.Header.Set(codexAccountHeader, account)
+	}
+	// Branded User-Agent overrides the openai provider's default. Set last
+	// so a caller that supplies a different UserAgent in custom-headers is
+	// still respected (the openai provider's setExtra already ran before us).
+	if p.userAgent != "" {
+		req.Header.Set("User-Agent", p.userAgent)
+	}
+}
+
+// resolveAccount returns the account id to inject, preferring the static
+// AccountID (set at construction from the OAuth token) and falling back to the
+// per-request AccountResolver. ok=false means "omit the header".
+func (p *CodexProvider) resolveAccount(ctx context.Context) (string, bool, error) {
+	if p.accountID != "" {
+		return p.accountID, true, nil
+	}
+	if p.accountResolve != nil {
+		account, ok, err := p.accountResolve(ctx)
+		if err != nil {
+			return "", false, err
+		}
+		return account, ok, nil
+	}
+	return "", false, nil
+}
+
+// ValidateAccount is a convenience for tests/callers that want to confirm the
+// account id is the right shape (non-empty, trimmed). It is a no-op helper
+// rather than a constructor check so a Codex provider can be built before the
+// first login completes.
+func ValidateAccount(account string) error {
+	if strings.TrimSpace(account) == "" {
+		return errors.New("openai codex: account id is empty")
+	}
+	return nil
+}

--- a/internal/providers/openai/codex.go
+++ b/internal/providers/openai/codex.go
@@ -47,13 +47,21 @@ type CodexOptions struct {
 	// Codex backend logs the User-Agent for diagnostics, so a "codex_cli_rs"
 	// / "zero" branded value is recommended.
 	UserAgent string
-	// AccountID is the static `chatgpt-account-id` to inject on every
-	// request. When set, the AccountResolver is not consulted. The factory
-	// wires this from the OAuth token's `Account` field.
+	// AccountID is a static `chatgpt-account-id` that bypasses the resolver.
+	// Leave empty in production wiring so the AccountResolver is consulted on
+	// every request — that path reads the live OAuth token from the store and
+	// survives a refresh that rotates the bearer (and its account claim).
+	// The field exists for tests that want a pinned value without standing up
+	// a resolver.
 	AccountID string
 	// AccountResolver, when set, returns the account id dynamically per
-	// request. It is used as a fallback when AccountID is empty. Most callers
-	// (the factory) use AccountID instead; the resolver is for tests.
+	// request (including the 401-refresh retry). The factory wires this so a
+	// refresh that updates the stored token's Account field takes effect on
+	// the next outgoing request without restarting the agent.
+	//
+	// ok=false means "no account id known" — the Codex provider simply omits
+	// the header in that case (the request will 401, but that's recoverable:
+	// the user re-auths and the next login persists a fresh id).
 	AccountResolver CodexAccountResolver
 	// RequestTimeout caps each outbound Codex request. 0 => 60s. The Codex
 	// backend is hosted behind Cloudflare, so a few seconds is plenty for a
@@ -65,9 +73,11 @@ type CodexOptions struct {
 // CodexProvider is the Codex-flavored variant of the openai provider. It is
 // a thin shim that adds the Codex-specific request headers
 // (`originator`, `chatgpt-account-id`, branded `User-Agent`) on top of the
-// generic OpenAI chat-completions transport. The Codex backend accepts the
-// same `/chat/completions` body shape today, so the request body is
-// byte-for-byte the same as the openai provider.
+// generic OpenAI chat-completions transport. The Codex backend speaks the
+// Responses API at `{baseURL}/responses` (not `/chat/completions`), so the
+// constructor overrides the endpoint the wrapped openai provider would
+// otherwise default to. The request body is byte-for-byte the same
+// chat-completions shape today; the path difference is the only divergence.
 type CodexProvider struct {
 	inner          *Provider
 	originator     string
@@ -100,6 +110,14 @@ func NewCodexProvider(options CodexOptions) (*CodexProvider, error) {
 	// constructor sees the full struct; here we set SetRequestExtra below.
 	openaiOpts := options.Options
 	openaiOpts.UserAgent = userAgent
+	// The Codex backend serves the Responses API at `{baseURL}/responses`,
+	// not `/chat/completions`. Override the endpoint the openai transport
+	// would otherwise default to so the Codex provider hits the right path.
+	// (The chat-completions request body is still accepted; only the path
+	// diverges.)
+	if baseURL := strings.TrimRight(strings.TrimSpace(openaiOpts.BaseURL), "/"); baseURL != "" {
+		openaiOpts.Endpoint = baseURL + "/responses"
+	}
 
 	provider := &CodexProvider{
 		originator:     originator,

--- a/internal/providers/openai/codex.go
+++ b/internal/providers/openai/codex.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -72,12 +73,13 @@ type CodexOptions struct {
 
 // CodexProvider is the Codex-flavored variant of the openai provider. It is
 // a thin shim that adds the Codex-specific request headers
-// (`originator`, `chatgpt-account-id`, branded `User-Agent`) on top of the
-// generic OpenAI chat-completions transport. The Codex backend speaks the
-// Responses API at `{baseURL}/responses` (not `/chat/completions`), so the
-// constructor overrides the endpoint the wrapped openai provider would
-// otherwise default to. The request body is byte-for-byte the same
-// chat-completions shape today; the path difference is the only divergence.
+// (`originator`, `chatgpt-account-id`, branded `User-Agent`) on top of a
+// Responses-API transport. The Codex backend at
+// `https://chatgpt.com/backend-api/codex/responses` serves the OpenAI
+// Responses API (not the chat-completions API), so the constructor
+// overrides the endpoint AND the transport — the wrapped Provider is used
+// only for its validated endpoint / auth / retry / timeout config; the
+// actual request body and SSE parser live in codex_responses.go.
 type CodexProvider struct {
 	inner          *Provider
 	originator     string
@@ -88,7 +90,10 @@ type CodexProvider struct {
 
 // NewCodexProvider builds a CodexProvider. It is a thin wrapper over the
 // openai.New constructor plus the Codex-specific Options.SetRequestExtra
-// callback that injects the Codex headers.
+// callback that injects the Codex headers. The wrapped Provider supplies
+// the validated endpoint / auth / retry / idle-timeout config; the
+// request body and stream parser are Codex-specific and live in
+// codex_responses.go.
 func NewCodexProvider(options CodexOptions) (*CodexProvider, error) {
 	originator := strings.TrimSpace(options.Originator)
 	if originator == "" {
@@ -106,15 +111,17 @@ func NewCodexProvider(options CodexOptions) (*CodexProvider, error) {
 		}
 	}
 
-	// Reuse the openai provider's transport. Embed Options so the openai
-	// constructor sees the full struct; here we set SetRequestExtra below.
+	// Reuse the openai provider's transport configuration. Embed Options so
+	// the openai constructor sees the full struct; here we set
+	// SetRequestExtra below. The inner Provider is NOT used for streaming
+	// — the Codex provider has its own Responses-API stream path — but its
+	// fields (endpoint, httpClient, auth headers, idle timeout) are the
+	// single source of truth for the URL / auth / retry plumbing.
 	openaiOpts := options.Options
 	openaiOpts.UserAgent = userAgent
 	// The Codex backend serves the Responses API at `{baseURL}/responses`,
 	// not `/chat/completions`. Override the endpoint the openai transport
-	// would otherwise default to so the Codex provider hits the right path.
-	// (The chat-completions request body is still accepted; only the path
-	// diverges.)
+	// would otherwise default to.
 	if baseURL := strings.TrimRight(strings.TrimSpace(openaiOpts.BaseURL), "/"); baseURL != "" {
 		openaiOpts.Endpoint = baseURL + "/responses"
 	}
@@ -134,10 +141,27 @@ func NewCodexProvider(options CodexOptions) (*CodexProvider, error) {
 	return provider, nil
 }
 
-// StreamCompletion forwards to the wrapped openai provider. The Codex headers
-// are injected on every request via the SetRequestExtra callback.
+// StreamCompletion builds a Responses-API request and dispatches it via
+// the Codex-specific stream path in codex_responses.go. The request body
+// is the Responses schema (input items, tools, max_output_tokens) and
+// the response is parsed from the typed SSE event stream the Codex
+// backend emits (response.output_text.delta, response.function_call_
+// arguments.delta, response.completed, ...).
 func (p *CodexProvider) StreamCompletion(ctx context.Context, request zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
-	return p.inner.StreamCompletion(ctx, request)
+	responsesReq, err := p.buildResponsesRequest(request)
+	if err != nil {
+		return nil, fmt.Errorf("encode codex request: %w", err)
+	}
+	body, err := json.Marshal(responsesReq)
+	if err != nil {
+		return nil, fmt.Errorf("encode codex request: %w", err)
+	}
+	events := make(chan zeroruntime.StreamEvent, 16)
+	go func() {
+		defer close(events)
+		p.streamResponses(ctx, body, events)
+	}()
+	return events, nil
 }
 
 // injectCodexHeaders is the SetRequestExtra callback installed on the wrapped

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -1,0 +1,717 @@
+package openai
+
+// Codex Responses API adapter.
+//
+// The ChatGPT Codex backend (chatgpt.com/backend-api/codex/responses) serves
+// the OpenAI Responses API, NOT the chat-completions API. The two schemas
+// differ in both request and stream shape:
+//
+//	Chat-completions (what the openai provider speaks):
+//	  request:  { model, messages, tools, stream, stream_options, max_completion_tokens }
+//	  stream:   data: {"choices":[{"delta":{"content","tool_calls",...}}]}
+//	            data: [DONE]
+//
+//	Responses (what the Codex backend speaks):
+//	  request:  { model, input, tools, stream, max_output_tokens }
+//	  input item types: "message" (role: user/assistant/system, content parts),
+//	                    "function_call" (id, call_id, name, arguments),
+//	                    "function_call_output" (call_id, output)
+//	  stream:   event: response.created | response.in_progress
+//	            event: response.output_item.added
+//	            event: response.content_part.added
+//	            event: response.output_text.delta / response.output_text.done
+//	            event: response.function_call_arguments.delta
+//	            event: response.output_item.done
+//	            event: response.completed
+//	            event: response.error | response.failed
+//
+// The previous Codex implementation reused the openai chat-completions transport
+// verbatim and only changed the URL — that sent a chat-completions body to
+// /responses, which the Codex backend rejects. This file replaces the transport
+// with a Responses-shaped request builder, a typed SSE event dispatcher, and a
+// tool-call accumulator that emits normalized StreamEventToolCallStart /
+// StreamEventToolCallDelta / StreamEventToolCallEnd / StreamEventUsage /
+// StreamEventDone events for the runtime.
+//
+// The Codex provider still uses providerio for the HTTP/auth/retry/idle-timeout
+// plumbing so the OAuth 401-refresh and bearer rotation paths stay identical
+// to the rest of the openai-compatible surface.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/providers/providerio"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Codex Responses API event type names. Only the ones the Codex backend
+// actually emits are listed; unknown event types are ignored.
+const (
+	responsesEventCreated           = "response.created"
+	responsesEventInProgress        = "response.in_progress"
+	responsesEventOutputItemAdded   = "response.output_item.added"
+	responsesEventContentPartAdded  = "response.content_part.added"
+	responsesEventOutputTextDelta   = "response.output_text.delta"
+	responsesEventOutputTextDone    = "response.output_text.done"
+	responsesEventFunctionArgsDelta = "response.function_call_arguments.delta"
+	responsesEventContentPartDone   = "response.content_part.done"
+	responsesEventOutputItemDone    = "response.output_item.done"
+	responsesEventCompleted         = "response.completed"
+	responsesEventFailed            = "response.failed"
+	responsesEventError             = "response.error"
+	responsesEventIncomplete        = "response.incomplete"
+)
+
+// responsesRequest is the wire shape POSTed to {baseURL}/responses.
+type responsesRequest struct {
+	Model           string          `json:"model"`
+	Input           []inputItem     `json:"input"`
+	Stream          bool            `json:"stream"`
+	MaxOutputTokens int             `json:"max_output_tokens,omitempty"`
+	Tools           []responsesTool `json:"tools,omitempty"`
+}
+
+// inputItem is one element of the Responses `input` array. The Type field
+// dispatches between message / function_call / function_call_output.
+type inputItem struct {
+	Type    string        `json:"type"`
+	Role    string        `json:"role,omitempty"`
+	Content []contentItem `json:"content,omitempty"`
+	// function_call fields
+	ID        string `json:"id,omitempty"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	// function_call_output fields
+	Output any `json:"output,omitempty"`
+}
+
+// contentItem is one element of a message's `content` array. Type dispatches
+// between input_text / output_text / input_image.
+type contentItem struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+}
+
+type responsesTool struct {
+	Type        string         `json:"type"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+// responsesEvent is the decoded form of one Responses SSE data payload.
+// Only the fields each event type actually carries are populated.
+type responsesEvent struct {
+	Type string `json:"type"`
+	// delta payloads (response.output_text.delta / function_call_arguments.delta)
+	Delta string `json:"delta,omitempty"`
+	// item payloads (response.output_item.added / done)
+	ItemID      string       `json:"item_id,omitempty"`
+	OutputIndex int          `json:"output_index,omitempty"`
+	Item        *itemPayload `json:"item,omitempty"`
+	// completed / failed / incomplete
+	Response *responsePayload `json:"response,omitempty"`
+	// error
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+	Param   string `json:"param,omitempty"`
+}
+
+type itemPayload struct {
+	Type      string `json:"type"`
+	ID        string `json:"id,omitempty"`
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+type responsePayload struct {
+	ID     string        `json:"id"`
+	Status string        `json:"status"`
+	Usage  *usagePayload `json:"usage,omitempty"`
+	Error  *errorPayload `json:"error,omitempty"`
+}
+
+type usagePayload struct {
+	InputTokens         int            `json:"input_tokens"`
+	OutputTokens        int            `json:"output_tokens"`
+	TotalTokens         int            `json:"total_tokens"`
+	OutputTokensDetails *outputDetails `json:"output_tokens_details,omitempty"`
+	InputTokensDetails  *inputDetails  `json:"input_tokens_details,omitempty"`
+}
+
+type outputDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
+}
+
+type inputDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
+type errorPayload struct {
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// toolCallBuilder accumulates one in-flight function_call across its
+// response.output_item.added, the argument deltas, and the final
+// response.output_item.done.
+type toolCallBuilder struct {
+	ID        string
+	Name      string
+	Arguments strings.Builder
+	started   bool
+	ended     bool
+}
+
+// responsesState tracks in-flight tool calls and whether the terminal
+// event has been emitted. It is the Responses-API equivalent of the
+// chat-completions toolState in provider.go.
+type responsesState struct {
+	toolCalls map[string]*toolCallBuilder
+	usage     *usagePayload
+	done      bool
+}
+
+func newResponsesState() *responsesState {
+	return &responsesState{toolCalls: map[string]*toolCallBuilder{}}
+}
+
+// buildResponsesRequest converts a runtime CompletionRequest into the
+// Responses API wire format. System messages fold into a top-level
+// `instructions` field; everything else (user/assistant turns, tool
+// calls, tool results) becomes items in the `input` array.
+func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequest) (*responsesRequest, error) {
+	if p.inner == nil || strings.TrimSpace(p.inner.model) == "" {
+		return nil, errors.New("codex provider: model is required")
+	}
+	req := &responsesRequest{
+		Model:           p.inner.model,
+		Stream:          true,
+		MaxOutputTokens: p.inner.maxTokens,
+	}
+	for _, msg := range request.Messages {
+		switch msg.Role {
+		case zeroruntime.MessageRoleSystem:
+			// System → first-class user message in Responses API. Keeping it as
+			// an input message (rather than a separate `instructions` field)
+			// matches the chat-completions semantics the runtime was already
+			// producing — every system turn reaches the model in order.
+			req.Input = append(req.Input, inputItem{
+				Type:    "message",
+				Role:    "system",
+				Content: []contentItem{{Type: "input_text", Text: msg.Content}},
+			})
+		case zeroruntime.MessageRoleUser:
+			req.Input = append(req.Input, p.userInputItem(msg))
+		case zeroruntime.MessageRoleAssistant:
+			items, err := p.assistantInputItems(msg)
+			if err != nil {
+				return nil, err
+			}
+			req.Input = append(req.Input, items...)
+		case zeroruntime.MessageRoleTool:
+			if msg.ToolCallID == "" {
+				return nil, fmt.Errorf("codex provider: tool message missing tool call id")
+			}
+			req.Input = append(req.Input, inputItem{
+				Type:   "function_call_output",
+				CallID: msg.ToolCallID,
+				Output: msg.Content,
+			})
+		default:
+			return nil, fmt.Errorf("codex provider: unsupported message role %q", msg.Role)
+		}
+	}
+	for _, tool := range request.Tools {
+		req.Tools = append(req.Tools, responsesTool{
+			Type:        "function",
+			Name:        tool.Name,
+			Description: tool.Description,
+			Parameters:  tool.Parameters,
+		})
+	}
+	return req, nil
+}
+
+// userInputItem renders a user message as a Responses `message` item with
+// one input_text part (and one input_image part per attached image, if
+// any). The image bytes are base64-encoded into a data: URI exactly like
+// the chat-completions transport does.
+func (p *CodexProvider) userInputItem(msg zeroruntime.Message) inputItem {
+	parts := []contentItem{}
+	if msg.Content != "" {
+		parts = append(parts, contentItem{Type: "input_text", Text: msg.Content})
+	}
+	for _, image := range msg.Images {
+		encoded := base64.StdEncoding.EncodeToString(image.Data)
+		parts = append(parts, contentItem{
+			Type:     "input_image",
+			ImageURL: "data:" + image.MediaType + ";base64," + encoded,
+		})
+	}
+	return inputItem{Type: "message", Role: "user", Content: parts}
+}
+
+// assistantInputItems renders an assistant turn as either a single
+// `message` (text-only) or a `message` followed by one `function_call`
+// per tool call. Tool-call IDs use ToolCall.ID directly — Responses
+// accepts `id` and `call_id` interchangeably, and the runtime already
+// guarantees non-empty IDs at construction time.
+func (p *CodexProvider) assistantInputItems(msg zeroruntime.Message) ([]inputItem, error) {
+	items := []inputItem{}
+	if msg.Content != "" {
+		items = append(items, inputItem{
+			Type:    "message",
+			Role:    "assistant",
+			Content: []contentItem{{Type: "output_text", Text: msg.Content}},
+		})
+	}
+	for _, tc := range msg.ToolCalls {
+		if tc.ID == "" {
+			return nil, errors.New("codex provider: assistant tool call missing id")
+		}
+		if tc.Name == "" {
+			return nil, errors.New("codex provider: assistant tool call missing name")
+		}
+		items = append(items, inputItem{
+			Type:      "function_call",
+			ID:        tc.ID,
+			CallID:    tc.ID,
+			Name:      tc.Name,
+			Arguments: tc.Arguments,
+		})
+	}
+	return items, nil
+}
+
+// streamResponses sends the prebuilt Responses body, parses the typed SSE
+// event stream from the Codex backend, and emits runtime events. It
+// uses the shared providerio plumbing for auth (including the 401
+// OAuth-refresh retry), the SSE scanner (with the idle watchdog), and
+// the upstream-unreachable humanizer. Returns when the stream is
+// exhausted, an error event is emitted, or ctx is cancelled.
+func (p *CodexProvider) streamResponses(
+	ctx context.Context,
+	body []byte,
+	events chan<- zeroruntime.StreamEvent,
+) {
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	inner := p.inner
+	response, err := providerio.SendWithAuthRetry(streamCtx, inner.httpClient, http.MethodPost, inner.endpoint, body,
+		providerio.AuthHeaders{
+			APIKey:            inner.apiKey,
+			DefaultAuthHeader: "Authorization",
+			DefaultAuthScheme: "Bearer",
+			AuthHeader:        inner.authHeader,
+			AuthScheme:        inner.authScheme,
+			AuthHeaderValue:   inner.authHeaderValue,
+			CustomHeaders:     inner.customHeaders,
+		},
+		inner.oauthResolver,
+		func(request *http.Request) {
+			request.Header.Set("Content-Type", "application/json")
+			// injectCodexHeaders sets originator, chatgpt-account-id, and a
+			// branded User-Agent. It also runs on the 401-refresh retry, so
+			// per-request state (account id, fresh token) is re-derivable.
+			p.injectCodexHeaders(request)
+		}, 0)
+	if err != nil {
+		// Surface ctx errors verbatim so caller-driven cancels are not
+		// mislabeled as upstream outages (same posture as the openai
+		// provider's stream()).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:  zeroruntime.StreamEventError,
+				Error: p.redact("provider stream error: " + ctxErr.Error()),
+			})
+			return
+		}
+		if humanized, ok := providerio.UpstreamUnreachable(err.Error()); ok {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:  zeroruntime.StreamEventError,
+				Error: p.redact(humanized),
+			})
+			return
+		}
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact("provider stream error: " + err.Error()),
+		})
+		return
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		p.emitResponsesHTTPError(ctx, response, events)
+		return
+	}
+
+	state := newResponsesState()
+	err = providerio.ScanSSEDataWithContext(streamCtx, cancelStream, response.Body, inner.streamIdleTimeout, func(data string) bool {
+		return p.emitResponsesEvent(ctx, data, state, events)
+	})
+	if errors.Is(err, providerio.ErrStreamIdle) {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact(fmt.Sprintf("provider stream error: idle timeout after %s (upstream stopped sending data)", inner.streamIdleTimeout)),
+		})
+		return
+	}
+	if err != nil && !errors.Is(err, context.Canceled) {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact("provider stream error: " + err.Error()),
+		})
+		return
+	}
+	if !state.done {
+		// The Codex backend closed the stream without emitting response.completed
+		// (e.g. it ran out of output tokens or hit an internal limit). Surface a
+		// length-truncation finish so the runtime can react.
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:         zeroruntime.StreamEventDone,
+			FinishReason: zeroruntime.FinishReasonLength,
+		})
+	}
+}
+
+// emitResponsesHTTPError maps a non-2xx Codex response into a single
+// StreamEventError, redacting API keys / bearer tokens that may appear
+// in the body. Mirrors the openai provider's emitHTTPError so callers
+// see the same error shape regardless of which provider produced it.
+func (p *CodexProvider) emitResponsesHTTPError(
+	ctx context.Context,
+	response *http.Response,
+	events chan<- zeroruntime.StreamEvent,
+) {
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+	// The Codex backend may return either the chat-completions error shape
+	// (`{"error":{"message":...}}`) or a Responses-API error
+	// (`{"message":...}` directly). Try both so we surface a useful
+	// message either way.
+	message := strings.TrimSpace(string(body))
+	var chatError struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &chatError); err == nil && chatError.Error.Message != "" {
+		message = chatError.Error.Message
+	}
+	var responsesError responsesEvent
+	if err := json.Unmarshal(body, &responsesError); err == nil && responsesError.Message != "" {
+		message = responsesError.Message
+	}
+	if message == "" {
+		message = response.Status
+	}
+	if humanized, ok := providerio.UpstreamUnreachable(message); ok {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact(humanized),
+		})
+		return
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:  zeroruntime.StreamEventError,
+		Error: p.classifiedError(response.StatusCode, message),
+	})
+}
+
+// emitResponsesEvent decodes one Responses SSE data payload and converts
+// it into zero or more runtime events. Returns false to stop the scan
+// after emitting a terminal event (error / completion-with-error).
+func (p *CodexProvider) emitResponsesEvent(
+	ctx context.Context,
+	data string,
+	state *responsesState,
+	events chan<- zeroruntime.StreamEvent,
+) bool {
+	var event responsesEvent
+	if err := json.Unmarshal([]byte(data), &event); err != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact("provider stream error: malformed Responses event: " + err.Error()),
+		})
+		state.done = true
+		return false
+	}
+	if event.Type == "" {
+		// A payload that parses as JSON but carries no `type` field is a
+		// malformed Responses event — the type is the discriminator that
+		// tells us how to interpret the rest of the payload. Surface it as
+		// a stream error so the runtime doesn't hang on a phantom
+		// completion that will never come.
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact("provider stream error: Responses event missing required `type` field"),
+		})
+		state.done = true
+		return false
+	}
+	switch event.Type {
+	case responsesEventCreated, responsesEventInProgress,
+		responsesEventContentPartAdded, responsesEventContentPartDone,
+		responsesEventOutputTextDone, responsesEventIncomplete:
+		// Informational or terminal-without-error events we don't surface to
+		// the runtime. response.incomplete is folded into a length finish at
+		// scan-end (state.done stays false so the wrapper emits the
+		// StreamEventDone with FinishReasonLength).
+		return true
+	case responsesEventOutputItemAdded:
+		p.handleOutputItemAdded(ctx, &event, state, events)
+		return true
+	case responsesEventOutputTextDelta:
+		if event.Delta != "" {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:    zeroruntime.StreamEventText,
+				Content: event.Delta,
+			})
+		}
+		return true
+	case responsesEventFunctionArgsDelta:
+		p.handleFunctionArgsDelta(ctx, &event, state, events)
+		return true
+	case responsesEventOutputItemDone:
+		p.handleOutputItemDone(ctx, &event, state, events)
+		return true
+	case responsesEventCompleted, responsesEventFailed:
+		return p.handleTerminalResponse(ctx, &event, state, events)
+	case responsesEventError:
+		message := event.Message
+		if event.Code != "" {
+			message = strings.TrimSpace(event.Code + " " + message)
+		}
+		if message == "" {
+			message = "provider error"
+		}
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact(message),
+		})
+		state.done = true
+		return false
+	default:
+		// Unknown event types are ignored (not errors). The Codex backend
+		// may emit Responses events the openai Codex provider doesn't
+		// recognize — surfacing them as errors would block every other
+		// field in the same payload.
+		return true
+	}
+}
+
+// handleOutputItemAdded registers a new function_call item so subsequent
+// argument deltas can be attributed, and emits StreamEventToolCallStart
+// (with the function name once it is known). A `message` item is just
+// tracked in case the backend ever ties text deltas to it — currently
+// text deltas carry their own item_id and the message itself is a
+// no-op for the runtime.
+func (p *CodexProvider) handleOutputItemAdded(
+	ctx context.Context,
+	event *responsesEvent,
+	state *responsesState,
+	events chan<- zeroruntime.StreamEvent,
+) {
+	if event.Item == nil {
+		return
+	}
+	switch event.Item.Type {
+	case "function_call":
+		key := p.toolCallKey(event)
+		if key == "" {
+			return
+		}
+		builder := &toolCallBuilder{
+			ID:   key,
+			Name: event.Item.Name,
+		}
+		state.toolCalls[key] = builder
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:       zeroruntime.StreamEventToolCallStart,
+			ToolCallID: key,
+			ToolName:   event.Item.Name,
+		})
+		builder.started = true
+	}
+}
+
+// handleFunctionArgsDelta appends one function-call argument fragment
+// to the in-flight builder and emits StreamEventToolCallDelta. The
+// Codex backend uses either `item_id` or `output_index` to attribute
+// the delta; we honor both.
+func (p *CodexProvider) handleFunctionArgsDelta(
+	ctx context.Context,
+	event *responsesEvent,
+	state *responsesState,
+	events chan<- zeroruntime.StreamEvent,
+) {
+	key := p.toolCallKey(event)
+	if key == "" {
+		return
+	}
+	builder, ok := state.toolCalls[key]
+	if !ok {
+		// The Codex backend started streaming arguments before the
+		// matching output_item.added (or the added event was dropped by
+		// an intermediate proxy). Treat the delta as the start of a new
+		// tool call with no known name yet — the eventual
+		// response.output_item.done carries the final name.
+		builder = &toolCallBuilder{ID: key}
+		state.toolCalls[key] = builder
+	}
+	builder.Arguments.WriteString(event.Delta)
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:              zeroruntime.StreamEventToolCallDelta,
+		ToolCallID:        key,
+		ArgumentsFragment: event.Delta,
+	})
+}
+
+// handleOutputItemDone finalizes a tool call when the item type is
+// function_call. The accumulated arguments and the (possibly late)
+// function name are written to the builder before StreamEventToolCallEnd
+// is emitted. A non-function_call done event (typically the assistant
+// `message` that wraps the text) is a no-op for the runtime.
+func (p *CodexProvider) handleOutputItemDone(
+	ctx context.Context,
+	event *responsesEvent,
+	state *responsesState,
+	events chan<- zeroruntime.StreamEvent,
+) {
+	if event.Item == nil || event.Item.Type != "function_call" {
+		return
+	}
+	key := p.toolCallKey(event)
+	if key == "" {
+		return
+	}
+	builder, ok := state.toolCalls[key]
+	if !ok {
+		builder = &toolCallBuilder{ID: key}
+		state.toolCalls[key] = builder
+	}
+	if event.Item.Name != "" {
+		builder.Name = event.Item.Name
+	}
+	if event.Item.Arguments != "" && builder.Arguments.Len() == 0 {
+		builder.Arguments.WriteString(event.Item.Arguments)
+	}
+	if !builder.started {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:       zeroruntime.StreamEventToolCallStart,
+			ToolCallID: key,
+			ToolName:   builder.Name,
+		})
+		builder.started = true
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+		Type:       zeroruntime.StreamEventToolCallEnd,
+		ToolCallID: key,
+		ToolName:   builder.Name,
+	})
+	builder.ended = true
+}
+
+// handleTerminalResponse emits the final usage + done event for a
+// response.completed / response.failed. response.failed carries an
+// error payload that we surface as a runtime error after the usage
+// chunk, so token accounting is preserved even on a failure path.
+func (p *CodexProvider) handleTerminalResponse(
+	ctx context.Context,
+	event *responsesEvent,
+	state *responsesState,
+	events chan<- zeroruntime.StreamEvent,
+) bool {
+	if event.Response == nil {
+		state.done = true
+		return false
+	}
+	state.usage = event.Response.Usage
+	if event.Response.Usage != nil {
+		usage := zeroruntime.Usage{
+			InputTokens:  event.Response.Usage.InputTokens,
+			OutputTokens: event.Response.Usage.OutputTokens,
+		}
+		if event.Response.Usage.InputTokensDetails != nil {
+			usage.CachedInputTokens = event.Response.Usage.InputTokensDetails.CachedTokens
+		}
+		if event.Response.Usage.OutputTokensDetails != nil {
+			usage.ReasoningTokens = event.Response.Usage.OutputTokensDetails.ReasoningTokens
+		}
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventUsage,
+			Usage: usage,
+		})
+	}
+	if event.Response.Error != nil {
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: p.redact(event.Response.Error.Message),
+		})
+		state.done = true
+		return false
+	}
+	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+	state.done = true
+	return false
+}
+
+// toolCallKey returns the canonical id used to track an in-flight
+// function call across multiple SSE events. The Codex backend may emit
+// `item_id` (the call id) or rely on `output_index` (the position in
+// the response.output array); we accept both for robustness.
+func (p *CodexProvider) toolCallKey(event *responsesEvent) string {
+	if event.ItemID != "" {
+		return event.ItemID
+	}
+	if event.Item != nil && event.Item.ID != "" {
+		return event.Item.ID
+	}
+	if event.Item != nil && event.Item.CallID != "" {
+		return event.Item.CallID
+	}
+	if event.OutputIndex > 0 {
+		// OutputIndex is 0-based; offset by one to keep "0" reserved for
+		// "no index known" so it cannot collide with a real zero-indexed
+		// call.
+		return fmt.Sprintf("output-%d", event.OutputIndex+1)
+	}
+	return ""
+}
+
+// redact is the same secret-stripping helper the openai provider uses
+// for its own error messages — provided as a method on CodexProvider so
+// the Responses stream path can call it without reaching across the
+// inner Provider.
+func (p *CodexProvider) redact(message string) string {
+	if p.inner == nil {
+		return providerio.Redact(message)
+	}
+	return providerio.Redact(message, p.inner.apiKey, p.inner.authHeaderValue)
+}
+
+// classifiedError wraps a non-2xx body with the same status-code-aware
+// prefix the openai provider uses ("auth error: ", "rate limit error: ",
+// "provider error: ", "provider request error: ").
+func (p *CodexProvider) classifiedError(statusCode int, message string) string {
+	if p.inner == nil {
+		return providerio.ClassifiedError(statusCode, message)
+	}
+	return providerio.ClassifiedError(statusCode, message, p.inner.apiKey, p.inner.authHeaderValue)
+}

--- a/internal/providers/openai/codex_test.go
+++ b/internal/providers/openai/codex_test.go
@@ -27,10 +27,26 @@ type codexRequest struct {
 }
 
 // newCodexTestServer returns an httptest.Server that records each request's
-// Codex headers and writes a minimal [DONE] SSE stream. The Codex provider
-// targets `{BaseURL}/responses` (the Responses API on the chatgpt backend),
-// so the handler is mounted on that path.
+// Codex headers and writes a minimal Responses-API SSE stream (a single
+// response.completed event with no content). The Codex provider targets
+// `{BaseURL}/responses` (the Responses API on the chatgpt backend), so the
+// handler is mounted on that path. Tests that want a richer stream (text
+// deltas, tool calls, errors) use newCodexResponsesServer with a custom
+// event sequence.
 func newCodexTestServer(t *testing.T, rec *codexRequest) *httptest.Server {
+	t.Helper()
+	return newCodexResponsesServer(t, rec,
+		`{"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+		`{"type":"response.completed","response":{"id":"resp-1","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}`,
+	)
+}
+
+// newCodexResponsesServer returns an httptest.Server that records each
+// request's Codex headers and writes the given SSE data payloads in order.
+// Each payload is emitted as one `data: <payload>\n\n` block, so a test
+// can supply a complete Responses-API event sequence (created, deltas,
+// completed) by passing them in order.
+func newCodexResponsesServer(t *testing.T, rec *codexRequest, payloads ...string) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/responses", func(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +62,9 @@ func newCodexTestServer(t *testing.T, rec *codexRequest) *httptest.Server {
 		}
 		_ = json.NewDecoder(r.Body).Decode(&rec.body)
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		for _, payload := range payloads {
+			_, _ = w.Write([]byte("data: " + payload + "\n\n"))
+		}
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
@@ -278,7 +296,7 @@ func TestCodexProviderResolverIsConsultedOnEveryRequest(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-2\",\"status\":\"completed\"}}\n\n"))
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
@@ -365,7 +383,11 @@ func TestCodexProviderOmitsAccountIDWhenResolverSaysNo(t *testing.T) {
 	}
 }
 
-func TestCodexProviderSendsRequestBody(t *testing.T) {
+func TestCodexProviderSendsResponsesRequestShape(t *testing.T) {
+	// The Codex provider speaks the Responses API, not the chat-completions
+	// API. The request body must carry `input` items (not `messages`), a
+	// `stream: true` flag, and `tools` (when the caller supplies any) — a
+	// chat-completions body would be rejected by the live Codex backend.
 	var rec codexRequest
 	srv := newCodexTestServer(t, &rec)
 	defer srv.Close()
@@ -386,16 +408,46 @@ func TestCodexProviderSendsRequestBody(t *testing.T) {
 			{Role: zeroruntime.MessageRoleSystem, Content: "sys"},
 			{Role: zeroruntime.MessageRoleUser, Content: "hi"},
 		},
+		Tools: []zeroruntime.ToolDefinition{
+			{Name: "get_weather", Description: "get the weather", Parameters: map[string]any{"type": "object"}},
+		},
 	})
 	if err != nil {
 		t.Fatalf("StreamCompletion: %v", err)
 	}
 	drainCodexEvents(t, stream)
+
 	if rec.body["model"] != "gpt-5" {
 		t.Fatalf("body.model = %#v, want gpt-5", rec.body["model"])
 	}
 	if rec.body["stream"] != true {
 		t.Fatalf("body.stream = %#v, want true", rec.body["stream"])
+	}
+	if _, ok := rec.body["messages"]; ok {
+		t.Fatalf("body must not carry chat-completions `messages` (got %#v); the Codex backend serves the Responses API", rec.body["messages"])
+	}
+	input, ok := rec.body["input"].([]any)
+	if !ok {
+		t.Fatalf("body.input = %#v, want []any with two message items", rec.body["input"])
+	}
+	if len(input) != 2 {
+		t.Fatalf("body.input has %d items, want 2 (system + user)", len(input))
+	}
+	system, _ := input[0].(map[string]any)
+	if system["type"] != "message" || system["role"] != "system" {
+		t.Fatalf("body.input[0] = %#v, want type=message role=system", system)
+	}
+	user, _ := input[1].(map[string]any)
+	if user["type"] != "message" || user["role"] != "user" {
+		t.Fatalf("body.input[1] = %#v, want type=message role=user", user)
+	}
+	tools, ok := rec.body["tools"].([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("body.tools = %#v, want a single tool", rec.body["tools"])
+	}
+	tool, _ := tools[0].(map[string]any)
+	if tool["type"] != "function" || tool["name"] != "get_weather" {
+		t.Fatalf("body.tools[0] = %#v, want type=function name=get_weather", tool)
 	}
 }
 
@@ -420,7 +472,7 @@ func TestCodexProviderRetriesHeadersAfter401(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-2\",\"status\":\"completed\"}}\n\n"))
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
@@ -537,8 +589,8 @@ func TestCodexProviderStreamIdleTimeoutPropagates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewCodexProvider: %v", err)
 	}
-	// A simple stream that returns [DONE] immediately does not hit the
-	// timeout — the test just confirms the option is accepted.
+	// A simple stream that returns response.completed immediately does not
+	// hit the timeout — the test just confirms the option is accepted.
 	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
 		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
 	})
@@ -546,4 +598,315 @@ func TestCodexProviderStreamIdleTimeoutPropagates(t *testing.T) {
 		t.Fatalf("StreamCompletion: %v", err)
 	}
 	drainCodexEvents(t, stream)
+}
+
+func TestCodexProviderParsesResponsesTextDeltas(t *testing.T) {
+	// The Codex backend streams text as a series of
+	// `response.output_text.delta` events. Each delta must surface as a
+	// runtime text event in order, and the terminal `response.completed`
+	// must emit StreamEventUsage (with the right token counts) and
+	// StreamEventDone in that order.
+	var rec codexRequest
+	srv := newCodexResponsesServer(t, &rec,
+		`{"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+		`{"type":"response.output_text.delta","delta":"hello "}`,
+		`{"type":"response.output_text.delta","delta":"world"}`,
+		`{"type":"response.output_text.delta","delta":"!"}`,
+		`{"type":"response.completed","response":{"id":"resp-1","status":"completed","usage":{"input_tokens":7,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":1},"input_tokens_details":{"cached_tokens":2}}}}`,
+	)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "say hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	var texts []string
+	var usage *zeroruntime.Usage
+	gotDone := false
+	for ev := range stream {
+		switch ev.Type {
+		case zeroruntime.StreamEventText:
+			texts = append(texts, ev.Content)
+		case zeroruntime.StreamEventUsage:
+			usage = &ev.Usage
+		case zeroruntime.StreamEventDone:
+			gotDone = true
+		case zeroruntime.StreamEventError:
+			t.Fatalf("unexpected error event: %q", ev.Error)
+		}
+	}
+	if joined := strings.Join(texts, ""); joined != "hello world!" {
+		t.Fatalf("text deltas concatenated = %q, want %q", joined, "hello world!")
+	}
+	if usage == nil {
+		t.Fatal("expected a usage event, got none")
+	}
+	if usage.InputTokens != 7 || usage.OutputTokens != 3 || usage.CachedInputTokens != 2 || usage.ReasoningTokens != 1 {
+		t.Fatalf("usage = %+v, want input=7 output=3 cached=2 reasoning=1", *usage)
+	}
+	if !gotDone {
+		t.Fatal("expected a done event, got none")
+	}
+}
+
+func TestCodexProviderParsesResponsesToolCalls(t *testing.T) {
+	// The Codex backend streams function calls as three coordinated event
+	// types: `response.output_item.added` (carries the call id and name),
+	// `response.function_call_arguments.delta` (one or more events that
+	// accumulate the arguments), and `response.output_item.done`
+	// (finalizes). The runtime must see a tool-call-start with the right
+	// name, deltas in order, and a tool-call-end that closes the call.
+	// Deltas are kept simple ("arg1"/"arg2") to avoid tangling this test
+	// in JSON-string escaping; the joined argument string is asserted
+	// directly.
+	var rec codexRequest
+	srv := newCodexResponsesServer(t, &rec,
+		`{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"call-1","call_id":"call-1","name":"get_weather"}}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"call-1","output_index":0,"delta":"arg1"}`,
+		`{"type":"response.function_call_arguments.delta","item_id":"call-1","output_index":0,"delta":"arg2"}`,
+		`{"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"call-1","call_id":"call-1","name":"get_weather","arguments":"arg1arg2"}}`,
+		`{"type":"response.completed","response":{"id":"resp-1","status":"completed","usage":{"input_tokens":3,"output_tokens":2}}}`,
+	)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "weather in SF?"}},
+		Tools: []zeroruntime.ToolDefinition{
+			{Name: "get_weather", Parameters: map[string]any{"type": "object"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	var starts, deltas, ends int
+	var startName, endName string
+	var fragments []string
+	for ev := range stream {
+		switch ev.Type {
+		case zeroruntime.StreamEventToolCallStart:
+			starts++
+			startName = ev.ToolName
+		case zeroruntime.StreamEventToolCallDelta:
+			deltas++
+			fragments = append(fragments, ev.ArgumentsFragment)
+		case zeroruntime.StreamEventToolCallEnd:
+			ends++
+			endName = ev.ToolName
+		case zeroruntime.StreamEventError:
+			t.Fatalf("unexpected error event: %q", ev.Error)
+		}
+	}
+	if starts != 1 || startName != "get_weather" {
+		t.Fatalf("tool-call-start count=%d name=%q, want 1 get_weather", starts, startName)
+	}
+	if deltas != 2 {
+		t.Fatalf("tool-call-delta count=%d, want 2", deltas)
+	}
+	if joined := strings.Join(fragments, ""); joined != "arg1arg2" {
+		t.Fatalf("tool-call-delta fragments = %q, want %q", joined, "arg1arg2")
+	}
+	if ends != 1 || endName != "get_weather" {
+		t.Fatalf("tool-call-end count=%d name=%q, want 1 get_weather", ends, endName)
+	}
+}
+
+func TestCodexProviderSendsAssistantToolCallsAsInputItems(t *testing.T) {
+	// When the runtime replays a prior assistant turn that issued a tool
+	// call, the Codex provider must serialize the turn as BOTH the
+	// assistant message (its text) AND a function_call item for the call.
+	// A bare assistant message without the function_call item would make
+	// the model think no tool was invoked.
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleUser, Content: "weather in SF?"},
+			{
+				Role:    zeroruntime.MessageRoleAssistant,
+				Content: "let me check",
+				ToolCalls: []zeroruntime.ToolCall{
+					{ID: "call-1", Name: "get_weather", Arguments: `{"location":"SF"}`},
+				},
+			},
+			{Role: zeroruntime.MessageRoleTool, ToolCallID: "call-1", Content: "72F and sunny"},
+			{Role: zeroruntime.MessageRoleUser, Content: "thanks"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+
+	input, ok := rec.body["input"].([]any)
+	if !ok || len(input) != 5 {
+		t.Fatalf("body.input = %#v, want 5 items (user + assistant text + function_call + function_call_output + user)", rec.body["input"])
+	}
+	user, _ := input[0].(map[string]any)
+	if user["type"] != "message" || user["role"] != "user" {
+		t.Fatalf("body.input[0] = %#v, want type=message role=user", user)
+	}
+	assistant, _ := input[1].(map[string]any)
+	if assistant["type"] != "message" || assistant["role"] != "assistant" {
+		t.Fatalf("body.input[1] = %#v, want type=message role=assistant", assistant)
+	}
+	functionCall, _ := input[2].(map[string]any)
+	if functionCall["type"] != "function_call" {
+		t.Fatalf("body.input[2] = %#v, want type=function_call", functionCall)
+	}
+	if functionCall["name"] != "get_weather" {
+		t.Fatalf("body.input[2].name = %#v, want get_weather", functionCall["name"])
+	}
+	if functionCall["arguments"] != `{"location":"SF"}` {
+		t.Fatalf("body.input[2].arguments = %#v, want %q", functionCall["arguments"], `{"location":"SF"}`)
+	}
+	functionOutput, _ := input[3].(map[string]any)
+	if functionOutput["type"] != "function_call_output" {
+		t.Fatalf("body.input[3] = %#v, want type=function_call_output", functionOutput)
+	}
+	if functionOutput["call_id"] != "call-1" {
+		t.Fatalf("body.input[3].call_id = %#v, want call-1", functionOutput["call_id"])
+	}
+	finalUser, _ := input[4].(map[string]any)
+	if finalUser["type"] != "message" || finalUser["role"] != "user" {
+		t.Fatalf("body.input[4] = %#v, want type=message role=user", finalUser)
+	}
+}
+
+func TestCodexProviderEmitsErrorOnResponseErrorEvent(t *testing.T) {
+	// A `response.error` event from the Codex backend is the stream-level
+	// error signal. It must surface as a single StreamEventError and stop
+	// the scan so the runtime doesn't hang waiting for a completion.
+	var rec codexRequest
+	srv := newCodexResponsesServer(t, &rec,
+		`{"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+		`{"type":"response.error","code":"rate_limit_exceeded","message":"too many requests"}`,
+	)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	var gotError string
+	for ev := range stream {
+		if ev.Type == zeroruntime.StreamEventError {
+			gotError = ev.Error
+		}
+	}
+	if gotError == "" {
+		t.Fatal("expected a StreamEventError, got none")
+	}
+	if !strings.Contains(gotError, "too many requests") {
+		t.Fatalf("error = %q, want one mentioning the response.error message", gotError)
+	}
+}
+
+func TestCodexProviderEmitsErrorOnMalformedStream(t *testing.T) {
+	// A non-JSON data payload (or a payload with a missing `type` field)
+	// must be reported as a stream error rather than silently dropped —
+	// otherwise the runtime would hang waiting for a completion event
+	// that never arrives.
+	var rec codexRequest
+	srv := newCodexResponsesServer(t, &rec,
+		`{"type":"response.created","response":{"id":"resp-1","status":"in_progress"}}`,
+		`{"not-a-valid-event":true}`,
+	)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	var gotError string
+	for ev := range stream {
+		if ev.Type == zeroruntime.StreamEventError {
+			gotError = ev.Error
+		}
+	}
+	if gotError == "" {
+		t.Fatal("expected a StreamEventError for a malformed event, got none")
+	}
+}
+
+func TestCodexProviderEmitsLengthFinishWhenStreamEndsWithoutCompletion(t *testing.T) {
+	// The Codex backend may close the SSE stream without emitting
+	// `response.completed` (e.g. an internal truncation). The wrapper
+	// must surface a StreamEventDone with FinishReasonLength so the
+	// runtime can react, instead of hanging on a missing completion.
+	var rec codexRequest
+	srv := newCodexResponsesServer(t, &rec,
+		`{"type":"response.output_text.delta","delta":"partial"}`,
+	)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk-test", BaseURL: srv.URL, Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	var finishReason string
+	var gotDone bool
+	for ev := range stream {
+		if ev.Type == zeroruntime.StreamEventDone {
+			gotDone = true
+			finishReason = ev.FinishReason
+		}
+	}
+	if !gotDone {
+		t.Fatal("expected a StreamEventDone, got none")
+	}
+	if finishReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("finish reason = %q, want %q", finishReason, zeroruntime.FinishReasonLength)
+	}
 }

--- a/internal/providers/openai/codex_test.go
+++ b/internal/providers/openai/codex_test.go
@@ -1,0 +1,465 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// codexRequest captures the headers + body of one outgoing Codex request so a
+// test can assert the Codex-specific headers were applied.
+type codexRequest struct {
+	method      string
+	path        string
+	originator  string
+	accountID   string
+	userAgent   string
+	auth        string
+	otherHeader map[string]string
+	body        map[string]any
+}
+
+// newCodexTestServer returns an httptest.Server that records each request's
+// Codex headers and writes a minimal [DONE] SSE stream.
+func newCodexTestServer(t *testing.T, rec *codexRequest) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		rec.method = r.Method
+		rec.path = r.URL.Path
+		rec.originator = r.Header.Get(codexOriginatorHeader)
+		rec.accountID = r.Header.Get(codexAccountHeader)
+		rec.userAgent = r.Header.Get("User-Agent")
+		rec.auth = r.Header.Get("Authorization")
+		rec.otherHeader = map[string]string{}
+		for _, k := range []string{"Content-Type", "X-Extra"} {
+			rec.otherHeader[k] = r.Header.Get(k)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&rec.body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+	return httptest.NewServer(mux)
+}
+
+func drainCodexEvents(t *testing.T, stream <-chan zeroruntime.StreamEvent) {
+	t.Helper()
+	for ev := range stream {
+		if ev.Type == zeroruntime.StreamEventError {
+			t.Fatalf("unexpected error event: %q", ev.Error)
+		}
+	}
+}
+
+func TestCodexProviderSetsExpectedHeaders(t *testing.T) {
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+		},
+		AccountID:  "acc-from-token",
+		Originator: "codex_cli_rs",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+
+	if rec.method != http.MethodPost {
+		t.Fatalf("method = %q, want POST", rec.method)
+	}
+	if rec.path != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", rec.path)
+	}
+	if rec.originator != "codex_cli_rs" {
+		t.Fatalf("originator = %q, want codex_cli_rs", rec.originator)
+	}
+	if rec.accountID != "acc-from-token" {
+		t.Fatalf("chatgpt-account-id = %q, want acc-from-token", rec.accountID)
+	}
+	if rec.auth != "Bearer sk-test" {
+		t.Fatalf("Authorization = %q, want Bearer sk-test", rec.auth)
+	}
+	if rec.otherHeader["Content-Type"] != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", rec.otherHeader["Content-Type"])
+	}
+	if rec.userAgent == "" {
+		t.Fatalf("User-Agent = empty, want the Codex default (codex_cli_rs)")
+	}
+}
+
+func TestCodexProviderUsesConfiguredBaseURL(t *testing.T) {
+	var rec codexRequest
+	// Run the test server on a custom path to confirm the request goes
+	// through {BaseURL}/chat/completions, not a hard-coded host.
+	mux := http.NewServeMux()
+	customPath := "/api/v1/codex/chat/completions"
+	var hit atomic.Int32
+	mux.HandleFunc(customPath, func(w http.ResponseWriter, r *http.Request) {
+		hit.Add(1)
+		rec.path = r.URL.Path
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL + "/api/v1/codex",
+			Model:   "gpt-5",
+		},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+	if rec.path != customPath {
+		t.Fatalf("path = %q, want %q (the Codex baseURL must be honored)", rec.path, customPath)
+	}
+	if hit.Load() != 1 {
+		t.Fatalf("server hit %d times, want 1", hit.Load())
+	}
+}
+
+func TestCodexProviderDefaultsOriginator(t *testing.T) {
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+		},
+		// Originator intentionally empty: defaults to "codex_cli_rs".
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+	if rec.originator != codexDefaultOriginator {
+		t.Fatalf("originator = %q, want default %q", rec.originator, codexDefaultOriginator)
+	}
+}
+
+func TestCodexProviderBrandsUserAgent(t *testing.T) {
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+			// openai Options.UserAgent overridden by CodexOptions.UserAgent below.
+			UserAgent: "zero/dev",
+		},
+		// CodexOptions.UserAgent wins over openai Options.UserAgent.
+		UserAgent: "codex_cli_rs/0.1",
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+	if rec.userAgent != "codex_cli_rs/0.1" {
+		t.Fatalf("User-Agent = %q, want codex_cli_rs/0.1 (CodexOptions.UserAgent should win)", rec.userAgent)
+	}
+}
+
+func TestCodexProviderAccountResolverIsUsedWhenAccountIDEmpty(t *testing.T) {
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	var resolverCalls atomic.Int32
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+		},
+		// AccountID empty: AccountResolver is the source.
+		AccountResolver: func(_ context.Context) (string, bool, error) {
+			resolverCalls.Add(1)
+			return "acc-resolver", true, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+	if resolverCalls.Load() != 1 {
+		t.Fatalf("resolver called %d times, want 1", resolverCalls.Load())
+	}
+	if rec.accountID != "acc-resolver" {
+		t.Fatalf("chatgpt-account-id = %q, want acc-resolver", rec.accountID)
+	}
+}
+
+func TestCodexProviderOmitsAccountIDWhenResolverSaysNo(t *testing.T) {
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+		},
+		AccountResolver: func(_ context.Context) (string, bool, error) {
+			return "", false, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+	if rec.accountID != "" {
+		t.Fatalf("chatgpt-account-id = %q, want empty (resolver returned ok=false)", rec.accountID)
+	}
+}
+
+func TestCodexProviderSendsRequestBody(t *testing.T) {
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:  "sk-test",
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+		},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{
+			{Role: zeroruntime.MessageRoleSystem, Content: "sys"},
+			{Role: zeroruntime.MessageRoleUser, Content: "hi"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+	if rec.body["model"] != "gpt-5" {
+		t.Fatalf("body.model = %#v, want gpt-5", rec.body["model"])
+	}
+	if rec.body["stream"] != true {
+		t.Fatalf("body.stream = %#v, want true", rec.body["stream"])
+	}
+}
+
+func TestCodexProviderRetriesHeadersAfter401(t *testing.T) {
+	var hits atomic.Int32
+	var rec1, rec2 codexRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		var rec *codexRequest
+		if n == 1 {
+			rec = &rec1
+		} else {
+			rec = &rec2
+		}
+		rec.path = r.URL.Path
+		rec.originator = r.Header.Get(codexOriginatorHeader)
+		rec.accountID = r.Header.Get(codexAccountHeader)
+		rec.auth = r.Header.Get("Authorization")
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Wire an OAuthResolver so the openai provider's 401-retry path runs
+	// (otherwise a 401 short-circuits to an auth error and the retry is
+	// never made). The Codex provider's setRequestExtra is what we want
+	// to verify; the resolver just needs to be a stable, force-refreshable
+	// token source.
+	resolver := func(_ context.Context, _ bool) (string, string, bool, error) {
+		return "Authorization", "Bearer oauth-tok", true, nil
+	}
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+			OAuthResolver: func(ctx context.Context, fr bool) (string, string, bool, error) {
+				return resolver(ctx, fr)
+			},
+		},
+		AccountID:  "acc-retry",
+		Originator: "codex_cli_rs",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	// The first request is a 401; the openai provider surfaces it as an
+	// auth error and does NOT retry automatically unless an OAuthResolver
+	// is wired AND sends ok=true. With our resolver in place the retry
+	// path runs and the second request returns [DONE]. The test asserts
+	// the Codex headers are applied on BOTH attempts.
+	drainCodexEvents(t, stream)
+	if hits.Load() != 2 {
+		t.Fatalf("server hit %d times, want 2 (initial + retry)", hits.Load())
+	}
+	if rec1.originator != "codex_cli_rs" || rec1.accountID != "acc-retry" {
+		t.Fatalf("first attempt headers: originator=%q accountID=%q", rec1.originator, rec1.accountID)
+	}
+	if rec2.originator != "codex_cli_rs" || rec2.accountID != "acc-retry" {
+		t.Fatalf("retry headers missing: originator=%q accountID=%q (Codex headers must survive 401-refresh)", rec2.originator, rec2.accountID)
+	}
+}
+
+func TestCodexProviderRequiresBaseURL(t *testing.T) {
+	// An empty baseURL falls back to the openai provider's default
+	// (https://api.openai.com/v1). The Codex provider is designed to be
+	// wired by the factory with the catalog's Codex baseURL, so the
+	// realistic misconfig is an INVALID baseURL (covered in the next
+	// test). This test just confirms the constructor accepts an empty
+	// baseURL — the factory will always supply the Codex-specific URL.
+	provider, err := NewCodexProvider(CodexOptions{
+		Options:   Options{Model: "gpt-5"},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider with empty baseURL should not error (factory will override): %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected a provider, got nil")
+	}
+}
+
+func TestCodexProviderRejectsBadBaseURL(t *testing.T) {
+	_, err := NewCodexProvider(CodexOptions{
+		Options:   Options{APIKey: "sk", Model: "gpt-5", BaseURL: "://not a url"},
+		AccountID: "acc-x",
+	})
+	if err == nil {
+		t.Fatal("NewCodexProvider with a bad baseURL should error")
+	}
+	if !strings.Contains(err.Error(), "base URL") && !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("error = %q, want one mentioning base URL", err.Error())
+	}
+}
+
+func TestValidateAccount(t *testing.T) {
+	if err := ValidateAccount(""); err == nil {
+		t.Fatal("empty account id should be rejected")
+	}
+	if err := ValidateAccount("  "); err == nil {
+		t.Fatal("whitespace-only account id should be rejected")
+	}
+	if err := ValidateAccount("acc-1"); err != nil {
+		t.Fatalf("non-empty account id should be accepted, got %v", err)
+	}
+}
+
+func TestCodexProviderStreamIdleTimeoutPropagates(t *testing.T) {
+	// Sanity check: the wrapped openai provider's StreamIdleTimeout flows
+	// through. The default is 90s; we override to a small value so a real
+	// hang surfaces in the test.
+	var rec codexRequest
+	srv := newCodexTestServer(t, &rec)
+	defer srv.Close()
+
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			APIKey:            "sk-test",
+			BaseURL:           srv.URL,
+			Model:             "gpt-5",
+			StreamIdleTimeout: 50 * time.Millisecond,
+		},
+		AccountID: "acc-x",
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+	// A simple stream that returns [DONE] immediately does not hit the
+	// timeout — the test just confirms the option is accepted.
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+}

--- a/internal/providers/openai/codex_test.go
+++ b/internal/providers/openai/codex_test.go
@@ -27,11 +27,13 @@ type codexRequest struct {
 }
 
 // newCodexTestServer returns an httptest.Server that records each request's
-// Codex headers and writes a minimal [DONE] SSE stream.
+// Codex headers and writes a minimal [DONE] SSE stream. The Codex provider
+// targets `{BaseURL}/responses` (the Responses API on the chatgpt backend),
+// so the handler is mounted on that path.
 func newCodexTestServer(t *testing.T, rec *codexRequest) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
-	mux.HandleFunc("/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/responses", func(w http.ResponseWriter, r *http.Request) {
 		rec.method = r.Method
 		rec.path = r.URL.Path
 		rec.originator = r.Header.Get(codexOriginatorHeader)
@@ -89,8 +91,8 @@ func TestCodexProviderSetsExpectedHeaders(t *testing.T) {
 	if rec.method != http.MethodPost {
 		t.Fatalf("method = %q, want POST", rec.method)
 	}
-	if rec.path != "/chat/completions" {
-		t.Fatalf("path = %q, want /chat/completions", rec.path)
+	if rec.path != "/responses" {
+		t.Fatalf("path = %q, want /responses", rec.path)
 	}
 	if rec.originator != "codex_cli_rs" {
 		t.Fatalf("originator = %q, want codex_cli_rs", rec.originator)
@@ -112,9 +114,9 @@ func TestCodexProviderSetsExpectedHeaders(t *testing.T) {
 func TestCodexProviderUsesConfiguredBaseURL(t *testing.T) {
 	var rec codexRequest
 	// Run the test server on a custom path to confirm the request goes
-	// through {BaseURL}/chat/completions, not a hard-coded host.
+	// through {BaseURL}/responses, not a hard-coded host.
 	mux := http.NewServeMux()
-	customPath := "/api/v1/codex/chat/completions"
+	customPath := "/api/v1/codex/responses"
 	var hit atomic.Int32
 	mux.HandleFunc(customPath, func(w http.ResponseWriter, r *http.Request) {
 		hit.Add(1)
@@ -251,6 +253,88 @@ func TestCodexProviderAccountResolverIsUsedWhenAccountIDEmpty(t *testing.T) {
 	}
 }
 
+func TestCodexProviderResolverIsConsultedOnEveryRequest(t *testing.T) {
+	// The factory wires the AccountResolver from the OAuth store so a refresh
+	// that updates the stored token's Account field takes effect on the next
+	// outgoing request — not just the first. This test asserts the resolver
+	// runs once per request (and that the second request picks up the
+	// account id the resolver starts returning on call #2).
+	var hits atomic.Int32
+	var rec1, rec2 codexRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/responses", func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		var rec *codexRequest
+		if n == 1 {
+			rec = &rec1
+		} else {
+			rec = &rec2
+		}
+		rec.path = r.URL.Path
+		rec.originator = r.Header.Get(codexOriginatorHeader)
+		rec.accountID = r.Header.Get(codexAccountHeader)
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resolverCalls := atomic.Int32{}
+	provider, err := NewCodexProvider(CodexOptions{
+		Options: Options{
+			BaseURL: srv.URL,
+			Model:   "gpt-5",
+			// Wire an OAuth resolver so the openai provider's 401-retry
+			// path runs. The Codex resolver (AccountResolver) is what
+			// this test actually exercises.
+			OAuthResolver: func(_ context.Context, _ bool) (string, string, bool, error) {
+				return "Authorization", "Bearer oauth-tok", true, nil
+			},
+		},
+		// Static AccountID intentionally empty so the resolver is the
+		// source. The first call returns ok=false (no account); the second
+		// call (after the 401 refresh) returns the new id.
+		AccountResolver: func(_ context.Context) (string, bool, error) {
+			n := resolverCalls.Add(1)
+			if n == 1 {
+				return "", false, nil
+			}
+			return "acc-from-store", true, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCodexProvider: %v", err)
+	}
+
+	stream, err := provider.StreamCompletion(context.Background(), zeroruntime.CompletionRequest{
+		Messages: []zeroruntime.Message{{Role: zeroruntime.MessageRoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("StreamCompletion: %v", err)
+	}
+	drainCodexEvents(t, stream)
+
+	if hits.Load() != 2 {
+		t.Fatalf("server hit %d times, want 2 (initial + retry)", hits.Load())
+	}
+	if resolverCalls.Load() != 2 {
+		t.Fatalf("resolver called %d times, want 2 (once per request, including the 401 retry)", resolverCalls.Load())
+	}
+	if rec1.accountID != "" {
+		t.Fatalf("first attempt account id = %q, want empty (resolver returned ok=false on call 1)", rec1.accountID)
+	}
+	if rec2.accountID != "acc-from-store" {
+		t.Fatalf("retry account id = %q, want acc-from-store (resolver must re-run on every request)", rec2.accountID)
+	}
+}
+
 func TestCodexProviderOmitsAccountIDWhenResolverSaysNo(t *testing.T) {
 	var rec codexRequest
 	srv := newCodexTestServer(t, &rec)
@@ -319,7 +403,7 @@ func TestCodexProviderRetriesHeadersAfter401(t *testing.T) {
 	var hits atomic.Int32
 	var rec1, rec2 codexRequest
 	mux := http.NewServeMux()
-	mux.HandleFunc("/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/responses", func(w http.ResponseWriter, r *http.Request) {
 		n := hits.Add(1)
 		var rec *codexRequest
 		if n == 1 {

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -47,6 +47,13 @@ type Options struct {
 	// ParseThinkTags converts streamed <think>...</think> content into reasoning
 	// events for OpenAI-compatible models known to emit that legacy format.
 	ParseThinkTags bool
+	// SetRequestExtra, when non-nil, is invoked on every outgoing request after
+	// the provider's built-in headers (Content-Type, User-Agent) are set, so a
+	// wrapper (notably the Codex provider) can inject request-specific headers
+	// — e.g. an account id resolved from the OAuth token, or a hard-coded
+	// "originator" value. It is also called on the 401-refresh retry, so any
+	// per-request state must be re-derivable from the live request.
+	SetRequestExtra func(*http.Request)
 }
 
 // Provider streams completions from an OpenAI-compatible chat completions API.
@@ -64,6 +71,7 @@ type Provider struct {
 	userAgent         string
 	streamIdleTimeout time.Duration
 	parseThinkTags    bool
+	setRequestExtra   func(*http.Request)
 }
 
 // New creates an OpenAI-compatible provider.
@@ -111,6 +119,7 @@ func New(options Options) (*Provider, error) {
 		userAgent:         options.UserAgent,
 		streamIdleTimeout: idleTimeout,
 		parseThinkTags:    options.ParseThinkTags,
+		setRequestExtra:   options.SetRequestExtra,
 	}, nil
 }
 
@@ -160,6 +169,9 @@ func (provider *Provider) stream(ctx context.Context, body []byte, events chan<-
 			request.Header.Set("Content-Type", "application/json")
 			if provider.userAgent != "" {
 				request.Header.Set("User-Agent", provider.userAgent)
+			}
+			if provider.setRequestExtra != nil {
+				provider.setRequestExtra(request)
 			}
 		}, 0)
 	if err != nil {

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -25,8 +25,14 @@ const defaultStreamIdleTimeout = 90 * time.Second
 
 // Options configures an OpenAI-compatible chat completions provider.
 type Options struct {
-	APIKey          string
-	BaseURL         string
+	APIKey  string
+	BaseURL string
+	// Endpoint, when non-empty, overrides the default `{BaseURL}/chat/completions`
+	// request URL. Used by flavors (notably the Codex provider) that speak a
+	// different path on the same host — e.g. `/responses` on the ChatGPT Codex
+	// backend. When empty, the openai provider falls back to its default
+	// chat-completions path so every existing caller is unchanged.
+	Endpoint        string
 	Model           string
 	AuthHeader      string
 	AuthScheme      string
@@ -60,6 +66,7 @@ type Options struct {
 type Provider struct {
 	apiKey            string
 	baseURL           string
+	endpoint          string
 	model             string
 	authHeader        string
 	authScheme        string
@@ -90,6 +97,15 @@ func New(options Options) (*Provider, error) {
 		return nil, fmt.Errorf("invalid OpenAI base URL: %w", err)
 	}
 
+	// Endpoint overrides the default chat-completions path. When empty we
+	// append `/chat/completions` to the (trimmed) baseURL. When non-empty we
+	// trust the caller's value verbatim so a flavor (Codex) can target a
+	// sibling path on the same host without re-implementing the transport.
+	endpoint := strings.TrimSpace(options.Endpoint)
+	if endpoint == "" {
+		endpoint = baseURL + "/chat/completions"
+	}
+
 	httpClient := options.HTTPClient
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -108,6 +124,7 @@ func New(options Options) (*Provider, error) {
 	return &Provider{
 		apiKey:            options.APIKey,
 		baseURL:           baseURL,
+		endpoint:          endpoint,
 		model:             model,
 		authHeader:        strings.TrimSpace(options.AuthHeader),
 		authScheme:        strings.TrimSpace(options.AuthScheme),
@@ -143,7 +160,7 @@ func (provider *Provider) StreamCompletion(
 }
 
 func (provider *Provider) stream(ctx context.Context, body []byte, events chan<- zeroruntime.StreamEvent) {
-	endpoint := provider.baseURL + "/chat/completions"
+	endpoint := provider.endpoint
 
 	// streamCtx lets the idle watchdog abort an in-flight body read by cancelling
 	// the request, rather than closing response.Body directly (which would race

--- a/internal/providers/openai/provider_test.go
+++ b/internal/providers/openai/provider_test.go
@@ -566,6 +566,7 @@ func newTestProviderWithOptions(t *testing.T, options Options, handler http.Hand
 		MaxTokens:         options.MaxTokens,
 		StreamIdleTimeout: options.StreamIdleTimeout,
 		ParseThinkTags:    options.ParseThinkTags,
+		SetRequestExtra:   options.SetRequestExtra,
 	})
 	if err != nil {
 		t.Fatalf("New returned error: %v", err)

--- a/internal/tui/onboarding.go
+++ b/internal/tui/onboarding.go
@@ -475,7 +475,8 @@ func (m *model) moveSetupMethod(delta int) {
 // setupOAuthCmd runs the chosen provider's browser OAuth login off the UI
 // goroutine for first-run setup. Mirrors the /provider wizard's flow.
 func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
-	if provider.OAuthMintsKey {
+	switch {
+	case provider.OAuthMintsKey:
 		return func() tea.Msg {
 			key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 				OpenBrowser: browser.OpenURL,
@@ -483,10 +484,16 @@ func setupOAuthCmd(provider providercatalog.Descriptor) tea.Cmd {
 			})
 			return setupOAuthMsg{apiKey: key, providerID: provider.ID, err: err}
 		}
-	}
-	name := provider.ID
-	return func() tea.Msg {
-		return setupOAuthMsg{tokenLogin: true, providerID: name, err: runProviderTokenLogin(name)}
+	case provider.ID == "chatgpt":
+		return func() tea.Msg {
+			err := runProviderChatGPTLogin()
+			return setupOAuthMsg{tokenLogin: true, providerID: provider.ID, err: err}
+		}
+	default:
+		name := provider.ID
+		return func() tea.Msg {
+			return setupOAuthMsg{tokenLogin: true, providerID: name, err: runProviderTokenLogin(name)}
+		}
 	}
 }
 

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -88,11 +88,15 @@ func providerWizardSupportsOAuth(provider providercatalog.Descriptor) bool {
 }
 
 // providerWizardOAuthCmdFor runs the chosen provider's browser OAuth login off the
-// UI goroutine and reports the outcome. OpenRouter mints an API key; other OAuth
-// providers (xAI) run the generic engine login which stores a refreshable token.
+// UI goroutine and reports the outcome. OpenRouter mints an API key; ChatGPT
+// (Codex) needs the bespoke flow that extracts the `chatgpt_account_id` claim
+// from the ID token and stores it on the saved token so the Codex provider can
+// inject it as a header on every request; other OAuth providers (xAI) run the
+// generic engine login which stores a refreshable token.
 func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID int) tea.Cmd {
 	providerID := provider.ID
-	if provider.OAuthMintsKey {
+	switch {
+	case provider.OAuthMintsKey:
 		return func() tea.Msg {
 			key, err := provideroauth.OpenRouterLogin(context.Background(), provideroauth.OpenRouterOptions{
 				OpenBrowser: browser.OpenURL,
@@ -100,10 +104,53 @@ func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID in
 			})
 			return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, apiKey: key, err: err}
 		}
+	case providerID == "chatgpt":
+		return func() tea.Msg {
+			err := runProviderChatGPTLogin()
+			return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, tokenLogin: true, err: err}
+		}
+	default:
+		return func() tea.Msg {
+			return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, tokenLogin: true, err: runProviderTokenLogin(providerID)}
+		}
 	}
-	return func() tea.Msg {
-		return providerWizardOAuthMsg{providerID: providerID, attemptID: attemptID, tokenLogin: true, err: runProviderTokenLogin(providerID)}
+}
+
+// runProviderChatGPTLogin runs the ChatGPT (Codex) bespoke login (which
+// extracts the `chatgpt_account_id` claim from the ID token and stores it on
+// the token's Account field) and persists the resulting token via the oauth
+// store. The runtime resolver then attaches the bearer to Codex calls and the
+// Codex provider reads the Account field for the `chatgpt-account-id` header.
+func runProviderChatGPTLogin() error {
+	env := buildOAuthPresetEnv()
+	token, err := provideroauth.ChatGPTLogin(context.Background(), provideroauth.ChatGPTOptions{
+		Env:        env,
+		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		OpenBrowser: browser.OpenURL,
+		Timeout:     3 * time.Minute,
+	})
+	if err != nil {
+		return err
 	}
+	store, err := oauth.NewStore(oauth.StoreOptions{})
+	if err != nil {
+		return err
+	}
+	return store.Save(oauth.ProviderKey("chatgpt"), token)
+}
+
+// buildOAuthPresetEnv layers the process env with the preset opt-in so a
+// `zero` launch from a TUI session can use the baked-in ChatGPT client_id
+// without requiring the user to export ZERO_OAUTH_ALLOW_PRESETS themselves.
+func buildOAuthPresetEnv() map[string]string {
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		if eq := strings.IndexByte(kv, '='); eq > 0 {
+			env[kv[:eq]] = kv[eq+1:]
+		}
+	}
+	env["ZERO_OAUTH_ALLOW_PRESETS"] = "1"
+	return env
 }
 
 // runProviderTokenLogin runs the generic OAuth engine login for a provider that
@@ -178,7 +225,7 @@ func (m model) startProviderDeviceLogin() (model, tea.Cmd) {
 	return m, providerWizardDevicePrepareCmd(provider.ID, attemptID)
 }
 
-const maxProviderWizardProvidersVisible = 8
+const maxProviderWizardProvidersVisible = 10
 const maxProviderWizardModelsVisible = 10
 const providerWizardMinWidth = 48
 const providerWizardProviderWidth = 64
@@ -212,7 +259,7 @@ func providerWizardMethodOptions() []providerWizardMethodOption {
 		options = append(options, providerWizardMethodOption{
 			oauth:    true,
 			label:    "Sign in with OAuth",
-			subtitle: "One-click browser login, no API key to copy (OpenRouter, xAI).",
+			subtitle: "One-click browser login, no API key to copy (OpenRouter, xAI, ChatGPT, Hugging Face).",
 		})
 	}
 	options = append(options, providerWizardMethodOption{

--- a/internal/tui/provider_wizard.go
+++ b/internal/tui/provider_wizard.go
@@ -124,8 +124,8 @@ func providerWizardOAuthCmdFor(provider providercatalog.Descriptor, attemptID in
 func runProviderChatGPTLogin() error {
 	env := buildOAuthPresetEnv()
 	token, err := provideroauth.ChatGPTLogin(context.Background(), provideroauth.ChatGPTOptions{
-		Env:        env,
-		HTTPClient: &http.Client{Timeout: 60 * time.Second},
+		Env:         env,
+		HTTPClient:  &http.Client{Timeout: 60 * time.Second},
 		OpenBrowser: browser.OpenURL,
 		Timeout:     3 * time.Minute,
 	})


### PR DESCRIPTION
## Summary

Adds two new built-in OAuth presets that round out the existing OpenRouter and xAI surfaces, so the TUI `/provider` OAuth chooser and `zero auth login` work out of the box for these providers.

**Hugging Face**
- Preset scopes, endpoints, and OIDC issuer are pre-filled; the operator supplies a "public" OAuth client_id (no secret) via `ZERO_OAUTH_HUGGINGFACE_CLIENT_ID` after registering an app at `huggingface.co/settings/applications/new`.
- Default flow is RFC 8628 device code, so headless/SSH is the first-class path.
- The bearer works against the OpenAI-compatible Inference Providers router at `https://router.huggingface.co/v1` for hundreds of OSS models (Llama, Qwen, DeepSeek, Mistral, etc.).

**ChatGPT (Codex backend)**
- Uses the publicly-shipped Codex CLI client identity (`app_EMoamEEZ73f0CkXaXp7hrann`), opt-in via `ZERO_OAUTH_ALLOW_PRESETS=1`, overridable via `ZERO_OAUTH_CHATGPT_*`.
- The bespoke `provideroauth.ChatGPTLogin` extracts the `chatgpt_account_id` claim from the OIDC ID token (added as `IDToken` on the `oauth.Token` struct) and stores it on `Token.Account` so the Codex provider can inject it as a header on every request.
- A new `internal/providers/openai/codex.go` wraps the openai provider with the Codex-flavored request shape: `originator: codex_cli_rs`, `chatgpt-account-id: <claim>`, branded User-Agent. The factory branches off the catalog id (not the provider kind) so other openai-compatible providers keep the standard openai path unchanged.
- The openai provider gained a `SetRequestExtra` callback so the Codex wrapper can inject per-request headers without coupling the openai provider to Codex.

## CLI / TUI

- `zero auth chatgpt` is a one-shot login command (analog to `zero auth openrouter`).
- The TUI's OAuth chooser now lists both new providers automatically (the list is built from `providercatalog.OAuthProviders()`).
- The provider-wizard visible-row cap was bumped from 8 to 10 so the common providers all fit without scrolling.

## Tests

- `internal/oauth/presets_test.go`: presets resolve correctly with the expected endpoints, scopes, and flows; env overrides win; Hugging Face preset stays inert without a client_id.
- `internal/providercatalog/oauth_test.go` + `catalog_test.go`: catalog now exposes 4 OAuth providers (`openrouter`, `huggingface`, `chatgpt`, `xai`); the `chatgpt` descriptor is `OAuth=true` with `OAuthDeviceFlow=false` and `RequiresAuth=true` via an inline IIFE.
- `internal/provideroauth/chatgpt_test.go`: ID-token claim extraction round-trips (happy path, missing claim, missing token, tampered JWS, non-string claim); the full login flow runs against a stub auth server.
- `internal/providers/openai/codex_test.go`: every request gets the three Codex headers; the 401-refresh retry path keeps them on the second attempt; configured baseURL wins; default originator is `codex_cli_rs`; branded User-Agent wins over the openai default; AccountResolver is consulted when AccountID is empty.

## Documentation

`docs/oauth-subscriptions.md`:
- §1 "How do you want to connect?" chooser now lists OpenRouter / xAI / ChatGPT / Hugging Face.
- §1 "Built-in OAuth providers" gains a ChatGPT (Codex) section and a Hugging Face section.
- §2 cross-references the new first-class ChatGPT path; the `chatgpt-proxy` route remains the conservative fallback when Cloudflare challenges become an issue.

## Out of scope (separate PRs)

- Multi-account / profiles
- Generic template-driven OAuth wizard
- MCP / provider OAuth store unification
- Subscription-proxy autoconfig

## Verification

```
$env:GOCACHE="D:\Users\Vasanth\AppData\Local\Temp\zero-go-cache"
go build ./...
go test ./... -count=1 -timeout 300s
```

All packages pass. The Codex provider is end-to-end tested: headers, retry behavior, account resolver, baseURL, originator defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ChatGPT and Hugging Face as selectable OAuth providers in the setup experience.
  * Introduced a browser-based `zero auth chatgpt` login command.
  * Added built-in OAuth presets for ChatGPT and Hugging Face, including a Codex-backed ChatGPT option (with proxy as a conservative fallback when needed).

* **Bug Fixes**
  * Improved OAuth token handling by capturing and preserving the OIDC `id_token` when returned, and keeping the prior value when it’s omitted.

* **Documentation**
  * Updated OAuth documentation to reflect the expanded ChatGPT subscription and proxy guidance for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->