### PR TITLE
fix(tui): give command-info screens real contrast (not flat grey)

### DIFF
--- a/internal/tui/command_card_contrast_test.go
+++ b/internal/tui/command_card_contrast_test.go
@@ -1,0 +1,78 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// helpRendersAsCard confirms /help is routed through the styled card path
+// (prefixed) rather than the flat grey system note.
+func TestHelpRoutesThroughStyledCard(t *testing.T) {
+	if _, ok := commandCardTranscriptPayload(helpText()); !ok {
+		t.Fatal("helpText() must carry the command-card prefix so it renders as a styled card, not a grey note")
+	}
+}
+
+// commandOutput screens (/tools, /context, …) also route through the card path.
+func TestRenderCommandOutputRoutesThroughStyledCard(t *testing.T) {
+	out := renderCommandOutput(commandOutput{Title: "Status", Status: commandStatusInfo})
+	if _, ok := commandCardTranscriptPayload(out); !ok {
+		t.Fatal("renderCommandOutput must carry the command-card prefix")
+	}
+}
+
+func TestCommandCardDropsNeutralStatusLine(t *testing.T) {
+	m := limeTestModel()
+	payload, ok := commandCardTranscriptPayload(helpText())
+	if !ok {
+		t.Fatal("expected command-card payload")
+	}
+	got := plainRender(t, renderCommandCardRow(payload, 96))
+	if strings.Contains(got, "status: info") {
+		t.Fatalf("the neutral 'status: info' line should be dropped, got:\n%s", got)
+	}
+	// But the real content must survive.
+	for _, want := range []string{"Model", "/model", "Session", "/help"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("command card missing %q, got:\n%s", want, got)
+		}
+	}
+	_ = m
+}
+
+func TestCommandCardKeepsNonOkStatus(t *testing.T) {
+	// A warning/blocked status carries signal and must stay visible.
+	warn := renderCommandOutput(commandOutput{Title: "Sandbox", Status: commandStatusWarning})
+	payload, _ := commandCardTranscriptPayload(warn)
+	got := plainRender(t, renderCommandCardRow(payload, 80))
+	if !strings.Contains(got, "status: warning") {
+		t.Fatalf("a non-ok status should stay visible, got:\n%s", got)
+	}
+}
+
+func TestStyleCommandCardContentRowTwoTonesCommands(t *testing.T) {
+	// A command row keeps the indent, splits name from description on " - ", and
+	// applies distinct styles (so the rendered bytes differ from a flat render).
+	styled := styleCommandCardContentRow("  /model [id] - switch the model")
+	plain := ansiPattern.ReplaceAllString(styled, "")
+	if !strings.HasPrefix(plain, "  /model [id]") {
+		t.Fatalf("indent + command name should lead the row, got %q", plain)
+	}
+	if !strings.Contains(plain, "switch the model") {
+		t.Fatalf("description should be preserved, got %q", plain)
+	}
+	// The styled form must actually carry SGR codes (two-tone), i.e. differ from
+	// the stripped form.
+	if styled == plain {
+		t.Fatalf("command row should be styled (carry color), got identical plain/styled: %q", styled)
+	}
+}
+
+func TestStyleCommandCardContentRowHandlesPlainFields(t *testing.T) {
+	// A "key   value" field row (no leading slash, no " - ") stays intact.
+	styled := styleCommandCardContentRow("  registered  2")
+	plain := ansiPattern.ReplaceAllString(styled, "")
+	if plain != "  registered  2" {
+		t.Fatalf("field row content should be preserved verbatim, got %q", plain)
+	}
+}

