### PR TITLE
fix(sandbox): stop bricking Windows when the sandbox isn't set up (degrade like Linux/macOS)

### DIFF
--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -207,7 +207,19 @@ func (engine *Engine) shellSandboxActive(policy Policy) bool {
 		return false
 	}
 	backend := engine.backend
-	return backend.Available && backend.Executable != "" && backend.CommandWrapping && backend.NativeIsolation
+	if !(backend.Available && backend.Executable != "" && backend.CommandWrapping && backend.NativeIsolation) {
+		return false
+	}
+	// On Windows the command is only actually wrapped once `zero sandbox setup`
+	// has written the marker; until then execution DEGRADES to unwrapped (see
+	// manager.BuildExecutionRequest). The engine must mirror that — otherwise it
+	// would auto-allow a shell command as "sandboxed" while it really runs
+	// unsandboxed, breaking the invariant above and the per-command approval
+	// floor. When not initialized, fall through so the command prompts.
+	if backend.Platform == "windows" && !windowsSandboxInitialized() {
+		return false
+	}
+	return true
 }
 
 // Precheck reports the sandbox blocks that would block a tool request BEFORE

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -1,9 +1,36 @@
 package sandbox
 
 import (
+	"errors"
+	"os"
 	"os/exec"
 	"runtime"
 )
+
+// errWindowsSandboxNotInitialized is returned only to a caller that explicitly
+// REQUIRED the sandbox (--sandbox require) on Windows before `zero sandbox setup`
+// has run. The default (auto) preference degrades instead — see BuildExecutionRequest.
+var errWindowsSandboxNotInitialized = errors.New(
+	"the Windows sandbox is not initialized — run `zero sandbox setup` from an elevated (Administrator) terminal, " +
+		"or drop `--sandbox require` to run with workspace path-confinement and per-command approval")
+
+// windowsSetupDowngradeReason is surfaced when Windows falls back to the
+// in-process policy gate because the OS sandbox has not been set up.
+const windowsSetupDowngradeReason = "Windows OS sandbox inactive — commands run with workspace path-confinement and " +
+	"per-command approval only. Run `zero sandbox setup` from an elevated (Administrator) terminal for full filesystem and network isolation."
+
+// windowsSandboxInitialized reports whether the per-host Windows sandbox setup
+// marker exists. A missing marker is the common fresh-install state, so the
+// caller degrades rather than bricking the command. Indirected through a var so
+// tests can drive both the initialized and not-initialized paths.
+var windowsSandboxInitialized = func() bool {
+	home, err := ResolveWindowsSandboxHome(nil)
+	if err != nil || home == "" {
+		return false
+	}
+	_, statErr := os.Stat(WindowsSandboxSetupMarkerPath(home))
+	return statErr == nil
+}
 
 type SandboxPreference string
 
