### PR TITLE
Align permission prompt rendering

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -23,6 +23,8 @@ const (
 	toolResultControlSpecReview = "spec_review_required"
 )
 
+var errPermissionApprovalCanceled = errors.New("permission approval cancelled")
+
 // abortedToolResultNotice is the placeholder tool result recorded for a tool
 // call that was advertised by the assistant turn but never executed because the
 // repeated-failure guard halted the run first. It keeps every tool_use paired
@@ -604,6 +606,9 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 					requestEvent.Grant = &grant
 				}
 			}
+		case PermissionDecisionCancel:
+			emitCanceledPermission(options, call, requestEvent, decisionReason)
+			return canceledPermissionResult(call, decisionReason, requestEvent), fmt.Errorf("%w for %s", errPermissionApprovalCanceled, call.Name)
 		default:
 			emitDeniedPermission(options, call, requestEvent, decisionReason)
 			return deniedPermissionResult(call, decisionReason, requestEvent), nil
@@ -952,7 +957,7 @@ func requestPermission(ctx context.Context, request PermissionRequest, options O
 
 func normalizePermissionDecisionAction(action PermissionDecisionAction) PermissionDecisionAction {
 	switch action {
-	case PermissionDecisionAllow, PermissionDecisionAllowForSession, PermissionDecisionAlwaysAllow:
+	case PermissionDecisionAllow, PermissionDecisionAllowForSession, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
 		return action
 	default:
 		return PermissionDecisionDeny
@@ -1024,6 +1029,25 @@ func emitDeniedPermission(options Options, call ToolCall, requestEvent Permissio
 	options.OnPermission(event)
 }
 
+func emitCanceledPermission(options Options, call ToolCall, requestEvent PermissionEvent, reason string) {
+	if options.OnPermission == nil {
+		return
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "cancelled in TUI"
+	}
+	event := requestEvent
+	event.ToolCallID = call.ID
+	event.ToolName = call.Name
+	event.Action = PermissionActionCancel
+	event.DecisionAction = PermissionDecisionCancel
+	event.PermissionGranted = false
+	event.DecisionReason = reason
+	event.Reason = reason
+	options.OnPermission(event)
+}
+
 func deniedPermissionResult(call ToolCall, reason string, requestEvent PermissionEvent) ToolResult {
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
@@ -1055,6 +1079,32 @@ func deniedPermissionResult(call ToolCall, reason string, requestEvent Permissio
 		Status:       tools.StatusError,
 		Output:       "Error: Permission denied for " + call.Name + ": " + reason,
 		DenialReason: denial,
+		Meta: map[string]string{
+			"permission_action": string(event.Action),
+		},
+	}
+}
+
+func canceledPermissionResult(call ToolCall, reason string, requestEvent PermissionEvent) ToolResult {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "cancelled in TUI"
+	}
+	event := requestEvent
+	event.Action = PermissionActionCancel
+	event.DecisionAction = PermissionDecisionCancel
+	event.PermissionGranted = false
+	event.DecisionReason = reason
+	event.Reason = reason
+	if requestEvent.ToolName == "" {
+		event.ToolName = call.Name
+	}
+	return ToolResult{
+		ToolCallID:   call.ID,
+		Name:         call.Name,
+		Status:       tools.StatusError,
+		Output:       "Error: Permission approval cancelled for " + call.Name + ": " + reason,
+		DenialReason: DenialApprovalCanceled,
 		Meta: map[string]string{
 			"permission_action": string(event.Action),
 		},
@@ -1203,12 +1253,28 @@ func availablePermissionDecisions(event PermissionEvent, options Options) []Perm
 	decisions := []PermissionDecisionAction{PermissionDecisionAllow}
 	if options.Sandbox != nil {
 		decisions = append(decisions, PermissionDecisionAllowForSession)
-		if options.Sandbox.CanPersistGrants() {
+		if options.Sandbox.CanPersistGrants() && permissionSupportsPersistentDecision(event.ToolName) {
 			decisions = append(decisions, PermissionDecisionAlwaysAllow)
 		}
 	}
-	decisions = append(decisions, PermissionDecisionDeny)
+	switch event.ToolName {
+	case "bash":
+		decisions = append(decisions, PermissionDecisionDeny, PermissionDecisionCancel)
+	case "apply_patch":
+		decisions = append(decisions, PermissionDecisionCancel)
+	default:
+		decisions = append(decisions, PermissionDecisionDeny)
+	}
 	return decisions
+}
+
+func permissionSupportsPersistentDecision(toolName string) bool {
+	switch toolName {
+	case "bash", "apply_patch":
+		return false
+	default:
+		return true
+	}
 }
 
 func cloneArgs(args map[string]any) map[string]any {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -580,6 +580,8 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 			permissionGranted = true
 			requestEvent.DecisionAction = decision.Action
 			if options.Sandbox != nil {
+				// The current call stays allowed if recording the session grant
+				// fails; the user is simply prompted again for a later match.
 				if grant, err := persistSessionPermissionGrant(call.Name, args, decisionReason, options); err == nil {
 					requestEvent.GrantMatched = true
 					requestEvent.Grant = &grant

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -54,6 +54,7 @@ func TestIsRetriableToolError(t *testing.T) {
 		// Structured denial categories are authoritative regardless of message text.
 		{"denial: filtered", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialFiltered}, false},
 		{"denial: permission", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialPermissionDenied}, false},
+		{"denial: approval canceled", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialApprovalCanceled}, false},
 		{"denial: sandbox", ToolResult{Status: tools.StatusError, Output: "anything", DenialReason: DenialSandboxViolation}, false},
 	}
 	for _, c := range cases {
@@ -889,6 +890,98 @@ func TestRunDeniesPromptToolWhenPermissionRequestDenied(t *testing.T) {
 	}
 }
 
+func TestRunAbortsWhenPermissionRequestCanceled(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewWriteFileTool(root))
+	provider := providerCallingWriteFileThenAnswer("write should not continue")
+	var permissionEvents []PermissionEvent
+
+	result, err := Run(context.Background(), "write notes", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		OnPermissionRequest: func(context.Context, PermissionRequest) (PermissionDecision, error) {
+			return PermissionDecision{Action: PermissionDecisionCancel, Reason: "redirect needed"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if !errors.Is(err, errPermissionApprovalCanceled) {
+		t.Fatalf("expected permission approval cancel error, got %v", err)
+	}
+	if result.FinalAnswer != "" {
+		t.Fatalf("canceled run must not continue to final answer, got %q", result.FinalAnswer)
+	}
+	if len(provider.requests) != 1 {
+		t.Fatalf("canceled permission prompt should stop after first turn, got %d provider requests", len(provider.requests))
+	}
+	if _, err := os.Stat(filepath.Join(root, "notes.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected canceled write to leave file missing, stat error: %v", err)
+	}
+	if len(permissionEvents) != 1 {
+		t.Fatalf("expected one cancel permission event, got %#v", permissionEvents)
+	}
+	event := permissionEvents[0]
+	if event.Action != PermissionActionCancel || event.DecisionAction != PermissionDecisionCancel || event.PermissionGranted {
+		t.Fatalf("expected final cancel event, got %#v", event)
+	}
+	if event.DecisionReason != "redirect needed" {
+		t.Fatalf("expected cancel reason in final event, got %#v", event)
+	}
+}
+
+func TestAvailablePermissionDecisionsSplitDenyAndCancel(t *testing.T) {
+	options := Options{Sandbox: sandbox.NewEngine(sandbox.EngineOptions{WorkspaceRoot: t.TempDir(), Policy: sandbox.DefaultPolicy()})}
+	cases := []struct {
+		name string
+		tool string
+		want []PermissionDecisionAction
+	}{
+		{
+			name: "bash keeps recoverable deny and explicit cancel",
+			tool: "bash",
+			want: []PermissionDecisionAction{
+				PermissionDecisionAllow,
+				PermissionDecisionAllowForSession,
+				PermissionDecisionDeny,
+				PermissionDecisionCancel,
+			},
+		},
+		{
+			name: "apply patch uses cancel without recoverable deny",
+			tool: "apply_patch",
+			want: []PermissionDecisionAction{
+				PermissionDecisionAllow,
+				PermissionDecisionAllowForSession,
+				PermissionDecisionCancel,
+			},
+		},
+		{
+			name: "file write keeps recoverable deny",
+			tool: "write_file",
+			want: []PermissionDecisionAction{
+				PermissionDecisionAllow,
+				PermissionDecisionAllowForSession,
+				PermissionDecisionDeny,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := availablePermissionDecisions(PermissionEvent{
+				ToolName: tc.tool,
+				Action:   PermissionActionPrompt,
+			}, options)
+			if !equalPermissionDecisions(got, tc.want) {
+				t.Fatalf("decisions = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunPersistsAlwaysAllowPermissionDecision(t *testing.T) {
 	root := t.TempDir()
 	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
@@ -1353,6 +1446,18 @@ func providerCallingWritePathThenAnswer(path string, answer string) *mockProvide
 func quoteJSONString(value string) string {
 	encoded, _ := json.Marshal(value)
 	return string(encoded)
+}
+
+func equalPermissionDecisions(a, b []PermissionDecisionAction) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestRunAppendsConfirmationPolicyToSystemPrompt(t *testing.T) {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -35,6 +35,7 @@ const (
 	PermissionActionAllow  PermissionAction = "allow"
 	PermissionActionPrompt PermissionAction = "prompt"
 	PermissionActionDeny   PermissionAction = "deny"
+	PermissionActionCancel PermissionAction = "cancel"
 )
 
 const (
@@ -42,6 +43,7 @@ const (
 	PermissionDecisionAllowForSession PermissionDecisionAction = "allow_for_session"
 	PermissionDecisionDeny            PermissionDecisionAction = "deny"
 	PermissionDecisionAlwaysAllow     PermissionDecisionAction = "always_allow"
+	PermissionDecisionCancel          PermissionDecisionAction = "cancel"
 )
 
 type ToolResult struct {
@@ -74,6 +76,7 @@ const (
 	DenialNone             DenialCategory = ""
 	DenialFiltered         DenialCategory = "filtered"          // tool not enabled for this run
 	DenialPermissionDenied DenialCategory = "permission_denied" // approval declined
+	DenialApprovalCanceled DenialCategory = "approval_canceled" // approval canceled and run aborted
 	DenialSandboxViolation DenialCategory = "sandbox_violation" // blocked by the sandbox
 	DenialHookBlocked      DenialCategory = "hook_blocked"      // vetoed by a beforeTool hook
 )

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1073,7 +1073,7 @@ func sessionPermissionEventType(event agent.PermissionEvent) sessions.EventType 
 	if event.Action == agent.PermissionActionPrompt {
 		return sessions.EventPermissionRequest
 	}
-	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny {
+	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny || event.Action == agent.PermissionActionCancel {
 		return sessions.EventPermissionDecision
 	}
 	return sessions.EventPermission

--- a/internal/cli/exec_writer.go
+++ b/internal/cli/exec_writer.go
@@ -242,7 +242,7 @@ func streamJSONPermissionEventType(event agent.PermissionEvent) streamjson.Event
 	if event.Action == agent.PermissionActionPrompt {
 		return streamjson.EventPermissionRequest
 	}
-	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny {
+	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny || event.Action == agent.PermissionActionCancel {
 		return streamjson.EventPermissionDecision
 	}
 	return streamjson.EventPermission

--- a/internal/oauth/encrypt.go
+++ b/internal/oauth/encrypt.go
@@ -78,7 +78,7 @@ func (c *aesGCMCrypter) open(blob []byte) ([]byte, error) {
 
 // loadOrCreateSecret reads the 32-byte secret at path. When create is set and
 // the file is absent, it generates a random secret and creates the file
-// exclusively (0600). A wrong-sized existing secret fails closed (corruption).
+// atomically (0600). A wrong-sized existing secret fails closed (corruption).
 func loadOrCreateSecret(path string, create bool) ([]byte, error) {
 	if data, err := readSecretFile(path); err == nil {
 		return data, nil
@@ -88,44 +88,68 @@ func loadOrCreateSecret(path string, create bool) ([]byte, error) {
 	if !create {
 		return nil, fmt.Errorf("oauth: token secret %s is missing; cannot decrypt the token file", path)
 	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+	return createSecretFile(path)
+}
+
+func createSecretFile(path string) ([]byte, error) {
+	lockPath := path + ".lock"
+	var lastErr error
+	for attempt := 0; attempt < 500; attempt++ {
+		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = lock.Close()
+			defer os.Remove(lockPath)
+			if data, rerr := readSecretFile(path); rerr == nil {
+				return data, nil
+			} else if !errors.Is(rerr, os.ErrNotExist) {
+				return nil, rerr
+			}
+			return writeNewSecretFile(path)
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("oauth: create token secret lock: %w", err)
+		}
+		if data, rerr := readSecretFile(path); rerr == nil {
+			return data, nil
+		} else {
+			lastErr = rerr
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("oauth: timed out waiting for token secret %s: %w", path, lastErr)
+	}
+	return nil, fmt.Errorf("oauth: timed out waiting for token secret lock %s", lockPath)
+}
+
+func writeNewSecretFile(path string) ([]byte, error) {
 	secret := make([]byte, secretBytes)
 	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
 		return nil, fmt.Errorf("oauth: generate token secret: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return nil, err
-	}
-	// Create exclusively: an os.Rename publish would clobber on POSIX, so two
-	// concurrent first-run processes could each generate a secret and the loser
-	// would silently orphan the tokens it encrypts. O_EXCL lets exactly one
-	// process win; everyone else adopts the winner's on-disk secret.
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
 	if err != nil {
-		if errors.Is(err, os.ErrExist) {
-			// The winner may not have finished writing yet, so a read here can see a
-			// short/absent file. Retry briefly so concurrent first-run invocations
-			// converge on the winner's secret instead of failing transiently.
-			var lastErr error
-			for attempt := 0; attempt < 50; attempt++ {
-				secret, rerr := readSecretFile(path)
-				if rerr == nil {
-					return secret, nil
-				}
-				lastErr = rerr
-				time.Sleep(2 * time.Millisecond)
-			}
-			return nil, lastErr
-		}
-		return nil, fmt.Errorf("oauth: create token secret: %w", err)
+		return nil, fmt.Errorf("oauth: create token secret temp file: %w", err)
 	}
-	if _, werr := f.Write(secret); werr != nil {
-		_ = f.Close()
-		_ = os.Remove(path)
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return nil, fmt.Errorf("oauth: chmod token secret temp file: %w", err)
+	}
+	if _, werr := tmp.Write(secret); werr != nil {
+		_ = tmp.Close()
 		return nil, fmt.Errorf("oauth: write token secret: %w", werr)
 	}
-	if cerr := f.Close(); cerr != nil {
-		_ = os.Remove(path)
+	if cerr := tmp.Close(); cerr != nil {
 		return nil, fmt.Errorf("oauth: write token secret: %w", cerr)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return nil, fmt.Errorf("oauth: publish token secret: %w", err)
 	}
 	return secret, nil
 }

--- a/internal/oauth/encrypt_test.go
+++ b/internal/oauth/encrypt_test.go
@@ -25,7 +25,7 @@ func TestLoadOrCreateSecretConcurrentConverges(t *testing.T) {
 	}
 	wg.Wait()
 	// Exactly one creator wins; every racer must converge on the same on-disk
-	// secret rather than orphaning its own (the O_EXCL + bounded-retry path).
+	// secret rather than reading a half-published file or orphaning its own.
 	for i := 0; i < n; i++ {
 		if errs[i] != nil {
 			t.Fatalf("goroutine %d: %v", i, errs[i])

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -318,6 +318,7 @@ const (
 	permissionDecisionAllowForSession permissionDecision = agent.PermissionDecisionAllowForSession
 	permissionDecisionDeny            permissionDecision = agent.PermissionDecisionDeny
 	permissionDecisionAlwaysAllow     permissionDecision = agent.PermissionDecisionAlwaysAllow
+	permissionDecisionCancel          permissionDecision = agent.PermissionDecisionCancel
 )
 
 type permissionRequestMsg struct {
@@ -2214,6 +2215,8 @@ func permissionDecisionReason(decision permissionDecision) string {
 		return "approved for this session in TUI"
 	case permissionDecisionAlwaysAllow:
 		return "persistently approved in TUI"
+	case permissionDecisionCancel:
+		return "cancelled in TUI"
 	case permissionDecisionDeny:
 		return "denied in TUI"
 	default:
@@ -3123,7 +3126,7 @@ func tuiPermissionEventType(event agent.PermissionEvent) sessions.EventType {
 	if event.Action == agent.PermissionActionPrompt {
 		return sessions.EventPermissionRequest
 	}
-	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny {
+	if event.Action == agent.PermissionActionAllow || event.Action == agent.PermissionActionDeny || event.Action == agent.PermissionActionCancel {
 		return sessions.EventPermissionDecision
 	}
 	return sessions.EventPermission

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1682,15 +1682,25 @@ func testPromptPermissionEvent() agent.PermissionEvent {
 func testPromptPermissionRequest() agent.PermissionRequest {
 	event := testPromptPermissionEvent()
 	return agent.PermissionRequest{
-		ToolCallID:     event.ToolCallID,
-		ToolName:       event.ToolName,
-		Action:         event.Action,
-		Permission:     event.Permission,
-		PermissionMode: event.PermissionMode,
-		Autonomy:       event.Autonomy,
-		SideEffect:     event.SideEffect,
-		Reason:         event.Reason,
-		Risk:           event.Risk,
+		ToolCallID:         event.ToolCallID,
+		ToolName:           event.ToolName,
+		Action:             event.Action,
+		Permission:         event.Permission,
+		PermissionMode:     event.PermissionMode,
+		Autonomy:           event.Autonomy,
+		SideEffect:         event.SideEffect,
+		Reason:             event.Reason,
+		Risk:               event.Risk,
+		AvailableDecisions: testAllPermissionDecisions(),
+	}
+}
+
+func testAllPermissionDecisions() []agent.PermissionDecisionAction {
+	return []agent.PermissionDecisionAction{
+		agent.PermissionDecisionAllow,
+		agent.PermissionDecisionAllowForSession,
+		agent.PermissionDecisionAlwaysAllow,
+		agent.PermissionDecisionDeny,
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1208,8 +1208,11 @@ func TestAgentResponsePreservesPermissionMetadata(t *testing.T) {
 		t.Fatalf("permission metadata was not preserved: %#v", row)
 	}
 	rendered := next.renderRow(row, 96, buildRowContext(next.transcript))
-	for _, want := range []string{"permission", "write_file", "prompt", "risk:high", "mode=ask", "Creates or overwrites"} {
+	for _, want := range []string{"permission", "write_file", "prompt", "mode=ask", "Creates or overwrites"} {
 		assertContains(t, rendered, want)
+	}
+	if strings.Contains(rendered, "risk:") || strings.Contains(rendered, "risk=") {
+		t.Fatalf("normal permission row must not render risk labels, got %q", rendered)
 	}
 }
 
@@ -1240,9 +1243,12 @@ func TestPermissionRequestShowsFocusedPrompt(t *testing.T) {
 	if !ok || row.permission == nil || row.permission.Scope != request.Scope {
 		t.Fatalf("expected permission row to preserve scope %q, got %#v", request.Scope, row)
 	}
-	view := next.View()
-	for _, want := range []string{"write_file", "Yes, proceed", "[a]", "these files in this session", "[s]", "don't ask again for this scope", "[y]", "tell Zero", "[d]", "scope: src/main.go", "risk:high", "Creates or overwrites files."} {
+	view := plainRender(t, next.View())
+	for _, want := range []string{"write_file", "Yes, proceed", "[a]", "these files in this session", "[s]", "don't ask again for this scope", "[y]", "continue without running it", "[d]", "scope: src/main.go", "Creates or overwrites files."} {
 		assertContains(t, view, want)
+	}
+	if strings.Contains(view, "risk:") || strings.Contains(view, "risk=") {
+		t.Fatalf("focused permission prompt must not render risk labels, got %q", view)
 	}
 }
 
@@ -1348,8 +1354,11 @@ func TestPermissionRowRendersSandboxViolations(t *testing.T) {
 
 	rendered := newModel(context.Background(), Options{}).renderRow(permissionTranscriptRow(event), 96, buildRowContext(nil))
 
-	for _, want := range []string{"write_file", "denied", "risk:high", "violation=outside_workspace risk=critical", "../secret.txt"} {
+	for _, want := range []string{"write_file", "denied", "violation=outside_workspace", "../secret.txt"} {
 		assertContains(t, rendered, want)
+	}
+	if strings.Contains(rendered, "risk:") || strings.Contains(rendered, "risk=") {
+		t.Fatalf("denied permission row must not render risk labels, got %q", rendered)
 	}
 }
 

--- a/internal/tui/permission_prompt.go
+++ b/internal/tui/permission_prompt.go
@@ -42,6 +42,8 @@ func permissionOptions(request agent.PermissionRequest) []permissionOption {
 			options = append(options, permissionOption{label: "always", hotkey: "y", choice: permissionDecisionAlwaysAllow})
 		case agent.PermissionDecisionDeny:
 			options = append(options, permissionOption{label: "deny", hotkey: "d", choice: permissionDecisionDeny})
+		case agent.PermissionDecisionCancel:
+			options = append(options, permissionOption{label: "cancel", hotkey: "n", choice: permissionDecisionCancel})
 		}
 	}
 	if len(options) == 0 {

--- a/internal/tui/permission_prompt.go
+++ b/internal/tui/permission_prompt.go
@@ -23,8 +23,6 @@ func permissionOptions(request agent.PermissionRequest) []permissionOption {
 	if len(decisions) == 0 {
 		decisions = []agent.PermissionDecisionAction{
 			agent.PermissionDecisionAllow,
-			agent.PermissionDecisionAllowForSession,
-			agent.PermissionDecisionAlwaysAllow,
 			agent.PermissionDecisionDeny,
 		}
 	}

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -34,6 +34,16 @@ func TestPermissionCursorDefaultsToAllowOnce(t *testing.T) {
 	}
 }
 
+func TestPermissionOptionsEmptyDecisionsUseRecoverableFallback(t *testing.T) {
+	options := permissionOptions(agent.PermissionRequest{})
+	if len(options) != 2 {
+		t.Fatalf("fallback options = %#v, want allow and deny only", options)
+	}
+	if options[0].choice != permissionDecisionAllow || options[1].choice != permissionDecisionDeny {
+		t.Fatalf("fallback options = %#v, want allow then deny", options)
+	}
+}
+
 func TestPermissionCursorMovesAndEnterConfirms(t *testing.T) {
 	decisions := []permissionDecision{}
 	m := pendingPermissionModel(t, func(d agent.PermissionDecision) {
@@ -80,7 +90,7 @@ func TestPermissionHotkeysStillResolveDirectly(t *testing.T) {
 }
 
 func TestPermissionRenderEmitsHighlightedClickableOffsets(t *testing.T) {
-	request := agent.PermissionRequest{ToolName: "bash"}
+	request := agent.PermissionRequest{ToolName: "bash", AvailableDecisions: testAllPermissionDecisions()}
 	card, offsets := renderFocusedPermissionPrompt(request, 2, 60) // cursor on future approval
 	if len(offsets) != len(permissionOptions(request)) {
 		t.Fatalf("offsets = %d, want %d", len(offsets), len(permissionOptions(request)))
@@ -97,9 +107,10 @@ func TestPermissionRenderEmitsHighlightedClickableOffsets(t *testing.T) {
 
 func TestPermissionRenderShowsNetworkTargetAndHostScopedAlways(t *testing.T) {
 	request := agent.PermissionRequest{
-		ToolName:   "web_fetch",
-		SideEffect: "network",
-		Scope:      "example.com",
+		ToolName:           "web_fetch",
+		SideEffect:         "network",
+		Scope:              "example.com",
+		AvailableDecisions: testAllPermissionDecisions(),
 	}
 	card, _ := renderFocusedPermissionPrompt(request, 1, 72)
 	got := plainRender(t, card)

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -12,12 +12,17 @@ import (
 
 func pendingPermissionModel(t *testing.T, decide func(agent.PermissionDecision)) model {
 	t.Helper()
+	return pendingPermissionModelWithRequest(t, testPromptPermissionRequest(), decide)
+}
+
+func pendingPermissionModelWithRequest(t *testing.T, request agent.PermissionRequest, decide func(agent.PermissionDecision)) model {
+	t.Helper()
 	m := newModel(context.Background(), Options{})
 	m.pending = true
 	m.activeRunID = 7
 	updated, _ := m.Update(permissionRequestMsg{
 		runID:   7,
-		request: testPromptPermissionRequest(),
+		request: request,
 		decide:  decide,
 	})
 	next := updated.(model)
@@ -41,6 +46,55 @@ func TestPermissionOptionsEmptyDecisionsUseRecoverableFallback(t *testing.T) {
 	}
 	if options[0].choice != permissionDecisionAllow || options[1].choice != permissionDecisionDeny {
 		t.Fatalf("fallback options = %#v, want allow then deny", options)
+	}
+}
+
+func TestPermissionOptionsExposeApprovalCancelWhenSupplied(t *testing.T) {
+	request := agent.PermissionRequest{
+		ToolName: "bash",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionDeny,
+			agent.PermissionDecisionCancel,
+		},
+	}
+	options := permissionOptions(request)
+	if len(options) != 4 {
+		t.Fatalf("options = %#v, want four supplied choices", options)
+	}
+	if options[2].choice != permissionDecisionDeny || options[2].hotkey != "d" {
+		t.Fatalf("recoverable deny option = %#v, want deny on d", options[2])
+	}
+	if options[3].choice != permissionDecisionCancel || options[3].hotkey != "n" {
+		t.Fatalf("cancel option = %#v, want cancel on n", options[3])
+	}
+
+	card, _ := renderFocusedPermissionPrompt(request, 3, 80)
+	got := plainRender(t, card)
+	for _, want := range []string{"continue without running it", "[d]", "tell Zero what to do differently", "[n]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("permission card = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestPermissionOptionsCanExposePatchCancelWithoutRecoverableDeny(t *testing.T) {
+	request := agent.PermissionRequest{
+		ToolName: "apply_patch",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionCancel,
+		},
+	}
+	card, _ := renderFocusedPermissionPrompt(request, 2, 80)
+	got := plainRender(t, card)
+	if !strings.Contains(got, "tell Zero what to do differently") || !strings.Contains(got, "[n]") {
+		t.Fatalf("permission card = %q, missing cancel option", got)
+	}
+	if strings.Contains(got, "continue without running it") || strings.Contains(got, "[d]") {
+		t.Fatalf("apply_patch approval must not show recoverable deny, got %q", got)
 	}
 }
 
@@ -89,8 +143,28 @@ func TestPermissionHotkeysStillResolveDirectly(t *testing.T) {
 	}
 }
 
+func TestPermissionCancelHotkeyResolvesDirectly(t *testing.T) {
+	request := testPromptPermissionRequest()
+	request.ToolName = "bash"
+	request.AvailableDecisions = []agent.PermissionDecisionAction{
+		agent.PermissionDecisionAllow,
+		agent.PermissionDecisionDeny,
+		agent.PermissionDecisionCancel,
+	}
+	got := []permissionDecision{}
+	m := pendingPermissionModelWithRequest(t, request, func(d agent.PermissionDecision) {
+		got = append(got, permissionDecision(d.Action))
+	})
+	if _, cmd := m.Update(testKeyText("n")); cmd != nil {
+		t.Fatal("'n' should resolve synchronously")
+	}
+	if len(got) != 1 || got[0] != permissionDecisionCancel {
+		t.Fatalf("'n' should resolve cancel directly, got %#v", got)
+	}
+}
+
 func TestPermissionRenderEmitsHighlightedClickableOffsets(t *testing.T) {
-	request := agent.PermissionRequest{ToolName: "bash", AvailableDecisions: testAllPermissionDecisions()}
+	request := agent.PermissionRequest{ToolName: "write_file", AvailableDecisions: testAllPermissionDecisions()}
 	card, offsets := renderFocusedPermissionPrompt(request, 2, 60) // cursor on future approval
 	if len(offsets) != len(permissionOptions(request)) {
 		t.Fatalf("offsets = %d, want %d", len(offsets), len(permissionOptions(request)))

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -780,9 +780,6 @@ func renderPermissionRow(row transcriptRow, width int) string {
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
 			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
 		}
-		if event.Risk.Level != "" {
-			line += dot + zeroTheme.muted.Render("risk:"+string(event.Risk.Level))
-		}
 		if reason := strings.TrimSpace(event.Reason); reason != "" {
 			line += zeroTheme.faint.Render(" — " + truncateRunes(reason, maxInt(16, width-lipgloss.Width(name)-16)))
 		}
@@ -795,9 +792,6 @@ func renderPermissionRow(row transcriptRow, width int) string {
 		line := zeroTheme.amber.Render("permission") + "  " + zeroTheme.ink.Render(name) + "  " + zeroTheme.amber.Render("prompt")
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
 			line += "  " + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
-		}
-		if event.Risk.Level != "" {
-			line += "  " + zeroTheme.muted.Render("risk:"+string(event.Risk.Level))
 		}
 		out := fitStyledLine(line, width)
 		if detail := strings.TrimSpace(row.detail); detail != "" {
@@ -828,9 +822,6 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	fill := zeroTheme.onPerm
 
 	top := zeroTheme.permBadge.Render(" PERMISSION ")
-	if request.Risk.Level != "" {
-		top += fill(zeroTheme.permRisk).Render("  risk: " + string(request.Risk.Level))
-	}
 
 	body := fill(zeroTheme.amber).Bold(true).Render(name)
 	if request.SideEffect != "" {
@@ -907,7 +898,7 @@ func permissionOptionLabel(option permissionOption, request agent.PermissionRequ
 		}
 		return option.label
 	case permissionDecisionDeny:
-		return "No, and tell Zero what to do differently"
+		return "No, continue without running it"
 	default:
 		return option.label
 	}

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -114,6 +114,8 @@ func buildRowContext(rows []transcriptRow) rowContext {
 				}
 			case agent.PermissionActionDeny:
 				rc.decided[key] = true
+			case agent.PermissionActionCancel:
+				rc.decided[key] = true
 			}
 		}
 	}
@@ -788,6 +790,19 @@ func renderPermissionRow(row transcriptRow, width int) string {
 			out += "\n" + wrapDetailBlock(detail, width)
 		}
 		return out
+	case agent.PermissionActionCancel:
+		line := zeroTheme.red.Render("cancelled") + dot + zeroTheme.red.Render(name)
+		if scope := strings.TrimSpace(event.Scope); scope != "" {
+			line += dot + zeroTheme.muted.Render(permissionEventScopeLabel(event)+":"+scope)
+		}
+		if reason := strings.TrimSpace(event.Reason); reason != "" {
+			line += zeroTheme.faint.Render(" — " + truncateRunes(reason, maxInt(16, width-lipgloss.Width(name)-16)))
+		}
+		out := fitStyledLine(line, width)
+		if detail := strings.TrimSpace(row.detail); detail != "" {
+			out += "\n" + wrapDetailBlock(detail, width)
+		}
+		return out
 	default:
 		line := zeroTheme.amber.Render("permission") + "  " + zeroTheme.ink.Render(name) + "  " + zeroTheme.amber.Render("prompt")
 		if scope := strings.TrimSpace(event.Scope); scope != "" {
@@ -899,6 +914,8 @@ func permissionOptionLabel(option permissionOption, request agent.PermissionRequ
 		return option.label
 	case permissionDecisionDeny:
 		return "No, continue without running it"
+	case permissionDecisionCancel:
+		return "No, and tell Zero what to do differently"
 	default:
 		return option.label
 	}

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -1240,7 +1240,7 @@ func TestGrepCardHeadShowsTargetAndPatternColumns(t *testing.T) {
 
 // --- Stage 3: interactive surfaces ------------------------------------------
 
-func TestFocusedPermissionCardShowsBadgeRiskAndKeys(t *testing.T) {
+func TestFocusedPermissionCardShowsBadgeAndKeys(t *testing.T) {
 	request := agent.PermissionRequest{
 		ToolName:   "edit_file",
 		Reason:     "writes internal/agent/exec.go",
@@ -1249,10 +1249,13 @@ func TestFocusedPermissionCardShowsBadgeRiskAndKeys(t *testing.T) {
 	}
 	card, offsets := renderFocusedPermissionPrompt(request, 0, 80)
 	got := plainRender(t, card)
-	for _, want := range []string{"PERMISSION", "risk: medium", "edit_file", "writes internal/agent/exec.go", "Yes, proceed", "[a]", "this session", "[s]", "don't ask again", "[y]", "tell Zero", "[d]", "[esc]"} {
+	for _, want := range []string{"PERMISSION", "edit_file", "writes internal/agent/exec.go", "Yes, proceed", "[a]", "this session", "[s]", "don't ask again", "[y]", "continue without running it", "[d]", "[esc]"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("permission card = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "risk:") {
+		t.Fatalf("normal permission prompt must not render risk labels, got %q", got)
 	}
 	if len(offsets) != len(permissionOptions(request)) {
 		t.Fatalf("offsets = %d, want one per option (%d)", len(offsets), len(permissionOptions(request)))

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -1242,10 +1242,11 @@ func TestGrepCardHeadShowsTargetAndPatternColumns(t *testing.T) {
 
 func TestFocusedPermissionCardShowsBadgeAndKeys(t *testing.T) {
 	request := agent.PermissionRequest{
-		ToolName:   "edit_file",
-		Reason:     "writes internal/agent/exec.go",
-		SideEffect: "write",
-		Risk:       sandbox.Risk{Level: sandbox.RiskMedium},
+		ToolName:           "edit_file",
+		Reason:             "writes internal/agent/exec.go",
+		SideEffect:         "write",
+		Risk:               sandbox.Risk{Level: sandbox.RiskMedium},
+		AvailableDecisions: testAllPermissionDecisions(),
 	}
 	card, offsets := renderFocusedPermissionPrompt(request, 0, 80)
 	got := plainRender(t, card)

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -61,7 +61,6 @@ type tuiTheme struct {
 
 	// Permission surfaces.
 	permBadge  lipgloss.Style // PERMISSION chip: onAccent on amber, bold
-	permRisk   lipgloss.Style // risk: <level> readout, amber
 	permBg     lipgloss.Style // permission card body tint
 	permBorder lipgloss.Style // permission card border (amber-mixed line)
 
@@ -152,7 +151,6 @@ var zeroTheme = tuiTheme{
 	delText:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorDelInk)),
 
 	permBadge:  lipgloss.NewStyle().Background(lipgloss.Color(colorAmber)).Foreground(lipgloss.Color(colorOnAccent)).Bold(true),
-	permRisk:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
 	permBg:     lipgloss.NewStyle().Background(lipgloss.Color(colorPermBg)),
 	permBorder: lipgloss.NewStyle().Foreground(lipgloss.Color(colorCardPerm)),
 

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -272,9 +272,6 @@ func permissionRowText(event agent.PermissionEvent) string {
 	if event.Action != "" {
 		parts = append(parts, string(event.Action))
 	}
-	if event.Risk.Level != "" {
-		parts = append(parts, "risk:"+string(event.Risk.Level))
-	}
 	if event.Violation != nil && event.Violation.Code != "" {
 		parts = append(parts, "violation:"+string(event.Violation.Code))
 	}
@@ -298,9 +295,6 @@ func permissionDetailText(event agent.PermissionEvent) string {
 	if event.SideEffect != "" {
 		parts = append(parts, "side_effect="+event.SideEffect)
 	}
-	if event.Risk.Level != "" {
-		parts = append(parts, "risk="+string(event.Risk.Level))
-	}
 	if event.GrantMatched {
 		parts = append(parts, "grant=matched")
 	}
@@ -309,9 +303,6 @@ func permissionDetailText(event agent.PermissionEvent) string {
 	}
 	if event.Violation != nil {
 		violation := "violation=" + string(event.Violation.Code)
-		if event.Violation.Risk.Level != "" {
-			violation += " risk=" + string(event.Violation.Risk.Level)
-		}
 		if event.Violation.Path != "" {
 			violation += " path=" + event.Violation.Path
 		}


### PR DESCRIPTION
## Summary
- remove normal permission prompt risk labels from focused TUI cards, transcript rows, and permission detail text
- change the recoverable deny option to say it continues without running the tool instead of implying a run-cancel redirect
- use conservative allow/deny fallback choices when a permission request lacks backend-supplied decisions, avoiding session or persistent choices the prompt cannot honor
- document that a failed session-grant recording attempt only means a later matching call prompts again, not that the current user-approved call is denied
- add an explicit cancel decision that aborts the active run while keeping deny as a recoverable tool refusal
- expose cancel choices for command and apply-patch approval prompts, with apply-patch using cancel instead of recoverable deny and command/apply-patch avoiding persistent always approvals until scoped prefix approval exists
- classify cancel outcomes as permission-decision events for TUI session logs and exec JSON output
- publish encrypted OAuth token secrets atomically under a creation lock so concurrent first-run callers cannot read a half-written secret

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui ./internal/agent
- GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/tui ./internal/cli
- go test ./internal/oauth -run TestLoadOrCreateSecretConcurrentConverges -count=100
- go test ./internal/oauth
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Cancel** permission option, including a direct cancel hotkey, with updated “cancelled” handling in the UI.
  * Permission choices are now tailored to context (sandbox persistence and tool-specific cancel/deny capabilities).
* **Bug Fixes**
  * Removed risk-level badges/labels from terminal permission views (rows, focused prompts, and transcript).
  * Updated denial-style wording to **“No, continue without running it.”**
* **Tests**
  * Expanded coverage for cancel behavior, decision fallback ordering when no options are provided, and correct option visibility across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
