### PR TITLE
Add session command prefix approvals

### DIFF
--- a/internal/agent/command_prefix.go
+++ b/internal/agent/command_prefix.go
@@ -1,0 +1,240 @@
+package agent
+
+import (
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var bannedCommandPrefixSuggestions = [][]string{
+	{"python3"},
+	{"python3", "-"},
+	{"python3", "-c"},
+	{"python"},
+	{"python", "-"},
+	{"python", "-c"},
+	{"py"},
+	{"py", "-3"},
+	{"pythonw"},
+	{"pyw"},
+	{"pypy"},
+	{"pypy3"},
+	{"git"},
+	{"bash"},
+	{"bash", "-lc"},
+	{"sh"},
+	{"sh", "-c"},
+	{"sh", "-lc"},
+	{"zsh"},
+	{"zsh", "-lc"},
+	{"/bin/zsh"},
+	{"/bin/zsh", "-lc"},
+	{"/bin/bash"},
+	{"/bin/bash", "-lc"},
+	{"pwsh"},
+	{"pwsh", "-Command"},
+	{"pwsh", "-c"},
+	{"powershell"},
+	{"powershell", "-Command"},
+	{"powershell", "-c"},
+	{"powershell.exe"},
+	{"powershell.exe", "-Command"},
+	{"powershell.exe", "-c"},
+	{"env"},
+	{"sudo"},
+	{"node"},
+	{"node", "-e"},
+	{"perl"},
+	{"perl", "-e"},
+	{"ruby"},
+	{"ruby", "-e"},
+	{"php"},
+	{"php", "-r"},
+	{"lua"},
+	{"lua", "-e"},
+	{"osascript"},
+}
+
+func proposedCommandPrefix(toolName string, args map[string]any) []string {
+	if toolName != "bash" {
+		return nil
+	}
+	command, ok := firstStringArg(args, "command", "cmd", "script", "shell")
+	if !ok {
+		return nil
+	}
+	tokens, ok := safeShellCommandTokens(command)
+	if !ok {
+		return nil
+	}
+	if requested, ok := requestedPrefixRule(args); ok {
+		if safeRequestedPrefix(requested, tokens) {
+			return requested
+		}
+		return nil
+	}
+	if unsafeCommandPrefix(tokens) {
+		return nil
+	}
+	return append([]string(nil), tokens...)
+}
+
+func matchSessionCommandPrefix(toolName string, args map[string]any, options Options) (sandbox.CommandPrefixGrant, bool) {
+	if toolName != "bash" || options.Sandbox == nil {
+		return sandbox.CommandPrefixGrant{}, false
+	}
+	command, ok := firstStringArg(args, "command", "cmd", "script", "shell")
+	if !ok {
+		return sandbox.CommandPrefixGrant{}, false
+	}
+	tokens, ok := safeShellCommandTokens(command)
+	if !ok {
+		return sandbox.CommandPrefixGrant{}, false
+	}
+	return options.Sandbox.LookupCommandPrefixForSession(toolName, tokens)
+}
+
+func firstStringArg(args map[string]any, names ...string) (string, bool) {
+	for _, name := range names {
+		if raw, ok := args[name].(string); ok {
+			value := strings.TrimSpace(raw)
+			if value != "" {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func requestedPrefixRule(args map[string]any) ([]string, bool) {
+	raw, ok := args["prefix_rule"]
+	if !ok {
+		return nil, false
+	}
+	switch value := raw.(type) {
+	case []string:
+		return cleanPrefixRule(value), true
+	case []any:
+		out := make([]string, 0, len(value))
+		for _, item := range value {
+			part, ok := item.(string)
+			if !ok {
+				return nil, true
+			}
+			out = append(out, part)
+		}
+		return cleanPrefixRule(out), true
+	default:
+		return nil, true
+	}
+}
+
+func cleanPrefixRule(prefix []string) []string {
+	cleaned := make([]string, 0, len(prefix))
+	for _, part := range prefix {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		cleaned = append(cleaned, part)
+	}
+	return cleaned
+}
+
+func safeRequestedPrefix(prefix []string, command []string) bool {
+	if len(prefix) == 0 || unsafeCommandPrefix(prefix) || len(prefix) > len(command) {
+		return false
+	}
+	for index := range prefix {
+		if prefix[index] != command[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func safeShellCommandTokens(command string) ([]string, bool) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, false
+	}
+	file, err := syntax.NewParser().Parse(strings.NewReader(command), "")
+	if err != nil || len(file.Stmts) != 1 {
+		return nil, false
+	}
+	stmt := file.Stmts[0]
+	if stmt.Negated || stmt.Background || stmt.Coprocess || stmt.Disown || stmt.Semicolon.IsValid() || len(stmt.Redirs) > 0 {
+		return nil, false
+	}
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Assigns) > 0 || len(call.Args) == 0 {
+		return nil, false
+	}
+	tokens := make([]string, 0, len(call.Args))
+	for _, word := range call.Args {
+		if len(word.Parts) != 1 {
+			return nil, false
+		}
+		lit, ok := word.Parts[0].(*syntax.Lit)
+		if !ok || unsafeCommandPrefixPart(lit.Value) {
+			return nil, false
+		}
+		tokens = append(tokens, lit.Value)
+	}
+	if unsafeCommandPrefix(tokens) {
+		return nil, false
+	}
+	return tokens, true
+}
+
+func unsafeCommandPrefix(prefix []string) bool {
+	if len(prefix) == 0 {
+		return true
+	}
+	for _, part := range prefix {
+		if unsafeCommandPrefixPart(part) {
+			return true
+		}
+	}
+	for _, banned := range bannedCommandPrefixSuggestions {
+		if equalStringSlices(prefix, banned) {
+			return true
+		}
+	}
+	if unsafeCommandPrefixLauncher(prefix[0]) {
+		return true
+	}
+	return false
+}
+
+func unsafeCommandPrefixPart(part string) bool {
+	part = strings.TrimSpace(part)
+	return part == "" ||
+		strings.ContainsAny(part, "\x00\r\n*?[]{}") ||
+		strings.Contains(part, "$(") ||
+		strings.Contains(part, "`")
+}
+
+func unsafeCommandPrefixLauncher(program string) bool {
+	switch program {
+	case "bash", "sh", "zsh", "/bin/bash", "/bin/zsh",
+		"pwsh", "powershell", "powershell.exe",
+		"env", "sudo", "osascript":
+		return true
+	default:
+		return false
+	}
+}
+
+func equalStringSlices(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/command_prefix_test.go
+++ b/internal/agent/command_prefix_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import "testing"
+
+func TestProposedCommandPrefixUsesSafeSimpleCommands(t *testing.T) {
+	got := proposedCommandPrefix("bash", map[string]any{"command": "go test ./..."})
+	want := []string{"go", "test", "./..."}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("prefix = %#v, want %#v", got, want)
+	}
+}
+
+func TestProposedCommandPrefixHonorsValidatedRequestedPrefix(t *testing.T) {
+	got := proposedCommandPrefix("bash", map[string]any{
+		"command":     "git status --short",
+		"prefix_rule": []any{"git", "status"},
+	})
+	want := []string{"git", "status"}
+	if !equalStringSlices(got, want) {
+		t.Fatalf("prefix = %#v, want %#v", got, want)
+	}
+}
+
+func TestProposedCommandPrefixRejectsUnsafeRequestedPrefix(t *testing.T) {
+	got := proposedCommandPrefix("bash", map[string]any{
+		"command":     "git status --short",
+		"prefix_rule": []any{"git"},
+	})
+	if got != nil {
+		t.Fatalf("broad requested prefix should be rejected, got %#v", got)
+	}
+}
+
+func TestProposedCommandPrefixRejectsUnsafeShellForms(t *testing.T) {
+	cases := []string{
+		"echo hi && echo bye",
+		"cat < in > out",
+		"FOO=bar go test",
+		"echo $(whoami)",
+		"cat *.go",
+		"bash -lc go test",
+	}
+	for _, command := range cases {
+		t.Run(command, func(t *testing.T) {
+			if got := proposedCommandPrefix("bash", map[string]any{"command": command}); got != nil {
+				t.Fatalf("unsafe command got prefix %#v", got)
+			}
+		})
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -587,14 +587,24 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 		permissionGranted = true
 	}
 
+	decisionReason := ""
+	var decisionAction PermissionDecisionAction
+	var decisionCommandPrefix []string
+	if toolFound && !permissionGranted {
+		if grant, ok := matchSessionCommandPrefix(call.Name, args, options); ok {
+			permissionGranted = true
+			decisionAction = PermissionDecisionAllowPrefix
+			decisionReason = "session command prefix approval matched"
+			decisionCommandPrefix = grant.Prefix
+		}
+	}
+
 	var preflightDecision *sandbox.Decision
 	if toolFound && options.Sandbox != nil {
 		decision := options.Sandbox.Evaluate(ctx, sandboxRequest(call.Name, tool, args, permissionGranted, permissionMode, options))
 		preflightDecision = &decision
 	}
 
-	decisionReason := ""
-	var decisionAction PermissionDecisionAction
 	if toolFound && options.OnPermissionRequest != nil && shouldRequestPermission(tool, permissionGranted, preflightDecision) {
 		requestEvent, ok := buildPermissionEvent(call, tool, args, permissionGranted, permissionMode, options, preflightDecision)
 		if !ok {
@@ -622,6 +632,17 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 					requestEvent.GrantMatched = true
 					requestEvent.Grant = &grant
 				}
+			}
+		case PermissionDecisionAllowPrefix:
+			if len(request.CommandPrefix) == 0 {
+				emitDeniedPermission(options, call, requestEvent, decisionReason)
+				return deniedPermissionResult(call, decisionReason, requestEvent), nil
+			}
+			permissionGranted = true
+			requestEvent.DecisionAction = decision.Action
+			decisionCommandPrefix = append([]string(nil), request.CommandPrefix...)
+			if options.Sandbox != nil && len(decisionCommandPrefix) > 0 {
+				options.Sandbox.GrantCommandPrefixForSession(call.Name, decisionCommandPrefix)
 			}
 		case PermissionDecisionAlwaysAllow:
 			permissionGranted = true
@@ -683,6 +704,9 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 			event.DecisionReason = decisionReason
 			if decisionAction != "" {
 				event.DecisionAction = decisionAction
+			}
+			if len(decisionCommandPrefix) > 0 {
+				event.CommandPrefix = append([]string(nil), decisionCommandPrefix...)
 			}
 			options.OnPermission(event)
 		}
@@ -1002,7 +1026,7 @@ func requestPermission(ctx context.Context, request PermissionRequest, options O
 
 func normalizePermissionDecisionAction(action PermissionDecisionAction) PermissionDecisionAction {
 	switch action {
-	case PermissionDecisionAllow, PermissionDecisionAllowStrict, PermissionDecisionAllowForSession, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
+	case PermissionDecisionAllow, PermissionDecisionAllowStrict, PermissionDecisionAllowForSession, PermissionDecisionAllowPrefix, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
 		return action
 	default:
 		return PermissionDecisionDeny
@@ -1488,6 +1512,7 @@ func buildPermissionEvent(call ToolCall, tool tools.Tool, args map[string]any, p
 		Violation:         violation,
 		GrantMatched:      grantMatched,
 		Grant:             grant,
+		CommandPrefix:     proposedCommandPrefix(call.Name, args),
 	}, true
 }
 
@@ -1525,6 +1550,7 @@ func permissionRequestFromEvent(event PermissionEvent, args map[string]any, opti
 		Violation:          event.Violation,
 		GrantMatched:       event.GrantMatched,
 		Grant:              event.Grant,
+		CommandPrefix:      append([]string(nil), event.CommandPrefix...),
 		AvailableDecisions: availablePermissionDecisions(event, options),
 	}
 }
@@ -1536,6 +1562,9 @@ func availablePermissionDecisions(event PermissionEvent, options Options) []Perm
 	decisions := []PermissionDecisionAction{PermissionDecisionAllow}
 	if options.Sandbox != nil {
 		decisions = append(decisions, PermissionDecisionAllowForSession)
+		if event.ToolName == "bash" && len(event.CommandPrefix) > 0 {
+			decisions = append(decisions, PermissionDecisionAllowPrefix)
+		}
 		if options.Sandbox.CanPersistGrants() && permissionSupportsPersistentDecision(event.ToolName) {
 			decisions = append(decisions, PermissionDecisionAlwaysAllow)
 		}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1139,6 +1139,119 @@ func TestRunSessionAllowSkipsMatchingPromptWithoutPersistentGrant(t *testing.T) 
 	}
 }
 
+func TestRunCommandPrefixApprovalSkipsLaterMatchingBashPrompt(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "bash"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"command":"echo prefix-ok"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-2", ToolName: "bash"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-2", ArgumentsFragment: `{"command":"echo prefix-ok again"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-2"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var requests []PermissionRequest
+	var permissionEvents []PermissionEvent
+
+	result, err := Run(context.Background(), "run twice", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        sandbox.DefaultPolicy(),
+			Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			requests = append(requests, request)
+			if !containsPermissionDecision(request.AvailableDecisions, PermissionDecisionAllowPrefix) {
+				t.Fatalf("bash prompt missing prefix approval decision: %#v", request.AvailableDecisions)
+			}
+			if !equalStringSlices(request.CommandPrefix, []string{"echo", "prefix-ok"}) {
+				t.Fatalf("request command prefix = %#v", request.CommandPrefix)
+			}
+			return PermissionDecision{Action: PermissionDecisionAllowPrefix, Reason: "trust this command prefix"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			permissionEvents = append(permissionEvents, event)
+		},
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.FinalAnswer != "done" {
+		t.Fatalf("expected final answer, got %q", result.FinalAnswer)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("expected only the first bash call to prompt, got %#v", requests)
+	}
+	if len(permissionEvents) != 2 {
+		t.Fatalf("expected two bash permission events, got %#v", permissionEvents)
+	}
+	for index, event := range permissionEvents {
+		if event.DecisionAction != PermissionDecisionAllowPrefix || !event.PermissionGranted {
+			t.Fatalf("event %d = %#v, want prefix allow", index, event)
+		}
+	}
+}
+
+func TestRunDoesNotOfferPrefixApprovalForUnsafeBashCommand(t *testing.T) {
+	root := t.TempDir()
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "bash"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"command":"echo hi && echo bye","prefix_rule":["echo"]}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+
+	_, err := Run(context.Background(), "run unsafe", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        sandbox.DefaultPolicy(),
+			Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			if len(request.CommandPrefix) != 0 {
+				t.Fatalf("unsafe command should not have a command prefix: %#v", request.CommandPrefix)
+			}
+			if containsPermissionDecision(request.AvailableDecisions, PermissionDecisionAllowPrefix) {
+				t.Fatalf("unsafe command should not offer prefix approval: %#v", request.AvailableDecisions)
+			}
+			return PermissionDecision{Action: PermissionDecisionDeny, Reason: "deny unsafe"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunAlwaysAllowWithoutSandboxStillAllowsCall(t *testing.T) {
 	// Choosing "always allow" with NO sandbox engine configured must still allow
 	// THIS call (there is just nowhere to persist a grant for future calls). The
@@ -1175,6 +1288,15 @@ func TestRunAlwaysAllowWithoutSandboxStillAllowsCall(t *testing.T) {
 	if len(permissionEvents) != 1 || permissionEvents[0].Action != PermissionActionAllow || !permissionEvents[0].PermissionGranted {
 		t.Fatalf("expected one allow event with permission granted, got %#v", permissionEvents)
 	}
+}
+
+func containsPermissionDecision(decisions []PermissionDecisionAction, want PermissionDecisionAction) bool {
+	for _, decision := range decisions {
+		if decision == want {
+			return true
+		}
+	}
+	return false
 }
 
 // cancelMidStreamProvider cancels the run while the provider stream is open and

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -42,6 +42,7 @@ const (
 	PermissionDecisionAllow           PermissionDecisionAction = "allow"
 	PermissionDecisionAllowStrict     PermissionDecisionAction = "allow_with_strict_auto_review"
 	PermissionDecisionAllowForSession PermissionDecisionAction = "allow_for_session"
+	PermissionDecisionAllowPrefix     PermissionDecisionAction = "allow_prefix_for_session"
 	PermissionDecisionDeny            PermissionDecisionAction = "deny"
 	PermissionDecisionAlwaysAllow     PermissionDecisionAction = "always_allow"
 	PermissionDecisionCancel          PermissionDecisionAction = "cancel"
@@ -97,6 +98,7 @@ type PermissionRequest struct {
 	Violation          *sandbox.Violation         `json:"violation,omitempty"`
 	GrantMatched       bool                       `json:"grantMatched,omitempty"`
 	Grant              *sandbox.Grant             `json:"grant,omitempty"`
+	CommandPrefix      []string                   `json:"commandPrefix,omitempty"`
 	AvailableDecisions []PermissionDecisionAction `json:"availableDecisions,omitempty"`
 }
 
@@ -122,6 +124,7 @@ type PermissionEvent struct {
 	Violation         *sandbox.Violation       `json:"violation,omitempty"`
 	GrantMatched      bool                     `json:"grantMatched,omitempty"`
 	Grant             *sandbox.Grant           `json:"grant,omitempty"`
+	CommandPrefix     []string                 `json:"commandPrefix,omitempty"`
 }
 
 // AskUserQuestion is one clarifying question the agent wants answered.

--- a/internal/sandbox/command_prefix.go
+++ b/internal/sandbox/command_prefix.go
@@ -1,0 +1,71 @@
+package sandbox
+
+import "sync"
+
+type commandPrefixGrantSet struct {
+	mu     sync.Mutex
+	grants []CommandPrefixGrant
+}
+
+type CommandPrefixGrant struct {
+	ToolName string
+	Prefix   []string
+}
+
+func newCommandPrefixGrantSet() *commandPrefixGrantSet {
+	return &commandPrefixGrantSet{}
+}
+
+func (set *commandPrefixGrantSet) add(grant CommandPrefixGrant) {
+	if set == nil || grant.ToolName == "" || len(grant.Prefix) == 0 {
+		return
+	}
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	for _, existing := range set.grants {
+		if existing.ToolName == grant.ToolName && sameStringSlice(existing.Prefix, grant.Prefix) {
+			return
+		}
+	}
+	grant.Prefix = append([]string(nil), grant.Prefix...)
+	set.grants = append(set.grants, grant)
+}
+
+func (set *commandPrefixGrantSet) match(toolName string, command []string) (CommandPrefixGrant, bool) {
+	if set == nil || toolName == "" || len(command) == 0 {
+		return CommandPrefixGrant{}, false
+	}
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	for _, grant := range set.grants {
+		if grant.ToolName == toolName && hasStringPrefix(command, grant.Prefix) {
+			grant.Prefix = append([]string(nil), grant.Prefix...)
+			return grant, true
+		}
+	}
+	return CommandPrefixGrant{}, false
+}
+
+func hasStringPrefix(values []string, prefix []string) bool {
+	if len(prefix) == 0 || len(prefix) > len(values) {
+		return false
+	}
+	for index := range prefix {
+		if values[index] != prefix[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameStringSlice(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -29,6 +29,7 @@ type Engine struct {
 	sessionGrants   *memoryGrantSet
 	sessionProfiles *permissionProfileGrantSet
 	turnProfiles    *permissionProfileGrantSet
+	commandPrefixes *commandPrefixGrantSet
 }
 
 func NewEngine(options EngineOptions) *Engine {
@@ -60,6 +61,7 @@ func NewEngine(options EngineOptions) *Engine {
 		sessionGrants:   newMemoryGrantSet(),
 		sessionProfiles: newPermissionProfileGrantSet(),
 		turnProfiles:    newPermissionProfileGrantSet(),
+		commandPrefixes: newCommandPrefixGrantSet(),
 	}
 }
 
@@ -75,6 +77,23 @@ func (engine *Engine) Scope() *Scope {
 
 func (engine *Engine) CanPersistGrants() bool {
 	return engine != nil && engine.store != nil
+}
+
+func (engine *Engine) GrantCommandPrefixForSession(toolName string, prefix []string) {
+	if engine == nil || len(prefix) == 0 {
+		return
+	}
+	engine.commandPrefixes.add(CommandPrefixGrant{
+		ToolName: toolName,
+		Prefix:   prefix,
+	})
+}
+
+func (engine *Engine) LookupCommandPrefixForSession(toolName string, command []string) (CommandPrefixGrant, bool) {
+	if engine == nil || len(command) == 0 {
+		return CommandPrefixGrant{}, false
+	}
+	return engine.commandPrefixes.match(toolName, command)
 }
 
 // ReadExclusions returns the resolved DenyRead/AllowRead exclusion matcher for

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -37,9 +37,10 @@ func NewScopedBashTool(workspaceRoot string, scope PathScope) Tool {
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
-					"command":    {Type: "string", Description: "Shell command to execute using the host shell. " + shellGuidance},
-					"cwd":        {Type: "string", Description: "Directory to run the command in. Relative paths stay in the workspace; use an absolute path to run in a granted extra directory. Defaults to workspace root. Prefer cwd over cd when changing directories.", Default: "."},
-					"timeout_ms": {Type: "integer", Description: "Command timeout in milliseconds.", Default: defaultBashTimeoutMS, Minimum: intPtr(1), Maximum: intPtr(maxBashTimeoutMS)},
+					"command":     {Type: "string", Description: "Shell command to execute using the host shell. " + shellGuidance},
+					"cwd":         {Type: "string", Description: "Directory to run the command in. Relative paths stay in the workspace; use an absolute path to run in a granted extra directory. Defaults to workspace root. Prefer cwd over cd when changing directories.", Default: "."},
+					"timeout_ms":  {Type: "integer", Description: "Command timeout in milliseconds.", Default: defaultBashTimeoutMS, Minimum: intPtr(1), Maximum: intPtr(maxBashTimeoutMS)},
+					"prefix_rule": {Type: "array", Items: &PropertySchema{Type: "string"}, Description: "Optional reusable approval prefix for this command, for example [\"git\", \"status\"]. Only simple command prefixes are accepted."},
 				},
 				Required:             []string{"command"},
 				AdditionalProperties: false,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -326,6 +326,7 @@ const (
 	permissionDecisionAllow           permissionDecision = agent.PermissionDecisionAllow
 	permissionDecisionAllowStrict     permissionDecision = agent.PermissionDecisionAllowStrict
 	permissionDecisionAllowForSession permissionDecision = agent.PermissionDecisionAllowForSession
+	permissionDecisionAllowPrefix     permissionDecision = agent.PermissionDecisionAllowPrefix
 	permissionDecisionDeny            permissionDecision = agent.PermissionDecisionDeny
 	permissionDecisionAlwaysAllow     permissionDecision = agent.PermissionDecisionAlwaysAllow
 	permissionDecisionCancel          permissionDecision = agent.PermissionDecisionCancel
@@ -2283,6 +2284,8 @@ func permissionDecisionReason(decision permissionDecision) string {
 		return "approved with model review request in TUI"
 	case permissionDecisionAllowForSession:
 		return "approved for this session in TUI"
+	case permissionDecisionAllowPrefix:
+		return "approved command prefix for this session in TUI"
 	case permissionDecisionAlwaysAllow:
 		return "persistently approved in TUI"
 	case permissionDecisionCancel:

--- a/internal/tui/permission_prompt.go
+++ b/internal/tui/permission_prompt.go
@@ -40,6 +40,8 @@ func permissionOptions(request agent.PermissionRequest) []permissionOption {
 			options = append(options, permissionOption{label: "allow with review", hotkey: "r", choice: permissionDecisionAllowStrict})
 		case agent.PermissionDecisionAllowForSession:
 			options = append(options, permissionOption{label: "allow for session", hotkey: "s", choice: permissionDecisionAllowForSession})
+		case agent.PermissionDecisionAllowPrefix:
+			options = append(options, permissionOption{label: "allow command prefix for session", hotkey: "p", choice: permissionDecisionAllowPrefix})
 		case agent.PermissionDecisionAlwaysAllow:
 			options = append(options, permissionOption{label: "always", hotkey: "y", choice: permissionDecisionAlwaysAllow})
 		case agent.PermissionDecisionDeny:

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -80,6 +80,29 @@ func TestPermissionOptionsExposeApprovalCancelWhenSupplied(t *testing.T) {
 	}
 }
 
+func TestPermissionOptionsExposeCommandPrefixApproval(t *testing.T) {
+	request := agent.PermissionRequest{
+		ToolName:      "bash",
+		CommandPrefix: []string{"git", "status"},
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowPrefix,
+			agent.PermissionDecisionCancel,
+		},
+	}
+	options := permissionOptions(request)
+	if len(options) != 3 || options[1].choice != permissionDecisionAllowPrefix || options[1].hotkey != "p" {
+		t.Fatalf("prefix option = %#v, want p hotkey in supplied order", options)
+	}
+	card, _ := renderFocusedPermissionPrompt(request, 1, 100)
+	got := plainRender(t, card)
+	for _, want := range []string{"allow `git status` in this session", "[p]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("permission card = %q, missing %q", got, want)
+		}
+	}
+}
+
 func TestPermissionOptionsCanExposePatchCancelWithoutRecoverableDeny(t *testing.T) {
 	request := agent.PermissionRequest{
 		ToolName: "apply_patch",

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -765,7 +765,9 @@ func renderPermissionRow(row transcriptRow, width int) string {
 	switch event.Action {
 	case agent.PermissionActionAllow:
 		label := "allowed once"
-		if event.DecisionAction == agent.PermissionDecisionAllowForSession ||
+		if event.DecisionAction == agent.PermissionDecisionAllowPrefix {
+			label = "allowed prefix"
+		} else if event.DecisionAction == agent.PermissionDecisionAllowForSession ||
 			(event.Grant != nil && event.Grant.Session) {
 			label = "allowed for session"
 		} else if event.DecisionAction == agent.PermissionDecisionAlwaysAllow ||
@@ -927,6 +929,11 @@ func permissionOptionLabel(option permissionOption, request agent.PermissionRequ
 			return "Yes, and don't ask again for these files in this session"
 		}
 		return "Yes, and don't ask again for this command in this session"
+	case permissionDecisionAllowPrefix:
+		if len(request.CommandPrefix) > 0 {
+			return "Yes, and allow `" + strings.Join(request.CommandPrefix, " ") + "` in this session"
+		}
+		return "Yes, and allow this command prefix in this session"
 	case permissionDecisionAlwaysAllow:
 		if request.SideEffect == string(tools.SideEffectNetwork) {
 			return "Yes, and allow this host in the future"


### PR DESCRIPTION
## Summary
- add validated session-scoped command prefix approvals for bash permission prompts
- support optional prefix_rule on bash tool calls and reject unsafe generalized prefixes
- store prefix approvals in the session sandbox engine while still running commands through the sandbox backend
- render a distinct TUI option for approving matching command prefixes in the current session

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/sandbox ./internal/tui ./internal/tools
- GOCACHE=/tmp/zero-go-cache go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced command prefix approval for sandboxed sessions: approve a command prefix once to automatically allow all matching commands in the session without additional prompts.
* Added "allow prefix for session" option to permission prompts in the interface.
* Integrated safety validation to prevent approval of unsafe command prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->