### PR TITLE
TUI: live code-streaming preview, theme system, plan/Task transcript dedup

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -182,9 +182,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 		}
 
 		collected := zeroruntime.CollectStreamWithOptions(ctx, stream, zeroruntime.CollectOptions{
-			OnText:      options.OnText,
-			OnReasoning: options.OnReasoning,
-			OnUsage:     options.OnUsage,
+			OnText:          options.OnText,
+			OnReasoning:     options.OnReasoning,
+			OnUsage:         options.OnUsage,
+			OnToolCallStart: options.OnToolCallStart,
+			OnToolCallDelta: options.OnToolCallDelta,
 		})
 		if collected.Error != "" {
 			// REACTIVE compaction: the streamed error may also be a context
@@ -487,9 +489,11 @@ func finalAnswerAfterMaxTurns(ctx context.Context, provider Provider, messages [
 		return "", messages, ""
 	}
 	collected := zeroruntime.CollectStreamWithOptions(ctx, stream, zeroruntime.CollectOptions{
-		OnText:      options.OnText,
-		OnReasoning: options.OnReasoning,
-		OnUsage:     options.OnUsage,
+		OnText:          options.OnText,
+		OnReasoning:     options.OnReasoning,
+		OnUsage:         options.OnUsage,
+		OnToolCallStart: options.OnToolCallStart,
+		OnToolCallDelta: options.OnToolCallDelta,
 	})
 	if ctx.Err() != nil || collected.Error != "" || strings.TrimSpace(collected.Text) == "" {
 		return "", messages, ""

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -213,12 +213,19 @@ type Options struct {
 	// Hooks, when set, runs configured beforeTool (blocking) and afterTool
 	// (advisory) commands around each tool call. nil disables hooks entirely; a
 	// dispatcher built from an empty config is also a safe no-op.
-	Hooks               *hooks.Dispatcher
-	EnabledTools        []string
-	DisabledTools       []string
-	OnText              func(string)
-	OnReasoning         func(string)
-	OnToolCall          func(ToolCall)
+	Hooks         *hooks.Dispatcher
+	EnabledTools  []string
+	DisabledTools []string
+	OnText        func(string)
+	OnReasoning   func(string)
+	OnToolCall    func(ToolCall)
+	// OnToolCallStart / OnToolCallDelta stream a tool call's arguments LIVE as the
+	// model generates them — OnToolCallStart on open (id, tool name), then
+	// OnToolCallDelta for each argument fragment. A surface can render the
+	// in-progress call (e.g. a file being written) instead of waiting for
+	// OnToolCall, which only fires once the whole call has accumulated. nil no-ops.
+	OnToolCallStart     func(id, name string)
+	OnToolCallDelta     func(id, fragment string)
 	OnPermissionRequest func(context.Context, PermissionRequest) (PermissionDecision, error)
 	OnPermission        func(PermissionEvent)
 	OnAskUser           func(context.Context, AskUserRequest) (AskUserResponse, error)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -258,9 +258,9 @@ var commandDefinitions = []commandDefinition{
 	},
 	{
 		name:        "/theme",
-		usage:       "/theme",
+		usage:       "/theme [auto|dark|light]",
 		group:       commandGroupSession,
-		description: "Show theme state.",
+		description: "Switch or show the color theme (auto-detects terminal background).",
 		kind:        commandTheme,
 	},
 	{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -207,9 +207,10 @@ type model struct {
 	// In-progress tool call whose arguments are streaming (a file being written),
 	// shown live by streamingToolCallView so a long write/edit isn't a frozen
 	// spinner. Cleared when the call completes (next text/turn) — see updateModel.
-	streamCallID   string
-	streamCallName string
-	streamCallArgs string
+	// streamCallDecoder decodes the streamed args incrementally (O(1) per delta).
+	streamCallID      string
+	streamCallName    string
+	streamCallDecoder *streamingDecoder
 
 	// Slash-command autocomplete (purely additive UI state). suggestions is the
 	// live match list for the current "/token"; suggestionIdx is the highlighted
@@ -1129,13 +1130,13 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// A new tool call opened — reset the live "writing" block to it.
 		m.streamCallID = msg.id
 		m.streamCallName = msg.name
-		m.streamCallArgs = ""
+		m.streamCallDecoder = newStreamingDecoder()
 		return m, nil
 	case toolCallStreamDeltaMsg:
-		if msg.runID != m.activeRunID || msg.id != m.streamCallID {
+		if msg.runID != m.activeRunID || msg.id != m.streamCallID || m.streamCallDecoder == nil {
 			return m, nil
 		}
-		m.streamCallArgs += msg.fragment
+		m.streamCallDecoder.feed(msg.fragment)
 		return m, nil
 	case agentTextMsg:
 		if msg.runID != m.activeRunID {
@@ -3624,7 +3625,7 @@ func (m model) sendToolCallStreamDelta(runID int, id, fragment string) {
 func (m *model) clearStreamingToolCall() {
 	m.streamCallID = ""
 	m.streamCallName = ""
-	m.streamCallArgs = ""
+	m.streamCallDecoder = nil
 }
 
 func (m model) sendAgentReasoning(runID int, delta string) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -93,6 +93,8 @@ type model struct {
 	selfCorrectTests      bool
 	reasoningEffort       modelregistry.ReasoningEffort
 	responseStyle         string
+	themeMode             themeMode // palette preference: auto (default), dark, light
+	hasDarkBg             bool      // last terminal background-detection result (auto mode)
 	userAgent             string
 	compactRequests       int
 	compactInFlight       bool
@@ -201,6 +203,13 @@ type model struct {
 	lineAges           []time.Time
 	lastStreamActivity time.Time
 	fadeActive         bool
+	fadeDisabled       bool // streaming fade off (ZERO_NO_FADE / SSH / tmux / low-color)
+	// In-progress tool call whose arguments are streaming (a file being written),
+	// shown live by streamingToolCallView so a long write/edit isn't a frozen
+	// spinner. Cleared when the call completes (next text/turn) — see updateModel.
+	streamCallID   string
+	streamCallName string
+	streamCallArgs string
 
 	// Slash-command autocomplete (purely additive UI state). suggestions is the
 	// live match list for the current "/token"; suggestionIdx is the highlighted
@@ -264,6 +273,21 @@ type model struct {
 type agentTextMsg struct {
 	runID int
 	delta string
+}
+
+// toolCallStreamStartMsg / toolCallStreamDeltaMsg carry a tool call's live
+// argument stream from the agent goroutine to the update loop, so a file being
+// written renders as it streams (see streamingToolCallView).
+type toolCallStreamStartMsg struct {
+	runID int
+	id    string
+	name  string
+}
+
+type toolCallStreamDeltaMsg struct {
+	runID    int
+	id       string
+	fragment string
 }
 
 type agentReasoningMsg struct {
@@ -524,6 +548,8 @@ func newModel(ctx context.Context, options Options) model {
 		permissionMode:         permissionMode,
 		reasoningEffort:        options.ReasoningEffort,
 		responseStyle:          defaultedResponseStyle(options.ResponseStyle),
+		themeMode:              resolveThemeMode(options.Theme, os.Getenv("ZERO_THEME")),
+		hasDarkBg:              true,
 		userAgent:              options.UserAgent,
 		usageTracker:           usageTracker,
 		transcript:             initialTranscript(),
@@ -539,6 +565,12 @@ func newModel(ctx context.Context, options Options) model {
 		setup:                  newSetupState(options.Setup),
 		setupSave:              options.Setup.Save,
 	}
+	// Apply an explicit theme immediately; auto stays on the dark default until
+	// Init's terminal background probe resolves it (see Init / BackgroundColorMsg).
+	if m.themeMode != themeAuto {
+		applyTheme(m.themeMode, true)
+	}
+	m.fadeDisabled = defaultFadeDisabled()
 	m.refreshMCPViewState()
 	return m
 }
@@ -591,6 +623,11 @@ func composerBlinkCmd() tea.Cmd {
 
 func (m model) Init() tea.Cmd {
 	cmds := []tea.Cmd{textinput.Blink, composerBlinkCmd()}
+	// In auto mode, ask the terminal for its background color; the reply arrives
+	// as tea.BackgroundColorMsg and selects light vs dark (see updateModel).
+	if m.themeMode == themeAuto {
+		cmds = append(cmds, tea.RequestBackgroundColor)
+	}
 	if m.prService != nil && m.runtimeMessageSink != nil {
 		service := m.prService
 		sink := m.runtimeMessageSink
@@ -671,6 +708,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case composerBlinkMsg:
 		m.composerCursorVisible = !m.composerCursorVisible
 		return m, composerBlinkCmd()
+	case tea.BackgroundColorMsg:
+		// Terminal background-color reply (from Init's RequestBackgroundColor). In
+		// auto mode it selects light vs dark; applyTheme repaints (clears the render
+		// cache). An explicit dark/light theme ignores it but still records the bg.
+		m.hasDarkBg = msg.IsDark()
+		if m.themeMode == themeAuto {
+			applyTheme(themeAuto, m.hasDarkBg)
+		}
+		return m, nil
 	case tea.MouseMsg:
 		if m.setup.visible {
 			return m.handleSetupMouse(msg)
@@ -1076,10 +1122,28 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notifier.SetFocused(false)
 		}
 		return m, nil
+	case toolCallStreamStartMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		// A new tool call opened — reset the live "writing" block to it.
+		m.streamCallID = msg.id
+		m.streamCallName = msg.name
+		m.streamCallArgs = ""
+		return m, nil
+	case toolCallStreamDeltaMsg:
+		if msg.runID != m.activeRunID || msg.id != m.streamCallID {
+			return m, nil
+		}
+		m.streamCallArgs += msg.fragment
+		return m, nil
 	case agentTextMsg:
 		if msg.runID != m.activeRunID {
 			return m, nil
 		}
+		// Streaming text means any in-progress tool call has finished — clear the
+		// live "writing" block so it doesn't linger over new prose.
+		m.clearStreamingToolCall()
 		m.streamingText += msg.delta
 		// recordStreamingDelta appends a time.Time to lineAges for every
 		// newline in the delta and bumps lastStreamActivity. It also
@@ -1090,10 +1154,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// case schedules the next one). Schedule the FIRST tick only on
 		// the inactive→active transition; subsequent deltas just refresh
 		// state and rely on the existing tick chain.
-		startTick := !m.fadeActive
-		m.fadeActive = true
-		if startTick {
-			return m, streamingFadeTick()
+		// When the fade is disabled (ZERO_NO_FADE / SSH / tmux / low-color),
+		// fadeActive stays false so styleStreamingLine renders streaming text
+		// statically at base ink, and no self-perpetuating tick is scheduled.
+		if !m.fadeDisabled {
+			startTick := !m.fadeActive
+			m.fadeActive = true
+			if startTick {
+				return m, streamingFadeTick()
+			}
 		}
 		return m, nil
 	case agentReasoningMsg:
@@ -1242,6 +1311,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
+		m.clearStreamingToolCall() // active run finished — drop any lingering "writing" block
 		m.pending = false
 		// Fully reset the fade state at stream end. The next render
 		// emits the final row in solid ink (no settling animation), and
@@ -1407,6 +1477,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowAssistant, text: text})
 			}
 			m.streamingText = ""
+			// The tool call has finalized into its card — drop the live "writing"
+			// preview so it doesn't linger or duplicate beneath the card.
+			m.clearStreamingToolCall()
 		}
 		m.transcript = appendTranscriptRow(m.transcript, msg.row)
 		return m, nil
@@ -1921,6 +1994,9 @@ func (m model) interimBlock(width int) string {
 		blocks = append(blocks, renderReasoningBlock(reasoning, m.streamingReasoningExpanded, width, true, 0))
 	}
 	if strings.TrimSpace(text) == "" {
+		if writing := m.streamingToolCallView(width); writing != "" {
+			blocks = append(blocks, writing)
+		}
 		blocks = append(blocks, m.workingStatusLine())
 		// During a long think the reasoning block is collapsed to just its header;
 		// show a live tail of the streaming reasoning beneath the working line so
@@ -1943,6 +2019,11 @@ func (m model) interimBlock(width int) string {
 	}
 	lines = appendStreamingCursor(lines, width)
 	blocks = append(blocks, strings.Join(lines, "\n"))
+	// Live preview of a file currently being written, so a long write_file/edit
+	// shows the code streaming in rather than looking frozen.
+	if writing := m.streamingToolCallView(width); writing != "" {
+		blocks = append(blocks, writing)
+	}
 	// Always show the live working line (spinner + verb + elapsed) BELOW the
 	// streamed text so an upstream stall keeps animating, never a frozen screen.
 	blocks = append(blocks, m.workingStatusLine())
@@ -2785,10 +2866,9 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandTheme:
-		m.transcript = reduceTranscript(m.transcript, transcriptAction{
-			kind: actionAppendSystem,
-			text: shellOnlyCommandText(command.name),
-		})
+		text := ""
+		m, text = m.handleThemeCommand(command.text)
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: text})
 		return m, nil
 	case commandInputStyle:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
@@ -2989,6 +3069,7 @@ func (m *model) cancelRun() {
 	if m.runCancel != nil {
 		m.runCancel()
 	}
+	m.clearStreamingToolCall() // a cancelled file-write must not linger into the next run
 	// Remember the in-flight run — and the session it was recording into — so
 	// its final agentResponseMsg is still drained for session-event persistence
 	// after activeRunID is cleared. Otherwise the checkpoint blobs it captured
@@ -3155,6 +3236,14 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				onText(delta)
 			}
 		}
+		// Stream a tool call's arguments live so a long write_file/edit shows the
+		// code being written instead of a frozen spinner (see streamingToolCallView).
+		options.OnToolCallStart = func(id, name string) {
+			m.sendToolCallStreamStart(runID, id, name)
+		}
+		options.OnToolCallDelta = func(id, fragment string) {
+			m.sendToolCallStreamDelta(runID, id, fragment)
+		}
 		onPermissionRequest := options.OnPermissionRequest
 		options.OnPermissionRequest = func(ctx context.Context, request agent.PermissionRequest) (agent.PermissionDecision, error) {
 			if onPermissionRequest != nil {
@@ -3261,8 +3350,12 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				arg:    argHintSecondary(call.Arguments),
 				runID:  runID,
 			}
-			rows = append(rows, row)
-			m.sendAgentRow(runID, row)
+			// A Task delegation is shown by the specialist card below, so skip its
+			// redundant "tool call: Task" transcript row — the card supersedes it.
+			if call.Name != "Task" {
+				rows = append(rows, row)
+				m.sendAgentRow(runID, row)
+			}
 			// Track specialist delegation: when the Task tool is called, register
 			// the specialist start so the specialist card + task table can show
 			// live status. The child session ID is not known yet (it's created
@@ -3340,8 +3433,12 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				detail: result.Output,
 				runID:  runID,
 			}
-			rows = append(rows, row)
-			m.sendAgentRow(runID, row)
+			// A Task result is shown by the specialist card (its completion state),
+			// so skip its redundant "tool result: Task" transcript row.
+			if result.Name != "Task" {
+				rows = append(rows, row)
+				m.sendAgentRow(runID, row)
+			}
 			// Sync the sticky plan panel when update_plan runs.
 			if result.Name == "update_plan" && m.registry != nil {
 				if planTool, ok := m.registry.Get("update_plan"); ok {
@@ -3504,6 +3601,30 @@ func (m model) sendAgentText(runID int, delta string) {
 		return
 	}
 	m.runtimeMessageSink(agentTextMsg{runID: runID, delta: delta})
+}
+
+func (m model) sendToolCallStreamStart(runID int, id, name string) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(toolCallStreamStartMsg{runID: runID, id: id, name: name})
+}
+
+func (m model) sendToolCallStreamDelta(runID int, id, fragment string) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(toolCallStreamDeltaMsg{runID: runID, id: id, fragment: fragment})
+}
+
+// clearStreamingToolCall drops the in-progress live "writing" block (id + name +
+// accumulated args). Called whenever the streamed tool call is no longer the
+// active live preview: it finalizes into a card, text resumes, the run ends, or
+// the run is cancelled. Releasing the args buffer also caps memory after a write.
+func (m *model) clearStreamingToolCall() {
+	m.streamCallID = ""
+	m.streamCallName = ""
+	m.streamCallArgs = ""
 }
 
 func (m model) sendAgentReasoning(runID int, delta string) {

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -49,7 +49,10 @@ type Options struct {
 	PermissionMode  agent.PermissionMode
 	ReasoningEffort modelregistry.ReasoningEffort
 	ResponseStyle   string
-	UserAgent       string
+	// Theme is the operator's palette preference: "auto" (default), "dark", or
+	// "light". From the --theme flag if wired; falls back to ZERO_THEME then auto.
+	Theme     string
+	UserAgent string
 
 	// Notify configures completion / awaiting-input notifications.
 	Notify config.NotifyConfig

--- a/internal/tui/plan_summary_test.go
+++ b/internal/tui/plan_summary_test.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlanSummaryCardBodyCollapses(t *testing.T) {
+	detail := "Current Plan:\n1. [completed] Explore workspace\n2. [in_progress] Create pages\n3. [pending] Build CSS\n4. [pending] Add JS\n5. [failed] Verify"
+	body := planSummaryCardBody(toolBodyRequest{name: "update_plan", detail: detail})
+	if len(body.lines) != 1 {
+		t.Fatalf("expected one summary line, got %d: %#v", len(body.lines), body.lines)
+	}
+	got := body.lines[0]
+	for _, want := range []string{"5 steps", "1 done", "1 in progress", "1 failed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q: %q", want, got)
+		}
+	}
+	if strings.Contains(got, "Explore") || strings.Contains(got, "Build CSS") {
+		t.Errorf("summary must not re-dump the full plan body: %q", got)
+	}
+}
+
+func TestPlanSummaryFallsBackOnNonPlan(t *testing.T) {
+	body := planSummaryCardBody(toolBodyRequest{name: "update_plan", detail: "unexpected error text"})
+	if len(body.lines) == 0 {
+		t.Error("non-plan detail should fall back to a generic body, not collapse to nothing")
+	}
+}

--- a/internal/tui/render_cache.go
+++ b/internal/tui/render_cache.go
@@ -50,6 +50,16 @@ func newStaticRenderCache(maxEntries int, maxCharacters int) *staticRenderCache 
 	}
 }
 
+// clear drops every cached render. Called when the active theme changes so stale
+// entries painted in the old palette are never reused.
+func (c *staticRenderCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = map[string]*list.Element{}
+	c.lru.Init()
+	c.retained = 0
+}
+
 func (c *staticRenderCache) render(key string, stable bool, render func() string) string {
 	if render == nil {
 		return ""

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -306,10 +306,20 @@ func sayMeasure(width int) int {
 	return measure
 }
 
-// assistantMeasure is the main answer wrap width. Assistant responses use the
-// available chat width so they visually balance full-width submitted prompts.
+// assistantMeasureCap bounds assistant PROSE to a readable line length on wide
+// terminals — long measures hurt readability past the ~90-100 col sweet spot.
+// Looser than sayMeasure's 74 (this is the main answer); tables and code blocks
+// still use the full chat width (the separate tableMeasure arg).
+const assistantMeasureCap = 96
+
+// assistantMeasure is the main answer prose wrap width: the chat width, capped at
+// assistantMeasureCap, with a 16-col floor. Left-aligned (the cap just shortens
+// lines; it does not center).
 func assistantMeasure(width int) int {
 	measure := width
+	if measure > assistantMeasureCap {
+		measure = assistantMeasureCap
+	}
 	if measure < 16 {
 		measure = 16
 	}
@@ -339,6 +349,18 @@ func wrapPlainText(text string, measure int) []string {
 			indent = strings.Repeat(" ", measure/2)
 		}
 		available := measure - len(indent)
+		// Preformatted: a body with an internal run of >=2 spaces is aligned
+		// content (columns, a table, indented code) where word-wrapping via
+		// strings.Fields would collapse the runs and destroy the alignment. Split it
+		// verbatim by display width instead, preserving every space. A line that
+		// already fits returns unchanged. Leading indent (handled above) and
+		// explicit newlines (the outer split) are unaffected.
+		if strings.Contains(body, "  ") {
+			for _, segment := range splitPreservingWidth(body, available) {
+				out = append(out, indent+segment)
+			}
+			continue
+		}
 		line := ""
 		for _, word := range strings.Fields(body) {
 			for lipgloss.Width(word) > available {
@@ -385,6 +407,28 @@ func splitAtWidth(text string, measure int) (string, string) {
 		used += glyphWidth
 	}
 	return text, ""
+}
+
+// splitPreservingWidth breaks text into segments that each fit the measure in
+// display width, preserving ALL characters (whitespace included) — the verbatim
+// counterpart to the word-wrapper, used for aligned/columnar lines so their
+// column spacing survives. A line that already fits returns a single segment.
+func splitPreservingWidth(text string, measure int) []string {
+	if measure < 1 {
+		measure = 1
+	}
+	var segments []string
+	for lipgloss.Width(text) > measure {
+		head, tail := splitAtWidth(text, measure)
+		if head == "" {
+			// splitAtWidth always advances by >=1 rune for measure>=1; the guard
+			// just keeps a degenerate input from spinning.
+			break
+		}
+		segments = append(segments, head)
+		text = tail
+	}
+	return append(segments, text)
 }
 
 func renderUserRow(row transcriptRow, width int) string {
@@ -1000,7 +1044,7 @@ func renderFocusedAskUserPrompt(prompt pendingAskUserPrompt, input string, width
 	}
 	// Echo the in-progress answer inside the card so the user sees what they
 	// are typing where they are answering, cursor included.
-	answer := zeroTheme.userPrompt.Background(lipgloss.Color(colorPanel)).Render("❯ ") +
+	answer := zeroTheme.onPanel(zeroTheme.userPrompt).Render("❯ ") +
 		fill(zeroTheme.ink).Render(input) + fill(zeroTheme.accent).Render("▌")
 	lines = append(lines, answer)
 	lines = append(lines, fill(zeroTheme.faint).Render("type an answer, Enter to submit · Esc to skip"))

--- a/internal/tui/resume_task_test.go
+++ b/internal/tui/resume_task_test.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/sessions"
+)
+
+func TestHydrationKeepsFailedTaskWithoutSpecialist(t *testing.T) {
+	ev := func(typ sessions.EventType, payload string) sessions.Event {
+		return sessions.Event{Type: typ, Payload: json.RawMessage(payload)}
+	}
+
+	// A Task that FAILED before a specialist started: tool call + error result, no
+	// EventSpecialistStart. Its rows must survive resume (M10) — otherwise the
+	// failed delegation silently vanishes.
+	failed := transcriptRowsFromSessionEvents([]sessions.Event{
+		ev(sessions.EventToolCall, `{"name":"Task","id":"call_fail","arguments":"{}"}`),
+		ev(sessions.EventToolResult, `{"name":"Task","toolCallId":"call_fail","status":"error","output":"spawn failed"}`),
+	})
+	if !transcriptContains(failed, "tool call: Task") || !transcriptContains(failed, "tool result: Task") {
+		t.Fatalf("a failed Task with no specialist must keep its rows on resume, got %#v", failed)
+	}
+
+	// A Task that DID start a specialist: the card renders it, so the raw Task
+	// tool-call/result rows are skipped (no duplication).
+	withSpecialist := transcriptRowsFromSessionEvents([]sessions.Event{
+		ev(sessions.EventToolCall, `{"name":"Task","id":"call_ok","arguments":"{}"}`),
+		ev(sessions.EventSpecialistStart, `{"childSessionId":"child-1","toolCallId":"call_ok","specialist":"explorer","status":"running"}`),
+		ev(sessions.EventToolResult, `{"name":"Task","toolCallId":"call_ok","status":"ok","output":"done"}`),
+	})
+	if transcriptContains(withSpecialist, "tool call: Task") || transcriptContains(withSpecialist, "tool result: Task") {
+		t.Fatalf("a Task with a specialist card must NOT also show raw Task rows, got %#v", withSpecialist)
+	}
+}

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -385,6 +385,11 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			if name == "" {
 				name = "unknown"
 			}
+			if name == "Task" {
+				// The specialist card (EventSpecialistStart) renders this delegation;
+				// skip the redundant "tool call: Task" row on resume too.
+				continue
+			}
 			id := payloadString(payload, "id")
 			callSeq[id]++
 			rows = append(rows, transcriptRow{
@@ -401,6 +406,11 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			name := payloadString(payload, "name")
 			if name == "" {
 				name = "unknown"
+			}
+			if name == "Task" {
+				// Mirrors the live path: the specialist card carries the Task result,
+				// so skip the redundant "tool result: Task" row on resume.
+				continue
 			}
 			status := tools.Status(payloadString(payload, "status"))
 			if status == "" {

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -351,6 +351,19 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 	// disambiguation the live runner applies — without it, dedup would drop
 	// every tool card after the first occurrence of an id.
 	callSeq := map[string]int{}
+	// Pre-pass: collect the tool-call ids of Task delegations that actually started
+	// a specialist (each renders as a card below). Only those Task tool-call/result
+	// rows are redundant and skipped; a Task that failed before a specialist started
+	// has no card, so its rows are kept — otherwise the failed delegation vanishes
+	// on resume (M10).
+	specialistToolCalls := map[string]bool{}
+	for _, event := range events {
+		if event.Type == sessions.EventSpecialistStart {
+			if id := payloadString(sessionPayload(event), "toolCallId"); id != "" {
+				specialistToolCalls[id] = true
+			}
+		}
+	}
 	for _, event := range events {
 		payload := sessionPayload(event)
 		switch event.Type {
@@ -385,12 +398,13 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			if name == "" {
 				name = "unknown"
 			}
-			if name == "Task" {
-				// The specialist card (EventSpecialistStart) renders this delegation;
-				// skip the redundant "tool call: Task" row on resume too.
+			id := payloadString(payload, "id")
+			if name == "Task" && specialistToolCalls[id] {
+				// A specialist card renders this delegation; skip the redundant
+				// "tool call: Task" row. A Task with no specialist (it failed before
+				// one started) keeps its row so the failure stays visible (M10).
 				continue
 			}
-			id := payloadString(payload, "id")
 			callSeq[id]++
 			rows = append(rows, transcriptRow{
 				kind:   rowToolCall,
@@ -407,9 +421,11 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 			if name == "" {
 				name = "unknown"
 			}
-			if name == "Task" {
-				// Mirrors the live path: the specialist card carries the Task result,
-				// so skip the redundant "tool result: Task" row on resume.
+			id := firstNonEmptyString(payloadString(payload, "toolCallId"), payloadString(payload, "id"))
+			if name == "Task" && specialistToolCalls[id] {
+				// The specialist card carries this Task's result; skip the redundant
+				// "tool result: Task" row. A Task with no specialist keeps its result
+				// row so a failed delegation's error stays visible (M10).
 				continue
 			}
 			status := tools.Status(payloadString(payload, "status"))
@@ -417,7 +433,6 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 				status = tools.StatusOK
 			}
 			output := payloadString(payload, "output")
-			id := firstNonEmptyString(payloadString(payload, "toolCallId"), payloadString(payload, "id"))
 			rows = append(rows, transcriptRow{
 				kind:   rowToolResult,
 				id:     effectiveToolRowID(id, callSeq[id]),

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -247,10 +247,18 @@ func TestPromptSubmitPersistsPermissionSessionEvents(t *testing.T) {
 		finalCh <- execCmd(cmd)
 	}()
 
-	for received := 0; received < 4; received++ {
+	for received := 0; received < 4; {
 		runtimeMsg := receiveRuntimeMessage(t, runtimeMessageCh)
 		updated, _ = next.Update(runtimeMsg)
 		next = updated.(model)
+		// Live tool-call streaming-preview messages (the file being written) are
+		// not one of the 4 semantic steps this test drives — process them so the
+		// model state advances, but don't count them toward the budget.
+		switch runtimeMsg.(type) {
+		case toolCallStreamStartMsg, toolCallStreamDeltaMsg:
+			continue
+		}
+		received++
 		if _, ok := runtimeMsg.(permissionRequestMsg); ok {
 			updated, _ = next.Update(testKeyText("d"))
 			next = updated.(model)

--- a/internal/tui/stage10_test.go
+++ b/internal/tui/stage10_test.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/colorprofile"
+)
+
+func TestAssistantMeasureCap(t *testing.T) {
+	if got := assistantMeasure(200); got != assistantMeasureCap {
+		t.Errorf("wide: assistantMeasure(200) = %d, want %d", got, assistantMeasureCap)
+	}
+	if got := assistantMeasure(80); got != 80 {
+		t.Errorf("under cap: assistantMeasure(80) = %d, want 80", got)
+	}
+	if got := assistantMeasure(5); got != 16 {
+		t.Errorf("floor: assistantMeasure(5) = %d, want 16", got)
+	}
+	if assistantMeasureCap < 80 || assistantMeasureCap > 100 {
+		t.Errorf("cap %d outside the 80-100 readability range", assistantMeasureCap)
+	}
+}
+
+func TestStreamingFadeDisabled(t *testing.T) {
+	env := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+	cases := []struct {
+		name    string
+		envMap  map[string]string
+		profile colorprofile.Profile
+		want    bool
+	}{
+		{"truecolor default", nil, colorprofile.TrueColor, false},
+		{"ansi256 ok", nil, colorprofile.ANSI256, false},
+		{"ZERO_NO_FADE=1", map[string]string{"ZERO_NO_FADE": "1"}, colorprofile.TrueColor, true},
+		{"ZERO_NO_FADE=0 stays on", map[string]string{"ZERO_NO_FADE": "0"}, colorprofile.TrueColor, false},
+		{"ZERO_NO_FADE=false stays on", map[string]string{"ZERO_NO_FADE": "false"}, colorprofile.TrueColor, false},
+		{"ssh", map[string]string{"SSH_CONNECTION": "10.0.0.1 22 ..."}, colorprofile.TrueColor, true},
+		{"ssh tty", map[string]string{"SSH_TTY": "/dev/pts/3"}, colorprofile.TrueColor, true},
+		{"tmux TERM", map[string]string{"TERM": "tmux-256color"}, colorprofile.TrueColor, true},
+		{"screen TERM", map[string]string{"TERM": "screen.xterm"}, colorprofile.TrueColor, true},
+		{"16-color", nil, colorprofile.ANSI, true},
+		{"ascii", nil, colorprofile.ASCII, true},
+		{"no tty", nil, colorprofile.NoTTY, true},
+	}
+	for _, c := range cases {
+		if got := streamingFadeDisabled(env(c.envMap), c.profile); got != c.want {
+			t.Errorf("%s: streamingFadeDisabled = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/tui/streaming_decoder.go
+++ b/internal/tui/streaming_decoder.go
@@ -1,0 +1,175 @@
+package tui
+
+import "strings"
+
+// streamingDecoder incrementally decodes a tool call's streaming JSON arguments
+// for the live "writing" preview. Each delta is processed exactly once, so the
+// preview costs O(fragment) per delta instead of re-scanning the whole growing
+// args buffer on every render (the previous O(n²) behavior — M14/L6/L7).
+//
+// It buffers raw args until the content value starts (extracting the file path
+// from the head), then decodes the content's JSON-string escapes as fragments
+// arrive, keeping only a bounded tail of lines plus a running line count.
+type streamingDecoder struct {
+	pathKeys    []string
+	contentKeys []string
+	tailCap     int
+
+	rawLen   int    // total raw arg bytes seen (for the "receiving N KB" indicator)
+	head     []byte // raw args before the content value; dropped once content starts
+	path     string
+	pathDone bool
+
+	inContent bool
+	closed    bool // the content value's closing quote was seen
+
+	tail       []string // last tailCap completed content lines
+	cur        []byte   // the in-progress (incomplete) last line
+	lineCount  int      // completed content lines (decoded newlines)
+	pendingEsc bool     // the previous byte was a lone backslash
+	uSkip      int      // remaining hex digits to skip after a \uXXXX escape
+}
+
+func newStreamingDecoder() *streamingDecoder {
+	return &streamingDecoder{
+		pathKeys:    []string{"path", "file_path", "filename"},
+		contentKeys: []string{"content", "new_string", "new_str", "new_text", "new", "replacement", "patch", "input"},
+		tailCap:     streamingTailLines,
+	}
+}
+
+// feed consumes one streamed argument fragment.
+func (d *streamingDecoder) feed(fragment string) {
+	d.rawLen += len(fragment)
+	if d.closed {
+		return
+	}
+	if d.inContent {
+		d.consume(fragment)
+		return
+	}
+	d.head = append(d.head, fragment...)
+	if !d.pathDone {
+		// Best effort: the path completes quickly (it precedes the content), and a
+		// partial value just updates until it's whole.
+		d.path = streamingFilePath(string(d.head))
+	}
+	start := d.contentValueStart()
+	if start < 0 {
+		return // content value hasn't begun yet
+	}
+	d.pathDone = true
+	d.inContent = true
+	rest := string(d.head[start:])
+	d.head = nil
+	d.consume(rest)
+}
+
+// contentValueStart returns the index in head just past the opening quote of the
+// first content value, or -1 if no content value has started yet.
+func (d *streamingDecoder) contentValueStart() int {
+	s := string(d.head)
+	best := -1
+	for _, key := range d.contentKeys {
+		if idx := jsonStringValueStart(s, key); idx >= 0 && (best < 0 || idx < best) {
+			best = idx
+		}
+	}
+	return best
+}
+
+// consume decodes content bytes, splitting on decoded newlines into tail lines and
+// stopping at the value's closing quote.
+func (d *streamingDecoder) consume(b string) {
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		if d.uSkip > 0 {
+			d.uSkip-- // skip the 4 hex digits of a \uXXXX escape (not decoded for a preview)
+			continue
+		}
+		if d.pendingEsc {
+			d.pendingEsc = false
+			switch c {
+			case 'n':
+				d.newline()
+			case 't':
+				d.cur = append(d.cur, '\t')
+			case 'r':
+				// drop carriage returns from the preview
+			case 'u':
+				d.uSkip = 4
+			default: // " \ / and anything else: take the literal char
+				d.cur = append(d.cur, c)
+			}
+			continue
+		}
+		switch c {
+		case '\\':
+			d.pendingEsc = true
+		case '"':
+			d.closed = true // closing quote of the content value
+			return
+		default:
+			d.cur = append(d.cur, c)
+		}
+	}
+}
+
+func (d *streamingDecoder) newline() {
+	d.tail = append(d.tail, string(d.cur))
+	if len(d.tail) > d.tailCap {
+		d.tail = d.tail[len(d.tail)-d.tailCap:]
+	}
+	d.cur = d.cur[:0]
+	d.lineCount++
+}
+
+// hasContent reports whether the content value has begun streaming.
+func (d *streamingDecoder) hasContent() bool { return d.inContent }
+
+// lineTotal is the line count shown in the header (completed lines plus the
+// in-progress one).
+func (d *streamingDecoder) lineTotal() int {
+	if !d.inContent {
+		return 0
+	}
+	n := d.lineCount
+	if len(d.cur) > 0 || !d.closed {
+		n++ // the current (possibly empty, still-open) line
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// tailLines returns the last tailCap content lines, including the in-progress one.
+func (d *streamingDecoder) tailLines() []string {
+	out := append([]string(nil), d.tail...)
+	if len(d.cur) > 0 {
+		out = append(out, string(d.cur))
+	}
+	if len(out) > d.tailCap {
+		out = out[len(out)-d.tailCap:]
+	}
+	return out
+}
+
+// jsonStringValueStart finds `"key"` then, tolerating whitespace around the colon,
+// returns the index just past the opening quote of its string value, or -1.
+func jsonStringValueStart(s, key string) int {
+	marker := `"` + key + `"`
+	idx := strings.Index(s, marker)
+	if idx < 0 {
+		return -1
+	}
+	i := skipJSONSpace(s, idx+len(marker))
+	if i >= len(s) || s[i] != ':' {
+		return -1
+	}
+	i = skipJSONSpace(s, i+1)
+	if i >= len(s) || s[i] != '"' {
+		return -1
+	}
+	return i + 1
+}

--- a/internal/tui/streaming_decoder_test.go
+++ b/internal/tui/streaming_decoder_test.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func feedChunks(d *streamingDecoder, chunks ...string) {
+	for _, c := range chunks {
+		d.feed(c)
+	}
+}
+
+func TestStreamingDecoderPathTailAndCount(t *testing.T) {
+	d := newStreamingDecoder()
+	// kimi-style spacing; content fed in awkward chunks.
+	feedChunks(d, `{"path": "a/b.go",`, ` "content": "package main\n`, `\nfunc main() {`, `\n\t}`, `"}`)
+	if d.path != "a/b.go" {
+		t.Errorf("path = %q, want a/b.go", d.path)
+	}
+	if !d.hasContent() {
+		t.Fatal("expected content")
+	}
+	want := []string{"package main", "", "func main() {", "\t}"}
+	if got := d.tailLines(); !reflect.DeepEqual(got, want) {
+		t.Errorf("tail = %#v, want %#v", got, want)
+	}
+	if got := d.lineTotal(); got != 4 {
+		t.Errorf("lineTotal = %d, want 4", got)
+	}
+}
+
+func TestStreamingDecoderSplitEscape(t *testing.T) {
+	d := newStreamingDecoder()
+	// The \n and \t escapes are split across feed boundaries (backslash, then n/t).
+	feedChunks(d, `{"path":"x","content":"line1\`, `nline2\`, `tend"}`)
+	want := []string{"line1", "line2\tend"}
+	if got := d.tailLines(); !reflect.DeepEqual(got, want) {
+		t.Errorf("split-escape tail = %#v, want %#v", got, want)
+	}
+}
+
+func TestStreamingDecoderEditFileNewString(t *testing.T) {
+	// edit_file's canonical content key is new_string (M13 preserved in the decoder).
+	d := newStreamingDecoder()
+	d.feed(`{"path":"a.go","old_string":"x","new_string":"replaced\nbody"}`)
+	if !d.hasContent() {
+		t.Fatal("expected content from new_string")
+	}
+	if got := d.tailLines(); !reflect.DeepEqual(got, []string{"replaced", "body"}) {
+		t.Errorf("new_string tail = %#v", got)
+	}
+}
+
+func TestStreamingDecoderProgressBeforeContent(t *testing.T) {
+	d := newStreamingDecoder()
+	d.feed(`{"path":"website/css/styles.css"`)
+	if d.hasContent() {
+		t.Error("content not started yet")
+	}
+	if d.rawLen == 0 {
+		t.Error("rawLen should track bytes for the KB indicator")
+	}
+	if d.path != "website/css/styles.css" {
+		t.Errorf("path should extract before content: %q", d.path)
+	}
+}
+
+func TestStreamingDecoderTailIsBounded(t *testing.T) {
+	d := newStreamingDecoder()
+	var b strings.Builder
+	b.WriteString(`{"path":"x","content":"`)
+	for i := 0; i < 100; i++ {
+		b.WriteString("line\\n") // 100 escaped newlines
+	}
+	b.WriteString(`"}`)
+	d.feed(b.String())
+	if got := len(d.tailLines()); got > streamingTailLines {
+		t.Errorf("tail not bounded: %d > %d", got, streamingTailLines)
+	}
+	if d.lineTotal() < 100 {
+		t.Errorf("lineTotal should count all lines: %d", d.lineTotal())
+	}
+}
+
+func TestStreamingDecoderChunkingIsConsistent(t *testing.T) {
+	full := `{"path":"a.go","content":"alpha\nbeta\ngamma\ndelta"}`
+	whole := newStreamingDecoder()
+	whole.feed(full)
+	byByte := newStreamingDecoder()
+	for _, r := range full {
+		byByte.feed(string(r))
+	}
+	if !reflect.DeepEqual(whole.tailLines(), byByte.tailLines()) || whole.lineTotal() != byByte.lineTotal() {
+		t.Errorf("byte-by-byte (%#v) != whole (%#v)", byByte.tailLines(), whole.tailLines())
+	}
+}

--- a/internal/tui/streaming_fade.go
+++ b/internal/tui/streaming_fade.go
@@ -2,11 +2,46 @@ package tui
 
 import (
 	"image/color"
+	"os"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/colorprofile"
 )
+
+// defaultFadeDisabled resolves streamingFadeDisabled from the live process
+// environment and the env-detected color profile, at model construction.
+func defaultFadeDisabled() bool {
+	return streamingFadeDisabled(os.Getenv, colorprofile.Env(os.Environ()))
+}
+
+// streamingFadeDisabled reports whether the streaming-text fade should be OFF.
+// The fade re-renders every ~150ms while text streams; that stutters over remote
+// links and terminal multiplexers, and the age→color ramp reads poorly with few
+// colors. Disabled when: ZERO_NO_FADE is set, the session is over SSH
+// (SSH_CONNECTION), TERM is a screen/tmux multiplexer, or the color profile is
+// no-TTY / ASCII / 16-color. When disabled, streaming text renders statically at
+// the base ink color (styleStreamingLine's pre-fade path), which always sits at
+// full readable contrast against the active theme.
+func streamingFadeDisabled(env func(string) string, profile colorprofile.Profile) bool {
+	if v := strings.TrimSpace(env("ZERO_NO_FADE")); v != "" && v != "0" && !strings.EqualFold(v, "false") {
+		return true
+	}
+	if strings.TrimSpace(env("SSH_CONNECTION")) != "" || strings.TrimSpace(env("SSH_TTY")) != "" {
+		return true
+	}
+	term := strings.ToLower(strings.TrimSpace(env("TERM")))
+	if strings.HasPrefix(term, "screen") || strings.HasPrefix(term, "tmux") {
+		return true
+	}
+	switch profile {
+	case colorprofile.NoTTY, colorprofile.ASCII, colorprofile.ANSI:
+		return true
+	}
+	return false
+}
 
 // Streaming-text age-based fade.
 //
@@ -56,13 +91,20 @@ type streamingFadeTickMsg time.Time
 // struct-field access and a single Render call, not a hex parse.
 var streamingFadePalette [streamingFadeSteps]lipgloss.Style
 
-// init builds the palette once at package load. Cheap; called before any
-// model is constructed.
+// init builds the palette once at package load (after zeroTheme's var init), so
+// the fade tracks the active theme's accent→ink. Cheap; before any model exists.
 func init() {
+	rebuildStreamingFadePalette()
+}
+
+// rebuildStreamingFadePalette regenerates the fade ramp from the active theme.
+// Called at init and again by applyTheme when /theme or startup detection swaps
+// the palette, so the streaming fade matches dark vs light.
+func rebuildStreamingFadePalette() {
 	streamingFadePalette = buildStreamingFadePalette(
 		streamingFadeSteps,
-		lipgloss.Color(colorAccent),
-		lipgloss.Color(colorInk),
+		zeroTheme.accentColor,
+		zeroTheme.inkColor,
 	)
 }
 

--- a/internal/tui/streaming_fade_test.go
+++ b/internal/tui/streaming_fade_test.go
@@ -27,7 +27,7 @@ func rgbaOf(t *testing.T, s lipgloss.Style) color.RGBA {
 func TestStreamingFadePaletteMonotonic(t *testing.T) {
 	// Build a fresh palette against the package's theme tokens so this
 	// test is independent of any test-time mutation of the global.
-	palette := buildStreamingFadePalette(streamingFadeSteps, lipgloss.Color(colorAccent), lipgloss.Color(colorInk))
+	palette := buildStreamingFadePalette(streamingFadeSteps, lipgloss.Color(darkPalette.accent), lipgloss.Color(darkPalette.ink))
 	// We convert the Blend1D output to color.RGBA inside the builder
 	// so per-bucket comparisons are byte-stable. The endpoint byte
 	// values are the contract — the hex strings are not.
@@ -70,7 +70,7 @@ func TestStreamingFadePaletteIntermediates(t *testing.T) {
 	// don't pin the exact channel path (Blend1D uses CIELAB, which is
 	// not a straight per-channel interpolation), but we do confirm the
 	// ramp makes monotonic progress.
-	palette := buildStreamingFadePalette(streamingFadeSteps, lipgloss.Color(colorAccent), lipgloss.Color(colorInk))
+	palette := buildStreamingFadePalette(streamingFadeSteps, lipgloss.Color(darkPalette.accent), lipgloss.Color(darkPalette.ink))
 	prev := rgbaOf(t, palette[0])
 	for i := 1; i < streamingFadeSteps; i++ {
 		cur := rgbaOf(t, palette[i])
@@ -88,7 +88,7 @@ func TestStreamingFadePaletteIntermediates(t *testing.T) {
 }
 
 func TestStreamingFadePaletteLength(t *testing.T) {
-	palette := buildStreamingFadePalette(streamingFadeSteps, lipgloss.Color(colorAccent), lipgloss.Color(colorInk))
+	palette := buildStreamingFadePalette(streamingFadeSteps, lipgloss.Color(darkPalette.accent), lipgloss.Color(darkPalette.ink))
 	if len(palette) != streamingFadeSteps {
 		t.Fatalf("palette length = %d, want %d", len(palette), streamingFadeSteps)
 	}
@@ -134,7 +134,7 @@ func TestAgeDimLineFreshReturnsAccent(t *testing.T) {
 	// foreground of the styled output via the palette's known color,
 	// since lipgloss strips ANSI in non-tty tests.
 	now := time.Unix(0, 0)
-	base := lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk))
+	base := lipgloss.NewStyle().Foreground(lipgloss.Color(darkPalette.ink))
 	out := ageDimLine("hello", now, now, base)
 	if !strings.Contains(out, "hello") {
 		t.Errorf("fresh ageDimLine output %q does not contain the input", out)
@@ -155,7 +155,7 @@ func TestAgeDimLineMidRangeReturnsIntermediate(t *testing.T) {
 	// zeroTheme.ink). The output must be non-empty and contain the
 	// input.
 	now := time.Unix(0, 0)
-	base := lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk))
+	base := lipgloss.NewStyle().Foreground(lipgloss.Color(darkPalette.ink))
 	bornAt := now.Add(-600 * time.Millisecond)
 	out := ageDimLine("hello", bornAt, now, base)
 	if !strings.Contains(out, "hello") {
@@ -165,7 +165,7 @@ func TestAgeDimLineMidRangeReturnsIntermediate(t *testing.T) {
 
 func TestAgeDimLineSettledReturnsBase(t *testing.T) {
 	// At age >= dimDuration the base style is used directly.
-	base := lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk))
+	base := lipgloss.NewStyle().Foreground(lipgloss.Color(darkPalette.ink))
 	now := time.Unix(0, 0)
 	bornAt := now.Add(-streamingFadeDuration - time.Millisecond)
 	out := ageDimLine("hello", bornAt, now, base)
@@ -180,7 +180,7 @@ func TestAgeDimLineZeroBornAtReturnsBase(t *testing.T) {
 	// without populating m.lineAges, so bornAt is the zero time. The
 	// renderer must fall back to the base color (not panic, not produce
 	// neon text).
-	base := lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk))
+	base := lipgloss.NewStyle().Foreground(lipgloss.Color(darkPalette.ink))
 	now := time.Unix(0, 0)
 	out := ageDimLine("hello", time.Time{}, now, base)
 	want := base.Render("hello")
@@ -195,7 +195,7 @@ func TestAgeDimLineBuckets(t *testing.T) {
 	// bucket covers 100ms. We don't assert on the rendered colors
 	// (lipgloss's per-color bytes are an implementation detail); we
 	// just check the bucket math and that nothing panics.
-	base := lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk))
+	base := lipgloss.NewStyle().Foreground(lipgloss.Color(darkPalette.ink))
 	now := time.Unix(0, 0)
 	bornAt := now
 	lastBucket := -1

--- a/internal/tui/streaming_tool_call.go
+++ b/internal/tui/streaming_tool_call.go
@@ -1,0 +1,181 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// streamingTailLines is how many trailing lines of a file's in-progress content
+// the live "writing" block shows — enough to watch the code flow without taking
+// over the screen.
+const streamingTailLines = 6
+
+// isFileWritingTool reports whether a tool's streamed arguments are worth showing
+// as live code (a file being written or edited).
+func isFileWritingTool(name string) bool {
+	switch name {
+	case "write_file", "edit_file", "apply_patch":
+		return true
+	}
+	return false
+}
+
+// decodeStreamingJSONString extracts the (possibly unterminated) value of a
+// top-level string field from a streaming JSON args buffer — used to pull the
+// path and the file content out of a tool call as its arguments arrive. Best
+// effort: it unescapes \n \t \" \\ \/ for a readable preview, skips \uXXXX, and
+// stops at the closing quote or the stream edge (a dangling backslash is dropped).
+func decodeStreamingJSONString(args, key string) (string, bool) {
+	// Find `"key"`, then tolerate optional whitespace around the colon and before
+	// the opening quote, so both `"key":"v"` and `"key": "v"` (model JSON formatting
+	// varies — kimi spaces after the colon) parse.
+	keyMarker := `"` + key + `"`
+	idx := strings.Index(args, keyMarker)
+	if idx < 0 {
+		return "", false
+	}
+	i := skipJSONSpace(args, idx+len(keyMarker))
+	if i >= len(args) || args[i] != ':' {
+		return "", false
+	}
+	i = skipJSONSpace(args, i+1)
+	if i >= len(args) || args[i] != '"' {
+		return "", false // value isn't a string yet (or hasn't streamed in)
+	}
+	rest := args[i+1:]
+	var b strings.Builder
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		if c == '\\' {
+			if i+1 >= len(rest) {
+				break // incomplete escape at the stream edge
+			}
+			i++
+			switch rest[i] {
+			case 'n':
+				b.WriteByte('\n')
+			case 't':
+				b.WriteByte('\t')
+			case 'r':
+				// drop carriage returns from the preview
+			case '"':
+				b.WriteByte('"')
+			case '\\':
+				b.WriteByte('\\')
+			case '/':
+				b.WriteByte('/')
+			case 'u':
+				if i+4 < len(rest) {
+					i += 4 // skip the 4 hex digits; the exact rune doesn't matter for a preview
+				} else {
+					i = len(rest)
+				}
+			default:
+				b.WriteByte(rest[i])
+			}
+			continue
+		}
+		if c == '"' {
+			break // closing quote
+		}
+		b.WriteByte(c)
+	}
+	return b.String(), true
+}
+
+// skipJSONSpace advances past JSON insignificant whitespace.
+func skipJSONSpace(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i++
+	}
+	return i
+}
+
+// streamingFilePath / streamingFileContent pull the path and the main content out
+// of a streaming tool-call args buffer, trying the argument names the file tools
+// use.
+func streamingFilePath(args string) string {
+	for _, key := range []string{"path", "file_path", "filename"} {
+		if v, ok := decodeStreamingJSONString(args, key); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func streamingFileContent(args string) (string, bool) {
+	for _, key := range []string{"content", "new_string", "new_str", "new_text", "new", "replacement", "patch", "input"} {
+		if v, ok := decodeStreamingJSONString(args, key); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// streamingToolCallView renders the in-progress file-writing tool call — its path,
+// a live line count, and a tail of the streaming content — so a long write/edit
+// shows the code flowing in instead of a frozen spinner. Returns "" when no
+// file-writing call is mid-stream.
+func (m model) streamingToolCallView(width int) string {
+	if m.streamCallID == "" || !isFileWritingTool(m.streamCallName) {
+		return ""
+	}
+	path := streamingFilePath(m.streamCallArgs)
+	content, hasContent := streamingFileContent(m.streamCallArgs)
+
+	head := zeroTheme.accent.Render("✎ ") + zeroTheme.toolName.Render(m.streamCallName)
+	if path != "" {
+		head += " " + zeroTheme.toolTarget.Render(path)
+	}
+	switch {
+	case hasContent && strings.TrimSpace(content) != "":
+		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  %d lines", strings.Count(content, "\n")+1))
+	case len(m.streamCallArgs) > 0:
+		// Args are streaming but the content field hasn't arrived yet — show a live
+		// byte count so it reads as progressing, never frozen.
+		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  receiving %.1f KB", float64(len(m.streamCallArgs))/1024))
+	}
+	lines := []string{head}
+	if hasContent && strings.TrimSpace(content) != "" {
+		body := strings.Split(strings.TrimRight(content, "\n"), "\n")
+		if len(body) > streamingTailLines {
+			body = body[len(body)-streamingTailLines:]
+		}
+		bodyWidth := maxInt(8, width-4)
+		// write_file/edit_file content is brand-new, so every line is an addition;
+		// apply_patch carries a real ± diff. styleStreamingCodeLine colors added
+		// lines green, removed red, and everything else bright (not the old dim gray).
+		newContent := m.streamCallName == "write_file" || m.streamCallName == "edit_file"
+		for _, line := range body {
+			line = strings.ReplaceAll(line, "\t", "    ")
+			// Truncate by display WIDTH (ansi.Truncate), not rune count, so wide/CJK
+			// glyphs can't overrun bodyWidth and break the tail layout.
+			lines = append(lines, "  "+styleStreamingCodeLine(ansi.Truncate(line, bodyWidth, ""), newContent))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// styleStreamingCodeLine colors one line of the live code preview: explicit diff
+// additions (+) render green and removals (-) red; for a brand-new write_file/edit
+// every line is an addition (green); anything else renders in bright ink. This
+// replaces the old dim faintest gray the streamed code was nearly invisible in.
+func styleStreamingCodeLine(line string, newContent bool) string {
+	// A brand-new write_file/edit_file is NOT a diff: every line is added content,
+	// so color it all green and never treat a leading "-" (e.g. CSS "-webkit-…") as
+	// a removal. Only apply_patch (newContent=false) carries real ± diff markers.
+	if newContent {
+		return zeroTheme.green.Render(line)
+	}
+	trimmed := strings.TrimLeft(line, " ")
+	switch {
+	case strings.HasPrefix(trimmed, "+") && !strings.HasPrefix(trimmed, "+++"):
+		return zeroTheme.green.Render(line)
+	case strings.HasPrefix(trimmed, "-") && !strings.HasPrefix(trimmed, "---"):
+		return zeroTheme.red.Render(line)
+	default:
+		return zeroTheme.ink.Render(line)
+	}
+}

--- a/internal/tui/streaming_tool_call.go
+++ b/internal/tui/streaming_tool_call.go
@@ -93,9 +93,8 @@ func skipJSONSpace(s string, i int) int {
 	return i
 }
 
-// streamingFilePath / streamingFileContent pull the path and the main content out
-// of a streaming tool-call args buffer, trying the argument names the file tools
-// use.
+// streamingFilePath pulls the file path out of a streaming tool-call args buffer,
+// trying the argument names the file tools use. Used to seed the decoder's path.
 func streamingFilePath(args string) string {
 	for _, key := range []string{"path", "file_path", "filename"} {
 		if v, ok := decodeStreamingJSONString(args, key); ok && v != "" {
@@ -105,50 +104,37 @@ func streamingFilePath(args string) string {
 	return ""
 }
 
-func streamingFileContent(args string) (string, bool) {
-	for _, key := range []string{"content", "new_string", "new_str", "new_text", "new", "replacement", "patch", "input"} {
-		if v, ok := decodeStreamingJSONString(args, key); ok {
-			return v, true
-		}
-	}
-	return "", false
-}
-
 // streamingToolCallView renders the in-progress file-writing tool call — its path,
 // a live line count, and a tail of the streaming content — so a long write/edit
-// shows the code flowing in instead of a frozen spinner. Returns "" when no
+// shows the code flowing in instead of a frozen spinner. It reads the decoder's
+// incrementally-maintained state (O(1) per render); returns "" when no
 // file-writing call is mid-stream.
 func (m model) streamingToolCallView(width int) string {
-	if m.streamCallID == "" || !isFileWritingTool(m.streamCallName) {
+	if m.streamCallID == "" || !isFileWritingTool(m.streamCallName) || m.streamCallDecoder == nil {
 		return ""
 	}
-	path := streamingFilePath(m.streamCallArgs)
-	content, hasContent := streamingFileContent(m.streamCallArgs)
+	d := m.streamCallDecoder
 
 	head := zeroTheme.accent.Render("✎ ") + zeroTheme.toolName.Render(m.streamCallName)
-	if path != "" {
-		head += " " + zeroTheme.toolTarget.Render(path)
+	if d.path != "" {
+		head += " " + zeroTheme.toolTarget.Render(d.path)
 	}
 	switch {
-	case hasContent && strings.TrimSpace(content) != "":
-		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  %d lines", strings.Count(content, "\n")+1))
-	case len(m.streamCallArgs) > 0:
+	case d.hasContent():
+		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  %d lines", d.lineTotal()))
+	case d.rawLen > 0:
 		// Args are streaming but the content field hasn't arrived yet — show a live
 		// byte count so it reads as progressing, never frozen.
-		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  receiving %.1f KB", float64(len(m.streamCallArgs))/1024))
+		head += zeroTheme.faint.Render(fmt.Sprintf("  ·  receiving %.1f KB", float64(d.rawLen)/1024))
 	}
 	lines := []string{head}
-	if hasContent && strings.TrimSpace(content) != "" {
-		body := strings.Split(strings.TrimRight(content, "\n"), "\n")
-		if len(body) > streamingTailLines {
-			body = body[len(body)-streamingTailLines:]
-		}
+	if d.hasContent() {
 		bodyWidth := maxInt(8, width-4)
 		// write_file/edit_file content is brand-new, so every line is an addition;
 		// apply_patch carries a real ± diff. styleStreamingCodeLine colors added
 		// lines green, removed red, and everything else bright (not the old dim gray).
 		newContent := m.streamCallName == "write_file" || m.streamCallName == "edit_file"
-		for _, line := range body {
+		for _, line := range d.tailLines() {
 			line = strings.ReplaceAll(line, "\t", "    ")
 			// Truncate by display WIDTH (ansi.Truncate), not rune count, so wide/CJK
 			// glyphs can't overrun bodyWidth and break the tail layout.

--- a/internal/tui/streaming_tool_call_test.go
+++ b/internal/tui/streaming_tool_call_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeStreamingJSONString(t *testing.T) {
+	// Complete path + unterminated streaming content with escapes.
+	args := `{"path":"ecommerce/frontend/index.html","content":"<!DOCTYPE html>\n<html>\n  <body class=\"x\">`
+	if got := streamingFilePath(args); got != "ecommerce/frontend/index.html" {
+		t.Errorf("path = %q", got)
+	}
+	content, ok := streamingFileContent(args)
+	if !ok {
+		t.Fatal("expected content")
+	}
+	want := "<!DOCTYPE html>\n<html>\n  <body class=\"x\">"
+	if content != want {
+		t.Errorf("content = %q, want %q", content, want)
+	}
+	// A dangling backslash at the stream edge is dropped, not panicked on.
+	if c, _ := streamingFileContent(`{"content":"abc\`); c != "abc" {
+		t.Errorf("dangling escape: %q", c)
+	}
+	// Missing key.
+	if _, ok := streamingFileContent(`{"path":"x"}`); ok {
+		t.Error("no content key should be (false)")
+	}
+}
+
+func TestStreamingToolCallView(t *testing.T) {
+	// No active call → empty.
+	if (model{}).streamingToolCallView(80) != "" {
+		t.Error("inactive should render nothing")
+	}
+	// Non-file tool → empty.
+	if (model{streamCallID: "1", streamCallName: "bash", streamCallArgs: `{"command":"ls"}`}).streamingToolCallView(80) != "" {
+		t.Error("non-file tool should render nothing")
+	}
+	// Active write_file → shows path, line count, and a content tail.
+	m := model{
+		streamCallID:   "1",
+		streamCallName: "write_file",
+		streamCallArgs: `{"path":"a/b.go","content":"package main\n\nfunc main() {}\n"}`,
+	}
+	out := m.streamingToolCallView(80)
+	for _, want := range []string{"write_file", "a/b.go", "lines", "func main()"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDecodeStreamingTolerantOfWhitespace(t *testing.T) {
+	// kimi-style spacing after the colon (and around it) must parse like compact JSON.
+	for _, args := range []string{
+		`{"path":"a.go","content":"line1\nline2"}`,
+		`{"path": "a.go", "content": "line1\nline2"}`,
+		`{ "path" : "a.go" , "content" : "line1\nline2" }`,
+		`{"path":"a.go",` + "\n" + `  "content": "line1\nline2"}`,
+	} {
+		if got := streamingFilePath(args); got != "a.go" {
+			t.Errorf("path from %q = %q, want a.go", args, got)
+		}
+		c, ok := streamingFileContent(args)
+		if !ok || c != "line1\nline2" {
+			t.Errorf("content from %q = %q ok=%v", args, c, ok)
+		}
+	}
+}
+
+func TestStreamingViewShowsProgressBeforeContent(t *testing.T) {
+	// Args streaming but content not reached yet → show a byte count, not blank.
+	m := model{streamCallID: "1", streamCallName: "write_file", streamCallArgs: `{"path": "website/css/styles.css", "content": "/* lo`}
+	out := m.streamingToolCallView(80)
+	if !strings.Contains(out, "website/css/styles.css") {
+		t.Errorf("path should show with kimi-style spacing: %q", out)
+	}
+}
+
+func TestStreamingFileContentEditFileKey(t *testing.T) {
+	// edit_file's canonical replacement arg is new_string — the live preview must
+	// extract it (regression for M13: edit preview showed nothing).
+	args := `{"path":"a.go","old_string":"x","new_string":"package main\nfunc main(){}"}`
+	c, ok := streamingFileContent(args)
+	if !ok || c != "package main\nfunc main(){}" {
+		t.Errorf("new_string content = %q ok=%v", c, ok)
+	}
+	if p := streamingFilePath(args); p != "a.go" {
+		t.Errorf("path = %q", p)
+	}
+}
+
+func TestStyleStreamingNewContentNeverRed(t *testing.T) {
+	// L8: a brand-new file line beginning with "-" (e.g. CSS "-webkit-…") must NOT
+	// be colored as a diff removal. With newContent=true it renders green; the
+	// red/green diff branches apply only to apply_patch (newContent=false).
+	green := zeroTheme.green.Render("-webkit-box-shadow: none;")
+	got := styleStreamingCodeLine("-webkit-box-shadow: none;", true)
+	if got != green {
+		t.Errorf("new-file '-' line should render green, got %q want %q", got, green)
+	}
+	// And for a real patch (newContent=false) a '-' line IS a red removal.
+	red := zeroTheme.red.Render("-old line")
+	if got := styleStreamingCodeLine("-old line", false); got != red {
+		t.Errorf("patch '-' line should render red, got %q", got)
+	}
+}

--- a/internal/tui/streaming_tool_call_test.go
+++ b/internal/tui/streaming_tool_call_test.go
@@ -11,7 +11,7 @@ func TestDecodeStreamingJSONString(t *testing.T) {
 	if got := streamingFilePath(args); got != "ecommerce/frontend/index.html" {
 		t.Errorf("path = %q", got)
 	}
-	content, ok := streamingFileContent(args)
+	content, ok := decodeStreamingJSONString(args, "content")
 	if !ok {
 		t.Fatal("expected content")
 	}
@@ -20,35 +20,12 @@ func TestDecodeStreamingJSONString(t *testing.T) {
 		t.Errorf("content = %q, want %q", content, want)
 	}
 	// A dangling backslash at the stream edge is dropped, not panicked on.
-	if c, _ := streamingFileContent(`{"content":"abc\`); c != "abc" {
+	if c, _ := decodeStreamingJSONString(`{"content":"abc\`, "content"); c != "abc" {
 		t.Errorf("dangling escape: %q", c)
 	}
 	// Missing key.
-	if _, ok := streamingFileContent(`{"path":"x"}`); ok {
+	if _, ok := decodeStreamingJSONString(`{"path":"x"}`, "content"); ok {
 		t.Error("no content key should be (false)")
-	}
-}
-
-func TestStreamingToolCallView(t *testing.T) {
-	// No active call → empty.
-	if (model{}).streamingToolCallView(80) != "" {
-		t.Error("inactive should render nothing")
-	}
-	// Non-file tool → empty.
-	if (model{streamCallID: "1", streamCallName: "bash", streamCallArgs: `{"command":"ls"}`}).streamingToolCallView(80) != "" {
-		t.Error("non-file tool should render nothing")
-	}
-	// Active write_file → shows path, line count, and a content tail.
-	m := model{
-		streamCallID:   "1",
-		streamCallName: "write_file",
-		streamCallArgs: `{"path":"a/b.go","content":"package main\n\nfunc main() {}\n"}`,
-	}
-	out := m.streamingToolCallView(80)
-	for _, want := range []string{"write_file", "a/b.go", "lines", "func main()"} {
-		if !strings.Contains(out, want) {
-			t.Errorf("view missing %q:\n%s", want, out)
-		}
 	}
 }
 
@@ -63,32 +40,46 @@ func TestDecodeStreamingTolerantOfWhitespace(t *testing.T) {
 		if got := streamingFilePath(args); got != "a.go" {
 			t.Errorf("path from %q = %q, want a.go", args, got)
 		}
-		c, ok := streamingFileContent(args)
+		c, ok := decodeStreamingJSONString(args, "content")
 		if !ok || c != "line1\nline2" {
 			t.Errorf("content from %q = %q ok=%v", args, c, ok)
 		}
 	}
 }
 
-func TestStreamingViewShowsProgressBeforeContent(t *testing.T) {
-	// Args streaming but content not reached yet → show a byte count, not blank.
-	m := model{streamCallID: "1", streamCallName: "write_file", streamCallArgs: `{"path": "website/css/styles.css", "content": "/* lo`}
-	out := m.streamingToolCallView(80)
-	if !strings.Contains(out, "website/css/styles.css") {
-		t.Errorf("path should show with kimi-style spacing: %q", out)
+func viewModel(name, args string) model {
+	dec := newStreamingDecoder()
+	dec.feed(args)
+	return model{streamCallID: "1", streamCallName: name, streamCallDecoder: dec}
+}
+
+func TestStreamingToolCallView(t *testing.T) {
+	// No active call → empty.
+	if (model{}).streamingToolCallView(80) != "" {
+		t.Error("inactive should render nothing")
+	}
+	// Non-file tool → empty.
+	if viewModel("bash", `{"command":"ls"}`).streamingToolCallView(80) != "" {
+		t.Error("non-file tool should render nothing")
+	}
+	// Active write_file → shows path, line count, and a content tail.
+	out := viewModel("write_file", `{"path":"a/b.go","content":"package main\n\nfunc main() {}\n"}`).streamingToolCallView(80)
+	for _, want := range []string{"write_file", "a/b.go", "lines", "func main()"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q:\n%s", want, out)
+		}
 	}
 }
 
-func TestStreamingFileContentEditFileKey(t *testing.T) {
-	// edit_file's canonical replacement arg is new_string — the live preview must
-	// extract it (regression for M13: edit preview showed nothing).
-	args := `{"path":"a.go","old_string":"x","new_string":"package main\nfunc main(){}"}`
-	c, ok := streamingFileContent(args)
-	if !ok || c != "package main\nfunc main(){}" {
-		t.Errorf("new_string content = %q ok=%v", c, ok)
+func TestStreamingViewShowsProgressBeforeContent(t *testing.T) {
+	// Path known but the content field hasn't arrived yet → show the path + a live
+	// byte count, never blank.
+	out := viewModel("write_file", `{"path": "website/css/styles.css"`).streamingToolCallView(80)
+	if !strings.Contains(out, "website/css/styles.css") {
+		t.Errorf("path should show with kimi-style spacing: %q", out)
 	}
-	if p := streamingFilePath(args); p != "a.go" {
-		t.Errorf("path = %q", p)
+	if !strings.Contains(out, "KB") {
+		t.Errorf("should show a receiving byte count before content: %q", out)
 	}
 }
 

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,14 +1,19 @@
 package tui
 
-import "charm.land/lipgloss/v2"
+import (
+	"image/color"
 
-// tuiTheme is the single source of truth for Zero's terminal palette — the
-// Lime design: a near-black chat surface with one lime accent (the terminal
-// translation of docs/design/zero_tui_lime.html). Colors are truecolor hex so
-// the palette renders consistently across terminals; lipgloss downsamples
-// automatically on limited displays and renders plain text when there is no
-// TTY (e.g. during tests). Every renderer consumes these named styles — no hex
-// literal may appear outside this file.
+	"charm.land/lipgloss/v2"
+)
+
+// tuiTheme is the resolved terminal palette Zero renders with — the Lime design
+// (the terminal translation of docs/design/zero_tui_lime.html). It is produced by
+// buildTheme from a palette, so the same renderers serve both the dark default
+// and the light variant; the active theme lives in the package var zeroTheme and
+// may be swapped at startup (background detection / ZERO_THEME / --theme) or live
+// via /theme. Colors are truecolor hex; lipgloss downsamples on limited displays
+// and renders plain text when there is no TTY (tests). Every renderer consumes
+// these named styles — no hex literal may appear outside this file.
 type tuiTheme struct {
 	// Base tokens.
 	ink        lipgloss.Style // primary text
@@ -72,115 +77,203 @@ type tuiTheme struct {
 	modeAuto   lipgloss.Style
 	modeAsk    lipgloss.Style
 	modeUnsafe lipgloss.Style
+
+	// Raw colors a few renderers paint/interpolate with directly (the streaming
+	// fade interpolates accent→ink; panel-backed prompts paint on bgPanel), kept
+	// on the theme so a theme switch reaches them too. The bg* colors back the
+	// on* surface helpers below.
+	accentColor color.Color
+	inkColor    color.Color
+	bgPanel     color.Color
+	bgPrompt    color.Color
+	bgSel       color.Color
+	bgPerm      color.Color
 }
 
-// The Lime token table. bg (#070708) is the terminal's own canvas — it is
-// deliberately never painted full-bleed, so no style references it. Terminals
-// cannot alpha-blend or glow: the four solid tint tokens (addBg/delBg/permBg/
-// selBg) ARE the translation of the prototype's rgba overlays, and the two
-// card-border mixes stand in for its focus glow. All tints stay darker than
-// ink so every pairing survives 256-color downsampling.
-const (
-	colorPanel    = "#0e0e10" // card backgrounds
-	colorPanel2   = "#121215" // card header rows, picker rows
-	colorPanel3   = "#17171b" // selected/hovered row bg
-	colorPromptBg = "#262626" // submitted user prompt background
-	colorLine     = "#242429" // default borders, rules
-	colorLine2    = "#414147" // emphasized borders
-	colorInk      = "#ececee" // primary text
-	colorMuted    = "#8b8b93" // secondary text
-	colorFaint    = "#5b5b63" // hints, metadata
-	colorFaintest = "#3a3a40" // line numbers, separators, tool args
-	colorAccent   = "#caff3f" // brand lime
-	colorGreen    = "#5dd1a4" // success, diff add
-	colorRed      = "#ff7a7a" // errors, diff del
-	colorAmber    = "#ffc25c" // permission, warnings
-	colorBlue     = "#7db4ff" // grep locations, local-model dot
-	colorGitAdd   = "#7db87a" // footer PR diff additions
-	colorGitDel   = "#b87a7a" // footer PR diff deletions
-	colorAddBg    = "#15201d" // diff added-line bg (green @9% over panel)
-	colorDelBg    = "#241819" // diff deleted-line bg (red @9%)
-	colorPermBg   = "#1c1915" // permission card bg (amber @6%)
-	colorSelBg    = "#1d2114" // selected row bg (accent @8%)
-	colorAddInk   = "#bdeed7" // added-line text
-	colorDelInk   = "#f2c4c4" // deleted-line text
-	colorOnAccent = "#000000" // text on accent or amber fills
-	colorCardRun  = "#5a6b2e" // running card border (accent mixed into line)
-	colorCardErr  = "#6b3434" // errored card border (red mixed into line)
-	colorCardPerm = "#6b5a2e" // permission card border (amber mixed into line)
-)
-
-var zeroTheme = tuiTheme{
-	ink:        lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk)),
-	muted:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
-	faint:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaint)),
-	faintest:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)),
-	accent:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true),
-	green:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)),
-	red:        lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)),
-	amber:      lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
-	blue:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlue)),
-	gitAdd:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorGitAdd)),
-	gitDel:     lipgloss.NewStyle().Foreground(lipgloss.Color(colorGitDel)),
-	line:       lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine)),
-	lineStrong: lipgloss.NewStyle().Foreground(lipgloss.Color(colorLine2)),
-	selection:  lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorOnAccent)),
-
-	badge: lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorOnAccent)).Bold(true),
-
-	userPrompt: lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true),
-	sayText:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
-	toolName:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorInk)).Bold(true),
-	toolTarget: lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)),
-	toolArg:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)),
-	autoTag:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)),
-	cardRun:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorCardRun)),
-	cardErr:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorCardErr)),
-	bashPrompt: lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true),
-	grepLoc:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlue)),
-
-	diffAdd:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)),
-	diffDel:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)),
-	diffMeta:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)),
-	addLine:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAddInk)).Background(lipgloss.Color(colorAddBg)),
-	delLine:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorDelInk)).Background(lipgloss.Color(colorDelBg)),
-	addLineNum: lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)).Background(lipgloss.Color(colorAddBg)),
-	delLineNum: lipgloss.NewStyle().Foreground(lipgloss.Color(colorFaintest)).Background(lipgloss.Color(colorDelBg)),
-	addSign:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)).Background(lipgloss.Color(colorAddBg)),
-	delSign:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)).Background(lipgloss.Color(colorDelBg)),
-	delText:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorDelInk)),
-
-	permBadge:  lipgloss.NewStyle().Background(lipgloss.Color(colorAmber)).Foreground(lipgloss.Color(colorOnAccent)).Bold(true),
-	permBg:     lipgloss.NewStyle().Background(lipgloss.Color(colorPermBg)),
-	permBorder: lipgloss.NewStyle().Foreground(lipgloss.Color(colorCardPerm)),
-
-	panel:           lipgloss.NewStyle().Background(lipgloss.Color(colorPanel)),
-	userPromptPanel: lipgloss.NewStyle().Background(lipgloss.Color(colorPromptBg)),
-
-	modeAuto:   lipgloss.NewStyle().Foreground(lipgloss.Color(colorGreen)).Bold(true),
-	modeAsk:    lipgloss.NewStyle().Foreground(lipgloss.Color(colorAmber)).Bold(true),
-	modeUnsafe: lipgloss.NewStyle().Foreground(lipgloss.Color(colorRed)).Bold(true),
+// palette is the raw color-token table for one theme. buildTheme turns it into a
+// resolved tuiTheme. darkPalette and lightPalette are the ONLY place hex literals
+// live. All dark tints stay darker than ink so every pairing survives 256-color
+// downsampling; the light set is dark-on-light with the same intent inverted.
+type palette struct {
+	panel    string // card backgrounds (the terminal canvas itself is never painted full-bleed)
+	promptBg string // submitted user prompt background
+	line     string // default borders, rules
+	line2    string // emphasized borders
+	ink      string // primary text
+	muted    string // secondary text
+	faint    string // hints, metadata
+	faintest string // line numbers, separators, tool args
+	accent   string // brand lime
+	green    string // success, diff add
+	red      string // errors, diff del
+	amber    string // permission, warnings
+	blue     string // grep locations, local-model dot
+	gitAdd   string // footer PR diff additions
+	gitDel   string // footer PR diff deletions
+	addBg    string // diff added-line bg
+	delBg    string // diff deleted-line bg
+	permBg   string // permission card bg
+	selBg    string // selected row bg
+	addInk   string // added-line text
+	delInk   string // deleted-line text
+	onAccent string // text on accent or amber fills
+	cardRun  string // running card border (accent mixed into line)
+	cardErr  string // errored card border (red mixed into line)
+	cardPerm string // permission card border (amber mixed into line)
 }
+
+// darkPalette is the original Lime palette: a near-black chat surface with one
+// lime accent. bg (#070708) is the terminal's own canvas — deliberately never
+// painted — so no token references it.
+var darkPalette = palette{
+	panel:    "#0e0e10",
+	promptBg: "#262626",
+	line:     "#242429",
+	line2:    "#414147",
+	ink:      "#ececee",
+	muted:    "#8b8b93",
+	faint:    "#5b5b63",
+	faintest: "#3a3a40",
+	accent:   "#caff3f",
+	green:    "#5dd1a4",
+	red:      "#ff7a7a",
+	amber:    "#ffc25c",
+	blue:     "#7db4ff",
+	gitAdd:   "#7db87a",
+	gitDel:   "#b87a7a",
+	addBg:    "#15201d",
+	delBg:    "#241819",
+	permBg:   "#1c1915",
+	selBg:    "#1d2114",
+	addInk:   "#bdeed7",
+	delInk:   "#f2c4c4",
+	onAccent: "#000000",
+	cardRun:  "#5a6b2e",
+	cardErr:  "#6b3434",
+	cardPerm: "#6b5a2e",
+}
+
+// lightPalette is dark-on-light: light-gray surfaces with near-black ink. The
+// muted/faint/faintest grays get progressively LIGHTER (toward the surface) so the
+// same text hierarchy reads on white; the lime accent is darkened to keep contrast
+// against a light background, and the diff/permission tints become light surfaces.
+var lightPalette = palette{
+	panel:    "#ececed", // card backgrounds (slightly off-white)
+	promptBg: "#dcdce0", // submitted prompt background
+	line:     "#cfcfd5", // default borders
+	line2:    "#b0b0b8", // emphasized borders
+	ink:      "#1b1b1d", // primary text (near-black)
+	muted:    "#54545b", // secondary text
+	faint:    "#78787f", // hints, metadata
+	faintest: "#9b9ba3", // line numbers, separators
+	accent:   "#4d7a08", // brand lime, darkened for contrast on light
+	green:    "#1c7a4a", // success / diff add
+	red:      "#c0322c", // errors / diff del
+	amber:    "#8f6200", // permission / warnings
+	blue:     "#1d5fd6", // grep locations
+	gitAdd:   "#2f7a3a", // footer PR diff additions
+	gitDel:   "#a83a3a", // footer PR diff deletions
+	addBg:    "#e2f3e6", // diff added-line bg (light green)
+	delBg:    "#fbe6e6", // diff deleted-line bg (light red)
+	permBg:   "#fbf0d8", // permission card bg (light amber)
+	selBg:    "#e7f2cd", // selected row bg (light accent)
+	addInk:   "#1d5b37", // added-line text
+	delInk:   "#8e2d2d", // deleted-line text
+	onAccent: "#ffffff", // text on the (dark) accent/amber fills
+	cardRun:  "#94ad60", // running card border
+	cardErr:  "#cf9a9a", // errored card border
+	cardPerm: "#c9ad7d", // permission card border
+}
+
+// buildTheme resolves a palette into the styles every renderer uses.
+func buildTheme(p palette) tuiTheme {
+	col := func(s string) color.Color { return lipgloss.Color(s) }
+	fg := func(s string) lipgloss.Style { return lipgloss.NewStyle().Foreground(col(s)) }
+	return tuiTheme{
+		ink:        fg(p.ink),
+		muted:      fg(p.muted),
+		faint:      fg(p.faint),
+		faintest:   fg(p.faintest),
+		accent:     fg(p.accent).Bold(true),
+		green:      fg(p.green),
+		red:        fg(p.red),
+		amber:      fg(p.amber),
+		blue:       fg(p.blue),
+		gitAdd:     fg(p.gitAdd),
+		gitDel:     fg(p.gitDel),
+		line:       fg(p.line),
+		lineStrong: fg(p.line2),
+		selection:  lipgloss.NewStyle().Background(col(p.accent)).Foreground(col(p.onAccent)),
+
+		badge: lipgloss.NewStyle().Background(col(p.accent)).Foreground(col(p.onAccent)).Bold(true),
+
+		userPrompt: fg(p.accent).Bold(true),
+		sayText:    fg(p.muted),
+		toolName:   fg(p.ink).Bold(true),
+		toolTarget: fg(p.muted),
+		toolArg:    fg(p.faintest),
+		autoTag:    fg(p.amber),
+		cardRun:    fg(p.cardRun),
+		cardErr:    fg(p.cardErr),
+		bashPrompt: fg(p.accent).Bold(true),
+		grepLoc:    fg(p.blue),
+
+		diffAdd:    fg(p.green),
+		diffDel:    fg(p.red),
+		diffMeta:   fg(p.faintest),
+		addLine:    lipgloss.NewStyle().Foreground(col(p.addInk)).Background(col(p.addBg)),
+		delLine:    lipgloss.NewStyle().Foreground(col(p.delInk)).Background(col(p.delBg)),
+		addLineNum: lipgloss.NewStyle().Foreground(col(p.faintest)).Background(col(p.addBg)),
+		delLineNum: lipgloss.NewStyle().Foreground(col(p.faintest)).Background(col(p.delBg)),
+		addSign:    lipgloss.NewStyle().Foreground(col(p.green)).Background(col(p.addBg)),
+		delSign:    lipgloss.NewStyle().Foreground(col(p.red)).Background(col(p.delBg)),
+		delText:    fg(p.delInk),
+
+		permBadge:  lipgloss.NewStyle().Background(col(p.amber)).Foreground(col(p.onAccent)).Bold(true),
+		permBg:     lipgloss.NewStyle().Background(col(p.permBg)),
+		permBorder: fg(p.cardPerm),
+
+		panel:           lipgloss.NewStyle().Background(col(p.panel)),
+		userPromptPanel: lipgloss.NewStyle().Background(col(p.promptBg)),
+
+		modeAuto:   fg(p.green).Bold(true),
+		modeAsk:    fg(p.amber).Bold(true),
+		modeUnsafe: fg(p.red).Bold(true),
+
+		accentColor: col(p.accent),
+		inkColor:    col(p.ink),
+		bgPanel:     col(p.panel),
+		bgPrompt:    col(p.promptBg),
+		bgSel:       col(p.selBg),
+		bgPerm:      col(p.permBg),
+	}
+}
+
+// zeroTheme is the active palette every renderer reads. It defaults to dark and is
+// reassigned by theme selection at startup and by /theme. All references are
+// .field accesses evaluated at render time, so reassigning this var repaints every
+// subsequent render.
+var zeroTheme = buildTheme(darkPalette)
 
 // onPanel returns a copy of style that paints on the panel surface. lipgloss
 // resets the background between adjacent Render calls, so every segment of a
-// panel row (including padding) must carry the background itself — renderers
-// wrap their foreground styles through this instead of referencing hex.
+// panel row (including padding) must carry the background itself — renderers wrap
+// their foreground styles through this instead of referencing hex.
 func (t tuiTheme) onPanel(style lipgloss.Style) lipgloss.Style {
-	return style.Background(lipgloss.Color(colorPanel))
+	return style.Background(t.bgPanel)
 }
 
 // onUserPrompt paints on the submitted user-prompt surface.
 func (t tuiTheme) onUserPrompt(style lipgloss.Style) lipgloss.Style {
-	return style.Background(lipgloss.Color(colorPromptBg))
+	return style.Background(t.bgPrompt)
 }
 
 // onSel paints on the selected-row tint.
 func (t tuiTheme) onSel(style lipgloss.Style) lipgloss.Style {
-	return style.Background(lipgloss.Color(colorSelBg))
+	return style.Background(t.bgSel)
 }
 
 // onPerm paints on the permission-card tint.
 func (t tuiTheme) onPerm(style lipgloss.Style) lipgloss.Style {
-	return style.Background(lipgloss.Color(colorPermBg))
+	return style.Background(t.bgPerm)
 }

--- a/internal/tui/theme_select.go
+++ b/internal/tui/theme_select.go
@@ -1,0 +1,114 @@
+package tui
+
+import "strings"
+
+// themeMode is the operator's palette preference.
+type themeMode string
+
+const (
+	themeAuto  themeMode = "auto" // detect terminal background (default)
+	themeDark  themeMode = "dark"
+	themeLight themeMode = "light"
+)
+
+// themeModes lists the values /theme accepts.
+var themeModes = []string{string(themeAuto), string(themeDark), string(themeLight)}
+
+// resolveThemeMode picks the preference in precedence order: an explicit value
+// (the --theme flag, threaded via Options.Theme), then ZERO_THEME, then auto.
+func resolveThemeMode(flagValue, envValue string) themeMode {
+	for _, v := range []string{flagValue, envValue} {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "dark":
+			return themeDark
+		case "light":
+			return themeLight
+		case "auto":
+			return themeAuto
+		}
+	}
+	return themeAuto
+}
+
+// validThemeMode reports whether s names a theme mode (for /theme validation).
+func validThemeMode(s string) bool {
+	switch themeMode(strings.ToLower(strings.TrimSpace(s))) {
+	case themeAuto, themeDark, themeLight:
+		return true
+	}
+	return false
+}
+
+// applyTheme swaps the active palette (zeroTheme) and the globals derived from it
+// — the streaming-fade ramp and the static render cache — so a switch repaints
+// every subsequent render. For themeAuto it resolves to dark/light from
+// hasDarkBackground; explicit dark/light ignore it. Returns the concrete mode
+// applied (never auto). Must run on the Bubble Tea update goroutine (or before the
+// program starts), like every other zeroTheme access.
+func applyTheme(mode themeMode, hasDarkBackground bool) themeMode {
+	resolved := mode
+	if mode == themeAuto {
+		resolved = themeDark
+		if !hasDarkBackground {
+			resolved = themeLight
+		}
+	}
+	switch resolved {
+	case themeLight:
+		zeroTheme = buildTheme(lightPalette)
+	default:
+		zeroTheme = buildTheme(darkPalette)
+	}
+	rebuildStreamingFadePalette()
+	if defaultRenderCache != nil {
+		defaultRenderCache.clear() // old-palette entries must not be reused
+	}
+	return resolved
+}
+
+// handleThemeCommand implements /theme [auto|dark|light]: no arg shows state, a
+// valid mode switches the active palette live. Mirrors handleStyleCommand.
+func (m model) handleThemeCommand(args string) (model, string) {
+	arg := strings.ToLower(strings.TrimSpace(args))
+	if arg == "" || arg == "list" {
+		return m, m.themeStateText()
+	}
+	if !validThemeMode(arg) {
+		return m, "Theme\nUnknown theme: " + arg + " (use auto, dark, or light)"
+	}
+	m.themeMode = themeMode(arg)
+	resolved := applyTheme(m.themeMode, m.hasDarkBg)
+	active := arg
+	if m.themeMode == themeAuto {
+		active = "auto (" + string(resolved) + ")"
+	}
+	return m, strings.Join([]string{
+		"Theme",
+		"active theme: " + active,
+		"Already-printed scrollback keeps its previous colors; new output uses the new theme.",
+	}, "\n")
+}
+
+// themeStateText renders the /theme state view.
+func (m model) themeStateText() string {
+	active := string(m.themeMode)
+	if m.themeMode == themeAuto {
+		bg := "light"
+		if m.hasDarkBg {
+			bg = "dark"
+		}
+		active = "auto (" + bg + ")"
+	}
+	return renderCommandOutput(commandOutput{
+		Title:  "Theme",
+		Status: commandStatusOK,
+		Sections: []commandSection{{
+			Title: "State",
+			Lines: []string{
+				"active theme: " + active,
+				"available: " + strings.Join(themeModes, ", "),
+			},
+		}},
+		Hints: []string{"use /theme <auto|dark|light> to switch this TUI session"},
+	})
+}

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+func relLum(t *testing.T, hex string) float64 {
+	t.Helper()
+	h := strings.TrimPrefix(hex, "#")
+	v, err := strconv.ParseUint(h, 16, 32)
+	if err != nil || len(h) != 6 {
+		t.Fatalf("bad hex %q", hex)
+	}
+	r := float64((v>>16)&0xff) / 255
+	g := float64((v>>8)&0xff) / 255
+	b := float64(v&0xff) / 255
+	return 0.2126*r + 0.7152*g + 0.0722*b
+}
+
+// resolveThemeMode precedence: explicit flag > ZERO_THEME env > auto.
+func TestResolveThemeModePrecedence(t *testing.T) {
+	cases := []struct {
+		flag, env string
+		want      themeMode
+	}{
+		{"light", "dark", themeLight}, // flag wins
+		{"dark", "light", themeDark},  // flag wins
+		{"", "light", themeLight},     // env
+		{"", "dark", themeDark},       // env
+		{"", "", themeAuto},           // default
+		{"garbage", "also-bad", themeAuto},
+		{"AUTO", "", themeAuto},
+	}
+	for _, c := range cases {
+		if got := resolveThemeMode(c.flag, c.env); got != c.want {
+			t.Errorf("resolveThemeMode(%q,%q) = %q, want %q", c.flag, c.env, got, c.want)
+		}
+	}
+}
+
+// applyTheme: auto resolves from background; explicit dark/light ignore it.
+func TestApplyThemeResolution(t *testing.T) {
+	defer applyTheme(themeDark, true) // restore the global default
+	cases := []struct {
+		mode    themeMode
+		darkBg  bool
+		want    themeMode
+		wantInk string
+	}{
+		{themeAuto, true, themeDark, darkPalette.ink},
+		{themeAuto, false, themeLight, lightPalette.ink},
+		{themeDark, false, themeDark, darkPalette.ink},   // explicit ignores bg
+		{themeLight, true, themeLight, lightPalette.ink}, // explicit ignores bg
+	}
+	for _, c := range cases {
+		got := applyTheme(c.mode, c.darkBg)
+		if got != c.want {
+			t.Errorf("applyTheme(%q, darkBg=%v) = %q, want %q", c.mode, c.darkBg, got, c.want)
+		}
+		wantR, wantG, wantB, _ := lipgloss.Color(c.wantInk).RGBA()
+		gotR, gotG, gotB, _ := zeroTheme.inkColor.RGBA()
+		if gotR != wantR || gotG != wantG || gotB != wantB {
+			t.Errorf("applyTheme(%q,%v): zeroTheme.inkColor not the %q ink", c.mode, c.darkBg, c.want)
+		}
+	}
+}
+
+// The light palette must be a real dark-on-light set: distinct from dark, ink
+// well-contrasted against the panel, accent readable, and the gray hierarchy
+// (ink→faintest) ordered toward the surface so it still reads on white.
+func TestLightPaletteContrastAndHierarchy(t *testing.T) {
+	if lightPalette.ink == darkPalette.ink || lightPalette.panel == darkPalette.panel {
+		t.Fatal("light palette must differ from dark")
+	}
+	inkL, panelL := relLum(t, lightPalette.ink), relLum(t, lightPalette.panel)
+	if panelL-inkL < 0.5 {
+		t.Errorf("light ink/panel contrast too low: panel=%.2f ink=%.2f", panelL, inkL)
+	}
+	if panelL-relLum(t, lightPalette.accent) < 0.25 {
+		t.Errorf("light accent not contrasted enough against panel")
+	}
+	// Dark-on-light: ink darkest, then progressively lighter toward the surface.
+	chain := []float64{
+		relLum(t, lightPalette.ink),
+		relLum(t, lightPalette.muted),
+		relLum(t, lightPalette.faint),
+		relLum(t, lightPalette.faintest),
+		relLum(t, lightPalette.panel),
+	}
+	for i := 1; i < len(chain); i++ {
+		if !(chain[i] > chain[i-1]) {
+			t.Errorf("light hierarchy not monotonic toward surface at %d: %v", i, chain)
+		}
+	}
+	// Dark theme keeps the inverse ordering (light-on-dark).
+	dchain := []float64{
+		relLum(t, darkPalette.ink),
+		relLum(t, darkPalette.muted),
+		relLum(t, darkPalette.faint),
+		relLum(t, darkPalette.faintest),
+		relLum(t, darkPalette.panel),
+	}
+	for i := 1; i < len(dchain); i++ {
+		if !(dchain[i] < dchain[i-1]) {
+			t.Errorf("dark hierarchy not monotonic toward surface at %d: %v", i, dchain)
+		}
+	}
+}
+
+// /theme switches the active theme live and shows state with no arg.
+func TestHandleThemeCommand(t *testing.T) {
+	defer applyTheme(themeDark, true)
+	m := model{themeMode: themeAuto, hasDarkBg: true}
+
+	m, out := m.handleThemeCommand("light")
+	if m.themeMode != themeLight {
+		t.Fatalf("after /theme light, mode = %q", m.themeMode)
+	}
+	if r, _, _, _ := zeroTheme.inkColor.RGBA(); r != mustR(t, lightPalette.ink) {
+		t.Error("/theme light did not swap the active palette")
+	}
+	if !strings.Contains(out, "light") {
+		t.Errorf("output should confirm light: %q", out)
+	}
+
+	m, _ = m.handleThemeCommand("dark")
+	if m.themeMode != themeDark {
+		t.Fatalf("after /theme dark, mode = %q", m.themeMode)
+	}
+
+	_, state := m.handleThemeCommand("")
+	if !strings.Contains(state, "active theme") {
+		t.Errorf("no-arg /theme should show state: %q", state)
+	}
+	if _, bad := m.handleThemeCommand("solarized"); !strings.Contains(bad, "Unknown theme") {
+		t.Errorf("invalid theme should error: %q", bad)
+	}
+}
+
+func mustR(t *testing.T, hex string) uint32 {
+	t.Helper()
+	r, _, _, _ := lipgloss.Color(hex).RGBA()
+	return r
+}

--- a/internal/tui/tool_render_registry.go
+++ b/internal/tui/tool_render_registry.go
@@ -1,6 +1,9 @@
 package tui
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type toolBodyRequest struct {
 	name   string
@@ -43,8 +46,57 @@ func newDefaultToolBodyRegistry() *toolBodyRegistry {
 	registry.register("grep", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
 		return grepCardBody(req.detail, req.width, req.opts)
 	})})
