### PR TITLE
token efficiency: lossless cost accounting + minified file reads (read_minified_file)

### DIFF
--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Gitlawb/zero/internal/specmode"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/usage"
 	"github.com/Gitlawb/zero/internal/worktrees"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
@@ -544,18 +545,13 @@ func runExec(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) in
 			}
 			sessionRecorder.append(sessions.EventToolResult, payload)
 		},
-		OnUsage: func(usage agent.Usage) {
-			writer.usage(usage)
-			payload := map[string]any{
-				"promptTokens":     usage.EffectiveInputTokens(),
-				"completionTokens": usage.EffectiveOutputTokens(),
-				"totalTokens":      usage.TotalTokens(),
-			}
+		OnUsage: func(u agent.Usage) {
+			writer.usage(u)
+			payload := usage.EventUsagePayload(u)
 			// Attribute usage to a specific model ONLY when escalation is enabled:
 			// the model in force can change mid-run only under --allow-escalation, so
 			// the "model" key is meaningful exclusively then. Omitting it otherwise
-			// keeps a non-escalation run's persisted usage payload byte-identical to
-			// before this feature (the origin/main guarantee).
+			// keeps a non-escalation run's persisted usage payload compact.
 			if options.allowEscalation {
 				payload["model"] = currentModel
 			}

--- a/internal/cli/exec_spec.go
+++ b/internal/cli/exec_spec.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Gitlawb/zero/internal/specmode"
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/usage"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -152,13 +153,9 @@ func runExecSpecDraft(run execSpecDraftRun) int {
 			}
 			sessionRecorder.append(sessions.EventToolResult, payload)
 		},
-		OnUsage: func(usage agent.Usage) {
-			writer.usage(usage)
-			sessionRecorder.append(sessions.EventUsage, map[string]any{
-				"promptTokens":     usage.EffectiveInputTokens(),
-				"completionTokens": usage.EffectiveOutputTokens(),
-				"totalTokens":      usage.TotalTokens(),
-			})
+		OnUsage: func(u agent.Usage) {
+			writer.usage(u)
+			sessionRecorder.append(sessions.EventUsage, usage.EventUsagePayload(u))
 		},
 	})
 	run.notifier.Notify(notify.Completion, notify.DefaultMessage(notify.Completion))

--- a/internal/minify/comments.go
+++ b/internal/minify/comments.go
@@ -1,0 +1,189 @@
+package minify
+
+import "strings"
+
+// commentStyle describes one language's comment + string lexical rules for the
+// string-aware stripper. ONLY languages whose every string form this scanner can
+// model exactly appear in commentStyles. Languages with raw-string delimiters
+// (C++ R"(...)", C# @"..."), lifetimes (Rust 'a), template literals (JS/TS
+// `${...}`), nested block comments (Rust/Swift), or heredocs (shell/Ruby) are
+// deliberately omitted — they fall back to whitespace-only minification — so the
+// stripper can never mistake code or string content for a comment, nor a comment
+// for code. Correctness over coverage.
+type commentStyle struct {
+	name       string
+	line       []string // line-comment markers; the rest of the line is dropped
+	blockOpen  string   // "" when the language has no block comments
+	blockClose string
+	triples    []string // raw multi-line string delimiters (Python ''' """, Java text block """)
+	fStrings   bool     // Python f-strings: a quote inside {…} does not end the string
+}
+
+// commentStyles maps a file extension to its stripper config. Every entry here is
+// covered by golden tests in comments_test.go, including the tricky cases
+// (comment chars inside strings, strings inside comments, escapes, triple-quotes,
+// f-string same-quote nesting, Java text blocks).
+var commentStyles = map[string]commentStyle{
+	".c":    {name: "c", line: []string{"//"}, blockOpen: "/*", blockClose: "*/"},
+	".java": {name: "java", line: []string{"//"}, blockOpen: "/*", blockClose: "*/", triples: []string{`"""`}},
+	".css":  {name: "css", blockOpen: "/*", blockClose: "*/"},
+	".scss": {name: "scss", line: []string{"//"}, blockOpen: "/*", blockClose: "*/"},
+	".less": {name: "less", line: []string{"//"}, blockOpen: "/*", blockClose: "*/"},
+	".py":   {name: "python", line: []string{"#"}, triples: []string{`"""`, `'''`}, fStrings: true},
+	".pyi":  {name: "python", line: []string{"#"}, triples: []string{`"""`, `'''`}, fStrings: true},
+}
+
+// stripComments removes line and block comments from src for one language while
+// correctly skipping string, char, triple-quoted, and (Python) f-string literals,
+// so a comment marker inside a literal is never stripped and literal content is
+// never mistaken for a comment. Delimiters are all ASCII, so scanning byte-wise is
+// safe — UTF-8 content is copied verbatim.
+func stripComments(src string, style commentStyle) string {
+	var out strings.Builder
+	out.Grow(len(src))
+	i, n := 0, len(src)
+	for i < n {
+		// Raw multi-line strings first: """ must win over a bare " literal.
+		if d, ok := longestPrefix(src[i:], style.triples); ok {
+			j := scanDelimited(src, i+len(d), d)
+			out.WriteString(src[i:j])
+			i = j
+			continue
+		}
+		// Block comment: drop through the close marker (or to EOF if unterminated).
+		if style.blockOpen != "" && strings.HasPrefix(src[i:], style.blockOpen) {
+			rest := src[i+len(style.blockOpen):]
+			if end := strings.Index(rest, style.blockClose); end >= 0 {
+				i += len(style.blockOpen) + end + len(style.blockClose)
+			} else {
+				i = n
+			}
+			continue
+		}
+		// Line comment: drop to the newline, which is emitted on the next iteration.
+		if _, ok := longestPrefix(src[i:], style.line); ok {
+			if nl := strings.IndexByte(src[i:], '\n'); nl >= 0 {
+				i += nl
+			} else {
+				i = n
+			}
+			continue
+		}
+		// String / char literal.
+		if c := src[i]; c == '"' || c == '\'' {
+			j := scanString(src, i, style.fStrings)
+			out.WriteString(src[i:j])
+			i = j
+			continue
+		}
+		out.WriteByte(src[i])
+		i++
+	}
+	return out.String()
+}
+
+// longestPrefix reports the longest candidate that prefixes s (markers are short
+// and few, so a linear scan is fine).
+func longestPrefix(s string, candidates []string) (string, bool) {
+	best := ""
+	for _, c := range candidates {
+		if len(c) > len(best) && strings.HasPrefix(s, c) {
+			best = c
+		}
+	}
+	return best, best != ""
+}
+
+// scanDelimited returns the index just past the closing delim, starting from
+// bodyStart (just past the opening delim). A backslash escapes the next byte so a
+// \-escaped delimiter does not terminate; an unterminated literal runs to EOF.
+func scanDelimited(src string, bodyStart int, delim string) int {
+	j, n := bodyStart, len(src)
+	for j < n {
+		if src[j] == '\\' {
+			j += 2
+			continue
+		}
+		if strings.HasPrefix(src[j:], delim) {
+			return j + len(delim)
+		}
+		j++
+	}
+	return n
+}
+
+// scanString returns the index just past a closing quote for the string/char
+// literal that opens at i. Backslash escapes the next byte. When fStrings is set
+// and the literal is an f-string (an f/F prefix precedes the quote), a quote that
+// sits inside a {…} replacement field does NOT close the literal — and a nested
+// string inside that field is scanned in turn — so Python 3.12 same-quote-nested
+// f-strings are handled correctly.
+func scanString(src string, i int, fStrings bool) int {
+	quote := src[i]
+	isF := fStrings && hasFStringPrefix(src, i)
+	j, n := i+1, len(src)
+	brace := 0
+	for j < n {
+		c := src[j]
+		if c == '\\' {
+			j += 2
+			continue
+		}
+		if isF {
+			switch c {
+			case '{':
+				if j+1 < n && src[j+1] == '{' { // {{ is a literal brace
+					j += 2
+					continue
+				}
+				brace++
+				j++
+				continue
+			case '}':
+				if j+1 < n && src[j+1] == '}' {
+					j += 2
+					continue
+				}
+				if brace > 0 {
+					brace--
+				}
+				j++
+				continue
+			case '"', '\'':
+				if brace > 0 { // a nested string inside the replacement field
+					j = scanString(src, j, false)
+					continue
+				}
+			}
+		}
+		if c == quote && brace == 0 {
+			return j + 1
+		}
+		j++
+	}
+	return n
+}
+
+// hasFStringPrefix reports whether the quote at i is preceded by a Python string
+// prefix containing f/F (e.g. f", rf", Rf"), bounded so a quote that merely
+// follows an identifier ending in f is not misread as an f-string.
+func hasFStringPrefix(src string, i int) bool {
+	k := i - 1
+	sawF := false
+	for k >= 0 {
+		switch src[k] {
+		case 'f', 'F':
+			sawF = true
+		case 'r', 'R', 'b', 'B', 'u', 'U':
+		default:
+			goto bounded
+		}
+		k--
+	}
+bounded:
+	return sawF && (k < 0 || !isIdentByte(src[k]))
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}

