### PR TITLE
sessions: make the events log authoritative for sequencing + fsync checkpoints/rewind

### DIFF
--- a/internal/sessions/checkpoint.go
+++ b/internal/sessions/checkpoint.go
@@ -185,13 +185,8 @@ func (store *Store) writeBlob(sessionID string, content []byte) (string, error) 
 	if _, err := os.Stat(path); err == nil {
 		return hash, nil // dedup: identical content already stored
 	}
-	tmp := fmt.Sprintf("%s.tmp-%d", path, store.idCounter.Add(1))
-	if err := os.WriteFile(tmp, content, 0o600); err != nil {
+	if err := store.writeFileAtomicSync(path, content, 0o600); err != nil {
 		return "", fmt.Errorf("write checkpoint blob: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return "", fmt.Errorf("commit checkpoint blob: %w", err)
 	}
 	return hash, nil
 }
@@ -230,13 +225,8 @@ func (store *Store) copyBlobs(srcSessionID, dstSessionID string) error {
 			}
 			madeDir = true
 		}
-		tmp := fmt.Sprintf("%s.tmp-%d", dstPath, store.idCounter.Add(1))
-		if err := os.WriteFile(tmp, content, 0o600); err != nil {
+		if err := store.writeFileAtomicSync(dstPath, content, 0o600); err != nil {
 			return fmt.Errorf("write checkpoint blob: %w", err)
-		}
-		if err := os.Rename(tmp, dstPath); err != nil {
-			_ = os.Remove(tmp)
-			return fmt.Errorf("commit checkpoint blob: %w", err)
 		}
 	}
 	return nil

--- a/internal/sessions/rewind.go
+++ b/internal/sessions/rewind.go
@@ -217,13 +217,8 @@ func (store *Store) truncateEventsLocked(sessionID string, keepThroughSequence i
 		encoded = append(bytes.Join(kept, []byte{'\n'}), '\n')
 	}
 	path := store.eventsPath(sessionID)
