### PR TITLE
tui: image-input UX — drag-drop attach, inline numbered chips, vision fallback, cursor + copy fixes

### DIFF
--- a/internal/modelregistry/vision.go
+++ b/internal/modelregistry/vision.go
@@ -51,15 +51,31 @@ func visionCapableByName(modelID string) bool {
 		strings.HasPrefix(id, "o3-") || strings.HasPrefix(id, "o4-"):
 		return true // OpenAI o-series accept images
 	case strings.Contains(id, "grok-4"),
-		strings.Contains(id, "grok") && strings.Contains(id, "vision"):
+		strings.Contains(id, "grok") && mentionsVision(id):
 		return true // Grok 4 (and grok vision variants) are multimodal
 	case strings.Contains(id, "llava"), strings.Contains(id, "pixtral"),
 		strings.Contains(id, "internvl"), strings.Contains(id, "minicpm-v"),
 		strings.Contains(id, "moondream"), strings.Contains(id, "bakllava"),
 		strings.Contains(id, "-vl"), strings.Contains(id, "vl-"),
-		strings.Contains(id, "vision"):
+		mentionsVision(id):
 		return true // common open multimodal families + *-vl / *-vision
 	default:
 		return false
 	}
+}
+
+// mentionsVision reports whether id advertises vision via the word "vision",
+// excluding negated forms (vision-less / no-vision): a model named for LACKING
+// vision must not be treated as multimodal.
+func mentionsVision(id string) bool {
+	if !strings.Contains(id, "vision") {
+		return false
+	}
+	switch {
+	case strings.Contains(id, "vision-less"), strings.Contains(id, "visionless"),
+		strings.Contains(id, "no-vision"), strings.Contains(id, "non-vision"),
+		strings.Contains(id, "novision"), strings.Contains(id, "nonvision"):
+		return false
+	}
+	return true
 }

--- a/internal/modelregistry/vision.go
+++ b/internal/modelregistry/vision.go
@@ -1,15 +1,65 @@
 package modelregistry
 
-// SupportsVision reports whether the model identified by modelID is known to the
-// registry and advertises the vision capability. It returns false when the model
-// cannot be resolved (e.g. a custom or openai-compatible id absent from the
-// catalog): an unknown model is treated as "cannot confirm", so callers drop
-// images rather than send them to a model that may reject them.
+import "strings"
+
+// SupportsVision reports whether the model identified by modelID accepts image
+// input. A model in the curated catalog is authoritative (its declared
+// capability wins). For a model the catalog does NOT know — a custom /
+// openai-compatible / ollama id that will never be in the catalog — it falls
+// back to recognizing well-known multimodal families by name, so a real vision
+// model still accepts images. A name outside those families stays refused (the
+// previous "cannot confirm → drop" behavior), so text-only models are unaffected.
 //
 // modelID is resolved through the registry's normal alias/pattern matching, so
 // any spelling that Get accepts works here too. This helper is the single
 // capability check shared by the headless (exec) and interactive (TUI) input
 // surfaces; the warn-and-drop behavior lives at those call sites.
 func SupportsVision(registry Registry, modelID string) bool {
-	return registry.SupportsCapability(modelID, ModelCapabilityVision)
+	if registry.SupportsCapability(modelID, ModelCapabilityVision) {
+		return true
+	}
+	// The catalog knows this model and it lacks vision: trust that — never let the
+	// name heuristic override an authoritative "no".
+	if _, known := registry.Get(modelID); known {
+		return false
+	}
+	return visionCapableByName(modelID)
+}
+
+// visionCapableByName reports whether modelID names a known multimodal family.
+// It is conservative: it matches the established vision families and leaves
+// everything else (including text-only models like gpt-oss, kimi, and coder
+// models) refused, so a false "supported" is unlikely. Used only as a fallback
+// for models absent from the curated catalog.
+func visionCapableByName(modelID string) bool {
+	id := strings.ToLower(strings.TrimSpace(modelID))
+	if slash := strings.LastIndexByte(id, '/'); slash >= 0 {
+		id = id[slash+1:] // drop a "provider/" prefix
+	}
+	switch {
+	case strings.Contains(id, "gemini"):
+		return true // every Gemini model is multimodal
+	case strings.Contains(id, "claude-3"), strings.Contains(id, "claude-4"),
+		strings.Contains(id, "claude-opus"), strings.Contains(id, "claude-sonnet"),
+		strings.Contains(id, "claude-haiku"):
+		return true // Claude 3+ are multimodal
+	case strings.Contains(id, "gpt-4o"), strings.Contains(id, "gpt-4.1"),
+		strings.Contains(id, "gpt-4-turbo"), strings.Contains(id, "gpt-4-vision"),
+		strings.Contains(id, "gpt-5"):
+		return true // GPT-4o / 4.1 / 4-turbo / 5 are multimodal (gpt-oss is NOT matched)
+	case id == "o1" || id == "o3" || strings.HasPrefix(id, "o1-") ||
+		strings.HasPrefix(id, "o3-") || strings.HasPrefix(id, "o4-"):
+		return true // OpenAI o-series accept images
+	case strings.Contains(id, "grok-4"),
+		strings.Contains(id, "grok") && strings.Contains(id, "vision"):
+		return true // Grok 4 (and grok vision variants) are multimodal
+	case strings.Contains(id, "llava"), strings.Contains(id, "pixtral"),
+		strings.Contains(id, "internvl"), strings.Contains(id, "minicpm-v"),
+		strings.Contains(id, "moondream"), strings.Contains(id, "bakllava"),
+		strings.Contains(id, "-vl"), strings.Contains(id, "vl-"),
+		strings.Contains(id, "vision"):
+		return true // common open multimodal families + *-vl / *-vision
+	default:
+		return false
+	}
 }

