### PR TITLE
Fix TUI UX issues

### DIFF
--- a/internal/tui/collapse_tools_test.go
+++ b/internal/tui/collapse_tools_test.go
@@ -72,7 +72,10 @@ func TestToolResultRowExposesClickToggle(t *testing.T) {
 	m := transcriptViewTestModel()
 	row := transcriptRow{kind: rowToolResult, id: "t", tool: "custom_tool", status: tools.StatusOK, detail: numberedLines(cardBodyMaxLines + 5)}
 	_, selectable := m.renderSelectableToolResultRow(0, row, m.width, buildRowContext(nil), 0)
-	if len(selectable) != 1 || !selectable[0].toggle {
+	if len(selectable) < 1 || !selectable[0].toggle {
 		t.Fatalf("tool result head must be a clickable toggle line, got %#v", selectable)
+	}
+	if len(selectable) < 2 || selectable[1].text == "" {
+		t.Fatalf("tool result visible body/footer must stay selectable, got %#v", selectable)
 	}
 }

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -257,7 +257,7 @@ func (m model) handleComposerSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd, b
 }
 
 func (m model) composerPositionAtMouse(msg tea.MouseMsg) (int, bool) {
-	if !m.altScreen || m.height <= 0 {
+	if !m.altScreen || m.height <= 0 || m.composerMouseSelectionBlocked() {
 		return 0, false
 	}
 	width := chatWidth(m.width)
@@ -277,6 +277,11 @@ func (m model) composerPositionAtMouse(msg tea.MouseMsg) (int, bool) {
 		return 0, false
 	}
 	return m.composerPositionAtVisualCell(localX-2, contentY, maxInt(1, width-4))
+}
+
+func (m model) composerMouseSelectionBlocked() bool {
+	return m.setup.visible || m.providerWizard != nil || m.mcpAddWizard != nil ||
+		m.mcpManager != nil || m.picker != nil || m.suggestionsActive()
 }
 
 func (m model) composerPositionAtVisualCell(x int, y int, width int) (int, bool) {

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -16,6 +16,12 @@ type composerState struct {
 	cursor int
 }
 
+type composerSelectionState struct {
+	active bool
+	anchor int
+	cursor int
+}
+
 type composerPastePreview struct {
 	active bool
 	start  int
@@ -151,6 +157,7 @@ func (m *model) clearComposer() {
 	m.composer = composerState{}
 	m.composerActive = false
 	m.composerPastePreviews = nil
+	m.composerSelection = composerSelectionState{}
 	m.input.SetValue("")
 }
 
@@ -158,6 +165,7 @@ func (m *model) resetComposerFromInput() {
 	m.composer = composerState{}
 	m.composerActive = false
 	m.composerPastePreviews = nil
+	m.composerSelection = composerSelectionState{}
 }
 
 func (m *model) syncInputFromComposer() {
@@ -173,6 +181,121 @@ func composerDisplayCursor(state composerState) int {
 		count++
 	}
 	return count
+}
+
+func (selection composerSelectionState) rangeFor(state composerState) (int, int, bool) {
+	if !selection.active {
+		return 0, 0, false
+	}
+	state = normalizeComposerState(state)
+	start := clamp(selection.anchor, 0, len([]rune(state.text)))
+	end := clamp(selection.cursor, 0, len([]rune(state.text)))
+	if start > end {
+		start, end = end, start
+	}
+	return start, end, start != end
+}
+
+func (m model) selectedComposerText() string {
+	state := m.currentComposerState()
+	start, end, ok := m.composerSelection.rangeFor(state)
+	if !ok {
+		return ""
+	}
+	return string([]rune(state.text)[start:end])
+}
+
+func (m model) handleComposerSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd, bool) {
+	switch {
+	case mouseLeftPress(msg):
+		pos, ok := m.composerPositionAtMouse(msg)
+		if !ok {
+			if m.composerSelection.active {
+				m.composerSelection = composerSelectionState{}
+				return m, nil, true
+			}
+			return m, nil, false
+		}
+		state := m.currentComposerState()
+		state.cursor = pos
+		m.setComposerState(state)
+		m.copyStatus = ""
+		m.composerSelection = composerSelectionState{active: true, anchor: pos, cursor: pos}
+		return m, nil, true
+	case mouseMotion(msg):
+		if !m.composerSelection.active {
+			return m, nil, false
+		}
+		if pos, ok := m.composerPositionAtMouse(msg); ok {
+			state := m.currentComposerState()
+			state.cursor = pos
+			m.setComposerState(state)
+			m.composerSelection.active = true
+			m.composerSelection.cursor = pos
+		}
+		return m, nil, true
+	case mouseRelease(msg):
+		if !m.composerSelection.active {
+			return m, nil, false
+		}
+		if pos, ok := m.composerPositionAtMouse(msg); ok {
+			state := m.currentComposerState()
+			state.cursor = pos
+			m.setComposerState(state)
+			m.composerSelection.active = true
+			m.composerSelection.cursor = pos
+		}
+		text := m.selectedComposerText()
+		m.composerSelection = composerSelectionState{}
+		if strings.TrimSpace(text) == "" {
+			return m, nil, true
+		}
+		return m, copyTranscriptSelectionCmd(text), true
+	default:
+		return m, nil, false
+	}
+}
+
+func (m model) composerPositionAtMouse(msg tea.MouseMsg) (int, bool) {
+	if !m.altScreen || m.height <= 0 {
+		return 0, false
+	}
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	localX, localY, ok := frame.composerRect.local(mouseX(msg), mouseY(msg))
+	if !ok {
+		return 0, false
+	}
+	if width < 8 {
+		return m.composerPositionAtVisualCell(localX, localY, width)
+	}
+	contentY := localY - 1
+	if renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments) != "" {
+		contentY--
+	}
+	if contentY < 0 {
+		return 0, false
+	}
+	return m.composerPositionAtVisualCell(localX-2, contentY, maxInt(1, width-4))
+}
+
+func (m model) composerPositionAtVisualCell(x int, y int, width int) (int, bool) {
+	input := m.input
+	state := m.currentComposerState()
+	previews := validComposerPastePreviews(state, m.composerPastePreviews)
+	displayState := composerDisplayStateForPastePreviews(state, previews)
+	segments, _ := composerVisibleVisualLines(input, displayState, width)
+	if len(segments) == 0 {
+		return 0, y == 0
+	}
+	if y < 0 || y >= len(segments) {
+		return 0, false
+	}
+	segment := segments[y]
+	prefixWidth := lipgloss.Width(composerVisualLinePrefix(input, segment.first))
+	column := maxInt(0, x-prefixWidth)
+	displayCursor := composerCursorForVisualColumn(displayState, segment, column)
+	return clamp(composerOriginalCursorForPastePreviews(displayCursor, previews), 0, len([]rune(state.text))), true
 }
 
 func (m model) applyComposerKey(msg tea.KeyMsg) (model, bool) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -116,6 +116,7 @@ type model struct {
 	composerActive        bool
 	composerCursorVisible bool
 	composerPastePreviews []composerPastePreview
+	composerSelection     composerSelectionState
 	// plan holds the sticky plan panel state (steps, expansion, timings)
 	// synced from the update_plan tool. See plan_panel.go.
 	plan        planPanelState
@@ -829,6 +830,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleSetupKey(msg)
 		}
 		m.transcriptSelection = transcriptSelectionState{}
+		m.composerSelection = composerSelectionState{}
 		m.clearMouseSelection()
 		// The `?` help overlay is modal: `?`, Esc, q, or Enter close it; every
 		// other key is swallowed so nothing types into the hidden composer.
@@ -2252,7 +2254,15 @@ func (m model) composerLine(width int) string {
 	}
 	previews := validComposerPastePreviews(state, m.composerPastePreviews)
 	displayState := composerDisplayStateForPastePreviews(state, previews)
-	return renderComposerInput(input, displayState, width, m.composerCursorVisible)
+	displaySelection := composerSelectionState{}
+	if start, end, ok := m.composerSelection.rangeFor(state); ok {
+		displaySelection = composerSelectionState{
+			active: true,
+			anchor: composerDisplayCursorForPastePreviews(start, previews),
+			cursor: composerDisplayCursorForPastePreviews(end, previews),
+		}
+	}
+	return renderComposerInput(input, displayState, width, m.composerCursorVisible, displaySelection)
 }
 
 type composerVisualLine struct {
@@ -2261,7 +2271,7 @@ type composerVisualLine struct {
 	end   int
 }
 
-func renderComposerInput(input textinput.Model, state composerState, width int, cursorVisible bool) string {
+func renderComposerInput(input textinput.Model, state composerState, width int, cursorVisible bool, selection composerSelectionState) string {
 	state = normalizeComposerState(state)
 	if width <= 0 {
 		return ""
@@ -2277,23 +2287,28 @@ func renderComposerInput(input textinput.Model, state composerState, width int, 
 		return fitStyledLine(composerVisualLinePrefix(input, true)+cursor+zeroTheme.faint.Render(input.Placeholder), width)
 	}
 
-	segments := composerWrappedVisualLines(input, state, width)
-	cursorLine := composerCursorVisualLine(segments, state.cursor)
-	if len(segments) > composerMaxVisibleLines {
-		start := clamp(cursorLine-composerMaxVisibleLines+1, 0, len(segments)-composerMaxVisibleLines)
-		end := start + composerMaxVisibleLines
-		cursorLine -= start
-		segments = segments[start:end]
-		if len(segments) > 0 {
-			segments[0].first = true
-		}
-	}
-
+	segments, cursorLine := composerVisibleVisualLines(input, state, width)
 	lines := make([]string, 0, len(segments))
 	for index, segment := range segments {
-		lines = append(lines, fitStyledLine(renderComposerVisualLine(input, state, segment, index == cursorLine, cursorVisible), width))
+		lines = append(lines, fitStyledLine(renderComposerVisualLine(input, state, segment, index == cursorLine, cursorVisible, selection), width))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func composerVisibleVisualLines(input textinput.Model, state composerState, width int) ([]composerVisualLine, int) {
+	segments := composerWrappedVisualLines(input, state, width)
+	cursorLine := composerCursorVisualLine(segments, state.cursor)
+	if len(segments) <= composerMaxVisibleLines {
+		return segments, cursorLine
+	}
+	start := clamp(cursorLine-composerMaxVisibleLines+1, 0, len(segments)-composerMaxVisibleLines)
+	end := start + composerMaxVisibleLines
+	cursorLine -= start
+	segments = segments[start:end]
+	if len(segments) > 0 {
+		segments[0].first = true
+	}
+	return segments, cursorLine
 }
 
 func composerWrappedVisualLines(input textinput.Model, state composerState, width int) []composerVisualLine {
@@ -2357,33 +2372,33 @@ func composerCursorVisualLine(segments []composerVisualLine, cursor int) int {
 	return len(segments) - 1
 }
 
-func renderComposerVisualLine(input textinput.Model, state composerState, segment composerVisualLine, hasCursor bool, cursorVisible bool) string {
+func renderComposerVisualLine(input textinput.Model, state composerState, segment composerVisualLine, hasCursor bool, cursorVisible bool, selection composerSelectionState) string {
 	runes := []rune(state.text)
 	prefix := composerVisualLinePrefix(input, segment.first)
 	textStyle := zeroTheme.ink.Inline(true)
-	if !hasCursor {
-		return prefix + textStyle.Render(string(runes[segment.start:segment.end]))
+	selectionStart, selectionEnd, hasSelection := selection.rangeFor(state)
+	cursorIndex := -1
+	if hasCursor && !hasSelection {
+		cursorIndex = clamp(state.cursor, segment.start, segment.end)
 	}
 
-	offset := clamp(state.cursor-segment.start, 0, segment.end-segment.start)
-	cursorIndex := segment.start + offset
-	before := string(runes[segment.start:cursorIndex])
-	if cursorIndex < segment.end {
-		cursorChar := string(runes[cursorIndex])
-		after := string(runes[cursorIndex+1 : segment.end])
-		// Blinked off: draw the character normally (no caret highlight).
-		cell := textStyle.Render(cursorChar)
-		if cursorVisible {
-			cell = composerCursor(cursorChar)
+	var line strings.Builder
+	line.WriteString(prefix)
+	for index := segment.start; index < segment.end; index++ {
+		cell := string(runes[index])
+		switch {
+		case index == cursorIndex && cursorVisible:
+			line.WriteString(composerCursor(cell))
+		case hasSelection && index >= selectionStart && index < selectionEnd:
+			line.WriteString(zeroTheme.selection.Render(cell))
+		default:
+			line.WriteString(textStyle.Render(cell))
 		}
-		return prefix + textStyle.Render(before) + cell + textStyle.Render(after)
 	}
-	// Cursor at end of line: a caret block when on, nothing when blinked off.
-	end := ""
-	if cursorVisible {
-		end = composerCursor(" ")
+	if cursorIndex == segment.end && cursorVisible {
+		line.WriteString(composerCursor(" "))
 	}
-	return prefix + textStyle.Render(before) + end
+	return line.String()
 }
 
 func composerVisualLinePrefix(input textinput.Model, first bool) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -691,13 +691,11 @@ func (m model) handleCtrlC() (tea.Model, tea.Cmd) {
 	if !m.pending && m.composerValue() != "" && m.noBlockingModal() && !m.transcriptDetailed && !m.subchat.active {
 		m.clearComposer()
 		m.clearSuggestions()
-		m.exitConfirmActive = false
-		m.exitConfirmSeq++
+		m = m.disarmExitConfirmation()
 		return m, nil
 	}
 	if m.exitConfirmActive {
-		m.exitConfirmActive = false
-		m.exitConfirmSeq++
+		m = m.disarmExitConfirmation()
 		m.cancelRun()
 		m.exiting = true
 		// A cancelled run may still need to flush checkpoint/session events; quit
@@ -714,6 +712,14 @@ func (m model) handleCtrlC() (tea.Model, tea.Cmd) {
 	return m, tea.Tick(ctrlCExitConfirmDuration, func(time.Time) tea.Msg {
 		return exitConfirmExpiredMsg{seq: seq}
 	})
+}
+
+func (m model) disarmExitConfirmation() model {
+	if m.exitConfirmActive {
+		m.exitConfirmActive = false
+		m.exitConfirmSeq++
+	}
+	return m
 }
 
 // Update routes every message through updateModel, then advances the flush
@@ -832,6 +838,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.transcriptSelection = transcriptSelectionState{}
 		m.composerSelection = composerSelectionState{}
 		m.clearMouseSelection()
+		if !keyCtrl(msg, 'c') {
+			m = m.disarmExitConfirmation()
+		}
 		// The `?` help overlay is modal: `?`, Esc, q, or Enter close it; every
 		// other key is swallowed so nothing types into the hidden composer.
 		if m.helpOverlay {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -699,6 +699,8 @@ func (m model) handleCtrlC() (tea.Model, tea.Cmd) {
 		m.exitConfirmSeq++
 		m.cancelRun()
 		m.exiting = true
+		// A cancelled run may still need to flush checkpoint/session events; quit
+		// only after agentResponseMsg drains flushRunIDs so /rewind stays valid.
 		if len(m.flushRunIDs) > 0 {
 			return m, nil
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -36,6 +36,8 @@ import (
 const tuiToolOutputLimit = 240
 const defaultResponseStyle = "balanced"
 const chatWheelScrollLines = 5
+const ctrlCExitConfirmDuration = 3 * time.Second
+const ctrlCExitConfirmText = "Press Ctrl+C again to exit"
 
 type model struct {
 	ctx                    context.Context
@@ -242,6 +244,8 @@ type model struct {
 	transcriptSelection transcriptSelectionState
 	copyStatus          string
 	copyStatusSeq       int
+	exitConfirmActive   bool
+	exitConfirmSeq      int
 
 	// picker, when non-nil, is an open interactive selector overlay (/model,
 	// /effort, /mode with no argument). It captures ↑/↓/Enter/Esc and applies
@@ -278,6 +282,10 @@ type model struct {
 type agentTextMsg struct {
 	runID int
 	delta string
+}
+
+type exitConfirmExpiredMsg struct {
+	seq int
 }
 
 // toolCallStreamStartMsg / toolCallStreamDeltaMsg carry a tool call's live
@@ -678,6 +686,26 @@ func (m model) quit() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
+func (m model) handleCtrlC() (tea.Model, tea.Cmd) {
+	if m.exitConfirmActive {
+		m.exitConfirmActive = false
+		m.exitConfirmSeq++
+		m.cancelRun()
+		m.exiting = true
+		if len(m.flushRunIDs) > 0 {
+			return m, nil
+		}
+		return m.quit()
+	}
+	m.cancelRun()
+	m.exitConfirmActive = true
+	m.exitConfirmSeq++
+	seq := m.exitConfirmSeq
+	return m, tea.Tick(ctrlCExitConfirmDuration, func(time.Time) tea.Msg {
+		return exitConfirmExpiredMsg{seq: seq}
+	})
+}
+
 // Update routes every message through updateModel, then advances the flush
 // frontier for inline rendering. Alt-screen runs keep rows in the managed view
 // instead of printing into terminal scrollback (see flush.go).
@@ -751,6 +779,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.copyStatus = ""
 		}
 		return m, nil
+	case exitConfirmExpiredMsg:
+		if msg.seq == m.exitConfirmSeq {
+			m.exitConfirmActive = false
+		}
+		return m, nil
 	case providerWizardOAuthMsg:
 		return m.applyProviderWizardOAuth(msg)
 	case providerWizardDeviceCodeMsg:
@@ -798,23 +831,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch {
 		case keyCtrl(msg, 'c'):
-			// cancelRun records the in-flight run into flushRunIDs and writes the
-			// "Run cancelled." marker, exactly like the Esc path. While ANY cancelled
-			// run is still flushing we must NOT quit yet: each cancelled goroutine
-			// returns its accumulated session events (including the
-			// EventSessionCheckpoint blobs it already wrote to disk before each
-			// mutating tool) in a final agentResponseMsg, and quitting now would drop
-			// that message, orphaning the checkpoints and breaking /rewind. This
-			// covers both a run cancelled BY this Ctrl+C and one cancelled by an
-			// earlier Esc whose flush hasn't landed (m.pending is already false then,
-			// but flushRunIDs is not empty). The agentResponseMsg handler fires
-			// tea.Quit once flushRunIDs drains.
-			m.cancelRun()
-			m.exiting = true
-			if len(m.flushRunIDs) > 0 {
-				return m, nil
-			}
-			return m.quit()
+			return m.handleCtrlC()
 		case keyCtrl(msg, 'o'):
 			return m.toggleDetailedTranscript(), nil
 		case keyCtrl(msg, 'e'):

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -687,6 +687,13 @@ func (m model) quit() (tea.Model, tea.Cmd) {
 }
 
 func (m model) handleCtrlC() (tea.Model, tea.Cmd) {
+	if !m.pending && m.composerValue() != "" && m.noBlockingModal() && !m.transcriptDetailed && !m.subchat.active {
+		m.clearComposer()
+		m.clearSuggestions()
+		m.exitConfirmActive = false
+		m.exitConfirmSeq++
+		return m, nil
+	}
 	if m.exitConfirmActive {
 		m.exitConfirmActive = false
 		m.exitConfirmSeq++

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1577,17 +1577,60 @@ func TestShiftTabDoesNotCycleWhileModalsActive(t *testing.T) {
 	})
 }
 
-func TestCtrlCExits(t *testing.T) {
-	m := newModel(context.Background(), Options{})
+func TestCtrlCRequiresSecondPressToExit(t *testing.T) {
+	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
 
 	updated, cmd := m.Update(testKeyCtrl('c'))
 	next := updated.(model)
 
-	if !next.exiting {
-		t.Fatal("expected Ctrl+C to mark model exiting")
+	if next.exiting {
+		t.Fatal("first Ctrl+C should not mark model exiting")
+	}
+	if !next.exitConfirmActive {
+		t.Fatal("first Ctrl+C should arm exit confirmation")
 	}
 	if cmd == nil {
-		t.Fatal("expected Ctrl+C to return quit command")
+		t.Fatal("first Ctrl+C should schedule confirmation expiry")
+	}
+	status := plainRender(t, next.statusLine(80))
+	if !strings.Contains(status, ctrlCExitConfirmText) {
+		t.Fatalf("status line = %q, want exit confirmation", status)
+	}
+	if strings.Contains(status, "tokenrouter") {
+		t.Fatalf("status line = %q, should replace provider while exit confirmation is active", status)
+	}
+
+	updated, cmd = next.Update(testKeyCtrl('c'))
+	next = updated.(model)
+	if !next.exiting {
+		t.Fatal("second Ctrl+C should mark model exiting")
+	}
+	if cmd == nil {
+		t.Fatal("second Ctrl+C should return quit command")
+	}
+}
+
+func TestCtrlCExitConfirmationExpires(t *testing.T) {
+	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
+
+	updated, _ := m.Update(testKeyCtrl('c'))
+	next := updated.(model)
+	seq := next.exitConfirmSeq
+
+	updated, _ = next.Update(exitConfirmExpiredMsg{seq: seq - 1})
+	next = updated.(model)
+	if !next.exitConfirmActive {
+		t.Fatal("stale expiry should not clear active exit confirmation")
+	}
+
+	updated, _ = next.Update(exitConfirmExpiredMsg{seq: seq})
+	next = updated.(model)
+	if next.exitConfirmActive {
+		t.Fatal("matching expiry should clear exit confirmation")
+	}
+	status := plainRender(t, next.statusLine(80))
+	if strings.Contains(status, ctrlCExitConfirmText) || !strings.Contains(status, "tokenrouter") {
+		t.Fatalf("status line after expiry = %q, want provider restored", status)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1610,6 +1610,41 @@ func TestCtrlCRequiresSecondPressToExit(t *testing.T) {
 	}
 }
 
+func TestCtrlCClearsComposerBeforeExitConfirmation(t *testing.T) {
+	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
+	m.input.SetValue("draft prompt")
+	m.recomputeSuggestions()
+
+	updated, cmd := m.Update(testKeyCtrl('c'))
+	next := updated.(model)
+
+	if cmd != nil {
+		t.Fatal("Ctrl+C with a draft should clear the composer without scheduling exit confirmation")
+	}
+	if next.composerValue() != "" {
+		t.Fatalf("composer value = %q, want empty after Ctrl+C", next.composerValue())
+	}
+	if next.exitConfirmActive {
+		t.Fatal("Ctrl+C with a draft should not arm exit confirmation")
+	}
+	if next.exiting {
+		t.Fatal("Ctrl+C with a draft should not mark model exiting")
+	}
+	status := plainRender(t, next.statusLine(80))
+	if strings.Contains(status, ctrlCExitConfirmText) || !strings.Contains(status, "tokenrouter") {
+		t.Fatalf("status line = %q, want provider restored with no exit confirmation", status)
+	}
+
+	updated, cmd = next.Update(testKeyCtrl('c'))
+	next = updated.(model)
+	if !next.exitConfirmActive {
+		t.Fatal("Ctrl+C on an empty composer should arm exit confirmation")
+	}
+	if cmd == nil {
+		t.Fatal("Ctrl+C on an empty composer should schedule confirmation expiry")
+	}
+}
+
 func TestCtrlCExitConfirmationExpires(t *testing.T) {
 	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1610,6 +1610,41 @@ func TestCtrlCRequiresSecondPressToExit(t *testing.T) {
 	}
 }
 
+func TestCtrlCExitConfirmationDisarmsOnInterveningKey(t *testing.T) {
+	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
+
+	updated, _ := m.Update(testKeyCtrl('c'))
+	next := updated.(model)
+	if !next.exitConfirmActive {
+		t.Fatal("first Ctrl+C should arm exit confirmation")
+	}
+	seq := next.exitConfirmSeq
+
+	updated, cmd := next.Update(testKey(tea.KeyLeft))
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("intervening navigation key should not return a command")
+	}
+	if next.exitConfirmActive {
+		t.Fatal("intervening non-Ctrl+C key should disarm exit confirmation")
+	}
+	if next.exitConfirmSeq == seq {
+		t.Fatal("disarming should advance the sequence so stale expiry ticks are ignored")
+	}
+
+	updated, cmd = next.Update(testKeyCtrl('c'))
+	next = updated.(model)
+	if next.exiting {
+		t.Fatal("Ctrl+C after an intervening key should re-arm, not exit")
+	}
+	if !next.exitConfirmActive {
+		t.Fatal("Ctrl+C after an intervening key should arm a fresh confirmation")
+	}
+	if cmd == nil {
+		t.Fatal("fresh Ctrl+C confirmation should schedule expiry")
+	}
+}
+
 func TestCtrlCClearsComposerBeforeExitConfirmation(t *testing.T) {
 	m := newModel(context.Background(), Options{ProviderName: "tokenrouter"})
 	m.input.SetValue("draft prompt")

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -78,6 +78,9 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	}
+	if next, cmd, ok := m.handleComposerSelectionMouse(msg); ok {
+		return next, cmd
+	}
 	if next, cmd, ok := m.handleTranscriptSelectionMouse(msg); ok {
 		return next, cmd
 	}

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/Gitlawb/zero/internal/config"
+	"github.com/Gitlawb/zero/internal/tools"
 )
 
 func TestMouseClickSelectsThenAppliesCommandSuggestionRow(t *testing.T) {
@@ -386,6 +387,47 @@ func TestTranscriptSelectionClearsAfterCopy(t *testing.T) {
 	}
 }
 
+func TestTranscriptSelectionIncludesToolResultBody(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowToolCall, id: "call_1", tool: "bash", detail: "go build ./..."})
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{
+		kind:   rowToolResult,
+		id:     "call_1",
+		tool:   "bash",
+		status: tools.StatusError,
+		detail: "stdout:\nok build\nstderr:\nwarning: slow\nexit_code: 1",
+	})
+
+	line := transcriptSelectableLineContaining(t, m, "warning: slow")
+	m.transcriptSelection = transcriptSelectionState{
+		active: true,
+		anchor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart},
+		cursor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart + lipgloss.Width(line.text)},
+	}
+
+	if got := m.selectedTranscriptText(); strings.TrimSpace(got) != "warning: slow" {
+		t.Fatalf("selectedTranscriptText() = %q, want warning: slow", got)
+	}
+}
+
+func TestTranscriptSelectionIncludesErrorRows(t *testing.T) {
+	m := mouseTestModel()
+	m.mouseCapture = true
+	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowError, text: "provider stream error: connection reset"})
+
+	line := transcriptSelectableLineContaining(t, m, "provider stream error")
+	m.transcriptSelection = transcriptSelectionState{
+		active: true,
+		anchor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart},
+		cursor: transcriptSelectionPoint{bodyY: line.bodyY, x: line.textStart + lipgloss.Width(line.text)},
+	}
+
+	if got := m.selectedTranscriptText(); got != "provider stream error: connection reset" {
+		t.Fatalf("selectedTranscriptText() = %q, want provider stream error: connection reset", got)
+	}
+}
+
 func TestMouseClickTogglesReasoningRow(t *testing.T) {
 	m := mouseTestModel()
 	m.mouseCapture = true
@@ -620,6 +662,19 @@ func firstTranscriptTextMousePoint(t *testing.T, m model) (int, int) {
 	}
 	t.Fatalf("no selectable transcript text line found: %#v", selectable)
 	return 0, 0
+}
+
+func transcriptSelectableLineContaining(t *testing.T, m model, text string) transcriptSelectableLine {
+	t.Helper()
+	width := chatWidth(m.width)
+	layout := m.transcriptBodyLayout(width, "")
+	for _, line := range layout.selectable {
+		if strings.Contains(line.text, text) {
+			return line
+		}
+	}
+	t.Fatalf("no selectable transcript line containing %q found: %#v", text, layout.selectable)
+	return transcriptSelectableLine{}
 }
 
 func composerMousePoint(t *testing.T, m model, column int) (int, int) {

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -277,6 +277,43 @@ func TestComposerMouseDragSelectsCopiesAndClears(t *testing.T) {
 	}
 }
 
+func TestComposerMouseSelectionBlockedWhileSuggestionsOpen(t *testing.T) {
+	m := mouseTestModel()
+	m = typeRunes(t, m, "/sp")
+	if !m.suggestionsActive() {
+		t.Fatalf("expected suggestions to be open, got %#v", m.suggestions)
+	}
+	initial := m.currentComposerState()
+	startX, y := composerMousePoint(t, m, 0)
+	endX, _ := composerMousePoint(t, m, 2)
+
+	updated, cmd := m.Update(testMouseClick(tea.MouseLeft, startX, y))
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("composer click behind suggestions should not return a command")
+	}
+	if next.composerSelection.active {
+		t.Fatal("composer selection should not start while suggestions are open")
+	}
+	if got := next.currentComposerState().cursor; got != initial.cursor {
+		t.Fatalf("composer cursor changed behind suggestions: got %d want %d", got, initial.cursor)
+	}
+
+	updated, cmd = next.Update(testMouseMotion(tea.MouseLeft, endX, y))
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("composer drag behind suggestions should not return a command")
+	}
+	updated, cmd = next.Update(testMouseRelease(tea.MouseNone, endX, y))
+	next = updated.(model)
+	if cmd != nil {
+		t.Fatal("composer release behind suggestions should not copy")
+	}
+	if next.composerSelection.active {
+		t.Fatal("composer selection should remain inactive while suggestions are open")
+	}
+}
+
 func TestTranscriptSelectionOnlyStartsOnTranscriptText(t *testing.T) {
 	m := mouseTestModel()
 	m.mouseCapture = true

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/Gitlawb/zero/internal/config"
 )
@@ -226,6 +227,52 @@ func TestMouseCaptureOnEmptyChatSplash(t *testing.T) {
 	m.transcript = appendRow(m.transcript, rowUser, "hello")
 	if !m.wantsMouseCapture() {
 		t.Fatal("chat with transcript rows should keep mouse capture for Zero-owned selection")
+	}
+}
+
+func TestComposerMouseClickMovesCursor(t *testing.T) {
+	m := mouseTestModel()
+	m.input.SetValue("hello world")
+	m.input.CursorEnd()
+	x, y := composerMousePoint(t, m, 5)
+
+	updated, cmd := m.Update(testMouseClick(tea.MouseLeft, x, y))
+	next := updated.(model)
+	if cmd != nil {
+		t.Fatal("composer click should not return a command")
+	}
+	if got := next.currentComposerState().cursor; got != 5 {
+		t.Fatalf("composer cursor = %d, want 5", got)
+	}
+	if text := next.selectedComposerText(); text != "" {
+		t.Fatalf("composer click should not select text, got %q", text)
+	}
+}
+
+func TestComposerMouseDragSelectsCopiesAndClears(t *testing.T) {
+	m := mouseTestModel()
+	m.input.SetValue("hello world")
+	startX, y := composerMousePoint(t, m, 0)
+	endX, _ := composerMousePoint(t, m, 5)
+
+	updated, _ := m.Update(testMouseClick(tea.MouseLeft, startX, y))
+	next := updated.(model)
+	updated, _ = next.Update(testMouseMotion(tea.MouseLeft, endX, y))
+	next = updated.(model)
+	if got := next.selectedComposerText(); got != "hello" {
+		t.Fatalf("selectedComposerText() = %q, want hello", got)
+	}
+
+	updated, cmd := next.Update(testMouseRelease(tea.MouseNone, endX, y))
+	next = updated.(model)
+	if cmd == nil {
+		t.Fatal("composer drag release should return copy command")
+	}
+	if next.composerSelection.active {
+		t.Fatal("composer selection should clear automatically after release")
+	}
+	if got := next.currentComposerState().cursor; got != 5 {
+		t.Fatalf("composer cursor after release = %d, want 5", got)
 	}
 }
 
@@ -573,6 +620,22 @@ func firstTranscriptTextMousePoint(t *testing.T, m model) (int, int) {
 	}
 	t.Fatalf("no selectable transcript text line found: %#v", selectable)
 	return 0, 0
+}
+
+func composerMousePoint(t *testing.T, m model, column int) (int, int) {
+	t.Helper()
+	width := chatWidth(m.width)
+	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
+	if frame.composerRect.height <= 0 {
+		t.Fatalf("expected visible composer rect, frame=%#v", frame)
+	}
+	contentY := 1
+	if renderAttachmentChips(m.pendingImageLabels, m.pendingDocuments) != "" {
+		contentY++
+	}
+	x := frame.composerRect.x + 2 + lipgloss.Width(composerVisualLinePrefix(m.input, true)) + column
+	y := frame.composerRect.y + contentY
+	return x, y
 }
 
 func mouseTestModel() model {

--- a/internal/tui/session_test.go
+++ b/internal/tui/session_test.go
@@ -875,7 +875,7 @@ func TestCancelledRunFlushesCheckpointSessionEvents(t *testing.T) {
 	assertPayloadField(t, cancelErr, "message", "Run cancelled.")
 }
 
-func TestCtrlCFlushesCheckpointSessionEvents(t *testing.T) {
+func TestCtrlCCancelsAndFlushesCheckpointSessionEvents(t *testing.T) {
 	store := testSessionStore(t)
 	root := t.TempDir()
 	writeTestFile(t, root, "notes.txt", "before")
@@ -910,17 +910,16 @@ func TestCtrlCFlushesCheckpointSessionEvents(t *testing.T) {
 		next = updated.(model)
 		if _, ok := runtimeMsg.(permissionRequestMsg); ok {
 			// Ctrl+C while the permission prompt is pending: this must cancel the
-			// in-flight run (unblocking the goroutine via ctx) AND mark the model
-			// exiting — but it must NOT quit before the in-flight run's final
-			// message has been drained, or the captured checkpoint is orphaned.
-			var exitCmd tea.Cmd
-			updated, exitCmd = next.Update(testKeyCtrl('c'))
+			// in-flight run (unblocking the goroutine via ctx), arm the second-press
+			// exit confirmation, and still avoid quitting before the in-flight run's
+			// final message has been drained, or the captured checkpoint is orphaned.
+			updated, _ = next.Update(testKeyCtrl('c'))
 			next = updated.(model)
-			if !next.exiting {
-				t.Fatal("expected Ctrl+C to mark model exiting")
+			if next.exiting {
+				t.Fatal("first Ctrl+C should not mark model exiting")
 			}
-			if exitCmd != nil {
-				t.Fatal("expected Ctrl+C to defer quit while an in-flight run still needs flushing")
+			if !next.exitConfirmActive {
+				t.Fatal("first Ctrl+C should arm exit confirmation")
 			}
 			cancelled = true
 		}
@@ -932,17 +931,26 @@ func TestCtrlCFlushesCheckpointSessionEvents(t *testing.T) {
 		t.Fatal("expected cancelled run to be flagged for session-event flush")
 	}
 
+	updated, quitCmd := next.Update(testKeyCtrl('c'))
+	next = updated.(model)
+	if !next.exiting {
+		t.Fatal("second Ctrl+C should mark model exiting")
+	}
+	if quitCmd != nil {
+		t.Fatal("second Ctrl+C should wait for the cancelled run's flush before quitting")
+	}
+
 	// The cancelled goroutine still returns its accumulated session events. Deliver
 	// that final message; the checkpoint must be persisted even though activeRunID
-	// is already zeroed, and the deferred quit must fire now.
+	// is already zeroed, and the second Ctrl+C's deferred quit must fire now.
 	finalMsg := receiveFinalMessage(t, finalCh)
-	updated, quitCmd := next.Update(finalMsg)
+	updated, quitCmd = next.Update(finalMsg)
 	next = updated.(model)
 	if len(next.flushRunIDs) != 0 {
 		t.Fatalf("expected flush set to clear after draining cancelled run, got %v", next.flushRunIDs)
 	}
 	if quitCmd == nil {
-		t.Fatal("expected deferred quit to fire once the in-flight run is flushed on Ctrl+C")
+		t.Fatal("expected deferred quit to fire once the in-flight run is flushed on second Ctrl+C")
 	}
 
 	events := readOnlySessionEvents(t, store)

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -431,6 +431,8 @@ func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, r
 		return m.renderSelectableAssistantRow(rowIndex, row, width, startBodyY)
 	case rowReasoning:
 		return m.renderSelectableReasoningRow(rowIndex, row, width, startBodyY)
+	case rowSystem, rowError, rowToolCall, rowPermission, rowAskUser:
+		return m.renderSelectableRenderedRow(rowIndex, row, width, rc, startBodyY)
 	case rowToolResult:
 		return m.renderSelectableToolResultRow(rowIndex, row, width, rc, startBodyY)
 	case rowSpecialist:
@@ -441,13 +443,142 @@ func (m model) renderTranscriptRow(rowIndex int, row transcriptRow, width int, r
 }
 
 // renderSelectableToolResultRow renders the tool result card and marks its head
-// (first line) as a clickable collapse/expand toggle while the row is live.
+// (first line) as a clickable collapse/expand toggle. Body/footer text remains
+// selectable so copying a visible transcript range includes command output.
 func (m model) renderSelectableToolResultRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {
 	rendered := m.renderRow(row, width, rc)
 	if rendered == "" {
 		return "", nil
 	}
-	return rendered, []transcriptSelectableLine{{bodyY: startBodyY, rowIndex: rowIndex, toggle: true}}
+	selectable := []transcriptSelectableLine{{bodyY: startBodyY, rowIndex: rowIndex, toggle: true}}
+	selectable = append(selectable, selectableLinesFromRendered(rowIndex, rendered, startBodyY, 1)...)
+	if !m.transcriptSelection.active {
+		return rendered, selectable
+	}
+	return m.renderRenderedSelection(rendered, selectable, startBodyY), selectable
+}
+
+func (m model) renderSelectableRenderedRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {
+	rendered := m.renderRow(row, width, rc)
+	if rendered == "" {
+		return "", nil
+	}
+	selectable := selectableLinesFromRendered(rowIndex, rendered, startBodyY, 0)
+	if !m.transcriptSelection.active {
+		return rendered, selectable
+	}
+	return m.renderRenderedSelection(rendered, selectable, startBodyY), selectable
+}
+
+func selectableLinesFromRendered(rowIndex int, rendered string, startBodyY int, skipLeading int) []transcriptSelectableLine {
+	lines := viewLines(rendered)
+	boxed := renderedLinesHaveBoxBorder(lines)
+	selectable := make([]transcriptSelectableLine, 0, len(lines))
+	for index, line := range lines {
+		if index < skipLeading {
+			continue
+		}
+		meta, ok := selectableLineFromRenderedLine(rowIndex, startBodyY+index, line, boxed)
+		if ok {
+			selectable = append(selectable, meta)
+		}
+	}
+	return selectable
+}
+
+func selectableLineFromRenderedLine(rowIndex int, bodyY int, rendered string, boxed bool) (transcriptSelectableLine, bool) {
+	text := ansi.Strip(rendered)
+	if isTranscriptStructuralLine(text) {
+		return transcriptSelectableLine{}, false
+	}
+
+	textStart := 0
+	if strings.HasPrefix(text, "│ ") {
+		textStart = lipgloss.Width("│ ")
+		text = strings.TrimPrefix(text, "│ ")
+		if boxed && strings.HasSuffix(text, " │") {
+			text = strings.TrimSuffix(text, " │")
+		}
+	}
+	text = strings.TrimRight(text, " ")
+	if strings.TrimSpace(text) == "" {
+		return transcriptSelectableLine{}, false
+	}
+	return transcriptSelectableLine{
+		bodyY:     bodyY,
+		rowIndex:  rowIndex,
+		textStart: textStart,
+		text:      text,
+	}, true
+}
+
+func renderedLinesHaveBoxBorder(lines []string) bool {
+	hasTop := false
+	hasBottom := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(ansi.Strip(line))
+		if strings.HasPrefix(trimmed, "╭") && strings.HasSuffix(trimmed, "╮") {
+			hasTop = true
+		}
+		if strings.HasPrefix(trimmed, "╰") && strings.HasSuffix(trimmed, "╯") {
+			hasBottom = true
+		}
+	}
+	return hasTop && hasBottom
+}
+
+func isTranscriptStructuralLine(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return true
+	}
+	for _, r := range trimmed {
+		switch r {
+		case '╭', '╮', '╰', '╯', '┌', '┐', '└', '┘', '─', '━':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (m model) renderRenderedSelection(rendered string, selectable []transcriptSelectableLine, startBodyY int) string {
+	if len(selectable) == 0 {
+		return rendered
+	}
+	byY := make(map[int]transcriptSelectableLine, len(selectable))
+	for _, line := range selectable {
+		if line.text == "" || line.toggle || line.permOption || line.specialistCard {
+			continue
+		}
+		byY[line.bodyY] = line
+	}
+	lines := viewLines(rendered)
+	for index, line := range lines {
+		meta, ok := byY[startBodyY+index]
+		if !ok {
+			continue
+		}
+		lines[index] = m.renderTranscriptSelectableStyledLine(meta, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m model) renderTranscriptSelectableStyledLine(line transcriptSelectableLine, styledLine string) string {
+	start, end, ok := m.selectedColumnsForTranscriptLine(line)
+	if !ok {
+		return styledLine
+	}
+	absoluteStart := line.textStart + start
+	absoluteEnd := line.textStart + end
+	lineWidth := ansi.StringWidth(styledLine)
+	absoluteStart = clampInt(absoluteStart, 0, lineWidth)
+	absoluteEnd = clampInt(absoluteEnd, absoluteStart, lineWidth)
+	prefix := ansi.Cut(styledLine, 0, absoluteStart)
+	selected := ansi.Strip(ansi.Cut(styledLine, absoluteStart, absoluteEnd))
+	suffix := ansi.Cut(styledLine, absoluteEnd, lineWidth)
+	return prefix + zeroTheme.selection.Render(selected) + suffix
 }
 
 // renderSelectableSpecialistRow renders a specialist card and marks every line

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -199,12 +199,18 @@ func (m model) statusLine(width int) string {
 	providerName := displayValue(strings.TrimSpace(m.providerDisplayName()), "no provider")
 
 	if tier == tierTiny {
+		if m.exitConfirmActive {
+			warning := prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(ctrlCExitConfirmText)
+			return fitStyledLine(warning, width)
+		}
 		provider := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
 		return fitStyledLine(provider, width)
 	}
 
 	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
-	if summary := m.backgroundTerminalSummary(); summary != "" {
+	if m.exitConfirmActive {
+		left = prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(ctrlCExitConfirmText)
+	} else if summary := m.backgroundTerminalSummary(); summary != "" {
 		left += separator + zeroTheme.muted.Render(summary)
 	}
 


### PR DESCRIPTION
## Summary\n- require a second Ctrl+C before exiting the TUI\n- show `Press Ctrl+C again to exit` in the footer/status area for 3 seconds\n- preserve active-run cancellation and checkpoint/session flush safety before any second-press quit\n\n## Tests\n- `GOCACHE=/tmp/zero-go-cache go test ./internal/tui -run 'TestCtrlC|TestStatusLineGroups|TestGenericCustomProviderDisplayUsesEndpointName' -count=1`\n- `GOCACHE=/tmp/zero-go-cache go test ./internal/tui -count=1`\n- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Ctrl+C exit flow: first Ctrl+C shows an amber “press again to exit” prompt (provider indicator hidden), with automatic expiry; if a run is flushing, exit is deferred until it completes.
  * Enhanced composer text selection with highlighted rendering and mouse click/drag selection that copies selection on release.
  * Expanded transcript selection to cover additional row types (including tool-result bodies and error rows) with selectable column highlighting.

* **Tests**
  * Updated and added coverage for the two-step Ctrl+C flow, disarming on intervening keys, composer-clearing behavior, expiry sequencing, deferred quit, composer mouse selection, and expanded transcript selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->