### PR TITLE
feat(tui): chat + context sidebar redesign, AGENTS panel, animations

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1845,7 +1845,12 @@ func partitionTools(registry *tools.Registry, permissionMode PermissionMode, opt
 			continue
 		}
 		visible = append(visible, tool)
-		if tools.IsDeferred(tool) {
+		// Count by deferral-ELIGIBILITY, not current deferred state: a tool that
+		// un-defers at runtime (e.g. swarm coordination tools once a swarm is
+		// active) still counts, so it can't drop `eligible` below the threshold
+		// and force-expose every other deferred tool. Whether a tool is actually
+		// hidden is decided by IsDeferred in the exposure loop below.
+		if tools.IsDeferralEligible(tool) {
 			eligible++
 		}
 	}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -659,7 +659,11 @@ func newExecSelfCorrector(enabled bool, workspaceRoot string, autonomy string) (
 func deferredEligibleCount(registry *tools.Registry, permissionMode agent.PermissionMode, enabledTools []string, disabledTools []string) int {
 	count := 0
 	for _, tool := range registry.All() {
-		if !tools.IsDeferred(tool) {
+		// Count by deferral-eligibility (not current deferred state) to match
+		// partitionTools' active-gate: a tool that un-defers at runtime still
+		// participates in the threshold. At registration time the swarm is empty
+		// so this equals IsDeferred, but it keeps the two count sites consistent.
+		if !tools.IsDeferralEligible(tool) {
 			continue
 		}
 		if !agent.ToolVisible(tool, permissionMode, enabledTools, disabledTools) {

--- a/internal/swarm/deferred_test.go
+++ b/internal/swarm/deferred_test.go
@@ -6,9 +6,10 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
-// All swarm tools must be deferred-eligible so their schemas stay out of the
-// eager per-request tool prefix (loaded on demand via tool_search), while the
-// core built-ins remain eager.
+// With NO active swarm, all swarm tools must be deferred-eligible so their
+// schemas stay out of the eager per-request tool prefix (loaded on demand via
+// tool_search), while the core built-ins remain eager. (A zero-value &Swarm{}
+// has a nil coordinator, so hasActiveSwarm reports inactive — see nil-safety.)
 func TestSwarmToolsAreDeferred(t *testing.T) {
 	registry := tools.NewRegistry()
 	RegisterTools(registry, &Swarm{})
@@ -17,7 +18,75 @@ func TestSwarmToolsAreDeferred(t *testing.T) {
 			t.Errorf("swarm tool %q is NOT deferred-eligible (would bloat the eager prefix)", tool.Name())
 		}
 	}
-	if len(registry.All()) < 6 {
-		t.Fatalf("expected the swarm tools registered, got %d", len(registry.All()))
+	if len(registry.All()) != 7 {
+		t.Fatalf("expected 7 swarm tools registered, got %d", len(registry.All()))
+	}
+	// Every swarm tool counts toward the deferral threshold (deferral-eligible),
+	// cold start and always.
+	for _, tool := range registry.All() {
+		if !tools.IsDeferralEligible(tool) {
+			t.Errorf("swarm tool %q should be deferral-eligible", tool.Name())
+		}
+	}
+}
+
+// Once a swarm is active, the COORDINATION tools un-defer (IsDeferred==false) so a
+// coordinating model sees them eagerly and doesn't misroute the calls to the
+// specialist tool. The entry-point/handoff tools stay deferred for cold-start
+// discovery. Critically, the un-deferred tools STAY deferral-eligible, so the
+// global deferral count is unchanged and other deferred tools (MCP) are never
+// force-exposed — in any threshold/filter config.
+func TestSwarmCoordinationToolsUndeferWhenActive(t *testing.T) {
+	reg, sw := newToolSwarm(t, newLauncher(okFor))
+
+	// Cold start: every swarm tool is deferred.
+	for _, tool := range reg.All() {
+		if !tools.IsDeferred(tool) {
+			t.Errorf("with no active swarm, %q should be deferred", tool.Name())
+		}
+	}
+
+	// Activate the swarm by registering a task in the coordinator.
+	if _, err := sw.Coordinator().Register("t1", "teammate-1", "default", "do work"); err != nil {
+		t.Fatalf("register task: %v", err)
+	}
+
+	undeferred := map[string]bool{SendToolName: true, StatusToolName: true, InboxToolName: true, CollectToolName: true}
+	stillDeferred := map[string]bool{SpawnToolName: true, ScheduleToolName: true, HandoffToolName: true}
+	eligibleCount := 0
+	for _, tool := range reg.All() {
+		name := tool.Name()
+		got := tools.IsDeferred(tool)
+		// The active-gate counts deferral-ELIGIBLE tools; every swarm tool must
+		// stay eligible even when un-deferred, so the count never drops.
+		if !tools.IsDeferralEligible(tool) {
+			t.Errorf("swarm tool %q must stay deferral-eligible even when un-deferred", name)
+		} else {
+			eligibleCount++
+		}
+		switch {
+		case undeferred[name] && got:
+			t.Errorf("with an active swarm, coordination tool %q should NOT be deferred", name)
+		case stillDeferred[name] && !got:
+			t.Errorf("entry/handoff tool %q must stay deferred", name)
+		}
+	}
+	// All 7 stay deferral-eligible (the count partitionTools' active-gate uses),
+	// so un-deferring the 4 coordination tools cannot deactivate deferral.
+	if eligibleCount != 7 {
+		t.Fatalf("expected all 7 swarm tools deferral-eligible while active, got %d", eligibleCount)
+	}
+}
+
+// hasActiveSwarm must be nil-safe: a nil *Swarm or a zero-value Swarm (nil
+// coordinator) reports inactive, so the coordination tools stay deferred rather
+// than panicking — this is what keeps TestSwarmToolsAreDeferred (&Swarm{}) green.
+func TestHasActiveSwarmNilSafe(t *testing.T) {
+	var nilSwarm *Swarm
+	if nilSwarm.hasActiveSwarm() {
+		t.Error("nil swarm should report inactive")
+	}
+	if (&Swarm{}).hasActiveSwarm() {
+		t.Error("zero-value swarm (nil coord) should report inactive")
 	}
 }

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -21,7 +21,7 @@ const (
 	CollectToolName = "swarm_collect"
 )
 
-// RegisterTools registers the six swarm tools backed by one shared Swarm. The
+// RegisterTools registers the seven swarm tools backed by one shared Swarm. The
 // caller owns the Swarm's lifetime (call Swarm.Close on shutdown).
 func RegisterTools(registry *tools.Registry, sw *Swarm) {
 	registry.Register(&spawnTool{sw: sw})
@@ -37,11 +37,44 @@ func RegisterTools(registry *tools.Registry, sw *Swarm) {
 // advanced, rarely-first-move orchestration feature and the base system prompt
 // does not name them, so they are hidden behind tool_search (loaded on demand)
 // instead of shipping their full schemas in the eager per-request tool prefix.
-// Embedding it in each swarm tool struct is enough — partitionTools keys off the
-// shared tools.IsDeferred check, exactly as it does for MCP tools.
+// Embedding it keys each tool into partitionTools' deferral, exactly like MCP.
+//
+// The COORDINATION tools (swarm_send/swarm_status/swarm_inbox/swarm_collect)
+// override Deferred() to un-defer (expose eagerly) once a swarm is active (see
+// hasActiveSwarm): a weaker model coordinating a live swarm that can't see those
+// tools tends to misroute the calls to the specialist tool ("specialist
+// swarm_send not found") in a retry loop. The ENTRY-POINT tools (swarm_spawn/
+// swarm_schedule) and swarm_handoff keep the default true — they stay
+// discoverable via tool_search from a cold start.
+//
+// Un-deferring a coordination tool must NOT lower the global deferral count and
+// risk dropping it below DeferThreshold (which would deactivate deferral and
+// force-expose every other deferred tool, e.g. MCP). DeferralEligible() keeps
+// every swarm tool counting toward the threshold even while exposed eagerly, so
+// partitionTools' active-gate is unaffected by the un-defer in ANY config —
+// raised threshold or filtered tools included (see tools.IsDeferralEligible).
 type deferredSwarmTool struct{}
 
 func (deferredSwarmTool) Deferred() bool { return true }
+
+// DeferralEligible keeps a swarm tool counting toward the DeferThreshold even
+// when a coordination tool un-defers (Deferred()==false). This decouples
+// "counts toward the threshold" from "currently hidden", so un-deferring the
+// coordination tools can never deactivate deferral for other tools.
+func (deferredSwarmTool) DeferralEligible() bool { return true }
+
+// hasActiveSwarm reports whether the swarm currently tracks any task — i.e. a
+// swarm exists worth coordinating (members running, queued, on standby, or done
+// awaiting collection). It is the gate the coordination tools' Deferred() reads,
+// so they surface eagerly for the swarm's whole life rather than flapping as
+// members move to standby/done. Thread-safe (Summarize RLocks the coordinator)
+// and nil-safe: a zero-value or unwired Swarm reports inactive (stays deferred).
+func (s *Swarm) hasActiveSwarm() bool {
+	if s == nil || s.coord == nil {
+		return false
+	}
+	return s.coord.Summarize().Total > 0
+}
 
 // policyFrom derives the member-inheritance policy from the live tool options so
 // each spawned member runs on the orchestrator's current model + permission mode.
@@ -133,6 +166,9 @@ type sendTool struct {
 	deferredSwarmTool
 }
 
+// Deferred un-defers swarm_send once a swarm is active (see deferredSwarmTool).
+func (t *sendTool) Deferred() bool { return !t.sw.hasActiveSwarm() }
+
 func (t *sendTool) Name() string { return SendToolName }
 func (t *sendTool) Description() string {
 	return "Send a message to another swarm member's inbox on a team."
@@ -190,6 +226,9 @@ type inboxTool struct {
 	sw *Swarm
 	deferredSwarmTool
 }
+
+// Deferred un-defers swarm_inbox once a swarm is active (see deferredSwarmTool).
+func (t *inboxTool) Deferred() bool { return !t.sw.hasActiveSwarm() }
 
 func (t *inboxTool) Name() string { return InboxToolName }
 func (t *inboxTool) Description() string {
@@ -252,6 +291,9 @@ type statusTool struct {
 	sw *Swarm
 	deferredSwarmTool
 }
+
+// Deferred un-defers swarm_status once a swarm is active (see deferredSwarmTool).
+func (t *statusTool) Deferred() bool { return !t.sw.hasActiveSwarm() }
 
 func (t *statusTool) Name() string { return StatusToolName }
 func (t *statusTool) Description() string {
@@ -354,6 +396,9 @@ type collectTool struct {
 	sw *Swarm
 	deferredSwarmTool
 }
+
+// Deferred un-defers swarm_collect once a swarm is active (see deferredSwarmTool).
+func (t *collectTool) Deferred() bool { return !t.sw.hasActiveSwarm() }
 
 func (t *collectTool) Name() string { return CollectToolName }
 func (t *collectTool) Description() string {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -69,6 +69,30 @@ func IsDeferred(t Tool) bool {
 	return ok && d.Deferred()
 }
 
+// deferralEligibleTool lets a tool keep counting toward the deferral threshold
+// even when it is dynamically exposed eagerly (Deferred()==false). A tool whose
+// Deferred() flips false at runtime — e.g. the swarm coordination tools once a
+// swarm is active — would otherwise lower the global eligible count and risk
+// dropping it below DeferThreshold, which would deactivate deferral for ALL
+// tools (force-exposing every MCP schema). Implementing this keeps the count
+// stable so un-deferring one tool can never force-expose others.
+type deferralEligibleTool interface {
+	DeferralEligible() bool
+}
+
+// IsDeferralEligible reports whether a tool counts toward the DeferThreshold.
+// A currently-deferred tool always counts. A tool may ALSO opt in via
+// DeferralEligible() to keep counting while exposed eagerly (see above). This is
+// the count partitionTools uses for the active-gate; whether a tool is actually
+// hidden is still decided by IsDeferred.
+func IsDeferralEligible(t Tool) bool {
+	if IsDeferred(t) {
+		return true
+	}
+	d, ok := t.(deferralEligibleTool)
+	return ok && d.DeferralEligible()
+}
+
 func (registry *Registry) Register(tool Tool) {
 	registry.tools[tool.Name()] = tool
 }

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -426,3 +426,46 @@ func TestIsDeferredReportsOptionalInterface(t *testing.T) {
 		t.Fatal("IsDeferred(plain) = true, want false for a tool that does not implement deferredTool")
 	}
 }
+
+// fakeUndeferredEligibleTool is exposed eagerly (Deferred()==false) yet still
+// counts toward the threshold (DeferralEligible()==true) — like a swarm
+// coordination tool while a swarm is active.
+type fakeUndeferredEligibleTool struct {
+	baseTool
+}
+
+func (tool fakeUndeferredEligibleTool) Run(context.Context, map[string]any) Result {
+	return okResult("ok")
+}
+
+func (tool fakeUndeferredEligibleTool) Deferred() bool         { return false }
+func (tool fakeUndeferredEligibleTool) DeferralEligible() bool { return true }
+
+func TestIsDeferralEligibleDecouplesFromDeferred(t *testing.T) {
+	// A currently-deferred tool is eligible via the IsDeferred fallback.
+	deferred := fakeDeferredTool{baseTool: baseTool{name: "deferred"}, deferred: true}
+	if !IsDeferralEligible(deferred) {
+		t.Fatal("IsDeferralEligible(deferred) = false, want true (deferred tools always count)")
+	}
+
+	// Exposed eagerly but opted into DeferralEligible: still counts toward the gate.
+	undeferred := fakeUndeferredEligibleTool{baseTool: baseTool{name: "undeferred_eligible"}}
+	if IsDeferred(undeferred) {
+		t.Fatal("IsDeferred(undeferred) = true, want false")
+	}
+	if !IsDeferralEligible(undeferred) {
+		t.Fatal("IsDeferralEligible(undeferred) = false, want true (opts in via DeferralEligible)")
+	}
+
+	// A plain eager tool counts toward neither.
+	plain := fakePlainTool{baseTool: baseTool{name: "plain"}}
+	if IsDeferralEligible(plain) {
+		t.Fatal("IsDeferralEligible(plain) = true, want false")
+	}
+
+	// Deferred()==false and no DeferralEligible interface: not eligible.
+	optedOut := fakeDeferredTool{baseTool: baseTool{name: "opted_out"}, deferred: false}
+	if IsDeferralEligible(optedOut) {
+		t.Fatal("IsDeferralEligible(optedOut) = true, want false")
+	}
+}

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -109,9 +109,9 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 
 		if heading := markdownHeadingText(trimmed); heading != "" {
 			blankBefore()
-			// Headings stand out as accent + bold + underline — a clear top tier above
-			// the ink body and the accent-bold inline emphasis.
-			headingStyle := zeroTheme.accent.Bold(true).Underline(true)
+			// Headings are distinguished by weight + underline, not a bright colour —
+			// calm for dark-mode terminals (ink, the body colour, not the lime accent).
+			headingStyle := zeroTheme.ink.Bold(true).Underline(true)
 			plain := strings.ReplaceAll(strings.ReplaceAll(heading, "**", ""), "`", "")
 			for _, hl := range wrapPlainText(plain, proseMeasure) {
 				lines = append(lines, headingStyle.Render(hl))
@@ -169,9 +169,8 @@ func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
 		text := run.String()
 		switch style {
 		case markdownDisplayBold:
-			// Important / emphasised words render in the brand accent so they read as
-			// a clear second tier against the ink body text.
-			builder.WriteString(zeroTheme.accent.Bold(true).Render(text))
+			// Emphasis is weight-only (no colour) — dark-mode-friendly and calm.
+			builder.WriteString(zeroTheme.ink.Bold(true).Render(text))
 		case markdownDisplayRule:
 			builder.WriteString(zeroTheme.lineStrong.Render(text))
 		default:

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -109,7 +109,13 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 
 		if heading := markdownHeadingText(trimmed); heading != "" {
 			blankBefore()
-			lines = append(lines, wrapMarkdownInline(heading, proseMeasure)...)
+			// Headings stand out as accent + bold + underline — a clear top tier above
+			// the ink body and the accent-bold inline emphasis.
+			headingStyle := zeroTheme.accent.Bold(true).Underline(true)
+			plain := strings.ReplaceAll(strings.ReplaceAll(heading, "**", ""), "`", "")
+			for _, hl := range wrapPlainText(plain, proseMeasure) {
+				lines = append(lines, headingStyle.Render(hl))
+			}
 			index++
 			continue
 		}
@@ -163,7 +169,9 @@ func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
 		text := run.String()
 		switch style {
 		case markdownDisplayBold:
-			builder.WriteString(zeroTheme.ink.Bold(true).Render(text))
+			// Important / emphasised words render in the brand accent so they read as
+			// a clear second tier against the ink body text.
+			builder.WriteString(zeroTheme.accent.Bold(true).Render(text))
 		case markdownDisplayRule:
 			builder.WriteString(zeroTheme.lineStrong.Render(text))
 		default:

--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -46,6 +46,16 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 	}
 
 	lines := []string{}
+	// blankBefore inserts one separator blank line before a block (heading or
+	// paragraph) for vertical breathing room, but never doubles an existing blank
+	// and never leads with one (lines is empty at the top; trimMarkdownDisplay-
+	// BlankEdges strips any leading blank anyway). Lists, code, and tables are left
+	// tight — they don't call it.
+	blankBefore := func() {
+		if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) != "" {
+			lines = append(lines, "")
+		}
+	}
 	for index := 0; index < len(raw); {
 		line := raw[index]
 		trimmed := strings.TrimSpace(line)
@@ -98,6 +108,7 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 		}
 
 		if heading := markdownHeadingText(trimmed); heading != "" {
+			blankBefore()
 			lines = append(lines, wrapMarkdownInline(heading, proseMeasure)...)
 			index++
 			continue
@@ -109,6 +120,7 @@ func renderAssistantMarkdownText(text string, proseMeasure int, tableMeasure int
 			continue
 		}
 
+		blankBefore()
 		paragraph := []string{strings.TrimSpace(line)}
 		index++
 		for index < len(raw) {

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -348,7 +348,9 @@ func TestSuggestionOverlayStaysVisibleWhenTranscriptScrolled(t *testing.T) {
 		switch {
 		case strings.Contains(line, "Commands"):
 			paletteLine = index
-		case strings.Contains(line, "no model") && strings.Contains(line, "auto-approve"):
+		case strings.Contains(line, "no model"):
+			// The composer rule shows the model; the mode ("auto-approve") is now on
+			// the status line below it, so locate the composer by its model label.
 			composerLine = index
 		}
 	}

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -260,7 +260,7 @@ func (m model) composerPositionAtMouse(msg tea.MouseMsg) (int, bool) {
 	if !m.altScreen || m.height <= 0 || m.composerMouseSelectionBlocked() {
 		return 0, false
 	}
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	localX, localY, ok := frame.composerRect.local(mouseX(msg), mouseY(msg))
 	if !ok {

--- a/internal/tui/keybinding_help.go
+++ b/internal/tui/keybinding_help.go
@@ -50,6 +50,7 @@ var keybindingGroups = []keybindingGroup{
 			{"PgUp / PgDn", "scroll the transcript by a page"},
 			{"↑ / ↓", "scroll, or move within a popup / multi-line input"},
 			{"Ctrl+O", "toggle the detailed (full-screen) transcript"},
+			{"Ctrl+B", "hide / show the right context sidebar"},
 			{"Ctrl+E", "release the mouse to drag-select & copy text"},
 			{"Tab", "accept the autocomplete / picker selection"},
 		},

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -14,7 +14,7 @@ func TestTranscriptFrameLayoutPinsMainRegions(t *testing.T) {
 	m.providerName = "openai"
 	m.modelName = "gpt-4.1"
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 
 	if frame.headerRect != (tuiRect{width: width, height: len(frame.headerLines)}) {
@@ -46,7 +46,7 @@ func TestTranscriptFrameLayoutClipsFooterInTinyTerminal(t *testing.T) {
 	m.copyStatus = "Copied!"
 	m.input.SetValue("Create a book library dashboard page with cards, filters, charts, and responsive behavior.")
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 
 	if frame.bodyRect.height != 1 {
@@ -80,7 +80,7 @@ func TestTranscriptFrameLayoutHandlesDegenerateDimensions(t *testing.T) {
 			m.width = size.width
 			m.height = size.height
 
-			width := chatWidth(m.width)
+			width := m.chatColumnWidth()
 			frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 			if width <= 0 {
 				t.Fatalf("chatWidth(%d) = %d, want positive fallback", size.width, width)
@@ -101,7 +101,7 @@ func TestFrameComposerRegionDrivesMouseHit(t *testing.T) {
 	m.height = 20
 	m.input.SetValue("Create a book library dashboard page with cards, filters, charts, and responsive behavior.")
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	if frame.composerRect.height <= 0 {
 		t.Fatalf("expected visible composer rect, frame=%#v", frame)
@@ -119,7 +119,7 @@ func TestOverlayMouseRectCentersInsideTranscriptBody(t *testing.T) {
 	m.width = 100
 	m.height = 30
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	rect := m.overlayMouseRect(5, width)
 
@@ -137,7 +137,7 @@ func TestOverlayMouseHitClampsToVisibleBody(t *testing.T) {
 	m.width = 80
 	m.height = 8
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	overlay := strings.Join([]string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"}, "\n")
 	rect := m.overlayMouseRect(len(viewLines(overlay)), width)
@@ -159,7 +159,7 @@ func TestTranscriptLineAtMouseUsesFrameBodyRegion(t *testing.T) {
 	m.height = 12
 	m.transcript = appendRow(m.transcript, rowUser, "target text")
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	body, selectable := m.transcriptBody(width, "")
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	start, _, _ := transcriptViewportStartForFrame(body, frame, m.chatScrollOffset)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -134,7 +134,12 @@ type model struct {
 	// (ripple.go). Reusing the spinner's existing tick keeps a single ~80ms timer
 	// driving both the braille glyph and the colour wave — no second ticker.
 	spinnerPhase int
-	pending      bool
+	// spinnerTicking tracks whether the spinner's self-scheduling tick loop is
+	// currently alive, so a kick (ensureSpinnerTick) never double-issues the tick
+	// when the loop is already running. Set true whenever a Tick cmd is returned
+	// from the TickMsg handler / beginRun, cleared when the handler stops the loop.
+	spinnerTicking bool
+	pending        bool
 	// turnStartedAt is when the in-flight run began; the working status line
 	// renders the live elapsed time from it so a long or stalled turn never looks
 	// like a frozen terminal (for ANY provider, not just slow ones). Zero = idle.
@@ -1250,10 +1255,21 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case spinner.TickMsg:
 		// Not forwarding the tick while idle stops the spinner's self-scheduling,
-		// so no timer fires between runs.
+		// so no timer fires between runs. The one exception is an active sidebar
+		// holding agents: their cool ripple animation needs the phase to keep
+		// advancing even when no run is pending, so the tick loop stays alive while
+		// sidebarHasAgents() holds (and stops the moment the agents/sidebar clear).
 		if !m.pending && !m.compactInFlight && !m.doctorInFlight {
+			if m.sidebarHasAgents() && !m.reducedMotion {
+				m.spinner, _ = m.spinner.Update(msg)
+				m.spinnerPhase++
+				m.spinnerTicking = true
+				return m, m.spinner.Tick
+			}
+			m.spinnerTicking = false
 			return m, nil
 		}
+		m.spinnerTicking = true
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
 		// Advance the shared ripple phase in lock-step with the spinner glyph;
@@ -1302,7 +1318,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.headerPrinted = true
 			m.flushQueue = append(m.flushQueue, m.titleBar(chatWidth(msg.Width)))
 		}
-		return m, nil
+		// A resumed/idle session may already hold sidebar agents now that geometry
+		// (and thus sidebarActive) is known; kick the ripple tick loop if so. No-op
+		// when the loop is already running or there is nothing to animate.
+		return m, m.ensureSpinnerTick()
 	case permissionRequestMsg:
 		if msg.runID != m.activeRunID {
 			return m, nil
@@ -3209,7 +3228,22 @@ func (m model) beginRun(cancel context.CancelFunc) model {
 	m.specialists.clear()
 	m.plan.clear()
 	m.turnStartedAt = m.now()
+	m.spinnerTicking = true
 	return m
+}
+
+// ensureSpinnerTick returns the spinner.Tick cmd to (re)start the self-scheduling
+// tick loop when an active sidebar holds agents to animate but the loop is not
+// already running (e.g. a resumed session whose swarm members exist before any
+// run started this process). It returns nil — issuing no second timer — when the
+// loop is already alive, when reduced motion is set, or when there is nothing to
+// animate, so an idle plain session schedules no timer.
+func (m *model) ensureSpinnerTick() tea.Cmd {
+	if m.spinnerTicking || m.reducedMotion || !m.sidebarHasAgents() {
+		return nil
+	}
+	m.spinnerTicking = true
+	return m.spinner.Tick
 }
 
 func (m model) launchQueuedMessageIfReady() (model, tea.Cmd) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1867,9 +1867,9 @@ func (m model) composerIdleHint() string {
 	case tierNarrow:
 		hint = "? shortcuts"
 	case tierMedium:
-		hint = "? shortcuts · Ctrl+B sidebar · Shift+Tab mode"
+		hint = "? shortcuts · Ctrl+B sidebar · Ctrl+E copy"
 	default:
-		hint = "? shortcuts · Ctrl+B sidebar · Ctrl+O detail · Shift+Tab mode"
+		hint = "? shortcuts · Ctrl+B sidebar · Ctrl+O detail · Ctrl+E copy · Shift+Tab mode"
 	}
 	return zeroTheme.faint.Render(hint)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -172,7 +172,16 @@ type model struct {
 	// hidePinnedPlan suppresses the pinned plan panel above the composer. Set on
 	// the chat-column model copy in the two-column layout, where the plan is
 	// surfaced in the context sidebar instead so it isn't shown twice.
-	hidePinnedPlan   bool
+	hidePinnedPlan bool
+	// sidebarHidden is the user's Ctrl+B preference to collapse the right context
+	// sidebar; when set, the chat reflows to full width. Distinct from the
+	// availability conditions in sidebarAvailable (geometry / mode / overlays).
+	sidebarHidden bool
+	// swarmDoneAt records when each swarm member was first seen finished (done/
+	// failed) in a swarm_status report, so the sidebar can linger it briefly with a
+	// fading ✓ before dropping it (a smooth exit, not an abrupt pop). Stamped in the
+	// spinner tick; keyed by member id. Always non-nil (initialised in newModel).
+	swarmDoneAt      map[string]time.Time
 	now              func() time.Time
 	chatScrollOffset int
 	// chatBodyLines is the live body's line count at the last update; used to pin
@@ -544,6 +553,7 @@ func newModel(ctx context.Context, options Options) model {
 	m := model{
 		ctx:                    ctx,
 		cwd:                    cwd,
+		swarmDoneAt:            map[string]time.Time{},
 		userCommands:           loadedUserCommands,
 		composerCursorVisible:  true,
 		userConfigPath:         options.UserConfigPath,
@@ -1011,6 +1021,23 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.plan.expanded = !m.plan.expanded
 				return m, nil
 			}
+		case keyCtrl(msg, 'b'):
+			// Ctrl+B collapses / restores the right context sidebar. Only acts when
+			// the sidebar would otherwise be on screen (managed mode, wide enough,
+			// real conversation) so it's a no-op — not a confusing notice — on the
+			// home screen or a narrow terminal. Hiding reflows the chat to full
+			// width, so mirror the width-change bookkeeping (re-wrap the streaming
+			// fade, resize the composer) the WindowSizeMsg path does.
+			if m.noBlockingModal() && m.sidebarAvailable() {
+				m.sidebarHidden = !m.sidebarHidden
+				m.lineAges = nil
+				m.input.SetWidth(maxInt(20, m.chatColumnWidth()-14))
+				notice := "Context sidebar shown · Ctrl+B to hide"
+				if m.sidebarHidden {
+					notice = "Context sidebar hidden · Ctrl+B to show"
+				}
+				return m.appendSystemNotice(notice), nil
+			}
 		case keyCtrl(msg, 'f'):
 			if m.picker != nil && m.picker.kind == pickerModel {
 				if m.modelPickerIsLoading() {
@@ -1254,6 +1281,10 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.streamingReasoning += msg.delta
 		return m, nil
 	case spinner.TickMsg:
+		// Record when swarm members first finish so the sidebar can linger them
+		// with a fading ✓ before removal. Cheap (the tick only fires while a run is
+		// in flight or the sidebar holds agents — exactly when this can change).
+		m.stampSwarmDone()
 		// Not forwarding the tick while idle stops the spinner's self-scheduling,
 		// so no timer fires between runs. The one exception is an active sidebar
 		// holding agents: their cool ripple animation needs the phase to keep
@@ -1792,12 +1823,16 @@ func (m model) footerView(width int) string {
 		footer.WriteString(plan)
 		footer.WriteString("\n")
 	}
+	// The row above the composer: transient copy feedback takes priority; otherwise
+	// a faint idle affordance — discoverable key hints on the left, a jump-to-bottom
+	// cue on the right when scrolled up. Always one line (blank when nothing shows),
+	// so the footer height is unchanged.
 	if copyStatus := strings.TrimSpace(m.copyStatus); copyStatus != "" {
 		footer.WriteString(rightAlignedLine(zeroTheme.ink.Render(copyStatus), width))
-		footer.WriteString("\n")
-	} else {
-		footer.WriteString("\n")
+	} else if left, right := m.composerIdleHint(), m.jumpToBottomHint(); left != "" || right != "" {
+		footer.WriteString(fitStyledLine(joinHeaderLine("  "+left, right, width), width))
 	}
+	footer.WriteString("\n")
 	footer.WriteString(m.composerBox(width))
 	if hint := m.composerDescriptionHint(width); hint != "" {
 		footer.WriteString("\n")
@@ -1810,6 +1845,43 @@ func (m model) footerView(width int) string {
 	footer.WriteString("\n")
 	footer.WriteString(m.statusLine(width))
 	return footer.String()
+}
+
+// composerIdleHint returns a faint one-line key-shortcut hint shown above the
+// composer on an empty, idle prompt, so the chord bindings are discoverable
+// without opening the ? overlay. Empty while typing, during a run, in the
+// full-screen transcript, or under any modal/overlay so it never competes for
+// attention. Width-tiered so a narrow terminal only shows the essential pointer.
+func (m model) composerIdleHint() string {
+	// Managed (alt-screen) mode only: inline mode prints to native scrollback where
+	// this footer row isn't a stable surface. Hidden while typing, during a run, in
+	// the full-screen transcript, or under any modal/overlay.
+	if !m.altScreen || m.pending || m.composerValue() != "" || !m.noBlockingModal() ||
+		m.subchat.active || m.suggestionsActive() || m.transcriptDetailed {
+		return ""
+	}
+	var hint string
+	switch widthTier(m.width) {
+	case tierTiny:
+		return "" // too cramped for a hint
+	case tierNarrow:
+		hint = "? shortcuts"
+	case tierMedium:
+		hint = "? shortcuts · Ctrl+B sidebar · Shift+Tab mode"
+	default:
+		hint = "? shortcuts · Ctrl+B sidebar · Ctrl+O detail · Shift+Tab mode"
+	}
+	return zeroTheme.faint.Render(hint)
+}
+
+// jumpToBottomHint returns a faint "↓ N more · PgDn" cue when the transcript is
+// scrolled up (chatScrollOffset counts lines below the fold), so it's clear new
+// output may be below and how to catch up. Empty at the bottom.
+func (m model) jumpToBottomHint() string {
+	if m.chatScrollOffset <= 0 {
+		return ""
+	}
+	return zeroTheme.faint.Render(fmt.Sprintf("↓ %d more · PgDn", m.chatScrollOffset))
 }
 
 // pinnedPlanMaxHeight is the line budget for the pinned plan panel: at most a
@@ -2186,7 +2258,7 @@ func (m model) interimBlock(width int) string {
 		// branch keep rendering identically to before.
 		lines[index] = m.styleStreamingLine(line, index, len(lines))
 	}
-	lines = appendStreamingCursor(lines, width)
+	lines = m.appendStreamingCursor(lines, width)
 	blocks = append(blocks, strings.Join(lines, "\n"))
 	// Live preview of a file currently being written, so a long write_file/edit
 	// shows the code streaming in rather than looking frozen.
@@ -2288,8 +2360,14 @@ func previewTail(s string, width int) string {
 	return "…" + string(runes[len(runes)-(width-1):])
 }
 
-func appendStreamingCursor(lines []string, width int) []string {
+func (m model) appendStreamingCursor(lines []string, width int) []string {
+	// Pulse the caret on the shared spinner clock so the typing edge reads as alive
+	// even during fade-tick gaps or upstream stalls. Width-stable (bright ↔ dim,
+	// never on/off, so the line never jitters). Steady bright under reduced motion.
 	cursor := zeroTheme.accent.Render("▌")
+	if !m.reducedMotion && (m.spinnerPhase/6)%2 == 1 {
+		cursor = zeroTheme.faint.Render("▌")
+	}
 	if len(lines) == 0 {
 		return []string{cursor}
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -129,7 +129,12 @@ type model struct {
 	// with each run and stops itself once pending clears (the TickMsg is simply
 	// not forwarded), so an idle UI schedules no timers.
 	spinner spinner.Model
-	pending bool
+	// spinnerPhase advances once per spinner tick while a run is in flight and is
+	// the shared animation clock for the cosine ripple on the working status line
+	// (ripple.go). Reusing the spinner's existing tick keeps a single ~80ms timer
+	// driving both the braille glyph and the colour wave — no second ticker.
+	spinnerPhase int
+	pending      bool
 	// turnStartedAt is when the in-flight run began; the working status line
 	// renders the live elapsed time from it so a long or stalled turn never looks
 	// like a frozen terminal (for ANY provider, not just slow ones). Zero = idle.
@@ -159,8 +164,12 @@ type model struct {
 	pendingSpecReview *pendingSpecReviewPrompt
 	width             int
 	height            int
-	now               func() time.Time
-	chatScrollOffset  int
+	// hidePinnedPlan suppresses the pinned plan panel above the composer. Set on
+	// the chat-column model copy in the two-column layout, where the plan is
+	// surfaced in the context sidebar instead so it isn't shown twice.
+	hidePinnedPlan   bool
+	now              func() time.Time
+	chatScrollOffset int
 	// chatBodyLines is the live body's line count at the last update; used to pin
 	// the viewport (hold the read position) when content streams in while the user
 	// has scrolled up. 0 means "at the bottom / not pinned".
@@ -1247,6 +1256,11 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
+		// Advance the shared ripple phase in lock-step with the spinner glyph;
+		// frozen under reduced motion so the colour wave stops with the glyph.
+		if !m.reducedMotion {
+			m.spinnerPhase++
+		}
 		if m.compactInFlight {
 			if !m.reducedMotion {
 				m.compactFrame++ // frozen frame under reduced motion -> static ring
@@ -1391,6 +1405,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.runCancel = nil
 		m.activeRunID = 0
+		m.plan.frozenAt = m.now() // freeze the plan clock while idle (no run in flight)
 		m.pendingPermission = nil
 		m.pendingAskUser = nil
 		for _, event := range msg.usageEvents {
@@ -1634,6 +1649,15 @@ func (m model) transcriptEmpty() bool {
 // the managed conversation view. Streaming/modal blocks and composer chrome are
 // always rendered here.
 func (m model) transcriptView() string {
+	// Two-column layout: in alt-screen managed mode on a wide-enough terminal,
+	// the chat renders into a left column and a context sidebar (FILES / PLAN /
+	// tokens) into a right column. The chat is rendered by the existing scroll
+	// engine at the reduced column width via a model copy, then joined with the
+	// sidebar row-by-row. The subchat drill-in keeps its own single-column view.
+	if m.sidebarActive() && !m.subchat.active {
+		return m.twoColumnTranscriptView()
+	}
+
 	width := chatWidth(m.width)
 
 	// Subchat drill-in: when active, show the child session's transcript with
@@ -1695,6 +1719,36 @@ func (m model) transcriptView() string {
 		body += "\n" + overlayForViewport + "\n"
 	}
 	return body + footer
+}
+
+// twoColumnTranscriptView renders the alt-screen chat into a left column and
+// the context sidebar (FILES / PLAN / tokens) into a right column. The chat is
+// produced by the existing scroll engine at the reduced chat-column width (via
+// chatColumnWidth, which every frame/geometry caller already routes through),
+// yielding exactly m.height lines at the column width; the sidebar block is
+// built to the same height and joined row-by-row. Overlays/wizards never reach
+// here — sidebarActive() returns false while any is up, falling back to the
+// single-column path. Caller guarantees sidebarActive() && !subchat.active.
+func (m model) twoColumnTranscriptView() string {
+	chatW := m.chatColumnWidth()
+	sidebarW := sidebarWidth(m.width)
+
+	width := chatW
+
+	suggestionOverlay := m.suggestionOverlay(width)
+	bodyItems := m.transcriptBodyItems(width, "")
+	footer := m.footerView(width)
+	overlayForViewport := suggestionOverlay
+	if m.transcriptEmpty() && !m.pending {
+		overlayForViewport = ""
+	}
+
+	header := m.pinnedTitleBar(width)
+	chatBlock := viewLines(m.scrollableTranscriptItemsView(header, bodyItems, footer, width, overlayForViewport))
+
+	sidebar := m.renderContextSidebar(sidebarW, len(chatBlock))
+	rows := joinColumns(chatBlock, sidebar, chatW, sidebarW)
+	return strings.Join(rows, "\n")
 }
 
 func (m model) titleBarInTranscriptBody() bool {
@@ -1813,7 +1867,7 @@ func (m model) scrollableTranscriptFrame(header string, footer string) transcrip
 	if bodyHeight < 1 {
 		bodyHeight = 1
 	}
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	footerTop := len(headerLines) + bodyHeight
 	frame := transcriptFrameLayout{
 		width:           width,
@@ -2027,7 +2081,7 @@ func (m model) chatTranscriptViewport() (transcriptViewport, bool) {
 	if !m.altScreen || m.height <= 0 {
 		return transcriptViewport{}, false
 	}
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	items := m.transcriptBodyItems(width, "")
 	body := measureTranscriptBodyItems(items, m.transcriptBodyHeights)
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
@@ -2144,9 +2198,19 @@ func (m model) spinnerGlyph() string {
 }
 
 func (m model) workingStatusLine() string {
-	line := zeroTheme.accent.Render(m.spinnerGlyph()) + " " + zeroTheme.muted.Render("Working")
+	// Cosine ripple FX: "Working" breathes through a cold-to-warm theme ramp, the
+	// wave moving one character per spinner tick (shared m.spinnerPhase clock). A
+	// 6-char wavelength fits the 7-letter word so a full oscillation is visible.
+	// Under reduced motion the phase is frozen, so this renders a static gradient.
+	working := rippleText("Working", ripplePalette(), m.spinnerPhase, 6)
+	line := zeroTheme.accent.Render(m.spinnerGlyph()) + " " + working
 	if !m.turnStartedAt.IsZero() {
 		line += zeroTheme.faint.Render("  ·  " + formatWorkingElapsed(m.now().Sub(m.turnStartedAt)))
+	}
+	// Compact "↑ from-to/total ↓" scroll indicator for the in-flight transcript,
+	// so a long multi-tool run shows which slice the working line reports on.
+	if indicator := m.transcriptPhaseIndicator(); indicator != "" {
+		line += " " + zeroTheme.faint.Render(indicator)
 	}
 	return line
 }
@@ -3240,6 +3304,7 @@ func (m *model) cancelRun() {
 	m.pending = false
 	m.runCancel = nil
 	m.activeRunID = 0
+	m.plan.frozenAt = m.now() // freeze the plan clock while idle (no run in flight)
 	m.pendingPermission = nil
 	m.pendingAskUser = nil
 	// The interim block renders streamingText live; a cancelled run's partial

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2288,6 +2288,17 @@ func (m model) spinnerGlyph() string {
 	return m.spinner.View()
 }
 
+// workingActivity labels what the agent is doing right now for the working
+// status line: "writing" while the final answer streams, otherwise "thinking"
+// (reasoning, waiting on the model, or a tool in flight). Cheap and robust — no
+// transcript scan — so it can't misreport on a long, output-less step.
+func (m model) workingActivity() string {
+	if strings.TrimSpace(m.streamingText) != "" {
+		return "writing"
+	}
+	return "thinking"
+}
+
 func (m model) workingStatusLine() string {
 	// Cosine ripple FX: "Working" breathes through a cold-to-warm theme ramp, the
 	// wave moving one character per spinner tick (shared m.spinnerPhase clock). A
@@ -2295,6 +2306,10 @@ func (m model) workingStatusLine() string {
 	// Under reduced motion the phase is frozen, so this renders a static gradient.
 	working := rippleText("Working", ripplePalette(), m.spinnerPhase, 6)
 	line := zeroTheme.accent.Render(m.spinnerGlyph()) + " " + working
+	// Phase label so a long, output-less step reads as live progress rather than a
+	// frozen screen: "writing" while the answer streams, "thinking" otherwise
+	// (reasoning, waiting on the model, or running a tool).
+	line += zeroTheme.faint.Render("  ·  " + m.workingActivity())
 	if !m.turnStartedAt.IsZero() {
 		line += zeroTheme.faint.Render("  ·  " + formatWorkingElapsed(m.now().Sub(m.turnStartedAt)))
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1710,6 +1710,84 @@ func TestCtrlCExitConfirmationExpires(t *testing.T) {
 	}
 }
 
+func TestTranscriptReadingColumnHelpers(t *testing.T) {
+	if g := transcriptGutter(160); g != 4 {
+		t.Fatalf("wide gutter = %d, want 4", g)
+	}
+	if cw := transcriptContentWidth(160); cw != transcriptContentCap {
+		t.Fatalf("wide contentWidth = %d, want cap %d", cw, transcriptContentCap)
+	}
+	if g := transcriptGutter(70); g != 0 {
+		t.Fatalf("narrow gutter = %d, want 0", g)
+	}
+	if cw := transcriptContentWidth(70); cw != 70 {
+		t.Fatalf("narrow contentWidth = %d, want full 70", cw)
+	}
+}
+
+func TestTranscriptBodyRowsUseReadingColumnAndAlignSelection(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 160, 30
+	m.altScreen = true
+	m.transcript = append(m.transcript, transcriptRow{
+		kind: rowAssistant, text: strings.Repeat("word ", 60), final: true,
+	})
+
+	width := m.chatColumnWidth()
+	gutter := transcriptGutter(width)
+	if gutter <= 0 {
+		t.Fatalf("expected a gutter at width %d", width)
+	}
+
+	items := m.transcriptBodyItems(width, "")
+	var row *transcriptBodyItem
+	for i := range items {
+		if items[i].kind == transcriptBodyItemRow && items[i].rowIndex >= 0 {
+			row = &items[i]
+		}
+	}
+	if row == nil {
+		t.Fatal("no assistant row item found")
+	}
+	rendered := row.render(0)
+
+	wroteIndented := false
+	for _, line := range rendered.lines {
+		if w := lipgloss.Width(line); w > transcriptContentCap+gutter {
+			t.Fatalf("body line width %d exceeds reading column %d: %q", w, transcriptContentCap+gutter, line)
+		}
+		if strings.TrimSpace(line) != "" {
+			if !strings.HasPrefix(line, strings.Repeat(" ", gutter)) {
+				t.Fatalf("non-blank body line is not gutter-indented: %q", line)
+			}
+			wroteIndented = true
+		}
+	}
+	if !wroteIndented {
+		t.Fatal("expected at least one indented content line")
+	}
+	// Selection alignment: text-carrying selectable lines start at/after the gutter
+	// so click-to-select and the highlight track the indented glyphs.
+	for _, sl := range rendered.selectable {
+		if sl.text != "" && sl.textStart < gutter {
+			t.Fatalf("selectable textStart %d < gutter %d — selection would misalign", sl.textStart, gutter)
+		}
+	}
+}
+
+func TestMarkdownAddsBlankBeforeHeadingAndParagraph(t *testing.T) {
+	lines := renderAssistantMarkdownText("First paragraph.\n## Heading\nSecond body.", 80, 80, false)
+	headingIdx := -1
+	for i, l := range lines {
+		if strings.Contains(l, "Heading") {
+			headingIdx = i
+		}
+	}
+	if headingIdx <= 0 || strings.TrimSpace(lines[headingIdx-1]) != "" {
+		t.Fatalf("expected a blank line before the heading, got %#v", lines)
+	}
+}
+
 func TestComposerIdleHintAndJumpCue(t *testing.T) {
 	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
 	m.altScreen = true

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1710,17 +1710,23 @@ func TestCtrlCExitConfirmationExpires(t *testing.T) {
 	}
 }
 
-func TestRunCancelledRendersPlainColoredLineNotBox(t *testing.T) {
-	got := plainRender(t, renderSystemNote("Run cancelled.", 80))
-	if strings.ContainsAny(got, "│╭╮╰╯") {
-		t.Fatalf("cancellation should be a plain line, not a box: %q", got)
+func TestSystemNotesRenderPlainLinesNotBoxes(t *testing.T) {
+	cancel := plainRender(t, renderSystemNote("Run cancelled.", 80))
+	if strings.ContainsAny(cancel, "│╭╮╰╯") {
+		t.Fatalf("cancellation should be a plain line, not a box: %q", cancel)
 	}
-	if !strings.Contains(got, "Run cancelled.") {
-		t.Fatalf("cancellation text missing: %q", got)
+	if !strings.Contains(cancel, "Run cancelled.") {
+		t.Fatalf("cancellation text missing: %q", cancel)
 	}
-	// A regular system notice keeps the bordered box.
-	if boxed := plainRender(t, renderSystemNote("Mode set to ask.", 80)); !strings.Contains(boxed, "│") {
-		t.Fatalf("regular notice should stay boxed: %q", boxed)
+	// Every other system notice is ALSO a boxless plain line now.
+	for _, note := range []string{"Mouse interaction re-enabled.", "Mode set to ask."} {
+		got := plainRender(t, renderSystemNote(note, 80))
+		if strings.ContainsAny(got, "│╭╮╰╯") {
+			t.Fatalf("system notice should be a plain line, not a box: %q", got)
+		}
+		if !strings.Contains(got, note) {
+			t.Fatalf("notice text missing: %q", got)
+		}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -12,6 +12,7 @@ import (
 
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/Gitlawb/zero/internal/agent"
 	"github.com/Gitlawb/zero/internal/config"
@@ -1474,7 +1475,8 @@ func TestAgentEventRenderingMappingCoversRuntimeContract(t *testing.T) {
 	}
 	assertContains(t, m.usageStatusSegment(), "120 tok")
 	assertContains(t, m.composerDividerLine(96), "gpt-4.1")
-	assertContains(t, m.composerDividerLine(96), "ask")
+	// Permission mode moved from the composer rule to the status line.
+	assertContains(t, m.statusLine(96), "ask")
 }
 
 func TestToolResultRowDefaultsEmptyStatusToOK(t *testing.T) {
@@ -1666,8 +1668,10 @@ func TestCtrlCClearsComposerBeforeExitConfirmation(t *testing.T) {
 		t.Fatal("Ctrl+C with a draft should not mark model exiting")
 	}
 	status := plainRender(t, next.statusLine(80))
-	if strings.Contains(status, ctrlCExitConfirmText) || !strings.Contains(status, "tokenrouter") {
-		t.Fatalf("status line = %q, want provider restored with no exit confirmation", status)
+	// No exit confirmation armed, so the normal run-state chip shows (the status
+	// line carries the permission mode now, not the provider).
+	if strings.Contains(status, ctrlCExitConfirmText) || !strings.Contains(status, "auto-approve") {
+		t.Fatalf("status line = %q, want the run-state chip with no exit confirmation", status)
 	}
 
 	updated, cmd = next.Update(testKeyCtrl('c'))
@@ -1699,8 +1703,50 @@ func TestCtrlCExitConfirmationExpires(t *testing.T) {
 		t.Fatal("matching expiry should clear exit confirmation")
 	}
 	status := plainRender(t, next.statusLine(80))
-	if strings.Contains(status, ctrlCExitConfirmText) || !strings.Contains(status, "tokenrouter") {
-		t.Fatalf("status line after expiry = %q, want provider restored", status)
+	// After expiry the warning clears and the normal run-state chip is restored
+	// (the status line now shows the permission mode, not the provider).
+	if strings.Contains(status, ctrlCExitConfirmText) || !strings.Contains(status, "auto-approve") {
+		t.Fatalf("status line after expiry = %q, want the run-state chip restored", status)
+	}
+}
+
+func TestComposerIdleHintAndJumpCue(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.altScreen = true
+	m.width, m.height = 100, 30
+	m.transcript = append(m.transcript, transcriptRow{kind: rowAssistant, text: "hi", final: true})
+
+	// Idle, empty composer, managed mode -> the discoverability hint shows.
+	if h := plainRender(t, m.composerIdleHint()); !strings.Contains(h, "shortcuts") {
+		t.Fatalf("expected idle hint, got %q", h)
+	}
+	// Hidden during a run.
+	busy := m
+	busy.pending = true
+	if h := busy.composerIdleHint(); h != "" {
+		t.Fatalf("hint should hide during a run, got %q", h)
+	}
+	// Hidden in inline mode.
+	inline := m
+	inline.altScreen = false
+	if h := inline.composerIdleHint(); h != "" {
+		t.Fatalf("hint should hide in inline mode, got %q", h)
+	}
+	// Jump cue only when scrolled up.
+	if c := m.jumpToBottomHint(); c != "" {
+		t.Fatalf("jump cue should be empty at the bottom, got %q", c)
+	}
+	scrolled := m
+	scrolled.chatScrollOffset = 5
+	if c := plainRender(t, scrolled.jumpToBottomHint()); !strings.Contains(c, "5 more") {
+		t.Fatalf("expected jump cue with line count, got %q", c)
+	}
+	// The footer carrying the hint must never overflow its width.
+	w := m.chatColumnWidth()
+	for i, line := range strings.Split(plainRender(t, m.footerView(w)), "\n") {
+		if got := lipgloss.Width(line); got > w {
+			t.Fatalf("footer line %d width %d > %d: %q", i, got, w, line)
+		}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1710,6 +1710,44 @@ func TestCtrlCExitConfirmationExpires(t *testing.T) {
 	}
 }
 
+func TestRunCancelledRendersPlainColoredLineNotBox(t *testing.T) {
+	got := plainRender(t, renderSystemNote("Run cancelled.", 80))
+	if strings.ContainsAny(got, "│╭╮╰╯") {
+		t.Fatalf("cancellation should be a plain line, not a box: %q", got)
+	}
+	if !strings.Contains(got, "Run cancelled.") {
+		t.Fatalf("cancellation text missing: %q", got)
+	}
+	// A regular system notice keeps the bordered box.
+	if boxed := plainRender(t, renderSystemNote("Mode set to ask.", 80)); !strings.Contains(boxed, "│") {
+		t.Fatalf("regular notice should stay boxed: %q", boxed)
+	}
+}
+
+func TestSpecialistCardLinesAreSelectableForCopy(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width = 120
+	row := transcriptRow{kind: rowSpecialist, specialistInfo: &specialistInfo{
+		name: "explorer", description: "audit the code", status: specialistCompleted, childSessionID: "sess-x",
+	}}
+	rendered, selectable := m.renderSelectableSpecialistRow(0, row, 100, buildRowContext(nil), 0)
+	if rendered == "" || len(selectable) == 0 {
+		t.Fatal("expected a rendered specialist card with selectable lines")
+	}
+	hasText := false
+	for _, sl := range selectable {
+		if !sl.specialistCard {
+			t.Fatalf("card line lost its specialistCard click flag: %+v", sl)
+		}
+		if sl.text != "" {
+			hasText = true
+		}
+	}
+	if !hasText {
+		t.Fatal("specialist card lines must carry text so a dragged selection copies them")
+	}
+}
+
 func TestTranscriptReadingColumnHelpers(t *testing.T) {
 	if g := transcriptGutter(160); g != 4 {
 		t.Fatalf("wide gutter = %d, want 4", g)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1754,6 +1754,29 @@ func TestSpecialistCardLinesAreSelectableForCopy(t *testing.T) {
 	}
 }
 
+func TestSelectionHighlightUsesGutterShiftedCoordinate(t *testing.T) {
+	// Select screen columns 10..15 on body line 0. With a 4-cell reading gutter the
+	// rendered line is "    Hello world" and columns 10-14 are "world", so the
+	// highlight must land on "world" — proving it's computed in the SAME shifted
+	// coordinate the mouse uses. The old bug painted it on the unshifted line, so it
+	// landed gutter cells off.
+	var m model
+	m.transcriptSelection = transcriptSelectionState{
+		active: true,
+		anchor: transcriptSelectionPoint{bodyY: 0, x: 10},
+		cursor: transcriptSelectionPoint{bodyY: 0, x: 15},
+	}
+	selectable := []transcriptSelectableLine{{bodyY: 0, rowIndex: 0, text: "Hello world", textStart: 0}}
+	item := m.finalizeTranscriptBodyRow("Hello world", selectable, 4, 0)
+	styled := strings.Join(item.lines, "\n")
+	if !strings.Contains(plainRender(t, styled), "    Hello world") {
+		t.Fatalf("expected a 4-cell gutter-padded line, got %q", styled)
+	}
+	if !strings.Contains(styled, zeroTheme.selection.Render("world")) {
+		t.Fatalf("expected 'world' highlighted at the gutter-shifted position, got %q", styled)
+	}
+}
+
 func TestReasoningAfterToolCardGetsBlankSeparator(t *testing.T) {
 	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
 	m.width, m.height = 120, 40

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1849,7 +1849,9 @@ func TestMarkdownAddsBlankBeforeHeadingAndParagraph(t *testing.T) {
 	lines := renderAssistantMarkdownText("First paragraph.\n## Heading\nSecond body.", 80, 80, false)
 	headingIdx := -1
 	for i, l := range lines {
-		if strings.Contains(l, "Heading") {
+		// Headings render accent+bold+underline (per-grapheme ANSI), so strip styling
+		// before matching the text.
+		if strings.Contains(plainRender(t, l), "Heading") {
 			headingIdx = i
 		}
 	}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1754,6 +1754,32 @@ func TestSpecialistCardLinesAreSelectableForCopy(t *testing.T) {
 	}
 }
 
+func TestReasoningAfterToolCardGetsBlankSeparator(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "gpt-4"})
+	m.width, m.height = 120, 40
+	m.altScreen = true
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowUser, text: "do it"},
+		transcriptRow{kind: rowToolResult, id: "t1", tool: "list_directory", status: tools.StatusOK, detail: "a\nb"},
+		transcriptRow{kind: rowReasoning, text: "Considering the next step in detail before acting"},
+		transcriptRow{kind: rowToolResult, id: "t2", tool: "read_file", status: tools.StatusOK, detail: "x\ny"},
+	)
+	items := m.transcriptBodyItems(m.chatColumnWidth(), "")
+	reasoningIdx := -1
+	for i := range items {
+		if items[i].rowIndex >= 0 && items[i].rowIndex < len(m.transcript) &&
+			m.transcript[items[i].rowIndex].kind == rowReasoning {
+			reasoningIdx = i
+		}
+	}
+	if reasoningIdx <= 0 {
+		t.Fatal("reasoning item not found in the body")
+	}
+	if items[reasoningIdx-1].kind != transcriptBodyItemSeparator {
+		t.Fatalf("expected a blank separator before the reasoning group, got kind %v", items[reasoningIdx-1].kind)
+	}
+}
+
 func TestTranscriptReadingColumnHelpers(t *testing.T) {
 	if g := transcriptGutter(160); g != 4 {
 		t.Fatalf("wide gutter = %d, want 4", g)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -192,7 +192,7 @@ func (m model) mouseOverComposer(msg tea.MouseMsg) bool {
 	if !m.altScreen || m.height <= 0 {
 		return false
 	}
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	return frame.composerRect.contains(mouseX(msg), mouseY(msg))
 }

--- a/internal/tui/mouse_test.go
+++ b/internal/tui/mouse_test.go
@@ -19,7 +19,7 @@ func TestMouseClickSelectsThenAppliesCommandSuggestionRow(t *testing.T) {
 		t.Fatalf("expected command suggestions, got %#v", m.suggestions)
 	}
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	top := m.overlayMouseTop(len(viewLines(m.suggestionOverlay(width))), width)
 	click := testMouseClick(tea.MouseLeft, width/2, top+3)
 	updated, cmd := m.Update(click)
@@ -60,7 +60,7 @@ func TestMouseClickSelectsThenAppliesPickerRow(t *testing.T) {
 	m.picker.allItems = append([]pickerItem{}, m.picker.items...)
 	m.mouseCapture = true
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	top := m.overlayMouseTop(len(viewLines(m.pickerOverlay(width))), width)
 	click := testMouseClick(tea.MouseLeft, width/2, top+3)
 	updated, cmd := m.Update(click)
@@ -95,7 +95,7 @@ func TestMouseClickSelectsProviderWizardRow(t *testing.T) {
 	}
 	m.mouseCapture = true
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	top := m.overlayMouseTop(len(viewLines(m.providerWizardOverlay(width))), width)
 	click := testMouseClick(tea.MouseLeft, width/2, top+5)
 	updated, cmd := m.Update(click)
@@ -139,7 +139,7 @@ func TestMouseClickSelectsThenContinuesSetupProviderRow(t *testing.T) {
 	m.mouseCapture = true
 	m.setup.stage = setupStageProvider
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	height := normalizedStartupHeight(m.height)
 	rowWidth := setupProviderBlockWidth(width, m.setup.providers)
 	top := setupContentTop(height, len(m.setupProviderLines(width, height)), m.setup.err != "")
@@ -174,7 +174,7 @@ func TestMouseClickSelectsThenContinuesSetupModelRow(t *testing.T) {
 	}
 	m.setup.modelForID = m.setupProviderDescriptor().ID
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	height := normalizedStartupHeight(m.height)
 	rowWidth := setupModelBlockWidth(width, m.setup.models)
 	top := setupContentTop(height, len(m.setupModelLines(width, height)), m.setup.err != "")
@@ -470,7 +470,7 @@ func TestMouseClickTogglesReasoningRow(t *testing.T) {
 	m.mouseCapture = true
 	m.transcript = appendTranscriptRow(m.transcript, transcriptRow{kind: rowReasoning, text: "private thought"})
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	body, selectable := m.transcriptBody(width, "")
 	start, _, top := m.transcriptViewportStart(body, width)
 	var target transcriptSelectableLine
@@ -504,7 +504,7 @@ func TestMouseClickTogglesStreamingReasoning(t *testing.T) {
 	m.activeRunID = 1
 	m.streamingReasoning = "private **thought**"
 
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	body, selectable := m.transcriptBody(width, "")
 	start, _, top := m.transcriptViewportStart(body, width)
 	var target transcriptSelectableLine
@@ -565,7 +565,7 @@ func TestMCPManagerMouseSelectsFirstItemRow(t *testing.T) {
 	m.width = 120
 	m.height = 36
 	m = m.openMCPManager()
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	overlay := m.mcpManagerOverlay(width)
 	lines := viewLines(overlay)
 	left, _, _ := normalizeOverlayBlock(lines, width)
@@ -586,7 +586,7 @@ func TestMCPAddWizardMouseSelectsAndActivatesType(t *testing.T) {
 	m.height = 36
 	m.mcpAddWizard = newMCPAddWizard("http")
 	m.mcpAddWizard.step = mcpAddWizardStepType
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	overlay := m.mcpAddWizardOverlay(width)
 	lines := viewLines(overlay)
 	left, _, _ := normalizeOverlayBlock(lines, width)
@@ -689,7 +689,7 @@ func firstTranscriptTextMouseY(t *testing.T, m model) int {
 
 func firstTranscriptTextMousePoint(t *testing.T, m model) (int, int) {
 	t.Helper()
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	body, selectable := m.transcriptBody(width, "")
 	start, _, top := m.transcriptViewportStart(body, width)
 	for _, line := range selectable {
@@ -703,7 +703,7 @@ func firstTranscriptTextMousePoint(t *testing.T, m model) (int, int) {
 
 func transcriptSelectableLineContaining(t *testing.T, m model, text string) transcriptSelectableLine {
 	t.Helper()
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	layout := m.transcriptBodyLayout(width, "")
 	for _, line := range layout.selectable {
 		if strings.Contains(line.text, text) {
@@ -716,7 +716,7 @@ func transcriptSelectableLineContaining(t *testing.T, m model, text string) tran
 
 func composerMousePoint(t *testing.T, m model, column int) (int, int) {
 	t.Helper()
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	if frame.composerRect.height <= 0 {
 		t.Fatalf("expected visible composer rect, frame=%#v", frame)

--- a/internal/tui/phase_indicator.go
+++ b/internal/tui/phase_indicator.go
@@ -1,0 +1,114 @@
+// phase_indicator.go renders a compact "↑ from-to/total ↓" scroll indicator for
+// the live working status line. It tells the user, at a glance, which slice of
+// the in-flight run's transcript the working line is reporting on, using the
+// tmux/Emacs mode-line convention: an up arrow when earlier rows exist, a down
+// arrow when later rows exist, both blanked at the respective edges.
+package tui
+
+import "strings"
+
+// phaseScrollIndicator renders a compact "↑ from-to/total ↓" string. The arrows
+// communicate which scroll direction is still reachable from the current
+// position:
+//
+//   - The up-arrow "↑" appears only when from > 1, i.e. there are earlier rows
+//     above the current turn boundary. It is replaced by a single space when
+//     from == 1 ("at the top, nothing to scroll up to").
+//   - The down-arrow "↓" appears only when to < total, i.e. there are later
+//     rows below the current position. It is replaced by a single space when
+//     to == total ("at the bottom").
+//
+// Trivial inputs collapse:
+//
+//   - total <= 0  ->  returns "" (nothing to indicate)
+//   - from < 1    ->  clamps from to 1
+//   - to > total  ->  clamps to to total
+//   - to < from   ->  clamps to to from
+//
+// The function is intentionally pure: three ints in, a string out, no model
+// state and no rendering-style side effects, so it is trivially unit-testable
+// and reusable from any caller.
+func phaseScrollIndicator(from, to, total int) string {
+	if total <= 0 {
+		return ""
+	}
+	if from < 1 {
+		from = 1
+	}
+	if to < from {
+		to = from
+	}
+	if to > total {
+		to = total
+	}
+
+	var b strings.Builder
+	b.WriteString(" ")
+	if from > 1 {
+		b.WriteString("↑")
+	} else {
+		b.WriteString(" ")
+	}
+	b.WriteString(" ")
+	b.WriteString(itoa(from))
+	b.WriteString("-")
+	b.WriteString(itoa(to))
+	b.WriteString("/")
+	b.WriteString(itoa(total))
+	b.WriteString(" ")
+	if to < total {
+		b.WriteString("↓")
+	} else {
+		b.WriteString(" ")
+	}
+	return b.String()
+}
+
+// itoa is a bare, dependency-free equivalent of strconv.Itoa, keeping this file
+// to a single import ("strings") so the indicator logic is a small auditable
+// surface.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	negative := n < 0
+	if negative {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if negative {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// transcriptPhaseIndicator derives (from, to, total) from m.transcript and
+// renders phaseScrollIndicator for inline use by the working status line. On an
+// empty transcript it returns "" so callers can skip the indicator without a
+// second nil check.
+func (m model) transcriptPhaseIndicator() string {
+	total := len(m.transcript)
+	if total == 0 {
+		return ""
+	}
+	// Find the boundary of the turn currently in flight: walk the transcript
+	// backwards and stop at the first turn-starting row (rowUser, rowAssistant,
+	// rowSystem, rowError per startsTurn). That row's 1-indexed position is
+	// "from".
+	from := total // fallback: a transcript with no turn start is one phase
+	for i := total - 1; i >= 0; i-- {
+		if startsTurn(m.transcript[i].kind) {
+			from = i + 1 // 1-indexed
+			break
+		}
+	}
+	to := total
+	return phaseScrollIndicator(from, to, total)
+}

--- a/internal/tui/phase_indicator_test.go
+++ b/internal/tui/phase_indicator_test.go
@@ -1,0 +1,137 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPhaseScrollIndicatorAtTopBlanksUpArrow checks that the up arrow is blanked
+// when from == 1 ("nothing to scroll up to").
+func TestPhaseScrollIndicatorAtTopBlanksUpArrow(t *testing.T) {
+	got := phaseScrollIndicator(1, 5, 20)
+	if strings.Contains(got, "↑") {
+		t.Fatalf("up arrow should be blank at top; got %q", got)
+	}
+	if !strings.Contains(got, "↓") {
+		t.Fatalf("down arrow should be present when to < total; got %q", got)
+	}
+	if !strings.Contains(got, "1-5/20") {
+		t.Fatalf("indicator should contain '1-5/20'; got %q", got)
+	}
+}
+
+// TestPhaseScrollIndicatorAtBottomBlanksDownArrow checks the symmetric case at
+// the bottom of the transcript: down arrow blanked, up arrow present.
+func TestPhaseScrollIndicatorAtBottomBlanksDownArrow(t *testing.T) {
+	got := phaseScrollIndicator(16, 20, 20)
+	if strings.Contains(got, "↓") {
+		t.Fatalf("down arrow should be blank at bottom; got %q", got)
+	}
+	if !strings.Contains(got, "↑") {
+		t.Fatalf("up arrow should be present when from > 1; got %q", got)
+	}
+	if !strings.Contains(got, "16-20/20") {
+		t.Fatalf("indicator should contain '16-20/20'; got %q", got)
+	}
+}
+
+// TestPhaseScrollIndicatorWholeTranscriptBlanksBothArrows is the degenerate case
+// for a single-screen transcript — both arrows blanked.
+func TestPhaseScrollIndicatorWholeTranscriptBlanksBothArrows(t *testing.T) {
+	got := phaseScrollIndicator(1, 20, 20)
+	if strings.Contains(got, "↑") {
+		t.Fatalf("up arrow should be blank when from == 1; got %q", got)
+	}
+	if strings.Contains(got, "↓") {
+		t.Fatalf("down arrow should be blank when to == total; got %q", got)
+	}
+	if !strings.Contains(got, "1-20/20") {
+		t.Fatalf("indicator should contain '1-20/20'; got %q", got)
+	}
+}
+
+// TestPhaseScrollIndicatorMiddleTranscriptShowsBothArrows is the in-flight case
+// the indicator is designed for: both arrows visible.
+func TestPhaseScrollIndicatorMiddleTranscriptShowsBothArrows(t *testing.T) {
+	got := phaseScrollIndicator(8, 12, 20)
+	if !strings.Contains(got, "↑ 8-12/20 ↓") {
+		t.Fatalf("mid-transcript indicator must be '↑ 8-12/20 ↓'; got %q", got)
+	}
+}
+
+// TestPhaseScrollIndicatorEmptyTranscriptReturnsEmpty asserts the safe-skip
+// contract.
+func TestPhaseScrollIndicatorEmptyTranscriptReturnsEmpty(t *testing.T) {
+	got := phaseScrollIndicator(0, 0, 0)
+	if got != "" {
+		t.Fatalf("expected \"\" for empty transcript, got %q", got)
+	}
+}
+
+// TestPhaseScrollIndicatorClampsFromBelowOne verifies from < 1 is clamped to 1.
+func TestPhaseScrollIndicatorClampsFromBelowOne(t *testing.T) {
+	got := phaseScrollIndicator(0, 5, 10)
+	if strings.Contains(got, "0-5") {
+		t.Fatalf("from must be clamped to 1, not 0; got %q", got)
+	}
+	if !strings.Contains(got, "1-5") {
+		t.Fatalf("expected '1-5' after clamp; got %q", got)
+	}
+}
+
+// TestPhaseScrollIndicatorClampsToAboveTotal verifies to > total collapses to total.
+func TestPhaseScrollIndicatorClampsToAboveTotal(t *testing.T) {
+	got := phaseScrollIndicator(2, 999, 10)
+	if strings.Contains(got, "999") {
+		t.Fatalf("to must be clamped to total; got %q", got)
+	}
+	if !strings.Contains(got, "2-10") {
+		t.Fatalf("expected '2-10' after clamp; got %q", got)
+	}
+}
+
+// TestTranscriptPhaseIndicatorEmptyTranscript verifies the method returns "" for
+// an empty transcript so the working line can skip it.
+func TestTranscriptPhaseIndicatorEmptyTranscript(t *testing.T) {
+	m := newModel(t.Context(), Options{})
+	m.transcript = nil // newModel seeds a welcome row; clear it for the empty case
+	if got := m.transcriptPhaseIndicator(); got != "" {
+		t.Fatalf("empty transcript should yield empty indicator; got %q", got)
+	}
+}
+
+// TestTranscriptPhaseIndicatorComputesFromTurnBoundary builds a small transcript
+// and verifies the indicator reflects total and the latest turn boundary.
+func TestTranscriptPhaseIndicatorComputesFromTurnBoundary(t *testing.T) {
+	m := newModel(t.Context(), Options{})
+	m.transcript = appendRow(nil, rowUser, "go")
+	m.transcript = appendRow(m.transcript, rowToolCall, "tool call: read_file")
+	m.transcript = appendRow(m.transcript, rowToolResult, "file content")
+	m.transcript = appendRow(m.transcript, rowAssistant, "thinking...")
+	m.transcript = appendRow(m.transcript, rowToolCall, "tool call: write_file")
+	// total = 5, last turn-starting row is the assistant at index 3 (1-indexed 4),
+	// to == total == 5, so the indicator shows "↑ 4-5/5" with the down arrow blanked.
+	got := m.transcriptPhaseIndicator()
+	if !strings.Contains(got, "4-5/5") {
+		t.Fatalf("indicator should contain '4-5/5'; got %q", got)
+	}
+	if strings.Contains(got, "↓") {
+		t.Fatalf("down arrow should be blank when to == total; got %q", got)
+	}
+}
+
+// TestWorkingStatusLineShowsPhaseIndicator is the integration test: the working
+// status line must carry the phase indicator when the transcript is non-empty.
+func TestWorkingStatusLineShowsPhaseIndicator(t *testing.T) {
+	m := newModel(t.Context(), Options{})
+	m.width = 100
+	m.transcript = appendRow(nil, rowUser, "go")
+	m.transcript = appendRow(m.transcript, rowToolCall, "tool call: read_file")
+	got := plainRender(t, m.workingStatusLine())
+	if !strings.Contains(got, "Working") {
+		t.Fatalf("working status line missing 'Working'; got %q", got)
+	}
+	if !strings.Contains(got, "/2") {
+		t.Fatalf("working status line missing phase indicator '/2'; got %q", got)
+	}
+}

--- a/internal/tui/plan_panel.go
+++ b/internal/tui/plan_panel.go
@@ -319,7 +319,10 @@ func renderPlanStepLine(step planStep, now time.Time, maxContent int) string {
 	switch step.status {
 	case "completed":
 		icon = zeroTheme.green.Render("✓")
-		body = zeroTheme.green.Render(content)
+		// Quiet the completed body (muted, not saturated green) so the single
+		// in-progress accent step is the obvious focus: past=quiet, now=bright,
+		// future=faint. The green ✓ icon still marks success.
+		body = zeroTheme.muted.Render(content)
 		timeStr = formatElapsedSeconds(step.completedAt.Sub(step.startedAt))
 	case "in_progress":
 		icon = zeroTheme.accent.Render("•")

--- a/internal/tui/plan_panel.go
+++ b/internal/tui/plan_panel.go
@@ -34,6 +34,11 @@ type planPanelState struct {
 	expanded    bool
 	completedAt time.Time // set once all steps reach a terminal status
 	startedAt   time.Time // set on the first non-empty update
+	// frozenAt freezes the live plan clock while the agent is idle (between
+	// turns / waiting on the user). Stamped when a run ends; cleared by clear()
+	// at the next run's start. While set and idle, an in_progress step's elapsed
+	// time stops ticking up instead of counting forever against a yielded turn.
+	frozenAt time.Time
 }
 
 // completedHideAfter is how long a finished plan stays pinned before the
@@ -111,6 +116,7 @@ func (s *planPanelState) clear() {
 	s.expanded = false
 	s.completedAt = time.Time{}
 	s.startedAt = time.Time{}
+	s.frozenAt = time.Time{}
 }
 
 // isEmpty reports whether the panel has no steps to show.
@@ -158,6 +164,18 @@ func (s planPanelState) height(width int, now time.Time) int {
 	return 2
 }
 
+// planNow returns the clock used for live plan durations. While the agent is
+// idle (no run in flight, activeRunID == 0) it freezes at the moment the last
+// run ended, so an in_progress step left mid-plan when the agent yields (e.g.
+// after ask_user) stops ticking up instead of counting forever against a turn
+// that is no longer running. During a run it tracks the live clock as before.
+func (m model) planNow() time.Time {
+	if m.activeRunID == 0 && !m.plan.frozenAt.IsZero() {
+		return m.plan.frozenAt
+	}
+	return m.now()
+}
+
 // renderPlanPanel renders the full sticky plan panel. It returns an empty
 // string when the plan is empty or when a finished plan has been collapsed
 // past completedHideAfter without being expanded.
@@ -167,7 +185,7 @@ func (m model) renderPlanPanel(width int) string {
 	}
 
 	state := m.plan
-	now := m.now()
+	now := m.planNow()
 	if !state.visible(now) {
 		return ""
 	}
@@ -214,6 +232,14 @@ func (m model) renderPlanPanel(width int) string {
 // full list via m.plan.expanded, but the height budget always wins to keep the
 // composer on screen.
 func (m model) renderPinnedPlanPanel(width int, maxHeight int) string {
+	// When the two-column layout is active the plan lives in the context
+	// sidebar (FILES / PLAN / tokens), so suppress the pinned panel above the
+	// composer to avoid showing it twice. Both the real model (sidebarActive)
+	// and the narrow chat-column copy (hidePinnedPlan) suppress it, so the
+	// view and the mouse-geometry frame stay aligned.
+	if m.hidePinnedPlan || m.sidebarActive() {
+		return ""
+	}
 	if !m.plan.visible(m.now()) {
 		return ""
 	}

--- a/internal/tui/plan_panel_test.go
+++ b/internal/tui/plan_panel_test.go
@@ -198,6 +198,37 @@ func TestPlanPanelRenderRunning(t *testing.T) {
 	}
 }
 
+// TestPlanNowFreezeAndResume covers the idle-freeze fix: while the agent is idle
+// (activeRunID == 0) and a freeze time is stamped, the plan clock is frozen so an
+// in_progress step left mid-plan stops ticking; during a run it tracks live time.
+func TestPlanNowFreezeAndResume(t *testing.T) {
+	frozen := time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)
+	live := frozen.Add(2 * time.Minute)
+	m := model{now: func() time.Time { return live }, plan: planPanelState{frozenAt: frozen}}
+
+	m.activeRunID = 0 // idle -> frozen clock
+	if got := m.planNow(); !got.Equal(frozen) {
+		t.Fatalf("idle planNow = %v, want frozen %v", got, frozen)
+	}
+	m.activeRunID = 3 // running -> live clock
+	if got := m.planNow(); !got.Equal(live) {
+		t.Fatalf("running planNow = %v, want live %v", got, live)
+	}
+	m.activeRunID = 0
+	m.plan.frozenAt = time.Time{} // idle but never stamped -> live fallback
+	if got := m.planNow(); !got.Equal(live) {
+		t.Fatalf("unstamped idle planNow = %v, want live fallback %v", got, live)
+	}
+}
+
+func TestPlanPanelClearResetsFrozenAt(t *testing.T) {
+	s := planPanelState{frozenAt: time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)}
+	s.clear()
+	if !s.frozenAt.IsZero() {
+		t.Fatal("clear() must reset frozenAt so the next run starts with a live clock")
+	}
+}
+
 // runningPlanModel builds a model with an n-step running plan for the pinned
 // panel tests.
 func runningPlanModel(t *testing.T, steps int) model {
@@ -253,7 +284,7 @@ func TestPinnedPlanHiddenWhenEmpty(t *testing.T) {
 func TestFooterIncludesPinnedPlanAboveComposer(t *testing.T) {
 	m := runningPlanModel(t, 3)
 	m.height = 40
-	footer := plainRender(t, m.footerView(chatWidth(m.width)))
+	footer := plainRender(t, m.footerView(m.chatColumnWidth()))
 	planIdx := strings.Index(footer, "PLAN")
 	composerIdx := strings.Index(footer, "describe a task")
 	if planIdx < 0 {

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -589,20 +589,30 @@ func doneLine(row transcriptRow) string {
 	return zeroTheme.faint.Render("worked for " + formatElapsedSeconds(row.turnElapsed))
 }
 
-// renderSystemNote draws a system notice. A run-cancellation is a transient
-// marker, not structured info, so it renders as a single plain amber line (no
-// heavy box) — the colour reads "stopped" at a glance. Every other notice keeps
-// the bordered note: faint text on the panel surface inside a line border.
+// renderSystemNote draws a system notice as plain, lightly-marked lines — not a
+// heavy box. A run cancellation reads amber ("stopped"); every other notice is
+// calm muted info. Multi-line notices keep the marker on the first line and
+// indent the continuation so the block still reads as one note.
 func renderSystemNote(text string, width int) string {
-	if isCancellationNotice(text) {
-		return fitStyledLine(zeroTheme.amber.Render("⊘ "+strings.TrimSpace(text)), width)
+	trimmed := strings.TrimSpace(text)
+	marker, style := zeroTheme.faint.Render("·"), zeroTheme.muted
+	if isCancellationNotice(trimmed) {
+		marker, style = zeroTheme.amber.Render("⊘"), zeroTheme.amber
 	}
-	return noteBox(text, width, zeroTheme.line, zeroTheme.onPanel(zeroTheme.faint))
+	srcLines := strings.Split(trimmed, "\n")
+	out := make([]string, 0, len(srcLines))
+	for i, line := range srcLines {
+		prefix := marker + " "
+		if i > 0 {
+			prefix = "  " // continuation lines align under the first word
+		}
+		out = append(out, fitStyledLine(prefix+style.Render(line), width))
+	}
+	return strings.Join(out, "\n")
 }
 
 // isCancellationNotice reports whether a system notice is the run-cancelled
-// marker (single line, written by the cancel path), so it renders as a plain
-// coloured line instead of a box.
+// marker (single line, written by the cancel path), so it renders amber.
 func isCancellationNotice(text string) bool {
 	t := strings.ToLower(strings.TrimSpace(text))
 	return !strings.Contains(t, "\n") && strings.HasPrefix(t, "run cancelled")

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -589,10 +589,23 @@ func doneLine(row transcriptRow) string {
 	return zeroTheme.faint.Render("worked for " + formatElapsedSeconds(row.turnElapsed))
 }
 
-// renderSystemNote draws a system notice as a bordered note: faint text on
-// the panel surface inside a line border. Content is passed through unchanged.
+// renderSystemNote draws a system notice. A run-cancellation is a transient
+// marker, not structured info, so it renders as a single plain amber line (no
+// heavy box) — the colour reads "stopped" at a glance. Every other notice keeps
+// the bordered note: faint text on the panel surface inside a line border.
 func renderSystemNote(text string, width int) string {
+	if isCancellationNotice(text) {
+		return fitStyledLine(zeroTheme.amber.Render("⊘ "+strings.TrimSpace(text)), width)
+	}
 	return noteBox(text, width, zeroTheme.line, zeroTheme.onPanel(zeroTheme.faint))
+}
+
+// isCancellationNotice reports whether a system notice is the run-cancelled
+// marker (single line, written by the cancel path), so it renders as a plain
+// coloured line instead of a box.
+func isCancellationNotice(text string) bool {
+	t := strings.ToLower(strings.TrimSpace(text))
+	return !strings.Contains(t, "\n") && strings.HasPrefix(t, "run cancelled")
 }
 
 func renderCommandCardRow(text string, width int) string {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -715,12 +715,16 @@ func TestErrorRowRendersTintedNoteAndErrorDoneLine(t *testing.T) {
 	}
 }
 
-func TestSystemNoteRendersBordered(t *testing.T) {
+func TestSystemNoteRendersPlainLine(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{kind: rowSystem, text: "Mode set to ask."}
 	got := plainRender(t, m.renderRow(row, 60, buildRowContext(nil)))
-	if !strings.Contains(got, "╭") || !strings.Contains(got, "Mode set to ask.") {
-		t.Fatalf("system row = %q, want bordered note with content unchanged", got)
+	// System notices are plain marked lines now, not boxes.
+	if strings.ContainsAny(got, "╭╮╰╯│") {
+		t.Fatalf("system row = %q, want a plain line (no box border)", got)
+	}
+	if !strings.Contains(got, "Mode set to ask.") {
+		t.Fatalf("system row = %q, want the notice text unchanged", got)
 	}
 }
 

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -998,15 +998,20 @@ func TestComposerLineShowsRequiredCommandArgumentHint(t *testing.T) {
 	}
 }
 
-func TestComposerBoxFramesInputAndBottomModelModeLabel(t *testing.T) {
+func TestComposerBoxFramesInputAndBottomModelLabel(t *testing.T) {
 	m := limeTestModel()
 	m.input.SetValue("add a flag")
 
 	got := plainRender(t, m.composerBox(96))
-	for _, want := range []string{"╭", "│", "❯ add a flag", "╰", "test-model", "auto-approve"} {
+	// The box bottom rule shows the model only; the permission mode moved to the
+	// status line below the box.
+	for _, want := range []string{"╭", "│", "❯ add a flag", "╰", "test-model"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("composer box = %q, missing %q", got, want)
 		}
+	}
+	if strings.Contains(got, "auto-approve") {
+		t.Fatalf("composer box = %q, should not show the mode (moved to status line)", got)
 	}
 	if strings.Contains(got, "run ↵") {
 		t.Fatalf("composer box = %q, should not show run hint", got)
@@ -1080,39 +1085,39 @@ func TestMalformedToolArgumentResultIsHiddenFromChatSurface(t *testing.T) {
 func TestStatusLineGroups(t *testing.T) {
 	m := limeTestModel()
 	got := plainRender(t, m.statusLine(110))
-	for _, want := range []string{"● test-provider"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("status line = %q, missing %q", got, want)
-		}
+	// Status line shows the run-state chip (permission mode), NOT the provider,
+	// surface, or model — those live in the title bar / composer rule.
+	if !strings.Contains(got, "● auto-approve") {
+		t.Fatalf("status line = %q, missing the permission-mode chip", got)
 	}
-	if strings.Contains(got, "interactive") || strings.Contains(got, "test-model") || strings.Contains(got, "auto-approve") {
-		t.Fatalf("status line = %q, should not include surface, model, or permission mode", got)
+	if strings.Contains(got, "interactive") || strings.Contains(got, "test-model") || strings.Contains(got, "test-provider") {
+		t.Fatalf("status line = %q, should not include surface, model, or provider", got)
 	}
 	divider := plainRender(t, m.composerDividerLine(110))
-	for _, want := range []string{"test-model", "auto-approve"} {
-		if !strings.Contains(divider, want) {
-			t.Fatalf("composer divider = %q, missing %q", divider, want)
-		}
+	if !strings.Contains(divider, "test-model") {
+		t.Fatalf("composer divider = %q, missing the model label", divider)
+	}
+	if strings.Contains(divider, "auto-approve") {
+		t.Fatalf("composer divider = %q, should not show the mode (moved to status line)", divider)
 	}
 }
 
-func TestComposerDividerShowsEffortWhenSet(t *testing.T) {
+func TestStatusLineShowsEffortWhenSet(t *testing.T) {
 	m := limeTestModel()
 	m.reasoningEffort = modelregistry.ReasoningEffortHigh
-	divider := plainRender(t, m.composerDividerLine(110))
-	if !strings.Contains(divider, "high") {
-		t.Fatalf("composer divider = %q, missing effort segment when set", divider)
+	status := plainRender(t, m.statusLine(110))
+	if !strings.Contains(status, "high") {
+		t.Fatalf("status line = %q, missing effort segment when set", status)
 	}
 }
 
-func TestComposerDividerOmitsEffortWhenAuto(t *testing.T) {
+func TestStatusLineOmitsEffortWhenAuto(t *testing.T) {
 	m := limeTestModel()
-	// reasoningEffort == "" (auto) by default — the segment is omitted entirely,
-	// matching opencode hiding the variant when unset.
-	divider := plainRender(t, m.composerDividerLine(110))
+	// reasoningEffort == "" (auto) by default — the effort segment is omitted.
+	status := plainRender(t, m.statusLine(110))
 	for _, effort := range []string{"low", "medium", "high", "minimal", "xhigh", "none"} {
-		if strings.Contains(divider, effort) {
-			t.Fatalf("composer divider = %q, should omit effort segment when auto", divider)
+		if strings.Contains(status, effort) {
+			t.Fatalf("status line = %q, should omit effort segment when auto", status)
 		}
 	}
 }
@@ -1171,17 +1176,14 @@ func TestGenericCustomProviderDisplayUsesEndpointName(t *testing.T) {
 		},
 	})
 
+	// The derived provider label lives in the title bar (no longer duplicated in
+	// the status line, which now shows the run-state chip instead).
 	title := plainRender(t, m.titleBar(120))
 	if !strings.Contains(title, "minimax/MiniMax-M3") {
 		t.Fatalf("title bar = %q, want derived custom provider label", title)
 	}
 	if strings.Contains(title, "custom-openai-compatible/MiniMax-M3") {
 		t.Fatalf("title bar = %q, should not show generic custom catalog id", title)
-	}
-
-	status := plainRender(t, m.statusLine(100))
-	if !strings.Contains(status, "● minimax") {
-		t.Fatalf("status line = %q, want derived custom provider label", status)
 	}
 }
 

--- a/internal/tui/ripple.go
+++ b/internal/tui/ripple.go
@@ -1,0 +1,96 @@
+// ripple.go adds a slow cosine "breathing" colour wave for the working status
+// line: each character cycles through a cold-to-warm ramp of the curated theme
+// styles, and the wave travels across the text one character per phase tick. The
+// phase is sourced from the shared spinner clock (m.spinnerPhase, advanced by the
+// existing spinner.TickMsg handler) so the ripple and the braille spinner animate
+// in lock-step with no extra ticker.
+package tui
+
+import (
+	"math"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// rippleLevel returns a palette index in [0, travel] computed from a cosine wave
+// of wavelength waveLen at integer offset distance. The wave is the standard
+// "breathing" half-wave-rectified cosine:
+//
+//	q     = distance mod waveLen
+//	level = int( travel * (0.5 + 0.5*cos(2*Pi*q/waveLen)) )
+//
+// At distance == 0 the level is travel (brightest), at distance == waveLen/2 it
+// is 0 (dimmest), and the cycle repeats every waveLen. A string rendered with
+// rippleLevel(i+phase, ...) for i in [0, N) therefore shows a single cosine wave
+// of colour that moves as phase advances.
+//
+// Edge cases:
+//   - waveLen <= 0 returns 0 (no wave; flat dimmest entry)
+//   - travel  <= 0 returns 0 (no palette; flat dimmest entry)
+//   - distance < 0 mod-normalises to a non-negative value
+//
+// The function is intentionally pure: three ints in, an int out, depending only
+// on the Go standard library math package — no model state, no rendering.
+func rippleLevel(distance, travel, waveLen int) int {
+	if travel <= 0 || waveLen <= 0 {
+		return 0
+	}
+	// Normalise distance to [0, waveLen) so negative phases still behave: Go's %
+	// can return a negative for negative inputs.
+	q := distance % waveLen
+	if q < 0 {
+		q += waveLen
+	}
+	ratio := 0.5 + 0.5*math.Cos(2*math.Pi*float64(q)/float64(waveLen))
+	return int(float64(travel) * ratio)
+}
+
+// rippleText applies one palette style per rune of text, using rippleLevel with
+// index = i+phase so the wave travels across the string one character per phase
+// tick. The palette holds curated theme styles (cold-to-warm); travel = len-1 so
+// the cosine spans every entry exactly once.
+//
+// phase advances the wave; the caller passes m.spinnerPhase so the ripple and the
+// braille spinner share a single animation clock.
+//
+// On an empty palette or empty text the input string is returned verbatim (no
+// styling) — a safe-skip contract for callers.
+func rippleText(text string, palette []lipgloss.Style, phase, waveLen int) string {
+	if len(palette) == 0 || text == "" {
+		return text
+	}
+	travel := len(palette) - 1
+	if travel == 0 {
+		return palette[0].Render(text)
+	}
+
+	var b strings.Builder
+	for i, r := range text {
+		level := rippleLevel(i+phase, travel, waveLen)
+		if level < 0 {
+			level = 0
+		}
+		if level > travel {
+			level = travel
+		}
+		b.WriteString(palette[level].Render(string(r)))
+	}
+	return b.String()
+}
+
+// ripplePalette is the run-state colour ramp used by the working status line: the
+// curated zeroTheme styles ordered cold (faint) at the cosine troughs to
+// warm-bright (accent) at its peaks, giving a visible "the agent is thinking"
+// temperature feel. Built lazily from the active theme so a /theme swap is
+// reflected. No hex literal appears here — every entry is a named theme style
+// (theme.go), satisfying the repo's no-hex-outside-theme rule.
+func ripplePalette() []lipgloss.Style {
+	return []lipgloss.Style{
+		zeroTheme.faint,  // dimmest (cosine trough)
+		zeroTheme.muted,  // dim
+		zeroTheme.amber,  // mid (warm)
+		zeroTheme.green,  // bright
+		zeroTheme.accent, // brightest (cosine peak)
+	}
+}

--- a/internal/tui/ripple.go
+++ b/internal/tui/ripple.go
@@ -1,12 +1,13 @@
 // ripple.go adds a slow cosine "breathing" colour wave for the working status
-// line: each character cycles through a cold-to-warm ramp of the curated theme
-// styles, and the wave travels across the text one character per phase tick. The
+// line: each character cycles through a dim→lime ramp blended from the brand
+// accent, and the wave travels across the text one character per phase tick. The
 // phase is sourced from the shared spinner clock (m.spinnerPhase, advanced by the
 // existing spinner.TickMsg handler) so the ripple and the braille spinner animate
 // in lock-step with no extra ticker.
 package tui
 
 import (
+	"image/color"
 	"math"
 	"strings"
 
@@ -86,11 +87,21 @@ func rippleText(text string, palette []lipgloss.Style, phase, waveLen int) strin
 // reflected. No hex literal appears here — every entry is a named theme style
 // (theme.go), satisfying the repo's no-hex-outside-theme rule.
 func ripplePalette() []lipgloss.Style {
-	return []lipgloss.Style{
-		zeroTheme.faint,  // dimmest (cosine trough)
-		zeroTheme.muted,  // dim
-		zeroTheme.amber,  // mid (warm)
-		zeroTheme.green,  // bright
-		zeroTheme.accent, // brightest (cosine peak)
+	// A dim→lime ramp blended from the brand accent — deliberately NOT the semantic
+	// amber (permission) / green (success) hues. Flashing those every spinner tick
+	// trains the eye to ignore the exact colours that signal a real permission
+	// prompt or a success, so the decorative working line stays in the brand lime.
+	// Falls back to a coarse named ramp if the theme has no parseable accent/faint.
+	bright := zeroTheme.accent.GetForeground()
+	dim := zeroTheme.faint.GetForeground()
+	if bright == nil || dim == nil {
+		return []lipgloss.Style{zeroTheme.faint, zeroTheme.muted, zeroTheme.accent}
 	}
+	blend := lipgloss.Blend1D(5, dim, bright)
+	out := make([]lipgloss.Style, len(blend))
+	for i, c := range blend {
+		r, g, b, a := c.RGBA()
+		out[i] = lipgloss.NewStyle().Foreground(color.RGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(a >> 8)})
+	}
+	return out
 }

--- a/internal/tui/ripple_test.go
+++ b/internal/tui/ripple_test.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRippleLevelAtTrough verifies the cosine trough: with q = waveLen/2,
+// cos(pi) = -1, so the half-wave-rectified cosine is 0 and level is 0.
+func TestRippleLevelAtTrough(t *testing.T) {
+	if got := rippleLevel(4, 4, 8); got != 0 {
+		t.Fatalf("rippleLevel(4, 4, 8) = %d, want 0 (cosine trough)", got)
+	}
+}
+
+// TestRippleLevelAtPeak verifies the cosine peak at distance 0: cos(0) = 1, so
+// level equals travel.
+func TestRippleLevelAtPeak(t *testing.T) {
+	if got := rippleLevel(0, 4, 8); got != 4 {
+		t.Fatalf("rippleLevel(0, 4, 8) = %d, want 4 (cosine peak)", got)
+	}
+}
+
+// TestRippleLevelAtQuarterPeriod verifies the midpoint: cos(pi/2) = 0, so the
+// half-wave-rectified cosine is 0.5 and level equals travel/2.
+func TestRippleLevelAtQuarterPeriod(t *testing.T) {
+	if got := rippleLevel(2, 4, 8); got != 2 {
+		t.Fatalf("rippleLevel(2, 4, 8) = %d, want 2 (quarter-period midpoint)", got)
+	}
+}
+
+// TestRippleLevelAtThreeQuarterPeriod verifies the symmetric back-half midpoint.
+// cos(3pi/2) is mathematically 0, but float rounding yields a tiny negative, and
+// int() truncation floors 4*0.4999… to 1. We assert the deterministic truncated
+// value rather than the ideal 2 — the wave is still a smooth dim-mid level here.
+func TestRippleLevelAtThreeQuarterPeriod(t *testing.T) {
+	if got := rippleLevel(6, 4, 8); got != 1 {
+		t.Fatalf("rippleLevel(6, 4, 8) = %d, want 1 (three-quarter midpoint, truncated)", got)
+	}
+}
+
+// TestRippleLevelPeriodic verifies the wave repeats every waveLen.
+func TestRippleLevelPeriodic(t *testing.T) {
+	if rippleLevel(0, 4, 8) != rippleLevel(8, 4, 8) {
+		t.Fatalf("wave should repeat: l(0)=%d != l(8)=%d", rippleLevel(0, 4, 8), rippleLevel(8, 4, 8))
+	}
+	if rippleLevel(2, 4, 8) != rippleLevel(10, 4, 8) {
+		t.Fatalf("wave should repeat: l(2)=%d != l(10)=%d", rippleLevel(2, 4, 8), rippleLevel(10, 4, 8))
+	}
+}
+
+// TestRippleLevelZeroInputsShortCircuits checks the safe-guard clauses.
+func TestRippleLevelZeroInputsShortCircuits(t *testing.T) {
+	if rippleLevel(5, 4, 0) != 0 {
+		t.Fatalf("rippleLevel(_, _, 0) should be 0, got %d", rippleLevel(5, 4, 0))
+	}
+	if rippleLevel(5, 0, 8) != 0 {
+		t.Fatalf("rippleLevel(_, 0, _) should be 0, got %d", rippleLevel(5, 0, 8))
+	}
+}
+
+// TestRippleLevelNegativeDistanceNormalises confirms the negative-safety branch:
+// distance -1 with waveLen 8 normalises to q = 7.
+func TestRippleLevelNegativeDistanceNormalises(t *testing.T) {
+	if got, want := rippleLevel(-1, 4, 8), rippleLevel(7, 4, 8); got != want {
+		t.Fatalf("rippleLevel(-1, 4, 8)=%d, want value at distance=7 = %d", got, want)
+	}
+}
+
+// TestRippleEmptyPaletteReturnsText is the safe-skip contract.
+func TestRippleEmptyPaletteReturnsText(t *testing.T) {
+	if got := rippleText("hello", nil, 0, 8); got != "hello" {
+		t.Fatalf("rippleText with empty palette = %q, want %q", got, "hello")
+	}
+}
+
+// TestRippleEmptyTextIsEmpty verifies the trivial input case.
+func TestRippleEmptyTextIsEmpty(t *testing.T) {
+	if got := rippleText("", ripplePalette(), 0, 8); got != "" {
+		t.Fatalf("rippleText with empty input = %q, want \"\"", got)
+	}
+}
+
+// TestRipplePhaseShiftChangesBytesAcrossString verifies adjacent phase values
+// produce different byte streams, the contract that lets the caller animate.
+func TestRipplePhaseShiftChangesBytesAcrossString(t *testing.T) {
+	a := rippleText("Working", ripplePalette(), 0, 6)
+	b := rippleText("Working", ripplePalette(), 3, 6)
+	if a == b {
+		t.Fatalf("rippleText at phase 0 and 3 produced identical bytes: %q", a)
+	}
+}
+
+// TestRippleAdvancesPhaseAcrossFrames ties Stage 3 to the spinner clock: stepping
+// phase must produce distinct outputs (the run-state text actually changes).
+func TestRippleAdvancesPhaseAcrossFrames(t *testing.T) {
+	seen := map[string]bool{}
+	for phase := 0; phase < 12; phase++ {
+		seen[rippleText("Working", ripplePalette(), phase, 6)] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("expected at least 2 distinct ripple outputs across 12 phase steps; got %d", len(seen))
+	}
+}
+
+// TestWorkingStatusLineRipplesWorkingWord is the integration test: the working
+// status line must carry styling around "Working" (not the literal word) and the
+// styling must change as the shared spinner phase advances.
+func TestWorkingStatusLineRipplesWorkingWord(t *testing.T) {
+	m := newModel(t.Context(), Options{})
+	m.width = 100
+	m.pending = true
+
+	m.spinnerPhase = 0
+	a := m.workingStatusLine()
+	if !strings.Contains(plainRender(t, a), "Working") {
+		t.Fatalf("working status line missing 'Working' substring; got %q", a)
+	}
+
+	m.spinnerPhase = 3
+	b := m.workingStatusLine()
+	if a == b {
+		t.Fatalf("working status line did not change as spinnerPhase advanced; got %q", a)
+	}
+}

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -93,6 +93,35 @@ func (m model) chatColumnWidth() int {
 	return chatWidth(m.width)
 }
 
+// transcriptContentCap is the readable measure the chat BODY wraps to, so text
+// on a wide terminal doesn't run edge-to-edge. The frame/composer/sidebar keep
+// the full chatColumnWidth; only transcript rows use the reading column.
+const transcriptContentCap = 90
+
+// transcriptGutter is the fixed left margin applied to transcript body rows so
+// the reading column floats off the left edge. Zero on terminals too narrow to
+// afford it (the body then uses the full column, just capped).
+func transcriptGutter(columnWidth int) int {
+	if columnWidth <= transcriptContentCap+8 {
+		return 0
+	}
+	return 4
+}
+
+// transcriptContentWidth is the wrap width for transcript body rows: the column
+// width minus the gutter, capped at transcriptContentCap. Degrades to the full
+// column on tiny terminals so prose never collapses to the wrap floor.
+func transcriptContentWidth(columnWidth int) int {
+	cw := columnWidth - transcriptGutter(columnWidth)
+	if cw > transcriptContentCap {
+		cw = transcriptContentCap
+	}
+	if cw < 24 {
+		return columnWidth
+	}
+	return cw
+}
+
 // sidebarWidthForLayout returns the active sidebar column width, or 0 when the
 // two-column layout is not active.
 func (m model) sidebarWidthForLayout() int {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -14,6 +14,7 @@ import (
 	"image/color"
 	"regexp"
 	"strings"
+	"time"
 
 	"charm.land/lipgloss/v2"
 )
@@ -37,15 +38,29 @@ func sidebarWidth(total int) int {
 	return clamp(total*30/100, sidebarMinWidth, sidebarMaxWidth)
 }
 
-// sidebarActive reports whether the two-column layout should render: only in
-// alt-screen managed mode, with a measured height, on a wide-enough terminal.
-// The subchat drill-in keeps its own single-column view, so the sidebar is
-// suppressed there.
+// sidebarActive reports whether the two-column layout should render right now:
+// the sidebar is available AND the user hasn't collapsed it with Ctrl+B.
 func (m model) sidebarActive() bool {
+	return !m.sidebarHidden && m.sidebarAvailable()
+}
+
+// sidebarAvailable reports whether the two-column layout CAN render: only in
+// alt-screen managed mode, with a measured height, on a wide-enough terminal,
+// outside subchat/overlays, with real conversation. It ignores the user's Ctrl+B
+// hide preference (sidebarHidden) so the toggle handler can tell whether Ctrl+B
+// would have any visible effect. The subchat drill-in keeps its own single-column
+// view, so the sidebar is suppressed there.
+func (m model) sidebarAvailable() bool {
 	if !m.altScreen || m.height <= 0 || m.subchat.active {
 		return false
 	}
 	if sidebarWidth(m.width) <= 0 {
+		return false
+	}
+	// Only split once the chat column survives it: require the medium tier (>=80
+	// cols). Between 60-79 the sidebar would starve the chat to ~30 cells, so the
+	// layout commits to two healthy columns or stays cleanly single-column.
+	if widthTier(m.width) < tierMedium {
 		return false
 	}
 	// Full-screen overlays (setup, wizards, pickers, the empty-state suggestion
@@ -71,7 +86,9 @@ func (m model) sidebarActive() bool {
 // agree on where the chat column ends.
 func (m model) chatColumnWidth() int {
 	if sw := m.sidebarWidthForLayout(); sw > 0 {
-		return chatWidth(m.width - sw - 1)
+		// Reserve 3 cells for the padded " │ " divider (a cell of air on each side
+		// of the rule) — see joinColumns.
+		return chatWidth(m.width - sw - 3)
 	}
 	return chatWidth(m.width)
 }
@@ -98,6 +115,12 @@ func (m model) sidebarSpecialists() []specialistInfo {
 		if a.status == specialistError && strings.Contains(strings.ToLower(a.errorMsg), "not found") {
 			continue
 		}
+		// Linger a finished specialist for sidebarAgentLinger (a fading ✓), then
+		// drop it — a smooth exit rather than an abrupt pop.
+		if a.status != specialistRunning && !a.completedAt.IsZero() &&
+			m.now().Sub(a.completedAt) >= sidebarAgentLinger {
+			continue
+		}
 		out = append(out, a)
 	}
 	return out
@@ -122,7 +145,7 @@ func (m model) sidebarAgentHeader(width int) string {
 	if n == 0 {
 		return sidebarHeader("AGENTS", width)
 	}
-	return sidebarHeaderWithCount("AGENTS", fmt.Sprintf("%d", n), width)
+	return sidebarHeaderWithCount("AGENTS", fmt.Sprintf("%d", n), zeroTheme.muted, width)
 }
 
 // swarmSpawnRe extracts a member id from a swarm_spawn tool result, whose text
@@ -133,8 +156,10 @@ var swarmSpawnRe = regexp.MustCompile(`as task (\S+) on team`)
 // stable id recovered from the spawn result, plus a human display name derived
 // from the spawn call's task briefing (falling back to the id).
 type swarmAgent struct {
-	id   string // e.g. "subagent-1" — the dedup key and fallback name
-	name string // the task briefing (argHint of the call row), or id when empty
+	id         string    // e.g. "subagent-1" — the dedup key and fallback name
+	name       string    // the task briefing (argHint of the call row), or id when empty
+	finishing  bool      // done/failed but still lingering before removal (smooth exit)
+	finishedAt time.Time // when first seen finished (zero until the spinner tick stamps it)
 }
 
 // swarmSpawnedAgents derives the swarm/team members from the transcript's
@@ -191,15 +216,22 @@ func (m model) swarmSpawnedAgents() []swarmAgent {
 			agents = append(agents, swarmAgent{id: id, name: name})
 		}
 	}
-	// Drop members the latest swarm_status reports as finished (done/failed) so
-	// they disappear from the sidebar once their work completes. Members not yet
-	// in a status report (just spawned) stay visible.
+	// Members the latest swarm_status reports finished LINGER briefly with a fading
+	// ✓ (a smooth exit, not an abrupt pop) then drop. Members not yet in a status
+	// report (just spawned) stay live. The done-time is stamped by the spinner tick
+	// (stampSwarmDone); until then a freshly-finished member shows as finishing.
 	if status := m.swarmMemberStatus(); len(status) > 0 {
 		live := agents[:0:0]
 		for _, a := range agents {
 			switch status[a.id] {
 			case "done", "failed", "completed", "cancelled":
-				// finished — hide it
+				doneAt, stamped := m.swarmDoneAt[a.id]
+				if stamped && m.now().Sub(doneAt) >= sidebarAgentLinger {
+					continue // past the linger window — remove
+				}
+				a.finishing = true
+				a.finishedAt = doneAt
+				live = append(live, a)
 			default:
 				live = append(live, a)
 			}
@@ -232,6 +264,26 @@ func (m model) swarmMemberStatus() map[string]string {
 	return status
 }
 
+// sidebarAgentLinger is how long a finished agent (specialist or swarm member)
+// stays in the AGENTS panel with a fading ✓ before it's removed, so the exit
+// reads as "done" rather than an abrupt pop.
+const sidebarAgentLinger = 1500 * time.Millisecond
+
+// stampSwarmDone records the first time each swarm member is seen finished, so
+// swarmSpawnedAgents can linger it for sidebarAgentLinger before dropping it. It
+// only adds entries (never clears) and is called from the spinner tick while the
+// sidebar holds agents. Mutates the (always-initialised) swarmDoneAt map.
+func (m *model) stampSwarmDone() {
+	for id, s := range m.swarmMemberStatus() {
+		switch s {
+		case "done", "failed", "completed", "cancelled":
+			if _, seen := m.swarmDoneAt[id]; !seen {
+				m.swarmDoneAt[id] = m.now()
+			}
+		}
+	}
+}
+
 // sidebarAgentLines renders one line per active agent. Specialist delegations
 // show a live status glyph (• running, ✓ done, ✗ error) plus a "↳ <tool>" working
 // line; swarm/team members (from swarm_spawn) show a ready dot and their id.
@@ -248,7 +300,10 @@ func (m model) sidebarAgentLines(width int) []string {
 		var icon string
 		switch a.status {
 		case specialistRunning:
-			icon = zeroTheme.accent.Render("•")
+			// A working specialist spins (same glyph its transcript card uses) so
+			// the sidebar reads "this one is busy" at a glance; the tick is kept
+			// alive by sidebarHasAgents. Static "•" stays for idle/parked members.
+			icon = zeroTheme.accent.Render(m.spinnerGlyph())
 		case specialistError:
 			icon = zeroTheme.red.Render("✗")
 		default: // completed
@@ -258,7 +313,18 @@ func (m model) sidebarAgentLines(width int) []string {
 		if name == "" {
 			name = "agent"
 		}
-		lines = append(lines, " "+icon+" "+zeroTheme.ink.Render(truncateStep(name, room)))
+		nameStyle := zeroTheme.ink
+		// As a finished specialist nears the end of its linger, dim the whole row
+		// toward faint so its removal reads as a fade-out rather than a pop.
+		if a.status != specialistRunning && m.agentExitFading(a.completedAt) {
+			glyph := "✓"
+			if a.status == specialistError {
+				glyph = "✗"
+			}
+			icon = zeroTheme.faint.Render(glyph)
+			nameStyle = zeroTheme.faint
+		}
+		lines = append(lines, " "+icon+" "+nameStyle.Render(truncateStep(name, room)))
 		if a.status != specialistRunning {
 			continue
 		}
@@ -279,13 +345,31 @@ func (m model) sidebarAgentLines(width int) []string {
 			lines = append(lines, "   "+zeroTheme.faint.Render("↳ "+truncateStep(detail, maxInt(2, room-2))))
 		}
 	}
-	// Swarm/team members: the whole task-name carries a mild, slow cool pulse
-	// (NOT a per-letter ripple) so a live member reads as alive without noise.
+	// Swarm/team members: a live member's whole task-name carries a mild, slow cool
+	// pulse (NOT a per-letter ripple). A finished member instead shows a green ✓
+	// that dims toward faint over its linger — a smooth exit before removal.
 	style := m.swarmNameStyle()
 	for _, a := range swarm {
+		if a.finishing {
+			icon := zeroTheme.green.Render("✓")
+			nameStyle := zeroTheme.muted
+			if m.agentExitFading(a.finishedAt) {
+				icon = zeroTheme.faint.Render("✓")
+				nameStyle = zeroTheme.faint
+			}
+			lines = append(lines, " "+icon+" "+nameStyle.Render(truncateStep(a.name, room)))
+			continue
+		}
 		lines = append(lines, " "+zeroTheme.accent.Render("•")+" "+style.Render(truncateStep(a.name, room)))
 	}
 	return lines
+}
+
+// agentExitFading reports whether a finished agent is in the later half of its
+// linger window (sidebarAgentLinger), so its row dims toward faint just before
+// it's removed. A zero finishedAt (not yet stamped) is not fading.
+func (m model) agentExitFading(finishedAt time.Time) bool {
+	return !finishedAt.IsZero() && m.now().Sub(finishedAt) >= sidebarAgentLinger/2
 }
 
 // swarmNameStyle returns a gentle, whole-line cool tint for a live swarm member
@@ -430,17 +514,20 @@ func (m model) renderContextSidebar(width, height int) []string {
 	return lines
 }
 
-// sidebarHeader renders an uppercase faint section header with an optional
-// right-aligned suffix (used for the PLAN N/M count).
-func sidebarHeader(label string, width int) string {
-	return zeroTheme.faint.Render(strings.ToUpper(label))
+// sidebarHeader renders a bold-muted uppercase section label. Bold muted (vs the
+// faint body items and placeholders) gives the header enough weight to read as a
+// section heading rather than more filler. The width arg is unused — kept so it
+// shares a signature with sidebarHeaderWithCount.
+func sidebarHeader(label string, _ int) string {
+	return zeroTheme.muted.Bold(true).Render(strings.ToUpper(label))
 }
 
-// sidebarHeaderWithCount renders a section header with a right-aligned count
-// (e.g. "PLAN   2/5"), padded to width.
-func sidebarHeaderWithCount(label, count string, width int) string {
-	left := zeroTheme.faint.Render(strings.ToUpper(label))
-	right := zeroTheme.faint.Render(count)
+// sidebarHeaderWithCount renders a bold-muted section label with a right-aligned
+// count (e.g. "PLAN   2/5") rendered in countStyle, so a section can colour its
+// count by state — accent while in-flight, green when complete.
+func sidebarHeaderWithCount(label, count string, countStyle lipgloss.Style, width int) string {
+	left := zeroTheme.muted.Bold(true).Render(strings.ToUpper(label))
+	right := countStyle.Render(count)
 	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
 	if gap < 1 {
 		return left
@@ -466,7 +553,12 @@ func (m model) sidebarPlanHeader(width int) string {
 			done++
 		}
 	}
-	return sidebarHeaderWithCount("PLAN", fmt.Sprintf("%d/%d", done, total), width)
+	// Stateful count: green once every step is done, accent while in-flight.
+	countStyle := zeroTheme.accent
+	if done == total {
+		countStyle = zeroTheme.green
+	}
+	return sidebarHeaderWithCount("PLAN", fmt.Sprintf("%d/%d", done, total), countStyle, width)
 }
 
 // sidebarPlanLines renders the plan step list for the sidebar using the same
@@ -509,7 +601,15 @@ func (m model) sidebarTokenLine(width int) string {
 	if label == "" {
 		label = "0 tokens"
 	}
-	return " " + zeroTheme.faint.Render(truncateRunes(label, maxInt(1, width-1)))
+	// Append the graded context-fill % — the at-a-glance "how full is the window"
+	// the compaction trigger reasons about. Reserve its width so the token label
+	// truncates around it rather than overflowing.
+	chip := ""
+	if pct, _, _, style, ok := m.contextFillPercent(); ok {
+		chip = zeroTheme.faint.Render(" · ") + style.Render(fmt.Sprintf("%d%%", pct))
+	}
+	budget := maxInt(1, width-1-lipgloss.Width(chip))
+	return " " + zeroTheme.faint.Render(truncateRunes(label, budget)) + chip
 }
 
 // sidebarTokenText computes the token figure shown at the sidebar floor: the
@@ -546,7 +646,11 @@ func joinColumns(chat []string, sidebar []string, chatW, sidebarW int) []string 
 	if len(sidebar) > rows {
 		rows = len(sidebar)
 	}
-	divider := zeroTheme.line.Render("│")
+	// A cell of air on each side of the rule (" │ ") so the columns don't butt
+	// flush against it. The chat side gets its gutter from the leading space; the
+	// sidebar side from the trailing space (plus items' own leading inset, which
+	// nests them under the flush section headers). Budgeted by chatColumnWidth(-3).
+	divider := " " + zeroTheme.line.Render("│") + " "
 	out := make([]string, rows)
 	for i := 0; i < rows; i++ {
 		left := ""

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -11,6 +11,8 @@ package tui
 
 import (
 	"fmt"
+	"image/color"
+	"regexp"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -83,34 +85,166 @@ func (m model) sidebarWidthForLayout() int {
 	return sidebarWidth(m.width)
 }
 
-// sidebarAgentHeader renders the AGENTS section header with a running/total
-// count of the subagents spawned this turn.
-func (m model) sidebarAgentHeader(width int) string {
-	agents := m.specialists.all()
-	if len(agents) == 0 {
-		return sidebarHeader("AGENTS", width)
-	}
-	running := 0
-	for _, a := range agents {
-		if a.status == specialistRunning {
-			running++
+// sidebarSpecialists returns the specialist delegations worth surfacing in the
+// AGENTS panel, EXCLUDING failed tool-misroutes: when a model calls a swarm (or
+// any other) tool name as if it were a specialist, the lookup fails with
+// "specialist <name> not found". That was never a real sub-agent, so it would
+// otherwise pile up bogus "× swarm_send" rows. Real specialists (e.g. "worker")
+// and genuine run failures still show.
+func (m model) sidebarSpecialists() []specialistInfo {
+	all := m.specialists.all()
+	out := all[:0:0]
+	for _, a := range all {
+		if a.status == specialistError && strings.Contains(strings.ToLower(a.errorMsg), "not found") {
+			continue
 		}
+		out = append(out, a)
 	}
-	return sidebarHeaderWithCount("AGENTS", fmt.Sprintf("%d/%d", running, len(agents)), width)
+	return out
 }
 
-// sidebarAgentLines renders one line per spawned subagent — a status glyph
-// (• running, ✓ done, ✗ error) and its name — plus a "↳ <tool> <detail>"
-// working line for each running agent so the live subagent activity is visible.
-// Returns nil when none are spawned (the caller then shows a placeholder).
+// sidebarHasAgents reports whether the two-column sidebar is active AND has at
+// least one agent line to animate (a specialist delegation or a swarm member).
+// The spinner tick keeps firing while this holds so the cool swarm ripple on
+// member names stays alive even when no run is in flight; gating it on the
+// sidebar+agent presence means a plain idle session schedules no timer.
+func (m model) sidebarHasAgents() bool {
+	if !m.sidebarActive() {
+		return false
+	}
+	return len(m.sidebarSpecialists())+len(m.swarmSpawnedAgents()) > 0
+}
+
+// sidebarAgentHeader renders the AGENTS section header with the total count of
+// active agents — specialist delegations plus swarm/team members.
+func (m model) sidebarAgentHeader(width int) string {
+	n := len(m.sidebarSpecialists()) + len(m.swarmSpawnedAgents())
+	if n == 0 {
+		return sidebarHeader("AGENTS", width)
+	}
+	return sidebarHeaderWithCount("AGENTS", fmt.Sprintf("%d", n), width)
+}
+
+// swarmSpawnRe extracts a member id from a swarm_spawn tool result, whose text
+// is "Spawned <type> as task <id> on team <team>." (internal/swarm/tools.go).
+var swarmSpawnRe = regexp.MustCompile(`as task (\S+) on team`)
+
+// swarmAgent is one spawned swarm/team member surfaced in the sidebar: the
+// stable id recovered from the spawn result, plus a human display name derived
+// from the spawn call's task briefing (falling back to the id).
+type swarmAgent struct {
+	id   string // e.g. "subagent-1" — the dedup key and fallback name
+	name string // the task briefing (argHint of the call row), or id when empty
+}
+
+// swarmSpawnedAgents derives the swarm/team members from the transcript's
+// swarm_spawn rows — the swarm roster lives in the CLI runtime, not the TUI
+// model, so members are recovered from the tool stream. Each member pairs a
+// swarm_spawn CALL row (whose detail = the task briefing, via argHint) with the
+// next swarm_spawn RESULT row (whose text yields the id, via swarmSpawnRe), so
+// the sidebar can name the agent by what it was asked to do rather than an
+// opaque "subagent-N". Only spawns that produced a result row (success) are
+// returned, and the list is deduped by id.
+func (m model) swarmSpawnedAgents() []swarmAgent {
+	// If a swarm_collect has run on any team, the swarm is considered closed
+	// and we no longer surface its members in the AGENTS sidebar.
+	for _, row := range m.transcript {
+		if row.tool == "swarm_collect" && row.kind == rowToolResult {
+			return nil
+		}
+	}
+
+	seen := map[string]bool{}
+	var agents []swarmAgent
+	// pendingTask holds the task from the most recent unmatched swarm_spawn call
+	// row, to be paired with the next swarm_spawn result row.
+	pendingTask := ""
+	havePending := false
+	for _, row := range m.transcript {
+		if row.tool != "swarm_spawn" {
+			continue
+		}
+		switch row.kind {
+		case rowToolCall:
+			pendingTask = strings.TrimSpace(row.detail)
+			havePending = true
+		case rowToolResult:
+			match := swarmSpawnRe.FindStringSubmatch(row.detail)
+			if match == nil {
+				continue
+			}
+			id := match[1]
+			task := ""
+			if havePending {
+				task = pendingTask
+			}
+			pendingTask = ""
+			havePending = false
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			name := shortTaskName(task)
+			if name == "" {
+				name = id
+			}
+			agents = append(agents, swarmAgent{id: id, name: name})
+		}
+	}
+	// Drop members the latest swarm_status reports as finished (done/failed) so
+	// they disappear from the sidebar once their work completes. Members not yet
+	// in a status report (just spawned) stay visible.
+	if status := m.swarmMemberStatus(); len(status) > 0 {
+		live := agents[:0:0]
+		for _, a := range agents {
+			switch status[a.id] {
+			case "done", "failed", "completed", "cancelled":
+				// finished — hide it
+			default:
+				live = append(live, a)
+			}
+		}
+		agents = live
+	}
+	return agents
+}
+
+// swarmStatusRe matches one member line of a swarm_status result, e.g.
+// "– teammate-1 [done] (cyan) <task>" → captures the id and the status word.
+var swarmStatusRe = regexp.MustCompile(`(?m)^\s*[-–—]?\s*(\S+)\s+\[([a-zA-Z]+)\]`)
+
+// swarmMemberStatus parses the LATEST swarm_status result in the transcript into
+// id → status (lowercased). Empty when no swarm_status has run yet.
+func (m model) swarmMemberStatus() map[string]string {
+	status := map[string]string{}
+	for _, row := range m.transcript {
+		if row.tool != "swarm_status" || row.kind != rowToolResult {
+			continue
+		}
+		latest := map[string]string{}
+		for _, mt := range swarmStatusRe.FindAllStringSubmatch(row.detail, -1) {
+			latest[mt[1]] = strings.ToLower(mt[2])
+		}
+		if len(latest) > 0 {
+			status = latest
+		}
+	}
+	return status
+}
+
+// sidebarAgentLines renders one line per active agent. Specialist delegations
+// show a live status glyph (• running, ✓ done, ✗ error) plus a "↳ <tool>" working
+// line; swarm/team members (from swarm_spawn) show a ready dot and their id.
+// Returns nil when there are none (the caller shows a placeholder).
 func (m model) sidebarAgentLines(width int) []string {
-	agents := m.specialists.all()
-	if len(agents) == 0 {
+	specialists := m.sidebarSpecialists()
+	swarm := m.swarmSpawnedAgents()
+	if len(specialists) == 0 && len(swarm) == 0 {
 		return nil
 	}
 	room := maxInt(4, width-3)
 	var lines []string
-	for _, a := range agents {
+	for _, a := range specialists {
 		var icon string
 		switch a.status {
 		case specialistRunning:
@@ -145,7 +279,98 @@ func (m model) sidebarAgentLines(width int) []string {
 			lines = append(lines, "   "+zeroTheme.faint.Render("↳ "+truncateStep(detail, maxInt(2, room-2))))
 		}
 	}
+	// Swarm/team members: the whole task-name carries a mild, slow cool pulse
+	// (NOT a per-letter ripple) so a live member reads as alive without noise.
+	style := m.swarmNameStyle()
+	for _, a := range swarm {
+		lines = append(lines, " "+zeroTheme.accent.Render("•")+" "+style.Render(truncateStep(a.name, room)))
+	}
 	return lines
+}
+
+// swarmNameStyle returns a gentle, whole-line cool tint for a live swarm member
+// name: mostly a calm blue, easing through a dimmer shade on a slow cycle — a
+// mild breathe, not a flashing per-letter ripple. Static blue under reduced
+// motion (or when the animation clock isn't advancing).
+func (m model) swarmNameStyle() lipgloss.Style {
+	if m.reducedMotion {
+		return zeroTheme.blue
+	}
+	styles := swarmPulseStyles()
+	if len(styles) == 0 {
+		return zeroTheme.blue
+	}
+	// Slow ping-pong through the subtle ramp for a smooth, slight breathe: the
+	// index eases up then back down so the colour never jumps (no flicker).
+	n := len(styles)
+	period := 2 * (n - 1)
+	if period <= 0 {
+		return styles[0]
+	}
+	p := (m.spinnerPhase / 5) % period
+	idx := p
+	if idx >= n {
+		idx = period - p
+	}
+	return styles[idx]
+}
+
+// swarmPulseStyles is a short, SUBTLE ramp from the cool blue toward a slightly
+// dimmer shade — only the bright portion of a blue→muted blend, so the dim end
+// stays bluish (a slight shift, not a blue→grey swing). Smooth gradient = no
+// flicker. Returns nil when the theme has no parseable colours (static fallback).
+func swarmPulseStyles() []lipgloss.Style {
+	fg := zeroTheme.blue.GetForeground()
+	dim := zeroTheme.muted.GetForeground()
+	if fg == nil || dim == nil {
+		return nil
+	}
+	blend := lipgloss.Blend1D(12, fg, dim)
+	if len(blend) > 5 {
+		blend = blend[:5] // brightest portion: blue → slightly dimmed blue
+	}
+	out := make([]lipgloss.Style, len(blend))
+	for i, c := range blend {
+		r, g, b, a := c.RGBA()
+		out[i] = lipgloss.NewStyle().Foreground(color.RGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(a >> 8)})
+	}
+	return out
+}
+
+// shortTaskName condenses a task briefing into a 1-2 word agent name: the first
+// significant word (usually the verb) plus the next non-filler word, so a member
+// reads as e.g. "Explore repository" instead of the full one-line briefing.
+func shortTaskName(task string) string {
+	task = strings.TrimSpace(task)
+	if task == "" {
+		return ""
+	}
+	picked := make([]string, 0, 2)
+	for _, w := range strings.Fields(task) {
+		clean := strings.Trim(w, ".,:;!?\"'`()[]{}")
+		if clean == "" {
+			continue
+		}
+		if len(picked) > 0 && nameFillerWords[strings.ToLower(clean)] {
+			continue
+		}
+		picked = append(picked, clean)
+		if len(picked) == 2 {
+			break
+		}
+	}
+	if len(picked) == 0 {
+		return task
+	}
+	return strings.Join(picked, " ")
+}
+
+// nameFillerWords are skipped (after the first word) when condensing a task into
+// a short agent name, so "Review the current branch" → "Review current".
+var nameFillerWords = map[string]bool{
+	"the": true, "a": true, "an": true, "to": true, "of": true, "for": true,
+	"and": true, "or": true, "on": true, "in": true, "with": true, "any": true,
+	"all": true, "its": true, "this": true, "that": true, "into": true, "from": true,
 }
 
 // renderContextSidebar builds the sidebar block: exactly height lines, each

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -1,0 +1,340 @@
+// sidebar.go renders the right-hand context sidebar for the two-column chat
+// layout (alt-screen managed mode only). The sidebar surfaces three sections —
+// the spawned AGENTS and their live working detail, the live PLAN (the same data
+// the pinned plan panel reads), and a token/context readout at the bottom — so
+// the chat column stays focused on the conversation. It is a set of pure
+// helpers: the layout in
+// transcriptView renders the chat at a reduced width via the existing scroll
+// engine, builds a sidebar block of the same height here, and joins the two
+// columns row-by-row through joinColumns.
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// sidebar geometry. The sidebar takes ~30% of the width, clamped so it never
+// crowds the chat on a narrow terminal nor sprawls on a wide one. A 1-cell
+// divider sits between the two columns.
+const (
+	sidebarMinWidth  = 26
+	sidebarMaxWidth  = 40
+	sidebarMinColumn = 60 // below this total width the sidebar is suppressed
+)
+
+// sidebarWidth returns the sidebar column width for a given total width, or 0
+// when the terminal is too narrow to justify a second column (the caller then
+// renders the single-column chat at full width).
+func sidebarWidth(total int) int {
+	if total < sidebarMinColumn {
+		return 0
+	}
+	return clamp(total*30/100, sidebarMinWidth, sidebarMaxWidth)
+}
+
+// sidebarActive reports whether the two-column layout should render: only in
+// alt-screen managed mode, with a measured height, on a wide-enough terminal.
+// The subchat drill-in keeps its own single-column view, so the sidebar is
+// suppressed there.
+func (m model) sidebarActive() bool {
+	if !m.altScreen || m.height <= 0 || m.subchat.active {
+		return false
+	}
+	if sidebarWidth(m.width) <= 0 {
+		return false
+	}
+	// Full-screen overlays (setup, wizards, pickers, the empty-state suggestion
+	// list) take over the chat column and render at full width; suppress the
+	// second column while any is active so their geometry and mouse hit-testing
+	// stay full-width as before.
+	if m.setup.visible || m.providerWizard != nil || m.mcpAddWizard != nil ||
+		m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
+		return false
+	}
+	// Home/welcome screen: stay single-column until there's real conversation, so
+	// the empty home screen isn't split by an (empty) sidebar.
+	if m.transcriptEmpty() {
+		return false
+	}
+	return true
+}
+
+// chatColumnWidth is the chat's render width: the full chat width normally, and
+// the reduced left-column width when the two-column layout is active (total
+// minus the sidebar and the 1-cell divider). All frame/geometry callers route
+// through this so the rendered chat, the scroll engine, and mouse hit-testing
+// agree on where the chat column ends.
+func (m model) chatColumnWidth() int {
+	if sw := m.sidebarWidthForLayout(); sw > 0 {
+		return chatWidth(m.width - sw - 1)
+	}
+	return chatWidth(m.width)
+}
+
+// sidebarWidthForLayout returns the active sidebar column width, or 0 when the
+// two-column layout is not active.
+func (m model) sidebarWidthForLayout() int {
+	if !m.sidebarActive() {
+		return 0
+	}
+	return sidebarWidth(m.width)
+}
+
+// sidebarAgentHeader renders the AGENTS section header with a running/total
+// count of the subagents spawned this turn.
+func (m model) sidebarAgentHeader(width int) string {
+	agents := m.specialists.all()
+	if len(agents) == 0 {
+		return sidebarHeader("AGENTS", width)
+	}
+	running := 0
+	for _, a := range agents {
+		if a.status == specialistRunning {
+			running++
+		}
+	}
+	return sidebarHeaderWithCount("AGENTS", fmt.Sprintf("%d/%d", running, len(agents)), width)
+}
+
+// sidebarAgentLines renders one line per spawned subagent — a status glyph
+// (• running, ✓ done, ✗ error) and its name — plus a "↳ <tool> <detail>"
+// working line for each running agent so the live subagent activity is visible.
+// Returns nil when none are spawned (the caller then shows a placeholder).
+func (m model) sidebarAgentLines(width int) []string {
+	agents := m.specialists.all()
+	if len(agents) == 0 {
+		return nil
+	}
+	room := maxInt(4, width-3)
+	var lines []string
+	for _, a := range agents {
+		var icon string
+		switch a.status {
+		case specialistRunning:
+			icon = zeroTheme.accent.Render("•")
+		case specialistError:
+			icon = zeroTheme.red.Render("✗")
+		default: // completed
+			icon = zeroTheme.green.Render("✓")
+		}
+		name := strings.TrimSpace(a.name)
+		if name == "" {
+			name = "agent"
+		}
+		lines = append(lines, " "+icon+" "+zeroTheme.ink.Render(truncateStep(name, room)))
+		if a.status != specialistRunning {
+			continue
+		}
+		// Live working detail for a running subagent: current tool + arg hint,
+		// falling back to the running tool count.
+		detail := strings.TrimSpace(a.currentTool)
+		if d := strings.TrimSpace(a.currentDetail); d != "" {
+			if detail != "" {
+				detail += " " + d
+			} else {
+				detail = d
+			}
+		}
+		if detail == "" && a.toolCount > 0 {
+			detail = fmt.Sprintf("%d tools", a.toolCount)
+		}
+		if detail != "" {
+			lines = append(lines, "   "+zeroTheme.faint.Render("↳ "+truncateStep(detail, maxInt(2, room-2))))
+		}
+	}
+	return lines
+}
+
+// renderContextSidebar builds the sidebar block: exactly height lines, each
+// exactly width cells (after fitStyledLine + padding). Sections render top to
+// bottom — FILES, PLAN — with the token readout pinned to the bottom line. Each
+// section header is a faint uppercase label; items use ink/muted. Empty
+// sections render a quiet placeholder rather than vanishing so the layout stays
+// stable.
+func (m model) renderContextSidebar(width, height int) []string {
+	if width <= 0 || height <= 0 {
+		return nil
+	}
+
+	var lines []string
+	add := func(s string) { lines = append(lines, s) }
+
+	// AGENTS section — spawned subagents and their live working detail.
+	add(m.sidebarAgentHeader(width))
+	agentLines := m.sidebarAgentLines(width)
+	if len(agentLines) == 0 {
+		add(sidebarPlaceholder("no agents spawned", width))
+	} else {
+		lines = append(lines, agentLines...)
+	}
+
+	// PLAN section.
+	add("")
+	add(m.sidebarPlanHeader(width))
+	planLines := m.sidebarPlanLines(width)
+	if len(planLines) == 0 {
+		add(sidebarPlaceholder("no active plan", width))
+	} else {
+		lines = append(lines, planLines...)
+	}
+
+	// Token readout pinned to the bottom.
+	tokenLine := m.sidebarTokenLine(width)
+	// Reserve the bottom row for tokens; pad the gap so it sits at the floor.
+	for len(lines) < height-1 {
+		add("")
+	}
+	if len(lines) > height-1 {
+		lines = lines[:height-1]
+	}
+	add(tokenLine)
+
+	// Normalize every row to exactly width cells.
+	for i := range lines {
+		lines[i] = padStyledLine(lines[i], width)
+	}
+	for len(lines) < height {
+		lines = append(lines, strings.Repeat(" ", width))
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return lines
+}
+
+// sidebarHeader renders an uppercase faint section header with an optional
+// right-aligned suffix (used for the PLAN N/M count).
+func sidebarHeader(label string, width int) string {
+	return zeroTheme.faint.Render(strings.ToUpper(label))
+}
+
+// sidebarHeaderWithCount renders a section header with a right-aligned count
+// (e.g. "PLAN   2/5"), padded to width.
+func sidebarHeaderWithCount(label, count string, width int) string {
+	left := zeroTheme.faint.Render(strings.ToUpper(label))
+	right := zeroTheme.faint.Render(count)
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		return left
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+// sidebarPlaceholder renders a quiet placeholder line for an empty section.
+func sidebarPlaceholder(text string, width int) string {
+	return " " + zeroTheme.faint.Render(truncateRunes(text, maxInt(1, width-1)))
+}
+
+// sidebarPlanHeader renders the PLAN section header with the done/total count.
+func (m model) sidebarPlanHeader(width int) string {
+	state := m.plan
+	if state.isEmpty() {
+		return sidebarHeader("PLAN", width)
+	}
+	total := len(state.steps)
+	done := 0
+	for _, step := range state.steps {
+		if step.status == "completed" || step.status == "failed" {
+			done++
+		}
+	}
+	return sidebarHeaderWithCount("PLAN", fmt.Sprintf("%d/%d", done, total), width)
+}
+
+// sidebarPlanLines renders the plan step list for the sidebar using the same
+// status glyphs as the pinned panel (✓ done, • in-progress, ○ pending, ✗
+// failed), reading m.plan directly so it stays in sync. Returns nil for an
+// empty plan (the caller then shows a placeholder).
+func (m model) sidebarPlanLines(width int) []string {
+	state := m.plan
+	if state.isEmpty() {
+		return nil
+	}
+	room := maxInt(4, width-3)
+	lines := make([]string, 0, len(state.steps))
+	for _, step := range state.steps {
+		var icon, body string
+		switch step.status {
+		case "completed":
+			icon = zeroTheme.green.Render("✓")
+			body = zeroTheme.muted.Render(truncateStep(step.content, room))
+		case "in_progress":
+			icon = zeroTheme.accent.Render("•")
+			body = zeroTheme.ink.Render(truncateStep(step.content, room))
+		case "failed":
+			icon = zeroTheme.red.Render("✗")
+			body = zeroTheme.muted.Render(truncateStep(step.content, room))
+		default: // pending
+			icon = zeroTheme.faint.Render("○")
+			body = zeroTheme.faint.Render(truncateStep(step.content, room))
+		}
+		lines = append(lines, " "+icon+" "+body)
+	}
+	return lines
+}
+
+// sidebarTokenLine renders the bottom token/context readout. It prefers the
+// live context-fill figure (last request's input tokens) and falls back to the
+// session's cumulative token count.
+func (m model) sidebarTokenLine(width int) string {
+	label := m.sidebarTokenText()
+	if label == "" {
+		label = "0 tokens"
+	}
+	return " " + zeroTheme.faint.Render(truncateRunes(label, maxInt(1, width-1)))
+}
+
+// sidebarTokenText computes the token figure shown at the sidebar floor: the
+// last request's context usage when known, else the cumulative session tokens.
+func (m model) sidebarTokenText() string {
+	if m.usageTracker == nil {
+		return ""
+	}
+	summary := m.usageTracker.Summary()
+	if summary.LastRecord != nil {
+		used := summary.LastRecord.Usage.InputTokens
+		if used > 0 {
+			if window := modelContextWindow(m.modelName); window > 0 {
+				return fmt.Sprintf("%s / %s tokens", humanCount(used), humanCount(window))
+			}
+			return humanCount(used) + " tokens"
+		}
+	}
+	if summary.RecordCount > 0 {
+		return humanCount(summary.InputTokens+summary.OutputTokens) + " tokens"
+	}
+	if m.unpricedRequests > 0 {
+		return humanCount(m.unpricedTokens) + " tokens"
+	}
+	return ""
+}
+
+// joinColumns splices a chat block and a sidebar block side-by-side, one
+// divider cell between them, into total-width rows. Both blocks are normalized
+// to their column widths and to the same row count first, so every joined row
+// is exactly chatWidth + 1 + sidebarWidth cells and the columns stay aligned.
+func joinColumns(chat []string, sidebar []string, chatW, sidebarW int) []string {
+	rows := len(chat)
+	if len(sidebar) > rows {
+		rows = len(sidebar)
+	}
+	divider := zeroTheme.line.Render("│")
+	out := make([]string, rows)
+	for i := 0; i < rows; i++ {
+		left := ""
+		if i < len(chat) {
+			left = chat[i]
+		}
+		right := ""
+		if i < len(sidebar) {
+			right = sidebar[i]
+		}
+		left = padStyledLine(left, chatW)
+		right = padStyledLine(right, sidebarW)
+		out[i] = left + divider + right
+	}
+	return out
+}

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -133,10 +133,120 @@ func TestSidebarShowsSpawnedAgents(t *testing.T) {
 	if !strings.Contains(plain, "grep") {
 		t.Fatalf("running subagent working detail missing:\n%s", plain)
 	}
-	// Header shows running/total.
+	// Header shows the total agent count.
 	hdr := stripSidebar([]string{m.sidebarAgentHeader(width)})
-	if !strings.Contains(hdr, "AGENTS") || !strings.Contains(hdr, "1/2") {
-		t.Fatalf("agent header should show AGENTS 1/2, got: %s", hdr)
+	if !strings.Contains(hdr, "AGENTS") || !strings.Contains(hdr, "2") {
+		t.Fatalf("agent header should show AGENTS 2, got: %s", hdr)
+	}
+}
+
+func TestSidebarShowsSwarmSpawnedAgents(t *testing.T) {
+	m := sidebarTestModel()
+	// Each swarm member is a CALL row (detail = the task briefing, as argHint
+	// would produce it) paired with its following RESULT row (yielding the id).
+	// The sidebar names the agent by the task, not the opaque "subagent-N".
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "audit the auth flow"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-1 on team default."},
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "write integration tests"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-2 on team default."},
+		// Duplicate id (a re-report): deduped, keeps the first member's name.
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "audit the auth flow"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-1 on team default."},
+	)
+	agents := m.swarmSpawnedAgents()
+	if len(agents) != 2 {
+		t.Fatalf("expected 2 unique swarm members, got %v", agents)
+	}
+	if agents[0].id != "subagent-1" || agents[0].name != "audit auth" {
+		t.Fatalf("member 0 = %+v, want id subagent-1 named 'audit auth' (short task name)", agents[0])
+	}
+	if agents[1].id != "subagent-2" || agents[1].name != "write integration" {
+		t.Fatalf("member 1 = %+v, want id subagent-2 named 'write integration' (short task name)", agents[1])
+	}
+	width := sidebarWidth(m.width)
+	plain := stripSidebar(m.sidebarAgentLines(width))
+	// The sidebar shows the short task-derived names, not the raw ids or full task.
+	if !strings.Contains(plain, "audit auth") || !strings.Contains(plain, "write integration") {
+		t.Fatalf("swarm member short task names missing from sidebar:\n%s", plain)
+	}
+	hdr := stripSidebar([]string{m.sidebarAgentHeader(width)})
+	if !strings.Contains(hdr, "AGENTS") || !strings.Contains(hdr, "2") {
+		t.Fatalf("header should show AGENTS 2, got: %s", hdr)
+	}
+}
+
+// TestSwarmSpawnedAgentFallsBackToID covers a result row with no preceding call
+// row (e.g. a resumed transcript that dropped the call): the member is still
+// shown, named by its id.
+func TestSwarmSpawnedAgentFallsBackToID(t *testing.T) {
+	m := sidebarTestModel()
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-9 on team default."},
+	)
+	agents := m.swarmSpawnedAgents()
+	if len(agents) != 1 || agents[0].id != "subagent-9" || agents[0].name != "subagent-9" {
+		t.Fatalf("expected one member named by id, got %+v", agents)
+	}
+}
+
+func TestShortTaskName(t *testing.T) {
+	cases := map[string]string{
+		"Explore the repository structure and summarize": "Explore repository",
+		"Review the current git branch":                  "Review current",
+		"Check for any TODOs, FIXMEs":                    "Check TODOs",
+		"Provide a high-level overview":                  "Provide high-level",
+		"single":                                         "single",
+		"":                                               "",
+	}
+	for task, want := range cases {
+		if got := shortTaskName(task); got != want {
+			t.Errorf("shortTaskName(%q) = %q, want %q", task, got, want)
+		}
+	}
+}
+
+func TestSwarmAgentsDisappearWhenDone(t *testing.T) {
+	m := sidebarTestModel()
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "explore repo"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned teammate as task teammate-1 on team default."},
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "review branch"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned teammate as task teammate-2 on team default."},
+	)
+	if got := len(m.swarmSpawnedAgents()); got != 2 {
+		t.Fatalf("expected 2 live members before any status report, got %d", got)
+	}
+	// A swarm_status marking teammate-1 done drops it; teammate-2 stays.
+	m.transcript = append(m.transcript, transcriptRow{
+		kind: rowToolResult, tool: "swarm_status",
+		detail: "Swarm status (team default): 2 task(s)\n– teammate-1 [done] (cyan) explore repo\n– teammate-2 [running] (blue) review branch",
+	})
+	agents := m.swarmSpawnedAgents()
+	if len(agents) != 1 || agents[0].id != "teammate-2" {
+		t.Fatalf("the done member should disappear; want only teammate-2, got %+v", agents)
+	}
+}
+
+func TestSidebarHidesNotFoundSpecialistMisroutes(t *testing.T) {
+	m := sidebarTestModel()
+	now := time.Now()
+	// A real running specialist + a failed tool-misroute (a swarm tool name called
+	// as a specialist → "specialist not found"), which should be filtered out.
+	m.specialists.start("worker", "build frontend", "sess-real", now)
+	m.specialists.start("swarm_send", "coordinate", "sess-bogus", now)
+	m.specialists.complete("sess-bogus", specialistError, 0, `specialist "swarm_send" not found`, now)
+
+	got := m.sidebarSpecialists()
+	if len(got) != 1 || got[0].name != "worker" {
+		t.Fatalf("not-found misroute should be filtered; want only worker, got %+v", got)
+	}
+	plain := stripSidebar(m.sidebarAgentLines(sidebarWidth(m.width)))
+	if strings.Contains(plain, "swarm_send") {
+		t.Fatalf("bogus swarm_send specialist should not appear:\n%s", plain)
+	}
+	if !strings.Contains(plain, "worker") {
+		t.Fatalf("real worker specialist should still appear:\n%s", plain)
 	}
 }
 

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -68,13 +68,39 @@ func TestSidebarActiveGating(t *testing.T) {
 	}
 }
 
+func TestSidebarToggleHidesAndShows(t *testing.T) {
+	m := sidebarTestModel()
+	if !m.sidebarActive() || !m.sidebarAvailable() {
+		t.Fatal("sidebar should be active and available for the test model")
+	}
+
+	// Ctrl+B hide preference suppresses the sidebar even though it's available.
+	m.sidebarHidden = true
+	if m.sidebarActive() {
+		t.Fatal("sidebar should be inactive when hidden by the user")
+	}
+	if !m.sidebarAvailable() {
+		t.Fatal("sidebarAvailable must ignore the hide preference (so Ctrl+B can re-show)")
+	}
+	// Hidden → the chat reflows to full width.
+	if got, want := m.chatColumnWidth(), chatWidth(m.width); got != want {
+		t.Fatalf("hidden sidebar: chat width = %d, want full %d", got, want)
+	}
+
+	// Toggling back restores the two-column layout.
+	m.sidebarHidden = false
+	if !m.sidebarActive() {
+		t.Fatal("sidebar should be active again after un-hiding")
+	}
+}
+
 func TestChatColumnWidthLeavesRoomForSidebar(t *testing.T) {
 	m := sidebarTestModel()
 	chatW := m.chatColumnWidth()
 	sidebarW := sidebarWidth(m.width)
-	if chatW+1+sidebarW != m.width {
-		t.Fatalf("chat(%d) + divider(1) + sidebar(%d) = %d, want total width %d",
-			chatW, sidebarW, chatW+1+sidebarW, m.width)
+	if chatW+3+sidebarW != m.width {
+		t.Fatalf("chat(%d) + divider(3) + sidebar(%d) = %d, want total width %d",
+			chatW, sidebarW, chatW+3+sidebarW, m.width)
 	}
 
 	// When the sidebar is inactive, chat width is the full chat width.
@@ -206,8 +232,10 @@ func TestShortTaskName(t *testing.T) {
 	}
 }
 
-func TestSwarmAgentsDisappearWhenDone(t *testing.T) {
+func TestSwarmAgentsLingerThenDisappearWhenDone(t *testing.T) {
+	base := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
 	m := sidebarTestModel()
+	m.now = func() time.Time { return base }
 	m.transcript = append(m.transcript,
 		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "explore repo"},
 		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned teammate as task teammate-1 on team default."},
@@ -217,14 +245,36 @@ func TestSwarmAgentsDisappearWhenDone(t *testing.T) {
 	if got := len(m.swarmSpawnedAgents()); got != 2 {
 		t.Fatalf("expected 2 live members before any status report, got %d", got)
 	}
-	// A swarm_status marking teammate-1 done drops it; teammate-2 stays.
+	// teammate-1 reported done, teammate-2 still running.
 	m.transcript = append(m.transcript, transcriptRow{
 		kind: rowToolResult, tool: "swarm_status",
 		detail: "Swarm status (team default): 2 task(s)\n– teammate-1 [done] (cyan) explore repo\n– teammate-2 [running] (blue) review branch",
 	})
+	// Freshly done (not yet stamped by the tick): teammate-1 LINGERS (finishing).
 	agents := m.swarmSpawnedAgents()
+	if len(agents) != 2 {
+		t.Fatalf("a freshly-done member should linger, got %d: %+v", len(agents), agents)
+	}
+	var done *swarmAgent
+	for i := range agents {
+		if agents[i].id == "teammate-1" {
+			done = &agents[i]
+		}
+	}
+	if done == nil || !done.finishing {
+		t.Fatalf("teammate-1 should be finishing (lingering), got %+v", agents)
+	}
+
+	// The spinner tick stamps the done time; once the linger window elapses the
+	// member is removed.
+	m.stampSwarmDone()
+	if _, ok := m.swarmDoneAt["teammate-1"]; !ok {
+		t.Fatal("stampSwarmDone should record the finished member")
+	}
+	m.swarmDoneAt["teammate-1"] = base.Add(-2 * sidebarAgentLinger) // past the window
+	agents = m.swarmSpawnedAgents()
 	if len(agents) != 1 || agents[0].id != "teammate-2" {
-		t.Fatalf("the done member should disappear; want only teammate-2, got %+v", agents)
+		t.Fatalf("after the linger the done member should be gone; got %+v", agents)
 	}
 }
 
@@ -279,7 +329,7 @@ func TestJoinColumnsAligns(t *testing.T) {
 	if len(rows) != 3 {
 		t.Fatalf("joined %d rows, want max(3,2)=3", len(rows))
 	}
-	want := chatW + 1 + sidebarW
+	want := chatW + 3 + sidebarW // " │ " padded divider
 	for i, row := range rows {
 		if w := lipgloss.Width(row); w != want {
 			t.Fatalf("row %d width = %d, want %d", i, w, want)

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -1,0 +1,197 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"charm.land/lipgloss/v2"
+)
+
+func sidebarTestModel() model {
+	m := newModel(context.Background(), Options{ProviderName: "test-provider", ModelName: "test-model"})
+	m.width = 100
+	m.height = 30
+	m.altScreen = true
+	m.headerPrinted = true
+	// Real conversation content so the home-screen gate doesn't suppress the
+	// sidebar (it stays single-column until the transcript has non-welcome rows).
+	m.transcript = append(m.transcript, transcriptRow{kind: rowToolCall, tool: "read_file", detail: "main.go"})
+	return m
+}
+
+func TestSidebarWidthClampsAndSuppresses(t *testing.T) {
+	if got := sidebarWidth(40); got != 0 {
+		t.Fatalf("sidebarWidth(40) = %d, want 0 (too narrow for a second column)", got)
+	}
+	if got := sidebarWidth(100); got < sidebarMinWidth || got > sidebarMaxWidth {
+		t.Fatalf("sidebarWidth(100) = %d, want within [%d,%d]", got, sidebarMinWidth, sidebarMaxWidth)
+	}
+	if got := sidebarWidth(400); got != sidebarMaxWidth {
+		t.Fatalf("sidebarWidth(400) = %d, want clamped to %d", got, sidebarMaxWidth)
+	}
+}
+
+func TestSidebarActiveGating(t *testing.T) {
+	m := sidebarTestModel()
+	if !m.sidebarActive() {
+		t.Fatalf("expected sidebar active for wide alt-screen model")
+	}
+
+	// Home/welcome screen (no real conversation yet): single column.
+	home := m
+	home.transcript = nil
+	if home.sidebarActive() {
+		t.Fatalf("sidebar should be inactive on the empty home screen")
+	}
+
+	// Too narrow: single column only.
+	narrow := m
+	narrow.width = 50
+	if narrow.sidebarActive() {
+		t.Fatalf("sidebar should be inactive on a narrow terminal")
+	}
+
+	// Inline (non-alt-screen) mode keeps the legacy single-column layout.
+	inline := m
+	inline.altScreen = false
+	if inline.sidebarActive() {
+		t.Fatalf("sidebar should be inactive in inline mode")
+	}
+
+	// Subchat drill-in owns the full width.
+	sub := m
+	sub.subchat.active = true
+	if sub.sidebarActive() {
+		t.Fatalf("sidebar should be inactive during subchat drill-in")
+	}
+}
+
+func TestChatColumnWidthLeavesRoomForSidebar(t *testing.T) {
+	m := sidebarTestModel()
+	chatW := m.chatColumnWidth()
+	sidebarW := sidebarWidth(m.width)
+	if chatW+1+sidebarW != m.width {
+		t.Fatalf("chat(%d) + divider(1) + sidebar(%d) = %d, want total width %d",
+			chatW, sidebarW, chatW+1+sidebarW, m.width)
+	}
+
+	// When the sidebar is inactive, chat width is the full chat width.
+	narrow := m
+	narrow.width = 50
+	if got := narrow.chatColumnWidth(); got != chatWidth(narrow.width) {
+		t.Fatalf("narrow chatColumnWidth = %d, want full chatWidth %d", got, chatWidth(narrow.width))
+	}
+}
+
+func TestRenderContextSidebarDimensions(t *testing.T) {
+	m := sidebarTestModel()
+	width := sidebarWidth(m.width)
+	const height = 20
+	lines := m.renderContextSidebar(width, height)
+	if len(lines) != height {
+		t.Fatalf("sidebar produced %d lines, want exactly %d", len(lines), height)
+	}
+	for i, line := range lines {
+		if w := lipgloss.Width(line); w != width {
+			t.Fatalf("sidebar line %d width = %d, want exactly %d", i, w, width)
+		}
+	}
+	// Section headers and the token floor should be present.
+	plain := stripSidebar(lines)
+	if !strings.Contains(plain, "AGENTS") {
+		t.Fatalf("sidebar missing AGENTS header:\n%s", plain)
+	}
+	if !strings.Contains(plain, "PLAN") {
+		t.Fatalf("sidebar missing PLAN header:\n%s", plain)
+	}
+	if !strings.Contains(plain, "tokens") {
+		t.Fatalf("sidebar missing token floor:\n%s", plain)
+	}
+}
+
+func TestSidebarShowsSpawnedAgents(t *testing.T) {
+	m := sidebarTestModel()
+	now := time.Now()
+	// One running subagent with live tool activity, one completed.
+	m.specialists.start("explorer", "map the codebase", "sess-1", now)
+	m.specialists.setCurrentTool("sess-1", "grep", "auth")
+	m.specialists.incrementToolCount("sess-1")
+	m.specialists.start("reviewer", "review diff", "sess-2", now)
+	m.specialists.complete("sess-2", specialistCompleted, 0, "", now)
+
+	width := sidebarWidth(m.width)
+	plain := stripSidebar(m.sidebarAgentLines(width))
+	if !strings.Contains(plain, "explorer") {
+		t.Fatalf("running subagent name missing:\n%s", plain)
+	}
+	if !strings.Contains(plain, "reviewer") {
+		t.Fatalf("completed subagent name missing:\n%s", plain)
+	}
+	// The running subagent surfaces its live working detail (current tool).
+	if !strings.Contains(plain, "grep") {
+		t.Fatalf("running subagent working detail missing:\n%s", plain)
+	}
+	// Header shows running/total.
+	hdr := stripSidebar([]string{m.sidebarAgentHeader(width)})
+	if !strings.Contains(hdr, "AGENTS") || !strings.Contains(hdr, "1/2") {
+		t.Fatalf("agent header should show AGENTS 1/2, got: %s", hdr)
+	}
+}
+
+func TestSidebarPlanReflectsState(t *testing.T) {
+	m := sidebarTestModel()
+	m.plan.steps = []planStep{
+		{content: "read code", status: "completed"},
+		{content: "refactor auth", status: "in_progress"},
+		{content: "run tests", status: "pending"},
+	}
+	header := plainRender(t, m.sidebarPlanHeader(40))
+	if !strings.Contains(header, "PLAN") || !strings.Contains(header, "1/3") {
+		t.Fatalf("plan header = %q, want PLAN with 1/3 count", header)
+	}
+	lines := m.sidebarPlanLines(40)
+	if len(lines) != 3 {
+		t.Fatalf("plan lines = %d, want 3", len(lines))
+	}
+	joined := stripSidebar(lines)
+	if !strings.Contains(joined, "✓") || !strings.Contains(joined, "•") || !strings.Contains(joined, "○") {
+		t.Fatalf("plan lines missing status glyphs:\n%s", joined)
+	}
+}
+
+func TestJoinColumnsAligns(t *testing.T) {
+	chat := []string{"hello", "world", "third row that is longer"}
+	sidebar := []string{"A", "B"}
+	const chatW, sidebarW = 12, 6
+	rows := joinColumns(chat, sidebar, chatW, sidebarW)
+	if len(rows) != 3 {
+		t.Fatalf("joined %d rows, want max(3,2)=3", len(rows))
+	}
+	want := chatW + 1 + sidebarW
+	for i, row := range rows {
+		if w := lipgloss.Width(row); w != want {
+			t.Fatalf("row %d width = %d, want %d", i, w, want)
+		}
+	}
+}
+
+func TestTwoColumnTranscriptViewWidth(t *testing.T) {
+	m := sidebarTestModel()
+	out := m.twoColumnTranscriptView()
+	lines := strings.Split(out, "\n")
+	if len(lines) != m.height {
+		t.Fatalf("two-column view = %d lines, want terminal height %d", len(lines), m.height)
+	}
+	for i, line := range lines {
+		if w := lipgloss.Width(line); w != m.width {
+			t.Fatalf("two-column row %d width = %d, want full width %d", i, w, m.width)
+		}
+	}
+}
+
+// stripSidebar joins sidebar lines and strips ANSI for content assertions.
+func stripSidebar(lines []string) string {
+	return ansiPattern.ReplaceAllString(strings.Join(lines, "\n"), "")
+}

--- a/internal/tui/specialist_click_test.go
+++ b/internal/tui/specialist_click_test.go
@@ -40,7 +40,7 @@ func specialistClickTestModel(t *testing.T, childSessionID string) model {
 // specialistCardClickPoint resolves the screen coordinates (x, y) of the first
 // selectable specialist card line in the model's transcript layout.
 func specialistCardClickPoint(m model, x int) (int, int, bool) {
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	layout := m.transcriptBodyLayout(width, "")
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	for _, line := range layout.selectable {

--- a/internal/tui/startup.go
+++ b/internal/tui/startup.go
@@ -38,7 +38,7 @@ const emptyStateTagline = "Any model. Every tool. Zero limits."
 // emptyState renders the centered stream-area block shown while the
 // transcript has no real content: the brand glyph and tagline.
 func (m model) emptyState(width int) string {
-	lines := emptyStateLines(width)
+	lines := m.emptyStateLines(width)
 
 	// Vertically center within the stream area: the frame around it (title bar,
 	// rules, composer, status line) occupies ~6 terminal rows.
@@ -63,21 +63,52 @@ func (m model) emptyStateWithOverlay(width int, overlay string) string {
 	return strings.Repeat("\n", gap) + strings.Join(lines, "\n") + strings.Repeat("\n", gap)
 }
 
-func emptyStateLines(width int) []string {
+func (m model) emptyStateLines(width int) []string {
 	lines := []string{}
 	for _, glyph := range zeroWordmarkLines() {
 		lines = append(lines, centerLine(glyph, width))
 	}
 	lines = append(lines, "")
 	lines = append(lines, centerLine(zeroTheme.muted.Render(emptyStateTagline), width))
+	// Orientation: where ZERO is pointed (cwd · branch · model) so a returning user
+	// sees the context before typing instead of a blank brand screen.
+	if orient := m.emptyStateOrientation(); orient != "" {
+		lines = append(lines, "")
+		lines = append(lines, centerLine(orient, width))
+	}
+	// A couple of example prompts to seed the first message.
+	lines = append(lines, "")
+	lines = append(lines, centerLine(zeroTheme.faint.Render(emptyStateExamples), width))
 	lines = append(lines, "")
 	lines = append(lines, centerLine(zeroTheme.faint.Render("Press ? for keyboard shortcuts · / for commands"), width))
-	// centerLine pads but never truncates; below ~62 cols the tagline would
-	// exceed the frame without this fit.
+	// centerLine pads but never truncates; below ~62 cols the lines would exceed
+	// the frame without this fit.
 	for index := range lines {
 		lines[index] = fitStyledLine(lines[index], width)
 	}
 	return lines
+}
+
+// emptyStateExamples seeds the first prompt with a few representative asks.
+const emptyStateExamples = `Try  "explain this codebase"  ·  "fix the failing test"  ·  "add a --json flag"`
+
+// emptyStateOrientation renders a faint "cwd · branch · model" line for the home
+// screen, omitting any piece that's unknown. Empty when nothing is known.
+func (m model) emptyStateOrientation() string {
+	parts := make([]string, 0, 3)
+	if cwd := strings.TrimSpace(m.cwd); cwd != "" {
+		parts = append(parts, shortenPath(cwd))
+	}
+	if branch := strings.TrimSpace(m.gitBranch); branch != "" {
+		parts = append(parts, branch)
+	}
+	if model := strings.TrimSpace(m.modelName); model != "" {
+		parts = append(parts, model)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return zeroTheme.faint.Render(strings.Join(parts, "  ·  "))
 }
 
 func zeroWordmarkLines() []string {

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -42,7 +42,6 @@ type tuiTheme struct {
 	toolName   lipgloss.Style // head-row tool name, ink bold
 	toolTarget lipgloss.Style // head-row target path, muted
 	toolArg    lipgloss.Style // one-line arg hint, faintest
-	autoTag    lipgloss.Style // `auto` auto-approval marker, amber
 	cardRun    lipgloss.Style // card border while the call runs (accent-mixed)
 	cardErr    lipgloss.Style // card border after an error (red-mixed)
 	bashPrompt lipgloss.Style // ❯ command gutter inside bash cards, accent bold
@@ -135,9 +134,9 @@ var darkPalette = palette{
 	line:      "#242429",
 	line2:     "#414147",
 	ink:       "#ececee",
-	muted:     "#8b8b93",
-	faint:     "#838389",
-	faintest:  "#7c7c82",
+	muted:     "#9a9aa2", // secondary text — lifted so it clearly out-ranks faint
+	faint:     "#8a8a92", // hints/metadata — nudged up to separate from faintest
+	faintest:  "#7c7c82", // line numbers/separators — pinned at the WCAG-AA floor on the dark panel
 	accent:    "#caff3f",
 	green:     "#5dd1a4",
 	red:       "#ff7a7a",
@@ -169,9 +168,9 @@ var lightPalette = palette{
 	line:      "#cfcfd5", // default borders
 	line2:     "#b0b0b8", // emphasized borders
 	ink:       "#1b1b1d", // primary text (near-black)
-	muted:     "#54545b", // secondary text
-	faint:     "#5b5b62", // hints, metadata
-	faintest:  "#646469", // line numbers, separators
+	muted:     "#4a4a52", // secondary text — darkened so it clearly out-ranks faint on light
+	faint:     "#57575f", // hints, metadata — nudged down to separate from faintest
+	faintest:  "#646469", // line numbers, separators — pinned at the WCAG-AA floor on the light panel
 	accent:    "#477006", // brand lime, darkened to AA contrast on light
 	green:     "#1c7a4a", // success / diff add
 	red:       "#c0322c", // errors / diff del
@@ -220,7 +219,6 @@ func buildTheme(p palette) tuiTheme {
 		toolName:   fg(p.ink).Bold(true),
 		toolTarget: fg(p.muted),
 		toolArg:    fg(p.faintest),
-		autoTag:    fg(p.amber),
 		cardRun:    fg(p.cardRun),
 		cardErr:    fg(p.cardErr),
 		bashPrompt: fg(p.accent).Bold(true),
@@ -246,8 +244,11 @@ func buildTheme(p palette) tuiTheme {
 		panel:           lipgloss.NewStyle().Background(col(p.panel)),
 		userPromptPanel: lipgloss.NewStyle().Background(col(p.promptBg)),
 
-		modeAuto:   fg(p.green).Bold(true),
-		modeAsk:    fg(p.amber).Bold(true),
+		modeAuto: fg(p.green).Bold(true),
+		// The steady "ask" footer label is calm (un-bolded) so it doesn't compete
+		// with the transient bold-amber permission badge (permBadge) shown when a
+		// tool is actually asking right now — a glance separates state from event.
+		modeAsk:    fg(p.amber),
 		modeUnsafe: fg(p.red).Bold(true),
 
 		accentColor: col(p.accent),

--- a/internal/tui/transcript_body_test.go
+++ b/internal/tui/transcript_body_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestTranscriptBodyItemsRepresentEmptyState(t *testing.T) {
 	m := mouseTestModel()
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 
 	items := m.transcriptBodyItems(width, "")
 	layout := layoutTranscriptBodyItems(items)
@@ -23,7 +23,7 @@ func TestTranscriptBodyItemsRepresentEmptyState(t *testing.T) {
 func TestTranscriptBodyItemsShiftSelectableLinesByItemStart(t *testing.T) {
 	m := mouseTestModel()
 	m.transcript = appendRow(m.transcript, rowUser, "hello")
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 
 	layout := layoutTranscriptBodyItems(m.transcriptBodyItems(width, ""))
 
@@ -49,7 +49,7 @@ func TestTranscriptBodyItemsKeepPendingInterimSelectableLocal(t *testing.T) {
 	m := mouseTestModel()
 	m.pending = true
 	m.streamingReasoning = "private thought"
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 
 	layout := layoutTranscriptBodyItems(m.transcriptBodyItems(width, ""))
 
@@ -178,7 +178,7 @@ func TestScrollableTranscriptItemsViewMatchesFullLayout(t *testing.T) {
 	m.transcript = appendRow(m.transcript, rowUser, "please inspect this request")
 	m.transcript = appendRow(m.transcript, rowAssistant, "first response line\nsecond response line\nthird response line")
 	m.transcript = appendRow(m.transcript, rowUser, "follow up")
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	header := m.pinnedTitleBar(width)
 	footer := m.footerView(width)
 	items := m.transcriptBodyItems(width, "")

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -194,6 +194,13 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 			if shownAny && havePreviousKind && isToolCardKind(previousKind) && isToolCardKind(row.kind) {
 				items = append(items, transcriptBlankBodyItem())
 			}
+			// A "Thought for X" reasoning header opens the next think→act group, so
+			// give it a blank above when it follows a tool card. Reasoning interleaves
+			// the tool cards (tool → thought → tool …), which breaks the
+			// tool-card→tool-card rule above; without this the groups pack into a wall.
+			if shownAny && havePreviousKind && row.kind == rowReasoning && isToolCardKind(previousKind) {
+				items = append(items, transcriptBlankBodyItem())
+			}
 			// The plan panel is no longer injected inline here — it is pinned
 			// above the composer (see footerView) so a streaming turn can't push
 			// it off-screen.

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -495,7 +495,18 @@ func (m model) renderSelectableToolResultRow(rowIndex int, row transcriptRow, wi
 	if rendered == "" {
 		return "", nil
 	}
-	selectable := []transcriptSelectableLine{{bodyY: startBodyY, rowIndex: rowIndex, toggle: true}}
+	// The first rendered line is the clickable toggle header; carry its text so a
+	// selection dragged through it copies the label too (the toggle flag still
+	// expands/collapses on a direct click, resolved on press before selection).
+	allLines := viewLines(rendered)
+	header := transcriptSelectableLine{bodyY: startBodyY, rowIndex: rowIndex, toggle: true}
+	if len(allLines) > 0 {
+		if meta, ok := selectableLineFromRenderedLine(rowIndex, startBodyY, allLines[0], false); ok {
+			header.text = meta.text
+			header.textStart = meta.textStart
+		}
+	}
+	selectable := []transcriptSelectableLine{header}
 	selectable = append(selectable, selectableLinesFromRendered(rowIndex, rendered, startBodyY, 1)...)
 	if !m.transcriptSelection.active {
 		return rendered, selectable
@@ -594,7 +605,10 @@ func (m model) renderRenderedSelection(rendered string, selectable []transcriptS
 	}
 	byY := make(map[int]transcriptSelectableLine, len(selectable))
 	for _, line := range selectable {
-		if line.text == "" || line.toggle || line.permOption || line.specialistCard {
+		// Toggle headers and specialist cards now carry text, so a selection
+		// dragged through them highlights and copies their content. Empty lines and
+		// permission buttons (no copyable content) stay excluded.
+		if line.text == "" || line.permOption {
 			continue
 		}
 		byY[line.bodyY] = line
@@ -635,14 +649,23 @@ func (m model) renderSelectableSpecialistRow(rowIndex int, row transcriptRow, wi
 		return "", nil
 	}
 	lines := viewLines(rendered)
+	boxed := renderedLinesHaveBoxBorder(lines)
 	selectable := make([]transcriptSelectableLine, len(lines))
 	for i := range lines {
-		selectable[i] = transcriptSelectableLine{
+		sl := transcriptSelectableLine{
 			bodyY:          startBodyY + i,
 			rowIndex:       rowIndex,
 			specialistCard: true,
 			specialistID:   row.specialistInfo.childSessionID,
 		}
+		// Carry the line's plain text + start so a selection dragged THROUGH the
+		// card copies its content; the specialistCard flag still makes a direct
+		// click drill into the sub-session (handled on press, before selection).
+		if meta, ok := selectableLineFromRenderedLine(rowIndex, startBodyY+i, lines[i], boxed); ok {
+			sl.text = meta.text
+			sl.textStart = meta.textStart
+		}
+		selectable[i] = sl
 	}
 	return rendered, selectable
 }

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -118,8 +118,41 @@ func (l transcriptBodyLayout) visibleLines(window transcriptViewportWindow) []st
 	return append([]string(nil), l.lines[start:end]...)
 }
 
+// padTranscriptBodyLines left-indents transcript body rows by gutter cells (the
+// reading-column margin). Horizontal only — it never changes the line count, so
+// the width-keyed height cache stays valid. Two-column mode right-pads the chat
+// block to the column width in joinColumns; single-column leaves the right blank.
+func padTranscriptBodyLines(lines []string, gutter int) []string {
+	if gutter <= 0 {
+		return lines
+	}
+	pad := strings.Repeat(" ", gutter)
+	for i := range lines {
+		lines[i] = pad + lines[i]
+	}
+	return lines
+}
+
+// shiftSelectableX bumps each selectable line's textStart by the gutter so
+// click-to-select and the highlight stay aligned with the indented glyphs (the
+// text now begins gutter cells further right on screen).
+func shiftSelectableX(lines []transcriptSelectableLine, gutter int) []transcriptSelectableLine {
+	if gutter <= 0 {
+		return lines
+	}
+	for i := range lines {
+		lines[i].textStart += gutter
+	}
+	return lines
+}
+
 func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptBodyItem {
 	items := []transcriptBodyItem{}
+	// Transcript ROWS render in a reading column: wrapped to contentWidth and
+	// indented by gutter, so wide terminals don't run text edge-to-edge. Block
+	// items (title bar, empty state, prompts) keep the full column width below.
+	contentWidth := transcriptContentWidth(width)
+	gutter := transcriptGutter(width)
 
 	// The inline title bar prints once into scrollback on the first WindowSizeMsg;
 	// until then it renders managed so the surface never appears headless.
@@ -188,15 +221,20 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				}
 			}
 			rowIndex, transcriptRow := index, row
-			heightCacheKey, heightCacheStable := m.transcriptRowBodyHeightCacheKey(transcriptRow, width, rc)
+			// Key the height cache on contentWidth (the wrap width drives line count);
+			// the gutter is a horizontal-only post-pad and never changes height.
+			heightCacheKey, heightCacheStable := m.transcriptRowBodyHeightCacheKey(transcriptRow, contentWidth, rc)
 			items = append(items, transcriptBodyItem{
 				kind:              transcriptBodyItemRow,
 				rowIndex:          rowIndex,
 				heightCacheKey:    heightCacheKey,
 				heightCacheStable: heightCacheStable,
 				render: func(startBodyY int) transcriptBodyRenderedItem {
-					rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, width, rc, startBodyY)
-					return transcriptBodyRenderedItem{lines: viewLines(rendered), selectable: selectable}
+					rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, contentWidth, rc, startBodyY)
+					return transcriptBodyRenderedItem{
+						lines:      padTranscriptBodyLines(viewLines(rendered), gutter),
+						selectable: shiftSelectableX(selectable, gutter),
+					}
 				},
 			})
 			shownAny = true
@@ -241,9 +279,11 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				kind:     transcriptBodyItemPendingInterim,
 				rowIndex: -1,
 				render: func(startBodyY int) transcriptBodyRenderedItem {
+					// Streaming text shares the reading column so it doesn't snap
+					// width when the turn finalizes into a row.
 					return transcriptBodyRenderedItem{
-						lines:      viewLines(m.interimBlock(width)),
-						selectable: m.renderSelectableStreamingReasoning(width, startBodyY),
+						lines:      padTranscriptBodyLines(viewLines(m.interimBlock(contentWidth)), gutter),
+						selectable: shiftSelectableX(m.renderSelectableStreamingReasoning(contentWidth, startBodyY), gutter),
 					}
 				},
 			})
@@ -291,6 +331,8 @@ func (m model) transcriptBodyItemsFromRows(rows []transcriptRow, width int) []tr
 		items = append(items, transcriptBlockBodyItem(transcriptBodyItemEmpty, -1, "No events in this subagent session."))
 		return items
 	}
+	contentWidth := transcriptContentWidth(width)
+	gutter := transcriptGutter(width)
 	rc := buildRowContext(rows)
 	shownAny := false
 	var previousKind rowKind
@@ -309,10 +351,13 @@ func (m model) transcriptBodyItemsFromRows(rows []transcriptRow, width int) []tr
 		items = append(items, transcriptBodyItem{
 			kind:           transcriptBodyItemRow,
 			rowIndex:       rowIndex,
-			heightCacheKey: "subchat:" + strconv.Itoa(index),
+			heightCacheKey: "subchat:" + strconv.Itoa(index) + ":" + strconv.Itoa(contentWidth),
 			render: func(startBodyY int) transcriptBodyRenderedItem {
-				rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, width, rc, startBodyY)
-				return transcriptBodyRenderedItem{lines: viewLines(rendered), selectable: selectable}
+				rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, contentWidth, rc, startBodyY)
+				return transcriptBodyRenderedItem{
+					lines:      padTranscriptBodyLines(viewLines(rendered), gutter),
+					selectable: shiftSelectableX(selectable, gutter),
+				}
 			},
 		})
 		shownAny = true

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -146,6 +146,19 @@ func shiftSelectableX(lines []transcriptSelectableLine, gutter int) []transcript
 	return lines
 }
 
+// finalizeTranscriptBodyRow indents a rendered row by the reading-column gutter,
+// shifts its selectable spans to match, and THEN paints the selection highlight —
+// so the highlight is computed in the same shifted coordinate the mouse maps to
+// and lands exactly where the user selected (instead of gutter cells off).
+func (m model) finalizeTranscriptBodyRow(rendered string, selectable []transcriptSelectableLine, gutter int, startBodyY int) transcriptBodyRenderedItem {
+	lines := padTranscriptBodyLines(viewLines(rendered), gutter)
+	shifted := shiftSelectableX(selectable, gutter)
+	if m.transcriptSelection.active {
+		lines = viewLines(m.renderRenderedSelection(strings.Join(lines, "\n"), shifted, startBodyY))
+	}
+	return transcriptBodyRenderedItem{lines: lines, selectable: shifted}
+}
+
 func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptBodyItem {
 	items := []transcriptBodyItem{}
 	// Transcript ROWS render in a reading column: wrapped to contentWidth and
@@ -238,10 +251,7 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				heightCacheStable: heightCacheStable,
 				render: func(startBodyY int) transcriptBodyRenderedItem {
 					rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, contentWidth, rc, startBodyY)
-					return transcriptBodyRenderedItem{
-						lines:      padTranscriptBodyLines(viewLines(rendered), gutter),
-						selectable: shiftSelectableX(selectable, gutter),
-					}
+					return m.finalizeTranscriptBodyRow(rendered, selectable, gutter, startBodyY)
 				},
 			})
 			shownAny = true
@@ -288,10 +298,7 @@ func (m model) transcriptBodyItems(width int, emptyOverlay string) []transcriptB
 				render: func(startBodyY int) transcriptBodyRenderedItem {
 					// Streaming text shares the reading column so it doesn't snap
 					// width when the turn finalizes into a row.
-					return transcriptBodyRenderedItem{
-						lines:      padTranscriptBodyLines(viewLines(m.interimBlock(contentWidth)), gutter),
-						selectable: shiftSelectableX(m.renderSelectableStreamingReasoning(contentWidth, startBodyY), gutter),
-					}
+					return m.finalizeTranscriptBodyRow(m.interimBlock(contentWidth), m.renderSelectableStreamingReasoning(contentWidth, startBodyY), gutter, startBodyY)
 				},
 			})
 		}
@@ -361,10 +368,7 @@ func (m model) transcriptBodyItemsFromRows(rows []transcriptRow, width int) []tr
 			heightCacheKey: "subchat:" + strconv.Itoa(index) + ":" + strconv.Itoa(contentWidth),
 			render: func(startBodyY int) transcriptBodyRenderedItem {
 				rendered, selectable := m.renderTranscriptRow(rowIndex, transcriptRow, contentWidth, rc, startBodyY)
-				return transcriptBodyRenderedItem{
-					lines:      padTranscriptBodyLines(viewLines(rendered), gutter),
-					selectable: shiftSelectableX(selectable, gutter),
-				}
+				return m.finalizeTranscriptBodyRow(rendered, selectable, gutter, startBodyY)
 			},
 		})
 		shownAny = true
@@ -515,10 +519,11 @@ func (m model) renderSelectableToolResultRow(rowIndex int, row transcriptRow, wi
 	}
 	selectable := []transcriptSelectableLine{header}
 	selectable = append(selectable, selectableLinesFromRendered(rowIndex, rendered, startBodyY, 1)...)
-	if !m.transcriptSelection.active {
-		return rendered, selectable
-	}
-	return m.renderRenderedSelection(rendered, selectable, startBodyY), selectable
+	// The selection highlight is painted once, at the body-item level, AFTER the
+	// reading-column gutter shift (finalizeTranscriptBodyRow) — in the same shifted
+	// coordinate the mouse maps to. Painting it here (unshifted) made the highlight
+	// land gutter cells off from where the user clicked.
+	return rendered, selectable
 }
 
 func (m model) renderSelectableRenderedRow(rowIndex int, row transcriptRow, width int, rc rowContext, startBodyY int) (string, []transcriptSelectableLine) {
@@ -527,10 +532,11 @@ func (m model) renderSelectableRenderedRow(rowIndex int, row transcriptRow, widt
 		return "", nil
 	}
 	selectable := selectableLinesFromRendered(rowIndex, rendered, startBodyY, 0)
-	if !m.transcriptSelection.active {
-		return rendered, selectable
-	}
-	return m.renderRenderedSelection(rendered, selectable, startBodyY), selectable
+	// The selection highlight is painted once, at the body-item level, AFTER the
+	// reading-column gutter shift (finalizeTranscriptBodyRow) — in the same shifted
+	// coordinate the mouse maps to. Painting it here (unshifted) made the highlight
+	// land gutter cells off from where the user clicked.
+	return rendered, selectable
 }
 
 func selectableLinesFromRendered(rowIndex int, rendered string, startBodyY int, skipLeading int) []transcriptSelectableLine {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -785,7 +785,7 @@ func (m model) transcriptLineAtMouse(msg tea.MouseMsg) (transcriptSelectableLine
 	if !m.altScreen || m.height <= 0 || m.setup.visible || m.providerWizard != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
 		return transcriptSelectableLine{}, false
 	}
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	frame := m.scrollableTranscriptFrame(m.pinnedTitleBar(width), m.footerView(width))
 	items := m.transcriptBodyItems(width, "")
 	metrics := measureTranscriptBodyItems(items, m.transcriptBodyHeights)
@@ -909,7 +909,7 @@ func (m model) toggleTranscriptRow(rowIndex int) model {
 }
 
 func (m model) selectedTranscriptText() string {
-	width := chatWidth(m.width)
+	width := m.chatColumnWidth()
 	layout := m.transcriptBodyLayout(width, "")
 	parts := []string{}
 	for _, line := range layout.selectable {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -862,7 +862,7 @@ func modelPickerItemDetail(item pickerItem) string {
 // argHint extracts the most representative argument from a tool call's raw JSON
 // arguments for the single-line tool row (the path, pattern, or command acted on).
 func argHint(raw string) string {
-	return firstArgValue(raw, []string{"path", "file", "file_path", "filepath", "pattern", "query", "command", "cmd", "url"})
+	return firstArgValue(raw, []string{"path", "file", "file_path", "filepath", "pattern", "query", "command", "cmd", "url", "task"})
 }
 
 // argHintSecondary extracts the card head's faintest arg column: the

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -167,17 +167,10 @@ func (m model) titleModelSegment() string {
 
 func (m model) composerDividerLine(width int) string {
 	model := displayValue(strings.TrimSpace(m.modelName), "no model")
-	label, style := m.modeLabel()
-	meta := zeroTheme.muted.Render(model) + zeroTheme.muted.Render(" · ") + style.Render(label)
-	if m.reasoningEffort != "" {
-		// Show the active reasoning effort in the brand lime so a just-cycled
-		// value (Ctrl+T) draws the eye. Omitted on "auto" (m.reasoningEffort ==
-		// "") so the segment appearing/disappearing is itself the auto-state
-		// feedback. Models without effort controls can't set a non-empty value
-		// here (handleModelCommand and the /effort picker both gate on
-		// availableReasoningEfforts), so no extra check is needed.
-		meta += zeroTheme.muted.Render(" · ") + zeroTheme.accent.Render(string(m.reasoningEffort))
-	}
+	// The composer rule is a quiet model reminder above the input. Permission mode
+	// and reasoning effort now live in the persistent status line (the conventional
+	// footer for run-state), so they're not duplicated on this rule.
+	meta := zeroTheme.muted.Render(model)
 	metaWidth := lipgloss.Width(meta)
 	if width < 8 {
 		return zeroTheme.lineStrong.Render(strings.Repeat("─", width))
@@ -189,25 +182,32 @@ func (m model) composerDividerLine(width int) string {
 	return zeroTheme.lineStrong.Render("╰"+rule+" ") + meta + zeroTheme.lineStrong.Render(" ╯")
 }
 
-// statusLine renders the bottom readout as ` │ `-separated groups: provider
-// on the left, then a flexible gap, then token/cost usage on the right. Groups
-// drop with the width tier: narrow keeps provider+usage, tiny shows provider.
+// statusLine renders the bottom readout as ` │ `-separated groups: the run-state
+// chip (permission mode + effort) on the left, a flexible gap, then the
+// context-fill gauge and token/cost usage on the right. The provider lives in the
+// title bar and is NOT duplicated here. Groups drop with the width tier.
 func (m model) statusLine(width int) string {
 	tier := widthTier(width)
 	separator := zeroTheme.line.Render(" │ ")
 	prefix := "  "
-	providerName := displayValue(strings.TrimSpace(m.providerDisplayName()), "no provider")
+
+	// Left chip: the safety-relevant run-state — permission mode (auto/ask/unsafe)
+	// in its mode colour. This was previously only on the easy-to-miss composer
+	// rule; the persistent footer is where users look for "will it run commands?".
+	modeText, modeStyle := m.modeLabel()
+	left := prefix + zeroTheme.accent.Render("●") + " " + modeStyle.Render(modeText)
 
 	if tier == tierTiny {
 		if m.exitConfirmActive {
-			warning := prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(ctrlCExitConfirmText)
-			return fitStyledLine(warning, width)
+			return fitStyledLine(prefix+zeroTheme.amber.Render("●")+" "+zeroTheme.amber.Render(ctrlCExitConfirmText), width)
 		}
-		provider := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
-		return fitStyledLine(provider, width)
+		return fitStyledLine(left, width)
 	}
 
-	left := prefix + zeroTheme.accent.Render("●") + " " + zeroTheme.ink.Render(providerName)
+	// Non-tiny: append the active reasoning effort (brand lime, omitted on auto).
+	if m.reasoningEffort != "" {
+		left += zeroTheme.muted.Render(" · ") + zeroTheme.accent.Render(string(m.reasoningEffort))
+	}
 	if m.exitConfirmActive {
 		left = prefix + zeroTheme.amber.Render("●") + " " + zeroTheme.amber.Render(ctrlCExitConfirmText)
 	} else if summary := m.backgroundTerminalSummary(); summary != "" {
@@ -215,9 +215,10 @@ func (m model) statusLine(width int) string {
 	}
 
 	rightGroups := []string{}
-	// The context-fill gauge needs the room a Medium+ terminal gives; below that
-	// the cumulative tok·cost segment alone keeps the line readable.
-	if tier >= tierMedium {
+	// Context-fill gauge: surface it down to the narrow tier (where it matters
+	// most), but skip it when the context sidebar is already showing the % so the
+	// figure isn't duplicated.
+	if tier >= tierNarrow && !m.sidebarActive() {
 		if gauge := m.contextWindowSegment(); gauge != "" {
 			rightGroups = append(rightGroups, gauge)
 		}
@@ -313,36 +314,47 @@ func (m model) usageStatusSegment() string {
 	)
 }
 
-// contextWindowSegment renders a live context-fill gauge: the last request's
-// input tokens against the active model's context window, as "◔ used/window ·
-// NN%", graded green (<75%) → amber (≥75%) → red (≥90%). Empty until a priced
-// request lands or when the model's window is unknown. This is the "you're at
-// X% of context" readout the compaction trigger already reasons about at 80%.
-func (m model) contextWindowSegment() string {
+// contextFillPercent returns the last request's context-window fill as a percent
+// (0-100), the tokens used, the model's window, and a colour graded for the fill
+// (green <75% → amber ≥75% → red ≥90%). ok is false until a priced request lands
+// or when the model's window is unknown. Shared by the status-line gauge and the
+// sidebar context chip so they grade identically. This is the "you're at X% of
+// context" reading the compaction trigger already reasons about at ~80%.
+func (m model) contextFillPercent() (pct, used, window int, style lipgloss.Style, ok bool) {
 	if m.usageTracker == nil {
-		return ""
+		return 0, 0, 0, lipgloss.Style{}, false
 	}
 	summary := m.usageTracker.Summary()
 	if summary.LastRecord == nil {
-		return ""
+		return 0, 0, 0, lipgloss.Style{}, false
 	}
-	used := summary.LastRecord.Usage.InputTokens
-	window := modelContextWindow(m.modelName)
+	used = summary.LastRecord.Usage.InputTokens
+	window = modelContextWindow(m.modelName)
 	if used <= 0 || window <= 0 {
-		return ""
+		return 0, 0, 0, lipgloss.Style{}, false
 	}
 	ratio := float64(used) / float64(window)
 	if ratio > 1 {
 		ratio = 1
 	}
-	style := zeroTheme.green
+	style = zeroTheme.green
 	switch {
 	case ratio >= 0.90:
 		style = zeroTheme.red
 	case ratio >= 0.75:
 		style = zeroTheme.amber
 	}
-	return style.Render(fmt.Sprintf("◔ %s/%s · %d%%", humanCount(used), humanCount(window), int(ratio*100+0.5)))
+	return int(ratio*100 + 0.5), used, window, style, true
+}
+
+// contextWindowSegment renders the status-line context-fill gauge as
+// "◔ used/window · NN%", graded by contextFillPercent.
+func (m model) contextWindowSegment() string {
+	pct, used, window, style, ok := m.contextFillPercent()
+	if !ok {
+		return ""
+	}
+	return style.Render(fmt.Sprintf("◔ %s/%s · %d%%", humanCount(used), humanCount(window), pct))
 }
 
 // humanCount renders a token count the way the status line wants it: 999,

--- a/internal/tui/width_tiers_test.go
+++ b/internal/tui/width_tiers_test.go
@@ -70,12 +70,21 @@ func TestWidthTierSegments(t *testing.T) {
 		}
 
 		status := plainRender(t, m.statusLine(tc.width))
-		if strings.Contains(status, "interactive") || strings.Contains(status, "claude-sonnet-4.5") || strings.Contains(status, "auto-approve") {
-			t.Errorf("width %d: status should not include surface, model, or permission mode (%q)", tc.width, status)
+		// Status line now carries the run-state chip (permission mode), NOT the
+		// surface or model (those live in the title bar / composer rule).
+		if strings.Contains(status, "interactive") || strings.Contains(status, "claude-sonnet-4.5") {
+			t.Errorf("width %d: status should not include surface or model (%q)", tc.width, status)
+		}
+		if !strings.Contains(status, "auto-approve") {
+			t.Errorf("width %d: status should show the permission mode (%q)", tc.width, status)
 		}
 		divider := plainRender(t, m.composerDividerLine(tc.width))
-		if !strings.Contains(divider, "claude-sonnet-4.5") || !strings.Contains(divider, "auto-approve") {
-			t.Errorf("width %d: composer divider must keep model and mode labels (%q)", tc.width, divider)
+		// The composer rule is model-only now; mode/effort moved to the status line.
+		if !strings.Contains(divider, "claude-sonnet-4.5") {
+			t.Errorf("width %d: composer divider must keep the model label (%q)", tc.width, divider)
+		}
+		if strings.Contains(divider, "auto-approve") {
+			t.Errorf("width %d: composer divider should no longer show the mode (%q)", tc.width, divider)
 		}
 	}
 }
@@ -85,15 +94,20 @@ func TestTinyTierSingleSegmentAndRailLessCards(t *testing.T) {
 	m.width, m.height = 40, 20
 
 	status := plainRender(t, m.statusLine(40))
-	if !strings.Contains(status, "anthropic") {
-		t.Fatalf("tiny status = %q, want provider status", status)
+	// Tiny status shows the permission-mode chip (the safety-relevant run-state),
+	// not the provider or model.
+	if !strings.Contains(status, "auto-approve") {
+		t.Fatalf("tiny status = %q, want the permission-mode chip", status)
 	}
-	if strings.Contains(status, "claude-sonnet-4.5") || strings.Contains(status, "auto-approve") {
-		t.Fatalf("tiny status = %q, want provider only", status)
+	if strings.Contains(status, "anthropic") || strings.Contains(status, "claude-sonnet-4.5") {
+		t.Fatalf("tiny status = %q, want mode only (no provider/model)", status)
 	}
 	divider := plainRender(t, m.composerDividerLine(40))
-	if !strings.Contains(divider, "claude-sonnet-4.5") || !strings.Contains(divider, "auto-approve") {
-		t.Fatalf("tiny composer divider = %q, want model and mode labels", divider)
+	if !strings.Contains(divider, "claude-sonnet-4.5") {
+		t.Fatalf("tiny composer divider = %q, want the model label", divider)
+	}
+	if strings.Contains(divider, "auto-approve") {
+		t.Fatalf("tiny composer divider = %q, mode should have moved to the status line", divider)
 	}
 
 	row := transcriptRow{kind: rowToolResult, id: "c", tool: "grep", status: tools.StatusOK, detail: "a.go:1: x"}
@@ -131,16 +145,16 @@ func TestTitleBarKeepsWorkspaceWithLongBranchAndModel(t *testing.T) {
 
 func TestComposerDividerRendersMetaAtExactFit(t *testing.T) {
 	m := newModel(context.Background(), Options{
-		ModelName:      "m",
+		ModelName:      "gpt-4o",
 		PermissionMode: agent.PermissionModeAsk,
 	})
-	label, style := m.modeLabel()
-	meta := zeroTheme.muted.Render("m") + zeroTheme.muted.Render(" · ") + style.Render(label)
+	// The divider meta is model-only now (mode/effort moved to the status line).
+	meta := zeroTheme.muted.Render("gpt-4o")
 	width := lipgloss.Width(meta) + 4
 
 	got := plainRender(t, m.composerDividerLine(width))
-	if !strings.Contains(got, "m") || !strings.Contains(got, label) {
-		t.Fatalf("exact-fit composer divider = %q, want metadata", got)
+	if !strings.Contains(got, "gpt-4o") {
+		t.Fatalf("exact-fit composer divider = %q, want the model label", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
A two-column managed-mode TUI: the existing **chat** (scroll/viewport engine, rendered at a reduced width) on the left, and a new right **context sidebar**.

### Sidebar
- **AGENTS** — spawned subagents with a status glyph (`•` running / `✓` done / `✗` error), the agent name, and a `↳ <tool> <detail>` **live working line** for running ones, plus a running/total count.
- **PLAN** — the live plan (same data as the pinned panel): `✓ / • / ○ / ✗` glyphs + `done/total`.
- **Tokens** — a context/token readout pinned to the floor.
- Suppressed on the **home screen** and under overlays / subchat drill-in; alt-screen managed mode only, gated to wide terminals.

### Plan-timer fix
Freeze the plan clock while the agent is idle (`activeRunID == 0`): an `in_progress` step left mid-plan when the agent yields (e.g. after `ask_user`) stops ticking up instead of counting forever against a turn that is no longer running; it resumes live on the next turn.

### Animations
- A **phase scroll indicator** (`↑ N-M/T ↓`) on the working line.
- A **cosine ripple** that breathes the "Working" label cold→warm, sharing the existing spinner tick; frozen under `ZERO_REDUCED_MOTION`. (The spinner itself was already animated.)

## Implementation
Reuses the existing scroll/viewport engine — the chat renders at a reduced width and the sidebar is composed alongside it row-by-row; no engine rewrite. Inline (non-managed) mode is unchanged (single column).

## Tests
New unit tests for the sidebar (home-screen gating, exact dimensions, spawned-agents render), the plan-clock freeze, and the pure animation helpers. `go build` / `go vet` / `go test ./internal/tui/...` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alt-screen two-column transcript view with a right context sidebar (Agents, Plan, tokens), toggleable with **Ctrl+B**.
* **Bug Fixes**
  * Improved mouse hit-testing and selection alignment across the composer, transcript, and overlays.
  * Notices now render as plain lines for clearer scanning.
* **Behavior Changes**
  * The permission-mode chip moved to the status line; the composer divider now shows only the model label.
  * Swarm tools update deferral behavior so eligible tools can be discoverable when a swarm is active.
  * Plan time now pauses while idle after runs complete or are cancelled.
* **Tests**
  * Added/updated coverage for sidebar layout, ripple/phase indicators, plan freezing, and transcript sizing/mouse interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — live swarm AGENTS sidebar + tool-deferral fix (2nd commit)

### Sidebar AGENTS — accurate live swarm/team
- Members are named by a **short 1-2 word task** (e.g. "Explore repository") instead of `subagent-N`.
- A **mild, slow cool pulse** on live member names (whole-line, no per-letter flicker).
- Members **disappear when done** — parsed from `swarm_status` `[done]`/`[failed]`.
- Bogus **"specialist not found" tool-misroutes are filtered** out of the panel (defense-in-depth).
- The animation tick stays alive while sidebar agents exist (so idle/standby members still breathe).

### Root-cause fix — stop the `specialist "swarm_send" not found` retry loop
Swarm tools are deferred (hidden behind `tool_search`), so a weaker model coordinating a live swarm couldn't see `swarm_send`/`swarm_status` and **misrouted them to the specialist tool** in a loop, flooding the panel. Now the swarm **coordination tools un-defer** (surface eagerly) once a swarm is active; `swarm_spawn`/`swarm_schedule`/`swarm_handoff` stay discoverable via `tool_search`.

A new optional **`DeferralEligible()`** interface keeps every swarm tool counting toward `DeferThreshold` even when exposed, so un-deferring can **never** drop the global deferral count and force-expose MCP schemas — in *any* threshold/filter config (verified by adversarial review across raised-threshold and tool-filter scenarios).

`go build`/`vet`/`test` green; `-race` clean on the swarm package.

---

## Update — TUI polish pass + reading column (commits 3-4)

A grounded polish pass across the TUI (surveyed first, then implemented in build-and-test-gated batches), plus a readable chat column.

**Hierarchy & color** — spread the gray tiers (WCAG-AA-safe); the "Working" ripple is lime-only (no semantic amber/green flashing); calmer steady `ask` label; dimmed completed plan steps; bold-muted sidebar headers + stateful PLAN count.

**Status line & footer** — a run-state chip (permission mode + effort) replaces the duplicated provider; composer rule is model-only; context-fill gauge down to the narrow tier + a sidebar context-% chip; a persistent idle key-hint and a jump-to-bottom cue.

**Motion** — pulsing streaming caret; a running specialist spins in the sidebar; finishing agents linger with a fading ✓ before removal (no abrupt pop).

**Layout** — `Ctrl+B` toggles the sidebar; padded `│` divider; sidebar gated to the medium tier so it never starves the chat. The chat transcript now renders in a **reading column** (≈90-col measure + small left gutter) so wide terminals don't run text edge-to-edge, with extra spacing before headings / between paragraphs. Selection stays aligned (textStart shifted by the gutter); mouse card hit-testing is Y-based so it's unaffected.

**Home screen** — `cwd · branch · model` orientation + example prompts.

`go build` / `vet` / `test` green; `-race` clean; no hex outside `theme.go`.