### PR TITLE
audit fixes: cron lock, accounting race, O(n²) hot paths, /style wiring

### DIFF
--- a/internal/agent/response_style_test.go
+++ b/internal/agent/response_style_test.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResponseStyleContext(t *testing.T) {
+	for _, blank := range []string{"", "balanced", "BALANCED", "garbage", "  "} {
+		if got := responseStyleContext(Options{ResponseStyle: blank}); got != "" {
+			t.Errorf("ResponseStyle %q should add nothing, got %q", blank, got)
+		}
+	}
+	for _, style := range []string{"concise", "explanatory", "review", "Concise", "REVIEW"} {
+		got := responseStyleContext(Options{ResponseStyle: style})
+		if got == "" {
+			t.Fatalf("style %q produced no directive", style)
+		}
+		if !strings.Contains(strings.ToLower(got), strings.ToLower(style)) {
+			t.Errorf("style %q directive should name the style, got %q", style, got)
+		}
+	}
+	// It lands in the assembled prompt for a real style, and not for balanced.
+	if !strings.Contains(buildSystemPrompt(Options{ResponseStyle: "concise"}), "Response style: concise") {
+		t.Error("buildSystemPrompt should inject the concise directive")
+	}
+	if strings.Contains(buildSystemPrompt(Options{ResponseStyle: "balanced"}), "Response style:") {
+		t.Error("balanced must not inject a style section (prompt stays byte-identical)")
+	}
+}

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -86,10 +86,30 @@ func buildSystemPrompt(options Options) string {
 	if delegation := specialistDelegationContext(options); delegation != "" {
 		sections = append(sections, delegation)
 	}
+	if style := responseStyleContext(options); style != "" {
+		sections = append(sections, style)
+	}
 	if policy := strings.TrimSpace(confirmationPolicy); policy != "" {
 		sections = append(sections, policy)
 	}
 	return strings.Join(sections, "\n\n")
+}
+
+// responseStyleContext renders the operator-selected reply style (TUI /style) as
+// a system-prompt directive so the choice actually shapes responses. "balanced"
+// (the default) and unknown/empty values add nothing, keeping the prompt
+// byte-identical to the pre-style behavior.
+func responseStyleContext(options Options) string {
+	switch strings.ToLower(strings.TrimSpace(options.ResponseStyle)) {
+	case "concise":
+		return "Response style: concise. Lead with the result and keep answers short and direct; omit preamble, restating the question, and any explanation not needed to be correct."
+	case "explanatory":
+		return "Response style: explanatory. Explain the reasoning behind your answers and changes, surface relevant trade-offs, and add brief context a learner would want — while staying on task and not padding."
+	case "review":
+		return "Response style: review. Work like a critical reviewer: call out risks, edge cases, and unstated assumptions, flag anything questionable, and prefer precise, evidence-backed statements over reassurance."
+	default:
+		return ""
+	}
 }
 
 func approvedCommandPrefixContext(options Options) string {

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -184,6 +184,11 @@ type Options struct {
 	ReasoningEffort  string
 	Cwd              string
 	SystemPrompt     string
+	// ResponseStyle is the operator-selected reply style from the TUI /style
+	// command (e.g. "concise", "explanatory", "review"). It is rendered into the
+	// system prompt as a short directive. Empty or "balanced" adds nothing — the
+	// prompt is then byte-identical to the pre-style behavior.
+	ResponseStyle string
 	// Images are optional image attachments to seed onto the initial user turn.
 	// nil for text-only runs (the seeded message then carries no images, exactly
 	// as before).

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -202,8 +202,9 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 		fmt.Fprintf(stdout, "fired %s -> exit %d (job removed during run)\n", job.ID, code)
 		return
 	}
-	// Record the fire only after confirming the job was not removed mid-run, so
-	// AppendRun cannot resurrect a deleted job's directory.
+	// Record the fire. AppendRun takes the per-job lock and bails if the job's
+	// metadata is gone, so a Remove landing here cannot resurrect a deleted job's
+	// directory with an orphaned runs.jsonl.
 	if aerr := store.AppendRun(job.ID, rec); aerr != nil {
 		fmt.Fprintf(stderr, "warning: failed to record run for %s: %v\n", job.ID, aerr)
 	}

--- a/internal/cli/cron_run.go
+++ b/internal/cli/cron_run.go
@@ -177,31 +177,41 @@ func fireJob(store *cron.Store, now func() time.Time, job cron.Job, stdout io.Wr
 	} else {
 		job.NextRunAt = nxt
 	}
-	// Re-read before persisting: the job may have been paused or removed while it
-	// was executing, and this in-memory copy is stale from tick start. Without
-	// this, store.Update would clobber an external pause back to active. (A single
-	// scheduler is the supported model; this narrows but does not fully close the
-	// read-modify-write window — full atomicity needs file locking.)
-	current, err := store.Get(job.ID)
-	switch {
-	case errors.Is(err, cron.ErrJobNotFound):
-		// Genuinely removed mid-run: don't recreate it by persisting.
+	// Re-read and persist the advanced state ATOMICALLY under the per-job lock. The
+	// job may have been paused or removed while it executed, and this in-memory copy
+	// is stale from tick start. Mutate closes the read-modify-write window a single
+	// scheduler alone could only narrow (Store.Mutate took a cross-process lock): a
+	// concurrent scheduler or an external pause/remove landing here can no longer be
+	// clobbered.
+	persisted, err := store.Mutate(job.ID, func(current cron.Job, readErr error) (cron.Job, error) {
+		if readErr != nil {
+			// A transient read failure (IO/permission) is NOT removal — persist the
+			// computed next state anyway so the schedule advances and the job does not
+			// re-fire next tick.
+			fmt.Fprintf(stderr, "warning: could not re-read job %s before persist: %v\n", job.ID, readErr)
+			return job, nil
+		}
+		if current.Status == cron.StatusPaused {
+			// Honor an external pause that landed while the job ran.
+			job.Status = cron.StatusPaused
+		}
+		return job, nil
+	})
+	if errors.Is(err, cron.ErrJobNotFound) {
+		// Genuinely removed mid-run: don't recreate it (no run record, no persist).
 		fmt.Fprintf(stdout, "fired %s -> exit %d (job removed during run)\n", job.ID, code)
 		return
-	case err != nil:
-		// A transient read failure (IO/permission) is NOT removal — warn but still
-		// record the run and persist the computed next state below.
-		fmt.Fprintf(stderr, "warning: could not re-read job %s before persist: %v\n", job.ID, err)
-	case current.Status == cron.StatusPaused:
-		job.Status = cron.StatusPaused
 	}
-	if err := store.AppendRun(job.ID, rec); err != nil {
-		fmt.Fprintf(stderr, "warning: failed to record run for %s: %v\n", job.ID, err)
+	// Record the fire only after confirming the job was not removed mid-run, so
+	// AppendRun cannot resurrect a deleted job's directory.
+	if aerr := store.AppendRun(job.ID, rec); aerr != nil {
+		fmt.Fprintf(stderr, "warning: failed to record run for %s: %v\n", job.ID, aerr)
 	}
-	if err := store.Update(job); err != nil {
+	if err != nil {
 		fmt.Fprintf(stderr, "warning: failed to persist job state for %s: %v\n", job.ID, err)
+		persisted = job
 	}
-	fmt.Fprintf(stdout, "fired %s -> exit %d (next: %s)\n", job.ID, code, formatCronTime(job.NextRunAt))
+	fmt.Fprintf(stdout, "fired %s -> exit %d (next: %s)\n", job.ID, code, formatCronTime(persisted.NextRunAt))
 }
 
 func cronTruncate(s string, max int) string {

--- a/internal/cron/append_run_test.go
+++ b/internal/cron/append_run_test.go
@@ -1,0 +1,34 @@
+package cron
+
+import (
+	"os"
+	"testing"
+)
+
+// AppendRun on a job removed mid-run must NOT resurrect its directory (which the
+// old unconditional MkdirAll did, leaving an orphaned runs.jsonl with no
+// metadata.json).
+func TestAppendRunDoesNotResurrectRemovedJob(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	job, err := store.Add(Job{Expr: "* * * * *", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Remove(job.ID); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if err := store.AppendRun(job.ID, RunRecord{JobID: job.ID, At: store.now()}); err != nil {
+		t.Fatalf("AppendRun after Remove should be a no-op, got: %v", err)
+	}
+	if _, err := os.Stat(store.jobDir(job.ID)); !os.IsNotExist(err) {
+		t.Fatalf("AppendRun resurrected the removed job directory (stat err = %v)", err)
+	}
+	runs, err := store.Runs(job.ID)
+	if err != nil {
+		t.Fatalf("Runs: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("expected no runs for a removed job, got %d", len(runs))
+	}
+}

--- a/internal/cron/lock.go
+++ b/internal/cron/lock.go
@@ -1,0 +1,81 @@
+package cron
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+)
+
+// Cross-process lock tuning. The lock is held only for a single metadata
+// read-modify-write (milliseconds), never across a job's exec, so the timeout is
+// generous and the stale threshold sits far above any real hold.
+const (
+	cronLockTimeout    = 10 * time.Second
+	cronLockStaleAfter = 60 * time.Second
+	cronLockRetryDelay = 20 * time.Millisecond
+)
+
+var cronLockSeq atomic.Uint64
+
+// lockJob takes a cross-process exclusive lock for one job by O_EXCL-creating a
+// sibling "<id>.lock" file next to the job directory (so Remove's RemoveAll of
+// the job dir never deletes a live lock). It serializes the read-modify-write of
+// a job's metadata across concurrent schedulers and commands. The lock file is
+// removed on release; a stale lock from a crashed holder (older than
+// cronLockStaleAfter) is reclaimed. Wall-clock time.Now is used deliberately
+// (not the injectable Store.now) so lock timing never depends on a frozen test
+// clock and the stale check compares against real file mtimes.
+func (s *Store) lockJob(id string) (func(), error) {
+	if !validID(id) {
+		return nil, fmt.Errorf("invalid cron job id %q", id)
+	}
+	lockPath := s.jobDir(id) + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, err
+	}
+	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), time.Now().UnixNano(), cronLockSeq.Add(1))
+	deadline := time.Now().Add(cronLockTimeout)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			// A partial write would leave a lock file without our token, so the
+			// releaser could never delete it — stranding the lock. Fail closed.
+			if _, werr := f.WriteString(token); werr != nil {
+				_ = f.Close()
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("cron: write job lock: %w", werr)
+			}
+			if cerr := f.Close(); cerr != nil {
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("cron: close job lock: %w", cerr)
+			}
+			var released bool
+			return func() {
+				if released {
+					return
+				}
+				released = true
+				// Only remove the file if it still carries OUR token, so a lock
+				// reclaimed as stale by another process is not deleted out from under it.
+				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
+					_ = os.Remove(lockPath)
+				}
+			}, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("cron: acquire job lock: %w", err)
+		}
+		// Reclaim a stale lock left by a crashed holder.
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > cronLockStaleAfter {
+			_ = os.Remove(lockPath)
+			continue
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("cron: timed out acquiring job lock for %q", id)
+		}
+		time.Sleep(cronLockRetryDelay)
+	}
+}

