### PR TITLE
Fix token accounting and usage display

### DIFF
--- a/internal/modelregistry/cost.go
+++ b/internal/modelregistry/cost.go
@@ -92,11 +92,10 @@ func CalculateCost(model ModelEntry, usage zeroruntime.Usage) (CostBreakdown, er
 	if uncachedInputTokens < 0 {
 		uncachedInputTokens = 0
 	}
-	billableOutputTokens := outputTokens + reasoningTokens
 	inputCost := costForTokens(uncachedInputTokens, inputRate)
 	cachedInputCost := costForTokens(cachedInputTokens, cachedRate)
 	cacheWriteCost := costForTokens(cacheWriteTokens, cacheWriteRate)
-	outputCost := costForTokens(billableOutputTokens, outputRate)
+	outputCost := costForTokens(outputTokens, outputRate)
 
 	breakdown := CostBreakdown{
 		ModelID:           model.ID,

--- a/internal/modelregistry/cost_test.go
+++ b/internal/modelregistry/cost_test.go
@@ -94,6 +94,33 @@ func TestRegistryCostIgnoresCachedInputWithoutCachePricing(t *testing.T) {
 	assertClose(t, cost.OutputCost, 0.03)
 }
 
+func TestRegistryCostTreatsReasoningAsOutputBreakdown(t *testing.T) {
+	registry, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry returned error: %v", err)
+	}
+
+	withReasoning, err := registry.EstimateCost("gpt-4.1", zeroruntime.Usage{
+		InputTokens:     1_000,
+		OutputTokens:    1_000,
+		ReasoningTokens: 400,
+	})
+	if err != nil {
+		t.Fatalf("EstimateCost(withReasoning) returned error: %v", err)
+	}
+	plain, err := registry.EstimateCost("gpt-4.1", zeroruntime.Usage{
+		InputTokens:  1_000,
+		OutputTokens: 1_000,
+	})
+	if err != nil {
+		t.Fatalf("EstimateCost(plain) returned error: %v", err)
+	}
+
+	if withReasoning.OutputCost != plain.OutputCost || withReasoning.TotalCost != plain.TotalCost {
+		t.Fatalf("reasoning should be a breakdown of output cost, with=%#v plain=%#v", withReasoning, plain)
+	}
+}
+
 func TestRegistryCostSelectsTierForLongContextPricing(t *testing.T) {
 	registry, err := DefaultRegistry()
 	if err != nil {

--- a/internal/providers/gemini/provider.go
+++ b/internal/providers/gemini/provider.go
@@ -212,8 +212,8 @@ func (provider *Provider) emitPayload(ctx context.Context, data string, state *s
 	}
 	if payload.UsageMetadata != nil {
 		state.inputTokens = payload.UsageMetadata.PromptTokenCount
-		state.outputTokens = payload.UsageMetadata.CandidatesTokenCount
 		state.reasoningTokens = payload.UsageMetadata.ThoughtsTokenCount
+		state.outputTokens = payload.UsageMetadata.CandidatesTokenCount + state.reasoningTokens
 		state.cachedTokens = payload.UsageMetadata.CachedContentTokenCount
 		state.hasUsage = true
 	}

--- a/internal/providers/gemini/provider_test.go
+++ b/internal/providers/gemini/provider_test.go
@@ -288,7 +288,7 @@ func TestStreamCompletionEmitsTextUsageAndReasoningTokens(t *testing.T) {
 	want := []zeroruntime.StreamEvent{
 		{Type: zeroruntime.StreamEventText, Content: "Hello"},
 		{Type: zeroruntime.StreamEventText, Content: " Zero"},
-		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 25, OutputTokens: 15, PromptTokens: 25, CompletionTokens: 15, ReasoningTokens: 3, CachedInputTokens: 7}},
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 25, OutputTokens: 18, PromptTokens: 25, CompletionTokens: 18, ReasoningTokens: 3, CachedInputTokens: 7}},
 		{Type: zeroruntime.StreamEventDone},
 	}
 	if !reflect.DeepEqual(events, want) {

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -310,6 +310,7 @@ func (provider *Provider) emitChunk(
 				PromptTokens:      chunk.Usage.PromptTokens,
 				CompletionTokens:  chunk.Usage.CompletionTokens,
 				CachedInputTokens: chunk.Usage.PromptTokensDetails.CachedTokens,
+				ReasoningTokens:   chunk.Usage.CompletionTokensDetails.ReasoningTokens,
 			},
 		})
 	}

--- a/internal/providers/openai/types.go
+++ b/internal/providers/openai/types.go
@@ -88,13 +88,18 @@ type streamFunctionDelta struct {
 }
 
 type usage struct {
-	PromptTokens        int                `json:"prompt_tokens"`
-	CompletionTokens    int                `json:"completion_tokens"`
-	PromptTokensDetails promptTokenDetails `json:"prompt_tokens_details"`
+	PromptTokens            int                    `json:"prompt_tokens"`
+	CompletionTokens        int                    `json:"completion_tokens"`
+	PromptTokensDetails     promptTokenDetails     `json:"prompt_tokens_details"`
+	CompletionTokensDetails completionTokenDetails `json:"completion_tokens_details"`
 }
 
 type promptTokenDetails struct {
 	CachedTokens int `json:"cached_tokens"`
+}
+
+type completionTokenDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
 }
 
 type apiError struct {

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -57,6 +57,25 @@ func TestReadFileToolMarksTruncation(t *testing.T) {
 	}
 }
 
+func TestReadFileToolAppliesByteBudget(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "large.txt"), strings.Repeat("0123456789abcdef\n", 9000))
+
+	result := NewReadFileTool(root).Run(context.Background(), map[string]any{
+		"path": "large.txt",
+	})
+
+	if result.Status != StatusOK || !result.Truncated {
+		t.Fatalf("expected ok+truncated, got status=%s truncated=%v", result.Status, result.Truncated)
+	}
+	if !strings.Contains(result.Output, "output exceeded") || !strings.Contains(result.Output, "start_line") {
+		t.Fatalf("expected byte-budget continuation hint, got %q", result.Output[len(result.Output)-200:])
+	}
+	if result.Meta["raw_bytes"] == "" || result.Meta["emitted_bytes"] == "" {
+		t.Fatalf("expected output byte metadata, got %#v", result.Meta)
+	}
+}
+
 func TestReadFileToolRejectsOutsideWorkspace(t *testing.T) {
 	root := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "secret.txt")