--- a/internal/modelregistry/vision_name_test.go
+++ b/internal/modelregistry/vision_name_test.go
@@ -1,0 +1,50 @@
+package modelregistry
+
+import "testing"
+
+func TestVisionCapableByName(t *testing.T) {
+	vision := []string{
+		"gemini-3-flash-preview", "gemini-2.5-flash", "ollama-cloud/gemini-3-flash-preview",
+		"grok-4.3", "grok-4-fast", "grok-2-vision",
+		"gpt-4o", "gpt-4.1-mini", "gpt-4-turbo", "gpt-5", "o3-mini", "o1",
+		"claude-sonnet-4.5", "claude-3-haiku",
+		"llava:13b", "qwen2.5-vl-7b", "llama3.2-vision", "pixtral-12b", "moondream",
+	}
+	textOnly := []string{
+		"gpt-oss:120b", "kimi-for-coding", "deepseek-coder", "qwen2.5-coder",
+		"codestral", "llama3.1-8b", "grok-text-only", "mistral-large",
+	}
+	for _, m := range vision {
+		if !visionCapableByName(m) {
+			t.Errorf("expected %q to be recognized as vision-capable", m)
+		}
+	}
+	for _, m := range textOnly {
+		if visionCapableByName(m) {
+			t.Errorf("expected %q to NOT be vision-capable", m)
+		}
+	}
+}
+
+func TestSupportsVisionFallbackForUnknownModels(t *testing.T) {
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Catalog model: authoritative vision flag.
+	if !SupportsVision(reg, "gpt-4o") {
+		t.Error("gpt-4o should be vision (catalog)")
+	}
+	// Unknown-to-catalog but real vision models now pass via the name fallback.
+	for _, m := range []string{"gemini-3-flash-preview", "grok-4.3"} {
+		if !SupportsVision(reg, m) {
+			t.Errorf("%q should be vision via name fallback", m)
+		}
+	}
+	// Unknown text-only models stay refused.
+	for _, m := range []string{"gpt-oss:120b", "kimi-for-coding"} {
+		if SupportsVision(reg, m) {
+			t.Errorf("%q should NOT be vision", m)
+		}
+	}
+}

