### PR TITLE
tools: tool_search redirects eager-tool lookups instead of "no tools matched"

### DIFF
--- a/internal/tools/tool_search.go
+++ b/internal/tools/tool_search.go
@@ -80,7 +80,17 @@ func (tool toolSearchTool) RunWithOptions(_ context.Context, args map[string]any
 		matches = tool.rankByKeyword(query, deferred)
 	}
 
+	// Names the model asked for that it ALREADY has eagerly. tool_search only
+	// loads DEFERRED tools, so a request for an eager tool (e.g. Task or
+	// update_plan) otherwise falls through to a misleading "no tools matched" —
+	// a common confusion that leaves weaker models looping. Redirect the model to
+	// call those tools directly instead.
+	alreadyAvailable := tool.eagerToolsForQuery(query, options.EnabledTools, options.DisabledTools)
+
 	if len(matches) == 0 {
+		if len(alreadyAvailable) > 0 {
+			return okResult(alreadyAvailableMessage(alreadyAvailable))
+		}
 		return okResult(tool.noMatchMessage(query, deferred))
 	}
 
@@ -88,9 +98,13 @@ func (tool toolSearchTool) RunWithOptions(_ context.Context, args map[string]any
 	for _, match := range matches {
 		names = append(names, match.Name())
 	}
+	output := renderLoadedTools(matches)
+	if len(alreadyAvailable) > 0 {
+		output += "\n\n" + alreadyAvailableMessage(alreadyAvailable)
+	}
 	return Result{
 		Status: StatusOK,
-		Output: renderLoadedTools(matches),
+		Output: output,
 		Meta:   map[string]string{"load_tools": strings.Join(names, ",")},
 	}
 }
@@ -118,6 +132,74 @@ func (tool toolSearchTool) visibleDeferredTools(enabled []string, disabled []str
 		return deferred[left].Name() < deferred[right].Name()
 	})
 	return deferred
