### PR TITLE
Fix model-discovery fallback + redact opaque Authorization tokens

### DIFF
--- a/internal/providermodeldiscovery/discover_fallback_test.go
+++ b/internal/providermodeldiscovery/discover_fallback_test.go
@@ -1,0 +1,40 @@
+package providermodeldiscovery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/providercatalog"
+)
+
+func TestDiscoverCatalogFallsBackWhenLiveIDsMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api.json":
+			_, _ = w.Write([]byte(`{"openai":{"models":{"gpt-4.1":{"id":"gpt-4.1","name":"GPT-4.1","tool_call":true,"reasoning":true,"limit":{"context":1048576}}}}}`))
+		case "/v1/models":
+			// 200, but live model IDs don't match any curated coding model, so the
+			// merge is empty (M11): the result must fall back to the curated catalog,
+			// not collapse to an empty list.
+			_, _ = w.Write([]byte(`{"data":[{"id":"gpt-image-1"},{"id":"text-embedding-3-large"}]}`))
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	provider := providercatalog.Descriptor{ID: "openai", Transport: providercatalog.TransportOpenAI, DefaultBaseURL: server.URL + "/v1", RequiresAuth: true}
+	models, err := DiscoverCatalog(context.Background(), provider, config.ProviderProfile{
+		CatalogID: "openai", ProviderKind: config.ProviderKindOpenAI, BaseURL: server.URL + "/v1", APIKey: "sk-live",
+	}, Options{HTTPClient: server.Client(), ModelsDevURL: server.URL + "/api.json"})
+	if err != nil {
+		t.Fatalf("DiscoverCatalog returned error: %v", err)
+	}
+	if got := strings.Join(modelIDs(models), ","); got != "gpt-4.1" {
+		t.Fatalf("models = %q, want curated catalog fallback (gpt-4.1) instead of an empty list", got)
+	}
+}

