### PR TITLE
feat(tui): `?` keyboard-shortcut overlay

### DIFF
--- a/internal/tui/keybinding_help.go
+++ b/internal/tui/keybinding_help.go
@@ -1,0 +1,147 @@
+// keybinding_help.go renders the `?` keyboard-shortcut overlay. Zero has a
+// rich set of chord bindings (Ctrl+T effort, Ctrl+P plan, drill-in subchat,
+// Shift+Tab permission mode, …) that are otherwise invisible — only learnable
+// by reading the source. A single-key `?` overlay (opened on an empty composer)
+// lists them grouped, so the keymap is discoverable the way the reference TUIs
+// do it. The list is declarative and hand-curated to match the real handlers in
+// model.go's Update switch; keep them in sync when a binding changes.
+package tui
+
+import "strings"
+
+// keybinding is one row in the help overlay: the key chord and what it does.
+type keybinding struct {
+	keys string
+	desc string
+}
+
+// keybindingGroup is a titled cluster of related bindings.
+type keybindingGroup struct {
+	title    string
+	bindings []keybinding
+}
+
+// keybindingGroups is the full, grouped shortcut list shown by the `?` overlay.
+// Sourced from the real key cases in model.go (Update) — not invented. When a
+// binding is added/changed there, update it here too (a test guards that the
+// data is non-empty and well-formed, but it can't verify the bindings exist).
+var keybindingGroups = []keybindingGroup{
+	{
+		title: "Chat",
+		bindings: []keybinding{
+			{"Enter", "send the message"},
+			{"Alt+Enter", "insert a newline (multi-line compose)"},
+			{"Esc", "cancel the run / dismiss a popup / clear the input"},
+			{"Ctrl+C", "cancel the run, then quit"},
+			{"?", "show this help (on an empty input)"},
+		},
+	},
+	{
+		title: "Model & run controls",
+		bindings: []keybinding{
+			{"Ctrl+T", "cycle reasoning effort (auto → low → medium → high)"},
+			{"Shift+Tab", "cycle permission mode (auto ↔ ask)"},
+			{"Ctrl+P", "expand / collapse the plan panel"},
+		},
+	},
+	{
+		title: "Navigation & scrollback",
+		bindings: []keybinding{
+			{"PgUp / PgDn", "scroll the transcript by a page"},
+			{"↑ / ↓", "scroll, or move within a popup / multi-line input"},
+			{"Ctrl+O", "toggle the detailed (full-screen) transcript"},
+			{"Ctrl+E", "release the mouse to drag-select & copy text"},
+			{"Tab", "accept the autocomplete / picker selection"},
+		},
+	},
+	{
+		title: "Specialists & pickers",
+		bindings: []keybinding{
+			{"Click a specialist card", "drill into its sub-session"},
+			{"↑ / Esc (in a sub-session)", "return to the main chat"},
+			{"Ctrl+F (in /model)", "toggle the highlighted model as a favorite"},
+			{"Click a tool card", "expand / collapse its output"},
+			{"Right-click", "paste the clipboard"},
+		},
+	},
+}
+
+// keybindingHelpFooter is the dismiss hint shown at the bottom of the overlay.
+const keybindingHelpFooter = "? or Esc to close · /help for slash commands"
+
+// renderKeybindingHelpLines builds the overlay body lines (group titles +
+// aligned key/description rows + footer), wrapped to the inner width. Exposed
+// separately from the framed renderer so tests can assert on content without
+// the border chrome.
+func (m model) renderKeybindingHelpLines(innerWidth int) []string {
+	keyColumn := keybindingKeyColumnWidth()
+	lines := make([]string, 0, 64)
+	for index, group := range keybindingGroups {
+		if index > 0 {
+			lines = append(lines, "")
+		}
+		lines = append(lines, zeroTheme.accent.Render(group.title))
+		for _, binding := range group.bindings {
+			lines = append(lines, formatKeybindingLine(binding, keyColumn, innerWidth))
+		}
+	}
+	lines = append(lines, "")
+	lines = append(lines, zeroTheme.faint.Render(keybindingHelpFooter))
+	return lines
+}
+
+// keybindingKeyColumnWidth returns the width of the key column: the widest key
+// chord across all groups, so the descriptions align in a clean second column.
+func keybindingKeyColumnWidth() int {
+	widest := 0
+	for _, group := range keybindingGroups {
+		for _, binding := range group.bindings {
+			if n := len([]rune(binding.keys)); n > widest {
+				widest = n
+			}
+		}
+	}
+	return widest
+}
+
+// formatKeybindingLine renders one "  <keys>   <desc>" row: the key chord in
+// the accent color, padded to keyColumn, then the muted description truncated
+// to fit innerWidth.
+func formatKeybindingLine(binding keybinding, keyColumn int, innerWidth int) string {
+	keys := binding.keys
+	pad := keyColumn - len([]rune(keys))
+	if pad < 0 {
+		pad = 0
+	}
+	keyCell := zeroTheme.ink.Render(keys) + strings.Repeat(" ", pad)
+	// Indent(2) + keyCell + gap(2) consumed before the description.
+	descBudget := innerWidth - 2 - keyColumn - 2
+	if descBudget < 4 {
+		descBudget = 4
+	}
+	desc := zeroTheme.muted.Render(truncateRunes(binding.desc, descBudget))
+	return "  " + keyCell + "  " + desc
+}
+
+// renderKeybindingHelpOverlay renders the framed, centered `?` help overlay for
+// the given terminal dimensions.
+func (m model) renderKeybindingHelpOverlay(width int, height int) string {
+	overlayWidth := keybindingHelpOverlayWidth(width)
+	lines := m.renderKeybindingHelpLines(overlayWidth - 4)
+	block := styledBlockFillTitle(overlayWidth, "Keyboard Shortcuts", lines, zeroTheme.line, zeroTheme.panel)
+	return centerRenderedBlock(block, width)
+}
+
+// keybindingHelpOverlayWidth picks the overlay width: wide enough that the
+// descriptions don't truncate next to the key column, capped, and never wider
+// than the terminal.
+func keybindingHelpOverlayWidth(terminalWidth int) int {
+	width := 76
+	if terminalWidth-4 < width {
+		width = terminalWidth - 4
+	}
+	if width < 24 {
+		width = 24
+	}
+	return width
+}