--- a/internal/modelregistry/vision_name_test.go
+++ b/internal/modelregistry/vision_name_test.go
@@ -13,6 +13,8 @@ func TestVisionCapableByName(t *testing.T) {
 	textOnly := []string{
 		"gpt-oss:120b", "kimi-for-coding", "deepseek-coder", "qwen2.5-coder",
 		"codestral", "llama3.1-8b", "grok-text-only", "mistral-large",
+		// Negated "vision" names must NOT match the bare-"vision" fallback.
+		"my-custom-vision-less-model", "no-vision-model", "grok-vision-less",
 	}
 	for _, m := range vision {
 		if !visionCapableByName(m) {

--- a/internal/tui/attachment_remove_test.go
+++ b/internal/tui/attachment_remove_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestRemoveLastAttachment(t *testing.T) {
+	m := model{
+		pendingImages:      []zeroruntime.ImageBlock{{MediaType: "image/png"}, {MediaType: "image/png"}},
+		pendingImageLabels: []string{"a.png", "b.png"},
+		pendingDocuments:   []pendingDocument{{label: "spec.pdf"}},
+	}
+
+	// Documents render last, so a staged doc is removed first.
+	m, ok := m.removeLastAttachment()
+	if !ok || len(m.pendingDocuments) != 0 {
+		t.Fatalf("doc should be removed first: ok=%v docs=%d", ok, len(m.pendingDocuments))
+	}
+	// Then the last image (images + labels stay in lockstep).
+	m, ok = m.removeLastAttachment()
+	if !ok || len(m.pendingImages) != 1 || len(m.pendingImageLabels) != 1 || m.pendingImageLabels[0] != "a.png" {
+		t.Fatalf("last image should be removed: ok=%v imgs=%d labels=%v", ok, len(m.pendingImages), m.pendingImageLabels)
+	}
+	// Remove the final image.
+	m, ok = m.removeLastAttachment()
+	if !ok || len(m.pendingImages) != 0 || len(m.pendingImageLabels) != 0 {
+		t.Fatalf("all images should be removed: ok=%v imgs=%d", ok, len(m.pendingImages))
+	}
+	// Nothing left.
+	if _, ok := m.removeLastAttachment(); ok {
+		t.Fatal("removeLastAttachment on an empty set must report false")
+	}
+}

--- a/internal/tui/clipboard.go
+++ b/internal/tui/clipboard.go
@@ -48,6 +48,12 @@ func (m model) routePaste(content string) (tea.Model, tea.Cmd) {
 	if m.transcriptDetailed || m.pendingSpecReview != nil || m.pendingPermission != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil {
 		return m, nil
 	}
+	// A drag-dropped image/PDF arrives as a (backslash-escaped) file path. Attach
+	// it as an image instead of inserting the raw path — otherwise a "/Users/…"
+	// path would be submitted as an unknown slash-command.
+	if path, ok := droppedAttachmentPath(content, m.cwd); ok {
+		return m.handleImageCommand(path), nil
+	}
 	state := m.currentComposerState()
 	m = m.applyComposerText(state, content, true)
 	m.recomputeSuggestions()

--- a/internal/tui/dropped_attachment_test.go
+++ b/internal/tui/dropped_attachment_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDroppedAttachmentPath(t *testing.T) {
+	dir := t.TempDir()
+	// A screenshot-style name with spaces.
+	img := filepath.Join(dir, "Screenshot 2026-06-17 at 5.22.03 PM.png")
+	if err := os.WriteFile(img, []byte("\x89PNG\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	txt := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(txt, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Positives — each must resolve to the image path.
+	for name, in := range map[string]string{
+		"backslash-escaped drop": strings.ReplaceAll(img, " ", `\ `),
+		"double-quoted drop":     `"` + img + `"`,
+		"single-quoted drop":     `'` + img + `'`,
+		"plain absolute path":    img,
+	} {
+		got, ok := droppedAttachmentPath(in, dir)
+		if !ok || got != img {
+			t.Fatalf("%s: got %q ok=%v, want %q true", name, got, ok, img)
+		}
+	}
+
+	// Negatives — must NOT be treated as a dropped attachment (so text paste and
+	// real slash-commands are untouched).
+	for name, in := range map[string]string{
+		"real slash command": "/help",
+		"non-existent image": filepath.Join(dir, "nope.png"),
+		"plain text":         "what is this image?",
+		"non-image file":     txt,
+		"multi-line":         strings.ReplaceAll(img, " ", `\ `) + "\nmore text",
+		"empty":              "   ",
+	} {
+		if got, ok := droppedAttachmentPath(in, dir); ok {
+			t.Fatalf("%s: should NOT attach, got %q", name, got)
+		}
+	}
+}

--- a/internal/tui/dropped_attachment_test.go
+++ b/internal/tui/dropped_attachment_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -20,12 +21,17 @@ func TestDroppedAttachmentPath(t *testing.T) {
 	}
 
 	// Positives — each must resolve to the image path.
-	for name, in := range map[string]string{
-		"backslash-escaped drop": strings.ReplaceAll(img, " ", `\ `),
-		"double-quoted drop":     `"` + img + `"`,
-		"single-quoted drop":     `'` + img + `'`,
-		"plain absolute path":    img,
-	} {
+	positives := map[string]string{
+		"double-quoted drop":  `"` + img + `"`,
+		"single-quoted drop":  `'` + img + `'`,
+		"plain absolute path": img,
+	}
+	if runtime.GOOS != "windows" {
+		// Backslash-escaping of spaces is a Unix terminal drag-drop convention; on
+		// Windows the backslash is the path separator, so this form does not occur.
+		positives["backslash-escaped drop"] = strings.ReplaceAll(img, " ", `\ `)
+	}
+	for name, in := range positives {
 		got, ok := droppedAttachmentPath(in, dir)
 		if !ok || got != img {
 			t.Fatalf("%s: got %q ok=%v, want %q true", name, got, ok, img)

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -2,12 +2,81 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/imageinput"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 )
+
+// droppableImageExts are the image extensions a dragged-and-dropped file may
+// carry (matched case-insensitively); PDFs are recognized separately.
+var droppableImageExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".webp": true,
+}
+
+// droppedAttachmentPath recognizes a single drag-dropped (or pasted) file path
+// that points at an existing image or PDF, returning the cleaned path. Terminals
+// deliver a dropped file as its path with spaces/special chars backslash-escaped
+// (or the whole path quoted); this undoes that so "Screenshot 2026 at 1.png"
+// resolves. ok is false for anything that is not a single existing image/PDF
+// file, so normal text pastes and real slash-commands are left untouched.
+func droppedAttachmentPath(content, cwd string) (string, bool) {
+	s := strings.TrimSpace(content)
+	if s == "" || strings.ContainsAny(s, "\n\r") {
+		return "", false // empty or multi-line: not a single dropped file
+	}
+	if unq, quoted := stripMatchingQuotes(s); quoted {
+		s = unq // a quoted path is literal — do not unescape inside it
+	} else {
+		s = unescapeDroppedPath(s)
+	}
+	if s == "" {
+		return "", false
+	}
+	resolved := s
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(cwd, resolved)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", false
+	}
+	ext := strings.ToLower(filepath.Ext(s))
+	if droppableImageExts[ext] || ext == ".pdf" || imageinput.LooksLikeDocumentFile(s, cwd) {
+		return s, true
+	}
+	return "", false
+}
+
+// unescapeDroppedPath drops a backslash before any following byte, undoing the
+// terminal's drag-drop escaping ("\ " -> " ", "\(" -> "(", "\\" -> "\").
+func unescapeDroppedPath(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// stripMatchingQuotes removes a single pair of surrounding ' or " quotes.
+func stripMatchingQuotes(s string) (string, bool) {
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '"' || q == '\'') && s[len(s)-1] == q {
+			return s[1 : len(s)-1], true
+		}
+	}
+	return s, false
+}
 
 // modelSupportsVisionTUI reports whether the active model can accept image input.
 // An unknown / custom id (not in the catalog) returns false: we cannot confirm
@@ -66,7 +135,9 @@ func (m model) handleImageCommand(arg string) model {
 
 	m.pendingImages = append(m.pendingImages, block)
 	m.pendingImageLabels = append(m.pendingImageLabels, filepath.Base(trimmed))
-	return m.appendImageNotice("Attached " + filepath.Base(trimmed) + " (" + block.MediaType + ").")
+	// No "attached" system message: the composer attachment chip ([Image #N]) is
+	// the confirmation, matching the compact attach UX.
+	return m
 }
 
 // pendingDocument is a PDF staged by /image for the next user turn: its extracted
@@ -91,24 +162,16 @@ func (m model) handleDocumentAttach(path string) model {
 	}
 
 	label := filepath.Base(path)
-	parts := make([]string, 0, 2)
 	if strings.TrimSpace(doc.Text) != "" {
 		m.pendingDocuments = append(m.pendingDocuments, pendingDocument{label: label, text: doc.Text})
-		summary := "text"
-		if doc.Truncated {
-			summary = "text, truncated at the size limit"
-		}
-		parts = append(parts, summary)
 	}
 	for _, block := range doc.Images {
 		m.pendingImages = append(m.pendingImages, block)
 		m.pendingImageLabels = append(m.pendingImageLabels, label)
 	}
-	if len(doc.Images) > 0 {
-		parts = append(parts, fmt.Sprintf("%d page image(s)", len(doc.Images)))
-	}
-
-	return m.appendImageNotice("Attached " + label + " (" + strings.Join(parts, ", ") + ").")
+	// The composer attachment chip ([Doc #N] / [Image #N]) is the confirmation; no
+	// "attached" system message.
+	return m
 }
 
 // consumePendingDocuments returns the staged document text formatted as a prompt
@@ -134,32 +197,50 @@ func (m model) appendImageNotice(text string) model {
 	return m.appendSystemNotice(text)
 }
 
-// renderImageChips builds a one-line "[img: a.png] [img: b.png]" row for the
-// pending attachments, or "" when there are none. Kept plain so the renderer
-// can wrap/style it consistently.
+// removeLastAttachment drops the rightmost pending attachment chip and reports
+// whether anything was removed. Documents render after images, so a staged
+// document is removed before images; image pops keep pendingImages and
+// pendingImageLabels in lockstep.
+func (m model) removeLastAttachment() (model, bool) {
+	if n := len(m.pendingDocuments); n > 0 {
+		m.pendingDocuments = m.pendingDocuments[:n-1]
+		return m, true
+	}
+	if n := len(m.pendingImageLabels); n > 0 {
+		m.pendingImageLabels = m.pendingImageLabels[:n-1]
+		if len(m.pendingImages) > 0 {
+			m.pendingImages = m.pendingImages[:len(m.pendingImages)-1]
+		}
+		return m, true
+	}
+	return m, false
+}
+
+// renderImageChips builds a compact "[Image #1] [Image #2]" row for the pending
+// image attachments, or "" when there are none, so the long file name never
+// clutters the input. Kept plain so the renderer can wrap/style it consistently.
 func renderImageChips(labels []string) string {
 	if len(labels) == 0 {
 		return ""
 	}
 	chips := make([]string, 0, len(labels))
-	for _, label := range labels {
-		chips = append(chips, "[img: "+label+"]")
+	for i := range labels {
+		chips = append(chips, fmt.Sprintf("[Image #%d]", i+1))
 	}
 	return strings.Join(chips, " ")
 }
 
-// renderAttachmentChips builds the pending-attachment row from both staged
-// images and staged documents, e.g. "[img: a.png] [doc: spec.pdf]". Returns ""
-// when nothing is staged. Document chips are de-duplicated by label so a PDF
-// that produced both a text block and several page images shows one "[doc: …]"
-// rather than one per page (its page images already show as "[img: …]").
+// renderAttachmentChips builds the pending-attachment row from both staged images
+// and staged documents, e.g. "[Image #1] [Image #2] [Doc #1]". Returns "" when
+// nothing is staged. Numbered (not named) so a long screenshot path never shows
+// in the composer.
 func renderAttachmentChips(imageLabels []string, docs []pendingDocument) string {
 	chips := make([]string, 0, len(imageLabels)+len(docs))
-	for _, label := range imageLabels {
-		chips = append(chips, "[img: "+label+"]")
+	for i := range imageLabels {
+		chips = append(chips, fmt.Sprintf("[Image #%d]", i+1))
 	}
-	for _, doc := range docs {
-		chips = append(chips, "[doc: "+doc.label+"]")
+	for i := range docs {
+		chips = append(chips, fmt.Sprintf("[Doc #%d]", i+1))
 	}
 	return strings.Join(chips, " ")
 }

--- a/internal/tui/image_attach.go
+++ b/internal/tui/image_attach.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/imageinput"
@@ -53,6 +54,12 @@ func droppedAttachmentPath(content, cwd string) (string, bool) {
 // unescapeDroppedPath drops a backslash before any following byte, undoing the
 // terminal's drag-drop escaping ("\ " -> " ", "\(" -> "(", "\\" -> "\").
 func unescapeDroppedPath(s string) string {
+	if runtime.GOOS == "windows" {
+		// On Windows the backslash is the path separator, not a drag-drop escape;
+		// stripping it would corrupt real paths (C:\Users\… -> C:Users…). Dropped
+		// paths there arrive quoted (handled by stripMatchingQuotes) or plain.
+		return s
+	}
 	if !strings.Contains(s, `\`) {
 		return s
 	}

--- a/internal/tui/image_attach_test.go
+++ b/internal/tui/image_attach_test.go
@@ -80,8 +80,8 @@ func TestImageCommandAttachRendersChip(t *testing.T) {
 	}
 	if chips := renderImageChips(next.pendingImageLabels); chips == "" {
 		t.Fatal("expected a chip row for pending images")
-	} else if !strings.Contains(chips, "photo.png") {
-		t.Fatalf("chip row %q should name the image", chips)
+	} else if !strings.Contains(chips, "[Image #1]") || strings.Contains(chips, "photo.png") {
+		t.Fatalf("chip row %q should be the compact numbered chip, not the file name", chips)
 	}
 }
 
@@ -144,8 +144,8 @@ func TestTranscriptViewShowsImageChips(t *testing.T) {
 	m.pendingImageLabels = []string{"photo.png", "diagram.gif"}
 
 	view := m.transcriptView()
-	if !strings.Contains(view, "photo.png") || !strings.Contains(view, "diagram.gif") {
-		t.Fatalf("transcript view should show pending image chips, got:\n%s", view)
+	if !strings.Contains(view, "[Image #1]") || !strings.Contains(view, "[Image #2]") {
+		t.Fatalf("transcript view should show numbered image chips, got:\n%s", view)
 	}
 }
 
@@ -324,9 +324,8 @@ func TestImageCommandAttachesPDFTextOnNonVisionModel(t *testing.T) {
 	if len(next.pendingImages) != 0 {
 		t.Fatalf("no rasterizer: expected 0 page images, got %d", len(next.pendingImages))
 	}
-	if notice := lastTranscriptText(next); !strings.Contains(notice, "spec.pdf") {
-		t.Fatalf("expected an attach notice naming the PDF, got %q", notice)
-	}
+	// A successful attach is silent now (the [Doc #N] composer chip is the
+	// confirmation); the pending-document assertions above verify it.
 }
 
 // A real PDF whose path lacks a ".pdf" extension is still routed to the document
@@ -401,7 +400,7 @@ func TestTranscriptViewShowsDocumentChips(t *testing.T) {
 	m.pendingDocuments = []pendingDocument{{label: "spec.pdf", text: "body"}}
 
 	view := m.transcriptView()
-	if !strings.Contains(view, "spec.pdf") {
+	if !strings.Contains(view, "[Doc #1]") {
 		t.Fatalf("transcript view should show the document chip, got:\n%s", view)
 	}
 }
@@ -471,11 +470,15 @@ func TestRenderAttachmentChips(t *testing.T) {
 	if got := renderAttachmentChips(nil, nil); got != "" {
 		t.Fatalf("empty attachments should render no chips, got %q", got)
 	}
-	got := renderAttachmentChips([]string{"a.png"}, []pendingDocument{{label: "spec.pdf"}})
-	if !strings.Contains(got, "[img: a.png]") {
-		t.Fatalf("chip row %q should include the image", got)
+	got := renderAttachmentChips([]string{"a.png", "b.png"}, []pendingDocument{{label: "spec.pdf"}})
+	if !strings.Contains(got, "[Image #1]") || !strings.Contains(got, "[Image #2]") {
+		t.Fatalf("chip row %q should include numbered images", got)
 	}
-	if !strings.Contains(got, "[doc: spec.pdf]") {
+	if !strings.Contains(got, "[Doc #1]") {
 		t.Fatalf("chip row %q should include the document", got)
+	}
+	// The long file name must NOT appear — compact numbered chips only.
+	if strings.Contains(got, "a.png") || strings.Contains(got, "spec.pdf") {
+		t.Fatalf("chip row %q should not show file names", got)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -106,6 +106,7 @@ type model struct {
 	input                 textinput.Model
 	composer              composerState
 	composerActive        bool
+	composerCursorVisible bool
 	composerPastePreviews []composerPastePreview
 	altScreen             bool
 	setup                 setupState
@@ -206,6 +207,10 @@ type model struct {
 	suggestionsAreFiles bool
 	lastMouseSelection  mouseSelectionTarget
 	mouseCapture        bool
+	// mouseReleased, when true, forces terminal mouse capture OFF so the user can
+	// drag-select and copy text natively (Ctrl+E toggles it). App mouse features
+	// (clickable suggestions, right-click paste, transcript select) pause while on.
+	mouseReleased       bool
 	transcriptSelection transcriptSelectionState
 	copyStatus          string
 	copyStatusSeq       int
@@ -437,6 +442,7 @@ func newModel(ctx context.Context, options Options) model {
 	m := model{
 		ctx:                    ctx,
 		cwd:                    cwd,
+		composerCursorVisible:  true,
 		userConfigPath:         options.UserConfigPath,
 		doctorUserConfigPath:   doctorUserConfigPath,
 		projectConfigPath:      options.ProjectConfigPath,
@@ -514,8 +520,22 @@ const (
 	composerMaxVisibleLines = 4
 )
 
+// composerCursorBlinkInterval is the on/off period of the composer text cursor.
+const composerCursorBlinkInterval = 530 * time.Millisecond
+
+// composerBlinkMsg toggles the composer cursor's visibility each tick. The custom
+// composer render draws its own cursor (not textinput's), so it drives its own
+// blink rather than relying on textinput.Blink.
+type composerBlinkMsg struct{}
+
+func composerBlinkCmd() tea.Cmd {
+	return tea.Tick(composerCursorBlinkInterval, func(time.Time) tea.Msg {
+		return composerBlinkMsg{}
+	})
+}
+
 func (m model) Init() tea.Cmd {
-	cmds := []tea.Cmd{textinput.Blink}
+	cmds := []tea.Cmd{textinput.Blink, composerBlinkCmd()}
 	if m.prService != nil && m.runtimeMessageSink != nil {
 		service := m.prService
 		sink := m.runtimeMessageSink
@@ -593,6 +613,9 @@ func batchCommands(cmds ...tea.Cmd) tea.Cmd {
 
 func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case composerBlinkMsg:
+		m.composerCursorVisible = !m.composerCursorVisible
+		return m, composerBlinkCmd()
 	case tea.MouseMsg:
 		if m.setup.visible {
 			return m.handleSetupMouse(msg)
@@ -662,6 +685,14 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.quit()
 		case keyCtrl(msg, 'o'):
 			return m.toggleDetailedTranscript(), nil
+		case keyCtrl(msg, 'e'):
+			// Release/recapture the mouse so the user can drag-select and copy text
+			// natively (mouse capture otherwise intercepts terminal selection).
+			m.mouseReleased = !m.mouseReleased
+			if m.mouseReleased {
+				return m.appendSystemNotice("Mouse released — drag to select and copy text. Press Ctrl+E again to re-enable mouse interaction (clicks, right-click paste)."), nil
+			}
+			return m.appendSystemNotice("Mouse interaction re-enabled."), nil
 		case keyIs(msg, tea.KeyEsc):
 			if m.mcpCommandCancel != nil {
 				m.cancelMCPCommand()
@@ -806,6 +837,14 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.picker.deleteQueryRune()
 				return m, nil
+			}
+			// On an empty composer, Backspace removes the last attachment chip
+			// ([Image #N] / [Doc #N]) so you can drop one you don't need without
+			// clearing them all. With text present it deletes a character as usual.
+			if m.composerValue() == "" {
+				if next, removed := m.removeLastAttachment(); removed {
+					return next, nil
+				}
 			}
 		case keyIs(msg, tea.KeyTab):
 			if m.transcriptDetailed {
@@ -1400,10 +1439,6 @@ func (m model) footerView(width int) string {
 	} else {
 		footer.WriteString("\n")
 	}
-	if chips := renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments); chips != "" {
-		footer.WriteString(fitStyledLine(zeroTheme.muted.Render(chips), width))
-		footer.WriteString("\n")
-	}
 	footer.WriteString(m.composerBox(width))
 	if hint := m.composerDescriptionHint(width); hint != "" {
 		footer.WriteString("\n")
@@ -1810,7 +1845,7 @@ func (m model) composerLine(width int) string {
 	}
 	previews := validComposerPastePreviews(state, m.composerPastePreviews)
 	displayState := composerDisplayStateForPastePreviews(state, previews)
-	return renderComposerInput(input, displayState, width)
+	return renderComposerInput(input, displayState, width, m.composerCursorVisible)
 }
 
 type composerVisualLine struct {
@@ -1819,13 +1854,20 @@ type composerVisualLine struct {
 	end   int
 }
 
-func renderComposerInput(input textinput.Model, state composerState, width int) string {
+func renderComposerInput(input textinput.Model, state composerState, width int, cursorVisible bool) string {
 	state = normalizeComposerState(state)
 	if width <= 0 {
 		return ""
 	}
 	if state.text == "" {
-		return fitStyledLine(composerVisualLinePrefix(input, true)+zeroTheme.faint.Render(input.Placeholder), width)
+		// Empty box: show a (blinking) cursor before the placeholder so the focused
+		// input always has a visible caret. A plain space when blinked off keeps the
+		// placeholder column stable.
+		cursor := " "
+		if cursorVisible {
+			cursor = composerCursor(" ")
+		}
+		return fitStyledLine(composerVisualLinePrefix(input, true)+cursor+zeroTheme.faint.Render(input.Placeholder), width)
 	}
 
 	segments := composerWrappedVisualLines(input, state, width)
@@ -1842,7 +1884,7 @@ func renderComposerInput(input textinput.Model, state composerState, width int) 
 
 	lines := make([]string, 0, len(segments))
 	for index, segment := range segments {
-		lines = append(lines, fitStyledLine(renderComposerVisualLine(input, state, segment, index == cursorLine), width))
+		lines = append(lines, fitStyledLine(renderComposerVisualLine(input, state, segment, index == cursorLine, cursorVisible), width))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -1908,7 +1950,7 @@ func composerCursorVisualLine(segments []composerVisualLine, cursor int) int {
 	return len(segments) - 1
 }
 
-func renderComposerVisualLine(input textinput.Model, state composerState, segment composerVisualLine, hasCursor bool) string {
+func renderComposerVisualLine(input textinput.Model, state composerState, segment composerVisualLine, hasCursor bool, cursorVisible bool) string {
 	runes := []rune(state.text)
 	prefix := composerVisualLinePrefix(input, segment.first)
 	textStyle := zeroTheme.ink.Inline(true)
@@ -1920,10 +1962,21 @@ func renderComposerVisualLine(input textinput.Model, state composerState, segmen
 	cursorIndex := segment.start + offset
 	before := string(runes[segment.start:cursorIndex])
 	if cursorIndex < segment.end {
+		cursorChar := string(runes[cursorIndex])
 		after := string(runes[cursorIndex+1 : segment.end])
-		return prefix + textStyle.Render(before) + composerCursor(string(runes[cursorIndex])) + textStyle.Render(after)
+		// Blinked off: draw the character normally (no caret highlight).
+		cell := textStyle.Render(cursorChar)
+		if cursorVisible {
+			cell = composerCursor(cursorChar)
+		}
+		return prefix + textStyle.Render(before) + cell + textStyle.Render(after)
 	}
-	return prefix + textStyle.Render(before) + composerCursor(" ")
+	// Cursor at end of line: a caret block when on, nothing when blinked off.
+	end := ""
+	if cursorVisible {
+		end = composerCursor(" ")
+	}
+	return prefix + textStyle.Render(before) + end
 }
 
 func composerVisualLinePrefix(input textinput.Model, first bool) string {
@@ -2084,8 +2137,15 @@ func (m model) composerBox(width int) string {
 	content := m.composerLine(innerWidth)
 	lines := strings.Split(content, "\n")
 
-	rendered := make([]string, 0, len(lines)+2)
+	rendered := make([]string, 0, len(lines)+3)
 	rendered = append(rendered, zeroTheme.lineStrong.Render("╭"+strings.Repeat("─", width-2)+"╮"))
+	// Attachment chips ([Image #1] …) render INSIDE the box, above the input line,
+	// instead of as a separate row above the box.
+	if chips := renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments); chips != "" {
+		fitted := fitStyledLine(zeroTheme.muted.Render(chips), innerWidth)
+		pad := strings.Repeat(" ", maxInt(0, innerWidth-lipgloss.Width(fitted)))
+		rendered = append(rendered, zeroTheme.lineStrong.Render("│ ")+fitted+pad+zeroTheme.lineStrong.Render(" │"))
+	}
 	for _, line := range lines {
 		fitted := fitStyledLine(line, innerWidth)
 		pad := strings.Repeat(" ", maxInt(0, innerWidth-lipgloss.Width(fitted)))
@@ -2292,6 +2352,14 @@ func (m model) chooseSuggestion() (tea.Model, tea.Cmd) {
 
 func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	input := m.composerValue()
+	// A drag-dropped image/PDF path that reached the composer (e.g. inserted as
+	// text) attaches instead of being parsed as an unknown "/…" command.
+	if path, ok := droppedAttachmentPath(input, m.cwd); ok {
+		m = m.handleImageCommand(path)
+		m.clearComposer()
+		m.clearSuggestions()
+		return m, nil
+	}
 	command := parseCommand(input)
 	// While exiting (Ctrl+C waiting on the cancelled run's checkpoint flush) a
 	// new run must not start: the deferred tea.Quit would abort it mid-flight

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -159,6 +159,9 @@ func (m *model) clearMouseSelection() {
 }
 
 func (m model) wantsMouseCapture() bool {
+	if m.mouseReleased {
+		return false // user released the mouse for native text selection/copy
+	}
 	return m.altScreen && (m.setupWantsMouseCapture() || m.chatWantsMouseCapture() || m.providerWizard != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive())
 }
 

--- a/internal/tui/mouse_release_test.go
+++ b/internal/tui/mouse_release_test.go
@@ -1,0 +1,14 @@
+package tui
+
+import "testing"
+
+func TestMouseReleaseDisablesCapture(t *testing.T) {
+	m := model{altScreen: true} // chat surface (setup not visible) wants capture
+	if !m.wantsMouseCapture() {
+		t.Fatal("chat should want mouse capture by default")
+	}
+	m.mouseReleased = true
+	if m.wantsMouseCapture() {
+		t.Fatal("mouseReleased must force mouse capture OFF so native selection/copy works")
+	}
+}


### PR DESCRIPTION
Improves the image/PDF attachment flow and two long-standing composer papercuts. Independent of the sub-agent delegation PR; touches only `internal/tui` + `internal/modelregistry`.

## What's new
- **Drag-and-drop attach** — dropping an image/PDF onto the composer attaches it instead of erroring as an unknown `/…` command. The dropped path is detected on paste and on submit (absolute / backslash-escaped / quoted paths that resolve to an existing image or PDF).
- **Inline numbered chips** — staged attachments render as compact `[Image #1]` / `[Doc #1]` chips **inside** the input box; the verbose `Attached … (image/png)` system line is gone. **Backspace on an empty composer removes the last chip** (`/image clear` still drops all).
- **Vision fallback** — a real multimodal model that's absent from the curated catalog (custom / openai-compatible / local ids) now accepts images via a conservative name match. Text-only ids stay refused, and a catalog entry remains authoritative (the heuristic never overrides a known "no").
- **Blinking composer cursor** — including when the box is empty (previously no caret was drawn for a focused, empty box).
- **`Ctrl+E` mouse release** — toggles terminal mouse capture off so native drag-select + copy works, then back on for clickable UI. (Holding ⌥Option while dragging also works without toggling.)

## Tests
- `dropped_attachment_test.go` — drop-path detection (escaped/quoted/plain positives; text, non-existent, non-image, multi-line negatives).
- `vision_name_test.go` — vision-by-name families + unknown-model fallback + text-only stays refused.
- `mouse_release_test.go` — capture forced off when released.
- `attachment_remove_test.go` — last-chip removal ordering (doc before image, labels in lockstep).
- Updated `image_attach_test.go` chip-render assertions for the numbered format.

`gofmt` · `go vet` · `go build ./...` · `go test ./internal/tui/... ./internal/modelregistry/... -race` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stricter drag-and-drop/paste handling for image and PDF paths, with compact numbered attachment chips ([Image `#N`], [Doc `#N`])
  * Introduced a blinking composer cursor and a **Ctrl+E** shortcut to toggle mouse interaction
* **Bug Fixes**
  * Paste of image/PDF paths now routes correctly (no raw path insertion) and attachment removal stays consistent
  * Vision capability detection is now more reliable, using catalog/registry truth when available
  * Image/PDF attachments no longer show an extra inline “Attached …” notice
* **Tests**
  * Added/updated coverage for vision detection fallback, attachment removal/chip rendering, dropped-path recognition, and mouse-release capture behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->