### PR TITLE
fix(sandbox): make the Windows sandbox work in dev (self-dispatch helpers)

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -190,6 +190,21 @@ func defaultUserPluginsDir() string {
 }
 
 func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) (exitCode int) {
+	// Self-dispatch as the Windows sandbox helper. When no standalone helper .exe
+	// is shipped (dev / plain `go build`), the sandbox launches the running zero
+	// binary with one of these hidden subcommands instead of a separate
+	// executable (see resolveWindowsSandboxHelper). Routed before crash-recover,
+	// dep-fill, and --add-dir splitting so it can never collide with a real
+	// subcommand; the "__" prefix is unreachable by normal invocation.
+	if len(args) > 0 {
+		switch args[0] {
+		case sandbox.WindowsCommandRunnerSubcommand:
+			return sandbox.RunWindowsSandboxCommandRunner(args[1:], stderr)
+		case sandbox.WindowsSandboxSetupSubcommand:
+			return sandbox.RunWindowsSandboxSetup(args[1:], stderr)
+		}
+	}
+
 	// Convert an unexpected panic anywhere in the CLI into a saved crash report and
 	// a brief notice, rather than a raw stack trace dumped at the user.
 	defer observability.Recover(observability.DefaultCrashDir(), "cli", stderr, &exitCode)

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -155,7 +155,14 @@ func runSandboxSetup(args []string, stdout io.Writer, stderr io.Writer, deps app
 		return writeExecUsageError(stderr, err.Error())
 	}
 	profile := zeroSandbox.PermissionProfileFromPolicy(workspaceRoot, policy, scope)
-	setupPath := zeroSandbox.WindowsSandboxSetupPathForRunner(backend.Executable)
+	// Resolve the setup helper the same way the runner is resolved: a standalone
+	// .exe when shipped (release), else self-dispatch via the running zero binary
+	// (dev / plain build). This mirrors the backend's command-runner resolution
+	// so `zero sandbox setup` works in every layout, not just release.
+	setupHelper := zeroSandbox.ResolveWindowsSandboxSetupHelper(nil)
+	if !setupHelper.Available() {
+		return writeAppError(stderr, "Windows sandbox setup helper is not available", exitProvider)
+	}
 	setupArgs, err := zeroSandbox.BuildWindowsSandboxSetupArgs(zeroSandbox.WindowsSandboxSetupArgsOptions{
 		CommandCWD:        workspaceRoot,
 		WorkspaceRoots:    []string{workspaceRoot},
@@ -164,13 +171,14 @@ func runSandboxSetup(args []string, stdout io.Writer, stderr io.Writer, deps app
 	if err != nil {
 		return writeAppError(stderr, err.Error(), exitCrash)
 	}
-	if err := deps.runSandboxSetupHelper(setupPath, setupArgs, stdout, stderr); err != nil {
+	setupArgs = append(append([]string{}, setupHelper.ArgsPrefix...), setupArgs...)
+	if err := deps.runSandboxSetupHelper(setupHelper.Name, setupArgs, stdout, stderr); err != nil {
 		return writeAppError(stderr, "Windows sandbox setup failed: "+err.Error(), exitProvider)
 	}
 	return writeSandboxSetupResult(stdout, options.json, sandboxSetupResult{
 		Platform: "windows",
 		Backend:  backend.Name,
-		Helper:   setupPath,
+		Helper:   setupHelper.Name,
 		Ran:      true,
 		Message:  "Windows sandbox setup complete",
 	})

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -339,6 +339,35 @@ func TestRunSandboxPolicyInspectTextAndJSON(t *testing.T) {
 	}
 }
 
+func TestHiddenWindowsSandboxSubcommandsSelfDispatch(t *testing.T) {
+	// The runner/setup sentinels are routed before normal CLI parsing, straight
+	// into the sandbox helper mains — never the unknown-command path. With no
+	// helper-specific flags they fail their own arg validation (non-zero), but
+	// crucially the message is the helper's, proving the dispatch.
+	for _, tc := range []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"runner", sandbox.WindowsCommandRunnerSubcommand, sandbox.WindowsSandboxCommandRunnerName},
+		{"setup", sandbox.WindowsSandboxSetupSubcommand, sandbox.WindowsSandboxSetupName},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exit := runWithDeps([]string{tc.arg}, &stdout, &stderr, appDeps{})
+			if exit == 0 {
+				t.Fatalf("expected non-zero exit from the helper's own arg validation, got 0")
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr = %q, want the %s helper's message (proves self-dispatch)", stderr.String(), tc.want)
+			}
+			if strings.Contains(stderr.String(), "unknown command") {
+				t.Fatalf("sentinel %q fell through to normal CLI dispatch: %q", tc.arg, stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunSandboxSetupRunsWindowsHelper(t *testing.T) {
 	workspace := t.TempDir()
 	runnerDir := t.TempDir()
@@ -374,11 +403,22 @@ func TestRunSandboxSetupRunsWindowsHelper(t *testing.T) {
 	if exitCode != exitSuccess {
 		t.Fatalf("setup exit = %d, stderr %q", exitCode, stderr.String())
 	}
-	wantPath := filepath.Join(runnerDir, sandbox.WindowsSandboxSetupName)
-	if gotPath != wantPath {
-		t.Fatalf("setup helper path = %q, want %q", gotPath, wantPath)
+	// The setup helper is now resolved independently of backend.Executable: an
+	// adjacent zero-windows-sandbox-setup.exe in release, else self-dispatch via
+	// the running binary. Under `go test` no sibling helper exists, so it
+	// self-dispatches: path is the running binary and the first arg is the hidden
+	// setup subcommand, followed by the real setup args.
+	wantPath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
 	}
-	config, err := sandbox.ParseWindowsSandboxSetupArgs(gotArgs)
+	if gotPath != wantPath {
+		t.Fatalf("setup helper path = %q, want self-dispatch binary %q", gotPath, wantPath)
+	}
+	if len(gotArgs) == 0 || gotArgs[0] != sandbox.WindowsSandboxSetupSubcommand {
+		t.Fatalf("setup args = %#v, want leading %q subcommand", gotArgs, sandbox.WindowsSandboxSetupSubcommand)
+	}
+	config, err := sandbox.ParseWindowsSandboxSetupArgs(gotArgs[1:])
 	if err != nil {
 		t.Fatalf("ParseWindowsSandboxSetupArgs: %v", err)
 	}

--- a/internal/doctor/hardening_test.go
+++ b/internal/doctor/hardening_test.go
@@ -139,34 +139,23 @@ func TestSandboxCheckReportsWindowsNativeSetupStates(t *testing.T) {
 		t.Fatalf("setup warning details = %#v, want missing/out-of-date with setup remedy", needsSetup.Details)
 	}
 
-	setupMissing := Run(Options{
+	// With self-dispatch, the standalone helper .exe files no longer need to be
+	// on PATH for the Windows backend to be usable — the running zero binary acts
+	// as its own command-runner/setup helper. So a missing PATH helper no longer
+	// reports "unavailable"; the backend is available and (with no workspace to
+	// require a setup marker) the check passes. The actionable "run `zero sandbox
+	// setup`" guidance is covered by the marker-missing case above.
+	noPathHelpers := Run(Options{
 		Now:              fixedDoctorClock("2026-06-12T10:09:00Z"),
-		Runtime:          "go",
-		GOOS:             "windows",
-		LookupExecutable: stubLookup(sandbox.WindowsSandboxCommandRunnerName),
-	}).Check("sandbox.backend")
-	if setupMissing == nil || setupMissing.Status != StatusWarn {
-		t.Fatalf("expected setup-missing warning, got %#v", setupMissing)
-	}
-	remedy, _ := setupMissing.Details["remedy"].(string)
-	if !strings.Contains(setupMissing.Message, "setup helper") || !strings.Contains(remedy, "zero sandbox setup") {
-		t.Fatalf("setup-missing check message=%q remedy=%q details=%#v", setupMissing.Message, remedy, setupMissing.Details)
-	}
-	if strings.Contains(setupMissing.Message, "not yet available") || strings.Contains(remedy, "WSL2") {
-		t.Fatalf("windows remedy should not claim native sandboxing is unavailable: message=%q remedy=%q", setupMissing.Message, remedy)
-	}
-
-	runnerMissing := Run(Options{
-		Now:              fixedDoctorClock("2026-06-12T10:10:00Z"),
 		Runtime:          "go",
 		GOOS:             "windows",
 		LookupExecutable: stubLookup(),
 	}).Check("sandbox.backend")
-	if runnerMissing == nil || runnerMissing.Status != StatusWarn {
-		t.Fatalf("expected runner-missing warning, got %#v", runnerMissing)
+	if noPathHelpers == nil || noPathHelpers.Status != StatusPass {
+		t.Fatalf("expected available windows backend via self-dispatch when no PATH helpers, got %#v", noPathHelpers)
 	}
-	if !strings.Contains(runnerMissing.Message, "command runner") {
-		t.Fatalf("runner-missing message = %q, want command runner guidance", runnerMissing.Message)
+	if !strings.Contains(noPathHelpers.Message, string(sandbox.BackendWindowsRestrictedToken)) {
+		t.Fatalf("expected native Windows backend in message, got %q", noPathHelpers.Message)
 	}
 }
 

--- a/internal/sandbox/adapters.go
+++ b/internal/sandbox/adapters.go
@@ -17,7 +17,13 @@ type Backend struct {
 	CommandWrapping bool        `json:"commandWrapping"`
 	NativeIsolation bool        `json:"nativeIsolation"`
 	Executable      string      `json:"executable,omitempty"`
-	Message         string      `json:"message,omitempty"`
+	// ExecutableArgsPrefix is prepended to a wrapped command's args before the
+	// sandbox arguments. Non-empty only for the Windows self-dispatch helper,
+	// where Executable is the running zero binary and this carries the hidden
+	// subcommand token (e.g. "__windows-command-runner"). nil for every other
+	// backend, so their serialized form is unchanged.
+	ExecutableArgsPrefix []string `json:"executableArgsPrefix,omitempty"`
+	Message              string   `json:"message,omitempty"`
 }
 
 type BackendPlan struct {

--- a/internal/sandbox/adapters_test.go
+++ b/internal/sandbox/adapters_test.go
@@ -103,25 +103,37 @@ func TestSelectBackendChoosesPlatformAdapterWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("windows setup helper missing", func(t *testing.T) {
+	t.Run("windows missing helper exes self-dispatch", func(t *testing.T) {
+		// No adjacent or PATH helper .exe (the dev / plain `go build` case): the
+		// backend self-dispatches via the running zero binary, so it is AVAILABLE
+		// rather than failing every command. Pin os.Executable for determinism.
+		restore := osExecutable
+		osExecutable = func() (string, error) { return `C:\zero\zero.exe`, nil }
+		defer func() { osExecutable = restore }()
 		backend := SelectBackend(BackendOptions{
-			GOOS: "windows",
-			LookupExecutable: func(name string) (string, error) {
-				if name == WindowsSandboxCommandRunnerName {
-					return `C:\zero\zero-windows-command-runner.exe`, nil
-				}
-				return "", errors.New("missing")
-			},
+			GOOS:             "windows",
+			LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },
 		})
-		if backend.Name != BackendUnavailable || backend.Available || backend.Platform != "windows" {
-			t.Fatalf("windows backend = %#v, want unavailable windows backend", backend)
+		if backend.Name != BackendWindowsRestrictedToken || !backend.Available || backend.Platform != "windows" {
+			t.Fatalf("windows backend = %#v, want available via self-dispatch", backend)
 		}
-		if !strings.Contains(backend.Message, "Windows sandbox setup helper is not available") {
-			t.Fatalf("expected Windows setup helper fallback message, got %q", backend.Message)
+		if backend.Executable != `C:\zero\zero.exe` {
+			t.Fatalf("self-dispatch executable = %q, want the running binary", backend.Executable)
+		}
+		if len(backend.ExecutableArgsPrefix) != 1 || backend.ExecutableArgsPrefix[0] != WindowsCommandRunnerSubcommand {
+			t.Fatalf("self-dispatch args prefix = %#v, want [%q]", backend.ExecutableArgsPrefix, WindowsCommandRunnerSubcommand)
+		}
+		if !backend.CommandWrapping || !backend.NativeIsolation {
+			t.Fatalf("windows backend capabilities = %#v, want native wrapping", backend)
 		}
 	})
 
-	t.Run("windows falls back explicitly", func(t *testing.T) {
+	t.Run("windows unavailable only when running binary is unresolvable", func(t *testing.T) {
+		// Self-dispatch removes every other unavailable path; the sole remaining
+		// one is os.Executable failing, which the resolver degrades cleanly.
+		restore := osExecutable
+		osExecutable = func() (string, error) { return "", errors.New("no exe") }
+		defer func() { osExecutable = restore }()
 		backend := SelectBackend(BackendOptions{
 			GOOS:             "windows",
 			LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },
@@ -228,6 +240,11 @@ func TestBackendBuildPlanDocumentsBestEffortIsolation(t *testing.T) {
 }
 
 func TestBackendCapabilitiesReflectDisabledPolicy(t *testing.T) {
+	// Force the Windows backend genuinely unavailable (no self-dispatch) so
+	// command_wrapping reflects an unavailable backend under a disabled policy.
+	restore := osExecutable
+	osExecutable = func() (string, error) { return "", errors.New("no exe") }
+	defer func() { osExecutable = restore }()
 	backend := SelectBackend(BackendOptions{
 		GOOS:             "windows",
 		LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },

--- a/internal/sandbox/architecture_baseline_test.go
+++ b/internal/sandbox/architecture_baseline_test.go
@@ -51,10 +51,15 @@ func TestBackendPlanCarriesPhase0ManagerFields(t *testing.T) {
 		}
 	}
 
+	// Force the Windows backend genuinely unavailable (no self-dispatch) to
+	// exercise the degraded/unwrapped plan representation here.
+	restoreExe := osExecutable
+	osExecutable = func() (string, error) { return "", errors.New("no exe") }
 	windows := SelectBackend(BackendOptions{
 		GOOS:             "windows",
 		LookupExecutable: func(string) (string, error) { return "", errors.New("missing") },
 	}).BuildPlan("/workspace", DefaultPolicy())
+	osExecutable = restoreExe
 
 	if windows.TargetBackend != BackendWindowsRestrictedToken {
 		t.Fatalf("windows target backend = %q, want %q", windows.TargetBackend, BackendWindowsRestrictedToken)

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -92,10 +92,12 @@ func selectPlatformBackend(goos string, lookup func(string) (string, error)) Bac
 	case "windows":
 		runner := findWindowsSandboxCommandRunner(lookup)
 		setup := findWindowsSandboxSetupHelper(lookup)
-		if runner != "" && setup != "" {
-			return nativeBackend(goos, BackendWindowsRestrictedToken, runner, "Windows sandbox command runner and setup helper available")
+		if runner.Available() && setup.Available() {
+			backend := nativeBackend(goos, BackendWindowsRestrictedToken, runner.Name, "Windows sandbox command runner and setup helper available")
+			backend.ExecutableArgsPrefix = runner.ArgsPrefix
+			return backend
 		}
-		if runner != "" {
+		if runner.Available() {
 			return unavailableBackend(goos, "Windows sandbox setup helper is not available")
 		}
 		return unavailableBackend(goos, "Windows sandbox command runner is not available")

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -255,7 +256,7 @@ func TestSelectBackendDelegatesToSandboxManagerSelection(t *testing.T) {
 			return "", errors.New("missing")
 		},
 	}).Backend()
-	if backend != managerBackend {
+	if !reflect.DeepEqual(backend, managerBackend) {
 		t.Fatalf("SelectBackend = %#v, manager backend = %#v", backend, managerBackend)
 	}
 }

--- a/internal/sandbox/windows_helper_discovery_test.go
+++ b/internal/sandbox/windows_helper_discovery_test.go
@@ -1,0 +1,89 @@
+package sandbox
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveWindowsSandboxHelperTiers covers the three-tier resolution that
+// makes the Windows sandbox reachable in dev (self-dispatch) while preserving
+// the release layout (adjacent .exe) and PATH discovery.
+func TestResolveWindowsSandboxHelperTiers(t *testing.T) {
+	restore := osExecutable
+	defer func() { osExecutable = restore }()
+
+	t.Run("tier1 adjacent exe wins", func(t *testing.T) {
+		dir := t.TempDir()
+		adjacent := filepath.Join(dir, WindowsSandboxCommandRunnerName)
+		writeFile(t, adjacent)
+		osExecutable = func() (string, error) { return filepath.Join(dir, "zero.exe"), nil }
+		got := ResolveWindowsSandboxCommandRunner(func(string) (string, error) {
+			return `C:\on-path\runner.exe`, nil // must NOT be chosen — adjacent wins
+		})
+		if got.Name != adjacent || len(got.ArgsPrefix) != 0 {
+			t.Fatalf("tier1 = %#v, want adjacent exe with no prefix", got)
+		}
+	})
+
+	t.Run("tier2 PATH when no adjacent", func(t *testing.T) {
+		dir := t.TempDir()
+		osExecutable = func() (string, error) { return filepath.Join(dir, "zero.exe"), nil }
+		got := ResolveWindowsSandboxCommandRunner(func(name string) (string, error) {
+			if name == WindowsSandboxCommandRunnerName {
+				return `C:\on-path\runner.exe`, nil
+			}
+			return "", errors.New("missing")
+		})
+		if got.Name != `C:\on-path\runner.exe` || len(got.ArgsPrefix) != 0 {
+			t.Fatalf("tier2 = %#v, want PATH exe with no prefix", got)
+		}
+	})
+
+	t.Run("tier3 self-dispatch when nothing found", func(t *testing.T) {
+		dir := t.TempDir()
+		self := filepath.Join(dir, "zero.exe")
+		osExecutable = func() (string, error) { return self, nil }
+		got := ResolveWindowsSandboxCommandRunner(func(string) (string, error) {
+			return "", errors.New("missing")
+		})
+		if got.Name != self {
+			t.Fatalf("tier3 name = %q, want self-dispatch binary %q", got.Name, self)
+		}
+		if len(got.ArgsPrefix) != 1 || got.ArgsPrefix[0] != WindowsCommandRunnerSubcommand {
+			t.Fatalf("tier3 prefix = %#v, want [%q]", got.ArgsPrefix, WindowsCommandRunnerSubcommand)
+		}
+		if !got.Available() {
+			t.Fatal("tier3 helper should be Available")
+		}
+	})
+
+	t.Run("setup helper uses its own subcommand", func(t *testing.T) {
+		dir := t.TempDir()
+		osExecutable = func() (string, error) { return filepath.Join(dir, "zero.exe"), nil }
+		got := ResolveWindowsSandboxSetupHelper(func(string) (string, error) {
+			return "", errors.New("missing")
+		})
+		if len(got.ArgsPrefix) != 1 || got.ArgsPrefix[0] != WindowsSandboxSetupSubcommand {
+			t.Fatalf("setup prefix = %#v, want [%q]", got.ArgsPrefix, WindowsSandboxSetupSubcommand)
+		}
+	})
+
+	t.Run("unavailable only when os.Executable fails", func(t *testing.T) {
+		osExecutable = func() (string, error) { return "", errors.New("no exe") }
+		got := ResolveWindowsSandboxCommandRunner(func(string) (string, error) {
+			return "", errors.New("missing")
+		})
+		if got.Available() {
+			t.Fatalf("helper = %#v, want unavailable when os.Executable fails", got)
+		}
+	})
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/sandbox/windows_runner.go
+++ b/internal/sandbox/windows_runner.go
@@ -15,23 +15,75 @@ const WindowsSandboxCommandRunnerName = "zero-windows-command-runner.exe"
 
 const windowsCapabilitySIDSchemaVersion = 1
 
-func findWindowsSandboxCommandRunner(lookup func(string) (string, error)) string {
-	return findAdjacentOrPathExecutable(WindowsSandboxCommandRunnerName, lookup)
+// Hidden subcommands the main zero binary answers to when it acts as its own
+// Windows sandbox helper (self-dispatch). The "__" prefix can never collide with
+// a real user subcommand; internal/cli/app.go routes these before normal CLI
+// parsing.
+const (
+	WindowsCommandRunnerSubcommand = "__windows-command-runner"
+	WindowsSandboxSetupSubcommand  = "__windows-sandbox-setup"
+)
+
+// WindowsSandboxHelper locates a Windows sandbox helper to launch. Name is the
+// executable; ArgsPrefix is prepended to the helper's own arguments. For a
+// standalone helper .exe (the release layout) ArgsPrefix is empty; for
+// self-dispatch — the running zero binary acting as its own helper — Name is
+// os.Executable() and ArgsPrefix carries the hidden subcommand token.
+type WindowsSandboxHelper struct {
+	Name       string
+	ArgsPrefix []string
 }
 
-func findAdjacentOrPathExecutable(name string, lookup func(string) (string, error)) string {
-	if exe, err := os.Executable(); err == nil {
-		candidate := filepath.Join(filepath.Dir(exe), name)
-		if regularFile(candidate) {
-			return candidate
+// Available reports whether a helper executable was resolved.
+func (helper WindowsSandboxHelper) Available() bool {
+	return strings.TrimSpace(helper.Name) != ""
+}
+
+// ResolveWindowsSandboxCommandRunner locates the command-runner helper.
+func ResolveWindowsSandboxCommandRunner(lookup func(string) (string, error)) WindowsSandboxHelper {
+	return resolveWindowsSandboxHelper(WindowsSandboxCommandRunnerName, WindowsCommandRunnerSubcommand, lookup)
+}
+
+// ResolveWindowsSandboxSetupHelper locates the one-time setup helper.
+func ResolveWindowsSandboxSetupHelper(lookup func(string) (string, error)) WindowsSandboxHelper {
+	return resolveWindowsSandboxHelper(WindowsSandboxSetupName, WindowsSandboxSetupSubcommand, lookup)
+}
+
+func findWindowsSandboxCommandRunner(lookup func(string) (string, error)) WindowsSandboxHelper {
+	return ResolveWindowsSandboxCommandRunner(lookup)
+}
+
+func findWindowsSandboxSetupHelper(lookup func(string) (string, error)) WindowsSandboxHelper {
+	return ResolveWindowsSandboxSetupHelper(lookup)
+}
+
+// osExecutable resolves the running binary's path. A package var so tests can
+// pin it deterministically (self-dispatch resolution depends on it).
+var osExecutable = os.Executable
+
+// resolveWindowsSandboxHelper resolves a helper in three tiers, mirroring the
+// Linux helper resolution (linux_helper.go): (1) a standalone .exe adjacent to
+// the running binary — the release layout, kept first so a packaged helper still
+// wins; (2) the same name on PATH; (3) SELF-DISPATCH — the running zero binary
+// itself, invoked with the hidden subcommand. Tier 3 is what makes the sandbox
+// reachable under `go run`/plain `go build` (no separate helper shipped),
+// fixing the dev-only "command runner is not available" failure that hard-failed
+// every bash command. Returns an empty helper only if os.Executable() fails.
+func resolveWindowsSandboxHelper(name, subcommand string, lookup func(string) (string, error)) WindowsSandboxHelper {
+	if exe, err := osExecutable(); err == nil {
+		if candidate := filepath.Join(filepath.Dir(exe), name); regularFile(candidate) {
+			return WindowsSandboxHelper{Name: candidate}
 		}
 	}
 	if lookup != nil {
 		if path, err := lookup(name); err == nil && path != "" {
-			return path
+			return WindowsSandboxHelper{Name: path}
 		}
 	}
-	return ""
+	if exe, err := osExecutable(); err == nil && strings.TrimSpace(exe) != "" {
+		return WindowsSandboxHelper{Name: exe, ArgsPrefix: []string{subcommand}}
+	}
+	return WindowsSandboxHelper{}
 }
 
 func regularFile(path string) bool {
@@ -231,6 +283,11 @@ func windowsRestrictedTokenCommandPlan(execRequest SandboxExecutionRequest, poli
 	if err != nil {
 		return CommandPlan{}, err
 	}
+	// Prepend the helper's args prefix: for self-dispatch this is the hidden
+	// subcommand token (Name is the running zero binary), so the launched command
+	// is `zero __windows-command-runner <sandbox args>`. Empty for a standalone
+	// helper .exe, where args are passed unchanged.
+	fullArgs := append(append([]string{}, execRequest.Backend.ExecutableArgsPrefix...), args...)
 	return withSandboxExecutionMetadata(CommandPlan{
 		Backend:           execRequest.Backend,
 		TargetBackend:     execRequest.TargetBackend,
@@ -240,7 +297,7 @@ func windowsRestrictedTokenCommandPlan(execRequest SandboxExecutionRequest, poli
 		SandboxEnvMarkers: execRequest.SandboxEnvMarkers,
 		EnforcementLevel:  execRequest.EnforcementLevel,
 		Name:              execRequest.Backend.Executable,
-		Args:              args,
+		Args:              fullArgs,
 		Dir:               spec.Dir,
 		Env:               childEnv,
 		SandboxDir:        spec.Dir,

--- a/internal/sandbox/windows_setup.go
+++ b/internal/sandbox/windows_setup.go
@@ -40,10 +40,10 @@ type WindowsSandboxSetupMarker struct {
 	NetworkFilters    int    `json:"networkFilters"`
 }
 
-func findWindowsSandboxSetupHelper(lookup func(string) (string, error)) string {
-	return findAdjacentOrPathExecutable(WindowsSandboxSetupName, lookup)
-}
-
+// WindowsSandboxSetupPathForRunner derives the setup helper's path from a
+// standalone command-runner path (the sibling .exe in the release layout).
+// Retained for that layout; self-dispatch callers use
+// ResolveWindowsSandboxSetupHelper instead.
 func WindowsSandboxSetupPathForRunner(runnerPath string) string {
 	if strings.TrimSpace(runnerPath) == "" {
 		return ""
@@ -247,7 +247,7 @@ func ValidateWindowsSandboxSetupMarker(config WindowsSandboxSetupConfig) error {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("windows sandbox setup is required: missing %s", filepath.Base(path))
+			return fmt.Errorf("windows sandbox is not initialized for this workspace — run `zero sandbox setup` from an elevated (Administrator) terminal (missing %s)", filepath.Base(path))
 		}
 		return fmt.Errorf("read windows sandbox setup marker: %w", err)
 	}

--- a/internal/sandbox/windows_setup_windows.go
+++ b/internal/sandbox/windows_setup_windows.go
@@ -5,9 +5,18 @@ package sandbox
 import (
 	"fmt"
 	"io"
+
+	"golang.org/x/sys/windows"
 )
 
 func runWindowsSandboxSetup(config WindowsSandboxSetupConfig, stderr io.Writer) int {
+	// Applying the WFP network filters and workspace ACLs requires Administrator
+	// rights; without them WFP fails deep inside with a raw ACCESS_DENIED (0x5).
+	// Check up front and return an actionable message instead.
+	if !windowsProcessIsElevated() {
+		fmt.Fprintln(stderr, WindowsSandboxSetupName+": Administrator rights are required. Re-run `zero sandbox setup` from an elevated (Run as administrator) terminal.")
+		return 1
+	}
 	plan, err := BuildWindowsACLPlan(config.commandConfig())
 	if err != nil {
 		fmt.Fprintln(stderr, WindowsSandboxSetupName+": "+err.Error())
@@ -40,4 +49,17 @@ func runWindowsSandboxSetup(config WindowsSandboxSetupConfig, stderr io.Writer) 
 		return 1
 	}
 	return 0
+}
+
+// windowsProcessIsElevated reports whether the current process runs with an
+// elevated (Administrator) token. On any error obtaining the token it returns
+// true so the setup proceeds and surfaces the real WFP/ACL error rather than a
+// false "needs admin" claim.
+func windowsProcessIsElevated() bool {
+	var token windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err != nil {
+		return true
+	}
+	defer token.Close()
+	return token.IsElevated()
 }


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows sandbox setup now verifies Administrator/elevated permissions before applying firewall and workspace security rules, returning a clearer instruction instead of confusing access-denied errors.

* **New Features**
  * Improved Windows sandbox helper resolution and execution: if helper executables aren’t available where expected, the system can fall back to hidden self-dispatch to run the runner/setup helpers correctly.
  * Updated sandbox “doctor” checks to more accurately report Windows native backend availability under these fallback conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->