### PR TITLE
chore: scrub named other-CLI references from the codebase

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Extending Zero
 
-Zero is an open-source terminal coding agent in the same family as Claude Code, Codex, and Droid. Out of the box it does the obvious things — read, edit, run, search — but the design point of the project is that **every surface is configurable**. This document is the user-facing guide for that configuration.
+Zero is an open-source terminal coding agent. Out of the box it does the obvious things — read, edit, run, search — but the design point of the project is that **every surface is configurable**. This document is the user-facing guide for that configuration.
 
 If you only want to *use* Zero, the [README](README.md) is enough. This page is for the other three jobs:
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,7 +1,7 @@
 # Zero — Product Requirements Document (v1.0)
 
 **Status:** DRAFT v1.0
-**Target:** Compete with Claude Code + Cursor + OpenCode
+**Target:** Compete with Claude Code + Cursor + other multi-provider terminal agents
 **Timeline:** 6-12 months
 **Stack:** Go native core + npm distribution wrapper
 
@@ -14,7 +14,7 @@
 It combines the best of:
 - **Claude Code** — terminal-native agentic coding
 - **Cursor** — IDE integration + smart editing
-- **OpenCode** — multi-provider + headless
+- **Multi-provider terminal agents** — provider-agnostic + headless
 
 **One Go-native agent core. Three surfaces. Zero lock-in.**
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1016,7 +1016,7 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.transcriptDetailed {
 				return m, nil
 			}
-			// Ctrl+T cycles reasoning effort opencode-style (auto -> low ->
+			// Ctrl+T cycles reasoning effort (auto -> low ->
 			// medium -> high -> auto), but only when nothing modal is up — the
 			// same gate shift+tab uses above. Not gated on m.pending: cycling
 			// mid-run is allowed and takes effect on the next turn, matching
@@ -1791,7 +1791,7 @@ func (m model) transcriptView() string {
 
 	// Plan panel renders inline in the transcript body (as a transcript row),
 	// not pinned at the top. It appears above the specialist cards like a
-	// chat message, matching how opencode renders todo/plan updates inline.
+	// chat message, the way todo/plan updates render inline.
 	if m.altScreen && m.height > 0 {
 		header := m.pinnedTitleBar(width)
 		return m.scrollableTranscriptItemsView(header, bodyItems, footer, width, overlayForViewport)

--- a/internal/tui/rendering.go
+++ b/internal/tui/rendering.go
@@ -1360,7 +1360,7 @@ func toolCardHead(name string, target string, arg string, headTag string, nameSt
 // edge, the head (with the status glyph right-aligned to the card edge) on the
 // first line, body lines below, and an optional footer line — no top, right, or
 // bottom borders. This matches the lighter inline style of specialist cards
-// (renderLeftRuleCard) and the reference TUIs (opencode, codex), instead of the
+// (renderLeftRuleCard) and comparable terminal agents, instead of the
 // older full rounded box. Every emitted line is exactly `width` cells, and the
 // inner content budget stays width-4, so the diff/read/bash body renderers
 // (which assume width-4) need no change. On the tiny tier the rail goes away

--- a/internal/tui/session_controls.go
+++ b/internal/tui/session_controls.go
@@ -148,7 +148,7 @@ func (m model) effortDisplay() string {
 	return string(m.reasoningEffort)
 }
 
-// cycleReasoningEffort advances the reasoning-effort ring opencode-style:
+// cycleReasoningEffort advances the reasoning-effort ring:
 // auto ("") -> first supported -> ... -> last supported -> auto. No-op (model
 // unchanged) when the active model exposes no effort controls, so Ctrl+T stays
 // quiet on non-reasoning models. Called from the Ctrl+T key case — a rare

--- a/internal/tui/session_controls_test.go
+++ b/internal/tui/session_controls_test.go
@@ -75,7 +75,7 @@ func TestEffortCommandRejectsUnsupportedActiveModel(t *testing.T) {
 	}
 }
 
-// The Ctrl+T cycle walks the active model's supported ring opencode-style:
+// The Ctrl+T cycle walks the active model's supported ring:
 // auto ("") -> first supported -> ... -> last supported -> auto. These cover
 // every branch of cycleReasoningEffort: empty/auto start, mid-ring advance,
 // last-slot wrap, an effort the model doesn't support, and a model with no


### PR DESCRIPTION
## What

Scrub every **named other-CLI reference** out of the codebase and replace it with neutral phrasing. Two motivations:

1. **Identity leak.** `AGENTS.MD` described Zero as *"in the same family as Claude Code, Codex, and Droid."* Since `AGENTS.MD` is injected into the model as project context, the agent parroted that line verbatim when asked **"who are you?"** — naming other agents in its own identity.
2. **Comments + PRD.** A handful of doc comments and the PRD named specific other CLIs as the thing a behaviour was "matching".

## Changes

- **`AGENTS.MD`** — Zero is now described on its own terms ("an open-source terminal coding agent"), no comparison.
- **`internal/tui/rendering.go`, `model.go`, `session_controls.go` (+ test)** — doc comments that named other CLIs now say "comparable terminal agents"; the existing generic "reference agents/TUIs" phrasing is unchanged. Comment-only, no behaviour change.
- **`docs/PRD.md`** — target/vision use generic "multi-provider terminal agents" instead of a named product. `Claude Code` and `Cursor` are kept as legitimate public-competitor positioning.

## Not touched (intentionally)

- The **ChatGPT Codex provider** (`internal/providers/openai/codex*.go`) keeps its name — that's a real product Zero connects to, not a reference to another tool's source.
- The "factory" pattern code (`factory.go`, `ClientFactory`) — ordinary software term.

## Verification

`go build ./...` + `gofmt` clean. A tracked-file sweep for `opencode|openclaude|vix|droid` returns nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Zero’s introductory text to remove comparisons and better highlight out-of-the-box basic task performance while keeping the “fully configurable surfaces” message.
  * Revised PRD positioning language to generalize the target to other multi-provider terminal agents.
  * Refreshed related TUI comments to use consistent, non-specific terminology (no behavior changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->