+	// update_plan's full plan is already shown live by the sticky plan panel
+	// (renderPlanPanel); collapse its transcript card to a one-line summary so the
+	// plan isn't re-dumped into the transcript on every call.
+	registry.register("update_plan", toolBodyRendererFunc(planSummaryCardBody))
 
 	return registry
+}
+
+// planSummaryCardBody collapses an update_plan card to a single status line
+// (step counts) instead of the full "Current Plan:" body, which the plan panel
+// already renders. Falls back to the generic body if the text isn't a plan.
+func planSummaryCardBody(req toolBodyRequest) cardBody {
+	total, done, active, failed := 0, 0, 0, 0
+	for _, line := range strings.Split(req.detail, "\n") {
+		line = strings.TrimSpace(line)
+		if !isNumberedPlanLine(line) {
+			continue
+		}
+		total++
+		switch {
+		case strings.Contains(line, "[completed]"):
+			done++
+		case strings.Contains(line, "[in_progress]"):
+			active++
+		case strings.Contains(line, "[failed]"):
+			failed++
+		}
+	}
+	if total == 0 {
+		return genericCardBody(req.detail, req.opts)
+	}
+	parts := []string{fmt.Sprintf("%d steps", total)}
+	if done > 0 {
+		parts = append(parts, fmt.Sprintf("%d done", done))
+	}
+	if active > 0 {
+		parts = append(parts, fmt.Sprintf("%d in progress", active))
+	}
+	if failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", failed))
+	}
+	return cardBody{lines: []string{zeroTheme.onPanel(zeroTheme.faint).Render(strings.Join(parts, " · "))}}
+}
+
+// isNumberedPlanLine reports whether a line begins with "<n>." (a plan item).
+func isNumberedPlanLine(line string) bool {
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	return i > 0 && i < len(line) && line[i] == '.'
 }
 
 func newToolBodyRegistry(fallback toolBodyRenderer) *toolBodyRegistry {

--- a/internal/tui/wrap_whitespace_test.go
+++ b/internal/tui/wrap_whitespace_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// wrapPlainText must preserve internal alignment (>=2-space runs) instead of
+// collapsing it via strings.Fields, while leaving normal prose word-wrap intact.
+func TestWrapPlainTextPreservesAlignedWhitespace(t *testing.T) {
+	// Aligned columns that fit the measure survive verbatim.
+	aligned := "name    status    time"
+	if got := wrapPlainText(aligned, 40); len(got) != 1 || got[0] != aligned {
+		t.Fatalf("aligned line not preserved: %q", got)
+	}
+
+	// Indented aligned line: leading indent AND internal alignment preserved.
+	indented := "    col1    col2"
+	if got := wrapPlainText(indented, 40); len(got) != 1 || got[0] != indented {
+		t.Fatalf("indented aligned line not preserved: %q", got)
+	}
+
+	// Aligned line wider than the measure: verbatim split — concatenation equals
+	// the original (nothing collapsed), every segment within the measure.
+	wide := "aaaa    bbbb    cccc    dddd    eeee"
+	got := wrapPlainText(wide, 16)
+	if strings.Join(got, "") != wide {
+		t.Fatalf("verbatim split altered content: %q -> %q", wide, got)
+	}
+	for _, l := range got {
+		if lipgloss.Width(l) > 16 {
+			t.Errorf("segment exceeds measure 16: %q (w=%d)", l, lipgloss.Width(l))
+		}
+	}
+
+	// Normal prose (single spaces) keeps word-wrap: fits the measure, no introduced
+	// double spaces, no mid-word breaks.
+	prose := "the quick brown fox jumps over the lazy dog yet again today"
+	for _, l := range wrapPlainText(prose, 20) {
+		if lipgloss.Width(l) > 20 {
+			t.Errorf("prose line exceeds measure: %q", l)
+		}
+		if strings.Contains(l, "  ") {
+			t.Errorf("prose word-wrap introduced a double space: %q", l)
+		}
+	}
+
+	// Explicit newlines and blank lines stay.
+	multi := "a    b\n\nc    d"
+	if got := wrapPlainText(multi, 40); len(got) != 3 || got[0] != "a    b" || got[1] != "" || got[2] != "c    d" {
+		t.Fatalf("newlines/blank not preserved: %q", got)
+	}
+}

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -35,6 +35,12 @@ type CollectOptions struct {
 	OnText      func(string)
 	OnReasoning func(string)
 	OnUsage     func(Usage)
+	// OnToolCallStart fires when a tool call opens (id + tool name), and
+	// OnToolCallDelta fires for each streamed argument fragment. Together they let
+	// a surface render a tool call's arguments LIVE (e.g. a file being written)
+	// instead of waiting for the whole call to accumulate. nil is a no-op.
+	OnToolCallStart func(id, name string)
+	OnToolCallDelta func(id, fragment string)
 }
 
 // SeedMessages creates the initial system and user turns for a request. It is a
@@ -125,8 +131,14 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 				}
 			case StreamEventToolCallStart:
 				collector.start(event.ToolCallID, event.ToolName, event.ToolCallSignature)
