### PR TITLE
feat(tools): red/green diff preview on write_file and edit_file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/atotto/clipboard v0.1.4
+	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728

--- a/internal/tools/diff_preview.go
+++ b/internal/tools/diff_preview.go
@@ -1,0 +1,20 @@
+package tools
+
+import udiff "github.com/aymanbagabas/go-udiff"
+
+// maxToolPreviewBytes caps the inline diff a write tool appends to its result, so
+// a large generated file can't flood the transcript or balloon the persisted
+// session events. Past this the tool falls back to its summary line alone.
+const maxToolPreviewBytes = 48 * 1024
+
+// boundedUnifiedDiff returns a unified diff of oldContent -> newContent labelled
+// with path, suitable for the TUI's diff card renderer. A create (oldContent "")
+// yields an all-additions (green) preview; an overwrite/edit yields red/green.
+// Returns "" when there is no change or the diff exceeds maxToolPreviewBytes.
+func boundedUnifiedDiff(path, oldContent, newContent string) string {
+	diff := udiff.Unified(path, path, oldContent, newContent)
+	if diff == "" || len(diff) > maxToolPreviewBytes {
+		return ""
+	}
+	return diff
+}

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -111,7 +111,14 @@ func (tool editFileTool) RunWithOptions(_ context.Context, args map[string]any, 
 		suffix = "s"
 	}
 	summary := fmt.Sprintf("Successfully edited %s (replaced %d occurrence%s).", relativePath, replacedCount, suffix)
-	result := okResult(summary)
+	output := summary
+	// Append a unified diff so the card renders the change as red/green instead of
+	// a bare byte-count. The summary stays the first line for any consumer that
+	// reads it (the swarm/Task result bubbles it up).
+	if diff := boundedUnifiedDiff(relativePath, content, updated); diff != "" {
+		output += "\n" + diff
+	}
+	result := okResult(output)
 	result.ChangedFiles = []string{relativePath}
 	result.Display = Display{Summary: fmt.Sprintf("Edited %s", relativePath), Kind: "diff"}
 	return result

--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -91,6 +91,15 @@ func (tool writeFileTool) RunWithOptions(_ context.Context, args map[string]any,
 		}
 	}
 
+	// Capture the prior content (before we replace it) so an overwrite can show a
+	// real diff; a fresh create stays "" and previews as all-additions.
+	priorContent := ""
+	if existed {
+		if prev, rerr := os.ReadFile(absolutePath); rerr == nil {
+			priorContent = string(prev)
+		}
+	}
+
 	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
 		return errorResult("Error writing file " + relativePath + ": " + err.Error())
 	}
@@ -110,7 +119,14 @@ func (tool writeFileTool) RunWithOptions(_ context.Context, args map[string]any,
 		verb = "Overwrote"
 	}
 	summary := fmt.Sprintf("%s %s (%d bytes).", verb, relativePath, len([]byte(content)))
-	result := okResult(summary)
+	output := summary
+	// Append a diff so the card previews the file (all-green additions for a new
+	// file, red/green for an overwrite) instead of a bare byte count. The summary
+	// stays the first line for any consumer that reads it.
+	if diff := boundedUnifiedDiff(relativePath, priorContent, content); diff != "" {
+		output += "\n" + diff
+	}
+	result := okResult(output)
 	result.ChangedFiles = []string{relativePath}
 	result.Display = Display{Summary: summary, Kind: "file"}
 	return result

--- a/internal/tools/write_tools_test.go
+++ b/internal/tools/write_tools_test.go
@@ -231,6 +231,61 @@ func TestEditFileToolReplacesExactStrings(t *testing.T) {
 	}
 }
 
