### PR TITLE
fix: behavioral-audit follow-ups (exec -p, cron/version/specialist UX, update_plan coercion, Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# Zero build/test/lint targets. AGENTS.MD says "Build with `make`" and "Run `make
+# lint` before opening a PR" — these targets back those instructions.
+.DEFAULT_GOAL := build
+.PHONY: build build-all test test-race vet fmt fmt-check lint tidy clean help
+
+# Build the main CLI binary into ./zero.
+build:
+	go build -o zero ./cmd/zero
+
+# Build every command in cmd/.
+build-all:
+	go build ./...
+
+# Run the full test suite with the race detector (matches CI expectations).
+test:
+	go test ./... -race -count=1
+
+# Faster, no race detector.
+test-quick:
+	go test ./...
+
+vet:
+	go vet ./...
+
+fmt:
+	gofmt -w $(shell git ls-files '*.go')
+
+# Fail if any tracked Go file is not gofmt-clean.
+fmt-check:
+	@out="$$(gofmt -l $$(git ls-files '*.go'))"; \
+	if [ -n "$$out" ]; then echo "gofmt needed:"; echo "$$out"; exit 1; fi
+
+# Lint = formatting check + vet (no extra tooling required).
+lint: fmt-check vet
+
+tidy:
+	go mod tidy
+
+clean:
+	rm -f zero
+	go clean ./...
+
+help:
+	@echo "Targets: build (default), build-all, test, test-quick, vet, fmt, fmt-check, lint, tidy, clean"

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -283,6 +283,14 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		}
 		return 0
 	case "-v", "--version", "version":
+		for _, a := range args[1:] {
+			if a == "-h" || a == "--help" {
+				if _, err := fmt.Fprintln(stdout, "Usage: zero version\n\nPrint the Zero CLI version. Takes no flags."); err != nil {
+					return 1
+				}
+				return 0
+			}
+		}
 		if _, err := fmt.Fprintf(stdout, "zero %s\n", version); err != nil {
 			return 1
 		}