--- a/internal/minify/comments_test.go
+++ b/internal/minify/comments_test.go
@@ -1,0 +1,105 @@
+package minify
+
+import (
+	"strings"
+	"testing"
+)
+
+func mustContain(t *testing.T, s string, subs ...string) {
+	t.Helper()
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			t.Errorf("expected to CONTAIN %q in:\n%s", sub, s)
+		}
+	}
+}
+func mustNotContain(t *testing.T, s string, subs ...string) {
+	t.Helper()
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			t.Errorf("expected NOT to contain %q in:\n%s", sub, s)
+		}
+	}
+}
+
+func TestStripC(t *testing.T) {
+	src := "int x = 1; // DROPLINE\n" +
+		"/* DROPBLOCK\n   spanning */\n" +
+		"int y = 2;\n" +
+		"char *u = \"http://e.com/a//b\"; // DROPURLNOTE\n" +
+		"char c = '\\''; /* DROPCHARNOTE */\n"
+	r := File("f.c", []byte(src))
+	if !r.Applied || r.Language != "c" {
+		t.Fatalf("got %+v", r)
+	}
+	mustNotContain(t, r.Content, "DROPLINE", "DROPBLOCK", "spanning", "DROPURLNOTE", "DROPCHARNOTE")
+	mustContain(t, r.Content, "int x = 1;", "int y = 2;", `"http://e.com/a//b"`, `'\''`)
+}
+
+func TestStripCSSHasNoLineComments(t *testing.T) {
+	// CSS: only /* */ are comments. A //-looking value must survive untouched.
+	src := "a { color: red; /* DROPBLOCK */ }\n" +
+		"b { background: url(http://x//y); }\n" +
+		"/* DROPWHOLE */\n" +
+		"c { content: \"/* KEEPSTR */\"; }\n"
+	r := File("s.css", []byte(src))
+	mustNotContain(t, r.Content, "DROPBLOCK", "DROPWHOLE")
+	mustContain(t, r.Content, "color: red;", "url(http://x//y)", `"/* KEEPSTR */"`)
+}
+
+func TestStripSCSSKeepsInterpolationAndHex(t *testing.T) {
+	src := "$c: #fff; // DROPLINE\n.x { color: #{$c}; } /* DROPBLOCK */\n"
+	r := File("s.scss", []byte(src))
+	mustNotContain(t, r.Content, "DROPLINE", "DROPBLOCK")
+	mustContain(t, r.Content, "#fff", "#{$c}", "color:")
+}
+
+func TestStripJavaTextBlock(t *testing.T) {
+	src := "class A {\n" +
+		"  // DROPLINE\n" +
+		"  String s = \"\"\"\n" +
+		"    KEEP // this and /* this */ and \"\" too\n" +
+		"    \"\"\";\n" +
+		"  int x = 1; /* DROPBLOCK */\n" +
+		"}\n"
+	r := File("A.java", []byte(src))
+	mustNotContain(t, r.Content, "DROPLINE", "DROPBLOCK")
+	mustContain(t, r.Content, "KEEP // this and /* this */ and \"\" too", "int x = 1;")
+}
+
+func TestStripPython(t *testing.T) {
+	src := "x = 1  # DROPCOMMENT\n" +
+		"s = 'has # KEEPHASH inside'\n" +
+		"t = \"\"\"\ntriple # KEEPTRIPLE\n\"\"\"\n" +
+		"u = f\"{d['k']}# KEEPFSTR\"\n" +
+		"r = r'raw\\# KEEPRAW'\n" +
+		"# DROPLINE\n" +
+		"y = 2\n"
+	r := File("m.py", []byte(src))
+	if !r.Applied || r.Language != "python" {
+		t.Fatalf("got %+v", r)
+	}
+	mustNotContain(t, r.Content, "DROPCOMMENT", "DROPLINE")
+	mustContain(t, r.Content, "x = 1", "KEEPHASH", "KEEPTRIPLE", "KEEPFSTR", "KEEPRAW", "y = 2")
+}
+
+func TestStripPythonFStringSameQuoteNesting(t *testing.T) {
+	// Python 3.12 same-quote-nested f-string with a # inside must be preserved.
+	src := "v = f\"{d[\"k\"]}# KEEPINNER\"\nz = 3  # DROPREAL\n"
+	r := File("m.py", []byte(src))
+	mustNotContain(t, r.Content, "DROPREAL")
+	mustContain(t, r.Content, "# KEEPINNER", "z = 3")
+}
+
+func TestUnsupportedLangFallsBackToWhitespaceOnly(t *testing.T) {
+	// JS/TS/C++/Rust/shell are intentionally NOT comment-stripped (hazards).
+	for _, f := range []string{"a.js", "a.ts", "a.cpp", "a.rs", "a.sh"} {
+		r := File(f, []byte("x // KEEPJSCOMMENT\n\n\n y\n"))
+		if r.Applied {
+			t.Errorf("%s: expected whitespace-only (Applied=false), got %+v", f, r)
+		}
+		if !strings.Contains(r.Content, "KEEPJSCOMMENT") {
+			t.Errorf("%s: comment must be preserved for unsupported langs:\n%s", f, r.Content)
+		}
+	}
+}

