### PR TITLE
providers: surface non-normal terminal turns instead of silent empty completions

### DIFF
--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -595,10 +595,17 @@ type thinkingBuf struct {
 // normalized terminal reasons. A normal stop ("end_turn"/"tool_use"/"stop_sequence"/"")
 // returns "".
 func mapStopReason(reason string) string {
-	if reason == "max_tokens" {
+	switch reason {
+	case "max_tokens":
 		return zeroruntime.FinishReasonLength
+	case "refusal":
+		// The model declined to respond — surface it as content-filtered so the
+		// empty/partial turn isn't mistaken for a normal completion (M4).
+		return zeroruntime.FinishReasonContentFilter
+	default:
+		// end_turn / tool_use / stop_sequence / pause_turn (and "") are normal.
+		return ""
 	}
-	return ""
 }
 
 func newStreamState() *streamState {

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -603,7 +603,12 @@ func mapStopReason(reason string) string {
 		// empty/partial turn isn't mistaken for a normal completion (M4).
 		return zeroruntime.FinishReasonContentFilter
 	default:
-		// end_turn / tool_use / stop_sequence / pause_turn (and "") are normal.
+		// end_turn / tool_use / stop_sequence (and "") are normal completions.
+		// pause_turn is also normal here: it is Anthropic's long-running-turn pause
+		// (used with server-side tools), where the turn is NOT truncated or refused —
+		// the client is expected to resume it by sending the response back. Treating
+		// it as a non-normal early stop would fire a spurious truncation notice, so it
+		// maps to "" like the other clean stops.
 		return ""
 	}
 }

--- a/internal/providers/anthropic/stop_reason_test.go
+++ b/internal/providers/anthropic/stop_reason_test.go
@@ -1,0 +1,21 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestMapStopReasonRefusal(t *testing.T) {
+	if got := mapStopReason("refusal"); got != zeroruntime.FinishReasonContentFilter {
+		t.Errorf("refusal → %q, want content_filter (M4)", got)
+	}
+	if got := mapStopReason("max_tokens"); got != zeroruntime.FinishReasonLength {
+		t.Errorf("max_tokens → %q, want length", got)
+	}
+	for _, normal := range []string{"end_turn", "tool_use", "stop_sequence", "pause_turn", ""} {
+		if got := mapStopReason(normal); got != "" {
+			t.Errorf("%q should be a normal stop (empty), got %q", normal, got)
+		}
+	}
+}

--- a/internal/providers/gemini/finish_reason_test.go
+++ b/internal/providers/gemini/finish_reason_test.go
@@ -1,11 +1,16 @@
 package gemini
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
+// TestMapFinishReasonNonNormal unit-tests the reason mapping in isolation: the
+// normal set collapses to "", content-filter reasons map to content_filter,
+// MAX_TOKENS to length, and every other non-STOP reason surfaces its raw value
+// (M3) so the turn is not mistaken for a clean completion.
 func TestMapFinishReasonNonNormal(t *testing.T) {
 	for _, normal := range []string{"", "STOP", "FINISH_REASON_UNSPECIFIED"} {
 		if got := mapFinishReason(normal); got != "" {
@@ -24,5 +29,165 @@ func TestMapFinishReasonNonNormal(t *testing.T) {
 	// not mistaken for a clean completion.
 	if got := mapFinishReason("MALFORMED_FUNCTION_CALL"); got != "MALFORMED_FUNCTION_CALL" {
 		t.Errorf("MALFORMED_FUNCTION_CALL → %q, want the raw reason", got)
+	}
+}
+
+// A candidate finishReason of MAX_TOKENS means the response was truncated at the
+// output cap. The provider must surface it on the done event.
+func TestStreamCompletionSurfacesMaxTokensFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"cut"}]},"finishReason":"MAX_TOKENS"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var doneReason string
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			doneReason = e.FinishReason
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+	if doneReason != zeroruntime.FinishReasonLength {
+		t.Fatalf("done FinishReason = %q, want %q", doneReason, zeroruntime.FinishReasonLength)
+	}
+}
+
+// A SAFETY finishReason maps to the runtime's content-filter reason.
+func TestStreamCompletionSurfacesSafetyFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"SAFETY"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != zeroruntime.FinishReasonContentFilter {
+				t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+			}
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+}
+
+// A RECITATION finishReason previously fell through to "" (a clean completion);
+// M3 maps it to content_filter. This exercises that fix through the full
+// SSE → done-event wiring, not just mapFinishReason in isolation.
+func TestStreamCompletionSurfacesRecitationFinishReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"RECITATION"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != zeroruntime.FinishReasonContentFilter {
+				t.Fatalf("RECITATION done FinishReason = %q, want %q (M3)", e.FinishReason, zeroruntime.FinishReasonContentFilter)
+			}
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+}
+
+// A normal STOP finishReason must leave the done event's FinishReason empty.
+func TestStreamCompletionNormalFinishReasonHasNoReason(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var sawDone bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventDone {
+			sawDone = true
+			if e.FinishReason != "" {
+				t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
+			}
+		}
+	}
+	if !sawDone {
+		t.Fatalf("no done event; events: %+v", events)
+	}
+}
+
+// A functionCall part with an empty Name can't be dispatched. The provider must
+// signal a dropped tool call (once) so the agent can ask the model to retry,
+// rather than silently skipping it.
+func TestStreamCompletionEmitsDroppedOnNamelessFunctionCallPart(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"","args":{"a":1}}}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var dropped, started int
+	for _, e := range events {
+		switch e.Type {
+		case zeroruntime.StreamEventToolCallDropped:
+			dropped++
+		case zeroruntime.StreamEventToolCallStart:
+			started++
+		}
+	}
+	if started != 0 {
+		t.Errorf("a nameless functionCall must not start a tool call, got %d starts", started)
+	}
+	if dropped != 1 {
+		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
+	}
+}
+
+// A nameless top-level functionCall must also be signalled as dropped.
+func TestStreamCompletionEmitsDroppedOnNamelessTopLevelFunctionCall(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"functionCalls":[{"name":"","args":{"a":1}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var dropped, started int
+	for _, e := range events {
+		switch e.Type {
+		case zeroruntime.StreamEventToolCallDropped:
+			dropped++
+		case zeroruntime.StreamEventToolCallStart:
+			started++
+		}
+	}
+	if started != 0 {
+		t.Errorf("a nameless functionCall must not start a tool call, got %d starts", started)
+	}
+	if dropped != 1 {
+		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
+	}
+}
+
+// A well-formed functionCall must NOT emit a dropped signal.
+func TestStreamCompletionDoesNotDropValidFunctionCall(t *testing.T) {
+	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"x"}}}]}}]}`)
+	})
+
+	events := collectProviderEvents(t, provider)
+	var sawStart bool
+	for _, e := range events {
+		if e.Type == zeroruntime.StreamEventToolCallDropped {
+			t.Errorf("valid functionCall must not be dropped; events: %+v", events)
+		}
+		if e.Type == zeroruntime.StreamEventToolCallStart && e.ToolName == "read_file" {
+			sawStart = true
+		}
+	}
+	if !sawStart {
+		t.Fatalf("valid functionCall did not start a read_file tool call; events: %+v", events)
 	}
 }

--- a/internal/providers/gemini/finish_reason_test.go
+++ b/internal/providers/gemini/finish_reason_test.go
@@ -1,145 +1,28 @@
 package gemini
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
-// A candidate finishReason of MAX_TOKENS means the response was truncated at the
-// output cap. The provider must surface it on the done event.
-func TestStreamCompletionSurfacesMaxTokensFinishReason(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"cut"}]},"finishReason":"MAX_TOKENS"}]}`)
-	})
-
-	events := collectProviderEvents(t, provider)
-	var doneReason string
-	var sawDone bool
-	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone {
-			sawDone = true
-			doneReason = e.FinishReason
+func TestMapFinishReasonNonNormal(t *testing.T) {
+	for _, normal := range []string{"", "STOP", "FINISH_REASON_UNSPECIFIED"} {
+		if got := mapFinishReason(normal); got != "" {
+			t.Errorf("%q should be a normal stop (empty), got %q", normal, got)
 		}
 	}
-	if !sawDone {
-		t.Fatalf("no done event; events: %+v", events)
-	}
-	if doneReason != zeroruntime.FinishReasonLength {
-		t.Fatalf("done FinishReason = %q, want %q", doneReason, zeroruntime.FinishReasonLength)
-	}
-}
-
-// A SAFETY finishReason maps to the runtime's content-filter reason.
-func TestStreamCompletionSurfacesSafetyFinishReason(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"SAFETY"}]}`)
-	})
-
-	events := collectProviderEvents(t, provider)
-	var sawDone bool
-	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone {
-			sawDone = true
-			if e.FinishReason != zeroruntime.FinishReasonContentFilter {
-				t.Fatalf("done FinishReason = %q, want %q", e.FinishReason, zeroruntime.FinishReasonContentFilter)
-			}
+	for _, cf := range []string{"SAFETY", "RECITATION", "IMAGE_SAFETY", "PROHIBITED_CONTENT", "BLOCKLIST", "SPII"} {
+		if got := mapFinishReason(cf); got != zeroruntime.FinishReasonContentFilter {
+			t.Errorf("%q → %q, want content_filter (M3)", cf, got)
 		}
 	}
-	if !sawDone {
-		t.Fatalf("no done event; events: %+v", events)
+	if got := mapFinishReason("MAX_TOKENS"); got != zeroruntime.FinishReasonLength {
+		t.Errorf("MAX_TOKENS → %q, want length", got)
 	}
-}
-
-// A normal STOP finishReason must leave the done event's FinishReason empty.
-func TestStreamCompletionNormalFinishReasonHasNoReason(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
-	})
-
-	events := collectProviderEvents(t, provider)
-	var sawDone bool
-	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventDone {
-			sawDone = true
-			if e.FinishReason != "" {
-				t.Fatalf("normal finish leaked FinishReason %q", e.FinishReason)
-			}
-		}
-	}
-	if !sawDone {
-		t.Fatalf("no done event; events: %+v", events)
-	}
-}
-
-// A functionCall part with an empty Name can't be dispatched. The provider must
-// signal a dropped tool call (once) so the agent can ask the model to retry,
-// rather than silently skipping it.
-func TestStreamCompletionEmitsDroppedOnNamelessFunctionCallPart(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"","args":{"a":1}}}]}}]}`)
-	})
-
-	events := collectProviderEvents(t, provider)
-	var dropped, started int
-	for _, e := range events {
-		switch e.Type {
-		case zeroruntime.StreamEventToolCallDropped:
-			dropped++
-		case zeroruntime.StreamEventToolCallStart:
-			started++
-		}
-	}
-	if started != 0 {
-		t.Errorf("a nameless functionCall must not start a tool call, got %d starts", started)
-	}
-	if dropped != 1 {
-		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
-	}
-}
-
-// A nameless top-level functionCall must also be signalled as dropped.
-func TestStreamCompletionEmitsDroppedOnNamelessTopLevelFunctionCall(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"functionCalls":[{"name":"","args":{"a":1}}]}`)
-	})
-
-	events := collectProviderEvents(t, provider)
-	var dropped, started int
-	for _, e := range events {
-		switch e.Type {
-		case zeroruntime.StreamEventToolCallDropped:
-			dropped++
-		case zeroruntime.StreamEventToolCallStart:
-			started++
-		}
-	}
-	if started != 0 {
-		t.Errorf("a nameless functionCall must not start a tool call, got %d starts", started)
-	}
-	if dropped != 1 {
-		t.Errorf("expected exactly one dropped-tool-call signal, got %d; events: %+v", dropped, events)
-	}
-}
-
-// A well-formed functionCall must NOT emit a dropped signal.
-func TestStreamCompletionDoesNotDropValidFunctionCall(t *testing.T) {
-	provider := newTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
-		writeSSE(w, `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"x"}}}]}}]}`)
-	})
-
-	events := collectProviderEvents(t, provider)
-	var sawStart bool
-	for _, e := range events {
-		if e.Type == zeroruntime.StreamEventToolCallDropped {
-			t.Errorf("valid functionCall must not be dropped; events: %+v", events)
-		}
-		if e.Type == zeroruntime.StreamEventToolCallStart && e.ToolName == "read_file" {
-			sawStart = true
-		}
-	}
-	if !sawStart {
-		t.Fatalf("valid functionCall did not start a read_file tool call; events: %+v", events)
+	// Remaining non-STOP reasons surface the raw reason (non-empty) so the turn is
+	// not mistaken for a clean completion.
+	if got := mapFinishReason("MALFORMED_FUNCTION_CALL"); got != "MALFORMED_FUNCTION_CALL" {
+		t.Errorf("MALFORMED_FUNCTION_CALL → %q, want the raw reason", got)
 	}
 }

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -531,11 +531,17 @@ type streamState struct {
 // normalized terminal reasons. A normal stop ("STOP"/"") returns "".
 func mapFinishReason(reason string) string {
 	switch reason {
+	case "", "STOP", "FINISH_REASON_UNSPECIFIED":
+		return "" // normal completion
 	case "MAX_TOKENS":
 		return zeroruntime.FinishReasonLength
-	case "SAFETY", "PROHIBITED_CONTENT", "BLOCKLIST", "SPII":
+	case "SAFETY", "PROHIBITED_CONTENT", "BLOCKLIST", "SPII", "RECITATION", "IMAGE_SAFETY":
 		return zeroruntime.FinishReasonContentFilter
 	default:
-		return ""
+		// MALFORMED_FUNCTION_CALL, OTHER, LANGUAGE, UNEXPECTED_TOOL_CALL, and any
+		// future non-STOP reason: surface the raw reason so a truncated/aborted turn
+		// isn't mistaken for a clean completion (M3). TruncationNotice renders it as
+		// "Response ended early (<reason>)".
+		return reason
 	}
 }

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -681,6 +681,24 @@ func (p *CodexProvider) handleTerminalResponse(
 		state.done = true
 		return false
 	}
+	// A response.failed carrying a payload whose `error` object is null/omitted (the
+	// backend can emit a failed terminal with the reason only in `status`) must still
+	// surface as an error — not fall through to a clean Done. Otherwise a real failure
+	// is reported as a normal successful turn, the same silent-failure class the
+	// nil-payload branch above guards (M2). A response.failed with a `status` carries
+	// it in the message for context.
+	if event.Type == responsesEventFailed || event.Response.Status == "failed" {
+		msg := "codex: response.failed with no error detail"
+		if status := strings.TrimSpace(event.Response.Status); status != "" {
+			msg = fmt.Sprintf("codex: response.failed (status %q) with no error detail", status)
+		}
+		providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+			Type:  zeroruntime.StreamEventError,
+			Error: msg,
+		})
+		state.done = true
+		return false
+	}
 	providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
 	state.done = true
 	return false

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -115,8 +115,10 @@ type responsesEvent struct {
 	// delta payloads (response.output_text.delta / function_call_arguments.delta)
 	Delta string `json:"delta,omitempty"`
 	// item payloads (response.output_item.added / done)
-	ItemID      string       `json:"item_id,omitempty"`
-	OutputIndex int          `json:"output_index,omitempty"`
+	ItemID string `json:"item_id,omitempty"`
+	// OutputIndex is a *int so a real 0 (the first output) is distinguishable from
+	// "absent" — a plain int defaulting to 0 dropped a no-item_id call's args (M1).
+	OutputIndex *int         `json:"output_index,omitempty"`
 	Item        *itemPayload `json:"item,omitempty"`
 	// completed / failed / incomplete
 	Response *responsePayload `json:"response,omitempty"`
@@ -639,6 +641,18 @@ func (p *CodexProvider) handleTerminalResponse(
 	events chan<- zeroruntime.StreamEvent,
 ) bool {
 	if event.Response == nil {
+		// A terminal event with no Response payload must still emit a terminal
+		// stream event, or the collector returns a clean-looking empty completion
+		// that masks a real failure (M2). A response.failed without a payload is an
+		// error; a response.completed without one is just an empty (but clean) turn.
+		if event.Type == responsesEventFailed {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{
+				Type:  zeroruntime.StreamEventError,
+				Error: "codex: response.failed with no error detail",
+			})
+		} else {
+			providerio.SendEvent(ctx, events, zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone})
+		}
 		state.done = true
 		return false
 	}
@@ -686,11 +700,11 @@ func (p *CodexProvider) toolCallKey(event *responsesEvent) string {
 	if event.Item != nil && event.Item.CallID != "" {
 		return event.Item.CallID
 	}
-	if event.OutputIndex > 0 {
-		// OutputIndex is 0-based; offset by one to keep "0" reserved for
-		// "no index known" so it cannot collide with a real zero-indexed
-		// call.
-		return fmt.Sprintf("output-%d", event.OutputIndex+1)
+	if event.OutputIndex != nil {
+		// output_index is present (a *int distinguishes a real 0 — the first output
+		// in the response — from "absent"), so key on it even when 0 instead of
+		// dropping the call's args when no item_id is present (M1).
+		return fmt.Sprintf("output-%d", *event.OutputIndex)
 	}
 	return ""
 }

--- a/internal/providers/openai/codex_terminal_test.go
+++ b/internal/providers/openai/codex_terminal_test.go
@@ -1,0 +1,58 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+func TestToolCallKeyOutputIndexZero(t *testing.T) {
+	p := &CodexProvider{}
+	zero, two := 0, 2
+	// output_index 0 with no item_id must produce a key (it was dropped before M1).
+	if got := p.toolCallKey(&responsesEvent{OutputIndex: &zero}); got != "output-0" {
+		t.Errorf("OutputIndex 0 → %q, want output-0", got)
+	}
+	if got := p.toolCallKey(&responsesEvent{OutputIndex: &two}); got != "output-2" {
+		t.Errorf("OutputIndex 2 → %q, want output-2", got)
+	}
+	if got := p.toolCallKey(&responsesEvent{}); got != "" {
+		t.Errorf("absent output_index + no item_id → %q, want empty", got)
+	}
+	if got := p.toolCallKey(&responsesEvent{ItemID: "call_x", OutputIndex: &zero}); got != "call_x" {
+		t.Errorf("item_id should take precedence → %q", got)
+	}
+}
+
+func TestHandleTerminalResponseNilPayload(t *testing.T) {
+	p := &CodexProvider{}
+
+	// response.failed with no Response payload must emit an error, not a silent done.
+	failed := make(chan zeroruntime.StreamEvent, 4)
+	st := &responsesState{}
+	p.handleTerminalResponse(context.Background(), &responsesEvent{Type: responsesEventFailed}, st, failed)
+	close(failed)
+	sawError := false
+	for ev := range failed {
+		if ev.Type == zeroruntime.StreamEventError {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Error("response.failed with nil payload should emit StreamEventError (M2)")
+	}
+	if !st.done {
+		t.Error("state.done should be set")
+	}
+
+	// response.completed with no payload is a clean (empty) done, not an error.
+	completed := make(chan zeroruntime.StreamEvent, 4)
+	p.handleTerminalResponse(context.Background(), &responsesEvent{Type: responsesEventCompleted}, &responsesState{}, completed)
+	close(completed)
+	for ev := range completed {
+		if ev.Type == zeroruntime.StreamEventError {
+			t.Error("response.completed with nil payload should NOT emit an error")
+		}
+	}
+}

--- a/internal/providers/openai/codex_terminal_test.go
+++ b/internal/providers/openai/codex_terminal_test.go
@@ -56,3 +56,45 @@ func TestHandleTerminalResponseNilPayload(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleTerminalResponseFailedPayloadWithoutError(t *testing.T) {
+	p := &CodexProvider{}
+
+	// A response.failed carrying a payload whose error object is null/omitted (the
+	// reason is in status) must still surface as an error, not fall through to a
+	// clean done — the same silent-failure class the nil-payload branch guards.
+	out := make(chan zeroruntime.StreamEvent, 8)
+	st := &responsesState{}
+	p.handleTerminalResponse(context.Background(),
+		&responsesEvent{Type: responsesEventFailed, Response: &responsePayload{Status: "failed"}}, st, out)
+	close(out)
+	sawError, sawDone := false, false
+	for ev := range out {
+		switch ev.Type {
+		case zeroruntime.StreamEventError:
+			sawError = true
+		case zeroruntime.StreamEventDone:
+			sawDone = true
+		}
+	}
+	if !sawError {
+		t.Error("response.failed with a non-nil payload and nil error must emit StreamEventError, not a clean done")
+	}
+	if sawDone {
+		t.Error("a failed terminal must not also emit a clean StreamEventDone")
+	}
+	if !st.done {
+		t.Error("state.done should be set")
+	}
+
+	// A response.completed with a payload and no error remains a clean done.
+	ok := make(chan zeroruntime.StreamEvent, 8)
+	p.handleTerminalResponse(context.Background(),
+		&responsesEvent{Type: responsesEventCompleted, Response: &responsePayload{Status: "completed"}}, &responsesState{}, ok)
+	close(ok)
+	for ev := range ok {
+		if ev.Type == zeroruntime.StreamEventError {
+			t.Error("response.completed with a non-error payload must NOT emit an error")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Four provider stream-adapter bugs where a **non-normal terminal turn was treated as a clean, empty completion** — so a dropped tool call, an upstream failure, a content block, or a refusal looked like the model simply returned nothing. Surfaced by a full-tree audit; each ships a regression test.

## Fixes

| Adapter | Bug | Fix |
|---|---|---|
| Responses (codex) | A tool call with `output_index` 0 and no `item_id` had its argument deltas **dropped** — the tool ran with empty/partial JSON. `output_index` was an `int`, so a real 0 was indistinguishable from "absent". | `output_index` is now a `*int`; `toolCallKey` keys on it even when 0. |
| Responses (codex) | `response.failed` / `response.completed` with a nil payload **returned with no terminal event** — the collector saw a clean empty completion that masked a real failure. | `failed` emits `StreamEventError`, `completed` emits `StreamEventDone`. |
| Gemini | Terminal `finishReason`s (RECITATION, MALFORMED_FUNCTION_CALL, IMAGE_SAFETY, OTHER, LANGUAGE, UNEXPECTED_TOOL_CALL) mapped to a normal stop → silent empty/truncated turn. | Safety reasons → `content_filter`; remaining non-STOP reasons surface the raw reason so the "ended early (…)" notice fires. Only `""`/`STOP`/`FINISH_REASON_UNSPECIFIED` are normal. |
| Anthropic | `stop_reason: refusal` treated as a normal completion → silent empty turn. | `refusal` → `content_filter`. |

## Tests
`TestToolCallKeyOutputIndexZero`, `TestHandleTerminalResponseNilPayload`, `TestMapFinishReasonNonNormal`, `TestMapStopReasonRefusal`.

`go build ./...`, `go vet ./...`, `gofmt`, and the full `go test ./...` are all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming terminal-event handling so missing or incomplete failure details still produce correct error signaling and always stop cleanly.
  * Fixed tool-call correlation for terminal SSE events, especially when output indices include zero.
* **Refactor**
  * Standardized finish/stop reason mapping to more accurately distinguish normal completions from content-filtered and length-limited outcomes.
* **Tests**
  * Added/updated unit and integration tests to cover refined reason mappings and terminal-event edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->