### PR TITLE
Fix four high-severity concurrency/correctness bugs (swarm, locks, lsp, config)

### DIFF
--- a/internal/config/env_provider_kind_test.go
+++ b/internal/config/env_provider_kind_test.go
@@ -1,0 +1,37 @@
+package config
+
+import "testing"
+
+func TestEnvKeyPreservesExistingCompatibleProviderKind(t *testing.T) {
+	// A same-named openai-compatible provider (a proxy/gateway) must keep its kind
+	// when the user exports OPENAI_API_KEY (credentials only, no baseURL). H2.
+	cfg := &FileConfig{
+		ActiveProvider: "openai",
+		Providers: []ProviderProfile{{
+			Name:         "openai",
+			ProviderKind: ProviderKindOpenAICompatible,
+			BaseURL:      "https://gateway.example/v1",
+			Model:        "gpt-4o",
+		}},
+	}
+	applyProviderEnv(cfg, ProviderKindOpenAI, envProfile{Name: "openai", APIKey: "sk-from-env"})
+	p := cfg.Providers[0]
+	if p.ProviderKind != ProviderKindOpenAICompatible {
+		t.Errorf("transport kind clobbered: got %q, want %q", p.ProviderKind, ProviderKindOpenAICompatible)
+	}
+	if p.APIKey != "sk-from-env" {
+		t.Errorf("env api key not applied: %q", p.APIKey)
+	}
+	if p.BaseURL != "https://gateway.example/v1" {
+		t.Errorf("existing baseURL lost: %q", p.BaseURL)
+	}
+}
+
+func TestEnvKeyCreatesStandardProviderWhenAbsent(t *testing.T) {
+	// With no same-named provider, the env key still creates a standard provider.
+	cfg := &FileConfig{}
+	applyProviderEnv(cfg, ProviderKindOpenAI, envProfile{Name: "openai", APIKey: "sk-x"})
+	if len(cfg.Providers) != 1 || cfg.Providers[0].ProviderKind != ProviderKindOpenAI {
+		t.Fatalf("absent provider should be created as standard openai, got %+v", cfg.Providers)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -472,6 +472,18 @@ func applyProviderEnv(cfg *FileConfig, providerKind ProviderKind, env envProfile
 	if providerKind == ProviderKindOpenAI && baseURL != "" && !isOfficialOpenAIBaseURL(baseURL) {
 		profile.ProviderKind = ProviderKindOpenAICompatible
 	}
+	// When the env supplies only credentials (no baseURL) for a provider name that
+	// already exists, don't force the standard transport kind — a same-named
+	// openai-compatible/anthropic-compatible proxy or gateway must keep its kind.
+	// An empty kind makes mergeProfile preserve the existing provider's kind (H2).
+	if baseURL == "" {
+		for _, existing := range cfg.Providers {
+			if strings.TrimSpace(existing.Name) == profile.Name {
+				profile.ProviderKind = ""
+				break
+			}
+		}
+	}
 	mergeProvider(cfg, profile)
 }
 

--- a/internal/cron/lock.go
+++ b/internal/cron/lock.go
@@ -73,14 +73,44 @@ func (s *Store) lockJob(id string) (func(), error) {
 		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("cron: acquire job lock: %w", err)
 		}
-		// Reclaim a stale lock left by a crashed holder.
+		// Reclaim a stale lock left by a crashed holder — atomically (H3). A blind
+		// Remove lets two racers both "reclaim" and recreate, so both hold the lock;
+		// reclaimStaleLock renames the file aside (only one rename of a given file
+		// wins) and restores it if it turns out fresh, so a live lock is never deleted
+		// out from under its holder.
 		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > cronLockStaleAfter {
-			_ = os.Remove(lockPath)
-			continue
+			if reclaimStaleLock(lockPath, token, cronLockStaleAfter) {
+				continue // cleared a genuinely stale lock; retry the O_EXCL create now
+			}
+			// Lost the reclaim race (or it was actually fresh) — fall through to the
+			// bounded wait instead of hot-spinning on a reclaim that never wins (L13).
 		}
 		if !time.Now().Before(deadline) {
 			return nil, fmt.Errorf("cron: timed out acquiring job lock for %q", id)
 		}
 		time.Sleep(cronLockRetryDelay)
 	}
+}
+
+// reclaimStaleLock atomically reclaims a stale lock file. It renames the lock to a
+// per-acquirer unique name (only one racer can rename a given file, so two racers
+// can never both reclaim the same lock), then verifies the moved file is still
+// stale; if it became fresh (another holder reacquired in the gap between the
+// stale check and the rename) it is restored rather than stolen. Returns true only
+// when a genuinely stale lock was removed, so the caller knows it is safe to retry
+// the exclusive create immediately; on a lost race it returns false and the caller
+// falls through to its bounded wait.
+func reclaimStaleLock(lockPath, token string, staleAfter time.Duration) bool {
+	reclaimed := fmt.Sprintf("%s.stale.%s", lockPath, token)
+	if err := os.Rename(lockPath, reclaimed); err != nil {
+		return false // another racer already moved/removed it, or it vanished
+	}
+	if info, err := os.Stat(reclaimed); err == nil && time.Since(info.ModTime()) <= staleAfter {
+		// Not actually stale anymore — a holder reacquired it in the gap. Put it
+		// back instead of stealing a live lock, and let the caller wait.
+		_ = os.Rename(reclaimed, lockPath)
+		return false
+	}
+	_ = os.Remove(reclaimed)
+	return true
 }

