### PR TITLE
Add managed background terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ into clean markdown locally, with no third party. For localhost/private dev-serv
 URLs, use shell commands such as `curl` through `exec_command` so sandbox network
 permission applies. For local dev servers, start the server in the foreground with
 `exec_command` and keep the returned `session_id`; use `write_stdin` to poll or
-interrupt it.
+interrupt it. Use `/ps` to list running background terminals and `/stop` or
+`/stop <session_id>` to close them. Interactive terminal-style commands can set
+`tty: true` on `exec_command` so stdin works like a terminal session.
 
 For **search**, JS-rendered scraping,
 whole-site crawls, PDF→markdown, and structured extraction, Zero ships the

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -72,8 +72,8 @@ work.
   foreground with exec_command and use write_stdin to poll or interrupt it;
   do not rely on `nohup`, `disown`, or backgrounding to keep it alive.
 - Use exec_command with `tty: true` for interactive terminal-style commands that
-  need stdin beyond Ctrl-C. Use `/ps` to inspect running background terminals and
-  `/stop` to close them.
+  need stdin beyond Ctrl-C. `/ps` and `/stop` are user-facing TUI commands; when
+  you need to clean up a running foreground command yourself, use write_stdin.
 - write_stdin with empty input polls an existing exec_command session, and
   `\u0003` interrupts it. Sending other stdin bytes may require approval because
   it can drive the running process beyond the original command.

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -76,7 +76,9 @@ work.
   you need to clean up a running foreground command yourself, use write_stdin.
 - write_stdin with empty input polls an existing exec_command session, and
   `\u0003` interrupts it. Sending other stdin bytes may require approval because
-  it can drive the running process beyond the original command.
+  it can drive the running process beyond the original command. Non-tty sessions
+  accept only empty polling and interrupt/stop input; start with `tty: true`
+  when you need to send literal stdin such as prompts, menu choices, or REPL text.
 - bash is the legacy one-shot shell tool. Prefer exec_command for new shell
   work, especially for local dev servers.
 - Treat tool output as ground truth. If a command fails, read the error, form a

--- a/internal/agent/system_prompt.md
+++ b/internal/agent/system_prompt.md
@@ -71,6 +71,9 @@ work.
   package managers). If a command needs to keep running, run it in the
   foreground with exec_command and use write_stdin to poll or interrupt it;
   do not rely on `nohup`, `disown`, or backgrounding to keep it alive.
+- Use exec_command with `tty: true` for interactive terminal-style commands that
+  need stdin beyond Ctrl-C. Use `/ps` to inspect running background terminals and
+  `/stop` to close them.
 - write_stdin with empty input polls an existing exec_command session, and
   `\u0003` interrupts it. Sending other stdin bytes may require approval because
   it can drive the running process beyond the original command.

--- a/internal/sandbox/linux_helper_test.go
+++ b/internal/sandbox/linux_helper_test.go
@@ -128,6 +128,39 @@ func TestBuildLinuxSandboxBwrapArgsWrapsInnerSeccompStage(t *testing.T) {
 	}
 }
 
