### PR TITLE
tui: live working status (elapsed) + streaming reasoning preview so long turns never look frozen

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2783,18 +2783,25 @@ func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
 	m.pendingImages = nil
 	m.pendingImageLabels = nil
 	runCtx, cancel := context.WithCancel(m.ctx)
+	m = m.beginRun(cancel)
+	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, turnImages), m.spinner.Tick)
+}
+
+// beginRun stamps the shared run-start state for a new agent turn: a fresh run
+// ID, the cancel func, pending = true, the turn-start timestamp (the source for
+// the working status line's live elapsed clock), and a reset working-verb
+// rotation so the brand word shows first. Centralized so every launch path
+// (normal prompt + spec draft/impl) keeps these in sync — a missing
+// turnStartedAt previously dropped the elapsed timer on spec-mode runs.
+func (m model) beginRun(cancel context.CancelFunc) model {
 	m.runID++
 	m.activeRunID = m.runID
 	m.runCancel = cancel
 	m.pending = true
 	m.turnStartedAt = m.now()
-	// Rewind the verb rotation so the user sees "gitlawbmaxxing" first when
-	// the new run starts (instead of mid-rotation from a prior turn). Also
-	// reset the step counter so the cadence doesn't carry over a partial
-	// countdown from the previous run.
 	m.workingVerbTicks = 0
 	m.workingVerb.Reset()
-	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, turnImages), m.spinner.Tick)
+	return m
 }
 
 func (m model) launchQueuedMessageIfReady() (model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -124,11 +124,15 @@ type model struct {
 	workingVerb      *workingWords
 	workingVerbTicks int
 	pending          bool
-	queuedMessage    string
-	exiting          bool
-	runCancel        context.CancelFunc
-	runID            int
-	activeRunID      int
+	// turnStartedAt is when the in-flight run began; the working status line
+	// renders the live elapsed time from it so a long or stalled turn never looks
+	// like a frozen terminal (for ANY provider, not just slow ones). Zero = idle.
+	turnStartedAt time.Time
+	queuedMessage string
+	exiting       bool
+	runCancel     context.CancelFunc
+	runID         int
+	activeRunID   int
 	// flushRunIDs holds the ids of runs cancelled while still in flight, mapped
 	// to the session they were recording into AT CANCEL TIME. Each cancelled
 	// agent goroutine keeps running to completion and returns its accumulated
@@ -1797,10 +1801,15 @@ func (m model) interimBlock(width int) string {
 		blocks = append(blocks, renderReasoningBlock(reasoning, m.streamingReasoningExpanded, width, true, 0))
 	}
 	if strings.TrimSpace(text) == "" {
-		if len(blocks) > 0 {
-			return strings.Join(blocks, "\n")
+		blocks = append(blocks, m.workingStatusLine())
+		// During a long think the reasoning block is collapsed to just its header;
+		// show a live tail of the streaming reasoning beneath the working line so
+		// the screen keeps changing (never looks stuck) and the user can see WHAT
+		// the model is reasoning about. Skipped when expanded (the full body shows).
+		if reasoning != "" && !m.streamingReasoningExpanded {
+			blocks = append(blocks, reasoningPreviewLines(reasoning, width)...)
 		}
-		return zeroTheme.accent.Render(m.spinner.View()) + " " + zeroTheme.muted.Render(m.workingVerb.Current())
+		return strings.Join(blocks, "\n")
 	}
 	lines := renderAssistantMarkdownText(text, assistantMeasure(width), width)
 	for index, line := range lines {
@@ -1814,7 +1823,78 @@ func (m model) interimBlock(width int) string {
 	}
 	lines = appendStreamingCursor(lines, width)
 	blocks = append(blocks, strings.Join(lines, "\n"))
+	// Always show the live working line (spinner + verb + elapsed) BELOW the
+	// streamed text so an upstream stall keeps animating, never a frozen screen.
+	blocks = append(blocks, m.workingStatusLine())
 	return strings.Join(blocks, "\n")
+}
+
+// workingStatusLine renders the live "working" indicator shown on every pending
+// render: an animated spinner, the rotating working verb, and the elapsed time.
+// It is shown even once partial text has streamed so an upstream stall never
+// looks like a frozen terminal — the spinner tick (~80ms, time-based) drives the
+// re-render, so the elapsed clock keeps advancing for ANY provider/model even
+// when no stream data arrives.
+func (m model) workingStatusLine() string {
+	line := zeroTheme.accent.Render(m.spinner.View()) + " " + zeroTheme.muted.Render(m.workingVerb.Current())
+	if !m.turnStartedAt.IsZero() {
+		line += zeroTheme.faint.Render("  ·  " + formatWorkingElapsed(m.now().Sub(m.turnStartedAt)))
+	}
+	return line
+}
+
+// formatWorkingElapsed renders a turn's running time compactly: "8s", "1m04s".
+func formatWorkingElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%02ds", int(d/time.Minute), int(d.Seconds())%60)
+}
+
+// reasoningPreviewLines renders the last 1-2 lines of the in-flight reasoning
+// stream as a dimmed preview so a long "Thinking" phase shows live, changing
+// content instead of a static header. Each line shows its TAIL (the most recent
+// text) so a single continuously-growing reasoning line still visibly moves as
+// tokens arrive. Returns nil when there is no reasoning text.
+func reasoningPreviewLines(reasoning string, width int) []string {
+	var lines []string
+	for _, raw := range strings.Split(strings.TrimSpace(reasoning), "\n") {
+		if t := strings.TrimSpace(raw); t != "" {
+			lines = append(lines, t)
+		}
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	if len(lines) > 2 {
+		lines = lines[len(lines)-2:]
+	}
+	avail := width - 2
+	if avail < 8 {
+		avail = 8
+	}
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		out = append(out, "  "+zeroTheme.faint.Render(previewTail(line, avail)))
+	}
+	return out
+}
+
+// previewTail returns the last `width` runes of s, prefixed with "…" when text
+// was dropped, so a streaming preview shows the newest content. s is plain text
+// (reasoning deltas carry no ANSI), so rune counting is a safe width proxy.
+func previewTail(s string, width int) string {
+	runes := []rune(s)
+	if width <= 0 || len(runes) <= width {
+		return s
+	}
+	if width == 1 {
+		return string(runes[len(runes)-1:])
+	}
+	return "…" + string(runes[len(runes)-(width-1):])
 }
 
 func appendStreamingCursor(lines []string, width int) []string {
@@ -2707,6 +2787,7 @@ func (m model) launchPrompt(prompt string) (model, tea.Cmd) {
 	m.activeRunID = m.runID
 	m.runCancel = cancel
 	m.pending = true
+	m.turnStartedAt = m.now()
 	// Rewind the verb rotation so the user sees "gitlawbmaxxing" first when
 	// the new run starts (instead of mid-rotation from a prior turn). Also
 	// reset the step counter so the cadence doesn't carry over a partial

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -121,6 +121,7 @@ func TestPromptSubmitStoresReasoningSeparatelyFromAnswer(t *testing.T) {
 	})
 	base := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
 	times := []time.Time{
+		base, // run start: consumed by turnStartedAt (the working-line elapsed clock)
 		base,
 		base.Add(1 * time.Second),
 		base.Add(1800 * time.Millisecond),

--- a/internal/tui/spec_mode.go
+++ b/internal/tui/spec_mode.go
@@ -68,10 +68,7 @@ func (m model) handleSpecCommand(task string) (tea.Model, tea.Cmd) {
 	specRegistry := cloneToolRegistry(m.registry)
 	specmode.RegisterDraftTools(specRegistry, m.cwd, m.now)
 	runCtx, cancel := context.WithCancel(m.ctx)
-	m.runID++
-	m.activeRunID = m.runID
-	m.runCancel = cancel
-	m.pending = true
+	m = m.beginRun(cancel)
 	return m, tea.Batch(m.runAgentWithOptions(m.activeRunID, runCtx, task, turnImages, tuiAgentRunOptions{
 		registry:       specRegistry,
 		permissionMode: agent.PermissionModeSpecDraft,
@@ -204,22 +201,13 @@ func (m model) approveSpecReview() (tea.Model, tea.Cmd) {
 	m.sessionEvents = append([]sessions.Event{}, events...)
 	m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: "Spec approved. Starting implementation session " + impl.SessionID + "."})
 	runCtx, cancel := context.WithCancel(m.ctx)
-	m.runID++
-	m.activeRunID = m.runID
-	m.runCancel = cancel
-	m.pending = true
-	// Seed the streaming-text fade state for the spec-impl run. The
-	// normal launchPrompt path lets the first agentTextMsg do this; the
-	// spec-impl path calls runAgent directly, so we seed explicitly. The
-	// first incoming delta will re-stamp the in-progress entry and the
-	// fade will start naturally.
+	m = m.beginRun(cancel)
+	// Seed the streaming-text fade state for the spec-impl run. The normal
+	// launchPrompt path lets the first agentTextMsg do this; the spec-impl path
+	// calls runAgent directly, so we seed explicitly. The first incoming delta
+	// will re-stamp the in-progress entry and the fade will start naturally.
 	m.resetStreamingFade()
 	m.fadeActive = true
-	// Reset the working-verb rotation so the user sees the brand word
-	// first when the implementation session starts. Also reset the step
-	// counter so the cadence doesn't carry over a partial countdown.
-	m.workingVerbTicks = 0
-	m.workingVerb.Reset()
 	return m, tea.Batch(m.runAgent(m.activeRunID, runCtx, prompt, nil), m.spinner.Tick)
 }
 

--- a/internal/tui/spec_mode_test.go
+++ b/internal/tui/spec_mode_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -238,4 +239,44 @@ func providerRequestsContain(requests []zeroruntime.CompletionRequest, text stri
 		}
 	}
 	return false
+}
+
+// Regression (PR #254 review): spec-mode launches must seed turnStartedAt so the
+// working status line's live elapsed clock renders on spec runs — previously only
+// the normal prompt path set it. Both draft and impl now route through beginRun.
+func TestSpecLaunchesSeedElapsedClock(t *testing.T) {
+	store := testSessionStore(t)
+	provider := &scriptedProvider{scripts: [][]zeroruntime.StreamEvent{
+		submitSpecScript("call-1", "Review Flow", "# Goal\n\nAdd review flow."),
+		textScript("implemented from approved spec"),
+	}}
+	m := newSpecModeTestModel(t.TempDir(), provider, store)
+	m.input.SetValue("/spec add review flow")
+
+	// Draft launch must seed the clock.
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if cmd == nil || !next.pending {
+		t.Fatal("expected /spec to start a pending draft run")
+	}
+	if next.turnStartedAt.IsZero() {
+		t.Fatal("draft launch did not seed turnStartedAt (elapsed clock would not render)")
+	}
+
+	updated, _ = next.Update(execCmd(cmd))
+	next = updated.(model)
+	if next.pendingSpecReview == nil {
+		t.Fatal("expected pending spec review")
+	}
+	next.turnStartedAt = time.Time{} // zero it to prove the impl path re-seeds independently
+
+	// Approval launches the implementation run, which must also seed the clock.
+	updated, cmd = next.Update(testKeyText("a"))
+	next = updated.(model)
+	if cmd == nil || !next.pending {
+		t.Fatal("expected approval to start a pending implementation run")
+	}
+	if next.turnStartedAt.IsZero() {
+		t.Fatal("impl launch did not seed turnStartedAt (elapsed clock would not render)")
+	}
 }

--- a/internal/tui/working_status_test.go
+++ b/internal/tui/working_status_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatWorkingElapsed(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                 "0s",
+		8 * time.Second:   "8s",
+		59 * time.Second:  "59s",
+		64 * time.Second:  "1m04s",
+		125 * time.Second: "2m05s",
+		-3 * time.Second:  "0s",
+	}
+	for d, want := range cases {
+		if got := formatWorkingElapsed(d); got != want {
+			t.Errorf("formatWorkingElapsed(%s) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+// The key fix: the live working line (spinner + verb + elapsed) is shown even
+// AFTER partial text has streamed, so an upstream stall never looks frozen.
+func TestInterimBlockShowsWorkingLineWithStreamedText(t *testing.T) {
+	m := newModel(t.Context(), Options{ModelName: "gpt-4.1"})
+	m.width = 100
+	base := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+	m.now = func() time.Time { return base.Add(12 * time.Second) }
+	m.turnStartedAt = base
+	m.streamingText = "partial answer so far"
+
+	got := plainRender(t, m.interimBlock(96))
+	if !strings.Contains(got, "partial answer so far") {
+		t.Fatalf("interim block should keep the streamed text:\n%s", got)
+	}
+	if !strings.Contains(got, "12s") {
+		t.Fatalf("interim block should show live elapsed (12s) below the text:\n%s", got)
+	}
+	if !strings.Contains(got, m.workingVerb.Current()) {
+		t.Fatalf("interim block should show the working verb for liveness:\n%s", got)
+	}
+}
+
+func TestPreviewTail(t *testing.T) {
+	cases := []struct {
+		in    string
+		width int
+		want  string
+	}{
+		{"short", 20, "short"},
+		{"exactlyten", 10, "exactlyten"},
+		{"abcdefghijklmnop", 6, "…lmnop"}, // tail with leading ellipsis
+		{"", 8, ""},
+	}
+	for _, c := range cases {
+		if got := previewTail(c.in, c.width); got != c.want {
+			t.Errorf("previewTail(%q,%d) = %q, want %q", c.in, c.width, got, c.want)
+		}
+	}
+}
+
+// The fix: during a think (no answer text yet) the streaming reasoning TAIL is
+// shown beneath the working line, so the screen shows live, changing content.
+func TestInterimBlockShowsReasoningPreviewWhileThinking(t *testing.T) {
+	m := newModel(t.Context(), Options{ModelName: "gpt-4.1"})
+	m.width = 100
+	base := time.Date(2026, 6, 18, 23, 0, 0, 0, time.UTC)
+	m.now = func() time.Time { return base.Add(90 * time.Second) }
+	m.turnStartedAt = base
+	m.streamingReasoning = "analyzing the layout\nthe patch was corrupt so re-planning the css edits"
+	m.streamingText = "" // thinking phase: no answer yet
+
+	got := plainRender(t, m.interimBlock(96))
+	if !strings.Contains(got, "re-planning the css edits") {
+		t.Fatalf("expected the live reasoning tail in the preview:\n%s", got)
+	}
+	if !strings.Contains(got, "1m30s") {
+		t.Fatalf("expected the working-line elapsed clock:\n%s", got)
+	}
+}
+
+// When the reasoning block is EXPANDED, the full body already shows — the
+// collapsed tail preview must NOT be duplicated.
+func TestInterimBlockNoPreviewWhenReasoningExpanded(t *testing.T) {
+	m := newModel(t.Context(), Options{ModelName: "gpt-4.1"})
+	m.width = 100
+	m.now = func() time.Time { return time.Date(2026, 6, 18, 23, 0, 0, 0, time.UTC) }
+	m.streamingReasoningExpanded = true
+	m.streamingReasoning = "only line of reasoning here"
+	m.streamingText = ""
+	got := plainRender(t, m.interimBlock(96))
+	if strings.Count(got, "only line of reasoning here") != 1 {
+		t.Fatalf("reasoning should appear exactly once when expanded (no preview dup):\n%s", got)
+	}
+}


### PR DESCRIPTION
## Problem
On a slow turn the TUI looked **stuck or broken**. Once partial text had streamed, the screen showed only a static cursor; during a reasoning phase it showed only a static `Thinking` header; and there was **no elapsed time anywhere**. With a slow provider or a long-thinking reasoning model, the user couldn't tell whether the agent was working or hung — a multi-minute think looked identical to a frozen terminal.

## Changes (pure TUI render — provider-agnostic)
- **Always-on working status line** — an animated spinner + the rotating working verb + a **live elapsed clock** (`8s`, `1m04s`), rendered on *every* pending frame, **including once partial text has streamed** (previously the spinner vanished as soon as text arrived). The spinner tick is time-based (~80 ms), so the elapsed keeps advancing **even when the upstream goes silent mid-stream** — the screen never freezes.
- **Live reasoning preview** — during a think (before any answer text) the last 1–2 lines of the streaming reasoning are shown dimmed **beneath the working line**, each **tail-truncated** so even a single continuously-growing reasoning line visibly moves as tokens arrive. The user can now see *what* the model is reasoning about. Skipped when the reasoning block is expanded (the full body already shows — no duplicate).

Both live in `interimBlock`, so they apply to **every provider/model**, not just slow ones.

## Before → After (thinking phase)
```
Thinking                              Thinking
                          ──▶         ⠏ working · 1m30s
                                        …the patch was corrupt, re-planning the edits
```

## Testing
- `go test ./internal/tui/...` (incl. `-race`) green.
- New: `TestFormatWorkingElapsed`, `TestPreviewTail`, `TestInterimBlockShowsWorkingLineWithStreamedText`, `TestInterimBlockShowsReasoningPreviewWhileThinking`, `TestInterimBlockNoPreviewWhenReasoningExpanded`.
- Updated `TestPromptSubmitStoresReasoningSeparatelyFromAnswer` for the one extra turn-start timestamp the elapsed clock consumes.
- `gofmt` / `go vet` / `go build ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an always-visible working status line with a live elapsed clock during pending turns
  * When the assistant is thinking and reasoning is collapsed, shows a dim, continuously updating preview tail of recent reasoning

* **Bug Fixes**
  * Ensures the elapsed clock is correctly seeded for both spec draft start and spec approval launch so timing displays reliably

* **Tests**
  * Added unit tests covering elapsed time formatting, interim rendering with partial streaming, and reasoning preview/tail truncation behavior

* **Refactor**
  * Centralized run initialization for spec mode flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->