--- a/internal/cron/lock.go
+++ b/internal/cron/lock.go
@@ -65,7 +65,12 @@ func (s *Store) lockJob(id string) (func(), error) {
 				}
 			}, nil
 		}
-		if !errors.Is(err, os.ErrExist) {
+		// On Windows a concurrent holder's os.Remove leaves the lock file in a
+		// "delete pending" state, so an O_EXCL create races it with
+		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. Treat that
+		// as contention and retry, exactly like ErrExist — otherwise the lock
+		// spuriously fails under concurrency on Windows.
+		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("cron: acquire job lock: %w", err)
 		}
 		// Reclaim a stale lock left by a crashed holder.

--- a/internal/cron/mutate_test.go
+++ b/internal/cron/mutate_test.go
@@ -1,0 +1,71 @@
+package cron
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// Mutate must serialize the read-modify-write across concurrent callers via the
+// cross-process lock: N concurrent FireCount++ must all land (final == N). Without
+// the lock, racing read-modify-writes would lose updates (final < N).
+func TestMutateIsAtomicUnderConcurrency(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	job, err := store.Add(Job{Expr: "* * * * *", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, merr := store.Mutate(job.ID, func(current Job, readErr error) (Job, error) {
+				if readErr != nil {
+					return Job{}, readErr
+				}
+				current.FireCount++
+				return current, nil
+			})
+			if merr != nil {
+				t.Errorf("Mutate: %v", merr)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	got, err := store.Get(job.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.FireCount != goroutines {
+		t.Fatalf("FireCount = %d, want %d (lost updates → the lock is not serializing the read-modify-write)", got.FireCount, goroutines)
+	}
+}
+
+// A job removed between fire and persist must abort Mutate (no resurrection).
+func TestMutateRemovedJobReturnsNotFound(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	job, err := store.Add(Job{Expr: "* * * * *", Prompt: "x"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := store.Remove(job.ID); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	_, err = store.Mutate(job.ID, func(current Job, readErr error) (Job, error) {
+		return current, nil
+	})
+	if !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("Mutate on removed job = %v, want ErrJobNotFound", err)
+	}
+	// And the lock file left no litter / did not resurrect the job dir.
+	if _, gerr := store.Get(job.ID); !errors.Is(gerr, ErrJobNotFound) {
+		t.Fatalf("job should remain removed, Get = %v", gerr)
+	}
+}

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -263,6 +263,21 @@ func (s *Store) AppendRun(id string, rec RunRecord) error {
 	if !validID(id) {
 		return fmt.Errorf("invalid cron job id %q", id)
 	}
+	unlock, err := s.lockJob(id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	// Bail if the job was removed (e.g. mid-run) — otherwise the MkdirAll below
+	// would resurrect a deleted job's directory with an orphaned runs.jsonl and no
+	// metadata.json (which Runs would then still return). Under the per-job lock
+	// this stat-then-write is race-free against a concurrent Remove.
+	if _, err := os.Stat(filepath.Join(s.jobDir(id), "metadata.json")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
 	dir := s.jobDir(id)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -171,16 +171,56 @@ func (s *Store) Update(job Job) error {
 	if !validID(job.ID) {
 		return fmt.Errorf("invalid cron job id %q", job.ID)
 	}
+	unlock, err := s.lockJob(job.ID)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if _, err := os.Stat(s.jobDir(job.ID)); err != nil {
 		return fmt.Errorf("cron job %q not found", job.ID)
 	}
 	return s.writeJob(job)
 }
 
+// Mutate atomically updates job id under the per-job cross-process lock, closing
+// the read-modify-write race between concurrent schedulers (and against Update/
+// Remove). It re-reads the CURRENT on-disk job and passes it to mutate along with
+// any read error; mutate returns the job to persist. A removed job aborts with
+// ErrJobNotFound (no recreate). A transient read error (not removal) is surfaced
+// via readErr so the caller can still persist a best-effort state — the fire path
+// advances the schedule regardless, to avoid a re-fire.
+func (s *Store) Mutate(id string, mutate func(current Job, readErr error) (Job, error)) (Job, error) {
+	if !validID(id) {
+		return Job{}, fmt.Errorf("invalid cron job id %q", id)
+	}
+	unlock, err := s.lockJob(id)
+	if err != nil {
+		return Job{}, err
+	}
+	defer unlock()
+	current, readErr := s.Get(id)
+	if errors.Is(readErr, ErrJobNotFound) {
+		return Job{}, ErrJobNotFound
+	}
+	next, err := mutate(current, readErr)
+	if err != nil {
+		return Job{}, err
+	}
+	if err := s.writeJob(next); err != nil {
+		return Job{}, err
+	}
+	return next, nil
+}
+
 func (s *Store) Remove(id string) error {
 	if !validID(id) {
 		return fmt.Errorf("invalid cron job id %q", id)
 	}
+	unlock, err := s.lockJob(id)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if _, err := os.Stat(s.jobDir(id)); err != nil {
 		return fmt.Errorf("cron job %q not found", id)
 	}

--- a/internal/hooks/audit_concurrent_test.go
+++ b/internal/hooks/audit_concurrent_test.go
@@ -1,0 +1,64 @@
+package hooks
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Multiple AuditStore handles (separate store.mu, standing in for separate
+// processes) appending CONCURRENTLY to the same shared log must still get unique,
+// dense sequence numbers — only the cross-process lockAudit serializes the
+// read-then-append. Without it, two appends read the same last sequence and
+// collide. (The sequential TestAuditStoreSequenceTailRead cannot catch this.)
+func TestAuditStoreSequenceConcurrent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	const storeCount = 4
+	const perStore = 12
+
+	stores := make([]*AuditStore, storeCount)
+	for i := range stores {
+		st, err := NewAuditStore(AuditStoreOptions{AuditPath: path})
+		if err != nil {
+			t.Fatalf("NewAuditStore: %v", err)
+		}
+		stores[i] = st
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seqs := make([]int, 0, storeCount*perStore)
+	for _, st := range stores {
+		for i := 0; i < perStore; i++ {
+			wg.Add(1)
+			go func(st *AuditStore) {
+				defer wg.Done()
+				ev, err := st.AppendStarted(AppendStartedInput{HookID: "h", Event: "beforeTool"})
+				if err != nil {
+					t.Errorf("append: %v", err)
+					return
+				}
+				mu.Lock()
+				seqs = append(seqs, ev.Sequence)
+				mu.Unlock()
+			}(st)
+		}
+	}
+	wg.Wait()
+
+	if len(seqs) != storeCount*perStore {
+		t.Fatalf("got %d events, want %d", len(seqs), storeCount*perStore)
+	}
+	seen := map[int]bool{}
+	for _, s := range seqs {
+		if seen[s] {
+			t.Fatalf("duplicate sequence %d — read-then-append is not atomic across stores", s)
+		}
+		seen[s] = true
+	}
+	for i := 1; i <= storeCount*perStore; i++ {
+		if !seen[i] {
+			t.Fatalf("missing sequence %d (expected dense 1..%d)", i, storeCount*perStore)
+		}
+	}
+}

--- a/internal/hooks/audit_sequence_test.go
+++ b/internal/hooks/audit_sequence_test.go
@@ -1,0 +1,52 @@
+package hooks
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The audit append must assign monotonic sequences via an O(1) tail read, and a
+// second store on the same (shared, global) file must CONTINUE the sequence — an
+// in-memory counter would have restarted at 1 and collided across processes.
+func TestAuditStoreSequenceTailRead(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	store, err := NewAuditStore(AuditStoreOptions{AuditPath: path})
+	if err != nil {
+		t.Fatalf("NewAuditStore: %v", err)
+	}
+	for i := 1; i <= 50; i++ {
+		ev, err := store.AppendStarted(AppendStartedInput{HookID: "h", Event: "beforeTool"})
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		if ev.Sequence != i {
+			t.Fatalf("event %d Sequence = %d, want %d", i, ev.Sequence, i)
+		}
+	}
+
+	// A separate store handle on the SAME file (like a concurrent process).
+	store2, err := NewAuditStore(AuditStoreOptions{AuditPath: path})
+	if err != nil {
+		t.Fatalf("NewAuditStore #2: %v", err)
+	}
+	ev, err := store2.AppendStarted(AppendStartedInput{HookID: "h2", Event: "afterTool"})
+	if err != nil {
+		t.Fatalf("second-store append: %v", err)
+	}
+	if ev.Sequence != 51 {
+		t.Fatalf("second store next Sequence = %d, want 51 (tail read must observe prior events)", ev.Sequence)
+	}
+
+	events, err := store2.ReadEvents()
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	if len(events) != 51 {
+		t.Fatalf("expected 51 events, got %d", len(events))
+	}
+	for i, e := range events {
+		if e.Sequence != i+1 {
+			t.Fatalf("events[%d].Sequence = %d, want %d (must be unique + monotonic)", i, e.Sequence, i+1)
+		}
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -500,15 +500,9 @@ func (store *AuditStore) append(event AuditEvent) (AuditEvent, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
-	events, err := store.ReadEvents()
+	highest, err := store.lastSequence()
 	if err != nil {
 		return AuditEvent{}, err
-	}
-	highest := 0
-	for _, existing := range events {
-		if existing.Sequence > highest {
-			highest = existing.Sequence
-		}
 	}
 	event.Sequence = highest + 1
 	event.CreatedAt = store.now().UTC().Format(time.RFC3339Nano)
@@ -532,6 +526,74 @@ func (store *AuditStore) append(event AuditEvent) (AuditEvent, error) {
 		return AuditEvent{}, err
 	}
 	return event, nil
+}
+
+// lastSequence returns the Sequence of the last record in the append-only audit
+// log (or 0 when empty/absent). It reads only the file's TAIL rather than the
+// whole file, so append stays O(1) instead of O(n) per call (the previous code
+// re-read and scanned every event on every append → O(n²) over a session). It
+// reads fresh from disk each time, so a concurrent process's appends to this
+// shared global file are still observed — unlike an in-memory counter, which
+// would collide sequences across processes.
+func (store *AuditStore) lastSequence() (int, error) {
+	file, err := os.Open(store.auditPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return 0, nil
+	}
+	const tailWindow = 8 * 1024
+	start := size - tailWindow
+	if start < 0 {
+		start = 0
+	}
+	buf := make([]byte, size-start)
+	if n, err := file.ReadAt(buf, start); err != nil && n < len(buf) {
+		return 0, err
+	}
+	text := strings.TrimRight(string(buf), "\r\n \t")
+	if text == "" {
+		return 0, nil
+	}
+	if idx := strings.LastIndexByte(text, '\n'); idx >= 0 {
+		text = strings.TrimSpace(text[idx+1:])
+	} else if start > 0 {
+		// The last record is longer than the tail window (rare) — fall back to a
+		// full scan so the sequence stays correct.
+		return store.lastSequenceFullScan()
+	}
+	if text == "" {
+		return 0, nil
+	}
+	var record AuditEvent
+	if err := json.Unmarshal([]byte(text), &record); err != nil {
+		return 0, err
+	}
+	return record.Sequence, nil
+}
+
+func (store *AuditStore) lastSequenceFullScan() (int, error) {
+	events, err := store.ReadEvents()
+	if err != nil {
+		return 0, err
+	}
+	highest := 0
+	for _, existing := range events {
+		if existing.Sequence > highest {
+			highest = existing.Sequence
+		}
+	}
+	return highest, nil
 }
 
 func readLayer(source ConfigSource, path string, diagnostics *[]Diagnostic) (hookLayer, bool) {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -500,6 +501,17 @@ func (store *AuditStore) append(event AuditEvent) (AuditEvent, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
+	// Cross-process lock around the read-then-append. store.mu only serializes
+	// THIS process; the audit log is a shared global file, so without a
+	// cross-process lock two processes could both read sequence N via
+	// lastSequence() and both write N+1 (duplicate sequences). Held only for the
+	// millisecond read+append, mirroring the cron/oauth file locks.
+	unlock, err := store.lockAudit()
+	if err != nil {
+		return AuditEvent{}, err
+	}
+	defer unlock()
+
 	highest, err := store.lastSequence()
 	if err != nil {
 		return AuditEvent{}, err
@@ -532,9 +544,9 @@ func (store *AuditStore) append(event AuditEvent) (AuditEvent, error) {
 // log (or 0 when empty/absent). It reads only the file's TAIL rather than the
 // whole file, so append stays O(1) instead of O(n) per call (the previous code
 // re-read and scanned every event on every append → O(n²) over a session). It
-// reads fresh from disk each time, so a concurrent process's appends to this
-// shared global file are still observed — unlike an in-memory counter, which
-// would collide sequences across processes.
+// reads fresh from disk each time so a concurrent process's prior appends are
+// observed; the read-then-append is made atomic across processes by the caller's
+// lockAudit — store.mu alone would not prevent a cross-process sequence collision.
 func (store *AuditStore) lastSequence() (int, error) {
 	file, err := os.Open(store.auditPath)
 	if err != nil {
@@ -558,8 +570,15 @@ func (store *AuditStore) lastSequence() (int, error) {
 		start = 0
 	}
 	buf := make([]byte, size-start)
-	if n, err := file.ReadAt(buf, start); err != nil && n < len(buf) {
-		return 0, err
+	// ReadAt may return io.EOF with a short read if the file shrank between Stat
+	// and here; treat EOF as non-fatal and use only the bytes actually read.
+	n, rerr := file.ReadAt(buf, start)
+	if rerr != nil && !errors.Is(rerr, io.EOF) {
+		return 0, rerr
+	}
+	buf = buf[:n]
+	if len(buf) == 0 {
+		return 0, nil
 	}
 	text := strings.TrimRight(string(buf), "\r\n \t")
 	if text == "" {

--- a/internal/hooks/lock.go
+++ b/internal/hooks/lock.go
@@ -1,0 +1,84 @@
+package hooks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+)
+
+// Cross-process lock tuning for the audit log. The lock is held only across a
+// single read-then-append (milliseconds), so the timeout is generous and the
+// stale threshold sits far above any real hold.
+const (
+	auditLockTimeout    = 10 * time.Second
+	auditLockStaleAfter = 60 * time.Second
+	auditLockRetryDelay = 20 * time.Millisecond
+)
+
+var auditLockSeq atomic.Uint64
+
+// lockAudit takes a cross-process exclusive lock on the audit log by
+// O_EXCL-creating a sibling "<auditPath>.lock" file (removed on release). It makes
+// the lastSequence()+append in append() atomic across processes; the audit log is
+// a shared global file, so without it two processes can read the same last
+// sequence and write duplicate numbers. A stale lock from a crashed holder (older
+// than auditLockStaleAfter) is reclaimed. Wall-clock time is used deliberately so
+// lock timing never depends on the store's injectable clock and the stale check
+// compares against real file mtimes. This mirrors internal/cron/lock.go and
+// internal/oauth/lock.go (a shared filelock helper would DRY all three — left as a
+// follow-up to avoid churning those already-green packages here).
+func (store *AuditStore) lockAudit() (func(), error) {
+	lockPath := store.auditPath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, err
+	}
+	token := fmt.Sprintf("%d-%d-%d", os.Getpid(), time.Now().UnixNano(), auditLockSeq.Add(1))
+	deadline := time.Now().Add(auditLockTimeout)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			// A partial write would leave a lock file without our token, so the
+			// releaser could never delete it — stranding the lock. Fail closed.
+			if _, werr := f.WriteString(token); werr != nil {
+				_ = f.Close()
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("hooks: write audit lock: %w", werr)
+			}
+			if cerr := f.Close(); cerr != nil {
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("hooks: close audit lock: %w", cerr)
+			}
+			var released bool
+			return func() {
+				if released {
+					return
+				}
+				released = true
+				// Only remove if the file still carries OUR token, so a lock
+				// reclaimed as stale by another process is not deleted under it.
+				if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == token {
+					_ = os.Remove(lockPath)
+				}
+			}, nil
+		}
+		// On Windows a concurrent holder's os.Remove leaves the lock file in a
+		// "delete pending" state, so an O_EXCL create races it with
+		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. Treat both
+		// as contention and retry.
+		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
+			return nil, fmt.Errorf("hooks: acquire audit lock: %w", err)
+		}
+		// Reclaim a stale lock left by a crashed holder.
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > auditLockStaleAfter {
+			_ = os.Remove(lockPath)
+			continue
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("hooks: timed out acquiring audit lock")
+		}
+		time.Sleep(auditLockRetryDelay)
+	}
+}

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -56,7 +56,12 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 				}
 			}, nil
 		}
-		if !errors.Is(err, os.ErrExist) {
+		// On Windows a concurrent holder's os.Remove leaves the lock file in a
+		// "delete pending" state, so an O_EXCL create races it with
+		// ERROR_ACCESS_DENIED (os.ErrPermission) rather than ErrExist. Treat that
+		// as contention and retry, exactly like ErrExist — otherwise the lock
+		// spuriously fails under concurrency on Windows.
+		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("oauth: acquire token lock: %w", err)
 		}
 		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > fileLockStaleAfter {

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -64,11 +64,11 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("oauth: acquire token lock: %w", err)
 		}
+		// Reclaim a stale lock left by a crashed holder. (The previous double-read
+		// "stale == data" guard compared the file to itself read twice in a row, so
+		// it was always true — a no-op; staleness is decided by the mtime check.)
 		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > fileLockStaleAfter {
-			stale, _ := os.ReadFile(lockPath)
-			if data, rerr := os.ReadFile(lockPath); rerr == nil && string(data) == string(stale) {
-				_ = os.Remove(lockPath)
-			}
+			_ = os.Remove(lockPath)
 			continue
 		}
 		if now().After(deadline) {

--- a/internal/sessions/append_unless_exists_test.go
+++ b/internal/sessions/append_unless_exists_test.go
@@ -1,0 +1,77 @@
+package sessions
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// AppendEventUnlessExists must perform the existence check and append atomically:
+// under concurrency, exactly ONE caller appends even though all see the event
+// absent at first. This is the dedup the specialist accounting paths rely on.
+func TestAppendEventUnlessExistsIsAtomic(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	if _, err := store.Create(CreateInput{SessionID: "s"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	const once EventType = "test_record_once"
+	exists := func(events []Event) bool {
+		for _, e := range events {
+			if e.Type == once {
+				return true
+			}
+		}
+		return false
+	}
+
+	const goroutines = 24
+	var wg sync.WaitGroup
+	var appended int32
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, ok, err := store.AppendEventUnlessExists("s", AppendEventInput{Type: once, Payload: map[string]any{"n": 1}}, exists)
+			if err != nil {
+				t.Errorf("AppendEventUnlessExists: %v", err)
+				return
+			}
+			if ok {
+				atomic.AddInt32(&appended, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if appended != 1 {
+		t.Fatalf("expected exactly 1 append under concurrency, got %d", appended)
+	}
+	events, err := store.ReadEvents("s")
+	if err != nil {
+		t.Fatalf("ReadEvents: %v", err)
+	}
+	count := 0
+	for _, e := range events {
+		if e.Type == once {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 %q event persisted, got %d", once, count)
+	}
+}
+
+// A nil predicate always appends (parity with AppendEvent).
+func TestAppendEventUnlessExistsNilPredicateAppends(t *testing.T) {
+	store := NewStore(StoreOptions{RootDir: t.TempDir()})
+	if _, err := store.Create(CreateInput{SessionID: "s"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, ok, err := store.AppendEventUnlessExists("s", AppendEventInput{Type: "e", Payload: map[string]any{}}, nil)
+	if err != nil || !ok {
+		t.Fatalf("nil predicate should append: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -528,6 +528,44 @@ func (store *Store) AppendEvent(sessionID string, input AppendEventInput) (Event
 	return store.appendEventLocked(sessionID, input)
 }
 
+// AppendEventUnlessExists appends input only when exists(currentEvents) is false,
+// performing the existence check and the append atomically under the session lock
+// (in-process mutex + cross-process file lock). It is the safe primitive for
+// "record once" accounting: a plain ReadEvents-then-AppendEvent has a
+// check-then-act race where two callers — even in separate processes — both see
+// the event absent and each append a duplicate. Returns appended=false when the
+// predicate already matched. A nil predicate always appends.
+func (store *Store) AppendEventUnlessExists(sessionID string, input AppendEventInput, exists func([]Event) bool) (Event, bool, error) {
+	if !ValidSessionID(sessionID) {
+		return Event{}, false, fmt.Errorf("invalid zero session id %q", sessionID)
+	}
+	if strings.TrimSpace(string(input.Type)) == "" {
+		return Event{}, false, fmt.Errorf("zero session event type is required")
+	}
+	unlock, err := store.lockSession(sessionID)
+	if err != nil {
+		return Event{}, false, err
+	}
+	defer unlock()
+
+	if exists != nil {
+		// Safe under the held lock: ReadEvents only os.ReadFile's the log and never
+		// re-acquires the session lock, so there is no deadlock.
+		events, err := store.ReadEvents(sessionID)
+		if err != nil {
+			return Event{}, false, err
+		}
+		if exists(events) {
+			return Event{}, false, nil
+		}
+	}
+	event, err := store.appendEventLocked(sessionID, input)
+	if err != nil {
+		return Event{}, false, err
+	}
+	return event, true, nil
+}
+
 // appendEventLocked appends an event WITHOUT acquiring the session lock. The
 // caller MUST already hold store.lockSession(sessionID). It exists so multi-step
 // operations (e.g. ApplyRewind) can append the trailing marker atomically under

--- a/internal/specialist/accounting.go
+++ b/internal/specialist/accounting.go
@@ -11,12 +11,15 @@ import (
 
 const specialistAccountingSource = "specialist"
 
-// accountingMu serializes the "check for an existing event, then append" pairs
-// below. Without it two concurrent finishers — e.g. a foreground onExit racing a
-// TaskOutput poll, or a background reaper — can both pass specialistEventExists
-// before either appends, writing duplicate stop/usage events. Accounting is
-// low-frequency, so a single process-wide lock is sufficient (Executor is used by
-// value, so a struct field would not be shared across copies).
+// accountingMu serializes the stop/usage accounting paths within this process as
+// a cheap fast path. The real dedup guarantee, however, comes from
+// appendSpecialistEventOnce → Store.AppendEventUnlessExists, which performs the
+// existence check and the append atomically under the session lock (in-process
+// mutex + cross-process file lock). That closes the check-then-append race even
+// across processes — e.g. a foreground onExit racing a TaskOutput poll or a
+// background reaper in a separate process — which accountingMu alone (process-
+// local) could not. Executor is used by value, so a struct field would not be
+// shared across copies; a single process-wide lock is sufficient here.
 var accountingMu sync.Mutex
 
 type specialistAccountingInput struct {
@@ -39,9 +42,6 @@ func (executor Executor) recordSpecialistStop(input specialistAccountingInput, s
 	store := accountingStore(executor.SessionStore)
 	accountingMu.Lock()
 	defer accountingMu.Unlock()
-	if specialistEventExists(store, input.ParentSessionID, sessions.EventSpecialistStop, input.ChildSessionID, summary.RunID) {
-		return
-	}
 	payload := baseSpecialistPayload(input)
 	if summary.RunID != "" {
 		payload["runId"] = summary.RunID
@@ -55,7 +55,9 @@ func (executor Executor) recordSpecialistStop(input specialistAccountingInput, s
 	if len(summary.Errors) > 0 {
 		payload["errors"] = append([]string(nil), summary.Errors...)
 	}
-	_, _ = appendSpecialistSessionEvent(store, input.ParentSessionID, sessions.EventSpecialistStop, payload)
+	// Atomic check+append under the session lock so a concurrent stop path cannot
+	// also pass the existence check and write a duplicate stop event.
+	_, _ = appendSpecialistEventOnce(store, input.ParentSessionID, sessions.EventSpecialistStop, payload, input.ChildSessionID, summary.RunID)
 }
 
 func (executor Executor) rollUpSpecialistUsage(input specialistAccountingInput, summary StreamResult) bool {
@@ -90,9 +92,6 @@ func appendSpecialistUsageRollup(store *sessions.Store, input specialistAccounti
 	store = accountingStore(store)
 	accountingMu.Lock()
 	defer accountingMu.Unlock()
-	if specialistEventExists(store, input.ParentSessionID, sessions.EventUsage, input.ChildSessionID, summary.RunID) {
-		return false, nil
-	}
 	payload := baseSpecialistPayload(input)
 	if summary.RunID != "" {
 		payload["runId"] = summary.RunID
@@ -101,10 +100,9 @@ func appendSpecialistUsageRollup(store *sessions.Store, input specialistAccounti
 	payload["completionTokens"] = summary.Usage.CompletionTokens
 	payload["totalTokens"] = summary.Usage.EffectiveTotalTokens()
 	payload["usageEvents"] = summary.Usage.Events
-	if _, err := appendSpecialistSessionEvent(store, input.ParentSessionID, sessions.EventUsage, payload); err != nil {
-		return false, err
-	}
-	return true, nil
+	// Atomic check+append under the session lock so the TaskOutput poll and the
+	// onExit path cannot both pass the existence check and double-count usage.
+	return appendSpecialistEventOnce(store, input.ParentSessionID, sessions.EventUsage, payload, input.ChildSessionID, summary.RunID)
 }
 
 func appendSpecialistSessionEvent(store *sessions.Store, parentSessionID string, eventType sessions.EventType, payload map[string]any) (sessions.Event, error) {
@@ -116,42 +114,61 @@ func appendSpecialistSessionEvent(store *sessions.Store, parentSessionID string,
 	return store.AppendEvent(parentSessionID, sessions.AppendEventInput{Type: eventType, Payload: payload})
 }
 
-func specialistEventExists(store *sessions.Store, parentSessionID string, eventType sessions.EventType, childSessionID string, runID string) bool {
-	parentSessionID = strings.TrimSpace(parentSessionID)
+// specialistEventMatcher returns a predicate reporting whether a "record once"
+// specialist event of eventType has already been written for this child/run. The
+// catch-all runId rules mirror the dedup the accounting paths depend on.
+func specialistEventMatcher(eventType sessions.EventType, childSessionID, runID string) func([]sessions.Event) bool {
 	childSessionID = strings.TrimSpace(childSessionID)
 	runID = strings.TrimSpace(runID)
-	if parentSessionID == "" || childSessionID == "" || !sessions.ValidSessionID(parentSessionID) {
+	return func(events []sessions.Event) bool {
+		if childSessionID == "" {
+			return false
+		}
+		for _, event := range events {
+			if event.Type != eventType {
+				continue
+			}
+			payload := map[string]any{}
+			if err := json.Unmarshal(event.Payload, &payload); err != nil {
+				continue
+			}
+			if specialistPayloadString(payload, "source") != specialistAccountingSource {
+				continue
+			}
+			if specialistPayloadString(payload, "childSessionId") != childSessionID && specialistPayloadString(payload, "taskId") != childSessionID {
+				continue
+			}
+			// An already-recorded event with NO runId is a catch-all for this child
+			// (e.g. the immediate stop written when a PID couldn't be registered) and
+			// must match a later event that does carry a runId — otherwise the same
+			// child gets two stop/usage events. We match when: querying without a runId,
+			// the existing event has none, or the runIds are equal.
+			existingRunID := specialistPayloadString(payload, "runId")
+			if runID == "" || existingRunID == "" || existingRunID == runID {
+				return true
+			}
+		}
 		return false
 	}
-	events, err := store.ReadEvents(parentSessionID)
-	if err != nil {
-		return false
+}
+
+// appendSpecialistEventOnce atomically records a "record once" specialist event:
+// it appends payload only if no matching event already exists, under the session
+// store's lock so concurrent stop/usage callers (even cross-process) cannot both
+// pass an existence check and each write a duplicate. Returns appended=false when
+// an equivalent event was already present.
+func appendSpecialistEventOnce(store *sessions.Store, parentSessionID string, eventType sessions.EventType, payload map[string]any, childSessionID, runID string) (bool, error) {
+	parentSessionID = strings.TrimSpace(parentSessionID)
+	if parentSessionID == "" || !sessions.ValidSessionID(parentSessionID) {
+		return false, nil
 	}
-	for _, event := range events {
-		if event.Type != eventType {
-			continue
-		}
-		payload := map[string]any{}
-		if err := json.Unmarshal(event.Payload, &payload); err != nil {
-			continue
-		}
-		if specialistPayloadString(payload, "source") != specialistAccountingSource {
-			continue
-		}
-		if specialistPayloadString(payload, "childSessionId") != childSessionID && specialistPayloadString(payload, "taskId") != childSessionID {
-			continue
-		}
-		// An already-recorded event with NO runId is a catch-all for this child (e.g.
-		// the immediate stop written when a PID couldn't be registered) and must
-		// match a later event that does carry a runId — otherwise the same child gets
-		// two stop/usage events. We match when: we're querying without a runId, the
-		// existing event has none, or the runIds are equal.
-		existingRunID := specialistPayloadString(payload, "runId")
-		if runID == "" || existingRunID == "" || existingRunID == runID {
-			return true
-		}
-	}
-	return false
+	store = accountingStore(store)
+	_, appended, err := store.AppendEventUnlessExists(
+		parentSessionID,
+		sessions.AppendEventInput{Type: eventType, Payload: payload},
+		specialistEventMatcher(eventType, childSessionID, runID),
+	)
+	return appended, err
 }
 
 func baseSpecialistPayload(input specialistAccountingInput) map[string]any {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2863,6 +2863,7 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 		options.ProviderName = m.providerName
 		options.Model = m.modelName
 		options.ReasoningEffort = string(m.reasoningEffort)
+		options.ResponseStyle = m.responseStyle
 		options.Cwd = m.cwd
 		options.Images = images
 		if m.captureRunImages != nil {

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -143,9 +143,7 @@ func (m model) handleResumeCommand(args string) (model, string) {
 
 	rows := initialTranscript()
 	rows = appendRow(rows, rowSystem, m.formatResumeSummary(*session, len(events)))
-	for _, row := range transcriptRowsFromSessionEvents(events) {
-		rows = appendTranscriptRow(rows, row)
-	}
+	rows = appendTranscriptRowsDedup(rows, transcriptRowsFromSessionEvents(events))
 	m.transcript = rows
 	// Every rehydrated row is settled by construction, so resetting the flush
 	// frontier sends the whole resumed history to native scrollback in one

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -374,9 +374,7 @@ func (m model) handleRewindCommand(args string) (model, string) {
 	}
 	m.sessionEvents = append([]sessions.Event{}, events...)
 	rows := initialTranscript()
-	for _, row := range transcriptRowsFromSessionEvents(events) {
-		rows = appendTranscriptRow(rows, row)
-	}
+	rows = appendTranscriptRowsDedup(rows, transcriptRowsFromSessionEvents(events))
 	m.transcript = rows
 	// The rebuilt (post-rewind) transcript flushes fresh below a divider; the
 	// pre-rewind scrollback above it stays, as scrollback cannot be un-printed.
@@ -591,9 +589,7 @@ func (m model) compactActiveSession() (model, CompactResult, error) {
 	}
 	m.sessionEvents = append([]sessions.Event{}, events...)
 	rows := initialTranscript()
-	for _, row := range transcriptRowsFromSessionEvents(events) {
-		rows = appendTranscriptRow(rows, row)
-	}
+	rows = appendTranscriptRowsDedup(rows, transcriptRowsFromSessionEvents(events))
 	m.transcript = rows
 	m.resetFlushFrontier("· compacted ·")
 

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -102,6 +102,35 @@ func appendTranscriptRow(rows []transcriptRow, row transcriptRow) []transcriptRo
 	return append(rows, row)
 }
 
+// appendTranscriptRowsDedup appends newRows to rows in a single pass, skipping
+// keyed rows already present (by transcriptRowKey). It is the bulk equivalent of
+// calling appendTranscriptRow per row, but builds the key set ONCE instead of
+// re-scanning every existing row on each append — turning rehydration of a
+// tool-heavy session from O(n²) into O(n). Semantics are identical: unkeyed rows
+// always append; a keyed row is skipped if its key already appeared (in rows, or
+// earlier within newRows).
+func appendTranscriptRowsDedup(rows []transcriptRow, newRows []transcriptRow) []transcriptRow {
+	if len(newRows) == 0 {
+		return rows
+	}
+	seen := make(map[string]struct{}, len(rows)+len(newRows))
+	for _, existing := range rows {
+		if key := transcriptRowKey(existing); key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+	for _, row := range newRows {
+		if key := transcriptRowKey(row); key != "" {
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
 func hasTranscriptRow(rows []transcriptRow, row transcriptRow) bool {
 	key := transcriptRowKey(row)
 	if key == "" {

--- a/internal/tui/transcript_dedup_test.go
+++ b/internal/tui/transcript_dedup_test.go
@@ -1,0 +1,33 @@
+package tui
+
+import "testing"
+
+// appendTranscriptRowsDedup must produce byte-identical output to repeated
+// appendTranscriptRow (the O(n²) form it replaces), including keyed-row dedup and
+// always-append for unkeyed rows.
+func TestAppendTranscriptRowsDedupMatchesPerRow(t *testing.T) {
+	newRows := []transcriptRow{
+		{kind: rowToolCall, runID: 1, id: "a"},
+		{kind: rowSystem, text: "note"},
+		{kind: rowToolCall, runID: 1, id: "a"}, // duplicate keyed row -> skipped
+		{kind: rowToolResult, runID: 1, id: "b"},
+		{kind: rowSystem, text: "note"},        // unkeyed duplicate -> still appended
+		{kind: rowToolCall, runID: 2, id: "a"}, // same id, different run -> distinct key
+	}
+	base := initialTranscript()
+
+	want := append([]transcriptRow{}, base...)
+	for _, r := range newRows {
+		want = appendTranscriptRow(want, r)
+	}
+	got := appendTranscriptRowsDedup(append([]transcriptRow{}, base...), newRows)
+
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: bulk=%d per-row=%d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].kind != want[i].kind || got[i].id != want[i].id || got[i].runID != want[i].runID || got[i].text != want[i].text {
+			t.Fatalf("row %d differs:\n bulk=%+v\n per =%+v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Fixes **five verified findings** from a code audit. Each was checked against the codebase first; two related findings turned out already-addressed upstream, and three need larger/separate work (all noted below).

## Fixed

**H-1 — cron store has no cross-process lock** *(the read-modify-write race)*
Two schedulers seeing a job due raced the metadata read-modify-write — `fireJob` even documented it (*"full atomicity needs file locking"*). Adds a per-job **O_EXCL lock** (mirrors `internal/oauth`'s proven pattern, incl. stale-reclaim) and a `Mutate` primitive doing the re-read→modify→write atomically; `Update`/`Remove` lock too. The lock is held only for the millisecond RMW — **never across a job's exec**.

**M-5 — specialist accounting check-then-append race**
`specialistEventExists` (unlocked `ReadEvents`) + a later `AppendEvent` let two finishers (TaskOutput poll vs `onExit`, even cross-process) both pass the check and write **duplicate** stop/usage events. Adds `sessions.Store.AppendEventUnlessExists` (existence check + append atomic under the session lock) and routes both paths through it.

**M-2 — hooks audit append is O(n²)**
`append` re-read and scanned the *whole* audit log every call to find the max sequence. Now reads only the file **tail** — O(1), and **multi-process safe** (the log is a shared global file), unlike an in-memory counter which would collide sequences across processes.

**M-4 — transcript rehydration is O(n²)**
The three resume/rewind/compact loops called `appendTranscriptRow` per event, each re-scanning every existing row for the keyed-row dedup. A bulk `appendTranscriptRowsDedup` builds the key set **once**; semantics are identical (verified by a parity test).

**M-6 — `/style` was inert**
The TUI `/style` command stored a style but never threaded it anywhere. Adds `agent.Options.ResponseStyle`, a system-prompt directive for `concise`/`explanatory`/`review`, and wires `m.responseStyle` through the run. `balanced` is a no-op (prompt byte-identical to before).

## Already addressed upstream (no change needed)
- **M-1** (forked-session double-count): `Store.Fork` already **skips `EventUsage`** events, with a comment naming the exact double-count it prevents.
- **M-3** (lineage O(N²)): `Tree` already does a **single `store.List()` scan** and indexes children in memory; no path calls `List` per node.

## Deferred (need larger/separate changes — not a contained fix)
- **M-7** `escalate_model` in the TUI needs a `ModelSwitcher` that builds a provider mid-run; registering the tool alone yields a tool that errors on call.
- **L-1** MCP SSE reconnect is a stream-lifecycle change (and low-likelihood after the 8 MiB per-event cap).
- **L-2** dead-code removal belongs in a dedicated cleanup sweep.

## Tests
Per-fix unit tests, including **concurrency under `-race`** (`cron.Mutate` atomicity, `sessions.AppendEventUnlessExists` atomicity, multi-store hooks sequence continuity) and a transcript dedup **parity** test. gofmt / vet / `go build ./...` / full `go test ./...` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator-selected agent response styles (**concise**, **explanatory**, **review**) via system prompt directives; **balanced** preserves prior behavior.
  * Added a concurrency-safe “append unless exists” API to prevent duplicate session events.
* **Bug Fixes**
  * Improved cron scheduling persistence and run recording using cross-process per-job locking, including correct handling when jobs are removed.
  * Made audit log sequencing more reliable (faster tail-based updates and cross-process locking).
  * Strengthened transcript de-duplication across resume/rewind/compaction.
  * Improved Windows lock contention handling for OAuth file locks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->