@@ -117,6 +136,9 @@ func TestGlobToolFindsMatchesWithLimit(t *testing.T) {
 	if result.Truncated != true {
 		t.Fatalf("expected truncated result")
 	}
+	if !strings.Contains(result.Output, "[truncated: showing first 1 of 2 matches") {
+		t.Fatalf("expected visible glob truncation marker, got %q", result.Output)
+	}
 	matchedPaths := regexp.MustCompile(`(?m)^[^\n]*\.go\b`).FindAllString(result.Output, -1)
 	if got := len(matchedPaths); got != 1 {
 		t.Fatalf("expected exactly one go match, got %d in %q", got, result.Output)
@@ -162,6 +184,24 @@ func TestGrepToolSearchesContent(t *testing.T) {
 	}
 	if strings.Contains(result.Output, "README.md") {
 		t.Fatalf("glob filter leaked README match: %q", result.Output)
+	}
+}
+
+func TestGrepToolMakesHeadLimitTruncationVisible(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "notes.txt"), "needle 1\nneedle 2\nneedle 3\n")
+
+	result := NewGrepTool(root).Run(context.Background(), map[string]any{
+		"pattern":    "needle",
+		"path":       ".",
+		"head_limit": 2,
+	})
+
+	if result.Status != StatusOK || !result.Truncated {
+		t.Fatalf("expected ok+truncated, got status=%s truncated=%v output=%q", result.Status, result.Truncated, result.Output)
+	}
+	if !strings.Contains(result.Output, "[truncated: showing first 2 of 3 matches") {
+		t.Fatalf("expected visible grep truncation marker, got %q", result.Output)
 	}
 }
 

--- a/internal/tools/glob.go
+++ b/internal/tools/glob.go
@@ -97,18 +97,32 @@ func (tool globTool) runWith(args map[string]any, exclude readExcluder) Result {
 	}
 
 	sort.Strings(matches)
-	truncated := len(matches) > limit
+	totalMatches := len(matches)
+	truncated := totalMatches > limit
 	if truncated {
 		matches = matches[:limit]
+	}
+	output := strings.Join(matches, "\n")
+	if truncated {
+		output += fmt.Sprintf("\n\n[truncated: showing first %d of %d matches; increase limit or narrow cwd/pattern]", len(matches), totalMatches)
+	}
+	budgeted := applyOutputBudget(output, searchOutputBudgetBytes, "increase limit or narrow cwd/pattern")
+	meta := outputBudgetMeta(budgeted)
+	meta["pattern"] = pattern
+	if truncated || budgeted.Truncated {
+		meta["truncated"] = "true"
+		if budgeted.Truncated {
+			meta["truncation_reason"] = "byte_budget"
+		} else {
+			meta["truncation_reason"] = "limit"
+		}
 	}
 
 	return Result{
 		Status:    StatusOK,
-		Output:    strings.Join(matches, "\n"),
-		Truncated: truncated,
-		Meta: map[string]string{
-			"pattern": pattern,
-		},
+		Output:    budgeted.Output,
+		Truncated: truncated || budgeted.Truncated,
+		Meta:      meta,
 	}
 }
 

--- a/internal/tools/grep.go
+++ b/internal/tools/grep.go
@@ -171,7 +171,13 @@ func (tool grepTool) runWith(args map[string]any, exclude readExcluder) Result {
 			}
 		}
 		sort.Strings(files)
-		return okResult(strings.Join(files, "\n"))
+		budgeted := applyOutputBudget(strings.Join(files, "\n"), searchOutputBudgetBytes, "narrow path/glob/pattern to continue")
+		meta := outputBudgetMeta(budgeted)
+		if budgeted.Truncated {
+			meta["truncated"] = "true"
+			meta["truncation_reason"] = "byte_budget"
+		}
+		return Result{Status: StatusOK, Output: budgeted.Output, Truncated: budgeted.Truncated, Meta: meta}
 	default:
 		lines := make([]string, 0, len(matches))
 		for _, match := range matches {
@@ -180,10 +186,26 @@ func (tool grepTool) runWith(args map[string]any, exclude readExcluder) Result {
 			}
 			lines = append(lines, fmt.Sprintf("%s:%d: %s", match.file, match.line, match.text))
 		}
+		truncated := len(matches) > headLimit
+		output := strings.Join(lines, "\n")
+		if truncated {
+			output += fmt.Sprintf("\n\n[truncated: showing first %d of %d matches; narrow path/glob/pattern or increase head_limit]", len(lines), len(matches))
+		}
+		budgeted := applyOutputBudget(output, searchOutputBudgetBytes, "narrow path/glob/pattern or increase head_limit")
+		meta := outputBudgetMeta(budgeted)
+		if truncated || budgeted.Truncated {
+			meta["truncated"] = "true"
+			if budgeted.Truncated {
+				meta["truncation_reason"] = "byte_budget"
+			} else {
+				meta["truncation_reason"] = "head_limit"
+			}
+		}
 		return Result{
 			Status:    StatusOK,
-			Output:    strings.Join(lines, "\n"),
-			Truncated: len(matches) > headLimit,
+			Output:    budgeted.Output,
+			Truncated: truncated || budgeted.Truncated,
+			Meta:      meta,
 		}
 	}
 }

--- a/internal/tools/list_directory.go
+++ b/internal/tools/list_directory.go
@@ -74,7 +74,14 @@ func (tool listDirectoryTool) Run(_ context.Context, args map[string]any) Result
 	if len(entries) == 0 {
 		return okResult("Directory is empty: " + relativePath)
 	}
