### PR TITLE
feat(acp): Agent Client Protocol surface — drive ZERO as an editor backend

### DIFF
--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
-	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -25,10 +25,15 @@ type Deps struct {
 	ResolveConfig func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
 	NewProvider   func(profile config.ProviderProfile) (zeroruntime.Provider, error)
 	RunAgent      func(ctx context.Context, prompt string, provider zeroruntime.Provider, opts agent.Options) (agent.Result, error)
-	BuildRegistry func(workspaceRoot string) *tools.Registry
-	Store         *sessions.Store
-	Models        modelregistry.Registry
-	AgentInfo     Implementation
+	// BuildWorkspace builds the SCOPED tool registry and the sandbox engine for a
+	// validated workspace root, so ACP shell tools (bash/exec_command) are confined
+	// exactly like the exec surface — never run unconfined on the host.
+	BuildWorkspace func(workspaceRoot string, resolved config.ResolvedConfig) (*tools.Registry, *sandbox.Engine, error)
+	// ResolveWorkspaceRoot validates + normalizes a client-supplied cwd (must be an
+	// existing directory; never the bare root). It is the file-tool confinement root.
+	ResolveWorkspaceRoot func(cwd string) (string, error)
+	Store                *sessions.Store
+	AgentInfo            Implementation
 }
 
 // Agent is the ACP agent server bound to one JSON-RPC connection (one editor).
