### PR TITLE
Add request permissions flow

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1031,8 +1031,17 @@ func executeRequestPermissions(ctx context.Context, call ToolCall, args map[stri
 			Output:     "Error: request_permissions requires at least one permission.",
 		}, nil
 	}
+	grantProfile, err := sandbox.RequestPermissionGrantProfile(normalized)
+	if err != nil {
+		return ToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Status:     tools.StatusError,
+			Output:     "Error: Invalid permissions for request_permissions: " + err.Error(),
+		}, nil
+	}
 
-	request := requestPermissionsPrompt(call, parsed, normalized, permissionMode, options)
+	request := requestPermissionsPrompt(call, parsed, grantProfile, permissionMode, options)
 	if options.OnPermissionRequest == nil {
 		response := sandbox.RequestPermissionsResponse{
 			Permissions: sandbox.RequestPermissionProfile{},
@@ -1058,16 +1067,16 @@ func executeRequestPermissions(ctx context.Context, call ToolCall, args map[stri
 	permissionGranted := false
 	switch decision.Action {
 	case PermissionDecisionAllow:
-		response.Permissions = normalized
+		response.Permissions = grantProfile
 		response.Scope = sandbox.PermissionGrantScopeTurn
 		permissionGranted = true
 	case PermissionDecisionAllowStrict:
-		response.Permissions = normalized
+		response.Permissions = grantProfile
 		response.Scope = sandbox.PermissionGrantScopeTurn
 		response.StrictAutoReview = true
 		permissionGranted = true
 	case PermissionDecisionAllowForSession:
-		response.Permissions = normalized
+		response.Permissions = grantProfile
 		response.Scope = sandbox.PermissionGrantScopeSession
 		permissionGranted = true
 	case PermissionDecisionCancel:
@@ -1158,7 +1167,7 @@ func requestPermissionsPrompt(call ToolCall, parsed requestPermissionsArgs, prof
 func requestPermissionsScope(profile sandbox.RequestPermissionProfile) string {
 	parts := []string{}
 	if profile.Network != nil && profile.Network.Enabled != nil && *profile.Network.Enabled {
-		parts = append(parts, "network")
+		parts = append(parts, "network all outbound access")
 	}
 	if profile.FileSystem != nil {
 		for _, path := range profile.FileSystem.Read {
@@ -1171,7 +1180,7 @@ func requestPermissionsScope(profile sandbox.RequestPermissionProfile) string {
 			parts = append(parts, "deny read "+path)
 		}
 	}
-	return truncateScope(strings.Join(parts, ", "))
+	return strings.Join(parts, ", ")
 }
 
 func emitRequestPermissionsDecision(options Options, call ToolCall, request PermissionRequest, action PermissionDecisionAction, reason string, granted bool) {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/Gitlawb/zero/internal/hooks"
 	"github.com/Gitlawb/zero/internal/redaction"
@@ -24,6 +25,33 @@ const (
 )
 
 var errPermissionApprovalCanceled = errors.New("permission approval cancelled")
+
+type permissionRunState struct {
+	mu       sync.Mutex
+	cleanups []func()
+}
+
+func (state *permissionRunState) add(cleanup func()) {
+	if state == nil || cleanup == nil {
+		return
+	}
+	state.mu.Lock()
+	state.cleanups = append(state.cleanups, cleanup)
+	state.mu.Unlock()
+}
+
+func (state *permissionRunState) cleanup() {
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	cleanups := state.cleanups
+	state.cleanups = nil
+	state.mu.Unlock()
+	for i := len(cleanups) - 1; i >= 0; i-- {
+		cleanups[i]()
+	}
+}
 
 // abortedToolResultNotice is the placeholder tool result recorded for a tool
 // call that was advertised by the assistant turn but never executed because the
@@ -66,6 +94,9 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 	if permissionMode == "" {
 		permissionMode = PermissionModeAuto
 	}
+	runPermissions := &permissionRunState{}
+	options.runPermissions = runPermissions
+	defer runPermissions.cleanup()
 
 	messages := zeroruntime.SeedMessagesWithImages(buildSystemPrompt(options), prompt, options.Images)
 
@@ -547,6 +578,9 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	if call.Name == "ask_user" {
 		return executeAskUser(ctx, registry, call, args, permissionMode, options)
 	}
+	if call.Name == tools.RequestPermissionsToolName {
+		return executeRequestPermissions(ctx, call, args, permissionMode, options)
+	}
 
 	permissionGranted := permissionMode == PermissionModeUnsafe
 	if toolFound && tool.Safety().Permission == tools.PermissionAllow {
@@ -957,11 +991,240 @@ func requestPermission(ctx context.Context, request PermissionRequest, options O
 
 func normalizePermissionDecisionAction(action PermissionDecisionAction) PermissionDecisionAction {
 	switch action {
-	case PermissionDecisionAllow, PermissionDecisionAllowForSession, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
+	case PermissionDecisionAllow, PermissionDecisionAllowStrict, PermissionDecisionAllowForSession, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
 		return action
 	default:
 		return PermissionDecisionDeny
 	}
+}
+
+type requestPermissionsArgs struct {
+	EnvironmentID string                           `json:"environment_id"`
+	Reason        string                           `json:"reason"`
+	Permissions   sandbox.RequestPermissionProfile `json:"permissions"`
+}
+
+func executeRequestPermissions(ctx context.Context, call ToolCall, args map[string]any, permissionMode PermissionMode, options Options) (ToolResult, error) {
+	parsed, err := parseRequestPermissionsArgs(args)
+	if err != nil {
+		return ToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Status:     tools.StatusError,
+			Output:     "Error: Invalid arguments for request_permissions: " + err.Error(),
+		}, nil
+	}
+	normalized, err := sandbox.NormalizeRequestPermissionProfile(parsed.Permissions, options.Cwd)
+	if err != nil {
+		return ToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Status:     tools.StatusError,
+			Output:     "Error: Invalid permissions for request_permissions: " + err.Error(),
+		}, nil
+	}
+	if normalized.Empty() {
+		return ToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Status:     tools.StatusError,
+			Output:     "Error: request_permissions requires at least one permission.",
+		}, nil
+	}
+
+	request := requestPermissionsPrompt(call, parsed, normalized, permissionMode, options)
+	if options.OnPermissionRequest == nil {
+		response := sandbox.RequestPermissionsResponse{
+			Permissions: sandbox.RequestPermissionProfile{},
+			Scope:       sandbox.PermissionGrantScopeTurn,
+		}
+		return requestPermissionsResult(call, response, false), nil
+	}
+
+	decision, err := requestPermission(ctx, request, options)
+	if err != nil {
+		decision = PermissionDecision{Action: PermissionDecisionDeny, Reason: err.Error()}
+	}
+	decision.Action = normalizePermissionDecisionAction(decision.Action)
+	decisionReason := strings.TrimSpace(decision.Reason)
+	if decisionReason == "" {
+		decisionReason = request.Reason
+	}
+
+	response := sandbox.RequestPermissionsResponse{
+		Permissions: sandbox.RequestPermissionProfile{},
+		Scope:       sandbox.PermissionGrantScopeTurn,
+	}
+	permissionGranted := false
+	switch decision.Action {
+	case PermissionDecisionAllow:
+		response.Permissions = normalized
+		response.Scope = sandbox.PermissionGrantScopeTurn
+		permissionGranted = true
+	case PermissionDecisionAllowStrict:
+		response.Permissions = normalized
+		response.Scope = sandbox.PermissionGrantScopeTurn
+		response.StrictAutoReview = true
+		permissionGranted = true
+	case PermissionDecisionAllowForSession:
+		response.Permissions = normalized
+		response.Scope = sandbox.PermissionGrantScopeSession
+		permissionGranted = true
+	case PermissionDecisionCancel:
+		decision.Action = PermissionDecisionDeny
+		decisionReason = firstNonEmptyString(decisionReason, "continued without granting permissions")
+	default:
+		decision.Action = PermissionDecisionDeny
+		decisionReason = firstNonEmptyString(decisionReason, "continued without granting permissions")
+	}
+
+	if permissionGranted {
+		if options.Sandbox == nil {
+			return ToolResult{
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Status:     tools.StatusError,
+				Output:     "Error: request_permissions cannot grant permissions because the sandbox engine is not configured.",
+			}, nil
+		}
+		cleanup, err := options.Sandbox.GrantRequestPermissions(response.Permissions, response.Scope)
+		if err != nil {
+			return ToolResult{
+				ToolCallID: call.ID,
+				Name:       call.Name,
+				Status:     tools.StatusError,
+				Output:     "Error: Failed to grant requested permissions: " + err.Error(),
+			}, nil
+		}
+		if response.Scope == sandbox.PermissionGrantScopeTurn && options.runPermissions != nil {
+			options.runPermissions.add(cleanup)
+		}
+	}
+
+	emitRequestPermissionsDecision(options, call, request, decision.Action, decisionReason, permissionGranted)
+	return requestPermissionsResult(call, response, false), nil
+}
+
+func parseRequestPermissionsArgs(args map[string]any) (requestPermissionsArgs, error) {
+	data, err := json.Marshal(args)
+	if err != nil {
+		return requestPermissionsArgs{}, err
+	}
+	var parsed requestPermissionsArgs
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return requestPermissionsArgs{}, err
+	}
+	if parsed.EnvironmentID == "" {
+		if raw, ok := args["environmentId"].(string); ok {
+			parsed.EnvironmentID = raw
+		}
+	}
+	return parsed, nil
+}
+
+func requestPermissionsPrompt(call ToolCall, parsed requestPermissionsArgs, profile sandbox.RequestPermissionProfile, permissionMode PermissionMode, options Options) PermissionRequest {
+	autonomy := options.Autonomy
+	if normalized, err := sandbox.NormalizeAutonomy(sandbox.Autonomy(autonomy)); err == nil {
+		autonomy = string(normalized)
+	}
+	reason := strings.TrimSpace(parsed.Reason)
+	if reason == "" {
+		reason = "The agent is requesting additional permissions."
+	}
+	return PermissionRequest{
+		ToolCallID:     call.ID,
+		ToolName:       tools.RequestPermissionsToolName,
+		Action:         PermissionActionPrompt,
+		Permission:     string(tools.PermissionPrompt),
+		PermissionMode: permissionMode,
+		Autonomy:       autonomy,
+		SideEffect:     "permissions",
+		Reason:         reason,
+		Scope:          requestPermissionsScope(profile),
+		Args: map[string]any{
+			"environment_id": parsed.EnvironmentID,
+			"reason":         parsed.Reason,
+			"permissions":    profile,
+		},
+		AvailableDecisions: []PermissionDecisionAction{
+			PermissionDecisionAllow,
+			PermissionDecisionAllowStrict,
+			PermissionDecisionAllowForSession,
+			PermissionDecisionDeny,
+		},
+	}
+}
+
+func requestPermissionsScope(profile sandbox.RequestPermissionProfile) string {
+	parts := []string{}
+	if profile.Network != nil && profile.Network.Enabled != nil && *profile.Network.Enabled {
+		parts = append(parts, "network")
+	}
+	if profile.FileSystem != nil {
+		for _, path := range profile.FileSystem.Read {
+			parts = append(parts, "read "+path)
+		}
+		for _, path := range profile.FileSystem.Write {
+			parts = append(parts, "write "+path)
+		}
+		for _, path := range profile.FileSystem.DenyRead {
+			parts = append(parts, "deny read "+path)
+		}
+	}
+	return truncateScope(strings.Join(parts, ", "))
+}
+
+func emitRequestPermissionsDecision(options Options, call ToolCall, request PermissionRequest, action PermissionDecisionAction, reason string, granted bool) {
+	if options.OnPermission == nil {
+		return
+	}
+	eventAction := PermissionActionDeny
+	if granted {
+		eventAction = PermissionActionAllow
+	}
+	options.OnPermission(PermissionEvent{
+		ToolCallID:        call.ID,
+		ToolName:          call.Name,
+		Action:            eventAction,
+		DecisionAction:    action,
+		Permission:        request.Permission,
+		PermissionGranted: granted,
+		PermissionMode:    request.PermissionMode,
+		Autonomy:          request.Autonomy,
+		SideEffect:        request.SideEffect,
+		Reason:            reason,
+		Scope:             request.Scope,
+		DecisionReason:    reason,
+	})
+}
+
+func requestPermissionsResult(call ToolCall, response sandbox.RequestPermissionsResponse, redacted bool) ToolResult {
+	data, err := json.Marshal(response)
+	if err != nil {
+		return ToolResult{
+			ToolCallID: call.ID,
+			Name:       call.Name,
+			Status:     tools.StatusError,
+			Output:     "Error: Failed to serialize request_permissions response: " + err.Error(),
+		}
+	}
+	output, didRedact := scrubInterceptedOutput(string(data))
+	return ToolResult{
+		ToolCallID: call.ID,
+		Name:       call.Name,
+		Status:     tools.StatusOK,
+		Output:     output,
+		Redacted:   redacted || didRedact,
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func persistPermissionGrant(toolName string, args map[string]any, reason string, options Options) (sandbox.Grant, error) {

--- a/internal/agent/request_permissions_test.go
+++ b/internal/agent/request_permissions_test.go
@@ -1,0 +1,188 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestRequestPermissionsTurnGrantAllowsLaterToolAndCleansUp(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "vegetables.txt")
+	scope, err := sandbox.NewScope(workspace, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	engine := sandbox.NewEngine(sandbox.EngineOptions{
+		WorkspaceRoot: workspace,
+		Policy:        sandbox.DefaultPolicy(),
+		Scope:         scope,
+	})
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewRequestPermissionsTool())
+	registry.Register(tools.NewScopedWriteFileTool(workspace, scope))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "grant-1", ToolName: tools.RequestPermissionsToolName},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "grant-1", ArgumentsFragment: `{"reason":"Need to write outside the workspace.","permissions":{"file_system":{"write":[` + quoteJSONString(target) + `]}}}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "grant-1"},
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "write-1", ToolName: "write_file"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "write-1", ArgumentsFragment: `{"path":` + quoteJSONString(target) + `,"content":"carrot\n","overwrite":true}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "write-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var requests []PermissionRequest
+	var results []ToolResult
+
+	result, err := Run(context.Background(), "write the file", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAuto,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Cwd:            workspace,
+		Sandbox:        engine,
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			requests = append(requests, request)
+			return PermissionDecision{Action: PermissionDecisionAllow, Reason: "ok"}, nil
+		},
+		OnToolResult: func(result ToolResult) {
+			results = append(results, result)
+		},
+		MaxTurns: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("final answer = %q, want done", result.FinalAnswer)
+	}
+	if len(requests) != 1 || requests[0].ToolName != tools.RequestPermissionsToolName {
+		t.Fatalf("permission requests = %#v, want one request_permissions prompt", requests)
+	}
+	if len(results) != 2 || results[0].Status != tools.StatusOK || results[1].Status != tools.StatusOK {
+		t.Fatalf("tool results = %#v, want request_permissions and write_file ok", results)
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "carrot\n" {
+		t.Fatalf("target content = %q", content)
+	}
+
+	decision := engine.Evaluate(context.Background(), sandbox.Request{
+		WorkspaceRoot:  workspace,
+		ToolName:       "write_file",
+		SideEffect:     sandbox.SideEffectWrite,
+		Permission:     sandbox.PermissionPrompt,
+		PermissionMode: sandbox.PermissionModeAuto,
+		Autonomy:       sandbox.AutonomyMedium,
+		Args:           map[string]any{"path": target},
+	})
+	if decision.Action != sandbox.ActionDeny {
+		t.Fatalf("turn grant should be cleaned up after Run, got decision %#v", decision)
+	}
+}
+
+func TestRequestPermissionsDenyReturnsEmptyGrantAndContinues(t *testing.T) {
+	workspace := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewRequestPermissionsTool())
+	provider := requestPermissionsOnlyProvider(`{"reason":"Need network.","permissions":{"network":{"enabled":true}}}`, "done")
+	var results []ToolResult
+
+	result, err := Run(context.Background(), "request network", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAuto,
+		Cwd:            workspace,
+		Sandbox:        sandbox.NewEngine(sandbox.EngineOptions{WorkspaceRoot: workspace, Policy: sandbox.DefaultPolicy()}),
+		OnPermissionRequest: func(context.Context, PermissionRequest) (PermissionDecision, error) {
+			return PermissionDecision{Action: PermissionDecisionDeny, Reason: "no"}, nil
+		},
+		OnToolResult: func(result ToolResult) { results = append(results, result) },
+		MaxTurns:     2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("final answer = %q, want done", result.FinalAnswer)
+	}
+	if len(results) != 1 || results[0].Status != tools.StatusOK {
+		t.Fatalf("request_permissions denial should be an ok tool result, got %#v", results)
+	}
+	var response sandbox.RequestPermissionsResponse
+	if err := json.Unmarshal([]byte(results[0].Output), &response); err != nil {
+		t.Fatalf("unmarshal response %q: %v", results[0].Output, err)
+	}
+	if !response.Permissions.Empty() || response.Scope != sandbox.PermissionGrantScopeTurn {
+		t.Fatalf("deny response = %#v, want empty turn grant", response)
+	}
+}
+
+func TestRequestPermissionsStrictReviewResponse(t *testing.T) {
+	workspace := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewRequestPermissionsTool())
+	provider := requestPermissionsOnlyProvider(`{"reason":"Need read access.","permissions":{"file_system":{"read":[`+quoteJSONString(workspace)+`]}}}`, "done")
+	var output string
+
+	_, err := Run(context.Background(), "request read", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAuto,
+		Cwd:            workspace,
+		Sandbox:        sandbox.NewEngine(sandbox.EngineOptions{WorkspaceRoot: workspace, Policy: sandbox.DefaultPolicy()}),
+		OnPermissionRequest: func(context.Context, PermissionRequest) (PermissionDecision, error) {
+			return PermissionDecision{Action: PermissionDecisionAllowStrict, Reason: "review commands"}, nil
+		},
+		OnToolResult: func(result ToolResult) { output = result.Output },
+		MaxTurns:     2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response sandbox.RequestPermissionsResponse
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		t.Fatalf("unmarshal response %q: %v", output, err)
+	}
+	if !response.StrictAutoReview || response.Scope != sandbox.PermissionGrantScopeTurn {
+		t.Fatalf("strict response = %#v, want strict turn grant", response)
+	}
+	if response.Permissions.FileSystem == nil || len(response.Permissions.FileSystem.Read) != 1 {
+		t.Fatalf("strict response permissions = %#v, want read permission", response.Permissions)
+	}
+}
+
+func requestPermissionsOnlyProvider(arguments string, finalAnswer string) *mockProvider {
+	if !strings.HasPrefix(arguments, "{") {
+		arguments = "{}"
+	}
+	return &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "grant-1", ToolName: tools.RequestPermissionsToolName},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "grant-1", ArgumentsFragment: arguments},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "grant-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: finalAnswer},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+}

--- a/internal/agent/request_permissions_test.go
+++ b/internal/agent/request_permissions_test.go
@@ -48,6 +48,17 @@ func TestRequestPermissionsTurnGrantAllowsLaterToolAndCleansUp(t *testing.T) {
 	}
 	var requests []PermissionRequest
 	var results []ToolResult
+	normalizedProfile, err := sandbox.NormalizeRequestPermissionProfile(sandbox.RequestPermissionProfile{
+		FileSystem: &sandbox.FileSystemPermissions{Write: []string{target}},
+	}, workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedGrantProfile, err := sandbox.RequestPermissionGrantProfile(normalizedProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedWriteRoot := expectedGrantProfile.FileSystem.Write[0]
 
 	result, err := Run(context.Background(), "write the file", provider, Options{
 		Registry:       registry,
@@ -73,8 +84,20 @@ func TestRequestPermissionsTurnGrantAllowsLaterToolAndCleansUp(t *testing.T) {
 	if len(requests) != 1 || requests[0].ToolName != tools.RequestPermissionsToolName {
 		t.Fatalf("permission requests = %#v, want one request_permissions prompt", requests)
 	}
+	if !strings.Contains(requests[0].Scope, "write "+expectedWriteRoot) || strings.Contains(requests[0].Scope, target) {
+		t.Fatalf("permission request scope = %q, want widened directory root %q and not file %q", requests[0].Scope, expectedWriteRoot, target)
+	}
 	if len(results) != 2 || results[0].Status != tools.StatusOK || results[1].Status != tools.StatusOK {
 		t.Fatalf("tool results = %#v, want request_permissions and write_file ok", results)
+	}
+	var grantResponse sandbox.RequestPermissionsResponse
+	if err := json.Unmarshal([]byte(results[0].Output), &grantResponse); err != nil {
+		t.Fatalf("unmarshal grant response %q: %v", results[0].Output, err)
+	}
+	if grantResponse.Permissions.FileSystem == nil ||
+		len(grantResponse.Permissions.FileSystem.Write) != 1 ||
+		grantResponse.Permissions.FileSystem.Write[0] != expectedWriteRoot {
+		t.Fatalf("grant response permissions = %#v, want write root %q", grantResponse.Permissions, expectedWriteRoot)
 	}
 	content, err := os.ReadFile(target)
 	if err != nil {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -40,6 +40,7 @@ const (
 
 const (
 	PermissionDecisionAllow           PermissionDecisionAction = "allow"
+	PermissionDecisionAllowStrict     PermissionDecisionAction = "allow_with_strict_auto_review"
 	PermissionDecisionAllowForSession PermissionDecisionAction = "allow_for_session"
 	PermissionDecisionDeny            PermissionDecisionAction = "deny"
 	PermissionDecisionAlwaysAllow     PermissionDecisionAction = "always_allow"
@@ -214,6 +215,8 @@ type Options struct {
 	// ceiling and the autonomy gate. nil disables it entirely (the loop is
 	// byte-identical to before). One instance per run — it holds attempt state.
 	SelfCorrect *SelfCorrector
+
+	runPermissions *permissionRunState
 }
 
 type Result struct {

--- a/internal/oauth/encrypt.go
+++ b/internal/oauth/encrypt.go
@@ -12,8 +12,13 @@ import (
 	"time"
 )
 
-// secretBytes is the AES-256 key length kept in the per-user secret file.
-const secretBytes = 32
+const (
+	// secretBytes is the AES-256 key length kept in the per-user secret file.
+	secretBytes = 32
+
+	secretRetryAttempts = 500
+	secretRetryDelay    = 2 * time.Millisecond
+)
 
 // aesGCMCrypter encrypts the token file at rest with AES-256-GCM under a
 // per-user random secret persisted (0600) beside the token file. The on-disk
@@ -80,7 +85,7 @@ func (c *aesGCMCrypter) open(blob []byte) ([]byte, error) {
 // the file is absent, it generates a random secret and creates the file
 // atomically (0600). A wrong-sized existing secret fails closed (corruption).
 func loadOrCreateSecret(path string, create bool) ([]byte, error) {
-	if data, err := readSecretFile(path); err == nil {
+	if data, err := readSecretFileRetry(path); err == nil {
 		return data, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
@@ -97,12 +102,12 @@ func loadOrCreateSecret(path string, create bool) ([]byte, error) {
 func createSecretFile(path string) ([]byte, error) {
 	lockPath := path + ".lock"
 	var lastErr error
-	for attempt := 0; attempt < 500; attempt++ {
+	for attempt := 0; attempt < secretRetryAttempts; attempt++ {
 		lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err == nil {
 			_ = lock.Close()
 			defer os.Remove(lockPath)
-			if data, rerr := readSecretFile(path); rerr == nil {
+			if data, rerr := readSecretFileRetry(path); rerr == nil {
 				return data, nil
 			} else if !errors.Is(rerr, os.ErrNotExist) {
 				return nil, rerr
@@ -112,12 +117,12 @@ func createSecretFile(path string) ([]byte, error) {
 		if !errors.Is(err, os.ErrExist) {
 			return nil, fmt.Errorf("oauth: create token secret lock: %w", err)
 		}
-		if data, rerr := readSecretFile(path); rerr == nil {
+		if data, rerr := readSecretFileRetry(path); rerr == nil {
 			return data, nil
 		} else {
 			lastErr = rerr
 		}
-		time.Sleep(2 * time.Millisecond)
+		time.Sleep(secretRetryDelay)
 	}
 	if lastErr != nil {
 		return nil, fmt.Errorf("oauth: timed out waiting for token secret %s: %w", path, lastErr)
@@ -152,6 +157,19 @@ func writeNewSecretFile(path string) ([]byte, error) {
 		return nil, fmt.Errorf("oauth: publish token secret: %w", err)
 	}
 	return secret, nil
+}
+
+func readSecretFileRetry(path string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < secretRetryAttempts; attempt++ {
+		data, err := readSecretFile(path)
+		if !isTransientSecretAccessError(err) {
+			return data, err
+		}
+		lastErr = err
+		time.Sleep(secretRetryDelay)
+	}
+	return nil, fmt.Errorf("oauth: timed out waiting for token secret %s: %w", path, lastErr)
 }
 
 // readSecretFile reads and validates the secret at path, returning a wrapped

--- a/internal/oauth/secret_access_other.go
+++ b/internal/oauth/secret_access_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package oauth
+
+func isTransientSecretAccessError(error) bool {
+	return false
+}

--- a/internal/oauth/secret_access_windows.go
+++ b/internal/oauth/secret_access_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package oauth
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isTransientSecretAccessError(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -22,13 +21,14 @@ type EngineOptions struct {
 }
 
 type Engine struct {
-	workspaceRoot string
-	policy        Policy
-	store         *GrantStore
-	backend       Backend
-	scope         *Scope
-	sessionMu     sync.Mutex
-	sessionGrants map[string][]Grant
+	workspaceRoot   string
+	policy          Policy
+	store           *GrantStore
+	backend         Backend
+	scope           *Scope
+	sessionGrants   *memoryGrantSet
+	sessionProfiles *permissionProfileGrantSet
+	turnProfiles    *permissionProfileGrantSet
 }
 
 func NewEngine(options EngineOptions) *Engine {
@@ -52,11 +52,14 @@ func NewEngine(options EngineOptions) *Engine {
 		scope = &Scope{workspaceRoot: normalizeWorkspaceRootBestEffort(workspaceRoot)}
 	}
 	return &Engine{
-		workspaceRoot: workspaceRoot,
-		policy:        policy,
-		store:         options.Store,
-		backend:       options.Backend,
-		scope:         scope,
+		workspaceRoot:   workspaceRoot,
+		policy:          policy,
+		store:           options.Store,
+		backend:         options.Backend,
+		scope:           scope,
+		sessionGrants:   newMemoryGrantSet(),
+		sessionProfiles: newPermissionProfileGrantSet(),
+		turnProfiles:    newPermissionProfileGrantSet(),
 	}
 }
 
@@ -82,13 +85,17 @@ func (engine *Engine) CanPersistGrants() bool {
 func (engine *Engine) ReadExclusions() *ReadExclusions {
 	// A disabled policy enforces nothing, so it must not filter search results
 	// either (Evaluate already allows every request under ModeDisabled).
-	if engine == nil || engine.policy.Mode == ModeDisabled {
+	if engine == nil {
+		return nil
+	}
+	policy := engine.effectivePolicy(engine.policy)
+	if policy.Mode == ModeDisabled {
 		return nil
 	}
 	return &ReadExclusions{
 		workspaceRoot: engine.workspaceRoot,
-		denyRoots:     resolvePolicyPaths(engine.policy.DenyRead),
-		allowRoots:    resolvePolicyPaths(engine.policy.AllowRead),
+		denyRoots:     resolvePolicyPaths(policy.DenyRead),
+		allowRoots:    resolvePolicyPaths(policy.AllowRead),
 	}
 }
 
@@ -97,10 +104,14 @@ func (engine *Engine) ReadExclusions() *ReadExclusions {
 // DenyRead is unset or the engine has no scope.
 func (engine *Engine) ReadExclusionGlobs() []string {
 	// A disabled policy filters nothing (parity with ReadExclusions / Evaluate).
-	if engine == nil || engine.policy.Mode == ModeDisabled {
+	if engine == nil {
 		return nil
 	}
-	return ReadExclusionGlobs(engine.policy, engine.scope)
+	policy := engine.effectivePolicy(engine.policy)
+	if policy.Mode == ModeDisabled {
+		return nil
+	}
+	return ReadExclusionGlobs(policy, engine.scope)
 }
 
 // effectiveNetworkMode is the single source of truth for the engine's active
@@ -139,7 +150,7 @@ func (engine *Engine) NetworkHostAllowed(host string) (bool, NetworkMode) {
 	if engine == nil {
 		return true, NetworkAllow
 	}
-	policy := engine.policy
+	policy := engine.effectivePolicy(engine.policy)
 	if policy.Mode == ModeDisabled {
 		return true, NetworkAllow
 	}
@@ -245,7 +256,7 @@ func (engine *Engine) Evaluate(ctx context.Context, request Request) Decision {
 	if engine == nil {
 		return Decision{Action: ActionAllow, Risk: Classify(request), Reason: "sandbox disabled"}
 	}
-	policy := engine.policy
+	policy := engine.effectivePolicy(engine.policy)
 	if policy.Mode == "" {
 		policy = DefaultPolicy()
 	}
@@ -415,20 +426,7 @@ func (engine *Engine) GrantForSession(input GrantInput) (Grant, error) {
 		return Grant{}, err
 	}
 	grant.Session = true
-	engine.sessionMu.Lock()
-	defer engine.sessionMu.Unlock()
-	if engine.sessionGrants == nil {
-		engine.sessionGrants = map[string][]Grant{}
-	}
-	bucket := engine.sessionGrants[grant.ToolName]
-	for index := range bucket {
-		if bucket[index].Scope == grant.Scope && bucket[index].ScopeKind == grant.ScopeKind {
-			bucket[index] = grant
-			engine.sessionGrants[grant.ToolName] = bucket
-			return grant, nil
-		}
-	}
-	engine.sessionGrants[grant.ToolName] = append(bucket, grant)
+	engine.sessionGrants.add(grant)
 	return grant, nil
 }
 
@@ -456,9 +454,7 @@ func (engine *Engine) lookupSessionGrant(toolName string, reqScope string, reque
 	if err != nil {
 		return GrantLookup{}
 	}
-	engine.sessionMu.Lock()
-	defer engine.sessionMu.Unlock()
-	return lookupGrantBucket(engine.sessionGrants[strings.TrimSpace(toolName)], reqScope, requested)
+	return engine.sessionGrants.lookup(toolName, reqScope, requested)
 }
 
 func workspaceWriteAutoAllowed(policy Policy, request Request, scope *Scope) bool {

--- a/internal/sandbox/pathlists.go
+++ b/internal/sandbox/pathlists.go
@@ -271,7 +271,7 @@ func validatePathWithPolicy(scope *Scope, policy Policy, sideEffect SideEffect, 
 			}
 		}
 		if enforceWorkspace {
-			return scope.validate(path)
+			return scope.validateRead(path)
 		}
 		return nil
 	case SideEffectWrite, SideEffectOutOfWorkspace:

--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -63,6 +63,7 @@ func PermissionProfileFromPolicy(workspaceRoot string, policy Policy, scope *Sco
 	if extra := normalizeProfileDirs(policy.AllowWrite); len(extra) > 0 {
 		roots = dedupeStrings(append(roots, extra...))
 	}
+	readRoots := permissionProfileReadRoots(workspaceRoot, policy, scope, roots)
 	writeRoots := make([]WritableRoot, 0, len(roots))
 	for _, root := range roots {
 		writeRoots = append(writeRoots, WritableRoot{
@@ -73,7 +74,7 @@ func PermissionProfileFromPolicy(workspaceRoot string, policy Policy, scope *Sco
 	return PermissionProfile{
 		FileSystem: FileSystemPolicy{
 			Kind:                 FileSystemRestricted,
-			ReadRoots:            append([]string{}, roots...),
+			ReadRoots:            readRoots,
 			WriteRoots:           writeRoots,
 			DenyRead:             normalizeProfilePaths(policy.DenyRead),
 			DenyWrite:            normalizeProfilePaths(policy.DenyWrite),
@@ -107,6 +108,19 @@ func permissionProfileRoots(workspaceRoot string, scope *Scope) []string {
 		return []string{root}
 	}
 	return nil
+}
+
+func permissionProfileReadRoots(workspaceRoot string, policy Policy, scope *Scope, writeRoots []string) []string {
+	readRoots := append([]string{}, writeRoots...)
+	if scope != nil {
+		readRoots = dedupeStrings(append(readRoots, scope.ReadRoots()...))
+	} else if root := normalizeProfilePath(workspaceRoot); root != "" {
+		readRoots = dedupeStrings(append(readRoots, root))
+	}
+	if extra := normalizeProfileDirs(policy.AllowRead); len(extra) > 0 {
+		readRoots = dedupeStrings(append(readRoots, extra...))
+	}
+	return readRoots
 }
 
 func normalizeProfileDirs(entries []string) []string {

--- a/internal/sandbox/request_permissions.go
+++ b/internal/sandbox/request_permissions.go
@@ -105,6 +105,51 @@ func NormalizeRequestPermissionProfile(profile RequestPermissionProfile, basePat
 	return normalized, nil
 }
 
+// RequestPermissionGrantProfile returns the effective grant profile the engine
+// can enforce. File-like read/write requests become their normalized parent
+// directory roots, matching GrantRequestPermissions and native sandbox profiles.
+func RequestPermissionGrantProfile(profile RequestPermissionProfile) (RequestPermissionProfile, error) {
+	var grant RequestPermissionProfile
+	if profile.Network != nil && profile.Network.Enabled != nil && *profile.Network.Enabled {
+		enabled := true
+		grant.Network = &NetworkPermissions{Enabled: &enabled}
+	}
+	if profile.FileSystem != nil {
+		read, err := grantPermissionRoots(profile.FileSystem.Read)
+		if err != nil {
+			return RequestPermissionProfile{}, err
+		}
+		write, err := grantPermissionRoots(profile.FileSystem.Write)
+		if err != nil {
+			return RequestPermissionProfile{}, err
+		}
+		fs := FileSystemPermissions{
+			Read:     read,
+			Write:    write,
+			DenyRead: append([]string{}, profile.FileSystem.DenyRead...),
+		}
+		if len(fs.Read) > 0 || len(fs.Write) > 0 || len(fs.DenyRead) > 0 {
+			grant.FileSystem = &fs
+		}
+	}
+	return grant, nil
+}
+
+func grantPermissionRoots(paths []string) ([]string, error) {
+	roots := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		root, err := normalizeScopeRoot(permissionRoot(path))
+		if err != nil {
+			return nil, err
+		}
+		roots = append(roots, root)
+	}
+	return dedupeStrings(roots), nil
+}
+
 func normalizeFileSystemPermissions(fs FileSystemPermissions, basePath string) (FileSystemPermissions, error) {
 	var out FileSystemPermissions
 	var err error

--- a/internal/sandbox/request_permissions.go
+++ b/internal/sandbox/request_permissions.go
@@ -1,0 +1,376 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type PermissionGrantScope string
+
+const (
+	PermissionGrantScopeTurn    PermissionGrantScope = "turn"
+	PermissionGrantScopeSession PermissionGrantScope = "session"
+)
+
+type RequestPermissionProfile struct {
+	Network    *NetworkPermissions    `json:"network,omitempty"`
+	FileSystem *FileSystemPermissions `json:"file_system,omitempty"`
+}
+
+type RequestPermissionsResponse struct {
+	Permissions      RequestPermissionProfile `json:"permissions"`
+	Scope            PermissionGrantScope     `json:"scope"`
+	StrictAutoReview bool                     `json:"strict_auto_review,omitempty"`
+}
+
+type NetworkPermissions struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type FileSystemPermissions struct {
+	Read             []string                 `json:"read,omitempty"`
+	Write            []string                 `json:"write,omitempty"`
+	DenyRead         []string                 `json:"deny_read,omitempty"`
+	GlobScanMaxDepth *int                     `json:"glob_scan_max_depth,omitempty"`
+	Entries          []FileSystemSandboxEntry `json:"entries,omitempty"`
+}
+
+type FileSystemSandboxEntry struct {
+	Path   FileSystemPath       `json:"path"`
+	Access FileSystemAccessMode `json:"access"`
+}
+
+type FileSystemAccessMode string
+
+const (
+	FileSystemAccessRead  FileSystemAccessMode = "read"
+	FileSystemAccessWrite FileSystemAccessMode = "write"
+	FileSystemAccessDeny  FileSystemAccessMode = "deny"
+)
+
+type FileSystemPath struct {
+	Kind    string `json:"kind,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Pattern string `json:"pattern,omitempty"`
+}
+
+func (path *FileSystemPath) UnmarshalJSON(data []byte) error {
+	var rawString string
+	if err := json.Unmarshal(data, &rawString); err == nil {
+		path.Kind = "path"
+		path.Type = "path"
+		path.Path = rawString
+		return nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	_ = json.Unmarshal(raw["kind"], &path.Kind)
+	_ = json.Unmarshal(raw["type"], &path.Type)
+	_ = json.Unmarshal(raw["path"], &path.Path)
+	_ = json.Unmarshal(raw["pattern"], &path.Pattern)
+	return nil
+}
+
+func (profile RequestPermissionProfile) Empty() bool {
+	networkEmpty := profile.Network == nil || profile.Network.Enabled == nil || !*profile.Network.Enabled
+	fs := profile.FileSystem
+	fileSystemEmpty := fs == nil ||
+		(len(fs.Read) == 0 && len(fs.Write) == 0 && len(fs.DenyRead) == 0 && len(fs.Entries) == 0)
+	return networkEmpty && fileSystemEmpty
+}
+
+func NormalizeRequestPermissionProfile(profile RequestPermissionProfile, basePath string) (RequestPermissionProfile, error) {
+	var normalized RequestPermissionProfile
+	if profile.Network != nil && profile.Network.Enabled != nil && *profile.Network.Enabled {
+		enabled := true
+		normalized.Network = &NetworkPermissions{Enabled: &enabled}
+	}
+	if profile.FileSystem != nil {
+		fs, err := normalizeFileSystemPermissions(*profile.FileSystem, basePath)
+		if err != nil {
+			return RequestPermissionProfile{}, err
+		}
+		if len(fs.Read) > 0 || len(fs.Write) > 0 || len(fs.DenyRead) > 0 {
+			normalized.FileSystem = &fs
+		}
+	}
+	return normalized, nil
+}
+
+func normalizeFileSystemPermissions(fs FileSystemPermissions, basePath string) (FileSystemPermissions, error) {
+	var out FileSystemPermissions
+	var err error
+	if out.Read, err = normalizePermissionPaths(fs.Read, basePath); err != nil {
+		return FileSystemPermissions{}, err
+	}
+	if out.Write, err = normalizePermissionPaths(fs.Write, basePath); err != nil {
+		return FileSystemPermissions{}, err
+	}
+	if out.DenyRead, err = normalizePermissionPaths(fs.DenyRead, basePath); err != nil {
+		return FileSystemPermissions{}, err
+	}
+	for _, entry := range fs.Entries {
+		path, ok := entry.Path.pathString()
+		if !ok {
+			continue
+		}
+		normalized, err := normalizePermissionPath(path, basePath)
+		if err != nil {
+			return FileSystemPermissions{}, err
+		}
+		switch normalizeFileSystemAccess(entry.Access) {
+		case FileSystemAccessRead:
+			out.Read = append(out.Read, normalized)
+		case FileSystemAccessWrite:
+			out.Write = append(out.Write, normalized)
+		case FileSystemAccessDeny:
+			out.DenyRead = append(out.DenyRead, normalized)
+		}
+	}
+	out.Read = dedupeStrings(out.Read)
+	out.Write = dedupeStrings(out.Write)
+	out.DenyRead = dedupeStrings(out.DenyRead)
+	return out, nil
+}
+
+func (path FileSystemPath) pathString() (string, bool) {
+	kind := strings.TrimSpace(firstNonEmpty(path.Type, path.Kind))
+	if kind == "" || kind == "path" {
+		value := strings.TrimSpace(path.Path)
+		return value, value != ""
+	}
+	return "", false
+}
+
+func normalizeFileSystemAccess(access FileSystemAccessMode) FileSystemAccessMode {
+	switch strings.ToLower(strings.TrimSpace(string(access))) {
+	case "read":
+		return FileSystemAccessRead
+	case "write":
+		return FileSystemAccessWrite
+	case "deny", "none":
+		return FileSystemAccessDeny
+	default:
+		return ""
+	}
+}
+
+func normalizePermissionPaths(paths []string, basePath string) ([]string, error) {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		normalized, err := normalizePermissionPath(path, basePath)
+		if err != nil {
+			return nil, err
+		}
+		if normalized != "" {
+			out = append(out, normalized)
+		}
+	}
+	return dedupeStrings(out), nil
+}
+
+func normalizePermissionPath(path string, basePath string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(trimmed) {
+		base := strings.TrimSpace(basePath)
+		if base == "" {
+			var err error
+			base, err = os.Getwd()
+			if err != nil {
+				return "", err
+			}
+		}
+		trimmed = filepath.Join(base, trimmed)
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return filepath.Clean(resolved), nil
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func (engine *Engine) GrantRequestPermissions(profile RequestPermissionProfile, scope PermissionGrantScope) (func(), error) {
+	if engine == nil {
+		return nil, errors.New("sandbox engine is not configured")
+	}
+	if scope == "" {
+		scope = PermissionGrantScopeTurn
+	}
+	var cleanups []func()
+	cleanup := func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+	if engine.scope != nil && profile.FileSystem != nil {
+		for _, path := range profile.FileSystem.Read {
+			root := permissionRoot(path)
+			var undo func()
+			var err error
+			if scope == PermissionGrantScopeSession {
+				_, err = engine.scope.AddRead(root)
+			} else {
+				_, undo, err = engine.scope.AddTemporaryRead(root)
+				if undo != nil {
+					cleanups = append(cleanups, undo)
+				}
+			}
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("grant read permission %s: %w", path, err)
+			}
+		}
+		for _, path := range profile.FileSystem.Write {
+			root := permissionRoot(path)
+			var undo func()
+			var err error
+			if scope == PermissionGrantScopeSession {
+				_, err = engine.scope.Add(root)
+			} else {
+				_, undo, err = engine.scope.AddTemporaryWrite(root)
+				if undo != nil {
+					cleanups = append(cleanups, undo)
+				}
+			}
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("grant write permission %s: %w", path, err)
+			}
+		}
+	}
+	switch scope {
+	case PermissionGrantScopeSession:
+		engine.sessionProfiles.add(profile)
+		return func() {}, nil
+	case PermissionGrantScopeTurn:
+		remove := engine.turnProfiles.add(profile)
+		cleanups = append(cleanups, remove)
+		return cleanup, nil
+	default:
+		cleanup()
+		return nil, fmt.Errorf("unsupported permission grant scope %q", scope)
+	}
+}
+
+func permissionRoot(path string) string {
+	clean := filepath.Clean(path)
+	if info, err := os.Stat(clean); err == nil && info.IsDir() {
+		return clean
+	}
+	return filepath.Dir(clean)
+}
+
+func (engine *Engine) effectivePolicy(policy Policy) Policy {
+	if engine == nil {
+		return policy
+	}
+	for _, profile := range engine.sessionProfiles.list() {
+		policy = applyRequestPermissionProfile(policy, profile)
+	}
+	for _, profile := range engine.turnProfiles.list() {
+		policy = applyRequestPermissionProfile(policy, profile)
+	}
+	return policy
+}
+
+func applyRequestPermissionProfile(policy Policy, profile RequestPermissionProfile) Policy {
+	if profile.Network != nil && profile.Network.Enabled != nil && *profile.Network.Enabled {
+		policy.Network = NetworkAllow
+		policy.AllowedDomains = nil
+		policy.DeniedDomains = nil
+	}
+	if profile.FileSystem != nil {
+		policy.AllowRead = dedupeStrings(append(policy.AllowRead, profile.FileSystem.Read...))
+		policy.AllowWrite = dedupeStrings(append(policy.AllowWrite, profile.FileSystem.Write...))
+		policy.DenyRead = dedupeStrings(append(policy.DenyRead, profile.FileSystem.DenyRead...))
+	}
+	return policy
+}
+
+type memoryGrantSet struct {
+	mu     sync.Mutex
+	grants map[string][]Grant
+}
+
+func newMemoryGrantSet() *memoryGrantSet {
+	return &memoryGrantSet{grants: map[string][]Grant{}}
+}
+
+func (set *memoryGrantSet) add(grant Grant) {
+	if set == nil {
+		return
+	}
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	bucket := set.grants[grant.ToolName]
+	for index := range bucket {
+		if bucket[index].Scope == grant.Scope && bucket[index].ScopeKind == grant.ScopeKind {
+			bucket[index] = grant
+			set.grants[grant.ToolName] = bucket
+			return
+		}
+	}
+	set.grants[grant.ToolName] = append(bucket, grant)
+}
+
+func (set *memoryGrantSet) lookup(toolName string, reqScope string, requested Autonomy) GrantLookup {
+	if set == nil {
+		return GrantLookup{}
+	}
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	return lookupGrantBucket(set.grants[strings.TrimSpace(toolName)], reqScope, requested)
+}
+
+type permissionProfileGrantSet struct {
+	mu       sync.Mutex
+	nextID   int
+	profiles map[int]RequestPermissionProfile
+}
+
+func newPermissionProfileGrantSet() *permissionProfileGrantSet {
+	return &permissionProfileGrantSet{profiles: map[int]RequestPermissionProfile{}}
+}
+
+func (set *permissionProfileGrantSet) add(profile RequestPermissionProfile) func() {
+	if set == nil {
+		return func() {}
+	}
+	set.mu.Lock()
+	set.nextID++
+	id := set.nextID
+	set.profiles[id] = profile
+	set.mu.Unlock()
+	return func() {
+		set.mu.Lock()
+		delete(set.profiles, id)
+		set.mu.Unlock()
+	}
+}
+
+func (set *permissionProfileGrantSet) list() []RequestPermissionProfile {
+	if set == nil {
+		return nil
+	}
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	out := make([]RequestPermissionProfile, 0, len(set.profiles))
+	for _, profile := range set.profiles {
+		out = append(out, profile)
+	}
+	return out
+}

--- a/internal/sandbox/request_permissions_test.go
+++ b/internal/sandbox/request_permissions_test.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -139,6 +140,50 @@ func TestPermissionProfileIncludesReadOnlyGrantAsReadRootOnly(t *testing.T) {
 		if root.Root == expectedReadRoot {
 			t.Fatalf("read-only grant must not become writable, write roots = %#v", profile.FileSystem.WriteRoots)
 		}
+	}
+}
+
+func TestRequestPermissionGrantProfileWidensFilesToGrantRoots(t *testing.T) {
+	workspace := t.TempDir()
+	readDir := filepath.Join(workspace, "read")
+	writeDir := filepath.Join(workspace, "write")
+	if err := os.MkdirAll(readDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(writeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	readFile := filepath.Join(readDir, "secret.txt")
+	writeFile := filepath.Join(writeDir, "output.txt")
+	if err := os.WriteFile(readFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	grant, err := RequestPermissionGrantProfile(RequestPermissionProfile{
+		FileSystem: &FileSystemPermissions{
+			Read:  []string{readFile},
+			Write: []string{writeFile},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.FileSystem == nil {
+		t.Fatal("expected filesystem grant")
+	}
+	expectedReadRoot, err := normalizeScopeRoot(readDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedWriteRoot, err := normalizeScopeRoot(writeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grant.FileSystem.Read) != 1 || grant.FileSystem.Read[0] != expectedReadRoot {
+		t.Fatalf("read grant roots = %#v, want %#v", grant.FileSystem.Read, []string{expectedReadRoot})
+	}
+	if len(grant.FileSystem.Write) != 1 || grant.FileSystem.Write[0] != expectedWriteRoot {
+		t.Fatalf("write grant roots = %#v, want %#v", grant.FileSystem.Write, []string{expectedWriteRoot})
 	}
 }
 

--- a/internal/sandbox/request_permissions_test.go
+++ b/internal/sandbox/request_permissions_test.go
@@ -1,0 +1,152 @@
+package sandbox
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestGrantRequestPermissionsReadDoesNotGrantWrite(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "notes.txt")
+	scope, err := NewScope(workspace, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: workspace,
+		Policy:        DefaultPolicy(),
+		Scope:         scope,
+	})
+
+	cleanup, err := engine.GrantRequestPermissions(RequestPermissionProfile{
+		FileSystem: &FileSystemPermissions{Read: []string{outside}},
+	}, PermissionGrantScopeTurn)
+	if err != nil {
+		t.Fatalf("GrantRequestPermissions: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	read := engine.Evaluate(context.Background(), Request{
+		WorkspaceRoot: workspace,
+		ToolName:      "read_file",
+		SideEffect:    SideEffectRead,
+		Permission:    PermissionAllow,
+		Args:          map[string]any{"path": target},
+	})
+	if read.Action != ActionAllow {
+		t.Fatalf("read grant should allow reads, got %#v", read)
+	}
+	write := engine.Evaluate(context.Background(), Request{
+		WorkspaceRoot: workspace,
+		ToolName:      "write_file",
+		SideEffect:    SideEffectWrite,
+		Permission:    PermissionAllow,
+		Args:          map[string]any{"path": target},
+	})
+	if write.Action != ActionDeny {
+		t.Fatalf("read grant must not allow writes, got %#v", write)
+	}
+
+	cleanup()
+	readAfterCleanup := engine.Evaluate(context.Background(), Request{
+		WorkspaceRoot: workspace,
+		ToolName:      "read_file",
+		SideEffect:    SideEffectRead,
+		Permission:    PermissionAllow,
+		Args:          map[string]any{"path": target},
+	})
+	if readAfterCleanup.Action != ActionDeny {
+		t.Fatalf("turn read grant should be cleaned up, got %#v", readAfterCleanup)
+	}
+}
+
+func TestGrantRequestPermissionsNetworkOverlaysPolicyForTurn(t *testing.T) {
+	workspace := t.TempDir()
+	policy := DefaultPolicy()
+	policy.EnforceToolNetwork = true
+	engine := NewEngine(EngineOptions{WorkspaceRoot: workspace, Policy: policy})
+	request := Request{
+		WorkspaceRoot: workspace,
+		ToolName:      "web_fetch",
+		SideEffect:    SideEffectNetwork,
+		Permission:    PermissionAllow,
+		Args:          map[string]any{"url": "https://example.com"},
+	}
+	if before := engine.Evaluate(context.Background(), request); before.Action != ActionDeny {
+		t.Fatalf("default policy should deny shell network, got %#v", before)
+	}
+	enabled := true
+	cleanup, err := engine.GrantRequestPermissions(RequestPermissionProfile{
+		Network: &NetworkPermissions{Enabled: &enabled},
+	}, PermissionGrantScopeTurn)
+	if err != nil {
+		t.Fatalf("GrantRequestPermissions: %v", err)
+	}
+	if after := engine.Evaluate(context.Background(), request); after.Action != ActionAllow {
+		t.Fatalf("network turn grant should allow shell network, got %#v", after)
+	}
+	cleanup()
+	if afterCleanup := engine.Evaluate(context.Background(), request); afterCleanup.Action != ActionDeny {
+		t.Fatalf("network turn grant should be cleaned up, got %#v", afterCleanup)
+	}
+}
+
+func TestGrantRequestPermissionsSessionPersists(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "notes.txt")
+	engine := NewEngine(EngineOptions{WorkspaceRoot: workspace, Policy: DefaultPolicy()})
+
+	cleanup, err := engine.GrantRequestPermissions(RequestPermissionProfile{
+		FileSystem: &FileSystemPermissions{Write: []string{outside}},
+	}, PermissionGrantScopeSession)
+	if err != nil {
+		t.Fatalf("GrantRequestPermissions: %v", err)
+	}
+	cleanup()
+
+	decision := engine.Evaluate(context.Background(), Request{
+		WorkspaceRoot: workspace,
+		ToolName:      "write_file",
+		SideEffect:    SideEffectWrite,
+		Permission:    PermissionAllow,
+		Args:          map[string]any{"path": target},
+	})
+	if decision.Action != ActionAllow {
+		t.Fatalf("session grant should persist after cleanup no-op, got %#v", decision)
+	}
+}
+
+func TestPermissionProfileIncludesReadOnlyGrantAsReadRootOnly(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	scope, err := NewScope(workspace, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	expectedReadRoot, err := scope.AddRead(outside)
+	if err != nil {
+		t.Fatalf("AddRead: %v", err)
+	}
+
+	profile := PermissionProfileFromPolicy(workspace, DefaultPolicy(), scope)
+	if !containsString(profile.FileSystem.ReadRoots, expectedReadRoot) {
+		t.Fatalf("read roots = %#v, want %s", profile.FileSystem.ReadRoots, expectedReadRoot)
+	}
+	for _, root := range profile.FileSystem.WriteRoots {
+		if root.Root == expectedReadRoot {
+			t.Fatalf("read-only grant must not become writable, write roots = %#v", profile.FileSystem.WriteRoots)
+		}
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -166,7 +166,8 @@ func (engine *Engine) writeRoots(workspaceRoot string) []string {
 	// sandboxed shell command may write where the policy grants writes. DenyWrite
 	// is enforced at the policy gate, and on sandbox-exec additionally as an
 	// explicit deny rule (see sandboxExecProfile).
-	if extra := resolveWriteRootPaths(engine.policy.AllowWrite); len(extra) > 0 {
+	policy := engine.effectivePolicy(engine.policy)
+	if extra := resolveWriteRootPaths(policy.AllowWrite); len(extra) > 0 {
 		roots = dedupeStrings(append(roots, extra...))
 	}
 	return roots
@@ -176,7 +177,7 @@ func (engine *Engine) BuildCommandPlan(spec CommandSpec) (CommandPlan, error) {
 	if engine == nil {
 		return directCommandPlan(spec, Backend{Name: BackendPolicyOnly, Message: "sandbox disabled"}, Policy{}, ""), nil
 	}
-	policy := engine.policy
+	policy := engine.effectivePolicy(engine.policy)
 	if policy.Mode == "" {
 		policy = DefaultPolicy()
 	}

--- a/internal/sandbox/scope.go
+++ b/internal/sandbox/scope.go
@@ -16,6 +16,7 @@ import (
 type Scope struct {
 	mu            sync.RWMutex
 	workspaceRoot string
+	readRoots     []string
 	extraRoots    []string
 }
 
@@ -50,6 +51,19 @@ func (s *Scope) Roots() []string {
 	return roots
 }
 
+// ReadRoots returns the workspace root, write roots, and read-only roots as a
+// copy. Write roots are included because anything writable must also be readable
+// by the tool layer and native sandbox profile.
+func (s *Scope) ReadRoots() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	roots := make([]string, 0, 1+len(s.extraRoots)+len(s.readRoots))
+	roots = append(roots, s.workspaceRoot)
+	roots = append(roots, s.extraRoots...)
+	roots = append(roots, s.readRoots...)
+	return dedupeScopeRoots(roots)
+}
+
 // Add grants write access under path. The path must be an existing directory;
 // it is home-expanded, made absolute, and symlink-resolved before being
 // trusted, and the filesystem root is rejected outright. Adding a path already
@@ -70,6 +84,107 @@ func (s *Scope) Add(path string) (string, error) {
 	return root, nil
 }
 
+// AddRead grants read-only access under path. If the path is already covered by
+// a writable root, no separate read root is stored.
+func (s *Scope) AddRead(path string) (string, error) {
+	root, err := normalizeScopeRoot(path)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeRootCoversLocked(root) {
+		return root, nil
+	}
+	for _, existing := range s.readRoots {
+		if pathWithinRoot(existing, root) {
+			return root, nil
+		}
+	}
+	s.readRoots = append(s.readRoots, root)
+	return root, nil
+}
+
+func (s *Scope) AddTemporaryRead(path string) (string, func(), error) {
+	root, err := normalizeScopeRoot(path)
+	if err != nil {
+		return "", nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeRootCoversLocked(root) {
+		return root, func() {}, nil
+	}
+	for _, existing := range s.readRoots {
+		if pathWithinRoot(existing, root) {
+			return root, func() {}, nil
+		}
+	}
+	s.readRoots = append(s.readRoots, root)
+	return root, func() { s.removeReadRoot(root) }, nil
+}
+
+func (s *Scope) AddTemporaryWrite(path string) (string, func(), error) {
+	root, err := normalizeScopeRoot(path)
+	if err != nil {
+		return "", nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writeRootCoversLocked(root) {
+		return root, func() {}, nil
+	}
+	s.extraRoots = append(s.extraRoots, root)
+	return root, func() { s.removeWriteRoot(root) }, nil
+}
+
+func (s *Scope) writeRootCoversLocked(root string) bool {
+	for _, existing := range append([]string{s.workspaceRoot}, s.extraRoots...) {
+		if pathWithinRoot(existing, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Scope) removeReadRoot(root string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.readRoots = removeScopeRoot(s.readRoots, root)
+}
+
+func (s *Scope) removeWriteRoot(root string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.extraRoots = removeScopeRoot(s.extraRoots, root)
+}
+
+func removeScopeRoot(roots []string, root string) []string {
+	next := roots[:0]
+	for _, existing := range roots {
+		if existing != root {
+			next = append(next, existing)
+		}
+	}
+	return next
+}
+
+func dedupeScopeRoots(roots []string) []string {
+	seen := map[string]struct{}{}
+	out := roots[:0]
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		if _, ok := seen[root]; ok {
+			continue
+		}
+		seen[root] = struct{}{}
+		out = append(out, root)
+	}
+	return out
+}
+
 // validate reports whether requestedPath is allowed by any scope root.
 // Relative paths resolve against the workspace root only; absolute paths are
 // accepted if they validate (including per-segment symlink checks) under ANY
@@ -82,7 +197,21 @@ func (s *Scope) Add(path string) (string, error) {
 // only on outside_workspace results. The returned violation always carries
 // the caller's original requestedPath.
 func (s *Scope) validate(requestedPath string) *pathViolation {
-	roots := s.Roots()
+	return s.validateAgainstRoots(requestedPath, s.Roots())
+}
+
+func (s *Scope) validateRead(requestedPath string) *pathViolation {
+	return s.validateAgainstRoots(requestedPath, s.ReadRoots())
+}
+
+func (s *Scope) validateAgainstRoots(requestedPath string, roots []string) *pathViolation {
+	if len(roots) == 0 {
+		return &pathViolation{
+			Code:   ViolationOutsideWorkspace,
+			Path:   requestedPath,
+			Reason: fmt.Sprintf("%s is outside the workspace", requestedPath),
+		}
+	}
 	if !filepath.IsAbs(requestedPath) {
 		return validateWorkspacePath(roots[0], requestedPath)
 	}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -99,19 +99,20 @@ var forbiddenToolNames = map[string]bool{
 var defaultToolSelection = []string{"read-only"}
 
 var knownToolNames = map[string]bool{
-	"read_file":      true,
-	"list_directory": true,
-	"glob":           true,
-	"grep":           true,
-	"skill":          true,
-	"ask_user":       true,
-	"write_file":     true,
-	"edit_file":      true,
-	"apply_patch":    true,
-	"update_plan":    true,
-	"bash":           true,
-	"web_fetch":      true,
-	"web_search":     true,
+	"read_file":           true,
+	"list_directory":      true,
+	"glob":                true,
+	"grep":                true,
+	"skill":               true,
+	"ask_user":            true,
+	"request_permissions": true,
+	"write_file":          true,
+	"edit_file":           true,
+	"apply_patch":         true,
+	"update_plan":         true,
+	"bash":                true,
+	"web_fetch":           true,
+	"web_search":          true,
 }
 
 func DefaultPaths(workspaceRoot string) (Paths, error) {

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -304,6 +304,35 @@ func TestScopedToolsAllowExtraRootWrites(t *testing.T) {
 	}
 }
 
+func TestScopedToolsAllowReadOnlyRootsWithoutWrite(t *testing.T) {
+	workspace := t.TempDir()
+	extra := t.TempDir()
+	scope, err := sandbox.NewScope(workspace, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	if _, err := scope.AddRead(extra); err != nil {
+		t.Fatalf("AddRead: %v", err)
+	}
+	target := filepath.Join(extra, "readable.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	read := NewScopedReadFileTool(workspace, scope).Run(context.Background(), map[string]any{"path": target})
+	if read.Status != StatusOK || !strings.Contains(read.Output, "hello") {
+		t.Fatalf("read-only root read_file status=%s output=%s", read.Status, read.Output)
+	}
+	write := NewScopedWriteFileTool(workspace, scope).Run(context.Background(), map[string]any{
+		"path":      filepath.Join(extra, "created.txt"),
+		"content":   "no",
+		"overwrite": true,
+	})
+	if write.Status != StatusError {
+		t.Fatalf("read-only root write_file status=%s output=%s, want error", write.Status, write.Output)
+	}
+}
+
 func TestScopedToolsKeepRelativePathsInWorkspace(t *testing.T) {
 	workspace := t.TempDir()
 	extra := t.TempDir()

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -79,7 +79,7 @@ func (tool globTool) runWith(args map[string]any, exclude readExcluder) Result {
 		return errorResult("Error: Invalid arguments for glob: " + err.Error())
 	}
 
-	root, displayRoot, err := resolveScopedPath(tool.workspaceRoot, tool.scope, cwd)
+	root, displayRoot, err := resolveScopedReadPath(tool.workspaceRoot, tool.scope, cwd)
 	if err != nil {
 		return errorResult("Error running glob " + fmt.Sprintf("%q", pattern) + ": " + err.Error())
 	}

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -113,7 +113,7 @@ func (tool grepTool) runWith(args map[string]any, exclude readExcluder) Result {
 		return errorResult("Error running grep: " + err.Error())
 	}
 
-	target, displayRoot, err := resolveScopedPath(tool.workspaceRoot, tool.scope, targetPath)
+	target, displayRoot, err := resolveScopedReadPath(tool.workspaceRoot, tool.scope, targetPath)
 	if err != nil {
 		return errorResult("Error running grep: " + err.Error())
 	}

--- a/internal/tools/list_directory.go
+++ b/internal/tools/list_directory.go
@@ -62,7 +62,7 @@ func (tool listDirectoryTool) Run(_ context.Context, args map[string]any) Result
 		maxDepth = 0
 	}
 
-	absolutePath, relativePath, err := resolveScopedPath(tool.workspaceRoot, tool.scope, requestedPath)
+	absolutePath, relativePath, err := resolveScopedReadPath(tool.workspaceRoot, tool.scope, requestedPath)
 	if err != nil {
 		return errorResult("Error listing directory " + requestedPath + ": " + err.Error())
 	}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -63,7 +63,7 @@ func (tool readFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 		return errorResult("Error: Invalid arguments for read_file: " + err.Error())
 	}
 
-	absolutePath, relativePath, err := resolveScopedPath(tool.workspaceRoot, tool.scope, requestedPath)
+	absolutePath, relativePath, err := resolveScopedReadPath(tool.workspaceRoot, tool.scope, requestedPath)
 	if err != nil {
 		return errorResult("Error reading file " + requestedPath + ": " + err.Error())
 	}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -196,6 +196,7 @@ func CoreReadOnlyToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 		// skills.DefaultDir itself); read-only, so it is safe in the core/MCP set.
 		NewSkillTool(""),
 		NewAskUserTool(),
+		NewRequestPermissionsTool(),
 	}
 }
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -12,19 +12,25 @@ import (
 
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
-	if len(toolset) != 6 {
-		t.Fatalf("expected 6 core read-only tools, got %d", len(toolset))
+	if len(toolset) != 7 {
+		t.Fatalf("expected 7 core read-only tools, got %d", len(toolset))
 	}
 
+	seen := map[string]bool{}
 	for _, tool := range toolset {
+		seen[tool.Name()] = true
 		if tool.Name() == "" {
 			t.Fatalf("tool has empty name")
 		}
 		if tool.Description() == "" {
 			t.Fatalf("%s has empty description", tool.Name())
 		}
-		if tool.Safety().SideEffect != SideEffectRead {
-			t.Fatalf("%s side effect = %s, want read", tool.Name(), tool.Safety().SideEffect)
+		wantSideEffect := SideEffectRead
+		if tool.Name() == RequestPermissionsToolName {
+			wantSideEffect = SideEffectNone
+		}
+		if tool.Safety().SideEffect != wantSideEffect {
+			t.Fatalf("%s side effect = %s, want %s", tool.Name(), tool.Safety().SideEffect, wantSideEffect)
 		}
 		if tool.Safety().Permission != PermissionAllow {
 			t.Fatalf("%s permission = %s, want allow", tool.Name(), tool.Safety().Permission)
@@ -43,6 +49,9 @@ func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 		if schema.AdditionalProperties {
 			t.Fatalf("%s schema should disallow additional properties", tool.Name())
 		}
+	}
+	if !seen[RequestPermissionsToolName] {
+		t.Fatalf("expected %s in core read-only tools", RequestPermissionsToolName)
 	}
 }
 

--- a/internal/tools/request_permissions.go
+++ b/internal/tools/request_permissions.go
@@ -1,0 +1,111 @@
+package tools
+
+import "context"
+
+const RequestPermissionsToolName = "request_permissions"
+
+type requestPermissionsTool struct {
+	baseTool
+}
+
+func NewRequestPermissionsTool() Tool {
+	return requestPermissionsTool{
+		baseTool: baseTool{
+			name:        RequestPermissionsToolName,
+			description: "Request additional filesystem or network permissions from the user. Granted permissions apply to later tool calls in this task, or for the rest of the session when approved with session scope.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"reason": {
+						Type:        "string",
+						Description: "Optional short explanation for why additional permissions are needed.",
+					},
+					"environment_id": {
+						Type:        "string",
+						Description: "Environment id from the active environment context. Omit to use the current workspace.",
+					},
+					"permissions": requestPermissionsProfileSchema(),
+				},
+				Required:             []string{"permissions"},
+				AdditionalProperties: false,
+			},
+			safety: Safety{
+				SideEffect: SideEffectNone,
+				Permission: PermissionAllow,
+				Reason:     "Requests a user permission decision but does not read, write, run commands, or use the network.",
+			},
+		},
+	}
+}
+
+func (tool requestPermissionsTool) Run(context.Context, map[string]any) Result {
+	return errorResult("Error: request_permissions must be handled by the agent runtime.")
+}
+
+func requestPermissionsProfileSchema() PropertySchema {
+	return PropertySchema{
+		Type: "object",
+		Properties: map[string]PropertySchema{
+			"network": {
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"enabled": {
+						Type:        "boolean",
+						Description: "Set true to request network access.",
+					},
+				},
+			},
+			"file_system": {
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"read": {
+						Type:        "array",
+						Description: "Filesystem paths to read. Relative paths resolve against the workspace.",
+						Items:       &PropertySchema{Type: "string"},
+					},
+					"write": {
+						Type:        "array",
+						Description: "Filesystem paths to write. Relative paths resolve against the workspace.",
+						Items:       &PropertySchema{Type: "string"},
+					},
+					"deny_read": {
+						Type:        "array",
+						Description: "Filesystem paths to keep unreadable.",
+						Items:       &PropertySchema{Type: "string"},
+					},
+					"entries": {
+						Type:        "array",
+						Description: "Canonical filesystem permission entries.",
+						Items: &PropertySchema{
+							Type: "object",
+							Properties: map[string]PropertySchema{
+								"path": {
+									Type: "object",
+									Properties: map[string]PropertySchema{
+										"type": {
+											Type:        "string",
+											Description: "Use path for normal filesystem paths.",
+											Enum:        []string{"path"},
+										},
+										"path": {
+											Type:        "string",
+											Description: "Filesystem path. Relative paths resolve against the workspace.",
+										},
+									},
+									Required: []string{"type", "path"},
+								},
+								"access": {
+									Type:        "string",
+									Description: "Permission for this path.",
+									Enum:        []string{"read", "write", "deny"},
+								},
+							},
+							Required: []string{"path", "access"},
+						},
+					},
+				},
+			},
+		},
+		Required: []string{},
+	}
+}

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -213,6 +213,10 @@ type PathScope interface {
 	Roots() []string
 }
 
+type readPathScope interface {
+	ReadRoots() []string
+}
+
 // scopedRoots returns the ordered roots to try for an absolute path: the
 // scope's roots when present, else just the workspace root. A non-nil scope
 // must expose at least one root (the workspace root first, per PathScope); an
@@ -229,6 +233,45 @@ func scopedRoots(workspaceRoot string, scope PathScope) ([]string, error) {
 		return nil, fmt.Errorf("invalid path scope: no write roots configured")
 	}
 	return roots, nil
+}
+
+func scopedReadRoots(workspaceRoot string, scope PathScope) ([]string, error) {
+	if scope == nil {
+		return []string{workspaceRoot}, nil
+	}
+	if reader, ok := scope.(readPathScope); ok {
+		roots := reader.ReadRoots()
+		if len(roots) == 0 {
+			return nil, fmt.Errorf("invalid path scope: no read roots configured")
+		}
+		return roots, nil
+	}
+	return scopedRoots(workspaceRoot, scope)
+}
+
+func resolveScopedReadPath(workspaceRoot string, scope PathScope, requestedPath string) (string, string, error) {
+	if requestedPath == "" || !filepath.IsAbs(requestedPath) || scope == nil {
+		return resolveWorkspacePath(workspaceRoot, requestedPath)
+	}
+	roots, err := scopedReadRoots(workspaceRoot, scope)
+	if err != nil {
+		return "", "", err
+	}
+	var firstErr error
+	for index, root := range roots {
+		candidate := sandbox.NormalizePrefixForRoot(requestedPath, root)
+		absolute, relative, err := resolveWorkspacePath(root, candidate)
+		if err == nil {
+			if index > 0 {
+				return absolute, absolute, nil
+			}
+			return absolute, relative, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return "", "", firstErr
 }
 
 // resolveScopedPath is resolveWorkspacePath generalized to a scope: relative

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2216,7 +2216,7 @@ func permissionDecisionReason(decision permissionDecision) string {
 	case permissionDecisionAllow:
 		return "approved in TUI"
 	case permissionDecisionAllowStrict:
-		return "approved with strict review in TUI"
+		return "approved with model review request in TUI"
 	case permissionDecisionAllowForSession:
 		return "approved for this session in TUI"
 	case permissionDecisionAlwaysAllow:

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -315,6 +315,7 @@ type permissionDecision = agent.PermissionDecisionAction
 
 const (
 	permissionDecisionAllow           permissionDecision = agent.PermissionDecisionAllow
+	permissionDecisionAllowStrict     permissionDecision = agent.PermissionDecisionAllowStrict
 	permissionDecisionAllowForSession permissionDecision = agent.PermissionDecisionAllowForSession
 	permissionDecisionDeny            permissionDecision = agent.PermissionDecisionDeny
 	permissionDecisionAlwaysAllow     permissionDecision = agent.PermissionDecisionAlwaysAllow
@@ -686,6 +687,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.pendingSpecReview != nil {
 				return m.cancelSpecReview()
+			}
+			if m.pendingPermission != nil && m.pendingPermission.request.ToolName == tools.RequestPermissionsToolName {
+				return m.resolvePermission(permissionDecisionDeny)
 			}
 			if m.providerWizard != nil {
 				m.providerWizard = nil
@@ -2211,6 +2215,8 @@ func permissionDecisionReason(decision permissionDecision) string {
 	switch decision {
 	case permissionDecisionAllow:
 		return "approved in TUI"
+	case permissionDecisionAllowStrict:
+		return "approved with strict review in TUI"
 	case permissionDecisionAllowForSession:
 		return "approved for this session in TUI"
 	case permissionDecisionAlwaysAllow:

--- a/internal/tui/permission_prompt.go
+++ b/internal/tui/permission_prompt.go
@@ -36,6 +36,8 @@ func permissionOptions(request agent.PermissionRequest) []permissionOption {
 		switch decision {
 		case agent.PermissionDecisionAllow:
 			options = append(options, permissionOption{label: "allow once", hotkey: "a", choice: permissionDecisionAllow})
+		case agent.PermissionDecisionAllowStrict:
+			options = append(options, permissionOption{label: "allow with review", hotkey: "r", choice: permissionDecisionAllowStrict})
 		case agent.PermissionDecisionAllowForSession:
 			options = append(options, permissionOption{label: "allow for session", hotkey: "s", choice: permissionDecisionAllowForSession})
 		case agent.PermissionDecisionAlwaysAllow:

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -117,8 +117,8 @@ func TestRequestPermissionsPromptUsesGrantLabelsAndEscDenies(t *testing.T) {
 	for _, want := range []string{
 		"Grant requested permissions?",
 		"permissions: write /tmp/project",
-		"Grant for this turn",
-		"Grant for this turn and review commands",
+		"Grant for this task",
+		"Grant for this task and ask model to review commands",
 		"Grant for this session",
 		"Continue without permissions",
 		"[esc] continue without permissions",

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 func pendingPermissionModel(t *testing.T, decide func(agent.PermissionDecision)) model {
@@ -95,6 +96,49 @@ func TestPermissionOptionsCanExposePatchCancelWithoutRecoverableDeny(t *testing.
 	}
 	if strings.Contains(got, "continue without running it") || strings.Contains(got, "[d]") {
 		t.Fatalf("apply_patch approval must not show recoverable deny, got %q", got)
+	}
+}
+
+func TestRequestPermissionsPromptUsesGrantLabelsAndEscDenies(t *testing.T) {
+	request := agent.PermissionRequest{
+		ToolName: tools.RequestPermissionsToolName,
+		Action:   agent.PermissionActionPrompt,
+		Reason:   "Need write access.",
+		Scope:    "write /tmp/project",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowStrict,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionDeny,
+		},
+	}
+	card, _ := renderFocusedPermissionPrompt(request, 1, 96)
+	got := plainRender(t, card)
+	for _, want := range []string{
+		"Grant requested permissions?",
+		"permissions: write /tmp/project",
+		"Grant for this turn",
+		"Grant for this turn and review commands",
+		"Grant for this session",
+		"Continue without permissions",
+		"[esc] continue without permissions",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("request_permissions card = %q, missing %q", got, want)
+		}
+	}
+
+	var resolved agent.PermissionDecision
+	m := pendingPermissionModelWithRequest(t, request, func(d agent.PermissionDecision) {
+		resolved = d
+	})
+	updated, _ := m.Update(testKey(tea.KeyEsc))
+	m = updated.(model)
+	if resolved.Action != agent.PermissionDecisionDeny {
+		t.Fatalf("Esc should continue without permissions, got %#v", resolved)
+	}
+	if m.pendingPermission != nil {
+		t.Fatal("request_permissions prompt should clear after Esc")
 	}
 }
 

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -902,9 +902,9 @@ func permissionOptionLabel(option permissionOption, request agent.PermissionRequ
 	if request.ToolName == tools.RequestPermissionsToolName {
 		switch option.choice {
 		case permissionDecisionAllow:
-			return "Grant for this turn"
+			return "Grant for this task"
 		case permissionDecisionAllowStrict:
-			return "Grant for this turn and review commands"
+			return "Grant for this task and ask model to review commands"
 		case permissionDecisionAllowForSession:
 			return "Grant for this session"
 		case permissionDecisionDeny, permissionDecisionCancel:

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -839,7 +839,9 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	top := zeroTheme.permBadge.Render(" PERMISSION ")
 
 	body := fill(zeroTheme.amber).Bold(true).Render(name)
-	if request.SideEffect != "" {
+	if request.ToolName == tools.RequestPermissionsToolName {
+		body = fill(zeroTheme.amber).Bold(true).Render("Grant requested permissions?")
+	} else if request.SideEffect != "" {
 		body += fill(zeroTheme.ink).Render("  " + request.SideEffect)
 	}
 	lines := []string{top, body}
@@ -877,12 +879,19 @@ func renderFocusedPermissionPrompt(request agent.PermissionRequest, cursor int, 
 	}
 
 	lines = append(lines, "")
-	lines = append(lines, fill(zeroTheme.faint).Render("↑↓ move · enter or click to confirm · [esc] cancel run"))
+	footer := "↑↓ move · enter or click to confirm · [esc] cancel run"
+	if request.ToolName == tools.RequestPermissionsToolName {
+		footer = "↑↓ move · enter or click to confirm · [esc] continue without permissions"
+	}
+	lines = append(lines, fill(zeroTheme.faint).Render(footer))
 
 	return styledBlockFill(width, lines, zeroTheme.permBorder, zeroTheme.permBg), offsets
 }
 
 func permissionScopeLine(request agent.PermissionRequest, scope string) string {
+	if request.ToolName == tools.RequestPermissionsToolName {
+		return "permissions: " + scope
+	}
 	if request.SideEffect == string(tools.SideEffectNetwork) {
 		return "target: " + scope
 	}
@@ -890,6 +899,20 @@ func permissionScopeLine(request agent.PermissionRequest, scope string) string {
 }
 
 func permissionOptionLabel(option permissionOption, request agent.PermissionRequest) string {
+	if request.ToolName == tools.RequestPermissionsToolName {
+		switch option.choice {
+		case permissionDecisionAllow:
+			return "Grant for this turn"
+		case permissionDecisionAllowStrict:
+			return "Grant for this turn and review commands"
+		case permissionDecisionAllowForSession:
+			return "Grant for this session"
+		case permissionDecisionDeny, permissionDecisionCancel:
+			return "Continue without permissions"
+		default:
+			return option.label
+		}
+	}
 	switch option.choice {
 	case permissionDecisionAllow:
 		if request.SideEffect == string(tools.SideEffectNetwork) {


### PR DESCRIPTION
## Summary
- add a runtime-handled request_permissions tool for temporary turn/session filesystem and network grants
- thread granted read/write/network profiles through sandbox policy, scope, command planning, and native sandbox profiles
- update the TUI prompt with request-specific grant choices, strict-review response support, and Esc-as-continue-without-permissions

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `request_permissions` tool to request turn- or session-scoped network and filesystem permissions, with a “allow with review” strict option.
  * Updated the permissions prompt UI for `request_permissions`, including clearer grant labels and “[esc] continue without permissions”.

* **Bug Fixes**
  * Improved read-only scoping: read paths are validated against read roots to allow reads while preventing writes.
  * Refined permission decision handling and turn-scoped permission cleanup/undo behavior.

* **Tests**
  * Added unit tests covering granting, denial/continuation, strict-review output, and cleanup/enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->