-	return okResult("Contents of " + relativePath + ":\n\n" + strings.Join(entries, "\n"))
+	output := "Contents of " + relativePath + ":\n\n" + strings.Join(entries, "\n")
+	budgeted := applyOutputBudget(output, searchOutputBudgetBytes, "use path, recursive=false, or a smaller max_depth to narrow the listing")
+	meta := outputBudgetMeta(budgeted)
+	if budgeted.Truncated {
+		meta["truncated"] = "true"
+		meta["truncation_reason"] = "byte_budget"
+	}
+	return Result{Status: StatusOK, Output: budgeted.Output, Truncated: budgeted.Truncated, Meta: meta}
 }
 
 func listDirectoryEntries(path string, depth int, maxDepth int) ([]string, error) {

--- a/internal/tools/output_budget.go
+++ b/internal/tools/output_budget.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	readOutputBudgetBytes   = 128 * 1024
+	searchOutputBudgetBytes = 64 * 1024
+)
+
+type outputBudgetResult struct {
+	Output       string
+	Truncated    bool
+	RawBytes     int
+	EmittedBytes int
+}
+
+func applyOutputBudget(output string, maxBytes int, hint string) outputBudgetResult {
+	result := outputBudgetResult{
+		Output:       output,
+		RawBytes:     len(output),
+		EmittedBytes: len(output),
+	}
+	if maxBytes <= 0 || len(output) <= maxBytes {
+		return result
+	}
+
+	marker := fmt.Sprintf("\n\n[truncated: output exceeded %d bytes; %s]", maxBytes, hint)
+	budget := maxBytes - len(marker)
+	if budget < 0 {
+		budget = 0
+	}
+	result.Output = utf8Prefix(output, budget) + marker
+	result.Truncated = true
+	result.EmittedBytes = len(result.Output)
+	return result
+}
+
+func outputBudgetMeta(result outputBudgetResult) map[string]string {
+	return map[string]string{
+		"raw_bytes":        strconv.Itoa(result.RawBytes),
+		"emitted_bytes":    strconv.Itoa(result.EmittedBytes),
+		"estimated_tokens": strconv.Itoa(estimatedTokensFromBytes(result.EmittedBytes)),
+	}
+}
+
+func estimatedTokensFromBytes(bytes int) int {
+	if bytes <= 0 {
+		return 0
+	}
+	return (bytes + 3) / 4
+}

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -122,9 +122,18 @@ func (tool readFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 		body += fmt.Sprintf("\n\n[truncated: %d more line(s) in the requested range not shown; set start_line=%d to continue]", endLine-lastLine, lastLine+1)
 	}
 
+	output := header + "\n\n" + body
+	budgeted := applyOutputBudget(output, readOutputBudgetBytes, "use start_line/end_line or max_lines to continue with a smaller range")
+	meta := outputBudgetMeta(budgeted)
+	if budgeted.Truncated {
+		meta["truncated"] = "true"
+		meta["truncation_reason"] = "byte_budget"
+	}
+
 	return Result{
 		Status:    StatusOK,
-		Output:    header + "\n\n" + body,
-		Truncated: truncated,
+		Output:    budgeted.Output,
+		Truncated: truncated || budgeted.Truncated,
+		Meta:      meta,
 	}
 }

--- a/internal/tools/read_minified_file.go
+++ b/internal/tools/read_minified_file.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/Gitlawb/zero/internal/minify"
@@ -83,7 +84,30 @@ func (tool readMinifiedFileTool) RunWithOptions(_ context.Context, args map[stri
 			relativePath, rawLines, minLines)
 	}
 
-	return Result{Status: StatusOK, Output: header + "\n\n" + result.Content}
+	rawBytes := len(content)
+	compactBytes := len(result.Content)
+	savedTokens := 0
+	if savedBytes := rawBytes - compactBytes; savedBytes > 0 {
+		savedTokens = estimatedTokensFromBytes(savedBytes)
+	}
+	output := header + "\n\n" + result.Content
+	budgeted := applyOutputBudget(output, readOutputBudgetBytes, "use read_file with start_line/end_line or max_lines for a smaller exact range")
+	meta := outputBudgetMeta(budgeted)
+	meta["path"] = relativePath
+	meta["mode"] = result.Language
+	meta["compacted"] = strconv.FormatBool(result.Applied)
+	meta["raw_bytes"] = strconv.Itoa(rawBytes)
+	meta["compact_bytes"] = strconv.Itoa(compactBytes)
+	meta["emitted_bytes"] = strconv.Itoa(budgeted.EmittedBytes)
+	meta["raw_lines"] = strconv.Itoa(rawLines)
+	meta["emitted_lines"] = strconv.Itoa(minLines)
+	meta["estimated_tokens_saved"] = strconv.Itoa(savedTokens)
+	if budgeted.Truncated {
+		meta["truncated"] = "true"
+		meta["truncation_reason"] = "byte_budget"
+	}
+
+	return Result{Status: StatusOK, Output: budgeted.Output, Truncated: budgeted.Truncated, Meta: meta}
 }
 
 // lineCount reports the number of newline-separated lines in s (an empty string

