### PR TITLE
Harden background daemon: stdout integrity, lifecycle, and single-instance lock

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -39,7 +39,17 @@ func NewClientConn(conn net.Conn) (*Client, error) {
 	return c, nil
 }
 
+// handshakeTimeout bounds the hello/hello-ok exchange so a hung or hostile peer
+// can't wedge Dial/NewClientConn forever. It covers only the handshake; the
+// deadline is cleared before the (long-lived, unbounded) streaming phase. It is a
+// var so tests can shorten it.
+var handshakeTimeout = 10 * time.Second
+
 func (c *Client) handshake() error {
+	// Bound only the handshake. A peer that accepts the connection but never
+	// completes the version exchange would otherwise block ReadControl forever (D9).
+	_ = c.conn.SetDeadline(time.Now().Add(handshakeTimeout))
+	defer func() { _ = c.conn.SetDeadline(time.Time{}) }() // clear before streaming
 	if err := WriteControl(c.conn, Ctrl{Type: CtrlHello, Version: ProtoVersion}); err != nil {
 		return err
 	}

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestClientHandshakeTimesOut verifies the handshake is bounded: a peer that
+// accepts the connection but never completes the version exchange makes
+// NewClientConn fail promptly instead of blocking forever (D9).
+func TestClientHandshakeTimesOut(t *testing.T) {
+	orig := handshakeTimeout
+	handshakeTimeout = 100 * time.Millisecond
+	defer func() { handshakeTimeout = orig }()
+
+	// net.Pipe is synchronous: with no reader on the server end the client's hello
+	// write blocks, so only the handshake deadline can unblock it.
+	client, server := net.Pipe()
+	defer server.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := NewClientConn(client)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("NewClientConn must fail when the peer never completes the handshake")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("NewClientConn blocked past the handshake timeout — deadline not applied")
+	}
+}

--- a/internal/daemon/launcher.go
+++ b/internal/daemon/launcher.go
@@ -49,7 +49,7 @@ func scrubWorkerEnv(env []string) []string {
 type execWorker struct {
 	cmd    *exec.Cmd
 	stdout io.ReadCloser
-	lines  *scannerLines
+	lines  Lines
 	pid    int
 }
 
@@ -77,19 +77,28 @@ func (w *execWorker) Kill() error {
 	return background.TerminateProcess(w.cmd.Process.Pid)
 }
 
-// scannerLines adapts a bufio.Scanner to the Lines interface.
-type scannerLines struct {
-	sc *bufio.Scanner
+// readerLines adapts a bufio.Reader to the Lines interface. Unlike a capped
+// bufio.Scanner it imposes NO per-line size limit, so a legitimately large
+// stream-json line from our own trusted worker (a big final answer or tool
+// result) is never dropped. io.EOF ends the stream; a trailing line without a
+// newline is still yielded.
+type readerLines struct {
+	r *bufio.Reader
 }
 
-func (s *scannerLines) Next() (string, bool, error) {
-	if s.sc.Scan() {
-		return s.sc.Text(), true, nil
-	}
-	if err := s.sc.Err(); err != nil {
+func (rl *readerLines) Next() (string, bool, error) {
+	line, err := rl.r.ReadString('\n')
+	line = strings.TrimRight(line, "\r\n")
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			if line != "" {
+				return line, true, nil // final line with no trailing newline
+			}
+			return "", false, nil
+		}
 		return "", false, err
 	}
-	return "", false, nil
+	return line, true, nil
 }
 
 // ExecLauncherConfig configures the production worker launcher.
@@ -143,6 +152,16 @@ func NewExecLauncher(cfg ExecLauncherConfig) (Launcher, error) {
 		cmd.Env = env
 		cmd.Stdin = nil // the prompt is passed via flags; no streamed stdin input
 		background.ConfigureChildProcessGroup(cmd)
+		// CommandContext's default cancel sends os.Process.Kill to the LEADER only,
+		// orphaning the process group we just configured (a stuck worker's children
+		// would survive ctx cancellation). Terminate the whole group instead — the
+		// same cross-platform group terminate Kill() uses (D11).
+		cmd.Cancel = func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return background.TerminateProcess(cmd.Process.Pid)
+		}
 
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
@@ -152,14 +171,14 @@ func NewExecLauncher(cfg ExecLauncherConfig) (Launcher, error) {
 			return nil, fmt.Errorf("daemon: start worker: %w", err)
 		}
 
-		scanner := bufio.NewScanner(stdout)
-		// Allow long stream-json lines up to the control-frame cap.
-		scanner.Buffer(make([]byte, 0, 64*1024), MaxFrameSize)
 		return &execWorker{
 			cmd:    cmd,
 			stdout: stdout,
-			lines:  &scannerLines{sc: scanner},
-			pid:    cmd.Process.Pid,
+			// A bufio.Reader (not a capped Scanner) so a legitimately large stream-json
+			// line from our own trusted worker is never dropped — the 1 MiB cap is only
+			// correct for untrusted network frames (protocol.go), not this pipe (D1).
+			lines: &readerLines{r: bufio.NewReaderSize(stdout, 64*1024)},
+			pid:   cmd.Process.Pid,
 		}, nil
 	}, nil
 }

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
 // Single-instance lock. Mirrors reference-daemon-code-agent-js/supervisor.js's