-	tmp := fmt.Sprintf("%s.tmp-%d", path, store.idCounter.Add(1))
-	if err := os.WriteFile(tmp, encoded, 0o600); err != nil {
+	if err := store.writeFileAtomicSync(path, encoded, 0o600); err != nil {
 		return fmt.Errorf("write truncated events: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("commit truncated events: %w", err)
 	}
 	session, err := store.readMetadata(sessionID)
 	if err != nil {
@@ -284,11 +279,13 @@ func (store *Store) writeFileAtomic(path string, content []byte, mode uint32) er
 		perm = info.Mode().Perm()
 	}
 	tmp := fmt.Sprintf("%s.zero-restore-tmp-%d", path, store.idCounter.Add(1))
-	if err := os.WriteFile(tmp, content, perm); err != nil {
+	// fsync the temp so a restored file's bytes are durable, not just in the page
+	// cache, before it is renamed into place.
+	if err := writeFileSync(tmp, content, perm); err != nil {
 		return err
 	}
-	// WriteFile only applies perm on creation and is subject to umask; force the
-	// exact bits so an executable script's mode is faithfully restored.
+	// writeFileSync applies perm only on creation and is subject to umask; force
+	// the exact bits so an executable script's mode is faithfully restored.
 	if err := os.Chmod(tmp, perm); err != nil {
 		_ = os.Remove(tmp)
 		return err
@@ -297,5 +294,6 @@ func (store *Store) writeFileAtomic(path string, content []byte, mode uint32) er
 		_ = os.Remove(tmp)
 		return err
 	}
-	return nil
+	// fsync the parent dir so the rename itself survives a crash.
+	return syncDir(filepath.Dir(path))
 }

--- a/internal/sessions/sequence_durability_test.go
+++ b/internal/sessions/sequence_durability_test.go
@@ -1,0 +1,128 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func seqTestStore(t *testing.T) *Store {
+	t.Helper()
+	return NewStore(StoreOptions{RootDir: t.TempDir(), Now: fixedClock("2026-06-04T10:00:00Z")})
+}
+
+func appendN(t *testing.T, store *Store, sid string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := store.AppendEvent(sid, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "ok"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// The reported repro: a crash between the event append and the metadata write
+// leaves EventCount BEHIND the log; the next append must derive the sequence from
+// the log and NOT reuse a number (which would mis-target /rewind).
+func TestAppendDerivesSequenceFromLogAfterStaleMetadata(t *testing.T) {
+	store := seqTestStore(t)
+	s, err := store.Create(CreateInput{SessionID: "zero_seq_1", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendN(t, store, s.SessionID, 3) // log + metadata both at seq 3
+
+	// Simulate the crash: rewind metadata.EventCount to 2 while the log keeps 1,2,3.
+	meta, err := store.readMetadata(s.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.EventCount = 2
+	if err := store.writeMetadata(meta); err != nil {
+		t.Fatal(err)
+	}
+
+	ev, err := store.AppendEvent(s.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "after"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Sequence != 4 {
+		t.Fatalf("expected log-derived sequence 4, got %d (would have been a duplicate 3)", ev.Sequence)
+	}
+	events, err := store.ReadEvents(s.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[int]bool{}
+	for _, e := range events {
+		if seen[e.Sequence] {
+			t.Fatalf("duplicate sequence %d in log: %+v", e.Sequence, events)
+		}
+		seen[e.Sequence] = true
+	}
+}
+
+// The mirror case (stale-HIGH EventCount, e.g. an interrupted truncate) must
+// leave a benign gap, never a duplicate.
+func TestAppendWithStaleHighMetadataLeavesGapNotDuplicate(t *testing.T) {
+	store := seqTestStore(t)
+	s, _ := store.Create(CreateInput{SessionID: "zero_seq_2", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	appendN(t, store, s.SessionID, 2)
+
+	meta, _ := store.readMetadata(s.SessionID)
+	meta.EventCount = 5 // stale-high; the log only has 1,2
+	if err := store.writeMetadata(meta); err != nil {
+		t.Fatal(err)
+	}
+	ev, err := store.AppendEvent(s.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": "x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Sequence != 6 {
+		t.Fatalf("stale-high metadata should advance to 6 (benign gap), got %d", ev.Sequence)
+	}
+}
+
+func TestLastEventSequence_EmptyAndMultiple(t *testing.T) {
+	store := seqTestStore(t)
+	s, _ := store.Create(CreateInput{SessionID: "zero_tail_1", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	if seq, err := store.lastEventSequence(s.SessionID); err != nil || seq != 0 {
+		t.Fatalf("empty log: got %d err=%v, want 0", seq, err)
+	}
+	appendN(t, store, s.SessionID, 3)
+	if seq, err := store.lastEventSequence(s.SessionID); err != nil || seq != 3 {
+		t.Fatalf("3 events: got %d err=%v, want 3", seq, err)
+	}
+}
+
+func TestLastEventSequence_IgnoresTornTail(t *testing.T) {
+	store := seqTestStore(t)
+	s, _ := store.Create(CreateInput{SessionID: "zero_tail_2", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	appendN(t, store, s.SessionID, 3)
+	// Append a torn partial line (interrupted write: no trailing newline).
+	f, err := os.OpenFile(filepath.Join(store.RootDir, s.SessionID, EventsFile), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"sequence":4,"type":"message","partial`); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if seq, err := store.lastEventSequence(s.SessionID); err != nil || seq != 3 {
+		t.Fatalf("torn tail must be ignored: got %d err=%v, want 3", seq, err)
+	}
+}
+
+func TestLastEventSequence_LargeLastEvent(t *testing.T) {
+	store := seqTestStore(t)
+	s, _ := store.Create(CreateInput{SessionID: "zero_tail_3", Title: "t", Cwd: "/repo", ModelID: "m", Provider: "p"})
+	// A single event larger than the 64 KiB initial tail window forces the read
+	// to grow its window; the sequence must still be found.
+	big := strings.Repeat("x", 100*1024)
+	if _, err := store.AppendEvent(s.SessionID, AppendEventInput{Type: EventMessage, Payload: map[string]any{"content": big}}); err != nil {
+		t.Fatal(err)
+	}
+	if seq, err := store.lastEventSequence(s.SessionID); err != nil || seq != 1 {
+		t.Fatalf("large last event: got %d err=%v, want 1", seq, err)
+	}
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -543,6 +543,15 @@ func (store *Store) appendEventLocked(sessionID string, input AppendEventInput) 
 		return Event{}, err
 	}
 	sequence := session.EventCount + 1
+	// The events log is the source of truth for sequencing. metadata.EventCount is
+	// persisted separately (after the event line below), so a crash between the two
+	// can leave it behind the log; deriving from the log's last sequence then avoids
+	// reusing a number (a duplicate that would mis-target /rewind). Best-effort: a
+	// log read error falls back to the metadata count. Only triggers on a real
+	// desync (log at/ahead of the metadata-derived sequence).
+	if logSeq, err := store.lastEventSequence(sessionID); err == nil && logSeq >= sequence {
+		sequence = logSeq + 1
+	}
 	timestamp := store.timestamp()
 	event := Event{
 		ID:        fmt.Sprintf("%s:%d", sessionID, sequence),
@@ -793,6 +802,98 @@ func writeFileSync(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	return file.Close()
+}
+
+// writeFileAtomicSync durably writes content to path with the same crash-safe
+// sequence writeMetadata uses: write a temp file and fsync it, atomically rename
+// it into place, then fsync the parent directory. Checkpoint blobs and rewind
+// restores go through this so they are as durable as session metadata (plain
+// WriteFile+Rename leaves the bytes in the page cache, so a crash can surface a
+// torn or empty file).
+func (store *Store) writeFileAtomicSync(path string, content []byte, perm os.FileMode) error {
+	tmp := fmt.Sprintf("%s.tmp-%d", path, store.idCounter.Add(1))
+	if err := writeFileSync(tmp, content, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return syncDir(filepath.Dir(path))
+}
+
+// lastEventSequence returns the sequence of the last COMPLETE (newline-
+// terminated) event in the session log, or 0 if the log is empty/absent. A torn
+// trailing partial line (an interrupted append) is ignored, matching ReadEvents.
+// It reads only the file's tail, so it is O(1) regardless of log length. It lets
+// the events log — not the separately-persisted metadata.EventCount — be the
+// source of truth for the next sequence number, so a crash between the event
+// append and the metadata write can never cause a reused (duplicate) sequence.
+func (store *Store) lastEventSequence(sessionID string) (int, error) {
+	file, err := os.Open(store.eventsPath(sessionID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return 0, nil
+	}
+	// Read the tail, growing the window until it contains the last complete line
+	// (events are usually small; a very large last event grows it up to the file).
+	window := int64(64 * 1024)
+	for {
+		if window > size {
+			window = size
+		}
+		buf := make([]byte, window)
+		if _, err := file.ReadAt(buf, size-window); err != nil {
+			return 0, err
+		}
+		lastNL := bytes.LastIndexByte(buf, '\n')
+		if lastNL < 0 {
+			if window >= size {
+				return 0, nil // no newline in the whole file -> no complete event
+			}
+			window *= 2
+			continue
+		}
+		prevNL := bytes.LastIndexByte(buf[:lastNL], '\n')
+		if prevNL < 0 && window < size {
+			window *= 2 // the last complete line may start before the window
+			continue
+		}
+		line := bytes.TrimSpace(buf[prevNL+1 : lastNL])
+		if len(line) == 0 {
+			return 0, nil
+		}
+		var probe struct {
+			Sequence int `json:"sequence"`
+		}
+		if err := json.Unmarshal(line, &probe); err != nil {
+			// A complete-but-corrupt last line: defer to the full, recovery-aware
+			// read so a single bad line never silently mis-sequences the next event.
+			events, rerr := store.ReadEvents(sessionID)
+			if rerr != nil {
+				return 0, rerr
+			}
+			maxSeq := 0
+			for _, event := range events {
+				if event.Sequence > maxSeq {
+					maxSeq = event.Sequence
+				}
+			}
+			return maxSeq, nil
+		}
+		return probe.Sequence, nil
+	}
 }
 
 func rawPayload(payload any) (json.RawMessage, error) {


### PR DESCRIPTION
A data-integrity audit of `internal/sessions` surfaced two crash-durability gaps (the locking, rewind sequence/path logic, replay fidelity, and perms all audited clean). Both are fixed here.

## 1. Sequence numbers could be reused after a crash → mis-targeted `/rewind`
`appendEventLocked` derived the next sequence from `metadata.EventCount`, but that count is persisted in a *separate* file (`metadata.json`) **after** the event line is appended to `events.jsonl`. A crash between the two writes leaves `EventCount` behind the log, so the next append **reuses the sequence** (a duplicate `sid:N` + colliding id). `findRewindTarget` returns the *first* match, so a rewind/fork then targets the wrong event. (The truncate path's reverse order could similarly leave a gap.)

**Fix:** the events log is now the source of truth. New `lastEventSequence()` does an **O(1) tail read** (ignoring a torn trailing partial, matching `ReadEvents`), and `appendEventLocked` uses `max(EventCount, lastLoggedSequence) + 1`. A stale/desynced `EventCount` can no longer cause a reused number; it falls back to the metadata count only if the log is unreadable, and the normal path is unchanged.

## 2. Checkpoints and rewind restores were not crash-durable
`checkpoint.go` (blob writes, `copyBlobs`) and `rewind.go` (truncated-events write, workspace `writeFileAtomic`) used plain `os.WriteFile + os.Rename` with **no fsync**, while `store.go` deliberately fsyncs the temp file **and** the parent dir for session metadata (a crash otherwise yields "a torn or empty file that corrupts the whole session"). So the `/rewind` safety net and restored workspace files weren't durable.

**Fix:** new `writeFileAtomicSync()` (fsync temp + `syncDir`) is used at all four sites; the workspace restore keeps its exact-perm chmod.

## Tests
`sequence_durability_test.go`: stale-low `EventCount` → no duplicate (the reproducible case), stale-high → benign gap, and `lastEventSequence` over empty / multi / torn-tail / >64 KiB-event logs.

`gofmt` · `go vet` · `staticcheck` · `go test ./internal/sessions/... -race` · build all · `internal/tui` + `internal/agent` + `internal/cli` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session durability and crash recovery by ensuring checkpoint and rewind operations persist atomically
  * Enhanced event sequencing logic to prevent duplicate or reused sequence numbers when metadata becomes inconsistent with the event log
  * Strengthened fsync guarantees for restored files to ensure durability across system crashes

* **Tests**
  * Added comprehensive durability tests for session event sequencing and metadata consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->