### PR TITLE
feat: five capability features from the reference-agent comparison

### DIFF
--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -340,6 +340,19 @@ func (state *compactionState) maybeCompact(
 		return messages
 	}
 
+	// CHEAP FIRST STAGE: reclaim context at zero token/latency cost by pruning
+	// the bodies of old, large tool results (the model has already acted on
+	// them). If that brings us back under threshold, skip the paid summarizer
+	// entirely and preserve recent turns verbatim.
+	if pruned, reclaimed := pruneStaleToolOutput(messages, state.preserveLast); reclaimed > 0 {
+		messages = pruned
+		size = estimateTokens(messages) + toolTokens
+		if size <= state.threshold {
+			state.lowWaterMark = size
+			return messages
+		}
+	}
+
 	compacted, err := Compact(messages, CompactionOptions{
 		PreserveLast: state.preserveLast,
 		Summarize:    summarizeClosure(ctx, provider, state.onUsage),

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -165,7 +165,11 @@ func Run(ctx context.Context, prompt string, provider Provider, options Options)
 			options.OnContext(MeasureContext(messages, request.Tools, options.ContextWindow))
 		}
 
-		stream, err := provider.StreamCompletion(ctx, request)
+		// A transient upstream disconnect on the initial connect is retried with
+		// backoff (before any content is forwarded, so no OnText is duplicated);
+		// a context-limit / image-rejection / cancellation is NOT retried here —
+		// those fall through to their own handlers below.
+		stream, err := streamWithReconnect(ctx, provider, request, reconnectNoticeFor(options))
 		if err != nil {
 			if isImageRejectionError(err) {
 				result.Messages = copyMessages(messages)

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Stale tool-output pruning reclaims context at ZERO token/latency cost before
+// the loop falls back to the paid LLM summarizer. A long, dump-heavy session
+// accumulates large read_file/grep/glob/bash tool results that the model has
+// long since acted on; their bodies are dead weight. Pruning replaces those
+// older bodies with a compact placeholder (keeping the tool message + its
+// ToolCallID so provider replay stays valid and the model knows what was
+// there), preserving recent turns exactly — no paraphrase loss.
+const (
+	// pruneProtectRecentTokens is the trailing window of tool output kept
+	// verbatim — the model is most likely still using it.
+	pruneProtectRecentTokens = 40000
+	// pruneMinReclaimTokens gates the whole pass: only prune when the reclaimable
+	// (older, large) tool output exceeds this, so a short session is untouched.
+	pruneMinReclaimTokens = 20000
+	// pruneMinBodyTokens skips small tool results — replacing a tiny body saves
+	// nothing and just loses information.
+	pruneMinBodyTokens = 200
+)
+
+// prunedPlaceholder is the body a pruned tool result is replaced with. It names
+// the tool and the original size so the model can re-fetch if it needs to.
+func prunedPlaceholder(toolName string, originalTokens int) string {
+	if toolName == "" {
+		toolName = "tool"
+	}
+	return fmt.Sprintf("[pruned %s output (~%d tokens) to reclaim context — re-run the tool if you need it again]", toolName, originalTokens)
+}
+
+// pruneStaleToolOutput walks messages newest-first, protects the last
+// preserveLast messages and a trailing pruneProtectRecentTokens of tool output,
+// then replaces the body of older large tool results with a placeholder. It
+// returns the (possibly) rewritten slice and the number of tokens reclaimed.
+// When nothing meets the bar it returns the input unchanged with reclaimed=0.
+//
+// It never drops a message, never touches non-tool messages, and never prunes
+// an already-pruned body — so it is idempotent and safe to run every turn.
+func pruneStaleToolOutput(messages []zeroruntime.Message, preserveLast int) ([]zeroruntime.Message, int) {
+	if len(messages) == 0 {
+		return messages, 0
+	}
+	if preserveLast < 0 {
+		preserveLast = 0
+	}
+
+	// Index → original token cost of each prunable tool body, scanning newest
+	// first and skipping the protected suffix.
+	type candidate struct {
+		index  int
+		tokens int
+	}
+	var candidates []candidate
+	recentToolTokens := 0
+	reclaimable := 0
+	protectUntil := len(messages) - preserveLast // indices >= this are protected
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != zeroruntime.MessageRoleTool {
+			continue
+		}
+		bodyTokens := ApproxTextTokens(msg.Content)
+		if i >= protectUntil {
+			recentToolTokens += bodyTokens
+			continue
+		}
+		// Still within the trailing-output protection window?
+		if recentToolTokens < pruneProtectRecentTokens {
+			recentToolTokens += bodyTokens
+			continue
+		}
+		if bodyTokens < pruneMinBodyTokens || isPrunedPlaceholder(msg.Content) {
+			continue
+		}
+		candidates = append(candidates, candidate{index: i, tokens: bodyTokens})
+		reclaimable += bodyTokens
+	}
+
+	if reclaimable < pruneMinReclaimTokens || len(candidates) == 0 {
+		return messages, 0
+	}
+
+	// Copy-on-write so we never mutate the caller's slice in place.
+	out := make([]zeroruntime.Message, len(messages))
+	copy(out, messages)
+	reclaimed := 0
+	for _, c := range candidates {
+		toolName := toolNameForResult(out, c.index)
+		newBody := prunedPlaceholder(toolName, c.tokens)
+		reclaimed += c.tokens - ApproxTextTokens(newBody)
+		out[c.index].Content = newBody
+	}
+	return out, reclaimed
+}
+
+// toolNameForResult finds the tool name for the tool-result message at index by
+// matching its ToolCallID against the assistant tool_call that produced it.
+func toolNameForResult(messages []zeroruntime.Message, index int) string {
+	id := messages[index].ToolCallID
+	if id == "" {
+		return ""
+	}
+	for j := index - 1; j >= 0; j-- {
+		for _, call := range messages[j].ToolCalls {
+			if call.ID == id {
+				return call.Name
+			}
+		}
+	}
+	return ""
+}
+
+func isPrunedPlaceholder(content string) bool {
+	return strings.HasPrefix(strings.TrimSpace(content), "[pruned ")
+}

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// bigToolResult builds a tool-result message with approximately tokens worth of
+// body, paired to a tool call id. ApproxTextTokens counts non-space chars / 4,
+// so 4*tokens non-space chars yields ~tokens.
+func bigToolResult(id string, tokens int) zeroruntime.Message {
+	return zeroruntime.Message{
+		Role:       zeroruntime.MessageRoleTool,
+		ToolCallID: id,
+		Content:    strings.Repeat("x", tokens*4),
+	}
+}
+
+func toolCallMsg(id, name string) zeroruntime.Message {
+	return zeroruntime.Message{
+		Role:      zeroruntime.MessageRoleAssistant,
+		ToolCalls: []zeroruntime.ToolCall{{ID: id, Name: name}},
+	}
+}
+
+func TestPruneSkipsSmallSessions(t *testing.T) {
+	// Total reclaimable is under the gate → no pruning.
+	msgs := []zeroruntime.Message{
+		toolCallMsg("c1", "read_file"),
+		bigToolResult("c1", 5000),
+	}
+	out, reclaimed := pruneStaleToolOutput(msgs, 4)
+	if reclaimed != 0 {
+		t.Fatalf("small session should reclaim nothing, got %d", reclaimed)
+	}
+	if out[1].Content != msgs[1].Content {
+		t.Fatal("content must be untouched when under the gate")
+	}
+}
+
+func TestPrunePreservesRecentAndPrunesOld(t *testing.T) {
+	// One huge OLD result (beyond the protect window) + recent small ones.
+	msgs := []zeroruntime.Message{
+		toolCallMsg("old", "grep"),
+		bigToolResult("old", 60000), // old, big → prunable
+		// Filler to push "old" past the recent-protection window:
+		toolCallMsg("mid", "read_file"),
+		bigToolResult("mid", 45000), // protected by the 40k recent window
+		zeroruntime.Message{Role: zeroruntime.MessageRoleAssistant, Content: "thinking"},
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "next"},
+	}
+	out, reclaimed := pruneStaleToolOutput(msgs, 2)
+	if reclaimed <= 0 {
+		t.Fatalf("expected the old 60k tool result to be pruned, reclaimed=%d", reclaimed)
+	}
+	if !isPrunedPlaceholder(out[1].Content) {
+		t.Fatalf("old result should be replaced with a placeholder, got %q", out[1].Content[:40])
+	}
+	// The placeholder names the tool, and the message + id survive (provider replay).
+	if !strings.Contains(out[1].Content, "grep") {
+		t.Fatalf("placeholder should name the tool, got %q", out[1].Content)
+	}
+	if out[1].ToolCallID != "old" || out[1].Role != zeroruntime.MessageRoleTool {
+		t.Fatal("pruned message must keep its role and ToolCallID for replay")
+	}
+	// The recent big result stays verbatim.
+	if isPrunedPlaceholder(out[3].Content) {
+		t.Fatal("a result inside the recent-protection window must not be pruned")
+	}
+}
+
+func TestPruneIsIdempotent(t *testing.T) {
+	msgs := []zeroruntime.Message{
+		toolCallMsg("old", "bash"),
+		bigToolResult("old", 60000),
+		toolCallMsg("mid", "read_file"),
+		bigToolResult("mid", 45000),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "go"},
+	}
+	once, r1 := pruneStaleToolOutput(msgs, 1)
+	if r1 == 0 {
+		t.Fatal("first pass should prune")
+	}
+	_, r2 := pruneStaleToolOutput(once, 1)
+	if r2 != 0 {
+		t.Fatalf("second pass should be a no-op (already pruned), reclaimed=%d", r2)
+	}
+}
+
+func TestPruneNeverTouchesNonToolMessages(t *testing.T) {
+	msgs := []zeroruntime.Message{
+		{Role: zeroruntime.MessageRoleUser, Content: strings.Repeat("u ", 60000)},
+		{Role: zeroruntime.MessageRoleAssistant, Content: strings.Repeat("a ", 60000)},
+	}
+	out, reclaimed := pruneStaleToolOutput(msgs, 0)
+	if reclaimed != 0 {
+		t.Fatalf("non-tool messages must never be pruned, reclaimed=%d", reclaimed)
+	}
+	if out[0].Content != msgs[0].Content || out[1].Content != msgs[1].Content {
+		t.Fatal("non-tool content changed")
+	}
+}
+
+func TestPruneDoesNotMutateInput(t *testing.T) {
+	msgs := []zeroruntime.Message{
+		toolCallMsg("old", "grep"),
+		bigToolResult("old", 60000),
+		toolCallMsg("mid", "read_file"),
+		bigToolResult("mid", 45000),
+		zeroruntime.Message{Role: zeroruntime.MessageRoleUser, Content: "go"},
+	}
+	original := msgs[1].Content
+	_, reclaimed := pruneStaleToolOutput(msgs, 1)
+	if reclaimed == 0 {
+		t.Fatal("expected a prune")
+	}
+	if msgs[1].Content != original {
+		t.Fatal("pruneStaleToolOutput must not mutate the caller's slice")
+	}
+}

