### PR TITLE
Fix ChatGPT Codex OAuth model list and request shape

### DIFF
--- a/docs/oauth-subscriptions.md
+++ b/docs/oauth-subscriptions.md
@@ -170,7 +170,7 @@ preset (no API key — the proxy authenticates):
       "name": "chatgpt",
       "catalogID": "chatgpt-proxy",     // OpenAI-compatible, local, no key
       "baseURL": "http://localhost:10531/v1", // override for your proxy's port
-      "model": "gpt-5"                   // whatever model your proxy serves
+      "model": "gpt-5.5"                 // whatever model your proxy serves
     }
   ]
 }

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -137,7 +137,7 @@ func runAuthChatGPT(args []string, stdout io.Writer, stderr io.Writer, deps appD
 	if _, err := fmt.Fprint(stdout, statuses); err != nil {
 		return exitCrash
 	}
-	if _, err := fmt.Fprint(stdout, "\nUse it with zero, e.g.:\n  zero --provider chatgpt --model gpt-5\n"); err != nil {
+	if _, err := fmt.Fprint(stdout, "\nUse it with zero, e.g.:\n  zero --provider chatgpt --model gpt-5.5\n"); err != nil {
 		return exitCrash
 	}
 	return exitSuccess

--- a/internal/providercatalog/catalog.go
+++ b/internal/providercatalog/catalog.go
@@ -104,7 +104,7 @@ var descriptors = []Descriptor{
 	// way in; RequiresAuth is forced true so catalog consumers know the provider
 	// needs an interactive login before a request will succeed.
 	func() Descriptor {
-		d := openAICompat("chatgpt", "ChatGPT", "https://chatgpt.com/backend-api/codex", "gpt-5", nil)
+		d := openAICompat("chatgpt", "ChatGPT", "https://chatgpt.com/backend-api/codex", "gpt-5.5", nil)
 		d.RequiresAuth = true
 		return oauthProvider(d, false, false)
 	}(),

--- a/internal/providermodelcatalog/catalog.go
+++ b/internal/providermodelcatalog/catalog.go
@@ -56,6 +56,12 @@ var curatedModels = map[string][]Model{
 		{ID: "minimax/minimax-m2.1", Description: "agentic coding model"},
 		{ID: "deepseek/deepseek-chat", Description: "coding model"},
 	},
+	"chatgpt": {
+		{ID: "gpt-5.5", Description: "recommended Codex model"},
+		{ID: "gpt-5.4", Description: "strong Codex model"},
+		{ID: "gpt-5.4-mini", Description: "fast Codex model"},
+		{ID: "gpt-5.3-codex-spark", Description: "research preview fast Codex model"},
+	},
 	"deepseek": {
 		{ID: "deepseek-chat", Description: "catalog default"},
 		{ID: "deepseek-reasoner", Description: "reasoning model"},

--- a/internal/providermodelcatalog/catalog_test.go
+++ b/internal/providermodelcatalog/catalog_test.go
@@ -28,6 +28,11 @@ func TestModelsAreProviderScoped(t *testing.T) {
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5"},
 		},
 		{
+			provider: "chatgpt",
+			want:     []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"},
+			notWant:  []string{"gpt-5", "gpt-4.1", "openai/gpt-4.1"},
+		},
+		{
 			provider: "mistral",
 			want:     []string{"mistral-large-latest", "codestral-latest"},
 			notWant:  []string{"gpt-4.1", "claude-sonnet-4.5"},

--- a/internal/providers/openai/codex_responses.go
+++ b/internal/providers/openai/codex_responses.go
@@ -72,8 +72,10 @@ const (
 // responsesRequest is the wire shape POSTed to {baseURL}/responses.
 type responsesRequest struct {
 	Model           string          `json:"model"`
+	Instructions    string          `json:"instructions"`
 	Input           []inputItem     `json:"input"`
 	Stream          bool            `json:"stream"`
+	Store           bool            `json:"store"`
 	MaxOutputTokens int             `json:"max_output_tokens,omitempty"`
 	Tools           []responsesTool `json:"tools,omitempty"`
 }
@@ -203,18 +205,13 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 		Stream:          true,
 		MaxOutputTokens: p.inner.maxTokens,
 	}
+	instructions := []string{}
 	for _, msg := range request.Messages {
 		switch msg.Role {
 		case zeroruntime.MessageRoleSystem:
-			// System → first-class user message in Responses API. Keeping it as
-			// an input message (rather than a separate `instructions` field)
-			// matches the chat-completions semantics the runtime was already
-			// producing — every system turn reaches the model in order.
-			req.Input = append(req.Input, inputItem{
-				Type:    "message",
-				Role:    "system",
-				Content: []contentItem{{Type: "input_text", Text: msg.Content}},
-			})
+			if content := strings.TrimSpace(msg.Content); content != "" {
+				instructions = append(instructions, content)
+			}
 		case zeroruntime.MessageRoleUser:
 			req.Input = append(req.Input, p.userInputItem(msg))
 		case zeroruntime.MessageRoleAssistant:
@@ -236,6 +233,7 @@ func (p *CodexProvider) buildResponsesRequest(request zeroruntime.CompletionRequ
 			return nil, fmt.Errorf("codex provider: unsupported message role %q", msg.Role)
 		}
 	}
+	req.Instructions = strings.Join(instructions, "\n\n")
 	for _, tool := range request.Tools {
 		req.Tools = append(req.Tools, responsesTool{
 			Type:        "function",

--- a/internal/providers/openai/codex_test.go
+++ b/internal/providers/openai/codex_test.go
@@ -385,9 +385,10 @@ func TestCodexProviderOmitsAccountIDWhenResolverSaysNo(t *testing.T) {
 
 func TestCodexProviderSendsResponsesRequestShape(t *testing.T) {
 	// The Codex provider speaks the Responses API, not the chat-completions
-	// API. The request body must carry `input` items (not `messages`), a
-	// `stream: true` flag, and `tools` (when the caller supplies any) — a
-	// chat-completions body would be rejected by the live Codex backend.
+	// API. The request body must carry top-level `instructions`, `input` items
+	// (not `messages`), a `stream: true` flag, and `tools` (when the caller
+	// supplies any) — a chat-completions body would be rejected by the live
+	// Codex backend.
 	var rec codexRequest
 	srv := newCodexTestServer(t, &rec)
 	defer srv.Close()
@@ -423,23 +424,25 @@ func TestCodexProviderSendsResponsesRequestShape(t *testing.T) {
 	if rec.body["stream"] != true {
 		t.Fatalf("body.stream = %#v, want true", rec.body["stream"])
 	}
+	if store, ok := rec.body["store"].(bool); !ok || store {
+		t.Fatalf("body.store = %#v, want explicit false", rec.body["store"])
+	}
 	if _, ok := rec.body["messages"]; ok {
 		t.Fatalf("body must not carry chat-completions `messages` (got %#v); the Codex backend serves the Responses API", rec.body["messages"])
 	}
+	if rec.body["instructions"] != "sys" {
+		t.Fatalf("body.instructions = %#v, want system prompt", rec.body["instructions"])
+	}
 	input, ok := rec.body["input"].([]any)
 	if !ok {
-		t.Fatalf("body.input = %#v, want []any with two message items", rec.body["input"])
+		t.Fatalf("body.input = %#v, want []any with user message item", rec.body["input"])
 	}
-	if len(input) != 2 {
-		t.Fatalf("body.input has %d items, want 2 (system + user)", len(input))
+	if len(input) != 1 {
+		t.Fatalf("body.input has %d items, want 1 (user)", len(input))
 	}
-	system, _ := input[0].(map[string]any)
-	if system["type"] != "message" || system["role"] != "system" {
-		t.Fatalf("body.input[0] = %#v, want type=message role=system", system)
-	}
-	user, _ := input[1].(map[string]any)
+	user, _ := input[0].(map[string]any)
 	if user["type"] != "message" || user["role"] != "user" {
-		t.Fatalf("body.input[1] = %#v, want type=message role=user", user)
+		t.Fatalf("body.input[0] = %#v, want type=message role=user", user)
 	}
 	tools, ok := rec.body["tools"].([]any)
 	if !ok || len(tools) != 1 {

--- a/internal/tui/provider_wizard_oauth_test.go
+++ b/internal/tui/provider_wizard_oauth_test.go
@@ -214,6 +214,29 @@ func TestProviderWizardSupportsOAuth(t *testing.T) {
 	}
 }
 
+func TestProviderWizardChatGPTOAuthModelsUseCodexSet(t *testing.T) {
+	chatgpt, ok := providercatalog.Get("chatgpt")
+	if !ok {
+		t.Fatal("chatgpt provider missing from catalog")
+	}
+	models := providerWizardModelOptions(chatgpt)
+	got := map[string]bool{}
+	for _, model := range models {
+		got[model.ID] = true
+	}
+	for _, want := range []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"} {
+		if !got[want] {
+			t.Fatalf("ChatGPT OAuth models missing %q; got %#v", want, providerWizardModelIDs(models))
+		}
+	}
+	if got["gpt-5"] {
+		t.Fatalf("ChatGPT OAuth models should not include stale gpt-5 fallback; got %#v", providerWizardModelIDs(models))
+	}
+	if models[0].ID != "gpt-5.5" {
+		t.Fatalf("default ChatGPT OAuth model = %q, want gpt-5.5", models[0].ID)
+	}
+}
+
 func TestProviderWizardCtrlOStartsOAuthForOpenRouter(t *testing.T) {
 	m := wizardModelAt(t, "openrouter", providerWizardStepCredential)
 	next, cmd := m.handleProviderWizardKey(testKeyCtrl('o'))


### PR DESCRIPTION
Summary: Updates the ChatGPT OAuth provider default/model picker to the Codex-supported model set, and sends Codex Responses requests with top-level instructions plus explicit store=false. Tests: GOTOOLCHAIN=local go test ./internal/providers/openai ./internal/providercatalog ./internal/providermodelcatalog ./internal/tui ./internal/cli; ZERO_OAUTH_TOKENS_PATH=/tmp/zero-empty-oauth-provider-test.json GOTOOLCHAIN=local go test ./internal/providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded ChatGPT model catalog with additional Codex-variant models (gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark)
  * Enhanced Codex Responses API request handling

* **Documentation**
  * Updated default ChatGPT model to gpt-5.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->