### PR TITLE
fix(providers): global, configurable stream idle timeout (fixes 90s false-trip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Bring your own key — or no key at all for local runtimes.
 
 The model registry tracks each model's capabilities, context window, and cost — and the live model picker discovers what your provider actually serves.
 
+**Slow or stalling streams.** Every provider aborts a stream that goes completely silent (no data and no keep-alive) for `ZERO_STREAM_IDLE_TIMEOUT` (default **5 minutes**) so a hung connection can't block the agent forever. SSE keep-alives reset the timer, so a heartbeating-but-slow backend is never killed. If a slow cloud or reasoning model still trips it, raise the limit — `ZERO_STREAM_IDLE_TIMEOUT=10m` (accepts a Go duration or bare seconds; `0`/`off` disables the watchdog).
+
 ## Tools
 
 | Tool | Purpose | Side effect |

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -68,11 +68,6 @@ func resolveThinking(effort string, maxTokens int) (budget int, effectiveMax int
 	return budget, effectiveMax, true
 }
 
-// defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
-// without closing the connection, so a stalled-but-open upstream cannot hang the
-// agent forever.
-const defaultStreamIdleTimeout = 90 * time.Second
-
 // Options configures an Anthropic Messages API provider.
 type Options struct {
 	APIKey          string
@@ -92,7 +87,8 @@ type Options struct {
 	// the API key. See providerio.SendWithAuthRetry.
 	OAuthResolver providerio.TokenResolver
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
-	// Zero uses defaultStreamIdleTimeout.
+	// When unset, Zero uses providerio.ResolveStreamIdleTimeout — the
+	// ZERO_STREAM_IDLE_TIMEOUT override or providerio.DefaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
 }
 
@@ -132,10 +128,6 @@ func New(options Options) (*Provider, error) {
 	if version == "" {
 		version = defaultVersion
 	}
-	idleTimeout := options.StreamIdleTimeout
-	if idleTimeout <= 0 {
-		idleTimeout = defaultStreamIdleTimeout
-	}
 	return &Provider{
 		apiKey:            options.APIKey,
 		baseURL:           baseURL,
@@ -150,7 +142,7 @@ func New(options Options) (*Provider, error) {
 		oauthResolver:     options.OAuthResolver,
 		httpClient:        providerio.HTTPClient(options.HTTPClient),
 		userAgent:         options.UserAgent,
-		streamIdleTimeout: idleTimeout,
+		streamIdleTimeout: providerio.ResolveStreamIdleTimeout(options.StreamIdleTimeout),
 	}, nil
 }
 

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -37,11 +37,6 @@ func thinkingBudgetForEffort(effort string) int {
 	}
 }
 
-// defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
-// without closing the connection, so a stalled-but-open upstream cannot hang the
-// agent forever.
-const defaultStreamIdleTimeout = 90 * time.Second
-
 // Options configures a Gemini streamGenerateContent provider.
 type Options struct {
 	APIKey          string
@@ -55,7 +50,8 @@ type Options struct {
 	HTTPClient      *http.Client
 	UserAgent       string
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
-	// Zero uses defaultStreamIdleTimeout.
+	// When unset, Zero uses providerio.ResolveStreamIdleTimeout — the
+	// ZERO_STREAM_IDLE_TIMEOUT override or providerio.DefaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
 }
 
@@ -88,10 +84,6 @@ func New(options Options) (*Provider, error) {
 	if err != nil {
 		return nil, err
 	}
-	idleTimeout := options.StreamIdleTimeout
-	if idleTimeout <= 0 {
-		idleTimeout = defaultStreamIdleTimeout
-	}
 	return &Provider{
 		apiKey:            options.APIKey,
 		baseURL:           baseURL,
@@ -103,7 +95,7 @@ func New(options Options) (*Provider, error) {
 		customHeaders:     providerio.CopyHeaders(options.CustomHeaders),
 		httpClient:        providerio.HTTPClient(options.HTTPClient),
 		userAgent:         options.UserAgent,
-		streamIdleTimeout: idleTimeout,
+		streamIdleTimeout: providerio.ResolveStreamIdleTimeout(options.StreamIdleTimeout),
 	}, nil
 }
 

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -18,11 +18,6 @@ import (
 
 const defaultBaseURL = "https://api.openai.com/v1"
 
-// defaultStreamIdleTimeout aborts a streaming read when the upstream goes silent
-// without closing the connection. Hosted gateways (e.g. Ollama Cloud) sometimes
-// stall mid-stream after a tool-call delta; without this the agent blocks forever.
-const defaultStreamIdleTimeout = 90 * time.Second
-
 // Options configures an OpenAI-compatible chat completions provider.
 type Options struct {
 	APIKey  string
@@ -48,7 +43,8 @@ type Options struct {
 	// own default applies). Resolved from the model registry by the factory.
 	MaxTokens int
 	// StreamIdleTimeout aborts the stream if no data arrives for this long.
-	// Zero uses defaultStreamIdleTimeout.
+	// When unset, Zero uses providerio.ResolveStreamIdleTimeout — the
+	// ZERO_STREAM_IDLE_TIMEOUT override or providerio.DefaultStreamIdleTimeout.
 	StreamIdleTimeout time.Duration
 	// ParseThinkTags converts streamed <think>...</think> content into reasoning
 	// events for OpenAI-compatible models known to emit that legacy format.
@@ -111,11 +107,6 @@ func New(options Options) (*Provider, error) {
 		httpClient = http.DefaultClient
 	}
 
-	idleTimeout := options.StreamIdleTimeout
-	if idleTimeout <= 0 {
-		idleTimeout = defaultStreamIdleTimeout
-	}
-
 	maxTokens := options.MaxTokens
 	if maxTokens < 0 {
 		maxTokens = 0
@@ -134,7 +125,7 @@ func New(options Options) (*Provider, error) {
 		maxTokens:         maxTokens,
 		httpClient:        httpClient,
 		userAgent:         options.UserAgent,
-		streamIdleTimeout: idleTimeout,
+		streamIdleTimeout: providerio.ResolveStreamIdleTimeout(options.StreamIdleTimeout),
 		parseThinkTags:    options.ParseThinkTags,
 		setRequestExtra:   options.SetRequestExtra,
 	}, nil

--- a/internal/providers/providerio/providerio.go
+++ b/internal/providers/providerio/providerio.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +22,47 @@ const maxSSELineBytes = 16 * 1024 * 1024
 // ErrStreamIdle reports that a streaming upstream stopped sending data without
 // closing the connection. Callers surface it as an idle-timeout error.
 var ErrStreamIdle = errors.New("idle timeout (upstream stopped sending data)")
+
+// DefaultStreamIdleTimeout is the single source of truth for how long every
+// provider waits on a silent stream before aborting it. The watchdog only fires
+// on genuine silence — SSE keep-alive comments reset it (see
+// ScanSSEDataWithContext) — so this needs to be generous enough for slow cloud
+// and reasoning backends that pause for minutes without heartbeating, while
+// still bounding a truly hung connection. 90s was too aggressive and killed
+// healthy long generations; 5 minutes is the floor a real stall must cross.
+// Override globally with ZERO_STREAM_IDLE_TIMEOUT.
+const DefaultStreamIdleTimeout = 5 * time.Minute
+
+// streamIdleTimeoutEnv is the global override for the stream idle timeout. It
+// accepts a Go duration ("5m", "300s", "90s") or a bare number of seconds
+// ("300"). A value of "0", "off", "none", or "disabled" turns the watchdog off
+// entirely (streams may then hang until the HTTP/transport layer gives up).
+const streamIdleTimeoutEnv = "ZERO_STREAM_IDLE_TIMEOUT"
+
+// ResolveStreamIdleTimeout selects the effective stream idle timeout. Precedence:
+// an explicit positive option (e.g. set by a test) wins; otherwise the
+// ZERO_STREAM_IDLE_TIMEOUT env override if set and valid; otherwise
+// DefaultStreamIdleTimeout. A returned value <= 0 disables the idle watchdog.
+func ResolveStreamIdleTimeout(option time.Duration) time.Duration {
+	if option > 0 {
+		return option
+	}
+	if raw := strings.TrimSpace(os.Getenv(streamIdleTimeoutEnv)); raw != "" {
+		switch strings.ToLower(raw) {
+		case "0", "off", "none", "disabled":
+			return 0
+		}
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+		if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+		// Unparseable / non-positive: fall through to the default rather than
+		// silently disabling the watchdog on a typo.
+	}
+	return DefaultStreamIdleTimeout
+}
 
 // NormalizeBaseURL trims trailing slashes and validates an HTTP API base URL.
 func NormalizeBaseURL(baseURL string, defaultBaseURL string, label string) (string, error) {

--- a/internal/providers/providerio/stream_idle_resolve_test.go
+++ b/internal/providers/providerio/stream_idle_resolve_test.go
@@ -1,0 +1,64 @@
+package providerio
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResolveStreamIdleTimeout(t *testing.T) {
+	const env = "ZERO_STREAM_IDLE_TIMEOUT"
+
+	t.Run("explicit option wins over env", func(t *testing.T) {
+		t.Setenv(env, "30s")
+		if got := ResolveStreamIdleTimeout(50 * time.Millisecond); got != 50*time.Millisecond {
+			t.Fatalf("got %v, want 50ms (explicit option must win)", got)
+		}
+	})
+
+	t.Run("default when option and env are unset", func(t *testing.T) {
+		t.Setenv(env, "")
+		if got := ResolveStreamIdleTimeout(0); got != DefaultStreamIdleTimeout {
+			t.Fatalf("got %v, want default %v", got, DefaultStreamIdleTimeout)
+		}
+	})
+
+	t.Run("env Go duration", func(t *testing.T) {
+		t.Setenv(env, "30s")
+		if got := ResolveStreamIdleTimeout(0); got != 30*time.Second {
+			t.Fatalf("got %v, want 30s", got)
+		}
+		t.Setenv(env, "4m")
+		if got := ResolveStreamIdleTimeout(0); got != 4*time.Minute {
+			t.Fatalf("got %v, want 4m", got)
+		}
+	})
+
+	t.Run("env bare seconds", func(t *testing.T) {
+		t.Setenv(env, "45")
+		if got := ResolveStreamIdleTimeout(0); got != 45*time.Second {
+			t.Fatalf("got %v, want 45s", got)
+		}
+	})
+
+	t.Run("env disables the watchdog", func(t *testing.T) {
+		for _, value := range []string{"0", "off", "none", "disabled", "OFF"} {
+			t.Setenv(env, value)
+			if got := ResolveStreamIdleTimeout(0); got != 0 {
+				t.Fatalf("%q: got %v, want 0 (disabled)", value, got)
+			}
+		}
+	})
+
+	t.Run("invalid env falls back to default, not disabled", func(t *testing.T) {
+		t.Setenv(env, "banana")
+		if got := ResolveStreamIdleTimeout(0); got != DefaultStreamIdleTimeout {
+			t.Fatalf("got %v, want default %v on a typo (must not silently disable)", got, DefaultStreamIdleTimeout)
+		}
+	})
+
+	t.Run("default is generous enough for reasoning/cloud backends", func(t *testing.T) {
+		if DefaultStreamIdleTimeout < 3*time.Minute {
+			t.Fatalf("default %v is too aggressive; silent reasoning/cloud pauses can exceed it", DefaultStreamIdleTimeout)
+		}
+	})
+}


### PR DESCRIPTION
## The problem

A long generation could die mid-stream with:

```
provider stream error: idle timeout after 1m30s (upstream stopped sending data)
```

The idle watchdog was hardcoded to **90s**, duplicated as `defaultStreamIdleTimeout` in **three** providers (anthropic, gemini, openai; codex inherits openai), and **wired to no config**. Slow cloud/reasoning backends (e.g. an Ollama-Cloud → MiniMax model) that go genuinely silent for >90s without emitting SSE keep-alives were killed mid-generation, failing the whole task.

## The fix — one global, configurable, less-aggressive timeout

Centralized in `providerio`:

- **`providerio.DefaultStreamIdleTimeout`** — single source of truth, raised **90s → 5m**. The watchdog still resets on SSE keep-alive comments (that logic is unchanged), so a *heartbeating-but-slow* upstream is never aborted — this only widens how long **true silence** is tolerated before aborting a hung stream.
- **`providerio.ResolveStreamIdleTimeout(option)`** — precedence: explicit option (e.g. a test) > **`ZERO_STREAM_IDLE_TIMEOUT`** env > default. The env accepts a Go duration (`10m`, `300s`) or bare seconds (`600`); `0`/`off`/`none`/`disabled` turns the watchdog off. A typo falls back to the default rather than silently disabling it.

All four providers resolve through it, so **one env var tunes every provider at once**.

```bash
ZERO_STREAM_IDLE_TIMEOUT=10m zero      # more headroom for a very slow backend
ZERO_STREAM_IDLE_TIMEOUT=off zero      # disable the watchdog entirely
```

## Why 5 minutes

The watchdog exists to stop a truly hung connection from blocking forever. With keep-alive resets already in place, it only ever fires on *complete* silence — so the threshold should be "this stream is really dead," not "this model is thinking." 90s was tripping healthy long generations; 5m is the floor a real stall must cross, and it's now tunable for anything slower.

## Notes
- **No behavior change for healthy streams** — keep-alive heartbeats still reset the timer; only the silent-stall threshold and its configurability change.
- Removes the three duplicated constants (net −duplication).
- Existing idle tests keep passing (they set an explicit short timeout, which still wins). Adds resolver tests (precedence, env parsing, disable, typo→default) and documents the env var in the README.

Verified: `go test ./internal/providers/... ./internal/agent/...` green; gofmt/vet/build clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation to clarify the streaming watchdog behavior for provider connections, including default 5-minute idle timeout and environment variable configuration options.
  * Added support for `ZERO_STREAM_IDLE_TIMEOUT` environment variable to customize or disable the idle timeout (accepts duration formats like `5m`, `300s`, or disable with `0`/`off`/`disabled`).

* **Tests**
  * Added test coverage for stream idle timeout resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->