### PR TITLE
fix(sandbox): run Homebrew/usr-local tools (node, python3) in the macOS sandbox

### DIFF
--- a/internal/sandbox/homebrew_tools_test.go
+++ b/internal/sandbox/homebrew_tools_test.go
@@ -1,0 +1,116 @@
+package sandbox
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ensureMacToolPaths must make Homebrew / usr-local bin dirs reachable without
+// duplicating entries the inherited PATH already has.
+func TestEnsureMacToolPaths(t *testing.T) {
+	const allFour = "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin"
+
+	t.Run("empty path gets the tool dirs", func(t *testing.T) {
+		if got := ensureMacToolPaths(""); got != allFour {
+			t.Fatalf("ensureMacToolPaths(\"\") = %q, want %q", got, allFour)
+		}
+	})
+
+	t.Run("scrubbed default path is prefixed, original kept", func(t *testing.T) {
+		got := ensureMacToolPaths("/usr/bin:/bin:/usr/sbin:/sbin")
+		want := allFour + ":/usr/bin:/bin:/usr/sbin:/sbin"
+		if got != want {
+			t.Fatalf("ensureMacToolPaths(default) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("existing tool dir is not duplicated", func(t *testing.T) {
+		got := ensureMacToolPaths("/opt/homebrew/bin:/usr/bin")
+		// /opt/homebrew/bin was already present, so only the other three prepend.
+		want := "/opt/homebrew/sbin:/usr/local/bin:/usr/local/sbin:/opt/homebrew/bin:/usr/bin"
+		if got != want {
+			t.Fatalf("ensureMacToolPaths(partial) = %q, want %q", got, want)
+		}
+		if strings.Count(got, "/opt/homebrew/bin") != 1 {
+			t.Fatalf("ensureMacToolPaths duplicated /opt/homebrew/bin: %q", got)
+		}
+	})
+
+	t.Run("path that already has every tool dir is unchanged", func(t *testing.T) {
+		input := allFour + ":/usr/bin"
+		if got := ensureMacToolPaths(input); got != input {
+			t.Fatalf("ensureMacToolPaths(complete) = %q, want unchanged %q", got, input)
+		}
+	})
+}
+
+// The macOS read roots must cover the whole user-tool trees so an interpreter in
+// .../bin and its Cellar/opt dylibs are readable under a restricted (workspace-
+// enforced) policy — not just the bare lib dirs.
+func TestMacosPlatformReadRootsCoverUserToolTrees(t *testing.T) {
+	roots := macosPlatformReadRoots()
+	for _, want := range []string{"/opt/homebrew", "/usr/local"} {
+		found := false
+		for _, r := range roots {
+			if r == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("macosPlatformReadRoots() missing %q (needed so /opt/homebrew/bin + Cellar dylibs are readable); got %v", want, roots)
+		}
+	}
+}
+
+// A Homebrew/usr-local binary loads its own dylibs (node -> libnode/libuv,
+// python3 -> its framework), so the seatbelt profile must map-executable those
+// trees or the binary can't start even when it is on PATH and readable.
+func TestSeatbeltProfileMapsUserToolDylibs(t *testing.T) {
+	rules := seatbeltPlatformRuntimeRules()
+	if !strings.Contains(rules, "file-map-executable") {
+		t.Fatal("seatbeltPlatformRuntimeRules has no file-map-executable rule")
+	}
+	for _, want := range []string{`(subpath "/opt/homebrew")`, `(subpath "/usr/local")`} {
+		if !strings.Contains(rules, want) {
+			t.Errorf("seatbelt file-map-executable rule missing %s", want)
+		}
+	}
+}
+
+// realpath()/getcwd() lstat every ancestor of a tool's path, so the profile must
+// grant file-read-metadata on the ancestors of the user-tool trees (/opt, /usr).
+// Without this a Homebrew python3 dies at startup with
+// "realpath: /opt/homebrew/bin/: Operation not permitted" even though the tree is
+// otherwise readable — the (subpath ...) read rule does not cover /opt itself.
+func TestSeatbeltProfileAllowsUserToolAncestorMetadata(t *testing.T) {
+	rules := seatbeltPlatformRuntimeRules()
+	for _, want := range []string{`(path-ancestors "/opt/homebrew")`, `(path-ancestors "/usr/local")`} {
+		if !strings.Contains(rules, want) {
+			t.Errorf("seatbelt profile missing ancestor-metadata rule %s (realpath of a Homebrew tool would be denied)", want)
+		}
+	}
+	if !strings.Contains(rules, "file-read-metadata") {
+		t.Fatal("expected a file-read-metadata rule for tool ancestors")
+	}
+}
+
+// On macOS the scrubbed sandbox environment must still expose the Homebrew bin
+// dir so `python3`/`node` resolve to the user's install, not a system stub.
+func TestSandboxEnvironmentExposesHomebrewOnMac(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("PATH augmentation is macOS-only")
+	}
+	env := sandboxEnvironment(Policy{}, BackendMacOSSeatbelt, t.TempDir())
+	path := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			path = strings.TrimPrefix(kv, "PATH=")
+			break
+		}
+	}
+	if !strings.Contains(path, "/opt/homebrew/bin") {
+		t.Fatalf("sandbox PATH = %q, want it to include /opt/homebrew/bin", path)
+	}
+}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -370,9 +370,18 @@ func existingBubblewrapMounts() []string {
 }
 
 func sandboxEnvironment(policy Policy, backend BackendName, home string) []string {
+	pathValue := firstEnv("PATH", defaultPath())
+	if runtime.GOOS == "darwin" {
+		// The sandbox runs commands with a scrubbed, minimal PATH that omits the
+		// Homebrew / usr-local bin dirs, so a bare `python3`/`node` resolves to a
+		// system stub (the macOS /usr/bin/python3 placeholder) or is not found at
+		// all. Make the user-tool dirs reachable to match the read/map-executable
+		// allowances added for those trees.
+		pathValue = ensureMacToolPaths(pathValue)
+	}
 	env := []string{
 		"HOME=" + home,
-		"PATH=" + firstEnv("PATH", defaultPath()),
+		"PATH=" + pathValue,
 		"TERM=" + firstEnv("TERM", "dumb"),
 		EnvSandboxBackend + "=" + string(backend),
 		"ZERO_SANDBOX_NETWORK=" + string(policy.Network),
@@ -403,6 +412,42 @@ func defaultPath() string {
 		return os.Getenv("PATH")
 	}
 	return "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+}
+
+// macToolPaths are the user-package bin dirs that hold node/python/etc. on macOS
+// (Homebrew on Apple Silicon under /opt/homebrew, and /usr/local for Intel/older
+// installs). They are NOT in the scrubbed default PATH, so the sandbox would
+// otherwise miss user-installed interpreters.
+var macToolPaths = []string{
+	"/opt/homebrew/bin",
+	"/opt/homebrew/sbin",
+	"/usr/local/bin",
+	"/usr/local/sbin",
+}
+
+// ensureMacToolPaths prepends any missing macToolPaths to a PATH value so a
+// sandboxed command can find Homebrew/usr-local tools. Existing entries are kept
+// in place (no duplicates, original order preserved after the prepended dirs).
+func ensureMacToolPaths(path string) string {
+	present := make(map[string]bool)
+	for _, entry := range strings.Split(path, ":") {
+		if entry != "" {
+			present[entry] = true
+		}
+	}
+	missing := make([]string, 0, len(macToolPaths))
+	for _, dir := range macToolPaths {
+		if !present[dir] {
+			missing = append(missing, dir)
+		}
+	}
+	if len(missing) == 0 {
+		return path
+	}
+	if path == "" {
+		return strings.Join(missing, ":")
+	}
+	return strings.Join(missing, ":") + ":" + path
 }
 
 // sandboxWritableDevices are the standard character devices that virtually every
@@ -717,8 +762,12 @@ func macosPlatformReadRoots() []string {
 		"/usr/lib",
 		"/usr/libexec",
 		"/usr/share",
-		"/usr/local/lib",
-		"/opt/homebrew/lib",
+		// User-installed package trees (Homebrew on Apple Silicon, /usr/local on
+		// Intel / older installs). Broadened from the bare lib dirs to the whole
+		// tree so the interpreters in .../bin and their Cellar/opt dylibs are
+		// readable; writes stay confined to the workspace.
+		"/usr/local",
+		"/opt/homebrew",
 		"/etc",
 		"/private/etc",
 		"/var/db",
@@ -746,7 +795,12 @@ func seatbeltPlatformRuntimeRules() string {
 		`  (subpath "/System/iOSSupport/System/Library/Frameworks")`,
 		`  (subpath "/System/iOSSupport/System/Library/PrivateFrameworks")`,
 		`  (subpath "/System/iOSSupport/System/Library/SubFrameworks")`,
-		`  (subpath "/usr/lib"))`,
+		`  (subpath "/usr/lib")`,
+		// User-installed tools load their own dylibs (e.g. node -> libnode/libuv,
+		// python3 -> its framework) from these trees; without map-executable here
+		// a Homebrew/usr-local binary fails to start even when it is on PATH.
+		`  (subpath "/usr/local")`,
+		`  (subpath "/opt/homebrew"))`,
 		`(allow system-mac-syscall (mac-policy-name "vnguard"))`,
 		`(allow system-mac-syscall (require-all (mac-policy-name "Sandbox") (mac-syscall-number 67)))`,
 		`(allow file-read-metadata file-test-existence`,
@@ -755,6 +809,14 @@ func seatbeltPlatformRuntimeRules() string {
 		`  (literal "/var")`,
 		`  (literal "/private/etc/localtime"))`,
 		`(allow file-read-metadata file-test-existence (path-ancestors "/System/Volumes/Data/private"))`,
+		// realpath()/getcwd() lstat every ancestor of a path, so resolving a tool
+		// under /opt/homebrew or /usr/local also stats the parent dirs (e.g. /opt,
+		// /usr). The subpath read rules above cover the trees themselves but not
+		// those ancestors, so without this a Homebrew python3 fails at startup with
+		// "realpath: /opt/homebrew/bin/: Operation not permitted" even though it is
+		// on PATH and readable. node only exec()s (kernel traversal) so it is not
+		// affected — which is exactly how this asymmetry was diagnosed.
+		`(allow file-read-metadata file-test-existence (path-ancestors "/opt/homebrew") (path-ancestors "/usr/local"))`,
 		`(allow file-read* file-test-existence (literal "/"))`,
 		`(allow system-fsctl (fsctl-command FSIOC_CAS_BSDFLAGS))`,
 		`(allow file-read* file-test-existence`,


### PR DESCRIPTION
## Why

On macOS, a **scoped** (workspace-enforced) `exec_command`/`bash` could not run user-installed interpreters like Homebrew `python3`/`node`. Two symptoms, same area:

- `python3` resolved to the broken `/usr/bin/python3` stub → `xcode-select: No developer tools were found`.
- After making the tools reachable, `python3` still failed at startup with `realpath: /opt/homebrew/bin/: Operation not permitted`, while `node` worked — a telling asymmetry.

The scoped profile uses a scrubbed minimal PATH and **restricted** reads, and the user-package trees weren't fully accounted for.

## Root cause

Running a Homebrew/`usr-local` binary needs four things from the macOS seatbelt profile, and each was missing:

1. **PATH** — the scrubbed env omitted `/opt/homebrew/{bin,sbin}` (+ `/usr/local`), so the interpreter wasn't found (or resolved to a system stub).
2. **read** — only the bare `.../lib` dirs were readable; the interpreter in `.../bin` and its Cellar/opt dylibs were not.
3. **`file-map-executable`** — restricted to system frameworks + `/usr/lib`, so a Homebrew binary couldn't load its own dylibs (`node` → `libnode`/`libuv`/…, `python3` → its framework).
4. **`file-read-metadata` on the *ancestors*** — `realpath()`/`getcwd()` lstat every path component, so resolving a tool also stats the parent dirs (`/opt`, `/usr`). The subpath read rules cover the trees themselves but **not `/opt`**, so `python3`'s startup `realpath()` was denied. `node` only `exec`s (kernel traversal, allowed), which is exactly how the gap was isolated.

Confirmed by dumping the **real** scoped profile and reproducing under `sandbox-exec` (a control test with/without rule #4 flipped the result deterministically).

## What changed — `internal/sandbox/runner.go`

- `ensureMacToolPaths`: prepend `/opt/homebrew/{bin,sbin}` + `/usr/local/{bin,sbin}` to the sandbox PATH on darwin (no duplicates).
- Broaden the platform read roots from `.../lib` to the whole `/opt/homebrew` and `/usr/local` trees.
- Add `/opt/homebrew` and `/usr/local` to `file-map-executable`.
- Add `file-read-metadata` on `(path-ancestors "/opt/homebrew")` / `(path-ancestors "/usr/local")`.

## Scope / safety

- **Writes stay confined to the workspace** — only reads/exec of user-package trees are added.
- **Network is untouched** — binding a listening socket (e.g. `python3 -m http.server`) is still governed by the existing network policy; this PR does not change it.
- Non-macOS platforms are unaffected (PATH augmentation is `darwin`-gated; the rules live in the seatbelt profile).

## Verification

End-to-end under the real profile via `sandbox-exec`: `python3` and `node` now resolve, start, import stdlib, and read/write the workspace. New regression tests cover the PATH helper, the read roots, the map-executable roots, and the ancestor-metadata rule. `go build ./...`, `go vet`, full `internal/sandbox` suite, and gofmt are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating macOS Homebrew tool integration in sandbox environments.

* **New Features**
  * Sandboxed environments on macOS now properly expose Homebrew (`/opt/homebrew`) and user-local (`/usr/local`) tool directories, enabling access to user-installed interpreters and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->