### PR TITLE
feat(tui): easier-to-scan tool results + visible selection bands

### DIFF
--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1178,7 +1178,9 @@ func (m model) renderRunningToolCard(row transcriptRow, width int, rc rowContext
 	if arg == "" {
 		arg = rc.args[rcKey(row.runID, row.id)]
 	}
-	head := toolCardHead(toolRowName(row), hint, arg, "", glyph, rc.auto[rcKey(row.runID, row.id)], width, opts)
+	// Running cards keep the normal name color; the accent spinner glyph at the
+	// front already marks them live (and orphaned dead cards must not look active).
+	head := toolCardHead(toolRowName(row), hint, arg, "", zeroTheme.ink, rc.auto[rcKey(row.runID, row.id)], width, opts)
 	return toolCard(head, glyph, nil, "", zeroTheme.cardRun, width)
 }
 
@@ -1186,9 +1188,11 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 	name := toolRowName(row)
 	failed := row.status == tools.StatusError
 	glyph := zeroTheme.green.Render("✓")
+	nameStyle := zeroTheme.green
 	borderStyle := zeroTheme.line
 	if failed {
 		glyph = zeroTheme.red.Render("✗")
+		nameStyle = zeroTheme.red
 		borderStyle = zeroTheme.cardErr
 	}
 	key := rcKey(row.runID, row.id)
@@ -1198,7 +1202,7 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 	// the card collapse to a single line — matching the reference agents' density.
 	// Only for clean OK results: errors and anything multi-line keep their body.
 	if !failed && opts.bodyCap > 0 && !toolCardAlwaysExpands(name) && looksLikeRedundantConfirmation(row.detail) {
-		head := toolCardHead(name, rc.hints[key], rc.args[key], "", glyph, rc.auto[key], width, opts)
+		head := toolCardHead(name, rc.hints[key], rc.args[key], "", nameStyle, rc.auto[key], width, opts)
 		return toolCard(head, glyph, nil, "", borderStyle, width)
 	}
 	// Collapse long, noisy output (web-search/MCP/read dumps) by default so the
@@ -1211,11 +1215,11 @@ func renderToolResultCard(row transcriptRow, width int, rc rowContext, opts card
 		collapsedFooter = collapsedToolFooter(row.detail)
 	}
 	if collapsedFooter != "" && !row.expanded {
-		head := toolCardHead(name, rc.hints[key], rc.args[key], "", glyph, rc.auto[key], width, opts)
+		head := toolCardHead(name, rc.hints[key], rc.args[key], "", nameStyle, rc.auto[key], width, opts)
 		return toolCard(head, glyph, nil, collapsedFooter, borderStyle, width)
 	}
 	body := toolCardBody(name, rc.hints[key], row.detail, width, opts)
