### PR TITLE
fix(swarm): make swarm_collect wait for members instead of polling

### DIFF
--- a/internal/swarm/coordinator.go
+++ b/internal/swarm/coordinator.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -67,15 +68,29 @@ type Coordinator struct {
 	colors     map[string]string // agentID -> color
 	colorIndex int
 	now        func() time.Time // injectable clock for tests
+	// changed is closed (and replaced) on every task state change so WaitSettled
+	// can block for a transition without polling. Always non-nil after construction.
+	changed chan struct{}
 }
 
 // NewCoordinator returns an empty coordinator using the wall clock.
 func NewCoordinator() *Coordinator {
 	return &Coordinator{
-		tasks:  map[string]*Task{},
-		colors: map[string]string{},
-		now:    time.Now,
+		tasks:   map[string]*Task{},
+		colors:  map[string]string{},
+		now:     time.Now,
+		changed: make(chan struct{}),
 	}
+}
+
+// notifyChangeLocked wakes every WaitSettled caller by closing the current change
+// channel and installing a fresh one. Must be called while holding c.mu for
+// writing; lazily initialises changed so a zero-value coordinator is still safe.
+func (c *Coordinator) notifyChangeLocked() {
+	if c.changed != nil {
+		close(c.changed)
+	}
+	c.changed = make(chan struct{})
 }
 
 // ErrTaskExists is returned when registering a duplicate task ID.
@@ -106,6 +121,7 @@ func (c *Coordinator) Register(id, agentID, team, description string) (Task, err
 	}
 	c.tasks[id] = t
 	c.assignColorLocked(agentID)
+	c.notifyChangeLocked()
 	return *t, nil
 }
 
@@ -127,6 +143,7 @@ func (c *Coordinator) SetStatus(id string, status TaskStatus) error {
 	}
 	t.Status = status
 	t.UpdatedAt = c.now()
+	c.notifyChangeLocked()
 	return nil
 }
 
@@ -154,6 +171,7 @@ func (c *Coordinator) finish(id string, status TaskStatus, result, errMsg string
 	t.Result = result
 	t.Err = errMsg
 	t.UpdatedAt = c.now()
+	c.notifyChangeLocked()
 	return nil
 }
 
@@ -173,6 +191,7 @@ func (c *Coordinator) Reassign(id, newAgentID string) error {
 	t.Status = StatusPending
 	t.UpdatedAt = c.now()
 	c.assignColorLocked(newAgentID)
+	c.notifyChangeLocked()
 	return nil
 }
 
@@ -203,6 +222,55 @@ func (c *Coordinator) List() []Task {
 		return out[i].CreatedAt.Before(out[j].CreatedAt)
 	})
 	return out
+}
+
+// scopedList returns task snapshots for one team, or every task when team=="".
+func (c *Coordinator) scopedList(team string) []Task {
+	all := c.List()
+	if team == "" {
+		return all
+	}
+	out := all[:0:0]
+	for _, t := range all {
+		if t.Team == team {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// WaitSettled blocks until every task in the scope (one team, or all teams when
+// team=="") has reached a terminal status, then returns a snapshot of the scope.
+// It also returns — with the latest partial state — as soon as ctx is done, so a
+// stuck or long-running member can't hang the caller forever (the caller bounds
+// it with a timeout / user-cancel context). A scope with no tasks is settled
+// immediately, so an empty or unknown team never blocks. This is the primitive
+// that lets swarm_collect deliver final results in one call instead of forcing
+// the orchestrator to poll swarm_status in a loop.
+func (c *Coordinator) WaitSettled(ctx context.Context, team string) []Task {
+	for {
+		c.mu.RLock()
+		settled := true
+		for _, t := range c.tasks {
+			if team != "" && t.Team != team {
+				continue
+			}
+			if !t.Status.terminal() {
+				settled = false
+				break
+			}
+		}
+		ch := c.changed
+		c.mu.RUnlock()
+		if settled || ch == nil {
+			return c.scopedList(team)
+		}
+		select {
+		case <-ctx.Done():
+			return c.scopedList(team)
+		case <-ch:
+		}
+	}
 }
 
 // Color returns the stable color assigned to an agent (assigning one on first

--- a/internal/swarm/coordinator.go
+++ b/internal/swarm/coordinator.go
@@ -215,28 +215,18 @@ func (c *Coordinator) List() []Task {
 		out = append(out, *t)
 	}
 	c.mu.RUnlock()
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
-			return out[i].ID < out[j].ID
-		}
-		return out[i].CreatedAt.Before(out[j].CreatedAt)
-	})
+	sortTasksByCreation(out)
 	return out
 }
 