@@ -131,10 +158,27 @@ func (manager SandboxManager) BuildExecutionRequest(request SandboxManagerReques
 	if request.ValidateExecution && requiresPlatformSandbox && backend.SupportLevel() != BackendSupportNative {
 		return SandboxExecutionRequest{}, nativeSandboxUnavailableError(backend)
 	}
+	// Windows: the OS sandbox needs a one-time elevated `zero sandbox setup` (it
+	// applies WFP network filters + workspace ACLs and writes a marker). Without
+	// it the command runner hard-fails — so on the default preference, DEGRADE to
+	// the in-process policy gate + per-command approval (matching Linux/macOS when
+	// their sandbox is unavailable) instead of bricking every command. A strict
+	// caller (--sandbox require) still gets a clear error pointing at setup.
+	windowsNeedsSetup := false
+	if manager.goos == "windows" && requiresPlatformSandbox && enforcementLevel == EnforcementNative && !windowsSandboxInitialized() {
+		if preference == SandboxPreferenceRequire {
+			return SandboxExecutionRequest{}, errWindowsSandboxNotInitialized
+		}
+		enforcementLevel = EnforcementDegraded
+		windowsNeedsSetup = true
+	}
 	targetBackend := manager.targetBackend(preference, policy, requiresPlatformSandbox)
 	downgradeReason := ""
 	if requiresPlatformSandbox && enforcementLevel == EnforcementDegraded {
 		downgradeReason = backend.DowngradeReason(policy)
+		if windowsNeedsSetup {
+			downgradeReason = windowsSetupDowngradeReason
+		}
 	}
 	wrapped := backend.CommandWrapping && backend.Available && enforcementLevel == EnforcementNative
 	markers := backend.SandboxEnvMarkers(policy)

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -129,6 +129,11 @@ func TestSandboxManagerBuildsCommandPlanThroughLinuxHelper(t *testing.T) {
 }
 
 func TestSandboxManagerBuildsCommandPlanThroughWindowsRunner(t *testing.T) {
+	// This exercises the native wrapped path, which requires the workspace to be
+	// sandbox-initialized; stub the marker present (otherwise it degrades).
+	restore := windowsSandboxInitialized
+	t.Cleanup(func() { windowsSandboxInitialized = restore })
+	windowsSandboxInitialized = func() bool { return true }
 	backend := Backend{Name: BackendWindowsRestrictedToken, Available: true, Executable: `C:\zero\zero-windows-command-runner.exe`, Platform: "windows"}
 	policy := DefaultPolicy()
 	manager := NewSandboxManager(SandboxManagerOptions{GOOS: "windows", Backend: backend})

--- a/internal/sandbox/windows_degrade_test.go
+++ b/internal/sandbox/windows_degrade_test.go
@@ -1,0 +1,61 @@
+package sandbox
+
+import (
+	"errors"
+	"testing"
+)
+
+// On Windows, a not-yet-set-up sandbox must DEGRADE (run unwrapped with a
+// downgrade reason) on the default preference — never brick the command — while
+// a strict --sandbox require still errors with a setup hint. Once the marker
+// exists, enforcement is native and the command wraps.
+func TestWindowsDegradesWhenSandboxNotInitialized(t *testing.T) {
+	restore := windowsSandboxInitialized
+	t.Cleanup(func() { windowsSandboxInitialized = restore })
+
+	mgr := NewSandboxManager(SandboxManagerOptions{
+		GOOS:    "windows",
+		Backend: Backend{Name: BackendWindowsRestrictedToken, Available: true, Executable: "zero.exe", Platform: "windows"},
+	})
+	base := SandboxManagerRequest{
+		WorkspaceRoot:     `C:\ws`,
+		Command:           CommandSpec{Name: "bash", Args: []string{"-c", "echo hi"}},
+		Policy:            DefaultPolicy(),
+		ValidateExecution: true,
+	}
+
+	// Marker missing + auto -> degrade (unwrapped, with a reason), no error.
+	windowsSandboxInitialized = func() bool { return false }
+	auto := base
+	auto.Preference = SandboxPreferenceAuto
+	req, err := mgr.BuildExecutionRequest(auto)
+	if err != nil {
+		t.Fatalf("auto must degrade, not error: %v", err)
+	}
+	if req.EnforcementLevel != EnforcementDegraded {
+		t.Fatalf("enforcement = %v, want degraded", req.EnforcementLevel)
+	}
+	if req.CommandWrapped {
+		t.Fatal("degraded command must NOT be wrapped through the sandbox runner")
+	}
+	if req.DowngradeReason == "" {
+		t.Fatal("expected a downgrade reason explaining the missing setup")
+	}
+
+	// Marker missing + require -> hard error pointing at setup.
+	require := base
+	require.Preference = SandboxPreferenceRequire
+	if _, err := mgr.BuildExecutionRequest(require); !errors.Is(err, errWindowsSandboxNotInitialized) {
+		t.Fatalf("require must error with the setup hint, got %v", err)
+	}
+
+	// Marker present -> native, wrapped.
+	windowsSandboxInitialized = func() bool { return true }
+	req, err = mgr.BuildExecutionRequest(auto)
+	if err != nil {
+		t.Fatalf("initialized auto: %v", err)
+	}
+	if req.EnforcementLevel != EnforcementNative || !req.CommandWrapped {
+		t.Fatalf("initialized -> native wrapped, got enforcement=%v wrapped=%v", req.EnforcementLevel, req.CommandWrapped)
+	}
+}

--- a/internal/sandbox/windows_shell_autoallow_test.go
+++ b/internal/sandbox/windows_shell_autoallow_test.go
@@ -1,0 +1,48 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+)
+
+// The engine's shell auto-allow must track the ACTUAL runtime enforcement, not
+// just backend capability: on Windows the command is only wrapped once setup has
+// run. Degraded (no marker) -> an ordinary shell command must PROMPT (per-command
+// approval is the floor); native (marker present) -> auto-allow (the OS sandbox
+// is the boundary). Regression guard for the #295 degrade gap.
+func TestEngineWindowsShellAutoAllowTracksSetup(t *testing.T) {
+	restore := windowsSandboxInitialized
+	t.Cleanup(func() { windowsSandboxInitialized = restore })
+
+	eng := NewEngine(EngineOptions{
+		WorkspaceRoot: `C:\ws`,
+		Policy:        DefaultPolicy(),
+		Backend: Backend{
+			Name: BackendWindowsRestrictedToken, Available: true, Executable: "zero.exe",
+			Platform: "windows", CommandWrapping: true, NativeIsolation: true,
+		},
+	})
+	req := Request{
+		ToolName: "bash", SideEffect: SideEffectShell,
+		Permission: PermissionPrompt, PermissionMode: PermissionModeAsk,
+		Args: map[string]any{"command": "echo hi"},
+	}
+
+	// Degraded: setup not run -> not actually sandboxed -> must prompt.
+	windowsSandboxInitialized = func() bool { return false }
+	if eng.shellSandboxActive(DefaultPolicy()) {
+		t.Fatal("degraded: shellSandboxActive must be false (command runs unwrapped)")
+	}
+	if d := eng.Evaluate(context.Background(), req); d.Action != ActionPrompt {
+		t.Fatalf("degraded ordinary shell command must PROMPT, got action=%q reason=%q", d.Action, d.Reason)
+	}
+
+	// Native: setup done -> the sandbox is the boundary -> auto-allow.
+	windowsSandboxInitialized = func() bool { return true }
+	if !eng.shellSandboxActive(DefaultPolicy()) {
+		t.Fatal("native: shellSandboxActive must be true")
+	}
+	if d := eng.Evaluate(context.Background(), req); d.Action != ActionAllow || !d.AutoAllowed {
+		t.Fatalf("native ordinary shell command must AUTO-ALLOW, got action=%q autoAllowed=%v", d.Action, d.AutoAllowed)
+	}
+}


### PR DESCRIPTION
## The bug (every Windows user hits this)
On Windows, the sandbox command runner **hard-fails every shell command** until a one-time **elevated** `zero sandbox setup` writes the `windows-setup.json` marker:
```
zero-windows-command-runner.exe: windows sandbox is not initialized for this
workspace — run `zero sandbox setup` from an elevated (Administrator) terminal
exit 1
```
So a fresh Windows user can't run a single command. **Linux/macOS already *degrade*** when their sandbox is unavailable — Windows was the lone outlier that bricks itself.

## Grounding (analyzed all the reference agents)
None of them brick the CLI because a setup step hasn't run:
- **One reference agent** — has a real Windows sandbox but **defaults it OFF**; runs under approval policy; elevated setup is an opt-in first-run prompt, never a precondition.
- **The others** — degrade on Windows (no OS sandbox / silent fallback + warn); permission prompts are the real safety floor.
- The only sanctioned hard-fail anywhere is an explicit *opt-in* mandatory-sandbox policy.

## The fix
`BuildExecutionRequest`, on Windows when the marker is missing:
| Preference | Behavior |
|---|---|
| **auto** (default) | **Degrade** → command runs unwrapped under the in-process **path-confinement + per-command approval**, with a one-time "run `zero sandbox setup` for full isolation" notice. No brick. |
| **`--sandbox require`** | Still hard-errors with a clear setup hint — strict users keep their guarantee. |
| marker present | Unchanged: native, wrapped, fully sandboxed. |

This is safe because the human-in-the-loop approval gate + path confinement *are* the actual control; the OS sandbox (WFP/ACLs) is defense-in-depth, not the only defense.

## Verified
`TestWindowsDegradesWhenSandboxNotInitialized` covers all three paths (degrade / require-errors / native-when-initialized). Sandbox + doctor + cli suites green; vet + repo build clean.

## Follow-ups (separate)
- Extend **self-dispatch to Linux** so dev doesn't need to build `zero-linux-sandbox`/`zero-seccomp` helpers (the friction a contributor hit).
- Optionally adopt an **unelevated restricted-token tier** as the Windows default hardening (real isolation, no admin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows sandbox setup detection to improve decision-making and provide clearer downgrade/error messaging when initialization is incomplete.

* **Bug Fixes**
  * Updated Windows enforcement behavior to optionally fail when sandbox setup is missing, or otherwise downgrade gracefully.
  * Tightened native shell sandbox activation so shell execution remains unwrapped until Windows sandbox setup completes.

* **Tests**
  * Added and updated Windows-focused regression coverage to verify downgrade/enforcement behavior and shell auto-allow tracking based on setup status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
