### PR TITLE
feat(tui): show provider on each model-picker row

### DIFF
--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -35,6 +35,7 @@ type pickerItem struct {
 	Label    string
 	Value    string
 	Meta     string
+	Provider string
 	Remote   bool
 	Local    bool
 	Favorite bool
@@ -287,6 +288,18 @@ func discoveredModelPickerItem(provider providercatalog.Descriptor, model provid
 func applyProviderPickerMeta(item *pickerItem, provider providercatalog.Descriptor) {
 	item.Remote = !provider.Local
 	item.Local = provider.Local
+	item.Provider = providerPickerTag(provider)
+}
+
+// providerPickerTag is the short, lowercase provider slug shown right-aligned on
+// each model row (e.g. "anthropic", "deepseek", "ollama"). Prefers the catalog
+// ID since it is already the stable lowercase identifier; falls back to a
+// lowercased display name for descriptors that only carry one.
+func providerPickerTag(provider providercatalog.Descriptor) string {
+	if id := strings.TrimSpace(provider.ID); id != "" {
+		return id
+	}
+	return strings.ToLower(strings.TrimSpace(provider.Name))
 }
 
 func registryModelPickerMeta(entry modelregistry.ModelEntry) string {

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -1462,6 +1462,46 @@ func TestModelPickerRowsCarryCapabilityMeta(t *testing.T) {
 	}
 }
 
+func TestModelPickerRowShowsProviderTag(t *testing.T) {
+	item := pickerItem{Label: "Claude Sonnet 4.6", Value: "claude-sonnet-4-6", Provider: "anthropic", Remote: true}
+	got := plainRender(t, renderModelPickerRow(60, false, item))
+	if !strings.Contains(got, "Claude Sonnet 4.6") {
+		t.Fatalf("row = %q, missing model label", got)
+	}
+	if !strings.Contains(got, "anthropic") {
+		t.Fatalf("row = %q, missing right-aligned provider tag", got)
+	}
+	// The provider tag must trail the model name, not lead it.
+	if strings.Index(got, "anthropic") < strings.Index(got, "Claude") {
+		t.Fatalf("row = %q, provider tag should be right-aligned after the model name", got)
+	}
+}
+
+func TestModelPickerRowDropsProviderTagWhenNarrow(t *testing.T) {
+	item := pickerItem{Label: "Claude Sonnet 4.6", Value: "claude-sonnet-4-6", Provider: "anthropic"}
+	got := plainRender(t, renderModelPickerRow(12, false, item))
+	if strings.Contains(got, "anthropic") {
+		t.Fatalf("narrow row = %q, should drop the provider tag rather than crowd the model name", got)
+	}
+}
+
+func TestModelPickerItemsCarryProviderTag(t *testing.T) {
+	m := limeTestModel()
+	picker := m.newModelPicker()
+	if picker == nil {
+		t.Fatal("expected a model picker")
+	}
+	tagged := 0
+	for _, item := range picker.items {
+		if strings.TrimSpace(item.Provider) != "" {
+			tagged++
+		}
+	}
+	if tagged == 0 {
+		t.Fatalf("expected catalog models to carry a provider tag, got %#v", picker.items[:minInt(3, len(picker.items))])
+	}
+}
+
 func TestSpecReviewCardShowsBadgePathAndKeys(t *testing.T) {
 	got := plainRender(t, renderFocusedSpecReviewPrompt(pendingSpecReviewPrompt{
 		SpecFilePath: "/repo/specs/zero-1.md",

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -852,8 +852,20 @@ func renderModelPickerRow(width int, selected bool, item pickerItem) string {
 	if item.Favorite {
 		prefix = "* "
 	}
-	line := marker + surface(zeroTheme.ink).Render(prefix+label)
-	return fillPaletteLine(line, width, surface)
+	left := marker + surface(zeroTheme.ink).Render(prefix+label)
+	right := ""
+	if tag := strings.TrimSpace(item.Provider); tag != "" {
+		right = surface(zeroTheme.faintest).Render(tag)
+	}
+	// Right-align the provider slug so each row reads "<model> … <provider>".
+	// Drop it when the row is too narrow to keep a clear gap from the model
+	// name (mirrors the generic picker's gap math at pickerOverlay).
+	gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+	if right == "" || gap < 2 {
+		return fillPaletteLine(left, width, surface)
+	}
+	line := left + surface(zeroTheme.ink).Render(strings.Repeat(" ", gap)) + right
+	return fitStyledLine(line, width)
 }
 
 func modelPickerItemDetail(item pickerItem) string {


### PR DESCRIPTION
## What

The `/model` picker showed a flat list of model names with no provider context — models from different providers (e.g. `deepseek-v3.2`, `gemini-3-flash-preview`, `Kimi K2.7 Code`) were indistinguishable. You couldn''t tell which connected provider a model belonged to.

Each row now shows a **right-aligned provider slug**:

```
Choose a model
search > model name...
──────────────────────
❯ Claude Sonnet 4.6      anthropic
  deepseek-v3.2          deepseek
  deepseek-v4-pro        deepseek
  gemini-3-flash-preview google
  Kimi K2.7 Code         moonshot
```

## Why a one-line render bug

The items already computed and stored the provider (Group + remote/local dot) — but `modelPickerOverlay` rendered only the label and threw the rest away, unlike the generic `/effort`/`/mode` picker which renders them. This just surfaces data the picker already had.

## How

- `pickerItem` gains a `Provider` field; `applyProviderPickerMeta` stamps it from the catalog descriptor (lowercase `ID` slug, falling back to a lowercased name) — so every constructor path (active-provider catalog, live-discovered, registry fallback) tags rows correctly.
- `renderModelPickerRow` right-aligns the slug using the same gap math the generic picker uses, and drops it on rows too narrow to keep a clear gap from the model name.

## Tests

- `TestModelPickerRowShowsProviderTag` — tag renders, right of the model name.
- `TestModelPickerRowDropsProviderTagWhenNarrow` — narrow rows omit it cleanly.
- `TestModelPickerItemsCarryProviderTag` — items carry the provider slug.
- Full `./internal/tui/...` suite green.

~30 LoC + tests, 2 files. No new architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model picker rows now show a provider tag aligned on the right when there is enough space.
  * Provider information is now included alongside model entries throughout the picker.
* **Bug Fixes**
  * On narrower screens, the provider tag is automatically hidden to keep rows readable and avoid cramped layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->