### PR TITLE
feat(tui): click a swarm member in the sidebar to open its subchat

### DIFF
--- a/internal/swarm/coordinator.go
+++ b/internal/swarm/coordinator.go
@@ -52,8 +52,11 @@ type Task struct {
 	Status      TaskStatus
 	Result      string
 	Err         string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// SessionID is the member's durable child session id, recorded on completion
+	// so the TUI can drill into the member's conversation. Empty until done.
+	SessionID string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // agentColors palette for stable per-agent coloring in the TUI/status. Provider
@@ -149,15 +152,21 @@ func (c *Coordinator) SetStatus(id string, status TaskStatus) error {
 
 // Complete marks a task done with its result.
 func (c *Coordinator) Complete(id, result string) error {
-	return c.finish(id, StatusDone, result, "")
+	return c.finish(id, StatusDone, result, "", "")
+}
+
+// CompleteWithSession marks a task done with its result and the member's durable
+// child session id (so the TUI can drill into the member's conversation).
+func (c *Coordinator) CompleteWithSession(id, result, sessionID string) error {
+	return c.finish(id, StatusDone, result, "", sessionID)
 }
 
 // Fail marks a task failed with an error message.
 func (c *Coordinator) Fail(id, errMsg string) error {
-	return c.finish(id, StatusFailed, "", errMsg)
+	return c.finish(id, StatusFailed, "", errMsg, "")
 }
 
-func (c *Coordinator) finish(id string, status TaskStatus, result, errMsg string) error {
+func (c *Coordinator) finish(id string, status TaskStatus, result, errMsg, sessionID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	t, ok := c.tasks[id]
@@ -170,6 +179,9 @@ func (c *Coordinator) finish(id string, status TaskStatus, result, errMsg string
 	t.Status = status
 	t.Result = result
 	t.Err = errMsg
+	if sessionID != "" {
+		t.SessionID = sessionID
+	}
 	t.UpdatedAt = c.now()
 	c.notifyChangeLocked()
 	return nil

--- a/internal/swarm/coordinator_test.go
+++ b/internal/swarm/coordinator_test.go
@@ -23,6 +23,21 @@ func TestCoordinatorRegisterAndDuplicate(t *testing.T) {
 	}
 }
 
+func TestCompleteWithSessionRecordsSessionID(t *testing.T) {
+	c := NewCoordinator()
+	_, _ = c.Register("t1", "a1", "team", "desc")
+	if err := c.CompleteWithSession("t1", "result", "sess-xyz"); err != nil {
+		t.Fatalf("CompleteWithSession: %v", err)
+	}
+	task, _ := c.Get("t1")
+	if task.Status != StatusDone || task.Result != "result" {
+		t.Fatalf("unexpected task state: %+v", task)
+	}
+	if task.SessionID != "sess-xyz" {
+		t.Fatalf("SessionID = %q, want sess-xyz", task.SessionID)
+	}
+}
+
 func TestCoordinatorLifecycleTransitions(t *testing.T) {
 	c := NewCoordinator()
 	_, _ = c.Register("t1", "a1", "team", "desc")

--- a/internal/swarm/lifecycle.go
+++ b/internal/swarm/lifecycle.go
@@ -73,7 +73,7 @@ func (s *Swarm) watch(t *Team, m *Member, spec MemberSpec) {
 		}
 		_ = s.coord.Fail(m.TaskID, memberError(err))
 	} else {
-		_ = s.coord.Complete(m.TaskID, res.Result)
+		_ = s.coord.CompleteWithSession(m.TaskID, res.Result, res.SessionID)
 	}
 	t.removeMember(m.ID)
 	s.afterExit(t)

--- a/internal/swarm/tools.go
+++ b/internal/swarm/tools.go
@@ -479,7 +479,19 @@ func (t *collectTool) RunWithOptions(ctx context.Context, args map[string]any, _
 		b.WriteString(line + "\n")
 	}
 	out := strings.TrimRight(b.String(), "\n")
-	return okResult(out, "swarm", fmt.Sprintf("%d task(s)", len(tasks)))
+	res := okResult(out, "swarm", fmt.Sprintf("%d task(s)", len(tasks)))
+	// Surface each completed member's durable session id (task_id -> session_id)
+	// so the TUI can make the AGENTS sidebar rows drill into the member's session.
+	meta := map[string]string{}
+	for _, task := range tasks {
+		if task.SessionID != "" {
+			meta[task.ID] = task.SessionID
+		}
+	}
+	if len(meta) > 0 {
+		res.Meta = meta
+	}
+	return res
 }
 
 // renderTasks formats a status summary + per-task lines, colored per agent.

--- a/internal/swarm/tools_test.go
+++ b/internal/swarm/tools_test.go
@@ -233,6 +233,25 @@ func TestCollectReturnsPartialOnTimeout(t *testing.T) {
 	}
 }
 
+// swarm_collect surfaces each completed member's durable session id in Meta so
+// the TUI can drill into the member's conversation.
+func TestCollectMetaCarriesMemberSessionIDs(t *testing.T) {
+	reg, _ := newToolSwarm(t, newLauncher(okFor))
+	spawn := reg.RunWithOptions(context.Background(), SpawnToolName, map[string]any{
+		"agent_type": "teammate", "task": "compute", "team": "alpha",
+	}, tools.RunOptions{PermissionGranted: true, Model: "m"})
+	id := spawn.Meta["task_id"]
+
+	// collect blocks until the member finishes, so its session id is recorded.
+	collect := reg.RunWithOptions(context.Background(), CollectToolName, map[string]any{"team": "alpha"}, tools.RunOptions{})
+	if collect.Meta == nil || collect.Meta[id] == "" {
+		t.Fatalf("collect Meta should carry the member session id for %s, got %#v", id, collect.Meta)
+	}
+	if want := "sess-" + id; collect.Meta[id] != want {
+		t.Fatalf("collect Meta[%s] = %q, want %q", id, collect.Meta[id], want)
+	}
+}
+
 func TestSpawnToolUnknownTypeListsAvailable(t *testing.T) {
 	_, sw := newToolSwarm(t, newLauncher(okFor))
 	tool := &spawnTool{sw: sw}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -166,8 +166,13 @@ type model struct {
 	// contaminate the new session's log with the old run's events. The
 	// agentResponseMsg handler persists each such run's session events (only) so
 	// the checkpoints stay referenced, then removes the id.
-	flushRunIDs       map[int]string
-	liveUsageCounts   map[int]int
+	flushRunIDs     map[int]string
+	liveUsageCounts map[int]int
+	// swarmSessionMap maps a swarm task id to its member's durable child session
+	// id (carried up by swarm_collect's Meta), so the AGENTS sidebar rows can drill
+	// into a member's conversation. Persists across turns; only completed members
+	// have an entry.
+	swarmSessionMap   map[string]string
 	pendingPermission *pendingPermissionPrompt
 	pendingAskUser    *pendingAskUserPrompt
 	pendingSpecReview *pendingSpecReviewPrompt
@@ -384,6 +389,14 @@ type specialistCompleteMsg struct {
 	childSessionID string
 	status         specialistStatus
 	errorMsg       string
+}
+
+// swarmSessionsMsg carries swarm task_id -> member session_id pairs (from
+// swarm_collect's Meta) so the AGENTS sidebar rows can drill into a member's
+// session like a specialist card.
+type swarmSessionsMsg struct {
+	runID    int
+	sessions map[string]string
 }
 
 // specialistProgressMsg carries a live tool-call progress update from the
@@ -612,6 +625,7 @@ func newModel(ctx context.Context, options Options) model {
 		notifier:               notifier,
 		altScreen:              options.AltScreen,
 		liveUsageCounts:        map[int]int{},
+		swarmSessionMap:        map[string]string{},
 		setup:                  newSetupState(options.Setup),
 		setupSave:              options.Setup.Save,
 	}
@@ -1660,6 +1674,19 @@ func (m model) updateModel(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the chat with identical blocks.
 		m.transcript = collapseRepeatedStatusCard(m.transcript, msg.row)
 		m.transcript = appendTranscriptRow(m.transcript, msg.row)
+		return m, nil
+	case swarmSessionsMsg:
+		// Merge completed swarm members' session ids so their AGENTS sidebar rows
+		// become drill-in clickable. Session ids are durable facts, so this is not
+		// gated on the active run.
+		if m.swarmSessionMap == nil {
+			m.swarmSessionMap = map[string]string{}
+		}
+		for taskID, sessionID := range msg.sessions {
+			if taskID != "" && sessionID != "" {
+				m.swarmSessionMap[taskID] = sessionID
+			}
+		}
 		return m, nil
 	case doctorCommandResultMsg:
 		if msg.id == 0 || msg.id == m.doctorCommandSeq {
@@ -3889,6 +3916,12 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 						errorMsg:       result.Output,
 					})
 				}
+			}
+			// swarm_collect carries task_id -> session_id for completed members, so
+			// the AGENTS sidebar rows can drill into a member's session like a
+			// specialist card.
+			if result.Name == "swarm_collect" && len(result.Meta) > 0 && m.runtimeMessageSink != nil {
+				m.runtimeMessageSink(swarmSessionsMsg{runID: runID, sessions: result.Meta})
 			}
 			if onToolResult != nil {
 				onToolResult(result)

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -153,6 +153,38 @@ func (m model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 }
 
+// sidebarLineAtMouse maps a left-click in the AGENTS sidebar column to the swarm
+// member whose row was clicked, when that member's session is known. Geometry:
+// twoColumnTranscriptView is the full screen (sidebarActive ⇒ alt-screen), and
+// joinColumns lays out [chat(chatColumnWidth)][" │ " 3-cell divider][sidebar],
+// zipping row-by-row — so a sidebar line's screen Y equals its sidebar index and
+// the sidebar starts at screen X = chatColumnWidth + 3. Recomputed on demand
+// (View can't persist a registry on the value-receiver model), like
+// transcriptLineAtMouse.
+func (m model) sidebarLineAtMouse(msg tea.MouseMsg) (sidebarAgentHit, bool) {
+	if !m.sidebarActive() {
+		return sidebarAgentHit{}, false
+	}
+	if m.setup.visible || m.providerWizard != nil || m.mcpAddWizard != nil || m.mcpManager != nil || m.picker != nil || m.suggestionsActive() {
+		return sidebarAgentHit{}, false
+	}
+	sidebarW := sidebarWidth(m.width)
+	if sidebarW <= 0 {
+		return sidebarAgentHit{}, false
+	}
+	x0 := m.chatColumnWidth() + 3 // " │ " divider between the columns
+	x, y := mouseX(msg), mouseY(msg)
+	if x < x0 || x >= x0+sidebarW {
+		return sidebarAgentHit{}, false
+	}
+	for _, hit := range m.sidebarAgentSelectables(sidebarW) {
+		if hit.lineOffset == y && hit.sessionID != "" {
+			return hit, true
+		}
+	}
+	return sidebarAgentHit{}, false
+}
+
 func (m model) repeatMouseSelection(target mouseSelectionTarget) bool {
 	return target.Scope != "" && m.lastMouseSelection == target
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -188,6 +188,7 @@ type swarmAgent struct {
 	id         string    // e.g. "subagent-1" — the dedup key and fallback name
 	name       string    // the task briefing (argHint of the call row), or id when empty
 	state      string    // latest reported state (running/done/failed/…), "" until a report lands
+	sessionID  string    // member's durable child session id (from swarm_collect), "" until known
 	finishing  bool      // done/failed but still lingering before removal (smooth exit)
 	finishedAt time.Time // when first seen finished (zero until the spinner tick stamps it)
 }
@@ -235,7 +236,7 @@ func (m model) swarmSpawnedAgents() []swarmAgent {
 			if name == "" {
 				name = id
 			}
-			agents = append(agents, swarmAgent{id: id, name: name})
+			agents = append(agents, swarmAgent{id: id, name: name, sessionID: m.swarmSessionMap[id]})
 		}
 	}
 	// Members the latest swarm_status reports finished LINGER briefly with a fading
@@ -314,18 +315,36 @@ func (m *model) stampSwarmDone() {
 	}
 }
 
+// sidebarAgentHit marks a rendered agent line (by its index within the agent
+// lines block) that is clickable, carrying the member session to drill into.
+type sidebarAgentHit struct {
+	lineOffset int
+	sessionID  string
+	title      string
+}
+
 // sidebarAgentLines renders one line per active agent. Specialist delegations
 // show a live status glyph (• running, ✓ done, ✗ error) plus a "↳ <tool>" working
 // line; swarm/team members (from swarm_spawn) show a ready dot and their id.
 // Returns nil when there are none (the caller shows a placeholder).
 func (m model) sidebarAgentLines(width int) []string {
+	lines, _ := m.sidebarAgentRows(width)
+	return lines
+}
+
+// sidebarAgentRows renders the agent lines and, alongside, records which lines
+// are clickable swarm members (those whose member session is known), so a click
+// in the sidebar can drill into the member's subchat. lineOffset indexes the
+// returned lines slice.
+func (m model) sidebarAgentRows(width int) ([]string, []sidebarAgentHit) {
 	specialists := m.sidebarSpecialists()
 	swarm := m.swarmSpawnedAgents()
 	if len(specialists) == 0 && len(swarm) == 0 {
-		return nil
+		return nil, nil
 	}
 	room := maxInt(4, width-3)
 	var lines []string
+	var hits []sidebarAgentHit
 	for _, a := range specialists {
 		var icon string
 		switch a.status {
@@ -380,6 +399,11 @@ func (m model) sidebarAgentLines(width int) []string {
 	// that dims toward faint over its linger — a smooth exit before removal.
 	style := m.swarmNameStyle()
 	for _, a := range swarm {
+		// A member with a known session is clickable: record the hit at the index
+		// this line will occupy before appending it.
+		if a.sessionID != "" {
+			hits = append(hits, sidebarAgentHit{lineOffset: len(lines), sessionID: a.sessionID, title: a.name})
+		}
 		if a.finishing {
 			icon := zeroTheme.green.Render("✓")
 			nameStyle := zeroTheme.muted
@@ -401,7 +425,20 @@ func (m model) sidebarAgentLines(width int) []string {
 		}
 		lines = append(lines, " "+zeroTheme.accent.Render("•")+" "+style.Render(truncateStep(a.name, nameRoom))+suffix)
 	}
-	return lines
+	return lines, hits
+}
+
+// sidebarAgentSelectables returns the clickable swarm-member lines with their
+// ABSOLUTE index inside the rendered sidebar (the AGENTS header occupies index 0,
+// so agent rows start at index 1). Recomputed on demand by the mouse hit-test —
+// View cannot persist a registry on the value-receiver model — mirroring
+// transcriptLineAtMouse.
+func (m model) sidebarAgentSelectables(width int) []sidebarAgentHit {
+	_, hits := m.sidebarAgentRows(width)
+	for i := range hits {
+		hits[i].lineOffset++ // shift past the AGENTS header at sidebar index 0
+	}
+	return hits
 }
 
 // agentExitFading reports whether a finished agent is in the later half of its

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -8,12 +8,14 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"github.com/Gitlawb/zero/internal/sessions"
 )
 
-func swarmSidebarTestModel(t *testing.T, sessions map[string]string) model {
+func swarmSidebarTestModel(t *testing.T, sessionIDs map[string]string) model {
 	t.Helper()
 	m := sidebarTestModel()
-	m.swarmSessionMap = sessions
+	m.swarmSessionMap = sessionIDs
 	m.transcript = append(m.transcript,
 		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "build the homepage"},
 		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-1 on team default."},
@@ -76,11 +78,30 @@ func TestSidebarLineAtMouseHitsMemberRow(t *testing.T) {
 }
 
 func TestSidebarMemberClickRoutesToSubchatDrillIn(t *testing.T) {
-	m := swarmSidebarTestModel(t, map[string]string{"subagent-1": "sess-1"})
+	// A real session so the click can actually drill in (not just be "handled").
+	store := testSessionStore(t)
+	session, err := store.Create(sessions.CreateInput{Title: "member: build the homepage", ModelID: "gpt-4.1", Provider: "openai"})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if _, err := store.AppendEvent(session.SessionID, sessions.AppendEventInput{
+		Type:    sessions.EventMessage,
+		Payload: map[string]any{"role": "assistant", "content": "member work output"},
+	}); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+
+	m := swarmSidebarTestModel(t, map[string]string{"subagent-1": session.SessionID})
+	m.sessionStore = store
 	x := m.chatColumnWidth() + 3 + 2
-	_, _, handled := m.handleTranscriptSelectionMouse(testMouseClick(tea.MouseLeft, x, 1))
+	next, _, handled := m.handleTranscriptSelectionMouse(testMouseClick(tea.MouseLeft, x, 1))
 	if !handled {
-		t.Fatal("clicking a clickable member row should be handled (routed to the subchat drill-in)")
+		t.Fatal("clicking a clickable member row should be handled")
+	}
+	// It must actually enter the member's subchat session, not merely consume the click.
+	if !next.subchat.active || next.subchat.childSessionID != session.SessionID {
+		t.Fatalf("click should drill into member session %q, got active=%v id=%q",
+			session.SessionID, next.subchat.active, next.subchat.childSessionID)
 	}
 }
 

--- a/internal/tui/sidebar_test.go
+++ b/internal/tui/sidebar_test.go
@@ -6,8 +6,100 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 )
+
+func swarmSidebarTestModel(t *testing.T, sessions map[string]string) model {
+	t.Helper()
+	m := sidebarTestModel()
+	m.swarmSessionMap = sessions
+	m.transcript = append(m.transcript,
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "build the homepage"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-1 on team default."},
+		transcriptRow{kind: rowToolCall, tool: "swarm_spawn", detail: "build the stylesheet"},
+		transcriptRow{kind: rowToolResult, tool: "swarm_spawn", detail: "Spawned subagent as task subagent-2 on team default."},
+	)
+	return m
+}
+
+func TestSwarmMemberRowCarriesSessionID(t *testing.T) {
+	m := swarmSidebarTestModel(t, map[string]string{"subagent-1": "sess-1"})
+	agents := m.swarmSpawnedAgents()
+	if len(agents) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(agents))
+	}
+	if agents[0].sessionID != "sess-1" {
+		t.Fatalf("member 1 should carry its session id, got %q", agents[0].sessionID)
+	}
+	if agents[1].sessionID != "" {
+		t.Fatalf("member 2 has no mapped session yet, got %q", agents[1].sessionID)
+	}
+}
+
+func TestSidebarAgentSelectablesMapToScreenRows(t *testing.T) {
+	m := swarmSidebarTestModel(t, map[string]string{"subagent-1": "sess-1", "subagent-2": "sess-2"})
+	sel := m.sidebarAgentSelectables(sidebarWidth(m.width))
+	if len(sel) != 2 {
+		t.Fatalf("expected 2 selectable member rows, got %d: %+v", len(sel), sel)
+	}
+	// AGENTS header occupies sidebar index 0, so the two members are at 1 and 2.
+	if sel[0].lineOffset != 1 || sel[1].lineOffset != 2 {
+		t.Fatalf("selectable offsets = %d,%d, want 1,2", sel[0].lineOffset, sel[1].lineOffset)
+	}
+	if sel[0].sessionID != "sess-1" || sel[1].sessionID != "sess-2" {
+		t.Fatalf("selectable session ids = %q,%q", sel[0].sessionID, sel[1].sessionID)
+	}
+}
+
+func TestSidebarLineAtMouseHitsMemberRow(t *testing.T) {
+	m := swarmSidebarTestModel(t, map[string]string{"subagent-1": "sess-1"})
+	// Sidebar starts at screen X = chatColumnWidth + 3 (the " │ " divider); the
+	// first member row is at sidebar line 1 → screen Y 1.
+	x := m.chatColumnWidth() + 3 + 2
+	hit, ok := m.sidebarLineAtMouse(testMouseClick(tea.MouseLeft, x, 1))
+	if !ok || hit.sessionID != "sess-1" {
+		t.Fatalf("expected to hit member row (sess-1), got ok=%v hit=%+v", ok, hit)
+	}
+	// A click in the chat column (left of the divider) must miss the sidebar.
+	if _, ok := m.sidebarLineAtMouse(testMouseClick(tea.MouseLeft, 2, 1)); ok {
+		t.Fatal("a click in the chat column should not hit the sidebar")
+	}
+	// The AGENTS header row (Y 0) is not a clickable member.
+	if _, ok := m.sidebarLineAtMouse(testMouseClick(tea.MouseLeft, x, 0)); ok {
+		t.Fatal("the AGENTS header row should not be clickable")
+	}
+	// A member with no known session (subagent-2 at Y 2) is not clickable.
+	if _, ok := m.sidebarLineAtMouse(testMouseClick(tea.MouseLeft, x, 2)); ok {
+		t.Fatal("a member without a session id should not be clickable")
+	}
+}
+
+func TestSidebarMemberClickRoutesToSubchatDrillIn(t *testing.T) {
+	m := swarmSidebarTestModel(t, map[string]string{"subagent-1": "sess-1"})
+	x := m.chatColumnWidth() + 3 + 2
+	_, _, handled := m.handleTranscriptSelectionMouse(testMouseClick(tea.MouseLeft, x, 1))
+	if !handled {
+		t.Fatal("clicking a clickable member row should be handled (routed to the subchat drill-in)")
+	}
+}
+
+func TestSwarmSessionsMsgPopulatesMap(t *testing.T) {
+	m := newModel(context.Background(), Options{})
+	updated, _ := m.Update(swarmSessionsMsg{sessions: map[string]string{
+		"subagent-1": "sess-1", "": "skip", "subagent-2": "",
+	}})
+	next := updated.(model)
+	if next.swarmSessionMap["subagent-1"] != "sess-1" {
+		t.Fatalf("expected sess-1, got %q", next.swarmSessionMap["subagent-1"])
+	}
+	if _, ok := next.swarmSessionMap[""]; ok {
+		t.Fatal("an empty task id must be skipped")
+	}
+	if _, ok := next.swarmSessionMap["subagent-2"]; ok {
+		t.Fatal("an empty session id must be skipped")
+	}
+}
 
 func sidebarTestModel() model {
 	m := newModel(context.Background(), Options{ProviderName: "test-provider", ModelName: "test-model"})

--- a/internal/tui/transcript_selection.go
+++ b/internal/tui/transcript_selection.go
@@ -934,6 +934,16 @@ func transcriptSelectionPointForMouse(line transcriptSelectableLine, x int) tran
 func (m model) handleTranscriptSelectionMouse(msg tea.MouseMsg) (model, tea.Cmd, bool) {
 	switch {
 	case mouseLeftPress(msg):
+		// A click on a clickable AGENTS sidebar row drills into that swarm member's
+		// session, reusing the specialist-card subchat path. Checked before the
+		// transcript hit-test since the sidebar is outside the chat column.
+		if hit, ok := m.sidebarLineAtMouse(msg); ok {
+			if errMsg := m.subchat.enter(m.sessionStore, hit.sessionID, hit.title, m.chatScrollOffset); errMsg != "" {
+				m = m.appendSystemNotice(errMsg)
+			}
+			m.chatScrollOffset = 0
+			return m, nil, true
+		}
 		line, ok := m.transcriptLineAtMouse(msg)
 		if !ok {
 			if m.transcriptSelection.active {


### PR DESCRIPTION
## What

Makes the **AGENTS sidebar rows clickable** — click a swarm member to open its conversation in the existing subchat drill-in, exactly like a specialist card. This was the remaining piece from the swarm UX work.

## Why it's possible without new plumbing

A feasibility analysis confirmed the load-bearing fact: each swarm member already runs as a `zero exec --init-session-id <sid>` child (`internal/specialist/exec.go:227`) that persists a **durable session** in the same store the TUI's `subchat.enter` reads. So the member's conversation is already on disk — this PR just surfaces the session id and wires the click.

## How (6 small steps, all reusing existing machinery)

1. **Coordinator** records the member's child session id on completion — `CompleteWithSession` / `Task.SessionID` (`internal/swarm/coordinator.go`, `lifecycle.go`).
2. **`swarm_collect`** emits a `task_id → session_id` map in its `Result.Meta` (`internal/swarm/tools.go`).
3. **TUI** forwards that map via a new `swarmSessionsMsg` into `m.swarmSessionMap` — mirroring the Task tool's `session_id` reconciliation pattern (`internal/tui/model.go`).
4. **`swarmAgent`** carries the session id (`internal/tui/sidebar.go`).
5. The AGENTS sidebar records a **clickable hit** per member whose session is known (`sidebarAgentRows` / `sidebarAgentSelectables`).
6. **`sidebarLineAtMouse`** maps a left-click in the sidebar column to the member row and reuses `subchat.enter` verbatim (`internal/tui/mouse.go`, `transcript_selection.go`).

Geometry: `twoColumnTranscriptView` is the full screen and `joinColumns` zips chat + sidebar row-by-row, so a sidebar line's screen Y equals its line index and the sidebar starts at screen X = `chatColumnWidth() + 3` (the ` │ ` divider).

## Graceful by design

A member is clickable **only once its session id is known** (after `swarm_collect`), so in-flight members simply aren't clickable — no dead clicks, no "could not load session". Reuses the subchat machinery, `Result.Meta` transport, and the specialist click handler end-to-end; **no new persistence or agent-loop changes**.

## Tests

- swarm: `CompleteWithSession` records the id; `swarm_collect` Meta carries member session ids.
- tui: member rows carry the session id; `sidebarAgentSelectables` map to the right screen rows; `sidebarLineAtMouse` hit-tests correctly (incl. chat-column miss, header miss, unmapped-member miss); a member click routes to the subchat drill-in; `swarmSessionsMsg` merges the map.
- Full `./internal/swarm/...`, `./internal/tui/...`, `./internal/specialist/...` suites green; `go vet` clean.
- A 3-dimension adversarial review (geometry / concurrency / edge-cases, each finding independently refuted) returned **zero confirmed findings**.

## Stacking

Stacks on **#309** (sidebar roster) and **#310** (blocking `swarm_collect`, which carries the session-id Meta) — they touch disjoint files and are merged into this branch. Merge order: **#309 → #310 → this**. Once those land on main, this rebases to just the feature diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for waiting on swarm task completion without polling, making collect flows more responsive.
  * Added durable session tracking so completed member sessions can be surfaced later in the UI and output metadata.
  * Enabled clicking member rows in the AGENTS sidebar to jump directly into that member’s subchat.

* **Bug Fixes**
  * Improved sidebar visibility and click behavior so completed swarm members remain accessible.
  * Prevented repeated status cards from flooding the transcript during refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->