--- a/internal/cron/lock_reclaim_test.go
+++ b/internal/cron/lock_reclaim_test.go
@@ -1,0 +1,46 @@
+package cron
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestReclaimStaleLock(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "job.lock")
+
+	// A genuinely stale lock (old mtime) is reclaimed and removed.
+	if err := os.WriteFile(lockPath, []byte("crashed-holder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-2 * cronLockStaleAfter)
+	if err := os.Chtimes(lockPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if !reclaimStaleLock(lockPath, "tok-a", cronLockStaleAfter) {
+		t.Fatal("a stale lock should be reclaimed")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("reclaimed stale lock should be gone, stat err=%v", err)
+	}
+
+	// A FRESH lock (someone reacquired in the gap) must be RESTORED intact, not
+	// stolen — this is the H3 mutual-exclusion protection.
+	if err := os.WriteFile(lockPath, []byte("live-holder"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if reclaimStaleLock(lockPath, "tok-b", cronLockStaleAfter) {
+		t.Fatal("a fresh lock must not be reclaimed")
+	}
+	if data, err := os.ReadFile(lockPath); err != nil || string(data) != "live-holder" {
+		t.Fatalf("fresh lock must be left intact, got %q err %v", data, err)
+	}
+
+	// A missing lock reports no reclaim (nothing to steal).
+	_ = os.Remove(lockPath)
+	if reclaimStaleLock(lockPath, "tok-c", cronLockStaleAfter) {
+		t.Fatal("a missing lock should not report a reclaim")
+	}
+}

--- a/internal/hooks/lock.go
+++ b/internal/hooks/lock.go
@@ -71,14 +71,38 @@ func (store *AuditStore) lockAudit() (func(), error) {
 		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("hooks: acquire audit lock: %w", err)
 		}
-		// Reclaim a stale lock left by a crashed holder.
+		// Reclaim a stale lock left by a crashed holder — atomically (H3). A blind
+		// Remove lets two racers both reclaim + recreate and so both hold the lock;
+		// reclaimStaleLock renames the file aside (only one rename wins) and restores
+		// it if it turns out fresh, so a live lock is never deleted out from under it.
 		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > auditLockStaleAfter {
-			_ = os.Remove(lockPath)
-			continue
+			if reclaimStaleLock(lockPath, token, auditLockStaleAfter) {
+				continue
+			}
+			// Lost the reclaim race (or it was actually fresh) — fall through to the
+			// bounded wait rather than hot-spinning on a reclaim that never wins.
 		}
 		if !time.Now().Before(deadline) {
 			return nil, fmt.Errorf("hooks: timed out acquiring audit lock")
 		}
 		time.Sleep(auditLockRetryDelay)
 	}
+}
+
+// reclaimStaleLock atomically reclaims a stale lock file: it renames the lock to a
+// per-acquirer unique name (only one racer can rename a given file), then verifies
+// the moved file is still stale; if a holder reacquired it in the gap it is
+// restored rather than stolen. Returns true only when a genuinely stale lock was
+// removed. Mirrors internal/cron/lock.go and internal/oauth/lock.go.
+func reclaimStaleLock(lockPath, token string, staleAfter time.Duration) bool {
+	reclaimed := fmt.Sprintf("%s.stale.%s", lockPath, token)
+	if err := os.Rename(lockPath, reclaimed); err != nil {
+		return false
+	}
+	if info, err := os.Stat(reclaimed); err == nil && time.Since(info.ModTime()) <= staleAfter {
+		_ = os.Rename(reclaimed, lockPath)
+		return false
+	}
+	_ = os.Remove(reclaimed)
+	return true
 }

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -216,6 +216,19 @@ func (c *Client) readError() error {
 	return errors.New("lsp client closed")
 }
 
+// IsClosed reports whether the client's connection has been torn down — the
+// server exited, a read error occurred, or Close was called (all close c.closed).
+// A closed client can never serve another request, so the manager evicts and
+// restarts its session rather than returning a permanently-dead one.
+func (c *Client) IsClosed() bool {
+	select {
+	case <-c.closed:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *Client) write(payload any) error {
 	// Reject writes once the client is closed so Notify (and Call's request write)
 	// can't keep pushing frames onto a dead connection.

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -130,10 +130,19 @@ func (m *Manager) sessionFor(ctx context.Context, command []string) (*session, e
 	key := command[0]
 	m.mu.Lock()
 	if sess, ok := m.sessions[key]; ok {
+		if !sess.client.IsClosed() {
+			m.mu.Unlock()
+			return sess, nil
+		}
+		// The cached session's client has died (server crashed/exited/malformed
+		// frame). Evict it so a fresh server is started below — otherwise every
+		// later diagnostic fails forever against a permanently-dead session (H4).
+		delete(m.sessions, key)
 		m.mu.Unlock()
-		return sess, nil
+		_ = sess.server.Shutdown(context.Background()) // best-effort reap of the dead server
+	} else {
+		m.mu.Unlock()
 	}
-	m.mu.Unlock()
 
 	server, err := m.starter(ctx, command, m.workspaceRoot)
 	if err != nil {
@@ -142,12 +151,12 @@ func (m *Manager) sessionFor(ctx context.Context, command []string) (*session, e
 	sess := newSession(server)
 
 	m.mu.Lock()
-	if existing, ok := m.sessions[key]; ok {
+	if existing, ok := m.sessions[key]; ok && !existing.client.IsClosed() {
 		m.mu.Unlock()
 		_ = server.Shutdown(context.Background()) // lost the start race; discard ours
 		return existing, nil
 	}
-	m.sessions[key] = sess
+	m.sessions[key] = sess // install ours (replacing an absent or already-dead entry)
 	m.mu.Unlock()
 	return sess, nil
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -251,3 +251,44 @@ func TestManagerCheckDegradesWhenServerBinaryMissing(t *testing.T) {
 		t.Fatalf("missing server binary should degrade to (nil,nil), got (%#v, %v)", diags, err)
 	}
 }
+
+func TestSessionForEvictsDeadSession(t *testing.T) {
+	var starts int
+	inner := stubStarter(nil, true) // neverPublish; this test only exercises session lifecycle
+	m := fastManager(func(ctx context.Context, cmd []string, root string) (lspServer, error) {
+		starts++
+		return inner(ctx, cmd, root)
+	})
+
+	sess1, err := m.sessionFor(context.Background(), []string{"gopls"})
+	if err != nil {
+		t.Fatalf("sessionFor: %v", err)
+	}
+	if starts != 1 {
+		t.Fatalf("starts = %d, want 1", starts)
+	}
+
+	// A live session is reused — no new server started.
+	if sess2, _ := m.sessionFor(context.Background(), []string{"gopls"}); sess2 != sess1 || starts != 1 {
+		t.Fatalf("live session should be reused: same=%v starts=%d", sess2 == sess1, starts)
+	}
+
+	// Simulate the language server crashing: its client closes.
+	_ = sess1.client.Close()
+	if !sess1.client.IsClosed() {
+		t.Fatal("client should report closed after Close")
+	}
+
+	// sessionFor must now evict the dead session and start a fresh server (H4) —
+	// otherwise every later diagnostic would fail forever against the dead one.
+	sess3, err := m.sessionFor(context.Background(), []string{"gopls"})
+	if err != nil {
+		t.Fatalf("sessionFor after crash: %v", err)
+	}
+	if starts != 2 {
+		t.Fatalf("a dead session must trigger a restart: starts=%d, want 2", starts)
+	}
+	if sess3 == sess1 {
+		t.Fatal("should return a fresh session, not the dead one")
+	}
+}

--- a/internal/oauth/lock.go
+++ b/internal/oauth/lock.go
@@ -64,16 +64,38 @@ func acquireFileLock(lockPath string, now func() time.Time) (func(), error) {
 		if !errors.Is(err, os.ErrExist) && !errors.Is(err, os.ErrPermission) {
 			return nil, fmt.Errorf("oauth: acquire token lock: %w", err)
 		}
-		// Reclaim a stale lock left by a crashed holder. (The previous double-read
-		// "stale == data" guard compared the file to itself read twice in a row, so
-		// it was always true — a no-op; staleness is decided by the mtime check.)
+		// Reclaim a stale lock left by a crashed holder — atomically (H3). A blind
+		// Remove lets two racers both reclaim + recreate and so both hold the lock;
+		// reclaimStaleLock renames the file aside (only one rename wins) and restores
+		// it if it turns out fresh, so a live lock is never deleted out from under it.
 		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > fileLockStaleAfter {
-			_ = os.Remove(lockPath)
-			continue
+			if reclaimStaleLock(lockPath, token, fileLockStaleAfter) {
+				continue
+			}
+			// Lost the reclaim race (or it was actually fresh) — fall through to the
+			// bounded wait rather than hot-spinning on a reclaim that never wins.
 		}
 		if now().After(deadline) {
 			return nil, fmt.Errorf("oauth: timed out acquiring token lock %s", filepath.Base(lockPath))
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+// reclaimStaleLock atomically reclaims a stale lock file: it renames the lock to a
+// per-acquirer unique name (only one racer can rename a given file), then verifies
+// the moved file is still stale; if a holder reacquired it in the gap it is
+// restored rather than stolen. Returns true only when a genuinely stale lock was
+// removed. Mirrors internal/cron/lock.go and internal/hooks/lock.go.
+func reclaimStaleLock(lockPath, token string, staleAfter time.Duration) bool {
+	reclaimed := fmt.Sprintf("%s.stale.%s", lockPath, token)
+	if err := os.Rename(lockPath, reclaimed); err != nil {
+		return false
+	}
+	if info, err := os.Stat(reclaimed); err == nil && time.Since(info.ModTime()) <= staleAfter {
+		_ = os.Rename(reclaimed, lockPath)
+		return false
+	}
+	_ = os.Remove(reclaimed)
+	return true
 }

--- a/internal/swarm/lifecycle_test.go
+++ b/internal/swarm/lifecycle_test.go
@@ -306,6 +306,27 @@ func TestAdoptOrphans(t *testing.T) {
 	}
 }
 
+func TestLiveAgentsIncludesQueuedSpecs(t *testing.T) {
+	// H1 regression: a spec queued over the concurrency cap is owned and about to
+	// launch, so it must count as a live agent. Otherwise AdoptOrphans sees its
+	// task as orphaned and re-dispatches it — double-executing the same task.
+	team := &Team{Name: "t", members: map[string]*Member{}, maxSize: 1}
+	if !team.admit(MemberSpec{ID: "a1", TaskID: "t1"}) {
+		t.Fatal("first spec should take the only slot and launch immediately")
+	}
+	team.addMember(&Member{ID: "a1"})
+	if team.admit(MemberSpec{ID: "a2", TaskID: "t2"}) {
+		t.Fatal("second spec is over the cap and should queue, not launch")
+	}
+	live := team.liveAgents()
+	if _, ok := live["a1"]; !ok {
+		t.Error("running member a1 missing from liveAgents")
+	}
+	if _, ok := live["a2"]; !ok {
+		t.Error("queued spec a2 missing from liveAgents — would be double-dispatched by AdoptOrphans")
+	}
+}
+
 func TestCollectScopesToTeam(t *testing.T) {
 	l := newLauncher(okFor)
 	sw := newSwarmFor(t, l)

--- a/internal/swarm/team.go
+++ b/internal/swarm/team.go
@@ -305,9 +305,15 @@ func (t *Team) removeMember(id string) {
 func (t *Team) liveAgents() map[string]struct{} {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	live := make(map[string]struct{}, len(t.members))
+	live := make(map[string]struct{}, len(t.members)+len(t.queue))
 	for _, m := range t.members {
 		live[m.ID] = struct{}{}
+	}
+	// Queued specs are over the concurrency cap but still owned and about to launch
+	// as slots free; count them live so orphan adoption never re-dispatches (and
+	// thus double-executes) a task whose member is merely waiting for a slot.
+	for _, spec := range t.queue {
+		live[spec.ID] = struct{}{}
 	}
 	return live
 }


### PR DESCRIPTION
## Summary

Four high-severity concurrency/correctness bugs surfaced by a full-tree audit. All are **latent** — `go test ./...` passes — because they live in race windows and provider/error edges the suite doesn't exercise. Each fix ships with a regression test.

## Fixes

| Area | Bug | Fix |
|---|---|---|
| **swarm** | `AdoptOrphans` re-dispatches a task whose member is queued over the concurrency cap → the same delegated task runs **twice** (duplicate file/shell side effects, broken one-member-per-task invariant). | `liveAgents()` now counts queued specs as live, so a merely-waiting member is never treated as an orphan. |
| **config** | An `*_API_KEY` env var rewrites a same-named *compatible-transport* provider's kind, breaking proxy/gateway setups with a confusing "requires official baseURL" error. | When the env supplies credentials only (no base URL) and a same-named provider exists, leave the kind unset so the merge preserves the existing one. |
| **cron / hooks / oauth** | Stale-lock reclaim did a blind `Remove`+recreate; under contention two processes both take the lock — a mutual-exclusion violation (duplicate audit sequence numbers, reopened metadata read-modify-write race). | Atomic **rename-with-verify** reclaim (only one racer wins; a freshly-reacquired lock is restored, not stolen). Also falls through to the bounded wait instead of hot-spinning when a reclaim never wins. |
| **lsp** | A crashed/exited language-server session is never evicted → every later diagnostic errors forever, and self-correct fails on every changed file every iteration with no recovery short of a restart. | `Client.IsClosed()` + evict-and-restart in `sessionFor`. |

## Tests
- `TestLiveAgentsIncludesQueuedSpecs`
- `TestEnvKeyPreservesExistingCompatibleProviderKind`, `TestEnvKeyCreatesStandardProviderWhenAbsent`
- `TestReclaimStaleLock` (atomic reclaim + the fresh-lock-restored protection)
- `TestSessionForEvictsDeadSession`

`go build ./...`, `go vet ./...`, `gofmt`, and the full `go test ./...` are all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Provider configuration now preserves existing compatible settings when environment credentials are supplied without a custom base URL.
  * Improved stale lock handling across multiple components using atomic rename operations, preventing race conditions where live locks could be prematurely deleted.
  * LSP session management now validates client connections and automatically recovers by starting fresh sessions when needed.
  * Queued agent specs are now properly included in live agent tracking for correct orphan/adoption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->