--- a/internal/tui/keybinding_help_test.go
+++ b/internal/tui/keybinding_help_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestQuestionMarkOpensHelpOnEmptyComposer(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	updated, _ := m.Update(testKeyText("?"))
+	next := updated.(model)
+	if !next.helpOverlay {
+		t.Fatal("? on an empty composer should open the help overlay")
+	}
+	// The ? must NOT have been typed into the composer.
+	if next.composerValue() != "" {
+		t.Fatalf("composer should stay empty when ? opens help, got %q", next.composerValue())
+	}
+}
+
+func TestQuestionMarkTypesIntoNonEmptyComposer(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m = typeRunes(t, m, "what")
+	updated, _ := m.Update(testKeyText("?"))
+	next := updated.(model)
+	if next.helpOverlay {
+		t.Fatal("? after text should type a literal '?', not open help")
+	}
+	if got := next.composerValue(); got != "what?" {
+		t.Fatalf("composer = %q, want %q", got, "what?")
+	}
+}
+
+func TestHelpOverlayClosesOnQuestionMarkAndEsc(t *testing.T) {
+	for _, closer := range []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"question-mark", testKeyText("?")},
+		{"esc", testKey(tea.KeyEsc)},
+		{"q", testKeyText("q")},
+		{"enter", testKey(tea.KeyEnter)},
+	} {
+		m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+		m.helpOverlay = true
+		updated, _ := m.Update(closer.key)
+		next := updated.(model)
+		if next.helpOverlay {
+			t.Fatalf("%s should close the help overlay", closer.name)
+		}
+	}
+}
+
+func TestHelpOverlaySwallowsOtherKeys(t *testing.T) {
+	// While the overlay is open, an ordinary key must not type into the composer.
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m.helpOverlay = true
+	updated, _ := m.Update(testKeyText("x"))
+	next := updated.(model)
+	if !next.helpOverlay {
+		t.Fatal("an ordinary key should not close the overlay")
+	}
+	if next.composerValue() != "" {
+		t.Fatalf("keys must be swallowed while the overlay is open, composer = %q", next.composerValue())
+	}
+}
+
+func TestHelpOverlayViewRendersGroupsAndKeys(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4o"})
+	m.width = 90
+	m.height = 40
+	m.helpOverlay = true
+	view := plainRender(t, m.View())
+	for _, want := range []string{
+		"Keyboard Shortcuts",
+		"Ctrl+T", "cycle reasoning effort",
+		"Shift+Tab", "Ctrl+P", "Ctrl+O",
+		"drill into its sub-session",
+		keybindingHelpFooter,
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("help overlay view missing %q, got:\n%s", want, view)
+		}
+	}
+}
+
+func TestKeybindingGroupsAreWellFormed(t *testing.T) {
+	if len(keybindingGroups) == 0 {
+		t.Fatal("keybindingGroups must not be empty")
+	}
+	for _, group := range keybindingGroups {
+		if strings.TrimSpace(group.title) == "" {
+			t.Fatal("every keybinding group needs a title")
+		}
+		if len(group.bindings) == 0 {
+			t.Fatalf("group %q has no bindings", group.title)
+		}
+		for _, binding := range group.bindings {
+			if strings.TrimSpace(binding.keys) == "" || strings.TrimSpace(binding.desc) == "" {
+				t.Fatalf("group %q has a binding with an empty key or description: %+v", group.title, binding)
+			}
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,6 +105,7 @@ type model struct {
 	unpricedTokens        int
 	transcript            []transcriptRow
 	transcriptDetailed    bool
+	helpOverlay           bool // the `?` keyboard-shortcut overlay is open
 	transcriptBodyHeights *transcriptBodyHeightCache
 	input                 textinput.Model
 	composer              composerState
@@ -766,6 +767,14 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.transcriptSelection = transcriptSelectionState{}
 		m.clearMouseSelection()
+		// The `?` help overlay is modal: `?`, Esc, q, or Enter close it; every
+		// other key is swallowed so nothing types into the hidden composer.
+		if m.helpOverlay {
+			if keyText(msg) == "?" || keyText(msg) == "q" || keyIs(msg, tea.KeyEsc) || keyIs(msg, tea.KeyEnter) || keyCtrl(msg, 'c') {
+				m.helpOverlay = false
+			}
+			return m, nil
+		}
 		switch {
 		case keyCtrl(msg, 'c'):
 			// cancelRun records the in-flight run into flushRunIDs and writes the
@@ -945,6 +954,15 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				return m.toggleModelFavorite(), nil
+			}
+		case keyText(msg) == "?" && !keyAlt(msg) && !keyHasMod(msg, tea.ModCtrl):
+			// `?` opens the keyboard-shortcut overlay, but ONLY on an empty
+			// composer with nothing modal up — otherwise it must type a literal
+			// "?" into the prompt. Falls through to the rune-insert path below
+			// when the composer is non-empty or a popup is active.
+			if m.composerValue() == "" && m.noBlockingModal() && !m.transcriptDetailed && !m.subchat.active && !m.suggestionsActive() {
+				m.helpOverlay = true
+				return m, nil
 			}
 		case keyBackspace(msg):
 			if m.picker != nil {
@@ -1535,6 +1553,8 @@ func (m model) View() tea.View {
 	var content string
 	if m.setup.visible {
 		content = m.setupView(chatWidth(m.width))
+	} else if m.helpOverlay {
+		content = m.renderKeybindingHelpOverlay(chatWidth(m.width), m.height)
 	} else if m.transcriptDetailed {
 		content = m.detailedTranscriptView()
 	} else {

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -70,6 +70,8 @@ func emptyStateLines(width int) []string {
 	}
 	lines = append(lines, "")
 	lines = append(lines, centerLine(zeroTheme.muted.Render(emptyStateTagline), width))
+	lines = append(lines, "")
+	lines = append(lines, centerLine(zeroTheme.faint.Render("Press ? for keyboard shortcuts · / for commands"), width))
 	// centerLine pads but never truncates; below ~62 cols the tagline would
 	// exceed the frame without this fit.
 	for index := range lines {


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcuts help overlay accessible via the `?` key
  * Help overlay displays all available keybindings organized by category with descriptions
  * Help overlay closes when pressing `?`, `Esc`, `q`, or `Enter`

* **User Interface**
  * Updated empty state message to highlight keyboard shortcuts availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->