+func TestBuildLinuxSandboxBwrapArgsKeepsHostNetworkWhenAllowed(t *testing.T) {
+	helperPath := filepath.Join(t.TempDir(), LinuxSandboxHelperName)
+	if err := os.WriteFile(helperPath, []byte("helper"), 0o755); err != nil {
+		t.Fatalf("WriteFile helper: %v", err)
+	}
+	profile := DefaultPermissionProfile("/workspace")
+	profile.Network = NetworkPolicy{Mode: NetworkAllow}
+	args, err := BuildLinuxSandboxCommandArgs(LinuxSandboxCommandArgsOptions{
+		SandboxPolicyCWD:  "/workspace",
+		PermissionProfile: profile,
+		BlockUnixSockets:  true,
+		Command:           []string{"python3", "-m", "http.server", "8000"},
+	})
+	if err != nil {
+		t.Fatalf("BuildLinuxSandboxCommandArgs: %v", err)
+	}
+	config, err := ParseLinuxSandboxHelperArgs(args)
+	if err != nil {
+		t.Fatalf("ParseLinuxSandboxHelperArgs: %v", err)
+	}
+	bwrapArgs, err := BuildLinuxSandboxBwrapArgs(LinuxSandboxBwrapOptions{
+		Config:     config,
+		HelperPath: helperPath,
+	})
+	if err != nil {
+		t.Fatalf("BuildLinuxSandboxBwrapArgs: %v", err)
+	}
+	if indexString(bwrapArgs, "--unshare-net") >= 0 {
+		t.Fatalf("network-allowed bwrap args must not isolate loopback: %#v", bwrapArgs)
+	}
+	assertArgsContainSequence(t, bwrapArgs, "--setenv", "ZERO_SANDBOX_NETWORK", string(NetworkAllow))
+}
+
 func indexString(values []string, want string) int {
 	for index, value := range values {
 		if value == want {

--- a/internal/tools/bash_proc_windows.go
+++ b/internal/tools/bash_proc_windows.go
@@ -4,6 +4,7 @@ package tools
 
 import (
 	"os/exec"
+	"strconv"
 	"time"
 )
 
@@ -13,10 +14,17 @@ import (
 // tests can shorten it.
 var bashWaitDelay = 2 * time.Second
 
-// hardenProcessLifetime sets WaitDelay so a leaked child cannot block Wait
-// indefinitely. Windows lacks POSIX process groups; tree-killing the shell's
-// descendants (taskkill /T) is not wired for the synchronous bash path, so the
-// default Cancel (Process.Kill on the shell) plus WaitDelay is used.
+// hardenProcessLifetime makes a Windows shell command killable as a process
+// tree. cmd.exe starts helper commands as child processes, so killing only the
+// shell can leave a long-running child alive and holding cwd/temp handles after
+// Zero exits.
 func hardenProcessLifetime(command *exec.Cmd) {
 	command.WaitDelay = bashWaitDelay
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		_ = exec.Command("taskkill.exe", "/T", "/F", "/PID", strconv.Itoa(command.Process.Pid)).Run()
+		return nil
+	}
 }

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -28,6 +28,8 @@ const (
 	completedSessionRetention = 30 * time.Second
 	maxExecSessions           = 64
 	recentExecOutputBytes     = 4096
+	execSessionStopTimeout    = 3 * time.Second
+	execSessionEvictedMessage = "[zero] session evicted: too many background terminals\n"
 )
 
 type execSessionManager struct {
@@ -60,15 +62,20 @@ func (manager *execSessionManager) allocateID() int {
 func (manager *execSessionManager) store(session *execSession) {
 	manager.mu.Lock()
 	var pruned *execSession
+	removePruned := false
 	if manager.maxSessions > 0 && len(manager.sessions) >= manager.maxSessions {
 		pruned = manager.sessionToPruneLocked()
 		if pruned != nil {
-			delete(manager.sessions, pruned.id)
+			removePruned = pruned.doneClosed()
+			if removePruned {
+				delete(manager.sessions, pruned.id)
+			}
 		}
 	}
 	manager.sessions[session.id] = session
 	manager.mu.Unlock()
-	if pruned != nil {
+	if pruned != nil && !removePruned {
+		pruned.output.Write([]byte(execSessionEvictedMessage))
 		pruned.terminate()
 	}
 }
@@ -169,8 +176,34 @@ func (manager *execSessionManager) stopAll() []int {
 		session.terminate()
 		ids = append(ids, session.id)
 	}
+	waitForExecSessions(sessions, execSessionStopTimeout)
 	sort.Ints(ids)
 	return ids
+}
+
+func waitForExecSessions(sessions []*execSession, timeout time.Duration) {
+	if timeout <= 0 || len(sessions) == 0 {
+		return
+	}
+	deadline := time.Now().Add(timeout)
+	for _, session := range sessions {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return
+		}
+		timer := time.NewTimer(remaining)
+		select {
+		case <-session.done:
+		case <-timer.C:
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}
 }
 
 type ExecSessionSnapshot struct {

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os/exec"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +26,8 @@ const (
 	defaultMaxOutputTokens    = 10000
 	maxExecOutputTokenRequest = 200000
 	completedSessionRetention = 30 * time.Second
+	maxExecSessions           = 64
+	recentExecOutputBytes     = 4096
 )
 
 type execSessionManager struct {
@@ -32,6 +35,7 @@ type execSessionManager struct {
 	nextID             int
 	sessions           map[int]*execSession
 	completedRetention time.Duration
+	maxSessions        int
 }
 
 func newExecSessionManager() *execSessionManager {
@@ -39,6 +43,7 @@ func newExecSessionManager() *execSessionManager {
 		nextID:             1000,
 		sessions:           make(map[int]*execSession),
 		completedRetention: completedSessionRetention,
+		maxSessions:        maxExecSessions,
 	}
 }
 
@@ -54,8 +59,18 @@ func (manager *execSessionManager) allocateID() int {
 
 func (manager *execSessionManager) store(session *execSession) {
 	manager.mu.Lock()
-	defer manager.mu.Unlock()
+	var pruned *execSession
+	if manager.maxSessions > 0 && len(manager.sessions) >= manager.maxSessions {
+		pruned = manager.sessionToPruneLocked()
+		if pruned != nil {
+			delete(manager.sessions, pruned.id)
+		}
+	}
 	manager.sessions[session.id] = session
+	manager.mu.Unlock()
+	if pruned != nil {
+		pruned.terminate()
+	}
 }
 
 func (manager *execSessionManager) get(id int) (*execSession, bool) {
@@ -89,16 +104,107 @@ func (manager *execSessionManager) len() int {
 	return len(manager.sessions)
 }
 
+func (manager *execSessionManager) sessionToPruneLocked() *execSession {
+	if len(manager.sessions) == 0 {
+		return nil
+	}
+	sessions := make([]*execSession, 0, len(manager.sessions))
+	for _, session := range manager.sessions {
+		sessions = append(sessions, session)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].lastUsedAt.Before(sessions[j].lastUsedAt)
+	})
+	for _, session := range sessions {
+		if session.doneClosed() {
+			return session
+		}
+	}
+	if len(sessions) <= 8 {
+		return nil
+	}
+	return sessions[0]
+}
+
+func (manager *execSessionManager) list() []ExecSessionSnapshot {
+	manager.mu.Lock()
+	sessions := make([]*execSession, 0, len(manager.sessions))
+	for _, session := range manager.sessions {
+		if !session.doneClosed() {
+			sessions = append(sessions, session)
+		}
+	}
+	manager.mu.Unlock()
+
+	snapshots := make([]ExecSessionSnapshot, 0, len(sessions))
+	for _, session := range sessions {
+		snapshots = append(snapshots, session.snapshot())
+	}
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].ID < snapshots[j].ID
+	})
+	return snapshots
+}
+
+func (manager *execSessionManager) stop(id int) bool {
+	session, ok := manager.get(id)
+	if !ok {
+		return false
+	}
+	session.terminate()
+	return true
+}
+
+func (manager *execSessionManager) stopAll() []int {
+	manager.mu.Lock()
+	sessions := make([]*execSession, 0, len(manager.sessions))
+	for _, session := range manager.sessions {
+		if !session.doneClosed() {
+			sessions = append(sessions, session)
+		}
+	}
+	manager.mu.Unlock()
+	ids := make([]int, 0, len(sessions))
+	for _, session := range sessions {
+		session.terminate()
+		ids = append(ids, session.id)
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+type ExecSessionSnapshot struct {
+	ID           int
+	Command      string
+	Cwd          string
+	RelativeCwd  string
+	StartedAt    time.Time
+	LastUsedAt   time.Time
+	TTY          bool
+	Status       string
+	ExitCode     *int
+	RecentOutput string
+}
+
+type ExecSessionController interface {
+	ExecSessions() []ExecSessionSnapshot
+	StopExecSession(id int) bool
+	StopAllExecSessions() []int
+}
+
 type execSession struct {
 	id          int
 	commandText string
 	cwd         string
 	relativeCwd string
 	startedAt   time.Time
+	lastUsedAt  time.Time
+	tty         bool
 	command     *exec.Cmd
 	plan        zeroSandbox.CommandPlan
 	cancel      context.CancelFunc
 	stdin       io.WriteCloser
+	cleanup     func()
 	output      *execOutputBuffer
 
 	doneOnce sync.Once
@@ -134,15 +240,51 @@ func (session *execSession) exitStatus() (int, bool) {
 	return *session.exitCode, true
 }
 
+func (session *execSession) touch() {
+	session.mu.Lock()
+	session.lastUsedAt = time.Now()
+	session.mu.Unlock()
+}
+
 func (session *execSession) terminate() {
 	if session.cancel != nil {
 		session.cancel()
 	}
 }
 
+func (session *execSession) snapshot() ExecSessionSnapshot {
+	session.mu.Lock()
+	startedAt := session.startedAt
+	lastUsedAt := session.lastUsedAt
+	exitCode := session.exitCode
+	var copiedExit *int
+	if exitCode != nil {
+		value := *exitCode
+		copiedExit = &value
+	}
+	session.mu.Unlock()
+	status := "running"
+	if copiedExit != nil {
+		status = "exited"
+	}
+	return ExecSessionSnapshot{
+		ID:           session.id,
+		Command:      session.commandText,
+		Cwd:          session.cwd,
+		RelativeCwd:  session.relativeCwd,
+		StartedAt:    startedAt,
+		LastUsedAt:   lastUsedAt,
+		TTY:          session.tty,
+		Status:       status,
+		ExitCode:     copiedExit,
+		RecentOutput: session.output.recentString(),
+	}
+}
+
 type execOutputBuffer struct {
 	mu     sync.Mutex
 	data   []byte
+	recent []byte
 	notify chan struct{}
 }
 
@@ -153,12 +295,22 @@ func newExecOutputBuffer() *execOutputBuffer {
 func (buffer *execOutputBuffer) Write(p []byte) (int, error) {
 	buffer.mu.Lock()
 	buffer.data = append(buffer.data, p...)
+	buffer.recent = append(buffer.recent, p...)
+	if len(buffer.recent) > recentExecOutputBytes {
+		buffer.recent = buffer.recent[len(buffer.recent)-recentExecOutputBytes:]
+	}
 	buffer.mu.Unlock()
 	select {
 	case buffer.notify <- struct{}{}:
 	default:
 	}
 	return len(p), nil
+}
+
+func (buffer *execOutputBuffer) recentString() string {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return string(buffer.recent)
 }
 
 func (buffer *execOutputBuffer) drainString() string {
@@ -201,6 +353,7 @@ func NewScopedExecCommandTool(workspaceRoot string, scope PathScope, manager *ex
 					"yield_time_ms":     {Type: "integer", Description: "Wait before yielding output. If the command is still running after this, the result includes session_id.", Default: defaultExecYieldTimeMS, Minimum: intPtr(1), Maximum: intPtr(maxExecYieldTimeMS)},
 					"max_output_tokens": {Type: "integer", Description: "Output token budget. Defaults to 10000; larger requests may be capped.", Default: defaultMaxOutputTokens, Minimum: intPtr(1), Maximum: intPtr(maxExecOutputTokenRequest)},
 					"prefix_rule":       {Type: "array", Items: &PropertySchema{Type: "string"}, Description: "Optional reusable approval prefix for this command, for example [\"git\", \"status\"]. Only simple command prefixes are accepted."},
+					"tty":               {Type: "boolean", Description: "Run the command attached to a pseudo-terminal when supported. Use this for interactive terminal-style programs; defaults to false.", Default: false},
 				},
 				Required:             []string{"cmd"},
 				AdditionalProperties: false,
@@ -221,6 +374,18 @@ func (tool execCommandTool) RunWithSandbox(ctx context.Context, args map[string]
 	return tool.run(ctx, args, engine)
 }
 
+func (tool execCommandTool) ExecSessions() []ExecSessionSnapshot {
+	return tool.manager.list()
+}
+
+func (tool execCommandTool) StopExecSession(id int) bool {
+	return tool.manager.stop(id)
+}
+
+func (tool execCommandTool) StopAllExecSessions() []int {
+	return tool.manager.stopAll()
+}
+
 func (tool execCommandTool) run(ctx context.Context, args map[string]any, engine *zeroSandbox.Engine) Result {
 	commandText, err := aliasedStringArg(args, []string{"cmd", "command", "script", "shell"}, "", true, false)
 	if err != nil {
@@ -238,6 +403,10 @@ func (tool execCommandTool) run(ctx context.Context, args map[string]any, engine
 	if err != nil {
 		return errorResult("Error: Invalid arguments for exec_command: " + err.Error())
 	}
+	ttyRequested, err := boolArg(args, "tty", false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for exec_command: " + err.Error())
+	}
 	if issue := detectShellCommandIssue(commandText, runtimeGOOS()); issue != nil {
 		return shellIssueBlockResult(*issue)
 	}
@@ -249,7 +418,7 @@ func (tool execCommandTool) run(ctx context.Context, args map[string]any, engine
 		return errorResult("Error running exec_command: " + err.Error())
 	}
 
-	session, err := tool.startSession(commandText, absoluteCwd, relativeCwd, engine)
+	session, err := tool.startSession(commandText, absoluteCwd, relativeCwd, ttyRequested, engine)
 	if err != nil {
 		return errorResult("Error starting exec_command: " + err.Error())
 	}
@@ -269,12 +438,13 @@ func (tool execCommandTool) run(ctx context.Context, args map[string]any, engine
 		exitCode:        exitCode,
 		exited:          exited,
 		relativeCwd:     relativeCwd,
+		tty:             session.tty,
 		plan:            session.plan,
 		maxOutputTokens: maxOutputTokens,
 	})
 }
 
-func (tool execCommandTool) startSession(commandText string, absoluteCwd string, relativeCwd string, engine *zeroSandbox.Engine) (*execSession, error) {
+func (tool execCommandTool) startSession(commandText string, absoluteCwd string, relativeCwd string, ttyRequested bool, engine *zeroSandbox.Engine) (*execSession, error) {
 	id := tool.manager.allocateID()
 	commandCtx, cancel := context.WithCancel(context.Background())
 	command, plan, err := buildBashCommand(commandCtx, commandText, absoluteCwd, engine)
@@ -282,18 +452,10 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 		cancel()
 		return nil, err
 	}
-	stdin, err := command.StdinPipe()
-	if err != nil {
-		plan.Cleanup()
-		cancel()
-		return nil, err
-	}
 	output := newExecOutputBuffer()
-	command.Stdout = output
-	command.Stderr = output
-	hardenProcessLifetime(command)
 	monitor := zeroSandbox.StartDenialMonitor(context.Background(), plan.MonitorTag)
-	if err := command.Start(); err != nil {
+	stdin, tty, cleanup, err := startExecProcess(command, output, ttyRequested)
+	if err != nil {
 		_ = monitor.Stop()
 		plan.Cleanup()
 		cancel()
@@ -305,10 +467,13 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 		cwd:         absoluteCwd,
 		relativeCwd: relativeCwd,
 		startedAt:   time.Now(),
+		lastUsedAt:  time.Now(),
+		tty:         tty,
 		command:     command,
 		plan:        plan,
 		cancel:      cancel,
 		stdin:       stdin,
+		cleanup:     cleanup,
 		output:      output,
 		done:        make(chan struct{}),
 	}
@@ -318,6 +483,9 @@ func (tool execCommandTool) startSession(commandText string, absoluteCwd string,
 		err := command.Wait()
 		if blocks := monitor.Stop(); len(blocks) > 0 {
 			output.Write([]byte(appendSandboxBlocks("", blocks)))
+		}
+		if session.cleanup != nil {
+			session.cleanup()
 		}
 		plan.Cleanup()
 		cancel()
@@ -452,9 +620,12 @@ func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]a
 	if !ok {
 		return errorResult(fmt.Sprintf("Error: Unknown exec session_id %d.", sessionID))
 	}
+	session.touch()
 	if chars != "" {
 		if chars == "\x03" {
 			session.terminate()
+		} else if !session.tty {
+			return errorResult(fmt.Sprintf("Error: exec session_id %d does not accept stdin; start the command with tty=true for interactive input.", sessionID))
 		} else if session.stdin != nil {
 			if _, err := io.WriteString(session.stdin, chars); err != nil && !session.doneClosed() {
 				return errorResult("Error writing to exec session: " + err.Error())
@@ -473,6 +644,7 @@ func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]a
 		exitCode:        exitCode,
 		exited:          exited,
 		relativeCwd:     session.relativeCwd,
+		tty:             session.tty,
 		plan:            session.plan,
 		maxOutputTokens: maxOutputTokens,
 	})
@@ -485,6 +657,7 @@ type execToolResultInput struct {
 	exitCode        int
 	exited          bool
 	relativeCwd     string
+	tty             bool
 	plan            zeroSandbox.CommandPlan
 	maxOutputTokens int
 }
@@ -493,6 +666,7 @@ func execToolResult(input execToolResultInput) Result {
 	output, truncated := truncateExecOutput(input.output, input.maxOutputTokens)
 	meta := map[string]string{
 		"cwd": input.relativeCwd,
+		"tty": strconv.FormatBool(input.tty),
 	}
 	addSandboxMeta(meta, input.plan)
 	if input.exited {

--- a/internal/tools/exec_command.go
+++ b/internal/tools/exec_command.go
@@ -600,6 +600,9 @@ func (tool writeStdinTool) Run(ctx context.Context, args map[string]any) Result 
 }
 
 func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]any, _ RunOptions) Result {
+	if value, ok := args["session_id"]; !ok || value == nil {
+		return errorResult("Error: Invalid arguments for write_stdin: session_id is required")
+	}
 	sessionID, err := intArg(args, "session_id", 0, 1, 0)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for write_stdin: " + err.Error())
@@ -621,11 +624,13 @@ func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]a
 		return errorResult(fmt.Sprintf("Error: Unknown exec session_id %d.", sessionID))
 	}
 	session.touch()
+	interrupted := false
 	if chars != "" {
-		if chars == "\x03" {
+		if shouldInterruptExecSession(chars, session.tty) {
+			interrupted = true
 			session.terminate()
 		} else if !session.tty {
-			return errorResult(fmt.Sprintf("Error: exec session_id %d does not accept stdin; start the command with tty=true for interactive input.", sessionID))
+			return errorResult(fmt.Sprintf("Error: exec session_id %d does not accept stdin. Use empty chars to poll, or send chars \"\\u0003\" to interrupt/stop it.", sessionID))
 		} else if session.stdin != nil {
 			if _, err := io.WriteString(session.stdin, chars); err != nil && !session.doneClosed() {
 				return errorResult("Error writing to exec session: " + err.Error())
@@ -645,9 +650,30 @@ func (tool writeStdinTool) RunWithOptions(ctx context.Context, args map[string]a
 		exited:          exited,
 		relativeCwd:     session.relativeCwd,
 		tty:             session.tty,
+		interrupted:     interrupted,
 		plan:            session.plan,
 		maxOutputTokens: maxOutputTokens,
 	})
+}
+
+func shouldInterruptExecSession(chars string, tty bool) bool {
+	if strings.Contains(chars, "\x03") {
+		return true
+	}
+	normalized := strings.ToLower(strings.TrimSpace(chars))
+	normalizedNoSpace := strings.ReplaceAll(normalized, " ", "")
+	switch normalizedNoSpace {
+	case `\u0003`, `\\u0003`, `\x03`, `\\x03`, "^c", "ctrl-c", "control-c", "sigint", "interrupt":
+		return true
+	}
+	if tty {
+		return false
+	}
+	switch normalized {
+	case "q", "quit", "exit", "stop", "kill", "terminate":
+		return true
+	}
+	return false
 }
 
 type execToolResultInput struct {
@@ -658,6 +684,7 @@ type execToolResultInput struct {
 	exited          bool
 	relativeCwd     string
 	tty             bool
+	interrupted     bool
 	plan            zeroSandbox.CommandPlan
 	maxOutputTokens int
 }
@@ -671,15 +698,18 @@ func execToolResult(input execToolResultInput) Result {
 	addSandboxMeta(meta, input.plan)
 	if input.exited {
 		meta["exit_code"] = strconv.Itoa(input.exitCode)
+		if input.interrupted {
+			meta["interrupted"] = "true"
+		}
 	} else {
 		meta["session_id"] = strconv.Itoa(input.sessionID)
 	}
 
 	status := StatusOK
-	if input.exited && input.exitCode != 0 {
+	if input.exited && input.exitCode != 0 && !input.interrupted {
 		status = StatusError
 	}
-	body := formatExecCommandOutput(output, input.sessionID, input.exited, input.exitCode)
+	body := formatExecCommandOutput(output, input.sessionID, input.exited, input.exitCode, input.interrupted)
 	return Result{
 		Status:    status,
 		Output:    body,
@@ -692,7 +722,7 @@ func execToolResult(input execToolResultInput) Result {
 	}
 }
 
-func formatExecCommandOutput(output string, sessionID int, exited bool, exitCode int) string {
+func formatExecCommandOutput(output string, sessionID int, exited bool, exitCode int, interrupted bool) string {
 	output = strings.TrimRight(output, "\r\n")
 	parts := []string{}
 	if output != "" {
@@ -700,7 +730,14 @@ func formatExecCommandOutput(output string, sessionID int, exited bool, exitCode
 	}
 	if exited {
 		if output == "" {
-			parts = append(parts, "Command completed with no output.")
+			if interrupted {
+				parts = append(parts, "Command interrupted.")
+			} else {
+				parts = append(parts, "Command completed with no output.")
+			}
+		}
+		if interrupted {
+			parts = append(parts, "interrupted: true")
 		}
 		parts = append(parts, fmt.Sprintf("exit_code: %d", exitCode))
 	} else {
@@ -708,7 +745,7 @@ func formatExecCommandOutput(output string, sessionID int, exited bool, exitCode
 			parts = append(parts, "Command is still running.")
 		}
 		parts = append(parts, fmt.Sprintf("session_id: %d", sessionID))
-		parts = append(parts, fmt.Sprintf("Use write_stdin with session_id %d to poll, send input, or interrupt it.", sessionID))
+		parts = append(parts, fmt.Sprintf("Use write_stdin with session_id %d and empty chars to poll; send chars \"\\u0003\" to interrupt/stop it.", sessionID))
 	}
 	return strings.Join(parts, "\n")
 }

--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -201,6 +202,110 @@ func TestWriteStdinInterruptTerminatesSession(t *testing.T) {
 	}
 	if interrupted.Meta["exit_code"] == "" {
 		t.Fatalf("interrupted session should report exit_code, meta=%#v output=%q", interrupted.Meta, interrupted.Output)
+	}
+}
+
+func TestWriteStdinRejectsInputForNonTTYSession(t *testing.T) {
+	root := t.TempDir()
+	manager := newExecSessionManager()
+	execTool := NewScopedExecCommandTool(root, nil, manager)
+	writeTool := NewWriteStdinTool(manager)
+
+	start := execTool.Run(context.Background(), map[string]any{
+		"cmd":           helperCommand("long-sleep"),
+		"yield_time_ms": 10,
+	})
+	if start.Status != StatusOK {
+		t.Fatalf("exec_command start status = %s: %s", start.Status, start.Output)
+	}
+	sessionID, err := strconv.Atoi(start.Meta["session_id"])
+	if err != nil {
+		t.Fatalf("session_id is not numeric: %v", err)
+	}
+
+	result := writeTool.Run(context.Background(), map[string]any{
+		"session_id":    sessionID,
+		"chars":         "hello\n",
+		"yield_time_ms": 10,
+	})
+	if result.Status != StatusError {
+		t.Fatalf("write_stdin status = %s, want error", result.Status)
+	}
+	if !strings.Contains(result.Output, "does not accept stdin") {
+		t.Fatalf("unexpected output: %q", result.Output)
+	}
+	manager.stop(sessionID)
+}
+
+func TestExecCommandTTYSessionAcceptsInputOnLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("pty transport is currently implemented for linux")
+	}
+	root := t.TempDir()
+	manager := newExecSessionManager()
+	execTool := NewScopedExecCommandTool(root, nil, manager)
+	writeTool := NewWriteStdinTool(manager)
+
+	start := execTool.Run(context.Background(), map[string]any{
+		"cmd":           "read line; echo got:$line",
+		"tty":           true,
+		"yield_time_ms": 10,
+	})
+	if start.Status != StatusOK {
+		t.Fatalf("exec_command start status = %s: %s", start.Status, start.Output)
+	}
+	if start.Meta["tty"] != "true" {
+		t.Fatalf("expected tty metadata, got %#v output=%q", start.Meta, start.Output)
+	}
+	sessionID, err := strconv.Atoi(start.Meta["session_id"])
+	if err != nil {
+		t.Fatalf("session_id is not numeric: %v", err)
+	}
+
+	result := writeTool.Run(context.Background(), map[string]any{
+		"session_id":    sessionID,
+		"chars":         "hello\n",
+		"yield_time_ms": 1000,
+	})
+	if result.Status != StatusOK {
+		t.Fatalf("write_stdin status = %s: %s", result.Status, result.Output)
+	}
+	if !strings.Contains(result.Output, "got:hello") {
+		t.Fatalf("expected PTY input output, got %q", result.Output)
+	}
+	if result.Meta["exit_code"] != "0" {
+		t.Fatalf("expected exited session, got meta=%#v output=%q", result.Meta, result.Output)
+	}
+}
+
+func TestExecSessionSnapshotsAndStopAll(t *testing.T) {
+	root := t.TempDir()
+	manager := newExecSessionManager()
+	execTool := NewScopedExecCommandTool(root, nil, manager).(execCommandTool)
+
+	start := execTool.Run(context.Background(), map[string]any{
+		"cmd":           helperCommand("long-sleep"),
+		"yield_time_ms": 10,
+	})
+	if start.Status != StatusOK {
+		t.Fatalf("exec_command start status = %s: %s", start.Status, start.Output)
+	}
+	sessionID, err := strconv.Atoi(start.Meta["session_id"])
+	if err != nil {
+		t.Fatalf("session_id is not numeric: %v", err)
+	}
+
+	snapshots := execTool.ExecSessions()
+	if len(snapshots) != 1 {
+		t.Fatalf("expected one session snapshot, got %#v", snapshots)
+	}
+	if snapshots[0].ID != sessionID || snapshots[0].Command == "" || snapshots[0].Status != "running" {
+		t.Fatalf("unexpected snapshot: %#v", snapshots[0])
+	}
+
+	stopped := execTool.StopAllExecSessions()
+	if len(stopped) != 1 || stopped[0] != sessionID {
+		t.Fatalf("StopAllExecSessions = %#v, want [%d]", stopped, sessionID)
 	}
 }
 

--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -2,10 +2,14 @@ package tools
 
 import (
 	"context"
+	"errors"
+	"io"
 	"os"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -129,6 +133,121 @@ func TestExecCommandReapsFinishedUnpolledSession(t *testing.T) {
 			t.Fatalf("session %d was not reaped; manager has %d sessions", sessionID, manager.len())
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestStopAllWaitsForSessionsToExit(t *testing.T) {
+	manager := newExecSessionManager()
+	release := make(chan struct{})
+	returned := make(chan struct{})
+	cancelled := make(chan struct{})
+	session := &execSession{
+		id:     1000,
+		output: newExecOutputBuffer(),
+		done:   make(chan struct{}),
+	}
+	session.cancel = func() {
+		close(cancelled)
+		go func() {
+			<-release
+			session.markDone(nil, -1)
+		}()
+	}
+	manager.sessions[session.id] = session
+
+	go func() {
+		manager.stopAll()
+		close(returned)
+	}()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("stopAll did not terminate the session")
+	}
+	select {
+	case <-returned:
+		t.Fatal("stopAll returned before session.done closed")
+	default:
+	}
+	close(release)
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("stopAll did not return after session.done closed")
+	}
+}
+
+func TestStoreEvictsLiveSessionWithExplanation(t *testing.T) {
+	manager := newExecSessionManager()
+	manager.maxSessions = 9
+	evicted := &execSession{
+		id:         1000,
+		startedAt:  time.Unix(1000, 0),
+		lastUsedAt: time.Unix(1000, 0),
+		output:     newExecOutputBuffer(),
+		done:       make(chan struct{}),
+	}
+	evictedDone := make(chan struct{})
+	evicted.cancel = func() { close(evictedDone) }
+	manager.sessions[evicted.id] = evicted
+	for id := 1001; id <= 1008; id++ {
+		manager.sessions[id] = &execSession{
+			id:         id,
+			startedAt:  time.Unix(int64(id), 0),
+			lastUsedAt: time.Unix(int64(id), 0),
+			output:     newExecOutputBuffer(),
+			done:       make(chan struct{}),
+		}
+	}
+
+	manager.store(&execSession{
+		id:         1009,
+		startedAt:  time.Unix(1009, 0),
+		lastUsedAt: time.Unix(1009, 0),
+		output:     newExecOutputBuffer(),
+		done:       make(chan struct{}),
+	})
+
+	select {
+	case <-evictedDone:
+	case <-time.After(time.Second):
+		t.Fatal("live pruned session was not terminated")
+	}
+	if got := evicted.output.recentString(); !strings.Contains(got, "session evicted") {
+		t.Fatalf("evicted session output = %q, want explanation", got)
+	}
+	if _, ok := manager.get(evicted.id); !ok {
+		t.Fatal("evicted live session should remain visible until its reaper removes it")
+	}
+}
+
+func TestStartExecProcessFallsBackAfterPTYStartMutation(t *testing.T) {
+	original := startPTYProcessFunc
+	t.Cleanup(func() { startPTYProcessFunc = original })
+	startPTYProcessFunc = func(command *exec.Cmd, _ *execOutputBuffer) (io.WriteCloser, func(), error) {
+		command.SysProcAttr = &syscall.SysProcAttr{}
+		command.Cancel = func() error { return nil }
+		command.WaitDelay = time.Second
+		return nil, nil, errors.New("pty start failed")
+	}
+
+	command := exec.CommandContext(context.Background(), os.Args[0], "--zero-bash-helper", "success")
+	output := newExecOutputBuffer()
+	stdin, tty, cleanup, err := startExecProcess(command, output, true)
+	if err != nil {
+		t.Fatalf("startExecProcess fallback failed: %v", err)
+	}
+	if tty {
+		t.Fatal("fallback process must report tty=false")
+	}
+	_ = stdin.Close()
+	if err := command.Wait(); err != nil {
+		t.Fatalf("fallback command wait failed: %v", err)
+	}
+	cleanup()
+	if got := output.drainString(); !strings.Contains(got, "hello from bash") {
+		t.Fatalf("fallback output = %q", got)
 	}
 }
 
@@ -281,6 +400,38 @@ func TestWriteStdinStopIntentTerminatesNonTTYSession(t *testing.T) {
 		}
 		if result.Meta["interrupted"] != "true" {
 			t.Fatalf("stop input %q should report interrupted metadata, meta=%#v output=%q", chars, result.Meta, result.Output)
+		}
+	}
+}
+
+func TestShouldInterruptExecSession(t *testing.T) {
+	cases := []struct {
+		chars string
+		tty   bool
+		want  bool
+	}{
+		{chars: "\x03", tty: false, want: true},
+		{chars: `\u0003`, tty: false, want: true},
+		{chars: `\\u0003`, tty: false, want: true},
+		{chars: "^C", tty: false, want: true},
+		{chars: "ctrl-c", tty: false, want: true},
+		{chars: "control-c", tty: false, want: true},
+		{chars: "sigint", tty: false, want: true},
+		{chars: "interrupt", tty: false, want: true},
+		{chars: "q", tty: false, want: true},
+		{chars: "quit", tty: false, want: true},
+		{chars: "exit\n", tty: false, want: true},
+		{chars: "stop", tty: false, want: true},
+		{chars: "kill", tty: false, want: true},
+		{chars: "terminate", tty: false, want: true},
+		{chars: "exit\n", tty: true, want: false},
+		{chars: "quit", tty: true, want: false},
+		{chars: "hello\n", tty: false, want: false},
+		{chars: "hello\n", tty: true, want: false},
+	}
+	for _, tc := range cases {
+		if got := shouldInterruptExecSession(tc.chars, tc.tty); got != tc.want {
+			t.Fatalf("shouldInterruptExecSession(%q, tty=%v) = %v, want %v", tc.chars, tc.tty, got, tc.want)
 		}
 	}
 }

--- a/internal/tools/exec_command_test.go
+++ b/internal/tools/exec_command_test.go
@@ -56,6 +56,9 @@ func TestExecCommandReturnsSessionAndWriteStdinPollsCompletion(t *testing.T) {
 	if start.Meta["session_id"] == "" {
 		t.Fatalf("expected running session metadata, got %#v output=%q", start.Meta, start.Output)
 	}
+	if !strings.Contains(start.Output, `chars "\u0003"`) {
+		t.Fatalf("running session output should explain Ctrl-C cleanup, got %q", start.Output)
+	}
 	sessionID, err := strconv.Atoi(start.Meta["session_id"])
 	if err != nil {
 		t.Fatalf("session_id is not numeric: %v", err)
@@ -197,11 +200,17 @@ func TestWriteStdinInterruptTerminatesSession(t *testing.T) {
 		"chars":         "\x03",
 		"yield_time_ms": 1000,
 	})
+	if interrupted.Status != StatusOK {
+		t.Fatalf("interrupted session status = %s: %s", interrupted.Status, interrupted.Output)
+	}
 	if interrupted.Meta["session_id"] != "" {
 		t.Fatalf("interrupted session should not remain running, meta=%#v output=%q", interrupted.Meta, interrupted.Output)
 	}
 	if interrupted.Meta["exit_code"] == "" {
 		t.Fatalf("interrupted session should report exit_code, meta=%#v output=%q", interrupted.Meta, interrupted.Output)
+	}
+	if interrupted.Meta["interrupted"] != "true" {
+		t.Fatalf("interrupted session should report interrupted metadata, meta=%#v output=%q", interrupted.Meta, interrupted.Output)
 	}
 }
 
@@ -235,6 +244,45 @@ func TestWriteStdinRejectsInputForNonTTYSession(t *testing.T) {
 		t.Fatalf("unexpected output: %q", result.Output)
 	}
 	manager.stop(sessionID)
+}
+
+func TestWriteStdinStopIntentTerminatesNonTTYSession(t *testing.T) {
+	for _, chars := range []string{`\u0003`, "exit\n"} {
+		root := t.TempDir()
+		manager := newExecSessionManager()
+		execTool := NewScopedExecCommandTool(root, nil, manager)
+		writeTool := NewWriteStdinTool(manager)
+
+		start := execTool.Run(context.Background(), map[string]any{
+			"cmd":           helperCommand("long-sleep"),
+			"yield_time_ms": 10,
+		})
+		if start.Status != StatusOK {
+			t.Fatalf("exec_command start status = %s: %s", start.Status, start.Output)
+		}
+		sessionID, err := strconv.Atoi(start.Meta["session_id"])
+		if err != nil {
+			t.Fatalf("session_id is not numeric: %v", err)
+		}
+
+		result := writeTool.Run(context.Background(), map[string]any{
+			"session_id":    sessionID,
+			"chars":         chars,
+			"yield_time_ms": 1000,
+		})
+		if result.Status != StatusOK {
+			t.Fatalf("stop input %q status = %s: %s", chars, result.Status, result.Output)
+		}
+		if result.Meta["session_id"] != "" {
+			t.Fatalf("stop input %q should not leave session running, meta=%#v output=%q", chars, result.Meta, result.Output)
+		}
+		if result.Meta["exit_code"] == "" {
+			t.Fatalf("stop input %q should report exit_code, meta=%#v output=%q", chars, result.Meta, result.Output)
+		}
+		if result.Meta["interrupted"] != "true" {
+			t.Fatalf("stop input %q should report interrupted metadata, meta=%#v output=%q", chars, result.Meta, result.Output)
+		}
+	}
 }
 
 func TestExecCommandTTYSessionAcceptsInputOnLinux(t *testing.T) {
@@ -352,6 +400,22 @@ func TestWriteStdinReportsUnknownSession(t *testing.T) {
 	}
 	if !strings.Contains(result.Output, "Unknown exec session_id 1234") {
 		t.Fatalf("unexpected output: %q", result.Output)
+	}
+}
+
+func TestWriteStdinRequiresPositiveSessionID(t *testing.T) {
+	tool := NewWriteStdinTool(newExecSessionManager())
+	for _, args := range []map[string]any{
+		{},
+		{"session_id": 0},
+	} {
+		result := tool.Run(context.Background(), args)
+		if result.Status != StatusError {
+			t.Fatalf("Run(%#v) status = %s, want error", args, result.Status)
+		}
+		if !strings.Contains(result.Output, "Invalid arguments for write_stdin") {
+			t.Fatalf("Run(%#v) output = %q, want invalid arguments", args, result.Output)
+		}
 	}
 }
 

--- a/internal/tools/exec_pty_fallback.go
+++ b/internal/tools/exec_pty_fallback.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package tools
+
+import (
+	"errors"
+	"io"
+	"os/exec"
+)
+
+var errPTYUnavailable = errors.New("pty transport is unavailable on this platform")
+
+func startPTYProcess(_ *exec.Cmd, _ *execOutputBuffer) (io.WriteCloser, func(), error) {
+	return nil, nil, errPTYUnavailable
+}

--- a/internal/tools/exec_pty_linux.go
+++ b/internal/tools/exec_pty_linux.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func startPTYProcess(command *exec.Cmd, output *execOutputBuffer) (io.WriteCloser, func(), error) {
+	master, slave, err := openPTY()
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() {
+		_ = master.Close()
+		_ = slave.Close()
+	}
+	command.Stdin = slave
+	command.Stdout = slave
+	command.Stderr = slave
+	hardenPTYProcessLifetime(command, slave)
+	if err := command.Start(); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	_ = slave.Close()
+	go func() {
+		_, _ = io.Copy(output, master)
+	}()
+	return master, func() { _ = master.Close() }, nil
+}
+
+func openPTY() (*os.File, *os.File, error) {
+	masterFD, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	master := os.NewFile(uintptr(masterFD), "/dev/ptmx")
+	if err := unix.IoctlSetPointerInt(masterFD, unix.TIOCSPTLCK, 0); err != nil {
+		_ = master.Close()
+		return nil, nil, err
+	}
+	pts, err := unix.IoctlGetInt(masterFD, unix.TIOCGPTN)
+	if err != nil {
+		_ = master.Close()
+		return nil, nil, err
+	}
+	slaveName := fmt.Sprintf("/dev/pts/%d", pts)
+	slaveFD, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		_ = master.Close()
+		return nil, nil, err
+	}
+	slave := os.NewFile(uintptr(slaveFD), slaveName)
+	return master, slave, nil
+}
+
+func hardenPTYProcessLifetime(command *exec.Cmd, slave *os.File) {
+	if command.SysProcAttr == nil {
+		command.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	command.SysProcAttr.Setsid = true
+	command.SysProcAttr.Setctty = true
+	command.SysProcAttr.Ctty = 0
+	command.WaitDelay = bashWaitDelay
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-command.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return nil
+	}
+}

--- a/internal/tools/exec_transport.go
+++ b/internal/tools/exec_transport.go
@@ -7,14 +7,23 @@ import (
 
 func startExecProcess(command *exec.Cmd, output *execOutputBuffer, ttyRequested bool) (io.WriteCloser, bool, func(), error) {
 	if ttyRequested {
-		if stdin, cleanup, err := startPTYProcess(command, output); err == nil {
+		if stdin, cleanup, err := startPTYProcessFunc(command, output); err == nil {
 			return stdin, true, cleanup, nil
 		}
-		command.Stdin = nil
-		command.Stdout = nil
-		command.Stderr = nil
+		resetExecCommandForPipeFallback(command)
 	}
 	return startPipeProcess(command, output)
+}
+
+var startPTYProcessFunc = startPTYProcess
+
+func resetExecCommandForPipeFallback(command *exec.Cmd) {
+	command.Stdin = nil
+	command.Stdout = nil
+	command.Stderr = nil
+	command.SysProcAttr = nil
+	command.Cancel = nil
+	command.WaitDelay = 0
 }
 
 func startPipeProcess(command *exec.Cmd, output *execOutputBuffer) (io.WriteCloser, bool, func(), error) {

--- a/internal/tools/exec_transport.go
+++ b/internal/tools/exec_transport.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"io"
+	"os/exec"
+)
+
+func startExecProcess(command *exec.Cmd, output *execOutputBuffer, ttyRequested bool) (io.WriteCloser, bool, func(), error) {
+	if ttyRequested {
+		if stdin, cleanup, err := startPTYProcess(command, output); err == nil {
+			return stdin, true, cleanup, nil
+		}
+		command.Stdin = nil
+		command.Stdout = nil
+		command.Stderr = nil
+	}
+	return startPipeProcess(command, output)
+}
+
+func startPipeProcess(command *exec.Cmd, output *execOutputBuffer) (io.WriteCloser, bool, func(), error) {
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		return nil, false, nil, err
+	}
+	command.Stdout = output
+	command.Stderr = output
+	hardenProcessLifetime(command)
+	if err := command.Start(); err != nil {
+		return nil, false, nil, err
+	}
+	return stdin, false, func() {}, nil
+}

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -391,7 +391,7 @@ func TestSuggestionOverlayCapsRowsWithoutMoreText(t *testing.T) {
 	if strings.Contains(plain, "more") {
 		t.Fatalf("bare slash palette should not render a more-count row, got %q", plain)
 	}
-	if !strings.Contains(plain, "│ ❯ provider") || !strings.Contains(plain, "│   context") {
+	if !strings.Contains(plain, "│ ❯ provider") || !strings.Contains(plain, "│   stop") {
 		t.Fatalf("top of palette should render first visible command window, got %q", plain)
 	}
 	if strings.Contains(plain, "compact") {

--- a/internal/tui/background_terminals.go
+++ b/internal/tui/background_terminals.go
@@ -1,0 +1,159 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func (m model) execSessionController() (tools.ExecSessionController, bool) {
+	if m.registry == nil {
+		return nil, false
+	}
+	tool, ok := m.registry.Get(tools.ExecCommandToolName)
+	if !ok {
+		return nil, false
+	}
+	controller, ok := tool.(tools.ExecSessionController)
+	return controller, ok
+}
+
+func (m model) backgroundTerminalSessions() []tools.ExecSessionSnapshot {
+	controller, ok := m.execSessionController()
+	if !ok {
+		return nil
+	}
+	return controller.ExecSessions()
+}
+
+func (m model) backgroundTerminalSummary() string {
+	count := len(m.backgroundTerminalSessions())
+	if count == 0 {
+		return ""
+	}
+	plural := ""
+	if count != 1 {
+		plural = "s"
+	}
+	return fmt.Sprintf("%d background terminal%s running · /ps to view · /stop to close", count, plural)
+}
+
+func (m model) backgroundTerminalsText() string {
+	sessions := m.backgroundTerminalSessions()
+	card := commandCard{
+		Title:   "Background Terminals",
+		Summary: []string{fmt.Sprintf("%d running", len(sessions))},
+	}
+	if len(sessions) == 0 {
+		card.Sections = []commandCardSection{{
+			Rows: []commandRow{{Text: "No background terminals running."}},
+		}}
+		return renderCommandCardTranscript(card)
+	}
+	rows := make([]commandRow, 0, len(sessions))
+	now := m.now()
+	for _, session := range sessions {
+		rows = append(rows, commandRow{Text: formatBackgroundTerminalRow(session, now)})
+	}
+	card.Sections = []commandCardSection{{
+		Title: "running",
+		Rows:  rows,
+	}}
+	card.Actions = []string{"/stop <session_id>", "/stop"}
+	return renderCommandCardTranscript(card)
+}
+
+func (m model) stopBackgroundTerminalsText(input string) string {
+	controller, ok := m.execSessionController()
+	if !ok {
+		return renderCommandCardTranscript(commandCard{
+			Title:   "Background Terminals",
+			Summary: []string{"unavailable"},
+			Sections: []commandCardSection{{
+				Rows: []commandRow{{Text: "exec_command is not registered."}},
+			}},
+		})
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		stopped := controller.StopAllExecSessions()
+		return renderStopBackgroundTerminalsCard(stopped, "")
+	}
+	id, err := strconv.Atoi(input)
+	if err != nil || id <= 0 {
+		return renderCommandCardTranscript(commandCard{
+			Title:   "Background Terminals",
+			Summary: []string{"invalid session id"},
+			Sections: []commandCardSection{{
+				Rows: []commandRow{{Text: "Usage: /stop [session_id]"}},
+			}},
+		})
+	}
+	if !controller.StopExecSession(id) {
+		return renderCommandCardTranscript(commandCard{
+			Title:   "Background Terminals",
+			Summary: []string{"not found"},
+			Sections: []commandCardSection{{
+				Rows: []commandRow{{Text: fmt.Sprintf("No running background terminal with session_id %d.", id)}},
+			}},
+		})
+	}
+	return renderStopBackgroundTerminalsCard([]int{id}, "")
+}
+
+func renderStopBackgroundTerminalsCard(stopped []int, note string) string {
+	card := commandCard{Title: "Background Terminals"}
+	if len(stopped) == 0 {
+		card.Summary = []string{"none running"}
+		card.Sections = []commandCardSection{{
+			Rows: []commandRow{{Text: "No background terminals running."}},
+		}}
+		return renderCommandCardTranscript(card)
+	}
+	values := make([]string, 0, len(stopped))
+	for _, id := range stopped {
+		values = append(values, strconv.Itoa(id))
+	}
+	card.Summary = []string{"stopping " + strings.Join(values, ", ")}
+	rows := []commandRow{{Text: "Stopping background terminal sessions."}}
+	if strings.TrimSpace(note) != "" {
+		rows = append(rows, commandRow{Text: note})
+	}
+	card.Sections = []commandCardSection{{Rows: rows}}
+	return renderCommandCardTranscript(card)
+}
+
+func formatBackgroundTerminalRow(session tools.ExecSessionSnapshot, now time.Time) string {
+	age := formatTerminalAge(now.Sub(session.StartedAt))
+	cwd := strings.TrimSpace(session.RelativeCwd)
+	if cwd == "" {
+		cwd = shortenPath(session.Cwd)
+	}
+	command := compactCommandOutputText(session.Command)
+	if command == "" {
+		command = "command"
+	}
+	preview := compactCommandOutputText(session.RecentOutput)
+	prefix := fmt.Sprintf("%d · %s · %s · %s", session.ID, session.Status, age, cwd)
+	if preview != "" {
+		return prefix + " · " + command + " · " + preview
+	}
+	return prefix + " · " + command
+}
+
+func formatTerminalAge(duration time.Duration) string {
+	if duration < 0 {
+		duration = 0
+	}
+	switch {
+	case duration < time.Minute:
+		return fmt.Sprintf("%ds", int(duration.Seconds()))
+	case duration < time.Hour:
+		return fmt.Sprintf("%dm", int(duration.Minutes()))
+	default:
+		return fmt.Sprintf("%dh", int(duration.Hours()))
+	}
+}

--- a/internal/tui/background_terminals.go
+++ b/internal/tui/background_terminals.go
@@ -41,6 +41,14 @@ func (m model) backgroundTerminalSummary() string {
 	return fmt.Sprintf("%d background terminal%s running · /ps to view · /stop to close", count, plural)
 }
 
+func (m model) stopAllBackgroundTerminalSessions() []int {
+	controller, ok := m.execSessionController()
+	if !ok {
+		return nil
+	}
+	return controller.StopAllExecSessions()
+}
+
 func (m model) backgroundTerminalsText() string {
 	sessions := m.backgroundTerminalSessions()
 	card := commandCard{
@@ -79,7 +87,7 @@ func (m model) stopBackgroundTerminalsText(input string) string {
 	}
 	input = strings.TrimSpace(input)
 	if input == "" {
-		stopped := controller.StopAllExecSessions()
+		stopped := m.stopAllBackgroundTerminalSessions()
 		return renderStopBackgroundTerminalsCard(stopped, "")
 	}
 	id, err := strconv.Atoi(input)

--- a/internal/tui/background_terminals_test.go
+++ b/internal/tui/background_terminals_test.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+type fakeExecSessionTool struct {
+	sessions []tools.ExecSessionSnapshot
+	stopped  []int
+	stopAll  bool
+}
+
+func (tool *fakeExecSessionTool) Name() string { return tools.ExecCommandToolName }
+
+func (tool *fakeExecSessionTool) Description() string { return "fake exec sessions" }
+
+func (tool *fakeExecSessionTool) Parameters() tools.Schema {
+	return tools.Schema{Type: "object", AdditionalProperties: false}
+}
+
+func (tool *fakeExecSessionTool) Safety() tools.Safety {
+	return tools.Safety{SideEffect: tools.SideEffectShell, Permission: tools.PermissionPrompt}
+}
+
+func (tool *fakeExecSessionTool) Run(context.Context, map[string]any) tools.Result {
+	return tools.Result{Status: tools.StatusOK}
+}
+
+func (tool *fakeExecSessionTool) ExecSessions() []tools.ExecSessionSnapshot {
+	return append([]tools.ExecSessionSnapshot(nil), tool.sessions...)
+}
+
+func (tool *fakeExecSessionTool) StopExecSession(id int) bool {
+	for _, session := range tool.sessions {
+		if session.ID == id {
+			tool.stopped = append(tool.stopped, id)
+			return true
+		}
+	}
+	return false
+}
+
+func (tool *fakeExecSessionTool) StopAllExecSessions() []int {
+	tool.stopAll = true
+	ids := make([]int, 0, len(tool.sessions))
+	for _, session := range tool.sessions {
+		ids = append(ids, session.ID)
+	}
+	return ids
+}
+
+func modelWithFakeExecSessions(tool *fakeExecSessionTool, now time.Time) model {
+	registry := tools.NewRegistry()
+	registry.Register(tool)
+	return model{
+		registry: registry,
+		now:      func() time.Time { return now },
+	}
+}
+
+func TestBackgroundTerminalsTextEmpty(t *testing.T) {
+	m := modelWithFakeExecSessions(&fakeExecSessionTool{}, time.Unix(100, 0))
+
+	text := m.backgroundTerminalsText()
+	for _, want := range []string{"Background Terminals", "0 running", "No background terminals running."} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("backgroundTerminalsText missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestBackgroundTerminalsTextListsSessions(t *testing.T) {
+	now := time.Unix(200, 0)
+	m := modelWithFakeExecSessions(&fakeExecSessionTool{
+		sessions: []tools.ExecSessionSnapshot{{
+			ID:           1000,
+			Command:      "python3 -m http.server 8000",
+			RelativeCwd:  ".",
+			StartedAt:    now.Add(-2 * time.Minute),
+			Status:       "running",
+			RecentOutput: "Serving HTTP on 0.0.0.0 port 8000",
+		}},
+	}, now)
+
+	text := m.backgroundTerminalsText()
+	for _, want := range []string{"Background Terminals", "1000", "running", "2m", "python3 -m http.server 8000", "/stop <session_id>"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("backgroundTerminalsText missing %q:\n%s", want, text)
+		}
+	}
+	if summary := m.backgroundTerminalSummary(); summary != "1 background terminal running · /ps to view · /stop to close" {
+		t.Fatalf("summary = %q", summary)
+	}
+}
+
+func TestStopBackgroundTerminalsTextStopsAllAndOne(t *testing.T) {
+	tool := &fakeExecSessionTool{
+		sessions: []tools.ExecSessionSnapshot{
+			{ID: 1000, StartedAt: time.Unix(100, 0), Status: "running"},
+			{ID: 1001, StartedAt: time.Unix(100, 0), Status: "running"},
+		},
+	}
+	m := modelWithFakeExecSessions(tool, time.Unix(200, 0))
+
+	all := m.stopBackgroundTerminalsText("")
+	if !tool.stopAll || !strings.Contains(all, "stopping 1000, 1001") {
+		t.Fatalf("stop all did not render expected result: stopAll=%v text=%s", tool.stopAll, all)
+	}
+
+	one := m.stopBackgroundTerminalsText("1001")
+	if len(tool.stopped) != 1 || tool.stopped[0] != 1001 || !strings.Contains(one, "stopping 1001") {
+		t.Fatalf("stop one did not render expected result: stopped=%#v text=%s", tool.stopped, one)
+	}
+}
+
+func TestStopBackgroundTerminalsTextRejectsInvalidSessionID(t *testing.T) {
+	m := modelWithFakeExecSessions(&fakeExecSessionTool{}, time.Unix(100, 0))
+
+	text := m.stopBackgroundTerminalsText("abc")
+	if !strings.Contains(text, "Usage: /stop [session_id]") {
+		t.Fatalf("expected usage, got:\n%s", text)
+	}
+}

--- a/internal/tui/background_terminals_test.go
+++ b/internal/tui/background_terminals_test.go
@@ -126,3 +126,15 @@ func TestStopBackgroundTerminalsTextRejectsInvalidSessionID(t *testing.T) {
 		t.Fatalf("expected usage, got:\n%s", text)
 	}
 }
+
+func TestQuitStopsBackgroundTerminals(t *testing.T) {
+	tool := &fakeExecSessionTool{
+		sessions: []tools.ExecSessionSnapshot{{ID: 1000, StartedAt: time.Unix(100, 0), Status: "running"}},
+	}
+	m := modelWithFakeExecSessions(tool, time.Unix(200, 0))
+
+	_, _ = m.quit()
+	if !tool.stopAll {
+		t.Fatal("quit should stop all background terminal sessions")
+	}
+}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -15,6 +15,8 @@ const (
 	commandTools
 	commandMCP
 	commandPermissions
+	commandPS
+	commandStop
 	commandSandboxSetup
 	commandProvider
 	commandModel
@@ -102,6 +104,20 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupRuntime,
 		description: "Show the active permission mode and sandbox grants.",
 		kind:        commandPermissions,
+	},
+	{
+		name:        "/ps",
+		usage:       "/ps",
+		group:       commandGroupRuntime,
+		description: "List running background terminal sessions.",
+		kind:        commandPS,
+	},
+	{
+		name:        "/stop",
+		usage:       "/stop [session_id]",
+		group:       commandGroupRuntime,
+		description: "Stop running background terminal sessions.",
+		kind:        commandStop,
 	},
 	{
 		name:        "/sandbox-setup",

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -951,6 +951,24 @@ func TestParseImageCommand(t *testing.T) {
 	}
 }
 
+func TestParseBackgroundTerminalCommands(t *testing.T) {
+	cases := []struct {
+		input string
+		kind  commandKind
+		text  string
+	}{
+		{input: "/ps", kind: commandPS, text: ""},
+		{input: "/stop", kind: commandStop, text: ""},
+		{input: "/stop 1000", kind: commandStop, text: "1000"},
+	}
+	for _, tc := range cases {
+		got := parseCommand(tc.input)
+		if got.kind != tc.kind || got.text != tc.text {
+			t.Fatalf("%q: got kind=%v text=%q, want kind=%v text=%q", tc.input, got.kind, got.text, tc.kind, tc.text)
+		}
+	}
+}
+
 func TestCommandSelectionRequiresInputFromUsage(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -666,6 +666,7 @@ func (m model) noBlockingModal() bool {
 
 func (m model) quit() (tea.Model, tea.Cmd) {
 	m.stopPRWatcher()
+	m.stopAllBackgroundTerminalSessions()
 	return m, tea.Quit
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2785,6 +2785,12 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 	case commandPermissions:
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.permissionsText()})
 		return m, nil
+	case commandPS:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.backgroundTerminalsText()})
+		return m, nil
+	case commandStop:
+		m.transcript = reduceTranscript(m.transcript, transcriptAction{kind: actionAppendSystem, text: m.stopBackgroundTerminalsText(command.text)})
+		return m, nil
 	case commandSandboxSetup:
 		return m.startSandboxSetupCommand(command.text)
 	case commandProvider:

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1621,6 +1621,42 @@ func bashCardBody(command string, detail string, width int, opts cardRenderOptio
 	return cardBody{lines: capCardLines(lines, opts.bodyCap), footer: footer}
 }
 
+func execCommandCardBody(command string, detail string, width int, opts cardRenderOptions) cardBody {
+	innerWidth := width - 4
+	lines := []string{}
+	if command = strings.TrimSpace(command); command != "" {
+		lines = append(lines, zeroTheme.onPanel(zeroTheme.bashPrompt).Render("❯ ")+zeroTheme.onPanel(zeroTheme.ink).Render(truncateRunes(command, maxInt(8, innerWidth-2))))
+		lines = append(lines, zeroTheme.onPanel(zeroTheme.line).Render(strings.Repeat("─", maxInt(1, innerWidth))))
+	}
+
+	footer := ""
+	section := ""
+	for _, line := range strings.Split(detail, "\n") {
+		switch {
+		case line == "output:":
+			section = "output"
+		case strings.HasPrefix(line, "exit_code: "):
+			code := strings.TrimPrefix(line, "exit_code: ")
+			if code == "0" {
+				footer = zeroTheme.green.Render("exit 0")
+			} else {
+				footer = zeroTheme.red.Render("exit " + code)
+			}
+		case strings.HasPrefix(line, "session_id: "):
+			footer = zeroTheme.faint.Render("session " + strings.TrimSpace(strings.TrimPrefix(line, "session_id: ")))
+		case strings.HasPrefix(line, "Use write_stdin "):
+			continue
+		default:
+			style := zeroTheme.muted
+			if section == "" && strings.HasPrefix(line, "Command is still running.") {
+				style = zeroTheme.faint
+			}
+			lines = append(lines, zeroTheme.panel.Render("  ")+zeroTheme.onPanel(style).Render(line))
+		}
+	}
+	return cardBody{lines: capCardLines(lines, opts.bodyCap), footer: footer}
+}
+
 // renderSessionsCards draws the /resume list as stacked cards: id (accent) +
 // age (faint) on the top row, title (ink), then the meta line (faint with
 // faintest dots). Records arrive as sessionsCardFieldSep-joined fields; a

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1631,14 +1631,20 @@ func execCommandCardBody(command string, detail string, width int, opts cardRend
 
 	footer := ""
 	section := ""
+	interrupted := false
 	for _, line := range strings.Split(detail, "\n") {
 		switch {
 		case line == "output:":
 			section = "output"
+		case line == "interrupted: true":
+			interrupted = true
+			footer = zeroTheme.green.Render("interrupted")
 		case strings.HasPrefix(line, "exit_code: "):
 			code := strings.TrimPrefix(line, "exit_code: ")
 			if code == "0" {
 				footer = zeroTheme.green.Render("exit 0")
+			} else if interrupted {
+				footer = zeroTheme.green.Render("interrupted")
 			} else {
 				footer = zeroTheme.red.Render("exit " + code)
 			}

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Gitlawb/zero/internal/config"
 	"github.com/Gitlawb/zero/internal/modelregistry"
 	"github.com/Gitlawb/zero/internal/sandbox"
+	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -809,6 +810,59 @@ func TestBashCardBodyShowsCommandOutputAndExit(t *testing.T) {
 	}
 	if strings.Contains(got, "stdout:") || strings.Contains(got, "exit_code:") {
 		t.Fatalf("bash card = %q, must restyle section markers", got)
+	}
+}
+
+func TestExecCommandCardBodyShowsSessionAndExit(t *testing.T) {
+	m := limeTestModel()
+	runningDetail := "output:\nServing HTTP on 0.0.0.0 port 8000\nsession_id: 1000\nUse write_stdin with session_id 1000 to poll, send input, or interrupt it."
+	running := transcriptRow{kind: rowToolResult, id: "call_1", tool: "exec_command", status: tools.StatusOK, detail: runningDetail}
+	rc := buildRowContext([]transcriptRow{{kind: rowToolCall, id: "call_1", tool: "exec_command", detail: "python3 -m http.server 8000"}})
+	got := plainRender(t, m.renderRow(running, 90, rc))
+	for _, want := range []string{"❯ python3 -m http.server 8000", "Serving HTTP", "session 1000"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("exec_command card = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "Use write_stdin") || strings.Contains(got, "session_id:") {
+		t.Fatalf("exec_command card = %q, must restyle session markers", got)
+	}
+
+	exited := transcriptRow{kind: rowToolResult, id: "call_2", tool: "write_stdin", status: tools.StatusOK, detail: "output:\ndone\nexit_code: 0"}
+	got = plainRender(t, m.renderRow(exited, 90, buildRowContext(nil)))
+	for _, want := range []string{"done", "exit 0"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("write_stdin card = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestToolCallSummaryDescribesExecSessions(t *testing.T) {
+	cases := []struct {
+		event streamjson.Event
+		want  string
+	}{
+		{
+			event: streamjson.Event{Name: "exec_command", Args: map[string]any{"cmd": "python3 -m http.server 8000"}},
+			want:  "python3 -m http.server 8000",
+		},
+		{
+			event: streamjson.Event{Name: "write_stdin", Args: map[string]any{"session_id": 1000}},
+			want:  "poll session 1000",
+		},
+		{
+			event: streamjson.Event{Name: "write_stdin", Args: map[string]any{"session_id": float64(1001), "chars": "\x03"}},
+			want:  "interrupt session 1001",
+		},
+		{
+			event: streamjson.Event{Name: "write_stdin", Args: map[string]any{"session_id": "1002", "chars": "q"}},
+			want:  "send input to session 1002",
+		},
+	}
+	for _, tc := range cases {
+		if got := toolCallSummary(tc.event); got != tc.want {
+			t.Fatalf("toolCallSummary(%#v) = %q, want %q", tc.event, got, tc.want)
+		}
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -835,6 +835,12 @@ func TestExecCommandCardBodyShowsSessionAndExit(t *testing.T) {
 			t.Fatalf("write_stdin card = %q, missing %q", got, want)
 		}
 	}
+
+	interrupted := transcriptRow{kind: rowToolResult, id: "call_3", tool: "write_stdin", status: tools.StatusOK, detail: "output:\n127.0.0.1 GET / HTTP/1.1 200\ninterrupted: true\nexit_code: -1"}
+	got = plainRender(t, m.renderRow(interrupted, 90, buildRowContext(nil)))
+	if !strings.Contains(got, "interrupted") || strings.Contains(got, "exit -1") {
+		t.Fatalf("interrupted write_stdin card = %q", got)
+	}
 }
 
 func TestToolCallSummaryDescribesExecSessions(t *testing.T) {

--- a/internal/tui/specialist_card.go
+++ b/internal/tui/specialist_card.go
@@ -395,14 +395,44 @@ func toolCallSummary(event streamjson.Event) string {
 		if pattern, ok := args["pattern"].(string); ok {
 			return truncateRunes(pattern, 40)
 		}
-	case "bash":
+	case "bash", "exec_command":
 		if cmd, ok := args["command"].(string); ok {
 			return truncateRunes(cmd, 40)
+		}
+		if cmd, ok := args["cmd"].(string); ok {
+			return truncateRunes(cmd, 40)
+		}
+	case "write_stdin":
+		sessionID := toolCallIntArg(args, "session_id")
+		chars, _ := args["chars"].(string)
+		switch {
+		case chars == "":
+			return fmt.Sprintf("poll session %d", sessionID)
+		case chars == "\x03":
+			return fmt.Sprintf("interrupt session %d", sessionID)
+		default:
+			return fmt.Sprintf("send input to session %d", sessionID)
 		}
 	case "update_plan":
 		return "plan"
 	}
 	return ""
+}
+
+func toolCallIntArg(args map[string]any, key string) int {
+	switch value := args[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case string:
+		parsed, _ := strconv.Atoi(value)
+		return parsed
+	default:
+		return 0
+	}
 }
 
 // truncateRunes is provided by view.go; specialist_card.go relies on it for

--- a/internal/tui/tool_render_registry.go
+++ b/internal/tui/tool_render_registry.go
@@ -43,6 +43,12 @@ func newDefaultToolBodyRegistry() *toolBodyRegistry {
 	registry.register("bash", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
 		return bashCardBody(req.hint, req.detail, req.width, req.opts)
 	})})
+	registry.register("exec_command", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return execCommandCardBody(req.hint, req.detail, req.width, req.opts)
+	})})
+	registry.register("write_stdin", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
+		return execCommandCardBody("", req.detail, req.width, req.opts)
+	})})
 	registry.register("grep", diffFirstToolBodyRenderer{next: toolBodyRendererFunc(func(req toolBodyRequest) cardBody {
 		return grepCardBody(req.detail, req.width, req.opts)
 	})})

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -204,6 +204,9 @@ func (m model) statusLine(width int) string {
 	}
 
 	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
+	if summary := m.backgroundTerminalSummary(); summary != "" {
+		left += separator + zeroTheme.muted.Render(summary)
+	}
 
 	rightGroups := []string{}
 	// The context-fill gauge needs the room a Medium+ terminal gives; below that


### PR DESCRIPTION
Summary
- Adds managed exec sessions with bounded tracking, recent-output snapshots, stop controls, and Linux PTY transport behind the existing exec_command/write_stdin tools.
- Adds local TUI background terminal controls and rendering: /ps, /stop, status-line summary, exec_command/write_stdin terminal cards, and focused tests.
- Keeps web_fetch public-only while documenting localhost/private verification through shell/curl, and covers approved local network sandbox mode.
- Stops managed terminal sessions on TUI shutdown.

Verification
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui -run 'TestExecCommandCardBody|TestToolCallSummaryDescribesExecSessions' -count=1
- GOCACHE=/tmp/zero-go-cache go test ./internal/tui
- GOCACHE=/tmp/zero-go-cache go test ./internal/tools ./internal/tui ./internal/agent ./internal/sandbox
- /bin/bash -lc 'GOCACHE=/tmp/zero-go-cache go test ./...'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/ps` to list running background terminal sessions (status, age, working directory, and optional recent output).
  * Added `/stop` to stop a specific session or all background terminal sessions.
  * Added `tty: true` to `exec_command` for interactive terminal-style input.
  * Updated the TUI to display a background terminal summary in the status line.
* **Bug Fixes**
  * Improved `exec_command`/`write_stdin` interrupt, stop, and result display (including clearer “interrupted” and session hints), with safer PTY fallback.
* **Documentation**
  * Expanded README guidance for interrupting running commands and managing `/ps`/`/stop` sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->