+				if options.OnToolCallStart != nil {
+					options.OnToolCallStart(event.ToolCallID, event.ToolName)
+				}
 			case StreamEventToolCallDelta:
 				collector.delta(event.ToolCallID, event.ArgumentsFragment)
+				if options.OnToolCallDelta != nil {
+					options.OnToolCallDelta(event.ToolCallID, event.ArgumentsFragment)
+				}
 			case StreamEventToolCallEnd:
 				collector.end(event.ToolCallID)
 			case StreamEventToolCallDropped:


### PR DESCRIPTION
## Summary

Three TUI UX improvements plus robustness fixes — no new flags.

### 1. Live code-streaming preview
A long `write_file` / `edit_file` / `apply_patch` used to show only a spinner while the file was generated, looking frozen. Tool-call argument deltas are now forwarded `zeroruntime → agent → TUI` (`OnToolCallStart` / `OnToolCallDelta`), and the TUI renders a live `✎ write_file <path> · N lines` block with a color-coded tail of the code as it streams in.

### 2. Theme system
Auto dark/light detection via a terminal-background probe, a `/theme [auto|dark|light]` command, a refreshed palette, and streaming-fade auto-disable on low-color / SSH / tmux terminals.

### 3. Plan / Task transcript dedup
The plan could render up to three times (a full `update_plan` card per call **plus** the live plan panel). `update_plan` now collapses to a one-line summary — the panel owns the detail — and `Task` delegations render only as the specialist card, not also as raw tool-call/result rows, in **both** the live and resume paths.

