### PR TITLE
feat(tools+tui): code preview/diff on file writes & edits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	golang.org/x/sys v0.46.0
 	mvdan.cc/sh/v3 v3.13.1

--- a/internal/mcp/file_preview_test.go
+++ b/internal/mcp/file_preview_test.go
@@ -1,0 +1,26 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// An MCP filesystem write_file call should yield a preview body from its content
+// argument; directory-creation and read tools must not.
+func TestMCPFileWriteArgsDetection(t *testing.T) {
+	path, content, ok := mcpFileWriteArgs("write_file", map[string]any{
+		"path": "site/index.html", "content": "<html>\n<body>hi</body>\n</html>\n",
+	})
+	if !ok || path != "site/index.html" || !strings.Contains(content, "<html>") {
+		t.Fatalf("write_file should be detected, got ok=%v path=%q", ok, path)
+	}
+	if _, _, ok := mcpFileWriteArgs("create_directory", map[string]any{"path": "site"}); ok {
+		t.Error("create_directory (no content) must not be treated as a file write")
+	}
+	if _, _, ok := mcpFileWriteArgs("read_file", map[string]any{"path": "x", "content": "y"}); ok {
+		t.Error("read_file must not be treated as a file write")
+	}
+	if _, _, ok := mcpFileWriteArgs("write_file", map[string]any{"path": "x"}); ok {
+		t.Error("a write_file without content must not produce a preview")
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -321,11 +321,48 @@ func (tool registryTool) Run(ctx context.Context, args map[string]any) tools.Res
 	if output == "" {
 		output = "(empty MCP tool result)"
 	}
-	return tools.Result{
+	res := tools.Result{
 		Status: status,
 		Output: output,
 		Meta:   tool.meta(),
 	}
+	// If this MCP tool wrote a file, surface the written content as a UI preview
+	// (Zero never saw the bytes, so it's an all-added preview). The model-facing
+	// Output stays the server's own text.
+	if status == tools.StatusOK {
+		if path, content, ok := mcpFileWriteArgs(tool.remote.Name, args); ok {
+			if body := tools.WrittenContentPreview(path, content); body != "" {
+				res.Display = tools.Display{Kind: "diff", Body: body}
+			}
+		}
+	}
+	return res
+}
+
+// mcpFileWriteArgs detects an MCP file-writing tool call and pulls its target
+// path and content from the arguments. It matches names containing "write_file"
+// / "create_file" (the common MCP filesystem servers) that also carry both a
+// content and a path argument, so directory-creation and non-file tools skip.
+func mcpFileWriteArgs(name string, args map[string]any) (path, content string, ok bool) {
+	lower := strings.ToLower(name)
+	if !strings.Contains(lower, "write_file") && !strings.Contains(lower, "create_file") && !strings.Contains(lower, "writefile") {
+		return "", "", false
+	}
+	content = firstStringArg(args, "content", "contents", "text", "data", "file_content", "body")
+	path = firstStringArg(args, "path", "file_path", "filename", "file", "target", "filepath")
+	if content == "" || path == "" {
+		return "", "", false
+	}
+	return path, content, true
+}
+
+func firstStringArg(args map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := args[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func (tool registryTool) meta() map[string]string {

--- a/internal/tools/apply_patch.go
+++ b/internal/tools/apply_patch.go
@@ -100,7 +100,7 @@ func (tool applyPatchTool) RunWithOptions(ctx context.Context, args map[string]a
 	}
 	result := okResult(summary)
 	result.ChangedFiles = changedFilesFromPatch(relativeRoot, patch)
-	result.Display = Display{Summary: summary, Kind: "diff"}
+	result.Display = Display{Summary: summary, Kind: "diff", Body: capPreview(patch)}
 	// git apply already rejects a patch whose context drifted, so it has its own
 	// staleness guard. Drop any tracked baseline for the files it rewrote so a
 	// subsequent edit_file/write_file re-reads instead of false-flagging the

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -113,6 +113,6 @@ func (tool editFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 	summary := fmt.Sprintf("Successfully edited %s (replaced %d occurrence%s).", relativePath, replacedCount, suffix)
 	result := okResult(summary)
 	result.ChangedFiles = []string{relativePath}
-	result.Display = Display{Summary: fmt.Sprintf("Edited %s", relativePath), Kind: "diff"}
+	result.Display = Display{Summary: fmt.Sprintf("Edited %s", relativePath), Kind: "diff", Body: unifiedDiff(relativePath, content, updated)}
 	return result
 }

--- a/internal/tools/filepreview.go
+++ b/internal/tools/filepreview.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+)
+
+// maxPreviewLines caps a UI preview/diff body so a huge file or rewrite doesn't
+// produce a multi-thousand-line render payload. The TUI caps again per its width
+// tier; this is the upstream guard, and it never affects the model-facing Output.
+const maxPreviewLines = 500
+
+// unifiedDiff returns a unified diff of oldContent -> newContent labeled with the
+// workspace-relative path, for the TUI to render (Display.Body with Kind "diff").
+// Returns "" when the contents are identical.
+func unifiedDiff(relativePath, oldContent, newContent string) string {
+	if oldContent == newContent {
+		return ""
+	}
+	edits := myers.ComputeEdits(span.URIFromPath(relativePath), oldContent, newContent)
+	if len(edits) == 0 {
+		return ""
+	}
+	diff := fmt.Sprint(gotextdiff.ToUnified("a/"+relativePath, "b/"+relativePath, oldContent, edits))
+	return capPreview(diff)
+}
+
+// capPreview trims a render body to maxPreviewLines, appending a hidden-count
+// trailer when it overflows so the UI never renders an enormous payload.
+func capPreview(body string) string {
+	body = strings.TrimRight(body, "\n")
+	if body == "" {
+		return ""
+	}
+	lines := strings.Split(body, "\n")
+	if len(lines) <= maxPreviewLines {
+		return body
+	}
+	hidden := len(lines) - maxPreviewLines
+	kept := make([]string, 0, maxPreviewLines+1)
+	kept = append(kept, lines[:maxPreviewLines]...)
+	kept = append(kept, fmt.Sprintf("… %d more lines", hidden))
+	return strings.Join(kept, "\n")
+}

--- a/internal/tools/filepreview.go
+++ b/internal/tools/filepreview.go
@@ -29,6 +29,14 @@ func unifiedDiff(relativePath, oldContent, newContent string) string {
 	return capPreview(diff)
 }
 
+// WrittenContentPreview returns an all-added diff of content, for the TUI to
+// preview a freshly written file when no prior content is available — e.g. an
+// external MCP file-write tool, where Zero never saw the old bytes. Returns ""
+// for empty content.
+func WrittenContentPreview(relativePath, content string) string {
+	return unifiedDiff(relativePath, "", content)
+}
+
 // capPreview trims a render body to maxPreviewLines, appending a hidden-count
 // trailer when it overflows so the UI never renders an enormous payload.
 func capPreview(body string) string {

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -86,7 +86,12 @@ type Result struct {
 // Display carries a short, structured summary of a tool result for the TUI/stream.
 type Display struct {
 	Summary string
-	Kind    string // e.g. file, diff, search, shell
+	Kind    string // e.g. file, diff, search, shell, preview
+	// Body is a UI-only render payload (a unified diff for Kind=="diff", or file
+	// content for Kind=="preview"). It is NOT sent to the model — it exists so the
+	// TUI can show a code preview/diff without bloating the model's context with
+	// the full file. Empty when the tool has no richer view than its Output.
+	Body string
 }
 
 type Tool interface {

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -91,6 +91,13 @@ func (tool writeFileTool) RunWithOptions(_ context.Context, args map[string]any,
 		}
 	}
 
+	// Capture the pre-write content so an overwrite can render a real diff.
+	oldContent := ""
+	if existed {
+		if prev, rerr := os.ReadFile(absolutePath); rerr == nil {
+			oldContent = string(prev)
+		}
+	}
 	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
@@ -110,9 +117,16 @@ func (tool writeFileTool) RunWithOptions(_ context.Context, args map[string]any,
 		verb = "Overwrote"
 	}
 	summary := fmt.Sprintf("%s %s (%d bytes).", verb, relativePath, len([]byte(content)))
+	// A new file renders as an all-added diff; an overwrite renders the real diff.
+	// Either way it flows through the TUI's existing diff card. oldContent is ""
+	// for a new file, so unifiedDiff yields all-added lines.
+	display := Display{Summary: summary, Kind: "file"}
+	if diff := unifiedDiff(relativePath, oldContent, content); diff != "" {
+		display = Display{Summary: summary, Kind: "diff", Body: diff}
+	}
 	result := okResult(summary)
 	result.ChangedFiles = []string{relativePath}
-	result.Display = Display{Summary: summary, Kind: "file"}
+	result.Display = display
 	return result
 }
 

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -482,8 +482,15 @@ func TestWriteFileReportsChangedFileAndDisplay(t *testing.T) {
 	if len(res.ChangedFiles) != 1 || res.ChangedFiles[0] != "notes.txt" {
 		t.Fatalf("ChangedFiles = %v, want [notes.txt]", res.ChangedFiles)
 	}
-	if res.Display.Kind != "file" {
-		t.Errorf("Display.Kind = %q, want file", res.Display.Kind)
+	// A non-empty new file carries an all-added diff for the TUI to preview.
+	if res.Display.Kind != "diff" {
+		t.Errorf("Display.Kind = %q, want diff", res.Display.Kind)
+	}
+	if !strings.Contains(res.Display.Body, "+hello") {
+		t.Errorf("Display.Body should preview the new content as an added line, got %q", res.Display.Body)
+	}
+	if strings.Contains(res.Output, "+hello") {
+		t.Errorf("model-facing Output must stay the concise summary, not the diff body: %q", res.Output)
 	}
 	if res.Display.Summary == "" {
 		t.Error("expected a non-empty Display.Summary")

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3510,13 +3510,20 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 					specReview = &info
 				}
 			}
+			// Display.Body is a UI-only render payload (a diff for file writes/edits)
+			// that the tool attaches so the card can show a code preview without
+			// echoing the file into the model's context. Prefer it over Output.
+			detail := result.Output
+			if result.Display.Body != "" {
+				detail = result.Display.Body
+			}
 			row := transcriptRow{
 				kind:   rowToolResult,
 				id:     effectiveToolRowID(result.ToolCallID, callSeq[result.ToolCallID]),
 				text:   toolResultRowText(result),
 				tool:   result.Name,
 				status: result.Status,
-				detail: result.Output,
+				detail: detail,
 				runID:  runID,
 			}
 			// A Task result is shown by the specialist card (its completion state),


### PR DESCRIPTION
## Why
When `write_file`/`edit_file`/`apply_patch` ran, the card showed only a one-line summary — `Created cmd/calculator/main.go (1271 bytes).` — **no code**. Comparable coding agents all show the content (preview for new files, diff for edits). Zero already had the **entire** diff-render pipeline (`diffCardBody`, line numbers, +/- coloring, capping) — the tools just never fed it any content.

## What changed
- **UI-only `Display.Body`** on the tool result — a render payload that is **NOT sent to the model**, so a code preview never bloats the model's context. The model-facing `Output` stays the concise summary.
- **`write_file`** → emits a unified diff of old→new: a **new file is an all-added diff**, an overwrite is the **real change** (via `gotextdiff`, the gopls differ).
- **`edit_file`** → emits the real red/green diff.
- **`apply_patch`** → surfaces the applied patch.
- **TUI** → prefers `Display.Body` over `Output` as the card detail; the existing diff card renders it. Bodies cap at 500 lines (the width tier caps again).

```
✓ write_file
  cmd/calculator/main.go                         +3
  @@ -1 +1,3 @@
     1 + package main
     2 +
     3 + func main() {}
```

## Verified
- Diff helper produces correct unified diffs (new = all-added, edit = `-/+`).
- End-to-end: a `write_file` row renders the code through `diffCardBody` (shown above).
- Full `internal/tools` + `internal/tui` suites green; gofmt/vet/build/**deadcode** clean.

## Notes
- Stacks on **#291** (chat declutter) — base is `feat/tui-declutter-chat` so the diff is just this feature.
- New files render as an **all-added (green) diff** with line numbers (standard, like a PR). A syntax-highlighted new-file preview (vs green) is an easy follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool results now include visual unified diff previews for file modifications from `write_file`, `edit_file`, and `apply_patch`.
  * The interface tool cards now use the diff preview content when available, improving what’s shown in the transcript and code preview areas.
  * File-write calls surfaced via the MCP layer now also get diff-style previews when both path and content are present.
* **Chores**
  * Updated dependencies to include a unified text diff library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
