### PR TITLE
Persist command prefix approvals

### DIFF
--- a/internal/agent/command_prefix.go
+++ b/internal/agent/command_prefix.go
@@ -7,55 +7,6 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
-var bannedCommandPrefixSuggestions = [][]string{
-	{"python3"},
-	{"python3", "-"},
-	{"python3", "-c"},
-	{"python"},
-	{"python", "-"},
-	{"python", "-c"},
-	{"py"},
-	{"py", "-3"},
-	{"pythonw"},
-	{"pyw"},
-	{"pypy"},
-	{"pypy3"},
-	{"git"},
-	{"bash"},
-	{"bash", "-lc"},
-	{"sh"},
-	{"sh", "-c"},
-	{"sh", "-lc"},
-	{"zsh"},
-	{"zsh", "-lc"},
-	{"/bin/zsh"},
-	{"/bin/zsh", "-lc"},
-	{"/bin/bash"},
-	{"/bin/bash", "-lc"},
-	{"pwsh"},
-	{"pwsh", "-Command"},
-	{"pwsh", "-c"},
-	{"powershell"},
-	{"powershell", "-Command"},
-	{"powershell", "-c"},
-	{"powershell.exe"},
-	{"powershell.exe", "-Command"},
-	{"powershell.exe", "-c"},
-	{"env"},
-	{"sudo"},
-	{"node"},
-	{"node", "-e"},
-	{"perl"},
-	{"perl", "-e"},
-	{"ruby"},
-	{"ruby", "-e"},
-	{"php"},
-	{"php", "-r"},
-	{"lua"},
-	{"lua", "-e"},
-	{"osascript"},
-}
-
 func proposedCommandPrefix(toolName string, args map[string]any) []string {
 	if toolName != "bash" {
 		return nil
@@ -74,25 +25,31 @@ func proposedCommandPrefix(toolName string, args map[string]any) []string {
 		}
 		return nil
 	}
-	if unsafeCommandPrefix(tokens) {
+	if !sandbox.ValidCommandPrefix(tokens) {
 		return nil
 	}
 	return append([]string(nil), tokens...)
 }
 
-func matchSessionCommandPrefix(toolName string, args map[string]any, options Options) (sandbox.CommandPrefixGrant, bool) {
+func matchCommandPrefix(toolName string, args map[string]any, options Options) (sandbox.CommandPrefixGrant, bool, bool) {
 	if toolName != "bash" || options.Sandbox == nil {
-		return sandbox.CommandPrefixGrant{}, false
+		return sandbox.CommandPrefixGrant{}, false, false
 	}
 	command, ok := firstStringArg(args, "command", "cmd", "script", "shell")
 	if !ok {
-		return sandbox.CommandPrefixGrant{}, false
+		return sandbox.CommandPrefixGrant{}, false, false
 	}
 	tokens, ok := safeShellCommandTokens(command)
 	if !ok {
-		return sandbox.CommandPrefixGrant{}, false
+		return sandbox.CommandPrefixGrant{}, false, false
 	}
-	return options.Sandbox.LookupCommandPrefixForSession(toolName, tokens)
+	if grant, ok := options.Sandbox.LookupCommandPrefix(toolName, tokens); ok {
+		return grant, true, false
+	}
+	if grant, ok := options.Sandbox.LookupCommandPrefixForSession(toolName, tokens); ok {
+		return grant, true, true
+	}
+	return sandbox.CommandPrefixGrant{}, false, false
 }
 
 func firstStringArg(args map[string]any, names ...string) (string, bool) {
@@ -143,7 +100,7 @@ func cleanPrefixRule(prefix []string) []string {
 }
 
 func safeRequestedPrefix(prefix []string, command []string) bool {
-	if len(prefix) == 0 || unsafeCommandPrefix(prefix) || len(prefix) > len(command) {
+	if len(prefix) == 0 || !sandbox.ValidCommandPrefix(prefix) || len(prefix) > len(command) {
 		return false
 	}
 	for index := range prefix {
@@ -177,54 +134,15 @@ func safeShellCommandTokens(command string) ([]string, bool) {
 			return nil, false
 		}
 		lit, ok := word.Parts[0].(*syntax.Lit)
-		if !ok || unsafeCommandPrefixPart(lit.Value) {
+		if !ok {
 			return nil, false
 		}
 		tokens = append(tokens, lit.Value)
 	}
-	if unsafeCommandPrefix(tokens) {
+	if !sandbox.ValidCommandPrefix(tokens) {
 		return nil, false
 	}
 	return tokens, true
-}
-
-func unsafeCommandPrefix(prefix []string) bool {
-	if len(prefix) == 0 {
-		return true
-	}
-	for _, part := range prefix {
-		if unsafeCommandPrefixPart(part) {
-			return true
-		}
-	}
-	for _, banned := range bannedCommandPrefixSuggestions {
-		if equalStringSlices(prefix, banned) {
-			return true
-		}
-	}
-	if unsafeCommandPrefixLauncher(prefix[0]) {
-		return true
-	}
-	return false
-}
-
-func unsafeCommandPrefixPart(part string) bool {
-	part = strings.TrimSpace(part)
-	return part == "" ||
-		strings.ContainsAny(part, "\x00\r\n*?[]{}") ||
-		strings.Contains(part, "$(") ||
-		strings.Contains(part, "`")
-}
-
-func unsafeCommandPrefixLauncher(program string) bool {
-	switch program {
-	case "bash", "sh", "zsh", "/bin/bash", "/bin/zsh",
-		"pwsh", "powershell", "powershell.exe",
-		"env", "sudo", "osascript":
-		return true
-	default:
-		return false
-	}
 }
 
 func equalStringSlices(left []string, right []string) bool {

--- a/internal/agent/command_prefix_test.go
+++ b/internal/agent/command_prefix_test.go
@@ -48,3 +48,41 @@ func TestProposedCommandPrefixRejectsUnsafeShellForms(t *testing.T) {
 		})
 	}
 }
+
+func TestProposedCommandPrefixRejectsUnsafeLaunchers(t *testing.T) {
+	cases := []string{
+		"find . -type f",
+		"xargs rm -rf /tmp/x",
+		"timeout 5 go test ./...",
+		"nice go test ./...",
+		"nohup go test ./...",
+		"watch ls",
+		"ssh host ls",
+		"make test",
+		"npm run dev",
+		"command git status",
+		"eval echo hi",
+		"exec echo hi",
+		"python script.py",
+		"node script.js",
+		"./script.sh --flag",
+		"/tmp/script.sh --flag",
+	}
+	for _, command := range cases {
+		t.Run(command, func(t *testing.T) {
+			if got := proposedCommandPrefix("bash", map[string]any{"command": command}); got != nil {
+				t.Fatalf("unsafe launcher got prefix %#v", got)
+			}
+		})
+	}
+}
+
+func TestProposedCommandPrefixRejectsRequestedUnsafeLauncherPrefix(t *testing.T) {
+	got := proposedCommandPrefix("bash", map[string]any{
+		"command":     "find . -type f",
+		"prefix_rule": []any{"find", "."},
+	})
+	if got != nil {
+		t.Fatalf("unsafe requested launcher prefix should be rejected, got %#v", got)
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -591,10 +591,15 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 	var decisionAction PermissionDecisionAction
 	var decisionCommandPrefix []string
 	if toolFound && !permissionGranted {
-		if grant, ok := matchSessionCommandPrefix(call.Name, args, options); ok {
+		if grant, ok, session := matchCommandPrefix(call.Name, args, options); ok {
 			permissionGranted = true
-			decisionAction = PermissionDecisionAllowPrefix
-			decisionReason = "session command prefix approval matched"
+			if session {
+				decisionAction = PermissionDecisionAllowPrefix
+				decisionReason = "session command prefix approval matched"
+			} else {
+				decisionAction = PermissionDecisionAlwaysAllowPrefix
+				decisionReason = "persistent command prefix approval matched"
+			}
 			decisionCommandPrefix = grant.Prefix
 		}
 	}
@@ -643,6 +648,19 @@ func executeToolCall(ctx context.Context, registry *tools.Registry, call ToolCal
 			decisionCommandPrefix = append([]string(nil), request.CommandPrefix...)
 			if options.Sandbox != nil && len(decisionCommandPrefix) > 0 {
 				options.Sandbox.GrantCommandPrefixForSession(call.Name, decisionCommandPrefix)
+			}
+		case PermissionDecisionAlwaysAllowPrefix:
+			if len(request.CommandPrefix) == 0 {
+				emitDeniedPermission(options, call, requestEvent, decisionReason)
+				return deniedPermissionResult(call, decisionReason, requestEvent), nil
+			}
+			permissionGranted = true
+			requestEvent.DecisionAction = decision.Action
+			decisionCommandPrefix = append([]string(nil), request.CommandPrefix...)
+			if options.Sandbox != nil && len(decisionCommandPrefix) > 0 {
+				if grant, err := persistCommandPrefixGrant(call.Name, decisionCommandPrefix, decisionReason, options); err == nil {
+					decisionCommandPrefix = append([]string(nil), grant.Prefix...)
+				}
 			}
 		case PermissionDecisionAlwaysAllow:
 			permissionGranted = true
@@ -1026,7 +1044,7 @@ func requestPermission(ctx context.Context, request PermissionRequest, options O
 
 func normalizePermissionDecisionAction(action PermissionDecisionAction) PermissionDecisionAction {
 	switch action {
-	case PermissionDecisionAllow, PermissionDecisionAllowStrict, PermissionDecisionAllowForSession, PermissionDecisionAllowPrefix, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
+	case PermissionDecisionAllow, PermissionDecisionAllowStrict, PermissionDecisionAllowForSession, PermissionDecisionAllowPrefix, PermissionDecisionAlwaysAllowPrefix, PermissionDecisionAlwaysAllow, PermissionDecisionCancel:
 		return action
 	default:
 		return PermissionDecisionDeny
@@ -1318,6 +1336,17 @@ func persistSessionPermissionGrant(toolName string, args map[string]any, reason 
 	})
 }
 
+func persistCommandPrefixGrant(toolName string, prefix []string, reason string, options Options) (sandbox.CommandPrefixGrant, error) {
+	if options.Sandbox == nil {
+		return sandbox.CommandPrefixGrant{}, errors.New("sandbox engine is not configured")
+	}
+	return options.Sandbox.GrantCommandPrefix(sandbox.CommandPrefixInput{
+		ToolName: toolName,
+		Prefix:   prefix,
+		Reason:   reason,
+	})
+}
+
 func emitDeniedPermission(options Options, call ToolCall, requestEvent PermissionEvent, reason string) {
 	if options.OnPermission == nil {
 		return
@@ -1564,6 +1593,9 @@ func availablePermissionDecisions(event PermissionEvent, options Options) []Perm
 		decisions = append(decisions, PermissionDecisionAllowForSession)
 		if event.ToolName == "bash" && len(event.CommandPrefix) > 0 {
 			decisions = append(decisions, PermissionDecisionAllowPrefix)
+			if options.Sandbox.CanPersistGrants() {
+				decisions = append(decisions, PermissionDecisionAlwaysAllowPrefix)
+			}
 		}
 		if options.Sandbox.CanPersistGrants() && permissionSupportsPersistentDecision(event.ToolName) {
 			decisions = append(decisions, PermissionDecisionAlwaysAllow)

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1209,6 +1209,161 @@ func TestRunCommandPrefixApprovalSkipsLaterMatchingBashPrompt(t *testing.T) {
 	}
 }
 
+func TestRunPersistentCommandPrefixApprovalSkipsFutureSessionPrompt(t *testing.T) {
+	root := t.TempDir()
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+	policy := sandbox.DefaultPolicy()
+	policy.Network = sandbox.NetworkAllow
+
+	firstProvider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "bash"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"command":"echo persist-ok"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "first done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var firstRequests []PermissionRequest
+	var firstEvents []PermissionEvent
+	if _, err := Run(context.Background(), "run once", firstProvider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        policy,
+			Store:         store,
+			Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			firstRequests = append(firstRequests, request)
+			if !containsPermissionDecision(request.AvailableDecisions, PermissionDecisionAlwaysAllowPrefix) {
+				t.Fatalf("bash prompt missing persistent prefix approval decision: %#v", request.AvailableDecisions)
+			}
+			return PermissionDecision{Action: PermissionDecisionAlwaysAllowPrefix, Reason: "trust this command prefix"}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			firstEvents = append(firstEvents, event)
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(firstRequests) != 1 {
+		t.Fatalf("expected first run to prompt once, got %#v", firstRequests)
+	}
+	if len(firstEvents) != 1 || firstEvents[0].DecisionAction != PermissionDecisionAlwaysAllowPrefix {
+		t.Fatalf("expected persistent prefix event, got %#v", firstEvents)
+	}
+	prefixes, err := store.ListCommandPrefixes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prefixes) != 1 || !equalStringSlices(prefixes[0].Prefix, []string{"echo", "persist-ok"}) {
+		t.Fatalf("persisted prefixes = %#v, want echo persist-ok", prefixes)
+	}
+
+	secondProvider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-2", ToolName: "bash"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-2", ArgumentsFragment: `{"command":"echo persist-ok again"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-2"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "second done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var secondEvents []PermissionEvent
+	if _, err := Run(context.Background(), "run again", secondProvider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        policy,
+			Store:         store,
+			Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			t.Fatalf("persistent command prefix should skip prompt, got %#v", request)
+			return PermissionDecision{}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			secondEvents = append(secondEvents, event)
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(secondEvents) != 1 || secondEvents[0].DecisionAction != PermissionDecisionAlwaysAllowPrefix || !secondEvents[0].PermissionGranted {
+		t.Fatalf("expected persistent prefix match event, got %#v", secondEvents)
+	}
+}
+
+func TestRunPersistentCommandPrefixDoesNotBypassNetworkDeny(t *testing.T) {
+	root := t.TempDir()
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantCommandPrefix(sandbox.CommandPrefixInput{ToolName: "bash", Prefix: []string{"curl"}}); err != nil {
+		t.Fatalf("seed command prefix: %v", err)
+	}
+	registry := tools.NewRegistry()
+	registry.Register(tools.NewBashTool(root))
+	provider := &mockProvider{
+		turns: [][]zeroruntime.StreamEvent{
+			{
+				{Type: zeroruntime.StreamEventToolCallStart, ToolCallID: "call-1", ToolName: "bash"},
+				{Type: zeroruntime.StreamEventToolCallDelta, ToolCallID: "call-1", ArgumentsFragment: `{"command":"curl https://example.com"}`},
+				{Type: zeroruntime.StreamEventToolCallEnd, ToolCallID: "call-1"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+			{
+				{Type: zeroruntime.StreamEventText, Content: "done"},
+				{Type: zeroruntime.StreamEventDone},
+			},
+		},
+	}
+	var events []PermissionEvent
+	if _, err := Run(context.Background(), "curl", provider, Options{
+		Registry:       registry,
+		PermissionMode: PermissionModeAsk,
+		Autonomy:       string(sandbox.AutonomyMedium),
+		Sandbox: sandbox.NewEngine(sandbox.EngineOptions{
+			WorkspaceRoot: root,
+			Policy:        sandbox.DefaultPolicy(),
+			Store:         store,
+			Backend:       sandbox.Backend{Name: sandbox.BackendPolicyOnly, Message: "policy-only fallback"},
+		}),
+		OnPermissionRequest: func(_ context.Context, request PermissionRequest) (PermissionDecision, error) {
+			t.Fatalf("matched persistent command prefix should not prompt before sandbox denial, got %#v", request)
+			return PermissionDecision{}, nil
+		},
+		OnPermission: func(event PermissionEvent) {
+			events = append(events, event)
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Action != PermissionActionDeny || events[0].Violation == nil || events[0].Violation.Code != sandbox.ViolationNetwork {
+		t.Fatalf("expected network sandbox denial despite prefix match, got %#v", events)
+	}
+}
+
 func TestRunDoesNotOfferPrefixApprovalForUnsafeBashCommand(t *testing.T) {
 	root := t.TempDir()
 	registry := tools.NewRegistry()

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -74,6 +74,9 @@ func buildSystemPrompt(options Options) string {
 	if session := sessionRuntimeContext(options); session != "" {
 		sections = append(sections, session)
 	}
+	if prefixes := approvedCommandPrefixContext(options); prefixes != "" {
+		sections = append(sections, prefixes)
+	}
 	if seed := workspaceSeedContext(options.Cwd); seed != "" {
 		sections = append(sections, seed)
 	}
@@ -87,6 +90,27 @@ func buildSystemPrompt(options Options) string {
 		sections = append(sections, policy)
 	}
 	return strings.Join(sections, "\n\n")
+}
+
+func approvedCommandPrefixContext(options Options) string {
+	if options.Sandbox == nil {
+		return ""
+	}
+	prefixes := options.Sandbox.ApprovedCommandPrefixes()
+	if len(prefixes) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(prefixes))
+	for _, grant := range prefixes {
+		if len(grant.Prefix) == 0 {
+			continue
+		}
+		lines = append(lines, "- "+grant.ToolName+": "+strings.Join(grant.Prefix, " "))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return "## Approved Command Prefixes\n\nThe following command prefixes have already been approved and do not need another permission prompt:\n" + strings.Join(lines, "\n")
 }
 
 // specialistDelegationContext nudges the orchestrator to offload read-heavy or

--- a/internal/agent/system_prompt_test.go
+++ b/internal/agent/system_prompt_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
 func TestCoreSystemPromptIncludesCodingQualityRules(t *testing.T) {
@@ -68,6 +70,22 @@ func TestBuildSystemPromptOmitsWorkspaceSeedWithoutCwd(t *testing.T) {
 
 	if strings.Contains(prompt, "<workspace_seed>") || strings.Contains(prompt, "Workspace context seed") {
 		t.Fatalf("workspace seed should be absent without cwd, got:\n%s", prompt)
+	}
+}
+
+func TestBuildSystemPromptIncludesApprovedCommandPrefixes(t *testing.T) {
+	store, err := sandbox.NewGrantStore(sandbox.StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.GrantCommandPrefix(sandbox.CommandPrefixInput{ToolName: "bash", Prefix: []string{"git", "status"}}); err != nil {
+		t.Fatalf("GrantCommandPrefix returned error: %v", err)
+	}
+	prompt := buildSystemPrompt(Options{Sandbox: sandbox.NewEngine(sandbox.EngineOptions{Store: store})})
+	for _, want := range []string{"Approved Command Prefixes", "bash: git status"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("system prompt missing %q:\n%s", want, prompt)
+		}
 	}
 }
 

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -39,13 +39,14 @@ const (
 )
 
 const (
-	PermissionDecisionAllow           PermissionDecisionAction = "allow"
-	PermissionDecisionAllowStrict     PermissionDecisionAction = "allow_with_strict_auto_review"
-	PermissionDecisionAllowForSession PermissionDecisionAction = "allow_for_session"
-	PermissionDecisionAllowPrefix     PermissionDecisionAction = "allow_prefix_for_session"
-	PermissionDecisionDeny            PermissionDecisionAction = "deny"
-	PermissionDecisionAlwaysAllow     PermissionDecisionAction = "always_allow"
-	PermissionDecisionCancel          PermissionDecisionAction = "cancel"
+	PermissionDecisionAllow             PermissionDecisionAction = "allow"
+	PermissionDecisionAllowStrict       PermissionDecisionAction = "allow_with_strict_auto_review"
+	PermissionDecisionAllowForSession   PermissionDecisionAction = "allow_for_session"
+	PermissionDecisionAllowPrefix       PermissionDecisionAction = "allow_prefix_for_session"
+	PermissionDecisionAlwaysAllowPrefix PermissionDecisionAction = "always_allow_prefix"
+	PermissionDecisionDeny              PermissionDecisionAction = "deny"
+	PermissionDecisionAlwaysAllow       PermissionDecisionAction = "always_allow"
+	PermissionDecisionCancel            PermissionDecisionAction = "cancel"
 )
 
 type ToolResult struct {

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -354,15 +354,20 @@ func runSandboxGrants(args []string, stdout io.Writer, stderr io.Writer, deps ap
 		if err != nil {
 			return writeAppError(stderr, err.Error(), exitCrash)
 		}
+		prefixes, err := store.ListCommandPrefixes()
+		if err != nil {
+			return writeAppError(stderr, err.Error(), exitCrash)
+		}
 		if options.json {
 			if err := writePrettyJSON(stdout, struct {
-				Grants []zeroSandbox.Grant `json:"grants"`
-			}{Grants: grants}); err != nil {
+				Grants          []zeroSandbox.Grant              `json:"grants"`
+				CommandPrefixes []zeroSandbox.CommandPrefixGrant `json:"commandPrefixes,omitempty"`
+			}{Grants: grants, CommandPrefixes: prefixes}); err != nil {
 				return exitCrash
 			}
 			return exitSuccess
 		}
-		if _, err := fmt.Fprintln(stdout, zeroSandbox.FormatGrantList(grants)); err != nil {
+		if _, err := fmt.Fprintln(stdout, zeroSandbox.FormatGrantListWithCommandPrefixes(grants, prefixes)); err != nil {
 			return exitCrash
 		}
 		return exitSuccess

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -105,6 +105,41 @@ func TestRunSandboxGrantsAllowListDenyRevokeAndClear(t *testing.T) {
 	}
 }
 
+func TestRunSandboxGrantsListIncludesCommandPrefixes(t *testing.T) {
+	store := newSandboxTestStore(t)
+	if _, err := store.GrantCommandPrefix(sandbox.CommandPrefixInput{ToolName: "bash", Prefix: []string{"git", "status"}, Reason: "status checks"}); err != nil {
+		t.Fatalf("GrantCommandPrefix: %v", err)
+	}
+	deps := appDeps{newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil }}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := runWithDeps([]string{"sandbox", "grants", "list", "--json"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("list json exit = %d, stderr %q", exitCode, stderr.String())
+	}
+	var payload struct {
+		CommandPrefixes []sandbox.CommandPrefixGrant `json:"commandPrefixes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode list JSON: %v\n%s", err, stdout.String())
+	}
+	if len(payload.CommandPrefixes) != 1 || !reflect.DeepEqual(payload.CommandPrefixes[0].Prefix, []string{"git", "status"}) {
+		t.Fatalf("unexpected commandPrefixes payload: %#v", payload.CommandPrefixes)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = runWithDeps([]string{"sandbox", "grants", "list"}, &stdout, &stderr, deps)
+	if exitCode != exitSuccess {
+		t.Fatalf("list text exit = %d, stderr %q", exitCode, stderr.String())
+	}
+	for _, want := range []string{"bash", "`git status`", "command-prefix", "status checks"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("list text = %q, missing %q", stdout.String(), want)
+		}
+	}
+}
+
 func TestRunSandboxGrantsCreateAndRevokeByPath(t *testing.T) {
 	store := newSandboxTestStore(t)
 	deps := appDeps{newSandboxStore: func() (*sandbox.GrantStore, error) { return store, nil }}

--- a/internal/sandbox/analyzer.go
+++ b/internal/sandbox/analyzer.go
@@ -93,7 +93,7 @@ func analyzeInto(script string, result *AnalysisResult, seen map[string]bool, de
 		if networkPrograms[prog] {
 			result.Network = true
 		}
-		if destructivePrograms[prog] || (prog == "rm" && hasRecursiveForce(rest)) {
+		if destructivePrograms[prog] || (prog == "rm" && hasRecursiveForce(rest)) || (prog == "find" && hasFindDelete(rest)) {
 			result.Destructive = true
 		}
 		return true
@@ -237,4 +237,13 @@ func hasRecursiveForce(args []*syntax.Word) bool {
 		}
 	}
 	return recursive && force
+}
+
+func hasFindDelete(args []*syntax.Word) bool {
+	for _, arg := range args {
+		if wordText(arg) == "-delete" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sandbox/analyzer_test.go
+++ b/internal/sandbox/analyzer_test.go
@@ -25,6 +25,7 @@ func TestAnalyzeCommand(t *testing.T) {
 		{name: "rm inside quoted arg", script: `git commit -m "rm -rf /"`, destructive: false},
 		{name: "rm end-of-options literal filename", script: "rm -- -rf", destructive: false},
 		{name: "dd", script: "dd if=/dev/zero of=/dev/disk2", destructive: true},
+		{name: "find delete", script: "find . -type f -delete", destructive: true},
 
 		// Wrappers are unwrapped to the real payload, not classified on the launcher.
 		{name: "sudo wraps rm -rf", script: "sudo rm -rf /tmp/x", destructive: true},

--- a/internal/sandbox/command_prefix.go
+++ b/internal/sandbox/command_prefix.go
@@ -1,6 +1,9 @@
 package sandbox
 
-import "sync"
+import (
+	"strings"
+	"sync"
+)
 
 type commandPrefixGrantSet struct {
 	mu     sync.Mutex
@@ -8,8 +11,17 @@ type commandPrefixGrantSet struct {
 }
 
 type CommandPrefixGrant struct {
+	ToolName   string   `json:"toolName"`
+	Prefix     []string `json:"prefix"`
+	ApprovedAt string   `json:"approvedAt,omitempty"`
+	Reason     string   `json:"reason,omitempty"`
+	Session    bool     `json:"session,omitempty"`
+}
+
+type CommandPrefixInput struct {
 	ToolName string
 	Prefix   []string
+	Reason   string
 }
 
 func newCommandPrefixGrantSet() *commandPrefixGrantSet {
@@ -56,6 +68,123 @@ func hasStringPrefix(values []string, prefix []string) bool {
 		}
 	}
 	return true
+}
+
+func NormalizeCommandPrefix(prefix []string) ([]string, bool) {
+	cleaned := make([]string, 0, len(prefix))
+	for _, part := range prefix {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, false
+		}
+		cleaned = append(cleaned, part)
+	}
+	if unsafeCommandPrefix(cleaned) {
+		return nil, false
+	}
+	return cleaned, true
+}
+
+func ValidCommandPrefix(prefix []string) bool {
+	_, ok := NormalizeCommandPrefix(prefix)
+	return ok
+}
+
+var bannedCommandPrefixSuggestions = [][]string{
+	{"python3"},
+	{"python3", "-"},
+	{"python3", "-c"},
+	{"python"},
+	{"python", "-"},
+	{"python", "-c"},
+	{"py"},
+	{"py", "-3"},
+	{"pythonw"},
+	{"pyw"},
+	{"pypy"},
+	{"pypy3"},
+	{"git"},
+	{"bash"},
+	{"bash", "-lc"},
+	{"sh"},
+	{"sh", "-c"},
+	{"sh", "-lc"},
+	{"zsh"},
+	{"zsh", "-lc"},
+	{"/bin/zsh"},
+	{"/bin/zsh", "-lc"},
+	{"/bin/bash"},
+	{"/bin/bash", "-lc"},
+	{"pwsh"},
+	{"pwsh", "-Command"},
+	{"pwsh", "-c"},
+	{"powershell"},
+	{"powershell", "-Command"},
+	{"powershell", "-c"},
+	{"powershell.exe"},
+	{"powershell.exe", "-Command"},
+	{"powershell.exe", "-c"},
+	{"env"},
+	{"sudo"},
+	{"node"},
+	{"node", "-e"},
+	{"perl"},
+	{"perl", "-e"},
+	{"ruby"},
+	{"ruby", "-e"},
+	{"php"},
+	{"php", "-r"},
+	{"lua"},
+	{"lua", "-e"},
+	{"osascript"},
+}
+
+func unsafeCommandPrefix(prefix []string) bool {
+	if len(prefix) == 0 {
+		return true
+	}
+	for _, part := range prefix {
+		if unsafeCommandPrefixPart(part) {
+			return true
+		}
+	}
+	for _, banned := range bannedCommandPrefixSuggestions {
+		if sameStringSlice(prefix, banned) {
+			return true
+		}
+	}
+	if unsafeCommandPrefixLauncher(prefix[0]) {
+		return true
+	}
+	return false
+}
+
+func unsafeCommandPrefixPart(part string) bool {
+	part = strings.TrimSpace(part)
+	return part == "" ||
+		strings.ContainsAny(part, "\x00\r\n*?[]{}") ||
+		strings.Contains(part, "$(") ||
+		strings.Contains(part, "`")
+}
+
+func unsafeCommandPrefixLauncher(program string) bool {
+	program = strings.ToLower(strings.TrimSpace(program))
+	if strings.ContainsAny(program, `/\`) {
+		return true
+	}
+	switch program {
+	case "bash", "sh", "zsh", "/bin/bash", "/bin/zsh",
+		"pwsh", "powershell", "powershell.exe",
+		"env", "sudo", "doas", "su", "run0", "osascript",
+		"command", "eval", "exec", "time",
+		"find", "xargs", "timeout", "nice", "nohup", "watch", "setsid", "stdbuf", "ionice",
+		"ssh", "make", "npm", "npx",
+		"python", "python3", "py", "pythonw", "pyw", "pypy", "pypy3",
+		"node", "perl", "ruby", "php", "lua", "deno", "bun":
+		return true
+	default:
+		return false
+	}
 }
 
 func sameStringSlice(left []string, right []string) bool {

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -83,10 +83,44 @@ func (engine *Engine) GrantCommandPrefixForSession(toolName string, prefix []str
 	if engine == nil || len(prefix) == 0 {
 		return
 	}
+	prefix, ok := NormalizeCommandPrefix(prefix)
+	if !ok {
+		return
+	}
 	engine.commandPrefixes.add(CommandPrefixGrant{
 		ToolName: toolName,
 		Prefix:   prefix,
+		Session:  true,
 	})
+}
+
+func (engine *Engine) GrantCommandPrefix(input CommandPrefixInput) (CommandPrefixGrant, error) {
+	if engine == nil || engine.store == nil {
+		return CommandPrefixGrant{}, errors.New("sandbox grant store is not configured")
+	}
+	return engine.store.GrantCommandPrefix(input)
+}
+
+func (engine *Engine) LookupCommandPrefix(toolName string, command []string) (CommandPrefixGrant, bool) {
+	if engine == nil || engine.store == nil || len(command) == 0 {
+		return CommandPrefixGrant{}, false
+	}
+	grant, matched, err := engine.store.LookupCommandPrefix(toolName, command)
+	if err != nil {
+		return CommandPrefixGrant{}, false
+	}
+	return grant, matched
+}
+
+func (engine *Engine) ApprovedCommandPrefixes() []CommandPrefixGrant {
+	if engine == nil || engine.store == nil {
+		return nil
+	}
+	grants, err := engine.store.ListCommandPrefixes()
+	if err != nil {
+		return nil
+	}
+	return grants
 }
 
 func (engine *Engine) LookupCommandPrefixForSession(toolName string, command []string) (CommandPrefixGrant, bool) {

--- a/internal/sandbox/grants.go
+++ b/internal/sandbox/grants.go
@@ -52,8 +52,9 @@ type GrantLookup struct {
 }
 
 type grantFile struct {
-	SchemaVersion int                `json:"schemaVersion"`
-	Grants        map[string][]Grant `json:"grants"`
+	SchemaVersion   int                             `json:"schemaVersion"`
+	Grants          map[string][]Grant              `json:"grants"`
+	CommandPrefixes map[string][]CommandPrefixGrant `json:"commandPrefixes,omitempty"`
 }
 
 type GrantStore struct {
@@ -151,6 +152,36 @@ func (store *GrantStore) Grant(input GrantInput) (Grant, error) {
 	return grant, nil
 }
 
+func (store *GrantStore) GrantCommandPrefix(input CommandPrefixInput) (CommandPrefixGrant, error) {
+	grant, err := createCommandPrefixGrant(input, store.now)
+	if err != nil {
+		return CommandPrefixGrant{}, err
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	state, err := store.readState()
+	if err != nil {
+		return CommandPrefixGrant{}, err
+	}
+	bucket := state.CommandPrefixes[grant.ToolName]
+	replaced := false
+	for i := range bucket {
+		if sameStringSlice(bucket[i].Prefix, grant.Prefix) {
+			bucket[i] = grant
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		bucket = append(bucket, grant)
+	}
+	state.CommandPrefixes[grant.ToolName] = bucket
+	if err := store.writeState(state); err != nil {
+		return CommandPrefixGrant{}, err
+	}
+	return grant, nil
+}
+
 // Lookup returns the grant that governs a tool call whose normalized scope is
 // reqScope (empty for a tool-wide request, e.g. a shell command with no cwd).
 // Among the tool's grants that cover the request, a covering deny wins outright
@@ -172,6 +203,29 @@ func (store *GrantStore) Lookup(toolName string, reqScope string, requestedAuton
 	}
 	bucket := state.Grants[strings.TrimSpace(toolName)]
 	return lookupGrantBucket(bucket, reqScope, requested), nil
+}
+
+func (store *GrantStore) LookupCommandPrefix(toolName string, command []string) (CommandPrefixGrant, bool, error) {
+	if err := ValidateToolName(toolName); err != nil {
+		return CommandPrefixGrant{}, false, err
+	}
+	if _, ok := NormalizeCommandPrefix(command); !ok {
+		return CommandPrefixGrant{}, false, nil
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	state, err := store.readState()
+	if err != nil {
+		return CommandPrefixGrant{}, false, err
+	}
+	bucket := state.CommandPrefixes[strings.TrimSpace(toolName)]
+	for _, grant := range bucket {
+		if hasStringPrefix(command, grant.Prefix) {
+			grant.Prefix = append([]string(nil), grant.Prefix...)
+			return grant, true, nil
+		}
+	}
+	return CommandPrefixGrant{}, false, nil
 }
 
 func lookupGrantBucket(bucket []Grant, reqScope string, requested Autonomy) GrantLookup {
@@ -225,6 +279,32 @@ func (store *GrantStore) List() ([]Grant, error) {
 	return grants, nil
 }
 
+func (store *GrantStore) ListCommandPrefixes() ([]CommandPrefixGrant, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	state, err := store.readState()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(state.CommandPrefixes))
+	for name := range state.CommandPrefixes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	grants := make([]CommandPrefixGrant, 0, len(names))
+	for _, name := range names {
+		bucket := append([]CommandPrefixGrant(nil), state.CommandPrefixes[name]...)
+		sort.Slice(bucket, func(i, j int) bool {
+			return strings.Join(bucket[i].Prefix, "\x00") < strings.Join(bucket[j].Prefix, "\x00")
+		})
+		for i := range bucket {
+			bucket[i].Prefix = append([]string(nil), bucket[i].Prefix...)
+		}
+		grants = append(grants, bucket...)
+	}
+	return grants, nil
+}
+
 func (store *GrantStore) Revoke(toolName string) (int, error) {
 	if err := ValidateToolName(toolName); err != nil {
 		return 0, err
@@ -237,11 +317,13 @@ func (store *GrantStore) Revoke(toolName string) (int, error) {
 	}
 	key := strings.TrimSpace(toolName)
 	bucket, ok := state.Grants[key]
-	if !ok || len(bucket) == 0 {
+	prefixes := state.CommandPrefixes[key]
+	if (!ok || len(bucket) == 0) && len(prefixes) == 0 {
 		return 0, nil
 	}
-	count := len(bucket)
+	count := len(bucket) + len(prefixes)
 	delete(state.Grants, key)
+	delete(state.CommandPrefixes, key)
 	if err := store.writeState(state); err != nil {
 		return 0, err
 	}
@@ -307,6 +389,9 @@ func (store *GrantStore) Clear() (int, error) {
 	for _, bucket := range state.Grants {
 		count += len(bucket)
 	}
+	for _, bucket := range state.CommandPrefixes {
+		count += len(bucket)
+	}
 	if count == 0 {
 		return 0, nil
 	}
@@ -317,7 +402,11 @@ func (store *GrantStore) Clear() (int, error) {
 }
 
 func FormatGrantList(grants []Grant) string {
-	if len(grants) == 0 {
+	return FormatGrantListWithCommandPrefixes(grants, nil)
+}
+
+func FormatGrantListWithCommandPrefixes(grants []Grant, prefixes []CommandPrefixGrant) string {
+	if len(grants) == 0 && len(prefixes) == 0 {
 		return "No persistent sandbox grants."
 	}
 	lines := []string{"Sandbox Grants:"}
@@ -327,6 +416,13 @@ func FormatGrantList(grants []Grant) string {
 			scope = "*" // tool-wide
 		}
 		line := fmt.Sprintf("  %s (%s) [%s/%s] approved %s", grant.ToolName, scope, grant.Decision, grant.MaxAutonomy, grant.ApprovedAt)
+		if grant.Reason != "" {
+			line += " - " + redaction.RedactString(grant.Reason, redaction.Options{})
+		}
+		lines = append(lines, line)
+	}
+	for _, grant := range prefixes {
+		line := fmt.Sprintf("  %s (`%s`) [command-prefix] approved %s", grant.ToolName, strings.Join(grant.Prefix, " "), grant.ApprovedAt)
 		if grant.Reason != "" {
 			line += " - " + redaction.RedactString(grant.Reason, redaction.Options{})
 		}
@@ -370,6 +466,23 @@ func createGrant(input GrantInput, now func() time.Time) (Grant, error) {
 		MaxAutonomy: autonomy,
 		ApprovedAt:  now().UTC().Format(time.RFC3339),
 		Reason:      redaction.RedactString(strings.TrimSpace(input.Reason), redaction.Options{}),
+	}, nil
+}
+
+func createCommandPrefixGrant(input CommandPrefixInput, now func() time.Time) (CommandPrefixGrant, error) {
+	toolName := strings.TrimSpace(input.ToolName)
+	if err := ValidateToolName(toolName); err != nil {
+		return CommandPrefixGrant{}, err
+	}
+	prefix, ok := NormalizeCommandPrefix(input.Prefix)
+	if !ok {
+		return CommandPrefixGrant{}, fmt.Errorf("invalid command prefix")
+	}
+	return CommandPrefixGrant{
+		ToolName:   toolName,
+		Prefix:     prefix,
+		ApprovedAt: now().UTC().Format(time.RFC3339),
+		Reason:     redaction.RedactString(strings.TrimSpace(input.Reason), redaction.Options{}),
 	}, nil
 }
 
@@ -419,13 +532,15 @@ func (store *GrantStore) readState() (grantFile, error) {
 	// directly to a single Grant — can be decoded and migrated separately from the
 	// current (v2) map[tool][]Grant shape.
 	var head struct {
-		SchemaVersion int             `json:"schemaVersion"`
-		Grants        json.RawMessage `json:"grants"`
+		SchemaVersion   int             `json:"schemaVersion"`
+		Grants          json.RawMessage `json:"grants"`
+		CommandPrefixes json.RawMessage `json:"commandPrefixes"`
 	}
 	if err := json.Unmarshal(data, &head); err != nil {
 		return grantFile{}, store.invalidGrantFile(err)
 	}
 	buckets := map[string][]Grant{}
+	commandPrefixBuckets := map[string][]CommandPrefixGrant{}
 	switch head.SchemaVersion {
 	case 1:
 		var legacy map[string]Grant
@@ -443,6 +558,11 @@ func (store *GrantStore) readState() (grantFile, error) {
 	case grantSchemaVersion:
 		if len(head.Grants) > 0 {
 			if err := json.Unmarshal(head.Grants, &buckets); err != nil {
+				return grantFile{}, store.invalidGrantFile(err)
+			}
+		}
+		if len(head.CommandPrefixes) > 0 {
+			if err := json.Unmarshal(head.CommandPrefixes, &commandPrefixBuckets); err != nil {
 				return grantFile{}, store.invalidGrantFile(err)
 			}
 		}
@@ -465,7 +585,21 @@ func (store *GrantStore) readState() (grantFile, error) {
 			normalized[key] = append(normalized[key], ng)
 		}
 	}
-	return grantFile{SchemaVersion: grantSchemaVersion, Grants: normalized}, nil
+	normalizedPrefixes := map[string][]CommandPrefixGrant{}
+	for name, bucket := range commandPrefixBuckets {
+		key := strings.TrimSpace(name)
+		if err := ValidateToolName(key); err != nil {
+			return grantFile{}, store.invalidGrantFile(err)
+		}
+		for _, grant := range bucket {
+			ng, err := normalizeStoredCommandPrefixGrant(key, grant)
+			if err != nil {
+				return grantFile{}, store.invalidGrantFile(err)
+			}
+			normalizedPrefixes[key] = append(normalizedPrefixes[key], ng)
+		}
+	}
+	return grantFile{SchemaVersion: grantSchemaVersion, Grants: normalized, CommandPrefixes: normalizedPrefixes}, nil
 }
 
 func (store *GrantStore) invalidGrantFile(err error) error {
@@ -522,10 +656,32 @@ func normalizeStoredGrant(name string, grant Grant) (Grant, error) {
 	return grant, nil
 }
 
+func normalizeStoredCommandPrefixGrant(name string, grant CommandPrefixGrant) (CommandPrefixGrant, error) {
+	if strings.TrimSpace(grant.ToolName) == "" {
+		grant.ToolName = name
+	}
+	if strings.TrimSpace(grant.ToolName) != name {
+		return CommandPrefixGrant{}, fmt.Errorf("command prefix key %q does not match toolName %q", name, grant.ToolName)
+	}
+	if strings.TrimSpace(grant.ApprovedAt) == "" {
+		return CommandPrefixGrant{}, fmt.Errorf("command prefix grant %s approvedAt is required", name)
+	}
+	prefix, ok := NormalizeCommandPrefix(grant.Prefix)
+	if !ok {
+		return CommandPrefixGrant{}, fmt.Errorf("invalid command prefix for %s", name)
+	}
+	grant.ToolName = name
+	grant.Prefix = prefix
+	grant.ApprovedAt = strings.TrimSpace(grant.ApprovedAt)
+	grant.Reason = redaction.RedactString(strings.TrimSpace(grant.Reason), redaction.Options{})
+	return grant, nil
+}
+
 func emptyGrantState() grantFile {
 	return grantFile{
-		SchemaVersion: grantSchemaVersion,
-		Grants:        map[string][]Grant{},
+		SchemaVersion:   grantSchemaVersion,
+		Grants:          map[string][]Grant{},
+		CommandPrefixes: map[string][]CommandPrefixGrant{},
 	}
 }
 

--- a/internal/sandbox/grants_test.go
+++ b/internal/sandbox/grants_test.go
@@ -77,6 +77,88 @@ func TestGrantStorePersistsListsRevokesAndClears(t *testing.T) {
 	}
 }
 
+func TestGrantStorePersistsCommandPrefixes(t *testing.T) {
+	store, err := NewGrantStore(StoreOptions{
+		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),
+		Now:      fixedSandboxTime("2026-06-05T14:30:00Z"),
+	})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	grant, err := store.GrantCommandPrefix(CommandPrefixInput{
+		ToolName: "bash",
+		Prefix:   []string{"git", "status"},
+		Reason:   "status checks",
+	})
+	if err != nil {
+		t.Fatalf("GrantCommandPrefix returned error: %v", err)
+	}
+	if grant.ApprovedAt != "2026-06-05T14:30:00Z" {
+		t.Fatalf("approvedAt = %q, want fixed timestamp", grant.ApprovedAt)
+	}
+
+	// Re-granting the same prefix updates instead of duplicating.
+	if _, err := store.GrantCommandPrefix(CommandPrefixInput{ToolName: "bash", Prefix: []string{"git", "status"}, Reason: "updated"}); err != nil {
+		t.Fatalf("GrantCommandPrefix update returned error: %v", err)
+	}
+	reopened, err := NewGrantStore(StoreOptions{FilePath: store.FilePath()})
+	if err != nil {
+		t.Fatalf("reopen grant store: %v", err)
+	}
+	prefixes, err := reopened.ListCommandPrefixes()
+	if err != nil {
+		t.Fatalf("ListCommandPrefixes returned error: %v", err)
+	}
+	if len(prefixes) != 1 || prefixes[0].ToolName != "bash" || !sameStringSlice(prefixes[0].Prefix, []string{"git", "status"}) || prefixes[0].Reason != "updated" {
+		t.Fatalf("unexpected command prefixes: %#v", prefixes)
+	}
+	match, matched, err := reopened.LookupCommandPrefix("bash", []string{"git", "status", "--short"})
+	if err != nil {
+		t.Fatalf("LookupCommandPrefix returned error: %v", err)
+	}
+	if !matched || !sameStringSlice(match.Prefix, []string{"git", "status"}) {
+		t.Fatalf("lookup = (%#v,%t), want git status match", match, matched)
+	}
+	if _, matched, err := reopened.LookupCommandPrefix("bash", []string{"git", "diff"}); err != nil || matched {
+		t.Fatalf("git diff lookup = matched %t err %v, want no match", matched, err)
+	}
+	text := FormatGrantListWithCommandPrefixes(nil, prefixes)
+	for _, want := range []string{"Sandbox Grants:", "bash", "`git status`", "command-prefix", "updated"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("formatted grants = %q, missing %q", text, want)
+		}
+	}
+
+	revoked, err := reopened.Revoke("bash")
+	if err != nil {
+		t.Fatalf("Revoke returned error: %v", err)
+	}
+	if revoked != 1 {
+		t.Fatalf("revoked = %d, want 1", revoked)
+	}
+	if prefixes, err := reopened.ListCommandPrefixes(); err != nil || len(prefixes) != 0 {
+		t.Fatalf("prefixes after revoke = %#v err %v, want none", prefixes, err)
+	}
+}
+
+func TestGrantStoreRejectsUnsafeCommandPrefixes(t *testing.T) {
+	store, err := NewGrantStore(StoreOptions{FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json")})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	for _, prefix := range [][]string{
+		{"find"},
+		{"xargs"},
+		{"python", "script.py"},
+		{"./script.sh"},
+		{"git"},
+	} {
+		if _, err := store.GrantCommandPrefix(CommandPrefixInput{ToolName: "bash", Prefix: prefix}); err == nil {
+			t.Fatalf("GrantCommandPrefix(%#v) succeeded, want validation error", prefix)
+		}
+	}
+}
+
 func TestGrantStoreRejectsUnsafeInputsAndMalformedFiles(t *testing.T) {
 	root := t.TempDir()
 	store, err := NewGrantStore(StoreOptions{FilePath: filepath.Join(root, "sandbox-grants.json")})
@@ -99,6 +181,21 @@ func TestGrantStoreRejectsUnsafeInputsAndMalformedFiles(t *testing.T) {
 	}
 	if _, err := store.List(); err == nil || !strings.Contains(err.Error(), "unsupported schemaVersion") {
 		t.Fatalf("expected unsupported schema error, got %v", err)
+	}
+}
+
+func TestGrantStoreRejectsUnsafeStoredCommandPrefix(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "sandbox-grants.json")
+	if err := writeText(path, `{"schemaVersion":2,"grants":{},"commandPrefixes":{"bash":[{"toolName":"bash","prefix":["find"],"approvedAt":"2026-06-05T14:30:00Z"}]}}`); err != nil {
+		t.Fatalf("write malformed command prefix: %v", err)
+	}
+	store, err := NewGrantStore(StoreOptions{FilePath: path})
+	if err != nil {
+		t.Fatalf("NewGrantStore returned error: %v", err)
+	}
+	if _, err := store.ListCommandPrefixes(); err == nil || !strings.Contains(err.Error(), "invalid command prefix") {
+		t.Fatalf("expected invalid command prefix error, got %v", err)
 	}
 }
 

--- a/internal/sandbox/risk_hardening_test.go
+++ b/internal/sandbox/risk_hardening_test.go
@@ -253,6 +253,13 @@ func TestClassifyASTCatchesDestructiveProgramsRegexMisses(t *testing.T) {
 	}
 }
 
+func TestClassifyFlagsFindDeleteAsDestructive(t *testing.T) {
+	risk := classifyCommand("find . -type f -delete")
+	if risk.Level != RiskCritical || !HasRiskCategory(risk, "destructive") {
+		t.Fatalf("Classify(find -delete) = level %s, categories %v; want critical destructive", risk.Level, risk.Categories)
+	}
+}
+
 func TestClassifyASTCatchesNetworkProgramsRegexMisses(t *testing.T) {
 	for _, command := range []string{
 		"telnet example.com 23",

--- a/internal/tui/command_views.go
+++ b/internal/tui/command_views.go
@@ -307,10 +307,33 @@ func (m model) permissionsTextWithStore(store grantLister) string {
 			},
 		})
 	}
+	prefixes := []sandbox.CommandPrefixGrant{}
+	if prefixStore, ok := store.(commandPrefixGrantLister); ok {
+		var prefixErr error
+		prefixes, prefixErr = prefixStore.ListCommandPrefixes()
+		if prefixErr != nil {
+			return renderCommandCardTranscript(commandCard{
+				Title:   "Permissions",
+				Summary: []string{mode + " permissions", "grants error"},
+				Sections: []commandCardSection{
+					{
+						Title: "State",
+						Fields: []commandField{
+							{Key: "mode", Value: mode},
+						},
+					},
+					{
+						Title: "Grants",
+						Lines: []string{"error: " + prefixErr.Error()},
+					},
+				},
+			})
+		}
+	}
 
 	snapshots := zerocommands.SandboxGrantSnapshots(grants)
 	grantRows := []commandRow{}
-	if len(snapshots) == 0 {
+	if len(snapshots) == 0 && len(prefixes) == 0 {
 		grantRows = append(grantRows, commandRow{Text: "none"})
 	} else {
 		for _, grant := range snapshots {
@@ -323,11 +346,21 @@ func (m model) permissionsTextWithStore(store grantLister) string {
 			}
 			grantRows = append(grantRows, commandRow{Text: line})
 		}
+		for _, grant := range prefixes {
+			line := fmt.Sprintf("%s `%s` [command-prefix]", grant.ToolName, strings.Join(grant.Prefix, " "))
+			if grant.ApprovedAt != "" {
+				line += " approved " + grant.ApprovedAt
+			}
+			if grant.Reason != "" {
+				line += " - " + grant.Reason
+			}
+			grantRows = append(grantRows, commandRow{Text: line})
+		}
 	}
 
 	return renderCommandCardTranscript(commandCard{
 		Title:   "Permissions",
-		Summary: []string{mode + " permissions", formatGrantCount(len(snapshots))},
+		Summary: []string{mode + " permissions", formatGrantCount(len(snapshots) + len(prefixes))},
 		Sections: []commandCardSection{
 			{
 				Title: "State",
@@ -348,6 +381,10 @@ func (m model) permissionsTextWithStore(store grantLister) string {
 // filesystem path.
 type grantLister interface {
 	List() ([]sandbox.Grant, error)
+}
+
+type commandPrefixGrantLister interface {
+	ListCommandPrefixes() ([]sandbox.CommandPrefixGrant, error)
 }
 
 func formatGrantCount(count int) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -323,13 +323,14 @@ type prWatcherStartedMsg struct {
 type permissionDecision = agent.PermissionDecisionAction
 
 const (
-	permissionDecisionAllow           permissionDecision = agent.PermissionDecisionAllow
-	permissionDecisionAllowStrict     permissionDecision = agent.PermissionDecisionAllowStrict
-	permissionDecisionAllowForSession permissionDecision = agent.PermissionDecisionAllowForSession
-	permissionDecisionAllowPrefix     permissionDecision = agent.PermissionDecisionAllowPrefix
-	permissionDecisionDeny            permissionDecision = agent.PermissionDecisionDeny
-	permissionDecisionAlwaysAllow     permissionDecision = agent.PermissionDecisionAlwaysAllow
-	permissionDecisionCancel          permissionDecision = agent.PermissionDecisionCancel
+	permissionDecisionAllow             permissionDecision = agent.PermissionDecisionAllow
+	permissionDecisionAllowStrict       permissionDecision = agent.PermissionDecisionAllowStrict
+	permissionDecisionAllowForSession   permissionDecision = agent.PermissionDecisionAllowForSession
+	permissionDecisionAllowPrefix       permissionDecision = agent.PermissionDecisionAllowPrefix
+	permissionDecisionAlwaysAllowPrefix permissionDecision = agent.PermissionDecisionAlwaysAllowPrefix
+	permissionDecisionDeny              permissionDecision = agent.PermissionDecisionDeny
+	permissionDecisionAlwaysAllow       permissionDecision = agent.PermissionDecisionAlwaysAllow
+	permissionDecisionCancel            permissionDecision = agent.PermissionDecisionCancel
 )
 
 type permissionRequestMsg struct {
@@ -2286,6 +2287,8 @@ func permissionDecisionReason(decision permissionDecision) string {
 		return "approved for this session in TUI"
 	case permissionDecisionAllowPrefix:
 		return "approved command prefix for this session in TUI"
+	case permissionDecisionAlwaysAllowPrefix:
+		return "persistently approved command prefix in TUI"
 	case permissionDecisionAlwaysAllow:
 		return "persistently approved in TUI"
 	case permissionDecisionCancel:

--- a/internal/tui/permission_prompt.go
+++ b/internal/tui/permission_prompt.go
@@ -42,6 +42,8 @@ func permissionOptions(request agent.PermissionRequest) []permissionOption {
 			options = append(options, permissionOption{label: "allow for session", hotkey: "s", choice: permissionDecisionAllowForSession})
 		case agent.PermissionDecisionAllowPrefix:
 			options = append(options, permissionOption{label: "allow command prefix for session", hotkey: "p", choice: permissionDecisionAllowPrefix})
+		case agent.PermissionDecisionAlwaysAllowPrefix:
+			options = append(options, permissionOption{label: "always allow command prefix", hotkey: "y", choice: permissionDecisionAlwaysAllowPrefix})
 		case agent.PermissionDecisionAlwaysAllow:
 			options = append(options, permissionOption{label: "always", hotkey: "y", choice: permissionDecisionAlwaysAllow})
 		case agent.PermissionDecisionDeny:

--- a/internal/tui/permission_prompt_test.go
+++ b/internal/tui/permission_prompt_test.go
@@ -103,6 +103,30 @@ func TestPermissionOptionsExposeCommandPrefixApproval(t *testing.T) {
 	}
 }
 
+func TestPermissionOptionsExposePersistentCommandPrefixApproval(t *testing.T) {
+	request := agent.PermissionRequest{
+		ToolName:      "bash",
+		CommandPrefix: []string{"git", "status"},
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowPrefix,
+			agent.PermissionDecisionAlwaysAllowPrefix,
+			agent.PermissionDecisionCancel,
+		},
+	}
+	options := permissionOptions(request)
+	if len(options) != 4 || options[2].choice != permissionDecisionAlwaysAllowPrefix || options[2].hotkey != "y" {
+		t.Fatalf("persistent prefix option = %#v, want y hotkey in supplied order", options)
+	}
+	card, _ := renderFocusedPermissionPrompt(request, 2, 100)
+	got := plainRender(t, card)
+	for _, want := range []string{"always allow `git status`", "[y]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("permission card = %q, missing %q", got, want)
+		}
+	}
+}
+
 func TestPermissionOptionsCanExposePatchCancelWithoutRecoverableDeny(t *testing.T) {
 	request := agent.PermissionRequest{
 		ToolName: "apply_patch",

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -765,7 +765,9 @@ func renderPermissionRow(row transcriptRow, width int) string {
 	switch event.Action {
 	case agent.PermissionActionAllow:
 		label := "allowed once"
-		if event.DecisionAction == agent.PermissionDecisionAllowPrefix {
+		if event.DecisionAction == agent.PermissionDecisionAlwaysAllowPrefix {
+			label = "always prefix"
+		} else if event.DecisionAction == agent.PermissionDecisionAllowPrefix {
 			label = "allowed prefix"
 		} else if event.DecisionAction == agent.PermissionDecisionAllowForSession ||
 			(event.Grant != nil && event.Grant.Session) {
@@ -934,6 +936,11 @@ func permissionOptionLabel(option permissionOption, request agent.PermissionRequ
 			return "Yes, and allow `" + strings.Join(request.CommandPrefix, " ") + "` in this session"
 		}
 		return "Yes, and allow this command prefix in this session"
+	case permissionDecisionAlwaysAllowPrefix:
+		if len(request.CommandPrefix) > 0 {
+			return "Yes, and always allow `" + strings.Join(request.CommandPrefix, " ") + "`"
+		}
+		return "Yes, and always allow this command prefix"
 	case permissionDecisionAlwaysAllow:
 		if request.SideEffect == string(tools.SideEffectNetwork) {
 			return "Yes, and allow this host in the future"


### PR DESCRIPTION
## Summary
- add persistent command-prefix grants to the sandbox grants store and engine lookup path
- add a separate persistent prefix approval decision in the agent and TUI
- show saved prefixes in prompt context and sandbox grants list output
- tighten reusable prefix validation for runner-style launchers and script paths, plus classify find -delete as destructive

## Validation
- GOCACHE=/tmp/zero-go-cache go test ./internal/agent ./internal/sandbox ./internal/tui ./internal/cli
- GOCACHE=/tmp/zero-go-cache go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent command-prefix approvals that survive across sessions
  * "Always allow command prefix" option in permission prompts
  * Approved command prefixes displayed in system prompts to the AI agent
  * CLI support for listing command-prefix grants

* **Bug Fixes**
  * Enhanced detection of destructive commands (e.g., `find -delete`)
  * Stricter validation rejecting unsafe command launchers (e.g., interpreters, `sudo`, `xargs`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->