### PR TITLE
fix(config): don't crash startup when a non-active provider can't resolve

### DIFF
--- a/internal/config/resolve_skip_test.go
+++ b/internal/config/resolve_skip_test.go
@@ -1,0 +1,29 @@
+package config
+
+import "testing"
+
+// A single unresolvable, NON-active provider (e.g. one whose catalogID preset this
+// build doesn't ship) must not crash resolution — it's dropped, the rest survive.
+func TestNormalizeProvidersSkipsUnresolvableNonActive(t *testing.T) {
+	good := ProviderProfile{Name: "good", ProviderKind: ProviderKindOpenAICompatible, BaseURL: "https://api.example.com/v1", Model: "m"}
+	bad := ProviderProfile{Name: "badcat", CatalogID: "definitely-not-a-real-catalog-xyz", Model: "m"}
+
+	got, active, err := normalizeProviders([]ProviderProfile{good, bad}, "good")
+	if err != nil {
+		t.Fatalf("a bad NON-active provider must not fail resolution, got: %v", err)
+	}
+	if active.Name != "good" {
+		t.Fatalf("active = %q, want good", active.Name)
+	}
+	if len(got) != 1 || got[0].Name != "good" {
+		t.Fatalf("the unresolvable provider should be dropped, got %#v", got)
+	}
+}
+
+// But an unresolvable ACTIVE provider IS fatal — the run can't proceed without it.
+func TestNormalizeProvidersFatalWhenActiveUnresolvable(t *testing.T) {
+	bad := ProviderProfile{Name: "badcat", CatalogID: "definitely-not-a-real-catalog-xyz", Model: "m"}
+	if _, _, err := normalizeProviders([]ProviderProfile{bad}, "badcat"); err == nil {
+		t.Fatal("an unresolvable ACTIVE provider must be a fatal error")
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -676,7 +676,14 @@ func normalizeProvidersWithOptions(providers []ProviderProfile, activeName strin
 	for _, provider := range providers {
 		next, err := normalizeProvider(provider, env, options)
 		if err != nil {
-			return nil, ProviderProfile{}, err
+			// One unresolvable provider (e.g. a profile referencing a provider preset
+			// this build doesn't ship) must NOT brick the whole app — drop it and keep
+			// the rest. Only the ACTIVE provider failing is fatal, since the run can't
+			// proceed without it.
+			if strings.TrimSpace(provider.Name) == activeName {
+				return nil, ProviderProfile{}, err
+			}
+			continue
 		}
 		normalized = append(normalized, next)
 		if next.Name == activeName {


### PR DESCRIPTION
## Summary

`normalizeProviders` resolved **every** configured provider and aborted the entire config load if **any single** provider failed to normalize — e.g. a profile referencing a provider catalog preset this build doesn't ship, or an otherwise-unresolvable entry. That bricked startup completely: `zero` exited with `unknown provider "<name>"` and never launched, **even when the active provider was perfectly valid**.

A configured-but-unusable *secondary* provider shouldn't take down the whole app.

## Change

- In `normalizeProviders`, a single unresolvable **non-active** provider is now **dropped** — the remaining providers, including the active one, load normally.
- The **active** provider failing to resolve stays **fatal** (the run genuinely can't proceed without it).

`internal/config/resolver.go` — the per-provider normalize loop now skips a failing non-active profile instead of returning the error for the whole list.

## Tests

- `TestNormalizeProvidersSkipsUnresolvableNonActive` — a bad non-active provider is dropped; the active provider and valid providers survive; no error.
- `TestNormalizeProvidersFatalWhenActiveUnresolvable` — an unresolvable **active** provider is still a fatal error.

## Repro (before this PR)

A config with a valid active provider plus one provider whose `catalogID` isn't known to the running build → `zero` exited at startup with `unknown provider "<name>" (apiKey=[REDACTED])` and refused to start. With this change it starts and silently skips the unknown provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider resolution to gracefully skip unresolvable non-active providers while maintaining strict validation for the active provider.

* **Tests**
  * Added unit tests to verify provider resolution behavior when encountering unresolvable providers in both active and non-active scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->