### PR TITLE
fix(tui): stop showing the token count on both sides

### DIFF
--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -771,6 +771,34 @@ func TestUnpricedUsageStatusUsesLatestEventNotCumulative(t *testing.T) {
 	}
 }
 
+func TestStatusLineDropsTokenFigureWhenSidebarShowsIt(t *testing.T) {
+	m := sidebarTestModel()
+	m, _ = m.recordUsageEvent("test-model", zeroruntime.Usage{InputTokens: 100, OutputTokens: 20})
+	if !m.sidebarActive() {
+		t.Fatal("expected the sidebar to be active for this model")
+	}
+
+	// The sidebar owns the token readout at its floor.
+	if got := m.sidebarTokenText(); !strings.Contains(got, "120 tokens") {
+		t.Fatalf("sidebar token text = %q, want it to carry the 120-token figure", got)
+	}
+	// With the sidebar open, the status line must not repeat the token figure.
+	status := plainRender(t, m.statusLine(m.width))
+	if strings.Contains(status, "tok") {
+		t.Fatalf("status line = %q, should not duplicate the token figure while the sidebar shows it", status)
+	}
+
+	// Sidebar hidden → the status line is the only home for the figure again.
+	m.sidebarHidden = true
+	if m.sidebarActive() {
+		t.Fatal("sidebar should be inactive once hidden")
+	}
+	hidden := plainRender(t, m.statusLine(m.width))
+	if !strings.Contains(hidden, "120 tok") {
+		t.Fatalf("status line with sidebar hidden = %q, want the token figure back", hidden)
+	}
+}
+
 func TestInvalidUsageEventsAppendTranscriptError(t *testing.T) {
 	provider := &fakeProvider{events: []zeroruntime.StreamEvent{
 		{Type: zeroruntime.StreamEventText, Content: "done"},

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -223,7 +223,13 @@ func (m model) statusLine(width int) string {
 			rightGroups = append(rightGroups, gauge)
 		}
 	}
-	if usage := m.usageStatusSegment(); usage != "" {
+	// The sidebar pins the token readout at its floor, so when it's open keep
+	// only the cost here — otherwise the token figure shows on both sides.
+	usage := m.usageStatusSegment()
+	if m.sidebarActive() {
+		usage = m.usageCostSegment()
+	}
+	if usage != "" {
 		rightGroups = append(rightGroups, zeroTheme.muted.Render(usage))
 	}
 	right := strings.Join(rightGroups, separator)
@@ -313,6 +319,21 @@ func (m model) usageStatusSegment() string {
 		humanCount(tokens),
 		summary.FormattedTotalCost,
 	)
+}
+
+// usageCostSegment returns just the session cost, with the token figure dropped.
+// Used in the status line when the sidebar is open and already showing tokens at
+// its floor, so the cost survives without duplicating the token count. Empty
+// until a priced usage record lands (no cost to show yet).
+func (m model) usageCostSegment() string {
+	if m.usageTracker == nil {
+		return ""
+	}
+	summary := m.usageTracker.Summary()
+	if summary.RecordCount == 0 {
+		return ""
+	}
+	return strings.TrimSpace(summary.FormattedTotalCost)
 }
 
 // contextFillPercent returns the latest request's context-window fill as a percent


### PR DESCRIPTION
## What

The token count showed up **twice** when the sidebar is open: the sidebar pins `10.2K tokens` at its floor, and the status line *also* rendered its own `10.2K tok` usage segment — the same figure on both sides of the screen.

## Why

The status line already suppresses the **context-fill gauge** while the sidebar is open (the sidebar shows the `%`), but the **usage/token** segment was never given the same treatment, so it kept printing alongside the sidebar's readout.

## Fix

When the sidebar is active, the status line drops the token figure and keeps a **cost-only** segment instead — because the sidebar shows tokens but *not* cost, so the session cost would otherwise be lost. The cost segment is empty until a priced usage record lands (matching today's behaviour where unpriced sessions show only tokens).

- Sidebar open, unpriced: status line shows no usage; sidebar shows `N tokens`.
- Sidebar open, priced: status line shows just the cost; sidebar shows `N tokens`.
- Sidebar hidden (Ctrl+B) or unavailable: status line shows `N tok · $cost` exactly as before.

## Tests

`TestStatusLineDropsTokenFigureWhenSidebarShowsIt` — asserts the token figure is absent from the status line while the sidebar shows it, and returns to the status line when the sidebar is hidden. Full `./internal/tui/...` suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the status line so it no longer repeats token usage when the sidebar already shows that information.
  * When the sidebar is open, the status line now shows only the session cost; token details return once the sidebar is hidden.
  * Added coverage to verify the status line and sidebar display the expected usage values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->