### PR TITLE
feat(npm): publish @gitlawb/zero with a postinstall binary installer

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -45,6 +45,21 @@ jobs:
       - name: Test
         run: go test ./...
 
+      # zero-release names assets zero-v<package.json version>-… while the release
+      # is published under the pushed git tag. If they disagree, install.sh/install.ps1
+      # and the npm postinstall all build a download URL that 404s. Fail fast so a
+      # forgotten version bump can never publish mis-versioned, un-installable assets.
+      - name: Check tag matches package.json version
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "v$pkg_version" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match package.json version v$pkg_version — bump package.json before tagging so the release assets and the npm package agree." >&2
+            exit 1
+          fi
+          echo "tag $GITHUB_REF_NAME matches package.json version v$pkg_version."
+
       - name: Package release artifact
         run: go run ./cmd/zero-release package
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,17 @@ zero exec -o stream-json < turns.jsonl        # programmatic, for scripts & CI
 go run ./cmd/zero
 ```
 
-> **Pre-built binaries are coming soon.** Once the first GitHub release is published, you'll be able
-> to install with `scripts/install.sh` (Linux/macOS) or `scripts/install.ps1` (Windows); those
-> scripts download release assets that don't exist yet. Until then, build from source with
+Or, once the first release is published, install the prebuilt binary via npm — the wrapper
+downloads the right binary for your platform:
+
+```bash
+npm install -g @gitlawb/zero
+zero
+```
+
+> **Pre-built binaries are coming soon.** The npm package and the `scripts/install.sh`
+> (Linux/macOS) / `scripts/install.ps1` (Windows) installers all download GitHub Release
+> assets, which require the first release to be published. Until then, build from source with
 > `go run ./cmd/zero` (or `go build -o zero ./cmd/zero`).
 
 First launch opens a **guided setup wizard** — pick a provider, paste a key, choose a model, done. Or do it non-interactively:

--- a/docs/NPM_WRAPPER_SMOKE.md
+++ b/docs/NPM_WRAPPER_SMOKE.md
@@ -23,7 +23,13 @@ go run ./cmd/zero-release smoke
 
 ## Checklist
 
-- `package.json` has the expected package name, version, and `bin.zero` entry.
+- `package.json` has the expected package name (`@gitlawb/zero`), version,
+  `bin.zero` entry, and exactly one `scripts` entry — the `postinstall` hook.
+- `scripts/postinstall.mjs` resolves the correct release asset name/URL per
+  platform (`ZERO_INSTALL_DRY_RUN=1` prints the plan), verifies the downloaded
+  archive's SHA-256, and extracts only the known binary basenames into place.
+  `ZERO_SKIP_DOWNLOAD=1` opts out cleanly (exit 0) and an unsupported
+  platform/arch is a non-fatal skip.
 - The wrapper binary resolves through the package `bin` entry and
   `node_modules/.bin` in a package-install smoke test.
 - The built binary exits 0 for `zero --version` or `zero --help`.

--- a/internal/npmwrapper/npmwrapper_test.go
+++ b/internal/npmwrapper/npmwrapper_test.go
@@ -19,12 +19,20 @@ func TestPackageBinPointsToNodeWrapper(t *testing.T) {
 		t.Fatalf("ReadFile package.json: %v", err)
 	}
 	var pkg struct {
-		Module  string            `json:"module"`
-		Bin     map[string]string `json:"bin"`
-		Scripts map[string]string `json:"scripts"`
+		Name       string            `json:"name"`
+		Module     string            `json:"module"`
+		Bin        map[string]string `json:"bin"`
+		Scripts    map[string]string `json:"scripts"`
+		License    string            `json:"license"`
+		Files      []string          `json:"files"`
+		Repository json.RawMessage   `json:"repository"`
+		Engines    map[string]string `json:"engines"`
 	}
 	if err := json.Unmarshal(bytes, &pkg); err != nil {
 		t.Fatalf("Unmarshal package.json: %v", err)
+	}
+	if pkg.Name != "@gitlawb/zero" {
+		t.Fatalf("name = %q, want @gitlawb/zero", pkg.Name)
 	}
 	if pkg.Bin["zero"] != "bin/zero.js" {
 		t.Fatalf("bin.zero = %q, want bin/zero.js", pkg.Bin["zero"])
@@ -32,9 +40,149 @@ func TestPackageBinPointsToNodeWrapper(t *testing.T) {
 	if pkg.Module != "bin/zero.js" {
 		t.Fatalf("module = %q, want bin/zero.js", pkg.Module)
 	}
-	if len(pkg.Scripts) != 0 {
-		t.Fatalf("package.json scripts = %#v, want no repository build scripts in npm package metadata", pkg.Scripts)
+	// Only a postinstall hook (which downloads the prebuilt binary) is allowed.
+	// Repository build scripts (build/prepare/prepack/…) must not ship in the
+	// published package — the tarball has no Go source to build from.
+	if pkg.Scripts["postinstall"] != "node scripts/postinstall.mjs" {
+		t.Fatalf("scripts.postinstall = %q, want node scripts/postinstall.mjs", pkg.Scripts["postinstall"])
 	}
+	for name := range pkg.Scripts {
+		if name != "postinstall" {
+			t.Fatalf("package.json scripts contains %q; only a postinstall hook is allowed (no repository build scripts)", name)
+		}
+	}
+	if pkg.License == "" {
+		t.Fatalf("package.json license is empty; set it (ties to the pending LICENSE file) so npm publish is not unlicensed")
+	}
+	if len(pkg.Repository) == 0 {
+		t.Fatalf("package.json repository is missing; npm needs it for provenance")
+	}
+	if pkg.Engines["node"] == "" {
+		t.Fatalf("package.json engines.node is empty; the wrapper and installer require a modern Node")
+	}
+	wantFiles := map[string]bool{"bin/zero.js": false, "scripts/postinstall.mjs": false}
+	for _, f := range pkg.Files {
+		if _, ok := wantFiles[f]; ok {
+			wantFiles[f] = true
+		}
+	}
+	for f, present := range wantFiles {
+		if !present {
+			t.Fatalf("package.json files is missing %q; it would not be published in the tarball", f)
+		}
+	}
+}
+
+func TestPostinstallComputesAssetPlan(t *testing.T) {
+	version := packageVersion(t)
+	cases := []struct {
+		platform, arch        string
+		wantAsset, wantBinary string
+	}{
+		{"linux", "x64", "zero-v" + version + "-linux-x64.tar.gz", "zero"},
+		{"darwin", "arm64", "zero-v" + version + "-macos-arm64.tar.gz", "zero"},
+		{"win32", "x64", "zero-v" + version + "-windows-x64.zip", "zero.exe"},
+	}
+	for _, tc := range cases {
+		stdout, stderr, err := runPostinstall(t,
+			"ZERO_INSTALL_DRY_RUN=1",
+			"ZERO_INSTALL_PLATFORM="+tc.platform,
+			"ZERO_INSTALL_ARCH="+tc.arch,
+		)
+		if err != nil {
+			t.Fatalf("%s/%s: dry-run err=%v stderr=%s", tc.platform, tc.arch, err, stderr)
+		}
+		var plan struct {
+			AssetName  string `json:"assetName"`
+			AssetURL   string `json:"assetUrl"`
+			BinaryName string `json:"binaryName"`
+			Tag        string `json:"tag"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &plan); err != nil {
+			t.Fatalf("%s/%s: parse plan %q: %v", tc.platform, tc.arch, stdout, err)
+		}
+		if plan.AssetName != tc.wantAsset {
+			t.Fatalf("%s/%s: assetName=%q want %q", tc.platform, tc.arch, plan.AssetName, tc.wantAsset)
+		}
+		if plan.BinaryName != tc.wantBinary {
+			t.Fatalf("%s/%s: binaryName=%q want %q", tc.platform, tc.arch, plan.BinaryName, tc.wantBinary)
+		}
+		wantURL := "https://github.com/Gitlawb/zero/releases/download/v" + version + "/" + tc.wantAsset
+		if plan.AssetURL != wantURL {
+			t.Fatalf("%s/%s: assetUrl=%q want %q", tc.platform, tc.arch, plan.AssetURL, wantURL)
+		}
+		if plan.Tag != "v"+version {
+			t.Fatalf("%s/%s: tag=%q want v%s", tc.platform, tc.arch, plan.Tag, version)
+		}
+	}
+}
+
+func TestPostinstallSkipsUnsupportedPlatform(t *testing.T) {
+	stdout, stderr, err := runPostinstall(t,
+		"ZERO_INSTALL_DRY_RUN=1",
+		"ZERO_INSTALL_PLATFORM=plan9",
+		"ZERO_INSTALL_ARCH=x64",
+	)
+	if err != nil {
+		t.Fatalf("unsupported platform should exit 0, got err=%v stderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("unsupported platform should not print a plan, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "no prebuilt binary") {
+		t.Fatalf("stderr=%q, want it to mention no prebuilt binary", stderr)
+	}
+}
+
+func TestPostinstallHonorsSkipEnv(t *testing.T) {
+	stdout, stderr, err := runPostinstall(t, "ZERO_SKIP_DOWNLOAD=1")
+	if err != nil {
+		t.Fatalf("ZERO_SKIP_DOWNLOAD should exit 0, got err=%v stderr=%s", err, stderr)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Fatalf("skip should print nothing to stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "skipping native binary download") {
+		t.Fatalf("stderr=%q, want skip message", stderr)
+	}
+}
+
+func runPostinstall(t *testing.T, env ...string) (string, string, error) {
+	t.Helper()
+	node := requireNode(t)
+	root := repoRoot(t)
+	script := filepath.Join(root, "scripts", "postinstall.mjs")
+	ctx, cancel := context.WithTimeout(context.Background(), nodeWrapperTimeout())
+	defer cancel()
+	command := exec.CommandContext(ctx, node, script)
+	command.Env = append(append(os.Environ(), "NODE_OPTIONS="), env...)
+	var stdout, stderr strings.Builder
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	runErr := command.Run()
+	if ctx.Err() != nil {
+		t.Fatalf("postinstall timed out: %v; stderr: %s", ctx.Err(), stderr.String())
+	}
+	return stdout.String(), stderr.String(), runErr
+}
+
+func packageVersion(t *testing.T) string {
+	t.Helper()
+	root := repoRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "package.json"))
+	if err != nil {
+		t.Fatalf("ReadFile package.json: %v", err)
+	}
+	var pkg struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		t.Fatalf("Unmarshal package.json: %v", err)
+	}
+	if pkg.Version == "" {
+		t.Fatal("package.json version is empty")
+	}
+	return pkg.Version
 }
 
 func TestNodeWrapperIsExecutableAndDoesNotImportBun(t *testing.T) {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,38 @@
 {
-  "name": "zero",
+  "name": "@gitlawb/zero",
   "version": "0.1.0",
-  "module": "bin/zero.js",
+  "description": "Zero — a fast, multi-provider terminal coding agent.",
   "type": "module",
+  "module": "bin/zero.js",
   "bin": {
     "zero": "bin/zero.js"
-  }
+  },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.mjs"
+  },
+  "files": [
+    "bin/zero.js",
+    "scripts/postinstall.mjs"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "linux",
+    "darwin",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Gitlawb/zero.git"
+  },
+  "homepage": "https://github.com/Gitlawb/zero#readme",
+  "bugs": {
+    "url": "https://github.com/Gitlawb/zero/issues"
+  },
+  "license": "SEE LICENSE IN LICENSE"
 }

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// postinstall: fetch the prebuilt `zero` binary for this platform from the
+// matching GitHub Release and place it next to bin/zero.js, which execs it.
+//
+// Mirrors scripts/install.sh and scripts/install.ps1. The asset-name scheme is
+// the source of truth in internal/release/release.go:
+//   zero-v{version}-{linux|macos|windows}-{x64|arm64}.{tar.gz|zip}  (+ .sha256)
+//
+// Safety: HTTPS-only download from the pinned repo, SHA-256 verification against
+// the release's own .sha256, and extraction that never trusts archive paths —
+// we extract to a temp dir and copy only known binary basenames into place, so a
+// crafted archive cannot write outside the package (no zip-slip).
+//
+// Env overrides (testing / mirrors / locked-down installs):
+//   ZERO_SKIP_DOWNLOAD=1      skip entirely, exit 0 (wrapper will guide if run)
+//   ZERO_INSTALL_DRY_RUN=1    print the resolved plan as JSON, no network, exit 0
+//   ZERO_INSTALL_PLATFORM=…   override process.platform (linux|darwin|win32)
+//   ZERO_INSTALL_ARCH=…       override process.arch (x64|arm64)
+//   ZERO_REPO=owner/name      override the GitHub repo (default Gitlawb/zero)
+//   ZERO_GITHUB_BASE_URL=…    override the download host (default https://github.com)
+
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkg = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+const VERSION = pkg.version;
+
+const REPO = process.env.ZERO_REPO || 'Gitlawb/zero';
+const BASE = (process.env.ZERO_GITHUB_BASE_URL || 'https://github.com').replace(/\/+$/, '');
+// The .sha256 is fetched from the same origin as the archive, so TLS authenticity
+// is the only real integrity control — require https unless explicitly overridden
+// for local testing (e.g. a localhost mirror in tests).
+const ALLOW_INSECURE = process.env.ZERO_ALLOW_INSECURE_DOWNLOAD === '1';
+const MAX_DOWNLOAD_BYTES = 512 * 1024 * 1024;
+
+function fail(message) {
+  console.error(`[zero] ${message}`);
+  process.exit(1);
+}
+
+function warnSkip(message) {
+  // Exit 0 so an unsupported platform or an opt-out does not break `npm install`;
+  // bin/zero.js reports a clear "no native binary" message if the user runs zero.
+  console.error(`[zero] ${message}`);
+  process.exit(0);
+}
+
+// Maps mirror internal/release/release.go (ReleasePlatform / ReleaseArch).
+function resolvePlatform(p) {
+  switch (p) {
+    case 'linux':
+      return 'linux';
+    case 'darwin':
+      return 'macos';
+    case 'win32':
+      return 'windows';
+    default:
+      return null;
+  }
+}
+
+function resolveArch(a) {
+  switch (a) {
+    case 'x64':
+      return 'x64';
+    case 'arm64':
+      return 'arm64';
+    default:
+      return null;
+  }
+}
+
+if (process.env.ZERO_SKIP_DOWNLOAD === '1') {
+  warnSkip('ZERO_SKIP_DOWNLOAD=1 set — skipping native binary download.');
+}
+
+const rawPlatform = process.env.ZERO_INSTALL_PLATFORM || process.platform;
+const rawArch = process.env.ZERO_INSTALL_ARCH || process.arch;
+const platform = resolvePlatform(rawPlatform);
+const arch = resolveArch(rawArch);
+
+if (!platform || !arch) {
+  warnSkip(
+    `no prebuilt binary for ${rawPlatform}/${rawArch}. Build from source: ` +
+      `https://github.com/${REPO} (go run ./cmd/zero).`,
+  );
+}
+
+const ext = platform === 'windows' ? 'zip' : 'tar.gz';
+const binaryName = platform === 'windows' ? 'zero.exe' : 'zero';
+const tag = `v${VERSION}`;
+const assetName = `zero-v${VERSION}-${platform}-${arch}.${ext}`;
+const assetUrl = `${BASE}/${REPO}/releases/download/${tag}/${assetName}`;
+const checksumUrl = `${assetUrl}.sha256`;
+
+// Extra binaries the archive may carry; copied when present so the platform
+// sandbox finds its adjacent helpers (tier-1 discovery), but never required.
+const optionalBinaries =
+  platform === 'windows'
+    ? ['zero-windows-command-runner.exe', 'zero-windows-sandbox-setup.exe']
+    : platform === 'linux'
+      ? ['zero-linux-sandbox', 'zero-seccomp']
+      : [];
+
+if (process.env.ZERO_INSTALL_DRY_RUN === '1') {
+  process.stdout.write(
+    JSON.stringify({
+      version: VERSION,
+      platform,
+      arch,
+      tag,
+      assetName,
+      assetUrl,
+      checksumUrl,
+      binaryName,
+      optionalBinaries,
+    }) + '\n',
+  );
+  process.exit(0);
+}
+
+// Idempotent: skip if the binary for this exact version is already in place.
+const markerPath = join(packageRoot, '.zero-binary-version');
+const installedBinary = join(packageRoot, binaryName);
+if (
+  existsSync(installedBinary) &&
+  existsSync(markerPath) &&
+  readFileSync(markerPath, 'utf8').trim() === VERSION
+) {
+  process.exit(0);
+}
+
+async function download(url) {
+  if (!ALLOW_INSECURE && !url.startsWith('https://')) {
+    fail(
+      `refusing insecure download origin for ${url}: only https:// is allowed ` +
+        `(set ZERO_ALLOW_INSECURE_DOWNLOAD=1 to override for local testing).`,
+    );
+  }
+  let response;
+  try {
+    response = await fetch(url, { redirect: 'follow' });
+  } catch (error) {
+    fail(`download failed for ${url}: ${error.message}`);
+  }
+  // Catch an https->http downgrade across redirects: the verified bytes must
+  // still have arrived over TLS for the same-origin checksum to mean anything.
+  if (!ALLOW_INSECURE && response.url && !response.url.startsWith('https://')) {
+    fail(`refusing insecure redirect to ${response.url}`);
+  }
+  if (!response.ok) {
+    fail(
+      `download failed (HTTP ${response.status}) for ${url} (release tag ${tag}). ` +
+        `If no release exists yet, or the tag and package.json version disagree, ` +
+        `build from source: https://github.com/${REPO} (go run ./cmd/zero).`,
+    );
+  }
+  const declared = Number(response.headers.get('content-length') || 0);
+  if (declared && declared > MAX_DOWNLOAD_BYTES) {
+    fail(`refusing oversized download (${declared} bytes) from ${url}`);
+  }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.length > MAX_DOWNLOAD_BYTES) {
+    fail(`download from ${url} exceeded ${MAX_DOWNLOAD_BYTES} bytes`);
+  }
+  return buffer;
+}
+
+// Parse a sha256sum-style file. Anchored per line, and when the line carries a
+// filename field it must equal the requested asset — mirrors the Go
+// ParseSHA256Checksum so a checksum file cannot misattribute a digest.
+function parseSha256(text, wantName) {
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const match = line.match(/^([a-fA-F0-9]{64})(?:\s+\*?(.+))?$/);
+    if (!match) continue;
+    const [, hex, name] = match;
+    if (!name || name.trim() === wantName) {
+      return hex.toLowerCase();
+    }
+  }
+  fail(`could not find a SHA-256 digest for ${wantName} in ${wantName}.sha256`);
+}
+
+function findByBasename(dir, name) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = findByBasename(full, name);
+      if (nested) return nested;
+    } else if (entry.name === name) {
+      return full;
+    }
+  }
+  return null;
+}
+
+// extract runs from `workDir` and passes RELATIVE names so no Windows drive
+// letter (e.g. C:\) appears in tar's archive argument — GNU tar otherwise reads
+// `C:foo` as a remote `host:path` and fails. archiveName and destName are both
+// relative to workDir.
+function extract(workDir, archiveName, destName) {
+  const opts = { stdio: 'inherit', cwd: workDir };
+  if (ext === 'zip') {
+    // Windows 10+ ships bsdtar as tar.exe, which extracts zips; fall back to
+    // PowerShell Expand-Archive if tar is unavailable or cannot read the zip.
+    const viaTar = spawnSync('tar', ['-xf', archiveName, '-C', destName], opts);
+    if (viaTar.status === 0) return;
+    const absArchive = join(workDir, archiveName);
+    const absDest = join(workDir, destName);
+    const viaPwsh = spawnSync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Expand-Archive -LiteralPath '${absArchive.replace(/'/g, "''")}' ` +
+          `-DestinationPath '${absDest.replace(/'/g, "''")}' -Force`,
+      ],
+      { stdio: 'inherit' },
+    );
+    if (viaPwsh.status !== 0) fail(`failed to extract ${assetName}`);
+    return;
+  }
+  const viaTar = spawnSync('tar', ['-xzf', archiveName, '-C', destName], opts);
+  if (viaTar.status !== 0) fail(`failed to extract ${assetName} (tar exited ${viaTar.status})`);
+}
+
+async function main() {
+  const archiveBuffer = await download(assetUrl);
+  const checksumText = (await download(checksumUrl)).toString('utf8');
+  const expected = parseSha256(checksumText, assetName);
+  const actual = createHash('sha256').update(archiveBuffer).digest('hex');
+  if (actual !== expected) {
+    fail(`checksum mismatch for ${assetName}: expected ${expected}, got ${actual}`);
+  }
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'zero-install-'));
+  try {
+    const archivePath = join(tempDir, assetName);
+    writeFileSync(archivePath, archiveBuffer);
+    const extractDir = join(tempDir, 'extracted');
+    mkdirSync(extractDir);
+    extract(tempDir, assetName, 'extracted');
+
+    // Copy only known basenames into the package root. We never honor
+    // archive-relative paths, so a crafted entry cannot escape the package.
+    const primarySource = findByBasename(extractDir, binaryName);
+    if (!primarySource) fail(`archive ${assetName} did not contain ${binaryName}`);
+    copyFileSync(primarySource, installedBinary);
+    if (platform !== 'windows') chmodSync(installedBinary, 0o755);
+
+    for (const name of optionalBinaries) {
+      const source = findByBasename(extractDir, name);
+      if (!source) {
+        console.error(
+          `[zero] note: optional helper ${name} was not in ${assetName}; ` +
+            `the sandbox may run with reduced isolation.`,
+        );
+        continue;
+      }
+      const dest = join(packageRoot, name);
+      copyFileSync(source, dest);
+      if (platform !== 'windows') chmodSync(dest, 0o755);
+    }
+
+    writeFileSync(markerPath, VERSION + '\n');
+    const sizeKb = Math.round(statSync(installedBinary).size / 1024);
+    console.error(`[zero] installed ${binaryName} ${VERSION} (${platform}-${arch}, ${sizeKb} KB).`);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => fail(error.message));