--- a/internal/cli/cron.go
+++ b/internal/cli/cron.go
@@ -38,11 +38,11 @@ func runCronWith(store *cron.Store, now func() time.Time, args []string, stdout 
 	case "list", "ls":
 		return cronList(store, now, stdout, stderr)
 	case "rm", "remove":
-		return cronSimple(store, rest, stderr, func(id string) error { return store.Remove(id) }, "removed")
+		return cronSimple(store, rest, stdout, stderr, func(id string) error { return store.Remove(id) }, "Removed")
 	case "pause":
-		return cronSetStatus(store, rest, stderr, cron.StatusPaused)
+		return cronSetStatus(store, rest, stdout, stderr, cron.StatusPaused, "Paused")
 	case "resume":
-		return cronResume(store, now, rest, stderr)
+		return cronResume(store, now, rest, stdout, stderr)
 	case "run":
 		return cronRun(store, now, rest, stdout, stderr, Run)
 	default:
@@ -195,7 +195,7 @@ func cronList(store *cron.Store, now func() time.Time, stdout io.Writer, stderr 
 	return exitSuccess
 }
 
-func cronSimple(store *cron.Store, args []string, stderr io.Writer, fn func(string) error, verb string) int {
+func cronSimple(store *cron.Store, args []string, stdout io.Writer, stderr io.Writer, fn func(string) error, verb string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "An id is required.")
 		return exitUsage
@@ -204,10 +204,11 @@ func cronSimple(store *cron.Store, args []string, stderr io.Writer, fn func(stri
 		fmt.Fprintln(stderr, err.Error())
 		return exitUsage
 	}
+	fmt.Fprintf(stdout, "%s cron job %s.\n", verb, args[0])
 	return exitSuccess
 }
 
-func cronSetStatus(store *cron.Store, args []string, stderr io.Writer, status string) int {
+func cronSetStatus(store *cron.Store, args []string, stdout io.Writer, stderr io.Writer, status string, verb string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "An id is required.")
 		return exitUsage
@@ -222,11 +223,12 @@ func cronSetStatus(store *cron.Store, args []string, stderr io.Writer, status st
 		fmt.Fprintln(stderr, err.Error())
 		return exitCrash
 	}
+	fmt.Fprintf(stdout, "%s cron job %s.\n", verb, job.ID)
 	return exitSuccess
 }
 
 // cronResume sets a job active and recomputes NextRunAt.
-func cronResume(store *cron.Store, now func() time.Time, args []string, stderr io.Writer) int {
+func cronResume(store *cron.Store, now func() time.Time, args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "An id is required.")
 		return exitUsage
@@ -254,6 +256,7 @@ func cronResume(store *cron.Store, now func() time.Time, args []string, stderr i
 		fmt.Fprintln(stderr, err.Error())
 		return exitCrash
 	}
+	fmt.Fprintf(stdout, "Resumed cron job %s (next run %s).\n", job.ID, next.Format(time.RFC3339))
 	return exitSuccess
 }
 

--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -233,7 +233,7 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 				return options, false, err
 			}
 			options.outputFormat = format
-		case arg == "--prompt":
+		case arg == "-p" || arg == "--prompt":
 			value, next, err := nextFlagValue(args, index, arg)
 			if err != nil {
 				return options, false, err
@@ -242,6 +242,8 @@ func parseExecArgs(args []string) (execOptions, bool, error) {
 			index = next
 		case strings.HasPrefix(arg, "--prompt="):
 			options.promptParts = append(options.promptParts, strings.TrimSpace(strings.TrimPrefix(arg, "--prompt=")))
+		case strings.HasPrefix(arg, "-p="):
+			options.promptParts = append(options.promptParts, strings.TrimSpace(strings.TrimPrefix(arg, "-p=")))
 		case arg == "--resume":
 			if index+1 < len(args) && !strings.HasPrefix(args[index+1], "-") && strings.TrimSpace(args[index+1]) != "" {
 				options.resume = strings.TrimSpace(args[index+1])

--- a/internal/cli/specialist.go
+++ b/internal/cli/specialist.go
@@ -325,6 +325,11 @@ func runSpecialistEdit(paths specialist.Paths, name string, options specialistOp
 	info, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			for _, b := range specialist.Builtins() {
+				if b.Metadata.Name == name {
+					return writeExecUsageError(stderr, fmt.Sprintf("cannot edit builtin specialist %q: builtins are read-only. Create a user or project specialist of the same name to override it.", name))
+				}
+			}
 			return writeExecUsageError(stderr, "specialist not found: "+name)
 		}
 		return writeAppError(stderr, err.Error(), exitCrash)

--- a/internal/tools/plan_tool_test.go
+++ b/internal/tools/plan_tool_test.go
@@ -43,18 +43,80 @@ func TestUpdatePlanToolStoresAndFormatsPlan(t *testing.T) {
 	}
 }
 
-func TestUpdatePlanToolRejectsInvalidStatus(t *testing.T) {
-	result := NewUpdatePlanTool().Run(context.Background(), map[string]any{
+func TestUpdatePlanToolCoercesStatuses(t *testing.T) {
+	// A weaker model may emit non-canonical statuses ("nope", "done", "in-progress").
+	// These must be coerced (unknown -> pending, synonyms -> canonical) rather than
+	// failing the whole update_plan call — a rejected call leaves the stored plan
+	// unchanged, which freezes the plan panel on its previous state.
+	tool := NewUpdatePlanTool()
+	result := tool.Run(context.Background(), map[string]any{
 		"plan": []any{
 			map[string]any{"id": "1", "content": "Bad step", "status": "nope"},
+			map[string]any{"id": "2", "content": "Done step", "status": "done"},
+			map[string]any{"id": "3", "content": "Active step", "status": "in-progress"},
 		},
 	})
 
-	if result.Status != StatusError {
-		t.Fatalf("expected error status, got %s", result.Status)
+	if result.Status == StatusError {
+		t.Fatalf("unknown/synonym statuses must not error, got: %q", result.Output)
 	}
-	if !strings.Contains(result.Output, "status must be pending, in_progress, completed, or failed") {
-		t.Fatalf("unexpected output: %q", result.Output)
+	plan := tool.CurrentPlan()
+	if len(plan) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(plan))
+	}
+	if plan[0].Status != "pending" {
+		t.Errorf("unknown status should coerce to pending, got %q", plan[0].Status)
+	}
+	if plan[1].Status != "completed" {
+		t.Errorf("'done' should coerce to completed, got %q", plan[1].Status)
+	}
+	if plan[2].Status != "in_progress" {
+		t.Errorf("'in-progress' should coerce to in_progress, got %q", plan[2].Status)
+	}
+}
+
+func TestEnforceSingleInProgress(t *testing.T) {
+	// More than one in_progress is downgraded so only the LAST stays.
+	plan := []PlanItem{
+		{Content: "a", Status: "in_progress"},
+		{Content: "b", Status: "completed"},
+		{Content: "c", Status: "in_progress"},
+		{Content: "d", Status: "pending"},
+	}
+	out := enforceSingleInProgress(plan)
+	if out[0].Status != "completed" {
+		t.Errorf("earlier in_progress should downgrade to completed, got %q", out[0].Status)
+	}
+	if out[2].Status != "in_progress" {
+		t.Errorf("last in_progress should remain, got %q", out[2].Status)
+	}
+	count := 0
+	for _, it := range out {
+		if it.Status == "in_progress" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("want exactly 1 in_progress, got %d", count)
+	}
+
+	single := []PlanItem{{Status: "completed"}, {Status: "in_progress"}, {Status: "pending"}}
+	if got := enforceSingleInProgress(single); got[1].Status != "in_progress" {
+		t.Fatalf("single in_progress must be preserved, got %q", got[1].Status)
+	}
+}
+
+func TestUpdatePlanRunEnforcesSingleInProgress(t *testing.T) {
+	tool := NewUpdatePlanTool()
+	tool.Run(context.Background(), map[string]any{
+		"plan": []any{
+			map[string]any{"content": "a", "status": "in_progress"},
+			map[string]any{"content": "b", "status": "in_progress"},
+		},
+	})
+	plan := tool.CurrentPlan()
+	if plan[0].Status != "completed" || plan[1].Status != "in_progress" {
+		t.Fatalf("Run should enforce one in_progress, got %q,%q", plan[0].Status, plan[1].Status)
 	}
 }
 

--- a/internal/tools/update_plan.go
+++ b/internal/tools/update_plan.go
@@ -29,7 +29,9 @@ func NewUpdatePlanTool() *updatePlanTool {
 			description: "Create or update the in-memory plan for the current task. " +
 				"Pass the full ordered list of steps each call; it replaces the previous plan. " +
 				"Each item needs a `content` string; `status` defaults to \"pending\" and `id` is " +
-				"auto-numbered, so you only need to supply `content` (and `status` as the task progresses).",
+				"auto-numbered, so you only need to supply `content` (and `status` as the task progresses). " +
+				"Non-canonical status values are coerced to the nearest of pending/in_progress/completed/failed, " +
+				"and at most one item stays in_progress (earlier ones are marked completed).",
 			parameters: Schema{
 				Type: "object",
 				Properties: map[string]PropertySchema{
@@ -70,6 +72,7 @@ func (tool *updatePlanTool) Run(_ context.Context, args map[string]any) Result {
 	if err != nil {
 		return errorResult("Error: Invalid arguments for update_plan: " + err.Error())
 	}
+	plan = enforceSingleInProgress(plan)
 	tool.mu.Lock()
 	tool.currentPlan = plan
 	tool.mu.Unlock()
@@ -114,17 +117,15 @@ func parsePlanItems(value any) ([]PlanItem, error) {
 		if id == "" {
 			id = fmt.Sprintf("%d", index+1)
 		}
-		// status is optional and defaults to pending.
+		// status is optional and defaults to pending. Non-canonical values from
+		// weaker models (e.g. "done", "in-progress", "nope") are COERCED to the
+		// nearest canonical status rather than rejected: a rejected call leaves the
+		// stored plan unchanged, which freezes the plan panel on its previous state.
 		status, err := stringArgWithEmpty(object, "status", "pending", false, true)
 		if err != nil {
 			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
 		}
-		if status == "" {
-			status = "pending"
-		}
-		if !isPlanStatus(status) {
-			return nil, fmt.Errorf("plan item %d status must be pending, in_progress, completed, or failed", index+1)
-		}
+		status = normalizePlanStatus(status)
 		notes, err := stringArgWithEmpty(object, "notes", "", false, true)
 		if err != nil {
 			return nil, fmt.Errorf("plan item %d %s", index+1, err.Error())
@@ -140,8 +141,44 @@ func parsePlanItems(value any) ([]PlanItem, error) {
 	return plan, nil
 }
 
-func isPlanStatus(status string) bool {
-	return status == "pending" || status == "in_progress" || status == "completed" || status == "failed"
+// normalizePlanStatus coerces a free-form status into one of the four canonical
+// values. Unknown/empty input maps to "pending" so a weak model's stray status
+// never fails the whole update_plan call (which would freeze the plan panel).
+func normalizePlanStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "complete", "done", "finished", "resolved", "✓", "x", "[x]":
+		return "completed"
+	case "in_progress", "in-progress", "inprogress", "in progress", "active",
+		"doing", "started", "current", "wip", "ongoing", "running":
+		return "in_progress"
+	case "failed", "fail", "error", "errored", "blocked", "cancelled", "canceled", "abandoned", "skipped":
+		return "failed"
+	default: // pending, todo, not_started, queued, "", or anything unrecognized
+		return "pending"
+	}
+}
+
+// enforceSingleInProgress keeps at most one in_progress item: if several are
+// marked, only the LAST stays in_progress and the earlier ones are downgraded to
+// completed. Mirrors how a single active step should drive the plan panel.
+func enforceSingleInProgress(plan []PlanItem) []PlanItem {
+	last := -1
+	count := 0
+	for i, item := range plan {
+		if item.Status == "in_progress" {
+			count++
+			last = i
+		}
+	}
+	if count <= 1 {
+		return plan
+	}
+	for i := range plan {
+		if i != last && plan[i].Status == "in_progress" {
+			plan[i].Status = "completed"
+		}
+	}
+	return plan
 }
 
 func formatPlan(plan []PlanItem) string {


### PR DESCRIPTION
## Summary

Follow-up fixes from the 2026-06-21 behavioral audit. Small, self-contained CLI/tool correctness + UX issues. Every item was verified with `go test` and by exercising the built binary; the full `go test ./... -race` suite is green (68 pkgs, 0 fail, 0 data races).

## Fixes

- **`exec` accepts the advertised `-p` short flag.** Top-level help advertises `-p, --prompt`, but the `exec` subcommand parser only handled `--prompt`, so the documented headless form `zero exec -p "…"` errored with `unknown exec flag "-p"` (exit 2). Now `-p` and `-p=` work. (`internal/cli/exec_parse.go`)
- **`version --help` prints usage** instead of the version string. (`internal/cli/app.go`)
- **`specialist edit <builtin>`** now reports that builtins are read-only (create a same-named user/project specialist to override) instead of the misleading `specialist not found`. (`internal/cli/specialist.go`)
- **`cron pause` / `resume` / `rm` print a success confirmation.** Previously they were silent — `rm`'s confirmation verb was even passed but never used. (`internal/cli/cron.go`)
- **`update_plan` coerces non-canonical statuses** (e.g. `"done"`, `"in-progress"`, unknown → nearest of pending/in_progress/completed/failed) instead of failing the whole call, and keeps **at most one `in_progress`** item. A rejected `update_plan` call left the stored plan unchanged, which froze the plan panel on its previous state. (`internal/tools/update_plan.go` + tests)
- **Add a `Makefile`** with `build`/`test`/`lint`/`vet`/`fmt`… targets, backing AGENTS.MD's "Build with `make`" and "Run `make lint`" — previously there was no Makefile.

## Investigated but intentionally NOT changed

The audit flagged two more items that turned out to be **intentional, with guarding tests** — changing them broke those tests, so they're left as-is:

- `write_stdin` advertised in Auto mode — `TestCoreToolsExposeShellTools` asserts it must stay visible in Auto for polling/interrupts.
- `--list-tools` not resolving provider config (so `tool_search` doesn't appear there) — `TestRunExecListsMCPToolsWithoutProviderResolution` asserts `--list-tools` must not resolve config.

## Out of scope

`LICENSE` (owner decision), the provider-resolve startup crash (separate PR #283), OAuth default token storage and MCP auto-reconnect (design choices), and `update --check` 404 (works once releases are published).

## Test plan

- `make build`, `make lint` ✓
- `go test ./... -race -count=1` → 68 pkgs ok, 0 fail, 0 race
- Binary: `zero exec -p` accepted; `version --help`; `specialist edit worker`; `cron add/pause/resume/rm` confirmations — all observed correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-p` shorthand flag for prompts
  * `--version` flag now recognizes `--help` for usage information
  * Plan tool accepts common status variations and enforces single active item
  * Built-in specialists are now read-only with guidance on customization

* **Bug Fixes**
  * Fixed cron commands to display success confirmations

* **Chores**
  * Added development build and test automation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->