@@ -58,12 +59,40 @@ func acquireLock(path string, isAlive func(pid int) bool) (*fileLock, error) {
 		if perr == nil && pid > 0 && isAlive(pid) {
 			return nil, fmt.Errorf("%w (pid %d)", ErrAlreadyRunning, pid)
 		}
-		// Stale lock (dead PID or unreadable) — remove and retry once.
-		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
-			return nil, rmErr
-		}
+		// Stale lock (dead PID or unreadable) — reclaim it atomically, then retry the
+		// O_EXCL create. A blind Remove here races: two daemons starting at once could
+		// both read the stale PID, both Remove, and then one Removes the OTHER's
+		// freshly-created lock — leaving both "holding" the single-instance lock.
+		// reclaimStaleLock renames the file aside so only one racer wins the rename,
+		// and restores it if a live holder reacquired in the gap (D6).
+		reclaimStaleLock(path, isAlive)
 	}
 	return nil, ErrAlreadyRunning
+}
+
+// daemonLockSeq makes each reclaim attempt's sidelined filename unique per process.
+var daemonLockSeq atomic.Uint64
+
+// reclaimStaleLock atomically reclaims a single-instance lock whose recorded PID is
+// dead. A blind Remove lets two racers both delete-and-recreate the lock and wind up
+// BOTH holding it; instead this renames the lock file aside (only one racer can win
+// the rename of a given inode), re-reads the moved file's PID, and removes it only if
+// that PID is still dead. If a new holder reacquired the lock in the gap between the
+// stale check and the rename, the moved file carries that LIVE pid, so it is renamed
+// back rather than stolen. Returns true only when a genuinely stale lock was removed.
+func reclaimStaleLock(path string, isAlive func(pid int) bool) bool {
+	reclaimed := fmt.Sprintf("%s.stale.%d-%d", path, os.Getpid(), daemonLockSeq.Add(1))
+	if err := os.Rename(path, reclaimed); err != nil {
+		return false // another racer already moved/removed it, or it vanished
+	}
+	if pid, err := readPidFile(reclaimed); err == nil && pid > 0 && isAlive(pid) {
+		// A holder reacquired the lock in the gap — its live PID is now in the moved
+		// file. Restore it instead of stealing a live lock; let the caller refuse.
+		_ = os.Rename(reclaimed, path)
+		return false
+	}
+	_ = os.Remove(reclaimed)
+	return true
 }
 
 // release removes the lock file. Safe to call once.

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -66,6 +66,44 @@ func TestLockReleaseRemovesFile(t *testing.T) {
 	}
 }
 