+}
+
+// visibleEagerToolNames returns the names of tools the model ALREADY has in its
+// list this run: registered, NOT deferred, passing the operator filters, and not
+// tool_search itself. These never need (and never resolve through) tool_search.
+func (tool toolSearchTool) visibleEagerToolNames(enabled []string, disabled []string) map[string]bool {
+	names := map[string]bool{}
+	if tool.registry == nil {
+		return names
+	}
+	for _, candidate := range tool.registry.All() {
+		if IsDeferred(candidate) || candidate.Name() == ToolSearchToolName {
+			continue
+		}
+		if !toolAllowedByFilters(candidate.Name(), enabled, disabled) {
+			continue
+		}
+		names[candidate.Name()] = true
+	}
+	return names
+}
+
+// eagerToolsForQuery returns, sorted, the already-available (eager) tool names a
+// tool_search query refers to: exact names for a "select:" query, or eager tools
+// whose name matches a keyword otherwise. Used to steer the model back to calling
+// a tool it already has instead of fruitlessly searching for it.
+func (tool toolSearchTool) eagerToolsForQuery(query string, enabled []string, disabled []string) []string {
+	eager := tool.visibleEagerToolNames(enabled, disabled)
+	if len(eager) == 0 {
+		return nil
+	}
+	hit := map[string]bool{}
+	if rest, ok := strings.CutPrefix(query, "select:"); ok {
+		for _, raw := range strings.Split(rest, ",") {
+			if name := strings.TrimSpace(raw); name != "" && eager[name] {
+				hit[name] = true
+			}
+		}
+	} else {
+		keywords := strings.Fields(strings.ToLower(query))
+		for name := range eager {
+			lower := strings.ToLower(name)
+			for _, keyword := range keywords {
+				if strings.Contains(lower, keyword) {
+					hit[name] = true
+					break
+				}
+			}
+		}
+	}
+	out := make([]string, 0, len(hit))
+	for name := range hit {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// alreadyAvailableMessage tells the model the named tools are already in its list
+// and must be called directly — tool_search is only for deferred tools.
+func alreadyAvailableMessage(names []string) string {
+	subject, verb := names[0], "is"
+	if len(names) > 1 {
+		subject, verb = strings.Join(names, ", "), "are"
+	}
+	return subject + " " + verb + " already in your tool list — call " +
+		map[bool]string{true: "them", false: "it"}[len(names) > 1] +
+		" directly. tool_search only loads DEFERRED tools (those in the deferred-tools notice), not tools you already have."
 }
 
 // toolAllowedByFilters mirrors agent.ToolAllowedByFilters (kept here to avoid an

--- a/internal/tools/tool_search_eager_test.go
+++ b/internal/tools/tool_search_eager_test.go
@@ -1,0 +1,77 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// searchEagerTool is a minimal EAGER tool: it does NOT implement Deferred(), so
+// IsDeferred returns false — it's always in the model's list (like Task/update_plan).
+type searchEagerTool struct{ name string }
+
+func (t searchEagerTool) Name() string        { return t.name }
+func (t searchEagerTool) Description() string { return "eager tool " + t.name }
+func (t searchEagerTool) Parameters() Schema  { return Schema{Type: "object"} }
+func (t searchEagerTool) Safety() Safety {
+	return Safety{SideEffect: SideEffectRead, Permission: PermissionAllow}
+}
+func (t searchEagerTool) Run(context.Context, map[string]any) Result { return Result{Status: StatusOK} }
+
+// The bug from the Windows screenshot: select:Task (an eager tool) returned a
+// misleading "No tools matched". It must instead redirect to "call it directly".
+func TestToolSearchRedirectsEagerSelectToCallDirectly(t *testing.T) {
+	reg := newDeferredFixtureRegistry() // weather_lookup + stock_quote (deferred)
+	reg.Register(searchEagerTool{name: "Task"})
+	reg.Register(searchEagerTool{name: "update_plan"})
+	tool := NewToolSearchTool(reg).(optionsAwareTool)
+
+	res := tool.RunWithOptions(context.Background(), map[string]any{"query": "select:Task,update_plan"}, RunOptions{})
+	if strings.Contains(res.Output, "No tools matched") {
+		t.Errorf("eager tools must NOT report 'No tools matched':\n%s", res.Output)
+	}
+	for _, want := range []string{"Task", "update_plan", "already in your tool list", "call them directly"} {
+		if !strings.Contains(res.Output, want) {
+			t.Errorf("expected %q in:\n%s", want, res.Output)
+		}
+	}
+	if res.Meta["load_tools"] != "" {
+		t.Errorf("eager tools must not be 'loaded', got meta %q", res.Meta["load_tools"])
+	}
+}
+
+// Mixed: load the deferred one, note the eager one.
+func TestToolSearchLoadsDeferredAndNotesEager(t *testing.T) {
+	reg := newDeferredFixtureRegistry()
+	reg.Register(searchEagerTool{name: "Task"})
+	tool := NewToolSearchTool(reg).(optionsAwareTool)
+
+	res := tool.RunWithOptions(context.Background(), map[string]any{"query": "select:weather_lookup,Task"}, RunOptions{})
+	if res.Meta["load_tools"] != "weather_lookup" {
+		t.Errorf("expected weather_lookup loaded, got %q", res.Meta["load_tools"])
+	}
+	if !strings.Contains(res.Output, "Task is already in your tool list") {
+		t.Errorf("expected the eager note for Task:\n%s", res.Output)
+	}
+}
+
+// A genuinely-unknown tool must still get the honest "No tools matched".
+func TestToolSearchUnknownStillReportsNoMatch(t *testing.T) {
+	reg := newDeferredFixtureRegistry()
+	tool := NewToolSearchTool(reg).(optionsAwareTool)
+	res := tool.RunWithOptions(context.Background(), map[string]any{"query": "select:nope_not_a_tool"}, RunOptions{})
+	if !strings.Contains(res.Output, "No tools matched") {
+		t.Errorf("unknown tool should still report 'No tools matched':\n%s", res.Output)
+	}
+}
+
+// Keyword search for an eager tool name also redirects.
+func TestToolSearchKeywordEagerRedirects(t *testing.T) {
+	reg := newDeferredFixtureRegistry()
+	reg.Register(searchEagerTool{name: "update_plan"})
+	tool := NewToolSearchTool(reg).(optionsAwareTool)
+	res := tool.RunWithOptions(context.Background(), map[string]any{"query": "update_plan"}, RunOptions{})
+	if !strings.Contains(res.Output, "update_plan is already in your tool list") {
+		t.Errorf("keyword search for an eager tool should redirect:\n%s", res.Output)
+	}
+}


### PR DESCRIPTION
## Problem
A Windows user hit an agent that got stuck looping (screenshot: `tool_search select:Task` and `select:Task,update_plan` → **"No tools matched. Available: mcp_filesystem_…"**, then halted).

Root cause: `tool_search`'s `resolveExact`/`noMatchMessage` only ever consult the **deferred** tool set. When the model searches for a tool it *already has eagerly* — `Task`, `update_plan`, any core tool — it finds nothing and returns a message that **lists only the deferred MCP tools**, implying the requested tool doesn't exist. A weaker model (cloud deepseek-v4-flash / minimax-m3) reads "not available" and **loops** retrying `tool_search` instead of just calling the tool.

## Fix
`tool_search` now recognizes eager tools (registered, not deferred, passing the operator filters) and steers the model correctly:

| Model does | Before | After |
|---|---|---|
| `select:Task,update_plan` (eager) | "No tools matched. Available: mcp_…" | **"Task, update_plan are already in your tool list — call them directly."** |
| `select:weather,Task` (mixed) | loads weather, ignores Task | loads weather **+ notes** Task is already available |
| `select:nonexistent` | "No tools matched" | "No tools matched" *(unchanged)* |
| keyword `update_plan` (eager) | misleading | redirect to call directly |

Surgical — only the error/redirect path changed; loading deferred tools is byte-identical. `NewToolSearchTool` already holds the full registry; it just wasn't using it to recognize eager tools.

Scope: this fixes the **looping/confusion** (the Zero-side bug). It does **not** address tool-call JSON mangling by weak models (the `@specialist` mention syntax, where Zero builds the JSON, is the mitigation for that), and the agent's "failed 4× → halt" is correct loop-protection.

## Tests
`TestToolSearchRedirectsEagerSelectToCallDirectly`, `…LoadsDeferredAndNotesEager`, `…UnknownStillReportsNoMatch`, `…KeywordEagerRedirects` — plus all existing tool_search tests. gofmt / vet / `go build ./...` / full `go test ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool search results messaging: when searching for tools, the app now clearly indicates which tools are already in your toolkit, preventing confusing "no tools matched" responses when tools are actually available. Enhanced feedback when both newly loaded and existing tools match a query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->