### PR TITLE
feat(tui): transcript polish — left-rule cards, tool-call density, pinned plan

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1642,6 +1642,15 @@ func (m model) pinnedTitleBar(width int) string {
 
 func (m model) footerView(width int) string {
 	var footer strings.Builder
+	// Pinned plan panel: sits directly above the composer so it stays visible
+	// while the transcript scrolls underneath (a streaming turn no longer pushes
+	// the plan off-screen). Budgeted to at most a third of the screen height; a
+	// taller plan collapses to a one-line summary so the composer always stays
+	// on screen.
+	if plan := m.renderPinnedPlanPanel(width, m.pinnedPlanMaxHeight()); plan != "" {
+		footer.WriteString(plan)
+		footer.WriteString("\n")
+	}
 	if copyStatus := strings.TrimSpace(m.copyStatus); copyStatus != "" {
 		footer.WriteString(rightAlignedLine(zeroTheme.ink.Render(copyStatus), width))
 		footer.WriteString("\n")
@@ -1660,6 +1669,21 @@ func (m model) footerView(width int) string {
 	footer.WriteString("\n")
 	footer.WriteString(m.statusLine(width))
 	return footer.String()
+}
+
+// pinnedPlanMaxHeight is the line budget for the pinned plan panel: at most a
+// third of the screen, so even a long plan can't crowd out the transcript or
+// the composer. Beyond this the panel collapses to its one-line summary. Falls
+// back to a generous cap when the height isn't known yet (unmeasured/headless).
+func (m model) pinnedPlanMaxHeight() int {
+	if m.height <= 0 {
+		return 12
+	}
+	budget := m.height / 3
+	if budget < 3 {
+		budget = 3
+	}
+	return budget
 }
 
 type tuiRect struct {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2490,6 +2490,14 @@ func startsTurn(kind rowKind) bool {
 	}
 }
 
+// isToolCardKind reports whether a row renders as a tool card (a running call or
+// its collapsed result). Used to add one blank line between consecutive tool
+// cards in a turn. Specialist cards are excluded — they own their own grouping
+// (summary line + injected spacing) and must not be double-spaced.
+func isToolCardKind(kind rowKind) bool {
+	return kind == rowToolCall || kind == rowToolResult
+}
+
 func (m model) handlePermissionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.pendingPermission == nil {
 		return m, nil
@@ -3496,10 +3504,16 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 
 		onPermission := options.OnPermission
 		options.OnPermission = func(event agent.PermissionEvent) {
-			row := permissionTranscriptRow(event)
-			row.runID = runID
-			rows = append(rows, row)
-			m.sendAgentRow(runID, row)
+			// The audit event is recorded for every call so the session log stays
+			// complete; the visible row is only emitted when the event carries
+			// user-facing information (a real prompt, a denial, an explicit durable
+			// grant), not for silent auto-approvals.
+			if permissionEventIsNoteworthy(event) {
+				row := permissionTranscriptRow(event)
+				row.runID = runID
+				rows = append(rows, row)
+				m.sendAgentRow(runID, row)
+			}
 			sessionEvents = append(sessionEvents, pendingSessionEvent{
 				Type:    tuiPermissionEventType(event),
 				Payload: event,

--- a/internal/tui/plan_panel.go
+++ b/internal/tui/plan_panel.go
@@ -199,6 +199,68 @@ func (m model) renderPlanPanel(width int) string {
 	return strings.Join(lines, "\n")
 }
 
+// renderPinnedPlanPanel renders the plan for the pinned slot above the
+// composer. It returns the full panel when it fits within maxHeight, otherwise
+// a one-line summary (so a long plan can't crowd out the transcript or the
+// input). maxHeight <= 0 means "no budget" and always uses the summary line.
+// Returns "" when the plan is not visible. Ctrl+P (expand) still forces the
+// full list via m.plan.expanded, but the height budget always wins to keep the
+// composer on screen.
+func (m model) renderPinnedPlanPanel(width int, maxHeight int) string {
+	if !m.plan.visible(m.now()) {
+		return ""
+	}
+	full := m.renderPlanPanel(width)
+	if full == "" {
+		return ""
+	}
+	if maxHeight > 0 && strings.Count(full, "\n")+1 <= maxHeight {
+		return full
+	}
+	return m.renderPlanSummaryLine(width)
+}
+
+// renderPlanSummaryLine renders the collapsed one-line plan summary used when
+// the full panel won't fit the pinned slot: a spinner/check, the done/total
+// count, and the current (or first incomplete) step, truncated to width.
+func (m model) renderPlanSummaryLine(width int) string {
+	if width < 20 {
+		width = 20
+	}
+	state := m.plan
+	total := len(state.steps)
+	done := 0
+	current := ""
+	for _, step := range state.steps {
+		switch step.status {
+		case "completed", "failed":
+			done++
+		case "in_progress":
+			if current == "" {
+				current = step.content
+			}
+		}
+	}
+	if current == "" {
+		// No in-progress step: show the first not-yet-done step, else the first.
+		for _, step := range state.steps {
+			if step.status != "completed" && step.status != "failed" {
+				current = step.content
+				break
+			}
+		}
+	}
+	if state.isComplete() {
+		return zeroTheme.green.Render(fmt.Sprintf("✓ PLAN · %d/%d complete", done, total))
+	}
+	label := fmt.Sprintf("%s PLAN · %d/%d · ", m.spinner.View(), done, total)
+	room := width - len([]rune(label)) - 1
+	if room < 4 {
+		room = 4
+	}
+	return zeroTheme.accent.Render(label + truncateStep(current, room))
+}
+
 // renderPlanHeader builds the single header line. While running it shows the
 // live spinner, the truncated first step, the done/total count, and the
 // elapsed time in the accent color; once complete it shows a green check and

--- a/internal/tui/plan_panel_test.go
+++ b/internal/tui/plan_panel_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -167,5 +169,71 @@ func TestPlanPanelRenderRunning(t *testing.T) {
 	got := m.renderPlanPanel(80)
 	if got == "" {
 		t.Fatal("expected non-empty plan panel render")
+	}
+}
+
+// runningPlanModel builds a model with an n-step running plan for the pinned
+// panel tests.
+func runningPlanModel(t *testing.T, steps int) model {
+	t.Helper()
+	m := newModel(t.Context(), Options{ModelName: "gpt-4"})
+	m.width = 100
+	base := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	m.now = func() time.Time { return base.Add(15 * time.Second) }
+	items := make([]tools.PlanItem, steps)
+	for i := range items {
+		status := "pending"
+		if i == 0 {
+			status = "in_progress"
+		}
+		items[i] = tools.PlanItem{Content: fmt.Sprintf("Step number %d here", i+1), Status: status}
+	}
+	m.plan.updateFromItems(items, base)
+	return m
+}
+
+func TestPinnedPlanFullWhenItFits(t *testing.T) {
+	m := runningPlanModel(t, 3)
+	// 3 steps => header + bar + 3 lines = 5; budget 10 fits.
+	got := m.renderPinnedPlanPanel(80, 10)
+	if strings.Count(got, "\n")+1 < 5 {
+		t.Fatalf("expected full multi-line panel within budget, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Step number 1") || !strings.Contains(got, "Step number 3") {
+		t.Fatalf("full panel should list every step, got:\n%s", got)
+	}
+}
+
+func TestPinnedPlanCollapsesToSummaryWhenTooTall(t *testing.T) {
+	m := runningPlanModel(t, 12)
+	// 12 steps would be 14 lines; budget 5 forces the one-line summary.
+	got := m.renderPinnedPlanPanel(80, 5)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("over-budget plan should collapse to one line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "PLAN") {
+		t.Fatalf("summary line should still show PLAN, got:\n%s", got)
+	}
+}
+
+func TestPinnedPlanHiddenWhenEmpty(t *testing.T) {
+	m := newModel(t.Context(), Options{ModelName: "gpt-4"})
+	m.width = 100
+	if got := m.renderPinnedPlanPanel(80, 10); got != "" {
+		t.Fatalf("no plan => empty pinned render, got %q", got)
+	}
+}
+
+func TestFooterIncludesPinnedPlanAboveComposer(t *testing.T) {
+	m := runningPlanModel(t, 3)
+	m.height = 40
+	footer := plainRender(t, m.footerView(chatWidth(m.width)))
+	planIdx := strings.Index(footer, "PLAN")
+	composerIdx := strings.Index(footer, "describe a task")
+	if planIdx < 0 {
+		t.Fatalf("footer should contain the pinned plan, got:\n%s", footer)
+	}
+	if composerIdx >= 0 && planIdx > composerIdx {
+		t.Fatalf("pinned plan should render ABOVE the composer, got:\n%s", footer)
 	}
 }

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1087,7 +1087,7 @@ func (m model) renderRunningToolCard(row transcriptRow, width int, rc rowContext
 		arg = rc.args[rcKey(row.runID, row.id)]
 	}
 	head := toolCardHead(toolRowName(row), hint, arg, "", glyph, rc.auto[rcKey(row.runID, row.id)], width, opts)
-	return toolCard(head, nil, "", zeroTheme.cardRun, width)
+	return toolCard(head, glyph, nil, "", zeroTheme.cardRun, width)
 }
 
 func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts cardRenderOptions) string {
@@ -1111,7 +1111,7 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 	}
 	if collapsedFooter != "" && !row.expanded {
 		head := toolCardHead(name, rc.hints[key], rc.args[key], "", glyph, rc.auto[key], width, opts)
-		return toolCard(head, nil, collapsedFooter, borderStyle, width)
+		return toolCard(head, glyph, nil, collapsedFooter, borderStyle, width)
 	}
 	body := toolCardBody(name, rc.hints[key], row.detail, width, opts)
 	head := toolCardHead(name, rc.hints[key], rc.args[key], body.headTag, glyph, rc.auto[key], width, opts)
@@ -1119,7 +1119,7 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 	if collapsedFooter != "" && row.expanded && footer == "" {
 		footer = "▾ collapse"
 	}
-	return toolCard(head, body.lines, footer, borderStyle, width)
+	return toolCard(head, glyph, body.lines, footer, borderStyle, width)
 }
 
 // toolCardAlwaysExpands reports tools whose body is a code diff that must stay
@@ -1179,9 +1179,11 @@ func toolDisplayName(name string) string {
 	return strings.ReplaceAll(rest, "_", " ")
 }
 
-// toolCardHead composes the border-embedded head: tool name, middle-truncated
-// target (hyperlinked when it names a file), the faintest arg column, optional
-// extra tag, the auto marker, and the status glyph.
+// toolCardHead composes the card head: tool name, middle-truncated target
+// (hyperlinked when it names a file), the faintest arg column, optional extra
+// tag, and the auto marker. The status glyph is NOT included here — toolCard
+// right-aligns it on the rule line so it sits at the card's right edge instead
+// of trailing the head text.
 func toolCardHead(name string, target string, arg string, headTag string, glyph string, auto bool, width int, opts cardRenderOptions) string {
 	head := zeroTheme.toolName.Render(toolDisplayName(name))
 	if target = strings.TrimSpace(target); target != "" {
@@ -1201,54 +1203,69 @@ func toolCardHead(name string, target string, arg string, headTag string, glyph 
 	if auto {
 		head += "  " + zeroTheme.autoTag.Render("[auto]")
 	}
-	return head + "  " + glyph
+	return head
 }
 
-// toolCard draws the rounded card: head embedded in the top border, optional
-// footer embedded in the bottom border, body lines between on the panel
-// surface. Every emitted line is exactly `width` cells. On tiny terminals the
-// side borders go away (top/bottom rules stay) so content keeps the columns.
-func toolCard(head string, body []string, footer string, borderStyle lipgloss.Style, width int) string {
+// toolCard draws a left-rule card: a status-tinted "│ " rail down the left
+// edge, the head (with the status glyph right-aligned to the card edge) on the
+// first line, body lines below, and an optional footer line — no top, right, or
+// bottom borders. This matches the lighter inline style of specialist cards
+// (renderLeftRuleCard) and the reference TUIs (opencode, codex), instead of the
+// older full rounded box. Every emitted line is exactly `width` cells, and the
+// inner content budget stays width-4, so the diff/read/bash body renderers
+// (which assume width-4) need no change. On the tiny tier the rail goes away
+// (bare lines) so content keeps every column — and so a tiny card carries no
+// leading "│", matching TestTinyToolCardDropsSideBorders.
+func toolCard(head string, glyph string, body []string, footer string, borderStyle lipgloss.Style, width int) string {
 	tiny := widthTier(width) == tierTiny
 	if width < 24 {
 		width = 24
 	}
-	innerWidth := width - 4
+	rail := borderStyle.Render("│ ")
+	railWidth := 2
+	innerWidth := width - 4 // "│ " (2) + content + 2 trailing cells where the old right border sat
 	if tiny {
+		rail = ""
+		railWidth = 0
 		innerWidth = width
 	}
 
-	head = fitStyledLine(head, width-6)
-	dashes := maxInt(1, width-4-lipgloss.Width(head))
-	top := borderStyle.Render("╭ ") + head + " " + borderStyle.Render(strings.Repeat("─", dashes)+"╮")
-	if tiny {
-		top = head + " " + borderStyle.Render(strings.Repeat("─", maxInt(1, width-1-lipgloss.Width(head))))
+	// Head line: rail + head, with the status glyph right-aligned to the card
+	// edge. The glyph (and the space before it) is reserved out of the head's
+	// width budget so a long head truncates before it collides with the glyph.
+	glyphWidth := lipgloss.Width(glyph)
+	glyphGap := 0
+	if glyphWidth > 0 {
+		glyphGap = 1
 	}
+	headBudget := maxInt(1, width-railWidth-glyphWidth-glyphGap)
+	head = fitStyledLine(head, headBudget)
+	headPad := maxInt(0, width-railWidth-lipgloss.Width(head)-glyphWidth)
+	headLine := rail + head + strings.Repeat(" ", headPad) + glyph
 
 	lines := make([]string, 0, len(body)+2)
-	lines = append(lines, top)
+	lines = append(lines, headLine)
 	for _, line := range body {
 		fitted := fitStyledLine(line, innerWidth)
 		if tiny {
 			lines = append(lines, fitted)
 			continue
 		}
-		pad := zeroTheme.panel.Render(strings.Repeat(" ", maxInt(0, innerWidth-lipgloss.Width(fitted))))
-		lines = append(lines, borderStyle.Render("│ ")+fitted+pad+borderStyle.Render(" │"))
+		// Fill to the full card width (not just innerWidth) so the panel band
+		// reads as one solid block now that there is no right border; the extra
+		// two cells are bare panel background.
+		pad := zeroTheme.panel.Render(strings.Repeat(" ", maxInt(0, width-railWidth-lipgloss.Width(fitted))))
+		lines = append(lines, rail+fitted+pad)
 	}
 
-	switch {
-	case tiny && strings.TrimSpace(footer) == "":
-		lines = append(lines, borderStyle.Render(strings.Repeat("─", width)))
-	case tiny:
-		footer = fitStyledLine(footer, width-4)
-		lines = append(lines, footer+" "+borderStyle.Render(strings.Repeat("─", maxInt(1, width-1-lipgloss.Width(footer)))))
-	case strings.TrimSpace(footer) == "":
-		lines = append(lines, borderStyle.Render("╰"+strings.Repeat("─", width-2)+"╯"))
-	default:
-		footer = fitStyledLine(footer, width-6)
-		dashes = maxInt(1, width-4-lipgloss.Width(footer))
-		lines = append(lines, borderStyle.Render("╰ ")+footer+" "+borderStyle.Render(strings.Repeat("─", dashes)+"╯"))
+	if strings.TrimSpace(footer) != "" {
+		fittedFooter := fitStyledLine(footer, width-railWidth)
+		if tiny {
+			lines = append(lines, fittedFooter)
+		} else {
+			pad := zeroTheme.panel.Render(strings.Repeat(" ", maxInt(0, width-railWidth-lipgloss.Width(fittedFooter))))
+			lines = append(lines, rail+fittedFooter+pad)
+		}
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -292,6 +293,50 @@ func looksLikePath(value string) bool {
 		return false
 	}
 	return strings.Contains(value, "/") || filepath.Ext(value) != ""
+}
+
+// userHomeDir is overridable in tests; os.UserHomeDir in production.
+var userHomeDir = os.UserHomeDir
+
+// displayPath shortens an absolute path for the transcript so a tool card shows
+// `examples/calc/calc.go` instead of `D:\…\examples\calc\calc.go`. Built-in
+// tools already emit workspace-relative paths; this mainly tames MCP tools and
+// any tool that surfaces an absolute path. Display-only: never mutate the path
+// sent to a tool or stored in the session. The ladder mirrors the reference
+// agents — relative under the workspace, `~`-relative under home, else the
+// trailing segments with a `…/` prefix:
+//
+//	under cwd      → examples/calc/calc.go
+//	under $HOME    → ~/projects/zero/main.go
+//	elsewhere      → …/other/calc.go   (last displayPathTailSegments segments)
+//	already short  → returned unchanged (relative input, no separators, etc.)
+//
+// Output always uses forward slashes so it reads the same on every platform.
+const displayPathTailSegments = 3
+
+func displayPath(cwd string, p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" || !filepath.IsAbs(p) {
+		// Relative inputs (the built-in-tool common case) are already short and
+		// workspace-anchored; just normalize separators.
+		return filepath.ToSlash(p)
+	}
+	if cwd = strings.TrimSpace(cwd); cwd != "" {
+		if rel, err := filepath.Rel(cwd, p); err == nil && !strings.HasPrefix(rel, "..") && rel != "." {
+			return filepath.ToSlash(rel)
+		}
+	}
+	if home, err := userHomeDir(); err == nil && home != "" {
+		if rel, err := filepath.Rel(home, p); err == nil && !strings.HasPrefix(rel, "..") && rel != "." {
+			return "~/" + filepath.ToSlash(rel)
+		}
+	}
+	slashed := filepath.ToSlash(p)
+	segments := strings.Split(strings.Trim(slashed, "/"), "/")
+	if len(segments) <= displayPathTailSegments {
+		return slashed
+	}
+	return "…/" + strings.Join(segments[len(segments)-displayPathTailSegments:], "/")
 }
 
 // sayMeasure is the narrow prose wrap width for compact secondary text.
@@ -1100,6 +1145,15 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 		borderStyle = zeroTheme.cardErr
 	}
 	key := rcKey(row.runID, row.id)
+	// A successful call whose only output is a one-line confirmation ("Created
+	// examples/calc.go (45 bytes).", "Successfully created directory …") restates
+	// what the head already shows (action + target + ✓), so drop the body and let
+	// the card collapse to a single line — matching the reference agents' density.
+	// Only for clean OK results: errors and anything multi-line keep their body.
+	if !failed && opts.bodyCap > 0 && !toolCardAlwaysExpands(name) && looksLikeRedundantConfirmation(row.detail) {
+		head := toolCardHead(name, rc.hints[key], rc.args[key], "", glyph, rc.auto[key], width, opts)
+		return toolCard(head, glyph, nil, "", borderStyle, width)
+	}
 	// Collapse long, noisy output (web-search/MCP/read dumps) by default so the
 	// transcript stays scannable; the model still received the full output. Click
 	// the card to expand (▸ → ▾) while it is live; collapsed rows flush to
@@ -1120,6 +1174,25 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 		footer = "▾ collapse"
 	}
 	return toolCard(head, glyph, body.lines, footer, borderStyle, width)
+}
+
+// confirmationVerbPattern matches a single-line success confirmation that only
+// restates the action + target: a leading verb ("Created", "Overwrote",
+// "Successfully created directory", "Wrote", "Deleted", …) optionally followed
+// by a path/detail. Kept deliberately narrow — anything it doesn't recognize
+// keeps its body, so the worst case is the status quo, never lost output.
+var confirmationVerbPattern = regexp.MustCompile(`(?i)^(successfully\s+\w+|created|overwrote|wrote|updated|edited|deleted|removed|renamed|moved|copied|appended)\b`)
+
+// looksLikeRedundantConfirmation reports whether a tool's output is a single
+// short line that merely confirms a mutation (so the card body would just echo
+// the head). Multi-line output, or anything not starting with a known
+// confirmation verb, is NOT redundant and keeps its body.
+func looksLikeRedundantConfirmation(detail string) bool {
+	trimmed := strings.TrimSpace(detail)
+	if trimmed == "" || strings.Contains(trimmed, "\n") {
+		return false
+	}
+	return confirmationVerbPattern.MatchString(trimmed)
 }
 
 // toolCardAlwaysExpands reports tools whose body is a code diff that must stay
@@ -1187,7 +1260,13 @@ func toolDisplayName(name string) string {
 func toolCardHead(name string, target string, arg string, headTag string, glyph string, auto bool, width int, opts cardRenderOptions) string {
 	head := zeroTheme.toolName.Render(toolDisplayName(name))
 	if target = strings.TrimSpace(target); target != "" {
-		styled := zeroTheme.toolTarget.Render(middleTruncate(target, maxInt(16, width/2)))
+		// Show a shortened, workspace-relative path, but keep the hyperlink
+		// pointing at the original absolute path so the file still opens.
+		shown := target
+		if looksLikePath(target) {
+			shown = displayPath(opts.cwd, target)
+		}
+		styled := zeroTheme.toolTarget.Render(middleTruncate(shown, maxInt(16, width/2)))
 		if looksLikePath(target) {
 			styled = hyperlink(fileURL(opts.cwd, target), styled)
 		}

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -728,8 +728,13 @@ func TestRunningToolCardShowsHeadAndSpinnerSlot(t *testing.T) {
 	if !strings.Contains(got, "grep") || !strings.Contains(got, "internal/cli") {
 		t.Fatalf("running card = %q, want tool name and target in head", got)
 	}
-	if !strings.Contains(got, "╭") || !strings.Contains(got, "╰") {
-		t.Fatalf("running card = %q, want a bordered card", got)
+	// Tool cards render as a left-rule card (status-tinted "│ " rail, no box),
+	// matching specialist cards and the reference TUIs.
+	if !strings.HasPrefix(got, "│ ") {
+		t.Fatalf("running card = %q, want a left-rule card", got)
+	}
+	if strings.ContainsAny(got, "╭╮╰╯") {
+		t.Fatalf("running card = %q, must not carry box-border corners", got)
 	}
 }
 
@@ -1162,6 +1167,33 @@ func TestToolCardLinesAllSameWidth(t *testing.T) {
 		if got := len([]rune(line)); got != 60 {
 			t.Fatalf("card line width %d, want 60: %q", got, line)
 		}
+	}
+}
+
+func TestToolResultCardRendersAsLeftRule(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind:   rowToolResult,
+		id:     "c",
+		tool:   "read_file",
+		status: tools.StatusOK,
+		detail: "File: README.md\n\n1: # Zero\n2: line two",
+	}
+	card := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	lines := strings.Split(card, "\n")
+	// Every line carries the left rail; none carries a box corner or a right
+	// border — the unified left-rule card shape (matches specialist cards).
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "│ ") {
+			t.Fatalf("line %d = %q, want left-rule prefix", i, line)
+		}
+		if strings.ContainsAny(line, "╭╮╰╯") || strings.HasSuffix(line, "│") {
+			t.Fatalf("line %d = %q, must not carry box borders", i, line)
+		}
+	}
+	// The status glyph sits on the head line (first line), right-aligned.
+	if !strings.Contains(lines[0], "✓") {
+		t.Fatalf("head line = %q, want the status glyph on the rule line", lines[0])
 	}
 }
 

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -415,7 +415,12 @@ func transcriptRowsFromSessionEvents(events []sessions.Event) []transcriptRow {
 				arg:    argHintSecondary(payloadString(payload, "arguments")),
 			})
 		case sessions.EventPermission, sessions.EventPermissionRequest, sessions.EventPermissionDecision:
-			rows = append(rows, permissionTranscriptRow(permissionEventFromPayload(payload)))
+			// Mirror the live path: a silently auto-approved call recorded its
+			// audit event but rendered no row, so don't resurrect one on resume.
+			event := permissionEventFromPayload(payload)
+			if permissionEventIsNoteworthy(event) {
+				rows = append(rows, permissionTranscriptRow(event))
+			}
 		case sessions.EventToolResult:
 			name := payloadString(payload, "name")
 			if name == "" {

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -582,12 +582,13 @@ func TestResumeCommandHydratesSessionTranscript(t *testing.T) {
 	}
 	appendTestEvent(t, store, session.SessionID, sessions.EventMessage, map[string]any{"role": "user", "content": "previous request"})
 	appendTestEvent(t, store, session.SessionID, sessions.EventToolCall, map[string]any{"id": "call_1", "name": "grep", "arguments": `{"pattern":"Zero"}`})
-	appendTestEvent(t, store, session.SessionID, sessions.EventPermission, map[string]any{
+	appendTestEvent(t, store, session.SessionID, sessions.EventPermissionDecision, map[string]any{
 		"toolCallId":     "call_1",
 		"name":           "grep",
 		"action":         "allow",
+		"decisionAction": "allow",
 		"permission":     "allow",
-		"permissionMode": "auto",
+		"permissionMode": "ask",
 		"sideEffect":     "read",
 		"scope":          "src",
 		"risk":           map[string]any{"level": "low"},

--- a/internal/tui/tool_call_density_test.go
+++ b/internal/tui/tool_call_density_test.go
@@ -1,0 +1,210 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+var sandboxBlockForTest = sandbox.Block{
+	Code:     sandbox.BlockOutsideWorkspace,
+	ToolName: "write_file",
+	Action:   sandbox.ActionDeny,
+	Reason:   "writes must stay inside workspace",
+}
+
+// --- Fix 1: permissionEventIsNoteworthy ---------------------------------------
+
+func TestPermissionEventNoteworthySuppressesSilentAutoApprove(t *testing.T) {
+	// action=allow, no decisionAction → a silent auto-approve (auto mode, or a
+	// pre-granted scope that matched). Not noteworthy: the tool card speaks for it.
+	event := agent.PermissionEvent{
+		ToolName:       "mcp_filesystem_create_directory",
+		Action:         agent.PermissionActionAllow,
+		PermissionMode: agent.PermissionModeAuto,
+		GrantMatched:   true,
+	}
+	if permissionEventIsNoteworthy(event) {
+		t.Fatal("silent auto-approve should not be noteworthy")
+	}
+}
+
+func TestPermissionEventNoteworthyKeepsRealDecisions(t *testing.T) {
+	cases := []struct {
+		name  string
+		event agent.PermissionEvent
+	}{
+		{"prompt", agent.PermissionEvent{Action: agent.PermissionActionPrompt}},
+		{"deny", agent.PermissionEvent{Action: agent.PermissionActionDeny}},
+		{"cancel", agent.PermissionEvent{Action: agent.PermissionActionCancel}},
+		{"allow-once-decided", agent.PermissionEvent{Action: agent.PermissionActionAllow, DecisionAction: agent.PermissionDecisionAllow}},
+		{"always", agent.PermissionEvent{Action: agent.PermissionActionAllow, DecisionAction: agent.PermissionDecisionAlwaysAllow}},
+		{"session", agent.PermissionEvent{Action: agent.PermissionActionAllow, DecisionAction: agent.PermissionDecisionAllowForSession}},
+		{"blocked", agent.PermissionEvent{Action: agent.PermissionActionAllow, Block: &sandboxBlockForTest}},
+	}
+	for _, tc := range cases {
+		if !permissionEventIsNoteworthy(tc.event) {
+			t.Fatalf("%s: expected noteworthy permission event", tc.name)
+		}
+	}
+}
+
+// --- Fix 2+4: displayPath -----------------------------------------------------
+
+func TestDisplayPathRelativizesUnderCwd(t *testing.T) {
+	// Use a real OS-absolute path (t.TempDir is absolute on every platform) so
+	// filepath.IsAbs holds on Windows too (where "/work" is NOT absolute).
+	cwd := t.TempDir()
+	abs := filepath.Join(cwd, "examples", "calc", "calc.go")
+	if got := displayPath(cwd, abs); got != "examples/calc/calc.go" {
+		t.Fatalf("displayPath under cwd = %q, want examples/calc/calc.go", got)
+	}
+}
+
+func TestDisplayPathAbbreviatesHome(t *testing.T) {
+	home := t.TempDir()
+	restore := userHomeDir
+	userHomeDir = func() (string, error) { return home, nil }
+	defer func() { userHomeDir = restore }()
+
+	abs := filepath.Join(home, "projects", "zero", "main.go")
+	if got := displayPath(t.TempDir(), abs); got != "~/projects/zero/main.go" {
+		t.Fatalf("displayPath under home = %q, want ~/projects/zero/main.go", got)
+	}
+}
+
+func TestDisplayPathTruncatesExternalToTail(t *testing.T) {
+	// A path that is OS-absolute but under neither cwd nor home → tail segments.
+	// Build it under a temp root, then point cwd/home elsewhere so neither matches.
+	external := t.TempDir() // absolute on every platform
+	abs := filepath.Join(external, "vendor", "deep", "pkg", "calc", "calc.go")
+
+	restore := userHomeDir
+	userHomeDir = func() (string, error) { return t.TempDir(), nil } // unrelated home
+	defer func() { userHomeDir = restore }()
+
+	got := displayPath(t.TempDir(), abs) // unrelated cwd
+	if got != "…/pkg/calc/calc.go" {
+		t.Fatalf("displayPath external = %q, want …/pkg/calc/calc.go (last 3 segments)", got)
+	}
+}
+
+func TestDisplayPathLeavesRelativeInputUntouched(t *testing.T) {
+	if got := displayPath("/work/zero", "examples/calc.go"); got != "examples/calc.go" {
+		t.Fatalf("relative input = %q, want examples/calc.go", got)
+	}
+}
+
+// --- Fix 3: collapse redundant success bodies ---------------------------------
+
+func TestRedundantConfirmationCollapsesSuccessBody(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind:   rowToolResult,
+		id:     "c1",
+		tool:   "mcp_filesystem_create_directory",
+		status: tools.StatusOK,
+		detail: "Successfully created directory /work/zero/examples/calc",
+	}
+	card := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	lines := strings.Split(strings.TrimRight(card, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("redundant-confirmation card should be one line, got %d:\n%s", len(lines), card)
+	}
+	if strings.Contains(card, "Successfully created directory") {
+		t.Fatalf("confirmation body should be suppressed (head already says it), got:\n%s", card)
+	}
+}
+
+func TestRealOutputKeepsBody(t *testing.T) {
+	m := limeTestModel()
+	row := transcriptRow{
+		kind:   rowToolResult,
+		id:     "c2",
+		tool:   "grep",
+		status: tools.StatusOK,
+		detail: "internal/cli/root.go:41: fs := flag.NewFlagSet",
+	}
+	card := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if !strings.Contains(card, "flag.NewFlagSet") {
+		t.Fatalf("real grep output must NOT be suppressed, got:\n%s", card)
+	}
+}
+
+func TestErrorConfirmationKeepsBody(t *testing.T) {
+	m := limeTestModel()
+	// Even if the text looks like a confirmation verb, an error keeps its body.
+	row := transcriptRow{
+		kind:   rowToolResult,
+		id:     "c3",
+		tool:   "write_file",
+		status: tools.StatusError,
+		detail: "Created nothing — permission denied",
+	}
+	card := plainRender(t, m.renderRow(row, 80, buildRowContext(nil)))
+	if !strings.Contains(card, "permission denied") {
+		t.Fatalf("error body must be kept, got:\n%s", card)
+	}
+}
+
+// --- Fix 5: blank line between consecutive tool cards -------------------------
+
+func TestConsecutiveToolCardsAreBlankSeparated(t *testing.T) {
+	m := limeTestModel()
+	m.headerPrinted = true
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowUser, text: "go"})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{
+		kind: rowToolResult, id: "a", tool: "grep", status: tools.StatusOK,
+		detail: "internal/a.go:1: hit",
+	})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{
+		kind: rowToolResult, id: "b", tool: "grep", status: tools.StatusOK,
+		detail: "internal/b.go:2: hit",
+	})
+
+	body, _ := m.transcriptBody(96, "")
+	got := plainRender(t, body)
+	// Both cards must be present, and a blank line must sit between the end of the
+	// first card and the start of the second (the "wall" fix).
+	firstIdx := strings.Index(got, "internal/a.go")
+	secondIdx := strings.Index(got, "internal/b.go")
+	if firstIdx < 0 || secondIdx < 0 || secondIdx <= firstIdx {
+		t.Fatalf("both tool cards should render in order, got:\n%s", got)
+	}
+	between := got[firstIdx:secondIdx]
+	if !strings.Contains(between, "\n\n") {
+		t.Fatalf("expected a blank line between consecutive tool cards, got:\n%s", got)
+	}
+}
+
+// looksLikeRedundantConfirmation unit coverage (verb table + multiline guard).
+func TestLooksLikeRedundantConfirmation(t *testing.T) {
+	yes := []string{
+		"Created examples/calc.go (45 bytes).",
+		"Overwrote main.go (12 bytes).",
+		"Successfully created directory /a/b/c",
+		"Successfully wrote to notes.txt",
+		"Deleted old.txt",
+	}
+	no := []string{
+		"",
+		"File: README.md\n1: # Zero", // multi-line read
+		"internal/cli/root.go:41: fs := flag.NewSet", // grep hit
+		"3 matches found",  // not a known verb
+		"--- a/x\n+++ b/x", // diff
+	}
+	for _, s := range yes {
+		if !looksLikeRedundantConfirmation(s) {
+			t.Errorf("expected redundant confirmation: %q", s)
+		}
+	}
+	for _, s := range no {
+		if looksLikeRedundantConfirmation(s) {
+			t.Errorf("expected NOT redundant: %q", s)
+		}
+	}
+}

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -280,6 +280,41 @@ func permissionTranscriptRow(event agent.PermissionEvent) transcriptRow {
 	}
 }
 
+// permissionEventIsNoteworthy reports whether a permission event carries
+// user-facing information worth a visible transcript row. A silently
+// auto-approved call (auto mode, or a previously-granted scope that just
+// matched) is NOT noteworthy: the tool card already shows the action, target,
+// and result, so a separate "always · <tool> · target:<path>" row is pure
+// noise — the reference agents only surface approval when the user is actually
+// prompted or makes an explicit durable choice. The underlying audit event is
+// still recorded regardless (see the OnPermission handler and resume rebuild);
+// this only gates the rendered row, so the session log / `zero sessions` stay
+// complete.
+//
+// Used in BOTH the live path (model.go OnPermission) and the resume rebuild
+// (session.go) so a resumed session shows exactly the rows the live view did.
+func permissionEventIsNoteworthy(event agent.PermissionEvent) bool {
+	switch event.Action {
+	case agent.PermissionActionPrompt, agent.PermissionActionDeny, agent.PermissionActionCancel:
+		// A real prompt was shown, or the call was blocked/cancelled — always show.
+		return true
+	}
+	// A non-empty DecisionAction means the user actually decided (allow once,
+	// allow for session, always, prefix, …): the agent only sets it when a
+	// decision was made, leaving it empty for a silent auto-approve. So any real
+	// decision is worth one visible row, even a plain "allow once".
+	if strings.TrimSpace(string(event.DecisionAction)) != "" {
+		return true
+	}
+	// A safety-relevant block stays visible even if somehow allowed.
+	if event.Block != nil {
+		return true
+	}
+	// Everything else (plain auto-approve, or a pre-granted scope auto-matching)
+	// is silent — the tool card speaks for it.
+	return false
+}
+
 func permissionEventFromRequest(request agent.PermissionRequest) agent.PermissionEvent {
 	return agent.PermissionEvent{
 		ToolCallID:     request.ToolCallID,

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -137,7 +137,6 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 		rc := buildRowContext(m.transcript)
 		shownAny := false
 		previousKind, havePreviousKind := previousVisibleTranscriptKind(m.transcript, m.flushed, rc)
-		planPanelEmitted := false
 		specialistSummaryEmitted := false
 		for index := m.flushed; index < len(m.transcript); index++ {
 			row := m.transcript[index]
@@ -162,16 +161,9 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 			if shownAny && havePreviousKind && isToolCardKind(previousKind) && isToolCardKind(row.kind) {
 				items = append(items, transcriptBlankBodyItem())
 			}
-			// Inject the plan panel inline before the specialist cards, so it
-			// appears in the chat flow (not pinned at the top).
-			if row.kind == rowSpecialist && !planPanelEmitted {
-				planPanelEmitted = true
-				planPanel := m.renderPlanPanel(width)
-				if planPanel != "" {
-					items = append(items, transcriptBlockBodyItem(transcriptBodyItemRow, -1, planPanel))
-					items = append(items, transcriptBlankBodyItem())
-				}
-			}
+			// The plan panel is no longer injected inline here — it is pinned
+			// above the composer (see footerView) so a streaming turn can't push
+			// it off-screen.
 			// Inject the specialist summary line once, before the first
 			// specialist card in this turn's contiguous group.
 			if row.kind == rowSpecialist && !specialistSummaryEmitted {
@@ -211,17 +203,8 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 			previousKind = row.kind
 			havePreviousKind = true
 		}
-		// If the plan panel wasn't injected during the row loop (no specialist
-		// rows yet), inject it here so update_plan-only turns still show it.
-		if !planPanelEmitted {
-			planPanel := m.renderPlanPanel(width)
-			if planPanel != "" {
-				if shownAny || m.flushedAny {
-					items = append(items, transcriptBlankBodyItem())
-				}
-				items = append(items, transcriptBlockBodyItem(transcriptBodyItemRow, -1, planPanel))
-			}
-		}
+		// The plan panel is pinned above the composer (footerView), not injected
+		// into the scrolling body, so there is nothing to emit here anymore.
 	}
 
 	if m.pending {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -154,6 +154,14 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 			if (shownAny || (m.flushedAny && havePreviousKind)) && previousKind == rowUser && row.kind == rowReasoning {
 				items = append(items, transcriptBlankBodyItem())
 			}
+			// Breathing room between back-to-back tool cards in the same turn: a
+			// tool result collapses its call into one card, so consecutive cards
+			// would otherwise stack with no gap (the dense "wall" look). One blank
+			// line between them matches the reference agents. Turn-starters are
+			// separated above, so this only fires tool-card -> tool-card.
+			if shownAny && havePreviousKind && isToolCardKind(previousKind) && isToolCardKind(row.kind) {
+				items = append(items, transcriptBlankBodyItem())
+			}
 			// Inject the plan panel inline before the specialist cards, so it
 			// appears in the chat flow (not pinned at the top).
 			if row.kind == rowSpecialist && !planPanelEmitted {


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pinned plan panel above the composer that can expand or collapse based on available terminal height.
* **Style**
  * Redesigned tool cards to use a left-rail rule with right-aligned status glyphs, including improved target path display (shortened cwd/home-relative formatting) while keeping clickable links.
* **Bug Fixes**
  * Reduced transcript clutter by only rendering noteworthy permission decisions.
  * Prevented dense “stacking” by adding spacing between consecutive tool-card rows; improved collapsed “confirmation-only” result rendering.
* **Tests**
  * Updated and added regression coverage for tool-card layout, path shortening, redundancy collapsing, pinned-plan behavior, and spacing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->