### PR DESCRIPTION
## What

Makes `npm install -g @gitlawb/zero` deliver a working CLI. `bin/zero.js` already execs an adjacent binary, but nothing fetched it, and the package name `zero` is taken on npm. This wires up the missing delivery + publishing path.

## How

- **`package.json`** → rename to **`@gitlawb/zero`** (scoped; `zero` is taken). Add a `postinstall` hook, `files`, `engines` (`node>=18`), `os`/`cpu`, `repository`, and a `license` placeholder (the LICENSE file is still pending — separate task).
- **`scripts/postinstall.mjs`** (new) → detect platform/arch (mapping mirrors `internal/release/release.go`: `darwin→macos`, `amd64→x64`), download `zero-v{version}-{os}-{arch}.{tar.gz|zip}` from the matching GitHub Release, **verify SHA-256**, and extract into place. Extraction unpacks to a temp dir and copies **only known binary basenames** into the package — archive paths are never honored, so a crafted archive can't escape (no zip-slip). Idempotent via a version marker. `ZERO_SKIP_DOWNLOAD` and unsupported platforms are non-fatal skips.
- **`release-artifacts.yml`** → on a tag push, assert `git tag == v{package.json version}` before packaging. `zero-release` names assets from `package.json` while the release publishes under the tag, so any drift would 404 *every* install (install.sh, install.ps1, and npm). This also closes the version-drift follow-up flagged in the #282 review.
- **README / smoke doc** → document the `npm i -g @gitlawb/zero` path.

