### PR TITLE
fix(sandbox): don't block 'node --version' & other print-and-exit REPL commands

### DIFF
--- a/internal/sandbox/safe_command.go
+++ b/internal/sandbox/safe_command.go
@@ -85,13 +85,23 @@ var interactivePrograms = map[string]interactiveProgram{
 var nonInteractiveREPLFlags = map[string][]string{
 	"python":  {"-c", "-m"},
 	"python3": {"-c", "-m"},
-	"node":    {"-e", "--eval", "-p", "--print"},
+	"node":    {"-e", "--eval", "-p", "--print", "-v", "--check", "-h"},
 	"ruby":    {"-e"},
 	"php":     {"-r", "-f"},
 	"psql":    {"-c", "--command", "-f", "--file", "-l", "--list"},
 	"mysql":   {"-e", "--execute"},
 	"mongo":   {"--eval", "-f", "--file"},
 	"mongosh": {"--eval", "-f", "--file"},
+}
+
+// infoExitFlags make ANY repl/interactive program print a message and exit
+// instead of opening a prompt. `--version` and `--help` are unambiguous across
+// these programs (unlike, say, `-v`, which is "version" for node but "verbose"
+// for mysql), so they universally suppress the interactive guard — without them
+// a harmless `node --version` / `python3 --version` was wrongly blocked.
+var infoExitFlags = map[string]bool{
+	"--version": true,
+	"--help":    true,
 }
 
 // interactiveSegments are multi-word interactive invocations. The detector
@@ -387,6 +397,15 @@ func hasNonInteractiveFlag(program string, fields []string) bool {
 		return false
 	}
 	for _, arg := range fields[start+1:] {
+		// Universal print-and-exit flags (`--version`/`--help`) make the program
+		// print and quit rather than open a prompt, for every repl program.
+		base := arg
+		if i := strings.IndexByte(base, '='); i >= 0 {
+			base = base[:i]
+		}
+		if infoExitFlags[base] {
+			return true
+		}
 		for _, flag := range flags {
 			if arg == flag || strings.HasPrefix(arg, flag+"=") {
 				return true

--- a/internal/sandbox/safe_command_test.go
+++ b/internal/sandbox/safe_command_test.go
@@ -17,6 +17,9 @@ func TestDetectInteractiveCommandBlocksEditors(t *testing.T) {
 		{name: "less pager", command: "less /var/log/syslog", wantCmd: "less", wantSuggHint: "cat"},
 		{name: "python repl", command: "python", wantCmd: "python", wantSuggHint: "-c"},
 		{name: "node repl", command: "node", wantCmd: "node", wantSuggHint: "-e"},
+		// -v is "verbose" for mysql (NOT "version"), so it must still open the
+		// prompt — the info-exit allowance is for unambiguous --version/--help only.
+		{name: "mysql verbose not version", command: "mysql -v", wantCmd: "mysql", wantSuggHint: "-e"},
 		{name: "ssh interactive", command: "ssh host.example.com", wantCmd: "ssh"},
 		{name: "top", command: "top", wantCmd: "top"},
 		{name: "git rebase interactive", command: "git rebase -i HEAD~3", wantCmd: "git rebase -i"},
@@ -51,6 +54,13 @@ func TestDetectInteractiveCommandAllowsNonInteractive(t *testing.T) {
 		"python3 script.py",
 		"node -e 'console.log(1)'",
 		"node build.js",
+		"node --version",
+		"node -v",
+		"node --check app.js",
+		"node --help",
+		"node --version && npm --version",
+		"python3 --version",
+		"php --version",
 		"cat file.txt",
 		"git rebase --continue",
 		"git status",


### PR DESCRIPTION
## Why

The interactive-command guard (`DetectInteractiveCommand`) blocks programs that would hang a non-interactive agent (a bare `node`/`python` REPL). But it treated those REPL programs as interactive **unless** an argument was a script file or one of a small allow-list of eval/print flags:

```go
"node": {"-e", "--eval", "-p", "--print"},
```

So a perfectly harmless **`node --version`** (`--version` isn't a script file and isn't in that list) got blocked before execution:

```
Error: Blocked interactive command "node" before execution: node with no script…
Suggestion: Run `node script.js` or `node -e '<code>'`.
```

This false-positive hit `node --version`, `node -v`, `node --check x.js`, `node --help`, `python3 --version`, etc. — all print-and-exit commands. Both the `bash` and `exec_command` tools share the guard, so there was no workaround except using `-e`/`-p`.

## What changed

- Added **universal print-and-exit flags** `--version` / `--help` that suppress the guard for **every** repl program. These are unambiguous across all of them.
- Added node's unambiguous short forms `-v`, `--check`, `-h` to its allow-list.
- **Kept it conservative:** only `--version`/`--help` are universal. Short flags that mean different things per program are NOT universal — e.g. `mysql -v` is *verbose* (still opens the prompt), so it stays blocked. A bare `node`/`python` REPL also stays blocked.

## Tests

- `TestDetectInteractiveCommandAllowsNonInteractive` now includes `node --version`, `node -v`, `node --check app.js`, `node --help`, the exact failing `node --version && npm --version`, `python3 --version`, and `php --version`.
- `TestDetectInteractiveCommandBlocksEditors` adds `mysql -v` (verbose ≠ version → still interactive) to lock the conservative behavior; bare `node` stays blocked.
- `go build ./...`, `go vet`, and the full `internal/sandbox` + `internal/tools` suites are green; gofmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of version and help flags (`--version`, `--help`) across interpreters. Commands like `node --version` and `python3 --version` will no longer be incorrectly blocked.

* **Tests**
  * Added test coverage for additional command parsing scenarios involving version and help flag invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->