### PR TITLE
Fix shared temp roots in sandbox scope

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2075,7 +2075,7 @@ func TestRunEmitsPermissionEventForPersistentSandboxGrant(t *testing.T) {
 
 func TestRunPromptsAndAllowsOutsideWorkspaceWrite(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := filepath.Join(tempDirOutsideDefaultTemp(t), "escape.txt")
 	engine := sandbox.NewEngine(sandbox.EngineOptions{
 		WorkspaceRoot: root,
 		Policy:        sandbox.DefaultPolicy(),
@@ -2137,7 +2137,7 @@ func TestRunPromptsAndAllowsOutsideWorkspaceWrite(t *testing.T) {
 
 func TestRunSessionAllowsLaterOutsideWorkspaceWrite(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := filepath.Join(tempDirOutsideDefaultTemp(t), "escape.txt")
 	engine := sandbox.NewEngine(sandbox.EngineOptions{
 		WorkspaceRoot: root,
 		Policy:        sandbox.DefaultPolicy(),
@@ -2207,7 +2207,7 @@ func TestRunSessionAllowsLaterOutsideWorkspaceWrite(t *testing.T) {
 
 func TestRunAppliesSandboxEvenInUnsafeMode(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := filepath.Join(tempDirOutsideDefaultTemp(t), "escape.txt")
 	registry := tools.NewRegistry()
 	registry.Register(tools.NewWriteFileTool(root))
 	provider := providerCallingWritePathThenAnswer(outside, "sandbox handled")

--- a/internal/agent/request_permissions_test.go
+++ b/internal/agent/request_permissions_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRequestPermissionsTurnGrantAllowsLaterToolAndCleansUp(t *testing.T) {
 	workspace := t.TempDir()
-	outside := t.TempDir()
+	outside := tempDirOutsideDefaultTemp(t)
 	target := filepath.Join(outside, "vegetables.txt")
 	scope, err := sandbox.NewScope(workspace, nil)
 	if err != nil {
@@ -118,6 +118,23 @@ func TestRequestPermissionsTurnGrantAllowsLaterToolAndCleansUp(t *testing.T) {
 	if decision.Action != sandbox.ActionPrompt {
 		t.Fatalf("turn grant should be cleaned up after Run, got decision %#v", decision)
 	}
+}
+
+func tempDirOutsideDefaultTemp(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".zero-sandbox-outside-")
+	if err != nil {
+		t.Fatalf("MkdirTemp outside default temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", dir, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }
 
 func TestInlineAdditionalPermissionsGrantAllowsNetworkCommand(t *testing.T) {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -617,9 +617,6 @@ func TestRunAddDirWiresExtraWriteRootIntoTUISandboxScope(t *testing.T) {
 		t.Fatal("AgentOptions.Sandbox = nil, want sandbox engine")
 	}
 	roots := launchedOptions.AgentOptions.Sandbox.Scope().Roots()
-	if len(roots) != 2 {
-		t.Fatalf("scope roots = %v, want exactly workspace + extra", roots)
-	}
 	// The scope stores symlink-resolved roots (e.g. macOS /var -> /private/var),
 	// so compare against the resolved extra dir.
 	resolvedExtra, err := filepath.EvalSymlinks(extra)
@@ -679,10 +676,14 @@ func TestRunSkipPermissionsUnsafeMergesAddDirGrants(t *testing.T) {
 				t.Fatal("AgentOptions.Sandbox = nil, want sandbox engine")
 			}
 			roots := launchedOptions.AgentOptions.Sandbox.Scope().Roots()
-			if len(roots) != 2 {
-				t.Fatalf("scope roots = %v, want exactly workspace + extra", roots)
+			found := false
+			for _, root := range roots {
+				if root == resolvedExtra {
+					found = true
+					break
+				}
 			}
-			if roots[1] != resolvedExtra {
+			if !found {
 				t.Fatalf("scope roots = %v, want extra root %q", roots, resolvedExtra)
 			}
 		})

--- a/internal/cli/exec_scope_test.go
+++ b/internal/cli/exec_scope_test.go
@@ -44,7 +44,7 @@ func TestRunAddDirDispatchForwardsGrantIntoExecScope(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("XDG_DATA_HOME", t.TempDir())
 			cwd := t.TempDir()
-			extra := t.TempDir()
+			extra := tempDirOutsideDefaultTemp(t)
 			target := filepath.Join(extra, "granted.txt")
 
 			exitCode, stderr := runExecAddDirWriteProbe(t, cwd, tc.args(extra), target)
@@ -117,7 +117,7 @@ func runExecAddDirWriteProbe(t *testing.T, cwd string, args []string, target str
 // prove both the overwrite and the scoped enforcement it ships.
 func TestExecScopeReRegistrationSwapsCoreToolsByName(t *testing.T) {
 	root := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	inside := filepath.Join(extra, "inside.txt")
 
 	registry := newCoreRegistry(root)
@@ -160,7 +160,7 @@ func TestExecScopeReRegistrationSwapsCoreToolsByName(t *testing.T) {
 	}
 
 	// A path outside every scope root must still be denied after re-registration.
-	outside := filepath.Join(t.TempDir(), "outside.txt")
+	outside := filepath.Join(tempDirOutsideDefaultTemp(t), "outside.txt")
 	deniedOutside := registry.RunWithOptions(context.Background(), "write_file", map[string]any{
 		"path":    outside,
 		"content": "never",
@@ -174,4 +174,21 @@ func TestExecScopeReRegistrationSwapsCoreToolsByName(t *testing.T) {
 	if _, err := os.Stat(outside); !os.IsNotExist(err) {
 		t.Fatalf("expected outside file to remain absent, stat err=%v", err)
 	}
+}
+
+func tempDirOutsideDefaultTemp(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".zero-sandbox-outside-")
+	if err != nil {
+		t.Fatalf("MkdirTemp outside default temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", dir, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }

--- a/internal/cli/sandbox_check_test.go
+++ b/internal/cli/sandbox_check_test.go
@@ -31,8 +31,8 @@ func TestRunSandboxCheckJSONDeniesOutOfWorkspaceWrite(t *testing.T) {
 	deps, _ := sandboxCheckDeps(t)
 	// An absolute path outside the workspace, portable across OSes: a Unix literal
 	// like /etc/passwd is not absolute on Windows (it would be joined into the
-	// workspace and allowed), so build one under a separate temp dir instead.
-	outside := filepath.Join(t.TempDir(), "outside.txt")
+	// workspace and allowed), so build one under a non-temp test dir instead.
+	outside := filepath.Join(tempDirOutsideDefaultTemp(t), "outside.txt")
 	var stdout, stderr bytes.Buffer
 	exitCode := runWithDeps([]string{"sandbox", "check", "write_file", "--side-effect", "write", "--path", outside, "--json"}, &stdout, &stderr, deps)
 	if exitCode != exitSuccess {

--- a/internal/cli/sandbox_test.go
+++ b/internal/cli/sandbox_test.go
@@ -510,13 +510,92 @@ func TestRunSandboxPolicyJSONGoldenIncludesManagerBaselineFields(t *testing.T) {
 	got := stdout.String()
 	got = replacePathToken(got, workspace, "$WORKSPACE")
 	got = replacePathToken(got, store.FilePath(), "$GRANTS")
+	gotBytes := normalizeSandboxPolicyGoldenTempRoots(t, []byte(got), workspace)
 	wantBytes, err := os.ReadFile(filepath.Join("testdata", "sandbox_policy_windows_unavailable.golden.json"))
 	if err != nil {
 		t.Fatalf("read golden: %v", err)
 	}
-	if !jsonValuesEqual(t, wantBytes, []byte(got)) {
-		t.Fatalf("policy JSON golden mismatch\nwant:\n%s\ngot:\n%s", string(wantBytes), got)
+	if !jsonValuesEqual(t, wantBytes, gotBytes) {
+		t.Fatalf("policy JSON golden mismatch\nwant:\n%s\ngot:\n%s", string(wantBytes), string(gotBytes))
 	}
+}
+
+func normalizeSandboxPolicyGoldenTempRoots(t *testing.T, gotBytes []byte, workspace string) []byte {
+	t.Helper()
+	scope, err := sandbox.NewScope(workspace, nil)
+	if err != nil {
+		t.Fatalf("NewScope(%q): %v", workspace, err)
+	}
+	roots := scope.Roots()
+	if len(roots) <= 1 {
+		return gotBytes
+	}
+	tempRoots := map[string]struct{}{}
+	for _, root := range roots[1:] {
+		tempRoots[root] = struct{}{}
+	}
+	var value any
+	if err := json.Unmarshal(gotBytes, &value); err != nil {
+		t.Fatalf("decode got JSON for normalization: %v\n%s", err, string(gotBytes))
+	}
+	plan, _ := value.(map[string]any)["plan"].(map[string]any)
+	profile, _ := plan["permissionProfile"].(map[string]any)
+	fileSystem, _ := profile["fileSystem"].(map[string]any)
+	fileSystem["readRoots"] = filterJSONStringRoots(fileSystem["readRoots"], tempRoots)
+	fileSystem["writeRoots"] = filterJSONWriteRoots(fileSystem["writeRoots"], tempRoots)
+	normalized, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("encode normalized policy JSON: %v", err)
+	}
+	return append(normalized, '\n')
+}
+
+func filterJSONStringRoots(value any, excluded map[string]struct{}) any {
+	roots, ok := value.([]any)
+	if !ok {
+		return value
+	}
+	out := make([]any, 0, len(roots))
+	for _, root := range roots {
+		text, ok := root.(string)
+		if !ok {
+			out = append(out, root)
+			continue
+		}
+		if _, skip := excluded[text]; !skip {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+func filterJSONWriteRoots(value any, excluded map[string]struct{}) any {
+	roots, ok := value.([]any)
+	if !ok {
+		return value
+	}
+	out := make([]any, 0, len(roots))
+	for _, root := range roots {
+		entry, ok := root.(map[string]any)
+		if !ok {
+			out = append(out, root)
+			continue
+		}
+		text, _ := entry["root"].(string)
+		if _, skip := excluded[text]; !skip {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func jsonValuesEqual(t *testing.T, wantBytes []byte, gotBytes []byte) bool {
@@ -675,7 +754,7 @@ func TestEffectiveSandboxPolicyShowsWriteRootsError(t *testing.T) {
 
 func TestRunSandboxPolicyEffectiveListsConfiguredWriteRoots(t *testing.T) {
 	store := newSandboxTestStore(t)
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	resolvedExtra, err := filepath.EvalSymlinks(extra)
 	if err != nil {
 		t.Fatalf("EvalSymlinks(%q) returned error: %v", extra, err)
@@ -714,11 +793,11 @@ func TestRunSandboxPolicyEffectiveListsConfiguredWriteRoots(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("decode effective JSON: %v\n%s", err, stdout.String())
 	}
-	if len(payload.WriteRoots) != 2 {
-		t.Fatalf("writeRoots = %#v, want workspace root + extra root", payload.WriteRoots)
+	if len(payload.WriteRoots) < 2 {
+		t.Fatalf("writeRoots = %#v, want workspace root, extra root, and default temp roots", payload.WriteRoots)
 	}
-	if payload.WriteRoots[1] != resolvedExtra {
-		t.Fatalf("writeRoots[1] = %q, want %q", payload.WriteRoots[1], resolvedExtra)
+	if !containsString(payload.WriteRoots, resolvedExtra) {
+		t.Fatalf("writeRoots = %#v, want configured extra root %q", payload.WriteRoots, resolvedExtra)
 	}
 	if strings.Contains(stdout.String(), "writeRootsError") {
 		t.Fatalf("unexpected writeRootsError key for valid roots:\n%s", stdout.String())
@@ -766,8 +845,11 @@ func TestRunSandboxPolicyEffectiveWriteRootsFailSoft(t *testing.T) {
 	if !strings.Contains(payload.WriteRootsError, missing) {
 		t.Fatalf("writeRootsError = %q, want it to name the stale root %q", payload.WriteRootsError, missing)
 	}
-	if len(payload.WriteRoots) != 1 {
-		t.Fatalf("writeRoots = %#v, want workspace-only fallback", payload.WriteRoots)
+	if len(payload.WriteRoots) == 0 {
+		t.Fatalf("writeRoots = %#v, want workspace/default-temp fallback", payload.WriteRoots)
+	}
+	if containsString(payload.WriteRoots, missing) {
+		t.Fatalf("writeRoots = %#v, must not include stale root %q", payload.WriteRoots, missing)
 	}
 }
 

--- a/internal/sandbox/engine.go
+++ b/internal/sandbox/engine.go
@@ -46,7 +46,7 @@ func NewEngine(options EngineOptions) *Engine {
 		}
 	}
 	if scope == nil && workspaceRoot != "" {
-		scope = &Scope{workspaceRoot: normalizeWorkspaceRootBestEffort(workspaceRoot)}
+		scope = newScopeBestEffort(workspaceRoot)
 	}
 	return &Engine{
 		workspaceRoot:   workspaceRoot,
@@ -203,7 +203,15 @@ func (engine *Engine) scopeFor(requestRoot string) *Scope {
 	if engine.scope != nil && requestRoot == engine.workspaceRoot {
 		return engine.scope
 	}
-	return &Scope{workspaceRoot: requestRoot}
+	return newScopeBestEffort(requestRoot)
+}
+
+func newScopeBestEffort(workspaceRoot string) *Scope {
+	scope, err := NewScope(workspaceRoot, nil)
+	if err == nil {
+		return scope
+	}
+	return &Scope{workspaceRoot: normalizeWorkspaceRootBestEffort(workspaceRoot)}
 }
 
 // shellSandboxActive reports whether a native wrapping sandbox would actually

--- a/internal/sandbox/engine_test.go
+++ b/internal/sandbox/engine_test.go
@@ -239,7 +239,7 @@ func TestEngineAutoAllowsWorkspaceFileMutationTools(t *testing.T) {
 		SideEffect:     SideEffectWrite,
 		Permission:     PermissionPrompt,
 		PermissionMode: PermissionModeAsk,
-		Args:           map[string]any{"path": filepath.Join(t.TempDir(), "escape.txt")},
+		Args:           map[string]any{"path": outsideDefaultTempPath(root, "escape.txt")},
 	})
 	if outside.Action != ActionPrompt || outside.Block == nil || outside.Block.Code != BlockOutsideWorkspace || !outside.Block.Recoverable {
 		t.Fatalf("outside workspace mutation decision = %#v, want recoverable prompt", outside)
@@ -325,7 +325,7 @@ func TestEngineSessionGrantDoesNotMatchSiblingFile(t *testing.T) {
 
 func TestEnginePersistentGrantAllowsPromptableOutsideWorkspacePath(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := outsideDefaultTempPath(root, "escape.txt")
 	store, err := NewGrantStore(StoreOptions{
 		FilePath: filepath.Join(t.TempDir(), "sandbox-grants.json"),
 		Now:      fixedSandboxTime("2026-06-05T14:00:00Z"),
@@ -362,7 +362,7 @@ func TestEnginePersistentGrantAllowsPromptableOutsideWorkspacePath(t *testing.T)
 
 func TestEnginePersistentGrantDoesNotBypassSymlinkTraversal(t *testing.T) {
 	root := t.TempDir()
-	outside := t.TempDir()
+	outside := outsideDefaultTempPath(root, "symlink-target")
 	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
 		t.Skipf("symlink unavailable: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestEnginePersistentGrantDoesNotBypassSymlinkTraversal(t *testing.T) {
 
 func TestEngineDeniesAutoAllowedSymlinkEscape(t *testing.T) {
 	root := t.TempDir()
-	outside := t.TempDir()
+	outside := outsideDefaultTempPath(root, "symlink-target")
 	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
 		t.Skipf("symlink unavailable: %v", err)
 	}
@@ -460,7 +460,7 @@ func TestEngineGrantScopesWebFetchToHost(t *testing.T) {
 
 func TestEngineDeniesOutOfWorkspacePaths(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := outsideDefaultTempPath(root, "escape.txt")
 	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
 
 	decision := engine.Evaluate(context.Background(), Request{
@@ -484,7 +484,7 @@ func TestEngineDeniesOutOfWorkspacePaths(t *testing.T) {
 
 func TestEnginePrecheckReportsBlocksBeforeExecution(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := outsideDefaultTempPath(root, "escape.txt")
 	engine := NewEngine(EngineOptions{WorkspaceRoot: root, Policy: DefaultPolicy()})
 
 	// A denied request reports its block without running anything.
@@ -519,7 +519,7 @@ func TestEnginePrecheckReportsBlocksBeforeExecution(t *testing.T) {
 
 func TestEngineDeniesWorkspaceSymlinkTraversal(t *testing.T) {
 	root := t.TempDir()
-	outside := t.TempDir()
+	outside := outsideDefaultTempPath(root, "symlink-target")
 	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
 		t.Skipf("symlink unavailable: %v", err)
 	}
@@ -642,7 +642,7 @@ func TestEngineReportsContextCancellation(t *testing.T) {
 
 func TestEvaluateOverrideRootDoesNotInheritEngineScope(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -702,7 +702,7 @@ func promptWorkspaceWritePolicy() Policy {
 
 func TestEvaluateAllowsWritesInsideExtraScopeRoot(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -730,7 +730,7 @@ func TestEvaluateAllowsWritesInsideExtraScopeRoot(t *testing.T) {
 		ToolName:   "write_file",
 		SideEffect: SideEffectWrite,
 		Permission: PermissionAllow,
-		Args:       map[string]any{"path": filepath.Join(t.TempDir(), "escape.txt")},
+		Args:       map[string]any{"path": outsideDefaultTempPath(workspace, "escape.txt")},
 	})
 	if outside.Action != ActionPrompt || outside.Block == nil || !outside.Block.Recoverable {
 		t.Fatalf("outside write Action=%q, want recoverable prompt with block", outside.Action)
@@ -747,7 +747,7 @@ func TestEvaluateAllowsWritesInsideExtraScopeRoot(t *testing.T) {
 // skip, turning the engine into an escape hatch.
 func TestNewEngineDerivesWorkspaceRootFromScope(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -764,7 +764,7 @@ func TestNewEngineDerivesWorkspaceRootFromScope(t *testing.T) {
 		ToolName:   "write_file",
 		SideEffect: SideEffectWrite,
 		Permission: PermissionAllow,
-		Args:       map[string]any{"path": filepath.Join(t.TempDir(), "escape.txt")},
+		Args:       map[string]any{"path": outsideDefaultTempPath(workspace, "escape.txt")},
 	})
 	if outside.Action != ActionPrompt || outside.Block == nil {
 		t.Fatalf("scope-only engine, out-of-scope write Action=%q, want prompt with block", outside.Action)
@@ -779,5 +779,33 @@ func TestNewEngineDerivesWorkspaceRootFromScope(t *testing.T) {
 	})
 	if inside.Action != ActionAllow {
 		t.Fatalf("scope-only engine, in-workspace write Action=%q (%s), want allow", inside.Action, inside.Reason)
+	}
+}
+
+func TestEvaluateAllowsWritesInsideDefaultTempRoot(t *testing.T) {
+	workspace := t.TempDir()
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+	scope, err := NewScope(workspace, nil)
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	engine := NewEngine(EngineOptions{
+		WorkspaceRoot: workspace,
+		Policy:        DefaultPolicy(),
+		Scope:         scope,
+	})
+
+	decision := engine.Evaluate(context.Background(), Request{
+		ToolName:   "write_file",
+		SideEffect: SideEffectWrite,
+		Permission: PermissionAllow,
+		Args:       map[string]any{"path": filepath.Join(tempRoot, "zero-toolcheck", "go.mod")},
+	})
+	if decision.Action != ActionAllow {
+		t.Fatalf("temp-root write Action=%q (%s), want allow", decision.Action, decision.Reason)
+	}
+	if HasRiskCategory(decision.Risk, "out_of_workspace") {
+		t.Fatalf("temp-root write risk=%v, must not be out_of_workspace", decision.Risk)
 	}
 }

--- a/internal/sandbox/linux_helper.go
+++ b/internal/sandbox/linux_helper.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -219,9 +220,9 @@ func linuxBwrapFilesystemArgs(profile PermissionProfile) []string {
 		}
 	}
 	if fs.AllowTemp {
-		args = append(args, "--tmpfs", "/tmp")
+		fs.WriteRoots = linuxWriteRootsWithTemp(fs)
 	}
-	for _, root := range fs.WriteRoots {
+	for _, root := range linuxSortedWriteRoots(fs.WriteRoots) {
 		if !pathExists(root.Root) {
 			continue
 		}
@@ -240,6 +241,43 @@ func linuxBwrapFilesystemArgs(profile PermissionProfile) []string {
 		args = appendUnreadableLinuxPathArgs(args, path)
 	}
 	return args
+}
+
+func linuxWriteRootsWithTemp(fs FileSystemPolicy) []WritableRoot {
+	roots := append([]WritableRoot{}, fs.WriteRoots...)
+	for _, tempRoot := range defaultTempWriteRoots() {
+		found := false
+		for _, root := range roots {
+			if filepath.Clean(root.Root) == filepath.Clean(tempRoot) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			roots = append(roots, WritableRoot{Root: tempRoot})
+		}
+	}
+	return roots
+}
+
+func linuxSortedWriteRoots(roots []WritableRoot) []WritableRoot {
+	sorted := append([]WritableRoot{}, roots...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return pathDepth(sorted[i].Root) < pathDepth(sorted[j].Root)
+	})
+	return sorted
+}
+
+func pathDepth(path string) int {
+	cleaned := filepath.Clean(path)
+	if cleaned == "" || filepath.Dir(cleaned) == cleaned {
+		return 0
+	}
+	trimmed := strings.Trim(cleaned, string(filepath.Separator))
+	if trimmed == "" {
+		return 0
+	}
+	return strings.Count(trimmed, string(filepath.Separator)) + 1
 }
 
 func linuxProfileHasFullReadRoot(fs FileSystemPolicy) bool {

--- a/internal/sandbox/linux_helper_test.go
+++ b/internal/sandbox/linux_helper_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -130,6 +131,9 @@ func TestBuildLinuxSandboxBwrapArgsWrapsInnerSeccompStage(t *testing.T) {
 	if argsContainSequence(bwrapArgs, "--tmpfs", "/") {
 		t.Fatalf("default workspace-write profile must not start from an empty root: %#v", bwrapArgs)
 	}
+	if argsContainSequence(bwrapArgs, "--tmpfs", "/tmp") {
+		t.Fatalf("default workspace-write profile must not replace host /tmp: %#v", bwrapArgs)
+	}
 	if stringSliceContains(bwrapArgs, "--clearenv") {
 		t.Fatalf("Linux bwrap args must preserve caller environment like upstream: %#v", bwrapArgs)
 	}
@@ -192,6 +196,46 @@ func TestLinuxBwrapRootReadUsesReadOnlyHostRoot(t *testing.T) {
 	}
 }
 
+func TestLinuxBwrapTempUsesHostWriteRoots(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Linux bwrap temp root assertions use Unix paths")
+	}
+	tmpdir := t.TempDir()
+	t.Setenv("TMPDIR", tmpdir)
+	workspace := filepath.Join(tmpdir, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll workspace: %v", err)
+	}
+	profile := PermissionProfile{
+		FileSystem: FileSystemPolicy{
+			Kind:       FileSystemRestricted,
+			ReadRoots:  []string{string(filepath.Separator)},
+			WriteRoots: []WritableRoot{{Root: workspace, ProtectedMetadataNames: []string{".git"}}},
+			AllowTemp:  true,
+		},
+		Network: NetworkPolicy{Mode: NetworkAllow},
+	}
+
+	args := linuxBwrapFilesystemArgs(profile)
+	if argsContainSequence(args, "--tmpfs", "/tmp") {
+		t.Fatalf("workspace-write temp access must bind host /tmp, not create private tmpfs: %#v", args)
+	}
+	for _, tempRoot := range defaultTempWriteRoots() {
+		if pathExists(tempRoot) {
+			assertArgsContainSequence(t, args, "--bind", tempRoot, tempRoot)
+		}
+	}
+	assertArgsContainSequence(t, args, "--bind", workspace, workspace)
+
+	if runtime.GOOS == "linux" {
+		tmpdirBind := argsSequenceIndex(args, "--bind", tmpdir, tmpdir)
+		workspaceBind := argsSequenceIndex(args, "--bind", workspace, workspace)
+		if tmpdirBind < 0 || workspaceBind < 0 || tmpdirBind > workspaceBind {
+			t.Fatalf("broader temp root must be bound before nested workspace root; args=%#v", args)
+		}
+	}
+}
+
 func TestLinuxBwrapUnrestrictedFilesystemUsesWritableHostRoot(t *testing.T) {
 	profile := PermissionProfile{
 		FileSystem: FileSystemPolicy{
@@ -251,8 +295,12 @@ func indexString(values []string, want string) int {
 }
 
 func argsContainSequence(args []string, sequence ...string) bool {
+	return argsSequenceIndex(args, sequence...) >= 0
+}
+
+func argsSequenceIndex(args []string, sequence ...string) int {
 	if len(sequence) == 0 {
-		return true
+		return 0
 	}
 	for index := 0; index <= len(args)-len(sequence); index++ {
 		matched := true
@@ -263,8 +311,8 @@ func argsContainSequence(args []string, sequence ...string) bool {
 			}
 		}
 		if matched {
-			return true
+			return index
 		}
 	}
-	return false
+	return -1
 }

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -28,11 +29,14 @@ func TestPermissionProfileFromPolicyBuildsWorkspaceWriteProfile(t *testing.T) {
 	if profile.FileSystem.Kind != FileSystemRestricted {
 		t.Fatalf("filesystem kind = %q, want restricted", profile.FileSystem.Kind)
 	}
-	if len(profile.FileSystem.WriteRoots) != 2 {
-		t.Fatalf("write roots = %#v, want workspace + extra", profile.FileSystem.WriteRoots)
+	roots := scope.Roots()
+	if len(profile.FileSystem.WriteRoots) != len(roots) {
+		t.Fatalf("write roots = %#v, want scope roots %#v", profile.FileSystem.WriteRoots, roots)
 	}
-	if profile.FileSystem.WriteRoots[0].Root != scope.Roots()[0] || profile.FileSystem.WriteRoots[1].Root != scope.Roots()[1] {
-		t.Fatalf("write roots = %#v, want scope roots %#v", profile.FileSystem.WriteRoots, scope.Roots())
+	for i, root := range roots {
+		if profile.FileSystem.WriteRoots[i].Root != root {
+			t.Fatalf("write roots = %#v, want scope roots %#v", profile.FileSystem.WriteRoots, roots)
+		}
 	}
 	if !stringSliceContains(profile.FileSystem.ReadRoots, profileRootPath()) {
 		t.Fatalf("read roots = %#v, want full read root %q", profile.FileSystem.ReadRoots, profileRootPath())
@@ -49,6 +53,38 @@ func TestPermissionProfileFromPolicyBuildsWorkspaceWriteProfile(t *testing.T) {
 	if !profile.RequiresPlatformSandbox() {
 		t.Fatal("workspace-write profile must require a platform sandbox")
 	}
+}
+
+func TestPermissionProfileFromPolicyIncludesDefaultTempWriteRoots(t *testing.T) {
+	tmpdir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("TEMP", tmpdir)
+		t.Setenv("TMP", tmpdir)
+	} else {
+		t.Setenv("TMPDIR", tmpdir)
+	}
+	workspace := t.TempDir()
+
+	profile := PermissionProfileFromPolicy(workspace, DefaultPolicy(), nil)
+	if !writeRootsContain(profile.FileSystem.WriteRoots, workspace) {
+		t.Fatalf("write roots = %#v, want workspace %q", profile.FileSystem.WriteRoots, workspace)
+	}
+	if !writeRootsContain(profile.FileSystem.WriteRoots, tmpdir) {
+		t.Fatalf("write roots = %#v, want temp root %q", profile.FileSystem.WriteRoots, tmpdir)
+	}
+	if pathExists("/tmp") && !writeRootsContain(profile.FileSystem.WriteRoots, "/tmp") {
+		t.Fatalf("write roots = %#v, want /tmp", profile.FileSystem.WriteRoots)
+	}
+}
+
+func writeRootsContain(roots []WritableRoot, want string) bool {
+	want = normalizeProfilePath(want)
+	for _, root := range roots {
+		if normalizeProfilePath(root.Root) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestUnknownNetworkModeFailsClosed(t *testing.T) {

--- a/internal/sandbox/pathlists_test.go
+++ b/internal/sandbox/pathlists_test.go
@@ -84,10 +84,10 @@ func TestWritePrecedenceMatrix(t *testing.T) {
 	ws := resolvedTempDir(t)
 	mkdir(t, filepath.Join(ws, "src"))
 	wsSecret := mkdir(t, filepath.Join(ws, "secret"))
-	ext := resolvedTempDir(t)
+	ext := tempDirOutsideDefaultTemp(t)
 	mkdir(t, filepath.Join(ext, "build"))
 	extProtected := mkdir(t, filepath.Join(ext, "build", "protected"))
-	outside := resolvedTempDir(t) // never allowed
+	outside := outsideDefaultTempPath(ws, "outside")
 
 	scope, err := NewScope(ws, nil)
 	if err != nil {
@@ -348,7 +348,7 @@ func TestEvaluateAppliesReadDeny(t *testing.T) {
 // but permitted once the path is on AllowWrite.
 func TestEvaluateAppliesWriteAllow(t *testing.T) {
 	ws := resolvedTempDir(t)
-	ext := resolvedTempDir(t)
+	ext := tempDirOutsideDefaultTemp(t)
 	build := mkdir(t, filepath.Join(ext, "build"))
 
 	base := Policy{Mode: ModeEnforce, EnforceWorkspace: true}
@@ -381,7 +381,7 @@ func TestEvaluateAppliesWriteAllow(t *testing.T) {
 // backend write binds (so a sandboxed shell can write there).
 func TestWriteRootsReflectAllowWrite(t *testing.T) {
 	ws := resolvedTempDir(t)
-	ext := resolvedTempDir(t)
+	ext := tempDirOutsideDefaultTemp(t)
 	build := mkdir(t, filepath.Join(ext, "build"))
 
 	engine := NewEngine(EngineOptions{

--- a/internal/sandbox/profile.go
+++ b/internal/sandbox/profile.go
@@ -93,10 +93,12 @@ func permissionProfileRoots(workspaceRoot string, scope *Scope) []string {
 	if scope != nil {
 		return scope.Roots()
 	}
+	var roots []string
 	if root := normalizeProfilePath(workspaceRoot); root != "" {
-		return []string{root}
+		roots = append(roots, root)
 	}
-	return nil
+	roots = append(roots, defaultTempWriteRoots()...)
+	return dedupeStrings(roots)
 }
 
 func permissionProfileReadRoots(workspaceRoot string, policy Policy, scope *Scope, writeRoots []string) []string {

--- a/internal/sandbox/request_permissions_test.go
+++ b/internal/sandbox/request_permissions_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGrantRequestPermissionsReadDoesNotGrantWrite(t *testing.T) {
 	workspace := t.TempDir()
-	outside := t.TempDir()
+	outside := tempDirOutsideDefaultTemp(t)
 	target := filepath.Join(outside, "notes.txt")
 	scope, err := NewScope(workspace, nil)
 	if err != nil {
@@ -116,7 +116,7 @@ func TestGrantRequestPermissionsNetworkOverlaysPolicyForTurn(t *testing.T) {
 
 func TestGrantRequestPermissionsSessionPersists(t *testing.T) {
 	workspace := t.TempDir()
-	outside := t.TempDir()
+	outside := tempDirOutsideDefaultTemp(t)
 	target := filepath.Join(outside, "notes.txt")
 	engine := NewEngine(EngineOptions{WorkspaceRoot: workspace, Policy: DefaultPolicy()})
 
@@ -142,7 +142,7 @@ func TestGrantRequestPermissionsSessionPersists(t *testing.T) {
 
 func TestPermissionProfileIncludesReadOnlyGrantAsReadRootOnly(t *testing.T) {
 	workspace := t.TempDir()
-	outside := t.TempDir()
+	outside := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, nil)
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)

--- a/internal/sandbox/runner.go
+++ b/internal/sandbox/runner.go
@@ -486,7 +486,8 @@ var sandboxWritableDevices = []string{
 }
 
 // sandboxWritableSubpaths are non-workspace trees the sandbox-exec profile must
-// keep writable for parity with the bubblewrap backend's writable /tmp tmpfs.
+// keep writable for parity with the shared host temp roots used by the Linux
+// bubblewrap backend.
 // macOS resolves /tmp and /var to their /private counterparts before the sandbox
 // check, so both forms are listed. /dev/fd covers process-substitution writes.
 var sandboxWritableSubpaths = []string{

--- a/internal/sandbox/runner_test.go
+++ b/internal/sandbox/runner_test.go
@@ -120,13 +120,14 @@ func TestBuildCommandPlanRejectsUnavailableFallback(t *testing.T) {
 }
 
 func TestBuildCommandPlanRejectsOutsideDirectory(t *testing.T) {
+	root := t.TempDir()
 	engine := NewEngine(EngineOptions{
-		WorkspaceRoot: t.TempDir(),
+		WorkspaceRoot: root,
 		Policy:        DefaultPolicy(),
 		Backend:       Backend{Name: BackendUnavailable},
 	})
 
-	_, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Dir: t.TempDir()})
+	_, err := engine.BuildCommandPlan(CommandSpec{Name: "/bin/sh", Dir: tempDirOutsideDefaultTemp(t)})
 	if err == nil || !strings.Contains(err.Error(), "outside_workspace") {
 		t.Fatalf("error = %v, want outside workspace block", err)
 	}
@@ -532,7 +533,7 @@ func TestSandboxExecProfileGrantsSignalAndMachLookup(t *testing.T) {
 
 func TestLinuxHelperPlanCarriesExtraWriteRoots(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -559,7 +560,7 @@ func TestLinuxHelperPlanCarriesExtraWriteRoots(t *testing.T) {
 
 func TestResolveCommandDirAllowsExtraRootCwd(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -568,14 +569,14 @@ func TestResolveCommandDirAllowsExtraRootCwd(t *testing.T) {
 	if _, _, err := engine.resolveCommandDir(extra, engine.policy); err != nil {
 		t.Fatalf("resolveCommandDir(extra root) = %v, want nil", err)
 	}
-	if _, _, err := engine.resolveCommandDir(t.TempDir(), engine.policy); err == nil {
+	if _, _, err := engine.resolveCommandDir(tempDirOutsideDefaultTemp(t), engine.policy); err == nil {
 		t.Fatal("resolveCommandDir(outside all roots) = nil error, want block")
 	}
 }
 
 func TestLinuxHelperPlanPreservesRealExtraRootCwd(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)

--- a/internal/sandbox/scope.go
+++ b/internal/sandbox/scope.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 )
@@ -29,6 +30,11 @@ func NewScope(workspaceRoot string, extras []string) (*Scope, error) {
 	for _, extra := range extras {
 		if _, err := scope.Add(extra); err != nil {
 			return nil, fmt.Errorf("write root %q: %w", extra, err)
+		}
+	}
+	if scope.workspaceRoot != "" {
+		for _, root := range defaultTempWriteRootCandidates() {
+			_, _ = scope.Add(root)
 		}
 	}
 	return scope, nil
@@ -373,6 +379,33 @@ func normalizeScopeRoot(path string) (string, error) {
 		return "", fmt.Errorf("refusing filesystem root %s as a write root", resolved)
 	}
 	return resolved, nil
+}
+
+func defaultTempWriteRootCandidates() []string {
+	return defaultTempWriteRootCandidatesForGOOS(runtime.GOOS, os.Getenv)
+}
+
+func defaultTempWriteRootCandidatesForGOOS(goos string, getenv func(string) string) []string {
+	var roots []string
+	if goos == "windows" {
+		for _, key := range []string{"TEMP", "TMP"} {
+			if root := strings.TrimSpace(getenv(key)); root != "" {
+				roots = append(roots, root)
+			}
+		}
+		return roots
+	}
+	if goos != "windows" {
+		roots = append(roots, "/tmp")
+	}
+	if tmpdir := strings.TrimSpace(getenv("TMPDIR")); tmpdir != "" {
+		roots = append(roots, tmpdir)
+	}
+	return roots
+}
+
+func defaultTempWriteRoots() []string {
+	return normalizeProfileDirs(defaultTempWriteRootCandidates())
 }
 
 func pathWithinRoot(root string, candidate string) bool {

--- a/internal/sandbox/scope_test.go
+++ b/internal/sandbox/scope_test.go
@@ -14,7 +14,7 @@ import (
 func TestScopeValidateMultiRootSymlinkTraversalPreferred(t *testing.T) {
 	workspace := t.TempDir()
 	extra := t.TempDir()
-	outside := t.TempDir()
+	outside := outsideDefaultTempPath(workspace, "symlink-target")
 	link := filepath.Join(extra, "link")
 	if err := os.Symlink(outside, link); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -46,7 +46,7 @@ func TestScopeValidateMultiRootSymlinkTraversalPreferred(t *testing.T) {
 // in-root symlink escaping outside is still caught as BlockSymlinkTraversal.
 func TestValidateResolvesAliasedPathPrefixes(t *testing.T) {
 	real := t.TempDir()
-	aliasParent := t.TempDir()
+	aliasParent := tempDirOutsideDefaultTemp(t)
 	alias := filepath.Join(aliasParent, "alias")
 	if err := os.Symlink(real, alias); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -58,7 +58,7 @@ func TestValidateResolvesAliasedPathPrefixes(t *testing.T) {
 	if block := scope.validate(filepath.Join(alias, "new.txt")); block != nil {
 		t.Fatalf("validate(alias-prefixed path) = %v, want nil", block)
 	}
-	outside := t.TempDir()
+	outside := outsideDefaultTempPath(real, "symlink-target")
 	link := filepath.Join(real, "link")
 	if err := os.Symlink(outside, link); err != nil {
 		t.Fatalf("Symlink: %v", err)
@@ -71,8 +71,8 @@ func TestValidateResolvesAliasedPathPrefixes(t *testing.T) {
 // TestScopeAddNormalizesSymlinkedRoot verifies that Add resolves symlinks so
 // the stored root is the real path.
 func TestScopeAddNormalizesSymlinkedRoot(t *testing.T) {
-	real := t.TempDir()
-	linkParent := t.TempDir()
+	real := tempDirOutsideDefaultTemp(t)
+	linkParent := tempDirOutsideDefaultTemp(t)
 	link := filepath.Join(linkParent, "link")
 	if err := os.Symlink(real, link); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -93,8 +93,8 @@ func TestScopeAddNormalizesSymlinkedRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EvalSymlinks(real): %v", err)
 	}
-	if roots[1] != resolvedReal {
-		t.Fatalf("Roots()[1]=%q want resolved path %q (no symlink component)", roots[1], resolvedReal)
+	if !stringSliceContains(roots, resolvedReal) {
+		t.Fatalf("Roots()=%v want resolved path %q (no symlink component)", roots, resolvedReal)
 	}
 }
 
@@ -122,11 +122,14 @@ func TestNewScopeNormalizesAndValidatesExtraRoots(t *testing.T) {
 		t.Fatalf("NewScope: %v", err)
 	}
 	roots := scope.Roots()
-	if len(roots) != 2 {
-		t.Fatalf("Roots()=%v want workspace + 1 extra", roots)
-	}
 	if roots[0] != scope.WorkspaceRoot() {
 		t.Fatalf("Roots()[0]=%q want workspace root %q", roots[0], scope.WorkspaceRoot())
+	}
+	if !stringSliceContains(roots, normalizeWorkspaceRootBestEffort(extra)) {
+		t.Fatalf("Roots()=%v want extra root %q", roots, normalizeWorkspaceRootBestEffort(extra))
+	}
+	if pathExists("/tmp") && !stringSliceContains(roots, normalizeWorkspaceRootBestEffort("/tmp")) {
+		t.Fatalf("Roots()=%v want default /tmp write root", roots)
 	}
 }
 
@@ -175,9 +178,70 @@ func TestScopeAddIsIdempotentAndRejectsContainedPaths(t *testing.T) {
 	if _, err := scope.Add(workspace); err != nil {
 		t.Fatalf("Add (workspace itself): %v", err)
 	}
-	if got := scope.Roots(); len(got) != 2 {
-		t.Fatalf("Roots()=%v want exactly workspace + %q (idempotent adds)", got, added)
+	if got := scope.Roots(); !stringSliceContains(got, normalizeWorkspaceRootBestEffort(workspace)) {
+		t.Fatalf("Roots()=%v want workspace root", got)
+	} else if !stringSliceContains(got, normalizeWorkspaceRootBestEffort(added)) && !rootsCoverPath(got, normalizeWorkspaceRootBestEffort(added)) {
+		t.Fatalf("Roots()=%v want %q or a broader root covering it", got, added)
 	}
+}
+
+func TestDefaultTempWriteRootCandidatesMatchPlatformEnvironment(t *testing.T) {
+	env := func(values map[string]string) func(string) string {
+		return func(key string) string {
+			return values[key]
+		}
+	}
+
+	windows := defaultTempWriteRootCandidatesForGOOS("windows", env(map[string]string{
+		"TEMP":   `C:\Users\me\AppData\Local\Temp`,
+		"TMP":    `D:\scratch`,
+		"TMPDIR": `/ignored`,
+	}))
+	if len(windows) != 2 || windows[0] != `C:\Users\me\AppData\Local\Temp` || windows[1] != `D:\scratch` {
+		t.Fatalf("windows temp roots = %#v, want TEMP and TMP", windows)
+	}
+
+	unix := defaultTempWriteRootCandidatesForGOOS("linux", env(map[string]string{
+		"TMPDIR": "/var/tmp/zero",
+		"TEMP":   "/ignored",
+		"TMP":    "/ignored",
+	}))
+	if len(unix) != 2 || unix[0] != "/tmp" || unix[1] != "/var/tmp/zero" {
+		t.Fatalf("unix temp roots = %#v, want /tmp and TMPDIR", unix)
+	}
+}
+
+func rootsCoverPath(roots []string, path string) bool {
+	for _, root := range roots {
+		if pathWithinRoot(root, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func outsideDefaultTempPath(workspaceRoot string, elems ...string) string {
+	volume := filepath.VolumeName(workspaceRoot)
+	root := volume + string(filepath.Separator)
+	parts := append([]string{root, "zero-sandbox-outside-test"}, elems...)
+	return filepath.Join(parts...)
+}
+
+func tempDirOutsideDefaultTemp(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".zero-sandbox-outside-")
+	if err != nil {
+		t.Fatalf("MkdirTemp outside default temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", dir, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }
 
 func TestScopeValidateAllowsAnyRootButRelativeOnlyWorkspace(t *testing.T) {
@@ -198,7 +262,7 @@ func TestScopeValidateAllowsAnyRootButRelativeOnlyWorkspace(t *testing.T) {
 		t.Fatalf("validate(relative path) = %v, want nil (resolves against workspace)", block)
 	}
 
-	outside := filepath.Join(t.TempDir(), "elsewhere.txt")
+	outside := outsideDefaultTempPath(workspace, "elsewhere.txt")
 	block := scope.validate(outside)
 	if block == nil {
 		t.Fatal("validate(outside all roots) = nil, want block")
@@ -213,7 +277,7 @@ func TestScopeValidateAllowsAnyRootButRelativeOnlyWorkspace(t *testing.T) {
 
 func TestScopeValidateKeepsSymlinkTraversalProtection(t *testing.T) {
 	workspace := t.TempDir()
-	outside := t.TempDir()
+	outside := outsideDefaultTempPath(workspace, "symlink-target")
 	link := filepath.Join(workspace, "link")
 	if err := os.Symlink(outside, link); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)

--- a/internal/sandbox/scope_windows_test.go
+++ b/internal/sandbox/scope_windows_test.go
@@ -34,7 +34,7 @@ func TestScopeValidateHandlesVolumePathsOnWindows(t *testing.T) {
 
 	// An absolute path outside all roots must still be denied (no fail-open
 	// from drive-path mangling).
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := outsideDefaultTempPath(workspace, "escape.txt")
 	block := scope.validate(outside)
 	if block == nil {
 		t.Fatal("validate(outside all roots) = nil, want block (fail-open regression)")

--- a/internal/sandbox/seatbelt_integration_darwin_test.go
+++ b/internal/sandbox/seatbelt_integration_darwin_test.go
@@ -32,7 +32,7 @@ func TestSeatbeltEnforcesExtraWriteRoots(t *testing.T) {
 	extra := t.TempDir()
 	// The "outside" target must live OUTSIDE the sandbox's baseline-writable temp
 	// trees: the profile now allows /tmp and /var/folders for parity with the
-	// bubblewrap backend (--tmpfs /tmp, --dev /dev). t.TempDir() lives under
+	// Linux backend's shared host temp roots. t.TempDir() lives under
 	// $TMPDIR (/var/folders on macOS), which is writable, so a write there would no
 	// longer be denied. Use a directory under $HOME to prove the kernel denies a
 	// write to an ungranted, non-temp location.

--- a/internal/tools/file_tools_test.go
+++ b/internal/tools/file_tools_test.go
@@ -284,7 +284,7 @@ func TestGrepReturnsCleanRelativePathsUnderSymlinkedRoot(t *testing.T) {
 
 func TestScopedToolsAllowExtraRootWrites(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := sandbox.NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -306,7 +306,7 @@ func TestScopedToolsAllowExtraRootWrites(t *testing.T) {
 
 func TestScopedToolsAllowReadOnlyRootsWithoutWrite(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := sandbox.NewScope(workspace, nil)
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -335,7 +335,7 @@ func TestScopedToolsAllowReadOnlyRootsWithoutWrite(t *testing.T) {
 
 func TestScopedToolsKeepRelativePathsInWorkspace(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := sandbox.NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -354,7 +354,7 @@ func TestScopedToolsKeepRelativePathsInWorkspace(t *testing.T) {
 
 func TestScopedGlobReturnsAbsoluteMatchesForExtraRoot(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := sandbox.NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -396,7 +396,7 @@ func TestScopedGlobReturnsAbsoluteMatchesForExtraRoot(t *testing.T) {
 
 func TestScopedGrepReturnsAbsoluteMatchesForExtraRoot(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := sandbox.NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)
@@ -469,7 +469,7 @@ func TestUnscopedWriteRefusesInRootSymlinkTraversal(t *testing.T) {
 
 func TestScopedWriteThroughSymlinkIntoGrantedRoot(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	link := filepath.Join(workspace, "into-extra")
 	if err := os.Symlink(extra, link); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
@@ -489,7 +489,7 @@ func TestScopedWriteThroughSymlinkIntoGrantedRoot(t *testing.T) {
 	}
 	// A symlink escaping a granted root to ungated territory stays denied.
 	escape := filepath.Join(extra, "out")
-	if err := os.Symlink(t.TempDir(), escape); err != nil {
+	if err := os.Symlink(filepath.Join(tempDirOutsideDefaultTemp(t), "target"), escape); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 	res = NewScopedWriteFileTool(workspace, scope).Run(context.Background(), map[string]any{
@@ -561,7 +561,7 @@ func TestGrepSkipsAlwaysExcludedDirectories(t *testing.T) {
 
 func TestScopedWriteRefusesSameRootSymlinkTraversal(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	if err := os.MkdirAll(filepath.Join(extra, "subdir"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -587,7 +587,7 @@ func TestScopedWriteRefusesSameRootSymlinkTraversal(t *testing.T) {
 
 func TestScopedWriteReportsAbsolutePathForExtraRoot(t *testing.T) {
 	workspace := t.TempDir()
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
 	scope, err := sandbox.NewScope(workspace, []string{extra})
 	if err != nil {
 		t.Fatalf("NewScope: %v", err)

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/Gitlawb/zero/internal/sandbox"
 )
 
+func tempDirOutsideDefaultTemp(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".zero-sandbox-outside-")
+	if err != nil {
+		t.Fatalf("MkdirTemp outside default temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", dir, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
+}
+
 func TestCoreReadOnlyToolsExposeSafeMetadata(t *testing.T) {
 	toolset := CoreReadOnlyTools(t.TempDir())
 	if len(toolset) != 9 {
@@ -192,7 +209,7 @@ func TestRegistryReportsUnknownTools(t *testing.T) {
 
 func TestRegistryAppliesSandboxBeforeToolExecution(t *testing.T) {
 	root := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "escape.txt")
+	outside := filepath.Join(tempDirOutsideDefaultTemp(t), "escape.txt")
 	registry := NewRegistry()
 	registry.Register(NewWriteFileTool(root))
 	engine := sandbox.NewEngine(sandbox.EngineOptions{
@@ -225,7 +242,7 @@ func TestRegistryAppliesSandboxBeforeToolExecution(t *testing.T) {
 func TestRegistrySandboxGatesPathAliasKeys(t *testing.T) {
 	for _, key := range []string{"file_path", "filename", "filepath"} {
 		root := t.TempDir()
-		outside := filepath.Join(t.TempDir(), "escape.txt")
+		outside := filepath.Join(tempDirOutsideDefaultTemp(t), "escape.txt")
 		registry := NewRegistry()
 		registry.Register(NewWriteFileTool(root))
 		engine := sandbox.NewEngine(sandbox.EngineOptions{WorkspaceRoot: root, Policy: sandbox.DefaultPolicy()})

--- a/internal/tools/workspace.go
+++ b/internal/tools/workspace.go
@@ -61,10 +61,10 @@ func resolveWorkspacePath(workspaceRoot string, requestedPath string) (string, s
 
 	relative, err := filepath.Rel(root, target)
 	if err != nil {
-		return "", "", err
+		return "", "", outsideWorkspaceError(requestedPath)
 	}
 	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
-		return "", "", fmt.Errorf("%s must stay inside the workspace", requestedPath)
+		return "", "", outsideWorkspaceError(requestedPath)
 	}
 	if relative == "." {
 		return target, ".", nil
@@ -126,10 +126,10 @@ func resolveWorkspaceTargetPath(workspaceRoot string, requestedPath string) (str
 
 	relative, err := filepath.Rel(root, resolved)
 	if err != nil {
-		return "", "", err
+		return "", "", outsideWorkspaceError(requestedPath)
 	}
 	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
-		return "", "", fmt.Errorf("%s must stay inside the workspace", requestedPath)
+		return "", "", outsideWorkspaceError(requestedPath)
 	}
 	if relative == "." {
 		return resolved, ".", nil
@@ -162,10 +162,10 @@ func recheckWorkspaceWriteTarget(workspaceRoot string, requestedPath string) err
 
 	relative, err := filepath.Rel(root, target)
 	if err != nil {
-		return err
+		return outsideWorkspaceError(requestedPath)
 	}
 	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
-		return fmt.Errorf("%s must stay inside the workspace", requestedPath)
+		return outsideWorkspaceError(requestedPath)
 	}
 	if relative == "." {
 		return nil
@@ -195,6 +195,10 @@ func recheckWorkspaceWriteTarget(workspaceRoot string, requestedPath string) err
 	}
 
 	return nil
+}
+
+func outsideWorkspaceError(requestedPath string) error {
+	return fmt.Errorf("%s must stay inside the workspace", requestedPath)
 }
 
 func shouldSkipDirectory(name string) bool {

--- a/internal/tui/add_dir_test.go
+++ b/internal/tui/add_dir_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -33,12 +34,13 @@ func newAddDirTestModel(t *testing.T) (model, *sandbox.Scope) {
 
 func TestHandleAddDirCommand(t *testing.T) {
 	m, scope := newAddDirTestModel(t)
-	extra := t.TempDir()
+	extra := tempDirOutsideDefaultTemp(t)
+	initialRootCount := len(scope.Roots())
 
 	// Granting a directory widens the shared scope and confirms inline.
 	next := m.handleAddDirCommand(extra)
-	if roots := scope.Roots(); len(roots) != 2 {
-		t.Fatalf("expected 2 write roots after grant, got %#v", roots)
+	if roots := scope.Roots(); len(roots) != initialRootCount+1 {
+		t.Fatalf("expected one additional write root after grant, got %#v", roots)
 	}
 	notice := lastTranscriptText(next)
 	if !strings.Contains(notice, "write access added") || !strings.Contains(notice, "session only") {
@@ -56,4 +58,21 @@ func TestHandleAddDirCommand(t *testing.T) {
 	if notice := lastTranscriptText(bad); !strings.Contains(notice, "add-dir:") {
 		t.Fatalf("bad-path notice = %q, want an add-dir: error", notice)
 	}
+}
+
+func tempDirOutsideDefaultTemp(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".zero-sandbox-outside-")
+	if err != nil {
+		t.Fatalf("MkdirTemp outside default temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("Abs(%q): %v", dir, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return filepath.Clean(abs)
 }


### PR DESCRIPTION
## Summary
- Treat platform temp directories as default writable roots across sandbox scope and permission profiles
- Bind host temp roots on Linux instead of mounting an isolated tmpfs at /tmp, so tool-created files remain visible to sandboxed commands
- Update scope, CLI, tool, and agent tests so platform temp is no longer treated as outside the allowed write roots

## Tests
- git diff --check
- GOCACHE=/tmp/zero-go-cache go test ./internal/sandbox ./internal/tools ./internal/cli ./internal/agent

Note: the focused Go suite was rerun outside the restricted sandbox because existing local socket and bwrap tests need host socket permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox and tool permission checks now recognize additional host temporary locations as writable (including system temp roots and `TMPDIR`/`TEMP`/`TMP`), reducing false denials for common temp-file use.

* **Bug Fixes**
  * Improved handling of “outside the workspace” paths so allow/deny decisions and user-facing errors are more consistent.
  * Made sandbox bind behavior more reliable and deterministic on Linux, stabilizing which temp roots get access when multiple are involved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->