+func TestEditFileToolEmitsUnifiedDiff(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "code.go"), "const a = 1\nconst b = 2\n")
+	res := NewEditFileTool(root).Run(context.Background(), map[string]any{
+		"path": "code.go", "old_string": "const a = 1", "new_string": "const a = 42",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("edit failed: %s", res.Output)
+	}
+	// The summary stays the first line; a unified diff follows so the card can
+	// render the change red/green instead of a bare byte count.
+	if !strings.HasPrefix(res.Output, "Successfully edited") {
+		t.Fatalf("summary must remain the first line: %q", res.Output)
+	}
+	for _, want := range []string{"@@", "-const a = 1", "+const a = 42"} {
+		if !strings.Contains(res.Output, want) {
+			t.Fatalf("edit output missing diff marker %q: %q", want, res.Output)
+		}
+	}
+}
+
+func TestWriteFileToolEmitsAdditionsDiff(t *testing.T) {
+	root := t.TempDir()
+	res := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path": "new.txt", "content": "line one\nline two\n",
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("write failed: %s", res.Output)
+	}
+	for _, want := range []string{"@@", "+line one", "+line two"} {
+		if !strings.Contains(res.Output, want) {
+			t.Fatalf("new-file output missing additions diff %q: %q", want, res.Output)
+		}
+	}
+	if strings.Contains(res.Output, "\n-line") {
+		t.Fatalf("a fresh-create diff must have no removed lines: %q", res.Output)
+	}
+}
+
+func TestWriteFileToolOverwriteEmitsRedGreenDiff(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "f.txt"), "old line\nkeep\n")
+	res := NewWriteFileTool(root).Run(context.Background(), map[string]any{
+		"path": "f.txt", "content": "new line\nkeep\n", "overwrite": true,
+	})
+	if res.Status != StatusOK {
+		t.Fatalf("overwrite failed: %s", res.Output)
+	}
+	for _, want := range []string{"-old line", "+new line"} {
+		if !strings.Contains(res.Output, want) {
+			t.Fatalf("overwrite output missing %q: %q", want, res.Output)
+		}
+	}
+}
+
 func TestEditFileToolAllowsDeletingRegions(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "notes.txt")


### PR DESCRIPTION
## Problem

`write_file`/`edit_file` only printed a one-line summary — `Created index.html (8462 bytes).` / `Successfully edited X`. You never saw **what** was written or changed: no code preview, no **red/green** add/remove. (This was the core "not showing code preview as red and green code add on or editing preview" complaint.)

## Why it's a small fix

The render half is already built and wired: the TUI renders a colored diff card for any tool whose output **looks like a unified diff** (`diffFirstToolBodyRenderer` + `looksLikeDiff`), and `edit_file`/`apply_patch` already route through it. They just emitted a summary instead of a diff. And `go-udiff` was already in `go.sum` (transitive). So the fix is **tool-side only: emit a diff**.

## Changes

- **`edit_file`** — appends a unified diff (old → new) after its summary → red/green change preview.
- **`write_file`** — appends a unified diff of prior → new content:
  - **create** → all-green additions (the "code add on" view),
  - **overwrite** → red/green (reads the prior bytes before writing, only when the file existed).
- **`boundedUnifiedDiff`** (new, via the now-direct `go-udiff` require) caps the emitted diff at **48 KB** so a large generated file can't flood the transcript or balloon persisted session events — past the cap, only the summary shows.
- The **summary stays the first output line**, so any consumer that parses it (swarm/Task result bubbling) is unaffected.

## Tests
- `TestEditFileToolEmitsUnifiedDiff` — `@@` + `-old` + `+new`, summary first.
- `TestWriteFileToolEmitsAdditionsDiff` — new file is additions-only (no removals).
- `TestWriteFileToolOverwriteEmitsRedGreenDiff` — overwrite shows `-`/`+`.
- Full `tools` + `tui` + `agent` + `swarm` suites green; `go vet` clean.

## Series
Part 3 of 3 of the chat-clarity comparison (with #316 ANSI-leak/plan-noise and #317 narration preamble). Independent PRs; this is the biggest visual win. `apply_patch` already sets `Kind:"diff"`; echoing its patch into the output is a tiny optional follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File edit and write actions now include a preview diff in their result output when available.
  * New diffs are bounded so very large changes won’t overwhelm the display.
* **Bug Fixes**
  * Improved change previews for overwrites and additions, making file updates easier to review at a glance.
* **Tests**
  * Added coverage for diff output formatting across edit, create, and overwrite scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->