-	head := toolCardHead(name, rc.hints[key], rc.args[key], body.headTag, glyph, rc.auto[key], width, opts)
+	head := toolCardHead(name, rc.hints[key], rc.args[key], body.headTag, nameStyle, rc.auto[key], width, opts)
 	footer := body.footer
 	if collapsedFooter != "" && row.expanded && footer == "" {
 		footer = "▾ collapse"
@@ -1304,8 +1308,10 @@ func toolDisplayName(name string) string {
 // tag, and the auto marker. The status glyph is NOT included here — toolCard
 // right-aligns it on the rule line so it sits at the card's right edge instead
 // of trailing the head text.
-func toolCardHead(name string, target string, arg string, headTag string, glyph string, auto bool, width int, opts cardRenderOptions) string {
-	head := zeroTheme.toolName.Render(toolDisplayName(name))
+func toolCardHead(name string, target string, arg string, headTag string, nameStyle lipgloss.Style, auto bool, width int, opts cardRenderOptions) string {
+	// Color the tool name by state (accent running / green done / red failed) so
+	// the head row reads at a glance, reinforcing the leading status glyph.
+	head := nameStyle.Bold(true).Render(toolDisplayName(name))
 	if target = strings.TrimSpace(target); target != "" {
 		// Show a shortened, workspace-relative path, but keep the hyperlink
 		// pointing at the original absolute path so the file still opens.
@@ -1356,18 +1362,22 @@ func toolCard(head string, glyph string, body []string, footer string, borderSty
 		innerWidth = width
 	}
 
-	// Head line: rail + head, with the status glyph right-aligned to the card
-	// edge. The glyph (and the space before it) is reserved out of the head's
-	// width budget so a long head truncates before it collides with the glyph.
+	// Head line: rail + LEADING status glyph + head. Leading the row with the
+	// glyph (✓ done / ✗ failed / spinner running) puts state in the first cell the
+	// eye lands on, instead of right-aligning it to the far card edge. The glyph
+	// (and the space after it) is reserved out of the head's width budget so a long
+	// head truncates cleanly; the row is right-padded to the full card width.
 	glyphWidth := lipgloss.Width(glyph)
-	glyphGap := 0
+	leading := ""
+	leadingWidth := 0
 	if glyphWidth > 0 {
-		glyphGap = 1
+		leading = glyph + " "
+		leadingWidth = glyphWidth + 1
 	}
-	headBudget := maxInt(1, width-railWidth-glyphWidth-glyphGap)
+	headBudget := maxInt(1, width-railWidth-leadingWidth)
 	head = fitStyledLine(head, headBudget)
-	headPad := maxInt(0, width-railWidth-lipgloss.Width(head)-glyphWidth)
-	headLine := rail + head + strings.Repeat(" ", headPad) + glyph
+	headPad := maxInt(0, width-railWidth-leadingWidth-lipgloss.Width(head))
+	headLine := rail + leading + head + strings.Repeat(" ", headPad)
 
 	lines := make([]string, 0, len(body)+2)
 	lines = append(lines, headLine)

--- a/internal/tui/scannable_results_test.go
+++ b/internal/tui/scannable_results_test.go
@@ -1,0 +1,28 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The status glyph must LEAD the tool-card head row (✓/✗/spinner in the first
+// cell after the rail), not be right-aligned to the far edge — so state reads at
+// a glance. Guards the "easier-to-scan results" change.
+func TestToolCardGlyphLeadsHeadRow(t *testing.T) {
+	head := zeroTheme.toolName.Render("bash")
+	glyph := zeroTheme.green.Render("✓")
+	out := toolCard(head, glyph, nil, "", zeroTheme.line, 60)
+	first := strings.SplitN(out, "\n", 2)[0]
+
+	glyphIdx := strings.Index(first, "✓")
+	nameIdx := strings.Index(first, "bash")
+	if glyphIdx < 0 {
+		t.Fatalf("head row missing status glyph: %q", first)
+	}
+	if nameIdx < 0 {
+		t.Fatalf("head row missing tool name: %q", first)
+	}
+	if glyphIdx > nameIdx {
+		t.Fatalf("status glyph must lead the tool name, got glyph@%d after name@%d: %q", glyphIdx, nameIdx, first)
+	}
+}

--- a/internal/tui/specialist_card.go
+++ b/internal/tui/specialist_card.go
@@ -322,6 +322,10 @@ func (m model) renderSpecialistCard(info specialistInfo, width int) string {
 	} else {
 		body = zeroTheme.muted.Render(bodyText)
 	}
+	// Surface the otherwise-invisible drill-in affordance: a left-click or Enter on
+	// the card opens its subchat (transcript_selection.go). A faint hint makes that
+	// discoverable instead of hidden; it truncates first on narrow cards.
+	body += zeroTheme.faint.Render("   · enter to open")
 
 	lines := []string{header, body}
 

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -144,7 +144,7 @@ var darkPalette = palette{
 	addBg:    "#15201d",
 	delBg:    "#241819",
 	permBg:   "#1c1915",
-	selBg:    "#1d2114",
+	selBg:    "#32401b", // selected row bg — brightened from #1d2114 so the highlighted row separates from the panel (sep 1.18→1.73) while ink label contrast stays ~9.4:1
 	addInk:   "#bdeed7",
 	delInk:   "#f2c4c4",
 	onAccent: "#000000",
@@ -176,7 +176,7 @@ var lightPalette = palette{
 	addBg:    "#e2f3e6", // diff added-line bg (light green)
 	delBg:    "#fbe6e6", // diff deleted-line bg (light red)
 	permBg:   "#fbf0d8", // permission card bg (light amber)
-	selBg:    "#e7f2cd", // selected row bg (light accent)
+	selBg:    "#cfe78f", // selected row bg (light accent) — deepened from #e7f2cd so it separates from the near-white panel (sep 1.01→1.15); ink label stays >12:1, faint ~5:1
 	addInk:   "#1d5b37", // added-line text
 	delInk:   "#8e2d2d", // deleted-line text
 	onAccent: "#ffffff", // text on the (dark) accent/amber fills

--- a/internal/tui/theme_select_test.go
+++ b/internal/tui/theme_select_test.go
@@ -49,6 +49,26 @@ func wcagRatio(t *testing.T, fg, bg string) float64 {
 	return (l1 + 0.05) / (l2 + 0.05)
 }
 
+// The highlighted picker/autocomplete row must both stand out from the panel
+// AND keep its label readable. Guards the regression this fixes: the light
+// selBg (#e7f2cd) sat at 1.01 vs the panel (#ececed) — effectively invisible.
+func TestSelectedRowBandIsVisibleAndReadable(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		pal  palette
+	}{
+		{"dark", darkPalette},
+		{"light", lightPalette},
+	} {
+		if r := wcagRatio(t, c.pal.ink, c.pal.selBg); r < 4.5 {
+			t.Errorf("%s: ink on selBg contrast %.2f < 4.5 — selected-row label unreadable", c.name, r)
+		}
+		if sep := wcagRatio(t, c.pal.selBg, c.pal.panel); sep < 1.10 {
+			t.Errorf("%s: selBg vs panel separation %.2f < 1.10 — selected row does not stand out", c.name, sep)
+		}
+	}
+}
+
 // resolveThemeMode precedence: explicit flag > ZERO_THEME env > auto.
 func TestResolveThemeModePrecedence(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
First batch of UI tuning from a reference-TUI comparison. These are the "easier-to-scan results" group — high impact, low risk, token/glyph-level polish, no architecture change.

## 1. Status reads at a glance — glyph to the front
The ✓/✗/spinner that tells you if a step worked moved from the far-right edge to the **front** of the row, and the tool name is now colored by state.

```
BEFORE:  │ bash  mkdir -p site                    ✓     (mark hidden far right)
AFTER:   │ ✓ bash  mkdir -p site                        (✓ + name in green, up front)
         │ ✗ edit_file ...                              (red on failure)
```
Running keeps the normal name with the accent spinner (so orphaned/dead cards don't look live). A common pattern: leading every row with a colored glyph.

## 2. The selected menu row is actually visible now
`selBg` sat almost on top of the panel, so the highlighted row barely separated — **worst on the light theme, where it was effectively invisible (1.01:1 vs the panel).**

- dark `#1d2114 → #32401b` (separation 1.18 → 1.73)
- light `#e7f2cd → #cfe78f` (1.01 → 1.15)

Label contrast stays **>9:1 dark / >12:1 light**. It's one token, so `/model`, autocomplete, and the model picker all brighten together. Values picked by computing WCAG ratios, not by eye.

## 3. The specialist drill-in is no longer a hidden feature
A specialist card opens its subchat on click/Enter but advertised nothing — added a faint `· enter to open`.

## Tests
- Lock the glyph-leads-head layout so it can't silently regress.
- New contrast guard: the selected band must both **separate from the panel (≥1.10)** and keep its **label AA-readable (≥4.5)** on both themes — this test would have caught the invisible light band.
- Full `internal/tui` suite green; gofmt/vet clean.

Note: I can't see the rendered UI (no vision), so colors were chosen by WCAG computation + layout was confirmed by rendering the card through the real renderer. Worth a quick `go run ./cmd/zero` look — happy to tune the exact shades or push the selection to a full inverted bar if you want more pop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "enter to open" hint in specialist cards to help discover drill-in navigation.

* **Style**
  * Repositioned status indicators to lead card headers instead of trailing edge.
  * Enhanced selected-row background colors for improved visibility and contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