## Security

The installer downloads + verifies + stages an executable, so it went through an adversarial review (4 lenses, each finding independently verified). Path-traversal and command-injection were confirmed **genuinely closed** (temp-extract + copy-by-basename; argv arrays, no shell; correct PowerShell quote-escaping). Folded in the review's two `shouldFix` items + cheap nice-to-haves:

- **Require https** for the download origin — the same-origin `.sha256` makes TLS the load-bearing integrity control. `ZERO_ALLOW_INSECURE_DOWNLOAD=1` opts out for local testing; an `https→http` redirect is refused.
- **Tag/version drift-guard** (above) so a forgotten bump can't publish un-installable assets.
- Anchored, filename-validated checksum parsing; download size cap; missing-helper warning.

## Verification

- `go test ./internal/npmwrapper ./internal/release` ✅; gofmt/vet/build clean; `node --check` clean.
- New node-driven tests: per-platform asset plan, skip env, unsupported-platform.
- End-to-end against a local mirror: `download → verify → extract` places the binary, **a tampered checksum is rejected (exit 1, no binary)**, and **http is refused without the opt-in**.

## Going live — maintainer steps (not in this PR)

1. Create the `gitlawb` npm org (or publish under a personal scope) and add an `NPM_TOKEN` secret.
2. Publish the first `v0.1.0` GitHub Release (so there's an asset to download), then `npm publish --access public`.

A follow-up can add the `npm publish` step to the release workflow once the token exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * npm package installation support via `@gitlawb/zero` with automatic native binary download on install

* **Documentation**
  * Updated installation guidance for npm package wrapper approach
  * Added postinstall behavior verification checklist

* **Chores**
  * Enhanced release workflow with version consistency validation before artifact packaging
  * Expanded test coverage for package metadata validation and installation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->