--- a/internal/agent/reconnect.go
+++ b/internal/agent/reconnect.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Mid-stream reconnect: a long autonomous task (a big refactor, a swarm member,
+// a headless/cron run) should survive a single transient upstream hiccup
+// instead of dying and re-burning every token on a restart. When the initial
+// StreamCompletion connect fails with a disconnect-shaped error — before any
+// content has been forwarded — re-issue the same request with backoff a few
+// times. We retry ONLY the connect (not a partially-consumed stream), so no
+// already-forwarded OnText is ever duplicated.
+const (
+	maxStreamReconnects = 2
+	streamReconnectBase = 500 * time.Millisecond
+)
+
+// reconnectNotifier is called before each retry with the 1-based attempt number
+// and the max, so the caller can surface a "Reconnecting N/max" notice. Nil is
+// fine.
+type reconnectNotifier func(attempt, max int)
+
+// reconnectNoticeFor builds a notifier that surfaces reconnect attempts through
+// OnReasoning — a non-content channel that is never folded into the answer
+// text, so the user sees "Reconnecting…" without corrupting streamed output.
+// Returns nil when there is no reasoning sink (the reconnect still happens
+// silently).
+func reconnectNoticeFor(options Options) reconnectNotifier {
+	if options.OnReasoning == nil {
+		return nil
+	}
+	return func(attempt, max int) {
+		options.OnReasoning(fmt.Sprintf("\n[connection lost — reconnecting %d/%d…]\n", attempt, max))
+	}
+}
+
+// streamWithReconnect issues request via provider.StreamCompletion and, on a
+// transient disconnect error, retries the connect up to maxStreamReconnects
+// times with exponential backoff. It returns the live stream on success, or the
+// last error. A context-cancellation, a non-disconnect error, or a context
+// already past its deadline is returned immediately (no retry) — those have
+// their own handling (compaction for context-limit, image-rejection, etc.).
+func streamWithReconnect(ctx context.Context, provider Provider, request zeroruntime.CompletionRequest, notify reconnectNotifier) (<-chan zeroruntime.StreamEvent, error) {
+	stream, err := provider.StreamCompletion(ctx, request)
+	if err == nil {
+		return stream, nil
+	}
+	for attempt := 1; attempt <= maxStreamReconnects; attempt++ {
+		if !shouldReconnect(ctx, err) {
+			return nil, err
+		}
+		if notify != nil {
+			notify(attempt, maxStreamReconnects)
+		}
+		if waitErr := sleepWithContext(ctx, backoffFor(attempt)); waitErr != nil {
+			return nil, err // ctx cancelled while waiting; surface the original error
+		}
+		stream, err = provider.StreamCompletion(ctx, request)
+		if err == nil {
+			return stream, nil
+		}
+	}
+	return nil, err
+}
+
+// shouldReconnect reports whether err is a transient disconnect worth retrying.
+// It excludes context cancellation/expiry (caller is shutting down) and
+// context-limit errors (the compactor recovers those), so the reconnect path
+// never fights the existing handlers.
+func shouldReconnect(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if isContextLimitError(msg) || isImageRejectionError(err) {
+		return false
+	}
+	for _, needle := range []string{
+		"eof",
+		"connection reset",
+		"connection refused",
+		"broken pipe",
+		"connection closed",
+		"timeout",
+		"timed out",
+		"temporarily unavailable",
+		"i/o timeout",
+		"503",
+		"502",
+		"server closed",
+		"unexpected end",
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func backoffFor(attempt int) time.Duration {
+	d := streamReconnectBase
+	for i := 1; i < attempt; i++ {
+		d *= 2
+	}
+	return d
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/agent/reconnect_test.go
+++ b/internal/agent/reconnect_test.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// flakyProvider fails the first failBefore connect attempts with failErr, then
+// succeeds with a single-text stream.
+type flakyProvider struct {
+	calls      int32
+	failBefore int32
+	failErr    error
+}
+
+func (p *flakyProvider) StreamCompletion(_ context.Context, _ zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	n := atomic.AddInt32(&p.calls, 1)
+	if n <= p.failBefore {
+		return nil, p.failErr
+	}
+	ch := make(chan zeroruntime.StreamEvent, 1)
+	ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	close(ch)
+	return ch, nil
+}
+
+func TestStreamWithReconnectRecoversFromTransientDisconnect(t *testing.T) {
+	p := &flakyProvider{failBefore: 1, failErr: errors.New("unexpected EOF")}
+	stream, err := streamWithReconnect(context.Background(), p, zeroruntime.CompletionRequest{}, nil)
+	if err != nil {
+		t.Fatalf("expected reconnect to recover, got %v", err)
+	}
+	if stream == nil {
+		t.Fatal("expected a live stream after reconnect")
+	}
+	if got := atomic.LoadInt32(&p.calls); got != 2 {
+		t.Fatalf("expected 2 connect attempts (1 fail + 1 success), got %d", got)
+	}
+}
+
+func TestStreamWithReconnectGivesUpAfterMax(t *testing.T) {
+	// Always fails with a disconnect error → exhausts retries and returns it.
+	p := &flakyProvider{failBefore: 99, failErr: errors.New("connection reset by peer")}
+	_, err := streamWithReconnect(context.Background(), p, zeroruntime.CompletionRequest{}, nil)
+	if err == nil {
+		t.Fatal("expected an error after exhausting reconnects")
+	}
+	// 1 initial + maxStreamReconnects retries.
+	if got := atomic.LoadInt32(&p.calls); got != int32(1+maxStreamReconnects) {
+		t.Fatalf("expected %d attempts, got %d", 1+maxStreamReconnects, got)
+	}
+}
+
+func TestStreamWithReconnectDoesNotRetryNonDisconnect(t *testing.T) {
+	// A context-limit error is the compactor's job, not the reconnect's — return
+	// immediately without retrying.
+	p := &flakyProvider{failBefore: 99, failErr: errors.New("context length exceeded")}
+	_, err := streamWithReconnect(context.Background(), p, zeroruntime.CompletionRequest{}, nil)
+	if err == nil {
+		t.Fatal("expected the original error")
+	}
+	if got := atomic.LoadInt32(&p.calls); got != 1 {
+		t.Fatalf("context-limit error must not be retried, got %d attempts", got)
+	}
+}
+
+func TestStreamWithReconnectStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p := &flakyProvider{failBefore: 99, failErr: errors.New("i/o timeout")}
+	_, err := streamWithReconnect(ctx, p, zeroruntime.CompletionRequest{}, nil)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// Cancelled ctx → no retry beyond the first attempt.
+	if got := atomic.LoadInt32(&p.calls); got != 1 {
+		t.Fatalf("cancelled context must not retry, got %d attempts", got)
+	}
+}
+
+func TestShouldReconnectClassification(t *testing.T) {
+	ctx := context.Background()
+	disconnects := []string{
+		"unexpected EOF", "connection reset by peer", "broken pipe",
+		"i/o timeout", "503 Service Unavailable", "server closed the connection",
+	}
+	for _, m := range disconnects {
+		if !shouldReconnect(ctx, errors.New(m)) {
+			t.Errorf("expected reconnect for %q", m)
+		}
+	}
+	notDisconnects := []string{
+		"context length exceeded", "invalid api key", "model not found",
+		"400 bad request: unsupported parameter",
+	}
+	for _, m := range notDisconnects {
+		if shouldReconnect(ctx, errors.New(m)) {
+			t.Errorf("did NOT expect reconnect for %q", m)
+		}
+	}
+}
+
+func TestBackoffGrows(t *testing.T) {
+	if backoffFor(1) != streamReconnectBase {
+		t.Fatalf("attempt 1 backoff = %v, want %v", backoffFor(1), streamReconnectBase)
+	}
+	if backoffFor(2) != 2*streamReconnectBase {
+		t.Fatalf("attempt 2 backoff = %v, want %v", backoffFor(2), 2*streamReconnectBase)
+	}
+}
+
+func TestReconnectNoticeRoutesThroughReasoning(t *testing.T) {
+	var got string
+	notify := reconnectNoticeFor(Options{OnReasoning: func(s string) { got += s }})
+	if notify == nil {
+		t.Fatal("expected a notifier when OnReasoning is set")
+	}
+	notify(1, 2)
+	if got == "" || !contains(got, "reconnecting 1/2") {
+		t.Fatalf("notice = %q, want a reconnecting message", got)
+	}
+	if reconnectNoticeFor(Options{}) != nil {
+		t.Fatal("expected nil notifier when OnReasoning is unset")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (indexFold(s, sub) >= 0)
+}
+
+func indexFold(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(sub); j++ {
+			a, b := s[i+j], sub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+var _ = time.Second

--- a/internal/agentinit/agentinit.go
+++ b/internal/agentinit/agentinit.go
@@ -1,0 +1,102 @@
+// Package agentinit builds the bootstrap prompt for the guided /init flow that
+// generates a project AGENTS.md. It seeds the agent with structured repo facts
+// from internal/repoinfo so the agent starts from what is already known and
+// only investigates the gaps, then writes a concise high-signal AGENTS.md.
+package agentinit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/repoinfo"
+)
+
+// BuildPrompt returns the bootstrap prompt for `zero init` / `/init`. It runs
+// repoinfo.Collect(cwd) and embeds the result as a fact block; collection
+// failures are non-fatal (the agent investigates from scratch). now is
+// injectable for tests; zero falls back to time.Now.
+func BuildPrompt(ctx context.Context, cwd string, now time.Time) string {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	facts := collectFacts(ctx, cwd, now)
+	return promptHeader + facts + promptInstructions
+}
+
+func collectFacts(ctx context.Context, cwd string, now time.Time) string {
+	info, err := repoinfo.Collect(ctx, repoinfo.Options{Cwd: cwd, Now: now})
+	if err != nil {
+		return "Pre-computed repo facts: unavailable (" + err.Error() + "). Investigate the repository yourself.\n"
+	}
+	return FormatFacts(info)
+}
+
+// FormatFacts renders a repoinfo.Info as a compact, model-readable fact block.
+// Exported so the headless command can show the same summary.
+func FormatFacts(info repoinfo.Info) string {
+	var b strings.Builder
+	b.WriteString("Pre-computed repository facts (from a local scan — verify and fill gaps):\n")
+
+	if info.PrimaryLanguage != "" {
+		b.WriteString(fmt.Sprintf("- Primary language: %s (of %d detected)\n", info.PrimaryLanguage, info.LanguageCount))
+	}
+	if langs := topLanguages(info.Languages, 5); langs != "" {
+		b.WriteString("- Languages: " + langs + "\n")
+	}
+	b.WriteString(fmt.Sprintf("- Size: ~%d files, ~%d LOC, max dir depth %d\n", info.FileCount, info.LOCEstimate, info.MaxDepth))
+	if info.WorkspaceType != "" && info.WorkspaceType != "none" {
+		b.WriteString(fmt.Sprintf("- Workspace: %s (%d packages)\n", info.WorkspaceType, info.WorkspacePackageCount))
+	}
+	if len(info.BuildTools) > 0 {
+		b.WriteString("- Build tools: " + strings.Join(info.BuildTools, ", ") + "\n")
+	}
+	if len(info.TestTools) > 0 {
+		b.WriteString("- Test tools: " + strings.Join(info.TestTools, ", ") + "\n")
+	}
+	if len(info.CICD) > 0 {
+		b.WriteString("- CI/CD: " + strings.Join(info.CICD, ", ") + "\n")
+	}
+	if info.HasGit {
+		git := "- Git: yes"
+		if info.Branch != "" {
+			git += ", branch " + info.Branch
+		}
+		if info.Contributors90d != nil {
+			git += fmt.Sprintf(", %d contributors (90d)", *info.Contributors90d)
+		}
+		b.WriteString(git + "\n")
+	}
+	return b.String()
+}
+
+func topLanguages(langs []repoinfo.LangStat, n int) string {
+	parts := make([]string, 0, n)
+	for i, l := range langs {
+		if i >= n {
+			break
+		}
+		parts = append(parts, l.Name)
+	}
+	return strings.Join(parts, ", ")
+}
+
+const promptHeader = `Generate an AGENTS.md for this repository so future agent runs start with the right context.
+
+`
+
+const promptInstructions = `
+Now investigate the repository to fill in what the facts above don't cover, then write a concise, high-signal AGENTS.md at the repo root. Steps:
+
+1. Use the pre-computed facts as your starting point — don't re-derive what's already stated; investigate the GAPS (conventions, how to build/test/lint, architecture, what to avoid).
+2. Read the key entry points, the build/test config, and any existing README or CONTRIBUTING for project-specific rules.
+3. Write AGENTS.md with these sections, omitting any that don't apply:
+   - A one-line description of what the project is.
+   - Build / test / lint commands (the exact commands a contributor runs).
+   - Project conventions (naming, file layout, idioms the code follows).
+   - Things to avoid (vendored dirs, generated files, gotchas).
+4. Keep it tight — aim for under ~60 lines. Prefer imperative, specific rules ("Run make test", not "you could test"). No secrets, no environment-specific paths.
+5. If a critical fact is genuinely ambiguous (e.g. two plausible test commands), ask the user ONE batched question; otherwise just write the file.
+
+When done, briefly summarize what you wrote.`

--- a/internal/agentinit/agentinit_test.go
+++ b/internal/agentinit/agentinit_test.go
@@ -1,0 +1,71 @@
+package agentinit
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/repoinfo"
+)
+
+func intPtr(n int) *int { return &n }
+
+func TestFormatFactsRendersKnownFields(t *testing.T) {
+	info := repoinfo.Info{
+		PrimaryLanguage: "Go",
+		LanguageCount:   3,
+		Languages: []repoinfo.LangStat{
+			{Name: "Go"}, {Name: "TypeScript"}, {Name: "Shell"},
+		},
+		FileCount:       820,
+		LOCEstimate:     210000,
+		MaxDepth:        6,
+		WorkspaceType:   "go-modules",
+		BuildTools:      []string{"go", "make"},
+		TestTools:       []string{"go test"},
+		CICD:            []string{"github-actions"},
+		HasGit:          true,
+		Branch:          "main",
+		Contributors90d: intPtr(4),
+	}
+	got := FormatFacts(info)
+	for _, want := range []string{
+		"Primary language: Go (of 3 detected)",
+		"Languages: Go, TypeScript, Shell",
+		"~820 files, ~210000 LOC",
+		"Build tools: go, make",
+		"Test tools: go test",
+		"CI/CD: github-actions",
+		"Git: yes, branch main, 4 contributors",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("FormatFacts missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatFactsOmitsEmpty(t *testing.T) {
+	got := FormatFacts(repoinfo.Info{FileCount: 1})
+	for _, unwanted := range []string{"Primary language", "Build tools", "CI/CD", "Git:", "Workspace"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("FormatFacts should omit %q for an empty Info, got:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestBuildPromptEmbedsFactsAndInstructions(t *testing.T) {
+	// BuildPrompt runs repoinfo.Collect on a real dir; t.TempDir() is not a git
+	// repo, so collection fails soft and the prompt explains it will investigate.
+	prompt := BuildPrompt(context.Background(), t.TempDir(), time.Now())
+	if !strings.Contains(prompt, "Generate an AGENTS.md") {
+		t.Fatal("prompt should state the goal")
+	}
+	if !strings.Contains(prompt, "write a concise") && !strings.Contains(prompt, "AGENTS.md at the repo root") {
+		t.Fatalf("prompt should include the write instructions, got:\n%s", prompt)
+	}
+	// Non-git temp dir → facts unavailable branch.
+	if !strings.Contains(prompt, "unavailable") && !strings.Contains(prompt, "Pre-computed repository facts") {
+		t.Fatalf("prompt should include a facts block (or its unavailable fallback), got:\n%s", prompt)
+	}
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -284,6 +284,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runSessions(args[1:], stdout, stderr, deps)
 	case "spec":
 		return runSpec(args[1:], stdout, stderr, deps)
+	case "init":
+		return runInit(args[1:], stdout, stderr, deps)
 	case "specialists", "specialist":
 		return runSpecialists(args[1:], stdout, stderr, deps)
 	case "plugins", "plugin":

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/agentinit"
+)
+
+// runInit implements `zero init`: investigate the repo and generate an
+// AGENTS.md. It builds a bootstrap prompt seeded with repo facts and forwards
+// it to the normal `exec` machinery (provider, tools, sandbox, AGENTS.md write
+// path are all the standard ones). Any flags the user passes (--model, -w,
+// --add-dir, …) are forwarded to exec unchanged; the built prompt is appended
+// as the trailing positional, so a user-supplied prompt is not expected.
+func runInit(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	if wantsHelp(args) {
+		_, _ = io.WriteString(stdout, initHelp)
+		return exitSuccess
+	}
+
+	// Resolve the workspace the same way exec will, so the seeded facts describe
+	// the right repo. A failure here is non-fatal — BuildPrompt degrades to
+	// "investigate yourself".
+	cwd := initCwdFromArgs(args)
+	workspaceRoot, err := resolveWorkspaceRoot(cwd, deps)
+	if err != nil {
+		workspaceRoot = cwd
+	}
+	prompt := agentinit.BuildPrompt(context.Background(), workspaceRoot, time.Now())
+
+	// Forward the user's flags, then the built prompt as the trailing positional.
+	execArgs := append(append([]string{}, args...), prompt)
+	return runExec(execArgs, stdout, stderr, deps)
+}
+
+// initCwdFromArgs extracts a -C/--cwd value if present, else "" (exec defaults
+// to the process cwd). Kept minimal — exec owns the real flag parsing.
+func initCwdFromArgs(args []string) string {
+	for i, a := range args {
+		switch {
+		case a == "-C" || a == "--cwd":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		case strings.HasPrefix(a, "--cwd="):
+			return strings.TrimPrefix(a, "--cwd=")
+		}
+	}
+	return ""
+}
+
+func wantsHelp(args []string) bool {
+	for _, a := range args {
+		if a == "-h" || a == "--help" || a == "help" {
+			return true
+		}
+	}
+	return false
+}
+
+const initHelp = `zero init — investigate the repository and generate an AGENTS.md.
+
+Runs an agent turn seeded with a local repo scan (languages, build/test tools,
+CI, workspace layout), investigates the gaps, and writes a concise AGENTS.md at
+the repo root so future runs start with project context.
+
+Usage:
+  zero init [exec flags]
+
+Accepts the same flags as 'zero exec' (e.g. --model, -w/--worktree, --add-dir).
+`

--- a/internal/lsp/navigate.go
+++ b/internal/lsp/navigate.go
@@ -1,0 +1,245 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// NavOp is a supported LSP navigation operation.
+type NavOp string
+
+const (
+	NavDefinition      NavOp = "definition"
+	NavReferences      NavOp = "references"
+	NavImplementation  NavOp = "implementation"
+	NavWorkspaceSymbol NavOp = "workspace_symbol"
+)
+
+// SymbolResult is one workspace-symbol match (name + where it lives).
+type SymbolResult struct {
+	Name     string
+	Kind     string
+	Location Location
+}
+
+// NavRequest describes a navigation query. For the position-based ops
+// (definition/references/implementation) Path + Line + Character are required
+// (1-based, as the agent sees file:line:col). For workspace_symbol only Query
+// is used. IncludeDeclaration applies to references.
+type NavRequest struct {
+	Op                 NavOp
+	Path               string
+	Line               int // 1-based
+	Character          int // 1-based
+	Query              string
+	Text               string // current file content, for didOpen sync
+	IncludeDeclaration bool
+}
+
+// Navigate runs an LSP navigation request and returns the resulting locations
+// (for the position ops) or symbols (for workspace_symbol). A file whose
+// extension has no available server, or a server lacking the capability,
+// degrades to an empty result with ok=false rather than an error — LSP is an
+// opportunistic layer. A genuine protocol/transport failure returns an error.
+func (m *Manager) Navigate(ctx context.Context, req NavRequest) (locations []Location, symbols []SymbolResult, ok bool, err error) {
+	switch req.Op {
+	case NavWorkspaceSymbol:
+		return m.workspaceSymbol(ctx, req)
+	case NavDefinition, NavReferences, NavImplementation:
+		return m.positionNav(ctx, req)
+	default:
+		return nil, nil, false, fmt.Errorf("lsp: unknown navigation op %q", req.Op)
+	}
+}
+
+func (m *Manager) positionNav(ctx context.Context, req NavRequest) ([]Location, []SymbolResult, bool, error) {
+	command, served := ServerFor(req.Path)
+	if !served {
+		return nil, nil, false, nil
+	}
+	languageID, _ := LanguageID(req.Path)
+	abs := m.absPath(req.Path)
+	uri := PathToURI(abs)
+
+	sess, err := m.sessionFor(ctx, command)
+	if err != nil {
+		if isServerUnavailable(err) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, err
+	}
+	if err := sess.sync(ctx, abs, languageID, req.Text); err != nil {
+		return nil, nil, false, err
+	}
+
+	// LSP positions are 0-based; the tool's API is 1-based (file:line:col).
+	pos := Position{Line: maxZero(req.Line - 1), Character: maxZero(req.Character - 1)}
+	method, params := positionRequest(req.Op, uri, pos, req.IncludeDeclaration)
+
+	raw, err := sess.client.Call(ctx, method, params)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	locs, err := decodeLocations(raw)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return locs, nil, true, nil
+}
+
+func (m *Manager) workspaceSymbol(ctx context.Context, req NavRequest) ([]Location, []SymbolResult, bool, error) {
+	// workspace/symbol needs a running server; pick one by the request path if
+	// given, else there is nothing to query against.
+	command, served := ServerFor(req.Path)
+	if !served {
+		return nil, nil, false, nil
+	}
+	sess, err := m.sessionFor(ctx, command)
+	if err != nil {
+		if isServerUnavailable(err) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, err
+	}
+	// Open the anchor file so the server has the workspace loaded.
+	if req.Text != "" {
+		languageID, _ := LanguageID(req.Path)
+		_ = sess.sync(ctx, m.absPath(req.Path), languageID, req.Text)
+	}
+	raw, err := sess.client.Call(ctx, "workspace/symbol", map[string]any{"query": req.Query})
+	if err != nil {
+		return nil, nil, false, err
+	}
+	symbols, err := decodeSymbols(raw)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return nil, symbols, true, nil
+}
+
+func positionRequest(op NavOp, uri string, pos Position, includeDecl bool) (string, any) {
+	base := map[string]any{
+		"textDocument": map[string]any{"uri": uri},
+		"position":     map[string]any{"line": pos.Line, "character": pos.Character},
+	}
+	switch op {
+	case NavDefinition:
+		return "textDocument/definition", base
+	case NavImplementation:
+		return "textDocument/implementation", base
+	case NavReferences:
+		base["context"] = map[string]any{"includeDeclaration": includeDecl}
+		return "textDocument/references", base
+	default:
+		return "textDocument/definition", base
+	}
+}
+
+// decodeLocations handles the three shapes definition/references can return: a
+// single Location, an array of Location, or an array of LocationLink.
+func decodeLocations(raw json.RawMessage) ([]Location, error) {
+	trimmed := trimJSON(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, nil
+	}
+	if trimmed[0] == '[' {
+		// Try []Location first, then []LocationLink (targetUri/targetRange).
+		var locs []Location
+		if err := json.Unmarshal(trimmed, &locs); err == nil && allHaveURI(locs) {
+			return locs, nil
+		}
+		var links []locationLink
+		if err := json.Unmarshal(trimmed, &links); err != nil {
+			return nil, err
+		}
+		out := make([]Location, 0, len(links))
+		for _, l := range links {
+			out = append(out, Location{URI: l.TargetURI, Range: l.TargetRange})
+		}
+		return out, nil
+	}
+	var single Location
+	if err := json.Unmarshal(trimmed, &single); err != nil {
+		return nil, err
+	}
+	if single.URI == "" {
+		return nil, nil
+	}
+	return []Location{single}, nil
+}
+
+type locationLink struct {
+	TargetURI   string `json:"targetUri"`
+	TargetRange Range  `json:"targetRange"`
+}
+
+type workspaceSymbol struct {
+	Name     string   `json:"name"`
+	Kind     int      `json:"kind"`
+	Location Location `json:"location"`
+}
+
+func decodeSymbols(raw json.RawMessage) ([]SymbolResult, error) {
+	trimmed := trimJSON(raw)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil, nil
+	}
+	var syms []workspaceSymbol
+	if err := json.Unmarshal(trimmed, &syms); err != nil {
+		return nil, err
+	}
+	out := make([]SymbolResult, 0, len(syms))
+	for _, s := range syms {
+		out = append(out, SymbolResult{Name: s.Name, Kind: symbolKindName(s.Kind), Location: s.Location})
+	}
+	return out, nil
+}
+
+func allHaveURI(locs []Location) bool {
+	for _, l := range locs {
+		if l.URI == "" {
+			return false
+		}
+	}
+	return len(locs) > 0
+}
+
+func maxZero(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func trimJSON(raw json.RawMessage) json.RawMessage {
+	s := 0
+	for s < len(raw) && (raw[s] == ' ' || raw[s] == '\n' || raw[s] == '\t' || raw[s] == '\r') {
+		s++
+	}
+	return raw[s:]
+}
+
+// symbolKindName maps the LSP SymbolKind enum to a short label.
+func symbolKindName(kind int) string {
+	switch kind {
+	case 5:
+		return "class"
+	case 6:
+		return "method"
+	case 8:
+		return "field"
+	case 11:
+		return "interface"
+	case 12:
+		return "function"
+	case 13:
+		return "variable"
+	case 14:
+		return "constant"
+	case 23:
+		return "struct"
+	default:
+		return "symbol"
+	}
+}

--- a/internal/lsp/navigate_test.go
+++ b/internal/lsp/navigate_test.go
@@ -1,0 +1,95 @@
+package lsp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecodeLocationsArrayOfLocation(t *testing.T) {
+	raw := json.RawMessage(`[{"uri":"file:///a.go","range":{"start":{"line":4,"character":2},"end":{"line":4,"character":8}}}]`)
+	locs, err := decodeLocations(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(locs) != 1 || locs[0].URI != "file:///a.go" || locs[0].Range.Start.Line != 4 {
+		t.Fatalf("unexpected locations: %#v", locs)
+	}
+}
+
+func TestDecodeLocationsSingleLocation(t *testing.T) {
+	raw := json.RawMessage(`{"uri":"file:///b.go","range":{"start":{"line":1,"character":0},"end":{"line":1,"character":3}}}`)
+	locs, err := decodeLocations(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(locs) != 1 || locs[0].URI != "file:///b.go" {
+		t.Fatalf("unexpected single location: %#v", locs)
+	}
+}
+
+func TestDecodeLocationsLocationLink(t *testing.T) {
+	// definition can return LocationLink (targetUri/targetRange) instead of Location.
+	raw := json.RawMessage(`[{"targetUri":"file:///c.go","targetRange":{"start":{"line":9,"character":1},"end":{"line":9,"character":5}}}]`)
+	locs, err := decodeLocations(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(locs) != 1 || locs[0].URI != "file:///c.go" || locs[0].Range.Start.Line != 9 {
+		t.Fatalf("LocationLink not converted: %#v", locs)
+	}
+}
+
+func TestDecodeLocationsNull(t *testing.T) {
+	for _, raw := range []string{`null`, ``, `   `, `[]`} {
+		locs, err := decodeLocations(json.RawMessage(raw))
+		if err != nil {
+			t.Fatalf("decode(%q): %v", raw, err)
+		}
+		if len(locs) != 0 {
+			t.Fatalf("decode(%q) = %#v, want empty", raw, locs)
+		}
+	}
+}
+
+func TestDecodeSymbols(t *testing.T) {
+	raw := json.RawMessage(`[{"name":"Run","kind":12,"location":{"uri":"file:///loop.go","range":{"start":{"line":99,"character":0},"end":{"line":99,"character":3}}}}]`)
+	syms, err := decodeSymbols(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(syms) != 1 || syms[0].Name != "Run" || syms[0].Kind != "function" {
+		t.Fatalf("unexpected symbols: %#v", syms)
+	}
+}
+
+func TestNavigateUnknownOp(t *testing.T) {
+	m := NewManager(t.TempDir())
+	_, _, ok, err := m.Navigate(nil, NavRequest{Op: "bogus", Path: "x.go"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown nav op")
+	}
+	if ok {
+		t.Fatal("ok should be false for an unknown op")
+	}
+}
+
+func TestNavigateUnsupportedExtensionDegrades(t *testing.T) {
+	// A file type with no configured server degrades to ok=false, no error.
+	m := NewManager(t.TempDir())
+	_, _, ok, err := m.Navigate(nil, NavRequest{Op: NavDefinition, Path: "notes.unknownext", Line: 1, Character: 1})
+	if err != nil {
+		t.Fatalf("unsupported extension should not error, got %v", err)
+	}
+	if ok {
+		t.Fatal("unsupported extension should degrade to ok=false")
+	}
+}
+
+func TestSymbolKindName(t *testing.T) {
+	cases := map[int]string{5: "class", 11: "interface", 12: "function", 23: "struct", 999: "symbol"}
+	for kind, want := range cases {
+		if got := symbolKindName(kind); got != want {
+			t.Fatalf("symbolKindName(%d) = %q, want %q", kind, got, want)
+		}
+	}
+}

--- a/internal/specialist/manifest.go
+++ b/internal/specialist/manifest.go
@@ -104,6 +104,7 @@ var knownToolNames = map[string]bool{
 	"list_directory":      true,
 	"glob":                true,
 	"grep":                true,
+	"lsp_navigate":        true,
 	"skill":               true,
 	"ask_user":            true,
 	"request_permissions": true,

--- a/internal/tools/lsp_navigate.go
+++ b/internal/tools/lsp_navigate.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/lsp"
+)
+
+// lspNavigateTool exposes LSP code navigation (jump-to-definition, find-all-
+// references, find-implementations, workspace symbol search) as a read-only,
+// model-callable tool. It answers "where is X defined / who calls X / what
+// implements this interface" semantically, where grep collides on names or
+// misses indirect references. Degrades to a clear "unavailable" message when no
+// language server is installed for the file's type — LSP is opportunistic.
+type lspNavigateTool struct {
+	baseTool
+	workspaceRoot string
+	manager       *lsp.Manager
+}
+
+// NewLSPNavigateTool builds the tool with its own lazily-started LSP manager
+// (servers spin up on first use and are reused across calls within a session).
+func NewLSPNavigateTool(workspaceRoot string) Tool {
+	root := normalizeWorkspaceRoot(workspaceRoot)
+	return lspNavigateTool{
+		baseTool: baseTool{
+			name: "lsp_navigate",
+			description: "Navigate code semantically via the language server: jump to a symbol's " +
+				"definition, find all references, find implementations of an interface/method, or " +
+				"search workspace symbols by name. Use this instead of grep when you need precise " +
+				"definition/reference/implementation results. Returns file:line:col locations.",
+			parameters: Schema{
+				Type: "object",
+				Properties: map[string]PropertySchema{
+					"op": {
+						Type:        "string",
+						Description: "Operation: definition, references, implementation, or workspace_symbol.",
+						Enum:        []string{"definition", "references", "implementation", "workspace_symbol"},
+					},
+					"path":      {Type: "string", Description: "File to anchor the query (required for all ops; for workspace_symbol it selects the language server)."},
+					"line":      {Type: "integer", Description: "1-based line of the symbol (definition/references/implementation).", Minimum: intPtr(1)},
+					"character": {Type: "integer", Description: "1-based column of the symbol (definition/references/implementation).", Minimum: intPtr(1)},
+					"query":     {Type: "string", Description: "Symbol name to search for (workspace_symbol)."},
+				},
+				Required:             []string{"op", "path"},
+				AdditionalProperties: false,
+			},
+			safety: readOnlySafety("Queries the language server for code navigation; reads files, modifies nothing."),
+		},
+		workspaceRoot: root,
+		manager:       lsp.NewManager(root),
+	}
+}
+
+func (tool lspNavigateTool) Run(ctx context.Context, args map[string]any) Result {
+	opRaw, err := stringArg(args, "op", "", true)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for lsp_navigate: " + err.Error())
+	}
+	op := lsp.NavOp(strings.ToLower(strings.TrimSpace(opRaw)))
+
+	path, err := aliasedStringArg(args, []string{"path", "file", "file_path"}, "", true, false)
+	if err != nil {
+		return errorResult("Error: Invalid arguments for lsp_navigate: " + err.Error())
+	}
+
+	text, readErr := tool.readFile(path)
+	if readErr != nil && op != lsp.NavWorkspaceSymbol {
+		return errorResult("Error: lsp_navigate could not read " + path + ": " + readErr.Error())
+	}
+
+	req := lsp.NavRequest{Op: op, Path: path, Text: text}
+	switch op {
+	case lsp.NavWorkspaceSymbol:
+		query, qErr := stringArg(args, "query", "", true)
+		if qErr != nil {
+			return errorResult("Error: lsp_navigate workspace_symbol requires a query.")
+		}
+		req.Query = strings.TrimSpace(query)
+	case lsp.NavDefinition, lsp.NavReferences, lsp.NavImplementation:
+		line, lErr := intArg(args, "line", 0, 1, 0)
+		col, cErr := intArg(args, "character", 1, 1, 0)
+		if lErr != nil || cErr != nil || line == 0 {
+			return errorResult("Error: lsp_navigate " + string(op) + " requires 1-based line and character.")
+		}
+		req.Line = line
+		req.Character = col
+		req.IncludeDeclaration = true
+	default:
+		return errorResult("Error: lsp_navigate unknown op " + string(op) + " (use definition, references, implementation, or workspace_symbol).")
+	}
+
+	locations, symbols, ok, navErr := tool.manager.Navigate(ctx, req)
+	if navErr != nil {
+		return errorResult("Error: lsp_navigate failed: " + navErr.Error())
+	}
+	if !ok {
+		return okResult(fmt.Sprintf("No language server available for %s — lsp_navigate is unavailable for this file type. Fall back to grep/read_file.", filepath.Base(path)))
+	}
+
+	return okResult(tool.formatResult(op, locations, symbols))
+}
+
+func (tool lspNavigateTool) readFile(path string) (string, error) {
+	abs := path
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(tool.workspaceRoot, path)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (tool lspNavigateTool) formatResult(op lsp.NavOp, locations []lsp.Location, symbols []lsp.SymbolResult) string {
+	if op == lsp.NavWorkspaceSymbol {
+		if len(symbols) == 0 {
+			return "No matching symbols."
+		}
+		lines := make([]string, 0, len(symbols)+1)
+		lines = append(lines, fmt.Sprintf("%d symbol(s):", len(symbols)))
+		for _, s := range symbols {
+			lines = append(lines, fmt.Sprintf("  %s %s — %s", s.Kind, s.Name, tool.formatLocation(s.Location)))
+		}
+		return strings.Join(lines, "\n")
+	}
+	if len(locations) == 0 {
+		return "No " + string(op) + " results."
+	}
+	lines := make([]string, 0, len(locations)+1)
+	lines = append(lines, fmt.Sprintf("%d %s result(s):", len(locations), op))
+	for _, l := range locations {
+		lines = append(lines, "  "+tool.formatLocation(l))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// formatLocation renders a location as a workspace-relative file:line:col
+// (1-based for the user, converting from LSP's 0-based positions).
+func (tool lspNavigateTool) formatLocation(l lsp.Location) string {
+	path := lsp.URIToPath(l.URI)
+	if rel, err := filepath.Rel(tool.workspaceRoot, path); err == nil && !strings.HasPrefix(rel, "..") {
+		path = filepath.ToSlash(rel)
+	}
+	return fmt.Sprintf("%s:%d:%d", path, l.Range.Start.Line+1, l.Range.Start.Character+1)
+}

--- a/internal/tools/lsp_navigate.go
+++ b/internal/tools/lsp_navigate.go
@@ -19,12 +19,21 @@ import (
 type lspNavigateTool struct {
 	baseTool
 	workspaceRoot string
+	scope         PathScope
 	manager       *lsp.Manager
 }
 
-// NewLSPNavigateTool builds the tool with its own lazily-started LSP manager
-// (servers spin up on first use and are reused across calls within a session).
+// NewLSPNavigateTool builds the tool with workspace-only path confinement.
 func NewLSPNavigateTool(workspaceRoot string) Tool {
+	return NewScopedLSPNavigateTool(workspaceRoot, nil)
+}
+
+// NewScopedLSPNavigateTool builds the tool with its own lazily-started LSP
+// manager (servers spin up on first use and are reused across calls within a
+// session). The model-supplied path is resolved through the same scoped
+// confinement the sibling read-only tools use, so a `..` or absolute path
+// cannot read or open a file outside the workspace (or an extra granted root).
+func NewScopedLSPNavigateTool(workspaceRoot string, scope PathScope) Tool {
 	root := normalizeWorkspaceRoot(workspaceRoot)
 	return lspNavigateTool{
 		baseTool: baseTool{
@@ -52,6 +61,7 @@ func NewLSPNavigateTool(workspaceRoot string) Tool {
 			safety: readOnlySafety("Queries the language server for code navigation; reads files, modifies nothing."),
 		},
 		workspaceRoot: root,
+		scope:         scope,
 		manager:       lsp.NewManager(root),
 	}
 }
@@ -63,17 +73,28 @@ func (tool lspNavigateTool) Run(ctx context.Context, args map[string]any) Result
 	}
 	op := lsp.NavOp(strings.ToLower(strings.TrimSpace(opRaw)))
 
-	path, err := aliasedStringArg(args, []string{"path", "file", "file_path"}, "", true, false)
+	requestedPath, err := aliasedStringArg(args, []string{"path", "file", "file_path"}, "", true, false)
 	if err != nil {
 		return errorResult("Error: Invalid arguments for lsp_navigate: " + err.Error())
 	}
 
-	text, readErr := tool.readFile(path)
-	if readErr != nil && op != lsp.NavWorkspaceSymbol {
-		return errorResult("Error: lsp_navigate could not read " + path + ": " + readErr.Error())
+	// Confine the model-supplied path to the workspace (or an extra granted root)
+	// BEFORE reading it or handing it to the language server — a `..` or absolute
+	// path must not read/open a file outside the boundary the sibling read-only
+	// tools enforce. Errors echo only the relative path, never an absolute one.
+	absPath, relPath, scopeErr := resolveScopedReadPath(tool.workspaceRoot, tool.scope, requestedPath)
+	if scopeErr != nil {
+		return errorResult("Error: lsp_navigate " + scopeErr.Error())
 	}
 
-	req := lsp.NavRequest{Op: op, Path: path, Text: text}
+	text, readErr := readWorkspaceFile(absPath)
+	if readErr != nil && op != lsp.NavWorkspaceSymbol {
+		return errorResult("Error: lsp_navigate could not read " + relPath + ": " + readErr.Error())
+	}
+
+	// Hand the LSP manager the resolved absolute path so it opens only the
+	// confined file (not the raw, possibly-escaping, model input).
+	req := lsp.NavRequest{Op: op, Path: absPath, Text: text}
 	switch op {
 	case lsp.NavWorkspaceSymbol:
 		query, qErr := stringArg(args, "query", "", true)
@@ -99,18 +120,16 @@ func (tool lspNavigateTool) Run(ctx context.Context, args map[string]any) Result
 		return errorResult("Error: lsp_navigate failed: " + navErr.Error())
 	}
 	if !ok {
-		return okResult(fmt.Sprintf("No language server available for %s — lsp_navigate is unavailable for this file type. Fall back to grep/read_file.", filepath.Base(path)))
+		return okResult(fmt.Sprintf("No language server available for %s — lsp_navigate is unavailable for this file type. Fall back to grep/read_file.", filepath.Base(relPath)))
 	}
 
 	return okResult(tool.formatResult(op, locations, symbols))
 }
 
-func (tool lspNavigateTool) readFile(path string) (string, error) {
-	abs := path
-	if !filepath.IsAbs(abs) {
-		abs = filepath.Join(tool.workspaceRoot, path)
-	}
-	data, err := os.ReadFile(abs)
+// readWorkspaceFile reads an already-confined absolute path (resolved by
+// resolveScopedReadPath). Returns "" + error when the file can't be read.
+func readWorkspaceFile(absPath string) (string, error) {
+	data, err := os.ReadFile(absPath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/lsp_navigate_test.go
+++ b/internal/tools/lsp_navigate_test.go
@@ -8,6 +8,38 @@ import (
 	"testing"
 )
 
+func TestLSPNavigateConfinesPathToWorkspace(t *testing.T) {
+	// Regression: lsp_navigate must enforce the same workspace confinement its
+	// sibling read-only tools do — an absolute or `..`-escaping path must be
+	// rejected before any read or LSP open, so it can't exfiltrate files off disk
+	// (reachable via indirect prompt injection).
+	root := t.TempDir()
+	tool := NewLSPNavigateTool(root) // workspace-only scope (nil)
+	escapes := []string{
+		"/etc/passwd",
+		"../../../../etc/passwd",
+		"../../../../../../etc/ssh/id_rsa",
+	}
+	for _, p := range escapes {
+		for _, op := range []string{"definition", "workspace_symbol"} {
+			args := map[string]any{"op": op, "path": p}
+			if op == "definition" {
+				args["line"], args["character"] = 1, 1
+			} else {
+				args["query"] = "x"
+			}
+			got := tool.Run(context.Background(), args)
+			if got.Status != StatusError {
+				t.Fatalf("path %q op %s: expected StatusError (confinement), got %s: %s", p, op, got.Status, got.Output)
+			}
+			// The error must not leak the resolved absolute path.
+			if strings.Contains(got.Output, "/etc/") && strings.Contains(got.Output, root) {
+				t.Fatalf("path %q: error should not echo an absolute out-of-workspace path: %q", p, got.Output)
+			}
+		}
+	}
+}
+
 func TestLSPNavigateRejectsBadArgs(t *testing.T) {
 	tool := NewLSPNavigateTool(t.TempDir())
 	cases := []map[string]any{

--- a/internal/tools/lsp_navigate_test.go
+++ b/internal/tools/lsp_navigate_test.go
@@ -1,0 +1,55 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLSPNavigateRejectsBadArgs(t *testing.T) {
+	tool := NewLSPNavigateTool(t.TempDir())
+	cases := []map[string]any{
+		{},                   // missing op + path
+		{"op": "definition"}, // missing path
+		{"op": "workspace_symbol", "path": "x.go"},                 // missing query
+		{"op": "definition", "path": "x.go"},                       // missing line
+		{"op": "bogus", "path": "x.go", "line": 1, "character": 1}, // unknown op
+	}
+	for i, args := range cases {
+		if got := tool.Run(context.Background(), args); got.Status != StatusError {
+			t.Fatalf("case %d: expected StatusError for %#v, got %s: %s", i, args, got.Status, got.Output)
+		}
+	}
+}
+
+func TestLSPNavigateUnsupportedFileDegrades(t *testing.T) {
+	root := t.TempDir()
+	// A file type with no language server → the tool returns OK with a clear
+	// "unavailable, fall back to grep" message rather than an error.
+	path := filepath.Join(root, "notes.unknownext")
+	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewLSPNavigateTool(root)
+	got := tool.Run(context.Background(), map[string]any{
+		"op": "definition", "path": "notes.unknownext", "line": 1, "character": 1,
+	})
+	if got.Status != StatusOK {
+		t.Fatalf("unsupported file should degrade to StatusOK, got %s: %s", got.Status, got.Output)
+	}
+	if !strings.Contains(got.Output, "unavailable") {
+		t.Fatalf("expected an 'unavailable' message, got %q", got.Output)
+	}
+}
+
+func TestLSPNavigateIsReadOnly(t *testing.T) {
+	tool := NewLSPNavigateTool(t.TempDir())
+	if s := tool.Safety(); s.SideEffect != SideEffectRead || s.Permission != PermissionAllow {
+		t.Fatalf("lsp_navigate should be read-only/allow, got %+v", s)
+	}
+	if tool.Name() != "lsp_navigate" {
+		t.Fatalf("name = %q", tool.Name())
+	}
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -211,6 +211,10 @@ func CoreReadOnlyToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 		NewScopedListDirectoryTool(workspaceRoot, scope),
 		NewScopedGlobTool(workspaceRoot, scope),
 		NewScopedGrepTool(workspaceRoot, scope),
+		// lsp_navigate is semantic code navigation (definition/references/impl/
+		// workspace_symbol) via the language server; read-only and degrades to a
+		// clear "unavailable" when no server is installed for the file type.
+		NewLSPNavigateTool(workspaceRoot),
 		// skill reads reusable instruction files from the skills dir (it resolves
 		// skills.DefaultDir itself); read-only, so it is safe in the core/MCP set.
 		NewSkillTool(""),

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -212,9 +212,10 @@ func CoreReadOnlyToolsScoped(workspaceRoot string, scope PathScope) []Tool {
 		NewScopedGlobTool(workspaceRoot, scope),
 		NewScopedGrepTool(workspaceRoot, scope),
 		// lsp_navigate is semantic code navigation (definition/references/impl/
-		// workspace_symbol) via the language server; read-only and degrades to a
-		// clear "unavailable" when no server is installed for the file type.
-		NewLSPNavigateTool(workspaceRoot),
+		// workspace_symbol) via the language server; read-only, scoped to the
+		// workspace, and degrades to a clear "unavailable" when no server is
+		// installed for the file type.
+		NewScopedLSPNavigateTool(workspaceRoot, scope),
 		// skill reads reusable instruction files from the skills dir (it resolves
 		// skills.DefaultDir itself); read-only, so it is safe in the core/MCP set.
 		NewSkillTool(""),

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
-	if len(toolset) != 8 {
-		t.Fatalf("expected 8 core read-only tools, got %d", len(toolset))
+	if len(toolset) != 9 {
+		t.Fatalf("expected 9 core read-only tools, got %d", len(toolset))
 	}
 
 	seen := map[string]bool{}

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -185,9 +185,31 @@ func isPathQueryBoundary(r rune) bool {
 }
 
 func (m model) matchCommandSuggestions(token string) []commandSuggestion {
-	return matchCommandSuggestionsWithFilter(token, func(command commandDefinition) bool {
+	out := matchCommandSuggestionsWithFilter(token, func(command commandDefinition) bool {
 		return command.kind != commandSandboxSetup || m.sandboxSetupCommand != nil
 	})
+	return append(out, m.matchUserCommandSuggestions(token)...)
+}
+
+// matchUserCommandSuggestions returns file-sourced /commands whose name has the
+// typed prefix, so user-defined commands appear in the autocomplete menu
+// alongside builtins. Builtins win on a name collision (they are listed first
+// and a builtin name shadows a same-named user command at dispatch time).
+func (m model) matchUserCommandSuggestions(token string) []commandSuggestion {
+	prefix := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(token, "/")))
+	if prefix == "" {
+		return nil
+	}
+	var out []commandSuggestion
+	for _, cmd := range m.userCommands {
+		if strings.HasPrefix(cmd.Name, prefix) {
+			out = append(out, commandSuggestion{Name: "/" + cmd.Name, Desc: cmd.Description})
+			if len(out) >= maxCommandSuggestions {
+				break
+			}
+		}
+	}
+	return out
 }
 
 // matchCommandSuggestions returns commands whose canonical name or any alias has

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -30,6 +30,7 @@ const (
 	commandResume
 	commandRetitle
 	commandSpec
+	commandInit
 	commandCompact
 	commandRewind
 	commandEffort
@@ -198,6 +199,13 @@ var commandDefinitions = []commandDefinition{
 		group:       commandGroupSession,
 		description: "Draft an implementation spec for review before editing.",
 		kind:        commandSpec,
+	},
+	{
+		name:        "/init",
+		usage:       "/init",
+		group:       commandGroupSession,
+		description: "Investigate the repo and generate an AGENTS.md for the agent.",
+		kind:        commandInit,
 	},
 	{
 		name:        "/compact",

--- a/internal/tui/init_command.go
+++ b/internal/tui/init_command.go
@@ -1,0 +1,19 @@
+package tui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/agentinit"
+)
+
+// handleInitCommand runs the guided /init flow: build a bootstrap prompt seeded
+// with repo facts (agentinit.BuildPrompt) and launch a normal agent turn that
+// investigates the repo and writes AGENTS.md. It reuses launchPrompt, so the
+// run, tools, and AGENTS.md write path are exactly the standard ones.
+func (m model) handleInitCommand() (tea.Model, tea.Cmd) {
+	if m.exiting {
+		return m, nil
+	}
+	prompt := agentinit.BuildPrompt(m.ctx, m.cwd, m.now())
+	return m.launchPrompt(prompt)
+}

--- a/internal/tui/init_command_test.go
+++ b/internal/tui/init_command_test.go
@@ -1,0 +1,22 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestInitCommandLaunchesBootstrapRun(t *testing.T) {
+	m := newModel(context.Background(), Options{Cwd: t.TempDir()})
+	m.input.SetValue("/init")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	// /init launches a normal agent turn seeded with the AGENTS.md bootstrap
+	// prompt; the prompt lands in the transcript as the user turn.
+	if !transcriptContains(next.transcript, "Generate an AGENTS.md") {
+		t.Fatalf("/init should launch the bootstrap run, got %#v", next.transcript)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Gitlawb/zero/internal/streamjson"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/usage"
+	"github.com/Gitlawb/zero/internal/usercommands"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
 )
 
@@ -39,6 +40,7 @@ const chatWheelScrollLines = 5
 type model struct {
 	ctx                    context.Context
 	cwd                    string
+	userCommands           []usercommands.Command // file-sourced /commands (.zero/commands)
 	userConfigPath         string
 	doctorUserConfigPath   string
 	projectConfigPath      string
@@ -467,6 +469,9 @@ func newModel(ctx context.Context, options Options) model {
 		}
 	}
 
+	userConfigDir, _ := os.UserConfigDir()
+	loadedUserCommands := usercommands.Load(usercommands.DefaultPaths(cwd, userConfigDir))
+
 	registry := options.Registry
 	if registry == nil {
 		registry = options.AgentOptions.Registry
@@ -523,6 +528,7 @@ func newModel(ctx context.Context, options Options) model {
 	m := model{
 		ctx:                    ctx,
 		cwd:                    cwd,
+		userCommands:           loadedUserCommands,
 		composerCursorVisible:  true,
 		userConfigPath:         options.UserConfigPath,
 		doctorUserConfigPath:   doctorUserConfigPath,
@@ -2955,6 +2961,12 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		m = m.handleAddDirCommand(command.text)
 		return m, nil
 	case commandUnknown:
+		// A "/name" not in the builtin registry may be a user-defined command
+		// from .zero/commands/<name>.md — expand its template and run it as a
+		// normal prompt before reporting "unknown".
+		if next, cmd, handled := m.handleUserCommand(command.text); handled {
+			return next, cmd
+		}
 		m.transcript = reduceTranscript(m.transcript, transcriptAction{
 			kind: actionAppendError,
 			text: "unknown command: " + command.text,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2905,6 +2905,8 @@ func (m model) handleSubmit() (tea.Model, tea.Cmd) {
 		return m, retitleCmd
 	case commandSpec:
 		return m.handleSpecCommand(command.text)
+	case commandInit:
+		return m.handleInitCommand()
 	case commandCompact:
 		text := ""
 		var compactCmd tea.Cmd

--- a/internal/tui/user_commands.go
+++ b/internal/tui/user_commands.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/Gitlawb/zero/internal/usercommands"
+)
+
+// handleUserCommand resolves a "/name args" that wasn't a builtin command
+// against the file-sourced user commands (.zero/commands/<name>.md). When a
+// match is found it expands the command's template with the args and launches a
+// normal agent turn, returning handled=true. handled=false means no user
+// command matched, so the caller falls through to "unknown command".
+//
+// raw is the full slash input as parseCommand captured it for commandUnknown
+// (e.g. "/release v1.2"), so we re-split it here rather than thread the parsed
+// name/args through the builtin parser (which doesn't know about file commands).
+func (m model) handleUserCommand(raw string) (model, tea.Cmd, bool) {
+	name, args := splitUserCommand(raw)
+	if name == "" {
+		return m, nil, false
+	}
+	cmd, ok := m.lookupUserCommand(name)
+	if !ok {
+		return m, nil, false
+	}
+	prompt := usercommands.Expand(cmd.Template, args)
+	if strings.TrimSpace(prompt) == "" {
+		return m, nil, false
+	}
+	next, teaCmd := m.launchPrompt(prompt)
+	return next, teaCmd, true
+}
+
+// lookupUserCommand returns the loaded user command with the given (lowercased)
+// name. Linear scan — the set is small (a handful of files).
+func (m model) lookupUserCommand(name string) (usercommands.Command, bool) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, cmd := range m.userCommands {
+		if cmd.Name == name {
+			return cmd, true
+		}
+	}
+	return usercommands.Command{}, false
+}
+
+// splitUserCommand splits "/name rest of args" into the bare name (no leading
+// slash, lowercased) and the trailing argument string.
+func splitUserCommand(raw string) (string, string) {
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(raw, "/") {
+		return "", ""
+	}
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return "", ""
+	}
+	name := strings.ToLower(strings.TrimPrefix(fields[0], "/"))
+	args := strings.TrimSpace(raw[len(fields[0]):])
+	return name, args
+}

--- a/internal/tui/user_commands_test.go
+++ b/internal/tui/user_commands_test.go
@@ -1,0 +1,71 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func writeUserCommand(t *testing.T, root, name, content string) {
+	t.Helper()
+	dir := filepath.Join(root, ".zero", "commands")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestUserCommandExpandsAndSubmits(t *testing.T) {
+	root := t.TempDir()
+	writeUserCommand(t, root, "greet.md", "Say hello to $1 from the team.")
+
+	m := newModel(context.Background(), Options{Cwd: root})
+	if len(m.userCommands) != 1 {
+		t.Fatalf("expected the user command to load, got %d", len(m.userCommands))
+	}
+	m.input.SetValue("/greet world")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	if transcriptContains(next.transcript, "unknown command") {
+		t.Fatalf("a defined user command must not be 'unknown', got %#v", next.transcript)
+	}
+	if !transcriptContains(next.transcript, "Say hello to world from the team.") {
+		t.Fatalf("expanded user-command prompt should appear in the transcript, got %#v", next.transcript)
+	}
+}
+
+func TestUnknownSlashStillReportsUnknown(t *testing.T) {
+	m := newModel(context.Background(), Options{Cwd: t.TempDir()})
+	m.input.SetValue("/definitelynotacommand")
+
+	updated, _ := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+
+	if !transcriptContains(next.transcript, "unknown command") {
+		t.Fatalf("a /command with no builtin or user match should report unknown, got %#v", next.transcript)
+	}
+}
+
+func TestUserCommandAppearsInAutocomplete(t *testing.T) {
+	root := t.TempDir()
+	writeUserCommand(t, root, "deploy.md", "Deploy it.")
+	m := newModel(context.Background(), Options{Cwd: root})
+
+	got := m.matchCommandSuggestions("/dep")
+	found := false
+	for _, s := range got {
+		if s.Name == "/deploy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("user command /deploy should appear in autocomplete for '/dep', got %#v", got)
+	}
+}

--- a/internal/usercommands/usercommands.go
+++ b/internal/usercommands/usercommands.go
@@ -1,0 +1,212 @@
+// Package usercommands loads user-defined slash commands from markdown files.
+//
+// A user drops a file at `.zero/commands/<name>.md` (project, checked into the
+// repo and shared with the team) or `<userConfigDir>/zero/commands/<name>.md`
+// (personal), with optional YAML-style frontmatter:
+//
+//	---
+//	description: Open a PR for the current branch
+//	model: claude-sonnet-4.5
+//	---
+//	Create a pull request for the current branch. Title: $1. Summarize: $ARGUMENTS
+//
+// Typing `/<name> some args` expands the body template ($ARGUMENTS, $1..$N) and
+// submits it as a normal prompt. This turns Zero's model-pulled skills into
+// user-invokable, repo-checked-in team workflows. Project commands override
+// user commands of the same name (mirrors the specialist scope precedence).
+package usercommands
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Command is a user-defined slash command parsed from a markdown file.
+type Command struct {
+	Name        string // the `/name` (file basename, lowercased, sans .md)
+	Description string // frontmatter `description:`, for help + autocomplete
+	Model       string // optional frontmatter `model:` override
+	Agent       string // optional frontmatter `agent:`/`mode:` routing
+	Template    string // the markdown body, expanded on invocation
+	Path        string // source file, for diagnostics
+	Project     bool   // true if from the project `.zero/commands` dir
+}
+
+// Paths are the directories scanned for command files, project first.
+type Paths struct {
+	ProjectDir string
+	UserDir    string
+}
+
+// DefaultPaths returns the project and user command directories. workspaceRoot
+// is the repo root; userConfigDir is the OS config dir (os.UserConfigDir).
+func DefaultPaths(workspaceRoot, userConfigDir string) Paths {
+	p := Paths{}
+	if strings.TrimSpace(workspaceRoot) != "" {
+		p.ProjectDir = filepath.Join(workspaceRoot, ".zero", "commands")
+	}
+	if strings.TrimSpace(userConfigDir) != "" {
+		p.UserDir = filepath.Join(userConfigDir, "zero", "commands")
+	}
+	return p
+}
+
+// Load reads every `*.md` command file under the given paths and returns them
+// keyed by lowercased name, sorted by name. A project command shadows a user
+// command of the same name. Unreadable files are skipped (best-effort);
+// directories that do not exist are simply empty.
+func Load(paths Paths) []Command {
+	byName := map[string]Command{}
+	// User first, then project — so the project entry overwrites on collision.
+	for _, dir := range []string{paths.UserDir, paths.ProjectDir} {
+		project := dir == paths.ProjectDir && dir != ""
+		for _, cmd := range loadDir(dir, project) {
+			byName[cmd.Name] = cmd
+		}
+	}
+	out := make([]Command, 0, len(byName))
+	for _, cmd := range byName {
+		out = append(out, cmd)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func loadDir(dir string, project bool) []Command {
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var cmds []Command
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".md") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())))
+		if !validCommandName(name) {
+			continue
+		}
+		cmds = append(cmds, parseCommand(name, path, project, string(raw)))
+	}
+	return cmds
+}
+
+// validCommandName keeps file-sourced names to a safe slash-command shape so a
+// stray file can't shadow a builtin via odd characters: lowercase letters,
+// digits, and hyphens, non-empty.
+func validCommandName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9') && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func parseCommand(name, path string, project bool, raw string) Command {
+	cmd := Command{Name: name, Path: path, Project: project}
+	body := strings.ReplaceAll(raw, "\r\n", "\n")
+	if fm, remainder, ok := splitFrontmatter(body); ok {
+		body = remainder
+		cmd.Description = frontmatterValue(fm, "description")
+		cmd.Model = frontmatterValue(fm, "model")
+		cmd.Agent = frontmatterValue(fm, "agent")
+		if cmd.Agent == "" {
+			cmd.Agent = frontmatterValue(fm, "mode")
+		}
+	}
+	cmd.Template = strings.TrimSpace(body)
+	if cmd.Description == "" {
+		cmd.Description = "User command: /" + name
+	}
+	return cmd
+}
+
+// Expand substitutes the argument placeholders in a command template:
+//
+//	$ARGUMENTS      → all args, space-joined (the whole arg string)
+//	$1 .. $9        → the Nth whitespace-separated positional arg ("" if absent)
+//	$$              → a literal "$"
+//
+// A template with no placeholders is returned with the raw arg string appended
+// on its own line, so a trivial command still receives the user's input.
+func Expand(template, args string) string {
+	args = strings.TrimSpace(args)
+	positional := strings.Fields(args)
+
+	if !strings.Contains(template, "$") {
+		if args == "" {
+			return template
+		}
+		return template + "\n\n" + args
+	}
+
+	var b strings.Builder
+	runes := []rune(template)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] != '$' || i == len(runes)-1 {
+			b.WriteRune(runes[i])
+			continue
+		}
+		next := runes[i+1]
+		switch {
+		case next == '$':
+			b.WriteByte('$')
+			i++
+		case next >= '1' && next <= '9':
+			idx := int(next - '1')
+			if idx < len(positional) {
+				b.WriteString(positional[idx])
+			}
+			i++
+		case strings.HasPrefix(string(runes[i+1:]), "ARGUMENTS"):
+			b.WriteString(args)
+			i += len("ARGUMENTS")
+		default:
+			b.WriteRune('$')
+		}
+	}
+	return b.String()
+}
+
+// --- frontmatter helpers (self-contained; mirror internal/skills) ------------
+
+func splitFrontmatter(normalized string) (string, string, bool) {
+	if !strings.HasPrefix(normalized, "---\n") {
+		return "", "", false
+	}
+	lines := strings.Split(normalized, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for index := 1; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) == "---" {
+			return strings.Join(lines[1:index], "\n"), strings.Join(lines[index+1:], "\n"), true
+		}
+	}
+	return "", "", false
+}
+
+func frontmatterValue(frontmatter, key string) string {
+	prefix := strings.ToLower(key) + ":"
+	for _, line := range strings.Split(frontmatter, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), prefix) {
+			return strings.Trim(strings.TrimSpace(trimmed[len(prefix):]), `"'`)
+		}
+	}
+	return ""
+}

--- a/internal/usercommands/usercommands_test.go
+++ b/internal/usercommands/usercommands_test.go
@@ -1,0 +1,108 @@
+package usercommands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestLoadParsesFrontmatterAndBody(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".zero", "commands")
+	writeFile(t, dir, "release.md", "---\ndescription: Cut a release\nmodel: claude-sonnet-4.5\n---\nCut release $1 from the current branch.")
+
+	cmds := Load(DefaultPaths(root, ""))
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	c := cmds[0]
+	if c.Name != "release" {
+		t.Fatalf("name = %q, want release", c.Name)
+	}
+	if c.Description != "Cut a release" {
+		t.Fatalf("description = %q", c.Description)
+	}
+	if c.Model != "claude-sonnet-4.5" {
+		t.Fatalf("model = %q", c.Model)
+	}
+	if c.Template != "Cut release $1 from the current branch." {
+		t.Fatalf("template = %q", c.Template)
+	}
+	if !c.Project {
+		t.Fatal("expected Project=true for a .zero/commands file")
+	}
+}
+
+func TestLoadProjectOverridesUser(t *testing.T) {
+	root := t.TempDir()
+	userCfg := t.TempDir()
+	writeFile(t, filepath.Join(userCfg, "zero", "commands"), "review.md", "USER version")
+	writeFile(t, filepath.Join(root, ".zero", "commands"), "review.md", "PROJECT version")
+
+	cmds := Load(DefaultPaths(root, userCfg))
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 deduped command, got %d", len(cmds))
+	}
+	if cmds[0].Template != "PROJECT version" {
+		t.Fatalf("project should override user, got %q", cmds[0].Template)
+	}
+	if !cmds[0].Project {
+		t.Fatal("winning command should be the project one")
+	}
+}
+
+func TestLoadSkipsNonMarkdownAndInvalidNames(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".zero", "commands")
+	writeFile(t, dir, "ok.md", "fine")
+	writeFile(t, dir, "notes.txt", "ignored")   // not .md
+	writeFile(t, dir, "Bad Name.md", "ignored") // space → invalid name
+
+	cmds := Load(DefaultPaths(root, ""))
+	if len(cmds) != 1 || cmds[0].Name != "ok" {
+		t.Fatalf("expected only the valid 'ok' command, got %#v", cmds)
+	}
+}
+
+func TestLoadMissingDirsAreEmpty(t *testing.T) {
+	if cmds := Load(DefaultPaths(t.TempDir(), t.TempDir())); len(cmds) != 0 {
+		t.Fatalf("expected no commands for empty dirs, got %d", len(cmds))
+	}
+	if cmds := Load(Paths{}); len(cmds) != 0 {
+		t.Fatalf("expected no commands for blank paths, got %d", len(cmds))
+	}
+}
+
+func TestExpandPlaceholders(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+		args     string
+		want     string
+	}{
+		{"arguments", "Fix: $ARGUMENTS", "the flaky test in pkg", "Fix: the flaky test in pkg"},
+		{"positional", "Release $1 ($2)", "v1.2 patch", "Release v1.2 (patch)"},
+		{"missing positional is empty", "Tag $1 then $2", "only", "Tag only then "},
+		{"literal dollar", "cost is $$5", "x", "cost is $5"},
+		{"no placeholders no args", "Just do it.", "", "Just do it."},
+		{"no placeholders with args appends", "Do it.", "now please", "Do it.\n\nnow please"},
+		{"mixed", "PR $1: $ARGUMENTS", "title body words here", "PR title: title body words here"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Expand(tc.template, tc.args); got != tc.want {
+				t.Fatalf("Expand(%q,%q) = %q, want %q", tc.template, tc.args, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a guided `/init` flow to generate a repo-level `AGENTS.md`.
  * Added user-defined slash commands from `.zero/commands`, including template expansion, autocomplete, and execution support.
  * Added semantic code navigation via `lsp_navigate` (definition, references, implementation, workspace symbols), with clear “unavailable” fallback.
* **Improvements / Bug Fixes**
  * Improved streaming resiliency by reconnecting after transient disconnects.
  * Reduced expensive context handling by pruning stale tool outputs before costly summarization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->