--- a/internal/minify/minify.go
+++ b/internal/minify/minify.go
@@ -1,0 +1,90 @@
+// Package minify produces a denser, token-cheaper VIEW of a source file for
+// read-only exploration. It strips comments and redundant whitespace so the
+// model can scan or understand code for far fewer tokens than read_file's raw,
+// line-numbered output — without ever changing the file on disk.
+//
+// Correctness over aggression: Go is minified through the real go/parser AST
+// (guaranteed valid, comment-free output), and any file it cannot parse — or any
+// non-Go file — falls back to a conservative whitespace normalization that can
+// never alter code meaning (it strips no comments, since doing that safely needs
+// a real parser per language). The transform is therefore incapable of corrupting
+// what the model sees: the worst case is "no reduction", never "wrong content".
+package minify
+
+import (
+	"bytes"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"path/filepath"
+	"strings"
+)
+
+// Result is the outcome of minifying one file's bytes.
+type Result struct {
+	Content  string // minified (or whitespace-normalized) text; never line-numbered
+	Language string // strategy taken: "go" or "text"
+	Applied  bool   // true only when real comment-stripping minification ran
+}
+
+// File minifies content addressed by path; the extension selects the strategy.
+func File(path string, content []byte) Result {
+	ext := strings.ToLower(filepath.Ext(path))
+	if ext == ".go" {
+		if out, ok := minifyGo(content); ok {
+			return Result{Content: out, Language: "go", Applied: true}
+		}
+		// Unparsable Go (a snippet, generics edge, or syntax error): fall through
+		// to the safe generic path rather than risk a partial AST reprint.
+	} else if style, ok := commentStyles[ext]; ok {
+		// Strip comments with a string-aware lexer, then collapse the whitespace the
+		// removed comments left behind. The stripper only handles languages whose
+		// string forms it models exactly, so it cannot corrupt content.
+		stripped := stripComments(string(content), style)
+		return Result{Content: minifyGeneric([]byte(stripped)), Language: style.name, Applied: true}
+	}
+	return Result{Content: minifyGeneric(content), Language: "text", Applied: false}
+}
+
+// minifyGo parses Go WITHOUT comments (omitting parser.ParseComments leaves them
+// unattached) and reprints the AST, yielding valid, comment-free, gofmt-shaped
+// source with tab indentation (1 char per level). It returns ok=false on any
+// parse error so the caller falls back to the raw text — a non-package snippet or
+// syntactically invalid file is never mangled.
+func minifyGo(content []byte) (string, bool) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", content, parser.SkipObjectResolution)
+	if err != nil {
+		return "", false
+	}
+	var buf bytes.Buffer
+	cfg := printer.Config{Mode: printer.TabIndent, Tabwidth: 1}
+	if err := cfg.Fprint(&buf, fset, file); err != nil {
+		return "", false
+	}
+	return strings.TrimRight(buf.String(), "\n"), true
+}
+
+// minifyGeneric is the safe fallback for non-Go (and unparsable Go) content: it
+// normalizes CRLF, trims trailing whitespace, and collapses runs of blank lines
+// to a single blank — removing easy bloat with zero risk to code semantics. It
+// deliberately strips NO comments.
+func minifyGeneric(content []byte) string {
+	normalized := strings.ReplaceAll(string(content), "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	out := make([]string, 0, len(lines))
+	blankRun := 0
+	for _, line := range lines {
+		trimmed := strings.TrimRight(line, " \t")
+		if trimmed == "" {
+			blankRun++
+			if blankRun > 1 {
+				continue
+			}
+		} else {
+			blankRun = 0
+		}
+		out = append(out, trimmed)
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}

--- a/internal/minify/minify_test.go
+++ b/internal/minify/minify_test.go
@@ -1,0 +1,64 @@
+package minify
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func TestMinifyGoStripsCommentsKeepsValidCode(t *testing.T) {
+	src := `package demo
+
+import "fmt"
+
+// Greet returns a greeting. This doc comment MUST be removed.
+func Greet(name string) string {
+	// inline comment to drop
+	msg := fmt.Sprintf("hi %s", name) // trailing comment
+	return msg
+}
+`
+	r := File("x.go", []byte(src))
+	if !r.Applied || r.Language != "go" {
+		t.Fatalf("expected go minification, got %+v", r)
+	}
+	for _, c := range []string{"MUST be removed", "inline comment", "trailing comment", "//"} {
+		if strings.Contains(r.Content, c) {
+			t.Errorf("comment text leaked: %q\n%s", c, r.Content)
+		}
+	}
+	for _, code := range []string{"func Greet", "fmt.Sprintf", "return msg"} {
+		if !strings.Contains(r.Content, code) {
+			t.Errorf("code dropped: %q\n%s", code, r.Content)
+		}
+	}
+	// The minified output must still be valid Go.
+	if _, err := parser.ParseFile(token.NewFileSet(), "", r.Content, 0); err != nil {
+		t.Fatalf("minified Go does not parse: %v\n%s", err, r.Content)
+	}
+}
+
+func TestMinifyGoFallsBackOnUnparsableGo(t *testing.T) {
+	// A snippet (no package clause) cannot parse as a file -> safe generic path.
+	r := File("snippet.go", []byte("x := 1   \n\n\n// keep me\ny := 2\n"))
+	if r.Applied {
+		t.Fatalf("expected fallback for unparsable Go, got %+v", r)
+	}
+	if strings.Contains(r.Content, "\n\n\n") {
+		t.Errorf("generic should collapse blank runs:\n%q", r.Content)
+	}
+	if !strings.Contains(r.Content, "// keep me") {
+		t.Errorf("generic must NOT strip comments (unsafe without a parser): %q", r.Content)
+	}
+}
+
+func TestMinifyGenericCollapsesBlanksAndTrims(t *testing.T) {
+	r := File("notes.txt", []byte("a   \n\n\n\nb\t\n"))
+	if r.Applied {
+		t.Fatalf("text is not 'applied' minification")
+	}
+	if r.Content != "a\n\nb" {
+		t.Fatalf("generic = %q, want %q", r.Content, "a\n\nb")
+	}
+}

--- a/internal/modelregistry/cache_write_test.go
+++ b/internal/modelregistry/cache_write_test.go
@@ -1,0 +1,62 @@
+package modelregistry
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// A premium cache-write rate prices cache-creation tokens separately from the
+// uncached input and the discounted cache-read.
+func TestCalculateCostCacheWritePremium(t *testing.T) {
+	model := ModelEntry{
+		ID: "test-cw", Provider: ProviderAnthropic,
+		Cost: ModelCost{Currency: "USD", InputPerMillion: 10, OutputPerMillion: 30, CachedInputPerMillion: 1, CacheWritePerMillion: 12.5},
+	}
+	// 1M total input = 600k uncached + 300k cache-read + 100k cache-write.
+	usage := zeroruntime.Usage{InputTokens: 1_000_000, CachedInputTokens: 300_000, CacheWriteTokens: 100_000, OutputTokens: 200_000}
+	cost, err := CalculateCost(model, usage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 6.00 /*uncached 600k@10*/ + 0.30 /*read 300k@1*/ + 1.25 /*write 100k@12.5*/ + 6.00 /*out 200k@30*/
+	if math.Abs(cost.TotalCost-want) > 1e-9 {
+		t.Fatalf("total = %v, want %v", cost.TotalCost, want)
+	}
+	if cost.CacheWriteTokens != 100_000 || math.Abs(cost.CacheWriteCost-1.25) > 1e-9 {
+		t.Fatalf("cacheWrite = %d tok / $%v", cost.CacheWriteTokens, cost.CacheWriteCost)
+	}
+}
+
+// Without a configured cache-write rate, cache-write tokens fall back to the full
+// input rate (the prior behavior) — no regression for models lacking the rate.
+func TestCalculateCostCacheWriteFallsBackToInputRate(t *testing.T) {
+	model := ModelEntry{ID: "test", Provider: ProviderOpenAI, Cost: ModelCost{Currency: "USD", InputPerMillion: 10, OutputPerMillion: 30}}
+	usage := zeroruntime.Usage{InputTokens: 1_000_000, CacheWriteTokens: 100_000, OutputTokens: 0}
+	cost, err := CalculateCost(model, usage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.Abs(cost.TotalCost-10.0) > 1e-9 { // all 1M input at 10/1e6
+		t.Fatalf("total = %v, want 10.0 (cache-write folds into input when unpriced)", cost.TotalCost)
+	}
+	if cost.CacheWriteTokens != 0 {
+		t.Fatalf("cache-write should not split out when unpriced, got %d", cost.CacheWriteTokens)
+	}
+}
+
+// Anthropic models derive cache-write = 1.25x input from the helper.
+func TestAnthropicModelsDeriveCacheWriteRate(t *testing.T) {
+	reg, err := DefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := reg.Require("claude-sonnet-4.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := m.Cost.CacheWritePerMillion, 3.0*1.25; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("sonnet cache-write rate = %v, want %v", got, want)
+	}
+}

--- a/internal/modelregistry/catalog.go
+++ b/internal/modelregistry/catalog.go
@@ -212,7 +212,13 @@ func anthropicModel(id string, displayName string, apiModel string, status Model
 	cost.Unit = "per_1m_tokens"
 	cost.Source = anthropicPricingSource
 	cost.SourceLastVerified = sourceLastVerified
-	cost.Notes = append(cost.Notes, "Claude cached input pricing models cache hits and refreshes.")
+	// Anthropic bills cache writes (5-minute TTL) at 1.25x the base input rate.
+	// Derive it from the input rate so every cacheable Claude model is priced
+	// without restating it per entry; explicit values still win if ever set.
+	if cost.CacheWritePerMillion == 0 && cost.InputPerMillion > 0 {
+		cost.CacheWritePerMillion = cost.InputPerMillion * 1.25
+	}
+	cost.Notes = append(cost.Notes, "Claude cached input pricing models cache hits and refreshes; cache writes bill at 1.25x input.")
 	return ModelEntry{
 		ID:               id,
 		DisplayName:      displayName,

--- a/internal/modelregistry/cost.go
+++ b/internal/modelregistry/cost.go
@@ -16,10 +16,12 @@ type CostBreakdown struct {
 	Currency          string
 	InputTokens       int
 	CachedInputTokens int
+	CacheWriteTokens  int
 	OutputTokens      int
 	ReasoningTokens   int
 	InputCost         float64
 	CachedInputCost   float64
+	CacheWriteCost    float64
 	OutputCost        float64
 	TotalCost         float64
 	PricingTier       *ModelCostTier
@@ -53,13 +55,24 @@ func CalculateCost(model ModelEntry, usage zeroruntime.Usage) (CostBreakdown, er
 	if requestedCachedInputTokens > inputTokens {
 		requestedCachedInputTokens = inputTokens
 	}
+	requestedCacheWriteTokens, err := nonNegativeUsage(usage.CacheWriteTokens, "cache write tokens")
+	if err != nil {
+		return CostBreakdown{}, err
+	}
+	// Cache-read and cache-write are disjoint subsets of the input.
+	if requestedCacheWriteTokens > inputTokens-requestedCachedInputTokens {
+		requestedCacheWriteTokens = inputTokens - requestedCachedInputTokens
+		if requestedCacheWriteTokens < 0 {
+			requestedCacheWriteTokens = 0
+		}
+	}
 
 	tier, err := selectCostTier(model.Cost, inputTokens)
 	if err != nil {
 		return CostBreakdown{}, err
 	}
 
-	inputRate, outputRate, cachedRate, err := costRates(model.Cost, tier)
+	inputRate, outputRate, cachedRate, cacheWriteRate, err := costRates(model.Cost, tier)
 	if err != nil {
 		return CostBreakdown{}, err
 	}
@@ -68,10 +81,21 @@ func CalculateCost(model ModelEntry, usage zeroruntime.Usage) (CostBreakdown, er
 	if cachedRate > 0 {
 		cachedInputTokens = requestedCachedInputTokens
 	}
-	uncachedInputTokens := inputTokens - cachedInputTokens
+	// Only split cache-write tokens out at the premium rate when one is
+	// configured; otherwise they stay billed at the full input rate (the prior
+	// behavior for every model that lacks a cache-write rate).
+	cacheWriteTokens := 0
+	if cacheWriteRate > 0 {
+		cacheWriteTokens = requestedCacheWriteTokens
+	}
+	uncachedInputTokens := inputTokens - cachedInputTokens - cacheWriteTokens
+	if uncachedInputTokens < 0 {
+		uncachedInputTokens = 0
+	}
 	billableOutputTokens := outputTokens + reasoningTokens
 	inputCost := costForTokens(uncachedInputTokens, inputRate)
 	cachedInputCost := costForTokens(cachedInputTokens, cachedRate)
+	cacheWriteCost := costForTokens(cacheWriteTokens, cacheWriteRate)
 	outputCost := costForTokens(billableOutputTokens, outputRate)
 
 	breakdown := CostBreakdown{
@@ -80,12 +104,14 @@ func CalculateCost(model ModelEntry, usage zeroruntime.Usage) (CostBreakdown, er
 		Currency:          model.Cost.Currency,
 		InputTokens:       inputTokens,
 		CachedInputTokens: cachedInputTokens,
+		CacheWriteTokens:  cacheWriteTokens,
 		OutputTokens:      outputTokens,
 		ReasoningTokens:   reasoningTokens,
 		InputCost:         inputCost,
 		CachedInputCost:   cachedInputCost,
+		CacheWriteCost:    cacheWriteCost,
 		OutputCost:        outputCost,
-		TotalCost:         inputCost + cachedInputCost + outputCost,
+		TotalCost:         inputCost + cachedInputCost + cacheWriteCost + outputCost,
 	}
 	if tier != nil {
 		tierCopy := *tier
@@ -135,25 +161,32 @@ func selectCostTier(cost ModelCost, inputTokens int) (*ModelCostTier, error) {
 	return nil, fmt.Errorf("no model cost tier covers %d input tokens", inputTokens)
 }
 
-func costRates(cost ModelCost, tier *ModelCostTier) (float64, float64, float64, error) {
+func costRates(cost ModelCost, tier *ModelCostTier) (float64, float64, float64, float64, error) {
 	inputRate := cost.InputPerMillion
 	outputRate := cost.OutputPerMillion
 	cachedRate := cost.CachedInputPerMillion
+	cacheWriteRate := cost.CacheWritePerMillion
 	if tier != nil {
 		inputRate = tier.InputPerMillion
 		outputRate = tier.OutputPerMillion
 		cachedRate = tier.CachedInputPerMillion
+		cacheWriteRate = tier.CacheWritePerMillion
 	}
 	if !validRate(inputRate) || inputRate == 0 {
-		return 0, 0, 0, fmt.Errorf("missing model input pricing rate")
+		return 0, 0, 0, 0, fmt.Errorf("missing model input pricing rate")
 	}
 	if !validRate(outputRate) || outputRate == 0 {
-		return 0, 0, 0, fmt.Errorf("missing model output pricing rate")
+		return 0, 0, 0, 0, fmt.Errorf("missing model output pricing rate")
 	}
 	if !validRate(cachedRate) {
-		return 0, 0, 0, fmt.Errorf("invalid model cached input pricing rate")
+		return 0, 0, 0, 0, fmt.Errorf("invalid model cached input pricing rate")
 	}
-	return inputRate, outputRate, cachedRate, nil
+	// Cache-write is optional; 0 means "not priced separately". Only reject a
+	// genuinely invalid (NaN/Inf/negative) rate.
+	if !validRate(cacheWriteRate) {
+		return 0, 0, 0, 0, fmt.Errorf("invalid model cache write pricing rate")
+	}
+	return inputRate, outputRate, cachedRate, cacheWriteRate, nil
 }
 
 func costForTokens(tokens int, perMillionRate float64) float64 {

--- a/internal/modelregistry/models.go
+++ b/internal/modelregistry/models.go
@@ -62,10 +62,15 @@ type ModelCost struct {
 	InputPerMillion       float64
 	OutputPerMillion      float64
 	CachedInputPerMillion float64
-	Tiers                 []ModelCostTier
-	Source                string
-	SourceLastVerified    string
-	Notes                 []string
+	// CacheWritePerMillion is the cache-creation (cache-write) rate, billed at a
+	// premium over input by providers that support it (Anthropic ~1.25x input).
+	// Zero means "not priced separately" — cache-write tokens fall back to the
+	// input rate, preserving prior behavior for models without the rate.
+	CacheWritePerMillion float64
+	Tiers                []ModelCostTier
+	Source               string
+	SourceLastVerified   string
+	Notes                []string
 }
 
 type ModelCostTier struct {
@@ -73,6 +78,7 @@ type ModelCostTier struct {
 	InputPerMillion       float64
 	OutputPerMillion      float64
 	CachedInputPerMillion float64
+	CacheWritePerMillion  float64
 	Note                  string
 }
 

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -331,11 +331,13 @@ func (provider *Provider) emitDone(ctx context.Context, state *streamState, even
 	if state.hasInputUsage || state.hasOutputUsage {
 		usage, err := zeroruntime.NormalizeUsage(zeroruntime.TokenUsage{
 			// Anthropic reports input_tokens (uncached), cache_read, and
-			// cache_creation SEPARATELY. The runtime models the cached count as a
-			// SUBSET of total input (it clamps cached <= input), so report the full
-			// prompt size as InputTokens and the cache hits as CachedInputTokens.
+			// cache_creation SEPARATELY. The runtime models cache-read and
+			// cache-write as disjoint SUBSETS of total input, so report the full
+			// prompt size as InputTokens, cache hits as CachedInputTokens, and
+			// cache creation as CacheWriteTokens (priced at the premium rate).
 			InputTokens:       state.inputTokens + state.cacheReadTokens + state.cacheCreationTokens,
 			CachedInputTokens: state.cacheReadTokens,
+			CacheWriteTokens:  state.cacheCreationTokens,
 			OutputTokens:      state.outputTokens,
 		})
 		if err == nil {

--- a/internal/specialist/exec.go
+++ b/internal/specialist/exec.go
@@ -135,11 +135,12 @@ const permissionModeUnsafe = "unsafe"
 // modify the workspace or run commands, so spawning it is harmless and the Task
 // tool auto-approves it (no permission prompt).
 var readOnlySpecialistTools = map[string]bool{
-	"read_file":      true,
-	"list_directory": true,
-	"grep":           true,
-	"glob":           true,
-	"update_plan":    true,
+	"read_file":          true,
+	"read_minified_file": true,
+	"list_directory":     true,
+	"grep":               true,
+	"glob":               true,
+	"update_plan":        true,
 }
 
 // IsReadOnlySpecialist reports whether the named specialist resolves to a

--- a/internal/specialist/exec_test.go
+++ b/internal/specialist/exec_test.go
@@ -199,7 +199,7 @@ func TestBuildArgsDefaultsToReadOnlyToolAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildArgs returned error: %v", err)
 	}
-	if !containsSequence(result.Args, []string{"--enabled-tools", "glob,grep,list_directory,read_file"}) {
+	if !containsSequence(result.Args, []string{"--enabled-tools", "glob,grep,list_directory,read_file,read_minified_file"}) {
 		t.Fatalf("args missing default read-only allowlist: %#v", result.Args)
 	}
 }

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -81,9 +81,9 @@ var knownMetadataKeys = map[string]bool{
 }
 
 var toolCategories = map[string][]string{
-	"read-only": {"read_file", "list_directory", "grep", "glob"},
-	"edit":      {"read_file", "list_directory", "grep", "glob", "write_file", "edit_file", "apply_patch"},
-	"execute":   {"read_file", "list_directory", "grep", "glob", "bash"},
+	"read-only": {"read_file", "read_minified_file", "list_directory", "grep", "glob"},
+	"edit":      {"read_file", "read_minified_file", "list_directory", "grep", "glob", "write_file", "edit_file", "apply_patch"},
+	"execute":   {"read_file", "read_minified_file", "list_directory", "grep", "glob", "bash"},
 	"plan":      {"update_plan"},
 }
 
@@ -100,6 +100,7 @@ var defaultToolSelection = []string{"read-only"}
 
 var knownToolNames = map[string]bool{
 	"read_file":           true,
+	"read_minified_file":  true,
 	"list_directory":      true,
 	"glob":                true,
 	"grep":                true,

--- a/internal/tools/read_minified_file.go
+++ b/internal/tools/read_minified_file.go
@@ -1,0 +1,96 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/minify"
+)
+
+type readMinifiedFileTool struct {
+	baseTool
+	workspaceRoot string
+	scope         PathScope
+}
+
+func NewReadMinifiedFileTool(workspaceRoot string) Tool {
+	return NewScopedReadMinifiedFileTool(workspaceRoot, nil)
+}
+
+func NewScopedReadMinifiedFileTool(workspaceRoot string, scope PathScope) Tool {
+	return readMinifiedFileTool{
+		baseTool: baseTool{
+			name:        "read_minified_file",
+			description: "Read a source file in a dense, token-cheap form: comments and redundant whitespace removed, no line numbers. Use it to scan or understand code for far fewer tokens than read_file. For exact text, comments, line numbers, or before editing, use read_file instead.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"path": {Type: "string", Description: "Path of the file to read in minified form."},
+				},
+				Required:             []string{"path"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Reads a minified view of file contents without modifying files."),
+		},
+		workspaceRoot: normalizeWorkspaceRoot(workspaceRoot),
+		scope:         scope,
+	}
+}
+
+func (tool readMinifiedFileTool) Run(ctx context.Context, args map[string]any) Result {
+	return tool.RunWithOptions(ctx, args, RunOptions{})
+}
+
+func (tool readMinifiedFileTool) RunWithOptions(_ context.Context, args map[string]any, options RunOptions) Result {
+	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path", "filepath", "filename"}, "", true, false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for read_minified_file: " + err.Error())
+	}
+
+	absolutePath, relativePath, err := resolveScopedReadPath(tool.workspaceRoot, tool.scope, requestedPath)
+	if err != nil {
+		return errorResult("Error reading file " + requestedPath + ": " + err.Error())
+	}
+
+	content, err := os.ReadFile(absolutePath)
+	if err != nil {
+		return errorResult("Error reading file " + relativePath + ": " + err.Error())
+	}
+	// Record the raw whole-file baseline (matching read_file/edit_file) so a later
+	// write can still detect an out-of-Zero modification — the minification only
+	// affects what the model SEES, not the tracked on-disk state.
+	info, _ := os.Stat(absolutePath)
+	options.FileTracker.Record(absolutePath, content, info)
+
+	result := minify.File(relativePath, content)
+	rawLines := lineCount(string(content))
+	minLines := lineCount(result.Content)
+	pct := 0
+	if rawBytes := len(content); rawBytes > 0 {
+		if saved := rawBytes - len(result.Content); saved > 0 {
+			pct = saved * 100 / rawBytes
+		}
+	}
+
+	var header string
+	if result.Applied {
+		header = fmt.Sprintf("File: %s — minified %s view (comments stripped, no line numbers; %d→%d lines, ~%d%% fewer bytes). For exact text/comments or before editing, use read_file.",
+			relativePath, result.Language, rawLines, minLines, pct)
+	} else {
+		header = fmt.Sprintf("File: %s — whitespace-normalized view (no line numbers; %d→%d lines; full minification not available for this file type). For exact text, use read_file.",
+			relativePath, rawLines, minLines)
+	}
+
+	return Result{Status: StatusOK, Output: header + "\n\n" + result.Content}
+}
+
+// lineCount reports the number of newline-separated lines in s (an empty string
+// counts as 0 lines, matching how a reader perceives an empty file).
+func lineCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}

--- a/internal/tools/read_minified_file_test.go
+++ b/internal/tools/read_minified_file_test.go
@@ -1,0 +1,41 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadMinifiedFileStripsCommentsAndLineNumbers(t *testing.T) {
+	dir := t.TempDir()
+	src := "package demo\n\nimport \"fmt\"\n\n// secret doc comment\nfunc F() { fmt.Println(\"x\") }\n"
+	if err := os.WriteFile(filepath.Join(dir, "f.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := NewReadMinifiedFileTool(dir).Run(context.Background(), map[string]any{"path": "f.go"})
+	if res.Status != StatusOK {
+		t.Fatalf("status %v: %s", res.Status, res.Output)
+	}
+	if strings.Contains(res.Output, "secret doc comment") {
+		t.Errorf("comment leaked:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "func F()") {
+		t.Errorf("code missing:\n%s", res.Output)
+	}
+	if strings.Contains(res.Output, " | ") {
+		t.Errorf("minified output should carry NO line-number prefixes:\n%s", res.Output)
+	}
+	if !strings.Contains(res.Output, "minified go view") {
+		t.Errorf("expected a minified header note:\n%s", res.Output)
+	}
+}
+
+func TestReadMinifiedFileRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	res := NewReadMinifiedFileTool(dir).Run(context.Background(), map[string]any{"path": "../escape.go"})
+	if res.Status == StatusOK {
+		t.Fatalf("expected traversal rejection, got OK:\n%s", res.Output)
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -189,6 +189,7 @@ func CoreReadOnlyTools(workspaceRoot string) []Tool {
 func CoreReadOnlyToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 	return []Tool{
 		NewScopedReadFileTool(workspaceRoot, scope),
+		NewScopedReadMinifiedFileTool(workspaceRoot, scope),
 		NewScopedListDirectoryTool(workspaceRoot, scope),
 		NewScopedGlobTool(workspaceRoot, scope),
 		NewScopedGrepTool(workspaceRoot, scope),

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
-	if len(toolset) != 7 {
-		t.Fatalf("expected 7 core read-only tools, got %d", len(toolset))
+	if len(toolset) != 8 {
+		t.Fatalf("expected 8 core read-only tools, got %d", len(toolset))
 	}
 
 	seen := map[string]bool{}

--- a/internal/tui/context_gauge_test.go
+++ b/internal/tui/context_gauge_test.go
@@ -1,0 +1,29 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/usage"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// The context-fill gauge is empty before any request, then shows
+// used/window · pct from the last turn's input tokens against the model window.
+func TestContextWindowSegment(t *testing.T) {
+	m := newModel(t.Context(), Options{ModelName: "claude-sonnet-4.5"})
+	if got := m.contextWindowSegment(); got != "" {
+		t.Fatalf("expected empty gauge before any request, got %q", got)
+	}
+	// 160k input against the 200k window = 80%.
+	if _, err := m.usageTracker.Record(usage.RecordInput{
+		ModelID: "claude-sonnet-4.5",
+		Usage:   zeroruntime.Usage{InputTokens: 160_000, OutputTokens: 1000},
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	got := plainRender(t, m.contextWindowSegment())
+	if !strings.Contains(got, "160K/200K") || !strings.Contains(got, "80%") {
+		t.Fatalf("gauge = %q, want 160K/200K · 80%%", got)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3141,12 +3141,8 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		options.OnUsage = func(event zeroruntime.Usage) {
 			usageEvents = append(usageEvents, event)
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
-				Type: sessions.EventUsage,
-				Payload: map[string]any{
-					"promptTokens":     event.EffectiveInputTokens(),
-					"completionTokens": event.EffectiveOutputTokens(),
-					"totalTokens":      event.TotalTokens(),
-				},
+				Type:    sessions.EventUsage,
+				Payload: usage.EventUsagePayload(event),
 			})
 			if onUsage != nil {
 				onUsage(event)

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -206,6 +206,13 @@ func (m model) statusLine(width int) string {
 	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
 
 	rightGroups := []string{}
+	// The context-fill gauge needs the room a Medium+ terminal gives; below that
+	// the cumulative tok·cost segment alone keeps the line readable.
+	if tier >= tierMedium {
+		if gauge := m.contextWindowSegment(); gauge != "" {
+			rightGroups = append(rightGroups, gauge)
+		}
+	}
 	if usage := m.usageStatusSegment(); usage != "" {
 		rightGroups = append(rightGroups, zeroTheme.muted.Render(usage))
 	}
@@ -295,6 +302,38 @@ func (m model) usageStatusSegment() string {
 		humanCount(summary.InputTokens+summary.OutputTokens),
 		summary.FormattedTotalCost,
 	)
+}
+
+// contextWindowSegment renders a live context-fill gauge: the last request's
+// input tokens against the active model's context window, as "◔ used/window ·
+// NN%", graded green (<75%) → amber (≥75%) → red (≥90%). Empty until a priced
+// request lands or when the model's window is unknown. This is the "you're at
+// X% of context" readout the compaction trigger already reasons about at 80%.
+func (m model) contextWindowSegment() string {
+	if m.usageTracker == nil {
+		return ""
+	}
+	summary := m.usageTracker.Summary()
+	if summary.LastRecord == nil {
+		return ""
+	}
+	used := summary.LastRecord.Usage.InputTokens
+	window := modelContextWindow(m.modelName)
+	if used <= 0 || window <= 0 {
+		return ""
+	}
+	ratio := float64(used) / float64(window)
+	if ratio > 1 {
+		ratio = 1
+	}
+	style := zeroTheme.green
+	switch {
+	case ratio >= 0.90:
+		style = zeroTheme.red
+	case ratio >= 0.75:
+		style = zeroTheme.amber
+	}
+	return style.Render(fmt.Sprintf("◔ %s/%s · %d%%", humanCount(used), humanCount(window), int(ratio*100+0.5)))
 }
 
 // humanCount renders a token count the way the status line wants it: 999,

--- a/internal/usage/report.go
+++ b/internal/usage/report.go
@@ -11,15 +11,46 @@ import (
 )
 
 // usageEventPayload mirrors the persisted EventUsage payload written by the exec
-// runtime. Token counts are always stored; Model is persisted only on escalation
-// runs (the model in force can change mid-run only under --allow-escalation).
-// When Model is absent, cost is reconstructed from the session's Metadata.ModelID
-// and is a labeled estimate.
+// runtime. Prompt/completion/total are always stored; the cache and reasoning
+// breakdown is stored when present (omitempty) so cost reconstruction matches the
+// live tracker instead of over-pricing cache-heavy or reasoning-heavy turns.
+// Older events without those fields decode to zero and price exactly as before.
+// Model is persisted only on escalation runs (the model in force can change
+// mid-run only under --allow-escalation); when absent, cost is reconstructed from
+// the session's Metadata.ModelID and is a labeled estimate.
 type usageEventPayload struct {
-	PromptTokens     int    `json:"promptTokens"`
-	CompletionTokens int    `json:"completionTokens"`
-	TotalTokens      int    `json:"totalTokens"`
-	Model            string `json:"model,omitempty"`
+	PromptTokens      int    `json:"promptTokens"`
+	CompletionTokens  int    `json:"completionTokens"`
+	TotalTokens       int    `json:"totalTokens"`
+	CachedInputTokens int    `json:"cachedInputTokens,omitempty"`
+	CacheWriteTokens  int    `json:"cacheWriteTokens,omitempty"`
+	ReasoningTokens   int    `json:"reasoningTokens,omitempty"`
+	Model             string `json:"model,omitempty"`
+}
+
+// EventUsagePayload builds the persisted EventUsage payload for a usage record.
+// It is the single writer paired with usageEventPayload (the reader), so the JSON
+// keys can never drift. Cache and reasoning counts are written only when non-zero,
+// keeping payloads compact and older readers unaffected; BuildReport reads them
+// back to price a turn exactly (cache discount + cache-write premium + reasoning)
+// rather than estimating from prompt/completion alone. Callers add "model"
+// afterward on escalation runs.
+func EventUsagePayload(u zeroruntime.Usage) map[string]any {
+	payload := map[string]any{
+		"promptTokens":     u.EffectiveInputTokens(),
+		"completionTokens": u.EffectiveOutputTokens(),
+		"totalTokens":      u.TotalTokens(),
+	}
+	if u.CachedInputTokens > 0 {
+		payload["cachedInputTokens"] = u.CachedInputTokens
+	}
+	if u.CacheWriteTokens > 0 {
+		payload["cacheWriteTokens"] = u.CacheWriteTokens
+	}
+	if u.ReasoningTokens > 0 {
+		payload["reasoningTokens"] = u.ReasoningTokens
+	}
+	return payload
 }
 
 // DayBucket aggregates usage events sharing the same UTC calendar date.
@@ -116,8 +147,11 @@ func BuildReport(events []sessions.Event, meta []sessions.Metadata, registry *mo
 			continue
 		}
 		cost, err := modelregistry.CalculateCost(model, zeroruntime.Usage{
-			InputTokens:  payload.PromptTokens,
-			OutputTokens: payload.CompletionTokens,
+			InputTokens:       payload.PromptTokens,
+			OutputTokens:      payload.CompletionTokens,
+			CachedInputTokens: payload.CachedInputTokens,
+			CacheWriteTokens:  payload.CacheWriteTokens,
+			ReasoningTokens:   payload.ReasoningTokens,
 		})
 		if err != nil {
 			continue

--- a/internal/usage/token_economy_test.go
+++ b/internal/usage/token_economy_test.go
@@ -1,0 +1,79 @@
+package usage
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// The persistence round-trip is LOSSLESS for cost: a cache-heavy + reasoning turn
+// priced live reconstructs to the SAME cost from the persisted event. Before the
+// cache/reasoning breakdown was persisted, BuildReport billed all input at the
+// full rate and dropped reasoning, over-pricing the session.
+func TestEventUsageRoundTripPreservesCacheAndReasoningCost(t *testing.T) {
+	registry, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	model, err := registry.Require("claude-sonnet-4.5")
+	if err != nil {
+		t.Fatalf("Require: %v", err)
+	}
+	live := zeroruntime.Usage{
+		InputTokens:       500_000,
+		CachedInputTokens: 400_000,
+		CacheWriteTokens:  50_000,
+		OutputTokens:      20_000,
+		ReasoningTokens:   10_000,
+	}
+	liveCost, err := modelregistry.CalculateCost(model, live)
+	if err != nil {
+		t.Fatalf("CalculateCost: %v", err)
+	}
+
+	raw, err := json.Marshal(EventUsagePayload(live))
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	events := []sessions.Event{{
+		SessionID: "s1", Sequence: 1, Type: sessions.EventUsage,
+		CreatedAt: "2026-06-19T10:00:00Z", Payload: raw,
+	}}
+	meta := []sessions.Metadata{{SessionID: "s1", ModelID: "claude-sonnet-4.5"}}
+
+	report, err := BuildReport(events, meta, &registry, 0)
+	if err != nil {
+		t.Fatalf("BuildReport: %v", err)
+	}
+	if math.Abs(report.Total.TotalCost-liveCost.TotalCost) > 1e-9 {
+		t.Fatalf("reconstructed cost = %v, live = %v (cache/reasoning lost in persistence)", report.Total.TotalCost, liveCost.TotalCost)
+	}
+
+	// Regression guard: the old lossy reconstruction (prompt/completion only) bills
+	// all 500k input at the full rate — strictly MORE than the true cost.
+	lossy, err := modelregistry.CalculateCost(model, zeroruntime.Usage{InputTokens: 500_000, OutputTokens: 20_000})
+	if err != nil {
+		t.Fatalf("CalculateCost(lossy): %v", err)
+	}
+	if lossy.TotalCost <= liveCost.TotalCost {
+		t.Fatalf("precondition: lossy cost %v should exceed true cost %v", lossy.TotalCost, liveCost.TotalCost)
+	}
+}
+
+// Zero cache/reasoning fields are omitted so non-cache turns stay compact and
+// decode identically to the pre-feature payload.
+func TestEventUsagePayloadOmitsZeroFields(t *testing.T) {
+	p := EventUsagePayload(zeroruntime.Usage{InputTokens: 1000, OutputTokens: 200})
+	for _, k := range []string{"cachedInputTokens", "cacheWriteTokens", "reasoningTokens"} {
+		if _, ok := p[k]; ok {
+			t.Errorf("expected %q omitted when zero", k)
+		}
+	}
+	if p["promptTokens"] != 1000 || p["completionTokens"] != 200 {
+		t.Fatalf("base fields wrong: %#v", p)
+	}
+}

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -11,6 +11,7 @@ import (
 type Normalized struct {
 	InputTokens       int
 	CachedInputTokens int
+	CacheWriteTokens  int
 	OutputTokens      int
 	ReasoningTokens   int
 	TotalTokens       int
@@ -39,11 +40,13 @@ type ModelSummary struct {
 	RecordCount        int
 	InputTokens        int
 	CachedInputTokens  int
+	CacheWriteTokens   int
 	OutputTokens       int
 	ReasoningTokens    int
 	TotalTokens        int
 	InputCost          float64
 	CachedInputCost    float64
+	CacheWriteCost     float64
 	OutputCost         float64
 	TotalCost          float64
 	FormattedTotalCost string
@@ -54,11 +57,13 @@ type Summary struct {
 	Currency           string
 	InputTokens        int
 	CachedInputTokens  int
+	CacheWriteTokens   int
 	OutputTokens       int
 	ReasoningTokens    int
 	TotalTokens        int
 	InputCost          float64
 	CachedInputCost    float64
+	CacheWriteCost     float64
 	OutputCost         float64
 	TotalCost          float64
 	FormattedTotalCost string
@@ -176,6 +181,13 @@ func Normalize(usage zeroruntime.Usage) (Normalized, zeroruntime.Usage, error) {
 	if cachedInputTokens > inputTokens {
 		cachedInputTokens = inputTokens
 	}
+	cacheWriteTokens, err := nonNegative(usage.CacheWriteTokens, "cacheWriteTokens")
+	if err != nil {
+		return Normalized{}, zeroruntime.Usage{}, err
+	}
+	if cacheWriteTokens > inputTokens-cachedInputTokens {
+		cacheWriteTokens = inputTokens - cachedInputTokens
+	}
 	reasoningTokens, err := nonNegative(usage.ReasoningTokens, "reasoningTokens")
 	if err != nil {
 		return Normalized{}, zeroruntime.Usage{}, err
@@ -183,6 +195,7 @@ func Normalize(usage zeroruntime.Usage) (Normalized, zeroruntime.Usage, error) {
 	normalized := Normalized{
 		InputTokens:       inputTokens,
 		CachedInputTokens: cachedInputTokens,
+		CacheWriteTokens:  cacheWriteTokens,
 		OutputTokens:      outputTokens,
 		ReasoningTokens:   reasoningTokens,
 		TotalTokens:       inputTokens + outputTokens + reasoningTokens,
@@ -191,6 +204,7 @@ func Normalize(usage zeroruntime.Usage) (Normalized, zeroruntime.Usage, error) {
 		InputTokens:       inputTokens,
 		PromptTokens:      inputTokens,
 		CachedInputTokens: cachedInputTokens,
+		CacheWriteTokens:  cacheWriteTokens,
 		OutputTokens:      outputTokens,
 		CompletionTokens:  outputTokens,
 		ReasoningTokens:   reasoningTokens,
@@ -208,6 +222,7 @@ func FormatSummary(summary Summary) string {
 func addUsageToSummary(summary *Summary, usage Normalized) {
 	summary.InputTokens += usage.InputTokens
 	summary.CachedInputTokens += usage.CachedInputTokens
+	summary.CacheWriteTokens += usage.CacheWriteTokens
 	summary.OutputTokens += usage.OutputTokens
 	summary.ReasoningTokens += usage.ReasoningTokens
 	summary.TotalTokens += usage.TotalTokens
@@ -217,6 +232,7 @@ func addUsageToModel(summary *ModelSummary, usage Normalized) {
 	summary.RecordCount++
 	summary.InputTokens += usage.InputTokens
 	summary.CachedInputTokens += usage.CachedInputTokens
+	summary.CacheWriteTokens += usage.CacheWriteTokens
 	summary.OutputTokens += usage.OutputTokens
 	summary.ReasoningTokens += usage.ReasoningTokens
 	summary.TotalTokens += usage.TotalTokens
@@ -225,6 +241,7 @@ func addUsageToModel(summary *ModelSummary, usage Normalized) {
 func addCostToSummary(summary *Summary, cost modelregistry.CostBreakdown) {
 	summary.InputCost += cost.InputCost
 	summary.CachedInputCost += cost.CachedInputCost
+	summary.CacheWriteCost += cost.CacheWriteCost
 	summary.OutputCost += cost.OutputCost
 	summary.TotalCost += cost.TotalCost
 }
@@ -232,6 +249,7 @@ func addCostToSummary(summary *Summary, cost modelregistry.CostBreakdown) {
 func addCostToModel(summary *ModelSummary, cost modelregistry.CostBreakdown) {
 	summary.InputCost += cost.InputCost
 	summary.CachedInputCost += cost.CachedInputCost
+	summary.CacheWriteCost += cost.CacheWriteCost
 	summary.OutputCost += cost.OutputCost
 	summary.TotalCost += cost.TotalCost
 }

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -113,18 +113,28 @@ type TokenUsage struct {
 	InputTokens       int
 	PromptTokens      int
 	CachedInputTokens int
-	OutputTokens      int
-	CompletionTokens  int
-	ReasoningTokens   int
+	// CacheWriteTokens is the cache-creation (cache-write) portion of the input,
+	// billed at a premium rate by providers that support it (e.g. Anthropic).
+	// Like CachedInputTokens it is a SUBSET of InputTokens, not additive.
+	CacheWriteTokens int
+	OutputTokens     int
+	CompletionTokens int
+	ReasoningTokens  int
 }
 
 // Usage records normalized token accounting reported by a provider.
+//
+// Token accounting is consistent across providers: InputTokens is the TOTAL
+// prompt size (uncached + cache-read + cache-write); CachedInputTokens (cache
+// read, discounted) and CacheWriteTokens (cache creation, premium) are subsets
+// of it, so uncached input = InputTokens - CachedInputTokens - CacheWriteTokens.
 type Usage struct {
 	InputTokens       int
 	OutputTokens      int
 	PromptTokens      int
 	CompletionTokens  int
 	CachedInputTokens int
+	CacheWriteTokens  int
 	ReasoningTokens   int
 }
 

--- a/internal/zeroruntime/usage.go
+++ b/internal/zeroruntime/usage.go
@@ -22,6 +22,16 @@ func NormalizeUsage(input TokenUsage) (Usage, error) {
 		cachedInputTokens = inputTokens
 	}
 
+	cacheWriteTokens, err := nonNegative(input.CacheWriteTokens, "cache write tokens")
+	if err != nil {
+		return Usage{}, err
+	}
+	// Cache-read and cache-write are disjoint subsets of the input; together they
+	// can never exceed it. Clamp the write portion to whatever input remains.
+	if cacheWriteTokens > inputTokens-cachedInputTokens {
+		cacheWriteTokens = inputTokens - cachedInputTokens
+	}
+
 	reasoningTokens, err := nonNegative(input.ReasoningTokens, "reasoning tokens")
 	if err != nil {
 		return Usage{}, err
@@ -33,6 +43,7 @@ func NormalizeUsage(input TokenUsage) (Usage, error) {
 		PromptTokens:      inputTokens,
 		CompletionTokens:  outputTokens,
 		CachedInputTokens: cachedInputTokens,
+		CacheWriteTokens:  cacheWriteTokens,
 		ReasoningTokens:   reasoningTokens,
 	}, nil
 }


### PR DESCRIPTION
Two complementary improvements to how Zero handles tokens — one makes cost *measurement* correct, the other *reduces* tokens on file-heavy work.

## Part 1 — Accounting: lossless, correct cost
Zero captured cache-read + reasoning tokens, then dropped them before persisting — so `zero usage report` over-priced cache-heavy sessions, and Anthropic's cache-creation tokens were parsed then discarded.

- **One lossless `Usage`** carrying all five token dimensions (input, cache-read, **cache-write**, output, reasoning) threaded `TokenUsage → NormalizeUsage → Usage → CalculateCost`.
- **Cache-write pricing** at the premium rate (Anthropic ~1.25× input, derived per model in the `anthropicModel` helper). **Regression-safe:** a model with no cache-write rate bills those tokens at the input rate exactly as before.
- **Lossless persistence:** `EventUsage` now stores cache-read/cache-write/reasoning (omitempty), so `BuildReport` reconstructs the **same** cost as the live tracker. A single `EventUsagePayload` writer is paired with the `usageEventPayload` reader so the JSON keys can't drift. Older events decode to zero and price exactly as before.
- **Live context-window gauge** in the status bar — `◔ 128K/200K · 64%`, graded green → amber(≥75%) → red(≥90%) — from the last request's input tokens vs the model window.

## Part 2 — Reduction: `read_minified_file`
A new read-only tool returning a **dense, comment-free, line-number-free** view of a file, so the model can scan code for far fewer tokens than `read_file`.

- **Go** → minified through the real `go/parser` AST (guaranteed-valid, comment-free).
- **C / Java / CSS / SCSS / LESS / Python** → comment-stripped via a **string-aware lexer** that tracks strings, char literals, triple-quotes, Java text blocks, and Python f-strings (incl. 3.12 same-quote nesting).
- **Every other language** (JS/TS/C++/C#/Rust/Swift/Kotlin/shell/…) → safe **whitespace-only** — their raw-strings/regex/lifetimes/heredocs make naive comment-stripping unsafe. The stripper only handles languages whose string forms it models exactly, so **it cannot corrupt content**.
- Measured **~32% fewer tokens** on a realistic 8-file "understand a subsystem" read. Costs +~102 fixed tokens (the tool schema), recovered many times over by a single subsystem read.

## Testing
- Accounting: cache-write premium + fallback pricing, Anthropic rate derivation, **lossless persistence round-trip** (report cost == live cost), omit-zero payload, context gauge.
- Minification: Go strips-comments-keeps-valid-code + fallback; per-language golden cases — comment chars inside strings, `//`/`/*` in strings, **Java text blocks**, **Python f-string same-quote nesting**, **CSS has no `//`**, SCSS interpolation/hex; and the unsupported-language whitespace-only fallback.
- `gofmt` / `go vet` / `go build ./...` / full suites incl. `-race` all green.

No provider/protocol changes beyond surfacing the already-parsed Anthropic cache-creation count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a minified-file read capability that can strip comments (multi-language) and remove line numbers for token-efficient scanning.
  * Enhanced usage accounting to track cache-write tokens and incorporate them into cost breakdowns.
  * Added a context utilization gauge showing prompt usage vs model capacity (with color thresholds).

* **Bug Fixes**
  * Improved persistence and reconstruction of usage details so cost calculations reflect cached reads and cache writes accurately.

* **Tests**
  * Expanded coverage for comment stripping, minified-file reading, and cache-write token/cost reconstruction.
  * Added UI test coverage for the context gauge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->