-// scopedList returns task snapshots for one team, or every task when team=="".
-func (c *Coordinator) scopedList(team string) []Task {
-	all := c.List()
-	if team == "" {
-		return all
-	}
-	out := all[:0:0]
-	for _, t := range all {
-		if t.Team == team {
-			out = append(out, t)
+// sortTasksByCreation orders tasks by creation time then ID for stable output.
+func sortTasksByCreation(tasks []Task) {
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].CreatedAt.Equal(tasks[j].CreatedAt) {
+			return tasks[i].ID < tasks[j].ID
 		}
-	}
-	return out
+		return tasks[i].CreatedAt.Before(tasks[j].CreatedAt)
+	})
 }
 
 // WaitSettled blocks until every task in the scope (one team, or all teams when
@@ -247,27 +237,34 @@ func (c *Coordinator) scopedList(team string) []Task {
 // immediately, so an empty or unknown team never blocks. This is the primitive
 // that lets swarm_collect deliver final results in one call instead of forcing
 // the orchestrator to poll swarm_status in a loop.
+//
+// The settled decision and the returned snapshot are taken in the SAME locked
+// pass, so a concurrent Register/Reassign slipping in between cannot make the
+// call return a non-terminal task it never actually waited on.
 func (c *Coordinator) WaitSettled(ctx context.Context, team string) []Task {
 	for {
 		c.mu.RLock()
 		settled := true
+		snapshot := make([]Task, 0, len(c.tasks))
 		for _, t := range c.tasks {
 			if team != "" && t.Team != team {
 				continue
 			}
+			snapshot = append(snapshot, *t)
 			if !t.Status.terminal() {
 				settled = false
-				break
 			}
 		}
 		ch := c.changed
 		c.mu.RUnlock()
 		if settled || ch == nil {
-			return c.scopedList(team)
+			sortTasksByCreation(snapshot)
+			return snapshot
 		}
 		select {
 		case <-ctx.Done():
-			return c.scopedList(team)
+			sortTasksByCreation(snapshot)
+			return snapshot
 		case <-ch:
 		}
 	}

--- a/internal/swarm/lifecycle.go
+++ b/internal/swarm/lifecycle.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -174,4 +175,12 @@ func (s *Swarm) Collect(teamName string) []Task {
 		}
 	}
 	return out
+}
+
+// CollectWait blocks until the team's tasks all reach a terminal state (or ctx is
+// done), then returns their snapshots. This is what swarm_collect uses so the
+// orchestrator gets final results in a single call instead of polling
+// swarm_status repeatedly while members are still running.
+func (s *Swarm) CollectWait(ctx context.Context, teamName string) []Task {
+	return s.coord.WaitSettled(ctx, sanitizeName(teamName))
 }

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Gitlawb/zero/internal/tools"
 )
