### PR TITLE
Fix custom provider model discovery

### DIFF
--- a/internal/providermodeldiscovery/discovery.go
+++ b/internal/providermodeldiscovery/discovery.go
@@ -18,6 +18,8 @@ import (
 	"github.com/Gitlawb/zero/internal/redaction"
 )
 
+const anthropicVersion = "2023-06-01"
+
 type Model struct {
 	ID               string
 	Description      string
@@ -40,7 +42,7 @@ type Options struct {
 
 func DiscoverCatalog(ctx context.Context, provider providercatalog.Descriptor, profile config.ProviderProfile, options Options) ([]Model, error) {
 	catalogModels, catalogErr := fetchCatalogModels(ctx, provider, options)
-	canProbeProvider := openAICompatibleDiscoveryAllowed(profile) && (!provider.RequiresAuth || discoveryHasCredential(profile))
+	canProbeProvider := modelDiscoveryAllowed(profile) && (!provider.RequiresAuth || discoveryHasCredential(profile))
 	if canProbeProvider {
 		liveModels, liveErr := Discover(ctx, profile, options)
 		if liveErr == nil {
@@ -73,23 +75,22 @@ func discoveryHasCredential(profile config.ProviderProfile) bool {
 }
 
 func Discover(ctx context.Context, profile config.ProviderProfile, options Options) ([]Model, error) {
-	if !openAICompatibleDiscoveryAllowed(profile) {
-		return nil, fmt.Errorf("provider %s does not expose OpenAI-compatible model discovery", displayProviderName(profile))
+	switch discoveryProviderKind(profile) {
+	case config.ProviderKindOpenAI, config.ProviderKindOpenAICompatible:
+		return discoverOpenAIModels(ctx, profile, options)
+	case config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
+		return discoverAnthropicModels(ctx, profile, options)
+	default:
+		return nil, fmt.Errorf("provider %s does not expose model discovery", displayProviderName(profile))
 	}
+}
+
+func discoverOpenAIModels(ctx context.Context, profile config.ProviderProfile, options Options) ([]Model, error) {
 	endpoint, err := modelsEndpoint(profile.BaseURL)
 	if err != nil {
 		return nil, err
 	}
-
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	// Authenticate via either an APIKey (Authorization: Bearer ...) or a raw
-	// auth-header value / custom headers, matching how the live providers build
-	// their requests (internal/providers/providerio). Honoring AuthHeaderValue
-	// keeps discovery consistent with the credential-present logic elsewhere.
-	providerio.ApplyAuthHeaders(request, providerio.AuthHeaders{
+	return fetchProviderModels(ctx, endpoint, profile, options, providerio.AuthHeaders{
 		APIKey:            profile.APIKey,
 		DefaultAuthHeader: "Authorization",
 		DefaultAuthScheme: "Bearer",
@@ -97,8 +98,40 @@ func Discover(ctx context.Context, profile config.ProviderProfile, options Optio
 		AuthScheme:        profile.AuthScheme,
 		AuthHeaderValue:   profile.AuthHeaderValue,
 		CustomHeaders:     profile.CustomHeaders,
+	}, nil)
+}
+
+func discoverAnthropicModels(ctx context.Context, profile config.ProviderProfile, options Options) ([]Model, error) {
+	endpoint, err := anthropicModelsEndpoint(profile.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	return fetchProviderModels(ctx, endpoint, profile, options, providerio.AuthHeaders{
+		APIKey:            profile.APIKey,
+		DefaultAuthHeader: "x-api-key",
+		AuthHeader:        profile.AuthHeader,
+		AuthScheme:        profile.AuthScheme,
+		AuthHeaderValue:   profile.AuthHeaderValue,
+		CustomHeaders:     profile.CustomHeaders,
+	}, func(request *http.Request) {
+		request.Header.Set("anthropic-version", anthropicVersion)
 	})
+}
+
+func fetchProviderModels(ctx context.Context, endpoint string, profile config.ProviderProfile, options Options, auth providerio.AuthHeaders, configure func(*http.Request)) ([]Model, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Authenticate via either an APIKey or a raw auth-header value / custom
+	// headers, matching how the live providers build their requests
+	// (internal/providers/providerio). Honoring AuthHeaderValue keeps discovery
+	// consistent with the credential-present logic elsewhere.
+	providerio.ApplyAuthHeaders(request, auth)
 	request.Header.Set("Accept", "application/json")
+	if configure != nil {
+		configure(request)
+	}
 
 	client := options.HTTPClient
 	if client == nil {
@@ -125,12 +158,21 @@ func Discover(ctx context.Context, profile config.ProviderProfile, options Optio
 	return models, nil
 }
 
-func openAICompatibleDiscoveryAllowed(profile config.ProviderProfile) bool {
+func modelDiscoveryAllowed(profile config.ProviderProfile) bool {
+	switch discoveryProviderKind(profile) {
+	case config.ProviderKindOpenAI, config.ProviderKindOpenAICompatible, config.ProviderKindAnthropic, config.ProviderKindAnthropicCompat:
+		return true
+	default:
+		return false
+	}
+}
+
+func discoveryProviderKind(profile config.ProviderProfile) config.ProviderKind {
 	kind := config.ProviderKind(strings.TrimSpace(strings.ToLower(string(profile.ProviderKind))))
 	if kind == "" {
 		kind = config.ProviderKind(strings.TrimSpace(strings.ToLower(profile.Provider)))
 	}
-	return kind == config.ProviderKindOpenAI || kind == config.ProviderKindOpenAICompatible
+	return kind
 }
 
 func modelsEndpoint(baseURL string) (string, error) {
@@ -148,9 +190,31 @@ func modelsEndpoint(baseURL string) (string, error) {
 	return parsed.String(), nil
 }
 
+func anthropicModelsEndpoint(baseURL string) (string, error) {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return "", fmt.Errorf("provider base URL is required for model discovery")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid provider base URL %q", baseURL)
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	if strings.HasSuffix(strings.ToLower(path), "/v1") {
+		parsed.Path = path + "/models"
+	} else {
+		parsed.Path = path + "/v1/models"
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
 type modelsResponse struct {
 	Data []struct {
-		ID string `json:"id"`
+		ID          string `json:"id"`
+		DisplayName string `json:"display_name"`
+		Name        string `json:"name"`
 	} `json:"data"`
 }
 
@@ -167,7 +231,11 @@ func parseModelsResponse(body []byte) ([]Model, error) {
 			continue
 		}
 		seen[id] = true
-		models = append(models, Model{ID: id})
+		description := strings.TrimSpace(item.DisplayName)
+		if description == "" {
+			description = strings.TrimSpace(item.Name)
+		}
+		models = append(models, Model{ID: id, Description: description})
 	}
 	sort.SliceStable(models, func(i, j int) bool {
 		return models[i].ID < models[j].ID

--- a/internal/providermodeldiscovery/discovery_test.go
+++ b/internal/providermodeldiscovery/discovery_test.go
@@ -123,12 +123,56 @@ func TestDiscoverOpenAICompatibleModelsHandlesBaseURLWithoutVersion(t *testing.T
 
 func TestDiscoverOpenAICompatibleModelsRejectsUnsupportedProviders(t *testing.T) {
 	_, err := Discover(context.Background(), config.ProviderProfile{
-		Name:         "anthropic",
-		ProviderKind: config.ProviderKindAnthropic,
-		BaseURL:      "https://api.anthropic.com",
+		Name:         "google",
+		ProviderKind: config.ProviderKindGoogle,
+		BaseURL:      "https://generativelanguage.googleapis.com",
 	}, Options{})
-	if err == nil || !strings.Contains(err.Error(), "does not expose OpenAI-compatible model discovery") {
+	if err == nil || !strings.Contains(err.Error(), "does not expose model discovery") {
 		t.Fatalf("Discover error = %v, want unsupported provider message", err)
+	}
+}
+
+func TestDiscoverAnthropicCompatibleModelsFetchesModelsEndpoint(t *testing.T) {
+	const apiKey = "sk-ant-secret"
+	var gotPath string
+	var gotAPIKey string
+	var gotVersion string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id": "claude-custom-b", "display_name": "Claude Custom B"},
+				{"id": "claude-custom-a", "display_name": "Claude Custom A"},
+				{"id": "claude-custom-a", "display_name": "Claude Custom A"},
+				{}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	models, err := Discover(context.Background(), config.ProviderProfile{
+		Name:         "custom",
+		ProviderKind: config.ProviderKindAnthropicCompat,
+		BaseURL:      server.URL + "/anthropic",
+		APIKey:       apiKey,
+	}, Options{HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+	if gotPath != "/anthropic/v1/models" {
+		t.Fatalf("requested path = %q, want /anthropic/v1/models", gotPath)
+	}
+	if gotAPIKey != apiKey {
+		t.Fatalf("x-api-key = %q, want API key", gotAPIKey)
+	}
+	if gotVersion == "" {
+		t.Fatal("anthropic-version header is required")
+	}
+	if got, want := modelIDs(models), []string{"claude-custom-a", "claude-custom-b"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("models = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/tui/command_center.go
+++ b/internal/tui/command_center.go
@@ -522,6 +522,9 @@ func (m model) resolveModelSwitchTarget(registry modelregistry.Registry, args st
 				return modelSwitchTarget{modelID: model.ID}, true
 			}
 		}
+		if genericProviderCatalogID(provider.ID) && strings.TrimSpace(args) != "" {
+			return modelSwitchTarget{modelID: strings.TrimSpace(args)}, true
+		}
 	}
 	return modelSwitchTarget{}, false
 }

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -349,6 +349,9 @@ func (m model) activeProviderDescriptor() (providercatalog.Descriptor, bool) {
 	if descriptor, ok := providerDescriptorByBaseURL(m.providerProfile.BaseURL); ok {
 		return descriptor, true
 	}
+	if descriptor, ok := customProviderDescriptorForProfile(m.providerProfile); ok {
+		return descriptor, true
+	}
 	for _, candidate := range []string{
 		m.providerProfile.Name,
 		m.providerName,
@@ -360,6 +363,46 @@ func (m model) activeProviderDescriptor() (providercatalog.Descriptor, bool) {
 		}
 	}
 	return providercatalog.Descriptor{}, false
+}
+
+func customProviderDescriptorForProfile(profile config.ProviderProfile) (providercatalog.Descriptor, bool) {
+	if descriptor, ok := providercatalog.Get(profile.CatalogID); ok && genericProviderCatalogID(descriptor.ID) {
+		return descriptor, true
+	}
+
+	baseURL := strings.TrimSpace(profile.BaseURL)
+	if baseURL == "" {
+		return providercatalog.Descriptor{}, false
+	}
+	switch profileProviderKind(profile) {
+	case config.ProviderKindOpenAICompatible:
+		if !sameNormalizedProviderBaseURL(baseURL, config.OpenAIBaseURL) {
+			return providercatalog.Get("custom-openai-compatible")
+		}
+	case config.ProviderKindAnthropicCompat:
+		if !sameNormalizedProviderBaseURL(baseURL, config.AnthropicBaseURL) {
+			return providercatalog.Get("custom-anthropic-compatible")
+		}
+	case config.ProviderKindOpenAI:
+		if !sameNormalizedProviderBaseURL(baseURL, config.OpenAIBaseURL) {
+			return providercatalog.Get("custom-openai-compatible")
+		}
+	case config.ProviderKindAnthropic:
+		if !sameNormalizedProviderBaseURL(baseURL, config.AnthropicBaseURL) {
+			return providercatalog.Get("custom-anthropic-compatible")
+		}
+	}
+	return providercatalog.Descriptor{}, false
+}
+
+func profileProviderKind(profile config.ProviderProfile) config.ProviderKind {
+	if kind := strings.TrimSpace(string(profile.ProviderKind)); kind != "" {
+		return config.ProviderKind(strings.ToLower(kind))
+	}
+	if provider := strings.TrimSpace(profile.Provider); provider != "" {
+		return config.ProviderKind(strings.ToLower(provider))
+	}
+	return ""
 }
 
 func providerDescriptorByBaseURL(baseURL string) (providercatalog.Descriptor, bool) {
@@ -380,6 +423,10 @@ func providerDescriptorByBaseURL(baseURL string) (providercatalog.Descriptor, bo
 
 func normalizeProviderBaseURL(baseURL string) string {
 	return strings.TrimRight(strings.ToLower(strings.TrimSpace(baseURL)), "/")
+}
+
+func sameNormalizedProviderBaseURL(left string, right string) bool {
+	return normalizeProviderBaseURL(left) == normalizeProviderBaseURL(right)
 }
 
 func genericProviderCatalogID(id string) bool {

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -92,6 +92,54 @@ func TestModelPickerRefreshesLiveModelsForActiveProvider(t *testing.T) {
 	}
 }
 
+func TestModelPickerTreatsCustomOpenAIEndpointAsCustomProvider(t *testing.T) {
+	var captured config.ProviderProfile
+	m := newModel(context.Background(), Options{
+		ProviderName: "openai",
+		ModelName:    "custom-coder",
+		ProviderProfile: config.ProviderProfile{
+			Name:         "openai",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://proxy.example.test/v1",
+			APIKey:       "proxy-key",
+			Model:        "custom-coder",
+		},
+		DiscoverProviderModels: func(ctx context.Context, profile config.ProviderProfile) ([]providermodeldiscovery.Model, error) {
+			captured = profile
+			return []providermodeldiscovery.Model{
+				{ID: "custom-coder-plus", Description: "Custom Coder Plus"},
+			}, nil
+		},
+	})
+	m.input.SetValue("/model")
+
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if next.picker == nil {
+		t.Fatal("expected model picker to open")
+	}
+	if cmd == nil {
+		t.Fatal("opening /model for a custom endpoint should start model discovery")
+	}
+	updated, _ = next.Update(cmd())
+	next = updated.(model)
+
+	if captured.CatalogID != "custom-openai-compatible" || captured.ProviderKind != config.ProviderKindOpenAICompatible {
+		t.Fatalf("discovery profile = %#v, want custom OpenAI-compatible identity", captured)
+	}
+	groups := pickerGroups(next.picker.items)
+	if !contains(groups, "Custom OpenAI-compatible catalog") {
+		t.Fatalf("picker groups = %#v, want custom catalog group", groups)
+	}
+	got := pickerValues(next.picker.items)
+	if !contains(got, "custom-coder-plus") {
+		t.Fatalf("picker values = %#v, want discovered custom model", got)
+	}
+	if contains(got, "gpt-4.1") {
+		t.Fatalf("custom endpoint picker should not fall back to official OpenAI models: %#v", got)
+	}
+}
+
 func TestModelPickerShowsLoadingUntilDiscoveryCompletes(t *testing.T) {
 	m := newModel(context.Background(), Options{
 		ProviderName: "ollama-cloud",
@@ -445,6 +493,43 @@ func TestModelPickerAppliesActiveProviderCatalogModelID(t *testing.T) {
 	}
 	if !transcriptContains(next.transcript, "model: openai/gpt-4.1") {
 		t.Fatalf("expected model switch status, got %#v", next.transcript)
+	}
+}
+
+func TestModelCommandAcceptsManualModelForCustomProvider(t *testing.T) {
+	var captured config.ProviderProfile
+	m := newModel(context.Background(), Options{
+		ProviderName: "custom-openai-compatible",
+		ModelName:    "custom-model",
+		Provider:     &fakeProvider{},
+		ProviderProfile: config.ProviderProfile{
+			Name:         "custom-openai-compatible",
+			CatalogID:    "custom-openai-compatible",
+			ProviderKind: config.ProviderKindOpenAICompatible,
+			BaseURL:      "https://proxy.example.test/v1",
+			APIKey:       "proxy-key",
+			Model:        "custom-model",
+		},
+		NewProvider: func(profile config.ProviderProfile) (zeroruntime.Provider, error) {
+			captured = profile
+			return &fakeProvider{}, nil
+		},
+	})
+	m.input.SetValue("/model qwen-custom-latest")
+
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("expected /model to be handled without starting a run")
+	}
+	if captured.Model != "qwen-custom-latest" {
+		t.Fatalf("captured model = %q, want manual custom model", captured.Model)
+	}
+	if next.modelName != "qwen-custom-latest" {
+		t.Fatalf("active model = %q, want manual custom model", next.modelName)
+	}
+	if transcriptContains(next.transcript, "unknown Zero model") {
+		t.Fatalf("manual custom model should not be rejected, got %#v", next.transcript)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat custom OpenAI/Anthropic endpoints as custom providers in the /model picker instead of falling back to official provider catalogs
- Discover Anthropic-compatible models via the provider /v1/models endpoint
- Allow manual /model <id> switches for custom providers when remote discovery cannot provide a catalog

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./internal/providermodeldiscovery ./internal/providermodelcatalog ./internal/tui ./internal/config ./internal/providers
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model discovery support for Anthropic-compatible providers.
  * Added support for custom OpenAI-compatible and Anthropic-compatible endpoints.
  * Model descriptions are now captured and displayed during discovery.
  * Manual model selection is now available for custom providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->