--- a/internal/tui/command_output.go
+++ b/internal/tui/command_output.go
@@ -210,7 +210,12 @@ func compactCommandOutputText(text string) string {
 }
 
 func renderCommandOutput(output commandOutput) string {
-	return formatCommandOutput(output)
+	// Route every command-info screen (/tools, /permissions, /context, /config,
+	// /sessions, doctor, …) through the styled command-card renderer so it gets
+	// real visual hierarchy (accent group headers, two-tone command rows) instead
+	// of the flat dim-grey system note. The structured text is unchanged — the
+	// prefix just selects the card renderer in renderRowModeUncached.
+	return commandCardTranscriptPrefix + formatCommandOutput(output)
 }
 
 func commandBullet(value string) string {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -52,7 +52,9 @@ func shellOnlyCommandText(name string) string {
 }
 
 func helpText() string {
-	return formatGroupedCommandHelp()
+	// Render /help as a styled command card (accent group headers, two-tone
+	// command rows) rather than a flat grey system note.
+	return commandCardTranscriptPrefix + formatGroupedCommandHelp()
 }
 
 // rowContext carries the cross-row knowledge renderRow needs: which tool
@@ -586,34 +588,91 @@ func renderCommandCardRow(text string, width int) string {
 
 	title := strings.TrimSpace(raw[0])
 	lines := make([]string, 0, len(raw)-1)
-	for index, line := range raw[1:] {
+	for _, line := range raw[1:] {
 		trimmed := strings.TrimSpace(line)
 		switch {
 		case trimmed == "":
 			lines = append(lines, "")
-		case index == 0:
-			lines = append(lines, zeroTheme.ink.Bold(true).Render(line))
-		case isCommandCardHeading(trimmed):
-			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
-		case strings.HasPrefix(trimmed, "actions:"):
-			lines = append(lines, zeroTheme.accent.Render("actions:")+zeroTheme.ink.Render(strings.TrimPrefix(trimmed, "actions:")))
-		case strings.HasPrefix(trimmed, "- "):
-			lines = append(lines, zeroTheme.ink.Render(line))
+		case isCommandCardStatusLine(trimmed):
+			// "status: info" and the like are structural noise — the card border
+			// and title already convey state; only surface a non-ok status.
+			if styled := styledCommandCardStatus(trimmed); styled != "" {
+				lines = append(lines, styled)
+			}
+		case isCommandCardActionsLine(trimmed):
+			lines = append(lines, zeroTheme.accent.Render("actions: ")+zeroTheme.ink.Render(strings.TrimSpace(strings.TrimPrefix(trimmed, "actions:"))))
+		case isCommandCardHintLine(trimmed):
+			lines = append(lines, zeroTheme.faint.Render(line))
+		case isIndentedCommandCardRow(line):
+			// A content row (indented): a "/cmd … - description" gets two-tone
+			// styling (bright name, muted description); a "key  value" field or a
+			// "- bullet" keeps the value readable rather than dim grey.
+			lines = append(lines, styleCommandCardContentRow(line))
 		default:
-			lines = append(lines, zeroTheme.muted.Render(line))
+			// A non-indented, non-empty line is a group header (Model, Session…).
+			lines = append(lines, zeroTheme.accent.Bold(true).Render(line))
 		}
 	}
 	return styledBlockFillTitle(width, title, lines, zeroTheme.accent, lipgloss.NewStyle())
 }
 
-func isCommandCardHeading(value string) bool {
-	if value == "" {
-		return false
+// isIndentedCommandCardRow reports whether a line is an indented content row
+// (a command, field, or bullet) rather than a group header.
+func isIndentedCommandCardRow(line string) bool {
+	return strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "\t")
+}
+
+// styleCommandCardContentRow two-tones an indented content row. A command row
+// ("  /name [args] - description") renders the "/name [args]" half in bright ink
+// and the description in muted; a plain field/bullet row keeps the leading
+// marker bright and the rest readable. Indentation is preserved.
+func styleCommandCardContentRow(line string) string {
+	indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+	body := strings.TrimLeft(line, " \t")
+
+	// "/cmd … - description": split on the FIRST " - " so the command (and its
+	// arg/alias syntax) stays bright and the prose dims.
+	if strings.HasPrefix(body, "/") {
+		if name, desc, ok := strings.Cut(body, " - "); ok {
+			return indent + zeroTheme.ink.Bold(true).Render(name) + zeroTheme.muted.Render(" — "+desc)
+		}
+		return indent + zeroTheme.ink.Bold(true).Render(body)
 	}
-	if strings.HasPrefix(value, "- ") || strings.HasPrefix(value, "actions:") {
-		return false
+	// "- bullet" list item: keep it readable (not dim grey).
+	if strings.HasPrefix(body, "- ") {
+		return indent + zeroTheme.ink.Render(body)
 	}
-	return !strings.Contains(value, " | ") && !strings.Contains(value, "  ")
+	// "key   value" field row: the value carries the information, so keep the
+	// whole row in readable ink rather than the old faint grey.
+	return indent + zeroTheme.ink.Render(body)
+}
+
+// isCommandCardStatusLine reports whether trimmed is a "status: <state>" line.
+func isCommandCardStatusLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "status: ")
+}
+
+// styledCommandCardStatus returns a styled status line for a non-ok/non-info
+// state (warning/blocked surface in their tint), or "" to drop a neutral
+// "status: ok"/"status: info" entirely.
+func styledCommandCardStatus(trimmed string) string {
+	state := strings.TrimSpace(strings.TrimPrefix(trimmed, "status:"))
+	switch state {
+	case "warning":
+		return zeroTheme.amber.Render(trimmed)
+	case "blocked":
+		return zeroTheme.red.Render(trimmed)
+	default: // ok, info — no signal worth the line
+		return ""
+	}
+}
+
+func isCommandCardActionsLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "actions:")
+}
+
+func isCommandCardHintLine(trimmed string) bool {
+	return strings.HasPrefix(trimmed, "hint:")
 }
 
 func renderMCPManagerCard(text string, width int) string {


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed styling and rendering of help screens and command output in the terminal interface.

* **Improvements**
  * Enhanced status line visibility: neutral status lines are now hidden, while warning statuses remain visible.
  * Improved visual distinction between command names, descriptions, and field rows in the command card display.
  * Refined styling for action hints and other command metadata in the terminal interface.

* **Tests**
  * Added comprehensive tests for command card rendering and status line handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->