### PR TITLE
fix(tui): stop ANSI escape leaks + drop redundant update_plan cards

### DIFF
--- a/internal/tui/assistant_markdown.go
+++ b/internal/tui/assistant_markdown.go
@@ -191,6 +191,19 @@ func styleAssistantMarkdownLine(line string, base lipgloss.Style) string {
 			style = markdownDisplayNormal
 			index += len(markdownBoldEnd)
 			continue
+		case line[index] == '\x1b':
+			// Already-styled input (highlighted code, headings, tables) carries real
+			// ANSI. Emit each escape verbatim instead of treating its bytes as runes
+			// and re-Render()ing them: re-wrapping doubles the SGR density and a
+			// flush()/truncate can then slice mid-escape, leaking "[38;2;…" / "[1;4;…"
+			// fragments into the visible text. Mirrors truncateStyledLine. The bold
+			// markers above are matched first, so their semantic style switch is kept.
+			if end := ansiSequenceEnd(line, index); end > index {
+				flush()
+				builder.WriteString(line[index:end])
+				index = end
+				continue
+			}
 		}
 
 		r, size := utf8.DecodeRuneInString(line[index:])

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2382,6 +2382,14 @@ func (m model) workingActivity() string {
 	return "thinking"
 }
 
+// toolCardSuppressedInTranscript reports tools whose transcript card is redundant
+// because a dedicated UI surface already shows their state: Task (its specialist
+// card) and update_plan (the pinned plan panel + PLAN sidebar). Their session
+// events are still recorded; only the visible card is skipped.
+func toolCardSuppressedInTranscript(name string) bool {
+	return name == "Task" || name == "update_plan"
+}
+
 func (m model) workingStatusLine() string {
 	// Cosine ripple FX: "Working" breathes through a cold-to-warm theme ramp, the
 	// wave moving one character per spinner tick (shared m.spinnerPhase clock). A
@@ -3779,9 +3787,10 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				arg:    argHintSecondary(call.Arguments),
 				runID:  runID,
 			}
