### PR TITLE
redaction: catch compound secret keys + non-bearer auth schemes; stop scanner over-redaction

### DIFF
--- a/internal/redaction/audit_fixes_test.go
+++ b/internal/redaction/audit_fixes_test.go
@@ -1,0 +1,123 @@
+package redaction
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSensitiveKey_CompoundAndTokenCounts(t *testing.T) {
+	o := Options{}
+	sensitive := []string{
+		"db_password", "smtp_password", "user_password",
+		"session_secret", "webhook_secret", "stripe_secret_key", "client-secret",
+		"auth_token", "csrf_token", "vault_token", "my_token", "xsrf-token",
+		"ssh_private_key", "rsa_private_key",
+		"backup_api_key", "my_apikey", "service_apikey",
+		"db_passphrase", "aws_credential", "gcp_credentials",
+	}
+	for _, k := range sensitive {
+		if !IsSensitiveKey(k, o) {
+			t.Errorf("expected %q to be sensitive", k)
+		}
+	}
+	// CRITICAL: token-count and ordinary "*_key" fields must NOT be redacted —
+	// they are everywhere in an LLM agent and redacting them would break it.
+	notSensitive := []string{
+		"max_tokens", "prompt_tokens", "completion_tokens", "total_tokens",
+		"input_tokens", "output_tokens", "reasoning_tokens", "tokens",
+		"token_count", "token_usage", "tokens_used",
+		"primary_key", "public_key", "cache_key", "foreign_key", "sort_key",
+		"idempotency_key", "key", "key_name", "api_version", "username", "message",
+	}
+	for _, k := range notSensitive {
+		if IsSensitiveKey(k, o) {
+			t.Errorf("expected %q to NOT be sensitive (false positive)", k)
+		}
+	}
+}
+
+func TestRedactString_CompoundKeyForms(t *testing.T) {
+	o := Options{}
+	cases := []struct{ in, secret string }{
+		{"db_password=hunter2supersecret", "hunter2supersecret"},
+		{`{"stripe_secret_key": "rk_live_plaintextvalue"}`, "rk_live_plaintextvalue"},
+		{"GET /x?session_secret=plainsecretvalue HTTP/1.1", "plainsecretvalue"},
+		{"auth_token='opaque-assigned-token-value'", "opaque-assigned-token-value"},
+	}
+	for _, c := range cases {
+		out := RedactString(c.in, o)
+		if strings.Contains(out, c.secret) {
+			t.Errorf("RedactString(%q) leaked %q: got %q", c.in, c.secret, out)
+		}
+		if !strings.Contains(out, RedactedSecret) {
+			t.Errorf("RedactString(%q) should contain %q: got %q", c.in, RedactedSecret, out)
+		}
+	}
+	// Token-count lines must pass through untouched.
+	for _, c := range []string{"max_tokens: 4096", "prompt_tokens=128", "token_count: 50"} {
+		if out := RedactString(c, o); out != c {
+			t.Errorf("RedactString(%q) should be unchanged, got %q", c, out)
+		}
+	}
+}
+
+func TestRedactString_AuthHeaderSchemes(t *testing.T) {
+	o := Options{}
+	// Opaque values (no token-format prefix) so only the header/colon logic can
+	// redact them — isolates the auth-scheme fix from the text-pattern fallback.
+	cases := []struct{ in, secret string }{
+		{"Authorization: Bearer opaquebearervalue1234567", "opaquebearervalue1234567"},
+		{"Authorization: token opaquetokenvalue1234567", "opaquetokenvalue1234567"},
+		{"Authorization: ApiKey opaqueapikeyvalue1234567", "opaqueapikeyvalue1234567"},
+		{"Proxy-Authorization: Digest opaquedigestvalue1234", "opaquedigestvalue1234"},
+	}
+	for _, c := range cases {
+		out := RedactString(c.in, o)
+		if strings.Contains(out, c.secret) {
+			t.Errorf("RedactString(%q) leaked %q: got %q", c.in, c.secret, out)
+		}
+	}
+}
+
+// Guard against re-introducing an over-broad "key: value" pattern: a
+// "file.go:line: message" line (universal in test/compiler output, where the
+// filename may even contain a secret-looking segment) must keep its structure so
+// downstream parsers still work. Only an actual secret VALUE on the line is
+// redacted (by the token-format patterns), never the file:line prefix.
+func TestRedactString_PreservesFileLineColons(t *testing.T) {
+	o := Options{}
+	in := "    secret_test.go:12: token sk-proj-abcdefghijklmnopqrstuvwxyz"
+	out := RedactString(in, o)
+	if !strings.Contains(out, "secret_test.go:12:") {
+		t.Errorf("file:line prefix mangled: %q", out)
+	}
+	if strings.Contains(out, "sk-proj-abcdefghijklmnopqrstuvwxyz") {
+		t.Errorf("secret leaked: %q", out)
+	}
+	if !strings.Contains(out, RedactedSecret) {
+		t.Errorf("expected the token to be redacted: %q", out)
+	}
+}
+
+func TestRedactValue_CompoundKeys(t *testing.T) {
+	o := Options{}
+	in := map[string]any{
+		"db_password": "plainpw",
+		"max_tokens":  4096,
+		"nested":      map[string]any{"session_secret": "innersecretvalue"},
+	}
+	out, ok := RedactValue(in, o).(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", RedactValue(in, o))
+	}
+	if out["db_password"] != RedactedSecret {
+		t.Errorf("db_password not redacted: %v", out["db_password"])
+	}
+	if out["max_tokens"] != int64(4096) {
+		t.Errorf("max_tokens should be preserved as 4096, got %v (%T)", out["max_tokens"], out["max_tokens"])
+	}
+	inner := out["nested"].(map[string]any)
+	if inner["session_secret"] != RedactedSecret {
+		t.Errorf("nested session_secret not redacted: %v", inner["session_secret"])
+	}
+}