--- a/internal/tools/read_minified_file_test.go
+++ b/internal/tools/read_minified_file_test.go
@@ -30,6 +30,11 @@ func TestReadMinifiedFileStripsCommentsAndLineNumbers(t *testing.T) {
 	if !strings.Contains(res.Output, "minified go view") {
 		t.Errorf("expected a minified header note:\n%s", res.Output)
 	}
+	for _, key := range []string{"mode", "compacted", "raw_bytes", "emitted_bytes", "estimated_tokens_saved"} {
+		if res.Meta[key] == "" {
+			t.Fatalf("expected compact-read metadata key %q, got %#v", key, res.Meta)
+		}
+	}
 }
 
 func TestReadMinifiedFileRejectsTraversal(t *testing.T) {
@@ -37,5 +42,23 @@ func TestReadMinifiedFileRejectsTraversal(t *testing.T) {
 	res := NewReadMinifiedFileTool(dir).Run(context.Background(), map[string]any{"path": "../escape.go"})
 	if res.Status == StatusOK {
 		t.Fatalf("expected traversal rejection, got OK:\n%s", res.Output)
+	}
+}
+
+func TestReadMinifiedFileAppliesByteBudget(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "large.txt"), []byte(strings.Repeat("0123456789abcdef\n", 9000)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := NewReadMinifiedFileTool(dir).Run(context.Background(), map[string]any{"path": "large.txt"})
+	if res.Status != StatusOK || !res.Truncated {
+		t.Fatalf("expected ok+truncated, got status=%s truncated=%v", res.Status, res.Truncated)
+	}
+	if !strings.Contains(res.Output, "output exceeded") || !strings.Contains(res.Output, "read_file") {
+		t.Fatalf("expected byte-budget continuation hint, got %q", res.Output[len(res.Output)-200:])
+	}
+	if res.Meta["truncated"] != "true" {
+		t.Fatalf("expected truncation metadata, got %#v", res.Meta)
 	}
 }

--- a/internal/tui/context_gauge_test.go
+++ b/internal/tui/context_gauge_test.go
@@ -15,7 +15,7 @@ func TestContextWindowSegment(t *testing.T) {
 	if got := m.contextWindowSegment(); got != "" {
 		t.Fatalf("expected empty gauge before any request, got %q", got)
 	}
-	// 160k input against the 200k window = 80%.
+	// 161k latest-step tokens against the 200k window = 81%.
 	if _, err := m.usageTracker.Record(usage.RecordInput{
 		ModelID: "claude-sonnet-4.5",
 		Usage:   zeroruntime.Usage{InputTokens: 160_000, OutputTokens: 1000},
@@ -23,7 +23,7 @@ func TestContextWindowSegment(t *testing.T) {
 		t.Fatalf("Record: %v", err)
 	}
 	got := plainRender(t, m.contextWindowSegment())
-	if !strings.Contains(got, "160K/200K") || !strings.Contains(got, "80%") {
-		t.Fatalf("gauge = %q, want 160K/200K · 80%%", got)
+	if !strings.Contains(got, "161K/200K") || !strings.Contains(got, "81%") {
+		t.Fatalf("gauge = %q, want 161K/200K · 81%%", got)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -107,6 +107,8 @@ type model struct {
 	lastCompactError      string
 	unpricedRequests      int
 	unpricedTokens        int
+	lastUsage             usage.Normalized
+	lastUsageSeen         bool
 	transcript            []transcriptRow
 	transcriptDetailed    bool
 	helpOverlay           bool // the `?` keyboard-shortcut overlay is open
@@ -164,6 +166,7 @@ type model struct {
 	// agentResponseMsg handler persists each such run's session events (only) so
 	// the checkpoints stay referenced, then removes the id.
 	flushRunIDs       map[int]string
+	liveUsageCounts   map[int]int
 	pendingPermission *pendingPermissionPrompt
 	pendingAskUser    *pendingAskUserPrompt
 	pendingSpecReview *pendingSpecReviewPrompt
@@ -322,6 +325,12 @@ type toolCallStreamDeltaMsg struct {
 type agentReasoningMsg struct {
 	runID int
 	delta string
+}
+
+type agentUsageMsg struct {
+	runID   int
+	modelID string
+	usage   zeroruntime.Usage
 }
 
 type agentResponseMsg struct {
@@ -595,6 +604,7 @@ func newModel(ctx context.Context, options Options) model {
 		now:                    time.Now,
 		notifier:               notifier,
 		altScreen:              options.AltScreen,
+		liveUsageCounts:        map[int]int{},
 		setup:                  newSetupState(options.Setup),
 		setupSave:              options.Setup.Save,
 	}
@@ -1404,13 +1414,18 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 				delete(m.flushRunIDs, msg.runID)
 				// The cancelled run still consumed tokens; record them so the usage
 				// readout doesn't undercount interrupted turns.
-				for _, event := range msg.usageEvents {
+				liveUsageCount := m.liveUsageCounts[msg.runID]
+				for index, event := range msg.usageEvents {
+					if index < liveUsageCount {
+						continue
+					}
 					var usageRows []transcriptRow
 					m, usageRows = m.recordUsageEvent(msg.usageModelID, event)
 					for _, row := range usageRows {
 						m.transcript = appendTranscriptRow(m.transcript, row)
 					}
 				}
+				delete(m.liveUsageCounts, msg.runID)
 				// Events are persisted into the session the run was recording into AT
 				// CANCEL TIME — the active session may have changed since (/resume),
 				// and writing there would contaminate its log with checkpoint payloads
@@ -1458,13 +1473,18 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.plan.frozenAt = m.now() // freeze the plan clock while idle (no run in flight)
 		m.pendingPermission = nil
 		m.pendingAskUser = nil
-		for _, event := range msg.usageEvents {
+		liveUsageCount := m.liveUsageCounts[msg.runID]
+		for index, event := range msg.usageEvents {
+			if index < liveUsageCount {
+				continue
+			}
 			var usageRows []transcriptRow
 			m, usageRows = m.recordUsageEvent(msg.usageModelID, event)
 			for _, row := range usageRows {
 				m.transcript = appendTranscriptRow(m.transcript, row)
 			}
 		}
+		delete(m.liveUsageCounts, msg.runID)
 		var sessionRows []transcriptRow
 		m, sessionRows = m.appendSessionEvents(msg.sessionEvents)
 		for _, row := range sessionRows {
@@ -1544,6 +1564,20 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.plan.updateFromItems(msg.items, m.now())
+		return m, nil
+	case agentUsageMsg:
+		if msg.runID != m.activeRunID {
+			return m, nil
+		}
+		var usageRows []transcriptRow
+		m, usageRows = m.recordUsageEvent(msg.modelID, msg.usage)
+		if m.liveUsageCounts == nil {
+			m.liveUsageCounts = map[int]int{}
+		}
+		m.liveUsageCounts[msg.runID]++
+		for _, row := range usageRows {
+			m.transcript = appendTranscriptRow(m.transcript, row)
+		}
 		return m, nil
 	case specialistStartMsg:
 		if msg.runID != m.activeRunID {
@@ -3859,6 +3893,7 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				Type:    sessions.EventUsage,
 				Payload: usage.EventUsagePayload(event),
 			})
+			m.sendAgentUsage(runID, usageModelID, event)
 			if onUsage != nil {
 				onUsage(event)
 			}
@@ -3976,6 +4011,13 @@ func (m model) sendAgentReasoning(runID int, delta string) {
 		return
 	}
 	m.runtimeMessageSink(agentReasoningMsg{runID: runID, delta: delta})
+}
+
+func (m model) sendAgentUsage(runID int, modelID string, event zeroruntime.Usage) {
+	if m.runtimeMessageSink == nil {
+		return
+	}
+	m.runtimeMessageSink(agentUsageMsg{runID: runID, modelID: modelID, usage: event})
 }
 
 func toolResultRowText(result agent.ToolResult) string {

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -703,6 +703,8 @@ func (m model) recordUsageEvent(modelID string, event zeroruntime.Usage) (model,
 	if err != nil {
 		return m, []transcriptRow{{kind: rowError, text: "usage: " + err.Error()}}
 	}
+	m.lastUsage = normalized
+	m.lastUsageSeen = true
 	if _, err := m.usageTracker.Record(usage.RecordInput{
 		ModelID: modelID,
 		Usage:   runtimeUsage,
@@ -716,6 +718,16 @@ func (m model) recordUsageEvent(modelID string, event zeroruntime.Usage) (model,
 		return m, []transcriptRow{{kind: rowError, text: "usage: " + err.Error()}}
 	}
 	return m, nil
+}
+
+func (m model) latestUsageTokens(summary usage.Summary) int {
+	if m.lastUsageSeen && m.lastUsage.TotalTokens > 0 {
+		return m.lastUsage.TotalTokens
+	}
+	if summary.LastRecord != nil && summary.LastRecord.Usage.TotalTokens > 0 {
+		return summary.LastRecord.Usage.TotalTokens
+	}
+	return m.unpricedTokens
 }
 
 func isUnpricedUsageError(err error) bool {

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -628,6 +628,55 @@ func TestUsageEventsUpdateFooterAndContext(t *testing.T) {
 	}
 }
 
+func TestUsageRuntimeMessageUpdatesFooterBeforeFinalResponse(t *testing.T) {
+	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
+		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 10, OutputTokens: 5}},
+		{Type: zeroruntime.StreamEventText, Content: "done"},
+		{Type: zeroruntime.StreamEventDone},
+	}}
+	runtimeMessages := []tea.Msg{}
+	m := newModel(context.Background(), Options{
+		ModelName:    "gpt-4.1",
+		Provider:     provider,
+		Registry:     tools.NewRegistry(),
+		SessionStore: testSessionStore(t),
+		RuntimeMessageSink: func(msg tea.Msg) {
+			runtimeMessages = append(runtimeMessages, msg)
+		},
+	})
+	m.input.SetValue("track usage")
+
+	updated, cmd := m.Update(testKey(tea.KeyEnter))
+	next := updated.(model)
+	if cmd == nil {
+		t.Fatal("expected prompt to start agent run")
+	}
+	finalMsg := execCmd(cmd)
+
+	liveUsageCount := 0
+	for _, msg := range runtimeMessages {
+		if usageMsg, ok := msg.(agentUsageMsg); ok {
+			updated, _ = next.Update(usageMsg)
+			next = updated.(model)
+			liveUsageCount++
+		}
+	}
+	if liveUsageCount == 0 {
+		t.Fatalf("expected a live usage message, got %#v", runtimeMessages)
+	}
+
+	if !strings.Contains(next.usageSummaryText(), "15 tokens") {
+		t.Fatalf("expected live usage before final response, got %q", next.usageSummaryText())
+	}
+
+	updated, _ = next.Update(finalMsg)
+	next = updated.(model)
+	summary := next.usageTracker.Summary()
+	if summary.RecordCount != 1 || summary.TotalTokens != 15 {
+		t.Fatalf("expected final response not to double count live usage, got records=%d tokens=%d", summary.RecordCount, summary.TotalTokens)
+	}
+}
+
 func TestUsageEventsForwardExistingAgentCallback(t *testing.T) {
 	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
 		{Type: zeroruntime.StreamEventUsage, Usage: zeroruntime.Usage{InputTokens: 10, OutputTokens: 5}},
@@ -695,6 +744,30 @@ func TestUsageEventsForCustomModelUseTokenOnlyFallback(t *testing.T) {
 	}
 	if transcriptContains(next.transcript, "usage:") {
 		t.Fatalf("custom model usage should not append a transcript error, got %#v", next.transcript)
+	}
+}
+
+func TestUnpricedUsageStatusUsesLatestEventNotCumulative(t *testing.T) {
+	m := newModel(context.Background(), Options{ModelName: "custom-coder"})
+
+	var rows []transcriptRow
+	m, rows = m.recordUsageEvent("custom-coder", zeroruntime.Usage{InputTokens: 100, OutputTokens: 20})
+	if len(rows) != 0 {
+		t.Fatalf("unpriced usage should not append transcript rows, got %#v", rows)
+	}
+	m, rows = m.recordUsageEvent("custom-coder", zeroruntime.Usage{InputTokens: 10, OutputTokens: 5})
+	if len(rows) != 0 {
+		t.Fatalf("unpriced usage should not append transcript rows, got %#v", rows)
+	}
+
+	if !strings.Contains(m.usageSummaryText(), "135 tokens") {
+		t.Fatalf("expected cumulative usage summary to stay intact, got %q", m.usageSummaryText())
+	}
+	if got := m.usageStatusSegment(); !strings.Contains(got, "15 tok") || strings.Contains(got, "135") {
+		t.Fatalf("expected status to show latest usage only, got %q", got)
+	}
+	if got := m.sidebarTokenText(); !strings.Contains(got, "15 tokens") || strings.Contains(got, "135") {
+		t.Fatalf("expected sidebar to show latest usage only, got %q", got)
 	}
 }
 

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -641,29 +641,21 @@ func (m model) sidebarTokenLine(width int) string {
 	return " " + zeroTheme.faint.Render(truncateRunes(label, budget)) + chip
 }
 
-// sidebarTokenText computes the token figure shown at the sidebar floor: the
-// last request's context usage when known, else the cumulative session tokens.
+// sidebarTokenText computes the token figure shown at the sidebar floor from
+// the latest provider step's token footprint.
 func (m model) sidebarTokenText() string {
 	if m.usageTracker == nil {
 		return ""
 	}
 	summary := m.usageTracker.Summary()
-	if summary.LastRecord != nil {
-		used := summary.LastRecord.Usage.InputTokens
-		if used > 0 {
-			if window := modelContextWindow(m.modelName); window > 0 {
-				return fmt.Sprintf("%s / %s tokens", humanCount(used), humanCount(window))
-			}
-			return humanCount(used) + " tokens"
-		}
+	used := m.latestUsageTokens(summary)
+	if used <= 0 {
+		return ""
 	}
-	if summary.RecordCount > 0 {
-		return humanCount(summary.InputTokens+summary.OutputTokens) + " tokens"
+	if window := modelContextWindow(m.modelName); window > 0 {
+		return fmt.Sprintf("%s / %s tokens", humanCount(used), humanCount(window))
 	}
-	if m.unpricedRequests > 0 {
-		return humanCount(m.unpricedTokens) + " tokens"
-	}
-	return ""
+	return humanCount(used) + " tokens"
 }
 
 // joinColumns splices a chat block and a sidebar block side-by-side, one

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -295,29 +295,30 @@ func (m model) modeLabel() (string, lipgloss.Style) {
 	}
 }
 
-// usageStatusSegment summarizes this session's consumption for the status
-// line: cumulative tokens, plus cost once anything is priced.
+// usageStatusSegment shows the latest provider step's token footprint, plus
+// cumulative cost once anything is priced.
 func (m model) usageStatusSegment() string {
 	if m.usageTracker == nil {
 		return ""
 	}
 	summary := m.usageTracker.Summary()
-	if summary.RecordCount == 0 {
-		if m.unpricedRequests > 0 {
-			return humanCount(m.unpricedTokens) + " tok"
-		}
+	tokens := m.latestUsageTokens(summary)
+	if tokens <= 0 {
 		return ""
 	}
+	if summary.RecordCount == 0 {
+		return humanCount(tokens) + " tok"
+	}
 	return fmt.Sprintf("%s tok · %s",
-		humanCount(summary.InputTokens+summary.OutputTokens),
+		humanCount(tokens),
 		summary.FormattedTotalCost,
 	)
 }
 
-// contextFillPercent returns the last request's context-window fill as a percent
+// contextFillPercent returns the latest request's context-window fill as a percent
 // (0-100), the tokens used, the model's window, and a colour graded for the fill
-// (green <75% → amber ≥75% → red ≥90%). ok is false until a priced request lands
-// or when the model's window is unknown. Shared by the status-line gauge and the
+// (green <75% → amber ≥75% → red ≥90%). ok is false until a usage event lands or
+// when the model's window is unknown. Shared by the status-line gauge and the
 // sidebar context chip so they grade identically. This is the "you're at X% of
 // context" reading the compaction trigger already reasons about at ~80%.
 func (m model) contextFillPercent() (pct, used, window int, style lipgloss.Style, ok bool) {
@@ -325,10 +326,7 @@ func (m model) contextFillPercent() (pct, used, window int, style lipgloss.Style
 		return 0, 0, 0, lipgloss.Style{}, false
 	}
 	summary := m.usageTracker.Summary()
-	if summary.LastRecord == nil {
-		return 0, 0, 0, lipgloss.Style{}, false
-	}
-	used = summary.LastRecord.Usage.InputTokens
+	used = m.latestUsageTokens(summary)
 	window = modelContextWindow(m.modelName)
 	if used <= 0 || window <= 0 {
 		return 0, 0, 0, lipgloss.Style{}, false

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -198,7 +198,7 @@ func Normalize(usage zeroruntime.Usage) (Normalized, zeroruntime.Usage, error) {
 		CacheWriteTokens:  cacheWriteTokens,
 		OutputTokens:      outputTokens,
 		ReasoningTokens:   reasoningTokens,
-		TotalTokens:       inputTokens + outputTokens + reasoningTokens,
+		TotalTokens:       inputTokens + outputTokens,
 	}
 	return normalized, zeroruntime.Usage{
 		InputTokens:       inputTokens,

--- a/internal/usage/tracker_test.go
+++ b/internal/usage/tracker_test.go
@@ -51,6 +51,24 @@ func TestTrackerRejectsInvalidUsageAndUnknownModels(t *testing.T) {
 	}
 }
 
+func TestTrackerTreatsReasoningAsOutputBreakdown(t *testing.T) {
+	tracker := NewTracker(TrackerOptions{})
+	record, err := tracker.Record(RecordInput{
+		ModelID: "gpt-4.1",
+		Usage: zeroruntime.Usage{
+			InputTokens:     100,
+			OutputTokens:    40,
+			ReasoningTokens: 10,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Record returned error: %v", err)
+	}
+	if record.Usage.TotalTokens != 140 {
+		t.Fatalf("total tokens = %d, want 140", record.Usage.TotalTokens)
+	}
+}
+
 func TestTrackerResetClearsRecords(t *testing.T) {
 	tracker := NewTracker(TrackerOptions{})
 	if _, err := tracker.Record(RecordInput{ModelID: "gpt-4.1", Usage: zeroruntime.Usage{InputTokens: 1, OutputTokens: 1}}); err != nil {

--- a/internal/zeroruntime/helpers.go
+++ b/internal/zeroruntime/helpers.go
@@ -90,17 +90,23 @@ func CollectStream(ctx context.Context, events <-chan StreamEvent) CollectedStre
 func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, options CollectOptions) CollectedStream {
 	collected := CollectedStream{}
 	collector := newToolCallCollector()
+	usageSeen := false
+	finish := func() CollectedStream {
+		collector.flush(&collected)
+		if usageSeen && options.OnUsage != nil {
+			options.OnUsage(collected.Usage)
+		}
+		return collected
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			collected.Error = ctx.Err().Error()
-			collector.flush(&collected)
-			return collected
+			return finish()
 		case event, ok := <-events:
 			if !ok {
-				collector.flush(&collected)
-				return collected
+				return finish()
 			}
 
 			// A non-normal terminal stop reason can ride on any event (providers
@@ -144,27 +150,55 @@ func CollectStreamWithOptions(ctx context.Context, events <-chan StreamEvent, op
 			case StreamEventToolCallDropped:
 				collected.DroppedToolCalls++
 			case StreamEventUsage:
-				inputTokens := event.Usage.EffectiveInputTokens()
-				outputTokens := event.Usage.EffectiveOutputTokens()
-				collected.Usage.InputTokens += inputTokens
-				collected.Usage.OutputTokens += outputTokens
-				collected.Usage.PromptTokens += inputTokens
-				collected.Usage.CompletionTokens += outputTokens
-				collected.Usage.CachedInputTokens += event.Usage.CachedInputTokens
-				collected.Usage.ReasoningTokens += event.Usage.ReasoningTokens
-				if options.OnUsage != nil {
-					options.OnUsage(event.Usage)
-				}
+				collected.Usage = mergeUsageSnapshot(collected.Usage, event.Usage)
+				usageSeen = true
 			case StreamEventError:
 				collected.Error = event.Error
-				collector.flush(&collected)
-				return collected
+				return finish()
 			case StreamEventDone:
-				collector.flush(&collected)
-				return collected
+				return finish()
 			}
 		}
 	}
+}
+
+func mergeUsageSnapshot(left Usage, right Usage) Usage {
+	inputTokens := left.EffectiveInputTokens()
+	if value := right.EffectiveInputTokens(); value != 0 {
+		inputTokens = value
+	}
+
+	outputTokens := left.EffectiveOutputTokens()
+	if value := right.EffectiveOutputTokens(); value != 0 {
+		outputTokens = value
+	}
+
+	cachedInputTokens := left.CachedInputTokens
+	if right.CachedInputTokens != 0 {
+		cachedInputTokens = right.CachedInputTokens
+	}
+
+	cacheWriteTokens := left.CacheWriteTokens
+	if right.CacheWriteTokens != 0 {
+		cacheWriteTokens = right.CacheWriteTokens
+	}
+
+	reasoningTokens := left.ReasoningTokens
+	if right.ReasoningTokens != 0 {
+		reasoningTokens = right.ReasoningTokens
+	}
+
+	usage, err := NormalizeUsage(TokenUsage{
+		InputTokens:       inputTokens,
+		OutputTokens:      outputTokens,
+		CachedInputTokens: cachedInputTokens,
+		CacheWriteTokens:  cacheWriteTokens,
+		ReasoningTokens:   reasoningTokens,
+	})
+	if err != nil {
+		return right
+	}
+	return usage
 }
 
 // toolCallCollector accumulates streamed tool calls in start order. Calls are

--- a/internal/zeroruntime/provider_test.go
+++ b/internal/zeroruntime/provider_test.go
@@ -103,11 +103,11 @@ func TestNormalizeUsageMapsProviderAliasesAndReasoningTokens(t *testing.T) {
 	if usage.ReasoningTokens != 10 {
 		t.Fatalf("reasoning tokens = %d, want 10", usage.ReasoningTokens)
 	}
-	if usage.TotalTokens() != 150 {
-		t.Fatalf("total tokens = %d, want 150", usage.TotalTokens())
+	if usage.TotalTokens() != 140 {
+		t.Fatalf("total tokens = %d, want 140", usage.TotalTokens())
 	}
-	if usage.BillableOutputTokens() != 50 {
-		t.Fatalf("billable output tokens = %d, want 50", usage.BillableOutputTokens())
+	if usage.BillableOutputTokens() != 40 {
+		t.Fatalf("billable output tokens = %d, want 40", usage.BillableOutputTokens())
 	}
 }
 
@@ -122,6 +122,23 @@ func TestNormalizeUsageClampsCachedInputTokens(t *testing.T) {
 	}
 	if usage.CachedInputTokens != 5 {
 		t.Fatalf("cached input tokens = %d, want 5", usage.CachedInputTokens)
+	}
+}
+
+func TestNormalizeUsageClampsReasoningTokensToOutput(t *testing.T) {
+	usage, err := NormalizeUsage(TokenUsage{
+		InputTokens:     10,
+		OutputTokens:    4,
+		ReasoningTokens: 9,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeUsage returned error: %v", err)
+	}
+	if usage.ReasoningTokens != 4 {
+		t.Fatalf("reasoning tokens = %d, want 4", usage.ReasoningTokens)
+	}
+	if usage.TotalTokens() != 14 {
+		t.Fatalf("total tokens = %d, want 14", usage.TotalTokens())
 	}
 }
 
@@ -201,12 +218,12 @@ func TestCollectStreamAccumulatesNormalizedUsageAliases(t *testing.T) {
 	if collected.Usage.ReasoningTokens != 3 {
 		t.Fatalf("reasoning tokens = %d, want 3", collected.Usage.ReasoningTokens)
 	}
-	if collected.Usage.TotalTokens() != 20 {
-		t.Fatalf("total tokens = %d, want 20", collected.Usage.TotalTokens())
+	if collected.Usage.TotalTokens() != 17 {
+		t.Fatalf("total tokens = %d, want 17", collected.Usage.TotalTokens())
 	}
 }
 
-func TestCollectStreamAccumulatesMixedUsageShapes(t *testing.T) {
+func TestCollectStreamMergesMixedUsageSnapshots(t *testing.T) {
 	normalizedUsage, err := NormalizeUsage(TokenUsage{InputTokens: 6, OutputTokens: 3, ReasoningTokens: 2})
 	if err != nil {
 		t.Fatalf("NormalizeUsage returned error: %v", err)
@@ -222,11 +239,11 @@ func TestCollectStreamAccumulatesMixedUsageShapes(t *testing.T) {
 
 	collected := CollectStream(context.Background(), events)
 
-	if collected.Usage.EffectiveInputTokens() != 16 {
-		t.Fatalf("input tokens = %d, want 16", collected.Usage.EffectiveInputTokens())
+	if collected.Usage.EffectiveInputTokens() != 6 {
+		t.Fatalf("input tokens = %d, want 6", collected.Usage.EffectiveInputTokens())
 	}
-	if collected.Usage.EffectiveOutputTokens() != 7 {
-		t.Fatalf("output tokens = %d, want 7", collected.Usage.EffectiveOutputTokens())
+	if collected.Usage.EffectiveOutputTokens() != 3 {
+		t.Fatalf("output tokens = %d, want 3", collected.Usage.EffectiveOutputTokens())
 	}
 	if collected.Usage.CachedInputTokens != 3 {
 		t.Fatalf("cached input tokens = %d, want 3", collected.Usage.CachedInputTokens)
@@ -234,8 +251,41 @@ func TestCollectStreamAccumulatesMixedUsageShapes(t *testing.T) {
 	if collected.Usage.ReasoningTokens != 2 {
 		t.Fatalf("reasoning tokens = %d, want 2", collected.Usage.ReasoningTokens)
 	}
-	if collected.Usage.TotalTokens() != 25 {
-		t.Fatalf("total tokens = %d, want 25", collected.Usage.TotalTokens())
+	if collected.Usage.TotalTokens() != 9 {
+		t.Fatalf("total tokens = %d, want 9", collected.Usage.TotalTokens())
+	}
+}
+
+func TestCollectStreamReportsOneMergedUsageCallback(t *testing.T) {
+	events := make(chan StreamEvent)
+	go func() {
+		defer close(events)
+		events <- StreamEvent{Type: StreamEventUsage, Usage: Usage{
+			PromptTokens:      100,
+			CachedInputTokens: 20,
+			CacheWriteTokens:  10,
+		}}
+		events <- StreamEvent{Type: StreamEventUsage, Usage: Usage{
+			CompletionTokens: 12,
+			ReasoningTokens:  4,
+		}}
+		events <- StreamEvent{Type: StreamEventDone}
+	}()
+
+	var usageEvents []Usage
+	collected := CollectStreamWithOptions(context.Background(), events, CollectOptions{
+		OnUsage: func(usage Usage) { usageEvents = append(usageEvents, usage) },
+	})
+
+	if len(usageEvents) != 1 {
+		t.Fatalf("usage callbacks = %#v, want one merged callback", usageEvents)
+	}
+	if collected.Usage.EffectiveInputTokens() != 100 ||
+		collected.Usage.EffectiveOutputTokens() != 12 ||
+		collected.Usage.CachedInputTokens != 20 ||
+		collected.Usage.CacheWriteTokens != 10 ||
+		collected.Usage.ReasoningTokens != 4 {
+		t.Fatalf("merged usage = %#v", collected.Usage)
 	}
 }
 

--- a/internal/zeroruntime/types.go
+++ b/internal/zeroruntime/types.go
@@ -128,6 +128,9 @@ type TokenUsage struct {
 // prompt size (uncached + cache-read + cache-write); CachedInputTokens (cache
 // read, discounted) and CacheWriteTokens (cache creation, premium) are subsets
 // of it, so uncached input = InputTokens - CachedInputTokens - CacheWriteTokens.
+// OutputTokens is the TOTAL output size, including hidden reasoning tokens when
+// a provider reports them separately; ReasoningTokens is a subset of OutputTokens,
+// not an additive count.
 type Usage struct {
 	InputTokens       int
 	OutputTokens      int
@@ -140,7 +143,7 @@ type Usage struct {
 
 // TotalTokens returns prompt plus completion tokens.
 func (usage Usage) TotalTokens() int {
-	return usage.EffectiveInputTokens() + usage.EffectiveOutputTokens() + usage.ReasoningTokens
+	return usage.EffectiveInputTokens() + usage.EffectiveOutputTokens()
 }
 
 func (usage Usage) EffectiveInputTokens() int {
@@ -158,7 +161,15 @@ func (usage Usage) EffectiveOutputTokens() int {
 }
 
 func (usage Usage) BillableOutputTokens() int {
-	return usage.EffectiveOutputTokens() + usage.ReasoningTokens
+	return usage.EffectiveOutputTokens()
+}
+
+func (usage Usage) VisibleOutputTokens() int {
+	visible := usage.EffectiveOutputTokens() - usage.ReasoningTokens
+	if visible < 0 {
+		return 0
+	}
+	return visible
 }
 
 // StreamEvent is one normalized event emitted by a streaming provider.

--- a/internal/zeroruntime/usage.go
+++ b/internal/zeroruntime/usage.go
@@ -36,6 +36,9 @@ func NormalizeUsage(input TokenUsage) (Usage, error) {
 	if err != nil {
 		return Usage{}, err
 	}
+	if reasoningTokens > outputTokens {
+		reasoningTokens = outputTokens
+	}
 
 	return Usage{
 		InputTokens:       inputTokens,


### PR DESCRIPTION
## Summary
- Normalize token accounting so reasoning and cache tokens are handled as subsets instead of double counted.
- Add output budgeting for high-volume file/search tool results with explicit truncation metadata.
- Stream usage updates into the TUI and show latest-step tokens while preserving cumulative usage/cost reporting.

## Tests
- `go test ./internal/tui`
- `XDG_CONFIG_HOME="$tmp_home/.config" XDG_CACHE_HOME="$tmp_home/.cache" HOME="$tmp_home" go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live usage event updates display token consumption during active agent runs.
  * Search, glob, and directory tools now show visible truncation indicators when results exceed limits.

* **Improvements**
  * Reasoning tokens are now included in output token billing rather than charged separately.
  * File reading and directory listing tools enforce byte-size output limits to prevent overwhelming results.
  * Enhanced token usage tracking and UI status display for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->