--- a/internal/providermodeldiscovery/discovery.go
+++ b/internal/providermodeldiscovery/discovery.go
@@ -44,9 +44,14 @@ func DiscoverCatalog(ctx context.Context, provider providercatalog.Descriptor, p
 	if canProbeProvider {
 		liveModels, liveErr := Discover(ctx, profile, options)
 		if liveErr == nil {
-			return mergeLiveModels(provider, liveModels, catalogModels), nil
-		}
-		if len(catalogModels) == 0 {
+			if merged := mergeLiveModels(provider, liveModels, catalogModels); len(merged) > 0 {
+				return merged, nil
+			}
+			// Live probe returned 200 but its model ids didn't match the catalog, so
+			// the merge is empty. Fall through to the curated catalog below instead of
+			// returning an empty list that collapses the picker to the bare built-in
+			// set (and shows a misleading "no model ids" error) (M11).
+		} else if len(catalogModels) == 0 {
 			return nil, liveErr
 		}
 	}

--- a/internal/redaction/opaque_auth_test.go
+++ b/internal/redaction/opaque_auth_test.go
@@ -1,0 +1,28 @@
+package redaction
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactStringRedactsOpaqueAuthorization(t *testing.T) {
+	// Opaque tokens and custom (non-standard) schemes must still be redacted in
+	// free text — not just the recognized bearer/basic/digest/etc. schemes (M12).
+	cases := []struct{ in, secret string }{
+		{"Authorization: Bearer sk-secret-123", "sk-secret-123"},
+		{"Authorization: sk-opaque-no-scheme-456", "sk-opaque-no-scheme-456"},
+		{"authorization: Custom-Scheme deadbeefsecret", "deadbeefsecret"},
+		{"Proxy-Authorization: rawproxytoken789", "rawproxytoken789"},
+	}
+	for _, c := range cases {
+		out := RedactString(c.in, Options{})
+		if strings.Contains(out, c.secret) {
+			t.Errorf("secret leaked for %q -> %q", c.in, out)
+		}
+	}
+	// A recognized scheme keeps its name for readability.
+	out := RedactString("Authorization: Bearer sk-x", Options{})
+	if !strings.Contains(strings.ToLower(out), "bearer") {
+		t.Errorf("known scheme name should be preserved: %q", out)
+	}
+}

--- a/internal/redaction/redaction.go
+++ b/internal/redaction/redaction.go
@@ -86,9 +86,10 @@ var (
 	// Redact the ENTIRE credential after the scheme (to end of line), not just the
 	// first token: parameterized schemes (Digest, OAuth, AWS4-HMAC-SHA256) spread
 	// the secret across comma-separated params (…, response=…, Signature=…), so a
-	// single-token capture would leave the actual secret visible. The scheme name
-	// is kept; only the value is replaced.
-	headerPattern = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(bearer|basic|token|apikey|api-key|digest|negotiate|oauth|aws4-hmac-sha256)\s+([^\r\n]+)`)
+	// single-token capture would leave the actual secret visible. A known scheme is
+	// kept for readability; the scheme is OPTIONAL so an opaque or custom-scheme
+	// credential (no recognized scheme) still has its whole value redacted (M12).
+	headerPattern = regexp.MustCompile(`(?i)\b(authorization|proxy-authorization)\s*:\s*(?:(bearer|basic|token|apikey|api-key|digest|negotiate|oauth|aws4-hmac-sha256)\s+)?([^\r\n]+)`)
 	secretHeader  = regexp.MustCompile(`(?i)\b(x-api-key|api-key|cookie|set-cookie)\s*:\s*([^\r\n]+)`)
 	queryPattern  = regexp.MustCompile(`([?&])([^=&#\s]+)=([^&#\s]+)`)
 )
@@ -182,7 +183,15 @@ func RedactString(value string, options Options) string {
 		}
 		return parts[1] + parts[2] + replacement
 	})
-	redacted = headerPattern.ReplaceAllString(redacted, "$1: $2 "+replacement)
+	redacted = headerPattern.ReplaceAllStringFunc(redacted, func(match string) string {
+		groups := headerPattern.FindStringSubmatch(match)
+		// groups[2] is the known scheme (kept for readability) or "" for an opaque /
+		// custom-scheme credential — in which case the whole value is redacted (M12).
+		if groups[2] != "" {
+			return groups[1] + ": " + groups[2] + " " + replacement
+		}
+		return groups[1] + ": " + replacement
+	})
 	redacted = secretHeader.ReplaceAllString(redacted, "$1: "+replacement)
 	redacted = redactURLPasswords(redacted, replacement)
 	redacted = queryPattern.ReplaceAllStringFunc(redacted, func(match string) string {


### PR DESCRIPTION
## Summary

Two robustness/security bugs surfaced by a full-tree audit, each with a regression test.

## Fixes

| Area | Bug | Fix |
|---|---|---|
| **model discovery** | When a live `/models` probe returns 200 but its model ids don't match the curated catalog, `mergeLiveModels` is empty and `DiscoverCatalog` returned that empty list — the picker/wizard **lost the whole live+curated list** (context windows, tool-call flags) and fell back to the bare built-in set with a misleading "no model ids" error. | When the merge is empty but the catalog is non-empty, fall back to the curated catalog. |
| **redaction** (security) | `Authorization` / `Proxy-Authorization` headers with an **opaque token** or a **custom/non-standard scheme** weren't matched by the scheme-aware pattern, so `RedactString` echoed live credentials back into model context and rendered output (logs, command/diff output, errors, session search). | The scheme is now optional — any credential value is redacted to end-of-line; a recognized scheme name (`Bearer`, `Basic`, …) is still kept for readability. |

## Tests
- `TestDiscoverCatalogFallsBackWhenLiveIDsMismatch`
- `TestRedactStringRedactsOpaqueAuthorization`

`go build ./...`, `go vet ./...`, `gofmt`, and the full `go test ./...` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model discovery to fall back to a curated catalog when live model data is unavailable or mismatched, preventing empty results.
  * Enhanced authorization header redaction to properly handle both standard and custom authentication schemes.

* **Tests**
  * Added test coverage for catalog discovery fallback behavior.
  * Added test coverage for redacting various authorization header formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->