@@ -111,7 +112,7 @@ type spawnTool struct {
 
 func (t *spawnTool) Name() string { return SpawnToolName }
 func (t *spawnTool) Description() string {
-	return "Spawn a swarm member of the given agent type to run a task concurrently under a team. Returns a task id immediately; results are reported through swarm_status/swarm_collect."
+	return "Spawn a swarm member of the given agent type to run a task concurrently under a team. Returns a task id immediately and the member runs in the background. After spawning all members, call swarm_collect once to wait for them and read their results — do not poll swarm_status in a loop."
 }
 func (t *spawnTool) Parameters() tools.Schema {
 	return tools.Schema{
@@ -297,7 +298,8 @@ func (t *statusTool) Deferred() bool { return !t.sw.hasActiveSwarm() }
 
 func (t *statusTool) Name() string { return StatusToolName }
 func (t *statusTool) Description() string {
-	return "Report swarm task status: counts by state and per-task lines. Optionally scoped to one team."
+	return "Return a one-shot snapshot of swarm task status: counts by state and per-task lines, optionally scoped to one team. " +
+		"This does NOT wait. To wait for members to finish and read their results, call swarm_collect once — do not call swarm_status repeatedly in a loop."
 }
 func (t *statusTool) Parameters() tools.Schema {
 	return tools.Schema{
@@ -402,13 +404,16 @@ func (t *collectTool) Deferred() bool { return !t.sw.hasActiveSwarm() }
 
 func (t *collectTool) Name() string { return CollectToolName }
 func (t *collectTool) Description() string {
-	return "Collect the results of a team's tasks (status, result, and any error per task)."
+	return "Wait for a team's tasks to finish, then return each task's status, result, and any error. " +
+		"This BLOCKS until every member completes (bounded by a timeout), so call it once after spawning to get the results — " +
+		"do not poll swarm_status in a loop. Use swarm_status only for a quick mid-run snapshot."
 }
 func (t *collectTool) Parameters() tools.Schema {
 	return tools.Schema{
 		Type: "object",
 		Properties: map[string]tools.PropertySchema{
-			"team": {Type: "string", Description: "Team to collect from. Defaults to \"default\"."},
+			"team":            {Type: "string", Description: "Team to collect from. Defaults to \"default\"."},
+			"timeout_seconds": {Type: "number", Description: "Max seconds to wait for members to finish before returning partial results. Defaults to 600, capped at 1800."},
 		},
 		AdditionalProperties: false,
 	}
@@ -424,9 +429,39 @@ func (t *collectTool) Safety() tools.Safety {
 func (t *collectTool) Run(ctx context.Context, args map[string]any) tools.Result {
 	return t.RunWithOptions(ctx, args, tools.RunOptions{})
 }
-func (t *collectTool) RunWithOptions(_ context.Context, args map[string]any, _ tools.RunOptions) tools.Result {
+
+const (
+	defaultCollectWaitTimeout = 10 * time.Minute
+	maxCollectWaitTimeout     = 30 * time.Minute
+)
+
+// collectWaitTimeout reads the optional timeout_seconds arg (JSON numbers arrive
+// as float64), falling back to the default and clamping to the max so a single
+// collect call can never block unboundedly.
+func collectWaitTimeout(args map[string]any) time.Duration {
+	if v, ok := args["timeout_seconds"]; ok {
+		if f, ok := v.(float64); ok && f > 0 {
+			if d := time.Duration(f * float64(time.Second)); d < maxCollectWaitTimeout {
+				return d
+			}
+			return maxCollectWaitTimeout
+		}
+	}
+	return defaultCollectWaitTimeout
+}
+
+func (t *collectTool) RunWithOptions(ctx context.Context, args map[string]any, _ tools.RunOptions) tools.Result {
 	team := swarmStr(args, "team")
-	tasks := t.sw.Collect(team)
+	// Block until the team's members all finish so the orchestrator gets final
+	// results in one call instead of polling. Bounded by the run context (user
+	// cancel) and a timeout cap; on timeout/cancel it returns the latest partial
+	// state rather than hanging on a stuck member.
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, collectWaitTimeout(args))
+	defer cancel()
+	tasks := t.sw.CollectWait(waitCtx, team)
 	var b strings.Builder
 	fmt.Fprintf(&b, "Results for team %s: %d task(s)\n", displayTeam(team), len(tasks))
 	for _, task := range tasks {

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -441,10 +441,14 @@ const (
 func collectWaitTimeout(args map[string]any) time.Duration {
 	if v, ok := args["timeout_seconds"]; ok {
 		if f, ok := v.(float64); ok && f > 0 {
-			if d := time.Duration(f * float64(time.Second)); d < maxCollectWaitTimeout {
-				return d
+			// Clamp in float space first: a very large f * float64(time.Second)
+			// overflows the int64 nanosecond Duration and wraps negative, which
+			// would make context.WithTimeout fire immediately instead of honoring
+			// the cap. Compare seconds, then convert only a known-safe value.
+			if f >= maxCollectWaitTimeout.Seconds() {
+				return maxCollectWaitTimeout
 			}
-			return maxCollectWaitTimeout
+			return time.Duration(f * float64(time.Second))
 		}
 	}
 	return defaultCollectWaitTimeout

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/Gitlawb/zero/internal/tools"
@@ -134,6 +135,78 @@ func TestStatusAndCollectTools(t *testing.T) {
 	collect := reg.RunWithOptions(context.Background(), CollectToolName, map[string]any{"team": "alpha"}, tools.RunOptions{})
 	if collect.Status != tools.StatusOK || !strings.Contains(collect.Output, "ok:compute") {
 		t.Fatalf("collect output missing result: %q", collect.Output)
+	}
+}
+
+// swarm_collect must BLOCK until the team's members finish, then return their
+// results in one call — this is what frees the orchestrator from polling.
+func TestCollectBlocksUntilMembersFinish(t *testing.T) {
+	gate := make(chan struct{})
+	l := newLauncher(okFor)
+	l.gate = gate // members block until the gate is closed
+	reg, sw := newToolSwarm(t, l)
+
+	spawn := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate", "task": "compute", "team": "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m"})
+	id := spawn.Meta["task_id"]
+	waitFor(t, "member running", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusRunning
+	})
+
+	done := make(chan tools.Result, 1)
+	go func() {
+		done <- reg.RunWithOptions(context.Background(), CollectToolName, map[string]any{"team": "alpha"}, tools.RunOptions{})
+	}()
+
+	// collect must not return while the member is still running.
+	select {
+	case res := <-done:
+		t.Fatalf("collect returned before the member finished: %q", res.Output)
+	case <-time.After(60 * time.Millisecond):
+	}
+
+	close(gate) // let the member finish
+	select {
+	case res := <-done:
+		if res.Status != tools.StatusOK || !strings.Contains(res.Output, "ok:compute") {
+			t.Fatalf("collect after completion missing result: %q", res.Output)
+		}
+		if !strings.Contains(res.Output, "[done]") {
+			t.Fatalf("collect should report the task done: %q", res.Output)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("collect did not return after the member finished")
+	}
+}
+
+// A stuck member must not hang collect forever: with a small timeout it returns
+// the latest partial state (the still-running task) instead of blocking.
+func TestCollectReturnsPartialOnTimeout(t *testing.T) {
+	gate := make(chan struct{})
+	defer close(gate) // release the member at cleanup so the swarm closes cleanly
+	l := newLauncher(okFor)
+	l.gate = gate
+	reg, sw := newToolSwarm(t, l)
+
+	spawn := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate", "task": "compute", "team": "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m"})
+	id := spawn.Meta["task_id"]
+	waitFor(t, "member running", func() bool {
+		task, ok := sw.Coordinator().Get(id)
+		return ok && task.Status == StatusRunning
+	})
+
+	res := reg.RunWithOptions(context.Background(), CollectToolName, map[string]any{
+		"team": "alpha", "timeout_seconds": 0.03,
+	}, tools.RunOptions{})
+	if res.Status != tools.StatusOK {
+		t.Fatalf("collect status = %v output=%q", res.Status, res.Output)
+	}
+	if !strings.Contains(res.Output, "[running]") {
+		t.Fatalf("a stuck member should come back as running on timeout, got %q", res.Output)
 	}
 }
 

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -138,10 +138,32 @@ func TestStatusAndCollectTools(t *testing.T) {
 	}
 }
 
+func TestCollectWaitTimeoutClampsAndOverflows(t *testing.T) {
+	// A huge timeout_seconds must clamp to the cap, not overflow the int64-ns
+	// Duration into a negative value (which would make collect return at once).
+	if got := collectWaitTimeout(map[string]any{"timeout_seconds": 1e20}); got != maxCollectWaitTimeout {
+		t.Fatalf("huge timeout = %v, want cap %v", got, maxCollectWaitTimeout)
+	}
+	if got := collectWaitTimeout(map[string]any{"timeout_seconds": float64(30)}); got != 30*time.Second {
+		t.Fatalf("30s timeout = %v, want 30s", got)
+	}
+	if got := collectWaitTimeout(map[string]any{}); got != defaultCollectWaitTimeout {
+		t.Fatalf("missing timeout = %v, want default %v", got, defaultCollectWaitTimeout)
+	}
+}
+
 // swarm_collect must BLOCK until the team's members finish, then return their
 // results in one call — this is what frees the orchestrator from polling.
 func TestCollectBlocksUntilMembersFinish(t *testing.T) {
 	gate := make(chan struct{})
+	gateClosed := false
+	// Release the gated member even if an assertion fails before the explicit
+	// close below, so a failing run can't leak the blocked member's goroutine.
+	defer func() {
+		if !gateClosed {
+			close(gate)
+		}
+	}()
 	l := newLauncher(okFor)
 	l.gate = gate // members block until the gate is closed
 	reg, sw := newToolSwarm(t, l)
@@ -168,6 +190,7 @@ func TestCollectBlocksUntilMembersFinish(t *testing.T) {
 	}
 
 	close(gate) // let the member finish
+	gateClosed = true
 	select {
 	case res := <-done:
 		if res.Status != tools.StatusOK || !strings.Contains(res.Output, "ok:compute") {

--- a/internal/tui/collapse_tools_test.go
+++ b/internal/tui/collapse_tools_test.go
@@ -7,6 +7,48 @@ import (
 	"github.com/Gitlawb/zero/internal/tools"
 )
 
+func TestCollapseRepeatedStatusCardDropsDuplicate(t *testing.T) {
+	detail := "Swarm status (team default): 4 task(s) — 4 running"
+	rows := []transcriptRow{
+		{kind: rowAssistant, text: "let me check"},
+		{kind: rowToolCall, tool: "swarm_status"},
+		{kind: rowToolResult, tool: "swarm_status", detail: detail},
+		{kind: rowToolCall, tool: "swarm_status"}, // the new check's call row
+	}
+	out := collapseRepeatedStatusCard(rows, transcriptRow{kind: rowToolResult, tool: "swarm_status", detail: detail})
+	if len(out) != 2 {
+		t.Fatalf("duplicate status pair should collapse to 2 rows, got %d: %+v", len(out), out)
+	}
+	if out[0].kind != rowAssistant || out[1].kind != rowToolCall {
+		t.Fatalf("collapse kept the wrong rows: %+v", out)
+	}
+}
+
+func TestCollapseRepeatedStatusCardKeepsChangedState(t *testing.T) {
+	rows := []transcriptRow{
+		{kind: rowToolCall, tool: "swarm_status"},
+		{kind: rowToolResult, tool: "swarm_status", detail: "4 running"},
+		{kind: rowToolCall, tool: "swarm_status"},
+	}
+	out := collapseRepeatedStatusCard(rows, transcriptRow{kind: rowToolResult, tool: "swarm_status", detail: "2 running, 2 done"})
+	if len(out) != 3 {
+		t.Fatalf("a changed status must not collapse, got %d rows", len(out))
+	}
+}
+
+func TestCollapseRepeatedStatusCardIgnoresInterveningContent(t *testing.T) {
+	rows := []transcriptRow{
+		{kind: rowToolCall, tool: "swarm_status"},
+		{kind: rowToolResult, tool: "swarm_status", detail: "4 running"},
+		{kind: rowReasoning, text: "thinking"},
+		{kind: rowToolCall, tool: "swarm_status"},
+	}
+	out := collapseRepeatedStatusCard(rows, transcriptRow{kind: rowToolResult, tool: "swarm_status", detail: "4 running"})
+	if len(out) != 4 {
+		t.Fatalf("intervening content must prevent collapse, got %d rows", len(out))
+	}
+}
+
 func TestToolResultCollapsesLongOutputByDefault(t *testing.T) {
 	m := transcriptViewTestModel()
 	long := numberedLines(cardBodyMaxLines + 10)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1647,6 +1647,9 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// preview so it doesn't linger or duplicate beneath the card.
 			m.clearStreamingToolCall()
 		}
+		// Collapse a repeated swarm status/collect card so re-checks don't flood
+		// the chat with identical blocks.
+		m.transcript = collapseRepeatedStatusCard(m.transcript, msg.row)
 		m.transcript = appendTranscriptRow(m.transcript, msg.row)
 		return m, nil
 	case doctorCommandResultMsg:

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -136,6 +136,42 @@ func appendTranscriptRowsDedup(rows []transcriptRow, newRows []transcriptRow) []
 	return rows
 }
 
+// isSwarmStatusTool reports whether a tool is one of the swarm polling tools
+// whose repeated identical result cards should be collapsed in the transcript.
+func isSwarmStatusTool(name string) bool {
+	return name == "swarm_status" || name == "swarm_collect"
+}
+
+// collapseRepeatedStatusCard drops the immediately-preceding identical swarm
+// status card (its call+result pair) when newResult repeats it verbatim, so a
+// model that re-checks swarm_status/swarm_collect doesn't flood the chat with
+// the same card. It only fires when the tail is exactly
+// [prev call][prev identical result][new call] — two back-to-back checks with
+// nothing between them — so it never removes a card that has intervening content
+// or a changed state. The new call row at the tail is kept; the caller appends
+// the new result row afterwards.
+func collapseRepeatedStatusCard(rows []transcriptRow, newResult transcriptRow) []transcriptRow {
+	if newResult.kind != rowToolResult || !isSwarmStatusTool(newResult.tool) {
+		return rows
+	}
+	n := len(rows)
+	if n < 3 {
+		return rows
+	}
+	newCall, prevResult, prevCall := rows[n-1], rows[n-2], rows[n-3]
+	if newCall.kind != rowToolCall || newCall.tool != newResult.tool {
+		return rows
+	}
+	if prevResult.kind != rowToolResult || prevResult.tool != newResult.tool || prevResult.detail != newResult.detail {
+		return rows
+	}
+	if prevCall.kind != rowToolCall || prevCall.tool != newResult.tool {
+		return rows
+	}
+	// Drop the older call+result pair (n-3, n-2); keep the new call row (n-1).
+	return append(rows[:n-3], newCall)
+}
+
 func hasTranscriptRow(rows []transcriptRow, row transcriptRow) bool {
 	key := transcriptRowKey(row)
 	if key == "" {


### PR DESCRIPTION
## Problem

Spawning swarm subagents felt broken: they appeared to "never finish", and the chat filled with repeated `swarm_status`/`swarm_collect` cards.

**Root cause:** `swarm_spawn` is fire-and-forget and there is **no completion event** — the only way to learn a member finished was to call `swarm_status`/`swarm_collect`, which returned an **instant snapshot** and never waited. So the orchestrator had no choice but to **poll in a loop**: that's the status-check spam, and why it never reaches a clean "done."

(Studied a mature reference agent for comparison — its delegation **blocks** and returns results when children finish, rather than exposing a poll-only status tool. This PR brings the same model to our `swarm_collect`.)

## Fix — `swarm_collect` now waits

- **`Coordinator.WaitSettled(ctx, team)`** blocks until the scope has no pending/running task, then returns the snapshot. A change-broadcast channel (closed on every register/setstatus/finish/reassign) wakes waiters with no polling. Empty/unknown team settles immediately.
- **`Swarm.CollectWait`** wraps it; the **collect tool** calls it bounded by:
  - the **run context** (so Esc / user-cancel returns immediately), and
  - a **timeout** — default 600s, cap 1800s, overridable via `timeout_seconds` — so a genuinely stuck member returns **partial** state instead of hanging.
- **Tool descriptions** now steer the model: *spawn all members, then call `swarm_collect` once to wait for results; `swarm_status` is a one-shot snapshot, don't poll it in a loop.*

## Fix — chat de-spam

`collapseRepeatedStatusCard` drops the previous identical swarm status/collect card when a check repeats **verbatim back-to-back**, so any residual re-checks don't stack duplicate blocks. It only fires on an exact `[call][identical result][call]` tail — never removes a card with intervening content or a changed state.

## Tests

- `TestCollectBlocksUntilMembersFinish` — collect does not return while a member runs; returns the result once it finishes.
- `TestCollectReturnsPartialOnTimeout` — a stuck member + small `timeout_seconds` returns the running snapshot instead of hanging.
- `TestCollapseRepeatedStatusCard{DropsDuplicate,KeepsChangedState,IgnoresInterveningContent}`.
- Existing `TestStatusAndCollectTools` still green (it waits for done before collecting, so blocking is a no-op there). Full `./internal/swarm/...` + `./internal/tui/...` suites green.

## Follow-up (not in this PR)

Clickable **drill-in subchat** for individual swarm members — they're runtime-only (no session), so that needs per-member sessions wired into the existing subchat machinery. Tracked separately; this PR fixes the completion/spam loop first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a wait-based collect experience so team task results can be gathered after work finishes, with optional timeout support.
  * Improved status polling behavior to return partial results when time runs out instead of waiting indefinitely.

* **Bug Fixes**
  * Reduced repeated status/collect entries in the TUI transcript, making chat output shorter and easier to read.
  * Prevented duplicate status blocks from appearing when the same check is repeated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->