### PR TITLE
fix(tui): cap the expanded live reasoning to ~half screen

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2224,12 +2224,22 @@ func (m model) chatPageScrollLines() int {
 // Before the first delta arrives it falls back to the spinner so the surface
 // still shows liveness. The cursor needs no ticker — it appears exactly while
 // pending.
+// liveReasoningBodyCap caps an EXPANDED live ("Thinking…") reasoning block to
+// roughly half the screen so it doesn't fill the terminal and its clickable
+// toggle header stays on-screen. Returns 0 (no cap) when the height is unknown.
+func (m model) liveReasoningBodyCap() int {
+	if m.height <= 0 {
+		return 0
+	}
+	return maxInt(6, m.height/2)
+}
+
 func (m model) interimBlock(width int) string {
 	text := strings.TrimRight(m.streamingText, "\n")
 	reasoning := strings.TrimRight(m.streamingReasoning, "\n")
 	blocks := []string{}
 	if strings.TrimSpace(reasoning) != "" {
-		blocks = append(blocks, renderReasoningBlock(reasoning, m.streamingReasoningExpanded, width, true, 0))
+		blocks = append(blocks, renderReasoningBlock(reasoning, m.streamingReasoningExpanded, width, true, 0, m.liveReasoningBodyCap()))
 	}
 	if strings.TrimSpace(text) == "" {
 		if writing := m.streamingToolCallView(width); writing != "" {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1754,6 +1754,33 @@ func TestSpecialistCardLinesAreSelectableForCopy(t *testing.T) {
 	}
 }
 
+func TestLiveReasoningExpandIsCappedAndAligned(t *testing.T) {
+	var m model
+	m.height = 20 // liveReasoningBodyCap = max(6, 10) = 10
+	width := 80
+	text := strings.Repeat("thinking about the problem in detail here\n", 30)
+	cap := m.liveReasoningBodyCap()
+
+	lines, selectable := m.renderSelectableReasoningBlock(-1, text, true, true, 0, width, 0)
+	// The selectable spans MUST stay 1:1 with the displayed lines, or the gutter
+	// highlighter lands on the wrong rows.
+	if len(lines) != len(selectable) {
+		t.Fatalf("display lines (%d) and selectable spans (%d) must align", len(lines), len(selectable))
+	}
+	// Capped to ~half-screen: header + marker + cap body, not all ~30 lines.
+	if len(lines) > cap+3 {
+		t.Fatalf("live reasoning not capped: %d lines for cap %d", len(lines), cap)
+	}
+	if !strings.Contains(plainRender(t, strings.Join(lines, "\n")), "earlier lines") {
+		t.Fatalf("expected the '… earlier lines' marker:\n%s", strings.Join(lines, "\n"))
+	}
+	// The display path must produce the same line count as the selectable path.
+	display := renderReasoningBlock(strings.TrimSpace(text), true, width, true, 0, cap)
+	if got := len(strings.Split(display, "\n")); got != len(lines) {
+		t.Fatalf("display path (%d lines) and selectable path (%d lines) must match", got, len(lines))
+	}
+}
+
 func TestSelectionHighlightUsesGutterShiftedCoordinate(t *testing.T) {
 	// Select screen columns 10..15 on body line 0. With a 4-cell reading gutter the
 	// rendered line is "    Hello world" and columns 10-14 are "world", so the

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -521,10 +521,16 @@ func renderAssistantRow(row transcriptRow, width int) string {
 }
 
 func renderReasoningRow(row transcriptRow, width int) string {
-	return renderReasoningBlock(row.text, row.expanded, width, false, row.turnElapsed)
+	// Committed rows live in the scrollable history, so show the whole body (no cap).
+	return renderReasoningBlock(row.text, row.expanded, width, false, row.turnElapsed, 0)
 }
 
-func renderReasoningBlock(text string, expanded bool, width int, running bool, elapsed time.Duration) string {
+// renderReasoningBlock renders a reasoning ("Thinking…") block. When expanded and
+// maxBodyLines > 0, the body is capped to the LATEST maxBodyLines (with a faint
+// "… N earlier" marker), so a live thought stays ~half-screen and its clickable
+// toggle header stays on-screen instead of filling the terminal. maxBodyLines = 0
+// shows the whole body.
+func renderReasoningBlock(text string, expanded bool, width int, running bool, elapsed time.Duration, maxBodyLines int) string {
 	text = strings.TrimSpace(text)
 	if strings.TrimSpace(text) == "" {
 		return ""
@@ -534,10 +540,22 @@ func renderReasoningBlock(text string, expanded bool, width int, running bool, e
 		return fitStyledLine(header, width)
 	}
 	lines := []string{fitStyledLine(header, width)}
-	for _, line := range renderReasoningBodyLines(text, width) {
+	body := renderReasoningBodyLines(text, width)
+	if maxBodyLines > 0 && len(body) > maxBodyLines {
+		hidden := len(body) - maxBodyLines
+		lines = append(lines, fitStyledLine("  "+reasoningHiddenMarker(hidden), width))
+		body = body[hidden:]
+	}
+	for _, line := range body {
 		lines = append(lines, fitStyledLine("  "+styleAssistantMarkdownLine(line, zeroTheme.sayText), width))
 	}
 	return strings.Join(lines, "\n")
+}
+
+// reasoningHiddenMarker is the faint line shown in place of capped reasoning body
+// lines; the display and selectable paths share it so they stay line-aligned.
+func reasoningHiddenMarker(hidden int) string {
+	return zeroTheme.faint.Render(fmt.Sprintf("… %d earlier lines · Ctrl+O for all", hidden))
 }
 
 func renderReasoningBodyLines(text string, width int) []string {

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -777,13 +777,32 @@ func (m model) renderSelectableReasoningBlock(rowIndex int, text string, expande
 	if expanded {
 		renderedLines := renderReasoningBodyLines(text, width)
 		plainLines := renderAssistantMarkdownPlainText(text, maxInt(16, sayMeasure(width)-2), maxInt(16, sayMeasure(width)-2))
+		// A LIVE reasoning block is capped to ~half the screen so its toggle header
+		// stays on-screen. This MUST mirror renderReasoningBlock exactly (same cap,
+		// same marker line) so the selectable spans stay line-aligned with the
+		// displayed lines that finalizeTranscriptBodyRow highlights.
+		bodyOffset := 1
+		if running {
+			if bodyCap := m.liveReasoningBodyCap(); bodyCap > 0 && len(renderedLines) > bodyCap {
+				hidden := len(renderedLines) - bodyCap
+				selectable = append(selectable, transcriptSelectableLine{bodyY: startBodyY + 1, rowIndex: rowIndex, textStart: 2})
+				lines = append(lines, fitStyledLine("  "+reasoningHiddenMarker(hidden), width))
+				renderedLines = renderedLines[hidden:]
+				if hidden < len(plainLines) {
+					plainLines = plainLines[hidden:]
+				} else {
+					plainLines = nil
+				}
+				bodyOffset = 2
+			}
+		}
 		for index, line := range renderedLines {
 			plainLine := ""
 			if index < len(plainLines) {
 				plainLine = plainLines[index]
 			}
 			meta := transcriptSelectableLine{
-				bodyY:     startBodyY + index + 1,
+				bodyY:     startBodyY + index + bodyOffset,
 				rowIndex:  rowIndex,
 				textStart: 2,
 				text:      plainLine,


### PR DESCRIPTION
## Problem

Clicking the live **"Thinking…"** line expanded the streaming reasoning to its *full* length. As the thought kept streaming it filled the terminal and scrolled the clickable toggle header off-screen — so it couldn't be collapsed again.

## Fix

Cap an **expanded live** reasoning block to ~half the screen height:
- show the **latest** lines (what's actively being written),
- with a faint `… N earlier lines · Ctrl+O for all` marker for the hidden portion,
- so the **toggle header stays on-screen and clickable**.

Committed thoughts (the `▸ Thought for X` rows expanded later in the scrollable history) are unchanged — only the live/streaming block is capped.

## Safety

The cap is applied **identically** to the display and the selectable render paths, so it doesn't disturb mouse-selection alignment. A regression test asserts the two paths stay line-for-line aligned and that the cap + marker engage. Full TUI suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live reasoning ("Thinking…") display now dynamically caps its height based on terminal size, showing only the most recent lines when reasoning is lengthy, with a marker indicating hidden lines available via keyboard shortcut.

* **Tests**
  * Added test to verify live reasoning height capping and alignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->