-			// A Task delegation is shown by the specialist card below, so skip its
-			// redundant "tool call: Task" transcript row — the card supersedes it.
-			if call.Name != "Task" {
+			// A Task delegation is shown by the specialist card below, and update_plan
+			// is shown by the pinned plan panel + PLAN sidebar, so skip both redundant
+			// transcript cards — the dedicated UI supersedes them.
+			if !toolCardSuppressedInTranscript(call.Name) {
 				rows = append(rows, row)
 				m.sendAgentRow(runID, row)
 			}
@@ -3862,9 +3871,9 @@ func (m model) runAgentWithOptions(runID int, runCtx context.Context, prompt str
 				detail: result.Output,
 				runID:  runID,
 			}
-			// A Task result is shown by the specialist card (its completion state),
-			// so skip its redundant "tool result: Task" transcript row.
-			if result.Name != "Task" {
+			// A Task result is shown by the specialist card, and update_plan by the
+			// plan panel/sidebar, so skip both redundant transcript rows.
+			if !toolCardSuppressedInTranscript(result.Name) {
 				rows = append(rows, row)
 				m.sendAgentRow(runID, row)
 			}

--- a/internal/tui/rendering_lime_test.go
+++ b/internal/tui/rendering_lime_test.go
@@ -34,6 +34,46 @@ func limeTestModel() model {
 	return newModel(context.Background(), Options{ProviderName: "test-provider", ModelName: "test-model"})
 }
 
+// Already-styled markdown lines (highlighted code, headings, tables carry real
+// ANSI) must pass through styleAssistantMarkdownLine VERBATIM, not get their
+// escape bytes treated as runes and the whole line re-wrapped in base.Render —
+// that double-wrapping inflated SGR density and let a downstream truncation slice
+// mid-escape, leaking "[38;2;…" / "[1;4;…" garbage into the visible transcript.
+func TestStyleAssistantMarkdownLinePassesAnsiVerbatim(t *testing.T) {
+	old := lipgloss.Writer.Profile
+	lipgloss.Writer.Profile = colorprofile.TrueColor
+	defer func() { lipgloss.Writer.Profile = old }()
+
+	in := "\x1b[31mtoken\x1b[0m" // an already-colored code token
+	out := styleAssistantMarkdownLine(in, lipgloss.NewStyle().Bold(true))
+
+	// With the fix the input escape leads the output verbatim. Without it, the
+	// whole line is re-wrapped so the output would START with base's own "\x1b[1m"
+	// and the input escape would be nested inside it.
+	if !strings.HasPrefix(out, "\x1b[31m") {
+		t.Fatalf("already-styled input was re-wrapped instead of passed verbatim: %q", out)
+	}
+	// The input's reset must also survive, not be re-encoded as runes.
+	if !strings.Contains(out, "\x1b[0m") {
+		t.Fatalf("input reset escape not preserved: %q", out)
+	}
+}
+
+// update_plan and Task render as a dedicated UI (plan panel / specialist card),
+// so their transcript tool cards are suppressed; everything else still shows.
+func TestToolCardSuppressedInTranscript(t *testing.T) {
+	for _, name := range []string{"Task", "update_plan"} {
+		if !toolCardSuppressedInTranscript(name) {
+			t.Errorf("%q should be suppressed from the transcript (shown by a dedicated UI)", name)
+		}
+	}
+	for _, name := range []string{"read_file", "write_file", "edit_file", "bash", "swarm_spawn"} {
+		if toolCardSuppressedInTranscript(name) {
+			t.Errorf("%q must still show its transcript card", name)
+		}
+	}
+}
+
 func TestUserRowRendersPromptGutter(t *testing.T) {
 	m := limeTestModel()
 	row := transcriptRow{kind: rowUser, text: "add a --version flag"}


### PR DESCRIPTION
## What

Two chat-clarity fixes from comparing Zero's output to a reference agent on a "build a website" task.

### 1. ANSI escape garbage in the final answer 🐛
The final text was leaking raw, truncated terminal color codes as literal characters next to code blocks:
```
[1;4;38;2;236;
[38;2;236;236;238m    [m[38;2;
```
**Root cause:** `styleAssistantMarkdownLine` treated *already-styled* input (syntax-highlighted code, headings, tables — which carry real ANSI) byte-by-byte as runes and re-wrapped the whole line in another `base.Render`. That **doubled the SGR density**, and a downstream width-truncation then sliced **mid-escape**, dropping the leading `ESC` and printing the leftover (`[38;2;…`) as text. Only styled segments were affected — plain prose has no embedded escapes to split.

**Fix:** real escape sequences now pass through **verbatim** (using the existing `ansiSequenceEnd` helper, exactly like `truncateStyledLine`); the synthetic bold markers are still matched first so their style switch is preserved. ~14 lines.

### 2. Redundant `update_plan` tool cards 🧹
The plan is already shown in **two** places — the pinned plan panel above the composer *and* the PLAN sidebar — so rendering every `update_plan` call as its own transcript card was pure duplication (it stacked 3× in the demo). Generalized the existing `Task`-card skip into `toolCardSuppressedInTranscript` and now skip `update_plan`'s call+result rows too. The plan-panel sync and session events are unchanged.

## Tests
- `TestStyleAssistantMarkdownLinePassesAnsiVerbatim` — proves already-styled input passes through verbatim; **verified it fails before the fix** (output re-wraps the input escape inside base's `\x1b[1m`).
- `TestToolCardSuppressedInTranscript` — `Task`/`update_plan` suppressed, everything else still shown.
- Full `./internal/tui/...` suite green; build + gofmt clean.

## Part of a series
This is 1 of 3 from the chat-clarity comparison. Follow-ups: **diff/code preview** on write/edit cards (the render half + `go-udiff` already exist), and a **system-prompt preamble** so the agent briefly states its approach. Independent PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown styling in the TUI so pre-styled text with ANSI colors renders correctly without broken or duplicated formatting.
  * Reduced duplicate transcript entries by hiding tool cards that are already shown in other parts of the interface, including plan-related and specialist activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->