### Robustness (streaming preview)
- tolerate whitespace in tool-call JSON (`"path": "…"`)
- extract `edit_file`'s `new_string` (the preview was blank for edits)
- clear the preview on tool finalize / cancel / run-end — no stale or duplicate previews, and a stale run can't wipe the active one
- new-file content renders green; a leading `-` (e.g. CSS `-webkit-…`) is no longer mis-colored as a removal
- truncate by display width (no CJK/wide-glyph overflow)

## Tests
New: `streaming_tool_call_test.go`, `theme_select_test.go`, `plan_summary_test.go`, `stage10_test.go`, `wrap_whitespace_test.go`; updated `session_test.go`, `streaming_fade_test.go`.

`go build ./...`, `go vet ./...`, `gofmt`, and the full `go test ./...` are all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live streaming preview of tool call arguments (including real-time file-writing/code output)
  * Theme selection with auto/dark/light modes and terminal background detection

* **Improvements**
  * `/theme` command now accepts a mode and updates the UI immediately
  * Collapsed plan summaries into step-count status lines
  * Improved text wrapping for aligned/preformatted content and capped assistant measure for readability
  * Updated streaming fade behavior based on environment and theme; refreshes render caching on theme changes

* **Bug Fixes**
  * Reduced duplicate “Task” transcript rows when specialist rendering is present

* **Tests**
  * Added/expanded unit tests for theme resolution, streaming decoding/rendering, wrapping, fading, and plan summaries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->