### PR TITLE
fix(sandbox): grant ancestor metadata so cd into the workspace works

### DIFF
--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -109,7 +109,28 @@ func permissionProfileReadRoots(workspaceRoot string, policy Policy, scope *Scop
 	if extra := normalizeProfileDirs(policy.AllowRead); len(extra) > 0 {
 		readRoots = dedupeStrings(append(readRoots, extra...))
 	}
-	return readRoots
+	for _, path := range userGitConfigReadPaths() {
+		if normalized := normalizeProfilePath(path); normalized != "" {
+			readRoots = append(readRoots, normalized)
+		}
+	}
+	return dedupeStrings(readRoots)
+}
+
+// userGitConfigReadPaths returns the user's global git config FILES so a
+// sandboxed git can read identity and config (user.name/email, aliases) instead
+// of failing with "unable to access ~/.gitconfig". It is deliberately the config
+// files only — not the ~/.config/git directory, which can hold an XDG credential
+// store — so credentials and the rest of HOME stay unreadable.
+func userGitConfigReadPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return nil
+	}
+	return []string{
+		filepath.Join(home, ".gitconfig"),
+		filepath.Join(home, ".config", "git", "config"),
+	}
 }
 
 func normalizeProfileDirs(entries []string) []string {

--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -109,11 +109,6 @@ func permissionProfileReadRoots(workspaceRoot string, policy Policy, scope *Scop
 	if extra := normalizeProfileDirs(policy.AllowRead); len(extra) > 0 {
 		readRoots = dedupeStrings(append(readRoots, extra...))
 	}
-	for _, path := range userGitConfigReadPaths() {
-		if normalized := normalizeProfilePath(path); normalized != "" {
-			readRoots = append(readRoots, normalized)
-		}
-	}
 	return dedupeStrings(readRoots)
 }
 
@@ -121,7 +116,9 @@ func permissionProfileReadRoots(workspaceRoot string, policy Policy, scope *Scop
 // sandboxed git can read identity and config (user.name/email, aliases) instead
 // of failing with "unable to access ~/.gitconfig". It is deliberately the config
 // files only — not the ~/.config/git directory, which can hold an XDG credential
-// store — so credentials and the rest of HOME stay unreadable.
+// store — so credentials and the rest of HOME stay unreadable. Granted at the
+// macOS-seatbelt read rule (not the cross-platform PermissionProfile) so the
+// HOME-dependent paths don't leak into the platform-agnostic policy snapshot.
 func userGitConfigReadPaths() []string {
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -553,7 +553,11 @@ func seatbeltProfileFromPermissionProfile(profile PermissionProfile, policy Poli
 		"(version 1)",
 		denyDefault,
 		"(allow process*)",
-		"(allow process-info* (target same-sandbox))",
+		// Process info for all processes so `ps`, `lsof`, `pgrep` and friends can find
+		// the processes the user asks the agent to inspect or terminate (e.g. a stale
+		// dev server). Read-only inspection; actually signalling them is governed by
+		// the signal rule below, and the kernel enforces UID ownership either way.
+		"(allow process-info*)",
 		"(allow sysctl-read)",
 		"(allow sysctl-write (sysctl-name \"kern.grade_cputype\"))",
 		"(allow iokit-open (iokit-registry-entry-class \"RootDomainUserClient\"))",

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -593,7 +593,12 @@ func seatbeltReadRule(fs FileSystemPolicy) string {
 	if fs.Kind == FileSystemUnrestricted {
 		return "(allow file-read*)"
 	}
-	filters := make([]string, 0, len(fs.ReadRoots)+len(macosPlatformReadRoots()))
+	// The user's global git config files so a sandboxed git can read identity and
+	// config. Granted here (macOS seatbelt) rather than the cross-platform
+	// PermissionProfile so the HOME-dependent paths don't leak into the platform-
+	// agnostic policy snapshot.
+	gitConfig := normalizeProfilePaths(userGitConfigReadPaths())
+	filters := make([]string, 0, len(fs.ReadRoots)+len(macosPlatformReadRoots())+len(gitConfig))
 	for _, root := range fs.ReadRoots {
 		filters = appendSeatbeltSubpathFilter(filters, root)
 	}
@@ -601,6 +606,9 @@ func seatbeltReadRule(fs FileSystemPolicy) string {
 		for _, root := range macosPlatformReadRoots() {
 			filters = appendSeatbeltSubpathFilter(filters, root)
 		}
+	}
+	for _, path := range gitConfig {
+		filters = appendSeatbeltSubpathFilter(filters, path)
 	}
 	if len(filters) == 0 {
 		return ""
@@ -615,7 +623,8 @@ func seatbeltReadRule(fs FileSystemPolicy) string {
 	// permission error. This is metadata only: ancestor directory *contents* stay
 	// unreadable. Platform roots are top-level or already covered, so this only
 	// needs the dynamic read roots (workspace, write roots, granted dirs).
-	if ancestors := seatbeltAncestorMetadataRule(fs.ReadRoots); ancestors != "" {
+	ancestorRoots := append(append([]string{}, fs.ReadRoots...), gitConfig...)
+	if ancestors := seatbeltAncestorMetadataRule(ancestorRoots); ancestors != "" {
 		rule += "\n" + ancestors
 	}
 	return rule

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -621,9 +621,14 @@ func seatbeltReadRule(fs FileSystemPolicy) string {
 	// denied at the first ungranted parent — and macOS seatbelt surfaces that
 	// denial as the misleading "cd: …: Not a directory" (ENOTDIR), not a clear
 	// permission error. This is metadata only: ancestor directory *contents* stay
-	// unreadable. Platform roots are top-level or already covered, so this only
-	// needs the dynamic read roots (workspace, write roots, granted dirs).
-	ancestorRoots := append(append([]string{}, fs.ReadRoots...), gitConfig...)
+	// unreadable. Platform read roots are included too: not all are top-level —
+	// /Library/Developer (the CLT toolchain) needs /Library stat-able, or a `cd`
+	// into it (and any chdir-style traversal) ENOTDIRs even though reads succeed.
+	ancestorRoots := append([]string{}, fs.ReadRoots...)
+	if fs.IncludePlatformRoots {
+		ancestorRoots = append(ancestorRoots, macosPlatformReadRoots()...)
+	}
+	ancestorRoots = append(ancestorRoots, gitConfig...)
 	if ancestors := seatbeltAncestorMetadataRule(ancestorRoots); ancestors != "" {
 		rule += "\n" + ancestors
 	}

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -598,7 +598,36 @@ func seatbeltReadRule(fs FileSystemPolicy) string {
 	if len(filters) == 0 {
 		return ""
 	}
-	return "(allow file-read* file-test-existence\n  " + strings.Join(filters, "\n  ") + ")"
+	rule := "(allow file-read* file-test-existence\n  " + strings.Join(filters, "\n  ") + ")"
+	// Grant stat/existence on the ANCESTOR chain of every granted read root so path
+	// resolution can traverse down to it. A (subpath "/a/b/ws") filter grants the
+	// root and its descendants but NOT its parents (/a, /a/b), so resolving an
+	// absolute path like `cd /a/b/ws` (or any path the kernel canonicalises) is
+	// denied at the first ungranted parent — and macOS seatbelt surfaces that
+	// denial as the misleading "cd: …: Not a directory" (ENOTDIR), not a clear
+	// permission error. This is metadata only: ancestor directory *contents* stay
+	// unreadable. Platform roots are top-level or already covered, so this only
+	// needs the dynamic read roots (workspace, write roots, granted dirs).
+	if ancestors := seatbeltAncestorMetadataRule(fs.ReadRoots); ancestors != "" {
+		rule += "\n" + ancestors
+	}
+	return rule
+}
+
+// seatbeltAncestorMetadataRule allows stat/test-existence on the ancestor
+// directories of each root via the path-ancestors filter, so chdir and
+// absolute-path resolution can traverse to a deeply-nested granted root.
+func seatbeltAncestorMetadataRule(roots []string) string {
+	filters := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root = strings.TrimSpace(root); root != "" {
+			filters = append(filters, `(path-ancestors "`+sandboxProfileString(root)+`")`)
+		}
+	}
+	if len(filters) == 0 {
+		return ""
+	}
+	return "(allow file-read-metadata file-test-existence\n  " + strings.Join(filters, "\n  ") + ")"
 }
 
 func seatbeltWriteRule(fs FileSystemPolicy) string {

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -620,9 +620,17 @@ func seatbeltReadRule(fs FileSystemPolicy) string {
 func seatbeltAncestorMetadataRule(roots []string) string {
 	filters := make([]string, 0, len(roots))
 	for _, root := range roots {
-		if root = strings.TrimSpace(root); root != "" {
-			filters = append(filters, `(path-ancestors "`+sandboxProfileString(root)+`")`)
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
 		}
+		// A filesystem/volume root (e.g. "/") has no ancestors, and (path-ancestors
+		// "/") is INVALID SBPL — sandbox-exec aborts and the command can't launch at
+		// all. Skip it; the root itself is already covered by its subpath read grant.
+		if clean := filepath.Clean(root); filepath.Dir(clean) == clean {
+			continue
+		}
+		filters = append(filters, `(path-ancestors "`+sandboxProfileString(root)+`")`)
 	}
 	if len(filters) == 0 {
 		return ""

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -565,11 +565,14 @@ func seatbeltProfileFromPermissionProfile(profile PermissionProfile, policy Poli
 		`(allow file-ioctl (regex #"^/dev/ttys[0-9]+"))`,
 		"(allow ipc-posix-shm-read* (ipc-posix-name-prefix \"apple.cfprefs.\"))",
 		"(allow user-preference-read)",
-		// Let a sandboxed command signal itself and its own process group so scripts
-		// that spawn and kill children (e.g. `sleep 30 & kill %1`, test runners,
-		// timeouts) work. The target restriction keeps it from signalling any
-		// process outside its own group.
-		"(allow signal (target self) (target pgrp))",
+		// Let a sandboxed command send signals. This covers its own children (test
+		// runners, timeouts, `sleep 30 & kill %1`) AND user-owned processes the user
+		// asks the agent to terminate — e.g. a stale dev server left listening on a
+		// port by a previous session, which lives in a different process group and so
+		// was previously unkillable. The kernel still enforces UID ownership: a
+		// sandboxed command runs as the user, so it can only signal the user's own
+		// processes, never root's or another user's.
+		"(allow signal)",
 		sandboxMachLookupRule(),
 		seatbeltPlatformRuntimeRules(),
 		readRule,

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -805,6 +805,12 @@ func macosPlatformReadRoots() []string {
 		// readable; writes stay confined to the workspace.
 		"/usr/local",
 		"/opt/homebrew",
+		// Xcode Command Line Tools toolchain. /usr/bin/git (and clang, make, etc.)
+		// are thin stubs that resolve the real binary under the active developer
+		// dir — usually /Library/Developer/CommandLineTools. Without read+exec here
+		// the stub can't reach the real tool and fails with the misleading
+		// "xcode-select: No developer tools were found" error.
+		"/Library/Developer",
 		"/etc",
 		"/private/etc",
 		"/var/db",

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -262,6 +262,28 @@ func TestSeatbeltProfileGrantsAncestorMetadataForTraversal(t *testing.T) {
 	}
 }
 
+func TestSeatbeltAncestorRuleSkipsFilesystemRoot(t *testing.T) {
+	// A "/" read root has no ancestors; (path-ancestors "/") is invalid SBPL and
+	// makes sandbox-exec abort (exit 65), so the rule must skip it entirely.
+	if rule := seatbeltAncestorMetadataRule([]string{"/"}); rule != "" {
+		t.Fatalf(`expected no ancestor rule for "/", got: %q`, rule)
+	}
+	// Mixed roots: a real root still gets its grant; "/" is dropped.
+	rule := seatbeltAncestorMetadataRule([]string{"/", "/Users/me/app"})
+	if strings.Contains(rule, `(path-ancestors "/")`) {
+		t.Fatalf(`rule must not contain (path-ancestors "/"): %q`, rule)
+	}
+	if !strings.Contains(rule, `(path-ancestors "/Users/me/app")`) {
+		t.Fatalf("expected ancestor grant for the real root: %q", rule)
+	}
+	// The compat builder hard-codes ReadRoots=["/"] and flips to restricted under
+	// EnforceWorkspace — the generated profile must not contain the malformed rule.
+	compat := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "")
+	if strings.Contains(compat, `(path-ancestors "/")`) {
+		t.Fatalf("compat profile must not contain (path-ancestors \"/\"):\n%s", compat)
+	}
+}
+
 func TestSeatbeltProfileConsumesPermissionProfile(t *testing.T) {
 	profile := PermissionProfile{
 		FileSystem: FileSystemPolicy{

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -297,6 +297,12 @@ func TestSeatbeltProfileGrantsCLTToolchain(t *testing.T) {
 	if !strings.Contains(sbpl, `(subpath "/Library/Developer")`) {
 		t.Fatalf("profile must grant read on the CLT toolchain (/Library/Developer):\n%s", sbpl)
 	}
+	// /Library/Developer is not top-level, so its ancestor (/Library) must be
+	// stat-able or a chdir-style traversal into the toolchain ENOTDIRs even though
+	// reads succeed. Platform read roots must get the ancestor-metadata grant too.
+	if !strings.Contains(sbpl, `(path-ancestors "/Library/Developer")`) {
+		t.Fatalf("profile must grant ancestor metadata for /Library/Developer so /Library is traversable:\n%s", sbpl)
+	}
 }
 
 func TestUserGitConfigReadPathsScopedToConfigFiles(t *testing.T) {

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -231,6 +231,37 @@ func TestSandboxExecProfileIncludesExtraWriteRoots(t *testing.T) {
 	}
 }
 
+func TestSeatbeltProfileGrantsAncestorMetadataForTraversal(t *testing.T) {
+	// A deeply-nested workspace: the (subpath …) read filter grants the root and
+	// its descendants but not its parents, so resolving `cd /Users/me/proj/app`
+	// must stat /Users, /Users/me, /Users/me/proj — none of which are granted by
+	// the subpath alone. Seatbelt then denies the chdir and reports the misleading
+	// "Not a directory". The path-ancestors metadata grant fixes the traversal.
+	profile := PermissionProfile{
+		FileSystem: FileSystemPolicy{
+			Kind:                 FileSystemRestricted,
+			ReadRoots:            []string{"/Users/me/proj/app"},
+			WriteRoots:           []WritableRoot{{Root: "/Users/me/proj/app"}},
+			IncludePlatformRoots: true,
+		},
+		Network: NetworkPolicy{Mode: NetworkDeny},
+	}
+	sbpl := seatbeltProfileFromPermissionProfile(profile, Policy{Mode: ModeEnforce}, "")
+	if !strings.Contains(sbpl, "(allow file-read-metadata file-test-existence") {
+		t.Fatalf("profile missing ancestor metadata rule:\n%s", sbpl)
+	}
+	if !strings.Contains(sbpl, `(path-ancestors "/Users/me/proj/app")`) {
+		t.Fatalf("profile missing path-ancestors for the workspace read root:\n%s", sbpl)
+	}
+	// Metadata only — the ancestors must NOT get a content-read (subpath) grant.
+	if strings.Contains(sbpl, `file-read-data`) && strings.Contains(sbpl, `(path-ancestors`) {
+		// guard against a future change that widens the ancestor grant to data
+		if strings.Contains(sbpl, `file-read* file-test-existence file-read-data`) {
+			t.Fatalf("ancestor grant must stay metadata-only:\n%s", sbpl)
+		}
+	}
+}
+
 func TestSeatbeltProfileConsumesPermissionProfile(t *testing.T) {
 	profile := PermissionProfile{
 		FileSystem: FileSystemPolicy{

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -299,6 +299,27 @@ func TestSeatbeltProfileGrantsCLTToolchain(t *testing.T) {
 	}
 }
 
+func TestUserGitConfigReadPathsScopedToConfigFiles(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		t.Skip("no home dir")
+	}
+	paths := userGitConfigReadPaths()
+	found := false
+	for _, p := range paths {
+		if p == filepath.Join(home, ".gitconfig") {
+			found = true
+		}
+		// Must NOT grant the whole ~/.config/git dir — it can hold a credential store.
+		if p == filepath.Join(home, ".config", "git") {
+			t.Fatalf("must not grant the ~/.config/git directory (credential store): %v", paths)
+		}
+	}
+	if !found {
+		t.Fatalf("expected ~/.gitconfig in git config read paths, got %v", paths)
+	}
+}
+
 func TestSeatbeltProfileConsumesPermissionProfile(t *testing.T) {
 	profile := PermissionProfile{
 		FileSystem: FileSystemPolicy{

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -284,6 +284,21 @@ func TestSeatbeltAncestorRuleSkipsFilesystemRoot(t *testing.T) {
 	}
 }
 
+func TestSeatbeltProfileGrantsCLTToolchain(t *testing.T) {
+	// /usr/bin/git, clang, make, etc. are stubs that resolve the real binary under
+	// the active developer dir (/Library/Developer/CommandLineTools). The platform
+	// read roots must include it or the stub fails with "xcode-select: No developer
+	// tools were found".
+	profile := PermissionProfile{
+		FileSystem: FileSystemPolicy{Kind: FileSystemRestricted, ReadRoots: []string{"/ws"}, IncludePlatformRoots: true},
+		Network:    NetworkPolicy{Mode: NetworkDeny},
+	}
+	sbpl := seatbeltProfileFromPermissionProfile(profile, Policy{Mode: ModeEnforce}, "")
+	if !strings.Contains(sbpl, `(subpath "/Library/Developer")`) {
+		t.Fatalf("profile must grant read on the CLT toolchain (/Library/Developer):\n%s", sbpl)
+	}
+}
+
 func TestSeatbeltProfileConsumesPermissionProfile(t *testing.T) {
 	profile := PermissionProfile{
 		FileSystem: FileSystemPolicy{

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -497,9 +497,11 @@ func TestSandboxExecCommandPlanUsesUniquePerPlanDenialTag(t *testing.T) {
 func TestSandboxExecProfileGrantsSignalAndMachLookup(t *testing.T) {
 	profile := sandboxExecProfile([]string{"/ws"}, Policy{Mode: ModeEnforce, EnforceWorkspace: true}, "")
 
-	// Signalling own process group lets a sandboxed script kill the children it
-	// spawns; without it seatbelt denies kill() with "Operation not permitted".
-	if !strings.Contains(profile, "(allow signal (target self) (target pgrp))") {
+	// Signalling is allowed so a sandboxed command can kill the children it spawns
+	// AND user-owned processes the user asks it to terminate (e.g. a stale dev
+	// server from a previous session, in a different process group). The kernel
+	// still enforces UID ownership, so root/other-user processes stay protected.
+	if !strings.Contains(profile, "(allow signal)") {
 		t.Fatalf("profile missing signal allowance:\n%s", profile)
 	}
 	// Curated mach-lookup so keychain/opendirectory/preferences/network-config

--- a/internal/tools/shell_runtime.go
+++ b/internal/tools/shell_runtime.go
@@ -34,7 +34,14 @@ func shellGuidanceForGOOS(goos string) string {
 	if goos == "windows" {
 		return "Uses " + runtime.Syntax + " syntax on Windows; prefer cwd over cd when changing directories."
 	}
-	return "Uses " + runtime.Syntax + " syntax."
+	guidance := "Uses " + runtime.Syntax + " syntax."
+	if goos == "darwin" {
+		// `ps` is setuid root and cannot run under the macOS sandbox; `pgrep` needs a
+		// blocked system service. Point the model at the tools that DO work so it
+		// doesn't waste turns: lsof to find a process, kill to stop it.
+		guidance += " To find or stop a process, use `lsof -i :PORT` (or `lsof -nP -iTCP -sTCP:LISTEN`) for the PID then `kill <pid>`; `ps` and `pgrep` do not work under the sandbox."
+	}
+	return guidance
 }
 
 func detectShellCommandIssue(command string, goos string) *shellIssue {


### PR DESCRIPTION
## Problem

On macOS the seatbelt sandbox grants `file-read*` to each read root via `(subpath "<root>")`, which covers the root and everything **under** it — but **not its parent directories**. Resolving an absolute path to a deeply-nested workspace (e.g. `cd /Users/me/Downloads/app`) must `stat` each ancestor (`/Users`, `/Users/me`, `/Users/me/Downloads`) to walk down to it. Those parents aren't granted, so seatbelt denies the `chdir` — and macOS surfaces that denial as the **misleading `cd: <path>: Not a directory` (ENOTDIR)**, not a clear permission error.

This blocked a sandboxed shell from `cd`-ing into its own workspace: `cd /abs/workspace && go test ./...` failed with "Not a directory" even though the path is a valid directory. Commands that ran relative to the pre-set working directory (`find`, `python3 -c …`) worked, which made the failure baffling.

## Fix

Grant `file-read-metadata` + `file-test-existence` on the **`path-ancestors`** of each read root, so path resolution can traverse to a deeply-nested root. This is **metadata only** — ancestor directory *contents* stay unreadable, write confinement is unchanged, and it stays correctly subordinate to explicit `DenyRead` rules (last-match-wins). Same pattern already used for `/opt/homebrew`, `/usr/local`, `/System/Volumes/Data/private`.

A follow-up commit skips filesystem/volume roots: `(path-ancestors "/")` is invalid SBPL and makes `sandbox-exec` abort (exit 65), so the command couldn't launch at all.

## Verification

- Reproduced: denying an ancestor's metadata produces the exact `cd: …: Not a directory`.
- Fixed: the `path-ancestors` grant makes `cd` succeed; confirmed end-to-end under the real generated profile (`cd /abs/workspace && pwd && ls go.mod`).
- Metadata-only (no content/listing leak); no Linux (landlock/bubblewrap) or Windows changes needed (each is structurally immune); the compat profile compiles under `sandbox-exec`.
- `go build`/`vet`/`test ./internal/sandbox/...` green; regression tests added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS sandbox permissions to support safe traversal for deeply nested workspace read roots using ancestor-metadata (no file-content reads).
  * Broadened macOS sandbox process inspection and signal handling to better match typical tooling needs.
  * Expanded macOS platform read roots to include `/Library/Developer` (Command Line Tools stubs).
  * Scoped git config reads to expected config files and prevented malformed ancestor filters (including `/`).
* **Documentation**
  * Added macOS-specific sandbox guidance for the detected shell runtime.
* **Tests**
  * Added/updated macOS coverage for ancestor-metadata traversal, filesystem root skipping, Command Line Tools coverage, git config scoping, and signal rule expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->