### PR TITLE
Install Windows sandbox helper binaries

### DIFF
--- a/internal/installtest/install_scripts_test.go
+++ b/internal/installtest/install_scripts_test.go
@@ -44,8 +44,10 @@ func TestPowerShellInstallerScriptMatchesWindowsReleaseContracts(t *testing.T) {
 		`$checksumName = "$archiveName.sha256"`,
 		`Get-FileHash -Path $archivePath -Algorithm SHA256`,
 		`Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force`,
-		`Get-ChildItem -Path $extractDir -Filter "zero.exe" -File -Recurse`,
-		`Copy-Item -Path $binaryPath -Destination $targetPath -Force`,
+		`Find-ZeroExtractedFile -Root $extractDir -FileName $fileName`,
+		`"zero-windows-command-runner.exe"`,
+		`"zero-windows-sandbox-setup.exe"`,
+		`Copy-Item -Path $sourcePath -Destination (Join-Path $InstallDir $fileName) -Force`,
 	})
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -43,6 +43,25 @@ function Get-ZeroArch {
   }
 }
 
+function Find-ZeroExtractedFile {
+  param(
+    [string]$Root,
+    [string]$FileName
+  )
+
+  $candidate = Join-Path $Root $FileName
+  if (Test-Path $candidate -PathType Leaf) {
+    return $candidate
+  }
+
+  $matches = @(Get-ChildItem -Path $Root -Filter $FileName -File -Recurse)
+  if ($matches.Count -eq 1) {
+    return $matches[0].FullName
+  }
+
+  throw "Release archive did not contain exactly one $FileName"
+}
+
 if ($Version -eq "latest") {
   $tag = Get-ZeroLatestTag -Repository $Repository -GitHubApi $GitHubApi
 } elseif ($Version.StartsWith("v")) {
@@ -78,24 +97,19 @@ try {
   }
 
   Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
-  $binaryPath = Join-Path $extractDir "zero.exe"
-
-  if (-not (Test-Path $binaryPath)) {
-    $binaryMatches = @(Get-ChildItem -Path $extractDir -Filter "zero.exe" -File -Recurse)
-
-    if ($binaryMatches.Count -eq 1) {
-      $binaryPath = $binaryMatches[0].FullName
-    }
-  }
-
-  if (-not (Test-Path $binaryPath)) {
-    throw "Release archive did not contain exactly one zero.exe"
-  }
 
   New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-  $targetPath = Join-Path $InstallDir "zero.exe"
-  Copy-Item -Path $binaryPath -Destination $targetPath -Force
+  $requiredFiles = @(
+    "zero.exe",
+    "zero-windows-command-runner.exe",
+    "zero-windows-sandbox-setup.exe"
+  )
+  foreach ($fileName in $requiredFiles) {
+    $sourcePath = Find-ZeroExtractedFile -Root $extractDir -FileName $fileName
+    Copy-Item -Path $sourcePath -Destination (Join-Path $InstallDir $fileName) -Force
+  }
 
+  $targetPath = Join-Path $InstallDir "zero.exe"
   Write-Host "Installed $targetPath"
 
   $pathEntries = $env:PATH -split [System.IO.Path]::PathSeparator


### PR DESCRIPTION
## Summary
- Copy the Windows sandbox command runner and setup helper during PowerShell install
- Resolve required files from either the archive root or nested package directory
- Extend installer contract coverage so helper copying cannot regress

## Why
Windows sandboxed commands fail before execution when only zero.exe is installed because the native sandbox command runner cannot be found. Release packaging already includes these helper binaries; the installer was dropping them.

## Tests
- GOCACHE=/tmp/zero-go-cache go test ./internal/installtest -count=1
- GOCACHE=/tmp/zero-go-cache go test ./internal/release -count=1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Windows installer now deploys additional required executable components alongside the primary binary to ensure complete installation.
  * Enhanced file extraction validation to confirm each required component is located and installed correctly to the installation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->