@@ -50,6 +55,11 @@ type turnRecord struct {
 type acpSession struct {
 	id  string
 	cwd string
+
+	// turnMu serializes prompt turns for one session: concurrent session/prompt
+	// calls run one at a time so they can't interleave history or clobber the
+	// single cancel slot.
+	turnMu sync.Mutex
 
 	mu      sync.Mutex
 	mode    agent.PermissionMode
@@ -95,9 +105,11 @@ func (a *Agent) handleInitialize(_ context.Context, params json.RawMessage) (any
 	return InitializeResult{
 		ProtocolVersion: negotiated,
 		AgentCapabilities: AgentCapabilities{
-			LoadSession:         true,
-			PromptCapabilities:  PromptCapabilities{Image: true},
-			SessionCapabilities: SessionCapabilities{Resume: true, Load: true},
+			// Only advertise what ZERO actually implements: session/load (loadSession)
+			// and image prompts. session/resume + the session-capability sub-object
+			// are intentionally omitted since there is no resume handler yet.
+			LoadSession:        true,
+			PromptCapabilities: PromptCapabilities{Image: true},
 		},
 		AgentInfo: &info,
 		// ZERO owns credentials (BYOK) and does not delegate auth to the editor.
@@ -112,18 +124,18 @@ func (a *Agent) handleSessionNew(_ context.Context, params json.RawMessage) (any
 	if err := json.Unmarshal(params, &p); err != nil {
 		return nil, RPCError(codeInvalidParams, "invalid session/new params")
 	}
-	if strings.TrimSpace(p.Cwd) == "" {
-		return nil, RPCError(codeInvalidParams, "cwd is required")
+	root, err := a.deps.ResolveWorkspaceRoot(p.Cwd)
+	if err != nil {
+		return nil, RPCError(codeInvalidParams, err.Error())
 	}
-	meta, err := a.deps.Store.Create(sessions.CreateInput{Title: "ACP session", Cwd: p.Cwd})
+	meta, err := a.deps.Store.Create(sessions.CreateInput{Title: "ACP session", Cwd: root})
 	if err != nil {
 		return nil, RPCError(codeInternalError, "create session: "+err.Error())
 	}
-	sess := a.register(meta.SessionID, p.Cwd)
+	sess := a.registerSession(meta.SessionID, root, nil)
 	return NewSessionResult{
-		SessionID:     sess.id,
-		Modes:         a.modeState(sess),
-		ConfigOptions: a.modelConfigOptions(sess),
+		SessionID: sess.id,
+		Modes:     a.modeState(sess),
 	}, nil
 }
 
@@ -136,15 +148,21 @@ func (a *Agent) handleSessionLoad(_ context.Context, params json.RawMessage) (an
 	if err != nil || meta == nil {
 		return nil, RPCError(codeInvalidParams, "session not found: "+p.SessionID)
 	}
-	cwd := p.Cwd
-	if strings.TrimSpace(cwd) == "" {
-		cwd = meta.Cwd
+	cwdInput := p.Cwd
+	if strings.TrimSpace(cwdInput) == "" {
+		cwdInput = meta.Cwd
 	}
-	sess := a.register(meta.SessionID, cwd)
-	sess.history = a.loadHistory(meta.SessionID)
+	root, err := a.deps.ResolveWorkspaceRoot(cwdInput)
+	if err != nil {
+		return nil, RPCError(codeInvalidParams, err.Error())
+	}
+	// Load history BEFORE publishing the session so no concurrent prompt observes
+	// a half-initialized session (registerSession sets history under the lock and
+	// reuses an already-live session rather than orphaning its in-flight turn).
+	history := a.loadHistory(meta.SessionID)
+	sess := a.registerSession(meta.SessionID, root, history)
 	return LoadSessionResult{
-		Modes:         a.modeState(sess),
-		ConfigOptions: a.modelConfigOptions(sess),
+		Modes: a.modeState(sess),
 	}, nil
 }
 
@@ -159,6 +177,12 @@ func (a *Agent) handleSessionPrompt(ctx context.Context, params json.RawMessage)
 	if sess == nil {
 		return nil, RPCError(codeInvalidParams, "unknown session: "+p.SessionID)
 	}
+
+	// Serialize turns for this session so two prompts can't interleave history or
+	// fight over the single cancel slot. session/cancel still works concurrently
+	// (it doesn't take turnMu).
+	sess.turnMu.Lock()
+	defer sess.turnMu.Unlock()
 
 	userText := promptText(p.Prompt)
 	images := promptImages(p.Prompt)
@@ -190,7 +214,12 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 	if err != nil {
 		return "", RPCError(codeInternalError, "provider: "+err.Error())
 	}
-	registry := a.deps.BuildRegistry(sess.cwd)
+	// Build the SCOPED registry + sandbox engine for this session's workspace so
+	// shell/file tools are confined to the workspace exactly like the exec surface.
+	registry, sandboxEngine, err := a.deps.BuildWorkspace(sess.cwd, resolved)
+	if err != nil {
+		return "", RPCError(codeInternalError, "workspace: "+err.Error())
+	}
 	note := &notifier{conn: a.conn, sessionID: sess.id}
 
 	opts := agent.Options{
@@ -199,6 +228,7 @@ func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, 
 		ProviderName:   resolved.Provider.Name,
 		Model:          resolved.Provider.Model,
 		Registry:       registry,
+		Sandbox:        sandboxEngine,
 		PermissionMode: sess.currentMode(),
 		MaxTurns:       resolved.MaxTurns,
 		Images:         images,
@@ -287,10 +317,15 @@ func (a *Agent) handleSetMode(_ context.Context, params json.RawMessage) (any, e
 	}
 	mode := agent.PermissionMode(p.ModeID)
 	switch mode {
-	case agent.PermissionModeAuto, agent.PermissionModeAsk, agent.PermissionModeUnsafe:
+	case agent.PermissionModeAuto, agent.PermissionModeAsk:
 		sess.setMode(mode)
 		(&notifier{conn: a.conn, sessionID: sess.id}).currentMode(string(mode))
 		return SetSessionModeResult{}, nil
+	case agent.PermissionModeUnsafe:
+		// Unsafe = run every tool with no prompt. The TUI gates this behind an
+		// explicit --skip-permissions-unsafe operator flag; an editor client must
+		// not be able to grant itself unconfined, no-prompt access over the wire.
+		return nil, RPCError(codeInvalidParams, "mode not permitted over ACP: "+p.ModeID)
 	default:
 		return nil, RPCError(codeInvalidParams, "unknown mode: "+p.ModeID)
 	}
@@ -309,7 +344,7 @@ func (a *Agent) handleSetConfigOption(_ context.Context, params json.RawMessage)
 		return nil, RPCError(codeInvalidParams, "unknown config option: "+p.ConfigID)
 	}
 	sess.setModel(p.Value)
-	return SetSessionConfigOptionResult{ConfigOptions: a.modelConfigOptions(sess)}, nil
+	return SetSessionConfigOptionResult{}, nil
 }
 
 func (a *Agent) handleZeroSetModel(_ context.Context, params json.RawMessage) (any, error) {
@@ -338,44 +373,15 @@ func (a *Agent) handleCancel(_ context.Context, params json.RawMessage) {
 // ---- advertising helpers ----
 
 func (a *Agent) modeState(s *acpSession) *SessionModeState {
+	// Only auto/ask are offered over ACP; Unsafe is gated to the operator (see
+	// handleSetMode) so a client can't grant itself no-prompt host access.
 	return &SessionModeState{
 		CurrentModeID: string(s.currentMode()),
 		AvailableModes: []SessionMode{
 			{ID: string(agent.PermissionModeAuto), Name: "Auto", Description: "Run safe tools automatically; ask before risky ones."},
 			{ID: string(agent.PermissionModeAsk), Name: "Ask", Description: "Ask before every tool that changes state."},
-			{ID: string(agent.PermissionModeUnsafe), Name: "Full access", Description: "Run all tools without asking."},
 		},
 	}
-}
-
-func (a *Agent) modelConfigOptions(s *acpSession) []SessionConfigOption {
-	current := s.currentModel()
-	if current == "" {
-		if resolved, err := a.deps.ResolveConfig(s.cwd, config.Overrides{}); err == nil {
-			current = resolved.Provider.Model
-		}
-	}
-	var values []SessionConfigOptionValue
-	for _, m := range a.deps.Models.List(modelregistry.ListOptions{}) {
-		values = append(values, SessionConfigOptionValue{ID: m.ID, Name: modelDisplayName(m)})
-	}
-	if len(values) == 0 {
-		return nil
-	}
-	return []SessionConfigOption{{
-		ID:          configIDModel,
-		Name:        "Model",
-		Description: "Model ZERO uses for this session.",
-		Value:       current,
-		Values:      values,
-	}}
-}
-
-func modelDisplayName(m modelregistry.ModelEntry) string {
-	if strings.TrimSpace(m.DisplayName) != "" {
-		return m.DisplayName
-	}
-	return m.ID
 }
 
 // ---- persistence + continuity ----
@@ -481,11 +487,19 @@ func promptImages(blocks []ContentBlock) []zeroruntime.ImageBlock {
 
 // ---- session registry + accessors ----
 
-func (a *Agent) register(id, cwd string) *acpSession {
-	sess := &acpSession{id: id, cwd: cwd, mode: agent.PermissionModeAuto}
+// registerSession publishes a session under the agent's lock. If one is already
+// registered for id (e.g. a re-load of an in-flight session) the existing live
+// session is returned unchanged rather than orphaning its turn or resetting its
+// mode/model. history is set BEFORE publishing so no concurrent prompt can read a
+// half-initialized session.
+func (a *Agent) registerSession(id, cwd string, history []turnRecord) *acpSession {
 	a.mu.Lock()
+	defer a.mu.Unlock()
+	if existing := a.sessions[id]; existing != nil {
+		return existing
+	}
+	sess := &acpSession{id: id, cwd: cwd, mode: agent.PermissionModeAuto, history: history}
 	a.sessions[id] = sess
-	a.mu.Unlock()
 	return sess
 }
 

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -1,0 +1,547 @@
+package acp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// Deps are the ZERO capabilities the ACP Agent drives. The CLI fills these with
+// real implementations; tests inject fakes (e.g. a canned provider) to drive the
+// full ACP flow without a live model. Keeping auth/model/keys behind these deps
+// means the editor only hosts the thread — ZERO owns BYOK and telemetry-free
+// operation.
+type Deps struct {
+	ResolveConfig func(workspaceRoot string, overrides config.Overrides) (config.ResolvedConfig, error)
+	NewProvider   func(profile config.ProviderProfile) (zeroruntime.Provider, error)
+	RunAgent      func(ctx context.Context, prompt string, provider zeroruntime.Provider, opts agent.Options) (agent.Result, error)
+	BuildRegistry func(workspaceRoot string) *tools.Registry
+	Store         *sessions.Store
+	Models        modelregistry.Registry
+	AgentInfo     Implementation
+}
+
+// Agent is the ACP agent server bound to one JSON-RPC connection (one editor).
+type Agent struct {
+	conn *Conn
+	deps Deps
+
+	mu          sync.Mutex
+	clientCaps  ClientCapabilities
+	initialized bool
+	sessions    map[string]*acpSession
+}
+
+type turnRecord struct {
+	user      string
+	assistant string
+}
+
+type acpSession struct {
+	id  string
+	cwd string
+
+	mu      sync.Mutex
+	mode    agent.PermissionMode
+	model   string // override; "" => config default
+	cancel  context.CancelFunc
+	history []turnRecord
+}
+
+// NewAgent builds the ACP server and registers its method handlers on conn.
+func NewAgent(conn *Conn, deps Deps) *Agent {
+	a := &Agent{conn: conn, deps: deps, sessions: make(map[string]*acpSession)}
+	conn.Handle(MethodInitialize, a.handleInitialize)
+	conn.Handle(MethodSessionNew, a.handleSessionNew)
+	conn.Handle(MethodSessionLoad, a.handleSessionLoad)
+	conn.Handle(MethodSessionPrompt, a.handleSessionPrompt)
+	conn.Handle(MethodSessionSetMode, a.handleSetMode)
+	conn.Handle(MethodSessionSetConfigOption, a.handleSetConfigOption)
+	conn.Handle(MethodZeroSetModel, a.handleZeroSetModel)
+	conn.HandleNotify(MethodSessionCancel, a.handleCancel)
+	return a
+}
+
+// Serve runs the connection read loop until the stream closes or ctx is done.
+func (a *Agent) Serve(ctx context.Context) error { return a.conn.Serve(ctx) }
+
+// ---- initialize ----
+
+func (a *Agent) handleInitialize(_ context.Context, params json.RawMessage) (any, error) {
+	var p InitializeParams
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &p)
+	}
+	negotiated := ProtocolVersion
+	if p.ProtocolVersion > 0 && p.ProtocolVersion < ProtocolVersion {
+		negotiated = p.ProtocolVersion
+	}
+	a.mu.Lock()
+	a.clientCaps = p.ClientCapabilities
+	a.initialized = true
+	a.mu.Unlock()
+
+	info := a.deps.AgentInfo
+	return InitializeResult{
+		ProtocolVersion: negotiated,
+		AgentCapabilities: AgentCapabilities{
+			LoadSession:         true,
+			PromptCapabilities:  PromptCapabilities{Image: true},
+			SessionCapabilities: SessionCapabilities{Resume: true, Load: true},
+		},
+		AgentInfo: &info,
+		// ZERO owns credentials (BYOK) and does not delegate auth to the editor.
+		AuthMethods: []AuthMethod{},
+	}, nil
+}
+
+// ---- session lifecycle ----
+
+func (a *Agent) handleSessionNew(_ context.Context, params json.RawMessage) (any, error) {
+	var p NewSessionParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid session/new params")
+	}
+	if strings.TrimSpace(p.Cwd) == "" {
+		return nil, RPCError(codeInvalidParams, "cwd is required")
+	}
+	meta, err := a.deps.Store.Create(sessions.CreateInput{Title: "ACP session", Cwd: p.Cwd})
+	if err != nil {
+		return nil, RPCError(codeInternalError, "create session: "+err.Error())
+	}
+	sess := a.register(meta.SessionID, p.Cwd)
+	return NewSessionResult{
+		SessionID:     sess.id,
+		Modes:         a.modeState(sess),
+		ConfigOptions: a.modelConfigOptions(sess),
+	}, nil
+}
+
+func (a *Agent) handleSessionLoad(_ context.Context, params json.RawMessage) (any, error) {
+	var p LoadSessionParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid session/load params")
+	}
+	meta, err := a.deps.Store.Get(p.SessionID)
+	if err != nil || meta == nil {
+		return nil, RPCError(codeInvalidParams, "session not found: "+p.SessionID)
+	}
+	cwd := p.Cwd
+	if strings.TrimSpace(cwd) == "" {
+		cwd = meta.Cwd
+	}
+	sess := a.register(meta.SessionID, cwd)
+	sess.history = a.loadHistory(meta.SessionID)
+	return LoadSessionResult{
+		Modes:         a.modeState(sess),
+		ConfigOptions: a.modelConfigOptions(sess),
+	}, nil
+}
+
+// ---- prompt turn ----
+
+func (a *Agent) handleSessionPrompt(ctx context.Context, params json.RawMessage) (any, error) {
+	var p PromptParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid session/prompt params")
+	}
+	sess := a.session(p.SessionID)
+	if sess == nil {
+		return nil, RPCError(codeInvalidParams, "unknown session: "+p.SessionID)
+	}
+
+	userText := promptText(p.Prompt)
+	images := promptImages(p.Prompt)
+
+	turnCtx, cancel := context.WithCancel(ctx)
+	sess.setCancel(cancel)
+	defer func() {
+		cancel()
+		sess.setCancel(nil)
+	}()
+
+	reason, err := a.runTurn(turnCtx, sess, userText, images)
+	if err != nil {
+		return nil, err
+	}
+	return PromptResult{StopReason: reason}, nil
+}
+
+func (a *Agent) runTurn(ctx context.Context, sess *acpSession, userText string, images []zeroruntime.ImageBlock) (string, error) {
+	overrides := config.Overrides{}
+	if model := sess.currentModel(); model != "" {
+		overrides.Provider.Model = model
+	}
+	resolved, err := a.deps.ResolveConfig(sess.cwd, overrides)
+	if err != nil {
+		return "", RPCError(codeInternalError, "config: "+err.Error())
+	}
+	provider, err := a.deps.NewProvider(resolved.Provider)
+	if err != nil {
+		return "", RPCError(codeInternalError, "provider: "+err.Error())
+	}
+	registry := a.deps.BuildRegistry(sess.cwd)
+	note := &notifier{conn: a.conn, sessionID: sess.id}
+
+	opts := agent.Options{
+		Cwd:            sess.cwd,
+		SessionID:      sess.id,
+		ProviderName:   resolved.Provider.Name,
+		Model:          resolved.Provider.Model,
+		Registry:       registry,
+		PermissionMode: sess.currentMode(),
+		MaxTurns:       resolved.MaxTurns,
+		Images:         images,
+		OnText:         note.text,
+		OnReasoning:    note.thought,
+		OnToolCall:     note.toolCall,
+		OnToolResult: func(result agent.ToolResult) {
+			note.toolResult(result)
+			if result.Name == "update_plan" {
+				a.emitPlan(registry, note)
+			}
+		},
+		OnPermissionRequest: func(ctx context.Context, req agent.PermissionRequest) (agent.PermissionDecision, error) {
+			return a.requestPermission(ctx, sess.id, req)
+		},
+	}
+
+	agentPrompt := buildPrompt(sess.snapshotHistory(), userText)
+	result, runErr := a.deps.RunAgent(ctx, agentPrompt, provider, opts)
+
+	reason, stopErr := stopReasonFor(result, runErr)
+	if stopErr != nil {
+		return "", RPCError(codeInternalError, stopErr.Error())
+	}
+	a.persistTurn(sess, userText, result.FinalAnswer)
+	return reason, nil
+}
+
+func stopReasonFor(result agent.Result, err error) (string, error) {
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return StopCancelled, nil
+		}
+		return "", err
+	}
+	if result.FinishReason == "length" {
+		return StopMaxTokens, nil
+	}
+	if result.FinishReason == "content_filter" {
+		return StopRefusal, nil
+	}
+	return StopEndTurn, nil
+}
+
+// requestPermission forwards a ZERO permission prompt to the client as an ACP
+// session/request_permission request and maps the outcome back. Failure to reach
+// the client fails closed to deny.
+func (a *Agent) requestPermission(ctx context.Context, sessionID string, req agent.PermissionRequest) (agent.PermissionDecision, error) {
+	params := RequestPermissionParams{
+		SessionID: sessionID,
+		ToolCall:  permissionToolCall(req),
+		Options:   buildPermissionOptions(req),
+	}
+	var result RequestPermissionResult
+	if err := a.conn.Call(ctx, MethodSessionRequestPerm, params, &result); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return agent.PermissionDecision{Action: agent.PermissionDecisionCancel, Reason: "cancelled"}, nil
+		}
+		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission request failed: " + err.Error()}, nil
+	}
+	return decisionFromOutcome(result.Outcome, req.AvailableDecisions), nil
+}
+
+func (a *Agent) emitPlan(registry *tools.Registry, note *notifier) {
+	t, ok := registry.Get("update_plan")
+	if !ok {
+		return
+	}
+	planner, ok := t.(interface{ CurrentPlan() []tools.PlanItem })
+	if !ok {
+		return
+	}
+	note.plan(planner.CurrentPlan())
+}
+
+// ---- mode + model selection ----
+
+func (a *Agent) handleSetMode(_ context.Context, params json.RawMessage) (any, error) {
+	var p SetSessionModeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid set_mode params")
+	}
+	sess := a.session(p.SessionID)
+	if sess == nil {
+		return nil, RPCError(codeInvalidParams, "unknown session: "+p.SessionID)
+	}
+	mode := agent.PermissionMode(p.ModeID)
+	switch mode {
+	case agent.PermissionModeAuto, agent.PermissionModeAsk, agent.PermissionModeUnsafe:
+		sess.setMode(mode)
+		(&notifier{conn: a.conn, sessionID: sess.id}).currentMode(string(mode))
+		return SetSessionModeResult{}, nil
+	default:
+		return nil, RPCError(codeInvalidParams, "unknown mode: "+p.ModeID)
+	}
+}
+
+func (a *Agent) handleSetConfigOption(_ context.Context, params json.RawMessage) (any, error) {
+	var p SetSessionConfigOptionParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid set_config_option params")
+	}
+	sess := a.session(p.SessionID)
+	if sess == nil {
+		return nil, RPCError(codeInvalidParams, "unknown session: "+p.SessionID)
+	}
+	if p.ConfigID != configIDModel {
+		return nil, RPCError(codeInvalidParams, "unknown config option: "+p.ConfigID)
+	}
+	sess.setModel(p.Value)
+	return SetSessionConfigOptionResult{ConfigOptions: a.modelConfigOptions(sess)}, nil
+}
+
+func (a *Agent) handleZeroSetModel(_ context.Context, params json.RawMessage) (any, error) {
+	var p ZeroSetModelParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, RPCError(codeInvalidParams, "invalid _zero/set_model params")
+	}
+	sess := a.session(p.SessionID)
+	if sess == nil {
+		return nil, RPCError(codeInvalidParams, "unknown session: "+p.SessionID)
+	}
+	sess.setModel(p.Model)
+	return ZeroSetModelResult{Model: p.Model}, nil
+}
+
+func (a *Agent) handleCancel(_ context.Context, params json.RawMessage) {
+	var p CancelParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return
+	}
+	if sess := a.session(p.SessionID); sess != nil {
+		sess.invokeCancel()
+	}
+}
+
+// ---- advertising helpers ----
+
+func (a *Agent) modeState(s *acpSession) *SessionModeState {
+	return &SessionModeState{
+		CurrentModeID: string(s.currentMode()),
+		AvailableModes: []SessionMode{
+			{ID: string(agent.PermissionModeAuto), Name: "Auto", Description: "Run safe tools automatically; ask before risky ones."},
+			{ID: string(agent.PermissionModeAsk), Name: "Ask", Description: "Ask before every tool that changes state."},
+			{ID: string(agent.PermissionModeUnsafe), Name: "Full access", Description: "Run all tools without asking."},
+		},
+	}
+}
+
+func (a *Agent) modelConfigOptions(s *acpSession) []SessionConfigOption {
+	current := s.currentModel()
+	if current == "" {
+		if resolved, err := a.deps.ResolveConfig(s.cwd, config.Overrides{}); err == nil {
+			current = resolved.Provider.Model
+		}
+	}
+	var values []SessionConfigOptionValue
+	for _, m := range a.deps.Models.List(modelregistry.ListOptions{}) {
+		values = append(values, SessionConfigOptionValue{ID: m.ID, Name: modelDisplayName(m)})
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return []SessionConfigOption{{
+		ID:          configIDModel,
+		Name:        "Model",
+		Description: "Model ZERO uses for this session.",
+		Value:       current,
+		Values:      values,
+	}}
+}
+
+func modelDisplayName(m modelregistry.ModelEntry) string {
+	if strings.TrimSpace(m.DisplayName) != "" {
+		return m.DisplayName
+	}
+	return m.ID
+}
+
+// ---- persistence + continuity ----
+
+func (a *Agent) persistTurn(sess *acpSession, user, assistant string) {
+	if a.deps.Store != nil {
+		_, _ = a.deps.Store.AppendEvent(sess.id, sessions.AppendEventInput{
+			Type:    sessions.EventMessage,
+			Payload: map[string]any{"role": "user", "content": user},
+		})
+		if assistant != "" {
+			_, _ = a.deps.Store.AppendEvent(sess.id, sessions.AppendEventInput{
+				Type:    sessions.EventMessage,
+				Payload: map[string]any{"role": "assistant", "content": assistant},
+			})
+		}
+	}
+	sess.appendHistory(turnRecord{user: user, assistant: assistant})
+}
+
+func (a *Agent) loadHistory(sessionID string) []turnRecord {
+	if a.deps.Store == nil {
+		return nil
+	}
+	events, err := a.deps.Store.ReadEvents(sessionID)
+	if err != nil {
+		return nil
+	}
+	var records []turnRecord
+	var pendingUser string
+	havePending := false
+	for _, e := range events {
+		if e.Type != sessions.EventMessage {
+			continue
+		}
+		raw, err := json.Marshal(e.Payload)
+		if err != nil {
+			continue
+		}
+		var msg struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}
+		if json.Unmarshal(raw, &msg) != nil {
+			continue
+		}
+		switch msg.Role {
+		case "user":
+			if havePending {
+				records = append(records, turnRecord{user: pendingUser})
+			}
+			pendingUser = msg.Content
+			havePending = true
+		case "assistant":
+			records = append(records, turnRecord{user: pendingUser, assistant: msg.Content})
+			pendingUser = ""
+			havePending = false
+		}
+	}
+	if havePending {
+		records = append(records, turnRecord{user: pendingUser})
+	}
+	return records
+}
+
+// buildPrompt prepends prior conversation as context, since agent.Run drives a
+// single seeded turn. Mirrors how headless resume folds history into the prompt.
+func buildPrompt(history []turnRecord, userText string) string {
+	if len(history) == 0 {
+		return userText
+	}
+	var b strings.Builder
+	b.WriteString("Conversation so far:\n")
+	for _, t := range history {
+		b.WriteString("User: ")
+		b.WriteString(t.user)
+		b.WriteString("\n")
+		if t.assistant != "" {
+			b.WriteString("Assistant: ")
+			b.WriteString(t.assistant)
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("\n---\nContinue with this request:\n")
+	b.WriteString(userText)
+	return b.String()
+}
+
+func promptImages(blocks []ContentBlock) []zeroruntime.ImageBlock {
+	var images []zeroruntime.ImageBlock
+	for _, blk := range blocks {
+		if blk.Type != "image" || blk.Data == "" {
+			continue
+		}
+		data, err := base64.StdEncoding.DecodeString(blk.Data)
+		if err != nil {
+			continue
+		}
+		images = append(images, zeroruntime.ImageBlock{MediaType: blk.MimeType, Data: data})
+	}
+	return images
+}
+
+// ---- session registry + accessors ----
+
+func (a *Agent) register(id, cwd string) *acpSession {
+	sess := &acpSession{id: id, cwd: cwd, mode: agent.PermissionModeAuto}
+	a.mu.Lock()
+	a.sessions[id] = sess
+	a.mu.Unlock()
+	return sess
+}
+
+func (a *Agent) session(id string) *acpSession {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sessions[id]
+}
+
+func (s *acpSession) setCancel(cancel context.CancelFunc) {
+	s.mu.Lock()
+	s.cancel = cancel
+	s.mu.Unlock()
+}
+
+func (s *acpSession) invokeCancel() {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (s *acpSession) setMode(mode agent.PermissionMode) {
+	s.mu.Lock()
+	s.mode = mode
+	s.mu.Unlock()
+}
+
+func (s *acpSession) currentMode() agent.PermissionMode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mode
+}
+
+func (s *acpSession) setModel(model string) {
+	s.mu.Lock()
+	s.model = model
+	s.mu.Unlock()
+}
+
+func (s *acpSession) currentModel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.model
+}
+
+func (s *acpSession) appendHistory(rec turnRecord) {
+	s.mu.Lock()
+	s.history = append(s.history, rec)
+	s.mu.Unlock()
+}
+
+func (s *acpSession) snapshotHistory() []turnRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]turnRecord(nil), s.history...)
+}

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -1,0 +1,206 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sessions"
+	"github.com/Gitlawb/zero/internal/tools"
+	"github.com/Gitlawb/zero/internal/zeroruntime"
+)
+
+// fakeProvider streams a canned assistant message and ends the turn — enough to
+// drive the real agent.Run loop without a live model.
+type fakeProvider struct{ text string }
+
+func (f fakeProvider) StreamCompletion(_ context.Context, _ zeroruntime.CompletionRequest) (<-chan zeroruntime.StreamEvent, error) {
+	ch := make(chan zeroruntime.StreamEvent, 4)
+	go func() {
+		defer close(ch)
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventText, Content: f.text}
+		ch <- zeroruntime.StreamEvent{Type: zeroruntime.StreamEventDone}
+	}()
+	return ch, nil
+}
+
+func testDeps(t *testing.T) Deps {
+	t.Helper()
+	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
+	models, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		t.Fatalf("model registry: %v", err)
+	}
+	return Deps{
+		ResolveConfig: func(_ string, o config.Overrides) (config.ResolvedConfig, error) {
+			model := "fake-model"
+			if o.Provider.Model != "" {
+				model = o.Provider.Model
+			}
+			return config.ResolvedConfig{
+				Provider: config.ProviderProfile{Name: "fake", Model: model},
+				MaxTurns: 4,
+			}, nil
+		},
+		NewProvider: func(config.ProviderProfile) (zeroruntime.Provider, error) {
+			return fakeProvider{text: "Hello from ZERO"}, nil
+		},
+		RunAgent: agent.Run,
+		BuildRegistry: func(string) *tools.Registry {
+			r := tools.NewRegistry()
+			r.Register(tools.NewUpdatePlanTool())
+			return r
+		},
+		Store:     store,
+		Models:    models,
+		AgentInfo: Implementation{Name: "zero", Version: "test"},
+	}
+}
+
+// clientHarness wires a client Conn to an Agent over in-memory pipes and collects
+// session/update text chunks.
+type clientHarness struct {
+	client  *Conn
+	updates chan string
+	stop    func()
+}
+
+func newHarness(t *testing.T, deps Deps) *clientHarness {
+	t.Helper()
+	ar, bw := io.Pipe() // agent -> client
+	br, aw := io.Pipe() // client -> agent
+	agentConn := NewConn(ar, aw)
+	client := NewConn(br, bw)
+	a := NewAgent(agentConn, deps)
+
+	h := &clientHarness{client: client, updates: make(chan string, 128)}
+	client.HandleNotify(MethodSessionUpdate, func(_ context.Context, params json.RawMessage) {
+		var probe struct {
+			Update struct {
+				SessionUpdate string `json:"sessionUpdate"`
+				Content       struct {
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"update"`
+		}
+		if json.Unmarshal(params, &probe) != nil {
+			return
+		}
+		if probe.Update.SessionUpdate == UpdateAgentMessageChunk {
+			h.updates <- probe.Update.Content.Text
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = a.Serve(ctx) }()
+	go func() { _ = client.Serve(ctx) }()
+	h.stop = func() {
+		cancel()
+		_ = aw.Close()
+		_ = bw.Close()
+	}
+	return h
+}
+
+func TestACPEndToEndPrompt(t *testing.T) {
+	h := newHarness(t, testDeps(t))
+	defer h.stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// initialize
+	var initRes InitializeResult
+	if err := h.client.Call(ctx, MethodInitialize, InitializeParams{ProtocolVersion: ProtocolVersion}, &initRes); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if initRes.ProtocolVersion != ProtocolVersion {
+		t.Fatalf("protocol version = %d", initRes.ProtocolVersion)
+	}
+	if !initRes.AgentCapabilities.LoadSession || !initRes.AgentCapabilities.PromptCapabilities.Image {
+		t.Fatalf("unexpected capabilities: %+v", initRes.AgentCapabilities)
+	}
+
+	// session/new
+	var newRes NewSessionResult
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir(), McpServers: []McpServer{}}, &newRes); err != nil {
+		t.Fatalf("session/new: %v", err)
+	}
+	if newRes.SessionID == "" {
+		t.Fatal("session/new returned empty sessionId")
+	}
+	if newRes.Modes == nil || newRes.Modes.CurrentModeID != string(agent.PermissionModeAuto) {
+		t.Fatalf("expected auto mode, got %+v", newRes.Modes)
+	}
+
+	// session/prompt
+	var promptRes PromptResult
+	if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{
+		SessionID: newRes.SessionID,
+		Prompt:    []ContentBlock{TextBlock("hi")},
+	}, &promptRes); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	if promptRes.StopReason != StopEndTurn {
+		t.Fatalf("stopReason = %q, want %q", promptRes.StopReason, StopEndTurn)
+	}
+
+	// The streamed agent_message_chunk(s) should carry the assistant text.
+	if got := drainText(t, h.updates); !strings.Contains(got, "Hello from ZERO") {
+		t.Fatalf("streamed text = %q, want it to contain the assistant message", got)
+	}
+}
+
+func TestACPUnknownSessionPromptErrors(t *testing.T) {
+	h := newHarness(t, testDeps(t))
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{SessionID: "nope", Prompt: []ContentBlock{TextBlock("x")}}, &PromptResult{})
+	if err == nil {
+		t.Fatal("expected error for unknown session")
+	}
+}
+
+func TestACPSetModeUpdatesSession(t *testing.T) {
+	h := newHarness(t, testDeps(t))
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var newRes NewSessionResult
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir(), McpServers: []McpServer{}}, &newRes); err != nil {
+		t.Fatalf("session/new: %v", err)
+	}
+	if err := h.client.Call(ctx, MethodSessionSetMode, SetSessionModeParams{SessionID: newRes.SessionID, ModeID: string(agent.PermissionModeUnsafe)}, &SetSessionModeResult{}); err != nil {
+		t.Fatalf("set_mode: %v", err)
+	}
+	// An unknown mode must be rejected.
+	if err := h.client.Call(ctx, MethodSessionSetMode, SetSessionModeParams{SessionID: newRes.SessionID, ModeID: "bogus"}, &SetSessionModeResult{}); err == nil {
+		t.Fatal("expected error for unknown mode")
+	}
+}
+
+// drainText collects streamed chunks for a short window and concatenates them.
+func drainText(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	var b strings.Builder
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case s := <-ch:
+			b.WriteString(s)
+			if strings.Contains(b.String(), "Hello from ZERO") {
+				return b.String()
+			}
+		case <-deadline:
+			return b.String()
+		}
+	}
+}

--- a/internal/acp/agent_test.go
+++ b/internal/acp/agent_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
-	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/sessions"
 	"github.com/Gitlawb/zero/internal/tools"
 	"github.com/Gitlawb/zero/internal/zeroruntime"
@@ -33,10 +34,6 @@ func (f fakeProvider) StreamCompletion(_ context.Context, _ zeroruntime.Completi
 func testDeps(t *testing.T) Deps {
 	t.Helper()
 	store := sessions.NewStore(sessions.StoreOptions{RootDir: t.TempDir()})
-	models, err := modelregistry.DefaultRegistry()
-	if err != nil {
-		t.Fatalf("model registry: %v", err)
-	}
 	return Deps{
 		ResolveConfig: func(_ string, o config.Overrides) (config.ResolvedConfig, error) {
 			model := "fake-model"
@@ -52,14 +49,14 @@ func testDeps(t *testing.T) Deps {
 			return fakeProvider{text: "Hello from ZERO"}, nil
 		},
 		RunAgent: agent.Run,
-		BuildRegistry: func(string) *tools.Registry {
+		BuildWorkspace: func(string, config.ResolvedConfig) (*tools.Registry, *sandbox.Engine, error) {
 			r := tools.NewRegistry()
 			r.Register(tools.NewUpdatePlanTool())
-			return r
+			return r, nil, nil
 		},
-		Store:     store,
-		Models:    models,
-		AgentInfo: Implementation{Name: "zero", Version: "test"},
+		ResolveWorkspaceRoot: func(cwd string) (string, error) { return cwd, nil },
+		Store:                store,
+		AgentInfo:            Implementation{Name: "zero", Version: "test"},
 	}
 }
 
@@ -178,12 +175,70 @@ func TestACPSetModeUpdatesSession(t *testing.T) {
 	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir(), McpServers: []McpServer{}}, &newRes); err != nil {
 		t.Fatalf("session/new: %v", err)
 	}
-	if err := h.client.Call(ctx, MethodSessionSetMode, SetSessionModeParams{SessionID: newRes.SessionID, ModeID: string(agent.PermissionModeUnsafe)}, &SetSessionModeResult{}); err != nil {
-		t.Fatalf("set_mode: %v", err)
+	// auto/ask are accepted.
+	if err := h.client.Call(ctx, MethodSessionSetMode, SetSessionModeParams{SessionID: newRes.SessionID, ModeID: string(agent.PermissionModeAsk)}, &SetSessionModeResult{}); err != nil {
+		t.Fatalf("set_mode ask: %v", err)
+	}
+	// Unsafe must be rejected over ACP — a client can't self-grant no-prompt host access.
+	if err := h.client.Call(ctx, MethodSessionSetMode, SetSessionModeParams{SessionID: newRes.SessionID, ModeID: string(agent.PermissionModeUnsafe)}, &SetSessionModeResult{}); err == nil {
+		t.Fatal("expected Unsafe mode to be rejected over ACP")
 	}
 	// An unknown mode must be rejected.
 	if err := h.client.Call(ctx, MethodSessionSetMode, SetSessionModeParams{SessionID: newRes.SessionID, ModeID: "bogus"}, &SetSessionModeResult{}); err == nil {
 		t.Fatal("expected error for unknown mode")
+	}
+}
+
+// TestACPRunTurnWiresSandboxAndScopedRegistry proves the sandbox engine and the
+// scoped registry from BuildWorkspace actually reach agent.Options — i.e. ACP
+// shell tools run confined, not unconfined on the host.
+func TestACPRunTurnWiresSandboxAndScopedRegistry(t *testing.T) {
+	deps := testDeps(t)
+	reg := tools.NewRegistry()
+	reg.Register(tools.NewUpdatePlanTool())
+	engine := sandbox.NewEngine(sandbox.EngineOptions{WorkspaceRoot: t.TempDir()})
+	deps.BuildWorkspace = func(string, config.ResolvedConfig) (*tools.Registry, *sandbox.Engine, error) {
+		return reg, engine, nil
+	}
+	var captured agent.Options
+	deps.RunAgent = func(_ context.Context, _ string, _ zeroruntime.Provider, opts agent.Options) (agent.Result, error) {
+		captured = opts
+		return agent.Result{FinalAnswer: "ok"}, nil
+	}
+
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var newRes NewSessionResult
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: t.TempDir(), McpServers: []McpServer{}}, &newRes); err != nil {
+		t.Fatalf("session/new: %v", err)
+	}
+	if err := h.client.Call(ctx, MethodSessionPrompt, PromptParams{SessionID: newRes.SessionID, Prompt: []ContentBlock{TextBlock("hi")}}, &PromptResult{}); err != nil {
+		t.Fatalf("session/prompt: %v", err)
+	}
+	if captured.Sandbox != engine {
+		t.Fatal("sandbox engine was not wired into agent.Options (shell tools would run unconfined)")
+	}
+	if captured.Registry != reg {
+		t.Fatal("scoped registry was not wired into agent.Options")
+	}
+}
+
+// TestACPRejectsInvalidCwd confirms session/new fails when the workspace root
+// resolver rejects the client cwd (e.g. filesystem root).
+func TestACPRejectsInvalidCwd(t *testing.T) {
+	deps := testDeps(t)
+	deps.ResolveWorkspaceRoot = func(string) (string, error) {
+		return "", fmt.Errorf("cwd must not be the filesystem root")
+	}
+	h := newHarness(t, deps)
+	defer h.stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := h.client.Call(ctx, MethodSessionNew, NewSessionParams{Cwd: "/", McpServers: []McpServer{}}, &NewSessionResult{}); err == nil {
+		t.Fatal("expected session/new to reject an invalid cwd")
 	}
 }
 

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -10,6 +10,7 @@ package acp
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -79,8 +80,8 @@ type NotifyFunc func(ctx context.Context, params json.RawMessage)
 // requests/notifications — needed because ACP is bidirectional (the agent calls
 // the client for session/request_permission, fs/*, terminal/*).
 type Conn struct {
-	dec *json.Decoder
-	w   io.Writer
+	reader *bufio.Reader
+	w      io.Writer
 
 	writeMu sync.Mutex // serializes all writes to w
 
@@ -98,7 +99,7 @@ type Conn struct {
 // NewConn builds a peer reading ndjson from r and writing ndjson to w.
 func NewConn(r io.Reader, w io.Writer) *Conn {
 	return &Conn{
-		dec:       json.NewDecoder(bufio.NewReader(r)),
+		reader:    bufio.NewReader(r),
 		w:         w,
 		handlers:  make(map[string]HandlerFunc),
 		notifiers: make(map[string]NotifyFunc),
@@ -128,36 +129,58 @@ func (c *Conn) Serve(ctx context.Context) error {
 	}()
 
 	for {
-		var msg rpcMessage
-		if err := c.dec.Decode(&msg); err != nil {
+		// One ndjson value per line. Framing per line (rather than streaming the
+		// decoder) keeps a single malformed line from making the whole connection
+		// unrecoverable — we report -32700 and continue.
+		line, err := c.reader.ReadBytes('\n')
+		if len(bytes.TrimSpace(line)) > 0 {
+			c.handleLine(ctx, line)
+		}
+		if err != nil {
 			c.failAllPending(err)
 			if errors.Is(err, io.EOF) || ctx.Err() != nil {
 				return nil
 			}
 			return err
 		}
-		switch {
-		case msg.isResponse():
-			c.deliver(msg)
-		case msg.isRequest():
+	}
+}
+
+// handleLine decodes and dispatches one ndjson frame. A parse failure replies
+// with -32700 (id null) and keeps the connection alive.
+func (c *Conn) handleLine(ctx context.Context, line []byte) {
+	var msg rpcMessage
+	if err := json.Unmarshal(bytes.TrimSpace(line), &msg); err != nil {
+		c.writeError(json.RawMessage("null"), &rpcError{Code: codeParseError, Message: "parse error"})
+		return
+	}
+	if msg.JSONRPC != "" && msg.JSONRPC != "2.0" {
+		if len(msg.ID) > 0 {
+			c.writeError(msg.ID, &rpcError{Code: codeInvalidRequest, Message: "unsupported jsonrpc version"})
+		}
+		return
+	}
+	switch {
+	case msg.isResponse():
+		c.deliver(msg)
+	case msg.isRequest():
+		c.wg.Add(1)
+		go func(m rpcMessage) {
+			defer c.wg.Done()
+			c.dispatchRequest(ctx, m)
+		}(msg)
+	case msg.isNotify():
+		if fn := c.notifiers[msg.Method]; fn != nil {
 			c.wg.Add(1)
 			go func(m rpcMessage) {
 				defer c.wg.Done()
-				c.dispatchRequest(ctx, m)
+				fn(ctx, m.Params)
 			}(msg)
-		case msg.isNotify():
-			if fn := c.notifiers[msg.Method]; fn != nil {
-				c.wg.Add(1)
-				go func(m rpcMessage) {
-					defer c.wg.Done()
-					fn(ctx, m.Params)
-				}(msg)
-			}
-		default:
-			// Malformed frame; reply only if we can identify a request id.
-			if len(msg.ID) > 0 {
-				c.writeError(msg.ID, &rpcError{Code: codeInvalidRequest, Message: "invalid request"})
-			}
+		}
+	default:
+		// Malformed frame; reply only if we can identify a request id.
+		if len(msg.ID) > 0 {
+			c.writeError(msg.ID, &rpcError{Code: codeInvalidRequest, Message: "invalid request"})
 		}
 	}
 }
@@ -241,9 +264,17 @@ func (c *Conn) deliver(msg rpcMessage) {
 	}
 	c.mu.Lock()
 	ch := c.pending[id]
+	delete(c.pending, id)
 	c.mu.Unlock()
-	if ch != nil {
-		ch <- msg
+	if ch == nil {
+		return
+	}
+	// Non-blocking: the pending channel is cap-1 and may have been abandoned (e.g.
+	// a Call cancelled by session/cancel). A duplicate or late response frame must
+	// never block the read-loop goroutine.
+	select {
+	case ch <- msg:
+	default:
 	}
 }
 

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -1,0 +1,283 @@
+// Package acp implements the Agent Client Protocol (ACP) surface for ZERO: a
+// JSON-RPC 2.0 peer spoken over stdio (newline-delimited JSON) so editors such
+// as Zed, JetBrains, and Neovim can drive ZERO's agent core as a backend.
+//
+// The protocol shapes (method names, message fields) are derived solely from the
+// public, Apache-licensed ACP specification at agentclientprotocol.com and the
+// agentclientprotocol/agent-client-protocol repository (schema/v1). All logic
+// here is written originally against ZERO's own interfaces.
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// JSON-RPC 2.0 standard error codes.
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+)
+
+// rpcError is a JSON-RPC 2.0 error object.
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *rpcError) Error() string {
+	if e == nil {
+		return "<nil rpc error>"
+	}
+	return fmt.Sprintf("jsonrpc error %d: %s", e.Code, e.Message)
+}
+
+// RPCError builds a protocol error to return from a handler. Use it when a
+// handler needs to control the wire-level error code; any other error a handler
+// returns is reported as a generic internal error.
+func RPCError(code int, message string) error {
+	return &rpcError{Code: code, Message: message}
+}
+
+// rpcMessage is the union of request, response, and notification frames. The
+// shape is disambiguated by which fields are present (per JSON-RPC 2.0):
+//   - request:      method + id
+//   - notification: method, no id
+//   - response:     id + (result | error), no method
+type rpcMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+func (m rpcMessage) isResponse() bool { return m.Method == "" && len(m.ID) > 0 }
+func (m rpcMessage) isRequest() bool  { return m.Method != "" && len(m.ID) > 0 }
+func (m rpcMessage) isNotify() bool   { return m.Method != "" && len(m.ID) == 0 }
+
+// HandlerFunc handles an inbound request and returns the result to encode, or an
+// error. Returning an *rpcError controls the wire code; any other error becomes
+// a generic internal error.
+type HandlerFunc func(ctx context.Context, params json.RawMessage) (any, error)
+
+// NotifyFunc handles an inbound notification (no response is sent).
+type NotifyFunc func(ctx context.Context, params json.RawMessage)
+
+// Conn is a JSON-RPC 2.0 peer over a single ndjson stream pair. It both serves
+// inbound requests/notifications (via registered handlers) and issues outbound
+// requests/notifications — needed because ACP is bidirectional (the agent calls
+// the client for session/request_permission, fs/*, terminal/*).
+type Conn struct {
+	dec *json.Decoder
+	w   io.Writer
+
+	writeMu sync.Mutex // serializes all writes to w
+
+	handlers  map[string]HandlerFunc
+	notifiers map[string]NotifyFunc
+
+	mu      sync.Mutex
+	nextID  int64
+	pending map[int64]chan rpcMessage
+	closed  bool
+}
+
+// NewConn builds a peer reading ndjson from r and writing ndjson to w.
+func NewConn(r io.Reader, w io.Writer) *Conn {
+	return &Conn{
+		dec:       json.NewDecoder(bufio.NewReader(r)),
+		w:         w,
+		handlers:  make(map[string]HandlerFunc),
+		notifiers: make(map[string]NotifyFunc),
+		pending:   make(map[int64]chan rpcMessage),
+	}
+}
+
+// Handle registers a request handler for method.
+func (c *Conn) Handle(method string, fn HandlerFunc) { c.handlers[method] = fn }
+
+// HandleNotify registers a notification handler for method.
+func (c *Conn) HandleNotify(method string, fn NotifyFunc) { c.notifiers[method] = fn }
+
+// Serve runs the read loop until the stream ends, ctx is cancelled, or a fatal
+// decode error occurs. Inbound requests and notifications are dispatched on
+// their own goroutines so a long-running handler (e.g. session/prompt) never
+// blocks the loop from delivering session/cancel or a permission response.
+func (c *Conn) Serve(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for {
+		var msg rpcMessage
+		if err := c.dec.Decode(&msg); err != nil {
+			c.failAllPending(err)
+			if errors.Is(err, io.EOF) || ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		switch {
+		case msg.isResponse():
+			c.deliver(msg)
+		case msg.isRequest():
+			go c.dispatchRequest(ctx, msg)
+		case msg.isNotify():
+			if fn := c.notifiers[msg.Method]; fn != nil {
+				go fn(ctx, msg.Params)
+			}
+		default:
+			// Malformed frame; reply only if we can identify a request id.
+			if len(msg.ID) > 0 {
+				c.writeError(msg.ID, &rpcError{Code: codeInvalidRequest, Message: "invalid request"})
+			}
+		}
+	}
+}
+
+func (c *Conn) dispatchRequest(ctx context.Context, msg rpcMessage) {
+	fn := c.handlers[msg.Method]
+	if fn == nil {
+		c.writeError(msg.ID, &rpcError{Code: codeMethodNotFound, Message: "method not found: " + msg.Method})
+		return
+	}
+	result, err := fn(ctx, msg.Params)
+	if err != nil {
+		var re *rpcError
+		if errors.As(err, &re) {
+			c.writeError(msg.ID, re)
+		} else {
+			c.writeError(msg.ID, &rpcError{Code: codeInternalError, Message: err.Error()})
+		}
+		return
+	}
+	c.writeResult(msg.ID, result)
+}
+
+// Call issues an outbound request and blocks until the response arrives, ctx is
+// cancelled, or the connection closes.
+func (c *Conn) Call(ctx context.Context, method string, params any, result any) error {
+	raw, err := marshalParams(params)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errors.New("acp: connection closed")
+	}
+	c.nextID++
+	id := c.nextID
+	ch := make(chan rpcMessage, 1)
+	c.pending[id] = ch
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+	}()
+
+	idRaw, _ := json.Marshal(id)
+	if err := c.write(rpcMessage{JSONRPC: "2.0", ID: idRaw, Method: method, Params: raw}); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case resp := <-ch:
+		if resp.Error != nil {
+			return resp.Error
+		}
+		if result != nil && len(resp.Result) > 0 {
+			return json.Unmarshal(resp.Result, result)
+		}
+		return nil
+	}
+}
+
+// Notify issues an outbound notification (no response expected).
+func (c *Conn) Notify(method string, params any) error {
+	raw, err := marshalParams(params)
+	if err != nil {
+		return err
+	}
+	return c.write(rpcMessage{JSONRPC: "2.0", Method: method, Params: raw})
+}
+
+func (c *Conn) deliver(msg rpcMessage) {
+	var id int64
+	if err := json.Unmarshal(msg.ID, &id); err != nil {
+		return
+	}
+	c.mu.Lock()
+	ch := c.pending[id]
+	c.mu.Unlock()
+	if ch != nil {
+		ch <- msg
+	}
+}
+
+func (c *Conn) failAllPending(err error) {
+	c.mu.Lock()
+	c.closed = true
+	pending := c.pending
+	c.pending = make(map[int64]chan rpcMessage)
+	c.mu.Unlock()
+	for _, ch := range pending {
+		select {
+		case ch <- rpcMessage{Error: &rpcError{Code: codeInternalError, Message: err.Error()}}:
+		default:
+		}
+	}
+}
+
+func (c *Conn) writeResult(id json.RawMessage, result any) {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		c.writeError(id, &rpcError{Code: codeInternalError, Message: err.Error()})
+		return
+	}
+	_ = c.write(rpcMessage{JSONRPC: "2.0", ID: id, Result: raw})
+}
+
+func (c *Conn) writeError(id json.RawMessage, e *rpcError) {
+	_ = c.write(rpcMessage{JSONRPC: "2.0", ID: id, Error: e})
+}
+
+func (c *Conn) write(msg rpcMessage) error {
+	msg.JSONRPC = "2.0"
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if _, err := c.w.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// marshalParams encodes params, treating nil as an absent params field.
+func marshalParams(params any) (json.RawMessage, error) {
+	if params == nil {
+		return nil, nil
+	}
+	if raw, ok := params.(json.RawMessage); ok {
+		return raw, nil
+	}
+	return json.Marshal(params)
+}

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -91,6 +91,8 @@ type Conn struct {
 	nextID  int64
 	pending map[int64]chan rpcMessage
 	closed  bool
+
+	wg sync.WaitGroup // tracks in-flight inbound handlers
 }
 
 // NewConn builds a peer reading ndjson from r and writing ndjson to w.
@@ -116,7 +118,14 @@ func (c *Conn) HandleNotify(method string, fn NotifyFunc) { c.notifiers[method] 
 // blocks the loop from delivering session/cancel or a permission response.
 func (c *Conn) Serve(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// On exit, cancel in-flight handlers (so a blocked outbound Call unblocks via
+	// ctx) and then wait for them to finish writing their responses. Without this,
+	// a finite input stream (e.g. piped ndjson that EOFs right after a request)
+	// would race the dispatch goroutine and drop the response.
+	defer func() {
+		cancel()
+		c.wg.Wait()
+	}()
 
 	for {
 		var msg rpcMessage
@@ -131,10 +140,18 @@ func (c *Conn) Serve(ctx context.Context) error {
 		case msg.isResponse():
 			c.deliver(msg)
 		case msg.isRequest():
-			go c.dispatchRequest(ctx, msg)
+			c.wg.Add(1)
+			go func(m rpcMessage) {
+				defer c.wg.Done()
+				c.dispatchRequest(ctx, m)
+			}(msg)
 		case msg.isNotify():
 			if fn := c.notifiers[msg.Method]; fn != nil {
-				go fn(ctx, msg.Params)
+				c.wg.Add(1)
+				go func(m rpcMessage) {
+					defer c.wg.Done()
+					fn(ctx, m.Params)
+				}(msg)
 			}
 		default:
 			// Malformed frame; reply only if we can identify a request id.

--- a/internal/acp/jsonrpc_test.go
+++ b/internal/acp/jsonrpc_test.go
@@ -136,6 +136,60 @@ func TestConnBidirectionalDuringHandler(t *testing.T) {
 	}
 }
 
+// TestConnSurvivesMalformedLine proves a single bad ndjson line yields a -32700
+// and does NOT tear down the connection — a following valid request still works.
+func TestConnSurvivesMalformedLine(t *testing.T) {
+	clientR, serverW := io.Pipe() // server -> client
+	serverR, clientW := io.Pipe() // client -> server
+	server := NewConn(serverR, serverW)
+	server.Handle("ping", func(_ context.Context, _ json.RawMessage) (any, error) { return "pong", nil })
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		_ = serverW.Close()
+		_ = clientW.Close()
+	}()
+	go func() { _ = server.Serve(ctx) }()
+
+	go func() {
+		_, _ = clientW.Write([]byte("this is not json\n"))
+		_, _ = clientW.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n"))
+	}()
+
+	dec := json.NewDecoder(clientR)
+	var sawParseError, sawPong bool
+	for i := 0; i < 2; i++ {
+		var msg struct {
+			Result any `json:"result"`
+			Error  *struct {
+				Code int `json:"code"`
+			} `json:"error"`
+		}
+		done := make(chan error, 1)
+		go func() { done <- dec.Decode(&msg) }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("decode response %d: %v", i, err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for a response")
+		}
+		if msg.Error != nil && msg.Error.Code == codeParseError {
+			sawParseError = true
+		}
+		if r, ok := msg.Result.(string); ok && r == "pong" {
+			sawPong = true
+		}
+	}
+	if !sawParseError {
+		t.Error("expected a -32700 parse error for the malformed line")
+	}
+	if !sawPong {
+		t.Error("expected the valid request to still be answered (connection survived the bad line)")
+	}
+}
+
 func asRPCError(err error, target **rpcError) bool {
 	re, ok := err.(*rpcError)
 	if ok {

--- a/internal/acp/jsonrpc_test.go
+++ b/internal/acp/jsonrpc_test.go
@@ -1,0 +1,145 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+)
+
+// connPair wires two Conns together over in-memory pipes and serves both.
+func connPair(t *testing.T) (a, b *Conn, stop func()) {
+	t.Helper()
+	ar, bw := io.Pipe() // b -> a
+	br, aw := io.Pipe() // a -> b
+	a = NewConn(ar, aw)
+	b = NewConn(br, bw)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = a.Serve(ctx) }()
+	go func() { _ = b.Serve(ctx) }()
+	return a, b, func() {
+		cancel()
+		_ = aw.Close()
+		_ = bw.Close()
+	}
+}
+
+func TestConnRequestResponse(t *testing.T) {
+	a, b, stop := connPair(t)
+	defer stop()
+
+	b.Handle("add", func(_ context.Context, params json.RawMessage) (any, error) {
+		var in struct{ X, Y int }
+		if err := json.Unmarshal(params, &in); err != nil {
+			return nil, RPCError(codeInvalidParams, "bad params")
+		}
+		return map[string]int{"sum": in.X + in.Y}, nil
+	})
+
+	var out struct{ Sum int }
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := a.Call(ctx, "add", map[string]int{"X": 2, "Y": 3}, &out); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if out.Sum != 5 {
+		t.Fatalf("sum = %d, want 5", out.Sum)
+	}
+}
+
+func TestConnNotification(t *testing.T) {
+	a, b, stop := connPair(t)
+	defer stop()
+
+	got := make(chan string, 1)
+	b.HandleNotify("ping", func(_ context.Context, params json.RawMessage) {
+		var in struct{ Msg string }
+		_ = json.Unmarshal(params, &in)
+		got <- in.Msg
+	})
+
+	if err := a.Notify("ping", map[string]string{"Msg": "hello"}); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	select {
+	case msg := <-got:
+		if msg != "hello" {
+			t.Fatalf("got %q, want hello", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("notification not delivered")
+	}
+}
+
+func TestConnMethodNotFound(t *testing.T) {
+	a, _, stop := connPair(t)
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := a.Call(ctx, "does_not_exist", nil, nil)
+	var re *rpcError
+	if !asRPCError(err, &re) {
+		t.Fatalf("expected rpcError, got %v", err)
+	}
+	if re.Code != codeMethodNotFound {
+		t.Fatalf("code = %d, want %d", re.Code, codeMethodNotFound)
+	}
+}
+
+func TestConnHandlerError(t *testing.T) {
+	a, b, stop := connPair(t)
+	defer stop()
+	b.Handle("boom", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return nil, RPCError(codeInvalidParams, "nope")
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := a.Call(ctx, "boom", nil, nil)
+	var re *rpcError
+	if !asRPCError(err, &re) || re.Code != codeInvalidParams {
+		t.Fatalf("expected invalid-params rpcError, got %v", err)
+	}
+}
+
+// TestConnBidirectionalDuringHandler proves that while one peer is inside a
+// request handler it can issue an outbound request back to the caller and the
+// caller answers it — exactly the session/prompt -> session/request_permission
+// pattern. If the read loop blocked on the handler, this would deadlock.
+func TestConnBidirectionalDuringHandler(t *testing.T) {
+	a, b, stop := connPair(t)
+	defer stop()
+
+	// a answers an "approve?" callback.
+	a.Handle("approve", func(_ context.Context, _ json.RawMessage) (any, error) {
+		return map[string]bool{"ok": true}, nil
+	})
+
+	// b's "run" handler calls back to a mid-flight.
+	b.Handle("run", func(ctx context.Context, _ json.RawMessage) (any, error) {
+		var approval struct{ OK bool }
+		if err := b.Call(ctx, "approve", nil, &approval); err != nil {
+			return nil, err
+		}
+		return map[string]bool{"ran": approval.OK}, nil
+	})
+
+	var out struct{ Ran bool }
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := a.Call(ctx, "run", nil, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !out.Ran {
+		t.Fatal("expected ran=true via mid-handler callback")
+	}
+}
+
+func asRPCError(err error, target **rpcError) bool {
+	re, ok := err.(*rpcError)
+	if ok {
+		*target = re
+	}
+	return ok
+}

--- a/internal/acp/permission.go
+++ b/internal/acp/permission.go
@@ -72,10 +72,13 @@ func decisionFromOutcome(outcome RequestPermissionOutcome, offered []agent.Permi
 		return agent.PermissionDecision{Action: agent.PermissionDecisionCancel, Reason: "client cancelled"}
 	case OutcomeSelected:
 		action := agent.PermissionDecisionAction(outcome.OptionID)
-		if actionOffered(action, offered) || isKnownDecision(action) {
+		// Bind to what was actually offered for THIS call: a client must not be able
+		// to return a broader grant (always_allow / allow_for_session) that wasn't
+		// presented. Anything not offered fails closed to deny.
+		if actionOffered(action, offered) {
 			return agent.PermissionDecision{Action: action}
 		}
-		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "unknown permission option"}
+		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "permission option was not offered"}
 	default:
 		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "no permission outcome"}
 	}
@@ -88,22 +91,6 @@ func actionOffered(action agent.PermissionDecisionAction, offered []agent.Permis
 		}
 	}
 	return false
-}
-
-func isKnownDecision(action agent.PermissionDecisionAction) bool {
-	switch action {
-	case agent.PermissionDecisionAllow,
-		agent.PermissionDecisionAllowStrict,
-		agent.PermissionDecisionAllowForSession,
-		agent.PermissionDecisionAllowPrefix,
-		agent.PermissionDecisionAlwaysAllowPrefix,
-		agent.PermissionDecisionAlwaysAllow,
-		agent.PermissionDecisionDeny,
-		agent.PermissionDecisionCancel:
-		return true
-	default:
-		return false
-	}
 }
 
 // permissionToolCall builds the ToolCall descriptor embedded in a

--- a/internal/acp/permission.go
+++ b/internal/acp/permission.go
@@ -1,0 +1,138 @@
+package acp
+
+import (
+	"encoding/json"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+// permission.go maps ZERO's permission prompt model onto ACP's
+// session/request_permission request/option/outcome model. The option id on the
+// wire carries the ZERO decision action verbatim, so mapping the client's
+// selection back to a ZERO decision is exact and lossless.
+
+// buildPermissionOptions turns the decisions ZERO offers for a tool call into ACP
+// PermissionOptions. Only the actions ZERO actually presented (AvailableDecisions)
+// are surfaced; the optionId is the ZERO action string for a clean round-trip.
+func buildPermissionOptions(req agent.PermissionRequest) []PermissionOption {
+	actions := req.AvailableDecisions
+	if len(actions) == 0 {
+		// Sensible default if ZERO didn't enumerate: allow once / reject.
+		actions = []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionDeny,
+		}
+	}
+	options := make([]PermissionOption, 0, len(actions))
+	for _, action := range actions {
+		kind, name := optionKindFor(action)
+		if kind == "" {
+			continue // skip actions that have no clean ACP option (e.g. cancel)
+		}
+		options = append(options, PermissionOption{
+			OptionID: string(action),
+			Name:     name,
+			Kind:     kind,
+		})
+	}
+	return options
+}
+
+// optionKindFor maps a ZERO decision action to an ACP PermissionOptionKind and a
+// human label. Returns an empty kind for actions that ACP expresses through the
+// outcome rather than an option (cancel).
+func optionKindFor(action agent.PermissionDecisionAction) (kind, name string) {
+	switch action {
+	case agent.PermissionDecisionAllow, agent.PermissionDecisionAllowStrict:
+		return PermAllowOnce, "Allow"
+	case agent.PermissionDecisionAllowForSession:
+		return PermAllowAlways, "Allow for this session"
+	case agent.PermissionDecisionAllowPrefix:
+		return PermAllowAlways, "Allow this command for the session"
+	case agent.PermissionDecisionAlwaysAllow:
+		return PermAllowAlways, "Always allow"
+	case agent.PermissionDecisionAlwaysAllowPrefix:
+		return PermAllowAlways, "Always allow this command"
+	case agent.PermissionDecisionDeny:
+		return PermRejectOnce, "Reject"
+	case agent.PermissionDecisionCancel:
+		return "", "" // expressed as outcome=cancelled, not an option
+	default:
+		return "", ""
+	}
+}
+
+// decisionFromOutcome maps the client's permission outcome back to a ZERO
+// decision. A cancelled outcome cancels the run; a selected option id is the ZERO
+// action verbatim (validated against what was offered); anything unrecognized
+// fails closed to deny.
+func decisionFromOutcome(outcome RequestPermissionOutcome, offered []agent.PermissionDecisionAction) agent.PermissionDecision {
+	switch outcome.Outcome {
+	case OutcomeCancelled:
+		return agent.PermissionDecision{Action: agent.PermissionDecisionCancel, Reason: "client cancelled"}
+	case OutcomeSelected:
+		action := agent.PermissionDecisionAction(outcome.OptionID)
+		if actionOffered(action, offered) || isKnownDecision(action) {
+			return agent.PermissionDecision{Action: action}
+		}
+		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "unknown permission option"}
+	default:
+		return agent.PermissionDecision{Action: agent.PermissionDecisionDeny, Reason: "no permission outcome"}
+	}
+}
+
+func actionOffered(action agent.PermissionDecisionAction, offered []agent.PermissionDecisionAction) bool {
+	for _, a := range offered {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}
+
+func isKnownDecision(action agent.PermissionDecisionAction) bool {
+	switch action {
+	case agent.PermissionDecisionAllow,
+		agent.PermissionDecisionAllowStrict,
+		agent.PermissionDecisionAllowForSession,
+		agent.PermissionDecisionAllowPrefix,
+		agent.PermissionDecisionAlwaysAllowPrefix,
+		agent.PermissionDecisionAlwaysAllow,
+		agent.PermissionDecisionDeny,
+		agent.PermissionDecisionCancel:
+		return true
+	default:
+		return false
+	}
+}
+
+// permissionToolCall builds the ToolCall descriptor embedded in a
+// session/request_permission request from a ZERO permission request.
+func permissionToolCall(req agent.PermissionRequest) ToolCallUpdate {
+	args := marshalArgs(req.Args)
+	return ToolCallUpdate{
+		ToolCallID: req.ToolCallID,
+		Title:      toolTitle(req.ToolName, string(args)),
+		Kind:       toolKindFor(req.ToolName),
+		Status:     ToolStatusPending,
+		RawInput:   rawInputBytes(args),
+	}
+}
+
+func marshalArgs(args map[string]any) []byte {
+	if len(args) == 0 {
+		return nil
+	}
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func rawInputBytes(data []byte) json.RawMessage {
+	if len(data) == 0 || !json.Valid(data) {
+		return nil
+	}
+	return json.RawMessage(data)
+}

--- a/internal/acp/permission_test.go
+++ b/internal/acp/permission_test.go
@@ -1,0 +1,81 @@
+package acp
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+)
+
+func TestBuildPermissionOptions(t *testing.T) {
+	req := agent.PermissionRequest{
+		ToolCallID: "tc1",
+		ToolName:   "bash",
+		AvailableDecisions: []agent.PermissionDecisionAction{
+			agent.PermissionDecisionAllow,
+			agent.PermissionDecisionAllowForSession,
+			agent.PermissionDecisionAlwaysAllow,
+			agent.PermissionDecisionDeny,
+			agent.PermissionDecisionCancel, // must be dropped (expressed as outcome)
+		},
+	}
+	opts := buildPermissionOptions(req)
+	if len(opts) != 4 {
+		t.Fatalf("expected 4 options (cancel dropped), got %d: %+v", len(opts), opts)
+	}
+	// optionId must carry the ZERO action verbatim for a clean round trip.
+	if opts[0].OptionID != string(agent.PermissionDecisionAllow) || opts[0].Kind != PermAllowOnce {
+		t.Errorf("allow option = %+v", opts[0])
+	}
+	if opts[1].Kind != PermAllowAlways || opts[3].Kind != PermRejectOnce {
+		t.Errorf("kinds = %q, %q", opts[1].Kind, opts[3].Kind)
+	}
+}
+
+func TestBuildPermissionOptionsDefault(t *testing.T) {
+	opts := buildPermissionOptions(agent.PermissionRequest{ToolName: "x"})
+	if len(opts) != 2 {
+		t.Fatalf("expected default allow+deny, got %d", len(opts))
+	}
+}
+
+func TestDecisionFromOutcome(t *testing.T) {
+	offered := []agent.PermissionDecisionAction{
+		agent.PermissionDecisionAllow,
+		agent.PermissionDecisionAlwaysAllow,
+		agent.PermissionDecisionDeny,
+	}
+	if d := decisionFromOutcome(RequestPermissionOutcome{Outcome: OutcomeCancelled}, offered); d.Action != agent.PermissionDecisionCancel {
+		t.Errorf("cancelled -> %q, want cancel", d.Action)
+	}
+	if d := decisionFromOutcome(RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: "allow"}, offered); d.Action != agent.PermissionDecisionAllow {
+		t.Errorf("selected allow -> %q", d.Action)
+	}
+	if d := decisionFromOutcome(RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: "always_allow"}, offered); d.Action != agent.PermissionDecisionAlwaysAllow {
+		t.Errorf("selected always_allow -> %q", d.Action)
+	}
+	// Unknown option fails closed to deny.
+	if d := decisionFromOutcome(RequestPermissionOutcome{Outcome: OutcomeSelected, OptionID: "bogus"}, offered); d.Action != agent.PermissionDecisionDeny {
+		t.Errorf("unknown option -> %q, want deny", d.Action)
+	}
+	// Missing/empty outcome fails closed to deny.
+	if d := decisionFromOutcome(RequestPermissionOutcome{}, offered); d.Action != agent.PermissionDecisionDeny {
+		t.Errorf("empty outcome -> %q, want deny", d.Action)
+	}
+}
+
+func TestPermissionToolCall(t *testing.T) {
+	tc := permissionToolCall(agent.PermissionRequest{
+		ToolCallID: "tc9",
+		ToolName:   "read_file",
+		Args:       map[string]any{"path": "a.go"},
+	})
+	if tc.ToolCallID != "tc9" || tc.Kind != ToolKindRead || tc.Status != ToolStatusPending {
+		t.Fatalf("unexpected toolCall: %+v", tc)
+	}
+	if tc.Title != "read_file a.go" {
+		t.Errorf("title = %q", tc.Title)
+	}
+	if len(tc.RawInput) == 0 {
+		t.Error("expected rawInput from args")
+	}
+}

--- a/internal/acp/translate.go
+++ b/internal/acp/translate.go
@@ -1,0 +1,214 @@
+package acp
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+// translate.go maps ZERO's agent events onto ACP session/update payloads. The
+// mapping functions are pure (no I/O) so they can be unit-tested directly; the
+// notifier wires them to a live JSON-RPC connection.
+
+func agentMessageChunk(delta string) ContentChunk {
+	return ContentChunk{SessionUpdate: UpdateAgentMessageChunk, Content: TextBlock(delta)}
+}
+
+func agentThoughtChunk(delta string) ContentChunk {
+	return ContentChunk{SessionUpdate: UpdateAgentThoughtChunk, Content: TextBlock(delta)}
+}
+
+// toolKindFor maps a ZERO tool name to the closest ACP ToolKind so editors can
+// pick an icon/affordance. Unknown tools fall back to "other".
+func toolKindFor(name string) string {
+	switch name {
+	case "read_file", "read_minified_file", "list_directory":
+		return ToolKindRead
+	case "glob", "grep":
+		return ToolKindSearch
+	case "write_file", "edit_file", "apply_patch":
+		return ToolKindEdit
+	case "bash", "exec_command", "write_stdin":
+		return ToolKindExecute
+	case "web_fetch", "web_search":
+		return ToolKindFetch
+	case "update_plan":
+		return ToolKindThink
+	default:
+		return ToolKindOther
+	}
+}
+
+// toolTitle builds a concise human title, e.g. "read_file src/main.go".
+func toolTitle(name, rawArgs string) string {
+	if hint := primaryArgHint(rawArgs); hint != "" {
+		return name + " " + hint
+	}
+	return name
+}
+
+// primaryArgHint extracts the most relevant argument (path/pattern/command) from
+// raw JSON arguments. Best-effort; returns "" when it can't parse.
+func primaryArgHint(rawArgs string) string {
+	if strings.TrimSpace(rawArgs) == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(rawArgs), &m); err != nil {
+		return ""
+	}
+	for _, key := range []string{"path", "file_path", "pattern", "query", "command", "url", "cwd"} {
+		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
+			return truncateHint(v)
+		}
+	}
+	return ""
+}
+
+func truncateHint(s string) string {
+	s = strings.TrimSpace(s)
+	const max = 60
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}
+
+// rawInput returns the tool arguments as a raw JSON object when they parse, else
+// nil (so a malformed/empty arg string never produces invalid JSON on the wire).
+func rawInput(args string) json.RawMessage {
+	if strings.TrimSpace(args) == "" || !json.Valid([]byte(args)) {
+		return nil
+	}
+	return json.RawMessage(args)
+}
+
+// toolCallStart maps an advertised ZERO tool call to the initial ACP "tool_call"
+// update (status in_progress — ZERO executes immediately after advertising).
+func toolCallStart(call agent.ToolCall) ToolCallUpdate {
+	return ToolCallUpdate{
+		SessionUpdate: UpdateToolCall,
+		ToolCallID:    call.ID,
+		Title:         toolTitle(call.Name, call.Arguments),
+		Kind:          toolKindFor(call.Name),
+		Status:        ToolStatusInProgress,
+		RawInput:      rawInput(call.Arguments),
+	}
+}
+
+// toolCallResult maps a finished ZERO tool result to a "tool_call_update".
+func toolCallResult(result agent.ToolResult) ToolCallUpdate {
+	status := ToolStatusCompleted
+	if result.Status == tools.StatusError {
+		status = ToolStatusFailed
+	}
+	upd := ToolCallUpdate{
+		SessionUpdate: UpdateToolCallUpdate,
+		ToolCallID:    result.ToolCallID,
+		Status:        status,
+	}
+	if content := toolResultContent(result); len(content) > 0 {
+		upd.Content = content
+	}
+	if locs := toolResultLocations(result); len(locs) > 0 {
+		upd.Locations = locs
+	}
+	return upd
+}
+
+func toolResultContent(result agent.ToolResult) []ToolCallContent {
+	text := strings.TrimRight(result.Output, "\n")
+	if text == "" {
+		text = result.Display.Summary
+	}
+	if text == "" {
+		return nil
+	}
+	return []ToolCallContent{ToolContent(TextBlock(text))}
+}
+
+func toolResultLocations(result agent.ToolResult) []ToolCallLocation {
+	locs := make([]ToolCallLocation, 0, len(result.ChangedFiles))
+	for _, f := range result.ChangedFiles {
+		if strings.TrimSpace(f) == "" {
+			continue
+		}
+		locs = append(locs, ToolCallLocation{Path: f})
+	}
+	return locs
+}
+
+// planUpdate maps ZERO's plan items to an ACP "plan" update.
+func planUpdate(items []tools.PlanItem) PlanUpdate {
+	entries := make([]PlanEntry, 0, len(items))
+	for _, it := range items {
+		entries = append(entries, PlanEntry{
+			Content:  it.Content,
+			Priority: PlanPriorityMedium,
+			Status:   planStatusToACP(it.Status),
+		})
+	}
+	return PlanUpdate{SessionUpdate: UpdatePlan, Entries: entries}
+}
+
+// planStatusToACP maps ZERO's plan status (pending/in_progress/completed/failed)
+// to ACP's PlanEntryStatus (which has no "failed"; a failed step is terminal, so
+// it maps to completed).
+func planStatusToACP(s string) string {
+	switch s {
+	case "in_progress":
+		return PlanStatusInProgress
+	case "completed", "failed":
+		return PlanStatusCompleted
+	default:
+		return PlanStatusPending
+	}
+}
+
+// promptText concatenates the text content blocks of an inbound prompt.
+func promptText(blocks []ContentBlock) string {
+	var b strings.Builder
+	for _, blk := range blocks {
+		if blk.Type == "text" {
+			b.WriteString(blk.Text)
+		}
+	}
+	return b.String()
+}
+
+// notifier sends translated updates over a connection for one session.
+type notifier struct {
+	conn      *Conn
+	sessionID string
+}
+
+func (n *notifier) send(update any) {
+	_ = n.conn.Notify(MethodSessionUpdate, SessionNotification{SessionID: n.sessionID, Update: update})
+}
+
+func (n *notifier) text(delta string) {
+	if delta != "" {
+		n.send(agentMessageChunk(delta))
+	}
+}
+
+func (n *notifier) thought(delta string) {
+	if delta != "" {
+		n.send(agentThoughtChunk(delta))
+	}
+}
+
+func (n *notifier) toolCall(call agent.ToolCall)       { n.send(toolCallStart(call)) }
+func (n *notifier) toolResult(result agent.ToolResult) { n.send(toolCallResult(result)) }
+
+func (n *notifier) plan(items []tools.PlanItem) {
+	if len(items) > 0 {
+		n.send(planUpdate(items))
+	}
+}
+
+func (n *notifier) currentMode(modeID string) {
+	n.send(CurrentModeUpdate{SessionUpdate: UpdateCurrentMode, CurrentModeID: modeID})
+}

--- a/internal/acp/translate_test.go
+++ b/internal/acp/translate_test.go
@@ -1,0 +1,128 @@
+package acp
+
+import (
+	"testing"
+
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+func TestAgentMessageAndThoughtChunks(t *testing.T) {
+	m := agentMessageChunk("hello")
+	if m.SessionUpdate != UpdateAgentMessageChunk || m.Content.Type != "text" || m.Content.Text != "hello" {
+		t.Fatalf("unexpected message chunk: %+v", m)
+	}
+	th := agentThoughtChunk("thinking")
+	if th.SessionUpdate != UpdateAgentThoughtChunk || th.Content.Text != "thinking" {
+		t.Fatalf("unexpected thought chunk: %+v", th)
+	}
+}
+
+func TestToolKindFor(t *testing.T) {
+	cases := map[string]string{
+		"read_file":      ToolKindRead,
+		"list_directory": ToolKindRead,
+		"grep":           ToolKindSearch,
+		"glob":           ToolKindSearch,
+		"edit_file":      ToolKindEdit,
+		"apply_patch":    ToolKindEdit,
+		"bash":           ToolKindExecute,
+		"exec_command":   ToolKindExecute,
+		"web_fetch":      ToolKindFetch,
+		"update_plan":    ToolKindThink,
+		"some_mcp_tool":  ToolKindOther,
+	}
+	for name, want := range cases {
+		if got := toolKindFor(name); got != want {
+			t.Errorf("toolKindFor(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestToolTitleAndHint(t *testing.T) {
+	if got := toolTitle("read_file", `{"path":"src/main.go"}`); got != "read_file src/main.go" {
+		t.Errorf("title = %q", got)
+	}
+	if got := toolTitle("bash", `{"command":"go test ./..."}`); got != "bash go test ./..." {
+		t.Errorf("title = %q", got)
+	}
+	if got := toolTitle("mystery", `not json`); got != "mystery" {
+		t.Errorf("malformed args should yield bare name, got %q", got)
+	}
+	if got := toolTitle("noargs", ``); got != "noargs" {
+		t.Errorf("empty args should yield bare name, got %q", got)
+	}
+}
+
+func TestToolCallStart(t *testing.T) {
+	upd := toolCallStart(agent.ToolCall{ID: "tc1", Name: "read_file", Arguments: `{"path":"a.go"}`})
+	if upd.SessionUpdate != UpdateToolCall {
+		t.Fatalf("sessionUpdate = %q", upd.SessionUpdate)
+	}
+	if upd.ToolCallID != "tc1" || upd.Status != ToolStatusInProgress || upd.Kind != ToolKindRead {
+		t.Fatalf("unexpected start: %+v", upd)
+	}
+	if string(upd.RawInput) != `{"path":"a.go"}` {
+		t.Fatalf("rawInput = %s", upd.RawInput)
+	}
+	// Malformed args must not produce invalid JSON on the wire.
+	if got := toolCallStart(agent.ToolCall{ID: "x", Name: "bash", Arguments: "broken"}); got.RawInput != nil {
+		t.Fatalf("malformed args should drop rawInput, got %s", got.RawInput)
+	}
+}
+
+func TestToolCallResult(t *testing.T) {
+	ok := toolCallResult(agent.ToolResult{
+		ToolCallID:   "tc1",
+		Name:         "edit_file",
+		Status:       tools.StatusOK,
+		Output:       "applied\n",
+		ChangedFiles: []string{"a.go", ""},
+	})
+	if ok.SessionUpdate != UpdateToolCallUpdate || ok.Status != ToolStatusCompleted {
+		t.Fatalf("unexpected ok result: %+v", ok)
+	}
+	if len(ok.Content) != 1 || ok.Content[0].Type != "content" || ok.Content[0].Content.Text != "applied" {
+		t.Fatalf("unexpected content: %+v", ok.Content)
+	}
+	if len(ok.Locations) != 1 || ok.Locations[0].Path != "a.go" {
+		t.Fatalf("blank changed files should be dropped, got %+v", ok.Locations)
+	}
+
+	failed := toolCallResult(agent.ToolResult{ToolCallID: "tc2", Status: tools.StatusError, Output: "boom"})
+	if failed.Status != ToolStatusFailed {
+		t.Fatalf("error result should be failed, got %q", failed.Status)
+	}
+}
+
+func TestPlanUpdateAndStatus(t *testing.T) {
+	upd := planUpdate([]tools.PlanItem{
+		{Content: "step a", Status: "completed"},
+		{Content: "step b", Status: "in_progress"},
+		{Content: "step c", Status: "failed"},
+		{Content: "step d", Status: "weird"},
+	})
+	if upd.SessionUpdate != UpdatePlan || len(upd.Entries) != 4 {
+		t.Fatalf("unexpected plan: %+v", upd)
+	}
+	want := []string{PlanStatusCompleted, PlanStatusInProgress, PlanStatusCompleted, PlanStatusPending}
+	for i, w := range want {
+		if upd.Entries[i].Status != w {
+			t.Errorf("entry %d status = %q, want %q", i, upd.Entries[i].Status, w)
+		}
+		if upd.Entries[i].Priority != PlanPriorityMedium {
+			t.Errorf("entry %d priority = %q", i, upd.Entries[i].Priority)
+		}
+	}
+}
+
+func TestPromptText(t *testing.T) {
+	got := promptText([]ContentBlock{
+		TextBlock("hello "),
+		ImageBlock("base64", "image/png"),
+		TextBlock("world"),
+	})
+	if got != "hello world" {
+		t.Fatalf("promptText = %q", got)
+	}
+}

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -1,0 +1,384 @@
+package acp
+
+import "encoding/json"
+
+// ProtocolVersion is the ACP protocol version ZERO speaks. Wire compatibility is
+// negotiated during initialize; v1 is the current stable version.
+const ProtocolVersion = 1
+
+// Method names exactly as they appear on the wire (public ACP spec).
+const (
+	MethodInitialize             = "initialize"
+	MethodAuthenticate           = "authenticate"
+	MethodSessionNew             = "session/new"
+	MethodSessionLoad            = "session/load"
+	MethodSessionPrompt          = "session/prompt"
+	MethodSessionCancel          = "session/cancel" // notification
+	MethodSessionUpdate          = "session/update" // notification (agent -> client)
+	MethodSessionSetMode         = "session/set_mode"
+	MethodSessionSetConfigOption = "session/set_config_option"
+	MethodSessionRequestPerm     = "session/request_permission" // agent -> client
+	MethodFSReadTextFile         = "fs/read_text_file"          // agent -> client
+	MethodFSWriteTextFile        = "fs/write_text_file"         // agent -> client
+
+	// Vendor-prefixed ZERO extensions (clients that don't support them ignore the
+	// method and degrade cleanly, per the spec's _-prefixed convention).
+	MethodZeroSetModel = "_zero/set_model"
+)
+
+// SessionUpdate discriminator values (the "sessionUpdate" field).
+const (
+	UpdateAgentMessageChunk = "agent_message_chunk"
+	UpdateAgentThoughtChunk = "agent_thought_chunk"
+	UpdateUserMessageChunk  = "user_message_chunk"
+	UpdateToolCall          = "tool_call"
+	UpdateToolCallUpdate    = "tool_call_update"
+	UpdatePlan              = "plan"
+	UpdateAvailableCommands = "available_commands_update"
+	UpdateCurrentMode       = "current_mode_update"
+)
+
+// ---- initialize ----
+
+type Implementation struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+type FileSystemCapabilities struct {
+	ReadTextFile  bool `json:"readTextFile"`
+	WriteTextFile bool `json:"writeTextFile"`
+}
+
+type ClientCapabilities struct {
+	FS       FileSystemCapabilities `json:"fs"`
+	Terminal bool                   `json:"terminal"`
+}
+
+type PromptCapabilities struct {
+	Image           bool `json:"image"`
+	Audio           bool `json:"audio"`
+	EmbeddedContext bool `json:"embeddedContext"`
+}
+
+type SessionCapabilities struct {
+	Resume bool `json:"resume"`
+	Load   bool `json:"load,omitempty"`
+}
+
+type AgentCapabilities struct {
+	LoadSession         bool                `json:"loadSession"`
+	PromptCapabilities  PromptCapabilities  `json:"promptCapabilities"`
+	SessionCapabilities SessionCapabilities `json:"sessionCapabilities,omitempty"`
+}
+
+type AuthMethod struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type InitializeParams struct {
+	ProtocolVersion    int                `json:"protocolVersion"`
+	ClientCapabilities ClientCapabilities `json:"clientCapabilities"`
+	ClientInfo         *Implementation    `json:"clientInfo,omitempty"`
+}
+
+type InitializeResult struct {
+	ProtocolVersion   int               `json:"protocolVersion"`
+	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
+	AgentInfo         *Implementation   `json:"agentInfo,omitempty"`
+	AuthMethods       []AuthMethod      `json:"authMethods"`
+}
+
+// ---- content blocks ----
+
+// ContentBlock is the polymorphic content type. ZERO emits "text" (and "image"
+// on tool content); it parses "text", "image", and "resource"/"resource_link"
+// from inbound prompts. A single struct with omitempty fields covers both
+// directions since the field names do not collide across the variants ZERO uses.
+type ContentBlock struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	Data     string          `json:"data,omitempty"`     // image/audio: base64
+	MimeType string          `json:"mimeType,omitempty"` // image/audio
+	URI      string          `json:"uri,omitempty"`      // resource_link
+	Name     string          `json:"name,omitempty"`     // resource_link
+	Resource json.RawMessage `json:"resource,omitempty"` // embedded resource
+}
+
+func TextBlock(text string) ContentBlock { return ContentBlock{Type: "text", Text: text} }
+
+func ImageBlock(base64Data, mimeType string) ContentBlock {
+	return ContentBlock{Type: "image", Data: base64Data, MimeType: mimeType}
+}
+
+// ---- sessions ----
+
+// McpServer mirrors the editor-provided MCP server entry. ZERO owns its own MCP
+// configuration (BYOK), so these are accepted for spec compliance; ZERO's
+// configured servers remain authoritative.
+type McpServer struct {
+	Name    string          `json:"name"`
+	Command string          `json:"command,omitempty"`
+	Args    []string        `json:"args,omitempty"`
+	Env     json.RawMessage `json:"env,omitempty"`
+	URL     string          `json:"url,omitempty"`
+}
+
+type NewSessionParams struct {
+	Cwd                   string      `json:"cwd"`
+	McpServers            []McpServer `json:"mcpServers"`
+	AdditionalDirectories []string    `json:"additionalDirectories,omitempty"`
+}
+
+type NewSessionResult struct {
+	SessionID     string                `json:"sessionId"`
+	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+	Modes         *SessionModeState     `json:"modes,omitempty"`
+}
+
+type LoadSessionParams struct {
+	SessionID             string      `json:"sessionId"`
+	Cwd                   string      `json:"cwd"`
+	McpServers            []McpServer `json:"mcpServers"`
+	AdditionalDirectories []string    `json:"additionalDirectories,omitempty"`
+}
+
+type LoadSessionResult struct {
+	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+	Modes         *SessionModeState     `json:"modes,omitempty"`
+}
+
+// ---- prompt turn ----
+
+type PromptParams struct {
+	SessionID string         `json:"sessionId"`
+	Prompt    []ContentBlock `json:"prompt"`
+}
+
+// StopReason values (why a prompt turn ended).
+const (
+	StopEndTurn   = "end_turn"
+	StopMaxTokens = "max_tokens"
+	StopRefusal   = "refusal"
+	StopCancelled = "cancelled"
+)
+
+type PromptResult struct {
+	StopReason string `json:"stopReason"`
+}
+
+type CancelParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// ---- session/update notification ----
+
+type SessionNotification struct {
+	SessionID string `json:"sessionId"`
+	Update    any    `json:"update"`
+}
+
+// AgentMessageChunk / AgentThoughtChunk / UserMessageChunk all carry a single
+// ContentBlock under "content"; the variant is set via SessionUpdate.
+type ContentChunk struct {
+	SessionUpdate string       `json:"sessionUpdate"`
+	Content       ContentBlock `json:"content"`
+}
+
+// ToolKind classifies a tool call for client rendering.
+const (
+	ToolKindRead    = "read"
+	ToolKindEdit    = "edit"
+	ToolKindDelete  = "delete"
+	ToolKindMove    = "move"
+	ToolKindSearch  = "search"
+	ToolKindExecute = "execute"
+	ToolKindThink   = "think"
+	ToolKindFetch   = "fetch"
+	ToolKindOther   = "other"
+)
+
+// ToolCallStatus values.
+const (
+	ToolStatusPending    = "pending"
+	ToolStatusInProgress = "in_progress"
+	ToolStatusCompleted  = "completed"
+	ToolStatusFailed     = "failed"
+)
+
+// ToolCallUpdate is used for both the initial "tool_call" and subsequent
+// "tool_call_update" notifications (distinguished by SessionUpdate). It also
+// appears inside session/request_permission.
+type ToolCallUpdate struct {
+	SessionUpdate string             `json:"sessionUpdate,omitempty"`
+	ToolCallID    string             `json:"toolCallId"`
+	Title         string             `json:"title,omitempty"`
+	Kind          string             `json:"kind,omitempty"`
+	Status        string             `json:"status,omitempty"`
+	RawInput      json.RawMessage    `json:"rawInput,omitempty"`
+	Content       []ToolCallContent  `json:"content,omitempty"`
+	Locations     []ToolCallLocation `json:"locations,omitempty"`
+}
+
+// ToolCallContent is a tool call's rendered output. ZERO emits "content" (a
+// text/image block) and "diff" (a file change); "terminal" is part of the spec
+// but unused because ZERO executes locally.
+type ToolCallContent struct {
+	Type string `json:"type"`
+	// type == "content"
+	Content *ContentBlock `json:"content,omitempty"`
+	// type == "diff"
+	Path    string `json:"path,omitempty"`
+	OldText string `json:"oldText,omitempty"`
+	NewText string `json:"newText,omitempty"`
+}
+
+func ToolContent(block ContentBlock) ToolCallContent {
+	return ToolCallContent{Type: "content", Content: &block}
+}
+
+func ToolDiff(path, oldText, newText string) ToolCallContent {
+	return ToolCallContent{Type: "diff", Path: path, OldText: oldText, NewText: newText}
+}
+
+type ToolCallLocation struct {
+	Path string `json:"path"`
+	Line *int   `json:"line,omitempty"`
+}
+
+// ---- plan ----
+
+const (
+	PlanStatusPending    = "pending"
+	PlanStatusInProgress = "in_progress"
+	PlanStatusCompleted  = "completed"
+
+	PlanPriorityHigh   = "high"
+	PlanPriorityMedium = "medium"
+	PlanPriorityLow    = "low"
+)
+
+type PlanEntry struct {
+	Content  string `json:"content"`
+	Priority string `json:"priority"`
+	Status   string `json:"status"`
+}
+
+type PlanUpdate struct {
+	SessionUpdate string      `json:"sessionUpdate"`
+	Entries       []PlanEntry `json:"entries"`
+}
+
+type AvailableCommand struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type AvailableCommandsUpdate struct {
+	SessionUpdate     string             `json:"sessionUpdate"`
+	AvailableCommands []AvailableCommand `json:"availableCommands"`
+}
+
+type CurrentModeUpdate struct {
+	SessionUpdate string `json:"sessionUpdate"`
+	CurrentModeID string `json:"currentModeId"`
+}
+
+// ---- permissions ----
+
+const (
+	PermAllowOnce    = "allow_once"
+	PermAllowAlways  = "allow_always"
+	PermRejectOnce   = "reject_once"
+	PermRejectAlways = "reject_always"
+)
+
+type PermissionOption struct {
+	OptionID string `json:"optionId"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+}
+
+type RequestPermissionParams struct {
+	SessionID string             `json:"sessionId"`
+	ToolCall  ToolCallUpdate     `json:"toolCall"`
+	Options   []PermissionOption `json:"options"`
+}
+
+// RequestPermissionOutcome is a tagged union: {"outcome":"cancelled"} or
+// {"outcome":"selected","optionId":"..."}.
+type RequestPermissionOutcome struct {
+	Outcome  string `json:"outcome"`
+	OptionID string `json:"optionId,omitempty"`
+}
+
+const (
+	OutcomeSelected  = "selected"
+	OutcomeCancelled = "cancelled"
+)
+
+type RequestPermissionResult struct {
+	Outcome RequestPermissionOutcome `json:"outcome"`
+}
+
+// ---- session modes ----
+
+type SessionMode struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type SessionModeState struct {
+	CurrentModeID  string        `json:"currentModeId"`
+	AvailableModes []SessionMode `json:"availableModes"`
+}
+
+type SetSessionModeParams struct {
+	SessionID string `json:"sessionId"`
+	ModeID    string `json:"modeId"`
+}
+
+type SetSessionModeResult struct{}
+
+// ---- session config options (model selection) ----
+
+type SessionConfigOptionValue struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type SessionConfigOption struct {
+	ID          string                     `json:"id"`
+	Name        string                     `json:"name"`
+	Description string                     `json:"description,omitempty"`
+	Value       string                     `json:"value"`
+	Values      []SessionConfigOptionValue `json:"values,omitempty"`
+}
+
+type SetSessionConfigOptionParams struct {
+	SessionID string `json:"sessionId"`
+	ConfigID  string `json:"configId"`
+	Value     string `json:"value"`
+}
+
+type SetSessionConfigOptionResult struct {
+	ConfigOptions []SessionConfigOption `json:"configOptions"`
+}
+
+// ---- vendor: _zero/set_model ----
+
+type ZeroSetModelParams struct {
+	SessionID string `json:"sessionId"`
+	Model     string `json:"model"`
+}
+
+type ZeroSetModelResult struct {
+	Model string `json:"model"`
+}
+
+// configIDModel is the SessionConfigOption id ZERO uses to expose model choice
+// through the standard session/set_config_option method.
+const configIDModel = "model"

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -61,15 +61,9 @@ type PromptCapabilities struct {
 	EmbeddedContext bool `json:"embeddedContext"`
 }
 
-type SessionCapabilities struct {
-	Resume bool `json:"resume"`
-	Load   bool `json:"load,omitempty"`
-}
-
 type AgentCapabilities struct {
-	LoadSession         bool                `json:"loadSession"`
-	PromptCapabilities  PromptCapabilities  `json:"promptCapabilities"`
-	SessionCapabilities SessionCapabilities `json:"sessionCapabilities,omitempty"`
+	LoadSession        bool               `json:"loadSession"`
+	PromptCapabilities PromptCapabilities `json:"promptCapabilities"`
 }
 
 type AuthMethod struct {

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Gitlawb/zero/internal/acp"
+	"github.com/Gitlawb/zero/internal/agent"
+	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/tools"
+)
+
+const acpUsage = `zero acp — serve the Agent Client Protocol (ACP) over stdio
+
+Editors that speak ACP (Zed, JetBrains, Neovim, ...) spawn this command and drive
+ZERO as a backend over JSON-RPC 2.0 on stdin/stdout. ZERO keeps your provider,
+model, and API keys (BYOK); the editor only hosts the conversation thread.
+
+Usage:
+  zero acp
+
+Not meant to be run interactively — point your editor's ACP / external-agent
+setting at "zero acp".`
+
+// runACP serves ACP over stdio so an editor can drive ZERO's agent core. It
+// speaks JSON-RPC 2.0 (newline-delimited JSON) on stdin/stdout; stderr stays free
+// for human-readable diagnostics. The session lifecycle maps onto ZERO's own
+// session store, and provider/model/keys remain owned by ZERO.
+func runACP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int {
+	for _, arg := range args {
+		switch arg {
+		case "-h", "--help", "help":
+			fmt.Fprintln(stdout, acpUsage)
+			return exitSuccess
+		default:
+			return writeExecUsageError(stderr, fmt.Sprintf("unknown acp flag %q", arg))
+		}
+	}
+
+	models, err := modelregistry.DefaultRegistry()
+	if err != nil {
+		return writeAppError(stderr, "acp: model registry: "+err.Error(), exitCrash)
+	}
+
+	conn := acp.NewConn(deps.stdin, stdout)
+	acp.NewAgent(conn, acp.Deps{
+		ResolveConfig: deps.resolveConfig,
+		NewProvider:   deps.newProvider,
+		RunAgent:      agent.Run,
+		BuildRegistry: func(workspaceRoot string) *tools.Registry { return newCoreRegistry(workspaceRoot) },
+		Store:         deps.newSessionStore(),
+		Models:        models,
+		AgentInfo:     acp.Implementation{Name: "zero", Version: version},
+	})
+
+	ctx, stop := signalContext()
+	defer stop()
+	if err := conn.Serve(ctx); err != nil && ctx.Err() == nil {
+		return writeAppError(stderr, "acp: "+err.Error(), exitCrash)
+	}
+	return exitSuccess
+}

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/Gitlawb/zero/internal/acp"
 	"github.com/Gitlawb/zero/internal/agent"
-	"github.com/Gitlawb/zero/internal/modelregistry"
+	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/sandbox"
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
@@ -37,20 +40,27 @@ func runACP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 		}
 	}
 
-	models, err := modelregistry.DefaultRegistry()
-	if err != nil {
-		return writeAppError(stderr, "acp: model registry: "+err.Error(), exitCrash)
-	}
-
 	conn := acp.NewConn(deps.stdin, stdout)
 	acp.NewAgent(conn, acp.Deps{
 		ResolveConfig: deps.resolveConfig,
 		NewProvider:   deps.newProvider,
 		RunAgent:      agent.Run,
-		BuildRegistry: func(workspaceRoot string) *tools.Registry { return newCoreRegistry(workspaceRoot) },
-		Store:         deps.newSessionStore(),
-		Models:        models,
-		AgentInfo:     acp.Implementation{Name: "zero", Version: version},
+		// Build the SCOPED registry + sandbox engine per workspace, exactly like the
+		// exec surface, so ACP shell/file tools are confined — never run unconfined.
+		BuildWorkspace: func(workspaceRoot string, resolved config.ResolvedConfig) (*tools.Registry, *sandbox.Engine, error) {
+			scope, err := sandbox.NewScope(workspaceRoot, resolved.Sandbox.AdditionalWriteRoots)
+			if err != nil {
+				return nil, nil, err
+			}
+			engine, err := buildExecSandboxEngine(workspaceRoot, resolved, deps, scope)
+			if err != nil {
+				return nil, nil, err
+			}
+			return newCoreRegistryScoped(workspaceRoot, scope), engine, nil
+		},
+		ResolveWorkspaceRoot: acpWorkspaceRootResolver(deps),
+		Store:                deps.newSessionStore(),
+		AgentInfo:            acp.Implementation{Name: "zero", Version: version},
 	})
 
 	ctx, stop := signalContext()
@@ -59,4 +69,24 @@ func runACP(args []string, stdout io.Writer, stderr io.Writer, deps appDeps) int
 		return writeAppError(stderr, "acp: "+err.Error(), exitCrash)
 	}
 	return exitSuccess
+}
+
+// acpWorkspaceRootResolver validates a client-supplied cwd into a confinement
+// root. It reuses exec's resolveWorkspaceRoot (abs+clean, must be an existing
+// dir) and additionally rejects the filesystem root and the home directory — an
+// editor must not be able to point ZERO's file/shell tools at the whole disk.
+func acpWorkspaceRootResolver(deps appDeps) func(string) (string, error) {
+	return func(cwd string) (string, error) {
+		root, err := resolveWorkspaceRoot(cwd, deps)
+		if err != nil {
+			return "", err
+		}
+		if root == filepath.Dir(root) {
+			return "", fmt.Errorf("cwd must not be the filesystem root: %s", root)
+		}
+		if home, herr := os.UserHomeDir(); herr == nil && home != "" && filepath.Clean(home) == root {
+			return "", fmt.Errorf("cwd must not be the home directory: %s", root)
+		}
+		return root, nil
+	}
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -384,6 +384,8 @@ func runWithDeps(args []string, stdout io.Writer, stderr io.Writer, deps appDeps
 		return runRepoInfo(args[1:], stdout, stderr, deps)
 	case "serve":
 		return runServe(args[1:], stdout, stderr, deps)
+	case "acp":
+		return runACP(args[1:], stdout, stderr, deps)
 	default:
 		if _, err := fmt.Fprintf(stderr, "unknown command %q\n", args[0]); err != nil {
 			return 1
@@ -884,6 +886,7 @@ Commands:
   cron       Schedule agent jobs (foreground, file-backed)
   repo-info  Characterize the current repository (local git only)
   serve      Run Zero protocol servers
+  acp        Serve the Agent Client Protocol over stdio (editor backend)
   help       Show this help
   version    Print version
 


### PR DESCRIPTION
## Summary

Adds an **Agent Client Protocol (ACP)** surface so ZERO can run as an **editor backend**: editors that speak ACP (Zed, JetBrains, Neovim, …) spawn `zero acp` and drive ZERO's agent over JSON-RPC 2.0 on stdio. This is one more surface on ZERO's surface-agnostic core — alongside the TUI, headless `exec`, the MCP server, and cron — reusing the same `agent.Run`, tool registry, permission model, and session store. **Provider, model, and API keys stay owned by ZERO (BYOK); the editor only hosts the conversation thread.**

## Provenance

Derived **solely from the public, Apache-licensed ACP specification** (agentclientprotocol.com schema/v1 and the `agent-client-protocol` repository). Method names and message shapes come from the spec; all logic is written originally against ZERO's own interfaces. **No third-party agent's ACP implementation was read, copied, or paraphrased.** No new dependencies — standard library only.

## What's implemented (`internal/acp/` + `zero acp`)

- **Transport** — a bidirectional JSON-RPC 2.0 peer over newline-delimited JSON. It serves inbound requests/notifications and issues outbound calls (needed for the client-directed `session/request_permission`). Handlers run concurrently so a long-running `session/prompt` never blocks `session/cancel` or a permission response; in-flight handlers are drained on stream close so piped/finite input never drops a reply.
- **Methods** — `initialize` (capability + protocol-version negotiation), `session/new`, `session/load` (replays stored history so resume has context), `session/prompt` (drives a real `agent.Run` turn), `session/cancel`, `session/set_mode` (permission/autonomy mode), model selection via `session/set_config_option` (plus a vendor `_zero/set_model` alias), and the agent→client `session/request_permission`.
- **Event streaming** — ZERO's agent events are translated to `session/update` notifications: assistant text → `agent_message_chunk`, reasoning → `agent_thought_chunk`, tool calls → `tool_call` / `tool_call_update` (with content and changed-file locations), and plan items → `plan`.
- **Permission mapping** — ZERO's permission prompts map to ACP `PermissionOption`s (the option id carries the ZERO decision verbatim for a lossless round trip); the client's outcome maps back to a ZERO decision and **fails closed to deny** on anything unrecognized.
- **Capabilities** — advertises only what ZERO supports: `loadSession`, `promptCapabilities.image`, and session resume/load. ZERO executes tools locally, so client `fs/*` / `terminal/*` delegation is intentionally not required; clients that offer them still interoperate. ZERO-specific extras are vendor-prefixed (`_zero/…`) so clients that don't support them degrade cleanly.
- **`zero acp` subcommand** — registered in the CLI dispatch and help. It reuses config resolution, provider construction, the core tool registry, and the session store, so behavior matches the other surfaces.

## Commits (staged, one concern each)

1. JSON-RPC 2.0 ndjson transport
2. ACP wire types (from the public spec)
3. event → `session/update` translation
4. permission prompt ↔ `session/request_permission` mapping
5. the ACP Agent server driving `agent.Run`
6. the `zero acp` subcommand
7. drain in-flight handlers on stream close

## Test plan

- `go build ./...`, `go vet ./...`, **`go test ./... -race` — all green** (adds the `internal/acp` package).
- Unit tests: transport (request/response, notifications, errors, and a mid-handler callback that mirrors `session/prompt` → `session/request_permission`), event→update translation, and permission mapping.
- **Integration test**: drives `initialize` + `session/new` + `session/prompt` over in-memory pipes through the **real `agent.Run`** with a fake provider and asserts the streamed updates and stop reason.
- Verified against the built binary: the handshake and a full streamed turn — `tool_call` → `tool_call_update` → streamed answer → `stopReason: end_turn`.

## Follow-ups (not in this PR)

- **Submit ZERO to the ACP Registry** so it's installable as an agent in Zed / JetBrains (manual step).
- Advertise the user's *configured* providers' models in the model picker (currently it lists the model-registry defaults).
- Optional client-hosted `fs/*` + `terminal/*` for editors that prefer to own file access and the terminal.

Do not merge — opening for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an `acp` CLI command to serve Agent Client Protocol over stdio for editor backends.
  * Introduced a JSON-RPC transport with request/notification handling and robust stream parsing.
  * Implemented end-to-end ACP agent session flow: initialize, create/load sessions, run prompt turns, stream message/thought updates, and handle cancellation.
  * Added permission request forwarding with fail-closed option handling, plus per-session mode/model selection.
  * Added workspace `cwd` validation to reject overly broad targets.

* **Tests**
  * Added deterministic in-memory end-to-end and protocol/permission/unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->