--- a/internal/redaction/audit_fixes_test.go
+++ b/internal/redaction/audit_fixes_test.go
@@ -79,6 +79,42 @@ func TestRedactString_AuthHeaderSchemes(t *testing.T) {
 	}
 }
 
+// Parameterized schemes spread the secret across comma-separated params, so the
+// WHOLE value after the scheme must be redacted — not just the first token.
+func TestRedactString_MultiPartAuthSchemes(t *testing.T) {
+	o := Options{}
+	cases := []struct {
+		in      string
+		leaked  []string // every one of these must be gone
+		keepsch string   // scheme name that should remain visible
+	}{
+		{
+			in:      `Authorization: Digest username="alice", realm="api", nonce="abc123", uri="/x", response="deadbeefcafef00ddeadbeefcafef00d", qop=auth`,
+			leaked:  []string{"deadbeefcafef00ddeadbeefcafef00d", `nonce="abc123"`, `username="alice"`},
+			keepsch: "Digest",
+		},
+		{
+			in:      `Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260618/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024`,
+			leaked:  []string{"fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024", "SignedHeaders=host;x-amz-date", "AKIAIOSFODNN7EXAMPLE"},
+			keepsch: "AWS4-HMAC-SHA256",
+		},
+	}
+	for _, c := range cases {
+		out := RedactString(c.in, o)
+		for _, secret := range c.leaked {
+			if strings.Contains(out, secret) {
+				t.Errorf("multi-part header leaked %q\n  in:  %s\n  out: %s", secret, c.in, out)
+			}
+		}
+		if !strings.Contains(out, c.keepsch) {
+			t.Errorf("scheme %q should remain visible, got: %s", c.keepsch, out)
+		}
+		if !strings.Contains(out, RedactedSecret) {
+			t.Errorf("expected a redaction marker, got: %s", out)
+		}
+	}
+}
+
 // Guard against re-introducing an over-broad "key: value" pattern: a
 // "file.go:line: message" line (universal in test/compiler output, where the
 // filename may even contain a secret-looking segment) must keep its structure so

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -83,9 +83,14 @@ var (
 	privateKeyPattern = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
 	jsonStringPattern = regexp.MustCompile(`("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)"([^"\\]*(?:\\.[^"\\]*)*)"`)
 	assignPattern     = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s&]+))`)
-	headerPattern     = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(bearer|basic|token|apikey|api-key|digest|negotiate|oauth|aws4-hmac-sha256)\s+([^\s,;]+)`)
-	secretHeader      = regexp.MustCompile(`(?i)\b(x-api-key|api-key|cookie|set-cookie)\s*:\s*([^\r\n]+)`)
-	queryPattern      = regexp.MustCompile(`([?&])([^=&#\s]+)=([^&#\s]+)`)
+	// Redact the ENTIRE credential after the scheme (to end of line), not just the
+	// first token: parameterized schemes (Digest, OAuth, AWS4-HMAC-SHA256) spread
+	// the secret across comma-separated params (…, response=…, Signature=…), so a
+	// single-token capture would leave the actual secret visible. The scheme name
+	// is kept; only the value is replaced.
+	headerPattern = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(bearer|basic|token|apikey|api-key|digest|negotiate|oauth|aws4-hmac-sha256)\s+([^\r\n]+)`)
+	secretHeader  = regexp.MustCompile(`(?i)\b(x-api-key|api-key|cookie|set-cookie)\s*:\s*([^\r\n]+)`)
+	queryPattern  = regexp.MustCompile(`([?&])([^=&#\s]+)=([^&#\s]+)`)
 )
 
 func IsSensitiveKey(key string, options Options) bool {

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -83,7 +83,7 @@ var (
 	privateKeyPattern = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
 	jsonStringPattern = regexp.MustCompile(`("([^"\\]*(?:\\.[^"\\]*)*)"\s*:\s*)"([^"\\]*(?:\\.[^"\\]*)*)"`)
 	assignPattern     = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_.-]*)(\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s&]+))`)
-	headerPattern     = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(bearer|basic)\s+([^\s,;]+)`)
+	headerPattern     = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(bearer|basic|token|apikey|api-key|digest|negotiate|oauth|aws4-hmac-sha256)\s+([^\s,;]+)`)
 	secretHeader      = regexp.MustCompile(`(?i)\b(x-api-key|api-key|cookie|set-cookie)\s*:\s*([^\r\n]+)`)
 	queryPattern      = regexp.MustCompile(`([?&])([^=&#\s]+)=([^&#\s]+)`)
 )
@@ -99,6 +99,49 @@ func IsSensitiveKey(key string, options Options) bool {
 	for _, extra := range options.ExtraSensitiveKeys {
 		if normalizeKey(extra) == normalized {
 			return true
+		}
+	}
+	return keyLooksSensitive(normalized)
+}
+
+// secretKeySegments are "_"-delimited segments that mark the whole key sensitive
+// even when the full name isn't in the exact list, so compound names like
+// db_password, session_secret, and stripe_secret_key are caught. "token" is
+// handled separately (suffix-only, in keyLooksSensitive) so the agent's many
+// token-COUNT fields (max_tokens, prompt_tokens, token_count) are never redacted.
+var secretKeySegments = map[string]struct{}{
+	"password":    {},
+	"passwd":      {},
+	"passphrase":  {},
+	"secret":      {},
+	"credential":  {},
+	"credentials": {},
+	"apikey":      {},
+}
+
+// keyLooksSensitive applies conservative structural heuristics to a normalized
+// key (already lower-cased and "_"-delimited by normalizeKey). It is deliberately
+// narrow: a bare "token"/"key" segment is NOT enough, so token-count and ordinary
+// "*_key" fields (max_tokens, primary_key, public_key) stay un-redacted.
+func keyLooksSensitive(normalized string) bool {
+	segments := strings.Split(normalized, "_")
+	for i, seg := range segments {
+		if _, ok := secretKeySegments[seg]; ok {
+			return true
+		}
+		// "<x>_token" (singular, trailing) is a credential — auth_token, csrf_token,
+		// vault_token. NOT "tokens" (plural count) and NOT "token_<x>" (token_count,
+		// token_usage), where token is pluralized or not the trailing segment.
+		if seg == "token" && i > 0 && i == len(segments)-1 {
+			return true
+		}
+		// "api_key" / "private_key" as adjacent segments. A bare "key" stays
+		// non-sensitive (primary_key, public_key, cache_key, foreign_key, …).
+		if seg == "key" && i > 0 {
+			switch segments[i-1] {
+			case "api", "private":
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/secrets/boundary_test.go
+++ b/internal/secrets/boundary_test.go
@@ -1,0 +1,38 @@
+package secrets
+
+import "testing"
+
+// Kebab-case words must NOT be redacted: "sk-" inside "task"/"ask"/"risk"/etc.
+// is not an openai_key. This is the over-redaction the \b anchors fix.
+func TestScan_NoOverRedactionOnKebabWords(t *testing.T) {
+	clean := []string{
+		"see task-management-and-coordination-plan for the roadmap",
+		"we should ask-the-user-about-this-before-proceeding now",
+		"the risk-assessment-and-mitigation-strategy-doc is ready",
+		"disk-usage-monitoring-and-alerting-subsystem looks good",
+		"desk-booking-and-reservation-management-flow updated",
+	}
+	for _, c := range clean {
+		red, f := Redact(c)
+		if len(f) != 0 || red != c {
+			t.Errorf("over-redacted %q -> %q (findings=%d)", c, red, len(f))
+		}
+	}
+}
+
+// Real secrets preceded by a delimiter (space, =, :, quote, start) still match —
+// the \b is satisfied by all of those, so the fix loses no real coverage.
+func TestScan_RealSecretsStillCaught(t *testing.T) {
+	cases := []string{
+		"export OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwx",
+		`token: "sk-abcdefghijklmnopqrstuvwxyz"`,
+		"key is sk-svcacct-abcdefghijklmnopqrstuvwx at the end",
+		"github_pat_11ABCDEFG0abcdefghijklmnopqrst",
+		"creds AKIAIOSFODNN7EXAMPLE here",
+	}
+	for _, c := range cases {
+		if _, f := Redact(c); len(f) == 0 {
+			t.Errorf("real secret NOT caught in %q", c)
+		}
+	}
+}

--- a/internal/secrets/scanner.go
+++ b/internal/secrets/scanner.go
@@ -26,19 +26,23 @@ type pattern struct {
 
 // patterns are intentionally specific (fixed prefixes / structural shapes) so
 // they don't fire on arbitrary identifiers.
+// A leading \b anchors each prefixed pattern to a word boundary so it can't fire
+// mid-word — e.g. "sk-" inside "task-management-and-coordination" must NOT match
+// as an openai_key. Real secrets are preceded by a delimiter (space, quote, =, :,
+// start-of-string), all of which satisfy \b.
 var patterns = []pattern{
-	{"aws_access_key_id", regexp.MustCompile(`AKIA[0-9A-Z]{16}`)},
-	{"github_token", regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{36}`)},
-	{"github_pat", regexp.MustCompile(`github_pat_[A-Za-z0-9_]{22,}`)},
-	{"slack_token", regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)},
-	{"google_api_key", regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`)},
+	{"aws_access_key_id", regexp.MustCompile(`\bAKIA[0-9A-Z]{16}`)},
+	{"github_token", regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36}`)},
+	{"github_pat", regexp.MustCompile(`\bgithub_pat_[A-Za-z0-9_]{22,}`)},
+	{"slack_token", regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}`)},
+	{"google_api_key", regexp.MustCompile(`\bAIza[0-9A-Za-z\-_]{35}`)},
 	// Body allows - and _ so modern prefixed keys (sk-proj-…, sk-svcacct-…) match,
 	// not just the legacy sk-<alnum> shape.
-	{"openai_key", regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`)},
+	{"openai_key", regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}`)},
 	// Match the ENTIRE PEM/OpenSSH block (header THROUGH the END marker, body
 	// included) so redaction removes the key material, not just the header.
 	{"private_key_block", regexp.MustCompile(`(?s)-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----.*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},
-	{"jwt", regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
+	{"jwt", regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
 }
 
 // Scan returns the distinct secrets found in text (deduplicated by match,


### PR DESCRIPTION
Audit of `internal/redaction` + `internal/secrets` surfaced three verified gaps in the secret-redaction last line of defense. The configured provider key is already exact-scrubbed; these affect **secondary** secrets that appear in tool/command output.

## Fixes
1. **Compound secret keys** *(leak)* — `IsSensitiveKey` was exact-match, so `db_password`, `session_secret`, `stripe_secret_key`, `auth_token`, `csrf_token`, `ssh_private_key`, `backup_api_key` … passed through. New `keyLooksSensitive` uses conservative structural rules. **Critically token-count-safe:** `max_tokens` / `prompt_tokens` / `token_count` and ordinary `primary_key` / `public_key` / `cache_key` are **not** redacted (`token` only triggers as a singular trailing segment; bare `key` never triggers).
2. **Auth header schemes** *(leak)* — `Authorization:` now redacts `token` / `apikey` / `digest` / `negotiate` / `oauth` / `aws4-hmac-sha256`, not just `bearer`/`basic`.
3. **Scanner over-redaction** *(correctness)* — added `\b` to the prefixed patterns so kebab-case words (`task-…`, `ask-…`, `risk-…`) no longer match as a fake key, while real secrets (preceded by space/`=`/`:`/quote/start) still match.

## Deliberately not shipped
A free-text `key: value` colon pattern — it mangled `file.go:line: message` output (a filename's `secret` segment read as a sensitive key), the same over-redaction class fix #3 addresses. Structured paths (`RedactValue`, plus assign/JSON/query in `RedactString`) are covered; free-text colon-form is left as a known limitation, with `TestRedactString_PreservesFileLineColons` guarding against re-introduction.

## Tests
`audit_fixes_test.go` (compound-key + token-count matrix, auth schemes, file:line guard, `RedactValue` nesting) and `boundary_test.go` (scanner over-redaction negatives + real-secret positives). `gofmt` · `go vet` · `staticcheck` · `-race` on redaction+secrets+verify · 9 consumer packages — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sensitive field detection with enhanced heuristics for identifying secret-like keys
  * Expanded HTTP header redaction to support additional authentication schemes
  * Fixed secret detection patterns to reduce false positives by requiring word boundaries in pattern matching

* **Tests**
  * Added comprehensive test coverage for redaction behavior and secret detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->