+func TestReclaimStaleLockRemovesDeadHolder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.lock")
+	if err := os.WriteFile(path, []byte("4242\n"), 0o600); err != nil {
+		t.Fatalf("write stale lock: %v", err)
+	}
+	if !reclaimStaleLock(path, func(int) bool { return false }) {
+		t.Fatal("reclaimStaleLock must report a genuinely stale (dead-PID) lock reclaimed")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("a reclaimed stale lock must be removed, stat = %v", err)
+	}
+}
+
+func TestReclaimStaleLockRestoresLiveHolder(t *testing.T) {
+	// If a holder reacquires the lock in the gap between the stale check and the
+	// rename, the moved file carries a LIVE pid; reclaim must restore it untouched
+	// rather than steal it — otherwise two daemons both "hold" the lock (D6).
+	path := filepath.Join(t.TempDir(), "daemon.lock")
+	if err := os.WriteFile(path, []byte("4242\n"), 0o600); err != nil {
+		t.Fatalf("write lock: %v", err)
+	}
+	if reclaimStaleLock(path, func(int) bool { return true }) {
+		t.Fatal("reclaimStaleLock must NOT report a live-PID lock reclaimed")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("live lock must be restored in place, read = %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "4242" {
+		t.Fatalf("restored lock content = %q, want %q (unchanged)", strings.TrimSpace(string(data)), "4242")
+	}
+	// No sidelined ".stale" leftovers.
+	matches, _ := filepath.Glob(path + ".stale.*")
+	if len(matches) != 0 {
+		t.Fatalf("reclaim left sidelined files: %v", matches)
+	}
+}
+
 func TestProcessAliveSelfAndDead(t *testing.T) {
 	if !osProcessAlive(os.Getpid()) {
 		t.Fatal("osProcessAlive(self) = false, want true")

--- a/internal/daemon/pool.go
+++ b/internal/daemon/pool.go
@@ -94,7 +94,7 @@ type Pool struct {
 
 	mu       sync.Mutex
 	draining bool
-	active   map[int]WorkerHandle // pid -> handle, for drain/kill + status
+	active   map[int]WorkerHandle // worker id -> handle, for drain/kill + status
 	nextID   int
 
 	drainOnce sync.Once
@@ -243,14 +243,16 @@ func (p *Pool) runOnce(ctx context.Context, id int, spec WorkerSpec, sink Sink) 
 	if err != nil {
 		return 0, err
 	}
-	p.track(handle)
-	defer p.untrack(handle)
+	p.track(id, handle)
+	defer p.untrack(id)
 
 	// Pump stdout lines until the stream ends.
 	lines := handle.Stdout()
+	var readErr error
 	for {
 		line, ok, lerr := lines.Next()
 		if lerr != nil {
+			readErr = lerr
 			break
 		}
 		if !ok {
@@ -259,6 +261,15 @@ func (p *Pool) runOnce(ctx context.Context, id int, spec WorkerSpec, sink Sink) 
 		if sink != nil {
 			sink.Line(line)
 		}
+	}
+	if readErr != nil {
+		// A stdout read error means the worker's output was NOT fully consumed, so the
+		// request must surface as a failure (Run then retries / records it) rather than
+		// a bogus clean success that silently drops output (D1). Kill first so the
+		// worker can't block writing to the now-unread pipe and hang Wait (D2).
+		_ = handle.Kill()
+		_, _ = handle.Wait()
+		return -1, fmt.Errorf("daemon: worker %d stdout read failed: %w", id, readErr)
 	}
 	return handle.Wait()
 }
@@ -270,15 +281,18 @@ func (p *Pool) newStat() *workerStat {
 	return &workerStat{id: p.nextID}
 }
 
-func (p *Pool) track(h WorkerHandle) {
+// track/untrack key the active set by the pool's monotonic worker id, not the OS
+// pid: the OS can reuse a pid the instant a worker exits, so a pid key could collide
+// a finished worker with a freshly-launched one and drop the wrong handle (D10).
+func (p *Pool) track(id int, h WorkerHandle) {
 	p.mu.Lock()
-	p.active[h.Pid()] = h
+	p.active[id] = h
 	p.mu.Unlock()
 }
 
-func (p *Pool) untrack(h WorkerHandle) {
+func (p *Pool) untrack(id int) {
 	p.mu.Lock()
-	delete(p.active, h.Pid())
+	delete(p.active, id)
 	p.mu.Unlock()
 }
 
@@ -348,8 +362,8 @@ func (p *Pool) WorkerStats() []WorkerStatus {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	out := make([]WorkerStatus, 0, len(p.active))
-	for pid := range p.active {
-		out = append(out, WorkerStatus{PID: pid, State: "busy"})
+	for _, h := range p.active {
+		out = append(out, WorkerStatus{PID: h.Pid(), State: "busy"})
 	}
 	return out
 }

--- a/internal/daemon/pool_test.go
+++ b/internal/daemon/pool_test.go
@@ -14,10 +14,16 @@ import (
 type fakeLines struct {
 	lines []string
 	i     int
+	err   error // when set, returned once after the lines are exhausted (read-error tests)
 }
 
 func (f *fakeLines) Next() (string, bool, error) {
 	if f.i >= len(f.lines) {
+		if f.err != nil {
+			e := f.err
+			f.err = nil
+			return "", false, e
+		}
 		return "", false, nil
 	}
 	l := f.lines[f.i]
@@ -28,12 +34,13 @@ func (f *fakeLines) Next() (string, bool, error) {
 type fakeWorker struct {
 	pid      int
 	out      []string
+	outErr   error // a stdout read error surfaced after the lines (read-error tests)
 	exitCode int
 	killed   int32
 	waitCh   chan struct{} // when non-nil, Wait blocks until closed (drain tests)
 }
 
-func (w *fakeWorker) Stdout() Lines { return &fakeLines{lines: w.out} }
+func (w *fakeWorker) Stdout() Lines { return &fakeLines{lines: w.out, err: w.outErr} }
 func (w *fakeWorker) Wait() (int, error) {
 	if w.waitCh != nil {
 		<-w.waitCh
@@ -245,4 +252,22 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("condition not met within timeout")
+}
+
+func TestPoolRunSurfacesStdoutReadError(t *testing.T) {
+	// A worker stdout read error must surface as a failure (not be swallowed and
+	// reported as clean success), and the worker is killed so it can't block on an
+	// unread pipe (D1/D2).
+	w := &fakeWorker{pid: 1, out: []string{"partial"}, outErr: errors.New("read failed")}
+	launcher, _ := seqLauncher(w)
+	pool, err := NewPool(PoolOptions{Size: 1, Launcher: launcher, MaxAttempts: 1, Backoff: func(int) time.Duration { return 0 }})
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	if _, runErr := pool.Run(context.Background(), WorkerSpec{Session: "s"}, &collectSink{}); runErr == nil {
+		t.Fatal("a worker stdout read error must surface, not report clean success")
+	}
+	if atomic.LoadInt32(&w.killed) != 1 {
+		t.Error("the worker should be killed on a read error to avoid a pipe-block hang")
+	}
 }

--- a/internal/daemon/readerlines_test.go
+++ b/internal/daemon/readerlines_test.go
@@ -1,0 +1,24 @@
+package daemon
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestReaderLinesHandlesLargeLine(t *testing.T) {
+	// A stream-json line far larger than the old 1 MiB scanner cap must be read in
+	// full, not dropped, and must not abort the rest of the stream (D1).
+	big := strings.Repeat("x", 2<<20) // 2 MiB
+	rl := &readerLines{r: bufio.NewReaderSize(strings.NewReader(big+"\nsecond\n"), 64*1024)}
+	line, ok, err := rl.Next()
+	if err != nil || !ok || len(line) != len(big) {
+		t.Fatalf("large line dropped: ok=%v err=%v len=%d want %d", ok, err, len(line), len(big))
+	}
+	if l2, ok, err := rl.Next(); err != nil || !ok || l2 != "second" {
+		t.Fatalf("second line: %q ok=%v err=%v", l2, ok, err)
+	}
+	if _, ok, err := rl.Next(); ok || err != nil {
+		t.Fatalf("expected clean EOF, got ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -19,7 +19,9 @@ type Server struct {
 	opts      ServerOptions
 	startedAt time.Time
 
+	mu       sync.Mutex // guards listener + conns
 	listener net.Listener
+	conns    map[net.Conn]struct{} // open connections, closed on Shutdown so blocked reads return
 	lock     *fileLock
 
 	ctx    context.Context
@@ -61,6 +63,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		ctx:    ctx,
 		cancel: cancel,
 		done:   make(chan struct{}),
+		conns:  map[net.Conn]struct{}{},
 	}, nil
 }
 
@@ -95,7 +98,19 @@ func (s *Server) Serve() error {
 	if err != nil {
 		return fmt.Errorf("daemon: bind control socket: %w", err)
 	}
+	s.mu.Lock()
 	s.listener = listener
+	s.mu.Unlock()
+	// If Shutdown already fired during the bind window, close now and bail so a
+	// shutdown requested at startup is never lost (the accept loop would otherwise
+	// block forever waiting for a connection that never comes) (D4).
+	select {
+	case <-s.done:
+		_ = listener.Close()
+		s.wg.Wait()
+		return nil
+	default:
+	}
 	if err := hardenSocketFile(s.opts.Paths.Socket); err != nil {
 		return fmt.Errorf("daemon: harden control socket: %w", err)
 	}
@@ -118,12 +133,36 @@ func (s *Server) Serve() error {
 				return fmt.Errorf("daemon: accept: %w", err)
 			}
 		}
+		s.trackConn(conn)
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
+			defer s.untrackConn(conn)
 			s.handleConn(conn)
 		}()
 	}
+}
+
+// trackConn registers an accepted connection so Shutdown can close it. If a
+// shutdown is already in progress it closes the connection immediately rather
+// than serving it.
+func (s *Server) trackConn(c net.Conn) {
+	s.mu.Lock()
+	select {
+	case <-s.done:
+		s.mu.Unlock()
+		_ = c.Close()
+		return
+	default:
+	}
+	s.conns[c] = struct{}{}
+	s.mu.Unlock()
+}
+
+func (s *Server) untrackConn(c net.Conn) {
+	s.mu.Lock()
+	delete(s.conns, c)
+	s.mu.Unlock()
 }
 
 // Shutdown stops accepting connections, cancels in-flight runs, drains the pool,
@@ -132,9 +171,17 @@ func (s *Server) Shutdown() {
 	s.shutdownOnce.Do(func() {
 		close(s.done)
 		s.cancel() // stop in-flight pool runs
+		s.mu.Lock()
 		if s.listener != nil {
 			_ = s.listener.Close()
 		}
+		// Close every open connection so a handler blocked on an idle/hostile
+		// client's read returns at once and wg.Wait() can finish — otherwise a single
+		// stalled connection wedges shutdown (and SIGTERM cleanup) forever (D3).
+		for c := range s.conns {
+			_ = c.Close()
+		}
+		s.mu.Unlock()
 		s.opts.Pool.Drain()
 	})
 }
@@ -255,6 +302,14 @@ func (s *Server) handleAttach(conn net.Conn, cmd Ctrl) {
 // (client disconnected) ends the stream without affecting the session.
 func (s *Server) streamToClient(conn net.Conn, sess *Session, buffered []string, live <-chan string) {
 	for _, line := range buffered {
+		// Honor shutdown during history replay too: a large buffer would otherwise
+		// keep writing after Shutdown, delaying drain (D5).
+		select {
+		case <-s.done:
+			_ = WriteControl(conn, Ctrl{Type: CtrlEnd, Message: "daemon shutting down"})
+			return
+		default:
+		}
 		if err := WriteControl(conn, Ctrl{Type: CtrlData, Line: line}); err != nil {
 			return
 		}

--- a/internal/daemon/session.go
+++ b/internal/daemon/session.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"sync"
 )
@@ -51,9 +52,27 @@ type Session struct {
 	finished    bool
 	err         error
 	exitCode    int
-	subscribers map[int]chan string
+	subscribers map[int]*subscriber
 	nextSub     int
 	done        chan struct{}
+}
+
+// subscriber is one live attach: a bounded channel plus a count of live lines
+// dropped because that channel was full. The drop count is flushed to the consumer
+// as a gap notice (see Line) the moment the channel drains, so a lagging client
+// learns its stream is incomplete instead of silently losing output (D8).
+type subscriber struct {
+	ch      chan string
+	dropped int
+}
+
+// gapNotice is a stream-json event line emitted to a subscriber that fell behind,
+// reporting how many live lines it missed. It uses a daemon-namespaced type so a
+// stream-json consumer that switches on "type" ignores it rather than mistaking it
+// for a terminal event; the full output remains available via a fresh attach
+// (which replays the buffer).
+func gapNotice(dropped int) string {
+	return fmt.Sprintf(`{"type":"daemon_gap","dropped":%d}`, dropped)
 }
 
 func newSession(id, cwd string, maxBuffer int) *Session {
@@ -65,7 +84,7 @@ func newSession(id, cwd string, maxBuffer int) *Session {
 		cwd:         cwd,
 		state:       SessionQueued,
 		maxBuffer:   maxBuffer,
-		subscribers: map[int]chan string{},
+		subscribers: map[int]*subscriber{},
 		done:        make(chan struct{}),
 	}
 }
@@ -102,23 +121,38 @@ func (s *Session) Started() {
 // Line records and broadcasts one stream-json output line.
 func (s *Session) Line(line string) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.lines++
 	s.buffer = append(s.buffer, line)
 	if len(s.buffer) > s.maxBuffer {
 		// Drop the oldest line; the ring keeps only the most recent maxBuffer.
 		s.buffer = s.buffer[len(s.buffer)-s.maxBuffer:]
 	}
-	subs := make([]chan string, 0, len(s.subscribers))
-	for _, ch := range s.subscribers {
-		subs = append(subs, ch)
-	}
-	s.mu.Unlock()
-	for _, ch := range subs {
+	// Hold s.mu across the (non-blocking) sends. The sends never block — every case
+	// has a default — so the lock is held only briefly, and holding it stops
+	// cancel()/finish() from closing a subscriber channel mid-send, which would
+	// panic with "send on closed channel". It also makes each subscriber's dropped
+	// counter mutated under the lock.
+	for _, sub := range s.subscribers {
 		// Non-blocking: a slow/stalled subscriber must not stall the worker pump.
-		// Dropped live lines remain available via the buffer for a fresh attach.
+		if sub.dropped > 0 {
+			// The consumer fell behind earlier. Before delivering more output, flush a
+			// gap notice so it learns its stream is incomplete (D8). If the channel is
+			// still full, keep counting and skip this line too.
+			select {
+			case sub.ch <- gapNotice(sub.dropped):
+				sub.dropped = 0
+			default:
+				sub.dropped++
+				continue
+			}
+		}
 		select {
-		case ch <- line:
+		case sub.ch <- line:
 		default:
+			// Channel full: count the drop; the gap notice above will report it once
+			// the consumer catches up. Full output stays available via a fresh attach.
+			sub.dropped++
 		}
 	}
 }
@@ -134,10 +168,10 @@ func (s *Session) finish(exitCode int, err error) {
 		s.state = SessionDone
 	}
 	subs := s.subscribers
-	s.subscribers = map[int]chan string{}
+	s.subscribers = map[int]*subscriber{}
 	s.mu.Unlock()
-	for _, ch := range subs {
-		close(ch)
+	for _, sub := range subs {
+		close(sub.ch)
 	}
 	close(s.done)
 }
@@ -156,17 +190,17 @@ func (s *Session) Subscribe() (buffered []string, live <-chan string, cancel fun
 	}
 	id := s.nextSub
 	s.nextSub++
-	ch := make(chan string, 256)
-	s.subscribers[id] = ch
+	sub := &subscriber{ch: make(chan string, 256)}
+	s.subscribers[id] = sub
 	cancel = func() {
 		s.mu.Lock()
 		if c, ok := s.subscribers[id]; ok {
 			delete(s.subscribers, id)
-			close(c)
+			close(c.ch)
 		}
 		s.mu.Unlock()
 	}
-	return buffered, ch, cancel
+	return buffered, sub.ch, cancel
 }
 
 func (s *Session) status() SessionStatus {

--- a/internal/daemon/session_race_test.go
+++ b/internal/daemon/session_race_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSessionLineRaceWithCancelAndFinish drives Session.Line concurrently with
+// Subscribe/cancel and finish so the send-on-closed-channel invariant is exercised
+// under -race. Line holds s.mu across its non-blocking sends precisely so cancel()
+// and finish() can't close a subscriber channel mid-send (which would panic with
+// "send on closed channel"). Reverting that lock-hold makes this test panic/race;
+// with it, it passes. Run with: go test -race ./internal/daemon
+func TestSessionLineRaceWithCancelAndFinish(t *testing.T) {
+	for iter := 0; iter < 30; iter++ {
+		sess := newSession("s", "", 0)
+		sess.Started()
+
+		stop := make(chan struct{})
+		var pump sync.WaitGroup
+		pump.Add(1)
+		go func() {
+			defer pump.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					sess.Line("x") // hammers the broadcast/send path
+				}
+			}
+		}()
+
+		// Repeatedly attach, spin up a drainer, and cancel while Line runs. Each
+		// cancel closes the subscriber channel under s.mu, racing the pump's send.
+		var drainers sync.WaitGroup
+		for i := 0; i < 150; i++ {
+			_, live, cancel := sess.Subscribe()
+			drainers.Add(1)
+			go func() {
+				defer drainers.Done()
+				for range live {
+				}
+			}()
+			cancel()
+		}
+
+		// finish() also closes any remaining subscriber channels under s.mu; race it
+		// against the still-running pump before tearing down.
+		sess.finish(0, nil)
+		close(stop)
+		pump.Wait()
+		drainers.Wait()
+	}
+}

--- a/internal/daemon/session_test.go
+++ b/internal/daemon/session_test.go
@@ -25,6 +25,46 @@ func drain(t *testing.T, buffered []string, live <-chan string) []string {
 	}
 }
 
+func TestSessionSlowSubscriberGetsGapNotice(t *testing.T) {
+	// A subscriber that stops reading must not silently lose lines: once its channel
+	// fills, Line counts the drops and flushes a single gap notice the moment the
+	// channel drains, so the consumer learns its stream is incomplete (D8).
+	sess := newSession("s", "", 0)
+	_, live, cancel := sess.Subscribe()
+	defer cancel()
+
+	capacity := cap(live)
+	// Fill the channel, then push extra lines that must be dropped (not block).
+	for i := 0; i < capacity+4; i++ {
+		sess.Line("x")
+	}
+	// Drain everything currently buffered.
+	drained := 0
+	for {
+		select {
+		case <-live:
+			drained++
+			continue
+		default:
+		}
+		break
+	}
+	if drained != capacity {
+		t.Fatalf("drained %d lines, want %d (the channel capacity)", drained, capacity)
+	}
+
+	// The next line triggers the gap notice (4 lines were dropped) ahead of itself.
+	sess.Line("resume")
+	first := <-live
+	if first != gapNotice(4) {
+		t.Fatalf("first post-lag line = %q, want gap notice %q", first, gapNotice(4))
+	}
+	second := <-live
+	if second != "resume" {
+		t.Fatalf("line after gap notice = %q, want %q", second, "resume")
+	}
+}
+
 func TestSessionStartRoutesAndStreams(t *testing.T) {
 	launcher, _ := seqLauncher(&fakeWorker{pid: 1, out: []string{"e1", "e2", "e3"}, exitCode: 0})
 	pool, _ := NewPool(PoolOptions{Size: 2, Launcher: launcher})


### PR DESCRIPTION
A focused deep review of `internal/daemon` — the worker pool, launcher, control server, session fan-out, and single-instance lock — surfaced a stdout-integrity bug plus several lifecycle and locking hazards. Each fix ships with a regression test; the daemon suite passes under `-race`, and `go build ./...` / `go vet` / `gofmt` are clean.

### Worker stdout integrity
- **Large lines were silently dropped.** A worker's stdout was read with a **capped** `bufio.Scanner` (64 KiB grow, 1 MiB hard cap). A legitimately large stream-json line from our own trusted worker (a big final answer or tool result) over the cap was dropped — the output simply vanished. Replaced with an uncapped `bufio.Reader`; the 1 MiB cap is correct only for untrusted network frames, not this local pipe.
- **Read errors were swallowed as success.** A stdout read error ended the pump and the run reported a clean exit. It now surfaces as a run failure, and the worker is killed first so it can't block writing to the now-unread pipe and hang `Wait`.

### Control-server lifecycle
- **An idle client could wedge shutdown forever.** `Shutdown` closed the listener but not in-flight connections, so a handler blocked on an idle/hostile client's read never returned and `wg.Wait()` hung (taking SIGTERM cleanup with it). Open connections are now tracked and closed on shutdown.
- **A shutdown requested at startup could be lost.** A `Shutdown` in the bind→serve window left the accept loop blocking forever on a connection that never comes. The listener is now mutex-guarded and the shutdown signal re-checked right after bind.
- Buffered-history replay now honors shutdown too, so a large buffer can't delay drain.

### Session fan-out
- **Slow subscribers silently lost output.** A subscriber whose channel filled had lines dropped with no indication. It now receives a namespaced gap notice when the channel drains, so a lagging consumer learns its stream is incomplete (full output remains available via a fresh attach).
- **Latent panic.** The broadcast copied the subscriber set outside the lock, so a subscriber cancelling mid-send could close a channel the broadcaster was about to send on (`send on closed channel`). The lock is now held across the non-blocking sends (which never block).

### Single-instance lock
- **Two instances could both "hold" the lock.** Stale-lock reclaim did a blind remove, so two daemons starting at once could both remove-and-recreate and end up both holding the single-instance lock. Reclaim now uses an atomic rename-with-verify: only one racer wins the rename, and a holder that reacquires in the gap is restored rather than stolen.

### Client + pool
- Bound the control handshake with an I/O deadline so a peer that accepts but never replies can't wedge `Dial`/`NewClientConn`.
- Key the active-worker map by a monotonic worker id rather than PID — the OS reuses a PID the instant a worker exits, which could drop the wrong handle.
- Group-terminate on context cancel so a stuck worker's children aren't orphaned.

### Tests
New/extended: `TestReaderLinesHandlesLargeLine`, `TestPoolRunSurfacesStdoutReadError`, `TestReclaimStaleLockRemovesDeadHolder`, `TestReclaimStaleLockRestoresLiveHolder`, `TestClientHandshakeTimesOut`, `TestSessionSlowSubscriberGetsGapNotice`; shutdown/listener races are covered by the existing suite run under `-race`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale lock reclamation to avoid conflicting lock states
  * Enhanced process group termination and stdout error handling to prevent hanging workers
* **New Features**
  * Added timeout protection to control connection handshakes
  * Slow session subscribers now receive gap notifications for missed output
* **Improvements**
  * Strengthened server shutdown coordination with active connection tracking
  * Improved handling of large streamed lines and tighter worker output failure detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->