### PR TITLE
fix(tui): keep running swarm subagents in the AGENTS sidebar

### DIFF
--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -187,6 +187,7 @@ var swarmSpawnRe = regexp.MustCompile(`as task (\S+) on team`)
 type swarmAgent struct {
 	id         string    // e.g. "subagent-1" — the dedup key and fallback name
 	name       string    // the task briefing (argHint of the call row), or id when empty
+	state      string    // latest reported state (running/done/failed/…), "" until a report lands
 	finishing  bool      // done/failed but still lingering before removal (smooth exit)
 	finishedAt time.Time // when first seen finished (zero until the spinner tick stamps it)
 }
@@ -200,14 +201,6 @@ type swarmAgent struct {
 // opaque "subagent-N". Only spawns that produced a result row (success) are
 // returned, and the list is deduped by id.
 func (m model) swarmSpawnedAgents() []swarmAgent {
-	// If a swarm_collect has run on any team, the swarm is considered closed
-	// and we no longer surface its members in the AGENTS sidebar.
-	for _, row := range m.transcript {
-		if row.tool == "swarm_collect" && row.kind == rowToolResult {
-			return nil
-		}
-	}
-
 	seen := map[string]bool{}
 	var agents []swarmAgent
 	// pendingTask holds the task from the most recent unmatched swarm_spawn call
@@ -252,7 +245,8 @@ func (m model) swarmSpawnedAgents() []swarmAgent {
 	if status := m.swarmMemberStatus(); len(status) > 0 {
 		live := agents[:0:0]
 		for _, a := range agents {
-			switch status[a.id] {
+			a.state = status[a.id]
+			switch a.state {
 			case "done", "failed", "completed", "cancelled":
 				doneAt, stamped := m.swarmDoneAt[a.id]
 				if stamped && m.now().Sub(doneAt) >= sidebarAgentLinger {
@@ -274,12 +268,19 @@ func (m model) swarmSpawnedAgents() []swarmAgent {
 // "– teammate-1 [done] (cyan) <task>" → captures the id and the status word.
 var swarmStatusRe = regexp.MustCompile(`(?m)^\s*[-–—]?\s*(\S+)\s+\[([a-zA-Z]+)\]`)
 
-// swarmMemberStatus parses the LATEST swarm_status result in the transcript into
-// id → status (lowercased). Empty when no swarm_status has run yet.
+// swarmMemberStatus parses the LATEST swarm roster report in the transcript into
+// id → status (lowercased). Both swarm_status and swarm_collect results list
+// every member with its "[state]", so either one refreshes the live roster; the
+// last report in transcript order wins. Empty when no report has run yet. This
+// is what lets a swarm_collect that runs while members are still working keep the
+// AGENTS panel populated instead of clearing it.
 func (m model) swarmMemberStatus() map[string]string {
 	status := map[string]string{}
 	for _, row := range m.transcript {
-		if row.tool != "swarm_status" || row.kind != rowToolResult {
+		if row.kind != rowToolResult {
+			continue
+		}
+		if row.tool != "swarm_status" && row.tool != "swarm_collect" {
 			continue
 		}
 		latest := map[string]string{}
@@ -389,7 +390,16 @@ func (m model) sidebarAgentLines(width int) []string {
 			lines = append(lines, " "+icon+" "+nameStyle.Render(truncateStep(a.name, room)))
 			continue
 		}
-		lines = append(lines, " "+zeroTheme.accent.Render("•")+" "+style.Render(truncateStep(a.name, room)))
+		// A non-running state (pending/handoff/…) is shown faintly after the task
+		// so the panel reports the member's actual status; running is left implied
+		// by the live pulse to keep the common case clean.
+		nameRoom := room
+		suffix := ""
+		if st := strings.TrimSpace(a.state); st != "" && st != "running" {
+			suffix = " " + zeroTheme.faint.Render(st)
+			nameRoom = maxInt(4, room-len(st)-1)
+		}
+		lines = append(lines, " "+zeroTheme.accent.Render("•")+" "+style.Render(truncateStep(a.name, nameRoom))+suffix)
 	}
 	return lines
 }

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -278,6 +278,40 @@ func TestSwarmAgentsLingerThenDisappearWhenDone(t *testing.T) {
 	}
 }
 
+// Regression: a swarm_collect that runs WHILE members are still working must not
+// clear the AGENTS panel. Previously any swarm_collect result wiped the roster,
+// so the sidebar showed "no agents spawned" mid-run even with 4 subagents live.
+func TestSwarmAgentsStayVisibleWhileCollectRunsMidFlight(t *testing.T) {
+	m := sidebarTestModel()
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "build the homepage"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-1 on team default."},
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "build the stylesheet"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-2 on team default."},
+		// A collect mid-flight, both members still running.
+		transcriptRow{kind: rowToolResult, tool: "swarm_collect",
+			detail: "Results for team default: 2 task(s)\n- subagent-1 [running] build the homepage\n- subagent-2 [running] build the stylesheet"},
+	)
+
+	agents := m.swarmSpawnedAgents()
+	if len(agents) != 2 {
+		t.Fatalf("running members must survive a mid-flight swarm_collect, got %d: %+v", len(agents), agents)
+	}
+	for _, a := range agents {
+		if a.finishing {
+			t.Fatalf("a running member must not be marked finishing: %+v", a)
+		}
+		if a.state != "running" {
+			t.Fatalf("swarm_collect should set member state to running, got %q for %s", a.state, a.id)
+		}
+	}
+
+	plain := stripSidebar(m.sidebarAgentLines(sidebarWidth(m.width)))
+	if !strings.Contains(plain, "homepage") || !strings.Contains(plain, "stylesheet") {
+		t.Fatalf("sidebar should list the running members and their tasks:\n%s", plain)
+	}
+}
+
 func TestSidebarHidesNotFoundSpecialistMisroutes(t *testing.T) {
 	m := sidebarTestModel()
 	now := time.Now()


### PR DESCRIPTION
## Problem

With 4 swarm subagents actively running, the **AGENTS** sidebar showed **"no agents spawned"** — the roster was empty even though the transcript clearly listed all four as `[running]`.

## Root cause

`swarmSpawnedAgents()` returned `nil` the instant **any** `swarm_collect` result existed in the transcript, on the assumption that a collect means the swarm is closed. But `swarm_collect` is routinely called **mid-run** to poll for partial results — so polling once wiped the entire panel while every member was still working.

A second gap: `swarmMemberStatus()` only parsed `swarm_status` results, ignoring the identical `[state]` roster that `swarm_collect` also returns.

## Fix

- **Remove the "collect clears the roster" heuristic.** Members are now removed only when they actually report `done`/`failed`/`cancelled` (via the existing linger-then-drop logic), not when a collect happens to run.
- **`swarmMemberStatus()` reads both `swarm_status` and `swarm_collect`** (latest report wins), so a mid-flight collect *refreshes* live states instead of erasing them.
- **Surface a non-running state inline** (`pending`/`handoff`/…) after each member's task, so the panel reports real status — running stays implied by the live pulse to keep the common case clean.

Result: the four running subagents stay listed with what each is working on, and they fade out (✓ → gone) only once they genuinely finish.

## Tests

- `TestSwarmAgentsStayVisibleWhileCollectRunsMidFlight` — spawns 2, runs a mid-flight `swarm_collect` showing both `[running]`, asserts both stay visible with `state == "running"` and their tasks render. (Fails on the old code.)
- Existing `TestSwarmAgentsLingerThenDisappearWhenDone` and the rest of the sidebar suite stay green.

## Not in this PR

The sidebar agent rows still aren't **clickable** to drill into a single subagent's live output — the swarm runs in the CLI runtime and doesn't stream per-member output into a TUI subchat, so that's a larger change. Filing it as a follow-up; this PR makes the panel *correct and readable* first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Swarm/team members now remain visible in the sidebar even when a collect/update event arrives while they are still active.
  * Member status is shown more accurately, including a subtle label for non-running states.
  * Long member names are now truncated more consistently so the sidebar layout stays aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->